### PR TITLE
feat(meshcore): channel "heard repeaters" via self-echo correlation (#3700)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_HEARD_REPEATERS_PLAN.md
+++ b/docs/internal/dev-notes/MESHCORE_HEARD_REPEATERS_PLAN.md
@@ -1,0 +1,66 @@
+# MeshCore Channel "Heard Repeaters" (#3700)
+
+## Problem
+When you send a MeshCore **channel (broadcast)** message, nothing tells you whether
+any repeater actually relayed it. DMs get an ACK (`expectedAckCrc` →
+`meshcore:send-confirmed`); channel sends carry no ACK by protocol —
+`sendChannelTextMessage` resolves on the device `Ok` and the native backend
+returns only `{ sent: true }`.
+
+## Feasibility — self-echo correlation
+Channel messages are `PAYLOAD_TYPE_GRP_TXT` (0x05) packets. On the wire a packet
+is `[header][?transportCodes][pathLen][path…][payload]`. For GRP_TXT the
+`payload` is `[channel_hash 1B][ciphertext(timestamp,"name:msg")][MAC]`. The
+**payload bytes are invariant** as the packet floods the mesh — only `header`
+(route type) and `path` (the relay-hash chain) mutate per hop.
+
+Every packet the device **receives over the air** is surfaced via the companion
+`LogRxData` push → parsed in `meshcoreNativeBackend.wirePushEvents` → emitted as
+the `ota_packet` bridge event (carries `raw_hex`, `path_hops`, `snr`,
+`payload_type`). When a nearby repeater re-floods **our own** channel packet, our
+device hears that re-flood as an inbound packet whose GRP_TXT payload is
+byte-identical to what we sent, but whose `path` now contains the relaying
+repeater's hash. **That is the signal.**
+
+### Correlation
+1. On a channel send, register a *pending channel send* `{ msgId, channelIdx,
+   sentAt }` for the source. We do **not** have the outgoing payload bytes
+   (the bridge does not return them), so we cannot key on the payload up front.
+2. For each inbound `GRP_TXT` `ota_packet` arriving within
+   `HEARD_WINDOW_MS` of a pending send, treat it as a candidate self-echo of
+   that send. The packet's `path_hops` are relay hashes of repeaters that
+   carried it. Reuse the `bufferedAt`-style staleness window (#3589) so we never
+   attribute packets heard long after the send.
+3. Dedup repeaters by relay-hash. Resolve each hash to a known repeater contact
+   via `resolveContactByPrefix` (best-effort; show the raw hash when unknown).
+   Track the best (max) SNR seen per repeater.
+4. Persist the heard-repeater set onto the message and push an incremental
+   `meshcore:channel-heard` WS event (mirrors `meshcore:send-confirmed`).
+
+### Why best-effort
+Without the outgoing payload we cannot prove a given GRP_TXT in the window is
+*ours* vs. unrelated channel chatter on the same channel. We bound the risk:
+only GRP_TXT, only within a short window after one of *our* sends, only on a
+matching channel. This matches the issue's "best-effort; show raw hash when
+unknown" guidance and the original MeshCore app's heard-repeater list.
+
+## Per-source side table (migration 102)
+`meshcore_heard_repeaters` — one row per (message, repeater hash). PER-SOURCE
+(`sourceId`, scoped). Independent of the opt-in packet monitor: correlation runs
+on the raw `ota_packet` data **before** the monitor's `isEnabled()` gate.
+
+Columns: `id` PK, `sourceId`, `messageId` (FK-ish to meshcore_messages.id),
+`repeaterHash` (hex relay hash), `repeaterName` (resolved contact name, nullable),
+`snr` (nullable), `heardAt`, `createdAt`. Unique on (messageId, repeaterHash).
+
+A side table (not a JSON column) keeps the variable-length list normalized,
+supports cheap per-message aggregation, and avoids read-modify-write races on a
+single message row as multiple echoes stream in.
+
+## Surfacing
+- `getChannelMessages` / message snapshot enrich each outgoing channel message
+  with `heardBy: { hash, name?, snr? }[]`.
+- WS `meshcore:channel-heard` `{ sourceId, messageId, heardBy }` updates the
+  in-memory message list (same pattern as send-confirmed).
+- UI: in `MeshCoreMessageStream`, outgoing channel messages show a
+  count badge (`📡 N`) that expands to the repeater/path list.

--- a/src/cli/migrationTables.ts
+++ b/src/cli/migrationTables.ts
@@ -34,6 +34,7 @@ export const TABLE_ORDER = [
   'meshcore_messages',
   'meshcore_neighbor_info',
   'meshcore_packet_log',
+  'meshcore_heard_repeaters',
   // Auth tables (must come before channel_database — channel_database
   // FKs to users for createdBy and channel_database_permissions FKs to users
   // for userId/grantedBy).
@@ -101,6 +102,7 @@ export const SOURCE_SCOPED_TABLES = new Set([
   // every backend, so the `sourceId` backfill check never applies to it.
   'embed_profiles', 'meshcore_nodes', 'meshcore_messages',
   'meshcore_neighbor_info', 'meshcore_packet_log',
+  'meshcore_heard_repeaters',
   'auto_favorite_targets', 'auto_favorite_assignments',
   'dead_drop_messages',
 ]);

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -65,7 +65,17 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+  // Message ids whose "heard repeaters" list (#3700) is expanded.
+  const [expandedHeardBy, setExpandedHeardBy] = useState<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement>(null);
+
+  const toggleHeardBy = useCallback((id: string) => {
+    setExpandedHeardBy(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
 
   // MeshCore inbound messages carry `pubkey_prefix` (typically 6-byte / 12-char
   // hex) in `fromPublicKey`, while contacts are keyed by full pubkey. Match by
@@ -268,9 +278,32 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                         : ' …'}
                     </span>
                   )}
+                  {outgoing && m.heardBy && m.heardBy.length > 0 && (
+                    <button
+                      type="button"
+                      className="mc-heard-by-badge"
+                      title={t('meshcore.heard_by_tooltip', 'Repeaters that relayed this message')}
+                      aria-expanded={expandedHeardBy.has(m.id)}
+                      onClick={() => toggleHeardBy(m.id)}
+                    >
+                      {' 📡 '}{m.heardBy.length}
+                    </button>
+                  )}
                 </span>
               </div>
               <div className="mc-message-text">{renderMessageText(m.text)}</div>
+              {outgoing && m.heardBy && m.heardBy.length > 0 && expandedHeardBy.has(m.id) && (
+                <ul className="mc-heard-by-list">
+                  {m.heardBy.map(h => (
+                    <li key={h.hash} className="mc-heard-by-item">
+                      <span className="mc-heard-by-name">{h.name || h.hash}</span>
+                      {typeof h.snr === 'number' && (
+                        <span className="mc-heard-by-snr"> ({h.snr} dB)</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
               {m.text && <LinkPreview text={m.text} />}
               </div>
             </React.Fragment>

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -671,6 +671,38 @@
 .mc-delivery-failed { color: var(--ctp-red); }
 .mc-delivery-sending { color: var(--ctp-overlay0); }
 
+/* Channel "heard repeaters" badge + expandable list (#3700) */
+.mc-heard-by-badge {
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--ctp-blue);
+  cursor: pointer;
+}
+.mc-heard-by-badge:hover {
+  color: var(--ctp-sapphire);
+  text-decoration: underline;
+}
+.mc-heard-by-list {
+  list-style: none;
+  margin: 0.15rem 0 0;
+  padding: 0.15rem 0 0 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ctp-subtext0);
+  border-left: 2px solid var(--ctp-surface1);
+}
+.mc-heard-by-item {
+  line-height: 1.3;
+}
+.mc-heard-by-name {
+  color: var(--ctp-blue);
+}
+.mc-heard-by-snr {
+  color: var(--ctp-overlay0);
+}
+
 .meshcore-send-bar {
   display: flex;
   gap: 0.5rem;

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -81,6 +81,10 @@ export interface MeshCoreMessage {
   estTimeout?: number;
   deliveryStatus?: MessageDeliveryStatus;
   roundTripMs?: number;
+  /** Repeaters that re-flooded this outgoing channel message, inferred by
+   *  self-echo correlation (#3700). Best-effort; `name` is null when the relay
+   *  hash couldn't be resolved to a known contact. */
+  heardBy?: Array<{ hash: string; name?: string | null; snr?: number | null }>;
 }
 
 export interface ConnectionStatus {
@@ -546,11 +550,26 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       ));
     };
 
+    // Channel "heard repeaters" (#3700): a repeater re-flooded one of our
+    // outgoing channel messages and the server correlated the self-echo. The
+    // event carries the current full heard-by set, so we replace state by id.
+    const onChannelHeard = (evt: {
+      sourceId: string;
+      id: string;
+      heardBy: Array<{ hash: string; name?: string | null; snr?: number | null }>;
+    }) => {
+      if (evt.sourceId !== sourceId) return;
+      setMessages(prev => prev.map(m =>
+        m.id === evt.id ? { ...m, heardBy: evt.heardBy } : m,
+      ));
+    };
+
     socket.on('meshcore:message', onMessage);
     socket.on('meshcore:contact:updated', onContactUpdated);
     socket.on('meshcore:status:updated', onStatusUpdated);
     socket.on('meshcore:local-node:updated', onLocalNodeUpdated);
     socket.on('meshcore:send-confirmed', onSendConfirmed);
+    socket.on('meshcore:channel-heard', onChannelHeard);
     socket.io.on('reconnect', onReconnect);
 
     return () => {
@@ -562,6 +581,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       socket.off('meshcore:status:updated', onStatusUpdated);
       socket.off('meshcore:local-node:updated', onLocalNodeUpdated);
       socket.off('meshcore:send-confirmed', onSendConfirmed);
+      socket.off('meshcore:channel-heard', onChannelHeard);
       socket.io.off('reconnect', onReconnect);
     };
   }, [enabled, sourceId, socket, mcPrefix, csrfFetch, setMeshCoreNodes, recomputeNodes]);

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -98,6 +98,9 @@ import {
 import {
   meshcorePacketLogSqlite, meshcorePacketLogPostgres, meshcorePacketLogMysql,
 } from './schema/meshcorePacketLog.js';
+import {
+  meshcoreHeardRepeatersSqlite, meshcoreHeardRepeatersPostgres, meshcoreHeardRepeatersMysql,
+} from './schema/meshcoreHeardRepeaters.js';
 
 // Embed Profiles table
 import {
@@ -201,6 +204,7 @@ export interface ActiveSchema {
   meshcoreMessages: any;
   meshcoreNeighbors: any;
   meshcorePacketLog: any;
+  meshcoreHeardRepeaters: any;
 
   // Embed Profiles
   embedProfiles: any;
@@ -278,6 +282,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     meshcoreMessages: meshcoreMessagesSqlite,
     meshcoreNeighbors: meshcoreNeighborsSqlite,
     meshcorePacketLog: meshcorePacketLogSqlite,
+    meshcoreHeardRepeaters: meshcoreHeardRepeatersSqlite,
     embedProfiles: embedProfilesSqlite,
     automations: automationsSqlite,
     automationRuns: automationRunsSqlite,
@@ -331,6 +336,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     meshcoreMessages: meshcoreMessagesPostgres,
     meshcoreNeighbors: meshcoreNeighborsPostgres,
     meshcorePacketLog: meshcorePacketLogPostgres,
+    meshcoreHeardRepeaters: meshcoreHeardRepeatersPostgres,
     embedProfiles: embedProfilesPostgres,
     automations: automationsPostgres,
     automationRuns: automationRunsPostgres,
@@ -384,6 +390,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     meshcoreMessages: meshcoreMessagesMysql,
     meshcoreNeighbors: meshcoreNeighborsMysql,
     meshcorePacketLog: meshcorePacketLogMysql,
+    meshcoreHeardRepeaters: meshcoreHeardRepeatersMysql,
     embedProfiles: embedProfilesMysql,
     automations: automationsMysql,
     automationRuns: automationRunsMysql,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 101 migrations registered', () => {
-    expect(registry.count()).toBe(101);
+  it('has all 102 migrations registered', () => {
+    expect(registry.count()).toBe(102);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_node_unmessagable', () => {
+  it('last migration is create_meshcore_heard_repeaters', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(101);
-    expect(last.name).toContain('add_node_unmessagable');
+    expect(last.number).toBe(102);
+    expect(last.name).toContain('create_meshcore_heard_repeaters');
   });
 
-  it('migrations are sequentially numbered from 1 to 101', () => {
+  it('migrations are sequentially numbered from 1 to 102', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -116,6 +116,7 @@ import { migration as createAutomationsMigration, runMigration098Postgres, runMi
 import { migration as createAutomationVariablesMigration, runMigration099Postgres, runMigration099Mysql } from '../server/migrations/099_create_automation_variables.js';
 import { migration as meshcoreChannelScopeMigration, runMigration100Postgres as runMeshcoreChannelScopePostgres, runMigration100Mysql as runMeshcoreChannelScopeMysql } from '../server/migrations/100_meshcore_channel_scope.js';
 import { migration as nodeUnmessagableMigration, runMigration101Postgres as runNodeUnmessagablePostgres, runMigration101Mysql as runNodeUnmessagableMysql } from '../server/migrations/101_add_node_unmessagable.js';
+import { migration as meshcoreHeardRepeatersMigration, runMigration102Postgres as runMeshcoreHeardRepeatersPostgres, runMigration102Mysql as runMeshcoreHeardRepeatersMysql } from '../server/migrations/102_create_meshcore_heard_repeaters.js';
 
 // ============================================================================
 // Registry
@@ -1608,4 +1609,19 @@ registry.register({
   sqlite: (db) => nodeUnmessagableMigration.up(db),
   postgres: (client) => runNodeUnmessagablePostgres(client),
   mysql: (pool) => runNodeUnmessagableMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 102: create meshcore_heard_repeaters (#3700). Per-source side
+// table recording repeaters that re-flooded our outgoing channel messages,
+// inferred by self-echo correlation on inbound GRP_TXT OTA packets.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 102,
+  name: 'create_meshcore_heard_repeaters',
+  settingsKey: 'migration_102_create_meshcore_heard_repeaters',
+  sqlite: (db) => meshcoreHeardRepeatersMigration.up(db),
+  postgres: (client) => runMeshcoreHeardRepeatersPostgres(client),
+  mysql: (pool) => runMeshcoreHeardRepeatersMysql(pool),
 });

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -122,6 +122,35 @@ export interface DbMeshCorePacket {
 }
 
 /**
+ * MeshCore "heard repeater" row (#3700). One per (outgoing channel message,
+ * repeater relay-hash) inferred by self-echo correlation. See
+ * `src/db/schema/meshcoreHeardRepeaters.ts`.
+ */
+export interface DbMeshCoreHeardRepeater {
+  id?: number;
+  /** Owning source id; required on writes. */
+  sourceId: string;
+  /** meshcore_messages.id of the outgoing channel message that was relayed. */
+  messageId: string;
+  /** Lowercase hex relay-hash of the repeater that re-flooded the packet. */
+  repeaterHash: string;
+  /** Resolved repeater contact name (best-effort; null when unknown). */
+  repeaterName?: string | null;
+  /** Best (max) SNR observed for this repeater across echoes. */
+  snr?: number | null;
+  /** When the echo was heard (Unix ms). */
+  heardAt: number;
+  createdAt: number;
+}
+
+/** Max of two nullable numbers; null only when both are null. */
+function maxNullable(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.max(a, b);
+}
+
+/**
  * Filters accepted by the MeshCore packet-log query/count methods.
  */
 export interface MeshCorePacketQuery {
@@ -877,6 +906,134 @@ export class MeshCoreRepository extends BaseRepository {
     const { meshcoreMessages } = this.tables;
     await this.db.delete(meshcoreMessages);
     return count;
+  }
+
+  // ============ Heard-Repeater Methods (#3700) ============
+
+  /**
+   * Record (or refresh) a repeater that re-flooded an outgoing channel message
+   * (self-echo correlation, #3700). Dedups on (sourceId, messageId,
+   * repeaterHash); on a repeat echo we keep the best (max) SNR and fill in a
+   * `repeaterName` if one becomes known. Returns the merged record so the caller
+   * can broadcast the current heard-by state.
+   *
+   * `sourceId` is required — every row is per-source scoped.
+   */
+  async recordHeardRepeater(
+    record: {
+      sourceId: string;
+      messageId: string;
+      repeaterHash: string;
+      repeaterName?: string | null;
+      snr?: number | null;
+      heardAt: number;
+    },
+  ): Promise<DbMeshCoreHeardRepeater> {
+    if (!record.sourceId) {
+      throw new Error('MeshCoreRepository.recordHeardRepeater requires a sourceId');
+    }
+    const { meshcoreHeardRepeaters } = this.tables;
+    const now = this.now();
+
+    const existingRows = await this.db
+      .select()
+      .from(meshcoreHeardRepeaters)
+      .where(
+        and(
+          eq(meshcoreHeardRepeaters.sourceId, record.sourceId),
+          eq(meshcoreHeardRepeaters.messageId, record.messageId),
+          eq(meshcoreHeardRepeaters.repeaterHash, record.repeaterHash),
+        ),
+      )
+      .limit(1);
+    const existing = existingRows[0]
+      ? (this.normalizeBigInts(existingRows[0]) as unknown as DbMeshCoreHeardRepeater)
+      : undefined;
+
+    if (existing) {
+      const mergedSnr = maxNullable(existing.snr ?? null, record.snr ?? null);
+      const mergedName = record.repeaterName ?? existing.repeaterName ?? null;
+      await this.db
+        .update(meshcoreHeardRepeaters)
+        .set({ snr: mergedSnr, repeaterName: mergedName, heardAt: record.heardAt })
+        .where(
+          and(
+            eq(meshcoreHeardRepeaters.sourceId, record.sourceId),
+            eq(meshcoreHeardRepeaters.messageId, record.messageId),
+            eq(meshcoreHeardRepeaters.repeaterHash, record.repeaterHash),
+          ),
+        );
+      return { ...existing, snr: mergedSnr, repeaterName: mergedName, heardAt: record.heardAt };
+    }
+
+    await this.db.insert(meshcoreHeardRepeaters).values({
+      sourceId: record.sourceId,
+      messageId: record.messageId,
+      repeaterHash: record.repeaterHash,
+      repeaterName: record.repeaterName ?? null,
+      snr: record.snr ?? null,
+      heardAt: record.heardAt,
+      createdAt: now,
+    });
+    return {
+      sourceId: record.sourceId,
+      messageId: record.messageId,
+      repeaterHash: record.repeaterHash,
+      repeaterName: record.repeaterName ?? null,
+      snr: record.snr ?? null,
+      heardAt: record.heardAt,
+      createdAt: now,
+    };
+  }
+
+  /**
+   * Fetch all heard-repeater rows for a single message (per-source scoped),
+   * newest first. Used to broadcast the current heard-by set after each echo.
+   */
+  async getHeardRepeatersForMessage(
+    messageId: string,
+    sourceId: string,
+  ): Promise<DbMeshCoreHeardRepeater[]> {
+    const { meshcoreHeardRepeaters } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreHeardRepeaters)
+      .where(
+        and(
+          eq(meshcoreHeardRepeaters.sourceId, sourceId),
+          eq(meshcoreHeardRepeaters.messageId, messageId),
+        ),
+      )
+      .orderBy(desc(meshcoreHeardRepeaters.snr));
+    return this.normalizeBigInts(result) as unknown as DbMeshCoreHeardRepeater[];
+  }
+
+  /**
+   * Fetch heard-repeater rows for many messages at once (per-source scoped),
+   * grouped by messageId — used to enrich a channel message list in one query.
+   */
+  async getHeardRepeatersForMessages(
+    messageIds: string[],
+    sourceId: string,
+  ): Promise<Record<string, DbMeshCoreHeardRepeater[]>> {
+    if (messageIds.length === 0) return {};
+    const { meshcoreHeardRepeaters } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreHeardRepeaters)
+      .where(
+        and(
+          eq(meshcoreHeardRepeaters.sourceId, sourceId),
+          inArray(meshcoreHeardRepeaters.messageId, messageIds),
+        ),
+      )
+      .orderBy(desc(meshcoreHeardRepeaters.snr));
+    const rows = this.normalizeBigInts(result) as unknown as DbMeshCoreHeardRepeater[];
+    const grouped: Record<string, DbMeshCoreHeardRepeater[]> = {};
+    for (const row of rows) {
+      (grouped[row.messageId] ??= []).push(row);
+    }
+    return grouped;
   }
 
   // ============ Neighbor Methods ============

--- a/src/db/repositories/meshcoreHeardRepeaters.perSource.test.ts
+++ b/src/db/repositories/meshcoreHeardRepeaters.perSource.test.ts
@@ -1,0 +1,150 @@
+/**
+ * MeshCore "heard repeaters" repository — unit + per-source isolation tests
+ * (#3700).
+ *
+ * The `meshcore_heard_repeaters` table (migration 102) carries a `sourceId` on
+ * every row. These tests assert recording/dedup/max-SNR behaviour and that
+ * queries never leak across sources.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MeshCoreRepository } from './meshcore.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+const HEARD_AT = 1_700_000_000_000;
+
+describe('MeshCoreRepository — heard-repeaters', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MeshCoreRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MeshCoreRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('recordHeardRepeater requires a sourceId', async () => {
+    await expect(
+      repo.recordHeardRepeater({
+        sourceId: '',
+        messageId: 'm1',
+        repeaterHash: 'a3',
+        heardAt: HEARD_AT,
+      }),
+    ).rejects.toThrow(/sourceId/);
+  });
+
+  it('inserts a new heard-repeater row and returns it', async () => {
+    const row = await repo.recordHeardRepeater({
+      sourceId: 'src-a',
+      messageId: 'm1',
+      repeaterHash: 'a3',
+      repeaterName: 'Repeater Alpha',
+      snr: 5,
+      heardAt: HEARD_AT,
+    });
+    expect(row).toMatchObject({
+      sourceId: 'src-a',
+      messageId: 'm1',
+      repeaterHash: 'a3',
+      repeaterName: 'Repeater Alpha',
+      snr: 5,
+    });
+
+    const all = await repo.getHeardRepeatersForMessage('m1', 'src-a');
+    expect(all).toHaveLength(1);
+    expect(all[0].repeaterHash).toBe('a3');
+  });
+
+  it('dedups on (sourceId, messageId, repeaterHash) and keeps the max SNR', async () => {
+    await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 3, heardAt: HEARD_AT,
+    });
+    const merged = await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 7, heardAt: HEARD_AT + 1000,
+    });
+    expect(merged.snr).toBe(7);
+
+    const lower = await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 1, heardAt: HEARD_AT + 2000,
+    });
+    expect(lower.snr).toBe(7); // max retained
+
+    const all = await repo.getHeardRepeatersForMessage('m1', 'src-a');
+    expect(all).toHaveLength(1);
+    expect(all[0].snr).toBe(7);
+  });
+
+  it('fills in a repeaterName on a later echo when it becomes known', async () => {
+    await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', repeaterName: null, snr: 2, heardAt: HEARD_AT,
+    });
+    const merged = await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', repeaterName: 'Alpha', snr: 2, heardAt: HEARD_AT + 10,
+    });
+    expect(merged.repeaterName).toBe('Alpha');
+  });
+
+  it('handles a null SNR without clobbering an existing value', async () => {
+    await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 8, heardAt: HEARD_AT,
+    });
+    const merged = await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: null, heardAt: HEARD_AT + 10,
+    });
+    expect(merged.snr).toBe(8);
+  });
+
+  it('getHeardRepeatersForMessage is scoped by sourceId', async () => {
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 5, heardAt: HEARD_AT });
+    await repo.recordHeardRepeater({ sourceId: 'src-b', messageId: 'm1', repeaterHash: 'a3', snr: 5, heardAt: HEARD_AT });
+
+    const a = await repo.getHeardRepeatersForMessage('m1', 'src-a');
+    const b = await repo.getHeardRepeatersForMessage('m1', 'src-b');
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+    expect(a.every(r => r.sourceId === 'src-a')).toBe(true);
+    expect(b.every(r => r.sourceId === 'src-b')).toBe(true);
+
+    // Same (messageId, repeaterHash) in two sources are distinct rows.
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: '7f', snr: 1, heardAt: HEARD_AT });
+    expect(await repo.getHeardRepeatersForMessage('m1', 'src-a')).toHaveLength(2);
+    expect(await repo.getHeardRepeatersForMessage('m1', 'src-b')).toHaveLength(1);
+  });
+
+  it('getHeardRepeatersForMessage orders by SNR descending', async () => {
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 2, heardAt: HEARD_AT });
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: '7f', snr: 9, heardAt: HEARD_AT });
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: 'bc', snr: 5, heardAt: HEARD_AT });
+    const all = await repo.getHeardRepeatersForMessage('m1', 'src-a');
+    expect(all.map(r => r.repeaterHash)).toEqual(['7f', 'bc', 'a3']);
+  });
+
+  it('getHeardRepeatersForMessages groups by messageId and is source-scoped', async () => {
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 5, heardAt: HEARD_AT });
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm1', repeaterHash: '7f', snr: 3, heardAt: HEARD_AT });
+    await repo.recordHeardRepeater({ sourceId: 'src-a', messageId: 'm2', repeaterHash: 'bc', snr: 1, heardAt: HEARD_AT });
+    await repo.recordHeardRepeater({ sourceId: 'src-b', messageId: 'm1', repeaterHash: 'a3', snr: 5, heardAt: HEARD_AT });
+
+    const grouped = await repo.getHeardRepeatersForMessages(['m1', 'm2', 'm3'], 'src-a');
+    expect(Object.keys(grouped).sort()).toEqual(['m1', 'm2']);
+    expect(grouped['m1']).toHaveLength(2);
+    expect(grouped['m2']).toHaveLength(1);
+    expect(grouped['m3']).toBeUndefined();
+    // src-b row excluded.
+    expect(grouped['m1'].every(r => r.sourceId === 'src-a')).toBe(true);
+  });
+
+  it('getHeardRepeatersForMessages returns {} for an empty id list', async () => {
+    const grouped = await repo.getHeardRepeatersForMessages([], 'src-a');
+    expect(grouped).toEqual({});
+  });
+});

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -35,6 +35,7 @@ export * from './meshcoreNodes.js';
 export * from './meshcoreMessages.js';
 export * from './meshcoreNeighbors.js';
 export * from './meshcorePacketLog.js';
+export * from './meshcoreHeardRepeaters.js';
 
 // Embed Profiles table
 export * from './embedProfiles.js';

--- a/src/db/schema/meshcoreHeardRepeaters.ts
+++ b/src/db/schema/meshcoreHeardRepeaters.ts
@@ -1,0 +1,74 @@
+/**
+ * Drizzle schema for the `meshcore_heard_repeaters` side table (#3700).
+ *
+ * MeshCore channel (broadcast) messages carry no protocol-level ACK, so there is
+ * normally no signal that any repeater relayed an outgoing channel post. We infer
+ * one best-effort by self-echo correlation: when a nearby repeater re-floods our
+ * own GRP_TXT channel packet, our device hears that re-flood as an inbound OTA
+ * packet (`LogRxData` → `ota_packet`) whose relay-hash chain (`path_hops`)
+ * names the repeaters that carried it. We attribute those repeater hashes to the
+ * most recent matching outgoing channel send within a short window.
+ *
+ * One row per (message, repeater hash). PER-SOURCE (`sourceId`, scoped) — a row
+ * belongs to the source whose device heard the echo. A side table (rather than a
+ * JSON column on `meshcore_messages`) keeps the variable-length list normalized,
+ * supports cheap per-message aggregation, and avoids read-modify-write races as
+ * multiple echoes stream in.
+ */
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, bigint as pgBigint, serial as pgSerial } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, bigint as myBigint } from 'drizzle-orm/mysql-core';
+
+// ============ SQLite Schema ============
+
+export const meshcoreHeardRepeatersSqlite = sqliteTable('meshcore_heard_repeaters', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  // Owning source (the device that heard the self-echo).
+  sourceId: text('sourceId').notNull(),
+  // FK-ish to meshcore_messages.id (the outgoing channel message that was relayed).
+  messageId: text('messageId').notNull(),
+  // Relay hash (hex) of the repeater that re-flooded the packet.
+  repeaterHash: text('repeaterHash').notNull(),
+  // Resolved repeater contact name (best-effort; null when the hash is unknown).
+  repeaterName: text('repeaterName'),
+  // Best (max) SNR observed for this repeater across echoes (nullable).
+  snr: integer('snr'),
+  // When the echo was heard (Unix ms).
+  heardAt: integer('heardAt').notNull(),
+  createdAt: integer('createdAt').notNull(),
+});
+
+// ============ PostgreSQL Schema ============
+
+export const meshcoreHeardRepeatersPostgres = pgTable('meshcore_heard_repeaters', {
+  id: pgSerial('id').primaryKey(),
+  sourceId: pgText('sourceId').notNull(),
+  messageId: pgText('messageId').notNull(),
+  repeaterHash: pgText('repeaterHash').notNull(),
+  repeaterName: pgText('repeaterName'),
+  snr: pgInteger('snr'),
+  heardAt: pgBigint('heardAt', { mode: 'number' }).notNull(),
+  createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// ============ MySQL Schema ============
+
+export const meshcoreHeardRepeatersMysql = mysqlTable('meshcore_heard_repeaters', {
+  id: myInt('id').autoincrement().primaryKey(),
+  sourceId: myVarchar('sourceId', { length: 64 }).notNull(),
+  messageId: myVarchar('messageId', { length: 64 }).notNull(),
+  repeaterHash: myVarchar('repeaterHash', { length: 16 }).notNull(),
+  repeaterName: myVarchar('repeaterName', { length: 128 }),
+  snr: myInt('snr'),
+  heardAt: myBigint('heardAt', { mode: 'number' }).notNull(),
+  createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// ============ Type Inference ============
+
+export type MeshCoreHeardRepeaterSqlite = typeof meshcoreHeardRepeatersSqlite.$inferSelect;
+export type NewMeshCoreHeardRepeaterSqlite = typeof meshcoreHeardRepeatersSqlite.$inferInsert;
+export type MeshCoreHeardRepeaterPostgres = typeof meshcoreHeardRepeatersPostgres.$inferSelect;
+export type NewMeshCoreHeardRepeaterPostgres = typeof meshcoreHeardRepeatersPostgres.$inferInsert;
+export type MeshCoreHeardRepeaterMysql = typeof meshcoreHeardRepeatersMysql.$inferSelect;
+export type NewMeshCoreHeardRepeaterMysql = typeof meshcoreHeardRepeatersMysql.$inferInsert;

--- a/src/server/meshcoreManager.channelHeard.test.ts
+++ b/src/server/meshcoreManager.channelHeard.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for MeshCoreManager's channel "heard repeaters" self-echo correlation
+ * (#3700).
+ *
+ * When a nearby repeater re-floods one of OUR outgoing channel messages, the
+ * device hears it as an inbound GRP_TXT OTA packet whose relay-hash chain names
+ * the relaying repeaters. We correlate that echo (best-effort, window-bounded)
+ * to the most recent matching outgoing channel send, dedup repeaters by hash,
+ * track max SNR, and broadcast the heard-by set.
+ *
+ * Two layers are covered:
+ *  - `findEchoMatch` (pure): matching, window expiry, dedup, type/path gating.
+ *  - `handleBridgeEvent('ota_packet')` (integration): records repeaters and
+ *    emits `meshcore:channel-heard`, independent of the packet-monitor gate.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const recordHeardRepeater = vi.fn();
+const getHeardRepeatersForMessage = vi.fn();
+const isEnabled = vi.fn().mockResolvedValue(false);
+const emitMeshCoreChannelHeard = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      recordHeardRepeater: (...args: unknown[]) => recordHeardRepeater(...args),
+      getHeardRepeatersForMessage: (...args: unknown[]) => getHeardRepeatersForMessage(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreChannelHeard: (...args: unknown[]) => emitMeshCoreChannelHeard(...args),
+    emitMeshCoreOtaPacket: vi.fn(),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreContactUpdated: vi.fn(),
+  },
+}));
+
+vi.mock('./services/meshcorePacketLogService.js', () => ({
+  default: {
+    isEnabled: (...args: unknown[]) => isEnabled(...args),
+    logPacket: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { MeshCoreManager } from './meshcoreManager.js';
+
+const GRP_TXT = 0x05;
+
+function dispatch(m: MeshCoreManager, evt: { event_type: string; data: Record<string, unknown> }): void {
+  // @ts-expect-error - exercising private method
+  m.handleBridgeEvent(evt);
+}
+
+/** Seed a pending channel send on a manager (mirrors performScopedSend). */
+function registerSend(m: MeshCoreManager, messageId: string, channelIdx: number): void {
+  // @ts-expect-error - exercising private method
+  m.registerPendingChannelSend(messageId, channelIdx);
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('MeshCoreManager.findEchoMatch (pure)', () => {
+  const WINDOW = 30_000;
+
+  it('matches a GRP_TXT packet to the most recent pending send within window', () => {
+    const now = 1_000_000;
+    const pending = new Map([
+      ['msg-old', { channelIdx: 0, sentAt: now - 5_000 }],
+      ['msg-new', { channelIdx: 1, sentAt: now - 1_000 }],
+    ]);
+    const match = MeshCoreManager.findEchoMatch(
+      { payload_type: GRP_TXT, path_hops: ['a3', '7f'] },
+      pending,
+      now,
+      WINDOW,
+    );
+    expect(match).not.toBeNull();
+    expect(match!.messageId).toBe('msg-new');
+    expect(match!.channelIdx).toBe(1);
+    expect(match!.pathHops).toEqual(['a3', '7f']);
+  });
+
+  it('returns null when no pending send is within the window', () => {
+    const now = 1_000_000;
+    const pending = new Map([['msg-stale', { channelIdx: 0, sentAt: now - (WINDOW + 1) }]]);
+    const match = MeshCoreManager.findEchoMatch(
+      { payload_type: GRP_TXT, path_hops: ['a3'] },
+      pending,
+      now,
+      WINDOW,
+    );
+    expect(match).toBeNull();
+  });
+
+  it('ignores non-GRP_TXT payload types', () => {
+    const now = 1_000_000;
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now }]]);
+    const match = MeshCoreManager.findEchoMatch(
+      { payload_type: 0x02, path_hops: ['a3'] },
+      pending,
+      now,
+      WINDOW,
+    );
+    expect(match).toBeNull();
+  });
+
+  it('ignores direct/zero-hop packets with no relay chain', () => {
+    const now = 1_000_000;
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now }]]);
+    expect(
+      MeshCoreManager.findEchoMatch({ payload_type: GRP_TXT, path_hops: [] }, pending, now, WINDOW),
+    ).toBeNull();
+    expect(
+      MeshCoreManager.findEchoMatch({ payload_type: GRP_TXT }, pending, now, WINDOW),
+    ).toBeNull();
+  });
+
+  it('returns null when there are no pending sends', () => {
+    const match = MeshCoreManager.findEchoMatch(
+      { payload_type: GRP_TXT, path_hops: ['a3'] },
+      new Map(),
+      1_000_000,
+      WINDOW,
+    );
+    expect(match).toBeNull();
+  });
+
+  it('dedups repeated relay hashes and normalises to lowercase', () => {
+    const now = 1_000_000;
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now }]]);
+    const match = MeshCoreManager.findEchoMatch(
+      { payload_type: GRP_TXT, path_hops: ['A3', 'a3', '7F', '7f', 'A3'] },
+      pending,
+      now,
+      WINDOW,
+    );
+    expect(match!.pathHops).toEqual(['a3', '7f']);
+  });
+});
+
+describe('MeshCoreManager — channel-heard correlation (integration)', () => {
+  beforeEach(() => {
+    recordHeardRepeater.mockReset();
+    getHeardRepeatersForMessage.mockReset();
+    emitMeshCoreChannelHeard.mockReset();
+    isEnabled.mockResolvedValue(false); // packet monitor OFF — correlation must still run
+  });
+
+  it('records repeaters and emits channel-heard for a self-echo (monitor off)', async () => {
+    recordHeardRepeater.mockImplementation(async (r: any) => ({
+      sourceId: r.sourceId,
+      messageId: r.messageId,
+      repeaterHash: r.repeaterHash,
+      repeaterName: r.repeaterName ?? null,
+      snr: r.snr ?? null,
+      heardAt: r.heardAt,
+      createdAt: r.heardAt,
+    }));
+    getHeardRepeatersForMessage.mockResolvedValue([
+      { repeaterHash: 'a3', repeaterName: null, snr: 6 },
+      { repeaterHash: '7f', repeaterName: null, snr: 4 },
+    ]);
+
+    const m = new MeshCoreManager('src-a');
+    registerSend(m, 'sent-123', 1);
+
+    dispatch(m, {
+      event_type: 'ota_packet',
+      data: { payload_type: GRP_TXT, path_hops: ['a3', '7f'], snr: 6 },
+    });
+    await flush();
+
+    expect(recordHeardRepeater).toHaveBeenCalledTimes(2);
+    expect(recordHeardRepeater).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'src-a', messageId: 'sent-123', repeaterHash: 'a3', snr: 6 }),
+    );
+    expect(recordHeardRepeater).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'src-a', messageId: 'sent-123', repeaterHash: '7f' }),
+    );
+
+    expect(emitMeshCoreChannelHeard).toHaveBeenCalledTimes(1);
+    expect(emitMeshCoreChannelHeard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'sent-123',
+        heardBy: [
+          { hash: 'a3', name: null, snr: 6 },
+          { hash: '7f', name: null, snr: 4 },
+        ],
+      }),
+      'src-a',
+    );
+  });
+
+  it('does not record anything when no pending channel send matches', async () => {
+    const m = new MeshCoreManager('src-a');
+    // No registerSend — nothing pending.
+    dispatch(m, {
+      event_type: 'ota_packet',
+      data: { payload_type: GRP_TXT, path_hops: ['a3'], snr: 5 },
+    });
+    await flush();
+    expect(recordHeardRepeater).not.toHaveBeenCalled();
+    expect(emitMeshCoreChannelHeard).not.toHaveBeenCalled();
+  });
+
+  it('ignores inbound DM (non-GRP_TXT) packets', async () => {
+    const m = new MeshCoreManager('src-a');
+    registerSend(m, 'sent-123', 0);
+    dispatch(m, {
+      event_type: 'ota_packet',
+      data: { payload_type: 0x02, path_hops: ['a3'], snr: 5 },
+    });
+    await flush();
+    expect(recordHeardRepeater).not.toHaveBeenCalled();
+    expect(emitMeshCoreChannelHeard).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -374,6 +374,11 @@ export interface MeshCoreMessage {
   /** Estimated timeout in ms before the message should be considered failed.
    *  Only set on outgoing DMs. */
   estTimeout?: number;
+  /** Repeaters that re-flooded this (outgoing channel) message, inferred by
+   *  self-echo correlation (#3700). Best-effort; only set on outgoing channel
+   *  messages that were heard re-flooded. `name` is null when the relay hash
+   *  couldn't be resolved to a known contact. */
+  heardBy?: Array<{ hash: string; name?: string | null; snr?: number | null }>;
 }
 
 export interface MeshCoreStatus {
@@ -557,8 +562,31 @@ class MeshCoreManager extends EventEmitter {
   private pendingCommands: Map<string, { resolve: (value: any) => void; reject: (error: Error) => void; timeout: NodeJS.Timeout }> = new Map();
   private commandId: number = 0;
 
+  /**
+   * Pending outgoing channel sends awaiting self-echo correlation (#3700).
+   * Keyed by message id. Each entry remembers the channel index and send time
+   * so an inbound GRP_TXT OTA packet arriving within HEARD_WINDOW_MS can be
+   * attributed (best-effort) to the most recent matching channel send. Pruned
+   * lazily on each inbound packet and on each new send.
+   */
+  private pendingChannelSends: Map<string, { channelIdx: number; sentAt: number }> = new Map();
+
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
+
+  /**
+   * MeshCore GRP_TXT (channel/broadcast text) payload type (0x05). Inbound OTA
+   * packets of this type are self-echo candidates for outgoing channel sends.
+   */
+  private static readonly PAYLOAD_TYPE_GRP_TXT = 0x05;
+
+  /**
+   * How long after an outgoing channel send we will attribute an inbound
+   * GRP_TXT OTA packet to it as a self-echo (#3700). Bounded so we never
+   * credit unrelated later channel chatter. Mirrors the bufferedAt-style
+   * staleness window used elsewhere (#3589).
+   */
+  private static readonly HEARD_WINDOW_MS = 30_000;
 
   /** Window over which we coalesce `contact_path_updated` pushes into a
    *  single device-side refreshContacts() call. Long enough to absorb a
@@ -1202,6 +1230,10 @@ class MeshCoreManager extends EventEmitter {
         );
       }
     } else if (event_type === 'ota_packet') {
+      // Self-echo correlation for channel "heard repeaters" (#3700) runs on the
+      // raw OTA data FIRST, independent of the opt-in packet monitor, so it
+      // works regardless of the monitor setting.
+      void this.correlateChannelEcho(data);
       // Full OTA packet metadata for the MeshCore Packet Monitor. Capture is
       // opt-in; gate persistence on the setting so we don't write a row for
       // every received packet unless the user has turned the monitor on.
@@ -1244,6 +1276,133 @@ class MeshCoreManager extends EventEmitter {
     } catch (err) {
       logger.warn(`[MeshCore:${this.sourceId}] Failed to handle OTA packet:`, err);
     }
+  }
+
+  /**
+   * Register an outgoing channel send as a candidate for self-echo correlation
+   * (#3700). Prunes entries older than HEARD_WINDOW_MS so the map never grows
+   * unbounded on a chatty channel.
+   */
+  private registerPendingChannelSend(messageId: string, channelIdx: number): void {
+    const now = Date.now();
+    this.prunePendingChannelSends(now);
+    this.pendingChannelSends.set(messageId, { channelIdx, sentAt: now });
+  }
+
+  /** Drop pending channel sends older than the heard window. */
+  private prunePendingChannelSends(now: number): void {
+    for (const [id, entry] of this.pendingChannelSends) {
+      if (now - entry.sentAt > MeshCoreManager.HEARD_WINDOW_MS) {
+        this.pendingChannelSends.delete(id);
+      }
+    }
+  }
+
+  /**
+   * Best-effort channel "heard repeaters" correlation (#3700).
+   *
+   * When a nearby repeater re-floods one of OUR channel messages, our device
+   * hears it as an inbound GRP_TXT OTA packet whose relay-hash chain
+   * (`path_hops`) names the repeaters that carried it. We can't prove the echo
+   * is ours (the bridge doesn't return our outgoing payload bytes), so we bound
+   * the attribution: only GRP_TXT, only within HEARD_WINDOW_MS of one of our
+   * channel sends, attributed to the most recent such send. Each relay hash is
+   * resolved to a known contact name when possible (raw hash otherwise), the
+   * max SNR is tracked per repeater, and the merged heard-by set is broadcast.
+   *
+   * Failures are swallowed — correlation must never break the packet pipeline.
+   */
+  private async correlateChannelEcho(data: any): Promise<void> {
+    try {
+      const now = Date.now();
+      this.prunePendingChannelSends(now);
+
+      const match = MeshCoreManager.findEchoMatch(
+        data,
+        this.pendingChannelSends,
+        now,
+        MeshCoreManager.HEARD_WINDOW_MS,
+      );
+      if (!match) return;
+
+      const snr = typeof data.snr === 'number' ? Math.round(data.snr) : null;
+      const heardBy: Array<{ hash: string; name?: string | null; snr?: number | null }> = [];
+
+      for (const hash of match.pathHops) {
+        const contact = this.resolveContactByPrefix(hash);
+        const name = contact?.advName ?? contact?.name ?? null;
+        const merged = await databaseService.meshcore.recordHeardRepeater({
+          sourceId: this.sourceId,
+          messageId: match.messageId,
+          repeaterHash: hash,
+          repeaterName: name,
+          snr,
+          heardAt: now,
+        });
+        heardBy.push({ hash: merged.repeaterHash, name: merged.repeaterName, snr: merged.snr });
+      }
+
+      if (heardBy.length === 0) return;
+
+      // Broadcast the current full heard-by set (read back so concurrent
+      // echoes for the same message stay consistent).
+      const all = await databaseService.meshcore.getHeardRepeatersForMessage(
+        match.messageId,
+        this.sourceId,
+      );
+      const fullHeardBy = all.map((r) => ({ hash: r.repeaterHash, name: r.repeaterName, snr: r.snr }));
+      dataEventEmitter.emitMeshCoreChannelHeard({ id: match.messageId, heardBy: fullHeardBy }, this.sourceId);
+
+      logger.debug(
+        `[MeshCore:${this.sourceId}] Channel echo: msg=${match.messageId} +${heardBy.length} repeater(s), total=${fullHeardBy.length}`,
+      );
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] correlateChannelEcho failed: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Decide whether an inbound OTA packet is a self-echo of a pending channel
+   * send (#3700). Pure (no I/O) so it can be unit-tested directly. Returns the
+   * matched message id and the de-duplicated relay-hash chain, or null.
+   *
+   * A match requires: payload_type === GRP_TXT, a non-empty `path_hops` relay
+   * chain (a direct/zero-hop packet names no repeaters), and at least one
+   * pending channel send within the window. Attribution goes to the MOST RECENT
+   * pending send (best-effort; the window + type bound the risk).
+   */
+  static findEchoMatch(
+    data: any,
+    pendingChannelSends: Map<string, { channelIdx: number; sentAt: number }>,
+    now: number,
+    windowMs: number,
+  ): { messageId: string; channelIdx: number; pathHops: string[] } | null {
+    if (!data || data.payload_type !== MeshCoreManager.PAYLOAD_TYPE_GRP_TXT) return null;
+
+    const rawHops: unknown = data.path_hops;
+    if (!Array.isArray(rawHops) || rawHops.length === 0) return null;
+    // De-dup while preserving order; normalise to lowercase hex strings.
+    const seen = new Set<string>();
+    const pathHops: string[] = [];
+    for (const h of rawHops) {
+      if (typeof h !== 'string' || h.length === 0) continue;
+      const hash = h.toLowerCase();
+      if (seen.has(hash)) continue;
+      seen.add(hash);
+      pathHops.push(hash);
+    }
+    if (pathHops.length === 0) return null;
+
+    let best: { messageId: string; channelIdx: number; sentAt: number } | null = null;
+    for (const [messageId, entry] of pendingChannelSends) {
+      if (now - entry.sentAt > windowMs) continue;
+      if (!best || entry.sentAt > best.sentAt) {
+        best = { messageId, channelIdx: entry.channelIdx, sentAt: entry.sentAt };
+      }
+    }
+    if (!best) return null;
+
+    return { messageId: best.messageId, channelIdx: best.channelIdx, pathHops };
   }
 
   /**
@@ -2083,6 +2242,15 @@ class MeshCoreManager extends EventEmitter {
         this.addMessage(sentMessage);
         this.emit('message', sentMessage);
         dataEventEmitter.emitMeshCoreMessage(sentMessage, this.sourceId);
+
+        // Register this channel send for self-echo correlation (#3700): a
+        // nearby repeater that re-floods our packet will be heard back as an
+        // inbound GRP_TXT OTA packet within HEARD_WINDOW_MS, naming the
+        // relaying repeaters in its path. DMs are excluded — they already get
+        // a real ACK (send-confirmed).
+        if (isChannelSend) {
+          this.registerPendingChannelSend(msgId, channelIdx!);
+        }
 
         return true;
       } else {
@@ -3930,18 +4098,30 @@ class MeshCoreManager extends EventEmitter {
       limit,
       this.sourceId,
     );
+    // Enrich outgoing channel messages with their heard-by repeater set (#3700)
+    // in one batched query.
+    const heardByMap = await databaseService.meshcore.getHeardRepeatersForMessages(
+      stored.map(m => m.id),
+      this.sourceId,
+    );
     // DB returns newest-first; reverse to oldest-first for the UI.
-    return stored.reverse().map(dbMsg => ({
-      id: dbMsg.id,
-      fromPublicKey: dbMsg.fromPublicKey,
-      fromName: dbMsg.fromName ?? undefined,
-      toPublicKey: dbMsg.toPublicKey ?? undefined,
-      text: dbMsg.text,
-      timestamp: dbMsg.timestamp,
-      rssi: dbMsg.rssi ?? undefined,
-      snr: dbMsg.snr ?? undefined,
-      sourceId: dbMsg.sourceId ?? undefined,
-    }));
+    return stored.reverse().map(dbMsg => {
+      const heard = heardByMap[dbMsg.id];
+      return {
+        id: dbMsg.id,
+        fromPublicKey: dbMsg.fromPublicKey,
+        fromName: dbMsg.fromName ?? undefined,
+        toPublicKey: dbMsg.toPublicKey ?? undefined,
+        text: dbMsg.text,
+        timestamp: dbMsg.timestamp,
+        rssi: dbMsg.rssi ?? undefined,
+        snr: dbMsg.snr ?? undefined,
+        sourceId: dbMsg.sourceId ?? undefined,
+        heardBy: heard && heard.length > 0
+          ? heard.map(r => ({ hash: r.repeaterHash, name: r.repeaterName, snr: r.snr }))
+          : undefined,
+      };
+    });
   }
 
   /**

--- a/src/server/migrations/102_create_meshcore_heard_repeaters.ts
+++ b/src/server/migrations/102_create_meshcore_heard_repeaters.ts
@@ -1,0 +1,112 @@
+/**
+ * Migration 102: MeshCore channel "heard repeaters" side table (#3700).
+ *
+ * Creates one per-source table:
+ *   - meshcore_heard_repeaters: one row per (outgoing channel message, repeater
+ *     relay-hash) inferred by self-echo correlation. When a nearby repeater
+ *     re-floods our own GRP_TXT channel packet, our device hears the re-flood as
+ *     an inbound OTA packet whose relay-hash chain names the relaying repeaters;
+ *     we attribute those hashes to the most recent matching outgoing channel
+ *     send within a short window. Best-effort by design.
+ *
+ * PER-SOURCE (`sourceId`). Unique on (sourceId, messageId, repeaterHash) so
+ * repeated echoes of the same packet by the same repeater dedup; SNR is updated
+ * to the max observed.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 102';
+const TABLE = 'meshcore_heard_repeaters';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): creating ${TABLE}...`);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sourceId TEXT NOT NULL,
+        messageId TEXT NOT NULL,
+        repeaterHash TEXT NOT NULL,
+        repeaterName TEXT,
+        snr INTEGER,
+        heardAt INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL
+      )
+    `);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS mchr_source_msg_hash_uniq ON ${TABLE}(sourceId, messageId, repeaterHash)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS mchr_source_msg_idx ON ${TABLE}(sourceId, messageId)`);
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): dropping ${TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration102Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): creating ${TABLE}...`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id SERIAL PRIMARY KEY,
+      "sourceId" TEXT NOT NULL,
+      "messageId" TEXT NOT NULL,
+      "repeaterHash" TEXT NOT NULL,
+      "repeaterName" TEXT,
+      snr INTEGER,
+      "heardAt" BIGINT NOT NULL,
+      "createdAt" BIGINT NOT NULL
+    )
+  `);
+  await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS mchr_source_msg_hash_uniq ON ${TABLE}("sourceId", "messageId", "repeaterHash")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS mchr_source_msg_idx ON ${TABLE}("sourceId", "messageId")`);
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration102Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): creating ${TABLE}...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [exists] = await conn.query(
+      `SELECT TABLE_NAME FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+      [TABLE],
+    );
+    if ((exists as any[]).length === 0) {
+      await conn.query(`
+        CREATE TABLE ${TABLE} (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          sourceId VARCHAR(64) NOT NULL,
+          messageId VARCHAR(64) NOT NULL,
+          repeaterHash VARCHAR(16) NOT NULL,
+          repeaterName VARCHAR(128),
+          snr INT,
+          heardAt BIGINT NOT NULL,
+          createdAt BIGINT NOT NULL,
+          UNIQUE KEY mchr_source_msg_hash_uniq (sourceId, messageId, repeaterHash),
+          KEY mchr_source_msg_idx (sourceId, messageId)
+        )
+      `);
+    } else {
+      logger.debug(`${TABLE} already exists, skipping create`);
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -30,6 +30,7 @@ export type DataEventType =
   | 'meshcore:status:updated'
   | 'meshcore:local-node:updated'
   | 'meshcore:send-confirmed'
+  | 'meshcore:channel-heard'
   | 'meshcore:ota-packet';
 
 export interface DataEvent {
@@ -376,6 +377,26 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] MeshCore send confirmed: RTT=${data.roundTripMs}ms (source: ${sourceId})`);
+  }
+
+  /**
+   * Emit a MeshCore channel "heard repeaters" update (#3700). Fired
+   * incrementally as repeaters re-flood an outgoing channel message and we
+   * correlate the self-echo; carries the current full heard-by set for the
+   * message so the client can replace its state idempotently.
+   */
+  emitMeshCoreChannelHeard(
+    data: { id: string; heardBy: Array<{ hash: string; name?: string | null; snr?: number | null }> },
+    sourceId: string,
+  ): void {
+    const event: DataEvent = {
+      type: 'meshcore:channel-heard',
+      data: { sourceId, ...data },
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] MeshCore channel heard: msg=${data.id} count=${data.heardBy.length} (source: ${sourceId})`);
   }
 
   /**


### PR DESCRIPTION
## Summary

MeshCore channel (broadcast) messages carry no protocol-level ACK, so nothing told you whether any repeater actually relayed an outgoing channel post (DMs get `meshcore:send-confirmed`; channel sends don't). This adds a best-effort "heard repeaters" signal via **self-echo correlation**.

When a nearby repeater re-floods one of our `GRP_TXT` (0x05) channel packets, our device hears the re-flood as an inbound OTA packet (`LogRxData` → `ota_packet`) whose relay-hash chain (`path_hops`) names the relaying repeaters. We attribute those hashes to the most recent matching outgoing channel send within a 30s window. It's best-effort by design (we don't have the outgoing payload bytes to prove identity) and bounded by window + GRP_TXT type + a pending channel send — matching the issue's guidance and the original MeshCore app's heard-repeater list.

## What's included

- **New per-source side table `meshcore_heard_repeaters`** (migration **102**, SQLite/PostgreSQL/MySQL, idempotent). One row per (message, repeater hash), unique on `(sourceId, messageId, repeaterHash)`, tracks max SNR. Scoped by `sourceId` per the multi-source rules.
- **Correlation runs on raw `ota_packet` data BEFORE the opt-in packet-monitor gate**, so it works regardless of the monitor setting.
- Relay hashes resolved to repeater names best-effort via the existing contact-prefix resolver; raw hash shown when unknown.
- Repository methods (`recordHeardRepeater`, `getHeardRepeatersForMessage`, `getHeardRepeatersForMessages`) using Drizzle query builders; outgoing channel messages enriched with `heardBy[]`.
- New incremental `meshcore:channel-heard` WS event (mirrors `meshcore:send-confirmed`).
- **UI:** count badge (📡 N) + expandable repeater/SNR list in the MeshCore message stream.

## Tests

- `findEchoMatch` (pure): match / window-expiry / dedup / type + path gating.
- Integration correlation via `handleBridgeEvent('ota_packet')`: records repeaters and emits the WS event with the packet monitor OFF; ignores no-match and non-GRP_TXT (DM) packets.
- Repository per-source isolation + dedup / max-SNR / name-fill / grouping.
- Migration registry count/last-name and `migrationTables` coverage updated.

Full Vitest suite green (7399 passed, 0 failed). Frontend build + server tsc clean.

Closes #3700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4