### PR TITLE
fix(mqtt): consolidate channels by name instead of splitting by slot/hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ docs/public/charts/
 # Python bytecode caches
 __pycache__/
 *.pyc
+
+# Local Docker dev overrides (machine-specific device mappings, etc.)
+docker-compose.dev.local.yml

--- a/docker-compose.dev.local.yml
+++ b/docker-compose.dev.local.yml
@@ -1,9 +1,0 @@
-services:
-  meshmonitor-sqlite:
-    devices:
-      - /dev/ttyUSB0:/dev/ttyUSB0:rw
-      - /dev/ttyUSB1:/dev/ttyUSB1:rw
-      - /dev/ttyUSB2:/dev/ttyUSB2:rw
-      - /dev/ttyUSB3:/dev/ttyUSB3:rw
-    group_add:
-      - dialout

--- a/docker-compose.dev.local.yml
+++ b/docker-compose.dev.local.yml
@@ -1,0 +1,9 @@
+services:
+  meshmonitor-sqlite:
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0:rw
+      - /dev/ttyUSB1:/dev/ttyUSB1:rw
+      - /dev/ttyUSB2:/dev/ttyUSB2:rw
+      - /dev/ttyUSB3:/dev/ttyUSB3:rw
+    group_add:
+      - dialout

--- a/docs/internal/dev-notes/MQTT_CHANNEL_CONSOLIDATION.md
+++ b/docs/internal/dev-notes/MQTT_CHANNEL_CONSOLIDATION.md
@@ -1,0 +1,79 @@
+# MQTT Channel Consolidation (issue: channels split by sending slot/hash)
+
+## Problem (confirmed in live data)
+
+For MQTT sources, the same logical channel is stored under multiple identities, so
+"LongFast" fragments across the per-source **Channels tab** and (partially) the
+**Unified Messages** display.
+
+Three independent splitters, all observed in the `Official MQTT` / `Florida MQTT`
+dev data:
+
+1. **`channels` table keyed by `packet.channel`.** `recordChannelFromEnvelope`
+   (`mqttIngestion.ts`) does `upsertChannel({ id: packet.channel, name }, sourceId)`.
+   On MQTT, `packet.channel` is a per-sender channel **hash** (0–255), not a stable
+   0–7 slot. Result: `LongFast` rows at ids `0,1,8,40`, `LoneWolf` at `5,99`, etc.
+   These are the duplicate physical entries in the Channels tab.
+
+2. **`channel_database` duplicate name rows (ingest race).**
+   `findOrCreatePassiveByNameAsync` is a non-atomic find-then-create and there is **no
+   unique index** on `name`. Concurrent MQTT packets for the same channel both miss the
+   SELECT and both INSERT → byte-identical pairs (`Primary` id 3 & 4, `Wong` 5 & 6,
+   `JAXMesh` 7 & 8, …, created in the same millisecond). Messages then split across
+   `CHANNEL_DB_OFFSET+dupId` (e.g. 103 vs 104).
+
+3. **Raw-hash fallback for messages.** `effectiveChannel` falls back to the raw
+   `packet.channel` when name resolution fails at ingest, stranding messages on numeric
+   hashes (`31`, `8`, `1` in the data) that never consolidate under the named channel.
+
+The display layer (`/api/unified/channels` groups by name; `/api/unified/messages`
+unions a name's channel numbers) papers over #1 and #2 but not #3, and the per-source
+Channels tab shows the raw `channels` rows directly (#1).
+
+## Canonical identity
+
+The single source of truth for an MQTT channel is its **`channel_database` row**,
+surfaced to messages and pickers as `CHANNEL_DB_OFFSET + dbId` (offset = 100):
+
+- Decrypted packets already carry `decoded.channelDatabaseId` (key-verified — honours
+  "same channel only if the key aligns").
+- Name-only packets resolve via `channelId` → `findOrCreatePassiveByNameAsync`
+  (case-insensitive, existing behaviour).
+
+The slot-keyed `channels` table stays for TCP device-synced channels (real slots 0–7);
+MQTT sources stop writing to it.
+
+## Fix
+
+### 1. `channel_database` dedup (foundational)
+- Add a **unique index on `(lower(name), psk)`** — kills race dups (identical name+psk)
+  while still allowing same-name/different-key rows the decryption feature needs.
+- Make `findOrCreatePassiveByNameAsync` atomic: `INSERT … ON CONFLICT DO NOTHING`
+  then SELECT (dialect-correct for sqlite/pg/mysql).
+
+### 2. Stop hash-keyed `channels` writes for MQTT
+- `recordChannelFromEnvelope`: remove the slot/hash-keyed `upsertChannel`. The channel
+  surfaces through (a) message rows on `CHANNEL_DB_OFFSET+dbId` and (b) the virtual-channel
+  path in `/api/unified/channels`. `resolveChannelDatabaseIdForMqtt` already ensures the
+  `channel_database` row exists.
+
+### 3. Migration (scoped to MQTT/bridge sources only — never touch TCP slots 0–7)
+- Merge `channel_database` rows identical in `(lower(name), psk)`: keep lowest id,
+  repoint `channel_database_permissions.channel_database_id` and
+  `messages.channel = CHANNEL_DB_OFFSET+dup → +canonical`, delete dups. Then add the
+  unique index.
+- For each `sources.type IN ('mqtt_bridge','mqtt_broker')`, for each `channels` row with
+  `id < CHANNEL_DB_OFFSET` and a non-empty name: resolve name→dbId, repoint
+  `messages.channel = rawId → CHANNEL_DB_OFFSET+dbId` for that source (rescues the
+  stranded raw-hash messages), then delete the hash `channels` row.
+
+### 4. Front-end (Channels tab)
+- With #2/#3, the per-source MQTT Channels tab builds its list from message channel
+  numbers (already canonical) + `channelDatabaseEntries` for naming. Verify one entry per
+  channel; adjust `getAvailableChannels`/naming only if a gap shows in verification.
+
+## Verification
+- Unit/integration: dedup race, atomic create, ingestion no longer writes hash rows,
+  migration merges + repoints (SQLite first, then pg/mysql functions).
+- Live: deploy dev container, confirm `Official MQTT` Channels tab shows one `LongFast`,
+  and Unified Messages shows LongFast traffic under a single channel.

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 101 migrations registered', () => {
-    expect(registry.count()).toBe(101);
+  it('has all 102 migrations registered', () => {
+    expect(registry.count()).toBe(102);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_node_unmessagable', () => {
+  it('last migration is consolidate_mqtt_channels', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(101);
-    expect(last.name).toContain('add_node_unmessagable');
+    expect(last.number).toBe(102);
+    expect(last.name).toContain('consolidate_mqtt_channels');
   });
 
-  it('migrations are sequentially numbered from 1 to 101', () => {
+  it('migrations are sequentially numbered from 1 to 102', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -116,6 +116,7 @@ import { migration as createAutomationsMigration, runMigration098Postgres, runMi
 import { migration as createAutomationVariablesMigration, runMigration099Postgres, runMigration099Mysql } from '../server/migrations/099_create_automation_variables.js';
 import { migration as meshcoreChannelScopeMigration, runMigration100Postgres as runMeshcoreChannelScopePostgres, runMigration100Mysql as runMeshcoreChannelScopeMysql } from '../server/migrations/100_meshcore_channel_scope.js';
 import { migration as nodeUnmessagableMigration, runMigration101Postgres as runNodeUnmessagablePostgres, runMigration101Mysql as runNodeUnmessagableMysql } from '../server/migrations/101_add_node_unmessagable.js';
+import { migration as consolidateMqttChannelsMigration, runMigration102Postgres as runConsolidateMqttChannelsPostgres, runMigration102Mysql as runConsolidateMqttChannelsMysql } from '../server/migrations/102_consolidate_mqtt_channels.js';
 
 // ============================================================================
 // Registry
@@ -1608,4 +1609,13 @@ registry.register({
   sqlite: (db) => nodeUnmessagableMigration.up(db),
   postgres: (client) => runNodeUnmessagablePostgres(client),
   mysql: (pool) => runNodeUnmessagableMysql(pool),
+});
+
+registry.register({
+  number: 102,
+  name: 'consolidate_mqtt_channels',
+  settingsKey: 'migration_102_consolidate_mqtt_channels',
+  sqlite: (db) => consolidateMqttChannelsMigration.up(db),
+  postgres: (client) => runConsolidateMqttChannelsPostgres(client),
+  mysql: (pool) => runConsolidateMqttChannelsMysql(pool),
 });

--- a/src/db/repositories/channelDatabase.test.ts
+++ b/src/db/repositories/channelDatabase.test.ts
@@ -434,6 +434,33 @@ function runChannelDbTests(getBackend: () => TestBackend) {
 
     expect(await repo.getPermissionAsync(testUserId, channelId)).toBeNull();
   });
+
+  // --- findOrCreatePassiveByNameAsync (MQTT ingest) ---
+
+  it('findOrCreatePassiveByNameAsync - reuses an existing row (case-insensitive)', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const id = await repo.findOrCreatePassiveByNameAsync('LongFast');
+    const again = await repo.findOrCreatePassiveByNameAsync('longfast'); // case drift
+    expect(again).toBe(id);
+    const all = await repo.getAllAsync();
+    expect(all.filter((c) => (c.name ?? '').toLowerCase() === 'longfast')).toHaveLength(1);
+  });
+
+  it('findOrCreatePassiveByNameAsync - concurrent calls do not create duplicate rows (race guard)', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    // Fire many concurrent creates for the same name — the in-flight guard must
+    // collapse them to a single row so MQTT ingest can't race in duplicates.
+    const ids = await Promise.all(
+      Array.from({ length: 12 }, () => repo.findOrCreatePassiveByNameAsync('Primary')),
+    );
+    expect(new Set(ids).size).toBe(1);
+    const all = await repo.getAllAsync();
+    expect(all.filter((c) => (c.name ?? '').toLowerCase() === 'primary')).toHaveLength(1);
+  });
 }
 
 // --- SQLite Backend ---

--- a/src/db/repositories/channelDatabase.ts
+++ b/src/db/repositories/channelDatabase.ts
@@ -62,6 +62,16 @@ export class ChannelDatabaseRepository extends BaseRepository {
     super(db, dbType);
   }
 
+  /**
+   * In-flight passive creates keyed by lower(name). MQTT ingest handles packets
+   * concurrently, so two packets for the same channel name can both miss the
+   * find SELECT and each INSERT a duplicate row. There is no cross-backend
+   * unique index on name (a functional/text unique index is awkward across
+   * SQLite/PostgreSQL/MySQL), so we serialize creates here — the race is in this
+   * single Node process. (Migration 102 merges any duplicates already on disk.)
+   */
+  private passiveCreateInFlight = new Map<string, Promise<number | null>>();
+
   // ============ CHANNEL DATABASE METHODS ============
 
   /**
@@ -126,15 +136,36 @@ export class ChannelDatabaseRepository extends BaseRepository {
     // from the DB always has it set, so fall through to create only if it
     // somehow isn't.
     if (existing && typeof existing.id === 'number') return existing.id;
-    return this.createAsync({
-      name: trimmed,
-      psk: '',
-      pskLength: 0,
-      isEnabled: false,
-      enforceNameValidation: false,
-      description: 'Auto-registered for MQTT channel permissions (no PSK)',
-      createdBy: null,
-    });
+
+    // Serialize concurrent creates for the same name (case-insensitive, matching
+    // getByNameAsync) so two in-flight MQTT packets don't each insert a
+    // duplicate passive row.
+    const key = trimmed.toLowerCase();
+    const inFlight = this.passiveCreateInFlight.get(key);
+    if (inFlight) return inFlight;
+
+    const promise = (async (): Promise<number | null> => {
+      // Re-check inside the guard: another call may have created the row between
+      // our initial find and acquiring the in-flight slot.
+      const recheck = await this.getByNameAsync(trimmed);
+      if (recheck && typeof recheck.id === 'number') return recheck.id;
+      return this.createAsync({
+        name: trimmed,
+        psk: '',
+        pskLength: 0,
+        isEnabled: false,
+        enforceNameValidation: false,
+        description: 'Auto-registered for MQTT channel permissions (no PSK)',
+        createdBy: null,
+      });
+    })();
+    // Register before the first await above has a chance to clear it.
+    this.passiveCreateInFlight.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      this.passiveCreateInFlight.delete(key);
+    }
   }
 
   /**

--- a/src/server/migrations/102_consolidate_mqtt_channels.test.ts
+++ b/src/server/migrations/102_consolidate_mqtt_channels.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Migration 102 — consolidate MQTT channels by name.
+ *
+ * Seeds the observed split scenario (duplicate channel_database rows, hash-keyed
+ * MQTT channels rows, stranded raw-hash messages) on an in-memory SQLite DB and
+ * asserts everything collapses onto the canonical CHANNEL_DB_OFFSET + dbId
+ * identity — while TCP device slots are left untouched.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './102_consolidate_mqtt_channels.js';
+
+const OFFSET = 100;
+
+function setupSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE sources (id TEXT PRIMARY KEY, type TEXT NOT NULL);
+    CREATE TABLE channel_database (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, psk TEXT NOT NULL, psk_length INTEGER NOT NULL DEFAULT 0,
+      description TEXT, is_enabled INTEGER NOT NULL DEFAULT 1,
+      enforce_name_validation INTEGER NOT NULL DEFAULT 0, sort_order INTEGER NOT NULL DEFAULT 0,
+      decrypted_packet_count INTEGER NOT NULL DEFAULT 0, last_decrypted_at INTEGER,
+      created_by INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE channel_database_permissions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
+      channel_database_id INTEGER NOT NULL, can_view_on_map INTEGER NOT NULL DEFAULT 0,
+      can_read INTEGER NOT NULL DEFAULT 0, granted_by INTEGER, granted_at INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE channels (
+      pk INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER NOT NULL, name TEXT,
+      sourceId TEXT, role INTEGER DEFAULT 2
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY, channel INTEGER NOT NULL DEFAULT 0, sourceId TEXT
+    );
+  `);
+}
+
+function seedDb(db: Database.Database) {
+  const now = 1700000000000;
+  const cd = db.prepare(
+    `INSERT INTO channel_database (id, name, psk, psk_length, description, is_enabled, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  // Duplicate passive "Primary" rows (race), distinct keyed channels.
+  cd.run(1, 'Primary', '', 0, 'passive', 0, now, now);
+  cd.run(2, 'Primary', '', 0, 'passive', 0, now, now); // dup of id 1
+  cd.run(3, 'LongFast', 'AQ==', 1, 'seeded', 1, now, now);
+  cd.run(4, 'MediumFast', 'AQ==', 1, 'seeded', 1, now, now);
+
+  // Permissions: user 7 granted on the dup id 2 → must repoint to id 1.
+  db.prepare(
+    `INSERT INTO channel_database_permissions (user_id, channel_database_id, can_read, granted_at) VALUES (?, ?, 1, ?)`,
+  ).run(7, 2, now);
+
+  db.prepare(`INSERT INTO sources (id, type) VALUES (?, ?)`).run('mqtt1', 'mqtt_bridge');
+  db.prepare(`INSERT INTO sources (id, type) VALUES (?, ?)`).run('tcp1', 'meshtastic_tcp');
+
+  const ch = db.prepare(`INSERT INTO channels (id, name, sourceId) VALUES (?, ?, ?)`);
+  // MQTT hash-keyed rows: LongFast split across 1/8/40(lowercase), MediumFast on 31.
+  ch.run(1, 'LongFast', 'mqtt1');
+  ch.run(8, 'LongFast', 'mqtt1');
+  ch.run(40, 'Longfast', 'mqtt1'); // case drift — same logical channel
+  ch.run(31, 'MediumFast', 'mqtt1');
+  // Hash >= OFFSET (channel hashes range 0-255) — must still be deleted.
+  ch.run(168, 'MediumFast', 'mqtt1');
+  // TCP device slot — MUST be left untouched.
+  ch.run(0, 'Primary', 'tcp1');
+
+  const m = db.prepare(`INSERT INTO messages (id, channel, sourceId) VALUES (?, ?, ?)`);
+  m.run('m1', OFFSET + 1, 'mqtt1'); // Primary canonical
+  m.run('m2', OFFSET + 2, 'mqtt1'); // Primary dup → should become OFFSET+1
+  m.run('m3', 8, 'mqtt1');          // stranded raw hash → LongFast (db 3) → 103
+  m.run('m4', 1, 'mqtt1');          // stranded raw hash → LongFast (db 3) → 103
+  m.run('m5', 31, 'mqtt1');         // stranded raw hash → MediumFast (db 4) → 104
+  m.run('m6', 40, 'mqtt1');         // stranded lowercase → LongFast (db 3) → 103
+  m.run('m7', 0, 'tcp1');           // TCP slot-0 message — MUST be untouched
+  m.run('m8', OFFSET + 4, 'mqtt1'); // already-canonical MediumFast (104) — unchanged
+}
+
+describe('migration 102 — consolidate MQTT channels', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    setupSchema(db);
+    seedDb(db);
+    migration.up(db);
+  });
+
+  it('merges duplicate channel_database rows by (lower(name), psk)', () => {
+    const primaries = db.prepare(`SELECT id FROM channel_database WHERE lower(name) = 'primary'`).all();
+    expect(primaries).toEqual([{ id: 1 }]); // dup id 2 removed
+  });
+
+  it('repoints messages off the merged duplicate dbId', () => {
+    const ch = (id: string) => (db.prepare(`SELECT channel FROM messages WHERE id = ?`).get(id) as { channel: number }).channel;
+    expect(ch('m1')).toBe(OFFSET + 1);
+    expect(ch('m2')).toBe(OFFSET + 1); // 102 → 101
+  });
+
+  it('repoints channel_database_permissions off the duplicate', () => {
+    const perm = db.prepare(`SELECT channel_database_id FROM channel_database_permissions WHERE user_id = 7`).get() as { channel_database_id: number };
+    expect(perm.channel_database_id).toBe(1);
+  });
+
+  it('deletes all hash-keyed channels rows for the MQTT source (incl. hashes >= OFFSET)', () => {
+    const rows = db.prepare(`SELECT id FROM channels WHERE sourceId = 'mqtt1'`).all();
+    expect(rows).toEqual([]);
+  });
+
+  it('leaves already-canonical messages and ambiguous hash>=OFFSET messages untouched', () => {
+    // m8 was already on the canonical 104 and must stay; the hash-168 row is
+    // deleted but its (ambiguous) messages, if any, are not blindly repointed.
+    const m8 = db.prepare(`SELECT channel FROM messages WHERE id = 'm8'`).get() as { channel: number };
+    expect(m8.channel).toBe(OFFSET + 4);
+  });
+
+  it('repoints stranded raw-hash messages onto CHANNEL_DB_OFFSET + dbId by name', () => {
+    const ch = (id: string) => (db.prepare(`SELECT channel FROM messages WHERE id = ?`).get(id) as { channel: number }).channel;
+    expect(ch('m3')).toBe(OFFSET + 3); // raw 8  (LongFast)   → 103
+    expect(ch('m4')).toBe(OFFSET + 3); // raw 1  (LongFast)   → 103
+    expect(ch('m5')).toBe(OFFSET + 4); // raw 31 (MediumFast) → 104
+    expect(ch('m6')).toBe(OFFSET + 3); // raw 40 (Longfast)   → 103 (case-insensitive)
+  });
+
+  it('leaves TCP device channels and their messages untouched', () => {
+    const slot = db.prepare(`SELECT id, name FROM channels WHERE sourceId = 'tcp1'`).all();
+    expect(slot).toEqual([{ id: 0, name: 'Primary' }]);
+    const m7 = db.prepare(`SELECT channel FROM messages WHERE id = 'm7'`).get() as { channel: number };
+    expect(m7.channel).toBe(0);
+  });
+
+  it('is idempotent — a second run changes nothing', () => {
+    migration.up(db); // run again
+    const cdCount = db.prepare(`SELECT COUNT(*) AS c FROM channel_database`).get() as { c: number };
+    const mqttChans = db.prepare(`SELECT COUNT(*) AS c FROM channels WHERE sourceId = 'mqtt1'`).get() as { c: number };
+    expect(cdCount.c).toBe(3); // Primary(1), LongFast(3), MediumFast(4)
+    expect(mqttChans.c).toBe(0);
+  });
+});

--- a/src/server/migrations/102_consolidate_mqtt_channels.ts
+++ b/src/server/migrations/102_consolidate_mqtt_channels.ts
@@ -1,0 +1,266 @@
+/**
+ * Migration 102: Consolidate MQTT channels by name (issue: channels split by
+ * sending slot/hash).
+ *
+ * For MQTT sources the same logical channel was stored under multiple
+ * identities, fragmenting the per-source Channels tab and Unified Messages:
+ *
+ *   A. `channel_database` accumulated byte-identical duplicate rows for the same
+ *      name (a non-atomic find-then-create race during concurrent MQTT ingest,
+ *      with no unique constraint). Messages then split across
+ *      `CHANNEL_DB_OFFSET + dupId`.
+ *   B. `recordChannelFromEnvelope` wrote a `channels` row keyed by the per-packet
+ *      `channel` byte — a channel *hash* on MQTT, not a stable 0-7 slot — so one
+ *      named channel produced many rows (LongFast at 0/1/8/40, …). Some messages
+ *      were also stranded on the raw hash when name resolution missed at ingest.
+ *
+ * This migration consolidates everything onto the canonical
+ * `CHANNEL_DB_OFFSET + channel_database.id` identity:
+ *
+ *   Part A — merge `channel_database` rows identical in (lower(name), psk):
+ *            keep the lowest id, repoint messages + channel_database_permissions,
+ *            delete the duplicates.
+ *   Part B — for MQTT/bridge sources only (never TCP device slots 0-7): for each
+ *            hash-keyed `channels` row (id < OFFSET, named), resolve the name to a
+ *            channel_database id (creating a passive row if missing), repoint that
+ *            source's messages from the raw id to `OFFSET + dbId`, and delete the
+ *            hash `channels` row.
+ *
+ * Going forward `recordChannelFromEnvelope` no longer writes hash-keyed rows and
+ * `findOrCreatePassiveByNameAsync` serializes concurrent creates, so neither
+ * splitter recurs.
+ *
+ * Idempotent: after one run there are no duplicate channel_database rows and no
+ * sub-OFFSET MQTT-source channels rows, so re-running is a no-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const OFFSET = 100;
+const MQTT_TYPES = ['mqtt_bridge', 'mqtt_broker'];
+const PASSIVE_DESC = 'Auto-registered for MQTT channel permissions (no PSK)';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 102 (SQLite): consolidating MQTT channels by name...');
+
+    // Part A — merge duplicate channel_database rows by (lower(name), psk).
+    const dupGroups = db.prepare(`
+      SELECT lower(name) AS lname, psk, MIN(id) AS keepId
+      FROM channel_database
+      GROUP BY lower(name), psk
+      HAVING COUNT(*) > 1
+    `).all() as Array<{ lname: string; psk: string; keepId: number }>;
+
+    let mergedDbRows = 0;
+    for (const g of dupGroups) {
+      const ids = (db.prepare(
+        `SELECT id FROM channel_database WHERE lower(name) = ? AND psk = ? ORDER BY id`,
+      ).all(g.lname, g.psk) as Array<{ id: number }>).map((r) => r.id);
+      const keep = g.keepId;
+      for (const dup of ids) {
+        if (dup === keep) continue;
+        db.prepare(`UPDATE messages SET channel = ? WHERE channel = ?`).run(OFFSET + keep, OFFSET + dup);
+        db.prepare(`UPDATE channel_database_permissions SET channel_database_id = ? WHERE channel_database_id = ?`).run(keep, dup);
+        db.prepare(`DELETE FROM channel_database WHERE id = ?`).run(dup);
+        mergedDbRows++;
+      }
+    }
+
+    // Part B — collapse hash-keyed channels rows for MQTT sources.
+    const placeholders = MQTT_TYPES.map(() => '?').join(', ');
+    const mqttSources = (db.prepare(
+      `SELECT id FROM sources WHERE type IN (${placeholders})`,
+    ).all(...MQTT_TYPES) as Array<{ id: string }>).map((r) => r.id);
+
+    const resolveDbId = (name: string): number => {
+      const lower = name.trim().toLowerCase();
+      const row = db.prepare(
+        `SELECT id FROM channel_database WHERE lower(name) = ? ORDER BY id LIMIT 1`,
+      ).get(lower) as { id: number } | undefined;
+      if (row) return row.id;
+      const now = Date.now();
+      const res = db.prepare(`
+        INSERT INTO channel_database
+          (name, psk, psk_length, description, is_enabled, enforce_name_validation,
+           sort_order, decrypted_packet_count, created_at, updated_at)
+        VALUES (?, '', 0, ?, 0, 0, 0, 0, ?, ?)
+      `).run(name.trim(), PASSIVE_DESC, now, now);
+      return Number(res.lastInsertRowid);
+    };
+
+    // MQTT sources never sync real device channels, so every `channels` row on
+    // them is hash junk — collapse them all (a hash can be 0-255, so we cannot
+    // filter on `id < OFFSET`). Messages are only repointed for unambiguous raw
+    // hashes (`< OFFSET`); a raw hash >= OFFSET is indistinguishable from a
+    // legitimate CHANNEL_DB_OFFSET+dbId message, so we leave those untouched.
+    let collapsedChannelRows = 0;
+    let repointedMessages = 0;
+    for (const sourceId of mqttSources) {
+      const rows = db.prepare(`
+        SELECT id, name FROM channels
+        WHERE sourceId = ? AND name IS NOT NULL AND trim(name) <> ''
+      `).all(sourceId) as Array<{ id: number; name: string }>;
+      for (const r of rows) {
+        const dbId = resolveDbId(r.name);
+        if (r.id < OFFSET) {
+          const upd = db.prepare(
+            `UPDATE messages SET channel = ? WHERE sourceId = ? AND channel = ?`,
+          ).run(OFFSET + dbId, sourceId, r.id);
+          repointedMessages += upd.changes;
+        }
+        db.prepare(`DELETE FROM channels WHERE sourceId = ? AND id = ?`).run(sourceId, r.id);
+        collapsedChannelRows++;
+      }
+    }
+
+    logger.info(
+      `Migration 102 complete (SQLite): merged ${mergedDbRows} duplicate channel_database row(s), ` +
+      `collapsed ${collapsedChannelRows} MQTT channel row(s), repointed ${repointedMessages} message(s).`,
+    );
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 102 down: not implemented (data consolidation is not reversible)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration102Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 102 (PostgreSQL): consolidating MQTT channels by name...');
+
+  // Part A — merge duplicate channel_database rows by (lower(name), psk).
+  const dupGroups = await client.query(`
+    SELECT lower(name) AS lname, psk, MIN(id) AS "keepId"
+    FROM channel_database
+    GROUP BY lower(name), psk
+    HAVING COUNT(*) > 1
+  `);
+  for (const g of dupGroups.rows) {
+    const ids = (await client.query(
+      `SELECT id FROM channel_database WHERE lower(name) = $1 AND psk = $2 ORDER BY id`,
+      [g.lname, g.psk],
+    )).rows.map((r) => r.id as number);
+    const keep = g.keepId as number;
+    for (const dup of ids) {
+      if (dup === keep) continue;
+      await client.query(`UPDATE messages SET channel = $1 WHERE channel = $2`, [OFFSET + keep, OFFSET + dup]);
+      await client.query(`UPDATE channel_database_permissions SET "channelDatabaseId" = $1 WHERE "channelDatabaseId" = $2`, [keep, dup]);
+      await client.query(`DELETE FROM channel_database WHERE id = $1`, [dup]);
+    }
+  }
+
+  // Part B — collapse hash-keyed channels rows for MQTT sources.
+  const mqttSources = (await client.query(
+    `SELECT id FROM sources WHERE type = ANY($1)`,
+    [MQTT_TYPES],
+  )).rows.map((r) => r.id as string);
+
+  const resolveDbId = async (name: string): Promise<number> => {
+    const lower = name.trim().toLowerCase();
+    const found = await client.query(
+      `SELECT id FROM channel_database WHERE lower(name) = $1 ORDER BY id LIMIT 1`,
+      [lower],
+    );
+    if (found.rows[0]) return found.rows[0].id as number;
+    const now = Date.now();
+    const ins = await client.query(`
+      INSERT INTO channel_database
+        (name, psk, "pskLength", description, "isEnabled", "enforceNameValidation",
+         "sortOrder", "decryptedPacketCount", "createdAt", "updatedAt")
+      VALUES ($1, '', 0, $2, false, false, 0, 0, $3, $4)
+      RETURNING id
+    `, [name.trim(), PASSIVE_DESC, now, now]);
+    return ins.rows[0].id as number;
+  };
+
+  for (const sourceId of mqttSources) {
+    const rows = (await client.query(`
+      SELECT id, name FROM channels
+      WHERE "sourceId" = $1 AND name IS NOT NULL AND trim(name) <> ''
+    `, [sourceId])).rows as Array<{ id: number; name: string }>;
+    for (const r of rows) {
+      const dbId = await resolveDbId(r.name);
+      if (r.id < OFFSET) {
+        await client.query(
+          `UPDATE messages SET channel = $1 WHERE "sourceId" = $2 AND channel = $3`,
+          [OFFSET + dbId, sourceId, r.id],
+        );
+      }
+      await client.query(`DELETE FROM channels WHERE "sourceId" = $1 AND id = $2`, [sourceId, r.id]);
+    }
+  }
+
+  logger.info('Migration 102 complete (PostgreSQL): MQTT channels consolidated by name.');
+}
+
+// ============ MySQL ============
+
+export async function runMigration102Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 102 (MySQL): consolidating MQTT channels by name...');
+
+  // Part A — merge duplicate channel_database rows by (lower(name), psk).
+  const [dupRows] = await pool.query(`
+    SELECT LOWER(name) AS lname, psk, MIN(id) AS keepId
+    FROM channel_database
+    GROUP BY LOWER(name), psk
+    HAVING COUNT(*) > 1
+  `);
+  for (const g of dupRows as Array<{ lname: string; psk: string; keepId: number }>) {
+    const [idRows] = await pool.query(
+      `SELECT id FROM channel_database WHERE LOWER(name) = ? AND psk = ? ORDER BY id`,
+      [g.lname, g.psk],
+    );
+    const keep = g.keepId;
+    for (const { id: dup } of idRows as Array<{ id: number }>) {
+      if (dup === keep) continue;
+      await pool.query(`UPDATE messages SET channel = ? WHERE channel = ?`, [OFFSET + keep, OFFSET + dup]);
+      await pool.query(`UPDATE channel_database_permissions SET channelDatabaseId = ? WHERE channelDatabaseId = ?`, [keep, dup]);
+      await pool.query(`DELETE FROM channel_database WHERE id = ?`, [dup]);
+    }
+  }
+
+  // Part B — collapse hash-keyed channels rows for MQTT sources.
+  const [srcRows] = await pool.query(`SELECT id FROM sources WHERE type IN (?)`, [MQTT_TYPES]);
+  const mqttSources = (srcRows as Array<{ id: string }>).map((r) => r.id);
+
+  const resolveDbId = async (name: string): Promise<number> => {
+    const lower = name.trim().toLowerCase();
+    const [found] = await pool.query(
+      `SELECT id FROM channel_database WHERE LOWER(name) = ? ORDER BY id LIMIT 1`,
+      [lower],
+    );
+    const existing = (found as Array<{ id: number }>)[0];
+    if (existing) return existing.id;
+    const now = Date.now();
+    const [ins] = await pool.query(`
+      INSERT INTO channel_database
+        (name, psk, pskLength, description, isEnabled, enforceNameValidation,
+         sortOrder, decryptedPacketCount, createdAt, updatedAt)
+      VALUES (?, '', 0, ?, false, false, 0, 0, ?, ?)
+    `, [name.trim(), PASSIVE_DESC, now, now]);
+    return Number((ins as { insertId: number }).insertId);
+  };
+
+  for (const sourceId of mqttSources) {
+    const [rows] = await pool.query(`
+      SELECT id, name FROM channels
+      WHERE sourceId = ? AND name IS NOT NULL AND TRIM(name) <> ''
+    `, [sourceId]);
+    for (const r of rows as Array<{ id: number; name: string }>) {
+      const dbId = await resolveDbId(r.name);
+      if (r.id < OFFSET) {
+        await pool.query(
+          `UPDATE messages SET channel = ? WHERE sourceId = ? AND channel = ?`,
+          [OFFSET + dbId, sourceId, r.id],
+        );
+      }
+      await pool.query(`DELETE FROM channels WHERE sourceId = ? AND id = ?`, [sourceId, r.id]);
+    }
+  }
+
+  logger.info('Migration 102 complete (MySQL): MQTT channels consolidated by name.');
+}

--- a/src/server/migrations/102_consolidate_mqtt_channels.ts
+++ b/src/server/migrations/102_consolidate_mqtt_channels.ts
@@ -132,6 +132,10 @@ export const migration = {
 export async function runMigration102Postgres(client: import('pg').PoolClient): Promise<void> {
   logger.info('Running migration 102 (PostgreSQL): consolidating MQTT channels by name...');
 
+  let mergedDbRows = 0;
+  let collapsedChannelRows = 0;
+  let repointedMessages = 0;
+
   // Part A — merge duplicate channel_database rows by (lower(name), psk).
   const dupGroups = await client.query(`
     SELECT lower(name) AS lname, psk, MIN(id) AS "keepId"
@@ -150,6 +154,7 @@ export async function runMigration102Postgres(client: import('pg').PoolClient): 
       await client.query(`UPDATE messages SET channel = $1 WHERE channel = $2`, [OFFSET + keep, OFFSET + dup]);
       await client.query(`UPDATE channel_database_permissions SET "channelDatabaseId" = $1 WHERE "channelDatabaseId" = $2`, [keep, dup]);
       await client.query(`DELETE FROM channel_database WHERE id = $1`, [dup]);
+      mergedDbRows++;
     }
   }
 
@@ -185,22 +190,31 @@ export async function runMigration102Postgres(client: import('pg').PoolClient): 
     for (const r of rows) {
       const dbId = await resolveDbId(r.name);
       if (r.id < OFFSET) {
-        await client.query(
+        const upd = await client.query(
           `UPDATE messages SET channel = $1 WHERE "sourceId" = $2 AND channel = $3`,
           [OFFSET + dbId, sourceId, r.id],
         );
+        repointedMessages += upd.rowCount ?? 0;
       }
       await client.query(`DELETE FROM channels WHERE "sourceId" = $1 AND id = $2`, [sourceId, r.id]);
+      collapsedChannelRows++;
     }
   }
 
-  logger.info('Migration 102 complete (PostgreSQL): MQTT channels consolidated by name.');
+  logger.info(
+    `Migration 102 complete (PostgreSQL): merged ${mergedDbRows} duplicate channel_database row(s), ` +
+    `collapsed ${collapsedChannelRows} MQTT channel row(s), repointed ${repointedMessages} message(s).`,
+  );
 }
 
 // ============ MySQL ============
 
 export async function runMigration102Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
   logger.info('Running migration 102 (MySQL): consolidating MQTT channels by name...');
+
+  let mergedDbRows = 0;
+  let collapsedChannelRows = 0;
+  let repointedMessages = 0;
 
   // Part A — merge duplicate channel_database rows by (lower(name), psk).
   const [dupRows] = await pool.query(`
@@ -220,11 +234,17 @@ export async function runMigration102Mysql(pool: import('mysql2/promise').Pool):
       await pool.query(`UPDATE messages SET channel = ? WHERE channel = ?`, [OFFSET + keep, OFFSET + dup]);
       await pool.query(`UPDATE channel_database_permissions SET channelDatabaseId = ? WHERE channelDatabaseId = ?`, [keep, dup]);
       await pool.query(`DELETE FROM channel_database WHERE id = ?`, [dup]);
+      mergedDbRows++;
     }
   }
 
-  // Part B — collapse hash-keyed channels rows for MQTT sources.
-  const [srcRows] = await pool.query(`SELECT id FROM sources WHERE type IN (?)`, [MQTT_TYPES]);
+  // Part B — collapse hash-keyed channels rows for MQTT sources. Use explicit
+  // placeholders rather than relying on mysql2's nested-array `IN (?)` expansion.
+  const typePlaceholders = MQTT_TYPES.map(() => '?').join(', ');
+  const [srcRows] = await pool.query(
+    `SELECT id FROM sources WHERE type IN (${typePlaceholders})`,
+    [...MQTT_TYPES],
+  );
   const mqttSources = (srcRows as Array<{ id: string }>).map((r) => r.id);
 
   const resolveDbId = async (name: string): Promise<number> => {
@@ -253,14 +273,19 @@ export async function runMigration102Mysql(pool: import('mysql2/promise').Pool):
     for (const r of rows as Array<{ id: number; name: string }>) {
       const dbId = await resolveDbId(r.name);
       if (r.id < OFFSET) {
-        await pool.query(
+        const [upd] = await pool.query(
           `UPDATE messages SET channel = ? WHERE sourceId = ? AND channel = ?`,
           [OFFSET + dbId, sourceId, r.id],
         );
+        repointedMessages += (upd as { affectedRows?: number }).affectedRows ?? 0;
       }
       await pool.query(`DELETE FROM channels WHERE sourceId = ? AND id = ?`, [sourceId, r.id]);
+      collapsedChannelRows++;
     }
   }
 
-  logger.info('Migration 102 complete (MySQL): MQTT channels consolidated by name.');
+  logger.info(
+    `Migration 102 complete (MySQL): merged ${mergedDbRows} duplicate channel_database row(s), ` +
+    `collapsed ${collapsedChannelRows} MQTT channel row(s), repointed ${repointedMessages} message(s).`,
+  );
 }

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -180,11 +180,13 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
     return { ingested: false, reason: 'decode-error', portnum };
   }
 
-  // Surface the channel this packet came in on so the unified channel
-  // picker shows it. Fire-and-forget: a failed upsert just means the
-  // picker won't surface this channel for this source — the packet
-  // ingest itself is unaffected.
-  recordChannelFromEnvelope(sourceId, envelope, packet);
+  // NOTE: we intentionally do NOT write a slot/hash-keyed row to the `channels`
+  // table here. On MQTT `packet.channel` is a per-sender channel *hash* (0-255),
+  // not a stable 0-7 slot, so doing so split one logical channel (e.g. LongFast)
+  // into many rows keyed by whatever hash each gateway used. The channel instead
+  // surfaces by NAME through its channel_database row (resolved just below) — as
+  // message rows on `CHANNEL_DB_OFFSET + dbId` and as a virtual channel in
+  // /api/unified/channels. See docs/internal/dev-notes/MQTT_CHANNEL_CONSOLIDATION.md.
 
   // Resolve the channel_database row for this packet so downstream rows are
   // permission-keyed via channel_database_permissions instead of the raw
@@ -891,15 +893,6 @@ async function ingestStoreForward(
 }
 
 /**
- * Per-source memo of (slot, channelName) pairs we've already upserted into
- * the channels table this process lifetime. Used to keep `recordChannelFromEnvelope`
- * cheap: only the first packet on a given (source, slot, name) combination
- * actually hits the DB. Names that change for an existing slot still trigger
- * a fresh upsert so the picker stays in sync.
- */
-const channelMemo = new Map<string, Map<number, string>>();
-
-/**
  * Process-lifetime cache mapping lower-cased channel names to channel_database
  * row IDs. Avoids hitting the DB on every MQTT packet for the same name. The
  * cache is invalidated for a single name on the rare write that mints a new
@@ -951,56 +944,7 @@ async function resolveChannelDatabaseIdForMqtt(
 
 /** Exposed for tests to reset between cases. */
 export function _resetMqttIngestCachesForTest(): void {
-  channelMemo.clear();
   channelNameToDbIdCache.clear();
-}
-
-function recordChannelFromEnvelope(
-  sourceId: string,
-  envelope: ServiceEnvelopeShape,
-  packet: NonNullable<ServiceEnvelopeShape['packet']>,
-): void {
-  const name = envelope.channelId?.trim();
-  if (!name) return;
-  const slot = typeof packet.channel === 'number' ? packet.channel : 0;
-  if (slot < 0 || slot > 255) return;
-
-  let perSource = channelMemo.get(sourceId);
-  if (!perSource) {
-    perSource = new Map();
-    channelMemo.set(sourceId, perSource);
-  }
-  if (perSource.get(slot) === name) return;
-  perSource.set(slot, name);
-
-  try {
-    const result = databaseService.channels?.upsertChannel(
-      {
-        id: slot,
-        name,
-        // Slot 0 is the primary channel on Meshtastic; anything else is
-        // secondary. Matches the role rules in `upsertChannel`.
-        role: slot === 0 ? 1 : 2,
-        uplinkEnabled: true,
-        downlinkEnabled: true,
-      },
-      sourceId,
-    );
-    if (result && typeof (result as any).catch === 'function') {
-      (result as Promise<unknown>).catch((err) => {
-        // Clear the memo entry so a retry can run on the next packet —
-        // losing a single write isn't fatal, but persistently skipping
-        // it would keep the channel invisible in the picker.
-        perSource!.delete(slot);
-        const m = err instanceof Error ? err.message : String(err);
-        logger.debug(`MQTT channel upsert skipped for source ${sourceId} slot ${slot}: ${m}`);
-      });
-    }
-  } catch (err) {
-    perSource.delete(slot);
-    const m = err instanceof Error ? err.message : String(err);
-    logger.debug(`MQTT channel upsert unavailable for source ${sourceId} slot ${slot}: ${m}`);
-  }
 }
 
 function bytesToHex(buf: Uint8Array | ArrayLike<number>): string {


### PR DESCRIPTION
## Summary

For MQTT sources, one logical channel (e.g. **LongFast**) was fragmenting into many across both the per-source **Channels tab** and **Unified Messages**, because channel identity was keyed off the per-packet `channel` byte — which on MQTT is a channel **hash** (0–255), not a stable 0–7 slot.

Confirmed in live dev data (`Official MQTT`): `LongFast` rows at `0/1/8/40`, `MediumFast` at `0/31`, plus duplicate `channel_database` rows and messages stranded on raw hashes.

## Three splitters fixed

1. **`recordChannelFromEnvelope` wrote a `channels` row per hash.** → Stop writing hash-keyed `channels` rows for MQTT entirely. The channel now surfaces by **name** through its `channel_database` row: message rows on `CHANNEL_DB_OFFSET + dbId` and the virtual-channel path in `/api/unified/channels`.
2. **`findOrCreatePassiveByNameAsync` raced in duplicate rows** (non-atomic find-then-create, no unique constraint) → byte-identical pairs (`Primary` 3&4, `Wong` 5&6, …). → Serialize concurrent creates per `lower(name)` via an in-flight promise cache (the race is in-process; a cross-backend functional/text unique index is awkward).
3. **Messages stranded on the raw hash** when the name didn't resolve at ingest.

## Migration 102 (`consolidate_mqtt_channels`)

Backfills existing data across SQLite/PostgreSQL/MySQL:
- Merge `channel_database` rows identical in `(lower(name), psk)` — repointing messages + `channel_database_permissions`, keeping the lowest id.
- For **MQTT/bridge sources only** (never TCP slots 0–7): collapse every hash-keyed `channels` row, and repoint unambiguous raw-hash (`< CHANNEL_DB_OFFSET`) messages onto `CHANNEL_DB_OFFSET + dbId`.

Idempotent; scoped to `mqtt_bridge`/`mqtt_broker` source types.

## Design notes

- Canonical identity = the `channel_database` row. Decrypted packets stay **key-verified** (`decoded.channelDatabaseId`); name-only packets resolve by `channelId`. So "same channel only if the key aligns" is honoured.
- Dedup key is `(lower(name), psk)`, not name alone — preserves the decryption feature's ability to hold same-named/different-key entries.
- Channel hashes span 0–255, so the migration collapses *all* MQTT `channels` rows (not just `< OFFSET`) but only repoints messages on unambiguous `< OFFSET` hashes (a raw hash ≥ OFFSET is indistinguishable from a real `CHANNEL_DB_OFFSET+dbId`).

## Verification

- **Full Vitest suite: 7391 passed / 0 failed.** New tests: migration consolidation + idempotency (incl. hash ≥ OFFSET and TCP-untouched), and the passive-create race guard.
- **Live data** (deployed dev container, migration ran on real split data):
  - `channel_database` duplicate names: **0 remaining**
  - MQTT-source `channels` rows: **0 remaining** (all hash junk collapsed)
  - Official MQTT messages re-consolidated: `LongFast` 20→**27** (stranded raw `8`+`1` folded in), `MediumFast` 479→**485** (stranded raw `31` folded in); raw channels `31/8/1` gone.
  - `/api/unified/channels`: `LongFast` a **single** entry @ `102`, `MediumFast` a single entry @ `101`, **zero duplicate names**.

See `docs/internal/dev-notes/MQTT_CHANNEL_CONSOLIDATION.md` for the full analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)