### PR TITLE
fix(mqtt): identify channels by name AND key; enumerate them on the Channels tab

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 103 migrations registered', () => {
-    expect(registry.count()).toBe(103);
+  it('has all 104 migrations registered', () => {
+    expect(registry.count()).toBe(104);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is consolidate_mqtt_channels', () => {
+  it('last migration is add_channel_database_hash', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(103);
-    expect(last.name).toContain('consolidate_mqtt_channels');
+    expect(last.number).toBe(104);
+    expect(last.name).toContain('add_channel_database_hash');
   });
 
-  it('migrations are sequentially numbered from 1 to 103', () => {
+  it('migrations are sequentially numbered from 1 to 104', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -118,6 +118,7 @@ import { migration as meshcoreChannelScopeMigration, runMigration100Postgres as 
 import { migration as nodeUnmessagableMigration, runMigration101Postgres as runNodeUnmessagablePostgres, runMigration101Mysql as runNodeUnmessagableMysql } from '../server/migrations/101_add_node_unmessagable.js';
 import { migration as meshcoreHeardRepeatersMigration, runMigration102Postgres as runMeshcoreHeardRepeatersPostgres, runMigration102Mysql as runMeshcoreHeardRepeatersMysql } from '../server/migrations/102_create_meshcore_heard_repeaters.js';
 import { migration as consolidateMqttChannelsMigration, runMigration103Postgres as runConsolidateMqttChannelsPostgres, runMigration103Mysql as runConsolidateMqttChannelsMysql } from '../server/migrations/103_consolidate_mqtt_channels.js';
+import { migration as channelDatabaseHashMigration, runMigration104Postgres as runChannelDatabaseHashPostgres, runMigration104Mysql as runChannelDatabaseHashMysql } from '../server/migrations/104_add_channel_database_hash.js';
 
 // ============================================================================
 // Registry
@@ -1634,4 +1635,19 @@ registry.register({
   sqlite: (db) => consolidateMqttChannelsMigration.up(db),
   postgres: (client) => runConsolidateMqttChannelsPostgres(client),
   mysql: (pool) => runConsolidateMqttChannelsMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 104: add channel_hash to channel_database so MQTT channels are
+// identified by (name, hash) — two same-name/different-key undecryptable
+// channels stay distinct.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 104,
+  name: 'add_channel_database_hash',
+  settingsKey: 'migration_104_add_channel_database_hash',
+  sqlite: (db) => channelDatabaseHashMigration.up(db),
+  postgres: (client) => runChannelDatabaseHashPostgres(client),
+  mysql: (pool) => runChannelDatabaseHashMysql(pool),
 });

--- a/src/db/repositories/channelDatabase.test.ts
+++ b/src/db/repositories/channelDatabase.test.ts
@@ -42,6 +42,7 @@ const POSTGRES_CREATE = `
     name TEXT NOT NULL,
     psk TEXT NOT NULL,
     "pskLength" INTEGER NOT NULL DEFAULT 32,
+    "channelHash" INTEGER,
     description TEXT,
     "isEnabled" BOOLEAN NOT NULL DEFAULT TRUE,
     "enforceNameValidation" BOOLEAN NOT NULL DEFAULT FALSE,
@@ -89,6 +90,7 @@ const MYSQL_CREATE = `
     name VARCHAR(255) NOT NULL,
     psk VARCHAR(255) NOT NULL,
     pskLength INT NOT NULL DEFAULT 32,
+    channelHash INT,
     description TEXT,
     isEnabled BOOLEAN NOT NULL DEFAULT TRUE,
     enforceNameValidation BOOLEAN NOT NULL DEFAULT FALSE,
@@ -460,6 +462,90 @@ function runChannelDbTests(getBackend: () => TestBackend) {
     expect(new Set(ids).size).toBe(1);
     const all = await repo.getAllAsync();
     expect(all.filter((c) => (c.name ?? '').toLowerCase() === 'primary')).toHaveLength(1);
+  });
+
+  // --- findOrCreateByNameAndHashAsync (name + key identity) ---
+  // LongFast on the default key (`AQ==`) has Meshtastic channel hash 8:
+  //   hash = xorHash("LongFast") ^ xorHash(expand(AQ==)).
+
+  it('findOrCreateByNameAndHashAsync - matches an enabled row by its computed hash', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    // Enabled LongFast on the default key.
+    const enabledId = await repo.createAsync({
+      name: 'LongFast', psk: 'AQ==', pskLength: 16, isEnabled: true,
+    });
+
+    // A decoded packet on LongFast with hash 8 should resolve to the enabled row,
+    // not mint a new passive one.
+    const resolved = await repo.findOrCreateByNameAndHashAsync('LongFast', 8);
+    expect(resolved).toBe(enabledId);
+    const all = await repo.getAllAsync();
+    expect(all.filter((c) => (c.name ?? '').toLowerCase() === 'longfast')).toHaveLength(1);
+  });
+
+  it('findOrCreateByNameAndHashAsync - same name, different hash creates a distinct passive row', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    // Enabled LongFast (default key, hash 8).
+    const enabledId = await repo.createAsync({
+      name: 'LongFast', psk: 'AQ==', pskLength: 16, isEnabled: true,
+    });
+
+    // An undecryptable LongFast packet under a DIFFERENT key arrives with hash 42.
+    const otherId = await repo.findOrCreateByNameAndHashAsync('LongFast', 42);
+    expect(otherId).not.toBe(enabledId);
+
+    const all = await repo.getAllAsync();
+    const longfasts = all.filter((c) => (c.name ?? '').toLowerCase() === 'longfast');
+    expect(longfasts).toHaveLength(2);
+    const passive = all.find((c) => c.id === otherId)!;
+    expect(passive.isEnabled).toBe(false);
+    expect(passive.psk).toBe('');
+    expect(passive.channelHash).toBe(42);
+
+    // The same name+hash reuses the passive row (no duplicate).
+    const again = await repo.findOrCreateByNameAndHashAsync('LongFast', 42);
+    expect(again).toBe(otherId);
+    expect((await repo.getAllAsync()).filter((c) => (c.name ?? '').toLowerCase() === 'longfast')).toHaveLength(2);
+  });
+
+  it('findOrCreateByNameAndHashAsync - two passive rows for distinct hashes stay distinct', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const a = await repo.findOrCreateByNameAndHashAsync('Gossip', 10);
+    const b = await repo.findOrCreateByNameAndHashAsync('Gossip', 20);
+    expect(a).not.toBe(b);
+    const all = await repo.getAllAsync();
+    expect(all.filter((c) => (c.name ?? '').toLowerCase() === 'gossip')).toHaveLength(2);
+  });
+
+  it('findOrCreateByNameAndHashAsync - null hash reuses a null-hash passive row (back-compat)', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    // findOrCreatePassiveByNameAsync passes hash=null under the hood.
+    const id = await repo.findOrCreatePassiveByNameAsync('NoHash');
+    const again = await repo.findOrCreateByNameAndHashAsync('NoHash', null);
+    expect(again).toBe(id);
+    // Zero / undefined hash normalizes to null too.
+    const zero = await repo.findOrCreateByNameAndHashAsync('NoHash', 0);
+    expect(zero).toBe(id);
+    expect((await repo.getAllAsync()).filter((c) => (c.name ?? '').toLowerCase() === 'nohash')).toHaveLength(1);
+  });
+
+  it('findOrCreateByNameAndHashAsync - concurrent calls for same name+hash collapse to one row', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const ids = await Promise.all(
+      Array.from({ length: 12 }, () => repo.findOrCreateByNameAndHashAsync('Busy', 99)),
+    );
+    expect(new Set(ids).size).toBe(1);
+    expect((await repo.getAllAsync()).filter((c) => (c.name ?? '').toLowerCase() === 'busy')).toHaveLength(1);
   });
 }
 

--- a/src/db/repositories/channelDatabase.ts
+++ b/src/db/repositories/channelDatabase.ts
@@ -8,6 +8,28 @@ import { eq, and, asc, sql } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbChannelDatabase, DbChannelDatabasePermission } from '../types.js';
 import { logger } from '../../utils/logger.js';
+import { expandShorthandPsk } from '../../server/constants/meshtastic.js';
+
+/**
+ * Meshtastic 8-bit XOR hash over a byte buffer. Mirrors `xorHash` in
+ * channelDecryptionService.ts. Duplicated here (rather than imported) to keep
+ * repositories free of a dependency on the server service layer, which would
+ * create a circular import (channelDecryptionService → databaseService →
+ * repositories).
+ */
+function xorHashBytes(bytes: Buffer): number {
+  let hash = 0;
+  for (let i = 0; i < bytes.length; i++) hash ^= bytes[i];
+  return hash & 0xff;
+}
+
+/**
+ * Compute the Meshtastic channel hash from a channel name and its (already
+ * expanded) PSK buffer: hash = xorHash(utf8(name)) ^ xorHash(psk).
+ */
+function computeChannelHashFromName(name: string, psk: Buffer): number {
+  return xorHashBytes(Buffer.from(name, 'utf8')) ^ xorHashBytes(psk);
+}
 
 /**
  * Channel database data for insert/update operations
@@ -16,6 +38,7 @@ export interface ChannelDatabaseInput {
   name: string;
   psk: string; // Base64-encoded PSK
   pskLength: number; // 16 for AES-128, 32 for AES-256
+  channelHash?: number | null; // Observed channel hash for passive MQTT rows
   description?: string | null;
   isEnabled?: boolean;
   enforceNameValidation?: boolean;
@@ -63,12 +86,13 @@ export class ChannelDatabaseRepository extends BaseRepository {
   }
 
   /**
-   * In-flight passive creates keyed by lower(name). MQTT ingest handles packets
-   * concurrently, so two packets for the same channel name can both miss the
-   * find SELECT and each INSERT a duplicate row. There is no cross-backend
-   * unique index on name (a functional/text unique index is awkward across
-   * SQLite/PostgreSQL/MySQL), so we serialize creates here — the race is in this
-   * single Node process. (Migration 103 merges any duplicates already on disk.)
+   * In-flight passive creates keyed by `lower(name)::hash`. MQTT ingest handles
+   * packets concurrently, so two packets for the same channel identity can both
+   * miss the find SELECT and each INSERT a duplicate row. There is no
+   * cross-backend unique index on (name, hash) (a functional/text unique index
+   * is awkward across SQLite/PostgreSQL/MySQL), so we serialize creates here —
+   * the race is in this single Node process. (Migration 103 merges any
+   * duplicates already on disk.)
    */
   private passiveCreateInFlight = new Map<string, Promise<number | null>>();
 
@@ -116,43 +140,64 @@ export class ChannelDatabaseRepository extends BaseRepository {
   }
 
   /**
-   * Find-or-create a "passive" channel_database row keyed by name. Passive =
-   * isEnabled=false with an empty PSK, so the row exists only as a target for
-   * channel_database_permissions (admins can grant view/read on it) and never
-   * participates in server-side decryption. Used by MQTT ingest to materialize
-   * a row for every observed channel name so the permission model can key
-   * MQTT-source data through channel_database instead of slot-indexed
-   * channel_0..7 grants.
-   *
-   * If a row already exists for the name (regardless of isEnabled), that row's
-   * id is returned and no changes are made — we never demote a real decryption
-   * entry by reusing its slot here.
+   * Find-or-create a "passive" channel_database row keyed by name only. Thin
+   * back-compat wrapper over {@link findOrCreateByNameAndHashAsync} with a null
+   * hash. Callers that have no observed channel hash (e.g. an unencrypted MQTT
+   * packet whose broker strips the channel byte) use this; it preserves the
+   * historical name-only matching behaviour.
    */
   async findOrCreatePassiveByNameAsync(name: string): Promise<number | null> {
+    return this.findOrCreateByNameAndHashAsync(name, null);
+  }
+
+  /**
+   * Find-or-create a channel_database row keyed by (name, channel hash). The
+   * channel hash is the Meshtastic 1-byte XOR hash seen on MQTT packets
+   * (`packet.channel`), which equals `xorHash(name) ^ xorHash(psk)`. Using it as
+   * a second identity dimension keeps two same-name / different-key channels
+   * distinct even when neither can be decrypted server-side.
+   *
+   * Matching, among rows sharing the same (case-insensitive) name:
+   *   1. An ENABLED row whose computed hash (from its name + expanded PSK)
+   *      equals `hash` → return it. This is the same, decryptable channel.
+   *   2. A PASSIVE row (no PSK) whose stored `channelHash` equals `hash` → return
+   *      it. This is the same observed-but-undecryptable channel.
+   *   3. If `hash` is null and a passive row with a null `channelHash` exists for
+   *      the name → return it (back-compat with name-only registration).
+   *   4. Otherwise create a new PASSIVE row (psk='', isEnabled=false) carrying
+   *      `channelHash = hash`.
+   *
+   * Passive rows exist only as targets for channel_database_permissions and
+   * never participate in server-side decryption. Enabled (real decryption)
+   * rows are never demoted or modified here.
+   */
+  async findOrCreateByNameAndHashAsync(name: string, hash: number | null): Promise<number | null> {
     const trimmed = name.trim();
     if (!trimmed) return null;
-    const existing = await this.getByNameAsync(trimmed);
-    // `DbChannelDatabase.id` is typed optional for insert shapes; a row read
-    // from the DB always has it set, so fall through to create only if it
-    // somehow isn't.
-    if (existing && typeof existing.id === 'number') return existing.id;
+    // Normalize a missing/zero-ish hash to null so callers can pass undefined/0
+    // meaning "no hash observed" without splitting a name-only channel.
+    const normalizedHash =
+      typeof hash === 'number' && Number.isFinite(hash) && hash > 0 ? Math.trunc(hash) & 0xff : null;
 
-    // Serialize concurrent creates for the same name (case-insensitive, matching
-    // getByNameAsync) so two in-flight MQTT packets don't each insert a
-    // duplicate passive row.
-    const key = trimmed.toLowerCase();
+    const matched = await this.matchByNameAndHash(trimmed, normalizedHash);
+    if (matched && typeof matched.id === 'number') return matched.id;
+
+    // Serialize concurrent creates for the same (name, hash) identity so two
+    // in-flight MQTT packets don't each insert a duplicate passive row.
+    const key = `${trimmed.toLowerCase()}::${normalizedHash ?? 'null'}`;
     const inFlight = this.passiveCreateInFlight.get(key);
     if (inFlight) return inFlight;
 
     const promise = (async (): Promise<number | null> => {
       // Re-check inside the guard: another call may have created the row between
       // our initial find and acquiring the in-flight slot.
-      const recheck = await this.getByNameAsync(trimmed);
+      const recheck = await this.matchByNameAndHash(trimmed, normalizedHash);
       if (recheck && typeof recheck.id === 'number') return recheck.id;
       return this.createAsync({
         name: trimmed,
         psk: '',
         pskLength: 0,
+        channelHash: normalizedHash,
         isEnabled: false,
         enforceNameValidation: false,
         description: 'Auto-registered for MQTT channel permissions (no PSK)',
@@ -165,6 +210,61 @@ export class ChannelDatabaseRepository extends BaseRepository {
       return await promise;
     } finally {
       this.passiveCreateInFlight.delete(key);
+    }
+  }
+
+  /**
+   * Find an existing channel_database row matching a (name, hash) identity using
+   * the priority rules documented on {@link findOrCreateByNameAndHashAsync}.
+   * Returns null if nothing matches.
+   */
+  private async matchByNameAndHash(
+    name: string,
+    normalizedHash: number | null,
+  ): Promise<DbChannelDatabase | null> {
+    const lower = name.trim().toLowerCase();
+    const all = await this.getAllAsync();
+    const sameName = all.filter((c) => (c.name ?? '').toLowerCase() === lower);
+    if (sameName.length === 0) return null;
+
+    if (normalizedHash !== null) {
+      // 1. Enabled row whose computed hash matches.
+      for (const row of sameName) {
+        if (!row.isEnabled || !row.psk) continue;
+        const computed = this.computeEnabledRowHash(row);
+        if (computed !== null && computed === normalizedHash) return row;
+      }
+      // 2. Passive row with a matching stored hash.
+      const passiveMatch = sameName.find(
+        (c) => !c.isEnabled && c.channelHash != null && (c.channelHash & 0xff) === normalizedHash,
+      );
+      if (passiveMatch) return passiveMatch;
+      return null;
+    }
+
+    // 3. Hash is null: reuse a passive row with a null stored hash (back-compat).
+    //    Prefer a passive null-hash row; fall back to any enabled row with the
+    //    name so we never mint a duplicate alongside a real decryption entry.
+    const passiveNull = sameName.find((c) => !c.isEnabled && (c.channelHash == null));
+    if (passiveNull) return passiveNull;
+    const enabled = sameName.find((c) => c.isEnabled);
+    if (enabled) return enabled;
+    return null;
+  }
+
+  /**
+   * Compute the Meshtastic channel hash for an ENABLED row from its stored name
+   * and base64 PSK (shorthand keys like `AQ==` are expanded the same way the
+   * decryption service does). Returns null if the PSK can't be expanded.
+   */
+  private computeEnabledRowHash(row: DbChannelDatabase): number | null {
+    try {
+      const raw = Buffer.from(row.psk, 'base64');
+      const expanded = expandShorthandPsk(raw);
+      if (!expanded) return null;
+      return computeChannelHashFromName(row.name, expanded);
+    } catch {
+      return null;
     }
   }
 
@@ -193,6 +293,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
       name: data.name,
       psk: data.psk,
       pskLength: data.pskLength,
+      channelHash: data.channelHash ?? null,
       description: data.description ?? null,
       isEnabled: data.isEnabled ?? true,
       enforceNameValidation: data.enforceNameValidation ?? false,
@@ -393,6 +494,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
       name: row.name,
       psk: row.psk,
       pskLength: row.pskLength,
+      channelHash: row.channelHash ?? null,
       description: row.description,
       isEnabled: Boolean(row.isEnabled),
       enforceNameValidation: Boolean(row.enforceNameValidation),

--- a/src/db/repositories/messages.distinctChannels.perSource.test.ts
+++ b/src/db/repositories/messages.distinctChannels.perSource.test.ts
@@ -1,0 +1,83 @@
+/**
+ * MessagesRepository.getDistinctChannelsForSource — verifies the Channels-tab
+ * helper enumerates distinct message channels per source (with counts and the
+ * latest timestamp), source-scoped, ordered most-active first.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MessagesRepository } from './messages.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+describe('MessagesRepository.getDistinctChannelsForSource', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MessagesRepository;
+
+  const NODE_NUM = 0xaabbccdd;
+  const NODE_ID = '!aabbccdd';
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    const now = Date.now();
+    for (const src of ['mqtt-1', 'mqtt-2']) {
+      db.prepare(
+        'INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)',
+      ).run(NODE_NUM, NODE_ID, src, now, now);
+    }
+    repo = new MessagesRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => db.close());
+
+  const insert = async (id: string, channel: number, sourceId: string, timestamp: number) =>
+    repo.insertMessage(
+      {
+        id,
+        fromNodeNum: NODE_NUM,
+        toNodeNum: NODE_NUM,
+        fromNodeId: NODE_ID,
+        toNodeId: NODE_ID,
+        text: 'hi',
+        channel,
+        portnum: 1,
+        timestamp,
+        rxTime: timestamp,
+        createdAt: timestamp,
+      } as any,
+      sourceId,
+    );
+
+  it('returns distinct channels with counts and last timestamp, ordered most-active first', async () => {
+    // mqtt-1: channel 101 x3 (latest ts 300), channel 102 x1.
+    await insert('a', 101, 'mqtt-1', 100);
+    await insert('b', 101, 'mqtt-1', 300);
+    await insert('c', 101, 'mqtt-1', 200);
+    await insert('d', 102, 'mqtt-1', 150);
+
+    const rows = await repo.getDistinctChannelsForSource('mqtt-1');
+    expect(rows).toEqual([
+      { channel: 101, messageCount: 3, lastTimestamp: 300 },
+      { channel: 102, messageCount: 1, lastTimestamp: 150 },
+    ]);
+  });
+
+  it('is source-scoped — does not leak channels from other sources', async () => {
+    await insert('a', 101, 'mqtt-1', 100);
+    await insert('b', 200, 'mqtt-2', 100);
+
+    const rows1 = await repo.getDistinctChannelsForSource('mqtt-1');
+    expect(rows1.map((r) => r.channel)).toEqual([101]);
+
+    const rows2 = await repo.getDistinctChannelsForSource('mqtt-2');
+    expect(rows2.map((r) => r.channel)).toEqual([200]);
+  });
+
+  it('returns [] for a source with no messages', async () => {
+    const rows = await repo.getDistinctChannelsForSource('mqtt-1');
+    expect(rows).toEqual([]);
+  });
+});

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -234,6 +234,41 @@ export class MessagesRepository extends BaseRepository {
   }
 
   /**
+   * Get the distinct `channel` numbers that have messages for a source, with a
+   * per-channel message count and the most recent message timestamp. Used by
+   * the Channels tab to enumerate the channel_database-backed virtual channels
+   * (`CHANNEL_DB_OFFSET + id`) that actually carry traffic for MQTT sources,
+   * which otherwise have no rows in the per-source `channels` table.
+   *
+   * Ordered most-active first (highest count), then by channel number.
+   */
+  async getDistinctChannelsForSource(
+    sourceId: string,
+  ): Promise<Array<{ channel: number; messageCount: number; lastTimestamp: number | null }>> {
+    const { messages } = this.tables;
+    const rows = await this.db
+      .select({
+        channel: messages.channel,
+        messageCount: count(),
+        lastTimestamp: sql<number | null>`MAX(${messages.timestamp})`,
+      })
+      .from(messages)
+      .where(this.withSourceScope(messages, sourceId))
+      .groupBy(messages.channel);
+
+    return rows
+      .map((r: any) => ({
+        channel: Number(r.channel),
+        messageCount: Number(r.messageCount),
+        lastTimestamp: r.lastTimestamp != null ? Number(r.lastTimestamp) : null,
+      }))
+      .filter((r: { channel: number }) => Number.isFinite(r.channel))
+      .sort((a: { messageCount: number; channel: number }, b: { messageCount: number; channel: number }) =>
+        b.messageCount - a.messageCount || a.channel - b.channel,
+      );
+  }
+
+  /**
    * Delete a message by ID
    */
   async deleteMessage(id: string): Promise<boolean> {

--- a/src/db/schema/channelDatabase.ts
+++ b/src/db/schema/channelDatabase.ts
@@ -32,6 +32,10 @@ export const channelDatabaseSqlite = sqliteTable('channel_database', {
   name: text('name').notNull(),
   psk: text('psk').notNull(), // Base64-encoded PSK
   pskLength: integer('psk_length').notNull(), // 16 for AES-128, 32 for AES-256
+  // Observed Meshtastic 1-byte channel hash (0-255) for PASSIVE (no-PSK) MQTT
+  // rows. Lets two same-name/different-key undecryptable channels stay distinct.
+  // NULL for enabled rows (their hash is computable from name + psk).
+  channelHash: integer('channel_hash'),
   description: text('description'),
   isEnabled: integer('is_enabled', { mode: 'boolean' }).notNull().default(true),
   enforceNameValidation: integer('enforce_name_validation', { mode: 'boolean' }).notNull().default(false),
@@ -66,6 +70,9 @@ export const channelDatabasePostgres = pgTable('channel_database', {
   name: pgText('name').notNull(),
   psk: pgText('psk').notNull(), // Base64-encoded PSK
   pskLength: pgInteger('pskLength').notNull(), // 16 for AES-128, 32 for AES-256
+  // Observed Meshtastic 1-byte channel hash (0-255) for PASSIVE (no-PSK) MQTT
+  // rows; NULL for enabled rows. See SQLite definition above.
+  channelHash: pgInteger('channelHash'),
   description: pgText('description'),
   isEnabled: pgBoolean('isEnabled').notNull().default(true),
   enforceNameValidation: pgBoolean('enforceNameValidation').notNull().default(false),
@@ -100,6 +107,9 @@ export const channelDatabaseMysql = mysqlTable('channel_database', {
   name: myVarchar('name', { length: 255 }).notNull(),
   psk: myVarchar('psk', { length: 255 }).notNull(), // Base64-encoded PSK
   pskLength: myInt('pskLength').notNull(), // 16 for AES-128, 32 for AES-256
+  // Observed Meshtastic 1-byte channel hash (0-255) for PASSIVE (no-PSK) MQTT
+  // rows; NULL for enabled rows. See SQLite definition above.
+  channelHash: myInt('channelHash'),
   description: myText('description'),
   isEnabled: myBoolean('isEnabled').notNull().default(true),
   enforceNameValidation: myBoolean('enforceNameValidation').notNull().default(false),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -403,6 +403,9 @@ export interface DbChannelDatabase {
   name: string;
   psk: string; // Base64-encoded PSK
   pskLength: number; // 16 for AES-128, 32 for AES-256
+  // Observed Meshtastic 1-byte channel hash (0-255) for passive (no-PSK) MQTT
+  // rows; null for enabled rows (computable from name + psk).
+  channelHash?: number | null;
   description?: string | null;
   isEnabled: boolean;
   enforceNameValidation: boolean;

--- a/src/server/migrations/104_add_channel_database_hash.test.ts
+++ b/src/server/migrations/104_add_channel_database_hash.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Migration 104 — Add channel_hash to channel_database (SQLite).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './104_add_channel_database_hash.js';
+
+function columnNames(db: Database.Database, table: string): string[] {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return cols.map((c) => c.name);
+}
+
+describe('Migration 104 — add channel_database.channel_hash (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`CREATE TABLE channel_database (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      psk TEXT NOT NULL
+    );`);
+  });
+
+  it('adds the channel_hash column', () => {
+    expect(columnNames(db, 'channel_database')).not.toContain('channel_hash');
+    migration.up(db);
+    expect(columnNames(db, 'channel_database')).toContain('channel_hash');
+  });
+
+  it('is idempotent — second run is a no-op', () => {
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+    expect(columnNames(db, 'channel_database')).toContain('channel_hash');
+  });
+
+  it('the new column defaults to NULL and round-trips a value', () => {
+    migration.up(db);
+
+    db.prepare(`INSERT INTO channel_database (name, psk) VALUES ('LongFast', 'AQ==')`).run();
+    const defaulted = db.prepare(`SELECT channel_hash FROM channel_database WHERE name = 'LongFast'`).get() as any;
+    expect(defaulted.channel_hash).toBeNull();
+
+    db.prepare(`INSERT INTO channel_database (name, psk, channel_hash) VALUES ('Secret', '', 42)`).run();
+    const stored = db.prepare(`SELECT channel_hash FROM channel_database WHERE name = 'Secret'`).get() as any;
+    expect(stored.channel_hash).toBe(42);
+  });
+});

--- a/src/server/migrations/104_add_channel_database_hash.ts
+++ b/src/server/migrations/104_add_channel_database_hash.ts
@@ -1,0 +1,86 @@
+/**
+ * Migration 104: Add channel_hash column to channel_database.
+ *
+ * MQTT channels are identified by NAME only, which collapses two same-name but
+ * differently-keyed channels into one row when neither can be decrypted
+ * server-side. The Meshtastic 1-byte channel hash (`packet.channel` on MQTT,
+ * = xorHash(name) ^ xorHash(psk)) gives us a second identity dimension.
+ *
+ * Column semantics:
+ *   - ENABLED rows (real PSK): channel_hash stays NULL — their hash is
+ *     computable from name + psk on demand.
+ *   - PASSIVE rows (psk=''): channel_hash stores the observed packet hash so
+ *     two same-name/different-key undecryptable channels stay distinct.
+ *
+ * Nullable integer (0-255), defaults to NULL. Existing rows keep NULL, which
+ * preserves the prior name-only matching behaviour.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 104 (SQLite): Adding channel_hash to channel_database...');
+
+    try {
+      db.exec('ALTER TABLE channel_database ADD COLUMN channel_hash INTEGER');
+      logger.debug('Added channel_database.channel_hash');
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug('channel_database.channel_hash already exists, skipping');
+      } else {
+        logger.warn('Could not add channel_database.channel_hash:', e.message);
+      }
+    }
+
+    logger.info('Migration 104 complete (SQLite): channel_database.channel_hash added');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 104 down: Not implemented (destructive column drop)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration104Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 104 (PostgreSQL): Adding channel_hash to channel_database...');
+
+  try {
+    await client.query('ALTER TABLE channel_database ADD COLUMN IF NOT EXISTS "channelHash" INTEGER');
+    logger.debug('Ensured channel_database.channelHash exists');
+  } catch (error: any) {
+    logger.error('Migration 104 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 104 complete (PostgreSQL): channel_database.channelHash added');
+}
+
+// ============ MySQL ============
+
+export async function runMigration104Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 104 (MySQL): Adding channel_hash to channel_database...');
+
+  try {
+    const [rows] = await pool.query(`
+      SELECT COLUMN_NAME FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'channel_database' AND COLUMN_NAME = 'channelHash'
+    `);
+    if (!Array.isArray(rows) || rows.length === 0) {
+      await pool.query('ALTER TABLE channel_database ADD COLUMN channelHash INT NULL');
+      logger.debug('Added channel_database.channelHash');
+    } else {
+      logger.debug('channel_database.channelHash already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Migration 104 (MySQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 104 complete (MySQL): channel_database.channelHash added');
+}

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -37,7 +37,10 @@ vi.mock('../services/database.js', () => ({
       // slot — keeps every pre-existing test seeing the same channel values
       // it asserted under the old behavior. Tests that want to exercise
       // the channel_database-keyed path override the mock per-case.
+      // The ingest path now resolves by (name, hash); the legacy name-only
+      // method is kept mocked too for any other callers.
       findOrCreatePassiveByNameAsync: vi.fn(async () => undefined),
+      findOrCreateByNameAndHashAsync: vi.fn(async () => undefined),
     },
   },
 }));
@@ -521,7 +524,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
   });
 
   it('stamps `channel` with CHANNEL_DB_OFFSET + id when the channel name resolves', async () => {
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(7);
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValueOnce(7);
 
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
@@ -529,13 +532,14 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     });
 
     expect(result.ingested).toBe(true);
-    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).toHaveBeenCalledWith('LongFast');
+    // envFor packets carry channel: 0, which normalizes to a null hash.
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).toHaveBeenCalledWith('LongFast', null);
     const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
     expect(inserted.channel).toBe(CHANNEL_DB_OFFSET + 7);
   });
 
-  it('memoizes lookups per channel name so repeated packets do not hit the DB twice', async () => {
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValue(11);
+  it('memoizes lookups per channel name+hash so repeated packets do not hit the DB twice', async () => {
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValue(11);
 
     await ingestServiceEnvelope({
       sourceId: 'bridge-1',
@@ -546,10 +550,46 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
       envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
     });
 
-    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).toHaveBeenCalledTimes(1);
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).toHaveBeenCalledTimes(1);
     const inserts = (databaseService.messages.insertMessage as any).mock.calls;
     expect(inserts[0][0].channel).toBe(CHANNEL_DB_OFFSET + 11);
     expect(inserts[1][0].channel).toBe(CHANNEL_DB_OFFSET + 11);
+  });
+
+  it('passes the packet channel hash to the resolver and keys the cache by name+hash', async () => {
+    // Two packets, same channel name "LongFast", DIFFERENT channel hashes.
+    // The resolver must be called once per distinct hash (cache keyed by
+    // name+hash), and each gets its own channel_database id.
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any)
+      .mockImplementation(async (_name: string, hash: number | null) => (hash === 8 ? 1 : 2));
+
+    const envWithHash = (hash: number): ServiceEnvelopeShape => ({
+      channelId: 'LongFast',
+      gatewayId: '!00000001',
+      packet: {
+        id: 0xfeed1000 + hash,
+        from: NODE_IN,
+        to: 0xffffffff,
+        channel: hash,
+        decoded: { portnum: 1 /* TEXT_MESSAGE_APP */, payload: new Uint8Array([0]) },
+      },
+    });
+
+    // Hash 8 → id 1.
+    await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: envWithHash(8) });
+    // Hash 42 → id 2 (same name, different key).
+    await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: envWithHash(42) });
+    // Hash 8 again → cache hit, resolver not called a third time.
+    await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: envWithHash(8) });
+
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).toHaveBeenCalledWith('LongFast', 8);
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).toHaveBeenCalledWith('LongFast', 42);
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).toHaveBeenCalledTimes(2);
+
+    const inserts = (databaseService.messages.insertMessage as any).mock.calls;
+    expect(inserts[0][0].channel).toBe(CHANNEL_DB_OFFSET + 1);
+    expect(inserts[1][0].channel).toBe(CHANNEL_DB_OFFSET + 2);
+    expect(inserts[2][0].channel).toBe(CHANNEL_DB_OFFSET + 1);
   });
 
   it('falls back to the raw slot when envelope.channelId is missing', async () => {
@@ -567,7 +607,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
 
     const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
     expect(result.ingested).toBe(true);
-    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).not.toHaveBeenCalled();
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).not.toHaveBeenCalled();
     const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
     expect(inserted.channel).toBe(3);
   });
@@ -595,7 +635,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
 
     const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
     expect(result.ingested).toBe(true);
-    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).not.toHaveBeenCalled();
+    expect(databaseService.channelDatabase!.findOrCreateByNameAndHashAsync).not.toHaveBeenCalled();
     const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
     expect(inserted.channel).toBe(CHANNEL_DB_OFFSET + 42);
   });
@@ -604,7 +644,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     // Edge case: an empty/whitespace-only channel name reaches the repo and
     // returns null — surface should still ingest the row with the slot
     // value, just not permission-key it through channel_database.
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(null);
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValueOnce(null);
 
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
@@ -616,7 +656,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
   });
 
   it('encodes the channel on traceroute rows the same way as messages', async () => {
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(5);
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValueOnce(5);
 
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
@@ -634,7 +674,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     // grant. But #3108 hides the channel_0..7 toggles for MQTT scopes
     // and directs admins to Virtual Channel Permissions, leaving no
     // way to grant map access — every non-admin saw "No nodes visible".
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(9);
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValueOnce(9);
 
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
@@ -647,7 +687,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
   });
 
   it('stamps node.channel on POSITION upserts the same way as NODEINFO', async () => {
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(4);
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValueOnce(4);
 
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
@@ -663,7 +703,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     // Mirrors the same fallback semantics as the message-side test
     // above — an empty channelId or null find-or-create should still
     // ingest the node, just keyed to the raw slot.
-    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(null);
+    (databaseService.channelDatabase!.findOrCreateByNameAndHashAsync as any).mockResolvedValueOnce(null);
 
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -893,11 +893,12 @@ async function ingestStoreForward(
 }
 
 /**
- * Process-lifetime cache mapping lower-cased channel names to channel_database
- * row IDs. Avoids hitting the DB on every MQTT packet for the same name. The
- * cache is invalidated for a single name on the rare write that mints a new
- * row; lookups for unknown names still go through findOrCreatePassiveByName
- * so admin-curated entries are picked up automatically.
+ * Process-lifetime cache mapping `lower(name)::hash` keys to channel_database
+ * row IDs. Avoids hitting the DB on every MQTT packet for the same channel
+ * identity. The key includes the packet channel hash so two same-name /
+ * different-key channels don't collide; lookups for unknown identities still
+ * go through findOrCreateByNameAndHash so admin-curated entries are picked up
+ * automatically.
  */
 const channelNameToDbIdCache = new Map<string, number>();
 
@@ -925,19 +926,30 @@ async function resolveChannelDatabaseIdForMqtt(
 
   const name = envelope.channelId?.trim();
   if (!name) return null;
-  const cacheKey = name.toLowerCase();
+
+  // `packet.channel` on MQTT is the Meshtastic 1-byte channel *hash*
+  // (xorHash(name) ^ xorHash(psk)), not a stable 0-7 slot. We use it as a
+  // second identity dimension so two same-name/different-key undecryptable
+  // channels resolve to distinct channel_database rows. Missing/0 ⇒ null
+  // (name-only path).
+  const rawHash = typeof packet.channel === 'number' ? Number(packet.channel) : null;
+  const hash = rawHash != null && Number.isFinite(rawHash) && rawHash > 0 ? rawHash & 0xff : null;
+
+  // Cache key includes the hash so different-key same-name channels don't
+  // collide in the cache.
+  const cacheKey = `${name.toLowerCase()}::${hash ?? 'null'}`;
   const cached = channelNameToDbIdCache.get(cacheKey);
   if (typeof cached === 'number') return cached;
 
   try {
-    const id = await databaseService.channelDatabase.findOrCreatePassiveByNameAsync(name);
+    const id = await databaseService.channelDatabase.findOrCreateByNameAndHashAsync(name, hash);
     if (typeof id === 'number') {
       channelNameToDbIdCache.set(cacheKey, id);
       return id;
     }
   } catch (err) {
     const m = err instanceof Error ? err.message : String(err);
-    logger.debug(`MQTT ingest: channel_database resolve failed for name="${name}": ${m}`);
+    logger.debug(`MQTT ingest: channel_database resolve failed for name="${name}" hash=${hash}: ${m}`);
   }
   return null;
 }

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -24,6 +24,9 @@ vi.mock('../utils/channelView.js', () => ({
     role: channel.role,
     ...(opts.includePsk ? { psk: channel.psk } : {}),
   })),
+  getEncryptionStatus: vi.fn((psk: string | null | undefined) =>
+    !psk || psk === '' ? 'none' : psk === 'AQ==' ? 'default' : 'secure'),
+  getRoleName: vi.fn(() => 'Unknown'),
 }));
 
 vi.mock('../utils/automationChannelMigration.js', () => ({
@@ -32,6 +35,7 @@ vi.mock('../utils/automationChannelMigration.js', () => ({
 
 vi.mock('../constants/meshtastic.js', () => ({
   modemPresetChannelName: vi.fn(() => 'LongFast'),
+  CHANNEL_DB_OFFSET: 100,
 }));
 
 const mockMeshcoreManager = vi.hoisted(() => ({
@@ -65,11 +69,14 @@ const mockDb = vi.hoisted(() => ({
   },
   channelDatabase: {
     getAllAsync: vi.fn().mockResolvedValue([]),
+    getByIdAsync: vi.fn().mockResolvedValue(null),
   },
   messages: {
     purgeChannelMessages: vi.fn().mockResolvedValue(0),
     migrateMessagesForChannelMoves: vi.fn().mockResolvedValue(undefined),
+    getDistinctChannelsForSource: vi.fn().mockResolvedValue([]),
   },
+  getChannelDatabasePermissionsForUserAsSetAsync: vi.fn().mockResolvedValue({}),
   settings: {
     getSetting: vi.fn().mockResolvedValue(null),
     setSetting: vi.fn().mockResolvedValue(undefined),
@@ -112,7 +119,10 @@ beforeEach(() => {
   mockDb.channels.getAllChannels.mockResolvedValue([]);
   mockDb.channels.getChannelCount.mockResolvedValue(0);
   mockDb.channelDatabase.getAllAsync.mockResolvedValue([]);
+  mockDb.channelDatabase.getByIdAsync.mockResolvedValue(null);
   mockDb.messages.purgeChannelMessages.mockResolvedValue(0);
+  mockDb.messages.getDistinctChannelsForSource.mockResolvedValue([]);
+  mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
   mockDb.sources.getSource.mockResolvedValue({ type: 'meshtastic_tcp' });
   mockMeshcoreRegistry.get.mockReturnValue(mockMeshcoreManager);
 });
@@ -143,6 +153,56 @@ describe('GET /channels and /channels/all', () => {
     const res = await request(app).get('/channels');
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('Failed to fetch channels');
+  });
+});
+
+describe('GET /channels for MQTT sources (virtual channel enumeration)', () => {
+  it('enumerates channel_database-backed channels that have messages', async () => {
+    mockDb.sources.getSource.mockResolvedValue({ type: 'mqtt_bridge' });
+    // Two virtual channels (100+id) plus one raw straggler, ordered by activity.
+    mockDb.messages.getDistinctChannelsForSource.mockResolvedValue([
+      { channel: 101, messageCount: 50, lastTimestamp: 2000 },
+      { channel: 102, messageCount: 10, lastTimestamp: 1000 },
+      { channel: 3, messageCount: 2, lastTimestamp: 500 },
+    ]);
+    mockDb.channelDatabase.getByIdAsync.mockImplementation(async (id: number) => {
+      if (id === 1) return { id: 1, name: 'MediumFast', psk: '' };
+      if (id === 2) return { id: 2, name: 'Secret', psk: 'AQ==' };
+      return null;
+    });
+
+    const res = await request(app).get('/channels?sourceId=mqtt-1');
+    expect(res.status).toBe(200);
+    // Device-slot getAllChannels must NOT be the source of truth here.
+    expect(mockDb.messages.getDistinctChannelsForSource).toHaveBeenCalledWith('mqtt-1');
+
+    const byId = Object.fromEntries(res.body.map((c: any) => [c.id, c]));
+    expect(res.body.map((c: any) => c.id)).toEqual([101, 102, 3]);
+    expect(byId[101].name).toBe('MediumFast');
+    expect(byId[101].displayName).toBe('MediumFast #101');
+    expect(byId[101].pskSet).toBe(false);
+    expect(byId[102].displayName).toBe('Secret #102');
+    expect(byId[102].pskSet).toBe(true);
+    expect(byId[3].name).toBe('Channel 3');
+  });
+
+  it('returns [] for an MQTT source with no messages', async () => {
+    mockDb.sources.getSource.mockResolvedValue({ type: 'mqtt_broker' });
+    mockDb.messages.getDistinctChannelsForSource.mockResolvedValue([]);
+    const res = await request(app).get('/channels?sourceId=mqtt-1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('TCP sources keep the device-slot code path (getDistinctChannelsForSource not used)', async () => {
+    mockDb.sources.getSource.mockResolvedValue({ type: 'meshtastic_tcp' });
+    mockDb.channels.getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Primary', role: 1, psk: 'AQ==' },
+    ]);
+    const res = await request(app).get('/channels?sourceId=tcp-1');
+    expect(res.status).toBe(200);
+    expect(res.body.map((c: any) => c.id)).toEqual([0]);
+    expect(mockDb.messages.getDistinctChannelsForSource).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -30,10 +30,90 @@ import { transformChannel } from '../utils/channelView.js';
 import { detectChannelCollisions } from '../utils/channelCollision.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { migrateAutomationChannels } from '../utils/automationChannelMigration.js';
-import { modemPresetChannelName } from '../constants/meshtastic.js';
+import { modemPresetChannelName, CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+import { getEncryptionStatus, getRoleName } from '../utils/channelView.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 
 const router: Router = Router();
+
+/**
+ * Build the Channels-tab channel list for an MQTT source (mqtt_bridge /
+ * mqtt_broker). MQTT sources don't sync device channel slots, so their
+ * per-source `channels` table is empty; instead every message is filed under a
+ * channel_database-backed virtual channel (`CHANNEL_DB_OFFSET + id`) or, for
+ * legacy stragglers, a raw hash slot (`< CHANNEL_DB_OFFSET`).
+ *
+ * We enumerate the distinct `messages.channel` values that actually carry
+ * traffic for the source and project each into the same shape `transformChannel`
+ * emits (id, name, displayName, role, roleName, pskSet, encryptionStatus, …),
+ * so the existing frontend Channels tab renders them without changes. Virtual
+ * channels resolve their name/PSK/enabled state from the channel_database row;
+ * raw stragglers get a best-effort label. Per-channel read permission is
+ * enforced (channel_database permissions for virtual ids, channel_${id} for raw
+ * ids); admins see all. Sorted most-active first.
+ */
+async function buildMqttSourceChannels(
+  req: Request,
+  sourceId: string,
+  isAdmin: boolean,
+): Promise<unknown[]> {
+  const distinct = await databaseService.messages.getDistinctChannelsForSource(sourceId);
+  if (distinct.length === 0) return [];
+
+  // Virtual-channel read permissions (channel_database) for the caller.
+  const virtualPerms = (!isAdmin && req.user)
+    ? await databaseService.getChannelDatabasePermissionsForUserAsSetAsync(req.user.id)
+    : {};
+
+  const out: unknown[] = [];
+  for (const { channel } of distinct) {
+    if (channel >= CHANNEL_DB_OFFSET) {
+      const dbId = channel - CHANNEL_DB_OFFSET;
+      // Permission gate for virtual channels.
+      if (!isAdmin && !(virtualPerms[dbId]?.read === true)) continue;
+
+      const row = await databaseService.channelDatabase.getByIdAsync(dbId);
+      const name = (row?.name ?? '').trim() || `Channel ${channel}`;
+      const psk = row?.psk ?? '';
+      out.push({
+        id: channel,
+        name,
+        // Virtual channels carry the channel number in their display name so
+        // the tab disambiguates same-name channels (e.g. "MediumFast #101").
+        displayName: `${name} #${channel}`,
+        role: null,
+        roleName: getRoleName(undefined),
+        uplinkEnabled: false,
+        downlinkEnabled: false,
+        positionPrecision: undefined,
+        scope: null,
+        pskSet: !!psk,
+        encryptionStatus: getEncryptionStatus(psk),
+      });
+    } else {
+      // Raw hash straggler (< OFFSET). Gate on channel_${id} read.
+      if (!isAdmin) {
+        const channelResource = `channel_${channel}` as import('../../types/permission.js').ResourceType;
+        const ok = req.user ? await hasPermission(req.user, channelResource, 'read', sourceId) : false;
+        if (!ok) continue;
+      }
+      out.push({
+        id: channel,
+        name: `Channel ${channel}`,
+        displayName: `Channel ${channel}`,
+        role: null,
+        roleName: getRoleName(undefined),
+        uplinkEnabled: false,
+        downlinkEnabled: false,
+        positionPrecision: undefined,
+        scope: null,
+        pskSet: false,
+        encryptionStatus: getEncryptionStatus(''),
+      });
+    }
+  }
+  return out;
+}
 
 // Get all channels (unfiltered, for export/config purposes)
 // MM-SEC-2: Per-row permission gate + transformChannel projection so the
@@ -80,8 +160,30 @@ router.get('/all', optionalAuth(), async (req: Request, res: Response) => {
 router.get('/', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const channelsSourceId = req.query.sourceId as string | undefined;
-    const allChannels = await databaseService.channels.getAllChannels(channelsSourceId);
     const isAdmin = req.user?.isAdmin === true;
+
+    // MQTT sources (mqtt_bridge / mqtt_broker) don't sync device channel slots;
+    // migration 103 emptied their `channels` table and ingestion files messages
+    // under channel_database-backed virtual channels (`CHANNEL_DB_OFFSET + id`).
+    // For those sources enumerate the virtual channels that actually carry
+    // traffic so the Channels tab isn't empty. TCP/device sources keep the
+    // existing slot-based code path below.
+    if (channelsSourceId) {
+      try {
+        const source = await databaseService.sources.getSource(channelsSourceId);
+        if (source && (source.type === 'mqtt_bridge' || source.type === 'mqtt_broker')) {
+          const mqttChannels = await buildMqttSourceChannels(req, channelsSourceId, isAdmin);
+          logger.debug(`📡 Serving ${mqttChannels.length} MQTT virtual channels for source ${channelsSourceId}`);
+          res.json(mqttChannels);
+          return;
+        }
+      } catch (err) {
+        logger.warn(`Failed to build MQTT channel list for source ${channelsSourceId}:`, err);
+        // Fall through to the slot-based path (returns [] for MQTT, but never 500s).
+      }
+    }
+
+    const allChannels = await databaseService.channels.getAllChannels(channelsSourceId);
 
     // Resolve the source's persisted modem preset (if scoped to one source)
     // so empty-name slot 0 displays as "MediumFast"/"LongFast"/etc. via


### PR DESCRIPTION
## Summary

Follow-up to #3708 (MQTT channel consolidation). Two fixes:

### 1. Consolidate MQTT channels by name **and** key (not just name)
Undecryptable MQTT packets were identified by channel **name** only (`findOrCreatePassiveByNameAsync`), so two distinct channels sharing a name but using different keys would collapse into one row. Now identity is **(name, channel-hash)** — the channel hash (`packet.channel`, Meshtastic `xorHash(name) ^ xorHash(psk)`) is the available key signal for undecryptable packets.

- Migration **104** adds a nullable `channel_hash` column to `channel_database` (all 3 backends, idempotent).
- ENABLED rows (real PSK) keep `channel_hash` NULL — their hash is computed from name+psk. PASSIVE rows (psk='') store the observed packet hash.
- New `findOrCreateByNameAndHashAsync(name, hash)`: matches an enabled row whose *computed* hash equals the packet hash, else a passive row with the same stored hash, else mints a passive row carrying that hash. `findOrCreatePassiveByNameAsync` is now a `hash=null` wrapper; concurrency guard + ingest cache re-keyed to `name::hash`. Server-side-decryption priority (`decoded.channelDatabaseId`) is unchanged.

### 2. Channels tab enumerates channel_database channels for MQTT sources
After #3708, `GET /api/channels?sourceId=<mqtt>` returned `[]` because it read only the per-source `channels` table (which #3708 emptied for MQTT sources). Now, for `mqtt_bridge`/`mqtt_broker` sources, the handler builds the channel list from the distinct `CHANNEL_DB_OFFSET+id` channels that actually have messages (new `getDistinctChannelsForSource`), resolving names via `channel_database`. TCP/device sources keep the existing slot-based path. Per-channel read permissions enforced.

## Test plan
- [x] Repo name+hash matching (enabled-match / passive-match / distinct rows / null back-compat / race guard)
- [x] Ingestion routes by name+hash; cache keyed by name+hash
- [x] Migration 104 idempotency + column round-trip
- [x] `GET /channels` MQTT enumeration; TCP path unchanged; `getDistinctChannelsForSource` per-source isolation
- [x] Full suite green locally (success=true); tsc clean
- [x] Verified live against real MQTT data: Florida source now lists all 4 channels; a different-key "LongFast" correctly split into its own row

🤖 Generated with [Claude Code](https://claude.com/claude-code)