### PR TITLE
fix(backup): scope manual device backup to selected source (#3711)

### DIFF
--- a/src/components/configuration/BackupManagementSection.test.tsx
+++ b/src/components/configuration/BackupManagementSection.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #3711: Manual Backup must scope to the currently-selected source so
+ * multi-source setups back up the active source instead of always defaulting
+ * to the primary one. Single-source (sourceId === null) views must keep the
+ * old un-parameterized URL so the backend's primary-manager fallback applies.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// --- mocks ---------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: vi.fn(),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../services/api', () => ({
+  default: {
+    getBaseUrl: vi.fn().mockResolvedValue('http://test'),
+  },
+}));
+
+// sourceId is configurable per-test via this mutable holder.
+const sourceState: { sourceId: string | null; sourceName: string | null } = {
+  sourceId: null,
+  sourceName: null,
+};
+vi.mock('../../contexts/SourceContext', () => ({
+  useSource: () => sourceState,
+}));
+
+import BackupManagementSection from './BackupManagementSection';
+
+function makeFetchMock() {
+  return vi.fn().mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.includes('/api/backup/settings')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ enabled: false, maxBackups: 7, backupTime: '02:00' }),
+      });
+    }
+    // device/backup
+    return Promise.resolve({
+      ok: true,
+      headers: { get: () => 'attachment; filename="abc.yaml"' },
+      text: () => Promise.resolve('yaml: content'),
+    });
+  });
+}
+
+describe('BackupManagementSection — issue #3711 source scoping', () => {
+  beforeEach(() => {
+    sourceState.sourceId = null;
+    sourceState.sourceName = null;
+    // Avoid real download side-effects.
+    global.URL.createObjectURL = vi.fn(() => 'blob:x');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes sourceId in the manual backup request when a source is selected', async () => {
+    sourceState.sourceId = 'src-b';
+    sourceState.sourceName = 'B';
+    const fetchMock = makeFetchMock();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<BackupManagementSection />);
+    fireEvent.click(screen.getByText('backup_management.create_button'));
+
+    await waitFor(() => {
+      const calledBackup = fetchMock.mock.calls.some(
+        ([u]) => typeof u === 'string' && u.includes('/api/device/backup') && u.includes('sourceId=src-b')
+      );
+      expect(calledBackup).toBe(true);
+    });
+  });
+
+  it('omits sourceId when no source is selected (single-source fallback)', async () => {
+    sourceState.sourceId = null;
+    const fetchMock = makeFetchMock();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<BackupManagementSection />);
+    fireEvent.click(screen.getByText('backup_management.create_button'));
+
+    await waitFor(() => {
+      const backupCall = fetchMock.mock.calls.find(
+        ([u]) => typeof u === 'string' && u.includes('/api/device/backup')
+      );
+      expect(backupCall).toBeTruthy();
+      expect(backupCall![0]).not.toContain('sourceId=');
+    });
+  });
+});

--- a/src/components/configuration/BackupManagementSection.tsx
+++ b/src/components/configuration/BackupManagementSection.tsx
@@ -4,6 +4,7 @@ import apiService from '../../services/api';
 import { useToast } from '../ToastContainer';
 import { logger } from '../../utils/logger';
 import { useSaveBar } from '../../hooks/useSaveBar';
+import { useSource } from '../../contexts/SourceContext';
 import '../../styles/BackupManagement.css';
 
 interface BackupFile {
@@ -20,6 +21,7 @@ interface BackupManagementSectionProps {
 const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBackupCreated }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const { sourceId } = useSource();
 
   // State
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
@@ -149,7 +151,14 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
       showToast(t('backup_management.toast_creating_backup'), 'info');
 
       const baseUrl = await apiService.getBaseUrl();
-      const response = await fetch(`${baseUrl}/api/device/backup?save=true`, {
+      // Scope the backup to the currently-selected source so multi-source
+      // setups back up the active source rather than always the primary one.
+      // When sourceId is null (legacy/single-source view) the backend falls
+      // back to the primary manager, preserving existing behavior.
+      const backupUrl = sourceId
+        ? `${baseUrl}/api/device/backup?save=true&sourceId=${encodeURIComponent(sourceId)}`
+        : `${baseUrl}/api/device/backup?save=true`;
+      const response = await fetch(backupUrl, {
         method: 'GET',
         credentials: 'same-origin'
       });


### PR DESCRIPTION
Closes #3711

## Problem
Manual Backup (Settings → Backup) always backed up the primary/first source. `BackupManagementSection` called `/api/device/backup?save=true` with no `sourceId`, and the backend (`deviceRoutes.ts`) falls back to `resolveSourceManager(undefined)` — the primary `meshtasticManager` — when none is provided. Multi-source setups had no way to back up non-primary sources from the UI.

## Fix
`ConfigurationTab` is already scoped to the active source via `useSource()`; every other config section in that tab passes `sourceId`. This makes `BackupManagementSection` consistent:

- Reads `sourceId` from `SourceContext`.
- Appends `&sourceId=<id>` to the backup request when a source is selected.
- Leaves the URL un-parameterized when `sourceId` is `null` (legacy/single-source view), preserving the existing primary-manager fallback.

No backend change needed — `/api/device/backup` already accepts and honors `sourceId`. The saved filename already encodes the per-source node ID, so backups remain distinguishable.

## Tests
Added `BackupManagementSection.test.tsx` asserting:
- multi-source: request URL includes `sourceId=...`
- single-source: request URL omits `sourceId`

Full Vitest suite green (7436 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4