### PR TITLE
fix(meshcore): {ROUTE} auto-ack token resolves on routed messages (#3710)

### DIFF
--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -305,4 +305,67 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     expect(dm.data.snr).toBeUndefined();
     expect(dm.data.path_hops).toBeUndefined();
   });
+
+  // --- issue #3710: hop-count (not raw-byte) correlation -----------------------
+  // The recv event's pathLen is a PLAIN hop count (0xFF == direct), while the
+  // buffered LogRxData rawPathLen is the PACKED OTA byte (top 2 bits = hash
+  // width). For any flood packet using a 2- or 3-byte relay-hash width the two
+  // raw values differ even for the SAME packet, so the old raw-equality guard
+  // dropped the path and {ROUTE} resolved to "—". We must correlate on the
+  // decoded hop count instead.
+
+  it('attaches the buffered path for a 2-byte-hash flood packet (issue #3710)', async () => {
+    const { conn, events } = await connectedBackend();
+    // TXT_MSG, FLOOD, packed pathLen=0x42 (2-byte hashes, 2 hops),
+    // path = [adb0, 1234]. extractPathHashCount(0x42) === 2.
+    const raw = Uint8Array.from([0x02, 0x01, 0x42, 0xad, 0xb0, 0x12, 0x34]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: 5.5, lastRssi: -44, raw });
+    // The matching recv reports a PLAIN hop count of 2, NOT the packed 0x42.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+      text: 'routed hello',
+      senderTimestamp: 1700,
+      pathLen: 2,
+      txtType: TxtTypes.Plain,
+    });
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.path_hops).toEqual(['adb0', '1234']);
+    expect(msg.data.snr).toBe(5.5);
+  });
+
+  it('attaches the buffered path for a 2-byte-hash flood channel_message (issue #3710)', async () => {
+    const { conn, events } = await connectedBackend();
+    const raw = Uint8Array.from([0x02, 0x01, 0x42, 0xad, 0xb0, 0x12, 0x34]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: -2.0, lastRssi: -70, raw });
+    conn.emit(ResponseCodes.ChannelMsgRecv, {
+      channelIdx: 0,
+      text: 'Bob: routed ping',
+      senderTimestamp: 1800,
+      pathLen: 2,
+    });
+    const msg = events.find((e) => e.event_type === 'channel_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.path_hops).toEqual(['adb0', '1234']);
+    expect(msg.data.snr).toBe(-2.0);
+  });
+
+  it('still rejects a buffered 2-byte-hash path when hop counts differ (issue #3710 guard intact)', async () => {
+    const { conn, events } = await connectedBackend();
+    // Buffered: 2-byte hashes, 2 hops (packed 0x42).
+    const raw = Uint8Array.from([0x02, 0x01, 0x42, 0xad, 0xb0, 0x12, 0x34]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: 9, lastRssi: -30, raw });
+    // Recv is a different packet: 3 hops. 3 !== decoded(0x42)=2 → reject.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]),
+      text: 'different',
+      senderTimestamp: 1900,
+      pathLen: 3,
+      txtType: TxtTypes.Plain,
+    });
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.path_hops).toBeUndefined();
+    expect(msg.data.snr).toBeUndefined();
+  });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -361,10 +361,19 @@ export class MeshCoreNativeBackend extends EventEmitter {
    *  1. Freshness — the buffer must be younger than `PENDING_PATH_MAX_AGE_MS`.
    *     LogRxData fires immediately before its txt-msg recv on the same tick;
    *     an older buffer belongs to a packet whose recv never arrived.
-   *  2. pathLen correlation — when the recv event carries its own packed
-   *     `pathLen` byte, it must equal the buffered packet's `rawPathLen`.
-   *     They are the same wire byte for the same packet, so a mismatch proves
-   *     the buffer is from a *different* packet and must not be attached.
+   *  2. hop-count correlation — when the recv event carries its own
+   *     `pathLen`, the *hop count* it implies must equal the hop count
+   *     decoded from the buffered packet's packed `rawPathLen`. A mismatch
+   *     proves the buffer is from a *different* packet and must not be
+   *     attached.
+   *
+   *     NOTE: the two values are NOT the same wire byte. ContactMsgRecv /
+   *     ChannelMsgRecv report a PLAIN hop count (0xFF == "sent direct"),
+   *     whereas LogRxData's `rawPathLen` is the PACKED OTA byte (top 2 bits
+   *     = hash-size-1, bottom 6 bits = hop count). Comparing them raw made
+   *     every flood packet using a 2- or 3-byte relay-hash width fail to
+   *     correlate, so {ROUTE} resolved to "—" for any routed message
+   *     (issue #3710). We decode the packed byte to a hop count first.
    *
    * Returns `{ hops, snr }` to attach, or `undefined` when the buffer is
    * absent, stale, or for a different packet.
@@ -379,13 +388,19 @@ export class MeshCoreNativeBackend extends EventEmitter {
       // Stale buffer — its matching recv never arrived. Don't mis-attach.
       return undefined;
     }
-    if (
-      typeof msgPathLen === 'number' &&
-      typeof buffered.rawPathLen === 'number' &&
-      msgPathLen !== buffered.rawPathLen
-    ) {
-      // Buffer is from a different packet (packed pathLen bytes differ).
-      return undefined;
+    if (typeof msgPathLen === 'number' && typeof buffered.rawPathLen === 'number') {
+      // Normalize both sides to a plain hop count before comparing. The recv
+      // event's pathLen is already a plain count (0xFF == sent-direct == 0
+      // hops); the buffered rawPathLen is the packed OTA byte.
+      const msgHopCount = msgPathLen === 0xff ? 0 : msgPathLen & 0x3f;
+      const bufferedHopCount =
+        buffered.rawPathLen === 0xff
+          ? 0
+          : (this.PacketCtor?.extractPathHashCount(buffered.rawPathLen) ?? (buffered.rawPathLen & 0x3f));
+      if (msgHopCount !== bufferedHopCount) {
+        // Buffer is from a different packet (hop counts differ).
+        return undefined;
+      }
     }
     return { hops: buffered.hops, snr: buffered.snr };
   }


### PR DESCRIPTION
Closes #3710

## Problem

The MeshCore auto-ack `{ROUTE}` token always resolved to `—` for any **routed** (multi-hop) message. Direct connections correctly resolved to `(direct)`. The compose-time "Sample preview" looked correct because it renders a **hardcoded** sample string (`a3 → 7f → 02`), not a real route — so only the actual send was broken.

## Root cause

`MeshCoreNativeBackend.consumePendingPath()` correlates the `LogRxData`-buffered relay-hash chain to the matching `ContactMsgRecv` / `ChannelMsgRecv` event so `{ROUTE}`/`{SNR}` only populate from the matching packet (issue #3589). It did this by comparing the raw `pathLen` values for equality — but the two values are **not** the same wire byte:

- `ContactMsgRecv` / `ChannelMsgRecv` report a **plain hop count** (`0xFF` == "sent direct"), per the meshcore.js connection parser.
- `LogRxData`'s `rawPathLen` is the **packed OTA byte** (top 2 bits = hash-size−1, bottom 6 bits = hop count).

They only coincide when the relay-hash width is 1 byte. For any flood packet using a 2- or 3-byte hash width, the packed byte differs from the plain hop count even for the **same** packet, so the guard rejected the correlation, left `path_hops` undefined, and `{ROUTE}` fell through to `—`. Direct messages were unaffected because their hop count is `0` and `replaceAutoAckTokens()` special-cases that to `direct`.

## Fix

Normalize both sides to a plain hop count before comparing — decode the buffered packed byte via `Packet.extractPathHashCount()` (with a `0xFF` == direct == 0 special case on both sides). The #3589 mis-correlation guard remains intact: a genuinely different packet still has a different hop count and is still rejected.

## Tests

Added regression tests in `meshcoreNativeBackend.otaPacket.test.ts`:
- 2-byte-hash flood `contact_message` attaches the buffered path
- 2-byte-hash flood `channel_message` attaches the buffered path
- hop-count mismatch on a 2-byte-hash buffer is still rejected

Full Vitest suite: 7437 passed, 0 failed (`success: true`). `tsc` introduces no new errors (the 57 pre-existing errors are present on clean `origin/main` and unrelated to these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4