### PR TITLE
feat(meshcore): show unread message indicator on the Channels view (#3703)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -67,6 +67,10 @@ function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions 
     setTelemetryModeEnv: vi.fn().mockResolvedValue(true),
     refreshAll: vi.fn().mockResolvedValue(undefined),
     clearError: vi.fn(),
+    // Scope helpers invoked by the component when status.connected is true; the
+    // component swallows failures, but mocking them avoids unhandled rejections.
+    getDefaultScope: vi.fn().mockResolvedValue(''),
+    discoverRegions: vi.fn().mockResolvedValue({ regions: [] }),
     ...overrides,
   };
 }

--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -425,3 +425,156 @@ describe('MeshCoreChannelsView — sending', () => {
     expect(actions.sendMessage).toHaveBeenCalledWith('channel ops msg', undefined, 2);
   });
 });
+
+describe('MeshCoreChannelsView — unread indicator (#3703)', () => {
+  // Route the list, per-channel-messages, and channel-counts endpoints. The
+  // counts endpoint now also returns `latestTimestamps` (idx → max ms) which
+  // drives the unread comparison.
+  function routedFetch(opts: {
+    latestTimestamps?: Record<number, number>;
+    counts?: Record<number, number>;
+    messagesByChannel?: Record<number, MeshCoreMessage[]>;
+  }) {
+    return vi.fn((url: string) => {
+      if (url.includes('/api/channels/all')) {
+        return Promise.resolve(jsonResponse([
+          { id: 0, name: 'Public' },
+          { id: 1, name: 'Town' },
+        ]));
+      }
+      if (url.includes('/messages/channel-counts')) {
+        return Promise.resolve(jsonResponse({
+          success: true,
+          counts: opts.counts ?? {},
+          latestTimestamps: opts.latestTimestamps ?? {},
+        }));
+      }
+      const m = url.match(/\/messages\/channel\/(\d+)/);
+      if (m) {
+        const idx = Number(m[1]);
+        const data = opts.messagesByChannel?.[idx] ?? [];
+        return Promise.resolve(jsonResponse({ success: true, data, count: data.length }));
+      }
+      return Promise.resolve(jsonResponse({ success: true, data: [] }));
+    });
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('flags an inactive channel as unread when its latest message is newer than the (absent) last-read marker', async () => {
+    // Active channel is Public (idx 0). Town (idx 1) has a newer message and has
+    // never been opened, so it must show an unread dot.
+    csrfFetchMock.mockImplementation(routedFetch({
+      latestTimestamps: { 0: 100, 1: 9999 },
+      counts: { 0: 1, 1: 1 },
+    }));
+
+    const { container } = render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('# Town')).toBeTruthy());
+    await waitFor(() => expect(container.querySelector('.mc-channel-unread-dot')).toBeTruthy());
+
+    // The active channel (Public) must NOT be unread.
+    const publicRow = screen.getByText('# Public').closest('.mc-channel-row');
+    expect(publicRow?.classList.contains('unread')).toBe(false);
+  });
+
+  it('clears the unread state for a channel once it is opened', async () => {
+    csrfFetchMock.mockImplementation(routedFetch({
+      latestTimestamps: { 0: 100, 1: 9999 },
+      counts: { 0: 1, 1: 1 },
+      messagesByChannel: { 1: [{ id: 't1', fromPublicKey: 'channel-1', text: 'town msg', timestamp: 9999 }] },
+    }));
+
+    const { container } = render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(container.querySelector('.mc-channel-unread-dot')).toBeTruthy());
+
+    // Open Town — it becomes the active/viewed channel and should clear.
+    fireEvent.click(screen.getByText('# Town'));
+    await waitFor(() => expect(container.querySelector('.mc-channel-unread-dot')).toBeNull());
+
+    // The last-read marker was persisted for this source/channel.
+    const stored = JSON.parse(localStorage.getItem('meshmonitor-meshcore-channel-lastread-src-a') ?? '{}');
+    expect(stored['1']).toBeGreaterThanOrEqual(9999);
+  });
+
+  it('does not flag a channel unread when its last-read marker is current', async () => {
+    localStorage.setItem(
+      'meshmonitor-meshcore-channel-lastread-src-a',
+      JSON.stringify({ 1: 9999 }),
+    );
+    csrfFetchMock.mockImplementation(routedFetch({
+      latestTimestamps: { 0: 100, 1: 9999 },
+      counts: { 0: 1, 1: 1 },
+    }));
+
+    const { container } = render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('# Town')).toBeTruthy());
+    // Give the counts/latest fetch a tick to resolve (both rows show "1 messages").
+    await waitFor(() => expect(screen.getAllByText('1 messages').length).toBe(2));
+    expect(container.querySelector('.mc-channel-unread-dot')).toBeNull();
+  });
+
+  it('reorders channels with unread first when the sort toggle is enabled', async () => {
+    csrfFetchMock.mockImplementation(routedFetch({
+      latestTimestamps: { 0: 100, 1: 9999 },
+      counts: { 0: 1, 1: 1 },
+    }));
+
+    const { container } = render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(container.querySelector('.mc-channel-unread-dot')).toBeTruthy());
+
+    // Default order: Public (idx 0) first.
+    let names = Array.from(container.querySelectorAll('.mc-channel-row-name')).map(n => n.textContent);
+    expect(names[0]).toBe('# Public');
+
+    // Enable "unread first" — Town (unread) should jump to the top.
+    fireEvent.click(screen.getByTitle('Show channels with unread messages first'));
+    await waitFor(() => {
+      const reordered = Array.from(container.querySelectorAll('.mc-channel-row-name')).map(n => n.textContent);
+      expect(reordered[0]).toBe('# Town');
+    });
+    expect(localStorage.getItem('meshmonitor-meshcore-channel-sort-unread-first')).toBe('true');
+  });
+});

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -69,6 +69,35 @@ function buildChannelFilter(channelIdx: number): (m: MeshCoreMessage) => boolean
   };
 }
 
+// ---------------------------------------------------------------------------
+// Unread tracking (#3703)
+//
+// MeshCore messages are NOT covered by the Meshtastic server-side read-tracking
+// system (`read_messages` table joins the Meshtastic `messages` table only), so
+// we track the operator's per-channel last-read marker client-side in
+// localStorage, scoped by sourceId. A channel is "unread" when its latest
+// persisted message timestamp is newer than the stored last-read marker. This
+// keeps the feature lightweight (no new per-user DB schema) while answering the
+// request: surface channels with new messages without opening each one.
+// ---------------------------------------------------------------------------
+
+const lastReadStorageKey = (sourceId: string) =>
+  `meshmonitor-meshcore-channel-lastread-${sourceId}`;
+const SORT_UNREAD_FIRST_KEY = 'meshmonitor-meshcore-channel-sort-unread-first';
+
+/** Read the persisted per-channel last-read map for a source (idx → ms). */
+function loadLastRead(sourceId: string): Record<number, number> {
+  if (!sourceId) return {};
+  try {
+    const raw = localStorage.getItem(lastReadStorageKey(sourceId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<number, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
 export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   messages,
   contacts,
@@ -96,6 +125,17 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // so a quiet channel doesn't read as empty next to a busy one just because
   // the shared pool's recent-tail happened to exclude it.
   const [counts, setCounts] = useState<Record<number, number>>({});
+  // Latest persisted message timestamp per channel index (#3703), fetched
+  // alongside `counts`. Compared against the per-channel last-read marker to
+  // decide which channels show an unread indicator.
+  const [latestTimestamps, setLatestTimestamps] = useState<Record<number, number>>({});
+  // Per-channel last-read marker (idx → ms), persisted in localStorage scoped by
+  // sourceId. Seeded from storage on mount/source change.
+  const [lastRead, setLastRead] = useState<Record<number, number>>(() => loadLastRead(sourceId));
+  // Optional "channels with unread first" ordering (#3703), persisted globally.
+  const [sortUnreadFirst, setSortUnreadFirst] = useState<boolean>(
+    () => localStorage.getItem(SORT_UNREAD_FIRST_KEY) === 'true',
+  );
   // Per-message scope/region override (#3701). `null` means "no override —
   // use the channel's resolved scope". A string is a one-off override applied
   // to the NEXT send only; it is never persisted to the channel row. Reset on
@@ -122,6 +162,33 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
+
+  // Re-seed the last-read map when the source changes (the map is per-source).
+  useEffect(() => {
+    setLastRead(loadLastRead(sourceId));
+  }, [sourceId]);
+
+  // Persist the sort preference whenever it changes.
+  useEffect(() => {
+    localStorage.setItem(SORT_UNREAD_FIRST_KEY, String(sortUnreadFirst));
+  }, [sortUnreadFirst]);
+
+  // Mark a channel read up to `ts`, persisting to localStorage. Never moves the
+  // marker backwards. `ts` defaults to now so opening an empty/quiet channel
+  // still clears any stale unread state.
+  const markChannelRead = useCallback((idx: number, ts: number = Date.now()) => {
+    if (!sourceId) return;
+    setLastRead(prev => {
+      if ((prev[idx] ?? 0) >= ts) return prev;
+      const next = { ...prev, [idx]: ts };
+      try {
+        localStorage.setItem(lastReadStorageKey(sourceId), JSON.stringify(next));
+      } catch {
+        /* storage full / disabled — unread state is best-effort */
+      }
+      return next;
+    });
+  }, [sourceId]);
 
   const handleSelectChannel = useCallback((idx: number) => {
     setSelectedIdx(idx);
@@ -196,7 +263,12 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
         const response = await csrfFetch(url);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
-        if (!cancelled && data?.success && data.counts) setCounts(data.counts as Record<number, number>);
+        if (!cancelled && data?.success) {
+          if (data.counts) setCounts(data.counts as Record<number, number>);
+          if (data.latestTimestamps) {
+            setLatestTimestamps(data.latestTimestamps as Record<number, number>);
+          }
+        }
       } catch (err) {
         if (!cancelled) console.error('Failed to fetch MeshCore channel counts:', err);
       }
@@ -296,6 +368,59 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     return Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp);
   }, [history, messages, activeFilter]);
 
+  // Mark the active channel read up to its newest visible message. Runs whenever
+  // the active channel's content changes (channel switch, backlog load, or a
+  // live message arriving while it's open), so an open channel never shows as
+  // unread. Falls back to "now" for an empty channel so opening it still clears
+  // any stale marker. On mobile the channel isn't actually being viewed until
+  // the operator drills in, so defer marking until the content pane is shown.
+  const newestVisibleTs = filtered.length > 0 ? filtered[filtered.length - 1].timestamp : 0;
+  useEffect(() => {
+    if (isMobileViewport() && !mobileShowContent) return;
+    markChannelRead(active.id, newestVisibleTs || Date.now());
+  }, [active.id, newestVisibleTs, mobileShowContent, markChannelRead]);
+
+  // Effective latest timestamp per channel: the persisted max from the
+  // counts/latest endpoint, bumped by any newer live message in the shared pool
+  // so a just-arrived message flags the channel unread before the next refetch.
+  const effectiveLatest = useMemo(() => {
+    const map: Record<number, number> = { ...latestTimestamps };
+    for (const c of displayChannels) {
+      const liveMatch = messages.filter(buildChannelFilter(c.id));
+      for (const m of liveMatch) {
+        if (m.timestamp > (map[c.id] ?? 0)) map[c.id] = m.timestamp;
+      }
+    }
+    return map;
+  }, [latestTimestamps, messages, displayChannels]);
+
+  /** A channel is unread when its latest message is newer than its last-read
+   *  marker. The currently-active (and viewed) channel is never unread. */
+  const isChannelUnread = useCallback((idx: number): boolean => {
+    if (idx === active.id && (!isMobileViewport() || mobileShowContent)) return false;
+    const latest = effectiveLatest[idx];
+    if (!latest) return false;
+    return latest > (lastRead[idx] ?? 0);
+  }, [active.id, mobileShowContent, effectiveLatest, lastRead]);
+
+  // Channel ordering for the list. Default: by index. "Unread first": unread
+  // channels (most recent activity first) then the rest by index (#3703).
+  const orderedChannels = useMemo(() => {
+    if (!sortUnreadFirst) return displayChannels;
+    return [...displayChannels].sort((a, b) => {
+      const ua = isChannelUnread(a.id);
+      const ub = isChannelUnread(b.id);
+      if (ua !== ub) return ua ? -1 : 1;
+      if (ua && ub) return (effectiveLatest[b.id] ?? 0) - (effectiveLatest[a.id] ?? 0);
+      return a.id - b.id;
+    });
+  }, [displayChannels, sortUnreadFirst, isChannelUnread, effectiveLatest]);
+
+  const unreadChannelCount = useMemo(
+    () => displayChannels.filter(c => isChannelUnread(c.id)).length,
+    [displayChannels, isChannelUnread],
+  );
+
   const selfKey = status?.localNode?.publicKey;
   const connected = status?.connected ?? false;
 
@@ -306,7 +431,26 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       <div className="meshcore-list-pane">
         <div className="meshcore-list-pane-header">
           <span>{t('meshcore.nav.channels', 'Channels')}</span>
-          <span className="pane-count">{displayChannels.length}</span>
+          <span className="meshcore-list-pane-header-actions">
+            {unreadChannelCount > 0 && (
+              <span
+                className="mc-channel-unread-total"
+                title={t('meshcore.channels.unread_total_title', '{{count}} channel(s) with unread messages', { count: unreadChannelCount })}
+              >
+                {unreadChannelCount}
+              </span>
+            )}
+            <button
+              type="button"
+              className={`mc-channel-sort-toggle ${sortUnreadFirst ? 'active' : ''}`}
+              onClick={() => setSortUnreadFirst(v => !v)}
+              aria-pressed={sortUnreadFirst}
+              title={t('meshcore.channels.sort_unread_first', 'Show channels with unread messages first')}
+            >
+              {sortUnreadFirst ? '★' : '☆'}
+            </button>
+            <span className="pane-count">{displayChannels.length}</span>
+          </span>
         </div>
         <div className="meshcore-list-pane-body">
           {loadingChannels && channels.length === 0 && (
@@ -316,18 +460,26 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
               </div>
             </div>
           )}
-          {displayChannels.map(c => {
+          {orderedChannels.map(c => {
             // Accurate persisted count from the counts endpoint. For the active
             // channel, prefer the merged stream length when it's larger so a
             // just-arrived live message bumps the badge before the next refetch.
             const persisted = counts[c.id] ?? messages.filter(buildChannelFilter(c.id)).length;
             const count = c.id === active.id ? Math.max(persisted, filtered.length) : persisted;
+            const unread = isChannelUnread(c.id);
             return (
               <button
                 key={c.id}
-                className={`mc-channel-row ${active.id === c.id ? 'selected' : ''}`}
+                className={`mc-channel-row ${active.id === c.id ? 'selected' : ''} ${unread ? 'unread' : ''}`}
                 onClick={() => handleSelectChannel(c.id)}
               >
+                {unread && (
+                  <span
+                    className="mc-channel-unread-dot"
+                    aria-label={t('meshcore.channels.unread_badge', 'Unread messages')}
+                    title={t('meshcore.channels.unread_badge', 'Unread messages')}
+                  />
+                )}
                 <div className="mc-channel-row-name">
                   {formatMeshCoreChannelName(
                     c.name,

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -540,6 +540,69 @@
   opacity: 0.9;
 }
 
+/* Unread indicator (#3703) */
+.mc-channel-row {
+  position: relative;
+}
+
+.mc-channel-row.unread .mc-channel-row-name {
+  font-weight: 700;
+}
+
+.mc-channel-unread-dot {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: var(--ctp-blue);
+  box-shadow: 0 0 0 2px var(--ctp-surface0);
+}
+
+.mc-channel-row.selected .mc-channel-unread-dot {
+  background: var(--ctp-accent-text);
+  box-shadow: 0 0 0 2px var(--ctp-blue);
+}
+
+.meshcore-list-pane-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.mc-channel-unread-total {
+  min-width: 1.2rem;
+  height: 1.2rem;
+  padding: 0 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--ctp-blue);
+  color: var(--ctp-accent-text);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.mc-channel-sort-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.1rem 0.2rem;
+  color: var(--ctp-subtext0);
+}
+
+.mc-channel-sort-toggle.active {
+  color: var(--ctp-yellow);
+}
+
+.mc-channel-sort-toggle:hover {
+  color: var(--ctp-text);
+}
+
 .mc-node-row-name {
   color: var(--ctp-text);
   font-weight: 500;

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -495,6 +495,7 @@
 
 /* Channel list items — card button style matching Meshtastic .channel-button */
 .mc-channel-row {
+  position: relative; /* anchor for the unread dot (#3703) */
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -541,10 +542,6 @@
 }
 
 /* Unread indicator (#3703) */
-.mc-channel-row {
-  position: relative;
-}
-
 .mc-channel-row.unread .mc-channel-row-name {
   font-weight: 700;
 }

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -616,4 +616,24 @@ describe('MeshCoreRepository — sourceId stamping', () => {
       expect(counts).toEqual({ 0: 3, 1: 1, 2: 0 });
     });
   });
+
+  describe('getChannelLatestTimestamps (#3703)', () => {
+    it('returns the max timestamp per channel, source-scoped, omitting empty channels', async () => {
+      const insert = (id: string, from: string, to: string | null, ts: number, src: string) =>
+        repo.insertMessage(
+          { id, fromPublicKey: from, toPublicKey: to, text: id, timestamp: ts, createdAt: ts },
+          src,
+        );
+      // channel 0: newest at ts 30 (incl. a legacy broadcast). channel 1: ts 40.
+      await insert('a', 'channel-0', null, 10, 'src-a');
+      await insert('b', 'x'.repeat(64), null, 30, 'src-a'); // channel-0 legacy, newest
+      await insert('c', 'channel-1', null, 40, 'src-a');
+      // Same channel, other source must not leak (would otherwise push ch1 to 99).
+      await insert('d', 'channel-1', null, 99, 'src-b');
+
+      const latest = await repo.getChannelLatestTimestamps([0, 1, 2], 'src-a');
+      // Channel 2 has no messages and is omitted entirely.
+      expect(latest).toEqual({ 0: 30, 1: 40 });
+    });
+  });
 });

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -806,6 +806,35 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
+   * Latest (max) message timestamp per channel index for a source, used by the
+   * channel list to flag channels that have messages newer than the operator's
+   * last-read marker (#3703 unread indicator). Returns a map keyed by channel
+   * index; indices with no messages are omitted. Uses the same channel-scoping
+   * rules as {@link getChannelMessages}.
+   */
+  async getChannelLatestTimestamps(
+    channelIndices: number[],
+    sourceId?: string,
+  ): Promise<Record<number, number>> {
+    const { meshcoreMessages } = this.tables;
+    const entries = await Promise.all(
+      channelIndices.map(async (idx) => {
+        const result = await this.db
+          .select({ latest: sql<number>`MAX(${meshcoreMessages.timestamp})` })
+          .from(meshcoreMessages)
+          .where(this.channelWhereClause(idx, sourceId));
+        const latest = result[0]?.latest;
+        return [idx, latest == null ? null : Number(latest)] as const;
+      }),
+    );
+    const latestTimestamps: Record<number, number> = {};
+    for (const [idx, latest] of entries) {
+      if (latest != null) latestTimestamps[idx] = latest;
+    }
+    return latestTimestamps;
+  }
+
+  /**
    * Build the WHERE clause that matches a single MeshCore channel index,
    * optionally scoped to a source. Shared by the per-channel message and count
    * queries so they stay in lockstep (incl. the channel-0 legacy null-recipient

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4178,6 +4178,14 @@ class MeshCoreManager extends EventEmitter {
     return databaseService.meshcore.getChannelMessageCounts(channelIndices, this.sourceId);
   }
 
+  /**
+   * Latest persisted message timestamp per channel index, for the channel-list
+   * unread indicator (#3703). Channels with no messages are omitted.
+   */
+  async getChannelLatestTimestamps(channelIndices: number[]): Promise<Record<number, number>> {
+    return databaseService.meshcore.getChannelLatestTimestamps(channelIndices, this.sourceId);
+  }
+
   isConnected(): boolean {
     return this.connected;
   }

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -1267,7 +1267,9 @@ router.get('/messages/channel/:idx', optionalAuth(), requirePermission('messages
 /**
  * GET /api/meshcore/messages/channel-counts?channels=0,1,2
  * Total persisted message count per channel index, for the channel-list badges.
- * Accurate per channel (not the capped in-memory pool).
+ * Accurate per channel (not the capped in-memory pool). Also returns the latest
+ * message timestamp per channel (`latestTimestamps`) for the unread indicator
+ * (#3703) — channels with no messages are omitted from that map.
  */
 router.get('/messages/channel-counts', optionalAuth(), requirePermission('messages', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
@@ -1278,10 +1280,14 @@ router.get('/messages/channel-counts', optionalAuth(), requirePermission('messag
       .filter((n) => Number.isInteger(n) && n >= 0);
     // De-dupe and cap to a sane number of channels per request.
     const unique = Array.from(new Set(indices)).slice(0, 64);
-    const counts = unique.length > 0
-      ? await managerFor(req).getChannelMessageCounts(unique)
-      : {};
-    res.json({ success: true, counts });
+    const manager = managerFor(req);
+    const [counts, latestTimestamps] = unique.length > 0
+      ? await Promise.all([
+          manager.getChannelMessageCounts(unique),
+          manager.getChannelLatestTimestamps(unique),
+        ])
+      : [{}, {}];
+    res.json({ success: true, counts, latestTimestamps });
   } catch (error) {
     logger.error('[API] Error getting channel message counts:', error);
     res.status(500).json({ success: false, error: 'Failed to get channel message counts' });


### PR DESCRIPTION
Closes #3703

## Problem
The MeshCore Channels view gave no way to see which channels had new messages without clicking into each one. The request: surface channels with unread messages at a glance, with optional "unread first" sorting.

## Why client-side tracking
MeshCore messages are **not** covered by the Meshtastic server-side read-tracking system — the `read_messages` table joins the Meshtastic `messages` table only, and MeshCore messages live in a separate `meshcore_messages` table with no per-user read state. Rather than introduce a new per-user table + migrations across all three backends, this tracks the operator's per-channel last-read marker client-side in `localStorage`, scoped by `sourceId`. A channel is "unread" when its latest persisted message timestamp is newer than that marker.

## Changes
**Backend**
- New `getChannelLatestTimestamps` repository method (max message timestamp per channel, same channel-scoping rules as the existing counts/backlog queries) + manager passthrough.
- `/messages/channel-counts` now also returns `latestTimestamps` alongside `counts`.

**Frontend (`MeshCoreChannelsView`)**
- Unread dot + bold name on channel rows with messages newer than the stored marker; live messages in the shared pool also bump the unread state before the next refetch.
- Opening a channel marks it read up to its newest visible message (deferred on mobile until the content pane is shown).
- Optional persisted "unread first" sort toggle, plus a header badge counting channels with unread messages.

## Tests
- Repository: max-timestamp source-scoping + empty-channel omission.
- Component: unread flagging, clear-on-open (with localStorage persistence assert), current-marker suppression, and the sort-toggle reordering.

Full Vitest suite green (8049 tests, 0 failures). No schema changes / migrations. Frontend + DB-read only — no device-communication behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4