### PR TITLE
fix(channels): scope channel queries, mark-read & message migration by sourceId (#3712)

### DIFF
--- a/src/db/repositories/channels.test.ts
+++ b/src/db/repositories/channels.test.ts
@@ -311,6 +311,35 @@ function runChannelsTests(getBackend: () => TestBackend) {
     expect(mcChannels.every(ch => ch.name.startsWith('MC-'))).toBe(true);
   });
 
+  // #3712: the sync (SQLite-only) read helpers must also honor sourceId so
+  // legacy sync callers don't get cross-source results.
+  it('sync read helpers scope by sourceId (SQLite only)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+    if (backend.dbType !== 'sqlite') return; // sync helpers are SQLite-only
+
+    await repo.upsertChannel({ id: 0, name: 'A-Primary', psk: 'p0', role: 1 }, 'src-a');
+    await repo.upsertChannel({ id: 1, name: 'A-Sec', psk: 'p1', role: 2 }, 'src-a');
+    await repo.upsertChannel({ id: 0, name: 'B-Primary', psk: 'q0', role: 1 }, 'src-b');
+
+    // getChannelByIdSync scoped
+    expect(repo.getChannelByIdSync(0, 'src-a')!.name).toBe('A-Primary');
+    expect(repo.getChannelByIdSync(0, 'src-b')!.name).toBe('B-Primary');
+
+    // getAllChannelsSync scoped
+    expect(repo.getAllChannelsSync('src-a').map(c => c.name).sort()).toEqual(['A-Primary', 'A-Sec']);
+    expect(repo.getAllChannelsSync('src-b').map(c => c.name)).toEqual(['B-Primary']);
+
+    // getChannelCountSync scoped
+    expect(repo.getChannelCountSync('src-a')).toBe(2);
+    expect(repo.getChannelCountSync('src-b')).toBe(1);
+    // Unscoped sees everything (legacy behaviour).
+    expect(repo.getChannelCountSync()).toBe(3);
+  });
+
   it('getChannelCount - returns correct count', async () => {
     const backend = getBackend();
     if (!backend.available) {

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -315,15 +315,20 @@ export class ChannelsRepository extends BaseRepository {
   // Used by legacy sync callers of DatabaseService. Throws on PG/MySQL.
 
   /**
-   * Synchronously get a channel by id (SQLite only).
+   * Synchronously get a channel by id (SQLite only), optionally scoped to a
+   * source (#3712). Without sourceId, returns the first matching row (legacy
+   * single-source behaviour).
    */
-  getChannelByIdSync(id: number): DbChannel | null {
+  getChannelByIdSync(id: number, sourceId?: string): DbChannel | null {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
+    const whereClause = sourceId
+      ? and(eq(channels.id, id), eq(channels.sourceId, sourceId))
+      : eq(channels.id, id);
     const rows = db
       .select()
       .from(channels)
-      .where(eq(channels.id, id))
+      .where(whereClause)
       .limit(1)
       .all();
     if (rows.length === 0) return null;
@@ -331,26 +336,32 @@ export class ChannelsRepository extends BaseRepository {
   }
 
   /**
-   * Synchronously get all channels (SQLite only).
+   * Synchronously get all channels (SQLite only), optionally scoped to a
+   * source (#3712).
    */
-  getAllChannelsSync(): DbChannel[] {
+  getAllChannelsSync(sourceId?: string): DbChannel[] {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
     const rows = db
       .select()
       .from(channels)
+      .where(this.withSourceScope(channels, sourceId))
       .orderBy(channels.id)
       .all();
     return (rows as any[]).map((row) => this.normalizeBigInts(row)) as DbChannel[];
   }
 
   /**
-   * Synchronously count channels (SQLite only).
+   * Synchronously count channels (SQLite only), optionally scoped to a
+   * source (#3712).
    */
-  getChannelCountSync(): number {
+  getChannelCountSync(sourceId?: string): number {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
-    const rows = db.select({ count: count() }).from(channels).all();
+    const whereClause = this.withSourceScope(channels, sourceId);
+    const rows = whereClause
+      ? db.select({ count: count() }).from(channels).where(whereClause).all()
+      : db.select({ count: count() }).from(channels).all();
     return Number((rows[0] as any).count);
   }
 

--- a/src/db/repositories/messages.migration.test.ts
+++ b/src/db/repositories/messages.migration.test.ts
@@ -50,6 +50,13 @@ describe('MessagesRepository.migrateMessagesForChannelMoves', () => {
     `);
   };
 
+  const insertMsgWithSource = (id: string, channel: number, sourceId: string) => {
+    db.exec(`
+      INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, text, channel, portnum, timestamp, createdAt, sourceId)
+      VALUES ('${id}', ${NODE1_NUM}, ${NODE2_NUM}, '${NODE1_ID}', '${NODE2_ID}', 'msg ${id}', ${channel}, 1, ${Date.now()}, ${Date.now()}, '${sourceId}')
+    `);
+  };
+
   const getChannel = (id: string): number => {
     const row = db.prepare('SELECT channel FROM messages WHERE id = ?').get(id) as any;
     return row?.channel;
@@ -157,6 +164,52 @@ describe('MessagesRepository.migrateMessagesForChannelMoves', () => {
     const result = await repo.migrateMessagesForChannelMoves([{ from: 7, to: 3 }]);
     expect(result.success).toBe(true);
     expect(result.totalRowsAffected).toBe(0);
+  });
+
+  // #3712: a channel move detected on one source must not rewrite the channel
+  // column for other sources that happen to share the slot.
+  it('should scope a move to the given sourceId only', async () => {
+    insertMsgWithSource('a-1', 1, 'source-a');
+    insertMsgWithSource('a-2', 1, 'source-a');
+    insertMsgWithSource('b-1', 1, 'source-b'); // same slot, different source
+
+    const result = await repo.migrateMessagesForChannelMoves([{ from: 1, to: 3 }], 'source-a');
+
+    expect(result.success).toBe(true);
+    expect(result.totalRowsAffected).toBe(2);
+    expect(getChannel('a-1')).toBe(3);
+    expect(getChannel('a-2')).toBe(3);
+    expect(getChannel('b-1')).toBe(1); // source-b untouched
+  });
+
+  it('should scope a swap to the given sourceId only', async () => {
+    insertMsgWithSource('a-1', 1, 'source-a');
+    insertMsgWithSource('a-4', 4, 'source-a');
+    insertMsgWithSource('b-1', 1, 'source-b');
+    insertMsgWithSource('b-4', 4, 'source-b');
+
+    const result = await repo.migrateMessagesForChannelMoves(
+      [{ from: 1, to: 4 }, { from: 4, to: 1 }],
+      'source-a',
+    );
+
+    expect(result.success).toBe(true);
+    expect(getChannel('a-1')).toBe(4);
+    expect(getChannel('a-4')).toBe(1);
+    expect(getChannel('b-1')).toBe(1); // source-b untouched
+    expect(getChannel('b-4')).toBe(4);
+  });
+
+  it('without sourceId, migrates across all sources (legacy behaviour)', async () => {
+    insertMsgWithSource('a-1', 1, 'source-a');
+    insertMsgWithSource('b-1', 1, 'source-b');
+
+    const result = await repo.migrateMessagesForChannelMoves([{ from: 1, to: 3 }]);
+
+    expect(result.success).toBe(true);
+    expect(result.totalRowsAffected).toBe(2);
+    expect(getChannel('a-1')).toBe(3);
+    expect(getChannel('b-1')).toBe(3);
   });
 
   it('should handle mix of swaps and simple moves', async () => {

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -931,11 +931,24 @@ export class MessagesRepository extends BaseRepository {
    * @param moves - Array of {from, to} slot pairs. Handles swaps automatically.
    * @returns {success, totalRowsAffected} or throws on failure (transaction rolled back)
    */
-  async migrateMessagesForChannelMoves(moves: { from: number; to: number }[]): Promise<{ success: boolean; totalRowsAffected: number }> {
+  async migrateMessagesForChannelMoves(
+    moves: { from: number; to: number }[],
+    sourceId?: string,
+  ): Promise<{ success: boolean; totalRowsAffected: number }> {
     if (moves.length === 0) return { success: true, totalRowsAffected: 0 };
 
     const TEMP_CHANNEL = -99;
     let totalRowsAffected = 0;
+
+    // Source scope (#3712): without this, a channel move detected on one source
+    // rewrites the `channel` column for EVERY source's messages that happen to
+    // sit in the same slot, corrupting message-channel assignment across
+    // sources. The column is `sourceId` in all three dialects (quoted for PG).
+    const scope = sourceId
+      ? (this.isPostgres()
+          ? sql` AND ${sql.raw('"sourceId"')} = ${sourceId}`
+          : sql` AND sourceId = ${sourceId}`)
+      : sql``;
 
     // Detect swaps: if A→B and B→A both exist
     const swapPairs = new Set<string>();
@@ -959,9 +972,9 @@ export class MessagesRepository extends BaseRepository {
         const a = Math.min(move.from, move.to);
         const b = Math.max(move.from, move.to);
         operations.push(
-          { sql: sql`UPDATE messages SET channel = ${TEMP_CHANNEL} WHERE channel = ${a}`, description: `swap step 1: channel ${a} → temp` },
-          { sql: sql`UPDATE messages SET channel = ${a} WHERE channel = ${b}`, description: `swap step 2: channel ${b} → ${a}` },
-          { sql: sql`UPDATE messages SET channel = ${b} WHERE channel = ${TEMP_CHANNEL}`, description: `swap step 3: temp → ${b}` }
+          { sql: sql`UPDATE messages SET channel = ${TEMP_CHANNEL} WHERE channel = ${a}${scope}`, description: `swap step 1: channel ${a} → temp` },
+          { sql: sql`UPDATE messages SET channel = ${a} WHERE channel = ${b}${scope}`, description: `swap step 2: channel ${b} → ${a}` },
+          { sql: sql`UPDATE messages SET channel = ${b} WHERE channel = ${TEMP_CHANNEL}${scope}`, description: `swap step 3: temp → ${b}` }
         );
       }
     }
@@ -971,7 +984,7 @@ export class MessagesRepository extends BaseRepository {
       const key = [Math.min(move.from, move.to), Math.max(move.from, move.to)].join(',');
       if (!swapPairs.has(key)) {
         operations.push(
-          { sql: sql`UPDATE messages SET channel = ${move.to} WHERE channel = ${move.from}`, description: `move: channel ${move.from} → ${move.to}` }
+          { sql: sql`UPDATE messages SET channel = ${move.to} WHERE channel = ${move.from}${scope}`, description: `move: channel ${move.from} → ${move.to}` }
         );
       }
     }

--- a/src/db/repositories/notifications.test.ts
+++ b/src/db/repositories/notifications.test.ts
@@ -141,7 +141,8 @@ const POSTGRES_CREATE = `
     emoji INTEGER,
     "viaMqtt" BOOLEAN,
     "rxSnr" DOUBLE PRECISION,
-    "rxRssi" DOUBLE PRECISION
+    "rxRssi" DOUBLE PRECISION,
+    "sourceId" TEXT
   );
 
   CREATE TABLE read_messages (
@@ -277,7 +278,8 @@ const MYSQL_CREATE = `
     emoji INTEGER,
     viaMqtt BOOLEAN,
     rxSnr DOUBLE,
-    rxRssi DOUBLE
+    rxRssi DOUBLE,
+    sourceId VARCHAR(36)
   );
 
   CREATE TABLE read_messages (

--- a/src/db/repositories/notifications.test.ts
+++ b/src/db/repositories/notifications.test.ts
@@ -338,6 +338,17 @@ function insertMessageSql(backend: TestBackend, id: string, channel: number, por
   }
 }
 
+// SQL to insert a test message tagged with a sourceId (per-source tests, #3712)
+function insertMessageWithSourceSql(backend: TestBackend, id: string, channel: number, portnum: number, timestamp: number, sourceId: string, fromNodeId: string = '!node1', toNodeId: string = '!node2'): string {
+  if (backend.dbType === 'sqlite') {
+    return `INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, text, channel, portnum, timestamp, createdAt, sourceId) VALUES ('${id}', 1, 2, '${fromNodeId}', '${toNodeId}', 'test', ${channel}, ${portnum}, ${timestamp}, ${timestamp}, '${sourceId}')`;
+  } else if (backend.dbType === 'postgres') {
+    return `INSERT INTO messages (id, "fromNodeNum", "toNodeNum", "fromNodeId", "toNodeId", text, channel, portnum, timestamp, "sourceId") VALUES ('${id}', 1, 2, '${fromNodeId}', '${toNodeId}', 'test', ${channel}, ${portnum}, ${timestamp}, '${sourceId}')`;
+  } else {
+    return `INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, \`text\`, channel, portnum, timestamp, sourceId) VALUES ('${id}', 1, 2, '${fromNodeId}', '${toNodeId}', 'test', ${channel}, ${portnum}, ${timestamp}, '${sourceId}')`;
+  }
+}
+
 // SQL to insert a node (needed for foreign keys in messages for sqlite)
 function insertNodeSql(backend: TestBackend, nodeNum: number): string {
   const now = Date.now();
@@ -751,6 +762,40 @@ function runNotificationsTests(getBackend: () => TestBackend) {
       // userId maps to 0 internally, which may or may not satisfy FK constraints
       const count = await repo.markChannelMessagesAsRead(0, null);
       expect(typeof count).toBe('number');
+    });
+
+    // #3712: marking a channel slot read must not bleed across sources that
+    // share the same slot number (e.g. an MQTT bridge and a radio source both
+    // using slot 2).
+    it('is source-scoped — does not mark other sources\' messages read', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      // Two sources, same slot 2.
+      await backend.exec(insertMessageWithSourceSql(backend, 'src-a-1', 2, 1, 1000, 'source-a'));
+      await backend.exec(insertMessageWithSourceSql(backend, 'src-a-2', 2, 1, 2000, 'source-a'));
+      await backend.exec(insertMessageWithSourceSql(backend, 'src-b-1', 2, 1, 3000, 'source-b'));
+
+      const marked = await repo.markChannelMessagesAsRead(2, 1, undefined, 'source-a');
+      // Only source-a's two messages are marked.
+      expect(marked).toBe(2);
+
+      // source-b's slot-2 message must remain unread (still markable).
+      const markedB = await repo.markChannelMessagesAsRead(2, 1, undefined, 'source-b');
+      expect(markedB).toBe(1);
+    });
+
+    it('without sourceId, marks across all sources (legacy behaviour)', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      await backend.exec(insertMessageWithSourceSql(backend, 'all-a', 3, 1, 1000, 'source-a'));
+      await backend.exec(insertMessageWithSourceSql(backend, 'all-b', 3, 1, 2000, 'source-b'));
+
+      const marked = await repo.markChannelMessagesAsRead(3, 1);
+      expect(marked).toBe(2);
     });
   });
 }

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -422,7 +422,8 @@ export class NotificationsRepository extends BaseRepository {
   async markChannelMessagesAsRead(
     channelId: number,
     userId: number | null,
-    beforeTimestamp?: number
+    beforeTimestamp?: number,
+    sourceId?: string
   ): Promise<number> {
     const now = this.now();
     const effectiveUserId = userId ?? 0;
@@ -430,28 +431,24 @@ export class NotificationsRepository extends BaseRepository {
     try {
       if (this.isSQLite()) {
         const db = this.getSqliteDb();
-        // Get message IDs for the channel
+        // Get message IDs for the channel, scoped to a source when provided so
+        // marking a slot read on one source doesn't bleed across sources that
+        // share the same slot number (#3712).
+        const baseFilters = [
+          eq(messagesSqlite.channel, channelId),
+          eq(messagesSqlite.portnum, 1),
+        ];
+        if (sourceId) baseFilters.push(eq(messagesSqlite.sourceId, sourceId));
         let query = db
           .select({ id: messagesSqlite.id })
           .from(messagesSqlite)
-          .where(
-            and(
-              eq(messagesSqlite.channel, channelId),
-              eq(messagesSqlite.portnum, 1)
-            )
-          );
+          .where(and(...baseFilters));
 
         if (beforeTimestamp !== undefined) {
           query = db
             .select({ id: messagesSqlite.id })
             .from(messagesSqlite)
-            .where(
-              and(
-                eq(messagesSqlite.channel, channelId),
-                eq(messagesSqlite.portnum, 1),
-                lte(messagesSqlite.timestamp, beforeTimestamp)
-              )
-            );
+            .where(and(...baseFilters, lte(messagesSqlite.timestamp, beforeTimestamp)));
         }
 
         const messages = await query;
@@ -476,6 +473,11 @@ export class NotificationsRepository extends BaseRepository {
         const db = this.getPostgresDb();
         // Use INSERT...SELECT with WHERE NOT EXISTS to avoid duplicates
         // (ON CONFLICT requires a unique constraint which may not exist on all installs)
+        // Source scope (#3712): when provided, restrict to messages owned by
+        // this source so shared slot numbers don't bleed across sources.
+        const pgSourceFilter = sourceId
+          ? sql` AND m.${this.col('sourceId')} = ${sourceId}`
+          : sql``;
         let result;
         if (beforeTimestamp !== undefined) {
           result = await db.execute(sql`
@@ -483,7 +485,7 @@ export class NotificationsRepository extends BaseRepository {
             SELECT m.id, ${effectiveUserId}, ${now} FROM messages m
             WHERE m.channel = ${channelId}
               AND m.portnum = 1
-              AND m.timestamp <= ${beforeTimestamp}
+              AND m.timestamp <= ${beforeTimestamp}${pgSourceFilter}
               AND NOT EXISTS (
                 SELECT 1 FROM read_messages rm
                 WHERE rm.${this.col('messageId')} = m.id AND rm.${this.col('userId')} = ${effectiveUserId}
@@ -494,7 +496,7 @@ export class NotificationsRepository extends BaseRepository {
             INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
             SELECT m.id, ${effectiveUserId}, ${now} FROM messages m
             WHERE m.channel = ${channelId}
-              AND m.portnum = 1
+              AND m.portnum = 1${pgSourceFilter}
               AND NOT EXISTS (
                 SELECT 1 FROM read_messages rm
                 WHERE rm.${this.col('messageId')} = m.id AND rm.${this.col('userId')} = ${effectiveUserId}
@@ -505,6 +507,10 @@ export class NotificationsRepository extends BaseRepository {
       } else {
         // MySQL
         const db = this.getMysqlDb();
+        // Source scope (#3712): restrict to this source's messages when given.
+        const mysqlSourceFilter = sourceId
+          ? sql` AND sourceId = ${sourceId}`
+          : sql``;
         // MySQL uses INSERT IGNORE for upsert behavior
         if (beforeTimestamp !== undefined) {
           const [result] = await db.execute(sql`
@@ -512,7 +518,7 @@ export class NotificationsRepository extends BaseRepository {
             SELECT id, ${effectiveUserId}, ${now} FROM messages
             WHERE channel = ${channelId}
               AND portnum = 1
-              AND timestamp <= ${beforeTimestamp}
+              AND timestamp <= ${beforeTimestamp}${mysqlSourceFilter}
           `);
           return Number((result as any).affectedRows ?? 0);
         } else {
@@ -520,7 +526,7 @@ export class NotificationsRepository extends BaseRepository {
             INSERT IGNORE INTO read_messages (messageId, userId, readAt)
             SELECT id, ${effectiveUserId}, ${now} FROM messages
             WHERE channel = ${channelId}
-              AND portnum = 1
+              AND portnum = 1${mysqlSourceFilter}
           `);
           return Number((result as any).affectedRows ?? 0);
         }

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -376,6 +376,30 @@ describe('POST /channels/reorder', () => {
     expect(res.body.requiresReboot).toBe(false);
     expect(mockManager.beginEditSettings).not.toHaveBeenCalled();
   });
+
+  it('scopes the message migration to the resolved source (#3712)', async () => {
+    mockManager.sourceId = 'src-reorder';
+    mockDb.channels.getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Primary', role: 1, psk: 'AQ==' },
+      { id: 1, name: 'Second', role: 2, psk: 'BB==' },
+    ]);
+    // Swap slots 0 and 1 so the reorder produces real moves.
+    const res = await request(app)
+      .post('/channels/reorder')
+      .send({ newOrder: [1, 0, 2, 3, 4, 5, 6, 7], sourceId: 'src-reorder' });
+    expect(res.status).toBe(200);
+    // The DB lookup driving the reorder must be scoped to the resolved source.
+    expect(mockDb.channels.getAllChannels).toHaveBeenCalledWith('src-reorder');
+    // The key fix: message migration must carry the sourceId so messages from
+    // other sources sharing the same slot ids are not migrated.
+    expect(mockDb.messages.migrateMessagesForChannelMoves).toHaveBeenCalledTimes(1);
+    const [moves, passedSourceId] = mockDb.messages.migrateMessagesForChannelMoves.mock.calls[0];
+    expect(passedSourceId).toBe('src-reorder');
+    expect(moves).toEqual(expect.arrayContaining([
+      { from: 1, to: 0 },
+      { from: 0, to: 1 },
+    ]));
+  });
 });
 
 describe('POST /channels/decode-url', () => {

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -969,7 +969,7 @@ router.post('/reorder', requireAuth(), async (req: Request, res: Response) => {
     if (moves.length > 0) {
       logger.info(`📦 Channel reorder message migration: ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
       try {
-        await databaseService.messages.migrateMessagesForChannelMoves(moves);
+        await databaseService.messages.migrateMessagesForChannelMoves(moves, reorderSourceScope);
       } catch (error) {
         logger.error('📦 Failed to migrate messages after channel reorder:', error);
       }
@@ -1016,6 +1016,7 @@ router.post('/encode-url', requirePermission('configuration', 'read'), async (re
   try {
     const { channelIds, includeLoraConfig, sourceId: encodeUrlSourceId } = req.body;
     const encodeUrlManager = resolveSourceManager(encodeUrlSourceId);
+    const encodeUrlSourceScope = encodeUrlManager.sourceId;
 
     if (!Array.isArray(channelIds)) {
       return res.status(400).json({ error: 'channelIds must be an array' });
@@ -1023,9 +1024,11 @@ router.post('/encode-url', requirePermission('configuration', 'read'), async (re
 
     const channelUrlService = (await import('../services/channelUrlService.js')).default;
 
-    // Get selected channels from database
+    // Get selected channels from database, scoped to this source. MeshCore and
+    // Meshtastic channels share the `channels` table with the same slot ids, so
+    // an unscoped getChannelById can return another source's row for the slot.
     const channelResults = await Promise.all(
-      channelIds.map((id: number) => databaseService.channels.getChannelById(id))
+      channelIds.map((id: number) => databaseService.channels.getChannelById(id, encodeUrlSourceScope))
     );
     const channels = channelResults
       .filter((ch): ch is NonNullable<typeof ch> => ch !== null)

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -330,7 +330,12 @@ router.get('/:id/export', requireAuth(), async (req: Request, res: Response) => 
       });
     }
 
-    const channel = await databaseService.channels.getChannelById(channelId);
+    // Scope to a source when supplied (#3712) so a multi-source install can't
+    // export the PSK from a different source's channel that shares this slot.
+    const exportSourceId = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
+      ? req.query.sourceId
+      : undefined;
+    const channel = await databaseService.channels.getChannelById(channelId, exportSourceId);
     if (!channel) {
       return res.status(404).json({ error: 'Channel not found' });
     }
@@ -406,17 +411,20 @@ function detectChannelMoves(
  * Snapshot channel slots and migrate messages after a channel configuration change.
  * Call snapshotBefore() before applying changes, then migrateIfNeeded() after.
  */
-async function snapshotChannelsBeforeChange() {
-  return (await databaseService.channels.getAllChannels()).map(ch => ({ id: ch.id, psk: ch.psk }));
+async function snapshotChannelsBeforeChange(sourceId?: string) {
+  return (await databaseService.channels.getAllChannels(sourceId)).map(ch => ({ id: ch.id, psk: ch.psk }));
 }
 
-async function migrateMessagesIfChannelsMoved(beforeSnapshot: { id: number; psk?: string | null }[]) {
+async function migrateMessagesIfChannelsMoved(
+  beforeSnapshot: { id: number; psk?: string | null }[],
+  sourceId?: string,
+) {
   try {
-    const afterSnapshot = (await databaseService.channels.getAllChannels()).map(ch => ({ id: ch.id, psk: ch.psk }));
+    const afterSnapshot = (await databaseService.channels.getAllChannels(sourceId)).map(ch => ({ id: ch.id, psk: ch.psk }));
     const moves = detectChannelMoves(beforeSnapshot, afterSnapshot);
     if (moves.length > 0) {
       logger.info(`📦 Detected channel move(s): ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
-      await databaseService.messages.migrateMessagesForChannelMoves(moves);
+      await databaseService.messages.migrateMessagesForChannelMoves(moves, sourceId);
       await migrateAutomationChannels(
         moves,
         (key) => databaseService.settings.getSetting(key),
@@ -518,15 +526,18 @@ router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
     // so there is no pre-existing DB row when adding a new slot. Skip the
     // existence check for MeshCore; enforce 404 only for Meshtastic, which
     // always pre-creates 8 slots.
+    const scopedSourceId = typeof chanSourceId === 'string' && chanSourceId.length > 0
+      ? chanSourceId
+      : undefined;
     const existingChannel = sourceType !== 'meshcore'
-      ? await databaseService.channels.getChannelById(channelId)
+      ? await databaseService.channels.getChannelById(channelId, scopedSourceId)
       : null;
     if (sourceType !== 'meshcore' && !existingChannel) {
       return res.status(404).json({ error: 'Channel not found' });
     }
 
-    // Snapshot channels before change for message migration
-    const beforeSnapshot = await snapshotChannelsBeforeChange();
+    // Snapshot channels before change for message migration (per-source — #3712)
+    const beforeSnapshot = await snapshotChannelsBeforeChange(scopedSourceId);
 
     // Prepare the updated channel data
     const updatedChannelData = {
@@ -598,7 +609,7 @@ router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
     // coalesce in upsertChannel silently keeps the old name (#1567 backfire).
     await databaseService.channels.upsertChannel(
       updatedChannelData,
-      typeof chanSourceId === 'string' && chanSourceId.length > 0 ? chanSourceId : undefined,
+      scopedSourceId,
       { allowBlankName: true },
     );
 
@@ -619,10 +630,10 @@ router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
       // Continue even if device update fails - database is updated
     }
 
-    // Migrate messages if channel PSK moved to a different slot
-    await migrateMessagesIfChannelsMoved(beforeSnapshot);
+    // Migrate messages if channel PSK moved to a different slot (per-source — #3712)
+    await migrateMessagesIfChannelsMoved(beforeSnapshot, scopedSourceId);
 
-    const updatedChannel = await databaseService.channels.getChannelById(channelId);
+    const updatedChannel = await databaseService.channels.getChannelById(channelId, scopedSourceId);
     logger.info(`✅ Updated channel ${channelId}: ${name}`);
     res.json({ success: true, channel: updatedChannel });
   } catch (error) {
@@ -776,8 +787,11 @@ router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response
       return !!value;
     };
 
-    // Snapshot channels before change for message migration
-    const beforeSnapshot = await snapshotChannelsBeforeChange();
+    // Snapshot channels before change for message migration (per-source — #3712)
+    const importScopedSourceId = typeof importSourceId === 'string' && importSourceId.length > 0
+      ? importSourceId
+      : undefined;
+    const beforeSnapshot = await snapshotChannelsBeforeChange(importScopedSourceId);
 
     const importedChannelData = {
       id: slotId,
@@ -789,8 +803,8 @@ router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response
       positionPrecision: positionPrecision !== null && positionPrecision !== undefined ? positionPrecision : undefined,
     };
 
-    // Import channel to the specified slot in database
-    await databaseService.channels.upsertChannel(importedChannelData);
+    // Import channel to the specified slot in database (scoped to source — #3712)
+    await databaseService.channels.upsertChannel(importedChannelData, importScopedSourceId);
 
     // Send channel configuration to Meshtastic device
     const importManager = (resolveSourceManager(importSourceId));
@@ -809,10 +823,10 @@ router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response
       // Continue even if device update fails - database is updated
     }
 
-    // Migrate messages if channel PSK moved to a different slot
-    await migrateMessagesIfChannelsMoved(beforeSnapshot);
+    // Migrate messages if channel PSK moved to a different slot (per-source — #3712)
+    await migrateMessagesIfChannelsMoved(beforeSnapshot, importScopedSourceId);
 
-    const importedChannel = await databaseService.channels.getChannelById(slotId);
+    const importedChannel = await databaseService.channels.getChannelById(slotId, importScopedSourceId);
     logger.info(`✅ Imported channel to slot ${slotId}: ${name}`);
     res.json({ success: true, channel: importedChannel });
   } catch (error) {
@@ -1114,8 +1128,11 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
       throw new Error(`Failed to start configuration transaction: ${errMsg}`, { cause: error });
     }
 
-    // Snapshot channels before change for message migration
-    const beforeSnapshot = await snapshotChannelsBeforeChange();
+    // Snapshot channels before change for message migration (per-source — #3712)
+    const configScopedSourceId = typeof configSourceId === 'string' && configSourceId.length > 0
+      ? configSourceId
+      : undefined;
+    const beforeSnapshot = await snapshotChannelsBeforeChange(configScopedSourceId);
 
     // Import channels FIRST (before LoRa config to avoid premature reboot)
     const importedChannels = [];
@@ -1191,7 +1208,7 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
       if (moves.length > 0) {
         logger.info(`📦 Detected channel move(s) from config import: ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
         try {
-          await databaseService.messages.migrateMessagesForChannelMoves(moves);
+          await databaseService.messages.migrateMessagesForChannelMoves(moves, configScopedSourceId);
           await migrateAutomationChannels(
             moves,
             (key) => databaseService.settings.getSetting(key),
@@ -1243,7 +1260,9 @@ router.post('/refresh', requirePermission('messages', 'write'), async (req: Requ
     // Trigger full node database refresh (includes channels)
     await chanRefreshManager.refreshNodeDatabase();
 
-    const channelCount = await databaseService.channels.getChannelCount();
+    const channelCount = await databaseService.channels.getChannelCount(
+      typeof chanRefreshSourceId === 'string' && chanRefreshSourceId.length > 0 ? chanRefreshSourceId : undefined,
+    );
 
     logger.debug(`✅ Channel refresh complete: ${channelCount} channels`);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2556,7 +2556,7 @@ apiRouter.post('/messages/mark-read', optionalAuth(), async (req, res) => {
       markedCount = await databaseService.markAllDMMessagesAsReadAsync(localNodeInfo.nodeId, userId);
     } else if (channelId !== undefined) {
       // Mark all messages in a channel as read (specific channel permission already checked above)
-      markedCount = await databaseService.markChannelMessagesAsReadAsync(channelId, userId, beforeTimestamp);
+      markedCount = await databaseService.markChannelMessagesAsReadAsync(channelId, userId, beforeTimestamp, markReadSourceId);
     } else if (nodeId) {
       // Mark all DMs with a node as read (permission already checked above)
       const localNodeInfo = markReadManager.getLocalNodeInfo();
@@ -3337,7 +3337,9 @@ apiRouter.post('/nodes/refresh', requirePermission('nodes', 'write'), async (req
     await refreshManager.refreshNodeDatabase();
 
     const nodeCount = await databaseService.nodes.getNodeCount();
-    const channelCount = await databaseService.channels.getChannelCount();
+    const channelCount = await databaseService.channels.getChannelCount(
+      typeof refreshSourceId === 'string' && refreshSourceId.length > 0 ? refreshSourceId : undefined,
+    );
 
     logger.debug(`✅ Node refresh complete: ${nodeCount} nodes, ${channelCount} channels`);
 
@@ -4973,8 +4975,9 @@ apiRouter.post('/admin/get-channel', requireAdmin(), async (req, res) => {
     const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
 
     if (isLocalNode) {
-      // For local node, get from database
-      const channel = await databaseService.channels.getChannelById(channelIndex);
+      // For local node, get from database (scoped to source — #3712)
+      const gcScopedSourceId = typeof gcSourceId === 'string' && gcSourceId.length > 0 ? gcSourceId : undefined;
+      const channel = await databaseService.channels.getChannelById(channelIndex, gcScopedSourceId);
       if (channel) {
         return res.json({ channel: {
           name: channel.name || '',
@@ -5271,10 +5274,13 @@ apiRouter.post('/admin/export-config', requireAdmin(), async (req, res) => {
     const channelUrlService = (await import('./services/channelUrlService.js')).default;
 
     // Get channels from local or remote node
+    const aecScopedSourceId = typeof aecSourceId === 'string' && aecSourceId.length > 0 ? aecSourceId : undefined;
     const channels = [];
     for (const channelId of channelIds) {
       if (isLocalNode) {
-        const channel = await databaseService.channels.getChannelById(channelId);
+        // Scoped to source (#3712) so the local-node export path reads this
+        // source's channel row, not the first matching source.
+        const channel = await databaseService.channels.getChannelById(channelId, aecScopedSourceId);
         if (channel) {
           channels.push({
             psk: channel.psk ? channel.psk : 'none',

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3718,7 +3718,7 @@ class DatabaseService {
   //  removed — dead code with no callers; all channel upserts go through the
   //  async, #1567-guarded databaseService.channels.upsertChannel)
 
-  getChannelById(id: number): DbChannel | null {
+  getChannelById(id: number, sourceId?: string): DbChannel | null {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (!this.cacheInitialized) {
@@ -3731,32 +3731,34 @@ class DatabaseService {
       }
       return channel;
     }
-    const channel = this.channelsRepo!.getChannelByIdSync(id);
+    const channel = this.channelsRepo!.getChannelByIdSync(id, sourceId);
     return channel;
   }
 
-  getAllChannels(): DbChannel[] {
+  getAllChannels(sourceId?: string): DbChannel[] {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (!this.cacheInitialized) {
         logger.debug(`getAllChannels() called before cache initialized`);
         return [];
       }
-      return Array.from(this.channelsCache.values()).sort((a, b) => a.id - b.id);
+      const cached = Array.from(this.channelsCache.values()).sort((a, b) => a.id - b.id);
+      return sourceId ? cached.filter((c) => (c as any).sourceId === sourceId) : cached;
     }
-    return this.channelsRepo!.getAllChannelsSync();
+    return this.channelsRepo!.getAllChannelsSync(sourceId);
   }
 
-  getChannelCount(): number {
+  getChannelCount(sourceId?: string): number {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (!this.cacheInitialized) {
         logger.debug(`getChannelCount() called before cache initialized`);
         return 0;
       }
-      return this.channelsCache.size;
+      if (!sourceId) return this.channelsCache.size;
+      return Array.from(this.channelsCache.values()).filter((c) => (c as any).sourceId === sourceId).length;
     }
-    return this.channelsRepo!.getChannelCountSync();
+    return this.channelsRepo!.getChannelCountSync(sourceId);
   }
 
   // Clean up invalid channels that shouldn't have been created
@@ -7829,12 +7831,12 @@ class DatabaseService {
     return this.notifications.markMessagesAsReadByIds(messageIds, userId);
   }
 
-  markChannelMessagesAsRead(channelId: number, userId: number | null, beforeTimestamp?: number): number {
-    logger.info(`[DatabaseService] markChannelMessagesAsRead called: channel=${channelId}, userId=${userId}, dbType=${this.drizzleDbType}`);
+  markChannelMessagesAsRead(channelId: number, userId: number | null, beforeTimestamp?: number, sourceId?: string): number {
+    logger.info(`[DatabaseService] markChannelMessagesAsRead called: channel=${channelId}, userId=${userId}, sourceId=${sourceId ?? 'all'}, dbType=${this.drizzleDbType}`);
     // For PostgreSQL/MySQL, use async repo
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.notificationsRepo) {
-        this.notificationsRepo.markChannelMessagesAsRead(channelId, userId, beforeTimestamp)
+        this.notificationsRepo.markChannelMessagesAsRead(channelId, userId, beforeTimestamp, sourceId)
           .then((count) => {
             logger.info(`[DatabaseService] Marked ${count} channel ${channelId} messages as read for user ${userId}`);
           })
@@ -7858,6 +7860,14 @@ class DatabaseService {
         AND portnum = 1
     `;
     const params: any[] = [userId, Date.now(), channelId];
+
+    // Source scope (#3712): without this, marking a slot read on one source
+    // also marks the same slot read on every other source (e.g. an MQTT bridge
+    // and a radio source both using slot 2).
+    if (sourceId) {
+      query += ` AND sourceId = ?`;
+      params.push(sourceId);
+    }
 
     if (beforeTimestamp !== undefined) {
       query += ` AND timestamp <= ?`;
@@ -9160,8 +9170,8 @@ class DatabaseService {
     return this.markAllDMMessagesAsRead(localNodeId, userId);
   }
 
-  async markChannelMessagesAsReadAsync(channelId: number, userId: number | null, beforeTimestamp?: number): Promise<number> {
-    return this.markChannelMessagesAsRead(channelId, userId, beforeTimestamp);
+  async markChannelMessagesAsReadAsync(channelId: number, userId: number | null, beforeTimestamp?: number, sourceId?: string): Promise<number> {
+    return this.markChannelMessagesAsRead(channelId, userId, beforeTimestamp, sourceId);
   }
 
   async markDMMessagesAsReadAsync(localNodeId: string, remoteNodeId: string, userId: number | null, beforeTimestamp?: number): Promise<number> {


### PR DESCRIPTION
Closes #3712

## Summary

`sourceId` was not consistently applied across channel reads, admin routes, the mark-read path, and the channel-move message migration. On multi-source installs (notably the MQTT-bridge scenario from the issue) this surfaced as the wrong source's channels appearing, PSK exports/admin reads from the wrong source, and two cross-source **correctness** bugs.

## Bugs fixed (mapped to the issue)

| # | What | Fix |
|---|------|-----|
| 4 (Critical) | `snapshotChannelsBeforeChange` / `migrateMessagesIfChannelsMoved` fetched channels from ALL sources; `migrateMessagesForChannelMoves` ran unscoped `UPDATE messages SET channel=...`, corrupting message-channel assignment across sources | Both helpers + the repo method take `sourceId` and scope every UPDATE (simple moves + swap steps) per dialect; threaded from all callers |
| 9 (Critical) | `markChannelMessagesAsRead` had no `sourceId` — marking a slot read bled across every source sharing that slot | Added `sourceId` to repo (SQLite/PG/MySQL), `DatabaseService` sync+async facades, and the route caller |
| 2 (High) | `GET /:id/export` could export PSK from wrong source | Accepts `?sourceId=` and passes it through |
| 3 (High) | import upsert + response fetch ignored `importSourceId` | Threaded into `upsertChannel` and `getChannelById` |
| 1 (Med) | PUT response fetch (Meshtastic path) unscoped | Pass scoped sourceId |
| 6,7 (Med) | admin get-channel / export-config local path unscoped | Pass scoped sourceId |
| 10 (Med) | sync repo methods (`getChannelByIdSync` / `getAllChannelsSync` / `getChannelCountSync`) never scoped | Added optional `sourceId`; facade threads it |
| 5,8 (Low) | refresh channel-count cosmetic | Scoped |

All new scoping is opt-in — omitting `sourceId` preserves legacy all-source behaviour, so single-source installs are unaffected.

## Tests

Added per-source isolation tests for `markChannelMessagesAsRead`, `migrateMessagesForChannelMoves` (move + swap), and the sync channel read helpers, plus legacy-unscoped coverage. Full Vitest suite green (0 failures, 7440 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4