### PR TITLE
fix(meshcore): serialize 0x8C binary-response consumers to prevent reply theft (#3667)

### DIFF
--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -379,4 +379,49 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
     expect(op(callLog[2])).toBe(op(callLog[3]));
     expect(op(callLog[0])).not.toBe(op(callLog[2]));
   });
+
+  it('advances the 0x8C chain when an op times out so the next op still runs (#3667)', async () => {
+    // The serializer must release on rejection, not just resolution: if
+    // request_regions times out (never receives a BinaryResponse), a queued
+    // request_telemetry must still proceed — otherwise a single dead repeater
+    // would wedge the connection's 0x8C queue.
+    const { backend, conn } = await connectedBackend();
+    const callLog: string[] = [];
+
+    // Regions: send the frame but NEVER reply, forcing the inner timeout.
+    (conn as any).sendToRadioFrame = (frame: Uint8Array) => {
+      conn.sentFrames.push(frame);
+      if (frame[0] === 57) {
+        callLog.push('regions:send');
+        return; // no Sent / no BinaryResponse → request_regions times out
+      }
+      setImmediate(() => conn.emit(ResponseCodes.Ok));
+    };
+
+    const telemetryBytes = Uint8Array.from([0xaa, 0xbb]);
+    (conn as any).sendBinaryRequest = (_pubkey: Uint8Array, _req: number[]) =>
+      new Promise<Uint8Array>((resolve) => {
+        callLog.push('telemetry:send');
+        setImmediate(() => {
+          callLog.push('telemetry:reply');
+          resolve(telemetryBytes);
+        });
+      });
+
+    // Regions is issued first, so it acquires the lock first (both resume from
+    // resolvePublicKey in FIFO microtask order); a short timeout_ms keeps the
+    // test fast. Telemetry must wait, then run once regions' timeout rejects.
+    const [regionsRes, telemetryRes] = await Promise.all([
+      backend.sendCommand('request_regions', { public_key: 'aa'.repeat(32), timeout_ms: 30 }),
+      backend.sendCommand('request_telemetry', { public_key: 'bb'.repeat(32) }),
+    ]);
+
+    expect(regionsRes.success).toBe(false);
+    expect(regionsRes.error).toMatch(/timed out/i);
+    expect(telemetryRes.success).toBe(true);
+
+    // Order proves the chain advanced past the rejection: regions sent (and held
+    // the lock) first, and telemetry only sent after regions' timeout released it.
+    expect(callLog).toEqual(['regions:send', 'telemetry:send', 'telemetry:reply']);
+  });
 });

--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -314,4 +314,69 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
     expect(res.data.clock).toBe(2);
     expect(res.data.regions).toEqual(['berlin']);
   });
+
+  it('serializes overlapping 0x8C consumers so a concurrent telemetry reply is not stolen by request_regions (#3667)', async () => {
+    // request_regions (raw frame, tag-blind first-match) and request_telemetry
+    // (library sendBinaryRequest) both ride PUSH_CODE_BINARY_RESPONSE (0x8C).
+    // runExclusiveBinaryResponse must keep them from overlapping on this
+    // connection — otherwise the regions listener consumes the telemetry reply
+    // and parses CayenneLPP bytes as a region list.
+    const { backend, conn } = await connectedBackend();
+    const callLog: string[] = [];
+
+    // Regions: payload-less Sent (sendToRadioFrame path) + a recognizable list.
+    (conn as any).sendToRadioFrame = (frame: Uint8Array) => {
+      conn.sentFrames.push(frame);
+      if (frame[0] === 57) {
+        callLog.push('regions:send');
+        setImmediate(() => {
+          conn.emit(ResponseCodes.Sent);
+          callLog.push('regions:reply');
+          conn.emit(PushCodes.BinaryResponse, {
+            reserved: 0,
+            tag: 0xcafef00d,
+            responseData: Uint8Array.from([1, 0, 0, 0, ...Buffer.from('saxony', 'ascii'), 0]),
+          });
+        });
+        return;
+      }
+      setImmediate(() => conn.emit(ResponseCodes.Ok));
+    };
+
+    // Telemetry: emit a 0x8C push on the SHARED bus (what a real reply does, and
+    // exactly what a concurrent regions listener would wrongly grab) then
+    // resolve with the binary payload the library's sendBinaryRequest returns.
+    const telemetryBytes = Uint8Array.from([0xff, 0xfe, 0xfd, 0xfc]);
+    (conn as any).sendBinaryRequest = (_pubkey: Uint8Array, _req: number[]) =>
+      new Promise<Uint8Array>((resolve) => {
+        callLog.push('telemetry:send');
+        setImmediate(() => {
+          conn.emit(PushCodes.BinaryResponse, { reserved: 0, tag: 0x11111111, responseData: telemetryBytes });
+          callLog.push('telemetry:reply');
+          resolve(telemetryBytes);
+        });
+      });
+
+    // Fire both concurrently on the same connection.
+    const [regionsRes, telemetryRes] = await Promise.all([
+      backend.sendCommand('request_regions', { public_key: 'aa'.repeat(32) }),
+      backend.sendCommand('request_telemetry', { public_key: 'bb'.repeat(32) }),
+    ]);
+
+    // Each op resolved with its OWN payload — no cross-contamination. If the
+    // regions listener had stolen the telemetry reply, regions would be [] (the
+    // 4 telemetry bytes parse as clock-only with no names).
+    expect(regionsRes.success).toBe(true);
+    expect(regionsRes.data.regions).toEqual(['saxony']);
+    expect(telemetryRes.success).toBe(true);
+
+    // The two ops never overlapped: each ':send' is immediately followed by its
+    // own ':reply' before the other op's ':send' (order between them is
+    // microtask-dependent, so assert pairing rather than absolute order).
+    expect(callLog).toHaveLength(4);
+    const op = (s: string) => s.split(':')[0];
+    expect(op(callLog[0])).toBe(op(callLog[1]));
+    expect(op(callLog[2])).toBe(op(callLog[3]));
+    expect(op(callLog[0])).not.toBe(op(callLog[2]));
+  });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -827,6 +827,37 @@ export class MeshCoreNativeBackend extends EventEmitter {
     }
   }
 
+  /**
+   * Serializes operations that await the shared PUSH_CODE_BINARY_RESPONSE
+   * (0x8C) push on THIS connection. That push carries only a 4-byte correlation
+   * `tag` and no responder pubkey. Our raw-frame `request_regions` can't obtain
+   * a tag — `sendToRadioFrame` fires the `Sent` ack with no `expectedAckCrc` —
+   * so it falls back to accepting the *first* 0x8C reply it sees. A
+   * `request_telemetry` binary request rides the same 0x8C push, so if the two
+   * overlap they race for that first reply and mis-attribute each other's
+   * payload (a telemetry CayenneLPP body parsed as a regions list, or vice
+   * versa). Chaining every 0x8C consumer on a single per-instance promise
+   * guarantees exactly one is listening at a time.
+   *
+   * The chain is an instance field, so it is inherently per-source: each source
+   * owns its own MeshCoreNativeBackend (and physical connection), so this never
+   * serializes across sources — only same-connection 0x8C ops wait on each
+   * other. The lock is held until the operation's own listeners tear down
+   * (bounded by each op's internal timeout), so it always releases.
+   */
+  private binaryResponseChain: Promise<unknown> = Promise.resolve();
+
+  private runExclusiveBinaryResponse<T>(fn: () => Promise<T>): Promise<T> {
+    // Run after whatever is already queued, regardless of how it settled
+    // (using `fn` for both handlers means a prior rejection still releases us).
+    const run = this.binaryResponseChain.then(fn, fn);
+    // Advance the chain to this op's completion. Swallow settlement here so the
+    // chain never carries an unhandled rejection — the caller still receives
+    // `run` (and its rejection) directly.
+    this.binaryResponseChain = run.then(() => {}, () => {});
+    return run;
+  }
+
   private async dispatch(cmd: string, params: Record<string, unknown>): Promise<any> {
     if (!this.connection || !this.constants) {
       throw new Error('Native backend not connected');
@@ -967,7 +998,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
         frame[33] = 0x01; // ANON_REQ_TYPE_REGIONS
         frame[34] = 0x00; // reply_path_len = 0
 
-        const responseData: Uint8Array = await new Promise((resolve, reject) => {
+        // Serialize against other 0x8C consumers (e.g. request_telemetry) on
+        // this connection — see runExclusiveBinaryResponse.
+        const responseData: Uint8Array = await this.runExclusiveBinaryResponse(() => new Promise<Uint8Array>((resolve, reject) => {
           let sentReceived = false;
           let tag: number | null = null;
           let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
@@ -1008,7 +1041,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
           c.on(K.PushCodes.BinaryResponse, onResp);
           c.once(K.ResponseCodes.Err, onErr);
           void c.sendToRadioFrame(frame);
-        });
+        }));
 
         // Parse: clock(4 LE) + NUL-terminated, comma-separated ASCII names.
         const buf = Buffer.from(responseData);
@@ -1016,7 +1049,14 @@ export class MeshCoreNativeBackend extends EventEmitter {
         let end = buf.indexOf(0, 4);
         if (end < 0) end = buf.length;
         const namesStr = buf.length > 4 ? buf.toString('ascii', 4, end) : '';
-        const regions = namesStr.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+        // Defense-in-depth on top of the 0x8C serialization: a genuine regions
+        // reply is printable ASCII. If a stray non-regions binary payload ever
+        // reached us, its control/high bytes would survive the split — drop any
+        // such token rather than render garbage region chips.
+        const regions = namesStr
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0 && /^[\x20-\x7e]+$/.test(s));
         return { ok: true, clock, regions };
       }
 
@@ -1348,7 +1388,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Telemetry target not found');
         const reqType = K.BinaryRequestTypes.GetTelemetryData;
-        const responseData: Uint8Array = await c.sendBinaryRequest(publicKey, [reqType]);
+        // Serialize against other 0x8C consumers (e.g. request_regions) on this
+        // connection — see runExclusiveBinaryResponse. The library's own
+        // sendBinaryRequest tag-matches its reply, but our raw-frame regions
+        // request can't, so the two must not overlap.
+        const responseData: Uint8Array = await this.runExclusiveBinaryResponse(
+          () => c.sendBinaryRequest(publicKey, [reqType]),
+        );
         const mod = await loadMeshCoreJs();
         const records = mod.CayenneLpp.parse(responseData);
         return { records };


### PR DESCRIPTION
## Problem

`request_regions` and `request_telemetry` both await the shared `PUSH_CODE_BINARY_RESPONSE` (`0x8C`) push, which carries only a 4-byte correlation `tag` and **no responder pubkey**. `request_regions` sends via the raw `sendToRadioFrame` path, whose `Sent` ack has no `expectedAckCrc`, so it can't obtain a tag and falls back to accepting the **first** `0x8C` reply it sees.

If a `request_telemetry` binary request (same `0x8C` push — e.g. the periodic remote-telemetry scheduler) overlaps it on the **same connection**, the two race for that first reply and mis-attribute each other's payload: a telemetry CayenneLPP body gets parsed as a regions list, or vice versa. Worst case is garbage/empty region chips on a manual, user-triggered action.

This is a latent issue that survives the already-merged timeout fix (#3702 / `3a035711`) — that fix made the null-tag fallback work, but the fallback is tag-blind and the `0x8C` event is shared.

## Fix

- **`runExclusiveBinaryResponse`** — chains every `0x8C`-awaiting op on a single **per-instance** promise so exactly one is listening at a time. Wraps both `request_regions` and `request_telemetry`.
- **Source-aware by construction:** the lock is an instance field, and each source owns its own `MeshCoreNativeBackend` + physical connection. Same-connection `0x8C` ops serialize; **concurrent sources never block each other**. A module-level global would have wrongly coupled sources — this doesn't.
- The lock is held only until each op's listeners tear down (bounded by its internal timeout), so it always releases.
- **Defense-in-depth:** the regions parser now drops any token that isn't printable ASCII, so a stray non-regions payload can't render garbage region chips.

## Test

Adds a regression test firing `request_regions` and `request_telemetry` concurrently on one connection, asserting (a) each resolves with its **own** payload (regions = `['saxony']`, not the telemetry bytes) and (b) the call log shows no overlap — each `:send` is immediately followed by its own `:reply`.

Verified: 481 MeshCore backend/manager tests pass (`success=true`); `tsc` clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)