### PR TITLE
feat(automations): fire trigger.schedule on a cron schedule (#3653)

### DIFF
--- a/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
+++ b/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
@@ -394,18 +394,13 @@ substitutions sidebar, channel-name trigger matching, source selector,
 protocol-aware unified-channel send, Test-panel selects, timestamp
 formatting). To pick up **after that PR merges**:
 
-1. **Implement the Schedule trigger fully.** `trigger.schedule` is currently a
-   catalog-only stub — it is **not fired by the engine at all** (no cron
-   wiring). The Test panel dry-runs it (`automationSimulator` `schedule` case →
-   matched), but nothing fires it live. Wire a cron scheduler (reuse
-   `src/server/utils/cronScheduler.ts` / croner) into
-   `automationEngineSingleton`: register a job per enabled `trigger.schedule`
-   automation from its `cron` param, re-register on automation create/update/
-   enable/disable and on engine reload, and call a new
-   `engine.onSchedule(automationId)` that builds a schedule `TriggerContext` and
-   runs the graph. Add a `buildScheduleContext` in `triggerContext.ts`. Tests:
-   job registered/cancelled on enable/disable/edit; fires on tick; invalid cron
-   rejected at save.
+1. ~~**Implement the Schedule trigger fully.**~~ **DONE** (follow-up PR). The
+   engine now arms a croner job per enabled `trigger.schedule` automation in
+   `load()` (`rescheduleCron()`), so create/update/enable/disable/reload all
+   re-arm correctly; the job calls `engine.onSchedule(id)` →
+   `buildScheduleContext` → graph run, honoring cooldown. Cron is injectable
+   (`CronScheduler`) for tests; invalid/missing crons are skipped+logged and
+   rejected at save (`validateForm` via `cron-validator`).
 
 2. **Smarter `{{ }}` text entry.** In the builder's text/textarea fields, render
    `{{ trigger.* }}` / `{{ var.* }}` tokens **visually distinct** from plain text

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -7,6 +7,7 @@
  * explaining types and scopes.
  */
 import { useCallback, useEffect, useState } from 'react';
+import { isValidCron } from 'cron-validator';
 import { appBasename } from '../../init';
 import apiService from '../../services/api';
 import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption } from './AutomationBuilder';
@@ -44,6 +45,12 @@ function validateForm(form: WorkflowForm): string[] {
     const shape = form.trigger.params.shape as { type?: string; vertices?: unknown[] } | undefined;
     if (!shape || (shape.type === 'polygon' && (shape.vertices?.length ?? 0) < 3)) {
       errs.push('Draw a geofence region (circle or polygon) on the map.');
+    }
+  }
+  if (form.trigger.type === 'trigger.schedule') {
+    const cron = String(form.trigger.params.cron ?? '').trim();
+    if (!cron || !isValidCron(cron, { seconds: false, alias: true, allowBlankDay: true })) {
+      errs.push('Enter a valid 5-field cron expression for the schedule (e.g. "0 * * * *").');
     }
   }
   if (form.rules.length === 0) errs.push('Add at least one rule.');

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -83,8 +83,6 @@ export const TRIGGERS: BlockDef[] = [
     ],
   },
   {
-    // NOTE: stub — the engine does NOT fire schedule triggers live yet (no cron
-    // wiring; see AUTOMATION_ENGINE_PLAN.md §11). The Test panel can dry-run it.
     type: 'trigger.schedule',
     label: 'On a schedule',
     description: 'Fires on a cron schedule (no mesh event).',

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -319,4 +319,80 @@ describe('AutomationEngineService', () => {
     expect(await engine.checkGeofences(9, 'default')).toBe(0); // still inside → no re-fire
     expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
   });
+
+  // ─── schedule (cron) ───────────────────────────────────────────────────────
+  function fakeCron() {
+    const jobs: Array<{ expr: string; cb: () => void; stopped: boolean }> = [];
+    const cron = {
+      schedule: (expr: string, cb: () => void) => {
+        const j = { expr, cb, stopped: false };
+        jobs.push(j);
+        return { stop: () => { j.stopped = true; } };
+      },
+      validate: (expr: string) => /\S/.test(expr) && expr !== 'BAD',
+    };
+    return { jobs, cron };
+  }
+  const scheduleGraph = (cron: string, cooldownSeconds?: number): AutomationGraph => ({
+    version: 1,
+    nodes: [
+      { id: 't', type: 'trigger.schedule', params: { cron, ...(cooldownSeconds ? { cooldownSeconds } : {}) } },
+      { id: 'a', type: 'action.notify', params: { body: 'tick' } },
+    ],
+    edges: [{ from: 't', to: 'a' }],
+  });
+  const engineWithCron = (deps: ActionDeps, cron: ReturnType<typeof fakeCron>['cron']) =>
+    new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock, cron });
+
+  it('schedule: arms a cron job per enabled schedule automation and onSchedule fires it', async () => {
+    const { calls, deps } = recorder();
+    const a = await createEnabled('cron-job', scheduleGraph('0 * * * *'));
+    const { jobs, cron } = fakeCron();
+    const engine = engineWithCron(deps, cron);
+    await engine.load();
+
+    expect(jobs.map((j) => j.expr)).toEqual(['0 * * * *']);
+    expect(await engine.onSchedule(a.id)).toBe(1);
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
+    // invoking the registered cron callback also fires it
+    jobs[0].cb();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(2);
+  });
+
+  it('schedule: an invalid/missing cron is not armed', async () => {
+    const { deps } = recorder();
+    await createEnabled('bad-cron', scheduleGraph('BAD'));
+    const { jobs, cron } = fakeCron();
+    const engine = engineWithCron(deps, cron);
+    await engine.load();
+    expect(jobs).toHaveLength(0);
+  });
+
+  it('schedule: reload stops the old job and re-arms', async () => {
+    const { deps } = recorder();
+    await createEnabled('cron-job', scheduleGraph('0 * * * *'));
+    const { jobs, cron } = fakeCron();
+    const engine = engineWithCron(deps, cron);
+    await engine.load();
+    await engine.load(); // simulate a reload after CRUD
+    expect(jobs).toHaveLength(2);
+    expect(jobs[0].stopped).toBe(true);  // old job cancelled
+    expect(jobs[1].stopped).toBe(false); // new job live
+  });
+
+  it('schedule: onSchedule honors the per-automation cooldown', async () => {
+    const { calls, deps } = recorder();
+    const a = await createEnabled('cron-cooldown', scheduleGraph('* * * * *', 60));
+    const { cron } = fakeCron();
+    const engine = engineWithCron(deps, cron);
+    await engine.load();
+
+    expect(await engine.onSchedule(a.id)).toBe(1); // t0
+    clock += 30_000;
+    expect(await engine.onSchedule(a.id)).toBe(0); // within cooldown
+    clock += 31_000;
+    expect(await engine.onSchedule(a.id)).toBe(1); // past cooldown
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(2);
+  });
 });

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -27,10 +27,12 @@ import {
   buildTelemetryContext,
   buildSystemContext,
   buildGeofenceContext,
+  buildScheduleContext,
   messageMatchesFilter,
   type TriggerContext,
   type SystemEvent,
 } from './triggerContext.js';
+import { scheduleCron, validateCron } from '../../utils/cronScheduler.js';
 import { haversineKm, geofenceFires, pointInShape, geofenceCenter, normalizeGeofenceParams, type GeofenceMode } from './geo.js';
 import { evaluateGraph, type EvaluatorHooks } from './graphEvaluator.js';
 import { evaluateCondition } from './conditionEvaluator.js';
@@ -51,6 +53,17 @@ interface LoadedAutomation {
   cooldownSeconds: number;
 }
 
+/** Pluggable cron backing for `trigger.schedule` — real croner in prod, a fake in tests. */
+export interface CronScheduler {
+  schedule(expression: string, callback: () => void): { stop: () => void };
+  validate(expression: string): boolean;
+}
+
+const REAL_CRON_SCHEDULER: CronScheduler = {
+  schedule: (expr, cb) => scheduleCron(expr, cb),
+  validate: validateCron,
+};
+
 export interface EngineServiceOptions {
   automationsRepo: AutomationsRepository;
   varResolver: VariableResolver;
@@ -61,6 +74,8 @@ export interface EngineServiceOptions {
   now?: () => number;
   /** Per-run action cap (loop/spam guard). Default 50. */
   maxActions?: number;
+  /** Cron backing for schedule triggers. Defaults to real croner. */
+  cron?: CronScheduler;
 }
 
 export class AutomationEngineService {
@@ -70,6 +85,7 @@ export class AutomationEngineService {
   private readonly data: NodeDataProvider;
   private readonly now: () => number;
   private readonly maxActions: number;
+  private readonly cron: CronScheduler;
 
   /** triggerType → loaded automations. */
   private index = new Map<TriggerType, LoadedAutomation[]>();
@@ -77,6 +93,8 @@ export class AutomationEngineService {
   private lastFired = new Map<string, number>();
   /** `${automationId}:${nodeNum}` → was the node inside the geofence last check. */
   private geofenceState = new Map<string, boolean>();
+  /** automationId → live cron job, for `trigger.schedule` automations. */
+  private cronJobs = new Map<string, { stop: () => void }>();
 
   constructor(opts: EngineServiceOptions) {
     this.automationsRepo = opts.automationsRepo;
@@ -85,6 +103,7 @@ export class AutomationEngineService {
     this.data = opts.data;
     this.now = opts.now ?? (() => Date.now());
     this.maxActions = opts.maxActions ?? 50;
+    this.cron = opts.cron ?? REAL_CRON_SCHEDULER;
   }
 
   /** (Re)load enabled automations and rebuild the trigger index. */
@@ -115,7 +134,49 @@ export class AutomationEngineService {
       index.get(triggerType)!.push(entry);
     }
     this.index = index;
+    this.rescheduleCron();
     logger.info(`[AutomationEngine] loaded ${rows.length} enabled automation(s)`);
+  }
+
+  /**
+   * (Re)arm cron jobs for every enabled `trigger.schedule` automation. Stops all
+   * prior jobs first, so a reload after CRUD never leaves a stale or duplicate
+   * job. An automation with a missing/invalid cron is logged and skipped.
+   */
+  private rescheduleCron(): void {
+    for (const job of this.cronJobs.values()) job.stop();
+    this.cronJobs.clear();
+    for (const a of this.index.get('trigger.schedule') ?? []) {
+      const cron = String((a.triggerNode.params as Record<string, unknown>)?.cron ?? '').trim();
+      if (!cron || !this.cron.validate(cron)) {
+        logger.warn(`[AutomationEngine] automation "${a.name}" has an invalid/missing cron ("${cron}"); not scheduled`);
+        continue;
+      }
+      const job = this.cron.schedule(cron, () => {
+        this.onSchedule(a.id).catch((e) => logger.error(`[AutomationEngine] schedule trigger error: ${e?.message}`));
+      });
+      this.cronJobs.set(a.id, job);
+    }
+  }
+
+  /** Stop all cron jobs (clean shutdown / test teardown). */
+  stop(): void {
+    for (const job of this.cronJobs.values()) job.stop();
+    this.cronJobs.clear();
+  }
+
+  /**
+   * Fire a single `trigger.schedule` automation by id (called from its cron job).
+   * Honors the per-automation cooldown. Returns 1 if it fired, else 0.
+   */
+  async onSchedule(automationId: string): Promise<number> {
+    const a = (this.index.get('trigger.schedule') ?? []).find((x) => x.id === automationId);
+    if (!a) return 0;
+    const now = this.now();
+    if (!this.cooledDown(a, now)) return 0;
+    this.lastFired.set(a.id, now);
+    await this.fireAutomation(a, buildScheduleContext(null, now), now);
+    return 1;
   }
 
   /** Number of loaded automations for a trigger type (test/introspection aid). */

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -4,6 +4,7 @@ import {
   buildNodeContext,
   buildTelemetryContext,
   buildSystemContext,
+  buildScheduleContext,
   deriveHops,
   messageMatchesFilter,
   resolveTriggerPath,
@@ -80,6 +81,13 @@ describe('other trigger contexts', () => {
     const ctx = buildSystemContext('bootup', null, null, undefined, 5);
     expect(ctx.subjectNodeNum).toBeNull();
     expect(ctx.fields.event).toBe('bootup');
+  });
+
+  it('schedule context carries timestamp, no subject node', () => {
+    const ctx = buildScheduleContext(null, 1234);
+    expect(ctx.triggerType).toBe('trigger.schedule');
+    expect(ctx.subjectNodeNum).toBeNull();
+    expect(ctx.fields.timestamp).toBe(1234);
   });
 });
 

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -154,6 +154,17 @@ export function buildSystemContext(
   };
 }
 
+/** Context for a `trigger.schedule` cron tick — no mesh payload, no subject node. */
+export function buildScheduleContext(sourceId: string | null, timestamp: number): TriggerContext {
+  return {
+    triggerType: 'trigger.schedule',
+    sourceId,
+    subjectNodeNum: null,
+    timestamp,
+    fields: { sourceId, timestamp },
+  };
+}
+
 /**
  * Tight pre-filter for `trigger.message`: cheap checks the engine runs before any
  * graph evaluation. Unset params don't constrain. Returns true on match.


### PR DESCRIPTION
First of the two documented post-#3721 follow-ups (`AUTOMATION_ENGINE_PLAN.md` §11).

## Problem
`trigger.schedule` was a catalog-only stub — the engine never fired it. Automations with a schedule trigger could be built and dry-run in the Test panel, but never ran live.

## Change
The engine now arms a **croner** job per enabled `trigger.schedule` automation inside `load()` (`rescheduleCron()`). Because `reloadAutomations()` → `load()` runs after every CRUD, create/update/enable/disable/delete/reload all re-arm correctly (old jobs stopped first — no stale or duplicate jobs). Each job calls `engine.onSchedule(id)` → `buildScheduleContext` → graph run, honoring the per-automation **cooldown**.

- New `buildScheduleContext` (no mesh payload, no subject node).
- The cron backing is **injectable** (`EngineServiceOptions.cron: CronScheduler`) — prod uses `cronScheduler.ts` (croner); tests use a fake to assert registration/cancellation without real timers.
- Invalid/missing crons are **skipped + logged**, and **rejected at save** (`validateForm` via `cron-validator`, matching the rest of the app: `{ seconds:false, alias:true, allowBlankDay:true }`).

## Tests
Arm-one-job-per-automation + `onSchedule` fires the graph (directly **and** via the registered cron callback), invalid cron not armed, reload stops the old job and re-arms, cooldown honored, and `buildScheduleContext` shape. Full suite **7513 passed, 0 failures**; tsc + build clean.

## Follow-up still open
The second §11 item — smarter `{{ }}` token entry (highlight trigger/var tokens, flag unrecognized) — is a separate upcoming PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)