### PR TITLE
feat(automations): highlight {{ }} tokens + flag typos in builder text fields (#3653)

### DIFF
--- a/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
+++ b/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
@@ -402,12 +402,10 @@ formatting). To pick up **after that PR merges**:
    (`CronScheduler`) for tests; invalid/missing crons are skipped+logged and
    rejected at save (`validateForm` via `cron-validator`).
 
-2. **Smarter `{{ }}` text entry.** In the builder's text/textarea fields, render
-   `{{ trigger.* }}` / `{{ var.* }}` tokens **visually distinct** from plain text
-   (chip/highlight), and **flag unrecognized tokens as an error** to catch typos
-   (e.g. `{{ trigger.lastestVersion }}`, or a `var.` name with no matching
-   variable). Validate against the per-trigger token registry in
-   `SubstitutionsHelp.ts` (`TRIGGER_TOKENS` + `UNIVERSAL_TOKENS`) and the known
-   variables list. Likely a small highlighting input/overlay component used by
-   the `text`/`textarea` field kinds; surface unknown-token warnings inline (and
-   optionally in `validateForm` before save).
+2. ~~**Smarter `{{ }}` text entry.**~~ **DONE** (follow-up PR). `TokenTextField`
+   wraps token-bearing `text`/`textarea` fields (flagged `tokens: true` in the
+   catalog) with a highlight backdrop — `{{ trigger.* }}`/`{{ var.* }}` tokens
+   render blue when recognized, red+wavy when not — and lists unrecognized tokens
+   inline. Validation is via `tokenHints.ts` (`validTokenSet` from
+   `TRIGGER_TOKENS`+`UNIVERSAL_TOKENS`+known vars). It is a non-blocking hint (not
+   a hard save gate) to avoid false positives.

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -10,6 +10,7 @@ import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, type BlockDef,
 import type { WorkflowForm, FormBlock, Rule } from './compile';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
 import GeofenceFieldInput from './GeofenceFieldInput';
+import TokenTextField from './TokenTextField';
 import type { GeofenceShape } from '../auto-responder/types';
 
 export interface VariableOption { name: string; type: string; }
@@ -56,17 +57,21 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
   return params;
 }
 
-function FieldInput({ field, value, onChange, variables, sources, channels }: {
-  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[];
+function FieldInput({ field, value, onChange, variables, sources, channels, triggerType }: {
+  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; triggerType: string;
 }) {
   let control;
+  const varNames = variables.map((v) => v.name);
   switch (field.kind) {
     case 'number':
       control = <input className="ae-input" type="number" value={(value ?? '') as string} placeholder={field.placeholder}
         onChange={(e) => onChange(e.target.value === '' ? '' : Number(e.target.value))} />;
       break;
     case 'textarea':
-      control = <textarea className="ae-textarea" value={(value ?? '') as string} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
+      control = field.tokens
+        ? <TokenTextField multiline value={(value ?? '') as string} placeholder={field.placeholder}
+            triggerType={triggerType} variableNames={varNames} onChange={onChange} />
+        : <textarea className="ae-textarea" value={(value ?? '') as string} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
       break;
     case 'select':
       control = (
@@ -160,7 +165,10 @@ function FieldInput({ field, value, onChange, variables, sources, channels }: {
       break;
     }
     default:
-      control = <input className="ae-input" value={(value ?? '') as string} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
+      control = field.tokens
+        ? <TokenTextField value={(value ?? '') as string} placeholder={field.placeholder}
+            triggerType={triggerType} variableNames={varNames} onChange={onChange} />
+        : <input className="ae-input" value={(value ?? '') as string} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
   }
   return (
     <div className="ae-field">
@@ -180,7 +188,7 @@ function BlockFields({ block, triggerType, variables, sources, channels, onParam
     <>
       {def.fields.map((f) => {
         const field = f.kind === 'fieldselect' ? { ...f, groups: fieldsFor(block.type, triggerType) } : f;
-        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels}
+        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} triggerType={triggerType}
           onChange={(v) => onParams({ ...block.params, [f.name]: v })} />;
       })}
     </>

--- a/src/components/automations/AutomationsPage.css
+++ b/src/components/automations/AutomationsPage.css
@@ -74,6 +74,31 @@
 .ae-textarea--code { font-family: var(--font-mono, monospace); font-size: 0.82rem; min-height: 280px; }
 .ae-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem 1rem; }
 .ae-help-text { font-size: 0.76rem; color: var(--ctp-subtext0); margin-top: 0.25rem; }
+
+/* Token-highlighting text field: a backdrop renders the chrome + highlighted
+   {{ }} tokens; a transparent input/textarea sits on top for editing. Both share
+   the .ae-input/.ae-textarea metrics so the text aligns exactly. */
+.ae-tokenfield { position: relative; }
+.ae-tokenfield-backdrop {
+  position: absolute; inset: 0; margin: 0; overflow: hidden; pointer-events: none;
+  white-space: pre; overflow-wrap: normal;
+}
+.ae-tokenfield--multiline .ae-tokenfield-backdrop { white-space: pre-wrap; overflow-wrap: break-word; word-break: break-word; }
+.ae-tokenfield-input {
+  position: relative; background: transparent; color: transparent; border-color: transparent;
+  caret-color: var(--ctp-text);
+}
+.ae-tokenfield-input::placeholder { color: var(--ctp-subtext0); }
+.ae-tokenfield:focus-within .ae-tokenfield-backdrop { border-color: var(--ctp-blue); }
+.ae-tokenfield-backdrop .ae-token-ok {
+  background: color-mix(in srgb, var(--ctp-blue) 22%, transparent);
+  color: var(--ctp-text); border-radius: 3px;
+}
+.ae-tokenfield-backdrop .ae-token-bad {
+  background: color-mix(in srgb, var(--ctp-red) 26%, transparent);
+  color: var(--ctp-text); border-radius: 3px; text-decoration: underline wavy var(--ctp-red);
+}
+.ae-token-warn { font-size: 0.76rem; color: var(--ctp-red); margin-top: 0.25rem; }
 .ae-error-list { color: var(--ctp-red); font-size: 0.85rem; margin: 0.5rem 0; padding-left: 1.1rem; }
 
 /* Builder WHEN / IF / THEN sections */

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -26,7 +26,7 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.geofence': [['event', 'enter / exit / dwell'], ['nodeNum', 'Node number'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude'], ['distanceKm', 'Distance from the region centre (km)']],
   'trigger.schedule': [],
 };
-const UNIVERSAL_TOKENS: Array<[string, string]> = [['sourceId', 'The source the event came from'], ['timestamp', 'Event time (rendered as a local date/time)']];
+export const UNIVERSAL_TOKENS: Array<[string, string]> = [['sourceId', 'The source the event came from'], ['timestamp', 'Event time (rendered as a local date/time)']];
 const TRIGGER_LABEL: Record<string, string> = {
   'trigger.message': 'Message', 'trigger.telemetry': 'Telemetry', 'trigger.nodeUpdated': 'Node updated',
   'trigger.nodeDiscovered': 'Node discovered', 'trigger.system': 'System event', 'trigger.geofence': 'Geofence', 'trigger.schedule': 'Schedule',

--- a/src/components/automations/TokenTextField.tsx
+++ b/src/components/automations/TokenTextField.tsx
@@ -1,0 +1,70 @@
+/**
+ * Text/textarea with live `{{ }}` token highlighting (#3653 follow-up).
+ *
+ * A highlight backdrop renders the same text with `{{ trigger.* }}`/`{{ var.* }}`
+ * tokens colored — blue when recognized, red+wavy when not — while a transparent
+ * textarea/input sits on top for editing. Unrecognized tokens (typos) are also
+ * listed inline below the field.
+ */
+import { useMemo, useRef } from 'react';
+import { tokenize, unknownTokens, validTokenSet } from './tokenHints';
+
+export default function TokenTextField({ value, onChange, multiline, placeholder, triggerType, variableNames }: {
+  value: string;
+  onChange: (v: string) => void;
+  multiline?: boolean;
+  placeholder?: string;
+  triggerType: string;
+  variableNames: string[];
+}) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const valid = useMemo(() => validTokenSet(triggerType, variableNames), [triggerType, variableNames]);
+  const segs = useMemo(() => tokenize(value, valid), [value, valid]);
+  const unknown = useMemo(() => unknownTokens(value, valid), [value, valid]);
+
+  const cls = multiline ? 'ae-textarea' : 'ae-input';
+  const syncScroll = (el: HTMLTextAreaElement | HTMLInputElement) => {
+    if (backdropRef.current) {
+      backdropRef.current.scrollTop = el.scrollTop;
+      backdropRef.current.scrollLeft = el.scrollLeft;
+    }
+  };
+
+  const highlighted = segs.map((s, i) =>
+    s.token
+      ? <mark key={i} className={s.known ? 'ae-token-ok' : 'ae-token-bad'}>{s.text}</mark>
+      : <span key={i}>{s.text}</span>,
+  );
+
+  return (
+    <div className={`ae-tokenfield ${multiline ? 'ae-tokenfield--multiline' : ''}`}>
+      <div ref={backdropRef} className={`${cls} ae-tokenfield-backdrop`} aria-hidden="true">
+        {highlighted}{'​'}
+      </div>
+      {multiline ? (
+        <textarea
+          className={`${cls} ae-tokenfield-input`}
+          value={value}
+          placeholder={placeholder}
+          spellCheck={false}
+          onChange={(e) => onChange(e.target.value)}
+          onScroll={(e) => syncScroll(e.currentTarget)}
+        />
+      ) : (
+        <input
+          className={`${cls} ae-tokenfield-input`}
+          value={value}
+          placeholder={placeholder}
+          spellCheck={false}
+          onChange={(e) => onChange(e.target.value)}
+          onScroll={(e) => syncScroll(e.currentTarget)}
+        />
+      )}
+      {unknown.length > 0 && (
+        <div className="ae-token-warn">
+          Unrecognized token{unknown.length > 1 ? 's' : ''}: {unknown.map((t) => `{{ ${t} }}`).join(', ')} — check for typos.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/automations/TokenTextField.tsx
+++ b/src/components/automations/TokenTextField.tsx
@@ -39,7 +39,9 @@ export default function TokenTextField({ value, onChange, multiline, placeholder
   return (
     <div className={`ae-tokenfield ${multiline ? 'ae-tokenfield--multiline' : ''}`}>
       <div ref={backdropRef} className={`${cls} ae-tokenfield-backdrop`} aria-hidden="true">
-        {highlighted}{'​'}
+        {highlighted}
+        {/* trailing zero-width space keeps a final newline's line visible in the backdrop */}
+        {'\u200b'}
       </div>
       {multiline ? (
         <textarea

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -21,6 +21,8 @@ export interface FieldDef {
   placeholder?: string;
   help?: string;
   advanced?: boolean;
+  /** This `text`/`textarea` field accepts `{{ }}` tokens → highlight + typo-check. */
+  tokens?: boolean;
 }
 
 export interface BlockDef {
@@ -220,7 +222,7 @@ export const CONDITIONS: BlockDef[] = [
     fields: [
       { name: 'field', label: 'Field', kind: 'fieldselect' },
       { name: 'op', label: 'Operator', kind: 'select', options: NUMERIC_OP_OPTIONS },
-      { name: 'value', label: 'Value', kind: 'text', placeholder: 'e.g. 20 or {{ var.threshold }}', help: 'A number, or {{ var.name }} to compare against a variable.' },
+      { name: 'value', label: 'Value', kind: 'text', tokens: true, placeholder: 'e.g. 20 or {{ var.threshold }}', help: 'A number, or {{ var.name }} to compare against a variable.' },
     ],
   },
   {
@@ -230,7 +232,7 @@ export const CONDITIONS: BlockDef[] = [
     fields: [
       { name: 'field', label: 'Field', kind: 'fieldselect' },
       { name: 'op', label: 'Operator', kind: 'select', options: STRING_OP_OPTIONS },
-      { name: 'value', label: 'Value', kind: 'text', placeholder: 'e.g. ROUTER' },
+      { name: 'value', label: 'Value', kind: 'text', tokens: true, placeholder: 'e.g. ROUTER' },
     ],
   },
   {
@@ -259,7 +261,7 @@ export const CONDITIONS: BlockDef[] = [
     fields: [
       { name: 'variable', label: 'Variable', kind: 'variable' },
       { name: 'op', label: 'Operator', kind: 'select', help: 'Leave blank to test "is set / true".', options: [{ value: '', label: 'is set / true' }, ...NUMERIC_OP_OPTIONS] },
-      { name: 'value', label: 'Value', kind: 'text', placeholder: 'optional' },
+      { name: 'value', label: 'Value', kind: 'text', tokens: true, placeholder: 'optional' },
     ],
   },
   {
@@ -287,10 +289,10 @@ export const ACTIONS: BlockDef[] = [
     label: 'Send a message',
     description: 'Send text to a channel or as a DM.',
     fields: [
-      { name: 'text', label: 'Message', kind: 'textarea', placeholder: 'Hello {{ trigger.fromId }}!', help: 'Use {{ trigger.field }} or {{ var.name }} to insert values.' },
+      { name: 'text', label: 'Message', kind: 'textarea', tokens: true, placeholder: 'Hello {{ trigger.fromId }}!', help: 'Use {{ trigger.field }} or {{ var.name }} to insert values.' },
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios to send through (MQTT sources are receive-only and excluded). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
-      { name: 'to', label: 'DM to node #', kind: 'text', placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
+      { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
       { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true },
     ],
   },
@@ -314,8 +316,8 @@ export const ACTIONS: BlockDef[] = [
     label: 'Send a notification',
     description: 'Send an external notification (Apprise).',
     fields: [
-      { name: 'title', label: 'Title', kind: 'text', placeholder: 'MeshMonitor alert' },
-      { name: 'body', label: 'Body', kind: 'textarea', placeholder: 'Node {{ trigger.fromId }} said {{ trigger.text }}' },
+      { name: 'title', label: 'Title', kind: 'text', tokens: true, placeholder: 'MeshMonitor alert' },
+      { name: 'body', label: 'Body', kind: 'textarea', tokens: true, placeholder: 'Node {{ trigger.fromId }} said {{ trigger.text }}' },
       {
         name: 'type', label: 'Severity', kind: 'select', advanced: true,
         options: [
@@ -344,7 +346,7 @@ export const ACTIONS: BlockDef[] = [
           { value: 'flag', label: 'Raise flag' }, { value: 'clear', label: 'Clear / lower flag' },
         ],
       },
-      { name: 'value', label: 'Value', kind: 'text', placeholder: 'for Set / Increment' },
+      { name: 'value', label: 'Value', kind: 'text', tokens: true, placeholder: 'for Set / Increment' },
     ],
   },
   {

--- a/src/components/automations/tokenHints.test.ts
+++ b/src/components/automations/tokenHints.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { validTokenSet, tokenize, unknownTokens } from './tokenHints';
+
+describe('validTokenSet', () => {
+  it('includes NOW, the trigger tokens, universals, and known vars', () => {
+    const set = validTokenSet('trigger.message', ['threshold']);
+    expect(set.has('NOW')).toBe(true);
+    expect(set.has('trigger.text')).toBe(true);      // message token
+    expect(set.has('trigger.timestamp')).toBe(true); // universal
+    expect(set.has('trigger.sourceId')).toBe(true);  // universal
+    expect(set.has('var.threshold')).toBe(true);
+    expect(set.has('trigger.nope')).toBe(false);
+    expect(set.has('var.missing')).toBe(false);
+  });
+});
+
+describe('unknownTokens', () => {
+  const set = validTokenSet('trigger.system', ['flag']);
+  it('flags typos and unknown var names', () => {
+    expect(unknownTokens('{{ trigger.lastestVersion }} at {{ trigger.timestamp }}', set)).toEqual(['trigger.lastestVersion']);
+    expect(unknownTokens('{{ var.flag }} {{ var.nope }}', set)).toEqual(['var.nope']);
+  });
+  it('returns nothing for all-valid text and ignores empty tokens', () => {
+    expect(unknownTokens('{{ trigger.event }} at {{ NOW }} {{  }}', set)).toEqual([]);
+    expect(unknownTokens('plain text', set)).toEqual([]);
+  });
+  it('de-dups repeated unknown tokens', () => {
+    expect(unknownTokens('{{ var.x }} {{ var.x }}', set)).toEqual(['var.x']);
+  });
+});
+
+describe('tokenize', () => {
+  const set = validTokenSet('trigger.message', []);
+  it('splits text into plain + token segments with known flags', () => {
+    const segs = tokenize('hi {{ trigger.text }} / {{ trigger.bad }}', set);
+    expect(segs.map((s) => s.token)).toEqual([false, true, false, true]);
+    expect(segs[1].known).toBe(true);   // trigger.text
+    expect(segs[3].known).toBe(false);  // trigger.bad
+    expect(segs.map((s) => s.text).join('')).toBe('hi {{ trigger.text }} / {{ trigger.bad }}');
+  });
+});

--- a/src/components/automations/tokenHints.ts
+++ b/src/components/automations/tokenHints.ts
@@ -1,0 +1,50 @@
+/**
+ * `{{ }}` token hinting for builder text fields (#3653 follow-up).
+ *
+ * Builds the set of valid interpolation paths for the current trigger + the
+ * known variables, so the editor can highlight `{{ trigger.* }}` / `{{ var.* }}`
+ * tokens and flag unrecognized ones (typos) inline.
+ */
+import { TRIGGER_TOKENS, UNIVERSAL_TOKENS } from './SubstitutionsHelp';
+
+// Mirrors the engine's interpolate TOKEN regex.
+const TOKEN_RE = /\{\{\s*([^}]+?)\s*\}\}/g;
+
+/** The set of valid token paths for a trigger type + the defined variables. */
+export function validTokenSet(triggerType: string, variableNames: string[]): Set<string> {
+  const set = new Set<string>(['NOW']);
+  for (const [k] of TRIGGER_TOKENS[triggerType] ?? []) set.add(`trigger.${k}`);
+  for (const [k] of UNIVERSAL_TOKENS) set.add(`trigger.${k}`);
+  for (const name of variableNames) set.add(`var.${name}`);
+  return set;
+}
+
+export interface TokenSegment { text: string; token: boolean; known: boolean }
+
+/**
+ * Split text into plain + token segments for highlighting. An empty token
+ * (`{{ }}`) is treated as plain text (it renders blank and isn't a typo).
+ */
+export function tokenize(text: string, valid: Set<string>): TokenSegment[] {
+  const segs: TokenSegment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(TOKEN_RE)) {
+    const start = m.index ?? 0;
+    if (start > last) segs.push({ text: text.slice(last, start), token: false, known: true });
+    const path = m[1].trim();
+    segs.push({ text: m[0], token: path.length > 0, known: path.length === 0 || valid.has(path) });
+    last = start + m[0].length;
+  }
+  if (last < text.length) segs.push({ text: text.slice(last), token: false, known: true });
+  return segs;
+}
+
+/** Distinct unrecognized token paths in the text (for an inline warning). */
+export function unknownTokens(text: string, valid: Set<string>): string[] {
+  const out = new Set<string>();
+  for (const m of text.matchAll(TOKEN_RE)) {
+    const path = m[1].trim();
+    if (path.length > 0 && !valid.has(path)) out.add(path);
+  }
+  return [...out];
+}


### PR DESCRIPTION
Second of the two documented post-#3721 follow-ups (`AUTOMATION_ENGINE_PLAN.md` §11).

## Why
`{{ }}` substitution tokens were indistinguishable from plain text in the builder, and a typo (e.g. `{{ trigger.lastestVersion }}`) silently rendered blank with no warning — exactly the confusion that surfaced while testing the Startup automation.

## Change
Token-bearing `text`/`textarea` fields (flagged `tokens: true` in the catalog: message text + DM-to, notify title + body, condition values, setVar value) now render with **`TokenTextField`** — a highlight backdrop layered under a transparent input:

- `{{ trigger.* }}` / `{{ var.* }}` / `{{ NOW }}` tokens are **blue** when recognized, **red + wavy underline** when not.
- Unrecognized tokens are also listed **inline below the field** ("Unrecognized token(s): … — check for typos").

Recognition uses `tokenHints.ts` (`validTokenSet`) built from the exported `TRIGGER_TOKENS` + `UNIVERSAL_TOKENS` for the current trigger plus the known variable names. It's a **non-blocking hint** (not a hard save gate) so a token the static registry doesn't enumerate can't block a legitimate save.

## Tests
`tokenHints.test.ts` covers `validTokenSet` (trigger tokens + universals + vars + `NOW`), `unknownTokens` (typo + unknown-var detection, empty-token + dedup handling), and `tokenize` (segment/known flags). Full suite **7518 passed, 0 failures**; tsc + build clean.

> The highlight overlay is a layered backdrop/transparent-input technique — worth a quick visual sanity check in the dev container (alignment/scroll-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)