### PR TITLE
fix(meshcore): unified radio-op lock so raw-frame commands can't false-reject each other (#3725)

### DIFF
--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -503,4 +503,57 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
     // sends afterwards — the two never share the ack channel.
     expect(callLog).toEqual(['regions:send', 'regions:reply', 'discover_path:send', 'discover_path:ack']);
   });
+
+  it('serializes set_device_time against request_regions under the unified lock (#3725)', async () => {
+    // set_device_time uses the same shared Ok/Err ack window as discover_*, and
+    // sends via c.sendCommandSetDeviceTime rather than sendToRadioFrame. The
+    // unified lock must keep it from overlapping request_regions' window.
+    const { backend, conn } = await connectedBackend();
+    const callLog: string[] = [];
+
+    (conn as any).sendToRadioFrame = (frame: Uint8Array) => {
+      conn.sentFrames.push(frame);
+      if (frame[0] === 57) { // request_regions
+        callLog.push('regions:send');
+        setImmediate(() => {
+          conn.emit(ResponseCodes.Sent);
+          callLog.push('regions:reply');
+          conn.emit(PushCodes.BinaryResponse, {
+            reserved: 0,
+            tag: 0x1,
+            responseData: Uint8Array.from([1, 0, 0, 0, ...Buffer.from('hesse', 'ascii'), 0]),
+          });
+        });
+        return;
+      }
+      setImmediate(() => conn.emit(ResponseCodes.Ok));
+    };
+    (conn as any).sendCommandSetDeviceTime = (_epoch: number) => {
+      callLog.push('settime:send');
+      setImmediate(() => {
+        callLog.push('settime:ack');
+        conn.emit(ResponseCodes.Ok);
+      });
+      return Promise.resolve();
+    };
+
+    const [regionsRes, timeRes] = await Promise.all([
+      backend.sendCommand('request_regions', { public_key: 'aa'.repeat(32) }),
+      backend.sendCommand('set_device_time', { epoch: 1_700_000_000 }),
+    ]);
+
+    expect(regionsRes.success).toBe(true);
+    expect(regionsRes.data.regions).toEqual(['hesse']);
+    expect(timeRes.success).toBe(true);
+
+    // The two never overlapped: each op's ':send' is immediately followed by its
+    // own ':ack'/':reply'. Lock-acquisition order is microtask-dependent here
+    // (set_device_time has no await before the lock), so assert pairing rather
+    // than absolute order.
+    expect(callLog).toHaveLength(4);
+    const op = (s: string) => s.split(':')[0];
+    expect(op(callLog[0])).toBe(op(callLog[1]));
+    expect(op(callLog[2])).toBe(op(callLog[3]));
+    expect(op(callLog[0])).not.toBe(op(callLog[2]));
+  });
 });

--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -318,9 +318,9 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
   it('serializes overlapping 0x8C consumers so a concurrent telemetry reply is not stolen by request_regions (#3667)', async () => {
     // request_regions (raw frame, tag-blind first-match) and request_telemetry
     // (library sendBinaryRequest) both ride PUSH_CODE_BINARY_RESPONSE (0x8C).
-    // runExclusiveBinaryResponse must keep them from overlapping on this
-    // connection — otherwise the regions listener consumes the telemetry reply
-    // and parses CayenneLPP bytes as a region list.
+    // runExclusiveRadioOp must keep them from overlapping on this connection —
+    // otherwise the regions listener consumes the telemetry reply and parses
+    // CayenneLPP bytes as a region list.
     const { backend, conn } = await connectedBackend();
     const callLog: string[] = [];
 
@@ -423,5 +423,84 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
     // Order proves the chain advanced past the rejection: regions sent (and held
     // the lock) first, and telemetry only sent after regions' timeout released it.
     expect(callLog).toEqual(['regions:send', 'telemetry:send', 'telemetry:reply']);
+  });
+
+  it('request_regions ignores a foreign Err that arrives after its Sent ack (#3725)', async () => {
+    // The Err channel is shared and untagged, and unlocked library commands
+    // (e.g. send_message) can emit on it. Once request_regions has its Sent ack,
+    // a later Err belongs to a different command and must NOT reject the in-flight
+    // BinaryResponse wait. Without the !sentReceived gate this rejects instead.
+    const { backend, conn } = await connectedBackend();
+
+    (conn as any).sendToRadioFrame = (frame: Uint8Array) => {
+      conn.sentFrames.push(frame);
+      if (frame[0] === 57) {
+        setImmediate(() => {
+          conn.emit(ResponseCodes.Sent);            // our send was accepted
+          conn.emit(ResponseCodes.Err);             // a FOREIGN command fails on the shared channel
+          conn.emit(PushCodes.BinaryResponse, {     // our real reply still arrives
+            reserved: 0,
+            tag: 0x1,
+            responseData: Uint8Array.from([3, 0, 0, 0, ...Buffer.from('bavaria', 'ascii'), 0]),
+          });
+        });
+        return;
+      }
+      setImmediate(() => conn.emit(ResponseCodes.Ok));
+    };
+
+    const res = await backend.sendCommand('request_regions', { public_key: 'aa'.repeat(32) });
+    expect(res.success).toBe(true);
+    expect(res.data.clock).toBe(3);
+    expect(res.data.regions).toEqual(['bavaria']);
+  });
+
+  it('serializes a command-ack op (discover_path) against request_regions under the unified lock (#3725)', async () => {
+    // discover_path waits on the shared Sent/Err ack; request_regions holds the
+    // lock through its multi-second BinaryResponse wait. The unified lock must
+    // keep discover_path from sending (and registering its Sent/Err listeners)
+    // until regions completes — otherwise regions' own onSent could grab
+    // discover_path's Sent, or vice versa.
+    const { backend, conn } = await connectedBackend();
+    const callLog: string[] = [];
+
+    (conn as any).sendToRadioFrame = (frame: Uint8Array) => {
+      conn.sentFrames.push(frame);
+      if (frame[0] === 57) { // request_regions
+        callLog.push('regions:send');
+        setImmediate(() => {
+          conn.emit(ResponseCodes.Sent);
+          callLog.push('regions:reply');
+          conn.emit(PushCodes.BinaryResponse, {
+            reserved: 0,
+            tag: 0x1,
+            responseData: Uint8Array.from([1, 0, 0, 0, ...Buffer.from('thuringia', 'ascii'), 0]),
+          });
+        });
+        return;
+      }
+      if (frame[0] === 52) { // discover_path
+        callLog.push('discover_path:send');
+        setImmediate(() => {
+          callLog.push('discover_path:ack');
+          conn.emit(ResponseCodes.Sent);
+        });
+        return;
+      }
+      setImmediate(() => conn.emit(ResponseCodes.Ok));
+    };
+
+    const [regionsRes, pathRes] = await Promise.all([
+      backend.sendCommand('request_regions', { public_key: 'aa'.repeat(32) }),
+      backend.sendCommand('discover_path', { public_key: 'cc'.repeat(32) }),
+    ]);
+
+    expect(regionsRes.success).toBe(true);
+    expect(regionsRes.data.regions).toEqual(['thuringia']);
+    expect(pathRes.success).toBe(true);
+
+    // regions (issued first) holds the lock through its reply; discover_path only
+    // sends afterwards — the two never share the ack channel.
+    expect(callLog).toEqual(['regions:send', 'regions:reply', 'discover_path:send', 'discover_path:ack']);
   });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -828,33 +828,51 @@ export class MeshCoreNativeBackend extends EventEmitter {
   }
 
   /**
-   * Serializes operations that await the shared PUSH_CODE_BINARY_RESPONSE
-   * (0x8C) push on THIS connection. That push carries only a 4-byte correlation
-   * `tag` and no responder pubkey. Our raw-frame `request_regions` can't obtain
-   * a tag — `sendToRadioFrame` fires the `Sent` ack with no `expectedAckCrc` —
-   * so it falls back to accepting the *first* 0x8C reply it sees. A
-   * `request_telemetry` binary request rides the same 0x8C push, so if the two
-   * overlap they race for that first reply and mis-attribute each other's
-   * payload (a telemetry CayenneLPP body parsed as a regions list, or vice
-   * versa). Chaining every 0x8C consumer on a single per-instance promise
-   * guarantees exactly one is listening at a time.
+   * Serializes "radio operations" that listen on UNCORRELATED device channels
+   * on THIS connection — i.e. raw-frame commands whose only completion signal is
+   * the shared, tag-less `Ok` / `Sent` / `Err` ack (discover_path, discover_nodes,
+   * request_regions, set_device_time), and/or the shared `PUSH_CODE_BINARY_RESPONSE`
+   * (0x8C) push (request_regions, request_telemetry). None of these carry a
+   * correlation tag we can match on (`sendToRadioFrame` fires `Sent` with no
+   * `expectedAckCrc`, and the 0x8C push carries only a tag we can't obtain), so
+   * each handler grabs the *first* event it sees on its channel. If two such ops
+   * overlap, one consumes the other's ack/reply — a stray `Err` false-rejects a
+   * discovery, or a telemetry CayenneLPP body gets parsed as a region list.
+   * Chaining them on a single per-instance promise guarantees exactly one is
+   * listening at a time (#3722, #3725).
+   *
+   * This is a unified lock (issue #3725, option 2): one chain covers both the
+   * command-ack window and the 0x8C reply window so there is a single mental
+   * model. The tradeoff is that these admin/discovery/telemetry ops serialize
+   * against each other on a connection; that is acceptable since they are
+   * infrequent and short (the only long holder is request_regions' BinaryResponse
+   * wait, which it must hold anyway to keep request_telemetry from stealing its
+   * reply).
    *
    * The chain is an instance field, so it is inherently per-source: each source
    * owns its own MeshCoreNativeBackend (and physical connection), so this never
-   * serializes across sources — only same-connection 0x8C ops wait on each
-   * other. The lock is held until the operation's own listeners tear down
-   * (bounded by each op's internal timeout), so it always releases.
+   * serializes across sources — only same-connection ops wait on each other. The
+   * lock is held until the operation's own listeners tear down (bounded by each
+   * op's internal timeout, or sendCommand's outer withTimeout), so it always
+   * releases.
+   *
+   * NOTE: this does not lock *library* commands (e.g. send_message via
+   * sendTextMessage), which can still emit an `Err` on the shared channel. The
+   * fragile handlers above guard against that where they can — request_regions
+   * ignores `Err` once `Sent` has arrived, so its multi-second reply wait is not
+   * exposed to a foreign `Err`; the discover_nodes, discover_path and
+   * set_device_time ack windows are sub-millisecond.
    */
-  private binaryResponseChain: Promise<unknown> = Promise.resolve();
+  private radioOpChain: Promise<unknown> = Promise.resolve();
 
-  private runExclusiveBinaryResponse<T>(fn: () => Promise<T>): Promise<T> {
+  private runExclusiveRadioOp<T>(fn: () => Promise<T>): Promise<T> {
     // Run after whatever is already queued, regardless of how it settled
     // (using `fn` for both handlers means a prior rejection still releases us).
-    const run = this.binaryResponseChain.then(fn, fn);
+    const run = this.radioOpChain.then(fn, fn);
     // Advance the chain to this op's completion. Swallow settlement here so the
     // chain never carries an unhandled rejection — the caller still receives
     // `run` (and its rejection) directly.
-    this.binaryResponseChain = run.then(() => {}, () => {});
+    this.radioOpChain = run.then(() => {}, () => {});
     return run;
   }
 
@@ -919,7 +937,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
         frame[0] = 52;
         frame[1] = 0x00;
         frame.set(publicKey, 2);
-        await new Promise<void>((resolve, reject) => {
+        // Serialize the Sent/Err command-ack window against other radio ops on
+        // this connection — see runExclusiveRadioOp.
+        await this.runExclusiveRadioOp(() => new Promise<void>((resolve, reject) => {
           const onSent = () => {
             c.off(this.constants!.ResponseCodes.Sent, onSent);
             c.off(this.constants!.ResponseCodes.Err, onErr);
@@ -933,7 +953,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
           c.once(this.constants!.ResponseCodes.Sent, onSent);
           c.once(this.constants!.ResponseCodes.Err, onErr);
           c.sendToRadioFrame(frame);
-        });
+        }));
         return { ok: true };
       }
 
@@ -949,7 +969,6 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // Responses arrive asynchronously as 0x8E pushes (see wirePushEvents).
         const filter = Number(params.filter) & 0xff;
         const tag = (Number(params.tag) >>> 0) || 0;
-        this.pendingDiscoverTag = tag;
         const frame = new Uint8Array(2 + 1 + 4);
         frame[0] = 55; // CMD_SEND_CONTROL_DATA
         frame[1] = 0x80; // CTL_TYPE_NODE_DISCOVER_REQ, prefix_only = false
@@ -959,7 +978,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
         frame[5] = (tag >>> 16) & 0xff;
         frame[6] = (tag >>> 24) & 0xff;
         // The firmware acks CMD_SEND_CONTROL_DATA with an OK frame (not Sent).
-        await new Promise<void>((resolve, reject) => {
+        // Serialize the Ok/Err command-ack window against other radio ops on
+        // this connection — see runExclusiveRadioOp.
+        await this.runExclusiveRadioOp(() => new Promise<void>((resolve, reject) => {
+          // Set the pending tag inside the lock, right before sending, so a
+          // discovery queued behind a running one can't clobber its tag while
+          // the running one's 0x8E responses are still arriving.
+          this.pendingDiscoverTag = tag;
           const onOk = () => {
             c.off(this.constants!.ResponseCodes.Ok, onOk);
             c.off(this.constants!.ResponseCodes.Err, onErr);
@@ -973,7 +998,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
           c.once(this.constants!.ResponseCodes.Ok, onOk);
           c.once(this.constants!.ResponseCodes.Err, onErr);
           c.sendToRadioFrame(frame);
-        });
+        }));
         return { ok: true };
       }
 
@@ -998,9 +1023,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
         frame[33] = 0x01; // ANON_REQ_TYPE_REGIONS
         frame[34] = 0x00; // reply_path_len = 0
 
-        // Serialize against other 0x8C consumers (e.g. request_telemetry) on
-        // this connection — see runExclusiveBinaryResponse.
-        const responseData: Uint8Array = await this.runExclusiveBinaryResponse(() => new Promise<Uint8Array>((resolve, reject) => {
+        // Serialize the Sent/Err ack AND the 0x8C reply window against other
+        // radio ops on this connection — see runExclusiveRadioOp.
+        const responseData: Uint8Array = await this.runExclusiveRadioOp(() => new Promise<Uint8Array>((resolve, reject) => {
           let sentReceived = false;
           let tag: number | null = null;
           let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
@@ -1025,7 +1050,16 @@ export class MeshCoreNativeBackend extends EventEmitter {
             cleanup();
             resolve((r?.responseData ?? new Uint8Array()) as Uint8Array);
           };
-          const onErr = () => { cleanup(); reject(new Error('Device rejected regions request')); };
+          const onErr = () => {
+            // An Err pertains to OUR send only until the device acks it with
+            // Sent. Once Sent has arrived, any Err on this shared, tag-less
+            // channel belongs to a different command (incl. unlocked library
+            // commands like send_message) — ignore it so a foreign failure can't
+            // false-reject our multi-second BinaryResponse wait (#3725).
+            if (sentReceived) return;
+            cleanup();
+            reject(new Error('Device rejected regions request'));
+          };
           function cleanup() {
             if (timer) { clearTimeout(timer); timer = null; }
             c.off(K.ResponseCodes.Sent, onSent);
@@ -1388,11 +1422,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Telemetry target not found');
         const reqType = K.BinaryRequestTypes.GetTelemetryData;
-        // Serialize against other 0x8C consumers (e.g. request_regions) on this
-        // connection — see runExclusiveBinaryResponse. The library's own
+        // Serialize the 0x8C reply window against other radio ops on this
+        // connection — see runExclusiveRadioOp. The library's own
         // sendBinaryRequest tag-matches its reply, but our raw-frame regions
         // request can't, so the two must not overlap.
-        const responseData: Uint8Array = await this.runExclusiveBinaryResponse(
+        const responseData: Uint8Array = await this.runExclusiveRadioOp(
           () => c.sendBinaryRequest(publicKey, [reqType]),
         );
         const mod = await loadMeshCoreJs();
@@ -1472,8 +1506,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // send failure propagates via `.catch(reject)`; if the firmware never
         // answers at all, the outer `withTimeout` wrapper in sendCommand() is
         // the only safety net (surfacing a generic timeout). Same structure as
-        // discover_nodes / discover_path.
-        await new Promise<void>((resolve, reject) => {
+        // discover_nodes / discover_path — serialize the Ok/Err command-ack
+        // window against other radio ops on this connection (see
+        // runExclusiveRadioOp) so a concurrent command's Err can't false-reject.
+        await this.runExclusiveRadioOp(() => new Promise<void>((resolve, reject) => {
           const onOk = () => {
             c.off(this.constants!.ResponseCodes.Ok, onOk);
             c.off(this.constants!.ResponseCodes.Err, onErr);
@@ -1487,7 +1523,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
           c.once(this.constants!.ResponseCodes.Ok, onOk);
           c.once(this.constants!.ResponseCodes.Err, onErr);
           c.sendCommandSetDeviceTime(epoch).catch(reject);
-        });
+        }));
         return { ok: true };
       }
 


### PR DESCRIPTION
Closes #3725.

## Problem

Four native-backend handlers send a raw frame via `sendToRadioFrame` and then `once()`-race the device's shared, **untagged** `Ok` / `Sent` / `Err` ack:

| Handler | Ack awaited |
|---------|-------------|
| `discover_path` | `Sent` vs `Err` |
| `discover_nodes` | `Ok` vs `Err` |
| `request_regions` | `Sent` (then `BinaryResponse`) vs `Err` |
| `set_device_time` | `Ok` vs `Err` |

Because the `Err` channel carries no correlation tag, a concurrent command's `Err` can fire the wrong handler's `once(Err)` and **false-reject an unrelated command**. This is the command-ack counterpart to the `0x8C` reply-theft race fixed in #3722.

## Fix — unified lock (issue #3725, option 2)

Generalize the per-instance `0x8C` serializer (`runExclusiveBinaryResponse`) into a single **`runExclusiveRadioOp`** that covers **both** the command-ack window (`Ok`/`Sent`/`Err`) and the `0x8C` reply window, and wrap all five fragile handlers (the four above + `request_telemetry`) in it. One chain, one mental model.

- **Per-source by construction:** the lock is an instance field, and each source owns its own backend + connection, so concurrent sources never block each other — only same-connection radio ops serialize.
- **Latency:** the only long holder is `request_regions`' `BinaryResponse` wait, which it must hold anyway to keep `request_telemetry` from stealing its reply. The `discover_*`/`set_device_time` windows are sub-millisecond.
- **Residual (documented):** library commands (e.g. `send_message` via `sendTextMessage`) aren't locked and can still emit `Err` on the shared channel. So `request_regions` now **ignores `Err` once its `Sent` ack has arrived** — its multi-second reply wait is no longer exposed to a foreign `Err` (this was the bot's exact #3722-review scenario). The brief `discover_*`/`set_device_time` ack windows are left as-is.
- **Bonus:** `discover_nodes`' `pendingDiscoverTag` is now set inside the lock, just before send, so a queued discovery can't clobber a running one's tag while its `0x8E` responses are still arriving.

## Tests

- `request_regions` ignores a post-`Sent` foreign `Err` and still resolves with its region list (fails without the gate).
- A command-ack op (`discover_path`) serializes against `request_regions` under the unified lock — asserted via call-log ordering (no overlap on the ack channel).

486 MeshCore backend/manager tests pass (`success=true`); `tsc` clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)