### PR TITLE
fix(auth): hide node identity from unauthenticated users in header and poll API

### DIFF
--- a/src/components/AppHeader/AppHeader.nodeAddress.test.tsx
+++ b/src/components/AppHeader/AppHeader.nodeAddress.test.tsx
@@ -8,6 +8,17 @@ import type { AuthStatus } from '../../contexts/AuthContext';
 
 // react-i18next is globally mocked in src/test/setup.ts (t(key) => key).
 
+// UserMenu calls useAuth() — provide a minimal mock so tests that render the
+// authenticated header state (authStatus.authenticated = true) don't require
+// a full AuthProvider tree.
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authStatus: { authenticated: true, user: { username: 'admin' } },
+    logout: vi.fn(),
+    hasPermission: () => false,
+  }),
+}));
+
 function baseProps(overrides: Partial<React.ComponentProps<typeof AppHeader>> = {}) {
   const props: React.ComponentProps<typeof AppHeader> = {
     baseUrl: '',
@@ -45,8 +56,30 @@ describe('AppHeader — node address never leaks the loading placeholder (#3611)
     expect(statusArea?.textContent ?? '').not.toContain('Loading...');
   });
 
-  it('renders the per-source address when it has been resolved', () => {
-    render(<AppHeader {...baseProps({ nodeAddress: '10.20.30.40:4403' })} />);
+  it('renders the per-source address for authenticated users', () => {
+    render(<AppHeader {...baseProps({
+      nodeAddress: '10.20.30.40:4403',
+      authStatus: { authenticated: true } as AuthStatus,
+    })} />);
     expect(screen.getByText('10.20.30.40:4403')).toBeInTheDocument();
+  });
+});
+
+describe('AppHeader — node identity hidden from unauthenticated users (#3729)', () => {
+  it('does not show node-info div to unauthenticated users', () => {
+    const { container } = render(<AppHeader {...baseProps({
+      nodeAddress: '10.20.30.40:4403',
+      deviceInfo: { localNodeInfo: { nodeId: '!aabbccdd', longName: 'Test Node', shortName: 'TN' } },
+      authStatus: { authenticated: false } as AuthStatus,
+    })} />);
+    expect(container.querySelector('.node-info')).toBeNull();
+  });
+
+  it('shows node identity to authenticated users', () => {
+    render(<AppHeader {...baseProps({
+      deviceInfo: { localNodeInfo: { nodeId: '!aabbccdd', longName: 'Test Node', shortName: 'TN' } },
+      authStatus: { authenticated: true } as AuthStatus,
+    })} />);
+    expect(screen.getByText(/Test Node/)).toBeInTheDocument();
   });
 });

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -80,14 +80,14 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 
   const renderNodeInfo = () => {
     const localNode = currentNodeId ? nodes.find(n => n.user?.id === currentNodeId) : null;
-    const isClickable = authStatus?.authenticated && onNodeClick;
+    const isClickable = !!onNodeClick;
 
     if (!localNode && deviceInfo?.localNodeInfo) {
       const { nodeId, longName, shortName } = deviceInfo.localNodeInfo;
       return (
         <span
           className={`node-address${isClickable ? ' clickable' : ''}`}
-          title={authStatus?.authenticated ? t('header.clickForNodeInfo') : undefined}
+          title={isClickable ? t('header.clickForNodeInfo') : undefined}
           style={{ cursor: isClickable ? 'pointer' : 'default' }}
           onClick={isClickable ? onNodeClick : undefined}
         >
@@ -100,7 +100,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       return (
         <span
           className={`node-address${isClickable ? ' clickable' : ''}`}
-          title={authStatus?.authenticated ? t('header.clickForNodeInfo') : undefined}
+          title={isClickable ? t('header.clickForNodeInfo') : undefined}
           style={{ cursor: isClickable ? 'pointer' : 'default' }}
           onClick={isClickable ? onNodeClick : undefined}
         >
@@ -131,7 +131,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             <span className="header-source-name">{sourceName}</span>
           )}
         </div>
-        {!mqttReadOnly && <div className="node-info">{renderNodeInfo()}</div>}
+        {!mqttReadOnly && authStatus?.authenticated && <div className="node-info">{renderNodeInfo()}</div>}
       </div>
       <div className="header-right">
         <div className="connection-status-container">

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3183,8 +3183,8 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
         meshtasticUseTls: false,
         meshtasticSourceType: conn.sourceType,
         baseUrl: BASE_URL,
-        deviceMetadata: deviceMetadata,
-        localNodeInfo: pollLocalNodeInfo,
+        // Only expose node identity and device metadata to authenticated users
+        ...(req.session.userId ? { deviceMetadata, localNodeInfo: pollLocalNodeInfo } : {}),
       };
     } catch (error) {
       logger.error('Error in config section of poll:', error);


### PR DESCRIPTION
## Summary

Fixes #3729 — the connected node's full name, short name, node ID, and device metadata were visible to unauthenticated (anonymous) users.

**Root cause:** `/api/poll` uses `optionalAuth()` middleware and was unconditionally including `localNodeInfo` and `deviceMetadata` in every response, regardless of auth state. `AppHeader` rendered this info without checking whether the visitor was logged in.

**Changes:**

- **`src/server/server.ts`** — gate `localNodeInfo` and `deviceMetadata` in the poll response on `req.session.userId`; unauthenticated callers receive neither field
- **`src/components/AppHeader/AppHeader.tsx`** — gate the entire `node-info` header slot on `authStatus?.authenticated`; unauthenticated users see neither node name/ID nor node address. Simplified `isClickable` inside `renderNodeInfo` now that auth is checked at the render site.
- **`src/components/AppHeader/AppHeader.nodeAddress.test.tsx`** — updated the "renders address" test to use an authenticated session; added `vi.mock` for `AuthContext` so `UserMenu` doesn't require a full provider tree; added two new explicit assertions: unauthenticated → no `node-info` div, authenticated → node name visible.

## Test plan

- [x] `vitest run src/components/AppHeader/` — 5/5 pass
- [x] `tsc --noEmit` — no type errors
- [ ] CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2AmHGNidnkXTikEDtpPtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2AmHGNidnkXTikEDtpPtn)_