### PR TITLE
fix(meshcore): resolve author full public key for room server messages

### DIFF
--- a/src/server/meshcoreManager.rooms.test.ts
+++ b/src/server/meshcoreManager.rooms.test.ts
@@ -89,7 +89,10 @@ describe('MeshCoreManager room server support', () => {
       const msg = emittedMessages[0];
       expect(msg.messageType).toBe('room_post');
       expect(msg.toPublicKey).toBe(roomPubkey);
-      expect(msg.fromPublicKey).toBe(authorPubkey.substring(0, 8));
+      // When the author contact is known, fromPublicKey resolves to the FULL
+      // public key (not the wire prefix) so nameForKey() can match it on the
+      // frontend — mirrors toPublicKey above (issue #3732).
+      expect(msg.fromPublicKey).toBe(authorPubkey);
       expect(msg.fromName).toBe('Alice');
       expect(msg.text).toBe('Hello from the room!');
       expect(msg.timestamp).toBe(1700000000000);

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1035,11 +1035,12 @@ class MeshCoreManager extends EventEmitter {
       const roomContact = this.resolveContactByPrefix(roomPubkeyPrefix);
       const roomFullKey = roomContact?.publicKey ?? roomPubkeyPrefix;
       const authorContact = this.resolveContactByPrefix(authorPrefixHex);
+      const authorFullKey = authorContact?.publicKey ?? authorPrefixHex;
       const authorName = authorContact?.advName ?? authorContact?.name ?? undefined;
 
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        fromPublicKey: authorPrefixHex,
+        fromPublicKey: authorFullKey,
         fromName: authorName,
         toPublicKey: roomFullKey,
         text: data.text,


### PR DESCRIPTION
## Summary

Fixes #3732 — room server messages showed a truncated hex string instead of the sender's name.

**Root cause:** The `room_message` event handler in `meshcoreManager.ts` was storing `author_pubkey_prefix` (a short prefix) directly as `fromPublicKey`, while the room itself was correctly resolved to its full public key via `resolveContactByPrefix()`. Since `nameForKey()` in the frontend does an exact-match lookup, it never matched the prefix and fell back to displaying `fromPublicKey.substring(0, 8)…`.

**Fix:** Mirror the existing `roomFullKey` resolution pattern for the author:

```typescript
// Before
fromPublicKey: authorPrefixHex,

// After
const authorFullKey = authorContact?.publicKey ?? authorPrefixHex;
fromPublicKey: authorFullKey,
```

When the contact is in the contacts map at ingest time, the full public key is stored, allowing `nameForKey()` to resolve the sender name on the frontend. If the contact isn't known yet, falls back to the prefix (same behaviour as before).

## Test plan

- [ ] Send a message from a companion to a room server
- [ ] Open the room from another companion — sender name should display correctly instead of a hex string
- [ ] CI suite

🤖 Generated with [Claude Code](https://claude.ai/code/session_018nJjqaZZjhXFtj4JcZSHCS)

---
_Generated by [Claude Code](https://claude.ai/code/session_018nJjqaZZjhXFtj4JcZSHCS)_