### PR TITLE
fix(unified): append-only message feed so windowing can't evict a seen message (#3719)

### DIFF
--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -28,6 +28,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { appBasename } from '../init';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
+import { foldUnifiedMessagePages } from '../utils/unifiedMessageAccumulator';
 import LinkPreview from '../components/LinkPreview';
 import '../styles/unified.css';
 
@@ -283,28 +284,23 @@ export default function UnifiedMessagesPage() {
     refetchOnMount: true,
   });
 
-  // ── Flatten + dedup pages by dedupKey ─────────────────────────────────
+  // ── Accumulate pages into an append-only feed ─────────────────────────
+  // The server feed is a capped newest-N window; rendering straight off the
+  // latest poll evicts a message once newer traffic pushes it past the window
+  // (#3719/#3720). Fold every poll's pages into a persistent map keyed by
+  // dedupKey so a message that has been shown stays shown regardless of how the
+  // window shifts. Upserts prefer the newest (most-complete) copy; sort is by
+  // createdAt (server DB arrival) so device-clock skew can't reorder (#3122).
+  const accumulatorRef = useRef<Map<string, UnifiedMessage>>(new Map());
+  const accChannelRef = useRef<string>(selectedChannel);
   const allMessages = useMemo<UnifiedMessage[]>(() => {
-    if (!data?.pages) return [];
-    const seen = new Set<string>();
-    const out: UnifiedMessage[] = [];
-    for (const page of data.pages) {
-      for (const m of page) {
-        if (seen.has(m.dedupKey)) continue;
-        seen.add(m.dedupKey);
-        out.push(m);
-      }
+    // Reset synchronously when the channel changes so feeds never blend.
+    if (accChannelRef.current !== selectedChannel) {
+      accChannelRef.current = selectedChannel;
+      accumulatorRef.current = new Map();
     }
-    // Sort ascending (oldest → newest) so the chat-style layout pins the
-    // newest message to the bottom of the scroll container. Polling can bring
-    // in new entries on any page; re-sort defensively so the feed is always
-    // monotonic regardless of how TanStack merged the pages.
-    // Sort by createdAt (server DB arrival) instead of device timestamp so
-    // future-skewed device clocks can't make old messages display as "newest"
-    // and pin themselves at the bottom of the chat window (#3122).
-    out.sort((a, b) => a.createdAt - b.createdAt);
-    return out;
-  }, [data?.pages]);
+    return foldUnifiedMessagePages(accumulatorRef.current, data?.pages);
+  }, [data?.pages, selectedChannel]);
 
   // ── All distinct sources heard across the loaded set ──────────────────
   const sourcesInView = useMemo(() => {

--- a/src/utils/unifiedMessageAccumulator.test.ts
+++ b/src/utils/unifiedMessageAccumulator.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  foldUnifiedMessagePages,
+  DEFAULT_ACCUMULATOR_CAP,
+  type AccumulableMessage,
+} from './unifiedMessageAccumulator';
+
+type Msg = AccumulableMessage & { receptions?: number };
+const msg = (key: string, createdAt: number, receptions = 1): Msg => ({
+  dedupKey: key,
+  createdAt,
+  receptions,
+});
+
+describe('foldUnifiedMessagePages', () => {
+  it('returns pages sorted ascending by createdAt', () => {
+    const acc = new Map<string, Msg>();
+    const out = foldUnifiedMessagePages(acc, [[msg('c', 300), msg('a', 100), msg('b', 200)]]);
+    expect(out.map((m) => m.dedupKey)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('dedups within and across pages by dedupKey', () => {
+    const acc = new Map<string, Msg>();
+    const out = foldUnifiedMessagePages(acc, [
+      [msg('a', 100), msg('b', 200)],
+      [msg('b', 200), msg('c', 300)],
+    ]);
+    expect(out.map((m) => m.dedupKey)).toEqual(['a', 'b', 'c']);
+  });
+
+  // The core #3719 regression: a message present in an earlier poll but ABSENT
+  // from a later poll (it scrolled past the server's newest-N window) must NOT
+  // disappear from the accumulated feed.
+  it('retains a message that is gone from a later poll (window starvation)', () => {
+    const acc = new Map<string, Msg>();
+
+    // Poll 1: the message of interest ('old') is the newest the server returned.
+    foldUnifiedMessagePages(acc, [[msg('old', 100), msg('x', 90)]]);
+
+    // Poll 2: 'old' has been pushed past the window; the server returns only
+    // newer traffic and no longer includes it.
+    const out = foldUnifiedMessagePages(acc, [[msg('n1', 200), msg('n2', 210)]]);
+
+    expect(out.map((m) => m.dedupKey)).toEqual(['x', 'old', 'n1', 'n2']);
+    expect(out.find((m) => m.dedupKey === 'old')).toBeTruthy();
+  });
+
+  it('upserts: a later, more-complete copy of the same key wins', () => {
+    const acc = new Map<string, Msg>();
+    foldUnifiedMessagePages(acc, [[msg('a', 100, 1)]]);
+    const out = foldUnifiedMessagePages(acc, [[msg('a', 100, 3)]]); // extra receptions
+    expect(out).toHaveLength(1);
+    expect(out[0].receptions).toBe(3);
+  });
+
+  it('undefined pages returns the existing accumulated set (poll with no data)', () => {
+    const acc = new Map<string, Msg>();
+    foldUnifiedMessagePages(acc, [[msg('a', 100)]]);
+    const out = foldUnifiedMessagePages(acc, undefined);
+    expect(out.map((m) => m.dedupKey)).toEqual(['a']);
+  });
+
+  it('caps the set to the newest `cap` entries, dropping the oldest', () => {
+    const acc = new Map<string, Msg>();
+    const page = Array.from({ length: 10 }, (_, i) => msg(`m${i}`, i)); // createdAt 0..9
+    const out = foldUnifiedMessagePages(acc, [page], 4);
+    expect(out.map((m) => m.dedupKey)).toEqual(['m6', 'm7', 'm8', 'm9']);
+    expect(acc.size).toBe(4); // accumulator itself is trimmed, not just the snapshot
+    expect(acc.has('m0')).toBe(false);
+  });
+
+  it('keeps a generous default cap', () => {
+    expect(DEFAULT_ACCUMULATOR_CAP).toBeGreaterThanOrEqual(2000);
+  });
+});

--- a/src/utils/unifiedMessageAccumulator.ts
+++ b/src/utils/unifiedMessageAccumulator.ts
@@ -1,0 +1,68 @@
+/**
+ * Accumulator for the unified message feed.
+ *
+ * The `/api/unified/messages` endpoint is a capped *newest-N* window: each poll
+ * returns the most recent page, deduplicated across sources. Rendering directly
+ * off the latest poll means a message that scrolls past that window on a later
+ * poll silently vanishes from the view — even though the user already saw it and
+ * the row still exists in the DB. This is the root of #3719/#3720: a message
+ * exclusive to a high-traffic source (e.g. a continental MQTT bridge) gets
+ * pushed past the window within ~60s as newer messages arrive.
+ *
+ * The structural fix is to make the live feed *append-only*: fold every poll's
+ * pages into a persistent map keyed by `dedupKey` and render from that, so once
+ * a message is shown it stays shown regardless of how the server window shifts.
+ * This decouples display persistence from the server window size entirely.
+ */
+
+/** Minimal shape the accumulator needs; the full `UnifiedMessage` is a superset. */
+export interface AccumulableMessage {
+  dedupKey: string;
+  createdAt: number;
+}
+
+/**
+ * Default cap on retained entries. Generous so realistic scroll-back never trims
+ * live history; only pathological sessions (very long live tail or massive
+ * scroll-back) hit it, and trimmed entries remain re-fetchable via scroll-back.
+ */
+export const DEFAULT_ACCUMULATOR_CAP = 5000;
+
+/**
+ * Fold freshly-fetched pages into a persistent accumulator and return the merged
+ * list sorted ascending by `createdAt` (oldest → newest, so the chat layout pins
+ * the newest message to the bottom).
+ *
+ * - **Upserts by `dedupKey`:** a later poll may carry a more-complete merged
+ *   object (extra `receptions`, ack state, upgraded sender names), so the newest
+ *   copy of a given key wins.
+ * - **Never removes on poll:** a key absent from the current pages is retained —
+ *   that is exactly what keeps a scrolled-out message visible (#3719).
+ * - **Caps memory:** when the set exceeds `cap`, the OLDEST entries (by
+ *   `createdAt`) are dropped.
+ *
+ * Mutates `acc` in place (so the caller can persist it across renders via a ref)
+ * and returns the sorted snapshot.
+ */
+export function foldUnifiedMessagePages<T extends AccumulableMessage>(
+  acc: Map<string, T>,
+  pages: T[][] | undefined,
+  cap: number = DEFAULT_ACCUMULATOR_CAP,
+): T[] {
+  if (pages) {
+    for (const page of pages) {
+      for (const m of page) acc.set(m.dedupKey, m);
+    }
+  }
+
+  let out = Array.from(acc.values());
+  out.sort((a, b) => a.createdAt - b.createdAt);
+
+  if (out.length > cap) {
+    out = out.slice(out.length - cap); // keep the newest `cap`
+    acc.clear();
+    for (const m of out) acc.set(m.dedupKey, m);
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary

Structural fix for the #3719 / #3720 disappearing-message bug, complementing the server-side mitigations in #3736.

**Root cause (read side):** `UnifiedMessagesPage` rendered `allMessages` straight off `data.pages` — i.e. the latest poll of a capped *newest-N* server window. A message exclusive to a high-traffic source (e.g. a continental MQTT bridge) gets pushed past that window within ~60s as newer traffic arrives, so the next 10s poll's page 1 no longer contains it and it vanishes from the view — even though the row is still in the DB.

#3736 raises the server fetch window (`limit×2 → limit×5`), which buys ~167s of headroom at ~3 msg/s. That's a mitigation: a burstier source or longer poll gap re-opens the same hole, and it fetches more rows every poll.

**This PR fixes it structurally on the client:** the live feed becomes *append-only*. Every poll's pages are folded into a persistent map keyed by `dedupKey`; we render from that map instead of the latest poll. Once a message has been shown it stays shown, regardless of how the server window shifts — so the disappearance can't happen at *any* source traffic rate.

## Changes

- New `src/utils/unifiedMessageAccumulator.ts` — pure `foldUnifiedMessagePages(acc, pages, cap)`:
  - **Upserts by `dedupKey`** so a later, more-complete merged copy (extra `receptions`, ack state, upgraded names) wins.
  - **Never removes on poll** — a key absent from the current pages is retained (the fix).
  - **Sort by `createdAt`** ascending (chat layout; clock-skew-safe, #3122).
  - **Caps at 5000** (oldest dropped, still re-fetchable via scroll-back).
- `UnifiedMessagesPage.tsx` — replaced the page-flatten `useMemo` with a `useRef` accumulator folded via the helper; reset synchronously on channel change so feeds never blend.

## Tradeoff

A message deleted server-side stays visible until channel switch / refresh (rare; the alternative — re-introducing windowing eviction — is worse). Memory is bounded by the 5000 cap.

## Tests

- `unifiedMessageAccumulator.test.ts` — sort, intra/cross-page dedup, upsert-wins, undefined-pages, cap-drops-oldest, and the **core regression**: a message present in poll 1 but absent from poll 2 stays in the feed.
- Full suite: **7528 passed, 0 failed**.

Refs #3719, #3720, #3736

🤖 Generated with [Claude Code](https://claude.com/claude-code)