### PR TITLE
fix(ratelimit): exempt GET requests from apiLimiter to fix source-toggle 429s (#3735)

### DIFF
--- a/src/server/middleware/rateLimiters.test.ts
+++ b/src/server/middleware/rateLimiters.test.ts
@@ -54,6 +54,7 @@ async function createTestApp(envOverrides: Record<string, unknown>): Promise<Exp
     await import('./rateLimiters.js');
 
   const app = express();
+  app.use(express.json());
   app.use('/api', apiLimiter, (_req, res) => res.json({ ok: true }));
   app.use('/auth', authLimiter, (_req, res) => res.json({ ok: true }));
   app.use('/messages', messageLimiter, (_req, res) => res.json({ ok: true }));
@@ -125,7 +126,7 @@ describe('Rate Limiters Middleware', () => {
   });
 
   describe('When rate limits are set to a small positive value', () => {
-    it('should enforce API rate limit after max requests exceeded from a public IP', async () => {
+    it('should enforce API rate limit on POST requests from a public IP', async () => {
       const app = await createTestApp({
         rateLimitApi: 2,
         rateLimitApiProvided: true,
@@ -133,7 +134,8 @@ describe('Rate Limiters Middleware', () => {
       // Enable trust proxy so X-Forwarded-For is honoured, bypassing the private-IP exemption
       app.set('trust proxy', 1);
 
-      const makeRequest = () => request(app).get('/api').set('X-Forwarded-For', '1.2.3.4');
+      // Use POST — GET is exempt from the API limiter (#3735)
+      const makeRequest = () => request(app).post('/api').set('X-Forwarded-For', '1.2.3.4');
 
       // First 2 should succeed
       expect((await makeRequest()).status).toBe(200);
@@ -143,6 +145,20 @@ describe('Rate Limiters Middleware', () => {
       const res = await makeRequest();
       expect(res.status).toBe(429);
       expect(res.body.error).toContain('Too many requests');
+    });
+
+    it('should NOT enforce API rate limit on GET requests from a public IP (#3735)', async () => {
+      const app = await createTestApp({
+        rateLimitApi: 2,
+        rateLimitApiProvided: true,
+      });
+      app.set('trust proxy', 1);
+
+      // GET requests are always exempt — source-switching fires 50+ simultaneous reads
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/api').set('X-Forwarded-For', '1.2.3.4');
+        expect(res.status).toBe(200);
+      }
     });
 
     it('should not throttle private/local network IPs regardless of limit', async () => {
@@ -279,9 +295,9 @@ describe('Rate Limiters Middleware', () => {
       );
       expect(disabledLogs).toHaveLength(3);
 
-      // Private-IP exemption line should always be logged
+      // GET-exemption line should always be logged
       expect(infoCalls).toContainEqual(
-        expect.stringContaining('private/local network addresses: always exempt')
+        expect.stringContaining('GET requests: always exempt')
       );
     });
 

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -61,7 +61,7 @@ const rateLimitConfig = {
 // Log rate limit configuration at startup
 logger.info('⏱️  Rate limit configuration:');
 logger.info(`   - API: ${env.rateLimitApi === 0 ? 'unlimited (disabled)' : `${env.rateLimitApi} requests per 15 minutes`}${env.rateLimitApiProvided ? ' (custom)' : ' (default)'}`);
-logger.info('   - API private/local network addresses: always exempt (RFC 1918 + loopback)');
+logger.info('   - API GET requests: always exempt (navigation-driven reads)');
 logger.info(`   - Auth: ${env.rateLimitAuth === 0 ? 'unlimited (disabled)' : `${env.rateLimitAuth} attempts per 15 minutes`}${env.rateLimitAuthProvided ? ' (custom)' : ' (default)'}`);
 logger.info(`   - Messages: ${env.rateLimitMessages === 0 ? 'unlimited (disabled)' : `${env.rateLimitMessages} messages per minute`}${env.rateLimitMessagesProvided ? ' (custom)' : ' (default)'}`);
 
@@ -77,11 +77,15 @@ if (!env.trustProxyProvided && env.isProduction) {
 // Private network IPs (RFC 1918 + loopback) are always exempt — a single active
 // MeshMonitor browser session generates ~900+ API requests per 15 minutes via its
 // polling hooks, and local-network deployments have no security need for rate limiting.
+// GET requests are also exempt: source-switching fires 50+ simultaneous read queries
+// and would exhaust the default 1000-req window in just a few toggles (#3735). Write
+// operations (POST/PUT/DELETE) remain rate-limited; auth and message sends have their
+// own dedicated limiters.
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: env.rateLimitApi,
   message: 'Too many requests from this IP, please try again later',
-  skip: (req) => env.rateLimitApi === 0 || isPrivateNetworkIp(req.ip ?? ''),
+  skip: (req) => env.rateLimitApi === 0 || isPrivateNetworkIp(req.ip ?? '') || req.method === 'GET',
   handler: (req, res) => {
     const ip = req.ip || 'unknown';
     logger.warn(`🚫 Rate limit exceeded for API - IP: ${ip}, Path: ${req.path}`);


### PR DESCRIPTION
## Summary

Fixes #3735 — toggling sources a few times exhausts the API rate limit (HTTP 429) and breaks the UI for 15 minutes.

**Root cause:** `apiLimiter` was applied to all `/api` routes including GETs. Source-switching invalidates and refetches ~50+ React Query hooks simultaneously (nodes, messages, channels, map data, route segments, …). For users behind a reverse proxy without `TRUST_PROXY=1`, all requests share a single bucket keyed to the proxy IP. At 50+ requests per toggle × a few toggles, the 1000 req/15-min default is easily exhausted.

**Fix:** Add `req.method === 'GET'` to the skip condition of `apiLimiter`. Read operations carry minimal security risk on a self-hosted tool; the relevant protections are already elsewhere:
- `authLimiter` guards login endpoints (5 attempts/15 min)
- `messageLimiter` guards message sends (30/min)
- `meshcoreDeviceLimiter` guards device operations (10/min)

POST/PUT/DELETE to the general API remain rate-limited as before.

## Changes

- **`src/server/middleware/rateLimiters.ts`** — add `req.method === 'GET'` to `apiLimiter`'s `skip` predicate; update startup log line accordingly
- **`src/server/middleware/rateLimiters.test.ts`** — update the "enforce after max exceeded" test to use POST (since GET is now exempt); add explicit regression test asserting GET requests bypass the limiter regardless of count

## Test plan

- [x] `vitest run src/server/middleware/rateLimiters.test.ts` — 27/27 pass (includes new GET-exempt test)
- [ ] CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAQy9K5MzFV2PJYha6RgFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAQy9K5MzFV2PJYha6RgFZ)_