### PR TITLE
feat(automations): "Run a script" action + JSON result variables (#3653)

### DIFF
--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -19,6 +19,7 @@ export interface UnifiedChannelOption {
   name: string; protocol?: string; encryption?: string;
   sources?: Array<{ sourceId: string; sourceName?: string; slot: number }>;
 }
+export interface ScriptOption { value: string; label: string; }
 
 /** Sendable = enabled and not an MQTT (receive-only) source. */
 const isSendableSource = (s: SourceOption): boolean =>
@@ -37,6 +38,7 @@ interface Props {
   variables: VariableOption[];
   sources: SourceOption[];
   channels: UnifiedChannelOption[];
+  scripts: ScriptOption[];
   onChange: (form: WorkflowForm) => void;
 }
 
@@ -57,8 +59,8 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
   return params;
 }
 
-function FieldInput({ field, value, onChange, variables, sources, channels, triggerType }: {
-  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; triggerType: string;
+function FieldInput({ field, value, onChange, variables, sources, channels, scripts, triggerType }: {
+  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; triggerType: string;
 }) {
   let control;
   const varNames = variables.map((v) => v.name);
@@ -120,6 +122,15 @@ function FieldInput({ field, value, onChange, variables, sources, channels, trig
     case 'geofence':
       control = <GeofenceFieldInput value={value as GeofenceShape | undefined} onChange={onChange} />;
       break;
+    case 'scriptselect':
+      control = (
+        <select className="ae-select" value={(value ?? '') as string} onChange={(e) => onChange(e.target.value)}>
+          <option value="">— select a script —</option>
+          {scripts.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+          {scripts.length === 0 && <option value="" disabled>No scripts in the scripts folder</option>}
+        </select>
+      );
+      break;
     case 'sendSourceMulti': {
       const sel = Array.isArray(value) ? (value as string[]) : [];
       const sendable = sources.filter(isSendableSource);
@@ -179,8 +190,8 @@ function FieldInput({ field, value, onChange, variables, sources, channels, trig
   );
 }
 
-function BlockFields({ block, triggerType, variables, sources, channels, onParams }: {
-  block: FormBlock; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; onParams: (p: Record<string, unknown>) => void;
+function BlockFields({ block, triggerType, variables, sources, channels, scripts, onParams }: {
+  block: FormBlock; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; onParams: (p: Record<string, unknown>) => void;
 }) {
   const def = BLOCK_BY_TYPE[block.type];
   if (!def) return null;
@@ -188,15 +199,15 @@ function BlockFields({ block, triggerType, variables, sources, channels, onParam
     <>
       {def.fields.map((f) => {
         const field = f.kind === 'fieldselect' ? { ...f, groups: fieldsFor(block.type, triggerType) } : f;
-        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} triggerType={triggerType}
+        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} scripts={scripts} triggerType={triggerType}
           onChange={(v) => onParams({ ...block.params, [f.name]: v })} />;
       })}
     </>
   );
 }
 
-function BlockListEditor({ blocks, options, triggerType, variables, sources, channels, onChange, addLabel }: {
-  blocks: FormBlock[]; options: BlockDef[]; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[];
+function BlockListEditor({ blocks, options, triggerType, variables, sources, channels, scripts, onChange, addLabel }: {
+  blocks: FormBlock[]; options: BlockDef[]; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[];
   onChange: (b: FormBlock[]) => void; addLabel: string;
 }) {
   const update = (i: number, b: FormBlock) => { const l = [...blocks]; l[i] = b; onChange(l); };
@@ -211,7 +222,7 @@ function BlockListEditor({ blocks, options, triggerType, variables, sources, cha
             </select>
             <button className="ae-btn ae-btn--ghost" onClick={() => onChange(blocks.filter((_, j) => j !== i))}>✕</button>
           </div>
-          <BlockFields block={b} triggerType={triggerType} variables={variables} sources={sources} channels={channels} onParams={(p) => update(i, { ...b, params: p })} />
+          <BlockFields block={b} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} onParams={(p) => update(i, { ...b, params: p })} />
         </div>
       ))}
       <button className="ae-btn" onClick={() => onChange([...blocks, { type: options[0].type, params: defaultParams(options[0].type, triggerType) }])}>{addLabel}</button>
@@ -219,7 +230,7 @@ function BlockListEditor({ blocks, options, triggerType, variables, sources, cha
   );
 }
 
-export default function AutomationBuilder({ form, variables, sources, channels, onChange }: Props) {
+export default function AutomationBuilder({ form, variables, sources, channels, scripts, onChange }: Props) {
   const triggerType = form.trigger.type;
   const [showHelp, setShowHelp] = useState(false);
   const setTrigger = (type: string) => onChange({ ...form, trigger: { type, params: defaultParams(type, type) } });
@@ -248,7 +259,7 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
             </select>
             <div className="ae-help-text">{BLOCK_BY_TYPE[triggerType]?.description}</div>
           </div>
-          <BlockFields block={form.trigger} triggerType={triggerType} variables={variables} sources={sources} channels={channels} onParams={setTriggerParams} />
+          <BlockFields block={form.trigger} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} onParams={setTriggerParams} />
         </div>
       </div>
 
@@ -262,10 +273,10 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
           <div className="ae-section-body">
             <div className="ae-field-label" style={{ marginBottom: '0.4rem' }}>IF — all of these are true (optional)</div>
             {rule.conditions.length === 0 && <div className="ae-muted" style={{ marginBottom: '0.5rem' }}>No conditions — runs every time the trigger fires.</div>}
-            <BlockListEditor blocks={rule.conditions} options={CONDITIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels}
+            <BlockListEditor blocks={rule.conditions} options={CONDITIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts}
               onChange={(c) => updateRule(i, { ...rule, conditions: c })} addLabel="+ Add condition" />
             <div className="ae-field-label" style={{ margin: '0.9rem 0 0.4rem' }}>THEN — do this</div>
-            <BlockListEditor blocks={rule.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels}
+            <BlockListEditor blocks={rule.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts}
               onChange={(a) => updateRule(i, { ...rule, actions: a })} addLabel="+ Add action" />
           </div>
         </div>
@@ -294,7 +305,7 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
               <div className="ae-help-text">“Matched” means a rule’s IF conditions passed.</div>
             </div>
             <div className="ae-field-label" style={{ margin: '0.6rem 0 0.4rem' }}>THEN — do this</div>
-            <BlockListEditor blocks={form.combine.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels}
+            <BlockListEditor blocks={form.combine.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts}
               onChange={(a) => setCombine({ ...form.combine!, actions: a })} addLabel="+ Add action" />
           </div>
         </div>

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { isValidCron } from 'cron-validator';
 import { appBasename } from '../../init';
 import apiService from '../../services/api';
-import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption } from './AutomationBuilder';
+import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption, type ScriptOption } from './AutomationBuilder';
 import AutomationTester from './AutomationTester';
 import { compile, decompile, type WorkflowForm } from './compile';
 import './AutomationsPage.css';
@@ -26,7 +26,7 @@ interface Variable {
 }
 interface Run { id: string; status: string; sourceId: string | null; startedAt: number; log: string | null; }
 
-const VARIABLE_TYPES = ['string', 'integer', 'float', 'boolean', 'flag'] as const;
+const VARIABLE_TYPES = ['string', 'integer', 'float', 'boolean', 'flag', 'json'] as const;
 const VARIABLE_SCOPES: { value: Variable['scope']; label: string }[] = [
   { value: 'global', label: 'Global' }, { value: 'source', label: 'Per Source' },
   { value: 'node', label: 'Per Node' }, { value: 'sourceNode', label: 'Per Source + Node' },
@@ -152,6 +152,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
   const [variables, setVariables] = useState<VariableOption[]>([]);
   const [sources, setSources] = useState<SourceOption[]>([]);
   const [channels, setChannels] = useState<UnifiedChannelOption[]>([]);
+  const [scripts, setScripts] = useState<ScriptOption[]>([]);
 
   // Decide builder vs JSON from the existing config.
   const parsedInitial = (() => { try { return initial ? decompile(JSON.parse(initial.config)) : DEFAULT_FORM; } catch { return null; } })();
@@ -183,6 +184,9 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     apiService.get<UnifiedChannelOption[]>('/api/automations/channels')
       .then((cs) => setChannels(cs))
       .catch(() => setChannels([]));
+    apiService.get<{ scripts: Array<{ filename: string; name?: string }> }>('/api/scripts')
+      .then((r) => setScripts((r.scripts ?? []).map((s) => ({ value: s.filename, label: s.name || s.filename }))))
+      .catch(() => setScripts([]));
   }, []);
 
   const switchToJson = () => { setJsonText(JSON.stringify(compile(form), null, 2)); setMode('json'); };
@@ -237,7 +241,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
       </div>
 
       {mode === 'builder'
-        ? <AutomationBuilder form={form} variables={variables} sources={sources} channels={channels} onChange={setForm} />
+        ? <AutomationBuilder form={form} variables={variables} sources={sources} channels={channels} scripts={scripts} onChange={setForm} />
         : (
           <div className="ae-field">
             <label className="ae-field-label">Workflow graph (JSON)</label>
@@ -301,6 +305,10 @@ function VariablesList() {
 
   const create = async () => {
     setError(null);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      setError('Name must be a letters/digits/underscore identifier (no dots or spaces) — needed so {{ var.name.field }} can index JSON.');
+      return;
+    }
     const config: Record<string, unknown> = {};
     if (defaultValue !== '') config.defaultValue = (type === 'integer' || type === 'float') ? Number(defaultValue) : defaultValue;
     if (type === 'flag' && flagDuration !== '') config.flagDurationSeconds = Number(flagDuration);

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -48,6 +48,7 @@ export default function SubstitutionsHelpDrawer({ triggerType, variables, onClos
       <h3>Variables &amp; misc</h3>
       <dl>
         <dt>{'{{ var.NAME }}'}</dt><dd>Any user variable{variables.length ? `: ${variables.map((v) => v.name).join(', ')}` : ' (none defined yet)'}.</dd>
+        <dt>{'{{ var.NAME.a.b }}'}</dt><dd>Index into a <strong>json</strong> variable (e.g. a “Run a script” result) — dotted path into the stored object/array. A whole object renders as JSON.</dd>
         <dt>{'{{ NOW }}'}</dt><dd>Current time (rendered as a local date/time).</dd>
       </dl>
 

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -6,7 +6,7 @@
  * `kind` maps to an input renderer in AutomationBuilder.
  */
 
-export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence';
+export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect';
 
 export interface FieldOpt { value: string; label: string; }
 export interface FieldGroup { label: string; options: FieldOpt[]; }
@@ -354,6 +354,16 @@ export const ACTIONS: BlockDef[] = [
     label: 'Do nothing',
     description: 'A no-op. Use it when a rule should only contribute its IF result to a FINALLY (ANY/ALL/NONE) step without doing anything on its own.',
     fields: [],
+  },
+  {
+    type: 'action.runScript',
+    label: 'Run a script',
+    description: 'Run a script from the server’s scripts folder. The trigger context is passed as MM_* environment variables; the script’s JSON output can be stored in a variable.',
+    fields: [
+      { name: 'scriptPath', label: 'Script', kind: 'scriptselect', help: 'A script file in the server’s scripts directory ($DATA_DIR/scripts).' },
+      { name: 'resultVariable', label: 'Store result in', kind: 'variable', advanced: true, help: 'Optional. Stores the script’s JSON output in this variable — use a "json" variable and index it later as {{ var.name.field }}.' },
+      { name: 'timeoutSeconds', label: 'Timeout (seconds)', kind: 'number', advanced: true, placeholder: '30' },
+    ],
   },
 ];
 

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -99,6 +99,11 @@ router.post('/variables', canWrite, async (req: Request, res: Response) => {
     if (!name || !type || !scope) {
       return res.status(400).json({ error: 'name, type and scope are required' });
     }
+    // Names must be dot-free identifiers so `{{ var.name.a.b }}` can split the
+    // variable name from the nested JSON path unambiguously.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(String(name))) {
+      return res.status(400).json({ error: 'name must be a letters/digits/underscore identifier (no dots or spaces)' });
+    }
     if (!VARIABLE_TYPES.includes(type) || !VARIABLE_SCOPES.includes(scope)) {
       return res.status(400).json({ error: 'invalid type or scope' });
     }

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { executeAction, type ActionDeps } from './actionExecutor.js';
+import { executeAction, triggerEnv, type ActionDeps } from './actionExecutor.js';
 import type { EngineEvalContext } from './engineContext.js';
 import type { TriggerContext } from './triggerContext.js';
 import type { AutomationNode } from '../../../types/automation.js';
@@ -12,6 +12,7 @@ function recorder() {
     sendTapback: async (a) => { calls.push({ fn: 'sendTapback', args: a }); return 2; },
     manageNode: async (a) => { calls.push({ fn: 'manageNode', args: a }); return 3; },
     notify: async (a) => { calls.push({ fn: 'notify', args: a }); return 4; },
+    runScript: async (a) => { calls.push({ fn: 'runScript', args: a }); return { success: true, stdout: '', returnValue: { ok: 1 } }; },
   };
   return { calls, deps };
 }
@@ -216,5 +217,43 @@ describe('executeAction', () => {
   it('throws on an unknown action type', async () => {
     const { deps } = recorder();
     await expect(executeAction(node('action.bogus', {}), ctx({}), deps)).rejects.toThrow(/unknown action/);
+  });
+
+  // ─── runScript ─────────────────────────────────────────────────────────────
+  it('triggerEnv maps the trigger context to MM_* + message aliases', () => {
+    const env = triggerEnv(ctx({ from: 5, text: 'hello', telemetryType: 'battery', changed: ['a', 'b'] }, 'src1'));
+    expect(env.MM_TRIGGER_TYPE).toBe('trigger.message');
+    expect(env.MM_SOURCE_ID).toBe('src1');
+    expect(env.MM_TEXT).toBe('hello');
+    expect(env.MM_TELEMETRY_TYPE).toBe('battery');     // camelCase → MM_SNAKE
+    expect(env.MM_CHANGED).toBe('["a","b"]');           // arrays JSON-stringified
+    expect(env.MESSAGE).toBe('hello');                   // message alias
+    expect(env.FROM_NODE).toBe('5');
+    expect('MM_NOTHERE' in env).toBe(false);             // absent field → no key
+  });
+
+  it('runScript: calls the dep with scriptPath + env, stores returnValue in the result variable', async () => {
+    const { calls, deps } = recorder();
+    const writes: Array<{ name: string; value: unknown }> = [];
+    const c = ctx({ from: 5, text: 'hi' });
+    (c.vars as any).setValue = async (name: string, value: unknown) => { writes.push({ name, value }); return { ok: true }; };
+    await executeAction(node('action.runScript', { scriptPath: 'foo.sh', resultVariable: 'scriptOut', timeoutSeconds: 5 }), c, deps);
+    const call = calls.find((x) => x.fn === 'runScript')!;
+    expect(call.args.scriptPath).toBe('foo.sh');
+    expect(call.args.timeoutMs).toBe(5000);
+    expect(call.args.env.MM_TEXT).toBe('hi');
+    expect(writes).toEqual([{ name: 'scriptOut', value: { ok: 1 } }]); // recorder returns returnValue {ok:1}
+  });
+
+  it('runScript: a failing script throws (recorded as action:error)', async () => {
+    const { deps } = recorder();
+    deps.runScript = async () => ({ success: false, stdout: '', error: 'boom' });
+    await expect(executeAction(node('action.runScript', { scriptPath: 'bad.sh' }), ctx({}), deps))
+      .rejects.toThrow(/script "bad\.sh" failed: boom/);
+  });
+
+  it('runScript: requires a scriptPath', async () => {
+    const { deps } = recorder();
+    await expect(executeAction(node('action.runScript', {}), ctx({}), deps)).rejects.toThrow(/no scriptPath/);
   });
 });

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -28,6 +28,41 @@ export interface ActionDeps {
   }): Promise<unknown>;
   manageNode(a: { sourceId: string | null; nodeNum: number; op: NodeManageOp }): Promise<unknown>;
   notify(a: { sourceId: string | null; title: string; body: string; type?: string; urls?: string[] }): Promise<unknown>;
+  /** Run a user script file (in $DATA_DIR/scripts) with the given env. Never throws — returns the outcome. */
+  runScript(a: { scriptPath: string; env: Record<string, string>; timeoutMs?: number }):
+    Promise<{ success: boolean; returnValue?: unknown; stdout: string; error?: string }>;
+}
+
+/**
+ * Build the env a `runScript` action exposes to the script: a generic
+ * MM_TRIGGER_TYPE / MM_SOURCE_ID / MM_NODE_NUM / MM_TIMESTAMP plus every trigger
+ * field as MM_<UPPER_SNAKE> (objects/arrays JSON-stringified, nulls skipped), and
+ * message-compatible aliases (MESSAGE/FROM_NODE/…) so existing scripts still work.
+ * Does NOT include process.env — runScript merges that itself.
+ */
+export function triggerEnv(ctx: EngineEvalContext): Record<string, string> {
+  const fields = ctx.trigger.fields ?? {};
+  const enc = (v: unknown): string => (typeof v === 'object' ? JSON.stringify(v) : String(v));
+  const env: Record<string, string> = {
+    MM_TRIGGER_TYPE: String(ctx.trigger.triggerType ?? ''),
+    MM_SOURCE_ID: ctx.trigger.sourceId ?? '',
+    MM_TIMESTAMP: String(ctx.trigger.timestamp ?? ''),
+  };
+  if (ctx.trigger.subjectNodeNum != null) env.MM_NODE_NUM = String(ctx.trigger.subjectNodeNum);
+  const toEnvKey = (k: string) =>
+    'MM_' + k.replace(/([a-z0-9])([A-Z])/g, '$1_$2').replace(/[^A-Za-z0-9]+/g, '_').toUpperCase();
+  for (const [k, v] of Object.entries(fields)) {
+    if (v == null) continue;
+    env[toEnvKey(k)] = enc(v);
+  }
+  const alias = (key: string, v: unknown) => { if (v != null) env[key] = enc(v); };
+  alias('MESSAGE', fields.text);
+  alias('FROM_NODE', fields.from);
+  alias('PACKET_ID', fields.packetId);
+  alias('CHANNEL', fields.channel);
+  alias('SNR', fields.snr);
+  alias('RSSI', fields.rssi);
+  return env;
 }
 
 /** Target source for an action: explicit param wins, else the trigger's source. */
@@ -57,6 +92,23 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
   switch (node.type) {
     case 'action.nothing':
       return undefined; // no-op — used so a rule can contribute only its IF result to a FINALLY step
+
+    case 'action.runScript': {
+      const scriptPath = String(p.scriptPath ?? '');
+      if (!scriptPath) throw new Error('action.runScript: no scriptPath');
+      const timeoutMs = p.timeoutSeconds != null && Number.isFinite(Number(p.timeoutSeconds))
+        ? Math.max(1, Number(p.timeoutSeconds)) * 1000 : undefined;
+      const result = await deps.runScript({ scriptPath, env: triggerEnv(ctx), timeoutMs });
+      if (!result.success) throw new Error(`script "${scriptPath}" failed: ${result.error ?? 'non-zero exit'}`);
+      // Store the script's JSON result into a variable (usable later as
+      // {{ var.NAME.a.b }}); fall back to trimmed stdout when there's no JSON.
+      const resultVar = typeof p.resultVariable === 'string' ? p.resultVariable : '';
+      if (resultVar) {
+        const value = result.returnValue !== undefined ? result.returnValue : result.stdout.trim();
+        await ctx.vars.setValue(resultVar, value, ctx.varCtx, ctx.now);
+      }
+      return { scriptPath, success: true, returnValue: result.returnValue };
+    }
 
     case 'action.sendMessage': {
       const text = await interpolateAsync(String(p.text ?? ''), ctx);

--- a/src/server/services/automation/automationSimulator.test.ts
+++ b/src/server/services/automation/automationSimulator.test.ts
@@ -174,4 +174,19 @@ describe('simulateAutomation', () => {
     const fail = await simulateAutomation({ graph, varsRepo, event: { kind: 'message', text: 'hi', sourceId: 'other' } });
     expect(fail.conditionResults['c']).toBe(false);
   });
+
+  it('runScript: dry-run records the action without spawning a process', async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'a', type: 'action.runScript', params: { scriptPath: 'foo.sh' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const r = await simulateAutomation({ graph, varsRepo, event: { kind: 'message', text: 'hi' } });
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0].type).toBe('action.runScript');
+    expect((r.actions[0].resolvedParams as any).scriptPath).toBe('foo.sh');
+  });
 });

--- a/src/server/services/automation/automationSimulator.ts
+++ b/src/server/services/automation/automationSimulator.ts
@@ -115,6 +115,8 @@ function recordingDeps(): ActionDeps {
     async sendTapback(a) { return { action: 'tapback', ...a }; },
     async manageNode(a) { return { action: 'nodeManage', ...a }; },
     async notify(a) { return { action: 'notify', ...a }; },
+    // Dry-run must never spawn a process — report success without executing.
+    async runScript() { return { success: true, stdout: '' }; },
   };
 }
 

--- a/src/server/services/automation/conditionEvaluator.test.ts
+++ b/src/server/services/automation/conditionEvaluator.test.ts
@@ -3,7 +3,7 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { AutomationVariablesRepository } from '../../../db/repositories/automationVariables.js';
 import { VariableResolver } from './variableResolver.js';
 import { evaluateCondition } from './conditionEvaluator.js';
-import type { EngineEvalContext } from './engineContext.js';
+import { resolveVarValue, interpolateAsync, type EngineEvalContext } from './engineContext.js';
 import type { TriggerContext } from './triggerContext.js';
 import type { AutomationNode } from '../../../types/automation.js';
 import * as schema from '../../../db/schema/index.js';
@@ -108,6 +108,21 @@ describe('evaluateCondition', () => {
     expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'contains', value: 'PING' }), ctx({ text: 'a ping b' }))).toBe(true);
     expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'regex', value: '^(test|ping)' }), ctx({ text: 'ping' }))).toBe(true);
     expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'eq', value: 'ping' }), ctx({ text: 'pong' }))).toBe(false);
+  });
+
+  it('json variable: nested access via {{ var.x.y.z }} and condition.variable', async () => {
+    await repo.createVariable({ name: 'obj', type: 'json', scope: 'global', config: '{}' });
+    await resolver.setValue('obj', { greeting: 'hi', stats: { count: 3 } }, { sourceId: 'default', nodeNum: 111 }, 1000);
+    const c = ctx({});
+    // direct traversal helper
+    expect(await resolveVarValue(resolver, 'obj.stats.count', c.varCtx, c.now)).toBe(3);
+    expect(await resolveVarValue(resolver, 'obj.missing.x', c.varCtx, c.now)).toBeUndefined();
+    // interpolation: nested scalar, and whole object as JSON
+    expect(await interpolateAsync('say {{ var.obj.greeting }} ({{ var.obj.stats.count }})', c)).toBe('say hi (3)');
+    expect(await interpolateAsync('{{ var.obj.stats }}', c)).toBe('{"count":3}');
+    // condition.variable on a nested numeric field
+    expect(await evaluateCondition(node('condition.variable', { variable: 'obj.stats.count', op: '>', value: 2 }), c)).toBe(true);
+    expect(await evaluateCondition(node('condition.variable', { variable: 'obj.stats.count', op: '>', value: 5 }), c)).toBe(false);
   });
 
   it('variable: is-set check and comparison', async () => {

--- a/src/server/services/automation/conditionEvaluator.ts
+++ b/src/server/services/automation/conditionEvaluator.ts
@@ -10,6 +10,7 @@ import {
   type EngineEvalContext,
   resolveFieldValue,
   resolveOperand,
+  resolveVarValue,
   getSubjectNode,
 } from './engineContext.js';
 import { haversineKm } from './geo.js';
@@ -92,7 +93,9 @@ export async function evaluateCondition(node: AutomationNode, ctx: EngineEvalCon
     case 'condition.variable': {
       const name = String(p.variable ?? '');
       if (!name) return false;
-      const value = await ctx.vars.getValue(name, ctx.varCtx, ctx.now);
+      // resolveVarValue supports nested access (var "data.status") for JSON vars;
+      // a plain name behaves exactly like getValue.
+      const value = await resolveVarValue(ctx.vars, name, ctx.varCtx, ctx.now);
       if (p.op == null) {
         // "is set / truthy": flag present, non-empty string, non-zero number, true
         if (value == null) return false;

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -87,10 +87,36 @@ export function getSubjectNode(ctx: EngineEvalContext): Promise<NodeFacts | null
 }
 
 /** Resolve a single `{{ }}` path: `var.` (async) or `trigger.`/system (sync). */
+/**
+ * Resolve a `var.NAME` or nested `var.NAME.a.b` reference. Splits on the FIRST
+ * dot: NAME is the variable (names contain no dots), the remainder is a path
+ * into its value (e.g. a JSON-typed variable holding a script result). Returns
+ * the traversed value, or undefined if the variable or any path segment is
+ * missing / not an object.
+ */
+export async function resolveVarValue(
+  vars: VariableResolver,
+  fullName: string,
+  varCtx: VarContext,
+  now: number,
+): Promise<unknown> {
+  const dot = fullName.indexOf('.');
+  const name = dot === -1 ? fullName : fullName.slice(0, dot);
+  const segments = dot === -1 ? [] : fullName.slice(dot + 1).split('.').filter(Boolean);
+  let value: unknown = await vars.getValue(name, varCtx, now);
+  for (const seg of segments) {
+    if (value == null || typeof value !== 'object') return undefined;
+    value = (value as Record<string, unknown>)[seg];
+  }
+  return value;
+}
+
 export async function resolvePath(ctx: EngineEvalContext, path: string): Promise<InterpolationValue> {
   if (path.startsWith('var.')) {
-    const v = await ctx.vars.getValue(path.slice('var.'.length), ctx.varCtx, ctx.now);
-    return v ?? undefined;
+    const v = await resolveVarValue(ctx.vars, path.slice('var.'.length), ctx.varCtx, ctx.now);
+    if (v == null) return undefined;
+    // Render objects/arrays as JSON so {{ var.obj }} shows the blob; scalars pass through.
+    return typeof v === 'object' ? JSON.stringify(v) : (v as InterpolationValue);
   }
   return resolveTriggerPath(ctx.trigger, path, ctx.now);
 }

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -13,6 +13,7 @@
 import databaseService from '../../../services/database.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { appriseNotificationService } from '../appriseNotificationService.js';
+import { runScript as runUserScript } from '../../utils/scriptRunner.js';
 import type { ActionDeps } from './actionExecutor.js';
 
 interface MeshSendManager {
@@ -95,6 +96,12 @@ export function createMeshActionDeps(): ActionDeps {
       const r = await appriseNotificationService.notifyDirect({ sourceId, title, body, type }, urls);
       if (!r.ok) throw new Error(`notify failed: ${r.message}`);
       return r;
+    },
+
+    async runScript({ scriptPath, env, timeoutMs }) {
+      // runUserScript resolves the path under $DATA_DIR/scripts (traversal-safe),
+      // picks the interpreter, and never throws — returns { success, ... }.
+      return runUserScript({ scriptPath, env, timeoutMs });
     },
   };
 }

--- a/src/server/services/automation/variableCodec.test.ts
+++ b/src/server/services/automation/variableCodec.test.ts
@@ -66,3 +66,19 @@ describe('flagExpiry', () => {
     expect(flagExpiry({ flagDurationSeconds: -5 }, 1_000_000)).toBeNull();
   });
 });
+
+describe('json variable type', () => {
+  it('round-trips objects and arrays', () => {
+    const obj = { a: 1, b: { c: 'x' }, d: [1, 2] };
+    expect(decodeValue('json', encodeValue('json', obj))).toEqual(obj);
+    expect(decodeValue('json', encodeValue('json', [1, 2, 3]))).toEqual([1, 2, 3]);
+  });
+  it('stores a JSON string as-is (round-trips)', () => {
+    expect(encodeValue('json', '{"a":1}')).toBe('{"a":1}');
+    expect(decodeValue('json', '{"a":1}')).toEqual({ a: 1 });
+  });
+  it('decodes malformed JSON as null', () => {
+    expect(decodeValue('json', 'not json')).toBeNull();
+    expect(decodeValue('json', null)).toBeNull();
+  });
+});

--- a/src/server/services/automation/variableCodec.ts
+++ b/src/server/services/automation/variableCodec.ts
@@ -15,7 +15,7 @@ export interface ParsedVarConfig {
   defaultValue?: unknown;
 }
 
-export type DecodedValue = string | number | boolean | null;
+export type DecodedValue = string | number | boolean | object | null;
 
 /** Parse the JSON `config` column, tolerating malformed/empty input. */
 export function parseVarConfig(config: string | null | undefined): ParsedVarConfig {
@@ -60,6 +60,12 @@ export function encodeValue(type: VariableType, value: unknown): string | null {
     case 'boolean':
     case 'flag':
       return toBool(value) ? 'true' : 'false';
+    case 'json': {
+      // Store any JSON-serializable value (e.g. a script's parsed result). A
+      // string that is already JSON is stored as-is so it round-trips cleanly.
+      if (typeof value === 'string') return value;
+      try { return JSON.stringify(value ?? null); } catch { return null; }
+    }
     default:
       return null;
   }
@@ -82,6 +88,8 @@ export function decodeValue(type: VariableType, raw: string | null): DecodedValu
     case 'boolean':
     case 'flag':
       return raw === 'true' || raw === '1';
+    case 'json':
+      try { return JSON.parse(raw); } catch { return null; }
     default:
       return null;
   }

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -38,7 +38,8 @@ export type ActionType =
   | 'action.sendMessage'
   | 'action.tapback'
   | 'action.nodeManage'
-  | 'action.notify';
+  | 'action.notify'
+  | 'action.runScript';
 
 // flow.delay is intentionally absent — deferred to Phase 1b (stateful waits).
 export type FlowType = 'flow.fanout' | 'flow.collapse' | 'flow.setVar';
@@ -74,6 +75,7 @@ export const ACTION_TYPES: readonly ActionType[] = [
   'action.tapback',
   'action.nodeManage',
   'action.notify',
+  'action.runScript',
 ];
 
 export const FLOW_TYPES: readonly FlowType[] = ['flow.fanout', 'flow.collapse', 'flow.setVar'];
@@ -100,7 +102,7 @@ export type NumericOp = (typeof NUMERIC_OPS)[number];
 
 // ─── Variable types (canonical home; repository re-exports these) ─────────────
 
-export const VARIABLE_TYPES = ['string', 'integer', 'float', 'boolean', 'flag'] as const;
+export const VARIABLE_TYPES = ['string', 'integer', 'float', 'boolean', 'flag', 'json'] as const;
 export type VariableType = (typeof VARIABLE_TYPES)[number];
 
 export const VARIABLE_SCOPES = ['global', 'source', 'node', 'sourceNode'] as const;
@@ -313,6 +315,11 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
         case 'flow.setVar':
           if (typeof p.variable !== 'string' || p.variable.length === 0) {
             errors.push(`${n.type} "${n.id}" requires params.variable`);
+          }
+          break;
+        case 'action.runScript':
+          if (typeof p.scriptPath !== 'string' || p.scriptPath.length === 0) {
+            errors.push(`action.runScript "${n.id}" requires params.scriptPath`);
           }
           break;
         default:


### PR DESCRIPTION
Adds the deferred **RunScript** capability — the last major Automation Engine gap (plan §1/§8).

## What it does
A new **"Run a script"** action runs a script file from the server's `$DATA_DIR/scripts` folder when an automation fires, passing the trigger context as `MM_*` env vars. The script's JSON output can be captured into a variable, and any later step can index into it with **`{{ var.name.a.b }}`**.

## Backend
- **`action.runScript`** reuses the existing `scriptRunner` (`resolveScriptPath` traversal protection, interpreter pick, deps dirs, timeout). Env = `triggerEnv(ctx)`: `MM_TRIGGER_TYPE`/`MM_SOURCE_ID`/`MM_NODE_NUM`/`MM_TIMESTAMP` + each trigger field as `MM_<UPPER_SNAKE>` (objects JSON-stringified) + message-compat aliases (`MESSAGE`,`FROM_NODE`,…). Non-zero exit → throws → recorded `action:error`. Injectable `ActionDeps.runScript`; the **simulator stubs it so dry-runs never spawn a process**.
- **New `json` variable type** (codec: `JSON.stringify`/`JSON.parse`). The action stores `returnValue` into the optional result variable.
- **Nested access `{{ var.name.a.b }}`** via a shared `resolveVarValue` helper used by **both** text interpolation and `condition.variable`; a whole object renders as JSON. Variable names are validated as dot-free identifiers (client + server) so the name/path split is unambiguous.

## Frontend
- "Run a script" action with a **script dropdown** (new `scriptselect` kind, populated from `GET /api/scripts`), optional **result variable** + **timeout**. Variables UI gains the **json** type; the substitutions help documents `{{ var.name.field }}`.

## Decisions (per discussion)
- Script result → a json variable indexed via `{{ var.x.y.z }}` (no `{{ script.* }}` token; the script doesn't send messages — a separate Send-a-message action does).
- Imported automations with a script action get **no special handling** (they land disabled like every import).

## Tests
`triggerEnv` mapping; runScript dep call + result-variable write + failure-throws + scriptPath-required; json codec round-trip + malformed→null; nested `{{ var.x.y.z }}` interpolation + whole-object-as-JSON + nested `condition.variable`; simulator records runScript without spawning. Full suite **7544 passed, 0 failures**; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)