### PR TITLE
fix(ci): watch-ci.sh inspects only runs for the current head commit

### DIFF
--- a/scripts/watch-ci.sh
+++ b/scripts/watch-ci.sh
@@ -5,6 +5,12 @@
 # (so an automated runner can stop waiting), and exits 0 only when every
 # workflow ended in `success` or `skipped`.
 #
+# Only runs for the target's CURRENT head commit are inspected. The tip SHA is
+# re-resolved every poll cycle (so a push mid-watch is picked up), and runs for
+# superseded commits are ignored. Without this, a fixed-and-repushed branch
+# keeps reporting the OLD commit's failure forever, because `gh run list
+# --branch` returns runs for every commit ever pushed to the branch.
+#
 # Usage: ./scripts/watch-ci.sh [-q] <PR_NUMBER|BRANCH_NAME>
 #
 # Exit codes:
@@ -38,7 +44,9 @@ LIMIT="${WATCH_CI_LIMIT:-20}"
 
 log() { $QUIET || echo "$@"; }
 
+PR_NUMBER=""
 if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
+  PR_NUMBER="$TARGET"
   if ! BRANCH=$(gh pr view "$TARGET" --json headRefName -q .headRefName 2>/dev/null); then
     echo "✗ Could not resolve PR #$TARGET" >&2
     exit 2
@@ -47,6 +55,14 @@ if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
 else
   BRANCH="$TARGET"
   log "Watching CI for branch: $BRANCH"
+fi
+
+# Repo (owner/name) is needed to resolve a plain branch's tip commit via the API
+# (a PR resolves its tip from headRefOid instead, so REPO is optional there).
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+if [[ -z "$PR_NUMBER" && -z "$REPO" ]]; then
+  echo "✗ Could not resolve repository for branch $BRANCH" >&2
+  exit 2
 fi
 
 log "Polling every ${INTERVAL}s (limit ${LIMIT})..."
@@ -62,20 +78,50 @@ is_terminal_failure() {
   esac
 }
 
+# Resolve the target's CURRENT head commit SHA, so only runs for the tip are
+# inspected (not stale runs from superseded commits). A PR reports its tip
+# directly via headRefOid (fork-safe); a plain branch is resolved through the
+# commits API. Prints nothing and returns non-zero on failure so the caller can
+# fall back to the last known tip during a transient API hiccup.
+resolve_sha() {
+  if [ -n "$PR_NUMBER" ]; then
+    gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid 2>/dev/null
+  else
+    gh api "repos/$REPO/commits/$BRANCH" -q .sha 2>/dev/null
+  fi
+}
+
 last_summary=""
+LAST_SHA=""
 
 while true; do
   TIMESTAMP=$(date '+%H:%M:%S')
 
+  # Re-resolve the tip each cycle so a new push is tracked automatically. On a
+  # transient resolution failure, reuse the last known tip rather than crashing.
+  HEAD_SHA=$(resolve_sha || true)
+  if [ -z "$HEAD_SHA" ]; then
+    if [ -n "$LAST_SHA" ]; then
+      HEAD_SHA="$LAST_SHA"
+    else
+      log "[$TIMESTAMP] Could not resolve head SHA for $BRANCH yet — waiting..."
+      sleep "$INTERVAL"
+      continue
+    fi
+  fi
+  LAST_SHA="$HEAD_SHA"
+
+  # Only consider runs whose headSha matches the current tip. (gh run list has
+  # no commit filter, so filter in jq. HEAD_SHA is a hex OID — safe to splice.)
   if ! RESULTS=$(gh run list --branch "$BRANCH" --limit "$LIMIT" \
-                   --json name,conclusion,status \
-                   -q '.[] | "\(.name)|\(.status)|\(.conclusion)"' 2>&1); then
+                   --json name,conclusion,status,headSha \
+                   -q ".[] | select(.headSha == \"$HEAD_SHA\") | \"\(.name)|\(.status)|\(.conclusion)\"" 2>&1); then
     echo "✗ gh run list failed: $RESULTS" >&2
     exit 2
   fi
 
   if [ -z "$RESULTS" ]; then
-    log "[$TIMESTAMP] No CI runs found for branch $BRANCH yet — waiting..."
+    log "[$TIMESTAMP] No CI runs for $BRANCH @ ${HEAD_SHA:0:8} yet — waiting..."
     sleep "$INTERVAL"
     continue
   fi
@@ -115,7 +161,7 @@ while true; do
 
   # Fail fast — don't wait for the remaining workflows once one has failed.
   if [ -n "$FAILED_NAME" ]; then
-    echo "✗ CI FAILED — $FAILED_NAME ($FAILED_CONCLUSION). Inspect with: gh run view --log-failed --branch $BRANCH"
+    echo "✗ CI FAILED — $FAILED_NAME ($FAILED_CONCLUSION) on $BRANCH @ ${HEAD_SHA:0:8}. Inspect with: gh run list --branch $BRANCH (then: gh run view <id> --log-failed)"
     if command -v notify-send &>/dev/null; then
       notify-send "CI Failed" "$FAILED_NAME on $BRANCH" --urgency=critical 2>/dev/null || true
     fi
@@ -123,7 +169,7 @@ while true; do
   fi
 
   if $ALL_COMPLETE; then
-    echo "✓ CI PASSED — all checks green on $BRANCH"
+    echo "✓ CI PASSED — all checks green on $BRANCH @ ${HEAD_SHA:0:8}"
     if command -v notify-send &>/dev/null; then
       notify-send "CI Passed" "Branch: $BRANCH" --urgency=normal 2>/dev/null || true
     fi


### PR DESCRIPTION
## Problem

`scripts/watch-ci.sh` polls `gh run list --branch <branch>`, which returns runs for **every commit ever pushed to the branch**. After a branch is fixed and re-pushed, the watcher kept surfacing the **old commit's failed run** indefinitely — reporting `✗ CI FAILED` even though the new tip's runs all passed.

Observed live while monitoring PR #3733: the fix commit (`077552dd`) was green, but the watcher repeatedly reported the pre-fix commit's `PR Tests` failure, because that stale completed run outranked the still-`queued` runs on the new tip.

## Fix

- **Resolve the target's current head SHA each poll cycle** and filter the run list to that SHA (in jq — `gh run list` has no commit filter):
  - PR target → `headRefOid` (fork-safe).
  - Plain branch target → `repos/{owner}/{repo}/commits/{branch}` via the API.
- Re-resolving every cycle means a **push mid-watch is tracked automatically**, and the existing "no runs yet → wait" branch now cleanly covers the window between a push and its runs being created.
- On a transient SHA-resolution hiccup, **fall back to the last known tip** instead of crashing.
- Fixed the failure hint, which printed the **invalid** `gh run view --log-failed --branch <branch>` (`run view` takes a run id, not `--branch`), and added the short SHA to the pass/fail summary lines.

## Verification

- `bash -n` clean.
- **Regression:** `watch-ci.sh -q 3733` (the case the old script wrongly failed) → `✓ CI PASSED — all checks green on claude/great-dijkstra-ueptaa @ 077552dd`.
- **Branch path:** `watch-ci.sh main` correctly resolves the tip and waits only on that commit's genuinely in-progress runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)