### PR TITLE
perf(dashboard): batch per-source reads to fix source-toggle 429s without exempting GETs (#3735)

### DIFF
--- a/src/hooks/useDashboardData.test.ts
+++ b/src/hooks/useDashboardData.test.ts
@@ -141,19 +141,23 @@ describe('useDashboardSourceData', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('fetches all data for a valid sourceId', async () => {
+  it('fetches data via the bundled dashboard endpoint plus status (#3735)', async () => {
     const mockNodes = [{ num: 1, id: '!abc' }, { num: 2, id: '!def' }];
     const mockTraceroutes = [{ id: 10, fromNodeNum: 1, toNodeNum: 2 }];
     const mockNeighborInfo = [{ nodeId: '!abc', neighbors: [] }];
     const mockChannels = [{ index: 0, name: 'Primary' }];
 
-    // The hook fires 5 parallel queries — provide responses for each.
-    // useQuery fires them in insertion order: nodes, traceroutes, neighborInfo, status, channels
-    mockFetchJson(mockNodes);
-    mockFetchJson(mockTraceroutes);
-    mockFetchJson(mockNeighborInfo);
+    // The hook now fires ONE bundled dashboard request (nodes+traceroutes+
+    // neighborInfo+channels) plus the lightweight status query, instead of five
+    // separate GETs. Insertion order: dashboard, status.
+    mockFetchJson({
+      sourceId: 'src-1',
+      nodes: mockNodes,
+      traceroutes: mockTraceroutes,
+      neighborInfo: mockNeighborInfo,
+      channels: mockChannels,
+    });
     mockFetchJson(mockStatus);
-    mockFetchJson(mockChannels);
 
     const { result } = renderHook(() => useDashboardSourceData('src-1'), {
       wrapper: createWrapper(),
@@ -161,15 +165,11 @@ describe('useDashboardSourceData', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
 
-    // Verify at least some expected URLs were called
     const calledUrls = mockFetch.mock.calls.map((c: unknown[]) => c[0]);
-    expect(calledUrls).toContain('/meshmonitor/api/sources/src-1/nodes');
-    expect(calledUrls).toContain('/meshmonitor/api/sources/src-1/traceroutes');
-    expect(calledUrls).toContain('/meshmonitor/api/sources/src-1/neighbor-info');
+    expect(calledUrls).toContain('/meshmonitor/api/sources/src-1/dashboard');
     expect(calledUrls).toContain('/meshmonitor/api/sources/src-1/status');
-    expect(calledUrls).toContain('/meshmonitor/api/sources/src-1/channels');
 
     expect(result.current.nodes).toEqual(mockNodes);
     expect(result.current.traceroutes).toEqual(mockTraceroutes);
@@ -502,21 +502,31 @@ describe('useDashboardUnifiedData', () => {
     expect(result.current.nodes).toEqual([]);
   });
 
-  it('fans out 4 fetches per source when enabled and merges deduped nodes', async () => {
-    // For each source we expect 4 endpoints: nodes, traceroutes, neighbor-info, channels.
-    // Returns whatever shape the URL implies; the same nodeNum is heard by both sources
-    // so the merge should keep the freshest entry.
+  it('fetches the whole unified view in ONE request and merges deduped nodes (#3735)', async () => {
+    // The unified hook now hits a single bundled endpoint that returns one
+    // per-source bundle each. The same nodeNum is heard by both sources, so the
+    // merge should keep the freshest entry.
     mockFetch.mockImplementation((url: string) => {
       const respond = (data: unknown) =>
         Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
-      if (url.endsWith('/sources/src-1/nodes')) return respond([{ nodeNum: 42, lastHeard: 100, longName: 'Old' }]);
-      if (url.endsWith('/sources/src-2/nodes')) return respond([{ nodeNum: 42, lastHeard: 200, longName: 'New' }]);
-      if (url.endsWith('/sources/src-1/traceroutes')) return respond([{ id: 'tr-1' }]);
-      if (url.endsWith('/sources/src-2/traceroutes')) return respond([{ id: 'tr-2' }]);
-      if (url.endsWith('/sources/src-1/neighbor-info')) return respond([{ id: 'ni-1' }]);
-      if (url.endsWith('/sources/src-2/neighbor-info')) return respond([]);
-      if (url.endsWith('/sources/src-1/channels')) return respond([{ id: 0, name: 'LongFast' }]);
-      if (url.endsWith('/sources/src-2/channels')) return respond([]);
+      if (url.includes('/api/unified/dashboard')) {
+        return respond([
+          {
+            sourceId: 'src-1',
+            nodes: [{ nodeNum: 42, lastHeard: 100, longName: 'Old' }],
+            traceroutes: [{ id: 'tr-1' }],
+            neighborInfo: [{ id: 'ni-1' }],
+            channels: [{ id: 0, name: 'LongFast' }],
+          },
+          {
+            sourceId: 'src-2',
+            nodes: [{ nodeNum: 42, lastHeard: 200, longName: 'New' }],
+            traceroutes: [{ id: 'tr-2' }],
+            neighborInfo: [],
+            channels: [],
+          },
+        ]);
+      }
       return respond([]);
     });
 
@@ -529,8 +539,11 @@ describe('useDashboardUnifiedData', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    // 2 sources × 4 endpoints = 8 fetches
-    expect(mockFetch).toHaveBeenCalledTimes(8);
+    // One request for the whole view, scoped to the source list.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toContain('/api/unified/dashboard?sources=');
+    expect(mockFetch.mock.calls[0][0]).toContain('src-1');
+    expect(mockFetch.mock.calls[0][0]).toContain('src-2');
     expect(result.current.nodes).toHaveLength(1);
     expect((result.current.nodes[0] as any).longName).toBe('New');
     expect(result.current.traceroutes).toEqual([{ id: 'tr-1' }, { id: 'tr-2' }]);

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -41,6 +41,21 @@ export interface SourceStatus {
   [key: string]: unknown;
 }
 
+/**
+ * One source's bundled dashboard datasets, as returned by the aggregate
+ * endpoints GET /api/sources/:id/dashboard and GET /api/unified/dashboard.
+ * Bundling these four reads into one request (instead of one GET each, per
+ * source, per 15s poll) is what keeps source-heavy dashboards from exhausting
+ * the API rate limiter / hammering low-powered servers (#3735).
+ */
+export interface SourceDashboardBundle {
+  sourceId: string;
+  nodes: unknown[];
+  traceroutes: unknown[];
+  neighborInfo: unknown[];
+  channels: unknown[];
+}
+
 /** Default poll interval for dashboard data (15 seconds) */
 export const DASHBOARD_POLL_INTERVAL = 15_000;
 
@@ -168,25 +183,12 @@ export function useDashboardSourceData(sourceId: string | null): DashboardSource
   const isAuthenticated = authStatus?.authenticated ?? false;
   const enabled = sourceId !== null;
 
-  const nodesQuery = useQuery({
-    queryKey: ['dashboard', 'nodes', sourceId, isAuthenticated],
-    queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${sourceId}/nodes`),
-    enabled,
-    retry: false,
-    refetchInterval: DASHBOARD_POLL_INTERVAL,
-  });
-
-  const traceroutesQuery = useQuery({
-    queryKey: ['dashboard', 'traceroutes', sourceId, isAuthenticated],
-    queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${sourceId}/traceroutes`),
-    enabled,
-    retry: false,
-    refetchInterval: DASHBOARD_POLL_INTERVAL,
-  });
-
-  const neighborInfoQuery = useQuery({
-    queryKey: ['dashboard', 'neighborInfo', sourceId, isAuthenticated],
-    queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${sourceId}/neighbor-info`),
+  // One bundled request for nodes+traceroutes+neighborInfo+channels instead of
+  // four separate GETs per poll (#3735). Status stays its own lightweight query
+  // (cheap COUNT(*)s) and is also polled per-source by the sidebar.
+  const dashboardQuery = useQuery({
+    queryKey: ['dashboard', 'source-dashboard', sourceId, isAuthenticated],
+    queryFn: () => fetchJson<SourceDashboardBundle>(`${appBasename}/api/sources/${sourceId}/dashboard`),
     enabled,
     retry: false,
     refetchInterval: DASHBOARD_POLL_INTERVAL,
@@ -195,14 +197,6 @@ export function useDashboardSourceData(sourceId: string | null): DashboardSource
   const statusQuery = useQuery({
     queryKey: ['dashboard', 'status', sourceId, isAuthenticated],
     queryFn: () => fetchJson<SourceStatus>(`${appBasename}/api/sources/${sourceId}/status`),
-    enabled,
-    retry: false,
-    refetchInterval: DASHBOARD_POLL_INTERVAL,
-  });
-
-  const channelsQuery = useQuery({
-    queryKey: ['dashboard', 'channels', sourceId, isAuthenticated],
-    queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${sourceId}/channels`),
     enabled,
     retry: false,
     refetchInterval: DASHBOARD_POLL_INTERVAL,
@@ -220,25 +214,14 @@ export function useDashboardSourceData(sourceId: string | null): DashboardSource
     };
   }
 
-  const isLoading =
-    nodesQuery.isLoading ||
-    traceroutesQuery.isLoading ||
-    neighborInfoQuery.isLoading ||
-    statusQuery.isLoading ||
-    channelsQuery.isLoading;
-
-  const isError =
-    nodesQuery.isError ||
-    traceroutesQuery.isError ||
-    neighborInfoQuery.isError ||
-    statusQuery.isError ||
-    channelsQuery.isError;
+  const isLoading = dashboardQuery.isLoading || statusQuery.isLoading;
+  const isError = dashboardQuery.isError || statusQuery.isError;
 
   return {
-    nodes: nodesQuery.data ?? [],
-    traceroutes: traceroutesQuery.data ?? [],
-    neighborInfo: neighborInfoQuery.data ?? [],
-    channels: channelsQuery.data ?? [],
+    nodes: dashboardQuery.data?.nodes ?? [],
+    traceroutes: dashboardQuery.data?.traceroutes ?? [],
+    neighborInfo: dashboardQuery.data?.neighborInfo ?? [],
+    channels: dashboardQuery.data?.channels ?? [],
     status: statusQuery.data ?? null,
     isLoading,
     isError,
@@ -437,37 +420,20 @@ export function useDashboardUnifiedData(
   const sourceList = sources.map((s) => (typeof s === 'string' ? { id: s } : s));
   const sourceIds = sourceList.map((s) => s.id);
 
-  const queries = useQueries({
-    queries: sourceIds.flatMap((id) => [
-      {
-        queryKey: ['dashboard', 'nodes', id, isAuthenticated],
-        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/nodes`),
-        enabled,
-        retry: false,
-        refetchInterval: DASHBOARD_POLL_INTERVAL,
-      },
-      {
-        queryKey: ['dashboard', 'traceroutes', id, isAuthenticated],
-        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/traceroutes`),
-        enabled,
-        retry: false,
-        refetchInterval: DASHBOARD_POLL_INTERVAL,
-      },
-      {
-        queryKey: ['dashboard', 'neighborInfo', id, isAuthenticated],
-        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/neighbor-info`),
-        enabled,
-        retry: false,
-        refetchInterval: DASHBOARD_POLL_INTERVAL,
-      },
-      {
-        queryKey: ['dashboard', 'channels', id, isAuthenticated],
-        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/channels`),
-        enabled,
-        retry: false,
-        refetchInterval: DASHBOARD_POLL_INTERVAL,
-      },
-    ]),
+  // ONE request for the whole unified view instead of four GETs per source per
+  // poll (#3735). The endpoint returns a per-source bundle array; we re-key it
+  // by sourceId and stamp the caller's name/protocol metadata back on so the
+  // merge can attribute each node to its source.
+  const sourcesKey = sourceIds.join(',');
+  const query = useQuery({
+    queryKey: ['dashboard', 'unified-dashboard', sourcesKey, isAuthenticated],
+    queryFn: () =>
+      fetchJson<SourceDashboardBundle[]>(
+        `${appBasename}/api/unified/dashboard?sources=${encodeURIComponent(sourcesKey)}`,
+      ),
+    enabled: enabled && sourceIds.length > 0,
+    retry: false,
+    refetchInterval: DASHBOARD_POLL_INTERVAL,
   });
 
   if (!enabled || sourceIds.length === 0) {
@@ -482,31 +448,33 @@ export function useDashboardUnifiedData(
     };
   }
 
-  const isLoading = queries.some((q) => q.isLoading);
-  const isError = queries.every((q) => q.isError);
+  const bundlesById = new Map<string, SourceDashboardBundle>(
+    (query.data ?? []).map((b: SourceDashboardBundle): [string, SourceDashboardBundle] => [b.sourceId, b]),
+  );
 
-  // Group every 4 sequential queries back into one source's bundle, mirroring
-  // the order we registered them in (nodes, traceroutes, neighborInfo, channels).
-  // When given full DashboardSource objects we carry id/name/protocol so the
-  // merge can stamp `sources` onto every node (MeshCore source types map to the
-  // MeshCore protocol; everything else is Meshtastic). Bare-string callers get
-  // no metadata, so merged nodes carry no `sources` field.
-  const perSource: UnifiedSourceBundle[] = sourceList.map((s, i) => ({
-    sourceId: 'name' in s ? s.id : undefined,
-    sourceName: 'name' in s ? s.name : undefined,
-    protocol: 'type' in s ? (s.type === 'meshcore' ? 'MeshCore' : 'Meshtastic') : undefined,
-    nodes: (queries[i * 4 + 0]?.data as unknown[] | undefined) ?? [],
-    traceroutes: (queries[i * 4 + 1]?.data as unknown[] | undefined) ?? [],
-    neighborInfo: (queries[i * 4 + 2]?.data as unknown[] | undefined) ?? [],
-    channels: (queries[i * 4 + 3]?.data as unknown[] | undefined) ?? [],
-  }));
+  // Re-attach id/name/protocol so the merge can stamp `sources` onto every node
+  // (MeshCore source types map to the MeshCore protocol; everything else is
+  // Meshtastic). Bare-string callers carry no metadata, so merged nodes get no
+  // `sources` field — matching the previous behavior.
+  const perSource: UnifiedSourceBundle[] = sourceList.map((s) => {
+    const b = bundlesById.get(s.id);
+    return {
+      sourceId: 'name' in s ? s.id : undefined,
+      sourceName: 'name' in s ? s.name : undefined,
+      protocol: 'type' in s ? (s.type === 'meshcore' ? 'MeshCore' : 'Meshtastic') : undefined,
+      nodes: b?.nodes ?? [],
+      traceroutes: b?.traceroutes ?? [],
+      neighborInfo: b?.neighborInfo ?? [],
+      channels: b?.channels ?? [],
+    };
+  });
 
   const merged = mergeUnifiedSourceData(perSource);
 
   return {
     ...merged,
     status: null,
-    isLoading,
-    isError,
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -6,7 +6,7 @@
  * per-source data fetched via the useDashboardData hooks.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -59,6 +59,22 @@ function DashboardInner() {
    */
   const refreshSources = () => {
     queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
+  };
+
+  /**
+   * Debounced variant for bursty mutations (rapid on/off/on source toggling).
+   * Coalesces a flurry of toggles into a single cache invalidation so we fire
+   * one refetch cycle instead of one per click — which, with the batched
+   * dashboard endpoints, keeps toggling comfortably under the API rate limit
+   * (#3735). The PUTs themselves still go through per click (each one changes
+   * server state); only the follow-up refetch is coalesced.
+   */
+  const refreshSourcesTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const refreshSourcesDebounced = () => {
+    if (refreshSourcesTimer.current) clearTimeout(refreshSourcesTimer.current);
+    refreshSourcesTimer.current = setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
+    }, 400);
   };
 
   /**
@@ -802,7 +818,7 @@ function DashboardInner() {
       },
       body: JSON.stringify({ enabled }),
     });
-    if (res.ok) refreshSources();
+    if (res.ok) refreshSourcesDebounced();
   };
 
   const onDeleteSource = (id: string) => {

--- a/src/server/routes/sourceRoutes.dashboard.test.ts
+++ b/src/server/routes/sourceRoutes.dashboard.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Source Routes — aggregate dashboard endpoint tests (#3735)
+ *
+ * GET /api/sources/:id/dashboard bundles a source's nodes, traceroutes,
+ * neighbor-info and channels into ONE response so the dashboard stops firing
+ * four separate GETs per source on every poll. These tests assert the bundle
+ * shape and that per-dataset permission gating matches the individual routes
+ * (a dataset the caller can't read comes back as [] instead of 403-ing the
+ * whole bundle).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import sourceRoutes from './sourceRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: { getSource: vi.fn(), getAllSources: vi.fn() },
+    nodes: { getAllNodes: vi.fn(), getNode: vi.fn(), getNodesByNums: vi.fn() },
+    traceroutes: { getAllTraceroutes: vi.fn() },
+    neighbors: { getAllNeighborInfo: vi.fn() },
+    channels: { getAllChannels: vi.fn() },
+    settings: { getSetting: vi.fn() },
+    checkPermissionAsync: vi.fn(),
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn(),
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: vi.fn().mockReturnValue(null), startManager: vi.fn(), stopManager: vi.fn() },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  MeshtasticManager: vi.fn().mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+const mockDb = databaseService as any;
+const MOCK_SOURCE = { id: 'src-mqtt', name: 'Test MQTT', type: 'mqtt_broker', enabled: true };
+
+const createApp = (user: any): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test-secret', resave: false, saveUninitialized: false, cookie: { secure: false } }));
+  app.use((req: any, _res: any, next: any) => {
+    if (user) {
+      req.session.userId = user.id;
+      mockDb.findUserByIdAsync.mockResolvedValue(user);
+    }
+    next();
+  });
+  app.use('/', sourceRoutes);
+  return app;
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 7, username: 'viewer', isActive: true, isAdmin: false };
+
+describe('GET /:id/dashboard — bundled source datasets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+    mockDb.nodes.getAllNodes.mockResolvedValue([{ nodeNum: 1, nodeId: '!00000001', channel: 0 }]);
+    mockDb.nodes.getNodesByNums.mockResolvedValue(new Map());
+    mockDb.traceroutes.getAllTraceroutes.mockResolvedValue([{ id: 1, fromNodeNum: 1, toNodeNum: 2, channel: 0 }]);
+    mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([]);
+    mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: 'Primary', role: 1 }]);
+    mockDb.settings.getSetting.mockResolvedValue(null);
+  });
+
+  it('404s for an unknown source', async () => {
+    mockDb.sources.getSource.mockResolvedValue(null);
+    const res = await request(createApp(adminUser)).get('/nope/dashboard');
+    expect(res.status).toBe(404);
+  });
+
+  it('bundles all four datasets for an admin', async () => {
+    const res = await request(createApp(adminUser)).get('/src-mqtt/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.body.sourceId).toBe('src-mqtt');
+    expect(res.body.nodes).toHaveLength(1);
+    expect(res.body.traceroutes).toHaveLength(1);
+    expect(res.body.neighborInfo).toEqual([]);
+    expect(res.body.channels).toHaveLength(1);
+  });
+
+  it('gates each dataset independently — a denied dataset comes back as [] without 403', async () => {
+    // nodes:read granted, traceroute:read denied. The traceroute dataset should
+    // be empty AND its query should be skipped entirely (no wasted DB read),
+    // while the rest of the bundle still returns.
+    mockDb.checkPermissionAsync.mockImplementation((_uid: number, resource: string) =>
+      Promise.resolve(resource !== 'traceroute'),
+    );
+
+    const res = await request(createApp(regularUser)).get('/src-mqtt/dashboard');
+
+    expect(res.status).toBe(200);
+    expect(res.body.traceroutes).toEqual([]);
+    expect(mockDb.traceroutes.getAllTraceroutes).not.toHaveBeenCalled();
+    // Other datasets are still present (arrays), not 403.
+    expect(Array.isArray(res.body.nodes)).toBe(true);
+    expect(Array.isArray(res.body.channels)).toBe(true);
+    expect(Array.isArray(res.body.neighborInfo)).toBe(true);
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import databaseService from '../../services/database.js';
-import { requirePermission, optionalAuth, hasPermission } from '../auth/authMiddleware.js';
+import { requirePermission, optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { MeshtasticManager } from '../meshtasticManager.js';
@@ -9,11 +9,15 @@ import { meshcoreManagerRegistry, meshcoreConfigFromSource } from '../meshcoreRe
 import { MqttBrokerManager, type MqttBrokerSourceConfig } from '../mqttBrokerManager.js';
 import { MqttBridgeManager, type MqttBridgeSourceConfig } from '../mqttBridgeManager.js';
 import waypointRoutes from './waypoints.js';
-import { filterNodesByChannelPermission, maskNodeLocationByChannel, maskTraceroutesByChannel, getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
-import { PortNum, modemPresetChannelName } from '../constants/meshtastic.js';
-import { transformChannel } from '../utils/channelView.js';
+import { PortNum } from '../constants/meshtastic.js';
+import {
+  buildSourceNodes,
+  buildSourceChannels,
+  buildSourceTraceroutes,
+  buildSourceNeighborInfo,
+  buildSourceDashboard,
+} from '../services/sourceDashboardData.js';
 import { getSourcePkiKeyStore, isPkiDmDecryptionGloballyEnabled } from '../services/sourcePkiKeyStore.js';
-import type { ResourceType } from '../../types/permission.js';
 
 const router = Router();
 
@@ -931,120 +935,8 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
     const source = await databaseService.sources.getSource(req.params.id);
     if (!source) return res.status(404).json({ error: 'Source not found' });
 
-    // MeshCore sources don't share the meshtastic node table — pull contacts
-    // (and localNode) directly from the per-source MeshCoreManager and map
-    // them into the dashboard's flat node shape. These return early and never
-    // reach the position-override logic below: MeshCore contacts have no
-    // override columns (that's a Meshtastic-node feature, #3551), so there's
-    // nothing to apply.
-    if (source.type === 'meshcore') {
-      const mcManager = meshcoreManagerRegistry.get(source.id);
-      const mcNodes: any[] = [];
-      if (mcManager) {
-        for (const n of await mcManager.getAllNodes()) {
-          if (n.latitude == null || n.longitude == null) continue;
-          if (n.latitude === 0 && n.longitude === 0) continue;
-          const lastHeard = typeof n.lastHeard === 'number'
-            ? Math.floor(n.lastHeard / 1000)
-            : Math.floor(Date.now() / 1000);
-          const pubKey = n.publicKey || '';
-          const nodeId = `mc:${mcManager.sourceId}:${pubKey.substring(0, 12)}`;
-          mcNodes.push({
-            nodeId,
-            nodeNum: 0,
-            sourceId: mcManager.sourceId,
-            isMeshCore: true,
-            publicKey: pubKey,
-            isIgnored: false,
-            isFavorite: false,
-            user: { id: nodeId, longName: n.name, shortName: (n.name || '').substring(0, 4) },
-            longName: n.name,
-            shortName: (n.name || '').substring(0, 4),
-            latitude: n.latitude,
-            longitude: n.longitude,
-            position: { latitude: n.latitude, longitude: n.longitude },
-            lastHeard,
-            hopsAway: 0,
-            role: 0,
-            // MeshCore advert type drives role-based map icons + filtering
-            // (issue #3546): 1=Companion, 2=Repeater, 3=Room, 4=Sensor.
-            advType: typeof n.advType === 'number' ? n.advType : 0,
-          });
-        }
-      }
-      return res.json(mcNodes);
-    }
-
-    // Nodes are stored per-source (composite PK (nodeNum, sourceId) since
-    // migration 029). Filter strictly by this source so two sources viewing
-    // overlapping meshes show only what each has actually heard.
-    const nodes = await databaseService.nodes.getAllNodes(source.id);
-
-    // The local node for this source may not be in DB yet (brand new device).
-    // Always include the manager's local node if absent.
-    const manager = sourceManagerRegistry.getManager(source.id);
-    if (manager) {
-      const localNodeInfo = manager.getLocalNodeInfo();
-      if (localNodeInfo && localNodeInfo.nodeNum && !nodes.some(n => n.nodeNum === localNodeInfo.nodeNum)) {
-        // Fetch the full node record from DB (regardless of sourceId) and inject it
-        const localNode = await databaseService.nodes.getNode(localNodeInfo.nodeNum);
-        if (localNode) {
-          nodes.push(localNode);
-        } else {
-          // Synthesize a minimal record if not yet in DB
-          nodes.push({
-            nodeNum: localNodeInfo.nodeNum,
-            nodeId: localNodeInfo.nodeId,
-            longName: localNodeInfo.longName,
-            shortName: localNodeInfo.shortName,
-            hwModel: localNodeInfo.hwModel ?? 0,
-            lastHeard: Math.floor(Date.now() / 1000),
-            sourceId: source.id,
-          } as any);
-        }
-      }
-    }
-
     const user = (req as any).user ?? null;
-
-    // Filter by channel viewOnMap permissions and mask private position channels
-    const filtered = await filterNodesByChannelPermission(nodes, user, source.id);
-    const masked = await maskNodeLocationByChannel(filtered, user, source.id);
-
-    // Apply per-node position override to the flat lat/lng the dashboard map
-    // reads (issue #3551). These are raw DB rows, so unlike /api/poll they
-    // never passed through enhanceNodeForClient — without this the map renders
-    // the raw GPS position and ignores the override. Mirror that helper's
-    // privacy semantics: private overrides are honored only for callers with
-    // nodes_private read, and the override coords are stripped for everyone else.
-    const canViewPrivate = user?.isAdmin
-      ? true
-      : (user ? await hasPermission(user, 'nodes_private', 'read') : false);
-    const withOverride = masked.map(node => {
-      const n = node as any;
-      const isPrivate = n.positionOverrideIsPrivate === true;
-
-      // Hide the override coordinates from callers who can't view private positions.
-      if (isPrivate && !canViewPrivate) {
-        const stripped = { ...n };
-        delete stripped.latitudeOverride;
-        delete stripped.longitudeOverride;
-        delete stripped.altitudeOverride;
-        return stripped;
-      }
-
-      const eff = getEffectiveDbNodePosition(n);
-      if (eff.isOverride) {
-        return {
-          ...n,
-          latitude: eff.latitude,
-          longitude: eff.longitude,
-          altitude: eff.altitude,
-          positionIsOverride: true,
-        };
-      }
-      return n;
-    });
+    const withOverride = await buildSourceNodes(source, user);
     res.json(withOverride);
   } catch (error) {
     logger.error('Error fetching nodes for source:', error);
@@ -1084,47 +976,8 @@ router.get('/:id/channels', optionalAuth(), async (req: Request, res: Response) 
     const source = await databaseService.sources.getSource(req.params.id);
     if (!source) return res.status(404).json({ error: 'Source not found' });
 
-    const allChannels = await databaseService.channels.getAllChannels(source.id);
-    const isAdmin = req.user?.isAdmin === true;
-
-    // Resolve this source's persisted modem preset (if any) so empty-name
-    // slot 0 can display as "MediumFast"/"LongFast"/etc. instead of the
-    // synthetic "Primary" fallback — matching the unified channels picker
-    // and the on-wire label gateways use. The setting is written by
-    // `meshtasticManager` on each LoRa config response.
-    let presetName: string | null = null;
-    try {
-      const raw = await databaseService.settings.getSetting(`lora.preset.${source.id}`);
-      const n = raw != null ? Number(raw) : NaN;
-      if (Number.isFinite(n)) presetName = modemPresetChannelName(n);
-    } catch (err) {
-      logger.debug(`Failed to load preset for source ${source.id}:`, err);
-    }
-
-    const accessible: typeof allChannels = [];
-    for (const channel of allChannels) {
-      if (isAdmin) {
-        accessible.push(channel);
-        continue;
-      }
-      const channelResource = `channel_${channel.id}` as ResourceType;
-      if (req.user && await hasPermission(req.user, channelResource, 'read', source.id)) {
-        accessible.push(channel);
-      }
-    }
-
-    // Issue #2951: include the raw `psk` only for admins or callers with
-    // write permission on the specific channel — otherwise the channel
-    // configuration UI cannot display the existing key for the operator
-    // who is allowed to change it.
-    const projected = await Promise.all(accessible.map(async (channel) => {
-      const channelResource = `channel_${channel.id}` as ResourceType;
-      const includePsk = isAdmin || (req.user
-        ? await hasPermission(req.user, channelResource, 'write', source.id)
-        : false);
-      return transformChannel(channel, { includePsk, presetName });
-    }));
-
+    const user = (req as any).user ?? null;
+    const projected = await buildSourceChannels(source, user);
     res.json(projected);
   } catch (error) {
     logger.error('Error fetching channels for source:', error);
@@ -1139,15 +992,8 @@ router.get('/:id/traceroutes', requirePermission('traceroute', 'read', { sourceI
     if (!source) return res.status(404).json({ error: 'Source not found' });
 
     const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
-    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(limit, source.id);
-    // Channel-gate traceroutes the same way nodes are gated. Without
-    // this, the rows' embedded `routePositions` JSON (a snapshot of
-    // every hop's lat/lng at traceroute time) lets the frontend draw
-    // line segments for routes the user has no viewOnMap permission
-    // for — appearing as "floating lines" once the nodes endpoint has
-    // stripped the corresponding markers. See #3092 follow-up.
     const user = (req as any).user ?? null;
-    const masked = await maskTraceroutesByChannel(traceroutes, user, source.id);
+    const masked = await buildSourceTraceroutes(source, user, limit);
     res.json(masked);
   } catch (error) {
     logger.error('Error fetching traceroutes for source:', error);
@@ -1161,97 +1007,35 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
     const source = await databaseService.sources.getSource(req.params.id);
     if (!source) return res.status(404).json({ error: 'Source not found' });
 
-    const neighborInfo = await databaseService.neighbors.getAllNeighborInfo(source.id);
-
-    // Get max node age setting (default 24 hours)
-    const maxNodeAgeStr = await databaseService.settings.getSetting('maxNodeAgeHours');
-    const maxNodeAgeHours = maxNodeAgeStr ? (parseInt(maxNodeAgeStr, 10) || 24) : 24;
-    const cutoffTime = Math.floor(Date.now() / 1000) - maxNodeAgeHours * 60 * 60;
-
-    // Build a set of all link keys for bidirectionality detection
-    const linkKeys = new Set(neighborInfo.map(ni => `${ni.nodeNum}-${ni.neighborNodeNum}`));
-
-    // Batch-fetch all nodes referenced in neighbor info
-    const allNodeNums = [...new Set([
-      ...neighborInfo.map(ni => ni.nodeNum),
-      ...neighborInfo.map(ni => ni.neighborNodeNum),
-    ])];
-    const nodeMap = await databaseService.nodes.getNodesByNums(allNodeNums);
-
-    // Apply the same channel gate the nodes endpoint uses, so that a
-    // neighbor-info link whose endpoint nodes the user can't see on the
-    // map doesn't leak their positions through the enriched response.
-    // Without this gate the map would draw neighbor lines between
-    // coordinates of nodes the user has no viewOnMap permission for —
-    // same "floating lines" symptom as the traceroute leak above.
-    // See #3092 follow-up.
     const neighborUser = (req as any).user ?? null;
-    const visibleNodes = await filterNodesByChannelPermission(
-      Array.from(nodeMap.values()),
-      neighborUser,
-      source.id,
-    );
-    const visibleNodeNums = new Set(visibleNodes.map(n => Number((n as any).nodeNum)));
-
-    // Enrich each record with node names, positions, and bidirectionality flag
-    const enrichedNeighborInfo = neighborInfo
-      .filter(ni =>
-        visibleNodeNums.has(Number(ni.nodeNum)) &&
-        visibleNodeNums.has(Number(ni.neighborNodeNum)),
-      )
-      .map(ni => {
-      const node = nodeMap.get(ni.nodeNum) ?? null;
-      const neighbor = nodeMap.get(ni.neighborNodeNum) ?? null;
-      const nodePos = getEffectiveDbNodePosition(node);
-      const neighborPos = getEffectiveDbNodePosition(neighbor);
-
-      const TX_MQTT = 5;
-      const TX_UDP = 6;
-      const nTx = (node as any)?.transportMechanism;
-      const nbTx = (neighbor as any)?.transportMechanism;
-      const isMqtt = nTx === TX_MQTT || nbTx === TX_MQTT || (node as any)?.viaMqtt || (neighbor as any)?.viaMqtt;
-      const isUdp = nTx === TX_UDP || nbTx === TX_UDP;
-      const transportClass: 'rf' | 'udp' | 'mqtt' = isMqtt ? 'mqtt' : isUdp ? 'udp' : 'rf';
-
-      return {
-        ...ni,
-        nodeId: node?.nodeId || `!${ni.nodeNum.toString(16).padStart(8, '0')}`,
-        nodeName: node?.longName || `Node !${ni.nodeNum.toString(16).padStart(8, '0')}`,
-        neighborNodeId: neighbor?.nodeId || `!${ni.neighborNodeNum.toString(16).padStart(8, '0')}`,
-        neighborName: neighbor?.longName || `Node !${ni.neighborNodeNum.toString(16).padStart(8, '0')}`,
-        bidirectional: linkKeys.has(`${ni.neighborNodeNum}-${ni.nodeNum}`),
-        transportClass,
-        nodeLatitude: nodePos.latitude,
-        nodeLongitude: nodePos.longitude,
-        neighborLatitude: neighborPos.latitude,
-        neighborLongitude: neighborPos.longitude,
-        node,
-        neighbor,
-      };
-    })
-      .filter(ni => {
-        // Report-time freshness: show a neighbor edge only when its NeighborInfo
-        // *report* falls within the window. This matches the Map Analysis
-        // "Neighbors" layer (GET /api/analysis/neighbors), which filters purely
-        // on the record `timestamp`. Previously this gated on the endpoint
-        // nodes' `lastHeard`, so a node's stale last-known neighbor list stayed
-        // on the map for as long as the node was otherwise active (e.g. still
-        // sending position/telemetry) — surfacing far more links than the
-        // analysis view and misrepresenting how recently each RF link was seen.
-        // Keying off the record timestamp also naturally keeps indirect-neighbor
-        // links whose neighbor row has a null `lastHeard` (#3025/#2615), since
-        // `lastHeard` is no longer consulted here. `timestamp` is set to the
-        // packet-receipt time (ms) when the report is stored, so a fresh report
-        // implies we heard the reporter within the window.
-        const reportSec = Math.floor((ni.timestamp ?? 0) / 1000);
-        return reportSec >= cutoffTime;
-      })
-      .map(({ node, neighbor, ...rest }) => rest);
-
+    const enrichedNeighborInfo = await buildSourceNeighborInfo(source, neighborUser);
     res.json(enrichedNeighborInfo);
   } catch (error) {
     logger.error('Error fetching neighbor info for source:', error);
     res.status(500).json({ error: 'Failed to fetch neighbor info' });
+  }
+});
+
+// GET /api/sources/:id/dashboard — bundled read of a source's nodes,
+// traceroutes, neighbor-info and channels in ONE response.
+//
+// The dashboard used to fire these as four separate GETs per source on every
+// 15s poll (4×N requests for N sources), exhausting the API rate limiter on
+// multi-source setups and hammering low-powered / heavily-utilized servers
+// (#3735). Bundling collapses that to one request per source. optionalAuth +
+// the per-dataset permission gating inside buildSourceDashboard mirror the
+// individual endpoints' access rules (a dataset the caller can't read comes
+// back as [] rather than 403-ing the whole bundle).
+router.get('/:id/dashboard', optionalAuth(), async (req: Request, res: Response) => {
+  try {
+    const source = await databaseService.sources.getSource(req.params.id);
+    if (!source) return res.status(404).json({ error: 'Source not found' });
+    const user = (req as any).user ?? null;
+    const payload = await buildSourceDashboard(source, user);
+    res.json(payload);
+  } catch (error) {
+    logger.error('Error fetching dashboard data for source:', error);
+    res.status(500).json({ error: 'Failed to fetch dashboard data' });
   }
 });
 

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -1245,3 +1245,42 @@ describe('Unified Routes', () => {
     });
   });
 });
+
+describe('GET /unified/dashboard — bundled cross-source datasets (#3735)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
+    mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+    mockDb.nodes.getAllNodes.mockResolvedValue([]);
+    mockDb.nodes.getNodesByNums = vi.fn().mockResolvedValue(new Map());
+    mockDb.traceroutes = { getAllTraceroutes: vi.fn().mockResolvedValue([]) };
+    mockDb.neighbors = { getAllNeighborInfo: vi.fn().mockResolvedValue([]) };
+    mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: 'Primary', role: 1 }]);
+    mockDb.settings.getSetting.mockResolvedValue(null);
+    mockMeshcoreRegistry.get.mockReturnValue(null);
+  });
+
+  it('returns one bundle per source, each with the four dataset arrays', async () => {
+    const res = await request(createApp(adminUser)).get('/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    const ids = res.body.map((b: any) => b.sourceId).sort();
+    expect(ids).toEqual(['src-a', 'src-b']);
+    for (const bundle of res.body) {
+      expect(Array.isArray(bundle.nodes)).toBe(true);
+      expect(Array.isArray(bundle.traceroutes)).toBe(true);
+      expect(Array.isArray(bundle.neighborInfo)).toBe(true);
+      expect(Array.isArray(bundle.channels)).toBe(true);
+    }
+  });
+
+  it('scopes the response to the ?sources= filter', async () => {
+    const res = await request(createApp(adminUser)).get('/dashboard?sources=src-a');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].sourceId).toBe('src-a');
+  });
+});

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -14,6 +14,7 @@ import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
+import { buildSourceDashboard } from '../services/sourceDashboardData.js';
 import type { DbChannelDatabase, DbPacketLog } from '../../db/types.js';
 import type { DbMeshCorePacket } from '../../db/repositories/meshcore.js';
 
@@ -1288,6 +1289,36 @@ router.get('/status', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error fetching unified status:', error);
     res.status(500).json({ error: 'Failed to fetch unified status' });
+  }
+});
+
+/**
+ * GET /api/unified/dashboard?sources=id1,id2
+ *
+ * Bundled cross-source dashboard read: returns one
+ * `{ sourceId, nodes, traceroutes, neighborInfo, channels }` entry per source.
+ *
+ * Replaces the Unified dashboard's old fan-out of FOUR GETs per source on every
+ * 15s poll (4×N requests), which exhausted the API rate limiter and hammered
+ * low-powered / busy servers (#3735). Now the whole view is a single request.
+ * Each dataset is permission-gated inside `buildSourceDashboard` exactly as the
+ * per-source endpoints are (unreadable datasets come back as []). An optional
+ * `sources` filter scopes the response to the caller's known source list;
+ * absent, every source is returned.
+ */
+router.get('/dashboard', async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user ?? null;
+    const allSources = await databaseService.sources.getAllSources();
+    const requested = typeof req.query.sources === 'string' && req.query.sources.length > 0
+      ? new Set(req.query.sources.split(',').map((s) => s.trim()).filter(Boolean))
+      : null;
+    const selected = requested ? allSources.filter((s) => requested.has(s.id)) : allSources;
+    const bundles = await Promise.all(selected.map((s) => buildSourceDashboard(s, user)));
+    res.json(bundles);
+  } catch (error) {
+    logger.error('Error fetching unified dashboard data:', error);
+    res.status(500).json({ error: 'Failed to fetch unified dashboard data' });
   }
 });
 

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -14,7 +14,7 @@ import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
-import { buildSourceDashboard } from '../services/sourceDashboardData.js';
+import { buildSourceDashboard, getMaxNodeAgeHours } from '../services/sourceDashboardData.js';
 import type { DbChannelDatabase, DbPacketLog } from '../../db/types.js';
 import type { DbMeshCorePacket } from '../../db/repositories/meshcore.js';
 
@@ -1308,13 +1308,23 @@ router.get('/status', async (req: Request, res: Response) => {
  */
 router.get('/dashboard', async (req: Request, res: Response) => {
   try {
+    // Anonymous access is deliberate and matches the per-source endpoints: with
+    // user=null, buildSourceDashboard's permission gates return [] for every
+    // dataset, so an unauthenticated caller gets empty bundles, not data.
     const user = (req as any).user ?? null;
     const allSources = await databaseService.sources.getAllSources();
-    const requested = typeof req.query.sources === 'string' && req.query.sources.length > 0
-      ? new Set(req.query.sources.split(',').map((s) => s.trim()).filter(Boolean))
+    // Bound the filter input — values are only used as set-membership keys
+    // against DB ids (no injection surface), but cap the string so a caller
+    // can't force a huge split/allocation.
+    const sourcesParam = typeof req.query.sources === 'string' ? req.query.sources.slice(0, 4096) : '';
+    const requested = sourcesParam.length > 0
+      ? new Set(sourcesParam.split(',').map((s) => s.trim()).filter(Boolean))
       : null;
     const selected = requested ? allSources.filter((s) => requested.has(s.id)) : allSources;
-    const bundles = await Promise.all(selected.map((s) => buildSourceDashboard(s, user)));
+    // maxNodeAgeHours is a global setting — fetch it once and pass it into every
+    // source's neighbor-info build instead of re-querying it per source.
+    const maxNodeAgeHours = await getMaxNodeAgeHours();
+    const bundles = await Promise.all(selected.map((s) => buildSourceDashboard(s, user, { maxNodeAgeHours })));
     res.json(bundles);
   } catch (error) {
     logger.error('Error fetching unified dashboard data:', error);

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -1,0 +1,304 @@
+/**
+ * Shared builders for a source's dashboard datasets (nodes, channels,
+ * traceroutes, neighbor-info).
+ *
+ * These were extracted verbatim from the per-dataset GET handlers in
+ * `sourceRoutes.ts` so that both the individual endpoints AND the aggregate
+ * dashboard endpoints (`GET /api/sources/:id/dashboard`,
+ * `GET /api/unified/dashboard`) compute identical, identically-masked results.
+ *
+ * The aggregate endpoints exist to cut request volume: the dashboard used to
+ * fire one GET per dataset per source on every 15s poll (4×N requests), which
+ * exhausts the API rate limiter on multi-source setups and hammers low-powered
+ * or busy servers (#3735). Bundling the four reads collapses that to one
+ * request per source (or one for the whole unified view).
+ *
+ * Each builder takes the already-resolved `source` row and the request `user`
+ * (may be null for anonymous, has `isAdmin`) and returns plain JSON-able data.
+ * Permission gating that the individual routes did via `requirePermission`
+ * middleware is applied per-dataset by `buildSourceDashboard`.
+ */
+import databaseService from '../../services/database.js';
+import { hasPermission } from '../auth/authMiddleware.js';
+import { logger } from '../../utils/logger.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
+import {
+  filterNodesByChannelPermission,
+  maskNodeLocationByChannel,
+  maskTraceroutesByChannel,
+  getEffectiveDbNodePosition,
+} from '../utils/nodeEnhancer.js';
+import { modemPresetChannelName } from '../constants/meshtastic.js';
+import { transformChannel } from '../utils/channelView.js';
+import type { ResourceType } from '../../types/permission.js';
+import type { User } from '../../types/auth.js';
+
+type SourceRow = { id: string; name: string; type: string };
+// The request user (null when anonymous), as attached by optionalAuth/requirePermission.
+type ReqUser = User | null;
+
+/** Nodes for a source, channel-filtered and position-masked (mirrors GET /:id/nodes). */
+export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promise<unknown[]> {
+  // MeshCore sources don't share the meshtastic node table — pull contacts
+  // (and localNode) directly from the per-source MeshCoreManager and map
+  // them into the dashboard's flat node shape. These return early and never
+  // reach the position-override logic below: MeshCore contacts have no
+  // override columns (that's a Meshtastic-node feature, #3551).
+  if (source.type === 'meshcore') {
+    const mcManager = meshcoreManagerRegistry.get(source.id);
+    const mcNodes: any[] = [];
+    if (mcManager) {
+      for (const n of await mcManager.getAllNodes()) {
+        if (n.latitude == null || n.longitude == null) continue;
+        if (n.latitude === 0 && n.longitude === 0) continue;
+        const lastHeard = typeof n.lastHeard === 'number'
+          ? Math.floor(n.lastHeard / 1000)
+          : Math.floor(Date.now() / 1000);
+        const pubKey = n.publicKey || '';
+        const nodeId = `mc:${mcManager.sourceId}:${pubKey.substring(0, 12)}`;
+        mcNodes.push({
+          nodeId,
+          nodeNum: 0,
+          sourceId: mcManager.sourceId,
+          isMeshCore: true,
+          publicKey: pubKey,
+          isIgnored: false,
+          isFavorite: false,
+          user: { id: nodeId, longName: n.name, shortName: (n.name || '').substring(0, 4) },
+          longName: n.name,
+          shortName: (n.name || '').substring(0, 4),
+          latitude: n.latitude,
+          longitude: n.longitude,
+          position: { latitude: n.latitude, longitude: n.longitude },
+          lastHeard,
+          hopsAway: 0,
+          role: 0,
+          advType: typeof n.advType === 'number' ? n.advType : 0,
+        });
+      }
+    }
+    return mcNodes;
+  }
+
+  // Nodes are stored per-source (composite PK (nodeNum, sourceId) since
+  // migration 029). Filter strictly by this source.
+  const nodes = await databaseService.nodes.getAllNodes(source.id);
+
+  // The local node for this source may not be in DB yet (brand new device).
+  const manager = sourceManagerRegistry.getManager(source.id);
+  if (manager) {
+    const localNodeInfo = manager.getLocalNodeInfo();
+    if (localNodeInfo && localNodeInfo.nodeNum && !nodes.some(n => n.nodeNum === localNodeInfo.nodeNum)) {
+      const localNode = await databaseService.nodes.getNode(localNodeInfo.nodeNum);
+      if (localNode) {
+        nodes.push(localNode);
+      } else {
+        nodes.push({
+          nodeNum: localNodeInfo.nodeNum,
+          nodeId: localNodeInfo.nodeId,
+          longName: localNodeInfo.longName,
+          shortName: localNodeInfo.shortName,
+          hwModel: localNodeInfo.hwModel ?? 0,
+          lastHeard: Math.floor(Date.now() / 1000),
+          sourceId: source.id,
+        } as any);
+      }
+    }
+  }
+
+  // Filter by channel viewOnMap permissions and mask private position channels.
+  const filtered = await filterNodesByChannelPermission(nodes, user, source.id);
+  const masked = await maskNodeLocationByChannel(filtered, user, source.id);
+
+  // Apply per-node position override to the flat lat/lng the dashboard map
+  // reads (issue #3551). Private overrides are honored only for callers with
+  // nodes_private read, and the override coords are stripped for everyone else.
+  const canViewPrivate = user?.isAdmin
+    ? true
+    : (user ? await hasPermission(user, 'nodes_private', 'read') : false);
+  const withOverride = masked.map(node => {
+    const n = node as any;
+    const isPrivate = n.positionOverrideIsPrivate === true;
+
+    if (isPrivate && !canViewPrivate) {
+      const stripped = { ...n };
+      delete stripped.latitudeOverride;
+      delete stripped.longitudeOverride;
+      delete stripped.altitudeOverride;
+      return stripped;
+    }
+
+    const eff = getEffectiveDbNodePosition(n);
+    if (eff.isOverride) {
+      return {
+        ...n,
+        latitude: eff.latitude,
+        longitude: eff.longitude,
+        altitude: eff.altitude,
+        positionIsOverride: true,
+      };
+    }
+    return n;
+  });
+  return withOverride;
+}
+
+/** Channels for a source, per-channel read-gated, PSK projected (mirrors GET /:id/channels). */
+export async function buildSourceChannels(source: SourceRow, user: ReqUser): Promise<unknown[]> {
+  const allChannels = await databaseService.channels.getAllChannels(source.id);
+  const isAdmin = user?.isAdmin === true;
+
+  // Resolve this source's persisted modem preset so empty-name slot 0 can
+  // display as "MediumFast"/"LongFast" instead of the synthetic "Primary".
+  let presetName: string | null = null;
+  try {
+    const raw = await databaseService.settings.getSetting(`lora.preset.${source.id}`);
+    const n = raw != null ? Number(raw) : NaN;
+    if (Number.isFinite(n)) presetName = modemPresetChannelName(n);
+  } catch (err) {
+    logger.debug(`Failed to load preset for source ${source.id}:`, err);
+  }
+
+  const accessible: typeof allChannels = [];
+  for (const channel of allChannels) {
+    if (isAdmin) {
+      accessible.push(channel);
+      continue;
+    }
+    const channelResource = `channel_${channel.id}` as ResourceType;
+    if (user && await hasPermission(user, channelResource, 'read', source.id)) {
+      accessible.push(channel);
+    }
+  }
+
+  // Issue #2951: include the raw `psk` only for admins or callers with write
+  // permission on the specific channel.
+  const projected = await Promise.all(accessible.map(async (channel) => {
+    const channelResource = `channel_${channel.id}` as ResourceType;
+    const includePsk = isAdmin || (user
+      ? await hasPermission(user, channelResource, 'write', source.id)
+      : false);
+    return transformChannel(channel, { includePsk, presetName });
+  }));
+
+  return projected;
+}
+
+/** Traceroutes for a source, channel-masked (mirrors GET /:id/traceroutes). */
+export async function buildSourceTraceroutes(
+  source: SourceRow,
+  user: ReqUser,
+  limit = 50,
+): Promise<unknown[]> {
+  const clamped = Math.min(limit, 200);
+  const traceroutes = await databaseService.traceroutes.getAllTraceroutes(clamped, source.id);
+  // Channel-gate traceroutes the same way nodes are gated so their embedded
+  // routePositions don't draw segments for routes the user can't view (#3092).
+  return maskTraceroutesByChannel(traceroutes, user, source.id);
+}
+
+/** Enriched neighbor-info for a source, channel-gated (mirrors GET /:id/neighbor-info). */
+export async function buildSourceNeighborInfo(source: SourceRow, user: ReqUser): Promise<unknown[]> {
+  const neighborInfo = await databaseService.neighbors.getAllNeighborInfo(source.id);
+
+  const maxNodeAgeStr = await databaseService.settings.getSetting('maxNodeAgeHours');
+  const maxNodeAgeHours = maxNodeAgeStr ? (parseInt(maxNodeAgeStr, 10) || 24) : 24;
+  const cutoffTime = Math.floor(Date.now() / 1000) - maxNodeAgeHours * 60 * 60;
+
+  const linkKeys = new Set(neighborInfo.map(ni => `${ni.nodeNum}-${ni.neighborNodeNum}`));
+
+  const allNodeNums = [...new Set([
+    ...neighborInfo.map(ni => ni.nodeNum),
+    ...neighborInfo.map(ni => ni.neighborNodeNum),
+  ])];
+  const nodeMap = await databaseService.nodes.getNodesByNums(allNodeNums);
+
+  // Same channel gate the nodes endpoint uses, so a neighbor-info link whose
+  // endpoint nodes the user can't see doesn't leak their positions (#3092).
+  const visibleNodes = await filterNodesByChannelPermission(
+    Array.from(nodeMap.values()),
+    user,
+    source.id,
+  );
+  const visibleNodeNums = new Set(visibleNodes.map(n => Number((n as any).nodeNum)));
+
+  const enrichedNeighborInfo = neighborInfo
+    .filter(ni =>
+      visibleNodeNums.has(Number(ni.nodeNum)) &&
+      visibleNodeNums.has(Number(ni.neighborNodeNum)),
+    )
+    .map(ni => {
+      const node = nodeMap.get(ni.nodeNum) ?? null;
+      const neighbor = nodeMap.get(ni.neighborNodeNum) ?? null;
+      const nodePos = getEffectiveDbNodePosition(node);
+      const neighborPos = getEffectiveDbNodePosition(neighbor);
+
+      const TX_MQTT = 5;
+      const TX_UDP = 6;
+      const nTx = (node as any)?.transportMechanism;
+      const nbTx = (neighbor as any)?.transportMechanism;
+      const isMqtt = nTx === TX_MQTT || nbTx === TX_MQTT || (node as any)?.viaMqtt || (neighbor as any)?.viaMqtt;
+      const isUdp = nTx === TX_UDP || nbTx === TX_UDP;
+      const transportClass: 'rf' | 'udp' | 'mqtt' = isMqtt ? 'mqtt' : isUdp ? 'udp' : 'rf';
+
+      return {
+        ...ni,
+        nodeId: node?.nodeId || `!${ni.nodeNum.toString(16).padStart(8, '0')}`,
+        nodeName: node?.longName || `Node !${ni.nodeNum.toString(16).padStart(8, '0')}`,
+        neighborNodeId: neighbor?.nodeId || `!${ni.neighborNodeNum.toString(16).padStart(8, '0')}`,
+        neighborName: neighbor?.longName || `Node !${ni.neighborNodeNum.toString(16).padStart(8, '0')}`,
+        bidirectional: linkKeys.has(`${ni.neighborNodeNum}-${ni.nodeNum}`),
+        transportClass,
+        nodeLatitude: nodePos.latitude,
+        nodeLongitude: nodePos.longitude,
+        neighborLatitude: neighborPos.latitude,
+        neighborLongitude: neighborPos.longitude,
+        node,
+        neighbor,
+      };
+    })
+    .filter(ni => {
+      // Report-time freshness: show a neighbor edge only when its NeighborInfo
+      // report falls within the window (matches GET /api/analysis/neighbors).
+      const reportSec = Math.floor((ni.timestamp ?? 0) / 1000);
+      return reportSec >= cutoffTime;
+    })
+    .map(({ node: _node, neighbor: _neighbor, ...rest }) => rest);
+
+  return enrichedNeighborInfo;
+}
+
+export interface SourceDashboardPayload {
+  sourceId: string;
+  nodes: unknown[];
+  traceroutes: unknown[];
+  neighborInfo: unknown[];
+  channels: unknown[];
+}
+
+/**
+ * Aggregate the four dashboard datasets for a source in one shot, applying the
+ * same per-dataset permission gating the individual routes enforced via
+ * middleware:
+ *   - nodes / neighborInfo → `nodes:read`
+ *   - traceroutes          → `traceroute:read`
+ *   - channels             → self-gated per-channel inside buildSourceChannels
+ * A dataset the caller can't read comes back as `[]` (the individual route
+ * would have 403'd; here we degrade gracefully so one missing grant doesn't
+ * sink the whole dashboard).
+ */
+export async function buildSourceDashboard(source: SourceRow, user: ReqUser): Promise<SourceDashboardPayload> {
+  const isAdmin = user?.isAdmin === true;
+  const canReadNodes = isAdmin || (user ? await hasPermission(user, 'nodes', 'read', source.id) : false);
+  const canReadTraceroutes = isAdmin || (user ? await hasPermission(user, 'traceroute', 'read', source.id) : false);
+
+  const [nodes, traceroutes, neighborInfo, channels] = await Promise.all([
+    canReadNodes ? buildSourceNodes(source, user) : Promise.resolve([]),
+    canReadTraceroutes ? buildSourceTraceroutes(source, user) : Promise.resolve([]),
+    canReadNodes ? buildSourceNeighborInfo(source, user) : Promise.resolve([]),
+    buildSourceChannels(source, user),
+  ]);
+
+  return { sourceId: source.id, nodes, traceroutes, neighborInfo, channels };
+}

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -29,7 +29,7 @@ import {
   maskTraceroutesByChannel,
   getEffectiveDbNodePosition,
 } from '../utils/nodeEnhancer.js';
-import { modemPresetChannelName } from '../constants/meshtastic.js';
+import { modemPresetChannelName, TransportMechanism } from '../constants/meshtastic.js';
 import { transformChannel } from '../utils/channelView.js';
 import type { ResourceType } from '../../types/permission.js';
 import type { User } from '../../types/auth.js';
@@ -37,6 +37,12 @@ import type { User } from '../../types/auth.js';
 type SourceRow = { id: string; name: string; type: string };
 // The request user (null when anonymous), as attached by optionalAuth/requirePermission.
 type ReqUser = User | null;
+
+/** Resolve the global `maxNodeAgeHours` setting (default 24). */
+export async function getMaxNodeAgeHours(): Promise<number> {
+  const raw = await databaseService.settings.getSetting('maxNodeAgeHours');
+  return raw ? (parseInt(raw, 10) || 24) : 24;
+}
 
 /** Nodes for a source, channel-filtered and position-masked (mirrors GET /:id/nodes). */
 export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promise<unknown[]> {
@@ -198,13 +204,23 @@ export async function buildSourceTraceroutes(
   return maskTraceroutesByChannel(traceroutes, user, source.id);
 }
 
-/** Enriched neighbor-info for a source, channel-gated (mirrors GET /:id/neighbor-info). */
-export async function buildSourceNeighborInfo(source: SourceRow, user: ReqUser): Promise<unknown[]> {
+/**
+ * Enriched neighbor-info for a source, channel-gated (mirrors GET /:id/neighbor-info).
+ *
+ * `maxNodeAgeHours` is a GLOBAL setting; pass it in to avoid re-querying it once
+ * per source when fanning out across many sources (the unified dashboard route
+ * fetches it once). When omitted, it's fetched here so single-source callers
+ * stay self-contained.
+ */
+export async function buildSourceNeighborInfo(
+  source: SourceRow,
+  user: ReqUser,
+  maxNodeAgeHours?: number,
+): Promise<unknown[]> {
   const neighborInfo = await databaseService.neighbors.getAllNeighborInfo(source.id);
 
-  const maxNodeAgeStr = await databaseService.settings.getSetting('maxNodeAgeHours');
-  const maxNodeAgeHours = maxNodeAgeStr ? (parseInt(maxNodeAgeStr, 10) || 24) : 24;
-  const cutoffTime = Math.floor(Date.now() / 1000) - maxNodeAgeHours * 60 * 60;
+  const resolvedMaxAge = maxNodeAgeHours ?? await getMaxNodeAgeHours();
+  const cutoffTime = Math.floor(Date.now() / 1000) - resolvedMaxAge * 60 * 60;
 
   const linkKeys = new Set(neighborInfo.map(ni => `${ni.nodeNum}-${ni.neighborNodeNum}`));
 
@@ -234,12 +250,11 @@ export async function buildSourceNeighborInfo(source: SourceRow, user: ReqUser):
       const nodePos = getEffectiveDbNodePosition(node);
       const neighborPos = getEffectiveDbNodePosition(neighbor);
 
-      const TX_MQTT = 5;
-      const TX_UDP = 6;
       const nTx = (node as any)?.transportMechanism;
       const nbTx = (neighbor as any)?.transportMechanism;
-      const isMqtt = nTx === TX_MQTT || nbTx === TX_MQTT || (node as any)?.viaMqtt || (neighbor as any)?.viaMqtt;
-      const isUdp = nTx === TX_UDP || nbTx === TX_UDP;
+      const isMqtt = nTx === TransportMechanism.MQTT || nbTx === TransportMechanism.MQTT
+        || (node as any)?.viaMqtt || (neighbor as any)?.viaMqtt;
+      const isUdp = nTx === TransportMechanism.MULTICAST_UDP || nbTx === TransportMechanism.MULTICAST_UDP;
       const transportClass: 'rf' | 'udp' | 'mqtt' = isMqtt ? 'mqtt' : isUdp ? 'udp' : 'rf';
 
       return {
@@ -288,7 +303,11 @@ export interface SourceDashboardPayload {
  * would have 403'd; here we degrade gracefully so one missing grant doesn't
  * sink the whole dashboard).
  */
-export async function buildSourceDashboard(source: SourceRow, user: ReqUser): Promise<SourceDashboardPayload> {
+export async function buildSourceDashboard(
+  source: SourceRow,
+  user: ReqUser,
+  opts?: { maxNodeAgeHours?: number },
+): Promise<SourceDashboardPayload> {
   const isAdmin = user?.isAdmin === true;
   const canReadNodes = isAdmin || (user ? await hasPermission(user, 'nodes', 'read', source.id) : false);
   const canReadTraceroutes = isAdmin || (user ? await hasPermission(user, 'traceroute', 'read', source.id) : false);
@@ -296,7 +315,7 @@ export async function buildSourceDashboard(source: SourceRow, user: ReqUser): Pr
   const [nodes, traceroutes, neighborInfo, channels] = await Promise.all([
     canReadNodes ? buildSourceNodes(source, user) : Promise.resolve([]),
     canReadTraceroutes ? buildSourceTraceroutes(source, user) : Promise.resolve([]),
-    canReadNodes ? buildSourceNeighborInfo(source, user) : Promise.resolve([]),
+    canReadNodes ? buildSourceNeighborInfo(source, user, opts?.maxNodeAgeHours) : Promise.resolve([]),
     buildSourceChannels(source, user),
   ]);
 


### PR DESCRIPTION
## Summary

Fixes #3735 (source toggling trips the API rate limiter → 429s break the UI for 15 min) by cutting request **volume**, rather than exempting all GETs from the limiter as proposed in #3741.

### Why not just exempt GETs (#3741)?

`skip: ... || req.method === 'GET'` removes back-pressure entirely for reads — exactly what hammers low-powered or heavily-utilized servers. The actual problem is that the dashboard fires far too many requests:

- Per 15s poll, the unified view fetched **one GET per dataset per source**: nodes + traceroutes + neighbor-info + channels (**4×N**), plus status (**N**).
- At 5 sources that's ~25 req/15s ≈ **1.7/sec — already over the 1000-per-15-min (~1.1/sec) limit before the user touches anything.** Toggling just spikes it past the edge.

### Fix — batch the reads

**Backend**
- `src/server/services/sourceDashboardData.ts` — `buildSourceNodes/Channels/Traceroutes/NeighborInfo` extracted **verbatim** from the existing per-dataset handlers (same masking/gating), plus `buildSourceDashboard` which applies the same per-dataset permission checks the routes did via middleware.
- `GET /api/sources/:id/dashboard` — bundles a source's four datasets (single-source view: **5→1**).
- `GET /api/unified/dashboard?sources=` — one request for the entire unified view (**4N→1**). A dataset the caller can't read returns `[]` rather than 403-ing the whole bundle.
- The four individual endpoints (`/nodes`, `/traceroutes`, `/neighbor-info`, `/channels`) are now thin wrappers over the shared builders — **behavior unchanged**, proven by the existing `sourceRoutes.*` suites staying green.

**Frontend**
- `useDashboardSourceData` and `useDashboardUnifiedData` consume the aggregates.
- The source-toggle refresh is **debounced** so a flurry of rapid toggles coalesces into a single refetch cycle.

### Result

Unified view drops from ~`4N+N` to ~`1+N` requests per poll, and the existing rate limiter stays fully in place — no protection removed. This supersedes #3741.

## Tests
- `sourceRoutes.dashboard.test.ts` — bundle shape + per-dataset permission gating (denied dataset → `[]`, no wasted query).
- `unifiedRoutes.test.ts` — `/unified/dashboard` returns one bundle per source and honors `?sources=`.
- `useDashboardData.test.ts` — updated to assert the batched request shape.
- Full suite: **7544 passed, 0 failed**.

Closes #3735

🤖 Generated with [Claude Code](https://claude.com/claude-code)