### PR TITLE
feat(meshcore): show hop count + relay route below received messages (#3742) — Phase 1

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -292,6 +292,14 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                 </span>
               </div>
               <div className="mc-message-text">{renderMessageText(m.text)}</div>
+              {!outgoing && typeof m.hopCount === 'number' && (
+                <div className="mc-message-route" title={t('meshcore.route_tooltip', 'How this message reached you')}>
+                  {m.hopCount === 0
+                    ? t('meshcore.route_direct', '📍 direct')
+                    : `🛰 ${m.hopCount} ${m.hopCount === 1 ? t('meshcore.hop', 'hop') : t('meshcore.hops', 'hops')}`}
+                  {m.routePath ? ` · ${m.routePath.split(',').filter(Boolean).join(' → ')}` : ''}
+                </div>
+              )}
               {outgoing && m.heardBy && m.heardBy.length > 0 && expandedHeardBy.has(m.id) && (
                 <ul className="mc-heard-by-list">
                   {m.heardBy.map(h => (

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -297,7 +297,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                   {m.hopCount === 0
                     ? t('meshcore.route_direct', '📍 direct')
                     : `🛰 ${m.hopCount} ${m.hopCount === 1 ? t('meshcore.hop', 'hop') : t('meshcore.hops', 'hops')}`}
-                  {m.routePath ? ` · ${m.routePath.split(',').filter(Boolean).join(' → ')}` : ''}
+                  {m.hopCount !== 0 && m.routePath ? ` · ${m.routePath.split(',').filter(Boolean).join(' → ')}` : ''}
                 </div>
               )}
               {outgoing && m.heardBy && m.heardBy.length > 0 && expandedHeardBy.has(m.id) && (

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -711,6 +711,8 @@
 
 .mc-message-time { color: var(--ctp-overlay0); }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
+/* Hop count + relay route for received messages (#3742). */
+.mc-message-route { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
 
 .mc-mention {
   color: var(--ctp-blue);

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -85,6 +85,10 @@ export interface MeshCoreMessage {
    *  self-echo correlation (#3700). Best-effort; `name` is null when the relay
    *  hash couldn't be resolved to a known contact. */
   heardBy?: Array<{ hash: string; name?: string | null; snr?: number | null }>;
+  /** Hop count for a received message; null/undefined = direct or unknown (#3742). */
+  hopCount?: number | null;
+  /** Relay-hash chain the message traveled, comma-separated (e.g. "a3,7f,02") (#3742). */
+  routePath?: string | null;
 }
 
 export interface ConnectionStatus {

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 104 migrations registered', () => {
-    expect(registry.count()).toBe(104);
+  it('has all 105 migrations registered', () => {
+    expect(registry.count()).toBe(105);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_channel_database_hash', () => {
+  it('last migration is add_meshcore_message_route', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(104);
-    expect(last.name).toContain('add_channel_database_hash');
+    expect(last.number).toBe(105);
+    expect(last.name).toContain('add_meshcore_message_route');
   });
 
-  it('migrations are sequentially numbered from 1 to 104', () => {
+  it('migrations are sequentially numbered from 1 to 105', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -119,6 +119,7 @@ import { migration as nodeUnmessagableMigration, runMigration101Postgres as runN
 import { migration as meshcoreHeardRepeatersMigration, runMigration102Postgres as runMeshcoreHeardRepeatersPostgres, runMigration102Mysql as runMeshcoreHeardRepeatersMysql } from '../server/migrations/102_create_meshcore_heard_repeaters.js';
 import { migration as consolidateMqttChannelsMigration, runMigration103Postgres as runConsolidateMqttChannelsPostgres, runMigration103Mysql as runConsolidateMqttChannelsMysql } from '../server/migrations/103_consolidate_mqtt_channels.js';
 import { migration as channelDatabaseHashMigration, runMigration104Postgres as runChannelDatabaseHashPostgres, runMigration104Mysql as runChannelDatabaseHashMysql } from '../server/migrations/104_add_channel_database_hash.js';
+import { migration as meshcoreMessageRouteMigration, runMigration105Postgres as runMeshcoreMessageRoutePostgres, runMigration105Mysql as runMeshcoreMessageRouteMysql } from '../server/migrations/105_add_meshcore_message_route.js';
 
 // ============================================================================
 // Registry
@@ -1650,4 +1651,18 @@ registry.register({
   sqlite: (db) => channelDatabaseHashMigration.up(db),
   postgres: (client) => runChannelDatabaseHashPostgres(client),
   mysql: (pool) => runChannelDatabaseHashMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 105: add hopCount + routePath to meshcore_messages so received
+// MeshCore messages can show their hop count and relay route in the UI (#3742).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 105,
+  name: 'add_meshcore_message_route',
+  settingsKey: 'migration_105_add_meshcore_message_route',
+  sqlite: (db) => meshcoreMessageRouteMigration.up(db),
+  postgres: (client) => runMeshcoreMessageRoutePostgres(client),
+  mysql: (pool) => runMeshcoreMessageRouteMysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -225,6 +225,24 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.text).toBe('hello');
   });
 
+  it('insertMessage persists hopCount + routePath and reads them back (#3742)', async () => {
+    await repo.insertMessage(
+      { id: 'm-route', fromPublicKey: 'pk-1', text: 'relayed', timestamp: 2000, createdAt: 2000, hopCount: 2, routePath: 'a3,7f' },
+      'src-a',
+    );
+    await repo.insertMessage(
+      { id: 'm-direct', fromPublicKey: 'pk-1', text: 'direct', timestamp: 2001, createdAt: 2001, hopCount: 0, routePath: null },
+      'src-a',
+    );
+    const msgs = await repo.getRecentMessages(10, 'src-a');
+    const relayed = msgs.find((m) => m.id === 'm-route')!;
+    const direct = msgs.find((m) => m.id === 'm-direct')!;
+    expect(relayed.hopCount).toBe(2);
+    expect(relayed.routePath).toBe('a3,7f');
+    expect(direct.hopCount).toBe(0);
+    expect(direct.routePath).toBeNull();
+  });
+
   it('insertMessage throws when called without a sourceId', async () => {
     await expect(
       repo.insertMessage(

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -243,6 +243,20 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(direct.routePath).toBeNull();
   });
 
+  it('insertMessage leaves hopCount/routePath null when omitted (pre-migration rows)', async () => {
+    // A message inserted without the new fields (legacy callers, or rows that
+    // predate migration 105) must read back as null — not undefined — so the
+    // boot DB-load `?? null` mapping and the UI's `typeof === 'number'` guard
+    // behave correctly.
+    await repo.insertMessage(
+      { id: 'm-legacy', fromPublicKey: 'pk-1', text: 'no route', timestamp: 2002, createdAt: 2002 },
+      'src-a',
+    );
+    const legacy = (await repo.getRecentMessages(10, 'src-a')).find((m) => m.id === 'm-legacy')!;
+    expect(legacy.hopCount).toBeNull();
+    expect(legacy.routePath).toBeNull();
+  });
+
   it('insertMessage throws when called without a sourceId', async () => {
     await expect(
       repo.insertMessage(

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -93,6 +93,9 @@ export interface DbMeshCoreMessage {
   deliveredAt?: number | null;
   /** Owning source id; required on writes since slice 1 (migration 056). */
   sourceId?: string | null;
+  /** Hop count + relay-hash route path for received messages (#3742). */
+  hopCount?: number | null;
+  routePath?: string | null;
   createdAt: number;
 }
 

--- a/src/db/schema/meshcoreMessages.ts
+++ b/src/db/schema/meshcoreMessages.ts
@@ -30,6 +30,10 @@ export const meshcoreMessagesSqlite = sqliteTable('meshcore_messages', {
   // Signal quality at receive time
   rssi: integer('rssi'),
   snr: integer('snr'),
+  // Routing metadata for received messages (#3742): hop count (from path_len)
+  // and the comma-separated relay-hash chain (e.g. "a3,7f,02"). Null = direct/unknown.
+  hopCount: integer('hopCount'),
+  routePath: text('routePath'),
 
   // Message type (for future use: text, location, etc.)
   messageType: text('messageType').default('text'),
@@ -56,6 +60,8 @@ export const meshcoreMessagesPostgres = pgTable('meshcore_messages', {
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   rssi: pgInteger('rssi'),
   snr: pgInteger('snr'),
+  hopCount: pgInteger('hopCount'),
+  routePath: pgText('routePath'),
   messageType: pgText('messageType').default('text'),
   delivered: pgBoolean('delivered').default(false),
   deliveredAt: pgBigint('deliveredAt', { mode: 'number' }),
@@ -74,6 +80,8 @@ export const meshcoreMessagesMysql = mysqlTable('meshcore_messages', {
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   rssi: myInt('rssi'),
   snr: myInt('snr'),
+  hopCount: myInt('hopCount'),
+  routePath: myText('routePath'),
   messageType: myVarchar('messageType', { length: 32 }).default('text'),
   delivered: myBoolean('delivered').default(false),
   deliveredAt: myBigint('deliveredAt', { mode: 'number' }),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -983,14 +983,17 @@ class MeshCoreManager extends EventEmitter {
     const { event_type, data } = event;
 
     if (event_type === 'contact_message') {
-      // Prefer the per-packet relay-hash chain recovered from LogRxData
-      // (the actual hops THIS packet traversed). Fall back to the
-      // sender contact's cached outPath if the native backend didn't
-      // surface a LogRxData event for this packet (e.g. mid-buffer race
-      // or a backend that doesn't subscribe to raw logging).
       const hopCount = decodePathLenHopCount(data.path_len);
       const senderContact = this.resolveContactByPrefix(data.pubkey_prefix);
-      const route = formatPathHops(data.path_hops) || senderContact?.outPath || null;
+      // The displayed/stored route is ONLY the per-packet relay-hash chain
+      // recovered from LogRxData — the actual hops THIS packet traversed.
+      // We deliberately do NOT fall back to the contact's cached outPath here:
+      // outPath is the OUTBOUND path from us to the sender, not the inbound
+      // route the message took, so showing it would mislead (#3742 review).
+      const observedRoute = formatPathHops(data.path_hops);
+      // The {ROUTE} auto-ack template keeps the outPath fallback (existing
+      // behavior) so an ack can still cite a route when no LogRxData surfaced.
+      const ackRoute = observedRoute || senderContact?.outPath || null;
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
         fromPublicKey: data.pubkey_prefix,
@@ -1000,13 +1003,13 @@ class MeshCoreManager extends EventEmitter {
         snr: data.snr,
         sourceId: this.sourceId,
         hopCount,
-        routePath: route,
+        routePath: observedRoute,
       };
       this.addMessage(message);
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
-      void this.checkAutoAcknowledge(message, true, undefined, hopCount, route);
+      void this.checkAutoAcknowledge(message, true, undefined, hopCount, ackRoute);
       void this.checkAutoResponder(message, true, undefined);
     } else if (event_type === 'channel_message') {
       // MeshCore channel packets have no sender field on the wire — the sender's

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -379,6 +379,12 @@ export interface MeshCoreMessage {
    *  messages that were heard re-flooded. `name` is null when the relay hash
    *  couldn't be resolved to a known contact. */
   heardBy?: Array<{ hash: string; name?: string | null; snr?: number | null }>;
+  /** Hop count for a received message (from path_len); null = direct / unknown.
+   *  Room messages carry no path, so this stays null for them. (#3742) */
+  hopCount?: number | null;
+  /** Relay-hash chain the message traveled, comma-separated (e.g. "a3,7f,02");
+   *  null when no path was reported. (#3742) */
+  routePath?: string | null;
 }
 
 export interface MeshCoreStatus {
@@ -677,6 +683,8 @@ class MeshCoreManager extends EventEmitter {
         rssi: dbMsg.rssi ?? undefined,
         snr: dbMsg.snr ?? undefined,
         sourceId: dbMsg.sourceId ?? undefined,
+        hopCount: dbMsg.hopCount ?? null,
+        routePath: dbMsg.routePath ?? null,
       }));
     } catch (loadErr) {
       logger.warn(`[MeshCore:${this.sourceId}] Failed to load messages from DB: ${(loadErr as Error).message}`);
@@ -975,19 +983,6 @@ class MeshCoreManager extends EventEmitter {
     const { event_type, data } = event;
 
     if (event_type === 'contact_message') {
-      const message: MeshCoreMessage = {
-        id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        fromPublicKey: data.pubkey_prefix,
-        toPublicKey: this.localNode?.publicKey || 'local',
-        text: data.text,
-        timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
-        snr: data.snr,
-        sourceId: this.sourceId,
-      };
-      this.addMessage(message);
-      this.emit('message', message);
-      dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
-      logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
       // Prefer the per-packet relay-hash chain recovered from LogRxData
       // (the actual hops THIS packet traversed). Fall back to the
       // sender contact's cached outPath if the native backend didn't
@@ -996,6 +991,21 @@ class MeshCoreManager extends EventEmitter {
       const hopCount = decodePathLenHopCount(data.path_len);
       const senderContact = this.resolveContactByPrefix(data.pubkey_prefix);
       const route = formatPathHops(data.path_hops) || senderContact?.outPath || null;
+      const message: MeshCoreMessage = {
+        id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        fromPublicKey: data.pubkey_prefix,
+        toPublicKey: this.localNode?.publicKey || 'local',
+        text: data.text,
+        timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
+        snr: data.snr,
+        sourceId: this.sourceId,
+        hopCount,
+        routePath: route,
+      };
+      this.addMessage(message);
+      this.emit('message', message);
+      dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
+      logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
       void this.checkAutoAcknowledge(message, true, undefined, hopCount, route);
       void this.checkAutoResponder(message, true, undefined);
     } else if (event_type === 'channel_message') {
@@ -1006,6 +1016,11 @@ class MeshCoreManager extends EventEmitter {
       const prefixMatch = rawText.match(/^([^:\n]{1,32}):\s*(.*)$/s);
       const fromName = prefixMatch ? prefixMatch[1].trim() : undefined;
       const body = prefixMatch ? prefixMatch[2] : rawText;
+      // Channel messages carry no sender pubkey on the wire, so there
+      // is no contact outPath fallback for {ROUTE}. The LogRxData
+      // path_hops (when present) is the only source of relay identities.
+      const hopCount = decodePathLenHopCount(data.path_len);
+      const route = formatPathHops(data.path_hops);
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
         fromPublicKey: MeshCoreManager.channelPublicKey(data.channel_idx),
@@ -1014,16 +1029,13 @@ class MeshCoreManager extends EventEmitter {
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
         snr: data.snr,
         sourceId: this.sourceId,
+        hopCount,
+        routePath: route,
       };
       this.addMessage(message);
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore] Channel ${data.channel_idx} message: ${data.text}`);
-      // Channel messages carry no sender pubkey on the wire, so there
-      // is no contact outPath fallback for {ROUTE}. The LogRxData
-      // path_hops (when present) is the only source of relay identities.
-      const hopCount = decodePathLenHopCount(data.path_len);
-      const route = formatPathHops(data.path_hops);
       void this.checkAutoAcknowledge(message, false, data.channel_idx, hopCount, route);
       void this.checkAutoResponder(message, false, data.channel_idx);
     } else if (event_type === 'room_message') {
@@ -1746,6 +1758,8 @@ class MeshCoreManager extends EventEmitter {
         snr: message.snr ?? null,
         messageType: message.messageType ?? 'text',
         sourceId: this.sourceId,
+        hopCount: message.hopCount ?? null,
+        routePath: message.routePath ?? null,
         createdAt: Date.now(),
       },
       this.sourceId,

--- a/src/server/migrations/105_add_meshcore_message_route.ts
+++ b/src/server/migrations/105_add_meshcore_message_route.ts
@@ -1,0 +1,77 @@
+/**
+ * Migration 105: Add hopCount + routePath to meshcore_messages (#3742).
+ *
+ * Surfaces the hop count and relay-hash route path for received MeshCore
+ * channel/DM messages (already decoded for auto-ack {ROUTE}/{HOPS} templates,
+ * now persisted + shown in the UI). Both nullable; existing rows keep NULL
+ * (direct/unknown). Room messages carry no path, so they stay NULL.
+ *
+ * The meshcore_messages table uses camelCase columns on every backend.
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 105 (SQLite): Adding hopCount + routePath to meshcore_messages...');
+    for (const col of ['hopCount INTEGER', 'routePath TEXT']) {
+      try {
+        db.exec(`ALTER TABLE meshcore_messages ADD COLUMN ${col}`);
+        logger.debug(`Added meshcore_messages.${col.split(' ')[0]}`);
+      } catch (e: any) {
+        if (e.message?.includes('duplicate column')) {
+          logger.debug(`meshcore_messages.${col.split(' ')[0]} already exists, skipping`);
+        } else {
+          logger.warn(`Could not add meshcore_messages.${col.split(' ')[0]}:`, e.message);
+        }
+      }
+    }
+    logger.info('Migration 105 complete (SQLite): meshcore_messages route columns added');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 105 down: Not implemented (destructive column drop)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration105Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 105 (PostgreSQL): Adding hopCount + routePath to meshcore_messages...');
+  try {
+    await client.query('ALTER TABLE meshcore_messages ADD COLUMN IF NOT EXISTS "hopCount" INTEGER');
+    await client.query('ALTER TABLE meshcore_messages ADD COLUMN IF NOT EXISTS "routePath" TEXT');
+    logger.debug('Ensured meshcore_messages.hopCount + routePath exist');
+  } catch (error: any) {
+    logger.error('Migration 105 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+  logger.info('Migration 105 complete (PostgreSQL): meshcore_messages route columns added');
+}
+
+// ============ MySQL ============
+
+export async function runMigration105Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 105 (MySQL): Adding hopCount + routePath to meshcore_messages...');
+  try {
+    for (const [name, ddl] of [['hopCount', 'hopCount INT NULL'], ['routePath', 'routePath TEXT NULL']] as const) {
+      const [rows] = await pool.query(`
+        SELECT COLUMN_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_messages' AND COLUMN_NAME = ?
+      `, [name]);
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await pool.query(`ALTER TABLE meshcore_messages ADD COLUMN ${ddl}`);
+        logger.debug(`Added meshcore_messages.${name}`);
+      } else {
+        logger.debug(`meshcore_messages.${name} already exists, skipping`);
+      }
+    }
+  } catch (error: any) {
+    logger.error('Migration 105 (MySQL) failed:', error.message);
+    throw error;
+  }
+  logger.info('Migration 105 complete (MySQL): meshcore_messages route columns added');
+}


### PR DESCRIPTION
Phase 1 of #3742 (the hop-count + routing-path display the repo owner scoped in the issue thread; the reporter confirmed Phase 1 as the starting point).

## What
MeshCore already decodes a received message's **hop count** (`path_len`) and **relay-hash route** (`path_hops`) for the auto-ack `{ROUTE}`/`{HOPS}` templates, but that data was never persisted or shown. Now each received channel/DM message displays its route, like the native MeshCore app.

## Changes
- **Schema/migration**: `meshcore_messages` gains `hopCount` (int) + `routePath` (text), nullable, on all three backends. Migration **105** (idempotent). Existing rows and room messages (no path on the wire) stay `NULL`.
- **Manager** (`meshcoreManager.ts`): the `contact_message` and `channel_message` handlers now compute hop/route *before* building the message and store them on it; `addMessage` persists them, and the boot DB-load maps them back.
- **Frontend**: `MeshCoreMessageStream` renders a route line under received messages — `📍 direct` for 0 hops, otherwise `🛰 N hops · a3 → 7f → 02`. New `MeshCoreMessage` type fields; messages pass through the API/socket raw so no mapping churn.

## Deferred
**Phase 2 (scope display)** — resolving the message's scope hash against the user's known scope list — is a follow-on per the reporter; this PR lays the per-message display slot it can reuse.

## Tests
Migration registry count/last-name bumped to 105; a meshcore-repo insert+read round-trip asserts `hopCount`/`routePath` persist (incl. `0 hops` → "direct" and `NULL`). Full suite **7549 passed, 0 failures**; server `tsc` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)