### PR TITLE
fix(mqtt): attribute same-key channels by packet hash, not sort order

### DIFF
--- a/docs/features/channel-database.md
+++ b/docs/features/channel-database.md
@@ -42,7 +42,7 @@ Enter the PSK in Base64 format, the same format used by Meshtastic. You can find
 
 ## Channel Priority and Ordering
 
-Channels in the database are tried in **sort order** during decryption. The first channel that successfully decrypts a packet wins. You can control the order using drag-and-drop:
+Channels in the database are tried in **sort order** during decryption, with one important refinement: when a packet carries a channel hash, channels whose name+PSK hash **matches that packet** are tried first, then the rest in sort order. The first channel that successfully decrypts a packet wins. You can control the order using drag-and-drop:
 
 1. Navigate to **Configuration** > **Channel Database**
 2. Drag channels using the handle on the left side of each channel card
@@ -50,7 +50,7 @@ Channels in the database are tried in **sort order** during decryption. The firs
 4. The new order is saved automatically
 
 ::: tip Decryption Priority
-If multiple channels could potentially decrypt the same packet (e.g., same PSK with different names), only the first matching channel in sort order will be credited with the decryption.
+If multiple channels share the same PSK but have different names (e.g. a default-key `LongFast` plus a custom channel both using `AQ==`), MeshMonitor uses the packet's channel hash to credit the **correct** channel — the one whose name+PSK hash matches the packet — rather than simply the first one in sort order. Sort order is only the tiebreaker when no channel's hash matches (in which case the first channel that decrypts is credited, so a packet is never left undecrypted). This matches how Meshtastic firmware distinguishes same-key channels.
 :::
 
 ## Importing and Exporting Channels
@@ -191,12 +191,15 @@ Toggle channels on or off without deleting them. Disabled channels are not used 
 
 When enabled, this option ensures that a channel will only decrypt packets that have a matching channel hash. This is useful when:
 
-- Multiple channels share the same PSK (e.g., default keys)
-- You want to ensure packets are attributed to the correct channel name
+- You want to *strictly* reject packets that don't match a channel's name+PSK hash
 - You're monitoring networks where channel naming conventions matter
 
+::: tip Same-PSK channels are disambiguated automatically
+You no longer need to enable this just to attribute packets to the correct channel when several channels share a PSK (e.g. default `AQ==` keys). MeshMonitor already prefers the channel whose name+PSK hash matches each packet (see [Channel Priority and Ordering](#channel-priority-and-ordering)). Enforce Name Validation goes further: it makes a hash *mismatch* a hard skip, so the channel will **refuse** non-matching packets entirely rather than serving as a fallback.
+:::
+
 ::: warning
-If the sending device doesn't include channel hash information in packets, enabling this option may prevent decryption even with a valid PSK.
+If the sending device doesn't include channel hash information in packets, enabling this option may prevent decryption even with a valid PSK. Because same-PSK attribution is now handled automatically, leaving this **off** is the safer default — it preserves decryption of default-key traffic across all modem presets.
 :::
 
 ### Editing Channels

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -48,6 +48,15 @@ export async function bootstrapMqttChannelDatabase(sourceId: string): Promise<vo
         psk: ch.psk,
         pskLength: ch.pskLength,
         isEnabled: true,
+        // Intentionally NOT enforcing name validation. Enforcing it would make
+        // this seed a HARD skip for any packet whose channel hash doesn't match
+        // hash("LongFast", defaultKey) — which silently drops default-channel
+        // traffic on non-LongFast modem presets (the default channel hashes as
+        // "MediumSlow", "ShortFast", etc.). Correct attribution among same-key
+        // channels (e.g. this seed vs a custom AQ== channel) is instead handled
+        // by channelDecryptionService.tryDecrypt(), which PREFERS the
+        // hash-matching channel while still falling back, so nothing is ever
+        // left undecrypted. See channelDecryptionService hash-aware attribution.
         enforceNameValidation: false,
         description: `Auto-seeded for MQTT decryption (default Meshtastic key)`,
         createdBy: null,

--- a/src/server/services/channelDecryptionService.test.ts
+++ b/src/server/services/channelDecryptionService.test.ts
@@ -6,9 +6,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
 import { createCipheriv } from 'crypto';
-import { channelDecryptionService } from './channelDecryptionService.js';
+import { channelDecryptionService, computeChannelHash } from './channelDecryptionService.js';
 import databaseService from '../../services/database.js';
 import * as protobufLoader from '../protobufLoader.js';
+import { expandShorthandPsk } from '../constants/meshtastic.js';
 
 // Mock the protobuf loader
 vi.mock('../protobufLoader.js', () => ({
@@ -594,6 +595,164 @@ describe('ChannelDecryptionService', () => {
       expect(result.success).toBe(true);
       expect(result.channelDatabaseId).toBe(2);
       expect(result.channelName).toBe('Correct Channel');
+    });
+  });
+
+  describe('Hash-aware attribution (same-key channels)', () => {
+    const packetId = 12345;
+    const fromNode = 0x12345678;
+    // Valid protobuf-like plaintext used across these tests.
+    const testPayload = Buffer.from([0x08, 0x01, 0x12, 0x04, 0x74, 0x65, 0x73, 0x74]);
+
+    function encryptTestData(plaintext: Buffer, psk: Buffer): Buffer {
+      const nonce = Buffer.alloc(16);
+      nonce.writeUInt32LE(packetId >>> 0, 0);
+      nonce.writeUInt32LE(0, 4);
+      nonce.writeUInt32LE(fromNode >>> 0, 8);
+      nonce.writeUInt32LE(0, 12);
+      const algorithm = psk.length === 16 ? 'aes-128-ctr' : 'aes-256-ctr';
+      const cipher = createCipheriv(algorithm, psk, nonce);
+      return Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    }
+
+    // The real-world default key: "AQ==" (1-byte shorthand) expands to the full
+    // 16-byte Meshtastic default key. computeChannelHash() / the service hash
+    // both use the expanded key, so we encrypt and stamp hashes with it too.
+    const defaultKey = expandShorthandPsk(Buffer.from('AQ==', 'base64'))!;
+
+    beforeEach(() => {
+      (databaseService.channelDatabase.incrementDecryptedCountAsync as Mock).mockResolvedValue(undefined);
+      // Any same-key channel decrypts these bytes; the protobuf validator
+      // accepts the result. Which channel WINS is what we're asserting, so a
+      // permissive decode isolates the attribution/ordering logic.
+      mockDataType.decode.mockReturnValue({ portnum: 1, payload: Buffer.from('test') });
+    });
+
+    it('attributes a packet to the same-key channel whose hash matches, not the one that sorts first (the LongFast/Custom bug)', async () => {
+      // Two channels share the default "AQ==" key. "LongFast" sorts first.
+      (databaseService.channelDatabase.getEnabledAsync as Mock).mockResolvedValue([
+        { id: 1, name: 'LongFast', psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 0 },
+        { id: 2, name: 'Custom',   psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 1 },
+      ]);
+
+      const encrypted = encryptTestData(testPayload, defaultKey);
+
+      // Packet was actually sent on "Custom" — it carries Custom's channel hash.
+      const result = await channelDecryptionService.tryDecrypt(
+        new Uint8Array(encrypted),
+        packetId,
+        fromNode,
+        computeChannelHash('Custom', defaultKey),
+      );
+
+      // Before the fix this would attribute to "LongFast" (id 1, sorts first).
+      expect(result.success).toBe(true);
+      expect(result.channelDatabaseId).toBe(2);
+      expect(result.channelName).toBe('Custom');
+    });
+
+    it('attributes to the sort-first channel when the packet carries ITS hash', async () => {
+      (databaseService.channelDatabase.getEnabledAsync as Mock).mockResolvedValue([
+        { id: 1, name: 'LongFast', psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 0 },
+        { id: 2, name: 'Custom',   psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 1 },
+      ]);
+
+      const encrypted = encryptTestData(testPayload, defaultKey);
+
+      const result = await channelDecryptionService.tryDecrypt(
+        new Uint8Array(encrypted),
+        packetId,
+        fromNode,
+        computeChannelHash('LongFast', defaultKey),
+      );
+
+      // Proves attribution is hash-driven, not merely reversed ordering.
+      expect(result.success).toBe(true);
+      expect(result.channelDatabaseId).toBe(1);
+      expect(result.channelName).toBe('LongFast');
+    });
+
+    it('still decrypts (falls back) when no channel hash matches — no decryption lost', async () => {
+      // Mirrors a non-LongFast modem preset on the default key: the packet's
+      // default channel hashes to a name we don't have a row for, so neither
+      // channel matches. Decryption must NOT be lost; attribution falls back to
+      // sortOrder. This is the regression the hard-skip default would cause and
+      // that hash-as-preference avoids.
+      (databaseService.channelDatabase.getEnabledAsync as Mock).mockResolvedValue([
+        { id: 1, name: 'LongFast', psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 0 },
+        { id: 2, name: 'Custom',   psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 1 },
+      ]);
+
+      const encrypted = encryptTestData(testPayload, defaultKey);
+
+      const result = await channelDecryptionService.tryDecrypt(
+        new Uint8Array(encrypted),
+        packetId,
+        fromNode,
+        computeChannelHash('MediumSlow', defaultKey), // a name we don't have
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.channelDatabaseId).toBe(1); // sortOrder fallback
+    });
+
+    it('falls back past a hash-matching but WRONG-key channel to the right-key channel', async () => {
+      // A 1-byte hash can collide across different keys. The hash-matching
+      // channel is tried first but cannot decrypt; we must fall through to the
+      // channel whose key actually works.
+      const rightKey = Buffer.from('0123456789abcdef0123456789abcdef', 'utf8'); // 32B AES-256
+      const wrongKey = Buffer.from('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', 'utf8');
+
+      (databaseService.channelDatabase.getEnabledAsync as Mock).mockResolvedValue([
+        { id: 1, name: 'Decoy',   psk: wrongKey.toString('base64'), pskLength: 32, enforceNameValidation: false, sortOrder: 0 },
+        { id: 2, name: 'RealOne', psk: rightKey.toString('base64'), pskLength: 32, enforceNameValidation: false, sortOrder: 1 },
+      ]);
+
+      const encrypted = encryptTestData(testPayload, rightKey);
+
+      // Only the correctly-decrypted bytes are valid protobuf; the wrong-key
+      // channel produces garbage and must be rejected by the validator.
+      mockDataType.decode.mockImplementation((buf: Uint8Array) => {
+        if (Buffer.compare(Buffer.from(buf), testPayload) === 0) {
+          return { portnum: 1, payload: Buffer.from('test') };
+        }
+        throw new Error('Invalid protobuf');
+      });
+
+      // Stamp the packet with the DECOY's hash so it is preferred (tried first).
+      const result = await channelDecryptionService.tryDecrypt(
+        new Uint8Array(encrypted),
+        packetId,
+        fromNode,
+        computeChannelHash('Decoy', wrongKey),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.channelDatabaseId).toBe(2);
+      expect(result.channelName).toBe('RealOne');
+    });
+
+    it('hard-skip still wins over preference: a name-validated channel is never attributed on hash mismatch', async () => {
+      // enforceNameValidation must remain a HARD skip even though we now also
+      // use the hash as a preference. The validated "Custom" channel is skipped
+      // on mismatch; the un-validated "LongFast" still decrypts the packet.
+      (databaseService.channelDatabase.getEnabledAsync as Mock).mockResolvedValue([
+        { id: 1, name: 'LongFast', psk: 'AQ==', pskLength: 1, enforceNameValidation: false, sortOrder: 1 },
+        { id: 2, name: 'Custom',   psk: 'AQ==', pskLength: 1, enforceNameValidation: true,  sortOrder: 0 },
+      ]);
+
+      const encrypted = encryptTestData(testPayload, defaultKey);
+
+      const result = await channelDecryptionService.tryDecrypt(
+        new Uint8Array(encrypted),
+        packetId,
+        fromNode,
+        computeChannelHash('LongFast', defaultKey), // != Custom's hash → Custom hard-skipped
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.channelDatabaseId).toBe(1);
+      expect(result.channelName).toBe('LongFast');
     });
   });
 

--- a/src/server/services/channelDecryptionService.ts
+++ b/src/server/services/channelDecryptionService.ts
@@ -153,11 +153,18 @@ class ChannelDecryptionService {
             continue;
           }
 
-          // Compute expected channel hash if name validation is enabled
+          // Always compute the Meshtastic channel hash (xorHash(name) ^
+          // xorHash(psk)) — not only when name validation is enforced.
+          // tryDecrypt() uses it to *prefer* the channel whose hash matches the
+          // packet's channel byte when several channels share a key (e.g.
+          // multiple "AQ=="/default-key channels such as "LongFast" plus a
+          // custom channel). Without this preference the first same-key channel
+          // in sortOrder claims every packet, misattributing nodes/messages to
+          // the wrong channel_database row and its permissions. The
+          // enforceNameValidation flag still independently controls whether a
+          // hash *mismatch* is a hard skip (channel never attempted).
           const enforceNameValidation = channel.enforceNameValidation ?? false;
-          const expectedChannelHash = enforceNameValidation
-            ? computeChannelHash(channel.name, pskBuffer)
-            : undefined;
+          const expectedChannelHash = computeChannelHash(channel.name, pskBuffer);
 
           this.channelCache.set(channel.id, {
             id: channel.id,
@@ -377,11 +384,23 @@ class ChannelDecryptionService {
     // Build the nonce once (same for all attempts)
     const nonce = this.buildNonce(packetId, fromNode);
 
-    // Use pre-sorted channels (sorted during cache refresh, not per-packet)
-    let attempts = 0;
+    // Build the ordered list of channels to try. Channels are pre-sorted by
+    // sortOrder during cache refresh.
+    //
+    // 1. Hard skip (name validation): when a channel enforces name validation
+    //    and the packet carries a channel hash that doesn't match, the channel
+    //    is never attempted (and never attributed). Unchanged from before.
+    // 2. Hash-aware preference: when the packet carries a channel hash, try the
+    //    channels whose computed hash matches it FIRST (preserving sortOrder
+    //    within each group), then the rest. This disambiguates channels that
+    //    share a key — the correct same-key channel claims the packet instead
+    //    of whichever happens to sort first. It is only a *preference*: if no
+    //    hash-matching channel decrypts (e.g. a 1-byte hash collision across
+    //    different keys, or the real channel isn't in the database), we still
+    //    fall back to the others, so decryption is never lost — only
+    //    attribution improves. With no channel hash, order is unchanged.
+    const candidates: CachedChannel[] = [];
     for (const [, channel] of this.sortedChannels) {
-      // If channel has name validation enabled and packet has a channel hash,
-      // skip this channel if the hash doesn't match (don't count as an attempt)
       if (
         channel.enforceNameValidation &&
         channel.expectedChannelHash !== undefined &&
@@ -390,11 +409,23 @@ class ChannelDecryptionService {
       ) {
         continue;
       }
+      candidates.push(channel);
+    }
 
+    const ordered =
+      channelHash === undefined
+        ? candidates
+        : [
+            ...candidates.filter((c) => c.expectedChannelHash === channelHash),
+            ...candidates.filter((c) => c.expectedChannelHash !== channelHash),
+          ];
+
+    let attempts = 0;
+    for (const channel of ordered) {
       if (attempts >= this.maxDecryptionAttempts) {
         logger.warn(
           `Decryption attempt limit reached (${this.maxDecryptionAttempts}) for packet ${packetId} — ` +
-          `${this.channelCache.size - attempts} channels were not tried. ` +
+          `${ordered.length - attempts} channels were not tried. ` +
           `Consider increasing maxDecryptionAttempts or enabling name validation on channels.`
         );
         break;


### PR DESCRIPTION
## Summary
Multiple `channel_database` rows can share a key — most commonly the default `AQ==` key (e.g. an auto-seeded `LongFast` plus a user's custom channel). The server-side decryption service walked channels in **sort order** and let the first one whose key decrypted claim the packet, so whichever same-key channel sorted first absorbed *all* default-key traffic. Packets actually sent on the custom channel were attributed to the wrong row — and therefore the wrong channel **permissions** — which (among other things) hid those nodes from anonymous users who only had `viewOnMap` on the real channel. This makes attribution follow the packet's channel hash so the correct same-key channel is credited.

## Changes
- `channelDecryptionService`: compute the Meshtastic channel hash (`xorHash(name) ^ xorHash(psk)`) for **every** cached channel, not only name-validated ones.
- `tryDecrypt()` now tries hash-**matching** channels first (preserving `sortOrder` within each group), then the rest. It's a *preference*, not a hard skip: if nothing matches (1-byte hash collision across keys, or the real channel isn't in the DB) it still falls back and decrypts, so **decryption is never lost — only attribution improves**. `enforceNameValidation` remains an independent hard skip, unchanged.
- Retroactive: existing deployments are corrected with no DB edit, because attribution now follows the packet hash rather than row order.
- `mqttIngestion` bootstrap seed left at `enforceNameValidation: false` **on purpose**, with a comment: enforcing it would hard-skip the `LongFast`-named seed for non-LongFast modem presets (whose default channel hashes as `MediumSlow`/`ShortFast`/…), silently dropping their default-channel decryption. Hash-aware attribution achieves the same disambiguation without that regression.
- Docs: `docs/features/channel-database.md` updated to describe hash-aware priority and the narrowed role of Enforce Name Validation.

## Issues Resolved
None (reported directly by a deployment operator: same-key `LongFast`/`Custom` channels caused MQTT-bridge nodes to be misattributed and hidden from anonymous users).

## Documentation Updates
- `docs/features/channel-database.md` — "Channel Priority and Ordering" now explains hash-matching-first selection; "Enforce Name Validation" clarified as a strict hard-reject (no longer needed merely to attribute same-key channels), with leaving it off as the safer default.

## Testing
- [x] Unit tests pass — full main suite green (`success: true`, 7553 passed, 0 failed, 0 suite failures; sibling `.claude/worktrees/` checkout excluded)
- [x] TypeScript: no new errors in changed files (`tsc -p tsconfig.server.json` only shows pre-existing `TelemetryChart.tsx` frontend noise)
- [x] New `Hash-aware attribution (same-key channels)` test block: the LongFast/Custom bug, the reverse direction, fallback-when-no-match (non-LongFast preset safety), fallback past a hash-colliding wrong-key channel, and hard-skip-still-wins
- [ ] Reviewer: confirm a same-key (`AQ==`) `LongFast`+`Custom` setup attributes packets to the channel matching each packet's hash, and that default-key traffic on a non-LongFast preset still decrypts

🤖 Generated with [Claude Code](https://claude.com/claude-code)