### PR TITLE
fix(dashboard): scope local-node injection lookup to the source (no cross-source leak)

### DIFF
--- a/src/server/routes/sourceRoutes.dashboard.test.ts
+++ b/src/server/routes/sourceRoutes.dashboard.test.ts
@@ -40,6 +40,9 @@ vi.mock('../meshtasticManager.js', () => ({
   MeshtasticManager: vi.fn().mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() })),
 }));
 
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+const mockRegistry = sourceManagerRegistry as any;
+
 const mockDb = databaseService as any;
 const MOCK_SOURCE = { id: 'src-mqtt', name: 'Test MQTT', type: 'mqtt_broker', enabled: true };
 
@@ -111,5 +114,26 @@ describe('GET /:id/dashboard — bundled source datasets', () => {
     expect(Array.isArray(res.body.nodes)).toBe(true);
     expect(Array.isArray(res.body.channels)).toBe(true);
     expect(Array.isArray(res.body.neighborInfo)).toBe(true);
+  });
+
+  it('scopes the local-node injection lookup to the source (no cross-source leak)', async () => {
+    // Local node not yet in this source's node list → the injection path fetches
+    // its full record. That lookup MUST be source-scoped, or getNode's
+    // cross-source first-match could inject another source's row (#3735 review).
+    mockDb.nodes.getAllNodes.mockResolvedValue([]); // local node absent from list
+    mockDb.nodes.getNode.mockResolvedValue(null);   // not stored under this source yet
+    mockRegistry.getManager.mockReturnValue({
+      sourceId: 'src-mqtt',
+      getLocalNodeInfo: () => ({ nodeNum: 42, nodeId: '!0000002a', longName: 'Local', shortName: 'LCL' }),
+    });
+
+    const res = await request(createApp(adminUser)).get('/src-mqtt/dashboard');
+
+    expect(res.status).toBe(200);
+    expect(mockDb.nodes.getNode).toHaveBeenCalledWith(42, 'src-mqtt');
+    // Falls through to the synthesized minimal record for this source.
+    expect(res.body.nodes).toHaveLength(1);
+    expect(res.body.nodes[0].nodeNum).toBe(42);
+    expect(res.body.nodes[0].sourceId).toBe('src-mqtt');
   });
 });

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -96,7 +96,13 @@ export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promis
   if (manager) {
     const localNodeInfo = manager.getLocalNodeInfo();
     if (localNodeInfo && localNodeInfo.nodeNum && !nodes.some(n => n.nodeNum === localNodeInfo.nodeNum)) {
-      const localNode = await databaseService.nodes.getNode(localNodeInfo.nodeNum);
+      // Scope the lookup to THIS source. `getNode(nodeNum)` without a sourceId
+      // does a cross-source first-match, which on a multi-source deployment can
+      // inject another source's row (and its position) into this source's node
+      // list when both have heard the same nodeNum (#3735 review). Per-source
+      // scoping keeps the feed isolated; if this source hasn't stored the local
+      // node yet, fall through to the synthesized minimal record below.
+      const localNode = await databaseService.nodes.getNode(localNodeInfo.nodeNum, source.id);
       if (localNode) {
         nodes.push(localNode);
       } else {


### PR DESCRIPTION
## Summary

Tightens a pre-existing cross-source edge case surfaced in the #3748 review.

`buildSourceNodes` injects the manager's local node (when it isn't already in the source's node list) by fetching its full DB record. That lookup was calling `getNode(localNodeInfo.nodeNum)` with **no `sourceId`** — and `getNode` without a `sourceId` does a cross-source first-match. On a multi-source deployment where two sources have heard the same `nodeNum`, this could inject **another source's row (and its position)** into the current source's node list.

Fix: pass `source.id` so the lookup is per-source. If this source hasn't stored the local node yet, it falls through to the synthesized minimal record exactly as before. The `/:id/status` route already scoped this lookup correctly (`getNode(nodeNum, source.id)`); this brings the nodes path in line.

### History
This was verbatim pre-existing behavior in the `/:id/nodes` route (`origin/main` `sourceRoutes.ts:990`, commented *"regardless of sourceId"*), carried over unchanged during the #3748 extraction so that PR stayed behavior-preserving. Now that both the `/:id/nodes` and `/:id/dashboard` (+ `/unified/dashboard`) callers share `buildSourceNodes`, this one-line fix corrects all of them.

## Tests
- `sourceRoutes.dashboard.test.ts` — new case asserting the injection lookup is called with `(nodeNum, source.id)` and falls through to the source-scoped synthesized record.
- Full suite: **7554 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)