### PR TITLE
fix(meshcore): exclude repeaters from DM peer list; disable send for repeater selection (#3755)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -68,6 +68,33 @@ function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions 
     setTelemetryModeEnv: vi.fn().mockResolvedValue(true),
     refreshAll: vi.fn().mockResolvedValue(undefined),
     clearError: vi.fn(),
+    resetContactPath: vi.fn().mockResolvedValue(true),
+    shareContact: vi.fn().mockResolvedValue({ ok: true }),
+    setContactOutPath: vi.fn().mockResolvedValue(true),
+    traceContactPath: vi.fn().mockResolvedValue(null),
+    discoverContactPath: vi.fn().mockResolvedValue(true),
+    discoverNodes: vi.fn().mockResolvedValue(null),
+    getDiscoverable: vi.fn().mockResolvedValue(false),
+    setDiscoverable: vi.fn().mockResolvedValue(false),
+    getDefaultScope: vi.fn().mockResolvedValue(''),
+    setDefaultScope: vi.fn().mockResolvedValue(null),
+    discoverRegions: vi.fn().mockResolvedValue(null),
+    removeContact: vi.fn().mockResolvedValue(true),
+    setNodeFavorite: vi.fn().mockResolvedValue(true),
+    exportContact: vi.fn().mockResolvedValue(null),
+    importContact: vi.fn().mockResolvedValue(false),
+    syncDeviceTime: vi.fn().mockResolvedValue(false),
+    getNeighbours: vi.fn().mockResolvedValue(null),
+    rebootDevice: vi.fn().mockResolvedValue(false),
+    exportPrivateKey: vi.fn().mockResolvedValue(null),
+    importPrivateKey: vi.fn().mockResolvedValue(false),
+    setTxPower: vi.fn().mockResolvedValue(false),
+    loginRemote: vi.fn().mockResolvedValue({ success: false }),
+    loginRemoteWithSaved: vi.fn().mockResolvedValue({ success: false }),
+    sendCliCommand: vi.fn().mockResolvedValue(null),
+    forgetRemoteCredential: vi.fn().mockResolvedValue(undefined),
+    getRemoteAdminCapability: vi.fn().mockResolvedValue(null),
+    getRemoteStatus: vi.fn().mockResolvedValue(null),
     ...overrides,
   };
 }
@@ -388,6 +415,63 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     await waitFor(() => {
       const urls = csrfFetchMock.mock.calls.map(c => c[0] as string);
       expect(urls.some(u => u.includes(REAL_PK_2))).toBe(true);
+    });
+  });
+
+  // Issue #3755: repeaters (advType=2) cannot receive DMs — they must not
+  // appear in the DM peer sidebar list.
+  it('excludes repeater contacts (advType=2) from the DM peer list', () => {
+    const repeaterContact: MeshCoreContact = {
+      publicKey: 'e'.repeat(64),
+      advName: 'My Repeater',
+      advType: 2,
+      lastSeen: Date.now(),
+    };
+    const companionContact: MeshCoreContact = {
+      publicKey: 'f'.repeat(64),
+      advName: 'My Companion',
+      advType: 1,
+      lastSeen: Date.now(),
+    };
+
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={[repeaterContact, companionContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+
+    expect(screen.queryByText('My Repeater')).toBeNull();
+    expect(screen.getByText('My Companion')).toBeTruthy();
+  });
+
+  // Issue #3755: if a repeater IS somehow selected (e.g. navigated via the
+  // nodes view "›" button), the message send input must be disabled.
+  it('disables the send input when the selected contact is a repeater (advType=2)', async () => {
+    const repeaterContact: MeshCoreContact = {
+      publicKey: 'e'.repeat(64),
+      advName: 'My Repeater',
+      advType: 2,
+      lastSeen: Date.now(),
+    };
+
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={[repeaterContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        initialSelectedContact={'e'.repeat(64)}
+      />,
+    );
+
+    // The message compose input only appears once `selected` is set (via
+    // useEffect from initialSelectedContact). Wait for it, then verify disabled.
+    await waitFor(() => {
+      const sendInput = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+      expect(sendInput.disabled).toBe(true);
     });
   });
 

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -182,8 +182,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     }
     // Always include all contacts so the user can start a new DM.
     // Exclude room servers (advType=3) — they belong in the Rooms view.
+    // Exclude repeaters (advType=2) — they cannot receive direct messages.
     for (const c of contacts) {
-      if (c.publicKey && !isChannelPseudoKey(c.publicKey) && c.advType !== 3) peers.add(c.publicKey);
+      if (c.publicKey && !isChannelPseudoKey(c.publicKey) && c.advType !== 3 && c.advType !== 2) peers.add(c.publicKey);
     }
     // Drop the local node — DMing yourself is meaningless and the local node
     // sometimes appears in the contacts list as a side-effect of seeding.
@@ -380,7 +381,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               messages={filtered}
               contacts={contacts}
               selfPublicKey={selfKey}
-              disabled={!connected || !canSend}
+              disabled={!connected || !canSend || contactsByKey.get(selected)?.advType === 2}
               emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
               onSend={text => actions.sendMessage(text, selected)}
               conversationKey={`dm-${selected}`}


### PR DESCRIPTION
## Summary

Fixes #3755 — repeaters (`advType=2`) cannot receive direct messages, but were showing up in the DM contact sidebar and leaving the send bar enabled. This produced misleading "delivered" indicators for messages that were never actually received.

- Exclude repeater contacts from the DM peer sidebar list, matching the existing room-server (`advType=3`) exclusion.
- Disable the message compose input when the selected peer is a repeater — defence-in-depth for navigation via the nodes-view "›" button, which can reach a repeater even if it isn't in the sidebar list.
- Two regression tests: repeater absent from sidebar; send input disabled when a repeater is pre-selected via `initialSelectedContact`.
- Expanded `makeActions()` mock in the DM view tests to cover remote-admin actions (`getRemoteAdminCapability` etc.) so repeater contact-detail panels render cleanly in the JSDOM environment.

## Test plan

- [x] New regression tests pass: repeater excluded from DM list; send input disabled for repeater selection
- [x] Full Vitest suite: 7508 passed, 3 pre-existing failures in `mqttBrokerManager.test.ts` (unrelated)
- [ ] Reviewer: confirm a repeater contact does not appear in the DM sidebar, and navigating to it via "›" in the nodes view greyed-out the send bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCT8z33322WjjBVSqSXhb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCT8z33322WjjBVSqSXhb5)_