### PR TITLE
fix(meshcore): block DMs to repeaters with explanatory notice (#3755)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -240,8 +240,11 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     if (isMobileViewport()) setMobileShowContent(true);
   };
 
+  const selectedContact = selected ? (contactsByKey.get(selected) ?? null) : null;
+  const isRepeater = (selectedContact?.advType ?? 0) === 2;
+
   const selectedContactName = selected
-    ? (contactsByKey.get(selected)?.advName || contactsByKey.get(selected)?.name || `${selected.substring(0, 8)}…`)
+    ? (selectedContact?.advName || selectedContact?.name || `${selected.substring(0, 8)}…`)
     : '';
 
   const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
@@ -384,6 +387,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
               onSend={text => actions.sendMessage(text, selected)}
               conversationKey={`dm-${selected}`}
+              readOnlyNotice={isRepeater
+                ? t('meshcore.repeater_no_dm', 'Repeaters cannot receive direct messages.')
+                : undefined}
             />
             <div className="meshcore-detail-pane">
               <MeshCoreContactDetailPanel

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -16,6 +16,9 @@ interface MeshCoreMessageStreamProps {
   /** Stable key identifying the current conversation. When it changes, the
    *  stream scrolls to the bottom. */
   conversationKey?: string;
+  /** When set, replaces the send bar with this notice text (e.g. for node
+   *  types that cannot receive DMs). */
+  readOnlyNotice?: string;
 }
 
 function formatTime(ts: number): string {
@@ -60,6 +63,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   onSend,
   onNodeNameClick,
   conversationKey,
+  readOnlyNotice,
 }) => {
   const { t } = useTranslation();
   const [draft, setDraft] = useState('');
@@ -310,23 +314,29 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
           );
         })}
       </div>
-      <div className="meshcore-send-bar">
-        <input
-          type="text"
-          value={draft}
-          onChange={e => setDraft(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={t('meshcore.type_message', 'Type a message…')}
-          disabled={disabled || sending}
-          maxLength={230}
-        />
-        <button
-          onClick={() => void handleSend()}
-          disabled={disabled || sending || !draft.trim()}
-        >
-          {sending ? t('meshcore.sending', 'Sending…') : t('meshcore.send', 'Send')}
-        </button>
-      </div>
+      {readOnlyNotice ? (
+        <div className="meshcore-readonly-notice">
+          {readOnlyNotice}
+        </div>
+      ) : (
+        <div className="meshcore-send-bar">
+          <input
+            type="text"
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={t('meshcore.type_message', 'Type a message…')}
+            disabled={disabled || sending}
+            maxLength={230}
+          />
+          <button
+            onClick={() => void handleSend()}
+            disabled={disabled || sending || !draft.trim()}
+          >
+            {sending ? t('meshcore.sending', 'Sending…') : t('meshcore.send', 'Send')}
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -802,6 +802,16 @@
   cursor: not-allowed;
 }
 
+.meshcore-readonly-notice {
+  padding: 0.6rem 0.75rem;
+  background: var(--ctp-surface0);
+  border-top: 1px solid var(--ctp-surface1);
+  color: var(--ctp-overlay1);
+  font-size: 0.85rem;
+  text-align: center;
+  font-style: italic;
+}
+
 /* Contact detail pane (below the message stream in the DM view).
    No longer height-capped — the surrounding `.meshcore-main-pane` is the
    page-level scroll container, so this block flows naturally below the


### PR DESCRIPTION
## Summary

Fixes #3755 — MeshCore repeaters (`advType=2`) cannot receive direct messages, but the DM view offered a full send bar and showed a false "delivered" (✓✓) status when the firmware acknowledged the relay packet.

- `MeshCoreMessageStream`: add optional `readOnlyNotice` prop — when set, the send bar is replaced with a styled notice div (italic, muted, same bar height). No behaviour change when prop is absent.
- `MeshCoreDirectMessagesView`: detect when the selected contact is a repeater (`advType === 2`) and pass `readOnlyNotice="Repeaters cannot receive direct messages."` to the stream.
- `MeshCorePage.css`: add `.meshcore-readonly-notice` rule matching the send-bar dimensions and colour.

Historical messages (if any) remain visible; only the ability to send new ones is removed.

## Test plan

- [x] 15 targeted tests pass (`MeshCoreDirectMessagesView.test.tsx` + `MeshCoreMessageStream.test.tsx`)
- [x] Full Vitest suite: 7506 passed, 3 pre-existing failures in `mqttBrokerManager.test.ts` (unrelated)
- [ ] Reviewer: select a MeshCore repeater contact in the DM view and confirm the send bar is replaced by the notice; confirm non-repeater contacts still show the normal send bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3wti3yXS1pcga9NEsg1sM

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wti3yXS1pcga9NEsg1sM)_