### PR TITLE
fix(messaging): no DM UI for MeshCore repeaters & Meshtastic unmessagable nodes (#3755)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -408,3 +408,80 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     expect(mainPane?.classList.contains('meshcore-main-pane--dm')).toBe(true);
   });
 });
+
+describe('MeshCoreDirectMessagesView — repeaters are not messageable (#3755)', () => {
+  const repeaterContact: MeshCoreContact = {
+    publicKey: REAL_PK_2,
+    advName: 'Repeater Rita',
+    advType: 2, // Repeater — cannot receive DMs
+    rssi: -80,
+    snr: 5,
+    pathLen: 1,
+    lastSeen: Date.now(),
+  };
+
+  it('keeps the repeater listed in the contact sidebar (still browsable)', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact, repeaterContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    // Repeaters are NOT filtered out of the list — only their messaging is removed.
+    expect(screen.getByText('Remote Bob')).toBeTruthy();
+    expect(screen.getByText('Repeater Rita')).toBeTruthy();
+  });
+
+  it('hides the message composer and shows a notice when a repeater is selected', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact, repeaterContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Repeater Rita'));
+
+    // No compose input for a repeater — the messaging feature is gone, not just disabled.
+    expect(screen.queryByPlaceholderText('Type a message…')).toBeNull();
+    // Replaced by an explanatory notice.
+    expect(screen.getByText(/Repeaters cannot receive direct messages/i)).toBeTruthy();
+  });
+
+  it('still renders the message composer for a normal (companion) contact', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact, repeaterContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Remote Bob'));
+
+    expect(screen.getByPlaceholderText('Type a message…')).toBeTruthy();
+    expect(screen.queryByText(/Repeaters cannot receive direct messages/i)).toBeNull();
+  });
+
+  it('still renders node details (telemetry) for a selected repeater', async () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact, repeaterContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+    fireEvent.click(screen.getByText('Repeater Rita'));
+
+    // The detail/telemetry side still mounts even though messaging is removed.
+    await waitFor(() => {
+      expect(screen.getByText('Telemetry Retrieval')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -68,6 +68,23 @@ function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions 
     setTelemetryModeEnv: vi.fn().mockResolvedValue(true),
     refreshAll: vi.fn().mockResolvedValue(undefined),
     clearError: vi.fn(),
+    // Contact + remote-admin actions: a repeater/room contact-detail panel
+    // mounts the remote-admin console, which calls getRemoteAdminCapability on
+    // mount. Without these the panel throws in JSDOM (#3755 repeater tests).
+    resetContactPath: vi.fn().mockResolvedValue(true),
+    shareContact: vi.fn().mockResolvedValue({ ok: true }),
+    setContactOutPath: vi.fn().mockResolvedValue(true),
+    traceContactPath: vi.fn().mockResolvedValue(null),
+    discoverContactPath: vi.fn().mockResolvedValue(true),
+    removeContact: vi.fn().mockResolvedValue(true),
+    exportContact: vi.fn().mockResolvedValue(null),
+    getNeighbours: vi.fn().mockResolvedValue(null),
+    loginRemote: vi.fn().mockResolvedValue({ success: false }),
+    loginRemoteWithSaved: vi.fn().mockResolvedValue({ success: false }),
+    sendCliCommand: vi.fn().mockResolvedValue(null),
+    getRemoteAdminCapability: vi.fn().mockResolvedValue(null),
+    forgetRemoteCredential: vi.fn().mockResolvedValue(true),
+    getRemoteStatus: vi.fn().mockResolvedValue(null),
     ...overrides,
   };
 }

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -244,6 +244,13 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     ? (contactsByKey.get(selected)?.advName || contactsByKey.get(selected)?.name || `${selected.substring(0, 8)}…`)
     : '';
 
+  // Repeaters (advType=2) cannot receive direct messages — the firmware acks
+  // the relay packet, which surfaced as a misleading "delivered" (✓✓). We keep
+  // the repeater listed in the contact sidebar and still render its detail panel
+  // (telemetry/position/remote-admin), but drop the messaging UI entirely rather
+  // than send messages that can never arrive (issue #3755).
+  const isSelectedRepeater = selected ? contactsByKey.get(selected)?.advType === 2 : false;
+
   const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
 
   return (
@@ -376,15 +383,21 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
         )}
         {selected ? (
           <>
-            <MeshCoreMessageStream
-              messages={filtered}
-              contacts={contacts}
-              selfPublicKey={selfKey}
-              disabled={!connected || !canSend}
-              emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
-              onSend={text => actions.sendMessage(text, selected)}
-              conversationKey={`dm-${selected}`}
-            />
+            {isSelectedRepeater ? (
+              <div className="meshcore-dm-no-messaging" role="note">
+                {t('meshcore.repeater_no_messaging', 'Repeaters cannot receive direct messages — showing node details only.')}
+              </div>
+            ) : (
+              <MeshCoreMessageStream
+                messages={filtered}
+                contacts={contacts}
+                selfPublicKey={selfKey}
+                disabled={!connected || !canSend}
+                emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
+                onSend={text => actions.sendMessage(text, selected)}
+                conversationKey={`dm-${selected}`}
+              />
+            )}
             <div className="meshcore-detail-pane">
               <MeshCoreContactDetailPanel
                 contact={contactsByKey.get(selected) ?? null}

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -322,6 +322,15 @@
   overflow-y: auto;
 }
 
+/* Notice shown in place of the message composer when the selected contact is a
+   repeater (advType=2), which cannot receive direct messages (#3755). */
+.meshcore-dm-no-messaging {
+  padding: 12px 16px;
+  font-style: italic;
+  color: var(--ctp-subtext0);
+  border-bottom: 1px solid var(--ctp-surface0);
+}
+
 /* Map area */
 .meshcore-map-pane {
   flex: 1;

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -756,6 +756,13 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
   const selectedNode = selectedDMNode ? nodes.find(n => n.user?.id === selectedDMNode) : null;
 
+  // A node flagged "unmessagable" (Meshtastic NodeInfo `is_unmessagable`, e.g.
+  // sensors/repeaters) can't receive DMs — sending would silently go nowhere.
+  // Treat its conversation like the MQTT-bridge read-only mirror: keep the node
+  // selectable in the DM list and still show its per-node telemetry, but hide
+  // the message log and the send composer / mesh-transmit actions (issue #3755).
+  const effectiveReadOnly = mqttReadOnly || selectedNode?.isUnmessagable === true;
+
   return (
     <div className="nodes-split-view messages-split-view">
       {/* Left Sidebar - Node List */}
@@ -1117,7 +1124,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             view is read-only and remains. */}
                         {hasPermission('traceroute', 'write') && (
                           <>
-                            {!mqttReadOnly && (
+                            {!effectiveReadOnly && (
                               <button
                                 className="actions-menu-item"
                                 onClick={() => {
@@ -1146,7 +1153,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             packet to the mesh (position exchange, NodeInfo
                             request, telemetry request). Hidden entirely in
                             the MQTT-bridge mirror. */}
-                        {!mqttReadOnly && hasPermission('messages', 'write') && (
+                        {!effectiveReadOnly && hasPermission('messages', 'write') && (
                           <>
                             <button
                               className="actions-menu-item"
@@ -1200,7 +1207,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
                         {/* Admin Scan — sends an admin probe packet to the
                             remote node. No-op in the MQTT-bridge mirror. */}
-                        {!mqttReadOnly && hasPermission('settings', 'write') && (
+                        {!effectiveReadOnly && hasPermission('settings', 'write') && (
                           <button
                             className="actions-menu-item"
                             onClick={() => {
@@ -1347,7 +1354,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
             <div
               className="messages-container"
               ref={dmMessagesContainerRef}
-              style={{ position: 'relative', display: mqttReadOnly ? 'none' : undefined }}
+              style={{ position: 'relative', display: effectiveReadOnly ? 'none' : undefined }}
             >
               {showJumpToBottom && (
                 <div
@@ -1587,7 +1594,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               style={!isMobileLayout ? { height: `${sendSectionHeight}px` } : undefined}
             >
               {/* Send DM form — suppressed in MQTT-bridge read-only mode */}
-              {!mqttReadOnly && connectionStatus === 'connected' && (
+              {!effectiveReadOnly && connectionStatus === 'connected' && (
                 <div className="send-message-form">
                 {replyingTo && (
                   <div className="reply-indicator">
@@ -1845,7 +1852,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Traceroute - Split Button */}
-              {!mqttReadOnly && hasPermission('traceroute', 'write') && (
+              {!effectiveReadOnly && hasPermission('traceroute', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleTraceroute(selectedDMNode)}
@@ -1931,7 +1938,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Exchange Node Info - Split Button */}
-              {!mqttReadOnly && hasPermission('messages', 'write') && (
+              {!effectiveReadOnly && hasPermission('messages', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangeNodeInfo(selectedDMNode)}
@@ -2017,7 +2024,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Exchange Position - Split Button */}
-              {!mqttReadOnly && hasPermission('messages', 'write') && (
+              {!effectiveReadOnly && hasPermission('messages', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangePosition(selectedDMNode)}
@@ -2103,7 +2110,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Request Neighbor Info */}
-              {!mqttReadOnly && hasPermission('traceroute', 'write') && (
+              {!effectiveReadOnly && hasPermission('traceroute', 'write') && (
                 <button
                   onClick={() => handleRequestNeighborInfo(selectedDMNode)}
                   disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1686,7 +1686,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       {node.hasRemoteAdmin && (
                         <span className="node-indicator-icon" title={t('nodes.has_remote_admin')}>🛠️</span>
                       )}
-                      {hasPermission('messages', 'read') && (
+                      {hasPermission('messages', 'read') && !node.isUnmessagable && (
                         <button
                           className="dm-icon"
                           title={t('nodes.send_dm')}


### PR DESCRIPTION
## Summary
Repeaters (MeshCore `advType=2`) and Meshtastic nodes with `is_unmessagable` set cannot receive direct messages — the firmware acks the relay/packet, which surfaced as a misleading "delivered" (✓✓) for messages that never arrived. This removes the messaging UI for those nodes while keeping them **first-class everywhere else**: they stay listed in the node/contact sidebars and still show full telemetry and other detail.

This supersedes the two earlier attempts:
- **#3758** removed repeaters from the DM sidebar — but they should stay listed.
- **#3759** only greyed the send bar with a notice — but the messaging UI should be removed, not annotated.

The chosen behavior (confirmed with the maintainer): keep the node in the list; when selected, show its **node details / telemetry** in place of the conversation.

## Changes
### MeshCore (`MeshCoreDirectMessagesView`)
- When the selected contact is a repeater (`advType===2`), drop the `MeshCoreMessageStream` (log + composer) and show a short notice; the `MeshCoreContactDetailPanel` + telemetry/graphs still render below as before.
- Repeaters remain in the contact sidebar (not filtered). The Nodes-view "›" button is already labelled **"More details"** and now lands on the detail-only pane, so it needed no change.
- `MeshCorePage.css`: `.meshcore-dm-no-messaging` notice style.

### Meshtastic
- `NodesTab`: hide the 💬 DM button for `is_unmessagable` nodes (no DM entry point); the node stays in the list with all indicators/details.
- `MessagesTab`: reuse the existing read-only mode via `effectiveReadOnly = mqttReadOnly || selectedNode.isUnmessagable`. Selecting an unmessagable node hides the message log + send composer + mesh-transmit actions and shows only the per-node telemetry, while the node stays selectable in the DM list.

## Issues Resolved
Fixes #3755. Supersedes #3758 and #3759.

## Documentation Updates
No documentation changes needed (behavioral UI change; no documented feature/config/API surface affected).

## Testing
- [x] 4 new MeshCore render tests (`MeshCoreDirectMessagesView.test.tsx`): repeater stays in the sidebar; composer hidden + notice shown on repeater select; composer still shown for companions; telemetry still mounts for a selected repeater. File 28/28.
- [x] Full suite green — `success: true`, 7562 passed, 0 failed, 0 suite failures (sibling `.claude/worktrees/` checkout excluded).
- [x] `tsc` clean on all changed files.
- [ ] Reviewer (MeshCore): select a repeater in Messages → no composer, notice shown, telemetry/detail panel still renders; companion contacts unchanged.
- [ ] Reviewer (Meshtastic): an `is_unmessagable` node has no 💬 in the Nodes list and, when selected in Messages, shows telemetry only (no log/composer) while remaining selectable.

> Note on Meshtastic test coverage: `MessagesTab`/`NodesTab` have no render harness (1.5k–2.5k LOC, ~70 props, 6+ contexts); the change is a small wiring that reuses the already-shipped `mqttReadOnly` read-only mode, verified by `tsc` + the full suite. Happy to add a heavier `MessagesTab` harness if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)