### PR TITLE
fix(meshcore): keep focus on the CLI command line after sending (#3752)

### DIFF
--- a/src/components/MeshCore/CliConsoleBody.test.tsx
+++ b/src/components/MeshCore/CliConsoleBody.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression for #3752: after sending a command, keyboard focus must return to
+ * the command input so an operator can fire commands back-to-back without
+ * re-clicking the field. The input is disabled while a command is in flight
+ * (which drops focus); the console restores it once the send completes.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { CliConsoleBody } from './CliConsoleBody';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+describe('CliConsoleBody — command input focus (#3752)', () => {
+  it('returns focus to the command input after a command is sent', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ ok: true, reply: 'pong' });
+    render(
+      <CliConsoleBody
+        targetId="t1"
+        targetName="Repeater"
+        runCommand={runCommand}
+        actionCatalog={[]}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/Type a command/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'ver' } });
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() => expect(runCommand).toHaveBeenCalledWith('ver', undefined));
+    // Once the send resolves and the input re-enables, focus is back on it.
+    await waitFor(() => expect(document.activeElement).toBe(input));
+    // And the field was cleared, ready for the next command.
+    expect(input.value).toBe('');
+  });
+});

--- a/src/components/MeshCore/CliConsoleBody.tsx
+++ b/src/components/MeshCore/CliConsoleBody.tsx
@@ -148,6 +148,11 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
   const historyRef = useRef<string[]>([]);
   const historyIndexRef = useRef<number | null>(null);
   const draftRef = useRef<string>('');
+  // The command input is disabled while a command is in flight, which drops
+  // keyboard focus. Return focus to it once the send completes so an operator
+  // can fire commands back-to-back without re-clicking the field (#3752).
+  const commandInputRef = useRef<HTMLInputElement | null>(null);
+  const refocusAfterSendRef = useRef(false);
   const HISTORY_MAX = 50;
 
   useEffect(() => {
@@ -201,6 +206,7 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
 
   const runAndLog = useCallback(async (cmd: string, opts?: { confirm?: boolean }) => {
     if (sending) return;
+    refocusAfterSendRef.current = true;
     setSending(true);
     appendTranscript({ kind: 'sent', text: cmd });
     setCommand('');
@@ -228,6 +234,16 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
       appendTranscript({ kind: 'error', text: `${result.error}${hint}` });
     }
   }, [appendTranscript, runCommand, sending, t]);
+
+  // Once a send completes and the input re-enables, return keyboard focus to
+  // the command line (#3752). The flag keeps this from grabbing focus on mount
+  // or on unrelated `sending`/`disabled` transitions.
+  useEffect(() => {
+    if (!sending && refocusAfterSendRef.current) {
+      refocusAfterSendRef.current = false;
+      if (!disabled) commandInputRef.current?.focus();
+    }
+  }, [sending, disabled]);
 
   useImperativeHandle(ref, () => ({
     appendInfo: (text: string) => appendTranscript({ kind: 'info', text }),
@@ -321,6 +337,7 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
         }}
       >
         <input
+          ref={commandInputRef}
           type="text"
           value={command}
           onChange={(e) => {


### PR DESCRIPTION
## Summary

Fixes #3752. In the MeshCore Remote Administration console, sending a command moved keyboard focus off the "Type a command…" input, forcing the operator to click back into the field before every command (and risking an accidental navigation that drops the admin session).

**Cause:** the command input is `disabled` while a command is in flight, which blurs it; focus wasn't restored when the input re-enabled.

**Fix:** capture the input via a ref and refocus it once the send completes. A small flag set at the start of `runAndLog` (and cleared in the effect) ensures we only refocus after an actual send — not on mount or on unrelated `sending`/`disabled` transitions.

Because the change lives in the shared `CliConsoleBody` primitive and routes through the single `runAndLog` choke point, it covers:
- the form **Send** button,
- the **quick-action** buttons,
- the **danger-confirm** path,

for **both** the Remote and Local MeshCore consoles.

## Tests
- `CliConsoleBody.test.tsx` — after a command is sent, asserts focus returns to the input and the field is cleared, ready for the next command.
- Full suite: **7559 passed, 0 failed**.

Closes #3752

🤖 Generated with [Claude Code](https://claude.com/claude-code)