### PR TITLE
feat(meshcore): show the scope/region a received message was sent with (#3742 Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 99 (latest: `099_create_automation_variables`).
+**Current migration count:** 106 (latest: `106_add_meshcore_message_scope`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -300,6 +300,18 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                   {m.hopCount !== 0 && m.routePath ? ` · ${m.routePath.split(',').filter(Boolean).join(' → ')}` : ''}
                 </div>
               )}
+              {!outgoing && typeof m.scopeCode === 'number' && (
+                <div
+                  className="mc-message-scope"
+                  title={t('meshcore.scope_tooltip', 'The region/scope this message was sent with')}
+                >
+                  {m.scopeCode === 0
+                    ? t('meshcore.scope_unscoped', '🌐 no scope')
+                    : m.scopeName
+                      ? `🔒 ${m.scopeName}`
+                      : `🔒 #${m.scopeCode.toString(16).padStart(4, '0')}`}
+                </div>
+              )}
               {outgoing && m.heardBy && m.heardBy.length > 0 && expandedHeardBy.has(m.id) && (
                 <ul className="mc-heard-by-list">
                   {m.heardBy.map(h => (

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -713,6 +713,7 @@
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
 .mc-message-route { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+.mc-message-scope { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 
 .mc-mention {
   color: var(--ctp-blue);

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -89,6 +89,10 @@ export interface MeshCoreMessage {
   hopCount?: number | null;
   /** Relay-hash chain the message traveled, comma-separated (e.g. "a3,7f,02") (#3742). */
   routePath?: string | null;
+  /** Scope transport code: 0 = sent unscoped, >0 = scoped, null/undefined = no info (#3742 Ph2). */
+  scopeCode?: number | null;
+  /** Region name resolved from the scope code; null = unscoped or unknown scope (#3742 Ph2). */
+  scopeName?: string | null;
 }
 
 export interface ConnectionStatus {

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 105 migrations registered', () => {
-    expect(registry.count()).toBe(105);
+  it('has all 106 migrations registered', () => {
+    expect(registry.count()).toBe(106);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_meshcore_message_route', () => {
+  it('last migration is add_meshcore_message_scope', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(105);
-    expect(last.name).toContain('add_meshcore_message_route');
+    expect(last.number).toBe(106);
+    expect(last.name).toContain('add_meshcore_message_scope');
   });
 
-  it('migrations are sequentially numbered from 1 to 105', () => {
+  it('migrations are sequentially numbered from 1 to 106', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -120,6 +120,7 @@ import { migration as meshcoreHeardRepeatersMigration, runMigration102Postgres a
 import { migration as consolidateMqttChannelsMigration, runMigration103Postgres as runConsolidateMqttChannelsPostgres, runMigration103Mysql as runConsolidateMqttChannelsMysql } from '../server/migrations/103_consolidate_mqtt_channels.js';
 import { migration as channelDatabaseHashMigration, runMigration104Postgres as runChannelDatabaseHashPostgres, runMigration104Mysql as runChannelDatabaseHashMysql } from '../server/migrations/104_add_channel_database_hash.js';
 import { migration as meshcoreMessageRouteMigration, runMigration105Postgres as runMeshcoreMessageRoutePostgres, runMigration105Mysql as runMeshcoreMessageRouteMysql } from '../server/migrations/105_add_meshcore_message_route.js';
+import { migration as meshcoreMessageScopeMigration, runMigration106Postgres as runMeshcoreMessageScopePostgres, runMigration106Mysql as runMeshcoreMessageScopeMysql } from '../server/migrations/106_add_meshcore_message_scope.js';
 
 // ============================================================================
 // Registry
@@ -1665,4 +1666,18 @@ registry.register({
   sqlite: (db) => meshcoreMessageRouteMigration.up(db),
   postgres: (client) => runMeshcoreMessageRoutePostgres(client),
   mysql: (pool) => runMeshcoreMessageRouteMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 106: meshcore_messages scope columns
+// MeshCore messages can show the scope/region they were sent with (#3742 Ph2).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 106,
+  name: 'add_meshcore_message_scope',
+  settingsKey: 'migration_106_add_meshcore_message_scope',
+  sqlite: (db) => meshcoreMessageScopeMigration.up(db),
+  postgres: (client) => runMeshcoreMessageScopePostgres(client),
+  mysql: (pool) => runMeshcoreMessageScopeMysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -257,6 +257,41 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(legacy.routePath).toBeNull();
   });
 
+  it('insertMessage persists scopeCode + scopeName and reads them back (#3742 Phase 2)', async () => {
+    await repo.insertMessage(
+      { id: 'm-scoped', fromPublicKey: 'pk-1', text: 'scoped', timestamp: 3000, createdAt: 3000, scopeCode: 30479, scopeName: 'muenchen' },
+      'src-a',
+    );
+    await repo.insertMessage(
+      { id: 'm-unscoped', fromPublicKey: 'pk-1', text: 'unscoped', timestamp: 3001, createdAt: 3001, scopeCode: 0, scopeName: null },
+      'src-a',
+    );
+    await repo.insertMessage(
+      { id: 'm-unknown', fromPublicKey: 'pk-1', text: 'scoped-unknown', timestamp: 3002, createdAt: 3002, scopeCode: 12345, scopeName: null },
+      'src-a',
+    );
+    const msgs = await repo.getRecentMessages(10, 'src-a');
+    const scoped = msgs.find((m) => m.id === 'm-scoped')!;
+    const unscoped = msgs.find((m) => m.id === 'm-unscoped')!;
+    const unknown = msgs.find((m) => m.id === 'm-unknown')!;
+    expect(scoped.scopeCode).toBe(30479);
+    expect(scoped.scopeName).toBe('muenchen');
+    expect(unscoped.scopeCode).toBe(0);     // 0 = known-unscoped sentinel, must round-trip (not coerced to null)
+    expect(unscoped.scopeName).toBeNull();
+    expect(unknown.scopeCode).toBe(12345);
+    expect(unknown.scopeName).toBeNull();
+  });
+
+  it('insertMessage leaves scopeCode/scopeName null when omitted', async () => {
+    await repo.insertMessage(
+      { id: 'm-noscope', fromPublicKey: 'pk-1', text: 'no scope info', timestamp: 3003, createdAt: 3003 },
+      'src-a',
+    );
+    const row = (await repo.getRecentMessages(10, 'src-a')).find((m) => m.id === 'm-noscope')!;
+    expect(row.scopeCode).toBeNull();
+    expect(row.scopeName).toBeNull();
+  });
+
   it('insertMessage throws when called without a sourceId', async () => {
     await expect(
       repo.insertMessage(

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -96,6 +96,13 @@ export interface DbMeshCoreMessage {
   /** Hop count + relay-hash route path for received messages (#3742). */
   hopCount?: number | null;
   routePath?: string | null;
+  /**
+   * Scope/region the message was sent with (#3742 Phase 2). scopeCode is the
+   * packet's transport_code_1 (0 = unscoped, null = no scope info); scopeName is
+   * the region name resolved against known scopes at receive time.
+   */
+  scopeCode?: number | null;
+  scopeName?: string | null;
   createdAt: number;
 }
 

--- a/src/db/schema/meshcoreMessages.ts
+++ b/src/db/schema/meshcoreMessages.ts
@@ -35,6 +35,12 @@ export const meshcoreMessagesSqlite = sqliteTable('meshcore_messages', {
   hopCount: integer('hopCount'),
   routePath: text('routePath'),
 
+  // Scope/region (#3742 Phase 2). scopeCode = the packet's transport_code_1
+  // (0 = sent unscoped, NULL = no scope info available). scopeName = the region
+  // name resolved against known scopes at receive time (NULL = unscoped/unknown).
+  scopeCode: integer('scopeCode'),
+  scopeName: text('scopeName'),
+
   // Message type (for future use: text, location, etc.)
   messageType: text('messageType').default('text'),
 
@@ -62,6 +68,8 @@ export const meshcoreMessagesPostgres = pgTable('meshcore_messages', {
   snr: pgInteger('snr'),
   hopCount: pgInteger('hopCount'),
   routePath: pgText('routePath'),
+  scopeCode: pgInteger('scopeCode'),
+  scopeName: pgText('scopeName'),
   messageType: pgText('messageType').default('text'),
   delivered: pgBoolean('delivered').default(false),
   deliveredAt: pgBigint('deliveredAt', { mode: 'number' }),
@@ -82,6 +90,8 @@ export const meshcoreMessagesMysql = mysqlTable('meshcore_messages', {
   snr: myInt('snr'),
   hopCount: myInt('hopCount'),
   routePath: myText('routePath'),
+  scopeCode: myInt('scopeCode'),
+  scopeName: myText('scopeName'),
   messageType: myVarchar('messageType', { length: 32 }).default('text'),
   delivered: myBoolean('delivered').default(false),
   deliveredAt: myBigint('deliveredAt', { mode: 'number' }),

--- a/src/server/meshcoreManager.scopeResolve.test.ts
+++ b/src/server/meshcoreManager.scopeResolve.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration test for #3742 Phase 2 — the manager wires a received message's
+ * raw OTA bytes + the cached known-scope set through resolveMessageScope and
+ * stamps scopeCode/scopeName onto the stored MeshCoreMessage.
+ *
+ * The crypto itself is covered exhaustively in meshcoreScopeResolve.test.ts;
+ * here we prove the handler plumbing (raw_hex → knownScopes → message fields).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const insertMessage = vi.fn().mockResolvedValue(undefined);
+const getSettingForSource = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./services/database.js', () => ({
+  default: {
+    meshcore: { insertMessage: (...a: unknown[]) => insertMessage(...a) },
+    settings: { getSettingForSource: (...a: unknown[]) => getSettingForSource(...a) },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreOtaPacket: vi.fn(),
+    emitMeshCoreChannelHeard: vi.fn(),
+    emitMeshCoreContactUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager } from './meshcoreManager.js';
+
+// TRANSPORT_FLOOD packet sent under scope "muenchen": header 0x14 (payloadType
+// 5), transportCode1 30479, path byte 0x02 (2 hops a3,7f), payload cafe0102.
+const SCOPED_RAW = '140f77000002a37fcafe0102';
+// Same packet sent FLOOD (route_type 1) → no transport code → unscoped.
+const UNSCOPED_RAW = '1502a37fcafe0102';
+
+function dispatch(m: MeshCoreManager, data: Record<string, unknown>): void {
+  // @ts-expect-error - exercising the private bridge-event handler
+  m.handleBridgeEvent({ event_type: 'channel_message', data });
+}
+
+function lastMessage(m: MeshCoreManager) {
+  const all = m.getRecentMessages(10);
+  return all[all.length - 1];
+}
+
+describe('MeshCoreManager scope resolution (#3742 Phase 2)', () => {
+  let m: MeshCoreManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    m = new MeshCoreManager('src-a');
+    // Seed the known-scope cache directly (normally primed on connect).
+    (m as any).knownScopes = new Set(['muenchen']);
+  });
+
+  it('resolves a scoped message to a known scope name', () => {
+    dispatch(m, { channel_idx: 0, text: 'Bob: hi', path_len: 2, path_hops: ['a3', '7f'], raw_hex: SCOPED_RAW });
+    const msg = lastMessage(m);
+    expect(msg.scopeCode).toBe(30479);
+    expect(msg.scopeName).toBe('muenchen');
+  });
+
+  it('marks a scoped message from an UNKNOWN scope with the raw code and no name', () => {
+    (m as any).knownScopes = new Set(['some-other-region']);
+    dispatch(m, { channel_idx: 0, text: 'Bob: hi', path_len: 2, path_hops: ['a3', '7f'], raw_hex: SCOPED_RAW });
+    const msg = lastMessage(m);
+    expect(msg.scopeCode).toBe(30479);
+    expect(msg.scopeName).toBeNull();
+  });
+
+  it('marks an unscoped (non-transport route) message with scopeCode 0', () => {
+    dispatch(m, { channel_idx: 0, text: 'Bob: hi', path_len: 2, path_hops: ['a3', '7f'], raw_hex: UNSCOPED_RAW });
+    const msg = lastMessage(m);
+    expect(msg.scopeCode).toBe(0);
+    expect(msg.scopeName).toBeNull();
+  });
+
+  it('leaves scope null when no raw_hex was correlated to the message', () => {
+    dispatch(m, { channel_idx: 0, text: 'Bob: hi', path_len: 2, path_hops: ['a3', '7f'] });
+    const msg = lastMessage(m);
+    expect(msg.scopeCode).toBeNull();
+    expect(msg.scopeName).toBeNull();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -17,6 +17,7 @@ import { scheduleCron, validateCron, type CronJob } from './utils/cronScheduler.
 import { replaceMeshCoreAnnounceTokens } from './utils/meshcoreAnnounceTokens.js';
 import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
+import { resolveMessageScope } from './meshcoreScopeResolve.js';
 import {
   MeshCoreVirtualNodeServer,
   type MeshCoreVirtualNodeConfig,
@@ -385,6 +386,12 @@ export interface MeshCoreMessage {
   /** Relay-hash chain the message traveled, comma-separated (e.g. "a3,7f,02");
    *  null when no path was reported. (#3742) */
   routePath?: string | null;
+  /** Scope/region the message was sent with (#3742 Phase 2). `scopeCode` is the
+   *  packet's transport_code_1: 0 = sent unscoped, null = no scope info. */
+  scopeCode?: number | null;
+  /** Region name resolved from `scopeCode` against this source's known scopes;
+   *  null = unscoped, or scoped-but-unknown (then the UI shows `#<code-hex>`). */
+  scopeName?: string | null;
 }
 
 export interface MeshCoreStatus {
@@ -553,6 +560,12 @@ class MeshCoreManager extends EventEmitter {
   // and stateful, two concurrent sends with different scopes must not interleave.
   private activeFloodScope: string | null | undefined = undefined;
   private sendScopeLock: Promise<unknown> = Promise.resolve();
+  // Known scope/region names for this source (#3742 Phase 2): the candidate set
+  // a received message's transport code is matched against to resolve its scope
+  // name. Sourced from per-channel scopes + the source default scope. Cached so
+  // the synchronous inbound-message path resolves with no DB round-trip;
+  // refreshed on connect and whenever a scope changes.
+  private knownScopes: Set<string> = new Set();
 
   // Shared state
   private localNode: MeshCoreNode | null = null;
@@ -685,11 +698,17 @@ class MeshCoreManager extends EventEmitter {
         sourceId: dbMsg.sourceId ?? undefined,
         hopCount: dbMsg.hopCount ?? null,
         routePath: dbMsg.routePath ?? null,
+        scopeCode: dbMsg.scopeCode ?? null,
+        scopeName: dbMsg.scopeName ?? null,
       }));
     } catch (loadErr) {
       logger.warn(`[MeshCore:${this.sourceId}] Failed to load messages from DB: ${(loadErr as Error).message}`);
       this.messages = [];
     }
+
+    // Prime the known-scope cache so the first received message can resolve its
+    // scope name without a DB round-trip (#3742 Phase 2).
+    await this.refreshKnownScopes();
 
     logger.info(`[MeshCore] Connecting via ${this.config.connectionType}...`);
     this.connectionState = 'connecting';
@@ -994,6 +1013,7 @@ class MeshCoreManager extends EventEmitter {
       // The {ROUTE} auto-ack template keeps the outPath fallback (existing
       // behavior) so an ack can still cite a route when no LogRxData surfaced.
       const ackRoute = observedRoute || senderContact?.outPath || null;
+      const scope = resolveMessageScope(data.raw_hex, this.knownScopes);
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
         fromPublicKey: data.pubkey_prefix,
@@ -1004,6 +1024,8 @@ class MeshCoreManager extends EventEmitter {
         sourceId: this.sourceId,
         hopCount,
         routePath: observedRoute,
+        scopeCode: scope.scopeCode,
+        scopeName: scope.scopeName,
       };
       this.addMessage(message);
       this.emit('message', message);
@@ -1024,6 +1046,7 @@ class MeshCoreManager extends EventEmitter {
       // path_hops (when present) is the only source of relay identities.
       const hopCount = decodePathLenHopCount(data.path_len);
       const route = formatPathHops(data.path_hops);
+      const scope = resolveMessageScope(data.raw_hex, this.knownScopes);
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
         fromPublicKey: MeshCoreManager.channelPublicKey(data.channel_idx),
@@ -1034,6 +1057,8 @@ class MeshCoreManager extends EventEmitter {
         sourceId: this.sourceId,
         hopCount,
         routePath: route,
+        scopeCode: scope.scopeCode,
+        scopeName: scope.scopeName,
       };
       this.addMessage(message);
       this.emit('message', message);
@@ -1561,6 +1586,8 @@ class MeshCoreManager extends EventEmitter {
       // A scope change may affect the next send on this channel — force a
       // re-assert rather than trusting the cached device scope.
       this.activeFloodScope = undefined;
+      // The known-scope set used to resolve received-message scopes changed.
+      void this.refreshKnownScopes();
     }
   }
 
@@ -1763,6 +1790,8 @@ class MeshCoreManager extends EventEmitter {
         sourceId: this.sourceId,
         hopCount: message.hopCount ?? null,
         routePath: message.routePath ?? null,
+        scopeCode: message.scopeCode ?? null,
+        scopeName: message.scopeName ?? null,
         createdAt: Date.now(),
       },
       this.sourceId,
@@ -2526,8 +2555,30 @@ class MeshCoreManager extends EventEmitter {
     const normalized = (scope || '').trim().replace(/^#/, '');
     await databaseService.settings.setSourceSetting(this.sourceId, 'meshcoreDefaultScope', normalized);
     this.activeFloodScope = undefined;
+    void this.refreshKnownScopes();
     logger.info(`[MeshCore:${this.sourceId}] Default scope set to ${normalized || '(unscoped)'}`);
     return normalized;
+  }
+
+  /**
+   * Rebuild the {@link knownScopes} cache from this source's per-channel scopes
+   * plus the default scope (#3742 Phase 2). Best-effort: a failure leaves the
+   * previous cache in place and never breaks the message stream.
+   */
+  private async refreshKnownScopes(): Promise<void> {
+    try {
+      const names = new Set<string>();
+      const channels = await databaseService.channels.getAllChannels(this.sourceId);
+      for (const ch of channels) {
+        const s = (ch.scope ?? '').trim();
+        if (s) names.add(s);
+      }
+      const def = (await this.getDefaultScope()).trim();
+      if (def) names.add(def);
+      this.knownScopes = names;
+    } catch (err) {
+      logger.debug(`[MeshCore:${this.sourceId}] refreshKnownScopes failed: ${(err as Error).message}`);
+    }
   }
 
   /**

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -219,7 +219,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * (it only appears on LogRxData, not on the txt-msg recv event) so the
    * message event — and {SNR} in auto-ack/auto-responder templates — has it.
    */
-  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number; snr?: number; bufferedAt: number } | null = null;
+  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number; snr?: number; rawHex?: string; bufferedAt: number } | null = null;
 
   /**
    * Maximum age (ms) of a buffered LogRxData path before we treat it as stale
@@ -379,7 +379,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * Returns `{ hops, snr }` to attach, or `undefined` when the buffer is
    * absent, stale, or for a different packet.
    */
-  private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number } | undefined {
+  private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number; rawHex?: string } | undefined {
     const buffered = this.pendingTxtMsgPath;
     // Consume-once: clear regardless of whether we end up attaching it.
     this.pendingTxtMsgPath = null;
@@ -403,7 +403,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return undefined;
       }
     }
-    return { hops: buffered.hops, snr: buffered.snr };
+    return { hops: buffered.hops, snr: buffered.snr, rawHex: buffered.rawHex };
   }
 
   private wirePushEvents(): void {
@@ -451,7 +451,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
           // lets the recv handler reject a stale buffer whose matching recv never
           // arrived (issue #3589 mis-correlation guard).
           if (pkt.payload_type === TXT_MSG || pkt.payload_type === GRP_TXT) {
-            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr, bufferedAt: Date.now() };
+            // Buffer raw_hex too so the message handler can resolve the scope/
+            // region the packet was sent under (#3742 Phase 2).
+            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr, rawHex: bytesToHex(raw), bufferedAt: Date.now() };
           }
           this.emitBridgeEvent('ota_packet', {
             payload_type: pkt.payload_type,
@@ -531,6 +533,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // not available (e.g. backend started without raw logging).
         path_hops: consumedPath?.hops,
         snr: consumedPath?.snr,
+        // Raw OTA bytes (from the same preceding LogRxData) so the manager can
+        // resolve the scope/region the message was sent under (#3742 Phase 2).
+        raw_hex: consumedPath?.rawHex,
       };
       this.emitBridgeEvent(isCliReply ? 'cli_reply' : 'contact_message', payload);
     });
@@ -546,6 +551,8 @@ export class MeshCoreNativeBackend extends EventEmitter {
         path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
         path_hops: consumedPath?.hops,
         snr: consumedPath?.snr,
+        // Raw OTA bytes for scope/region resolution (#3742 Phase 2).
+        raw_hex: consumedPath?.rawHex,
       });
     });
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -452,7 +452,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
           // arrived (issue #3589 mis-correlation guard).
           if (pkt.payload_type === TXT_MSG || pkt.payload_type === GRP_TXT) {
             // Buffer raw_hex too so the message handler can resolve the scope/
-            // region the packet was sent under (#3742 Phase 2).
+            // region the packet was sent under (#3742 Phase 2). Same correlation
+            // limitation as the Phase 1 route/SNR: if LogRxData arrives AFTER its
+            // text-msg recv event (rare ordering on a busy link), the buffer is
+            // missed and scope resolves to null — acceptable and inherent to the
+            // adjacency-buffer design.
             this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr, rawHex: bytesToHex(raw), bufferedAt: Date.now() };
           }
           this.emitBridgeEvent('ota_packet', {

--- a/src/server/meshcoreScopeResolve.test.ts
+++ b/src/server/meshcoreScopeResolve.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  scopeTransportKey,
+  computeTransportCode,
+  resolveMessageScope,
+} from './meshcoreScopeResolve.js';
+
+// Ground-truth vectors computed from the authoritative firmware algorithm
+// (TransportKey::calcTransportCode, mirrored by meshcore-ha's match_flood_scope):
+//   key  = SHA-256("#" + name)[:16]
+//   code = LE16(HMAC-SHA256(key, [payloadType, ...payload])[:2]), clamp 0->1 / 0xFFFF->0xFFFE
+describe('meshcoreScopeResolve: scopeTransportKey', () => {
+  it('is SHA-256("#"+name) truncated to 16 bytes', () => {
+    expect(scopeTransportKey('muenchen').toString('hex')).toBe('3f50b3350a8ed17a303f07e9641dff4a');
+    expect(scopeTransportKey('sample-city').toString('hex')).toBe('69a6dcd3eb05b4520bfa3e3522f2d953');
+    expect(scopeTransportKey('bot').length).toBe(16);
+  });
+});
+
+describe('meshcoreScopeResolve: computeTransportCode', () => {
+  it('matches the firmware HMAC for known vectors (payloadType=5, payload=deadbeef)', () => {
+    expect(computeTransportCode('muenchen', 0x05, 'deadbeef')).toBe(50998);
+    expect(computeTransportCode('sample-city', 0x05, 'deadbeef')).toBe(40293);
+    expect(computeTransportCode('bot', 0x05, 'deadbeef')).toBe(35587);
+  });
+
+  it('is payload-dependent (content-keyed HMAC, not a static name hash)', () => {
+    expect(computeTransportCode('muenchen', 0x05, 'cafe0102')).toBe(30479);
+    expect(computeTransportCode('muenchen', 0x05, 'cafe0102'))
+      .not.toBe(computeTransportCode('muenchen', 0x05, 'deadbeef'));
+  });
+
+  it('never returns the two reserved values (0x0000 / 0xFFFF)', () => {
+    for (let i = 0; i < 64; i++) {
+      const code = computeTransportCode(`scope-${i}`, 0x05, 'aa' + i.toString(16).padStart(2, '0'));
+      expect(code).not.toBe(0x0000);
+      expect(code).not.toBe(0xffff);
+      expect(code).toBeGreaterThanOrEqual(1);
+      expect(code).toBeLessThanOrEqual(0xfffe);
+    }
+  });
+});
+
+describe('meshcoreScopeResolve: resolveMessageScope', () => {
+  // TRANSPORT_FLOOD packet (route_type=0): header 0x14 (payloadType=5),
+  // transportCode1=30479 (LE 0f77), code2=0, path byte 0x02 (1-byte hash, 2 hops
+  // a3,7f), payload cafe0102 → was sent under scope "muenchen".
+  const SCOPED = '140f77000002a37fcafe0102';
+  // Same but route_type=1 (FLOOD) → no transport code → unscoped.
+  const UNSCOPED = '1502a37fcafe0102';
+
+  it('resolves a scoped packet to the matching known scope name', () => {
+    expect(resolveMessageScope(SCOPED, ['muenchen', 'bot'])).toEqual({
+      scopeCode: 30479,
+      scopeName: 'muenchen',
+    });
+  });
+
+  it('returns the raw code with a null name when the scope is unknown', () => {
+    expect(resolveMessageScope(SCOPED, ['bot', 'sample-city'])).toEqual({
+      scopeCode: 30479,
+      scopeName: null,
+    });
+  });
+
+  it('reports scopeCode 0 (known-unscoped) for a non-transport route', () => {
+    expect(resolveMessageScope(UNSCOPED, ['muenchen'])).toEqual({
+      scopeCode: 0,
+      scopeName: null,
+    });
+  });
+
+  it('trims and ignores blank candidate names', () => {
+    expect(resolveMessageScope(SCOPED, ['', '  ', ' muenchen '])).toEqual({
+      scopeCode: 30479,
+      scopeName: 'muenchen',
+    });
+  });
+
+  it('returns null/null for empty, missing, or undecodable raw hex', () => {
+    expect(resolveMessageScope('', ['muenchen'])).toEqual({ scopeCode: null, scopeName: null });
+    expect(resolveMessageScope(null, ['muenchen'])).toEqual({ scopeCode: null, scopeName: null });
+    expect(resolveMessageScope(undefined, ['muenchen'])).toEqual({ scopeCode: null, scopeName: null });
+  });
+
+  it('returns null scopeCode when a transport packet is truncated before its codes', () => {
+    // header 0x14 (TRANSPORT_FLOOD) but only 2 of the 4 transport-code bytes.
+    expect(resolveMessageScope('140f77', ['muenchen'])).toEqual({
+      scopeCode: null,
+      scopeName: null,
+    });
+  });
+});

--- a/src/server/meshcoreScopeResolve.ts
+++ b/src/server/meshcoreScopeResolve.ts
@@ -20,7 +20,12 @@
 import { createHash, createHmac } from 'node:crypto';
 import { decodeMeshCorePacket, hexToBytes } from '../utils/meshcorePacketDecode.js';
 
-/** Route-type nibble values that carry transport codes (i.e. are scoped). */
+// Route-type nibble values that carry transport codes (i.e. are scoped). These
+// mirror the firmware's TransportRoute enum / meshcore.js Packet.ROUTE_TYPE_*:
+// FLOOD(0x01) and DIRECT(0x02) carry no transport codes (unscoped); the
+// TRANSPORT_* variants prepend the two 16-bit codes. We treat both transport
+// variants as scoped — a scoped DM rides TRANSPORT_DIRECT, a scoped flood/
+// channel message rides TRANSPORT_FLOOD.
 const ROUTE_TYPE_TRANSPORT_FLOOD = 0x00;
 const ROUTE_TYPE_TRANSPORT_DIRECT = 0x03;
 
@@ -89,6 +94,9 @@ export function resolveMessageScope(
   const payloadType = decoded.header.payloadType;
   const payloadHex = decoded.payload.hex;
   if (payloadHex) {
+    // Linear scan: one HMAC per candidate. The candidate set is a source's known
+    // scopes (per-channel scopes + the default scope) — realistically 1–5, a
+    // handful at most — so this is trivially cheap on the inbound-message path.
     for (const name of candidateNames) {
       const trimmed = (name || '').trim();
       if (!trimmed) continue;

--- a/src/server/meshcoreScopeResolve.ts
+++ b/src/server/meshcoreScopeResolve.ts
@@ -1,0 +1,104 @@
+/**
+ * MeshCore scope (region) resolution for RECEIVED messages — issue #3742 Phase 2.
+ *
+ * A MeshCore message can be sent with a "scope" (a.k.a. region): a named
+ * forwarding tag that controls which repeaters relay the flood packet. The
+ * scope is NOT carried as plaintext on the wire — a TRANSPORT-route packet
+ * carries a 16-bit "transport code" that is an HMAC keyed by the scope's
+ * transport key over the packet's own payload. So a code cannot be reversed to
+ * a name; instead we recompute the code for each scope name we know about and
+ * look for the one that matches (exactly what the firmware authors' own
+ * Home-Assistant integration does — `match_flood_scope` in meshcore-ha).
+ *
+ * Derivation (authoritative: firmware `TransportKey::calcTransportCode`):
+ *   key  = SHA-256("#" + name).slice(0, 16)
+ *   code = HMAC-SHA256(key, [payloadTypeByte, ...payload]).readUInt16LE(0)
+ *   then clamp the two reserved values: 0x0000 -> 0x0001, 0xFFFF -> 0xFFFE.
+ * Only transport_code_1 is meaningful; transport_code_2 is reserved and the
+ * firmware never matches on it.
+ */
+import { createHash, createHmac } from 'node:crypto';
+import { decodeMeshCorePacket, hexToBytes } from '../utils/meshcorePacketDecode.js';
+
+/** Route-type nibble values that carry transport codes (i.e. are scoped). */
+const ROUTE_TYPE_TRANSPORT_FLOOD = 0x00;
+const ROUTE_TYPE_TRANSPORT_DIRECT = 0x03;
+
+/**
+ * The resolved scope of a received message.
+ * - `scopeCode === null`  → no scope information available (room post, serial
+ *   backend, uncorrelated packet, or a truncated header).
+ * - `scopeCode === 0`     → the packet used a non-transport route, i.e. it was
+ *   sent UNSCOPED (the "no scope at all" case). 0 is a safe sentinel because a
+ *   real transport code is always clamped into [1, 0xFFFE].
+ * - `scopeCode > 0`       → the message was scoped; `scopeName` is the resolved
+ *   region name, or `null` when the code matched none of the known scopes.
+ */
+export interface ResolvedScope {
+  scopeCode: number | null;
+  scopeName: string | null;
+}
+
+/** SHA-256("#" + name) truncated to the first 16 bytes (the scope transport key). */
+export function scopeTransportKey(name: string): Buffer {
+  return createHash('sha256').update('#' + name, 'utf8').digest().subarray(0, 16);
+}
+
+/**
+ * Compute the 16-bit transport code a packet with `payloadType` + `payloadHex`
+ * would carry if sent under scope `name`. Mirrors the firmware exactly,
+ * including the reserved-value clamping.
+ */
+export function computeTransportCode(name: string, payloadType: number, payloadHex: string): number {
+  const key = scopeTransportKey(name);
+  const payload = hexToBytes(payloadHex);
+  const data = Buffer.concat([Buffer.from([payloadType & 0xff]), Buffer.from(payload)]);
+  const digest = createHmac('sha256', key).update(data).digest();
+  let code = digest.readUInt16LE(0);
+  if (code === 0) code = 1;
+  else if (code === 0xffff) code = 0xfffe;
+  return code;
+}
+
+/**
+ * Resolve the scope of a received message from its raw OTA packet hex.
+ *
+ * `candidateNames` is the set of scope/region names this source knows about
+ * (per-channel scopes + the source default scope). Resolution is best-effort:
+ * any decode problem yields `{ scopeCode: null, scopeName: null }` rather than
+ * throwing, so the message stream is never broken by a malformed packet.
+ */
+export function resolveMessageScope(
+  rawHex: string | null | undefined,
+  candidateNames: Iterable<string>,
+): ResolvedScope {
+  const decoded = decodeMeshCorePacket(rawHex);
+  if (!decoded) return { scopeCode: null, scopeName: null };
+
+  const routeType = decoded.header.routeType;
+  const isTransport =
+    routeType === ROUTE_TYPE_TRANSPORT_FLOOD || routeType === ROUTE_TYPE_TRANSPORT_DIRECT;
+
+  // Non-transport route → the message was sent unscoped (known "no scope").
+  if (!isTransport) return { scopeCode: 0, scopeName: null };
+
+  const code1 = decoded.transportCodes?.code1;
+  // Transport route but the codes were truncated/unavailable — no usable info.
+  if (typeof code1 !== 'number') return { scopeCode: null, scopeName: null };
+
+  const payloadType = decoded.header.payloadType;
+  const payloadHex = decoded.payload.hex;
+  if (payloadHex) {
+    for (const name of candidateNames) {
+      const trimmed = (name || '').trim();
+      if (!trimmed) continue;
+      if (computeTransportCode(trimmed, payloadType, payloadHex) === code1) {
+        return { scopeCode: code1, scopeName: trimmed };
+      }
+    }
+  }
+
+  // Scoped, but none of the known scopes matched — surface the raw code so the
+  // UI can show it as `#<hex>` (an unknown scope the user hasn't configured).
+  return { scopeCode: code1, scopeName: null };
+}

--- a/src/server/migrations/106_add_meshcore_message_scope.ts
+++ b/src/server/migrations/106_add_meshcore_message_scope.ts
@@ -1,0 +1,77 @@
+/**
+ * Migration 106: Add scopeCode + scopeName to meshcore_messages (#3742 Phase 2).
+ *
+ * Surfaces the scope/region a received MeshCore message was sent with. scopeCode
+ * is the packet's transport_code_1 (0 = sent unscoped, NULL = no scope info);
+ * scopeName is the region name resolved against known scopes at receive time
+ * (NULL = unscoped/unknown). Both nullable; existing + room/legacy rows keep NULL.
+ *
+ * The meshcore_messages table uses camelCase columns on every backend.
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 106 (SQLite): Adding scopeCode + scopeName to meshcore_messages...');
+    for (const col of ['scopeCode INTEGER', 'scopeName TEXT']) {
+      try {
+        db.exec(`ALTER TABLE meshcore_messages ADD COLUMN ${col}`);
+        logger.debug(`Added meshcore_messages.${col.split(' ')[0]}`);
+      } catch (e: any) {
+        if (e.message?.includes('duplicate column')) {
+          logger.debug(`meshcore_messages.${col.split(' ')[0]} already exists, skipping`);
+        } else {
+          logger.warn(`Could not add meshcore_messages.${col.split(' ')[0]}:`, e.message);
+        }
+      }
+    }
+    logger.info('Migration 106 complete (SQLite): meshcore_messages scope columns added');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 106 down: Not implemented (destructive column drop)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration106Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 106 (PostgreSQL): Adding scopeCode + scopeName to meshcore_messages...');
+  try {
+    await client.query('ALTER TABLE meshcore_messages ADD COLUMN IF NOT EXISTS "scopeCode" INTEGER');
+    await client.query('ALTER TABLE meshcore_messages ADD COLUMN IF NOT EXISTS "scopeName" TEXT');
+    logger.debug('Ensured meshcore_messages.scopeCode + scopeName exist');
+  } catch (error: any) {
+    logger.error('Migration 106 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+  logger.info('Migration 106 complete (PostgreSQL): meshcore_messages scope columns added');
+}
+
+// ============ MySQL ============
+
+export async function runMigration106Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 106 (MySQL): Adding scopeCode + scopeName to meshcore_messages...');
+  try {
+    for (const [name, ddl] of [['scopeCode', 'scopeCode INT NULL'], ['scopeName', 'scopeName TEXT NULL']] as const) {
+      const [rows] = await pool.query(`
+        SELECT COLUMN_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_messages' AND COLUMN_NAME = ?
+      `, [name]);
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await pool.query(`ALTER TABLE meshcore_messages ADD COLUMN ${ddl}`);
+        logger.debug(`Added meshcore_messages.${name}`);
+      } else {
+        logger.debug(`meshcore_messages.${name} already exists, skipping`);
+      }
+    }
+  } catch (error: any) {
+    logger.error('Migration 106 (MySQL) failed:', error.message);
+    throw error;
+  }
+  logger.info('Migration 106 complete (MySQL): meshcore_messages scope columns added');
+}


### PR DESCRIPTION
Phase 2 of #3742 (builds on the merged Phase 1 hop/route display, #3750). Per the reporter (m0urs): surface the **scope/region** a received MeshCore message was sent under — so users can spot senders using *no scope* (a common newcomer issue in DE region-gated meshes) and reply in the same scope to improve delivery.

## How it works
A scope is **not** carried as plaintext. A TRANSPORT-route packet carries a 16-bit `transport_code_1` that is a content-keyed HMAC, not a static hash of the name:

```
key  = SHA-256("#" + name)[:16]
code = LE16( HMAC-SHA256(key, [payloadTypeByte, ...payload])[:2] )   # clamp 0->1, 0xFFFF->0xFFFE
```

So a code can't be reversed to a name. Instead we recompute the code for each scope name the source knows about (per-channel scopes + the default scope) over *this packet's* payload and match — the exact approach in the firmware authors' own Home-Assistant integration (`meshcore-ha`'s `match_flood_scope`). Validated against firmware ground-truth vectors.

## Changes
- **`meshcoreScopeResolve.ts`** (new, pure) — `scopeTransportKey` / `computeTransportCode` / `resolveMessageScope`, on top of the existing `decodeMeshCorePacket`. 10 unit tests against firmware vectors incl. the reserved-value clamp.
- **Native backend** — carries the OTA `raw_hex` through the existing inbound correlation buffer (`pendingTxtMsgPath`, the same path `{ROUTE}`/`{SNR}` already ride) onto `contact_message`/`channel_message`. Pure field plumbing, no logic.
- **Manager** — resolves scope against a cached `knownScopes` set (refreshed on connect + any channel/default-scope change), stamps `scopeCode`/`scopeName`, persists + maps back on boot.
- **Schema/migration 106** (all 3 backends, idempotent) — `scopeCode` (int) + `scopeName` (text), nullable.
- **UI** — a scope line under received messages:
  - `🌐 no scope` — sent unscoped (`scopeCode = 0`)
  - `🔒 muenchen` — resolved to a known scope
  - `🔒 #a3f2` — scoped, but not one of the user's known scopes (raw code hex)

`scopeCode` semantics: **0** = sent unscoped, **>0** = the transport code, **NULL** = no scope info (room posts, serial backend, uncorrelated packet).

## Tests
Resolver crypto (10), manager wiring raw_hex→knownScopes→message (4), repo round-trip incl. the `0` unscoped sentinel and NULL-omitted rows, migration registry → 106. Existing MeshCore suite (116) still green. Full suite **7574 passed, 0 failed**; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)