### PR TITLE
feat(map): filter out Null Island (0,0) positions (#3763)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 106 (latest: `106_add_meshcore_message_scope`).
+**Current migration count:** 107 (latest: `107_clear_null_island_positions`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -28,6 +28,7 @@ import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { useMapContext } from '../../contexts/MapContext';
 import { useSettings } from '../../contexts/SettingsContext';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
+import { isNullIsland } from '../../utils/nullIsland';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
@@ -61,7 +62,8 @@ function getNodeLatLng(node: any): { lat: number; lng: number } | null {
   // Flat shape from API: node.latitude, node.longitude
   let lat = node?.latitude ?? node?.position?.latitude;
   let lng = node?.longitude ?? node?.position?.longitude;
-  if (lat != null && lng != null && (lat !== 0 || lng !== 0)) {
+  // Skip "Null Island" (0,0) — uninitialized/stale GPS default (issue #3763).
+  if (lat != null && lng != null && !isNullIsland(lat, lng)) {
     return { lat, lng };
   }
   return null;

--- a/src/components/MapAnalysis/nodePositionUtil.ts
+++ b/src/components/MapAnalysis/nodePositionUtil.ts
@@ -1,8 +1,12 @@
+import { isNullIsland } from '../../utils/nullIsland';
+
 /**
  * Resolve a node's lat/lng from either the flat API shape (`{latitude, longitude}`)
  * or a nested `position` object (some hooks return `{position: {latitude, longitude}}`).
  *
- * Returns null when neither pair is fully populated. Mirrors the pattern in
+ * Returns null when neither pair is fully populated, or when the position is at
+ * "Null Island" (0,0) — an uninitialized/stale GPS default that should not be
+ * rendered on the map (issue #3763). Mirrors the pattern in
  * src/components/Dashboard/DashboardMap.tsx that handles both shapes.
  */
 export interface MaybePositionedNode {
@@ -18,5 +22,6 @@ export function resolveNodeLatLng(
   const lat = node.latitude ?? node.position?.latitude;
   const lng = node.longitude ?? node.position?.longitude;
   if (lat == null || lng == null) return null;
+  if (isNullIsland(lat, lng)) return null;
   return [lat, lng];
 }

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -16,6 +16,7 @@ import { roleGlyphMarkerSvg } from '../../utils/mapIcons';
 import { useSource } from '../../contexts/SourceContext';
 import { getTilesetById, type TilesetId } from '../../config/tilesets';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
+import { isNullIsland } from '../../utils/nullIsland';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import GeoJsonOverlay from '../GeoJsonOverlay';
@@ -226,7 +227,11 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const positioned = useMemo(
     () => contacts.filter(c =>
       typeof c.latitude === 'number' && isFinite(c.latitude)
-      && typeof c.longitude === 'number' && isFinite(c.longitude)),
+      && typeof c.longitude === 'number' && isFinite(c.longitude)
+      // Skip "Null Island" (0,0) — uninitialized/stale GPS default (issue #3763).
+      // The DB store filters this too, but live in-memory contacts can still
+      // carry a (0,0) fix that reaches the map via getAllNodes().
+      && !isNullIsland(c.latitude, c.longitude)),
     [contacts],
   );
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 106 migrations registered', () => {
-    expect(registry.count()).toBe(106);
+  it('has all 107 migrations registered', () => {
+    expect(registry.count()).toBe(107);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_meshcore_message_scope', () => {
+  it('last migration is clear_null_island_positions', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(106);
-    expect(last.name).toContain('add_meshcore_message_scope');
+    expect(last.number).toBe(107);
+    expect(last.name).toContain('clear_null_island_positions');
   });
 
-  it('migrations are sequentially numbered from 1 to 106', () => {
+  it('migrations are sequentially numbered from 1 to 107', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -121,6 +121,7 @@ import { migration as consolidateMqttChannelsMigration, runMigration103Postgres 
 import { migration as channelDatabaseHashMigration, runMigration104Postgres as runChannelDatabaseHashPostgres, runMigration104Mysql as runChannelDatabaseHashMysql } from '../server/migrations/104_add_channel_database_hash.js';
 import { migration as meshcoreMessageRouteMigration, runMigration105Postgres as runMeshcoreMessageRoutePostgres, runMigration105Mysql as runMeshcoreMessageRouteMysql } from '../server/migrations/105_add_meshcore_message_route.js';
 import { migration as meshcoreMessageScopeMigration, runMigration106Postgres as runMeshcoreMessageScopePostgres, runMigration106Mysql as runMeshcoreMessageScopeMysql } from '../server/migrations/106_add_meshcore_message_scope.js';
+import { migration as clearNullIslandMigration, runMigration107Postgres as runClearNullIslandPostgres, runMigration107Mysql as runClearNullIslandMysql } from '../server/migrations/107_clear_null_island_positions.js';
 
 // ============================================================================
 // Registry
@@ -1680,4 +1681,19 @@ registry.register({
   sqlite: (db) => meshcoreMessageScopeMigration.up(db),
   postgres: (client) => runMeshcoreMessageScopePostgres(client),
   mysql: (pool) => runMeshcoreMessageScopeMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 107: clear Null Island (0,0) node positions
+// One-shot cleanup of bogus (0,0) GPS fixes stored before the #3763 ingestion
+// filter; nulls latitude/longitude in nodes + meshcore_nodes.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 107,
+  name: 'clear_null_island_positions',
+  settingsKey: 'migration_107_clear_null_island_positions',
+  sqlite: (db) => clearNullIslandMigration.up(db),
+  postgres: (client) => runClearNullIslandPostgres(client),
+  mysql: (pool) => runClearNullIslandMysql(pool),
 });

--- a/src/db/repositories/analysis.test.ts
+++ b/src/db/repositories/analysis.test.ts
@@ -73,6 +73,25 @@ describe('AnalysisRepository.getPositions', () => {
     expect(result.hasMore).toBe(false);
   });
 
+  it('skips Null Island (0,0) fixes so trails/heatmap never plot them (#3763)', async () => {
+    // A complete (0,0) fix paired at a timestamp between `earlier` and `now`.
+    const nullTs = now - 500;
+    const insert = sqlite.prepare(
+      'INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, createdAt, sourceId) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    );
+    insert.run('!00000001', 1, 'latitude', nullTs, 0.0004, nullTs, 'src-a');
+    insert.run('!00000001', 1, 'longitude', nullTs, -0.0002, nullTs, 'src-a');
+
+    const result = await repo.getPositions({
+      sourceIds: ['src-a'],
+      sinceMs: now - 60_000,
+      pageSize: 10,
+    });
+    // Only the two legitimate fixes survive; the Null Island fix is dropped.
+    expect(result.items).toHaveLength(2);
+    expect(result.items.some((r: { timestamp: number }) => r.timestamp === nullTs)).toBe(false);
+  });
+
   it('skips orphaned latitude rows that have no matching longitude', async () => {
     // Insert an extra latitude row at a timestamp where no longitude exists.
     // Pick a timestamp BETWEEN `earlier` and `now` so it would otherwise be

--- a/src/db/repositories/analysis.ts
+++ b/src/db/repositories/analysis.ts
@@ -21,6 +21,7 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
 import { and, desc, gte, inArray, lt, or, eq } from 'drizzle-orm';
+import { isNullIsland } from '../../utils/nullIsland.js';
 import {
   telemetrySqlite,
   telemetryPostgres,
@@ -379,6 +380,12 @@ export class AnalysisRepository {
       const key = pairKey(lat.sourceId, lat.nodeNum, lat.timestamp);
       const lon = lonByKey.get(key);
       if (lon === undefined) continue;
+      // Skip "Null Island" (0,0) fixes so stale GPS defaults never reach the
+      // position trails or coverage heatmap (issue #3763). Covers both /positions
+      // and /coverage-grid (the grid reuses this pivot). New (0,0) fixes are
+      // blocked at ingestion and migration 107 purges the historical rows; this
+      // guard also hides any that pre-date the migration run.
+      if (isNullIsland(lat.value, lon)) continue;
       const alt = altByKey.get(key);
       pivots.push({
         nodeNum: lat.nodeNum,

--- a/src/server/meshcoreManager.contactPersistence.test.ts
+++ b/src/server/meshcoreManager.contactPersistence.test.ts
@@ -99,6 +99,35 @@ describe('MeshCoreManager contact persistence (issue #3092)', () => {
     );
   });
 
+  it('stores null lat/lon for a Null Island (0,0) contact (issue #3763)', async () => {
+    const manager = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+        // (0,0) — uninitialized GPS default; must not be persisted as a position.
+        latitude: 0,
+        longitude: 0,
+        last_advert: 1_700_000_000,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: REPEATER_PUBKEY,
+        latitude: null,
+        longitude: null,
+      }),
+      'src-a',
+    );
+  });
+
   it('persists advType to meshcore_nodes on contact_added', async () => {
     const manager = new MeshCoreManager('src-a');
     dispatchBridgeEvent(manager, {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -10,6 +10,7 @@
 
 import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
+import { isNullIsland } from '../utils/nullIsland.js';
 import databaseService from '../services/database.js';
 import { dataEventEmitter } from './services/dataEventEmitter.js';
 import { compileAutoAckRegex } from './utils/autoAckRegex.js';
@@ -1463,13 +1464,16 @@ class MeshCoreManager extends EventEmitter {
    */
   private async persistContact(contact: MeshCoreContact): Promise<void> {
     try {
+      // Drop "Null Island" (0,0) fixes — the GPS default before a lock — so a
+      // bogus position never lands in the node row (issue #3763).
+      const atNullIsland = isNullIsland(contact.latitude, contact.longitude);
       await databaseService.meshcore.upsertNode(
         {
           publicKey: contact.publicKey,
           name: contact.advName ?? contact.name ?? null,
           advType: contact.advType ?? null,
-          latitude: contact.latitude ?? null,
-          longitude: contact.longitude ?? null,
+          latitude: atNullIsland ? null : (contact.latitude ?? null),
+          longitude: atNullIsland ? null : (contact.longitude ?? null),
           rssi: contact.rssi ?? null,
           snr: contact.snr ?? null,
           lastHeard: contact.lastSeen ?? null,

--- a/src/server/meshtasticManager.positionChannel.test.ts
+++ b/src/server/meshtasticManager.positionChannel.test.ts
@@ -219,4 +219,43 @@ describe('MeshtasticManager — position channel resolution (issue #3682)', () =
       expect(latCall![0].channel).toBe(0);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Null Island filtering (issue #3763)
+  //
+  // GPS modules emit (0,0) before acquiring a fix. A stale (0,0) fix can still
+  // be transmitted, so we drop any position at or near (0,0) before it reaches
+  // the node row or the position-history telemetry.
+  // -------------------------------------------------------------------------
+  describe('processPositionMessageProtobuf filters Null Island (0,0)', () => {
+    it('drops a near-(0,0) position without storing telemetry', async () => {
+      const mgr = makeManager();
+      // 0.0005°, -0.0003° — both inside the Null Island radius (firmware rounding).
+      const meshPacket = { channel: 0, from: 123456, id: 999 };
+      const position = { latitudeI: 5000, longitudeI: -3000 };
+
+      await (mgr as any).processPositionMessageProtobuf(meshPacket, position, {
+        decryptedBy: null,
+        decryptedChannelId: undefined,
+      });
+
+      expect(insertTelemetryMock).not.toHaveBeenCalled();
+    });
+
+    it('still stores a legitimate position far from (0,0)', async () => {
+      const mgr = makeManager();
+      const meshPacket = { channel: 0, from: 123456, id: 999 };
+      const position = { latitudeI: 400000000, longitudeI: -750000000 };
+
+      await (mgr as any).processPositionMessageProtobuf(meshPacket, position, {
+        decryptedBy: null,
+        decryptedChannelId: undefined,
+      });
+
+      const latCall = insertTelemetryMock.mock.calls.find(
+        (c: any[]) => c[0]?.telemetryType === 'latitude',
+      );
+      expect(latCall).toBeDefined();
+    });
+  });
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8,6 +8,7 @@ import type { ITransport } from './transports/transport.js';
 import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import { calculateDistance } from '../utils/distance.js';
+import { isNullIsland } from '../utils/nullIsland.js';
 import { isPointInGeofence, distanceToGeofenceCenter } from '../utils/geometry.js';
 import { formatTime, formatDate } from '../utils/datetime.js';
 import { logger } from '../utils/logger.js';
@@ -6059,6 +6060,14 @@ class MeshtasticManager implements ISourceManager {
       return false;
     }
     if (longitude < -180 || longitude > 180) {
+      return false;
+    }
+
+    // Reject "Null Island" (0,0) — the GPS default before a fix, with no real
+    // mesh infrastructure there (issue #3763). This gate fronts both the
+    // POSITION_APP path and the NodeInfo position exchange, so a bogus (0,0)
+    // never reaches the node row or the position-history telemetry.
+    if (isNullIsland(latitude, longitude)) {
       return false;
     }
 

--- a/src/server/migrations/107_clear_null_island_positions.test.ts
+++ b/src/server/migrations/107_clear_null_island_positions.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Migration 107 — Clear Null Island (0,0) node positions (SQLite, #3763).
+ *
+ * The PostgreSQL/MySQL paths run the same UPDATE with backend-quoted column
+ * names and are exercised by integration tests; only the SQLite path is
+ * covered here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './107_clear_null_island_positions.js';
+
+interface PosRow {
+  id: string;
+  latitude: number | null;
+  longitude: number | null;
+  latitudeOverride?: number | null;
+}
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    latitude REAL,
+    longitude REAL,
+    latitudeOverride REAL
+  );`);
+  db.exec(`CREATE TABLE meshcore_nodes (
+    id TEXT PRIMARY KEY,
+    latitude REAL,
+    longitude REAL
+  );`);
+  return db;
+}
+
+function getNode(db: Database.Database, table: string, id: string): PosRow {
+  return db.prepare(`SELECT * FROM ${table} WHERE id = ?`).get(id) as PosRow;
+}
+
+describe('Migration 107 — clear Null Island positions (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  it('nulls latitude/longitude for exact (0,0) and near-(0,0) rows', () => {
+    db.prepare('INSERT INTO nodes (id, latitude, longitude) VALUES (?, ?, ?)').run('exact', 0, 0);
+    db.prepare('INSERT INTO nodes (id, latitude, longitude) VALUES (?, ?, ?)').run('near', 0.0005, -0.0003);
+    db.prepare('INSERT INTO meshcore_nodes (id, latitude, longitude) VALUES (?, ?, ?)').run('mc', 0, 0.000001);
+
+    migration.up(db);
+
+    expect(getNode(db, 'nodes', 'exact')).toMatchObject({ latitude: null, longitude: null });
+    expect(getNode(db, 'nodes', 'near')).toMatchObject({ latitude: null, longitude: null });
+    expect(getNode(db, 'meshcore_nodes', 'mc')).toMatchObject({ latitude: null, longitude: null });
+  });
+
+  it('preserves legitimate positions, including near-zero on a single axis', () => {
+    db.prepare('INSERT INTO nodes (id, latitude, longitude) VALUES (?, ?, ?)').run('sf', 37.7749, -122.4194);
+    // Greenwich: longitude ~0 but a real latitude — must NOT be cleared.
+    db.prepare('INSERT INTO nodes (id, latitude, longitude) VALUES (?, ?, ?)').run('greenwich', 51.4778, 0.0001);
+
+    migration.up(db);
+
+    expect(getNode(db, 'nodes', 'sf')).toMatchObject({ latitude: 37.7749, longitude: -122.4194 });
+    expect(getNode(db, 'nodes', 'greenwich')).toMatchObject({ latitude: 51.4778, longitude: 0.0001 });
+  });
+
+  it('leaves a manual latitudeOverride untouched', () => {
+    db.prepare('INSERT INTO nodes (id, latitude, longitude, latitudeOverride) VALUES (?, ?, ?, ?)')
+      .run('overridden', 0, 0, 12.34);
+
+    migration.up(db);
+
+    const row = getNode(db, 'nodes', 'overridden');
+    expect(row.latitude).toBeNull();
+    expect(row.latitudeOverride).toBe(12.34);
+  });
+
+  it('is idempotent — a second run is a no-op', () => {
+    db.prepare('INSERT INTO nodes (id, latitude, longitude) VALUES (?, ?, ?)').run('exact', 0, 0);
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+    expect(getNode(db, 'nodes', 'exact')).toMatchObject({ latitude: null, longitude: null });
+  });
+});

--- a/src/server/migrations/107_clear_null_island_positions.test.ts
+++ b/src/server/migrations/107_clear_null_island_positions.test.ts
@@ -29,7 +29,35 @@ function makeDb(): Database.Database {
     latitude REAL,
     longitude REAL
   );`);
+  db.exec(`CREATE TABLE telemetry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nodeNum INTEGER NOT NULL,
+    telemetryType TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    value REAL NOT NULL
+  );`);
   return db;
+}
+
+/** Insert a paired position fix (a latitude row + a longitude row) into telemetry. */
+function insertFix(
+  db: Database.Database,
+  nodeNum: number,
+  timestamp: number,
+  lat: number,
+  lon: number,
+): void {
+  const stmt = db.prepare(
+    'INSERT INTO telemetry (nodeNum, telemetryType, timestamp, value) VALUES (?, ?, ?, ?)',
+  );
+  stmt.run(nodeNum, 'latitude', timestamp, lat);
+  stmt.run(nodeNum, 'longitude', timestamp, lon);
+}
+
+function telemetryRows(db: Database.Database): Array<{ telemetryType: string; value: number }> {
+  return db
+    .prepare('SELECT telemetryType, value FROM telemetry ORDER BY id')
+    .all() as Array<{ telemetryType: string; value: number }>;
 }
 
 function getNode(db: Database.Database, table: string, id: string): PosRow {
@@ -82,5 +110,44 @@ describe('Migration 107 — clear Null Island positions (SQLite)', () => {
     migration.up(db);
     expect(() => migration.up(db)).not.toThrow();
     expect(getNode(db, 'nodes', 'exact')).toMatchObject({ latitude: null, longitude: null });
+  });
+
+  describe('telemetry position-history cleanup', () => {
+    it('deletes both rows of a (0,0) fix while keeping legitimate fixes', () => {
+      insertFix(db, 1, 1000, 0, 0); // Null Island → both rows deleted
+      insertFix(db, 1, 2000, 0.0004, -0.0002); // near-zero → both deleted
+      insertFix(db, 2, 3000, 37.7749, -122.4194); // real → kept
+      // Greenwich: lon ~0 but real lat — must be kept (not a pair of near-zeros).
+      insertFix(db, 3, 4000, 51.4778, 0.0001);
+
+      migration.up(db);
+
+      const rows = telemetryRows(db);
+      // Only the two legitimate fixes survive (2 rows each).
+      expect(rows).toHaveLength(4);
+      const lats = rows.filter((r) => r.telemetryType === 'latitude').map((r) => r.value);
+      expect(lats.sort()).toEqual([37.7749, 51.4778]);
+    });
+
+    it('does not delete an unpaired near-zero latitude row', () => {
+      // A lone latitude row with no matching longitude at the same (nodeNum,
+      // timestamp) is not a Null Island fix and must be left untouched.
+      db.prepare(
+        'INSERT INTO telemetry (nodeNum, telemetryType, timestamp, value) VALUES (?, ?, ?, ?)',
+      ).run(1, 'latitude', 5000, 0);
+
+      migration.up(db);
+
+      expect(telemetryRows(db)).toHaveLength(1);
+    });
+
+    it('is idempotent for telemetry — a second run deletes nothing more', () => {
+      insertFix(db, 1, 1000, 0, 0);
+      insertFix(db, 2, 2000, 10, 20);
+      migration.up(db);
+      const after = telemetryRows(db);
+      migration.up(db);
+      expect(telemetryRows(db)).toEqual(after);
+    });
   });
 });

--- a/src/server/migrations/107_clear_null_island_positions.ts
+++ b/src/server/migrations/107_clear_null_island_positions.ts
@@ -1,0 +1,85 @@
+/**
+ * Migration 107: Clear "Null Island" (0,0) node positions (#3763).
+ *
+ * GPS modules emit (0,0) before acquiring a fix, and a stale (0,0) fix can be
+ * transmitted and stored. As of #3763 new positions at or near (0,0) are
+ * filtered at ingestion, but rows captured before that fix still carry a bogus
+ * (0,0) and would render a marker in the South Atlantic. This one-shot data
+ * migration nulls the latitude/longitude of any such row in both the Meshtastic
+ * `nodes` table and the MeshCore `meshcore_nodes` table.
+ *
+ * Only the GPS-reported `latitude`/`longitude` columns are touched — a manual
+ * `latitudeOverride`/`longitudeOverride` is intentionally left alone.
+ *
+ * Naturally idempotent: once a row is nulled it no longer matches the WHERE
+ * clause, so re-running is a no-op. The radius (NULL_ISLAND_EPSILON) is shared
+ * with the runtime filter so the two never drift.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import { NULL_ISLAND_EPSILON as EPS } from '../../utils/nullIsland.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 107 (SQLite): Clearing Null Island (0,0) node positions...');
+    for (const table of ['nodes', 'meshcore_nodes']) {
+      try {
+        db.exec(
+          `UPDATE ${table} SET latitude = NULL, longitude = NULL ` +
+            `WHERE latitude IS NOT NULL AND longitude IS NOT NULL ` +
+            `AND ABS(latitude) < ${EPS} AND ABS(longitude) < ${EPS}`,
+        );
+        logger.debug(`Cleared Null Island positions in ${table}`);
+      } catch (e: any) {
+        logger.warn(`Could not clear Null Island positions in ${table}:`, e.message);
+      }
+    }
+    logger.info('Migration 107 complete (SQLite): Null Island positions cleared');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 107 down: Not implemented (cleared positions are not recoverable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration107Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 107 (PostgreSQL): Clearing Null Island (0,0) node positions...');
+  try {
+    for (const table of ['nodes', 'meshcore_nodes']) {
+      await client.query(
+        `UPDATE ${table} SET "latitude" = NULL, "longitude" = NULL ` +
+          `WHERE "latitude" IS NOT NULL AND "longitude" IS NOT NULL ` +
+          `AND ABS("latitude") < ${EPS} AND ABS("longitude") < ${EPS}`,
+      );
+      logger.debug(`Cleared Null Island positions in ${table}`);
+    }
+  } catch (error: any) {
+    logger.error('Migration 107 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+  logger.info('Migration 107 complete (PostgreSQL): Null Island positions cleared');
+}
+
+// ============ MySQL ============
+
+export async function runMigration107Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 107 (MySQL): Clearing Null Island (0,0) node positions...');
+  try {
+    for (const table of ['nodes', 'meshcore_nodes']) {
+      await pool.query(
+        `UPDATE ${table} SET latitude = NULL, longitude = NULL ` +
+          `WHERE latitude IS NOT NULL AND longitude IS NOT NULL ` +
+          `AND ABS(latitude) < ${EPS} AND ABS(longitude) < ${EPS}`,
+      );
+      logger.debug(`Cleared Null Island positions in ${table}`);
+    }
+  } catch (error: any) {
+    logger.error('Migration 107 (MySQL) failed:', error.message);
+    throw error;
+  }
+  logger.info('Migration 107 complete (MySQL): Null Island positions cleared');
+}

--- a/src/server/migrations/107_clear_null_island_positions.ts
+++ b/src/server/migrations/107_clear_null_island_positions.ts
@@ -4,16 +4,22 @@
  * GPS modules emit (0,0) before acquiring a fix, and a stale (0,0) fix can be
  * transmitted and stored. As of #3763 new positions at or near (0,0) are
  * filtered at ingestion, but rows captured before that fix still carry a bogus
- * (0,0) and would render a marker in the South Atlantic. This one-shot data
- * migration nulls the latitude/longitude of any such row in both the Meshtastic
- * `nodes` table and the MeshCore `meshcore_nodes` table.
+ * (0,0) and would render in the South Atlantic. This one-shot data migration:
+ *
+ *   1. Nulls the latitude/longitude of any such row in the Meshtastic `nodes`
+ *      table and the MeshCore `meshcore_nodes` table (node markers).
+ *   2. Deletes the paired (0,0) latitude/longitude rows from the Meshtastic
+ *      `telemetry` table (position trails + coverage heatmap), keyed on
+ *      (nodeNum, timestamp) so a row is removed only when BOTH the latitude and
+ *      longitude of the same fix are near zero. Altitude/speed rows of the fix
+ *      are left as harmless orphans (the render layer needs lat AND lon to plot).
  *
  * Only the GPS-reported `latitude`/`longitude` columns are touched — a manual
  * `latitudeOverride`/`longitudeOverride` is intentionally left alone.
  *
- * Naturally idempotent: once a row is nulled it no longer matches the WHERE
- * clause, so re-running is a no-op. The radius (NULL_ISLAND_EPSILON) is shared
- * with the runtime filter so the two never drift.
+ * Naturally idempotent: once a node row is nulled (or a telemetry pair deleted)
+ * it no longer matches, so re-running is a no-op. The radius
+ * (NULL_ISLAND_EPSILON) is shared with the runtime filter so the two never drift.
  */
 import type { Database } from 'better-sqlite3';
 import { logger } from '../../utils/logger.js';
@@ -36,6 +42,21 @@ export const migration = {
         logger.warn(`Could not clear Null Island positions in ${table}:`, e.message);
       }
     }
+    // Delete paired (0,0) lat/lon position-history rows from telemetry.
+    try {
+      db.exec(
+        `DELETE FROM telemetry ` +
+          `WHERE telemetryType IN ('latitude','longitude') AND ABS(value) < ${EPS} ` +
+          `AND (nodeNum, timestamp) IN (` +
+          `SELECT lat.nodeNum, lat.timestamp FROM telemetry lat ` +
+          `JOIN telemetry lon ON lon.nodeNum = lat.nodeNum AND lon.timestamp = lat.timestamp ` +
+          `WHERE lat.telemetryType = 'latitude' AND ABS(lat.value) < ${EPS} ` +
+          `AND lon.telemetryType = 'longitude' AND ABS(lon.value) < ${EPS})`,
+      );
+      logger.debug('Deleted Null Island position rows from telemetry');
+    } catch (e: any) {
+      logger.warn('Could not delete Null Island telemetry rows:', e.message);
+    }
     logger.info('Migration 107 complete (SQLite): Null Island positions cleared');
   },
 
@@ -57,6 +78,17 @@ export async function runMigration107Postgres(client: import('pg').PoolClient): 
       );
       logger.debug(`Cleared Null Island positions in ${table}`);
     }
+    // Delete paired (0,0) lat/lon position-history rows from telemetry.
+    await client.query(
+      `DELETE FROM telemetry ` +
+        `WHERE "telemetryType" IN ('latitude','longitude') AND ABS("value") < ${EPS} ` +
+        `AND ("nodeNum", "timestamp") IN (` +
+        `SELECT lat."nodeNum", lat."timestamp" FROM telemetry lat ` +
+        `JOIN telemetry lon ON lon."nodeNum" = lat."nodeNum" AND lon."timestamp" = lat."timestamp" ` +
+        `WHERE lat."telemetryType" = 'latitude' AND ABS(lat."value") < ${EPS} ` +
+        `AND lon."telemetryType" = 'longitude' AND ABS(lon."value") < ${EPS})`,
+    );
+    logger.debug('Deleted Null Island position rows from telemetry');
   } catch (error: any) {
     logger.error('Migration 107 (PostgreSQL) failed:', error.message);
     throw error;
@@ -77,6 +109,16 @@ export async function runMigration107Mysql(pool: import('mysql2/promise').Pool):
       );
       logger.debug(`Cleared Null Island positions in ${table}`);
     }
+    // Delete paired (0,0) lat/lon position-history rows from telemetry. MySQL
+    // forbids a DELETE whose subquery targets the same table (error 1093), so
+    // use a multi-table self-join delete that removes both rows of the pair.
+    await pool.query(
+      `DELETE lat, lon FROM telemetry lat ` +
+        `JOIN telemetry lon ON lon.nodeNum = lat.nodeNum AND lon.timestamp = lat.timestamp ` +
+        `WHERE lat.telemetryType = 'latitude' AND ABS(lat.value) < ${EPS} ` +
+        `AND lon.telemetryType = 'longitude' AND ABS(lon.value) < ${EPS}`,
+    );
+    logger.debug('Deleted Null Island position rows from telemetry');
   } catch (error: any) {
     logger.error('Migration 107 (MySQL) failed:', error.message);
     throw error;

--- a/src/utils/nullIsland.test.ts
+++ b/src/utils/nullIsland.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isNullIsland, NULL_ISLAND_EPSILON } from './nullIsland.js';
+
+describe('isNullIsland', () => {
+  it('flags exactly (0, 0)', () => {
+    expect(isNullIsland(0, 0)).toBe(true);
+  });
+
+  it('flags near-zero values within the epsilon (firmware rounding / float serialization)', () => {
+    expect(isNullIsland(0.000001, 0)).toBe(true);
+    expect(isNullIsland(0, 0.000001)).toBe(true);
+    expect(isNullIsland(-0.0005, 0.0009)).toBe(true);
+  });
+
+  it('does not flag a coordinate at or beyond the epsilon on either axis', () => {
+    expect(isNullIsland(NULL_ISLAND_EPSILON, 0)).toBe(false);
+    expect(isNullIsland(0, NULL_ISLAND_EPSILON)).toBe(false);
+    expect(isNullIsland(0.01, 0)).toBe(false);
+  });
+
+  it('does not flag legitimate real-world positions', () => {
+    expect(isNullIsland(37.7749, -122.4194)).toBe(false); // San Francisco
+    expect(isNullIsland(51.5074, -0.1278)).toBe(false); // London (near 0° lon, far from 0° lat)
+    expect(isNullIsland(0.5, 0.5)).toBe(false);
+    expect(isNullIsland(-33.8688, 151.2093)).toBe(false); // Sydney
+  });
+
+  it('treats a near-zero longitude with a real latitude as a real position', () => {
+    // The Greenwich meridian crosses populated land; only BOTH axes near zero is Null Island.
+    expect(isNullIsland(51.4778, 0.0001)).toBe(false); // Greenwich Observatory
+  });
+
+  it('returns false for missing or non-finite coordinates', () => {
+    expect(isNullIsland(null, null)).toBe(false);
+    expect(isNullIsland(0, null)).toBe(false);
+    expect(isNullIsland(undefined, 0)).toBe(false);
+    expect(isNullIsland(NaN, 0)).toBe(false);
+    expect(isNullIsland(0, Infinity)).toBe(false);
+  });
+});

--- a/src/utils/nullIsland.ts
+++ b/src/utils/nullIsland.ts
@@ -1,0 +1,29 @@
+/**
+ * "Null Island" filtering — issue #3763.
+ *
+ * Null Island is the point at 0°N, 0°E in the South Atlantic Ocean. GPS modules
+ * emit (0, 0) as their default reading before acquiring a fix, and a stale (0, 0)
+ * fix cached before a reboot can still be transmitted and stored. No real mesh
+ * infrastructure exists there, so a coordinate at or near (0, 0) is treated as a
+ * bogus position and filtered out before it is stored or rendered on the map.
+ *
+ * A small radius (rather than exact equality) is used because firmware rounding
+ * or floating-point serialization can yield values like 0.000001 instead of
+ * exactly 0.0, which an equality check would miss. ~0.001° is roughly 111 m at
+ * the equator — well inside any realistic GPS error, and far from any deployment.
+ */
+export const NULL_ISLAND_EPSILON = 0.001;
+
+/**
+ * True when a coordinate is at or within {@link NULL_ISLAND_EPSILON} degrees of
+ * Null Island (0, 0). Null/undefined inputs are not Null Island (there is no
+ * position to reject), so callers should handle missing coordinates separately.
+ */
+export function isNullIsland(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+): boolean {
+  if (latitude == null || longitude == null) return false;
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return false;
+  return Math.abs(latitude) < NULL_ISLAND_EPSILON && Math.abs(longitude) < NULL_ISLAND_EPSILON;
+}


### PR DESCRIPTION
Closes #3763.

Nodes with uninitialized or stale GPS emit (0,0) — "Null Island", in the middle of the South Atlantic — which rendered false markers on the main map, the unified map, and the Map Analysis workspace. This filters them at every store-and-render chokepoint and cleans up rows already stored.

## Approach

A shared helper `isNullIsland(lat, lon)` (`src/utils/nullIsland.ts`) treats a coordinate within `NULL_ISLAND_EPSILON` (`0.001°`, ~111 m) of (0,0) as bogus. A **radius** rather than exact equality, per the issue, so firmware-rounded values like `0.000001` are also caught. Lives in `src/utils` because it's imported by both backend and frontend.

## Filter before storing (backend)

- **`meshtasticManager.isValidPosition()`** — this single gate fronts both the `POSITION_APP` path and the NodeInfo position exchange, so a bogus (0,0) never reaches the node row *or* the position-history telemetry. (The pre-existing `latitudeI && longitudeI` guard only caught *exactly* 0,0; near-zero slipped through.)
- **`meshcoreManager.persistContact()`** — stores `null` lat/lon for a (0,0) contact advert.

## Filter before rendering (frontend)

- **`nodePositionUtil.resolveNodeLatLng()`** — covers the Map Analysis workspace and unified map (`NodeMarkersLayer` consumes it).
- **`DashboardMap.getNodeLatLng()`** — replaces the imprecise `(lat !== 0 || lng !== 0)` exact check; covers the Dashboard main map and unified map.
- **`MeshCoreMap` `positioned` filter** — needed because live in-memory contacts can still carry a (0,0) fix that reaches the map via `getAllNodes()`, bypassing the DB-store filter.

## One-shot cleanup

- **Migration 107** (`clear_null_island_positions`) nulls existing (0,0) `latitude`/`longitude` in `nodes` and `meshcore_nodes`. A manual `latitudeOverride`/`longitudeOverride` is intentionally left alone. Naturally idempotent (a nulled row no longer matches the WHERE clause) and shares `NULL_ISLAND_EPSILON` with the runtime filter so the two never drift. Implemented across all three backends (SQLite/PostgreSQL/MySQL).

## Tests

- New `nullIsland.test.ts` and `107_clear_null_island_positions.test.ts` suites, including the Greenwich-meridian edge case (lon≈0 but a real latitude → **not** filtered).
- Null Island cases added to `meshtasticManager.positionChannel.test.ts` and `meshcoreManager.contactPersistence.test.ts`.
- Migration count test bumped 106 → 107.
- Full Vitest suite green: **530 files, 0 failures**.

## Scope note

Scoped to **node markers** (the issue's stated impact). Position *trails* / coverage *heatmap* render historical telemetry; since the Meshtastic ingestion gate now also blocks (0,0) from the telemetry table, new history won't contain it either. Migration 107 covers the already-stored node rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBLhGGNh35oMwTL53va1Y5