### PR TITLE
feat(meshcore): query only 0-hop repeaters for region discovery + route the query direct (#3743)

### DIFF
--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -267,7 +267,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             </button>
             <p className="hint" style={{ fontSize: '0.8rem', marginTop: '0.25rem' }}>
               {t('meshcore.scope.discover_hint',
-                'Queries known repeaters for the regions they serve. Run "Discover Repeaters" (above) first for the fullest list.')}
+                'Sweeps for nearby (0-hop / direct-range) repeaters and asks each one which regions it serves.')}
             </p>
             {discoveredRegions && discoveredRegions.length > 0 && (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.5rem' }}>

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -70,9 +70,14 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
         return;
       }
       setDiscoveredRegions(result.regions);
-      if (result.regions.length === 0) {
+      if (result.noZeroHopRepeaters) {
         showToast(
-          t('meshcore.scope.discover_none', 'No regions found. Try "Discover Repeaters" first, then retry.'),
+          t('meshcore.scope.discover_no_repeaters', 'No nearby (0-hop) repeaters found. Move closer to a repeater and try again.'),
+          'info',
+        );
+      } else if (result.regions.length === 0) {
+        showToast(
+          t('meshcore.scope.discover_none', 'Nearby repeaters reported no regions.'),
           'info',
         );
       }

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -146,7 +146,7 @@ export interface MeshCoreActions {
   /** Set the per-source default region/scope. Returns the normalized value, or null on error. */
   setDefaultScope: (scope: string) => Promise<string | null>;
   /** Discover region/scope names served by nearby repeaters (#3667 phase 3). */
-  discoverRegions: () => Promise<{ regions: string[]; perRepeater: Array<{ publicKey: string; name: string; regions: string[] }> } | null>;
+  discoverRegions: () => Promise<{ regions: string[]; perRepeater: Array<{ publicKey: string; name: string; regions: string[] }>; noZeroHopRepeaters?: boolean } | null>;
   /** Remove a contact from the device's contact list. Resolves `true` when
    *  the device ACKed the removal; `false` for any error. */
   removeContact: (publicKey: string) => Promise<boolean>;
@@ -812,6 +812,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       return {
         regions: Array.isArray(data.regions) ? data.regions : [],
         perRepeater: Array.isArray(data.perRepeater) ? data.perRepeater : [],
+        noZeroHopRepeaters: data.noZeroHopRepeaters === true,
       };
     } catch (_err) {
       setError('Failed to discover regions');

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -107,6 +107,10 @@ function makeManager(opts: {
     sweepIdx += 1;
     return { returned: seen.length, newCount: 0, seen };
   });
+  // discoverRegions installs a zero-hop direct out_path before each
+  // request_regions (#3743) so the ANON_REQ routes direct. Stub the device
+  // round-trip + DB mirror; these tests assert selection/ordering, not routing.
+  vi.spyOn(m as any, 'setContactOutPath').mockResolvedValue(true);
 
   return { manager: m, bridgeCalls, scopeUpdates };
 }
@@ -456,6 +460,11 @@ describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
     expect(bridgeCalls.filter(c => c.cmd === 'request_regions').map(c => c.params.public_key)).toEqual([bb]);
     expect(result.perRepeater.map(r => r.publicKey)).toEqual([bb]);
     expect(result.regions).toEqual(['muenchen']);
+    // Installs a zero-hop direct out_path (empty bytes) before querying, so the
+    // regions ANON_REQ routes direct rather than flooding (#3743).
+    expect(manager.setContactOutPath).toHaveBeenCalledWith(bb, expect.any(Uint8Array), 1);
+    const [, installedPath] = (manager.setContactOutPath as any).mock.calls.find((c: any[]) => c[0] === bb);
+    expect(installedPath.length).toBe(0);
   });
 
   it('queries in sweep arrival order, not contact-map order', async () => {

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -462,7 +462,7 @@ describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
     expect(result.regions).toEqual(['muenchen']);
     // Installs a zero-hop direct out_path (empty bytes) before querying, so the
     // regions ANON_REQ routes direct rather than flooding (#3743).
-    expect(manager.setContactOutPath).toHaveBeenCalledWith(bb, expect.any(Uint8Array), 1);
+    expect(manager.setContactOutPath).toHaveBeenCalledWith(bb, expect.any(Uint8Array), 1, expect.any(Number));
     const [, installedPath] = (manager.setContactOutPath as any).mock.calls.find((c: any[]) => c[0] === bb);
     expect(installedPath.length).toBe(0);
   });

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -30,6 +30,12 @@ function makeManager(opts: {
   /** per-repeater `request_regions` replies, keyed by publicKey. A value of
    *  'fail' makes that repeater's request reject. */
   regionsByRepeater?: Record<string, string[] | 'fail'>;
+  /** Simulated 0-hop discovery sweep result(s) for discoverRegions (#3743).
+   *  - omitted → every sweep "discovers" all seeded repeater/room contacts
+   *  - string[] → every sweep discovers exactly these keys (in this order)
+   *  - string[][] → attempt i discovers zeroHop[i] (drives the retry path);
+   *    attempts past the end repeat the last entry. Pass [] for always-empty. */
+  zeroHop?: string[] | string[][];
 } = {}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[]; scopeUpdates: Array<{ id: number; scope: string | null }> } {
   const m = new MeshCoreManager('test-source');
   (m as any).deviceType = MeshCoreDeviceType.COMPANION;
@@ -83,6 +89,24 @@ function makeManager(opts: {
     }),
     setSourceSetting: vi.fn(async () => {}),
   } as any);
+
+  // Simulate the 0-hop discovery sweep that discoverRegions() runs (#3743) so
+  // tests don't wait on the real 8s collection window or fake discovery packets.
+  const defaultZeroHop = (opts.contacts ?? [])
+    .filter((c) => c.advType === 2 || c.advType === 3)
+    .map((c) => c.publicKey);
+  const sweepAttempts: string[][] =
+    opts.zeroHop === undefined
+      ? [defaultZeroHop]
+      : opts.zeroHop.length > 0 && Array.isArray(opts.zeroHop[0])
+        ? (opts.zeroHop as string[][])
+        : [opts.zeroHop as string[]];
+  let sweepIdx = 0;
+  vi.spyOn(m as any, 'discoverNodes').mockImplementation(async () => {
+    const seen = sweepAttempts[Math.min(sweepIdx, sweepAttempts.length - 1)] ?? [];
+    sweepIdx += 1;
+    return { returned: seen.length, newCount: 0, seen };
+  });
 
   return { manager: m, bridgeCalls, scopeUpdates };
 }
@@ -396,15 +420,6 @@ describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
     expect(result.perRepeater.map(r => r.publicKey)).toEqual(['bb'.repeat(32)]);
   });
 
-  it('returns empty when there are no repeater contacts', async () => {
-    const { manager, bridgeCalls } = makeManager({
-      contacts: [{ publicKey: 'cc'.repeat(32), advType: 0 }],
-    });
-    const result = await manager.discoverRegions();
-    expect(result).toEqual({ regions: [], perRepeater: [] });
-    expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
-  });
-
   it('returns empty on a non-companion device without querying', async () => {
     const { manager, bridgeCalls } = makeManager({
       contacts: [{ publicKey: 'aa'.repeat(32), advType: 2 }],
@@ -413,6 +428,81 @@ describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
     (manager as any).deviceType = MeshCoreDeviceType.REPEATER;
     const result = await manager.discoverRegions();
     expect(result).toEqual({ regions: [], perRepeater: [] });
+    expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
+    expect(manager.discoverNodes).not.toHaveBeenCalled();
+  });
+
+  it('runs a repeater+room-server (0x0C) sweep before querying', async () => {
+    const { manager } = makeManager({
+      contacts: [{ publicKey: 'aa'.repeat(32), advType: 2 }],
+      regionsByRepeater: { ['aa'.repeat(32)]: ['muenchen'] },
+    });
+    await manager.discoverRegions();
+    expect(manager.discoverNodes).toHaveBeenCalledWith(0x0c, expect.any(Number));
+  });
+
+  it('queries only the repeaters returned by the 0-hop sweep, not every known repeater', async () => {
+    const aa = 'aa'.repeat(32), bb = 'bb'.repeat(32), dd = 'dd'.repeat(32);
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [
+        { publicKey: aa, advType: 2 }, // known but far — not in sweep
+        { publicKey: bb, advType: 2 }, // 0-hop
+        { publicKey: dd, advType: 3 }, // known but far — not in sweep
+      ],
+      regionsByRepeater: { [bb]: ['muenchen'] },
+      zeroHop: [bb], // only bb answered the sweep
+    });
+    const result = await manager.discoverRegions();
+    expect(bridgeCalls.filter(c => c.cmd === 'request_regions').map(c => c.params.public_key)).toEqual([bb]);
+    expect(result.perRepeater.map(r => r.publicKey)).toEqual([bb]);
+    expect(result.regions).toEqual(['muenchen']);
+  });
+
+  it('queries in sweep arrival order, not contact-map order', async () => {
+    const aa = 'aa'.repeat(32), bb = 'bb'.repeat(32);
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [
+        { publicKey: aa, advType: 2 }, // inserted first
+        { publicKey: bb, advType: 2 },
+      ],
+      regionsByRepeater: { [aa]: ['augsburg'], [bb]: ['muenchen'] },
+      zeroHop: [bb, aa], // bb answered the sweep first
+    });
+    await manager.discoverRegions();
+    expect(bridgeCalls.filter(c => c.cmd === 'request_regions').map(c => c.params.public_key)).toEqual([bb, aa]);
+  });
+
+  it('retries the sweep once when the first finds no 0-hop repeaters, then queries', async () => {
+    const bb = 'bb'.repeat(32);
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [{ publicKey: bb, advType: 2 }],
+      regionsByRepeater: { [bb]: ['muenchen'] },
+      zeroHop: [[], [bb]], // first sweep empty, retry finds bb
+    });
+    const result = await manager.discoverRegions();
+    expect(manager.discoverNodes).toHaveBeenCalledTimes(2);
+    expect(result.regions).toEqual(['muenchen']);
+    expect(result.noZeroHopRepeaters).toBeUndefined();
+    expect(bridgeCalls.filter(c => c.cmd === 'request_regions')).toHaveLength(1);
+  });
+
+  it('returns noZeroHopRepeaters after two empty sweeps, querying nobody', async () => {
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [{ publicKey: 'bb'.repeat(32), advType: 2 }], // known but none answered
+      zeroHop: [], // every sweep empty
+    });
+    const result = await manager.discoverRegions();
+    expect(manager.discoverNodes).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ regions: [], perRepeater: [], noZeroHopRepeaters: true });
+    expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
+  });
+
+  it('reports noZeroHopRepeaters when no known contact is a repeater', async () => {
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [{ publicKey: 'cc'.repeat(32), advType: 0 }], // plain chat only
+    });
+    const result = await manager.discoverRegions();
+    expect(result).toEqual({ regions: [], perRepeater: [], noZeroHopRepeaters: true });
     expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2481,8 +2481,8 @@ class MeshCoreManager extends EventEmitter {
   async discoverNodes(
     filter: number,
     windowMs: number = 8000,
-  ): Promise<{ returned: number; newCount: number }> {
-    const empty = { returned: 0, newCount: 0 };
+  ): Promise<{ returned: number; newCount: number; seen: string[] }> {
+    const empty = { returned: 0, newCount: 0, seen: [] as string[] };
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       logger.warn('[MeshCore] Node discovery requires Companion firmware');
       return empty;
@@ -2507,6 +2507,10 @@ class MeshCoreManager extends EventEmitter {
       const result = {
         returned: this.activeDiscovery.returned,
         newCount: this.activeDiscovery.newCount,
+        // Snapshot the public keys that responded to this sweep (insertion
+        // order = arrival order) so callers like discoverRegions() can target
+        // only the current 0-hop set (#3743).
+        seen: [...this.activeDiscovery.seen],
       };
       logger.info(`[MeshCore] Node discovery complete: ${result.returned} returned, ${result.newCount} new`);
       return result;
@@ -2582,27 +2586,60 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
-   * Discover the region/scope names served by nearby repeaters (#3667 phase 3).
-   * Queries each known repeater / room-server contact with a "regions request"
-   * (firmware ANON_REQ sub-type 0x01) and collects the region names each one
-   * reports. Like the official app, coverage depends on which repeaters are in
-   * the contact list — run "Discover Repeaters" first for the fullest picture.
+   * Discover the region/scope names served by nearby repeaters (#3667 phase 3,
+   * refined in #3743).
    *
-   * Queries are issued sequentially: the firmware's per-request `tag` only
-   * arrives on the `Sent` ack, so overlapping requests could cross-match
+   * Rather than querying every repeater ever seen (including far-away ones that
+   * just waste a 20s timeout), this first runs a 0-hop discovery sweep and only
+   * queries the repeaters / room-servers that answered it, in arrival order. If
+   * the first sweep finds no 0-hop repeaters it retries once (a repeater may
+   * have been busy); if the retry is also empty it returns `noZeroHopRepeaters`
+   * so the caller can tell the user, rather than silently querying everyone.
+   *
+   * Region queries are issued sequentially: the firmware's per-request `tag`
+   * only arrives on the `Sent` ack, so overlapping requests could cross-match
    * replies. The wildcard `*` (null region) is filtered out — it isn't a
    * selectable scope. Repeaters that don't answer in time are skipped.
    */
   async discoverRegions(): Promise<{
     regions: string[];
     perRepeater: Array<{ publicKey: string; name: string; regions: string[] }>;
+    noZeroHopRepeaters?: boolean;
   }> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       return { regions: [], perRepeater: [] };
     }
-    const repeaters = [...this.contacts.values()].filter(
-      (c) => c.advType === MeshCoreDeviceType.REPEATER || c.advType === MeshCoreDeviceType.ROOM_SERVER,
-    );
+
+    // 1. Run a 0-hop discovery sweep and resolve it to the subset of known
+    //    repeater/room-server contacts that answered, ordered by arrival.
+    //    Repeaters (2) + room servers (3) → filter bitmask 0x0C.
+    const REPEATER_FILTER =
+      (1 << MeshCoreDeviceType.REPEATER) | (1 << MeshCoreDeviceType.ROOM_SERVER);
+    const sweepZeroHopRepeaters = async () => {
+      const { seen } = await this.discoverNodes(REPEATER_FILTER, 8000);
+      if (seen.length === 0) return [];
+      const order = new Map(seen.map((k, i) => [k, i]));
+      return [...this.contacts.values()]
+        .filter(
+          (c) =>
+            (c.advType === MeshCoreDeviceType.REPEATER ||
+              c.advType === MeshCoreDeviceType.ROOM_SERVER) &&
+            order.has(c.publicKey),
+        )
+        .sort((a, b) => (order.get(a.publicKey)! - order.get(b.publicKey)!));
+    };
+
+    // First attempt; on an empty result retry once before giving up (#3743).
+    let repeaters = await sweepZeroHopRepeaters();
+    if (repeaters.length === 0) {
+      logger.info(`[MeshCore:${this.sourceId}] No 0-hop repeaters on first sweep; retrying once`);
+      repeaters = await sweepZeroHopRepeaters();
+    }
+    if (repeaters.length === 0) {
+      logger.info(`[MeshCore:${this.sourceId}] No 0-hop repeaters found after retry`);
+      return { regions: [], perRepeater: [], noZeroHopRepeaters: true };
+    }
+
     const perRepeater: Array<{ publicKey: string; name: string; regions: string[] }> = [];
     const all = new Set<string>();
     for (const r of repeaters) {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2653,9 +2653,14 @@ class MeshCoreManager extends EventEmitter {
         // the 0-hop discovery sweep above only hears DIRECT-range repeaters, each
         // one here is a direct neighbour — install a zero-hop direct out_path so
         // the request routes direct instead of flooding into the void (#3743).
-        const routed = await this.setContactOutPath(r.publicKey, new Uint8Array(0), 1);
+        // Best-effort and quick: the device applies the CMD_ADD_UPDATE_CONTACT
+        // write even when its Ok ack is lost in the post-sweep radio chatter
+        // (meshcore.js resolves on Ok, so it reports a timeout while the route
+        // is in fact installed). The real success signal is the request_regions
+        // reply below, so use a short window and don't alarm on a missed ack.
+        const routed = await this.setContactOutPath(r.publicKey, new Uint8Array(0), 1, 3000);
         if (!routed) {
-          logger.warn(`[MeshCore:${this.sourceId}] could not install a direct route to ${r.publicKey.substring(0, 12)}…; regions request may flood and time out`);
+          logger.debug(`[MeshCore:${this.sourceId}] set_out_path ack not seen for ${r.publicKey.substring(0, 12)}… (route still likely applied); proceeding`);
         }
         const resp = await this.sendBridgeCommand('request_regions', { public_key: r.publicKey }, 20_000);
         if (!resp.success) {
@@ -2801,6 +2806,7 @@ class MeshCoreManager extends EventEmitter {
     publicKey: string,
     outPathBytes: Uint8Array,
     hashBytes: 1 | 2 | 3 = 1,
+    timeoutMs: number = 12000,
   ): Promise<boolean> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       logger.warn('[MeshCore] Set-out-path requires Companion firmware');
@@ -2824,7 +2830,7 @@ class MeshCoreManager extends EventEmitter {
         public_key: publicKey,
         out_path: outPathBytes,
         hash_bytes: hashBytes,
-      }, 12000);
+      }, timeoutMs);
       if (!response.success) {
         const isTimeout = response.error?.includes('timeout');
         logger.warn(

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2644,6 +2644,19 @@ class MeshCoreManager extends EventEmitter {
     const all = new Set<string>();
     for (const r of repeaters) {
       try {
+        // v1.15+ repeaters answer a regions ANON_REQ only when it arrives via a
+        // DIRECT route — firmware simple_repeater `onAnonDataRecv` gates the
+        // REGIONS branch on `packet->isRouteDirect()` and silently drops flooded
+        // ones (login is the lone flood-exception, which is why admin CLI works
+        // but Discover Regions didn't). The companion floods whenever the contact
+        // has no installed `out_path` (`sendAnonReq`: out_path_len == 0xFF). Since
+        // the 0-hop discovery sweep above only hears DIRECT-range repeaters, each
+        // one here is a direct neighbour — install a zero-hop direct out_path so
+        // the request routes direct instead of flooding into the void (#3743).
+        const routed = await this.setContactOutPath(r.publicKey, new Uint8Array(0), 1);
+        if (!routed) {
+          logger.warn(`[MeshCore:${this.sourceId}] could not install a direct route to ${r.publicKey.substring(0, 12)}…; regions request may flood and time out`);
+        }
         const resp = await this.sendBridgeCommand('request_regions', { public_key: r.publicKey }, 20_000);
         if (!resp.success) {
           logger.debug(`[MeshCore:${this.sourceId}] regions request to ${r.publicKey.substring(0, 12)}… returned an error: ${resp.error}`);

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2833,10 +2833,16 @@ class MeshCoreManager extends EventEmitter {
       }, timeoutMs);
       if (!response.success) {
         const isTimeout = response.error?.includes('timeout');
-        logger.warn(
-          `[MeshCore] set_out_path failed for ${publicKey}: ${response.error}` +
-            (isTimeout ? ' — check serial/TCP connection to the device' : ''),
-        );
+        if (isTimeout) {
+          // meshcore.js resolves CMD_ADD_UPDATE_CONTACT on its Ok ack, which is
+          // frequently lost in unrelated radio chatter even though the device
+          // applied the write. Treat a timeout as a non-fatal "ack not seen" —
+          // not a connectivity error — so it doesn't spam warnings on a path
+          // that did install (e.g. region discovery, #3743).
+          logger.debug(`[MeshCore] set_out_path ack not seen for ${publicKey} (write likely applied)`);
+        } else {
+          logger.warn(`[MeshCore] set_out_path rejected for ${publicKey}: ${response.error}`);
+        }
         return false;
       }
       // Group the flat byte buffer into hashBytes-wide hop tokens so the

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2832,6 +2832,8 @@ class MeshCoreManager extends EventEmitter {
         hash_bytes: hashBytes,
       }, timeoutMs);
       if (!response.success) {
+        // NOTE: matches on meshcore.js's timeout error text — fragile if the
+        // library changes its wording; revisit if a structured error code lands.
         const isTimeout = response.error?.includes('timeout');
         if (isTimeout) {
           // meshcore.js resolves CMD_ADD_UPDATE_CONTACT on its Ok ack, which is


### PR DESCRIPTION
## Summary

Closes #3743. Makes MeshCore region discovery actually return regions, in two parts:

1. **Query only current 0-hop repeaters** (the original #3743 ask): run a 0-hop discovery sweep first and query only the repeaters/room-servers that answered, in arrival order — instead of querying every repeater ever seen (each at a 20s timeout). Cuts a worst case from `N × 20s` (e.g. 62 known repeaters → ~21 min) to a single ~8s sweep plus quick replies from nearby repeaters.
2. **Route the regions request directly** so the repeater actually answers it (the part that made "Discover Regions" return empty even for a correctly-configured repeater).

## Root cause (firmware-verified against `repeater-v1.15.0`)

A MeshCore repeater answers a regions `ANON_REQ` **only when it arrives via a direct route** — `simple_repeater`'s `onAnonDataRecv` gates the regions branch on `packet->isRouteDirect()` and silently drops flooded ones. (Login is the lone flood-exception, which is why remote admin/CLI worked but Discover Regions didn't.) The companion floods whenever the contact has no installed `out_path` (`sendAnonReq`: `out_path_len == OUT_PATH_UNKNOWN`). MeshMonitor's `discover_path` only produces the **diagnostic** path (push `0x8D`) — it never installs the routing `out_path` — so the request kept flooding and timing out.

## What changed

- `discoverRegions()` now:
  - Runs a 0-hop sweep (`discover_nodes`, filter `0x0C` = repeater + room-server), retries once if it finds nothing, and reports `noZeroHopRepeaters` instead of silently querying everyone (addresses @m0urs's retry request on the issue).
  - Queries only the swept repeaters, in arrival order.
  - **Installs a zero-hop direct `out_path` (`setContactOutPath`) before each `request_regions`** — since a 0-hop sweep only hears direct-range repeaters, each one is a direct neighbour — so the `ANON_REQ` routes direct and the repeater replies.
- `setContactOutPath()` gains an optional timeout; a `set_out_path` *ack timeout* is now treated as benign (the `CMD_ADD_UPDATE_CONTACT` write lands even when meshcore.js loses its `Ok` ack in post-sweep radio chatter) — logged at debug instead of a misleading "check serial/TCP connection" warning.
- `discoverNodes()` now returns the `seen` public-key set so the sweep result can drive selection.
- Frontend: `useMeshCore` + `MeshCoreSettingsView` surface "no nearby (0-hop) repeaters found" vs "repeaters reported no regions".

## Testing

- New/updated unit tests in `meshcoreManager.scope.test.ts` (36 pass): `0x0C` sweep, query-only-swept-repeaters, arrival order, retry-then-succeed, two-empty-sweeps → `noZeroHopRepeaters`, and an assertion that a zero-hop direct `out_path` is installed before querying.
- Full Vitest suite green (0 failures); `tsc` clean.
- **Validated live** against a real v1.15.0 repeater: Discover Regions now returns its configured region reliably across repeated runs, where it previously always timed out empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
