### PR TITLE
fix(messaging): expose isUnmessagable/isLicensed so the DM UI hides for unmessagable nodes (#3755)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -14148,6 +14148,16 @@ class MeshtasticManager implements ISourceManager {
         deviceInfo.isIgnored = Boolean(node.isIgnored);
       }
 
+      // Add isUnmessagable / isLicensed if they exist (#3684). Without these
+      // the client never learns a remote node is unmessagable, so the DM UI
+      // (NodesTab DM button, MessagesTab compose) fails open for them (#3755).
+      if (node.isUnmessagable !== null && node.isUnmessagable !== undefined) {
+        deviceInfo.isUnmessagable = Boolean(node.isUnmessagable);
+      }
+      if (node.isLicensed !== null && node.isLicensed !== undefined) {
+        deviceInfo.isLicensed = Boolean(node.isLicensed);
+      }
+
       // Add channel if it exists
       if (node.channel !== null && node.channel !== undefined) {
         deviceInfo.channel = node.channel;

--- a/src/server/meshtasticManager.unmessagable.test.ts
+++ b/src/server/meshtasticManager.unmessagable.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+const { getAllNodes } = vi.hoisted(() => ({ getAllNodes: vi.fn() }));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    telemetry: {
+      // getAllNodesAsync reads an uptime map; .get() must exist.
+      getLatestTelemetryValueForAllNodes: vi.fn().mockResolvedValue(new Map()),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes,
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+function makeManager() {
+  return new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+}
+
+// Minimal DB row shape consumed by mapDbNodeToDeviceInfo.
+function dbNode(overrides: Record<string, any> = {}) {
+  return {
+    nodeNum: 382011584,
+    nodeId: '!16c508c0',
+    longName: 'STUART G2',
+    shortName: 'TRON',
+    ...overrides,
+  };
+}
+
+describe('getAllNodesAsync — isUnmessagable / isLicensed pass-through (#3755)', () => {
+  it('REGRESSION: exposes isUnmessagable so the DM UI can hide for unmessagable nodes', async () => {
+    // The bug: mapDbNodeToDeviceInfo dropped is_unmessagable, so the client
+    // node always had isUnmessagable === undefined and the DM button/compose
+    // (NodesTab.tsx, MessagesTab.tsx) fell open for unmessagable nodes.
+    getAllNodes.mockResolvedValue([dbNode({ isUnmessagable: 1, isLicensed: 1 })]);
+
+    const [node] = await makeManager().getAllNodesAsync('src-1');
+
+    expect(node.isUnmessagable).toBe(true);
+    expect(node.isLicensed).toBe(true);
+  });
+
+  it('reports a messagable node as isUnmessagable false', async () => {
+    getAllNodes.mockResolvedValue([dbNode({ isUnmessagable: 0, isLicensed: 0 })]);
+
+    const [node] = await makeManager().getAllNodesAsync('src-1');
+
+    expect(node.isUnmessagable).toBe(false);
+    expect(node.isLicensed).toBe(false);
+  });
+
+  it('omits the flags when the columns are null (legacy rows)', async () => {
+    getAllNodes.mockResolvedValue([dbNode({ isUnmessagable: null, isLicensed: null })]);
+
+    const [node] = await makeManager().getAllNodesAsync('src-1');
+
+    expect(node.isUnmessagable).toBeUndefined();
+    expect(node.isLicensed).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3755. The DM UI did not hide for Meshtastic nodes that have the **unmessagable** bit set — the DM button still appeared in the Nodes tab and the message composer stayed writable, despite the node's intent to not receive direct messages.

## Root cause

`is_unmessagable` / `is_licensed` are stored on the `nodes` table (migration 101, #3684), but `mapDbNodeToDeviceInfo()` — which builds the node object the API returns — never copied them onto the client object (it handles `isFavorite`, `isIgnored`, etc., but not these two). So every node reached the frontend with `isUnmessagable === undefined`, and the two UI guards fail **open**:

- `NodesTab.tsx` — DM button shown when `!node.isUnmessagable` → always shown
- `MessagesTab.tsx` — composer set read-only when `isUnmessagable === true` → never

Only the **local** node worked, because its flag flows through a separate owner/identity endpoint, not the node list.

## Fix

Pass `isUnmessagable` and `isLicensed` through `mapDbNodeToDeviceInfo()`, mirroring the existing `isIgnored` handling.

## Testing

- New `meshtasticManager.unmessagable.test.ts` — 3 cases: flag `1` → exposed `true`, `0` → exposed `false`, `null` (legacy rows) → omitted.
- Verified live against the dev DB: `/api/nodes` now returns `isUnmessagable: true` for the 36 nodes that carry the bit (previously `null` for all).
- Full Vitest suite green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
