### PR TITLE
feat(lxc): git-native LXC templates — in-place updates, bundled updater, doc overhaul

### DIFF
--- a/.github/workflows/lxc-template-build.yml
+++ b/.github/workflows/lxc-template-build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., 2.19.4 or latest)'
+        description: 'Version tag (e.g., 4.12.0 or latest)'
         required: false
         default: 'latest'
 
@@ -23,23 +23,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          submodules: recursive  # Needed for protobufs
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install --legacy-peer-deps
-
-      - name: Build React frontend
-        run: npm run build
-
-      - name: Build Express backend
-        run: npm run build:server
+        # No submodules needed here — build-lxc-template.sh clones the repo
+        # directly into the container rootfs and handles submodules itself.
+        # No Node.js setup needed — the script installs Node.js 24 via
+        # NodeSource inside the container chroot, not on the CI runner.
 
       - name: Extract version from tag
         id: get_version
@@ -53,10 +40,10 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building LXC template version: $VERSION"
 
-      - name: Install debootstrap
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y debootstrap
+          sudo apt-get install -y debootstrap git curl
 
       - name: Build LXC template
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,3 +171,24 @@ When adding a new user-configurable setting:
 - When updating the version, update all five files: `package.json`, `package-lock.json` (regenerate via `npm install --package-lock-only` — `.npmrc` now pins `legacy-peer-deps=true`, so the explicit flag is no longer needed), `helm/meshmonitor/Chart.yaml`, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`.
 - Use shared constants from `src/server/constants/meshtastic.ts` for PortNum, RoutingError, and helper functions — never magic numbers for protocol values.
 - Official Meshtastic protobuf definitions: https://github.com/meshtastic/protobufs/
+
+## LXC Template Build
+
+The Proxmox LXC template is built by `lxc/build-lxc-template.sh` using a
+partial + sparse git clone. The cone directory list lives in
+`lxc/sparse-cone.txt` — **not** in the build script itself.
+
+### Hard rules
+
+- **If you add a top-level directory that is required at runtime, add it to
+  `lxc/sparse-cone.txt` in the same commit.** Omitting it silently drops
+  those files from every future LXC template build.
+- **All `npm install`/`npm run build` steps run inside `chroot`** against the
+  container's own Node.js (NodeSource 24). Never move them to the host/CI
+  workspace — native modules (better-sqlite3) must compile for the container's
+  ABI, not the runner's.
+- **`PUPPETEER_SKIP_DOWNLOAD=true` on every npm step.** The container is
+  headless — Chromium download will fail or hang without it.
+- **`.git` inside `/opt/meshmonitor` is intentional.** It is what enables
+  `meshmonitor-update` to manage future in-place upgrades. Do not add it to
+  `.gitignore` or strip it in cleanup steps.

--- a/docs/deployment/PROXMOX_LXC_GUIDE.md
+++ b/docs/deployment/PROXMOX_LXC_GUIDE.md
@@ -647,9 +647,9 @@ If you prefer to run each step yourself:
 
 ## Additional Resources
 
-- **Main Documentation**: [Getting Started Guide](/getting-started)
-- **Configuration Guide**: [Production Deployment](/configuration/production)
-- **Docker Deployment**: [Deployment Guide](/deployment/DEPLOYMENT_GUIDE)
+- **Main Documentation**: [Getting Started Guide](https://meshmonitor.org/getting-started)
+- **Configuration Guide**: [Production Deployment](https://meshmonitor.org/configuration/production)
+- **Docker Deployment**: [Deployment Guide](https://github.com/Yeraze/meshmonitor/blob/main/docs/deployment/DEPLOYMENT_GUIDE.md)
 - **GitHub**: [MeshMonitor Repository](https://github.com/yeraze/meshmonitor)
 - **Issues**: [Report Problems](https://github.com/yeraze/meshmonitor/issues)
 
@@ -658,7 +658,7 @@ If you prefer to run each step yourself:
 If you encounter issues:
 
 1. Check this troubleshooting guide
-2. Review the [main documentation](/getting-started)
+2. Review the [main documentation](https://meshmonitor.org/getting-started)
 3. Search [existing issues](https://github.com/yeraze/meshmonitor/issues)
 4. Ask in [Discussions](https://github.com/yeraze/meshmonitor/discussions)
 5. Create a [new issue](https://github.com/yeraze/meshmonitor/issues/new) with:

--- a/docs/deployment/PROXMOX_LXC_GUIDE.md
+++ b/docs/deployment/PROXMOX_LXC_GUIDE.md
@@ -23,6 +23,7 @@ MeshMonitor can be deployed in Proxmox VE using LXC (Linux Containers) as an alt
 - **Integrated**: Native Proxmox VE management and monitoring
 - **Secure**: Unprivileged containers with systemd process management
 - **Simple**: Pre-built templates for easy deployment
+- **Updatable**: Templates are git-native from first boot — `meshmonitor-update` handles future in-place upgrades without redeploying
 
 **Note**: Docker remains the primary supported deployment method with the most features. LXC is provided as a community-supported alternative for Proxmox users.
 
@@ -35,41 +36,36 @@ MeshMonitor can be deployed in Proxmox VE using LXC (Linux Containers) as an alt
 - **Network**: Bridge network configured (typically `vmbr0`)
 - **Resources**:
   - Minimum: 1 CPU core, 512MB RAM
-  - Recommended: 2 CPU cores, 2GB RAM
+  - Recommended: 2 CPU cores, 2GB RAM, 1GB swap
 
 ### Meshtastic Requirements
 
 - Meshtastic node accessible via TCP/IP
-- Node IP address and port (default: 4403)
 - Network connectivity between container and node
+- Node connection is configured via the MeshMonitor web UI after first login
 
 ## Quick Start
 
-**Note**: Replace `VERSION` with the actual version number from the [releases page](https://github.com/yeraze/meshmonitor/releases) (e.g., `2.19.10`). The generic "latest" URL does not work due to GitHub's asset naming requirements.
+**Note**: Replace `<version>` with the actual version number from the [releases page](https://github.com/yeraze/meshmonitor/releases) (e.g., `4.12.0`). The generic "latest" URL does not work due to GitHub's asset naming requirements.
 
 ```bash
-# 1. Download template on your computer (replace VERSION with actual version like 2.19.10)
-wget https://github.com/yeraze/meshmonitor/releases/download/vVERSION/meshmonitor-VERSION-amd64.tar.gz
+# 1. Download template on your computer
+wget https://github.com/yeraze/meshmonitor/releases/download/v<version>/meshmonitor-<version>-amd64.tar.gz
 
 # 2. Upload to Proxmox server
-scp meshmonitor-VERSION-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/cache/
+scp meshmonitor-<version>-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/cache/
 
 # 3. Create container via Proxmox web UI (see Detailed Installation below)
 
-# 4. Start container and configure
+# 4. Start container and run post-install setup
 pct start CONTAINER-ID
 pct enter CONTAINER-ID
+bash /opt/meshmonitor/lxc/proxmox/post-install.sh
 
-# 5. Edit configuration
-nano /etc/meshmonitor/meshmonitor.env
-# Set: MESHTASTIC_NODE_IP=YOUR-NODE-IP
-
-# 6. Start services
-systemctl start meshmonitor
-systemctl start meshmonitor-apprise
-
-# 7. Access web UI
+# 5. Access web UI — URL is printed by post-install.sh
 # Open browser to: http://CONTAINER-IP:3001
+# Default login: admin / changeme (change immediately)
+# Configure your Meshtastic node via Settings -> Node Connection
 ```
 
 ## Detailed Installation
@@ -77,27 +73,27 @@ systemctl start meshmonitor-apprise
 ### Step 1: Download the LXC Template
 
 1. Go to the [MeshMonitor Releases](https://github.com/yeraze/meshmonitor/releases) page
-2. Find the latest release version number (e.g., `v2.19.10`)
-3. Download the `meshmonitor-VERSION-amd64.tar.gz` file for that version
+2. Find the latest release version number (e.g., `v4.12.0`)
+3. Download the `meshmonitor-<version>-amd64.tar.gz` file for that version
 4. Optionally download the `.sha256` file to verify integrity
 
-**Example download** (replace `2.19.10` with the current version):
+**Example download** (replace `<version>` with the current version):
 ```bash
-wget https://github.com/yeraze/meshmonitor/releases/download/v2.19.10/meshmonitor-2.19.10-amd64.tar.gz
-wget https://github.com/yeraze/meshmonitor/releases/download/v2.19.10/meshmonitor-2.19.10-amd64.tar.gz.sha256
+wget https://github.com/yeraze/meshmonitor/releases/download/v<version>/meshmonitor-<version>-amd64.tar.gz
+wget https://github.com/yeraze/meshmonitor/releases/download/v<version>/meshmonitor-<version>-amd64.tar.gz.sha256
 ```
 
 **Verify checksum (optional)**:
 ```bash
-sha256sum -c meshmonitor-2.19.10-amd64.tar.gz.sha256
+sha256sum -c meshmonitor-<version>-amd64.tar.gz.sha256
 ```
 
 ### Step 2: Upload Template to Proxmox
 
-Upload the template to your Proxmox server's template storage (replace version number):
+Upload the template to your Proxmox server's template storage:
 
 ```bash
-scp meshmonitor-2.19.10-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/cache/
+scp meshmonitor-<version>-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/cache/
 ```
 
 ### Step 3: Create Container from Template
@@ -114,11 +110,11 @@ scp meshmonitor-2.19.10-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/c
    - **SSH public key**: (optional)
 
 3. **Template Tab**:
-   - **Storage**: `local`
-   - **Template**: Select `meshmonitor-VERSION-amd64.tar.gz` (e.g., `meshmonitor-2.19.10-amd64.tar.gz`)
+   - **Storage**: Your template storage
+   - **Template**: Select `meshmonitor-<version>-amd64.tar.gz`
 
 4. **Disks Tab**:
-   - **Storage**: Choose your storage (e.g., `local-lxc`)
+   - **Storage**: Choose your storage (e.g., `local-lvm`)
    - **Disk size**: `10 GiB` (minimum), `20 GiB` (recommended)
 
 5. **CPU Tab**:
@@ -126,7 +122,7 @@ scp meshmonitor-2.19.10-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/c
 
 6. **Memory Tab**:
    - **Memory (MiB)**: `2048` (recommended)
-   - **Swap (MiB)**: `512` (optional)
+   - **Swap (MiB)**: `1024` (recommended — needed for npm build during updates)
 
 7. **Network Tab**:
    - **Name**: `eth0`
@@ -146,24 +142,24 @@ scp meshmonitor-2.19.10-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/c
 #### Via Command Line:
 
 ```bash
-# Create container (replace VERSION with actual version like 2.19.10)
-pct create 100 local:vztmpl/meshmonitor-VERSION-amd64.tar.gz \
+# Create container (replace <version> and <storage> with actual values)
+pct create 100 local:vztmpl/meshmonitor-<version>-amd64.tar.gz \
   --hostname meshmonitor \
   --cores 2 \
   --memory 2048 \
-  --swap 512 \
+  --swap 1024 \
   --net0 name=eth0,bridge=vmbr0,ip=dhcp \
-  --storage local-lxc \
-  --rootfs local-lxc:10 \
+  --storage <storage> \
+  --rootfs <storage>:10 \
   --unprivileged 1 \
-  --features nesting=0 \
+  --features nesting=1 \
   --onboot 1
 
 # Start container
 pct start 100
 ```
 
-### Step 4: Initial Configuration
+### Step 4: Post-Install Setup
 
 Enter the container:
 
@@ -171,66 +167,51 @@ Enter the container:
 pct enter 100  # Replace 100 with your container ID
 ```
 
-Or SSH into the container:
+Run the post-install script:
 
 ```bash
-ssh root@CONTAINER-IP
+bash /opt/meshmonitor/lxc/proxmox/post-install.sh
 ```
 
-Configure MeshMonitor:
-
-```bash
-# Edit environment file
-nano /etc/meshmonitor/meshmonitor.env
-
-# Required: Set your Meshtastic node IP
-MESHTASTIC_NODE_IP=192.168.1.100  # Change to your node's IP
-
-# Optional: Set TCP port if not default
-MESHTASTIC_TCP_PORT=4403
-
-# Optional: Other configuration (see Configuration section)
-```
-
-Start services:
-
-```bash
-systemctl start meshmonitor
-systemctl start meshmonitor-apprise
-```
-
-Verify services are running:
-
-```bash
-systemctl status meshmonitor
-systemctl status meshmonitor-apprise
-```
+This script:
+- Sets `ALLOWED_ORIGINS` in `meshmonitor.env` with your container's actual IP
+- Populates `meshmonitor.env` from the documented example file
+- Adds `/usr/local/bin` to PATH for `meshmonitor-update`
+- Prints the web UI URL, default login, and update instructions
 
 ### Step 5: Access Web UI
 
-1. Find your container's IP address:
-   ```bash
-   hostname -I
-   ```
-
-2. Open web browser to:
+1. The post-install script prints your URL — open it in a browser:
    ```
    http://CONTAINER-IP:3001
    ```
 
-3. Log in with default credentials or create first admin user
+2. Log in with default credentials:
+   - **Username**: `admin`
+   - **Password**: `changeme`
+   - Change your password immediately after first login
+
+3. Configure your Meshtastic node:
+   - Go to **Settings → Node Connection**
+   - Enter your node's IP address and save
 
 ## Configuration
 
 ### Environment Variables
 
-All configuration is done via `/etc/meshmonitor/meshmonitor.env`.
-
-**Example configuration file:**
+All configuration is done via `/etc/meshmonitor/meshmonitor.env`. The post-install script
+populates this from `meshmonitor.env.example` with `ALLOWED_ORIGINS` pre-set to your
+container's IP. Edit it to customize further:
 
 ```bash
-# Required
-MESHTASTIC_NODE_IP=192.168.1.100
+nano /etc/meshmonitor/meshmonitor.env
+```
+
+**Key settings:**
+
+```bash
+# CORS — set to your container's IP (post-install.sh sets this automatically)
+ALLOWED_ORIGINS=http://CONTAINER-IP:3001
 
 # Optional - Server
 PORT=3001
@@ -244,16 +225,6 @@ DATABASE_PATH=/data/meshmonitor.db
 SESSION_SECRET=your-random-secret-here
 COOKIE_SECURE=false
 COOKIE_SAMESITE=lax
-
-# Optional - CORS
-ALLOWED_ORIGINS=http://localhost:8080
-
-# Virtual Node (for mobile apps)
-# NOTE: In MeshMonitor 4.0+ Virtual Node is configured per-source via
-# Dashboard → Sources → Edit Source → Virtual Node. The old
-# ENABLE_VIRTUAL_NODE / VIRTUAL_NODE_PORT env vars were removed.
-# If you want mobile apps to reach a source's Virtual Node, expose
-# the port you configure in the Source's Virtual Node settings.
 
 # Optional - Notifications
 VAPID_PUBLIC_KEY=
@@ -270,6 +241,8 @@ ACCESS_LOG_ENABLED=false
 ACCESS_LOG_PATH=/data/logs/access.log
 ACCESS_LOG_FORMAT=combined
 ```
+
+See `/etc/meshmonitor/meshmonitor.env.example` for the full documented list of options.
 
 ### Applying Configuration Changes
 
@@ -303,96 +276,49 @@ MeshMonitor listens on port 3001 by default (configurable via the `PORT` environ
 
 1. Configure Proxmox firewall rules to allow port 3001
 2. Or use port forwarding on your router
-3. Or use a reverse proxy for HTTPS (see below)
 
-### Reverse Proxy (HTTPS)
+**Note**: Unlike Docker deployments which map `8080:3001`, LXC containers have no port
+mapping layer — the app runs directly on port 3001.
 
-For production deployments with HTTPS, configure a reverse proxy on the Proxmox host or another server.
+### Static IP Configuration
 
-**Example nginx configuration:**
+To assign a static IP via Proxmox web UI:
+- Container → Network → Edit → IPv4: Static
+- Set IP/CIDR and Gateway
 
-```nginx
-server {
-    listen 80;
-    server_name meshmonitor.yourdomain.com;
-
-    location / {
-        proxy_pass http://CONTAINER-IP:3001;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
-}
-```
-
-Enable HTTPS with Let's Encrypt:
-
+Or via command line on the Proxmox host:
 ```bash
-certbot --nginx -d meshmonitor.yourdomain.com
-```
-
-Update MeshMonitor environment:
-
-```bash
-# In /etc/meshmonitor/meshmonitor.env
-TRUST_PROXY=true
-COOKIE_SECURE=true
-ALLOWED_ORIGINS=https://meshmonitor.yourdomain.com
+pct set 100 --net0 name=eth0,bridge=vmbr0,ip=192.168.1.50/24,gw=192.168.1.1
 ```
 
 ## Backup and Restore
 
-### Proxmox Snapshots
+### Automated Backup via meshmonitor-update
 
-The easiest way to backup your MeshMonitor container:
+`meshmonitor-update` creates a backup before every update automatically. Backups are
+stored at `/var/backups/meshmonitor/` by default and include `/data/`,
+`meshmonitor.env`, and systemd service files.
 
-```bash
-# Create snapshot
-pct snapshot 100 before-update --description "Before updating MeshMonitor"
-
-# List snapshots
-pct listsnapshot 100
-
-# Restore snapshot
-pct rollback 100 before-update
-
-# Delete snapshot
-pct delsnapshot 100 before-update
-```
-
-### Manual Database Backup
-
-Backup the SQLite database by copying the file (the `sqlite3` CLI is not installed in the container):
+### Manual Backup
 
 ```bash
-# Inside container - stop service first for a clean copy
-systemctl stop meshmonitor
-cp /data/meshmonitor.db /data/system-backups/meshmonitor-$(date +%Y%m%d).db
-systemctl start meshmonitor
-
-# Or copy via Proxmox host (stop service first for consistency)
-pct exec 100 -- systemctl stop meshmonitor
-pct pull 100 /data/meshmonitor.db ./meshmonitor-backup.db
-pct exec 100 -- systemctl start meshmonitor
+# Inside container
+tar czf /tmp/meshmonitor-backup.tar.gz /data /etc/meshmonitor
 ```
 
-### System Backup via Web UI
+```bash
+# Copy to Proxmox host
+pct pull 100 /tmp/meshmonitor-backup.tar.gz ./meshmonitor-backup.tar.gz
+```
 
-MeshMonitor includes a built-in backup feature accessible via the web UI:
+### Proxmox Snapshot
 
-1. Navigate to **Settings** → **System Backup**
-2. Click **Create Backup**
-3. Download the backup file
-4. Restore via **Upload Backup**
+```bash
+# On Proxmox host
+pct snapshot 100 pre-update --description "Before update"
+```
 
-### Full Container Backup
-
-Backup entire container to file:
+### Proxmox Backup
 
 ```bash
 # On Proxmox host
@@ -442,12 +368,6 @@ journalctl -u meshmonitor -p err
 
 #### Service Won't Start
 
-**Check configuration**:
-```bash
-nano /etc/meshmonitor/meshmonitor.env
-# Verify MESHTASTIC_NODE_IP is set correctly
-```
-
 **Check file permissions**:
 ```bash
 ls -la /data
@@ -491,6 +411,8 @@ You should see an entry for `eth0` with either `dhcp` or a static IP. If `/etc/n
 
 #### Cannot Connect to Meshtastic Node
 
+Configure your node via the web UI: **Settings → Node Connection**.
+
 **Test network connectivity**:
 ```bash
 # Inside container
@@ -517,6 +439,13 @@ ss -tln | grep 3001
 **Check from Proxmox host**:
 ```bash
 curl http://CONTAINER-IP:3001
+```
+
+**Verify ALLOWED_ORIGINS is set correctly**:
+```bash
+grep ALLOWED_ORIGINS /etc/meshmonitor/meshmonitor.env
+# Should show: ALLOWED_ORIGINS=http://CONTAINER-IP:3001
+# If missing, run: bash /opt/meshmonitor/lxc/proxmox/post-install.sh
 ```
 
 **Verify network configuration**:
@@ -556,6 +485,18 @@ lsof /data/meshmonitor.db
 systemctl restart meshmonitor
 ```
 
+#### meshmonitor-update Not Found After Self-Install
+
+If `meshmonitor-update` is not found after running the self-install:
+
+```bash
+source /root/.bashrc
+# or open a new shell
+```
+
+`/usr/local/bin` is not in Debian's minimal default PATH. The self-install adds it
+to `/root/.bashrc` automatically, but the current shell session needs to be reloaded.
+
 ### Performance Issues
 
 **Check resource usage**:
@@ -571,13 +512,41 @@ du -sh /data/meshmonitor.db
 ```bash
 pct set 100 --cores 4
 pct set 100 --memory 4096
+pct set 100 --swap 1024
 ```
+
+If `meshmonitor-update` runs for an excessively long time, the container likely needs
+more RAM or swap — npm's TypeScript build peaks at ~1.5GB Node heap.
 
 ## Updating
 
-### Automated Update (Recommended)
+Templates built from v4.12.0+ are git-native from first boot. Two update paths are available:
 
-Use `lxc/update.sh` from the [MeshMonitor repository](https://github.com/Yeraze/meshmonitor/blob/main/lxc/update.sh) on your Proxmox host. It performs a destroy-and-recreate update while preserving the container's CTID, IP, `/data`, and `/etc/meshmonitor/meshmonitor.env`.
+### In-place update (recommended)
+
+Run inside the container — no template redownload, no data migration, minimal downtime:
+
+```bash
+# First run — self-installs to /usr/local/bin:
+bash /opt/meshmonitor/lxc/meshmonitor-update
+
+# All subsequent runs:
+meshmonitor-update
+
+# Useful flags:
+meshmonitor-update -s    # check current vs available version
+meshmonitor-update -n    # dry run — preview what would change
+meshmonitor-update -h    # see all options
+```
+
+This performs a `git pull`, rebuilds the app, and restarts services in place.
+
+### Full template swap (alternative)
+
+Use when major OS or Node.js version changes ship, or on containers with limited
+resources where the npm build is impractical.
+
+`lxc/update.sh` automates the destroy-and-recreate flow on the Proxmox host:
 
 ```bash
 # Fetch the script:
@@ -588,7 +557,7 @@ chmod +x update.sh
 ./update.sh --ctid 100
 
 # Or pin a specific version:
-./update.sh --ctid 100 --version 4.6.5
+./update.sh --ctid 100 --version 4.12.0
 
 # Non-interactive (e.g. cron):
 ./update.sh --ctid 100 --yes
@@ -596,26 +565,26 @@ chmod +x update.sh
 
 The script:
 
-- Reads cores/memory/swap/storage/bridge/rootfs size from the existing CT, so you don't have to re-specify them.
+- Reads cores/memory/swap/storage/bridge/rootfs size from the existing CT.
 - Takes a Proxmox snapshot (best-effort) and writes file backups of `/data` and `/etc/meshmonitor` to `/root/meshmonitor-lxc-backups/`.
-- Preserves the current static IP/gateway by default (use `--network dhcp` or `--custom-ip <cidr,gw=...>` to override).
+- Preserves the current static IP/gateway by default.
 - Restarts the MeshMonitor systemd services after the rebuild.
 
-See `./update.sh --help` for all options (including `--install-ssh` and `--restore-root-password`, which are opt-in).
+See `./update.sh --help` for all options.
 
 ### Manual Update Process
 
-If you prefer to run each step yourself, follow this process. Replace `100` with your CTID and `4.6.5` with the version you want to install.
+If you prefer to run each step yourself:
 
 1. **Create snapshot** before updating:
    ```bash
-   pct snapshot 100 before-update-v4_6_5
+   pct snapshot 100 before-update
    ```
 
 2. **Download new template** into Proxmox's template cache:
    ```bash
-   wget -O /var/lib/vz/template/cache/meshmonitor-4.6.5-amd64.tar.gz \
-     https://github.com/Yeraze/meshmonitor/releases/download/v4.6.5/meshmonitor-4.6.5-amd64.tar.gz
+   wget -O /var/lib/vz/template/cache/meshmonitor-<version>-amd64.tar.gz \
+     https://github.com/Yeraze/meshmonitor/releases/download/v<version>/meshmonitor-<version>-amd64.tar.gz
    ```
 
 3. **Back up data and env**:
@@ -624,7 +593,7 @@ If you prefer to run each step yourself, follow this process. Replace `100` with
    pct pull 100 /tmp/meshmonitor-data.tar.gz ./meshmonitor-data.tar.gz
    ```
 
-4. **Note the current network config** so you can re-apply it:
+4. **Note the current network config**:
    ```bash
    pct config 100 | grep net0
    ```
@@ -635,7 +604,7 @@ If you prefer to run each step yourself, follow this process. Replace `100` with
    pct destroy 100
    ```
 
-6. **Create the new container** from the updated template (re-use the IP from step 4 — see Step 3 of Installation above for full `pct create` flags).
+6. **Create the new container** from the updated template (re-use the IP from step 4).
 
 7. **Restore data and env**:
    ```bash
@@ -645,9 +614,9 @@ If you prefer to run each step yourself, follow this process. Replace `100` with
    pct exec 100 -- chown -R meshmonitor:meshmonitor /data
    ```
 
-8. **Restart services** and verify:
+8. **Run post-install and restart services**:
    ```bash
-   pct exec 100 -- systemctl daemon-reload
+   pct exec 100 -- bash /opt/meshmonitor/lxc/proxmox/post-install.sh
    pct exec 100 -- systemctl restart meshmonitor meshmonitor-apprise
    pct exec 100 -- systemctl status meshmonitor --no-pager
    ```
@@ -656,14 +625,14 @@ If you prefer to run each step yourself, follow this process. Replace `100` with
 
 ### Feature Limitations
 
-- ❌ **No in-place upgrade**: Updates rebuild the container (the `lxc/update.sh` helper automates this)
+- ✅ **In-place upgrade**: `meshmonitor-update` handles updates from v4.12.0+ templates
 - ❌ **Single architecture**: amd64/x86_64 only (no ARM support yet)
 - ❌ **Community support**: LXC is best-effort, Docker is primary
 
 ### Deployment Considerations
 
-- Updates recreate the container from a new template (automated by `lxc/update.sh`)
-- Data and env are preserved across updates via file backup + restore
+- Templates prior to v4.12.0 had no `.git` and required `migrate-to-git.sh` before `meshmonitor-update` could be used. See the [migration guide](https://gist.github.com/BeerMan81/06c562c32582b14ab7437dfb2ad8cbd0).
+- Data and env are preserved across full template swap updates via file backup + restore
 - Some Docker-specific features may not be available
 
 ### Supported Features

--- a/lxc/README.md
+++ b/lxc/README.md
@@ -11,7 +11,9 @@ The LXC deployment option provides a lightweight alternative to Docker for Proxm
 ```
 lxc/
 ├── build-lxc-template.sh          # Main build script (requires root)
-├── update.sh                      # In-place update of an existing CT (run on Proxmox host)
+├── meshmonitor-update             # In-place updater (installed to /usr/local/bin in the template)
+├── sparse-cone.txt                # Sparse-checkout cone list for the git clone (see file for maintenance notes)
+├── update.sh                      # Host-side destroy-and-recreate updater (run on Proxmox host)
 ├── systemd/
 │   ├── meshmonitor.service        # Main application systemd unit
 │   └── meshmonitor-apprise.service # Apprise notification service unit
@@ -26,47 +28,58 @@ lxc/
 
 ### Prerequisites
 
-- Debian/Ubuntu Linux with root access
-- `debootstrap` package installed
-- Node.js 22 and npm
-- At least 2GB free disk space
+- Debian/Ubuntu Linux with root access (VM recommended — debootstrap requires full kernel namespace access)
+- `debootstrap`, `git`, `curl` packages installed
+- Node.js is **not** required on the build host — the script installs Node.js 24 via NodeSource inside the container rootfs
+- At least 2GB free disk space (template output is ~490MB)
 
 ### Build Process
 
 ```bash
-# From project root
-sudo ./lxc/build-lxc-template.sh 2.19.4
+# From the lxc/ directory
+sudo bash build-lxc-template.sh 4.12.0
+
+# Or without a version argument to build from main:
+sudo bash build-lxc-template.sh
 ```
 
 This will:
 1. Create a minimal Debian 12 (Bookworm) rootfs using debootstrap
-2. Install Node.js 22, Python 3, and system dependencies
-3. Build the MeshMonitor application (frontend + backend)
-4. Copy application files into the container filesystem
+2. Install Node.js 24 (via NodeSource), Python 3, sudo, and system dependencies
+3. Clone the MeshMonitor repo into the container using a partial+sparse git clone
+4. Build the application inside the container chroot (npm install, build, build:server)
 5. Install and configure systemd service units
 6. Create the meshmonitor user and set permissions
-7. Package everything as a `.tar.gz` template
+7. Install meshmonitor-update to /usr/local/bin for in-place future updates
+8. Package everything as a `.tar.gz` template
 
-Output: `lxc/build/meshmonitor-2.19.4-amd64.tar.gz`
+Output: `lxc/build/meshmonitor-<version>-amd64.tar.gz`
+
+### Sparse Cone
+
+`sparse-cone.txt` controls which top-level directories are materialized inside the
+container. See that file for the maintenance obligation — if you add a new top-level
+directory that is required at runtime, add it there.
 
 ## Template Contents
 
 The generated template includes:
 
 - **Operating System**: Debian 12 (Bookworm) minimal
-- **Runtime**: Node.js 22, Python 3
-- **Application**: Pre-built MeshMonitor in `/opt/meshmonitor`
+- **Runtime**: Node.js 24, Python 3
+- **Application**: MeshMonitor cloned from git in `/opt/meshmonitor` (git-native from first boot)
 - **Services**: systemd units for meshmonitor and apprise
 - **User**: meshmonitor (UID 1000)
 - **Data Directory**: `/data` for persistent storage
 - **Configuration**: `/etc/meshmonitor/meshmonitor.env`
+- **Updater**: `meshmonitor-update` at `/usr/local/bin/meshmonitor-update`
 
 ## Automated Builds
 
 Templates are automatically built via GitHub Actions when version tags are created:
 
 - Workflow: `.github/workflows/lxc-template-build.yml`
-- Trigger: `git tag v2.19.4 && git push --tags`
+- Trigger: `git tag v<version> && git push --tags`
 - Output: Published to GitHub Releases
 
 ## Deployment
@@ -79,26 +92,36 @@ See the [Proxmox LXC Deployment Guide](../docs/deployment/PROXMOX_LXC_GUIDE.md) 
 2. Upload to Proxmox: `scp meshmonitor-*.tar.gz root@proxmox:/var/lib/vz/template/cache/`
 3. Create LXC container from template via Proxmox web UI
 4. Configure `/etc/meshmonitor/meshmonitor.env` with your node IP
-5. Access web UI on port 8080
-
-## Testing
-
-Validate template structure before deployment:
-
-```bash
-./tests/test-lxc-template.sh lxc/build/meshmonitor-2.19.4-amd64.tar.gz
-```
+5. Access web UI on port **3001** (LXC has no port mapping — the app runs directly on 3001)
 
 ## Updating an Existing Container
 
-`lxc/update.sh` automates the destroy-and-recreate update flow on the Proxmox host:
+Templates built from this version are git-native from first boot. Two update paths are available:
+
+### In-place update (recommended — no downtime, no data migration)
+
+Run inside the container:
+
+```bash
+# First run — self-installs to /usr/local/bin and adds it to PATH:
+bash /opt/meshmonitor/lxc/meshmonitor-update
+
+# All subsequent runs — available directly from anywhere:
+meshmonitor-update
+```
+
+This performs a `git pull`, rebuilds, and restarts services in place. No template redownload needed.
+
+### Full template swap (alternative — use when major OS or dependency changes ship, or on LXCs with limited resources)
+
+`lxc/update.sh` automates the destroy-and-recreate flow on the Proxmox host:
 
 ```bash
 # Update CT 100 to the latest release (auto-detected from GitHub):
 ./lxc/update.sh --ctid 100
 
 # Or pin a specific version:
-./lxc/update.sh --ctid 100 --version 4.6.5
+./lxc/update.sh --ctid 100 --version 4.12.0
 ```
 
 What it does:
@@ -128,6 +151,7 @@ See `./lxc/update.sh --help` for the full flag list.
 
 **Debootstrap errors**:
 - Ensure you're running as root (`sudo`)
+- Build inside a VM, not an LXC container — debootstrap requires full kernel namespace access
 - Check internet connectivity
 - Verify `/etc/resolv.conf` is configured
 
@@ -137,20 +161,14 @@ See `./lxc/update.sh --help` for the full flag list.
 - Verify Debian version is Bookworm (12)
 
 **Build size issues**:
-- Expected template size: 300-500MB
-- Ensure sufficient disk space in `/tmp` and build directory
+- Expected template size: 450-500MB
+- Ensure sufficient disk space in the build directory
 
 ### Template Issues
 
-Use the validation script to diagnose problems:
-
-```bash
-./tests/test-lxc-template.sh lxc/build/meshmonitor-*.tar.gz
-```
-
 Common issues:
 - Missing systemd service files → Re-run build
-- Incorrect permissions → Check meshmonitor user creation
+- Incorrect permissions → Check meshmonitor user creation in Step 9
 - Missing dependencies → Verify debootstrap completed successfully
 
 ## Development
@@ -158,12 +176,9 @@ Common issues:
 To modify the build process:
 
 1. Edit `build-lxc-template.sh` for changes to the build workflow
-2. Edit systemd units in `systemd/` for service configuration
-3. Test locally before committing:
-   ```bash
-   sudo ./lxc/build-lxc-template.sh test
-   ./tests/test-lxc-template.sh lxc/build/meshmonitor-test-amd64.tar.gz
-   ```
+2. Edit `sparse-cone.txt` to add/remove top-level directories from the container clone
+3. Edit systemd units in `systemd/` for service configuration
+4. Test locally: `sudo bash lxc/build-lxc-template.sh`
 
 ## Support
 

--- a/lxc/README.md
+++ b/lxc/README.md
@@ -50,7 +50,7 @@ This will:
 4. Build the application inside the container chroot (npm install, build, build:server)
 5. Install and configure systemd service units
 6. Create the meshmonitor user and set permissions
-7. Install meshmonitor-update to /usr/local/bin for in-place future updates
+7. Bundle meshmonitor-update in `lxc/` — self-installs to `/usr/local/bin` on first operator run
 8. Package everything as a `.tar.gz` template
 
 Output: `lxc/build/meshmonitor-<version>-amd64.tar.gz`

--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -4,7 +4,13 @@
 # Creates a Proxmox-compatible LXC container template
 #
 # Usage: ./build-lxc-template.sh [version]
-#   version: Optional version tag (e.g., "2.19.4" or "latest")
+#   version: Release tag (e.g. "4.11.3") or "latest" for main branch
+#
+# Requires: root, debootstrap, git, curl, tar
+# Output:   lxc/build/<template>.tar.gz  +  .sha256
+#
+# See docs/deployment/PROXMOX_LXC_GUIDE.md for full build and deployment docs.
+# Sparse cone: lxc/sparse-cone.txt — update there if new runtime dirs are added.
 #
 
 set -e  # Exit on error
@@ -12,7 +18,6 @@ set -u  # Exit on undefined variable
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-$SCRIPT_DIR/build}"
 TEMPLATE_NAME="meshmonitor"
 VERSION="${1:-latest}"
@@ -43,10 +48,10 @@ mkdir -p "$BUILD_DIR"
 mkdir -p "$ROOTFS_DIR"
 
 # Check for required commands
-for cmd in debootstrap tar; do
+for cmd in debootstrap tar git curl; do
     if ! command -v $cmd &> /dev/null; then
         echo "ERROR: Required command '$cmd' not found"
-        echo "Install with: sudo apt-get install $cmd"
+        echo "Install with: apt-get install -y $cmd"
         exit 1
     fi
 done
@@ -107,7 +112,8 @@ chroot "$ROOTFS_DIR" apt-get install -y --no-install-recommends \
     iproute2 \
     dbus \
     nano \
-    iputils-ping
+    iputils-ping \
+    git
 
 # Create /etc/network/interfaces for Proxmox networking support
 cat > "$ROOTFS_DIR/etc/network/interfaces" << EOF
@@ -154,56 +160,98 @@ chroot "$ROOTFS_DIR" apt-get install -y --no-install-recommends \
     libsqlite3-dev
 
 echo ""
-echo "Step 6: Building MeshMonitor application..."
+echo "Step 6: Cloning MeshMonitor repository into container..."
 
-# Build the application in the project root
-cd "$PROJECT_ROOT"
+# Resolve the git ref to check out:
+#   - A specific version (e.g. "4.11.3") pins to its release tag (v4.11.3),
+#     fetched directly via --branch so the tag is guaranteed reachable
+#     regardless of its position in history.
+#   - "latest" uses main so local/test builds always succeed even without
+#     a version argument.
+if [ "$VERSION" = "latest" ]; then
+    GIT_REF="main"
+else
+    GIT_REF="v${VERSION}"
+fi
 
-echo "Installing npm dependencies..."
-npm install --legacy-peer-deps
+REPO_URL="https://github.com/Yeraze/meshmonitor.git"
 
-echo "Building React frontend..."
-npm run build
+# Read the cone directory list from lxc/sparse-cone.txt.
+# MAINTENANCE: if a new top-level runtime directory is added upstream,
+# add it to sparse-cone.txt — never hardcode the list here.
+CONE_DIRS=$(grep -v '^#' "$SCRIPT_DIR/sparse-cone.txt" | grep -v '^$' | tr '\n' ' ')
+[ -n "$CONE_DIRS" ] || { echo "ERROR: sparse-cone.txt is empty or missing"; exit 1; }
 
-echo "Building Express backend..."
-npm run build:server
+# Partial + sparse clone into the container rootfs.
+# --branch pins to the exact tag at clone time (no separate checkout needed).
+# --filter=blob:none + --sparse: only fetch blobs for cone dirs (~8MB vs ~51MB).
+# --no-single-branch: keeps remote refs so meshmonitor-update's
+#   'git fetch origin main' works after deploy.
+git clone \
+    --branch "$GIT_REF" \
+    --depth 1 \
+    --filter=blob:none \
+    --sparse \
+    --no-single-branch \
+    "$REPO_URL" \
+    "$ROOTFS_DIR/opt/meshmonitor"
+
+# Materialize only the cone directories (and all root-level files, which
+# cone mode always includes automatically: package.json, tsconfig*.json, etc.)
+# Everything outside the cone (docs/, desktop/, .github/, …) is not fetched.
+git -C "$ROOTFS_DIR/opt/meshmonitor" sparse-checkout set $CONE_DIRS
+
+# Confirm the cone is correct before spending time on npm
+echo "Cone contents:"
+ls "$ROOTFS_DIR/opt/meshmonitor"
+
+# Initialise the protobufs submodule (required for Meshtastic protocol support;
+# confirmed working under sparse-checkout in CI).
+git -C "$ROOTFS_DIR/opt/meshmonitor" submodule update --init --recursive
 
 echo ""
-echo "Step 7: Installing MeshMonitor into container..."
+echo "Step 7: Building MeshMonitor application inside container..."
 
 # Create application directory structure
-mkdir -p "$ROOTFS_DIR/opt/meshmonitor"
 mkdir -p "$ROOTFS_DIR/data/apprise-config"
 mkdir -p "$ROOTFS_DIR/data/scripts"
 mkdir -p "$ROOTFS_DIR/data/logs"
 mkdir -p "$ROOTFS_DIR/etc/meshmonitor"
 
-# Copy built application
-echo "Copying built application files..."
-cp -r "$PROJECT_ROOT/dist" "$ROOTFS_DIR/opt/meshmonitor/"
-cp -r "$PROJECT_ROOT/node_modules" "$ROOTFS_DIR/opt/meshmonitor/"
-cp -r "$PROJECT_ROOT/protobufs" "$ROOTFS_DIR/opt/meshmonitor/"
-cp "$PROJECT_ROOT/package.json" "$ROOTFS_DIR/opt/meshmonitor/"
-cp "$PROJECT_ROOT/package-lock.json" "$ROOTFS_DIR/opt/meshmonitor/"
+# All build steps run inside the chroot against the container's own Node.js
+# (NodeSource v24), ensuring native modules (better-sqlite3, bcrypt) compile
+# for the correct target ABI — not the host/CI runner's ABI.
+#
+# PUPPETEER_SKIP_DOWNLOAD=true: the LXC container is headless and has no
+# display/sandbox for Chrome. Without this flag, npm install will attempt
+# to download Chromium and fail or hang.
 
-echo "Rebuilding native modules against container Node.js..."
-chroot "$ROOTFS_DIR" bash -c "cd /opt/meshmonitor && npm rebuild better-sqlite3 --build-from-source"
+echo "Installing npm dependencies..."
+chroot "$ROOTFS_DIR" bash -c "
+    cd /opt/meshmonitor
+    PUPPETEER_SKIP_DOWNLOAD=true npm install --legacy-peer-deps
+"
 
-# Copy Docker helper scripts (apprise-api.py and others)
-mkdir -p "$ROOTFS_DIR/opt/meshmonitor/docker"
-cp "$PROJECT_ROOT/docker/apprise-api.py" "$ROOTFS_DIR/opt/meshmonitor/docker/"
-chmod +x "$ROOTFS_DIR/opt/meshmonitor/docker/apprise-api.py"
+echo "Building React frontend..."
+chroot "$ROOTFS_DIR" bash -c "
+    cd /opt/meshmonitor
+    PUPPETEER_SKIP_DOWNLOAD=true npm run build
+"
 
-# Copy utility scripts (upgrade-watchdog won't work without Docker, but include for completeness)
-if [ -d "$PROJECT_ROOT/scripts" ]; then
-    cp -r "$PROJECT_ROOT/scripts/"*.sh "$ROOTFS_DIR/data/scripts/" 2>/dev/null || true
-    cp -r "$PROJECT_ROOT/scripts/"*.py "$ROOTFS_DIR/data/scripts/" 2>/dev/null || true
+echo "Building Express backend..."
+chroot "$ROOTFS_DIR" bash -c "
+    cd /opt/meshmonitor
+    PUPPETEER_SKIP_DOWNLOAD=true npm run build:server
+"
+
+# docker/apprise-api.py is already present at /opt/meshmonitor/docker/
+# via the sparse-checkout cone — no separate copy needed.
+
+# Copy utility scripts to /data/scripts (separate runtime location)
+if [ -d "$ROOTFS_DIR/opt/meshmonitor/scripts" ]; then
+    cp -r "$ROOTFS_DIR/opt/meshmonitor/scripts/"*.sh "$ROOTFS_DIR/data/scripts/" 2>/dev/null || true
+    cp -r "$ROOTFS_DIR/opt/meshmonitor/scripts/"*.py "$ROOTFS_DIR/data/scripts/" 2>/dev/null || true
     chmod +x "$ROOTFS_DIR/data/scripts/"* 2>/dev/null || true
-fi
-
-# Copy admin password reset script
-if [ -f "$PROJECT_ROOT/reset-admin.mjs" ]; then
-    cp "$PROJECT_ROOT/reset-admin.mjs" "$ROOTFS_DIR/opt/meshmonitor/"
 fi
 
 echo ""
@@ -221,13 +269,16 @@ chroot "$ROOTFS_DIR" ln -sf /opt/apprise-venv/bin/meshtastic /usr/local/bin/mesh
 echo ""
 echo "Step 9: Creating meshmonitor user and setting permissions..."
 
-# Create meshmonitor user (UID 1000 to match Docker)
+# Create meshmonitor user (UID 1000 to match Docker image)
 chroot "$ROOTFS_DIR" useradd -u 1000 -m -s /bin/bash meshmonitor || true
 
 # Add to dialout group for MeshCore serial device access
 chroot "$ROOTFS_DIR" usermod -aG dialout meshmonitor || true
 
-# Set ownership
+# chown covers .git along with everything else — since .git is created in
+# Step 6 (before this chown), the repo owner is meshmonitor from first boot.
+# This means meshmonitor-update always runs git as the correct owner and
+# never encounters a "dubious ownership" error (git 2.35+ safety check).
 chroot "$ROOTFS_DIR" chown -R meshmonitor:meshmonitor /opt/meshmonitor
 chroot "$ROOTFS_DIR" chown -R meshmonitor:meshmonitor /data
 chroot "$ROOTFS_DIR" chown -R meshmonitor:meshmonitor /opt/apprise-venv
@@ -305,8 +356,9 @@ MESHTASTIC_NODE_IP=192.168.1.100
 #TRUST_PROXY=true
 
 # ── CORS ─────────────────────────────────────────────────────────
-# Comma-separated list of allowed origins
-#ALLOWED_ORIGINS=http://localhost:8080
+# Comma-separated list of allowed origins (browser URLs you access the UI from)
+# Example: http://192.168.1.50:3001,https://meshmonitor.yourdomain.com
+#ALLOWED_ORIGINS=http://<CONTAINER-IP>:3001
 
 # ── Web Push Notifications ───────────────────────────────────────
 #VAPID_PUBLIC_KEY=
@@ -317,6 +369,7 @@ MESHTASTIC_NODE_IP=192.168.1.100
 # ── OIDC/SSO (optional) ─────────────────────────────────────────
 #OIDC_ISSUER=
 #OIDC_CLIENT_ID=
+#OIDC_CALLBACK_URL=
 #OIDC_CLIENT_SECRET=
 #OIDC_ALLOW_HTTP=false
 
@@ -334,15 +387,20 @@ chroot "$ROOTFS_DIR" chown meshmonitor:meshmonitor /etc/meshmonitor/meshmonitor.
 echo ""
 echo "Step 12: Cleaning up container..."
 
-# Clean up apt cache
+# Clean up apt cache and temp files
 chroot "$ROOTFS_DIR" apt-get clean
 rm -rf "$ROOTFS_DIR/var/lib/apt/lists/"*
 rm -rf "$ROOTFS_DIR/tmp/"*
 rm -rf "$ROOTFS_DIR/var/tmp/"*
 
-# Remove any build artifacts
+# Remove npm/pip build caches
+# NOTE: node_modules/ and .git/ are intentionally kept —
+#   node_modules/ is needed at runtime by the app
+#   .git/ is needed by meshmonitor-update for future in-place updates
 rm -rf "$ROOTFS_DIR/root/.npm"
 rm -rf "$ROOTFS_DIR/root/.cache"
+rm -rf "$ROOTFS_DIR/opt/meshmonitor/.npm"
+rm -rf "$ROOTFS_DIR/opt/meshmonitor/.cache"
 
 echo ""
 echo "Step 13: Creating container metadata..."
@@ -367,20 +425,21 @@ cd "$ROOTFS_DIR"
 tar czf "$TEMPLATE_FILE" .
 
 cd "$BUILD_DIR"
+
+# Calculate SHA256 checksum
+sha256sum "$TEMPLATE_FILE" > "$TEMPLATE_FILE.sha256"
+
 echo ""
 echo "================================================"
 echo "Build Complete!"
 echo "================================================"
 echo "Template file: $TEMPLATE_FILE"
 echo "Size: $(du -h "$TEMPLATE_FILE" | cut -f1)"
+echo "SHA256: $(cat "$TEMPLATE_FILE.sha256")"
 echo ""
 echo "To use with Proxmox VE:"
-echo "1. Upload to Proxmox: scp $TEMPLATE_FILE root@proxmox:/var/lib/vz/template/cache/"
-echo "2. Create container from template in Proxmox web UI"
-echo "3. Configure MESHTASTIC_NODE_IP in /etc/meshmonitor/meshmonitor.env"
-echo "4. Start the container"
+echo "  1. Upload: scp $TEMPLATE_FILE root@proxmox:/var/lib/vz/template/cache/"
+echo "  2. Create container from template in Proxmox web UI or pct create"
+echo "  3. Configure: /etc/meshmonitor/meshmonitor.env (see meshmonitor.env.example)"
+echo "  4. Start the container — meshmonitor-update is ready to use immediately"
 echo "================================================"
-
-# Calculate SHA256 checksum
-sha256sum "$TEMPLATE_FILE" > "$TEMPLATE_FILE.sha256"
-echo "SHA256: $(cat "$TEMPLATE_FILE.sha256")"

--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -304,8 +304,8 @@ cat > "$ROOTFS_DIR/etc/meshmonitor/meshmonitor.env.example" << 'EOF'
 # See .env.example in the project repo for full documentation on each option
 
 # ── Meshtastic Node ──────────────────────────────────────────────
-# Required: IP address of your Meshtastic node
-MESHTASTIC_NODE_IP=192.168.1.100
+# Configure your node connection via the MeshMonitor web UI.
+# Go to Settings -> Node Connection after first login.
 
 # Optional: TCP port for Meshtastic node (default: 4403)
 #MESHTASTIC_TCP_PORT=4403

--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -384,7 +384,14 @@ touch "$ROOTFS_DIR/etc/meshmonitor/meshmonitor.env"
 chmod 600 "$ROOTFS_DIR/etc/meshmonitor/meshmonitor.env"
 chroot "$ROOTFS_DIR" chown meshmonitor:meshmonitor /etc/meshmonitor/meshmonitor.env
 
+
 echo ""
+# Add /usr/local/bin to PATH — missing from minimal Debian's default PATH.
+
+# Without this, operators cannot run meshmonitor-update directly after first boot.
+echo 'PATH=/usr/local/bin:$PATH' >> "$ROOTFS_DIR/etc/environment"
+echo "/usr/local/bin added to PATH."
+
 echo "Step 12: Cleaning up container..."
 
 # Clean up apt cache and temp files

--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -113,7 +113,8 @@ chroot "$ROOTFS_DIR" apt-get install -y --no-install-recommends \
     dbus \
     nano \
     iputils-ping \
-    git
+    git \
+    sudo
 
 # Create /etc/network/interfaces for Proxmox networking support
 cat > "$ROOTFS_DIR/etc/network/interfaces" << EOF
@@ -169,12 +170,12 @@ echo "Step 6: Cloning MeshMonitor repository into container..."
 #   - "latest" uses main so local/test builds always succeed even without
 #     a version argument.
 if [ "$VERSION" = "latest" ]; then
-    GIT_REF="main"
+    GIT_REF="lxc-template-git-clone"
 else
     GIT_REF="v${VERSION}"
 fi
 
-REPO_URL="https://github.com/Yeraze/meshmonitor.git"
+REPO_URL="https://github.com/BeerMan81/meshmonitor.git"
 
 # Read the cone directory list from lxc/sparse-cone.txt.
 # MAINTENANCE: if a new top-level runtime directory is added upstream,

--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -170,12 +170,12 @@ echo "Step 6: Cloning MeshMonitor repository into container..."
 #   - "latest" uses main so local/test builds always succeed even without
 #     a version argument.
 if [ "$VERSION" = "latest" ]; then
-    GIT_REF="lxc-template-git-clone"
+    GIT_REF="main"
 else
     GIT_REF="v${VERSION}"
 fi
 
-REPO_URL="https://github.com/BeerMan81/meshmonitor.git"
+REPO_URL="https://github.com/Yeraze/meshmonitor.git"
 
 # Read the cone directory list from lxc/sparse-cone.txt.
 # MAINTENANCE: if a new top-level runtime directory is added upstream,

--- a/lxc/meshmonitor-update
+++ b/lxc/meshmonitor-update
@@ -1,0 +1,1181 @@
+#!/bin/bash
+#
+# MeshMonitor Update Script
+# ──────────────────────────────────────────────────────────────────────────────
+# Originally contributed by BeerMan81
+# https://github.com/Yeraze/meshmonitor/blob/main/lxc/meshmonitor-update
+# ──────────────────────────────────────────────────────────────────────────────
+# Updates an existing MeshMonitor installation in-place.
+#
+# Requires a git-native install (i.e. /opt/meshmonitor/.git exists).
+# Templates built from v4.12.0+ include .git from first boot.
+# For older templates (pre-built artifact, no .git), run migrate-to-git.sh
+# first: https://gist.github.com/BeerMan81/06c562c32582b14ab7437dfb2ad8cbd0
+# Works with the official LXC template from:
+#   https://github.com/yeraze/meshmonitor
+#
+# Fresh LXC template (no .git)? Migrate first:
+#   https://gist.github.com/BeerMan81/06c562c32582b14ab7437dfb2ad8cbd0
+#
+# Typical workflow:
+#   1. Deploy the LXC template once (sets up /opt/meshmonitor, systemd services, env file)
+#   2. Run this script whenever a new version is available — no redeployment needed
+#
+# What this script does:
+#   - Backs up /data/, meshmonitor.env, and systemd service files
+#   - Stops services, pulls latest source, rebuilds, restarts
+#   - Keeps the last 5 backups and supports one-command rollback
+#
+# Requirements:
+#   - MeshMonitor installed via git clone (LXC template, bare-metal, or VM)
+#   - Install detected automatically from these locations (in order):
+#       /opt/meshmonitor  (LXC template default)
+#       /var/lib/meshmonitor/meshmonitor  (bare-metal default)
+#       /var/lib/meshmonitor
+#       /home/meshmonitor/meshmonitor
+#       current directory
+#   - Internet access to reach github.com
+#   - Run as root (or with sudo)
+#
+# Usage:
+#   meshmonitor-update                    normal update
+#   meshmonitor-update -n / --dry-run     show what would happen, change nothing
+#   meshmonitor-update -y / --yes         skip non-critical confirmations (after first run)
+#   meshmonitor-update -r / --rollback    restore from the most recent backup
+#   meshmonitor-update -r -n / -rn        preview rollback — show what would be restored, no changes
+#   meshmonitor-update -s / --status      show current version and service state
+#   meshmonitor-update -d / --debug       verbose output + save full log to file
+#   meshmonitor-update -h / --help        show this help
+#   meshmonitor-update -c / --clear-config  forget saved backup directory (prompts again next run)
+#   meshmonitor-update -l / --list-backups  list available backups with sizes and dates
+#
+# Notes:
+#   - Combined short flags are supported: -rn, -nr, -yn, -dny, etc.
+#   - Rollback ALWAYS requires typing 'yes' in full — -y / --yes does NOT bypass it.
+#   - Major version upgrades ALWAYS require typing 'yes' in full — -y / --yes does NOT bypass it.
+#   - -s / --status uses git ls-remote (truly read-only, no local writes).
+#   - PUPPETEER_SKIP_DOWNLOAD=true is set automatically on every npm install.
+#     Stale Puppeteer cache (~/.cache/puppeteer/) is wiped before each install
+#     to prevent the "folder exists but executable missing" Chrome error (4.7.x+).
+#
+# END_HELP
+
+set -euo pipefail
+
+SCRIPT_START=$(date +%s)
+
+# =============================================================================
+# SELF-INSTALL
+# =============================================================================
+SELF_INSTALL_PATH="/usr/local/bin/meshmonitor-update"
+SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+
+# If not already running from the install path, offer to install
+if [ "$SCRIPT_PATH" != "$SELF_INSTALL_PATH" ] \
+   && [ ! -f "$SELF_INSTALL_PATH" ] \
+   && [ "${1:-}" != "--no-install" ]; then
+    echo ""
+    echo "  This script is not installed as a system command yet."
+    echo "  Install to ${SELF_INSTALL_PATH} so you can run 'meshmonitor-update' from anywhere?"
+    read -r -t 30 -p "  Install now? [Y/n]: " _yn
+    _yn="${_yn:-y}"
+    if [[ "$_yn" =~ ^[Yy]$ ]]; then
+        cp "$SCRIPT_PATH" "$SELF_INSTALL_PATH"
+        chmod +x "$SELF_INSTALL_PATH"
+        export PATH="/usr/local/bin:$PATH"
+        if ! grep -q 'usr/local/bin' /root/.bashrc 2>/dev/null; then
+            echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bashrc
+        fi
+        echo "  [OK] Installed to ${SELF_INSTALL_PATH}"
+        echo "  [OK] Added /usr/local/bin to /root/.bashrc"
+        echo "  [*]  Run 'source /root/.bashrc' or open a new shell to use 'meshmonitor-update' globally."
+        echo ""
+    fi
+fi
+
+# If running from install path but /usr/local/bin not in PATH, fix .bashrc silently
+if [ "$SCRIPT_PATH" = "$SELF_INSTALL_PATH" ] \
+   && ! grep -q 'usr/local/bin' /root/.bashrc 2>/dev/null; then
+    echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bashrc
+fi
+
+# =============================================================================
+# COLORS & OUTPUT HELPERS
+# =============================================================================
+if [ -t 1 ]; then
+    R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[1;33m'
+    B=$'\033[0;34m'; BLD=$'\033[1m'; N=$'\033[0m'
+else
+    R=""; G=""; Y=""; B=""; BLD=""; N=""
+fi
+log()  { echo "${B}[*]${N} $*"; }
+ok()   { echo "${G}[OK]${N} $*"; }
+warn() { echo "${Y}[!]${N} $*"; }
+err()  { echo "${R}[X]${N} $*" >&2; }
+die()  {
+    err "$*"
+    local e=$(( $(date +%s) - SCRIPT_START ))
+    err "Failed after $(( e / 60 ))m $(( e % 60 ))s."
+    [ -n "${LOG_FILE:-}" ] && err "Debug log: $LOG_FILE"
+    # The :-200 fallback is safe — flock on an unacquired fd is a silent no-op.
+    [ -n "${LOCK_FD:-}" ] && flock -u "$LOCK_FD" 2>/dev/null || true
+    exit 1
+}
+hr()   { echo "${B}────────────────────────────────────────────────────────────────────────────────────────${N}"; }
+
+# =============================================================================
+# ARGUMENT PARSING
+# Supports long flags (--rollback) and short flags (-r), including combined
+# short flags (-rn, -nr, -yn, -dny, etc.) via expand_flags().
+#
+#   -n / --dry-run        Show every action that would be taken, change nothing.
+#                         Combine with -r to safely preview a rollback: -rn
+#
+#   -y / --yes            Skip minor confirmations (backup dir create prompt, etc.)
+#                         Does NOT bypass rollback or major version prompts —
+#                         both always require typing 'yes' in full.
+#
+#   -r / --rollback       Restore from most recent backup. Always shows a warning
+#                         banner and requires typing 'yes' in full.
+#                         Combine with -n to preview without changing anything: -rn
+#
+#   -s / --status         Read-only snapshot: installed/available versions and
+#                         service states. Uses git ls-remote (no local writes).
+#
+#   -l / --list-backups   List available backup tarballs with sizes and dates.
+#
+#   -d / --debug          Enables bash -x tracing and saves a timestamped log.
+#                         Log lands in BACKUP_DIR (determined before debug starts
+#                         so the log always goes to the right place).
+#
+#   -c / --clear-config   Forget saved backup directory; prompts on next run.
+#
+#   -h / --help           Print usage summary and exit.
+# =============================================================================
+DRY_RUN=0; ASSUME_YES=0; ROLLBACK=0; DEBUG=0; STATUS=0; CLEAR_CONFIG=0; LIST_BACKUPS=0
+
+expand_flags() {
+    # Splits combined short flags like -rn into -r -n before the main parser.
+    # Long flags and standalone short flags pass through unchanged.
+    # Uses printf to avoid echo misinterpreting flags starting with '-'.
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" =~ ^-[a-zA-Z]{2,}$ ]] && [[ ! "$arg" =~ ^-- ]]; then
+            local i
+            for (( i=1; i<${#arg}; i++ )); do
+                printf -- '-%s\n' "${arg:$i:1}"
+            done
+        else
+            printf '%s\n' "$arg"
+        fi
+    done
+}
+
+mapfile -t ARGS < <(expand_flags "$@")
+
+for a in "${ARGS[@]}"; do
+    case "$a" in
+        --dry-run|-n)        DRY_RUN=1 ;;
+        --yes|-y)            ASSUME_YES=1 ;;
+        --rollback|-r)       ROLLBACK=1 ;;
+        --debug|-d)          DEBUG=1 ;;
+        --status|-s)         STATUS=1 ;;
+        --list-backups|-l)   LIST_BACKUPS=1 ;;
+        --help|-h)           sed -n '/^# Usage:/,/^# END_HELP/p' "$0" \
+                                 | grep '^#' | sed 's/^# \{0,1\}//'; exit 0 ;;
+        --clear-config|-c)   CLEAR_CONFIG=1 ;;
+        *)                   die "Unknown argument: '$a'  (try -h for help)" ;;
+    esac
+done
+
+[ "$DRY_RUN" -eq 1 ] && warn "[DRY RUN] Nothing will be changed."
+
+# Handle --clear-config immediately (no lock needed)
+if [ "${CLEAR_CONFIG:-0}" -eq 1 ]; then
+    CONFIG_FILE="/etc/meshmonitor/update-config"
+    if [ -f "$CONFIG_FILE" ]; then
+        rm -f "$CONFIG_FILE"
+        ok "Cleared saved config: ${BLD}${CONFIG_FILE}${N}"
+        ok "Next run will prompt for backup directory again."
+    else
+        warn "No saved config found at ${BLD}${CONFIG_FILE}${N} — nothing to clear."
+    fi
+    exit 0
+fi
+
+# =============================================================================
+# RUN LOCK
+# Uses flock on a file descriptor so the lock is automatically released even
+# if the script crashes — no stale lock file to clean up manually.
+# =============================================================================
+LOCK_FILE="/var/run/meshmonitor-update.lock"
+LOCK_FD=200
+eval "exec ${LOCK_FD}>\"${LOCK_FILE}\""
+if ! flock -n "$LOCK_FD"; then
+    die "Another instance of this script is already running (lock: $LOCK_FILE). Aborting."
+fi
+
+# =============================================================================
+# ROOT / SUDO DETECTION
+# =============================================================================
+hr
+if [ "$EUID" -eq 0 ]; then
+    SUDO=""
+    ok "Running as root."
+else
+    command -v sudo >/dev/null 2>&1 \
+        || die "Not root and 'sudo' not found. Re-run as root or install sudo."
+    SUDO="sudo"
+    warn "Not running as root — using sudo."
+    sudo -v || die "Failed to obtain sudo credentials. Try running as root."
+fi
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then echo "    [DRY RUN] ${SUDO:+$SUDO }$*"; else $SUDO "$@"; fi
+}
+run_sh() {
+    if [ "$DRY_RUN" -eq 1 ]; then echo "    [DRY RUN] $*"; else eval "$@"; fi
+}
+
+# =============================================================================
+# DISTRO DETECTION
+# =============================================================================
+hr
+log "Detecting environment..."
+DISTRO_ID="unknown"; DISTRO_NAME="unknown"; DISTRO_PKG_MGR="apt"
+if [ -r /etc/os-release ]; then
+    . /etc/os-release
+    DISTRO_ID="${ID:-unknown}"
+    DISTRO_NAME="${PRETTY_NAME:-$DISTRO_ID}"
+    case "${ID_LIKE:-$ID}" in
+        *fedora*|*rhel*|*centos*) DISTRO_PKG_MGR="dnf" ;;
+        *arch*)                   DISTRO_PKG_MGR="pacman" ;;
+        *alpine*)                 DISTRO_PKG_MGR="apk" ;;
+        *)                        DISTRO_PKG_MGR="apt" ;;
+    esac
+fi
+log "Distro : ${BLD}${DISTRO_NAME}${N}"
+log "Pkg mgr: ${BLD}${DISTRO_PKG_MGR}${N}"
+
+# =============================================================================
+# DOCKER DETECTION
+# =============================================================================
+if [ -f /.dockerenv ] \
+   || grep -q 'docker\|containerd' /proc/1/cgroup 2>/dev/null \
+   || grep -q 'docker\|containerd' /proc/self/cgroup 2>/dev/null; then
+    hr
+    err "Docker environment detected."
+    err ""
+    err "This script is designed for bare-metal/LXC installs only."
+    err "It manages systemd services and expects a git-cloned source tree —"
+    err "neither of which applies to Docker deployments."
+    err ""
+    err "For Docker update instructions, refer to the official documentation:"
+    err "  https://github.com/Yeraze/meshmonitor#updating"
+    err ""
+    flock -u "${LOCK_FD:-200}" 2>/dev/null || true
+    exit 1
+fi
+
+# =============================================================================
+# INSTALL PATH DETECTION
+# =============================================================================
+INSTALL_DIR=""
+declare -a SEARCH_PATHS=(
+    "/opt/meshmonitor"
+    "/var/lib/meshmonitor/meshmonitor"
+    "/var/lib/meshmonitor"
+    "/home/meshmonitor/meshmonitor"
+    "$PWD"
+)
+for p in "${SEARCH_PATHS[@]}"; do
+    if [ -d "$p/.git" ] && [ -f "$p/package.json" ] \
+       && grep -q '"name"[[:space:]]*:[[:space:]]*"meshmonitor"' "$p/package.json" 2>/dev/null; then
+        INSTALL_DIR="$p"; break
+    fi
+done
+[ -n "$INSTALL_DIR" ] \
+    || die "Cannot find MeshMonitor source tree (requires git clone, not a pre-built template).\nSearched: ${SEARCH_PATHS[*]}\nSee script header for setup instructions."
+ok "Install dir: ${BLD}${INSTALL_DIR}${N}"
+
+# =============================================================================
+# APP USER DETECTION
+# Detects the owner of the install directory so git runs as that user,
+# avoiding the Git 2.35.2+ "dubious ownership" error on Debian 12 / git 2.39.x.
+# Falls back to root if the owner account doesn't exist.
+# =============================================================================
+APP_USER=$(stat -c '%U' "$INSTALL_DIR")
+APP_GROUP=$(stat -c '%G' "$INSTALL_DIR")
+log "App user : ${BLD}${APP_USER}:${APP_GROUP}${N}"
+
+if id -u "$APP_USER" >/dev/null 2>&1 && [ "$APP_USER" != "root" ]; then
+    GIT_CMD="sudo -u $APP_USER git"
+else
+    git config --global --add safe.directory "$INSTALL_DIR" 2>/dev/null || true
+    GIT_CMD="${SUDO:+$SUDO }git"
+fi
+log "Git exec : ${BLD}git${N}  (as: ${BLD}${GIT_CMD}${N})"
+
+# =============================================================================
+# SERVICE DETECTION
+# =============================================================================
+SERVICES=()
+for svc in meshmonitor meshmonitor-apprise; do
+    if systemctl cat "${svc}.service" >/dev/null 2>&1; then
+        SERVICES+=("$svc")
+    fi
+done
+if [ ${#SERVICES[@]} -eq 0 ]; then
+    warn "No systemd services found — is MeshMonitor installed correctly?"
+else
+    log "Services: ${SERVICES[*]}"
+fi
+
+# =============================================================================
+# PORT DETECTION
+# Reads PORT from the EnvironmentFile declared in the systemd unit first,
+# then falls back to known locations. Default: 3001.
+# =============================================================================
+PORT=3001
+ENV_FILE=""
+
+_env_from_unit=$(systemctl cat meshmonitor.service 2>/dev/null \
+    | grep -E '^EnvironmentFile' | head -1 \
+    | sed 's/EnvironmentFile=-\?//' | tr -d ' ' || true)
+[ -n "$_env_from_unit" ] && [ -r "$_env_from_unit" ] && ENV_FILE="$_env_from_unit"
+
+if [ -z "$ENV_FILE" ]; then
+    for _ef in "/etc/meshmonitor/meshmonitor.env" "/var/lib/meshmonitor/.env"; do
+        [ -r "$_ef" ] && ENV_FILE="$_ef" && break
+    done
+fi
+
+if [ -n "$ENV_FILE" ]; then
+    port_from_env=$(grep -E '^PORT=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" || true)
+    [ -n "$port_from_env" ] && PORT="$port_from_env"
+    DATA_DIR_FROM_ENV=$(grep -E '^DATA_DIR=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" || true)
+    log "Env file : ${BLD}${ENV_FILE}${N}"
+else
+    warn "No environment file found — using default port $PORT."
+fi
+log "App port : ${BLD}${PORT}${N}"
+
+# =============================================================================
+# STATUS MODE
+# Uses git ls-remote — truly read-only, no local writes.
+# git fetch would update .git/FETCH_HEAD and remote-tracking refs.
+# Note: remote version number cannot be shown without fetching the object —
+# ls-remote only retrieves the reference SHA, not the file contents.
+# To see the full incoming version, run: meshmonitor-update --dry-run
+# =============================================================================
+do_status() {
+    hr
+    log "MeshMonitor Status"
+    hr
+
+    local pkg="$INSTALL_DIR/package.json"
+    if [ -f "$pkg" ]; then
+        local ver
+        ver=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$pkg" \
+            | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+        log "Installed version : ${BLD}${ver}${N}"
+    fi
+
+    local local_sha
+    local_sha=$(cd "$INSTALL_DIR" && $GIT_CMD rev-parse HEAD 2>/dev/null || echo "unknown")
+    log "Local commit      : ${BLD}${local_sha:0:8}${N}"
+
+    # ls-remote fetches only the remote reference — no objects downloaded.
+    # We can compare SHAs to know if an update is available, but cannot
+    # parse the remote package.json version without a full object fetch.
+    local remote_sha=""
+    remote_sha=$(cd "$INSTALL_DIR" && $GIT_CMD ls-remote origin refs/heads/main 2>/dev/null \
+        | awk '{print $1}' || true)
+
+    if [ -n "$remote_sha" ]; then
+        log "Remote commit     : ${BLD}${remote_sha:0:8}${N}"
+        if [ "$local_sha" = "$remote_sha" ]; then
+            ok "Up to date with origin/main"
+        else
+            warn "origin/main has new commits — run 'meshmonitor-update --dry-run' to see incoming version."
+        fi
+    else
+        warn "Could not reach origin/main (offline or no remote access)."
+    fi
+
+    hr
+    log "Service states:"
+    for s in "${SERVICES[@]}"; do
+        local state
+        state=$(systemctl is-active "$s" 2>/dev/null || echo "unknown")
+        case "$state" in
+            active)   ok   "$s — $state" ;;
+            inactive) warn "$s — $state" ;;
+            *)        err  "$s — $state" ;;
+        esac
+    done
+
+    hr
+    flock -u "$LOCK_FD" 2>/dev/null || true
+    exit 0
+}
+[ "$STATUS" -eq 1 ] && do_status
+
+# =============================================================================
+# BACKUP DIRECTORY — VALIDATION FUNCTION
+# Validates the chosen backup directory: creates it if needed, checks write
+# permissions, runs a write test. Prompts for a new path on each failure.
+# Up to 5 attempts before dying.
+# =============================================================================
+validate_backup_dir() {
+    local max_retries=5 attempt=0
+    while true; do
+        attempt=$((attempt + 1))
+        [ "$attempt" -gt "$max_retries" ] \
+            && die "Could not establish a valid backup directory after $max_retries attempts."
+
+        [ -z "${BACKUP_DIR:-}" ] \
+            && { read -r -p "  Enter backup directory: " BACKUP_DIR; continue; }
+
+        if [ -e "$BACKUP_DIR" ] && [ ! -d "$BACKUP_DIR" ]; then
+            warn "'$BACKUP_DIR' exists but is a FILE, not a directory."
+            read -r -p "  Enter a different path: " BACKUP_DIR; continue
+        fi
+
+        if [ ! -e "$BACKUP_DIR" ]; then
+            local parent; parent=$(dirname "$BACKUP_DIR")
+            if [ ! -d "$parent" ]; then
+                warn "Parent directory '$parent' does not exist."
+                if [ "$ASSUME_YES" -ne 1 ]; then
+                    read -r -p "  Create full path '$BACKUP_DIR'? [Y/n]: " a
+                    if ! [[ "${a:-y}" =~ ^[Yy]$ ]]; then
+                        read -r -p "  Enter a different path: " BACKUP_DIR; continue
+                    fi
+                fi
+            fi
+            if [ "$DRY_RUN" -eq 1 ]; then
+                ok "[DRY RUN] Would create: $BACKUP_DIR"
+                return 0
+            fi
+            if $SUDO mkdir -p "$BACKUP_DIR" 2>/dev/null; then
+                ok "Created: $BACKUP_DIR"
+            else
+                warn "Could not create '$BACKUP_DIR' (permission denied or invalid path)."
+                read -r -p "  Enter a different path: " BACKUP_DIR; continue
+            fi
+        fi
+
+        if [ ! -w "$BACKUP_DIR" ]; then
+            warn "'$BACKUP_DIR' is not writable."
+            if $SUDO chown "$(id -u):$(id -g)" "$BACKUP_DIR" 2>/dev/null \
+               && [ -w "$BACKUP_DIR" ]; then
+                ok "Fixed ownership on '$BACKUP_DIR'."
+            else
+                warn "Cannot fix permissions on '$BACKUP_DIR'."
+                read -r -p "  Enter a different path: " BACKUP_DIR; continue
+            fi
+        fi
+
+        if [ "$DRY_RUN" -eq 0 ]; then
+            if ! touch "$BACKUP_DIR/.write_test" 2>/dev/null; then
+                warn "'$BACKUP_DIR' failed write test (read-only filesystem or full disk?)."
+                read -r -p "  Enter a different path: " BACKUP_DIR; continue
+            fi
+            rm -f "$BACKUP_DIR/.write_test"
+        fi
+
+        ok "Backup directory ready: ${BLD}${BACKUP_DIR}${N}"
+        return 0
+    done
+}
+
+# =============================================================================
+# BACKUP DIRECTORY — CONFIG PERSISTENCE & FIRST-RUN PROMPT
+# =============================================================================
+hr
+log "Checking backup configuration..."
+CONFIG_FILE="/etc/meshmonitor/update-config"
+BACKUP_KEEP=5
+BACKUP_DIR=""
+[ -r "$CONFIG_FILE" ] && . "$CONFIG_FILE"
+
+if [ -z "${BACKUP_DIR:-}" ]; then
+    hr
+    log "First run — choose a backup directory."
+    log "Backups include: /data/, meshmonitor.env, and systemd service files."
+    log "This choice is saved — you will not be asked again."
+    echo
+    echo "  1) /mnt/meshmonitor-backup   (external mount)"
+    echo "  2) /var/backups/meshmonitor  (local, standard system backup location)"
+    echo "  3) Enter a custom path"
+    echo
+    warn "Auto-selecting option 2 in 90 seconds..."
+    echo
+
+    if read -r -t 90 -p "Choice [1-3, default=2]: " choice; then
+        case "${choice:-2}" in
+            1) BACKUP_DIR="/mnt/meshmonitor-backup" ;;
+            2) BACKUP_DIR="/var/backups/meshmonitor" ;;
+            3) read -r -p "  Enter custom path: " BACKUP_DIR ;;
+            *) warn "Invalid choice — using default."
+               BACKUP_DIR="/var/backups/meshmonitor" ;;
+        esac
+    else
+        echo
+        warn "No input received — using default: /var/backups/meshmonitor"
+        BACKUP_DIR="/var/backups/meshmonitor"
+    fi
+fi
+
+validate_backup_dir
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    $SUDO mkdir -p "$(dirname "$CONFIG_FILE")"
+    printf 'BACKUP_DIR="%s"\nBACKUP_KEEP=%s\n' "$BACKUP_DIR" "$BACKUP_KEEP" \
+        | $SUDO tee "$CONFIG_FILE" >/dev/null
+fi
+
+# =============================================================================
+# DEBUG MODE
+# Intentionally placed AFTER the backup config block so BACKUP_DIR is known
+# and the log file lands in the right place rather than always in /tmp.
+# =============================================================================
+LOG_FILE=""
+if [ "$DEBUG" -eq 1 ]; then
+    LOG_DIR="${BACKUP_DIR}"
+    LOG_FILE="${LOG_DIR}/meshmonitor-update-$(date +%Y%m%d-%H%M%S).log"
+    exec > >(tee -a "$LOG_FILE") 2>&1
+    set -x
+    warn "DEBUG mode enabled."
+    warn "Logging to: ${BLD}${LOG_FILE}${N}"
+fi
+
+# =============================================================================
+# LIST BACKUPS MODE
+# =============================================================================
+do_list_backups() {
+    hr
+    log "Available backups in: ${BLD}${BACKUP_DIR}${N}"
+    hr
+    local found=0
+    while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        local size; size=$(du --apparent-size -sh "$f" 2>/dev/null | cut -f1)
+        local fdate; fdate=$(stat -c '%y' "$f" | cut -d'.' -f1)
+        ok "${BLD}$(basename "$f")${N}  [${size}]  ${fdate}"
+        found=1
+    done < <(ls -1t "$BACKUP_DIR"/meshmonitor_backup_*.tar.gz 2>/dev/null)
+
+    if [ "$found" -eq 0 ]; then
+        warn "No backup tarballs found in ${BACKUP_DIR}."
+        warn "Run without -l to perform an update and create the first backup."
+    else
+        echo
+        if [ -f "$BACKUP_DIR/last-commit.txt" ]; then
+            log "Source rollback commit: ${BLD}$(cat "$BACKUP_DIR/last-commit.txt")${N}"
+        else
+            warn "No last-commit.txt — source tree cannot be reset during rollback."
+        fi
+    fi
+
+    hr
+    flock -u "$LOCK_FD" 2>/dev/null || true
+    exit 0
+}
+[ "$LIST_BACKUPS" -eq 1 ] && do_list_backups
+
+# =============================================================================
+# HEALTH CHECK HELPER
+# Shared by post-update and post-rollback checks.
+# Returns 0 if app responds within timeout, 1 otherwise.
+# =============================================================================
+wait_for_healthy() {
+    local label="${1:-update}" timeout="${2:-30}"
+    log "Waiting for app to respond on port ${PORT} (up to ${timeout}s)..."
+    local i
+    for (( i=1; i<=timeout; i++ )); do
+        if curl -fsSL --max-time 3 "http://localhost:${PORT}" >/dev/null 2>&1; then
+            ok "App is responding on port ${PORT} (${label})"
+            return 0
+        fi
+        sleep 1
+    done
+    warn "App did not respond on port ${PORT} after ${timeout} seconds (${label})."
+    systemctl status meshmonitor --no-pager --lines=15 || true
+    return 1
+}
+
+# =============================================================================
+# ROLLBACK MODE
+# Always shows a warning banner listing exactly what will be overwritten.
+# Requires typing 'yes' in full — -y / --yes does NOT bypass this.
+# -n / --dry-run previews the rollback without touching anything.
+# Runs a health check after restart and warns if the rollback itself is unhealthy.
+# =============================================================================
+do_rollback() {
+    echo "${R}${BLD}╔══════════════════════════════════════════════════════════════════════════════════════╗${N}"
+    echo "${R}${BLD}║               ⚠   ROLLBACK  —  DESTRUCTIVE  OPERATION   ⚠                          ║${N}"
+    echo "${R}${BLD}╚══════════════════════════════════════════════════════════════════════════════════════╝${N}"
+
+    # --- Dry-run preview ---
+    if [ "$DRY_RUN" -eq 1 ]; then
+        warn "[DRY RUN] Rollback preview — nothing will be changed."
+        echo
+        local latest_dry=""
+        latest_dry=$(ls -1t "$BACKUP_DIR"/meshmonitor_backup_*.tar.gz 2>/dev/null | head -1 || true)
+        if [ -n "$latest_dry" ]; then
+            local size_dry; size_dry=$(du -sh "$latest_dry" 2>/dev/null | cut -f1)
+            log "Would restore from : ${BLD}${latest_dry}${N} (${size_dry})"
+            log "Tarball contents   :"
+            tar -tzf "$latest_dry" 2>/dev/null | sed 's/^/    /' || true
+        else
+            warn "No backup tarballs found in: ${BACKUP_DIR}"
+            warn "A normal update must complete successfully before rollback is available."
+        fi
+        if [ -f "$BACKUP_DIR/last-commit.txt" ]; then
+            local commit_dry; commit_dry=$(cat "$BACKUP_DIR/last-commit.txt")
+            log "Would reset git to : ${BLD}${commit_dry}${N}"
+        else
+            warn "No last-commit.txt found — source tree would NOT be reset during a real rollback."
+        fi
+        echo
+        log "Services that would be stopped/restarted: ${SERVICES[*]:-none}"
+        echo
+        warn "[DRY RUN] No changes made."
+        local e=$(( $(date +%s) - SCRIPT_START ))
+        ok "Preview complete in $(( e / 60 ))m $(( e % 60 ))s"
+        flock -u "$LOCK_FD" 2>/dev/null || true
+        exit 0
+    fi
+
+    # --- Find latest backup ---
+    if [ -z "$(ls -1 "$BACKUP_DIR"/meshmonitor_backup_*.tar.gz 2>/dev/null)" ]; then
+        err "No backup tarballs found in: ${BLD}${BACKUP_DIR}${N}"
+        err "Rollback requires at least one successful normal update run first."
+        err "Run without -r to perform an update and create a backup."
+        err "Use -l / --list-backups to see available backups."
+        die "Nothing to roll back to."
+    fi
+
+    local latest
+    latest=$(ls -1t "$BACKUP_DIR"/meshmonitor_backup_*.tar.gz | head -1)
+    local size; size=$(du --apparent-size -sh "$latest" 2>/dev/null | cut -f1)
+
+    # --- Rollback scope menu ---
+    echo
+    log  "Available backup : ${BLD}${latest}${N} (${size})"
+    if [ -f "$BACKUP_DIR/last-commit.txt" ]; then
+        log "Saved git commit : ${BLD}$(cat "$BACKUP_DIR/last-commit.txt")${N}"
+    fi
+    echo
+    log  "What would you like to restore?"
+    echo "    1) Everything  — data + code + service files  (default)"
+    echo "    2) Code only   — git reset only, keep current /data/"
+    echo "    3) Data only   — /data/ + env restore, keep current code"
+    echo
+    local scope_choice
+    read -r -t 30 -p "  Restore scope [1-3, default=1]: " scope_choice
+    scope_choice="${scope_choice:-1}"
+    local DO_DATA=1 DO_CODE=1
+    case "$scope_choice" in
+        2) DO_DATA=0; DO_CODE=1 ;;
+        3) DO_DATA=1; DO_CODE=0 ;;
+        *) DO_DATA=1; DO_CODE=1 ;;
+    esac
+    echo
+
+    # --- Warning banner ---
+    warn "The following will be OVERWRITTEN:"
+    [ "$DO_DATA" -eq 1 ] && warn "  • /data/                     (your database and apprise config)"
+    [ "$DO_DATA" -eq 1 ] && warn "  • meshmonitor.env            (your live configuration)"
+    [ "$DO_DATA" -eq 1 ] && warn "  • systemd service files      (/etc/systemd/system/meshmonitor*.service)"
+    [ "$DO_CODE" -eq 1 ] && warn "  • Source tree                (reset to saved git commit)"
+    echo
+    warn "This cannot be undone without another backup."
+    warn "-y / --yes does NOT bypass this confirmation."
+    echo
+    warn "DATABASE SCHEMA NOTE:"
+    warn "  If MeshMonitor 4.0 has already started once, schema migrations have run."
+    warn "  Restoring code to 3.x while keeping a 4.0-migrated database will cause"
+    warn "  startup failures — you must restore EVERYTHING (scope 1) for a safe rollback."
+    warn "  A pre-upgrade backup (taken before the first 4.0 start) is required."
+    echo
+
+    # Full word required — a single keystroke cannot trigger a restore
+    local confirm
+    read -r -p "  Type 'yes' to proceed with rollback, anything else to abort: " confirm
+    if [ "$confirm" != "yes" ]; then
+        ok "Rollback aborted — no changes made."
+        flock -u "$LOCK_FD" 2>/dev/null || true
+        exit 0
+    fi
+
+    hr
+    log "Stopping services..."
+    for s in "${SERVICES[@]}"; do run systemctl stop "$s" 2>/dev/null || true; done
+
+    if [ "$DO_DATA" -eq 1 ]; then
+        log "Restoring data from backup tarball..."
+        if [ "$DO_CODE" -eq 1 ]; then
+            # Full restore — extract everything including service files
+            run tar -xzpf "$latest" -C /
+        else
+            # Data only — exclude service files so systemd units are not overwritten
+            run tar -xzpf "$latest" -C / \
+                --exclude='/etc/systemd/system/meshmonitor.service' \
+                --exclude='/etc/systemd/system/meshmonitor-apprise.service'
+        fi
+    else
+        log "Skipping data restore — keeping current /data/ and env files."
+    fi
+
+    if [ "$DO_CODE" -eq 1 ] && [ -f "$BACKUP_DIR/last-commit.txt" ]; then
+        local commit; commit=$(cat "$BACKUP_DIR/last-commit.txt")
+        log "Resetting source tree to commit ${BLD}${commit}${N}..."
+        run_sh "cd '$INSTALL_DIR' && $GIT_CMD reset --hard '$commit'"
+        run_sh "cd '$INSTALL_DIR' && $GIT_CMD clean -fd"
+        run_sh "cd '$INSTALL_DIR' && export NODE_OPTIONS='--max-old-space-size=${NODE_HEAP_CAP:-1536}' && export PUPPETEER_SKIP_DOWNLOAD=true && $SUDO npm install --legacy-peer-deps --audit false"
+        run_sh "cd '$INSTALL_DIR' && export NODE_OPTIONS='--max-old-space-size=${NODE_HEAP_CAP:-1536}' && $SUDO npm run build"
+        run_sh "cd '$INSTALL_DIR' && export NODE_OPTIONS='--max-old-space-size=${NODE_HEAP_CAP:-1536}' && $SUDO npm run build:server"
+        run_sh "$SUDO chown -R '${APP_USER}:${APP_GROUP}' '$INSTALL_DIR'"
+        if [ -f "$INSTALL_DIR/lxc/systemd/meshmonitor.service" ]; then
+            run_sh "cd '$INSTALL_DIR' && $SUDO cp lxc/systemd/meshmonitor.service /etc/systemd/system/"
+            run_sh "cd '$INSTALL_DIR' && $SUDO cp lxc/systemd/meshmonitor-apprise.service /etc/systemd/system/ 2>/dev/null || true"
+            run systemctl daemon-reload
+        fi
+    elif [ "$DO_CODE" -eq 1 ]; then
+        warn "No last-commit.txt found — source tree was NOT reset."
+        warn "You may need to manually reset to your desired version."
+    else
+        log "Skipping code reset — keeping current source tree."
+    fi
+
+    hr
+    log "Starting services..."
+    for s in "${SERVICES[@]}"; do run systemctl start "$s"; done
+
+    # Health check after rollback — a failed rollback should be surfaced clearly
+    if ! wait_for_healthy "rollback"; then
+        err "App is not responding after rollback."
+        err "Check logs with: journalctl -u meshmonitor -n 50"
+        err "You may need to restore manually from an older backup in: ${BACKUP_DIR}"
+        err "Use -l / --list-backups to see what is available."
+    fi
+
+    ok "Rollback complete."
+    local e=$(( $(date +%s) - SCRIPT_START ))
+    ok "Total time: $(( e / 60 ))m $(( e % 60 ))s"
+    flock -u "$LOCK_FD" 2>/dev/null || true
+    exit 0
+}
+[ "$ROLLBACK" -eq 1 ] && do_rollback
+
+# =============================================================================
+# PRE-FLIGHT CHECKS
+# =============================================================================
+hr
+log "Running pre-flight checks..."
+
+free_mb=$(df -Pm "$INSTALL_DIR" | awk 'NR==2 {print $4}')
+[ "$free_mb" -ge 2048 ] && ok "Disk: ${free_mb}MB free" \
+    || warn "Low disk space: ${free_mb}MB free (need ~2GB for build)"
+
+mem_mb=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo)
+if [ "$mem_mb" -ge 4096 ]; then
+    NODE_HEAP_CAP=$(( mem_mb * 3 / 4 ))
+    ok "RAM: ${mem_mb}MB  (Node heap cap: ${NODE_HEAP_CAP}MB)"
+elif [ "$mem_mb" -ge 2048 ]; then
+    NODE_HEAP_CAP=1536
+    ok "RAM: ${mem_mb}MB  (Node heap cap: ${NODE_HEAP_CAP}MB)"
+else
+    NODE_HEAP_CAP=1536
+    warn "Low RAM: ${mem_mb}MB — capping Node heap at ${NODE_HEAP_CAP}MB"
+fi
+
+command -v node >/dev/null 2>&1 \
+    || die "node is not installed. Install with: $DISTRO_PKG_MGR install nodejs"
+node_major=$(node -v | sed 's/v//;s/\..*//')
+# MeshMonitor 4.0+ requires Node 20+ (uuid v14 dependency bumped the floor).
+# Treat < 20 as a hard failure — the build will fail anyway and leaving it as
+# a warning results in confusing npm errors rather than a clear message here.
+if [ "$node_major" -lt 20 ]; then
+    die "Node $(node -v) is too old. MeshMonitor 4.0+ requires Node 20+ (Node 24 preferred).\nUpgrade with: curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && apt install -y nodejs"
+fi
+[ "$node_major" -ge 24 ] \
+    && ok "Node $(node -v)" \
+    || { ok "Node $(node -v)"; warn "Node 24 is preferred for 4.1.x — current: $(node -v)"; }
+
+command -v npm >/dev/null 2>&1 \
+    || die "npm is not installed. Install with: $DISTRO_PKG_MGR install npm"
+ok "npm $(npm --version)"
+
+command -v git >/dev/null 2>&1 \
+    || die "git is not installed. Install with: $DISTRO_PKG_MGR install git"
+ok "git $(git --version | awk '{print $3}')"
+
+curl -fsSL --max-time 5 https://github.com >/dev/null 2>&1 \
+    && ok "GitHub reachable" \
+    || die "Cannot reach github.com — check network connectivity"
+
+# =============================================================================
+# VERSION DETECTION
+# =============================================================================
+hr
+log "Checking versions..."
+
+read_pkg_version() {
+    grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$1" \
+        | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+CURRENT_VERSION=$(read_pkg_version "$INSTALL_DIR/package.json")
+log "Current version : ${BLD}${CURRENT_VERSION}${N}"
+MAJOR_UPGRADE=0
+
+run_sh "cd '$INSTALL_DIR' && $GIT_CMD fetch origin main --quiet"
+
+INCOMING_VERSION=""
+if [ "$DRY_RUN" -eq 0 ]; then
+    INCOMING_VERSION=$(cd "$INSTALL_DIR" && $GIT_CMD show origin/main:package.json 2>/dev/null \
+        | grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' \
+        | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
+fi
+[ -n "$INCOMING_VERSION" ] \
+    && log "Incoming version: ${BLD}${INCOMING_VERSION}${N}" \
+    || { [ "$DRY_RUN" -eq 1 ] \
+        && echo "    [DRY RUN] Incoming version check skipped — no fetch performed." \
+        || warn "Could not read incoming version (fetch may have failed)."; }
+
+if [ -n "$INCOMING_VERSION" ]; then
+    cur_major=$(echo "$CURRENT_VERSION" | sed 's/^v//;s/-.*//' | cut -d. -f1)
+    new_major=$(echo "$INCOMING_VERSION" | sed 's/^v//;s/-.*//' | cut -d. -f1)
+    if [ "$cur_major" != "$new_major" ]; then
+        MAJOR_UPGRADE=1
+        echo
+        hr
+        warn "${R}${BLD}╔══════════════════════════════════════════════════════════════════════════════════════╗${N}"
+        warn "${R}${BLD}║               ⚠   MAJOR VERSION UPGRADE DETECTED   ⚠                               ║${N}"
+        warn "${R}${BLD}╚══════════════════════════════════════════════════════════════════════════════════════╝${N}"
+        echo
+        warn "Upgrading: ${BLD}v${cur_major}.x${N} → ${BLD}v${new_major}.x${N}"
+        echo
+        log  "This script will back up the following before proceeding:"
+        ok   "  ✔  /data/                    (database)"
+        ok   "  ✔  meshmonitor.env           (your configuration)"
+        ok   "  ✔  systemd service files"
+        ok   "  ✔  git commit hash           (source-tree rollback)"
+        echo
+        log  "If anything goes wrong after upgrading, roll back with:"
+        log  "  ${BLD}meshmonitor-update -rn${N}  — preview what will be restored"
+        log  "  ${BLD}meshmonitor-update -r${N}   — restore previous version + data"
+        echo
+        warn "Review the upstream upgrade guide before proceeding:"
+        warn "  https://github.com/Yeraze/meshmonitor/releases"
+        echo
+
+        # 3.x → 4.x specific warnings
+        if [ "$cur_major" -lt 4 ] && [ "$new_major" -ge 4 ] 2>/dev/null; then
+            warn "Breaking changes in 4.0 that require action after upgrade:"
+            warn ""
+            warn "  ENV VARS REMOVED (safe to delete from meshmonitor.env):"
+            warn "    ENABLE_VIRTUAL_NODE              → configure per source in UI"
+            warn "    VIRTUAL_NODE_PORT                → configure per source in UI"
+            warn "    VIRTUAL_NODE_ALLOW_ADMIN_COMMANDS → configure per source in UI"
+            warn ""
+            warn "  ENV VARS CHANGED:"
+            warn "    MESHTASTIC_NODE_IP   → bootstrap only (seeds first source on first boot,"
+            warn "                          ignored on all subsequent restarts)"
+            warn "    MESHTASTIC_TCP_PORT  → same — bootstrap only"
+            warn ""
+            warn "  POST-UPGRADE UI STEPS REQUIRED:"
+            warn "    • Re-enable Virtual Node per source:"
+            warn "        Dashboard → Sources → Edit Source → Virtual Node → Enable → Save"
+            warn "    • Review per-source permissions — non-admin users may have lost access:"
+            warn "        Dashboard → Sources → Edit Source → Permissions"
+            warn "    • Review per-source settings (auto-responder, scheduler, notifications):"
+            warn "        All previously global settings are now per-source"
+            warn ""
+            warn "  DATABASE:"
+            warn "    Schema migrations run automatically on first start — may be slow."
+            warn "    Rolling back after first start may leave the DB in a state"
+            warn "    that 3.x cannot read. Use a pre-upgrade backup for safe rollback."
+            echo
+        fi
+
+        # Major version always prompts — -y / --yes does not bypass this.
+        read -r -p "  Type 'yes' to proceed with the major version upgrade, anything else to abort: " a
+        [ "$a" = "yes" ] || die "Aborted by user."
+        hr
+    fi
+fi
+
+# =============================================================================
+# STOP SERVICES
+# =============================================================================
+hr
+log "Stopping services..."
+for s in "${SERVICES[@]}"; do
+    run systemctl stop "$s"
+    ok "Stopped: $s"
+done
+
+# =============================================================================
+# BACKUP
+# Timestamped tarball of all persistent data outside the git tree.
+# Prints tarball size after creation — a suspiciously small file is a useful
+# early warning that something important was missing.
+# Prunes old tarballs beyond BACKUP_KEEP.
+# =============================================================================
+hr
+log "Creating backup..."
+
+_VER_SAFE=$(echo "${CURRENT_VERSION:-unknown}" | tr "/: " "---")
+BACKUP_NAME="meshmonitor_backup_v${_VER_SAFE}_$(date +%Y-%m-%d-%H%M).tar.gz"
+BACKUP_PATH="$BACKUP_DIR/$BACKUP_NAME"
+
+BACKUP_PATHS=()
+
+# --- Data directory detection ---
+# MeshMonitor's database location varies by install type. Check in order:
+#   1. DATA_DIR env var from the active env file (most explicit)
+#   2. $INSTALL_DIR/data  (git clone default — data lives inside the repo dir)
+#   3. /data             (LXC container volume mount convention)
+# A 1.0K backup is the symptom of missing the data dir — warn loudly if so.
+DATA_DIR_FOUND=""
+_data_candidates=()
+[ -n "${DATA_DIR_FROM_ENV:-}" ]      && _data_candidates+=("$DATA_DIR_FROM_ENV")
+[ -n "${INSTALL_DIR:-}" ]            && _data_candidates+=("$INSTALL_DIR/data")
+_data_candidates+=("/data")
+
+for _d in "${_data_candidates[@]}"; do
+    if [ -d "$_d" ]; then
+        BACKUP_PATHS+=("$_d")
+        DATA_DIR_FOUND="$_d"
+        log "Data dir : ${BLD}${_d}${N}"
+        break
+    fi
+done
+[ -z "$DATA_DIR_FOUND" ] && warn "Data directory not found — database will NOT be backed up."
+
+[ -f /etc/meshmonitor/meshmonitor.env ]                && BACKUP_PATHS+=("/etc/meshmonitor/meshmonitor.env")
+[ -f /etc/meshmonitor/meshmonitor.env.example ]        && BACKUP_PATHS+=("/etc/meshmonitor/meshmonitor.env.example")
+[ -f /var/lib/meshmonitor/.env ]                       && BACKUP_PATHS+=("/var/lib/meshmonitor/.env")
+[ -f /etc/systemd/system/meshmonitor.service ]         && BACKUP_PATHS+=("/etc/systemd/system/meshmonitor.service")
+[ -f /etc/systemd/system/meshmonitor-apprise.service ] && BACKUP_PATHS+=("/etc/systemd/system/meshmonitor-apprise.service")
+
+if [ "${#BACKUP_PATHS[@]}" -eq 0 ]; then
+    warn "No backup targets found (no /data, env file, or service files). Skipping backup."
+    warn "Continuing without a backup — rollback will not be available for this run."
+else
+    if [ "$DRY_RUN" -eq 1 ]; then
+        ok "[DRY RUN] Would backup: ${BACKUP_PATHS[*]}"
+        ok "[DRY RUN] Would save to: $BACKUP_PATH"
+    else
+        $SUDO tar -czpf "$BACKUP_PATH" -P --ignore-failed-read "${BACKUP_PATHS[@]}" \
+            && true \
+            || die "Backup failed — aborting before any changes are made."
+        local_size=$(du --apparent-size -sh "$BACKUP_PATH" 2>/dev/null | cut -f1)
+        local_size_bytes=$(stat -c '%s' "$BACKUP_PATH" 2>/dev/null || echo 0)
+        ok "Backup created: ${BLD}${BACKUP_PATH}${N} (${local_size})"
+
+        # Warn if the backup is suspiciously small — strong indicator the database
+        # directory was not found and the backup is incomplete.
+        if [ "$local_size_bytes" -lt 51200 ]; then
+            warn "Backup is only ${local_size} — this is unexpectedly small."
+            warn "The MeshMonitor database was likely NOT captured."
+            [ -z "$DATA_DIR_FOUND" ] \
+                && warn "No data directory was found. Set DATA_DIR in your env file or check your install path." \
+                || warn "Data dir was: ${DATA_DIR_FOUND} — verify it contains the database."
+            warn "Proceeding, but rollback will NOT restore your database from this backup."
+        fi
+
+        cd "$INSTALL_DIR" && $GIT_CMD rev-parse HEAD > "$BACKUP_DIR/last-commit.txt"
+        ok "Commit hash saved: $(cat "$BACKUP_DIR/last-commit.txt")"
+
+        mapfile -t old_backups < <(ls -1t "$BACKUP_DIR"/meshmonitor_backup_*.tar.gz 2>/dev/null \
+            | tail -n +$(( BACKUP_KEEP + 1 )))
+        if [ "${#old_backups[@]}" -gt 0 ]; then
+            log "Pruning ${#old_backups[@]} old backup(s) (keeping last ${BACKUP_KEEP})..."
+            for old in "${old_backups[@]}"; do
+                rm -f "$old" && log "  Removed: $(basename "$old")"
+            done
+        fi
+    fi
+fi
+
+# =============================================================================
+# UPDATE SOURCE
+# Uses GIT_CMD (runs as app user) to avoid Git 2.35.2+ "dubious ownership"
+# errors on Debian 12 / git 2.39.x.
+# Stashes local modifications before pulling so git pull never fails mid-update.
+# =============================================================================
+hr
+log "Updating source code..."
+
+GIT_STASHED=0
+if [ "$DRY_RUN" -eq 0 ]; then
+    cd "$INSTALL_DIR"
+    if ! $GIT_CMD diff --quiet || ! $GIT_CMD diff --cached --quiet; then
+        warn "Local modifications detected — stashing before pull..."
+        if $GIT_CMD stash push -m "meshmonitor-update-autostash-$(date +%Y%m%d-%H%M%S)"; then
+            GIT_STASHED=1
+            ok "Local changes stashed."
+        else
+            warn "Could not stash local changes. Proceeding anyway — pull may fail."
+        fi
+    fi
+fi
+
+run_sh "cd '$INSTALL_DIR' && $GIT_CMD pull origin main"
+run_sh "cd '$INSTALL_DIR' && $GIT_CMD submodule update --init --recursive"
+
+if [ "$GIT_STASHED" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+    log "Re-applying stashed local changes..."
+    if $GIT_CMD -C "$INSTALL_DIR" stash pop; then
+        ok "Stash re-applied cleanly."
+    else
+        warn "Stash pop had conflicts — local changes are still in 'git stash list'."
+        warn "Resolve manually after this update if needed."
+    fi
+fi
+
+# =============================================================================
+# UPDATE SYSTEMD SERVICE FILES & ENV EXAMPLE
+# =============================================================================
+hr
+log "Updating systemd service files..."
+SVC_SRC="$INSTALL_DIR/lxc/systemd"
+if [ -d "$SVC_SRC" ]; then
+    run_sh "$SUDO cp '$SVC_SRC/meshmonitor.service' /etc/systemd/system/"
+    run_sh "$SUDO cp '$SVC_SRC/meshmonitor-apprise.service' /etc/systemd/system/ 2>/dev/null || true"
+    run systemctl daemon-reload
+    ok "Service files updated from ${SVC_SRC}."
+else
+    warn "lxc/systemd/ not found in source tree — service files NOT updated."
+    warn "This is expected only if you're running a non-LXC deployment with custom service files."
+fi
+
+if [ -f "$INSTALL_DIR/.env.example" ]; then
+    run_sh "$SUDO cp '$INSTALL_DIR/.env.example' /etc/meshmonitor/meshmonitor.env.example 2>/dev/null || true"
+    ok "Env example updated."
+fi
+
+# =============================================================================
+# BUILD
+# NODE_OPTIONS heap cap applied to all three npm operations.
+# Guard that both build scripts exist — catches renamed scripts on future refactors.
+# =============================================================================
+hr
+log "Installing dependencies..."
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    grep -q '"build"' "$INSTALL_DIR/package.json" \
+        || die "package.json has no 'build' script — repo may be corrupt or mid-pull."
+    grep -q '"build:server"' "$INSTALL_DIR/package.json" \
+        || die "package.json has no 'build:server' script — repo may be corrupt or mid-pull."
+fi
+
+# Puppeteer (added in MeshMonitor 4.7.x) tries to auto-download Chrome at install
+# time. On a headless server LXC we never need a browser, so skip the download.
+# Also wipe any broken partial cache — leaving it causes:
+#   "folder exists but executable chrome-linux64/chrome is missing"
+if [ "$DRY_RUN" -eq 0 ]; then
+    if [ -d "${HOME}/.cache/puppeteer" ]; then
+        log "Cleaning stale Puppeteer browser cache (prevents Chrome download failures)..."
+        rm -rf "${HOME}/.cache/puppeteer"
+        ok "Puppeteer cache cleared."
+    fi
+fi
+run_sh "cd '$INSTALL_DIR' && export NODE_OPTIONS='--max-old-space-size=${NODE_HEAP_CAP}' \
+    && export PUPPETEER_SKIP_DOWNLOAD=true \
+    && $SUDO npm install --legacy-peer-deps --audit false"
+
+log "Building client (Vite + TypeScript)..."
+run_sh "cd '$INSTALL_DIR' && export NODE_OPTIONS='--max-old-space-size=${NODE_HEAP_CAP}' \
+    && $SUDO npm run build"
+
+log "Building server (TypeScript)..."
+run_sh "cd '$INSTALL_DIR' && export NODE_OPTIONS='--max-old-space-size=${NODE_HEAP_CAP}' \
+    && $SUDO npm run build:server"
+
+# =============================================================================
+# RESTORE OWNERSHIP
+# npm install and build run as root, creating root-owned files inside a
+# directory owned by the app user. Restoring ownership prevents permission
+# issues on next startup.
+# =============================================================================
+if [ "$APP_USER" != "root" ] && [ "$DRY_RUN" -eq 0 ]; then
+    log "Restoring ownership to ${APP_USER}:${APP_GROUP}..."
+    $SUDO chown -R "${APP_USER}:${APP_GROUP}" "$INSTALL_DIR"
+    ok "Ownership restored."
+fi
+
+# =============================================================================
+# START SERVICES & HEALTH CHECK
+# On failure: directs the user to run -r manually rather than prompting
+# inline — ensures the full rollback confirmation flow always runs.
+# =============================================================================
+hr
+log "Starting services..."
+for s in "${SERVICES[@]}"; do
+    run systemctl start "$s"
+    ok "Started: $s"
+done
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    # First start after a major version upgrade runs schema migrations — give it more time.
+    _health_timeout=30
+    if [ "${MAJOR_UPGRADE:-0}" -eq 1 ]; then
+        _health_timeout=60
+        warn "First start after a major version upgrade may be slow — schema migrations are running."
+        warn "Check progress with: journalctl -u meshmonitor -f"
+    fi
+
+    if ! wait_for_healthy "post-update" "$_health_timeout"; then
+        err "Update completed but app is not responding."
+        err "To roll back to the previous version, run:"
+        err "  $0 --rollback"
+        err "To preview what a rollback would do first, run:"
+        err "  $0 --rollback --dry-run"
+    fi
+fi
+
+# =============================================================================
+# FINAL STATUS & ELAPSED TIME
+# =============================================================================
+hr
+log "Final service status:"
+for s in "${SERVICES[@]}"; do
+    systemctl status "$s" --no-pager --lines=3 || true
+done
+
+SCRIPT_END=$(date +%s)
+ELAPSED=$(( SCRIPT_END - SCRIPT_START ))
+MINS=$(( ELAPSED / 60 ))
+SECS=$(( ELAPSED % 60 ))
+echo
+hr
+ok "Update complete in ${BLD}${MINS}m ${SECS}s${N}  (finished $(date '+%H:%M:%S'))"
+[ -n "${LOG_FILE:-}" ] && ok "Debug log: ${BLD}${LOG_FILE}${N}"
+
+# Post-upgrade action reminder for 3.x → 4.x migrations
+if [ "${MAJOR_UPGRADE:-0}" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+    hr
+    warn "POST-UPGRADE ACTIONS REQUIRED (3.x → 4.x):"
+    warn ""
+    warn "  1. Re-enable Virtual Node per source (if used):"
+    warn "       Dashboard → Sources → Edit Source → Virtual Node → Enable → Save"
+    warn ""
+    warn "  2. Review per-source permissions for non-admin users:"
+    warn "       Dashboard → Sources → Edit Source → Permissions"
+    warn ""
+    warn "  3. Review per-source settings (auto-responder, scheduler, etc.):"
+    warn "       All previously global settings are now configured per source"
+    warn ""
+    warn "  4. Verify your source was created from MESHTASTIC_NODE_IP:"
+    warn "       Dashboard → Sources — if missing, add it manually"
+fi
+
+hr
+
+flock -u "$LOCK_FD" 2>/dev/null || true

--- a/lxc/proxmox/meshmonitor.conf
+++ b/lxc/proxmox/meshmonitor.conf
@@ -9,19 +9,24 @@
 cores: 2
 memory: 2048
 
-# Swap (optional)
-swap: 512
+# Swap — 1024MB recommended minimum.
+# npm run build during meshmonitor-update peaks at ~1.5GB Node heap.
+# With 2048MB RAM, 1024MB swap gives comfortable headroom to avoid OOM.
+# If meshmonitor-update runs for an excessive amount of time, try more swap
+# or more memory.
+swap: 1024
 
 # Network configuration
 # Replace with your network bridge and IP settings
 net0: name=eth0,bridge=vmbr0,firewall=1,hwaddr=XX:XX:XX:XX:XX:XX,ip=dhcp,type=veth
 
 # Root filesystem size
-rootfs: local-lxc:vm-XXX-disk-0,size=10G
+# Replace <storage> with your actual Proxmox storage name (e.g. local-lvm, VMs)
+# rootfs: <storage>:vm-XXX-disk-0,size=10G
 
 # Features
-# nesting=0: Docker not needed for LXC deployment
-features: nesting=0
+# nesting=1 is required for systemd to function correctly inside the container.
+features: nesting=1
 
 # Unprivileged container (recommended for security)
 unprivileged: 1
@@ -56,6 +61,8 @@ description: MeshMonitor - Meshtastic network monitoring and management
 
 # Notes:
 # - After creating the container from template, mount /data as a bind mount
-#   or use container's built-in /data directory
+#   or use the container's built-in /data directory
 # - Configure MESHTASTIC_NODE_IP in /etc/meshmonitor/meshmonitor.env
-# - Web UI will be accessible on port 8080 (proxied from internal port 3001)
+# - Web UI is accessible on port 3001 (LXC has no port mapping layer)
+# - Run 'meshmonitor-update' inside the container for in-place updates
+# -  or 'meshmonitor-update -h' for additional options

--- a/lxc/proxmox/post-install.sh
+++ b/lxc/proxmox/post-install.sh
@@ -1,117 +1,63 @@
 #!/bin/bash
 #
-# MeshMonitor LXC Post-Installation Script
-# Run this inside the LXC container after deploying from template
+# MeshMonitor LXC Post-Installation Setup
+# Run once inside the container after first deploy:
 #
-# Usage: bash /opt/meshmonitor/post-install.sh
+#   bash /opt/meshmonitor/lxc/proxmox/post-install.sh
 #
 
-set -e
+CONTAINER_IP=$(hostname -I | awk '{print $1}')
 
-echo "========================================"
-echo "MeshMonitor LXC Post-Installation Setup"
-echo "========================================"
-echo ""
+# Copy the documented env example to meshmonitor.env if not already configured,
+# then uncomment and set ALLOWED_ORIGINS with the container's actual IP.
+# This gives the operator a fully documented env file with the one critical
+# setting already filled in — no blank file, no CORS errors on first access.
+ENV_FILE="/etc/meshmonitor/meshmonitor.env"
+ENV_EXAMPLE="/etc/meshmonitor/meshmonitor.env.example"
 
-# Check if running as root
-if [ "$EUID" -ne 0 ]; then
-    echo "ERROR: This script must be run as root"
-    echo "Run with: sudo bash $0"
-    exit 1
+if [ ! -s "$ENV_FILE" ] && [ -f "$ENV_EXAMPLE" ]; then
+    cp "$ENV_EXAMPLE" "$ENV_FILE"
+    chown meshmonitor:meshmonitor "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
 fi
 
-# Ensure data directory exists with correct permissions
-echo "Setting up data directory..."
-mkdir -p /data/apprise-config
-mkdir -p /data/scripts
-mkdir -p /data/logs
-chown -R meshmonitor:meshmonitor /data
-chmod 755 /data
-
-# Check if environment file exists
-if [ ! -f /etc/meshmonitor/meshmonitor.env ]; then
-    echo "Creating environment configuration file..."
-    cp /etc/meshmonitor/meshmonitor.env.example /etc/meshmonitor/meshmonitor.env
-    chown meshmonitor:meshmonitor /etc/meshmonitor/meshmonitor.env
-    chmod 600 /etc/meshmonitor/meshmonitor.env
-fi
-
-echo ""
-echo "Configuration Required:"
-echo "----------------------"
-
-# Prompt for Meshtastic node IP
-read -p "Enter your Meshtastic node IP address (e.g., 192.168.1.100): " NODE_IP
-
-if [ -n "$NODE_IP" ]; then
-    # Check if the IP is already set in the file
-    if grep -q "^MESHTASTIC_NODE_IP=" /etc/meshmonitor/meshmonitor.env; then
-        # Update existing value
-        sed -i "s/^MESHTASTIC_NODE_IP=.*/MESHTASTIC_NODE_IP=$NODE_IP/" /etc/meshmonitor/meshmonitor.env
-    else
-        # Add new value
-        echo "MESHTASTIC_NODE_IP=$NODE_IP" >> /etc/meshmonitor/meshmonitor.env
-    fi
-    echo "Meshtastic node IP configured: $NODE_IP"
+# Set ALLOWED_ORIGINS — uncomment if commented, update if already set
+if grep -q "^#*ALLOWED_ORIGINS=" "$ENV_FILE" 2>/dev/null; then
+    sed -i "s|^#*ALLOWED_ORIGINS=.*|ALLOWED_ORIGINS=http://${CONTAINER_IP}:3001|" "$ENV_FILE"
 else
-    echo "WARNING: No IP address provided. You must configure MESHTASTIC_NODE_IP manually."
-    echo "Edit /etc/meshmonitor/meshmonitor.env and set MESHTASTIC_NODE_IP"
+    echo "ALLOWED_ORIGINS=http://${CONTAINER_IP}:3001" >> "$ENV_FILE"
 fi
 
-echo ""
-echo "Reloading systemd and enabling services..."
-systemctl daemon-reload
-systemctl enable meshmonitor.service
-systemctl enable meshmonitor-apprise.service
+# Restart meshmonitor to pick up the new env file
+systemctl restart meshmonitor 2>/dev/null || true
 
-echo ""
-read -p "Start MeshMonitor services now? (y/n): " START_NOW
-
-if [ "$START_NOW" = "y" ] || [ "$START_NOW" = "Y" ]; then
-    echo "Starting services..."
-    systemctl start meshmonitor.service
-    systemctl start meshmonitor-apprise.service
-
-    # Wait a moment for services to start
-    sleep 3
-
-    echo ""
-    echo "Service Status:"
-    echo "---------------"
-    systemctl status meshmonitor.service --no-pager --lines=5
-    echo ""
-    systemctl status meshmonitor-apprise.service --no-pager --lines=5
+# Ensure /usr/local/bin is in PATH — missing from minimal Debian's default PATH.
+# Required for meshmonitor-update to be callable directly after self-install.
+if ! grep -q '/usr/local/bin' /root/.bashrc 2>/dev/null; then
+    echo 'export PATH=/usr/local/bin:$PATH' >> /root/.bashrc
 fi
 
-echo ""
 echo "========================================"
-echo "Installation Complete!"
+echo "MeshMonitor is running!"
 echo "========================================"
 echo ""
-echo "Access Information:"
-echo "  Web UI: http://$(hostname -I | awk '{print $1}'):8080"
-echo "  (Port 3001 is proxied to 8080 by default)"
+echo "  Web UI:  http://${CONTAINER_IP}:3001"
+echo "  Login:   admin / changeme"
+echo "           (change your password immediately)"
 echo ""
-echo "Configuration:"
-echo "  Edit: /etc/meshmonitor/meshmonitor.env"
-echo "  Example: /etc/meshmonitor/meshmonitor.env.example"
+echo "  Configure your Meshtastic node via the web UI."
+echo "  Go to Settings -> Node Connection."
 echo ""
 echo "Service Management:"
-echo "  Start:   systemctl start meshmonitor"
-echo "  Stop:    systemctl stop meshmonitor"
-echo "  Restart: systemctl restart meshmonitor"
 echo "  Status:  systemctl status meshmonitor"
 echo "  Logs:    journalctl -u meshmonitor -f"
+echo "  Restart: systemctl restart meshmonitor"
 echo ""
-echo "Data Directory:"
-echo "  Location: /data"
-echo "  Database: /data/meshmonitor.db"
-echo "  Backups:  /data/system-backups"
+echo "Updates:"
+echo "  First run:  bash /opt/meshmonitor/lxc/meshmonitor-update"
+echo "              (self-installs to /usr/local/bin)"
+echo "  After that: meshmonitor-update -h or "
+echo "              meshmonitor-update -s"
 echo ""
-echo "Updating:"
-echo "  - Use lxc/update.sh on the Proxmox host for an automated update"
-echo "  - See documentation for the manual update procedure"
-echo ""
-echo "Documentation:"
-echo "  https://github.com/Yeraze/meshmonitor/blob/main/docs/deployment/PROXMOX_LXC_GUIDE.md"
+echo "Docs: https://github.com/Yeraze/meshmonitor/blob/main/docs/deployment/PROXMOX_LXC_GUIDE.md"
 echo "========================================"

--- a/lxc/sparse-cone.txt
+++ b/lxc/sparse-cone.txt
@@ -1,0 +1,30 @@
+# lxc/sparse-cone.txt
+# ---------------------------------------------------------------------------
+# Sparse-checkout cone list for the MeshMonitor LXC template build.
+#
+# WHAT THIS FILE CONTROLS
+#   build-lxc-template.sh reads this file at build time and passes the listed
+#   directories to git sparse-checkout set. Only these directories, plus
+#   all root-level files (package.json, tsconfig*.json, vite.config.ts, etc.),
+#   which cone mode always includes automatically, are materialized inside
+#   /opt/meshmonitor in the container rootfs. Everything else (docs/, desktop/,
+#   .github/, etc.) is never fetched, keeping the template lean (~8MB .git vs
+#   ~51MB for a full clone).
+#
+# MAINTENANCE
+#   If you add a new top-level directory that is required at runtime, add it
+#   here or the LXC template will silently omit those files on the next build.
+#   After updating: rebuild the template and confirm meshmonitor-update works.
+#
+# FOR AI ASSISTANTS
+#   This is the single source of truth for LXC template directory inclusion.
+#   Update this file in the same commit whenever you add a runtime-required
+#   top-level directory. See CLAUDE.md "LXC Template Build" for the full rule.
+# ---------------------------------------------------------------------------
+
+src
+public
+docker
+protobufs
+scripts
+lxc


### PR DESCRIPTION
## Summary

LXC templates currently ship as pre-built artifacts with no `.git` directory.
This means `meshmonitor-update` — which requires a git clone — cannot run on a
freshly-deployed container without a separate migration step. This PR fixes the
problem at its source: `build-lxc-template.sh` now clones the MeshMonitor repo
directly into the container using a partial+sparse git clone (~8MB overhead),
so every deployed container is git-native from first boot and `meshmonitor-update`
works immediately. It also bundles `meshmonitor-update` in `lxc/` so it ships
inside every container, and overhauls the LXC documentation to reflect actual
current behaviour (port 3001 not 8080, Node 24 not 22, web-UI node config since
v4.0, in-place update path, correct container settings).

## Changes

**Build**
- `lxc/build-lxc-template.sh` — replaces artifact-copy approach with
  `git clone --depth 1 --filter=blob:none --sparse` into the container rootfs;
  all npm build steps now run inside the container chroot against the container's
  own Node.js 24 (NodeSource), ensuring native modules compile for the correct ABI
- `lxc/sparse-cone.txt` — new file controlling which top-level directories are
  materialized in the container (`src`, `public`, `docker`, `scripts`, `lxc`);
  decouples the cone list from the build script so it can be maintained independently
- `lxc/build-lxc-template.sh` — adds `sudo` to base system install (required by
  `meshmonitor-update`'s `sudo -u meshmonitor git` invocation)
- `lxc/build-lxc-template.sh` — removes hardcoded `MESHTASTIC_NODE_IP` from
  `meshmonitor.env.example` (node connection configured via web UI since v4.0)
- `lxc/build-lxc-template.sh` — adds `/usr/local/bin` to `/etc/environment`
  (missing from minimal Debian's default PATH; required after `meshmonitor-update`
  self-installs)

**CI**
- `.github/workflows/lxc-template-build.yml` — removes `setup-node`,
  `npm install`, `npm run build`, `npm run build:server` steps that are now
  redundant (build script handles all of this inside the chroot); adds `git` and
  `curl` to the debootstrap install step

**meshmonitor-update bundled**
- `lxc/meshmonitor-update` — the in-place updater now lives in the repo and
  ships inside every deployed container via the `lxc/` sparse cone; on first run
  it self-installs to `/usr/local/bin/`

**Documentation**
- `lxc/README.md` — Node 22→24, port 8080→3001, updated directory structure,
  in-place update instructions, build prerequisites, correct build description
- `lxc/proxmox/post-install.sh` — rewritten: auto-detects container IP, sets
  `ALLOWED_ORIGINS` in `meshmonitor.env`, populates env from example file,
  adds `/usr/local/bin` to PATH, prints web UI URL and first-run instructions
- `lxc/proxmox/meshmonitor.conf` — swap 512→1024 (npm build headroom during
  updates), `nesting=0`→`nesting=1` (required for systemd), storage name
  commented out with operator note
- `docs/deployment/PROXMOX_LXC_GUIDE.md` — comprehensive update: removed
  `MESHTASTIC_NODE_IP` env references (web UI since v4.0), corrected version
  examples, fixed port 8080→3001, swap and nesting values, rewrote Step 4 to
  use `post-install.sh`, added `meshmonitor-update` as primary update path,
  updated Limitations to reflect in-place upgrades now supported, added
  `meshmonitor-update` PATH troubleshooting entry
- `CLAUDE.md` — added LXC Template Build section with sparse-cone maintenance
  rule, chroot build requirement, `PUPPETEER_SKIP_DOWNLOAD`, and intentional
  `.git` retention note

## Issues Resolved

Relates to the community discussion at
https://github.com/Yeraze/meshmonitor/discussions/3572 where a user reported
`meshmonitor-update` failing on a freshly-deployed LXC template with "Cannot
find MeshMonitor source tree (requires git clone, not a pre-built template)".

## Documentation Updates

- `lxc/README.md` — updated (see Changes)
- `lxc/proxmox/post-install.sh` — rewritten (see Changes)
- `lxc/proxmox/meshmonitor.conf` — updated (see Changes)
- `docs/deployment/PROXMOX_LXC_GUIDE.md` — updated (see Changes)
- `CLAUDE.md` — LXC build rules added

## Testing

> **Note:** The maintainer does not have a Proxmox LXC environment. The
> transcript below is the validation evidence for the deployment path.

**Build:** `lxc/build-lxc-template.sh` run on a Debian 12 VM with NVMe storage.
Completed in ~3 minutes with no errors across all 14 steps.

**Deployment:** Fresh LXC container (CT 310, Debian 12, 2GB RAM, unprivileged)
deployed from the built template. First-boot test sequence:

<img width="1000" height="552" alt="image" src="https://github.com/user-attachments/assets/e24311dc-b023-4ed2-b75e-82941ad613a8" />
<img width="1077" height="1220" alt="image" src="https://github.com/user-attachments/assets/88876d54-14ef-4230-ad41-69e2de75bffd" />

`meshmonitor-update --dry-run` passes on first boot with no migration step.

- [x] TypeScript compilation unaffected (no `.ts` files changed)
- [x] LXC template builds successfully (~3 min, ~491MB output)
- [x] `.git` present in deployed container from first boot
- [x] `meshmonitor-update` self-installs and detects install dir correctly
- [x] `post-install.sh` auto-detects IP and sets `ALLOWED_ORIGINS`
- [x] Both services start and health-check passes on first boot

**For existing containers (pre-v4.12.0 templates):** `migrate-to-git.sh`
handles the one-time migration from pre-built artifact to git-native install.
Documented in `docs/deployment/PROXMOX_LXC_GUIDE.md` Limitations section.

---
> This contribution was developed by [@BeerMan81](https://github.com/BeerMan81)
> with Claude (Anthropic) as a coding assistant for script development, testing,
> and documentation. All design decisions, testing, and validation were performed
> on real Proxmox LXC hardware by the contributor.