### PR TITLE
fix(meshcore): preserve node name on empty advert + improve metadata text contrast

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -718,11 +718,11 @@
   font-weight: 500;
 }
 
-.mc-message-time { color: var(--ctp-overlay0); }
+.mc-message-time { color: var(--ctp-subtext0); }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
-.mc-message-route { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
-.mc-message-scope { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
+.mc-message-route { color: var(--ctp-subtext0); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+.mc-message-scope { color: var(--ctp-subtext0); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 
 .mc-mention {
   color: var(--ctp-blue);

--- a/src/server/meshcoreManager.contactPersistence.test.ts
+++ b/src/server/meshcoreManager.contactPersistence.test.ts
@@ -284,4 +284,47 @@ describe('MeshCoreManager contact persistence (issue #3092)', () => {
       advType: MeshCoreDeviceType.REPEATER,
     });
   });
+
+  // Regression for issue #3756: zero-hop repeaters send adverts with an
+  // empty adv_name string. The ?? operator would pass "" through (since it
+  // is neither null nor undefined), overwriting the previously stored name
+  // with an empty value. The fix uses || so empty strings fall back to the
+  // existing value.
+  it('does not overwrite a known contact name with an empty adv_name (issue #3756)', async () => {
+    const manager = new MeshCoreManager('src-a');
+
+    // First advert carries the real name.
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'ZeroHopRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    upsertNode.mockClear();
+
+    // Second advert (e.g. from zero-hop repeater) arrives with empty name.
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: '',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // In-memory contact should still carry the original name.
+    expect(manager.getContact(REPEATER_PUBKEY)?.advName).toBe('ZeroHopRepeater');
+
+    // The DB write must also use the preserved name, not the empty string.
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'ZeroHopRepeater' }),
+      'src-a',
+    );
+  });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1109,7 +1109,7 @@ class MeshCoreManager extends EventEmitter {
         const updated: MeshCoreContact = {
           ...existing,
           publicKey,
-          advName: data.adv_name ?? existing.advName,
+          advName: data.adv_name || existing.advName,
           advType: data.adv_type ?? existing.advType,
           lastAdvert: data.last_advert ?? existing.lastAdvert,
           latitude: data.latitude ?? existing.latitude,
@@ -1470,7 +1470,7 @@ class MeshCoreManager extends EventEmitter {
       await databaseService.meshcore.upsertNode(
         {
           publicKey: contact.publicKey,
-          name: contact.advName ?? contact.name ?? null,
+          name: contact.advName || contact.name || null,
           advType: contact.advType ?? null,
           latitude: atNullIsland ? null : (contact.latitude ?? null),
           longitude: atNullIsland ? null : (contact.longitude ?? null),


### PR DESCRIPTION
## Summary

Two small fixes for issues reported today:

### Fix 1 — MeshCore node name lost after empty advert (#3756)

**Root cause:** Zero-hop repeaters (and some MeshCore firmware builds) send `contact_advertised` events with `adv_name: ""`. The `??` null-coalescing operator passes an empty string through unchanged (since `""` is not `null`/`undefined`), so the stored node name was silently overwritten with an empty value on every re-advert.

**Fix:** Change both the in-memory update (`handleBridgeEvent` line 1112) and the DB write (`persistContact` line 1473) to use `||` instead of `??`. This makes empty strings fall back to the previously known value, the same way `null`/`undefined` already did.

**Test:** Added a regression test in `meshcoreManager.contactPersistence.test.ts` that fires a named advert followed by an empty-name re-advert and asserts both the in-memory contact and the upsertNode DB call retain the original name.

### Fix 2 — MeshCore message metadata text readability (#3769)

**Problem:** The timestamp, hop-route, and scope metadata lines in MeshCore channel messages used `--ctp-overlay0`, which is too faint in Catppuccin light themes and still quite subtle in dark themes.

**Fix:** Switch all three CSS classes (`mc-message-time`, `mc-message-route`, `mc-message-scope`) from `--ctp-overlay0` to `--ctp-subtext0`. This gives better contrast in both light and dark mode while keeping the metadata visually secondary to the message body.

## Files changed

| File | Change |
|------|--------|
| `src/server/meshcoreManager.ts` | `??` → `||` in advert name handling and persistContact (2 lines) |
| `src/server/meshcoreManager.contactPersistence.test.ts` | Regression test for empty adv_name |
| `src/components/MeshCore/MeshCorePage.css` | `--ctp-overlay0` → `--ctp-subtext0` for time/route/scope (3 lines) |

## Test plan

- [ ] Run `vitest run src/server/meshcoreManager.contactPersistence.test.ts` — new regression test should pass
- [ ] Connect a zero-hop repeater (MeshCore firmware v1.16) — node name should persist after re-advert and not revert to "Unknown"
- [ ] Open MeshCore channel messages — timestamp, hop-route, and scope text should be visibly more readable, especially in light theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKnaQv47NKrW5Srxk88HHG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKnaQv47NKrW5Srxk88HHG)_