### PR TITLE
fix(meshcore): preserve node name on empty advert + mute route/scope colors

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -720,9 +720,10 @@
 
 .mc-message-time { color: var(--ctp-overlay0); }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
-/* Hop count + relay route for received messages (#3742). */
-.mc-message-route { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
-.mc-message-scope { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
+/* Hop count + relay route for received messages (#3742). Use surface2 (more muted than overlay0) so route/scope
+   reads as clearly secondary metadata behind the timestamp. */
+.mc-message-route { color: var(--ctp-surface2); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+.mc-message-scope { color: var(--ctp-surface2); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 
 .mc-mention {
   color: var(--ctp-blue);

--- a/src/server/meshcoreManager.contactPersistence.test.ts
+++ b/src/server/meshcoreManager.contactPersistence.test.ts
@@ -265,6 +265,42 @@ describe('MeshCoreManager contact persistence (issue #3092)', () => {
     expect(notifyNewMeshCoreNode).not.toHaveBeenCalled();
   });
 
+  it('preserves stored name when a subsequent advert arrives with empty adv_name (issue #3756)', async () => {
+    const manager = new MeshCoreManager('src-a');
+    // First advert establishes the name.
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    upsertNode.mockClear();
+
+    // Second advert (e.g. from a zero-hop repeater) arrives with empty name.
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: '',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // In-memory contact must keep the previously stored name.
+    expect(manager.getContact(REPEATER_PUBKEY)?.advName).toBe('MyRepeater');
+    // DB persist must also use the preserved name, not the empty string.
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'MyRepeater' }),
+      'src-a',
+    );
+  });
+
   it('exposes the in-memory contact via getContact for route-side backfill', () => {
     const manager = new MeshCoreManager('src-a');
     expect(manager.getContact(REPEATER_PUBKEY)).toBeUndefined();

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1109,7 +1109,7 @@ class MeshCoreManager extends EventEmitter {
         const updated: MeshCoreContact = {
           ...existing,
           publicKey,
-          advName: data.adv_name ?? existing.advName,
+          advName: data.adv_name || existing.advName,
           advType: data.adv_type ?? existing.advType,
           lastAdvert: data.last_advert ?? existing.lastAdvert,
           latitude: data.latitude ?? existing.latitude,
@@ -1470,7 +1470,7 @@ class MeshCoreManager extends EventEmitter {
       await databaseService.meshcore.upsertNode(
         {
           publicKey: contact.publicKey,
-          name: contact.advName ?? contact.name ?? null,
+          name: contact.advName || contact.name || null,
           advType: contact.advType ?? null,
           latitude: atNullIsland ? null : (contact.latitude ?? null),
           longitude: atNullIsland ? null : (contact.longitude ?? null),


### PR DESCRIPTION
## Summary

Two small bug fixes from today's issue triage:

- **#3756** — Zero-hop repeater node names disappear after re-advertise
- **#3769** — MeshCore route/scope display colors too bright

## Fix 1: Preserve node name when advert has empty `adv_name` (#3756)

**Root cause:** `contact_advertised` events from zero-hop repeaters arrive with `adv_name` as an empty string `""`. The code used `??` (nullish coalescing) to merge names:
```typescript
advName: data.adv_name ?? existing.advName,   // "" ?? "MyRepeater" → ""
```
Since `""` is not `null`/`undefined`, the empty string won overwrote the stored name. The same value then propagated through `persistContact` into the DB (the `upsertNode` merge guard explicitly keeps `''` as a valid update).

**Fix:** Change `??` to `||` in both the in-memory merge and the `persistContact` name field so empty strings fall back to the existing value, the same way `null`/`undefined` already did.

**Test:** New regression test in `meshcoreManager.contactPersistence.test.ts` — dispatches a named advert followed by an empty-name advert for the same key and asserts both the in-memory contact and the DB call preserve the original name.

## Fix 2: Route/scope metadata colors more subdued (#3769)

Route and scope lines in MeshCore messages were using `--ctp-overlay0` (same shade as the timestamp). For secondary metadata they should be quieter. Moved to `--ctp-surface2` (one step more muted in both dark and light Catppuccin themes):

| Element | Before | After |
|---------|--------|-------|
| Message text | `--ctp-text` | `--ctp-text` |
| Timestamp | `--ctp-overlay0` | `--ctp-overlay0` |
| Route / scope | `--ctp-overlay0` | `--ctp-surface2` ← |

## Test plan

- [x] `meshcoreManager.contactPersistence.test.ts` — all 10 tests pass including new regression
- [x] Full Vitest suite — 0 failures
- [ ] Manual: verify zero-hop repeater node keeps its name after a re-advert cycle
- [ ] Manual: verify route/scope text is visibly more muted than the timestamp in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uH3HqQC4r4x7TRqhLTbc3

---
_Generated by [Claude Code](https://claude.ai/code/session_016uH3HqQC4r4x7TRqhLTbc3)_