### PR TITLE
fix(auto-favorite): CLIENT_BASE local nodes now only favorite relay-capable roles

### DIFF
--- a/src/server/constants/autoFavorite.ts
+++ b/src/server/constants/autoFavorite.ts
@@ -28,8 +28,7 @@ interface AutoFavoriteTarget {
  * - Target must be 0-hop (hopsAway === 0)
  * - Target must not have been received via MQTT
  * - Target must not already be favorited
- * - For ROUTER/ROUTER_LATE local: target must also be ROUTER/ROUTER_LATE/CLIENT_BASE
- * - For CLIENT_BASE local: any role is eligible
+ * - Target must also be ROUTER, ROUTER_LATE, or CLIENT_BASE (relay-capable roles)
  */
 export function isAutoFavoriteEligible(
   localRole: number | undefined | null,
@@ -47,10 +46,8 @@ export function isAutoFavoriteEligible(
   if (target.isFavorite) {
     return false;
   }
-  if (localRole === DeviceRole.ROUTER || localRole === DeviceRole.ROUTER_LATE) {
-    if (target.role == null || !ZERO_HOP_RELAY_ROLES.has(target.role)) {
-      return false;
-    }
+  if (target.role == null || !ZERO_HOP_RELAY_ROLES.has(target.role)) {
+    return false;
   }
   return true;
 }

--- a/src/server/meshtasticManager.autoFavorite.test.ts
+++ b/src/server/meshtasticManager.autoFavorite.test.ts
@@ -19,8 +19,12 @@ describe('isAutoFavoriteEligible', () => {
     expect(isAutoFavoriteEligible(DeviceRole.ROUTER, { hopsAway: 0, role: DeviceRole.CLIENT, isFavorite: false })).toBe(false);
   });
 
-  it('returns true for 0-hop CLIENT when local is CLIENT_BASE (any role eligible)', () => {
-    expect(isAutoFavoriteEligible(DeviceRole.CLIENT_BASE, { hopsAway: 0, role: DeviceRole.CLIENT, isFavorite: false })).toBe(true);
+  it('returns false for 0-hop CLIENT when local is CLIENT_BASE (not a relay role)', () => {
+    expect(isAutoFavoriteEligible(DeviceRole.CLIENT_BASE, { hopsAway: 0, role: DeviceRole.CLIENT, isFavorite: false })).toBe(false);
+  });
+
+  it('returns false for 0-hop CLIENT_MUTE when local is CLIENT_BASE (CLIENT_MUTE never relays)', () => {
+    expect(isAutoFavoriteEligible(DeviceRole.CLIENT_BASE, { hopsAway: 0, role: DeviceRole.CLIENT_MUTE, isFavorite: false })).toBe(false);
   });
 
   it('returns true for 0-hop ROUTER when local is CLIENT_BASE', () => {


### PR DESCRIPTION
## Summary

Fixes #3774 — the auto-favorite automation was favoriting every 0-hop neighbor when the local node is `CLIENT_BASE`, including `CLIENT_MUTE` nodes that never relay.

**Root cause:** `isAutoFavoriteEligible` in `src/server/constants/autoFavorite.ts` applied `ZERO_HOP_RELAY_ROLES` filtering only when the local node was `ROUTER` or `ROUTER_LATE`. For `CLIENT_BASE` locals, execution fell through to an unconditional `return true`, allowing any role to be favorited.

**Fix:** Remove the local-role condition — the `ZERO_HOP_RELAY_ROLES` check (`ROUTER`, `ROUTER_LATE`, `CLIENT_BASE`) now applies to all eligible local roles. This matches the Meshtastic spec: zero-cost hops only apply when the previous relay is `ROUTER`, `ROUTER_LATE`, or `CLIENT_BASE` — never `CLIENT_MUTE`, `CLIENT`, `TAK_TRACKER`, etc.

**Changed files:**
- `src/server/constants/autoFavorite.ts` — removed the `localRole ===` guard around the relay-role filter
- `src/server/meshtasticManager.autoFavorite.test.ts` — corrected the test that asserted `CLIENT_BASE + CLIENT → true`, added `CLIENT_BASE + CLIENT_MUTE → false` regression test

## Test plan
- [ ] All 28 `isAutoFavoriteEligible` unit tests pass
- [ ] Confirm a `CLIENT_BASE` local node no longer auto-favorites `CLIENT_MUTE` or `CLIENT` neighbors
- [ ] `ROUTER` and `ROUTER_LATE` target behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yi7rcchSnpBSDomzyTDa2

---
_Generated by [Claude Code](https://claude.ai/code/session_016yi7rcchSnpBSDomzyTDa2)_