### PR TITLE
fix(meshcore): darken message scope/path/time metadata for readability (#3769)

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -718,11 +718,13 @@
   font-weight: 500;
 }
 
-.mc-message-time { color: var(--ctp-overlay0); }
+/* Message metadata (time/route/scope) uses overlay1 — one step darker than
+   overlay0 for better readability in both light and dark themes (#3769). */
+.mc-message-time { color: var(--ctp-overlay1); }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
-.mc-message-route { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
-.mc-message-scope { color: var(--ctp-overlay0); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
+.mc-message-route { color: var(--ctp-overlay1); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+.mc-message-scope { color: var(--ctp-overlay1); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 
 .mc-mention {
   color: var(--ctp-blue);


### PR DESCRIPTION
Closes #3769

## Problem

For MeshCore channel messages, the metadata line that shows the message **scope/region** and the relay **path** rendered too bright/light against the message background, making it hard to read. The timestamp on the same kind of line was easier to read.

## Fix

All three metadata classes — `.mc-message-time`, `.mc-message-route` (hop count + path), and `.mc-message-scope` — were using `var(--ctp-overlay0)`. This bumps them one step down the Catppuccin gray scale to `var(--ctp-overlay1)`.

`overlay1` is darker / higher-contrast than `overlay0` in **every** theme:
- Dark themes (Frappé/Macchiato/Mocha): `overlay1` is a darker gray than `overlay0`.
- Light theme (Latte): `overlay1` (`#8c8fa1`) is darker than `overlay0` (`#9ca0b0`) against the light background.

Per the issue, this darkens the **whole** metadata group together (time included), so scope/path are now at least as dark as — and in fact equal to — the timestamp, while everything reads more clearly.

### Before / After

| Element | Before | After |
|---|---|---|
| `.mc-message-time` | `--ctp-overlay0` | `--ctp-overlay1` |
| `.mc-message-route` (path) | `--ctp-overlay0` | `--ctp-overlay1` |
| `.mc-message-scope` | `--ctp-overlay0` | `--ctp-overlay1` |

## Testing

CSS-only change. `MeshCoreMessageStream` tests pass (3/3). No new TypeScript errors introduced (the repo's pre-existing `tsc --noEmit` warnings are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)