### PR TITLE
feat(meshcore): compact {ROUTE} auto-ack variable by dropping arrow spaces (#3776)

### DIFF
--- a/src/server/meshcoreManager.autoAckRoute.test.ts
+++ b/src/server/meshcoreManager.autoAckRoute.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the {ROUTE} auto-ack template variable expansion (#3776).
+ *
+ * MeshCore channel messages are length-limited (~120 chars with a scope) and
+ * shorter messages transmit more reliably and cost less airtime. The {ROUTE}
+ * variable therefore joins the relay-hash hop chain with a BARE arrow ("a→b→c")
+ * — no surrounding spaces — to save 2 bytes per hop.
+ *
+ * `replaceAutoAckTokens` is private; we reach it via `(m as any)` rather than
+ * spinning up a real backend/DB, mirroring the access pattern in
+ * meshcoreManager.scope.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { MeshCoreManager } from './meshcoreManager.js';
+
+function expand(template: string, route: string | null, hops: number | null): string {
+  const m = new MeshCoreManager('test-source');
+  // Args: template, senderPubKey, senderName, snr, timestamp, hops, route
+  return (m as any).replaceAutoAckTokens(
+    template,
+    'deadbeefcafebabe0011223344556677',
+    'Tester',
+    5.5,
+    Date.now(),
+    hops,
+    route,
+  );
+}
+
+describe('replaceAutoAckTokens — {ROUTE} compaction (#3776)', () => {
+  it('joins hops with a bare arrow and NO surrounding spaces', () => {
+    const out = expand('Route: {ROUTE}', '43ad,b8bf,6abc,a5f2', 4);
+    expect(out).toBe('Route: 43ad→b8bf→6abc→a5f2');
+    // Guard against the previous spaced format ever returning.
+    expect(out).not.toContain(' → ');
+  });
+
+  it('trims and drops empty hop tokens before joining', () => {
+    const out = expand('{ROUTE}', ' a3 , 7f ,, 02 ', 3);
+    expect(out).toBe('a3→7f→02');
+  });
+
+  it('renders a single hop without any arrow', () => {
+    expect(expand('{ROUTE}', 'a3', 1)).toBe('a3');
+  });
+
+  it('falls back to "direct" when there is no route and hops === 0', () => {
+    expect(expand('{ROUTE}', null, 0)).toBe('direct');
+  });
+
+  it('falls back to "—" when route and hop count are unknown', () => {
+    expect(expand('{ROUTE}', null, null)).toBe('—');
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5209,16 +5209,18 @@ class MeshCoreManager extends EventEmitter {
     const dateStr = date.toLocaleDateString('en-US');
     const timeStr = date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
     const hopsStr = hops !== null ? String(hops) : '—';
-    // {ROUTE} expands the cached hop-hash chain into a readable
-    // arrow-separated list (e.g. "a3 → 7f → 02"). Empty / unknown
-    // route falls back to "direct" when hop count is 0 or "—" otherwise.
+    // {ROUTE} expands the cached hop-hash chain into a compact
+    // arrow-separated list (e.g. "a3→7f→02"). Arrows have no surrounding
+    // spaces to save airtime on length-limited MeshCore channels (#3776).
+    // Empty / unknown route falls back to "direct" when hop count is 0 or
+    // "—" otherwise.
     let routeStr: string;
     if (route && route.length > 0) {
       routeStr = route
         .split(',')
         .map(h => h.trim())
         .filter(Boolean)
-        .join(' → ');
+        .join('→');
     } else if (hops === 0) {
       routeStr = 'direct';
     } else {


### PR DESCRIPTION
## Summary

Closes #3776.

MeshCore channel messages are length-limited (~120 chars when a scope is present), and shorter messages transmit more reliably while costing less airtime. The `{ROUTE}` template variable used in Auto Acknowledge / auto-reply messages expanded the relay-hash hop chain with spaces around every arrow. This removes the surrounding spaces so the route stays readable but more compact, saving **2 bytes per hop**.

### Before / After

```
Before:  43ad → b8bf → 6abc → a5f2
After:   43ad→b8bf→6abc→a5f2
```

## Change

- `src/server/meshcoreManager.ts` — in `replaceAutoAckTokens`, the hop join changed from `.join(' → ')` to `.join('→')` (same `→` glyph, no surrounding spaces). Comment updated to document the airtime rationale.
- The `direct` (0 hops) and `—` (unknown) fallbacks are unchanged.

## Tests

- New `src/server/meshcoreManager.autoAckRoute.test.ts` asserts:
  - hops join with a bare arrow and **no** surrounding spaces (guards against the old ` → ` ever returning)
  - hop tokens are trimmed and empties dropped before joining
  - a single hop renders with no arrow
  - `direct` fallback when route is empty and hops === 0
  - `—` fallback when route and hop count are unknown
- Related suites green: `meshcoreManager.scope.test.ts`, `meshcoreNativeBackend.otaPacket.test.ts`, new suite — 56 tests, 0 failures.

Display/formatting change only; no `system-test` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)