### PR TITLE
fix(meshcore): heartbeat/auto-reconnect, drop detection, reconnect-after-disconnect (#3705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **MeshCore source heartbeat / auto-reconnect** — MeshCore sources now expose a user-configurable **Heartbeat** interval (seconds, 0 = off) in the source form, mirroring Meshtastic. When set, the Companion node is probed periodically and the source reconnects automatically with exponential backoff on repeated failure. (#3705)
+
+### Fixed
+- **MeshCore: source unusable after a manual disconnect** — Disconnecting a MeshCore source from the UI removed its manager from the registry, so every `/meshcore/*` route returned "No MeshCore manager for source" and the source could not be reconnected without a container restart. Disconnect now keeps the manager registered (tearing down only the device link), so reconnect works cleanly. (#3705)
+- **MeshCore: undetected socket drops** — A socket/serial-level link drop left the manager stuck "connected", so the Virtual Node server served a stale identity and real sends silently failed with no recovery. The manager now detects backend disconnects and either auto-reconnects or cleanly marks the source disconnected. (#3705)
+
 ## [4.11.3] - 2026-06-21
 
 ### Features

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -55,7 +55,8 @@ Add MeshCore sources from the UI — they hot-connect immediately without a rest
 3. Pick **MeshCore** as the source type
 4. Choose the transport — **USB** (enter the serial port, e.g. `/dev/ttyACM0`) or **TCP** (enter the host and port; see [TCP Transport](#tcp-transport) below)
 5. Pick the **device type** — **Companion** for full-featured devices, **Repeater** for direct-serial repeaters (USB only)
-6. Save — the source connects immediately if **Auto-connect** is on
+6. *(Optional)* Set a **Heartbeat** interval in seconds (0 = off). When set, MeshMonitor periodically probes the Companion node and automatically reconnects with exponential backoff if the link drops — the same setting Meshtastic sources have. Applies to Companion devices only.
+7. Save — the source connects immediately if **Auto-connect** is on
 
 Sources you create from the UI are wired into the per-source MeshCore manager registry the same way Meshtastic TCP sources are, so create / update / delete / connect / disconnect all work without a process restart.
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -536,6 +536,16 @@ function DashboardInner() {
         };
       }
 
+      // Companion heartbeat / auto-reconnect (mirrors the Meshtastic setting).
+      // 0 = disabled; otherwise probe + reconnect with backoff. Only the native
+      // backend (companion) honours it; repeater ignores it.
+      const mcHeartbeat = parseInt(formHeartbeat, 10);
+      if (isNaN(mcHeartbeat) || mcHeartbeat < 0 || mcHeartbeat > 3600) {
+        setFormError(t('source.form.error_heartbeat_range'));
+        return;
+      }
+      if (mcHeartbeat > 0) cfg.heartbeatIntervalSeconds = mcHeartbeat;
+
       // Virtual Node server (opt-in): expose this MeshCore node to the MeshCore
       // mobile app over WiFi/TCP (#3535). Shares the formVn* state with the
       // Meshtastic form.
@@ -1459,6 +1469,22 @@ function DashboardInner() {
                     <option value="companion">{t('meshcore.device_type.companion', 'Companion')}</option>
                     <option value="repeater">{t('meshcore.device_type.repeater', 'Repeater')}</option>
                   </select>
+                </label>
+
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('source.form.heartbeat')}</span>
+                  <input
+                    className="dashboard-form-input"
+                    type="number"
+                    min={0}
+                    max={3600}
+                    value={formHeartbeat}
+                    onChange={(e) => setFormHeartbeat(e.target.value)}
+                    placeholder="0"
+                  />
+                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                    {t('meshcore.form.heartbeat_help', 'Seconds between companion keepalive probes (0 = disabled). On repeated failure the source reconnects automatically with backoff. Applies to Companion devices only.')}
+                  </p>
                 </label>
 
                 <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, margin: '8px 0 4px' }}>

--- a/src/server/meshcoreManager.dropDetection.test.ts
+++ b/src/server/meshcoreManager.dropDetection.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for MeshCore unexpected socket-drop handling (issue #3705
+ * follow-up). Before this, the manager only logged when the native backend's
+ * meshcore.js connection reported a socket/serial-level 'disconnected': it left
+ * `connected = true`, so isConnected() kept returning true, the Virtual Node
+ * server answered AppStart with a stale SelfInfo, and — with auto-reconnect
+ * disabled (the default) — nothing recovered.
+ *
+ * `handleUnexpectedDisconnect()` now reflects reality (or hands off to the
+ * reconnect machinery), while ignoring drops that come from our own intentional
+ * teardown or that land after a teardown is already in flight.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager } from './meshcoreManager.js';
+
+describe('MeshCoreManager.handleUnexpectedDisconnect()', () => {
+  let manager: MeshCoreManager;
+
+  beforeEach(() => {
+    manager = new MeshCoreManager('test-source');
+    // Simulate a live connection.
+    (manager as any).connected = true;
+    (manager as any).connectionState = 'connected';
+    (manager as any).intentionalTeardown = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops to disconnected and stops the VN server when auto-reconnect is off', async () => {
+    const stopVnSpy = vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+    const emitSpy = vi.spyOn(manager, 'emit');
+    (manager as any).shouldReconnect = false;
+
+    await (manager as any).handleUnexpectedDisconnect();
+
+    expect((manager as any).connected).toBe(false);
+    expect((manager as any).connectionState).toBe('disconnected');
+    expect(stopVnSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith('disconnected');
+  });
+
+  it('hands off to the reconnect machinery when auto-reconnect is enabled', async () => {
+    const beginReconnectSpy = vi.spyOn(manager as any, 'beginReconnect').mockReturnValue(undefined);
+    const stopVnSpy = vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+    (manager as any).shouldReconnect = true;
+
+    await (manager as any).handleUnexpectedDisconnect();
+
+    expect(beginReconnectSpy).toHaveBeenCalledTimes(1);
+    // The reconnect path owns the teardown; the no-reconnect branch must not run.
+    expect(stopVnSpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores the drop when an intentional teardown is in progress', async () => {
+    const stopVnSpy = vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+    const beginReconnectSpy = vi.spyOn(manager as any, 'beginReconnect').mockReturnValue(undefined);
+    (manager as any).intentionalTeardown = true;
+    (manager as any).shouldReconnect = false;
+
+    await (manager as any).handleUnexpectedDisconnect();
+
+    expect(stopVnSpy).not.toHaveBeenCalled();
+    expect(beginReconnectSpy).not.toHaveBeenCalled();
+    // State untouched — disconnect()/teardownTransportOnly() own it.
+    expect((manager as any).connected).toBe(true);
+  });
+
+  it('is a no-op when not in the connected state (teardown already in flight)', async () => {
+    const stopVnSpy = vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+    const beginReconnectSpy = vi.spyOn(manager as any, 'beginReconnect').mockReturnValue(undefined);
+    (manager as any).connectionState = 'reconnecting';
+
+    await (manager as any).handleUnexpectedDisconnect();
+
+    expect(stopVnSpy).not.toHaveBeenCalled();
+    expect(beginReconnectSpy).not.toHaveBeenCalled();
+  });
+
+  it('disconnect() sets the intentionalTeardown guard so the backend close event is ignored', async () => {
+    expect((manager as any).intentionalTeardown).toBe(false);
+    await manager.disconnect();
+    expect((manager as any).intentionalTeardown).toBe(true);
+  });
+});

--- a/src/server/meshcoreManager.dropDetection.test.ts
+++ b/src/server/meshcoreManager.dropDetection.test.ts
@@ -41,6 +41,18 @@ describe('MeshCoreManager.handleUnexpectedDisconnect()', () => {
     expect(emitSpy).toHaveBeenCalledWith('disconnected');
   });
 
+  it('releases the dead native backend so later sends get a clean disconnected error', async () => {
+    vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+    const backendDisconnect = vi.fn().mockResolvedValue(undefined);
+    (manager as any).nativeBackend = { disconnect: backendDisconnect };
+    (manager as any).shouldReconnect = false;
+
+    await (manager as any).handleUnexpectedDisconnect();
+
+    expect(backendDisconnect).toHaveBeenCalledTimes(1);
+    expect((manager as any).nativeBackend).toBeNull();
+  });
+
   it('hands off to the reconnect machinery when auto-reconnect is enabled', async () => {
     const beginReconnectSpy = vi.spyOn(manager as any, 'beginReconnect').mockReturnValue(undefined);
     const stopVnSpy = vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -551,6 +551,15 @@ class MeshCoreManager extends EventEmitter {
   private reconnectAttempts: number = 0;
   private nextReconnectAt: number | null = null;
   private shouldReconnect: boolean = false;
+  /**
+   * True while an *intentional* teardown is in progress (disconnect() or
+   * teardownTransportOnly()). Closing the native backend makes meshcore.js emit
+   * its own 'disconnected' event; this flag lets the manager's handler tell an
+   * operator/heartbeat-driven teardown apart from an unexpected socket drop so
+   * it doesn't double-tear-down or fight an in-flight reconnect. Reset in
+   * connect() once a fresh attempt begins.
+   */
+  private intentionalTeardown: boolean = false;
 
   // MeshCore region/scope (#3667). The device holds a SINGLE global flood
   // scope, asserted via the `set_flood_scope` bridge command before a send.
@@ -713,6 +722,10 @@ class MeshCoreManager extends EventEmitter {
 
     logger.info(`[MeshCore] Connecting via ${this.config.connectionType}...`);
     this.connectionState = 'connecting';
+    // A fresh attempt begins: clear any leftover teardown guard so the new
+    // backend's socket-drop events are treated as real (and so a late event
+    // from the previous backend, already nulled, stays suppressed).
+    this.intentionalTeardown = false;
 
     try {
       if (this.config.connectionType === ConnectionType.SERIAL && this.config.firmwareType === 'repeater') {
@@ -869,6 +882,11 @@ class MeshCoreManager extends EventEmitter {
   async disconnect(): Promise<void> {
     logger.info('[MeshCore] Disconnecting...');
 
+    // Mark this as an intentional teardown so the native backend's own
+    // 'disconnected' event (fired when we close the connection below) isn't
+    // mistaken for an unexpected link drop. Stays set until the next connect().
+    this.intentionalTeardown = true;
+
     // Clear reconnect intent first so a pending reconnect closure can't
     // stomp the in-progress teardown.
     this.shouldReconnect = false;
@@ -953,16 +971,21 @@ class MeshCoreManager extends EventEmitter {
             baudRate: this.config.baudRate || 115200,
           };
 
-    this.nativeBackend = new MeshCoreNativeBackend(this.sourceId, backendConfig);
+    const backend = new MeshCoreNativeBackend(this.sourceId, backendConfig);
+    this.nativeBackend = backend;
 
     // Native backend emits bridge-shaped push events; route them through
     // the manager's existing event handler.
-    this.nativeBackend.on('event', (evt: BridgeShapedEvent) => {
+    backend.on('event', (evt: BridgeShapedEvent) => {
       this.handleBridgeEvent(evt);
     });
 
-    this.nativeBackend.on('disconnected', () => {
-      logger.warn(`[MeshCore:${this.sourceId}] Native backend reported disconnect`);
+    // The underlying meshcore.js connection lost its socket/serial link. Capture
+    // the backend instance so a late event from a replaced/torn-down backend is
+    // ignored — only the current one drives recovery.
+    backend.on('disconnected', () => {
+      if (this.nativeBackend !== backend) return;
+      void this.handleUnexpectedDisconnect();
     });
 
     logger.info(`[MeshCore:${this.sourceId}] Starting native backend (meshcore.js)`);
@@ -4433,10 +4456,54 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * React to a socket/serial-level drop the native backend reported on its own
+   * (meshcore.js 'disconnected'), as opposed to a teardown we initiated. Without
+   * this, a dropped link left the manager stuck `connected = true`: isConnected()
+   * kept returning true, so the Virtual Node server answered AppStart with a
+   * stale SelfInfo while real sends silently failed, and — when heartbeat/auto-
+   * reconnect is disabled (the default) — nothing ever recovered.
+   *
+   * When auto-reconnect is enabled (`shouldReconnect`), hand off to the existing
+   * backoff machinery. Otherwise just reflect reality: drop to disconnected and
+   * stop the VN server so it stops serving a phantom node. The next manual
+   * connect() brings everything back.
+   */
+  private async handleUnexpectedDisconnect(): Promise<void> {
+    // Our own disconnect()/teardownTransportOnly() closed the link — expected.
+    if (this.intentionalTeardown) return;
+    // Already past 'connected' (a teardown/reconnect is in flight) — nothing to do.
+    if (this.connectionState !== 'connected') return;
+
+    logger.warn(`[MeshCore:${this.sourceId}] Connection lost (native backend socket closed)`);
+
+    if (this.shouldReconnect) {
+      // Heartbeat-style auto-reconnect is enabled: drive the existing teardown +
+      // exponential-backoff path (which stops the VN server and reconnects).
+      this.beginReconnect();
+      return;
+    }
+
+    // Auto-reconnect disabled: surface the disconnect so the UI updates and the
+    // VN server stops answering with a stale identity. Mirrors disconnect()'s
+    // user-visible side effects without clearing the cached node/contacts.
+    this.connected = false;
+    this.connectionState = 'disconnected';
+    this.stopHeartbeat();
+    await this.stopVirtualNodeServer();
+    this.emit('disconnected');
+    dataEventEmitter.emitMeshCoreStatusUpdated({ connected: false }, this.sourceId);
+  }
+
+  /**
    * Tear down the transport without clearing `shouldReconnect`. Mirrors the
    * relevant half of `disconnect()` but preserves reconnect intent.
    */
   private async teardownTransportOnly(): Promise<void> {
+    // This is a deliberate teardown (heartbeat-driven reconnect); suppress the
+    // native backend's own 'disconnected' event so it doesn't re-enter the
+    // unexpected-drop path. connect() clears the flag when the reconnect lands.
+    this.intentionalTeardown = true;
+
     // Stop the Virtual Node server first, same as disconnect() does. Without
     // this, the VN server keeps accepting app connections while isConnected()
     // is false, causing every AppStart to get BadState and the app to loop in

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4486,10 +4486,25 @@ class MeshCoreManager extends EventEmitter {
     // Auto-reconnect disabled: surface the disconnect so the UI updates and the
     // VN server stops answering with a stale identity. Mirrors disconnect()'s
     // user-visible side effects without clearing the cached node/contacts.
+    // Set connectionState first so a re-emitted 'disconnected' from the backend
+    // teardown below short-circuits on the `!== 'connected'` guard above.
     this.connected = false;
     this.connectionState = 'disconnected';
     this.stopHeartbeat();
     await this.stopVirtualNodeServer();
+    // Release the dead backend. Without this `nativeBackend` keeps pointing at a
+    // closed connection, so sendBridgeCommand()'s `!nativeBackend` guard never
+    // trips and callers get a confusing write-to-closed error instead of a clean
+    // "disconnected" until /connect runs. Nulling it also makes the listener's
+    // stale-instance guard reject any late event from this backend.
+    if (this.nativeBackend) {
+      try {
+        await this.nativeBackend.disconnect();
+      } catch (err) {
+        logger.debug(`[MeshCore:${this.sourceId}] dead-backend cleanup threw: ${(err as Error).message}`);
+      }
+      this.nativeBackend = null;
+    }
     this.emit('disconnected');
     dataEventEmitter.emitMeshCoreStatusUpdated({ connected: false }, this.sourceId);
   }

--- a/src/server/meshcoreRegistry.test.ts
+++ b/src/server/meshcoreRegistry.test.ts
@@ -118,4 +118,25 @@ describe('meshcoreConfigFromSource', () => {
     );
     expect(cfg).toBeNull();
   });
+
+  it('passes heartbeatIntervalSeconds through on the SERIAL path', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion', heartbeatIntervalSeconds: 30 } }),
+    );
+    expect(cfg?.heartbeatIntervalSeconds).toBe(30);
+  });
+
+  it('passes heartbeatIntervalSeconds through on the TCP path', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'tcp', tcpHost: '10.0.0.5', deviceType: 'companion', heartbeatIntervalSeconds: 45 } }),
+    );
+    expect(cfg?.heartbeatIntervalSeconds).toBe(45);
+  });
+
+  it('leaves heartbeatIntervalSeconds undefined when not configured', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion' } }),
+    );
+    expect(cfg?.heartbeatIntervalSeconds).toBeUndefined();
+  });
 });

--- a/src/server/meshcoreRegistry.ts
+++ b/src/server/meshcoreRegistry.ts
@@ -22,6 +22,14 @@ interface MeshCoreSourceConfig {
   tcpPort?: number;
   deviceType?: 'companion' | 'repeater';
   autoConnect?: boolean;
+  /**
+   * Companion heartbeat / auto-reconnect interval in seconds (0 = disabled).
+   * Mirrors the Meshtastic source setting. When > 0 the manager periodically
+   * probes the node (cheap RTC read) and, on repeated failure, tears down and
+   * reconnects with exponential backoff. Only honoured for companion devices
+   * (the native backend); repeater/direct-serial ignores it.
+   */
+  heartbeatIntervalSeconds?: number;
   // Virtual Node server — expose this node to the MeshCore app over WiFi (#3535).
   virtualNode?: {
     enabled?: boolean;
@@ -67,6 +75,7 @@ export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null 
       baudRate: cfg.baudRate ?? 115200,
       firmwareType,
       virtualNode,
+      heartbeatIntervalSeconds: cfg.heartbeatIntervalSeconds,
     };
   }
 
@@ -77,6 +86,7 @@ export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null 
       tcpPort: cfg.tcpPort ?? 4403,
       firmwareType,
       virtualNode,
+      heartbeatIntervalSeconds: cfg.heartbeatIntervalSeconds,
     };
   }
 

--- a/src/server/routes/sourceRoutes.autoConnect.test.ts
+++ b/src/server/routes/sourceRoutes.autoConnect.test.ts
@@ -9,6 +9,7 @@ import request from 'supertest';
 import sourceRoutes from './sourceRoutes.js';
 import databaseService from '../../services/database.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 
 vi.mock('../../services/database.js', () => ({
   default: {
@@ -60,8 +61,18 @@ vi.mock('../meshtasticManager.js', () => {
   return { MeshtasticManager };
 });
 
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    get: vi.fn().mockReturnValue(undefined),
+    getOrCreate: vi.fn(),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+  meshcoreConfigFromSource: vi.fn().mockReturnValue({ connectionType: 'serial', serialPort: '/dev/ttyACM0', firmwareType: 'companion' }),
+}));
+
 const mockDb = databaseService as any;
 const mockRegistry = sourceManagerRegistry as any;
+const mockMcRegistry = meshcoreManagerRegistry as any;
 
 const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
 
@@ -90,6 +101,7 @@ beforeEach(() => {
   mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
   mockDb.checkPermissionAsync.mockResolvedValue(true);
   mockRegistry.getManager.mockReturnValue(null);
+  mockMcRegistry.get.mockReturnValue(undefined);
 });
 
 describe('sourceRoutes — autoConnect flag on create', () => {
@@ -256,6 +268,56 @@ describe('sourceRoutes — POST /:id/disconnect', () => {
     expect(res.status).toBe(200);
     expect(res.body.alreadyStopped).toBe(true);
     expect(mockRegistry.removeManager).not.toHaveBeenCalled();
+  });
+
+  it('disconnects a MeshCore source without removing its manager from the registry', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'mc-1',
+      name: 'MC',
+      type: 'meshcore',
+      enabled: true,
+      config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion' },
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    });
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    mockMcRegistry.get.mockReturnValue({ isConnected: () => true, disconnect });
+
+    const res = await request(app).post('/mc-1/disconnect');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    // Device link torn down...
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    // ...but the manager stays registered so /meshcore/* routes keep working
+    // and /connect can re-establish without a restart (regression: the source
+    // used to become unaddressable — "No MeshCore manager for source").
+    expect(mockMcRegistry.remove).not.toHaveBeenCalled();
+  });
+
+  it('reports alreadyStopped for a MeshCore source that is not connected', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'mc-1',
+      name: 'MC',
+      type: 'meshcore',
+      enabled: true,
+      config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion' },
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    });
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    mockMcRegistry.get.mockReturnValue({ isConnected: () => false, disconnect });
+
+    const res = await request(app).post('/mc-1/disconnect');
+
+    expect(res.status).toBe(200);
+    expect(res.body.alreadyStopped).toBe(true);
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(mockMcRegistry.remove).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -1097,7 +1097,14 @@ router.post('/:id/disconnect', requirePermission('sources', 'write'), async (req
       if (!existingMc?.isConnected()) {
         return res.json({ success: true, alreadyStopped: true });
       }
-      await meshcoreManagerRegistry.remove(source.id);
+      // Tear down the device link but KEEP the manager registered. Removing it
+      // from the registry leaves the source unaddressable: every /meshcore/*
+      // route is behind a guard that 404s ("No MeshCore manager for source")
+      // when the manager is absent, so the page's status/read polling errors
+      // out and the source can't be driven again without a restart. A plain
+      // disconnect() stops the link, VN server, heartbeat and schedulers while
+      // leaving the manager in place for a clean reconnect via /connect.
+      await existingMc.disconnect();
       return res.json({ success: true });
     }
     if (!sourceManagerRegistry.getManager(source.id)) {


### PR DESCRIPTION
## Summary
Investigating #3705 (MeshCore Virtual Node stuck "Connecting") surfaced three real gaps in how MeshMonitor handles a MeshCore source's connection lifecycle. None of them were the app-side `AppStart` behavior the issue ultimately hinges on, but they explain the "works once, then stuck until restart" class of failure — including the reporter's restart-fixes-it symptom and a locally-reproduced "Disconnect → can't reconnect" bug. Firmware was verified against `companion-v1.15.0`/`v1.16.0` (silent-until-AppStart, single-client, byte-identical between versions); findings posted on #3705.

## Changes
- **Heartbeat / auto-reconnect for MeshCore sources (was unreachable).** Neither the source config type nor `meshcoreConfigFromSource()` carried `heartbeatIntervalSeconds`, and there was no UI for it — so `startHeartbeat()` always early-returned and the reconnect path (including PR #3706's fix) never ran. Added a **Heartbeat** field to the MeshCore source form (mirrors Meshtastic) and plumbed `heartbeatIntervalSeconds` through `MeshCoreSourceConfig` → `meshcoreConfigFromSource()`. The update route already restarts the manager on config change.
- **Socket-drop detection.** The manager only logged the native backend's `disconnected` event, leaving `connected = true` on a real link drop — so the VN server served a stale identity and sends silently failed with no recovery. Added `handleUnexpectedDisconnect()` (guarded by an `intentionalTeardown` flag + a stale-backend-instance check) that auto-reconnects when heartbeat is enabled, or cleanly marks the source disconnected otherwise.
- **Reconnect-after-disconnect.** The UI Disconnect (`POST /api/sources/:id/disconnect`) called `meshcoreManagerRegistry.remove()`, deleting the manager; every `/meshcore/*` route then 404'd with "No MeshCore manager for source" and the source was unaddressable until a restart. Disconnect now calls `manager.disconnect()` and keeps the manager registered.
- Docs: documented the new Heartbeat field in `docs/features/meshcore.md`; CHANGELOG entries.

## Issues Resolved
Relates to #3705 (addresses the real-node link-recovery failure modes; the residual app-side `AppStart`-on-reconnect behavior is upstream in meshcore-flutter). Activates PR #3706's teardown fix, which was previously unreachable by default.

## Documentation Updates
- `docs/features/meshcore.md` — added the optional **Heartbeat** step to "Adding a Source".
- `CHANGELOG.md` — Added (heartbeat) + Fixed (disconnect reconnect, socket-drop detection) entries.

## Testing
- [x] Unit tests pass (full suite: 7657 passed, 0 failed, 0 suite failures)
- [x] TypeScript compiles cleanly (`tsconfig.server.json` — no new errors in changed files)
- [x] New regression tests: drop-detection branches, heartbeat config passthrough, disconnect keeps manager registered
- [x] Manually verified live against a real Heltec V3 (v1.15.0) in the dev container: 3× disconnect→reconnect cycles, `/meshcore/*` routes return 200 (not 404) while disconnected, full node state restored on reconnect
- [ ] Reviewer: edit a MeshCore source, set a Heartbeat value, confirm it persists and that pulling the link triggers an automatic reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)