### PR TITLE
fix(map): render every position fix + paginate full history (#3791)

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -86,9 +86,11 @@ Get historical position data for a specific node.
 - `nodeId`: Node identifier (string, e.g., "!a2e4ff4c")
 
 **Query Parameters:**
-- `hours` (optional): Hours of history to retrieve (default: 24)
+- `hours` (optional): Hours of history to retrieve (default: all history)
+- `before` (optional): Unix epoch milliseconds cursor. Returns only fixes strictly older than this timestamp. Each response is capped server-side (1500 telemetry rows ≈ 300 fixes); pass the oldest returned fix's timestamp as `before` to page backward through the complete history.
 
 **Example:** `/api/nodes/!a2e4ff4c/position-history?hours=48`
+**Paginated example:** `/api/nodes/!a2e4ff4c/position-history?before=1719360000000`
 
 **Response:**
 ```json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import Sidebar from './components/Sidebar';
 import { SearchModal } from './components/SearchModal/SearchModal.js';
 import { SettingsProvider, useSettings, useNotificationMuteSettings } from './contexts/SettingsContext';
 import { MapProvider, useMapContext } from './contexts/MapContext';
+import type { PositionHistoryItem } from './contexts/MapContext';
 import { DataProvider, useData } from './contexts/DataContext';
 import { MessagingProvider, useMessaging } from './contexts/MessagingContext';
 import { UIProvider, useUI } from './contexts/UIContext';
@@ -1527,21 +1528,57 @@ const location = useLocation();
       return;
     }
 
-    const fetchPositionHistory = async () => {
+    let cancelled = false;
+
+    // Progressively load the ENTIRE position history in bounded pages (#3791).
+    // The server caps each response at 1500 telemetry rows (~300 fixes), so we
+    // walk backwards in time using the oldest fix of each page as a `before`
+    // cursor, appending until a page comes back empty. State is updated after
+    // every page so the trail fills in progressively rather than all at once.
+    const fetchAllPositionHistory = async () => {
+      const accumulated: PositionHistoryItem[] = [];
+      let beforeCursor: number | undefined;
+      const MAX_PAGES = 50; // safety bound (~15k fixes) against a runaway loop
+
       try {
-        // Fetch all position history (no time limit) to show complete movement trail
-        const phQuery = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
-        const response = await authFetch(`${baseUrl}/api/nodes/${selectedNodeId}/position-history${phQuery}`);
-        if (response.ok) {
-          const history = await response.json();
-          setPositionHistory(history);
+        for (let page = 0; page < MAX_PAGES; page++) {
+          const params = new URLSearchParams();
+          if (sourceId) params.set('sourceId', sourceId);
+          if (beforeCursor !== undefined) params.set('before', String(beforeCursor));
+          const qs = params.toString();
+          const response = await authFetch(
+            `${baseUrl}/api/nodes/${selectedNodeId}/position-history${qs ? `?${qs}` : ''}`
+          );
+          if (cancelled) return;
+          if (!response.ok) break;
+
+          const pageItems: PositionHistoryItem[] = await response.json();
+          if (cancelled) return;
+          if (pageItems.length === 0) break; // reached the start of history
+
+          // Server returns fixes oldest-first; prepend each older page so the
+          // accumulated array stays chronological as we page back in time.
+          accumulated.unshift(...pageItems);
+          setPositionHistory([...accumulated]);
+
+          // Next page: strictly older than the oldest fix just received. A
+          // boundary fix split by the row cap is always older than this, so it
+          // re-assembles on the next page without duplicating an emitted fix.
+          const oldest = pageItems[0].timestamp;
+          if (beforeCursor !== undefined && oldest >= beforeCursor) break; // no-progress guard
+          beforeCursor = oldest;
+
+          // Gentle pacing so we neither hammer the server nor block rendering.
+          await new Promise(resolve => setTimeout(resolve, 150));
+          if (cancelled) return;
         }
       } catch (error) {
-        logger.error('Error fetching position history:', error);
+        if (!cancelled) logger.error('Error fetching position history:', error);
       }
     };
 
-    fetchPositionHistory();
+    fetchAllPositionHistory();
+    return () => { cancelled = true; };
   }, [selectedNodeId, nodes, baseUrl, sourceId]);
 
   // Open popup for selected node

--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -333,6 +333,17 @@ describe('TelemetryRepository (expanded)', () => {
       const results = await repo.getPositionTelemetryByNode('!00000000');
       expect(results).toHaveLength(0);
     });
+
+    it('filters by beforeTimestamp cursor (strictly older), enabling backward pagination (#3791)', async () => {
+      // Add an older record outside the seeded NOW - HOUR batch.
+      await insertTelemetry(NODE1, NODE1_NUM, 'latitude', NOW - 10 * HOUR);
+
+      // beforeTimestamp is the 5th positional arg (after sourceId).
+      const results = await repo.getPositionTelemetryByNode(NODE1, 100, undefined, undefined, NOW - 2 * HOUR);
+      expect(results.length).toBeGreaterThan(0);
+      // Strictly older than the cursor — the NOW - HOUR rows are excluded.
+      expect(results.every(r => r.timestamp < NOW - 2 * HOUR)).toBe(true);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -268,7 +268,8 @@ export class TelemetryRepository extends BaseRepository {
     nodeId: string,
     limit: number = 1500,
     sinceTimestamp?: number,
-    sourceId?: string
+    sourceId?: string,
+    beforeTimestamp?: number
   ): Promise<DbTelemetry[]> {
     const positionTypes = ['latitude', 'longitude', 'altitude', 'ground_speed', 'ground_track'];
     const { telemetry } = this.tables;
@@ -283,6 +284,13 @@ export class TelemetryRepository extends BaseRepository {
 
     if (sinceTimestamp !== undefined) {
       conditions.push(gte(telemetry.timestamp, sinceTimestamp));
+    }
+
+    // Cursor for backward pagination (#3791): fetch only rows strictly older
+    // than the caller's cursor so the entire history can be walked one bounded
+    // page at a time without re-reading earlier pages.
+    if (beforeTimestamp !== undefined) {
+      conditions.push(lt(telemetry.timestamp, beforeTimestamp));
     }
 
     const result = await this.db

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1334,6 +1334,14 @@ apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res
       : null;
     const cutoffTime = hoursParam ? Date.now() - hoursParam * 60 * 60 * 1000 : 0;
 
+    // Backward-pagination cursor (#3791). When supplied, only fixes strictly
+    // older than this timestamp are returned, letting the client walk the whole
+    // history one bounded 1500-row page at a time. Must be a positive integer.
+    const rawBefore = req.query.before ? parseInt(req.query.before as string) : null;
+    const beforeTimestamp = rawBefore !== null && !isNaN(rawBefore) && rawBefore > 0
+      ? rawBefore
+      : undefined;
+
     // Check privacy for position history — scope to caller's source so the
     // privacy setting reflects this source's node (same nodeNum may exist in
     // multiple sources with different privacy flags).
@@ -1350,7 +1358,7 @@ apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res
     }
 
     // Get only position-related telemetry (lat/lon/alt/speed/track) for the node - much more efficient!
-    const positionTelemetry = await databaseService.getPositionTelemetryByNodeAsync(nodeId, 1500, cutoffTime);
+    const positionTelemetry = await databaseService.getPositionTelemetryByNodeAsync(nodeId, 1500, cutoffTime, beforeTimestamp);
 
     // Pivot the per-metric telemetry rows into per-fix position objects.
     // Per-fix receive metadata (SNR + hop info, issue #3492) stamped on the

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3914,9 +3914,9 @@ class DatabaseService {
   }
 
   /** @deprecated Use databaseService.telemetry.getPositionTelemetryByNode() instead */
-  async getPositionTelemetryByNodeAsync(nodeId: string, limit: number = 1500, sinceTimestamp?: number): Promise<DbTelemetry[]> {
+  async getPositionTelemetryByNodeAsync(nodeId: string, limit: number = 1500, sinceTimestamp?: number, beforeTimestamp?: number): Promise<DbTelemetry[]> {
     // Cast to local DbTelemetry type (they have compatible structure)
-    return this.telemetry.getPositionTelemetryByNode(nodeId, limit, sinceTimestamp) as unknown as Promise<DbTelemetry[]>;
+    return this.telemetry.getPositionTelemetryByNode(nodeId, limit, sinceTimestamp, undefined, beforeTimestamp) as unknown as Promise<DbTelemetry[]>;
   }
 
   /**

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -393,10 +393,23 @@ describe('mapHelpers', () => {
       expect(triangles(els)).toHaveLength(0);
     });
 
-    it('caps the number of rendered points at maxArrows', () => {
+    it('renders a dot at EVERY fix without subsampling (#3791)', () => {
       const items = Array.from({ length: 100 }, (_, i) => ({ latitude: i, longitude: i, timestamp: i })) as any[];
       const els = generatePositionHistoryArrows(items, [], 10, 'km');
-      expect(dots(els).length).toBeLessThanOrEqual(10);
+      // Points are no longer capped — one dot per reported position.
+      expect(dots(els)).toHaveLength(100);
+    });
+
+    it('subsamples heading triangles to at most maxArrows while keeping all dots (#3791)', () => {
+      const items = Array.from(
+        { length: 100 },
+        (_, i) => ({ latitude: i, longitude: i, timestamp: i, groundTrack: 90 })
+      ) as any[];
+      const els = generatePositionHistoryArrows(items, [], 10, 'km');
+      // A dot at every fix...
+      expect(dots(els)).toHaveLength(100);
+      // ...but heading triangles stay capped to avoid clutter on dense trails.
+      expect(triangles(els).length).toBeLessThanOrEqual(10);
     });
 
     it('returns nothing for an empty history', () => {

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -394,11 +394,12 @@ const getCardinalDirection = (heading: number): string => {
 };
 
 /**
- * Generate position history arrow markers with limited count for performance
- * Places arrow at each position point, rotated to match groundTrack (heading)
+ * Generate position history markers. A dot is rendered at EVERY fix so every
+ * reported position is visible and hoverable (#3791); the decorative heading
+ * triangles are subsampled to at most `maxArrows` to keep dense trails legible.
  * @param historyItems Array of position history items with full data
  * @param colors Array of colors for each position
- * @param maxArrows Maximum number of arrows to generate
+ * @param maxArrows Maximum number of heading triangles to overlay (dots are not capped)
  * @param distanceUnit User's preferred distance unit ('km' or 'mi')
  * @returns Array of Marker components with clickable popups
  */
@@ -413,14 +414,12 @@ export const generatePositionHistoryArrows = (
 
   if (itemCount <= 0) return arrows;
 
-  // Calculate how many items to skip to stay under maxArrows
-  const step = Math.max(1, Math.ceil(itemCount / maxArrows));
+  // A dot is rendered at EVERY fix (#3791) so no reported position is dropped.
+  // Heading triangles, however, are subsampled to at most `maxArrows` so a
+  // dense or stationary trail doesn't become a wall of overlapping arrows.
+  const triangleStep = Math.max(1, Math.ceil(itemCount / maxArrows));
 
-  // Cap the number of rendered POINTS (not React elements — a fix may emit a
-  // dot plus an optional heading overlay).
-  let rendered = 0;
-  for (let i = 0; i < itemCount && rendered < maxArrows; i += step) {
-    rendered++;
+  for (let i = 0; i < itemCount; i++) {
     const item = historyItems[i];
     // Safely get color - default to blue if colors array is empty
     const color = colors.length > 0 ? colors[Math.min(i, colors.length - 1)] : '#3b82f6';
@@ -512,8 +511,9 @@ export const generatePositionHistoryArrows = (
     );
 
     // Overlay a decorative heading triangle on top when heading is known.
-    // Non-interactive so the dot underneath keeps the hover/click target.
-    if (angle !== null) {
+    // Subsampled to maxArrows so dense trails stay legible. Non-interactive so
+    // the dot underneath keeps the hover/click target.
+    if (angle !== null && i % triangleStep === 0) {
       const arrowIcon = L.divIcon({
         html: `<div style="transform: rotate(${angle}deg); font-size: 16px; font-weight: bold;">
           <span style="color: ${color}; text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;">▲</span>


### PR DESCRIPTION
## Summary
Position-history points were being dropped on the map: the dots were subsampled to a hard cap of 30 markers, so lengthening the tail thinned them out (only the connecting line stayed dense), and the server only ever returned the newest 1500 telemetry rows (~300 fixes) in a single request, so older history was unreachable. This PR renders a marker at **every** recorded fix and progressively loads the **entire** history in bounded pages, keeping the per-request 1500-row cap intact.

## Changes
- **`generatePositionHistoryArrows` (`mapHelpers.tsx`)**: render a `CircleMarker` (with hover tooltip + click popup) at *every* fix. Decorative heading triangles remain subsampled to `maxArrows` so dense/stationary trails don't become a wall of overlapping arrows — the dots underneath are the full-resolution interactive layer.
- **Server `before` cursor**: `GET /api/nodes/:nodeId/position-history` accepts an optional `before=<epoch ms>` param returning only fixes strictly older than the cursor. Threaded through `getPositionTelemetryByNodeAsync` → repo `getPositionTelemetryByNode` as a `lt(timestamp, before)` condition. The 1500-row per-request cap is unchanged; the new param is optional and positional-last, so existing callers (incl. the v1 route) are unaffected.
- **Client pagination (`App.tsx`)**: walks the full history backward in bounded pages, using each page's oldest fix as the next `before` cursor and appending to state progressively. Strict `<` on the oldest *complete* fix re-assembles any boundary fix split by the row cap without producing duplicates. Includes a no-progress guard, `MAX_PAGES` safety bound, gentle inter-page pacing, and cancellation when the selected node changes.
- **Docs**: documented the new `before` query param in `docs/api/API.md`.

## Issues Resolved
Relates to #3791 (addresses Bug 1: position-history points vanish above a ~2-day tail). Bugs 2–4 in that issue (hover/click on points, implausible velocity, missing SNR on directs) are not addressed here.

## Documentation Updates
- `docs/api/API.md`: added the `before` cursor query parameter and a paginated-usage example.

## Testing
- [x] Unit tests pass (full suite: 7649 passed, 0 failed, 0 suite failures)
- [x] TypeScript compiles cleanly (`tsconfig.server.json`; only pre-existing `TelemetryChart.tsx` noise remains)
- [x] New repo test: `getPositionTelemetryByNode` honors the `beforeTimestamp` cursor (strictly older)
- [x] New `mapHelpers` tests: a dot renders at every fix; heading triangles stay capped at `maxArrows`
- [ ] Manual: select a mobile node with >2 days of history — confirm dots appear at every fix and the trail fills in progressively page-by-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)