### PR TITLE
fix(notifications): fire "new node" notification for direct Meshtastic nodes (#3796)

### DIFF
--- a/src/server/meshtasticManager.ignoreReapply.test.ts
+++ b/src/server/meshtasticManager.ignoreReapply.test.ts
@@ -58,6 +58,9 @@ vi.mock('../services/database.js', () => {
       setSetting: vi.fn().mockResolvedValue(undefined),
     },
     sources: { getSource: vi.fn().mockResolvedValue(null) },
+    // #3796: meshtasticManager now routes node writes through upsertNodeAsync,
+    // which delegates to nodes.upsertNode (the fn this suite asserts on).
+    upsertNodeAsync: upsertNode,
     nodes: {
       getNode: vi.fn().mockResolvedValue(null),
       upsertNode,

--- a/src/server/meshtasticManager.node-identity-guards.test.ts
+++ b/src/server/meshtasticManager.node-identity-guards.test.ts
@@ -28,6 +28,8 @@ vi.mock('../services/database.js', () => ({
     getSetting: mockGetSetting,
     setSetting: mockSetSetting,
     upsertNode: mockUpsertNode,
+    // #3796: node writes route through upsertNodeAsync -> nodes.upsertNode.
+    upsertNodeAsync: mockUpsertNode,
     getNode: mockGetNode,
     deleteNode: mockDeleteNode,
     suppressGhostNode: mockSuppressGhostNode,

--- a/src/server/meshtasticManager.traceroute-hops.test.ts
+++ b/src/server/meshtasticManager.traceroute-hops.test.ts
@@ -38,6 +38,8 @@ vi.mock('../services/database.js', () => ({
     getSetting: mockGetSetting,
     getNode: mockGetNode,
     upsertNode: mockUpsertNode,
+    // #3796: node writes route through upsertNodeAsync -> nodes.upsertNode.
+    upsertNodeAsync: mockUpsertNode,
     insertMessage: mockInsertMessage,
     insertTraceroute: mockInsertTraceroute,
     findUserByIdAsync: vi.fn(),

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4161,11 +4161,11 @@ class MeshtasticManager implements ISourceManager {
                     updateData.keySecurityIssueDetails = null;
                   }
 
-                  await databaseService.nodes.upsertNode(updateData, this.sourceId);
+                  await databaseService.upsertNodeAsync(updateData, this.sourceId);
                   logger.info(`💾 Saved local node public key to database for ${localNodeId}`);
                 }).catch(async (err) => {
                   // If low entropy check fails, still save the key
-                  await databaseService.nodes.upsertNode({
+                  await databaseService.upsertNodeAsync({
                     nodeNum: localNodeNum,
                     nodeId: localNodeId,
                     publicKey: publicKeyBase64,
@@ -4242,7 +4242,7 @@ class MeshtasticManager implements ISourceManager {
             const localNodeNum = this.localNodeInfo.nodeNum;
             const localNodeId = this.localNodeInfo.nodeId;
             try {
-              await databaseService.nodes.upsertNode({
+              await databaseService.upsertNodeAsync({
                 nodeNum: localNodeNum,
                 nodeId: localNodeId,
                 lastHeard: Date.now() / 1000,
@@ -4403,7 +4403,7 @@ class MeshtasticManager implements ISourceManager {
 
           // Upsert new node with merged metadata — new node's existing data takes priority,
           // falls back to old node's data for missing fields
-          await databaseService.nodes.upsertNode({
+          await databaseService.upsertNodeAsync({
             nodeNum: nodeNum,
             nodeId: nodeId,
             longName: newNode?.longName || oldNode?.longName || undefined,
@@ -4507,7 +4507,7 @@ class MeshtasticManager implements ISourceManager {
     // Clear any erroneous security flags on the local node — we can't have a key mismatch with ourselves
     if (existingNode?.keyMismatchDetected || existingNode?.keySecurityIssueDetails) {
       logger.info(`🔐 Clearing erroneous security flags on local node ${nodeId}`);
-      await databaseService.nodes.upsertNode({
+      await databaseService.upsertNodeAsync({
         nodeNum,
         nodeId,
         keyMismatchDetected: false,
@@ -4536,7 +4536,7 @@ class MeshtasticManager implements ISourceManager {
       // is stale (no inbound packets via processMeshPacket since startup) would have its
       // own NeighborInfo links silently dropped by the freshness filter in
       // sourceRoutes.ts / server.ts (#3025).
-      await databaseService.nodes.upsertNode({
+      await databaseService.upsertNodeAsync({
         nodeNum: nodeNum,
         nodeId: nodeId,
         rebootCount: myNodeInfo.rebootCount !== undefined ? myNodeInfo.rebootCount : undefined,
@@ -4571,7 +4571,7 @@ class MeshtasticManager implements ISourceManager {
         isLocked: false  // Not locked yet, waiting for complete info
       } as any;
 
-      await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
       logger.debug(`📱 Stored basic local node info with rebootCount: ${myNodeInfo.rebootCount}, waiting for NodeInfo for names (${nodeId})`);
     }
     // Note: Local node's public key is extracted from security config when received
@@ -5034,7 +5034,7 @@ class MeshtasticManager implements ISourceManager {
           nodeId: this.localNodeInfo.nodeId,
           firmwareVersion: metadata.firmwareVersion
         };
-        await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+        await databaseService.upsertNodeAsync(nodeData, this.sourceId);
         logger.debug(`📱 Saved firmware version to database for node ${this.localNodeInfo.nodeId}`);
       }
     } else {
@@ -5467,7 +5467,7 @@ class MeshtasticManager implements ISourceManager {
       if (meshPacket.rxRssi != null && meshPacket.rxRssi !== 0) {
         nodeData.rssi = meshPacket.rxRssi;
       }
-      await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
 
       // Capture server-vs-node clock offset for time-offset telemetry
       if (meshPacket.rxTime && Number(meshPacket.rxTime) > 1600000000) {
@@ -5738,7 +5738,7 @@ class MeshtasticManager implements ISourceManager {
             createdAt: Date.now(),
             updatedAt: Date.now()
           };
-          await databaseService.nodes.upsertNode(basicNodeData, this.sourceId);
+          await databaseService.upsertNodeAsync(basicNodeData, this.sourceId);
           logger.debug(`📝 Created basic node entry for ${fromNodeId}`);
         }
 
@@ -5766,7 +5766,7 @@ class MeshtasticManager implements ISourceManager {
               createdAt: Date.now(),
               updatedAt: Date.now()
             };
-            await databaseService.nodes.upsertNode(broadcastNodeData, this.sourceId);
+            await databaseService.upsertNodeAsync(broadcastNodeData, this.sourceId);
             logger.debug(`📝 Created broadcast node entry (no lastHeard — pseudo-node)`);
           }
         }
@@ -6005,7 +6005,7 @@ class MeshtasticManager implements ISourceManager {
           logger.info(`📦 S&F heartbeat from ${fromNodeId}: period=${period}s, secondary=${secondary}`);
 
           // Mark this node as a Store & Forward server
-          await databaseService.nodes.upsertNode({
+          await databaseService.upsertNodeAsync({
             nodeNum: fromNum,
             nodeId: fromNodeId,
             isStoreForwardServer: true,
@@ -6282,7 +6282,7 @@ class MeshtasticManager implements ISourceManager {
           if (meshPacket.rxRssi && meshPacket.rxRssi !== 0) {
             technicalData.rssi = meshPacket.rxRssi;
           }
-          await databaseService.nodes.upsertNode(technicalData, this.sourceId);
+          await databaseService.upsertNodeAsync(technicalData, this.sourceId);
         } else {
           const nodeData: any = {
             nodeNum: fromNum,
@@ -6310,7 +6310,7 @@ class MeshtasticManager implements ISourceManager {
           }
 
           // Save position to nodes table (current position)
-          await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+          await databaseService.upsertNodeAsync(nodeData, this.sourceId);
 
           // Emit node update event to notify frontend via WebSocket. When a
           // user-set override is active for this node, strip the GPS coords
@@ -6358,7 +6358,7 @@ class MeshtasticManager implements ISourceManager {
   private async trackPKIEncryption(meshPacket: any, nodeNum: number): Promise<void> {
     if (meshPacket.pkiEncrypted || meshPacket.pki_encrypted) {
       const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
-      await databaseService.nodes.upsertNode({
+      await databaseService.upsertNodeAsync({
         nodeNum,
         nodeId,
         lastPKIPacket: Date.now()
@@ -6587,7 +6587,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       logger.debug(`🔍 Saving node with role=${user.role}, hopsAway=${meshPacket.hopsAway}`);
-      await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
       logger.debug(`👤 Updated user info: ${user.longName || nodeId}`);
 
       // Check if we should send auto-welcome message
@@ -6758,7 +6758,7 @@ class MeshtasticManager implements ISourceManager {
         );
       }
 
-      await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
       logger.debug(`📊 Updated node telemetry and saved to telemetry table: ${nodeId}`);
     } catch (error) {
       logger.error('❌ Error processing telemetry message:', error);
@@ -6820,7 +6820,7 @@ class MeshtasticManager implements ISourceManager {
         }, this.sourceId);
       }
 
-      await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
       logger.debug(`📡 Updated node with paxcounter data: ${nodeId}`);
     } catch (error) {
       logger.error('❌ Error processing paxcounter message:', error);
@@ -6868,7 +6868,7 @@ class MeshtasticManager implements ISourceManager {
       // Ensure from node exists in database (don't overwrite existing names)
       const existingFromNode = await databaseService.nodes.getNode(fromNum);
       if (!existingFromNode) {
-        await databaseService.nodes.upsertNode({
+        await databaseService.upsertNodeAsync({
           nodeNum: fromNum,
           nodeId: fromNodeId,
           longName: `Node ${fromNodeId}`,
@@ -6877,7 +6877,7 @@ class MeshtasticManager implements ISourceManager {
         }, this.sourceId);
       } else {
         // Just update lastHeard, don't touch the name
-        await databaseService.nodes.upsertNode({
+        await databaseService.upsertNodeAsync({
           nodeNum: fromNum,
           nodeId: fromNodeId,
           lastHeard: Date.now() / 1000
@@ -6887,7 +6887,7 @@ class MeshtasticManager implements ISourceManager {
       // Ensure to node exists in database (don't overwrite existing names)
       const existingToNode = await databaseService.nodes.getNode(toNum);
       if (!existingToNode) {
-        await databaseService.nodes.upsertNode({
+        await databaseService.upsertNodeAsync({
           nodeNum: toNum,
           nodeId: toNodeId,
           longName: `Node ${toNodeId}`,
@@ -6896,7 +6896,7 @@ class MeshtasticManager implements ISourceManager {
         }, this.sourceId);
       } else {
         // Just update lastHeard, don't touch the name
-        await databaseService.nodes.upsertNode({
+        await databaseService.upsertNodeAsync({
           nodeNum: toNum,
           nodeId: toNodeId,
           lastHeard: Date.now() / 1000
@@ -7004,7 +7004,7 @@ class MeshtasticManager implements ISourceManager {
         // Unknown hop — create a stub row with a placeholder name so future
         // lookups resolve. Real NodeInfo will overwrite the placeholder
         // fields and stamp a real lastHeard at that time.
-        await databaseService.nodes.upsertNode({
+        await databaseService.upsertNodeAsync({
           nodeNum: hopNum,
           nodeId: hopId,
           longName: `Node ${hopId}`,
@@ -7541,7 +7541,7 @@ class MeshtasticManager implements ISourceManager {
 
             logger.warn(`🔐 PKI error on request for node ${toNodeId}: ${errorDescription}`);
 
-            await databaseService.nodes.upsertNode({
+            await databaseService.upsertNodeAsync({
               nodeNum: toNum,
               nodeId: toNodeId,
               keyMismatchDetected: true,
@@ -7561,7 +7561,7 @@ class MeshtasticManager implements ISourceManager {
 
               logger.warn(`🔐 NO_CHANNEL on request detected for node ${toNodeId}: ${errorDescription}`);
 
-              await databaseService.nodes.upsertNode({
+              await databaseService.upsertNodeAsync({
                 nodeNum: toNum,
                 nodeId: toNodeId,
                 keyMismatchDetected: true,
@@ -7593,7 +7593,7 @@ class MeshtasticManager implements ISourceManager {
 
           logger.warn(`🔐 PKI error detected for node ${targetNodeId}: ${errorDescription}`);
 
-          await databaseService.nodes.upsertNode({
+          await databaseService.upsertNodeAsync({
             nodeNum: targetNodeNum,
             nodeId: targetNodeId,
             keyMismatchDetected: true,
@@ -7619,7 +7619,7 @@ class MeshtasticManager implements ISourceManager {
           // Flag the node with the key security issue (if not already flagged)
           const existingNode = await databaseService.nodes.getNode(targetNodeNum);
           if (!existingNode?.keyMismatchDetected) {
-            await databaseService.nodes.upsertNode({
+            await databaseService.upsertNodeAsync({
               nodeNum: targetNodeNum,
               nodeId: targetNodeId,
               keyMismatchDetected: true,
@@ -7757,7 +7757,7 @@ class MeshtasticManager implements ISourceManager {
 
       // Ensure sender node exists in database
       if (!senderNode) {
-        await databaseService.nodes.upsertNode({
+        await databaseService.upsertNodeAsync({
           nodeNum: fromNum,
           nodeId: fromNodeId,
           longName: `Node ${fromNodeId}`,
@@ -7809,7 +7809,7 @@ class MeshtasticManager implements ISourceManager {
         for (const vn of validNeighbors) {
           if (!existingNodes.has(vn.nodeNum)) {
             const neighborNodeId = `!${vn.nodeNum.toString(16).padStart(8, '0')}`;
-            await databaseService.nodes.upsertNode({
+            await databaseService.upsertNodeAsync({
               nodeNum: vn.nodeNum,
               nodeId: neighborNodeId,
               longName: `Node ${neighborNodeId}`,
@@ -8204,7 +8204,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // Upsert node first to ensure it exists before inserting telemetry
-      await databaseService.nodes.upsertNode(nodeData, this.sourceId);
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
 
       // Emit WebSocket event for node update
       dataEventEmitter.emitNodeUpdate(Number(nodeInfo.num), nodeData, this.sourceId);
@@ -13710,7 +13710,7 @@ class MeshtasticManager implements ISourceManager {
         if (this.localNodeInfo) {
           const localNodeNum = this.localNodeInfo.nodeNum;
           const localNodeId = `!${localNodeNum.toString(16).padStart(8, '0')}`;
-          await databaseService.nodes.upsertNode({
+          await databaseService.upsertNodeAsync({
             nodeNum: localNodeNum,
             nodeId: localNodeId,
             latitude,

--- a/src/server/meshtasticManager.virtualNode.test.ts
+++ b/src/server/meshtasticManager.virtualNode.test.ts
@@ -51,6 +51,8 @@ vi.mock('../services/database.js', () => {
       setSetting: vi.fn().mockResolvedValue(undefined),
     },
     getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    // #3796: meshtasticManager routes node writes through upsertNodeAsync.
+    upsertNodeAsync: vi.fn().mockResolvedValue(undefined),
     sources: {
       getSource: vi.fn().mockResolvedValue(null),
     },

--- a/src/services/database.service.test.ts
+++ b/src/services/database.service.test.ts
@@ -765,4 +765,40 @@ describe('DatabaseService.upsertNodeAsync — new node notification (#3796)', ()
 
     expect(mockNodesRepo.upsertNode).toHaveBeenCalledTimes(1);
   });
+
+  it('does NOT re-notify a node that was already complete before the upsert (reconnect/NodeDB re-dump)', async () => {
+    // The node already exists complete in the DB — e.g. the device reconnects
+    // and re-dumps its known NodeDB. isNodeComplete(existingNode) is true, so
+    // the incomplete->complete transition never happens and we must stay quiet.
+    vi.mocked(isNodeComplete).mockReturnValue(true);
+    getNodeSpy.mockReturnValue({
+      nodeNum: 0x5555eeee,
+      nodeId: '!5555eeee',
+      longName: 'Already Known',
+      shortName: 'AK',
+      hwModel: 4,
+    } as any);
+
+    await databaseService.upsertNodeAsync(
+      { nodeNum: 0x5555eeee, nodeId: '!5555eeee', longName: 'Already Known', shortName: 'AK', hwModel: 4 },
+      'src1'
+    );
+
+    await settle();
+    expect(mockNotifyNewNode).not.toHaveBeenCalled();
+  });
+
+  it('dedupes across sources — a node notified on src1 does not re-notify on src2 (nodeNum-keyed)', async () => {
+    // newNodeNotifiedSet is keyed by nodeNum only, so the same physical node
+    // seen on a second source in the same process run notifies just once.
+    vi.mocked(isNodeComplete).mockReturnValue(true);
+    const node = { nodeNum: 0x6666ffff, nodeId: '!6666ffff', longName: 'Multi Source', shortName: 'MS', hwModel: 7 };
+
+    await databaseService.upsertNodeAsync(node, 'src1');
+    await vi.waitFor(() => expect(mockNotifyNewNode).toHaveBeenCalledTimes(1));
+
+    await databaseService.upsertNodeAsync(node, 'src2');
+    await settle();
+    expect(mockNotifyNewNode).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/services/database.service.test.ts
+++ b/src/services/database.service.test.ts
@@ -6,7 +6,7 @@
  *
  * @vitest-environment node
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ─── Mock config before singleton construction ────────────────────────────────
 
@@ -215,9 +215,16 @@ vi.mock('../utils/themeValidation.js', () => ({
   OPTIONAL_THEME_COLORS: [],
 }));
 
+// notifyNewNode is reached via a dynamic import inside maybeNotifyNewNode (#3796).
+const mockNotifyNewNode = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../server/services/notificationService.js', () => ({
+  notificationService: { notifyNewNode: mockNotifyNewNode },
+}));
+
 // ─── Import singleton AFTER all mocks ────────────────────────────────────────
 
 import databaseService from './database.js';
+import { isNodeComplete } from '../utils/nodeHelpers.js';
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -677,5 +684,85 @@ describe('DatabaseService — checkPermissionAsync', () => {
       // User 7: nothing
       expect(await databaseService.checkPermissionAsync(7, 'messages', 'read', 'src-A')).toBe(false);
     });
+  });
+});
+
+// ─── upsertNodeAsync new-node notification (#3796) ───────────────────────────
+//
+// Regression for the bug where directly-connected Meshtastic nodes never
+// triggered a "Newly Found Node" notification: meshtasticManager wrote nodes
+// via databaseService.nodes.upsertNode() (the repo) which bypassed the notify
+// logic. It now routes through databaseService.upsertNodeAsync(), which fires
+// notifyNewNode on the incomplete -> complete transition.
+describe('DatabaseService.upsertNodeAsync — new node notification (#3796)', () => {
+  let getNodeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockNotifyNewNode.mockClear();
+    mockNodesRepo.upsertNode.mockClear();
+    // Default: nodes are incomplete unless a test opts in. No pre-existing node.
+    vi.mocked(isNodeComplete).mockReturnValue(false);
+    getNodeSpy = vi.spyOn(databaseService, 'getNode').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    getNodeSpy.mockRestore();
+    vi.mocked(isNodeComplete).mockReturnValue(false);
+  });
+
+  // maybeNotifyNewNode fires via a dynamic import().then() — give those
+  // microtasks a chance to settle before asserting a NON-call.
+  const settle = async () => {
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  };
+
+  it('fires notifyNewNode when a directly-connected node first becomes complete', async () => {
+    vi.mocked(isNodeComplete).mockReturnValue(true);
+
+    await databaseService.upsertNodeAsync(
+      { nodeNum: 0x1111aaaa, nodeId: '!1111aaaa', longName: 'Rover One', shortName: 'RV1', hwModel: 31 },
+      'src1'
+    );
+
+    await vi.waitFor(() => expect(mockNotifyNewNode).toHaveBeenCalledTimes(1));
+    expect(mockNotifyNewNode).toHaveBeenCalledWith(
+      '!1111aaaa', 'Rover One', 'RV1', 31, undefined, 'src1', expect.any(String)
+    );
+  });
+
+  it('does NOT fire for an incomplete node (no NodeInfo received yet)', async () => {
+    vi.mocked(isNodeComplete).mockReturnValue(false);
+
+    await databaseService.upsertNodeAsync(
+      { nodeNum: 0x2222bbbb, nodeId: '!2222bbbb' },
+      'src1'
+    );
+
+    await settle();
+    expect(mockNotifyNewNode).not.toHaveBeenCalled();
+  });
+
+  it('dedupes — a second upsert of the same node does not re-notify', async () => {
+    vi.mocked(isNodeComplete).mockReturnValue(true);
+    const node = { nodeNum: 0x3333cccc, nodeId: '!3333cccc', longName: 'Rover Two', shortName: 'RV2', hwModel: 9 };
+
+    await databaseService.upsertNodeAsync(node, 'src1');
+    await vi.waitFor(() => expect(mockNotifyNewNode).toHaveBeenCalledTimes(1));
+
+    await databaseService.upsertNodeAsync(node, 'src1');
+    await settle();
+    expect(mockNotifyNewNode).toHaveBeenCalledTimes(1);
+  });
+
+  it('still persists the node through the repository', async () => {
+    vi.mocked(isNodeComplete).mockReturnValue(true);
+
+    await databaseService.upsertNodeAsync(
+      { nodeNum: 0x4444dddd, nodeId: '!4444dddd', longName: 'Rover Three', shortName: 'RV3', hwModel: 1 },
+      'src1'
+    );
+
+    expect(mockNodesRepo.upsertNode).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2304,30 +2304,8 @@ class DatabaseService {
           logger.error('Failed to upsert node:', err);
         });
 
-        // Send new node notification when a node becomes complete (has longName, shortName, hwModel)
-        // This defers the notification until we have meaningful info instead of just a raw node ID
-        const wasComplete = existingNode ? isNodeComplete(existingNode) : false;
-        if (nodeData.nodeNum !== 4294967295 && !wasComplete &&
-            !this.newNodeNotifiedSet.has(nodeData.nodeNum) && isNodeComplete(updatedNode)) {
-          this.newNodeNotifiedSet.add(nodeData.nodeNum);
-          const newNodeSourceId = (updatedNode as any).sourceId ?? (nodeData as any).sourceId ?? 'default';
-          import('../server/services/notificationService.js').then(async ({ notificationService }) => {
-            let sourceName = newNodeSourceId;
-            try {
-              const src = await this.sources.getSource(newNodeSourceId);
-              if (src?.name) sourceName = src.name;
-            } catch { /* fall back to id */ }
-            await notificationService.notifyNewNode(
-              updatedNode.nodeId!,
-              updatedNode.longName!,
-              updatedNode.shortName!,
-              updatedNode.hwModel ?? undefined,
-              updatedNode.hopsAway,
-              newNodeSourceId,
-              sourceName
-            );
-          }).catch(err => logger.error('Failed to send new node notification:', err));
-        }
+        // Send new node notification when a node becomes complete (#3796).
+        this.maybeNotifyNewNode(nodeData, existingNode, upsertSourceId);
       }
       return;
     }
@@ -2358,39 +2336,98 @@ class DatabaseService {
       logger.debug(`Re-applied ignore flag for node ${nodeData.nodeNum} (per-source blocklist)`);
     }
 
-    // Send new node notification when a node becomes complete (has longName, shortName, hwModel)
-    // This defers the notification until we have meaningful info instead of just a raw node ID
-    // For SQLite, build the merged node state to check completeness (COALESCE merges in SQL)
-    if (nodeData.nodeNum !== 4294967295 && !this.newNodeNotifiedSet.has(nodeData.nodeNum)) {
-      const wasComplete = existingNode ? isNodeComplete(existingNode) : false;
-      if (!wasComplete) {
-        const mergedNode = {
-          nodeId: nodeData.nodeId ?? existingNode?.nodeId,
-          longName: nodeData.longName ?? existingNode?.longName,
-          shortName: nodeData.shortName ?? existingNode?.shortName,
-          hwModel: nodeData.hwModel ?? existingNode?.hwModel,
-        };
-        if (isNodeComplete(mergedNode)) {
-          this.newNodeNotifiedSet.add(nodeData.nodeNum);
-          const newNodeSourceId = (nodeData as any).sourceId ?? (existingNode as any)?.sourceId ?? 'default';
-          import('../server/services/notificationService.js').then(async ({ notificationService }) => {
-            let sourceName = newNodeSourceId;
-            try {
-              const src = await this.sources.getSource(newNodeSourceId);
-              if (src?.name) sourceName = src.name;
-            } catch { /* fall back to id */ }
-            await notificationService.notifyNewNode(
-              mergedNode.nodeId!,
-              mergedNode.longName!,
-              mergedNode.shortName!,
-              mergedNode.hwModel ?? undefined,
-              nodeData.hopsAway ?? existingNode?.hopsAway,
-              newNodeSourceId,
-              sourceName
-            );
-          }).catch(err => logger.error('Failed to send new node notification:', err));
-        }
-      }
+    // Send new node notification when a node becomes complete (#3796).
+    this.maybeNotifyNewNode(nodeData, existingNode, upsertSourceIdSqlite);
+  }
+
+  /**
+   * Fire the "new node discovered" notification when an upsert moves a node
+   * from incomplete -> complete (has longName + shortName + hwModel) for the
+   * first time. Deduped per-process via newNodeNotifiedSet, and gated against
+   * the node's prior persisted state so a device re-dumping its known NodeDB on
+   * reconnect does NOT re-notify already-complete nodes. Fire-and-forget — it
+   * never blocks the caller.
+   *
+   * Shared by upsertNode() (the sync MQTT path) and upsertNodeAsync() (the
+   * direct Meshtastic path) so both behave identically (issue #3796).
+   */
+  private maybeNotifyNewNode(
+    // Minimal structural shape so both the local-DbNode wrapper path and the
+    // repo-DbNode upsertNodeAsync path can pass their node objects without a
+    // cast (the two DbNode definitions differ on unrelated fields).
+    nodeData: {
+      nodeNum?: number | null;
+      nodeId?: string | null;
+      longName?: string | null;
+      shortName?: string | null;
+      hwModel?: number | null;
+      hopsAway?: number | null;
+      sourceId?: string | null;
+    },
+    existingNode: DbNode | null | undefined,
+    sourceId?: string
+  ): void {
+    const nodeNum = nodeData.nodeNum;
+    if (nodeNum === undefined || nodeNum === null || nodeNum === 4294967295) return;
+    if (this.newNodeNotifiedSet.has(nodeNum)) return;
+
+    // Only notify on the incomplete -> complete transition, never for a node
+    // that was already complete before this upsert.
+    const wasComplete = existingNode ? isNodeComplete(existingNode) : false;
+    if (wasComplete) return;
+
+    const mergedNode = {
+      nodeId: nodeData.nodeId ?? existingNode?.nodeId,
+      longName: nodeData.longName ?? existingNode?.longName,
+      shortName: nodeData.shortName ?? existingNode?.shortName,
+      hwModel: nodeData.hwModel ?? existingNode?.hwModel,
+    };
+    if (!isNodeComplete(mergedNode)) return;
+
+    this.newNodeNotifiedSet.add(nodeNum);
+    const newNodeSourceId = sourceId ?? (nodeData as any).sourceId ?? (existingNode as any)?.sourceId ?? 'default';
+    import('../server/services/notificationService.js').then(async ({ notificationService }) => {
+      let sourceName = newNodeSourceId;
+      try {
+        const src = await this.sources.getSource(newNodeSourceId);
+        if (src?.name) sourceName = src.name;
+      } catch { /* fall back to id */ }
+      await notificationService.notifyNewNode(
+        mergedNode.nodeId!,
+        mergedNode.longName!,
+        mergedNode.shortName!,
+        mergedNode.hwModel ?? undefined,
+        (nodeData.hopsAway ?? existingNode?.hopsAway) ?? undefined,
+        newNodeSourceId,
+        sourceName
+      );
+    }).catch(err => logger.error('Failed to send new node notification:', err));
+  }
+
+  /**
+   * Async node upsert that ALSO fires the new-node notification. The direct
+   * Meshtastic path (meshtasticManager) previously called
+   * databaseService.nodes.upsertNode() directly, bypassing the notification
+   * logic that lived only in the sync upsertNode() wrapper — so "Newly Found
+   * Node" notifications never fired for directly-connected Meshtastic nodes
+   * (issue #3796). This wraps the same repository write and adds the shared
+   * completeness/dedup-gated notification check.
+   */
+  async upsertNodeAsync(nodeData: Parameters<NodesRepository['upsertNode']>[0], sourceId?: string): Promise<void> {
+    const nodeNum = nodeData.nodeNum;
+    const sid = sourceId ?? (nodeData as any).sourceId;
+
+    // Only pay for the pre-upsert read when this node could still need a
+    // notification (not yet notified, not the broadcast address). Once a node
+    // has been notified this short-circuits to a single Set lookup.
+    const needsCheck = nodeNum !== undefined && nodeNum !== null &&
+      nodeNum !== 4294967295 && !this.newNodeNotifiedSet.has(nodeNum);
+    const existingNode = needsCheck ? this.getNode(nodeNum!, sid) : null;
+
+    await this.nodes.upsertNode(nodeData, sid);
+
+    if (needsCheck) {
+      this.maybeNotifyNewNode(nodeData, existingNode, sid);
     }
   }
 


### PR DESCRIPTION
## Summary
"Newly Found Node" notifications never fired for directly-connected (serial/TCP) Meshtastic nodes. The `notifyNewNode` call lived **only** inside the sync `DatabaseService.upsertNode()` wrapper, which the MQTT ingestion path uses — but `meshtasticManager` wrote nodes through `databaseService.nodes.upsertNode()` (the async repository), bypassing the wrapper and its notification logic entirely. This routes the direct path through a notification-aware upsert so the feature works for the reporter's setup (Apprise + Discord, direct node).

## Root cause
- `notifyNewNode` was invoked only from `DatabaseService.upsertNode()` (the sync wrapper).
- `meshtasticManager.processNodeInfoMessageProtobuf()` and ~30 other node writes call `databaseService.nodes.upsertNode()` directly → no notification.
- Test/traceroute notifications call `notificationService` directly (unaffected); MeshCore has its own `notifyNewNodeDiscovered()` callback (unaffected) — which is why only the direct Meshtastic path was broken.

## Changes
- **Extract** the incomplete→complete detection + dedup + notify block (previously duplicated in the PG/MySQL and SQLite branches of `upsertNode`) into a shared `DatabaseService.maybeNotifyNewNode()` helper.
- **Add `DatabaseService.upsertNodeAsync()`** — wraps the same repository write and runs the shared notification check. Short-circuits to a single `Set` lookup once a node has been notified, keeping the hot path cheap.
- **Reroute all 31 `databaseService.nodes.upsertNode()` calls** in `meshtasticManager.ts` through `upsertNodeAsync()`. The shared `newNodeNotifiedSet` dedups across the MQTT and direct paths, and the `wasComplete` check against persisted state means a device re-dumping its NodeDB on reconnect does **not** re-notify already-known nodes (no reconnect flood).

## Why reroute all sites (not just NodeInfo)
A node becomes "complete" (gets `longName`+`shortName`+`hwModel`) primarily via NodeInfo, but also via the device's NodeDB bulk-sync on connect. Routing every node write through the gated, deduped check catches whichever path first completes a node, without spamming — `isNodeComplete` rejects `"Node !…"` placeholders and the dedup set prevents repeats.

## Issues Resolved
Fixes #3796

## Documentation Updates
No documentation changes needed (internal notification plumbing; no API/config surface change).

## Testing
- [x] Unit tests pass (full suite: 7653 passed, 0 failed, 0 suite failures)
- [x] TypeScript compiles cleanly (`tsconfig.server.json`; only pre-existing `TelemetryChart.tsx` noise remains)
- [x] New `upsertNodeAsync` notification suite: fires on incomplete→complete, skips incomplete nodes, dedups a second upsert, still persists via the repository
- [x] Updated the 4 `meshtasticManager` mocks that assert on the upsert call (delegating `upsertNodeAsync`); all 655 meshtasticManager tests pass
- [ ] Manual: connect a Meshtastic node directly, enable "Newly Found Node" notifications, and confirm an Apprise notification fires when a new node's NodeInfo arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)