### PR TITLE
fix(position): ground_speed is km/h, not m/s — fixes ~3.6× speed inflation (#3797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - **MeshCore: source unusable after a manual disconnect** — Disconnecting a MeshCore source from the UI removed its manager from the registry, so every `/meshcore/*` route returned "No MeshCore manager for source" and the source could not be reconnected without a container restart. Disconnect now keeps the manager registered (tearing down only the device link), so reconnect works cleanly. (#3705)
 - **MeshCore: undetected socket drops** — A socket/serial-level link drop left the manager stuck "connected", so the Virtual Node server served a stale identity and real sends silently failed with no recovery. The manager now detects backend disconnects and either auto-reconnects or cleanly marks the source disconnected. (#3705)
+- **Position speed inflated ~3.6× (ground_speed unit)** — Meshtastic's `ground_speed` is **km/h** on the wire (the firmware writes it from TinyGPS++ `.kmph()`), not m/s as the protobuf comment claims. MeshMonitor was multiplying it by 3.6 as if m/s, so a node reporting `90` showed as 324 km/h in position-history popups, node popups, and telemetry. Speed is now displayed and stored as km/h. (#3797)
 
 ## [4.11.3] - 2026-06-21
 

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -8,7 +8,7 @@ export interface PositionHistoryItem {
   longitude: number;
   timestamp: number;
   altitude?: number;
-  groundSpeed?: number;   // m/s
+  groundSpeed?: number;   // km/h (firmware emits ground_speed via TinyGPS++ .kmph(); see #3797)
   groundTrack?: number;   // degrees (0-360, 0=North)
   // Receive metadata of the packet this fix arrived in (#3492). Only present
   // for fixes received after migration 089. SNR is only meaningful when the

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -204,7 +204,7 @@ const TYPE_UNITS: Record<string, string> = {
   latitude: '°',
   longitude: '°',
   altitude: 'm',
-  ground_speed: 'm/s',
+  ground_speed: 'km/h',
   ground_track: '°',
   estimated_latitude: '°',
   estimated_longitude: '°',

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6239,12 +6239,13 @@ class MeshtasticManager implements ISourceManager {
           }, this.sourceId);
         }
 
-        // Store ground speed if available (in m/s)
+        // Store ground speed if available. The firmware emits ground_speed in
+        // km/h (TinyGPS++ .kmph()), not m/s as the proto comment claims (#3797).
         const groundSpeed = position.groundSpeed ?? position.ground_speed;
         if (groundSpeed !== undefined && groundSpeed > 0) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'ground_speed',
-            timestamp, value: groundSpeed, unit: 'm/s', createdAt: now, packetTimestamp, packetId,
+            timestamp, value: groundSpeed, unit: 'km/h', createdAt: now, packetTimestamp, packetId,
             channel: channelIndex
           }, this.sourceId);
         }
@@ -8241,7 +8242,7 @@ class MeshtasticManager implements ISourceManager {
         if (positionTelemetryData.groundSpeed !== undefined && positionTelemetryData.groundSpeed > 0) {
           telemetryBatch.push({
             nodeId, nodeNum: nodeNumForTelemetry, telemetryType: 'ground_speed',
-            timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.groundSpeed, unit: 'm/s', createdAt: now,
+            timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.groundSpeed, unit: 'km/h', createdAt: now,
             channel: positionTelemetryData.channel
           });
         }

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -315,17 +315,19 @@ describe('mapHelpers', () => {
   });
 
   describe('convertSpeed', () => {
-    it('should convert m/s to km/h for metric units', () => {
-      // 10 m/s = 36 km/h
-      const result = convertSpeed(10, 'km');
+    // ground_speed is already km/h on the wire (firmware writes TinyGPS++
+    // .kmph()), so metric is a pass-through and imperial applies only the
+    // km/h→mph factor. See #3797 — we previously multiplied by 3.6 as if m/s.
+    it('passes km/h through unchanged for metric units', () => {
+      const result = convertSpeed(36, 'km');
       expect(result.speed).toBe(36);
       expect(result.unit).toBe('km/h');
     });
 
-    it('should convert m/s to mph for imperial units', () => {
-      // 10 m/s = 36 km/h = 22.4 mph
-      const result = convertSpeed(10, 'mi');
-      expect(result.speed).toBeCloseTo(22.4, 1);
+    it('converts km/h to mph for imperial units', () => {
+      // 100 km/h = 62.1 mph
+      const result = convertSpeed(100, 'mi');
+      expect(result.speed).toBeCloseTo(62.1, 1);
       expect(result.unit).toBe('mph');
     });
 
@@ -335,29 +337,29 @@ describe('mapHelpers', () => {
       expect(result.unit).toBe('km/h');
     });
 
-    it('should handle high speeds without misinterpretation (regression)', () => {
-      // 80 m/s = 288 km/h — this is a valid high speed (e.g. vehicle on highway)
-      // Previously a heuristic would reinterpret speeds > 200 km/h as already in km/h
-      const result = convertSpeed(80, 'km');
-      expect(result.speed).toBe(288);
+    it('does not inflate the wire value (regression #3797)', () => {
+      // A wire ground_speed of 90 means 90 km/h, NOT 324 km/h (90 × 3.6) and
+      // NOT 0.9 m/s — it must display as the same number for metric.
+      const result = convertSpeed(90, 'km');
+      expect(result.speed).toBe(90);
+      expect(result.unit).toBe('km/h');
+    });
+
+    it('should handle a valid high speed (e.g. vehicle on highway)', () => {
+      const result = convertSpeed(120, 'km');
+      expect(result.speed).toBe(120);
       expect(result.unit).toBe('km/h');
     });
 
     it('should handle typical walking speed', () => {
-      // 1.4 m/s ≈ 5.0 km/h (walking)
-      const result = convertSpeed(1.4, 'km');
+      // ~5 km/h walking pace passes through.
+      const result = convertSpeed(5, 'km');
       expect(result.speed).toBeCloseTo(5.0, 1);
     });
 
-    it('should handle typical driving speed', () => {
-      // 27.8 m/s ≈ 100 km/h
-      const result = convertSpeed(27.8, 'km');
-      expect(result.speed).toBeCloseTo(100.1, 1);
-    });
-
     it('should produce consistent results between metric and imperial', () => {
-      const metric = convertSpeed(10, 'km');
-      const imperial = convertSpeed(10, 'mi');
+      const metric = convertSpeed(100, 'km');
+      const imperial = convertSpeed(100, 'mi');
       // mph = km/h * 0.621371
       expect(imperial.speed).toBeCloseTo(metric.speed * 0.621371, 0);
     });

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -443,8 +443,9 @@ export const generatePositionHistoryArrows = (
     const dateStr = date.toLocaleDateString();
     const timeStr = date.toLocaleTimeString();
 
-    // Format speed (convert from m/s to km/h, then to mph if needed)
-    // Meshtastic protobuf defines ground_speed as m/s (uint32)
+    // Format speed. ground_speed is km/h on the wire (firmware writes
+    // TinyGPS++ .kmph(), despite the proto saying m/s) — convertSpeed only
+    // applies the imperial km/h→mph factor, no m/s scaling. See #3797.
     let speedDisplay: string | null = null;
     let speedUnit = distanceUnit === 'mi' ? 'mph' : 'km/h';
     if (item.groundSpeed !== undefined) {

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -324,7 +324,7 @@ export const getPositionHistoryColor = (
  * @param start Starting position [lat, lng]
  * @param end Ending position [lat, lng]
  * @param heading Ground track in degrees (0 = North, clockwise)
- * @param speed Ground speed in m/s (affects control point distance)
+ * @param speed Ground speed in km/h (affects control point distance; see #3797)
  * @param segments Number of segments to generate (default 10 for position history)
  * @returns Array of [lat, lng] points forming the curved path
  */

--- a/src/utils/speedConversion.ts
+++ b/src/utils/speedConversion.ts
@@ -1,10 +1,18 @@
 /**
- * Convert ground speed from m/s (Meshtastic protobuf uint32) to display units.
- * Returns { speed, unit } where speed is rounded to 1 decimal place.
+ * Convert a Meshtastic ground_speed value to the user's display unit.
+ *
+ * The value is already in km/h: the firmware writes `ground_speed` from
+ * TinyGPS++ `reader.speed.kmph()` (see GPS::lookForLocation in the Meshtastic
+ * firmware), so it is kilometers/hour on the wire — despite the mesh.proto
+ * comment claiming "m/s". We previously multiplied by 3.6 as if it were m/s,
+ * inflating every speed by ~3.6× (a wire value of 90 showed as 324 km/h). See
+ * issue #3797.
+ *
+ * Returns { speed, unit } where speed is rounded to 1 decimal place. For
+ * imperial, applies only the km/h→mph factor.
  */
-export function convertSpeed(metersPerSecond: number, distanceUnit: string): { speed: number; unit: string } {
-  const speedKmh = metersPerSecond * 3.6;
-  const speed = distanceUnit === 'mi' ? speedKmh * 0.621371 : speedKmh;
+export function convertSpeed(kilometersPerHour: number, distanceUnit: string): { speed: number; unit: string } {
+  const speed = distanceUnit === 'mi' ? kilometersPerHour * 0.621371 : kilometersPerHour;
   const unit = distanceUnit === 'mi' ? 'mph' : 'km/h';
   return { speed: parseFloat(speed.toFixed(1)), unit };
 }


### PR DESCRIPTION
## Summary
Position speeds (history popups, node popups, telemetry) were over-reported by ~3.6×: a node reporting `ground_speed = 90` displayed as **324 km/h**. The root cause is a unit mismatch — Meshtastic's `ground_speed` is **km/h** on the wire, but MeshMonitor treated it as **m/s** and multiplied by 3.6.

## Verification — the field is km/h, not m/s

The protobuf *comment* says m/s, but that comment is wrong; the firmware transmits km/h. The GPS path sets the field in exactly one place, using the TinyGPS++ km/h accessor:

```cpp
// src/gps/GPS.cpp — GPS::lookForLocation()
p.ground_speed = reader.speed.kmph();   // TinyGPS++ .kmph() → km/h
```
https://github.com/meshtastic/firmware/blob/a4b2021782d3e323b8fdc6da166f4305c53c6181/src/gps/GPS.cpp#L1824

`PositionModule` copies it through with no conversion:
https://github.com/meshtastic/firmware/blob/a4b2021782d3e323b8fdc6da166f4305c53c6181/src/modules/PositionModule.cpp#L260

So `90` on the wire = 90 km/h. Our `convertSpeed()` did `value * 3.6` (m/s→km/h) ⇒ 324 km/h.

> The original ticket guessed the field is **cm/s** (~100× error). That's also incorrect: the real factor is **3.6×** and the unit is **km/h**. The ticket's proposed ÷100 fix would wrongly render a genuine 90 km/h as 3.2 km/h. I've also opened an upstream doc fix: meshtastic/protobufs#963.

## Changes
- `src/utils/speedConversion.ts` — `convertSpeed()` now treats its input as km/h: metric passes through, imperial applies only the km/h→mph factor (drops the bogus ×3.6).
- `src/server/meshtasticManager.ts` (×2) — stored `ground_speed` telemetry unit relabeled `m/s` → `km/h` (the value was always km/h, so existing rows display correctly via `convertSpeed` — **no migration needed**).
- `src/pages/UnifiedTelemetryPage.tsx` — telemetry unit label `m/s` → `km/h`.
- `src/utils/mapHelpers.tsx`, `src/contexts/MapContext.tsx` — corrected misleading "m/s" comments.
- `src/utils/mapHelpers.test.tsx` — rewrote the `convertSpeed` suite for km/h semantics + a #3797 regression (`90 → 90`, not 324).

## Issues Resolved
Fixes #3797. Relates to #3791 (Bug 3, inflated position-segment velocity).

## Documentation Updates
- `CHANGELOG.md` — Fixed entry under \[Unreleased].

## Testing
- [x] Unit tests pass (full suite: 7660 passed, 0 failed, 0 suite failures)
- [x] TypeScript compiles cleanly (no new errors in changed files)
- [x] `convertSpeed` regression: `90 → 90 km/h` (metric), `100 → 62.1 mph` (imperial), `0 → 0`
- [ ] Reviewer: open a node's position history, click a fix — Speed should read a sane value (raw wire value as km/h), not ~3.6× inflated

🤖 Generated with [Claude Code](https://claude.com/claude-code)