### PR TITLE
release: 4.12.0 — version bump + PR audit & docs-site catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.12.0] - 2026-06-26
+
 ### Added
 - **MeshCore source heartbeat / auto-reconnect** — MeshCore sources now expose a user-configurable **Heartbeat** interval (seconds, 0 = off) in the source form, mirroring Meshtastic. When set, the Companion node is probed periodically and the source reconnects automatically with exponential backoff on repeated failure. (#3705)
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.12.0-rc2",
+  "version": "4.12.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.12.0-rc2",
+  "version": "4.12.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -114,6 +114,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'Automation', link: '/features/automation' },
+            { text: 'Automation Engine', link: '/features/automation-engine' },
             { text: 'Geofence Triggers', link: '/features/geofence-triggers' },
             { text: 'Auto Heap Management', link: '/features/auto-heap-management' },
             { text: 'Push Notifications', link: '/features/notifications' }

--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -1,0 +1,300 @@
+# Automation Engine
+
+<!-- This page documents the {{ token }} substitution syntax. The body is wrapped
+     in a v-pre block so VitePress/Vue renders the literal double-brace tokens
+     instead of evaluating them as Vue interpolation (which breaks the build). -->
+<div v-pre>
+
+::: tip New in 4.12
+A generic, visual **"when this happens, do that"** builder — Home Assistant / Node-RED / IFTTT-inspired — that lets you create your own automations instead of relying on the hardcoded ones. It runs **globally across every source**, with optional per-source scoping.
+:::
+
+The Automation Engine lives on its own top-level **Automations** tab. It complements the
+[legacy Automation features](/features/automation) (Auto Acknowledge, Auto Traceroute, Auto Ping,
+Auto Responder, Auto Announce, …): those remain available and unchanged, while the engine is the
+flexible "build it yourself" alternative. Where a legacy automation gives you one fixed form, the
+engine lets you wire a **trigger → conditions → actions** graph for almost any behavior you can
+describe.
+
+## Overview
+
+Each automation is a small graph built in a guided, linear builder:
+
+```
+WHEN  →  RULE (IF … THEN …)  →  optional FINALLY (combine the rules' results)
+```
+
+- **WHEN** — exactly one **trigger** that starts the automation (a message arrives, telemetry
+  crosses a threshold, a schedule fires, …).
+- **RULE** — one or more **conditions** that decide whether to act, each routing to its own
+  **actions** (the IF/THEN). Conditions are routers with a *true* and a *false* path, so you build
+  If / ElseIf / Else logic instead of the old fixed routing matrices.
+- **FINALLY** *(optional)* — a combine step that runs its actions based on how the rules turned out:
+  **ANY**, **ALL**, **NONE**, or **ALWAYS** (unconditionally).
+
+Key properties:
+
+- **Global by design.** An automation evaluates events from **all** connected sources at once
+  (like Map Analysis), rather than being tied to a single radio. Use a **Source filter** condition
+  (below) to scope a workflow to a subset of sources when you want.
+- **Permission-gated.** The tab and its API are gated by a dedicated global `automations`
+  permission, separate from the legacy per-source `automation` permission.
+- **Cooldown / rate-limit** per automation prevents mesh spam, plus a per-run action cap and a
+  loop guard so an automation can't runaway-recurse.
+- **Variables** — a separate management area for user-defined values (constants and runtime
+  flags/counters) referenced anywhere as `{{ var.name }}`.
+- **Run log** — every fire is recorded with its per-step outcome for debugging.
+- **JSON import/export** — automations export to JSON (personal node ids are rewritten to portable
+  system tokens). Imported automations always land **disabled** for review.
+- **Test / dry-run panel** — preview an automation against a synthetic event with no mesh traffic,
+  no notifications, and nothing saved.
+
+## Triggers
+
+Every automation has exactly one trigger (the **WHEN**). Each trigger exposes a set of
+`{{ trigger.* }}` fields you can use in conditions and message text (see [Tokens](#tokens)).
+
+| Trigger | Fires when… | Notable options |
+| --- | --- | --- |
+| **A message is received** | A text/packet message arrives | `Text contains` (case-insensitive substring), `Text matches regex`, channel match, `From node #` |
+| **A new node is discovered** | A node is seen for the first time | — |
+| **A node is updated** | A node record changes (name, role, position, …) | — |
+| **Telemetry is received** | A telemetry reading arrives | `Metric` filter (battery, voltage, temperature, channel utilization, air util TX, …) |
+| **On a schedule** | A cron expression fires | 5-field cron expression |
+| **A system event** | An engine/source lifecycle event | `System start`, `Source came online`, `Source went offline`, `Upgrade available` |
+| **A node enters/leaves a region** | A node crosses a geofence | `Enters` / `Leaves` / `Moves while inside (dwell)`, plus a map region editor |
+
+### Message trigger & channel-name matching
+
+The message trigger can filter on text (substring or regex) and on the **channel**. Prefer matching
+by **channel name** (`On channel (name)`) rather than raw slot index: the same logical channel can
+sit in a different slot on different sources, so a name match is portable across your whole mesh.
+The raw `On channel #` index is still available for single-source cases.
+
+### Schedule trigger (live cron)
+
+The schedule trigger fires on a standard **5-field cron** expression (e.g. `0 * * * *` = top of
+every hour). It is backed by a live [croner](https://github.com/Hexagon/croner) job:
+
+- A cron job is armed per enabled schedule automation; **create / update / enable / disable /
+  delete** all re-arm correctly (the old job is stopped first, so there are never stale or
+  duplicate jobs).
+- The per-automation **cooldown** is honored on each fire.
+- The cron is **validated at save time** (5-field, no seconds) — an invalid expression is rejected
+  in the builder rather than silently never firing.
+
+Because a schedule has no triggering message and no subject node, a **Send a message** action under
+a schedule trigger **must name a target source** (see [Send a message](#send-a-message)).
+
+### System trigger
+
+Fires on engine/source lifecycle events: **System start** (MeshMonitor booted), **Source came
+online**, **Source went offline**, and **Upgrade available** (a new release was detected). The
+upgrade event exposes `{{ trigger.latestVersion }}` and `{{ trigger.currentVersion }}` for use in a
+notification.
+
+### Geofence trigger
+
+Defines a geographic region and fires when a node **enters**, **leaves**, or **dwells (moves while
+inside)** it. The region is drawn directly on a Leaflet map — either a **circle** (center + radius)
+or a **polygon** — using the shared geofence map editor. Evaluation is shape-aware (point-in-circle
+or polygon ray-cast). See also the dedicated [Geofence Triggers](/features/geofence-triggers) page.
+
+## Conditions
+
+Conditions form the **IF** of each rule. Each condition is a *router*: matched events follow its
+**true** path to one set of actions, and non-matching events can follow a **false** path to a
+different set — this is how If / ElseIf / Else is built.
+
+| Condition | What it checks |
+| --- | --- |
+| **Always (no filtering)** | A pass-through that always matches — use it when a rule should act unconditionally |
+| **Number comparison** | A numeric field (`==`, `!=`, `>`, `<`, `>=`, `<=`). Fields come from the event (e.g. hop count, SNR/RSSI), the hydrated **node** record (battery, hops away, role, position, age, …), or the node's **latest telemetry**. The value can be a literal or `{{ var.name }}` |
+| **Text comparison** | A string field (`contains`, `equals`, `starts with`, `ends with`, `matches regex`, `doesn't contain`) over message text, node name/role, etc. |
+| **Source is one of…** | The **Source filter** — restricts the workflow to a chosen subset of sources (the "global but scopeable" knob). Leave empty to allow any source |
+| **Distance from a point** | The subject node is within / farther than *N* km of a reference lat/lon |
+| **Variable check** | Compares a [user-defined variable](#variables) against a literal or another value; with no operator it tests "is set / flag raised?" |
+| **Time of day** | The current time is within an `HH:MM`–`HH:MM` window |
+
+A missing or undefined field never throws — numeric/string comparisons against it simply evaluate
+**false**.
+
+### FINALLY combine modes
+
+The optional FINALLY step runs its own actions based on the combined results of the preceding rules:
+
+- **ANY** — at least one rule matched.
+- **ALL** — every rule matched.
+- **NONE** — no rule matched.
+- **ALWAYS** — run unconditionally, regardless of the rules.
+
+To make a rule contribute *only* its true/false result to a FINALLY combine (without doing anything
+itself), give it the **Do nothing** action (see below).
+
+## Actions
+
+Actions are the **THEN**. A rule's true path (and/or false path, and/or the FINALLY step) runs one
+or more actions.
+
+### Send a tapback (reaction)
+
+Reacts to the triggering message with an emoji. Minimal by design — it carries no routing logic
+(the conditions do the routing).
+
+### Send a message
+
+Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the body.
+
+- **Send via sources** — a multi-select of which radios to transmit through. **MQTT sources are
+  receive-only and excluded.** Both **Meshtastic and MeshCore** sources are valid send targets.
+  Leave it empty to use the source that triggered the automation — but a source **is required** for
+  source-less triggers (System events and Schedules).
+- **On channels** — a multi-select of channels, **unified across sources by protocol + name** and
+  shown with **MC / MT badges**. The correct local slot is resolved per source, and a Meshtastic
+  channel is never sent to a MeshCore source (and vice-versa). Disabled channel slots are excluded.
+  Raw channel PSKs are never sent to the browser.
+- **DM to node #** — send as a direct message instead of to a channel. `{{ trigger.from }}` replies
+  to the sender.
+- **Reply to the triggering message** — thread the reply to the message that fired the automation.
+
+The overall send is a **source × channel matrix**: each selected source posts to the matching local
+slot of each selected channel.
+
+### Manage the node
+
+Runs an admin/management operation on the subject node: **Favorite / Unfavorite**, **Ignore /
+Unignore**, or **Delete**.
+
+### Send a notification (Apprise)
+
+Dispatches an out-of-band notification through [Apprise](/features/notifications) with a `Title`,
+`Body` (both token-interpolated), and a **Severity** (Info / Success / Warning / Failure). It
+resolves the Apprise endpoint from the normal chain (per-source → global → `APPRISE_URL` → bundled
+service), and you can optionally supply inline **Apprise URL(s)** to override the target.
+
+### Run a script
+
+Runs a script file from the server's **`$DATA_DIR/scripts`** folder (the same directory the Auto
+Responder uses) when the automation fires.
+
+- **Script** — picked from a dropdown of files in the scripts directory.
+- The trigger context is passed to the script as **`MM_*` environment variables**:
+  `MM_TRIGGER_TYPE`, `MM_SOURCE_ID`, `MM_NODE_NUM`, `MM_TIMESTAMP`, and each trigger field as
+  `MM_<UPPER_SNAKE_NAME>` (object values are JSON-stringified). Message-style aliases (`MESSAGE`,
+  `FROM_NODE`, …) are provided for compatibility with existing scripts.
+- **Store result in** *(optional)* — captures the script's JSON stdout into a variable. Use a
+  **`json`** typed variable and index into the result later with `{{ var.name.field }}` (see
+  [Variables](#variables) and [Tokens](#tokens)).
+- A non-zero exit code is recorded as an action error on the run. Path-traversal protection, the
+  interpreter pick, and the execution timeout are reused from the existing script runner.
+
+> The script itself does **not** send messages — capture its output into a variable, then use a
+> separate **Send a message** action to relay it.
+
+### Set a variable / flag
+
+Writes a **dynamic** [variable](#variables): **Set to value**, **Increment by**, **Raise flag**, or
+**Clear / lower flag**. Read-only constants can't be written here.
+
+### Do nothing
+
+A no-op action. Use it so a rule contributes only its true/false outcome to a FINALLY combine step
+without performing any action of its own.
+
+## Variables
+
+Variables are a separate, first-class management area under the Automations tab. A variable is
+referenced everywhere as `{{ var.name }}` and participates in conditions, actions, and text
+interpolation.
+
+**Two roles** (a single `readonly` flag):
+
+- **Constant** (`readonly`) — you set the value directly in the Variables UI (e.g.
+  `lowBatteryThreshold = 20`). Automations may read it but never write it. This is the
+  "thresholds / config" case.
+- **Dynamic** — managed by automations at runtime via **Set a variable / flag** (flags, counters,
+  last-seen values).
+
+**Types:** `string`, `integer`, `float`, `boolean`, `flag`, and `json`.
+
+- A **`flag`** is a boolean that **auto-clears after a configured duration**. It's the anti-spam
+  primitive: *"have I already welcomed this node in the last 24 h?"* — raise the flag when you act,
+  and a `Variable check` that the flag is **not** set gates the next run. Expiry is evaluated at
+  read time, so it survives restarts.
+- A **`json`** variable holds structured data — typically the captured output of a **Run a script**
+  action — and is indexed with nested access (below).
+
+**Scopes** decide what the value is keyed by:
+
+| Scope | One value per… |
+| --- | --- |
+| `global` | the whole instance |
+| `source` | source connection |
+| `node` | physical node (shared across sources) |
+| `sourceNode` | a (source, node) pair |
+
+For scoped variables the key is resolved from the trigger context automatically — `node` /
+`sourceNode` bind to the trigger's **subject node**, `source` / `sourceNode` to the trigger's
+source. Schedule and system triggers have no subject node, so a node-scoped variable there needs an
+explicit reference.
+
+**Nested access:** for `json` variables (and any object value), index into fields with
+`{{ var.name.a.b }}`. Referencing the whole variable renders it as JSON. Variable **names must be
+dot-free identifiers** so the `name.path` split is unambiguous.
+
+## Tokens
+
+Text fields that support substitution (message body, DM-to, notification title/body, condition
+values, the set-variable value) accept **double-brace tokens**:
+
+| Token | Resolves to |
+| --- | --- |
+| `{{ trigger.* }}` | A field from the current trigger (e.g. `{{ trigger.text }}`, `{{ trigger.fromId }}`, `{{ trigger.hops }}`, `{{ trigger.value }}`, `{{ trigger.latestVersion }}`). The available fields depend on the trigger type |
+| `{{ trigger.sourceId }}` / `{{ trigger.timestamp }}` | Available for every trigger; `timestamp` renders as a local date/time |
+| `{{ var.name }}` | A user-defined variable; `{{ var.name.field }}` for nested `json` access |
+| `{{ NOW }}` | The current time, rendered as a local `YYYY-MM-DD HH:mm:ss` |
+
+### In-builder validation
+
+Token-bearing fields render with live highlighting so typos surface immediately:
+
+- A **recognized** token is shown **blue**.
+- An **unrecognized** token (a typo like `{{ trigger.lastestVersion }}`, or an unknown variable) is
+  shown **red with a wavy underline**, and is also listed inline below the field
+  ("Unrecognized token(s): … — check for typos").
+
+Recognition is built from the trigger's token set plus your known variable names. It's a
+**non-blocking hint** — it won't stop you saving, so a valid-but-unenumerated token is never
+falsely rejected.
+
+### Substitutions help drawer
+
+A **`?`** button at the top of the builder opens a docked, non-modal **Substitutions** sidebar that
+stays open while you edit. It lists every `{{ trigger.* }}` token for the current trigger type (and
+the rest), plus `{{ var.* }}` and `{{ NOW }}`, so you can author tokens without leaving the field.
+
+## Testing (dry-run)
+
+The builder includes a **▶ Test panel** that runs the automation against a **synthetic event** with
+**no mesh IO, no Apprise dispatch, and nothing persisted**. It returns the full trace — whether the
+trigger matched, each condition's verdict, the resolved action parameters, and any simulated
+variable writes. A **Run a script** action is stubbed in the dry-run, so testing never spawns a
+process.
+
+You supply the synthetic inputs the conditions need:
+
+- **Message inputs** — text, plus **SNR**, **RSSI**, and a **Via MQTT** toggle (so
+  `{{ trigger.snr }}` / `{{ trigger.rssi }}` can be exercised, including the MQTT case where signal
+  metrics are absent).
+- **Subject-node facts** — **Hops away**, channel utilization, air-util TX, node SNR, altitude, and
+  more, so `node.*` conditions can actually be made true.
+- **System Event** and telemetry **Metric** are dropdowns (not free text, which would silently
+  no-match on a typo); a **From source** selector lets you exercise the **Source filter** condition;
+  and a schedule trigger dry-runs as matched.
+
+The result is rendered human-readably — the interpolated message text, the tapback emoji, the
+notification title/body/URLs — with the raw resolved parameters behind a toggle. When a run matches
+the trigger but no action fires, the panel explains that every condition went false and points at
+which inputs/facts to change.
+
+</div>

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -1936,18 +1936,27 @@ Navigate to **Settings > Automation** and find the **Auto Favorite** section.
 
 ### Eligibility Rules
 
-Which nodes are auto-favorited depends on your local node's role:
+Auto-favorite only runs at all when your **local node's role** is `Router`, `Router_Late`, or `Client_Base`. On any other local role (`Client`, `Client_Mute`, etc.) the feature stays inactive.
 
-| Local Node Role | Eligible Nodes |
-|----------------|----------------|
-| Client / Client_Mute | Direct neighbors only (hopsAway = 1) |
-| Router / Router_Client | All heard nodes (any hop count) |
-| Repeater | All heard nodes (any hop count) |
+When active, it only auto-favorites a **target node** that is a **0-hop neighbor** (`hopsAway = 0`) whose own role is a **relay role**:
 
-Nodes must also:
-- Have a valid `longName` (not unknown/unnamed)
-- Not be the local node itself
+| Target Node Role | Auto-Favorited? |
+|------------------|-----------------|
+| Router | Yes (relay role) |
+| Router_Late | Yes (relay role) |
+| Client_Base | Yes (relay role) |
+| Client | **Never** (does not relay) |
+| Client_Mute | **Never** (does not relay) |
+
+`Client` and `Client_Mute` nodes never relay traffic, so they are **never** auto-favorited regardless of your local node's role (issue #3774).
+
+Targets must also:
+- Be exactly 0 hops away (`hopsAway = 0`) — direct RF neighbors only
+- Not have been heard via MQTT
+- Not already be favorited
 - Not have `favoriteLocked = true` (manually managed)
+
+> **Tip:** On a `Client_Base` local node, nearby `Client` / `Client_Mute` devices are intentionally skipped by auto-favorite. If you want those pinned, favorite them **manually** by clicking the star.
 
 ### Permissions
 

--- a/docs/features/device.md
+++ b/docs/features/device.md
@@ -46,6 +46,18 @@ Configuration changes directly modify your Meshtastic device settings. Always en
 - Typically derived from long name (e.g., "Base Station 1" → "BS01")
 - Avoid ambiguous abbreviations
 
+### Unmessagable Nodes
+
+**Description**: Nodes that advertise the `is_unmessagable` flag (and unlicensed nodes, `is_licensed = false`, where applicable) cannot receive direct messages — sensors, repeaters, and similar devices set this so DMs sent to them would silently go nowhere.
+
+**Effect in MeshMonitor**: For these nodes, MeshMonitor hides the direct-message UI entirely instead of offering a composer that can't deliver:
+- The 💬 DM button is hidden in the Nodes tab.
+- Selecting the node in the Messages tab shows its node detail and per-node telemetry in place of the conversation — the message log, send composer, and mesh-transmit actions are not shown.
+
+**Side Effects**:
+- The node remains fully listed and selectable in the node/contact lists, with all of its indicators, detail, and telemetry intact.
+- No messaging entry point is offered, avoiding the misleading "delivered" acknowledgements that occur when a relay acks a packet the target never received.
+
 ### Related Meshtastic Documentation
 
 - [Meshtastic Device Configuration](https://meshtastic.org/docs/configuration/radio/device/)

--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -67,7 +67,11 @@ Clear the box to restore the full map. The search term lives in the workspace st
 
 ### Node markers
 
-Renders every known node from the selected sources using the same icon set as the Dashboard map. Click a marker to populate the inspector panel; the standard Leaflet popup still opens too.
+Renders every known node from the selected sources using the same icon set as the Dashboard map. Click a marker to populate the inspector panel; it also opens the same rich node popup as the Unified map — a card showing name and short name, role, hops, hardware, battery, SNR, altitude, position, and last-heard.
+
+::: tip Multi-source node popups (New in 4.12)
+For a node reported by more than one source, the popup includes a **"Seen by N sources"** list with a row per source that links to that source's view — matching the Unified/Dashboard map. The page is also fully multi-source-aware: a node stays visible when **any** of its reporting sources is enabled in the source filter, not only its primary source.
+:::
 
 ::: tip Overlapping markers fan out (New in 4.10)
 When several nodes report the **same coordinates** — a shared site with multiple radios, or a cluster of nodes that inherited one position — they no longer stack into a single un-clickable marker. They **spiderfy** (fan out around the shared point) so each node is individually selectable.

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -84,6 +84,21 @@ When viewing traceroute data:
    - SNR indicators at each hop
    - Failed routes shown in red
 
+#### Channel Routing
+
+For a traceroute to resolve every hop, each intermediate node must be able to
+decrypt the packet so it can append itself to the route. That depends on the
+channel's **PSK**, not its slot number. MeshMonitor therefore routes
+traceroutes over the lowest-numbered channel that the whole mesh can decrypt —
+one using the well-known default key (`AQ==`, what LongFast uses by default) or
+an unencrypted channel — rather than a hardcoded channel slot 0. If no
+channel is mesh-readable, it falls back to channel 0.
+
+The **Traceroute** and **Exchange Node Info** actions in the messages/node UI
+are split buttons with a `▾` channel-selection dropdown (shown when more than
+one channel exists, mirroring the **Exchange Position** control). Use it to
+override the default and send on a specific channel.
+
 ### Waypoints
 
 Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. The same panel has a **Show Waypoints** checkbox (default on) that toggles waypoint marker visibility per-user — persisted alongside the other map feature toggles. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -23,6 +23,7 @@ When a MeshCore source is connected, you get:
 - **Repeater neighbour list** — Query a repeater's neighbour table with SNR and last-heard timestamps, with results rendered on the map
 - **Path visualization** — Show route lines on the map colored by hop count, with Discover Path buttons for manual route establishment
 - **Auto-pathfinding** — Scheduled path discovery and neighbor collection across your entire mesh
+- **Region / scope tagging** — Stamp outgoing flood traffic with a named region so meshes that drop un-scoped packets (e.g. `region denyf *`) forward it; per-channel, per-source default, and per-message override
 - **Room server support** — Login, post, and auto-sync with MeshCore room servers (BBS-style message boards)
 - **@mention highlighting** — Messages mentioning your name are visually highlighted
 - **Delivery status** — Sent DMs show pending/confirmed/failed indicators
@@ -122,6 +123,10 @@ A map of every contact with valid coordinates, plus a styled row list aligned to
 
 The device's channels with the most recent message stream. Channel-message senders are now extracted from the `"Name: body"` prefix that MeshCore embeds in the text body, so the sender column and the message body are no longer collapsed into one string.
 
+**Unread indicators** — channels with messages newer than the last time you opened them show an unread dot and a **bold name** in the channel list. A header badge counts how many channels currently have unread messages, and an optional **"unread first"** sort toggle (persisted) floats those channels to the top. Opening a channel marks it read up to the newest visible message. MeshCore read state is tracked **client-side in `localStorage`, scoped by `sourceId`** — there's no server-side MeshCore read table, so read markers are per-browser rather than per-account.
+
+**Heard repeaters** — outgoing channel posts show a **📡 N** badge with an expandable list of the repeaters that re-flooded the message and the SNR each was heard at. This is populated best-effort by **self-echo correlation**: when a repeater re-floods your `GRP_TXT` packet, MeshMonitor hears it inbound and attributes the relay hashes to the most recent matching channel send within a ~30-second window. Channel sends carry no protocol ACK, so this is a heuristic, not a delivery receipt. Correlation runs on the raw inbound packet before the opt-in packet-monitor gate, so it works **regardless of whether the packet monitor is enabled**. Relay hashes are resolved to repeater names where known; otherwise the raw hash is shown.
+
 ### Direct Messages
 
 Per-contact DM view with a **contact-detail panel** that mirrors the Meshtastic NodeDetailsBlock. It surfaces:
@@ -133,6 +138,7 @@ Per-contact DM view with a **contact-detail panel** that mirrors the Meshtastic 
 - Position (if known)
 - Full public key
 - **Discover Path** button — triggers firmware CMD 52 to establish/refresh the route to a companion contact
+- **Define Path** editor — manually set the route to a contact when you already know the relay hops, instead of probing for it. Add hops in order and pick the per-hop **hash width** (1, 2, or 3 bytes) — the selector is pre-filled from the current path, and changing the width clears the hop list since the encoding differs. The hop count is capped at 63. Use this when Discover Path can't reach the contact but you know the topology.
 - **Delivery status** — sent DMs show pending / confirmed / failed indicators with timestamp tooltips
 
 Contact names in messages are **clickable** — clicking a name navigates directly to that contact's DM thread. Messages containing **@YourName** are visually highlighted.
@@ -140,6 +146,31 @@ Contact names in messages are **clickable** — clicking a name navigates direct
 The panel is collapsible with state persisted to localStorage.
 
 The **per-node remote-telemetry config** panel hangs off the contact-detail panel (see [Per-Node Remote Telemetry](#per-node-remote-telemetry) below).
+
+::: warning Repeaters have no DM composer
+MeshCore repeaters (`advType=2`) can't hold a conversation, so they no longer expose a message composer. The 💬 button is hidden on repeater rows, and selecting a repeater shows its node detail and telemetry/graphs instead of an (empty) conversation pane. The repeater stays listed in the contact sidebar — only the chat surface is dropped. The Meshtastic side does the same for nodes flagged unmessagable.
+:::
+
+### Message route line
+
+Received channel and DM messages show a route line beneath the body, derived from the packet's relay path:
+
+- **📍 direct** — heard with zero hops (direct RF).
+- **🛰 N hops · a3 → 7f → 02** — relayed; the chain lists each relay's hash in order.
+
+Room-server posts and messages with no recoverable path show no route line.
+
+### Send bar
+
+Below every MeshCore composer (channel and DM) a live **`<bytes>/<limit>`** counter shows how much of the packet budget the current draft uses. Counting is **UTF-8 byte-accurate**, not character-based, so emoji and CJK characters cost more than one byte each. Limits are per-context:
+
+| Context | Limit |
+|---|---|
+| Channel message | 130 bytes |
+| Channel message with a scope/region | 120 bytes |
+| Direct message | 150 bytes |
+
+The counter appears only once the draft is non-empty, turns **yellow at 90%** of the limit and **red when over**, and the **Send button is disabled while over the limit** (the backend rejects an over-budget send as well).
 
 ### Node Info
 
@@ -192,7 +223,70 @@ You configure this from the contact-detail panel in the Direct Messages view:
 
 The config requires `configuration:write` on the source. Read-only users see the panel with controls disabled and a banner explaining why.
 
+#### On-demand polling
+
+Alongside the scheduled config, the panel has two buttons to pull telemetry from a node right now instead of waiting for its interval:
+
+- **Poll Status** — requests battery / uptime / counters (repeater- and room-server-oriented).
+- **Poll Environment (LPP)** — requests a Cayenne-LPP environment reading (companion-oriented).
+
+Both transmit on the mesh, so they share the per-source **60-second mesh-TX gate** — if another scheduled or manual op fired too recently the request is refused with **HTTP 429 and a `Retry-After`**, surfaced as a throttle message on the button. Each button shows a pending state and reports how many telemetry rows were written. On-demand polling requires only **`nodes:read`** on the source (and returns 409 if the source isn't connected).
+
 The composite primary key on `meshcore_nodes` is `(sourceId, publicKey)`, so the same device advertising under two different sources is tracked independently.
+
+## Regions / Scopes
+
+Some MeshCore meshes restrict which flood traffic their repeaters forward. A repeater running `region denyf *` **drops any un-scoped flood packet** — so a message MeshMonitor sends without a scope simply never propagates past those repeaters. The Germany mesh is the most common example.
+
+A **scope** (also called a **region**) is just a named tag — e.g. `germany` or `muenchen` — that MeshMonitor stamps onto outgoing flood traffic. Repeaters configured to allow that region then forward it. The wire value is derived purely from the name (a hash of `#<name>`), so two operators only have to agree on the text of the region name to interoperate; there's no shared key to exchange.
+
+::: warning One global scope on the device
+The MeshCore companion firmware exposes only a **single, global flood scope**, not a per-channel one. MeshMonitor owns the per-channel/per-source scope mapping itself and asserts the right scope on the device immediately before each send, serializing those operations per source. If the scope can't be asserted, the send is aborted rather than leaked un-scoped.
+:::
+
+### Setting a scope
+
+There are three layers, resolved most-specific-first (**channel scope → source default scope → unscoped**):
+
+- **Per-channel Region / Scope** — each channel's settings has a **Region / Scope** field. Traffic on that channel is stamped with this scope.
+- **Per-source default scope** — the MeshCore **Settings** view has a default-scope section backed by the `meshcoreDefaultScope` setting. Channels without their own scope fall back to this, so you can scope a whole source with one value.
+- **Unscoped** — leave both blank and traffic goes out with no scope (the legacy behavior).
+
+Channel-settings and the per-message override both offer a region-picker **datalist** drawn from your saved + discovered regions (see below); free typing is still allowed. Region names are normalized (leading `#` stripped; letters, digits, and hyphens kept).
+
+### What gets scoped
+
+Originated flood traffic is scoped end-to-end. That covers channel messages, DM messages, **adverts**, **remote-admin login**, **remote telemetry requests**, and **remote CLI commands**. Operations that are never flood-forwarded — node discovery (zero-hop), local/config-only commands, and direct-routed traffic — are intentionally left alone.
+
+### Discover Regions
+
+In the default-scope section of MeshCore **Settings**, the **Discover Regions** button asks nearby repeaters which regions they serve:
+
+- It runs a **0-hop sweep first** and queries **only the repeaters (and room servers) that answer in direct RF range**, in arrival order — not every repeater you've ever heard.
+- If the first sweep finds nothing it **retries once**.
+- It distinguishes the two empty cases: **no nearby (0-hop) repeaters were found** vs. **repeaters answered but reported no regions**.
+
+Discovered region names render as chips you can click to fill the scope field, and each chip has a save (**＋**, **✓** once saved) button to add it to the catalog.
+
+::: tip Why 0-hop
+A repeater only answers a regions query over a direct route, so MeshMonitor installs a zero-hop path to each responder before asking. A benign `set_out_path` ack-timeout during this step is expected and logged at debug level — it doesn't mean the discovery failed.
+:::
+
+### Per-message scope override
+
+Next to the channel compose box is an optional one-off **scope/region override**. It applies to that single message and is **never persisted** to the channel — your next normal send re-asserts the channel/default scope. It defaults to the channel's resolved scope, offers the same discovered/saved-region datalist, and resets when you switch channels. Leave it blank/whitespace to send that one message explicitly unscoped.
+
+### Scope of received messages
+
+Received channel and DM messages show a scope line so you can tell how a message reached you. MeshMonitor recovers the scope by recomputing each of your known region names against the packet (the raw name can't be reversed out of the wire value):
+
+- **🌐 no scope** — the message was sent un-scoped.
+- **🔒 muenchen** — scoped to a region you know; the name is shown.
+- **🔒 #a3f2** — scoped, but to a region not in your known set; the raw code is shown as hex.
+
+### Saved regions catalog
+
+The MeshCore **Settings** view has a **Saved regions** section — a catalog of region names (with optional notes) you've saved, so you don't have to retype them. The catalog is **global** (shared across all MeshCore sources, not per-source). Saved regions feed the region-picker datalists on the channel scope field and on the per-message override (the override list is the de-duplicated union of saved + discovered regions). Add regions inline (or via the **＋** on a discovered-region chip) and delete them per-item.
 
 ## Remote Administration
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.12.0-rc2
-appVersion: "4.12.0-rc2"
+version: 4.12.0
+appVersion: "4.12.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.0-rc2",
+  "version": "4.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.12.0-rc2",
+      "version": "4.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.0-rc2",
+  "version": "4.12.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/migrations/104_add_channel_database_hash.ts
+++ b/src/server/migrations/104_add_channel_database_hash.ts
@@ -64,6 +64,15 @@ export const migration = {
  * RENAME it into place.  The new table starts with 0 tombstones.
  */
 async function rebuildChannelDatabasePostgres(client: import('pg').PoolClient): Promise<void> {
+  // Wrap the destructive rebuild in a single transaction. It DROPs the live
+  // channel_database and RENAMEs a fresh copy into place, and the outer
+  // migration runner opens no transaction of its own. PostgreSQL DDL is
+  // transactional, so an error/crash mid-rebuild rolls back to the original
+  // table intact instead of leaving the database with no channel_database
+  // (which would also make this migration's own idempotency check throw
+  // "relation does not exist" on the next startup).
+  await client.query('BEGIN');
+  try {
   // Clean up a leftover scratch table from any previous failed rebuild.
   await client.query(`DROP TABLE IF EXISTS channel_database_new`);
 
@@ -143,6 +152,13 @@ async function rebuildChannelDatabasePostgres(client: import('pg').PoolClient): 
             ON DELETE CASCADE
     `);
     logger.debug('Migration 104 (PostgreSQL): re-attached FK on channel_database_permissions');
+  }
+
+    await client.query('COMMIT');
+  } catch (err) {
+    // Roll back to the original channel_database; nothing is dropped.
+    await client.query('ROLLBACK');
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
Finalizes **4.12.0** (from `4.12.0-rc2`). Includes the version bump across all release files, plus a documentation catch-up driven by an audit of **every one of the 74 PRs merged since v4.11.5**. System tests are enabled on this PR.

## Changes

### Version → 4.12.0
- `package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml`
- `CHANGELOG.md`: `[Unreleased]` → `[4.12.0] - 2026-06-26`

### Documentation (docs site / meshmonitor.org)
Two large user-facing feature areas had shipped with **no public docs**, plus several smaller gaps — all closed:
- **New page** `docs/features/automation-engine.md` (+ sidebar nav) — the node/builder-based Automation Engine (#3653 et al). Wrapped in `v-pre` so the `{{ }}` token syntax renders literally without breaking the VitePress build.
- `docs/features/meshcore.md` — new **Regions / Scopes** section (#3667 et al), channel unread indicators (#3716), heard-repeaters badge (#3707), per-message route line (#3750), byte-accurate send counter (#3790), on-demand telemetry polling (#3681), Define Path editor (#3686), repeater DM-hidden behavior (#3760).
- `docs/features/automation.md` — corrected the stale **auto-favorite eligibility** table (#3786/#3774).
- `docs/features/maps.md` — traceroute default-keyed channel routing + channel dropdowns (#3723).
- `docs/features/map-analysis.md` — rich multi-source node popups (#3692).
- `docs/features/device.md` — unmessagable-node DM-hidden behavior (#3760).

## PR audit — 2 release-risk items flagged (FYI, not introduced here)
The audit flagged two pre-existing items (already shipped in rc1/rc2) worth a second look:
1. **[high] Migration 104 (PR #3753)** — the PostgreSQL `channel_database` rebuild on tombstone exhaustion (attnum ≥1500) does a destructive `DROP TABLE … CASCADE` + copy. A mid-rebuild failure on a production PG DB risks channel-key/PSK loss. Worth verifying the live-column copy + FK re-attach and adding backup guidance.
2. **[medium] MeshCore contact `out_path_len` packed encoding (PR #3686)** — now stored in firmware PACKED format (top 2 bits = hash_size−1), contradicting prior project understanding. Harmless for 1-byte paths; could misroute 2/3-byte manual paths if the firmware assumption is wrong. PR claims firmware verification; a second confirmation is prudent.

## Issues Resolved
Release of 4.12.0. Documentation for #3653 and #3667 feature sets.

## Documentation Updates
See the Documentation section above. `vitepress build docs` passes; `{{ }}` tokens verified to render literally.

## Testing
- [x] Full unit suite: 7668 passed, 0 failed, 0 suite failures
- [x] `npm run docs:build` (VitePress) builds clean
- [x] **System tests enabled** on this PR (label)
- [ ] Reviewer: skim the new `automation-engine.md` and the meshcore `Regions / Scopes` section for accuracy; consider the two flagged release-risk items above before cutting the release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)