### PR TITLE
docs(blog): Automation Engine + MeshCore Regions feature posts (4.12.0)

### DIFF
--- a/docs/blog/2026-06-26-automation-engine.md
+++ b/docs/blog/2026-06-26-automation-engine.md
@@ -1,0 +1,54 @@
+---
+id: news-2026-06-26-automation-engine
+title: MeshMonitor 4.12.0 — Build Your Own Automations
+date: '2026-06-26T18:00:00Z'
+category: feature
+priority: important
+minVersion: 4.12.0
+---
+For a while now, MeshMonitor's automations have been a fixed menu: Auto Acknowledge, Auto Traceroute, Auto Ping, Auto Responder, Auto Announce. Each one does a single, well-defined job. They're great — but if you wanted something they didn't already do, you were out of luck.
+
+Not anymore. MeshMonitor 4.12.0 introduces the **Automation Engine** — a generic, visual *"when this happens, do that"* builder, in the spirit of Home Assistant, Node-RED, and IFTTT. It lives on its own top-level **Automations** tab, and it lets you wire up your own behavior instead of relying on the hardcoded ones. The legacy automations remain exactly as they were; the engine is the build-it-yourself alternative.
+
+## The shape of an automation
+
+Every automation is a small graph you build in a guided, linear editor:
+
+```
+WHEN  →  RULE (IF … THEN …)  →  optional FINALLY
+```
+
+- **WHEN** — exactly one **trigger** that starts things off.
+- **RULE** — one or more **conditions** that decide whether to act, each routing to its own **actions**. Conditions are routers with a *true* and *false* path, so you get If / ElseIf / Else logic.
+- **FINALLY** — an optional combine step that runs based on how the rules turned out: **ANY**, **ALL**, **NONE**, or **ALWAYS**.
+
+Automations run **globally** — they evaluate events from *every* connected source at once, just like Map Analysis — with an optional **Source filter** condition when you want to scope one down. They're gated by a dedicated `automations` permission, carry a per-automation cooldown and loop guard, log every run for debugging, and export/import as JSON (imports land disabled for review).
+
+## Triggers, conditions, actions
+
+**Triggers** — a message arrives (with channel-name matching and substring/regex filters), a node is discovered or updated, telemetry crosses a threshold, a **cron schedule** fires ([#3726](https://github.com/Yeraze/meshmonitor/pull/3726)), a system event happens (start, source online/offline, **upgrade available**), or a node **enters/leaves a geofence** drawn right on the map ([#3721](https://github.com/Yeraze/meshmonitor/pull/3721)).
+
+**Conditions** — number and text comparisons over the event, the hydrated node record (battery, hops, role, position, age…), or its latest telemetry; a source filter; distance from a point; a variable check; and a time-of-day window. A missing field never throws — it just evaluates false.
+
+**Actions** — send a tapback, **send a message** (with a "Send via sources" multi-select and unified "On channels" picker that badges MeshCore vs Meshtastic), manage a node, fire an **Apprise notification**, or **run a script** from your data directory with `MM_*` environment variables and a JSON-typed result you can reference later ([#3746](https://github.com/Yeraze/meshmonitor/pull/3746)).
+
+## Variables and tokens
+
+You can define your own **variables** — constants or runtime flags/counters — in a dedicated management area, with global/source/node scopes and nested access into JSON values. And everywhere you can type text, you can drop in **substitution tokens** that resolve at run time:
+
+```text
+Node {{ trigger.fromId }} just reported {{ trigger.value }} at {{ NOW }}.
+Last seen counter: {{ var.seenCount }}
+```
+
+The builder validates tokens as you type — recognized tokens turn blue, typos get a red wavy underline ([#3727](https://github.com/Yeraze/meshmonitor/pull/3727), [#3739](https://github.com/Yeraze/meshmonitor/pull/3739)) — and a Substitutions drawer lists every token available for the current trigger.
+
+## Test before you ship
+
+Every automation has a built-in **Test panel**: run it against a synthetic event — set SNR/RSSI/Via-MQTT, hops-away, node facts — with **no mesh traffic, no notifications, and nothing saved**. The panel shows the interpolated message, the chosen action, and, when nothing fires, explains which condition went false and what to change.
+
+## Try it
+
+The Automation Engine is in the new **Automations** tab in 4.12.0. The full guide — triggers, conditions, actions, variables, tokens, and the test panel — is in the [Automation Engine documentation](/features/automation-engine).
+
+This feature shipped across a series of PRs: [#3653](https://github.com/Yeraze/meshmonitor/issues/3653) (the engine), [#3721](https://github.com/Yeraze/meshmonitor/pull/3721), [#3726](https://github.com/Yeraze/meshmonitor/pull/3726), [#3727](https://github.com/Yeraze/meshmonitor/pull/3727), [#3739](https://github.com/Yeraze/meshmonitor/pull/3739), and [#3746](https://github.com/Yeraze/meshmonitor/pull/3746).

--- a/docs/blog/2026-06-26-meshcore-regions.md
+++ b/docs/blog/2026-06-26-meshcore-regions.md
@@ -1,0 +1,40 @@
+---
+id: news-2026-06-26-meshcore-regions
+title: MeshMonitor 4.12.0 — MeshCore Regions & Scopes
+date: '2026-06-26T18:05:00Z'
+category: feature
+priority: important
+minVersion: 4.12.0
+---
+As MeshCore meshes have grown, so has the noise. To keep a busy area from drowning in re-flooded traffic, MeshCore added the concept of **regions** (also called **scopes**) — a way to tag flood traffic so repeaters only forward what's meant for them. MeshMonitor 4.12.0 brings first-class support for regions to the MeshCore experience.
+
+## What is a region / scope?
+
+A region is a named tag attached to a flooded packet. MeshCore derives a *transport key* from the region name and uses it to decide whether a repeater should forward a packet — there's no parent/child hierarchy, just name matching. Operators in dense areas configure their repeaters with `region denyf *`, which **stops forwarding of legacy, unscoped flood packets** — so any sender that wants its traffic to propagate *must* tag it with the right region. (An alternative, `flood.max.unscoped`, lets a limited number of unscoped packets through instead.)
+
+If you've ever joined a regional MeshCore network — say a "Germany" or a Pacific-Northwest mesh — and found your messages weren't getting anywhere, a missing scope tag is very often why.
+
+The MeshCore project documents all of this in detail:
+
+- [Region Filtering](https://blog.meshcore.io/2026/01/20/region-filtering) — the original explanation of scoped group channels and repeater filtering.
+- [Default Scope Region](https://blog.meshcore.io/2026/04/17/default-scope) — the v1.15 "default scope" for companions and repeaters.
+- [MeshCore CLI Commands](https://docs.meshcore.io/cli_commands/) — including `region`, `region denyf`, and `flood.max.unscoped`.
+- [MeshCore Docs & FAQ](https://docs.meshcore.io/faq/) — general reference.
+
+## What MeshMonitor 4.12.0 adds
+
+**Per-channel and per-source scope.** Each MeshCore channel can carry a Region/Scope, and each source gets a default scope (`meshcoreDefaultScope`) in MeshCore Settings. In 4.12.0 the scope is applied to **all** originated flood traffic — channel messages, DMs, adverts, remote-admin logins, remote telemetry, and remote CLI — so your traffic actually propagates on a `denyf`'d mesh.
+
+**Discover Regions.** A one-click sweep ([#3765](https://github.com/Yeraze/meshmonitor/pull/3765)) queries the repeaters you can reach directly (zero hops), routes the query straight to them, and reports back the regions they advertise — distinguishing "no nearby repeaters" from "repeaters that reported no regions."
+
+**Per-message overrides.** Need to send a single message into a different region without changing your defaults? A scope control next to the compose box lets you override the region for just that message ([#3704](https://github.com/Yeraze/meshmonitor/pull/3704)). It's one-off and never persisted, with a datalist of discovered regions.
+
+**See the scope on received messages.** Incoming messages now show the region they were sent with ([#3762](https://github.com/Yeraze/meshmonitor/pull/3762)): 🌐 for no scope, 🔒 with the region name when it's known, or 🔒 with a short hex code when it isn't — so you can tell at a glance whether a message arrived scoped, and to which region.
+
+**A saved-regions catalog.** Regions you discover or use are kept in a catalog ([#3783](https://github.com/Yeraze/meshmonitor/pull/3783)), and region pickers throughout the UI offer them as suggestions, so you're not retyping names or hunting for hex codes.
+
+## Try it
+
+Open a MeshCore source, head to **Settings** to set a default scope, add a Region/Scope to a channel, or hit **Discover Regions** to see what's around you. The full walkthrough is in the [MeshCore documentation](/features/meshcore#regions-scopes).
+
+Regions support landed across [#3667](https://github.com/Yeraze/meshmonitor/issues/3667) and PRs [#3704](https://github.com/Yeraze/meshmonitor/pull/3704), [#3762](https://github.com/Yeraze/meshmonitor/pull/3762), [#3765](https://github.com/Yeraze/meshmonitor/pull/3765), and [#3783](https://github.com/Yeraze/meshmonitor/pull/3783).


### PR DESCRIPTION
## Summary
Two feature blog posts for the 4.12.0 release, added under `docs/blog/` (auto-discovered by the blog index and the `blog-to-news.mjs` news-feed generator).

## Posts
- **`2026-06-26-automation-engine.md` — "Build Your Own Automations"** — introduces the node/builder-based Automation Engine: the WHEN → RULE → FINALLY model, triggers (message/node/telemetry/schedule/system/geofence), conditions, actions (tapback / send / Apprise notify / run-a-script), user variables, `{{ }}` substitution tokens, and the dry-run Test panel. Links to the new `/features/automation-engine` doc page.
- **`2026-06-26-meshcore-regions.md` — "MeshCore Regions & Scopes"** — explains what MeshCore regions/scopes are and why they matter (`region denyf *`), and what 4.12.0 adds (per-channel/per-source scope, Discover Regions, per-message overrides, received-message scope display, saved-regions catalog). Includes links to the **official MeshCore documentation**: [Region Filtering](https://blog.meshcore.io/2026/01/20/region-filtering), [Default Scope](https://blog.meshcore.io/2026/04/17/default-scope), [CLI Commands](https://docs.meshcore.io/cli_commands/), and the [Docs/FAQ](https://docs.meshcore.io/faq/).

## Issues Resolved
None (docs/announcement). Relates to the 4.12.0 release (#3653 Automation Engine, #3667 MeshCore regions).

## Documentation Updates
The two blog posts themselves. `news.json` is regenerated at build time (gitignored), not committed.

## Testing
- [x] `npm run docs:build` (VitePress) passes — `{{ }}` token examples kept in fenced code blocks so they render literally on the site and in the in-app news feed
- [x] `blog-to-news.mjs` parses both posts (required `id`/`title`/`date` frontmatter present)
- [x] Both intra-doc anchor links resolve (`/features/automation-engine`, `/features/meshcore#regions-scopes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)