### PR TITLE
fix(migration): prevent UNIQUE constraint crash in migration 103 when user has permissions on both dup and keeper channel

### DIFF
--- a/src/server/migrations/103_consolidate_mqtt_channels.test.ts
+++ b/src/server/migrations/103_consolidate_mqtt_channels.test.ts
@@ -132,6 +132,41 @@ describe('migration 103 — consolidate MQTT channels', () => {
     expect(m7.channel).toBe(0);
   });
 
+  it('handles permission collision — user with perms on both dup and keeper survives without UNIQUE violation', () => {
+    // Seed a fresh db with a user (id=99) who has permissions on BOTH keep (id=1) and dup (id=2).
+    // This is the scenario that caused the UNIQUE constraint crash in issue #3804.
+    const db2 = new Database(':memory:');
+    setupSchema(db2);
+    const now = 1700000000000;
+    db2.prepare(
+      `INSERT INTO channel_database (id, name, psk, psk_length, description, is_enabled, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(1, 'Primary', '', 0, 'passive', 0, now, now);
+    db2.prepare(
+      `INSERT INTO channel_database (id, name, psk, psk_length, description, is_enabled, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(2, 'Primary', '', 0, 'passive', 0, now, now);
+    // User 99 has permissions on BOTH id=1 (keep) and id=2 (dup) — the collision case.
+    db2.prepare(
+      `INSERT INTO channel_database_permissions (user_id, channel_database_id, can_read, granted_at) VALUES (?, ?, 1, ?)`,
+    ).run(99, 1, now);
+    db2.prepare(
+      `INSERT INTO channel_database_permissions (user_id, channel_database_id, can_read, granted_at) VALUES (?, ?, 1, ?)`,
+    ).run(99, 2, now);
+
+    // Must not throw UNIQUE constraint error.
+    expect(() => migration.up(db2)).not.toThrow();
+
+    // After migration: only one Primary row remains.
+    const primaries = db2.prepare(`SELECT id FROM channel_database WHERE lower(name) = 'primary'`).all();
+    expect(primaries).toEqual([{ id: 1 }]);
+
+    // User 99 retains their permission on the keeper (id=1).
+    const perms = db2.prepare(`SELECT channel_database_id FROM channel_database_permissions WHERE user_id = 99`).all() as Array<{ channel_database_id: number }>;
+    expect(perms).toHaveLength(1);
+    expect(perms[0].channel_database_id).toBe(1);
+  });
+
   it('is idempotent — a second run changes nothing', () => {
     migration.up(db); // run again
     const cdCount = db.prepare(`SELECT COUNT(*) AS c FROM channel_database`).get() as { c: number };

--- a/src/server/migrations/103_consolidate_mqtt_channels.ts
+++ b/src/server/migrations/103_consolidate_mqtt_channels.ts
@@ -63,6 +63,13 @@ export const migration = {
       for (const dup of ids) {
         if (dup === keep) continue;
         db.prepare(`UPDATE messages SET channel = ? WHERE channel = ?`).run(OFFSET + keep, OFFSET + dup);
+        // Drop conflicting permission rows before reassigning — a user may already
+        // have a row on `keep`, which would cause a UNIQUE(user_id,channel_database_id) violation.
+        db.prepare(
+          `DELETE FROM channel_database_permissions
+           WHERE channel_database_id = ?
+           AND user_id IN (SELECT user_id FROM channel_database_permissions WHERE channel_database_id = ?)`,
+        ).run(dup, keep);
         db.prepare(`UPDATE channel_database_permissions SET channel_database_id = ? WHERE channel_database_id = ?`).run(keep, dup);
         db.prepare(`DELETE FROM channel_database WHERE id = ?`).run(dup);
         mergedDbRows++;
@@ -152,6 +159,11 @@ export async function runMigration103Postgres(client: import('pg').PoolClient): 
     for (const dup of ids) {
       if (dup === keep) continue;
       await client.query(`UPDATE messages SET channel = $1 WHERE channel = $2`, [OFFSET + keep, OFFSET + dup]);
+      // Drop conflicting permission rows before reassigning (same UNIQUE guard as SQLite).
+      await client.query(
+        `DELETE FROM channel_database_permissions WHERE "channelDatabaseId" = $1 AND "userId" IN (SELECT "userId" FROM channel_database_permissions WHERE "channelDatabaseId" = $2)`,
+        [dup, keep],
+      );
       await client.query(`UPDATE channel_database_permissions SET "channelDatabaseId" = $1 WHERE "channelDatabaseId" = $2`, [keep, dup]);
       await client.query(`DELETE FROM channel_database WHERE id = $1`, [dup]);
       mergedDbRows++;
@@ -232,6 +244,12 @@ export async function runMigration103Mysql(pool: import('mysql2/promise').Pool):
     for (const { id: dup } of idRows as Array<{ id: number }>) {
       if (dup === keep) continue;
       await pool.query(`UPDATE messages SET channel = ? WHERE channel = ?`, [OFFSET + keep, OFFSET + dup]);
+      // Drop conflicting permission rows before reassigning (same UNIQUE guard as SQLite).
+      // MySQL forbids a DELETE that directly sub-selects the same table, so wrap in a derived table.
+      await pool.query(
+        `DELETE FROM channel_database_permissions WHERE channelDatabaseId = ? AND userId IN (SELECT userId FROM (SELECT userId FROM channel_database_permissions WHERE channelDatabaseId = ?) AS tmp)`,
+        [dup, keep],
+      );
       await pool.query(`UPDATE channel_database_permissions SET channelDatabaseId = ? WHERE channelDatabaseId = ?`, [keep, dup]);
       await pool.query(`DELETE FROM channel_database WHERE id = ?`, [dup]);
       mergedDbRows++;


### PR DESCRIPTION
## Summary

Fixes #3804 — migration 103 (`consolidate_mqtt_channels`) crashes with `SqliteError: UNIQUE constraint failed: channel_database_permissions.user_id, channel_database_permissions.channel_database_id` when upgrading to 4.12.0 if a user holds permissions on both the duplicate and the keeper `channel_database` row.

## Root Cause

Part A of migration 103 merges duplicate `channel_database` rows and then reassigns permissions:

```js
UPDATE channel_database_permissions SET channel_database_id = keep WHERE channel_database_id = dup
```

If a user already has a permission row on `keep`, this UPDATE creates a second `(user_id, channel_database_id=keep)` row, violating the unique constraint. The existing test only seeded a user with permissions on the *dup* — not on both — so the collision case was never caught.

## Changes

- **`src/server/migrations/103_consolidate_mqtt_channels.ts`** — Before the UPDATE, add a DELETE that removes the `dup`-side row for any user who already holds a row on `keep`. Applied to all three backends:
  - SQLite: direct sub-select on `user_id`
  - PostgreSQL: same pattern with quoted `"userId"` / `"channelDatabaseId"` column names
  - MySQL: wraps the sub-select in a derived table (`AS tmp`) to avoid MySQL Error 1093 (cannot reference the target table of DELETE in a sub-select)

- **`src/server/migrations/103_consolidate_mqtt_channels.test.ts`** — New test case seeds user 99 with permissions on both the dup (id=2) and the keeper (id=1), then asserts the migration completes without throwing and the user retains exactly one permission row on the keeper.

## Test Results

All 9 tests pass (8 original + 1 new collision test).

## Workaround for Existing Broken Installs

Users who are already unable to start after upgrading to 4.12.0 can apply the same patch manually to `/opt/meshmonitor/dist/server/migrations/103_consolidate_mqtt_channels.js`, then run `systemctl start meshmonitor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNiMxHa13x5DpyjGqZNtSP)_