### PR TITLE
chore(release): 4.12.1 hotfix — migration 103 startup crash (#3804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.12.1] - 2026-06-27
+
+### Fixed
+- **Startup crash upgrading to 4.12.0 (migration 103)** — On installs with MQTT channel permissions, migration 103 could fail with `UNIQUE constraint failed: channel_database_permissions.user_id, channel_database_permissions.channel_database_id` and crash the app on every start. When consolidating duplicate MQTT channels, the migration now deletes conflicting permission rows before reassigning them to the keeper channel (all three backends; MySQL uses a derived-table subselect). (#3804, #3805)
+
 ## [4.12.0] - 2026-06-26
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.12.0",
+  "version": "4.12.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.12.0
-appVersion: "4.12.0"
+version: 4.12.1
+appVersion: "4.12.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.12.0",
+      "version": "4.12.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Hotfix release **4.12.1** for the migration-103 startup crash that breaks upgrades to 4.12.0 (#3804). The fix itself merged in #3805; this PR is the version bump.

## Changes
- Version → **4.12.1** across `package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml`.
- `CHANGELOG.md`: `[4.12.1]` entry.

## Issues Resolved
Releases the fix for #3804 (merged via #3805).

## Background
On installs with MQTT channel permissions, migration 103 could fail with `UNIQUE constraint failed: channel_database_permissions.user_id, channel_database_permissions.channel_database_id` and crash the app on every start, leaving it unbootable. #3805 deletes conflicting permission rows before reassigning them to the keeper channel (SQLite/PostgreSQL/MySQL, with a MySQL derived-table subselect) and adds a collision regression test.

## Testing
- [x] The fix (#3805) merged green: CI 17/17, claude-review LGTM, collision regression test added
- [x] Version bump only here — no code change; lockfile diff is the 2 version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)