### PR TITLE
fix(meshcore): improve message metadata readability on bright screens

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -718,13 +718,13 @@
   font-weight: 500;
 }
 
-/* Message metadata (time/route/scope) uses overlay1 — one step darker than
-   overlay0 for better readability in both light and dark themes (#3769). */
-.mc-message-time { color: var(--ctp-overlay1); }
+/* Message metadata uses subtext0 — sufficient contrast on bright screens (iPad)
+   in both Catppuccin light and dark themes (#3769, #3811). */
+.mc-message-time { color: var(--ctp-subtext0); }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
-.mc-message-route { color: var(--ctp-overlay1); font-size: 0.72rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
-.mc-message-scope { color: var(--ctp-overlay1); font-size: 0.72rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
+.mc-message-route { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+.mc-message-scope { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 
 .mc-mention {
   color: var(--ctp-blue);


### PR DESCRIPTION
## Summary

- Upgrades `.mc-message-time`, `.mc-message-route`, and `.mc-message-scope` from `--ctp-overlay1` to `--ctp-subtext0` for better contrast on high-brightness displays (e.g. iPad in light mode)
- Bumps route/scope `font-size` from `0.72rem` to `0.75rem` — the smaller text compounded the low-contrast problem
- Updates the comment block to reference both #3769 and #3811

Fixes #3811, follow-up to #3769.

## Root cause

The fix in PR #3772 (for #3769) moved all three metadata classes to `--ctp-overlay1` — an improvement over the original `--ctp-overlay0`, but still too muted on bright iPad screens. The `.mc-message-route` and `.mc-message-scope` classes also use `font-size: 0.72rem`, so the combination of muted color + small text made them hard to read on high-DPI/high-brightness displays even though the timestamp (default font size) was more tolerable.

`--ctp-subtext0` provides noticeably better contrast in both Catppuccin Latte (light) and Mocha (dark) while keeping the metadata visually secondary to the message body.

## Test plan

- [ ] Open MeshCore channel messages in both light and dark theme
- [ ] Verify timestamp, hop-route, and scope lines are all readable
- [ ] Check on a mobile/tablet browser (iPad or similar bright screen) for the reported improvement
- [ ] Confirm visual hierarchy is preserved: message text > metadata

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXG2rcLPoS5efrVNWYJV9K)_