### PR TITLE
fix: persist heardBy relay info in memory pool after channel echo (#3813)

### DIFF
--- a/src/server/meshcoreManager.channelHeard.test.ts
+++ b/src/server/meshcoreManager.channelHeard.test.ts
@@ -198,6 +198,38 @@ describe('MeshCoreManager — channel-heard correlation (integration)', () => {
     );
   });
 
+  it('updates the in-memory message pool with heardBy so getRecentMessages reflects relay info (#3813)', async () => {
+    recordHeardRepeater.mockImplementation(async (r: any) => ({
+      sourceId: r.sourceId,
+      messageId: r.messageId,
+      repeaterHash: r.repeaterHash,
+      repeaterName: r.repeaterName ?? null,
+      snr: r.snr ?? null,
+      heardAt: r.heardAt,
+      createdAt: r.heardAt,
+    }));
+    getHeardRepeatersForMessage.mockResolvedValue([
+      { repeaterHash: 'a3', repeaterName: 'Relay1', snr: 7 },
+    ]);
+
+    const m = new MeshCoreManager('src-a');
+    // Seed the in-memory pool with an outgoing message (no heardBy yet).
+    (m as any).messages = [
+      { id: 'sent-abc', fromPublicKey: 'mypk', text: 'hello', timestamp: 1000 },
+    ];
+    registerSend(m, 'sent-abc', 0);
+
+    dispatch(m, {
+      event_type: 'ota_packet',
+      data: { payload_type: GRP_TXT, path_hops: ['a3'], snr: 7 },
+    });
+    await flush();
+
+    const msgs = m.getRecentMessages(10);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].heardBy).toEqual([{ hash: 'a3', name: 'Relay1', snr: 7 }]);
+  });
+
   it('does not record anything when no pending channel send matches', async () => {
     const m = new MeshCoreManager('src-a');
     // No registerSend — nothing pending.

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -711,6 +711,19 @@ class MeshCoreManager extends EventEmitter {
         scopeCode: dbMsg.scopeCode ?? null,
         scopeName: dbMsg.scopeName ?? null,
       }));
+      // Enrich with heardBy so relay info survives server restarts (#3813).
+      if (this.messages.length > 0) {
+        const heardByMap = await databaseService.meshcore.getHeardRepeatersForMessages(
+          this.messages.map(m => m.id),
+          this.sourceId,
+        );
+        this.messages = this.messages.map(m => {
+          const heard = heardByMap[m.id];
+          return heard && heard.length > 0
+            ? { ...m, heardBy: heard.map(r => ({ hash: r.repeaterHash, name: r.repeaterName, snr: r.snr })) }
+            : m;
+        });
+      }
     } catch (loadErr) {
       logger.warn(`[MeshCore:${this.sourceId}] Failed to load messages from DB: ${(loadErr as Error).message}`);
       this.messages = [];
@@ -1420,6 +1433,13 @@ class MeshCoreManager extends EventEmitter {
       );
       const fullHeardBy = all.map((r) => ({ hash: r.repeaterHash, name: r.repeaterName, snr: r.snr }));
       dataEventEmitter.emitMeshCoreChannelHeard({ id: match.messageId, heardBy: fullHeardBy }, this.sourceId);
+
+      // Mirror heardBy into the in-memory pool so getRecentMessages() returns
+      // correct data after subsequent fetchMessages() calls (#3813).
+      const msgIdx = this.messages.findIndex(m => m.id === match.messageId);
+      if (msgIdx !== -1) {
+        this.messages[msgIdx] = { ...this.messages[msgIdx], heardBy: fullHeardBy };
+      }
 
       logger.debug(
         `[MeshCore:${this.sourceId}] Channel echo: msg=${match.messageId} +${heardBy.length} repeater(s), total=${fullHeardBy.length}`,


### PR DESCRIPTION
Fixes #3813

## Root cause

When a repeater re-floods an outgoing MeshCore channel message, `correlateChannelEcho()` correctly:
1. Saves the `heardBy` repeater set to the database
2. Emits the `meshcore:channel-heard` socket event → frontend updates the message's relay display ✅

But it **did not** update the server's in-memory message pool (`this.messages`).

When the user sent a second message, `sendMessage()` triggered `fetchMessages()` which calls `GET /api/meshcore/messages` → `getRecentMessages()` → `this.messages.slice(-limit)`. This returned the stale in-memory pool (no `heardBy`), and the React state was fully replaced, wiping the relay info that had been displayed.

## Changes

**`src/server/meshcoreManager.ts`**
- In `correlateChannelEcho()`: after emitting the socket event, mirror `heardBy` into the matching entry in `this.messages` so subsequent `getRecentMessages()` calls return correct data.
- In `connect()` initialization: enrich the in-memory message pool with `heardBy` from the DB when loading history on startup/reconnect, so relay info also survives server restarts.

**`src/server/meshcoreManager.channelHeard.test.ts`**
- Added regression test: verifies that after a self-echo correlation, `getRecentMessages()` returns the message with `heardBy` populated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCyB8Cozp8aeAd52eW4wnH)_