### PR TITLE
fix(meshcore): scroll to first unread (or bottom) on channel entry (#3810)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -132,6 +132,14 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // Per-channel last-read marker (idx → ms), persisted in localStorage scoped by
   // sourceId. Seeded from storage on mount/source change.
   const [lastRead, setLastRead] = useState<Record<number, number>>(() => loadLastRead(sourceId));
+  // Live mirror of `lastRead` so the channel-entry snapshot (#3810) can read the
+  // pre-read marker without re-subscribing to every marker change.
+  const lastReadRef = useRef(lastRead);
+  lastReadRef.current = lastRead;
+  // Pre-read marker snapshotted at channel entry, captured BEFORE the
+  // mark-on-view effect advances it. Used to locate the first-unread message so
+  // the stream can scroll there on entry (#3810).
+  const [entryReadTs, setEntryReadTs] = useState<number>(0);
   // Optional "channels with unread first" ordering (#3703), persisted globally.
   const [sortUnreadFirst, setSortUnreadFirst] = useState<boolean>(
     () => localStorage.getItem(SORT_UNREAD_FIRST_KEY) === 'true',
@@ -399,6 +407,22 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     return Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp);
   }, [history, messages, activeFilter]);
 
+  // Snapshot the active channel's pre-read marker on channel entry, BEFORE the
+  // mark-on-view effect below advances it (effects run in declaration order, so
+  // this one wins). Depends only on `active.id` so a later backlog load / mark
+  // doesn't clobber the snapshot. This is the boundary used to find the first
+  // unread message for the entry scroll (#3810).
+  useEffect(() => {
+    setEntryReadTs(lastReadRef.current[active.id] ?? 0);
+  }, [active.id]);
+
+  // The oldest unread message for this channel (timestamp strictly newer than
+  // the entry-read snapshot). Passed to the stream so it scrolls there on entry;
+  // `undefined` (everything already read) ⇒ the stream falls back to bottom.
+  const firstUnreadId = useMemo(() => {
+    return filtered.find(m => m.timestamp > entryReadTs)?.id;
+  }, [filtered, entryReadTs]);
+
   // Mark the active channel read up to its newest visible message. Runs whenever
   // the active channel's content changes (channel switch, backlog load, or a
   // live message arriving while it's open), so an open channel never shows as
@@ -611,6 +635,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           }}
           onNodeNameClick={onNodeNameClick}
           conversationKey={`channel-${active.id}`}
+          firstUnreadId={firstUnreadId}
           maxBytes={
             showScopeOverride && overrideScope !== null && overrideScope !== ''
               ? 120

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -6,7 +6,7 @@
  * message and whenever consecutive messages cross a calendar-day boundary,
  * but not between messages sent on the same day.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({
@@ -107,5 +107,96 @@ describe('MeshCoreMessageStream scope row (#3814)', () => {
     const scope = container.querySelector('.mc-message-scope');
     expect(scope).toBeTruthy();
     expect(scope?.textContent).toContain('berlin');
+  });
+});
+
+describe('MeshCoreMessageStream entry scroll (#3810)', () => {
+  let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Run rAF callbacks synchronously so the entry scroll commits during render.
+    vi.stubGlobal('requestAnimationFrame', (cb: (time: number) => void) => {
+      cb(0);
+      return 0;
+    });
+    scrollIntoViewSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewSpy as unknown as typeof Element.prototype.scrollIntoView;
+    // jsdom reports scrollHeight 0; force a non-zero value so the bottom-scroll
+    // path is observable via scrollTop.
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() { return 500; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (Element.prototype as Partial<typeof Element.prototype>).scrollIntoView;
+    delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight;
+  });
+
+  const threeMessages = () => {
+    const now = Date.now();
+    return [
+      msg('a', now - 3000, 'first'),
+      msg('b', now - 2000, 'second'),
+      msg('c', now - 1000, 'third'),
+    ];
+  };
+
+  it('scrolls the first-unread row into view on entry', () => {
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={threeMessages()}
+        conversationKey="channel-0"
+        firstUnreadId="b"
+        onSend={async () => true}
+      />,
+    );
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    // The scrolled element must be the row for the first-unread message.
+    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
+      container.querySelector('[data-message-id="b"]'),
+    );
+  });
+
+  it('scrolls to the bottom on entry when there is no unread anchor', () => {
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={threeMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    expect(list.scrollTop).toBe(500);
+  });
+
+  it('runs the entry scroll once the async backlog populates (empty → non-empty)', () => {
+    const { container, rerender } = render(
+      <MeshCoreMessageStream
+        messages={[]}
+        conversationKey="channel-0"
+        firstUnreadId="b"
+        onSend={async () => true}
+      />,
+    );
+    // Empty on first render (conversationKey already flipped) — nothing to scroll.
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+    // Backlog arrives for the SAME conversationKey.
+    rerender(
+      <MeshCoreMessageStream
+        messages={threeMessages()}
+        conversationKey="channel-0"
+        firstUnreadId="b"
+        onSend={async () => true}
+      />,
+    );
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
+      container.querySelector('[data-message-id="b"]'),
+    );
   });
 });

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -158,9 +158,15 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
           typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(firstUnreadId) : firstUnreadId
         }"]`;
         const row = container.querySelector<HTMLElement>(selector);
-        if (row) {
+        if (row && typeof row.scrollIntoView === 'function') {
           // Align the unread boundary near the top of the viewport.
           row.scrollIntoView({ block: 'start' });
+          return;
+        }
+        if (row) {
+          // Environments without scrollIntoView (e.g. jsdom): approximate by
+          // offsetting the container so the unread row sits near the top.
+          container.scrollTop = row.offsetTop - container.offsetTop;
           return;
         }
       }

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -15,8 +15,13 @@ interface MeshCoreMessageStreamProps {
   onSend: (text: string) => Promise<boolean>;
   onNodeNameClick?: (publicKey: string) => void;
   /** Stable key identifying the current conversation. When it changes, the
-   *  stream scrolls to the bottom. */
+   *  stream re-runs its entry scroll (to the first-unread row, or the bottom). */
   conversationKey?: string;
+  /** Id of the oldest unread message for this conversation, snapshotted at
+   *  channel entry. When provided, the stream scrolls this row into view on
+   *  entry (aligned near the top so the unread boundary is visible) instead of
+   *  jumping to the bottom. Absent (e.g. the DM view) ⇒ scroll to bottom. (#3810) */
+  firstUnreadId?: string;
   /** Maximum UTF-8 byte length for a message. Send is blocked when exceeded. */
   maxBytes?: number;
 }
@@ -63,6 +68,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   onSend,
   onNodeNameClick,
   conversationKey,
+  firstUnreadId,
   maxBytes = 130,
 }) => {
   const { t } = useTranslation();
@@ -121,16 +127,46 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     };
   }, [contacts]);
 
-  // Scroll to bottom whenever the conversation changes.
-  const prevKeyRef = useRef(conversationKey);
+  // Entry scroll (#3810): on conversation entry, scroll to the first-unread row
+  // (aligned near the top so the unread boundary is visible) or, when there is
+  // none, to the bottom. A channel's backlog is fetched ASYNCHRONOUSLY, so
+  // `messages` is often empty when `conversationKey` first flips — scrolling
+  // then would fire against empty content and leave the viewport stranded in the
+  // middle once the backlog renders. So we defer the entry scroll until messages
+  // are actually present, and only run it once per conversationKey (re-arming
+  // when the key changes). `entryScrollRef` tracks which key we've handled.
+  const entryScrollRef = useRef<{ key: string | undefined; done: boolean }>({
+    key: conversationKey,
+    done: false,
+  });
   useEffect(() => {
     const container = listRef.current;
     if (!container) return;
-    prevKeyRef.current = conversationKey;
+    const state = entryScrollRef.current;
+    if (state.key !== conversationKey) {
+      // New conversation — re-arm the entry scroll.
+      state.key = conversationKey;
+      state.done = false;
+    }
+    if (state.done) return;
+    // Wait for the (possibly async) backlog before committing the entry scroll.
+    if (messages.length === 0) return;
+    state.done = true;
     requestAnimationFrame(() => {
+      if (firstUnreadId) {
+        const selector = `[data-message-id="${
+          typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(firstUnreadId) : firstUnreadId
+        }"]`;
+        const row = container.querySelector<HTMLElement>(selector);
+        if (row) {
+          // Align the unread boundary near the top of the viewport.
+          row.scrollIntoView({ block: 'start' });
+          return;
+        }
+      }
       container.scrollTop = container.scrollHeight;
     });
-  }, [conversationKey]);
+  }, [conversationKey, messages.length, firstUnreadId]);
 
   // Auto-scroll on new messages only when the user is already near the bottom.
   useEffect(() => {
@@ -254,7 +290,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                   </span>
                 </div>
               )}
-              <div className={`mc-message-row ${outgoing ? 'outgoing' : ''}`}>
+              <div className={`mc-message-row ${outgoing ? 'outgoing' : ''}`} data-message-id={m.id}>
               <div className="mc-message-header">
                 {canClick ? (
                   <button


### PR DESCRIPTION
## Problem

Entering a MeshCore channel landed the viewport in the **middle** of message history instead of at the bottom (or, ideally, the first unread message).

## Root cause (a race)

`MeshCoreMessageStream` ran its entry scroll **only when `conversationKey` changed**. In the channels view, `conversationKey` (`channel-${active.id}`) flips *immediately* on channel switch, but the channel backlog is fetched **asynchronously** (`/messages/channel/${idx}`). So the scroll fired against empty/stale content, then the backlog rendered above it and shoved the viewport into the middle. The "auto-scroll on new messages" effect only scrolls when already near the bottom, so it never recovered.

The DM view never hit this because its messages arrive synchronously via props.

## Fix

- **`MeshCoreMessageStream`**
  - Re-arm the entry scroll per `conversationKey` and **defer it until messages are actually present** (empty → non-empty), so a late-arriving backlog triggers it (fixes the core race).
  - Add a stable `data-message-id` attribute to each message row.
  - On entry, scroll the **first-unread row** into view (aligned near the top so the unread boundary is visible); fall back to the existing **scroll-to-bottom** when there is no unread anchor (e.g. the DM view, which never passes one).
- **`MeshCoreChannelsView`**
  - Snapshot the pre-read last-read marker at channel entry, **before** the mark-on-view effect advances it (effects run in declaration order; the snapshot depends only on `active.id` so a later backlog load doesn't clobber it).
  - Compute the oldest unread message id and pass it to the stream as a new `firstUnreadId` prop.

The DM path is unchanged: it passes no `firstUnreadId`, so it scrolls to bottom exactly as before.

## Tests

Extended `MeshCoreMessageStream.test.tsx`:
- first-unread row is scrolled into view on entry when an anchor is provided
- scrolls to bottom on entry when there is no unread anchor
- the deferred entry scroll fires when the async backlog populates (empty → non-empty for the same `conversationKey`)

Full Vitest suite green (`success: true`, 0 failures). `tsc --noEmit` adds no new errors; changed files lint clean.

Fixes #3810

🤖 Generated with [Claude Code](https://claude.com/claude-code)