### PR TITLE
feat(meshcore): display scope/region on sent messages (#3814)

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -70,3 +70,42 @@ describe('MeshCoreMessageStream date separators', () => {
     expect(container.querySelectorAll('.mc-date-separator')).toHaveLength(0);
   });
 });
+
+describe('MeshCoreMessageStream scope row (#3814)', () => {
+  const SELF = 'abcdef0123456789';
+
+  function renderWithSelf(messages: MeshCoreMessage[]) {
+    return render(
+      <MeshCoreMessageStream
+        messages={messages}
+        selfPublicKey={SELF}
+        onSend={async () => true}
+      />,
+    );
+  }
+
+  it('renders the scope row on an outgoing message that used a scope', () => {
+    const { container } = renderWithSelf([
+      { id: 'a', fromPublicKey: SELF, text: 'hi', timestamp: Date.now(), scopeName: 'augsburg' },
+    ]);
+    const scope = container.querySelector('.mc-message-scope');
+    expect(scope).toBeTruthy();
+    expect(scope?.textContent).toContain('augsburg');
+  });
+
+  it('renders no scope row on an outgoing message with no scope', () => {
+    const { container } = renderWithSelf([
+      { id: 'a', fromPublicKey: SELF, text: 'hi', timestamp: Date.now(), scopeName: null },
+    ]);
+    expect(container.querySelector('.mc-message-scope')).toBeNull();
+  });
+
+  it('still renders the scope row on a received scoped message', () => {
+    const { container } = renderWithSelf([
+      { id: 'b', fromPublicKey: 'fedcba9876543210', text: 'hi', timestamp: Date.now(), scopeCode: 1234, scopeName: 'berlin' },
+    ]);
+    const scope = container.querySelector('.mc-message-scope');
+    expect(scope).toBeTruthy();
+    expect(scope?.textContent).toContain('berlin');
+  });
+});

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -312,7 +312,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                   {m.hopCount !== 0 && m.routePath ? ` · ${m.routePath.split(',').filter(Boolean).join(' → ')}` : ''}
                 </div>
               )}
-              {!outgoing && typeof m.scopeCode === 'number' && (
+              {(typeof m.scopeCode === 'number' || (m.scopeName != null && m.scopeName !== '')) && (
                 <div
                   className="mc-message-scope"
                   title={t('meshcore.scope_tooltip', 'The region/scope this message was sent with')}
@@ -321,7 +321,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                     ? t('meshcore.scope_unscoped', '🌐 no scope')
                     : m.scopeName
                       ? `🔒 ${m.scopeName}`
-                      : `🔒 #${m.scopeCode.toString(16).padStart(4, '0')}`}
+                      : `🔒 #${(m.scopeCode ?? 0).toString(16).padStart(4, '0')}`}
                 </div>
               )}
               {outgoing && m.heardBy && m.heardBy.length > 0 && expandedHeardBy.has(m.id) && (

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -10,7 +10,7 @@
  * meshcoreManager.channels.test.ts does — no real backend or DB.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreMessage } from './meshcoreManager.js';
 import databaseService from '../services/database.js';
 
 interface BridgeCall { cmd: string; params: Record<string, unknown>; }
@@ -513,5 +513,52 @@ describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
     const result = await manager.discoverRegions();
     expect(result).toEqual({ regions: [], perRepeater: [], noZeroHopRepeaters: true });
     expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
+  });
+});
+
+describe('MeshCoreManager — scope recorded on the sent message (#3814)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  // Capture the message object the manager emits/persists for an originated send.
+  const captureSent = (manager: MeshCoreManager): MeshCoreMessage[] => {
+    const sent: MeshCoreMessage[] = [];
+    manager.on('message', (m: MeshCoreMessage) => sent.push(m));
+    return sent;
+  };
+
+  it('records the per-message override scope as scopeName on the sent message', async () => {
+    const { manager } = makeManager({ channelScopes: { 1: 'muenchen' } });
+    const sent = captureSent(manager);
+    await manager.sendMessage('hi', undefined, 1, 'augsburg');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].scopeName).toBe('augsburg');
+  });
+
+  it('records the channel scope as scopeName on a normal channel send', async () => {
+    const { manager } = makeManager({ channelScopes: { 1: 'muenchen' } });
+    const sent = captureSent(manager);
+    await manager.sendMessage('hi', undefined, 1);
+    expect(sent[0].scopeName).toBe('muenchen');
+  });
+
+  it('records the source default scope as scopeName when the channel has none', async () => {
+    const { manager } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
+    const sent = captureSent(manager);
+    await manager.sendMessage('hi', undefined, 1);
+    expect(sent[0].scopeName).toBe('berlin');
+  });
+
+  it('leaves scopeName null on an unscoped send (no channel scope, no default)', async () => {
+    const { manager } = makeManager();
+    const sent = captureSent(manager);
+    await manager.sendMessage('hi', undefined, 1);
+    expect(sent[0].scopeName).toBeNull();
+  });
+
+  it('leaves scopeName null when an explicit empty override unscopes the send', async () => {
+    const { manager } = makeManager({ channelScopes: { 1: 'muenchen' } });
+    const sent = captureSent(manager);
+    await manager.sendMessage('hi', undefined, 1, '   ');
+    expect(sent[0].scopeName).toBeNull();
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2382,6 +2382,16 @@ class MeshCoreManager extends EventEmitter {
           sourceId: this.sourceId,
           expectedAckCrc: ackCrc ?? undefined,
           estTimeout: estTimeout ?? undefined,
+          // Record the region/scope this message was actually sent with (#3814)
+          // so the UI can display it on the sent message — useful for diagnosing
+          // why a scoped message may not have been received. `region` is the
+          // resolved region NAME (channel scope / source default / per-message
+          // override) or null when unscoped. We only set `scopeName`; the exact
+          // numeric transport code is a payload-dependent HMAC that can't be
+          // reconstructed post-send, and the UI gates the scope row on
+          // `scopeName` presence (no magic-number sentinel needed). A normal
+          // unscoped send leaves `scopeName` null, so it shows no scope row.
+          scopeName: region ?? null,
         };
         this.addMessage(sentMessage);
         this.emit('message', sentMessage);


### PR DESCRIPTION
## Summary

MeshCore lets a sender temporarily switch a channel message's scope/region when sending. Until now the scope (region) was only displayed on **received** messages, so a user could not see which scope a **sent** message actually used — making it hard to diagnose why a scoped message may not have been received.

This change records and displays the scope on sent messages too.

## What changed

- **Backend** (`performScopedSend` in `src/server/meshcoreManager.ts`): attaches the resolved region name to the outgoing message as `scopeName` (channel scope / source default / per-message override, or `null` when unscoped). `addMessage` already persists the `scopeCode`/`scopeName` columns and the realtime emit already carries the object, so the value round-trips with **no schema or migration change**.
  - We intentionally do **not** set a numeric `scopeCode` on sent messages: the exact transport code is a payload-dependent HMAC that cannot be reconstructed post-send. Display only needs the region name, and the UI is driven off `scopeName` presence (no magic-number sentinel).
- **Frontend** (`src/components/MeshCore/MeshCoreMessageStream.tsx`): the scope row now renders whenever scope info is present (`scopeName` set **or** a numeric `scopeCode`) instead of only for received messages. A normal unscoped send has no `scopeName`, so it shows no row. Received-message rendering (including the "🌐 no scope" case for `scopeCode === 0`) is unchanged.

## Tests

- Backend (`meshcoreManager.scope.test.ts`): a scoped send via per-message override / channel scope / source-default scope persists the matching `scopeName` on the emitted+persisted message; an unscoped send and an explicit empty-override send leave `scopeName` null.
- Component (`MeshCoreMessageStream.test.tsx`): an outgoing scoped message renders the scope row, an outgoing unscoped message does not, and received scoped messages still render it.

Full Vitest suite: 7661 passed, 0 test failures. (Pre-existing, unrelated `ts-overlapping-marker-spiderfier-leaflet` import-resolution failures in 4 spiderfier/map suites occur on the untouched baseline too.)

Closes #3814

🤖 Generated with [Claude Code](https://claude.com/claude-code)