### PR TITLE
fix(settings): unstick auto-acknowledge save when stored regex is RE2-incompatible (#3806)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2292,6 +2292,7 @@
   "automation.auto_ack.pattern_too_long": "Pattern too long (max 100 characters)",
   "automation.auto_ack.pattern_too_complex": "Pattern too complex or may cause performance issues",
   "automation.auto_ack.invalid_regex": "Invalid regex syntax",
+  "automation.auto_ack.unsupported_regex": "Lookaround (?=, ?!, ?<=, ?<!) and backreferences (\\1) are not supported. Use a simpler pattern.",
   "automation.auto_ack.active_channels": "Active Channels",
   "automation.auto_ack.active_channels_description": "Select which channels and direct messages should have auto-acknowledge enabled",
   "automation.auto_ack.direct_messages": "Direct Messages",

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -13,6 +13,7 @@ import {
   AUTOACK_CELLS,
   matrixToSettings,
 } from '../utils/autoAckMatrix';
+import { hasRE2IncompatibleConstructs } from '../utils/autoAckRegex';
 
 interface AutoAcknowledgeSectionProps {
   enabled: boolean;
@@ -137,6 +138,13 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
       return { valid: false, error: t('automation.auto_ack.pattern_too_complex') };
     }
 
+    // Reject lookaround/backreferences the server's RE2 engine can't compile
+    // (#3806). The browser's native RegExp below would happily accept them,
+    // letting a pattern be persisted that every subsequent save then 400s on.
+    if (hasRE2IncompatibleConstructs(pattern)) {
+      return { valid: false, error: t('automation.auto_ack.unsupported_regex') };
+    }
+
     // Try to compile
     try {
       new RegExp(pattern, 'i');
@@ -249,7 +257,18 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           showToast(t('automation.insufficient_permissions'), 'error');
           return;
         }
-        throw new Error(`Server returned ${response.status}`);
+        // Surface the server's specific error (e.g. an invalid regex) instead of
+        // the generic failure toast, so a stuck user understands what to fix
+        // rather than seeing an opaque "save failed" message (#3806).
+        let serverError = '';
+        try {
+          const body = await response.json();
+          if (body && typeof body.error === 'string') serverError = body.error;
+        } catch {
+          // Response had no JSON body — fall back to the generic message below.
+        }
+        showToast(serverError || t('automation.settings_save_failed'), 'error');
+        return;
       }
 
       // Only update parent state after successful API call (no localStorage)

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -262,6 +262,71 @@ describe('settingsRoutes', () => {
       expect(res.body.error).toContain('Invalid regex');
     });
 
+    // #3806: RE2 (server) rejects lookaround/backreferences that the browser's
+    // native RegExp accepts. The handler must keep rejecting such patterns when
+    // auto-ack is being enabled, but must NOT freeze the whole settings POST
+    // when auto-ack is being disabled with a previously-persisted bad regex.
+    describe('autoAckRegex RE2 leniency (#3806)', () => {
+      it('rejects a lookaround pattern when enabling auto-ack', async () => {
+        const app = createApp(adminUser);
+
+        const res = await request(app)
+          .post('/api/settings')
+          .send({ autoAckEnabled: 'true', autoAckRegex: '^(?!bot)test' })
+          .expect(400);
+
+        expect(res.body.error).toMatch(/lookaround|backreference/i);
+        expect(databaseService.settings.setSettings).not.toHaveBeenCalled();
+      });
+
+      it('allows toggling auto-ack OFF with a previously-persisted bad regex', async () => {
+        const app = createApp(adminUser);
+        // Simulate an install that already persisted an RE2-incompatible pattern.
+        (databaseService as any).settings.getAllSettings.mockResolvedValue({
+          meshName: 'TestMesh',
+          autoAckEnabled: 'true',
+          autoAckRegex: '^(?!bot)test',
+        });
+
+        // Client re-POSTs the same (unchanged) bad regex while disabling.
+        await request(app)
+          .post('/api/settings')
+          .send({ autoAckEnabled: 'false', autoAckRegex: '^(?!bot)test' })
+          .expect(200);
+
+        expect(databaseService.settings.setSettings).toHaveBeenCalledWith(
+          expect.objectContaining({ autoAckEnabled: 'false', autoAckRegex: '^(?!bot)test' })
+        );
+      });
+
+      it('rejects newly changing the regex to a bad pattern even while disabled', async () => {
+        const app = createApp(adminUser);
+        (databaseService as any).settings.getAllSettings.mockResolvedValue({
+          meshName: 'TestMesh',
+          autoAckEnabled: 'false',
+          autoAckRegex: '^(test|ping)',
+        });
+
+        const res = await request(app)
+          .post('/api/settings')
+          .send({ autoAckEnabled: 'false', autoAckRegex: '^(?!bot)test' })
+          .expect(400);
+
+        expect(res.body.error).toMatch(/lookaround|backreference/i);
+      });
+
+      it('accepts a valid regex when enabling auto-ack', async () => {
+        const app = createApp(adminUser);
+
+        await request(app)
+          .post('/api/settings')
+          .send({ autoAckEnabled: 'true', autoAckRegex: '^(test|ping)' })
+          .expect(200);
+
+        expect(databaseService.settings.setSettings).toHaveBeenCalled();
+      });
+    });
+
     it('should return 400 for out-of-range inactiveNodeThresholdHours', async () => {
       const app = createApp(adminUser);
 

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -200,22 +200,45 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       }
     }
 
-    // Validate autoAckRegex pattern
+    // Validate autoAckRegex pattern.
+    //
+    // The pattern is validated with RE2 (compileUserRegex), which — unlike the
+    // browser's native RegExp used by the client — rejects lookaround and
+    // backreferences (`(?=`, `(?<=`, `(?!`, `(?<!`, `\1`, …). Without the guard
+    // below, an install that previously persisted such a pattern would be
+    // permanently stuck: every save re-POSTs the stored regex and the whole
+    // request 400s, so the user can't even toggle auto-ack OFF (#3806).
+    //
+    // We therefore only hard-validate when the regex actually matters: when
+    // auto-acknowledge is being (or staying) enabled, or when the regex value
+    // is actually changing. Disabling auto-ack — or re-saving an unchanged bad
+    // pattern while it's disabled — is always allowed so the section unsticks.
     if ('autoAckRegex' in filteredSettings) {
       const pattern = filteredSettings.autoAckRegex;
 
-      if (pattern.length > 100) {
-        return res.status(400).json({ error: 'Regex pattern too long (max 100 characters)' });
-      }
+      const willBeEnabled =
+        'autoAckEnabled' in filteredSettings
+          ? filteredSettings.autoAckEnabled === 'true'
+          : currentSettings.autoAckEnabled === 'true';
+      const regexChanged = pattern !== (currentSettings.autoAckRegex ?? '');
 
-      if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(pattern)) {
-        return res.status(400).json({ error: 'Regex pattern too complex or may cause performance issues' });
-      }
+      if (willBeEnabled || regexChanged) {
+        if (pattern.length > 100) {
+          return res.status(400).json({ error: 'Regex pattern too long (max 100 characters)' });
+        }
 
-      try {
-        compileUserRegex(pattern, 'i');
-      } catch (error) {
-        return res.status(400).json({ error: 'Invalid regex syntax' });
+        if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(pattern)) {
+          return res.status(400).json({ error: 'Regex pattern too complex or may cause performance issues' });
+        }
+
+        try {
+          compileUserRegex(pattern, 'i');
+        } catch (error) {
+          return res.status(400).json({
+            error:
+              'Invalid regex syntax: lookaround and backreferences (e.g. (?=, (?!, (?<=, \\1) are not supported. Use a simpler pattern.',
+          });
+        }
       }
     }
 

--- a/src/utils/autoAckRegex.test.ts
+++ b/src/utils/autoAckRegex.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for the client-side RE2-compatibility guard used by
+ * AutoAcknowledgeSection's regex validator (#3806).
+ *
+ * The browser validates auto-ack patterns with native RegExp, which accepts
+ * lookaround and backreferences. The server compiles the same pattern with RE2,
+ * which rejects them. This guard mirrors the server's accept set so a pattern
+ * that the server cannot compile can never be persisted from the UI.
+ */
+import { describe, it, expect } from 'vitest';
+import { hasRE2IncompatibleConstructs } from './autoAckRegex';
+
+describe('hasRE2IncompatibleConstructs', () => {
+  it('rejects negative lookahead', () => {
+    expect(hasRE2IncompatibleConstructs('^(?!bot)test')).toBe(true);
+  });
+
+  it('rejects positive lookahead', () => {
+    expect(hasRE2IncompatibleConstructs('foo(?=bar)')).toBe(true);
+  });
+
+  it('rejects positive lookbehind', () => {
+    expect(hasRE2IncompatibleConstructs('(?<=foo)bar')).toBe(true);
+  });
+
+  it('rejects negative lookbehind', () => {
+    expect(hasRE2IncompatibleConstructs('(?<!foo)bar')).toBe(true);
+  });
+
+  it('rejects backreferences', () => {
+    expect(hasRE2IncompatibleConstructs('(test)\\1')).toBe(true);
+  });
+
+  it('accepts plain alternation patterns', () => {
+    expect(hasRE2IncompatibleConstructs('^(test|ping)')).toBe(false);
+  });
+
+  it('accepts non-capturing groups', () => {
+    expect(hasRE2IncompatibleConstructs('^(?:test|ping)$')).toBe(false);
+  });
+
+  it('accepts named capture groups (supported by RE2)', () => {
+    expect(hasRE2IncompatibleConstructs('(?<word>test)')).toBe(false);
+  });
+
+  it('accepts character classes and anchors', () => {
+    expect(hasRE2IncompatibleConstructs('^[a-z0-9]+$')).toBe(false);
+  });
+});

--- a/src/utils/autoAckRegex.ts
+++ b/src/utils/autoAckRegex.ts
@@ -1,0 +1,18 @@
+/**
+ * Auto-acknowledge regex helpers shared by the client validator.
+ *
+ * The server validates auto-ack patterns with RE2 (see `src/utils/safeRegex.ts`),
+ * which — unlike the browser's native `RegExp` — rejects lookaround and
+ * backreferences. The client must mirror that accept set so a pattern the server
+ * cannot compile is never persisted; otherwise the save 400s and the whole
+ * Auto-Acknowledge section freezes (#3806).
+ */
+
+/**
+ * Returns true when `pattern` uses regex constructs that RE2 cannot compile:
+ * lookaround (`(?=`, `(?!`, `(?<=`, `(?<!`) — but NOT named capture groups like
+ * `(?<name>)`, which RE2 supports — or backreferences (`\1`…`\9`).
+ */
+export function hasRE2IncompatibleConstructs(pattern: string): boolean {
+  return /\(\?<?[=!]/.test(pattern) || /\\[1-9]/.test(pattern);
+}


### PR DESCRIPTION
## Summary

Fixes #3806 — "Auto Acknowledge settings return 400 after saving other automation settings." Every auto-acknowledge save (including merely toggling auto-ack OFF) returned HTTP 400, freezing the section.

## Root cause

A regex-engine validation divergence:

- **Server** validates `autoAckRegex` with **RE2** (`compileUserRegex` in `src/utils/safeRegex.ts`), which **throws** on lookaround/backreferences (`(?=`, `(?<=`, `(?!`, `(?<!`, `\1`...). The 400 came from `settingsRoutes.ts` (`compileUserRegex` catch → `400 Invalid regex syntax`).
- **Client** validated the same field with native `new RegExp(...)`, which **accepts** those constructs.
- The save handler **always** re-POSTs the stored regex regardless of the enabled toggle, and the server validated whenever the key was present. So once an RE2-incompatible pattern was persisted, every later save re-sent it and got 400 — the section was frozen, and the generic client toast hid the real reason.

## Fix

1. **Server leniency (`src/server/routes/settingsRoutes.ts`)** — only hard-validate `autoAckRegex` when auto-acknowledge is being/staying **enabled** OR the regex value is **actually changing**. Disabling auto-ack, or re-saving an unchanged bad pattern while it is disabled, no longer 400s, so existing installs unstick. A newly-supplied invalid pattern is still rejected when enabling, now with a message that names the unsupported lookaround/backreference constructs.
2. **Client validator alignment (`src/components/AutoAcknowledgeSection.tsx`, `src/utils/autoAckRegex.ts`)** — structurally reject lookaround (`(?=`, `(?<=`, `(?!`, `(?<!`) and backreferences (`\1`…`\9`) with a clear inline message. RE2 can't run in the browser, so this mirrors the server's accept set and prevents an RE2-incompatible pattern from ever being persisted. (Named groups like `(?<name>)` and non-capturing groups remain allowed.)
3. **Surface the server error** — on a non-OK save, the section now shows the server's `{ error }` body instead of the generic `settings_save_failed` toast, so a stuck user understands it is the regex.

## Tests

- `src/server/routes/settingsRoutes.test.ts`: lookaround rejected when enabling; toggling auto-ack OFF with a previously-persisted bad regex succeeds (no 400); changing to a bad pattern while disabled is still rejected; valid regex accepted when enabling.
- `src/utils/autoAckRegex.test.ts`: lookaround/backreference rejection + accepted forms (non-capturing groups, named groups, character classes).
- Full Vitest suite: **7683 passed, 0 failed, 0 failed suites** (`success: true`). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)