### PR TITLE
fix(meshcore): serialize remote status requests to stop response cross-talk (#3815)

### DIFF
--- a/src/server/meshcoreNativeBackend.statusSerialization.test.ts
+++ b/src/server/meshcoreNativeBackend.statusSerialization.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression tests for #3815 — MeshCoreNativeBackend remote-status serialization.
+ *
+ * The vendored meshcore.js `getStatus()` registers a `.once` listener on the
+ * SHARED, tag-less `StatusResponse` push event. When several `getStatus` calls
+ * are in flight on the same connection a single arriving response fires EVERY
+ * pending once-listener: the matching one resolves while all the others log
+ * `"onStatusResponsePush is not for this status request, ignoring..."`, get
+ * consumed by `.once`, and hang until their own timeout. That is the
+ * self-amplifying log burst + spurious timeouts in #3815.
+ *
+ * The backend now serializes + dedupes status requests per connection. These
+ * tests assert:
+ *   1. Two concurrent get_status for the SAME key issue only ONE underlying
+ *      getStatus and both resolve with the same result.
+ *   2. Two concurrent get_status for DIFFERENT keys do not overlap — the
+ *      second's underlying call starts only after the first settles.
+ *   3. A rejection in the first request releases the lock so the next proceeds.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { MeshCoreNativeBackend, __setMeshCoreModule } from './meshcoreNativeBackend.js';
+
+const ResponseCodes = { Ok: 0, Err: 1, SelfInfo: 5, Sent: 6 };
+const PushCodes = { Advert: 0x80, PathUpdated: 0x81, MsgWaiting: 0x83, NewAdvert: 0x8a, StatusResponse: 0x84 };
+
+interface Deferred {
+  key: Uint8Array;
+  resolve: (value: any) => void;
+  reject: (err?: any) => void;
+}
+
+/** Minimal mock connection whose getStatus returns externally-controllable
+ *  deferreds so the test can observe call ordering and settle them by hand. */
+class StatusMockConnection extends EventEmitter {
+  public getStatusCalls: Uint8Array[] = [];
+  public pending: Deferred[] = [];
+
+  public selfInfoToEmit: any = {
+    type: 1,
+    txPower: 22,
+    maxTxPower: 22,
+    publicKey: Uint8Array.from(new Array(32).fill(0)),
+    advLat: 0,
+    advLon: 0,
+    manualAddContacts: 0,
+    radioFreq: 915525,
+    radioBw: 62500,
+    radioSf: 11,
+    radioCr: 5,
+    name: 'TestNode',
+  };
+
+  async connect() {
+    setTimeout(() => this.emit(ResponseCodes.SelfInfo, this.selfInfoToEmit), 1);
+  }
+  async close() {}
+  async getSelfInfo() {
+    return this.selfInfoToEmit;
+  }
+  async getContacts() {
+    return [];
+  }
+
+  getStatus(key: Uint8Array): Promise<any> {
+    this.getStatusCalls.push(key);
+    return new Promise((resolve, reject) => {
+      this.pending.push({ key, resolve, reject });
+    });
+  }
+}
+
+function installMock(): { current: StatusMockConnection | null } {
+  const ref: { current: StatusMockConnection | null } = { current: null };
+  class TrackedSerial extends StatusMockConnection {
+    constructor(_path: string) {
+      super();
+      ref.current = this;
+    }
+  }
+  __setMeshCoreModule({
+    NodeJSSerialConnection: TrackedSerial as any,
+    TCPConnection: TrackedSerial as any,
+    Constants: { ResponseCodes, PushCodes } as any,
+  });
+  return ref;
+}
+
+async function makeBackend() {
+  const backend = new MeshCoreNativeBackend('src-1', {
+    connectionType: 'serial',
+    serialPort: '/dev/ttyUSB0',
+  });
+  await backend.connect();
+  return backend;
+}
+
+// Two distinct full 64-char keys (no contact lookup needed).
+const KEY_A = 'aa'.repeat(32);
+const KEY_B = 'bb'.repeat(32);
+
+describe('MeshCoreNativeBackend get_status serialization (#3815)', () => {
+  let ref: { current: StatusMockConnection | null };
+
+  beforeEach(() => {
+    ref = installMock();
+  });
+
+  afterEach(() => {
+    __setMeshCoreModule(null);
+  });
+
+  it('dedupes two concurrent get_status for the SAME key into one underlying request', async () => {
+    const backend = await makeBackend();
+    const conn = ref.current!;
+
+    const p1 = backend.sendCommand('get_status', { public_key: KEY_A });
+    const p2 = backend.sendCommand('get_status', { public_key: KEY_A });
+
+    // Let the dispatch/dedupe microtasks flush.
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Only ONE underlying getStatus should have been issued for the shared key.
+    expect(conn.getStatusCalls).toHaveLength(1);
+    expect(conn.pending).toHaveLength(1);
+
+    // Settle the single in-flight request — both callers resolve with it.
+    conn.pending[0].resolve({ batt_milli_volts: 4200, total_up_time_secs: 1234 });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.success).toBe(true);
+    expect(r2.success).toBe(true);
+    expect(r1.data?.bat_mv).toBe(4200);
+    expect(r2.data?.bat_mv).toBe(4200);
+    expect(r1.data?.up_secs).toBe(1234);
+    // Still only one underlying request total.
+    expect(conn.getStatusCalls).toHaveLength(1);
+  });
+
+  it('serializes get_status for DIFFERENT keys so the second starts only after the first settles', async () => {
+    const backend = await makeBackend();
+    const conn = ref.current!;
+
+    const p1 = backend.sendCommand('get_status', { public_key: KEY_A });
+    const p2 = backend.sendCommand('get_status', { public_key: KEY_B });
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    // The second request must NOT have issued its underlying call yet — it is
+    // queued behind the first so only one StatusResponse listener is active.
+    expect(conn.getStatusCalls).toHaveLength(1);
+    expect(Array.from(conn.getStatusCalls[0])).toEqual(Array.from(Buffer.from(KEY_A, 'hex')));
+
+    // Settle the first; the second's underlying call should now fire.
+    conn.pending[0].resolve({ batt_milli_volts: 4000 });
+    const r1 = await p1;
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(conn.getStatusCalls).toHaveLength(2);
+    expect(Array.from(conn.getStatusCalls[1])).toEqual(Array.from(Buffer.from(KEY_B, 'hex')));
+
+    conn.pending[1].resolve({ batt_milli_volts: 3800 });
+    const r2 = await p2;
+
+    expect(r1.success).toBe(true);
+    expect(r1.data?.bat_mv).toBe(4000);
+    expect(r2.success).toBe(true);
+    expect(r2.data?.bat_mv).toBe(3800);
+  });
+
+  it('releases the lock when the first request rejects so the next proceeds', async () => {
+    const backend = await makeBackend();
+    const conn = ref.current!;
+
+    const p1 = backend.sendCommand('get_status', { public_key: KEY_A });
+    const p2 = backend.sendCommand('get_status', { public_key: KEY_B });
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(conn.getStatusCalls).toHaveLength(1);
+
+    // First request fails (library rejects with no argument on a firmware Err).
+    conn.pending[0].reject(undefined);
+    const r1 = await p1;
+    expect(r1.success).toBe(false);
+
+    // The queue must not be wedged — the second request now issues its call.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(conn.getStatusCalls).toHaveLength(2);
+
+    conn.pending[1].resolve({ batt_milli_volts: 3700 });
+    const r2 = await p2;
+    expect(r2.success).toBe(true);
+    expect(r2.data?.bat_mv).toBe(3700);
+  });
+
+  it('clears the in-flight entry after settle so a later request for the same key issues a fresh call', async () => {
+    const backend = await makeBackend();
+    const conn = ref.current!;
+
+    const p1 = backend.sendCommand('get_status', { public_key: KEY_A });
+    await new Promise((r) => setTimeout(r, 5));
+    conn.pending[0].resolve({ batt_milli_volts: 4100 });
+    await p1;
+
+    // A brand-new request for the same key after the first settled is NOT a
+    // dedupe hit — it must issue a second underlying getStatus.
+    const p2 = backend.sendCommand('get_status', { public_key: KEY_A });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(conn.getStatusCalls).toHaveLength(2);
+    conn.pending[1].resolve({ batt_milli_volts: 4050 });
+    const r2 = await p2;
+    expect(r2.data?.bat_mv).toBe(4050);
+  });
+});

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -896,6 +896,58 @@ export class MeshCoreNativeBackend extends EventEmitter {
     return run;
   }
 
+  /**
+   * Serializes remote status requests (library `getStatus`) on THIS connection
+   * and dedupes concurrent requests for the same contact.
+   *
+   * The vendored meshcore.js `getStatus()` registers a `.once` listener on the
+   * SHARED, tag-less `StatusResponse` push event and only keeps the response
+   * whose `pubKeyPrefix` matches the request. When multiple `getStatus` calls
+   * are in flight on one connection, a single arriving `StatusResponse` fires
+   * EVERY pending once-listener: the matching one resolves, while all the others
+   * log `"onStatusResponsePush is not for this status request, ignoring..."`,
+   * get consumed by `.once`, and then hang until their own timeout. That is the
+   * self-amplifying log burst + spurious timeouts in #3815 — cannibalized
+   * requests pile up while new ones keep arriving from the repeater stats panel.
+   *
+   * Fix: only one status request may listen at a time. Distinct contacts chain
+   * through a per-instance promise (so the second waits for the first to settle),
+   * and concurrent requests for the SAME contact share the single in-flight
+   * promise instead of issuing a second request.
+   *
+   * Per-instance (per-source/per-connection) by construction — each source owns
+   * its own backend + physical connection, so this never serializes across
+   * sources. The lock always releases (the in-flight entry is cleared in a
+   * `finally`, and the chain advances regardless of how the op settled), so a
+   * reject/timeout in one request never wedges the queue.
+   */
+  private statusOpChain: Promise<unknown> = Promise.resolve();
+  private inFlightStatus = new Map<string, Promise<any>>();
+
+  private getStatusSerialized(connection: AnyConnection, publicKey: Uint8Array): Promise<any> {
+    const keyHex = bytesToHex(publicKey);
+
+    // In-flight dedupe: a concurrent request for the same contact shares the
+    // single outstanding StatusResponse request instead of issuing a second.
+    const existing = this.inFlightStatus.get(keyHex);
+    if (existing) return existing;
+
+    // Serialize distinct requests so only one StatusResponse listener is active
+    // at a time. Chain after whatever is queued, regardless of how it settled
+    // (using the same fn for both handlers means a prior rejection still
+    // releases the queue).
+    const issue = () => connection.getStatus(publicKey);
+    const tracked = this.statusOpChain.then(issue, issue).finally(() => {
+      this.inFlightStatus.delete(keyHex);
+    });
+    // Advance the chain to this op's completion. Swallow settlement here so the
+    // chain never carries an unhandled rejection — callers still receive
+    // `tracked` (and its rejection) directly.
+    this.statusOpChain = tracked.then(() => {}, () => {});
+    this.inFlightStatus.set(keyHex, tracked);
+    return tracked;
+  }
+
   private async dispatch(cmd: string, params: Record<string, unknown>): Promise<any> {
     if (!this.connection || !this.constants) {
       throw new Error('Native backend not connected');
@@ -1296,7 +1348,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
       case 'get_status': {
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Status target not found');
-        const stats = await c.getStatus(publicKey);
+        // Serialize + dedupe on this connection: the library's getStatus listens
+        // on the shared, tag-less StatusResponse event with a `.once` handler, so
+        // overlapping requests cannibalize each other's response and spam the
+        // "ignoring..." log until they time out (#3815).
+        const stats = await this.getStatusSerialized(c, publicKey);
         return {
           bat_mv: stats?.batt_milli_volts,
           up_secs: stats?.total_up_time_secs,


### PR DESCRIPTION
## Summary

Users reported a self-amplifying burst of `onStatusResponsePush is not for this status request, ignoring...` log lines (many within the same second), often accompanied by remote-status requests that never resolve.

### Root cause: `.once` cross-talk on a shared event

The vendored `@liamcottle/meshcore.js` `getStatus(contactPublicKey)` registers its response handler with `this.once(Constants.PushCodes.StatusResponse, onStatusResponsePush)` on a **single shared** `StatusResponse` event, then sends the status request. The handler logs the "ignoring" line and `return`s when the incoming response's `pubKeyPrefix` doesn't match the request's.

Because the listener is `.once` on a shared event:

- A **single** in-flight `getStatus` can log "ignoring" at most **once** (its listener is then consumed).
- So a **burst** of these lines in one second means **many** `getStatus` calls were in flight on the same connection simultaneously. When one `StatusResponse` arrives, the emitter fires **every** pending once-listener: the one whose prefix matches resolves; **all the others** log "ignoring", get consumed by `.once`, and then **time out**. It is self-amplifying — cannibalized requests hang until timeout while new ones (from the repeater stats panel: remounts, rapid repeater switching, refreshes piling up) keep arriving.

The backend dispatched `get_status` straight to `c.getStatus()` with **no in-flight guard** (`src/server/meshcoreNativeBackend.ts`), so nothing prevented overlap.

## Fix: serialize + dedupe status requests per connection

A small, well-contained layer in `MeshCoreNativeBackend`:

1. **In-flight dedupe by resolved publicKey** — a concurrent `get_status` for the same contact awaits the **same** promise instead of issuing a second request.
2. **Per-instance promise-chain mutex** (`statusOpChain`) — distinct contacts never have overlapping outstanding `StatusResponse` requests; the second waits for the first to **settle** (resolve, reject, or timeout) before sending.
3. **Always release** — the in-flight entry is cleared in a `finally` and the chain advances regardless of how the op settled, so a reject/timeout never wedges the queue.

The mutex is an instance field, so it is inherently **per-source/per-connection** and never serializes across sources. This mirrors the existing `runExclusiveRadioOp` / `radioOpChain` pattern already in the file. **The library is not modified.**

Because only one status request listens at a time, the prefix mismatch never happens — which removes both the **log burst** and the **spurious timeouts**.

### Optional follow-up (not in this PR)
The library's hardcoded `console.log` could additionally be silenced via `patch-package`, but the serialization above is the primary and sufficient fix, so no `patch-package` infra is added here to keep scope tight.

## Tests

New `src/server/meshcoreNativeBackend.statusSerialization.test.ts`:
- Two concurrent `get_status` for the **same** key issue only **one** underlying `getStatus` and both resolve with the same result.
- Two concurrent `get_status` for **different** keys do not overlap — the second's underlying call starts only after the first settles (verified via deferreds the test controls).
- A **rejection** in the first request releases the lock so the next proceeds.
- The in-flight entry is cleared after settle so a later same-key request issues a fresh call.

Full Vitest suite: **7695 passed, 0 failed, 0 suite failures**. `tsc` adds no new errors; changed files lint clean.

Fixes #3815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
