### PR TITLE
fix(meshcore): relabel 'Errors' → 'Error Events' in Remote Node Status panel

### DIFF
--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
@@ -109,7 +109,7 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
               <StatField label={t('meshcore.remoteStats.last_snr', 'Last SNR')} value={formatSnr(status.lastSnr)} />
               <StatField label={t('meshcore.remoteStats.noise_floor', 'Noise floor')} value={formatRssi(status.noiseFloor)} />
               <StatField label={t('meshcore.remoteStats.air_time', 'Air time')} value={formatAirTime(status.airTimeSecs)} />
-              <StatField label={t('meshcore.remoteStats.errors', 'Errors')} value={formatNumber(status.errors)} />
+              <StatField label={t('meshcore.remoteStats.errors', 'Error Events')} value={formatNumber(status.errors)} />
 
               <div className="mrs-section">
                 <h5>{t('meshcore.remoteStats.rx', 'Received')}</h5>


### PR DESCRIPTION
## Summary

- Relabels the **"Errors"** stat in the MeshCore Remote Node Status panel to **"Error Events"** to accurately describe what the underlying `err_events` counter actually measures.

## Background

Fixes #3822.

The `SendStatusReq` status response contains a `err_events` field (uint16, max 65 535). This counter tracks firmware-level error *events* — things like radio resets, watchdog fires, and other recoverable hardware faults. It is **not** a packet receive-error counter.

The packet receive-error counter is a separate uint32 field (`nRecvErrors`) that can reach values in the tens of thousands. Because its max value exceeds the uint16 ceiling of `err_events`, the two values can never match — they measure completely different things.

The old label **"Errors"** was ambiguous enough that users compared it against the receive-error count and concluded MeshMonitor was reporting the wrong number (see #3822). Renaming it **"Error Events"** makes the field's scope explicit.

## Changes

- `src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx` — default English label for `meshcore.remoteStats.errors` changed from `'Errors'` to `'Error Events'`.

## Test plan

- [ ] Open Remote Node Status panel for a MeshCore repeater — confirm the field now reads **"Error Events"** instead of "Errors".
- [ ] Verify the numeric value is unchanged.
- [ ] Confirm no other stats labels were affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qsoe9fgYHz4T24FptwV7PZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qsoe9fgYHz4T24FptwV7PZ)_