### PR TITLE
feat(meshcore): restore focus to message input after send (#3823)

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -7,7 +7,7 @@
  * but not between messages sent on the same day.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -198,5 +198,38 @@ describe('MeshCoreMessageStream entry scroll (#3810)', () => {
     expect(scrollIntoViewSpy.mock.instances[0]).toBe(
       container.querySelector('[data-message-id="b"]'),
     );
+  });
+});
+
+describe('MeshCoreMessageStream focus restore (#3823)', () => {
+  it('returns focus to the input after a send resolves', async () => {
+    // Controllable send so we can observe the disabled→enabled transition.
+    let resolveSend: (ok: boolean) => void = () => {};
+    const onSend = vi.fn(() => new Promise<boolean>((r) => { resolveSend = r; }));
+
+    render(<MeshCoreMessageStream messages={[]} onSend={onSend} />);
+    const input = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'hello' } });
+    input.focus();
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    // While sending, the input is disabled (so the browser drops focus).
+    expect(input).toBeDisabled();
+
+    // Resolve the send: input re-enables and focus is restored to it (#3823).
+    resolveSend(true);
+    await waitFor(() => expect(input).not.toBeDisabled());
+    await waitFor(() => expect(document.activeElement).toBe(input));
+  });
+
+  it('does NOT steal focus when no send was initiated', async () => {
+    render(<MeshCoreMessageStream messages={[]} onSend={async () => true} />);
+    const input = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+    // A re-render unrelated to sending must not yank focus into the input.
+    fireEvent.change(input, { target: { value: 'x' } });
+    document.body.focus();
+    await waitFor(() => expect(input).not.toBeDisabled());
+    expect(document.activeElement).not.toBe(input);
   });
 });

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -218,9 +218,20 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   const byteCounter = useMemo(() => formatByteCount(byteLen, maxBytes), [byteLen, maxBytes]);
   const overLimit = byteLen > maxBytes;
 
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const refocusRef = useRef(false);
+
+  useEffect(() => {
+    if (!sending && refocusRef.current) {
+      refocusRef.current = false;
+      if (!disabled) inputRef.current?.focus();
+    }
+  }, [sending, disabled]);
+
   const handleSend = async () => {
     if (!draft.trim() || sending || overLimit) return;
     setSending(true);
+    refocusRef.current = true;
     const ok = await onSend(draft);
     setSending(false);
     if (ok) setDraft('');
@@ -386,6 +397,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
       </div>
       <div className="meshcore-send-bar">
         <input
+          ref={inputRef}
           type="text"
           value={draft}
           onChange={e => setDraft(e.target.value)}


### PR DESCRIPTION
## Summary

After sending a MeshCore message (channel or DM), keep keyboard focus in the **"Type a message…"** input so the user can type the next message without clicking back into the field. Fixes #3823.

## Root cause

While a send is in flight the input is `disabled`, so the browser drops focus. Calling `.focus()` directly in the async send handler fires before React re-enables the input, so the call is ignored.

## Fix

Mirrors the established pattern already used in the MeshCore CLI admin console (`CliConsoleBody.tsx`): an `inputRef` on the `<input>` plus a `refocusRef` flag set when a send begins, and a `useEffect` watching `[sending, disabled]` that restores focus once `sending` flips back to `false` and the input is re-enabled.

## Changes

- `src/components/MeshCore/MeshCoreMessageStream.tsx` — `inputRef` + `refocusRef` + refocus `useEffect`; `ref` attached to the message input. (12 lines.)
- `src/components/MeshCore/MeshCoreMessageStream.test.tsx` — regression tests: focus returns to the input after a send resolves; an unrelated re-render does not steal focus when no send was initiated.

## Testing

- Full Vitest suite green (7704 passed, 0 failed); `tsc --noEmit` clean.

Notes: original fix authored on `claude/determined-planck-im8a2u`; rebased onto current `main` (no conflicts) and regression tests added.

Fixes #3823

🤖 Generated with [Claude Code](https://claude.com/claude-code)
