### PR TITLE
fix(meshcore): pin virtual-node DeviceInfo to protocol v1 (#3705)

### DIFF
--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -9,6 +9,7 @@ import {
   PushCodes,
   FRAME_APP_TO_NODE,
   FRAME_NODE_TO_APP,
+  SUPPORTED_COMPANION_PROTOCOL_VERSION,
 } from './meshcoreCompanionCodec.js';
 import type { MeshCoreNode, MeshCoreContact, MeshCoreMessage } from './meshcoreManager.js';
 
@@ -175,9 +176,34 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     expect(epoch).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 1);
   });
 
-  it('replies to DeviceQuery with DeviceInfo', async () => {
+  it('replies to DeviceQuery with DeviceInfo advertising the supported protocol version', async () => {
     const payload = await client.request([CommandCodes.DeviceQuery, 1]);
     expect(payload[0]).toBe(ResponseCodes.DeviceInfo);
+    // Byte 1 is the companion protocol version the app must use to talk to us.
+    expect(payload.readInt8(1)).toBe(SUPPORTED_COMPANION_PROTOCOL_VERSION);
+  });
+
+  it('pins DeviceInfo protocol version to v1 even when the real node reports a higher firmwareVer (regression #3705)', async () => {
+    // Once the manager's background deviceQuery() caches the real node's
+    // firmware-version byte, that value must NOT leak into the VN's DeviceInfo
+    // version field — the VN only speaks v1 frames, and the meshcore-flutter app
+    // aborts the handshake (never sending AppStart) when it sees a version it
+    // can't reconcile. Stand up a fresh server whose local node reports fw ver 7.
+    const realNode: MeshCoreNode = { ...LOCAL_NODE, firmwareVer: 7, firmwareBuild: '25-Jun-2026', model: 'Heltec V3' };
+    const realManager = new FakeManager(realNode);
+    const realServer = new MeshCoreVirtualNodeServer({ port: 0, manager: realManager, databaseService: CHANNELS_DB });
+    await realServer.start();
+    const realClient = new TestClient();
+    await realClient.connect(realServer.getListeningPort()!);
+    try {
+      const payload = await realClient.request([CommandCodes.DeviceQuery, 1]);
+      expect(payload[0]).toBe(ResponseCodes.DeviceInfo);
+      expect(payload.readInt8(1)).toBe(SUPPORTED_COMPANION_PROTOCOL_VERSION);
+      expect(payload.readInt8(1)).not.toBe(7);
+    } finally {
+      realClient.close();
+      await realServer.stop();
+    }
   });
 
   it('replies to GetContacts with ContactsStart(N), Contact frames, then EndOfContacts', async () => {

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -354,8 +354,20 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
 
   private handleDeviceQuery(clientId: string): void {
     const localNode = this.options.manager.getLocalNode();
+    // The DeviceInfo version byte is the *companion protocol* version the app
+    // must use to talk to us — NOT the proxied node's firmware version. We only
+    // implement v1 frames, so this MUST always be SUPPORTED_COMPANION_PROTOCOL_VERSION.
+    //
+    // Leaking the real node's `firmwareVer` here (once the manager's background
+    // deviceQuery() has cached it) makes the meshcore-flutter app abort the
+    // handshake: it sends DeviceQuery *before* AppStart, and on seeing a version
+    // it can't reconcile with our v1 wire format it never sends AppStart and
+    // drops the socket after ~5s. Before the cache is warm we fell back to v1
+    // and the app connected — which is exactly the "works once after restart,
+    // then never again" symptom (issue #3705). Build date / model are display
+    // strings and stay real so the app shows a faithful identity.
     this.send(clientId, encodeDeviceInfo({
-      firmwareVer: localNode?.firmwareVer ?? SUPPORTED_COMPANION_PROTOCOL_VERSION,
+      firmwareVer: SUPPORTED_COMPANION_PROTOCOL_VERSION,
       firmwareBuildDate: localNode?.firmwareBuild ?? '',
       manufacturerModel: localNode?.model || 'MeshMonitor Virtual Node',
     }));

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -354,6 +354,10 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
 
   private handleDeviceQuery(clientId: string): void {
     const localNode = this.options.manager.getLocalNode();
+    // Intentionally does NOT gate on isConnected()/localNode (unlike
+    // handleAppStart, which replies BadState): the app sends DeviceQuery
+    // *before* AppStart, so we must reply even with a cold manager — display
+    // fields just fall back to safe defaults below.
     // The DeviceInfo version byte is the *companion protocol* version the app
     // must use to talk to us — NOT the proxied node's firmware version. We only
     // implement v1 frames, so this MUST always be SUPPORTED_COMPANION_PROTOCOL_VERSION.


### PR DESCRIPTION
## Summary

Fixes #3705 — MeshCore virtual node: app connects once after a container restart, then gets stuck on "Connecting…" forever.

## Root cause (from the packet captures in the issue)

The captures disprove the earlier thread hypothesis that the app's reconnect path simply never sends `AppStart`. Decoding the frames shows the meshcore-flutter app sends **`DeviceQuery` first**, *then* `AppStart` — and it aborts the handshake based on the `DeviceInfo` reply:

| | DeviceQuery reply (`DeviceInfo`) | App sends AppStart? |
|---|---|---|
| **Working connect** (cold cache, right after restart) | version byte = `1`, model `MeshMonitor Virtual Node` | ✅ yes → SelfInfo → connected |
| **Failing connect** (warm cache, seconds later) | version byte = real node's `fw ver`, model `Heltec V3`, build `25-Jun-2026` | ❌ no → drops socket after ~5s |

`MeshCoreVirtualNodeServer.handleDeviceQuery()` was sending `localNode.firmwareVer` (the **real** node's firmware-version byte, read by the manager's background `deviceQuery()`) as the `DeviceInfo` version field. That byte is the **companion protocol version** the app must use — but the VN only implements **v1** frames.

The timing explains the symptom exactly: right after a restart the manager hasn't finished its async `deviceQuery()`, so `localNode.firmwareVer` is `undefined` and the code fell back to `SUPPORTED_COMPANION_PROTOCOL_VERSION` (1) → app connects. Once the real value is cached, every subsequent `DeviceQuery` returns a version the app can't reconcile with our v1 wire format → handshake aborts.

## Fix

Always advertise `SUPPORTED_COMPANION_PROTOCOL_VERSION` for the `DeviceInfo` version byte. Build date / model stay real (display-only) so the app shows a faithful node identity.

## Tests

- Strengthened the existing `DeviceQuery` test to assert the version byte == `SUPPORTED_COMPANION_PROTOCOL_VERSION`.
- Added a regression test: with the local node reporting `firmwareVer: 7`, `DeviceInfo` still pins the version byte to v1.
- Full `meshcoreVirtualNodeServer.test.ts` suite: 21 passing (`success: true` via JSON reporter).

## Caveat

Both the version byte **and** the model/build strings differ between the working and failing captures, so packets alone can't prove the version byte is the *sole* trigger (vs. the app rejecting a changed identity). The version byte is the high-confidence cause — it's the protocol-negotiation field the VN genuinely can't honor above v1. If field testing shows it's insufficient, the follow-up is to also make model/build deterministic across connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4