### PR TITLE
fix(meshcore): include saved-regions catalog in scope resolution (#3829)

### DIFF
--- a/src/server/meshcoreManager.scopeResolve.test.ts
+++ b/src/server/meshcoreManager.scopeResolve.test.ts
@@ -10,12 +10,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const insertMessage = vi.fn().mockResolvedValue(undefined);
 const getSettingForSource = vi.fn().mockResolvedValue(undefined);
+const getAllSavedRegions = vi.fn().mockResolvedValue([]);
 
 vi.mock('./services/database.js', () => ({
   default: {
     meshcore: { insertMessage: (...a: unknown[]) => insertMessage(...a) },
     settings: { getSettingForSource: (...a: unknown[]) => getSettingForSource(...a) },
     channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+    savedRegions: { getAllAsync: (...a: unknown[]) => getAllSavedRegions(...a) },
   },
 }));
 
@@ -51,6 +53,7 @@ describe('MeshCoreManager scope resolution (#3742 Phase 2)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    getAllSavedRegions.mockResolvedValue([]);
     m = new MeshCoreManager('src-a');
     // Seed the known-scope cache directly (normally primed on connect).
     (m as any).knownScopes = new Set(['muenchen']);
@@ -83,5 +86,36 @@ describe('MeshCoreManager scope resolution (#3742 Phase 2)', () => {
     const msg = lastMessage(m);
     expect(msg.scopeCode).toBeNull();
     expect(msg.scopeName).toBeNull();
+  });
+});
+
+describe('MeshCoreManager refreshKnownScopes includes saved regions (#3829)', () => {
+  it('populates knownScopes from the saved-regions catalog', async () => {
+    vi.clearAllMocks();
+    // saved-regions catalog has "muenchen"; no per-channel scope, no default scope
+    getAllSavedRegions.mockResolvedValue([{ id: 1, name: 'muenchen', note: null, createdAt: 0, updatedAt: 0 }]);
+    getSettingForSource.mockResolvedValue(null);
+
+    const m2 = new MeshCoreManager('src-b');
+    await (m2 as any).refreshKnownScopes();
+
+    expect((m2 as any).knownScopes.has('muenchen')).toBe(true);
+  });
+
+  it('resolves inbound message scope when scope is only in the saved-regions catalog', async () => {
+    vi.clearAllMocks();
+    getAllSavedRegions.mockResolvedValue([{ id: 1, name: 'muenchen', note: null, createdAt: 0, updatedAt: 0 }]);
+    getSettingForSource.mockResolvedValue(null);
+
+    const m2 = new MeshCoreManager('src-b');
+    await (m2 as any).refreshKnownScopes();
+
+    // Dispatch the scoped packet — knownScopes now includes "muenchen" from the catalog
+    // @ts-expect-error exercising private handler
+    m2.handleBridgeEvent({ event_type: 'channel_message', data: { channel_idx: 0, text: 'hi', path_len: 2, path_hops: ['a3', '7f'], raw_hex: SCOPED_RAW } });
+    const all = m2.getRecentMessages(10);
+    const msg = all[all.length - 1];
+    expect(msg.scopeCode).toBe(30479);
+    expect(msg.scopeName).toBe('muenchen');
   });
 });

--- a/src/server/meshcoreManager.scopeResolve.test.ts
+++ b/src/server/meshcoreManager.scopeResolve.test.ts
@@ -12,7 +12,7 @@ const insertMessage = vi.fn().mockResolvedValue(undefined);
 const getSettingForSource = vi.fn().mockResolvedValue(undefined);
 const getAllSavedRegions = vi.fn().mockResolvedValue([]);
 
-vi.mock('./services/database.js', () => ({
+vi.mock('../services/database.js', () => ({
   default: {
     meshcore: { insertMessage: (...a: unknown[]) => insertMessage(...a) },
     settings: { getSettingForSource: (...a: unknown[]) => getSettingForSource(...a) },

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2712,9 +2712,10 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
-   * Rebuild the {@link knownScopes} cache from this source's per-channel scopes
-   * plus the default scope (#3742 Phase 2). Best-effort: a failure leaves the
-   * previous cache in place and never breaks the message stream.
+   * Rebuild the {@link knownScopes} cache from this source's per-channel scopes,
+   * the default scope, and the global saved-regions catalog (#3742 Phase 2,
+   * #3829). Best-effort: a failure leaves the previous cache in place and never
+   * breaks the message stream.
    */
   private async refreshKnownScopes(): Promise<void> {
     try {
@@ -2726,10 +2727,27 @@ class MeshCoreManager extends EventEmitter {
       }
       const def = (await this.getDefaultScope()).trim();
       if (def) names.add(def);
+      // Include the global saved-regions catalog so users who add a region there
+      // see it resolved in inbound messages even if it isn't the default scope
+      // or a per-channel scope (#3829).
+      const savedRegions = await databaseService.savedRegions.getAllAsync();
+      for (const region of savedRegions) {
+        const s = (region.name ?? '').trim();
+        if (s) names.add(s);
+      }
       this.knownScopes = names;
     } catch (err) {
       logger.debug(`[MeshCore:${this.sourceId}] refreshKnownScopes failed: ${(err as Error).message}`);
     }
+  }
+
+  /**
+   * Trigger a scope-cache rebuild on this manager. Call whenever the global
+   * saved-regions catalog changes, since those names feed into scope resolution
+   * for inbound messages (#3829).
+   */
+  notifySavedRegionsChanged(): void {
+    void this.refreshKnownScopes();
   }
 
   /**

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -71,6 +71,8 @@ const meshcoreManager = {
   // Mesh-TX throttle primitives read by the manual telemetry-poll route.
   getLastMeshTxAt: vi.fn().mockReturnValue(0),
   recordMeshTx: vi.fn(),
+  // Fire-and-forget scope-cache refresh invoked by the saved-regions routes (#3829).
+  notifySavedRegionsChanged: vi.fn(),
 };
 
 vi.mock('../meshcoreManager.js', () => ({

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -723,6 +723,11 @@ router.post(
         return res.status(400).json({ success: false, error: 'note must be a string' });
       }
       const region = await databaseService.savedRegions.addAsync(name, note ?? null);
+      // Refresh the scope cache on every manager so the new region name is
+      // available for resolving inbound messages immediately (#3829).
+      for (const mgr of meshcoreManagerRegistry.list()) {
+        mgr.notifySavedRegionsChanged();
+      }
       res.json({ success: true, region });
     } catch (error: any) {
       // addAsync throws on an empty/invalid normalized name.
@@ -746,6 +751,11 @@ router.delete(
         return res.status(400).json({ success: false, error: 'Invalid region id' });
       }
       await databaseService.savedRegions.deleteAsync(id);
+      // Refresh the scope cache on every manager so the deleted region is
+      // no longer matched against inbound messages (#3829).
+      for (const mgr of meshcoreManagerRegistry.list()) {
+        mgr.notifySavedRegionsChanged();
+      }
       res.json({ success: true });
     } catch (error) {
       logger.error('[API] Error deleting saved region:', error);


### PR DESCRIPTION
## Summary

Fixes #3829 — MeshCore scopes added to the **Saved Regions Catalog** were never consulted during inbound message scope resolution, causing the raw transport code (`#43cd`, `#b905`, etc.) to be displayed instead of the human-readable region name even when the user had defined the region in MeshMonitor.

## Root Cause

`refreshKnownScopes()` in `meshcoreManager.ts` built its candidate set from two sources only:
1. Per-channel scope assignments (from the `channels` table)
2. The per-source default scope setting (`meshcoreDefaultScope`)

The global **Saved Regions Catalog** (`meshcore_saved_regions`) — the dedicated UI list users maintain to name their scopes — was never queried. So a region like `de-sued` added to the catalog but not configured as the default scope or a per-channel scope would never appear in the HMAC brute-force match and every inbound message with that scope would show `🔒 #<hex>` instead of `🔒 de-sued`.

The "sometimes works" behaviour seen in the issue arose when the same name happened to be configured as a per-channel scope on one specific channel but not others.

## Changes

**`src/server/meshcoreManager.ts`**
- `refreshKnownScopes()`: also queries `databaseService.savedRegions.getAllAsync()` and merges all catalog names into the candidate set.
- Adds `notifySavedRegionsChanged()` public method — a fire-and-forget refresh trigger for route handlers.

**`src/server/routes/meshcoreRoutes.ts`**
- `POST /saved-regions`: calls `notifySavedRegionsChanged()` on all registered MeshCore managers after a region is added, so the new name is available for the very next inbound message.
- `DELETE /saved-regions/:id`: same, so a removed region stops matching immediately.

**`src/server/meshcoreManager.scopeResolve.test.ts`**
- Adds `savedRegions.getAllAsync` to the database mock (previously absent, so the new code path would have thrown in tests).
- Two new test cases covering: (1) `refreshKnownScopes` populates `knownScopes` from the catalog, and (2) a full end-to-end dispatch where the scope resolves only because it came from the saved-regions catalog.

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrCNs9GdV5bdzwUk2Us4Dc)_