### PR TITLE
fix(messages): restore traceroute/telemetry/nodeinfo actions for unmessageable nodes (#3831)

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -756,12 +756,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
   const selectedNode = selectedDMNode ? nodes.find(n => n.user?.id === selectedDMNode) : null;
 
-  // A node flagged "unmessagable" (Meshtastic NodeInfo `is_unmessagable`, e.g.
-  // sensors/repeaters) can't receive DMs — sending would silently go nowhere.
-  // Treat its conversation like the MQTT-bridge read-only mirror: keep the node
-  // selectable in the DM list and still show its per-node telemetry, but hide
-  // the message log and the send composer / mesh-transmit actions (issue #3755).
-  const effectiveReadOnly = mqttReadOnly || selectedNode?.isUnmessagable === true;
+  // An unmessageable node (Meshtastic `is_unmessagable`, e.g. sensors/repeaters)
+  // can't receive DMs, so the message log and compose field are hidden (#3755).
+  // However traceroute, telemetry, NodeInfo exchange etc. are channel packets —
+  // not DMs — and still reach the node. Only the true MQTT-bridge mirror (where
+  // we can't transmit at all) should suppress those action buttons (#3831).
+  const dmReadOnly = mqttReadOnly || selectedNode?.isUnmessagable === true;
 
   return (
     <div className="nodes-split-view messages-split-view">
@@ -1124,7 +1124,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             view is read-only and remains. */}
                         {hasPermission('traceroute', 'write') && (
                           <>
-                            {!effectiveReadOnly && (
+                            {!mqttReadOnly && (
                               <button
                                 className="actions-menu-item"
                                 onClick={() => {
@@ -1152,8 +1152,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         {/* Exchange Actions — every entry below transmits a
                             packet to the mesh (position exchange, NodeInfo
                             request, telemetry request). Hidden entirely in
-                            the MQTT-bridge mirror. */}
-                        {!effectiveReadOnly && hasPermission('messages', 'write') && (
+                            the MQTT-bridge mirror. Available for unmessageable
+                            nodes because these use channel routing, not DMs. */}
+                        {!mqttReadOnly && hasPermission('messages', 'write') && (
                           <>
                             <button
                               className="actions-menu-item"
@@ -1207,7 +1208,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
                         {/* Admin Scan — sends an admin probe packet to the
                             remote node. No-op in the MQTT-bridge mirror. */}
-                        {!effectiveReadOnly && hasPermission('settings', 'write') && (
+                        {!mqttReadOnly && hasPermission('settings', 'write') && (
                           <button
                             className="actions-menu-item"
                             onClick={() => {
@@ -1350,11 +1351,11 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               </div>
             )}
 
-            {/* Messages Container — hidden in MQTT-bridge read-only mode (telemetry-only DM view) */}
+            {/* Messages Container — hidden for unmessageable nodes and MQTT-bridge mirror */}
             <div
               className="messages-container"
               ref={dmMessagesContainerRef}
-              style={{ position: 'relative', display: effectiveReadOnly ? 'none' : undefined }}
+              style={{ position: 'relative', display: dmReadOnly ? 'none' : undefined }}
             >
               {showJumpToBottom && (
                 <div
@@ -1593,8 +1594,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               className={`dm-send-section ${isSendSectionResizing ? 'resizing' : ''}`}
               style={!isMobileLayout ? { height: `${sendSectionHeight}px` } : undefined}
             >
-              {/* Send DM form — suppressed in MQTT-bridge read-only mode */}
-              {!effectiveReadOnly && connectionStatus === 'connected' && (
+              {/* Send DM form — suppressed for unmessageable nodes and MQTT-bridge mirror */}
+              {!dmReadOnly && connectionStatus === 'connected' && (
                 <div className="send-message-form">
                 {replyingTo && (
                   <div className="reply-indicator">
@@ -1852,7 +1853,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Traceroute - Split Button */}
-              {!effectiveReadOnly && hasPermission('traceroute', 'write') && (
+              {!mqttReadOnly && hasPermission('traceroute', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleTraceroute(selectedDMNode)}
@@ -1938,7 +1939,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Exchange Node Info - Split Button */}
-              {!effectiveReadOnly && hasPermission('messages', 'write') && (
+              {!mqttReadOnly && hasPermission('messages', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangeNodeInfo(selectedDMNode)}
@@ -2024,7 +2025,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Exchange Position - Split Button */}
-              {!effectiveReadOnly && hasPermission('messages', 'write') && (
+              {!mqttReadOnly && hasPermission('messages', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangePosition(selectedDMNode)}
@@ -2110,7 +2111,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Request Neighbor Info */}
-              {!effectiveReadOnly && hasPermission('traceroute', 'write') && (
+              {!mqttReadOnly && hasPermission('traceroute', 'write') && (
                 <button
                   onClick={() => handleRequestNeighborInfo(selectedDMNode)}
                   disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode}

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -52,6 +52,7 @@ import { useToast } from './ToastContainer';
 import apiService from '../services/api';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { useSource } from '../contexts/SourceContext';
+import { computeMessagesReadOnlyState } from './messagesReadOnlyState';
 
 // Types for node with message metadata
 interface NodeWithMessages extends DeviceInfo {
@@ -756,12 +757,18 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
   const selectedNode = selectedDMNode ? nodes.find(n => n.user?.id === selectedDMNode) : null;
 
-  // An unmessageable node (Meshtastic `is_unmessagable`, e.g. sensors/repeaters)
-  // can't receive DMs, so the message log and compose field are hidden (#3755).
-  // However traceroute, telemetry, NodeInfo exchange etc. are channel packets —
-  // not DMs — and still reach the node. Only the true MQTT-bridge mirror (where
-  // we can't transmit at all) should suppress those action buttons (#3831).
-  const dmReadOnly = mqttReadOnly || selectedNode?.isUnmessagable === true;
+  // Two distinct read-only states (see computeMessagesReadOnlyState):
+  //  - dmReadOnly      → hide the DM log + composer (MQTT mirror OR unmessageable
+  //                      node, #3755).
+  //  - actionsReadOnly → hide the mesh-action buttons (traceroute/telemetry/
+  //                      nodeinfo/position/neighborinfo/admin scan). These are
+  //                      channel-routed packets, not DMs, so an unmessageable
+  //                      node still answers them — only the MQTT-bridge mirror
+  //                      suppresses them (#3831).
+  const { dmReadOnly, actionsReadOnly } = computeMessagesReadOnlyState({
+    mqttReadOnly,
+    isUnmessagable: selectedNode?.isUnmessagable,
+  });
 
   return (
     <div className="nodes-split-view messages-split-view">
@@ -1124,7 +1131,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             view is read-only and remains. */}
                         {hasPermission('traceroute', 'write') && (
                           <>
-                            {!mqttReadOnly && (
+                            {!actionsReadOnly && (
                               <button
                                 className="actions-menu-item"
                                 onClick={() => {
@@ -1154,7 +1161,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             request, telemetry request). Hidden entirely in
                             the MQTT-bridge mirror. Available for unmessageable
                             nodes because these use channel routing, not DMs. */}
-                        {!mqttReadOnly && hasPermission('messages', 'write') && (
+                        {!actionsReadOnly && hasPermission('messages', 'write') && (
                           <>
                             <button
                               className="actions-menu-item"
@@ -1208,7 +1215,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
                         {/* Admin Scan — sends an admin probe packet to the
                             remote node. No-op in the MQTT-bridge mirror. */}
-                        {!mqttReadOnly && hasPermission('settings', 'write') && (
+                        {!actionsReadOnly && hasPermission('settings', 'write') && (
                           <button
                             className="actions-menu-item"
                             onClick={() => {
@@ -1853,7 +1860,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Traceroute - Split Button */}
-              {!mqttReadOnly && hasPermission('traceroute', 'write') && (
+              {!actionsReadOnly && hasPermission('traceroute', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleTraceroute(selectedDMNode)}
@@ -1939,7 +1946,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Exchange Node Info - Split Button */}
-              {!mqttReadOnly && hasPermission('messages', 'write') && (
+              {!actionsReadOnly && hasPermission('messages', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangeNodeInfo(selectedDMNode)}
@@ -2025,7 +2032,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Exchange Position - Split Button */}
-              {!mqttReadOnly && hasPermission('messages', 'write') && (
+              {!actionsReadOnly && hasPermission('messages', 'write') && (
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangePosition(selectedDMNode)}
@@ -2111,7 +2118,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               )}
 
               {/* Request Neighbor Info */}
-              {!mqttReadOnly && hasPermission('traceroute', 'write') && (
+              {!actionsReadOnly && hasPermission('traceroute', 'write') && (
                 <button
                   onClick={() => handleRequestNeighborInfo(selectedDMNode)}
                   disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode}

--- a/src/components/messagesReadOnlyState.test.ts
+++ b/src/components/messagesReadOnlyState.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { computeMessagesReadOnlyState } from './messagesReadOnlyState';
+
+describe('computeMessagesReadOnlyState (#3831)', () => {
+  it('normal messageable node: nothing is read-only', () => {
+    expect(computeMessagesReadOnlyState({ mqttReadOnly: false, isUnmessagable: false })).toEqual({
+      dmReadOnly: false,
+      actionsReadOnly: false,
+    });
+  });
+
+  it('unmessageable node (not MQTT): DMs hidden but action buttons stay available', () => {
+    // The regression #3831 guards against: traceroute / telemetry / nodeinfo /
+    // position / neighbor-info / admin-scan are channel-routed, so an
+    // unmessageable node still answers them. dmReadOnly is true, actions are NOT.
+    expect(computeMessagesReadOnlyState({ mqttReadOnly: false, isUnmessagable: true })).toEqual({
+      dmReadOnly: true,
+      actionsReadOnly: false,
+    });
+  });
+
+  it('MQTT-bridge mirror: both DMs and action buttons are read-only', () => {
+    expect(computeMessagesReadOnlyState({ mqttReadOnly: true, isUnmessagable: false })).toEqual({
+      dmReadOnly: true,
+      actionsReadOnly: true,
+    });
+  });
+
+  it('MQTT mirror AND unmessageable: both read-only', () => {
+    expect(computeMessagesReadOnlyState({ mqttReadOnly: true, isUnmessagable: true })).toEqual({
+      dmReadOnly: true,
+      actionsReadOnly: true,
+    });
+  });
+
+  it('treats undefined isUnmessagable as messageable (only strict true gates DMs)', () => {
+    expect(computeMessagesReadOnlyState({ mqttReadOnly: false, isUnmessagable: undefined })).toEqual({
+      dmReadOnly: false,
+      actionsReadOnly: false,
+    });
+  });
+});

--- a/src/components/messagesReadOnlyState.ts
+++ b/src/components/messagesReadOnlyState.ts
@@ -1,0 +1,41 @@
+/**
+ * Read-only gating for the Messages DM view.
+ *
+ * MeshMonitor distinguishes two *different* reasons a DM conversation can be
+ * "read-only", and they gate different parts of the UI:
+ *
+ *  - **MQTT-bridge mirror** (`mqttReadOnly`): the selected source is a passive
+ *    MQTT mirror, so we cannot transmit ANY packet to the mesh. Both the DM
+ *    composer AND every mesh-action button (traceroute, telemetry, NodeInfo /
+ *    position exchange, neighbor-info, admin scan) must be hidden.
+ *
+ *  - **Unmessageable node** (Meshtastic NodeInfo `is_unmessagable`, e.g. sensors
+ *    and repeaters): the node can't receive text DMs, so the DM message log and
+ *    compose field are hidden (#3755). But it STILL answers channel-routed
+ *    requests — traceroute, telemetry, NodeInfo/position exchange, etc. are sent
+ *    to their own PortNums on the node's channel, not as text DMs — so those
+ *    action buttons must remain available (#3831).
+ *
+ * Conflating the two (the pre-#3831 `effectiveReadOnly` flag) wrongly hid the
+ * action buttons for unmessageable nodes. Keep them separate.
+ */
+export interface MessagesReadOnlyState {
+  /** Hide the DM message log and the compose field. */
+  dmReadOnly: boolean;
+  /** Hide the mesh-transmit action buttons (traceroute/telemetry/nodeinfo/…). */
+  actionsReadOnly: boolean;
+}
+
+export function computeMessagesReadOnlyState(opts: {
+  mqttReadOnly: boolean;
+  isUnmessagable: boolean | undefined;
+}): MessagesReadOnlyState {
+  const { mqttReadOnly, isUnmessagable } = opts;
+  return {
+    // DMs are suppressed by either condition.
+    dmReadOnly: mqttReadOnly || isUnmessagable === true,
+    // Action buttons are suppressed ONLY by the MQTT-bridge mirror — an
+    // unmessageable node still responds to these channel-routed requests.
+    actionsReadOnly: mqttReadOnly,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes #3831 — action buttons (Traceroute, Request Telemetry, Exchange NodeInfo, Exchange Position, Request Neighbor Info, Admin Scan) were hidden for nodes flagged `isUnmessagable`, even though those actions use channel routing (not DMs) and still work on unmessageable nodes.

## Root Cause

When #3684 was fixed (properly reading/storing the `isUnmessagable` flag), the `MessagesTab` `effectiveReadOnly` flag conflated two distinct read-only states:

```tsx
// Before — wrong: isUnmessagable treated identically to the MQTT-bridge mirror
const effectiveReadOnly = mqttReadOnly || selectedNode?.isUnmessagable === true;
```

The MQTT-bridge mirror (`mqttReadOnly`) is truly read-only — no packets can be sent at all. Unmessageable nodes are different: they can't receive **DMs**, but they do respond to channel packets — traceroute, telemetry requests, NodeInfo/position exchange, etc.

## Fix

Split into two flags (`src/components/MessagesTab.tsx`):

```tsx
// dmReadOnly — gates the DM message log and compose field only
const dmReadOnly = mqttReadOnly || selectedNode?.isUnmessagable === true;

// Action buttons (traceroute, telemetry, nodeInfo, position, neighborInfo, adminScan)
// now gate only on mqttReadOnly — visible for unmessageable nodes
```

**What stays hidden for unmessageable nodes:** DM message log, DM compose field (unchanged behaviour from #3755)

**What is now restored for unmessageable nodes:** Traceroute, Request Telemetry, Exchange NodeInfo, Exchange Position, Request Neighbor Info, Admin Scan

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_015eW4v588etb8U82NDHnMXq)_