### PR TITLE
feat(meshcore): scope/region control for MeshCore automations (#3833)

### DIFF
--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -4,6 +4,7 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
+import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 
 interface MeshCoreAutoAckSectionProps {
   baseUrl: string;
@@ -19,6 +20,9 @@ interface AutoAckSettings {
   useDM: boolean;
   cooldownSeconds: number;
   testMessages: string;
+  /** MeshCore scope/region for the ack reply (#3833). */
+  scopeMode: ScopeMode;
+  scopeName: string;
 }
 
 interface MeshCoreChannelRow {
@@ -39,6 +43,8 @@ const DEFAULTS: AutoAckSettings = {
   useDM: false,
   cooldownSeconds: 0,
   testMessages: DEFAULT_TEST_MESSAGES,
+  scopeMode: 'inherit',
+  scopeName: '',
 };
 
 const validateRegex = (pattern: string): { valid: boolean; error?: string } => {
@@ -103,6 +109,8 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
           useDM: !!json.data.useDM,
           cooldownSeconds: typeof json.data.cooldownSeconds === 'number' ? json.data.cooldownSeconds : 0,
           testMessages: json.data.testMessages || DEFAULT_TEST_MESSAGES,
+          scopeMode: (json.data.scopeMode as ScopeMode) || 'inherit',
+          scopeName: json.data.scopeName || '',
         };
         setSettings(s);
         setInitial(s);
@@ -151,6 +159,8 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
       settings.useDM !== initial.useDM ||
       settings.cooldownSeconds !== initial.cooldownSeconds ||
       settings.testMessages !== initial.testMessages ||
+      settings.scopeMode !== initial.scopeMode ||
+      settings.scopeName !== initial.scopeName ||
       channelsChanged,
     );
   }, [settings, initial, loaded]);
@@ -177,6 +187,8 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             useDM: settings.useDM,
             cooldownSeconds: settings.cooldownSeconds,
             testMessages: settings.testMessages,
+            scopeMode: settings.scopeMode,
+            scopeName: settings.scopeName,
           }),
         },
       );
@@ -394,6 +406,29 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
               {t('meshcore.automation.autoack.cooldown_help', 'seconds (0 = no cooldown)')}
             </span>
+          </div>
+        </div>
+
+        {/* MeshCore scope/region for the ack reply (#3833) */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.autoack.scope_label', 'Reply Scope')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.scope_description',
+                'Region the acknowledgement floods to. "Respond on the triggering message\'s scope" replies in the same region the request arrived on.',
+              )}
+            </span>
+          </label>
+          <div style={{ marginTop: '0.5rem' }}>
+            <ScopeSelectField
+              baseUrl={baseUrl}
+              sourceId={sourceId}
+              allowTrigger
+              idPrefix="autoack"
+              value={{ scopeMode: settings.scopeMode, scopeName: settings.scopeName }}
+              onChange={(v) => setSettings((s) => ({ ...s, scopeMode: v.scopeMode ?? 'inherit', scopeName: v.scopeName ?? '' }))}
+            />
           </div>
         </div>
 

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
@@ -5,6 +5,7 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
+import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 import { MESHCORE_AUTOMATION_TOKENS } from './meshcoreAutomationTokens';
 
 interface MeshCoreAutoAnnounceSectionProps {
@@ -22,6 +23,9 @@ interface AutoAnnounceSettings {
   schedule: string;
   advertEnabled: boolean;
   advertDelaySeconds: number;
+  /** MeshCore scope/region for the announcement (#3833). No trigger, so no 'trigger' mode. */
+  scopeMode: ScopeMode;
+  scopeName: string;
 }
 
 interface MeshCoreChannelRow {
@@ -42,6 +46,8 @@ const DEFAULTS: AutoAnnounceSettings = {
   schedule: DEFAULT_SCHEDULE,
   advertEnabled: false,
   advertDelaySeconds: 30,
+  scopeMode: 'inherit',
+  scopeName: '',
 };
 
 const TOKENS = MESHCORE_AUTOMATION_TOKENS;
@@ -91,6 +97,8 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
           schedule: json.data.schedule || DEFAULT_SCHEDULE,
           advertEnabled: !!json.data.advertEnabled,
           advertDelaySeconds: typeof json.data.advertDelaySeconds === 'number' ? json.data.advertDelaySeconds : 30,
+          scopeMode: (json.data.scopeMode as ScopeMode) || 'inherit',
+          scopeName: json.data.scopeName || '',
         };
         setSettings(s);
         setInitial(s);
@@ -160,7 +168,9 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
       settings.useSchedule !== initial.useSchedule ||
       settings.schedule !== initial.schedule ||
       settings.advertEnabled !== initial.advertEnabled ||
-      settings.advertDelaySeconds !== initial.advertDelaySeconds,
+      settings.advertDelaySeconds !== initial.advertDelaySeconds ||
+      settings.scopeMode !== initial.scopeMode ||
+      settings.scopeName !== initial.scopeName,
     );
   }, [settings, initial, loaded]);
 
@@ -196,6 +206,8 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
             schedule: settings.schedule,
             advertEnabled: settings.advertEnabled,
             advertDelaySeconds: settings.advertDelaySeconds,
+            scopeMode: settings.scopeMode,
+            scopeName: settings.scopeName,
           }),
         },
       );
@@ -455,6 +467,28 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
                 </label>
               </div>
             ))}
+          </div>
+        </div>
+
+        {/* MeshCore scope/region for the announcement (#3833) */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.announce.scope_label', 'Scope')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.announce.scope_description',
+                'Region the announcement floods to. Inherit uses each channel\'s configured scope or the source default.',
+              )}
+            </span>
+          </label>
+          <div style={{ marginTop: '0.5rem' }}>
+            <ScopeSelectField
+              baseUrl={baseUrl}
+              sourceId={sourceId}
+              idPrefix="announce"
+              value={{ scopeMode: settings.scopeMode, scopeName: settings.scopeName }}
+              onChange={(v) => setSettings((s) => ({ ...s, scopeMode: v.scopeMode ?? 'inherit', scopeName: v.scopeName ?? '' }))}
+            />
           </div>
         </div>
 

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { MeshCoreTokenLegend } from './MeshCoreTokenLegend';
+import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 
 interface MeshCoreAutoResponderSectionProps {
   baseUrl: string;
@@ -33,6 +34,9 @@ interface MeshCoreAutoResponderTrigger {
   listenDMs: boolean;
   replyAsDM: boolean;
   cooldownSeconds: number;
+  /** MeshCore scope/region for the reply (#3833). */
+  scopeMode?: ScopeMode;
+  scopeName?: string;
 }
 
 interface ScriptMetadata {
@@ -75,6 +79,8 @@ const newTrigger = (): MeshCoreAutoResponderTrigger => ({
   listenDMs: true,
   replyAsDM: false,
   cooldownSeconds: 60,
+  scopeMode: 'inherit',
+  scopeName: '',
 });
 
 export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSectionProps> = ({ baseUrl, sourceId }) => {
@@ -462,6 +468,16 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
                   ))}
                 </div>
               </fieldset>
+
+              {/* MeshCore scope/region for the reply (#3833) */}
+              <ScopeSelectField
+                baseUrl={baseUrl}
+                sourceId={sourceId}
+                allowTrigger
+                idPrefix={`responder-${tr.id}`}
+                value={{ scopeMode: tr.scopeMode, scopeName: tr.scopeName }}
+                onChange={(v) => updateTrigger(tr.id, { scopeMode: v.scopeMode, scopeName: v.scopeName })}
+              />
             </div>
           );
         })}

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
@@ -6,6 +6,7 @@ import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { MeshCoreTokenLegend } from './MeshCoreTokenLegend';
+import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 
 interface MeshCoreTimerTriggersSectionProps {
   baseUrl: string;
@@ -31,6 +32,9 @@ interface MeshCoreTimerTrigger {
   destination?: 'channel' | 'dm';
   channelIndex?: number;
   contactPublicKey?: string;
+  /** MeshCore scope/region for the sent message (#3833). */
+  scopeMode?: ScopeMode;
+  scopeName?: string;
   lastRun?: number;
   lastResult?: 'success' | 'error';
   lastError?: string;
@@ -67,6 +71,8 @@ const newTrigger = (): MeshCoreTimerTrigger => ({
   response: '',
   destination: 'channel',
   channelIndex: 0,
+  scopeMode: 'inherit',
+  scopeName: '',
 });
 
 const triggersEqual = (a: MeshCoreTimerTrigger[], b: MeshCoreTimerTrigger[]): boolean => {
@@ -508,6 +514,20 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
                     </select>
                   </label>
                 )}
+              </div>
+            )}
+
+            {(tr.responseType === 'text' || tr.responseType === 'script') && (
+              <div style={{ marginTop: '0.5rem' }}>
+                {/* MeshCore scope/region for the sent message (#3833). No trigger
+                    message here, so the "respond on trigger scope" option is omitted. */}
+                <ScopeSelectField
+                  baseUrl={baseUrl}
+                  sourceId={sourceId}
+                  idPrefix={`timer-${tr.id}`}
+                  value={{ scopeMode: tr.scopeMode, scopeName: tr.scopeName }}
+                  onChange={(v) => updateTrigger(tr.id, { scopeMode: v.scopeMode, scopeName: v.scopeName })}
+                />
               </div>
             )}
 

--- a/src/components/MeshCore/ScopeSelectField.tsx
+++ b/src/components/MeshCore/ScopeSelectField.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+
+/**
+ * Shared MeshCore scope/region selector for the Automations tab (#3833).
+ *
+ * Lets an automation choose which region a sent message floods to — the only
+ * per-message propagation lever in MeshCore (repeaters only forward a scoped
+ * flood for regions they carry). The mode maps to the backend's `scopeOverride`
+ * contract: inherit = channel/source default, unscoped = flood with no region,
+ * named = a specific region, trigger = the triggering message's own scope.
+ *
+ * `allowTrigger` is true only for reply automations that have a triggering
+ * message (auto-responder, auto-ack); scheduled senders (announce, timer) omit it.
+ */
+export type ScopeMode = 'inherit' | 'trigger' | 'unscoped' | 'named';
+
+export interface ScopeValue {
+  scopeMode?: ScopeMode;
+  scopeName?: string;
+}
+
+interface ScopeSelectFieldProps {
+  baseUrl: string;
+  sourceId: string;
+  value: ScopeValue;
+  onChange: (value: ScopeValue) => void;
+  /** Show the "Respond on the triggering message's scope" option. */
+  allowTrigger?: boolean;
+  /** Unique-ish id prefix so multiple instances don't collide on the datalist. */
+  idPrefix?: string;
+}
+
+export function ScopeSelectField({
+  baseUrl,
+  sourceId,
+  value,
+  onChange,
+  allowTrigger = false,
+  idPrefix = 'mc-scope',
+}: ScopeSelectFieldProps) {
+  const csrfFetch = useCsrfFetch();
+  const [regions, setRegions] = useState<string[]>([]);
+  const mode: ScopeMode = value.scopeMode ?? 'inherit';
+  const listId = `${idPrefix}-regions`;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/saved-regions`);
+        if (!res.ok) return; // e.g. no configuration:read — degrade to free-text entry
+        const data = await res.json();
+        const names: string[] = Array.isArray(data?.regions)
+          ? data.regions.map((r: { name?: string }) => r?.name).filter((n: unknown): n is string => typeof n === 'string' && n.length > 0)
+          : [];
+        if (!cancelled) setRegions(names);
+      } catch {
+        // Network/permission failure → leave the catalog empty; the combobox
+        // still accepts any typed region name.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  return (
+    <div className="meshcore-scope-field" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', alignItems: 'center' }}>
+      <label style={{ fontWeight: 500 }}>Scope</label>
+      <select
+        value={mode}
+        onChange={(e) => onChange({ ...value, scopeMode: e.target.value as ScopeMode })}
+        aria-label="MeshCore scope mode"
+      >
+        <option value="inherit">Inherit (channel / source default)</option>
+        {allowTrigger && <option value="trigger">Respond on the triggering message&apos;s scope</option>}
+        <option value="unscoped">Unscoped (flood, no region)</option>
+        <option value="named">A specific region…</option>
+      </select>
+      {mode === 'named' && (
+        <>
+          <input
+            type="text"
+            list={listId}
+            value={value.scopeName ?? ''}
+            placeholder="region name (e.g. paris)"
+            onChange={(e) => onChange({ ...value, scopeName: e.target.value })}
+            aria-label="MeshCore region name"
+          />
+          <datalist id={listId}>
+            {regions.map((r) => <option key={r} value={r} />)}
+          </datalist>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ScopeSelectField;

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -39,6 +39,7 @@ interface Props {
   sources: SourceOption[];
   channels: UnifiedChannelOption[];
   scripts: ScriptOption[];
+  regions: string[];
   onChange: (form: WorkflowForm) => void;
 }
 
@@ -59,8 +60,8 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
   return params;
 }
 
-function FieldInput({ field, value, onChange, variables, sources, channels, scripts, triggerType }: {
-  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; triggerType: string;
+function FieldInput({ field, value, onChange, variables, sources, channels, scripts, regions, triggerType }: {
+  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; triggerType: string;
 }) {
   let control;
   const varNames = variables.map((v) => v.name);
@@ -131,6 +132,20 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
         </select>
       );
       break;
+    case 'regionSelect':
+      // Editable combobox: pick a saved region or type any region name (incl. a
+      // {{ trigger.scopeName }} token). Not a hard <select> so users can target
+      // a region not yet in the saved catalog — the manager accepts any name.
+      control = (
+        <>
+          <input className="ae-input" list="ae-regions" value={(value ?? '') as string}
+            placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />
+          <datalist id="ae-regions">
+            {regions.map((r) => <option key={r} value={r} />)}
+          </datalist>
+        </>
+      );
+      break;
     case 'sendSourceMulti': {
       const sel = Array.isArray(value) ? (value as string[]) : [];
       const sendable = sources.filter(isSendableSource);
@@ -190,8 +205,8 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
   );
 }
 
-function BlockFields({ block, triggerType, variables, sources, channels, scripts, onParams }: {
-  block: FormBlock; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; onParams: (p: Record<string, unknown>) => void;
+function BlockFields({ block, triggerType, variables, sources, channels, scripts, regions, onParams }: {
+  block: FormBlock; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; onParams: (p: Record<string, unknown>) => void;
 }) {
   const def = BLOCK_BY_TYPE[block.type];
   if (!def) return null;
@@ -199,15 +214,15 @@ function BlockFields({ block, triggerType, variables, sources, channels, scripts
     <>
       {def.fields.map((f) => {
         const field = f.kind === 'fieldselect' ? { ...f, groups: fieldsFor(block.type, triggerType) } : f;
-        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} scripts={scripts} triggerType={triggerType}
+        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} triggerType={triggerType}
           onChange={(v) => onParams({ ...block.params, [f.name]: v })} />;
       })}
     </>
   );
 }
 
-function BlockListEditor({ blocks, options, triggerType, variables, sources, channels, scripts, onChange, addLabel }: {
-  blocks: FormBlock[]; options: BlockDef[]; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[];
+function BlockListEditor({ blocks, options, triggerType, variables, sources, channels, scripts, regions, onChange, addLabel }: {
+  blocks: FormBlock[]; options: BlockDef[]; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[];
   onChange: (b: FormBlock[]) => void; addLabel: string;
 }) {
   const update = (i: number, b: FormBlock) => { const l = [...blocks]; l[i] = b; onChange(l); };
@@ -222,7 +237,7 @@ function BlockListEditor({ blocks, options, triggerType, variables, sources, cha
             </select>
             <button className="ae-btn ae-btn--ghost" onClick={() => onChange(blocks.filter((_, j) => j !== i))}>✕</button>
           </div>
-          <BlockFields block={b} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} onParams={(p) => update(i, { ...b, params: p })} />
+          <BlockFields block={b} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} onParams={(p) => update(i, { ...b, params: p })} />
         </div>
       ))}
       <button className="ae-btn" onClick={() => onChange([...blocks, { type: options[0].type, params: defaultParams(options[0].type, triggerType) }])}>{addLabel}</button>
@@ -230,7 +245,7 @@ function BlockListEditor({ blocks, options, triggerType, variables, sources, cha
   );
 }
 
-export default function AutomationBuilder({ form, variables, sources, channels, scripts, onChange }: Props) {
+export default function AutomationBuilder({ form, variables, sources, channels, scripts, regions, onChange }: Props) {
   const triggerType = form.trigger.type;
   const [showHelp, setShowHelp] = useState(false);
   const setTrigger = (type: string) => onChange({ ...form, trigger: { type, params: defaultParams(type, type) } });
@@ -259,7 +274,7 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
             </select>
             <div className="ae-help-text">{BLOCK_BY_TYPE[triggerType]?.description}</div>
           </div>
-          <BlockFields block={form.trigger} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} onParams={setTriggerParams} />
+          <BlockFields block={form.trigger} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} onParams={setTriggerParams} />
         </div>
       </div>
 
@@ -273,10 +288,10 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
           <div className="ae-section-body">
             <div className="ae-field-label" style={{ marginBottom: '0.4rem' }}>IF — all of these are true (optional)</div>
             {rule.conditions.length === 0 && <div className="ae-muted" style={{ marginBottom: '0.5rem' }}>No conditions — runs every time the trigger fires.</div>}
-            <BlockListEditor blocks={rule.conditions} options={CONDITIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts}
+            <BlockListEditor blocks={rule.conditions} options={CONDITIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions}
               onChange={(c) => updateRule(i, { ...rule, conditions: c })} addLabel="+ Add condition" />
             <div className="ae-field-label" style={{ margin: '0.9rem 0 0.4rem' }}>THEN — do this</div>
-            <BlockListEditor blocks={rule.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts}
+            <BlockListEditor blocks={rule.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions}
               onChange={(a) => updateRule(i, { ...rule, actions: a })} addLabel="+ Add action" />
           </div>
         </div>
@@ -305,7 +320,7 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
               <div className="ae-help-text">“Matched” means a rule’s IF conditions passed.</div>
             </div>
             <div className="ae-field-label" style={{ margin: '0.6rem 0 0.4rem' }}>THEN — do this</div>
-            <BlockListEditor blocks={form.combine.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts}
+            <BlockListEditor blocks={form.combine.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions}
               onChange={(a) => setCombine({ ...form.combine!, actions: a })} addLabel="+ Add action" />
           </div>
         </div>

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -153,6 +153,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
   const [sources, setSources] = useState<SourceOption[]>([]);
   const [channels, setChannels] = useState<UnifiedChannelOption[]>([]);
   const [scripts, setScripts] = useState<ScriptOption[]>([]);
+  const [regions, setRegions] = useState<string[]>([]);
 
   // Decide builder vs JSON from the existing config.
   const parsedInitial = (() => { try { return initial ? decompile(JSON.parse(initial.config)) : DEFAULT_FORM; } catch { return null; } })();
@@ -187,6 +188,9 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     apiService.get<{ scripts: Array<{ filename: string; name?: string }> }>('/api/scripts')
       .then((r) => setScripts((r.scripts ?? []).map((s) => ({ value: s.filename, label: s.name || s.filename }))))
       .catch(() => setScripts([]));
+    apiService.get<{ regions: Array<{ name: string }> }>('/api/automations/regions')
+      .then((r) => setRegions((r.regions ?? []).map((x) => x.name)))
+      .catch(() => setRegions([]));
   }, []);
 
   const switchToJson = () => { setJsonText(JSON.stringify(compile(form), null, 2)); setMode('json'); };
@@ -241,7 +245,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
       </div>
 
       {mode === 'builder'
-        ? <AutomationBuilder form={form} variables={variables} sources={sources} channels={channels} scripts={scripts} onChange={setForm} />
+        ? <AutomationBuilder form={form} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} onChange={setForm} />
         : (
           <div className="ae-field">
             <label className="ae-field-label">Workflow graph (JSON)</label>

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -6,7 +6,7 @@
  * `kind` maps to an input renderer in AutomationBuilder.
  */
 
-export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect';
+export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect' | 'regionSelect';
 
 export interface FieldOpt { value: string; label: string; }
 export interface FieldGroup { label: string; options: FieldOpt[]; }
@@ -144,6 +144,7 @@ const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
 const EVENT_STRING: Record<string, FieldOpt[]> = {
   'trigger.message': [
     { value: 'text', label: 'Message text' }, { value: 'fromId', label: 'Sender node id' }, { value: 'toId', label: 'Recipient node id' },
+    { value: 'scopeName', label: 'MeshCore scope/region' },
   ],
   'trigger.telemetry': [{ value: 'telemetryType', label: 'Metric name' }],
   'trigger.system': [
@@ -294,6 +295,20 @@ export const ACTIONS: BlockDef[] = [
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
       { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true },
+      {
+        name: 'scopeMode', label: 'MeshCore scope', kind: 'select', advanced: true,
+        options: [
+          { value: 'inherit', label: 'Inherit (channel / source default)' },
+          { value: 'trigger', label: "Match the triggering message's scope" },
+          { value: 'unscoped', label: 'Unscoped (flood, no region)' },
+          { value: 'named', label: 'A specific region…' },
+        ],
+        help: 'Region a MeshCore message floods to (controls propagation). MeshCore only — ignored by Meshtastic sources.',
+      },
+      {
+        name: 'scopeName', label: 'Region', kind: 'regionSelect', advanced: true, tokens: true,
+        placeholder: 'e.g. paris', help: 'Used when MeshCore scope is "A specific region".',
+      },
     ],
   },
   {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -188,7 +188,23 @@ export enum ConnectionType {
  * land without dragging the script-runner sandbox into the MeshCore
  * surface.
  */
-export interface MeshCoreAutoResponderTrigger {
+/** Scope/region selection shared by every MeshCore automation that sends a
+ *  message (auto-responder, auto-ack, auto-announce, timer triggers) — #3833. */
+export type MeshCoreAutomationScopeMode = 'inherit' | 'trigger' | 'unscoped' | 'named';
+export interface MeshCoreAutomationScopeConfig {
+  /**
+   * Region a sent message floods to (the only per-message propagation lever in
+   * MeshCore — repeaters only forward a scoped flood for regions they carry).
+   * `inherit` (default) = channel scope → source default; `trigger` = the
+   * triggering message's own scope; `unscoped` = flood with no region;
+   * `named` = the region in `scopeName`.
+   */
+  scopeMode?: MeshCoreAutomationScopeMode;
+  /** Region name when `scopeMode === 'named'`. */
+  scopeName?: string;
+}
+
+export interface MeshCoreAutoResponderTrigger extends MeshCoreAutomationScopeConfig {
   id: string;
   name: string;
   enabled: boolean;
@@ -222,7 +238,7 @@ export interface MeshCoreAutoResponderTrigger {
  * row; the runner reads the row by id at fire time so a freshly-saved
  * template applies on the next tick.
  */
-export interface MeshCoreTimerTrigger {
+export interface MeshCoreTimerTrigger extends MeshCoreAutomationScopeConfig {
   id: string;
   name: string;
   enabled: boolean;
@@ -2275,6 +2291,35 @@ class MeshCoreManager extends EventEmitter {
    * (#3704 review item 2). The send route still rejects non-string types and
    * over-length input up front, so only stray punctuation reaches this strip.
    */
+  /**
+   * Translate an automation's scope selection (#3833) into the `scopeOverride`
+   * value `sendMessage` expects: `undefined` = inherit (channel/source default),
+   * `''` = explicit unscoped, a non-empty string = a named region.
+   *
+   * `trigger` mode replies on the triggering message's own scope — its resolved
+   * `scopeName` when known, `''` when the trigger was explicitly unscoped
+   * (`scopeCode === 0`), else inherit (unknown / no trigger message available).
+   */
+  private static resolveAutomationScopeOverride(
+    cfg: MeshCoreAutomationScopeConfig | undefined,
+    triggerMsg?: MeshCoreMessage,
+  ): string | null | undefined {
+    switch (cfg?.scopeMode) {
+      case 'unscoped':
+        return '';
+      case 'named':
+        return (cfg.scopeName ?? '').trim() || undefined; // empty named → inherit
+      case 'trigger': {
+        const name = (triggerMsg?.scopeName ?? '').trim();
+        if (name) return name;
+        if (triggerMsg?.scopeCode === 0) return ''; // trigger arrived explicitly unscoped
+        return undefined; // unknown scope / no trigger → inherit
+      }
+      default:
+        return undefined; // inherit
+    }
+  }
+
   private static normalizeScopeOverride(scope: string | null | undefined): string | null | undefined {
     if (scope === undefined || scope === null) return undefined;
     const stripped = scope.trim().replace(/^#/, '');
@@ -4947,11 +4992,19 @@ class MeshCoreManager extends EventEmitter {
       return { sent: 0, total: 0 };
     }
 
+    // Scope/region for the announcement (#3833). No trigger message, so 'trigger'
+    // mode degrades to inherit. `undefined` (inherit) preserves prior behavior
+    // where the per-channel / source-default scope already applied.
+    const scopeOverride = MeshCoreManager.resolveAutomationScopeOverride({
+      scopeMode: (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceScopeMode')) as MeshCoreAutomationScopeMode | undefined,
+      scopeName: (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceScopeName')) ?? undefined,
+    });
+
     const rendered = await replaceMeshCoreAnnounceTokens(message, this);
     let sent = 0;
     for (const idx of channelIndexes) {
       try {
-        const ok = await this.sendMessage(rendered, undefined, idx);
+        const ok = await this.sendMessage(rendered, undefined, idx, scopeOverride);
         if (ok) sent += 1;
       } catch (err) {
         logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: send to channel ${idx} threw: ${(err as Error).message}`);
@@ -5086,12 +5139,15 @@ class MeshCoreManager extends EventEmitter {
     // Pre-build the dispatch closure so the script + text paths route
     // through identical destination logic. Returns false when the
     // trigger has no destination — the caller surfaces that reason.
+    // Scope/region for the timer message (#3833). No trigger message, so
+    // 'trigger' mode degrades to inherit (channel/source default).
+    const scopeOverride = MeshCoreManager.resolveAutomationScopeOverride(trigger);
     const dispatch = async (text: string): Promise<boolean> => {
       if (trigger.destination === 'dm' && trigger.contactPublicKey) {
-        return this.sendMessage(text, trigger.contactPublicKey);
+        return this.sendMessage(text, trigger.contactPublicKey, undefined, scopeOverride);
       }
       if (typeof trigger.channelIndex === 'number') {
-        return this.sendMessage(text, undefined, trigger.channelIndex);
+        return this.sendMessage(text, undefined, trigger.channelIndex, scopeOverride);
       }
       return false;
     };
@@ -5351,13 +5407,15 @@ class MeshCoreManager extends EventEmitter {
         // response should go (DM to sender vs channel) so the script
         // path and text path can share it.
         const senderContact = this.resolveContactByPrefix(message.fromPublicKey);
+        // Scope/region for the reply (#3833): inherit / trigger / unscoped / named.
+        const scopeOverride = MeshCoreManager.resolveAutomationScopeOverride(trigger, message);
         const dispatch = async (text: string): Promise<boolean> => {
           if (trigger.replyAsDM || isDM) {
             const targetKey = senderContact?.publicKey || message.fromPublicKey;
-            return this.sendMessage(text, targetKey);
+            return this.sendMessage(text, targetKey, undefined, scopeOverride);
           }
           if (typeof channelIdx === 'number') {
-            return this.sendMessage(text, undefined, channelIdx);
+            return this.sendMessage(text, undefined, channelIdx, scopeOverride);
           }
           return false;
         };
@@ -5528,6 +5586,11 @@ class MeshCoreManager extends EventEmitter {
 
       const useDM = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckUseDM')) === 'true';
       const template = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckMessage')) || MeshCoreManager.AUTO_ACK_DEFAULT_MESSAGE;
+      // Scope/region for the ack reply (#3833): inherit / trigger / unscoped / named.
+      const scopeOverride = MeshCoreManager.resolveAutomationScopeOverride({
+        scopeMode: (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeMode')) as MeshCoreAutomationScopeMode | undefined,
+        scopeName: (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeName')) ?? undefined,
+      }, message);
 
       // Resolve sender's display name from contacts when available
       let senderName = message.fromName;
@@ -5562,10 +5625,10 @@ class MeshCoreManager extends EventEmitter {
           return;
         }
         logger.info(`[MeshCore:${sourceId}] Auto-ack DM → ${contact.advName ?? contact.publicKey.substring(0, 8)}: "${replyText}"`);
-        await this.sendMessage(replyText, contact.publicKey);
+        await this.sendMessage(replyText, contact.publicKey, undefined, scopeOverride);
       } else {
         logger.info(`[MeshCore:${sourceId}] Auto-ack channel ${channelIdx} → "${replyText}"`);
-        await this.sendMessage(replyText, undefined, channelIdx);
+        await this.sendMessage(replyText, undefined, channelIdx, scopeOverride);
       }
     } catch (err) {
       logger.error(`[MeshCore:${this.sourceId}] Auto-ack handler threw: ${(err as Error).message}`);

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -82,6 +82,23 @@ router.get('/channels', canRead, async (_req: Request, res: Response) => {
   }
 });
 
+// ─── MeshCore regions (for the Send-a-message scope picker) ──────────────────
+
+/**
+ * Global saved-region catalog (#3833). The Automations UI is source-less, so it
+ * uses the global catalog (regions are source-independent — a scope is just a
+ * transport code derived from a name). Returns names only for the dropdown.
+ */
+router.get('/regions', canRead, async (_req: Request, res: Response) => {
+  try {
+    const regions = await databaseService.savedRegions.getAllAsync();
+    res.json({ regions: regions.map((r) => ({ name: r.name })) });
+  } catch (error) {
+    logger.error('Error listing automation regions:', error);
+    res.status(500).json({ error: 'Failed to list regions' });
+  }
+});
+
 // ─── variables ───────────────────────────────────────────────────────────────
 
 router.get('/variables', canRead, async (_req: Request, res: Response) => {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2901,6 +2901,8 @@ router.get(
       const useDM = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckUseDM');
       const cooldownSeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckCooldownSeconds');
       const testMessages = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckTestMessages');
+      const scopeMode = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeMode');
+      const scopeName = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeName');
 
       res.json({
         success: true,
@@ -2918,6 +2920,9 @@ router.get(
           useDM: useDM === 'true',
           cooldownSeconds: parseInt(cooldownSeconds || '0', 10) || 0,
           testMessages: testMessages || 'test\nTest message\nping\nPING\nHello world\nTESTING 123',
+          // MeshCore scope/region for the ack reply (#3833).
+          scopeMode: (scopeMode as 'inherit' | 'trigger' | 'unscoped' | 'named') || 'inherit',
+          scopeName: scopeName || '',
         },
       });
     } catch (error) {
@@ -2944,6 +2949,8 @@ router.post(
         useDM,
         cooldownSeconds,
         testMessages,
+        scopeMode,
+        scopeName,
       } = req.body as {
         enabled?: boolean;
         regex?: string;
@@ -2953,6 +2960,8 @@ router.post(
         useDM?: boolean;
         cooldownSeconds?: number;
         testMessages?: string;
+        scopeMode?: 'inherit' | 'trigger' | 'unscoped' | 'named';
+        scopeName?: string;
       };
 
       if (enabled !== undefined) {
@@ -2992,6 +3001,13 @@ router.post(
       if (testMessages !== undefined) {
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAckTestMessages', testMessages);
       }
+      if (scopeMode !== undefined) {
+        const mode = ['inherit', 'trigger', 'unscoped', 'named'].includes(String(scopeMode)) ? String(scopeMode) : 'inherit';
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckScopeMode', mode);
+      }
+      if (scopeName !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckScopeName', String(scopeName).trim());
+      }
 
       res.json({ success: true });
     } catch (error) {
@@ -3027,6 +3043,8 @@ router.get(
       const advertEnabled = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceAdvertEnabled');
       const advertDelaySeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceAdvertDelaySeconds');
       const lastRunAt = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceLastRunAt');
+      const scopeMode = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceScopeMode');
+      const scopeName = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceScopeName');
 
       res.json({
         success: true,
@@ -3046,6 +3064,10 @@ router.get(
           advertEnabled: advertEnabled === 'true',
           advertDelaySeconds: parseInt(advertDelaySeconds || '30', 10) || 30,
           lastRunAt: lastRunAt ? parseInt(lastRunAt, 10) || null : null,
+          // MeshCore scope/region for the announcement (#3833). No trigger here,
+          // so only inherit / unscoped / named are meaningful.
+          scopeMode: (scopeMode as 'inherit' | 'unscoped' | 'named') || 'inherit',
+          scopeName: scopeName || '',
         },
       });
     } catch (error) {
@@ -3073,6 +3095,8 @@ router.post(
         schedule,
         advertEnabled,
         advertDelaySeconds,
+        scopeMode,
+        scopeName,
       } = req.body as {
         enabled?: boolean;
         intervalHours?: number;
@@ -3083,6 +3107,8 @@ router.post(
         schedule?: string;
         advertEnabled?: boolean;
         advertDelaySeconds?: number;
+        scopeMode?: 'inherit' | 'unscoped' | 'named';
+        scopeName?: string;
       };
 
       if (enabled !== undefined) {
@@ -3116,6 +3142,13 @@ router.post(
       if (advertDelaySeconds !== undefined) {
         const clamped = Math.max(0, Math.min(600, Math.floor(advertDelaySeconds) || 30));
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceAdvertDelaySeconds', String(clamped));
+      }
+      if (scopeMode !== undefined) {
+        const mode = ['inherit', 'unscoped', 'named'].includes(String(scopeMode)) ? String(scopeMode) : 'inherit';
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceScopeMode', mode);
+      }
+      if (scopeName !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceScopeName', String(scopeName).trim());
       }
 
       // Re-arm the scheduler so the new settings take effect immediately.

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -59,6 +59,87 @@ describe('executeAction', () => {
     expect(calls[0].args).toMatchObject({ destination: 777, replyId: 42, channel: 0 });
   });
 
+  // ── MeshCore scope/region (#3833) ──────────────────────────────────────────
+  it('sendMessage: inherit scope omits scopeOverride (default call shape unchanged)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1 }),
+      ctx({ from: 5, channel: 1, isDM: false }),
+      deps,
+    );
+    expect('scopeOverride' in calls[0].args).toBe(false);
+  });
+
+  it('sendMessage: unscoped scope passes empty-string override', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'unscoped' }),
+      ctx({ from: 5, channel: 1, isDM: false }),
+      deps,
+    );
+    expect(calls[0].args.scopeOverride).toBe('');
+  });
+
+  it('sendMessage: named scope passes the interpolated region name', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'named', scopeName: ' paris ' }),
+      ctx({ from: 5, channel: 1, isDM: false }),
+      deps,
+    );
+    expect(calls[0].args.scopeOverride).toBe('paris');
+  });
+
+  it('sendMessage: empty named scope falls back to inherit (no override)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'named', scopeName: '   ' }),
+      ctx({ from: 5, channel: 1, isDM: false }),
+      deps,
+    );
+    expect('scopeOverride' in calls[0].args).toBe(false);
+  });
+
+  it('sendMessage: trigger scope uses the triggering message scopeName', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'trigger' }),
+      ctx({ from: 5, channel: 1, isDM: false, scopeName: 'lyon', scopeCode: 123 }),
+      deps,
+    );
+    expect(calls[0].args.scopeOverride).toBe('lyon');
+  });
+
+  it('sendMessage: trigger scope on an explicitly-unscoped trigger sends unscoped', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'trigger' }),
+      ctx({ from: 5, channel: 1, isDM: false, scopeName: undefined, scopeCode: 0 }),
+      deps,
+    );
+    expect(calls[0].args.scopeOverride).toBe('');
+  });
+
+  it('sendMessage: trigger scope on a Meshtastic trigger (no scope) inherits', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'trigger' }),
+      ctx({ from: 5, channel: 1, isDM: false }),
+      deps,
+    );
+    expect('scopeOverride' in calls[0].args).toBe(false);
+  });
+
+  it('sendMessage: DM send never carries a scope override', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', channel: 0, scopeMode: 'unscoped' }),
+      ctx({ from: 777, channel: 0, isDM: true }),
+      deps,
+    );
+    expect('scopeOverride' in calls[0].args).toBe(false);
+  });
+
   it('tapback: defaults replyId to the trigger packet and routes DM→DM', async () => {
     const { calls, deps } = recorder();
     await executeAction(

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -18,7 +18,7 @@ function recorder() {
 }
 
 /** Context with a fake var resolver (var.* → a small fixed map). */
-function ctx(fields: Record<string, unknown>, sourceId: string | null = 'default'): EngineEvalContext {
+function ctx(fields: Record<string, unknown>, sourceId: string | null = 'default', protocol?: string): EngineEvalContext {
   const trigger: TriggerContext = {
     triggerType: 'trigger.message',
     sourceId,
@@ -29,7 +29,11 @@ function ctx(fields: Record<string, unknown>, sourceId: string | null = 'default
   const vars = {
     getValue: async (name: string) => (name === 'greeting' ? 'hi there' : null),
   } as unknown as VariableResolver;
-  const data = { getNode: async () => null, getTelemetry: async () => null };
+  // Only expose getSourceProtocol when a protocol is given, so legacy tests keep
+  // the original (no-protocol-info) data shape.
+  const data = protocol
+    ? { getNode: async () => null, getTelemetry: async () => null, getSourceProtocol: async () => protocol }
+    : { getNode: async () => null, getTelemetry: async () => null };
   return { trigger, vars, data, varCtx: { sourceId, nodeNum: trigger.subjectNodeNum }, now: 1000 };
 }
 
@@ -163,12 +167,35 @@ describe('executeAction', () => {
     expect(calls[0].args).toMatchObject({ channel: 3, destination: undefined, replyId: 99 });
   });
 
+  it('tapback: skips as a recorded no-op on a MeshCore source (#3833 follow-up)', async () => {
+    const { calls, deps } = recorder();
+    const result = await executeAction(
+      node('action.tapback', { emoji: '👍' }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false }, 'mc', 'meshcore'),
+      deps,
+    );
+    expect(result).toMatchObject({ skipped: true });
+    expect(calls).toHaveLength(0); // deps never invoked
+  });
+
   it('nodeManage: defaults to the subject node and validates op', async () => {
     const { calls, deps } = recorder();
     await executeAction(node('action.nodeManage', { op: 'favorite' }), ctx({ from: 222 }), deps);
     expect(calls[0]).toEqual({ fn: 'manageNode', args: { sourceId: 'default', nodeNum: 222, op: 'favorite' } });
 
     await expect(executeAction(node('action.nodeManage', { op: 'explode' }), ctx({ from: 1 }), deps)).rejects.toThrow(/invalid op/);
+  });
+
+  it('nodeManage: skips favorite/ignore on MeshCore but still allows delete (#3833 follow-up)', async () => {
+    const { calls, deps } = recorder();
+    // favorite is a Meshtastic-admin op → skipped no-op on MeshCore.
+    const fav = await executeAction(node('action.nodeManage', { op: 'favorite' }), ctx({ from: 7 }, 'mc', 'meshcore'), deps);
+    expect(fav).toMatchObject({ skipped: true });
+    expect(calls).toHaveLength(0);
+
+    // delete is DB-level → runs on any source, MeshCore included.
+    await executeAction(node('action.nodeManage', { op: 'delete' }), ctx({ from: 7 }, 'mc', 'meshcore'), deps);
+    expect(calls).toEqual([{ fn: 'manageNode', args: { sourceId: 'mc', nodeNum: 7, op: 'delete' } }]);
   });
 
   it('notify: interpolates title/body and passes type', async () => {

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -83,6 +83,19 @@ async function num(ctx: EngineEvalContext, raw: unknown): Promise<number | undef
 }
 
 /**
+ * True when the action's target source speaks MeshCore. Best-effort: when the
+ * data provider can't report a protocol (older callers / tests), returns false
+ * so behavior is unchanged. Used to skip Meshtastic-only actions (tapback,
+ * node favorite/ignore admin) on MeshCore sources as a recorded no-op instead
+ * of letting the deps throw — now that MeshCore messages also trigger the
+ * engine (#3833), a trigger.message automation can match MeshCore traffic.
+ */
+async function isMeshCoreSource(ctx: EngineEvalContext, sourceId: string | null): Promise<boolean> {
+  if (!sourceId) return false;
+  return (await ctx.data.getSourceProtocol?.(sourceId)) === 'meshcore';
+}
+
+/**
  * Execute an action node against the injected deps. Throws on unknown action
  * type or missing required data; the graph evaluator catches and records it.
  */
@@ -192,6 +205,12 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
     }
 
     case 'action.tapback': {
+      // MeshCore has no tapback / emoji-reaction concept. Skip as a recorded
+      // no-op rather than letting the deps throw, which would log a failed run
+      // for every MeshCore message a tapback automation happens to match.
+      if (await isMeshCoreSource(ctx, sourceId)) {
+        return { skipped: true, reason: 'tapback is not supported on MeshCore' };
+      }
       const emoji = String(p.emoji ?? '👍');
       // Default replyId is the triggering packet; route the way the trigger arrived.
       const replyId = p.replyId != null ? await num(ctx, p.replyId) : (ctx.trigger.fields.packetId as number | undefined);
@@ -206,6 +225,12 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       if (nodeNum == null) throw new Error('action.nodeManage: no target node');
       if (!['favorite', 'unfavorite', 'ignore', 'unignore', 'delete'].includes(op)) {
         throw new Error(`action.nodeManage: invalid op "${op}"`);
+      }
+      // favorite/ignore management rides a Meshtastic admin channel; MeshCore
+      // managers have no such senders. `delete` is DB-level and works for any
+      // source, so only gate the mesh-admin ops — skip (no-op) on MeshCore.
+      if (op !== 'delete' && await isMeshCoreSource(ctx, sourceId)) {
+        return { skipped: true, reason: `nodeManage:${op} is not supported on MeshCore` };
       }
       return deps.manageNode({ sourceId, nodeNum, op });
     }

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -165,8 +165,10 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       for (const sid of sourceIds) {
         if (destination != null || channelSel.length === 0) {
           // DM, or no unified-channel selection → single send on the fallback channel.
-          // DMs keep inherit scope (MeshCore DM-by-pubkey isn't reachable here anyway);
-          // a channel-only fallback send still honors the scope override.
+          // A numeric-`to` DM keeps inherit scope: MeshCore reply scope only applies
+          // to flooded channel broadcasts, and MeshCore pubkey DMs don't route through
+          // this path anyway — so dropping the override on a DM is correct, not a leak.
+          // A channel-only fallback send (no `to`) still honors the scope override.
           const fallbackScope = destination != null ? {} : scopeArg;
           results.push(await deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope }));
           continue;

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -18,6 +18,9 @@ export interface ActionDeps {
     channel: number;
     destination?: number;
     replyId?: number;
+    /** MeshCore scope/region override (#3833). undefined = inherit channel/default;
+     *  '' = explicit unscoped; non-empty = that region. Ignored by Meshtastic. */
+    scopeOverride?: string | null;
   }): Promise<unknown>;
   sendTapback(a: {
     sourceId: string | null;
@@ -116,6 +119,34 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       const replyId = p.replyToTrigger ? (ctx.trigger.fields.packetId as number | undefined) : await num(ctx, p.replyId);
       const fallbackChannel = p.channel != null ? Number(p.channel) : triggerChannel;
 
+      // MeshCore scope/region (#3833). Translate the selected mode into the
+      // manager's `scopeOverride` contract: undefined = inherit (channel/default),
+      // '' = explicit unscoped, non-empty = a named region. Meshtastic ignores it.
+      // Only applied to channel/broadcast sends below — DMs keep inherit.
+      let scopeOverride: string | null | undefined;
+      switch (String(p.scopeMode ?? 'inherit')) {
+        case 'unscoped':
+          scopeOverride = '';
+          break;
+        case 'named': {
+          const n = (await interpolateAsync(String(p.scopeName ?? ''), ctx)).trim();
+          scopeOverride = n || undefined; // empty named → inherit
+          break;
+        }
+        case 'trigger': {
+          const tn = ctx.trigger.fields.scopeName;
+          if (typeof tn === 'string' && tn.length > 0) scopeOverride = tn;
+          else if (ctx.trigger.fields.scopeCode === 0) scopeOverride = ''; // trigger was explicitly unscoped
+          else scopeOverride = undefined; // Meshtastic / unknown → inherit
+          break;
+        }
+        default:
+          scopeOverride = undefined; // inherit
+      }
+      // Only forward the key when set, so the default (inherit) call shape — and
+      // thus the run-log resolvedParams and existing tests — is unchanged.
+      const scopeArg = scopeOverride !== undefined ? { scopeOverride } : {};
+
       // Target sources: explicit multi-select, else the legacy single source /
       // the triggering source.
       const sourceIds = Array.isArray(p.sourceIds) && p.sourceIds.length > 0
@@ -134,7 +165,10 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       for (const sid of sourceIds) {
         if (destination != null || channelSel.length === 0) {
           // DM, or no unified-channel selection → single send on the fallback channel.
-          results.push(await deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId }));
+          // DMs keep inherit scope (MeshCore DM-by-pubkey isn't reachable here anyway);
+          // a channel-only fallback send still honors the scope override.
+          const fallbackScope = destination != null ? {} : scopeArg;
+          results.push(await deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope }));
           continue;
         }
         const proto = (await ctx.data.getSourceProtocol?.(sid)) ?? null;
@@ -143,7 +177,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           if (sel.protocol && proto && sel.protocol !== proto) continue; // wrong-protocol channel
           const match = srcChannels.find((c) => c.name.toLowerCase() === sel.name.toLowerCase() && c.role !== 0);
           if (!match) continue; // channel not present on this source
-          results.push(await deps.sendMessage({ sourceId: sid, text, channel: match.id, destination, replyId }));
+          results.push(await deps.sendMessage({ sourceId: sid, text, channel: match.id, destination, replyId, ...scopeArg }));
         }
       }
 

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -161,6 +161,25 @@ describe('AutomationEngineService', () => {
     expect(calls[0].args.scopeOverride).toBe('paris');
   });
 
+  it('replies UNSCOPED when trigger-scope mode meets an explicitly-unscoped MeshCore trigger (#3833)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('mc-ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'pong', scopeMode: 'trigger' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // scopeCode 0 = arrived explicitly unscoped, scopeName absent → reply unscoped ('').
+    const fired = await engine.onMeshCoreMessage(mcMessage({ text: 'ping', scopeCode: 0 }), 'default');
+    expect(fired).toBe(1);
+    expect(calls[0].args.scopeOverride).toBe('');
+  });
+
   it('does not fire a MeshCore message automation when the text filter misses', async () => {
     const { calls, deps } = recorder();
     await createEnabled('mc-ping', {

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -6,6 +6,7 @@ import { VariableResolver } from './variableResolver.js';
 import { AutomationEngineService } from './automationEngineService.js';
 import type { ActionDeps } from './actionExecutor.js';
 import type { DbMessage } from '../../../services/database.js';
+import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import type { AutomationGraph } from '../../../types/automation.js';
 import * as schema from '../../../db/schema/index.js';
 import { createTestDb } from '../../test-helpers/testDb.js';
@@ -38,6 +39,16 @@ function message(over: Partial<DbMessage> = {}): DbMessage {
     createdAt: 1000,
     ...over,
   } as DbMessage;
+}
+
+function mcMessage(over: Partial<MeshCoreMessage> = {}): MeshCoreMessage {
+  return {
+    id: 'mc1',
+    fromPublicKey: 'channel-0', // channel message on slot 0
+    text: 'ping',
+    timestamp: 1000,
+    ...over,
+  } as MeshCoreMessage;
 }
 
 describe('AutomationEngineService', () => {
@@ -129,6 +140,41 @@ describe('AutomationEngineService', () => {
     expect(await engine.onMessage(message({ channel: 2 }), 'default')).toBe(1); // name matches (case-insensitive)
     expect(await engine.onMessage(message({ channel: 0 }), 'default')).toBe(0); // "Primary" ≠ "gauntlet"
     expect(calls.map((c) => c.fn)).toEqual(['sendTapback']);
+  });
+
+  it('fires a message automation on a MeshCore message and replies on the trigger scope (#3833)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('mc-ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'pong', scopeMode: 'trigger' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    const engine = engineWith(deps);
+    await engine.load();
+
+    const fired = await engine.onMeshCoreMessage(mcMessage({ text: 'ping me', scopeName: 'paris', scopeCode: 9 }), 'default');
+    expect(fired).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['sendMessage']);
+    expect(calls[0].args.scopeOverride).toBe('paris');
+  });
+
+  it('does not fire a MeshCore message automation when the text filter misses', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('mc-ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'pong' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    const engine = engineWith(deps);
+    await engine.load();
+    expect(await engine.onMeshCoreMessage(mcMessage({ text: 'hello' }), 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
   });
 
   it('enforces the per-automation cooldown', async () => {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -23,15 +23,18 @@ import {
 import { VariableResolver } from './variableResolver.js';
 import {
   buildMessageContext,
+  buildMeshCoreMessageContext,
   buildNodeContext,
   buildTelemetryContext,
   buildSystemContext,
   buildGeofenceContext,
   buildScheduleContext,
   messageMatchesFilter,
+  meshCoreMessageMatchesFilter,
   type TriggerContext,
   type SystemEvent,
 } from './triggerContext.js';
+import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import { scheduleCron, validateCron } from '../../utils/cronScheduler.js';
 import { haversineKm, geofenceFires, pointInShape, geofenceCenter, normalizeGeofenceParams, type GeofenceMode } from './geo.js';
 import { evaluateGraph, type EvaluatorHooks } from './graphEvaluator.js';
@@ -282,6 +285,27 @@ export class AutomationEngineService {
       channelName = await this.data.getChannelName(sourceId, Number(msg.channel));
     }
     return this.runTrigger(ctx, (a) => messageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName));
+  }
+
+  /**
+   * MeshCore message entry point (#3833). Mirrors {@link onMessage} but builds a
+   * MeshCore-shaped trigger context and uses the MeshCore matcher, so the same
+   * `trigger.message` automations fire on MeshCore received messages (which the
+   * engine previously ignored entirely).
+   */
+  async onMeshCoreMessage(msg: MeshCoreMessage, sourceId: string | null): Promise<number> {
+    const ctx = buildMeshCoreMessageContext(msg, sourceId, this.now());
+    let channelName: string | null | undefined;
+    const usesChannelName = (this.index.get('trigger.message') ?? []).some((a) => {
+      const p = a.triggerNode.params as Record<string, unknown> | undefined;
+      return typeof p?.channelName === 'string' && p.channelName.length > 0;
+    });
+    // A received channel message stores its slot index in `from` as `channel-<idx>`.
+    const channelIdx = ctx.fields.channel;
+    if (usesChannelName && this.data.getChannelName && typeof channelIdx === 'number') {
+      channelName = await this.data.getChannelName(sourceId, channelIdx);
+    }
+    return this.runTrigger(ctx, (a) => meshCoreMessageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName));
   }
 
   async onNode(

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -10,6 +10,7 @@ import { logger } from '../../../utils/logger.js';
 import databaseService from '../../../services/database.js';
 import { dataEventEmitter, type DataEvent } from '../dataEventEmitter.js';
 import type { DbMessage, DbTelemetry } from '../../../services/database.js';
+import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import { AutomationEngineService } from './automationEngineService.js';
 import { VariableResolver } from './variableResolver.js';
 import { createMeshActionDeps } from './meshActionDeps.js';
@@ -98,6 +99,11 @@ async function handleEvent(event: DataEvent): Promise<void> {
   switch (event.type) {
     case 'message:new':
       await e.onMessage(event.data as DbMessage, sourceId);
+      break;
+
+    case 'meshcore:message':
+      // MeshCore received messages were previously ignored by the engine (#3833).
+      await e.onMeshCoreMessage(event.data as MeshCoreMessage, sourceId);
       break;
 
     case 'node:updated': {

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the registry so we can inject fake Meshtastic / MeshCore managers.
+const getManager = vi.fn();
+vi.mock('../../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: (id: string) => getManager(id) },
+}));
+// The deps module also imports these at load time; stub to harmless objects.
+vi.mock('../../../services/database.js', () => ({ default: {} }));
+vi.mock('../appriseNotificationService.js', () => ({ appriseNotificationService: {} }));
+vi.mock('../../utils/scriptRunner.js', () => ({ runScript: vi.fn() }));
+
+import { createMeshActionDeps } from './meshActionDeps.js';
+
+describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
+  beforeEach(() => getManager.mockReset());
+
+  it('forwards scopeOverride to a MeshCore manager (sendMessage signature)', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue({ sendMessage }); // MeshCore-shaped manager
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 2, scopeOverride: 'paris' });
+
+    // raw.sendMessage(text, toPublicKey=undefined, channelIdx, scopeOverride)
+    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 2, 'paris');
+  });
+
+  it('passes an empty-string (unscoped) override through unchanged', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue({ sendMessage });
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 0, scopeOverride: '' });
+
+    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 0, '');
+  });
+
+  it('drops scopeOverride for a Meshtastic manager (no scope concept)', async () => {
+    const sendTextMessage = vi.fn().mockResolvedValue(1);
+    getManager.mockReturnValue({ sendTextMessage }); // Meshtastic-shaped manager
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mt', text: 'hi', channel: 3, scopeOverride: 'paris' });
+
+    // sendTextMessage(text, channel, destination, replyId, emoji) — no scope arg.
+    expect(sendTextMessage).toHaveBeenCalledWith('hi', 3, undefined, undefined, 0);
+  });
+});

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -50,24 +50,27 @@ async function sendTextVia(
   destination?: number,
   replyId?: number,
   emoji = 0,
+  scopeOverride?: string | null,
 ): Promise<unknown> {
   if (!sourceId) throw new Error('automation action requires a target source');
   const raw = sourceManagerRegistry.getManager(sourceId) as unknown as
     (Partial<MeshSendManager> & Partial<MeshCoreSendManager>) | undefined;
   if (raw && typeof raw.sendTextMessage === 'function') {
+    // Meshtastic has no scope/region concept — scopeOverride is dropped.
     return raw.sendTextMessage(text, channel, destination, replyId, emoji);
   }
   if (raw && typeof raw.sendMessage === 'function') {
     // MeshCore: channel send only (DM-by-nodeNum / tapbacks not supported here).
-    return raw.sendMessage(text, undefined, channel);
+    // `scopeOverride` (#3833) controls which region the message floods to.
+    return raw.sendMessage(text, undefined, channel, scopeOverride);
   }
   throw new Error(`source "${sourceId}" cannot send messages`);
 }
 
 export function createMeshActionDeps(): ActionDeps {
   return {
-    async sendMessage({ sourceId, text, channel, destination, replyId }) {
-      return sendTextVia(sourceId, text, channel ?? 0, destination, replyId, 0);
+    async sendMessage({ sourceId, text, channel, destination, replyId, scopeOverride }) {
+      return sendTextVia(sourceId, text, channel ?? 0, destination, replyId, 0, scopeOverride);
     },
 
     async sendTapback({ sourceId, emoji, channel, destination, replyId }) {

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -1,16 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildMessageContext,
+  buildMeshCoreMessageContext,
   buildNodeContext,
   buildTelemetryContext,
   buildSystemContext,
   buildScheduleContext,
   deriveHops,
   messageMatchesFilter,
+  meshCoreMessageMatchesFilter,
   resolveTriggerPath,
   BROADCAST_ADDR,
 } from './triggerContext.js';
 import type { DbMessage } from '../../../services/database.js';
+import type { MeshCoreMessage } from '../../meshcoreManager.js';
+
+function mcMsg(overrides: Partial<MeshCoreMessage> = {}): MeshCoreMessage {
+  return {
+    id: 'm1',
+    fromPublicKey: 'aabbccddeeff',
+    text: 'hello',
+    timestamp: 1000,
+    ...overrides,
+  } as MeshCoreMessage;
+}
 
 function msg(overrides: Partial<DbMessage> = {}): DbMessage {
   return {
@@ -122,6 +135,70 @@ describe('messageMatchesFilter', () => {
   });
   it('an empty channelName does not constrain', () => {
     expect(messageMatchesFilter(msg(), { channelName: '' }, null)).toBe(true);
+  });
+});
+
+describe('buildMeshCoreMessageContext (#3833)', () => {
+  it('maps a channel message: synthetic from, channel index, broadcast, scope', () => {
+    const ctx = buildMeshCoreMessageContext(
+      mcMsg({ fromPublicKey: 'channel-3', fromName: 'Alice', text: 'hi', scopeCode: 7, scopeName: 'paris', hopCount: 2 }),
+      'default',
+      555,
+    );
+    expect(ctx.triggerType).toBe('trigger.message');
+    expect(ctx.subjectNodeNum).toBeNull();
+    expect(ctx.fields.channel).toBe(3);
+    expect(ctx.fields.isBroadcast).toBe(true);
+    expect(ctx.fields.isDM).toBe(false);
+    expect(ctx.fields.fromName).toBe('Alice');
+    expect(ctx.fields.protocol).toBe('meshcore');
+    expect(ctx.fields.scopeCode).toBe(7);
+    expect(ctx.fields.scopeName).toBe('paris');
+    expect(ctx.fields.scoped).toBe(true);
+    expect(ctx.fields.hops).toBe(2);
+  });
+
+  it('maps a DM: recipient pubkey present, no channel, isDM', () => {
+    const ctx = buildMeshCoreMessageContext(
+      mcMsg({ fromPublicKey: 'aabbcc', toPublicKey: 'localkey', scopeCode: 0 }),
+      'default',
+      1,
+    );
+    expect(ctx.fields.channel).toBeUndefined();
+    expect(ctx.fields.isDM).toBe(true);
+    expect(ctx.fields.isBroadcast).toBe(false);
+    expect(ctx.fields.from).toBe('aabbcc');
+    // scopeCode 0 = explicitly unscoped → not "scoped"
+    expect(ctx.fields.scoped).toBe(false);
+  });
+
+  it('a room post is neither DM nor broadcast and has no channel', () => {
+    const ctx = buildMeshCoreMessageContext(
+      mcMsg({ fromPublicKey: 'authorkey', toPublicKey: 'roomkey', messageType: 'room_post' }),
+      'default',
+      1,
+    );
+    expect(ctx.fields.channel).toBeUndefined();
+    expect(ctx.fields.isDM).toBe(false);
+    expect(ctx.fields.isBroadcast).toBe(false);
+  });
+});
+
+describe('meshCoreMessageMatchesFilter (#3833)', () => {
+  it('matches text/regex/channel for MeshCore messages', () => {
+    expect(meshCoreMessageMatchesFilter(mcMsg({ text: 'PING me' }), { textContains: 'ping' })).toBe(true);
+    expect(meshCoreMessageMatchesFilter(mcMsg({ text: 'nope' }), { regex: '^(test|ping)' })).toBe(false);
+    expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-2' }), { channel: 2 })).toBe(true);
+    expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-2' }), { channel: 5 })).toBe(false);
+  });
+  it('matches channel name case-insensitively against the resolved name', () => {
+    expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channelName: 'gauntlet' }, 'Gauntlet')).toBe(true);
+    expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channelName: 'gauntlet' }, 'Primary')).toBe(false);
+  });
+  it('Meshtastic-only params force a non-match (no pubkey↔nodeNum coercion)', () => {
+    expect(meshCoreMessageMatchesFilter(mcMsg(), { from: 111 })).toBe(false);
+    expect(meshCoreMessageMatchesFilter(mcMsg(), { to: 222 })).toBe(false);
+    expect(meshCoreMessageMatchesFilter(mcMsg(), { portnum: 1 })).toBe(false);
   });
 });
 

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -7,6 +7,7 @@
  * full DbNode happens in the engine; here we expose what the payload carries.
  */
 import type { DbMessage } from '../../../services/database.js';
+import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import type { TriggerType } from '../../../types/automation.js';
 import { compileUserRegex } from '../../../utils/safeRegex.js';
 
@@ -65,6 +66,73 @@ export function buildMessageContext(msg: DbMessage, sourceId: string | null, tim
     triggerType: 'trigger.message',
     sourceId,
     subjectNodeNum: Number(msg.fromNodeNum),
+    timestamp,
+    fields,
+  };
+}
+
+/**
+ * A received MeshCore channel message carries no sender pubkey on the wire, so
+ * the manager stores the channel slot in `fromPublicKey` as `channel-<idx>`
+ * (see `MeshCoreManager.channelPublicKey`). Parse that back to the slot index;
+ * returns undefined for DMs/room posts (a real/author pubkey, not a channel).
+ */
+function parseMeshCoreChannelIdx(fromPublicKey: string | undefined): number | undefined {
+  const m = /^channel-(\d+)$/.exec(fromPublicKey ?? '');
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
+ * Build the trigger context for a MeshCore `meshcore:message` event (#3833).
+ *
+ * MeshCore identity is a public-key string — there is no Meshtastic `nodeNum`,
+ * `portnum`, or numeric packet id — so this is a parallel builder to
+ * {@link buildMessageContext} rather than a coercion into `DbMessage` (which
+ * would corrupt the `Number()`-based matcher). `triggerType` stays
+ * `'trigger.message'` so the SAME message automations fire on both protocols.
+ */
+export function buildMeshCoreMessageContext(
+  msg: MeshCoreMessage,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
+  const isChannel = channelIdx !== undefined;
+  const isRoom = msg.messageType === 'room_post';
+  // DM = addressed to us (recipient pubkey set) and not a channel/room post.
+  const isDM = !isChannel && !isRoom && msg.toPublicKey != null;
+  const scopeCode = msg.scopeCode ?? undefined;
+  const fields: Record<string, unknown> = {
+    // MeshCore senders are pubkey strings; channel messages have no per-sender
+    // pubkey, so `from` is the synthetic `channel-<idx>` key. `fromName` carries
+    // the display name a channel sender prefixed onto the body, when present.
+    from: msg.fromPublicKey,
+    fromId: msg.fromPublicKey,
+    fromName: msg.fromName,
+    to: msg.toPublicKey,
+    toId: msg.toPublicKey,
+    text: msg.text,
+    channel: channelIdx,
+    isDM,
+    isBroadcast: isChannel,
+    hops: msg.hopCount ?? undefined,
+    snr: msg.snr,
+    rssi: msg.rssi,
+    // MeshCore scope/region (#3833). `scopeCode` 0 = explicitly unscoped, null/
+    // absent = no scope info; `scopeName` = resolved region name (null when
+    // unscoped or scoped-but-unknown). Powers the "respond on trigger scope" mode.
+    scopeCode,
+    scopeName: msg.scopeName ?? undefined,
+    scoped: scopeCode != null && scopeCode !== 0,
+    protocol: 'meshcore',
+    sourceId,
+    timestamp,
+  };
+  return {
+    triggerType: 'trigger.message',
+    sourceId,
+    // No Meshtastic-style numeric node → no node.* hydration for MeshCore messages.
+    subjectNodeNum: null,
     timestamp,
     fields,
   };
@@ -195,6 +263,43 @@ export function messageMatchesFilter(msg: DbMessage, params: Record<string, unkn
       re = compileUserRegex(params.regex);
     } catch {
       return false; // an invalid/unsupported regex never matches
+    }
+    if (!re.test(text)) return false;
+  }
+  return true;
+}
+
+/**
+ * Pre-filter for MeshCore `trigger.message` events — the MeshCore analogue of
+ * {@link messageMatchesFilter}. Honors only cross-protocol params (text/regex/
+ * channel/channelName). Meshtastic-only params (`from`/`to`/`portnum`) express
+ * node-number intent that can't match a MeshCore pubkey sender, so their
+ * presence forces a non-match (a "from node #N" rule never fires on MeshCore).
+ *
+ * @param channelName Pre-resolved name of the message's channel slot for its
+ *   source (same contract as {@link messageMatchesFilter}).
+ */
+export function meshCoreMessageMatchesFilter(
+  msg: MeshCoreMessage,
+  params: Record<string, unknown> = {},
+  channelName?: string | null,
+): boolean {
+  if (params.portnum != null || params.from != null || params.to != null) return false;
+  const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
+  if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return false;
+  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return false;
+  }
+  const text = msg.text ?? '';
+  if (typeof params.textContains === 'string' && params.textContains.length > 0) {
+    if (!text.toLowerCase().includes(params.textContains.toLowerCase())) return false;
+  }
+  if (typeof params.regex === 'string' && params.regex.length > 0) {
+    let re: RegExp;
+    try {
+      re = compileUserRegex(params.regex);
+    } catch {
+      return false;
     }
     if (!re.test(text)) return false;
   }


### PR DESCRIPTION
Closes #3833.

## Background: why scope, not a hop-limit

#3833 requested a configurable **flood hop-limit** on automated MeshCore messages so a bot's auto-replies don't flood the whole mesh when only locally relevant. Firmware investigation (against `meshcore-dev/MeshCore` source + docs) confirms a per-message hop limit is **not achievable via the companion protocol**:

- `CMD_SEND_CHANNEL_TXT_MSG` (3) / `CMD_SEND_TXT_MSG` (2) frames carry **no hop field** (`examples/companion_radio/MyMesh.cpp`).
- `CMD_SET_OTHER_PARAMS` (38) sets only `manual_add_contacts`, telemetry modes, `advert_loc_policy`, `multi_acks` — **no `flood.max`**. A companion app can't even set the device-global flood limit.
- MeshCore packets have **no sender-set TTL**. `flood.max` / `flood.max.unscoped` (0–64) are **repeater-side forwarding policies** — a repeater drops a flood once its accumulated `path_len` exceeds its own config. The originator can't stamp a per-message limit.

The only per-message propagation lever MeshMonitor has is **scope/region** (a scoped flood is only forwarded by repeaters configured for that region). This PR delivers scope-based control — per-automation scope selection plus "respond on the trigger's scope" — across **both** automation systems.

> Operators who need a hard hop cap can set `flood.max.unscoped` on their repeaters (CLI); it's out of MeshMonitor's reach by protocol design.

## What changed

**Legacy "Automations" tab** (per-source, native MeshCore)
- `scopeMode` (`inherit` / `trigger` / `unscoped` / `named`) + `scopeName` added to the **auto-responder**, **auto-ack**, **auto-announce**, and **timer-trigger** senders, resolved by a shared `resolveAutomationScopeOverride()` and passed to `sendMessage`'s existing `scopeOverride` arg. `trigger` mode replies on the triggering message's own scope (its `scopeName`, or unscoped when the trigger was explicitly unscoped, else inherit).
- New shared `<ScopeSelectField>` control wired into all four sections. Reply automations (responder, ack) offer **"Respond on the triggering message's scope"**; scheduled senders (announce, timer) omit it.

**Automation Engine** (graph)
- **MeshCore received messages now trigger the engine** (previously ignored — only Meshtastic `message:new` was handled). New `buildMeshCoreMessageContext` + `meshCoreMessageMatchesFilter` + `onMeshCoreMessage`, dispatched from the `meshcore:message` event. Pubkey identity is preserved (no `DbMessage` coercion); Meshtastic-only filters (`from`/`to`/`portnum`) force a non-match so a "from node #N" rule never fires on a pubkey sender.
- `trigger.message` now exposes `scopeCode` / `scopeName` / `scoped` for conditions and `{{ trigger.scopeName }}`.
- Scope selection added to the **"Send a message"** action (`scopeMode` + a new `regionSelect` field), translated to `scopeOverride` and threaded through `ActionDeps` → `meshActionDeps` to the MeshCore manager (Meshtastic ignores it). Applied to channel/broadcast sends only.
- New `GET /api/automations/regions` feeds the region dropdown from the global saved-regions catalog.

No DB migration (legacy rules are JSON-in-settings; engine action params are JSON in the graph; the saved-regions table already exists).

## Testing
- Unit: `triggerContext.test.ts` (MeshCore context mapping + matcher), `actionExecutor.test.ts` (every `scopeMode` → `scopeOverride`, default call shape unchanged), `automationEngineService.test.ts` (`onMeshCoreMessage` fires + replies on trigger scope), new `meshActionDeps.test.ts` (override forwards to MeshCore, dropped for Meshtastic).
- **Full Vitest suite: 8346 tests, 0 failures.** Typecheck adds zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)