### PR TITLE
feat(automation): live trace ("view logs") for Automation Engine rules

### DIFF
--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -11,6 +11,7 @@ import { useState, type ReactNode } from 'react';
 import apiService from '../../services/api';
 import type { VariableOption, SourceOption } from './AutomationBuilder';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
+import { OUTCOME_META } from './outcomeMeta';
 
 export interface SimResult {
   matched: boolean;
@@ -252,17 +253,6 @@ function renderEventInputs(kind: string, ev: EventState, set: (k: string, v: str
       return <div className="ae-muted">No event input needed — this trigger has no payload.</div>;
   }
 }
-
-const OUTCOME_META: Record<string, { icon: string; cls: string; label: string }> = {
-  'condition:true': { icon: '✓', cls: 'ok', label: 'condition true' },
-  'condition:false': { icon: '✗', cls: 'no', label: 'condition false' },
-  'action:ok': { icon: '➜', cls: 'ok', label: 'action ran' },
-  'action:error': { icon: '⚠', cls: 'err', label: 'action error' },
-  'setVar:ok': { icon: '✎', cls: 'ok', label: 'variable set' },
-  'setVar:error': { icon: '⚠', cls: 'err', label: 'variable error' },
-  'activated': { icon: '•', cls: 'muted', label: 'activated' },
-  'guard:maxActions': { icon: '⛔', cls: 'err', label: 'action cap hit' },
-};
 
 /** Human-readable "what would be sent" for one simulated action. */
 function ActionView({ a }: { a: SimResult['actions'][number] }) {

--- a/src/components/automations/AutomationsPage.css
+++ b/src/components/automations/AutomationsPage.css
@@ -177,3 +177,14 @@
 /* Test panel — "no actions ran" guidance note */
 .ae-test-note { background: var(--ctp-surface0); border-left: 3px solid var(--ctp-yellow); padding: 0.4rem 0.6rem; border-radius: var(--radius-sm, 6px); font-size: 0.82rem; color: var(--ctp-subtext1); line-height: 1.45; }
 .ae-test-note code { background: var(--ctp-mantle); padding: 0 0.25rem; border-radius: 3px; }
+
+/* Live trace panel ("view logs" for one rule) */
+.ae-trace-panel { display: flex; flex-direction: column; gap: 0.6rem; }
+.ae-trace-panel-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; flex-wrap: wrap; }
+.ae-trace-feed { display: flex; flex-direction: column; gap: 0.4rem; max-height: 60vh; overflow-y: auto; }
+.ae-trace-entry { border: 1px solid var(--ctp-surface1); border-radius: var(--radius-sm, 6px); background: var(--ctp-base); padding: 0.4rem 0.55rem; }
+.ae-trace-entry-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+.ae-trace-entry-summary { font-family: var(--font-mono, monospace); font-size: 0.8rem; color: var(--ctp-text); word-break: break-word; }
+.ae-trace-reason { font-size: 0.8rem; margin-top: 0.2rem; padding-left: 0.4rem; }
+.ae-trace-steps-wrap { margin-top: 0.35rem; }
+.ae-trace-steps-wrap > summary { cursor: pointer; font-size: 0.78rem; }

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -12,6 +12,7 @@ import { appBasename } from '../../init';
 import apiService from '../../services/api';
 import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption, type ScriptOption } from './AutomationBuilder';
 import AutomationTester from './AutomationTester';
+import LiveTracePanel from './LiveTracePanel';
 import { compile, decompile, type WorkflowForm } from './compile';
 import './AutomationsPage.css';
 
@@ -89,6 +90,7 @@ function AutomationsList() {
   const [items, setItems] = useState<Automation[]>([]);
   const [editing, setEditing] = useState<Automation | 'new' | null>(null);
   const [runsFor, setRunsFor] = useState<Automation | null>(null);
+  const [traceFor, setTraceFor] = useState<Automation | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -107,6 +109,12 @@ function AutomationsList() {
 
   if (editing) return <AutomationEditor automation={editing} onClose={() => { setEditing(null); load(); }} />;
   if (runsFor) return <RunLog automation={runsFor} onClose={() => setRunsFor(null)} />;
+  if (traceFor) return (
+    <div>
+      <button className="ae-btn ae-btn--ghost" onClick={() => setTraceFor(null)} style={{ marginBottom: '0.75rem' }}>← Back</button>
+      <LiveTracePanel automationId={traceFor.id} automationName={traceFor.name} enabled={traceFor.enabled} onClose={() => setTraceFor(null)} />
+    </div>
+  );
 
   return (
     <div>
@@ -126,6 +134,7 @@ function AutomationsList() {
               <label className="ae-switch"><input type="checkbox" checked={a.enabled} onChange={() => toggle(a)} /> Enabled</label>
               <button className="ae-btn" onClick={() => setEditing(a)}>Edit</button>
               <button className="ae-btn" onClick={() => setRunsFor(a)}>Runs</button>
+              <button className="ae-btn" onClick={() => setTraceFor(a)} title="Live debug trace of this rule">Trace</button>
               <button className="ae-btn" onClick={() => exportOne(a)}>Export</button>
               <button className="ae-btn ae-btn--danger" onClick={() => remove(a)}>Delete</button>
             </div>

--- a/src/components/automations/LiveTracePanel.tsx
+++ b/src/components/automations/LiveTracePanel.tsx
@@ -69,7 +69,10 @@ export default function LiveTracePanel({ automationId, automationName, enabled, 
   const [remaining, setRemaining] = useState<number>(TRACE_DURATION_MS);
   const expiresAtRef = useRef<number>(0);
 
-  // Arm the trace + subscribe while mounted. Re-runs if the socket (re)connects.
+  // Arm the trace + subscribe while mounted. Re-runs if the socket (re)connects:
+  // cleanup stops on the old socket (a no-op once it's gone) and we re-arm on the
+  // new one, which re-fires `automation-trace:started` and resets the countdown —
+  // intended, since a reconnect starts a fresh 5-minute server-side session.
   useEffect(() => {
     if (!socket) {
       setStatus('connecting');

--- a/src/components/automations/LiveTracePanel.tsx
+++ b/src/components/automations/LiveTracePanel.tsx
@@ -1,0 +1,178 @@
+/**
+ * LiveTracePanel — in-app "view logs" for a single automation rule.
+ *
+ * Opt-in, live-only debugging: while open it asks the server (over the shared
+ * Socket.io connection) to stream every event the engine evaluates against THIS
+ * rule, and shows why each did or didn't run (fired + step trace / filtered-out
+ * + reason / cooldown). Nothing is persisted — entries live in a capped in-memory
+ * buffer and the session auto-stops after 5 minutes (and on close / disconnect).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useWebSocketContext } from '../../contexts/WebSocketContext';
+import { StepList, type TraceStep } from './outcomeMeta';
+
+const TRACE_DURATION_MS = 5 * 60_000;
+const MAX_ENTRIES = 200;
+
+interface TraceEntry {
+  ts: number;
+  automationId: string;
+  triggerType: string;
+  sourceId: string | null;
+  event: Record<string, unknown>;
+  outcome: 'fired' | 'prefiltered' | 'cooldown';
+  reason?: string;
+  status?: 'completed' | 'failed';
+  conditionResults?: Record<string, boolean>;
+  actions?: Array<{ nodeId: string; ok: boolean; error?: string }>;
+  steps?: TraceStep[];
+}
+
+interface LiveTracePanelProps {
+  automationId: string;
+  automationName: string;
+  /** Whether the rule is enabled — disabled rules never evaluate, so warn. */
+  enabled: boolean;
+  onClose: () => void;
+}
+
+/** A compact one-line summary of the triggering event for the entry header. */
+function summarizeEvent(triggerType: string, event: Record<string, unknown>): string {
+  const bits: string[] = [];
+  if (triggerType === 'trigger.message') {
+    if (event.from != null) bits.push(`from ${event.from}`);
+    if (event.channel != null) bits.push(`ch ${event.channel}`);
+    if (typeof event.text === 'string') bits.push(`"${event.text}"`);
+  } else if (triggerType === 'trigger.telemetry') {
+    bits.push(`${event.telemetryType ?? '?'} = ${event.value ?? '?'}`);
+  } else if (triggerType === 'trigger.geofence') {
+    bits.push(`${event.event ?? '?'} · node ${event.nodeNum ?? '?'}`);
+  } else if (triggerType === 'trigger.system') {
+    bits.push(String(event.event ?? ''));
+  } else if (event.nodeNum != null) {
+    bits.push(`node ${event.nodeNum}`);
+  }
+  return bits.join(' · ') || '(no event payload)';
+}
+
+const OUTCOME_BADGE: Record<string, { label: string; cls: string }> = {
+  prefiltered: { label: 'filtered out', cls: 'no' },
+  cooldown: { label: 'cooldown', cls: 'muted' },
+};
+
+export default function LiveTracePanel({ automationId, automationName, enabled, onClose }: LiveTracePanelProps) {
+  const { state } = useWebSocketContext();
+  const socket = state.socket;
+  const [entries, setEntries] = useState<TraceEntry[]>([]);
+  const [status, setStatus] = useState<'connecting' | 'live' | 'stopped' | 'error'>('connecting');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [remaining, setRemaining] = useState<number>(TRACE_DURATION_MS);
+  const expiresAtRef = useRef<number>(0);
+
+  // Arm the trace + subscribe while mounted. Re-runs if the socket (re)connects.
+  useEffect(() => {
+    if (!socket) {
+      setStatus('connecting');
+      return;
+    }
+    const onTrace = (payload: TraceEntry) => {
+      if (!payload || payload.automationId !== automationId) return;
+      setEntries((prev) => {
+        const next = [payload, ...prev];
+        return next.length > MAX_ENTRIES ? next.slice(0, MAX_ENTRIES) : next;
+      });
+    };
+    const onStarted = (data: { automationId: string; expiresAt: number }) => {
+      if (data?.automationId !== automationId) return;
+      expiresAtRef.current = data.expiresAt;
+      setStatus('live');
+    };
+    const onError = (data: { automationId?: string; error: string }) => {
+      if (data?.automationId && data.automationId !== automationId) return;
+      setErrorMsg(data?.error ?? 'trace error');
+      setStatus('error');
+    };
+
+    socket.on('automation:trace', onTrace);
+    socket.on('automation-trace:started', onStarted);
+    socket.on('automation-trace:error', onError);
+    socket.emit('automation-trace:start', { automationId, durationMs: TRACE_DURATION_MS });
+
+    return () => {
+      socket.emit('automation-trace:stop', { automationId });
+      socket.off('automation:trace', onTrace);
+      socket.off('automation-trace:started', onStarted);
+      socket.off('automation-trace:error', onError);
+    };
+  }, [socket, automationId]);
+
+  // Countdown to auto-stop (the server expires it too).
+  useEffect(() => {
+    if (status !== 'live') return;
+    const tick = () => {
+      const left = Math.max(0, expiresAtRef.current - Date.now());
+      setRemaining(left);
+      if (left <= 0) setStatus('stopped');
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  const mmss = (ms: number) => {
+    const s = Math.ceil(ms / 1000);
+    return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+  };
+
+  return (
+    <div className="ae-trace-panel">
+      <div className="ae-trace-panel-head">
+        <div>
+          <strong>Live trace</strong> · {automationName}
+          {status === 'live' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}>● live · {mmss(remaining)} left</span>}
+          {status === 'connecting' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}>connecting…</span>}
+          {status === 'stopped' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}>stopped (auto)</span>}
+          {status === 'error' && <span className="ae-test-badge ae-test-badge--err" style={{ marginLeft: '0.5rem' }}>error: {errorMsg}</span>}
+        </div>
+        <div className="ae-row" style={{ gap: '0.4rem' }}>
+          <button className="ae-btn ae-btn--ghost" onClick={() => setEntries([])}>Clear</button>
+          <button className="ae-btn ae-btn--ghost" onClick={onClose}>Close</button>
+        </div>
+      </div>
+
+      {!enabled && (
+        <div className="ae-test-note">This rule is <strong>disabled</strong> — the engine never evaluates it, so no events will appear. Enable the rule to see live evaluations.</div>
+      )}
+
+      <div className="ae-trace-feed">
+        {entries.length === 0 && (
+          <div className="ae-muted" style={{ padding: '0.6rem 0' }}>
+            Waiting for events… send traffic that this rule's trigger listens for (e.g. a message on its channel) and each evaluation will appear here.
+          </div>
+        )}
+        {entries.map((e, i) => {
+          const fired = e.outcome === 'fired';
+          const badge = fired
+            ? { label: e.status === 'failed' ? 'fired · failed' : 'fired', cls: e.status === 'failed' ? 'err' : 'ok' }
+            : (OUTCOME_BADGE[e.outcome] ?? { label: e.outcome, cls: 'muted' });
+          return (
+            <div className="ae-trace-entry" key={`${e.ts}-${i}`}>
+              <div className="ae-trace-entry-head">
+                <span className={`ae-test-badge ae-test-badge--${badge.cls}`}>{badge.label}</span>
+                <span className="ae-muted">{new Date(e.ts).toLocaleTimeString()}</span>
+                <span className="ae-trace-entry-summary">{summarizeEvent(e.triggerType, e.event)}</span>
+              </div>
+              {!fired && e.reason && <div className="ae-muted ae-trace-reason">↳ {e.reason}</div>}
+              {fired && e.steps && e.steps.length > 0 && (
+                <details className="ae-trace-steps-wrap">
+                  <summary className="ae-muted">execution trace ({e.steps.length} steps)</summary>
+                  <StepList steps={e.steps} />
+                </details>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/automations/outcomeMeta.tsx
+++ b/src/components/automations/outcomeMeta.tsx
@@ -1,0 +1,43 @@
+/**
+ * Shared rendering vocabulary for automation evaluation steps — used by both the
+ * offline Test panel (AutomationTester) and the live trace panel (LiveTracePanel)
+ * so the two never drift in how a `condition:true` / `action:error` / … step looks.
+ */
+
+export interface TraceStep {
+  nodeId?: string;
+  type: string;
+  outcome: string;
+  error?: string;
+}
+
+export const OUTCOME_META: Record<string, { icon: string; cls: string; label: string }> = {
+  'condition:true': { icon: '✓', cls: 'ok', label: 'condition true' },
+  'condition:false': { icon: '✗', cls: 'no', label: 'condition false' },
+  'action:ok': { icon: '➜', cls: 'ok', label: 'action ran' },
+  'action:error': { icon: '⚠', cls: 'err', label: 'action error' },
+  'setVar:ok': { icon: '✎', cls: 'ok', label: 'variable set' },
+  'setVar:error': { icon: '⚠', cls: 'err', label: 'variable error' },
+  'activated': { icon: '•', cls: 'muted', label: 'activated' },
+  'guard:maxActions': { icon: '⛔', cls: 'err', label: 'action cap hit' },
+  'engine:error': { icon: '💥', cls: 'err', label: 'engine error' },
+};
+
+/** Render a list of evaluation steps with consistent icons/labels. */
+export function StepList({ steps }: { steps: TraceStep[] }) {
+  if (steps.length === 0) return <div className="ae-muted">No steps.</div>;
+  return (
+    <div className="ae-trace">
+      {steps.map((s, i) => {
+        const m = OUTCOME_META[s.outcome] ?? { icon: '·', cls: 'muted', label: s.outcome };
+        return (
+          <div className={`ae-trace-step ae-trace-step--${m.cls}`} key={i}>
+            <span className="ae-trace-icon">{m.icon}</span>
+            <span className="ae-trace-type">{s.type}</span>
+            <span className="ae-muted">{m.label}{s.error ? ` — ${s.error}` : ''}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -532,6 +532,34 @@ describe('AutomationEngineService', () => {
     expect(got.find((g) => g.outcome === 'cooldown').reason).toMatch(/cooldown active/);
   });
 
+  it('emits geofence traces: baseline (prefiltered) then enter (fired)', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    const { deps } = recorder();
+    const a = await createEnabled('geo-enter', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.geofence', params: { event: 'enter', lat: 0, lon: 0, radiusKm: 5 } },
+        { id: 'n', type: 'action.notify', params: { body: 'entered' } },
+      ],
+      edges: [{ from: 't', to: 'n' }],
+    });
+    const pos = { lat: 1, lon: 0 }; // outside
+    const geoData = { getNode: async () => ({ nodeNum: 5, latitude: pos.lat, longitude: pos.lon }), getTelemetry: async () => null };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: geoData, now: () => clock });
+    await engine.load();
+    automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+    await engine.checkGeofences(5, 'default'); // baseline (outside)
+    pos.lat = 0.01;                            // move inside
+    await engine.checkGeofences(5, 'default'); // enter → fires
+
+    const outcomes = got.map((g) => g.outcome);
+    expect(outcomes).toEqual(['prefiltered', 'fired']);
+    expect(got[0].reason).toMatch(/baseline only/);
+    expect(got[1]).toMatchObject({ status: 'completed' });
+  });
+
   it('emits NOTHING when the rule is not being traced (hot-path no-op)', async () => {
     const got: any[] = [];
     automationTraceBus.setSink((_id, payload) => got.push(payload));

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -552,6 +552,29 @@ describe('AutomationEngineService', () => {
     expect(got[0]).toMatchObject({ automationId: a.id, outcome: 'fired', triggerType: 'trigger.schedule' });
   });
 
+  it('emits a COOLDOWN trace for a throttled schedule rule', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    const a = await createEnabled('cron', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.schedule', params: { cron: '* * * * *', cooldownSeconds: 60 } },
+        { id: 'n', type: 'action.notify', params: { body: 'tick' } },
+      ],
+      edges: [{ from: 't', to: 'n' }],
+    });
+    const engine = engineWith(recorder().deps);
+    await engine.load();
+    automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+    await engine.onSchedule(a.id); // fires (t0)
+    clock += 30_000;
+    await engine.onSchedule(a.id); // within cooldown
+    const outcomes = got.map((g) => g.outcome);
+    expect(outcomes).toEqual(['fired', 'cooldown']);
+    expect(got[1].reason).toMatch(/cooldown active/);
+  });
+
   it('emits geofence traces: baseline (prefiltered) then enter (fired)', async () => {
     const got: any[] = [];
     automationTraceBus.setSink((_id, payload) => got.push(payload));

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -10,6 +10,9 @@ import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import type { AutomationGraph } from '../../../types/automation.js';
 import * as schema from '../../../db/schema/index.js';
 import { createTestDb } from '../../test-helpers/testDb.js';
+import { automationTraceBus } from './automationTraceBus.js';
+
+const FAR_FUTURE = 9_000_000_000_000;
 
 function recorder() {
   const calls: Array<{ fn: string; args: any }> = [];
@@ -68,7 +71,7 @@ describe('AutomationEngineService', () => {
     resolver = new VariableResolver(varsRepo);
     clock = 1_000_000;
   });
-  afterEach(() => db.close());
+  afterEach(() => { db.close(); automationTraceBus.reset(); automationTraceBus.setSink(null); });
 
   const data = { getNode: async () => null, getTelemetry: async () => null };
   const engineWith = (deps: ActionDeps) =>
@@ -459,5 +462,92 @@ describe('AutomationEngineService', () => {
     clock += 31_000;
     expect(await engine.onSchedule(a.id)).toBe(1); // past cooldown
     expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(2);
+  });
+
+  // ── Live trace ("view logs") emit instrumentation ──────────────────────────
+  it('emits a FIRED trace (with steps) for a traced rule that matches', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    const a = await createEnabled('ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    const engine = engineWith(recorder().deps);
+    await engine.load();
+    automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+    await engine.onMessage(message({ text: 'ping me' }), 'default');
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({ automationId: a.id, outcome: 'fired', status: 'completed' });
+    expect(Array.isArray(got[0].steps)).toBe(true);
+    expect(got[0].steps.length).toBeGreaterThan(0);
+  });
+
+  it('emits a PREFILTERED trace with a human reason when the filter misses', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    const a = await createEnabled('ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    const engine = engineWith(recorder().deps);
+    await engine.load();
+    automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+    await engine.onMessage(message({ text: 'hello' }), 'default');
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({ automationId: a.id, outcome: 'prefiltered' });
+    expect(got[0].reason).toBe('text does not contain "ping"');
+  });
+
+  it('emits a COOLDOWN trace while a traced rule is cooling down', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    const a = await createEnabled('ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60 } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    const engine = engineWith(recorder().deps);
+    await engine.load();
+    automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+    await engine.onMessage(message({ text: 'ping' }), 'default'); // fires (t0)
+    clock += 30_000;
+    await engine.onMessage(message({ text: 'ping' }), 'default'); // within cooldown
+    const outcomes = got.map((g) => g.outcome);
+    expect(outcomes).toContain('fired');
+    expect(outcomes).toContain('cooldown');
+    expect(got.find((g) => g.outcome === 'cooldown').reason).toMatch(/cooldown active/);
+  });
+
+  it('emits NOTHING when the rule is not being traced (hot-path no-op)', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    await createEnabled('ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    const engine = engineWith(recorder().deps);
+    await engine.load();
+    // No arm() → nothing traced.
+    await engine.onMessage(message({ text: 'ping' }), 'default');
+    await engine.onMessage(message({ text: 'hello' }), 'default');
+    expect(got).toHaveLength(0);
   });
 });

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -532,6 +532,26 @@ describe('AutomationEngineService', () => {
     expect(got.find((g) => g.outcome === 'cooldown').reason).toMatch(/cooldown active/);
   });
 
+  it('emits a FIRED trace for a traced schedule (cron) rule', async () => {
+    const got: any[] = [];
+    automationTraceBus.setSink((_id, payload) => got.push(payload));
+    const a = await createEnabled('cron', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.schedule', params: { cron: '* * * * *' } },
+        { id: 'n', type: 'action.notify', params: { body: 'tick' } },
+      ],
+      edges: [{ from: 't', to: 'n' }],
+    });
+    const engine = engineWith(recorder().deps);
+    await engine.load();
+    automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+    await engine.onSchedule(a.id);
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({ automationId: a.id, outcome: 'fired', triggerType: 'trigger.schedule' });
+  });
+
   it('emits geofence traces: baseline (prefiltered) then enter (fired)', async () => {
     const got: any[] = [];
     automationTraceBus.setSink((_id, payload) => got.push(payload));

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -31,6 +31,8 @@ import {
   buildScheduleContext,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
+  describeMessageFilterMiss,
+  describeMeshCoreFilterMiss,
   type TriggerContext,
   type SystemEvent,
 } from './triggerContext.js';
@@ -38,6 +40,7 @@ import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import { scheduleCron, validateCron } from '../../utils/cronScheduler.js';
 import { haversineKm, geofenceFires, pointInShape, geofenceCenter, normalizeGeofenceParams, type GeofenceMode } from './geo.js';
 import { evaluateGraph, type EvaluatorHooks } from './graphEvaluator.js';
+import { automationTraceBus } from './automationTraceBus.js';
 import { evaluateCondition } from './conditionEvaluator.js';
 import { executeAction, type ActionDeps } from './actionExecutor.js';
 import {
@@ -54,6 +57,26 @@ interface LoadedAutomation {
   triggerNode: AutomationNode;
   triggerType: TriggerType;
   cooldownSeconds: number;
+}
+
+/** Compact result of evaluating one automation — persisted run-log shape is unchanged;
+ *  this is the subset the live trace ("view logs") streams to the browser. */
+interface FireResult {
+  status: 'completed' | 'failed';
+  conditionResults: Record<string, boolean>;
+  actions: Array<{ nodeId: string; ok: boolean; error?: string }>;
+  // Looser than EvaluationStep[] so the synthetic engine-error step (outcome
+  // 'engine:error', not a StepOutcome) fits; the UI handles unknown outcomes.
+  steps: Array<{ nodeId: string; type: string; outcome: string; error?: string }>;
+}
+
+/** Shallow copy of a trigger's fields with long text truncated, for trace payloads. */
+function compactEventFields(fields: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    out[k] = typeof v === 'string' && v.length > 200 ? `${v.slice(0, 200)}…` : v;
+  }
+  return out;
 }
 
 /** Pluggable cron backing for `trigger.schedule` — real croner in prod, a fake in tests. */
@@ -222,24 +245,60 @@ export class AutomationEngineService {
   /**
    * Run a single trigger context against the automations registered for its type.
    * Returns the number of automations that fired (passed pre-filter + cooldown).
+   *
+   * `describeMiss` is the live-trace ("view logs") explainer: called ONLY when a
+   * rule is being traced AND its pre-filter rejected the event, to report why.
    */
-  private async runTrigger(ctx: TriggerContext, prefilter?: (a: LoadedAutomation) => boolean): Promise<number> {
+  private async runTrigger(
+    ctx: TriggerContext,
+    prefilter?: (a: LoadedAutomation) => boolean,
+    describeMiss?: (a: LoadedAutomation) => string | undefined,
+  ): Promise<number> {
     const entries = this.index.get(ctx.triggerType);
     if (!entries || entries.length === 0) return 0;
     const now = this.now();
+    const tracingAny = automationTraceBus.activeCount() > 0;
     let fired = 0;
     for (const a of entries) {
-      if (prefilter && !prefilter(a)) continue;
-      if (!this.cooledDown(a, now)) continue;
+      const traced = tracingAny && automationTraceBus.isTracing(a.id, now);
+      if (prefilter && !prefilter(a)) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: describeMiss?.(a) ?? 'did not match the trigger filter' });
+        continue;
+      }
+      if (!this.cooledDown(a, now)) {
+        if (traced) {
+          const remainingMs = Math.max(0, a.cooldownSeconds * 1000 - (now - (this.lastFired.get(a.id) ?? 0)));
+          this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining` });
+        }
+        continue;
+      }
       this.lastFired.set(a.id, now);
       fired++;
-      await this.fireAutomation(a, ctx, now);
+      const fr = await this.fireAutomation(a, ctx, now);
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
     }
     return fired;
   }
 
-  /** Evaluate one automation's graph against a trigger context and write a run-log row. */
-  private async fireAutomation(a: LoadedAutomation, ctx: TriggerContext, now: number): Promise<void> {
+  /** Emit one live-trace verdict for a rule to any browser tracing it (#view-logs). */
+  private emitTrace(a: LoadedAutomation, ctx: TriggerContext, now: number, verdict: Record<string, unknown>): void {
+    automationTraceBus.emit(a.id, {
+      ts: now,
+      automationId: a.id,
+      automationName: a.name,
+      triggerType: ctx.triggerType,
+      sourceId: ctx.sourceId,
+      event: compactEventFields(ctx.fields),
+      ...verdict,
+    }, now);
+  }
+
+  /**
+   * Evaluate one automation's graph against a trigger context and write a run-log
+   * row. Returns a compact result the live trace reuses (the persisted run-log
+   * shape is unchanged).
+   */
+  private async fireAutomation(a: LoadedAutomation, ctx: TriggerContext, now: number): Promise<FireResult> {
     const evalCtx: EngineEvalContext = {
       trigger: ctx,
       vars: this.vars,
@@ -257,6 +316,12 @@ export class AutomationEngineService {
         triggerEvent: JSON.stringify(ctx.fields),
         log: JSON.stringify(result.steps),
       });
+      return {
+        status: anyFailed ? 'failed' : 'completed',
+        conditionResults: result.conditionResults,
+        actions: result.actions.map((x) => ({ nodeId: x.nodeId, ok: x.ok, error: x.error })),
+        steps: result.steps,
+      };
     } catch (e: any) {
       logger.error(`[AutomationEngine] automation "${a.name}" threw: ${e?.message}`);
       await this.automationsRepo.createRun({
@@ -266,6 +331,12 @@ export class AutomationEngineService {
         triggerEvent: JSON.stringify(ctx.fields),
         log: JSON.stringify([{ outcome: 'engine:error', error: e?.message }]),
       });
+      return {
+        status: 'failed',
+        conditionResults: {},
+        actions: [],
+        steps: [{ nodeId: a.id, type: 'engine', outcome: 'engine:error', error: e?.message }],
+      };
     }
   }
 
@@ -284,7 +355,11 @@ export class AutomationEngineService {
     if (usesChannelName && this.data.getChannelName) {
       channelName = await this.data.getChannelName(sourceId, Number(msg.channel));
     }
-    return this.runTrigger(ctx, (a) => messageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName));
+    return this.runTrigger(
+      ctx,
+      (a) => messageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
+      (a) => describeMessageFilterMiss(msg, a.triggerNode.params ?? {}, channelName),
+    );
   }
 
   /**
@@ -305,7 +380,11 @@ export class AutomationEngineService {
     if (usesChannelName && this.data.getChannelName && typeof channelIdx === 'number') {
       channelName = await this.data.getChannelName(sourceId, channelIdx);
     }
-    return this.runTrigger(ctx, (a) => meshCoreMessageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName));
+    return this.runTrigger(
+      ctx,
+      (a) => meshCoreMessageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
+      (a) => describeMeshCoreFilterMiss(msg, a.triggerNode.params ?? {}, channelName),
+    );
   }
 
   async onNode(
@@ -325,10 +404,17 @@ export class AutomationEngineService {
     sourceId: string | null,
   ): Promise<number> {
     const ctx = buildTelemetryContext(nodeNum, telemetryType, value, unit, sourceId, this.now());
-    return this.runTrigger(ctx, (a) => {
-      const want = (a.triggerNode.params as any)?.telemetryType;
-      return want == null || want === telemetryType;
-    });
+    return this.runTrigger(
+      ctx,
+      (a) => {
+        const want = (a.triggerNode.params as any)?.telemetryType;
+        return want == null || want === telemetryType;
+      },
+      (a) => {
+        const want = (a.triggerNode.params as any)?.telemetryType;
+        return `telemetry "${telemetryType}" ≠ rule metric "${want}"`;
+      },
+    );
   }
 
   async onSystem(
@@ -341,10 +427,17 @@ export class AutomationEngineService {
     const ctx = buildSystemContext(event, sourceId, nodeNum, reason, this.now(), extra);
     // Pre-filter on the configured `event` param so a "system start" automation
     // doesn't also fire on "source online" etc. An unset event matches any.
-    return this.runTrigger(ctx, (a) => {
-      const want = (a.triggerNode.params as any)?.event;
-      return want == null || want === '' || want === event;
-    });
+    return this.runTrigger(
+      ctx,
+      (a) => {
+        const want = (a.triggerNode.params as any)?.event;
+        return want == null || want === '' || want === event;
+      },
+      (a) => {
+        const want = (a.triggerNode.params as any)?.event;
+        return `system event "${event}" ≠ rule event "${want}"`;
+      },
+    );
   }
 
   /**
@@ -375,11 +468,24 @@ export class AutomationEngineService {
       const prev = this.geofenceState.get(key);
       this.geofenceState.set(key, inside);
 
-      if (!geofenceFires(prev, inside, mode)) continue;
-      if (!this.cooledDown(a, now)) continue;
+      const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
+      const geoCtx = buildGeofenceContext(nodeNum, mode, node.latitude, node.longitude, distanceKm, sourceId, now);
+
+      if (!geofenceFires(prev, inside, mode)) {
+        if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'prefiltered', reason: prev === undefined ? 'first sighting — baseline only' : `no ${mode} transition (node ${inside ? 'inside' : 'outside'})` });
+        continue;
+      }
+      if (!this.cooledDown(a, now)) {
+        if (traced) {
+          const remainingMs = Math.max(0, a.cooldownSeconds * 1000 - (now - (this.lastFired.get(a.id) ?? 0)));
+          this.emitTrace(a, geoCtx, now, { outcome: 'cooldown', reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining` });
+        }
+        continue;
+      }
       this.lastFired.set(a.id, now);
       fired++;
-      await this.fireAutomation(a, buildGeofenceContext(nodeNum, mode, node.latitude, node.longitude, distanceKm, sourceId, now), now);
+      const fr = await this.fireAutomation(a, geoCtx, now);
+      if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
     }
     return fired;
   }

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -199,9 +199,18 @@ export class AutomationEngineService {
     const a = (this.index.get('trigger.schedule') ?? []).find((x) => x.id === automationId);
     if (!a) return 0;
     const now = this.now();
-    if (!this.cooledDown(a, now)) return 0;
+    const ctx = buildScheduleContext(null, now);
+    const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
+    if (!this.cooledDown(a, now)) {
+      if (traced) {
+        const remainingMs = Math.max(0, a.cooldownSeconds * 1000 - (now - (this.lastFired.get(a.id) ?? 0)));
+        this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining` });
+      }
+      return 0;
+    }
     this.lastFired.set(a.id, now);
-    await this.fireAutomation(a, buildScheduleContext(null, now), now);
+    const fr = await this.fireAutomation(a, ctx, now);
+    if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
     return 1;
   }
 

--- a/src/server/services/automation/automationTraceBus.test.ts
+++ b/src/server/services/automation/automationTraceBus.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { automationTraceBus, MAX_TRACE_MS } from './automationTraceBus.js';
+
+const FUTURE = 9_000_000_000_000; // far-future expiry (epoch ms)
+
+describe('automationTraceBus', () => {
+  beforeEach(() => { automationTraceBus.reset(); automationTraceBus.setSink(null); });
+
+  it('isTracing/activeCount reflect armed rules', () => {
+    expect(automationTraceBus.activeCount()).toBe(0);
+    expect(automationTraceBus.isTracing('a', 0)).toBe(false);
+    automationTraceBus.arm('a', 'sock1', FUTURE);
+    expect(automationTraceBus.activeCount()).toBe(1);
+    expect(automationTraceBus.isTracing('a', 0)).toBe(true);
+    expect(automationTraceBus.isTracing('b', 0)).toBe(false);
+  });
+
+  it('expires (and prunes) once past expiry', () => {
+    automationTraceBus.arm('a', 'sock1', 1000);
+    expect(automationTraceBus.isTracing('a', 999)).toBe(true);
+    expect(automationTraceBus.isTracing('a', 1001)).toBe(false); // expired → pruned
+    expect(automationTraceBus.activeCount()).toBe(0);
+  });
+
+  it('refcounts sockets: a rule stays armed until the last socket disarms', () => {
+    automationTraceBus.arm('a', 's1', FUTURE);
+    automationTraceBus.arm('a', 's2', FUTURE);
+    automationTraceBus.disarm('a', 's1');
+    expect(automationTraceBus.isTracing('a', 0)).toBe(true);
+    automationTraceBus.disarm('a', 's2');
+    expect(automationTraceBus.isTracing('a', 0)).toBe(false);
+  });
+
+  it('disarmSocket drops a disconnected socket from every rule', () => {
+    automationTraceBus.arm('a', 's1', FUTURE);
+    automationTraceBus.arm('b', 's1', FUTURE);
+    automationTraceBus.arm('b', 's2', FUTURE);
+    automationTraceBus.disarmSocket('s1');
+    expect(automationTraceBus.isTracing('a', 0)).toBe(false); // s1 was the only one
+    expect(automationTraceBus.isTracing('b', 0)).toBe(true);  // s2 still there
+  });
+
+  it('emit only delivers for armed, non-expired rules with a sink', () => {
+    const got: Array<{ id: string; payload: unknown }> = [];
+    automationTraceBus.setSink((id, payload) => got.push({ id, payload }));
+
+    automationTraceBus.emit('a', { x: 1 }, 0);            // not armed → dropped
+    automationTraceBus.arm('a', 's1', FUTURE);
+    automationTraceBus.emit('a', { x: 2 }, 0);            // armed → delivered
+    automationTraceBus.emit('a', { x: 3 }, FUTURE + 1);  // expired → dropped
+
+    expect(got).toEqual([{ id: 'a', payload: { x: 2 } }]);
+  });
+
+  it('caps a session at MAX_TRACE_MS (sanity on the exported constant)', () => {
+    expect(MAX_TRACE_MS).toBe(5 * 60_000);
+  });
+});

--- a/src/server/services/automation/automationTraceBus.ts
+++ b/src/server/services/automation/automationTraceBus.ts
@@ -36,7 +36,10 @@ class AutomationTraceBus {
     this.sink = sink;
   }
 
-  /** Arm a rule for tracing on behalf of a socket, until `expiry` (epoch ms). */
+  /** Arm a rule for tracing on behalf of a socket, until `expiry` (epoch ms).
+   *  When multiple tabs trace the same rule the session lives until the latest
+   *  requested expiry (`Math.max`) — "at least one listener still wants it". The
+   *  WS layer caps each request at MAX_TRACE_MS, so this can't run unbounded. */
   arm(automationId: string, socketId: string, expiry: number): void {
     const entry = this.registry.get(automationId);
     if (entry) {
@@ -55,7 +58,9 @@ class AutomationTraceBus {
     if (entry.sockets.size === 0) this.registry.delete(automationId);
   }
 
-  /** Drop a disconnected socket from every rule it was tracing. */
+  /** Drop a disconnected socket from every rule it was tracing.
+   *  Deleting the current key mid-iteration is safe: Map iteration is spec'd to
+   *  tolerate deletion of already-visited/current entries (no skip). */
   disarmSocket(socketId: string): void {
     for (const [id, entry] of this.registry) {
       entry.sockets.delete(socketId);

--- a/src/server/services/automation/automationTraceBus.ts
+++ b/src/server/services/automation/automationTraceBus.ts
@@ -1,0 +1,95 @@
+/**
+ * Live-trace bus for the Automation Engine — the server side of the in-app
+ * "view logs" debug feature.
+ *
+ * A per-automation, opt-in, time-bounded debug stream. While a rule is "armed"
+ * (a browser clicked "Start logging" on it), the engine emits a trace verdict for
+ * every event it evaluates against that rule — fired / filtered-out (+ reason) /
+ * cooldown — so an operator can see *why* a rule did or did not run. Nothing is
+ * persisted: payloads are pushed straight to the browser over Socket.io and held
+ * only in a small capped client buffer. Sessions auto-expire (the WS layer caps
+ * each arm at {@link MAX_TRACE_MS}); the engine prunes expired rules lazily.
+ *
+ * Decoupled from socket.io via an injectable sink so the engine and the bus stay
+ * unit-testable without a live server; webSocketService registers the real sink
+ * (a room emit) at init.
+ */
+
+/** Hard cap on how long a single trace session stays armed. */
+export const MAX_TRACE_MS = 5 * 60_000;
+
+export type AutomationTraceSink = (automationId: string, payload: unknown) => void;
+
+interface TraceEntry {
+  /** Socket ids currently interested in this rule (refcount). */
+  sockets: Set<string>;
+  /** Epoch-ms after which the session is considered expired. */
+  expiry: number;
+}
+
+class AutomationTraceBus {
+  private registry = new Map<string, TraceEntry>();
+  private sink: AutomationTraceSink | null = null;
+
+  /** Wire the delivery sink (webSocketService → room emit). Pass null to clear. */
+  setSink(sink: AutomationTraceSink | null): void {
+    this.sink = sink;
+  }
+
+  /** Arm a rule for tracing on behalf of a socket, until `expiry` (epoch ms). */
+  arm(automationId: string, socketId: string, expiry: number): void {
+    const entry = this.registry.get(automationId);
+    if (entry) {
+      entry.sockets.add(socketId);
+      entry.expiry = Math.max(entry.expiry, expiry);
+    } else {
+      this.registry.set(automationId, { sockets: new Set([socketId]), expiry });
+    }
+  }
+
+  /** Drop one socket's interest in a rule; removes the rule when no sockets remain. */
+  disarm(automationId: string, socketId: string): void {
+    const entry = this.registry.get(automationId);
+    if (!entry) return;
+    entry.sockets.delete(socketId);
+    if (entry.sockets.size === 0) this.registry.delete(automationId);
+  }
+
+  /** Drop a disconnected socket from every rule it was tracing. */
+  disarmSocket(socketId: string): void {
+    for (const [id, entry] of this.registry) {
+      entry.sockets.delete(socketId);
+      if (entry.sockets.size === 0) this.registry.delete(id);
+    }
+  }
+
+  /** Cheap hot-path guard — non-zero only when ≥1 rule is currently armed. */
+  activeCount(): number {
+    return this.registry.size;
+  }
+
+  /** Whether a specific rule is armed and not expired (prunes on expiry). */
+  isTracing(automationId: string, now: number = Date.now()): boolean {
+    const entry = this.registry.get(automationId);
+    if (!entry) return false;
+    if (now > entry.expiry) {
+      this.registry.delete(automationId);
+      return false;
+    }
+    return true;
+  }
+
+  /** Push a trace payload for a rule, if it's armed (not expired) and a sink exists. */
+  emit(automationId: string, payload: unknown, now: number = Date.now()): void {
+    if (!this.sink) return;
+    if (!this.isTracing(automationId, now)) return;
+    this.sink(automationId, payload);
+  }
+
+  /** Test seam: forget all armed sessions. */
+  reset(): void {
+    this.registry.clear();
+  }
+}
+
+export const automationTraceBus = new AutomationTraceBus();

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -9,6 +9,8 @@ import {
   deriveHops,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
+  describeMessageFilterMiss,
+  describeMeshCoreFilterMiss,
   resolveTriggerPath,
   BROADCAST_ADDR,
 } from './triggerContext.js';
@@ -199,6 +201,30 @@ describe('meshCoreMessageMatchesFilter (#3833)', () => {
     expect(meshCoreMessageMatchesFilter(mcMsg(), { from: 111 })).toBe(false);
     expect(meshCoreMessageMatchesFilter(mcMsg(), { to: 222 })).toBe(false);
     expect(meshCoreMessageMatchesFilter(mcMsg(), { portnum: 1 })).toBe(false);
+  });
+});
+
+describe('describeMessageFilterMiss (live-trace reasons)', () => {
+  it('returns the first failing constraint as a human reason', () => {
+    expect(describeMessageFilterMiss(msg({ text: 'hello' }), { textContains: 'ping' })).toBe('text does not contain "ping"');
+    expect(describeMessageFilterMiss(msg(), { from: 999 })).toBe('sender #111 ≠ from #999');
+    expect(describeMessageFilterMiss(msg(), { channel: 2 })).toBe('channel 0 ≠ 2');
+    expect(describeMessageFilterMiss(msg({ text: 'nope' }), { regex: '^(test|ping)' })).toBe('text does not match /^(test|ping)/');
+    expect(describeMessageFilterMiss(msg(), { channelName: 'gauntlet' }, 'Primary')).toBe('channel name "Primary" ≠ "gauntlet"');
+  });
+  it('returns undefined when the message actually matches', () => {
+    expect(describeMessageFilterMiss(msg({ text: 'ping' }), { textContains: 'ping' })).toBeUndefined();
+  });
+});
+
+describe('describeMeshCoreFilterMiss (live-trace reasons)', () => {
+  it('explains Meshtastic-only filters never matching MeshCore', () => {
+    expect(describeMeshCoreFilterMiss(mcMsg(), { from: 5 })).toMatch(/Meshtastic-only/);
+  });
+  it('explains channel and text misses', () => {
+    expect(describeMeshCoreFilterMiss(mcMsg({ fromPublicKey: 'channel-2' }), { channel: 5 })).toBe('channel 2 ≠ 5');
+    expect(describeMeshCoreFilterMiss(mcMsg({ text: 'hi' }), { textContains: 'ping' })).toBe('text does not contain "ping"');
+    expect(describeMeshCoreFilterMiss(mcMsg({ text: 'ping' }), { textContains: 'ping' })).toBeUndefined();
   });
 });
 

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -307,6 +307,67 @@ export function meshCoreMessageMatchesFilter(
 }
 
 /**
+ * Live-trace ("view logs") helper — explains WHY a Meshtastic message did not
+ * match a rule's trigger filter. Mirrors {@link messageMatchesFilter}'s checks
+ * but returns the first failing constraint as a human string (or undefined when
+ * it actually matches). Trace-only: invoked solely on a miss while a rule is
+ * being traced, so the hot matcher stays untouched.
+ */
+export function describeMessageFilterMiss(
+  msg: DbMessage,
+  params: Record<string, unknown> = {},
+  channelName?: string | null,
+): string | undefined {
+  if (params.portnum != null && Number(msg.portnum) !== Number(params.portnum)) return `portnum ${msg.portnum} ≠ ${params.portnum}`;
+  if (params.from != null && Number(msg.fromNodeNum) !== Number(params.from)) return `sender #${msg.fromNodeNum} ≠ from #${params.from}`;
+  if (params.to != null && Number(msg.toNodeNum) !== Number(params.to)) return `recipient #${msg.toNodeNum} ≠ to #${params.to}`;
+  if (params.channel != null && Number(msg.channel) !== Number(params.channel)) return `channel ${msg.channel} ≠ ${params.channel}`;
+  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return `channel name "${channelName ?? '(unresolved)'}" ≠ "${params.channelName}"`;
+  }
+  const text = msg.text ?? '';
+  if (typeof params.textContains === 'string' && params.textContains.length > 0) {
+    if (!text.toLowerCase().includes(params.textContains.toLowerCase())) return `text does not contain "${params.textContains}"`;
+  }
+  if (typeof params.regex === 'string' && params.regex.length > 0) {
+    try {
+      if (!compileUserRegex(params.regex).test(text)) return `text does not match /${params.regex}/`;
+    } catch {
+      return `invalid regex /${params.regex}/`;
+    }
+  }
+  return undefined; // actually matched (caller shouldn't have asked)
+}
+
+/** Live-trace miss explainer for MeshCore messages — mirror of {@link meshCoreMessageMatchesFilter}. */
+export function describeMeshCoreFilterMiss(
+  msg: MeshCoreMessage,
+  params: Record<string, unknown> = {},
+  channelName?: string | null,
+): string | undefined {
+  if (params.portnum != null || params.from != null || params.to != null) {
+    return 'rule uses Meshtastic-only filters (from/to/portnum) — never matches MeshCore';
+  }
+  const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
+  if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return `channel ${channelIdx ?? '(DM)'} ≠ ${params.channel}`;
+  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return `channel name "${channelName ?? '(unresolved)'}" ≠ "${params.channelName}"`;
+  }
+  const text = msg.text ?? '';
+  if (typeof params.textContains === 'string' && params.textContains.length > 0) {
+    if (!text.toLowerCase().includes(params.textContains.toLowerCase())) return `text does not contain "${params.textContains}"`;
+  }
+  if (typeof params.regex === 'string' && params.regex.length > 0) {
+    try {
+      if (!compileUserRegex(params.regex).test(text)) return `text does not match /${params.regex}/`;
+    } catch {
+      return `invalid regex /${params.regex}/`;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Resolve a `{{ trigger.* }}` / system path against a context. Returns undefined
  * for unknown paths (interpolation renders those empty).
  */

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -16,6 +16,7 @@ import { getEnvironmentConfig } from '../config/environment.js';
 import type { DbMessage } from '../../services/database.js';
 import databaseService from '../../services/database.js';
 import { canonicalMessageTime, messageReceivedAt } from '../utils/messageTime.js';
+import { automationTraceBus, MAX_TRACE_MS } from './automation/automationTraceBus.js';
 
 /**
  * Transform a DbMessage to the format expected by the client (MeshMessage)
@@ -279,9 +280,52 @@ export function initializeWebSocket(
       }
     });
 
+    // ── Automation Engine live-trace ("view logs") ─────────────────────────
+    // Opt-in, per-rule, time-bounded debug stream. Gated on automations:read.
+    socket.on('automation-trace:start', async (raw: { automationId?: string; durationMs?: number }) => {
+      const automationId = typeof raw?.automationId === 'string' ? raw.automationId : '';
+      if (!automationId) {
+        socket.emit('automation-trace:error', { error: 'bad-request' });
+        return;
+      }
+      const sockUserId = (socket as any).userId as number | undefined;
+      const sockIsAdmin = (socket as any).isAdmin as boolean | undefined;
+      try {
+        if (!sockIsAdmin) {
+          if (sockUserId === undefined) {
+            socket.emit('automation-trace:error', { automationId, error: 'unauthorized' });
+            return;
+          }
+          const allowed = await databaseService.checkPermissionAsync(sockUserId, 'automations', 'read');
+          if (!allowed) {
+            socket.emit('automation-trace:error', { automationId, error: 'forbidden' });
+            return;
+          }
+        }
+        const dur = Math.min(Math.max(Number(raw?.durationMs) || MAX_TRACE_MS, 1000), MAX_TRACE_MS);
+        const expiry = Date.now() + dur;
+        socket.join(`automation-trace:${automationId}`);
+        automationTraceBus.arm(automationId, socket.id, expiry);
+        socket.emit('automation-trace:started', { automationId, expiresAt: expiry });
+        logger.debug(`[WebSocket] Socket ${socket.id} started trace for automation ${automationId}`);
+      } catch (err) {
+        logger.error('[WebSocket] automation-trace:start failed:', err);
+        socket.emit('automation-trace:error', { automationId, error: 'internal' });
+      }
+    });
+
+    socket.on('automation-trace:stop', (raw: { automationId?: string }) => {
+      const automationId = typeof raw?.automationId === 'string' ? raw.automationId : '';
+      if (!automationId) return;
+      socket.leave(`automation-trace:${automationId}`);
+      automationTraceBus.disarm(automationId, socket.id);
+      logger.debug(`[WebSocket] Socket ${socket.id} stopped trace for automation ${automationId}`);
+    });
+
     // Handle disconnect
     socket.on('disconnect', (reason) => {
       dataEventEmitter.off('data', handler);
+      automationTraceBus.disarmSocket(socket.id);
       logger.info(`[WebSocket] Client disconnected: ${socket.id} (reason: ${reason})`);
     });
 
@@ -294,6 +338,12 @@ export function initializeWebSocket(
   // Handle server-level errors
   io.engine.on('connection_error', (err: any) => {
     logger.warn(`[WebSocket] Connection error: ${err.code} - ${err.message}`);
+  });
+
+  // Deliver Automation Engine live-trace payloads to the per-rule room. The
+  // engine calls automationTraceBus.emit(); this sink fans it out over socket.io.
+  automationTraceBus.setSink((automationId, payload) => {
+    io?.to(`automation-trace:${automationId}`).emit('automation:trace', payload);
   });
 
   return io;

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -304,6 +304,9 @@ export function initializeWebSocket(
         }
         const dur = Math.min(Math.max(Number(raw?.durationMs) || MAX_TRACE_MS, 1000), MAX_TRACE_MS);
         const expiry = Date.now() + dur;
+        // We don't verify the id exists in the DB: arming a non-existent/disabled
+        // rule is harmless (it simply never emits) and self-expires, so a lookup
+        // would add a query per arm for no safety benefit.
         socket.join(`automation-trace:${automationId}`);
         automationTraceBus.arm(automationId, socket.id, expiry);
         socket.emit('automation-trace:started', { automationId, expiresAt: expiry });


### PR DESCRIPTION
## Why

Debugging an automation is hard: when a rule *doesn't* fire there's no signal. The engine only persists a run-log (`automation_runs`) for rules that **actually fire** — the two most common "why didn't it fire?" reasons (**trigger pre-filter miss**, **cooldown skip**) happen in `runTrigger` *before* any run row is written, so they were invisible.

This adds an opt-in, **live-only, per-rule** trace — a "Start logging" you asked for that shows packets coming in, based on the trigger, and *why* each was or wasn't executed.

## What

A **"Trace"** button on each automation opens a live panel that streams, in real time, every event the engine evaluates against **that rule**:

- **fired** → status + the full condition/action **step trace** (reuses the Test panel's outcome icons)
- **filtered out** → the *specific* failing constraint, e.g. `text does not contain "ping"`, `channel 0 ≠ 2`, `system event "bootup" ≠ rule event "source-connected"`
- **cooldown** → remaining time

Nothing is persisted: payloads stream over the **existing Socket.io** connection to a capped (200-entry) in-memory client buffer, and the session **auto-stops after 5 minutes** (and on panel close / disconnect). The engine hot path is a no-op when no rule is traced (`activeCount()` guard).

### Server
- **`automationTraceBus.ts`** — per-automation arm/disarm registry (socket-refcounted, expiry-pruned) with an injectable sink so the engine + bus stay unit-testable.
- **`webSocketService`** — `automation-trace:start/stop` handlers gated on `automations:read`, per-rule room delivery (`automation-trace:<id>` → `automation:trace`), disconnect cleanup, sink wiring.
- **`automationEngineService`** — instruments `runTrigger` + `checkGeofences` to emit prefiltered/cooldown/fired verdicts only when a rule is traced. `fireAutomation` now returns a compact result; **the persisted run-log shape is unchanged**.
- **`triggerContext`** — `describeMessageFilterMiss` / `describeMeshCoreFilterMiss`, trace-only reason explainers that mirror the matchers (the hot matchers are untouched).

### Frontend
- **`LiveTracePanel.tsx`** — subscribes via the shared `useWebSocketContext` socket, ring-buffers entries, shows a 5-min countdown + Clear/Close, per-entry outcome badge + expandable step trace.
- **`outcomeMeta.tsx`** — extracted the shared `OUTCOME_META` + `StepList` from `AutomationTester` so the test panel and live trace never drift.
- **`AutomationsPage`** — a "Trace" action per rule.

No DB migration; no REST route (control is over Socket.io, data is ephemeral).

## Testing
- Unit: `automationTraceBus` (arm/expiry/refcount/`disarmSocket`/emit-gating); `describe*FilterMiss` reasons.
- Engine: emits `fired` (+steps) / `prefiltered` (+reason) / `cooldown`, and **nothing** when a rule isn't traced (hot-path no-op).
- **Full Vitest suite: 8368 passing, 0 failures.** `vite build` + server typecheck clean; zero new tsc errors.

> Note: automated coverage is comprehensive, but I did not run the live dev-container browser e2e (Socket.io round-trip) — happy to if you'd like a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)