### PR TITLE
feat(meshcore): Reply button on channel messages (mention + originating scope) (#3851)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -71,6 +71,7 @@ function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions 
     // component swallows failures, but mocking them avoids unhandled rejections.
     getDefaultScope: vi.fn().mockResolvedValue(''),
     discoverRegions: vi.fn().mockResolvedValue({ regions: [] }),
+    fetchSavedRegions: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
 }
@@ -619,5 +620,19 @@ describe('MeshCoreChannelsView — reply uses the originating scope (#3851)', ()
     fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
     const scopeInput = (await screen.findByLabelText('Send scope')) as HTMLInputElement;
     expect(scopeInput.value).toBe('');
+  });
+
+  it('leaves the scope at the default for a scoped-but-unknown message (HMAC code, no name)', async () => {
+    const unknown: MeshCoreMessage[] = [
+      { id: 'r0x', fromPublicKey: 'channel-0', fromName: 'Dee', text: 'mystery scope', timestamp: 1000, scopeCode: 4242 },
+    ];
+    render(
+      <MeshCoreChannelsView messages={unknown} contacts={contacts} status={makeStatus()} actions={makeActions()} baseUrl="" sourceId="src-a" />,
+    );
+    await waitFor(() => screen.getByText('mystery scope'));
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    // Region name isn't recoverable from the code → scope override stays hidden
+    // (the reply falls back to the channel/source default).
+    expect(screen.queryByLabelText('Send scope')).toBeNull();
   });
 });

--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -582,3 +582,42 @@ describe('MeshCoreChannelsView — unread indicator (#3703)', () => {
     expect(localStorage.getItem('meshmonitor-meshcore-channel-sort-unread-first')).toBe('true');
   });
 });
+
+describe('MeshCoreChannelsView — reply uses the originating scope (#3851)', () => {
+  beforeEach(() => {
+    csrfFetchMock.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/messages/channel/')) {
+        return Promise.resolve(jsonResponse({ success: true, data: [] }));
+      }
+      return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+    });
+  });
+
+  it('replying to a scoped channel message sets the send scope to its region', async () => {
+    const scoped: MeshCoreMessage[] = [
+      { id: 'r0s', fromPublicKey: 'channel-0', fromName: 'Bob', text: 'scoped hi', timestamp: 1000, scopeName: 'augsburg', scopeCode: 99 },
+    ];
+    render(
+      <MeshCoreChannelsView messages={scoped} contacts={contacts} status={makeStatus()} actions={makeActions()} baseUrl="" sourceId="src-a" />,
+    );
+    await waitFor(() => screen.getByText('scoped hi'));
+    // The send-scope widget is hidden until a reply (or manual toggle).
+    expect(screen.queryByLabelText('Send scope')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    const scopeInput = (await screen.findByLabelText('Send scope')) as HTMLInputElement;
+    expect(scopeInput.value).toBe('augsburg');
+  });
+
+  it('replying to an unscoped (scopeCode 0) message sends unscoped (empty scope)', async () => {
+    const unscoped: MeshCoreMessage[] = [
+      { id: 'r0u', fromPublicKey: 'channel-0', fromName: 'Cara', text: 'plain hi', timestamp: 1000, scopeCode: 0 },
+    ];
+    render(
+      <MeshCoreChannelsView messages={unscoped} contacts={contacts} status={makeStatus()} actions={makeActions()} baseUrl="" sourceId="src-a" />,
+    );
+    await waitFor(() => screen.getByText('plain hi'));
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    const scopeInput = (await screen.findByLabelText('Send scope')) as HTMLInputElement;
+    expect(scopeInput.value).toBe('');
+  });
+});

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -211,7 +211,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // the answer floods to the same region. The override widget is revealed so
   // the operator can see/edit the scope before sending.
   const handleReply = useCallback((m: MeshCoreMessage) => {
-    if (typeof m.scopeName === 'string' && m.scopeName.trim()) {
+    if (m.scopeName?.trim()) {
       setOverrideScope(m.scopeName);
       setShowScopeOverride(true);
     } else if (m.scopeCode === 0) {

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -206,6 +206,23 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     if (isMobileViewport()) setMobileShowContent(true);
   }, []);
 
+  // Reply to a channel message (#3851): the stream prefills the `@[Sender]:`
+  // mention; here we set the send scope to the originating message's scope so
+  // the answer floods to the same region. The override widget is revealed so
+  // the operator can see/edit the scope before sending.
+  const handleReply = useCallback((m: MeshCoreMessage) => {
+    if (typeof m.scopeName === 'string' && m.scopeName.trim()) {
+      setOverrideScope(m.scopeName);
+      setShowScopeOverride(true);
+    } else if (m.scopeCode === 0) {
+      setOverrideScope(''); // arrived explicitly unscoped → reply unscoped
+      setShowScopeOverride(true);
+    }
+    // else: scoped-but-unknown (scopeCode > 0, no resolvable name) or no scope
+    // info — the region name isn't recoverable from the HMAC transport code, so
+    // we can't replicate it; leave the scope as-is (channel / source default).
+  }, []);
+
   // Fetch the synced channel list for this source. We use /api/channels/all
   // (rather than /api/channels) so MeshCore rows with idx > 7 aren't dropped
   // by the legacy Meshtastic-shaped 0-7 filter on the basic endpoint. The
@@ -634,6 +651,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
             return ok;
           }}
           onNodeNameClick={onNodeNameClick}
+          onReply={handleReply}
           conversationKey={`channel-${active.id}`}
           firstUnreadId={firstUnreadId}
           maxBytes={

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -135,6 +135,16 @@ describe('MeshCoreMessageStream reply (#3851)', () => {
     render(<MeshCoreMessageStream messages={[{ id: 'o', fromPublicKey: SELF, text: 'mine', timestamp: Date.now() }]} selfPublicKey={SELF} onSend={async () => true} onReply={() => {}} />);
     expect(screen.queryByRole('button', { name: 'Reply' })).toBeNull();
   });
+
+  it('leaves the composer empty (no broken mention) when an anonymous channel message has no name', () => {
+    const onReply = vi.fn();
+    // Channel message with no parsed fromName and no resolvable contact.
+    render(<MeshCoreMessageStream messages={[channelMsg({ fromName: undefined })]} selfPublicKey={SELF} onSend={async () => true} onReply={onReply} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    // No name to mention → empty draft, but the reply (scope) still propagates.
+    expect((screen.getByPlaceholderText('Type a message…') as HTMLInputElement).value).toBe('');
+    expect(onReply).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('MeshCoreMessageStream entry scroll (#3810)', () => {

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -110,6 +110,33 @@ describe('MeshCoreMessageStream scope row (#3814)', () => {
   });
 });
 
+describe('MeshCoreMessageStream reply (#3851)', () => {
+  const SELF = 'abcdef0123456789';
+  const channelMsg = (over: Partial<MeshCoreMessage> = {}): MeshCoreMessage => ({
+    id: 'm1', fromPublicKey: 'channel-2', fromName: 'Alice', text: 'hello', timestamp: Date.now(), ...over,
+  });
+
+  it('shows a Reply button on a received channel message and prefills the @[Sender]: mention', () => {
+    const onReply = vi.fn();
+    render(<MeshCoreMessageStream messages={[channelMsg()]} selfPublicKey={SELF} onSend={async () => true} onReply={onReply} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    expect(onReply).toHaveBeenCalledTimes(1);
+    expect(onReply.mock.calls[0][0].id).toBe('m1');
+    const input = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+    expect(input.value).toBe('@[Alice]: ');
+  });
+
+  it('hides the Reply button when onReply is omitted (DM view)', () => {
+    render(<MeshCoreMessageStream messages={[channelMsg()]} selfPublicKey={SELF} onSend={async () => true} />);
+    expect(screen.queryByRole('button', { name: 'Reply' })).toBeNull();
+  });
+
+  it('hides the Reply button on outgoing messages', () => {
+    render(<MeshCoreMessageStream messages={[{ id: 'o', fromPublicKey: SELF, text: 'mine', timestamp: Date.now() }]} selfPublicKey={SELF} onSend={async () => true} onReply={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'Reply' })).toBeNull();
+  });
+});
+
 describe('MeshCoreMessageStream entry scroll (#3810)', () => {
   let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
 

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -344,7 +344,8 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                     {fromLabel}
                   </span>
                 )}
-                <span className="mc-message-time">
+                <span className="mc-message-meta">
+                  <span className="mc-message-time">
                   {formatTime(m.timestamp)}
                   {outgoing && m.deliveryStatus && (
                     <span
@@ -376,6 +377,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                       {' 📡 '}{m.heardBy.length}
                     </button>
                   )}
+                  </span>
                   {onReply && isChannel && !outgoing && (
                     <button
                       type="button"
@@ -384,7 +386,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                       aria-label={t('meshcore.reply', 'Reply')}
                       onClick={() => handleReply(m)}
                     >
-                      {' ↩'}
+                      ↩
                     </button>
                   )}
                 </span>

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -14,6 +14,10 @@ interface MeshCoreMessageStreamProps {
   disabled?: boolean;
   onSend: (text: string) => Promise<boolean>;
   onNodeNameClick?: (publicKey: string) => void;
+  /** When provided, received channel messages show a Reply button (#3851). The
+   *  stream prefills the composer with the `@[Sender]:` mention + focuses it;
+   *  the parent uses this callback to send the reply on the message's scope. */
+  onReply?: (message: MeshCoreMessage) => void;
   /** Stable key identifying the current conversation. When it changes, the
    *  stream re-runs its entry scroll (to the first-unread row, or the bottom). */
   conversationKey?: string;
@@ -67,6 +71,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   disabled,
   onSend,
   onNodeNameClick,
+  onReply,
   conversationKey,
   firstUnreadId,
   maxBytes = 130,
@@ -244,6 +249,23 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     }
   };
 
+  // Reply to a channel message (#3851): prefill the composer with the MeshCore
+  // `@[Sender]:` mention, focus it (caret at end), and let the parent send on
+  // the originating message's scope via onReply.
+  const handleReply = useCallback((m: MeshCoreMessage) => {
+    const name = (m.fromName ?? nameForKey(m.fromPublicKey) ?? '').trim();
+    setDraft(name ? `@[${name}]: ` : '');
+    onReply?.(m);
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (el) {
+        el.focus();
+        const end = el.value.length;
+        el.setSelectionRange(end, end);
+      }
+    });
+  }, [nameForKey, onReply]);
+
   return (
     <div className="meshcore-message-stream">
       <div className="meshcore-message-list" ref={listRef} style={{ position: 'relative' }}>
@@ -352,6 +374,17 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                       onClick={() => toggleHeardBy(m.id)}
                     >
                       {' 📡 '}{m.heardBy.length}
+                    </button>
+                  )}
+                  {onReply && isChannel && !outgoing && (
+                    <button
+                      type="button"
+                      className="mc-message-reply"
+                      title={t('meshcore.reply', 'Reply (mentions sender, replies on this scope)')}
+                      aria-label={t('meshcore.reply', 'Reply')}
+                      onClick={() => handleReply(m)}
+                    >
+                      {' ↩'}
                     </button>
                   )}
                 </span>

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -721,6 +721,21 @@
 /* Message metadata uses subtext0 — sufficient contrast on bright screens (iPad)
    in both Catppuccin light and dark themes (#3769, #3811). */
 .mc-message-time { color: var(--ctp-subtext0); }
+/* Reply affordance on received channel messages (#3851). Subtle until hovered;
+   always tappable on touch devices. */
+.mc-message-reply {
+  background: none;
+  border: none;
+  color: var(--ctp-subtext0);
+  cursor: pointer;
+  padding: 0 0.15rem;
+  font-size: 0.8rem;
+  opacity: 0.55;
+  transition: opacity 0.15s, color 0.15s;
+}
+.mc-message-row:hover .mc-message-reply { opacity: 1; }
+.mc-message-reply:hover { color: var(--ctp-mauve); opacity: 1; }
+@media (hover: none) { .mc-message-reply { opacity: 1; } }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
 .mc-message-route { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -721,6 +721,9 @@
 /* Message metadata uses subtext0 — sufficient contrast on bright screens (iPad)
    in both Catppuccin light and dark themes (#3769, #3811). */
 .mc-message-time { color: var(--ctp-subtext0); }
+/* Right-side metadata group (timestamp + reply). Keeps the Reply button a
+   sibling of the time span — not nested inside it — for cleaner semantics. */
+.mc-message-meta { display: inline-flex; align-items: center; gap: 0.25rem; }
 /* Reply affordance on received channel messages (#3851). Subtle until hovered;
    always tappable on touch devices. */
 .mc-message-reply {


### PR DESCRIPTION
Closes #3851.

## What
Adds a **↩ Reply** affordance to received MeshCore **channel** messages (mirrors the Meshtastic reply UX). Clicking it:
1. **Prefills** the composer with the MeshCore mention syntax — `@[Sender Name]: ` — and focuses the input (caret at end).
2. **Sets the send scope** to the *same scope the original message arrived on*, so a reply to a regional message floods to that region.

This is the maintainer's framing of #3851 ("a Reply button that uses the meshcore syntax… and automatically uses the originating message's scope").

## How
A reply click happens inside `MeshCoreMessageStream` (it owns the composer), while the scope lives in `MeshCoreChannelsView`:

- **`MeshCoreMessageStream`** — new optional `onReply?(message)` prop. The Reply button renders for **received channel messages only** (`onReply && isChannel && !outgoing`). On click it prefills `draft` with `@[<fromName>]: `, focuses the input, and calls `onReply(m)`.
- **`MeshCoreChannelsView`** — passes `onReply={handleReply}`, which maps the message's scope to the send scope and reveals the existing scope-override widget so the operator can see/edit it:
  - `scopeName` present → that region
  - `scopeCode === 0` (arrived unscoped) → `''` (unscoped)
  - scoped-but-**unknown** region (`scopeCode > 0`, no resolvable name) → left at the channel/source default — the region name isn't recoverable from the HMAC transport code, so it can't be replicated.
- **DM view** passes no `onReply`, so DMs are unchanged. The send path already accepts a per-message scope (#3701/#3833) — **no backend change**.

## Testing
- `MeshCoreMessageStream.test.tsx`: Reply button shows on a received channel message and prefills `@[Alice]: ` + fires `onReply`; hidden for outgoing messages and when `onReply` is omitted (DM view).
- `MeshCoreChannelsView.test.tsx`: replying to a scoped message sets the send scope to its region; replying to an unscoped (`scopeCode 0`) message sets it to `''`.
- **Full Vitest suite: 8389 passing, 0 failures.** Typecheck + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)