### PR TITLE
test(channels): add reorder + MeshCore delete happy-path tests (#3502)

### DIFF
--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -334,6 +334,28 @@ describe('DELETE /channels/:id', () => {
     expect(res.body.messagesDeleted).toBe(5);
     expect(mockDb.channels.deleteChannel).toHaveBeenCalledWith(3, 'src-1');
   });
+
+  it('MeshCore happy-path: deletes a channel via device manager and returns success', async () => {
+    // Set up a MeshCore source
+    mockDb.sources.getSource.mockResolvedValue({ type: 'meshcore' });
+    mockMeshcoreRegistry.get.mockReturnValue(mockMeshcoreManager);
+    mockMeshcoreManager.deleteChannel.mockResolvedValue(undefined);
+
+    // Delete channel 2 (not primary, which is allowed for MeshCore)
+    const res = await request(app).delete('/channels/2').send({ sourceId: 'meshcore-1' });
+
+    // Verify success response
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toContain('Channel 2 deleted');
+    expect(res.body.sourceId).toBe('meshcore-1');
+
+    // Verify the device manager was called to delete on the device
+    expect(mockMeshcoreManager.deleteChannel).toHaveBeenCalledWith(2);
+    
+    // Verify the manager registry was queried for the correct source
+    expect(mockMeshcoreRegistry.get).toHaveBeenCalledWith('meshcore-1');
+  });
 });
 
 describe('POST /channels/:slotId/import', () => {
@@ -399,6 +421,48 @@ describe('POST /channels/reorder', () => {
       { from: 1, to: 0 },
       { from: 0, to: 1 },
     ]));
+  });
+
+  it('happy-path: executes full reorder with device persistence and message migration', async () => {
+    // Test the complete happy-path flow: reorder channels, persist to device, and migrate messages.
+    // The route handles pacing delays internally (2000ms before, 1000ms between each slot, 1500ms before commit),
+    // so this test verifies the core logic without relying on timer controls.
+    mockManager.sourceId = 'src-reorder-full';
+    mockDb.channels.getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Primary', role: 1, psk: 'AQ==', uplinkEnabled: true, downlinkEnabled: true },
+      { id: 1, name: 'Channel A', role: 2, psk: 'BB==', uplinkEnabled: true, downlinkEnabled: true },
+      { id: 2, name: 'Channel B', role: 2, psk: 'CC==', uplinkEnabled: true, downlinkEnabled: false },
+      { id: 3, role: 0 }, // disabled slot
+    ]);
+    
+    // Reorder: move slot 1 → 2, slot 2 → 1, rest identity
+    const res = await request(app)
+      .post('/channels/reorder')
+      .send({ newOrder: [0, 2, 1, 3, 4, 5, 6, 7], sourceId: 'src-reorder-full' });
+    
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.requiresReboot).toBe(true);
+    
+    // Verify the device-interaction bookends
+    expect(mockManager.beginEditSettings).toHaveBeenCalledTimes(1);
+    expect(mockManager.commitEditSettings).toHaveBeenCalledTimes(1);
+    
+    // Verify setChannelConfig was called for affected slots
+    expect(mockManager.setChannelConfig).toHaveBeenCalled();
+    const setCalls = mockManager.setChannelConfig.mock.calls;
+    // Slot 0 is identity so it's not called; slots 1 and 2 should be updated
+    expect(setCalls.some(call => call[0] === 1 && call[1]?.name === 'Channel B')).toBe(true);
+    expect(setCalls.some(call => call[0] === 2 && call[1]?.name === 'Channel A')).toBe(true);
+    
+    // Verify message and permission migration
+    expect(mockDb.messages.migrateMessagesForChannelMoves).toHaveBeenCalledTimes(1);
+    const [moves] = mockDb.messages.migrateMessagesForChannelMoves.mock.calls[0];
+    expect(moves).toEqual(expect.arrayContaining([
+      { from: 1, to: 2 },
+      { from: 2, to: 1 },
+    ]));
+    expect(mockDb.auth.migratePermissionsForChannelMoves).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to the route-handler extraction work on #3502. When you wrapped up the
mechanical `channelRoutes` extraction you called out the remaining test gap directly:

> channelRoutes.test.ts needs a `/reorder` happy-path test + a MeshCore
> `deleteChannel` happy-path test

This PR adds exactly those two happy-path cases. The existing suite covered the
guard/validation branches well but exercised neither the full reorder persistence
flow nor the MeshCore delete path end-to-end.

## What

Two tests added to `src/server/routes/channelRoutes.test.ts` (+64 lines, no
production code touched):

1. **`POST /channels/reorder` — full happy path.** Reorders channels with real
   moves, asserts the device-interaction bookends (`beginEditSettings` /
   `commitEditSettings` each called once), that `setChannelConfig` runs for the
   moved slots with the correct channel payloads, and that both
   `migrateMessagesForChannelMoves` and `migratePermissionsForChannelMoves` fire
   with the expected move set.

2. **`DELETE /channels/:id` — MeshCore happy path.** Resolves a MeshCore source,
   deletes a non-primary channel via the meshcore manager registry, and asserts
   the 200/`success` response plus that `meshcoreManager.deleteChannel` and
   `meshcoreRegistry.get` were called with the right args.

## Test coverage

| Test | Path exercised | Asserts |
|------|----------------|---------|
| reorder full happy-path | `/channels/reorder` device persistence + migration | edit bookends, per-slot `setChannelConfig`, message + permission migration |
| MeshCore delete happy-path | `DELETE /channels/:id` (meshcore) | 200 success, `deleteChannel(2)`, registry lookup by sourceId |

## On the reorder timing

The reorder route paces its device writes with real delays (2000ms before,
1000ms between slots, 1500ms before commit). This test lets them run in real
time rather than mocking timers — matching the existing real-time reorder test
in this same file (`scopes the message migration to the resolved source (#3712)`).
Keeping the file consistent on this seemed better than making this the one test
that fakes timers; happy to switch it to `vi.useFakeTimers()` if you'd prefer the
suite move that direction.

## Out of scope

No production code changes. The broader `#3502` residual route groups (`/config`,
`/nodes`, `/admin`, etc.) are untouched — per your note those should follow the B4
`meshtasticManager` split rather than a cut-paste, so this stays purely additive
test coverage.

Gates: `tsc --noEmit` clean, `eslint` clean, `channelRoutes.test.ts` 40/40 passing.
