### PR TITLE
fix(meshcore): bottom-scroll + hide empty scope + preserve node name on re-discovery

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -136,10 +136,6 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // pre-read marker without re-subscribing to every marker change.
   const lastReadRef = useRef(lastRead);
   lastReadRef.current = lastRead;
-  // Pre-read marker snapshotted at channel entry, captured BEFORE the
-  // mark-on-view effect advances it. Used to locate the first-unread message so
-  // the stream can scroll there on entry (#3810).
-  const [entryReadTs, setEntryReadTs] = useState<number>(0);
   // Optional "channels with unread first" ordering (#3703), persisted globally.
   const [sortUnreadFirst, setSortUnreadFirst] = useState<boolean>(
     () => localStorage.getItem(SORT_UNREAD_FIRST_KEY) === 'true',
@@ -424,22 +420,6 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     return Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp);
   }, [history, messages, activeFilter]);
 
-  // Snapshot the active channel's pre-read marker on channel entry, BEFORE the
-  // mark-on-view effect below advances it (effects run in declaration order, so
-  // this one wins). Depends only on `active.id` so a later backlog load / mark
-  // doesn't clobber the snapshot. This is the boundary used to find the first
-  // unread message for the entry scroll (#3810).
-  useEffect(() => {
-    setEntryReadTs(lastReadRef.current[active.id] ?? 0);
-  }, [active.id]);
-
-  // The oldest unread message for this channel (timestamp strictly newer than
-  // the entry-read snapshot). Passed to the stream so it scrolls there on entry;
-  // `undefined` (everything already read) ⇒ the stream falls back to bottom.
-  const firstUnreadId = useMemo(() => {
-    return filtered.find(m => m.timestamp > entryReadTs)?.id;
-  }, [filtered, entryReadTs]);
-
   // Mark the active channel read up to its newest visible message. Runs whenever
   // the active channel's content changes (channel switch, backlog load, or a
   // live message arriving while it's open), so an open channel never shows as
@@ -653,7 +633,6 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           onNodeNameClick={onNodeNameClick}
           onReply={handleReply}
           conversationKey={`channel-${active.id}`}
-          firstUnreadId={firstUnreadId}
           maxBytes={
             showScopeOverride && overrideScope !== null && overrideScope !== ''
               ? 120

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -100,6 +100,14 @@ describe('MeshCoreMessageStream scope row (#3814)', () => {
     expect(container.querySelector('.mc-message-scope')).toBeNull();
   });
 
+  it('renders no scope row for an unscoped message (scopeCode 0)', () => {
+    // Unscoped messages used to show a "🌐 no scope" badge — now they show nothing.
+    const { container } = renderWithSelf([
+      { id: 'u', fromPublicKey: 'fedcba9876543210', text: 'hi', timestamp: Date.now(), scopeCode: 0, scopeName: null },
+    ]);
+    expect(container.querySelector('.mc-message-scope')).toBeNull();
+  });
+
   it('still renders the scope row on a received scoped message', () => {
     const { container } = renderWithSelf([
       { id: 'b', fromPublicKey: 'fedcba9876543210', text: 'hi', timestamp: Date.now(), scopeCode: 1234, scopeName: 'berlin' },
@@ -181,23 +189,7 @@ describe('MeshCoreMessageStream entry scroll (#3810)', () => {
     ];
   };
 
-  it('scrolls the first-unread row into view on entry', () => {
-    const { container } = render(
-      <MeshCoreMessageStream
-        messages={threeMessages()}
-        conversationKey="channel-0"
-        firstUnreadId="b"
-        onSend={async () => true}
-      />,
-    );
-    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
-    // The scrolled element must be the row for the first-unread message.
-    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
-      container.querySelector('[data-message-id="b"]'),
-    );
-  });
-
-  it('scrolls to the bottom on entry when there is no unread anchor', () => {
+  it('lands at the bottom (newest) on entry', () => {
     const { container } = render(
       <MeshCoreMessageStream
         messages={threeMessages()}
@@ -207,7 +199,7 @@ describe('MeshCoreMessageStream entry scroll (#3810)', () => {
     );
     expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     const list = container.querySelector('.meshcore-message-list') as HTMLElement;
-    expect(list.scrollTop).toBe(500);
+    expect(list.scrollTop).toBe(500); // == forced scrollHeight → bottom
   });
 
   it('runs the entry scroll once the async backlog populates (empty → non-empty)', () => {
@@ -215,26 +207,23 @@ describe('MeshCoreMessageStream entry scroll (#3810)', () => {
       <MeshCoreMessageStream
         messages={[]}
         conversationKey="channel-0"
-        firstUnreadId="b"
         onSend={async () => true}
       />,
     );
     // Empty on first render (conversationKey already flipped) — nothing to scroll.
-    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    let list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    expect(list.scrollTop).toBe(0);
 
-    // Backlog arrives for the SAME conversationKey.
+    // Backlog arrives for the SAME conversationKey → scroll to the bottom.
     rerender(
       <MeshCoreMessageStream
         messages={threeMessages()}
         conversationKey="channel-0"
-        firstUnreadId="b"
         onSend={async () => true}
       />,
     );
-    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
-    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
-      container.querySelector('[data-message-id="b"]'),
-    );
+    list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    expect(list.scrollTop).toBe(500);
   });
 });
 

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -21,11 +21,6 @@ interface MeshCoreMessageStreamProps {
   /** Stable key identifying the current conversation. When it changes, the
    *  stream re-runs its entry scroll (to the first-unread row, or the bottom). */
   conversationKey?: string;
-  /** Id of the oldest unread message for this conversation, snapshotted at
-   *  channel entry. When provided, the stream scrolls this row into view on
-   *  entry (aligned near the top so the unread boundary is visible) instead of
-   *  jumping to the bottom. Absent (e.g. the DM view) ⇒ scroll to bottom. (#3810) */
-  firstUnreadId?: string;
   /** Maximum UTF-8 byte length for a message. Send is blocked when exceeded. */
   maxBytes?: number;
 }
@@ -73,7 +68,6 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   onNodeNameClick,
   onReply,
   conversationKey,
-  firstUnreadId,
   maxBytes = 130,
 }) => {
   const { t } = useTranslation();
@@ -132,14 +126,12 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     };
   }, [contacts]);
 
-  // Entry scroll (#3810): on conversation entry, scroll to the first-unread row
-  // (aligned near the top so the unread boundary is visible) or, when there is
-  // none, to the bottom. A channel's backlog is fetched ASYNCHRONOUSLY, so
-  // `messages` is often empty when `conversationKey` first flips — scrolling
-  // then would fire against empty content and leave the viewport stranded in the
-  // middle once the backlog renders. So we defer the entry scroll until messages
-  // are actually present, and only run it once per conversationKey (re-arming
-  // when the key changes). `entryScrollRef` tracks which key we've handled.
+  // Entry scroll: on conversation entry, land at the BOTTOM (newest messages).
+  // A channel's backlog is fetched ASYNCHRONOUSLY, so `messages` is often empty
+  // when `conversationKey` first flips — scrolling then would fire against empty
+  // content and leave the viewport stranded. So we defer until messages are
+  // present, and only run it once per conversationKey (re-arming when the key
+  // changes). `entryScrollRef` tracks which key we've handled.
   const entryScrollRef = useRef<{ key: string | undefined; done: boolean }>({
     key: conversationKey,
     done: false,
@@ -158,26 +150,9 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     if (messages.length === 0) return;
     state.done = true;
     requestAnimationFrame(() => {
-      if (firstUnreadId) {
-        const selector = `[data-message-id="${
-          typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(firstUnreadId) : firstUnreadId
-        }"]`;
-        const row = container.querySelector<HTMLElement>(selector);
-        if (row && typeof row.scrollIntoView === 'function') {
-          // Align the unread boundary near the top of the viewport.
-          row.scrollIntoView({ block: 'start' });
-          return;
-        }
-        if (row) {
-          // Environments without scrollIntoView (e.g. jsdom): approximate by
-          // offsetting the container so the unread row sits near the top.
-          container.scrollTop = row.offsetTop - container.offsetTop;
-          return;
-        }
-      }
       container.scrollTop = container.scrollHeight;
     });
-  }, [conversationKey, messages.length, firstUnreadId]);
+  }, [conversationKey, messages.length]);
 
   // Auto-scroll on new messages only when the user is already near the bottom.
   useEffect(() => {
@@ -400,16 +375,17 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                   {m.hopCount !== 0 && m.routePath ? ` · ${m.routePath.split(',').filter(Boolean).join(' → ')}` : ''}
                 </div>
               )}
-              {(typeof m.scopeCode === 'number' || (m.scopeName != null && m.scopeName !== '')) && (
+              {/* Only render the scope row when the message actually carried a
+                  scope/region — an unscoped message (scopeCode 0) or one with no
+                  scope info shows nothing rather than a "no scope" badge (#3851 follow-up). */}
+              {((m.scopeName != null && m.scopeName !== '') || (typeof m.scopeCode === 'number' && m.scopeCode !== 0)) && (
                 <div
                   className="mc-message-scope"
                   title={t('meshcore.scope_tooltip', 'The region/scope this message was sent with')}
                 >
-                  {m.scopeCode === 0
-                    ? t('meshcore.scope_unscoped', '🌐 no scope')
-                    : m.scopeName
-                      ? `🔒 ${m.scopeName}`
-                      : `🔒 #${(m.scopeCode ?? 0).toString(16).padStart(4, '0')}`}
+                  {m.scopeName
+                    ? `🔒 ${m.scopeName}`
+                    : `🔒 #${(m.scopeCode ?? 0).toString(16).padStart(4, '0')}`}
                 </div>
               )}
               {outgoing && m.heardBy && m.heardBy.length > 0 && expandedHeardBy.has(m.id) && (

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -377,12 +377,25 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     // snapshot poll reconciles from the DB.
     setNodes(prev => {
       const favByKey = new Map(prev.map(n => [n.publicKey, n.isFavorite]));
+      // Likewise carry forward the last-known name. A re-discovered node
+      // returns from the device with an empty adv_name (discovery responses
+      // carry only key+type; the name follows via a later advert), so
+      // contactToNode() resolves it to "Unknown" and would clobber the good
+      // name live until a page reload re-reads it from the DB. Keep the prior
+      // real name in that gap.
+      const nameByKey = new Map(
+        prev.filter(n => n.name && n.name !== 'Unknown').map(n => [n.publicKey, n.name]),
+      );
       const merged: MeshCoreNode[] = [];
       if (localNodeRef.current) merged.push(localNodeRef.current);
       for (const c of contactsRef.current.values()) {
         const node = contactToNode(c);
         const fav = favByKey.get(c.publicKey);
         if (fav !== undefined) node.isFavorite = fav;
+        if (node.name === 'Unknown') {
+          const prevName = nameByKey.get(c.publicKey);
+          if (prevName) node.name = prevName;
+        }
         merged.push(node);
       }
       return merged;

--- a/src/server/meshcoreManager.newNodeRefresh.test.ts
+++ b/src/server/meshcoreManager.newNodeRefresh.test.ts
@@ -11,12 +11,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const upsertNode = vi.fn().mockResolvedValue(undefined);
+const getNodeByPublicKeyAndSource = vi.fn().mockResolvedValue(null);
 const emitMeshCoreContactUpdated = vi.fn();
 
 vi.mock('../services/database.js', () => ({
   default: {
     meshcore: {
       upsertNode: (...args: unknown[]) => upsertNode(...args),
+      getNodeByPublicKeyAndSource: (...args: unknown[]) => getNodeByPublicKeyAndSource(...args),
     },
   },
 }));
@@ -79,6 +81,8 @@ function makeCompanionManager(): {
 describe('MeshCoreManager — new-node contact refresh (#3646)', () => {
   beforeEach(() => {
     upsertNode.mockClear();
+    getNodeByPublicKeyAndSource.mockClear();
+    getNodeByPublicKeyAndSource.mockResolvedValue(null);
     emitMeshCoreContactUpdated.mockClear();
     vi.useFakeTimers();
   });
@@ -159,5 +163,66 @@ describe('MeshCoreManager — new-node contact refresh (#3646)', () => {
     const contact = manager.getContact(NEW_KEY);
     expect(contact?.advName).toBe('Repeater One');
     expect(contact?.advType).toBe(2);
+  });
+});
+
+describe('MeshCoreManager — re-discovered node name backfill (#3858)', () => {
+  beforeEach(() => {
+    upsertNode.mockClear();
+    getNodeByPublicKeyAndSource.mockClear();
+    getNodeByPublicKeyAndSource.mockResolvedValue(null);
+    emitMeshCoreContactUpdated.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Discovery schedules a debounced path-refresh; drop it so the timer
+    // doesn't leak into the next test.
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('backfills a re-discovered nameless node\'s name from the surviving DB row', async () => {
+    const { manager } = makeCompanionManager();
+    // User deleted "Yeraze Repeater" (gone from this.contacts) then hit
+    // "Discover Repeaters". The discovery response carries only key+type, but
+    // the persisted meshcore_nodes row survived the delete with the real name.
+    getNodeByPublicKeyAndSource.mockResolvedValue({ publicKey: NEW_KEY, name: 'Yeraze Repeater' });
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'node_discovered',
+      data: { public_key: NEW_KEY, adv_type: 2, snr: 5 },
+    });
+
+    // Let the async DB backfill resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getNodeByPublicKeyAndSource).toHaveBeenCalledWith(NEW_KEY, 'src-a');
+    // The contact-updated push the UI receives carries the recovered name,
+    // not "Unknown" — no page reload required.
+    const emitted = emitMeshCoreContactUpdated.mock.calls.map((c) => c[0] as { publicKey: string; advName?: string });
+    expect(emitted.some((ct) => ct.publicKey === NEW_KEY && ct.advName === 'Yeraze Repeater')).toBe(true);
+    expect(manager.getContact(NEW_KEY)?.advName).toBe('Yeraze Repeater');
+  });
+
+  it('emits the discovered node as-is when no DB row exists (genuinely new)', async () => {
+    const { manager } = makeCompanionManager();
+    getNodeByPublicKeyAndSource.mockResolvedValue(null);
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'node_discovered',
+      data: { public_key: NEW_KEY, adv_type: 2, snr: 5 },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Still emitted (so the UI shows the node), just without a name to backfill.
+    const emitted = emitMeshCoreContactUpdated.mock.calls.map((c) => c[0] as { publicKey: string; advName?: string });
+    expect(emitted.some((ct) => ct.publicKey === NEW_KEY)).toBe(true);
+    expect(manager.getContact(NEW_KEY)?.advName).toBeUndefined();
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1321,8 +1321,41 @@ class MeshCoreManager extends EventEmitter {
         };
         this.contacts.set(publicKey, updated);
         void this.persistContact(updated);
-        this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
-        dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
+
+        const emitContact = (contact: MeshCoreContact) => {
+          this.emit('contacts_updated', { sourceId: this.sourceId, contact });
+          dataEventEmitter.emitMeshCoreContactUpdated(contact, this.sourceId);
+        };
+        if (updated.advName || updated.name) {
+          emitContact(updated);
+        } else {
+          // A re-discovered node (delete → "Discover Repeaters") comes back
+          // with no name — discovery responses carry only key+type. But the
+          // persisted meshcore_nodes row survives a contact delete, so the
+          // server still knows the name. Backfill it from the DB before the
+          // first emit, otherwise the UI shows "Unknown" until a later passive
+          // advert (or a manual page reload re-reading the snapshot) supplies
+          // it. (#3858 follow-up)
+          void (async () => {
+            let toEmit = updated;
+            try {
+              const dbNode = await databaseService.meshcore.getNodeByPublicKeyAndSource(
+                publicKey,
+                this.sourceId,
+              );
+              if (dbNode?.name) {
+                toEmit = { ...updated, advName: dbNode.name };
+                this.contacts.set(publicKey, toEmit);
+              }
+            } catch (err) {
+              logger.warn(
+                `[MeshCore:${this.sourceId}] discover name backfill failed for ` +
+                `${publicKey.substring(0, 16)}…: ${(err as Error).message}`,
+              );
+            }
+            emitContact(toEmit);
+          })();
+        }
 
         // A discovery response carries only key+type — name and position aren't
         // included. For a newly-seen node, pull the full contact record

--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -30,9 +30,14 @@ const BinaryRequestTypes = { GetTelemetryData: 0x03 };
 const AdvType = { None: 0, Chat: 1, Repeater: 2, Room: 3 };
 const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
 
+/** Flush pending microtasks + setImmediate so async fire-and-forget work runs. */
+const flushAsync = () => new Promise<void>((r) => setImmediate(r));
+
 class MockConnection extends EventEmitter {
   sentFrames: Uint8Array[] = [];
   addOrUpdateContact = vi.fn().mockResolvedValue(undefined);
+  /** Device contact list — discovery skips auto-adding a key already present. */
+  getContacts = vi.fn<[], Promise<any[]>>().mockResolvedValue([]);
   /** Reply bytes a `request_regions` (CMD 57) frame should produce. */
   regionsResponseData: Uint8Array | null = null;
   async connect() { /* no-op */ }
@@ -159,12 +164,36 @@ describe('MeshCoreNativeBackend — node discovery', () => {
     );
 
     // Auto-added on the device with the full key, type, empty name, flood path.
+    // The add is async (it first checks getContacts), so flush before asserting.
+    await flushAsync();
     expect(conn.addOrUpdateContact).toHaveBeenCalledTimes(1);
     const [keyArg, typeArg, flagsArg, outPathLenArg] = conn.addOrUpdateContact.mock.calls[0];
     expect(Array.from(keyArg as Uint8Array)).toEqual(Array.from(pubkey));
     expect(typeArg).toBe(AdvType.Repeater);
     expect(flagsArg).toBe(0);
     expect(outPathLenArg).toBe(0xff);
+  });
+
+  it('does NOT re-add (clobber) a node already in the device contact list (#3853-class)', async () => {
+    const { backend, conn, events } = await connectedBackend();
+    const tag = 0xbeefface;
+    await backend.sendCommand('discover_nodes', { filter: 0x02, tag });
+
+    const pubkey = Uint8Array.from(Array.from({ length: 32 }, (_, i) => i + 1));
+    // Device already knows this contact (with a name) — re-adding with an empty
+    // name would wipe it. getContacts reports it as existing.
+    conn.getContacts.mockResolvedValue([{ publicKey: pubkey, advName: 'Yeraze Repeater' }]);
+
+    conn.emit('rx', buildDiscoverResp({
+      snrX4: 20, rssi: -40 & 0xff, pathLen: 0xff,
+      nodeType: AdvType.Repeater, responderSnrX4: 12, tag, pubkey,
+    }));
+
+    // Still surfaced to the UI as discovered…
+    expect(events.find((e) => e.event_type === 'node_discovered')).toBeDefined();
+    // …but the device contact (and its name) is left untouched.
+    await flushAsync();
+    expect(conn.addOrUpdateContact).not.toHaveBeenCalled();
   });
 
   it('ignores responses whose tag does not match the pending request', async () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -674,21 +674,31 @@ export class MeshCoreNativeBackend extends EventEmitter {
         const publicKeyBytes = keyBytes.slice(0, 32);
         const publicKey = bytesToHex(publicKeyBytes);
 
-        // Auto-add to the DEVICE contact store so the node is actually
-        // message-able and survives the next refreshContacts() (a
-        // MeshMonitor-only mirror would be clobbered by the device's list).
-        // We have no name/position/path from a discovery response, so use
-        // empty name + flood path (outPathLen 0xFF) and let the device
-        // learn the route. addOrUpdateContact is idempotent (Ok/Err only),
-        // so re-discovering an existing contact is harmless. Best-effort:
-        // a device-side failure must not break response parsing.
+        // Auto-add a GENUINELY NEW node to the DEVICE contact store so it's
+        // actually message-able and survives the next refreshContacts() (a
+        // MeshMonitor-only mirror would be clobbered by the device's list). A
+        // discovery response carries no name/position/path, so a new contact is
+        // added with an empty name + flood path (outPathLen 0xFF) and the device
+        // learns the route later.
+        //
+        // CRITICAL: we must NOT re-add an EXISTING contact. addOrUpdateContact
+        // overwrites ALL of a contact's fields, so re-adding a known node with an
+        // empty name wipes its stored name on the device — and a later
+        // refreshContacts() mirrors the nameless entry into MeshMonitor (bug:
+        // "Discover Repeaters erased the node name"). An existing contact is
+        // already message-able and survives a refresh, so we simply skip it.
+        // Best-effort + async so rx parsing isn't blocked.
         const c = this.connection;
         if (c) {
-          void c
-            .addOrUpdateContact(publicKeyBytes, nodeType, 0, 0xff, new Uint8Array(64), '', 0, 0, 0)
-            .catch((err: Error) =>
-              logger.warn(`[MeshCore:native] discover auto-add failed for ${publicKey.substring(0, 16)}…: ${err.message}`),
-            );
+          void (async () => {
+            try {
+              const existing: any[] = await c.getContacts();
+              if (existing.some((ct) => bytesToHex(ct.publicKey) === publicKey)) return;
+              await c.addOrUpdateContact(publicKeyBytes, nodeType, 0, 0xff, new Uint8Array(64), '', 0, 0, 0);
+            } catch (err) {
+              logger.warn(`[MeshCore:native] discover auto-add failed for ${publicKey.substring(0, 16)}…: ${(err as Error).message}`);
+            }
+          })();
         }
 
         this.emitBridgeEvent('node_discovered', {


### PR DESCRIPTION
Three MeshCore fixes found while validating the freshly-deployed `origin/main`.

### 1. Message view starts at the bottom (newest) — display tweak
Opening a MeshCore channel/DM now lands at the **bottom** immediately, where the newest messages are. This **supersedes** the `#3810` scroll-to-first-unread-on-entry behavior (per maintainer request) and removes its now-unused `firstUnreadId`/`entryReadTs` plumbing from the stream + ChannelsView.

### 2. No "no scope" badge — display tweak
The per-message scope row now renders **only when the message actually carried a scope**. Unscoped messages (`scopeCode 0`) and scope-less messages show nothing instead of a `🌐 no scope` badge.

### 3. 🐛 "Discover Repeaters" wiped an already-named node's name
**Root cause:** `meshcoreNativeBackend.ts` auto-added *every* `NODE_DISCOVER_RESP` to the device contact store via `addOrUpdateContact(…, '' /* empty name */, …)`. Since `AddUpdateContact` overwrites **all** of a contact's fields, re-discovering a node that was already a named contact (e.g. "Yeraze Repeater") wiped its name on the device — and the next `refreshContacts()` mirrored the nameless entry into MeshMonitor (node shown as a bare ID). The codebase's own `set_out_path` handler already preserves `contact.advName` on re-add for exactly this reason.

**Fix:** only auto-add a **genuinely new** key (checked against `getContacts()` first). Existing contacts are already message-able and survive a refresh, so we skip them and leave their name/path untouched. They're still surfaced to the UI as "discovered."

## Testing
- Message stream: lands at bottom on entry (+ async-backlog case); no scope row for unscoped (`scopeCode 0`).
- Discovery: new key → `addOrUpdateContact` called; **existing key → NOT called** (no clobber), while `node_discovered` is still emitted.
- **Full suite: 8395 passing, 0 failures.** Typecheck + `vite build` clean.

> The three are separable if you'd prefer them split — bundled here since all surfaced in the same validation pass and share a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)