### PR TITLE
release: 4.12.2 — version bump, docs, + MeshCore scope-correlation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.12.2] - 2026-06-29
+
+### Added
+- **Scope/region control for MeshCore automations** — Both the legacy Automations tab and the Automation Engine can now target a specific MeshCore scope/region when sending, or **respond on the trigger message's scope**, so an automated reply stays on the region it arrived on. (#3833, #3834)
+- **"Request from a node" Automation Engine action** — A single action can request telemetry, position, traceroute, node info, neighbor info, or an advert from a node, on both Meshtastic and MeshCore sources. (#3835, #3838)
+- **Automation Engine live trace** — Each rule now has a live "view logs" trace that streams its evaluation and firing in real time, making it far easier to see why a rule did (or didn't) run. (#3836)
+- **MeshCore Reply button on channel messages** — Received channel messages now have a Reply button that prefills the `@[Sender]:` mention and sends the reply on the originating message's scope. (#3851, #3855)
+- **MeshCore scope/region shown on sent messages** — Outgoing MeshCore messages now display the scope/region badge they were sent on, matching the existing badge on received messages. (#3814, #3818)
+- **Hardware models 132–140** — Bundled Meshtastic protobufs updated to v2.7.26, adding names for hardware models 132–140 so newer devices display correctly. (#3849)
+
+### Fixed
+- **MeshCore: re-discovered node showed "Unknown" until reload** — After deleting a contact and running Discover Repeaters, the node reappeared nameless until a manual page refresh (the discovery response carries no name, while the persisted node row still held it). The name is now backfilled from the persisted node row before the live update, the channel view reliably opens at the bottom (newest) on entry, and unscoped messages no longer render an empty scope badge. (#3810, #3817, #3858)
+- **MeshCore: discovering an existing repeater wiped its name** — An active discovery re-added contacts already on the device with an empty name, erasing it; existing contacts are now left untouched. (#3858)
+- **MeshCore: received-message scope/region (and `{ROUTE}`/`{SNR}`) blank on busy meshes** — The raw OTA bytes that carry a received message's relay path, SNR, and scope are handed from the `LogRxData` push to the message-receive event through an in-memory buffer that was a **single slot**. When two text packets were in flight, the second packet's `LogRxData` clobbered the first's buffer before its receive consumed it, so the first message lost its route/SNR and showed **no scope badge** — even though MeshMonitor had captured the bytes. The buffer is now a small **FIFO** matched to each receive by hop count, so concurrent packets no longer evict each other.
+- **MeshCore: discovered repeater names populate without admin login** — Discovered repeaters are named via an ANON_REQ OWNER request, so names appear without logging into the repeater. (#3820, #3825)
+- **MeshCore: remote status response cross-talk** — Remote status requests are now serialized, so overlapping requests no longer attach the wrong node's response. (#3815, #3821)
+- **MeshCore: virtual-node DeviceInfo handshake** — The virtual node's DeviceInfo is pinned to companion protocol v1, fixing the companion app's "works once after restart" handshake abort. (#3705, #3828)
+- **MeshCore: saved regions missing from scope resolution** — The saved-regions catalog is now included when resolving a scope name. (#3829, #3830)
+- **Messages: request actions restored for unmessageable nodes** — Traceroute / telemetry / node-info actions stay available for nodes you can't DM. (#3831, #3832)
+- **Messages: softened the "not in device DB" warning** when the key is actually known. (#3853, #3856)
+- **Remote Node Status: "Errors" relabeled to "Error Events"** for clarity. (#3824)
+- **Settings: auto-acknowledge save no longer sticks** when the stored regex is RE2-incompatible. (#3806, #3819)
+- **MeshCore: message metadata readability on bright screens** improved. (#3811, #3812)
+- **MeshCore: heardBy relay info persists** in the memory pool after a channel echo. (#3813, #3816)
+
+### Dependencies
+- Routine dependency updates: recharts 3.9.0, lucide-react 1.22.0, aedes 1.1.0, vite 8.1.0, puppeteer 25.2.1, @types/node 26.0.1, `actions/cache` v6, plus grouped production and development dependency bumps. (#3632, #3839–#3848)
+
 ## [4.12.1] - 2026-06-27
 
 ### Fixed

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.12.1",
+  "version": "4.12.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -156,6 +156,11 @@ Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the
 - **DM to node #** — send as a direct message instead of to a channel. `{{ trigger.from }}` replies
   to the sender.
 - **Reply to the triggering message** — thread the reply to the message that fired the automation.
+- **MeshCore scope** *(advanced; MeshCore sources only — ignored by Meshtastic)* — which region a
+  MeshCore message floods to: **Inherit (channel / source default)**, **Match the triggering
+  message's scope** (reply on the same region it arrived on), **Unscoped (flood, no region)**, or
+  **A specific region…** — the latter reveals a **Region** picker (token-aware). See
+  [Regions / Scopes](/features/meshcore#regions-scopes).
 
 The overall send is a **source × channel matrix**: each selected source posts to the matching local
 slot of each selected channel.
@@ -164,6 +169,21 @@ slot of each selected channel.
 
 Runs an admin/management operation on the subject node: **Favorite / Unfavorite**, **Ignore /
 Unignore**, or **Delete**.
+
+### Request data from a node
+
+Asks a node to report data — the automation equivalent of the manual request buttons. Works on
+**both Meshtastic and MeshCore** sources.
+
+- **Request** — what to ask for: **Telemetry**, **Position (Meshtastic)**, **Traceroute / path**,
+  **Node info exchange (Meshtastic)**, **Neighbor info**, or **Announce self (advert)**.
+- **Telemetry type** — which metric set to ask for, when the request is **Telemetry**.
+- **Via sources** — which radio(s) to send the request through. Leave empty to use the triggering
+  source — but a source **is required** for source-less triggers (Schedule / System).
+- **Target node** — node # (Meshtastic) or contact public key (MeshCore). Leave blank to target the
+  triggering node. Not used for **Announce self**.
+- **Channel #** *(advanced; Meshtastic only)* — which channel to send the request on (e.g. a private
+  sensor channel); ignored by MeshCore.
 
 ### Send a notification (Apprise)
 
@@ -298,3 +318,19 @@ the trigger but no action fires, the panel explains that every condition went fa
 which inputs/facts to change.
 
 </div>
+
+## Live trace ("view logs")
+
+Where the dry-run Test panel exercises a rule against a **synthetic** event, the **live trace**
+watches **real events** flowing through a rule without sending anything itself. Each rule in the
+Automations list has a **Trace** button that opens a live debug view of just that rule; once armed,
+every event that reaches the rule is streamed to the panel in real time (over the dashboard socket),
+showing **why it did or didn't run**:
+
+- **fired** — the trigger matched and the action steps ran; the per-step trace is shown.
+- **prefiltered** — the event was filtered out before the conditions ran (e.g. wrong source/channel),
+  with the reason.
+- **cooldown** — the rule matched but was suppressed by its cooldown window.
+
+The panel keeps the most recent entries in a rolling buffer and **auto-stops after 5 minutes** (and
+on close or disconnect), so a trace never runs unbounded.

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -125,6 +125,8 @@ The device's channels with the most recent message stream. Channel-message sende
 
 **Unread indicators** — channels with messages newer than the last time you opened them show an unread dot and a **bold name** in the channel list. A header badge counts how many channels currently have unread messages, and an optional **"unread first"** sort toggle (persisted) floats those channels to the top. Opening a channel marks it read up to the newest visible message. MeshCore read state is tracked **client-side in `localStorage`, scoped by `sourceId`** — there's no server-side MeshCore read table, so read markers are per-browser rather than per-account.
 
+**Reply** — received channel messages carry a **Reply** button. Clicking it prefills the composer with the sender's MeshCore mention (`@[Sender]: `) and sends the reply **on the scope the original message arrived on**, so a threaded answer stays in the same region. The button appears only on incoming channel messages — not on your own messages, and not in 1:1 DMs.
+
 **Heard repeaters** — outgoing channel posts show a **📡 N** badge with an expandable list of the repeaters that re-flooded the message and the SNR each was heard at. This is populated best-effort by **self-echo correlation**: when a repeater re-floods your `GRP_TXT` packet, MeshMonitor hears it inbound and attributes the relay hashes to the most recent matching channel send within a ~30-second window. Channel sends carry no protocol ACK, so this is a heuristic, not a delivery receipt. Correlation runs on the raw inbound packet before the opt-in packet-monitor gate, so it works **regardless of whether the packet monitor is enabled**. Relay hashes are resolved to repeater names where known; otherwise the raw hash is shown.
 
 ### Direct Messages
@@ -276,13 +278,14 @@ A repeater only answers a regions query over a direct route, so MeshMonitor inst
 
 Next to the channel compose box is an optional one-off **scope/region override**. It applies to that single message and is **never persisted** to the channel — your next normal send re-asserts the channel/default scope. It defaults to the channel's resolved scope, offers the same discovered/saved-region datalist, and resets when you switch channels. Leave it blank/whitespace to send that one message explicitly unscoped.
 
-### Scope of received messages
+### Scope of sent and received messages
 
-Received channel and DM messages show a scope line so you can tell how a message reached you. MeshMonitor recovers the scope by recomputing each of your known region names against the packet (the raw name can't be reversed out of the wire value):
+Channel and DM messages show a scope line so you can tell which region a message used — on **both** received messages (how it reached you) and your **own sent** messages (which scope it went out on). MeshMonitor recovers the scope by recomputing each of your known region names against the packet (the raw name can't be reversed out of the wire value):
 
-- **🌐 no scope** — the message was sent un-scoped.
 - **🔒 muenchen** — scoped to a region you know; the name is shown.
 - **🔒 #a3f2** — scoped, but to a region not in your known set; the raw code is shown as hex.
+
+Un-scoped messages show **no scope line at all** — the absence of a badge is itself the signal that the message flooded without a region.
 
 ### Saved regions catalog
 
@@ -405,6 +408,7 @@ Auto-Responder matches incoming messages against operator-defined patterns and r
 
 - **Per-trigger pattern** — match incoming text via a regular expression, with per-channel filtering, DM listening, and a per-sender cooldown to avoid loops.
 - **Two actions** — reply with a **text response** (same token expansion as Auto-Announce) or **run a script** (with token-expanded script args). Script execution reuses the shared script runner, with `MESHCORE_*` environment variables injected so a script can branch on which stack invoked it.
+- **Reply scope/region** — choose which region the reply floods to: **Inherit** the channel/source default, **Match the triggering message's scope** (answer back on the same region it arrived on), send **Unscoped**, or pick **a specific region**. This mirrors the MeshCore scope control in the [Automation Engine](/features/automation-engine#actions).
 
 ## Timer Triggers
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.12.1
-appVersion: "4.12.1"
+version: 4.12.2
+appVersion: "4.12.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.12.1",
+      "version": "4.12.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -14,7 +14,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#feat/meshmonitor-helpers",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-virtual": "^3.14.4",
         "@tmcw/togeojson": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -271,6 +271,36 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     expect(msg.data.path_hops).toBeUndefined();
   });
 
+  it('keeps each of two concurrent text packets buffered (FIFO, no single-slot clobber)', async () => {
+    // Real-world bug: on a busy mesh a second text packet's LogRxData arrived
+    // before the first packet's recv consumed its buffer. With a single slot the
+    // second LogRxData clobbered the first, so the first message lost its
+    // route/SNR and — most visibly — its scope/region (raw_hex). The FIFO keeps
+    // both, matched to their recvs by hop count.
+    const { conn, events } = await connectedBackend();
+    // Packet A: GRP_TXT FLOOD, 2-byte hashes, 2 hops (packed 0x42).
+    const rawA = Uint8Array.from([0x05, 0x01, 0x42, 0xde, 0xad, 0xbe, 0xef]);
+    // Packet B: GRP_TXT FLOOD, 1-byte hash, 1 hop (packed 0x01).
+    const rawB = Uint8Array.from([0x05, 0x01, 0x01, 0xaa]);
+    // Both LogRxData pushes land BEFORE either recv (the clobber window).
+    conn.emit(PushCodes.LogRxData, { lastSnr: 3.25, lastRssi: -55, raw: rawA });
+    conn.emit(PushCodes.LogRxData, { lastSnr: 7.0, lastRssi: -38, raw: rawB });
+    // Recvs arrive in order; each must pick up its OWN buffered packet by hops.
+    conn.emit(ResponseCodes.ChannelMsgRecv, { channelIdx: 0, text: 'Alice: first', senderTimestamp: 3000, pathLen: 2 });
+    conn.emit(ResponseCodes.ChannelMsgRecv, { channelIdx: 0, text: 'Bob: second', senderTimestamp: 3100, pathLen: 1 });
+
+    const msgs = events.filter((e) => e.event_type === 'channel_message');
+    expect(msgs).toHaveLength(2);
+    // First message keeps packet A's path + SNR + raw bytes (not clobbered).
+    expect(msgs[0].data.path_hops).toEqual(['dead', 'beef']);
+    expect(msgs[0].data.snr).toBe(3.25);
+    expect(msgs[0].data.raw_hex).toBe('050142deadbeef');
+    // Second message keeps packet B's.
+    expect(msgs[1].data.path_hops).toEqual(['aa']);
+    expect(msgs[1].data.snr).toBe(7.0);
+    expect(msgs[1].data.raw_hex).toBe('050101aa');
+  });
+
   it('does NOT attach a stale buffered path (older than the freshness window)', async () => {
     vi.useFakeTimers();
     try {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -210,16 +210,25 @@ export class MeshCoreNativeBackend extends EventEmitter {
   private commandSeq: number = 0;
   private drainInFlight: boolean = false;
   /**
-   * Most recent LogRxData-derived TXT_MSG packet metadata. The firmware
-   * emits LogRxData immediately before dispatching the txt-msg-specific
-   * recv event (ContactMsgRecv / ChannelMsgRecv) for the same packet, so
-   * we buffer the parsed path here and consume it on the next message
-   * recv to give the bridge event the real relay-hash chain rather than
-   * just the packed pathLen byte. The RX SNR is carried alongside the path
-   * (it only appears on LogRxData, not on the txt-msg recv event) so the
-   * message event — and {SNR} in auto-ack/auto-responder templates — has it.
+   * Recent LogRxData-derived TXT_MSG/GRP_TXT packet metadata, oldest-first. The
+   * firmware emits LogRxData immediately before dispatching the txt-msg-specific
+   * recv event (ContactMsgRecv / ChannelMsgRecv) for the same packet, so we
+   * buffer the parsed path here and consume it on the next message recv to give
+   * the bridge event the real relay-hash chain (and the raw OTA bytes for scope
+   * resolution) rather than just the packed pathLen byte. The RX SNR is carried
+   * alongside the path (it only appears on LogRxData, not on the txt-msg recv
+   * event) so the message event — and {SNR}/{ROUTE} in auto-ack/auto-responder
+   * templates, plus the MeshCore scope/region badge — has it.
+   *
+   * This is a small FIFO, NOT a single slot. On a busy mesh several text packets
+   * can be in flight; with a single slot a second packet's LogRxData clobbered
+   * the first's buffer before its recv consumed it, so the first message lost
+   * its route/SNR and — most visibly — its scope badge (received-message scope
+   * intermittently blank on busy meshes, even though the raw bytes were
+   * captured). {@link consumePendingPath} matches by hop count and takes the
+   * oldest unconsumed entry, so concurrent packets no longer evict each other.
    */
-  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number; snr?: number; rawHex?: string; bufferedAt: number } | null = null;
+  private pendingTxtMsgPaths: Array<{ hops: string[]; rawPathLen: number; snr?: number; rawHex?: string; bufferedAt: number }> = [];
 
   /**
    * Maximum age (ms) of a buffered LogRxData path before we treat it as stale
@@ -234,6 +243,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * a core guard against the intermittent mis-correlation in issue #3589.
    */
   private static readonly PENDING_PATH_MAX_AGE_MS = 500;
+  /**
+   * Cap on buffered LogRxData entries. The FIFO only holds text-packet metadata
+   * for the sub-millisecond gap until the matching recv consumes it (pruned by
+   * age on every push/consume), so this is just a backstop against unbounded
+   * growth if a burst of LogRxData arrives with no following recv events.
+   */
+  private static readonly PENDING_PATH_MAX_ENTRIES = 8;
   /** Constructor reference for the meshcore.js Packet parser, populated when the module loads. */
   private PacketCtor: MeshCoreJsModule['Packet'] | null = null;
   /**
@@ -380,29 +396,38 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * absent, stale, or for a different packet.
    */
   private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number; rawHex?: string } | undefined {
-    const buffered = this.pendingTxtMsgPath;
-    // Consume-once: clear regardless of whether we end up attaching it.
-    this.pendingTxtMsgPath = null;
-    if (!buffered) return undefined;
+    const now = Date.now();
+    // Drop stale entries first — a buffer whose matching recv never arrived
+    // would mis-correlate route/SNR/scope if attached to a later message
+    // (issue #3589 guard).
+    this.pendingTxtMsgPaths = this.pendingTxtMsgPaths.filter(
+      (e) => now - e.bufferedAt <= MeshCoreNativeBackend.PENDING_PATH_MAX_AGE_MS,
+    );
+    if (this.pendingTxtMsgPaths.length === 0) return undefined;
 
-    if (Date.now() - buffered.bufferedAt > MeshCoreNativeBackend.PENDING_PATH_MAX_AGE_MS) {
-      // Stale buffer — its matching recv never arrived. Don't mis-attach.
-      return undefined;
-    }
-    if (typeof msgPathLen === 'number' && typeof buffered.rawPathLen === 'number') {
-      // Normalize both sides to a plain hop count before comparing. The recv
-      // event's pathLen is already a plain count (0xFF == sent-direct == 0
-      // hops); the buffered rawPathLen is the packed OTA byte.
-      const msgHopCount = msgPathLen === 0xff ? 0 : msgPathLen & 0x3f;
-      const bufferedHopCount =
-        buffered.rawPathLen === 0xff
-          ? 0
-          : (this.PacketCtor?.extractPathHashCount(buffered.rawPathLen) ?? (buffered.rawPathLen & 0x3f));
-      if (msgHopCount !== bufferedHopCount) {
-        // Buffer is from a different packet (hop counts differ).
-        return undefined;
-      }
-    }
+    // Normalize the recv event's pathLen to a plain hop count (0xFF == sent
+    // direct == 0 hops). The buffered rawPathLen is the packed OTA byte.
+    const msgHopCount =
+      typeof msgPathLen === 'number' ? (msgPathLen === 0xff ? 0 : msgPathLen & 0x3f) : null;
+    const bufferedHopCount = (rawPathLen: number): number =>
+      rawPathLen === 0xff
+        ? 0
+        : (this.PacketCtor?.extractPathHashCount(rawPathLen) ?? (rawPathLen & 0x3f));
+
+    // Take the OLDEST unconsumed entry whose hop count matches. LogRxData is
+    // emitted just before its own recv, so across concurrent packets the oldest
+    // hop-matching buffer is this recv's packet. When the recv carries no usable
+    // pathLen, fall back to the oldest entry outright (prior single-slot
+    // behavior generalized to the FIFO).
+    const idx = this.pendingTxtMsgPaths.findIndex(
+      (e) =>
+        msgHopCount === null ||
+        typeof e.rawPathLen !== 'number' ||
+        bufferedHopCount(e.rawPathLen) === msgHopCount,
+    );
+    if (idx === -1) return undefined;
+
+    const [buffered] = this.pendingTxtMsgPaths.splice(idx, 1); // consume-once
     return { hops: buffered.hops, snr: buffered.snr, rawHex: buffered.rawHex };
   }
 
@@ -452,12 +477,17 @@ export class MeshCoreNativeBackend extends EventEmitter {
           // arrived (issue #3589 mis-correlation guard).
           if (pkt.payload_type === TXT_MSG || pkt.payload_type === GRP_TXT) {
             // Buffer raw_hex too so the message handler can resolve the scope/
-            // region the packet was sent under (#3742 Phase 2). Same correlation
-            // limitation as the Phase 1 route/SNR: if LogRxData arrives AFTER its
-            // text-msg recv event (rare ordering on a busy link), the buffer is
-            // missed and scope resolves to null — acceptable and inherent to the
-            // adjacency-buffer design.
-            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr, rawHex: bytesToHex(raw), bufferedAt: Date.now() };
+            // region the packet was sent under (#3742 Phase 2). Push onto the
+            // FIFO (consumed by the matching recv) rather than overwriting a
+            // single slot, so concurrent text packets on a busy mesh don't evict
+            // each other's route/SNR/scope. Remaining limitation: if LogRxData
+            // arrives AFTER its own recv (rare ordering), that packet's buffer is
+            // still missed — inherent to the adjacency-buffer design.
+            this.pendingTxtMsgPaths.push({ hops, rawPathLen: pkt.pathLen, snr, rawHex: bytesToHex(raw), bufferedAt: Date.now() });
+            // Backstop against unbounded growth (recv-less LogRxData bursts).
+            if (this.pendingTxtMsgPaths.length > MeshCoreNativeBackend.PENDING_PATH_MAX_ENTRIES) {
+              this.pendingTxtMsgPaths.shift();
+            }
           }
           this.emitBridgeEvent('ota_packet', {
             payload_type: pkt.payload_type,


### PR DESCRIPTION
## 4.12.2 release

Bumps the version and brings docs current for everything merged since 4.12.1, **plus** a real MeshCore fix surfaced during validation.

### Version (5 files)
`package.json`, `package-lock.json` (regenerated, `npm ci`-validated), `helm/meshmonitor/Chart.yaml` (version + appVersion), `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`.

### 🐛 Fix — received-message scope/region (and `{ROUTE}`/`{SNR}`) blank on busy meshes
A received MeshCore message's relay path, SNR, and scope ride in on a `LogRxData` push that's handed to the message-receive handler through an in-memory buffer that was a **single slot**. With two text packets in flight, the second packet's `LogRxData` **clobbered** the first's buffer before its receive consumed it — so the first message lost its route/SNR and showed **no scope badge**, even though MeshMonitor had captured the bytes.

Verified end-to-end against live data: a message sent on the `mmtest` scope arrived with `scopeCode=null` in the message row, yet the **same raw packet was still in `meshcore_packet_log`** and the app's own `resolveMessageScope()` recovered `scopeName="mmtest"` from it. So the data was always recoverable — only the correlation dropped it.

**Fix:** the buffer is now a small **FIFO** matched to each receive by hop count, so concurrent packets no longer evict each other. Adds a regression test reproducing the two-in-flight clobber (`meshcoreNativeBackend.otaPacket.test.ts`).

### 📝 Docs
- **CHANGELOG**: full `[4.12.2]` entry (Added / Fixed / Dependencies) for all 30 merges since 4.12.1, including this fix.
- **docs/features/automation-engine.md**: "Request data from a node" action, MeshCore scope options on Send-a-message, and the **Live Trace** section — labels verified against `catalog.ts` / `LiveTracePanel.tsx`.
- **docs/features/meshcore.md**: Reply button, Auto-Responder reply scope, and the **sent-message scope badge**; removed the now-stale "🌐 no scope" badge text (#3858 dropped that badge).

### Verification
- Full suite: **7778 passed / 0 failed / 0 suites failed**
- Server typecheck clean; lockfile validated via `npm ci`
- **System tests enabled** on this PR (label) — this touches MeshCore device-comms correlation, so real-hardware coverage is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)