### PR TITLE
fix(traceroute): clamp future device-clock timestamps so "last traced" can't go negative (#2768)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 107 (latest: `107_clear_null_island_positions`).
+**Current migration count:** 109 (latest: `109_clamp_future_traceroute_timestamps`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1687,7 +1687,11 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 (() => {
                   const recentTrace = getRecentTraceroute(selectedDMNode);
                   if (recentTrace) {
-                    const age = Math.floor((Date.now() - recentTrace.timestamp) / (1000 * 60));
+                    // Clamp at 0: a node with a wrong/ahead clock can stamp a
+                    // traceroute in the future, which would otherwise render as a
+                    // negative "-1676m ago" (#2768). The data write-path now caps
+                    // this at server time too; this guards any pre-fix rows.
+                    const age = Math.max(0, Math.floor((Date.now() - recentTrace.timestamp) / (1000 * 60)));
                     const ageStr = age < 60 ? `${age}m ago` : `${Math.floor(age / 60)}h ago`;
 
                     // Check if traceroute failed (both directions have no valid data)
@@ -1758,7 +1762,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
               // Get most recent timestamp (normalize: old data in seconds, new in ms)
               const mostRecent = Math.max(...nodeNeighbors.map(n => n.timestamp < 10_000_000_000 ? n.timestamp * 1000 : n.timestamp));
-              const age = Math.floor((Date.now() - mostRecent) / (1000 * 60));
+              // Clamp at 0 so a future device-clock timestamp can't render a
+              // negative "-1676m ago" (same guard as the traceroute age, #2768).
+              const age = Math.max(0, Math.floor((Date.now() - mostRecent) / (1000 * 60)));
               const ageStr = age < 60 ? `${age}m ago` : `${Math.floor(age / 60)}h ago`;
 
               const handlePurgeNeighbors = async () => {

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 108 migrations registered', () => {
-    expect(registry.count()).toBe(108);
+  it('has all 109 migrations registered', () => {
+    expect(registry.count()).toBe(109);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_saved_regions', () => {
+  it('last migration is clamp_future_traceroute_timestamps', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(108);
-    expect(last.name).toContain('meshcore_saved_regions');
+    expect(last.number).toBe(109);
+    expect(last.name).toContain('clamp_future_traceroute_timestamps');
   });
 
-  it('migrations are sequentially numbered from 1 to 108', () => {
+  it('migrations are sequentially numbered from 1 to 109', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -123,6 +123,7 @@ import { migration as meshcoreMessageRouteMigration, runMigration105Postgres as 
 import { migration as meshcoreMessageScopeMigration, runMigration106Postgres as runMeshcoreMessageScopePostgres, runMigration106Mysql as runMeshcoreMessageScopeMysql } from '../server/migrations/106_add_meshcore_message_scope.js';
 import { migration as clearNullIslandMigration, runMigration107Postgres as runClearNullIslandPostgres, runMigration107Mysql as runClearNullIslandMysql } from '../server/migrations/107_clear_null_island_positions.js';
 import { migration as meshcoreSavedRegionsMigration, runMigration108Postgres as runMeshcoreSavedRegionsPostgres, runMigration108Mysql as runMeshcoreSavedRegionsMysql } from '../server/migrations/108_meshcore_saved_regions.js';
+import { migration as clampFutureTracerouteMigration, runMigration109Postgres as runClampFutureTraceroutePostgres, runMigration109Mysql as runClampFutureTracerouteMysql } from '../server/migrations/109_clamp_future_traceroute_timestamps.js';
 
 // ============================================================================
 // Registry
@@ -1712,4 +1713,20 @@ registry.register({
   sqlite: (db) => meshcoreSavedRegionsMigration.up(db),
   postgres: (client) => runMeshcoreSavedRegionsPostgres(client),
   mysql: (pool) => runMeshcoreSavedRegionsMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 109: clamp future-dated traceroute timestamps (#2768)
+// Repairs traceroute rows whose `timestamp` (from a node's ahead device clock)
+// is later than their `createdAt` server time, which rendered as a negative
+// "last traced" age. One-shot; the ingest path now caps device time at now.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 109,
+  name: 'clamp_future_traceroute_timestamps',
+  settingsKey: 'migration_109_clamp_future_traceroute_timestamps',
+  sqlite: (db) => clampFutureTracerouteMigration.up(db),
+  postgres: (client) => runClampFutureTraceroutePostgres(client),
+  mysql: (pool) => runClampFutureTracerouteMysql(pool),
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7203,7 +7203,15 @@ class MeshtasticManager implements ISourceManager {
       // Traceroute responses are direct messages, not channel messages
       const isDirectMessage = toNum !== 4294967295;
       const channelIndex = isDirectMessage ? -1 : (meshPacket.channel !== undefined ? meshPacket.channel : 0);
-      const timestamp = meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : Date.now();
+      // A node with a wrong/ahead RTC reports an `rxTime` in the future. We just
+      // received the packet, so the traceroute can't have happened later than
+      // now — cap the device time at `Date.now()` so "last traced" never renders
+      // a negative "X minutes ago" (#2768). A legitimately slightly-past rxTime
+      // still passes through. (lastHeard/telemetry already use server time for
+      // the same reason — see replayGuard.ts.)
+      const timestamp = meshPacket.rxTime
+        ? Math.min(Number(meshPacket.rxTime) * 1000, Date.now())
+        : Date.now();
 
       // Save as a special message in the database
       // Use meshPacket.id for deduplication (same as text messages)

--- a/src/server/migrations/109_clamp_future_traceroute_timestamps.test.ts
+++ b/src/server/migrations/109_clamp_future_traceroute_timestamps.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Migration 109 — Clamp future-dated traceroute timestamps (SQLite, #2768).
+ *
+ * The PostgreSQL/MySQL paths run the same UPDATE with backend-quoted column
+ * names and are exercised by integration tests; only the SQLite path is
+ * covered here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './109_clamp_future_traceroute_timestamps.js';
+
+interface TraceRow {
+  id: number;
+  timestamp: number;
+  createdAt: number;
+}
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`CREATE TABLE traceroutes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    createdAt INTEGER NOT NULL
+  );`);
+  return db;
+}
+
+function insert(db: Database.Database, timestamp: number, createdAt: number): void {
+  db.prepare('INSERT INTO traceroutes (timestamp, createdAt) VALUES (?, ?)').run(timestamp, createdAt);
+}
+
+function rows(db: Database.Database): TraceRow[] {
+  return db.prepare('SELECT id, timestamp, createdAt FROM traceroutes ORDER BY id').all() as TraceRow[];
+}
+
+describe('Migration 109 — clamp future-dated traceroute timestamps (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  it('clamps a future timestamp (timestamp > createdAt) down to createdAt', () => {
+    const created = 1_700_000_000_000;
+    // Device clock ~28h ahead → timestamp well past createdAt (the #2768 case).
+    insert(db, created + 1676 * 60_000, created);
+
+    migration.up(db);
+
+    expect(rows(db)[0]).toMatchObject({ timestamp: created, createdAt: created });
+  });
+
+  it('leaves legitimate rows (timestamp <= createdAt) untouched', () => {
+    const created = 1_700_000_000_000;
+    insert(db, created - 5_000, created); // rxTime slightly before insert — normal
+    insert(db, created, created); // exactly equal — normal
+
+    migration.up(db);
+
+    const r = rows(db);
+    expect(r[0]).toMatchObject({ timestamp: created - 5_000, createdAt: created });
+    expect(r[1]).toMatchObject({ timestamp: created, createdAt: created });
+  });
+
+  it('repairs only the future rows in a mixed set', () => {
+    const created = 1_700_000_000_000;
+    insert(db, created + 99_000_000, created); // future → clamp
+    insert(db, created - 1_000, created); // past → keep
+    insert(db, created + 1, created); // 1ms future → clamp
+
+    migration.up(db);
+
+    const r = rows(db);
+    expect(r[0].timestamp).toBe(created);
+    expect(r[1].timestamp).toBe(created - 1_000);
+    expect(r[2].timestamp).toBe(created);
+  });
+
+  it('is idempotent — a second run changes nothing', () => {
+    const created = 1_700_000_000_000;
+    insert(db, created + 100_000, created);
+    migration.up(db);
+    const after = rows(db);
+    expect(() => migration.up(db)).not.toThrow();
+    expect(rows(db)).toEqual(after);
+  });
+});

--- a/src/server/migrations/109_clamp_future_traceroute_timestamps.ts
+++ b/src/server/migrations/109_clamp_future_traceroute_timestamps.ts
@@ -1,0 +1,74 @@
+/**
+ * Migration 109: Repair future-dated traceroute timestamps (#2768).
+ *
+ * The direct/TCP traceroute ingest path used to stamp a row's `timestamp` from
+ * the node's device clock (`rxTime`). A node whose RTC is set ahead of real time
+ * therefore produced a traceroute `timestamp` in the future, which the UI renders
+ * as a negative "last traced" age (e.g. "-1676m ago"). The ingest path is fixed
+ * to cap the device time at server time going forward; this one-shot migration
+ * repairs rows already written.
+ *
+ * Every traceroute row also stores `createdAt` (the server `Date.now()` at insert,
+ * which can never be in the future), so it is the authoritative "received at"
+ * time. We clamp any row whose `timestamp` is later than its own `createdAt` back
+ * down to `createdAt`. This also satisfies the field request to "clean the DB of
+ * entries from the future" — no manual Database-Maintenance action needed.
+ *
+ * Naturally idempotent: after the update every row has `timestamp <= createdAt`,
+ * so a re-run matches nothing. Only the `traceroutes` table is touched (the
+ * source of the "last traced" display); `createdAt` itself is never modified.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 109 (SQLite): Clamping future-dated traceroute timestamps...');
+    try {
+      const result = db
+        .prepare('UPDATE traceroutes SET timestamp = createdAt WHERE timestamp > createdAt')
+        .run();
+      logger.info(`Migration 109 complete (SQLite): clamped ${result.changes} future traceroute timestamp(s)`);
+    } catch (e: any) {
+      logger.warn('Migration 109 (SQLite): could not clamp traceroute timestamps:', e.message);
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 109 down: Not implemented (original future timestamps are not recoverable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration109Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 109 (PostgreSQL): Clamping future-dated traceroute timestamps...');
+  try {
+    const result = await client.query(
+      'UPDATE traceroutes SET "timestamp" = "createdAt" WHERE "timestamp" > "createdAt"',
+    );
+    logger.info(`Migration 109 complete (PostgreSQL): clamped ${result.rowCount ?? 0} future traceroute timestamp(s)`);
+  } catch (error: any) {
+    logger.error('Migration 109 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration109Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 109 (MySQL): Clamping future-dated traceroute timestamps...');
+  try {
+    // `timestamp` is a MySQL keyword — backtick the column names.
+    const [result] = await pool.query(
+      'UPDATE traceroutes SET `timestamp` = `createdAt` WHERE `timestamp` > `createdAt`',
+    );
+    const changed = (result as { affectedRows?: number }).affectedRows ?? 0;
+    logger.info(`Migration 109 complete (MySQL): clamped ${changed} future traceroute timestamp(s)`);
+  } catch (error: any) {
+    logger.error('Migration 109 (MySQL) failed:', error.message);
+    throw error;
+  }
+}


### PR DESCRIPTION
Fixes #2768.

## Symptom
"Last traced" renders a negative age, e.g. **"-1676m ago"** (reported by @gendebeat and @andrewolfy across multiple nodes / versions). Host time, last-seen, and telemetry times are all correct.

## Root cause
The direct/TCP traceroute ingest path stamped the row's `timestamp` from the node's device clock (`meshPacket.rxTime`):
```js
const timestamp = meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : Date.now();
```
A node whose RTC is set **ahead** of real time reports a future `rxTime`, so the stored traceroute time is in the future and `MessagesTab` computes a negative age (`(now − timestamp)/60000` → `-1676`). `last-seen`/telemetry are unaffected because they already use server time — the codebase explicitly treats device `rxTime` as unreliable (`replayGuard.ts`, and the `lastHeard`/telemetry comments). The traceroute path was simply never given the same treatment. (The MQTT traceroute path already used server time and is unaffected.)

## Fix (traceroute-scoped)
1. **Ingest clamp** — cap the device time at server time: `Math.min(rxTime*1000, Date.now())`. No new future-dated rows.
2. **Migration 109** (SQLite/PostgreSQL/MySQL) — repair existing rows where `timestamp > createdAt` by clamping to `createdAt` (the server insert time, which can never be in the future). Idempotent. **This auto-cleans the future-dated entries on upgrade** — directly answering @andrewolfy's "can the DB be cleaned of entries from the future?" without a manual Database-Maintenance button.
3. **Display guard** — `Math.max(0, …)` on the "last traced" age (and the adjacent neighbor "last heard" age) so any pre-fix/future value shows "0m ago" instead of a negative.

Also corrects the stale migration count in `CLAUDE.md` (107 → 109; 108 `meshcore_saved_regions` already existed) and updates the registry test.

## Audit note
An audit of all `rxTime` consumers found the **text-message** timestamp path (`canonicalMessageTime` / message write site) has the *same* latent future-clock exposure, but it's unreported and load-bearing for message sort/dedup (#3187), so it's **tracked separately** rather than changed here.

## Verification
- Full suite **7782 passed / 0 failed**; server tsc clean; vite build clean.
- New SQLite tests for migration 109 (clamp future, preserve legitimate, mixed set, idempotent); migration registry test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)