### PR TITLE
fix(meshcore): persist GPS position from telemetry poll to contact record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3506,6 +3506,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3523,6 +3526,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3540,6 +3546,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3557,6 +3566,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3574,6 +3586,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3591,6 +3606,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3894,6 +3912,9 @@
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3506,9 +3506,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3526,9 +3523,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3546,9 +3540,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3566,9 +3557,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3586,9 +3574,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3606,9 +3591,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3912,9 +3894,6 @@
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -580,6 +580,88 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
     expect(upsertNode).not.toHaveBeenCalled();
   });
 
+  it('persists GPS position to meshcore_nodes when LPP response includes type 136', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({
+      recordsToReturn: [
+        { channel: 0, type: 136, value: { latitude: 48.8566, longitude: 2.3522, altitude: 35 } },
+        { channel: 1, type: 103, value: 22.0 },
+      ],
+    });
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'companion-b', telemetryEnabled: true, advType: 1, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+          upsertNode,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(4) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: 'companion-b', latitude: 48.8566, longitude: 2.3522 }),
+      'src-a',
+    );
+  });
+
+  it('does not persist GPS position when LPP type 136 value is Null Island (0,0)', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({
+      recordsToReturn: [
+        { channel: 0, type: 136, value: { latitude: 0, longitude: 0, altitude: 0 } },
+      ],
+    });
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'companion-c', telemetryEnabled: true, advType: 1, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+          upsertNode,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(3) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('does not persist GPS position when LPP type 136 value lacks lat/lon fields', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({
+      recordsToReturn: [
+        { channel: 0, type: 136, value: { altitude: 35 } }, // lat/lon missing
+      ],
+    });
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'companion-d', telemetryEnabled: true, advType: 1, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+          upsertNode,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(1) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
   it('does not insert when both status and LPP are empty on a Repeater', async () => {
     const now = 10_000_000;
     const manager = makeFakeManager({ statusToReturn: null, recordsToReturn: [] });

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -30,6 +30,7 @@ import type {
 } from '../meshcoreManager.js';
 import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
 import { MC_TELEMETRY_PREFIX, nodeNumFromPubkey } from './meshcoreTelemetryPoller.js';
+import { isNullIsland } from '../../utils/nullIsland.js';
 
 /**
  * `adv_type` values for MeshCore contacts. Matches the `MeshCoreDeviceType`
@@ -41,6 +42,9 @@ import { MC_TELEMETRY_PREFIX, nodeNumFromPubkey } from './meshcoreTelemetryPolle
  * advTypes use path #3 only.
  */
 const REPEATER_ADV_TYPES = new Set<number>([2, 3]);
+
+/** Cayenne-LPP type id for GPS/GNSS position records (lat/lon/alt object). */
+const LPP_GPS_TYPE = 136;
 
 /** Database surface the scheduler depends on (kept thin for testability). */
 export interface RemoteTelemetrySchedulerDatabase {
@@ -485,6 +489,36 @@ export class MeshCoreRemoteTelemetryScheduler {
         if (lppRows.length > 0) {
           rows.push(...lppRows);
           sources.push(`lpp:${lppRows.length}`);
+        }
+
+        // Persist GPS position (Cayenne-LPP type 136) to meshcore_nodes so that
+        // Contact Details always reflects the latest GNSS fix from a telemetry poll,
+        // not just the position carried in the last advert. Mirror of the batteryMv
+        // persistence above. Issue: https://github.com/Yeraze/meshmonitor/issues/3861
+        const gpsRecord = records.find(
+          (r) =>
+            r.type === LPP_GPS_TYPE &&
+            typeof r.value === 'object' &&
+            r.value !== null &&
+            !Array.isArray(r.value),
+        );
+        if (gpsRecord) {
+          const gpsVal = gpsRecord.value as Record<string, number>;
+          const lat = typeof gpsVal.latitude === 'number' ? gpsVal.latitude : null;
+          const lon = typeof gpsVal.longitude === 'number' ? gpsVal.longitude : null;
+          if (lat !== null && lon !== null && !isNullIsland(lat, lon)) {
+            try {
+              await this.database.meshcore.upsertNode(
+                { publicKey: target.publicKey, latitude: lat, longitude: lon },
+                manager.sourceId,
+              );
+            } catch (err) {
+              logger.warn(
+                `[MeshCoreRemoteTelem:${manager.sourceId}] Failed to persist GPS position for ${keyShort}…:`,
+                err,
+              );
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

When a MeshCore remote telemetry poll (LPP path) returns a GNSS fix (Cayenne-LPP type 136), the position data was stored only as telemetry rows for historical charting — the `meshcore_nodes.latitude`/`longitude` columns were never updated. This caused Contact Details to always show the position from the last advert broadcast, regardless of how recently telemetry polling refreshed the GNSS data.

This PR adds the missing position persistence, mirroring the existing `batteryMv` persistence path that was already implemented for low-battery notifications.

## Changes

- **`src/server/services/meshcoreRemoteTelemetryScheduler.ts`**: After processing LPP records in `requestTelemetryForNode()`, detect any type-136 GPS record and call `upsertNode` with the extracted lat/lon. The Null Island (0,0) guard from `persistContact` is applied to avoid writing pre-lock bogus fixes.
- **`src/server/services/meshcoreRemoteTelemetryScheduler.test.ts`**: Three new tests covering GPS persistence, Null Island rejection, and incomplete GPS records.

## Issues Resolved

Fixes #3861

## Documentation Updates

No documentation changes needed — this is an internal bug fix to existing behavior. The Contact Details position display now reflects the latest GNSS fix from any path (advert or telemetry poll), which is the already-documented expected behavior.

## Testing

- [x] Unit tests pass (35 tests in scheduler suite, full suite green)
- [x] TypeScript compiles cleanly (`tsc -p tsconfig.server.json --noEmit` exits 0)
- [x] Test: `persists GPS position to meshcore_nodes when LPP response includes type 136`
- [x] Test: `does not persist GPS position when LPP type 136 value is Null Island (0,0)`
- [x] Test: `does not persist GPS position when LPP type 136 value lacks lat/lon fields`
- [ ] Manual: Enable telemetry polling on a MeshCore companion with GNSS enabled; after one poll cycle, verify Contact Details position matches the telemetry-reported GPS fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_017a6oUKeWVDRVaMDv5tQRzd)_