### PR TITLE
fix: eliminate duplicate WARN log spam from security/telemetry checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3506,6 +3506,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3523,6 +3526,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3540,6 +3546,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3557,6 +3566,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3574,6 +3586,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3591,6 +3606,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3894,6 +3912,9 @@
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3506,9 +3506,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3526,9 +3523,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3546,9 +3540,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3566,9 +3557,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3586,9 +3574,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3606,9 +3591,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3912,9 +3894,6 @@
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -38,7 +38,7 @@ function sanitizeTelemetryTimestamp<T extends DbTelemetry>(row: T): T {
     if (row.packetTimestamp == null && Number.isFinite(ts)) {
       row.packetTimestamp = ts;
     }
-    logger.warn(
+    logger.debug(
       `Telemetry timestamp in the future for ${row.nodeId} (${row.telemetryType}): ` +
       `claimed=${ts}, using receipt=${receipt}`
     );

--- a/src/services/lowEntropyKeyService.ts
+++ b/src/services/lowEntropyKeyService.ts
@@ -92,13 +92,7 @@ export function checkLowEntropyKey(publicKey: string, format: 'hex' | 'base64' =
     const keyHash = hash.digest('hex');
 
     // Check against known bad key hashes
-    const isLowEntropy = LOW_ENTROPY_HASHES.includes(keyHash);
-
-    if (isLowEntropy) {
-      logger.warn(`🔐 Low-entropy public key detected! Hash: ${keyHash}`);
-    }
-
-    return isLowEntropy;
+    return LOW_ENTROPY_HASHES.includes(keyHash);
   } catch (error) {
     logger.error('Error checking low-entropy key:', error);
     return false;
@@ -146,9 +140,6 @@ export function detectDuplicateKeys(
   for (const [keyHash, nodeNums] of keyMap.entries()) {
     if (nodeNums.length > 1) {
       duplicates.set(keyHash, nodeNums);
-      logger.warn(
-        `🔐 Duplicate public key detected! Nodes ${nodeNums.join(', ')} share key hash: ${keyHash.substring(0, 16)}...`
-      );
     }
   }
 


### PR DESCRIPTION
## Summary

On large meshes, MeshMonitor's WARN logs were flooded with repetitive security and telemetry messages even when the log level was set to `warn`. This PR eliminates the noise by removing duplicate logging from pure utility functions and downgrading an auto-corrected condition from WARN to DEBUG.

## Changes

- **`src/services/lowEntropyKeyService.ts`** — Removed `logger.warn` from inside `checkLowEntropyKey()` and `detectDuplicateKeys()`. These are pure utility functions; all three call sites in `meshtasticManager.ts` and the `duplicateKeySchedulerService` already emit their own contextual warning when the check returns `true`. The internal log was producing 2–3 duplicate WARN lines per event.

- **`src/db/repositories/telemetry.ts`** — Downgraded `sanitizeTelemetryTimestamp()` from `logger.warn` → `logger.debug`. Future-dated telemetry timestamps are automatically corrected on ingest (the fix from issue #3362); the log line is purely informational. On a large mesh with a broken-clock node, this produced a WARN burst for every telemetry field (`latitude`, `longitude`, `altitude` are stored as separate entries) on every received packet.

## Issues Resolved

Fixes #3863

## Documentation Updates

No documentation changes needed — feature behavior is unchanged; only internal logging verbosity is reduced.

## Testing

- [x] Unit tests pass (7,731 passed, 0 new failures — 3 pre-existing protobuf/submodule failures exist on `main` too)
- [x] TypeScript compiles cleanly (`npx tsc -p tsconfig.server.json --noEmit`)
- [x] `lowEntropyKeyService.test.ts` — all 21 tests pass, including detection of low-entropy keys and duplicate-key pairs (return values unchanged, only the side-effect log was removed)
- [x] `duplicateKeySchedulerService.perSource.test.ts` + `.timeOffset.test.ts` — all 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCh9KLVR3evLMrYBxbvnHv)_