### PR TITLE
feat(meshcore): add {SCOPE} token to auto-acknowledge templates (#3865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **MeshCore auto-acknowledge `{SCOPE}` token** — Auto-acknowledge message templates can now include `{SCOPE}` to surface the region/scope the triggering message arrived on (e.g. `EU`, `Berlin`). Resolves to `(unscoped)` for explicitly unscoped messages and `—` when no scope information is available. (#3865)
+
 ## [4.12.2] - 2026-06-29
 
 ### Added

--- a/src/server/meshcoreManager.autoAckRoute.test.ts
+++ b/src/server/meshcoreManager.autoAckRoute.test.ts
@@ -1,10 +1,13 @@
 /**
- * Tests for the {ROUTE} auto-ack template variable expansion (#3776).
+ * Tests for the {ROUTE} and {SCOPE} auto-ack template variable expansion.
  *
- * MeshCore channel messages are length-limited (~120 chars with a scope) and
- * shorter messages transmit more reliably and cost less airtime. The {ROUTE}
- * variable therefore joins the relay-hash hop chain with a BARE arrow ("a→b→c")
- * — no surrounding spaces — to save 2 bytes per hop.
+ * {ROUTE} (#3776): MeshCore channel messages are length-limited (~120 chars
+ * with a scope) and shorter messages transmit more reliably and cost less
+ * airtime. The {ROUTE} variable therefore joins the relay-hash hop chain with
+ * a BARE arrow ("a→b→c") — no surrounding spaces — to save 2 bytes per hop.
+ *
+ * {SCOPE} (#3865): expands to the region name the incoming message was sent
+ * with, "(unscoped)" for explicitly unscoped messages, or "—" when unknown.
  *
  * `replaceAutoAckTokens` is private; we reach it via `(m as any)` rather than
  * spinning up a real backend/DB, mirroring the access pattern in
@@ -13,9 +16,15 @@
 import { describe, it, expect } from 'vitest';
 import { MeshCoreManager } from './meshcoreManager.js';
 
-function expand(template: string, route: string | null, hops: number | null): string {
+function expand(
+  template: string,
+  route: string | null,
+  hops: number | null,
+  scopeName?: string | null,
+  scopeCode?: number | null,
+): string {
   const m = new MeshCoreManager('test-source');
-  // Args: template, senderPubKey, senderName, snr, timestamp, hops, route
+  // Args: template, senderPubKey, senderName, snr, timestamp, hops, route, scopeName, scopeCode
   return (m as any).replaceAutoAckTokens(
     template,
     'deadbeefcafebabe0011223344556677',
@@ -24,6 +33,8 @@ function expand(template: string, route: string | null, hops: number | null): st
     Date.now(),
     hops,
     route,
+    scopeName,
+    scopeCode,
   );
 }
 
@@ -50,5 +61,36 @@ describe('replaceAutoAckTokens — {ROUTE} compaction (#3776)', () => {
 
   it('falls back to "—" when route and hop count are unknown', () => {
     expect(expand('{ROUTE}', null, null)).toBe('—');
+  });
+});
+
+describe('replaceAutoAckTokens — {SCOPE} (#3865)', () => {
+  it('expands to the region name when scopeName is set', () => {
+    expect(expand('{SCOPE}', null, null, 'EU')).toBe('EU');
+  });
+
+  it('expands to "(unscoped)" when scopeCode is 0 and no scopeName', () => {
+    expect(expand('{SCOPE}', null, null, null, 0)).toBe('(unscoped)');
+  });
+
+  it('expands to "(unscoped)" when scopeCode is 0 even if scopeName is empty', () => {
+    expect(expand('{SCOPE}', null, null, '', 0)).toBe('(unscoped)');
+  });
+
+  it('expands to "—" when both scopeName and scopeCode are null', () => {
+    expect(expand('{SCOPE}', null, null, null, null)).toBe('—');
+  });
+
+  it('expands to "—" when scope params are omitted entirely', () => {
+    expect(expand('{SCOPE}', null, null)).toBe('—');
+  });
+
+  it('uses scopeName over scopeCode when both are set', () => {
+    expect(expand('{SCOPE}', null, null, 'Berlin', 42)).toBe('Berlin');
+  });
+
+  it('works alongside other tokens in a combined template', () => {
+    const out = expand('{NODE_NAME} via {SCOPE} | {HOPS} hops | {ROUTE}', 'a3,7f', 2, 'EU');
+    expect(out).toBe('Tester via EU | 2 hops | a3→7f');
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5511,6 +5511,8 @@ class MeshCoreManager extends EventEmitter {
     timestamp: number,
     hops: number | null,
     route: string | null,
+    scopeName?: string | null,
+    scopeCode?: number | null,
   ): string {
     const date = new Date(timestamp);
     const longName = senderName || `${senderPubKey.substring(0, 8)}…`;
@@ -5537,6 +5539,16 @@ class MeshCoreManager extends EventEmitter {
     } else {
       routeStr = '—';
     }
+    // {SCOPE} resolves to the region name when known, "(unscoped)" when the
+    // message was explicitly unscoped (scopeCode === 0), or "—" otherwise (#3865).
+    let scopeStr: string;
+    if (scopeName && scopeName.length > 0) {
+      scopeStr = scopeName;
+    } else if (scopeCode === 0) {
+      scopeStr = '(unscoped)';
+    } else {
+      scopeStr = '—';
+    }
 
     return template
       .replace(/\{NODE_ID\}/g, nodeId)
@@ -5549,6 +5561,7 @@ class MeshCoreManager extends EventEmitter {
       .replace(/\{HOPS\}/g, hopsStr)
       .replace(/\{NUMBER_HOPS\}/g, hopsStr)
       .replace(/\{ROUTE\}/g, routeStr)
+      .replace(/\{SCOPE\}/g, scopeStr)
       .replace(/\{VERSION\}/g, '4.8.0');
   }
 
@@ -5642,6 +5655,8 @@ class MeshCoreManager extends EventEmitter {
         message.timestamp,
         hops,
         route,
+        message.scopeName,
+        message.scopeCode,
       );
 
       // Decide destination:


### PR DESCRIPTION
## Summary

Adds a `{SCOPE}` template token to MeshCore auto-acknowledge messages so operators can surface the region/scope an incoming message was sent on — useful for building region-aware ack templates on meshes that use scoped flooding (e.g. Germany mesh). The `scopeName` and `scopeCode` were already tracked on every `MeshCoreMessage`; this PR simply wires them through to the template renderer.

## Changes

- **`src/server/meshcoreManager.ts`** — added optional `scopeName` and `scopeCode` parameters to `replaceAutoAckTokens`; added `{SCOPE}` substitution (resolves to region name, `(unscoped)`, or `—`); updated the one call site in `checkAutoAcknowledge` to pass `message.scopeName` / `message.scopeCode`
- **`src/server/meshcoreManager.autoAckRoute.test.ts`** — updated the `expand` helper to forward scope params; added 7 new test cases covering all `{SCOPE}` resolution branches
- **`CHANGELOG.md`** — added entry under `[Unreleased]`

**Token resolution rules:**

| Condition | `{SCOPE}` expands to |
|---|---|
| `scopeName` is a non-empty string | the region name (e.g. `EU`, `Berlin`) |
| `scopeCode === 0` (explicitly unscoped) | `(unscoped)` |
| no scope info | `—` |

**Example template:**
```
{NODE_NAME} via {SCOPE} | {HOPS} hops | {ROUTE}
```

## Issues Resolved

Fixes #3865

## Documentation Updates

CHANGELOG.md updated. The MeshCore auto-ack token set (`{ROUTE}`, `{HOPS}`, `{SNR}`, etc.) isn't yet listed in a public docs section — a follow-up to add a MeshCore auto-ack token reference table to `docs/features/meshcore.md` would be worth doing, but is out of scope for this targeted token addition.

## Testing

- [ ] Unit tests pass (CI) — 7 new `{SCOPE}` test cases added to `meshcoreManager.autoAckRoute.test.ts`; all existing `{ROUTE}` tests preserved
- [ ] TypeScript compiles cleanly (CI)
- [ ] Manual: configure a MeshCore auto-ack template containing `{SCOPE}`, trigger it with a scoped/unscoped message, verify the ack contains the correct region name / `(unscoped)` / `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp1jMTMwUMLFhhdM1Ykkxh)_