### PR TITLE
fix(meshcore): filter repeaters out of DM contact list (#3867)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -437,7 +437,7 @@ describe('MeshCoreDirectMessagesView — repeaters are not messageable (#3755)',
     lastSeen: Date.now(),
   };
 
-  it('keeps the repeater listed in the contact sidebar (still browsable)', () => {
+  it('filters repeaters out of the DM contact sidebar (#3809/#3867)', () => {
     render(
       <MeshCoreDirectMessagesView
         messages={messages}
@@ -446,26 +446,9 @@ describe('MeshCoreDirectMessagesView — repeaters are not messageable (#3755)',
         actions={makeActions()}
       />,
     );
-    // Repeaters are NOT filtered out of the list — only their messaging is removed.
+    // Companions appear in the DM list; repeaters are excluded entirely.
     expect(screen.getByText('Remote Bob')).toBeTruthy();
-    expect(screen.getByText('Repeater Rita')).toBeTruthy();
-  });
-
-  it('hides the message composer and shows a notice when a repeater is selected', () => {
-    render(
-      <MeshCoreDirectMessagesView
-        messages={messages}
-        contacts={[realContact, repeaterContact]}
-        status={makeStatus()}
-        actions={makeActions()}
-      />,
-    );
-    fireEvent.click(screen.getByText('Repeater Rita'));
-
-    // No compose input for a repeater — the messaging feature is gone, not just disabled.
-    expect(screen.queryByPlaceholderText('Type a message…')).toBeNull();
-    // Replaced by an explanatory notice.
-    expect(screen.getByText(/Repeaters cannot receive direct messages/i)).toBeTruthy();
+    expect(screen.queryByText('Repeater Rita')).toBeNull();
   });
 
   it('still renders the message composer for a normal (companion) contact', () => {
@@ -483,22 +466,30 @@ describe('MeshCoreDirectMessagesView — repeaters are not messageable (#3755)',
     expect(screen.queryByText(/Repeaters cannot receive direct messages/i)).toBeNull();
   });
 
-  it('still renders node details (telemetry) for a selected repeater', async () => {
+  it('also filters repeaters surfaced via message history (#3809/#3867)', () => {
+    // A repeater key that appeared in a DM message (edge case from before the fix)
+    // should still be excluded from the sidebar.
+    const repeaterMsg = {
+      id: 'msg-1',
+      fromPublicKey: REAL_PK_2, // repeater's key
+      toPublicKey: 'self'.padEnd(64, '0'),
+      text: 'ghost message',
+      timestamp: Date.now(),
+      messageType: 'private' as const,
+    };
+
     render(
       <MeshCoreDirectMessagesView
-        messages={messages}
+        messages={[repeaterMsg as any]}
         contacts={[realContact, repeaterContact]}
         status={makeStatus()}
         actions={makeActions()}
-        baseUrl=""
-        sourceId="src-a"
       />,
     );
-    fireEvent.click(screen.getByText('Repeater Rita'));
 
-    // The detail/telemetry side still mounts even though messaging is removed.
-    await waitFor(() => {
-      expect(screen.getByText('Telemetry Retrieval')).toBeTruthy();
-    });
+    // The repeater key came in via message history but the safety filter removes it.
+    expect(screen.queryByText('Repeater Rita')).toBeNull();
+    // Normal contact still present.
+    expect(screen.getByText('Remote Bob')).toBeTruthy();
   });
 });

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -182,8 +182,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     }
     // Always include all contacts so the user can start a new DM.
     // Exclude room servers (advType=3) — they belong in the Rooms view.
+    // Exclude repeaters (advType=2) — they cannot receive DMs; use the Node List to access their telemetry/admin panels.
     for (const c of contacts) {
-      if (c.publicKey && !isChannelPseudoKey(c.publicKey) && c.advType !== 3) peers.add(c.publicKey);
+      if (c.publicKey && !isChannelPseudoKey(c.publicKey) && c.advType !== 3 && c.advType !== 2) peers.add(c.publicKey);
     }
     // Drop the local node — DMing yourself is meaningless and the local node
     // sometimes appears in the contacts list as a side-effect of seeding.
@@ -197,7 +198,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
       return c?.advName || c?.name || key;
     };
     const dir = sortDirection === 'asc' ? 1 : -1;
-    return Array.from(peers).sort((a, b) => {
+    return Array.from(peers)
+      .filter(key => contactsByKey.get(key)?.advType !== 2)
+      .sort((a, b) => {
       // Favorites pin to the top regardless of sort field/direction, matching
       // the Meshtastic DM list and the MeshCore node list (issue #3620).
       const aFav = favoriteByKey.get(a) ?? false;


### PR DESCRIPTION
## Summary

- Issue #3809 was closed as "completed" but the `advType === 2` guard was never actually applied to `MeshCoreDirectMessagesView.tsx`, so repeaters continued appearing in the Direct Messages sidebar through v4.12.2 (re-reported as #3867).
- Adds `&& c.advType !== 2` to the contacts loop alongside the existing room-server (`advType === 3`) exclusion.
- Adds a safety `.filter()` before the sort step to also catch any repeater key that entered via message history (edge case from before #3755).

## Changes

**`src/components/MeshCore/MeshCoreDirectMessagesView.tsx`**
- `dmPeers` contacts loop: extend the `advType !== 3` guard to also exclude `advType !== 2` (repeaters).
- `dmPeers` return: add `.filter(key => contactsByKey.get(key)?.advType !== 2)` before `.sort()` as a second safety layer for keys surfaced via message history.

**`src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx`**
- Flipped `#3755` test "keeps the repeater listed in the contact sidebar" → now asserts the repeater is **not** shown.
- Removed the "select repeater in DM view for telemetry" test — repeaters are no longer reachable from the DM view; use the Node List instead.
- Added new test: "also filters repeaters surfaced via message history" to cover the edge-case safety filter.

## Test plan

- [x] `MeshCoreDirectMessagesView.test.tsx` — all 15 tests pass locally
- [ ] Verify repeaters no longer appear in the DM sidebar in the running container
- [ ] Confirm repeater telemetry/admin is still accessible via the Node List view

Fixes #3867
Closes #3809

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGS82LhhsVYRb81g5E2zBh)_