### PR TITLE
fix(meshcore,permissions): rename Direct Messages tab + permission to reflect Node Details scope (#3867)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4360,7 +4360,7 @@
   "meshcore.nav.channels": "Channels",
   "meshcore.nav.collapse": "Collapse",
   "meshcore.nav.configuration": "Configuration",
-  "meshcore.nav.dms": "Direct Messages",
+  "meshcore.nav.dms": "Node Details",
   "meshcore.nav.expand": "Expand",
   "meshcore.nav.nodes": "Nodes",
   "meshcore.nav.notifications": "Notifications",

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -273,7 +273,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
           </button>
           {!isCollapsed && (
             <>
-              <span>{t('meshcore.nav.dms', 'Direct Messages')}</span>
+              <span>{t('meshcore.nav.dms', 'Node Details')}</span>
               <span className="pane-count">{dmPeers.length}</span>
               <div className="sort-controls meshcore-sort-controls">
                 <select

--- a/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
@@ -65,7 +65,7 @@ describe('MeshCoreSubToolbar', () => {
     // Other tabs still visible.
     expect(screen.getByText('Nodes')).toBeDefined();
     expect(screen.getByText('Channels')).toBeDefined();
-    expect(screen.getByText('Direct Messages')).toBeDefined();
+    expect(screen.getByText('Node Details')).toBeDefined();
     expect(screen.getByText('Settings')).toBeDefined();
   });
 });

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -28,7 +28,7 @@ const ITEMS: Item[] = [
   { id: 'nodes', labelKey: 'meshcore.nav.nodes', fallback: 'Nodes' },
   { id: 'channels', labelKey: 'meshcore.nav.channels', fallback: 'Channels' },
   { id: 'rooms', labelKey: 'meshcore.nav.rooms', fallback: 'Rooms' },
-  { id: 'dms', labelKey: 'meshcore.nav.dms', fallback: 'Direct Messages' },
+  { id: 'dms', labelKey: 'meshcore.nav.dms', fallback: 'Node Details' },
   { id: 'telemetry', labelKey: 'meshcore.nav.telemetry', fallback: 'Telemetry' },
   { id: 'packets', labelKey: 'meshcore.nav.packets', fallback: 'Packet Monitor' },
   { id: 'info', labelKey: 'meshcore.nav.info', fallback: 'Node Info' },

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -28,6 +28,8 @@ const ITEMS: Item[] = [
   { id: 'nodes', labelKey: 'meshcore.nav.nodes', fallback: 'Nodes' },
   { id: 'channels', labelKey: 'meshcore.nav.channels', fallback: 'Channels' },
   { id: 'rooms', labelKey: 'meshcore.nav.rooms', fallback: 'Rooms' },
+  // id/key remain 'dms' for backward-compat; the visible label was renamed to
+  // 'Node Details' to reflect the view's full scope (#3867).
   { id: 'dms', labelKey: 'meshcore.nav.dms', fallback: 'Node Details' },
   { id: 'telemetry', labelKey: 'meshcore.nav.telemetry', fallback: 'Telemetry' },
   { id: 'packets', labelKey: 'meshcore.nav.packets', fallback: 'Packet Monitor' },

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -630,7 +630,10 @@ const UsersTab: React.FC = () => {
   const labelMap: Record<string, string> = {
     dashboard: 'Source Status',
     nodes: 'Node Map & List',
-    messages: t('nav.messages'),
+    // The `messages` permission gates both the Node Details view and direct
+    // messaging, so label it to reflect its full impact (issue #3867). Reuses the
+    // translated "Node Details" tab label and appends the DM scope.
+    messages: `${t('nav.messages')} & DM`,
     settings: t('nav.settings'),
     configuration: t('nav.configuration'),
     info: t('nav.info'),
@@ -650,7 +653,7 @@ const UsersTab: React.FC = () => {
     dashboard: 'Controls visibility of source cards on the main dashboard. Does NOT include node or message access — grant those separately.',
     nodes: 'Read: view node list, neighbor info, and map markers. Write: edit node names/notes.',
     nodes_private: 'Read: view detailed position history for individual nodes.',
-    messages: 'Read: view messages and channel list. Write: send messages.',
+    messages: 'Read: view node details, messages, and channel list. Write: send direct messages.',
     settings: 'Read: view global settings. Write: change settings, map styles, GeoJSON layers.',
     configuration: 'Read: view device configuration. Write: change device radio/module settings.',
     info: 'Read: view device info and statistics.',

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -106,7 +106,7 @@ export const RESOURCES: readonly ResourceDefinition[] = [
   { id: 'channel_5', name: 'Channel 5', description: 'View and send messages to channel 5' },
   { id: 'channel_6', name: 'Channel 6', description: 'View and send messages to channel 6' },
   { id: 'channel_7', name: 'Channel 7', description: 'View and send messages to channel 7' },
-  { id: 'messages', name: 'Direct Messages', description: 'Send and receive direct messages' },
+  { id: 'messages', name: 'Node Details & DM', description: 'View node details and send/receive direct messages' },
   { id: 'settings', name: 'Settings', description: 'Application settings' },
   { id: 'configuration', name: 'Configuration', description: 'Device configuration' },
   { id: 'info', name: 'Info', description: 'Telemetry and network information' },


### PR DESCRIPTION
## Summary

Addresses #3867 by renaming labels that understated their true impact. The MeshCore "Direct Messages" tab and the `messages` permission both gate the **Node Details** view in addition to direct messaging.

## Changes

### MeshCore tab rename → "Node Details"
- A single key `meshcore.nav.dms` drives both the sub-toolbar tab and the DM-view pane header.
- Updated the English value in `public/locales/en.json` and the inline fallbacks in `MeshCoreSubToolbar.tsx` / `MeshCoreDirectMessagesView.tsx`.
- Matches the existing Meshtastic rename (`nav.messages` → "Node Details"). Non-English locales follow the same precedent (translators backfill).

### Permission rename → "Node Details & DM" (all source types)
- The per-source permission grid in `UsersTab.tsx` renders every source type's permission labels via `labelMap[resource]`, so the change applies uniformly to Meshtastic / MQTT / MeshCore.
- `labelMap.messages` is now `` `${t('nav.messages')} & DM` `` → **"Node Details & DM"**, reusing the translated "Node Details" label for i18n consistency.
- Updated the hover tooltip and the canonical `RESOURCES` definition in `src/types/permission.ts` (name + description).

### Out of scope
- The permission `id` (`messages`), permission checks, and DB rows are unchanged — display strings only.
- Note: the original report in #3867 also mentions repeaters appearing in the DM peer list (a separate filtering concern). This PR covers the label/impact-clarity rename; the peer-list filtering is not addressed here.

## Testing
- `MeshCoreSubToolbar.test.tsx`: PASS (4) — updated assertion to "Node Details".
- `UsersTab.test.tsx`: PASS (6).
- `tsc`: no new errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NnNR1gD45VxgB249xaTS4