### PR TITLE
fix: section-nav sticks below header instead of scrolling behind it

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2813,7 +2813,7 @@ body {
   border: 1px solid var(--ctp-surface1);
   border-radius: var(--radius-lg);
   position: sticky;
-  top: 0;
+  top: var(--header-height);
   z-index: 10;
 }
 


### PR DESCRIPTION
## Summary

- Fixes #3872 — on any configuration page the sticky section navigation bar would scroll behind the fixed app header
- Root cause: `.section-nav` had `position: sticky; top: 0` which anchors it at the very top of the viewport — directly behind the fixed 60px header
- Fix: change `top: 0` to `top: var(--header-height)` so the bar sticks just below the header

## Change

**`src/App.css`** — 1 line changed:
```css
/* before */
top: 0;

/* after */
top: var(--header-height);   /* = 60px; keeps sticky nav below the fixed header */
```

## Test plan

- [ ] Open a source device → Device Configuration tab
- [ ] Scroll down on the configuration page
- [ ] Verify the section nav bar stays visible below the header and does not slide behind it
- [ ] Check on mobile (narrow viewport) — horizontal-scroll mode still works correctly
- [ ] Verify other sticky elements (map overlays, table headers) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEYGobudNQUZ2UHEZYY9Mu

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEYGobudNQUZ2UHEZYY9Mu)_