### PR TITLE
fix(meshcore): bridge DM acks + inbound hop count to the Virtual Node (#3869, #3871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - **MeshCore auto-acknowledge `{SCOPE}` token** — Auto-acknowledge message templates can now include `{SCOPE}` to surface the region/scope the triggering message arrived on (e.g. `EU`, `Berlin`). Resolves to `(unscoped)` for explicitly unscoped messages and `—` when no scope information is available. (#3865)
 
+### Fixed
+- **MeshCore Virtual Node: DM marked Failed despite delivery (no ACK returned)** — A direct message sent through a MeshCore companion connected via the Virtual Node was delivered, but its delivery ACK was never forwarded to the companion, so the companion retransmitted three times and finally marked it **Failed**. The Virtual Node bridge now puts the firmware's real ack CRC in the `Sent` response and forwards the matching `SendConfirmed` push to the originating companion, so the message is correctly marked delivered. (#3869)
+- **MeshCore Virtual Node: incoming messages always shown as "direct"** — Received channel and direct messages were forwarded to a Virtual Node companion with a hardcoded "direct" path length, hiding the real hop count. The actual `path_len` is now forwarded so the companion shows the correct number of hops. *(The related "heard by N repeaters" count for **outgoing** channel messages remains MeshMonitor-UI-only — a channel send is an unacked flood and the companion protocol has no frame to carry a post-send relay tally; see #3871.)* (#3871)
+
 ## [4.12.2] - 2026-06-29
 
 ### Added

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -22,6 +22,7 @@ import {
   encodeContactMsgRecv,
   encodeChannelMsgRecv,
   encodeSent,
+  encodeSendConfirmed,
   encodeNoMoreMessages,
   packTelemetryMode,
   pubKeyHexToBytes,
@@ -200,6 +201,14 @@ describe('meshcoreCompanionCodec — encoders round-trip through meshcore.js dec
     expect(decoded.result).toBe(0);
     expect(decoded.expectedAckCrc).toBe(0xdeadbeef);
     expect(decoded.estTimeout).toBe(8000);
+  });
+
+  it('SendConfirmed(0x82) decodes ackCode and roundTrip (#3869)', async () => {
+    // Round-trips through meshcore.js's own onSendConfirmedPush decoder, proving
+    // the byte layout matches what a real companion app expects.
+    const decoded = await decodeWithMeshcore(0x82, encodeSendConfirmed(0xdeadbeef, 1500));
+    expect(decoded.ackCode).toBe(0xdeadbeef);
+    expect(decoded.roundTrip).toBe(1500);
   });
 
   it('ChannelMsgRecv decodes channel index and text', async () => {

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -447,6 +447,22 @@ export function encodeSent(result: number, expectedAckCrc = 0, estTimeout = 0): 
   return b;
 }
 
+/**
+ * Encode a SendConfirmed(0x82) push — the node telling the app that a DM it
+ * sent was delivered (the mesh ACK matched). `ackCode` is the same CRC the app
+ * received in the preceding `Sent(6)` response (`expectedAckCrc`), which is how
+ * the app correlates this push to its pending message; `roundTripMs` is the
+ * measured delivery time. Layout mirrors meshcore.js's decode of this push
+ * (`connection.js onSendConfirmedPush`): `[0x82][ackCode:u32LE][roundTrip:u32LE]`.
+ */
+export function encodeSendConfirmed(ackCode: number, roundTripMs = 0): Buffer {
+  const b = Buffer.alloc(1 + 4 + 4);
+  b[0] = PushCodes.SendConfirmed;
+  b.writeUInt32LE(ackCode >>> 0, 1);
+  b.writeUInt32LE(roundTripMs >>> 0, 5);
+  return b;
+}
+
 /** Encode a NoMoreMessages(10) response — mailbox drained. */
 export function encodeNoMoreMessages(): Buffer {
   return Buffer.from([ResponseCodes.NoMoreMessages]);

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -367,6 +367,19 @@ export interface MeshCoreContact {
   outPath?: string | null;
 }
 
+/**
+ * Result of a MeshCore send. `ok` mirrors the legacy boolean return of
+ * `sendMessage`; for a DM the firmware also assigns an `expectedAckCrc` (the
+ * value a later SendConfirmed push will carry) and an `estTimeout` hint, both
+ * surfaced via {@link MeshCoreManager.sendMessageWithResult} for the Virtual
+ * Node ack bridge (#3869). Channel sends are unacked, so these are undefined.
+ */
+export interface MeshCoreSendResult {
+  ok: boolean;
+  expectedAckCrc?: number;
+  estTimeout?: number;
+}
+
 export interface MeshCoreMessage {
   id: string;
   fromPublicKey: string;
@@ -400,6 +413,10 @@ export interface MeshCoreMessage {
   /** Hop count for a received message (from path_len); null = direct / unknown.
    *  Room messages carry no path, so this stays null for them. (#3742) */
   hopCount?: number | null;
+  /** Raw packed `path_len` byte as reported by the device for a received message
+   *  (0xff = direct). Preserved verbatim so the Virtual Node bridge can forward
+   *  the real hop count to a companion instead of always "direct" (#3871). */
+  pathLen?: number | null;
   /** Relay-hash chain the message traveled, comma-separated (e.g. "a3,7f,02");
    *  null when no path was reported. (#3742) */
   routePath?: string | null;
@@ -1076,6 +1093,9 @@ class MeshCoreManager extends EventEmitter {
         snr: data.snr,
         sourceId: this.sourceId,
         hopCount,
+        // Raw packed path_len byte (0xff = direct) so the Virtual Node bridge
+        // can forward the real hop count to a companion instead of "direct" (#3871).
+        pathLen: data.path_len ?? null,
         routePath: observedRoute,
         scopeCode: scope.scopeCode,
         scopeName: scope.scopeName,
@@ -1109,6 +1129,9 @@ class MeshCoreManager extends EventEmitter {
         snr: data.snr,
         sourceId: this.sourceId,
         hopCount,
+        // Raw packed path_len byte (0xff = direct) so the Virtual Node bridge
+        // can forward the real hop count to a companion instead of "direct" (#3871).
+        pathLen: data.path_len ?? null,
         routePath: route,
         scopeCode: scope.scopeCode,
         scopeName: scope.scopeName,
@@ -1499,6 +1522,14 @@ class MeshCoreManager extends EventEmitter {
         this.sourceId,
       );
       const fullHeardBy = all.map((r) => ({ hash: r.repeaterHash, name: r.repeaterName, snr: r.snr }));
+      // This relay count is surfaced to MeshMonitor's own UI only. It is NOT
+      // forwarded to a Virtual Node companion, by protocol necessity (#3871):
+      // a channel send is an unacked fire-and-forget flood, so the companion
+      // already got `Ok(0)` and closed the send; the count is a MeshMonitor-
+      // derived metric that accrues asynchronously (here, up to HEARD_WINDOW_MS
+      // later) and the companion protocol has no push frame or message handle to
+      // annotate an already-sent channel message with it. The DM ack path
+      // (SendConfirmed 0x82) IS bridged because DMs have real delivery semantics.
       dataEventEmitter.emitMeshCoreChannelHeard({ id: match.messageId, heardBy: fullHeardBy }, this.sourceId);
 
       // Mirror heardBy into the in-memory pool so getRecentMessages() returns
@@ -2284,14 +2315,25 @@ class MeshCoreManager extends EventEmitter {
    * when only channel 0 was supported (issue follow-up to MeshCore channels plan).
    */
   async sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<boolean> {
+    return (await this.sendMessageWithResult(text, toPublicKey, channelIdx, scopeOverride)).ok;
+  }
+
+  /**
+   * Like {@link sendMessage}, but returns the firmware-assigned `expectedAckCrc`
+   * and `estTimeout` alongside the boolean. The Virtual Node bridge uses these
+   * to tell a connected companion which CRC to expect in its `Sent` response and
+   * to forward the later `SendConfirmed` push when the DM is acked (#3869).
+   * `sendMessage` delegates here and discards the extra fields.
+   */
+  async sendMessageWithResult(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<MeshCoreSendResult> {
     if (!this.connected) {
       logger.error('[MeshCore] Not connected');
-      return false;
+      return { ok: false };
     }
 
     if (this.deviceType === MeshCoreDeviceType.REPEATER) {
       logger.warn('[MeshCore] Repeaters cannot send messages');
-      return false;
+      return { ok: false };
     }
 
     // Serialise the scope-assert→send pair per source (#3667). The device's
@@ -2430,7 +2472,7 @@ class MeshCoreManager extends EventEmitter {
     }
   }
 
-  private async performScopedSend(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<boolean> {
+  private async performScopedSend(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<MeshCoreSendResult> {
     try {
       const isChannelSend = !toPublicKey && channelIdx !== undefined;
 
@@ -2502,14 +2544,14 @@ class MeshCoreManager extends EventEmitter {
           this.registerPendingChannelSend(msgId, channelIdx!);
         }
 
-        return true;
+        return { ok: true, expectedAckCrc: ackCrc ?? undefined, estTimeout: estTimeout ?? undefined };
       } else {
         logger.error('[MeshCore] Send failed:', response.error);
-        return false;
+        return { ok: false };
       }
     } catch (error) {
       logger.error('[MeshCore] Failed to send message:', error);
-      return false;
+      return { ok: false };
     }
   }
 

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -57,13 +57,18 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
     this.contacts = contacts;
   }
   sendMessageMock = vi.fn().mockResolvedValue(true);
+  sendMessageWithResultMock = vi.fn().mockResolvedValue({ ok: true });
   isConnected() { return this.localNode !== null; }
   getLocalNode() { return this.localNode; }
   getContacts() { return this.contacts; }
   sendMessage(text: string, toPublicKey?: string, channelIdx?: number) {
     return this.sendMessageMock(text, toPublicKey, channelIdx) as Promise<boolean>;
   }
+  sendMessageWithResult(text: string, toPublicKey?: string, channelIdx?: number) {
+    return this.sendMessageWithResultMock(text, toPublicKey, channelIdx) as Promise<{ ok: boolean; expectedAckCrc?: number; estTimeout?: number }>;
+  }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
+  emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
 }
 
 const CHANNELS_DB = {
@@ -321,13 +326,17 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     expect(manager.sendMessageMock).toHaveBeenCalledWith('hi chan', undefined, 1);
   });
 
-  it('forwards SendTxtMsg as a DM after resolving the contact prefix, replies Sent', async () => {
+  it('forwards SendTxtMsg as a DM after resolving the contact prefix, replies Sent with the real ack CRC (#3869)', async () => {
+    manager.sendMessageWithResultMock.mockResolvedValueOnce({ ok: true, expectedAckCrc: 0xdeadbeef, estTimeout: 9000 });
     const prefix = Buffer.from('b1'.repeat(6), 'hex'); // first 6 bytes of the sample contact
     // [code=2][txtType=0][attempt=0][senderTimestamp:u32=0][prefix:6][text]
     const frame = [CommandCodes.SendTxtMsg, 0, 0, 0, 0, 0, 0, ...prefix, ...Buffer.from('hi dm', 'utf8')];
     const payload = await client.request(frame);
     expect(payload[0]).toBe(ResponseCodes.Sent);
-    expect(manager.sendMessageMock).toHaveBeenCalledWith('hi dm', 'b1'.repeat(32), undefined);
+    // The Sent response must carry the firmware's real ack CRC so the app can
+    // correlate the later SendConfirmed push (not the old hardcoded 0).
+    expect(Buffer.from(payload).readUInt32LE(2)).toBe(0xdeadbeef);
+    expect(manager.sendMessageWithResultMock).toHaveBeenCalledWith('hi dm', 'b1'.repeat(32), undefined);
   });
 
   it('replies Err(NotFound) for a DM to an unknown contact prefix', async () => {
@@ -348,6 +357,46 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
 
   it('counts connected clients', () => {
     expect(server.getClientCount()).toBe(1);
+  });
+
+  it('pushes SendConfirmed(0x82) to the originating client when its DM is acked (#3869)', async () => {
+    manager.sendMessageWithResultMock.mockResolvedValueOnce({ ok: true, expectedAckCrc: 0x1234, estTimeout: 9000 });
+    const prefix = Buffer.from('b1'.repeat(6), 'hex');
+    const frame = [CommandCodes.SendTxtMsg, 0, 0, 0, 0, 0, 0, ...prefix, ...Buffer.from('hi dm', 'utf8')];
+    expect((await client.request(frame))[0]).toBe(ResponseCodes.Sent);
+
+    // The mesh acks the DM → the server pushes an unsolicited SendConfirmed.
+    const pushP = client.expectFrames(1);
+    manager.emitSendConfirmed({ ackCode: 0x1234, roundTripMs: 1500 });
+    const [push] = await pushP;
+    expect(push[0]).toBe(0x82); // PushCodes.SendConfirmed
+    expect(Buffer.from(push).readUInt32LE(1)).toBe(0x1234); // ack CRC matches the Sent response
+    expect(Buffer.from(push).readUInt32LE(5)).toBe(1500); // round-trip ms
+  });
+
+  it('ignores a send_confirmed whose CRC no connected client is awaiting (#3869)', async () => {
+    let pushed = false;
+    void client.expectFrames(1).then(() => { pushed = true; });
+    manager.emitSendConfirmed({ ackCode: 0x9999, roundTripMs: 10 }); // never sent by this client
+    await new Promise((r) => setTimeout(r, 40));
+    expect(pushed).toBe(false);
+  });
+
+  it('forwards the real hop count (pathLen) on an incoming channel message instead of "direct" (#3871)', () => {
+    const frame = (server as unknown as { encodeIncomingMessage(m: MeshCoreMessage): Buffer }).encodeIncomingMessage({
+      id: 'm1', fromPublicKey: 'channel-2', fromName: 'Alice', text: 'hi', timestamp: Date.now(), pathLen: 3,
+    } as MeshCoreMessage);
+    // ChannelMsgRecv frame: [code][channelIdx][pathLen][txtType][ts:4][text]
+    expect(frame[0]).toBe(ResponseCodes.ChannelMsgRecv);
+    expect(frame[1]).toBe(2); // channelIdx
+    expect(frame[2]).toBe(3); // real pathLen (was hardcoded 0xff before #3871)
+  });
+
+  it('falls back to 0xff (direct) when an incoming message has no pathLen (#3871)', () => {
+    const frame = (server as unknown as { encodeIncomingMessage(m: MeshCoreMessage): Buffer }).encodeIncomingMessage({
+      id: 'm2', fromPublicKey: 'channel-0', text: 'x', timestamp: Date.now(),
+    } as MeshCoreMessage);
+    expect(frame[2]).toBe(0xff);
   });
 });
 

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -22,6 +22,7 @@ import {
   encodeChannelMsgRecv,
   encodeMsgWaitingPush,
   encodeSent,
+  encodeSendConfirmed,
   encodeNoMoreMessages,
   encodeOk,
   encodeErr,
@@ -48,9 +49,22 @@ export interface MeshCoreVirtualNodeManager {
   getContacts(): MeshCoreContact[];
   /** Send a text message to the real node: channel (by index) or DM (full key). */
   sendMessage(text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean>;
+  /**
+   * Send a DM and return the firmware-assigned `expectedAckCrc`/`estTimeout` so
+   * the bridge can put the real CRC in the `Sent` response and later correlate
+   * the `send_confirmed` push to it (#3869).
+   */
+  sendMessageWithResult(
+    text: string,
+    toPublicKey?: string,
+    channelIdx?: number,
+  ): Promise<{ ok: boolean; expectedAckCrc?: number; estTimeout?: number }>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
+  /** The manager emits 'send_confirmed' when a sent DM is acked (#3869). */
+  on(event: 'send_confirmed', listener: (data: { ackCode: number; roundTripMs: number }) => void): unknown;
+  off(event: 'send_confirmed', listener: (data: { ackCode: number; roundTripMs: number }) => void): unknown;
 }
 
 /** Reverse map of command codes → names, for human-readable command logging. */
@@ -126,6 +140,16 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   private nextClientId = 1;
   private cleanupTimer: NodeJS.Timeout | null = null;
   private readonly onManagerMessage = (msg: MeshCoreMessage) => this.handleIncomingMessage(msg);
+  private readonly onManagerSendConfirmed = (data: { ackCode: number; roundTripMs: number }) =>
+    this.handleSendConfirmed(data);
+  /**
+   * Pending DM acks: `expectedAckCrc` → clientId of the companion that sent it.
+   * Populated when a client sends a DM, consumed when the matching
+   * `send_confirmed` arrives so we push the SendConfirmed(0x82) to that client
+   * only (#3869). The manager's `send_confirmed` is source-global, so without
+   * this map a second companion would see another's confirmation.
+   */
+  private readonly pendingAcks = new Map<number, string>();
 
   private readonly MAX_FRAME_BYTES = 4096;
   private readonly CLIENT_TIMEOUT_MS = 300000; // 5 min inactivity
@@ -162,6 +186,8 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         this.cleanupTimer = setInterval(() => this.cleanupInactiveClients(), this.CLEANUP_INTERVAL_MS);
         // Relay live incoming mesh messages to connected app clients.
         this.options.manager.on('message', this.onManagerMessage);
+        // Forward DM delivery acks back to the originating companion (#3869).
+        this.options.manager.on('send_confirmed', this.onManagerSendConfirmed);
         this.emit('listening');
         resolve();
       });
@@ -177,6 +203,8 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     }
 
     this.options.manager.off('message', this.onManagerMessage);
+    this.options.manager.off('send_confirmed', this.onManagerSendConfirmed);
+    this.pendingAcks.clear();
 
     for (const client of this.clients.values()) {
       client.socket.destroy();
@@ -247,6 +275,11 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     const client = this.clients.get(clientId);
     if (!client) return;
     this.clients.delete(clientId);
+    // Drop any unconfirmed DM acks this client was awaiting so the map doesn't
+    // leak entries for acks that will never be claimed (#3869).
+    for (const [crc, owner] of this.pendingAcks) {
+      if (owner === clientId) this.pendingAcks.delete(crc);
+    }
     logger.info(`📱 [MeshCore VN ${this.sourceId}] client disconnected: ${clientId} (${this.clients.size} remaining)`);
 
     databaseService.auditLogAsync(
@@ -477,10 +510,20 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       return;
     }
     try {
-      const ok = await this.options.manager.sendMessage(text, fullKey);
-      if (ok) {
+      const result = await this.options.manager.sendMessageWithResult(text, fullKey);
+      if (result.ok) {
         logger.info(`[MeshCore VN ${this.sourceId}] ▶ forwarded DM from ${clientId} to ${prefixHex}… (${text.length} chars)`);
-        this.send(clientId, encodeSent(0, 0, this.SEND_EST_TIMEOUT_MS));
+        // Carry the firmware's real ack CRC in the Sent response and remember it
+        // so the matching send_confirmed pushes a SendConfirmed(0x82) to THIS
+        // client — otherwise the app waits for an ack it never gets, retransmits,
+        // and marks the DM Failed despite delivery (#3869).
+        if (result.expectedAckCrc !== undefined) {
+          this.pendingAcks.set(result.expectedAckCrc >>> 0, clientId);
+        }
+        this.send(
+          clientId,
+          encodeSent(0, result.expectedAckCrc ?? 0, result.estTimeout ?? this.SEND_EST_TIMEOUT_MS),
+        );
       } else {
         logger.warn(`[MeshCore VN ${this.sourceId}] DM from ${clientId} failed at the node`);
         this.send(clientId, encodeErr(ErrorCodes.BadState));
@@ -489,6 +532,26 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       logger.error(`[MeshCore VN ${this.sourceId}] DM from ${clientId} threw: ${(err as Error).message}`);
       this.send(clientId, encodeErr(ErrorCodes.BadState));
     }
+  }
+
+  /**
+   * A DM this node sent was acked by the mesh. Push a SendConfirmed(0x82) to the
+   * companion that originated it (matched by ack CRC) so the app marks the
+   * message delivered instead of retrying to failure (#3869). The manager's
+   * `send_confirmed` is source-global, so we act only on a CRC we recorded for a
+   * client send; an unknown CRC (e.g. a DM MeshMonitor itself sent, or one whose
+   * client has disconnected) is ignored.
+   */
+  private handleSendConfirmed(data: { ackCode: number; roundTripMs: number }): void {
+    const key = data.ackCode >>> 0;
+    const clientId = this.pendingAcks.get(key);
+    if (clientId === undefined) return;
+    this.pendingAcks.delete(key);
+    if (!this.clients.has(clientId)) return; // originating client has gone away
+    this.send(clientId, encodeSendConfirmed(data.ackCode, data.roundTripMs));
+    logger.info(
+      `[MeshCore VN ${this.sourceId}] ◀ ack confirmed to ${clientId} (crc=${key}, rtt=${data.roundTripMs}ms)`,
+    );
   }
 
   /** Resolve a (≥6-byte) public-key prefix to a full contact key, or null. */
@@ -529,6 +592,11 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   /** Map a stored MeshCoreMessage to the right recv frame (channel vs direct). */
   private encodeIncomingMessage(msg: MeshCoreMessage): Buffer {
     const senderTimestamp = toEpochSeconds(msg.timestamp);
+    // Forward the real packed path_len byte (0xff = direct) so the companion
+    // shows the actual hop count instead of always "direct" (#3871). The value
+    // is the raw byte the device reported; the app decodes the hop count the
+    // same way MeshMonitor does. Falls back to 0xff (direct) when unknown.
+    const wirePathLen = msg.pathLen ?? 0xff;
     // The `channel-N` marker lands in toPublicKey for messages we sent and in
     // fromPublicKey for messages we received — check both.
     const channelMatch =
@@ -539,7 +607,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       const text = msg.fromName ? `${msg.fromName}: ${msg.text}` : msg.text;
       return encodeChannelMsgRecv({
         channelIdx: Number(channelMatch[1]),
-        pathLen: 0xff, // delivered direct (we don't track the relay path here)
+        pathLen: wirePathLen,
         txtType: 0,
         senderTimestamp,
         text,
@@ -547,7 +615,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     }
     return encodeContactMsgRecv({
       pubKeyPrefix: hexToBytes(msg.fromPublicKey).subarray(0, 6),
-      pathLen: 0xff,
+      pathLen: wirePathLen,
       txtType: 0,
       senderTimestamp,
       text: msg.text,


### PR DESCRIPTION
Fixes #3869. Addresses #3871 (see the protocol-limitation note below).

Both issues are the same root cause: the **MeshCore Virtual Node bridge forwards only inbound `message` events** to a connected companion, dropping everything else MeshMonitor already knows.

## #3869 — DM marked Failed despite delivery
A DM sent through a VN companion is delivered, but its ACK never reaches the companion, so the companion's firmware retransmits 3× and finally marks it **Failed**.

- The companion protocol **does** define `SendConfirmed 0x82`, but there was no encoder and the bridge never subscribed to the manager's `send_confirmed`. The DM `Sent` response also hardcoded `expectedAckCrc = 0`, so even a later confirm couldn't correlate.
- **Fix:** carry the firmware's real `expectedAckCrc` in the `Sent` response, and on `send_confirmed` push a `SendConfirmed(0x82)` to the **originating** companion (CRC→client map, cleaned up on disconnect). New `encodeSendConfirmed()` — **verified by round-tripping through meshcore.js's own `onSendConfirmedPush` decoder**, so the byte layout matches what a real app expects.

## #3871(b) — incoming messages always shown as "direct"
`encodeIncomingMessage()` hardcoded `pathLen: 0xff`, hiding the hop count. The emitted `MeshCoreMessage` now carries the raw `path_len` and the bridge forwards it (falling back to `0xff` when unknown).

## #3871(a) — outgoing "heard by N repeaters" is a protocol limitation (not fixed, by necessity)
A channel send is an **unacked flood**: the companion already got `Ok(0)` and closed the send, the relay count is a MeshMonitor-derived metric that accrues asynchronously (up to ~30 s later via self-echo correlation), and the companion protocol has **no push frame or message handle** to annotate an already-sent channel message with it. The only async pushes are `Advert 0x80 / SendConfirmed 0x82 / MsgWaiting 0x83` — none represents a relay tally. It stays a MeshMonitor-UI feature (#3700/#3707). Documented at the channel-heard emit site + CHANGELOG. (This is why `Fixes` is scoped to #3869; #3871 is partially addressed.)

## Verification
- New tests: `encodeSendConfirmed` round-trip vs meshcore.js; VN ack-push happy path + ignores-unknown-CRC scoping; inbound `pathLen` forwarding + `0xff` fallback.
- Full suite **7799 passed / 0 failed**; server tsc clean; vite build clean.

## Note on investigation
Root-caused via three subagents; two hit degraded tooling and produced unreliable citations (one hallucinated a non-existent adapter file), so **every load-bearing fact here was re-verified by hand** against the real source and the meshcore.js library before coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)