### PR TITLE
feat(meshcore): node position-history movement trails on the map (#3852)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 109 (latest: `109_clamp_future_traceroute_timestamps`).
+**Current migration count:** 110 (latest: `110_add_meshcore_position_history`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/src/cli/migrationTables.ts
+++ b/src/cli/migrationTables.ts
@@ -34,6 +34,7 @@ export const TABLE_ORDER = [
   'meshcore_messages',
   'meshcore_neighbor_info',
   'meshcore_packet_log',
+  'meshcore_position_history',
   'meshcore_heard_repeaters',
   // Auth tables (must come before channel_database — channel_database
   // FKs to users for createdBy and channel_database_permissions FKs to users

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -373,10 +373,14 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             success: boolean;
             data: { latitude: number; longitude: number }[];
           }>(`/api/sources/${sourceId}/meshcore/nodes/${publicKey}/position-history?since=${since}`);
-          if (resp.success && Array.isArray(resp.data) && resp.data.length >= 2) {
-            next.set(publicKey, resp.data
+          if (resp.success && Array.isArray(resp.data)) {
+            // Drop Null Island fixes first, then keep only trails with enough
+            // real points to draw a segment (a 2-point response that's all
+            // Null Island would otherwise store a degenerate 1-point trail).
+            const pts = resp.data
               .filter(p => !isNullIsland(p.latitude, p.longitude))
-              .map(p => [p.latitude, p.longitude] as [number, number]));
+              .map(p => [p.latitude, p.longitude] as [number, number]);
+            if (pts.length >= 2) next.set(publicKey, pts);
           }
         } catch {
           // best-effort: a failed trail fetch shouldn't break the map

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -17,6 +17,7 @@ import { useSource } from '../../contexts/SourceContext';
 import { getTilesetById, type TilesetId } from '../../config/tilesets';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { isNullIsland } from '../../utils/nullIsland';
+import { getPositionHistoryColor } from '../../utils/mapHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import GeoJsonOverlay from '../GeoJsonOverlay';
@@ -193,6 +194,60 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     localStorage.setItem('meshmonitor-showLegend', String(showLegend));
   }, [showLegend]);
 
+  // Position-history trail overlay (#3852) — the MeshCore analogue of the
+  // Meshtastic node-motion trail. Toggle + window length are per-browser
+  // (localStorage), matching the other MeshCore map toggles. The window length
+  // is clamped to the backend's rolling retention (7 days); points older than
+  // that are swept server-side and simply won't be returned.
+  const [showPositionHistory, setShowPositionHistory] = useState(
+    () => localStorage.getItem('meshmonitor-meshcore-showPositionHistory') === 'true',
+  );
+  const [positionHistoryHours, setPositionHistoryHours] = useState<number>(() => {
+    const raw = localStorage.getItem('meshmonitor-meshcore-positionHistoryHours');
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? Math.min(n, 168) : 24;
+  });
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-meshcore-showPositionHistory', String(showPositionHistory));
+  }, [showPositionHistory]);
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-meshcore-positionHistoryHours', String(positionHistoryHours));
+  }, [positionHistoryHours]);
+  // publicKey -> ordered (oldest→newest) [lat, lng] trail points.
+  const [positionHistory, setPositionHistory] = useState<Map<string, [number, number][]>>(new Map());
+
+  // Server-side rolling retention window (days) for stored trail points. This
+  // is a global setting (`meshcore_position_history_retention_days`, default 7)
+  // — points older than this are swept server-side. Loaded once; saved via the
+  // shared /api/settings endpoint (requires settings:write, like the packet
+  // monitor's max-age control).
+  const [retentionDays, setRetentionDays] = useState(7);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const settings = await api.get<Record<string, string>>('/api/settings');
+        const raw = settings?.meshcore_position_history_retention_days;
+        const n = raw ? parseInt(raw, 10) : NaN;
+        if (!cancelled && Number.isFinite(n) && n > 0) setRetentionDays(n);
+      } catch {
+        // best-effort: fall back to the default display value
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+  const saveRetentionDays = (days: number) => {
+    const clamped = Math.max(1, Math.min(365, Math.round(days)));
+    setRetentionDays(clamped);
+    api.getBaseUrl().then(baseUrl => {
+      csrfFetch(`${baseUrl}/api/settings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ meshcore_position_history_retention_days: String(clamped) }),
+      }).catch(err => console.error('Failed to save position-history retention:', err));
+    }).catch(err => console.error('Failed to get base URL:', err));
+  };
+
   // GeoJSON overlay layers (global, file-based) — fetched and toggled here so
   // the MeshCore map matches the NodesTab and Dashboard maps. Layer visibility
   // is global and shared with those maps' controls.
@@ -296,6 +351,60 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     return () => { cancelled = true; };
   }, [sourceId]);
 
+  // Fetch movement trails for the currently-positioned, visible nodes whenever
+  // the overlay is on (or its window changes). One request per node against
+  // `/nodes/:publicKey/position-history?since=`; cheap because the set of
+  // positioned nodes is small and the backend dedupes stationary fixes. When
+  // the overlay is off we drop the cache so re-enabling refetches fresh.
+  const historyKeysSig = visibleContacts.map(c => c.publicKey).join('|');
+  useEffect(() => {
+    if (!showPositionHistory || !sourceId) {
+      setPositionHistory(new Map());
+      return;
+    }
+    let cancelled = false;
+    const keys = historyKeysSig ? historyKeysSig.split('|') : [];
+    const since = Date.now() - positionHistoryHours * 60 * 60 * 1000;
+    (async () => {
+      const next = new Map<string, [number, number][]>();
+      await Promise.all(keys.map(async (publicKey) => {
+        try {
+          const resp = await api.get<{
+            success: boolean;
+            data: { latitude: number; longitude: number }[];
+          }>(`/api/sources/${sourceId}/meshcore/nodes/${publicKey}/position-history?since=${since}`);
+          if (resp.success && Array.isArray(resp.data) && resp.data.length >= 2) {
+            next.set(publicKey, resp.data
+              .filter(p => !isNullIsland(p.latitude, p.longitude))
+              .map(p => [p.latitude, p.longitude] as [number, number]));
+          }
+        } catch {
+          // best-effort: a failed trail fetch shouldn't break the map
+        }
+      }));
+      if (!cancelled) setPositionHistory(next);
+    })();
+    return () => { cancelled = true; };
+  }, [showPositionHistory, positionHistoryHours, sourceId, historyKeysSig]);
+
+  // Per-node trail segments, colored oldest→newest like the Meshtastic trail.
+  const historySegments = useMemo(() => {
+    if (!showPositionHistory) return [];
+    const segs: { key: string; positions: [number, number][]; color: string }[] = [];
+    for (const [publicKey, points] of positionHistory) {
+      if (points.length < 2) continue;
+      const segCount = points.length - 1;
+      for (let i = 0; i < segCount; i++) {
+        segs.push({
+          key: `hist-${publicKey}-${i}`,
+          positions: [points[i], points[i + 1]],
+          color: getPositionHistoryColor(i, segCount),
+        });
+      }
+    }
+    return segs;
+  }, [showPositionHistory, positionHistory]);
+
   const neighborSegments = useMemo(() => {
     if (!showNeighbors || !neighborEdges?.length) return [];
     const posByKey = new Map<string, [number, number]>();
@@ -398,6 +507,14 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           );
         })}
 
+        {historySegments.map(s => (
+          <Polyline
+            key={s.key}
+            positions={s.positions}
+            pathOptions={{ color: s.color, weight: 3, opacity: 0.8 }}
+          />
+        ))}
+
         {pathSegments.map(s => (
           <Polyline
             key={`path-${s.key}`}
@@ -455,6 +572,44 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             />
             <span>Show Neighbors</span>
           </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showPositionHistory}
+              onChange={(e) => setShowPositionHistory(e.target.checked)}
+            />
+            <span>Show Position History</span>
+          </label>
+          {showPositionHistory && (
+            <div className="map-control-item" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '2px' }}>
+              <span style={{ fontSize: '0.85em' }}>
+                History: {positionHistoryHours < 24
+                  ? `${positionHistoryHours}h`
+                  : `${(positionHistoryHours / 24).toFixed(positionHistoryHours % 24 === 0 ? 0 : 1)}d`}
+              </span>
+              <input
+                type="range"
+                min={1}
+                max={168}
+                step={1}
+                value={positionHistoryHours}
+                onChange={(e) => setPositionHistoryHours(parseInt(e.target.value, 10))}
+                aria-label="Position history length (hours)"
+              />
+              <span style={{ fontSize: '0.85em', marginTop: '4px' }}>Keep history (days)</span>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                step={1}
+                value={retentionDays}
+                onChange={(e) => setRetentionDays(parseInt(e.target.value, 10) || 1)}
+                onBlur={(e) => saveRetentionDays(parseInt(e.target.value, 10) || 7)}
+                aria-label="Position history retention (days)"
+                style={{ width: '4rem' }}
+              />
+            </div>
+          )}
           <label className="map-control-item">
             <input
               type="checkbox"

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -99,6 +99,9 @@ import {
   meshcorePacketLogSqlite, meshcorePacketLogPostgres, meshcorePacketLogMysql,
 } from './schema/meshcorePacketLog.js';
 import {
+  meshcorePositionHistorySqlite, meshcorePositionHistoryPostgres, meshcorePositionHistoryMysql,
+} from './schema/meshcorePositionHistory.js';
+import {
   meshcoreHeardRepeatersSqlite, meshcoreHeardRepeatersPostgres, meshcoreHeardRepeatersMysql,
 } from './schema/meshcoreHeardRepeaters.js';
 
@@ -209,6 +212,7 @@ export interface ActiveSchema {
   meshcoreMessages: any;
   meshcoreNeighbors: any;
   meshcorePacketLog: any;
+  meshcorePositionHistory: any;
   meshcoreHeardRepeaters: any;
 
   // Embed Profiles
@@ -290,6 +294,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     meshcoreMessages: meshcoreMessagesSqlite,
     meshcoreNeighbors: meshcoreNeighborsSqlite,
     meshcorePacketLog: meshcorePacketLogSqlite,
+    meshcorePositionHistory: meshcorePositionHistorySqlite,
     meshcoreHeardRepeaters: meshcoreHeardRepeatersSqlite,
     embedProfiles: embedProfilesSqlite,
     automations: automationsSqlite,
@@ -345,6 +350,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     meshcoreMessages: meshcoreMessagesPostgres,
     meshcoreNeighbors: meshcoreNeighborsPostgres,
     meshcorePacketLog: meshcorePacketLogPostgres,
+    meshcorePositionHistory: meshcorePositionHistoryPostgres,
     meshcoreHeardRepeaters: meshcoreHeardRepeatersPostgres,
     embedProfiles: embedProfilesPostgres,
     automations: automationsPostgres,
@@ -400,6 +406,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     meshcoreMessages: meshcoreMessagesMysql,
     meshcoreNeighbors: meshcoreNeighborsMysql,
     meshcorePacketLog: meshcorePacketLogMysql,
+    meshcorePositionHistory: meshcorePositionHistoryMysql,
     meshcoreHeardRepeaters: meshcoreHeardRepeatersMysql,
     embedProfiles: embedProfilesMysql,
     automations: automationsMysql,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 109 migrations registered', () => {
-    expect(registry.count()).toBe(109);
+  it('has all 110 migrations registered', () => {
+    expect(registry.count()).toBe(110);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is clamp_future_traceroute_timestamps', () => {
+  it('last migration is add_meshcore_position_history', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(109);
-    expect(last.name).toContain('clamp_future_traceroute_timestamps');
+    expect(last.number).toBe(110);
+    expect(last.name).toContain('add_meshcore_position_history');
   });
 
-  it('migrations are sequentially numbered from 1 to 109', () => {
+  it('migrations are sequentially numbered from 1 to 110', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -124,6 +124,7 @@ import { migration as meshcoreMessageScopeMigration, runMigration106Postgres as 
 import { migration as clearNullIslandMigration, runMigration107Postgres as runClearNullIslandPostgres, runMigration107Mysql as runClearNullIslandMysql } from '../server/migrations/107_clear_null_island_positions.js';
 import { migration as meshcoreSavedRegionsMigration, runMigration108Postgres as runMeshcoreSavedRegionsPostgres, runMigration108Mysql as runMeshcoreSavedRegionsMysql } from '../server/migrations/108_meshcore_saved_regions.js';
 import { migration as clampFutureTracerouteMigration, runMigration109Postgres as runClampFutureTraceroutePostgres, runMigration109Mysql as runClampFutureTracerouteMysql } from '../server/migrations/109_clamp_future_traceroute_timestamps.js';
+import { migration as meshcorePositionHistoryMigration, runMigration110Postgres as runMeshcorePositionHistoryPostgres, runMigration110Mysql as runMeshcorePositionHistoryMysql } from '../server/migrations/110_add_meshcore_position_history.js';
 
 // ============================================================================
 // Registry
@@ -1729,4 +1730,21 @@ registry.register({
   sqlite: (db) => clampFutureTracerouteMigration.up(db),
   postgres: (client) => runClampFutureTraceroutePostgres(client),
   mysql: (pool) => runClampFutureTracerouteMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 110: MeshCore position-history table (#3852)
+// One row per distinct GPS fix per MeshCore node (from adverts + the
+// Cayenne-LPP telemetry poll). Backs the MeshCore map's movement-trail
+// overlay; swept on a rolling retention window by
+// meshcorePositionHistoryService.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 110,
+  name: 'add_meshcore_position_history',
+  settingsKey: 'migration_110_add_meshcore_position_history',
+  sqlite: (db) => meshcorePositionHistoryMigration.up(db),
+  postgres: (client) => runMeshcorePositionHistoryPostgres(client),
+  mysql: (pool) => runMeshcorePositionHistoryMysql(pool),
 });

--- a/src/db/repositories/meshcore.positionHistory.test.ts
+++ b/src/db/repositories/meshcore.positionHistory.test.ts
@@ -1,0 +1,94 @@
+/**
+ * MeshCore position-history tests (#3852).
+ *
+ * Covers the movement-trail storage that backs the MeshCore map overlay:
+ * - upsertNode transparently records a point when a node's GPS fix moves,
+ * - stationary re-reports (identical / sub-epsilon) are deduped,
+ * - getPositionHistory returns points oldest-first and honors `since`,
+ * - retention + per-source deletion behave, and rows are source-scoped.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MeshCoreRepository } from './meshcore.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+describe('MeshCoreRepository — position history', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MeshCoreRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MeshCoreRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('upsertNode records a trail point on first fix and on movement, deduping stationary re-reports', async () => {
+    // First fix → one point.
+    await repo.upsertNode({ publicKey: 'pk1', latitude: 40.0, longitude: -75.0, lastHeard: 1000 }, 'src-a');
+    // Identical re-report → no new point.
+    await repo.upsertNode({ publicKey: 'pk1', latitude: 40.0, longitude: -75.0, lastHeard: 2000 }, 'src-a');
+    // Sub-epsilon jitter → no new point.
+    await repo.upsertNode({ publicKey: 'pk1', latitude: 40.0000001, longitude: -75.0000001, lastHeard: 3000 }, 'src-a');
+    // Real movement → second point.
+    await repo.upsertNode({ publicKey: 'pk1', latitude: 40.5, longitude: -75.5, lastHeard: 4000 }, 'src-a');
+
+    const points = await repo.getPositionHistory('src-a', 'pk1');
+    expect(points).toHaveLength(2);
+    // Oldest-first ordering.
+    expect(points[0].timestamp).toBe(1000);
+    expect(points[1].timestamp).toBe(4000);
+    expect(points[1].latitude).toBeCloseTo(40.5);
+  });
+
+  it('does not record Null Island or absent positions', async () => {
+    await repo.upsertNode({ publicKey: 'pk2', latitude: 0, longitude: 0, lastHeard: 1000 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk2', name: 'no-gps', lastHeard: 2000 }, 'src-a');
+    const points = await repo.getPositionHistory('src-a', 'pk2');
+    expect(points).toHaveLength(0);
+  });
+
+  it('getPositionHistory honors the `since` window', async () => {
+    await repo.upsertNode({ publicKey: 'pk3', latitude: 10, longitude: 10, lastHeard: 1000 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk3', latitude: 11, longitude: 11, lastHeard: 5000 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk3', latitude: 12, longitude: 12, lastHeard: 9000 }, 'src-a');
+
+    const recent = await repo.getPositionHistory('src-a', 'pk3', 5000);
+    expect(recent.map(p => p.timestamp)).toEqual([5000, 9000]);
+  });
+
+  it('points are source-scoped', async () => {
+    await repo.upsertNode({ publicKey: 'pk4', latitude: 1, longitude: 1, lastHeard: 1000 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk4', latitude: 2, longitude: 2, lastHeard: 1000 }, 'src-b');
+
+    expect(await repo.getPositionHistory('src-a', 'pk4')).toHaveLength(1);
+    expect(await repo.getPositionHistory('src-b', 'pk4')).toHaveLength(1);
+  });
+
+  it('deletePositionHistoryOlderThan prunes the rolling window', async () => {
+    await repo.upsertNode({ publicKey: 'pk5', latitude: 1, longitude: 1, lastHeard: 1000 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk5', latitude: 2, longitude: 2, lastHeard: 5000 }, 'src-a');
+
+    const removed = await repo.deletePositionHistoryOlderThan(4000);
+    expect(removed).toBe(1);
+    const remaining = await repo.getPositionHistory('src-a', 'pk5');
+    expect(remaining.map(p => p.timestamp)).toEqual([5000]);
+  });
+
+  it('deleteAllPositionHistory clears one source only when scoped', async () => {
+    await repo.upsertNode({ publicKey: 'pk6', latitude: 1, longitude: 1, lastHeard: 1000 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk6', latitude: 1, longitude: 1, lastHeard: 1000 }, 'src-b');
+
+    const removed = await repo.deleteAllPositionHistory('src-a');
+    expect(removed).toBe(1);
+    expect(await repo.getPositionHistory('src-a', 'pk6')).toHaveLength(0);
+    expect(await repo.getPositionHistory('src-b', 'pk6')).toHaveLength(1);
+  });
+});

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -132,6 +132,26 @@ export interface DbMeshCorePacket {
 }
 
 /**
+ * MeshCore position-history row (#3852). One per distinct GPS fix observed for
+ * a node (from contact adverts or the Cayenne-LPP telemetry poll). Backs the
+ * MeshCore map's movement-trail overlay. See
+ * `src/db/schema/meshcorePositionHistory.ts`.
+ */
+export interface DbMeshCorePositionHistory {
+  id?: number;
+  /** Owning source id; required on writes. */
+  sourceId: string;
+  /** 64-char hex public key of the node this fix belongs to. */
+  publicKey: string;
+  latitude: number;
+  longitude: number;
+  altitude?: number | null;
+  /** Fix time (ms epoch). */
+  timestamp: number;
+  createdAt: number;
+}
+
+/**
  * MeshCore "heard repeater" row (#3700). One per (outgoing channel message,
  * repeater relay-hash) inferred by self-echo correlation. See
  * `src/db/schema/meshcoreHeardRepeaters.ts`.
@@ -283,6 +303,15 @@ export class MeshCoreRepository extends BaseRepository {
     const now = this.now();
     const { meshcoreNodes } = this.tables;
     const existing = await this.getNodeByPublicKeyAndSource(node.publicKey, sourceId);
+
+    // Record a position-history point whenever this update carries a valid GPS
+    // fix that differs from the stored position (or is this node's first fix).
+    // This is the single choke point both ingest paths pass through — contact
+    // adverts (persistContact) and the Cayenne-LPP telemetry poll — so the
+    // movement trail (#3852) captures every distinct fix without each call
+    // site having to remember to log it. Stationary re-reports (identical
+    // lat/lon) are deduped here so the trail doesn't accumulate noise.
+    await this.recordPositionHistoryIfMoved(node, existing ?? null, sourceId, now);
 
     if (existing) {
       // Merge, don't clobber (#3504). Callers (persistContact, the telemetry
@@ -1310,5 +1339,125 @@ export class MeshCoreRepository extends BaseRepository {
       await this.db.delete(meshcorePacketLog);
     }
     return count;
+  }
+
+  // ============ Position History (#3852) ============
+
+  /**
+   * Two coordinates are "the same fix" when they agree within ~1e-6° (≈0.1 m).
+   * Below this, the difference is GPS jitter, not movement, so we don't record
+   * a new trail point. Above it, the node moved enough to be worth a point.
+   */
+  private static readonly POSITION_EPSILON = 1e-6;
+
+  /**
+   * Insert a position-history point if `node` carries a valid GPS fix that
+   * moved relative to `existing`. Best-effort and side-effect-only: a failure
+   * here must never break a node upsert, so errors are swallowed (the row that
+   * matters — the node's current position — is written by the caller).
+   */
+  private async recordPositionHistoryIfMoved(
+    node: Partial<DbMeshCoreNode> & { publicKey: string },
+    existing: DbMeshCoreNode | null,
+    sourceId: string,
+    now: number,
+  ): Promise<void> {
+    const lat = node.latitude;
+    const lon = node.longitude;
+    // Only a complete, finite, non-null-island fix is a real position.
+    if (typeof lat !== 'number' || typeof lon !== 'number' || !isFinite(lat) || !isFinite(lon)) {
+      return;
+    }
+    if (lat === 0 && lon === 0) return;
+
+    // Dedup against the stored position: skip when the node hasn't moved.
+    if (
+      existing &&
+      typeof existing.latitude === 'number' &&
+      typeof existing.longitude === 'number' &&
+      Math.abs(existing.latitude - lat) < MeshCoreRepository.POSITION_EPSILON &&
+      Math.abs(existing.longitude - lon) < MeshCoreRepository.POSITION_EPSILON
+    ) {
+      return;
+    }
+
+    try {
+      // Prefer the node's reported lastHeard as the fix time; fall back to now.
+      const timestamp = typeof node.lastHeard === 'number' && node.lastHeard > 0 ? node.lastHeard : now;
+      await this.insertPositionHistory({
+        sourceId,
+        publicKey: node.publicKey,
+        latitude: lat,
+        longitude: lon,
+        altitude: typeof node.altitude === 'number' ? node.altitude : null,
+        timestamp,
+        createdAt: now,
+      });
+    } catch {
+      // Never let trail logging break a node upsert.
+    }
+  }
+
+  /**
+   * Insert one position-history row. `sourceId` is required so every row is
+   * stamped with its owning source.
+   */
+  async insertPositionHistory(point: DbMeshCorePositionHistory): Promise<void> {
+    if (!point.sourceId) {
+      throw new Error('MeshCoreRepository.insertPositionHistory requires a sourceId');
+    }
+    const { meshcorePositionHistory } = this.tables;
+    await this.db.insert(meshcorePositionHistory).values(point);
+  }
+
+  /**
+   * Position-history points for one node, oldest-first (for trail rendering).
+   * `since` (ms) bounds the window; omit for all retained points.
+   */
+  async getPositionHistory(
+    sourceId: string,
+    publicKey: string,
+    since?: number,
+  ): Promise<DbMeshCorePositionHistory[]> {
+    const { meshcorePositionHistory } = this.tables;
+    const conditions: SQL[] = [
+      eq(meshcorePositionHistory.sourceId, sourceId),
+      eq(meshcorePositionHistory.publicKey, publicKey),
+    ];
+    if (typeof since === 'number') {
+      conditions.push(gte(meshcorePositionHistory.timestamp, since));
+    }
+    const result = await this.db
+      .select()
+      .from(meshcorePositionHistory)
+      .where(and(...conditions))
+      .orderBy(meshcorePositionHistory.timestamp);
+    return this.normalizeBigInts(result) as unknown as DbMeshCorePositionHistory[];
+  }
+
+  /**
+   * Delete position-history rows older than a timestamp (ms). Returns the
+   * number of rows removed. Used by the retention sweep.
+   */
+  async deletePositionHistoryOlderThan(timestamp: number, sourceId?: string): Promise<number> {
+    const { meshcorePositionHistory } = this.tables;
+    const conditions: SQL[] = [lt(meshcorePositionHistory.timestamp, timestamp)];
+    if (sourceId) {
+      conditions.push(eq(meshcorePositionHistory.sourceId, sourceId));
+    }
+    const result = await this.db.delete(meshcorePositionHistory).where(and(...conditions));
+    return this.getAffectedRows(result);
+  }
+
+  /**
+   * Delete all position-history rows, optionally scoped to one source.
+   * Returns the number of rows removed.
+   */
+  async deleteAllPositionHistory(sourceId?: string): Promise<number> {
+    const { meshcorePositionHistory } = this.tables;
+    const result = sourceId
+      ? await this.db.delete(meshcorePositionHistory).where(eq(meshcorePositionHistory.sourceId, sourceId))
+      : await this.db.delete(meshcorePositionHistory);
+    return this.getAffectedRows(result);
   }
 }

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -35,6 +35,7 @@ export * from './meshcoreNodes.js';
 export * from './meshcoreMessages.js';
 export * from './meshcoreNeighbors.js';
 export * from './meshcorePacketLog.js';
+export * from './meshcorePositionHistory.js';
 export * from './meshcoreHeardRepeaters.js';
 
 // Embed Profiles table

--- a/src/db/schema/meshcorePositionHistory.ts
+++ b/src/db/schema/meshcorePositionHistory.ts
@@ -1,0 +1,76 @@
+/**
+ * Drizzle schema definition for the MeshCore position-history table.
+ * Supports SQLite, PostgreSQL, and MySQL.
+ *
+ * One row per *distinct* GPS fix observed for a MeshCore node, recorded
+ * whenever a node's position changes (via contact adverts or the Cayenne-LPP
+ * telemetry poll — see `MeshCoreRepository.upsertNode`). This is the MeshCore
+ * analogue of the Meshtastic position-history trail (issue #3852), letting the
+ * MeshCore map draw a movement polyline per node.
+ *
+ * Retention is a rolling window swept by `meshcorePositionHistoryService`
+ * (default 7 days, configurable via `meshcore_position_history_retention_days`).
+ *
+ * MeshCore identifies nodes by 64-char hex public key, so rows are keyed by
+ * `(sourceId, publicKey)` + `timestamp` rather than a numeric nodeNum.
+ */
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, doublePrecision as pgDoublePrecision, bigint as pgBigint } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, double as myDouble, serial as mySerial, bigint as myBigint } from 'drizzle-orm/mysql-core';
+
+// ============ SQLite Schema ============
+
+export const meshcorePositionHistorySqlite = sqliteTable('meshcore_position_history', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  /** Owning source — every row is source-scoped (mandatory per CLAUDE.md). */
+  sourceId: text('sourceId').notNull(),
+  /** 64-char hex public key of the node this fix belongs to. */
+  publicKey: text('publicKey').notNull(),
+  /** Fix latitude in decimal degrees. */
+  latitude: real('latitude').notNull(),
+  /** Fix longitude in decimal degrees. */
+  longitude: real('longitude').notNull(),
+  /** Fix altitude in metres, when reported. */
+  altitude: real('altitude'),
+  /** Fix time (ms epoch) — the node's lastHeard at capture, used for ordering + retention. */
+  timestamp: integer('timestamp').notNull(),
+  /** Server insert time (ms epoch). */
+  createdAt: integer('createdAt').notNull(),
+});
+
+// ============ PostgreSQL Schema ============
+
+export const meshcorePositionHistoryPostgres = pgTable('meshcore_position_history', {
+  id: pgInteger('id').primaryKey().generatedAlwaysAsIdentity(),
+  sourceId: pgText('sourceId').notNull(),
+  publicKey: pgText('publicKey').notNull(),
+  latitude: pgDoublePrecision('latitude').notNull(),
+  longitude: pgDoublePrecision('longitude').notNull(),
+  altitude: pgDoublePrecision('altitude'),
+  // ms-epoch timestamps overflow 32-bit INTEGER (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
+  createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// ============ MySQL Schema ============
+
+export const meshcorePositionHistoryMysql = mysqlTable('meshcore_position_history', {
+  id: mySerial('id').primaryKey(),
+  sourceId: myVarchar('sourceId', { length: 255 }).notNull(),
+  publicKey: myVarchar('publicKey', { length: 64 }).notNull(),
+  latitude: myDouble('latitude').notNull(),
+  longitude: myDouble('longitude').notNull(),
+  altitude: myDouble('altitude'),
+  // ms-epoch timestamps overflow 32-bit INT (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
+  createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// ============ Type Inference ============
+
+export type MeshCorePositionHistorySqlite = typeof meshcorePositionHistorySqlite.$inferSelect;
+export type NewMeshCorePositionHistorySqlite = typeof meshcorePositionHistorySqlite.$inferInsert;
+export type MeshCorePositionHistoryPostgres = typeof meshcorePositionHistoryPostgres.$inferSelect;
+export type NewMeshCorePositionHistoryPostgres = typeof meshcorePositionHistoryPostgres.$inferInsert;
+export type MeshCorePositionHistoryMysql = typeof meshcorePositionHistoryMysql.$inferSelect;
+export type NewMeshCorePositionHistoryMysql = typeof meshcorePositionHistoryMysql.$inferInsert;

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -92,6 +92,8 @@ export const VALID_SETTINGS_KEYS = [
   'meshcore_packet_log_enabled',
   'meshcore_packet_log_max_count',
   'meshcore_packet_log_max_age_hours',
+  // Rolling retention window (days) for the MeshCore position-history trail (#3852).
+  'meshcore_position_history_retention_days',
   'solarMonitoringEnabled',
   'solarMonitoringLatitude',
   'solarMonitoringLongitude',

--- a/src/server/migrations/110_add_meshcore_position_history.ts
+++ b/src/server/migrations/110_add_meshcore_position_history.ts
@@ -1,0 +1,108 @@
+/**
+ * Migration 110: MeshCore position-history table (#3852).
+ *
+ * Creates `meshcore_position_history`: one row per distinct GPS fix observed
+ * for a MeshCore node (via contact adverts or the Cayenne-LPP telemetry poll).
+ * This is the MeshCore analogue of the Meshtastic position-history trail and
+ * backs the MeshCore map's movement-trail overlay.
+ *
+ * Source-scoped (`sourceId`) like every other per-source MeshCore table. A
+ * rolling retention window (default 7 days) is swept by
+ * `meshcorePositionHistoryService`; the index on (sourceId, publicKey,
+ * timestamp) serves both per-node trail queries and the age-based sweep.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 110';
+const TABLE = 'meshcore_position_history';
+const IDX = 'meshcore_position_history_node_idx';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): creating ${TABLE}...`);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sourceId TEXT NOT NULL,
+        publicKey TEXT NOT NULL,
+        latitude REAL NOT NULL,
+        longitude REAL NOT NULL,
+        altitude REAL,
+        timestamp INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL
+      )
+    `);
+    db.exec(`CREATE INDEX IF NOT EXISTS ${IDX} ON ${TABLE}(sourceId, publicKey, timestamp)`);
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): dropping ${TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration110Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): creating ${TABLE}...`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      "sourceId" TEXT NOT NULL,
+      "publicKey" TEXT NOT NULL,
+      latitude DOUBLE PRECISION NOT NULL,
+      longitude DOUBLE PRECISION NOT NULL,
+      altitude DOUBLE PRECISION,
+      timestamp BIGINT NOT NULL,
+      "createdAt" BIGINT NOT NULL
+    )
+  `);
+  await client.query(`CREATE INDEX IF NOT EXISTS ${IDX} ON ${TABLE}("sourceId", "publicKey", timestamp)`);
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration110Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): creating ${TABLE}...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [exists] = await conn.query(
+      `SELECT TABLE_NAME FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+      [TABLE],
+    );
+    if ((exists as any[]).length === 0) {
+      await conn.query(`
+        CREATE TABLE ${TABLE} (
+          id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+          sourceId VARCHAR(255) NOT NULL,
+          publicKey VARCHAR(64) NOT NULL,
+          latitude DOUBLE NOT NULL,
+          longitude DOUBLE NOT NULL,
+          altitude DOUBLE,
+          timestamp BIGINT NOT NULL,
+          createdAt BIGINT NOT NULL,
+          INDEX ${IDX} (sourceId, publicKey, timestamp)
+        )
+      `);
+    } else {
+      logger.debug(`${TABLE} already exists, skipping create`);
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/migrations/110_add_meshcore_position_history.ts
+++ b/src/server/migrations/110_add_meshcore_position_history.ts
@@ -19,6 +19,9 @@ import { logger } from '../../utils/logger.js';
 const LABEL = 'Migration 110';
 const TABLE = 'meshcore_position_history';
 const IDX = 'meshcore_position_history_node_idx';
+// Timestamp-only index for the age-based retention sweep, which filters on
+// `timestamp` alone and can't use the leading column of the composite index.
+const TS_IDX = 'meshcore_position_history_ts_idx';
 
 // ============ SQLite ============
 
@@ -39,6 +42,7 @@ export const migration = {
       )
     `);
     db.exec(`CREATE INDEX IF NOT EXISTS ${IDX} ON ${TABLE}(sourceId, publicKey, timestamp)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS ${TS_IDX} ON ${TABLE}(timestamp)`);
 
     logger.info(`${LABEL} complete (SQLite)`);
   },
@@ -67,6 +71,7 @@ export async function runMigration110Postgres(client: import('pg').PoolClient): 
     )
   `);
   await client.query(`CREATE INDEX IF NOT EXISTS ${IDX} ON ${TABLE}("sourceId", "publicKey", timestamp)`);
+  await client.query(`CREATE INDEX IF NOT EXISTS ${TS_IDX} ON ${TABLE}(timestamp)`);
 
   logger.info(`${LABEL} complete (PostgreSQL)`);
 }
@@ -94,7 +99,8 @@ export async function runMigration110Mysql(pool: import('mysql2/promise').Pool):
           altitude DOUBLE,
           timestamp BIGINT NOT NULL,
           createdAt BIGINT NOT NULL,
-          INDEX ${IDX} (sourceId, publicKey, timestamp)
+          INDEX ${IDX} (sourceId, publicKey, timestamp),
+          INDEX ${TS_IDX} (timestamp)
         )
       `);
     } else {

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -168,6 +168,13 @@ const mockPacketService = vi.hoisted(() => ({
 }));
 vi.mock('../services/meshcorePacketLogService.js', () => ({ default: mockPacketService }));
 
+// Mock the MeshCore position-history service so the trail route doesn't hit the
+// (fully-mocked) database and we can assert what `since` it was called with.
+const mockPositionHistoryService = vi.hoisted(() => ({
+  getPositionHistory: vi.fn(),
+}));
+vi.mock('../services/meshcorePositionHistoryService.js', () => ({ default: mockPositionHistoryService }));
+
 import DatabaseService from '../../services/database.js';
 
 import meshcoreRoutes from './meshcoreRoutes.js';
@@ -325,6 +332,42 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(404);
       expect(response.body.success).toBe(false);
       expect(response.body.error).toMatch(/does-not-exist/);
+    });
+  });
+
+  describe('GET /nodes/:publicKey/position-history (#3852)', () => {
+    const VALID_KEY = 'a'.repeat(64);
+
+    it('rejects an invalid public key with 400', async () => {
+      const response = await authenticatedAgent.get(
+        '/api/sources/test-source/meshcore/nodes/not-a-key/position-history',
+      );
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(mockPositionHistoryService.getPositionHistory).not.toHaveBeenCalled();
+    });
+
+    it('returns mapped points and forwards a valid `since`', async () => {
+      mockPositionHistoryService.getPositionHistory.mockResolvedValueOnce([
+        { timestamp: 1000, latitude: 40, longitude: -75, altitude: 12 },
+        { timestamp: 2000, latitude: 41, longitude: -76, altitude: null },
+      ]);
+      const response = await authenticatedAgent.get(
+        `/api/sources/test-source/meshcore/nodes/${VALID_KEY}/position-history?since=1500`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.count).toBe(2);
+      expect(response.body.data[0]).toEqual({ timestamp: 1000, latitude: 40, longitude: -75, altitude: 12 });
+      expect(mockPositionHistoryService.getPositionHistory).toHaveBeenCalledWith('test-source', VALID_KEY, 1500);
+    });
+
+    it('treats a negative `since` as no window (undefined)', async () => {
+      mockPositionHistoryService.getPositionHistory.mockResolvedValueOnce([]);
+      await authenticatedAgent.get(
+        `/api/sources/test-source/meshcore/nodes/${VALID_KEY}/position-history?since=-1`,
+      );
+      expect(mockPositionHistoryService.getPositionHistory).toHaveBeenCalledWith('test-source', VALID_KEY, undefined);
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -398,10 +398,13 @@ router.get(
       }
       const sinceRaw = req.query.since;
       const since = typeof sinceRaw === 'string' ? parseInt(sinceRaw, 10) : NaN;
+      // Only a finite, non-negative cutoff is a real window; a negative value
+      // would be a no-op cutoff that silently returns the entire history.
+      const sinceArg = Number.isFinite(since) && since >= 0 ? since : undefined;
       const points = await meshcorePositionHistoryService.getPositionHistory(
         sourceId,
         publicKey,
-        Number.isFinite(since) ? since : undefined,
+        sinceArg,
       );
       res.json({
         success: true,

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -24,6 +24,7 @@ import { validateAutoAckRegex } from '../utils/autoAckRegex.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
 import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.js';
 import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
+import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
 
 /**
  * Resolve the manager for a request. Mounted only under
@@ -375,6 +376,49 @@ router.get('/nodes', optionalAuth(), requirePermission('nodes', 'read', { source
     res.status(500).json({ success: false, error: 'Failed to get nodes' });
   }
 });
+
+/**
+ * GET /api/sources/:id/meshcore/nodes/:publicKey/position-history
+ *
+ * Movement-trail points for one MeshCore node, oldest-first (#3852). Each
+ * point is a distinct GPS fix recorded from contact adverts or the
+ * Cayenne-LPP telemetry poll. `?since=<ms>` bounds the window (the map sends
+ * the user-selected trail length); omit for the full retained window.
+ */
+router.get(
+  '/nodes/:publicKey/position-history',
+  optionalAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = req.params.id;
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key' });
+      }
+      const sinceRaw = req.query.since;
+      const since = typeof sinceRaw === 'string' ? parseInt(sinceRaw, 10) : NaN;
+      const points = await meshcorePositionHistoryService.getPositionHistory(
+        sourceId,
+        publicKey,
+        Number.isFinite(since) ? since : undefined,
+      );
+      res.json({
+        success: true,
+        count: points.length,
+        data: points.map((p) => ({
+          timestamp: p.timestamp,
+          latitude: p.latitude,
+          longitude: p.longitude,
+          altitude: p.altitude ?? null,
+        })),
+      });
+    } catch (error) {
+      logger.error('[API] Error getting MeshCore position history:', error);
+      res.status(500).json({ success: false, error: 'Failed to get position history' });
+    }
+  },
+);
 
 /**
  * GET /api/meshcore/contacts

--- a/src/server/services/meshcorePositionHistoryService.ts
+++ b/src/server/services/meshcorePositionHistoryService.ts
@@ -1,0 +1,78 @@
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Service for the MeshCore position-history trail (#3852).
+ *
+ * Position points are written transparently by `MeshCoreRepository.upsertNode`
+ * whenever a node's GPS fix changes; this service owns only the *retention*
+ * side — a periodic sweep that drops points older than the configured rolling
+ * window (default 7 days, per the issue). The window is configurable via the
+ * `meshcore_position_history_retention_days` setting, mirroring the packet-log
+ * service's age-based cleanup.
+ */
+class MeshCorePositionHistoryService {
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+  private readonly CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+  private readonly DEFAULT_RETENTION_DAYS = 7;
+
+  constructor() {
+    this.startCleanupScheduler();
+  }
+
+  private startCleanupScheduler(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+    }
+    logger.debug('🧹 Starting MeshCore position-history cleanup scheduler (runs hourly)');
+    // Sweep once shortly after boot, then on the interval.
+    setTimeout(() => void this.runCleanup(), 30_000);
+    this.cleanupInterval = setInterval(() => {
+      void this.runCleanup();
+    }, this.CLEANUP_INTERVAL_MS);
+  }
+
+  /**
+   * Remove position-history points older than the configured retention window.
+   */
+  async runCleanup(): Promise<void> {
+    try {
+      const retentionDays = await this.getRetentionDays();
+      const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+      const removed = await databaseService.meshcore.deletePositionHistoryOlderThan(cutoff);
+      if (removed > 0) {
+        logger.debug(`🧹 MeshCore position-history cleanup: removed ${removed} old points`);
+      }
+    } catch (error) {
+      logger.error('❌ Failed to cleanup MeshCore position history:', error);
+    }
+  }
+
+  async getPositionHistory(sourceId: string, publicKey: string, since?: number) {
+    return databaseService.meshcore.getPositionHistory(sourceId, publicKey, since);
+  }
+
+  async clearPositionHistory(sourceId?: string): Promise<number> {
+    return databaseService.meshcore.deleteAllPositionHistory(sourceId);
+  }
+
+  /**
+   * Rolling retention window in days. Defaults to 7 (the issue's spec); a
+   * positive integer override is read from settings.
+   */
+  async getRetentionDays(): Promise<number> {
+    const raw = await databaseService.getSettingAsync('meshcore_position_history_retention_days');
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : this.DEFAULT_RETENTION_DAYS;
+  }
+
+  stop(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+      logger.debug('🛑 Stopped MeshCore position-history cleanup scheduler');
+    }
+  }
+}
+
+export default new MeshCorePositionHistoryService();


### PR DESCRIPTION
## Summary

Closes #3852. Replicates the existing Meshtastic **Position History** feature for **MeshCore** nodes — a per-node movement trail (polyline) on the MeshCore map, with on/off toggle, a configurable display window, and a rolling-window retention store.

## What's included

**Storage**
- New source-scoped table `meshcore_position_history` (migration **110**, SQLite/PostgreSQL/MySQL) — one row per *distinct* GPS fix per node, indexed on `(sourceId, publicKey, timestamp)`.
- Recording is centralized in `MeshCoreRepository.upsertNode`, the single choke point both ingest paths pass through — contact adverts (`persistContact`) **and** the Cayenne-LPP telemetry poll. A point is recorded only when the fix actually moves (sub-epsilon jitter and Null Island are dropped), so stationary nodes don't accumulate noise.

**API**
- `GET /api/sources/:id/meshcore/nodes/:publicKey/position-history?since=<ms>` (gated `nodes:read`), returns points oldest-first.

**Retention**
- `meshcorePositionHistoryService` runs an hourly sweep on a **configurable** rolling window — `meshcore_position_history_retention_days` (default **7**, per the issue).

**Map UI (`MeshCoreMap`)**
- **Show Position History** toggle + **history length slider (1h–7d, default 24h)** — persisted per-browser, matching the existing MeshCore map toggles.
- Gradient (oldest→newest) trail polylines per positioned node.
- **Keep history (days)** retention input, wired to the shared `/api/settings` endpoint (like the packet-monitor max-age control).

## Testing

- New `meshcore.positionHistory.test.ts`: movement-dedup, Null Island rejection, `since` windowing, source isolation, retention + scoped deletion.
- Updated migration-count test (110) and the migrate-db table list.
- Full Vitest suite green; `tsc` adds no new errors; lint clean on changed files.

## Notes
- Data comes entirely from MeshCore GPS adverts + telemetry — no firmware changes.
- Source deletion leaves orphan rows that age out via retention, consistent with the other per-source MeshCore tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)