### PR TITLE
feat(automation,autoack): Pause action + configurable Auto-Ack pre-send delay (#3876)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,6 +603,7 @@ const location = useLocation();
     autoAckIgnoredNodes, setAutoAckIgnoredNodes,
     autoAckMatrix, setAutoAckMatrix,
     autoAckCooldownSeconds, setAutoAckCooldownSeconds,
+    autoAckPreSendDelaySeconds, setAutoAckPreSendDelaySeconds,
     autoAckTestMessages, setAutoAckTestMessages,
     autoAnnounceEnabled, setAutoAnnounceEnabled,
     autoAnnounceIntervalHours, setAutoAnnounceIntervalHours,
@@ -1035,6 +1036,9 @@ const location = useLocation();
 
           if (settings.autoAckCooldownSeconds !== undefined) {
             setAutoAckCooldownSeconds(parseInt(settings.autoAckCooldownSeconds) || 60);
+          }
+          if (settings.autoAckPreSendDelaySeconds !== undefined) {
+            setAutoAckPreSendDelaySeconds(parseInt(settings.autoAckPreSendDelaySeconds) || 0);
           }
 
           if (settings.autoAckTestMessages) {
@@ -5206,6 +5210,8 @@ const location = useLocation();
                   testMessages={autoAckTestMessages}
                   cooldownSeconds={autoAckCooldownSeconds}
                   onCooldownSecondsChange={setAutoAckCooldownSeconds}
+                  preSendDelaySeconds={autoAckPreSendDelaySeconds}
+                  onPreSendDelaySecondsChange={setAutoAckPreSendDelaySeconds}
                   baseUrl={baseUrl}
                   onEnabledChange={setAutoAckEnabled}
                   onRegexChange={setAutoAckRegex}

--- a/src/components/AutoAcknowledgeSection.test.tsx
+++ b/src/components/AutoAcknowledgeSection.test.tsx
@@ -65,6 +65,9 @@ describe.skip('AutoAcknowledgeSection Component', () => {
     enabledChannels: [0, 1],
     matrix: DEFAULT_AUTOACK_MATRIX,
     baseUrl: '',
+    cooldownSeconds: 60,
+    preSendDelaySeconds: 0,
+    testMessages: '',
     ...mockCallbacks
   } as any;
 
@@ -776,6 +779,7 @@ describe('AutoAcknowledgeSection — response matrix', () => {
     onIgnoredNodesChange: vi.fn(),
     onMatrixChange: vi.fn(),
     onCooldownSecondsChange: vi.fn(),
+    onPreSendDelaySecondsChange: vi.fn(),
     onTestMessagesChange: vi.fn(),
   };
 

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -36,6 +36,8 @@ interface AutoAcknowledgeSectionProps {
   onMatrixChange: (m: AutoAckMatrix) => void;
   cooldownSeconds: number;
   onCooldownSecondsChange: (value: number) => void;
+  preSendDelaySeconds: number;
+  onPreSendDelaySecondsChange: (value: number) => void;
   testMessages: string;
   onTestMessagesChange: (messages: string) => void;
 }
@@ -64,6 +66,8 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
   onMatrixChange,
   cooldownSeconds,
   onCooldownSecondsChange,
+  preSendDelaySeconds,
+  onPreSendDelaySecondsChange,
   testMessages: testMessagesProp,
   onTestMessagesChange,
 }) => {
@@ -81,6 +85,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
   const [localIgnoredNodes, setLocalIgnoredNodes] = useState(ignoredNodes || '');
   const [localMatrix, setLocalMatrix] = useState<AutoAckMatrix>(matrix);
   const [localCooldownSeconds, setLocalCooldownSeconds] = useState(cooldownSeconds);
+  const [localPreSendDelaySeconds, setLocalPreSendDelaySeconds] = useState(preSendDelaySeconds);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [testMessages, setTestMessages] = useState(testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
@@ -98,19 +103,21 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     setLocalIgnoredNodes(ignoredNodes || '');
     setLocalMatrix(matrix);
     setLocalCooldownSeconds(cooldownSeconds);
+    setLocalPreSendDelaySeconds(preSendDelaySeconds);
     if (testMessagesProp) {
       setTestMessages(testMessagesProp);
     }
-  }, [enabled, regex, message, messageDirect, enabledChannels, skipIncompleteNodes, ignoredNodes, matrix, cooldownSeconds, testMessagesProp]);
+  }, [enabled, regex, message, messageDirect, enabledChannels, skipIncompleteNodes, ignoredNodes, matrix, cooldownSeconds, preSendDelaySeconds, testMessagesProp]);
 
   // Check if any settings have changed
   useEffect(() => {
     const channelsChanged = JSON.stringify(localEnabledChannels.sort()) !== JSON.stringify(enabledChannels.sort());
     const cooldownChanged = localCooldownSeconds !== cooldownSeconds;
+    const preSendDelayChanged = localPreSendDelaySeconds !== preSendDelaySeconds;
     const matrixChanged = JSON.stringify(localMatrix) !== JSON.stringify(matrix);
-    const changed = localEnabled !== enabled || localRegex !== regex || localMessage !== message || localMessageDirect !== messageDirect || channelsChanged || localSkipIncompleteNodes !== skipIncompleteNodes || localIgnoredNodes !== (ignoredNodes || '') || matrixChanged || cooldownChanged || testMessages !== (testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
+    const changed = localEnabled !== enabled || localRegex !== regex || localMessage !== message || localMessageDirect !== messageDirect || channelsChanged || localSkipIncompleteNodes !== skipIncompleteNodes || localIgnoredNodes !== (ignoredNodes || '') || matrixChanged || cooldownChanged || preSendDelayChanged || testMessages !== (testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
     setHasChanges(changed);
-  }, [localEnabled, localRegex, localMessage, localMessageDirect, localEnabledChannels, localSkipIncompleteNodes, localIgnoredNodes, localMatrix, localCooldownSeconds, testMessages, enabled, regex, message, messageDirect, enabledChannels, skipIncompleteNodes, ignoredNodes, matrix, cooldownSeconds, testMessagesProp]);
+  }, [localEnabled, localRegex, localMessage, localMessageDirect, localEnabledChannels, localSkipIncompleteNodes, localIgnoredNodes, localMatrix, localCooldownSeconds, localPreSendDelaySeconds, testMessages, enabled, regex, message, messageDirect, enabledChannels, skipIncompleteNodes, ignoredNodes, matrix, cooldownSeconds, preSendDelaySeconds, testMessagesProp]);
 
   // Reset local state to props (used by SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -123,8 +130,9 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     setLocalIgnoredNodes(ignoredNodes || '');
     setLocalMatrix(matrix);
     setLocalCooldownSeconds(cooldownSeconds);
+    setLocalPreSendDelaySeconds(preSendDelaySeconds);
     setTestMessages(testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
-  }, [enabled, regex, message, messageDirect, enabledChannels, skipIncompleteNodes, ignoredNodes, matrix, cooldownSeconds, testMessagesProp]);
+  }, [enabled, regex, message, messageDirect, enabledChannels, skipIncompleteNodes, ignoredNodes, matrix, cooldownSeconds, preSendDelaySeconds, testMessagesProp]);
 
   // Validate regex pattern for safety
   const validateRegex = (pattern: string): { valid: boolean; error?: string } => {
@@ -248,6 +256,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           autoAckIgnoredNodes: localIgnoredNodes,
           ...matrixToSettings(localMatrix),
           autoAckCooldownSeconds: String(localCooldownSeconds),
+          autoAckPreSendDelaySeconds: String(localPreSendDelaySeconds),
           autoAckTestMessages: testMessages
         })
       });
@@ -281,6 +290,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
       onIgnoredNodesChange(localIgnoredNodes);
       onMatrixChange(localMatrix);
       onCooldownSecondsChange(localCooldownSeconds);
+      onPreSendDelaySecondsChange(localPreSendDelaySeconds);
       onTestMessagesChange(testMessages);
 
       setHasChanges(false);
@@ -291,7 +301,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     } finally {
       setIsSaving(false);
     }
-  }, [localRegex, localEnabled, localMessage, localMessageDirect, localEnabledChannels, localSkipIncompleteNodes, localIgnoredNodes, localMatrix, localCooldownSeconds, testMessages, baseUrl, csrfFetch, sourceQuery, showToast, t, onEnabledChange, onRegexChange, onMessageChange, onMessageDirectChange, onChannelsChange, onSkipIncompleteNodesChange, onIgnoredNodesChange, onMatrixChange, onCooldownSecondsChange, onTestMessagesChange]);
+  }, [localRegex, localEnabled, localMessage, localMessageDirect, localEnabledChannels, localSkipIncompleteNodes, localIgnoredNodes, localMatrix, localCooldownSeconds, localPreSendDelaySeconds, testMessages, baseUrl, csrfFetch, sourceQuery, showToast, t, onEnabledChange, onRegexChange, onMessageChange, onMessageDirectChange, onChannelsChange, onSkipIncompleteNodesChange, onIgnoredNodesChange, onMatrixChange, onCooldownSecondsChange, onPreSendDelaySecondsChange, onTestMessagesChange]);
 
   // Register with SaveBar
   useSaveBar({
@@ -461,6 +471,30 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
               />
               <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
                 {t('automation.auto_ack.cooldown_help')}
+              </span>
+            </div>
+          </div>
+
+          {/* Pre-send delay (#3876) — wait before replying so a repeater can finish its TX. */}
+          <div style={{ marginTop: '1rem' }}>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
+              {t('automation.auto_ack.presend_delay_label', 'Pre-Send Delay')}
+            </label>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              {t('automation.auto_ack.presend_delay_description', 'Wait this many seconds before sending the acknowledgement. Gives a repeater time to finish its own transmission so a zero-hop ack is not dropped. 0 sends immediately.')}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <input
+                type="number"
+                value={localPreSendDelaySeconds}
+                onChange={(e) => setLocalPreSendDelaySeconds(Math.max(0, Math.min(120, parseInt(e.target.value) || 0)))}
+                min={0}
+                max={120}
+                disabled={!localEnabled}
+                style={{ width: '80px', padding: '2px 4px' }}
+              />
+              <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+                {t('automation.auto_ack.presend_delay_help', 'seconds (0 = send immediately, max 120)')}
               </span>
             </div>
           </div>

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -19,6 +19,8 @@ interface AutoAckSettings {
   directMessages: boolean;
   useDM: boolean;
   cooldownSeconds: number;
+  /** Pre-send delay (seconds) before the ack reply is sent (#3876). */
+  preSendDelaySeconds: number;
   testMessages: string;
   /** MeshCore scope/region for the ack reply (#3833). */
   scopeMode: ScopeMode;
@@ -42,6 +44,7 @@ const DEFAULTS: AutoAckSettings = {
   directMessages: true,
   useDM: false,
   cooldownSeconds: 0,
+  preSendDelaySeconds: 0,
   testMessages: DEFAULT_TEST_MESSAGES,
   scopeMode: 'inherit',
   scopeName: '',
@@ -108,6 +111,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
           directMessages: !!json.data.directMessages,
           useDM: !!json.data.useDM,
           cooldownSeconds: typeof json.data.cooldownSeconds === 'number' ? json.data.cooldownSeconds : 0,
+          preSendDelaySeconds: typeof json.data.preSendDelaySeconds === 'number' ? json.data.preSendDelaySeconds : 0,
           testMessages: json.data.testMessages || DEFAULT_TEST_MESSAGES,
           scopeMode: (json.data.scopeMode as ScopeMode) || 'inherit',
           scopeName: json.data.scopeName || '',
@@ -158,6 +162,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
       settings.directMessages !== initial.directMessages ||
       settings.useDM !== initial.useDM ||
       settings.cooldownSeconds !== initial.cooldownSeconds ||
+      settings.preSendDelaySeconds !== initial.preSendDelaySeconds ||
       settings.testMessages !== initial.testMessages ||
       settings.scopeMode !== initial.scopeMode ||
       settings.scopeName !== initial.scopeName ||
@@ -186,6 +191,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             directMessages: settings.directMessages,
             useDM: settings.useDM,
             cooldownSeconds: settings.cooldownSeconds,
+            preSendDelaySeconds: settings.preSendDelaySeconds,
             testMessages: settings.testMessages,
             scopeMode: settings.scopeMode,
             scopeName: settings.scopeName,
@@ -405,6 +411,33 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             />
             <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
               {t('meshcore.automation.autoack.cooldown_help', 'seconds (0 = no cooldown)')}
+            </span>
+          </div>
+        </div>
+
+        {/* Pre-send delay (#3876) — wait before replying so a repeater can finish its TX. */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.autoack.presend_delay_label', 'Pre-Send Delay')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.presend_delay_description',
+                'Wait this many seconds before sending the reply. Gives a repeater time to finish its own transmission so a zero-hop ack is not dropped. 0 sends immediately.',
+              )}
+            </span>
+          </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
+            <input
+              type="number"
+              value={settings.preSendDelaySeconds}
+              onChange={(e) => update('preSendDelaySeconds', Math.max(0, Math.min(120, parseInt(e.target.value, 10) || 0)))}
+              min={0}
+              max={120}
+              disabled={disabled || !canWrite}
+              style={{ width: '100px', padding: '2px 4px' }}
+            />
+            <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              {t('meshcore.automation.autoack.presend_delay_help', 'seconds (0 = send immediately, max 120)')}
             </span>
           </div>
         </div>

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -412,6 +412,14 @@ export const ACTIONS: BlockDef[] = [
       { name: 'timeoutSeconds', label: 'Timeout (seconds)', kind: 'number', advanced: true, placeholder: '30' },
     ],
   },
+  {
+    type: 'action.delay',
+    label: 'Pause',
+    description: 'Wait a number of seconds before the next action runs. Use it to space out a sequence — e.g. let a repeater finish transmitting before you reply. Pauses only this run (max 300s); it is not durable across a restart.',
+    fields: [
+      { name: 'seconds', label: 'Seconds', kind: 'number', placeholder: '5', help: 'How long to wait before the next action (0–300).' },
+    ],
+  },
 ];
 
 export const BLOCK_BY_TYPE: Record<string, BlockDef> = Object.fromEntries(

--- a/src/contexts/AutomationContext.tsx
+++ b/src/contexts/AutomationContext.tsx
@@ -23,6 +23,8 @@ interface AutomationContextType {
   setAutoAckMatrix: React.Dispatch<React.SetStateAction<AutoAckMatrix>>;
   autoAckCooldownSeconds: number;
   setAutoAckCooldownSeconds: React.Dispatch<React.SetStateAction<number>>;
+  autoAckPreSendDelaySeconds: number;
+  setAutoAckPreSendDelaySeconds: React.Dispatch<React.SetStateAction<number>>;
   autoAckTestMessages: string;
   setAutoAckTestMessages: React.Dispatch<React.SetStateAction<string>>;
   autoAnnounceEnabled: boolean;
@@ -111,6 +113,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
   const [autoAckIgnoredNodes, setAutoAckIgnoredNodes] = useState<string>('');
   const [autoAckMatrix, setAutoAckMatrix] = useState<AutoAckMatrix>(DEFAULT_AUTOACK_MATRIX);
   const [autoAckCooldownSeconds, setAutoAckCooldownSeconds] = useState<number>(60);
+  const [autoAckPreSendDelaySeconds, setAutoAckPreSendDelaySeconds] = useState<number>(0);
   const [autoAckTestMessages, setAutoAckTestMessages] = useState<string>('');
   const [autoAnnounceEnabled, setAutoAnnounceEnabled] = useState<boolean>(false);
   const [autoAnnounceIntervalHours, setAutoAnnounceIntervalHours] = useState<number>(6);
@@ -194,6 +197,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         if (s.autoAckIgnoredNodes !== undefined) setAutoAckIgnoredNodes(s.autoAckIgnoredNodes);
         setAutoAckMatrix(settingsToMatrix(s));
         if (s.autoAckCooldownSeconds !== undefined) setAutoAckCooldownSeconds(num('autoAckCooldownSeconds', 60));
+        if (s.autoAckPreSendDelaySeconds !== undefined) setAutoAckPreSendDelaySeconds(num('autoAckPreSendDelaySeconds', 0));
         if (s.autoAckTestMessages !== undefined) setAutoAckTestMessages(s.autoAckTestMessages);
 
         if (s.autoAnnounceEnabled !== undefined) setAutoAnnounceEnabled(bool('autoAnnounceEnabled'));
@@ -253,6 +257,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         autoAckIgnoredNodes, setAutoAckIgnoredNodes,
         autoAckMatrix, setAutoAckMatrix,
         autoAckCooldownSeconds, setAutoAckCooldownSeconds,
+        autoAckPreSendDelaySeconds, setAutoAckPreSendDelaySeconds,
         autoAckTestMessages, setAutoAckTestMessages,
         autoAnnounceEnabled, setAutoAnnounceEnabled,
         autoAnnounceIntervalHours, setAutoAnnounceIntervalHours,

--- a/src/server/autoAckDelay.test.ts
+++ b/src/server/autoAckDelay.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAutoAckPreSendDelaySeconds,
+  AUTO_ACK_PRESEND_DELAY_DEFAULT_SECONDS,
+  AUTO_ACK_PRESEND_DELAY_MAX_SECONDS,
+} from './autoAckDelay';
+
+describe('resolveAutoAckPreSendDelaySeconds', () => {
+  it('defaults to 0 (off) when unset, preserving immediate-send behavior', () => {
+    expect(resolveAutoAckPreSendDelaySeconds(null)).toBe(AUTO_ACK_PRESEND_DELAY_DEFAULT_SECONDS);
+    expect(resolveAutoAckPreSendDelaySeconds(undefined)).toBe(0);
+    expect(resolveAutoAckPreSendDelaySeconds('')).toBe(0);
+  });
+
+  it('honors a valid configured value', () => {
+    expect(resolveAutoAckPreSendDelaySeconds('0')).toBe(0);
+    expect(resolveAutoAckPreSendDelaySeconds('5')).toBe(5);
+    expect(resolveAutoAckPreSendDelaySeconds('120')).toBe(120);
+  });
+
+  it('clamps above the 120s maximum', () => {
+    expect(resolveAutoAckPreSendDelaySeconds('300')).toBe(AUTO_ACK_PRESEND_DELAY_MAX_SECONDS);
+  });
+
+  it('falls back to 0 on invalid / negative input', () => {
+    expect(resolveAutoAckPreSendDelaySeconds('-5')).toBe(0);
+    expect(resolveAutoAckPreSendDelaySeconds('abc')).toBe(0);
+  });
+});

--- a/src/server/autoAckDelay.ts
+++ b/src/server/autoAckDelay.ts
@@ -1,0 +1,27 @@
+/**
+ * Auto-acknowledge pre-send delay (#3876).
+ *
+ * When the sender is (or is reached via) a repeater, an auto-ack fired the
+ * instant the trigger message arrives can land while that repeater is still
+ * finishing its own transmission — so a zero-hop reply is dropped. An optional
+ * pre-send delay lets the path settle before we reply. Mirrors the
+ * `autoWelcomeDelay` precedent, but defaults to 0 (off) so existing installs
+ * keep their current immediate-send behavior until a delay is configured.
+ *
+ * Used by both the Meshtastic (`autoAckPreSendDelaySeconds`) and MeshCore
+ * (`meshcoreAutoAckPreSendDelaySeconds`) auto-ack handlers.
+ */
+export const AUTO_ACK_PRESEND_DELAY_DEFAULT_SECONDS = 0;
+export const AUTO_ACK_PRESEND_DELAY_MAX_SECONDS = 120;
+
+/**
+ * Resolve a stored auto-ack pre-send delay setting to a clamped number of
+ * seconds. Absent / empty / invalid / negative values mean "no delay" (0);
+ * values are capped at 120s.
+ */
+export function resolveAutoAckPreSendDelaySeconds(raw: string | null | undefined): number {
+  if (raw == null || raw === '') return AUTO_ACK_PRESEND_DELAY_DEFAULT_SECONDS;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return AUTO_ACK_PRESEND_DELAY_DEFAULT_SECONDS;
+  return Math.min(n, AUTO_ACK_PRESEND_DELAY_MAX_SECONDS);
+}

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -36,6 +36,8 @@ export const VALID_SETTINGS_KEYS = [
   'autoAckMultihopReplyEnabled',
   'autoAckTestMessages',
   'autoAckCooldownSeconds',
+  // Pre-send delay (seconds) before a Meshtastic auto-ack reply is sent (#3876).
+  'autoAckPreSendDelaySeconds',
   // Auto-ack 2x2 matrix (discussion #3564): {Channel,Direct} × {ZeroHop,MultiHop},
   // each cell with Reply / Tapback / Respond-via-DM. These supersede the legacy
   // hop-only keys above (autoAckDirect*/autoAckMultihop*/autoAckUseDM/
@@ -219,6 +221,7 @@ export const VALID_SETTINGS_KEYS = [
   'meshcoreAutoAckDirectMessages',
   'meshcoreAutoAckUseDM',
   'meshcoreAutoAckCooldownSeconds',
+  'meshcoreAutoAckPreSendDelaySeconds',
   'meshcoreAutoAckTestMessages',
   // MeshCore auto-announce
   'meshcoreAutoAnnounceEnabled',
@@ -266,6 +269,7 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   // Auto-ack
   'autoAckChannels',
   'autoAckCooldownSeconds',
+  'autoAckPreSendDelaySeconds',
   'autoAckDirectEnabled',
   'autoAckDirectMessages',
   'autoAckDirectReplyEnabled',
@@ -360,6 +364,7 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'meshcoreAutoAckDirectMessages',
   'meshcoreAutoAckUseDM',
   'meshcoreAutoAckCooldownSeconds',
+  'meshcoreAutoAckPreSendDelaySeconds',
   'meshcoreAutoAckTestMessages',
   // MeshCore auto-announce
   'meshcoreAutoAnnounceEnabled',

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -14,6 +14,7 @@ import { isNullIsland } from '../utils/nullIsland.js';
 import databaseService from '../services/database.js';
 import { dataEventEmitter } from './services/dataEventEmitter.js';
 import { compileAutoAckRegex } from './utils/autoAckRegex.js';
+import { resolveAutoAckPreSendDelaySeconds } from './autoAckDelay.js';
 import { scheduleCron, validateCron, type CronJob } from './utils/cronScheduler.js';
 import { replaceMeshCoreAnnounceTokens } from './utils/meshcoreAnnounceTokens.js';
 import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
@@ -5700,6 +5701,17 @@ class MeshCoreManager extends EventEmitter {
         message.scopeName,
         message.scopeCode,
       );
+
+      // Pre-send delay (#3876): give a repeater time to finish its own TX
+      // before we reply, so a zero-hop ack isn't dropped. 0 = immediate
+      // (default). Safe to await — this handler is invoked fire-and-forget.
+      const preSendDelaySeconds = resolveAutoAckPreSendDelaySeconds(
+        await settings.getSettingForSource(sourceId, 'meshcoreAutoAckPreSendDelaySeconds'),
+      );
+      if (preSendDelaySeconds > 0) {
+        logger.debug(`[MeshCore:${sourceId}] Auto-ack: waiting ${preSendDelaySeconds}s before reply`);
+        await new Promise((resolve) => setTimeout(resolve, preSendDelaySeconds * 1000));
+      }
 
       // Decide destination:
       //  - DM trigger or "always DM" → send as DM (need contact pubkey)

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -33,6 +33,7 @@ import { waypointService } from './services/waypointService.js';
 import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceService.js';
 import { MessageQueueService } from './messageQueueService.js';
 import { resolveAutoWelcomeDelaySeconds } from './autoWelcomeDelay.js';
+import { resolveAutoAckPreSendDelaySeconds } from './autoAckDelay.js';
 import { normalizeTriggerPatterns, normalizeTriggerChannels } from '../utils/autoResponderUtils.js';
 import { isWithinTimeWindow } from './utils/timeWindow.js';
 import { compileUserRegex } from '../utils/safeRegex.js';
@@ -9396,6 +9397,22 @@ class MeshtasticManager implements ISourceManager {
       // sent as DMs are unreliable on Meshtastic, so tapbacks always go back the
       // way the trigger arrived (see resolveAutoAckReplyRouting for reply routing).
 
+      // Pre-send delay (#3876): optionally wait before queuing the ack so a
+      // repeater can finish its own TX (a zero-hop reply sent too early is
+      // dropped). This handler is awaited in the packet path, so we DEFER the
+      // enqueue via setTimeout rather than blocking — matching the
+      // autoWelcomeDelay pattern. 0 = enqueue immediately (default).
+      const preSendDelaySeconds = resolveAutoAckPreSendDelaySeconds(
+        await settings.getSettingForSource(sourceId, 'autoAckPreSendDelaySeconds'),
+      );
+      const dispatchAck = (enqueue: () => void): void => {
+        if (preSendDelaySeconds > 0) {
+          setTimeout(enqueue, preSendDelaySeconds * 1000);
+        } else {
+          enqueue();
+        }
+      };
+
       // --- Tapback (hop-count emoji reaction) ---
       // Delivered the same way the trigger arrived: DM→DM, channel→channel.
       // Note: packetId can be 0 (valid unsigned integer), so check explicitly.
@@ -9409,8 +9426,9 @@ class MeshtasticManager implements ISourceManager {
 
         logger.debug(`🤖 Auto-acknowledging with tapback ${hopEmoji} (${hopsTraveled} hops) to ${tapbackTarget}`);
 
-        // Route tapback through message queue for rate limiting
-        this.messageQueue.enqueue(
+        // Route tapback through message queue for rate limiting (after the
+        // optional pre-send delay).
+        dispatchAck(() => this.messageQueue.enqueue(
           hopEmoji,
           isDirectMessage ? fromNum : 0, // destination: node number for DM, 0 for channel
           packetId, // replyId - react to the original message
@@ -9423,7 +9441,7 @@ class MeshtasticManager implements ISourceManager {
           isDirectMessage ? undefined : channelIndex, // channel
           1, // maxAttempts - tapbacks are best-effort, don't retry
           1 // emoji flag = 1 for tapback/reaction
-        );
+        ));
       }
 
       // --- Message reply ---
@@ -9460,8 +9478,9 @@ class MeshtasticManager implements ISourceManager {
 
         logger.debug(`🤖 Auto-acknowledging message from ${message.fromNodeId}: "${messageText}" with "${ackText}"${replyViaDm ? ' (via DM)' : ''}`);
 
-        // Use message queue to send auto-acknowledge with rate limiting and retry logic
-        this.messageQueue.enqueue(
+        // Use message queue to send auto-acknowledge with rate limiting and
+        // retry logic (after the optional pre-send delay).
+        dispatchAck(() => this.messageQueue.enqueue(
           ackText,
           replyDest, // destination: node number for DM, 0 for channel
           replyId, // replyId
@@ -9472,7 +9491,7 @@ class MeshtasticManager implements ISourceManager {
             logger.warn(`❌ Auto-acknowledge message failed to ${replyTarget}: ${reason}`);
           },
           replyChannel // channel: undefined for DM, channel number for channel
-        );
+        ));
       }
 
       // Record cooldown timestamp after successful response

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -225,6 +225,8 @@ describe('MeshCore Routes', () => {
 
     (DatabaseService as any).settings = {
       getSetting: vi.fn(async () => null),
+      getSettingForSource: vi.fn(async () => null),
+      setSourceSetting: vi.fn(async () => undefined),
     };
 
     // Saved-regions catalog mock (#3770). Tests override these per-case.
@@ -289,7 +291,7 @@ describe('MeshCore Routes', () => {
       authProvider: 'local'
     });
 
-    for (const resource of ['connection', 'nodes', 'messages', 'configuration', 'remote_admin', 'packetmonitor'] as const) {
+    for (const resource of ['connection', 'nodes', 'messages', 'configuration', 'remote_admin', 'packetmonitor', 'automation'] as const) {
       await permissionModel.grant({
         userId: user.id,
         resource,
@@ -368,6 +370,28 @@ describe('MeshCore Routes', () => {
         `/api/sources/test-source/meshcore/nodes/${VALID_KEY}/position-history?since=-1`,
       );
       expect(mockPositionHistoryService.getPositionHistory).toHaveBeenCalledWith('test-source', VALID_KEY, undefined);
+    });
+  });
+
+  describe('Auto-ack pre-send delay (#3876)', () => {
+    it('GET /automation/autoack returns the stored pre-send delay', async () => {
+      (DatabaseService as any).settings.getSettingForSource = vi.fn(async (_s: string, key: string) =>
+        key === 'meshcoreAutoAckPreSendDelaySeconds' ? '15' : null,
+      );
+      const response = await authenticatedAgent.get('/api/sources/test-source/meshcore/automation/autoack');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.preSendDelaySeconds).toBe(15);
+    });
+
+    it('POST /automation/autoack clamps the pre-send delay to 120s', async () => {
+      const setSpy = vi.fn(async () => undefined);
+      (DatabaseService as any).settings.setSourceSetting = setSpy;
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/automation/autoack')
+        .send({ preSendDelaySeconds: 9999 });
+      expect(response.status).toBe(200);
+      expect(setSpy).toHaveBeenCalledWith('test-source', 'meshcoreAutoAckPreSendDelaySeconds', '120');
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2947,6 +2947,7 @@ router.get(
       const directMessages = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckDirectMessages');
       const useDM = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckUseDM');
       const cooldownSeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckCooldownSeconds');
+      const preSendDelaySeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckPreSendDelaySeconds');
       const testMessages = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckTestMessages');
       const scopeMode = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeMode');
       const scopeName = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeName');
@@ -2966,6 +2967,7 @@ router.get(
           directMessages: directMessages === 'true',
           useDM: useDM === 'true',
           cooldownSeconds: parseInt(cooldownSeconds || '0', 10) || 0,
+          preSendDelaySeconds: parseInt(preSendDelaySeconds || '0', 10) || 0,
           testMessages: testMessages || 'test\nTest message\nping\nPING\nHello world\nTESTING 123',
           // MeshCore scope/region for the ack reply (#3833).
           scopeMode: (scopeMode as 'inherit' | 'trigger' | 'unscoped' | 'named') || 'inherit',
@@ -2995,6 +2997,7 @@ router.post(
         directMessages,
         useDM,
         cooldownSeconds,
+        preSendDelaySeconds,
         testMessages,
         scopeMode,
         scopeName,
@@ -3006,6 +3009,7 @@ router.post(
         directMessages?: boolean;
         useDM?: boolean;
         cooldownSeconds?: number;
+        preSendDelaySeconds?: number;
         testMessages?: string;
         scopeMode?: 'inherit' | 'trigger' | 'unscoped' | 'named';
         scopeName?: string;
@@ -3044,6 +3048,12 @@ router.post(
       if (cooldownSeconds !== undefined) {
         const clamped = Math.max(0, Math.min(3600, cooldownSeconds));
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAckCooldownSeconds', String(clamped));
+      }
+      if (preSendDelaySeconds !== undefined) {
+        // Pre-send delay caps at 120s (#3876) — long enough to let a repeater
+        // settle, short enough that an ack stays prompt.
+        const clamped = Math.max(0, Math.min(120, preSendDelaySeconds));
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckPreSendDelaySeconds', String(clamped));
       }
       if (testMessages !== undefined) {
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAckTestMessages', testMessages);

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -25,6 +25,7 @@ import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiter
 import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.js';
 import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
 import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
+import { resolveAutoAckPreSendDelaySeconds } from '../autoAckDelay.js';
 
 /**
  * Resolve the manager for a request. Mounted only under
@@ -2967,7 +2968,9 @@ router.get(
           directMessages: directMessages === 'true',
           useDM: useDM === 'true',
           cooldownSeconds: parseInt(cooldownSeconds || '0', 10) || 0,
-          preSendDelaySeconds: parseInt(preSendDelaySeconds || '0', 10) || 0,
+          // Defense-in-depth: clamp on read too (default 0, cap 120s) so a
+          // value written directly to the DB can't escape the UI's bounds.
+          preSendDelaySeconds: resolveAutoAckPreSendDelaySeconds(preSendDelaySeconds),
           testMessages: testMessages || 'test\nTest message\nping\nPING\nHello world\nTESTING 123',
           // MeshCore scope/region for the ack reply (#3833).
           scopeMode: (scopeMode as 'inherit' | 'trigger' | 'unscoped' | 'named') || 'inherit',

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -453,6 +453,16 @@ describe('executeAction', () => {
     expect(slept).toEqual([]);
   });
 
+  it('delay: non-numeric / non-finite seconds is treated as 0 (never sleeps)', async () => {
+    const { deps } = recorder();
+    const slept: number[] = [];
+    const sleep = async (ms: number) => { slept.push(ms); };
+    expect(await executeAction(node('action.delay', { seconds: 'garbage' }), ctx({}), { ...deps, sleep })).toEqual({ delayedSeconds: 0 });
+    expect(await executeAction(node('action.delay', { seconds: NaN }), ctx({}), { ...deps, sleep })).toEqual({ delayedSeconds: 0 });
+    expect(await executeAction(node('action.delay', { seconds: {} }), ctx({}), { ...deps, sleep })).toEqual({ delayedSeconds: 0 });
+    expect(slept).toEqual([]);
+  });
+
   it('delay: clamps to the 300s cap and floors fractional seconds', async () => {
     const { deps } = recorder();
     const slept: number[] = [];

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -435,4 +435,30 @@ describe('executeAction', () => {
     const { deps } = recorder();
     await expect(executeAction(node('action.runScript', {}), ctx({}), deps)).rejects.toThrow(/no scriptPath/);
   });
+
+  it('delay: waits the requested seconds via the injected sleep', async () => {
+    const { deps } = recorder();
+    const slept: number[] = [];
+    const out = await executeAction(node('action.delay', { seconds: 5 }), ctx({}), { ...deps, sleep: async (ms) => { slept.push(ms); } });
+    expect(slept).toEqual([5000]);
+    expect(out).toEqual({ delayedSeconds: 5 });
+  });
+
+  it('delay: zero / missing seconds never sleeps', async () => {
+    const { deps } = recorder();
+    const slept: number[] = [];
+    const sleep = async (ms: number) => { slept.push(ms); };
+    expect(await executeAction(node('action.delay', { seconds: 0 }), ctx({}), { ...deps, sleep })).toEqual({ delayedSeconds: 0 });
+    expect(await executeAction(node('action.delay', {}), ctx({}), { ...deps, sleep })).toEqual({ delayedSeconds: 0 });
+    expect(slept).toEqual([]);
+  });
+
+  it('delay: clamps to the 300s cap and floors fractional seconds', async () => {
+    const { deps } = recorder();
+    const slept: number[] = [];
+    const sleep = async (ms: number) => { slept.push(ms); };
+    await executeAction(node('action.delay', { seconds: 9999 }), ctx({}), { ...deps, sleep });
+    await executeAction(node('action.delay', { seconds: 2.9 }), ctx({}), { ...deps, sleep });
+    expect(slept).toEqual([300_000, 2_000]);
+  });
 });

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -6,7 +6,7 @@
  * logic (DM vs channel, target source/node resolution, tapback replyId) is
  * unit-tested without a live node. The real deps wiring lives in meshActionDeps.ts.
  */
-import type { AutomationNode } from '../../../types/automation.js';
+import { type AutomationNode, AUTOMATION_DELAY_MAX_SECONDS } from '../../../types/automation.js';
 import { type EngineEvalContext, interpolateAsync, resolveOperand } from './engineContext.js';
 
 export type NodeManageOp = 'favorite' | 'unfavorite' | 'ignore' | 'unignore' | 'delete';
@@ -47,6 +47,8 @@ export interface ActionDeps {
   /** Run a user script file (in $DATA_DIR/scripts) with the given env. Never throws — returns the outcome. */
   runScript(a: { scriptPath: string; env: Record<string, string>; timeoutMs?: number }):
     Promise<{ success: boolean; returnValue?: unknown; stdout: string; error?: string }>;
+  /** Pause for `ms` (action.delay). Optional/injectable so tests don't wait in real time. */
+  sleep?(ms: number): Promise<void>;
 }
 
 /**
@@ -121,6 +123,19 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
   switch (node.type) {
     case 'action.nothing':
       return undefined; // no-op — used so a rule can contribute only its IF result to a FINALLY step
+
+    case 'action.delay': {
+      // Bounded, in-process pause that serializes with the sequential executor:
+      // later actions in the chain wait for it. Clamped to [0, MAX]; not durable
+      // across a restart (the run is in-memory).
+      const raw = Number((p as Record<string, unknown>).seconds);
+      const seconds = Number.isFinite(raw) ? Math.max(0, Math.min(AUTOMATION_DELAY_MAX_SECONDS, Math.floor(raw))) : 0;
+      if (seconds > 0) {
+        const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+        await sleep(seconds * 1000);
+      }
+      return { delayedSeconds: seconds };
+    }
 
     case 'action.runScript': {
       const scriptPath = String(p.scriptPath ?? '');

--- a/src/server/services/automation/automationSimulator.ts
+++ b/src/server/services/automation/automationSimulator.ts
@@ -118,6 +118,8 @@ function recordingDeps(): ActionDeps {
     async notify(a) { return { action: 'notify', ...a }; },
     // Dry-run must never spawn a process — report success without executing.
     async runScript() { return { success: true, stdout: '' }; },
+    // Dry-run must never actually wait — resolve the pause instantly.
+    async sleep() { /* no real wait in the simulator */ },
   };
 }
 

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -40,9 +40,15 @@ export type ActionType =
   | 'action.nodeManage'
   | 'action.requestData'
   | 'action.notify'
-  | 'action.runScript';
+  | 'action.runScript'
+  | 'action.delay';
 
-// flow.delay is intentionally absent — deferred to Phase 1b (stateful waits).
+// `action.delay` is a BOUNDED, in-process pause (caps at AUTOMATION_DELAY_MAX_SECONDS)
+// that blocks only its own run — it serializes naturally with the sequential,
+// awaited action executor. A DURABLE wait that survives a restart (the original
+// "flow.delay" Phase-1b idea) is still deferred; this is deliberately not that.
+export const AUTOMATION_DELAY_MAX_SECONDS = 300;
+
 export type FlowType = 'flow.fanout' | 'flow.collapse' | 'flow.setVar';
 
 export type AutomationNodeType = TriggerType | ConditionType | ActionType | FlowType;
@@ -78,6 +84,7 @@ export const ACTION_TYPES: readonly ActionType[] = [
   'action.requestData',
   'action.notify',
   'action.runScript',
+  'action.delay',
 ];
 
 export const FLOW_TYPES: readonly FlowType[] = ['flow.fanout', 'flow.collapse', 'flow.setVar'];
@@ -333,6 +340,13 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
             errors.push(`action.requestData "${n.id}" requires a valid params.op`);
           }
           break;
+        case 'action.delay': {
+          const secs = Number(p.seconds);
+          if (!Number.isFinite(secs) || secs < 0 || secs > AUTOMATION_DELAY_MAX_SECONDS) {
+            errors.push(`action.delay "${n.id}" requires params.seconds ∈ [0, ${AUTOMATION_DELAY_MAX_SECONDS}]`);
+          }
+          break;
+        }
         default:
           break;
       }


### PR DESCRIPTION
## Summary

Addresses #3876 (configurable pre-send delay for MeshCore Auto-Ack) and generalizes it per maintainer guidance: rather than only a single-purpose delay, this adds a reusable **Pause** building block to the Automation Engine *and* a pre-send delay on the built-in Auto-Ack for **both** protocols.

### Automation Engine — new `action.delay` ("Pause")
- A **bounded (≤300s) in-process pause** that serializes naturally with the sequential, awaited action executor — later actions in a branch wait for it. Deliberately **not** the deferred durable/stateful wait (kept out of scope).
- **Multiple sequential actions per condition/finally branch already work** (the compiler chains `rule.actions[]` / `combine.actions[]`), so users can now build their own delayed auto-ack: `message trigger → Pause → Send message`.
- Wired through types + validation, the builder catalog, and the executor. The dry-run **simulator resolves the pause instantly** (no real wait).

### Auto-Acknowledge — configurable pre-send delay (Meshtastic + MeshCore)
- Shared resolver `autoAckDelay.ts` (default **0 = immediate**, cap **120s**), mirroring the `autoWelcomeDelay` precedent. New per-source settings `autoAckPreSendDelaySeconds` / `meshcoreAutoAckPreSendDelaySeconds`.
- **MeshCore**: awaits the delay before sending (handler is fire-and-forget).
- **Meshtastic**: defers the queue `enqueue` via `setTimeout` (handler is awaited in the packet path) so packet processing isn't blocked.
- **UI**: a "Pre-Send Delay" field in both the Meshtastic `AutoAcknowledgeSection` and the MeshCore auto-ack section, threaded through `AutomationContext` + `App` and the MeshCore autoack route.

## Why this shape
The repeater-settle problem in #3876 is real, but a fixed single delay is narrow. Sequential multi-action branches + a Pause action let users compose *any* timed sequence, while the built-in Auto-Ack delay keeps the common case one field away.

## Testing
- `action.delay` executor (injected sleep — clamp to 300s / floor / zero-skip).
- `autoAckDelay` resolver (default 0, clamp 120, invalid/negative → 0).
- MeshCore autoack route round-trip (GET returns stored delay; POST clamps to 120s).
- Existing auto-ack manager + automation suites unchanged. **Full suite green** (546 files); `tsc` adds no new errors; lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)