### PR TITLE
fix(meshcore): stop re-fetching saved regions/default scope on every render

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -311,19 +311,26 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // Load the source default scope when (re)connected so the override control can
   // show the baseline. This is a cheap local DB read (no radio traffic), so it's
   // safe to re-run on reconnect.
+  //
+  // Depend on the specific action function, not the whole `actions` object —
+  // `useMeshCore` returns a fresh `actions` object literal on every render, so
+  // depending on `actions` re-fires this effect (and re-hits the network) on
+  // every status/message/node update from the mesh, even with zero user
+  // interaction (#3880).
+  const { getDefaultScope, fetchSavedRegions, discoverRegions } = actions;
   useEffect(() => {
     if (!status?.connected) return;
     let cancelled = false;
     (async () => {
       try {
-        const def = await actions.getDefaultScope();
+        const def = await getDefaultScope();
         if (!cancelled) setDefaultScope(def ?? '');
       } catch {
         /* non-fatal — the override still works without a baseline */
       }
     })();
     return () => { cancelled = true; };
-  }, [status?.connected, actions]);
+  }, [status?.connected, getDefaultScope]);
 
   // Load the global saved-regions catalog (#3770) for the override suggestions.
   // This is a cheap local DB read (no radio traffic), so it's safe to run on
@@ -332,14 +339,14 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     let cancelled = false;
     (async () => {
       try {
-        const rows = await actions.fetchSavedRegions();
+        const rows = await fetchSavedRegions();
         if (!cancelled && rows) setSavedRegions(rows.map(r => r.name));
       } catch {
         /* non-fatal — suggestions are optional */
       }
     })();
     return () => { cancelled = true; };
-  }, [actions, sourceId]);
+  }, [fetchSavedRegions, sourceId]);
 
   // Union of saved + discovered regions, de-duplicated, for the override
   // datalist. Saved regions come first (operator-curated), then any extra
@@ -364,7 +371,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     let cancelled = false;
     (async () => {
       try {
-        const res = await actions.discoverRegions();
+        const res = await discoverRegions();
         if (!cancelled && res?.regions) setDiscoveredRegions(res.regions);
       } catch {
         regionsDiscoveredRef.current = false; // allow a retry on next open
@@ -372,7 +379,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       }
     })();
     return () => { cancelled = true; };
-  }, [showScopeOverride, status?.connected, actions]);
+  }, [showScopeOverride, status?.connected, discoverRegions]);
 
   // Reset the one-off override when switching channels so it never leaks across
   // channels, and collapse the control back to its unobtrusive default.


### PR DESCRIPTION
## Summary

- Fixes #3880 — the intermittent, seemingly-random "Failed to load saved regions" red error banner in the MeshCore UI.
- Root cause: `MeshCoreChannelsView` had three `useEffect` hooks that depended on the *entire* `actions` object returned by `useMeshCore`. That object is a fresh literal on every render of `useMeshCore` (not memoized), and the MeshCore page re-renders constantly from live mesh traffic — a 30s status safety-poll plus every incoming message/node/status WebSocket event — none of which require any user to be looking at the screen.
- Because the effects' dependency arrays included the whole `actions` object, they re-fired on essentially every render, repeatedly hitting `GET .../saved-regions` and `GET .../config/default-scope` in the background. Any transient hiccup on one of those many redundant requests (network blip, brief backend hiccup, etc.) set the hook's `error` state, which renders as a sticky, unprompted red banner across the whole MeshCore page — matching the report that it "happens even if no one [is] actively using MeshMonitor."
- Fix: depend on the specific callback each effect actually calls (`actions.getDefaultScope`, `actions.fetchSavedRegions`, `actions.discoverRegions`) instead of the whole `actions` object. Each of those is already an independently-stabilized `useCallback` (with stable deps), so this makes the effects fire only when they're actually supposed to (mount / reconnect / explicit user action), not on every incidental re-render.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/components/MeshCore/` — 14 files / 119 tests pass
- [x] `npx eslint src/components/MeshCore/MeshCoreChannelsView.tsx` — no new warnings/errors
- [ ] CI (system tests, full suite)

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01DBg6o5eCohJFpWeVvkCJf5)_