### PR TITLE
fix(meshcore): make contact removal stick — stop re-sync resurrecting deleted nodes (#3878)

### DIFF
--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -205,6 +205,24 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     await expect(repo.upsertNode({ publicKey: 'pk-1' }, '')).rejects.toThrow(/requires a sourceId/);
   });
 
+  it('deleteNode reports whether a row was actually removed (#3878)', async () => {
+    await repo.upsertNode({ publicKey: 'pk-del', name: 'Doomed' }, 'src-a');
+
+    // No match (wrong source) → false, and the row survives.
+    expect(await repo.deleteNode('pk-del', 'src-other')).toBe(false);
+    expect(await repo.getNodeByPublicKeyAndSource('pk-del', 'src-a')).not.toBeNull();
+
+    // Unknown key → false.
+    expect(await repo.deleteNode('pk-missing', 'src-a')).toBe(false);
+
+    // Real match → true, and the row is gone.
+    expect(await repo.deleteNode('pk-del', 'src-a')).toBe(true);
+    expect(await repo.getNodeByPublicKeyAndSource('pk-del', 'src-a')).toBeNull();
+
+    // Deleting again (already gone) → false.
+    expect(await repo.deleteNode('pk-del', 'src-a')).toBe(false);
+  });
+
   it('insertMessage stamps sourceId', async () => {
     await repo.insertMessage(
       {

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -730,10 +730,14 @@ export class MeshCoreRepository extends BaseRepository {
       throw new Error('MeshCoreRepository.deleteNode requires a sourceId');
     }
     const { meshcoreNodes } = this.tables;
-    await this.db
+    // Report whether a row was actually removed. Returning `true`
+    // unconditionally (the old behavior) made a no-op delete — e.g. a
+    // publicKey that doesn't match any stored row — look successful, so the
+    // UI reported "removed" while the orphan stayed (#3878).
+    const result = await this.db
       .delete(meshcoreNodes)
       .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
-    return true;
+    return this.getAffectedRows(result) > 0;
   }
 
   /**

--- a/src/server/meshcoreManager.contactRemoval.test.ts
+++ b/src/server/meshcoreManager.contactRemoval.test.ts
@@ -30,9 +30,10 @@ vi.mock('./services/notificationService.js', () => ({
   notificationService: { notifyNewMeshCoreNode: vi.fn().mockResolvedValue(undefined) },
 }));
 
+const emitMeshCoreContactUpdated = vi.fn();
 vi.mock('./services/dataEventEmitter.js', () => ({
   dataEventEmitter: {
-    emitMeshCoreContactUpdated: vi.fn(),
+    emitMeshCoreContactUpdated: (...args: unknown[]) => emitMeshCoreContactUpdated(...args),
     emitMeshCoreMessage: vi.fn(),
     emitMeshCoreSelfInfoUpdated: vi.fn(),
   },
@@ -63,6 +64,7 @@ describe('MeshCore contact removal + resurrection guard (#3878)', () => {
     upsertNode.mockClear();
     deleteNode.mockClear();
     deleteNode.mockResolvedValue(true);
+    emitMeshCoreContactUpdated.mockClear();
   });
 
   it('forgetLocalContact tombstones the key so a re-sync cannot resurrect it', async () => {
@@ -95,11 +97,14 @@ describe('MeshCore contact removal + resurrection guard (#3878)', () => {
     );
   });
 
-  it('forgetLocalContact returns false for a key that matched neither a row nor memory', async () => {
+  it('forgetLocalContact returns false and emits nothing for a key that matched neither a row nor memory', async () => {
     const manager = new MeshCoreManager('src-a');
     deleteNode.mockResolvedValue(false); // no stored row
     const ok = await manager.forgetLocalContact('deadbeef'.repeat(8));
     expect(ok).toBe(false);
+    // A genuine no-op must not fire the removed-contact push — the UI would
+    // otherwise flicker (node vanishes then reappears on the next poll).
+    expect(emitMeshCoreContactUpdated).not.toHaveBeenCalled();
   });
 
   it('forgetLocalContact returns true when only an in-memory contact existed', async () => {

--- a/src/server/meshcoreManager.contactRemoval.test.ts
+++ b/src/server/meshcoreManager.contactRemoval.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for MeshCore contact removal + the resurrection guard (issue #3878).
+ *
+ * A room server that no longer exists on the network can linger on the
+ * companion's saved-contact list. Deleting it from MeshMonitor used to be
+ * undone by the next advert-triggered / reconnect `get_contacts` sync, which
+ * re-`persistContact`s every device contact — so "Remove" appeared to do
+ * nothing. Removal now tombstones the key so re-sync can't resurrect the row,
+ * and a live advert (or the TTL) lifts the tombstone.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+const deleteNode = vi.fn().mockResolvedValue(true);
+const getSource = vi.fn().mockResolvedValue({ name: 'Source A' });
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+      deleteNode: (...args: unknown[]) => deleteNode(...args),
+    },
+    sources: {
+      getSource: (...args: unknown[]) => getSource(...args),
+    },
+  },
+}));
+
+vi.mock('./services/notificationService.js', () => ({
+  notificationService: { notifyNewMeshCoreNode: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: vi.fn(),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+function advertise(m: MeshCoreManager, publicKey: string): void {
+  // @ts-expect-error - exercising the private bridge-event path
+  m.handleBridgeEvent({
+    event_type: 'contact_advertised',
+    data: { public_key: publicKey, adv_name: 'Room1', adv_type: MeshCoreDeviceType.ROOM_SERVER },
+  });
+}
+
+/** Simulate the get_contacts bulk re-sync's per-contact persist. */
+async function resyncPersist(m: MeshCoreManager, publicKey: string): Promise<void> {
+  // @ts-expect-error - persistContact is private; the bulk refresh calls it per contact
+  await m.persistContact({ publicKey, advName: 'Room1', advType: MeshCoreDeviceType.ROOM_SERVER });
+}
+
+describe('MeshCore contact removal + resurrection guard (#3878)', () => {
+  const PUBKEY = 'c2' + 'a'.repeat(62);
+
+  beforeEach(() => {
+    upsertNode.mockClear();
+    deleteNode.mockClear();
+    deleteNode.mockResolvedValue(true);
+  });
+
+  it('forgetLocalContact tombstones the key so a re-sync cannot resurrect it', async () => {
+    const manager = new MeshCoreManager('src-a');
+
+    const ok = await manager.forgetLocalContact(PUBKEY);
+    expect(ok).toBe(true);
+    expect(deleteNode).toHaveBeenCalledWith(PUBKEY, 'src-a');
+
+    // The lingering device contact comes back in the next get_contacts sync —
+    // persistContact must NOT re-insert it while the tombstone holds.
+    await resyncPersist(manager, PUBKEY);
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('a live advert lifts the tombstone so the node syncs again', async () => {
+    const manager = new MeshCoreManager('src-a');
+    await manager.forgetLocalContact(PUBKEY);
+
+    // Suppressed…
+    await resyncPersist(manager, PUBKEY);
+    expect(upsertNode).not.toHaveBeenCalled();
+
+    // …until a genuine advert proves the node is back.
+    advertise(manager, PUBKEY);
+    await flush();
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: PUBKEY }),
+      'src-a',
+    );
+  });
+
+  it('forgetLocalContact returns false for a key that matched neither a row nor memory', async () => {
+    const manager = new MeshCoreManager('src-a');
+    deleteNode.mockResolvedValue(false); // no stored row
+    const ok = await manager.forgetLocalContact('deadbeef'.repeat(8));
+    expect(ok).toBe(false);
+  });
+
+  it('forgetLocalContact returns true when only an in-memory contact existed', async () => {
+    const manager = new MeshCoreManager('src-a');
+    advertise(manager, PUBKEY); // populate in-memory contact
+    await flush();
+    upsertNode.mockClear();
+    deleteNode.mockResolvedValue(false); // nothing persisted yet
+
+    const ok = await manager.forgetLocalContact(PUBKEY);
+    expect(ok).toBe(true);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1627,6 +1627,11 @@ class MeshCoreManager extends EventEmitter {
       // Don't resurrect a just-removed contact (#3878). persistContact is called
       // from many event handlers (bulk sync, advert pushes, path updates), so
       // guarding here — not only in refreshContacts — closes every re-insert path.
+      // The `this.contacts.delete` here is a deliberate belt-and-braces cleanup,
+      // not just a DB guard: a caller can race a stale in-memory entry back in
+      // between removal and this persist (e.g. a debounced refreshContacts()
+      // queued just before the tombstone was set), so we scrub the map too
+      // rather than only skipping the DB write.
       if (this.isContactTombstoned(contact.publicKey)) {
         this.contacts.delete(contact.publicKey);
         return;
@@ -3280,12 +3285,17 @@ class MeshCoreManager extends EventEmitter {
       logger.warn(`[MeshCore:${this.sourceId}] forgetLocalContact deleteNode failed: ${(err as Error).message}`);
       return false;
     }
-    this.emit('contact_removed', { sourceId: this.sourceId, publicKey });
-    dataEventEmitter.emitMeshCoreContactUpdated({ publicKey, removed: true } as any, this.sourceId);
-    logger.info(`[MeshCore:${this.sourceId}] Forgot local contact ${publicKey.substring(0, 16)}… (row=${deletedRow}, mem=${hadInMemory})`);
     // Success when we removed a stored row or an in-memory entry. A key that
-    // matched neither is a genuine no-op the caller should surface as failure.
-    return deletedRow || hadInMemory;
+    // matched neither is a genuine no-op — don't fire the removed-contact event
+    // in that case, or the UI would flicker (node briefly vanishes on the
+    // WebSocket push, then reappears once the next poll finds it unchanged).
+    const removed = deletedRow || hadInMemory;
+    if (removed) {
+      this.emit('contact_removed', { sourceId: this.sourceId, publicKey });
+      dataEventEmitter.emitMeshCoreContactUpdated({ publicKey, removed: true } as any, this.sourceId);
+    }
+    logger.info(`[MeshCore:${this.sourceId}] Forgot local contact ${publicKey.substring(0, 16)}… (row=${deletedRow}, mem=${hadInMemory})`);
+    return removed;
   }
 
   /**

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -615,6 +615,17 @@ class MeshCoreManager extends EventEmitter {
   private localNode: MeshCoreNode | null = null;
   private contacts: Map<string, MeshCoreContact> = new Map();
   /**
+   * Recently-removed contacts (lowercased publicKey → tombstone-expiry ms).
+   * When a contact still lives on the companion's saved-contact list, an
+   * advert-triggered or reconnect `get_contacts` re-sync would otherwise
+   * re-insert the row we just deleted, so a "Remove" appears to do nothing
+   * (#3878). While a key is tombstoned we skip re-adding it on sync; the entry
+   * self-expires after TOMBSTONE_TTL_MS so a genuinely re-added contact can
+   * come back, and is cleared immediately if the user re-adds it.
+   */
+  private removedContacts: Map<string, number> = new Map();
+  private static readonly TOMBSTONE_TTL_MS = 60 * 60 * 1000; // 1 hour
+  /**
    * Collector for an in-flight `discoverNodes()` burst. NODE_DISCOVER_RESP
    * pushes arrive asynchronously over a few seconds; `node_discovered` bridge
    * events feed this so the awaiting call can report how many unique nodes
@@ -1176,6 +1187,10 @@ class MeshCoreManager extends EventEmitter {
     } else if (event_type === 'contact_advertised' || event_type === 'contact_added') {
       const publicKey: string = data.public_key;
       if (publicKey) {
+        // A live advert means this node is genuinely back — lift any removal
+        // tombstone so it syncs normally again (#3878). The reporter's gone
+        // room server never adverts, so it stays suppressed.
+        this.clearContactTombstone(publicKey);
         // Captured before the set below: a contact we didn't already know about
         // is a genuine new-node discovery. Bulk contact-list sync populates
         // this.contacts directly (not via this event), so a first connect
@@ -1609,6 +1624,13 @@ class MeshCoreManager extends EventEmitter {
    */
   private async persistContact(contact: MeshCoreContact): Promise<void> {
     try {
+      // Don't resurrect a just-removed contact (#3878). persistContact is called
+      // from many event handlers (bulk sync, advert pushes, path updates), so
+      // guarding here — not only in refreshContacts — closes every re-insert path.
+      if (this.isContactTombstoned(contact.publicKey)) {
+        this.contacts.delete(contact.publicKey);
+        return;
+      }
       // Drop "Null Island" (0,0) fixes — the GPS default before a lock — so a
       // bogus position never lands in the node row (issue #3763).
       const atNullIsland = isNullIsland(contact.latitude, contact.longitude);
@@ -2222,6 +2244,11 @@ class MeshCoreManager extends EventEmitter {
         this.contacts.clear();
         const nowMs = Date.now();
         for (const c of response.data) {
+          // Skip contacts the user just removed that still linger on the
+          // companion's saved-contact list — re-adding them here is exactly
+          // what resurrected deleted rows before (#3878). The tombstone expires
+          // (or is cleared by a live advert), so a genuine re-add still syncs.
+          if (this.isContactTombstoned(c.public_key)) continue;
           // Preserve the real Last Heard across reconnect (#3645). The companion
           // reports each contact's last advert time (epoch seconds) — use it for
           // lastSeen instead of the reconnect wall-clock, which previously reset
@@ -3184,6 +3211,9 @@ class MeshCoreManager extends EventEmitter {
         return false;
       }
       this.contacts.delete(publicKey);
+      // Tombstone before the DB delete so an advert-triggered refresh that races
+      // in can't re-persist the row we're removing (#3878).
+      this.tombstoneContact(publicKey);
       try {
         await databaseService.meshcore.deleteNode(publicKey, this.sourceId);
       } catch (err) {
@@ -3199,6 +3229,34 @@ class MeshCoreManager extends EventEmitter {
     }
   }
 
+  /** Tombstone a removed contact so `get_contacts` re-sync won't resurrect it (#3878). */
+  private tombstoneContact(publicKey: string): void {
+    if (!publicKey) return;
+    this.removedContacts.set(publicKey.toLowerCase(), Date.now() + MeshCoreManager.TOMBSTONE_TTL_MS);
+  }
+
+  /** True while `publicKey` is under an unexpired removal tombstone. Prunes on read. */
+  private isContactTombstoned(publicKey: string): boolean {
+    const key = publicKey.toLowerCase();
+    const expiry = this.removedContacts.get(key);
+    if (expiry === undefined) return false;
+    if (Date.now() >= expiry) {
+      this.removedContacts.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Clear a removal tombstone — the contact is genuinely back (a live advert
+   * from that key, or an explicit user re-add), so it should sync normally.
+   */
+  private clearContactTombstone(publicKey: string): void {
+    if (this.removedContacts.delete(publicKey.toLowerCase())) {
+      logger.debug(`[MeshCore:${this.sourceId}] Cleared removal tombstone for ${publicKey.substring(0, 16)}…`);
+    }
+  }
+
   /**
    * Forget a contact locally: delete its meshcore_nodes row and in-memory entry
    * and fire a contact-updated push — WITHOUT the device round-trip that
@@ -3209,17 +3267,25 @@ class MeshCoreManager extends EventEmitter {
    * and regardless of device type.
    */
   async forgetLocalContact(publicKey: string): Promise<boolean> {
-    this.contacts.delete(publicKey);
+    const hadInMemory = this.contacts.delete(publicKey);
+    // Tombstone regardless of the DB outcome: the contact still lives on the
+    // companion's saved-contact list, so without this the next advert-triggered
+    // or reconnect `get_contacts` re-sync re-inserts the row and the "Remove"
+    // appears to do nothing (#3878).
+    this.tombstoneContact(publicKey);
+    let deletedRow: boolean;
     try {
-      await databaseService.meshcore.deleteNode(publicKey, this.sourceId);
+      deletedRow = await databaseService.meshcore.deleteNode(publicKey, this.sourceId);
     } catch (err) {
       logger.warn(`[MeshCore:${this.sourceId}] forgetLocalContact deleteNode failed: ${(err as Error).message}`);
       return false;
     }
     this.emit('contact_removed', { sourceId: this.sourceId, publicKey });
     dataEventEmitter.emitMeshCoreContactUpdated({ publicKey, removed: true } as any, this.sourceId);
-    logger.info(`[MeshCore:${this.sourceId}] Forgot local contact ${publicKey.substring(0, 16)}…`);
-    return true;
+    logger.info(`[MeshCore:${this.sourceId}] Forgot local contact ${publicKey.substring(0, 16)}… (row=${deletedRow}, mem=${hadInMemory})`);
+    // Success when we removed a stored row or an in-memory entry. A key that
+    // matched neither is a genuine no-op the caller should surface as failure.
+    return deletedRow || hadInMemory;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the orphaned-node report in #3878. A MeshCore contact that still lingers on the companion's saved-contact list — e.g. an **old room server that's gone from the network** — was resurrected immediately after deletion, so "Remove" appeared to do nothing.

## Root cause

`refreshContacts()` (device `get_contacts` → bulk `persistContact` → `upsertNode`) fires on connect **and on every advert push** (debounced). It re-persists *every* device contact, so deleting a row from `meshcore_nodes` was undone by the next sync. Compounding it, `deleteNode` returned `true` unconditionally — even a 0-row delete looked successful, so the UI reported "removed" when nothing was.

## Fix

1. **Honest `deleteNode`** — returns real rows-affected (`getAffectedRows`), so a non-matching key reports failure. `forgetLocalContact` returns success only when it actually removed a stored row or an in-memory entry (the remove route already turns a `false` into a 409).
2. **Removal tombstone** — `removeContact`/`forgetLocalContact` tombstone the key (1h TTL, in-memory). While tombstoned, `refreshContacts` and `persistContact` skip re-adding it, so a re-sync can't resurrect it. A **live advert** from that key (node genuinely back) clears the tombstone immediately; a gone room server never adverts, so it stays removed.

## Immediate workaround (for the reporter)

Remove the contact **while connected to the companion** so the device-side `remove_contact` runs (or delete it on the companion directly) — then the device won't re-offer it on sync. This PR makes the delete stick even when that device round-trip can't apply.

## Testing

- `deleteNode`: honest rows-affected (wrong source / unknown key → false; real match → true; second delete → false).
- Removal tombstones the key → a simulated `get_contacts` re-sync persist is suppressed.
- A live advert lifts the tombstone → the node syncs again.
- `forgetLocalContact` returns false when a key matches neither a row nor memory.
- Full suite green (547 files); `tsc` clean; no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)