### PR TITLE
fix(meshcore): unresolvable trigger scope now replies unscoped, not channel default

### DIFF
--- a/src/server/meshcoreManager.autoAckScope.test.ts
+++ b/src/server/meshcoreManager.autoAckScope.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for MeshCore Auto-Acknowledge "trigger" scope mode (#3833, #3887).
+ *
+ * `resolveAutomationScopeOverride('trigger', ...)` picks the reply's scope
+ * override from the triggering message. #3887: when the trigger's scope could
+ * not be resolved at all (`scopeCode: null` — a common outcome, since scope
+ * resolution depends on best-effort raw-packet correlation), the reply must
+ * go out unscoped rather than silently falling back to the channel default —
+ * the far side's own unscoped repeater won't forward a scoped reply back.
+ *
+ * These stub the bridge transport and settings/channels DB the same way
+ * meshcoreManager.scope.test.ts does — no real backend or DB.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreMessage } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+
+interface BridgeCall { cmd: string; params: Record<string, unknown>; }
+
+function makeManager(opts: {
+  scopeMode?: string;
+  channelScopes?: Record<number, string | null>;
+  defaultScope?: string | null;
+} = {}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'get_channels') return { id: '1', success: true, data: [] };
+    return { id: '1', success: true, data: {} };
+  };
+
+  vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
+    getChannelById: vi.fn(async (id: number, _sourceId?: string) => {
+      const scope = opts.channelScopes?.[id];
+      return scope === undefined ? null : { id, name: `ch${id}`, scope };
+    }),
+    updateChannelScope: vi.fn(async () => {}),
+    upsertChannel: vi.fn(async () => {}),
+    getAllChannels: vi.fn(async () => []),
+    deleteChannel: vi.fn(async () => {}),
+  } as any);
+
+  const autoAckSettings: Record<string, string | null> = {
+    meshcoreAutoAckEnabled: 'true',
+    meshcoreAutoAckRegex: '^(test|ping)',
+    meshcoreAutoAckChannels: '1',
+    meshcoreAutoAckDirectMessages: 'false',
+    meshcoreAutoAckCooldownSeconds: '0',
+    meshcoreAutoAckUseDM: 'false',
+    meshcoreAutoAckMessage: 'ack',
+    meshcoreAutoAckPreSendDelaySeconds: '0',
+    meshcoreAutoAckScopeMode: opts.scopeMode ?? 'trigger',
+    meshcoreDefaultScope: opts.defaultScope ?? null,
+  };
+  vi.spyOn(databaseService, 'settings', 'get').mockReturnValue({
+    getSettingForSource: vi.fn(async (_sourceId: string, key: string) =>
+      key in autoAckSettings ? autoAckSettings[key] : null),
+    setSourceSetting: vi.fn(async () => {}),
+  } as any);
+
+  return { manager: m, bridgeCalls };
+}
+
+const scopeOf = (calls: BridgeCall[]) =>
+  calls.filter(c => c.cmd === 'set_flood_scope').map(c => c.params.region);
+
+function triggerMessage(overrides: Partial<MeshCoreMessage>): MeshCoreMessage {
+  return {
+    id: 'm1',
+    fromPublicKey: 'aa'.repeat(32),
+    fromName: 'Alice',
+    text: 'ping',
+    timestamp: Date.now(),
+    scopeName: null,
+    scopeCode: null,
+    ...overrides,
+  };
+}
+
+describe('MeshCoreManager — Auto-Ack "trigger" scope mode (#3887)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('replies unscoped when the trigger scope could not be resolved at all (scopeCode: null)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
+    const msg = triggerMessage({ scopeCode: null, scopeName: null });
+    await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
+    expect(scopeOf(bridgeCalls)).toEqual([null]);
+  });
+
+  it('replies unscoped when the trigger arrived explicitly unscoped (scopeCode: 0)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
+    const msg = triggerMessage({ scopeCode: 0, scopeName: null });
+    await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
+    expect(scopeOf(bridgeCalls)).toEqual([null]);
+  });
+
+  it('replies on the trigger\'s named scope when resolved', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
+    const msg = triggerMessage({ scopeCode: 123, scopeName: 'lyon' });
+    await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
+    expect(scopeOf(bridgeCalls)).toEqual(['lyon']);
+  });
+
+  it('falls back to the channel default scope for a known-but-unmapped scope code', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
+    const msg = triggerMessage({ scopeCode: 456, scopeName: null });
+    await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
+    expect(scopeOf(bridgeCalls)).toEqual(['berlin']);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2405,8 +2405,19 @@ class MeshCoreManager extends EventEmitter {
    * `''` = explicit unscoped, a non-empty string = a named region.
    *
    * `trigger` mode replies on the triggering message's own scope — its resolved
-   * `scopeName` when known, `''` when the trigger was explicitly unscoped
-   * (`scopeCode === 0`), else inherit (unknown / no trigger message available).
+   * `scopeName` when known; `''` when the trigger's scope resolved to unscoped
+   * (`scopeCode === 0`) OR when scope resolution simply couldn't tell
+   * (`scopeCode == null`, #3887); inherit only when the trigger's `scopeCode`
+   * resolved to a real transport code with no matching known region (an
+   * unrecognised scope, not an unresolvable one).
+   *
+   * The `scopeCode == null` case is common in practice: `scopeCode`/`scopeName`
+   * are only recoverable when the raw OTA packet bytes were correlated from a
+   * preceding LogRxData event (best-effort, see meshcoreNativeBackend.ts), so a
+   * genuinely unscoped message often can't be distinguished from "unknown" —
+   * treating both as unscoped matches the dominant real-world case (a mesh with
+   * no scopes configured at all) rather than silently falling back to the
+   * channel default, which the far side's own unscoped repeater won't forward.
    */
   private static resolveAutomationScopeOverride(
     cfg: MeshCoreAutomationScopeConfig | undefined,
@@ -2418,10 +2429,11 @@ class MeshCoreManager extends EventEmitter {
       case 'named':
         return (cfg.scopeName ?? '').trim() || undefined; // empty named → inherit
       case 'trigger': {
-        const name = (triggerMsg?.scopeName ?? '').trim();
+        if (!triggerMsg) return undefined; // no trigger message → inherit
+        const name = (triggerMsg.scopeName ?? '').trim();
         if (name) return name;
-        if (triggerMsg?.scopeCode === 0) return ''; // trigger arrived explicitly unscoped
-        return undefined; // unknown scope / no trigger → inherit
+        if (triggerMsg.scopeCode != null && triggerMsg.scopeCode > 0) return undefined; // known-but-unmapped scope → inherit
+        return ''; // scopeCode === 0 (confirmed unscoped) or null (unresolvable) → reply unscoped
       }
       default:
         return undefined; // inherit

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -135,6 +135,29 @@ describe('executeAction', () => {
     expect('scopeOverride' in calls[0].args).toBe(false);
   });
 
+  it('sendMessage: trigger scope on a MeshCore trigger whose scope could not be resolved sends unscoped (#3887)', async () => {
+    // scopeCode/scopeName both null (not absent): a real MeshCore message
+    // trigger where raw-packet scope resolution failed (LogRxData correlation
+    // miss) — must be treated as unscoped, not silently fall back to inherit.
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'trigger' }),
+      ctx({ from: 5, channel: 1, isDM: false, scopeName: null, scopeCode: null }),
+      deps,
+    );
+    expect(calls[0].args.scopeOverride).toBe('');
+  });
+
+  it('sendMessage: trigger scope on a known-but-unmapped scope code inherits', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'trigger' }),
+      ctx({ from: 5, channel: 1, isDM: false, scopeName: null, scopeCode: 456 }),
+      deps,
+    );
+    expect('scopeOverride' in calls[0].args).toBe(false);
+  });
+
   it('sendMessage: DM send never carries a scope override', async () => {
     const { calls, deps } = recorder();
     await executeAction(

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -176,9 +176,15 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
         }
         case 'trigger': {
           const tn = ctx.trigger.fields.scopeName;
+          const tc = ctx.trigger.fields.scopeCode;
+          // `scopeCode` is only present in fields at all for a MeshCore message
+          // trigger (buildMeshCoreMessageContext) — a schedule/telemetry/Meshtastic
+          // trigger has no such key, and must inherit rather than be forced unscoped.
+          const hasTriggerScope = 'scopeCode' in ctx.trigger.fields;
           if (typeof tn === 'string' && tn.length > 0) scopeOverride = tn;
-          else if (ctx.trigger.fields.scopeCode === 0) scopeOverride = ''; // trigger was explicitly unscoped
-          else scopeOverride = undefined; // Meshtastic / unknown → inherit
+          else if (!hasTriggerScope) scopeOverride = undefined; // no MeshCore message trigger → inherit
+          else if (typeof tc === 'number' && tc > 0) scopeOverride = undefined; // known-but-unmapped scope → inherit
+          else scopeOverride = ''; // scopeCode 0 (unscoped) or unresolvable (#3887) → reply unscoped
           break;
         }
         default:


### PR DESCRIPTION
## Summary

- Fixes #3887 — MeshCore Auto-Acknowledge "trigger" Reply Scope mode fell back to the channel default scope whenever the triggering message's scope couldn't be *resolved* at all, instead of replying unscoped like it does for a message that's *confirmed* unscoped.
- Root cause: `scopeCode`/`scopeName` on a received message are only recoverable when the raw OTA packet bytes are correlated from a preceding `LogRxData` bridge event (best-effort — see comments in `meshcoreNativeBackend.ts`). When that correlation misses, `resolveMessageScope()` returns `scopeCode: null` ("unknown") rather than `0` ("confirmed unscoped"). `resolveAutomationScopeOverride()`'s `trigger` case only special-cased `scopeCode === 0`, so `null` silently fell through to "inherit the channel default" — exactly the symptom reported: a genuinely-unscoped message (from a peer repeater with no region configured) got a scoped reply back, which that peer's own repeater won't forward.
- Fix: `trigger` mode now treats an unresolvable scope (`scopeCode == null`) the same as a confirmed-unscoped trigger (`scopeCode === 0`) — reply unscoped. A scope code that *did* resolve to a real (but unrecognized) region still falls back to the channel default, preserving the original #3850 behavior for that case.
- Mirrored the identical fix in the newer Automation Engine's `action.sendMessage` "Match the triggering message's scope" mode (`actionExecutor.ts`), which had the same bug — with an added guard so a non-MeshCore-message trigger (schedule/telemetry/Meshtastic) still inherits rather than being forced unscoped.

## Test plan

- [x] Added `src/server/meshcoreManager.autoAckScope.test.ts` — exercises `checkAutoAcknowledge` end-to-end through the bridge-command stub, covering: unresolvable scope → unscoped, confirmed-unscoped → unscoped, named scope → named, known-but-unmapped scope → channel default.
- [x] Extended `src/server/services/automation/actionExecutor.test.ts` with the equivalent cases for the Automation Engine action, including a regression check that a non-MeshCore trigger still inherits.
- [x] `npx vitest run` on the touched files and their existing neighbors (`meshcoreManager.scope.test.ts`, `actionExecutor.test.ts`) — 88/88 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on all touched files — no new warnings/errors (pre-existing issues elsewhere in `meshcoreManager.ts` are untouched by this diff).
- Full `npx vitest run` suite: 7782 passed, 3 unrelated failures — all in Meshtastic-protobuf-dependent test files (`ENOENT: protobufs/meshtastic/mesh.proto`), caused by the `protobufs` git submodule not being initialized in this sandbox, not by this change.

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFLGAtru68WsnGQLVn5StG)_