### PR TITLE
feat(meshcore): unread red-dot on Channels + Node Details sidebar icons (#3891)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -21,6 +21,7 @@ import { MeshCoreMessage, MeshCoreActions, ConnectionStatus } from './hooks/useM
 import { MeshCoreContact, formatMeshCoreChannelName } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { useAuth } from '../../contexts/AuthContext';
+import { loadChannelLastRead, markChannelRead as persistChannelRead } from './meshcoreUnreadStore';
 
 const MOBILE_BREAKPOINT = 768;
 const isMobileViewport = (): boolean =>
@@ -81,22 +82,10 @@ function buildChannelFilter(channelIdx: number): (m: MeshCoreMessage) => boolean
 // request: surface channels with new messages without opening each one.
 // ---------------------------------------------------------------------------
 
-const lastReadStorageKey = (sourceId: string) =>
-  `meshmonitor-meshcore-channel-lastread-${sourceId}`;
+// Per-channel last-read markers live in the shared unread store
+// (meshcoreUnreadStore) so the sidebar red-dot (#3891) and this view's list
+// badges read/write the same source of truth and stay in sync.
 const SORT_UNREAD_FIRST_KEY = 'meshmonitor-meshcore-channel-sort-unread-first';
-
-/** Read the persisted per-channel last-read map for a source (idx → ms). */
-function loadLastRead(sourceId: string): Record<number, number> {
-  if (!sourceId) return {};
-  try {
-    const raw = localStorage.getItem(lastReadStorageKey(sourceId));
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as Record<number, number>) : {};
-  } catch {
-    return {};
-  }
-}
 
 export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   messages,
@@ -131,7 +120,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   const [latestTimestamps, setLatestTimestamps] = useState<Record<number, number>>({});
   // Per-channel last-read marker (idx → ms), persisted in localStorage scoped by
   // sourceId. Seeded from storage on mount/source change.
-  const [lastRead, setLastRead] = useState<Record<number, number>>(() => loadLastRead(sourceId));
+  const [lastRead, setLastRead] = useState<Record<number, number>>(() => loadChannelLastRead(sourceId));
   // Live mirror of `lastRead` so the channel-entry snapshot (#3810) can read the
   // pre-read marker without re-subscribing to every marker change.
   const lastReadRef = useRef(lastRead);
@@ -172,7 +161,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
 
   // Re-seed the last-read map when the source changes (the map is per-source).
   useEffect(() => {
-    setLastRead(loadLastRead(sourceId));
+    setLastRead(loadChannelLastRead(sourceId));
   }, [sourceId]);
 
   // Persist the sort preference whenever it changes.
@@ -185,15 +174,12 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // still clears any stale unread state.
   const markChannelRead = useCallback((idx: number, ts: number = Date.now()) => {
     if (!sourceId) return;
+    // Persist through the shared store (writes localStorage + notifies the
+    // sidebar dot). Keep the local React state in sync for this view's badges.
+    persistChannelRead(sourceId, idx, ts);
     setLastRead(prev => {
       if ((prev[idx] ?? 0) >= ts) return prev;
-      const next = { ...prev, [idx]: ts };
-      try {
-        localStorage.setItem(lastReadStorageKey(sourceId), JSON.stringify(next));
-      } catch {
-        /* storage full / disabled — unread state is best-effort */
-      }
-      return next;
+      return { ...prev, [idx]: ts };
     });
   }, [sourceId]);
 

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -502,3 +502,26 @@ describe('MeshCoreDirectMessagesView — repeaters are not messageable (#3755)',
     });
   });
 });
+
+describe('MeshCoreDirectMessagesView — DM unread marking (#3891)', () => {
+  it('writes a per-source DM read-marker when a contact is opened', async () => {
+    localStorage.removeItem('meshmonitor-meshcore-dm-lastread-src-a');
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+    fireEvent.click(screen.getByText('Remote Bob'));
+
+    await waitFor(() => {
+      const raw = localStorage.getItem('meshmonitor-meshcore-dm-lastread-src-a');
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw as string)[REAL_PK]).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -11,6 +11,13 @@ import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 import TelemetryGraphs from '../TelemetryGraphs';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSettings } from '../../contexts/SettingsContext';
+import {
+  markDmRead,
+  loadDmLastRead,
+  subscribeUnreadChanged,
+  computeUnreadDmPeers,
+  canonicalizePeerKey,
+} from './meshcoreUnreadStore';
 
 interface MeshCoreDirectMessagesViewProps {
   messages: MeshCoreMessage[];
@@ -235,6 +242,35 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     });
   }, [messages, selected, selfKey]);
 
+  // Unread-marker re-read trigger (localStorage isn't reactive) (#3891).
+  const [unreadTick, setUnreadTick] = useState(0);
+  useEffect(() => subscribeUnreadChanged(() => setUnreadTick((n) => n + 1)), []);
+
+  // Mark the open conversation read up to its newest message. Re-runs when a
+  // new message arrives for the selected peer (filtered changes), so a
+  // conversation you're actively viewing never lingers as unread. markDmRead is
+  // a no-op when the marker is already current, so this stays cheap.
+  useEffect(() => {
+    if (!sourceId || !selected) return;
+    const peer = canonicalizePeerKey(selected, contacts);
+    const latest = filtered.reduce((mx, m) => Math.max(mx, m.timestamp), 0);
+    markDmRead(sourceId, peer, latest || Date.now());
+  }, [sourceId, selected, contacts, filtered]);
+
+  // Peers with unread incoming DMs — drives the per-row red-dot in the contact
+  // list. The currently-open peer is never flagged.
+  const unreadPeers = useMemo(() => {
+    void unreadTick;
+    if (!sourceId) return new Set<string>();
+    return computeUnreadDmPeers({
+      messages,
+      contacts,
+      selfKey,
+      dmLastRead: loadDmLastRead(sourceId),
+      activePeerKey: selected,
+    });
+  }, [sourceId, messages, contacts, selfKey, selected, unreadTick]);
+
   const handleSelectContact = (key: string) => {
     setSelected(key);
     if (isMobileViewport()) setMobileShowContent(true);
@@ -336,6 +372,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               const name = c?.advName || c?.name || `${key.substring(0, 8)}…`;
               const isFavorite = favoriteByKey.get(key) ?? false;
               const roleIcon = meshcoreRoleIcon(c?.advType);
+              const hasUnread = unreadPeers.has(key);
               return (
                 <button
                   key={key}
@@ -343,6 +380,13 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   onClick={() => handleSelectContact(key)}
                 >
                   <div className="mc-node-row-name">
+                    {hasUnread && (
+                      <span
+                        className="meshcore-dm-unread-dot"
+                        aria-label={t('meshcore.dms.unread', 'Unread messages')}
+                        title={t('meshcore.dms.unread', 'Unread messages')}
+                      />
+                    )}
                     {roleIcon && (
                       <span
                         className="mc-node-role-icon"

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -17,6 +17,7 @@ import {
   subscribeUnreadChanged,
   computeUnreadDmPeers,
   canonicalizePeerKey,
+  isChannelPseudoKey,
 } from './meshcoreUnreadStore';
 
 interface MeshCoreDirectMessagesViewProps {
@@ -149,15 +150,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     return a.startsWith(b) || b.startsWith(a);
   };
 
-  // Phase 2 of the MeshCore channels feature tags every locally-sent channel
-  // message with `toPublicKey = 'channel-${idx}'` so the per-channel filter in
-  // MeshCoreChannelsView can group sent messages back into the right tab.
-  // Those synthetic keys are NOT real DM peers and must not surface in the
-  // DM sidebar / conversation list — filter them out everywhere the DM view
-  // looks at toPublicKey / fromPublicKey.
-  const isChannelPseudoKey = (k: string | null | undefined): boolean =>
-    typeof k === 'string' && k.startsWith('channel-');
-
+  // Channel messages carry synthetic `channel-${idx}` keys (see the shared
+  // `isChannelPseudoKey` in meshcoreUnreadStore) — they are NOT real DM peers
+  // and are filtered out everywhere this view looks at to/fromPublicKey.
   const dmPeers = useMemo(() => {
     const peers = new Set<string>();
     const lastMessageAt = new Map<string, number>();

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -169,6 +169,33 @@
   justify-content: center;
   font-size: 1.1rem;
   flex-shrink: 0;
+  position: relative;
+}
+
+/* Unread red-dot indicator overlaid on the nav icon (#3891). Anchored to the
+   icon's top-right so it stays put whether the toolbar is collapsed or
+   expanded. */
+.meshcore-nav-unread-dot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 8px;
+  height: 8px;
+  background: var(--ctp-red);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--ctp-mantle);
+  pointer-events: none;
+}
+
+/* Per-contact unread red-dot in the Node Details (DM) contact list (#3891). */
+.meshcore-dm-unread-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: var(--ctp-red);
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+  margin-right: 2px;
 }
 
 .meshcore-sub-toolbar.collapsed .meshcore-sub-toolbar-item .label {

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -15,6 +15,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMeshCore, ConnectionStatus } from './hooks/useMeshCore';
+import { useMeshCoreUnread } from './hooks/useMeshCoreUnread';
 import { MeshCoreStatusBar } from './MeshCoreStatusBar';
 import { MeshCoreSubToolbar, MeshCoreView } from './MeshCoreSubToolbar';
 import { MeshCoreNodesView } from './MeshCoreNodesView';
@@ -66,6 +67,16 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
   const [toolbarExpanded, setToolbarExpanded] = useState(false);
   const [pendingDmContact, setPendingDmContact] = useState<string | null>(null);
 
+  // Unread red-dots for the Channels + Node Details (DMs) sidebar icons (#3891).
+  const unread = useMeshCoreUnread({
+    baseUrl,
+    sourceId,
+    messages,
+    contacts,
+    selfKey: status?.localNode?.publicKey,
+    enabled: enabled !== false,
+  });
+
   const navigateToDm = useCallback((publicKey: string) => {
     setPendingDmContact(publicKey);
     setView('dms');
@@ -105,6 +116,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
           expanded={toolbarExpanded}
           onToggleExpanded={() => setToolbarExpanded(v => !v)}
           showInfo
+          unread={{ channels: unread.channels, dms: unread.dms }}
         />
         <div className="meshcore-content">
           {view === 'nodes' && (

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -74,7 +74,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
     messages,
     contacts,
     selfKey: status?.localNode?.publicKey,
-    enabled: enabled !== false,
+    enabled: enabled ?? true,
   });
 
   const navigateToDm = useCallback((publicKey: string) => {

--- a/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
@@ -47,6 +47,33 @@ describe('MeshCoreSubToolbar', () => {
     iconStyle = 'icon'; // reset for other tests
   });
 
+  it('renders an unread red-dot only on the flagged nav items (#3891)', () => {
+    authPermission = () => true;
+    iconStyle = 'icon';
+    const { container } = render(
+      <MeshCoreSubToolbar
+        view="nodes"
+        onSelect={() => {}}
+        expanded
+        onToggleExpanded={() => {}}
+        unread={{ channels: true, dms: false }}
+      />,
+    );
+    const dots = container.querySelectorAll('.meshcore-nav-unread-dot');
+    expect(dots.length).toBe(1);
+    const channelsItem = Array.from(container.querySelectorAll('.meshcore-sub-toolbar-item'))
+      .find((el) => el.textContent?.includes('Channels'));
+    expect(channelsItem?.querySelector('.meshcore-nav-unread-dot')).not.toBeNull();
+  });
+
+  it('renders no unread dots when none are flagged', () => {
+    authPermission = () => true;
+    const { container } = render(
+      <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
+    );
+    expect(container.querySelectorAll('.meshcore-nav-unread-dot').length).toBe(0);
+  });
+
   it('renders the Configuration tab when configuration:read is granted', () => {
     authPermission = () => true;
     render(

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -16,6 +16,8 @@ interface MeshCoreSubToolbarProps {
   onToggleExpanded: () => void;
   /** When false, the Info entry is suppressed (no source context — it would have no data). */
   showInfo?: boolean;
+  /** Per-view unread indicator flags — renders a red dot on the icon (#3891). */
+  unread?: Partial<Record<MeshCoreView, boolean>>;
 }
 
 interface Item {
@@ -80,6 +82,7 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
   expanded,
   onToggleExpanded,
   showInfo = true,
+  unread = {},
 }) => {
   const { t } = useTranslation();
   const { authStatus, hasPermission } = useAuth();
@@ -116,7 +119,10 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
             onClick={() => onSelect(item.id)}
             title={!expanded ? label : undefined}
           >
-            <span className="icon">{renderIcon(item.id)}</span>
+            <span className="icon">
+              {renderIcon(item.id)}
+              {unread[item.id] && <span className="meshcore-nav-unread-dot" aria-hidden="true" />}
+            </span>
             <span className="label">{label}</span>
           </button>
         );

--- a/src/components/MeshCore/hooks/useMeshCoreUnread.test.tsx
+++ b/src/components/MeshCore/hooks/useMeshCoreUnread.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the page-level useMeshCoreUnread hook (#3891): channel unread from
+ * the polled channel-counts endpoint, DM unread from the in-memory message
+ * pool, and the enabled gate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const csrfFetchMock = vi.fn();
+vi.mock('../../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+import { useMeshCoreUnread } from './useMeshCoreUnread';
+
+const SELF = 'a'.repeat(64);
+const PEER = 'b'.repeat(64);
+const contacts = [{ publicKey: SELF }, { publicKey: PEER }] as any;
+
+function routeFetch(latestTimestamps: Record<number, number>) {
+  csrfFetchMock.mockImplementation((url: string) => {
+    if (url.includes('/api/channels/all')) {
+      return Promise.resolve({ ok: true, json: async () => [{ id: 0 }, { id: 1 }] });
+    }
+    if (url.includes('/channel-counts')) {
+      return Promise.resolve({ ok: true, json: async () => ({ latestTimestamps }) });
+    }
+    return Promise.resolve({ ok: false, json: async () => ({}) });
+  });
+}
+
+describe('useMeshCoreUnread', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    csrfFetchMock.mockReset();
+  });
+
+  it('flags channels unread when the server latest timestamp beats the read marker', async () => {
+    routeFetch({ 1: 5000 });
+    const { result } = renderHook(() =>
+      useMeshCoreUnread({ baseUrl: '', sourceId: 'src1', messages: [], contacts, selfKey: SELF, enabled: true }),
+    );
+    await waitFor(() => expect(result.current.channels).toBe(true));
+  });
+
+  it('does not flag channels when everything is already read', async () => {
+    localStorage.setItem('meshmonitor-meshcore-channel-lastread-src1', JSON.stringify({ 1: 9000 }));
+    routeFetch({ 1: 5000 });
+    const { result } = renderHook(() =>
+      useMeshCoreUnread({ baseUrl: '', sourceId: 'src1', messages: [], contacts, selfKey: SELF, enabled: true }),
+    );
+    // Give the fetch a tick to resolve, then assert it stays false.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.channels).toBe(false);
+  });
+
+  it('flags DMs unread from an incoming message in the pool (no fetch needed)', () => {
+    routeFetch({});
+    const messages = [{ fromPublicKey: PEER, toPublicKey: SELF, timestamp: 1000, text: 'hi' }] as any;
+    const { result } = renderHook(() =>
+      useMeshCoreUnread({ baseUrl: '', sourceId: 'src1', messages, contacts, selfKey: SELF, enabled: true }),
+    );
+    expect(result.current.dms).toBe(true);
+  });
+
+  it('does not poll or flag anything when disabled', async () => {
+    routeFetch({ 1: 5000 });
+    const { result } = renderHook(() =>
+      useMeshCoreUnread({ baseUrl: '', sourceId: 'src1', messages: [], contacts, selfKey: SELF, enabled: false }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(csrfFetchMock).not.toHaveBeenCalled();
+    expect(result.current.channels).toBe(false);
+    expect(result.current.dms).toBe(false);
+  });
+});

--- a/src/components/MeshCore/hooks/useMeshCoreUnread.ts
+++ b/src/components/MeshCore/hooks/useMeshCoreUnread.ts
@@ -1,0 +1,146 @@
+/**
+ * useMeshCoreUnread (#3891)
+ *
+ * Page-level hook that computes whether the MeshCore Channels view and the
+ * Node Details (DMs) view have unread messages, so MeshCorePage can render an
+ * unread red-dot on the corresponding sidebar icons — even when neither view is
+ * currently mounted.
+ *
+ * Channels: unread is authoritative from the server's per-channel latest
+ * message timestamp (`/messages/channel-counts`, polled) compared against the
+ * client-side last-read markers; live pool messages are merged in for
+ * immediacy. DMs: computed entirely from the in-memory message pool (received
+ * messages per peer) vs the DM last-read markers — the same pool the DM view
+ * itself groups by peer, so the sidebar dot and the view stay consistent.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { useCsrfFetch } from '../../../hooks/useCsrfFetch';
+import type { MeshCoreMessage } from './useMeshCore';
+import type { MeshCoreContact } from '../../../utils/meshcoreHelpers';
+import {
+  loadChannelLastRead,
+  loadDmLastRead,
+  subscribeUnreadChanged,
+  computeUnreadDmPeers,
+  isChannelPseudoKey,
+} from '../meshcoreUnreadStore';
+
+interface UseMeshCoreUnreadParams {
+  baseUrl: string;
+  sourceId: string;
+  messages: MeshCoreMessage[];
+  contacts: MeshCoreContact[];
+  selfKey: string | undefined;
+  enabled: boolean;
+}
+
+export interface MeshCoreUnread {
+  channels: boolean;
+  dms: boolean;
+}
+
+const CHANNEL_POLL_MS = 15000;
+
+export function useMeshCoreUnread({
+  baseUrl,
+  sourceId,
+  messages,
+  contacts,
+  selfKey,
+  enabled,
+}: UseMeshCoreUnreadParams): MeshCoreUnread {
+  const csrfFetch = useCsrfFetch();
+  const [channelIndices, setChannelIndices] = useState<number[]>([]);
+  const [channelLatest, setChannelLatest] = useState<Record<number, number>>({});
+  // Bumped whenever a last-read marker changes so the memoized unread booleans
+  // re-read localStorage (which isn't reactive on its own).
+  const [readTick, setReadTick] = useState(0);
+
+  useEffect(() => subscribeUnreadChanged(() => setReadTick((t) => t + 1)), []);
+
+  // Fetch the channel index list once per source — needed to query channel-counts.
+  useEffect(() => {
+    if (!enabled || !sourceId) {
+      setChannelIndices([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const idxs = Array.isArray(raw)
+          ? raw.filter((c: any) => typeof c?.id === 'number').map((c: any) => c.id as number)
+          : [];
+        setChannelIndices(idxs);
+      } catch {
+        /* ignore — no channel dot until reachable */
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [enabled, sourceId, baseUrl, csrfFetch]);
+
+  // Poll per-channel latest timestamps.
+  useEffect(() => {
+    if (!enabled || !sourceId || channelIndices.length === 0) {
+      setChannelLatest({});
+      return;
+    }
+    let cancelled = false;
+    const fetchLatest = async () => {
+      try {
+        const q = encodeURIComponent(channelIndices.join(','));
+        const res = await csrfFetch(
+          `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/messages/channel-counts?channels=${q}`,
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        if (data.latestTimestamps) setChannelLatest(data.latestTimestamps as Record<number, number>);
+      } catch {
+        /* ignore */
+      }
+    };
+    fetchLatest();
+    const id = setInterval(fetchLatest, CHANNEL_POLL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [enabled, sourceId, baseUrl, csrfFetch, channelIndices]);
+
+  // Merge live pool channel messages (explicit `channel-<idx>` keys) into the
+  // polled timestamps so a just-arrived channel message flips the dot without
+  // waiting for the next poll.
+  const channelLatestEffective = useMemo(() => {
+    const map: Record<number, number> = { ...channelLatest };
+    for (const m of messages) {
+      const key = isChannelPseudoKey(m.toPublicKey)
+        ? m.toPublicKey
+        : isChannelPseudoKey(m.fromPublicKey)
+          ? m.fromPublicKey
+          : null;
+      if (!key) continue;
+      const idx = parseInt(key.slice('channel-'.length), 10);
+      if (Number.isInteger(idx)) map[idx] = Math.max(map[idx] ?? 0, m.timestamp);
+    }
+    return map;
+  }, [channelLatest, messages]);
+
+  const channels = useMemo(() => {
+    void readTick;
+    if (!sourceId) return false;
+    const lastRead = loadChannelLastRead(sourceId);
+    return Object.entries(channelLatestEffective).some(
+      ([idx, ts]) => ts > (lastRead[Number(idx)] ?? 0),
+    );
+  }, [sourceId, channelLatestEffective, readTick]);
+
+  const dms = useMemo(() => {
+    void readTick;
+    if (!sourceId) return false;
+    const dmLastRead = loadDmLastRead(sourceId);
+    return computeUnreadDmPeers({ messages, contacts, selfKey, dmLastRead }).size > 0;
+  }, [sourceId, messages, contacts, selfKey, readTick]);
+
+  return { channels, dms };
+}

--- a/src/components/MeshCore/hooks/useMeshCoreUnread.ts
+++ b/src/components/MeshCore/hooks/useMeshCoreUnread.ts
@@ -127,7 +127,7 @@ export function useMeshCoreUnread({
   }, [channelLatest, messages]);
 
   const channels = useMemo(() => {
-    void readTick;
+    void readTick; // cache-bust: re-read localStorage markers when a marker changes
     if (!sourceId) return false;
     const lastRead = loadChannelLastRead(sourceId);
     return Object.entries(channelLatestEffective).some(
@@ -136,7 +136,7 @@ export function useMeshCoreUnread({
   }, [sourceId, channelLatestEffective, readTick]);
 
   const dms = useMemo(() => {
-    void readTick;
+    void readTick; // cache-bust: re-read localStorage markers when a marker changes
     if (!sourceId) return false;
     const dmLastRead = loadDmLastRead(sourceId);
     return computeUnreadDmPeers({ messages, contacts, selfKey, dmLastRead }).size > 0;

--- a/src/components/MeshCore/meshcoreUnreadStore.test.ts
+++ b/src/components/MeshCore/meshcoreUnreadStore.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the MeshCore unread-marker store (#3891) — the pure unread
+ * computation and the localStorage-backed read markers that drive the sidebar
+ * red-dots and per-contact DM dots.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  canonicalizePeerKey,
+  computeUnreadDmPeers,
+  markChannelRead,
+  loadChannelLastRead,
+  markDmRead,
+  loadDmLastRead,
+} from './meshcoreUnreadStore';
+
+const SELF = 'a'.repeat(64);
+const PEER1 = 'b'.repeat(64);
+const PEER2 = 'c'.repeat(64);
+const contacts = [{ publicKey: SELF }, { publicKey: PEER1 }, { publicKey: PEER2 }];
+
+function dm(from: string, to: string, timestamp: number, extra: Record<string, unknown> = {}) {
+  return { fromPublicKey: from, toPublicKey: to, timestamp, ...extra };
+}
+
+describe('canonicalizePeerKey', () => {
+  it('resolves a pubkey prefix to the full contact key', () => {
+    expect(canonicalizePeerKey(PEER1.substring(0, 12), contacts)).toBe(PEER1);
+  });
+  it('returns an exact key unchanged', () => {
+    expect(canonicalizePeerKey(PEER2, contacts)).toBe(PEER2);
+  });
+  it('returns an unknown key unchanged', () => {
+    expect(canonicalizePeerKey('deadbeef', [])).toBe('deadbeef');
+  });
+});
+
+describe('computeUnreadDmPeers', () => {
+  it('flags a peer whose latest incoming message is newer than the last-read marker', () => {
+    const messages = [dm(PEER1, SELF, 100)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: {} });
+    expect(unread.has(PEER1)).toBe(true);
+  });
+
+  it('does NOT flag own outgoing messages', () => {
+    const messages = [dm(SELF, PEER1, 100)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: {} });
+    expect(unread.size).toBe(0);
+  });
+
+  it('respects the last-read marker', () => {
+    const messages = [dm(PEER1, SELF, 100)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: { [PEER1]: 100 } });
+    expect(unread.has(PEER1)).toBe(false);
+  });
+
+  it('never flags the currently-open peer', () => {
+    const messages = [dm(PEER1, SELF, 100)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: {}, activePeerKey: PEER1 });
+    expect(unread.has(PEER1)).toBe(false);
+  });
+
+  it('canonicalizes a prefixed sender so it matches the read marker', () => {
+    const messages = [dm(PEER1.substring(0, 12), SELF, 100)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: { [PEER1]: 100 } });
+    expect(unread.has(PEER1)).toBe(false);
+  });
+
+  it('ignores channel pseudo-keys and room posts', () => {
+    const messages = [
+      dm('channel-0', SELF, 100),
+      dm(PEER2, SELF, 100, { messageType: 'room_post' }),
+    ];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: {} });
+    expect(unread.size).toBe(0);
+  });
+
+  it('reports nothing when the local key is unknown (can not tell sent from received)', () => {
+    const messages = [dm(PEER1, SELF, 100)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: undefined, dmLastRead: {} });
+    expect(unread.size).toBe(0);
+  });
+
+  it('tracks multiple unread peers independently', () => {
+    const messages = [dm(PEER1, SELF, 100), dm(PEER2, SELF, 200)];
+    const unread = computeUnreadDmPeers({ messages, contacts, selfKey: SELF, dmLastRead: { [PEER1]: 150 } });
+    expect(unread.has(PEER1)).toBe(false); // read past 100
+    expect(unread.has(PEER2)).toBe(true);
+  });
+});
+
+describe('read markers (localStorage round-trip)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('persists and reloads channel markers, never moving backwards', () => {
+    markChannelRead('src1', 0, 500);
+    expect(loadChannelLastRead('src1')[0]).toBe(500);
+    markChannelRead('src1', 0, 300); // older — ignored
+    expect(loadChannelLastRead('src1')[0]).toBe(500);
+    markChannelRead('src1', 0, 900);
+    expect(loadChannelLastRead('src1')[0]).toBe(900);
+  });
+
+  it('scopes markers by sourceId', () => {
+    markChannelRead('src1', 0, 500);
+    expect(loadChannelLastRead('src2')[0]).toBeUndefined();
+  });
+
+  it('persists and reloads DM markers per peer', () => {
+    markDmRead('src1', PEER1, 500);
+    markDmRead('src1', PEER2, 700);
+    const map = loadDmLastRead('src1');
+    expect(map[PEER1]).toBe(500);
+    expect(map[PEER2]).toBe(700);
+  });
+});

--- a/src/components/MeshCore/meshcoreUnreadStore.ts
+++ b/src/components/MeshCore/meshcoreUnreadStore.ts
@@ -1,0 +1,180 @@
+/**
+ * Shared client-side unread-marker store for MeshCore (#3891).
+ *
+ * MeshCore messages are NOT covered by the Meshtastic server-side read-tracking
+ * (`read_messages` joins the Meshtastic `messages` table only), so we track the
+ * operator's last-read markers client-side in localStorage, scoped by sourceId:
+ *
+ *   - channels: `meshmonitor-meshcore-channel-lastread-<sourceId>` → { idx: ms }
+ *               (pre-existing key from #3703 — kept as-is for backward compat)
+ *   - DMs:      `meshmonitor-meshcore-dm-lastread-<sourceId>`      → { peerKey: ms }
+ *
+ * Both the views that own a conversation (MeshCoreChannelsView /
+ * MeshCoreDirectMessagesView) and the page-level unread hook that drives the
+ * sidebar red-dots read/write through here, so a single source of truth keeps
+ * the in-view badges and the sidebar dots consistent. Writes dispatch a
+ * same-tab `CustomEvent` so listeners update immediately (the native `storage`
+ * event only fires in OTHER tabs).
+ */
+
+const CHANGE_EVENT = 'meshcore-unread-changed';
+
+export const channelLastReadKey = (sourceId: string) =>
+  `meshmonitor-meshcore-channel-lastread-${sourceId}`;
+export const dmLastReadKey = (sourceId: string) =>
+  `meshmonitor-meshcore-dm-lastread-${sourceId}`;
+
+function loadMap<K extends string | number>(storageKey: string): Record<K, number> {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return {} as Record<K, number>;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<K, number>) : ({} as Record<K, number>);
+  } catch {
+    return {} as Record<K, number>;
+  }
+}
+
+/** Read the per-channel last-read map (channel idx → ms) for a source. */
+export function loadChannelLastRead(sourceId: string): Record<number, number> {
+  if (!sourceId) return {};
+  return loadMap<number>(channelLastReadKey(sourceId));
+}
+
+/** Read the per-peer DM last-read map (canonical peer key → ms) for a source. */
+export function loadDmLastRead(sourceId: string): Record<string, number> {
+  if (!sourceId) return {};
+  return loadMap<string>(dmLastReadKey(sourceId));
+}
+
+function persist(storageKey: string, map: Record<string | number, number>): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(map));
+  } catch {
+    /* storage full / disabled — unread state is best-effort */
+  }
+  // Notify same-tab listeners (storage event only fires cross-tab).
+  try {
+    window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+  } catch {
+    /* non-DOM env (tests) — safe to ignore */
+  }
+}
+
+/**
+ * Mark a channel read up to `ts` (defaults to now). Never moves the marker
+ * backwards. No-op when the marker is already at/after `ts`.
+ */
+export function markChannelRead(sourceId: string, idx: number, ts: number = Date.now()): void {
+  if (!sourceId) return;
+  const map = loadChannelLastRead(sourceId);
+  if ((map[idx] ?? 0) >= ts) return;
+  map[idx] = ts;
+  persist(channelLastReadKey(sourceId), map);
+}
+
+/**
+ * Mark a DM conversation (with `peerKey`) read up to `ts` (defaults to now).
+ * `peerKey` must be the canonical peer key (see {@link canonicalizePeerKey}).
+ * Never moves the marker backwards.
+ */
+export function markDmRead(sourceId: string, peerKey: string, ts: number = Date.now()): void {
+  if (!sourceId || !peerKey) return;
+  const map = loadDmLastRead(sourceId);
+  if ((map[peerKey] ?? 0) >= ts) return;
+  map[peerKey] = ts;
+  persist(dmLastReadKey(sourceId), map);
+}
+
+/**
+ * Subscribe to unread-marker changes (both same-tab writes via this module and
+ * cross-tab `storage` events). Returns an unsubscribe function.
+ */
+export function subscribeUnreadChanged(cb: () => void): () => void {
+  const onCustom = () => cb();
+  const onStorage = (e: StorageEvent) => {
+    if (!e.key || e.key.startsWith('meshmonitor-meshcore-channel-lastread-') || e.key.startsWith('meshmonitor-meshcore-dm-lastread-')) {
+      cb();
+    }
+  };
+  window.addEventListener(CHANGE_EVENT, onCustom);
+  window.addEventListener('storage', onStorage);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onCustom);
+    window.removeEventListener('storage', onStorage);
+  };
+}
+
+/**
+ * Canonicalize a peer key to its full contact pubkey. Inbound `contact_message`
+ * events carry only a `pubkey_prefix` (~12 hex), while contacts and outbound
+ * messages use the full 64-hex key; resolving both to the same canonical key
+ * keeps a single peer from being tracked as two conversations. Mirrors the
+ * canonicalization in MeshCoreDirectMessagesView so read-markers written by the
+ * view line up with the unread computed by the hook.
+ */
+export function canonicalizePeerKey(
+  key: string,
+  contacts: ReadonlyArray<{ publicKey?: string }>,
+): string {
+  if (!key) return key;
+  for (const c of contacts) {
+    if (c.publicKey === key) return key;
+  }
+  for (const c of contacts) {
+    if (c.publicKey && c.publicKey.startsWith(key)) return c.publicKey;
+  }
+  return key;
+}
+
+/** True when `a` and `b` reference the same key allowing for prefix matching. */
+export function peerKeysMatch(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  return a.startsWith(b) || b.startsWith(a);
+}
+
+/** True when a key is a synthetic per-channel pseudo-key (`channel-<idx>`). */
+export function isChannelPseudoKey(k: string | null | undefined): boolean {
+  return typeof k === 'string' && k.startsWith('channel-');
+}
+
+/**
+ * Compute the set of DM peers with unread INCOMING messages: a peer is unread
+ * when its latest *received* message (from the peer, to us) is newer than the
+ * stored last-read marker. Own-sent messages never create unread. Keys are
+ * canonical peer keys.
+ */
+export function computeUnreadDmPeers(params: {
+  messages: ReadonlyArray<{ fromPublicKey: string; toPublicKey?: string; timestamp: number; messageType?: string }>;
+  contacts: ReadonlyArray<{ publicKey?: string }>;
+  selfKey: string | undefined;
+  dmLastRead: Record<string, number>;
+  /** Peer currently open in the DM view — never reported as unread. */
+  activePeerKey?: string | null;
+}): Set<string> {
+  const { messages, contacts, selfKey, dmLastRead, activePeerKey } = params;
+  // Without knowing our own key we can't tell received from sent, so we can't
+  // reliably attribute "unread" — report nothing rather than false positives.
+  if (!selfKey) return new Set<string>();
+  const latestIncoming = new Map<string, number>();
+  for (const m of messages) {
+    if (!m.toPublicKey) continue;
+    if (m.messageType === 'room_post') continue;
+    if (isChannelPseudoKey(m.fromPublicKey) || isChannelPseudoKey(m.toPublicKey)) continue;
+    // Only received messages count as unread — sender is NOT us, recipient IS us.
+    if (selfKey && peerKeysMatch(m.fromPublicKey, selfKey)) continue;
+    if (selfKey && !peerKeysMatch(m.toPublicKey, selfKey)) continue;
+    const peer = canonicalizePeerKey(m.fromPublicKey, contacts);
+    if (selfKey && peerKeysMatch(peer, selfKey)) continue;
+    const prev = latestIncoming.get(peer) ?? 0;
+    if (m.timestamp > prev) latestIncoming.set(peer, m.timestamp);
+  }
+  const activeCanonical = activePeerKey ? canonicalizePeerKey(activePeerKey, contacts) : null;
+  const unread = new Set<string>();
+  for (const [peer, ts] of latestIncoming) {
+    if (activeCanonical && peerKeysMatch(peer, activeCanonical)) continue;
+    if (ts > (dmLastRead[peer] ?? 0)) unread.add(peer);
+  }
+  return unread;
+}

--- a/src/components/MeshCore/meshcoreUnreadStore.ts
+++ b/src/components/MeshCore/meshcoreUnreadStore.ts
@@ -157,20 +157,31 @@ export function computeUnreadDmPeers(params: {
   // Without knowing our own key we can't tell received from sent, so we can't
   // reliably attribute "unread" — report nothing rather than false positives.
   if (!selfKey) return new Set<string>();
+  // Memoize canonicalization per raw key: a conversation has many messages from
+  // the same sender prefix, so this collapses the per-message O(contacts) scan
+  // to one scan per distinct key.
+  const canonCache = new Map<string, string>();
+  const canon = (key: string): string => {
+    const hit = canonCache.get(key);
+    if (hit !== undefined) return hit;
+    const resolved = canonicalizePeerKey(key, contacts);
+    canonCache.set(key, resolved);
+    return resolved;
+  };
   const latestIncoming = new Map<string, number>();
   for (const m of messages) {
     if (!m.toPublicKey) continue;
     if (m.messageType === 'room_post') continue;
     if (isChannelPseudoKey(m.fromPublicKey) || isChannelPseudoKey(m.toPublicKey)) continue;
     // Only received messages count as unread — sender is NOT us, recipient IS us.
-    if (selfKey && peerKeysMatch(m.fromPublicKey, selfKey)) continue;
-    if (selfKey && !peerKeysMatch(m.toPublicKey, selfKey)) continue;
-    const peer = canonicalizePeerKey(m.fromPublicKey, contacts);
-    if (selfKey && peerKeysMatch(peer, selfKey)) continue;
+    if (peerKeysMatch(m.fromPublicKey, selfKey)) continue;
+    if (!peerKeysMatch(m.toPublicKey, selfKey)) continue;
+    const peer = canon(m.fromPublicKey);
+    if (peerKeysMatch(peer, selfKey)) continue;
     const prev = latestIncoming.get(peer) ?? 0;
     if (m.timestamp > prev) latestIncoming.set(peer, m.timestamp);
   }
-  const activeCanonical = activePeerKey ? canonicalizePeerKey(activePeerKey, contacts) : null;
+  const activeCanonical = activePeerKey ? canon(activePeerKey) : null;
   const unread = new Set<string>();
   for (const [peer, ts] of latestIncoming) {
     if (activeCanonical && peerKeysMatch(peer, activeCanonical)) continue;


### PR DESCRIPTION
Closes #3891.

## What & why
For Meshtastic, the sidebar Channels/Messages icons show an unread red-dot. MeshCore had per-channel unread *tracking* (#3703) but never surfaced it on its sub-toolbar, and had **no** unread tracking for direct messages at all. This adds both.

## Changes
- **New shared unread store** (`meshcoreUnreadStore.ts`) — single source of truth for channel + DM last-read markers (localStorage, per-source) with a same-tab change event, so reading a conversation updates the dot immediately. Contains the pure `computeUnreadDmPeers` (received-only, canonicalizes pubkey prefixes, excludes the currently-open peer) and `canonicalizePeerKey`.
- **New page-level hook** (`useMeshCoreUnread.ts`) — returns `{ channels, dms }`. Channels use the authoritative `channel-counts` endpoint (polled) merged with live pool messages for immediacy; DMs are computed from the in-memory message pool vs the read markers (the same pool the DM view groups by peer, so they stay consistent).
- **Sidebar dots** — `MeshCoreSubToolbar` gains an `unread` prop and renders a red dot on the **Channels** and **Node Details** icons; `MeshCorePage` wires the hook in.
- **DM tracking (new)** — the Node Details view marks a conversation read when opened/viewed, and shows a **per-contact red dot** in the contact list for peers with unread incoming messages.
- **Channels refactor** — `MeshCoreChannelsView` now routes its read-markers through the shared store, so its in-view badges and the new sidebar dot share one source of truth.

## Notes
- MeshCore has no server-side read-tracking (the Meshtastic `read_messages` table joins the Meshtastic `messages` table only), so markers stay client-side in localStorage, scoped by `sourceId` — consistent with the existing #3703 channel tracking (whose localStorage key is reused unchanged).
- DM "unread" counts **received** messages only (own sends never create unread); when the local node key isn't known yet, no DM dot is shown rather than risk false positives.

## Testing
- New `meshcoreUnreadStore.test.ts` (14 cases): canonicalization, `computeUnreadDmPeers` (incoming-only, read markers, active-peer exclusion, prefix canonicalization, channel/room filtering, unknown-self guard), and localStorage round-trip / never-backwards.
- Added SubToolbar dot render cases.
- `npm run typecheck` clean; full Vitest suite **549 files / 7846 passed / 0 failures**.
- Built & smoke-tested in the dev container (dots render; `/automations` unaffected; data volumes intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n