### PR TITLE
fix(meshcore): stop losing local-node battery on getAllNodes(); add low-battery diagnostics

### DIFF
--- a/src/server/meshcoreManager.getAllNodes.test.ts
+++ b/src/server/meshcoreManager.getAllNodes.test.ts
@@ -110,19 +110,20 @@ describe('MeshCoreManager.getAllNodes (node-list-collapses-to-1 regression)', ()
     expect(matches[0].batteryMv).toBe(4010); // DB-only field preserved through the merge
   });
 
-  it('lists the live local node first and does not duplicate its persisted row', async () => {
+  it('lists the live local node first, merges its persisted batteryMv, and does not duplicate its row (#3884)', async () => {
     getNodesBySource.mockResolvedValue([
-      { publicKey: KEY_LOCAL, name: 'Me (stale)', advType: MeshCoreDeviceType.COMPANION, isLocalNode: true },
+      { publicKey: KEY_LOCAL, name: 'Me (stale)', advType: MeshCoreDeviceType.COMPANION, isLocalNode: true, batteryMv: 3900 },
       { publicKey: KEY_B, name: 'Node B', advType: MeshCoreDeviceType.REPEATER, isLocalNode: false },
     ]);
 
     const m = new MeshCoreManager('src-a');
-    // @ts-expect-error - seed the live local node directly
+    // @ts-expect-error - seed the live local node directly, as `get_self_info`
+    // would (no battery field — that only ever lands via the telemetry poller).
     m.localNode = { publicKey: KEY_LOCAL, name: 'Me (live)', advType: MeshCoreDeviceType.COMPANION };
 
     const nodes = await m.getAllNodes();
 
-    expect(nodes[0]).toMatchObject({ publicKey: KEY_LOCAL, name: 'Me (live)' });
+    expect(nodes[0]).toMatchObject({ publicKey: KEY_LOCAL, name: 'Me (live)', batteryMv: 3900 });
     expect(nodes.filter((n) => n.publicKey === KEY_LOCAL)).toHaveLength(1);
   });
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4559,7 +4559,12 @@ class MeshCoreManager extends EventEmitter {
     try {
       const dbNodes = await databaseService.meshcore.getNodesBySource(this.sourceId);
       for (const n of dbNodes) {
-        if (n.isLocalNode) continue; // local node is appended live below
+        // The local node's row is intentionally NOT skipped here (even though
+        // it's re-added "live" below) — it needs to land in `byKey` so the
+        // merge below can pull its DB-only fields (batteryMv, uptimeSecs)
+        // forward. It's deduped via the `byKey.delete()` call after the
+        // merge, not by exclusion here. Excluding it here previously made
+        // the merge a no-op once isLocalNode started being persisted (#3884).
         byKey.set(n.publicKey, {
           publicKey: n.publicKey,
           name: n.name || 'Unknown',

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4605,7 +4605,14 @@ class MeshCoreManager extends EventEmitter {
 
     const nodes: MeshCoreNode[] = [];
     if (this.localNode) {
-      nodes.push(this.localNode);
+      // this.localNode comes from `get_self_info` (name/radio config only —
+      // no battery/uptime), so merge it over the persisted DB row rather than
+      // replacing it outright. Without this, the local node's batteryMv from
+      // the telemetry poller was silently dropped every time it was
+      // overlaid, leaving the companion's own battery permanently blank in
+      // the UI even though it was correctly persisted (#3884).
+      const persisted = byKey.get(this.localNode.publicKey);
+      nodes.push(persisted ? { ...persisted, ...this.localNode } : this.localNode);
       byKey.delete(this.localNode.publicKey);
     }
     nodes.push(...byKey.values());

--- a/src/server/services/lowBatteryNotificationService.ts
+++ b/src/server/services/lowBatteryNotificationService.ts
@@ -38,6 +38,12 @@ class LowBatteryNotificationService {
   private readonly DEFAULT_THRESHOLD_PERCENT = 20; // Used when a user has no explicit threshold
   private readonly DEFAULT_VOLTAGE_THRESHOLD_MV = 3300; // MeshCore: alert below ~3.3V when no explicit threshold
   private readonly DEFAULT_NOTIFICATION_COOLDOWN_HOURS = 24; // Don't notify about same node more than once per 24 hours
+  // One-shot-per-process diagnostic so the MeshCore voltage check's actual
+  // state (monitored ids vs. what's in the DB vs. what matched) is visible
+  // in default (non-debug) logs at least once per run — see #3884, where
+  // three prior fixes each landed without any log evidence they actually
+  // took effect for the reporter's setup.
+  private readonly loggedMeshCoreDiagnostic = new Set<string>();
 
   /**
    * Start the low-battery monitoring service
@@ -267,6 +273,15 @@ class LowBatteryNotificationService {
         valueLabel: `${node.batteryMv}mV`,
         thresholdLabel: `${voltageThreshold}mV`,
       });
+    }
+
+    if (!this.loggedMeshCoreDiagnostic.has(sourceId)) {
+      this.loggedMeshCoreDiagnostic.add(sourceId);
+      const meshCoreMonitoredCount = monitoredNodeIds.filter(id => id.startsWith(`mc:${sourceId}:`)).length;
+      logger.info(
+        `🔋 [MeshCore low-battery] source=${sourceId}: threshold=${voltageThreshold}mV, ${meshCoreMonitoredCount} monitored node id(s) for this source, ` +
+        `${lowNodes.length} node(s) in meshcore_nodes currently below threshold, ${alerts.length} matched a monitored id (0 here usually means batteryMv was never persisted — check the MeshCorePoller logs)`
+      );
     }
     return alerts;
   }

--- a/src/server/services/meshcoreTelemetryPoller.test.ts
+++ b/src/server/services/meshcoreTelemetryPoller.test.ts
@@ -370,6 +370,7 @@ describe('MeshCoreTelemetryPoller.pollOnce', () => {
     expect(upsertedNodes[0].sourceId).toBe('src-batt');
     expect(upsertedNodes[0].node.publicKey).toBe(FULL_PUBKEY);
     expect(upsertedNodes[0].node.batteryMv).toBe(3800);
+    expect(upsertedNodes[0].node.isLocalNode).toBe(true);
   });
 
   it('does not upsert batteryMv when battery is zero or absent', async () => {

--- a/src/server/services/meshcoreTelemetryPoller.ts
+++ b/src/server/services/meshcoreTelemetryPoller.ts
@@ -114,6 +114,13 @@ export class MeshCoreTelemetryPoller {
   private running = false;
   private readonly prevSamples = new Map<string, PrevSample>();
   private readonly lastSnapshots = new Map<string, MeshCorePollSnapshot>();
+  // One-shot diagnostic flags (per source) so the battery-reporting state is
+  // visible in default (non-debug) logs exactly once, instead of either
+  // staying completely silent (issue #3884 — three prior "fixes" landed
+  // blind because nothing logged whether the device ever reports a voltage)
+  // or spamming a line every poll cycle forever.
+  private readonly loggedZeroBattery = new Set<string>();
+  private readonly loggedMissingBattery = new Set<string>();
 
   constructor(opts: MeshCoreTelemetryPollerOptions) {
     this.registry = opts.registry;
@@ -154,6 +161,8 @@ export class MeshCoreTelemetryPoller {
   clearSource(sourceId: string): void {
     this.prevSamples.delete(sourceId);
     this.lastSnapshots.delete(sourceId);
+    this.loggedZeroBattery.delete(sourceId);
+    this.loggedMissingBattery.delete(sourceId);
   }
 
   /**
@@ -245,14 +254,27 @@ export class MeshCoreTelemetryPoller {
         // low-battery notifications. Without this, batteryMv stays NULL in the
         // table and the notification service never fires for companion nodes.
         // Mirrors what meshcoreRemoteTelemetryScheduler does for repeaters.
+        // isLocalNode:true so this row is recognized as the local/companion
+        // node (getAllNodes() and the repository's getLocalNode() both key
+        // off this flag).
         if (core.batteryMv > 0) {
           this.database.meshcore.upsertNode(
-            { publicKey: nodeId, batteryMv: core.batteryMv },
+            { publicKey: nodeId, batteryMv: core.batteryMv, isLocalNode: true },
             manager.sourceId,
           ).catch((err) => {
             logger.warn(`[MeshCorePoller:${manager.sourceId}] Failed to persist batteryMv:`, err);
           });
+        } else if (!this.loggedZeroBattery.has(manager.sourceId)) {
+          this.loggedZeroBattery.add(manager.sourceId);
+          logger.info(
+            `[MeshCorePoller:${manager.sourceId}] get_stats(core) reported batteryMv=${core.batteryMv} — not persisting (need a value > 0). Low-battery notifications for this companion will never fire until a positive voltage reading is observed.`,
+          );
         }
+      } else if (!this.loggedMissingBattery.has(manager.sourceId)) {
+        this.loggedMissingBattery.add(manager.sourceId);
+        logger.info(
+          `[MeshCorePoller:${manager.sourceId}] get_stats(core) response had no battery_mv field — this companion connection/firmware may not be reporting battery voltage.`,
+        );
       }
       if (core.uptimeSecs !== undefined) {
         push(`${MC_TELEMETRY_PREFIX}uptime_secs`, core.uptimeSecs, 's');


### PR DESCRIPTION
## Summary

Continuation of #3884 (MeshCore "Notify on Low Battery" reported broken a 4th time, after three previous rounds each closed as fixed). This round found and fixed a real, previously-undiscovered bug and added diagnostics so the next report — if the problem persists — carries concrete evidence instead of another guess.

- **`getAllNodes()` silently dropped the local companion node's `batteryMv`/`uptimeSecs`**: the live in-memory `this.localNode` (populated from `get_self_info`, which has no battery field) was pushed to the result *replacing* the DB-persisted row instead of being merged over it. The telemetry poller was correctly writing `batteryMv` to `meshcore_nodes`, but every API/UI consumer of `getAllNodes()` (Node Info panel, dashboard) saw it as blank for the companion's own node. Now merges the persisted row as a base so DB-only fields survive.
- **`isLocalNode` was never set `true`** on the local node's `meshcore_nodes` row in production — only test fixtures set it. The telemetry poller now stamps `isLocalNode: true` when it persists battery, so the flag (and the repository's dead-but-present `getLocalNode()` query) actually reflects reality.
- **Added one-shot (per-source) INFO-level diagnostics** — in `meshcoreTelemetryPoller.ts` when `get_stats(core)` returns no battery field or a non-positive voltage, and in `lowBatteryNotificationService.ts` reporting the monitored/matched counts for a MeshCore source's low-battery check. Three prior fixes for this issue each landed without any log evidence they took effect for the reporter's setup (everything was gated behind `debug`, which they never enabled); these lines show up in default logs so the next report is actionable.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/server/services/lowBatteryNotificationService.test.ts src/server/services/meshcoreTelemetryPoller.test.ts src/server/meshcoreManager.getAllNodes.test.ts src/server/meshcoreManager.seedContacts.test.ts` — 41/41 passed
- [x] `npx eslint` on changed files — no new warnings/errors vs. base
- [ ] Full `vitest run` suite (in progress at time of PR creation; will follow up if anything regresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuxMUrWWeW8DwpLoo9hSG1)_