### PR TITLE
feat(meshcore): node-type filter on the Node Details contact list (#3890)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -503,6 +503,102 @@ describe('MeshCoreDirectMessagesView — repeaters are not messageable (#3755)',
   });
 });
 
+// Issue #3890: a node-type (advType) filter on the Node Details contact list so
+// users with many repeaters/sensors can narrow to just their companions.
+describe('MeshCoreDirectMessagesView — node-type filter (#3890)', () => {
+  const mixed: MeshCoreContact[] = [
+    { publicKey: 'a'.repeat(64), advName: 'Companion Carl', advType: 1, lastSeen: 4000 },
+    { publicKey: 'b'.repeat(64), advName: 'Repeater Rita', advType: 2, lastSeen: 3000 },
+    { publicKey: 'c'.repeat(64), advName: 'Sensor Sam', advType: 4, lastSeen: 2000 },
+    { publicKey: 'd'.repeat(64), advName: 'Companion Cora', advType: 1, lastSeen: 1000 },
+  ];
+
+  const listedNames = (): string[] =>
+    Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-display-name'))
+      .map((el) => el.textContent || '');
+
+  it('shows every advType by default (filter = All types)', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={mixed}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    const names = listedNames();
+    expect(names).toContain('Companion Carl');
+    expect(names).toContain('Repeater Rita');
+    expect(names).toContain('Sensor Sam');
+    expect(names).toContain('Companion Cora');
+  });
+
+  it('shows only companions when the Companion filter is selected', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={mixed}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    const filter = screen.getByTitle('Filter by node type') as HTMLSelectElement;
+    fireEvent.change(filter, { target: { value: '1' } });
+
+    const names = listedNames();
+    expect(names).toContain('Companion Carl');
+    expect(names).toContain('Companion Cora');
+    expect(names).not.toContain('Repeater Rita');
+    expect(names).not.toContain('Sensor Sam');
+  });
+
+  it('shows only repeaters when the Repeater filter is selected', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={mixed}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    const filter = screen.getByTitle('Filter by node type') as HTMLSelectElement;
+    fireEvent.change(filter, { target: { value: '2' } });
+
+    expect(listedNames()).toEqual(['Repeater Rita']);
+  });
+
+  it('combines the type filter with the search box', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={mixed}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    // Companions only…
+    fireEvent.change(screen.getByTitle('Filter by node type'), { target: { value: '1' } });
+    // …then narrow further to "Carl".
+    fireEvent.change(screen.getByPlaceholderText('Search contacts…'), { target: { value: 'Carl' } });
+
+    expect(listedNames()).toEqual(['Companion Carl']);
+  });
+
+  it('shows a type-specific empty state when no contact matches the filter', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={[mixed[0], mixed[3]]} // companions only — no repeaters
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    fireEvent.change(screen.getByTitle('Filter by node type'), { target: { value: '2' } });
+
+    expect(screen.getByText('No contacts of this type')).toBeTruthy();
+  });
+});
+
 describe('MeshCoreDirectMessagesView — DM unread marking (#3891)', () => {
   it('writes a per-source DM read-marker when a contact is opened', async () => {
     localStorage.removeItem('meshmonitor-meshcore-dm-lastread-src-a');

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -52,6 +52,12 @@ function isRealNodeKey(key: string): boolean {
 
 type DmSortField = 'name' | 'lastMessage';
 type DmSortDirection = 'asc' | 'desc';
+// Node-type (advType) filter for the contact list (issue #3890). 'all' = no
+// filter; otherwise a MeshCore advert type: 1=Companion, 2=Repeater, 4=Sensor.
+// Room Server (3) is intentionally omitted — those peers are already excluded
+// from this list (they live in the Rooms view), so they can never match here.
+type DmTypeFilter = 'all' | 1 | 2 | 4;
+const DM_TYPE_FILTER_OPTIONS: readonly (1 | 2 | 4)[] = [1, 2, 4];
 
 const MOBILE_BREAKPOINT = 768;
 const isMobileViewport = (): boolean =>
@@ -80,6 +86,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<DmSortField>('lastMessage');
   const [sortDirection, setSortDirection] = useState<DmSortDirection>('desc');
+  const [typeFilter, setTypeFilter] = useState<DmTypeFilter>('all');
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const [mobileShowContent, setMobileShowContent] = useState(false);
 
@@ -215,14 +222,21 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   }, [messages, contacts, selfKey, canonicalize, contactsByKey, favoriteByKey, sortField, sortDirection]);
 
   const filteredPeers = useMemo(() => {
-    if (!searchQuery.trim()) return dmPeers;
+    let peers = dmPeers;
+    // Node-type filter (#3890). A peer that only exists via a message thread
+    // (no matching contact) has no advType and is hidden by any specific-type
+    // filter — expected, since the filter targets known node roles.
+    if (typeFilter !== 'all') {
+      peers = peers.filter(key => contactsByKey.get(key)?.advType === typeFilter);
+    }
+    if (!searchQuery.trim()) return peers;
     const q = searchQuery.toLowerCase();
-    return dmPeers.filter(key => {
+    return peers.filter(key => {
       const c = contactsByKey.get(key);
       const name = c?.advName || c?.name || '';
       return name.toLowerCase().includes(q) || key.toLowerCase().includes(q);
     });
-  }, [dmPeers, searchQuery, contactsByKey]);
+  }, [dmPeers, searchQuery, contactsByKey, typeFilter]);
 
   const filtered = useMemo(() => {
     if (!selected) return [];
@@ -308,6 +322,23 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               <span className="pane-count">{dmPeers.length}</span>
               <div className="sort-controls meshcore-sort-controls">
                 <select
+                  aria-label={t('meshcore.filter_by_type', 'Filter by node type')}
+                  title={t('meshcore.filter_by_type', 'Filter by node type')}
+                  value={typeFilter === 'all' ? 'all' : String(typeFilter)}
+                  onChange={(e) =>
+                    setTypeFilter(e.target.value === 'all'
+                      ? 'all'
+                      : (Number(e.target.value) as DmTypeFilter))}
+                  className="sort-dropdown"
+                >
+                  <option value="all">{t('meshcore.filter_all_types', 'All types')}</option>
+                  {DM_TYPE_FILTER_OPTIONS.map((adv) => (
+                    <option key={adv} value={String(adv)}>
+                      {`${meshcoreRoleIcon(adv)} ${t(meshcoreRoleLabelKey(adv), meshcoreRoleLabel(adv))}`}
+                    </option>
+                  ))}
+                </select>
+                <select
                   aria-label={t('meshcore.sort_by', 'Sort by')}
                   title={t('meshcore.sort_by', 'Sort by')}
                   value={sortField}
@@ -360,7 +391,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               <div className="meshcore-empty-state">
                 {searchQuery
                   ? t('meshcore.no_search_results', 'No contacts match your search')
-                  : t('meshcore.no_contacts', 'No contacts yet')}
+                  : typeFilter !== 'all'
+                    ? t('meshcore.no_type_results', 'No contacts of this type')
+                    : t('meshcore.no_contacts', 'No contacts yet')}
               </div>
             ) : filteredPeers.map(key => {
               const c = contactsByKey.get(key);


### PR DESCRIPTION
Closes #3890.

## What
Adds a compact **Filter by node type** dropdown next to the existing search box / sort control in the MeshCore **Node Details** view. Users with many repeaters/sensors (e.g. ~200 nodes, ~5 companions) can now narrow the list to just their companions.

## How
- New `typeFilter` state: `'all' | 1 (Companion) | 2 (Repeater) | 4 (Sensor)`. Room Server (3) is intentionally omitted — those peers are already excluded from this list (they live in the Rooms view), so they can never match.
- `filteredPeers` filters by `advType` before applying the search filter. Message-only peers (no matching contact, hence no `advType`) are hidden by any specific-type filter — expected, since the filter targets known node roles.
- Type-specific empty state ("No contacts of this type").
- Reuses `meshcoreRoleIcon` / role labels for option consistency with the rest of the view.

## Scope
Frontend-only. Defaults to **All types**, so existing behavior/workflows are unaffected until a user opts in. No backend/API/schema/migration work.

## Tests
`MeshCoreDirectMessagesView.test.tsx` (all 22 pass):
- default shows every advType
- Companion filter shows only companions
- Repeater filter shows only repeaters
- filter + search combine
- type-specific empty state when nothing matches

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)