### PR TITLE
feat(meshcore): explicit "Unscoped" button when composing a channel message (#3888)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -636,3 +636,81 @@ describe('MeshCoreChannelsView — reply uses the originating scope (#3851)', ()
     expect(screen.queryByLabelText('Send scope')).toBeNull();
   });
 });
+
+// Issue #3888: an explicit "Unscoped" affordance when composing so users can
+// reliably send a channel message with no region scope, without the old
+// type-a-char-then-delete trick. `overrideScope === ''` = explicit unscoped;
+// `null` (untouched) = fall back to the channel/source default scope.
+describe('MeshCoreChannelsView — explicit Unscoped send (#3888)', () => {
+  beforeEach(() => {
+    csrfFetchMock.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/messages/channel/')) {
+        return Promise.resolve(jsonResponse({ success: true, data: [] }));
+      }
+      return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+    });
+  });
+
+  it('sends explicitly unscoped (scope = "") when the Unscoped button is clicked', async () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreChannelsView messages={[]} contacts={contacts} status={makeStatus()} actions={actions} baseUrl="" sourceId="src-a" />,
+    );
+    await waitFor(() => screen.getByText('# Public'));
+
+    // Open the scope-override control (collapsed by default).
+    fireEvent.click(screen.getByText('Scope: unscoped'));
+    // Click the discoverable "Unscoped" affordance.
+    const unscopedBtn = await screen.findByRole('button', { name: 'Unscoped' });
+    fireEvent.click(unscopedBtn);
+    // Active state disambiguates '' (unscoped) from null (default) — both leave
+    // the free-text input empty.
+    expect(unscopedBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(unscopedBtn.classList.contains('active')).toBe(true);
+
+    const input = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'no scope please' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Send'));
+    });
+
+    // The empty-string scope arg is passed through — the backend treats '' as
+    // explicit unscoped (distinct from omitting the arg).
+    expect(actions.sendMessage).toHaveBeenCalledWith('no scope please', undefined, 0, '');
+  });
+
+  it('sends with NO scope override (default scope) when the control is opened but untouched', async () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreChannelsView messages={[]} contacts={contacts} status={makeStatus()} actions={actions} baseUrl="" sourceId="src-a" />,
+    );
+    await waitFor(() => screen.getByText('# Public'));
+
+    // Open the control but do NOT click Unscoped — overrideScope stays null.
+    fireEvent.click(screen.getByText('Scope: unscoped'));
+
+    const input = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'use default' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Send'));
+    });
+
+    // No 4th arg → backend resolves the channel/source default scope.
+    expect(actions.sendMessage).toHaveBeenCalledWith('use default', undefined, 0);
+  });
+
+  it('marks the Unscoped button active after replying to an unscoped message', async () => {
+    const unscoped: MeshCoreMessage[] = [
+      { id: 'r0u', fromPublicKey: 'channel-0', fromName: 'Cara', text: 'plain hi', timestamp: 1000, scopeCode: 0 },
+    ];
+    render(
+      <MeshCoreChannelsView messages={unscoped} contacts={contacts} status={makeStatus()} actions={makeActions()} baseUrl="" sourceId="src-a" />,
+    );
+    await waitFor(() => screen.getByText('plain hi'));
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    // handleReply set overrideScope to '' — the Unscoped button reflects it.
+    const unscopedBtn = await screen.findByRole('button', { name: 'Unscoped' });
+    expect(unscopedBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -583,6 +583,15 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
                 </datalist>
                 <button
                   type="button"
+                  className={`mc-scope-override-unscoped${overrideScope === '' ? ' active' : ''}`}
+                  onClick={() => setOverrideScope('')}
+                  aria-pressed={overrideScope === ''}
+                  title={t('meshcore.scope.override_unscoped_title', 'Send this message with no region scope (flood)')}
+                >
+                  {t('meshcore.scope.unscoped', 'Unscoped')}
+                </button>
+                <button
+                  type="button"
                   className="mc-scope-override-clear"
                   onClick={() => { setOverrideScope(null); setShowScopeOverride(false); }}
                   title={t('meshcore.scope.override_clear', 'Use channel scope')}

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -1815,6 +1815,30 @@
   color: var(--ctp-text);
 }
 
+.mc-scope-override-unscoped {
+  flex: 0 0 auto;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  color: var(--ctp-subtext0);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-sm, 4px);
+  white-space: nowrap;
+}
+
+.mc-scope-override-unscoped:hover {
+  color: var(--ctp-text);
+  border-color: var(--ctp-overlay0);
+}
+
+/* Active = this send will go out explicitly unscoped (overrideScope === ''). */
+.mc-scope-override-unscoped.active {
+  background: var(--ctp-blue);
+  border-color: var(--ctp-blue);
+  color: var(--ctp-base);
+}
+
 .mc-scope-override-clear {
   background: none;
   border: none;


### PR DESCRIPTION
Closes #3888.

## What
Adds an explicit **Unscoped** button to the MeshCore channel "Send scope" control, so a channel message can be sent with no region scope in a single, discoverable click.

## Why
The scope-override control was a free-text input whose empty state was ambiguous:
- **untouched** (`overrideScope === null`) → falls back to the channel/source default scope
- **explicit unscoped** (`overrideScope === ''`) → previously only reachable by typing a character and deleting it again

There was no discoverable single action to "send unscoped."

## How
- New **Unscoped** button in the scope-override row sets `overrideScope` to `''` in one click.
- Active state (`aria-pressed` + highlight) disambiguates `''` (explicit unscoped) from `null` (default) — both otherwise leave the text input empty.

## Scope
**Frontend-only.** The empty-string scope already flows end-to-end as "explicit unscoped":
- hook `useMeshCore.sendMessage` includes `scope` in the POST body whenever it isn't `undefined` (so `''` is sent)
- route `POST /messages/send` forwards `''` verbatim (`if (scope !== undefined && scope !== null)`)
- `meshcoreManager` treats `''` as explicit unscoped (`transportCode = 0`), distinct from `undefined`/`null` (use default)

No backend change required.

## Part 2 (reply-to-unscoped)
Already shipped in #3851 — replying to a `scopeCode === 0` message pre-populates the control with unscoped. That path now also lights up the new button's active state.

## Tests
`MeshCoreChannelsView.test.tsx` (all 20 pass):
- clicking **Unscoped** then Send calls `sendMessage(text, undefined, channelIdx, '')`
- control opened-but-untouched sends with no scope arg (default scope)
- reply-to-unscoped marks the Unscoped button active

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)