### PR TITLE
fix(meshcore): make companion battery persistence observable + cover apprise-only low-battery (#3884)

### DIFF
--- a/src/db/repositories/notifications.test.ts
+++ b/src/db/repositories/notifications.test.ts
@@ -709,6 +709,30 @@ function runNotificationsTests(getBackend: () => TestBackend) {
       expect(users.find((u) => u.userId === 3)).toBeUndefined();
     });
 
+    // Regression for #3884: the reporter uses Apprise ONLY (no web push). The
+    // entry query gates on `or(notifyOnMessage[=enableWebPush], appriseEnabled)`,
+    // so an Apprise-only user with low battery enabled must still be returned —
+    // the previous test only covered a web-push user, leaving this path unproven.
+    it('includes an Apprise-only user (no web push) with low-battery enabled (#3884)', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'apprise_user'));
+      await repo.saveUserPreferences(1, makeDefaultPrefs({
+        enableWebPush: false,       // no web push subscription/channel
+        enableApprise: true,        // ...but Apprise is active
+        notifyOnLowBattery: true,
+        lowBatteryVoltageThreshold: 4100,
+        monitoredNodes: ['mc:src-a:deadbeefcafe'],
+      }));
+
+      const users = await repo.getUsersWithLowBatteryNotifications();
+      const user = users.find((u) => u.userId === 1);
+      expect(user).toBeDefined();
+      expect(user!.lowBatteryVoltageThreshold).toBe(4100);
+      expect(JSON.parse(user!.monitoredNodes || '[]')).toEqual(['mc:src-a:deadbeefcafe']);
+    });
+
     it('returns empty array when no users have low-battery notifications enabled', async () => {
       const backend = getBackend();
       if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }

--- a/src/server/services/meshcoreTelemetryPoller.test.ts
+++ b/src/server/services/meshcoreTelemetryPoller.test.ts
@@ -423,4 +423,29 @@ describe('MeshCoreTelemetryPoller.pollOnce', () => {
       errorSpy.mockRestore();
     }
   });
+
+  it('logs the meshcore_nodes persist confirmation only once across polls (#3884)', async () => {
+    const manager = makeManager({
+      sourceId: 'src-once',
+      publicKey: FULL_PUBKEY,
+      core: { batteryMv: 3800, uptimeSecs: 100, errors: 0, queueLen: 0 },
+      radio: null, packets: null, deviceTime: null, deviceInfo: null,
+    });
+    const { db } = makeDatabase();
+    // Same poller instance across both polls so the one-shot guard is exercised.
+    const poller = new MeshCoreTelemetryPoller({ registry: makeRegistry(manager), database: db });
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    try {
+      await poller.pollOnce();
+      await new Promise((r) => setTimeout(r, 0));
+      await poller.pollOnce();
+      await new Promise((r) => setTimeout(r, 0));
+      const persistLogs = infoSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((m) => m.includes('Persisted companion batteryMv'));
+      expect(persistLogs).toHaveLength(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
 });

--- a/src/server/services/meshcoreTelemetryPoller.test.ts
+++ b/src/server/services/meshcoreTelemetryPoller.test.ts
@@ -26,6 +26,7 @@ import type {
   MeshCoreDeviceInfo,
 } from '../meshcoreManager.js';
 import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
+import { logger } from '../../utils/logger.js';
 
 // ============================================================================
 // Test doubles
@@ -394,5 +395,32 @@ describe('MeshCoreTelemetryPoller.pollOnce', () => {
 
     expect(u1).toHaveLength(0);
     expect(u2).toHaveLength(0);
+  });
+
+  it('surfaces a failed batteryMv persist at error level instead of swallowing it (#3884)', async () => {
+    const manager = makeManager({
+      sourceId: 'src-fail',
+      publicKey: FULL_PUBKEY,
+      core: { batteryMv: 3800, uptimeSecs: 100, errors: 0, queueLen: 0 },
+      radio: null, packets: null, deviceTime: null, deviceInfo: null,
+    });
+    // A DB whose node upsert rejects — the exact failure that would leave
+    // meshcore_nodes empty (so low-battery notifications never fire) while the
+    // telemetry graph still shows a voltage. It must not be swallowed.
+    const db: PollerDatabase = {
+      telemetry: { insertTelemetryBatch: async (rows) => rows.length },
+      meshcore: { upsertNode: async () => { throw new Error('constraint failed'); } },
+    };
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    try {
+      await new MeshCoreTelemetryPoller({ registry: makeRegistry(manager), database: db }).pollOnce();
+      // Let the fire-and-forget upsert's rejection handler run.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(errorSpy).toHaveBeenCalled();
+      const logged = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('FAILED to persist companion batteryMv');
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/src/server/services/meshcoreTelemetryPoller.ts
+++ b/src/server/services/meshcoreTelemetryPoller.ts
@@ -114,6 +114,12 @@ export class MeshCoreTelemetryPoller {
   private running = false;
   private readonly prevSamples = new Map<string, PrevSample>();
   private readonly lastSnapshots = new Map<string, MeshCorePollSnapshot>();
+  // One-shot-per-source confirmation that the companion's battery reading was
+  // written to `meshcore_nodes` — the row low-battery notifications actually
+  // read, which is a DIFFERENT table from the telemetry-history rows that feed
+  // the battery graph. Lets an operator confirm from default logs that the
+  // notification source-of-truth is populated, not just the graph (#3884).
+  private readonly loggedBatteryPersisted = new Set<string>();
 
   constructor(opts: MeshCoreTelemetryPollerOptions) {
     this.registry = opts.registry;
@@ -154,6 +160,7 @@ export class MeshCoreTelemetryPoller {
   clearSource(sourceId: string): void {
     this.prevSamples.delete(sourceId);
     this.lastSnapshots.delete(sourceId);
+    this.loggedBatteryPersisted.delete(sourceId);
   }
 
   /**
@@ -246,11 +253,29 @@ export class MeshCoreTelemetryPoller {
         // table and the notification service never fires for companion nodes.
         // Mirrors what meshcoreRemoteTelemetryScheduler does for repeaters.
         if (core.batteryMv > 0) {
+          const persistedMv = core.batteryMv;
           this.database.meshcore.upsertNode(
-            { publicKey: nodeId, batteryMv: core.batteryMv },
+            { publicKey: nodeId, batteryMv: persistedMv },
             manager.sourceId,
-          ).catch((err) => {
-            logger.warn(`[MeshCorePoller:${manager.sourceId}] Failed to persist batteryMv:`, err);
+          ).then(() => {
+            // Positive, one-shot confirmation that the notification
+            // source-of-truth row is populated — distinct from the telemetry
+            // rows above that only feed the graph (#3884).
+            if (!this.loggedBatteryPersisted.has(manager.sourceId)) {
+              this.loggedBatteryPersisted.add(manager.sourceId);
+              logger.info(
+                `[MeshCorePoller:${manager.sourceId}] Persisted companion batteryMv=${persistedMv} to meshcore_nodes (node ${nodeId.substring(0, 12)}…) — this is the row low-battery notifications read.`,
+              );
+            }
+          }).catch((err) => {
+            // Elevated from warn: a silently-swallowed upsert here is the exact
+            // failure mode that leaves the battery graph populated (telemetry
+            // table) while notifications never fire (meshcore_nodes empty) —
+            // #3884. Make it impossible to miss in default logs.
+            logger.error(
+              `[MeshCorePoller:${manager.sourceId}] FAILED to persist companion batteryMv to meshcore_nodes — low-battery notifications cannot fire until this succeeds:`,
+              err,
+            );
           });
         }
       }


### PR DESCRIPTION
Continuation of #3884 ("MeshCore *Notify on Low Battery* never fires" — reported 4×). This does **not** claim to be the final fix; it closes two concrete gaps found by tracing the pipeline end-to-end against the reporter's actual logs.

## Context from the reporter (@HougeDK)
- Device: **Companion**, battery **3.8 V**, threshold **4.1 V** → should alert.
- Channel: **Apprise-only** (logs show `0 subscriptions`, `1 Apprise users`); other Apprise notifications (server events) fire.
- **No `Broadcasting notifyOnLowBattery…` line ever** → the low-battery *scan* produces zero alerts and dies before delivery.

Tracing showed the notification logic is actually correct end-to-end (registry union #3672, monitored-id reconstruction, voltage query, Apprise dispatch). So the remaining fault is at the **data/observability seam**, not the matching/delivery code.

## (A) Regression test: apprise-only low-battery path
`getUsersWithLowBatteryNotifications` gates on `or(notifyOnMessage[=enableWebPush], appriseEnabled)`. The existing test only covered a **web-push** user, so the reporter's exact config (Apprise on, web push off) was unproven. The new test asserts an **Apprise-only** user with `notifyOnLowBattery=true` **is returned** — confirming that gate is *not* what excludes them (`notifyOnMessage` being false is covered by the `appriseEnabled` branch).

## (B) Make companion battery persistence observable
The battery reading is written to **two tables on different conditions** (`meshcoreTelemetryPoller.ts`):
- **telemetry-history rows** → feed the **battery graph**, written on `batteryMv !== undefined`.
- **`meshcore_nodes.batteryMv`** → the **only** row low-battery notifications read (`getLowVoltageNodes`), written on `> 0` via a **fire-and-forget upsert whose failure was swallowed at `warn`**.

So a voltage visible on the graph does **not** prove the notification source-of-truth is populated. This change:
- adds a **one-shot INFO** line confirming the `meshcore_nodes` write landed (`Persisted companion batteryMv=… to meshcore_nodes …`), and
- logs an upsert failure at **`error`** (was silently warned) — `FAILED to persist companion batteryMv to meshcore_nodes …`.

Now the reporter's logs will show definitively whether the notification row is being written, is failing to write, or the device simply isn't reporting `>0`.

## Relationship to #3896
(B) edits the **same poller upsert block** as the open #3896 (which adds `isLocalNode` + zero/missing-battery diagnostics). They're **complementary** — #3896 instruments the *negative* cases (no/zero battery); this instruments the *positive persist* and *failure* cases. **Reconcile on merge** (fold together, or land this and rebase #3896). I deliberately did **not** touch `isLocalNode` here to minimize overlap.

## Testing
- New tests: apprise-only inclusion (`notifications.test.ts`), and swallowed-persist-failure is surfaced at error (`meshcoreTelemetryPoller.test.ts`). Both run on SQLite; PG/MySQL variants deferred to CI.
- `npm run typecheck` clean; full suite **551 files / 7859 passed / 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n