### PR TITLE
fix(distance-delete): make auto-delete-by-distance truly per-source for all source types (#3901)

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -26,6 +26,7 @@ import {
 } from './meshcoreVirtualNodeServer.js';
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import { notificationService } from './services/notificationService.js';
+import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
 import type { DbMeshCorePacket } from '../db/repositories/meshcore.js';
 
 // Dynamic imports for optional serialport dependency
@@ -711,13 +712,26 @@ class MeshCoreManager extends EventEmitter {
   // doesn't burn airtime if they spam the trigger phrase.
   private autoAckCooldowns: Map<string, number> = new Map();
 
+  private readonly distanceDeleteScheduler: DistanceDeleteScheduler;
+
   constructor(sourceId: string) {
     super();
     if (!sourceId) {
       throw new Error('MeshCoreManager requires a sourceId');
     }
     this.sourceId = sourceId;
+    this.distanceDeleteScheduler = new DistanceDeleteScheduler(sourceId);
     logger.info(`[MeshCore:${sourceId}] Manager initialized`);
+  }
+
+  /** Start this source's per-source auto-delete-by-distance scheduler (#3901). */
+  async startDistanceDeleteScheduler(): Promise<void> {
+    await this.distanceDeleteScheduler.start();
+  }
+
+  /** Stop this source's per-source auto-delete-by-distance scheduler (#3901). */
+  stopDistanceDeleteScheduler(): void {
+    this.distanceDeleteScheduler.stop();
   }
 
   /**
@@ -833,6 +847,10 @@ class MeshCoreManager extends EventEmitter {
       this.reconnectAttempts = 0;
       this.nextReconnectAt = null;
       this.emit('connected', this.localNode);
+      // Per-source auto-delete-by-distance (#3901) — scoped to this source's
+      // own nodes/settings; only runs while connected.
+      this.distanceDeleteScheduler.start().catch((err) =>
+        logger.error(`[MeshCore:${this.sourceId}] Failed to start distance-delete scheduler:`, err));
       dataEventEmitter.emitMeshCoreStatusUpdated({ connected: true, node: this.localNode }, this.sourceId);
       if (this.localNode) {
         dataEventEmitter.emitMeshCoreLocalNodeUpdated(this.localNode, this.sourceId);
@@ -956,6 +974,9 @@ class MeshCoreManager extends EventEmitter {
     // Stop heartbeat before tearing down the transport so a stray probe
     // doesn't fire mid-teardown.
     this.stopHeartbeat();
+
+    // Stop the per-source auto-delete-by-distance scheduler (#3901).
+    this.distanceDeleteScheduler.stop();
 
     // Cancel any pending path-refresh — refreshContacts() against a torn-
     // down connection would just log an error.

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -48,6 +48,7 @@ import {
   type PublisherStatus,
 } from './mqttBridgePublisherPool.js';
 import { channelDecryptionService } from './services/channelDecryptionService.js';
+import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
 
 /**
  * Direction the bridge is permitted to operate in against the upstream
@@ -274,6 +275,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
    * separate pool entry — see MQTT 3.1.1 §3.1.4 duplicate-clientId rule.
    */
   private brokerGatewayNum: number | null = null;
+  private readonly distanceDeleteScheduler: DistanceDeleteScheduler;
 
   constructor(sourceId: string, sourceName: string, config: MqttBridgeSourceConfig) {
     super();
@@ -282,6 +284,17 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     this.config = config;
     this.downlinkFilter = new MqttPacketFilter(config.downlinkFilters);
     this.uplinkFilter = new MqttPacketFilter(config.uplinkFilters);
+    this.distanceDeleteScheduler = new DistanceDeleteScheduler(sourceId);
+  }
+
+  /** Start this source's per-source auto-delete-by-distance scheduler (#3901). */
+  async startDistanceDeleteScheduler(): Promise<void> {
+    await this.distanceDeleteScheduler.start();
+  }
+
+  /** Stop this source's per-source auto-delete-by-distance scheduler (#3901). */
+  stopDistanceDeleteScheduler(): void {
+    this.distanceDeleteScheduler.stop();
   }
 
   /** Resolves the configured forwarding mode, defaulting to `'per_gateway'`. */
@@ -293,6 +306,12 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     this.attachParentBroker();
     await bootstrapMqttChannelDatabase(this.sourceId);
     await this.seedDownlinkMembership();
+
+    // Per-source auto-delete-by-distance (#3901). Started up front so the
+    // publish_only early-return below doesn't skip it. Background concern —
+    // a settings-read hiccup must not stop the bridge from coming up.
+    this.distanceDeleteScheduler.start().catch((err) =>
+      logger.error(`Failed to start distance-delete scheduler for source ${this.sourceId}:`, err));
 
     const mode = this.getMode();
     const forwardingMode = this.getForwardingMode();
@@ -370,6 +389,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
   }
 
   async stop(): Promise<void> {
+    this.distanceDeleteScheduler.stop();
     this.detachParentBroker();
     if (this.publisherPool) {
       await this.publisherPool.close();

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -19,6 +19,7 @@ import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import type { Source } from '../db/repositories/sources.js';
 import { loadAllNodesAsDeviceInfo } from './utils/dbNodeMapper.js';
 import type { DeviceInfo } from './meshtasticManager.js';
+import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
 import { logger } from '../utils/logger.js';
 
 export interface MqttBrokerSourceConfig {
@@ -77,6 +78,7 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
   private packetsIngested = 0;
   private packetsDropped = 0;
   private readonly filter: MqttPacketFilter;
+  private readonly distanceDeleteScheduler: DistanceDeleteScheduler;
 
   constructor(sourceId: string, sourceName: string, config: MqttBrokerSourceConfig) {
     super();
@@ -84,6 +86,17 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
     this.sourceName = sourceName;
     this.config = config;
     this.filter = new MqttPacketFilter({});
+    this.distanceDeleteScheduler = new DistanceDeleteScheduler(sourceId);
+  }
+
+  /** Start this source's per-source auto-delete-by-distance scheduler (#3901). */
+  async startDistanceDeleteScheduler(): Promise<void> {
+    await this.distanceDeleteScheduler.start();
+  }
+
+  /** Stop this source's per-source auto-delete-by-distance scheduler (#3901). */
+  stopDistanceDeleteScheduler(): void {
+    this.distanceDeleteScheduler.stop();
   }
 
   async start(): Promise<void> {
@@ -111,10 +124,17 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
     logger.info(
       `MQTT broker source ${this.sourceId} listening on ${this.config.listener.host ?? '0.0.0.0'}:${this.config.listener.port}`,
     );
+
+    // Per-source auto-delete-by-distance (#3901) — scoped to this broker's
+    // own nodes/settings, not the old global all-sources singleton. Background
+    // concern: a settings-read hiccup must not stop the broker from listening.
+    this.distanceDeleteScheduler.start().catch((err) =>
+      logger.error(`Failed to start distance-delete scheduler for source ${this.sourceId}:`, err));
   }
 
   async stop(): Promise<void> {
     if (!this.broker) return;
+    this.distanceDeleteScheduler.stop();
     await this.broker.stop();
     this.broker = null;
   }

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -7,6 +7,7 @@ import express, { Express } from 'express';
 import session from 'express-session';
 import request from 'supertest';
 import settingsRoutes, {
+  setSettingsCallbacks,
   validateTileUrl,
   validateCustomTilesets,
   validateAppriseProbeUrl,
@@ -21,6 +22,8 @@ vi.mock('../../services/database.js', () => ({
       setSettings: vi.fn(),
       getSetting: vi.fn(),
       deleteAllSettings: vi.fn(),
+      setSourceSettings: vi.fn(),
+      getSettingForSource: vi.fn(),
     },
     auditLogAsync: vi.fn(),
     drizzleDbType: 'sqlite',
@@ -90,6 +93,8 @@ describe('settingsRoutes', () => {
     mockDb.settings.setSettings.mockResolvedValue(undefined);
     mockDb.settings.getSetting.mockResolvedValue(null);
     mockDb.settings.deleteAllSettings.mockResolvedValue(undefined);
+    mockDb.settings.setSourceSettings.mockResolvedValue(undefined);
+    mockDb.settings.getSettingForSource.mockResolvedValue(null);
     mockDb.auditLogAsync.mockResolvedValue(undefined);
   });
 
@@ -491,6 +496,71 @@ describe('settingsRoutes', () => {
         .expect(400);
 
       expect(res.body.error).toContain('responseType');
+    });
+  });
+
+  // Issue #3901: saving auto-delete-by-distance settings on a specific source's
+  // panel (e.g. the MQTT broker) must restart THAT source's per-source scheduler
+  // — not fall through to a global singleton. Regression: previously the
+  // per-source save branch never restarted any distance scheduler at all.
+  describe('POST /api/settings — per-source auto-delete-by-distance (#3901)', () => {
+    const restartSpy = vi.fn();
+    const stopSpy = vi.fn();
+
+    beforeEach(() => {
+      setSettingsCallbacks({
+        restartAutoDeleteByDistanceService: restartSpy,
+        stopAutoDeleteByDistanceService: stopSpy,
+      });
+      restartSpy.mockClear();
+      stopSpy.mockClear();
+    });
+
+    afterAll(() => {
+      setSettingsCallbacks({});
+    });
+
+    it('restarts the per-source scheduler with the sourceId when enabled distance settings are saved', async () => {
+      (databaseService as any).settings.getSettingForSource.mockResolvedValue('true');
+      const app = createApp(adminUser);
+
+      const res = await request(app)
+        .post('/api/settings?sourceId=mqtt-broker-1')
+        .send({ autoDeleteByDistanceEnabled: 'true', autoDeleteByDistanceThresholdKm: '50' });
+
+      expect(res.status).toBe(200);
+      // Stored under the source prefix, and the source's own scheduler restarted.
+      expect((databaseService as any).settings.setSourceSettings).toHaveBeenCalledWith(
+        'mqtt-broker-1',
+        expect.objectContaining({ autoDeleteByDistanceEnabled: 'true' }),
+      );
+      expect(restartSpy).toHaveBeenCalledWith('mqtt-broker-1');
+      expect(stopSpy).not.toHaveBeenCalled();
+    });
+
+    it('stops the per-source scheduler when distance settings are saved with the feature disabled', async () => {
+      (databaseService as any).settings.getSettingForSource.mockResolvedValue('false');
+      const app = createApp(adminUser);
+
+      const res = await request(app)
+        .post('/api/settings?sourceId=mqtt-broker-1')
+        .send({ autoDeleteByDistanceEnabled: 'false' });
+
+      expect(res.status).toBe(200);
+      expect(stopSpy).toHaveBeenCalledWith('mqtt-broker-1');
+      expect(restartSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves the scheduler untouched when the payload has no distance keys', async () => {
+      const app = createApp(adminUser);
+
+      const res = await request(app)
+        .post('/api/settings?sourceId=mqtt-broker-1')
+        .send({ meshName: 'Somewhere' });
+
+      expect(res.status).toBe(200);
+      expect(restartSpy).not.toHaveBeenCalled();
+      expect(stopSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -131,7 +131,9 @@ export interface SettingsCallbacks {
   setAutomationAirtimeCutoffSource?: (source: string, sourceId?: string | null) => void;
   handleAutoWelcomeEnabled?: () => number;
   invalidateHtmlCache?: () => void;
-  restartAutoDeleteByDistanceService?: (intervalHours: number, sourceId?: string | null) => void;
+  // Per-source (#3901): the scheduler reads the source's own interval, so no
+  // intervalHours arg. A null sourceId is a no-op (no global scheduler).
+  restartAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
   stopAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
 }
 
@@ -661,6 +663,28 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
         callbacks.setAutomationAirtimeCutoffSource?.(filteredSettings.automationAirtimeCutoffSource, sourceId);
       }
 
+      // Auto-delete-by-distance is per-source (#3901): restart this source's
+      // own scheduler so a settings change takes effect without waiting for the
+      // source to reconnect. The scheduler reads enabled/interval itself.
+      const distanceDeleteKeys = [
+        'autoDeleteByDistanceEnabled',
+        'autoDeleteByDistanceIntervalHours',
+        'autoDeleteByDistanceThresholdKm',
+        'autoDeleteByDistanceLat',
+        'autoDeleteByDistanceLon',
+        'autoDeleteByDistanceAction',
+      ];
+      if (distanceDeleteKeys.some((key) => key in filteredSettings)) {
+        const enabled = await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceEnabled');
+        if (enabled === 'true') {
+          callbacks.restartAutoDeleteByDistanceService?.(sourceId);
+          logger.info(`✅ Auto-delete-by-distance scheduler restarted (source: ${sourceId})`);
+        } else {
+          callbacks.stopAutoDeleteByDistanceService?.(sourceId);
+          logger.info(`⏹️ Auto-delete-by-distance scheduler stopped (source: ${sourceId})`);
+        }
+      }
+
       return res.json({ success: true });
     }
 
@@ -864,36 +888,9 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       callbacks.restartGeofenceEngine?.(null);
     }
 
-    const distanceDeleteSettings = [
-      'autoDeleteByDistanceEnabled',
-      'autoDeleteByDistanceIntervalHours',
-      'autoDeleteByDistanceThresholdKm',
-      'autoDeleteByDistanceLat',
-      'autoDeleteByDistanceLon',
-    ];
-    const distanceDeleteSettingsChanged = distanceDeleteSettings.some((key) => key in filteredSettings);
-    if (distanceDeleteSettingsChanged) {
-      const dbDistEnabled = await databaseService.settings.getSetting('autoDeleteByDistanceEnabled');
-      const enabled =
-        filteredSettings.autoDeleteByDistanceEnabled === 'true' ||
-        (filteredSettings.autoDeleteByDistanceEnabled === undefined &&
-          dbDistEnabled === 'true');
-
-      if (enabled) {
-        const dbDistInterval = await databaseService.settings.getSetting('autoDeleteByDistanceIntervalHours');
-        const intervalHours = parseInt(
-          filteredSettings.autoDeleteByDistanceIntervalHours ||
-            dbDistInterval ||
-            '24',
-          10
-        );
-        callbacks.restartAutoDeleteByDistanceService?.(intervalHours, sourceId);
-        logger.info(`✅ Auto-delete-by-distance service restarted (source: ${sourceId ?? 'default'}, interval: ${intervalHours}h)`);
-      } else {
-        callbacks.stopAutoDeleteByDistanceService?.(sourceId);
-        logger.info(`⏹️ Auto-delete-by-distance service stopped (source: ${sourceId ?? 'default'})`);
-      }
-    }
+    // Auto-delete-by-distance is per-source only (#3901). A global (null-source)
+    // save persists the keys but drives no scheduler — every source owns its own
+    // via its manager lifecycle + the per-source branch above.
 
     // Audit log with before/after values.
     // Allowlist check is explicit here so static analyzers can see that

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1153,9 +1153,23 @@ setSettingsCallbacks({
   },
   handleAutoWelcomeEnabled: () => { databaseService.handleAutoWelcomeEnabledAsync().catch(() => {}); return 0; },
   invalidateHtmlCache,
-  restartAutoDeleteByDistanceService: (intervalHours: number) =>
-    autoDeleteByDistanceService.start(intervalHours),
-  stopAutoDeleteByDistanceService: () => autoDeleteByDistanceService.stop(),
+  // Auto-delete-by-distance is per-source (#3901): route the restart/stop to
+  // the owning source manager (across both the primary and MeshCore registries)
+  // so each source schedules against its own settings. There is no global
+  // singleton — a null sourceId is a no-op.
+  restartAutoDeleteByDistanceService: (sourceId?: string | null) => {
+    if (!sourceId) return;
+    const mgr = (sourceManagerRegistry.getManager(sourceId)
+      ?? meshcoreManagerRegistry.get(sourceId)) as { startDistanceDeleteScheduler?: () => Promise<void> } | undefined;
+    mgr?.startDistanceDeleteScheduler?.().catch((err: unknown) =>
+      logger.error(`Failed to restart auto-delete-by-distance scheduler for source ${sourceId}:`, err));
+  },
+  stopAutoDeleteByDistanceService: (sourceId?: string | null) => {
+    if (!sourceId) return;
+    const mgr = (sourceManagerRegistry.getManager(sourceId)
+      ?? meshcoreManagerRegistry.get(sourceId)) as { stopDistanceDeleteScheduler?: () => void } | undefined;
+    mgr?.stopDistanceDeleteScheduler?.();
+  },
 });
 
 // Wire up side-effect callbacks for systemRoutes (server-lifecycle shutdown).

--- a/src/server/services/autoDeleteByDistanceService.test.ts
+++ b/src/server/services/autoDeleteByDistanceService.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the per-source re-entrancy guard on autoDeleteByDistanceService
+ * (issue #3901). Each source may run its own delete cycle concurrently; only a
+ * SECOND in-flight cycle for the SAME source is skipped. (Previously a single
+ * global `isRunning` boolean let one source's cycle block every other source.)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getSettingForSource = vi.fn();
+const getAllNodes = vi.fn();
+const addDistanceDeleteLogEntry = vi.fn();
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    settings: { getSettingForSource: (...a: unknown[]) => getSettingForSource(...a) },
+    nodes: { getAllNodes: (...a: unknown[]) => getAllNodes(...a) },
+    misc: { addDistanceDeleteLogEntry: (...a: unknown[]) => addDistanceDeleteLogEntry(...a) },
+    deleteNodeAsync: vi.fn(),
+    setNodeIgnoredAsync: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/resolveSourceManager.js', () => ({
+  resolveSourceManager: () => ({ sendIgnoredNode: vi.fn() }),
+}));
+
+vi.mock('../utils/nodeEnhancer.js', () => ({
+  getEffectiveDbNodePosition: (n: { latitude?: number | null; longitude?: number | null }) => ({
+    latitude: n.latitude ?? null,
+    longitude: n.longitude ?? null,
+  }),
+}));
+
+import { autoDeleteByDistanceService } from './autoDeleteByDistanceService.js';
+
+describe('autoDeleteByDistanceService — per-source run guard (#3901)', () => {
+  beforeEach(() => {
+    getSettingForSource.mockReset();
+    getAllNodes.mockReset().mockResolvedValue([]);
+    addDistanceDeleteLogEntry.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('lets a different source run while one source is in-flight, and skips the same source', async () => {
+    // Source A hangs on its FIRST settings read, keeping its cycle "running".
+    let aCalls = 0;
+    let releaseA!: () => void;
+    getSettingForSource.mockImplementation((sourceId: string, key: string) => {
+      if (sourceId === 'A' && aCalls++ === 0) {
+        return new Promise<string>((res) => { releaseA = () => res('0'); });
+      }
+      const vals: Record<string, string> = {
+        autoDeleteByDistanceLat: '0',
+        autoDeleteByDistanceLon: '0',
+        autoDeleteByDistanceThresholdKm: '100',
+        autoDeleteByDistanceAction: 'delete',
+      };
+      return Promise.resolve(vals[key] ?? null);
+    });
+
+    const pA1 = autoDeleteByDistanceService.runDeleteCycle('A'); // parks in-flight
+
+    // Same source while A is still running → skipped, no scan.
+    const skipped = await autoDeleteByDistanceService.runDeleteCycle('A');
+    expect(skipped).toEqual({ deletedCount: 0 });
+    expect(getAllNodes).not.toHaveBeenCalledWith('A');
+
+    // Different source proceeds concurrently.
+    const bResult = await autoDeleteByDistanceService.runDeleteCycle('B');
+    expect(bResult).toEqual({ deletedCount: 0 });
+    expect(getAllNodes).toHaveBeenCalledWith('B');
+
+    // Release A and let it finish cleanly.
+    releaseA();
+    await pA1;
+  });
+
+  it('clears the guard after a cycle completes, so the same source can run again', async () => {
+    getSettingForSource.mockImplementation((_sourceId: string, key: string) => {
+      const vals: Record<string, string> = {
+        autoDeleteByDistanceLat: '0',
+        autoDeleteByDistanceLon: '0',
+        autoDeleteByDistanceThresholdKm: '100',
+        autoDeleteByDistanceAction: 'delete',
+      };
+      return Promise.resolve(vals[key] ?? null);
+    });
+
+    await autoDeleteByDistanceService.runDeleteCycle('A');
+    await autoDeleteByDistanceService.runDeleteCycle('A');
+
+    // Both sequential runs actually scanned (neither spuriously skipped).
+    expect(getAllNodes.mock.calls.filter((c) => c[0] === 'A')).toHaveLength(2);
+  });
+});

--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -13,39 +13,21 @@ interface ProcessedNodeInfo {
   action: DistanceAction;
 }
 
+/**
+ * Core auto-delete-by-distance logic (issue #3901).
+ *
+ * This service holds NO scheduling state — the periodic timers live on the
+ * per-source {@link DistanceDeleteScheduler} owned by each source manager, so
+ * every scheduled run is scoped to a single source. `runDeleteCycle(sourceId)`
+ * and `runNow(sourceId)` are the only entry points; the old global
+ * `start()`/`stop()` all-sources singleton was removed.
+ */
 class AutoDeleteByDistanceService {
-  private checkInterval: NodeJS.Timeout | null = null;
   private lastRunAt: number | null = null;
-  private isRunning = false;
-
-  /**
-   * Start the auto-delete-by-distance service
-   */
-  public start(intervalHours: number): void {
-    this.stop();
-
-    logger.info(`🗑️ Starting auto-delete-by-distance service (interval: ${intervalHours} hours)`);
-
-    // Run initial check after 2 minutes
-    setTimeout(() => {
-      this.runDeleteCycle();
-    }, 120_000);
-
-    this.checkInterval = setInterval(() => {
-      this.runDeleteCycle();
-    }, intervalHours * 60 * 60 * 1000);
-  }
-
-  /**
-   * Stop the service (does not abort in-progress runs)
-   */
-  public stop(): void {
-    if (this.checkInterval) {
-      clearInterval(this.checkInterval);
-      this.checkInterval = null;
-      logger.info('⏹️ Auto-delete-by-distance service stopped');
-    }
-  }
+  // Per-source re-entrancy guard: a source's cycle skips only if that SAME
+  // source already has one in flight, so concurrent per-source schedulers
+  // don't spuriously block each other (a global boolean used to).
+  private readonly runningSources = new Set<string>();
 
   /**
    * Run now (manual trigger from API)
@@ -59,7 +41,7 @@ class AutoDeleteByDistanceService {
    */
   public getStatus(): { running: boolean; lastRunAt?: number } {
     return {
-      running: this.checkInterval !== null,
+      running: this.runningSources.size > 0,
       lastRunAt: this.lastRunAt ?? undefined,
     };
   }
@@ -68,16 +50,18 @@ class AutoDeleteByDistanceService {
    * Core deletion logic
    */
   public async runDeleteCycle(sourceId?: string): Promise<{ deletedCount: number }> {
-    if (this.isRunning) {
-      logger.debug('⏭️ Auto-delete-by-distance: skipping, already running');
+    const runKey = sourceId ?? 'default';
+    if (this.runningSources.has(runKey)) {
+      logger.debug(`⏭️ Auto-delete-by-distance: skipping source ${runKey}, already running`);
       return { deletedCount: 0 };
     }
 
-    this.isRunning = true;
+    this.runningSources.add(runKey);
     const processedNodes: ProcessedNodeInfo[] = [];
 
     try {
-      // Read settings (per-source with global fallback)
+      // Read settings scoped to this source (no global fallback — an unset
+      // per-source key reads empty and the cycle no-ops on missing coords).
       const homeLat = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceLat') || '');
       const homeLon = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceLon') || '');
       const thresholdKm = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceThresholdKm') || '100');
@@ -193,7 +177,7 @@ class AutoDeleteByDistanceService {
       logger.error('❌ Auto-delete-by-distance: error during run:', error);
       return { deletedCount: 0 };
     } finally {
-      this.isRunning = false;
+      this.runningSources.delete(runKey);
     }
   }
 

--- a/src/server/services/distanceDeleteScheduler.test.ts
+++ b/src/server/services/distanceDeleteScheduler.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the per-source auto-delete-by-distance scheduler (issue #3901).
+ *
+ * The scheduler reads a SINGLE source's enabled/interval settings via
+ * getSettingForSource and drives autoDeleteByDistanceService.runDeleteCycle
+ * with that source's id — never a global all-sources scan.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const getSettingForSource = vi.fn();
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    settings: {
+      getSettingForSource: (...args: unknown[]) => getSettingForSource(...args),
+    },
+  },
+}));
+
+import { DistanceDeleteScheduler } from './distanceDeleteScheduler.js';
+import { autoDeleteByDistanceService } from './autoDeleteByDistanceService.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe('DistanceDeleteScheduler (#3901)', () => {
+  let runSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getSettingForSource.mockReset();
+    runSpy = vi.spyOn(autoDeleteByDistanceService, 'runDeleteCycle').mockResolvedValue({ deletedCount: 0 });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    runSpy.mockRestore();
+  });
+
+  function settings(map: Record<string, string | null>) {
+    getSettingForSource.mockImplementation((sourceId: string, key: string) =>
+      Promise.resolve(map[key] ?? null));
+  }
+
+  it('schedules delete cycles scoped to its own sourceId when enabled', async () => {
+    settings({ autoDeleteByDistanceEnabled: 'true', autoDeleteByDistanceIntervalHours: '6' });
+    const scheduler = new DistanceDeleteScheduler('source-A');
+
+    await scheduler.start();
+    expect(scheduler.running).toBe(true);
+    // Reads the per-source key, not the global one.
+    expect(getSettingForSource).toHaveBeenCalledWith('source-A', 'autoDeleteByDistanceEnabled');
+    // Nothing runs until the 2-minute initial delay elapses.
+    expect(runSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(runSpy).toHaveBeenCalledWith('source-A');
+
+    runSpy.mockClear();
+    await vi.advanceTimersByTimeAsync(6 * HOUR_MS);
+    expect(runSpy).toHaveBeenCalledWith('source-A');
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+  });
+
+  it('does not schedule anything when the source has the feature disabled', async () => {
+    settings({ autoDeleteByDistanceEnabled: 'false' });
+    const scheduler = new DistanceDeleteScheduler('source-B');
+
+    await scheduler.start();
+    expect(scheduler.running).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(48 * HOUR_MS);
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it('defaults to a 24h interval when none is configured', async () => {
+    settings({ autoDeleteByDistanceEnabled: 'true' }); // no interval key
+    const scheduler = new DistanceDeleteScheduler('source-C');
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(120_000);
+    runSpy.mockClear();
+
+    // No cycle before 24h…
+    await vi.advanceTimersByTimeAsync(23 * HOUR_MS);
+    expect(runSpy).not.toHaveBeenCalled();
+    // …one at 24h.
+    await vi.advanceTimersByTimeAsync(1 * HOUR_MS);
+    expect(runSpy).toHaveBeenCalledWith('source-C');
+
+    scheduler.stop();
+  });
+
+  it('stop() halts further cycles', async () => {
+    settings({ autoDeleteByDistanceEnabled: 'true', autoDeleteByDistanceIntervalHours: '1' });
+    const scheduler = new DistanceDeleteScheduler('source-D');
+
+    await scheduler.start();
+    scheduler.stop();
+    expect(scheduler.running).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5 * HOUR_MS);
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it('restart via start() clears the previous timer (no double-scheduling)', async () => {
+    settings({ autoDeleteByDistanceEnabled: 'true', autoDeleteByDistanceIntervalHours: '1' });
+    const scheduler = new DistanceDeleteScheduler('source-E');
+
+    await scheduler.start();
+    await scheduler.start(); // restart
+    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(1 * HOUR_MS);
+
+    // Only one live interval, so exactly one cycle per interval tick.
+    expect(runSpy).toHaveBeenCalledTimes(2); // initial + one interval
+    expect(runSpy).toHaveBeenCalledWith('source-E');
+
+    scheduler.stop();
+  });
+});

--- a/src/server/services/distanceDeleteScheduler.ts
+++ b/src/server/services/distanceDeleteScheduler.ts
@@ -1,0 +1,79 @@
+import { logger } from '../../utils/logger.js';
+import databaseService from '../../services/database.js';
+import { autoDeleteByDistanceService } from './autoDeleteByDistanceService.js';
+
+/**
+ * Per-source auto-delete-by-distance scheduler (issue #3901).
+ *
+ * Each source manager (MQTT broker, MQTT bridge, MeshCore) owns one of these,
+ * mirroring the inline scheduler MeshtasticManager already runs. It reads the
+ * source's own `autoDeleteByDistanceEnabled` / `autoDeleteByDistanceIntervalHours`
+ * via `getSettingForSource(sourceId, …)` and drives the shared
+ * `autoDeleteByDistanceService.runDeleteCycle(sourceId)` — which is source-scoped,
+ * so a source only ever prunes its own nodes with its own home coordinate /
+ * threshold. There is no global all-sources scheduler anymore.
+ */
+export class DistanceDeleteScheduler {
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private initialTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly sourceId: string) {}
+
+  /**
+   * Start (or restart) the scheduler from this source's persisted settings.
+   * A no-op (after clearing any existing timers) when the source has
+   * auto-delete-by-distance disabled.
+   */
+  async start(): Promise<void> {
+    this.stop();
+
+    const enabled = await databaseService.settings.getSettingForSource(
+      this.sourceId,
+      'autoDeleteByDistanceEnabled',
+    );
+    if (enabled !== 'true') {
+      logger.debug(`🗑️ Auto-delete-by-distance disabled for source ${this.sourceId}`);
+      return;
+    }
+
+    const intervalHoursStr = await databaseService.settings.getSettingForSource(
+      this.sourceId,
+      'autoDeleteByDistanceIntervalHours',
+    );
+    const intervalHours = parseInt(intervalHoursStr || '24', 10);
+    const intervalMs = Math.max(1, intervalHours) * 60 * 60 * 1000;
+
+    logger.info(
+      `🗑️ Starting auto-delete-by-distance scheduler for source ${this.sourceId} (interval: ${intervalHours}h)`,
+    );
+
+    // Initial run after 2 minutes (matches the prior singleton behavior).
+    this.initialTimeout = setTimeout(() => {
+      autoDeleteByDistanceService.runDeleteCycle(this.sourceId).catch((err) =>
+        logger.error(`❌ Auto-delete-by-distance initial run failed for source ${this.sourceId}:`, err));
+    }, 120_000);
+
+    this.interval = setInterval(() => {
+      autoDeleteByDistanceService.runDeleteCycle(this.sourceId).catch((err) =>
+        logger.error(`❌ Auto-delete-by-distance run failed for source ${this.sourceId}:`, err));
+    }, intervalMs);
+  }
+
+  /** Stop the scheduler (does not abort an in-progress delete cycle). */
+  stop(): void {
+    if (this.initialTimeout) {
+      clearTimeout(this.initialTimeout);
+      this.initialTimeout = null;
+    }
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+      logger.debug(`⏹️ Auto-delete-by-distance scheduler stopped for source ${this.sourceId}`);
+    }
+  }
+
+  /** True while a periodic timer is armed for this source. */
+  get running(): boolean {
+    return this.interval !== null;
+  }
+}


### PR DESCRIPTION
Closes #3901.

## Problem
Auto-delete-by-distance was only genuinely per-source for **meshtastic_tcp** sources (`MeshtasticManager` runs its own scheduler at connect, scoped to its `sourceId`). Every other source type — **mqtt_broker, mqtt_bridge, meshcore** — had no per-source scheduler and fell through to a **global singleton** (`autoDeleteByDistanceService.start()`) that scanned nodes across **all** sources with the global threshold/home coordinate.

Two concrete bugs (verified against the code — this corrects the issue's own analysis):
1. The settings-save handler's distance-restart block lives only in the **null-source (global) branch**; the per-source branch returns early, so **the per-source save path never restarted any distance scheduler at all**. A change to a source's rule didn't take effect until reconnect.
2. `server.ts`'s callback dropped the `sourceId` and restarted the global all-sources singleton, so configuring the rule on the MQTT broker panel overwrote the one shared global default.

## Approach (per maintainer decision)
Per-manager schedulers · all source types (incl. meshcore) · remove the global singleton.

- **New `DistanceDeleteScheduler`** (`services/distanceDeleteScheduler.ts`) — reusable helper that reads a single source's `autoDeleteByDistanceEnabled`/`IntervalHours` via `getSettingForSource` and drives `autoDeleteByDistanceService.runDeleteCycle(sourceId)` on a timer.
- **MqttBrokerManager / MqttBridgeManager / MeshCoreManager** each own one and start/stop it with their connect/disconnect lifecycle (started as a background concern — a settings-read hiccup never blocks the source from coming up). **MeshtasticManager is unchanged** (keeps its existing inline scheduler).
- **Removed** the global all-sources `start()`/`stop()` from `autoDeleteByDistanceService`. The re-entrancy guard changed from a single `isRunning` boolean to a **per-source `Set`**, so concurrent per-source cycles no longer block each other.
- **`server.ts`** callbacks now route restart/stop to the owning manager across **both** `sourceManagerRegistry` and `meshcoreManagerRegistry`; a null `sourceId` is a no-op.
- **`settingsRoutes`** — the per-source save branch now restarts that source's scheduler when distance keys change; the dead global-branch block was removed.

## Scope / behavior change
Auto-delete-by-distance is now **strictly per-source**. The settings data model already stores these keys per-source (`source:<id>:<key>`) and the frontend already sends `?sourceId=`, so no migration is needed. There is no longer a global all-sources scheduler.

## Tests
- `distanceDeleteScheduler.test.ts` — per-source setting read + scheduling; disabled no-op; 24h default; stop/restart (no double-scheduling).
- `autoDeleteByDistanceService.test.ts` — per-source run guard: distinct sources run concurrently, same source re-entry is skipped, guard clears after a cycle.
- `settingsRoutes.test.ts` — saving distance settings with `?sourceId=X` restarts/stops **that** source's scheduler (the regression), and is a no-op without distance keys.

Full Vitest suite: **7875 passed, 0 failed**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)