### PR TITLE
feat(map): fade node markers by age instead of hard cutoff (#3886)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -237,7 +237,10 @@ describe('DashboardMap', () => {
     expect(fresh).toBeGreaterThan(0.99);
     expect(favorite).toBe(1);
     expect(staleOpacity).toBeGreaterThan(0.25);
-    expect(staleOpacity).toBeLessThan(fresh);
+    // Strictly and clearly dimmer than fresh — guards against an inverted fade
+    // (newer = more transparent) slipping through, which `< fresh` alone would
+    // miss for a node heard just inside a wide window.
+    expect(staleOpacity).toBeLessThan(0.7);
   });
 
   it('forwards the configured map pin style to createNodeIcon (issue #3364)', () => {

--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -12,7 +12,9 @@ import DashboardMap from './DashboardMap';
 vi.mock('react-leaflet', () => ({
   MapContainer: ({ children }: any) => <div data-testid="map-container">{children}</div>,
   TileLayer: () => <div data-testid="tile-layer" />,
-  Marker: ({ children }: any) => <div data-testid="map-marker">{children}</div>,
+  Marker: ({ children, opacity }: any) => (
+    <div data-testid="map-marker" data-opacity={opacity}>{children}</div>
+  ),
   Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
   Polyline: () => <div data-testid="map-polyline" />,
   Rectangle: () => <div data-testid="map-rectangle" />,
@@ -214,6 +216,28 @@ describe('DashboardMap', () => {
     );
     const markers = screen.getAllByTestId('map-marker');
     expect(markers.length).toBe(1);
+  });
+
+  it('fades markers by recency and keeps favorites fully opaque (#3886)', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        // 72h window so the 48h-old stale node survives the cutoff and can fade.
+        maxNodeAgeHours={72}
+        nodes={[nodeWithPosition, staleNodeWithPosition, staleFavoriteNodeWithPosition]}
+      />,
+    );
+    const opacities = screen
+      .getAllByTestId('map-marker')
+      .map((m) => Number(m.getAttribute('data-opacity')));
+    expect(opacities).toHaveLength(3);
+    const [fresh, staleOpacity, favorite] = opacities;
+    // Freshly heard node is ~fully opaque; the 48h-old node is clearly faded
+    // but above the floor; the stale favorite bypasses the age fade entirely.
+    expect(fresh).toBeGreaterThan(0.99);
+    expect(favorite).toBe(1);
+    expect(staleOpacity).toBeGreaterThan(0.25);
+    expect(staleOpacity).toBeLessThan(fresh);
   });
 
   it('forwards the configured map pin style to createNodeIcon (issue #3364)', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -16,6 +16,7 @@ import 'leaflet/dist/leaflet.css';
 import { MapContainer, TileLayer, Marker, Popup, Polyline, Rectangle, useMap } from 'react-leaflet';
 import L, { type Marker as LeafletMarker } from 'leaflet';
 import { createNodeIcon } from '../../utils/mapIcons';
+import { markerAgeOpacity } from '../../utils/markerAgeOpacity';
 import { SpiderfierController, type SpiderfierControllerRef } from '../SpiderfierController';
 import { getTilesetById } from '../../config/tilesets';
 import type { CustomTileset, TilesetId } from '../../config/tilesets';
@@ -485,6 +486,17 @@ export default function DashboardMap({
               pinStyle: mapPinStyle,
             }),
           );
+          // #3886: fade markers by recency instead of a flat opacity — full when
+          // freshly heard, fading toward a floor as lastHeard nears the age
+          // cutoff (cutoffTime, seconds). Favorites bypass the age gate above so
+          // they stay fully opaque regardless of age.
+          const ageOpacity = node.isFavorite
+            ? 1
+            : markerAgeOpacity(
+                Date.now(),
+                cutoffTime * 1000,
+                node.lastHeard != null ? node.lastHeard * 1000 : null,
+              );
 
           return (
             <Marker
@@ -492,6 +504,7 @@ export default function DashboardMap({
               ref={getMarkerRef(markerKey)}
               position={stablePosition(markerKey, pos.lat, pos.lng)}
               icon={icon}
+              opacity={ageOpacity}
             >
               <Popup>
                 <DashboardNodePopup node={node} pos={pos} onSourceSelect={onNodeSourceSelect} />

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -293,7 +293,10 @@ export default function DashboardMap({
   // Build array of nodes that have valid positions, with their resolved lat/lng.
   // Mirrors NodesTab's processedNodes pipeline (App.tsx): ignored hidden, age cutoff
   // bypassed by favorites, transport-class filter from the Map Features panel.
-  const cutoffTime = Date.now() / 1000 - effectiveMaxAge * 60 * 60;
+  // Single "now" for this render so every marker's age fade (#3886) shares one
+  // reference instead of drifting per-node inside the marker map loop below.
+  const nowMs = Date.now();
+  const cutoffTime = nowMs / 1000 - effectiveMaxAge * 60 * 60;
   const nodesWithPosition = nodes
     .filter((n) => !n.isIgnored)
     .filter((n) => !n.hideFromMap) // #3549: per-node "Hide from Map" suppresses the marker only
@@ -489,11 +492,15 @@ export default function DashboardMap({
           // #3886: fade markers by recency instead of a flat opacity — full when
           // freshly heard, fading toward a floor as lastHeard nears the age
           // cutoff (cutoffTime, seconds). Favorites bypass the age gate above so
-          // they stay fully opaque regardless of age.
+          // they stay fully opaque regardless of age. NOTE: here a missing
+          // lastHeard yields full opacity ("assume fresh"), which differs on
+          // purpose from Map Analysis where a missing timestamp sits at the
+          // floor — the Dashboard already age-gates upstream, so anything that
+          // reaches this loop is presumed current.
           const ageOpacity = node.isFavorite
             ? 1
             : markerAgeOpacity(
-                Date.now(),
+                nowMs,
                 cutoffTime * 1000,
                 node.lastHeard != null ? node.lastHeard * 1000 : null,
               );

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -14,6 +14,7 @@ import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil
 import { nodeMatchesSearch } from '../nodeSearch';
 import { createNodeIcon } from '../../../utils/mapIcons';
 import { getNodeTypeCategory } from '../../../utils/nodeTypeCategory';
+import { markerAgeOpacity, MIN_MARKER_OPACITY } from '../../../utils/markerAgeOpacity';
 import DashboardNodePopup, { type NodeSourceRef } from '../../Dashboard/DashboardNodePopup';
 import '../../../styles/nodes.css'; // `.node-popup-*` classes used by DashboardNodePopup
 
@@ -27,6 +28,8 @@ interface NodeRecord extends MaybePositionedNode {
   user?: { role?: string | number | null } | null;
   isMeshCore?: boolean;
   advType?: number | null;
+  /** Unix seconds of last reception; drives time-slider opacity fade (#3886). */
+  lastHeard?: number | null;
   /** Every configured source that reported this node (unified merge, #2805). */
   sources?: NodeSourceRef[];
 }
@@ -193,6 +196,16 @@ export default function NodeMarkersLayer() {
     }
   }, [renderedKeysSig, removeMarker]);
 
+  // #3886: when the time slider is on, fade markers by recency across its
+  // window — fully opaque at the window's newest edge, fading toward a floor as
+  // lastHeard approaches the oldest edge. Markers with no timestamp sit at the
+  // floor. When the slider is off, every marker is fully opaque (unchanged).
+  const ts = config.timeSlider;
+  const fadeByAge =
+    ts.enabled && ts.windowStartMs != null && ts.windowEndMs != null;
+  const windowStartMs = ts.windowStartMs ?? 0;
+  const windowEndMs = ts.windowEndMs ?? 0;
+
   return (
     <>
       {filteredNodes.map(({ node: n, latLng }) => {
@@ -230,12 +243,18 @@ export default function NodeMarkersLayer() {
             pinStyle: mapPinStyle,
           }),
         );
+        const markerOpacity = !fadeByAge
+          ? 1
+          : n.lastHeard != null
+            ? markerAgeOpacity(windowEndMs, windowStartMs, n.lastHeard * 1000)
+            : MIN_MARKER_OPACITY;
         return (
           <Marker
             key={markerKey}
             ref={getMarkerRef(markerKey)}
             position={stablePosition(markerKey, lat, lon)}
             icon={icon}
+            opacity={markerOpacity}
             eventHandlers={{
               click: () =>
                 setSelected({

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -243,6 +243,10 @@ export default function NodeMarkersLayer() {
             pinStyle: mapPinStyle,
           }),
         );
+        // A missing lastHeard sits at the floor here (treated as "oldest
+        // visible"), intentionally diverging from DashboardMap where a missing
+        // timestamp stays fully opaque — that surface age-gates upstream, this
+        // one fades every marker across the raw slider window instead.
         const markerOpacity = !fadeByAge
           ? 1
           : n.lastHeard != null

--- a/src/utils/markerAgeOpacity.test.ts
+++ b/src/utils/markerAgeOpacity.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { markerAgeOpacity, MIN_MARKER_OPACITY } from './markerAgeOpacity';
+
+describe('markerAgeOpacity', () => {
+  const fresh = 100_000;
+  const stale = 0;
+
+  it('is fully opaque at (and beyond) the fresh boundary', () => {
+    expect(markerAgeOpacity(fresh, stale, fresh)).toBe(1);
+    expect(markerAgeOpacity(fresh, stale, fresh + 5_000)).toBe(1);
+  });
+
+  it('is at the floor at (and beyond) the stale boundary', () => {
+    expect(markerAgeOpacity(fresh, stale, stale)).toBe(MIN_MARKER_OPACITY);
+    expect(markerAgeOpacity(fresh, stale, stale - 5_000)).toBe(MIN_MARKER_OPACITY);
+  });
+
+  it('scales linearly between the boundaries', () => {
+    // Halfway → halfway between floor and 1.
+    const mid = markerAgeOpacity(fresh, stale, 50_000);
+    expect(mid).toBeCloseTo(MIN_MARKER_OPACITY + 0.5 * (1 - MIN_MARKER_OPACITY), 6);
+  });
+
+  it('never drops below the floor and is monotonic with recency', () => {
+    const newer = markerAgeOpacity(fresh, stale, 80_000);
+    const older = markerAgeOpacity(fresh, stale, 20_000);
+    expect(newer).toBeGreaterThan(older);
+    expect(older).toBeGreaterThanOrEqual(MIN_MARKER_OPACITY);
+  });
+
+  it('honours a custom floor', () => {
+    expect(markerAgeOpacity(fresh, stale, stale, 0.1)).toBe(0.1);
+    expect(markerAgeOpacity(fresh, stale, 50_000, 0.1)).toBeCloseTo(0.55, 6);
+  });
+
+  it('returns 1 for a missing or non-finite timestamp (no fade)', () => {
+    expect(markerAgeOpacity(fresh, stale, null)).toBe(1);
+    expect(markerAgeOpacity(fresh, stale, undefined)).toBe(1);
+    expect(markerAgeOpacity(fresh, stale, NaN)).toBe(1);
+  });
+
+  it('returns 1 for a degenerate window (fresh <= stale)', () => {
+    expect(markerAgeOpacity(stale, fresh, 50_000)).toBe(1);
+    expect(markerAgeOpacity(fresh, fresh, 50_000)).toBe(1);
+  });
+});

--- a/src/utils/markerAgeOpacity.test.ts
+++ b/src/utils/markerAgeOpacity.test.ts
@@ -37,6 +37,9 @@ describe('markerAgeOpacity', () => {
     expect(markerAgeOpacity(fresh, stale, null)).toBe(1);
     expect(markerAgeOpacity(fresh, stale, undefined)).toBe(1);
     expect(markerAgeOpacity(fresh, stale, NaN)).toBe(1);
+    // ±Infinity are non-finite → treated as "no timestamp", not clamped.
+    expect(markerAgeOpacity(fresh, stale, Infinity)).toBe(1);
+    expect(markerAgeOpacity(fresh, stale, -Infinity)).toBe(1);
   });
 
   it('returns 1 for a degenerate window (fresh <= stale)', () => {

--- a/src/utils/markerAgeOpacity.ts
+++ b/src/utils/markerAgeOpacity.ts
@@ -1,0 +1,36 @@
+/**
+ * Recency-based marker opacity (issue #3886).
+ *
+ * Instead of a hard include/exclude cutoff, node markers fade smoothly as their
+ * last-heard timestamp gets older: fully opaque when fresh, fading toward a
+ * floor as the timestamp approaches the "stale" boundary. Used by the Dashboard
+ * map (fade as nodes near the max-age cutoff) and Map Analysis (fade across the
+ * time-slider window).
+ */
+
+/** Oldest a faded marker gets — kept above 0 so aging nodes stay visible/clickable. */
+export const MIN_MARKER_OPACITY = 0.25;
+
+/**
+ * Map a timestamp to an opacity in `[minOpacity, 1]`.
+ *
+ * `freshMs` is the timestamp treated as fully opaque (1.0); `staleMs` is the
+ * timestamp treated as fully faded (`minOpacity`). Values newer than `freshMs`
+ * clamp to 1.0 and values older than `staleMs` clamp to `minOpacity`. All three
+ * timestamps must share the same unit (milliseconds).
+ *
+ * Returns `1` when `valueMs` is missing (no timestamp → no fade) or when the
+ * fresh/stale boundaries are degenerate.
+ */
+export function markerAgeOpacity(
+  freshMs: number,
+  staleMs: number,
+  valueMs: number | null | undefined,
+  minOpacity: number = MIN_MARKER_OPACITY,
+): number {
+  if (valueMs == null || !Number.isFinite(valueMs)) return 1;
+  if (!(freshMs > staleMs)) return 1;
+  const frac = (valueMs - staleMs) / (freshMs - staleMs);
+  const clamped = Math.max(0, Math.min(1, frac));
+  return minOpacity + clamped * (1 - minOpacity);
+}

--- a/src/utils/markerAgeOpacity.ts
+++ b/src/utils/markerAgeOpacity.ts
@@ -21,6 +21,11 @@ export const MIN_MARKER_OPACITY = 0.25;
  *
  * Returns `1` when `valueMs` is missing (no timestamp → no fade) or when the
  * fresh/stale boundaries are degenerate.
+ *
+ * @param freshMs   Timestamp treated as fully opaque (1.0).
+ * @param staleMs   Timestamp treated as fully faded (`minOpacity`).
+ * @param valueMs   The node's timestamp; null/undefined/non-finite → no fade.
+ * @param minOpacity Floor opacity for the oldest markers (default {@link MIN_MARKER_OPACITY}).
  */
 export function markerAgeOpacity(
   freshMs: number,


### PR DESCRIPTION
## Summary

Closes #3886. Node markers now **fade smoothly by recency** instead of popping in/out at a hard threshold, on both map surfaces called out in the issue thread:

- **Dashboard map** (Yeraze correction #2): markers that survive the max-age cutoff at `DashboardMap.tsx:299` now fade from fully opaque (freshly heard) toward a floor as their `lastHeard` approaches `cutoffTime`, rather than rendering at flat opacity and vanishing at the edge. **Favorites bypass the fade** and stay fully opaque, matching the existing favorite age-gate bypass ("kept on map" per NullVoid).
- **Map Analysis** (Yeraze correction #1 + NullVoid's final clarification): `NodeMarkersLayer` previously ignored the time slider entirely. When the slider is enabled, markers now fade across its window — fully opaque at the newest edge (`windowEndMs`), fading toward a floor as `lastHeard` nears the oldest edge (`windowStartMs`). Nodes with no timestamp sit at the floor. **With the slider off, behavior is unchanged.**

Fade basis is **last-heard, fade older** (per scope decision). A shared, unit-tested `markerAgeOpacity()` helper drives both surfaces.

## Why this approach

- Opacity rides the Leaflet `<Marker opacity>` prop, applied in-place via `setOpacity` — it does **not** churn the icon cache or collapse active spiderfy fans (issue #3685 concern).
- `lastHeard` is Unix **seconds** everywhere; the Map Analysis window is **ms**, so the layer converts (`lastHeard * 1000`) before comparing.
- The floor (`MIN_MARKER_OPACITY = 0.25`) keeps aging markers visible and clickable rather than fully invisible.

## Tests

- New `src/utils/markerAgeOpacity.test.ts` — boundary/clamp/linearity/floor/missing-timestamp cases.
- Extended `DashboardMap.test.tsx` — asserts fresh ≈ opaque, 48h-old node faded but above floor, stale favorite stays fully opaque.
- Full MapAnalysis suite + Dashboard suite pass (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n