### PR TITLE
Fix: MeshCore virtual node "Allow admin commands" checkbox missing/hardcoded off

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4612,6 +4612,8 @@
   "source.form.virtual_node_port": "Virtual Node Port",
   "source.form.allow_admin_commands": "Allow admin commands",
   "source.form.allow_admin_help": "Third-party clients connected to the virtual node can send admin commands to your Meshtastic node. Leave off unless you trust the clients.",
+  "meshcore.form.allow_admin_commands": "Allow admin commands",
+  "meshcore.form.allow_admin_help": "Third-party clients connected to the virtual node can send config/admin commands to your MeshCore node. Leave off unless you trust the clients.",
   "source.form.error_name_required": "Name is required",
   "source.form.error_host_required": "Host is required",
   "source.form.error_port_range": "Port must be 1–65535",

--- a/src/pages/DashboardPage.meshcoreAdminCheckbox.test.tsx
+++ b/src/pages/DashboardPage.meshcoreAdminCheckbox.test.tsx
@@ -210,4 +210,38 @@ describe('MeshCore virtual node "Allow admin commands" checkbox', () => {
     const body = JSON.parse(call[1].body as string);
     expect(body.config.virtualNode.allowAdminCommands).toBe(false);
   });
+
+  it('persists allowAdminCommands: true when the user checks it and saves', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...meshcoreSource }),
+    }) as any;
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'edit-MC Source' }));
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'meshcore.form.allow_admin_commands',
+    });
+    // Source starts with allowAdminCommands: true — toggle off then back on
+    // so this test exercises the "checked -> save true" write path
+    // independently of test 2's "checked -> save false" path.
+    fireEvent.click(checkbox);
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /^common\.save$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sources/src-mc',
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    const call = (global.fetch as any).mock.calls.find(([url]: [string]) => url === '/api/sources/src-mc');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.config.virtualNode.allowAdminCommands).toBe(true);
+  });
 });

--- a/src/pages/DashboardPage.meshcoreAdminCheckbox.test.tsx
+++ b/src/pages/DashboardPage.meshcoreAdminCheckbox.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression coverage for issue #3904 / PR #3905: the MeshCore Edit Source
+ * form's save path used to hardcode `allowAdminCommands: false` regardless
+ * of any UI state, and the checkbox itself didn't exist. These tests pin
+ * both the load (pre-population) and save (persistence) directions so the
+ * bug can't silently reappear.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DashboardPage from './DashboardPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const meshcoreSource = {
+  id: 'src-mc',
+  name: 'MC Source',
+  type: 'meshcore',
+  enabled: true,
+  config: {
+    transport: 'usb',
+    port: '/dev/ttyACM0',
+    deviceType: 'companion',
+    autoConnect: true,
+    virtualNode: { enabled: true, port: 5000, allowAdminCommands: true },
+  },
+};
+
+vi.mock('../hooks/useDashboardData', () => ({
+  useDashboardSources: vi.fn(() => ({
+    data: [meshcoreSource],
+    isSuccess: true,
+    isLoading: false,
+  })),
+  useSourceStatuses: vi.fn(() => new Map([['src-mc', { sourceId: 'src-mc', connected: true }]])),
+  useDashboardSourceData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: { sourceId: 'src-mc', connected: true },
+    isLoading: false,
+    isError: false,
+  })),
+  useDashboardUnifiedData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: null,
+    isLoading: false,
+    isError: false,
+  })),
+  useUnifiedStatus: vi.fn(() => ({ nodeCount: 0, connected: false })),
+  UNIFIED_SOURCE_ID: '__unified__',
+}));
+
+vi.mock('../hooks/useMapAnalysisData', () => ({
+  useMeshCoreNeighbors: vi.fn(() => ({ data: { items: [] }, isLoading: false, isError: false })),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    authStatus: {
+      authenticated: true,
+      user: {
+        id: 1,
+        username: 'admin',
+        email: null,
+        displayName: null,
+        authProvider: 'local',
+        isAdmin: true,
+        isActive: true,
+        passwordLocked: false,
+        mfaEnabled: false,
+        createdAt: 0,
+        lastLoginAt: null,
+      },
+      permissions: {} as any,
+      channelDbPermissions: {},
+      oidcEnabled: false,
+      localAuthDisabled: false,
+      anonymousDisabled: false,
+    },
+    loading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    hasPermission: vi.fn(() => true),
+    verifyMfa: vi.fn(),
+    loginWithOIDC: vi.fn(),
+    refreshAuth: vi.fn(),
+    hasChannelDbPermission: vi.fn(() => true),
+  })),
+}));
+
+vi.mock('../contexts/CsrfContext', () => ({
+  useCsrf: vi.fn(() => ({
+    csrfToken: 'test-token',
+    isLoading: false,
+    refreshToken: vi.fn(),
+    getToken: vi.fn(() => 'test-token'),
+  })),
+}));
+
+vi.mock('../contexts/SettingsContext', () => ({
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: vi.fn(() => ({
+    mapTileset: 'openstreetmap',
+    customTilesets: [],
+    defaultMapCenterLat: 30.0,
+    defaultMapCenterLon: -90.0,
+    defaultLandingPage: 'unified',
+  })),
+}));
+
+// Exposes an "Edit" button per source so the test can drive onEditSource
+// without needing the real sidebar's markup.
+vi.mock('../components/Dashboard/DashboardSidebar', () => ({
+  default: ({
+    sources,
+    onEditSource,
+  }: {
+    sources: Array<{ id: string; name: string }>;
+    onEditSource: (id: string) => void;
+  }) => (
+    <div data-testid="dashboard-sidebar">
+      {sources.map((s) => (
+        <button key={s.id} type="button" onClick={() => onEditSource(s.id)}>
+          edit-{s.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../components/Dashboard/DashboardMap', () => ({
+  default: () => <div data-testid="dashboard-map" />,
+}));
+
+vi.mock('../components/LoginModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean; onClose: () => void }) =>
+    (isOpen ? <div data-testid="login-modal" /> : null),
+}));
+
+vi.mock('../init', () => ({
+  appBasename: '',
+}));
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MeshCore virtual node "Allow admin commands" checkbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-populates checked when the source config has allowAdminCommands: true', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'edit-MC Source' }));
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'meshcore.form.allow_admin_commands',
+    });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('persists allowAdminCommands: false when the user unchecks it and saves', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...meshcoreSource }),
+    }) as any;
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'edit-MC Source' }));
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'meshcore.form.allow_admin_commands',
+    });
+    expect(checkbox).toBeChecked();
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /^common\.save$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sources/src-mc',
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    const call = (global.fetch as any).mock.calls.find(([url]: [string]) => url === '/api/sources/src-mc');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.config.virtualNode.allowAdminCommands).toBe(false);
+  });
+});

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -555,7 +555,7 @@ function DashboardInner() {
           setFormError(t('source.form.error_vn_port_range'));
           return;
         }
-        cfg.virtualNode = { enabled: true, port: vnPort, allowAdminCommands: false };
+        cfg.virtualNode = { enabled: true, port: vnPort, allowAdminCommands: formVnAllowAdmin };
       }
     } else {
       if (!formHost.trim()) { setFormError(t('source.form.error_host_required')); return; }
@@ -1510,21 +1510,34 @@ function DashboardInner() {
                     {t('meshcore.form.enable_virtual_node', 'Expose this node to the MeshCore app over WiFi')}
                   </label>
                   {formVnEnabled && (
-                    <label className="dashboard-form-field" style={{ marginTop: 8 }}>
-                      <span className="dashboard-form-label">{t('source.form.virtual_node_port')}</span>
-                      <input
-                        className="dashboard-form-input"
-                        type="number"
-                        min={1}
-                        max={65535}
-                        value={formVnPort}
-                        onChange={(e) => setFormVnPort(e.target.value)}
-                        placeholder="5000"
-                      />
+                    <>
+                      <label className="dashboard-form-field" style={{ marginTop: 8 }}>
+                        <span className="dashboard-form-label">{t('source.form.virtual_node_port')}</span>
+                        <input
+                          className="dashboard-form-input"
+                          type="number"
+                          min={1}
+                          max={65535}
+                          value={formVnPort}
+                          onChange={(e) => setFormVnPort(e.target.value)}
+                          placeholder="5000"
+                        />
+                        <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                          {t('meshcore.form.virtual_node_help', 'TCP port the MeshCore mobile app connects to. Point the app at this host and port over WiFi.')}
+                        </p>
+                      </label>
+                      <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 8 }}>
+                        <input
+                          type="checkbox"
+                          checked={formVnAllowAdmin}
+                          onChange={(e) => setFormVnAllowAdmin(e.target.checked)}
+                        />
+                        {t('meshcore.form.allow_admin_commands', 'Allow admin commands')}
+                      </label>
                       <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
-                        {t('meshcore.form.virtual_node_help', 'TCP port the MeshCore mobile app connects to. Point the app at this host and port over WiFi.')}
+                        {t('meshcore.form.allow_admin_help', 'Third-party clients connected to the virtual node can send config/admin commands to your MeshCore node. Leave off unless you trust the clients.')}
                       </p>
-                    </label>
+                    </>
                   )}
                 </fieldset>
               </>


### PR DESCRIPTION
## Summary

Partial fix for #3904.

- The MeshCore Edit Source form's Virtual Node fieldset never rendered the "Allow admin commands" checkbox that the Meshtastic TCP form already has.
- Worse, the save handler for `formType === 'meshcore'` **hardcoded** `allowAdminCommands: false` in the config object it POSTs/PUTs, regardless of any UI state — so the setting could never be persisted `true` through the web UI at all, only by hand-crafting a `PUT` to `/api/sources/:id` directly (as the issue reporter had to do).
- Added the checkbox (reusing the existing `formVnAllowAdmin` state already wired for the Meshtastic form) and wired it into the MeshCore save path.

## Scope note

This does **not** fix the underlying "config/admin commands silently dropped with `unhandled frame: code=142`" behavior reported in #3904 — that's a separate, larger gap in `src/server/meshcoreVirtualNodeServer.ts`: `MeshCoreVirtualNodeServer.dispatchCommand()` has no forwarding path at all for config-mutating companion commands (`SetAdvertName`, `SetRadioParams`, `SetTxPower`, `SetAdvertLatLon`, `SetChannel`, `SetOtherParams`, etc.) — they all fall through to `default:` and get `Err(UnsupportedCmd)` unconditionally. The `allowAdminCommands` flag is threaded through to a getter on the class but never consulted in the dispatch loop. See my comment on #3904 for the full analysis; that part needs a follow-up PR implementing real forwarding (mirroring `src/server/virtualNodeServer.ts`'s Meshtastic admin-forwarding pattern), not a one-line change.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/pages/DashboardPage.tsx` — 0 errors (pre-existing `no-explicit-any` warnings only, untouched by this diff)
- [x] `npx vitest run src/pages/DashboardPage.test.tsx src/pages/DashboardPage.bboxSeed.test.ts src/pages/MeshCoreSourcePage.test.tsx` — 21/21 passed
- [x] Full `npx vitest run` — 8531/8534 tests passed (3 unrelated failures traced to an uninitialized `protobufs` git submodule in the sandbox, not this change; confirmed passing after `git submodule update --init`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUSyQoiiVTZWL1X7pF7w9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUSyQoiiVTZWL1X7pF7w9S)_