### PR TITLE
fix(meshcore-vn): forward config/admin commands to the physical node (#3904)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_VN_ADMIN_FORWARDING.md
+++ b/docs/internal/dev-notes/MESHCORE_VN_ADMIN_FORWARDING.md
@@ -1,0 +1,64 @@
+# MeshCore Virtual Node — config/admin command forwarding
+
+**Issue:** #3904 (the `unhandled frame: code=142` / silently-dropped config commands).
+**Prereq (merged):** PR #3905 — the "Allow admin commands" UI checkbox + `allowAdminCommands` persistence.
+
+## What it does
+
+When the meshcore-flutter app (or any companion client) connected to the Virtual
+Node sends a config-mutating command, the VN now forwards it to the **physical**
+MeshCore node — gated on the source's `allowAdminCommands` flag — instead of
+dropping it with a blanket `Err(UnsupportedCmd)`.
+
+Before: `MeshCoreVirtualNodeServer.dispatchCommand()` only implemented a
+read/message subset; every `Set*` command hit `default:` → `Err(UnsupportedCmd)`,
+and `allowAdminCommands` was never consulted (dead code).
+
+## Design: parse-and-dispatch onto existing manager setters
+
+The physical Companion node is driven by `meshcore.js`, and `MeshCoreManager`
+already exposes typed, tested setters for these commands. So the VN parses each
+config frame and calls the matching manager method — rather than raw-relaying
+bytes (which would need a low-level frame writer and racy response correlation on
+a shared serial link). This mirrors how the VN already handles sends
+(`manager.sendMessage`, not a raw relay of `SendTxtMsg`).
+
+| App command (code) | Wire payload | Manager method | Units note |
+|---|---|---|---|
+| `SetAdvertName` (8)   | `[8][name: UTF-8]`                          | `setName(name)`               | — |
+| `SetRadioParams` (11) | `[11][freq:u32LE][bw:u32LE][sf:u8][cr:u8]`  | `setRadio(freq,bw,sf,cr)`     | wire freq=kHz→**MHz**, bw=Hz→**kHz** |
+| `SetTxPower` (12)     | `[12][power:u8]`                            | `setTxPower(power)`           | dBm |
+| `SetAdvertLatLon` (14)| `[14][lat:i32LE][lon:i32LE]`                | `setCoords(lat,lon)`          | fixed ×1e6 → **decimal degrees** |
+| `SetChannel` (32)     | `[32][idx:u8][name:cstring(32)][secret:16]` | `setChannel(idx,name,secretHex)` | secret bytes → hex; **no scope** passed (leaves DB scope untouched) |
+
+Parsers live in `meshcoreCompanionCodec.ts` (`parseSetAdvertName` … `parseSetChannel`,
+plus `fixedToDegrees` / `wireFreqToMhz` / `wireBwToKhz`), unit-tested by feeding
+meshcore.js's own `sendCommandSet*` builder output back through them. Dispatch and
+gating live in `MeshCoreVirtualNodeServer.handleConfigCommand()`.
+
+## Response semantics (what the app sees)
+
+| Situation | Response |
+|---|---|
+| `allowAdminCommands` off | `Err(UnsupportedCmd)` — explicit rejection, not a silent hang |
+| malformed / short payload | `Err(IllegalArg)` (manager not called) |
+| manager returns `false` (node rejected) | `Err(BadState)` |
+| manager throws | `Err(BadState)` |
+| success | `Ok` |
+
+Because the manager setters already await the node's ack, the VN's `Ok`
+truthfully reflects the node applying the change. All forwarding goes through the
+manager's single serialized command path, so there's no new serial contention.
+
+## Deliberately out of scope (follow-ups)
+
+- **`SetOtherParams` (38)** — a grab-bag (`manualAddContacts` + packed telemetry
+  modes + advLocPolicy). It needs a wire-int ↔ manager-string telemetry-mode
+  mapping, a `manualAddContacts` path the manager doesn't expose, and would fan
+  out into several non-atomic calls. Not one of the commands the issue named;
+  deferred to keep this change correct and reviewable.
+- **Destructive / identity / contact commands** — `Reboot`(19),
+  `ExportPrivateKey`(23)/`ImportPrivateKey`(24), `AddUpdateContact`(9)/
+  `RemoveContact`(15), `SendSelfAdvert`(7). Still `Err(UnsupportedCmd)`; each
+  warrants its own design + review.
+- **Repeater (serial-CLI) sources** — this is Companion (`meshcore.js`) only.

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -28,6 +28,14 @@ import {
   pubKeyHexToBytes,
   hexToBytes,
   degreesToFixed,
+  fixedToDegrees,
+  wireFreqToMhz,
+  wireBwToKhz,
+  parseSetAdvertName,
+  parseSetRadioParams,
+  parseSetTxPower,
+  parseSetAdvertLatLon,
+  parseSetChannel,
   toEpochSeconds,
   type SelfInfoWire,
 } from './meshcoreCompanionCodec.js';
@@ -274,5 +282,88 @@ describe('meshcoreCompanionCodec — framing + command decode', () => {
     const parsed = decodeCommand(Buffer.from([CommandCodes.DeviceQuery, 1]));
     expect(parsed.code).toBe(CommandCodes.DeviceQuery);
     expect(parsed.appTargetVer).toBe(1);
+  });
+});
+
+// ─────────────── config-command parsers (issue #3904) ───────────────
+// These parse the app→node config frames the meshcore-flutter app sends so the
+// Virtual Node can forward them to the physical node. Strongest guarantee: feed
+// meshcore.js's OWN command builders through our parser and assert we read back
+// what the app put in. meshcore.js builders hand `sendToRadioFrame` the raw
+// payload (command-code byte first) — exactly what our parsers accept.
+async function buildCommandBytes(
+  fn: (conn: any) => Promise<void>,
+): Promise<Buffer> {
+  const conn: any = new (Connection as any)();
+  let captured: Buffer | null = null;
+  conn.sendToRadioFrame = (bytes: Uint8Array) => {
+    captured = Buffer.from(bytes);
+    return Promise.resolve();
+  };
+  await fn(conn);
+  if (!captured) throw new Error('no frame captured');
+  return captured;
+}
+
+describe('config-command parsers (#3904)', () => {
+  it('fixedToDegrees inverts degreesToFixed', () => {
+    expect(fixedToDegrees(degreesToFixed(29.7604))).toBeCloseTo(29.7604, 6);
+    expect(fixedToDegrees(degreesToFixed(-95.3698))).toBeCloseTo(-95.3698, 6);
+    expect(fixedToDegrees(0)).toBe(0);
+  });
+
+  it('wire freq/bw converters invert the encode-side helpers', () => {
+    expect(wireFreqToMhz(917375)).toBeCloseTo(917.375, 6); // kHz → MHz
+    expect(wireBwToKhz(250000)).toBeCloseTo(250, 6); // Hz → kHz
+  });
+
+  it('parses SetAdvertName from meshcore.js builder output', async () => {
+    const bytes = await buildCommandBytes((c) => c.sendCommandSetAdvertName('Node XYZ'));
+    expect(bytes[0]).toBe(CommandCodes.SetAdvertName);
+    expect(parseSetAdvertName(bytes)).toEqual({ name: 'Node XYZ' });
+  });
+
+  it('parses SetRadioParams into manager units (MHz / kHz)', async () => {
+    // meshcore.js writes freq/bw as raw u32 wire units (kHz / Hz).
+    const bytes = await buildCommandBytes((c) => c.sendCommandSetRadioParams(917375, 250000, 11, 5));
+    expect(bytes[0]).toBe(CommandCodes.SetRadioParams);
+    const p = parseSetRadioParams(bytes);
+    expect(p.freq).toBeCloseTo(917.375, 6);
+    expect(p.bw).toBeCloseTo(250, 6);
+    expect(p.sf).toBe(11);
+    expect(p.cr).toBe(5);
+  });
+
+  it('parses SetTxPower', async () => {
+    const bytes = await buildCommandBytes((c) => c.sendCommandSetTxPower(22));
+    expect(bytes[0]).toBe(CommandCodes.SetTxPower);
+    expect(parseSetTxPower(bytes)).toEqual({ power: 22 });
+  });
+
+  it('parses SetAdvertLatLon back to decimal degrees', async () => {
+    const bytes = await buildCommandBytes((c) =>
+      c.sendCommandSetAdvertLatLon(degreesToFixed(29.7604), degreesToFixed(-95.3698)),
+    );
+    expect(bytes[0]).toBe(CommandCodes.SetAdvertLatLon);
+    const p = parseSetAdvertLatLon(bytes);
+    expect(p.lat).toBeCloseTo(29.7604, 6);
+    expect(p.lon).toBeCloseTo(-95.3698, 6);
+  });
+
+  it('parses SetChannel (idx, name, 16-byte secret → hex)', async () => {
+    const secret = new Uint8Array(16).map((_, i) => i + 1);
+    const bytes = await buildCommandBytes((c) => c.sendCommandSetChannel(2, 'gauntlet', secret));
+    expect(bytes[0]).toBe(CommandCodes.SetChannel);
+    const p = parseSetChannel(bytes);
+    expect(p.idx).toBe(2);
+    expect(p.name).toBe('gauntlet');
+    expect(p.secretHex).toBe('0102030405060708090a0b0c0d0e0f10');
+  });
+
+  it('throws on short/garbage payloads so the dispatcher can reply Err', () => {
+    expect(() => parseSetRadioParams(Buffer.from([CommandCodes.SetRadioParams, 1, 2]))).toThrow();
+    expect(() => parseSetTxPower(Buffer.from([CommandCodes.SetTxPower]))).toThrow();
+    expect(() => parseSetAdvertLatLon(Buffer.from([CommandCodes.SetAdvertLatLon, 0, 0]))).toThrow();
+    expect(() => parseSetChannel(Buffer.from([CommandCodes.SetChannel, 0]))).toThrow();
   });
 });

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -323,6 +323,11 @@ describe('config-command parsers (#3904)', () => {
     expect(parseSetAdvertName(bytes)).toEqual({ name: 'Node XYZ' });
   });
 
+  it('accepts a bare SetAdvertName (no name bytes) as an empty "clear name"', () => {
+    // Intentionally lenient — a name-less frame yields '' rather than throwing.
+    expect(parseSetAdvertName(Buffer.from([CommandCodes.SetAdvertName]))).toEqual({ name: '' });
+  });
+
   it('parses SetRadioParams into manager units (MHz / kHz)', async () => {
     // meshcore.js writes freq/bw as raw u32 wire units (kHz / Hz).
     const bytes = await buildCommandBytes((c) => c.sendCommandSetRadioParams(917375, 250000, 11, 5));
@@ -361,6 +366,8 @@ describe('config-command parsers (#3904)', () => {
   });
 
   it('throws on short/garbage payloads so the dispatcher can reply Err', () => {
+    // parseSetAdvertName is intentionally absent here — it has no min-length
+    // guard (an empty name is valid; see the "clear name" test above).
     expect(() => parseSetRadioParams(Buffer.from([CommandCodes.SetRadioParams, 1, 2]))).toThrow();
     expect(() => parseSetTxPower(Buffer.from([CommandCodes.SetTxPower]))).toThrow();
     expect(() => parseSetAdvertLatLon(Buffer.from([CommandCodes.SetAdvertLatLon, 0, 0]))).toThrow();

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -228,6 +228,11 @@ export function decodeCommand(payload: Buffer): ParsedCommand {
 // buffer so the dispatcher can reply Err(IllegalArg). Radio/position fields are
 // returned in the SAME units MeshCoreManager expects (MHz, kHz, decimal
 // degrees), not raw wire units.
+//
+// Parsers only DECODE + length-check. Range/semantic validation (e.g. LoRa freq
+// 100–1000 MHz, tx power 1–22 dBm) lives in the MeshCoreManager setters
+// (validateRadioParams, setTxPower, …); a corrupt in-range-typed value that the
+// node rejects surfaces to the app as Err(BadState), not a crash here.
 
 export interface SetAdvertNameCmd { name: string; }
 export interface SetRadioParamsCmd { freq: number; bw: number; sf: number; cr: number; }
@@ -235,7 +240,13 @@ export interface SetTxPowerCmd { power: number; }
 export interface SetAdvertLatLonCmd { lat: number; lon: number; }
 export interface SetChannelCmd { idx: number; name: string; secretHex: string; }
 
-/** SetAdvertName(8): `[code][name: UTF-8, rest of frame]`. */
+/**
+ * SetAdvertName(8): `[code][name: UTF-8, rest of frame]`.
+ *
+ * No minimum-length guard: a bare `[code]` frame (no name bytes) is intentionally
+ * accepted and yields `{ name: '' }` — "clear the advertised name" — rather than
+ * throwing. The MeshCoreManager.setName setter sanitizes the value downstream.
+ */
 export function parseSetAdvertName(payload: Buffer): SetAdvertNameCmd {
   return { name: payload.subarray(1).toString('utf8') };
 }

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -220,6 +220,66 @@ export function decodeCommand(payload: Buffer): ParsedCommand {
   return cmd;
 }
 
+// ─────────────────────── config-command parsers ───────────────────────
+// Parse the app→node config frames the meshcore-flutter app sends so the
+// Virtual Node can forward them to the physical node (issue #3904). Each takes
+// the raw command payload (leading code byte at offset 0, fields little-endian,
+// mirroring meshcore.js's `sendCommandSet*` builders) and throws on a short
+// buffer so the dispatcher can reply Err(IllegalArg). Radio/position fields are
+// returned in the SAME units MeshCoreManager expects (MHz, kHz, decimal
+// degrees), not raw wire units.
+
+export interface SetAdvertNameCmd { name: string; }
+export interface SetRadioParamsCmd { freq: number; bw: number; sf: number; cr: number; }
+export interface SetTxPowerCmd { power: number; }
+export interface SetAdvertLatLonCmd { lat: number; lon: number; }
+export interface SetChannelCmd { idx: number; name: string; secretHex: string; }
+
+/** SetAdvertName(8): `[code][name: UTF-8, rest of frame]`. */
+export function parseSetAdvertName(payload: Buffer): SetAdvertNameCmd {
+  return { name: payload.subarray(1).toString('utf8') };
+}
+
+/**
+ * SetRadioParams(11): `[code][freq:u32LE][bw:u32LE][sf:u8][cr:u8]`.
+ * Wire freq is kHz and bw is Hz; returned in MHz / kHz for MeshCoreManager.setRadio.
+ */
+export function parseSetRadioParams(payload: Buffer): SetRadioParamsCmd {
+  if (payload.length < 11) throw new Error('SetRadioParams: short payload');
+  return {
+    freq: wireFreqToMhz(payload.readUInt32LE(1)),
+    bw: wireBwToKhz(payload.readUInt32LE(5)),
+    sf: payload[9],
+    cr: payload[10],
+  };
+}
+
+/** SetTxPower(12): `[code][power:u8]` (dBm). */
+export function parseSetTxPower(payload: Buffer): SetTxPowerCmd {
+  if (payload.length < 2) throw new Error('SetTxPower: short payload');
+  return { power: payload[1] };
+}
+
+/** SetAdvertLatLon(14): `[code][lat:i32LE][lon:i32LE]` fixed-point → decimal degrees. */
+export function parseSetAdvertLatLon(payload: Buffer): SetAdvertLatLonCmd {
+  if (payload.length < 9) throw new Error('SetAdvertLatLon: short payload');
+  return {
+    lat: fixedToDegrees(payload.readInt32LE(1)),
+    lon: fixedToDegrees(payload.readInt32LE(5)),
+  };
+}
+
+/** SetChannel(32): `[code][idx:u8][name:cstring(32)][secret:16]`; secret returned as hex. */
+export function parseSetChannel(payload: Buffer): SetChannelCmd {
+  if (payload.length < 1 + 1 + 32 + 16) throw new Error('SetChannel: short payload');
+  const idx = payload[1];
+  const nameBuf = payload.subarray(2, 34);
+  const nul = nameBuf.indexOf(0);
+  const name = nameBuf.subarray(0, nul === -1 ? 32 : nul).toString('utf8');
+  const secretHex = payload.subarray(34, 50).toString('hex');
+  return { idx, name, secretHex };
+}
+
 // ───────────────────────── response encoders ─────────────────────────
 // Each returns a payload (response code byte first), NOT yet framed. Wrap with
 // frameNodeToApp() before writing to the socket.
@@ -532,6 +592,11 @@ export function degreesToFixed(deg: number | undefined | null): number {
   return Math.round(deg * 1e6) | 0;
 }
 
+/** Convert MeshCore fixed-point (degrees×1e6, int32) back to decimal degrees. */
+export function fixedToDegrees(fixed: number): number {
+  return fixed / 1e6;
+}
+
 /** Convert MHz to wire frequency units (kHz). */
 export function mhzToWireFreq(mhz: number | undefined | null): number {
   return typeof mhz === 'number' && Number.isFinite(mhz) ? Math.round(mhz * 1000) : 0;
@@ -540,4 +605,14 @@ export function mhzToWireFreq(mhz: number | undefined | null): number {
 /** Convert kHz to wire bandwidth units (Hz). */
 export function khzToWireBw(khz: number | undefined | null): number {
   return typeof khz === 'number' && Number.isFinite(khz) ? Math.round(khz * 1000) : 0;
+}
+
+/** Convert wire frequency units (kHz) to MHz — inverse of {@link mhzToWireFreq}. */
+export function wireFreqToMhz(khz: number): number {
+  return khz / 1000;
+}
+
+/** Convert wire bandwidth units (Hz) to kHz — inverse of {@link khzToWireBw}. */
+export function wireBwToKhz(hz: number): number {
+  return hz / 1000;
 }

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -6,10 +6,12 @@ import { MeshCoreVirtualNodeServer, type MeshCoreVirtualNodeManager } from './me
 import {
   CommandCodes,
   ResponseCodes,
+  ErrorCodes,
   PushCodes,
   FRAME_APP_TO_NODE,
   FRAME_NODE_TO_APP,
   SUPPORTED_COMPANION_PROTOCOL_VERSION,
+  degreesToFixed,
 } from './meshcoreCompanionCodec.js';
 import type { MeshCoreNode, MeshCoreContact, MeshCoreMessage } from './meshcoreManager.js';
 
@@ -58,6 +60,12 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   }
   sendMessageMock = vi.fn().mockResolvedValue(true);
   sendMessageWithResultMock = vi.fn().mockResolvedValue({ ok: true });
+  // Config-mutation mocks (issue #3904).
+  setNameMock = vi.fn().mockResolvedValue(true);
+  setRadioMock = vi.fn().mockResolvedValue(true);
+  setTxPowerMock = vi.fn().mockResolvedValue(true);
+  setCoordsMock = vi.fn().mockResolvedValue(true);
+  setChannelMock = vi.fn().mockResolvedValue(undefined);
   isConnected() { return this.localNode !== null; }
   getLocalNode() { return this.localNode; }
   getContacts() { return this.contacts; }
@@ -66,6 +74,15 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   }
   sendMessageWithResult(text: string, toPublicKey?: string, channelIdx?: number) {
     return this.sendMessageWithResultMock(text, toPublicKey, channelIdx) as Promise<{ ok: boolean; expectedAckCrc?: number; estTimeout?: number }>;
+  }
+  setName(name: string) { return this.setNameMock(name) as Promise<boolean>; }
+  setRadio(freq: number, bw: number, sf: number, cr: number) {
+    return this.setRadioMock(freq, bw, sf, cr) as Promise<boolean>;
+  }
+  setTxPower(power: number) { return this.setTxPowerMock(power) as Promise<boolean>; }
+  setCoords(lat: number, lon: number) { return this.setCoordsMock(lat, lon) as Promise<boolean>; }
+  setChannel(idx: number, name: string, secretHex: string, scope?: string | null) {
+    return this.setChannelMock(idx, name, secretHex, scope) as Promise<void>;
   }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
@@ -416,5 +433,130 @@ describe('MeshCoreVirtualNodeServer — local node not ready', () => {
 
     client.close();
     await server.stop();
+  });
+});
+
+// ─────────────── config-command forwarding (issue #3904) ───────────────
+// The VN forwards config-mutating companion commands to the real node via the
+// manager's typed setters, gated on allowAdminCommands. Before this, every such
+// command fell through to Err(UnsupportedCmd) unconditionally.
+const toNums = (b: Buffer): number[] => Array.from(b);
+
+function radioParamsFrame(freqKhz: number, bwHz: number, sf: number, cr: number): number[] {
+  const b = Buffer.alloc(11);
+  b[0] = CommandCodes.SetRadioParams;
+  b.writeUInt32LE(freqKhz, 1);
+  b.writeUInt32LE(bwHz, 5);
+  b[9] = sf;
+  b[10] = cr;
+  return toNums(b);
+}
+function latLonFrame(latDeg: number, lonDeg: number): number[] {
+  const b = Buffer.alloc(9);
+  b[0] = CommandCodes.SetAdvertLatLon;
+  b.writeInt32LE(degreesToFixed(latDeg), 1);
+  b.writeInt32LE(degreesToFixed(lonDeg), 5);
+  return toNums(b);
+}
+function setChannelFrame(idx: number, name: string, secret: Buffer): number[] {
+  const b = Buffer.alloc(50);
+  b[0] = CommandCodes.SetChannel;
+  b[1] = idx;
+  b.write(name, 2, 31, 'utf8'); // cstring(32), leave final byte null
+  secret.copy(b, 34, 0, 16);
+  return toNums(b);
+}
+const nameFrame = (name: string): number[] => [CommandCodes.SetAdvertName, ...Buffer.from(name, 'utf8')];
+
+describe('MeshCoreVirtualNodeServer — config-command forwarding (#3904)', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let client: TestClient;
+  let manager: FakeManager;
+
+  async function startWith(allowAdminCommands: boolean): Promise<void> {
+    manager = new FakeManager();
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, allowAdminCommands, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+  }
+
+  afterEach(async () => {
+    client?.close();
+    await server?.stop();
+  });
+
+  it('forwards SetAdvertName to manager.setName and replies Ok', async () => {
+    await startWith(true);
+    const res = await client.request(nameFrame('Rover'));
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    expect(manager.setNameMock).toHaveBeenCalledWith('Rover');
+  });
+
+  it('forwards SetRadioParams in manager units (MHz / kHz) and replies Ok', async () => {
+    await startWith(true);
+    const res = await client.request(radioParamsFrame(917375, 250000, 11, 5));
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    const [freq, bw, sf, cr] = manager.setRadioMock.mock.calls[0];
+    expect(freq).toBeCloseTo(917.375, 6);
+    expect(bw).toBeCloseTo(250, 6);
+    expect(sf).toBe(11);
+    expect(cr).toBe(5);
+  });
+
+  it('forwards SetTxPower and replies Ok', async () => {
+    await startWith(true);
+    const res = await client.request([CommandCodes.SetTxPower, 20]);
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    expect(manager.setTxPowerMock).toHaveBeenCalledWith(20);
+  });
+
+  it('forwards SetAdvertLatLon as decimal degrees and replies Ok', async () => {
+    await startWith(true);
+    const res = await client.request(latLonFrame(29.7604, -95.3698));
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    const [lat, lon] = manager.setCoordsMock.mock.calls[0];
+    expect(lat).toBeCloseTo(29.7604, 5);
+    expect(lon).toBeCloseTo(-95.3698, 5);
+  });
+
+  it('forwards SetChannel (idx, name, hex secret, no scope) and replies Ok', async () => {
+    await startWith(true);
+    const secret = Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex');
+    const res = await client.request(setChannelFrame(1, 'gauntlet', secret));
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    expect(manager.setChannelMock).toHaveBeenCalledWith(1, 'gauntlet', '000102030405060708090a0b0c0d0e0f', undefined);
+  });
+
+  it('blocks config commands with Err(UnsupportedCmd) when allowAdminCommands is off, without touching the node', async () => {
+    await startWith(false);
+    const res = await client.request(nameFrame('Rover'));
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.UnsupportedCmd);
+    expect(manager.setNameMock).not.toHaveBeenCalled();
+  });
+
+  it('replies Err(BadState) when the node rejects the change (manager returns false)', async () => {
+    await startWith(true);
+    manager.setTxPowerMock.mockResolvedValueOnce(false);
+    const res = await client.request([CommandCodes.SetTxPower, 20]);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.BadState);
+  });
+
+  it('replies Err(BadState) when the manager throws', async () => {
+    await startWith(true);
+    manager.setRadioMock.mockRejectedValueOnce(new Error('invalid radio'));
+    const res = await client.request(radioParamsFrame(917375, 250000, 11, 5));
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.BadState);
+  });
+
+  it('replies Err(IllegalArg) on a malformed config payload, without calling the manager', async () => {
+    await startWith(true);
+    const res = await client.request([CommandCodes.SetRadioParams, 1, 2]); // too short
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.IllegalArg);
+    expect(manager.setRadioMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -33,6 +33,11 @@ import {
   toEpochSeconds,
   mhzToWireFreq,
   khzToWireBw,
+  parseSetAdvertName,
+  parseSetRadioParams,
+  parseSetTxPower,
+  parseSetAdvertLatLon,
+  parseSetChannel,
   type ParsedCommand,
 } from './meshcoreCompanionCodec.js';
 
@@ -59,6 +64,14 @@ export interface MeshCoreVirtualNodeManager {
     toPublicKey?: string,
     channelIdx?: number,
   ): Promise<{ ok: boolean; expectedAckCrc?: number; estTimeout?: number }>;
+  // Config mutations forwarded to the real node when `allowAdminCommands` is on
+  // (issue #3904). Units match the manager's own methods: freq MHz, bw kHz,
+  // lat/lon decimal degrees. Return false / throw on failure.
+  setName(name: string): Promise<boolean>;
+  setRadio(freq: number, bw: number, sf: number, cr: number): Promise<boolean>;
+  setTxPower(power: number): Promise<boolean>;
+  setCoords(lat: number, lon: number): Promise<boolean>;
+  setChannel(idx: number, name: string, secretHex: string, scope?: string | null): Promise<void>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -360,6 +373,41 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
           // treating an Err as a fatal handshake failure). Phase 3 forwards it.
           this.send(clientId, encodeOk());
           break;
+        // Config-mutating commands (issue #3904): forwarded to the real node
+        // only when `allowAdminCommands` is enabled; otherwise the app gets an
+        // explicit Err (UnsupportedCmd) instead of a silent hang.
+        case CommandCodes.SetAdvertName:
+          void this.handleConfigCommand(clientId, command, () => {
+            const { name } = parseSetAdvertName(command.payload);
+            return this.options.manager.setName(name);
+          });
+          break;
+        case CommandCodes.SetRadioParams:
+          void this.handleConfigCommand(clientId, command, () => {
+            const { freq, bw, sf, cr } = parseSetRadioParams(command.payload);
+            return this.options.manager.setRadio(freq, bw, sf, cr);
+          });
+          break;
+        case CommandCodes.SetTxPower:
+          void this.handleConfigCommand(clientId, command, () => {
+            const { power } = parseSetTxPower(command.payload);
+            return this.options.manager.setTxPower(power);
+          });
+          break;
+        case CommandCodes.SetAdvertLatLon:
+          void this.handleConfigCommand(clientId, command, () => {
+            const { lat, lon } = parseSetAdvertLatLon(command.payload);
+            return this.options.manager.setCoords(lat, lon);
+          });
+          break;
+        case CommandCodes.SetChannel:
+          void this.handleConfigCommand(clientId, command, () => {
+            const { idx, name, secretHex } = parseSetChannel(command.payload);
+            // No scope in the wire frame — pass undefined so the DB scope the
+            // user set in MeshMonitor is left untouched (see MESHCORE scope trap).
+            return this.options.manager.setChannel(idx, name, secretHex);
+          });
+          break;
         default:
           logger.debug(`[MeshCore VN ${this.sourceId}] unsupported command ${command.code} from ${clientId}`);
           this.send(clientId, encodeErr(ErrorCodes.UnsupportedCmd));
@@ -367,6 +415,56 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       }
     } catch (error) {
       logger.error(`[MeshCore VN ${this.sourceId}] error handling command ${command.code} from ${clientId}:`, error);
+    }
+  }
+
+  /**
+   * Shared path for config-mutating commands (issue #3904). Gates on
+   * `allowAdminCommands`, runs `apply()` (which parses the payload and calls the
+   * matching MeshCoreManager method against the real node), and translates the
+   * outcome into a companion response:
+   *   - admin disabled          → Err(UnsupportedCmd) (explicit, not a silent hang)
+   *   - parse failure (throws)  → Err(IllegalArg)
+   *   - manager returns false    → Err(BadState)
+   *   - manager throws           → Err(BadState)
+   *   - success                  → Ok
+   * `apply` returns boolean (most setters) or void (setChannel) — void resolves
+   * are treated as success.
+   */
+  private async handleConfigCommand(
+    clientId: string,
+    command: ParsedCommand,
+    apply: () => Promise<boolean | void>,
+  ): Promise<void> {
+    const name = COMMAND_NAMES[command.code] ?? String(command.code);
+    if (!this.allowAdminCommands) {
+      logger.debug(
+        `[MeshCore VN ${this.sourceId}] ${name} blocked from ${clientId} (allowAdminCommands off)`,
+      );
+      this.send(clientId, encodeErr(ErrorCodes.UnsupportedCmd));
+      return;
+    }
+    let applied: Promise<boolean | void>;
+    try {
+      // Payload parsing happens inside apply(); a malformed frame throws here.
+      applied = apply();
+    } catch (parseErr) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] ${name} bad payload from ${clientId}: ${(parseErr as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.IllegalArg));
+      return;
+    }
+    try {
+      const ok = await applied;
+      if (ok === false) {
+        logger.warn(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} not applied by node`);
+        this.send(clientId, encodeErr(ErrorCodes.BadState));
+        return;
+      }
+      logger.info(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} forwarded to node`);
+      this.send(clientId, encodeOk());
+    } catch (err) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} failed: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.BadState));
     }
   }
 

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
 import databaseService from '../services/database.js';
 import type { MeshCoreNode, TelemetryMode, MeshCoreContact, MeshCoreMessage } from './meshcoreManager.js';
-import databaseServiceDefault from '../services/database.js';
 import {
   CommandCodes,
   ErrorCodes,
@@ -172,7 +171,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     super();
     this.options = options;
     this.allowAdminCommands = options.allowAdminCommands ?? false;
-    this.db = options.databaseService ?? (databaseServiceDefault as unknown as ChannelsDb);
+    this.db = options.databaseService ?? (databaseService as unknown as ChannelsDb);
   }
 
   get sourceId(): string {
@@ -446,7 +445,10 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     }
     let applied: Promise<boolean | void>;
     try {
-      // Payload parsing happens inside apply(); a malformed frame throws here.
+      // Payload parsing happens synchronously inside apply() before the manager
+      // promise is returned, so a malformed frame throws HERE (→ IllegalArg).
+      // Invariant: the parseSet* helpers must stay synchronous, or a parse error
+      // would escape this catch and be mis-reported as BadState below.
       applied = apply();
     } catch (parseErr) {
       logger.warn(`[MeshCore VN ${this.sourceId}] ${name} bad payload from ${clientId}: ${(parseErr as Error).message}`);


### PR DESCRIPTION
## Summary

Fixes the core of #3904 (item 2): MeshCore Virtual Node **config-mutating commands were silently dropped** — the app's radio/name/coords/channel changes hung with the reporter's `unhandled frame: code=142`. (PR #3905 already fixed item 1, the missing "Allow admin commands" checkbox.)

`MeshCoreVirtualNodeServer.dispatchCommand()` only implemented a read/message subset; every `Set*` command fell through to `Err(UnsupportedCmd)` **unconditionally**, and the `allowAdminCommands` flag was threaded to a getter but **never consulted** — dead code.

This forwards five config commands to the physical node via `MeshCoreManager`'s existing typed setters, **gated on `allowAdminCommands`**:

| App command (code) | Manager method | Units |
|---|---|---|
| `SetAdvertName` (8)   | `setName`   | — |
| `SetRadioParams` (11) | `setRadio`  | wire kHz/Hz → **MHz/kHz** |
| `SetTxPower` (12)     | `setTxPower`| dBm |
| `SetAdvertLatLon` (14)| `setCoords` | fixed ×1e6 → **decimal degrees** |
| `SetChannel` (32)     | `setChannel`| 16-byte secret → hex; **no scope** passed (leaves the MeshMonitor DB scope untouched) |

## Why parse-and-dispatch (not raw passthrough)

The physical Companion node is already driven by `meshcore.js` and the manager already exposes typed, tested setters for exactly these commands. Parsing each frame and calling the setter reuses proven code, gives clean success/failure semantics, and avoids serial contention + racy response correlation that a raw-byte relay on the shared link would introduce. This mirrors how the VN already routes sends through `manager.sendMessage` rather than raw-relaying `SendTxtMsg`.

## Response semantics (app can surface these instead of hanging)

| Situation | Response |
|---|---|
| `allowAdminCommands` off | `Err(UnsupportedCmd)` |
| malformed / short payload | `Err(IllegalArg)` (manager not called) |
| node rejects (`false`) / manager throws | `Err(BadState)` |
| success | `Ok` |

Manager setters await the node's ack, so `Ok` truthfully reflects the node applying the change.

## Correctness detail

Radio params required a unit conversion that's easy to get wrong: the wire sends freq in **kHz** and bandwidth in **Hz**, but `MeshCoreManager.setRadio` / `validateRadioParams` work in **MHz / kHz**. The parser divides by 1000 (inverse of the existing `mhzToWireFreq`/`khzToWireBw` encode helpers). Covered by a test.

## Scope (deliberately deferred — see `docs/internal/dev-notes/MESHCORE_VN_ADMIN_FORWARDING.md`)

- **`SetOtherParams` (38)** — grab-bag (manualAddContacts + packed telemetry modes + advLocPolicy) needing a wire-int↔manager-string telemetry mapping and a `manualAddContacts` path the manager doesn't expose; would fan out into several non-atomic calls. Not a command the issue named.
- **Destructive/identity/contact commands** (Reboot, key import/export, contact CRUD) — still `Err(UnsupportedCmd)`; each warrants its own review.
- **Repeater (serial-CLI) sources** — Companion (`meshcore.js`) only.

## Test plan

- [x] New codec parsers unit-tested by **round-tripping meshcore.js's own `sendCommandSet*` builder output** back through them (authentic wire fidelity), incl. the kHz→MHz / Hz→kHz conversions and short-payload throws.
- [x] VN dispatch tests: forward → correct manager call + `Ok`; gate off → `Err(UnsupportedCmd)` + manager not called; node-reject → `Err(BadState)`; manager throw → `Err(BadState)`; malformed → `Err(IllegalArg)`.
- [x] Full suite: `npx vitest run` — **7906 passed, 0 failed**.
- [x] `tsc -p tsconfig.server.json` — no new errors (pre-existing TelemetryChart noise only).
- [x] eslint — no new issues (the 5 flagged errors are pre-existing on `main`; local-eslint-not-CI-faithful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n