### PR TITLE
feat(meshcore-vn): forward SetOtherParams to the physical node (#3904)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_VN_ADMIN_FORWARDING.md
+++ b/docs/internal/dev-notes/MESHCORE_VN_ADMIN_FORWARDING.md
@@ -30,6 +30,7 @@ a shared serial link). This mirrors how the VN already handles sends
 | `SetTxPower` (12)     | `[12][power:u8]`                            | `setTxPower(power)`           | dBm |
 | `SetAdvertLatLon` (14)| `[14][lat:i32LE][lon:i32LE]`                | `setCoords(lat,lon)`          | fixed ×1e6 → **decimal degrees** |
 | `SetChannel` (32)     | `[32][idx:u8][name:cstring(32)][secret:16]` | `setChannel(idx,name,secretHex)` | secret bytes → hex; **no scope** passed (leaves DB scope untouched) |
+| `SetOtherParams` (38) | `[38][manualAddContacts:u8][telemetryMode:u8 packed][advLocPolicy:u8]` | `setOtherParams({…})` | telemetry byte unpacked to three 2-bit sections; forwarded atomically in one frame |
 
 Parsers live in `meshcoreCompanionCodec.ts` (`parseSetAdvertName` … `parseSetChannel`,
 plus `fixedToDegrees` / `wireFreqToMhz` / `wireBwToKhz`), unit-tested by feeding
@@ -50,13 +51,25 @@ Because the manager setters already await the node's ack, the VN's `Ok`
 truthfully reflects the node applying the change. All forwarding goes through the
 manager's single serialized command path, so there's no new serial contention.
 
+## SetOtherParams (38) — atomic path
+
+`SetOtherParams` bundles `manualAddContacts`, three 2-bit telemetry-visibility
+sections, and `advLocPolicy`. Rather than fan it out across the manager's
+piecemeal string-based setters (`setTelemetryModeBase` etc., each a separate
+non-atomic read-modify-write frame — and none for `manualAddContacts`), it gets
+a dedicated single-frame path:
+
+`parseSetOtherParams` → `MeshCoreManager.setOtherParams({…})` →
+native-backend `set_other_params` → `meshcore.js connection.setOtherParams(opts)`.
+
+Telemetry modes stay as **raw 2-bit integers** end to end — the backend's
+`telemetryModeStringToNumber` accepts numeric values directly, so there's no
+lossy wire-int ↔ manager-string round-trip (the two vocabularies also disagree:
+meshcore.js `TelemetryMode.AlwaysOn = 1` vs MeshMonitor `'always' → 2`). One
+frame, one node ack, no mapping ambiguity.
+
 ## Deliberately out of scope (follow-ups)
 
-- **`SetOtherParams` (38)** — a grab-bag (`manualAddContacts` + packed telemetry
-  modes + advLocPolicy). It needs a wire-int ↔ manager-string telemetry-mode
-  mapping, a `manualAddContacts` path the manager doesn't expose, and would fan
-  out into several non-atomic calls. Not one of the commands the issue named;
-  deferred to keep this change correct and reviewable.
 - **Destructive / identity / contact commands** — `Reboot`(19),
   `ExportPrivateKey`(23)/`ImportPrivateKey`(24), `AddUpdateContact`(9)/
   `RemoveContact`(15), `SendSelfAdvert`(7). Still `Err(UnsupportedCmd)`; each

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -36,6 +36,8 @@ import {
   parseSetTxPower,
   parseSetAdvertLatLon,
   parseSetChannel,
+  parseSetOtherParams,
+  unpackTelemetryMode,
   toEpochSeconds,
   type SelfInfoWire,
 } from './meshcoreCompanionCodec.js';
@@ -365,10 +367,29 @@ describe('config-command parsers (#3904)', () => {
     expect(p.secretHex).toBe('0102030405060708090a0b0c0d0e0f10');
   });
 
+  it('unpackTelemetryMode inverts packTelemetryMode', () => {
+    expect(unpackTelemetryMode(packTelemetryMode(1, 2, 1))).toEqual({ base: 1, loc: 2, env: 1 });
+    expect(unpackTelemetryMode(packTelemetryMode(0, 0, 0))).toEqual({ base: 0, loc: 0, env: 0 });
+    expect(unpackTelemetryMode(packTelemetryMode(2, 1, 2))).toEqual({ base: 2, loc: 1, env: 2 });
+  });
+
+  it('parses SetOtherParams from meshcore.js builder output', async () => {
+    const bytes = await buildCommandBytes((c) => c.sendCommandSetOtherParams(1, 2, 1, 2, 1));
+    expect(bytes[0]).toBe(CommandCodes.SetOtherParams);
+    expect(parseSetOtherParams(bytes)).toEqual({
+      manualAddContacts: 1,
+      telemetryModeBase: 2,
+      telemetryModeLoc: 1,
+      telemetryModeEnv: 2,
+      advLocPolicy: 1,
+    });
+  });
+
   it('throws on short/garbage payloads so the dispatcher can reply Err', () => {
     // parseSetAdvertName is intentionally absent here — it has no min-length
     // guard (an empty name is valid; see the "clear name" test above).
     expect(() => parseSetRadioParams(Buffer.from([CommandCodes.SetRadioParams, 1, 2]))).toThrow();
+    expect(() => parseSetOtherParams(Buffer.from([CommandCodes.SetOtherParams, 1, 2]))).toThrow();
     expect(() => parseSetTxPower(Buffer.from([CommandCodes.SetTxPower]))).toThrow();
     expect(() => parseSetAdvertLatLon(Buffer.from([CommandCodes.SetAdvertLatLon, 0, 0]))).toThrow();
     expect(() => parseSetChannel(Buffer.from([CommandCodes.SetChannel, 0]))).toThrow();

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -239,6 +239,16 @@ export interface SetRadioParamsCmd { freq: number; bw: number; sf: number; cr: n
 export interface SetTxPowerCmd { power: number; }
 export interface SetAdvertLatLonCmd { lat: number; lon: number; }
 export interface SetChannelCmd { idx: number; name: string; secretHex: string; }
+export interface SetOtherParamsCmd {
+  /** Add contacts only on explicit request (1) vs automatically (0). */
+  manualAddContacts: number;
+  /** Per-section telemetry visibility (2-bit each): 0=off, 1=always, 2=on-request. */
+  telemetryModeBase: number;
+  telemetryModeLoc: number;
+  telemetryModeEnv: number;
+  /** Include location in adverts (0/1). */
+  advLocPolicy: number;
+}
 
 /**
  * SetAdvertName(8): `[code][name: UTF-8, rest of frame]`.
@@ -289,6 +299,27 @@ export function parseSetChannel(payload: Buffer): SetChannelCmd {
   const name = nameBuf.subarray(0, nul === -1 ? 32 : nul).toString('utf8');
   const secretHex = payload.subarray(34, 50).toString('hex');
   return { idx, name, secretHex };
+}
+
+/** Unpack the SetOtherParams/SelfInfo telemetry byte — inverse of {@link packTelemetryMode}. */
+export function unpackTelemetryMode(byte: number): { base: number; loc: number; env: number } {
+  return { base: byte & 0b11, loc: (byte >> 2) & 0b11, env: (byte >> 4) & 0b11 };
+}
+
+/**
+ * SetOtherParams(38): `[code][manualAddContacts:u8][telemetryMode:u8 packed][advLocPolicy:u8]`.
+ * The telemetry byte packs three 2-bit sections (base|loc<<2|env<<4).
+ */
+export function parseSetOtherParams(payload: Buffer): SetOtherParamsCmd {
+  if (payload.length < 4) throw new Error('SetOtherParams: short payload');
+  const { base, loc, env } = unpackTelemetryMode(payload[2]);
+  return {
+    manualAddContacts: payload[1],
+    telemetryModeBase: base,
+    telemetryModeLoc: loc,
+    telemetryModeEnv: env,
+    advLocPolicy: payload[3],
+  };
 }
 
 // ───────────────────────── response encoders ─────────────────────────

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -301,7 +301,11 @@ export function parseSetChannel(payload: Buffer): SetChannelCmd {
   return { idx, name, secretHex };
 }
 
-/** Unpack the SetOtherParams/SelfInfo telemetry byte — inverse of {@link packTelemetryMode}. */
+/**
+ * Unpack the SetOtherParams/SelfInfo telemetry byte — inverse of
+ * {@link packTelemetryMode}. Only bits 0–5 are defined (three 2-bit sections);
+ * bits 6–7 are reserved and ignored.
+ */
 export function unpackTelemetryMode(byte: number): { base: number; loc: number; env: number } {
   return { base: byte & 0b11, loc: (byte >> 2) & 0b11, env: (byte >> 4) & 0b11 };
 }

--- a/src/server/meshcoreManager.telemetry.test.ts
+++ b/src/server/meshcoreManager.telemetry.test.ts
@@ -107,4 +107,34 @@ describe('MeshCoreManager telemetry mode setters', () => {
       });
     });
   }
+
+  describe('setOtherParams (#3904 — atomic multi-field forward)', () => {
+    const PARAMS = {
+      manualAddContacts: 1,
+      telemetryModeBase: 2,
+      telemetryModeLoc: 1,
+      telemetryModeEnv: 0,
+      advLocPolicy: 1,
+    };
+
+    it('sends set_other_params with all fields in a single bridge call', async () => {
+      const ok = await manager.setOtherParams(PARAMS);
+      expect(ok).toBe(true);
+      expect(manager.bridgeCalls).toEqual([{ cmd: 'set_other_params', params: PARAMS }]);
+    });
+
+    it('returns false without calling the bridge on repeater devices', async () => {
+      const repeater = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+      const ok = await repeater.setOtherParams(PARAMS);
+      expect(ok).toBe(false);
+      expect(repeater.bridgeCalls).toHaveLength(0);
+    });
+
+    it('returns false when the bridge call fails', async () => {
+      const failing = makeManager({ deviceType: MeshCoreDeviceType.COMPANION, bridgeFail: true });
+      const ok = await failing.setOtherParams(PARAMS);
+      expect(ok).toBe(false);
+      expect(failing.bridgeCalls).toHaveLength(1);
+    });
+  });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4332,6 +4332,35 @@ class MeshCoreManager extends EventEmitter {
     return this.setTelemetryMode('env', mode);
   }
 
+  /**
+   * Set all "other params" atomically in a single SetOtherParams frame
+   * (companion only) — manual-add-contacts, the three telemetry-visibility
+   * sections, and the advert location policy. Telemetry modes are the raw 2-bit
+   * values (0=off, 1=always, 2=on-request); the backend's converter accepts
+   * these numeric values directly. Used by the Virtual Node to forward an app's
+   * SetOtherParams(38) in one round-trip instead of several piecemeal patches
+   * (issue #3904).
+   */
+  async setOtherParams(params: {
+    manualAddContacts: number;
+    telemetryModeBase: number;
+    telemetryModeLoc: number;
+    telemetryModeEnv: number;
+    advLocPolicy: number;
+  }): Promise<boolean> {
+    if (this.deviceType === MeshCoreDeviceType.REPEATER) {
+      logger.warn('[MeshCore] set_other_params not supported on repeater');
+      return false;
+    }
+    try {
+      const response = await this.sendBridgeCommand('set_other_params', params);
+      return response.success;
+    } catch (error) {
+      logger.error('[MeshCore] Failed to set other params:', error);
+      return false;
+    }
+  }
+
   // ============ Mesh-op throttle primitive ============
 
   /**

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -54,6 +54,7 @@ class MockConnection extends EventEmitter {
   public setTelemetryModeBaseCalls: number[] = [];
   public setTelemetryModeLocCalls: number[] = [];
   public setTelemetryModeEnvCalls: number[] = [];
+  public setOtherParamsCalls: Array<Record<string, number>> = [];
   public statsRequests: number[] = [];
   public binaryRequests: Array<{ key: Uint8Array; req: number[] }> = [];
   public syncNextMessageQueue: any[] = [];
@@ -143,6 +144,10 @@ class MockConnection extends EventEmitter {
 
   async setAdvertLocPolicy(policy: number) {
     this.setAdvertLocPolicyCalls.push(policy);
+  }
+
+  async setOtherParams(opts: Record<string, number>) {
+    this.setOtherParamsCalls.push(opts);
   }
 
   async setTelemetryModeBase(mode: number) {
@@ -706,6 +711,28 @@ describe('MeshCoreNativeBackend', () => {
     const envResp = await backend.sendCommand('set_telemetry_mode_env', { mode: 'never' });
     expect(envResp.success).toBe(true);
     expect(conn.setTelemetryModeEnvCalls).toEqual([0]);
+  });
+
+  it('set_other_params forwards all fields atomically in one SetOtherParams frame (#3904)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    // Raw 2-bit telemetry values pass straight through (no string conversion).
+    const resp = await backend.sendCommand('set_other_params', {
+      manualAddContacts: 1,
+      telemetryModeBase: 2,
+      telemetryModeLoc: 1,
+      telemetryModeEnv: 0,
+      advLocPolicy: 1,
+    });
+    expect(resp.success).toBe(true);
+    expect(conn.setOtherParamsCalls).toEqual([
+      { manualAddContacts: 1, telemetryModeBase: 2, telemetryModeLoc: 1, telemetryModeEnv: 0, advLocPolicy: 1 },
+    ]);
   });
 
   // Regression: issue #3352 — MeshCore's wire protocol expects fixed-point

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1558,6 +1558,32 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true };
       }
 
+      case 'set_other_params': {
+        // Atomic multi-field SetOtherParams (issue #3904). telemetryMode* accept
+        // the raw 2-bit values (numeric pass-through) as well as strings.
+        const manualAddContacts = Number(params.manualAddContacts) ? 1 : 0;
+        const telemetryModeBase = telemetryModeStringToNumber(params.telemetryModeBase ?? 0);
+        const telemetryModeLoc = telemetryModeStringToNumber(params.telemetryModeLoc ?? 0);
+        const telemetryModeEnv = telemetryModeStringToNumber(params.telemetryModeEnv ?? 0);
+        const advLocPolicy = Number(params.advLocPolicy ?? 0) & 0xff;
+        await c.setOtherParams({
+          manualAddContacts,
+          telemetryModeBase,
+          telemetryModeLoc,
+          telemetryModeEnv,
+          advLocPolicy,
+        });
+        if (this.cachedSelfInfo) {
+          const s = this.cachedSelfInfo as any;
+          s.manualAddContacts = manualAddContacts;
+          s.telemetryModeBase = telemetryModeBase;
+          s.telemetryModeLoc = telemetryModeLoc;
+          s.telemetryModeEnv = telemetryModeEnv;
+          s.advLocPolicy = advLocPolicy;
+        }
+        return { ok: true };
+      }
+
       case 'get_stats': {
         const type = String(params.type ?? 'core');
         const typeCode =

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -66,6 +66,7 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   setTxPowerMock = vi.fn().mockResolvedValue(true);
   setCoordsMock = vi.fn().mockResolvedValue(true);
   setChannelMock = vi.fn().mockResolvedValue(undefined);
+  setOtherParamsMock = vi.fn().mockResolvedValue(true);
   isConnected() { return this.localNode !== null; }
   getLocalNode() { return this.localNode; }
   getContacts() { return this.contacts; }
@@ -83,6 +84,15 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   setCoords(lat: number, lon: number) { return this.setCoordsMock(lat, lon) as Promise<boolean>; }
   setChannel(idx: number, name: string, secretHex: string, scope?: string | null) {
     return this.setChannelMock(idx, name, secretHex, scope) as Promise<void>;
+  }
+  setOtherParams(params: {
+    manualAddContacts: number;
+    telemetryModeBase: number;
+    telemetryModeLoc: number;
+    telemetryModeEnv: number;
+    advLocPolicy: number;
+  }) {
+    return this.setOtherParamsMock(params) as Promise<boolean>;
   }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
@@ -467,6 +477,10 @@ function setChannelFrame(idx: number, name: string, secret: Buffer): number[] {
   return toNums(b);
 }
 const nameFrame = (name: string): number[] => [CommandCodes.SetAdvertName, ...Buffer.from(name, 'utf8')];
+function otherParamsFrame(manualAdd: number, base: number, loc: number, env: number, advLoc: number): number[] {
+  const packed = (base & 0b11) | ((loc & 0b11) << 2) | ((env & 0b11) << 4);
+  return [CommandCodes.SetOtherParams, manualAdd, packed, advLoc];
+}
 
 describe('MeshCoreVirtualNodeServer — config-command forwarding (#3904)', () => {
   let server: MeshCoreVirtualNodeServer;
@@ -526,6 +540,19 @@ describe('MeshCoreVirtualNodeServer — config-command forwarding (#3904)', () =
     const res = await client.request(setChannelFrame(1, 'gauntlet', secret));
     expect(res[0]).toBe(ResponseCodes.Ok);
     expect(manager.setChannelMock).toHaveBeenCalledWith(1, 'gauntlet', '000102030405060708090a0b0c0d0e0f', undefined);
+  });
+
+  it('forwards SetOtherParams (unpacked telemetry modes) and replies Ok', async () => {
+    await startWith(true);
+    const res = await client.request(otherParamsFrame(1, 2, 1, 2, 1));
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    expect(manager.setOtherParamsMock).toHaveBeenCalledWith({
+      manualAddContacts: 1,
+      telemetryModeBase: 2,
+      telemetryModeLoc: 1,
+      telemetryModeEnv: 2,
+      advLocPolicy: 1,
+    });
   });
 
   it('blocks config commands with Err(UnsupportedCmd) when allowAdminCommands is off, without touching the node', async () => {

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -37,6 +37,7 @@ import {
   parseSetTxPower,
   parseSetAdvertLatLon,
   parseSetChannel,
+  parseSetOtherParams,
   type ParsedCommand,
 } from './meshcoreCompanionCodec.js';
 
@@ -71,6 +72,13 @@ export interface MeshCoreVirtualNodeManager {
   setTxPower(power: number): Promise<boolean>;
   setCoords(lat: number, lon: number): Promise<boolean>;
   setChannel(idx: number, name: string, secretHex: string, scope?: string | null): Promise<void>;
+  setOtherParams(params: {
+    manualAddContacts: number;
+    telemetryModeBase: number;
+    telemetryModeLoc: number;
+    telemetryModeEnv: number;
+    advLocPolicy: number;
+  }): Promise<boolean>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -406,6 +414,11 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
             // user set in MeshMonitor is left untouched (see MESHCORE scope trap).
             return this.options.manager.setChannel(idx, name, secretHex);
           });
+          break;
+        case CommandCodes.SetOtherParams:
+          void this.handleConfigCommand(clientId, command, () =>
+            this.options.manager.setOtherParams(parseSetOtherParams(command.payload)),
+          );
           break;
         default:
           logger.debug(`[MeshCore VN ${this.sourceId}] unsupported command ${command.code} from ${clientId}`);


### PR DESCRIPTION
## Summary

Completes the MeshCore Virtual Node config-forwarding set from #3904 by handling the one command deferred out of #3906: **`SetOtherParams` (38)** — manual-add-contacts, the three 2-bit telemetry-visibility sections, and advert location policy. It now forwards to the physical node (gated on `allowAdminCommands`) instead of falling through to `Err(UnsupportedCmd)`.

## Why a dedicated atomic path

`SetOtherParams` bundles five fields. Fanning it out across the manager's existing piecemeal setters was rejected because:
- each `setTelemetryMode*` / `setAdvertLocPolicy` is a **separate read-modify-write frame** (non-atomic — 4 round-trips for one app command), and
- there's **no manager method for `manualAddContacts`** at all.

Instead it gets one path, one frame, one ack:

```
parseSetOtherParams → MeshCoreManager.setOtherParams({…})
  → native-backend `set_other_params` → meshcore.js connection.setOtherParams(opts)
```

## Correctness detail — telemetry modes stay integers

Telemetry modes travel as **raw 2-bit ints end to end**. The backend's `telemetryModeStringToNumber` already has numeric pass-through, so no lossy int↔string conversion is needed — which matters because the two vocabularies **disagree**: meshcore.js `TelemetryMode.AlwaysOn = 1` vs MeshMonitor's `'always' → 2`. Forwarding ints sidesteps the ambiguity entirely.

## Changes by layer

- **codec** — `parseSetOtherParams` + `unpackTelemetryMode` (inverse of the existing `packTelemetryMode`).
- **VN** — interface method, `SetOtherParams` dispatch case (through the shared `handleConfigCommand` gate/error path from #3906).
- **manager** — `setOtherParams({…})` (companion-only; repeater returns false).
- **native backend** — `set_other_params` command → `connection.setOtherParams`, updating `cachedSelfInfo`.

## Test plan

- [x] codec: `parseSetOtherParams` round-tripped against meshcore.js's own `sendCommandSetOtherParams` builder; `unpackTelemetryMode`↔`packTelemetryMode`; short-payload throw.
- [x] native backend: `set_other_params` forwards all fields atomically in one `setOtherParams` call.
- [x] VN dispatch: forward→`Ok` with correctly-unpacked fields; gate-off→`Err(UnsupportedCmd)`; reject/throw→`Err(BadState)`; malformed→`Err(IllegalArg)` (shared path, already covered per-command).
- [x] Full suite: `npx vitest run` — **7911 passed, 0 failed**.
- [x] `tsc -p tsconfig.server.json` — no new errors.
- [x] eslint — 0 new errors (1 new `as any` warning matching the surrounding `cachedSelfInfo` convention).

With this, **all config commands the issue named are forwarded**; only destructive/identity/contact commands and repeater sources remain deliberately out of scope (see `docs/internal/dev-notes/MESHCORE_VN_ADMIN_FORWARDING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n