### PR TITLE
fix(meshcore): stop static contact position from clobbering telemetry GNSS fixes

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 110 migrations registered', () => {
-    expect(registry.count()).toBe(110);
+  it('has all 111 migrations registered', () => {
+    expect(registry.count()).toBe(111);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_meshcore_position_history', () => {
+  it('last migration is meshcore_node_position_source', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(110);
-    expect(last.name).toContain('add_meshcore_position_history');
+    expect(last.number).toBe(111);
+    expect(last.name).toContain('meshcore_node_position_source');
   });
 
-  it('migrations are sequentially numbered from 1 to 110', () => {
+  it('migrations are sequentially numbered from 1 to 111', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -125,6 +125,7 @@ import { migration as clearNullIslandMigration, runMigration107Postgres as runCl
 import { migration as meshcoreSavedRegionsMigration, runMigration108Postgres as runMeshcoreSavedRegionsPostgres, runMigration108Mysql as runMeshcoreSavedRegionsMysql } from '../server/migrations/108_meshcore_saved_regions.js';
 import { migration as clampFutureTracerouteMigration, runMigration109Postgres as runClampFutureTraceroutePostgres, runMigration109Mysql as runClampFutureTracerouteMysql } from '../server/migrations/109_clamp_future_traceroute_timestamps.js';
 import { migration as meshcorePositionHistoryMigration, runMigration110Postgres as runMeshcorePositionHistoryPostgres, runMigration110Mysql as runMeshcorePositionHistoryMysql } from '../server/migrations/110_add_meshcore_position_history.js';
+import { migration as meshcoreNodePositionSourceMigration, runMigration111Postgres as runMeshcoreNodePositionSourcePostgres, runMigration111Mysql as runMeshcoreNodePositionSourceMysql } from '../server/migrations/111_meshcore_node_position_source.js';
 
 // ============================================================================
 // Registry
@@ -1747,4 +1748,20 @@ registry.register({
   sqlite: (db) => meshcorePositionHistoryMigration.up(db),
   postgres: (client) => runMeshcorePositionHistoryPostgres(client),
   mysql: (pool) => runMeshcorePositionHistoryMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 111: `positionSource` marker on `meshcore_nodes` (#3908)
+// Lets upsertNode distinguish a telemetry-derived GNSS fix from the static
+// contact/advert position so the latter never clobbers an established
+// telemetry fix (or the position-history trail it feeds).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 111,
+  name: 'meshcore_node_position_source',
+  settingsKey: 'migration_111_meshcore_node_position_source',
+  sqlite: (db) => meshcoreNodePositionSourceMigration.up(db),
+  postgres: (client) => runMeshcoreNodePositionSourcePostgres(client),
+  mysql: (pool) => runMeshcoreNodePositionSourceMysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -157,6 +157,29 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.positionSource).toBe('contact');
   });
 
+  it('upsertNode does not let an altitude-only contact write clobber a telemetry-sourced altitude (#3908)', async () => {
+    // Telemetry poll records a fix including altitude.
+    await repo.upsertNode(
+      { publicKey: 'pk-1', latitude: 10, longitude: 20, altitude: 100, positionSource: 'telemetry' },
+      'src-a',
+    );
+    // A later write carries only altitude (no lat/lon) and isn't tagged
+    // 'telemetry' — this must not overwrite the telemetry-sourced altitude,
+    // matching the precedence rule applied to lat/lon.
+    await repo.upsertNode(
+      { publicKey: 'pk-1', altitude: 5 },
+      'src-a',
+    );
+
+    const row = db.prepare(
+      `SELECT latitude, longitude, altitude, positionSource FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    ).get() as { latitude: number; longitude: number; altitude: number; positionSource: string };
+    expect(row.latitude).toBeCloseTo(10);
+    expect(row.longitude).toBeCloseTo(20);
+    expect(row.altitude).toBeCloseTo(100);
+    expect(row.positionSource).toBe('telemetry');
+  });
+
   it('upsertNode writes a falsy-but-valid value like batteryMv: 0 (not skipped as "absent")', async () => {
     // Guards the merge guard's `!== null && !== undefined` test against a
     // future change to a truthiness check (`!v`), which would wrongly drop 0.

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -99,6 +99,64 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.advType).toBe(1); // a provided value still updates
   });
 
+  it('upsertNode does not let a static contact position clobber an established telemetry fix (#3908)', async () => {
+    // Telemetry poll records the node's true GNSS fix first.
+    await repo.upsertNode(
+      { publicKey: 'pk-1', latitude: 10, longitude: 20, positionSource: 'telemetry' },
+      'src-a',
+    );
+    // A later contact advert re-asserts the static/advert-cached position —
+    // this must NOT overwrite the telemetry fix, and must not log a spurious
+    // position-history point for it.
+    await repo.upsertNode(
+      { publicKey: 'pk-1', latitude: 45, longitude: 90, positionSource: 'contact' },
+      'src-a',
+    );
+
+    const row = db.prepare(
+      `SELECT latitude, longitude, positionSource FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    ).get() as { latitude: number; longitude: number; positionSource: string };
+    expect(row.latitude).toBeCloseTo(10);
+    expect(row.longitude).toBeCloseTo(20);
+    expect(row.positionSource).toBe('telemetry');
+
+    const history = db.prepare(
+      `SELECT COUNT(*) AS n FROM meshcore_position_history WHERE publicKey = 'pk-1'`,
+    ).get() as { n: number };
+    expect(history.n).toBe(1); // only the telemetry fix, not the clobbering contact write
+  });
+
+  it('upsertNode lets a fresh telemetry fix replace an established one (#3908)', async () => {
+    await repo.upsertNode(
+      { publicKey: 'pk-1', latitude: 10, longitude: 20, positionSource: 'telemetry' },
+      'src-a',
+    );
+    await repo.upsertNode(
+      { publicKey: 'pk-1', latitude: 11, longitude: 21, positionSource: 'telemetry' },
+      'src-a',
+    );
+
+    const row = db.prepare(
+      `SELECT latitude, longitude FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    ).get() as { latitude: number; longitude: number };
+    expect(row.latitude).toBeCloseTo(11);
+    expect(row.longitude).toBeCloseTo(21);
+  });
+
+  it('upsertNode still applies the contact position as a fallback when no telemetry fix exists yet (#3908)', async () => {
+    await repo.upsertNode(
+      { publicKey: 'pk-1', latitude: 45, longitude: 90, positionSource: 'contact' },
+      'src-a',
+    );
+
+    const row = db.prepare(
+      `SELECT latitude, longitude, positionSource FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    ).get() as { latitude: number; longitude: number; positionSource: string };
+    expect(row.latitude).toBeCloseTo(45);
+    expect(row.longitude).toBeCloseTo(90);
+    expect(row.positionSource).toBe('contact');
+  });
+
   it('upsertNode writes a falsy-but-valid value like batteryMv: 0 (not skipped as "absent")', async () => {
     // Guards the merge guard's `!== null && !== undefined` test against a
     // future change to a truthiness check (`!v`), which would wrongly drop 0.
@@ -154,6 +212,7 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         lastRoomSyncAt INTEGER,
         lastRoomPostAt INTEGER,
         roomCredential TEXT,
+        positionSource TEXT,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL,
         PRIMARY KEY (publicKey, sourceId)
@@ -400,6 +459,7 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         lastRoomSyncAt INTEGER,
         lastRoomPostAt INTEGER,
         roomCredential TEXT,
+        positionSource TEXT,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL,
         PRIMARY KEY (publicKey, sourceId)
@@ -525,6 +585,7 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         lastRoomSyncAt INTEGER,
         lastRoomPostAt INTEGER,
         roomCredential TEXT,
+        positionSource TEXT,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL,
         PRIMARY KEY (sourceId, publicKey)
@@ -594,6 +655,7 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         lastRoomSyncAt INTEGER,
         lastRoomPostAt INTEGER,
         roomCredential TEXT,
+        positionSource TEXT,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL,
         PRIMARY KEY (sourceId, publicKey)

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -323,7 +323,7 @@ export class MeshCoreRepository extends BaseRepository {
     if (
       existing?.positionSource === 'telemetry' &&
       node.positionSource !== 'telemetry' &&
-      (node.latitude !== undefined || node.longitude !== undefined)
+      (node.latitude !== undefined || node.longitude !== undefined || node.altitude !== undefined)
     ) {
       const { latitude: _lat, longitude: _lon, altitude: _alt, positionSource: _src, ...rest } = node;
       effectiveNode = rest as typeof node;

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -32,6 +32,14 @@ export interface DbMeshCoreNode {
   latitude?: number | null;
   longitude?: number | null;
   altitude?: number | null;
+  /**
+   * Which ingest path last wrote latitude/longitude — 'contact' (static
+   * advert-cached position) or 'telemetry' (Cayenne-LPP GNSS fix). Lets
+   * `upsertNode` give an established telemetry fix precedence over the
+   * static contact position (migration 111, issue #3908). NULL/undefined
+   * means unknown (pre-migration row, or a caller not touching position).
+   */
+  positionSource?: 'contact' | 'telemetry' | null;
   batteryMv?: number | null;
   uptimeSecs?: number | null;
   rssi?: number | null;
@@ -304,6 +312,23 @@ export class MeshCoreRepository extends BaseRepository {
     const { meshcoreNodes } = this.tables;
     const existing = await this.getNodeByPublicKeyAndSource(node.publicKey, sourceId);
 
+    // A telemetry-derived GNSS fix (Cayenne-LPP poll) always wins over the
+    // static contact/advert position once one has been recorded — otherwise
+    // the far more frequent advert-driven writes (persistContact fires on
+    // every contact event, not just position changes) repeatedly clobber it
+    // (#3908). Drop the incoming latitude/longitude/altitude/positionSource
+    // so the merge below preserves the stored telemetry fix untouched; only
+    // an incoming write explicitly tagged 'telemetry' may replace it.
+    let effectiveNode = node;
+    if (
+      existing?.positionSource === 'telemetry' &&
+      node.positionSource !== 'telemetry' &&
+      (node.latitude !== undefined || node.longitude !== undefined)
+    ) {
+      const { latitude: _lat, longitude: _lon, altitude: _alt, positionSource: _src, ...rest } = node;
+      effectiveNode = rest as typeof node;
+    }
+
     // Record a position-history point whenever this update carries a valid GPS
     // fix that differs from the stored position (or is this node's first fix).
     // This is the single choke point both ingest paths pass through — contact
@@ -311,7 +336,7 @@ export class MeshCoreRepository extends BaseRepository {
     // movement trail (#3852) captures every distinct fix without each call
     // site having to remember to log it. Stationary re-reports (identical
     // lat/lon) are deduped here so the trail doesn't accumulate noise.
-    await this.recordPositionHistoryIfMoved(node, existing ?? null, sourceId, now);
+    await this.recordPositionHistoryIfMoved(effectiveNode, existing ?? null, sourceId, now);
 
     if (existing) {
       // Merge, don't clobber (#3504). Callers (persistContact, the telemetry
@@ -326,7 +351,7 @@ export class MeshCoreRepository extends BaseRepository {
       // there means the route was reset (CMD_RESET_PATH), not "unobserved"
       // (see CLEARABLE_VIA_NULL at module scope).
       const updateSet: Record<string, unknown> = { sourceId, updatedAt: now };
-      for (const [k, v] of Object.entries(node)) {
+      for (const [k, v] of Object.entries(effectiveNode)) {
         if (v !== null && v !== undefined) {
           updateSet[k] = v;
         } else if (v === null && CLEARABLE_VIA_NULL.has(k)) {

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -39,6 +39,11 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   latitude: real('latitude'),
   longitude: real('longitude'),
   altitude: real('altitude'),
+  // Which ingest path last wrote latitude/longitude: 'contact' (static/advert
+  // position) or 'telemetry' (Cayenne-LPP GNSS fix). Lets upsertNode give a
+  // telemetry fix precedence over the static contact position once
+  // established (migration 111, issue #3908). NULL means unknown/pre-migration.
+  positionSource: text('positionSource'),
 
   // Telemetry
   batteryMv: integer('batteryMv'),   // Battery voltage in millivolts
@@ -116,6 +121,7 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
   latitude: pgDoublePrecision('latitude'),
   longitude: pgDoublePrecision('longitude'),
   altitude: pgDoublePrecision('altitude'),
+  positionSource: pgText('positionSource'),
 
   batteryMv: pgInteger('batteryMv'),
   uptimeSecs: pgBigint('uptimeSecs', { mode: 'number' }),
@@ -171,6 +177,7 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
   latitude: myDouble('latitude'),
   longitude: myDouble('longitude'),
   altitude: myDouble('altitude'),
+  positionSource: myVarchar('positionSource', { length: 16 }),
 
   batteryMv: myInt('batteryMv'),
   uptimeSecs: myBigint('uptimeSecs', { mode: 'number' }),

--- a/src/server/meshcoreManager.contactPersistence.test.ts
+++ b/src/server/meshcoreManager.contactPersistence.test.ts
@@ -99,6 +99,52 @@ describe('MeshCoreManager contact persistence (issue #3092)', () => {
     );
   });
 
+  it('tags a real position as contact-sourced so it never clobbers a telemetry fix (issue #3908)', async () => {
+    const manager = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+        latitude: 51.5,
+        longitude: -0.1,
+        last_advert: 1_700_000_000,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ positionSource: 'contact' }),
+      'src-a',
+    );
+  });
+
+  it('omits positionSource for a Null Island (0,0) contact — no real position to tag (issue #3908)', async () => {
+    const manager = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+        latitude: 0,
+        longitude: 0,
+        last_advert: 1_700_000_000,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ positionSource: undefined }),
+      'src-a',
+    );
+  });
+
   it('stores null lat/lon for a Null Island (0,0) contact (issue #3763)', async () => {
     const manager = new MeshCoreManager('src-a');
     dispatchBridgeEvent(manager, {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1660,6 +1660,9 @@ class MeshCoreManager extends EventEmitter {
       // Drop "Null Island" (0,0) fixes — the GPS default before a lock — so a
       // bogus position never lands in the node row (issue #3763).
       const atNullIsland = isNullIsland(contact.latitude, contact.longitude);
+      const hasContactPosition = !atNullIsland
+        && typeof contact.latitude === 'number'
+        && typeof contact.longitude === 'number';
       await databaseService.meshcore.upsertNode(
         {
           publicKey: contact.publicKey,
@@ -1669,6 +1672,11 @@ class MeshCoreManager extends EventEmitter {
           advType: contact.advType ?? null,
           latitude: atNullIsland ? null : (contact.latitude ?? null),
           longitude: atNullIsland ? null : (contact.longitude ?? null),
+          // Tag this as the static/advert-cached position (#3908) so
+          // upsertNode won't let it clobber an established telemetry GNSS
+          // fix. Only tagged when we're actually writing a real coordinate —
+          // otherwise omitted so the merge preserves whatever is stored.
+          positionSource: hasContactPosition ? 'contact' : undefined,
           rssi: contact.rssi ?? null,
           snr: contact.snr ?? null,
           lastHeard: contact.lastSeen ?? null,

--- a/src/server/migrations/111_meshcore_node_position_source.ts
+++ b/src/server/migrations/111_meshcore_node_position_source.ts
@@ -1,0 +1,85 @@
+/**
+ * Migration 111: `positionSource` marker on `meshcore_nodes` (#3908).
+ *
+ * Adds a single nullable text column:
+ *
+ *   positionSource  TEXT  ('contact' | 'telemetry' | NULL)
+ *
+ * `meshcore_nodes.latitude/longitude` is written by two independent paths
+ * that previously shared the columns with no precedence rule: contact
+ * adverts (the static position cached on the in-memory contact record) and
+ * the Cayenne-LPP remote-telemetry poll (the node's actual live GNSS fix).
+ * Because advert-driven writes (`persistContact`) fire far more often than
+ * the telemetry poll, they repeatedly clobbered a telemetry-derived fix with
+ * the static one, corrupting both the node's current position and the
+ * `meshcore_position_history` trail.
+ *
+ * This column lets `MeshCoreRepository.upsertNode` tell the two apart and
+ * give telemetry-sourced fixes precedence once established, falling back to
+ * the static contact position only when no telemetry fix has ever been
+ * recorded for that node.
+ *
+ * Backfill is unnecessary — existing rows default to NULL (unknown source),
+ * which behaves like the pre-migration fallback path.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 111';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding positionSource column to meshcore_nodes...`);
+    try {
+      db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN positionSource TEXT`);
+      logger.debug(`${LABEL} (SQLite): added meshcore_nodes.positionSource`);
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug(`${LABEL} (SQLite): meshcore_nodes.positionSource already exists, skipping`);
+      } else {
+        logger.error(`${LABEL} (SQLite): could not add meshcore_nodes.positionSource:`, e.message);
+        throw e;
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration111Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding positionSource column to meshcore_nodes...`);
+  await client.query(
+    `ALTER TABLE meshcore_nodes ADD COLUMN IF NOT EXISTS "positionSource" TEXT`,
+  );
+  logger.debug(`${LABEL} (PostgreSQL): ensured meshcore_nodes.positionSource`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration111Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding positionSource column to meshcore_nodes...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_nodes' AND COLUMN_NAME = 'positionSource'`,
+    );
+    if (!Array.isArray(rows) || rows.length === 0) {
+      await conn.query(`ALTER TABLE meshcore_nodes ADD COLUMN positionSource VARCHAR(16)`);
+      logger.debug(`${LABEL} (MySQL): added meshcore_nodes.positionSource`);
+    } else {
+      logger.debug(`${LABEL} (MySQL): meshcore_nodes.positionSource already exists, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -1337,6 +1337,46 @@ describe('MeshCore Routes', () => {
       expect(upsertOrder).toBeLessThan(setCfgOrder);
     });
 
+    it('tags a real backfilled position as contact-sourced (issue #3908)', async () => {
+      meshcoreManager.getContact.mockReturnValueOnce({
+        publicKey: REPEATER_PUBKEY,
+        advName: 'MyRepeater',
+        advType: 2,
+        latitude: 51.0,
+        longitude: 0.5,
+        lastSeen: 1_700_000_000_000,
+      });
+
+      await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${REPEATER_PUBKEY}/telemetry-config`)
+        .send({ enabled: true });
+
+      expect(upsertNode).toHaveBeenCalledWith(
+        expect.objectContaining({ positionSource: 'contact' }),
+        'test-source',
+      );
+    });
+
+    it('does not tag a Null Island (0,0) backfilled position as contact-sourced (issue #3908)', async () => {
+      meshcoreManager.getContact.mockReturnValueOnce({
+        publicKey: REPEATER_PUBKEY,
+        advName: 'MyRepeater',
+        advType: 2,
+        latitude: 0,
+        longitude: 0,
+        lastSeen: 1_700_000_000_000,
+      });
+
+      await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${REPEATER_PUBKEY}/telemetry-config`)
+        .send({ enabled: true });
+
+      expect(upsertNode).toHaveBeenCalledWith(
+        expect.objectContaining({ positionSource: undefined }),
+        'test-source',
+      );
+    });
+
     it('skips the backfill upsert when the contact is not yet in memory', async () => {
       // User enables telemetry-retrieval on a publicKey we haven't
       // received an advert for yet. The route must still create the

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2734,6 +2734,11 @@ router.patch(
               advType: contact.advType ?? null,
               latitude: contact.latitude ?? null,
               longitude: contact.longitude ?? null,
+              // Tag as the static/advert-cached position (#3908) so it never
+              // clobbers an established telemetry GNSS fix — mirrors persistContact.
+              positionSource: (typeof contact.latitude === 'number' && typeof contact.longitude === 'number')
+                ? 'contact'
+                : undefined,
               lastHeard: contact.lastSeen ?? null,
             },
             sourceId,
@@ -2808,6 +2813,11 @@ router.post(
               advType: contact.advType ?? null,
               latitude: contact.latitude ?? null,
               longitude: contact.longitude ?? null,
+              // Tag as the static/advert-cached position (#3908) so it never
+              // clobbers an established telemetry GNSS fix — mirrors persistContact.
+              positionSource: (typeof contact.latitude === 'number' && typeof contact.longitude === 'number')
+                ? 'contact'
+                : undefined,
               lastHeard: contact.lastSeen ?? null,
             },
             sourceId,

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -26,6 +26,7 @@ import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.
 import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
 import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
 import { resolveAutoAckPreSendDelaySeconds } from '../autoAckDelay.js';
+import { isNullIsland } from '../../utils/nullIsland.js';
 
 /**
  * Resolve the manager for a request. Mounted only under
@@ -2735,8 +2736,12 @@ router.patch(
               latitude: contact.latitude ?? null,
               longitude: contact.longitude ?? null,
               // Tag as the static/advert-cached position (#3908) so it never
-              // clobbers an established telemetry GNSS fix — mirrors persistContact.
-              positionSource: (typeof contact.latitude === 'number' && typeof contact.longitude === 'number')
+              // clobbers an established telemetry GNSS fix — mirrors persistContact,
+              // including the Null Island (0,0) guard so an uninitialized GPS
+              // default is never tagged as a real 'contact' position.
+              positionSource: (typeof contact.latitude === 'number'
+                && typeof contact.longitude === 'number'
+                && !isNullIsland(contact.latitude, contact.longitude))
                 ? 'contact'
                 : undefined,
               lastHeard: contact.lastSeen ?? null,
@@ -2814,8 +2819,12 @@ router.post(
               latitude: contact.latitude ?? null,
               longitude: contact.longitude ?? null,
               // Tag as the static/advert-cached position (#3908) so it never
-              // clobbers an established telemetry GNSS fix — mirrors persistContact.
-              positionSource: (typeof contact.latitude === 'number' && typeof contact.longitude === 'number')
+              // clobbers an established telemetry GNSS fix — mirrors persistContact,
+              // including the Null Island (0,0) guard so an uninitialized GPS
+              // default is never tagged as a real 'contact' position.
+              positionSource: (typeof contact.latitude === 'number'
+                && typeof contact.longitude === 'number'
+                && !isNullIsland(contact.latitude, contact.longitude))
                 ? 'contact'
                 : undefined,
               lastHeard: contact.lastSeen ?? null,

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -605,7 +605,14 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
     });
     await scheduler.tickOneManager(manager);
     expect(upsertNode).toHaveBeenCalledWith(
-      expect.objectContaining({ publicKey: 'companion-b', latitude: 48.8566, longitude: 2.3522 }),
+      expect.objectContaining({
+        publicKey: 'companion-b',
+        latitude: 48.8566,
+        longitude: 2.3522,
+        // Tagged telemetry-sourced (#3908) so this fix takes precedence over
+        // the static contact/advert position on subsequent writes.
+        positionSource: 'telemetry',
+      }),
       'src-a',
     );
   });

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -509,7 +509,15 @@ export class MeshCoreRemoteTelemetryScheduler {
           if (lat !== null && lon !== null && !isNullIsland(lat, lon)) {
             try {
               await this.database.meshcore.upsertNode(
-                { publicKey: target.publicKey, latitude: lat, longitude: lon },
+                {
+                  publicKey: target.publicKey,
+                  latitude: lat,
+                  longitude: lon,
+                  // Tag as telemetry-sourced (#3908) so this GNSS fix takes
+                  // precedence over the static contact/advert position on
+                  // subsequent writes, instead of being clobbered by it.
+                  positionSource: 'telemetry',
+                },
                 manager.sourceId,
               );
             } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #3908 — MeshCore contact location history used the static contact/advert position instead of the GNSS fix received via telemetry.

`meshcore_nodes.latitude`/`longitude` (and by extension the new `meshcore_position_history` trail, #3852) was written by two independent ingest paths sharing the same columns with no precedence rule:

1. `meshcoreManager.ts` → `persistContact()` — re-asserts the **static/advert-cached** contact position on nearly every contact event (advert, path update, owner-name fetch, bulk `refreshContacts()`), regardless of whether GPS telemetry has ever been received.
2. `meshcoreRemoteTelemetryScheduler.ts` → the Cayenne-LPP telemetry poll (type 136 / GPS) — decodes the node's true GNSS fix on its poll interval.

Because `persistContact()` fires far more frequently, it repeatedly overwrote the telemetry-derived position with the static one, and `recordPositionHistoryIfMoved()` faithfully (but incorrectly) logged each such overwrite as a new movement-trail point — producing the flat/incorrect track described in the issue.

### Fix

- **Migration 111** adds a nullable `positionSource` (`'contact' | 'telemetry'`) column to `meshcore_nodes`.
- `meshcoreRemoteTelemetryScheduler.ts` now tags its GPS-derived writes `positionSource: 'telemetry'`.
- `meshcoreManager.ts` `persistContact()` and the two contact-backfill call sites in `meshcoreRoutes.ts` now tag real static positions `positionSource: 'contact'`.
- `MeshCoreRepository.upsertNode()` (the single choke point both paths pass through) now drops an incoming static/contact position when the stored row already has an established `positionSource: 'telemetry'` fix — the static position is only ever applied as a fallback when no telemetry fix has been recorded yet, per the issue's requested behavior.

### Testing

- Added repository-level tests exercising the precedence rule directly against a real SQLite DB (telemetry fix isn't clobbered by a later contact write; a fresh telemetry fix does replace an older one; contact position still applies as a fallback with no prior telemetry).
- Added/updated unit tests in `meshcoreManager.contactPersistence.test.ts` and `meshcoreRemoteTelemetryScheduler.test.ts` asserting the correct `positionSource` tag is sent on each write path.
- Updated `migrations.test.ts` for the new migration count (111) and latest-migration name.
- Full Vitest suite run: all MeshCore/migration/repository tests green. 9 unrelated pre-existing failures in Meshtastic protobuf-dependent tests are caused by the `protobufs` git submodule not being checked out in this sandbox (`ENOENT: .../protobufs/meshtastic/mesh.proto`), confirmed present on `main` as well — unrelated to this change.

## Test plan

- [x] `npx vitest run src/db/migrations.test.ts src/db/repositories/meshcore.test.ts`
- [x] `npx vitest run src/server/meshcoreManager.contactPersistence.test.ts`
- [x] `npx vitest run src/server/services/meshcoreRemoteTelemetryScheduler.test.ts`
- [x] `npx vitest run src/server/routes/meshcoreRoutes.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on all changed files (no new errors/warnings vs. baseline)

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQTD1kPG25LEU3LSo6SPx9)_