### PR TITLE
fix(meshcore-vn): report real manualAddContacts in SelfInfo (#3904 follow-up)

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -329,6 +329,8 @@ export interface MeshCoreNode {
   latitude?: number;
   longitude?: number;
   advLocPolicy?: number;
+  /** Add contacts only on explicit request (1) vs automatically (0). From SelfInfo. */
+  manualAddContacts?: number;
   /**
    * Server-side favorite flag (migration 094). Stored locally only — never
    * pushed to the device. Favorited nodes pin to the top of the node list.
@@ -2180,6 +2182,7 @@ class MeshCoreManager extends EventEmitter {
             latitude: info.latitude,
             longitude: info.longitude,
             advLocPolicy: info.adv_loc_policy,
+            manualAddContacts: info.manual_add_contacts,
             telemetryModeBase: parseTelemetryMode(info.telemetry_mode_base),
             telemetryModeLoc: parseTelemetryMode(info.telemetry_mode_loc),
             telemetryModeEnv: parseTelemetryMode(info.telemetry_mode_env),

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -87,7 +87,7 @@ class MockConnection extends EventEmitter {
     publicKey: Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     advLat: 40_000_000,
     advLon: -75_000_000,
-    manualAddContacts: 0,
+    manualAddContacts: 1,
     // Wire-format units: freq in kHz, bw in Hz. 915525 kHz == 915.525 MHz, 62500 Hz == 62.5 kHz.
     radioFreq: 915525,
     radioBw: 62500,
@@ -308,6 +308,9 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.data?.radio_bw).toBe(62.5);
     expect(resp.data?.latitude).toBeCloseTo(40, 4);
     expect(resp.data?.longitude).toBeCloseTo(-75, 4);
+    // #3904 follow-up: manual_add_contacts must be surfaced (was dropped),
+    // so the Virtual Node can report the real value in SelfInfo.
+    expect(resp.data?.manual_add_contacts).toBe(1);
 
     await backend.disconnect();
     expect(backend.isConnected()).toBe(false);

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1801,6 +1801,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
       latitude: fixedToDegrees(info.advLat),
       longitude: fixedToDegrees(info.advLon),
       adv_loc_policy: info.advLocPolicy,
+      manual_add_contacts: (info as any).manualAddContacts,
       telemetry_mode_base: (info as any).telemetryModeBase,
       telemetry_mode_loc: (info as any).telemetryModeLoc,
       telemetry_mode_env: (info as any).telemetryModeEnv,

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { Socket } from 'net';
-import { Constants } from '@liamcottle/meshcore.js';
+import { Connection, Constants } from '@liamcottle/meshcore.js';
 import { MeshCoreVirtualNodeServer, type MeshCoreVirtualNodeManager } from './meshcoreVirtualNodeServer.js';
 import {
   CommandCodes,
@@ -32,6 +32,7 @@ const LOCAL_NODE: MeshCoreNode = {
   radioCr: 5,
   latitude: 29.7604,
   longitude: -95.3698,
+  manualAddContacts: 1,
 };
 
 const SAMPLE_CONTACTS: MeshCoreContact[] = [
@@ -197,6 +198,19 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     expect(payload[0]).toBe(ResponseCodes.SelfInfo);
     // name is the remainder of the frame after the fixed SelfInfo fields
     expect(payload.subarray(-LOCAL_NODE.name.length).toString('utf8')).toBe('Phase0 Node');
+  });
+
+  it('reports the real manualAddContacts in SelfInfo instead of hardcoding 0 (#3904 follow-up)', async () => {
+    // LOCAL_NODE.manualAddContacts = 1; decode the SelfInfo via meshcore.js's own
+    // parser and assert the field round-trips rather than being pinned to 0.
+    const payload = await client.request([CommandCodes.AppStart, 1, 0, 0, 0, 0, 0, 0]);
+    expect(payload[0]).toBe(ResponseCodes.SelfInfo);
+    const decoded = await new Promise<any>((resolve) => {
+      const conn: any = new (Connection as any)();
+      conn.once(ResponseCodes.SelfInfo, (event: any) => resolve(event));
+      conn.onFrameReceived(new Uint8Array(payload));
+    });
+    expect(decoded.manualAddContacts).toBe(1);
   });
 
   it('replies to GetDeviceTime with a plausible CurrTime', async () => {

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -751,7 +751,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         this.telemetryModeToWire(node.telemetryModeLoc),
         this.telemetryModeToWire(node.telemetryModeEnv),
       ),
-      manualAddContacts: 0,
+      manualAddContacts: node.manualAddContacts ?? 0,
       radioFreq: mhzToWireFreq(node.radioFreq),
       radioBw: khzToWireBw(node.radioBw),
       radioSf: node.radioSf ?? 0,


### PR DESCRIPTION
## Summary

Follow-up to the #3904 config-forwarding work (surfaced in the #3907 review). `MeshCoreVirtualNodeServer.buildSelfInfo` hardcoded `manualAddContacts: 0`, so the Virtual Node always advertised `0` for that field in `SelfInfo` — even right after a `SetOtherParams` round-trip set it on the physical node, and permanently for a node that already had it enabled. Every other SelfInfo field (`advLocPolicy`, the telemetry modes) reads from the node model; this one didn't have a source.

## Fix — plumb the value end to end (mirrors `advLocPolicy`)

1. **native backend** — `selfInfoToBridgeShape()` now emits `manual_add_contacts` (it was dropped from the bridge shape).
2. **manager** — `MeshCoreNode` gains a `manualAddContacts?` field, populated from `get_self_info` in the companion-info mapping.
3. **VN** — `buildSelfInfo` reads `node.manualAddContacts ?? 0` instead of the literal `0`.

The value was already present on the backend's `cachedSelfInfo` (from the meshcore.js SelfInfo decode, and updated by the `set_other_params` path from #3907) — it just wasn't being surfaced up the chain.

## Test plan

- [x] **backend**: `get_self_info` now surfaces `manual_add_contacts` (mock set to 1, asserted).
- [x] **VN**: the `SelfInfo` reply, decoded via **meshcore.js's own parser**, reports the node's real `manualAddContacts` (1) instead of `0`.
- [x] Full suite: `npx vitest run` — **7915 passed, 0 failed**.
- [x] `tsc -p tsconfig.server.json` — clean.
- [x] eslint — 0 new errors (1 new `(info as any)` warning matching the adjacent telemetry-field casts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n