### PR TITLE
fix: add collapse toggle to Dashboard map Features panel

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DashboardMap from './DashboardMap';
 
 // ---------------------------------------------------------------------------
@@ -194,6 +194,29 @@ const defaultProps = {
 describe('DashboardMap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  // --- Features panel collapse (#3912) ---------------------------------------
+
+  it('shows the Features panel toggles by default', () => {
+    render(<DashboardMap {...defaultProps} />);
+    expect(screen.getByText('Show Traceroute')).toBeInTheDocument();
+  });
+
+  it('hides the Features panel toggles when the collapse button is clicked', () => {
+    render(<DashboardMap {...defaultProps} />);
+    fireEvent.click(screen.getByTitle('Collapse controls'));
+    expect(screen.queryByText('Show Traceroute')).not.toBeInTheDocument();
+    expect(screen.getByText('Features')).toBeInTheDocument();
+  });
+
+  it('restores a collapsed Features panel from localStorage (shared with the NodesTab map)', () => {
+    localStorage.setItem('isMapControlsCollapsed', 'true');
+    render(<DashboardMap {...defaultProps} />);
+    expect(screen.queryByText('Show Traceroute')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTitle('Expand controls'));
+    expect(screen.getByText('Show Traceroute')).toBeInTheDocument();
   });
 
   it('renders the map container', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -232,6 +232,16 @@ export default function DashboardMap({
     localStorage.setItem('meshmonitor-showLegend', String(showLegend));
   }, [showLegend]);
 
+  // Collapse the Features panel — shares the NodesTab map's localStorage key
+  // so the preference is unified across every map surface (issue #3912: on
+  // mobile the panel's full checkbox list has no way to be dismissed).
+  const [isMapControlsCollapsed, setIsMapControlsCollapsed] = useState(
+    () => localStorage.getItem('isMapControlsCollapsed') === 'true',
+  );
+  useEffect(() => {
+    localStorage.setItem('isMapControlsCollapsed', String(isMapControlsCollapsed));
+  }, [isMapControlsCollapsed]);
+
   const {
     showPaths,
     setShowPaths,
@@ -645,9 +655,20 @@ export default function DashboardMap({
 
       {/* Map Features control panel — mirrors NodesTab's "Features" panel but
           trimmed to the toggles meaningful on a cross-source map. */}
-      <div className="map-controls dashboard-map-controls">
+      <div className={`map-controls dashboard-map-controls ${isMapControlsCollapsed ? 'collapsed' : ''}`}>
         <div className="map-controls-body">
-          <div className="map-controls-title">Features</div>
+          <div className="map-controls-header">
+            <div className="map-controls-title">Features</div>
+            <button
+              className="map-controls-collapse-btn"
+              onClick={() => setIsMapControlsCollapsed(!isMapControlsCollapsed)}
+              title={isMapControlsCollapsed ? 'Expand controls' : 'Collapse controls'}
+            >
+              {isMapControlsCollapsed ? '▼' : '▲'}
+            </button>
+          </div>
+          {!isMapControlsCollapsed && (
+          <>
           {/* Map Features age slider (#3322): hides node markers, traceroutes,
               and route segments older than the chosen age. Ranges 1h–maxNodeAge. */}
           {(() => {
@@ -782,6 +803,8 @@ export default function DashboardMap({
               </span>
             </label>
           ))}
+          </>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- The per-source **Nodes** tab's map already has a fold/collapse button on its "Features" control panel (small ▲/▼ toggle in the panel header, persisted to localStorage).
- The **Dashboard** map's equivalent "Features" panel (Show Route Segments, Show Traceroute, Show Neighbors, Show RF/UDP/MQTT, Show Waypoints, Show Tile Selection, Show Legend, GeoJSON layers, etc.) never got the same collapse control — on a phone-sized viewport that full checkbox list can take up roughly half the screen with no way to dismiss it.
- This PR ports the same collapse button/header pattern onto `DashboardMap.tsx`, sharing the `isMapControlsCollapsed` localStorage key with the Nodes tab map so the preference is unified across both map surfaces.

Fixes #3912

## Changes

- `src/components/Dashboard/DashboardMap.tsx`: add `isMapControlsCollapsed` state (localStorage-backed), a `map-controls-header` with a collapse/expand button, and conditionally render the checkbox list only when expanded. Reuses existing `.map-controls.collapsed` CSS already in `nodes.css`, so no style changes were needed.
- `src/components/Dashboard/DashboardMap.test.tsx`: added tests covering default-expanded state, collapsing via the button, and restoring a collapsed state from localStorage.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx eslint src/components/Dashboard/DashboardMap.tsx` — no new errors (pre-existing `any` warnings only)
- [x] `npx vitest run src/components/Dashboard/DashboardMap.test.tsx` — 19/19 passing (3 new)
- [x] Full `vitest run` suite — 7871 passed, 3 failed / 9 suites failed only due to the `protobufs` git submodule not being checked out in this fresh clone (unrelated to this change); confirmed green after `git submodule update --init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M64VfuQ76P389AhqdwG74J)_