### PR TITLE
Improve automation error diagnostics for unusable send targets

### DIFF
--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -51,6 +51,15 @@ describe('createMeshActionDeps sendMessage — unusable source diagnostics (#391
       .rejects.toThrow(/not a Meshtastic or MeshCore manager/);
     expect(getSource).not.toHaveBeenCalled();
   });
+
+  it('falls back to the generic message when the source lookup itself throws', async () => {
+    getManager.mockReturnValue(undefined);
+    getSource.mockRejectedValue(new Error('db unavailable'));
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'db-down-src', text: 'hi', channel: 0 }))
+      .rejects.toThrow('source "db-down-src" cannot send messages');
+  });
 });
 
 describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -6,11 +6,52 @@ vi.mock('../../sourceManagerRegistry.js', () => ({
   sourceManagerRegistry: { getManager: (id: string) => getManager(id) },
 }));
 // The deps module also imports these at load time; stub to harmless objects.
-vi.mock('../../../services/database.js', () => ({ default: {} }));
+const getSource = vi.fn();
+vi.mock('../../../services/database.js', () => ({ default: { sources: { getSource: (id: string) => getSource(id) } } }));
 vi.mock('../appriseNotificationService.js', () => ({ appriseNotificationService: {} }));
 vi.mock('../../utils/scriptRunner.js', () => ({ runScript: vi.fn() }));
 
 import { createMeshActionDeps } from './meshActionDeps.js';
+
+describe('createMeshActionDeps sendMessage — unusable source diagnostics (#3915)', () => {
+  beforeEach(() => { getManager.mockReset(); getSource.mockReset(); });
+
+  it('reports a deleted/recreated source when no manager is registered and the id is unknown', async () => {
+    getManager.mockReturnValue(undefined);
+    getSource.mockResolvedValue(null);
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'gone', text: 'hi', channel: 0 }))
+      .rejects.toThrow(/no longer exists.*re-select the source/);
+  });
+
+  it('reports a disabled source by name when the id still exists but is disabled', async () => {
+    getManager.mockReturnValue(undefined);
+    getSource.mockResolvedValue({ id: 'disabled-src', name: 'Basement Node', enabled: false });
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'disabled-src', text: 'hi', channel: 0 }))
+      .rejects.toThrow(/Basement Node.*is disabled/);
+  });
+
+  it('reports a not-currently-connected source when enabled but no live manager exists', async () => {
+    getManager.mockReturnValue(undefined);
+    getSource.mockResolvedValue({ id: 'flaky-src', name: 'Attic Repeater', enabled: true });
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'flaky-src', text: 'hi', channel: 0 }))
+      .rejects.toThrow(/Attic Repeater.*not currently connected/);
+  });
+
+  it('reports wrong-protocol-for-messaging when a manager is live but lacks send capability (e.g. MQTT)', async () => {
+    getManager.mockReturnValue({}); // live manager, but no sendTextMessage/sendMessage
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'mqtt-src', text: 'hi', channel: 0 }))
+      .rejects.toThrow(/not a Meshtastic or MeshCore manager/);
+    expect(getSource).not.toHaveBeenCalled();
+  });
+});
 
 describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
   beforeEach(() => getManager.mockReset());

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -41,11 +41,37 @@ interface MeshCoreSendManager {
   sendAdvert(): Promise<unknown>;
 }
 
-function mgr(sourceId: string | null): MeshSendManager {
+/**
+ * Build an actionable error for a sourceId with no live, capable manager
+ * registered — distinguishing "never existed / deleted" from "disabled" from
+ * "exists but not currently connected" from "wrong protocol for this action".
+ * A bare "cannot send messages" gave users nothing to act on when their
+ * source list had drifted from a saved automation, e.g. after deleting and
+ * recreating a source under a new id (#3915).
+ */
+async function describeUnusableSource(sourceId: string, raw: unknown, capability: string): Promise<string> {
+  if (raw) {
+    return `source "${sourceId}" cannot ${capability} (not a Meshtastic or MeshCore manager)`;
+  }
+  try {
+    const source = await databaseService.sources.getSource(sourceId);
+    if (!source) {
+      return `source "${sourceId}" no longer exists — it may have been deleted or recreated; re-select the source in this automation`;
+    }
+    if (!source.enabled) {
+      return `source "${source.name}" (${sourceId}) is disabled — enable it in Settings > Sources for this automation to ${capability}`;
+    }
+    return `source "${source.name}" (${sourceId}) is not currently connected — check its status in Settings > Sources`;
+  } catch {
+    return `source "${sourceId}" cannot ${capability}`;
+  }
+}
+
+async function mgr(sourceId: string | null): Promise<MeshSendManager> {
   if (!sourceId) throw new Error('automation action requires a target source');
   const m = sourceManagerRegistry.getManager(sourceId) as unknown as MeshSendManager | undefined;
   if (!m || typeof m.sendTextMessage !== 'function') {
-    throw new Error(`source "${sourceId}" cannot send messages (not a Meshtastic manager)`);
+    throw new Error(await describeUnusableSource(sourceId, m, 'send messages'));
   }
   return m;
 }
@@ -76,7 +102,7 @@ async function sendTextVia(
     // `scopeOverride` (#3833) controls which region the message floods to.
     return raw.sendMessage(text, undefined, channel, scopeOverride);
   }
-  throw new Error(`source "${sourceId}" cannot send messages`);
+  throw new Error(await describeUnusableSource(sourceId, raw, 'send messages'));
 }
 
 export function createMeshActionDeps(): ActionDeps {
@@ -87,11 +113,11 @@ export function createMeshActionDeps(): ActionDeps {
 
     async sendTapback({ sourceId, emoji, channel, destination, replyId }) {
       // emoji flag = 1 marks a tapback/reaction; route the way the trigger arrived.
-      return mgr(sourceId).sendTextMessage(emoji, channel ?? 0, destination, replyId, 1);
+      return (await mgr(sourceId)).sendTextMessage(emoji, channel ?? 0, destination, replyId, 1);
     },
 
     async manageNode({ sourceId, nodeNum, op }) {
-      const m = mgr(sourceId);
+      const m = await mgr(sourceId);
       switch (op) {
         case 'favorite': return m.sendFavoriteNode(nodeNum);
         case 'unfavorite': return m.sendRemoveFavoriteNode(nodeNum);
@@ -140,7 +166,7 @@ export function createMeshActionDeps(): ActionDeps {
           default: throw new Error(`request op "${op}" not supported on MeshCore`);
         }
       }
-      throw new Error(`source "${sourceId}" cannot perform node requests`);
+      throw new Error(await describeUnusableSource(sourceId, raw, 'perform node requests'));
     },
 
     async notify({ sourceId, title, body, type, urls }) {

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -14,6 +14,7 @@ import databaseService from '../../../services/database.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { appriseNotificationService } from '../appriseNotificationService.js';
 import { runScript as runUserScript } from '../../utils/scriptRunner.js';
+import { logger } from '../../../utils/logger.js';
 import type { ActionDeps } from './actionExecutor.js';
 
 interface MeshSendManager {
@@ -59,10 +60,11 @@ async function describeUnusableSource(sourceId: string, raw: unknown, capability
       return `source "${sourceId}" no longer exists — it may have been deleted or recreated; re-select the source in this automation`;
     }
     if (!source.enabled) {
-      return `source "${source.name}" (${sourceId}) is disabled — enable it in Settings > Sources for this automation to ${capability}`;
+      return `source "${source.name}" (${sourceId}) is disabled — enable it in Settings > Sources, then this automation can ${capability}`;
     }
     return `source "${source.name}" (${sourceId}) is not currently connected — check its status in Settings > Sources`;
-  } catch {
+  } catch (err) {
+    logger.debug(`[Automation] describeUnusableSource: lookup failed for source "${sourceId}":`, err);
     return `source "${sourceId}" cannot ${capability}`;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the confusing error reported in #3915: `action.sendMessage` (and its siblings `action.sendTapback`, `action.manageNode`, `action.requestData`) all threw a bare `source "<id>" cannot send messages` whenever `sourceManagerRegistry.getManager(sourceId)` returned nothing — with no way to tell *why*.

- Deleted/recreated source (id no longer exists) — most likely root cause in #3915 given the automation was saved before the referenced source was rebuilt under a new id, which the automation builder's source picker wouldn't surface since it only lists currently-valid sources.
- Disabled source
- Enabled source that just isn't currently connected (e.g. mid-reconnect)
- A live manager that genuinely lacks send capability for this action (e.g. an MQTT source)

`src/server/services/automation/meshActionDeps.ts` now has a shared `describeUnusableSource()` helper that looks up the source row via `databaseService.sources.getSource(sourceId)` to distinguish these cases and names the source when known, e.g.:
- `source "…" no longer exists — it may have been deleted or recreated; re-select the source in this automation`
- `source "My MeshCore Node" (…) is disabled — enable it in Settings > Sources…`
- `source "My MeshCore Node" (…) is not currently connected — check its status in Settings > Sources`

`mgr()` became async (it now awaits the diagnostic lookup on the error path), so its two call sites (`sendTapback`, `manageNode`) were updated to `await` it.

This doesn't auto-fix a stale source reference in a saved automation — that still needs to be re-selected in the builder — but it turns a dead-end error into an actionable one in the run-log.

## Test plan

- [x] `npx vitest run src/server/services/automation` — 208 tests passed, including 4 new cases in `meshActionDeps.test.ts` covering each of the four diagnostic branches
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint` on both changed files — clean

Closes/fixes #3915 (diagnostics improvement; user's underlying automation config still needs the source re-selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go5TXe3BqojpemXFwyx1RB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Go5TXe3BqojpemXFwyx1RB)_