### PR TITLE
fix(automation): send/request actions can't reach MeshCore sources (#3915)

### DIFF
--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock the registry so we can inject fake Meshtastic / MeshCore managers.
+// Mock both registries so we can inject fake Meshtastic / MeshCore managers.
+// Meshtastic managers live in sourceManagerRegistry; MeshCore managers live in
+// the separate meshcoreManagerRegistry (#3915) — the deps must consult both.
 const getManager = vi.fn();
+const meshcoreGet = vi.fn();
 vi.mock('../../sourceManagerRegistry.js', () => ({
   sourceManagerRegistry: { getManager: (id: string) => getManager(id) },
+}));
+vi.mock('../../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: { get: (id: string) => meshcoreGet(id) },
 }));
 // The deps module also imports these at load time; stub to harmless objects.
 vi.mock('../../../services/database.js', () => ({ default: {} }));
@@ -13,7 +19,7 @@ vi.mock('../../utils/scriptRunner.js', () => ({ runScript: vi.fn() }));
 import { createMeshActionDeps } from './meshActionDeps.js';
 
 describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
-  beforeEach(() => getManager.mockReset());
+  beforeEach(() => { getManager.mockReset(); meshcoreGet.mockReset(); });
 
   it('forwards scopeOverride to a MeshCore manager (sendMessage signature)', async () => {
     const sendMessage = vi.fn().mockResolvedValue(true);
@@ -48,8 +54,57 @@ describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
   });
 });
 
+// Regression tests for #3915: MeshCore managers are NOT in sourceManagerRegistry
+// (getManager returns undefined for them) — the deps must fall back to
+// meshcoreManagerRegistry, or every MeshCore action fails with "cannot send
+// messages" even for a healthy, connected source.
+describe('createMeshActionDeps — MeshCore source resolved from meshcoreManagerRegistry (#3915)', () => {
+  beforeEach(() => { getManager.mockReset(); meshcoreGet.mockReset(); });
+
+  it('sendMessage reaches a MeshCore manager that is only in meshcoreManagerRegistry', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue(undefined);         // not a Meshtastic source
+    meshcoreGet.mockReturnValue({ sendMessage });  // lives in the MeshCore registry
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mc', text: 'PINGTEST received!', channel: 1, scopeOverride: '' });
+
+    expect(sendMessage).toHaveBeenCalledWith('PINGTEST received!', undefined, 1, '');
+  });
+
+  it('requestData reaches a MeshCore manager that is only in meshcoreManagerRegistry', async () => {
+    const requestRemoteTelemetry = vi.fn().mockResolvedValue({});
+    getManager.mockReturnValue(undefined);
+    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), requestRemoteTelemetry });
+    const deps = createMeshActionDeps();
+
+    await deps.requestData({ sourceId: 'mc', op: 'telemetry', target: 'aabbcc', channel: 0 });
+
+    expect(requestRemoteTelemetry).toHaveBeenCalledWith('aabbcc');
+  });
+
+  it('throws when neither registry has the source', async () => {
+    getManager.mockReturnValue(undefined);
+    meshcoreGet.mockReturnValue(undefined);
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'ghost', text: 'hi', channel: 0 }))
+      .rejects.toThrow(/cannot send messages/);
+  });
+
+  it('surfaces a MeshCore send failure (sendMessage resolves false) as a thrown error', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(false); // node disconnected / send rejected
+    getManager.mockReturnValue(undefined);
+    meshcoreGet.mockReturnValue({ sendMessage });
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 0 }))
+      .rejects.toThrow(/failed to send the MeshCore message/);
+  });
+});
+
 describe('createMeshActionDeps requestData — node operations (#3835)', () => {
-  beforeEach(() => getManager.mockReset());
+  beforeEach(() => { getManager.mockReset(); meshcoreGet.mockReset(); });
 
   function meshtasticManager() {
     return {

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -12,6 +12,7 @@
  */
 import databaseService from '../../../services/database.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
+import { meshcoreManagerRegistry } from '../../meshcoreRegistry.js';
 import { appriseNotificationService } from '../appriseNotificationService.js';
 import { runScript as runUserScript } from '../../utils/scriptRunner.js';
 import type { ActionDeps } from './actionExecutor.js';
@@ -41,9 +42,21 @@ interface MeshCoreSendManager {
   sendAdvert(): Promise<unknown>;
 }
 
+/**
+ * Resolve the live manager for a source across BOTH registries (#3915).
+ * Meshtastic managers live in `sourceManagerRegistry`; MeshCore managers live
+ * in the separate `meshcoreManagerRegistry`. Automation actions must consult
+ * both — otherwise every action targeting a MeshCore source fails with
+ * "cannot send messages", because a MeshCore manager is never present in
+ * `sourceManagerRegistry` no matter how healthy/connected the source is.
+ */
+function resolveManager(sourceId: string): unknown | undefined {
+  return sourceManagerRegistry.getManager(sourceId) ?? meshcoreManagerRegistry.get(sourceId);
+}
+
 function mgr(sourceId: string | null): MeshSendManager {
   if (!sourceId) throw new Error('automation action requires a target source');
-  const m = sourceManagerRegistry.getManager(sourceId) as unknown as MeshSendManager | undefined;
+  const m = resolveManager(sourceId) as MeshSendManager | undefined;
   if (!m || typeof m.sendTextMessage !== 'function') {
     throw new Error(`source "${sourceId}" cannot send messages (not a Meshtastic manager)`);
   }
@@ -65,7 +78,7 @@ async function sendTextVia(
   scopeOverride?: string | null,
 ): Promise<unknown> {
   if (!sourceId) throw new Error('automation action requires a target source');
-  const raw = sourceManagerRegistry.getManager(sourceId) as unknown as
+  const raw = resolveManager(sourceId) as
     (Partial<MeshSendManager> & Partial<MeshCoreSendManager>) | undefined;
   if (raw && typeof raw.sendTextMessage === 'function') {
     // Meshtastic has no scope/region concept — scopeOverride is dropped.
@@ -74,7 +87,14 @@ async function sendTextVia(
   if (raw && typeof raw.sendMessage === 'function') {
     // MeshCore: channel send only (DM-by-nodeNum / tapbacks not supported here).
     // `scopeOverride` (#3833) controls which region the message floods to.
-    return raw.sendMessage(text, undefined, channel, scopeOverride);
+    // `sendMessage` resolves `false` (not throw) when the node is disconnected
+    // or the send fails — surface that as a thrown error so the run-log records
+    // a failed step instead of a silent success.
+    const ok = await raw.sendMessage(text, undefined, channel, scopeOverride);
+    if (ok === false) {
+      throw new Error(`source "${sourceId}" failed to send the MeshCore message (node not connected or send rejected)`);
+    }
+    return ok;
   }
   throw new Error(`source "${sourceId}" cannot send messages`);
 }
@@ -109,7 +129,7 @@ export function createMeshActionDeps(): ActionDeps {
 
     async requestData({ sourceId, op, target, channel, telemetryType }) {
       if (!sourceId) throw new Error('automation action requires a target source');
-      const raw = sourceManagerRegistry.getManager(sourceId) as unknown as
+      const raw = resolveManager(sourceId) as
         (Partial<MeshSendManager> & Partial<MeshCoreSendManager>) | undefined;
       // Meshtastic: target is a node number.
       if (raw && typeof raw.sendTelemetryRequest === 'function') {


### PR DESCRIPTION
## Summary

Fixes #3915 — a `trigger.message` automation matching MeshCore traffic fires, but its `action.sendMessage` step fails with `source "<id>" cannot send messages`, even though the target MeshCore source is enabled and connected.

## Root cause

MeshCore managers are registered in **`meshcoreManagerRegistry`** (`src/server/meshcoreRegistry.ts`, accessor `.get(id)`), **not** in `sourceManagerRegistry` (`.getManager(id)`) — the two are separate maps, as documented in several places across the codebase.

The automation action deps (`src/server/services/automation/meshActionDeps.ts`) only ever queried `sourceManagerRegistry.getManager(sourceId)`. For **any** MeshCore source that returns `undefined`, so `sendTextVia()` / `mgr()` / `requestData()` all fall through to their "cannot send messages" throw. The MeshCore branch already written inside `sendTextVia`/`requestData` (`raw.sendMessage(...)`, MeshCore telemetry/trace/neighbor/advert senders) was effectively **dead code** — that lookup could never return a MeshCore manager. Net effect: no automation action has ever been able to send or request via a MeshCore source. The trigger side works because MeshCore messages feed the engine via events (#3833); only the action side was mis-wired.

This is why the previous diagnostics-only PR (#3916, now closed) didn't help — and would have actively misled, reporting a live MeshCore source as "deleted / disabled / not connected".

## Fix

- Add a shared `resolveManager(sourceId)` that consults **both** registries (`sourceManagerRegistry.getManager` first, then `meshcoreManagerRegistry.get`), and use it in `mgr()`, `sendTextVia()`, and `requestData()`.
- Surface a MeshCore send that resolves `false` (node disconnected / send rejected — `MeshCoreManager.sendMessage` returns `false` rather than throwing) as a thrown error, so the run-log records a failed step instead of a silent success.

## Tests

The prior tests masked the bug by injecting MeshCore-shaped managers through the **Meshtastic** registry mock. This PR:

- Adds a `meshcoreManagerRegistry` mock.
- Adds regression tests placing the MeshCore manager **only** in its real registry (`getManager` → undefined) and asserting `sendMessage`/`requestData` still reach it.
- Adds tests for the "neither registry has the source" throw and the MeshCore `false` → thrown-error path.

## Test plan

- [x] `./node_modules/.bin/vitest run src/server/services/automation/` — 208 passed, 0 failed, 0 suites failed (`success: true`)
- [x] `tsc --noEmit` — no new errors in changed files
- [x] Manual trace of the reporter's automation JSON confirms the path now reaches `MeshCoreManager.sendMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n