### PR TITLE
fix(meshcore): retry initial auto-connect attempt with backoff

### DIFF
--- a/src/server/meshcoreManager.connect-error.test.ts
+++ b/src/server/meshcoreManager.connect-error.test.ts
@@ -26,6 +26,10 @@ function makeConfiguredManager(rejectWith: unknown): MeshCoreManager {
   (m as any).startNativeBackend = vi.fn().mockRejectedValue(rejectWith);
   // disconnect() is awaited in the catch; stub it so we don't touch real state.
   (m as any).disconnect = vi.fn().mockResolvedValue(undefined);
+  // The catch handler now schedules a retry (#3918); stub it out here so
+  // these log-message tests don't leak a real setTimeout that would keep
+  // retrying (and rejecting) after the test finishes.
+  (m as any).scheduleNextReconnect = vi.fn();
   return m;
 }
 

--- a/src/server/meshcoreManager.initialConnectRetry.test.ts
+++ b/src/server/meshcoreManager.initialConnectRetry.test.ts
@@ -95,8 +95,7 @@ describe('MeshCoreManager.connect() initial-failure retry', () => {
     expect(firstAttempt).toBe(false);
     expect(scheduleSpy).toHaveBeenCalledTimes(1);
 
-    const secondAttempt = await (m as any).attemptReconnect();
-    void secondAttempt;
+    await (m as any).attemptReconnect();
 
     expect((m as any).connected).toBe(true);
     expect((m as any).shouldReconnect).toBe(false);

--- a/src/server/meshcoreManager.initialConnectRetry.test.ts
+++ b/src/server/meshcoreManager.initialConnectRetry.test.ts
@@ -100,4 +100,27 @@ describe('MeshCoreManager.connect() initial-failure retry', () => {
     expect((m as any).connected).toBe(true);
     expect((m as any).shouldReconnect).toBe(false);
   });
+
+  it('does not double-schedule a reconnect when attemptReconnect() drives a failing connect() (regression)', async () => {
+    // Exercises the REAL scheduleNextReconnect() (not stubbed) to catch the
+    // double-call bug flagged in review: connect()'s catch block schedules a
+    // retry, and attemptReconnect()'s own `!ok` branch used to schedule a
+    // second one on top of it — doubling reconnectAttempts (and the backoff
+    // growth it drives) and leaking the first timer.
+    vi.useFakeTimers();
+    try {
+      const m = new MeshCoreManager('test-source');
+      (m as any).startNativeBackend = vi.fn().mockRejectedValue(new Error('still not ready'));
+      (m as any).disconnect = vi.fn().mockResolvedValue(undefined);
+      (m as any).shouldReconnect = true;
+      (m as any).config = TEST_CONFIG;
+
+      await (m as any).attemptReconnect();
+
+      expect((m as any).reconnectAttempts).toBe(1);
+      expect(vi.getTimerCount()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/server/meshcoreManager.initialConnectRetry.test.ts
+++ b/src/server/meshcoreManager.initialConnectRetry.test.ts
@@ -65,6 +65,7 @@ describe('MeshCoreManager.connect() initial-failure retry', () => {
     (m as any).startAutoPathfinding = vi.fn().mockResolvedValue(undefined);
     (m as any).startAutoAnnounce = vi.fn().mockResolvedValue(undefined);
     (m as any).startTimerTriggers = vi.fn().mockResolvedValue(undefined);
+    (m as any).distanceDeleteScheduler = { start: vi.fn().mockResolvedValue(undefined), stop: vi.fn() };
 
     const ok = await m.connect(TEST_CONFIG);
 
@@ -87,6 +88,7 @@ describe('MeshCoreManager.connect() initial-failure retry', () => {
     (m as any).startAutoPathfinding = vi.fn().mockResolvedValue(undefined);
     (m as any).startAutoAnnounce = vi.fn().mockResolvedValue(undefined);
     (m as any).startTimerTriggers = vi.fn().mockResolvedValue(undefined);
+    (m as any).distanceDeleteScheduler = { start: vi.fn().mockResolvedValue(undefined), stop: vi.fn() };
     // Skip the real backoff delay — assert the scheduling call happened and
     // drive the retry manually via attemptReconnect().
     const scheduleSpy = vi.spyOn(m as any, 'scheduleNextReconnect').mockReturnValue(undefined);

--- a/src/server/meshcoreManager.initialConnectRetry.test.ts
+++ b/src/server/meshcoreManager.initialConnectRetry.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression tests for retrying a failed *initial* MeshCore connect() attempt
+ * (#3918). Before this fix, a failed auto-connect-on-startup attempt (or any
+ * other connect() call — manual "Connect" click, source create/enable) was
+ * terminal: the manager logged a warning and left the source disconnected
+ * until a manual Connect click, even though "Automatically connect on
+ * startup" was enabled. Unlike Meshtastic TCP sources — whose transport
+ * retries forever with backoff regardless of heartbeat config — MeshCore's
+ * only retry machinery (scheduleNextReconnect/attemptReconnect) previously
+ * fired solely for a drop *after* a successful connect, and only when the
+ * opt-in heartbeat feature was configured.
+ *
+ * connect() now arms `shouldReconnect` and calls scheduleNextReconnect() on
+ * a failed first attempt too, and resets `shouldReconnect` back to false on
+ * a successful connect so the heartbeat feature's own gating for post-connect
+ * drops is unaffected.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager, ConnectionType, type MeshCoreConfig } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+
+const TEST_CONFIG: MeshCoreConfig = {
+  connectionType: ConnectionType.SERIAL,
+  firmwareType: 'companion',
+  serialPort: '/dev/ttyTEST',
+};
+
+describe('MeshCoreManager.connect() initial-failure retry', () => {
+  beforeEach(() => {
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(databaseService.meshcore, 'getRecentMessages').mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('arms shouldReconnect and schedules a retry when the first attempt fails', async () => {
+    const m = new MeshCoreManager('test-source');
+    (m as any).startNativeBackend = vi.fn().mockRejectedValue(new Error('port busy'));
+    (m as any).disconnect = vi.fn().mockResolvedValue(undefined);
+    const scheduleSpy = vi.spyOn(m as any, 'scheduleNextReconnect').mockReturnValue(undefined);
+
+    const ok = await m.connect(TEST_CONFIG);
+
+    expect(ok).toBe(false);
+    expect((m as any).shouldReconnect).toBe(true);
+    expect((m as any).connectionState).toBe('reconnecting');
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets shouldReconnect to false once a connect attempt succeeds without heartbeat configured', async () => {
+    const m = new MeshCoreManager('test-source');
+    // Pretend a prior failed attempt already armed the retry flag.
+    (m as any).shouldReconnect = true;
+    (m as any).startNativeBackend = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshLocalNode = vi.fn().mockResolvedValue(undefined);
+    (m as any).seedContactsFromDb = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshContacts = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshKnownScopes = vi.fn().mockResolvedValue(undefined);
+    (m as any).startVirtualNodeServer = vi.fn().mockResolvedValue(undefined);
+    (m as any).startAutoPathfinding = vi.fn().mockResolvedValue(undefined);
+    (m as any).startAutoAnnounce = vi.fn().mockResolvedValue(undefined);
+    (m as any).startTimerTriggers = vi.fn().mockResolvedValue(undefined);
+
+    const ok = await m.connect(TEST_CONFIG);
+
+    expect(ok).toBe(true);
+    expect((m as any).shouldReconnect).toBe(false);
+  });
+
+  it('retries the eventual reconnect attempt via attemptReconnect once scheduled', async () => {
+    const m = new MeshCoreManager('test-source');
+    let attempts = 0;
+    (m as any).startNativeBackend = vi.fn().mockImplementation(() => {
+      attempts += 1;
+      return attempts < 2 ? Promise.reject(new Error('not ready yet')) : Promise.resolve(undefined);
+    });
+    (m as any).refreshLocalNode = vi.fn().mockResolvedValue(undefined);
+    (m as any).seedContactsFromDb = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshContacts = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshKnownScopes = vi.fn().mockResolvedValue(undefined);
+    (m as any).startVirtualNodeServer = vi.fn().mockResolvedValue(undefined);
+    (m as any).startAutoPathfinding = vi.fn().mockResolvedValue(undefined);
+    (m as any).startAutoAnnounce = vi.fn().mockResolvedValue(undefined);
+    (m as any).startTimerTriggers = vi.fn().mockResolvedValue(undefined);
+    // Skip the real backoff delay — assert the scheduling call happened and
+    // drive the retry manually via attemptReconnect().
+    const scheduleSpy = vi.spyOn(m as any, 'scheduleNextReconnect').mockReturnValue(undefined);
+
+    const firstAttempt = await m.connect(TEST_CONFIG);
+    expect(firstAttempt).toBe(false);
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+
+    const secondAttempt = await (m as any).attemptReconnect();
+    void secondAttempt;
+
+    expect((m as any).connected).toBe(true);
+    expect((m as any).shouldReconnect).toBe(false);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -848,6 +848,13 @@ class MeshCoreManager extends EventEmitter {
       this.heartbeatConsecutiveFailures = 0;
       this.reconnectAttempts = 0;
       this.nextReconnectAt = null;
+      // A prior failed attempt (see the catch block below) may have armed
+      // shouldReconnect to drive its own retry loop. Reset it here so a
+      // successful connect falls back to the heartbeat feature's own opt-in
+      // gating for *post-connect* drops, rather than leaving unexpected-
+      // disconnect auto-reconnect silently enabled when heartbeat isn't
+      // configured for this source.
+      this.shouldReconnect = false;
       this.emit('connected', this.localNode);
       // Per-source auto-delete-by-distance (#3901) — scoped to this source's
       // own nodes/settings; only runs while connected.
@@ -909,6 +916,17 @@ class MeshCoreManager extends EventEmitter {
             : String(error);
       logger.error(`[MeshCore] Connection failed: ${detail}`);
       await this.disconnect();
+      // Retry the initial connection attempt with exponential backoff instead
+      // of leaving the source stuck disconnected until a manual Connect click
+      // (#3918). Unlike Meshtastic TCP — whose transport retries forever by
+      // default — MeshCore had no retry path for a failed *first* attempt;
+      // the existing reconnect machinery only covered a drop after a
+      // successful connect, and only when the opt-in heartbeat feature was
+      // configured. disconnect() above reset shouldReconnect to false, so
+      // re-arm it here to drive scheduleNextReconnect/attemptReconnect.
+      this.shouldReconnect = true;
+      this.connectionState = 'reconnecting';
+      this.scheduleNextReconnect();
       return false;
     }
   }

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4977,6 +4977,12 @@ class MeshCoreManager extends EventEmitter {
   }
 
   private scheduleNextReconnect(): void {
+    // Idempotent: a retry may already be scheduled by an earlier step in the
+    // same failure path — e.g. connect()'s catch block schedules one before
+    // returning to attemptReconnect(), which would otherwise schedule a
+    // second one on top of it, doubling reconnectAttempts (and the backoff
+    // growth it drives) and leaking the first timer (#3918 follow-up).
+    if (this.reconnectTimer) return;
     if (!this.shouldReconnect) {
       this.connectionState = 'failed';
       return;


### PR DESCRIPTION
## Summary

Fixes #3918.

`MeshCoreManager.connect()` previously made exactly one attempt and gave up permanently on failure — leaving the source stuck disconnected until a manual "Connect" click, even with "Automatically connect on startup" enabled. This differs from Meshtastic TCP sources, whose transport retries forever with exponential backoff by default. MeshCore's existing reconnect machinery (`scheduleNextReconnect`/`attemptReconnect`) only ever engaged for a drop *after* an already-successful connect, and only when the opt-in heartbeat feature (`heartbeatIntervalSeconds`) was configured — never for the initial connect attempt itself.

- `connect()` now arms `shouldReconnect` and calls `scheduleNextReconnect()` when the very first attempt fails, so a transient startup race (device/native backend not yet ready) recovers on its own via the existing exponential-backoff timer instead of requiring manual intervention.
- On a successful connect, `shouldReconnect` is explicitly reset to `false` so the heartbeat feature's own opt-in gating for *post-connect* drops is unaffected — this change does not silently enable heartbeat-style auto-reconnect for sources that never configured it.

## Changes

- `src/server/meshcoreManager.ts`: retry-on-initial-failure in `connect()`'s catch block; explicit `shouldReconnect` reset on success.
- `src/server/meshcoreManager.connect-error.test.ts`: stub `scheduleNextReconnect` in the existing catch-handler tests so they don't leak a real retry timer.
- `src/server/meshcoreManager.initialConnectRetry.test.ts` (new): regression tests covering the retry-on-failure path, the `shouldReconnect` reset on success, and an end-to-end retry-then-succeed scenario via `attemptReconnect()`.

## Test plan

- [x] Targeted tests: `meshcoreManager.connect-error.test.ts`, `meshcoreManager.initialConnectRetry.test.ts`, `meshcoreManager.dropDetection.test.ts` — all pass
- [x] Full Vitest suite — 547 passed / 9 failed suites, all 9 failures traced to a missing `protobufs` git submodule in the sandbox (unrelated to this change); re-ran after `git submodule update --init` and all 9 pass (48/48 tests)
- [x] `eslint` on changed files — no new warnings/errors (21 pre-existing issues at unrelated lines, confirmed present before this change via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr4SAmd6b69UzqEnamyc4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gr4SAmd6b69UzqEnamyc4c)_