### PR TITLE
feat(automation): MeshCore scope condition + self-origin guard (#3914)

### DIFF
--- a/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
+++ b/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
@@ -153,6 +153,7 @@ Both tables follow the 3-backend Drizzle pattern (`src/db/schema/settings.ts` ex
    - **Loop guard:** max action count per run + max graph-step count; an action that re-triggers its own workflow must not recurse infinitely (track originating run id / depth).
    - **Cooldown / rate-limit** per automation (carry over the existing `autoAckCooldownSeconds` concept) to prevent mesh spam.
    - **Airtime awareness:** respect existing `automationAirtimeCutoff*` settings before send actions.
+   - **Self-origin guard (#3914):** the engine drops every event that originated from our OWN node — a message whose `fromNodeNum` (Meshtastic) / `fromPublicKey` (MeshCore) is the source's local node, and telemetry / node-updates for the local node. This is what stops an `action.sendMessage` reply (which re-enters the bus via `emitNewMessage`/`emitMeshCoreMessage`) from re-triggering its own rule in an infinite mesh loop, and stops our own periodic telemetry/node-info from spuriously firing rules. Identity is resolved per-source/protocol via optional `NodeDataProvider.getLocalNodeNum`/`getSelfPublicKey` accessors (real impls read the live manager registries; absent in a unit test → nothing is dropped). Mirrors the legacy MeshCore auto-responder's `checkAutoResponder` self-reply guard. (Geofence checks are intentionally NOT self-excluded — "when my own tracker enters a region" is a valid automation and carries no loop risk.)
    - Action failures are caught, logged to the run, and do not crash the engine.
 5. **Variable interpolation:** `{{ ... }}` templating in action params, resolving from `state.vars`, the trigger payload (`{{ trigger.from }}`, `{{ trigger.text }}`), and system vars (`{{ CURRENT_SOURCE_NODE_ID }}`, `{{ NOW }}`). Import strips/normalizes personal node ids via these system vars so shared workflows are portable.
 
@@ -174,6 +175,7 @@ Both tables follow the 3-backend Drizzle pattern (`src/db/schema/settings.ts` ex
 - `condition.timeRange` — within a time-of-day / day-of-week window.
 - `condition.variable` — compare a user-defined variable (§5.2) against a literal or another value; "is flag set?". Powers thresholds and the flag anti-spam gate.
 - `condition.logical` — AND/OR/NOT wrapper (Collapse covers most of this at the graph level).
+- `condition.meshcoreScope` — **(#3914)** match a MeshCore message by its region **scope**. `mode ∈ {named, unscoped, scoped}`; `named` takes a comma-separated `regions` list and an optional `includeUnscoped` toggle, so "region `de` **OR** unscoped" is a single block. Reads the inbound `scopeCode`/`scopeName` fields exposed by `buildMeshCoreMessageContext`; Meshtastic messages carry no scope and therefore never match. Serves the "nudge newbies who post unscoped or on a very broad region" use case.
 
 **Flow:**
 - `flow.fanout` — split to multiple branches.

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -18,6 +18,8 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
     ['wantAck', 'Sender requested an ack'], ['replyId', 'Replied-to packet id'],
     ['emoji', 'Tapback/reaction emoji flag'], ['viaMqtt', 'true if it arrived via MQTT'],
     ['decryptedBy', 'Channel/key that decrypted it'],
+    ['fromName', 'Sender name (MeshCore)'], ['scopeName', 'Region/scope name (MeshCore)'],
+    ['scopeCode', 'Region/scope code — 0 = unscoped (MeshCore)'], ['scoped', 'true if sent with a region (MeshCore)'],
   ],
   'trigger.telemetry': [['nodeNum', 'Node number'], ['telemetryType', 'Metric name'], ['value', 'Reading value'], ['unit', 'Unit']],
   'trigger.nodeUpdated': [['nodeNum', 'Node number'], ['changed', 'Changed field names (list)']],

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -237,6 +237,30 @@ export const CONDITIONS: BlockDef[] = [
     ],
   },
   {
+    type: 'condition.meshcoreScope',
+    label: 'MeshCore message scope',
+    description: 'Match a MeshCore message by its region scope — a specific region, unscoped (no region), or any scoped message. Meshtastic messages never match. Handy for nudging users who post unscoped or on a very broad region.',
+    fields: [
+      {
+        name: 'mode', label: 'Match', kind: 'select',
+        options: [
+          { value: 'named', label: 'A specific region…' },
+          { value: 'unscoped', label: 'Unscoped (no region)' },
+          { value: 'scoped', label: 'Any scoped message' },
+        ],
+      },
+      {
+        name: 'regions', label: 'Region(s)', kind: 'regionSelect',
+        placeholder: 'e.g. de, eu',
+        help: 'Comma-separated region names to match (used when Match = a specific region). Case-insensitive.',
+      },
+      {
+        name: 'includeUnscoped', label: 'Also match unscoped', kind: 'checkbox',
+        help: 'When matching specific region(s), ALSO match messages sent with no region — e.g. “region de OR unscoped”.',
+      },
+    ],
+  },
+  {
     type: 'condition.sourceFilter',
     label: 'Source is one of…',
     description: 'Only continue for the selected source connection(s).',

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -199,6 +199,63 @@ describe('AutomationEngineService', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('self-origin (#3914): ignores a Meshtastic message from our own local node', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    const selfData = { ...data, getLocalNodeNum: async () => 111 };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    // From our own node (111) → dropped before it can loop.
+    expect(await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+    // From a different node → fires normally.
+    expect(await engine.onMessage(message({ fromNodeNum: 222, text: 'ping' }), 'default')).toBe(1);
+  });
+
+  it('self-origin (#3914): ignores a MeshCore message from our own public key (case-insensitive)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('mc-ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'pong' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    const selfData = { ...data, getSelfPublicKey: async () => 'ABCD' };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    // Our own send (key differs only in case) → dropped.
+    expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'abcd', text: 'ping' }), 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+    // A different sender → fires.
+    expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'channel-0', text: 'ping' }), 'default')).toBe(1);
+  });
+
+  it('self-origin (#3914): ignores our own node telemetry', async () => {
+    const { deps } = recorder();
+    await createEnabled('batt', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.telemetry', params: {} },
+        { id: 'n', type: 'action.notify', params: { title: 'low', body: 'batt' } },
+      ],
+      edges: [{ from: 't', to: 'n' }],
+    });
+    const selfData = { ...data, getLocalNodeNum: async () => 111 };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    expect(await engine.onTelemetry(111, 'batteryLevel', 50, '%', 'default')).toBe(0); // our own → dropped
+    expect(await engine.onTelemetry(222, 'batteryLevel', 50, '%', 'default')).toBe(1); // another node → fires
+  });
+
   it('enforces the per-automation cooldown', async () => {
     const { calls, deps } = recorder();
     await createEnabled('ping', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -349,9 +349,34 @@ export class AutomationEngineService {
     }
   }
 
+  // ─── self-origin guard (#3914) ──────────────────────────────────────────
+  //
+  // Drop events that originated from our OWN node so an automation never fires
+  // on MeshMonitor's own traffic — most importantly so an `action.sendMessage`
+  // reply can't re-trigger the very rule that sent it (an infinite mesh loop),
+  // and so our own periodic telemetry / node-info doesn't spuriously fire rules.
+  // Mirrors the legacy MeshCore auto-responder guard. Identity is resolved per
+  // source via optional data-provider accessors; when they're absent (e.g. a
+  // unit test that doesn't wire them) nothing is dropped — existing behavior.
+
+  /** True if `fromNodeNum` is this Meshtastic source's own local node. */
+  private async isSelfMeshtastic(sourceId: string | null, fromNodeNum: number | null | undefined): Promise<boolean> {
+    if (!this.data.getLocalNodeNum || fromNodeNum == null) return false;
+    const local = await this.data.getLocalNodeNum(sourceId);
+    return local != null && Number(local) === Number(fromNodeNum);
+  }
+
+  /** True if `fromPublicKey` is this MeshCore source's own local node key. */
+  private async isSelfMeshCore(sourceId: string | null, fromPublicKey: string | null | undefined): Promise<boolean> {
+    if (!this.data.getSelfPublicKey || !fromPublicKey) return false;
+    const key = await this.data.getSelfPublicKey(sourceId);
+    return key != null && key.toLowerCase() === fromPublicKey.toLowerCase();
+  }
+
   // ─── event entry points ─────────────────────────────────────────────────
 
   async onMessage(msg: DbMessage, sourceId: string | null): Promise<number> {
+    if (await this.isSelfMeshtastic(sourceId, msg.fromNodeNum)) return 0; // #3914: ignore our own sends
     const ctx = buildMessageContext(msg, sourceId, this.now());
     // Resolve the message's channel NAME once (per-source slot→name), but only
     // when a loaded message automation actually filters by channelName — keeps
@@ -378,6 +403,7 @@ export class AutomationEngineService {
    * engine previously ignored entirely).
    */
   async onMeshCoreMessage(msg: MeshCoreMessage, sourceId: string | null): Promise<number> {
+    if (await this.isSelfMeshCore(sourceId, msg.fromPublicKey)) return 0; // #3914: ignore our own sends
     const ctx = buildMeshCoreMessageContext(msg, sourceId, this.now());
     let channelName: string | null | undefined;
     const usesChannelName = (this.index.get('trigger.message') ?? []).some((a) => {
@@ -402,6 +428,7 @@ export class AutomationEngineService {
     changedKeys: string[],
     sourceId: string | null,
   ): Promise<number> {
+    if (await this.isSelfMeshtastic(sourceId, nodeNum)) return 0; // #3914: ignore our own node updates
     return this.runTrigger(buildNodeContext(kind, nodeNum, changedKeys, sourceId, this.now()));
   }
 
@@ -412,6 +439,7 @@ export class AutomationEngineService {
     unit: string | undefined,
     sourceId: string | null,
   ): Promise<number> {
+    if (await this.isSelfMeshtastic(sourceId, nodeNum)) return 0; // #3914: ignore our own telemetry
     const ctx = buildTelemetryContext(nodeNum, telemetryType, value, unit, sourceId, this.now());
     return this.runTrigger(
       ctx,

--- a/src/server/services/automation/conditionEvaluator.test.ts
+++ b/src/server/services/automation/conditionEvaluator.test.ts
@@ -159,6 +159,38 @@ describe('evaluateCondition', () => {
     expect(await evaluateCondition(node('condition.timeRange', { start: '22:00', end: '06:00' }), ctx({}, { now: lateNight }))).toBe(true);
   });
 
+  it('meshcoreScope: unscoped / scoped modes key off scopeCode', async () => {
+    const unscoped = node('condition.meshcoreScope', { mode: 'unscoped' });
+    expect(await evaluateCondition(unscoped, ctx({ scopeCode: 0 }))).toBe(true);
+    expect(await evaluateCondition(unscoped, ctx({ scopeCode: 42, scopeName: 'de' }))).toBe(false);
+    // Meshtastic message (no scopeCode field) → never matches.
+    expect(await evaluateCondition(unscoped, ctx({}))).toBe(false);
+
+    const scoped = node('condition.meshcoreScope', { mode: 'scoped' });
+    expect(await evaluateCondition(scoped, ctx({ scopeCode: 42, scopeName: 'de' }))).toBe(true);
+    expect(await evaluateCondition(scoped, ctx({ scopeCode: 0 }))).toBe(false);
+    expect(await evaluateCondition(scoped, ctx({}))).toBe(false);
+  });
+
+  it('meshcoreScope: named matches listed regions (case-insensitive, comma list)', async () => {
+    const n = node('condition.meshcoreScope', { mode: 'named', regions: 'de, eu' });
+    expect(await evaluateCondition(n, ctx({ scopeCode: 42, scopeName: 'DE' }))).toBe(true);
+    expect(await evaluateCondition(n, ctx({ scopeCode: 7, scopeName: 'eu' }))).toBe(true);
+    expect(await evaluateCondition(n, ctx({ scopeCode: 7, scopeName: 'fr' }))).toBe(false);
+    // scoped but region unresolved (no scopeName) → cannot match a name.
+    expect(await evaluateCondition(n, ctx({ scopeCode: 7 }))).toBe(false);
+    // unscoped is NOT matched by named alone.
+    expect(await evaluateCondition(n, ctx({ scopeCode: 0 }))).toBe(false);
+  });
+
+  it('meshcoreScope: named + includeUnscoped matches "region OR unscoped" (the #3914 case)', async () => {
+    const n = node('condition.meshcoreScope', { mode: 'named', regions: 'de', includeUnscoped: true });
+    expect(await evaluateCondition(n, ctx({ scopeCode: 42, scopeName: 'de' }))).toBe(true); // the region
+    expect(await evaluateCondition(n, ctx({ scopeCode: 0 }))).toBe(true);                    // OR unscoped
+    expect(await evaluateCondition(n, ctx({ scopeCode: 7, scopeName: 'fr' }))).toBe(false);  // other region
+    expect(await evaluateCondition(n, ctx({}))).toBe(false);                                 // Meshtastic
+  });
+
   it('logical: AND / OR / NOT over sub-conditions', async () => {
     const t = { type: 'condition.numeric', params: { field: 'v', op: '==', value: 1 } };
     const f = { type: 'condition.numeric', params: { field: 'v', op: '==', value: 9 } };

--- a/src/server/services/automation/conditionEvaluator.ts
+++ b/src/server/services/automation/conditionEvaluator.ts
@@ -90,6 +90,29 @@ export async function evaluateCondition(node: AutomationNode, ctx: EngineEvalCon
       return stringCompare(String(p.op ?? 'eq'), left, right);
     }
 
+    case 'condition.meshcoreScope': {
+      // MeshCore region scope (#3914). Reads the inbound message's scope from the
+      // trigger context (populated only by buildMeshCoreMessageContext):
+      //   scopeCode === 0 → sent unscoped; > 0 → scoped; undefined → no scope
+      //   info (a Meshtastic message, a room post, or an unparseable header).
+      // Meshtastic messages carry no scopeCode, so every mode falls through to
+      // a non-match — the condition is inherently MeshCore-only.
+      const f = ctx.trigger.fields;
+      const scopeCode = typeof f.scopeCode === 'number' ? f.scopeCode : undefined;
+      const scopeName = typeof f.scopeName === 'string' ? f.scopeName : undefined;
+      const isUnscoped = scopeCode === 0;
+      const isScoped = typeof scopeCode === 'number' && scopeCode > 0;
+      const mode = String(p.mode ?? 'named');
+      if (mode === 'unscoped') return isUnscoped;
+      if (mode === 'scoped') return isScoped;
+      // 'named': match one of the listed regions, optionally also unscoped.
+      if (p.includeUnscoped === true && isUnscoped) return true;
+      if (scopeName == null) return false; // no resolved region name to match
+      const wanted = String((await resolveOperand(ctx, p.regions)) ?? '')
+        .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+      return wanted.includes(scopeName.toLowerCase());
+    }
+
     case 'condition.variable': {
       const name = String(p.variable ?? '');
       if (!name) return false;

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -55,6 +55,17 @@ export interface NodeDataProvider {
    * unified channel only sends to sources of its own protocol. Optional.
    */
   getSourceProtocol?(sourceId: string | null): Promise<string | null>;
+  /**
+   * Own/local node number for a Meshtastic source — used to drop self-originated
+   * events (messages/telemetry/node updates our own node produced) so automations
+   * never fire on MeshMonitor's own traffic (#3914). Optional; absent → no drop.
+   */
+  getLocalNodeNum?(sourceId: string | null): Promise<number | null>;
+  /**
+   * Own/local node public key for a MeshCore source — the self signal for MeshCore
+   * received messages (#3914). Optional; absent → no drop.
+   */
+  getSelfPublicKey?(sourceId: string | null): Promise<string | null>;
 }
 
 export interface EngineEvalContext {

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -6,6 +6,8 @@
 import databaseService from '../../../services/database.js';
 import type { NodeDataProvider, NodeFacts } from './engineContext.js';
 import { sourceProtocol } from './channelUnify.js';
+import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
+import { meshcoreManagerRegistry } from '../../meshcoreRegistry.js';
 
 function nodeIdOf(nodeNum: number): string {
   return `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`;
@@ -54,6 +56,28 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
         if (!sourceId) return null;
         const s = await databaseService.sources.getSource(sourceId);
         return s ? sourceProtocol(s.type) : null;
+      } catch {
+        return null;
+      }
+    },
+
+    // Self-identity accessors (#3914) — read the live manager for the source so
+    // the engine can drop self-originated events. Meshtastic and MeshCore live
+    // in separate registries; a miss (source not connected) returns null → no drop.
+    async getLocalNodeNum(sourceId) {
+      try {
+        if (!sourceId) return null;
+        const nodeNum = sourceManagerRegistry.getManager(sourceId)?.getLocalNodeInfo()?.nodeNum;
+        return nodeNum != null ? Number(nodeNum) : null;
+      } catch {
+        return null;
+      }
+    },
+
+    async getSelfPublicKey(sourceId) {
+      try {
+        if (!sourceId) return null;
+        return meshcoreManagerRegistry.get(sourceId)?.getLocalNode()?.publicKey ?? null;
       } catch {
         return null;
       }

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -54,6 +54,28 @@ describe('validateAutomationGraph', () => {
     expect(validateAutomationGraph(g).valid).toBe(true);
   });
 
+  it('condition.meshcoreScope: accepts valid modes, rejects an empty named block (#3914)', () => {
+    const withCond = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'c', type: 'condition.meshcoreScope', params },
+        { id: 'a', type: 'action.sendMessage', params: { text: 'hi' } },
+      ],
+      edges: [{ from: 't', to: 'c' }, { from: 'c', to: 'a' }],
+    });
+    expect(validateAutomationGraph(withCond({ mode: 'unscoped' })).valid).toBe(true);
+    expect(validateAutomationGraph(withCond({ mode: 'scoped' })).valid).toBe(true);
+    expect(validateAutomationGraph(withCond({ mode: 'named', regions: 'de' })).valid).toBe(true);
+    expect(validateAutomationGraph(withCond({ mode: 'named', includeUnscoped: true })).valid).toBe(true);
+    // named with neither regions nor includeUnscoped → error
+    const empty = validateAutomationGraph(withCond({ mode: 'named' }));
+    expect(empty.valid).toBe(false);
+    expect(empty.errors.join(' ')).toMatch(/requires params\.regions or params\.includeUnscoped/);
+    // unknown mode → error
+    expect(validateAutomationGraph(withCond({ mode: 'bogus' })).valid).toBe(false);
+  });
+
   it('rejects non-object config', () => {
     expect(validateAutomationGraph(null).valid).toBe(false);
     expect(validateAutomationGraph(42).errors[0]).toMatch(/must be an object/);

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -31,7 +31,8 @@ export type ConditionType =
   | 'condition.distance'
   | 'condition.timeRange'
   | 'condition.variable'
-  | 'condition.logical';
+  | 'condition.logical'
+  | 'condition.meshcoreScope';
 
 export type ActionType =
   | 'action.nothing'
@@ -74,6 +75,7 @@ export const CONDITION_TYPES: readonly ConditionType[] = [
   'condition.timeRange',
   'condition.variable',
   'condition.logical',
+  'condition.meshcoreScope',
 ];
 
 export const ACTION_TYPES: readonly ActionType[] = [
@@ -112,6 +114,19 @@ export type NumericOp = (typeof NUMERIC_OPS)[number];
 /** Node operations an `action.requestData` can ask for (#3835). */
 export const REQUEST_OPS = ['telemetry', 'position', 'traceroute', 'nodeinfo', 'neighbors', 'advert'] as const;
 export type RequestOp = (typeof REQUEST_OPS)[number];
+
+/**
+ * Match modes for `condition.meshcoreScope` (#3914). A MeshCore text message
+ * carries a region "scope" (`scopeCode` 0 = unscoped, >0 = a region; `scopeName`
+ * = the resolved region). This condition matches:
+ *  - `named`    — the message's region is one of the listed names (with an
+ *                 optional `includeUnscoped` toggle → "region de OR unscoped");
+ *  - `unscoped` — the message was sent with no region (`scopeCode === 0`);
+ *  - `scoped`   — the message carries any region (`scopeCode > 0`).
+ * Meshtastic messages carry no scope and therefore never match.
+ */
+export const MESHCORE_SCOPE_MODES = ['named', 'unscoped', 'scoped'] as const;
+export type MeshCoreScopeMode = (typeof MESHCORE_SCOPE_MODES)[number];
 
 // ─── Variable types (canonical home; repository re-exports these) ─────────────
 
@@ -330,6 +345,18 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
             errors.push(`${n.type} "${n.id}" requires params.variable`);
           }
           break;
+        case 'condition.meshcoreScope': {
+          const mode = p.mode == null ? 'named' : p.mode;
+          if (!MESHCORE_SCOPE_MODES.includes(mode as MeshCoreScopeMode)) {
+            errors.push(`condition.meshcoreScope "${n.id}" requires params.mode ∈ {named,unscoped,scoped}`);
+          } else if (mode === 'named') {
+            const hasRegions = typeof p.regions === 'string' && p.regions.trim().length > 0;
+            if (!hasRegions && p.includeUnscoped !== true) {
+              errors.push(`condition.meshcoreScope "${n.id}" (named) requires params.regions or params.includeUnscoped`);
+            }
+          }
+          break;
+        }
         case 'action.runScript':
           if (typeof p.scriptPath !== 'string' || p.scriptPath.length === 0) {
             errors.push(`action.runScript "${n.id}" requires params.scriptPath`);


### PR DESCRIPTION
## Summary
Implements the #3914 request: answer a MeshCore message based on its channel **scope** — e.g. nudge newbies who post **unscoped** or on a very broad region (like `de`) toward better node config. Adds a first-class `condition.meshcoreScope` block so this is a single, friendly condition rather than a hand-wired chain. Also adds a general **self-origin guard** to the Automation Engine so our own traffic never triggers rules (most importantly, so an auto-reply can't re-trigger itself in an infinite mesh loop).

## Changes
- **New `condition.meshcoreScope` block** (`src/types/automation.ts`, `conditionEvaluator.ts`, builder `catalog.ts`):
  - `mode ∈ {named, unscoped, scoped}`. `named` takes a comma-separated `regions` list plus an optional **"also match unscoped"** toggle → expresses *"region de OR unscoped"* in one block.
  - Reads the inbound `scopeCode`/`scopeName` already exposed by `buildMeshCoreMessageContext` (#3833). Meshtastic messages carry no scope and therefore never match (degrades gracefully). The reply half already works via `action.sendMessage` `scopeMode: 'trigger'`.
  - Graph validation: `named` requires `regions` or `includeUnscoped`; unknown modes rejected.
  - MeshCore scope tokens (`scopeName`/`scopeCode`/`scoped`/`fromName`) documented in the Substitutions drawer + typo-checker.
- **Self-origin guard** (`automationEngineService.ts`, `engineContext.ts`, `meshNodeData.ts`):
  - Drops events from our OWN node before any rule runs: message `fromNodeNum` (Meshtastic) / `fromPublicKey` (MeshCore, case-insensitive) == the source's local node, plus our own telemetry and node-updates.
  - Prevents `action.sendMessage` replies (which re-enter the bus via `emitNewMessage`/`emitMeshCoreMessage`) from re-triggering their own rule, and stops our own periodic telemetry/node-info from spuriously firing rules.
  - Identity resolved per-source/protocol via optional `NodeDataProvider.getLocalNodeNum`/`getSelfPublicKey` (real impls read the Meshtastic + MeshCore manager registries; absent in unit tests → no drop). Geofence checks intentionally exempt. Mirrors the legacy MeshCore auto-responder self-reply guard.

## Issues Resolved
Fixes #3914

## Documentation Updates
- `docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md` — added `condition.meshcoreScope` to the block catalog and the self-origin guard to the engine safety rails.

## Testing
- [x] Unit tests pass (full suite: 7933 passed / 0 failed, `success: true`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Condition: unscoped / scoped / named (+ includeUnscoped incl. the "de OR unscoped" case) / Meshtastic non-match
- [x] Graph validation of the new block (valid modes; empty `named` rejected)
- [x] Engine self-exclusion: Meshtastic message, MeshCore message (case-insensitive key), telemetry
- [ ] Manual: in the builder, add a MeshCore source rule → *When a message is received → If MeshCore message scope (named: de, also match unscoped) → Send a message (scope: match the triggering message's scope)* and confirm unscoped/de senders get a reply while other regions don't, and the reply doesn't loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)