### PR TITLE
fix(map): show direct-heard SNR in node hover tooltip (#3925)

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -16,7 +16,7 @@ import MapLegend from './MapLegend';
 import { formatTime, formatDateTime } from '../utils/datetime';
 import { getDistanceToNode, calculateDistance, formatDistance } from '../utils/distance';
 import { getTilesetById } from '../config/tilesets';
-import { getEffectiveHops } from '../utils/nodeHops';
+import { getEffectiveHops, getMapHoverTooltipMeta } from '../utils/nodeHops';
 import { buildNodeExportRows, nodesToCsv, nodesToHtml, downloadTextFile } from '../utils/nodeExport';
 import { useMapContext } from '../contexts/MapContext';
 import { useTelemetryNodes, useDeviceConfig, useNodes } from '../hooks/useServerData';
@@ -2284,11 +2284,20 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       </div>
                       {(() => {
                         const tooltipHops = getEffectiveHops(node, nodeHopsCalculation, traceroutes, currentNodeNum);
-                        return tooltipHops < 999 ? (
+                        const { hops, showSnr, snr } = getMapHoverTooltipMeta(tooltipHops, node.snr);
+                        if (hops === null && !showSnr) return null;
+                        return (
                           <div style={{ fontSize: '0.85em', opacity: 0.8 }}>
-                            {tooltipHops} hop{tooltipHops !== 1 ? 's' : ''}
+                            {hops !== null && (
+                              <span>{hops} hop{hops !== 1 ? 's' : ''}</span>
+                            )}
+                            {showSnr && (
+                              <span>
+                                {hops !== null ? ' · ' : ''}📶 {snr!.toFixed(1)}dB
+                              </span>
+                            )}
                           </div>
-                        ) : null;
+                        );
                       })()}
                     </div>
                   </Tooltip>

--- a/src/utils/nodeHops.test.ts
+++ b/src/utils/nodeHops.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { getMapHoverTooltipMeta } from './nodeHops';
+
+describe('getMapHoverTooltipMeta (issue #3925)', () => {
+  it('shows SNR when heard directly (0 hops) and SNR is known', () => {
+    const meta = getMapHoverTooltipMeta(0, -8.5);
+    expect(meta).toEqual({ hops: 0, showSnr: true, snr: -8.5 });
+  });
+
+  it('shows SNR for an SNR value of 0 (falsy but valid)', () => {
+    const meta = getMapHoverTooltipMeta(0, 0);
+    expect(meta).toEqual({ hops: 0, showSnr: true, snr: 0 });
+  });
+
+  it('does not show SNR when heard directly but SNR is null', () => {
+    const meta = getMapHoverTooltipMeta(0, null);
+    expect(meta).toEqual({ hops: 0, showSnr: false, snr: null });
+  });
+
+  it('does not show SNR when heard directly but SNR is undefined', () => {
+    const meta = getMapHoverTooltipMeta(0, undefined);
+    expect(meta).toEqual({ hops: 0, showSnr: false, snr: null });
+  });
+
+  it('does not show SNR for multi-hop nodes even when SNR is present', () => {
+    const meta = getMapHoverTooltipMeta(2, -12);
+    expect(meta).toEqual({ hops: 2, showSnr: false, snr: null });
+  });
+
+  it('reports unknown hops (>= 999) as null and hides SNR', () => {
+    const meta = getMapHoverTooltipMeta(999, -5);
+    expect(meta).toEqual({ hops: null, showSnr: false, snr: null });
+  });
+
+  it('preserves a known multi-hop count', () => {
+    const meta = getMapHoverTooltipMeta(3, undefined);
+    expect(meta).toEqual({ hops: 3, showSnr: false, snr: null });
+  });
+});

--- a/src/utils/nodeHops.ts
+++ b/src/utils/nodeHops.ts
@@ -75,3 +75,32 @@ export function getEffectiveHops(
       return node.hopsAway ?? 999;
   }
 }
+
+/**
+ * Metadata for the map node-circle hover tooltip's hop/SNR line.
+ *
+ * SNR is only meaningful (and only shown) when the node was heard directly
+ * (0 effective hops) and an SNR value is known. This mirrors the Nodes list
+ * card view and the position-history point tooltip (issue #3590 / #3925).
+ */
+export interface MapHoverTooltipMeta {
+  /** Effective hop count, or null when unknown (>= 999). */
+  hops: number | null;
+  /** Whether to render the direct-heard SNR value. */
+  showSnr: boolean;
+  /** The SNR value to render (dB), or null when it should not be shown. */
+  snr: number | null;
+}
+
+/**
+ * Compute what the map node-circle hover tooltip should display for the
+ * hop/SNR line, given the effective hop count and the node's SNR.
+ */
+export function getMapHoverTooltipMeta(
+  effectiveHops: number,
+  snr: number | null | undefined
+): MapHoverTooltipMeta {
+  const hops = effectiveHops < 999 ? effectiveHops : null;
+  const showSnr = effectiveHops === 0 && snr != null;
+  return { hops, showSnr, snr: showSnr ? snr! : null };
+}


### PR DESCRIPTION
## Summary

Fixes #3925. The map node-circle **hover tooltip** never displayed SNR, even when a node was heard directly (0 hops) and an SNR value was available. It only showed the node name and hop count.

This was a different code path from the position-history point tooltip (fixed in #3590) and inconsistent with the Nodes list card view, which both already show direct-heard SNR.

## Changes

- **`src/utils/nodeHops.ts`** — new pure helper `getMapHoverTooltipMeta(effectiveHops, snr)` returning `{ hops, showSnr, snr }`. SNR is shown only when `effectiveHops === 0 && snr != null`, mirroring the Nodes card view and the position-history tooltip.
- **`src/components/NodesTab.tsx`** — the map marker hover `<Tooltip>` now uses the helper and renders a `N hops · 📶 X.XdB` line for directly-heard nodes with known SNR. Unknown-hop nodes with no SNR still render nothing (unchanged behavior).
- **`src/utils/nodeHops.test.ts`** — new unit tests for the helper: 0 hops with SNR, SNR of exactly 0, null/undefined SNR, multi-hop (SNR hidden), and unknown hops.

## Behavior

| Node state | Before | After |
|---|---|---|
| 0 hops, SNR known | `0 hops` | `0 hops · 📶 X.XdB` |
| 0 hops, SNR null | `0 hops` | `0 hops` |
| N hops (>0) | `N hops` | `N hops` (unchanged) |
| unknown hops, no SNR | (nothing) | (nothing) |

## Testing

- New `nodeHops.test.ts`: 7 tests, all pass.
- Full Vitest suite: **7948 passed, 0 failed, 0 suite failures** (8570 total including skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n