### PR TITLE
fix(meshcore): scale repeater last_snr by /4 (quarter-dB) (#3955)

### DIFF
--- a/src/server/meshcoreNativeBackend.statusSerialization.test.ts
+++ b/src/server/meshcoreNativeBackend.statusSerialization.test.ts
@@ -193,6 +193,36 @@ describe('MeshCoreNativeBackend get_status serialization (#3815)', () => {
     expect(r2.data?.bat_mv).toBe(3700);
   });
 
+  it('scales last_snr by /4 (quarter-dB) while leaving last_rssi raw (#3955)', async () => {
+    const backend = await makeBackend();
+    const conn = ref.current!;
+
+    const p1 = backend.sendCommand('get_status', { public_key: KEY_A });
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Raw register value from the vendored parser: 47 quarter-dB => 11.75 dB.
+    conn.pending[0].resolve({ last_snr: 47, last_rssi: -95 });
+    const r1 = await p1;
+
+    expect(r1.success).toBe(true);
+    expect(r1.data?.last_snr).toBeCloseTo(11.75, 5);
+    // RSSI is not quarter-dB scaled; it passes through unchanged.
+    expect(r1.data?.last_rssi).toBe(-95);
+  });
+
+  it('leaves last_snr undefined when the firmware omits it (#3955)', async () => {
+    const backend = await makeBackend();
+    const conn = ref.current!;
+
+    const p1 = backend.sendCommand('get_status', { public_key: KEY_A });
+    await new Promise((r) => setTimeout(r, 5));
+    conn.pending[0].resolve({ batt_milli_volts: 4100 });
+    const r1 = await p1;
+
+    expect(r1.success).toBe(true);
+    expect(r1.data?.last_snr).toBeUndefined();
+  });
+
   it('clears the in-flight entry after settle so a later request for the same key issues a fresh call', async () => {
     const backend = await makeBackend();
     const conn = ref.current!;

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1469,7 +1469,12 @@ export class MeshCoreNativeBackend extends EventEmitter {
           queue_len: stats?.curr_tx_queue_len,
           noise_floor: stats?.noise_floor,
           last_rssi: stats?.last_rssi,
-          last_snr: stats?.last_snr,
+          // MeshCore reports SNR in quarter-dB units (raw register / 4 = true dB).
+          // The vendored meshcore.js repeater status parser reads `last_snr` as a
+          // raw int16 WITHOUT the /4 that every other SNR field in that file applies,
+          // so scale it here to match the Companion app. RSSI is not quarter-dB
+          // scaled, which is why `last_rssi` stays raw. (#3955)
+          last_snr: typeof stats?.last_snr === 'number' ? stats.last_snr / 4 : undefined,
           packets_recv: stats?.n_packets_recv,
           packets_sent: stats?.n_packets_sent,
           air_time_secs: stats?.total_air_time_secs,


### PR DESCRIPTION
## Summary

Fixes #3955 — MeshCore repeater **"Last SNR"** was displayed ~4x too high (e.g. 48 dB where the MeshCore app showed 11.8 dB).

MeshCore's radio reports SNR as a **quarter-dB register** (raw register / 4 = true dB). Every SNR read in the vendored `@liamcottle/meshcore.js` applies `/ 4` — *except* the repeater status-response parser, which reads `last_snr` as a raw `int16`. That unscaled value flowed through unchanged.

## Fix

Applied the `/ 4` scaling at the **native-backend `get_status` boundary** (`meshcoreNativeBackend.ts`), where the raw library value first enters MeshMonitor's normalized status object. This is a single point that corrects **all** downstream consumers:

- `requestNodeStatus` → `MeshCoreRemoteStatsPanel` (remote stats display)
- remote telemetry scheduler → `mc_status_last_snr` → `TelemetryChart` / Node Details gauge

RSSI is **not** quarter-dB scaled, so `last_rssi` deliberately passes through raw (which is why RSSI matched while SNR was 4x off).

## Tests

Added regression tests to `meshcoreNativeBackend.statusSerialization.test.ts`:
- `last_snr: 47` (raw register) → `11.75 dB`, while `last_rssi: -95` passes through unchanged.
- An omitted `last_snr` stays `undefined` (not coerced to 0).

All affected suites green (backend status, remote telemetry scheduler, telemetry poller, TelemetryChart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub