### PR TITLE
fix(meshcore): set repeater clock to real time on "clock sync" (#3954)

### DIFF
--- a/src/server/meshcoreManager.clockSync.test.ts
+++ b/src/server/meshcoreManager.clockSync.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the `clock sync` → `time <epoch>` rewrite and the periodic
+ * local-node RTC sync (issue #3954).
+ *
+ * MeshCore firmware's `clock sync` verb sets the RTC to the *sender_timestamp*
+ * of the incoming command frame, which is 0 over the local serial CLI (always
+ * rejected) and the sending node's own drifted clock over remote-admin. We
+ * rewrite it to the absolute `time <epoch>` verb stamped with the server clock
+ * so the target's RTC is set to real current time on both transports.
+ *
+ * Pattern follows meshcoreManager.localCli.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const TIME_CMD = /^time (\d+)$/;
+
+describe('clock sync rewrite (#3954)', () => {
+  describe('rewriteClockSync helper', () => {
+    it('rewrites `clock sync` to `time <server epoch>`', () => {
+      const m = new MeshCoreManager('test-source');
+      const before = Math.floor(Date.now() / 1000);
+      const out = (m as any).rewriteClockSync('clock sync') as string;
+      const after = Math.floor(Date.now() / 1000);
+
+      const match = out.match(TIME_CMD);
+      expect(match).not.toBeNull();
+      const epoch = Number(match![1]);
+      expect(epoch).toBeGreaterThanOrEqual(before);
+      expect(epoch).toBeLessThanOrEqual(after);
+    });
+
+    it('is case-insensitive and tolerates surrounding whitespace', () => {
+      const m = new MeshCoreManager('test-source');
+      expect((m as any).rewriteClockSync('CLOCK SYNC')).toMatch(TIME_CMD);
+      expect((m as any).rewriteClockSync('  clock sync  ')).toMatch(TIME_CMD);
+    });
+
+    it('leaves every other command untouched', () => {
+      const m = new MeshCoreManager('test-source');
+      for (const cmd of ['clock', 'stats', 'ver', 'clock synchronize', 'time 123', 'reboot']) {
+        expect((m as any).rewriteClockSync(cmd)).toBe(cmd);
+      }
+    });
+  });
+
+  describe('sendLocalCliCommand (Repeater serial path)', () => {
+    function makeRepeaterManager() {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.REPEATER;
+      (m as any).connected = true;
+      const repeaterCalls: string[] = [];
+      (m as any).sendRepeaterCommand = async (cmd: string) => {
+        repeaterCalls.push(cmd);
+        return 'OK - clock set: 13:11 - 6/7/2026 UTC';
+      };
+      return { manager: m, repeaterCalls };
+    }
+
+    it('sends `time <epoch>` to the serial CLI instead of `clock sync`', async () => {
+      const { manager, repeaterCalls } = makeRepeaterManager();
+      const before = Math.floor(Date.now() / 1000);
+      await manager.sendLocalCliCommand('clock sync');
+      const after = Math.floor(Date.now() / 1000);
+
+      expect(repeaterCalls).toHaveLength(1);
+      const match = repeaterCalls[0].match(TIME_CMD);
+      expect(match).not.toBeNull();
+      const epoch = Number(match![1]);
+      expect(epoch).toBeGreaterThanOrEqual(before);
+      expect(epoch).toBeLessThanOrEqual(after);
+    });
+
+    it('forwards non-clock commands verbatim (regression)', async () => {
+      const { manager, repeaterCalls } = makeRepeaterManager();
+      await manager.sendLocalCliCommand('stats');
+      expect(repeaterCalls).toEqual(['stats']);
+    });
+  });
+
+  describe('sendCliCommand (remote-admin path)', () => {
+    it('emits `time <epoch>` in the send_cli frame for `clock sync`', async () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+      (m as any).connected = true;
+
+      const pubkey = 'a'.repeat(64);
+      const sentTexts: string[] = [];
+
+      // sendWithDefaultScope just runs the thunk in these tests.
+      (m as any).sendWithDefaultScope = (fn: () => Promise<unknown>) => fn();
+      (m as any).sendBridgeCommand = async (cmd: string, params: any) => {
+        if (cmd === 'send_cli') {
+          sentTexts.push(params.text);
+          // The firmware reply arrives asynchronously via cli_reply; simulate
+          // it by resolving the pending entry the manager just registered.
+          const prefixKey = pubkey.substring(0, 12);
+          const pending = (m as any).pendingCliReplies.get(prefixKey);
+          if (pending) {
+            clearTimeout(pending.timer);
+            pending.resolve('OK - clock set: 13:11 - 6/7/2026 UTC');
+          }
+          return { id: '1', success: true };
+        }
+        return { id: '1', success: false, error: `no stub for ${cmd}` };
+      };
+
+      const before = Math.floor(Date.now() / 1000);
+      const result = await m.sendCliCommand(pubkey, 'clock sync');
+      const after = Math.floor(Date.now() / 1000);
+
+      expect(sentTexts).toHaveLength(1);
+      const match = sentTexts[0].match(TIME_CMD);
+      expect(match).not.toBeNull();
+      const epoch = Number(match![1]);
+      expect(epoch).toBeGreaterThanOrEqual(before);
+      expect(epoch).toBeLessThanOrEqual(after);
+      expect(result.reply).toContain('clock set');
+    });
+  });
+
+  describe('startDeviceTimeSync (periodic local RTC sync)', () => {
+    it('syncs immediately on start for a Companion', () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+      const syncSpy = vi.fn().mockResolvedValue({ ok: true });
+      (m as any).syncDeviceTime = syncSpy;
+
+      (m as any).startDeviceTimeSync();
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+
+      (m as any).stopDeviceTimeSync();
+      expect((m as any).deviceTimeSyncTimer).toBeNull();
+    });
+
+    it('is a no-op for non-Companion device types', () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.REPEATER;
+      const syncSpy = vi.fn().mockResolvedValue({ ok: true });
+      (m as any).syncDeviceTime = syncSpy;
+
+      (m as any).startDeviceTimeSync();
+      expect(syncSpy).not.toHaveBeenCalled();
+      expect((m as any).deviceTimeSyncTimer).toBeNull();
+    });
+
+    it('re-arms the single timer rather than stacking on repeat calls', () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+      (m as any).syncDeviceTime = vi.fn().mockResolvedValue({ ok: true });
+
+      (m as any).startDeviceTimeSync();
+      const firstTimer = (m as any).deviceTimeSyncTimer;
+      (m as any).startDeviceTimeSync();
+      const secondTimer = (m as any).deviceTimeSyncTimer;
+
+      expect(firstTimer).not.toBe(secondTimer);
+      expect(secondTimer).not.toBeNull();
+      (m as any).stopDeviceTimeSync();
+    });
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});

--- a/src/server/meshcoreManager.clockSync.test.ts
+++ b/src/server/meshcoreManager.clockSync.test.ts
@@ -16,6 +16,10 @@ import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
 const TIME_CMD = /^time (\d+)$/;
 
 describe('clock sync rewrite (#3954)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('rewriteClockSync helper', () => {
     it('rewrites `clock sync` to `time <server epoch>`', () => {
       const m = new MeshCoreManager('test-source');
@@ -45,9 +49,9 @@ describe('clock sync rewrite (#3954)', () => {
   });
 
   describe('sendLocalCliCommand (Repeater serial path)', () => {
-    function makeRepeaterManager() {
+    function makeRepeaterManager(deviceType: MeshCoreDeviceType = MeshCoreDeviceType.REPEATER) {
       const m = new MeshCoreManager('test-source');
-      (m as any).deviceType = MeshCoreDeviceType.REPEATER;
+      (m as any).deviceType = deviceType;
       (m as any).connected = true;
       const repeaterCalls: string[] = [];
       (m as any).sendRepeaterCommand = async (cmd: string) => {
@@ -75,6 +79,13 @@ describe('clock sync rewrite (#3954)', () => {
       const { manager, repeaterCalls } = makeRepeaterManager();
       await manager.sendLocalCliCommand('stats');
       expect(repeaterCalls).toEqual(['stats']);
+    });
+
+    it('also rewrites for Room Server (same firmware family)', async () => {
+      const { manager, repeaterCalls } = makeRepeaterManager(MeshCoreDeviceType.ROOM_SERVER);
+      await manager.sendLocalCliCommand('clock sync');
+      expect(repeaterCalls).toHaveLength(1);
+      expect(repeaterCalls[0]).toMatch(TIME_CMD);
     });
   });
 
@@ -159,8 +170,4 @@ describe('clock sync rewrite (#3954)', () => {
       (m as any).stopDeviceTimeSync();
     });
   });
-});
-
-beforeEach(() => {
-  vi.clearAllMocks();
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -583,6 +583,15 @@ class MeshCoreManager extends EventEmitter {
    *  the window — purely for logging; the refresh fetches everything. */
   private pathRefreshTimer: NodeJS.Timeout | null = null;
   private pathRefreshPendingKeys: Set<string> = new Set();
+  /**
+   * Keeps the local Companion node's RTC honest. MeshCore stamps every
+   * outbound frame (adverts, DMs, and crucially remote-admin `clock sync`
+   * commands) with the local node's own clock; if that clock is never set it
+   * drifts and poisons those timestamps (issue #3954). We push the server's
+   * wall clock on connect and then periodically for the life of the session.
+   */
+  private deviceTimeSyncTimer: NodeJS.Timeout | null = null;
+  private static readonly DEVICE_TIME_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
   private heartbeatLastSuccessAt: number | null = null;
   private heartbeatProbeInFlight: boolean = false;
   private reconnectAttempts: number = 0;
@@ -872,6 +881,10 @@ class MeshCoreManager extends EventEmitter {
         this.startHeartbeat();
       }
 
+      // Keep the local Companion RTC synced to the server clock so outbound
+      // frame timestamps (incl. remote-admin `clock sync`) are accurate (#3954).
+      this.startDeviceTimeSync();
+
       // Start the Virtual Node server (opt-in) now that the local node identity
       // is known — the server synthesizes SelfInfo from it. Non-fatal on error.
       await this.startVirtualNodeServer();
@@ -1001,6 +1014,9 @@ class MeshCoreManager extends EventEmitter {
     // Cancel any pending path-refresh — refreshContacts() against a torn-
     // down connection would just log an error.
     this.clearPathRefreshTimer();
+
+    // Stop the periodic local-node RTC sync (#3954).
+    this.stopDeviceTimeSync();
 
     // Stop auto-pathfinding scheduler.
     this.stopAutoPathfinding();
@@ -3454,6 +3470,36 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Push the server clock to the local Companion RTC now, then keep it fresh on
+   * a slow interval for the life of the connection (issue #3954). Companion-only
+   * and best-effort: a device that rejects `set_device_time` (or isn't a
+   * Companion) is simply left alone. Safe to call repeatedly — it re-arms the
+   * single timer rather than stacking them.
+   */
+  private startDeviceTimeSync(): void {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return;
+    this.stopDeviceTimeSync();
+
+    const syncOnce = () => {
+      void this.syncDeviceTime().then((result) => {
+        if (!result.ok && result.reason === 'command-failed') {
+          logger.debug(`[MeshCore:${this.sourceId}] Periodic device-time sync failed: ${result.error}`);
+        }
+      });
+    };
+
+    syncOnce();
+    this.deviceTimeSyncTimer = setInterval(syncOnce, MeshCoreManager.DEVICE_TIME_SYNC_INTERVAL_MS);
+  }
+
+  private stopDeviceTimeSync(): void {
+    if (this.deviceTimeSyncTimer !== null) {
+      clearInterval(this.deviceTimeSyncTimer);
+      this.deviceTimeSyncTimer = null;
+    }
+  }
+
+  /**
    * Query the neighbour list from a remote repeater node. Returns an array
    * of neighbour entries with pubkey prefix, last-heard age, and SNR.
    * Requires firmware v1.9.0+ on the target repeater.
@@ -3920,6 +3966,33 @@ class MeshCoreManager extends EventEmitter {
   private cliCommandLocks: Map<string, Promise<unknown>> = new Map();
 
   /**
+   * Rewrite the firmware `clock sync` CLI verb into the absolute
+   * `time <epoch>` verb, stamped with the server's authoritative wall clock
+   * at send time (issue #3954).
+   *
+   * MeshCore's `clock sync` (CommonCLI.cpp) sets the RTC to the
+   * *sender_timestamp* of the incoming command frame — NOT to any live clock:
+   *   - over the local serial CLI the firmware hard-codes sender_timestamp=0
+   *     (the local-access marker), so `clock sync` is ALWAYS rejected with
+   *     "clock cannot go backwards" and the RTC never moves;
+   *   - over remote-admin (CliData DM) it uses the *sending* node's RTC, which
+   *     MeshMonitor's local companion never keeps synced, so the target
+   *     inherits our drift (the reported "~22 minutes behind").
+   *
+   * The `time <epoch>` verb instead sets the RTC directly from the epoch in the
+   * command text (independent of sender_timestamp), so it works over BOTH
+   * transports and reflects real current time. The firmware still enforces its
+   * own "can't go backwards" guard (secs > curr) — identical to `clock sync` —
+   * so this is not a behavioural regression, only a correct time source.
+   */
+  private rewriteClockSync(command: string): string {
+    if (command.trim().toLowerCase() === 'clock sync') {
+      return `time ${Math.floor(Date.now() / 1000)}`;
+    }
+    return command;
+  }
+
+  /**
    * Send a CLI command to a remote MeshCore node and await its reply.
    *
    * The command is sent as an encrypted DM with txtType=CliData; the remote
@@ -3950,7 +4023,7 @@ class MeshCoreManager extends EventEmitter {
     if (!/^[0-9a-f]{64}$/.test(normalizedKey)) {
       throw new Error('publicKey must be a 64-char hex string');
     }
-    const trimmed = command.trim();
+    const trimmed = this.rewriteClockSync(command.trim());
     if (trimmed.length === 0) {
       throw new Error('CLI command must be non-empty');
     }
@@ -4069,7 +4142,10 @@ class MeshCoreManager extends EventEmitter {
     const timeoutMs = opts.timeoutMs ?? 10_000;
 
     if (this.deviceType === MeshCoreDeviceType.REPEATER || this.deviceType === MeshCoreDeviceType.ROOM_SERVER) {
-      const reply = await this.sendRepeaterCommand(trimmed, timeoutMs);
+      // `clock sync` over the direct serial CLI is a firmware no-op
+      // (sender_timestamp=0 → "clock cannot go backwards"); rewrite it to the
+      // absolute `time <epoch>` verb so the RTC actually gets set (#3954).
+      const reply = await this.sendRepeaterCommand(this.rewriteClockSync(trimmed), timeoutMs);
       return { reply, elapsedMs: Date.now() - sentAt };
     }
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -883,6 +883,7 @@ class MeshCoreManager extends EventEmitter {
 
       // Keep the local Companion RTC synced to the server clock so outbound
       // frame timestamps (incl. remote-admin `clock sync`) are accurate (#3954).
+      // Safe to call for any device type — it no-ops for non-Companion.
       this.startDeviceTimeSync();
 
       // Start the Virtual Node server (opt-in) now that the local node identity


### PR DESCRIPTION
## Summary

Fixes #3954 — MeshCore `clock sync` sets the target's clock to a stale time (or, over serial, does nothing at all).

## Root cause (from the firmware)

MeshCore's `clock sync` CLI verb (`CommonCLI.cpp`) sets the RTC to the **`sender_timestamp` of the incoming command frame**, not to any live clock:

```cpp
} else if (memcmp(command, "clock sync", 10) == 0) {
  uint32_t curr = getRTCClock()->getCurrentTime();
  if (sender_timestamp > curr) {
    getRTCClock()->setCurrentTime(sender_timestamp + 1);   // uses the FRAME timestamp
  } else {
    strcpy(reply, "ERR: clock cannot go backwards");
  }
}
```

That `sender_timestamp` differs by transport, and neither path carries the real current time:

- **Direct serial CLI:** firmware hard-codes `sender_timestamp = 0` (the local-access marker that unlocks privileged verbs), so `0 > curr` is always false → `clock sync` is **always rejected** over a USB-wired repeater. It can never work through MeshMonitor's serial path.
- **Remote-admin (`CliData` DM):** `sender_timestamp` is stamped by **MeshMonitor's local Companion node's own RTC** when it builds the packet. MeshMonitor never kept that node's clock synced, so it drifts — hence the reported "~22 minutes behind." The official phone app pushes the phone's time into the companion on connect, so its stamp is accurate.

## Fix

1. **Rewrite `clock sync` → `time <epoch>`.** The firmware's `time <epoch>` verb sets the RTC directly from the epoch in the command text (independent of `sender_timestamp`). We rewrite the command at both CLI chokepoints (`sendCliCommand` for remote-admin and the repeater branch of `sendLocalCliCommand` for serial), stamping the server's authoritative wall clock at send time. This works over **both** transports and reflects real current time. The firmware's own "can't go backwards" guard (`secs > curr`) is unchanged, so it's not a behavioural regression — just a correct time source. (Manually-typed `clock sync` benefits too.)
2. **Keep the local Companion RTC honest.** Proactively push the server clock to the local node's RTC on connect and periodically (every 6h), so *all* outbound frame timestamps — adverts, DMs, and any `clock sync` — are accurate, not just this command.

## Tests

New `meshcoreManager.clockSync.test.ts`:
- rewrite helper (both transports, case-insensitivity/whitespace, passthrough of every other command)
- `time <epoch>` actually reaches the serial CLI and the `send_cli` frame
- periodic-sync lifecycle (immediate sync on start, Companion-only guard, single-timer re-arm)

Full Vitest suite green (8026 passed, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n
