### PR TITLE
feat(meshcore-vn): forward SendSelfAdvert from the app to the physical node (#3904)

### DIFF
--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -68,6 +68,7 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   setCoordsMock = vi.fn().mockResolvedValue(true);
   setChannelMock = vi.fn().mockResolvedValue(undefined);
   setOtherParamsMock = vi.fn().mockResolvedValue(true);
+  sendAdvertMock = vi.fn().mockResolvedValue(true);
   isConnected() { return this.localNode !== null; }
   getLocalNode() { return this.localNode; }
   getContacts() { return this.contacts; }
@@ -95,6 +96,7 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   }) {
     return this.setOtherParamsMock(params) as Promise<boolean>;
   }
+  sendAdvert() { return this.sendAdvertMock() as Promise<boolean>; }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
 }
@@ -599,5 +601,61 @@ describe('MeshCoreVirtualNodeServer — config-command forwarding (#3904)', () =
     expect(res[0]).toBe(ResponseCodes.Err);
     expect(res[1]).toBe(ErrorCodes.IllegalArg);
     expect(manager.setRadioMock).not.toHaveBeenCalled();
+  });
+});
+
+// SendSelfAdvert(7) is a normal broadcast operation (like messaging), NOT an
+// admin/config mutation — a real node accepts it unconditionally, so the VN
+// forwards it regardless of allowAdminCommands (issue #3904 follow-up: the app
+// reported "Adverts to sending" failing with Err(UnsupportedCmd)).
+describe('MeshCoreVirtualNodeServer — SendSelfAdvert forwarding (#3904)', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let client: TestClient;
+  let manager: FakeManager;
+
+  async function startWith(allowAdminCommands: boolean): Promise<void> {
+    manager = new FakeManager();
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, allowAdminCommands, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+  }
+
+  afterEach(async () => {
+    client?.close();
+    await server?.stop();
+  });
+
+  // [code, type] — type 1 = flood; the manager always floods so the byte is ignored.
+  const advertFrame: number[] = [CommandCodes.SendSelfAdvert, 1];
+
+  it('forwards SendSelfAdvert to manager.sendAdvert and replies Ok', async () => {
+    await startWith(true);
+    const res = await client.request(advertFrame);
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    expect(manager.sendAdvertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards SendSelfAdvert even when allowAdminCommands is off (not an admin op)', async () => {
+    await startWith(false);
+    const res = await client.request(advertFrame);
+    expect(res[0]).toBe(ResponseCodes.Ok);
+    expect(manager.sendAdvertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('replies Err(BadState) when the node fails to send the advert', async () => {
+    await startWith(true);
+    manager.sendAdvertMock.mockResolvedValueOnce(false);
+    const res = await client.request(advertFrame);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.BadState);
+  });
+
+  it('replies Err(BadState) when manager.sendAdvert throws', async () => {
+    await startWith(true);
+    manager.sendAdvertMock.mockRejectedValueOnce(new Error('radio busy'));
+    const res = await client.request(advertFrame);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.BadState);
   });
 });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -79,6 +79,8 @@ export interface MeshCoreVirtualNodeManager {
     telemetryModeEnv: number;
     advLocPolicy: number;
   }): Promise<boolean>;
+  /** Broadcast a self-advertisement from the physical node (flood). */
+  sendAdvert(): Promise<boolean>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -380,6 +382,14 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
           // treating an Err as a fatal handshake failure). Phase 3 forwards it.
           this.send(clientId, encodeOk());
           break;
+        case CommandCodes.SendSelfAdvert:
+          // Broadcasting a self-advert is a normal (non-admin) operation on a
+          // real node — like sending a message — so it is NOT gated on
+          // allowAdminCommands (issue #3904 follow-up). Forward to the physical
+          // node and ack; the flood type byte in the payload is ignored since
+          // the manager always floods.
+          void this.handleSendSelfAdvert(clientId);
+          break;
         // Config-mutating commands (issue #3904): forwarded to the real node
         // only when `allowAdminCommands` is enabled; otherwise the app gets an
         // explicit Err (UnsupportedCmd) instead of a silent hang.
@@ -479,6 +489,29 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       this.send(clientId, encodeOk());
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} failed: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.BadState));
+    }
+  }
+
+  /**
+   * SendSelfAdvert(7): broadcast a self-advertisement from the physical node.
+   * Unlike the config setters this is a normal, non-admin operation (a real
+   * node accepts it unconditionally), so it is not gated on
+   * `allowAdminCommands`. Replies Ok when the node accepted the advert,
+   * Err(BadState) if the manager reported failure or threw (issue #3904).
+   */
+  private async handleSendSelfAdvert(clientId: string): Promise<void> {
+    try {
+      const ok = await this.options.manager.sendAdvert();
+      if (!ok) {
+        logger.warn(`[MeshCore VN ${this.sourceId}] SendSelfAdvert from ${clientId} not sent by node`);
+        this.send(clientId, encodeErr(ErrorCodes.BadState));
+        return;
+      }
+      logger.info(`[MeshCore VN ${this.sourceId}] SendSelfAdvert from ${clientId} forwarded to node`);
+      this.send(clientId, encodeOk());
+    } catch (err) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] SendSelfAdvert from ${clientId} failed: ${(err as Error).message}`);
       this.send(clientId, encodeErr(ErrorCodes.BadState));
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #3904. The reporter confirmed the config/settings commands are fixed but flagged that a few app-initiated actions still fail — one of them being **sending an advert** from the app. This PR fixes that one.

`MeshCore` app command `SendSelfAdvert` (code 7) fell through to `dispatchCommand()`'s `default:` branch and got `Err(UnsupportedCmd)`, so an advert triggered from the connected app never went out.

## Change

Add a `SendSelfAdvert` case that forwards to `manager.sendAdvert()` and acks:
- **Not gated on `allowAdminCommands`** — broadcasting a self-advert is a normal, non-admin operation (a real node accepts it unconditionally, same tier as sending a message, which is also ungated). Gating it would diverge from real-node behavior.
- Acks `Ok` on success, `Err(BadState)` when the node reports failure or the manager throws. The flood-type byte in the payload is ignored (the manager always floods, carrying the default scope per #3667).

Adds `sendAdvert()` to the `MeshCoreVirtualNodeManager` interface + 4 tests (forwards & acks Ok, forwards even with admin off, Err(BadState) on false and on throw). Full VN-server suite: 40 passed.

## Explicitly out of scope

The reporter's other three items — **`SendLogin`, `SendTracePath`, `SendTelemetryReq`** — are *not* in this PR. Unlike advert (fire-and-ack) and the config setters (set-and-ack), these are remote **transactions**: a real node replies with an immediate `Sent`/`Ok` and then delivers the actual result asynchronously as a **push frame** (login-result, telemetry-response, trace-result) that the app correlates by pubkey prefix. Forwarding them correctly means synthesizing and relaying those push frames back to the connected app — a larger, separate piece of work (and `SendTracePath`'s `tag/auth/path` payload doesn't map cleanly onto the existing pubkey-keyed `traceContactPath`). Tracked for a dedicated follow-up.

Fixes the advert portion of #3904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n
