### PR TITLE
fix(meshcore-vn): bridge raw RX feed to apps as LogRxData(0x88) push (#3963)

### DIFF
--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -23,7 +23,9 @@ import {
   encodeChannelMsgRecv,
   encodeSent,
   encodeSendConfirmed,
+  encodeLogRxData,
   encodeNoMoreMessages,
+  PushCodes,
   packTelemetryMode,
   pubKeyHexToBytes,
   hexToBytes,
@@ -71,6 +73,10 @@ describe('meshcoreCompanionCodec — constants stay in sync with meshcore.js', (
     expect(ResponseCodes.CurrTime).toBe(Constants.ResponseCodes.CurrTime);
     expect(ResponseCodes.DeviceInfo).toBe(Constants.ResponseCodes.DeviceInfo);
     expect(ResponseCodes.NoMoreMessages).toBe(Constants.ResponseCodes.NoMoreMessages);
+  });
+
+  it('LogRxData push code matches the library (#3963)', () => {
+    expect(PushCodes.LogRxData).toBe(Constants.PushCodes.LogRxData);
   });
 });
 
@@ -219,6 +225,27 @@ describe('meshcoreCompanionCodec — encoders round-trip through meshcore.js dec
     const decoded = await decodeWithMeshcore(0x82, encodeSendConfirmed(0xdeadbeef, 1500));
     expect(decoded.ackCode).toBe(0xdeadbeef);
     expect(decoded.roundTrip).toBe(1500);
+  });
+
+  it('LogRxData(0x88) decodes snr (quarter-dB), rssi and the raw frame (#3963)', async () => {
+    // Round-trips through meshcore.js's own onLogRxDataPush decoder, proving the
+    // raw packet feed a channel-finder consumes reads back byte-for-byte.
+    const raw = hexToBytes('0102030405aabbccddeeff'); // whole OTA frame, forwarded verbatim
+    const decoded = await decodeWithMeshcore(PushCodes.LogRxData, encodeLogRxData({ snr: -7.25, rssi: -95, raw }));
+    // snr is scaled ×4 on the wire (−7.25 → −29) and the app divides back by 4.
+    expect(decoded.lastSnr).toBeCloseTo(-7.25, 5);
+    expect(decoded.lastRssi).toBe(-95);
+    expect(Buffer.from(decoded.raw).toString('hex')).toBe('0102030405aabbccddeeff');
+  });
+
+  it('LogRxData clamps an out-of-range snr to the int8 wire range (#3963)', async () => {
+    // snr×4 for +40 dB = 160, past int8 max (127) → clamps to 127 → 31.75 dB.
+    const decoded = await decodeWithMeshcore(
+      PushCodes.LogRxData,
+      encodeLogRxData({ snr: 40, rssi: 5, raw: hexToBytes('ab') }),
+    );
+    expect(decoded.lastSnr).toBeCloseTo(127 / 4, 5);
+    expect(decoded.lastRssi).toBe(5);
   });
 
   it('ChannelMsgRecv decodes channel index and text', async () => {

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -92,6 +92,7 @@ export const PushCodes = {
   SendConfirmed: 0x82,
   MsgWaiting: 0x83,
   LoginSuccess: 0x85,
+  LogRxData: 0x88,
   TraceData: 0x89,
   TelemetryResponse: 0x8b,
 } as const;
@@ -678,6 +679,29 @@ export function encodeTelemetryResponsePush(
   b[1] = 0; // reserved
   Buffer.from(pubKeyPrefix).copy(b, 2, 0, 6);
   return Buffer.concat([b, Buffer.from(lppSensorData)]);
+}
+
+/**
+ * Encode a LogRxData(0x88) push — the node forwarding a raw received OTA packet
+ * to the app. This is the diagnostic "packet feed" that tools like
+ * Remote-Terminal-for-MeshCore's channel finder consume (#3963). Real firmware
+ * emits it unsolicited for every packet the radio hears while a companion
+ * client is attached; there is no command to enable it.
+ *
+ * Layout mirrors meshcore.js's `onLogRxDataPush` decoder:
+ * `[0x88][snr:int8 quarter-dB][rssi:int8 dBm][raw...]`.
+ * - `snr` is a dB value; the wire carries `snr×4` (int8) and the app divides by
+ *   4, so we scale here. `rssi` is a plain signed dBm byte.
+ * - `raw` is the ENTIRE OTA frame (header + path + payload), forwarded verbatim
+ *   with no length prefix — the consumer decodes payload type / route / relay
+ *   hashes from it, so nothing may be stripped.
+ */
+export function encodeLogRxData(rx: { snr?: number | null; rssi?: number | null; raw: Uint8Array }): Buffer {
+  const head = Buffer.alloc(1 + 1 + 1);
+  head[0] = PushCodes.LogRxData;
+  head.writeInt8(clampInt8(Math.round((rx.snr ?? 0) * 4)), 1);
+  head.writeInt8(clampInt8(Math.round(rx.rssi ?? 0)), 2);
+  return Buffer.concat([head, Buffer.from(rx.raw)]);
 }
 
 /** Encode a NoMoreMessages(10) response — mailbox drained. */

--- a/src/server/meshcoreManager.otaPacket.test.ts
+++ b/src/server/meshcoreManager.otaPacket.test.ts
@@ -77,6 +77,20 @@ describe('MeshCoreManager — ota_packet capture gate', () => {
     expect(emitMeshCoreOtaPacket).not.toHaveBeenCalled();
   });
 
+  it('re-emits an ota_packet event for the VN bridge even when capture is disabled (#3963)', async () => {
+    // The virtual node's LogRxData(0x88) feed must work regardless of the
+    // opt-in packet monitor, so the plain EventEmitter event fires unconditionally.
+    isEnabled.mockResolvedValue(false);
+    const m = new MeshCoreManager('src-a');
+    const seen: unknown[] = [];
+    m.on('ota_packet', (d) => seen.push(d));
+    dispatch(m, { event_type: 'ota_packet', data: { ...SAMPLE } });
+    await flush();
+    expect(logPacket).not.toHaveBeenCalled(); // still not persisted
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ snr: 6.25, rssi: -42, raw_hex: 'deadbeef' });
+  });
+
   it('persists and broadcasts a source-stamped packet when enabled', async () => {
     isEnabled.mockResolvedValue(true);
     const m = new MeshCoreManager('src-a');

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1479,6 +1479,13 @@ class MeshCoreManager extends EventEmitter {
       // raw OTA data FIRST, independent of the opt-in packet monitor, so it
       // works regardless of the monitor setting.
       void this.correlateChannelEcho(data);
+      // Re-emit the raw OTA packet as a plain EventEmitter event so the MeshCore
+      // Virtual Node can bridge it to connected apps as a LogRxData(0x88) push
+      // (#3963). Deliberately NOT gated on the packet-monitor setting: a feed
+      // consumer like Remote-Terminal's channel finder wants every packet even
+      // when MeshMonitor's own packet log is off. Fields used downstream:
+      // `snr` (dB), `rssi` (dBm), `raw_hex` (whole OTA frame).
+      this.emit('ota_packet', data);
       // Full OTA packet metadata for the MeshCore Packet Monitor. Capture is
       // opt-in; gate persistence on the setting so we don't write a row for
       // every received packet unless the user has turned the monitor on.

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -111,6 +111,9 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
+  emitOtaPacket(data: { snr?: number | null; rssi?: number | null; raw_hex?: string | null }) {
+    this.emit('ota_packet', data);
+  }
 }
 
 const CHANNELS_DB = {
@@ -433,6 +436,26 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     let pushed = false;
     void client.expectFrames(1).then(() => { pushed = true; });
     manager.emitSendConfirmed({ ackCode: 0x9999, roundTripMs: 10 }); // never sent by this client
+    await new Promise((r) => setTimeout(r, 40));
+    expect(pushed).toBe(false);
+  });
+
+  it('bridges a raw OTA packet to the client as a LogRxData(0x88) push (#3963)', async () => {
+    const pushP = client.expectFrames(1);
+    manager.emitOtaPacket({ snr: -7.25, rssi: -95, raw_hex: '0102030405aabbccddeeff' });
+    const [push] = await pushP;
+    expect(push[0]).toBe(0x88); // PushCodes.LogRxData
+    expect(Buffer.from(push).readInt8(1)).toBe(-29); // snr×4 (−7.25 → −29)
+    expect(Buffer.from(push).readInt8(2)).toBe(-95); // rssi dBm
+    // Bytes 3..end are the whole OTA frame, forwarded verbatim.
+    expect(Buffer.from(push).subarray(3).toString('hex')).toBe('0102030405aabbccddeeff');
+  });
+
+  it('does not push a LogRxData frame for an OTA packet with no raw bytes (#3963)', async () => {
+    let pushed = false;
+    void client.expectFrames(1).then(() => { pushed = true; });
+    manager.emitOtaPacket({ snr: 5, rssi: -80, raw_hex: null });
+    manager.emitOtaPacket({ snr: 5, rssi: -80, raw_hex: '' });
     await new Promise((r) => setTimeout(r, 40));
     expect(pushed).toBe(false);
   });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -20,6 +20,7 @@ import {
   encodeContactMsgRecv,
   encodeChannelMsgRecv,
   encodeMsgWaitingPush,
+  encodeLogRxData,
   encodeSent,
   encodeSendConfirmed,
   encodeLoginSuccessPush,
@@ -113,6 +114,24 @@ export interface MeshCoreVirtualNodeManager {
   /** The manager emits 'send_confirmed' when a sent DM is acked (#3869). */
   on(event: 'send_confirmed', listener: (data: { ackCode: number; roundTripMs: number }) => void): unknown;
   off(event: 'send_confirmed', listener: (data: { ackCode: number; roundTripMs: number }) => void): unknown;
+  /**
+   * The manager emits 'ota_packet' for every raw OTA packet the node receives
+   * (independent of the packet-monitor setting), so the server can bridge it to
+   * apps as a LogRxData(0x88) push for packet-feed / channel-finder tools (#3963).
+   */
+  on(event: 'ota_packet', listener: (data: OtaPacketEvent) => void): unknown;
+  off(event: 'ota_packet', listener: (data: OtaPacketEvent) => void): unknown;
+}
+
+/**
+ * Raw OTA packet the manager surfaces on its 'ota_packet' event. Fields mirror
+ * the native backend's bridge payload (snake_case). `raw_hex` is the ENTIRE OTA
+ * frame (header + path + payload); `snr` is dB, `rssi` is dBm.
+ */
+export interface OtaPacketEvent {
+  snr?: number | null;
+  rssi?: number | null;
+  raw_hex?: string | null;
 }
 
 /** Reverse map of command codes → names, for human-readable command logging. */
@@ -190,6 +209,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   private readonly onManagerMessage = (msg: MeshCoreMessage) => this.handleIncomingMessage(msg);
   private readonly onManagerSendConfirmed = (data: { ackCode: number; roundTripMs: number }) =>
     this.handleSendConfirmed(data);
+  private readonly onManagerOtaPacket = (data: OtaPacketEvent) => this.handleOtaPacket(data);
   /**
    * Pending DM acks: `expectedAckCrc` → clientId of the companion that sent it.
    * Populated when a client sends a DM, consumed when the matching
@@ -236,6 +256,9 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         this.options.manager.on('message', this.onManagerMessage);
         // Forward DM delivery acks back to the originating companion (#3869).
         this.options.manager.on('send_confirmed', this.onManagerSendConfirmed);
+        // Bridge the raw OTA packet feed to apps as LogRxData(0x88) pushes so
+        // packet-feed / channel-finder tools work through the virtual node (#3963).
+        this.options.manager.on('ota_packet', this.onManagerOtaPacket);
         this.emit('listening');
         resolve();
       });
@@ -252,6 +275,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
 
     this.options.manager.off('message', this.onManagerMessage);
     this.options.manager.off('send_confirmed', this.onManagerSendConfirmed);
+    this.options.manager.off('ota_packet', this.onManagerOtaPacket);
     this.pendingAcks.clear();
 
     for (const client of this.clients.values()) {
@@ -850,6 +874,25 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     logger.info(
       `[MeshCore VN ${this.sourceId}] ◀ ack confirmed to ${clientId} (crc=${key}, rtt=${data.roundTripMs}ms)`,
     );
+  }
+
+  /**
+   * Bridge a raw OTA packet to every connected app as a LogRxData(0x88) push —
+   * the diagnostic "packet feed" that channel-finder / packet-cracker tools
+   * (e.g. Remote-Terminal-for-MeshCore) consume (#3963). The whole OTA frame is
+   * forwarded verbatim; the SNR/RSSI ride the push header. A client with no
+   * packet-feed UI simply ignores the frame. Unlike text-message delivery this
+   * fans out unconditionally (no self-origin filtering): the feed is meant to
+   * mirror everything the radio heard, exactly as a real companion would.
+   */
+  private handleOtaPacket(data: OtaPacketEvent): void {
+    if (this.clients.size === 0) return;
+    const raw = hexToBytes(data.raw_hex);
+    if (raw.length === 0) return; // nothing to forward (missing/blank raw_hex)
+    const frame = encodeLogRxData({ snr: data.snr, rssi: data.rssi, raw });
+    for (const clientId of this.clients.keys()) {
+      this.send(clientId, frame);
+    }
   }
 
   /** Resolve a (≥6-byte) public-key prefix to a full contact key, or null. */


### PR DESCRIPTION
## Summary

Fixes #3963 (reported in discussion #3933).

The MeshCore **Virtual Node** completes the companion handshake with an external app but never forwards the **raw received-packet feed**. Tools that drive their UI from that feed — e.g. [Remote-Terminal-for-MeshCore](https://github.com/jkingsman/Remote-Terminal-for-MeshCore) and its **channel finder** — connect successfully ("connected to Radio") but see **zero packet flow**, so the channel finder can't work.

Real MeshCore firmware pushes every received OTA packet to an attached companion as `PUSH_CODE_LOG_RX_DATA` (**0x88**), unsolicited. The VN only forwarded `MsgWaiting` (0x83) and `SendConfirmed` (0x82), so the raw feed never reached connected apps. This PR bridges it.

## Changes

- **codec** (`meshcoreCompanionCodec.ts`): add `PushCodes.LogRxData = 0x88` and `encodeLogRxData()`. Wire layout `[0x88][snr:int8 quarter-dB][rssi:int8 dBm][raw…]` — SNR is scaled ×4 (the app divides back by 4), RSSI is a plain signed dBm byte, and the tail is the **entire** OTA frame (header + path + payload) forwarded verbatim.
- **manager** (`meshcoreManager.ts`): re-emit each raw OTA packet as a plain `'ota_packet'` EventEmitter event, deliberately **before** the packet-monitor gate — a feed consumer wants every packet even when MeshMonitor's own `meshcore_packet_log_enabled` is off.
- **VN server** (`meshcoreVirtualNodeServer.ts`): subscribe to `'ota_packet'` in `start()` (unsubscribe in `stop()`) and fan each packet out to every connected client as a 0x88 push.

The raw frame + SNR/RSSI were already available from the native backend's `ota_packet` bridge event, so **no new device IO** is needed — this is pure plumbing.

## Wire-format verification

The `0x88` layout was cross-verified against three independent sources before implementation:
- **MeshCore firmware** — `MyMesh::logRxRaw` (emit) + `Dispatcher::checkRecv` (called for every packet, pre-dispatch, gated only on "is a client attached").
- **meshcore.js** — `onLogRxDataPush` decoder.
- **Remote-Terminal-for-MeshCore** — subscribes `EventType.RX_LOG_DATA` on connect and sends **no** enable command (the feed is unconditional); its channel finder is driven entirely by it.

⚠️ Note `0x84` (`RawData`) has a *different* body (extra reserved byte) — this PR bridges `0x88` only, which is what channel-finder tools consume.

## Tests

- `meshcoreCompanionCodec.test.ts`: `encodeLogRxData` round-trips through meshcore.js's own `onLogRxDataPush` decoder (SNR quarter-dB, RSSI, verbatim raw frame); int8 clamping of out-of-range SNR; `PushCodes.LogRxData` matches the library constant.
- `meshcoreVirtualNodeServer.test.ts`: an `ota_packet` event reaches a connected client as a correct 0x88 frame; an OTA packet with empty/null `raw_hex` produces no push.
- `meshcoreManager.otaPacket.test.ts`: the manager re-emits `ota_packet` for the VN bridge **even when capture is disabled** (and still doesn't persist).

Full suite green: **2649/2649 suites, 8040 passed, 0 failed**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
