### PR TITLE
chore(release): bump version to 4.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.12.5] - 2026-07-06
+
+### Added
+- **MeshCore Virtual Node: send adverts, log in, trace paths, and request telemetry from a companion app** — Completes the app-facing command surface reported in #3904. A companion app connected to a MeshCore Virtual Node can now: broadcast a self-advert (`SendSelfAdvert`), log in to a remote node (`SendLogin` → `LoginSuccess`), trace a path (`SendTracePath` → `TraceData`), and request LPP telemetry (`SendTelemetryReq` → `TelemetryResponse`). These are relayed to the real node with the correct `Sent`→async-push handshake the app expects (correlated by the remote's public-key prefix, or by the app's own trace tag), instead of being rejected with `Err(UnsupportedCmd)`. Login/trace/telemetry/advert are not gated on **Allow admin commands** — a real node accepts them unconditionally. (#3904, #3959, #3961)
+- **MeshCore Virtual Node: bridge the raw RX feed to companion apps** — The node's raw received-packet feed is now forwarded to connected apps as a `LogRxData`(0x88) push, so channel-finder / packet-inspection tools in the app work through the Virtual Node. (#3963, #3964)
+- **LoRa: region-legality awareness for modem presets and amateur-radio regions** — The modem-preset picker now filters out presets that would be illegal for the selected region, and selecting a licensed amateur-radio region surfaces a warning. Adds `RegionCode` values 33–37 and corrects the `ITU2_2M` label. (#3924, #3927, #3928, #3930, #3936)
+- **Nodes: per-node free-text notes** — Each node gains an editable free-text notes field. (#3921, #3932)
+- **Messages: search conversations by content** — Conversations can be searched by message text; the in-tab content filter now also covers MeshCore direct messages. (#3922, #3931, #3935)
+- **MeshCore packet-log export: decode unencrypted packet data** — Packet-log exports now decode the data of unencrypted packets instead of leaving them opaque. (#3937, #3939)
+- **Automation: MeshCore scope condition + source resolution** — Automations gain a MeshCore scope condition (with a self-origin guard so a rule can't act on the node's own emitted events), and correctly resolve MeshCore sources from the manager registry. (#3914, #3915, #3917, #3920)
+
 ### Fixed
-- **PirateWeatherADV example script: "read operation timed out" under Timed Events** — The bundled community script's per-request Nominatim/Pirate Weather `urlopen` timeouts (3s/4s/3s) were based on a stale "10-second script timeout" assumption; the actual Auto-Responder/Timed Event script kill timeout is 30 seconds. A slow upstream response could exceed the old socket timeouts long before the real kill signal, surfacing as `The read operation timed out`. Timeouts are bumped to 5s/8s/5s (named constants) and the misleading "10-second" comment/docs are corrected to 30 seconds throughout. (#3941)
+- **MeshCore: `clock sync` now sets the repeater to the real current time** — The `clock sync` CLI/quick-action set the repeater's RTC from the incoming command frame's timestamp, which is `0` over a direct serial link (always rejected) and the sending node's own drifted clock over remote admin — so the repeater ended up minutes behind or unchanged. MeshMonitor now issues the firmware's absolute `time <epoch>` command with the server's authoritative clock, and keeps the local Companion node's own RTC synced on connect and periodically. (#3954, #3957)
+- **MeshCore: repeater SNR was reported 4× too high** — Repeater `last_snr` values are raw quarter-dB and are now divided by 4 before display, matching the units used everywhere else. (#3955, #3956)
+- **MeshCore: static contact position no longer clobbers live GNSS telemetry fixes** — A saved static position for a contact could overwrite a fresher GPS fix from telemetry; live GNSS fixes now win. (#3909)
+- **MeshCore: initial auto-connect now retries with backoff** — A missed first connection attempt is retried with backoff instead of leaving the source disconnected. (#3919)
+- **Automation: a stored bad `filterNameRegex` can no longer brick automations** — An invalid saved name-filter regex is now handled gracefully instead of throwing and taking the automation engine down with it. (#3934, #3938)
+- **Map: direct-heard SNR shown in the node hover tooltip** — The tooltip now surfaces the direct-heard SNR. (#3925, #3929)
+- **Dashboard map: collapse toggle for the Features panel** — The map Features panel can now be collapsed. (#3912, #3913)
+- **Hardware: rename hwModel 128 to `MESH_TRACKER_X1`** — Corrects the model name for hwModel 128. (#3952, #3958)
+- **PirateWeatherADV example script: "read operation timed out" under Timed Events** — The bundled community script's per-request Nominatim/Pirate Weather `urlopen` timeouts (3s/4s/3s) were based on a stale "10-second script timeout" assumption; the actual Auto-Responder/Timed Event script kill timeout is 30 seconds. A slow upstream response could exceed the old socket timeouts long before the real kill signal, surfacing as `The read operation timed out`. Timeouts are bumped to 5s/8s/5s (named constants) and the misleading "10-second" comment/docs are corrected to 30 seconds throughout. (#3941, #3942)
+
+### Changed
+- **Translations updated from Hosted Weblate.** (#3601)
+- **Dependencies:** bumped the production-dependencies group (8 updates) plus `@types/node`, `globals`, `@typescript-eslint/parser`, `puppeteer`, and `tsx`. (#3945, #3946, #3948, #3949, #3950, #3951)
 
 ## [4.12.4] - 2026-07-03
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.12.4",
+  "version": "4.12.5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.12.4",
+  "version": "4.12.5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
+++ b/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
@@ -2,9 +2,10 @@
 
 **Issue:** [#3535](https://github.com/Yeraze/meshmonitor/issues/3535) — expose a real MeshCore node, that MeshMonitor already manages, as a virtual node the MeshCore **mobile app** can connect to over WiFi/TCP.
 
-**Status:** Phases 0–2 implemented and verified against the real MeshCore
-(`meshcore-flutter`) app over WiFi — see "Phasing" below. Phase 3 (config writes +
-DM delivery receipts) pending.
+**Status:** Phases 0–4 implemented and verified against the real MeshCore
+(`meshcore-flutter`) app over WiFi — see "Phasing" below. The app can now mirror
+the node, send messages, apply admin-gated config, and relay adverts / login /
+trace / telemetry / raw-RX through to the physical node.
 
 > **Verified end-to-end:** the app connects over WiFi, shows the node identity,
 > loads contacts + channels, and sends/receives channel messages through the real
@@ -179,10 +180,19 @@ is **always** refused regardless of the gate. All connects/admin-forwards are au
 - **Phase 2 — Send path. ✅ IMPLEMENTED.** `SendChannelTxtMsg`/`SendTxtMsg` forwarded
   through `meshcoreManager.sendMessage`; DM prefixes resolved to full keys via the contact
   list.
-- **Phase 3 — Admin/config + DM receipts. ⏳ PENDING.** Admin-gated config commands
-  (`SetRadioParams`, `SetAdvertName`, …), and DM delivery receipts: relay the node's real
-  `expectedAckCrc` (currently logged-but-discarded by `sendMessage`) so the
-  `SendConfirmed`(0x82) push can be correlated and the app shows the delivered tick.
+- **Phase 3 — Admin/config + DM receipts. ✅ IMPLEMENTED.** Admin-gated config commands
+  (`SetRadioParams`, `SetAdvertName`, `SetTxPower`, `SetAdvertLatLon`, `SetChannel`,
+  `SetOtherParams`) are forwarded to the real node when the source's **Allow admin commands**
+  flag is on (else `Err(UnsupportedCmd)`) — #3904/#3906/#3907. DM delivery receipts relay the
+  node's real `expectedAckCrc` so the `SendConfirmed`(0x82) push is correlated and the app
+  shows the delivered tick — #3869.
+- **Phase 4 — Remote transactions + raw feed. ✅ IMPLEMENTED.** The remaining app-initiated
+  commands are relayed with the `Sent`→async-push handshake: `SendSelfAdvert` (ack `Ok`,
+  #3959); `SendLogin`→`LoginSuccess`(0x85), `SendTracePath`→`TraceData`(0x89),
+  `SendTelemetryReq`→`TelemetryResponse`(0x8B) (#3961, correlated by the remote's 6-byte
+  pubkey prefix or the app's own trace tag); and the node's raw RX feed bridged to apps as a
+  `LogRxData`(0x88) push (#3964). Login/trace/telemetry/advert are **not** gated on
+  `allowAdminCommands` — a real node accepts them unconditionally; only config *writes* are gated.
 
 ### Protocol subtleties found in testing (don't regress these)
 - **Channel send acks `Ok`, DM send acks `Sent`.** meshcore.js's `sendChannelTextMessage`

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.12.4
-appVersion: "4.12.4"
+version: 4.12.5
+appVersion: "4.12.5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.4",
+  "version": "4.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.12.4",
+      "version": "4.12.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.4",
+  "version": "4.12.5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release 4.12.5

Version bump across all five files (package.json, package-lock.json, Chart.yaml, tauri.conf.json, desktop/package.json) + documentation.

### Documentation reviewed / updated
- **CHANGELOG.md** — `[Unreleased]` promoted to `[4.12.5]`, with entries for everything merged since 4.12.4 (the `[Unreleased]` section previously only held the PirateWeather fix).
- **MESHCORE_VIRTUAL_NODE_DESIGN.md** — Phase 3 (admin/config + DM receipts) and the new Phase 4 (remote transactions + raw feed) marked implemented; status line updated. Everything else (README dynamic version badge, CLAUDE.md migration count) was already current.

### Highlights of 4.12.5
- **MeshCore Virtual Node** command surface completed (#3904): a companion app can now send adverts, log in, trace paths, request telemetry, and receive the raw RX feed through the VN (#3959, #3961, #3964) — hardware-validated against a live node.
- **LoRa region legality** — preset filtering + amateur-region warning + RegionCodes 33–37 (#3928, #3930, #3936).
- **Fixes** — `clock sync` sets the real time (#3957), repeater SNR /4 scaling (#3956), static position vs GNSS (#3909), auto-connect retry (#3919), bad-regex automation guard (#3938), and more.
- Per-node notes (#3932), conversation content search (#3931), plus dependency + translation updates.

System tests enabled on this PR per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n
