### PR TITLE
feat(server): process-level safety net for unhandledRejection/uncaughtException (#3962)

### DIFF
--- a/src/server/processSafetyNet.test.ts
+++ b/src/server/processSafetyNet.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  installProcessSafetyNet,
+  __resetProcessSafetyNetForTests,
+} from './processSafetyNet.js';
+
+describe('processSafetyNet', () => {
+  let mockShutdown: ReturnType<typeof vi.fn>;
+  let mockLog: { error: ReturnType<typeof vi.fn> };
+  // Capture pre-existing listeners so we can restore them after each test.
+  // Typed as unknown[] because the NodeJS namespace is not ESLint-visible; the
+  // cast when re-adding is safe — we captured these from the process itself.
+  let priorRejectionListeners: ((...args: unknown[]) => void)[];
+  let priorExceptionListeners: ((...args: unknown[]) => void)[];
+
+  beforeEach(() => {
+    priorRejectionListeners = process.listeners('unhandledRejection').slice() as ((...args: unknown[]) => void)[];
+    priorExceptionListeners = process.listeners('uncaughtException').slice() as ((...args: unknown[]) => void)[];
+
+    mockShutdown = vi.fn();
+    mockLog = { error: vi.fn() };
+
+    __resetProcessSafetyNetForTests();
+  });
+
+  afterEach(() => {
+    // Remove any listeners the test registered and restore originals.
+    process.removeAllListeners('unhandledRejection');
+    process.removeAllListeners('uncaughtException');
+    for (const l of priorRejectionListeners) process.on('unhandledRejection', l as any);
+    for (const l of priorExceptionListeners) process.on('uncaughtException', l as any);
+  });
+
+  it('calls shutdown with unhandledRejection and exit code 1 on an unhandled rejection', () => {
+    installProcessSafetyNet({ shutdown: mockShutdown, log: mockLog });
+
+    process.emit('unhandledRejection', new Error('boom'), Promise.resolve());
+
+    expect(mockShutdown).toHaveBeenCalledOnce();
+    expect(mockShutdown).toHaveBeenCalledWith('unhandledRejection', 1);
+    expect(mockLog.error).toHaveBeenCalledOnce();
+    const [, meta] = mockLog.error.mock.calls[0] as [string, { reason: string; promise: string }];
+    expect(meta.reason).toMatch(/boom/);
+  });
+
+  it('calls shutdown with uncaughtException and exit code 1 on an uncaught exception', () => {
+    installProcessSafetyNet({ shutdown: mockShutdown, log: mockLog });
+
+    process.emit('uncaughtException', new Error('crash'), 'uncaughtException');
+
+    expect(mockShutdown).toHaveBeenCalledOnce();
+    expect(mockShutdown).toHaveBeenCalledWith('uncaughtException', 1);
+    expect(mockLog.error).toHaveBeenCalledOnce();
+    const [, meta] = mockLog.error.mock.calls[0] as [string, { error: string; origin: string }];
+    expect(meta.error).toMatch(/crash/);
+  });
+
+  it('is idempotent — calling installProcessSafetyNet twice only registers one listener', () => {
+    installProcessSafetyNet({ shutdown: mockShutdown, log: mockLog });
+    installProcessSafetyNet({ shutdown: mockShutdown, log: mockLog });
+
+    process.emit('unhandledRejection', new Error('duplicate'), Promise.resolve());
+
+    // Only one listener should have fired, so shutdown is called exactly once.
+    expect(mockShutdown).toHaveBeenCalledOnce();
+  });
+
+  it('serializes a non-Error reason (plain object) without throwing and still calls shutdown', () => {
+    installProcessSafetyNet({ shutdown: mockShutdown, log: mockLog });
+
+    process.emit('unhandledRejection', { code: 42, msg: 'plain object reason' }, Promise.resolve());
+
+    expect(mockShutdown).toHaveBeenCalledOnce();
+    expect(mockShutdown).toHaveBeenCalledWith('unhandledRejection', 1);
+    const [, meta] = mockLog.error.mock.calls[0] as [string, { reason: string }];
+    expect(meta.reason).toContain('plain object reason');
+  });
+});

--- a/src/server/processSafetyNet.ts
+++ b/src/server/processSafetyNet.ts
@@ -1,0 +1,49 @@
+import { logger } from '../utils/logger.js';
+
+/** Serialize an unknown thrown/rejected value for a single log line. */
+function serializeReason(reason: unknown): string {
+  if (reason instanceof Error) return reason.stack ?? `${reason.name}: ${reason.message}`;
+  try {
+    return typeof reason === 'string' ? reason : JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+export interface SafetyNetDeps {
+  /** Route through the existing gracefulShutdown; exitCode 1 on fatal. */
+  shutdown: (reason: string, exitCode?: number) => void;
+  log?: Pick<typeof logger, 'error'>;
+}
+
+let installed = false;
+
+/**
+ * Register process-level last-resort handlers that log full context and route
+ * through gracefulShutdown with a non-zero exit code. Idempotent per process.
+ */
+export function installProcessSafetyNet({ shutdown, log = logger }: SafetyNetDeps): void {
+  if (installed) return;
+  installed = true;
+
+  process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
+    log.error('💥 Unhandled promise rejection — shutting down', {
+      reason: serializeReason(reason),
+      promise: String(promise),
+    });
+    shutdown('unhandledRejection', 1);
+  });
+
+  process.on('uncaughtException', (error: Error, origin) => {
+    log.error('💥 Uncaught exception — shutting down', {
+      error: serializeReason(error),
+      origin,
+    });
+    shutdown('uncaughtException', 1);
+  });
+}
+
+/** Test-only: reset the install guard between tests. */
+export function __resetProcessSafetyNetForTests(): void {
+  installed = false;
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -57,6 +57,7 @@ import { isValidModuleConfigType } from './constants/moduleConfig.js';
 import { CONFIG_TYPE_MAP, MODULE_FIELD_BY_ID, DEVICE_FIELD_BY_ID } from './constants/configTypes.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
+import { installProcessSafetyNet } from './processSafetyNet.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
@@ -6171,8 +6172,14 @@ process.on('SIGINT', () => {
 });
 
 // Graceful shutdown function
-function gracefulShutdown(reason: string): void {
-  logger.info(`🛑 Initiating graceful shutdown: ${reason}`);
+let isShuttingDown = false;
+function gracefulShutdown(reason: string, exitCode = 0): void {
+  if (isShuttingDown) {
+    logger.warn(`🛑 Shutdown already in progress — ignoring duplicate request: ${reason}`);
+    return;
+  }
+  isShuttingDown = true;
+  logger.info(`🛑 Initiating graceful shutdown: ${reason} (exit ${exitCode})`);
 
   const shutdownDependencies = (): void => {
     // Disconnect from Meshtastic
@@ -6192,7 +6199,7 @@ function gracefulShutdown(reason: string): void {
     }
 
     logger.info('✅ Graceful shutdown complete');
-    process.exit(0);
+    process.exit(exitCode);
   };
 
   // SIGTERM can arrive during startup (e.g. while long migrations run on a
@@ -6218,6 +6225,9 @@ function gracefulShutdown(reason: string): void {
 process.on('SIGTERM', () => {
   gracefulShutdown('SIGTERM received');
 });
+
+// Last-resort handlers: log full context and route through gracefulShutdown (exit 1).
+installProcessSafetyNet({ shutdown: gracefulShutdown });
 
 // Data migration: Set channel field to 'dm' for existing auto-responder triggers without channel
 async function migrateAutoResponderTriggers() {


### PR DESCRIPTION
## Summary

Task **0.1** of the remediation plan (#3962, Phase 0 — see `docs/internal/dev-notes/REMEDIATION_PLAN.md`).

Previously an unhandled promise rejection killed the process silently, bypassing all teardown. Now:

- **New `src/server/processSafetyNet.ts`** — registers `process.on('unhandledRejection')` and `process.on('uncaughtException')` handlers that log full context (serialized reason/stack, promise, origin) via the existing `logger` and route through the existing `gracefulShutdown()` with exit code 1. Idempotent registration (install guard) and dependency-injected for testability.
- **`gracefulShutdown` hardened** in `server.ts`: a module-level `isShuttingDown` guard makes it idempotent (a rejection cascade or second signal during teardown no longer double-runs disconnect/DB-close/exit), and a new `exitCode` param (default 0) lets fatal paths exit non-zero. The 10s force-exit timeout path still exits 1.
- Wired at top level next to the existing SIGINT/SIGTERM handlers.

## Testing

- New `src/server/processSafetyNet.test.ts` (4 tests): rejection path, exception path, idempotent install, non-Error reason serialization — with process-listener capture/restore so no handlers leak into the Vitest runner.
- Full suite: **8054 passed, 0 failed, 0 suite failures** (`--reporter=json`, `success: true`). `npm run typecheck` clean.

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n