### PR TITLE
fix(security)!: default trust proxy to false when TRUST_PROXY is unset (#3962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (deployments behind a reverse proxy): `TRUST_PROXY` now defaults to `false`.** Previously, production builds trusted the first proxy hop when `TRUST_PROXY` was unset, which let a direct-connected client spoof `X-Forwarded-For` to bypass the auth brute-force limiter and poison audit attribution. Proxied deployments must now set `TRUST_PROXY` explicitly (`TRUST_PROXY=1` for a single proxy). Direct (non-proxied) deployments need no change.
+
 ## [4.12.5] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ services:
 2. `TRUST_PROXY` is configured to trust your reverse proxy
 3. Your proxy validates authentication before forwarding requests
 
+As of v4.13, `TRUST_PROXY` defaults to `false`; you MUST set `TRUST_PROXY=1` (or the appropriate hop count/subnet) whenever MeshMonitor runs behind any reverse proxy, or client IP resolution, rate limiting, and audit logs will all show the proxy's IP.
+
 ### Email Uniqueness Caveat
 
 ⚠️ **Email uniqueness is NOT enforced** in the database schema. If multiple users share the same email address, the first match will be used. Ensure your proxy provides unique email addresses for each user.

--- a/docs/configuration/reverse-proxy.md
+++ b/docs/configuration/reverse-proxy.md
@@ -13,6 +13,10 @@ Benefits of using a reverse proxy:
 - **Centralized Logging**: Single point for access logs
 - **Multiple Services**: Host multiple applications on one server/domain
 
+## Changed in v4.13
+
+**`TRUST_PROXY` now defaults to `false`** (previously, production builds trusted the first proxy hop when `TRUST_PROXY` was unset). If you run MeshMonitor behind any reverse proxy and did not previously set `TRUST_PROXY`, you must now set it explicitly (e.g. `TRUST_PROXY=1` for a single proxy) to restore correct client-IP resolution for rate limiting and audit logs.
+
 ## ⚠️ Critical: Required Environment Variables
 
 When deploying MeshMonitor behind a reverse proxy with HTTPS, you **MUST** set these environment variables:

--- a/docs/internal/dev-notes/REMEDIATION_EPIC.md
+++ b/docs/internal/dev-notes/REMEDIATION_EPIC.md
@@ -14,8 +14,8 @@
 
 Each unchecked phase = one worktree → architect spec → implementation → review → PR → CI → merge cycle.
 
-- [ ] **P0-docs** — Merge `docs/remediation-plan` (REMEDIATION_PLAN.md + this file) to main.
-- [ ] **0.1** — Process-level safety net: `unhandledRejection`/`uncaughtException` handlers in `server.ts`, logging with full context and routing through `gracefulShutdown()`. Exit: deliberate `Promise.reject()` in dev logs and shuts down gracefully.
+- [x] **P0-docs** — Merge `docs/remediation-plan` (REMEDIATION_PLAN.md + this file) to main.
+- [x] **0.1** — Process-level safety net: `unhandledRejection`/`uncaughtException` handlers in `server.ts`, logging with full context and routing through `gracefulShutdown()`. Exit: deliberate `Promise.reject()` in dev logs and shuts down gracefully.
 - [ ] **0.2** — Trust-proxy default → `false` when `TRUST_PROXY` unset; keep startup warning; release-notes/README documentation for proxied deployments.
 - [ ] **0.3** — Pin `meshcore.js` fork dependency to a commit SHA; lockfile regenerated; `npm ci` reproducible.
 - [ ] **0.4** — Strip/gate the hot-path `console.log`s in `src/services/api.ts` (CSRF token status + token prefix on every mutation); kept diagnostics behind a debug flag.
@@ -37,4 +37,5 @@ Each unchecked phase = one worktree → architect spec → implementation → re
 
 Record per-phase: PR link, deviations from plan, follow-ups.
 
-- _(empty — updated as phases complete)_
+- **P0-docs** — PR #3966 merged (plan + epic doc on main). No deviations.
+- **0.1** — PR #3967 merged (processSafetyNet.ts + idempotent gracefulShutdown with exitCode param). Deviation: NodeJS.* type annotations replaced with inference/unknown due to ESLint no-undef.

--- a/src/server/config/environment.trustproxy.test.ts
+++ b/src/server/config/environment.trustproxy.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Trust Proxy Environment Configuration Tests
+ *
+ * Guards the parseTrustProxy() parser default via getEnvironmentConfig():
+ * when TRUST_PROXY is unset, trustProxy must be false and trustProxyProvided
+ * must be false (secure default introduced in v4.13).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resetEnvironmentConfig, getEnvironmentConfig } from './environment.js';
+
+describe('Trust Proxy Environment Configuration', () => {
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
+  afterEach(() => {
+    if (originalTrustProxy !== undefined) {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    } else {
+      delete process.env.TRUST_PROXY;
+    }
+    resetEnvironmentConfig();
+  });
+
+  describe('Default (TRUST_PROXY unset)', () => {
+    it('should default trustProxy to false when TRUST_PROXY is not set', () => {
+      delete process.env.TRUST_PROXY;
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxy).toBe(false);
+      expect(config.trustProxyProvided).toBe(false);
+    });
+  });
+
+  describe('Explicit values', () => {
+    it('should parse TRUST_PROXY=1 as numeric 1 with trustProxyProvided=true', () => {
+      process.env.TRUST_PROXY = '1';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxy).toBe(1);
+      expect(config.trustProxyProvided).toBe(true);
+    });
+
+    it('should parse TRUST_PROXY=true as truthy with trustProxyProvided=true', () => {
+      process.env.TRUST_PROXY = 'true';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxyProvided).toBe(true);
+      // 'true' parses as boolean true in parseTrustProxy
+      expect(config.trustProxy).toBe(true);
+    });
+
+    it('should parse TRUST_PROXY=false as false with trustProxyProvided=true', () => {
+      process.env.TRUST_PROXY = 'false';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxyProvided).toBe(true);
+      expect(config.trustProxy).toBe(false);
+    });
+  });
+});

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -67,8 +67,8 @@ logger.info(`   - Messages: ${env.rateLimitMessages === 0 ? 'unlimited (disabled
 
 // Log reverse proxy configuration warnings
 if (!env.trustProxyProvided && env.isProduction) {
-  logger.warn('⚠️  TRUST_PROXY not set - rate limiting will use proxy IP for all requests');
-  logger.warn('   If behind a reverse proxy (nginx, Traefik, etc.), set TRUST_PROXY=1');
+  logger.warn('⚠️  TRUST_PROXY not set — rate limiting keys on the direct socket IP (secure default).');
+  logger.warn('   If behind a reverse proxy, set TRUST_PROXY=1 so per-client limits use the real client IP.');
   logger.warn('   See: https://expressjs.com/en/guide/behind-proxies.html');
 }
 // General API rate limiting

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -107,10 +107,16 @@ JSON.stringify = function (value, replacer?: any, space?: any) {
 if (env.trustProxyProvided) {
   app.set('trust proxy', env.trustProxy);
   logger.debug(`✅ Trust proxy configured: ${env.trustProxy}`);
-} else if (env.isProduction) {
-  // Default: trust first proxy in production (common reverse proxy setup)
-  app.set('trust proxy', 1);
-  logger.debug('ℹ️  Trust proxy defaulted to 1 hop (production mode)');
+} else {
+  // Secure default: do NOT trust proxy headers unless TRUST_PROXY is explicitly set.
+  // Trusting them by default lets a direct-connected client spoof X-Forwarded-For to
+  // rotate req.ip past the auth brute-force limiter and poison audit attribution.
+  app.set('trust proxy', false);
+  if (env.isProduction) {
+    logger.warn('⚠️  TRUST_PROXY not set — using the direct socket IP for rate limiting and audit logs.');
+    logger.warn('   If MeshMonitor is behind a reverse proxy (nginx, Traefik, Caddy, Cloudflare), set TRUST_PROXY=1 (or the hop count / subnet) so client IPs resolve correctly.');
+    logger.warn('   See: https://expressjs.com/en/guide/behind-proxies.html');
+  }
 }
 
 // Security: Helmet.js for HTTP security headers


### PR DESCRIPTION
## Summary

Task **0.2** of the remediation plan (#3962, Phase 0). **User-approved behavior change.**

Production builds previously defaulted to `app.set('trust proxy', 1)` when `TRUST_PROXY` was unset. Combined with `validate: false` on the rate limiters, a direct-connected client could spoof `X-Forwarded-For` to rotate `req.ip` past the auth brute-force limiter and poison audit attribution.

- `server.ts`: unset `TRUST_PROXY` now yields an explicit `app.set('trust proxy', false)` (Express's secure default), with a prominent production startup warning telling reverse-proxied deployments to set `TRUST_PROXY=1`.
- `rateLimiters.ts`: warning text updated to match the new default; `validate: false` intentionally kept (removing it breaks legitimate `TRUST_PROXY=true` installs).
- `environment.ts` untouched — its parser already defaulted to `false`; the override lived only in server.ts.

**BREAKING for reverse-proxied deployments that never set `TRUST_PROXY`:** they must now set it explicitly (`TRUST_PROXY=1` for a single proxy) or rate limiting/audit logs will key on the proxy IP. Documented in CHANGELOG (`[Unreleased]` BREAKING entry), README, and `docs/configuration/reverse-proxy.md` ("Changed in v4.13" callout). Direct deployments are unaffected.

## Testing

- New `src/server/config/environment.trustproxy.test.ts` (4 tests): unset → `false`/not-provided; `1` → numeric 1; `true` → boolean true; `false` → boolean false.
- Full suite: **8058 passed, 0 failed, 0 suite failures** (JSON reporter, `success: true`). Typecheck clean.

Also checks off P0-docs and 0.1 in `REMEDIATION_EPIC.md` (epic bookkeeping).

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n