### PR TITLE
chore(deps): pin meshcore.js fork to commit SHA (#3962)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#feat/meshmonitor-helpers",
+        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#b98fc338be5b4c01894da711de98348516c294aa",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-virtual": "^3.14.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#feat/meshmonitor-helpers",
+    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#b98fc338be5b4c01894da711de98348516c294aa",
     "@maplibre/maplibre-gl-leaflet": "^0.1.3",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-virtual": "^3.14.5",


### PR DESCRIPTION
## Summary

Task **0.3** of the remediation plan (#3962, Phase 0).

`package.json` referenced the fork by mutable branch ref (`github:Yeraze/meshcore.js#feat/meshmonitor-helpers`). Now pinned to `b98fc338be5b4c01894da711de98348516c294aa` — the exact SHA the lockfile already resolved to (verified via `git ls-remote` at pin time), so the installed tree is byte-identical and this is purely a reproducibility/supply-chain fix.

Diff is exactly two spec lines (package.json + the mirrored package-lock spec); the resolved `#b98fc33…` entry is unchanged. No other package.json in the repo (incl. desktop/) references the fork.

When the fork gains new commits, bump the SHA deliberately instead of inheriting whatever the branch points at.

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n