### PR TITLE
fix(security): strip hot-path console logging and CSRF token exposure in api.ts (#3962)

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -50,9 +50,8 @@ class ApiService {
     const csrfToken = this.getCsrfToken();
     if (csrfToken) {
       headers['X-CSRF-Token'] = csrfToken;
-      console.log('[API] ✓ CSRF token added to headers');
     } else {
-      console.error('[API] ✗ NO CSRF TOKEN - Request may fail!');
+      logger.warn('[API] No CSRF token available for mutation request');
     }
 
     return headers;
@@ -92,22 +91,11 @@ class ApiService {
     // Add CSRF token for mutation requests
     if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method.toUpperCase())) {
       const csrfToken = this.getCsrfToken();
-      const tokenStatus = csrfToken ? `Found (${csrfToken.substring(0,8)}...)` : 'NOT FOUND';
-      // Pass method/endpoint as separate args rather than interpolating them
-      // into the format string — console.log treats the first arg as a format
-      // string under some runtimes and caller-controlled %s/%d can break
-      // formatting.
-      console.log('[API]', method, endpoint, '- CSRF token:', tokenStatus);
-
-      // Also check sessionStorage directly
-      const directCheck = sessionStorage.getItem('csrfToken');
-      console.log('[API] Direct sessionStorage check:', directCheck ? 'EXISTS' : 'MISSING');
 
       if (csrfToken) {
         headers['X-CSRF-Token'] = csrfToken;
-        console.log('[API] ✓ X-CSRF-Token header added');
       } else {
-        console.error('[API] ✗ NO CSRF TOKEN - Request will fail!');
+        logger.warn('[API] No CSRF token available — mutation request will likely fail');
       }
     }
 
@@ -931,13 +919,12 @@ class ApiService {
     await this.ensureBaseUrl();
     // Add cache-busting parameter to ensure fresh data after device reboot
     const timestamp = Date.now();
-    console.log(`[API] Fetching config with timestamp: ${timestamp}`);
     const params = new URLSearchParams({ t: String(timestamp) });
     if (sourceId) params.set('sourceId', sourceId);
     const response = await fetch(`${this.baseUrl}/api/config/current?${params}`);
     if (!response.ok) throw new Error('Failed to fetch current configuration');
     const config = await response.json();
-    console.log(`[API] Received config - hopLimit: ${config?.deviceConfig?.lora?.hopLimit}`);
+    logger.debug(`[API] Received config - hopLimit: ${config?.deviceConfig?.lora?.hopLimit}`);
     return config;
   }
 


### PR DESCRIPTION
## Summary

Task **0.4** of the remediation plan (#3962, Phase 0).

`src/services/api.ts` logged on every mutation request — including an 8-character prefix of the CSRF token (`csrfToken.substring(0,8)`). Changes:

- **Deleted** the token-prefix log and its supporting locals, the per-mutation ✓-noise logs ("CSRF token added", "header added", "sessionStorage check"), and the low-value config-fetch timestamp log.
- **Converted** the two genuine "no CSRF token" diagnostics from `console.error` to `logger.warn` (the existing frontend logger, which self-gates by environment) — with no token content.
- **Converted** the config-received hopLimit log to `logger.debug` (silent in production).

Zero `console.*` calls remain in api.ts; no part of the CSRF token is ever logged. No new logging mechanism introduced — reuses the already-imported `logger`.

## Testing

- No test asserted on the removed console lines (verified by grep; no api.test.ts exists).
- Full suite: **8058 passed, 0 failed, 0 suite failures** (JSON reporter, `success: true`). Typecheck clean; ESLint on the file clean.

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n