### PR TITLE
chore(lint): enable @typescript-eslint/no-floating-promises as error (#3962)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -114,6 +114,16 @@ export default [
       '@typescript-eslint/no-require-imports': 'off',
     },
   },
+  {
+    // Type-aware: no un-awaited promises in production code.
+    // Scoped to src non-test TS/TSX only (test files have project:false and
+    // would crash a type-aware rule). See eslint.config.mjs test override below.
+    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    ignores: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx'],
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
   // Test files are excluded from tsconfig.json, so disable project-based type-checking for them
   {
     files: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx'],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -474,7 +474,7 @@ const location = useLocation();
         logger.debug('Failed to fetch channel database entries:', err);
       }
     };
-    fetchChannelDatabaseEntries();
+    void fetchChannelDatabaseEntries();
   }, [authStatus?.authenticated]);
 
   // Show news popup when authenticated user has unread news
@@ -492,7 +492,7 @@ const location = useLocation();
         logger.debug('Failed to fetch unread news:', err);
       }
     };
-    checkUnreadNews();
+    void checkUnreadNews();
   }, [authStatus?.authenticated]);
 
   // Check if packet logging is enabled on the server
@@ -507,7 +507,7 @@ const location = useLocation();
         setPacketLogEnabled(false);
       }
     };
-    checkPacketLogStatus();
+    void checkPacketLogStatus();
   }, [authStatus]);
 
   // Messaging context
@@ -1221,7 +1221,7 @@ const location = useLocation();
       }
     };
 
-    initializeApp();
+    void initializeApp();
   }, []);
 
   // Check for default admin password
@@ -1239,7 +1239,7 @@ const location = useLocation();
       }
     };
 
-    checkConfigIssues();
+    void checkConfigIssues();
   }, [baseUrl]);
 
   // TX status is now handled by useTxStatus hook
@@ -1298,7 +1298,7 @@ const location = useLocation();
     // Check for updates every 4 hours
     const interval = setInterval(checkForUpdates, 4 * 60 * 60 * 1000);
 
-    checkForUpdates(interval);
+    void checkForUpdates(interval);
 
     return () => clearInterval(interval);
   }, [baseUrl]);
@@ -1335,7 +1335,7 @@ const location = useLocation();
       }
     };
 
-    checkUpgradeStatus();
+    void checkUpgradeStatus();
   }, [baseUrl, authFetch]);
 
   // Cleanup upgrade polling on unmount
@@ -1488,7 +1488,7 @@ const location = useLocation();
     };
 
     // Start polling
-    poll();
+    void poll();
   };
 
   // Debug effect to track selectedChannel changes and keep ref in sync
@@ -1512,7 +1512,7 @@ const location = useLocation();
   // Fetch neighbor info when connected (needed for both map display and Messages tab)
   useEffect(() => {
     if (shouldShowData()) {
-      fetchNeighborInfo();
+      void fetchNeighborInfo();
       // Only auto-refresh when connected (not when viewing cached data)
       if (connectionStatus === 'connected') {
         const interval = setInterval(fetchNeighborInfo, 60000); // Refresh every 60 seconds
@@ -1583,7 +1583,7 @@ const location = useLocation();
       }
     };
 
-    fetchAllPositionHistory();
+    void fetchAllPositionHistory();
     return () => { cancelled = true; };
   }, [selectedNodeId, nodes, baseUrl, sourceId]);
 
@@ -1779,7 +1779,7 @@ const location = useLocation();
       const now = Date.now();
       if (isScrolledNearTop(channelMessagesContainerRef.current) && now - lastScrollLoadTimeRef.current > 200) {
         lastScrollLoadTimeRef.current = now;
-        loadMoreChannelMessages();
+        void loadMoreChannelMessages();
       }
     }
   }, [isScrolledNearBottom, isScrolledNearTop, loadMoreChannelMessages]);
@@ -1793,7 +1793,7 @@ const location = useLocation();
       const now = Date.now();
       if (isScrolledNearTop(dmMessagesContainerRef.current) && now - lastScrollLoadTimeRef.current > 200) {
         lastScrollLoadTimeRef.current = now;
-        loadMoreDirectMessages();
+        void loadMoreDirectMessages();
       }
     }
   }, [isScrolledNearBottom, isScrolledNearTop, loadMoreDirectMessages]);
@@ -1918,7 +1918,7 @@ const location = useLocation();
           // If container doesn't have a scrollbar, load more messages
           const hasScrollbar = container.scrollHeight > container.clientHeight;
           if (!hasScrollbar) {
-            loadMoreChannelMessages();
+            void loadMoreChannelMessages();
           }
         }
       }, 200);
@@ -1967,7 +1967,7 @@ const location = useLocation();
           // If container doesn't have a scrollbar, load more messages
           const hasScrollbar = container.scrollHeight > container.clientHeight;
           if (!hasScrollbar) {
-            loadMoreDirectMessages();
+            void loadMoreDirectMessages();
           }
         }
       }, 200);
@@ -1985,7 +1985,7 @@ const location = useLocation();
   const currentChannelMsgCount = (channelMessages[selectedChannel] || []).length;
   useEffect(() => {
     if (activeTab === 'channels' && selectedChannel >= 0) {
-      markMessagesAsRead(undefined, selectedChannel);
+      void markMessagesAsRead(undefined, selectedChannel);
     }
   }, [selectedChannel, activeTab, markMessagesAsRead, currentChannelMsgCount]);
 
@@ -1996,7 +1996,7 @@ const location = useLocation();
     : 0;
   useEffect(() => {
     if (activeTab === 'messages' && selectedDMNode) {
-      markMessagesAsRead(undefined, undefined, selectedDMNode);
+      void markMessagesAsRead(undefined, undefined, selectedDMNode);
     }
   }, [selectedDMNode, activeTab, markMessagesAsRead, currentDMMsgCount]);
 
@@ -2073,7 +2073,7 @@ const location = useLocation();
       // Only check connection status when not connected
       // Data polling when connected is handled by usePoll hook
       if (currentConnectionStatus !== 'connected') {
-        checkConnectionStatus();
+        void checkConnectionStatus();
       }
     }, 5000);
 
@@ -2085,7 +2085,7 @@ const location = useLocation();
     const scheduleNodeRefresh = () => {
       if (connectionStatus === 'connected') {
         logger.debug('🔄 Performing scheduled node database refresh...');
-        requestFullNodeDatabase();
+        void requestFullNodeDatabase();
       }
     };
 
@@ -2202,7 +2202,7 @@ const location = useLocation();
     setConnectionStatus('connected');
 
     // Refresh all data after reboot - usePoll fetches nodes, messages, channels, config, telemetry
-    refetchPoll();
+    void refetchPoll();
 
     // Trigger config refresh in ConfigurationTab
     setConfigRefreshTrigger(prev => {
@@ -2308,7 +2308,7 @@ const location = useLocation();
             if (currentStatus !== 'connected') {
               logger.debug(`🔗 Connection established, will initialize... (transitioning from ${currentStatus})`);
               // Set to configuring and trigger initialization
-              (async () => {
+              void (async () => {
                 setConnectionStatus('configuring');
                 setError(null);
 
@@ -2881,7 +2881,7 @@ const location = useLocation();
       const pollDelays = [2000, 5000, 10000, 15000]; // 2s, 5s, 10s, 15s
       pollDelays.forEach(delay => {
         setTimeout(() => {
-          refetchPoll();
+          void refetchPoll();
         }, delay);
       });
 
@@ -3266,7 +3266,7 @@ const location = useLocation();
           ...prev,
           [message.channel]: (prev[message.channel] || []).filter(m => m.id !== message.id),
         }));
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_delete_message', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3306,7 +3306,7 @@ const location = useLocation();
           ...prev,
           [channelId]: [],
         }));
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_purge_messages', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3349,7 +3349,7 @@ const location = useLocation();
           setMessages(prev => prev.filter(m => !(m.fromNodeId === nodeId || m.toNodeId === nodeId)));
         }
         // Also refresh from backend to ensure consistency
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_purge_messages', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3385,7 +3385,7 @@ const location = useLocation();
         const data = await response.json();
         showToast(t('toast.purged_traceroutes', { count: data.deletedCount, node: nodeName }), 'success');
         // Refresh data from backend to ensure consistency
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_purge_traceroutes', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3423,7 +3423,7 @@ const location = useLocation();
         const data = await response.json();
         showToast(t('toast.purged_telemetry', { count: data.deletedCount, node: nodeName }), 'success');
         // Refresh data from backend to ensure consistency
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_purge_telemetry', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3460,7 +3460,7 @@ const location = useLocation();
       if (response.ok) {
         const data = await response.json();
         showToast(t('toast.purged_position_history', { count: data.deletedCount, node: nodeName }), 'success');
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_purge_position_history', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3513,7 +3513,7 @@ const location = useLocation();
           setSelectedDMNode('');
         }
         // Refresh data from backend to ensure consistency
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_delete_node', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3566,7 +3566,7 @@ const location = useLocation();
           setSelectedDMNode('');
         }
         // Refresh data from backend to ensure consistency
-        refetchPoll();
+        void refetchPoll();
       } else {
         const errorData = await response.json();
         showToast(t('toast.failed_purge_node_device', { error: errorData.message || t('errors.unknown') }), 'error');
@@ -3604,7 +3604,7 @@ const location = useLocation();
 
     showToast(t('position_override.save_success'), 'success');
     // Refresh data to get updated position
-    refetchPoll();
+    void refetchPoll();
   };
 
   const handleSendMessage = async (channel: number = 0) => {

--- a/src/cli/test-postgres.ts
+++ b/src/cli/test-postgres.ts
@@ -336,4 +336,4 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+void main();

--- a/src/components/APITokenManagement.tsx
+++ b/src/components/APITokenManagement.tsx
@@ -34,7 +34,7 @@ const APITokenManagement: React.FC = () => {
   const [showConfirmRevoke, setShowConfirmRevoke] = useState(false);
 
   useEffect(() => {
-    loadTokenInfo();
+    void loadTokenInfo();
   }, []);
 
   const loadTokenInfo = async () => {
@@ -85,7 +85,7 @@ const APITokenManagement: React.FC = () => {
   };
 
   const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+    void navigator.clipboard.writeText(text);
     showToast(t('api_token.copied'), 'success');
   };
 

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -338,7 +338,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
     }
 
     // Initial fetch
-    fetchPasskeyStatus();
+    void fetchPasskeyStatus();
 
     // Set up interval to update countdown
     const interval = setInterval(() => {

--- a/src/components/AirtimeCutoffSection.tsx
+++ b/src/components/AirtimeCutoffSection.tsx
@@ -86,8 +86,8 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   useEffect(() => {
-    fetchSettings();
-    fetchStatus();
+    void fetchSettings();
+    void fetchStatus();
   }, [fetchSettings, fetchStatus]);
 
   // Poll the live status so the banner reflects current utilization.
@@ -117,7 +117,7 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
         setInitialSource(localSource);
         setHasChanges(false);
         showToast(t('automation.airtime_cutoff.saved', 'Airtime cutoff settings saved'), 'success');
-        fetchStatus();
+        void fetchStatus();
       } else {
         showToast(t('automation.airtime_cutoff.save_error', 'Failed to save settings'), 'error');
       }

--- a/src/components/Analysis/SolarMonitoringReport.tsx
+++ b/src/components/Analysis/SolarMonitoringReport.tsx
@@ -175,7 +175,7 @@ const SolarMonitoringReport: React.FC<{ baseUrl: string }> = ({ baseUrl }) => {
             className="reports-btn"
             onClick={() => {
               if (run) {
-                refetch();
+                void refetch();
               } else {
                 setRun(true);
               }
@@ -193,7 +193,7 @@ const SolarMonitoringReport: React.FC<{ baseUrl: string }> = ({ baseUrl }) => {
             className="reports-btn reports-btn--ghost"
             onClick={() => {
               if (runForecast) {
-                refetchForecast();
+                void refetchForecast();
               } else {
                 setRunForecast(true);
               }

--- a/src/components/AuditLogTab.tsx
+++ b/src/components/AuditLogTab.tsx
@@ -67,9 +67,9 @@ const AuditLogTab: React.FC = () => {
   const itemsPerPage = filters.limit;
 
   useEffect(() => {
-    fetchLogs();
-    fetchStats();
-    fetchUsers();
+    void fetchLogs();
+    void fetchStats();
+    void fetchUsers();
   }, [filters]);
 
   const fetchLogs = async () => {

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -115,7 +115,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
       }
     };
 
-    fetchLastAnnouncementTime();
+    void fetchLastAnnouncementTime();
     // Refresh every 30 seconds
     const interval = setInterval(fetchLastAnnouncementTime, 30000);
     return () => clearInterval(interval);
@@ -322,7 +322,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
 
   // Stable callbacks
   const handleSendNowClick = useCallback(() => {
-    handleSendNow();
+    void handleSendNow();
   }, [handleSendNow]);
 
   const createInsertTokenHandler = useCallback((token: string) => {

--- a/src/components/AutoDeleteByDistanceSection.tsx
+++ b/src/components/AutoDeleteByDistanceSection.tsx
@@ -116,7 +116,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
   }, [sourceQuery]);
 
   useEffect(() => {
-    fetchLog();
+    void fetchLog();
     pollRef.current = setInterval(fetchLog, 30_000);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
@@ -199,7 +199,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
           t('automation.distance_delete.run_result', { count: result.deletedCount }),
           result.deletedCount > 0 ? 'warning' : 'success'
         );
-        fetchLog(); // Refresh log
+        void fetchLog(); // Refresh log
       } else {
         showToast(t('automation.settings_save_failed'), 'error');
       }

--- a/src/components/AutoFavoriteSection.tsx
+++ b/src/components/AutoFavoriteSection.tsx
@@ -64,7 +64,7 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
     }
   }, [baseUrl, csrfFetch, sourceQuery]);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => { void fetchData(); }, [fetchData]);
 
   useEffect(() => {
     if (!initialSettings) return;
@@ -89,7 +89,7 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
         setInitialSettings({ enabled: localEnabled, staleHours: localStaleHours });
         setHasChanges(false);
         showToast(t('automation.auto_favorite.saved', 'Auto Favorite settings saved'), 'success');
-        fetchData();
+        void fetchData();
       } else {
         showToast(t('automation.auto_favorite.save_error', 'Failed to save settings'), 'error');
       }
@@ -322,7 +322,7 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
                               });
                               if (resp.ok) {
                                 showToast(t('automation.auto_favorite.node_locked', 'Node locked from automation'), 'success');
-                                fetchData();
+                                void fetchData();
                               } else {
                                 showToast(t('automation.auto_favorite.lock_error', 'Failed to lock node'), 'error');
                               }

--- a/src/components/AutoHeapManagementSection.tsx
+++ b/src/components/AutoHeapManagementSection.tsx
@@ -58,8 +58,8 @@ const AutoHeapManagementSection: React.FC<AutoHeapManagementSectionProps> = ({ b
   }, [baseUrl, csrfFetch, currentNodeId]);
 
   useEffect(() => {
-    fetchSettings();
-    fetchHeapStatus();
+    void fetchSettings();
+    void fetchHeapStatus();
   }, [fetchSettings, fetchHeapStatus]);
 
   useEffect(() => {

--- a/src/components/AutoKeyManagementSection.tsx
+++ b/src/components/AutoKeyManagementSection.tsx
@@ -105,7 +105,7 @@ const AutoKeyManagementSection: React.FC<AutoKeyManagementSectionProps> = ({
       }
     };
 
-    fetchLog();
+    void fetchLog();
     // Refresh log every 30 seconds
     const interval = setInterval(fetchLog, 30000);
     return () => clearInterval(interval);

--- a/src/components/AutoLocalStatsSection.tsx
+++ b/src/components/AutoLocalStatsSection.tsx
@@ -116,7 +116,7 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
         console.error('Failed to fetch nodes:', error);
       }
     };
-    fetchNodes();
+    void fetchNodes();
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   // Fetch filter + general settings together
@@ -174,7 +174,7 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
         console.error('Failed to fetch remote LocalStats settings:', error);
       }
     };
-    fetchAllSettings();
+    void fetchAllSettings();
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   // Reset baselines when the source changes.

--- a/src/components/AutoPingSection.tsx
+++ b/src/components/AutoPingSection.tsx
@@ -79,7 +79,7 @@ const AutoPingSection: React.FC<AutoPingSectionProps> = ({ baseUrl }) => {
   }, [sourceId]);
 
   useEffect(() => {
-    fetchData();
+    void fetchData();
   }, [baseUrl, csrfFetch, sourceQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll for active sessions
@@ -178,7 +178,7 @@ const AutoPingSection: React.FC<AutoPingSectionProps> = ({ baseUrl }) => {
       });
       if (response.ok) {
         showToast(t('automation.auto_ping.session_stopped', 'Ping session stopped'), 'success');
-        fetchData();
+        void fetchData();
       }
     } catch (error) {
       console.error('Failed to stop ping session:', error);

--- a/src/components/AutoResponderSection.tsx
+++ b/src/components/AutoResponderSection.tsx
@@ -127,7 +127,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
     };
 
   useEffect(() => {
-    fetchScripts();
+    void fetchScripts();
   }, [baseUrl]);
 
   // Script management handlers
@@ -1330,7 +1330,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                     <button
                                       onClick={() => {
                                         if (newTriggerLiveTestResult?.result) {
-                                          navigator.clipboard.writeText(newTriggerLiveTestResult.result);
+                                          void navigator.clipboard.writeText(newTriggerLiveTestResult.result);
                                           showToast(t('common.copied_to_clipboard'), 'success');
                                         }
                                       }}
@@ -1965,7 +1965,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 <button
                                   onClick={() => {
                                     if (quickTestResult?.result) {
-                                      navigator.clipboard.writeText(quickTestResult.result);
+                                      void navigator.clipboard.writeText(quickTestResult.result);
                                       showToast(t('common.copied_to_clipboard'), 'success');
                                     }
                                   }}
@@ -2205,7 +2205,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       <button
                                         onClick={() => {
                                           if (liveTestResults[index]?.result) {
-                                            navigator.clipboard.writeText(liveTestResults[index].result!);
+                                            void navigator.clipboard.writeText(liveTestResults[index].result!);
                                             showToast(t('common.copied_to_clipboard'), 'success');
                                           }
                                         }}
@@ -2399,7 +2399,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                       filenameDisplay.textContent = `Selected: ${file.name}`;
                       filenameDisplay.style.color = 'var(--ctp-green)';
                     }
-                    handleImportScript(file);
+                    void handleImportScript(file);
                   } else {
                     if (filenameDisplay) {
                       filenameDisplay.textContent = 'No file selected';

--- a/src/components/AutoTimeSyncSection.tsx
+++ b/src/components/AutoTimeSyncSection.tsx
@@ -74,7 +74,7 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
         console.error('Failed to fetch nodes:', error);
       }
     };
-    fetchNodes();
+    void fetchNodes();
   }, [baseUrl, csrfFetch, currentNodeId, sourceQuery]);
 
   // Fetch current settings
@@ -95,7 +95,7 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
         console.error('Failed to fetch time sync settings:', error);
       }
     };
-    fetchSettings();
+    void fetchSettings();
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   // Reset initial settings when the selected source changes so SaveBar

--- a/src/components/AutoTracerouteSection.tsx
+++ b/src/components/AutoTracerouteSection.tsx
@@ -160,7 +160,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
         console.error('Failed to fetch nodes:', error);
       }
     };
-    fetchNodes();
+    void fetchNodes();
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   // Fetch current filter settings and schedule settings together to avoid race conditions
@@ -236,7 +236,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
         console.error('Failed to fetch settings:', error);
       }
     };
-    fetchAllSettings();
+    void fetchAllSettings();
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   // Reset initial settings when the selected source changes so the
@@ -261,12 +261,12 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
     };
 
     // Initial fetch
-    fetchTracerouteLog();
+    void fetchTracerouteLog();
 
     // Refresh every 30 seconds if auto-traceroute is enabled
     const intervalId = setInterval(() => {
       if (localEnabled) {
-        fetchTracerouteLog();
+        void fetchTracerouteLog();
       }
     }, 30000);
 

--- a/src/components/ChannelSoundPicker.tsx
+++ b/src/components/ChannelSoundPicker.tsx
@@ -64,7 +64,7 @@ const ChannelSoundPicker: React.FC = () => {
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const qs = currentSourceId ? `?sourceId=${encodeURIComponent(currentSourceId)}` : '';
         const response = await api.get<Channel[]>(`/api/channels${qs}`);

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -257,7 +257,7 @@ export default function ChannelsTab({
         // Default to false if we can't fetch settings
       }
     };
-    fetchHomoglyphSetting();
+    void fetchHomoglyphSetting();
   }, []);
 
   // Memoize byte count to avoid redundant homoglyph optimization on each render
@@ -572,7 +572,7 @@ export default function ChannelsTab({
                   setSelectedChannel(channelId);
                   selectedChannelRef.current = channelId;
                   setReplyingTo(null);
-                  markMessagesAsRead(undefined, channelId);
+                  void markMessagesAsRead(undefined, channelId);
                   setUnreadCounts(prev => {
                     const updated = { ...prev, [channelId]: 0 };
                     logger.debug('📝 Setting unread counts:', updated);
@@ -690,7 +690,7 @@ export default function ChannelsTab({
               <button
                 className="btn btn-secondary"
                 onClick={() => {
-                  markMessagesAsRead(undefined, selectedChannel);
+                  void markMessagesAsRead(undefined, selectedChannel);
                 }}
                 title={t('channels.mark_all_read_title')}
                 style={{ padding: '0.4rem 0.75rem', fontSize: '0.9rem', whiteSpace: 'nowrap' }}
@@ -736,7 +736,7 @@ export default function ChannelsTab({
                     </button>
                     <button
                       className="channel-overflow-item"
-                      onClick={() => { setShowChannelMenu(false); markMessagesAsRead(undefined, selectedChannel); }}
+                      onClick={() => { setShowChannelMenu(false); void markMessagesAsRead(undefined, selectedChannel); }}
                     >
                       ✅ {t('channels.mark_all_read_button')}
                     </button>
@@ -800,7 +800,7 @@ export default function ChannelsTab({
                       setSelectedChannel(channelId);
                       selectedChannelRef.current = channelId;
                       setReplyingTo(null);
-                      markMessagesAsRead(undefined, channelId);
+                      void markMessagesAsRead(undefined, channelId);
                       setUnreadCounts(prev => {
                         const updated = { ...prev, [channelId]: 0 };
                         logger.debug('📝 Setting unread counts:', updated);
@@ -1190,7 +1190,7 @@ export default function ChannelsTab({
                                   !e.nativeEvent.isComposing
                                 ) {
                                   e.preventDefault();
-                                  handleSendMessage(selectedChannel);
+                                  void handleSendMessage(selectedChannel);
                                 }
                               }}
                             />
@@ -1204,7 +1204,7 @@ export default function ChannelsTab({
                             onChange={setNewMessage}
                           />
                           <button
-                            onClick={() => { onSendBell?.(selectedChannel, newMessage); setNewMessage(''); }}
+                            onClick={() => { void onSendBell?.(selectedChannel, newMessage); setNewMessage(''); }}
                             className="send-btn channel-action-btn"
                             title="Send alert bell"
                             aria-label="Send alert bell"
@@ -1377,7 +1377,7 @@ export default function ChannelsTab({
                       <button
                         onClick={() => {
                           handleCloseModal();
-                          handlePurgeChannelMessages(channelInfoModal);
+                          void handlePurgeChannelMessages(channelInfoModal);
                         }}
                         style={{
                           width: '100%',

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -760,7 +760,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
       }
     };
 
-    fetchConfig();
+    void fetchConfig();
   }, [refreshTrigger, sourceId]); // Re-run when refreshTrigger or sourceId changes
 
   // Separate effect to load position data when nodes become available
@@ -794,7 +794,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
       }
     };
 
-    loadPositionFromNodes();
+    void loadPositionFromNodes();
   }, [nodes]); // Run when nodes first populate
 
   const handleSaveDeviceConfig = async () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -273,7 +273,7 @@ export default function DashboardMap({
   const [geoJsonLayers, setGeoJsonLayers] = useState<GeoJsonLayer[]>([]);
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const baseUrl = await api.getBaseUrl();
         const response = await fetch(`${baseUrl}/api/geojson/layers`);

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -745,7 +745,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
                   disabled={!source.enabled}
                   onClick={(e) => {
                     e.stopPropagation();
-                    navigate(`/source/${source.id}`);
+                    void navigate(`/source/${source.id}`);
                   }}
                 >
                   {t('source.open')}

--- a/src/components/Dashboard/hooks/useCustomWidgets.ts
+++ b/src/components/Dashboard/hooks/useCustomWidgets.ts
@@ -64,14 +64,14 @@ export function useCustomWidgets({
 
     const newWidgets = [...customWidgets, newWidget];
     setCustomWidgets(newWidgets);
-    saveWidgets(newWidgets);
+    void saveWidgets(newWidgets);
   }, [customWidgets, setCustomWidgets, saveWidgets]);
 
   // Remove a widget
   const removeWidget = useCallback((widgetId: string) => {
     const newWidgets = customWidgets.filter(w => w.id !== widgetId);
     setCustomWidgets(newWidgets);
-    saveWidgets(newWidgets);
+    void saveWidgets(newWidgets);
   }, [customWidgets, setCustomWidgets, saveWidgets]);
 
   // Add node to NodeStatus widget
@@ -83,7 +83,7 @@ export function useCustomWidgets({
       return w;
     });
     setCustomWidgets(newWidgets);
-    saveWidgets(newWidgets);
+    void saveWidgets(newWidgets);
   }, [customWidgets, setCustomWidgets, saveWidgets]);
 
   // Remove node from NodeStatus widget
@@ -95,7 +95,7 @@ export function useCustomWidgets({
       return w;
     });
     setCustomWidgets(newWidgets);
-    saveWidgets(newWidgets);
+    void saveWidgets(newWidgets);
   }, [customWidgets, setCustomWidgets, saveWidgets]);
 
   // Set target node for Traceroute widget
@@ -107,7 +107,7 @@ export function useCustomWidgets({
       return w;
     });
     setCustomWidgets(newWidgets);
-    saveWidgets(newWidgets);
+    void saveWidgets(newWidgets);
   }, [customWidgets, setCustomWidgets, saveWidgets]);
 
   // Update widget configuration (e.g., bucket size for distance distribution)
@@ -119,7 +119,7 @@ export function useCustomWidgets({
       return w;
     });
     setCustomWidgets(newWidgets);
-    saveWidgets(newWidgets);
+    void saveWidgets(newWidgets);
   }, [customWidgets, setCustomWidgets, saveWidgets]);
 
   return {

--- a/src/components/EmbedMap.tsx
+++ b/src/components/EmbedMap.tsx
@@ -148,7 +148,7 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
         }
       }
     }
-    fetchConfig();
+    void fetchConfig();
     return () => { cancelled = true; };
   }, [profileId, baseUrl]);
 
@@ -196,7 +196,7 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
   useEffect(() => {
     if (!config) return;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await fetch(`${baseUrl}/api/embed/${profileId}/geojson/layers`);
         if (!res.ok) return;
@@ -213,15 +213,15 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
   useEffect(() => {
     if (!config) return;
 
-    fetchNodes();
-    fetchNeighborInfo();
-    fetchTraceroutes();
+    void fetchNodes();
+    void fetchNeighborInfo();
+    void fetchTraceroutes();
 
     const intervalMs = (config.pollIntervalSeconds || 30) * 1000;
     pollTimerRef.current = setInterval(() => {
-      fetchNodes();
-      fetchNeighborInfo();
-      fetchTraceroutes();
+      void fetchNodes();
+      void fetchNeighborInfo();
+      void fetchTraceroutes();
     }, intervalMs);
 
     return () => {

--- a/src/components/GeoJsonLayerManager.tsx
+++ b/src/components/GeoJsonLayerManager.tsx
@@ -25,7 +25,7 @@ const GeoJsonLayerManager: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    fetchLayers();
+    void fetchLayers();
   }, [fetchLayers]);
 
   const handleUpload = async (file: File) => {
@@ -104,7 +104,7 @@ const GeoJsonLayerManager: React.FC = () => {
             style={{ display: 'none' }}
             onChange={(e) => {
               const file = e.target.files?.[0];
-              if (file) handleUpload(file);
+              if (file) void handleUpload(file);
             }}
           />
           <button

--- a/src/components/GeoJsonOverlay.tsx
+++ b/src/components/GeoJsonOverlay.tsx
@@ -43,7 +43,7 @@ const GeoJsonOverlay: React.FC<GeoJsonOverlayProps> = ({
   useEffect(() => {
     layers.forEach(layer => {
       if (layer.visible && !dataCache[layer.id]) {
-        fetchLayerData(layer);
+        void fetchLayerData(layer);
       }
     });
   }, [layers, dataCache, fetchLayerData]);

--- a/src/components/GeofenceTriggersSection.tsx
+++ b/src/components/GeofenceTriggersSection.tsx
@@ -125,7 +125,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
         console.error('Failed to fetch available scripts:', error);
       }
     };
-    fetchScripts();
+    void fetchScripts();
   }, [baseUrl]);
 
   const handleSaveForSaveBar = useCallback(async () => {

--- a/src/components/IgnoredNodesSection.tsx
+++ b/src/components/IgnoredNodesSection.tsx
@@ -48,7 +48,7 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   useEffect(() => {
-    fetchIgnoredNodes();
+    void fetchIgnoredNodes();
   }, [fetchIgnoredNodes]);
 
   const handleRemove = async (node: IgnoredNode) => {

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -268,43 +268,43 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
   };
 
   useEffect(() => {
-    fetchRouteSegments();
+    void fetchRouteSegments();
     const interval = setInterval(fetchRouteSegments, 60000); // Refresh every minute
     return () => clearInterval(interval);
   }, [connectionStatus, activeSourceId]);
 
   useEffect(() => {
-    fetchVirtualNodeStatus();
+    void fetchVirtualNodeStatus();
     const interval = setInterval(fetchVirtualNodeStatus, 60000); // Refresh every minute
     return () => clearInterval(interval);
   }, [connectionStatus]);
 
   useEffect(() => {
-    fetchServerInfo();
+    void fetchServerInfo();
     const interval = setInterval(fetchServerInfo, 60000); // Refresh every minute
     return () => clearInterval(interval);
   }, [connectionStatus]);
 
   useEffect(() => {
-    fetchLocalStats();
+    void fetchLocalStats();
     const interval = setInterval(fetchLocalStats, 60000); // Refresh every minute
     return () => clearInterval(interval);
   }, [connectionStatus, currentNodeId, activeSourceId]);
 
   useEffect(() => {
-    fetchSecurityKeys();
+    void fetchSecurityKeys();
     // Only fetch once when connected and authenticated - keys don't change frequently
   }, [connectionStatus, isAuthenticated, activeSourceId]);
 
   useEffect(() => {
-    fetchPacketDistribution();
+    void fetchPacketDistribution();
     const interval = setInterval(fetchPacketDistribution, 60000); // Refresh every minute
     return () => clearInterval(interval);
   }, [fetchPacketDistribution]);
 
   useEffect(() => {
     if (selectedPortnum !== null) {
-      fetchPortnumNodeDistribution();
+      void fetchPortnumNodeDistribution();
       const interval = setInterval(fetchPortnumNodeDistribution, 60000);
       return () => clearInterval(interval);
     }
@@ -328,7 +328,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
 
   // Stable callbacks
   const handleClearRecordClick = useCallback(() => {
-    handleClearRecordHolder();
+    void handleClearRecordHolder();
   }, [handleClearRecordHolder]);
 
   const handleCancelConfirm = useCallback(() => {
@@ -336,7 +336,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
   }, []);
 
   const handleConfirmClear = useCallback(() => {
-    confirmClearRecordHolder();
+    void confirmClearRecordHolder();
   }, [confirmClearRecordHolder]);
 
   return (

--- a/src/components/LinkPreview.tsx
+++ b/src/components/LinkPreview.tsx
@@ -42,7 +42,7 @@ export const LinkPreview: React.FC<LinkPreviewProps> = ({ text }) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting && !hasLoaded) {
             console.log('[LinkPreview] Message entered viewport, loading preview');
-            loadPreviews();
+            void loadPreviews();
             setHasLoaded(true);
             // Stop observing once loaded
             if (containerRef.current) {

--- a/src/components/MFAManagement.tsx
+++ b/src/components/MFAManagement.tsx
@@ -34,7 +34,7 @@ const MFAManagement: React.FC = () => {
   const [backupCodesCopied, setBackupCodesCopied] = useState(false);
 
   useEffect(() => {
-    loadStatus();
+    void loadStatus();
   }, []);
 
   const loadStatus = async () => {
@@ -71,7 +71,7 @@ const MFAManagement: React.FC = () => {
       setSetupData(null);
       setVerifyCode('');
       showToast(t('mfa.enabled_success'), 'success');
-      refreshAuth();
+      void refreshAuth();
     } catch (error) {
       logger.error('Failed to verify MFA setup:', error);
       showToast(t('mfa.invalid_code'), 'error');
@@ -93,7 +93,7 @@ const MFAManagement: React.FC = () => {
       setDisableCode('');
       setShowDisableConfirm(false);
       showToast(t('mfa.disabled_success'), 'success');
-      refreshAuth();
+      void refreshAuth();
     } catch (error) {
       logger.error('Failed to disable MFA:', error);
       showToast(t('mfa.invalid_code'), 'error');
@@ -105,7 +105,7 @@ const MFAManagement: React.FC = () => {
 
   const copyBackupCodes = () => {
     if (setupData) {
-      navigator.clipboard.writeText(setupData.backupCodes.join('\n'));
+      void navigator.clipboard.writeText(setupData.backupCodes.join('\n'));
       showToast(t('mfa.backup_codes_copied'), 'success');
       setBackupCodesCopied(true);
     }

--- a/src/components/MQTT/MqttBridgeConfigurationView.tsx
+++ b/src/components/MQTT/MqttBridgeConfigurationView.tsx
@@ -93,7 +93,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
     let cancelled = false;
     setLoading(true);
     setLoadError('');
-    (async () => {
+    void (async () => {
       try {
         const [srcRes, listRes, chDbRes, srcChRes] = await Promise.all([
           csrfFetch(`${appBasename}/api/sources/${sourceId}`),

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -60,10 +60,10 @@ export default function NodeMarkersLayer() {
   // mirrors the Unified/Dashboard map (DashboardPage.handleNodeSourceSelect).
   const handleSourceSelect = (source: NodeSourceRef, nodeId: string | undefined) => {
     if (source.protocol === 'MeshCore') {
-      navigate(`/source/${source.sourceId}/`);
+      void navigate(`/source/${source.sourceId}/`);
       return;
     }
-    navigate(`/source/${source.sourceId}/#messages`, {
+    void navigate(`/source/${source.sourceId}/#messages`, {
       state: nodeId ? { focusDmNodeId: nodeId } : undefined,
     });
   };

--- a/src/components/MapStyleManager.tsx
+++ b/src/components/MapStyleManager.tsx
@@ -31,7 +31,7 @@ const MapStyleManager: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    fetchStyles();
+    void fetchStyles();
   }, [fetchStyles]);
 
   const handleUpload = async (file: File) => {
@@ -170,7 +170,7 @@ const MapStyleManager: React.FC = () => {
               style={{ display: 'none' }}
               onChange={(e) => {
                 const file = e.target.files?.[0];
-                if (file) handleUpload(file);
+                if (file) void handleUpload(file);
               }}
             />
             <button

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -97,7 +97,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
   // Load auto-ack settings
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/autoack`);
         if (!res.ok) return;
@@ -129,7 +129,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
   // Load channels for the per-channel allowlist
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(
           `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`,

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
@@ -81,7 +81,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
   // Load settings
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/announce`);
         if (!res.ok) return;
@@ -114,7 +114,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
   // Load channels
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(
           `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`,

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
@@ -103,7 +103,7 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
   // Load triggers
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/responder`);
         if (!res.ok) return;
@@ -123,7 +123,7 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
   // Load channels
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
         if (!res.ok) return;
@@ -144,7 +144,7 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
   // Load available scripts (responseType='script' picker).
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/scripts`);
         if (!res.ok) return;

--- a/src/components/MeshCore/MeshCoreAutomationsView.tsx
+++ b/src/components/MeshCore/MeshCoreAutomationsView.tsx
@@ -74,7 +74,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
   }, [baseUrl, sourceId, csrfFetch]);
 
   useEffect(() => {
-    fetchSettings();
+    void fetchSettings();
   }, [fetchSettings]);
 
   useEffect(() => {

--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
@@ -126,7 +126,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
   useEffect(() => {
     if (!sourceId) return;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/saved-regions`;
         const response = await csrfFetch(url);
@@ -146,7 +146,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
     if (!sourceId) return;
     let cancelled = false;
     setLoading(true);
-    (async () => {
+    void (async () => {
       try {
         const url = `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`;
         const response = await csrfFetch(url);
@@ -193,7 +193,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
     const name = editName.trim();
     if (!name.startsWith('#')) return;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const hex = await deriveHashtagSecretHex(name);
         if (!cancelled) setEditSecretHex(hex);

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -213,7 +213,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     if (!sourceId) return;
     let cancelled = false;
     setLoadingChannels(true);
-    (async () => {
+    void (async () => {
       try {
         const url = `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`;
         const response = await csrfFetch(url);
@@ -267,7 +267,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   useEffect(() => {
     if (!sourceId || !channelIdsKey) return;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/messages/channel-counts?channels=${encodeURIComponent(channelIdsKey)}`;
         const response = await csrfFetch(url);
@@ -307,7 +307,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   useEffect(() => {
     if (!status?.connected) return;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const def = await getDefaultScope();
         if (!cancelled) setDefaultScope(def ?? '');
@@ -323,7 +323,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // mount / source change regardless of connection state.
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const rows = await fetchSavedRegions();
         if (!cancelled && rows) setSavedRegions(rows.map(r => r.name));
@@ -355,7 +355,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     if (regionsDiscoveredRef.current) return;
     regionsDiscoveredRef.current = true;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await discoverRegions();
         if (!cancelled && res?.regions) setDiscoveredRegions(res.regions);
@@ -381,7 +381,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     if (!sourceId) return;
     let cancelled = false;
     const idx = active.id;
-    (async () => {
+    void (async () => {
       try {
         const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/messages/channel/${idx}?limit=200`;
         const response = await csrfFetch(url);

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -224,7 +224,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const [retentionDays, setRetentionDays] = useState(7);
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const settings = await api.get<Record<string, string>>('/api/settings');
         const raw = settings?.meshcore_position_history_retention_days;
@@ -254,7 +254,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const [geoJsonLayers, setGeoJsonLayers] = useState<GeoJsonLayer[]>([]);
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const baseUrl = await api.getBaseUrl();
         const response = await fetch(`${baseUrl}/api/geojson/layers`);
@@ -365,7 +365,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     let cancelled = false;
     const keys = historyKeysSig ? historyKeysSig.split('|') : [];
     const since = Date.now() - positionHistoryHours * 60 * 60 * 1000;
-    (async () => {
+    void (async () => {
       const next = new Map<string, [number, number][]>();
       await Promise.all(keys.map(async (publicKey) => {
         try {

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -71,7 +71,7 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
     setError(null);
     setSaved(false);
     setPollMsg(null);
-    (async () => {
+    void (async () => {
       try {
         const response = await csrfFetch(endpoint);
         const data = await response.json();

--- a/src/components/MeshCore/MeshCoreRoomsView.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.tsx
@@ -88,7 +88,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
 
   // Fetch credential capability on mount
   useEffect(() => {
-    (async () => {
+    void (async () => {
       const creds = await actions.getRoomCredentials();
       if (creds) {
         setCanRemember(creds.canRemember);
@@ -135,7 +135,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
     if (autoLoginAttempted.current.has(selectedRoom)) return;
 
     autoLoginAttempted.current.add(selectedRoom);
-    (async () => {
+    void (async () => {
       setLoginLoading(true);
       const result = await actions.loginRoomWithSaved(selectedRoom);
       if (result.success) {
@@ -163,7 +163,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
     setLoginPassword('');
     setRememberPassword(false);
     setSyncConfigDirty(false);
-    loadSyncConfig(pubkey);
+    void loadSyncConfig(pubkey);
     if (isMobileViewport()) setMobileShowContent(true);
   }, [loadSyncConfig]);
 

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
@@ -100,7 +100,7 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
   // Load triggers
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/timers`);
         if (!res.ok) return;
@@ -120,7 +120,7 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
   // Load channels
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
         if (!res.ok) return;
@@ -142,7 +142,7 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
   // with Meshtastic — /api/scripts is protocol-neutral.
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/scripts`);
         if (!res.ok) return;
@@ -160,7 +160,7 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
   // Load contacts (for DM destination)
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/contacts`);
         if (!res.ok) return;

--- a/src/components/MeshCore/ScopeSelectField.tsx
+++ b/src/components/MeshCore/ScopeSelectField.tsx
@@ -46,7 +46,7 @@ export function ScopeSelectField({
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/saved-regions`);
         if (!res.ok) return; // e.g. no configuration:read — degrade to free-text entry

--- a/src/components/MeshCore/hooks/useMeshCoreUnread.ts
+++ b/src/components/MeshCore/hooks/useMeshCoreUnread.ts
@@ -65,7 +65,7 @@ export function useMeshCoreUnread({
       return;
     }
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const res = await csrfFetch(`${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
         if (!res.ok) return;
@@ -103,7 +103,7 @@ export function useMeshCoreUnread({
         /* ignore */
       }
     };
-    fetchLatest();
+    void fetchLatest();
     const id = setInterval(fetchLatest, CHANNEL_POLL_MS);
     return () => { cancelled = true; clearInterval(id); };
   }, [enabled, sourceId, baseUrl, csrfFetch, channelIndices]);

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -356,7 +356,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
         // Default to false if we can't fetch settings
       }
     };
-    fetchHomoglyphSetting();
+    void fetchHomoglyphSetting();
   }, []);
 
   // Close position channel dropdown on click outside
@@ -618,7 +618,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   }, [selectedNodeNum]);
 
   useEffect(() => {
-    fetchNodePacketDistribution();
+    void fetchNodePacketDistribution();
     const interval = setInterval(fetchNodePacketDistribution, 60000);
     return () => clearInterval(interval);
   }, [fetchNodePacketDistribution]);
@@ -863,7 +863,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         const nodeId = node.user?.id || '';
                         setSelectedDMNode(nodeId);
                         setReplyingTo(null);
-                        if (nodeId) markMessagesAsRead(undefined, -1, nodeId);
+                        if (nodeId) void markMessagesAsRead(undefined, -1, nodeId);
                       }}
                     >
                       <div className="node-header">
@@ -1029,7 +1029,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               const nodeId = e.target.value;
               setSelectedDMNode(nodeId);
               setReplyingTo(null);
-              if (nodeId) markMessagesAsRead(undefined, -1, nodeId);
+              if (nodeId) void markMessagesAsRead(undefined, -1, nodeId);
             }}
           >
             <option value="">{t('messages.select_conversation')}</option>
@@ -1150,7 +1150,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               <button
                                 className="actions-menu-item"
                                 onClick={() => {
-                                  handleTraceroute(selectedDMNode);
+                                  void handleTraceroute(selectedDMNode);
                                   setShowActionsMenu(false);
                                 }}
                                 disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode}
@@ -1181,7 +1181,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             <button
                               className="actions-menu-item"
                               onClick={() => {
-                                handleExchangePosition(selectedDMNode);
+                                void handleExchangePosition(selectedDMNode);
                                 setShowActionsMenu(false);
                               }}
                               disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode}
@@ -1192,7 +1192,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             <button
                               className="actions-menu-item"
                               onClick={() => {
-                                handleExchangeNodeInfo(selectedDMNode);
+                                void handleExchangeNodeInfo(selectedDMNode);
                                 setShowActionsMenu(false);
                               }}
                               disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode}
@@ -1234,7 +1234,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                           <button
                             className="actions-menu-item"
                             onClick={() => {
-                              handleScanForAdmin(selectedDMNode);
+                              void handleScanForAdmin(selectedDMNode);
                               setShowActionsMenu(false);
                             }}
                             disabled={connectionStatus !== 'connected' || adminScanLoading === selectedDMNode}
@@ -1251,7 +1251,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             <button
                               className="actions-menu-item"
                               onClick={(e) => {
-                                toggleFavorite(selectedNode, e);
+                                void toggleFavorite(selectedNode, e);
                                 setShowActionsMenu(false);
                               }}
                             >
@@ -1260,7 +1260,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             <button
                               className="actions-menu-item"
                               onClick={(e) => {
-                                toggleFavoriteLock(selectedNode, e);
+                                void toggleFavoriteLock(selectedNode, e);
                                 setShowActionsMenu(false);
                               }}
                             >
@@ -1269,7 +1269,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             <button
                               className="actions-menu-item"
                               onClick={(e) => {
-                                toggleIgnored(selectedNode, e);
+                                void toggleIgnored(selectedNode, e);
                                 setShowActionsMenu(false);
                               }}
                             >
@@ -1308,7 +1308,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                           <button
                             className="actions-menu-item"
                             onClick={(e) => {
-                              toggleHideFromMap(selectedNode, e);
+                              void toggleHideFromMap(selectedNode, e);
                               setShowActionsMenu(false);
                             }}
                           >
@@ -1662,7 +1662,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             !e.nativeEvent.isComposing
                           ) {
                             e.preventDefault();
-                            handleSendDirectMessage(selectedDMNode);
+                            void handleSendDirectMessage(selectedDMNode);
                           }
                         }}
                       />
@@ -1676,7 +1676,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       onChange={setNewMessage}
                     />
                     <button
-                      onClick={() => { onSendBell?.(selectedDMNode, newMessage); setNewMessage(''); }}
+                      onClick={() => { void onSendBell?.(selectedDMNode, newMessage); setNewMessage(''); }}
                       className="send-btn channel-action-btn"
                       title="Send alert bell"
                       aria-label="Send alert bell"
@@ -1952,7 +1952,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         <button
                           key={ch.id}
                           onClick={() => {
-                            handleTraceroute(selectedDMNode, ch.id);
+                            void handleTraceroute(selectedDMNode, ch.id);
                             setShowTracerouteChannelDropdown(false);
                           }}
                           style={{
@@ -2038,7 +2038,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         <button
                           key={ch.id}
                           onClick={() => {
-                            handleExchangeNodeInfo(selectedDMNode, ch.id);
+                            void handleExchangeNodeInfo(selectedDMNode, ch.id);
                             setShowNodeInfoChannelDropdown(false);
                           }}
                           style={{
@@ -2124,7 +2124,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         <button
                           key={ch.id}
                           onClick={() => {
-                            handleExchangePosition(selectedDMNode, ch.id);
+                            void handleExchangePosition(selectedDMNode, ch.id);
                             setShowPositionChannelDropdown(false);
                           }}
                           style={{
@@ -2315,7 +2315,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
           isOpen={showTelemetryRequestModal}
           onClose={() => setShowTelemetryRequestModal(false)}
           onRequest={(telemetryType: TelemetryType) => {
-            handleRequestTelemetry(selectedDMNode, telemetryType);
+            void handleRequestTelemetry(selectedDMNode, telemetryType);
             setShowTelemetryRequestModal(false);
           }}
           loading={telemetryRequestLoading === selectedDMNode}

--- a/src/components/NewsPopup/NewsPopup.tsx
+++ b/src/components/NewsPopup/NewsPopup.tsx
@@ -99,7 +99,7 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
       }
     };
 
-    fetchData();
+    void fetchData();
   }, [isOpen, forceShowAll, isAuthenticated]);
 
   // Reset state when popup closes
@@ -148,7 +148,7 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
       // Scroll content to top for new item
       contentRef.current?.scrollTo({ top: 0, behavior: 'instant' });
     } else {
-      handleClose();
+      void handleClose();
     }
   }, [currentIndex, newsItems.length, handleClose]);
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -504,7 +504,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       },
       onDelete: (wp: Waypoint) => {
         if (lockedToOther(wp)) return;
-        handleDeleteWaypoint(wp);
+        void handleDeleteWaypoint(wp);
       },
     }),
     [canWriteWaypoints, lockedToOther, handleEditWaypoint, handleDeleteWaypoint],
@@ -816,7 +816,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       }
     };
 
-    fetchPacketLogStatus();
+    void fetchPacketLogStatus();
   }, [canViewPacketMonitor]);
 
   useEffect(() => {
@@ -831,7 +831,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         console.error('Failed to fetch GeoJSON layers:', err);
       }
     };
-    fetchGeoJsonLayers();
+    void fetchGeoJsonLayers();
   }, []);
 
   useEffect(() => {
@@ -875,7 +875,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         console.error('Failed to fetch map styles:', err);
       }
     };
-    fetchMapStyles();
+    void fetchMapStyles();
   }, []);
 
   // Refs to access latest values without recreating listeners
@@ -941,7 +941,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   const handleLockClick = useCallback((node: DeviceInfo) => {
     return (e: React.MouseEvent) => {
-      if (toggleFavoriteLock) toggleFavoriteLock(node, e);
+      if (toggleFavoriteLock) void toggleFavoriteLock(node, e);
     };
   }, [toggleFavoriteLock]);
 
@@ -2103,7 +2103,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                             setActiveStyleId(styleId);
                             try { localStorage.setItem('meshmonitor-activeMapStyleId', styleId ?? ''); } catch { /* ignore */ }
                             // Save as server default so incognito/new browsers get this style
-                            api.getBaseUrl().then(baseUrl => {
+                            void api.getBaseUrl().then(baseUrl => {
                               csrfFetch(`${baseUrl}/api/settings`, {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },

--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -112,8 +112,8 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
 
   // Check notification permission and subscription status
   useEffect(() => {
-    checkNotificationStatus();
-    loadVapidStatus();
+    void checkNotificationStatus();
+    void loadVapidStatus();
   }, []);
 
   // Reload source-scoped data whenever the active source changes. Preferences
@@ -123,8 +123,8 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
   // channels.length > 0 previously meant MeshCore sources — which return no
   // Meshtastic channels — never loaded their saved preferences.
   useEffect(() => {
-    loadChannels().finally(() => loadPreferences());
-    loadNodes();
+    void loadChannels().finally(() => loadPreferences());
+    void loadNodes();
   }, [currentSourceId]);
 
   // Fetch available nodes

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -131,7 +131,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
       !loadingMore &&
       packets.length > 0
     ) {
-      loadMore();
+      void loadMore();
     }
   }, [lastVirtualItemIndex, packets.length, hasMore, loadingMore, loadMore]);
 
@@ -173,7 +173,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
       }
     };
 
-    fetchNeighborStats();
+    void fetchNeighborStats();
   }, [canView]);
 
   // Helper function to truncate long names
@@ -195,7 +195,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
     try {
       await clearPackets();
-      fetchPackets();
+      void fetchPackets();
     } catch (error) {
       console.error('Failed to clear packets:', error);
       alert(t('packet_monitor.clear_failed'));
@@ -336,7 +336,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
     try {
       // Use backend export endpoint with current filters
       // Note: hideOwnPackets is a client-side filter and not passed to backend
-      exportPackets(sourceId ? { ...filters, sourceId } : filters);
+      void exportPackets(sourceId ? { ...filters, sourceId } : filters);
     } catch (error) {
       console.error('Failed to export packets:', error);
       alert(t('packet_monitor.export_failed'));

--- a/src/components/PositionEstimationSection.tsx
+++ b/src/components/PositionEstimationSection.tsx
@@ -74,7 +74,7 @@ const PositionEstimationSection: React.FC<PositionEstimationSectionProps> = ({ b
   }, [csrfFetch, baseUrl]);
 
   useEffect(() => {
-    fetchStatus();
+    void fetchStatus();
   }, [fetchStatus]);
 
   const hasChanges =
@@ -143,7 +143,7 @@ const PositionEstimationSection: React.FC<PositionEstimationSectionProps> = ({ b
           }),
           'success'
         );
-        fetchStatus();
+        void fetchStatus();
       } else if (response.status === 409) {
         showToast(t('automation.position_estimation.already_running', 'Estimation already running'), 'warning');
       } else {

--- a/src/components/RebootModal.tsx
+++ b/src/components/RebootModal.tsx
@@ -188,7 +188,7 @@ export const RebootModal: React.FC<RebootModalProps> = ({ isOpen, onClose }) => 
 
     // Start the reboot sequence immediately
     console.log('[RebootModal] Launching waitForReboot() function...');
-    waitForReboot();
+    void waitForReboot();
 
     return () => {
       aborted = true;

--- a/src/components/RemoteAdminScannerSection.tsx
+++ b/src/components/RemoteAdminScannerSection.tsx
@@ -88,7 +88,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
         setIsLoading(false);
       }
     };
-    fetchSettings();
+    void fetchSettings();
   }, [baseUrl, csrfFetch, sourceQuery]);
 
   // Fetch scan log and stats
@@ -151,12 +151,12 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
       }
     };
 
-    fetchLogAndStats();
+    void fetchLogAndStats();
 
     // Refresh every 30 seconds if enabled
     const intervalId = setInterval(() => {
       if (localEnabled) {
-        fetchLogAndStats();
+        void fetchLogAndStats();
       }
     }, 30000);
 

--- a/src/components/SearchModal/SearchModal.tsx
+++ b/src/components/SearchModal/SearchModal.tsx
@@ -113,11 +113,11 @@ export const SearchModal: React.FC<SearchModalProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (query.length < 2) return;
-    performSearch(0);
+    void performSearch(0);
   };
 
   const handleLoadMore = () => {
-    performSearch(results.length);
+    void performSearch(results.length);
   };
 
   const handleResultClick = (result: SearchResult) => {

--- a/src/components/SecurityTab.tsx
+++ b/src/components/SecurityTab.tsx
@@ -131,7 +131,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
   };
 
   useEffect(() => {
-    fetchSecurityData();
+    void fetchSecurityData();
     // Refresh every 30 seconds
     const interval = setInterval(fetchSecurityData, 30000);
     return () => clearInterval(interval);
@@ -152,7 +152,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
         // Settings may not exist yet, use defaults
       }
     };
-    loadDigestSettings();
+    void loadDigestSettings();
   }, []);
 
   const saveDigestSettings = useCallback(async () => {

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -283,7 +283,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         logger.error('Failed to fetch system status:', error);
       }
     };
-    fetchSystemStatus();
+    void fetchSystemStatus();
   }, [baseUrl]);
 
   // Fetch database type from health endpoint (public, no auth required)
@@ -302,7 +302,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         logger.error('Failed to fetch database type:', error);
       }
     };
-    fetchDatabaseType();
+    void fetchDatabaseType();
   }, [baseUrl]);
 
   // Fetch packet monitor and other server-stored settings
@@ -375,7 +375,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         logger.error('Failed to fetch server settings:', error);
       }
     };
-    fetchServerSettings();
+    void fetchServerSettings();
   }, [baseUrl, setShowIncompleteNodes]);
 
   // Update local state when props change

--- a/src/components/TapbackEmojiSettings.tsx
+++ b/src/components/TapbackEmojiSettings.tsx
@@ -98,7 +98,7 @@ const TapbackEmojiSettings: React.FC = () => {
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !isSaving) {
-      handleAddEmoji();
+      void handleAddEmoji();
     }
   };
 

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -668,7 +668,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
         showToast(t('telemetry.purge_success', { type: getTelemetryLabel(telemetryType) }), 'success');
 
         // Refresh telemetry data using TanStack Query
-        refetchTelemetry();
+        void refetchTelemetry();
       } catch (error) {
         logger.error('Error purging telemetry data:', error);
         showToast(t('telemetry.purge_failed'), 'error');

--- a/src/components/TimerTriggersSection.tsx
+++ b/src/components/TimerTriggersSection.tsx
@@ -114,7 +114,7 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
         console.error('Failed to fetch available scripts:', error);
       }
     };
-    fetchScripts();
+    void fetchScripts();
   }, [baseUrl]);
 
   // Handle script selection with autofill

--- a/src/components/TracerouteHistoryModal.tsx
+++ b/src/components/TracerouteHistoryModal.tsx
@@ -57,7 +57,7 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
       }
     };
 
-    fetchHistory();
+    void fetchHistory();
     return () => {
       isMounted.current = false;
     };

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -115,9 +115,9 @@ const UsersTab: React.FC = () => {
   const [configuredChannelIds, setConfiguredChannelIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
-    fetchUsers();
-    fetchChannelDatabaseEntries();
-    fetchSources();
+    void fetchUsers();
+    void fetchChannelDatabaseEntries();
+    void fetchSources();
   }, []);
 
   const fetchSources = async () => {

--- a/src/components/admin-commands/AutoFavoriteManagementSection.tsx
+++ b/src/components/admin-commands/AutoFavoriteManagementSection.tsx
@@ -91,7 +91,7 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
   }, [selectedNodeNum, sourceId, showToast, t]);
 
   useEffect(() => {
-    loadConfig();
+    void loadConfig();
   }, [loadConfig]);
 
   const update = useCallback((patch: Partial<AutoFavoriteConfig>) => {

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -97,17 +97,17 @@ function AutomationsList() {
     try { setItems(await apiService.get<Automation[]>('/api/automations')); setError(null); }
     catch (e: any) { setError(e?.message ?? 'Failed to load'); }
   }, []);
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { void load(); }, [load]);
 
-  const toggle = async (a: Automation) => { await apiService.post(`/api/automations/${a.id}/${a.enabled ? 'disable' : 'enable'}`); load(); };
-  const remove = async (a: Automation) => { if (!confirm(`Delete automation “${a.name}”?`)) return; await apiService.delete(`/api/automations/${a.id}`); load(); };
+  const toggle = async (a: Automation) => { await apiService.post(`/api/automations/${a.id}/${a.enabled ? 'disable' : 'enable'}`); void load(); };
+  const remove = async (a: Automation) => { if (!confirm(`Delete automation “${a.name}”?`)) return; await apiService.delete(`/api/automations/${a.id}`); void load(); };
   const exportOne = async (a: Automation) => {
     const data = await apiService.get(`/api/automations/${a.id}/export`);
     await navigator.clipboard?.writeText(JSON.stringify(data, null, 2));
     alert('Exported JSON copied to clipboard.');
   };
 
-  if (editing) return <AutomationEditor automation={editing} onClose={() => { setEditing(null); load(); }} />;
+  if (editing) return <AutomationEditor automation={editing} onClose={() => { setEditing(null); void load(); }} />;
   if (runsFor) return <RunLog automation={runsFor} onClose={() => setRunsFor(null)} />;
   if (traceFor) return (
     <div>
@@ -314,7 +314,7 @@ function VariablesList() {
     try { setItems(await apiService.get<Variable[]>('/api/automations/variables')); }
     catch (e: any) { setError(e?.message ?? 'Failed to load'); }
   }, []);
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { void load(); }, [load]);
 
   const create = async () => {
     setError(null);
@@ -327,10 +327,10 @@ function VariablesList() {
     if (type === 'flag' && flagDuration !== '') config.flagDurationSeconds = Number(flagDuration);
     try {
       await apiService.post('/api/automations/variables', { name, type, scope, readonly, config });
-      setName(''); setDefaultValue(''); setFlagDuration(''); load();
+      setName(''); setDefaultValue(''); setFlagDuration(''); void load();
     } catch (e: any) { setError(e?.message ?? 'Create failed'); }
   };
-  const remove = async (v: Variable) => { if (!confirm(`Delete variable “${v.name}”?`)) return; await apiService.delete(`/api/automations/variables/${v.id}`); load(); };
+  const remove = async (v: Variable) => { if (!confirm(`Delete variable “${v.name}”?`)) return; await apiService.delete(`/api/automations/variables/${v.id}`); void load(); };
 
   return (
     <div>

--- a/src/components/configuration/AutoUpgradeTestSection.tsx
+++ b/src/components/configuration/AutoUpgradeTestSection.tsx
@@ -68,7 +68,7 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
         setIsLoadingSettings(false);
       }
     };
-    loadSettings();
+    void loadSettings();
   }, [baseUrl, csrfFetch]);
 
   const handleAutoUpgradeImmediateChange = async (enabled: boolean) => {
@@ -188,13 +188,13 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
 
         // Start polling for status
         const interval = setInterval(() => {
-          pollUpgradeStatus(data.upgradeId);
+          void pollUpgradeStatus(data.upgradeId);
         }, 2000); // Poll every 2 seconds
 
         setStatusPollInterval(interval);
 
         // Do initial poll immediately
-        pollUpgradeStatus(data.upgradeId);
+        void pollUpgradeStatus(data.upgradeId);
       } else {
         throw new Error(data.message || 'Failed to start test upgrade');
       }

--- a/src/components/configuration/BackupManagementSection.tsx
+++ b/src/components/configuration/BackupManagementSection.tsx
@@ -61,7 +61,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
 
   // Load backup settings on mount
   useEffect(() => {
-    loadBackupSettings();
+    void loadBackupSettings();
   }, []);
 
   const loadBackupSettings = async () => {
@@ -270,7 +270,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
 
       showToast(t('backup_management.toast_deleted'), 'success');
       // Refresh the backup list
-      handleShowBackups();
+      void handleShowBackups();
     } catch (error) {
       logger.error('Error deleting backup:', error);
       showToast(t('backup_management.toast_delete_failed', { error: error instanceof Error ? error.message : 'Unknown error' }), 'error');

--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -296,7 +296,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         const errorMsg = error instanceof Error ? error.message : t('channel_database.reorder_error');
         showToast(errorMsg, 'error');
         // Revert on error
-        fetchChannels();
+        void fetchChannels();
       }
     }
   };
@@ -304,7 +304,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
   // Fetch channels on mount
   useEffect(() => {
     if (isAdmin) {
-      fetchChannels();
+      void fetchChannels();
     }
   }, [isAdmin]);
 
@@ -318,7 +318,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             setDecryptionProgress(response.progress);
             if (response.progress.status === 'completed') {
               // Refresh channels to show updated decrypted counts
-              fetchChannels();
+              void fetchChannels();
               showToast(
                 t('channel_database.toast_decryption_completed', {
                   decrypted: response.progress.decrypted,
@@ -328,7 +328,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
               );
             } else if (response.progress.status === 'failed') {
               // Refresh channels and show error
-              fetchChannels();
+              void fetchChannels();
               const errorMsg = response.progress.error || t('channel_database.toast_decryption_failed');
               showToast(errorMsg, 'error');
             }
@@ -445,7 +445,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
 
       setShowEditModal(false);
       setEditingChannel(null);
-      fetchChannels();
+      void fetchChannels();
     } catch (error) {
       logger.error('Error saving channel:', error);
       const errorMsg = error instanceof Error ? error.message : t('channel_database.toast_save_failed');
@@ -461,7 +461,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
       await apiService.deleteChannelDatabaseEntry(id);
       showToast(t('channel_database.toast_channel_deleted'), 'success');
       setShowDeleteConfirm(null);
-      fetchChannels();
+      void fetchChannels();
     } catch (error) {
       logger.error('Error deleting channel:', error);
       const errorMsg = error instanceof Error ? error.message : t('channel_database.toast_delete_failed');
@@ -482,7 +482,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
           : t('channel_database.toast_channel_enabled'),
         'success'
       );
-      fetchChannels();
+      void fetchChannels();
     } catch (error) {
       logger.error('Error toggling channel:', error);
       const errorMsg = error instanceof Error ? error.message : t('channel_database.toast_update_failed');
@@ -603,7 +603,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
       }
-      fetchChannels();
+      void fetchChannels();
     } catch (error) {
       logger.error('Error importing channels:', error);
       const errorMsg = error instanceof Error ? error.message : t('channel_database.toast_import_failed');

--- a/src/components/configuration/DatabaseMaintenanceSection.tsx
+++ b/src/components/configuration/DatabaseMaintenanceSection.tsx
@@ -112,14 +112,14 @@ const DatabaseMaintenanceSection: React.FC = () => {
         logger.error('Error fetching database type:', error);
       }
     };
-    fetchDatabaseType();
+    void fetchDatabaseType();
   }, []);
 
   // Load status and settings on mount (only if SQLite)
   useEffect(() => {
     if (databaseType === 'sqlite') {
-      loadStatus();
-      loadDatabaseSize();
+      void loadStatus();
+      void loadDatabaseSize();
     }
   }, [databaseType]);
 
@@ -213,7 +213,7 @@ const DatabaseMaintenanceSection: React.FC = () => {
       setSaveCounter(c => c + 1);
 
       showToast(t('maintenance.toast_settings_saved'), 'success');
-      loadStatus();
+      void loadStatus();
     } catch (error) {
       logger.error('Error saving maintenance settings:', error);
       showToast(t('maintenance.toast_settings_failed', { error: error instanceof Error ? error.message : 'Unknown error' }), 'error');
@@ -272,8 +272,8 @@ const DatabaseMaintenanceSection: React.FC = () => {
       );
 
       // Refresh status and size
-      loadStatus();
-      loadDatabaseSize();
+      void loadStatus();
+      void loadDatabaseSize();
     } catch (error) {
       logger.error('Error running maintenance:', error);
       showToast(t('maintenance.toast_failed', { error: error instanceof Error ? error.message : 'Unknown error' }), 'error');

--- a/src/components/configuration/ExportConfigModal.tsx
+++ b/src/components/configuration/ExportConfigModal.tsx
@@ -101,7 +101,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
   useEffect(() => {
     // Generate URL whenever selections change
     if (isOpen && selectedChannels.size > 0) {
-      generateUrl();
+      void generateUrl();
     } else if (isOpen && selectedChannels.size === 0) {
       // Clear URL if no channels selected
       setGeneratedUrl('');

--- a/src/components/configuration/FirmwareUpdateSection.tsx
+++ b/src/components/configuration/FirmwareUpdateSection.tsx
@@ -236,8 +236,8 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         throw new Error(data.error || 'Failed to save channel');
       }
       showToast(t('firmware.channel', 'Release channel saved'), 'success');
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'releases'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'releases'] });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Error saving channel', 'error');
     } finally {
@@ -256,8 +256,8 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         throw new Error(data.error || 'Failed to check for updates');
       }
       showToast(t('firmware.check_now', 'Check complete'), 'success');
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'releases'] });
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'releases'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Error checking for updates', 'error');
     } finally {
@@ -282,7 +282,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         const data = await res.json();
         throw new Error(data.error || 'Failed to start update');
       }
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Error starting update', 'error');
     }
@@ -306,7 +306,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         // "No update step is awaiting confirmation" is a benign race condition —
         // the backend already advanced past this step. Just refetch silently.
         if (res.status === 400 && data.error?.includes('awaiting confirmation')) {
-          queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+          void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
           return;
         }
         // Issue #3413: Safety Rail 5 blocked the flash because the node is
@@ -318,7 +318,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         }
         throw new Error(data.error || 'Failed to confirm step');
       }
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Error confirming step', 'error');
     } finally {
@@ -375,7 +375,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         throw new Error(data.error || 'Failed to cancel update');
       }
       showToast(t('firmware.wizard_cancel', 'Update cancelled'), 'success');
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Error cancelling update', 'error');
     }
@@ -398,7 +398,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
       // Best-effort — even if the call fails, clear local queries
     }
     // Invalidate everything so the UI refreshes with new node data
-    queryClient.invalidateQueries();
+    void queryClient.invalidateQueries();
     queryClient.removeQueries({ queryKey: ['firmware', 'liveStatus'] });
   };
 
@@ -411,7 +411,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         const data = await res.json();
         throw new Error(data.error || 'Failed to retry flash');
       }
-      queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
+      void queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Error retrying flash', 'error');
     }

--- a/src/components/configuration/SecurityConfigSection.tsx
+++ b/src/components/configuration/SecurityConfigSection.tsx
@@ -151,7 +151,7 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
     if (!privateKey) return;
     const confirmed = window.confirm(t('security_config.copy_private_key_confirm'));
     if (confirmed) {
-      navigator.clipboard.writeText(privateKey);
+      void navigator.clipboard.writeText(privateKey);
     }
   }, [privateKey, t]);
 

--- a/src/components/configuration/SystemBackupSection.tsx
+++ b/src/components/configuration/SystemBackupSection.tsx
@@ -60,7 +60,7 @@ const SystemBackupSection: React.FC = () => {
 
   // Load backup settings on mount
   useEffect(() => {
-    loadBackupSettings();
+    void loadBackupSettings();
   }, []);
 
   const loadBackupSettings = async () => {
@@ -175,7 +175,7 @@ const SystemBackupSection: React.FC = () => {
 
       // Refresh backup list if modal is open
       if (isBackupModalOpen) {
-        handleShowBackups();
+        void handleShowBackups();
       }
     } catch (error) {
       logger.error('Error creating system backup:', error);
@@ -266,7 +266,7 @@ const SystemBackupSection: React.FC = () => {
 
       showToast(t('system_backup.toast_deleted'), 'success');
       // Refresh the backup list
-      handleShowBackups();
+      void handleShowBackups();
     } catch (error) {
       logger.error('Error deleting system backup:', error);
       showToast(t('system_backup.toast_delete_failed', { error: error instanceof Error ? error.message : 'Unknown error' }), 'error');

--- a/src/components/settings/EmbedSettings.tsx
+++ b/src/components/settings/EmbedSettings.tsx
@@ -145,7 +145,7 @@ const EmbedSettings = () => {
   }, [showToast, t]);
 
   useEffect(() => {
-    fetchProfiles();
+    void fetchProfiles();
   }, [fetchProfiles]);
 
   // ---- Form helpers ----
@@ -304,7 +304,7 @@ const EmbedSettings = () => {
   // ---- Embed code builder ----
   const [embedBaseUrl, setEmbedBaseUrl] = useState('');
   useEffect(() => {
-    apiService.getBaseUrl().then(base => setEmbedBaseUrl(base));
+    void apiService.getBaseUrl().then(base => setEmbedBaseUrl(base));
   }, []);
 
   const buildEmbedUrl = (profileId: string): string => {

--- a/src/components/settings/PkiDmGlobalToggle.tsx
+++ b/src/components/settings/PkiDmGlobalToggle.tsx
@@ -21,7 +21,7 @@ const PkiDmGlobalToggle: React.FC = () => {
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const baseUrl = await apiService.getBaseUrl();
         const res = await fetch(`${baseUrl}/api/settings`, { credentials: 'include' });

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -25,7 +25,7 @@ export const AVAILABLE_LANGUAGES = [
   { code: 'zh_Hans', name: 'Chinese (Simplified)', nativeName: '简体中文' },
 ];
 
-i18n
+void i18n
   .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -139,7 +139,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // Check auth status on mount
   useEffect(() => {
-    refreshAuth();
+    void refreshAuth();
   }, [refreshAuth]);
 
   // Local authentication

--- a/src/contexts/AutomationContext.tsx
+++ b/src/contexts/AutomationContext.tsx
@@ -241,7 +241,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         logger.error('[AutomationContext] Failed to load settings:', err);
       }
     };
-    load();
+    void load();
     return () => { cancelled = true; };
   }, [sourceId, baseUrl]);
 

--- a/src/contexts/CsrfContext.tsx
+++ b/src/contexts/CsrfContext.tsx
@@ -78,7 +78,7 @@ export const CsrfProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // Fetch token on mount
   useEffect(() => {
-    fetchToken();
+    void fetchToken();
   }, [fetchToken]);
 
   const value: CsrfContextType = {

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -165,73 +165,73 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const setShowPaths = React.useCallback((value: boolean) => {
     setShowPathsState(value);
     // Save to server (fire and forget)
-    savePreferenceToServer({ showPaths: value });
+    void savePreferenceToServer({ showPaths: value });
   }, []);
 
   const setShowNeighborInfo = React.useCallback((value: boolean) => {
     setShowNeighborInfoState(value);
-    savePreferenceToServer({ showNeighborInfo: value });
+    void savePreferenceToServer({ showNeighborInfo: value });
   }, []);
 
   const setShowRoute = React.useCallback((value: boolean) => {
     setShowRouteState(value);
-    savePreferenceToServer({ showRoute: value });
+    void savePreferenceToServer({ showRoute: value });
   }, []);
 
   const setShowMotion = React.useCallback((value: boolean) => {
     setShowMotionState(value);
-    savePreferenceToServer({ showMotion: value });
+    void savePreferenceToServer({ showMotion: value });
   }, []);
 
   const setShowMqttNodes = React.useCallback((value: boolean) => {
     setShowMqttNodesState(value);
-    savePreferenceToServer({ showMqttNodes: value });
+    void savePreferenceToServer({ showMqttNodes: value });
   }, []);
 
   const setShowUdpNodes = React.useCallback((value: boolean) => {
     setShowUdpNodesState(value);
-    savePreferenceToServer({ showUdpNodes: value });
+    void savePreferenceToServer({ showUdpNodes: value });
   }, []);
 
   const setShowRfNodes = React.useCallback((value: boolean) => {
     setShowRfNodesState(value);
-    savePreferenceToServer({ showRfNodes: value });
+    void savePreferenceToServer({ showRfNodes: value });
   }, []);
 
   const setShowMeshCoreNodes = React.useCallback((value: boolean) => {
     setShowMeshCoreNodesState(value);
-    savePreferenceToServer({ showMeshCoreNodes: value });
+    void savePreferenceToServer({ showMeshCoreNodes: value });
   }, []);
 
   const setShowWaypoints = React.useCallback((value: boolean) => {
     setShowWaypointsState(value);
-    savePreferenceToServer({ showWaypoints: value });
+    void savePreferenceToServer({ showWaypoints: value });
   }, []);
 
   const setPositionHistoryPointsOnly = React.useCallback((value: boolean) => {
     setPositionHistoryPointsOnlyState(value);
-    savePreferenceToServer({ positionHistoryPointsOnly: value });
+    void savePreferenceToServer({ positionHistoryPointsOnly: value });
   }, []);
 
   const setShowAnimations = React.useCallback((value: boolean) => {
     setShowAnimationsState(value);
-    savePreferenceToServer({ showAnimations: value });
+    void savePreferenceToServer({ showAnimations: value });
   }, []);
 
   const setShowEstimatedPositions = React.useCallback((value: boolean) => {
     setShowEstimatedPositionsState(value);
     localStorage.setItem('showEstimatedPositions', value.toString());
-    savePreferenceToServer({ showEstimatedPositions: value });
+    void savePreferenceToServer({ showEstimatedPositions: value });
   }, []);
 
   const setShowAccuracyRegions = React.useCallback((value: boolean) => {
     setShowAccuracyRegionsState(value);
-    savePreferenceToServer({ showAccuracyRegions: value });
+    void savePreferenceToServer({ showAccuracyRegions: value });
   }, []);
 
   const setShowPolarGrid = React.useCallback((value: boolean) => {
     setShowPolarGridState(value);
-    savePreferenceToServer({ showPolarGrid: value });
+    void savePreferenceToServer({ showPolarGrid: value });
   }, []);
 
   // Helper function to save preference to server
@@ -281,7 +281,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
       clearTimeout(positionHistoryDebounceRef.current);
     }
     positionHistoryDebounceRef.current = setTimeout(() => {
-      savePreferenceToServer({ positionHistoryHours: value });
+      void savePreferenceToServer({ positionHistoryHours: value });
     }, 500);
   }, [savePreferenceToServer]);
 
@@ -293,7 +293,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
       clearTimeout(mapMaxAgeDebounceRef.current);
     }
     mapMaxAgeDebounceRef.current = setTimeout(() => {
-      savePreferenceToServer({ mapMaxAgeHours: value });
+      void savePreferenceToServer({ mapMaxAgeHours: value });
     }, 500);
   }, [savePreferenceToServer]);
 
@@ -371,7 +371,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
       }
     };
 
-    loadServerPreferences();
+    void loadServerPreferences();
   }, []); // Run once on mount
 
   // Persist map center to localStorage

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -797,7 +797,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const setLanguage = async (lang: string) => {
     setLanguageState(lang);
     localStorage.setItem('language', lang);
-    i18n.changeLanguage(lang);
+    void i18n.changeLanguage(lang);
 
     // Persist to database for logged-in users (fire and forget)
     try {
@@ -1317,7 +1317,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
           if (settings.language) {
             setLanguageState(settings.language);
             localStorage.setItem('language', settings.language);
-            i18n.changeLanguage(settings.language);
+            void i18n.changeLanguage(settings.language);
             logger.debug(`🌐 Language loaded from server: ${settings.language}`);
           }
 
@@ -1451,12 +1451,12 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
       }
     };
 
-    loadServerSettings();
+    void loadServerSettings();
   }, [baseUrl]);
 
   // Load custom themes on mount
   React.useEffect(() => {
-    loadCustomThemes();
+    void loadCustomThemes();
   }, [loadCustomThemes]);
 
   React.useEffect(() => {
@@ -1479,7 +1479,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
 
   // Load mute preferences on mount (server-side, requires auth)
   React.useEffect(() => {
-    loadMutePreferences();
+    void loadMutePreferences();
   }, [loadMutePreferences]);
 
   // Apply custom theme CSS when themes are loaded or theme changes

--- a/src/hooks/useAutoUpgrade.ts
+++ b/src/hooks/useAutoUpgrade.ts
@@ -65,7 +65,7 @@ export function useAutoUpgrade(
       }
     };
 
-    checkUpgradeStatus();
+    void checkUpgradeStatus();
   }, [baseUrl, authFetch]);
 
   // Cleanup polling on unmount
@@ -150,7 +150,7 @@ export function useAutoUpgrade(
     };
 
     // Start polling
-    poll();
+    void poll();
   }, [baseUrl, authFetch, showToast]);
 
   // Trigger an upgrade

--- a/src/hooks/useMapAnalysisData.ts
+++ b/src/hooks/useMapAnalysisData.ts
@@ -69,7 +69,7 @@ function useAggregatedPaginated<T>(
     let cursor: string | null = null;
     let acc: T[] = [];
 
-    (async () => {
+    void (async () => {
       try {
         do {
           const res = await fetchPage({

--- a/src/hooks/useSecurityCheck.ts
+++ b/src/hooks/useSecurityCheck.ts
@@ -50,7 +50,7 @@ export function useSecurityCheck(
       }
     };
 
-    checkDefaultPassword();
+    void checkDefaultPassword();
   }, [baseUrl, authFetch]);
 
   // Check for configuration issues
@@ -67,7 +67,7 @@ export function useSecurityCheck(
       }
     };
 
-    checkConfigIssues();
+    void checkConfigIssues();
   }, [baseUrl, authFetch]);
 
   return {

--- a/src/hooks/useUnreadCounts.ts
+++ b/src/hooks/useUnreadCounts.ts
@@ -166,7 +166,7 @@ export function useMarkAsRead({ baseUrl = '' }: UseMarkAsReadOptions = {}) {
     },
     onSuccess: () => {
       // Invalidate and refetch unread counts after marking as read
-      queryClient.invalidateQueries({ queryKey: ['unreadCounts'] });
+      void queryClient.invalidateQueries({ queryKey: ['unreadCounts'] });
     },
   });
 }

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -71,7 +71,7 @@ export function useVersionCheck(baseUrl: string): VersionCheckResult {
     };
 
     // Initial check
-    checkForUpdates();
+    void checkForUpdates();
 
     // Check for updates at configured interval
     intervalId = setInterval(checkForUpdates, VERSION_CHECK_INTERVAL_MS);

--- a/src/hooks/useWaypoints.ts
+++ b/src/hooks/useWaypoints.ts
@@ -62,7 +62,7 @@ export function useWaypoints(sourceId: string | null | undefined) {
       return postJson<{ data: Waypoint }>(waypointsApiBase(sourceId), 'POST', input);
     },
     onSuccess: () => {
-      if (sourceId) qc.invalidateQueries({ queryKey: ['waypoints', sourceId] });
+      if (sourceId) void qc.invalidateQueries({ queryKey: ['waypoints', sourceId] });
     },
   });
 
@@ -76,7 +76,7 @@ export function useWaypoints(sourceId: string | null | undefined) {
       );
     },
     onSuccess: () => {
-      if (sourceId) qc.invalidateQueries({ queryKey: ['waypoints', sourceId] });
+      if (sourceId) void qc.invalidateQueries({ queryKey: ['waypoints', sourceId] });
     },
   });
 
@@ -89,7 +89,7 @@ export function useWaypoints(sourceId: string | null | undefined) {
       );
     },
     onSuccess: () => {
-      if (sourceId) qc.invalidateQueries({ queryKey: ['waypoints', sourceId] });
+      if (sourceId) void qc.invalidateQueries({ queryKey: ['waypoints', sourceId] });
     },
   });
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -215,7 +215,7 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
     const key = sourcePollQueryKey(sourceId);
     queryClient.setQueryData<PollData>(key, (old) => {
       if (!old) {
-        queryClient.invalidateQueries({ queryKey: key });
+        void queryClient.invalidateQueries({ queryKey: key });
         return old;
       }
 
@@ -345,7 +345,7 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
 
     socket.on('message:new', (data: RawMessage) => {
       addMessageToCache(data);
-      queryClient.invalidateQueries({ queryKey: ['unreadCounts'] });
+      void queryClient.invalidateQueries({ queryKey: ['unreadCounts'] });
     });
 
     socket.on('channel:updated', (data: Channel) => {
@@ -357,15 +357,15 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
     });
 
     socket.on('traceroute:complete', (_data: TracerouteCompleteEvent) => {
-      queryClient.invalidateQueries({ queryKey: sourcePollQueryKey(sourceId) });
+      void queryClient.invalidateQueries({ queryKey: sourcePollQueryKey(sourceId) });
     });
 
     socket.on('routing:update', (_data: { requestId: number; status: string }) => {
-      queryClient.invalidateQueries({ queryKey: sourcePollQueryKey(sourceId) });
+      void queryClient.invalidateQueries({ queryKey: sourcePollQueryKey(sourceId) });
     });
 
     socket.on('telemetry:batch', (_data: { [nodeNum: number]: unknown[] }) => {
-      queryClient.invalidateQueries({ queryKey: sourcePollQueryKey(sourceId) });
+      void queryClient.invalidateQueries({ queryKey: sourcePollQueryKey(sourceId) });
     });
 
     socket.on('firmware:status', (data: unknown) => {
@@ -377,9 +377,9 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
     // so the WaypointsLayer / map re-fetch and reconcile.
     const invalidateWaypoints = () => {
       if (sourceId) {
-        queryClient.invalidateQueries({ queryKey: ['waypoints', sourceId] });
+        void queryClient.invalidateQueries({ queryKey: ['waypoints', sourceId] });
       } else {
-        queryClient.invalidateQueries({ queryKey: ['waypoints'] });
+        void queryClient.invalidateQueries({ queryKey: ['waypoints'] });
       }
     };
     socket.on('waypoint:upserted', invalidateWaypoints);

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -58,7 +58,7 @@ function DashboardInner() {
    * waiting for the 15s poll interval. Same key as `useDashboardSources`.
    */
   const refreshSources = () => {
-    queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
+    void queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
   };
 
   /**
@@ -73,7 +73,7 @@ function DashboardInner() {
   const refreshSourcesDebounced = () => {
     if (refreshSourcesTimer.current) clearTimeout(refreshSourcesTimer.current);
     refreshSourcesTimer.current = setTimeout(() => {
-      queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
+      void queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
     }, 400);
   };
 
@@ -85,10 +85,10 @@ function DashboardInner() {
    */
   const handleNodeSourceSelect = (source: NodeSourceRef, nodeId: string | undefined) => {
     if (source.protocol === 'MeshCore') {
-      navigate(`/source/${source.sourceId}/`);
+      void navigate(`/source/${source.sourceId}/`);
       return;
     }
-    navigate(`/source/${source.sourceId}/#messages`, {
+    void navigate(`/source/${source.sourceId}/#messages`, {
       state: nodeId ? { focusDmNodeId: nodeId } : undefined,
     });
   };
@@ -206,13 +206,13 @@ function DashboardInner() {
     // hypothetical source whose UUID happens to collide.
     if (isReservedLandingValue(defaultLandingPage)) {
       const reservedPath = getReservedLandingPath(defaultLandingPage);
-      if (reservedPath) navigate(reservedPath, { replace: true });
+      if (reservedPath) void navigate(reservedPath, { replace: true });
       return;
     }
 
     const target = sources.find((s) => s.id === defaultLandingPage);
     if (!target) return;
-    navigate(`/source/${target.id}/`, { replace: true });
+    void navigate(`/source/${target.id}/`, { replace: true });
   }, [skipDefaultLanding, isSuccess, defaultLandingPage, sources, navigate]);
   const statusMap = useSourceStatuses(sourceIds);
   const unifiedStatus = useUnifiedStatus();
@@ -272,7 +272,7 @@ function DashboardInner() {
   useEffect(() => {
     if (!isAuthenticated) return;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const response = await api.getUnreadNews();
         if (cancelled) return;
@@ -813,7 +813,7 @@ function DashboardInner() {
       refreshSources();
       // Force an immediate status refetch so the "Connected" dot flips to
       // "Idle" without waiting for the next 15s poll tick.
-      queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
+      void queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
     }
   };
 
@@ -908,7 +908,7 @@ function DashboardInner() {
       // Refresh source status either way — a successful resync changes the
       // connection state once configComplete arrives, and a rejected click
       // doesn't hurt to re-poll.
-      queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
+      void queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
       if (!res.ok && res.status !== 409) {
         logger.warn('Manual resync request failed', { status: res.status });
       }
@@ -1394,7 +1394,7 @@ function DashboardInner() {
                       title={t('source.form.mqtt_bridge_advanced_open', 'Open Configuration page')}
                       onClick={() => {
                         setShowSourceModal(false);
-                        navigate(`/source/${editingSourceId}/#mqtt-config`);
+                        void navigate(`/source/${editingSourceId}/#mqtt-config`);
                       }}
                     >
                       {t('source.form.mqtt_bridge_advanced_open', 'Configuration')} →

--- a/src/pages/PacketMonitorPage.tsx
+++ b/src/pages/PacketMonitorPage.tsx
@@ -20,7 +20,7 @@ const PacketMonitorContent: React.FC = () => {
       }
     };
 
-    fetchDeviceInfo();
+    void fetchDeviceInfo();
   }, [setDeviceInfo]);
 
   return (

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -427,7 +427,7 @@ export default function UnifiedMessagesPage() {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
+          void fetchNextPage();
         }
       },
       { rootMargin: '200px' }

--- a/src/pages/UnifiedPacketMonitorPage.tsx
+++ b/src/pages/UnifiedPacketMonitorPage.tsx
@@ -106,7 +106,7 @@ export default function UnifiedPacketMonitorPage() {
         console.error('Failed to fetch unified packet distribution:', err);
       }
     };
-    fetchDist();
+    void fetchDist();
     const iv = paused ? undefined : setInterval(fetchDist, 30000);
     return () => { cancelled = true; if (iv) clearInterval(iv); };
   }, [canView, showCharts, rangeHours, paused]);
@@ -149,7 +149,7 @@ export default function UnifiedPacketMonitorPage() {
   useEffect(() => {
     if (lastVirtualItemIndex === undefined) return;
     if (lastVirtualItemIndex >= packets.length - 10 && hasMore && !loadingMore && packets.length > 0) {
-      loadMore();
+      void loadMore();
     }
   }, [lastVirtualItemIndex, packets.length, hasMore, loadingMore, loadMore]);
 

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -313,7 +313,7 @@ export default function UnifiedTelemetryPage() {
 
   useEffect(() => {
     setLoading(true);
-    fetchTelemetry();
+    void fetchTelemetry();
     const iv = setInterval(fetchTelemetry, 15000);
     return () => clearInterval(iv);
   }, [fetchTelemetry]);

--- a/src/server/auth/localAuth.ts
+++ b/src/server/auth/localAuth.ts
@@ -110,7 +110,7 @@ export async function createLocalUser(
     logger.debug(`✅ Created new local user: ${username} (admin: ${isAdmin})`);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       createdBy || null,
       'user_created',
       'users',
@@ -167,7 +167,7 @@ export async function changePassword(
     logger.debug(`✅ Password changed for user: ${user.username}`);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       userId,
       'password_changed',
       'users',
@@ -211,7 +211,7 @@ export async function resetUserPassword(
     logger.debug(`✅ Password reset for user: ${user.username}`);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       adminUserId,
       'password_reset',
       'users',
@@ -260,7 +260,7 @@ export async function setUserPassword(
     logger.debug(`✅ Password set for user: ${user.username}`);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       adminUserId,
       'password_set',
       'users',

--- a/src/server/auth/oidcAuth.ts
+++ b/src/server/auth/oidcAuth.ts
@@ -266,7 +266,7 @@ export async function handleOIDCCallback(
         user = await databaseService.findUserByIdAsync(existingUser.id) as User;
 
         // Audit log
-        databaseService.auditLogAsync(
+        void databaseService.auditLogAsync(
           user!.id,
           'user_migrated_to_oidc',
           'users',
@@ -343,7 +343,7 @@ export async function handleOIDCCallback(
         logger.debug(`✅ OIDC user auto-created: ${user!.username}${grantAdmin ? ' (admin)' : ''}`);
 
         // Audit log
-        databaseService.auditLogAsync(
+        void databaseService.auditLogAsync(
           user!.id,
           grantAdmin ? 'oidc_user_created_admin' : 'oidc_user_created',
           'users',

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5273,7 +5273,7 @@ class MeshCoreManager extends EventEmitter {
 
     this.autoPathfindingJitterTimeout = setTimeout(() => {
       this.autoPathfindingJitterTimeout = null;
-      executeRun();
+      executeRun().catch(err => logger.error('[MeshCore] Auto-pathfinding scheduler error:', err));
       this.autoPathfindingTimer = setInterval(executeRun, repeatMs);
     }, initialJitterMs);
   }

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -753,7 +753,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
     // the way python-meshcore did. Pulling the messages causes ContactMsgRecv
     // / ChannelMsgRecv to fire normally.
     this.connection.on(PushCodes.MsgWaiting, () => {
-      this.drainWaitingMessages();
+      void this.drainWaitingMessages();
     });
   }
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -800,7 +800,7 @@ class MeshtasticManager implements ISourceManager {
         | import('./mqttBrokerManager.js').MqttBrokerManager
         | import('./mqttBridgeManager.js').MqttBridgeManager;
       const listener = (p: import('./mqttBrokerManager.js').MqttBrokerLocalPacket) => {
-        this.handleLinkedBrokerLocalPacket(p);
+        void this.handleLinkedBrokerLocalPacket(p);
       };
       this.mqttLinkBrokerListener = listener;
       this.mqttLinkBroker.on('local-packet', listener);
@@ -1276,7 +1276,7 @@ class MeshtasticManager implements ISourceManager {
       });
 
       this.transport.on('message', (data: Uint8Array) => {
-        this.processIncomingData(data);
+        void this.processIncomingData(data);
       });
 
       this.transport.on('disconnect', () => {
@@ -1815,7 +1815,7 @@ class MeshtasticManager implements ISourceManager {
       ? 'broadcast'
       : `!${destination.toString(16).padStart(8, '0')}`;
 
-    packetLogService.logPacket({
+    void packetLogService.logPacket({
       timestamp: Date.now(),
       from_node: localNodeNum,
       from_node_id: localNodeId,
@@ -2004,7 +2004,7 @@ class MeshtasticManager implements ISourceManager {
     this.tracerouteJitterTimeout = setTimeout(() => {
       this.tracerouteJitterTimeout = null;
       // Execute first traceroute
-      executeTraceroute();
+      executeTraceroute().catch(err => logger.error('Auto-traceroute scheduler error:', err));
 
       // Start regular interval (no jitter on subsequent runs)
       this.tracerouteInterval = setInterval(executeTraceroute, intervalMs);
@@ -2186,7 +2186,7 @@ class MeshtasticManager implements ISourceManager {
 
     this.remoteLocalStatsJitterTimeout = setTimeout(() => {
       this.remoteLocalStatsJitterTimeout = null;
-      executeRemoteLocalStats();
+      executeRemoteLocalStats().catch(err => logger.error('Remote LocalStats scheduler error:', err));
       this.remoteLocalStatsInterval = setInterval(executeRemoteLocalStats, intervalMs);
     }, initialJitterMs);
   }
@@ -2681,23 +2681,23 @@ class MeshtasticManager implements ISourceManager {
             logger.info(`🔐 Key repair: Auto-purging node ${nodeName} from device database`);
             try {
               await this.sendRemoveNode(node.nodeNum);
-              databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'purge', true, null, null, this.sourceId);
+              void databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'purge', true, null, null, this.sourceId);
               logger.info(`🔐 Key repair: Purged node ${nodeName}, sending final node info exchange`);
 
               // Send one more node info exchange after purge — use channel, not DM
               // (keys are mismatched so PKI-encrypted DMs would fail)
               const purgedNodeData = await databaseService.nodes.getNode(node.nodeNum);
               await this.sendNodeInfoRequest(node.nodeNum, purgedNodeData?.channel ?? 0);
-              databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'exchange', null, null, null, this.sourceId);
+              void databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'exchange', null, null, null, this.sourceId);
             } catch (error) {
               logger.error(`🔐 Key repair: Failed to purge node ${nodeName}:`, error);
-              databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'purge', false, null, null, this.sourceId);
+              void databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'purge', false, null, null, this.sourceId);
             }
           }
 
           // Mark as exhausted
           await databaseService.setKeyRepairStateAsync(node.nodeNum, { exhausted: true });
-          databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'exhausted', null, null, null, this.sourceId);
+          void databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, 'exhausted', null, null, null, this.sourceId);
           continue;
         }
 
@@ -2716,10 +2716,10 @@ class MeshtasticManager implements ISourceManager {
             startedAt: node.startedAt ?? now
           });
 
-          databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, `exchange (${node.attemptCount + 1}/${this.keyRepairMaxExchanges})`, null, null, null, this.sourceId);
+          void databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, `exchange (${node.attemptCount + 1}/${this.keyRepairMaxExchanges})`, null, null, null, this.sourceId);
         } catch (error) {
           logger.error(`🔐 Key repair: Failed to send node info to ${nodeName}:`, error);
-          databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, `exchange (${node.attemptCount + 1}/${this.keyRepairMaxExchanges})`, false, null, null, this.sourceId);
+          void databaseService.logKeyRepairAttemptAsync(node.nodeNum, nodeName, `exchange (${node.attemptCount + 1}/${this.keyRepairMaxExchanges})`, false, null, null, this.sourceId);
         }
       }
     } catch (error) {
@@ -3329,7 +3329,7 @@ class MeshtasticManager implements ISourceManager {
         if (trigger.event === 'entry' || trigger.event === 'while_inside') {
           if (!this.isGeofenceCooldownActive(trigger.id, nodeNum, trigger.cooldownMinutes)) {
             logger.info(`📍 Geofence "${trigger.name}": node ${nodeNum} entered`);
-            this.executeGeofenceTrigger(trigger, nodeNum, lat, lng, 'entry');
+            void this.executeGeofenceTrigger(trigger, nodeNum, lat, lng, 'entry');
           } else {
             logger.debug(`📍 Geofence "${trigger.name}": cooldown active for node ${nodeNum}, skipping entry`);
           }
@@ -3341,7 +3341,7 @@ class MeshtasticManager implements ISourceManager {
         if (trigger.event === 'exit') {
           if (!this.isGeofenceCooldownActive(trigger.id, nodeNum, trigger.cooldownMinutes)) {
             logger.info(`📍 Geofence "${trigger.name}": node ${nodeNum} exited`);
-            this.executeGeofenceTrigger(trigger, nodeNum, lat, lng, 'exit');
+            void this.executeGeofenceTrigger(trigger, nodeNum, lat, lng, 'exit');
           } else {
             logger.debug(`📍 Geofence "${trigger.name}": cooldown active for node ${nodeNum}, skipping exit`);
           }
@@ -3582,7 +3582,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       logger.info(`📍 Geofence "${trigger.name}": while_inside tick for node ${nodeNum}`);
-      this.executeGeofenceTrigger(trigger, nodeNum, eff.latitude, eff.longitude, 'while_inside');
+      void this.executeGeofenceTrigger(trigger, nodeNum, eff.latitude, eff.longitude, 'while_inside');
     }
   }
 
@@ -5372,7 +5372,7 @@ class MeshtasticManager implements ISourceManager {
         // above) arrived over the air, so it is a reception, not our own 'tx'.
         const spoof = this.assessLocalSpoof(meshPacket);
 
-        packetLogService.logPacket({
+        void packetLogService.logPacket({
           packet_id: meshPacket.id ?? undefined,
           timestamp: Date.now(), // Use server time in ms for consistent ordering (rxTime preserved in metadata.rx_time)
           from_node: fromNum,
@@ -6514,9 +6514,9 @@ class MeshtasticManager implements ISourceManager {
             }
 
             // Clear the repair state and log success
-            databaseService.clearKeyRepairStateAsync(fromNum);
+            void databaseService.clearKeyRepairStateAsync(fromNum);
             const nodeName = user.longName || user.shortName || nodeId;
-            databaseService.logKeyRepairAttemptAsync(fromNum, nodeName, 'fixed', true, null, null, this.sourceId);
+            void databaseService.logKeyRepairAttemptAsync(fromNum, nodeName, 'fixed', true, null, null, this.sourceId);
 
             // Emit update to UI
             dataEventEmitter.emitNodeUpdate(fromNum, {
@@ -9668,7 +9668,7 @@ class MeshtasticManager implements ISourceManager {
    */
   private startAutoPingSession(session: AutoPingSession): void {
     session.timer = setInterval(() => {
-      this.sendNextAutoPing(session);
+      void this.sendNextAutoPing(session);
     }, session.intervalMs);
   }
 
@@ -9678,7 +9678,7 @@ class MeshtasticManager implements ISourceManager {
   private async sendNextAutoPing(session: AutoPingSession): Promise<void> {
     // Check if session is complete — send summary as the final message
     if (session.completedPings >= session.totalPings) {
-      this.finalizeAutoPingSession(session.requestedBy);
+      void this.finalizeAutoPingSession(session.requestedBy);
       return;
     }
 

--- a/src/server/messageQueueService.ts
+++ b/src/server/messageQueueService.ts
@@ -131,7 +131,7 @@ export class MessageQueueService {
     }
 
     // Process immediately, then continue with interval
-    this.processQueue();
+    void this.processQueue();
   }
 
   /**
@@ -216,7 +216,7 @@ export class MessageQueueService {
         logger.debug(`⏳ Rate limit: waiting ${Math.round(waitTime / 1000)}s before next send`);
         setTimeout(() => {
           if (this.processing) {
-            this.processQueue();
+            void this.processQueue();
           }
         }, waitTime);
         return;
@@ -239,7 +239,7 @@ export class MessageQueueService {
       // Schedule next processing cycle, but check processing flag first
       setTimeout(() => {
         if (this.processing) {
-          this.processQueue();
+          void this.processQueue();
         }
       }, this.SEND_INTERVAL_MS);
     } catch (error) {
@@ -247,7 +247,7 @@ export class MessageQueueService {
       // Continue processing on error, but check processing flag first
       setTimeout(() => {
         if (this.processing) {
-          this.processQueue();
+          void this.processQueue();
         }
       }, this.SEND_INTERVAL_MS);
     }

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -27,7 +27,7 @@ vi.mock('../services/database.js', () => ({
     },
     messages: {
       getMessage: vi.fn(async () => null),
-      insertMessage: vi.fn((_msg: any, _sourceId?: string) => true),
+      insertMessage: vi.fn(async (_msg: any, _sourceId?: string) => true),
     },
     channels: {
       upsertChannel: vi.fn(async () => undefined),

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -349,7 +349,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
       // Use the repo's per-source insert — the `databaseService.insertMessage`
       // facade drops the sourceId, leaving rows orphaned (`sourceId=NULL`)
       // and invisible to source-scoped queries like /api/unified/messages.
-      databaseService.messages.insertMessage(msg, sourceId);
+      databaseService.messages.insertMessage(msg, sourceId).catch(err => logger.error('Failed to insert MQTT message:', err));
       // Refresh lastHeard for the sender.
       databaseService.upsertNode({
         nodeNum: fromNum,
@@ -871,7 +871,7 @@ async function ingestStoreForward(
     (msg as any).viaStoreForward = true;
     // Same per-source insert path as the TEXT_MESSAGE_APP case above —
     // the facade drops sourceId; the repo accepts it.
-    databaseService.messages.insertMessage(msg, sourceId);
+    databaseService.messages.insertMessage(msg, sourceId).catch(err => logger.error('Failed to insert MQTT message:', err));
     return true;
   }
 

--- a/src/server/routes/apiTokenRoutes.ts
+++ b/src/server/routes/apiTokenRoutes.ts
@@ -72,7 +72,7 @@ router.post('/generate', requireAuth(), async (req: Request, res: Response) => {
     tokenInfo = result.tokenInfo;
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       userId,
       'api_token_generated',
       'api_token',
@@ -127,7 +127,7 @@ router.delete('/', requireAuth(), async (req: Request, res: Response) => {
     }
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       userId,
       'api_token_revoked',
       'api_token',

--- a/src/server/routes/auditRoutes.ts
+++ b/src/server/routes/auditRoutes.ts
@@ -141,7 +141,7 @@ router.post('/cleanup', requireAdmin(), async (req: Request, res: Response) => {
     const deletedCount = await databaseService.cleanupAuditLogsAsync(days);
 
     // Log the cleanup action
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'audit_cleanup',
       'audit',

--- a/src/server/routes/authRoutes.ts
+++ b/src/server/routes/authRoutes.ts
@@ -255,7 +255,7 @@ router.post('/login', authLimiter, async (req: Request, res: Response) => {
 
     if (!user) {
       // Audit log failed attempt
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         null,
         'login_failed',
         'auth',
@@ -273,7 +273,7 @@ router.post('/login', authLimiter, async (req: Request, res: Response) => {
       // Don't create full session yet - store pending MFA verification
       req.session.pendingMfaUserId = user.id;
 
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         user.id,
         'login_mfa_required',
         'auth',
@@ -300,7 +300,7 @@ router.post('/login', authLimiter, async (req: Request, res: Response) => {
     req.session.isAdmin = user.isAdmin;
 
     // Audit log successful login
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'login_success',
       'auth',
@@ -335,7 +335,7 @@ router.post('/logout', (req: Request, res: Response) => {
 
     // Audit log
     if (userId) {
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         userId,
         'logout',
         'auth',
@@ -386,7 +386,7 @@ router.post('/verify-mfa', authLimiter, async (req: Request, res: Response) => {
       if (remaining !== null) {
         verified = true;
         await databaseService.consumeBackupCodeAsync(user.id, JSON.stringify(remaining));
-        databaseService.auditLogAsync(
+        void databaseService.auditLogAsync(
           user.id,
           'mfa_backup_code_used',
           'auth',
@@ -397,7 +397,7 @@ router.post('/verify-mfa', authLimiter, async (req: Request, res: Response) => {
     }
 
     if (!verified) {
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         user.id,
         'mfa_verify_failed',
         'auth',
@@ -420,7 +420,7 @@ router.post('/verify-mfa', authLimiter, async (req: Request, res: Response) => {
     req.session.authProvider = 'local';
     req.session.isAdmin = user.isAdmin;
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'login_success',
       'auth',
@@ -589,7 +589,7 @@ router.get('/oidc/callback', async (req: Request, res: Response) => {
     req.session.isAdmin = user.isAdmin;
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'login_success',
       'auth',

--- a/src/server/routes/backupRoutes.ts
+++ b/src/server/routes/backupRoutes.ts
@@ -146,7 +146,7 @@ systemBackupRouter.post('/', requirePermission('configuration', 'write'), async 
     const dirname = await systemBackupService.createBackup('manual');
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'system_backup_created',
       'system_backup',
@@ -229,7 +229,7 @@ systemBackupRouter.get('/download/:dirname', requirePermission('configuration', 
     });
 
     // Audit log before streaming
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'system_backup_downloaded',
       'system_backup',
@@ -269,7 +269,7 @@ systemBackupRouter.delete('/delete/:dirname', requirePermission('configuration',
     await systemBackupService.deleteBackup(dirname);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'system_backup_deleted',
       'system_backup',

--- a/src/server/routes/connectionRoutes.ts
+++ b/src/server/routes/connectionRoutes.ts
@@ -49,7 +49,7 @@ router.post('/disconnect', requirePermission('connection', 'write'), async (req:
     await disconnectManager.userDisconnect();
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'connection_disconnected',
       'connection',
@@ -72,7 +72,7 @@ router.post('/reconnect', requirePermission('connection', 'write'), async (req: 
     const success = await reconnectManager.userReconnect();
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'connection_reconnected',
       'connection',
@@ -140,7 +140,7 @@ router.post('/configure', requireAdmin(), async (req: Request, res: Response) =>
     await connConfigManager.setNodeIpOverride(nodeIp);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'connection_address_changed',
       'connection',

--- a/src/server/routes/embedProfileRoutes.ts
+++ b/src/server/routes/embedProfileRoutes.ts
@@ -125,7 +125,7 @@ router.post('/', async (req: Request, res: Response) => {
       sourceId,
     });
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'embed_profile_created',
       'embed_profile',
@@ -177,7 +177,7 @@ router.put('/:id', async (req: Request, res: Response) => {
       return res.status(404).json({ error: 'Embed profile not found' });
     }
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'embed_profile_updated',
       'embed_profile',
@@ -202,7 +202,7 @@ router.delete('/:id', async (req: Request, res: Response) => {
       return res.status(404).json({ error: 'Embed profile not found' });
     }
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'embed_profile_deleted',
       'embed_profile',

--- a/src/server/routes/mfaRoutes.ts
+++ b/src/server/routes/mfaRoutes.ts
@@ -61,7 +61,7 @@ router.post('/setup', requireAuth(), authLimiter, async (req: Request, res: Resp
     );
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'mfa_setup_initiated',
       'auth',
@@ -106,7 +106,7 @@ router.post('/verify-setup', requireAuth(), authLimiter, async (req: Request, re
     // Verify the token
     const isValid = mfaService.verifyToken(freshUser.mfaSecret, token);
     if (!isValid) {
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         user.id,
         'mfa_setup_verify_failed',
         'auth',
@@ -120,7 +120,7 @@ router.post('/verify-setup', requireAuth(), authLimiter, async (req: Request, re
     await databaseService.enableUserMfaAsync(user.id);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'mfa_enabled',
       'auth',
@@ -167,7 +167,7 @@ router.post('/disable', requireAuth(), authLimiter, async (req: Request, res: Re
         verified = true;
         // Update remaining backup codes
         await databaseService.consumeBackupCodeAsync(user.id, JSON.stringify(remaining));
-        databaseService.auditLogAsync(
+        void databaseService.auditLogAsync(
           user.id,
           'mfa_backup_code_used',
           'auth',
@@ -180,7 +180,7 @@ router.post('/disable', requireAuth(), authLimiter, async (req: Request, res: Re
     }
 
     if (!verified) {
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         user.id,
         'mfa_disable_failed',
         'auth',
@@ -194,7 +194,7 @@ router.post('/disable', requireAuth(), authLimiter, async (req: Request, res: Re
     await databaseService.clearUserMfaAsync(user.id);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'mfa_disabled',
       'auth',

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -363,7 +363,7 @@ router.delete('/', requirePacketPermissions, async (req, res) => {
     logger.info(`🧹 Admin ${user.username} cleared ${deletedCount} packet logs`);
 
     // Log to audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       user.id,
       'packets_cleared',
       'packetmonitor',

--- a/src/server/routes/purgeRoutes.ts
+++ b/src/server/routes/purgeRoutes.ts
@@ -16,7 +16,7 @@ router.post('/nodes', async (req: Request, res: Response) => {
     const purgeNodesManager = resolveSourceManager(purgeNodesSourceId);
     await purgeNodesManager.refreshNodeDatabase();
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'nodes_purged',
       'nodes',
@@ -41,7 +41,7 @@ router.post('/telemetry', async (req: Request, res: Response) => {
     const { sourceId: purgeTelemetrySourceId } = req.body || {};
     await databaseService.purgeAllTelemetryAsync(purgeTelemetrySourceId);
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'telemetry_purged',
       'telemetry',
@@ -66,7 +66,7 @@ router.post('/messages', async (req: Request, res: Response) => {
     const messageCount = await databaseService.messages.getMessageCount();
     await databaseService.messages.deleteAllMessages();
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'messages_purged',
       'messages',
@@ -86,7 +86,7 @@ router.post('/traceroutes', async (req: Request, res: Response) => {
     await databaseService.traceroutes.deleteAllTraceroutes();
     await databaseService.traceroutes.deleteAllRouteSegments();
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'traceroutes_purged',
       'traceroute',

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -165,7 +165,7 @@ router.post(
         });
       }
 
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         req.user!.id,
         'security_scan_triggered',
         'security',
@@ -199,7 +199,7 @@ router.get('/export', async (req: Request, res: Response) => {
     const timestamp = new Date().toISOString();
 
     // Log the export action
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'security_export',
       'security',
@@ -301,7 +301,7 @@ router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), asy
     await databaseService.updateNodeTimeOffsetFlagsAsync(nodeNum, false, null, (node as any).sourceId);
 
     // Log the action
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'security_issues_cleared',
       'security',

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -707,7 +707,7 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
     }
 
     if ('customTilesets' in filteredSettings) {
-      callbacks.refreshTileHostnameCache?.();
+      void callbacks.refreshTileHostnameCache?.();
       logger.debug('🗺️ Refreshed CSP tile hostname cache after customTilesets update');
     }
 
@@ -910,7 +910,7 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
     });
 
     if (Object.keys(changedSettings).length > 0) {
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         req.user!.id,
         'settings_updated',
         'settings',
@@ -1056,7 +1056,7 @@ router.delete('/', requirePermission('settings', 'write'), async (req: Request, 
     await databaseService.settings.deleteAllSettings();
     callbacks.setTracerouteInterval?.(0);
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'settings_reset',
       'settings',

--- a/src/server/routes/systemRoutes.ts
+++ b/src/server/routes/systemRoutes.ts
@@ -178,7 +178,7 @@ router.get('/version/check', optionalAuth(), async (_req: Request, res: Response
             if (upgradeResult.success) {
               autoUpgradeTriggered = true;
               logger.info(`✅ Auto-upgrade triggered successfully: ${upgradeResult.upgradeId}`);
-              databaseService.auditLogAsync(
+              void databaseService.auditLogAsync(
                 null,
                 'auto_upgrade_triggered',
                 'system',

--- a/src/server/routes/themeRoutes.ts
+++ b/src/server/routes/themeRoutes.ts
@@ -58,7 +58,7 @@ router.post('/', requirePermission('themes', 'write'), async (req: Request, res:
 
     const theme = await databaseService.misc.createCustomTheme(name, slug, JSON.stringify(definition), req.user!.id);
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'theme_created',
       'themes',
@@ -116,7 +116,7 @@ router.put('/:slug', requirePermission('themes', 'write'), async (req: Request, 
     if (updates.definition) repoUpdates.definition = JSON.stringify(updates.definition);
     await databaseService.misc.updateCustomTheme(slug, repoUpdates);
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'theme_updated',
       'themes',
@@ -148,7 +148,7 @@ router.delete('/:slug', requirePermission('themes', 'write'), async (req: Reques
 
     await databaseService.misc.deleteCustomTheme(slug);
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'theme_deleted',
       'themes',

--- a/src/server/routes/tileServerTest.ts
+++ b/src/server/routes/tileServerTest.ts
@@ -455,7 +455,7 @@ async function runWithConcurrencyLimit<T>(
     })();
 
     executing.add(promise);
-    promise.finally(() => executing.delete(promise));
+    void promise.finally(() => executing.delete(promise));
 
     if (executing.size >= limit) {
       await Promise.race(executing);

--- a/src/server/routes/upgradeRoutes.ts
+++ b/src/server/routes/upgradeRoutes.ts
@@ -51,7 +51,7 @@ router.post('/clear-block', async (req: Request, res: Response) => {
   try {
     const userId = req.user?.id || null;
     await upgradeService.clearAutoUpgradeBlock(`Acknowledged by user ${userId ?? 'unknown'}`);
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       typeof userId === 'number' ? userId : null,
       'auto_upgrade_block_cleared',
       'system',
@@ -115,7 +115,7 @@ router.post('/trigger', async (req: Request, res: Response) => {
 
     if (result.success) {
       // Log upgrade trigger to audit log
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         typeof userId === 'number' ? userId : null,
         'upgrade_triggered',
         'system',
@@ -231,7 +231,7 @@ router.post('/cancel/:upgradeId', async (req: Request, res: Response) => {
         ? `${upgradeStatus.fromVersion} → ${upgradeStatus.toVersion}`
         : 'unknown version';
 
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         req.user?.id || null,
         'upgrade_cancelled',
         'system',

--- a/src/server/routes/userRoutes.ts
+++ b/src/server/routes/userRoutes.ts
@@ -123,7 +123,7 @@ router.put('/:id', async (req: Request, res: Response) => {
     }
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'user_updated',
       'security',
@@ -170,7 +170,7 @@ router.delete('/:id', async (req: Request, res: Response) => {
     await databaseService.auth.updateUser(userId, { isActive: false });
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'user_deleted',
       'users',
@@ -232,7 +232,7 @@ router.delete('/:id/permanent', async (req: Request, res: Response) => {
     await databaseService.auth.deleteUser(userId);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'user_permanently_deleted',
       'users',
@@ -282,7 +282,7 @@ router.put('/:id/admin', async (req: Request, res: Response) => {
     }
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'admin_status_changed',
       'users',
@@ -460,7 +460,7 @@ router.put('/:id/permissions', async (req: Request, res: Response) => {
     }
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'permissions_updated',
       'permissions',
@@ -598,7 +598,7 @@ router.put('/:id/channel-database-permissions', async (req: Request, res: Respon
     }
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'channel_db_permissions_updated',
       'permissions',
@@ -638,7 +638,7 @@ router.delete('/:id/mfa', async (req: Request, res: Response) => {
     await databaseService.clearUserMfaAsync(userId);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'mfa_admin_disabled',
       'auth',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -290,7 +290,7 @@ initializeOIDC()
 // IMPORTANT: We mark restore as started immediately to prevent race conditions
 // with createAdminIfNeeded() in database.ts
 systemRestoreService.markRestoreStarted();
-(async () => {
+void (async () => {
   try {
     const restoreFromBackup = systemRestoreService.shouldRestore();
 
@@ -321,7 +321,7 @@ systemRestoreService.markRestoreStarted();
         }
 
         // Audit log to mark restore completion point (after migrations)
-        databaseService.auditLogAsync(
+        void databaseService.auditLogAsync(
           null, // System action during bootstrap
           'system_restore_bootstrap_complete',
           'system_backup',
@@ -834,7 +834,7 @@ async function checkForAutoUpgrade(): Promise<void> {
 
     if (upgradeResult.success) {
       logger.info(`✅ Scheduled auto-upgrade triggered successfully: ${upgradeResult.upgradeId}`);
-      databaseService.auditLogAsync(
+      void databaseService.auditLogAsync(
         null,
         'auto_upgrade_triggered',
         'system',
@@ -4102,7 +4102,7 @@ apiRouter.get('/settings/position-estimation/status', requirePermission('setting
 apiRouter.post('/settings/position-estimation/run-now', requirePermission('settings', 'write'), async (req, res) => {
   try {
     const result = await positionEstimationScheduler.runNow();
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'position_estimation_run',
       'settings',
@@ -4228,7 +4228,7 @@ apiRouter.put('/admin/auto-favorite-targets/:nodeNum', requireAdmin(), async (re
       eligibleRoles: JSON.stringify(roles),
     });
 
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'auto_favorite_config',
       'admin',
@@ -4291,7 +4291,7 @@ apiRouter.post('/settings/mark-all-welcomed', requirePermission('settings', 'wri
     logger.info(`👋 Manually marked ${count} nodes as welcomed via API${sourceId ? ` (source=${sourceId})` : ''}`);
 
     // Audit log
-    databaseService.auditLogAsync(
+    void databaseService.auditLogAsync(
       req.user!.id,
       'mark_all_welcomed',
       'nodes',
@@ -6268,13 +6268,13 @@ async function migrateAutoResponderTriggers() {
 }
 
 // Run migration on startup
-migrateAutoResponderTriggers();
+void migrateAutoResponderTriggers();
 
 // Module-level server variable for graceful shutdown
 let server: ReturnType<typeof app.listen>;
 
 // Wrap server startup in async IIFE to wait for database before accepting requests
-(async () => {
+void (async () => {
   try {
     // Wait for database initialization to complete BEFORE starting server
     // This is critical for PostgreSQL/MySQL where Drizzle repositories are initialized async
@@ -6309,7 +6309,7 @@ let server: ReturnType<typeof app.listen>;
     firmwareUpdateService.startPolling();
 
     // Send server start notification
-    (async () => {
+    void (async () => {
       try {
         const enabledFeatures: string[] = ['WebSocket']; // WebSocket is always enabled
       if (env.oidcEnabled) enabledFeatures.push('OIDC');

--- a/src/server/services/backupSchedulerService.ts
+++ b/src/server/services/backupSchedulerService.ts
@@ -45,13 +45,13 @@ class BackupSchedulerService {
 
     // Check every minute if it's time to run a backup
     this.schedulerInterval = setInterval(() => {
-      this.checkAndRunBackup();
+      this.checkAndRunBackup().catch(err => logger.error('Backup scheduler error:', err));
     }, 60000); // Check every minute
 
     logger.info('▶️  Backup scheduler started (checks every minute)');
 
     // Run initial check
-    this.checkAndRunBackup();
+    this.checkAndRunBackup().catch(err => logger.error('Backup scheduler error:', err));
   }
 
   /**

--- a/src/server/services/duplicateKeySchedulerService.ts
+++ b/src/server/services/duplicateKeySchedulerService.ts
@@ -48,11 +48,11 @@ class DuplicateKeySchedulerService {
 
     this.initialScanTimer = setTimeout(() => {
       this.initialScanTimer = null;
-      this.runScanAllSources();
+      this.runScanAllSources().catch(err => logger.error('Security scanner error:', err));
     }, 5 * 60 * 1000);
 
     this.intervalId = setInterval(() => {
-      this.runScanAllSources();
+      this.runScanAllSources().catch(err => logger.error('Security scanner error:', err));
     }, this.scanInterval);
 
     logger.info('✅ Security scanner initialized');

--- a/src/server/services/inactiveNodeNotificationService.ts
+++ b/src/server/services/inactiveNodeNotificationService.ts
@@ -48,13 +48,13 @@ class InactiveNodeNotificationService {
     // Run initial check after a short delay
     // Capture parameters in closure to ensure correct values are used even if service is restarted
     this.initialCheckTimeout = setTimeout(() => {
-      this.checkInactiveNodes();
+      void this.checkInactiveNodes();
       this.initialCheckTimeout = null; // Clear reference after execution
     }, 60000); // Wait 1 minute before first check
 
     // Schedule periodic checks
     this.checkInterval = setInterval(() => {
-      this.checkInactiveNodes();
+      void this.checkInactiveNodes();
     }, checkIntervalMinutes * 60 * 1000);
   }
 

--- a/src/server/services/lowBatteryNotificationService.ts
+++ b/src/server/services/lowBatteryNotificationService.ts
@@ -65,13 +65,13 @@ class LowBatteryNotificationService {
 
     // Run initial check after a short delay
     this.initialCheckTimeout = setTimeout(() => {
-      this.checkLowBatteryNodes();
+      void this.checkLowBatteryNodes();
       this.initialCheckTimeout = null;
     }, 60000); // Wait 1 minute before first check
 
     // Schedule periodic checks
     this.checkInterval = setInterval(() => {
-      this.checkLowBatteryNodes();
+      void this.checkLowBatteryNodes();
     }, checkIntervalMinutes * 60 * 1000);
   }
 

--- a/src/server/services/packetLogService.ts
+++ b/src/server/services/packetLogService.ts
@@ -20,7 +20,7 @@ class PacketLogService {
 
     logger.debug('🧹 Starting packet log cleanup scheduler (runs every 15 minutes)');
     this.cleanupInterval = setInterval(() => {
-      this.runCleanup();
+      void this.runCleanup();
     }, this.CLEANUP_INTERVAL_MS);
   }
 

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -263,7 +263,7 @@ export function initializeWebSocket(
             return;
           }
         }
-        socket.join(`source:${sourceId}`);
+        void socket.join(`source:${sourceId}`);
         joinedSourceId = sourceId;
         logger.debug(`[WebSocket] Socket ${socket.id} joined room source:${sourceId}`);
       } catch (err) {
@@ -274,7 +274,7 @@ export function initializeWebSocket(
 
     socket.on('leave-source', (sourceId: string) => {
       if (typeof sourceId === 'string' && sourceId.length > 0) {
-        socket.leave(`source:${sourceId}`);
+        void socket.leave(`source:${sourceId}`);
         if (joinedSourceId === sourceId) joinedSourceId = null;
         logger.debug(`[WebSocket] Socket ${socket.id} left room source:${sourceId}`);
       }
@@ -307,7 +307,7 @@ export function initializeWebSocket(
         // We don't verify the id exists in the DB: arming a non-existent/disabled
         // rule is harmless (it simply never emits) and self-expires, so a lookup
         // would add a query per arm for no safety benefit.
-        socket.join(`automation-trace:${automationId}`);
+        void socket.join(`automation-trace:${automationId}`);
         automationTraceBus.arm(automationId, socket.id, expiry);
         socket.emit('automation-trace:started', { automationId, expiresAt: expiry });
         logger.debug(`[WebSocket] Socket ${socket.id} started trace for automation ${automationId}`);
@@ -320,7 +320,7 @@ export function initializeWebSocket(
     socket.on('automation-trace:stop', (raw: { automationId?: string }) => {
       const automationId = typeof raw?.automationId === 'string' ? raw.automationId : '';
       if (!automationId) return;
-      socket.leave(`automation-trace:${automationId}`);
+      void socket.leave(`automation-trace:${automationId}`);
       automationTraceBus.disarm(automationId, socket.id);
       logger.debug(`[WebSocket] Socket ${socket.id} stopped trace for automation ${automationId}`);
     });
@@ -374,7 +374,7 @@ export async function shutdownWebSocket(): Promise<void> {
 
     // Close all connections
     await new Promise<void>((resolve) => {
-      io!.close(() => {
+      void io!.close(() => {
         logger.info('[WebSocket] WebSocket server closed');
         resolve();
       });

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -290,7 +290,7 @@ export class VirtualNodeServer extends EventEmitter {
 
       if (result.type === 'complete') {
         // Process the message
-        this.handleClientMessage(clientId, result.payload);
+        void this.handleClientMessage(clientId, result.payload);
         client.buffer = result.remaining;
       }
     }
@@ -695,7 +695,7 @@ export class VirtualNodeServer extends EventEmitter {
 
     // Start processing queue if not already
     if (!this.isProcessingQueue) {
-      this.processQueue();
+      void this.processQueue();
     }
   }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4399,7 +4399,7 @@ class DatabaseService {
         const pendingTimeoutAgo = now - PENDING_TRACEROUTE_TIMEOUT_MS;
 
         // Fire async operation
-        (async () => {
+        void (async () => {
           try {
             // Check for pending traceroute (reversed direction - see note below)
             // NOTE: When a traceroute response comes in, fromNum is the destination (responder) and toNum is the local node (requester)

--- a/src/utils/notificationSounds.ts
+++ b/src/utils/notificationSounds.ts
@@ -254,7 +254,7 @@ export function playSound(soundId: string, ctx?: AudioContext): boolean {
     const audioContext = ctx ?? new AudioCtor!();
 
     if (audioContext.state === 'suspended') {
-      audioContext.resume();
+      void audioContext.resume();
     }
 
     const now = audioContext.currentTime;


### PR DESCRIPTION
## Summary

Task **0.5** of the remediation plan (#3962, Phase 0) — the lint counterpart to the 0.1 process safety net (#3967).

Enables `@typescript-eslint/no-floating-promises` as `error` for all non-test `src/**` TS/TSX (scoped config block — test files have `project: false` and cannot run type-aware rules), and fixes all **418 violations**:

- **409 sites → `void ` prefix** (behavior-preserving acknowledgment): all frontend fire-and-forget UI side-effects (components 217, App.tsx 30, contexts 25, hooks 17, pages 15, misc) plus backend sites whose callees handle errors internally (audit writes, IIFEs with try/catch, queue/cleanup runners).
- **9 sites → `.catch(err => logger.error(...))`** (deliberate behavior improvement where a silent rejection was a real defect): backup scheduler, security-scanner scheduler, auto-traceroute + remote LocalStats executors, MeshCore auto-pathfinding scheduler, MQTT `insertMessage` (2 call sites).
- **Zero `eslint-disable` comments added.**
- One test-mock fix: `mqttIngestion.test.ts` `insertMessage` mock made `async` (the `.catch()` chain requires a real Promise).

## Verification

- `npm run typecheck` — exit 0 (catches any mis-targeted `void`).
- `eslint src/` with the rule active — **0 violations**.
- Full suite (independent orchestrator re-run): **8058 passed, 0 failed, 0 suite failures** (`--reporter=json`, `success: true`).

**Note:** the spec's acceptance criterion "`npm run lint` exits 0" is not met — but for a pre-existing reason: `eslint .` fails on 367 errors in `tests/`/`.mjs` files outside tsconfig, which pre-date this PR (CI lint runs `continue-on-error: true`). Making lint blocking is Phase 1.4's job (lint ratchets).

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n