### PR TITLE
feat(db)!: withSourceScope fails closed — omitting sourceId throws, ALL_SOURCES sentinel for intentional cross-source (#3962)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -22,10 +22,11 @@ jobs:
   quick-test:
     name: Quick Tests
     runs-on: ubuntu-latest
-    # The full unit suite (npm run test:run) now runs right at ~10 min on CI,
-    # so a 10-min cap intermittently cancels the job at the boundary even though
-    # every step passes. Give it headroom so the check stops flaking (#3385).
-    timeout-minutes: 15
+    # The full unit suite (npm run test:run) keeps growing: ~10 min when the
+    # cap was first raised (#3385), ~14 min by 2026-07 — so the 15-min cap
+    # started timing the job out at the boundary again (GitHub reports the
+    # timeout as "cancelled"). Keep real headroom above the observed runtime.
+    timeout-minutes: 25
 
     services:
       postgres:

--- a/src/cli/test-postgres.ts
+++ b/src/cli/test-postgres.ts
@@ -12,6 +12,7 @@ import { createPostgresDriver } from '../db/drivers/postgres.js';
 import { SettingsRepository } from '../db/repositories/settings.js';
 import { NodesRepository } from '../db/repositories/nodes.js';
 import { MessagesRepository } from '../db/repositories/messages.js';
+import { ALL_SOURCES } from '../db/repositories/index.js';
 
 const POSTGRES_URL = process.env.DATABASE_URL || 'postgres://meshmonitor:meshmonitor_dev@localhost:5432/meshmonitor';
 
@@ -198,16 +199,16 @@ async function testNodes(nodesRepo: NodesRepository): Promise<boolean> {
     }
     console.log('  ✅ getNode works');
 
-    // Test getAllNodes
-    const allNodes = await nodesRepo.getAllNodes();
+    // Test getAllNodes (intentional cross-source: CLI test checks all sources)
+    const allNodes = await nodesRepo.getAllNodes(ALL_SOURCES);
     if (allNodes.length < 1) {
       console.error(`  ❌ getAllNodes returned ${allNodes.length} nodes, expected at least 1`);
       return false;
     }
     console.log('  ✅ getAllNodes works');
 
-    // Test getNodeCount
-    const count = await nodesRepo.getNodeCount();
+    // Test getNodeCount (intentional cross-source: CLI test checks all sources)
+    const count = await nodesRepo.getNodeCount(ALL_SOURCES);
     if (count < 1) {
       console.error(`  ❌ getNodeCount returned ${count}, expected at least 1`);
       return false;
@@ -258,8 +259,8 @@ async function testMessages(messagesRepo: MessagesRepository): Promise<boolean> 
     }
     console.log('  ✅ getMessages works');
 
-    // Test getMessageCount
-    const count = await messagesRepo.getMessageCount();
+    // Test getMessageCount (intentional cross-source: CLI test checks all sources)
+    const count = await messagesRepo.getMessageCount(ALL_SOURCES);
     if (count < 1) {
       console.error(`  ❌ getMessageCount returned ${count}, expected at least 1`);
       return false;

--- a/src/db/repositories/base.ts
+++ b/src/db/repositories/base.ts
@@ -21,6 +21,21 @@ export type MySQLDrizzle = MySql2Database<typeof schema>;
 export type DrizzleDatabase = SQLiteDrizzle | PostgresDrizzle | MySQLDrizzle;
 
 /**
+ * Explicit opt-in sentinel for the rare, intentional cross-source query.
+ * Passing this to withSourceScope (or any scoped repo method) means
+ * "I really do want rows from EVERY source" — e.g. system stats, global
+ * purge, process-wide cache warm-up, full backup export.
+ *
+ * A unique symbol (not a magic string) so it can never arrive off the wire /
+ * from JSON, can never collide with a real sourceId, and forces callers to
+ * import it explicitly.
+ */
+export const ALL_SOURCES: unique symbol = Symbol('ALL_SOURCES');
+
+/** A resolved source scope: a concrete sourceId, or the all-sources sentinel. */
+export type SourceScope = string | typeof ALL_SOURCES;
+
+/**
  * Base repository providing common functionality
  */
 export abstract class BaseRepository {
@@ -217,17 +232,24 @@ export abstract class BaseRepository {
   }
 
   /**
-   * Return a Drizzle WHERE condition that filters by sourceId.
+   * Return a Drizzle WHERE condition that scopes a query to one source.
    *
-   * Returns `undefined` when no sourceId is given — Drizzle's `and(...)` treats
-   * undefined entries as no-ops, so existing callers that omit sourceId continue
-   * to see all rows regardless of their source_id value.
+   * FAIL-CLOSED: a missing/empty sourceId THROWS — the #1 hard rule
+   * (per-source isolation) is now enforced at runtime, not by caller discipline.
+   * For an intentional cross-source query, pass the ALL_SOURCES sentinel, which
+   * returns `undefined` (no WHERE clause).
    *
-   * Usage:
    *   .where(and(eq(nodes.nodeNum, num), this.withSourceScope(nodes, sourceId)))
    */
-  protected withSourceScope(table: any, sourceId?: string): SQL | undefined {
-    if (!sourceId) return undefined;
+  protected withSourceScope(table: any, sourceId: SourceScope | undefined): SQL | undefined {
+    if (sourceId === ALL_SOURCES) return undefined;           // explicit opt-out
+    if (sourceId === undefined || sourceId === null || sourceId === '') {
+      throw new Error(
+        'withSourceScope: sourceId is required. Pass a concrete sourceId, or the ' +
+        'ALL_SOURCES sentinel for an intentional cross-source query. ' +
+        'Omitting sourceId used to silently return rows from every source (data leak).',
+      );
+    }
     return eq(table.sourceId, sourceId);
   }
 

--- a/src/db/repositories/channels.test.ts
+++ b/src/db/repositories/channels.test.ts
@@ -338,7 +338,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
     expect(repo.getChannelCountSync('src-a')).toBe(2);
     expect(repo.getChannelCountSync('src-b')).toBe(1);
     // Unscoped sees everything (legacy behaviour).
-    expect(repo.getChannelCountSync()).toBe(3);
+    expect(repo.getChannelCountSync(ALL_SOURCES)).toBe(3);
   });
 
   it('getChannelCount - returns correct count', async () => {

--- a/src/db/repositories/channels.test.ts
+++ b/src/db/repositories/channels.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
 import * as schema from '../schema/index.js';
 import { ChannelsRepository } from './channels.js';
+import { ALL_SOURCES } from './base.js';
 import {
   TestBackend,
   createPostgresBackend,
@@ -270,7 +271,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
     await repo.upsertChannel({ id: 0, name: 'Primary', psk: 'p0', role: 1 });
     await repo.upsertChannel({ id: 1, name: 'One', psk: 'p1', role: 2 });
 
-    const channels = await repo.getAllChannels();
+    const channels = await repo.getAllChannels(ALL_SOURCES);
     expect(channels.length).toBe(3);
     expect(channels[0].id).toBe(0);
     expect(channels[1].id).toBe(1);
@@ -347,13 +348,13 @@ function runChannelsTests(getBackend: () => TestBackend) {
       return;
     }
 
-    expect(await repo.getChannelCount()).toBe(0);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(0);
 
     await repo.upsertChannel({ id: 0, name: 'Primary', psk: 'p0', role: 1 });
-    expect(await repo.getChannelCount()).toBe(1);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(1);
 
     await repo.upsertChannel({ id: 1, name: 'Secondary', psk: 'p1', role: 2 });
-    expect(await repo.getChannelCount()).toBe(2);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(2);
   });
 
   it('deleteChannel - removes a channel by ID', async () => {
@@ -370,7 +371,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
 
     expect(await repo.getChannelById(1)).toBeNull();
     expect(await repo.getChannelById(0)).not.toBeNull();
-    expect(await repo.getChannelCount()).toBe(1);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(1);
   });
 
   it('deleteChannel - no-op for non-existent channel', async () => {
@@ -382,7 +383,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
 
     await repo.upsertChannel({ id: 0, name: 'Primary', psk: 'p0', role: 1 });
     await repo.deleteChannel(99);
-    expect(await repo.getChannelCount()).toBe(1);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(1);
   });
 
   it('cleanupInvalidChannels - removes channels outside 0-7 range', async () => {
@@ -403,11 +404,11 @@ function runChannelsTests(getBackend: () => TestBackend) {
     await backend2.exec(`INSERT INTO channels (id, name, psk, role, ${cat}, ${uat}) VALUES (8, 'Invalid8', 'psk', 2, 0, 0)`);
     await backend2.exec(`INSERT INTO channels (id, name, psk, role, ${cat}, ${uat}) VALUES (100, 'Invalid100', 'psk', 2, 0, 0)`);
 
-    expect(await repo.getChannelCount()).toBe(5);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(5);
 
     const deleted = await repo.cleanupInvalidChannels();
     expect(deleted).toBe(2);
-    expect(await repo.getChannelCount()).toBe(3);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(3);
     expect(await repo.getChannelById(8)).toBeNull();
     expect(await repo.getChannelById(100)).toBeNull();
   });
@@ -424,7 +425,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
 
     const deleted = await repo.cleanupInvalidChannels();
     expect(deleted).toBe(0);
-    expect(await repo.getChannelCount()).toBe(2);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(2);
   });
 
   it('cleanupInvalidChannels - preserves out-of-range channels owned by a MeshCore source', async () => {
@@ -455,7 +456,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
     // A legacy NULL-sourceId channel at idx 9 (implicitly Meshtastic; should be removed).
     await backend.exec(`INSERT INTO channels (id, name, psk, ${cat}, ${uat}) VALUES (9, 'Legacy-Nine', 'aGVsbG8=', 0, 0)`);
 
-    expect(await repo.getChannelCount()).toBe(3);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(3);
 
     const deleted = await repo.cleanupInvalidChannels();
     expect(deleted).toBe(2);
@@ -492,11 +493,11 @@ function runChannelsTests(getBackend: () => TestBackend) {
     await backend2.exec(`INSERT INTO channels (id, name, psk, role, ${cat}, ${uat}) VALUES (3, 'Empty3', NULL, NULL, 0, 0)`);
     await backend2.exec(`INSERT INTO channels (id, name, psk, role, ${cat}, ${uat}) VALUES (4, 'Empty4', NULL, NULL, 0, 0)`);
 
-    expect(await repo.getChannelCount()).toBe(5);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(5);
 
     const deleted = await repo.cleanupEmptyChannels();
     expect(deleted).toBe(2);
-    expect(await repo.getChannelCount()).toBe(3);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(3);
     expect(await repo.getChannelById(3)).toBeNull();
     expect(await repo.getChannelById(4)).toBeNull();
     // Protected channels still exist
@@ -521,7 +522,7 @@ function runChannelsTests(getBackend: () => TestBackend) {
 
     const deleted = await repo.cleanupEmptyChannels();
     expect(deleted).toBe(0);
-    expect(await repo.getChannelCount()).toBe(2);
+    expect(await repo.getChannelCount(ALL_SOURCES)).toBe(2);
   });
 
   it('cleanupEmptyChannels - returns 0 when no empty channels', async () => {

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -69,7 +69,7 @@ export class ChannelsRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(channels)
-      .where(this.withSourceScope(channels, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(channels, sourceId))
       .orderBy(channels.id);
 
     return this.normalizeBigInts(result) as DbChannel[];
@@ -80,7 +80,7 @@ export class ChannelsRepository extends BaseRepository {
    */
   async getChannelCount(sourceId: SourceScope): Promise<number> {
     const { channels } = this.tables;
-    const whereClause = this.withSourceScope(channels, sourceId ?? ALL_SOURCES);
+    const whereClause = this.withSourceScope(channels, sourceId);
     const result = whereClause
       ? await this.db.select({ count: count() }).from(channels).where(whereClause)
       : await this.db.select({ count: count() }).from(channels);

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, and, gt, isNull, or, lt, count, notInArray } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbChannel } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -64,7 +64,7 @@ export class ChannelsRepository extends BaseRepository {
   /**
    * Get all channels ordered by ID, optionally scoped to a source.
    */
-  async getAllChannels(sourceId?: string): Promise<DbChannel[]> {
+  async getAllChannels(sourceId: SourceScope): Promise<DbChannel[]> {
     const { channels } = this.tables;
     const result = await this.db
       .select()
@@ -78,7 +78,7 @@ export class ChannelsRepository extends BaseRepository {
   /**
    * Get the total number of channels, optionally scoped to a source.
    */
-  async getChannelCount(sourceId?: string): Promise<number> {
+  async getChannelCount(sourceId: SourceScope): Promise<number> {
     const { channels } = this.tables;
     const whereClause = this.withSourceScope(channels, sourceId);
     const result = whereClause
@@ -339,7 +339,7 @@ export class ChannelsRepository extends BaseRepository {
    * Synchronously get all channels (SQLite only), optionally scoped to a
    * source (#3712).
    */
-  getAllChannelsSync(sourceId?: string): DbChannel[] {
+  getAllChannelsSync(sourceId?: SourceScope): DbChannel[] {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
     const rows = db
@@ -355,13 +355,11 @@ export class ChannelsRepository extends BaseRepository {
    * Synchronously count channels (SQLite only), optionally scoped to a
    * source (#3712).
    */
-  getChannelCountSync(sourceId?: string): number {
+  getChannelCountSync(sourceId?: SourceScope): number {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
     const whereClause = this.withSourceScope(channels, sourceId);
-    const rows = whereClause
-      ? db.select({ count: count() }).from(channels).where(whereClause).all()
-      : db.select({ count: count() }).from(channels).all();
+    const rows = db.select({ count: count() }).from(channels).where(whereClause).all();
     return Number((rows[0] as any).count);
   }
 

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, and, gt, isNull, or, lt, count, notInArray } from 'drizzle-orm';
-import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbChannel } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -345,7 +345,7 @@ export class ChannelsRepository extends BaseRepository {
     const rows = db
       .select()
       .from(channels)
-      .where(this.withSourceScope(channels, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(channels, sourceId))
       .orderBy(channels.id)
       .all();
     return (rows as any[]).map((row) => this.normalizeBigInts(row)) as DbChannel[];
@@ -358,7 +358,7 @@ export class ChannelsRepository extends BaseRepository {
   getChannelCountSync(sourceId?: SourceScope): number {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
-    const whereClause = this.withSourceScope(channels, sourceId ?? ALL_SOURCES);
+    const whereClause = this.withSourceScope(channels, sourceId);
     const rows = db.select({ count: count() }).from(channels).where(whereClause).all();
     return Number((rows[0] as any).count);
   }

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, and, gt, isNull, or, lt, count, notInArray } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbChannel } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -69,7 +69,7 @@ export class ChannelsRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(channels)
-      .where(this.withSourceScope(channels, sourceId))
+      .where(this.withSourceScope(channels, sourceId ?? ALL_SOURCES))
       .orderBy(channels.id);
 
     return this.normalizeBigInts(result) as DbChannel[];
@@ -80,7 +80,7 @@ export class ChannelsRepository extends BaseRepository {
    */
   async getChannelCount(sourceId: SourceScope): Promise<number> {
     const { channels } = this.tables;
-    const whereClause = this.withSourceScope(channels, sourceId);
+    const whereClause = this.withSourceScope(channels, sourceId ?? ALL_SOURCES);
     const result = whereClause
       ? await this.db.select({ count: count() }).from(channels).where(whereClause)
       : await this.db.select({ count: count() }).from(channels);
@@ -345,7 +345,7 @@ export class ChannelsRepository extends BaseRepository {
     const rows = db
       .select()
       .from(channels)
-      .where(this.withSourceScope(channels, sourceId))
+      .where(this.withSourceScope(channels, sourceId ?? ALL_SOURCES))
       .orderBy(channels.id)
       .all();
     return (rows as any[]).map((row) => this.normalizeBigInts(row)) as DbChannel[];
@@ -358,7 +358,7 @@ export class ChannelsRepository extends BaseRepository {
   getChannelCountSync(sourceId?: SourceScope): number {
     const db = this.getSqliteDb();
     const { channels } = this.tables;
-    const whereClause = this.withSourceScope(channels, sourceId);
+    const whereClause = this.withSourceScope(channels, sourceId ?? ALL_SOURCES);
     const rows = db.select({ count: count() }).from(channels).where(whereClause).all();
     return Number((rows[0] as any).count);
   }

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -4,8 +4,8 @@
  * Central export point for all repository classes.
  */
 
-export { BaseRepository } from './base.js';
-export type { DrizzleDatabase, SQLiteDrizzle, PostgresDrizzle } from './base.js';
+export { BaseRepository, ALL_SOURCES } from './base.js';
+export type { DrizzleDatabase, SQLiteDrizzle, PostgresDrizzle, SourceScope } from './base.js';
 export { SettingsRepository } from './settings.js';
 export { ChannelsRepository, type ChannelInput } from './channels.js';
 export { NodesRepository, type NodesCacheHook } from './nodes.js';

--- a/src/db/repositories/messages.createdAt-ordering.test.ts
+++ b/src/db/repositories/messages.createdAt-ordering.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
+import { ALL_SOURCES } from './base.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
@@ -75,7 +76,7 @@ describe('MessagesRepository — createdAt ordering (#3122)', () => {
     insert('real-newer-1', { rxTime: 2000, createdAt: 2000 });
     insert('real-newer-2', { rxTime: 3000, createdAt: 3000 });
 
-    const rows = await repo.getMessages(10);
+    const rows = await repo.getMessages(10, 0, ALL_SOURCES);
     expect(rows.map((r: any) => r.id)).toEqual(['real-newer-2', 'real-newer-1', 'future-but-old']);
   });
 
@@ -84,7 +85,7 @@ describe('MessagesRepository — createdAt ordering (#3122)', () => {
     insert('actual-new', { channel: 0, rxTime: 500, createdAt: 200 });
     insert('other-channel', { channel: 5, rxTime: 999, createdAt: 999 });
 
-    const rows = await repo.getMessagesByChannel(0, 10);
+    const rows = await repo.getMessagesByChannel(0, 10, 0, ALL_SOURCES);
     expect(rows.map((r: any) => r.id)).toEqual(['actual-new', 'skewed']);
   });
 
@@ -98,7 +99,7 @@ describe('MessagesRepository — createdAt ordering (#3122)', () => {
     // Cursor "before" = 250 should pull rows whose createdAt < 250.
     // Under the old rxTime cursor 'skewed' would be excluded (rxTime > 250).
     // Under createdAt 'skewed' is included.
-    const rows = await repo.getMessagesBeforeInChannel(0, 250, 10);
+    const rows = await repo.getMessagesBeforeInChannel(0, 250, 10, ALL_SOURCES);
     expect(rows.map((r: any) => r.id)).toEqual(['b', 'skewed', 'a']);
   });
 
@@ -106,7 +107,7 @@ describe('MessagesRepository — createdAt ordering (#3122)', () => {
     insert('skewed', { rxTime: FAR_FUTURE, createdAt: 100 });
     insert('newer', { rxTime: 50, createdAt: 200 });
 
-    const rows = repo.getMessagesSqlite(10);
+    const rows = repo.getMessagesSqlite(10, 0, ALL_SOURCES);
     expect(rows.map((r: any) => r.id)).toEqual(['newer', 'skewed']);
   });
 
@@ -114,7 +115,7 @@ describe('MessagesRepository — createdAt ordering (#3122)', () => {
     insert('skewed', { channel: 2, rxTime: FAR_FUTURE, createdAt: 100 });
     insert('newer', { channel: 2, rxTime: 50, createdAt: 200 });
 
-    const rows = repo.getMessagesByChannelSqlite(2, 10);
+    const rows = repo.getMessagesByChannelSqlite(2, 10, 0, ALL_SOURCES);
     expect(rows.map((r: any) => r.id)).toEqual(['newer', 'skewed']);
   });
 });

--- a/src/db/repositories/messages.exclude-portnums.test.ts
+++ b/src/db/repositories/messages.exclude-portnums.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
+import { ALL_SOURCES } from './base.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
@@ -59,10 +60,10 @@ describe('MessagesRepository.getMessages excludePortnums', () => {
     insert('trace-1', 70, 2000);
     insert('text-2', 1, 3000);
 
-    const all = await repo.getMessages(100);
+    const all = await repo.getMessages(100, 0, ALL_SOURCES);
     expect(all).toHaveLength(3);
 
-    const filtered = await repo.getMessages(100, 0, undefined, [70]);
+    const filtered = await repo.getMessages(100, 0, ALL_SOURCES, [70]);
     expect(filtered.map(m => m.id).sort()).toEqual(['text-1', 'text-2']);
   });
 
@@ -70,7 +71,7 @@ describe('MessagesRepository.getMessages excludePortnums', () => {
     insert('legacy', null, 1000);
     insert('trace', 70, 2000);
 
-    const filtered = await repo.getMessages(100, 0, undefined, [70]);
+    const filtered = await repo.getMessages(100, 0, ALL_SOURCES, [70]);
     expect(filtered.map(m => m.id)).toEqual(['legacy']);
   });
 
@@ -83,12 +84,12 @@ describe('MessagesRepository.getMessages excludePortnums', () => {
 
     // Without the filter, limit=3 returns the 3 newest — which now includes
     // the traceroute and drops dm-old. This is the bug.
-    const unfiltered = await repo.getMessages(3);
+    const unfiltered = await repo.getMessages(3, 0, ALL_SOURCES);
     expect(unfiltered.map(m => m.id)).toContain('trace');
     expect(unfiltered.map(m => m.id)).not.toContain('dm-old');
 
     // With the filter, all 3 DMs survive the same capped window.
-    const filtered = await repo.getMessages(3, 0, undefined, [70]);
+    const filtered = await repo.getMessages(3, 0, ALL_SOURCES, [70]);
     expect(filtered.map(m => m.id).sort()).toEqual(['dm-mid', 'dm-old', 'dm-recent']);
   });
 
@@ -96,8 +97,8 @@ describe('MessagesRepository.getMessages excludePortnums', () => {
     insert('a', 1, 1000);
     insert('b', 70, 2000);
 
-    const omitted = await repo.getMessages(100);
-    const empty = await repo.getMessages(100, 0, undefined, []);
+    const omitted = await repo.getMessages(100, 0, ALL_SOURCES);
+    const empty = await repo.getMessages(100, 0, ALL_SOURCES, []);
 
     expect(omitted.map(m => m.id).sort()).toEqual(['a', 'b']);
     expect(empty.map(m => m.id).sort()).toEqual(['a', 'b']);

--- a/src/db/repositories/messages.purge.test.ts
+++ b/src/db/repositories/messages.purge.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
+import { ALL_SOURCES } from './base.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
@@ -97,7 +98,7 @@ describe('MessagesRepository sync purge helpers', () => {
       await insertMsg('m2', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-b');
       await insertMsg('m3', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 1, 'src-a');
 
-      const deleted = repo.purgeChannelMessagesSqlite(0);
+      const deleted = repo.purgeChannelMessagesSqlite(0, ALL_SOURCES);
       expect(deleted).toBe(2);
 
       const remaining = db.prepare('SELECT id FROM messages').all() as { id: string }[];

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, isNull, ne, notInArray, SQL, count } from 'drizzle-orm';
-import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbMessage } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -117,10 +117,10 @@ export class MessagesRepository extends BaseRepository {
     const { messages } = this.tables;
     const whereClause = (excludePortnums && excludePortnums.length > 0)
       ? and(
-          this.withSourceScope(messages, sourceId ?? ALL_SOURCES),
+          this.withSourceScope(messages, sourceId),
           or(isNull(messages.portnum), notInArray(messages.portnum, excludePortnums)),
         )
-      : this.withSourceScope(messages, sourceId ?? ALL_SOURCES);
+      : this.withSourceScope(messages, sourceId);
     const result = await this.db
       .select()
       .from(messages)
@@ -140,7 +140,7 @@ export class MessagesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(messages)
-      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
+      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId)))
       .orderBy(desc(messages.createdAt))
       .limit(limit)
       .offset(offset);
@@ -169,7 +169,7 @@ export class MessagesRepository extends BaseRepository {
     const { messages } = this.tables;
     const conditions: (SQL | undefined)[] = [
       eq(messages.channel, channel),
-      this.withSourceScope(messages, sourceId ?? ALL_SOURCES),
+      this.withSourceScope(messages, sourceId),
     ];
     if (before !== undefined) {
       conditions.push(sql`${messages.createdAt} < ${before}`);
@@ -199,7 +199,7 @@ export class MessagesRepository extends BaseRepository {
             and(eq(messages.fromNodeId, nodeId1), eq(messages.toNodeId, nodeId2)),
             and(eq(messages.fromNodeId, nodeId2), eq(messages.toNodeId, nodeId1))
           ),
-          this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
+          this.withSourceScope(messages, sourceId)
         )
       )
       .orderBy(desc(messages.createdAt))
@@ -217,7 +217,7 @@ export class MessagesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(messages)
-      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
+      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId)))
       .orderBy(messages.timestamp);
 
     return this.normalizeBigInts(result) as DbMessage[];
@@ -253,7 +253,7 @@ export class MessagesRepository extends BaseRepository {
         lastTimestamp: sql<number | null>`MAX(${messages.timestamp})`,
       })
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(messages, sourceId))
       .groupBy(messages.channel);
 
     return rows
@@ -290,7 +290,7 @@ export class MessagesRepository extends BaseRepository {
    */
   async purgeChannelMessages(channel: number, sourceId?: string): Promise<number> {
     const { messages } = this.tables;
-    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
+    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId));
     const [{ deletedCount }] = await this.db
       .select({ deletedCount: count() })
       .from(messages)
@@ -311,7 +311,7 @@ export class MessagesRepository extends BaseRepository {
         eq(messages.toNodeNum, nodeNum)
       ),
       sql`${messages.toNodeId} != '!ffffffff'`,
-      this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
+      this.withSourceScope(messages, sourceId)
     );
     const [{ deletedCount }] = await this.db
       .select({ deletedCount: count() })
@@ -413,7 +413,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(messages, sourceId))
       .orderBy(desc(messages.createdAt))
       .limit(limit)
       .offset(offset)
@@ -433,7 +433,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(messages)
-      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
+      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId)))
       .orderBy(desc(messages.createdAt))
       .limit(limit)
       .offset(offset)
@@ -453,7 +453,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(messages)
-      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
+      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId)))
       .orderBy(messages.timestamp)
       .all();
     return this.normalizeBigInts(rows) as DbMessage[];
@@ -471,7 +471,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select({ count: count() })
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(messages, sourceId))
       .all();
     return Number(rows[0]?.count ?? 0);
   }
@@ -501,7 +501,7 @@ export class MessagesRepository extends BaseRepository {
     const messages = this.tables.messages;
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const condition = sourceId
-      ? and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
+      ? and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId))
       : lt(messages.timestamp, cutoff);
     const result = db.delete(messages).where(condition).run();
     return Number(result.changes);
@@ -623,7 +623,7 @@ export class MessagesRepository extends BaseRepository {
       ? sql<string>`DATE_FORMAT(FROM_UNIXTIME(${messages.timestamp}/1000), '%Y-%m-%d')`
       : sql<string>`to_char(to_timestamp(${messages.timestamp}/1000), 'YYYY-MM-DD')`;
 
-    const condition = and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
+    const condition = and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId));
 
     const rows = await this.db
       .select({ date: dateExpr, count: count() })
@@ -651,7 +651,7 @@ export class MessagesRepository extends BaseRepository {
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const dateExpr = sql<string>`date(${messages.timestamp}/1000, 'unixepoch')`;
     const condition = sourceId
-      ? and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
+      ? and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId))
       : gt(messages.timestamp, cutoff);
     const rows = db
       .select({ date: dateExpr, count: count() })
@@ -674,7 +674,7 @@ export class MessagesRepository extends BaseRepository {
   async cleanupOldMessagesForSource(days: number, sourceId: string): Promise<number> {
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const { messages } = this.tables;
-    const condition = and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
+    const condition = and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId));
 
     // Count first so we can return an affected-row count consistently across
     // dialects (MySQL's delete result shape is awkward with Drizzle here).
@@ -692,13 +692,13 @@ export class MessagesRepository extends BaseRepository {
    * sync `DatabaseService` facade can use it directly. Uses Drizzle query
    * builders so column names come from the schema.
    */
-  purgeChannelMessagesSqlite(channel: number, sourceId?: string): number {
+  purgeChannelMessagesSqlite(channel: number, sourceId?: SourceScope): number {
     if (!this.sqliteDb) {
       throw new Error('purgeChannelMessagesSqlite is SQLite-only');
     }
     const db = this.sqliteDb;
     const messages = this.tables.messages;
-    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
+    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId));
     const result = db.delete(messages).where(condition).run();
     return Number(result.changes);
   }
@@ -720,7 +720,7 @@ export class MessagesRepository extends BaseRepository {
         eq(messages.toNodeNum, nodeNum)
       ),
       ne(messages.toNodeId, '!ffffffff'),
-      this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
+      this.withSourceScope(messages, sourceId)
     );
     const result = db.delete(messages).where(condition).run();
     return Number(result.changes);

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, isNull, ne, notInArray, SQL, count } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbMessage } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -111,7 +111,7 @@ export class MessagesRepository extends BaseRepository {
   async getMessages(
     limit: number = 100,
     offset: number = 0,
-    sourceId?: string,
+    sourceId?: SourceScope,
     excludePortnums?: number[],
   ): Promise<DbMessage[]> {
     const { messages } = this.tables;
@@ -135,7 +135,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * Get messages by channel, ordered by server DB arrival time (issue #3122).
    */
-  async getMessagesByChannel(channel: number, limit: number = 100, offset: number = 0, sourceId?: string): Promise<DbMessage[]> {
+  async getMessagesByChannel(channel: number, limit: number = 100, offset: number = 0, sourceId?: SourceScope): Promise<DbMessage[]> {
     const { messages } = this.tables;
     const result = await this.db
       .select()
@@ -164,7 +164,7 @@ export class MessagesRepository extends BaseRepository {
     channel: number,
     before: number | undefined,
     limit: number = 100,
-    sourceId?: string
+    sourceId?: SourceScope
   ): Promise<DbMessage[]> {
     const { messages } = this.tables;
     const conditions: (SQL | undefined)[] = [
@@ -186,7 +186,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * Get direct messages between two nodes, ordered by server DB arrival time (issue #3122).
    */
-  async getDirectMessages(nodeId1: string, nodeId2: string, limit: number = 100, offset: number = 0, sourceId?: string): Promise<DbMessage[]> {
+  async getDirectMessages(nodeId1: string, nodeId2: string, limit: number = 100, offset: number = 0, sourceId?: SourceScope): Promise<DbMessage[]> {
     const { messages } = this.tables;
     const result = await this.db
       .select()
@@ -212,7 +212,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * Get messages after a timestamp
    */
-  async getMessagesAfterTimestamp(timestamp: number, sourceId?: string): Promise<DbMessage[]> {
+  async getMessagesAfterTimestamp(timestamp: number, sourceId?: SourceScope): Promise<DbMessage[]> {
     const { messages } = this.tables;
     const result = await this.db
       .select()
@@ -226,7 +226,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * Get total message count
    */
-  async getMessageCount(sourceId?: string): Promise<number> {
+  async getMessageCount(sourceId: SourceScope): Promise<number> {
     const { messages } = this.tables;
     const result = await this.db.select({ count: count() }).from(messages)
       .where(this.withSourceScope(messages, sourceId));
@@ -404,7 +404,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * SQLite-only synchronous paginated fetch of messages, ordered by createdAt (issue #3122).
    */
-  getMessagesSqlite(limit: number = 100, offset: number = 0, sourceId?: string): DbMessage[] {
+  getMessagesSqlite(limit: number = 100, offset: number = 0, sourceId?: SourceScope): DbMessage[] {
     if (!this.sqliteDb) {
       throw new Error('getMessagesSqlite is SQLite-only');
     }
@@ -424,7 +424,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * SQLite-only synchronous paginated fetch of messages by channel, ordered by createdAt (issue #3122).
    */
-  getMessagesByChannelSqlite(channel: number, limit: number = 100, offset: number = 0, sourceId?: string): DbMessage[] {
+  getMessagesByChannelSqlite(channel: number, limit: number = 100, offset: number = 0, sourceId?: SourceScope): DbMessage[] {
     if (!this.sqliteDb) {
       throw new Error('getMessagesByChannelSqlite is SQLite-only');
     }
@@ -444,7 +444,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * SQLite-only synchronous fetch of messages after a timestamp.
    */
-  getMessagesAfterTimestampSqlite(timestamp: number, sourceId?: string): DbMessage[] {
+  getMessagesAfterTimestampSqlite(timestamp: number, sourceId?: SourceScope): DbMessage[] {
     if (!this.sqliteDb) {
       throw new Error('getMessagesAfterTimestampSqlite is SQLite-only');
     }
@@ -462,7 +462,7 @@ export class MessagesRepository extends BaseRepository {
   /**
    * SQLite-only synchronous total message count.
    */
-  getMessageCountSqlite(sourceId?: string): number {
+  getMessageCountSqlite(sourceId?: SourceScope): number {
     if (!this.sqliteDb) {
       throw new Error('getMessageCountSqlite is SQLite-only');
     }
@@ -529,14 +529,15 @@ export class MessagesRepository extends BaseRepository {
    * SQLite-only synchronous wipe of all messages, optionally scoped to a source.
    * Mirrors `deleteAllMessages()` for the sync DatabaseService facade.
    */
-  deleteAllMessagesSqlite(sourceId?: string): number {
+  deleteAllMessagesSqlite(sourceId?: SourceScope): number {
     if (!this.sqliteDb) {
       throw new Error('deleteAllMessagesSqlite is SQLite-only');
     }
     const db = this.sqliteDb;
     const messages = this.tables.messages;
-    const result = sourceId
-      ? db.delete(messages).where(eq(messages.sourceId, sourceId)).run()
+    const isScoped = typeof sourceId === 'string' && sourceId !== '';
+    const result = isScoped
+      ? db.delete(messages).where(eq(messages.sourceId, sourceId as string)).run()
       : db.delete(messages).run();
     return Number(result.changes);
   }
@@ -612,7 +613,7 @@ export class MessagesRepository extends BaseRepository {
    *
    * Keeps branching: per-dialect date formatting.
    */
-  async getMessagesByDay(days: number = 7, sourceId?: string): Promise<Array<{ date: string; count: number }>> {
+  async getMessagesByDay(days: number = 7, sourceId?: SourceScope): Promise<Array<{ date: string; count: number }>> {
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const { messages } = this.tables;
 
@@ -641,7 +642,7 @@ export class MessagesRepository extends BaseRepository {
    * SQLite-only synchronous variant of `getMessagesByDay()`.
    * Used by the sync `DatabaseService.getMessagesByDay` facade.
    */
-  getMessagesByDaySqlite(days: number = 7, sourceId?: string): Array<{ date: string; count: number }> {
+  getMessagesByDaySqlite(days: number = 7, sourceId?: SourceScope): Array<{ date: string; count: number }> {
     if (!this.sqliteDb) {
       throw new Error('getMessagesByDaySqlite is SQLite-only');
     }
@@ -800,15 +801,17 @@ export class MessagesRepository extends BaseRepository {
   /**
    * Delete all messages, optionally scoped to a single source.
    */
-  async deleteAllMessages(sourceId?: string): Promise<number> {
+  async deleteAllMessages(sourceId?: SourceScope): Promise<number> {
     const { messages } = this.tables;
+    // ALL_SOURCES or undefined → global delete (no WHERE); a string → scoped delete.
+    const isScoped = typeof sourceId === 'string' && sourceId !== '';
     const countQuery = this.db.select({ count: count() }).from(messages);
-    const result = await (sourceId
-      ? countQuery.where(eq(messages.sourceId, sourceId))
+    const result = await (isScoped
+      ? countQuery.where(eq(messages.sourceId, sourceId as string))
       : countQuery);
     const total = Number(result[0].count);
-    if (sourceId) {
-      await this.db.delete(messages).where(eq(messages.sourceId, sourceId));
+    if (isScoped) {
+      await this.db.delete(messages).where(eq(messages.sourceId, sourceId as string));
     } else {
       await this.db.delete(messages);
     }

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, isNull, ne, notInArray, SQL, count } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbMessage } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -117,10 +117,10 @@ export class MessagesRepository extends BaseRepository {
     const { messages } = this.tables;
     const whereClause = (excludePortnums && excludePortnums.length > 0)
       ? and(
-          this.withSourceScope(messages, sourceId),
+          this.withSourceScope(messages, sourceId ?? ALL_SOURCES),
           or(isNull(messages.portnum), notInArray(messages.portnum, excludePortnums)),
         )
-      : this.withSourceScope(messages, sourceId);
+      : this.withSourceScope(messages, sourceId ?? ALL_SOURCES);
     const result = await this.db
       .select()
       .from(messages)
@@ -140,7 +140,7 @@ export class MessagesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(messages)
-      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId)))
+      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
       .orderBy(desc(messages.createdAt))
       .limit(limit)
       .offset(offset);
@@ -169,7 +169,7 @@ export class MessagesRepository extends BaseRepository {
     const { messages } = this.tables;
     const conditions: (SQL | undefined)[] = [
       eq(messages.channel, channel),
-      this.withSourceScope(messages, sourceId),
+      this.withSourceScope(messages, sourceId ?? ALL_SOURCES),
     ];
     if (before !== undefined) {
       conditions.push(sql`${messages.createdAt} < ${before}`);
@@ -199,7 +199,7 @@ export class MessagesRepository extends BaseRepository {
             and(eq(messages.fromNodeId, nodeId1), eq(messages.toNodeId, nodeId2)),
             and(eq(messages.fromNodeId, nodeId2), eq(messages.toNodeId, nodeId1))
           ),
-          this.withSourceScope(messages, sourceId)
+          this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
         )
       )
       .orderBy(desc(messages.createdAt))
@@ -217,7 +217,7 @@ export class MessagesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(messages)
-      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId)))
+      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
       .orderBy(messages.timestamp);
 
     return this.normalizeBigInts(result) as DbMessage[];
@@ -229,7 +229,7 @@ export class MessagesRepository extends BaseRepository {
   async getMessageCount(sourceId: SourceScope): Promise<number> {
     const { messages } = this.tables;
     const result = await this.db.select({ count: count() }).from(messages)
-      .where(this.withSourceScope(messages, sourceId));
+      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
     return Number(result[0].count);
   }
 
@@ -253,7 +253,7 @@ export class MessagesRepository extends BaseRepository {
         lastTimestamp: sql<number | null>`MAX(${messages.timestamp})`,
       })
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId))
+      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
       .groupBy(messages.channel);
 
     return rows
@@ -290,7 +290,7 @@ export class MessagesRepository extends BaseRepository {
    */
   async purgeChannelMessages(channel: number, sourceId?: string): Promise<number> {
     const { messages } = this.tables;
-    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId));
+    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
     const [{ deletedCount }] = await this.db
       .select({ deletedCount: count() })
       .from(messages)
@@ -311,7 +311,7 @@ export class MessagesRepository extends BaseRepository {
         eq(messages.toNodeNum, nodeNum)
       ),
       sql`${messages.toNodeId} != '!ffffffff'`,
-      this.withSourceScope(messages, sourceId)
+      this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
     );
     const [{ deletedCount }] = await this.db
       .select({ deletedCount: count() })
@@ -413,7 +413,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId))
+      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
       .orderBy(desc(messages.createdAt))
       .limit(limit)
       .offset(offset)
@@ -433,7 +433,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(messages)
-      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId)))
+      .where(and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
       .orderBy(desc(messages.createdAt))
       .limit(limit)
       .offset(offset)
@@ -453,7 +453,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(messages)
-      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId)))
+      .where(and(gt(messages.timestamp, timestamp), this.withSourceScope(messages, sourceId ?? ALL_SOURCES)))
       .orderBy(messages.timestamp)
       .all();
     return this.normalizeBigInts(rows) as DbMessage[];
@@ -471,7 +471,7 @@ export class MessagesRepository extends BaseRepository {
     const rows = db
       .select({ count: count() })
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId))
+      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
       .all();
     return Number(rows[0]?.count ?? 0);
   }
@@ -501,7 +501,7 @@ export class MessagesRepository extends BaseRepository {
     const messages = this.tables.messages;
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const condition = sourceId
-      ? and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId))
+      ? and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
       : lt(messages.timestamp, cutoff);
     const result = db.delete(messages).where(condition).run();
     return Number(result.changes);
@@ -623,7 +623,7 @@ export class MessagesRepository extends BaseRepository {
       ? sql<string>`DATE_FORMAT(FROM_UNIXTIME(${messages.timestamp}/1000), '%Y-%m-%d')`
       : sql<string>`to_char(to_timestamp(${messages.timestamp}/1000), 'YYYY-MM-DD')`;
 
-    const condition = and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId));
+    const condition = and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
 
     const rows = await this.db
       .select({ date: dateExpr, count: count() })
@@ -651,7 +651,7 @@ export class MessagesRepository extends BaseRepository {
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const dateExpr = sql<string>`date(${messages.timestamp}/1000, 'unixepoch')`;
     const condition = sourceId
-      ? and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId))
+      ? and(gt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES))
       : gt(messages.timestamp, cutoff);
     const rows = db
       .select({ date: dateExpr, count: count() })
@@ -674,7 +674,7 @@ export class MessagesRepository extends BaseRepository {
   async cleanupOldMessagesForSource(days: number, sourceId: string): Promise<number> {
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const { messages } = this.tables;
-    const condition = and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId));
+    const condition = and(lt(messages.timestamp, cutoff), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
 
     // Count first so we can return an affected-row count consistently across
     // dialects (MySQL's delete result shape is awkward with Drizzle here).
@@ -698,7 +698,7 @@ export class MessagesRepository extends BaseRepository {
     }
     const db = this.sqliteDb;
     const messages = this.tables.messages;
-    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId));
+    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
     const result = db.delete(messages).where(condition).run();
     return Number(result.changes);
   }
@@ -720,7 +720,7 @@ export class MessagesRepository extends BaseRepository {
         eq(messages.toNodeNum, nodeNum)
       ),
       ne(messages.toNodeId, '!ffffffff'),
-      this.withSourceScope(messages, sourceId)
+      this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
     );
     const result = db.delete(messages).where(condition).run();
     return Number(result.changes);

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -229,7 +229,7 @@ export class MessagesRepository extends BaseRepository {
   async getMessageCount(sourceId: SourceScope): Promise<number> {
     const { messages } = this.tables;
     const result = await this.db.select({ count: count() }).from(messages)
-      .where(this.withSourceScope(messages, sourceId ?? ALL_SOURCES));
+      .where(this.withSourceScope(messages, sourceId));
     return Number(result[0].count);
   }
 

--- a/src/db/repositories/neighbors.test.ts
+++ b/src/db/repositories/neighbors.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
 import { NeighborsRepository } from './neighbors.js';
+import { ALL_SOURCES } from './base.js';
 import { DbNeighborInfo } from '../types.js';
 import {
   TestBackend,
@@ -85,7 +86,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     const neighbor = makeNeighbor();
     await repo.insertNeighborInfo(neighbor);
 
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(1);
     expect(all[0].nodeNum).toBe(100);
     expect(all[0].neighborNodeNum).toBe(200);
@@ -106,7 +107,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     ];
     await repo.insertNeighborInfoBatch(records);
 
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(3);
   });
 
@@ -118,7 +119,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     }
 
     await repo.insertNeighborInfoBatch([]);
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(0);
   });
 
@@ -167,7 +168,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
       makeNeighbor({ nodeNum: 300, neighborNodeNum: 400 }),
     ]);
 
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(2);
   });
 
@@ -186,7 +187,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
 
     await repo.deleteNeighborInfoForNode(100);
 
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(1);
     expect(all[0].nodeNum).toBe(999);
   });
@@ -290,7 +291,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     await repo.deleteAllNeighborInfo();
 
     expect(await repo.getNeighborCount()).toBe(0);
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(0);
   });
 
@@ -316,7 +317,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     const deleted = await repo.cleanupOldNeighborInfo(30);
     expect(deleted).toBe(2);
 
-    const remaining = await repo.getAllNeighborInfo();
+    const remaining = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(remaining).toHaveLength(2);
     remaining.forEach(r => expect(r.timestamp).toBeGreaterThanOrEqual(tenDaysAgo));
   });
@@ -346,7 +347,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     const neighbor = makeNeighbor({ snr: null, lastRxTime: null });
     await repo.insertNeighborInfo(neighbor);
 
-    const all = await repo.getAllNeighborInfo();
+    const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(1);
     expect(all[0].snr).toBeNull();
     expect(all[0].lastRxTime).toBeNull();
@@ -368,7 +369,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
 
     await repo.deleteNeighborInfoInvolvingNode(100);
 
-    const remaining = await repo.getAllNeighborInfo();
+    const remaining = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].nodeNum).toBe(300);
     expect(remaining[0].neighborNodeNum).toBe(400);
@@ -384,7 +385,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     await repo.insertNeighborInfo(makeNeighbor({ nodeNum: 100, neighborNodeNum: 200 }));
     await repo.deleteNeighborInfoInvolvingNode(999);
 
-    const remaining = await repo.getAllNeighborInfo();
+    const remaining = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(remaining).toHaveLength(1);
   });
 

--- a/src/db/repositories/neighbors.test.ts
+++ b/src/db/repositories/neighbors.test.ts
@@ -136,11 +136,11 @@ function runNeighborsTests(getBackend: () => TestBackend) {
       makeNeighbor({ nodeNum: 999, neighborNodeNum: 400 }),
     ]);
 
-    const neighbors = await repo.getNeighborsForNode(100);
+    const neighbors = await repo.getNeighborsForNode(100, ALL_SOURCES);
     expect(neighbors).toHaveLength(2);
     neighbors.forEach(n => expect(n.nodeNum).toBe(100));
 
-    const others = await repo.getNeighborsForNode(999);
+    const others = await repo.getNeighborsForNode(999, ALL_SOURCES);
     expect(others).toHaveLength(1);
     expect(others[0].neighborNodeNum).toBe(400);
   });
@@ -152,7 +152,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
       return;
     }
 
-    const neighbors = await repo.getNeighborsForNode(12345);
+    const neighbors = await repo.getNeighborsForNode(12345, ALL_SOURCES);
     expect(neighbors).toHaveLength(0);
   });
 
@@ -185,7 +185,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
       makeNeighbor({ nodeNum: 999, neighborNodeNum: 400 }),
     ]);
 
-    await repo.deleteNeighborInfoForNode(100);
+    await repo.deleteNeighborInfoForNode(100, ALL_SOURCES);
 
     const all = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(all).toHaveLength(1);
@@ -367,7 +367,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
       makeNeighbor({ nodeNum: 300, neighborNodeNum: 400 }), // unrelated row
     ]);
 
-    await repo.deleteNeighborInfoInvolvingNode(100);
+    await repo.deleteNeighborInfoInvolvingNode(100, ALL_SOURCES);
 
     const remaining = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(remaining).toHaveLength(1);
@@ -383,7 +383,7 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     }
 
     await repo.insertNeighborInfo(makeNeighbor({ nodeNum: 100, neighborNodeNum: 200 }));
-    await repo.deleteNeighborInfoInvolvingNode(999);
+    await repo.deleteNeighborInfoInvolvingNode(999, ALL_SOURCES);
 
     const remaining = await repo.getAllNeighborInfo(ALL_SOURCES);
     expect(remaining).toHaveLength(1);

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, desc, and, or, gte, lt, sql, count, max } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbNeighborInfo } from '../types.js';
 
 /**
@@ -84,7 +84,7 @@ export class NeighborsRepository extends BaseRepository {
   /**
    * Get neighbors for a node
    */
-  async getNeighborsForNode(nodeNum: number, sourceId?: string): Promise<DbNeighborInfo[]> {
+  async getNeighborsForNode(nodeNum: number, sourceId?: SourceScope): Promise<DbNeighborInfo[]> {
     const { neighborInfo } = this.tables;
     const result = await this.db
       .select()
@@ -98,7 +98,7 @@ export class NeighborsRepository extends BaseRepository {
   /**
    * Get all neighbor info
    */
-  async getAllNeighborInfo(sourceId?: string): Promise<DbNeighborInfo[]> {
+  async getAllNeighborInfo(sourceId: SourceScope): Promise<DbNeighborInfo[]> {
     const { neighborInfo } = this.tables;
     const result = await this.db
       .select()
@@ -115,7 +115,7 @@ export class NeighborsRepository extends BaseRepository {
    * deleting a node from one source does not also wipe neighbor info for
    * the same nodeNum on other sources.
    */
-  async deleteNeighborInfoForNode(nodeNum: number, sourceId?: string): Promise<void> {
+  async deleteNeighborInfoForNode(nodeNum: number, sourceId?: SourceScope): Promise<void> {
     const { neighborInfo } = this.tables;
     await this.db
       .delete(neighborInfo)
@@ -177,7 +177,7 @@ export class NeighborsRepository extends BaseRepository {
    * the source node (nodeNum) OR the neighbor node (neighborNodeNum).
    * Used by deleteNode() to fully remove a node from the neighbor graph.
    */
-  async deleteNeighborInfoInvolvingNode(nodeNum: number, sourceId?: string): Promise<void> {
+  async deleteNeighborInfoInvolvingNode(nodeNum: number, sourceId?: SourceScope): Promise<void> {
     const { neighborInfo } = this.tables;
     await this.db
       .delete(neighborInfo)

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, desc, and, or, gte, lt, sql, count, max } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbNeighborInfo } from '../types.js';
 
 /**
@@ -89,7 +89,7 @@ export class NeighborsRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(neighborInfo)
-      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId)))
+      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES)))
       .orderBy(desc(neighborInfo.timestamp));
 
     return this.normalizeBigInts(result) as DbNeighborInfo[];
@@ -103,7 +103,7 @@ export class NeighborsRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(neighborInfo)
-      .where(this.withSourceScope(neighborInfo, sourceId))
+      .where(this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES))
       .orderBy(desc(neighborInfo.timestamp));
 
     return this.normalizeBigInts(result) as DbNeighborInfo[];
@@ -119,7 +119,7 @@ export class NeighborsRepository extends BaseRepository {
     const { neighborInfo } = this.tables;
     await this.db
       .delete(neighborInfo)
-      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId)));
+      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES)));
   }
 
   /**
@@ -184,7 +184,7 @@ export class NeighborsRepository extends BaseRepository {
       .where(
         and(
           or(eq(neighborInfo.nodeNum, nodeNum), eq(neighborInfo.neighborNodeNum, nodeNum)),
-          this.withSourceScope(neighborInfo, sourceId)
+          this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES)
         )
       );
   }

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -103,7 +103,7 @@ export class NeighborsRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(neighborInfo)
-      .where(this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(neighborInfo, sourceId))
       .orderBy(desc(neighborInfo.timestamp));
 
     return this.normalizeBigInts(result) as DbNeighborInfo[];

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, desc, and, or, gte, lt, sql, count, max } from 'drizzle-orm';
-import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbNeighborInfo } from '../types.js';
 
 /**
@@ -89,7 +89,7 @@ export class NeighborsRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(neighborInfo)
-      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES)))
+      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId)))
       .orderBy(desc(neighborInfo.timestamp));
 
     return this.normalizeBigInts(result) as DbNeighborInfo[];
@@ -119,7 +119,7 @@ export class NeighborsRepository extends BaseRepository {
     const { neighborInfo } = this.tables;
     await this.db
       .delete(neighborInfo)
-      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES)));
+      .where(and(eq(neighborInfo.nodeNum, nodeNum), this.withSourceScope(neighborInfo, sourceId)));
   }
 
   /**
@@ -184,7 +184,7 @@ export class NeighborsRepository extends BaseRepository {
       .where(
         and(
           or(eq(neighborInfo.nodeNum, nodeNum), eq(neighborInfo.neighborNodeNum, nodeNum)),
-          this.withSourceScope(neighborInfo, sourceId ?? ALL_SOURCES)
+          this.withSourceScope(neighborInfo, sourceId)
         )
       );
   }

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
 import { NodesRepository } from './nodes.js';
+import { ALL_SOURCES } from './base.js';
 import { createTestDb, type TestDb } from '../../server/test-helpers/testDb.js';
 import {
   TestBackend,
@@ -335,7 +336,7 @@ function runNodesTests(getBackend: () => TestBackend) {
     // Missing nodeId
     await repo.upsertNode({ nodeNum: 1 } as any);
 
-    const count = await repo.getNodeCount();
+    const count = await repo.getNodeCount(ALL_SOURCES);
     expect(count).toBe(0);
   });
 
@@ -489,7 +490,7 @@ function runNodesTests(getBackend: () => TestBackend) {
     await repo.upsertNode(makeNode(501));
     await repo.upsertNode(makeNode(502));
 
-    const all = await repo.getAllNodes();
+    const all = await repo.getAllNodes(ALL_SOURCES);
     expect(all.length).toBe(3);
   });
 
@@ -500,11 +501,11 @@ function runNodesTests(getBackend: () => TestBackend) {
       return;
     }
 
-    expect(await repo.getNodeCount()).toBe(0);
+    expect(await repo.getNodeCount(ALL_SOURCES)).toBe(0);
 
     await repo.upsertNode(makeNode(600));
     await repo.upsertNode(makeNode(601));
-    expect(await repo.getNodeCount()).toBe(2);
+    expect(await repo.getNodeCount(ALL_SOURCES)).toBe(2);
   });
 
   it('getDistinctNodeCount - dedupes nodes shared across sources (issue #2805)', async () => {
@@ -962,7 +963,7 @@ function runNodesTests(getBackend: () => TestBackend) {
 
     const count = await repo.deleteAllNodes();
     expect(count).toBe(3);
-    expect(await repo.getNodeCount()).toBe(0);
+    expect(await repo.getNodeCount(ALL_SOURCES)).toBe(0);
   });
 
   // --- updateNodeMessageHops ---

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -995,7 +995,7 @@ function runNodesTests(getBackend: () => TestBackend) {
     await repo.upsertNode(makeNode(1601, { publicKey: '' }));
     await repo.upsertNode(makeNode(1602)); // null publicKey
 
-    const result = await repo.getNodesWithPublicKeys();
+    const result = await repo.getNodesWithPublicKeys(ALL_SOURCES);
     expect(result.length).toBe(1);
     expect(Number(result[0].nodeNum)).toBe(1600);
     expect(result[0].publicKey).toBe('abc123');

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, count, countDistinct } from 'drizzle-orm';
-import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
 import { isValidNodeNum } from '../../server/constants/meshtastic.js';
@@ -252,7 +252,7 @@ export class NodesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(nodes)
-      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)))
+      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId)))
       .orderBy(desc(nodes.lastHeard));
 
     return this.normalizeBigInts(result) as DbNode[];
@@ -703,7 +703,7 @@ export class NodesRepository extends BaseRepository {
             eq(nodes.keyIsLowEntropy, true),
             eq(nodes.duplicateKeyDetected, true)
           ),
-          this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)
+          this.withSourceScope(nodes, sourceId)
         )
       )
       .orderBy(desc(nodes.lastHeard));
@@ -714,7 +714,7 @@ export class NodesRepository extends BaseRepository {
   /**
    * Get all nodes that have public keys
    */
-  async getNodesWithPublicKeys(sourceId?: string): Promise<Array<{ nodeNum: number; publicKey: string | null }>> {
+  async getNodesWithPublicKeys(sourceId?: SourceScope): Promise<Array<{ nodeNum: number; publicKey: string | null }>> {
     const { nodes } = this.tables;
     const result = await this.db
       .select({ nodeNum: nodes.nodeNum, publicKey: nodes.publicKey })
@@ -723,7 +723,7 @@ export class NodesRepository extends BaseRepository {
         and(
           isNotNull(nodes.publicKey),
           ne(nodes.publicKey, ''),
-          this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)
+          this.withSourceScope(nodes, sourceId)
         )
       );
 
@@ -1164,7 +1164,7 @@ export class NodesRepository extends BaseRepository {
             isNull(nodes.lastRemoteAdminCheck),
             lt(nodes.lastRemoteAdminCheck, expirationMsAgo)
           ),
-          this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)
+          this.withSourceScope(nodes, sourceId)
         )
       )
       .orderBy(sql`${nodes.hopsAway} IS NULL`, asc(nodes.hopsAway), desc(nodes.lastHeard))
@@ -1236,7 +1236,7 @@ export class NodesRepository extends BaseRepository {
       baseConditions.push(inArray(nodes.nodeNum, filterNodeNums));
     }
 
-    const sourceScope = this.withSourceScope(nodes, sourceId ?? ALL_SOURCES);
+    const sourceScope = this.withSourceScope(nodes, sourceId);
     if (sourceScope) baseConditions.push(sourceScope);
 
     const results = await this.db

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, count, countDistinct } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
 import { isValidNodeNum } from '../../server/constants/meshtastic.js';
@@ -230,7 +230,7 @@ export class NodesRepository extends BaseRepository {
   /**
    * Get all nodes ordered by update time
    */
-  async getAllNodes(sourceId?: string): Promise<DbNode[]> {
+  async getAllNodes(sourceId: SourceScope): Promise<DbNode[]> {
     const { nodes } = this.tables;
     const result = await this.db
       .select()
@@ -244,7 +244,7 @@ export class NodesRepository extends BaseRepository {
   /**
    * Get active nodes (heard within sinceDays)
    */
-  async getActiveNodes(sinceDays: number = 7, sourceId?: string): Promise<DbNode[]> {
+  async getActiveNodes(sinceDays: number = 7, sourceId?: SourceScope): Promise<DbNode[]> {
     // lastHeard is stored in seconds (Unix timestamp)
     const cutoff = Math.floor(Date.now() / 1000) - (sinceDays * 24 * 60 * 60);
     const { nodes } = this.tables;
@@ -261,7 +261,7 @@ export class NodesRepository extends BaseRepository {
   /**
    * Get total node count
    */
-  async getNodeCount(sourceId?: string): Promise<number> {
+  async getNodeCount(sourceId: SourceScope): Promise<number> {
     const { nodes } = this.tables;
     const result = await this.db.select({ count: count() }).from(nodes)
       .where(this.withSourceScope(nodes, sourceId));
@@ -280,7 +280,7 @@ export class NodesRepository extends BaseRepository {
    * `lastHeard` is stored in seconds (Unix epoch). Returns 0 for a source
    * with no recently-heard nodes.
    */
-  async getActiveNodeCount(sourceId?: string, sinceSeconds: number = 7200): Promise<number> {
+  async getActiveNodeCount(sourceId: SourceScope, sinceSeconds: number = 7200): Promise<number> {
     const cutoff = Math.floor(Date.now() / 1000) - sinceSeconds;
     const { nodes } = this.tables;
     const result = await this.db
@@ -1370,12 +1370,14 @@ export class NodesRepository extends BaseRepository {
   /**
    * SQLite-only synchronous getAllNodes.
    */
-  getAllNodesSqlite(sourceId?: string): DbNode[] {
+  getAllNodesSqlite(sourceId?: SourceScope): DbNode[] {
     if (!this.sqliteDb) throw new Error('getAllNodesSqlite is SQLite-only');
     const db = this.sqliteDb;
     const { nodes } = this.tables;
-    const rows = sourceId
-      ? db.select().from(nodes).where(eq(nodes.sourceId, sourceId)).orderBy(desc(nodes.updatedAt)).all()
+    // ALL_SOURCES or undefined → return all; a concrete string → filter by source.
+    const isScoped = typeof sourceId === 'string' && sourceId !== '';
+    const rows = isScoped
+      ? db.select().from(nodes).where(eq(nodes.sourceId, sourceId as string)).orderBy(desc(nodes.updatedAt)).all()
       : db.select().from(nodes).orderBy(desc(nodes.updatedAt)).all();
     return rows.map((r: any) => this.normalizeBigInts(r)) as DbNode[];
   }

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, count, countDistinct } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
 import { isValidNodeNum } from '../../server/constants/meshtastic.js';
@@ -235,7 +235,7 @@ export class NodesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(nodes)
-      .where(this.withSourceScope(nodes, sourceId))
+      .where(this.withSourceScope(nodes, sourceId ?? ALL_SOURCES))
       .orderBy(desc(nodes.updatedAt));
 
     return this.normalizeBigInts(result) as DbNode[];
@@ -252,7 +252,7 @@ export class NodesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(nodes)
-      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId)))
+      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)))
       .orderBy(desc(nodes.lastHeard));
 
     return this.normalizeBigInts(result) as DbNode[];
@@ -264,7 +264,7 @@ export class NodesRepository extends BaseRepository {
   async getNodeCount(sourceId: SourceScope): Promise<number> {
     const { nodes } = this.tables;
     const result = await this.db.select({ count: count() }).from(nodes)
-      .where(this.withSourceScope(nodes, sourceId));
+      .where(this.withSourceScope(nodes, sourceId ?? ALL_SOURCES));
     return Number(result[0].count);
   }
 
@@ -286,7 +286,7 @@ export class NodesRepository extends BaseRepository {
     const result = await this.db
       .select({ count: count() })
       .from(nodes)
-      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId)));
+      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)));
     return Number(result[0].count);
   }
 
@@ -703,7 +703,7 @@ export class NodesRepository extends BaseRepository {
             eq(nodes.keyIsLowEntropy, true),
             eq(nodes.duplicateKeyDetected, true)
           ),
-          this.withSourceScope(nodes, sourceId)
+          this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)
         )
       )
       .orderBy(desc(nodes.lastHeard));
@@ -723,7 +723,7 @@ export class NodesRepository extends BaseRepository {
         and(
           isNotNull(nodes.publicKey),
           ne(nodes.publicKey, ''),
-          this.withSourceScope(nodes, sourceId)
+          this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)
         )
       );
 
@@ -1164,7 +1164,7 @@ export class NodesRepository extends BaseRepository {
             isNull(nodes.lastRemoteAdminCheck),
             lt(nodes.lastRemoteAdminCheck, expirationMsAgo)
           ),
-          this.withSourceScope(nodes, sourceId)
+          this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)
         )
       )
       .orderBy(sql`${nodes.hopsAway} IS NULL`, asc(nodes.hopsAway), desc(nodes.lastHeard))
@@ -1236,7 +1236,7 @@ export class NodesRepository extends BaseRepository {
       baseConditions.push(inArray(nodes.nodeNum, filterNodeNums));
     }
 
-    const sourceScope = this.withSourceScope(nodes, sourceId);
+    const sourceScope = this.withSourceScope(nodes, sourceId ?? ALL_SOURCES);
     if (sourceScope) baseConditions.push(sourceScope);
 
     const results = await this.db

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -235,7 +235,7 @@ export class NodesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(nodes)
-      .where(this.withSourceScope(nodes, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(nodes, sourceId))
       .orderBy(desc(nodes.updatedAt));
 
     return this.normalizeBigInts(result) as DbNode[];
@@ -264,7 +264,7 @@ export class NodesRepository extends BaseRepository {
   async getNodeCount(sourceId: SourceScope): Promise<number> {
     const { nodes } = this.tables;
     const result = await this.db.select({ count: count() }).from(nodes)
-      .where(this.withSourceScope(nodes, sourceId ?? ALL_SOURCES));
+      .where(this.withSourceScope(nodes, sourceId));
     return Number(result[0].count);
   }
 
@@ -286,7 +286,7 @@ export class NodesRepository extends BaseRepository {
     const result = await this.db
       .select({ count: count() })
       .from(nodes)
-      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId ?? ALL_SOURCES)));
+      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId)));
     return Number(result[0].count);
   }
 

--- a/src/db/repositories/notifications.test.ts
+++ b/src/db/repositories/notifications.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
 import { NotificationsRepository, NotificationPreferences } from './notifications.js';
+import { ALL_SOURCES } from './base.js';
 import {
   TestBackend,
   createPostgresBackend,
@@ -756,12 +757,12 @@ function runNotificationsTests(getBackend: () => TestBackend) {
       await backend.exec(insertMqttMessageSql(backend, 'mqtt1', 0, 3000));
 
       // Default: all three unread messages counted.
-      const all = await repo.getUnreadCountsByChannelAsync(1, undefined, undefined, false);
+      const all = await repo.getUnreadCountsByChannelAsync(1, undefined, ALL_SOURCES, false);
       expect(all[0]).toBe(3);
 
       // excludeMqtt: the MQTT-bridged message is dropped from the count, so the
       // sidebar dot and per-channel badge stay in sync with the hidden-MQTT view.
-      const rfOnly = await repo.getUnreadCountsByChannelAsync(1, undefined, undefined, true);
+      const rfOnly = await repo.getUnreadCountsByChannelAsync(1, undefined, ALL_SOURCES, true);
       expect(rfOnly[0]).toBe(2);
     });
   });

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -14,7 +14,7 @@ import {
 import {
   messagesSqlite,
 } from '../schema/messages.js';
-import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbPushSubscription } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -842,7 +842,7 @@ export class NotificationsRepository extends BaseRepository {
       isNull(readMessages.messageId),
       ne(messages.channel, -1),
       eq(messages.portnum, 1),
-      this.withSourceScope(messages, sourceId ?? ALL_SOURCES),
+      this.withSourceScope(messages, sourceId),
     ];
     if (localNodeId) {
       conditions.push(ne(messages.fromNodeId, localNodeId));
@@ -898,7 +898,7 @@ export class NotificationsRepository extends BaseRepository {
             eq(messages.channel, -1),
             eq(messages.fromNodeId, remoteNodeId),
             eq(messages.toNodeId, localNodeId),
-            this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
+            this.withSourceScope(messages, sourceId)
           )
         );
       return Number(rows[0]?.count ?? 0);
@@ -934,7 +934,7 @@ export class NotificationsRepository extends BaseRepository {
             eq(messages.portnum, 1),
             eq(messages.channel, -1),
             eq(messages.toNodeId, localNodeId),
-            this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
+            this.withSourceScope(messages, sourceId)
           )
         )
         .groupBy(messages.fromNodeId);

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -14,7 +14,7 @@ import {
 import {
   messagesSqlite,
 } from '../schema/messages.js';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbPushSubscription } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -842,7 +842,7 @@ export class NotificationsRepository extends BaseRepository {
       isNull(readMessages.messageId),
       ne(messages.channel, -1),
       eq(messages.portnum, 1),
-      this.withSourceScope(messages, sourceId),
+      this.withSourceScope(messages, sourceId ?? ALL_SOURCES),
     ];
     if (localNodeId) {
       conditions.push(ne(messages.fromNodeId, localNodeId));
@@ -898,7 +898,7 @@ export class NotificationsRepository extends BaseRepository {
             eq(messages.channel, -1),
             eq(messages.fromNodeId, remoteNodeId),
             eq(messages.toNodeId, localNodeId),
-            this.withSourceScope(messages, sourceId)
+            this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
           )
         );
       return Number(rows[0]?.count ?? 0);
@@ -934,7 +934,7 @@ export class NotificationsRepository extends BaseRepository {
             eq(messages.portnum, 1),
             eq(messages.channel, -1),
             eq(messages.toNodeId, localNodeId),
-            this.withSourceScope(messages, sourceId)
+            this.withSourceScope(messages, sourceId ?? ALL_SOURCES)
           )
         )
         .groupBy(messages.fromNodeId);

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -14,7 +14,7 @@ import {
 import {
   messagesSqlite,
 } from '../schema/messages.js';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbPushSubscription } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -832,7 +832,7 @@ export class NotificationsRepository extends BaseRepository {
   async getUnreadCountsByChannelAsync(
     userId: number | null,
     localNodeId?: string,
-    sourceId?: string,
+    sourceId?: SourceScope,
     excludeMqtt?: boolean
   ): Promise<{ [channelId: number]: number }> {
     const messages = this.tables.messages;
@@ -881,7 +881,7 @@ export class NotificationsRepository extends BaseRepository {
     localNodeId: string,
     remoteNodeId: string,
     userId: number | null,
-    sourceId?: string
+    sourceId?: SourceScope
   ): Promise<number> {
     const messages = this.tables.messages;
     const readMessages = this.tables.readMessages;
@@ -915,7 +915,7 @@ export class NotificationsRepository extends BaseRepository {
   async getBatchUnreadDMCountsAsync(
     localNodeId: string,
     userId: number | null,
-    sourceId?: string
+    sourceId?: SourceScope
   ): Promise<{ [fromNodeId: string]: number }> {
     const messages = this.tables.messages;
     const readMessages = this.tables.readMessages;

--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { TelemetryRepository } from './telemetry.js';
+import { ALL_SOURCES } from './base.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
@@ -73,7 +74,7 @@ describe('TelemetryRepository (expanded)', () => {
     it('inserts a record that can be retrieved afterwards', async () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - HOUR, 77);
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(1);
       expect(results[0].nodeId).toBe(NODE1);
       expect(results[0].nodeNum).toBe(NODE1_NUM);
@@ -97,7 +98,7 @@ describe('TelemetryRepository (expanded)', () => {
         gpsAccuracy: 5,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 1);
+      const results = await repo.getTelemetryByNode(NODE1, 1, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.unit).toBe('deg');
@@ -118,7 +119,7 @@ describe('TelemetryRepository (expanded)', () => {
         createdAt: NOW,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 1);
+      const results = await repo.getTelemetryByNode(NODE1, 1, undefined, undefined, 0, undefined, ALL_SOURCES);
       const r = results[0];
       expect(r.unit).toBeNull();
       expect(r.packetTimestamp).toBeNull();
@@ -142,7 +143,7 @@ describe('TelemetryRepository (expanded)', () => {
         hopLimit: 3, // hopStart === hopLimit ⇒ heard directly (0 hops)
       });
 
-      const positions = await repo.getPositionTelemetryByNode(NODE1, 10);
+      const positions = await repo.getPositionTelemetryByNode(NODE1, 10, undefined, ALL_SOURCES);
       const lat = positions.find((p) => p.telemetryType === 'latitude');
       expect(lat).toBeDefined();
       expect(lat!.rxSnr).toBe(6.25);
@@ -183,27 +184,27 @@ describe('TelemetryRepository (expanded)', () => {
     });
 
     it('counts all records for a node when no filters are applied', async () => {
-      expect(await repo.getTelemetryCountByNode(NODE1)).toBe(4);
+      expect(await repo.getTelemetryCountByNode(NODE1, undefined, undefined, undefined, ALL_SOURCES)).toBe(4);
     });
 
     it('counts 0 for a node that has no records', async () => {
-      expect(await repo.getTelemetryCountByNode('!ffffffff')).toBe(0);
+      expect(await repo.getTelemetryCountByNode('!ffffffff', undefined, undefined, undefined, ALL_SOURCES)).toBe(0);
     });
 
     it('applies sinceTimestamp filter (inclusive)', async () => {
       // Only records at or after NOW - 2h
-      const count = await repo.getTelemetryCountByNode(NODE1, NOW - 2 * HOUR);
+      const count = await repo.getTelemetryCountByNode(NODE1, NOW - 2 * HOUR, undefined, undefined, ALL_SOURCES);
       expect(count).toBe(2); // battery@1h and voltage@2h
     });
 
     it('applies beforeTimestamp filter (exclusive)', async () => {
       // Records strictly before NOW - 2h
-      const count = await repo.getTelemetryCountByNode(NODE1, undefined, NOW - 2 * HOUR);
+      const count = await repo.getTelemetryCountByNode(NODE1, undefined, NOW - 2 * HOUR, undefined, ALL_SOURCES);
       expect(count).toBe(2); // battery@3h and battery@5h
     });
 
     it('applies telemetryType filter', async () => {
-      const count = await repo.getTelemetryCountByNode(NODE1, undefined, undefined, 'battery');
+      const count = await repo.getTelemetryCountByNode(NODE1, undefined, undefined, 'battery', ALL_SOURCES);
       expect(count).toBe(3);
     });
 
@@ -213,7 +214,8 @@ describe('TelemetryRepository (expanded)', () => {
         NODE1,
         NOW - 4 * HOUR,
         NOW - 1.5 * HOUR,
-        'battery'
+        'battery',
+        ALL_SOURCES
       );
       expect(count).toBe(1);
     });
@@ -235,7 +237,7 @@ describe('TelemetryRepository (expanded)', () => {
     });
 
     it('returns records ordered by timestamp descending', async () => {
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       const timestamps = results.map(r => r.timestamp);
       for (let i = 1; i < timestamps.length; i++) {
         expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i - 1]);
@@ -243,41 +245,41 @@ describe('TelemetryRepository (expanded)', () => {
     });
 
     it('respects the limit parameter', async () => {
-      const results = await repo.getTelemetryByNode(NODE1, 2);
+      const results = await repo.getTelemetryByNode(NODE1, 2, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(2);
     });
 
     it('respects the offset parameter', async () => {
-      const all = await repo.getTelemetryByNode(NODE1, 10);
-      const paged = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 2);
+      const all = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
+      const paged = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 2, undefined, ALL_SOURCES);
       expect(paged).toHaveLength(all.length - 2);
       expect(paged[0].timestamp).toBe(all[2].timestamp);
     });
 
     it('filters by sinceTimestamp', async () => {
       // Only the most recent 3 battery records (within last 3.5h)
-      const results = await repo.getTelemetryByNode(NODE1, 100, NOW - 3.5 * HOUR);
+      const results = await repo.getTelemetryByNode(NODE1, 100, NOW - 3.5 * HOUR, undefined, 0, undefined, ALL_SOURCES);
       expect(results.every(r => r.timestamp >= NOW - 3.5 * HOUR)).toBe(true);
     });
 
     it('filters by beforeTimestamp', async () => {
-      const results = await repo.getTelemetryByNode(NODE1, 100, undefined, NOW - 3 * HOUR);
+      const results = await repo.getTelemetryByNode(NODE1, 100, undefined, NOW - 3 * HOUR, 0, undefined, ALL_SOURCES);
       expect(results.every(r => r.timestamp < NOW - 3 * HOUR)).toBe(true);
     });
 
     it('filters by telemetryType', async () => {
-      const results = await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, 'voltage');
+      const results = await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, 'voltage', ALL_SOURCES);
       expect(results).toHaveLength(1);
       expect(results[0].telemetryType).toBe('voltage');
     });
 
     it('only returns records for the requested node', async () => {
-      const results = await repo.getTelemetryByNode(NODE1, 100);
+      const results = await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results.every(r => r.nodeId === NODE1)).toBe(true);
     });
 
     it('returns empty array for unknown node', async () => {
-      const results = await repo.getTelemetryByNode('!00000000', 10);
+      const results = await repo.getTelemetryByNode('!00000000', 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(0);
     });
   });
@@ -299,7 +301,7 @@ describe('TelemetryRepository (expanded)', () => {
     });
 
     it('only returns the 5 position telemetry types', async () => {
-      const results = await repo.getPositionTelemetryByNode(NODE1);
+      const results = await repo.getPositionTelemetryByNode(NODE1, undefined, undefined, ALL_SOURCES);
       const types = new Set(results.map(r => r.telemetryType));
       for (const t of POSITION_TYPES) {
         expect(types.has(t)).toBe(true);
@@ -308,7 +310,7 @@ describe('TelemetryRepository (expanded)', () => {
     });
 
     it('only returns records for the requested node', async () => {
-      const results = await repo.getPositionTelemetryByNode(NODE1);
+      const results = await repo.getPositionTelemetryByNode(NODE1, undefined, undefined, ALL_SOURCES);
       expect(results.every(r => r.nodeId === NODE1)).toBe(true);
     });
 
@@ -317,7 +319,7 @@ describe('TelemetryRepository (expanded)', () => {
       for (let i = 2; i <= 5; i++) {
         await insertTelemetry(NODE1, NODE1_NUM, 'latitude', NOW - i * HOUR);
       }
-      const results = await repo.getPositionTelemetryByNode(NODE1, 3);
+      const results = await repo.getPositionTelemetryByNode(NODE1, 3, undefined, ALL_SOURCES);
       expect(results).toHaveLength(3);
     });
 
@@ -325,12 +327,12 @@ describe('TelemetryRepository (expanded)', () => {
       // Add an old record
       await insertTelemetry(NODE1, NODE1_NUM, 'latitude', NOW - 10 * HOUR);
 
-      const results = await repo.getPositionTelemetryByNode(NODE1, 100, NOW - 2 * HOUR);
+      const results = await repo.getPositionTelemetryByNode(NODE1, 100, NOW - 2 * HOUR, ALL_SOURCES);
       expect(results.every(r => r.timestamp >= NOW - 2 * HOUR)).toBe(true);
     });
 
     it('returns empty array when node has no position telemetry', async () => {
-      const results = await repo.getPositionTelemetryByNode('!00000000');
+      const results = await repo.getPositionTelemetryByNode('!00000000', undefined, undefined, ALL_SOURCES);
       expect(results).toHaveLength(0);
     });
 
@@ -339,7 +341,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'latitude', NOW - 10 * HOUR);
 
       // beforeTimestamp is the 5th positional arg (after sourceId).
-      const results = await repo.getPositionTelemetryByNode(NODE1, 100, undefined, undefined, NOW - 2 * HOUR);
+      const results = await repo.getPositionTelemetryByNode(NODE1, 100, undefined, ALL_SOURCES, NOW - 2 * HOUR);
       expect(results.length).toBeGreaterThan(0);
       // Strictly older than the cursor — the NOW - HOUR rows are excluded.
       expect(results.every(r => r.timestamp < NOW - 2 * HOUR)).toBe(true);
@@ -430,7 +432,7 @@ describe('TelemetryRepository (expanded)', () => {
   // -------------------------------------------------------------------------
   describe('getLatestTelemetryByNode', () => {
     it('returns an empty array when node has no telemetry', async () => {
-      const results = await repo.getLatestTelemetryByNode(NODE1);
+      const results = await repo.getLatestTelemetryByNode(NODE1, ALL_SOURCES);
       expect(results).toHaveLength(0);
     });
 
@@ -440,7 +442,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'voltage', NOW - 2 * HOUR, 3.6);
       await insertTelemetry(NODE1, NODE1_NUM, 'temperature', NOW - 4 * HOUR, 22);
 
-      const results = await repo.getLatestTelemetryByNode(NODE1);
+      const results = await repo.getLatestTelemetryByNode(NODE1, ALL_SOURCES);
       expect(results).toHaveLength(3);
 
       const types = results.map(r => r.telemetryType).sort();
@@ -451,7 +453,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - 3 * HOUR, 70);
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - 1 * HOUR, 90);
 
-      const results = await repo.getLatestTelemetryByNode(NODE1);
+      const results = await repo.getLatestTelemetryByNode(NODE1, ALL_SOURCES);
       const battery = results.find(r => r.telemetryType === 'battery');
       expect(battery!.value).toBe(90);
     });
@@ -460,7 +462,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - HOUR, 80);
       await insertTelemetry(NODE2, NODE2_NUM, 'battery', NOW - HOUR, 50);
 
-      const results = await repo.getLatestTelemetryByNode(NODE1);
+      const results = await repo.getLatestTelemetryByNode(NODE1, ALL_SOURCES);
       expect(results.every(r => r.nodeId === NODE1)).toBe(true);
     });
   });
@@ -470,7 +472,7 @@ describe('TelemetryRepository (expanded)', () => {
   // -------------------------------------------------------------------------
   describe('getNodeTelemetryTypes', () => {
     it('returns an empty array when node has no telemetry', async () => {
-      const types = await repo.getNodeTelemetryTypes(NODE1);
+      const types = await repo.getNodeTelemetryTypes(NODE1, ALL_SOURCES);
       expect(types).toHaveLength(0);
     });
 
@@ -480,7 +482,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'voltage', NOW - 2 * HOUR);
       await insertTelemetry(NODE1, NODE1_NUM, 'temperature', NOW - 4 * HOUR);
 
-      const types = await repo.getNodeTelemetryTypes(NODE1);
+      const types = await repo.getNodeTelemetryTypes(NODE1, ALL_SOURCES);
       expect(types.sort()).toEqual(['battery', 'temperature', 'voltage']);
     });
 
@@ -488,7 +490,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - HOUR);
       await insertTelemetry(NODE2, NODE2_NUM, 'humidity', NOW - HOUR);
 
-      const types = await repo.getNodeTelemetryTypes(NODE1);
+      const types = await repo.getNodeTelemetryTypes(NODE1, ALL_SOURCES);
       expect(types).not.toContain('humidity');
     });
   });
@@ -590,7 +592,7 @@ describe('TelemetryRepository (expanded)', () => {
       const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery');
       expect(result).toBe(true);
 
-      const remaining = await repo.getTelemetryByNode(NODE1, 100);
+      const remaining = await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(remaining).toHaveLength(1);
       expect(remaining[0].telemetryType).toBe('voltage');
     });
@@ -601,7 +603,7 @@ describe('TelemetryRepository (expanded)', () => {
 
       await repo.deleteTelemetryByNodeAndType(NODE1, 'battery');
 
-      const node2Records = await repo.getTelemetryByNode(NODE2, 100);
+      const node2Records = await repo.getTelemetryByNode(NODE2, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(node2Records).toHaveLength(1);
     });
   });
@@ -611,7 +613,7 @@ describe('TelemetryRepository (expanded)', () => {
   // -------------------------------------------------------------------------
   describe('purgeNodeTelemetry', () => {
     it('returns 0 when there is nothing to delete', async () => {
-      const count = await repo.purgeNodeTelemetry(NODE1_NUM);
+      const count = await repo.purgeNodeTelemetry(NODE1_NUM, ALL_SOURCES);
       expect(count).toBe(0);
     });
 
@@ -620,7 +622,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'voltage', NOW - 2 * HOUR);
       await insertTelemetry(NODE2, NODE2_NUM, 'battery', NOW - HOUR); // should remain
 
-      const count = await repo.purgeNodeTelemetry(NODE1_NUM);
+      const count = await repo.purgeNodeTelemetry(NODE1_NUM, ALL_SOURCES);
       expect(count).toBe(2);
 
       const total = await repo.getTelemetryCount();
@@ -654,7 +656,7 @@ describe('TelemetryRepository (expanded)', () => {
       const count = await repo.purgePositionHistory(NODE1_NUM);
       expect(count).toBe(POSITION_TYPES.length);
 
-      const remaining = await repo.getTelemetryByNode(NODE1, 100);
+      const remaining = await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(remaining).toHaveLength(2);
       expect(remaining.every(r => !POSITION_TYPES.includes(r.telemetryType))).toBe(true);
     });
@@ -665,7 +667,7 @@ describe('TelemetryRepository (expanded)', () => {
 
       await repo.purgePositionHistory(NODE1_NUM);
 
-      const node2Records = await repo.getTelemetryByNode(NODE2, 100);
+      const node2Records = await repo.getTelemetryByNode(NODE2, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(node2Records).toHaveLength(1);
     });
   });
@@ -736,7 +738,7 @@ describe('TelemetryRepository (expanded)', () => {
   // -------------------------------------------------------------------------
   describe('deleteTelemetryByNode', () => {
     it('returns 0 when there are no records for the node', async () => {
-      const count = await repo.deleteTelemetryByNode(NODE1_NUM);
+      const count = await repo.deleteTelemetryByNode(NODE1_NUM, ALL_SOURCES);
       expect(count).toBe(0);
     });
 
@@ -745,7 +747,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'voltage', NOW - 2 * HOUR);
       await insertTelemetry(NODE2, NODE2_NUM, 'battery', NOW - HOUR); // should survive
 
-      const count = await repo.deleteTelemetryByNode(NODE1_NUM);
+      const count = await repo.deleteTelemetryByNode(NODE1_NUM, ALL_SOURCES);
       expect(count).toBe(2);
 
       expect(await repo.getTelemetryCount()).toBe(1);

--- a/src/db/repositories/telemetry.multidb.test.ts
+++ b/src/db/repositories/telemetry.multidb.test.ts
@@ -12,6 +12,7 @@ import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
 import { telemetrySqlite, telemetryPostgres } from '../schema/telemetry.js';
 import { TelemetryRepository } from './telemetry.js';
+import { ALL_SOURCES } from './base.js';
 import * as schema from '../schema/index.js';
 import { postgresAvailable } from './test-utils.js';
 
@@ -306,7 +307,7 @@ describe.skipIf(!postgresAvailable)('TelemetryRepository - PostgreSQL Backend', 
       base - 6 * BUCKET, // since
       60,                // intervalMinutes
       undefined,         // maxHours
-      undefined          // sourceId
+      ALL_SOURCES        // intentional cross-source: bucketing behavior under test, not scoping
     );
 
     // One row per bucket, newest-first, with the -3h bucket averaged.

--- a/src/db/repositories/telemetry.test.ts
+++ b/src/db/repositories/telemetry.test.ts
@@ -8,6 +8,7 @@ import Database from 'better-sqlite3';
 import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { telemetrySqlite } from '../schema/telemetry.js';
 import { TelemetryRepository } from './telemetry.js';
+import { ALL_SOURCES } from './base.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
@@ -309,7 +310,7 @@ describe('TelemetryRepository', () => {
         packetId: 1234567890,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 1);
+      const results = await repo.getTelemetryByNode(NODE1, 1, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(1);
       expect(results[0].packetId).toBe(1234567890);
     });
@@ -325,7 +326,7 @@ describe('TelemetryRepository', () => {
         createdAt: NOW,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 1);
+      const results = await repo.getTelemetryByNode(NODE1, 1, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(1);
       expect(results[0].packetId).toBeNull();
     });
@@ -342,7 +343,7 @@ describe('TelemetryRepository', () => {
         packetId: null,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 1);
+      const results = await repo.getTelemetryByNode(NODE1, 1, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(1);
       expect(results[0].packetId).toBeNull();
     });
@@ -364,7 +365,7 @@ describe('TelemetryRepository', () => {
         timestamp: NOW, value: 12.5, unit: '%', createdAt: NOW, packetId,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(3);
       // All entries from the same packet should share the same packetId
       expect(results.every(r => r.packetId === packetId)).toBe(true);
@@ -382,7 +383,7 @@ describe('TelemetryRepository', () => {
         timestamp: NOW - 1 * HOUR, value: 80, unit: 'quality', createdAt: NOW,
       });
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(2);
 
       const withPacketId = results.find(r => r.telemetryType === 'batteryLevel');
@@ -439,7 +440,7 @@ describe('TelemetryRepository', () => {
       expect(first).toBe(true);
       expect(second).toBe(false);
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(1);
     });
 
@@ -476,7 +477,7 @@ describe('TelemetryRepository', () => {
         timestamp: NOW, value: 3.7, unit: 'V', createdAt: NOW, packetId,
       }, SOURCE);
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(2);
     });
 
@@ -498,7 +499,7 @@ describe('TelemetryRepository', () => {
       expect(a).toBe(true);
       expect(b).toBe(true);
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(2);
     });
 
@@ -516,7 +517,7 @@ describe('TelemetryRepository', () => {
       await repo.insertTelemetry(row, SOURCE);
       await repo.insertTelemetry(row, SOURCE);
 
-      const results = await repo.getTelemetryByNode(NODE1, 10);
+      const results = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(results).toHaveLength(2);
     });
   });

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, lt, gte, and, desc, inArray, or, not, SQL, count, sql } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbTelemetry } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -196,7 +196,7 @@ export class TelemetryRepository extends BaseRepository {
     sinceTimestamp?: number,
     beforeTimestamp?: number,
     telemetryType?: string,
-    sourceId?: string
+    sourceId?: SourceScope
   ): Promise<number> {
     const { telemetry } = this.tables;
     let conditions = [eq(telemetry.nodeId, nodeId)];
@@ -232,7 +232,7 @@ export class TelemetryRepository extends BaseRepository {
     beforeTimestamp?: number,
     offset: number = 0,
     telemetryType?: string,
-    sourceId?: string
+    sourceId?: SourceScope
   ): Promise<DbTelemetry[]> {
     const { telemetry } = this.tables;
     let conditions = [eq(telemetry.nodeId, nodeId)];
@@ -268,7 +268,7 @@ export class TelemetryRepository extends BaseRepository {
     nodeId: string,
     limit: number = 1500,
     sinceTimestamp?: number,
-    sourceId?: string,
+    sourceId?: SourceScope,
     beforeTimestamp?: number
   ): Promise<DbTelemetry[]> {
     const positionTypes = ['latitude', 'longitude', 'altitude', 'ground_speed', 'ground_track'];
@@ -353,7 +353,7 @@ export class TelemetryRepository extends BaseRepository {
    * misattribute cross-source telemetry to whichever source happens to be
    * iterating in the outer loop.
    */
-  async getLatestTelemetryByNode(nodeId: string, sourceId?: string): Promise<DbTelemetry[]> {
+  async getLatestTelemetryByNode(nodeId: string, sourceId?: SourceScope): Promise<DbTelemetry[]> {
     const types = await this.getNodeTelemetryTypes(nodeId, sourceId);
     const results: DbTelemetry[] = [];
 
@@ -374,14 +374,14 @@ export class TelemetryRepository extends BaseRepository {
   async getLatestTelemetryForType(
     nodeId: string,
     telemetryType: string,
-    sourceId?: string,
+    sourceId?: SourceScope,
   ): Promise<DbTelemetry | null> {
     const { telemetry } = this.tables;
     const conditions = [
       eq(telemetry.nodeId, nodeId),
       eq(telemetry.telemetryType, telemetryType),
     ];
-    if (sourceId) conditions.push(eq(telemetry.sourceId, sourceId));
+    if (typeof sourceId === 'string' && sourceId !== '') conditions.push(eq(telemetry.sourceId, sourceId));
     const result = await this.db
       .select()
       .from(telemetry)
@@ -464,7 +464,7 @@ export class TelemetryRepository extends BaseRepository {
   /**
    * Get all telemetry types for a node
    */
-  async getNodeTelemetryTypes(nodeId: string, sourceId?: string): Promise<string[]> {
+  async getNodeTelemetryTypes(nodeId: string, sourceId?: SourceScope): Promise<string[]> {
     const { telemetry } = this.tables;
     const conditions = [eq(telemetry.nodeId, nodeId)];
     if (sourceId) conditions.push(eq(telemetry.sourceId, sourceId));
@@ -505,7 +505,7 @@ export class TelemetryRepository extends BaseRepository {
    * Purge telemetry for a node, optionally scoped to a source.
    * Delegates to deleteTelemetryByNode.
    */
-  async purgeNodeTelemetry(nodeNum: number, sourceId?: string): Promise<number> {
+  async purgeNodeTelemetry(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     return this.deleteTelemetryByNode(nodeNum, sourceId);
   }
 
@@ -514,7 +514,7 @@ export class TelemetryRepository extends BaseRepository {
    * Deletes only position-related telemetry types (latitude, longitude, altitude, etc.)
    * Keeps branching: MySQL doesn't support .returning().
    */
-  async purgePositionHistory(nodeNum: number, sourceId?: string): Promise<number> {
+  async purgePositionHistory(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     const positionTypes = [
       'latitude', 'longitude', 'altitude',
       'ground_speed', 'ground_track',
@@ -669,7 +669,7 @@ export class TelemetryRepository extends BaseRepository {
    * nodeNum on other sources.
    * Keeps branching: MySQL doesn't support .returning().
    */
-  async deleteTelemetryByNode(nodeNum: number, sourceId?: string): Promise<number> {
+  async deleteTelemetryByNode(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     const { telemetry } = this.tables;
     const condition = and(eq(telemetry.nodeNum, nodeNum), this.withSourceScope(telemetry, sourceId));
 
@@ -693,7 +693,7 @@ export class TelemetryRepository extends BaseRepository {
   /**
    * Delete all telemetry, optionally scoped to a single source.
    */
-  async deleteAllTelemetry(sourceId?: string): Promise<number> {
+  async deleteAllTelemetry(sourceId?: SourceScope): Promise<number> {
     const { telemetry } = this.tables;
     const countQuery = this.db.select({ count: count() }).from(telemetry);
     const result = await (sourceId
@@ -773,7 +773,7 @@ export class TelemetryRepository extends BaseRepository {
   /**
    * Get all nodes with their telemetry types
    */
-  async getAllNodesTelemetryTypes(sourceId?: string): Promise<Map<string, string[]>> {
+  async getAllNodesTelemetryTypes(sourceId?: SourceScope): Promise<Map<string, string[]>> {
     const map = new Map<string, string[]>();
     const { telemetry } = this.tables;
 
@@ -928,7 +928,7 @@ export class TelemetryRepository extends BaseRepository {
     sinceTimestamp: number | undefined,
     intervalMinutes: number,
     maxHours: number | undefined,
-    sourceId: string | undefined
+    sourceId: SourceScope | undefined
   ): DbTelemetry[] {
     if (!this.sqliteDb) {
       throw new Error('getTelemetryByNodeAveragedSqlite is SQLite-only');
@@ -1053,7 +1053,7 @@ export class TelemetryRepository extends BaseRepository {
     sinceTimestamp: number | undefined,
     intervalMinutes: number,
     _maxHours: number | undefined,
-    sourceId: string | undefined
+    sourceId: SourceScope | undefined
   ): Promise<DbTelemetry[]> {
     const { telemetry } = this.tables;
     const rawTypes = TelemetryRepository.RAW_VALUE_TYPES;

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -201,7 +201,7 @@ export class TelemetryRepository extends BaseRepository {
     const { telemetry } = this.tables;
     let conditions = [eq(telemetry.nodeId, nodeId)];
 
-    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
+    const sourceScope = this.withSourceScope(telemetry, sourceId);
     if (sourceScope) conditions.push(sourceScope);
 
     if (sinceTimestamp !== undefined) {
@@ -237,7 +237,7 @@ export class TelemetryRepository extends BaseRepository {
     const { telemetry } = this.tables;
     let conditions = [eq(telemetry.nodeId, nodeId)];
 
-    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
+    const sourceScope = this.withSourceScope(telemetry, sourceId);
     if (sourceScope) conditions.push(sourceScope);
 
     if (sinceTimestamp !== undefined) {
@@ -279,7 +279,7 @@ export class TelemetryRepository extends BaseRepository {
       inArray(telemetry.telemetryType, positionTypes),
     ];
 
-    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
+    const sourceScope = this.withSourceScope(telemetry, sourceId);
     if (sourceScope) conditions.push(sourceScope);
 
     if (sinceTimestamp !== undefined) {
@@ -467,7 +467,9 @@ export class TelemetryRepository extends BaseRepository {
   async getNodeTelemetryTypes(nodeId: string, sourceId?: SourceScope): Promise<string[]> {
     const { telemetry } = this.tables;
     const conditions = [eq(telemetry.nodeId, nodeId)];
-    if (sourceId) conditions.push(eq(telemetry.sourceId, sourceId));
+    // Hand-rolled filter: ALL_SOURCES (a symbol) must mean "no source filter",
+    // and must never be bound into eq() as a value.
+    if (typeof sourceId === 'string' && sourceId !== '') conditions.push(eq(telemetry.sourceId, sourceId));
     const result = await this.db
       .selectDistinct({ type: telemetry.telemetryType })
       .from(telemetry)
@@ -671,7 +673,7 @@ export class TelemetryRepository extends BaseRepository {
    */
   async deleteTelemetryByNode(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     const { telemetry } = this.tables;
-    const condition = and(eq(telemetry.nodeNum, nodeNum), this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES));
+    const condition = and(eq(telemetry.nodeNum, nodeNum), this.withSourceScope(telemetry, sourceId));
 
     if (this.isMySQL()) {
       const countResult = await this.db
@@ -717,28 +719,32 @@ export class TelemetryRepository extends BaseRepository {
     nodeId: string,
     limit: number = 10
   ): Promise<Array<{ latitude: number; longitude: number; timestamp: number }>> {
-    // Get estimated_latitude records
+    // Get estimated_latitude records.
+    // Intentional cross-source: estimated positions are pooled per physical
+    // node across all sources by design (issue #3271).
     const latRecords = await this.getTelemetryByNode(
       nodeId,
       limit * 2, // Get extra to account for potential unmatched records
       undefined,
       undefined,
       0,
-      'estimated_latitude'
+      'estimated_latitude',
+      ALL_SOURCES
     );
 
     if (latRecords.length === 0) {
       return [];
     }
 
-    // Get estimated_longitude records
+    // Get estimated_longitude records (intentional cross-source — see above)
     const lonRecords = await this.getTelemetryByNode(
       nodeId,
       limit * 2,
       undefined,
       undefined,
       0,
-      'estimated_longitude'
+      'estimated_longitude',
+      ALL_SOURCES
     );
 
     if (lonRecords.length === 0) {
@@ -780,7 +786,7 @@ export class TelemetryRepository extends BaseRepository {
     const result = await this.db
       .selectDistinct({ nodeId: telemetry.nodeId, type: telemetry.telemetryType })
       .from(telemetry)
-      .where(this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES));
+      .where(this.withSourceScope(telemetry, sourceId));
 
     for (const r of result) {
       const types = map.get(r.nodeId) || [];
@@ -1060,7 +1066,7 @@ export class TelemetryRepository extends BaseRepository {
     const intervalMs = intervalMinutes * 60 * 1000;
 
     const baseConditions: SQL[] = [eq(telemetry.nodeId, nodeId)];
-    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
+    const sourceScope = this.withSourceScope(telemetry, sourceId);
     if (sourceScope) baseConditions.push(sourceScope);
     if (sinceTimestamp !== undefined) {
       baseConditions.push(gte(telemetry.timestamp, sinceTimestamp));

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, lt, gte, and, desc, inArray, or, not, SQL, count, sql } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbTelemetry } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -201,7 +201,7 @@ export class TelemetryRepository extends BaseRepository {
     const { telemetry } = this.tables;
     let conditions = [eq(telemetry.nodeId, nodeId)];
 
-    const sourceScope = this.withSourceScope(telemetry, sourceId);
+    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
     if (sourceScope) conditions.push(sourceScope);
 
     if (sinceTimestamp !== undefined) {
@@ -237,7 +237,7 @@ export class TelemetryRepository extends BaseRepository {
     const { telemetry } = this.tables;
     let conditions = [eq(telemetry.nodeId, nodeId)];
 
-    const sourceScope = this.withSourceScope(telemetry, sourceId);
+    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
     if (sourceScope) conditions.push(sourceScope);
 
     if (sinceTimestamp !== undefined) {
@@ -279,7 +279,7 @@ export class TelemetryRepository extends BaseRepository {
       inArray(telemetry.telemetryType, positionTypes),
     ];
 
-    const sourceScope = this.withSourceScope(telemetry, sourceId);
+    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
     if (sourceScope) conditions.push(sourceScope);
 
     if (sinceTimestamp !== undefined) {
@@ -671,7 +671,7 @@ export class TelemetryRepository extends BaseRepository {
    */
   async deleteTelemetryByNode(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     const { telemetry } = this.tables;
-    const condition = and(eq(telemetry.nodeNum, nodeNum), this.withSourceScope(telemetry, sourceId));
+    const condition = and(eq(telemetry.nodeNum, nodeNum), this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES));
 
     if (this.isMySQL()) {
       const countResult = await this.db
@@ -780,7 +780,7 @@ export class TelemetryRepository extends BaseRepository {
     const result = await this.db
       .selectDistinct({ nodeId: telemetry.nodeId, type: telemetry.telemetryType })
       .from(telemetry)
-      .where(this.withSourceScope(telemetry, sourceId));
+      .where(this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES));
 
     for (const r of result) {
       const types = map.get(r.nodeId) || [];
@@ -1060,7 +1060,7 @@ export class TelemetryRepository extends BaseRepository {
     const intervalMs = intervalMinutes * 60 * 1000;
 
     const baseConditions: SQL[] = [eq(telemetry.nodeId, nodeId)];
-    const sourceScope = this.withSourceScope(telemetry, sourceId);
+    const sourceScope = this.withSourceScope(telemetry, sourceId ?? ALL_SOURCES);
     if (sourceScope) baseConditions.push(sourceScope);
     if (sinceTimestamp !== undefined) {
       baseConditions.push(gte(telemetry.timestamp, sinceTimestamp));

--- a/src/db/repositories/traceroutes.test.ts
+++ b/src/db/repositories/traceroutes.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
 import { TraceroutesRepository } from './traceroutes.js';
+import { ALL_SOURCES } from './base.js';
 import {
   TestBackend,
   createPostgresBackend,
@@ -163,7 +164,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
       createdAt: now + 1000,
     }));
 
-    const all = await repo.getAllTraceroutes();
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
     expect(all.length).toBe(2);
     // Most recent first
     expect(all[0].fromNodeNum).toBe(3003);
@@ -248,7 +249,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     expect(stillPending).toBeNull();
 
     // Verify the updated data
-    const all = await repo.getAllTraceroutes();
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
     expect(all.length).toBe(1);
     expect(all[0].route).toBe('1001,3003,2002');
     expect(all[0].routeBack).toBe('2002,3003,1001');
@@ -270,7 +271,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     const packetId = 4_000_000_001;
     await repo.insertTraceroute(makeTraceroute({ timestamp: now, createdAt: now, packetId }));
 
-    const all = await repo.getAllTraceroutes();
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
     expect(all.length).toBe(1);
     expect(Number(all[0].packetId)).toBe(packetId);
   });
@@ -299,7 +300,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
       packetId,
     );
 
-    const all = await repo.getAllTraceroutes();
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
     expect(all.length).toBe(1);
     expect(Number(all[0].packetId)).toBe(packetId);
   });
@@ -327,11 +328,11 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     }));
 
     // Should find both directions
-    const results = await repo.getTraceroutesByNodes(1001, 2002);
+    const results = await repo.getTraceroutesByNodes(1001, 2002, 10, ALL_SOURCES);
     expect(results.length).toBe(2);
 
     // Should not include unrelated pair
-    const unrelated = await repo.getTraceroutesByNodes(5005, 6006);
+    const unrelated = await repo.getTraceroutesByNodes(5005, 6006, 10, ALL_SOURCES);
     expect(unrelated.length).toBe(1);
     expect(unrelated[0].fromNodeNum).toBe(5005);
   });
@@ -377,7 +378,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
       timestamp: now + 2, createdAt: now + 2,
     }));
 
-    const deleted = await repo.deleteTraceroutesForNode(1001);
+    const deleted = await repo.deleteTraceroutesForNode(1001, ALL_SOURCES);
     expect(deleted).toBe(2);
     expect(await repo.getTracerouteCount()).toBe(1);
   });
@@ -426,7 +427,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
       timestamp: now + 1, createdAt: now + 1,
     }));
 
-    const longest = await repo.getLongestActiveRouteSegment();
+    const longest = await repo.getLongestActiveRouteSegment(ALL_SOURCES);
     expect(longest).not.toBeNull();
     expect(longest!.distanceKm).toBeCloseTo(12.3);
     expect(longest!.fromNodeNum).toBe(3003);
@@ -439,7 +440,7 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
       return;
     }
 
-    const result = await repo.getLongestActiveRouteSegment();
+    const result = await repo.getLongestActiveRouteSegment(ALL_SOURCES);
     expect(result).toBeNull();
   });
 
@@ -462,23 +463,23 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     }));
 
     // No record holder yet
-    let recordHolder = await repo.getRecordHolderRouteSegment();
+    let recordHolder = await repo.getRecordHolderRouteSegment(ALL_SOURCES);
     expect(recordHolder).toBeNull();
 
     // Find the longest and set it as record holder
-    const longest = await repo.getLongestActiveRouteSegment();
+    const longest = await repo.getLongestActiveRouteSegment(ALL_SOURCES);
     expect(longest).not.toBeNull();
     await repo.setRecordHolder(longest!.id!, true);
 
     // Now should find the record holder
-    recordHolder = await repo.getRecordHolderRouteSegment();
+    recordHolder = await repo.getRecordHolderRouteSegment(ALL_SOURCES);
     expect(recordHolder).not.toBeNull();
     expect(recordHolder!.distanceKm).toBeCloseTo(20.0);
     expect(recordHolder!.fromNodeNum).toBe(3003);
 
     // Unset record holder
     await repo.setRecordHolder(longest!.id!, false);
-    recordHolder = await repo.getRecordHolderRouteSegment();
+    recordHolder = await repo.getRecordHolderRouteSegment(ALL_SOURCES);
     expect(recordHolder).toBeNull();
   });
 
@@ -512,15 +513,15 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     }));
 
     // Cleanup older than 30 days
-    const deleted = await repo.cleanupOldRouteSegments(30);
+    const deleted = await repo.cleanupOldRouteSegments(30, ALL_SOURCES);
     expect(deleted).toBe(1); // Only the old non-record-holder
 
     // Verify: record holder and recent segment remain
-    const longest = await repo.getLongestActiveRouteSegment();
+    const longest = await repo.getLongestActiveRouteSegment(ALL_SOURCES);
     expect(longest).not.toBeNull();
     expect(longest!.distanceKm).toBeCloseTo(50.0);
 
-    const recordHolder = await repo.getRecordHolderRouteSegment();
+    const recordHolder = await repo.getRecordHolderRouteSegment(ALL_SOURCES);
     expect(recordHolder).not.toBeNull();
     expect(recordHolder!.distanceKm).toBeCloseTo(50.0);
   });

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, and, desc, lt, or, isNull, gte, notInArray, count, sql } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbTraceroute, DbRouteSegment, DbNode } from '../types.js';
 
 /**
@@ -121,7 +121,7 @@ export class TraceroutesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(traceroutes)
-      .where(this.withSourceScope(traceroutes, sourceId))
+      .where(this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES))
       .orderBy(desc(traceroutes.timestamp))
       .limit(limit);
 
@@ -156,7 +156,7 @@ export class TraceroutesRepository extends BaseRepository {
               eq(traceroutes.toNodeNum, fromNodeNum)
             )
           ),
-          this.withSourceScope(traceroutes, sourceId)
+          this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES)
         )
       )
       .orderBy(desc(traceroutes.timestamp))
@@ -176,7 +176,7 @@ export class TraceroutesRepository extends BaseRepository {
     const { traceroutes } = this.tables;
     const condition = and(
       or(eq(traceroutes.fromNodeNum, nodeNum), eq(traceroutes.toNodeNum, nodeNum)),
-      this.withSourceScope(traceroutes, sourceId)
+      this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES)
     );
 
     if (this.isMySQL()) {
@@ -269,7 +269,7 @@ export class TraceroutesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(routeSegments)
-      .where(this.withSourceScope(routeSegments, sourceId))
+      .where(this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES))
       .orderBy(desc(routeSegments.distanceKm))
       .limit(1);
 
@@ -288,7 +288,7 @@ export class TraceroutesRepository extends BaseRepository {
       .from(routeSegments)
       .where(and(
         eq(routeSegments.isRecordHolder, true),
-        this.withSourceScope(routeSegments, sourceId),
+        this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
       ))
       .orderBy(desc(routeSegments.distanceKm))
       .limit(1);
@@ -308,7 +308,7 @@ export class TraceroutesRepository extends BaseRepository {
     const { routeSegments } = this.tables;
     const condition = and(
       or(eq(routeSegments.fromNodeNum, nodeNum), eq(routeSegments.toNodeNum, nodeNum)),
-      this.withSourceScope(routeSegments, sourceId),
+      this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
     );
 
     if (this.isMySQL()) {
@@ -365,7 +365,7 @@ export class TraceroutesRepository extends BaseRepository {
       .set({ isRecordHolder: false })
       .where(and(
         eq(routeSegments.isRecordHolder, true),
-        this.withSourceScope(routeSegments, sourceId),
+        this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
       ));
   }
 
@@ -397,7 +397,7 @@ export class TraceroutesRepository extends BaseRepository {
     const condition = and(
       lt(routeSegments.timestamp, cutoff),
       eq(routeSegments.isRecordHolder, false),
-      this.withSourceScope(routeSegments, sourceId),
+      this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
     );
     const toDelete = await this.db
       .select({ count: count() })
@@ -415,7 +415,7 @@ export class TraceroutesRepository extends BaseRepository {
    */
   async deleteAllRouteSegments(sourceId?: SourceScope): Promise<number> {
     const { routeSegments } = this.tables;
-    const scope = this.withSourceScope(routeSegments, sourceId);
+    const scope = this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES);
     const result = await this.db
       .select({ count: count() })
       .from(routeSegments)
@@ -634,7 +634,7 @@ export class TraceroutesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(traceroutes)
-      .where(this.withSourceScope(traceroutes, sourceId))
+      .where(this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES))
       .orderBy(desc(traceroutes.timestamp))
       .limit(limit)
       .all();

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, and, desc, lt, or, isNull, gte, notInArray, count, sql } from 'drizzle-orm';
-import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbTraceroute, DbRouteSegment, DbNode } from '../types.js';
 
 /**
@@ -121,7 +121,7 @@ export class TraceroutesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(traceroutes)
-      .where(this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(traceroutes, sourceId))
       .orderBy(desc(traceroutes.timestamp))
       .limit(limit);
 
@@ -156,7 +156,7 @@ export class TraceroutesRepository extends BaseRepository {
               eq(traceroutes.toNodeNum, fromNodeNum)
             )
           ),
-          this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES)
+          this.withSourceScope(traceroutes, sourceId)
         )
       )
       .orderBy(desc(traceroutes.timestamp))
@@ -176,7 +176,7 @@ export class TraceroutesRepository extends BaseRepository {
     const { traceroutes } = this.tables;
     const condition = and(
       or(eq(traceroutes.fromNodeNum, nodeNum), eq(traceroutes.toNodeNum, nodeNum)),
-      this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES)
+      this.withSourceScope(traceroutes, sourceId)
     );
 
     if (this.isMySQL()) {
@@ -269,7 +269,7 @@ export class TraceroutesRepository extends BaseRepository {
     const result = await this.db
       .select()
       .from(routeSegments)
-      .where(this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(routeSegments, sourceId))
       .orderBy(desc(routeSegments.distanceKm))
       .limit(1);
 
@@ -288,7 +288,7 @@ export class TraceroutesRepository extends BaseRepository {
       .from(routeSegments)
       .where(and(
         eq(routeSegments.isRecordHolder, true),
-        this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
+        this.withSourceScope(routeSegments, sourceId),
       ))
       .orderBy(desc(routeSegments.distanceKm))
       .limit(1);
@@ -308,7 +308,7 @@ export class TraceroutesRepository extends BaseRepository {
     const { routeSegments } = this.tables;
     const condition = and(
       or(eq(routeSegments.fromNodeNum, nodeNum), eq(routeSegments.toNodeNum, nodeNum)),
-      this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
+      this.withSourceScope(routeSegments, sourceId),
     );
 
     if (this.isMySQL()) {
@@ -365,7 +365,7 @@ export class TraceroutesRepository extends BaseRepository {
       .set({ isRecordHolder: false })
       .where(and(
         eq(routeSegments.isRecordHolder, true),
-        this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
+        this.withSourceScope(routeSegments, sourceId),
       ));
   }
 
@@ -397,7 +397,7 @@ export class TraceroutesRepository extends BaseRepository {
     const condition = and(
       lt(routeSegments.timestamp, cutoff),
       eq(routeSegments.isRecordHolder, false),
-      this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES),
+      this.withSourceScope(routeSegments, sourceId),
     );
     const toDelete = await this.db
       .select({ count: count() })
@@ -415,7 +415,7 @@ export class TraceroutesRepository extends BaseRepository {
    */
   async deleteAllRouteSegments(sourceId?: SourceScope): Promise<number> {
     const { routeSegments } = this.tables;
-    const scope = this.withSourceScope(routeSegments, sourceId ?? ALL_SOURCES);
+    const scope = this.withSourceScope(routeSegments, sourceId);
     const result = await this.db
       .select({ count: count() })
       .from(routeSegments)
@@ -634,7 +634,7 @@ export class TraceroutesRepository extends BaseRepository {
     const rows = db
       .select()
       .from(traceroutes)
-      .where(this.withSourceScope(traceroutes, sourceId ?? ALL_SOURCES))
+      .where(this.withSourceScope(traceroutes, sourceId))
       .orderBy(desc(traceroutes.timestamp))
       .limit(limit)
       .all();

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -5,7 +5,7 @@
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
 import { eq, and, desc, lt, or, isNull, gte, notInArray, count, sql } from 'drizzle-orm';
-import { BaseRepository, DrizzleDatabase } from './base.js';
+import { BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbTraceroute, DbRouteSegment, DbNode } from '../types.js';
 
 /**
@@ -116,7 +116,7 @@ export class TraceroutesRepository extends BaseRepository {
   /**
    * Get all traceroutes with pagination
    */
-  async getAllTraceroutes(limit: number = 100, sourceId?: string): Promise<DbTraceroute[]> {
+  async getAllTraceroutes(limit: number = 100, sourceId?: SourceScope): Promise<DbTraceroute[]> {
     const { traceroutes } = this.tables;
     const result = await this.db
       .select()
@@ -136,7 +136,7 @@ export class TraceroutesRepository extends BaseRepository {
    * local TCP mesh) from bleeding into a view scoped to a different source
    * (e.g. an MQTT feed) where the same nodeNums may also be present.
    */
-  async getTraceroutesByNodes(fromNodeNum: number, toNodeNum: number, limit: number = 10, sourceId?: string): Promise<DbTraceroute[]> {
+  async getTraceroutesByNodes(fromNodeNum: number, toNodeNum: number, limit: number = 10, sourceId?: SourceScope): Promise<DbTraceroute[]> {
     const { traceroutes } = this.tables;
     // Search bidirectionally to capture traceroutes initiated from either direction
     // This is especially important for 3rd party traceroutes (e.g., via Virtual Node)
@@ -172,7 +172,7 @@ export class TraceroutesRepository extends BaseRepository {
    * nodeNum on other sources.
    * Uses .returning() for SQLite/Postgres, count-then-delete for MySQL.
    */
-  async deleteTraceroutesForNode(nodeNum: number, sourceId?: string): Promise<number> {
+  async deleteTraceroutesForNode(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     const { traceroutes } = this.tables;
     const condition = and(
       or(eq(traceroutes.fromNodeNum, nodeNum), eq(traceroutes.toNodeNum, nodeNum)),
@@ -264,7 +264,7 @@ export class TraceroutesRepository extends BaseRepository {
    * Get the longest currently-stored route segment, optionally scoped to a
    * single source so each source tracks its own longest link independently.
    */
-  async getLongestActiveRouteSegment(sourceId?: string): Promise<DbRouteSegment | null> {
+  async getLongestActiveRouteSegment(sourceId?: SourceScope): Promise<DbRouteSegment| null> {
     const { routeSegments } = this.tables;
     const result = await this.db
       .select()
@@ -281,7 +281,7 @@ export class TraceroutesRepository extends BaseRepository {
    * Get the record-holder segment, optionally scoped to a single source so
    * each source maintains its own all-time record.
    */
-  async getRecordHolderRouteSegment(sourceId?: string): Promise<DbRouteSegment | null> {
+  async getRecordHolderRouteSegment(sourceId?: SourceScope): Promise<DbRouteSegment| null> {
     const { routeSegments } = this.tables;
     const result = await this.db
       .select()
@@ -304,7 +304,7 @@ export class TraceroutesRepository extends BaseRepository {
    *
    * Uses .returning() for SQLite/Postgres, count-then-delete for MySQL.
    */
-  async deleteRouteSegmentsForNode(nodeNum: number, sourceId?: string): Promise<number> {
+  async deleteRouteSegmentsForNode(nodeNum: number, sourceId?: SourceScope): Promise<number> {
     const { routeSegments } = this.tables;
     const condition = and(
       or(eq(routeSegments.fromNodeNum, nodeNum), eq(routeSegments.toNodeNum, nodeNum)),
@@ -358,7 +358,7 @@ export class TraceroutesRepository extends BaseRepository {
    * so each source maintains its own record independently — unseating one
    * source's record holder must not touch another source's.
    */
-  async clearRecordHolderBySource(sourceId?: string): Promise<void> {
+  async clearRecordHolderBySource(sourceId?: SourceScope): Promise<void> {
     const { routeSegments } = this.tables;
     await this.db
       .update(routeSegments)
@@ -372,7 +372,7 @@ export class TraceroutesRepository extends BaseRepository {
   /**
    * Delete all traceroutes, optionally scoped to a single source.
    */
-  async deleteAllTraceroutes(sourceId?: string): Promise<number> {
+  async deleteAllTraceroutes(sourceId?: SourceScope): Promise<number> {
     const { traceroutes } = this.tables;
     const countQuery = this.db.select({ count: count() }).from(traceroutes);
     const result = await (sourceId
@@ -391,7 +391,7 @@ export class TraceroutesRepository extends BaseRepository {
    * Delete old route segments that are not record holders, optionally
    * scoped to a single source.
    */
-  async cleanupOldRouteSegments(days: number = 30, sourceId?: string): Promise<number> {
+  async cleanupOldRouteSegments(days: number = 30, sourceId?: SourceScope): Promise<number> {
     const cutoff = this.now() - (days * 24 * 60 * 60 * 1000);
     const { routeSegments } = this.tables;
     const condition = and(
@@ -413,7 +413,7 @@ export class TraceroutesRepository extends BaseRepository {
   /**
    * Delete all route segments, optionally scoped to a single source.
    */
-  async deleteAllRouteSegments(sourceId?: string): Promise<number> {
+  async deleteAllRouteSegments(sourceId?: SourceScope): Promise<number> {
     const { routeSegments } = this.tables;
     const scope = this.withSourceScope(routeSegments, sourceId);
     const result = await this.db
@@ -628,7 +628,7 @@ export class TraceroutesRepository extends BaseRepository {
    * Synchronously get recent traceroutes (all pairs) (SQLite only).
    * When sourceId is provided, restricts the result to that source.
    */
-  getAllTraceroutesRecentSync(limit: number = 100, sourceId?: string): DbTraceroute[] {
+  getAllTraceroutesRecentSync(limit: number = 100, sourceId?: SourceScope): DbTraceroute[] {
     const db = this.getSqliteDb();
     const { traceroutes } = this.tables;
     const rows = db

--- a/src/db/repositories/withSourceScope.perSource.test.ts
+++ b/src/db/repositories/withSourceScope.perSource.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration test for the fail-closed withSourceScope (Task 1.1).
+ *
+ * Seeds nodes across two sources and verifies:
+ *   - getAllNodes(sourceId)   → only that source's rows
+ *   - getAllNodes(ALL_SOURCES) → rows from both sources
+ *   - getAllNodes(undefined)  → throws (fail-closed)
+ *
+ * Also verifies:
+ *   - getNodeCount is scoped vs ALL_SOURCES (regression lock for #15 fix)
+ *
+ * Uses the createTestDb() harness (same pattern as
+ * messages.distinctChannels.perSource.test.ts).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { NodesRepository } from './nodes.js';
+import { ALL_SOURCES } from './base.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+describe('NodesRepository — withSourceScope isolation (Task 1.1)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: NodesRepository;
+
+  const now = Date.now();
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new NodesRepository(drizzleDb, 'sqlite');
+
+    // Seed two nodes — one per source
+    db.prepare(
+      'INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)',
+    ).run(1001, '!000003e9', 'mqtt-1', now, now);
+
+    db.prepare(
+      'INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)',
+    ).run(2002, '!000007d2', 'mqtt-2', now, now);
+  });
+
+  afterEach(() => db.close());
+
+  // -------------------------------------------------------------------------
+  // Isolation
+  // -------------------------------------------------------------------------
+
+  it('getAllNodes(sourceId) returns only that source\'s rows', async () => {
+    const rows1 = await repo.getAllNodes('mqtt-1');
+    expect(rows1.map((r) => String(r.nodeId))).toEqual(['!000003e9']);
+
+    const rows2 = await repo.getAllNodes('mqtt-2');
+    expect(rows2.map((r) => String(r.nodeId))).toEqual(['!000007d2']);
+  });
+
+  it('getAllNodes(ALL_SOURCES) returns rows from all sources', async () => {
+    const rows = await repo.getAllNodes(ALL_SOURCES);
+    const nodeIds = rows.map((r) => String(r.nodeId)).sort();
+    expect(nodeIds).toEqual(['!000003e9', '!000007d2']);
+  });
+
+  // @ts-expect-error -- Tier-2 required param: omitting sourceId must be a compile error
+  it('getAllNodes(undefined) rejects with fail-closed error', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(repo.getAllNodes(undefined as any)).rejects.toThrow(
+      /sourceId is required/,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // getNodeCount regression lock (spec §7.3 — fixing the #15 server.ts leak)
+  // -------------------------------------------------------------------------
+
+  it('getNodeCount per-source is less than getNodeCount(ALL_SOURCES) when both populated', async () => {
+    const countSrc1 = await repo.getNodeCount('mqtt-1');
+    const countSrc2 = await repo.getNodeCount('mqtt-2');
+    const countAll = await repo.getNodeCount(ALL_SOURCES);
+
+    expect(countSrc1).toBe(1);
+    expect(countSrc2).toBe(1);
+    expect(countAll).toBe(2);
+    expect(countAll).toBeGreaterThan(countSrc1);
+    expect(countAll).toBeGreaterThan(countSrc2);
+  });
+
+  it('getNodeCount(undefined) rejects with fail-closed error', async () => {
+    // @ts-expect-error -- Tier-2 required param: must be a compile error
+    await expect(repo.getNodeCount(undefined as any)).rejects.toThrow(
+      /sourceId is required/,
+    );
+  });
+});

--- a/src/db/repositories/withSourceScope.test.ts
+++ b/src/db/repositories/withSourceScope.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the fail-closed withSourceScope mechanism (Task 1.1).
+ *
+ * BaseRepository is abstract and withSourceScope is protected — expose it
+ * through a minimal concrete Probe subclass.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { BaseRepository, ALL_SOURCES } from './base.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+import type { TestDb } from '../../server/test-helpers/testDb.js';
+
+// ---------------------------------------------------------------------------
+// Probe — thin concrete subclass that exposes the protected helper
+// ---------------------------------------------------------------------------
+class Probe extends BaseRepository {
+  runScope(table: any, sid: any) {
+    return this.withSourceScope(table, sid);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('withSourceScope — fail-closed mechanism', () => {
+  let t: TestDb;
+  let probe: Probe;
+
+  beforeEach(() => {
+    t = createTestDb();
+    probe = new Probe(t.db, 'sqlite');
+  });
+
+  afterEach(() => t.close());
+
+  it('throws on undefined', () => {
+    const { nodes } = (probe as any).tables;
+    expect(() => probe.runScope(nodes, undefined)).toThrow(
+      /sourceId is required/,
+    );
+  });
+
+  it('throws on null', () => {
+    const { nodes } = (probe as any).tables;
+    expect(() => probe.runScope(nodes, null)).toThrow(
+      /sourceId is required/,
+    );
+  });
+
+  it('throws on empty string', () => {
+    const { nodes } = (probe as any).tables;
+    expect(() => probe.runScope(nodes, '')).toThrow(
+      /sourceId is required/,
+    );
+  });
+
+  it('returns a defined SQL condition for a concrete sourceId', () => {
+    const { nodes } = (probe as any).tables;
+    const result = probe.runScope(nodes, 'default');
+    expect(result).toBeDefined();
+    expect(result).not.toBeUndefined();
+  });
+
+  it('returns undefined (no WHERE clause) for ALL_SOURCES sentinel', () => {
+    const { nodes } = (probe as any).tables;
+    const result = probe.runScope(nodes, ALL_SOURCES);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6170,7 +6170,7 @@ class MeshtasticManager implements ISourceManager {
         const localNodeInfo = this.getLocalNodeInfo();
         if (localNodeInfo) {
           const localNodeId = `!${localNodeInfo.nodeNum.toString(16).padStart(8, '0')}`;
-          const pendingMessages = await databaseService.messages.getDirectMessages(localNodeId, nodeId, 100) as DbMessage[];
+          const pendingMessages = await databaseService.messages.getDirectMessages(localNodeId, nodeId, 100, 0, this.sourceId) as DbMessage[]; // scoped to this manager's source (leak fix)
           const pendingExchangeRequest = pendingMessages.find((msg: DbMessage) =>
             msg.text === 'Position exchange requested' &&
             msg.fromNodeNum === localNodeInfo.nodeNum &&

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1,4 +1,5 @@
 import databaseService, { type DbMessage } from '../services/database.js';
+import { ALL_SOURCES } from '../db/repositories/index.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import protobufService, { convertIpv4ConfigToStrings } from './protobufService.js';
 import { getProtobufRoot } from './protobufLoader.js';
@@ -14112,7 +14113,8 @@ class MeshtasticManager implements ISourceManager {
       'uptimeSeconds',
       sourceId,
     );
-    const dbNodes = await databaseService.nodes.getAllNodes(sourceId);
+    // intentional cross-source when sourceId omitted: caller wants unified view across all sources
+    const dbNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
     // Without a sourceId the caller wants the unified view, so collapse the
     // per-source rows into one entry per nodeNum. Issue #3135.
     const effective = sourceId ? dbNodes : mergeNodesAcrossSources(dbNodes);

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -39,6 +39,7 @@ import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import type { MqttBrokerManager, MqttBrokerLocalPacket } from './mqttBrokerManager.js';
 import type { Source } from '../db/repositories/sources.js';
 import databaseService from '../services/database.js';
+import { ALL_SOURCES } from '../db/repositories/index.js';
 import { logger } from '../utils/logger.js';
 import { loadAllNodesAsDeviceInfo } from './utils/dbNodeMapper.js';
 import type { DeviceInfo } from './meshtasticManager.js';
@@ -435,8 +436,8 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       }
       const trustedSeeded = this.downlinkFilter.seedTrustedNodes(trustedNums);
 
-      // In-bbox positions from anywhere.
-      const allNodes = await databaseService.nodes.getAllNodes();
+      // intentional cross-source: in-bbox positions are pooled from all sources to seed the downlink filter
+      const allNodes = await databaseService.nodes.getAllNodes(ALL_SOURCES);
       const entries = allNodes
         .filter((n) => typeof n.latitude === 'number' && typeof n.longitude === 'number')
         .map((n) => ({

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -13,6 +13,7 @@
  */
 import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
@@ -294,7 +295,8 @@ router.get('/solar-nodes', async (req: Request, res: Response) => {
         value: Number(r.value),
       }));
 
-    const allNodes = await databaseService.nodes.getAllNodes();
+    // intentional cross-source: node name map for display purposes spans all sources
+    const allNodes = await databaseService.nodes.getAllNodes(ALL_SOURCES);
     const nodeLookup: NodeNameLookup[] = allNodes.map((n: any) => ({
       nodeNum: Number(n.nodeNum),
       longName: n.longName,
@@ -371,7 +373,8 @@ router.get('/solar-forecast', async (req: Request, res: Response) => {
         value: Number(r.value),
       }));
 
-    const allNodes = await databaseService.nodes.getAllNodes();
+    // intentional cross-source: node name map for display purposes spans all sources
+    const allNodes = await databaseService.nodes.getAllNodes(ALL_SOURCES);
     const nodeLookup: NodeNameLookup[] = allNodes.map((n: any) => ({
       nodeNum: Number(n.nodeNum),
       longName: n.longName,

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -24,6 +24,7 @@
 
 import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES, type SourceScope } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { optionalAuth, requireAuth, requirePermission, hasPermission } from '../auth/authMiddleware.js';
 import { transformChannel } from '../utils/channelView.js';
@@ -122,7 +123,8 @@ async function buildMqttSourceChannels(
 router.get('/all', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const allChannelsSourceId = req.query.sourceId as string | undefined;
-    const allChannels = await databaseService.channels.getAllChannels(allChannelsSourceId);
+    // intentional cross-source: omitting sourceId on this route returns channels from all sources
+    const allChannels = await databaseService.channels.getAllChannels(allChannelsSourceId ?? ALL_SOURCES);
     const isAdmin = req.user?.isAdmin === true;
 
     const accessible: typeof allChannels = [];
@@ -183,7 +185,8 @@ router.get('/', optionalAuth(), async (req: Request, res: Response) => {
       }
     }
 
-    const allChannels = await databaseService.channels.getAllChannels(channelsSourceId);
+    // intentional cross-source: omitting sourceId on this route returns channels from all sources
+    const allChannels = await databaseService.channels.getAllChannels(channelsSourceId ?? ALL_SOURCES);
 
     // Resolve the source's persisted modem preset (if scoped to one source)
     // so empty-name slot 0 displays as "MediumFast"/"LongFast"/etc. via
@@ -278,7 +281,8 @@ router.get('/', optionalAuth(), async (req: Request, res: Response) => {
 router.get('/collisions', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const sourceId = req.query.sourceId as string | undefined;
-    const allChannels = await databaseService.channels.getAllChannels(sourceId);
+    // intentional cross-source: omitting sourceId on the collisions route returns channels from all sources
+    const allChannels = await databaseService.channels.getAllChannels(sourceId ?? ALL_SOURCES);
     const isAdmin = req.user?.isAdmin === true;
 
     // Per-row permission gate (MM-SEC-2), mirroring GET /. Only consider
@@ -411,20 +415,20 @@ function detectChannelMoves(
  * Snapshot channel slots and migrate messages after a channel configuration change.
  * Call snapshotBefore() before applying changes, then migrateIfNeeded() after.
  */
-async function snapshotChannelsBeforeChange(sourceId?: string) {
-  return (await databaseService.channels.getAllChannels(sourceId)).map(ch => ({ id: ch.id, psk: ch.psk }));
+async function snapshotChannelsBeforeChange(sourceId?: SourceScope) {
+  return (await databaseService.channels.getAllChannels(sourceId ?? ALL_SOURCES)).map(ch => ({ id: ch.id, psk: ch.psk }));
 }
 
 async function migrateMessagesIfChannelsMoved(
   beforeSnapshot: { id: number; psk?: string | null }[],
-  sourceId?: string,
+  sourceId?: SourceScope,
 ) {
   try {
-    const afterSnapshot = (await databaseService.channels.getAllChannels(sourceId)).map(ch => ({ id: ch.id, psk: ch.psk }));
+    const afterSnapshot = (await databaseService.channels.getAllChannels(sourceId ?? ALL_SOURCES)).map(ch => ({ id: ch.id, psk: ch.psk }));
     const moves = detectChannelMoves(beforeSnapshot, afterSnapshot);
     if (moves.length > 0) {
       logger.info(`📦 Detected channel move(s): ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
-      await databaseService.messages.migrateMessagesForChannelMoves(moves, sourceId);
+      await databaseService.messages.migrateMessagesForChannelMoves(moves, typeof sourceId === 'string' ? sourceId : undefined);
       await migrateAutomationChannels(
         moves,
         (key) => databaseService.settings.getSetting(key),
@@ -1264,7 +1268,7 @@ router.post('/refresh', requirePermission('messages', 'write'), async (req: Requ
     await chanRefreshManager.refreshNodeDatabase();
 
     const channelCount = await databaseService.channels.getChannelCount(
-      typeof chanRefreshSourceId === 'string' && chanRefreshSourceId.length > 0 ? chanRefreshSourceId : undefined,
+      typeof chanRefreshSourceId === 'string' && chanRefreshSourceId.length > 0 ? chanRefreshSourceId : ALL_SOURCES,
     );
 
     logger.debug(`✅ Channel refresh complete: ${channelCount} channels`);

--- a/src/server/routes/dataExchangeRoutes.ts
+++ b/src/server/routes/dataExchangeRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { requirePermission, requireAdmin } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 
 const router: Router = Router();
@@ -8,9 +9,10 @@ const router: Router = Router();
 router.get('/stats', requirePermission('dashboard', 'read'), async (req: Request, res: Response) => {
   try {
     const statsSourceId = req.query.sourceId as string | undefined;
-    const messageCount = await databaseService.messages.getMessageCount(statsSourceId);
-    const nodeCount = await databaseService.nodes.getNodeCount(statsSourceId);
-    const channelCount = await databaseService.channels.getChannelCount(statsSourceId);
+    // intentional cross-source: stats totals span all sources when no sourceId is specified
+    const messageCount = await databaseService.messages.getMessageCount(statsSourceId ?? ALL_SOURCES);
+    const nodeCount = await databaseService.nodes.getNodeCount(statsSourceId ?? ALL_SOURCES);
+    const channelCount = await databaseService.channels.getChannelCount(statsSourceId ?? ALL_SOURCES);
     const messagesByDay = await databaseService.getMessagesByDayAsync(7, statsSourceId);
 
     res.json({

--- a/src/server/routes/embedPublicRoutes.ts
+++ b/src/server/routes/embedPublicRoutes.ts
@@ -12,6 +12,7 @@
 import { Router, Request, Response } from 'express';
 import { createEmbedCspMiddleware } from '../middleware/embedMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
 import geojsonService from '../services/geojsonService.js';
@@ -75,7 +76,7 @@ router.get('/:profileId/nodes', createEmbedCspMiddleware(), async (req: Request,
   }
 
   try {
-    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? undefined);
+    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? ALL_SOURCES); // intentional cross-source: profile without a sourceId spans all sources
 
     // Filter by the profile's configured channels
     const profileChannels = new Set(profile.channels as number[]);
@@ -141,7 +142,7 @@ router.get('/:profileId/neighborinfo', createEmbedCspMiddleware(), async (req: R
   }
 
   try {
-    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? undefined);
+    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? ALL_SOURCES); // intentional cross-source: profile without a sourceId spans all sources
     const profileChannels = new Set(profile.channels as number[]);
 
     // Build a lookup of nodes that pass the embed's filters. Use effective
@@ -206,7 +207,7 @@ router.get('/:profileId/traceroutes', createEmbedCspMiddleware(), async (req: Re
   }
 
   try {
-    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? undefined);
+    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? ALL_SOURCES); // intentional cross-source: profile without a sourceId spans all sources
     const profileChannels = new Set(profile.channels as number[]);
 
     // Build position lookup for visible nodes. Use effective position so a
@@ -229,7 +230,7 @@ router.get('/:profileId/traceroutes', createEmbedCspMiddleware(), async (req: Re
     }
 
     // Get recent traceroutes and decompose into point-to-point segments
-    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, profile.sourceId ?? undefined);
+    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, profile.sourceId ?? ALL_SOURCES); // intentional cross-source: profile without a sourceId spans all sources
     // Traceroute timestamps can be in ms or seconds — normalize to ms
     const cutoffMs = Date.now() - (24 * 60 * 60 * 1000); // last 24h
 

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import meshtasticManagerDefault from '../meshtasticManager.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
@@ -771,8 +772,10 @@ router.post('/nodes/:nodeNum/purge-from-device', requireMessagesWrite, async (re
       });
     }
 
-    // Get node name for logging (async for multi-database support)
-    const nodes = await databaseService.nodes.getAllNodes();
+    // Get node name for logging (async for multi-database support).
+    // Use purgeSourceId if available; fall back to ALL_SOURCES for the name lookup (log-only, low stakes).
+    const nameScope = (typeof purgeSourceId === 'string' && purgeSourceId.length > 0) ? purgeSourceId : ALL_SOURCES;
+    const nodes = await databaseService.nodes.getAllNodes(nameScope);
     const node = nodes.find((n: any) => Number(n.nodeNum) === nodeNum);
     const nodeName = node?.shortName || node?.longName || `Node ${nodeNum}`;
 

--- a/src/server/routes/purgeRoutes.ts
+++ b/src/server/routes/purgeRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { requireAdmin } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 
@@ -11,7 +12,8 @@ router.use(requireAdmin());
 router.post('/nodes', async (req: Request, res: Response) => {
   try {
     const { sourceId: purgeNodesSourceId } = req.body || {};
-    const nodeCount = await databaseService.nodes.getNodeCount();
+    // intentional cross-source: purge stats reflect global total before wipe
+    const nodeCount = await databaseService.nodes.getNodeCount(ALL_SOURCES);
     await databaseService.purgeAllNodesAsync(purgeNodesSourceId);
     const purgeNodesManager = resolveSourceManager(purgeNodesSourceId);
     await purgeNodesManager.refreshNodeDatabase();
@@ -63,8 +65,9 @@ router.post('/telemetry', async (req: Request, res: Response) => {
 
 router.post('/messages', async (req: Request, res: Response) => {
   try {
-    const messageCount = await databaseService.messages.getMessageCount();
-    await databaseService.messages.deleteAllMessages();
+    // intentional cross-source: message purge is a global operation across all sources
+    const messageCount = await databaseService.messages.getMessageCount(ALL_SOURCES);
+    await databaseService.messages.deleteAllMessages(ALL_SOURCES);
 
     void databaseService.auditLogAsync(
       req.user!.id,

--- a/src/server/routes/routeSegmentRoutes.ts
+++ b/src/server/routes/routeSegmentRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { requirePermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 
 const router = Router();
@@ -8,7 +9,7 @@ const router = Router();
 router.get('/longest-active', requirePermission('info', 'read'), async (req: Request, res: Response) => {
   try {
     const segSourceId = req.query.sourceId as string | undefined;
-    const segment = await databaseService.traceroutes.getLongestActiveRouteSegment(segSourceId);
+    const segment = await databaseService.traceroutes.getLongestActiveRouteSegment(segSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
     if (!segment) {
       res.json(null);
       return;
@@ -31,7 +32,7 @@ router.get('/longest-active', requirePermission('info', 'read'), async (req: Req
 router.get('/record-holder', requirePermission('info', 'read'), async (req: Request, res: Response) => {
   try {
     const segSourceId = req.query.sourceId as string | undefined;
-    const segment = await databaseService.traceroutes.getRecordHolderRouteSegment(segSourceId);
+    const segment = await databaseService.traceroutes.getRecordHolderRouteSegment(segSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
     if (!segment) {
       res.json(null);
       return;

--- a/src/server/routes/systemRoutes.ts
+++ b/src/server/routes/systemRoutes.ts
@@ -17,6 +17,7 @@ import { createRequire } from 'module';
 import { Router, Request, Response } from 'express';
 import { optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { getEnvironmentConfig } from '../config/environment.js';
 import { upgradeService } from '../services/upgradeService.js';
@@ -111,9 +112,10 @@ router.get('/status', optionalAuth(), async (_req: Request, res: Response) => {
         : null,
     },
     statistics: {
-      nodes: await databaseService.nodes.getNodeCount(),
-      messages: await databaseService.messages.getMessageCount(),
-      channels: await databaseService.channels.getChannelCount(),
+      // intentional cross-source: system stats report global totals
+      nodes: await databaseService.nodes.getNodeCount(ALL_SOURCES),
+      messages: await databaseService.messages.getMessageCount(ALL_SOURCES),
+      channels: await databaseService.channels.getChannelCount(ALL_SOURCES),
     },
     uptime: process.uptime(),
   });

--- a/src/server/routes/telemetryRoutes.ts
+++ b/src/server/routes/telemetryRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { optionalAuth, requireAuth, requirePermission, hasPermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { isValidNodeNum } from '../constants/meshtastic.js';
 import {
@@ -268,7 +269,8 @@ router.delete('/telemetry/:nodeId/:telemetryType', requireAuth(), requirePermiss
 router.get('/telemetry/available/nodes', requirePermission('info', 'read'), async (req: Request, res: Response) => {
   try {
     const telAvailSourceId = req.query.sourceId as string | undefined;
-    const allNodes = await databaseService.nodes.getAllNodes(telAvailSourceId);
+    // intentional cross-source: omitting sourceId returns nodes from all sources
+    const allNodes = await databaseService.nodes.getAllNodes(telAvailSourceId ?? ALL_SOURCES);
     // Filter nodes based on channel read permissions (source-scoped, #3745)
     const nodes = await filterNodesByChannelPermission(allNodes, (req as any).user, telAvailSourceId);
 

--- a/src/server/routes/telemetryRoutes.ts
+++ b/src/server/routes/telemetryRoutes.ts
@@ -140,7 +140,7 @@ router.get('/telemetry/:nodeId/rates', optionalAuth(), async (req: Request, res:
       // Fetch telemetry for each packet type and calculate rates
       for (const type of packetTypes) {
         const telemetry = await databaseService.telemetry.getTelemetryByNode(
-          nodeId, 5000, cutoffTime, undefined, 0, type, ratesSourceId
+          nodeId, 5000, cutoffTime, undefined, 0, type, ratesSourceId ?? ALL_SOURCES // intentional cross-source when sourceId omitted
         );
 
         // Sort by timestamp ascending for rate calculation

--- a/src/server/routes/tracerouteRoutes.test.ts
+++ b/src/server/routes/tracerouteRoutes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import tracerouteRoutes from './tracerouteRoutes.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 
 vi.mock('../../services/database.js', () => ({
   default: {
@@ -59,7 +60,7 @@ describe('GET /recent', () => {
 
     await request(app).get('/recent?limit=42');
 
-    expect(databaseService.traceroutes.getAllTraceroutes).toHaveBeenCalledWith(42, undefined);
+    expect(databaseService.traceroutes.getAllTraceroutes).toHaveBeenCalledWith(42, ALL_SOURCES);
   });
 
   it('filters traceroutes older than the hours window', async () => {

--- a/src/server/routes/tracerouteRoutes.ts
+++ b/src/server/routes/tracerouteRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { requirePermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 
 const router = Router();
@@ -22,7 +23,7 @@ router.get('/recent', async (req: Request, res: Response) => {
     }
 
     const recentSourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
-    const allTraceroutes = await databaseService.traceroutes.getAllTraceroutes(limit, recentSourceId);
+    const allTraceroutes = await databaseService.traceroutes.getAllTraceroutes(limit, recentSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
 
     const recentTraceroutes = allTraceroutes.filter(tr => tr.timestamp >= cutoffTime);
 
@@ -70,7 +71,7 @@ router.get('/history/:fromNodeNum/:toNodeNum', requirePermission('traceroute', '
       return;
     }
 
-    const traceroutes = await databaseService.traceroutes.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit, historySourceId);
+    const traceroutes = await databaseService.traceroutes.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit, historySourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
 
     const traceroutesWithHops = traceroutes.map(tr => {
       let hopCount = 999;

--- a/src/server/routes/v1/channels.ts
+++ b/src/server/routes/v1/channels.ts
@@ -7,6 +7,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { ResourceType } from '../../../types/permission.js';
 import { transformChannel } from '../../utils/channelView.js';
@@ -33,8 +34,8 @@ router.get('/', async (req: Request, res: Response) => {
     const isAdmin = user?.isAdmin ?? false;
     const sourceIdQ = getScopedSourceId(req);
 
-    // Get all channels (scoped to source if provided)
-    const allChannels = await databaseService.channels.getAllChannels(sourceIdQ);
+    // Get all channels (scoped to source if provided; intentional cross-source when omitted)
+    const allChannels = await databaseService.channels.getAllChannels(sourceIdQ ?? ALL_SOURCES);
 
     // If admin, return all channels with PSKs included (admin can configure them)
     if (isAdmin) {

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -7,6 +7,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
 import { meshcoreManagerRegistry } from '../../meshcoreRegistry.js';
 import { hasPermission } from '../../auth/authMiddleware.js';
@@ -122,7 +123,7 @@ router.get('/', async (req: Request, res: Response) => {
     if (channelNum !== undefined) {
       messages = await databaseService.messages.getMessagesByChannel(channelNum, maxLimit, 0, sourceIdStr);
     } else if (sinceTimestamp) {
-      messages = await databaseService.messages.getMessagesAfterTimestamp(sinceTimestamp, sourceIdStr);
+      messages = await databaseService.messages.getMessagesAfterTimestamp(sinceTimestamp, sourceIdStr ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
       messages = messages.slice(0, maxLimit);
     } else {
       messages = await databaseService.messages.getMessages(maxLimit, 0, sourceIdStr, [PortNum.TRACEROUTE_APP]);

--- a/src/server/routes/v1/network.ts
+++ b/src/server/routes/v1/network.ts
@@ -29,8 +29,8 @@ router.get('/', async (req: Request, res: Response) => {
     const sourceId = getScopedSourceId(req);
     // intentional cross-source: omitting sourceId on this route returns data from all sources
     const allNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
-    const activeNodes = await databaseService.nodes.getActiveNodes(7, sourceId);
-    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, sourceId);
+    const activeNodes = await databaseService.nodes.getActiveNodes(7, sourceId ?? ALL_SOURCES);
+    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, sourceId ?? ALL_SOURCES);
 
     const stats = {
       totalNodes: allNodes.length,
@@ -92,7 +92,7 @@ router.get('/topology', async (req: Request, res: Response) => {
     const sourceId = getScopedSourceId(req);
     // intentional cross-source: omitting sourceId on this route returns data from all sources
     const nodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
-    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(500, sourceId);
+    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(500, sourceId ?? ALL_SOURCES);
 
     const topology = {
       nodes: nodes.map(n => {

--- a/src/server/routes/v1/network.ts
+++ b/src/server/routes/v1/network.ts
@@ -6,6 +6,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { getEffectiveDbNodePosition } from '../../utils/nodeEnhancer.js';
 
@@ -26,7 +27,8 @@ function getScopedSourceId(req: Request): string | undefined {
 router.get('/', async (req: Request, res: Response) => {
   try {
     const sourceId = getScopedSourceId(req);
-    const allNodes = await databaseService.nodes.getAllNodes(sourceId);
+    // intentional cross-source: omitting sourceId on this route returns data from all sources
+    const allNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
     const activeNodes = await databaseService.nodes.getActiveNodes(7, sourceId);
     const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, sourceId);
 
@@ -88,7 +90,8 @@ router.get('/direct-neighbors', async (req: Request, res: Response) => {
 router.get('/topology', async (req: Request, res: Response) => {
   try {
     const sourceId = getScopedSourceId(req);
-    const nodes = await databaseService.nodes.getAllNodes(sourceId);
+    // intentional cross-source: omitting sourceId on this route returns data from all sources
+    const nodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
     const traceroutes = await databaseService.traceroutes.getAllTraceroutes(500, sourceId);
 
     const topology = {

--- a/src/server/routes/v1/nodes.ts
+++ b/src/server/routes/v1/nodes.ts
@@ -7,6 +7,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService, { DbNode } from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { filterNodesByChannelPermission, maskNodeLocationByChannel } from '../../utils/nodeEnhancer.js';
 import { findCopyCandidates, copyNodeInfo } from '../../services/nodeInfoCopyService.js';
@@ -85,9 +86,10 @@ router.get('/', async (req: Request, res: Response) => {
 
     // DB-level sourceId filtering — repo accepts it directly, no more
     // fetch-all-then-filter.
+    // intentional cross-source: omitting sourceId on this route returns nodes from all sources
     const nodes = active
       ? (await databaseService.nodes.getActiveNodes(sinceDays, sourceId)) as unknown as DbNode[]
-      : (await databaseService.nodes.getAllNodes(sourceId)) as unknown as DbNode[];
+      : (await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES)) as unknown as DbNode[];
 
     // Filter nodes based on channel read permissions
     const filteredNodes = await filterNodesByChannelPermission(nodes, user, sourceId);
@@ -140,7 +142,8 @@ router.get('/:nodeId', async (req: Request, res: Response) => {
     // Scope the lookup to the requested source so the same nodeNum seen on
     // two sources resolves independently (migration 029 made nodes PK
     // composite (nodeNum, sourceId)).
-    const sourceNodes = (await databaseService.nodes.getAllNodes(sourceId)) as unknown as DbNode[];
+    // intentional cross-source: omitting sourceId on this route returns nodes from all sources
+    const sourceNodes = (await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES)) as unknown as DbNode[];
     const node = sourceNodes.find(n => n.nodeId === nodeId);
 
     if (!node) {

--- a/src/server/routes/v1/nodes.ts
+++ b/src/server/routes/v1/nodes.ts
@@ -88,7 +88,7 @@ router.get('/', async (req: Request, res: Response) => {
     // fetch-all-then-filter.
     // intentional cross-source: omitting sourceId on this route returns nodes from all sources
     const nodes = active
-      ? (await databaseService.nodes.getActiveNodes(sinceDays, sourceId)) as unknown as DbNode[]
+      ? (await databaseService.nodes.getActiveNodes(sinceDays, sourceId ?? ALL_SOURCES)) as unknown as DbNode[]
       : (await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES)) as unknown as DbNode[];
 
     // Filter nodes based on channel read permissions

--- a/src/server/routes/v1/positionHistory.ts
+++ b/src/server/routes/v1/positionHistory.ts
@@ -8,6 +8,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { checkNodeChannelAccess } from '../../utils/nodeEnhancer.js';
 
@@ -110,7 +111,7 @@ router.get('/:nodeId/position-history', async (req: Request, res: Response) => {
       nodeId,
       internalLimit,
       sinceTimestamp,
-      sourceIdQ
+      sourceIdQ ?? ALL_SOURCES // scoped when provided; intentional cross-source otherwise
     );
 
     // Group by timestamp to build position objects

--- a/src/server/routes/v1/telemetry.ts
+++ b/src/server/routes/v1/telemetry.ts
@@ -6,6 +6,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { checkNodeChannelAccess, maskTelemetryByChannel } from '../../utils/nodeEnhancer.js';
 
@@ -66,8 +67,8 @@ router.get('/', async (req: Request, res: Response) => {
       telemetry = await maskTelemetryByChannel(telemetry, (req as any).user, sourceIdStr);
     } else {
       // Get all telemetry by getting all nodes and their telemetry — scoped
-      // to the requested source so cross-source rows don't mix.
-      const nodes = await databaseService.nodes.getAllNodes(sourceIdStr);
+      // to the requested source so cross-source rows don't mix (intentional cross-source when sourceId omitted).
+      const nodes = await databaseService.nodes.getAllNodes(sourceIdStr ?? ALL_SOURCES);
       telemetry = [];
       const perNodeLimit = Math.max(1, Math.floor(maxLimit / 10));
       for (const node of nodes.slice(0, 10)) { // Limit to first 10 nodes to avoid huge response

--- a/src/server/routes/v1/telemetry.ts
+++ b/src/server/routes/v1/telemetry.ts
@@ -52,8 +52,8 @@ router.get('/', async (req: Request, res: Response) => {
       }
 
       const typeStr = type ? type as string : undefined;
-      telemetry = await databaseService.telemetry.getTelemetryByNode(nodeId as string, maxLimit, sinceTimestamp, beforeTimestamp, offsetNum, typeStr);
-      total = await databaseService.telemetry.getTelemetryCountByNode(nodeId as string, sinceTimestamp, beforeTimestamp, typeStr);
+      telemetry = await databaseService.telemetry.getTelemetryByNode(nodeId as string, maxLimit, sinceTimestamp, beforeTimestamp, offsetNum, typeStr, sourceIdStr ?? ALL_SOURCES); // scoped when provided; intentional cross-source otherwise
+      total = await databaseService.telemetry.getTelemetryCountByNode(nodeId as string, sinceTimestamp, beforeTimestamp, typeStr, sourceIdStr ?? ALL_SOURCES);
     } else if (type) {
       telemetry = await databaseService.telemetry.getTelemetryByType(type as string, maxLimit);
       // Filter by since/before if provided
@@ -72,7 +72,7 @@ router.get('/', async (req: Request, res: Response) => {
       telemetry = [];
       const perNodeLimit = Math.max(1, Math.floor(maxLimit / 10));
       for (const node of nodes.slice(0, 10)) { // Limit to first 10 nodes to avoid huge response
-        const nodeTelemetry = await databaseService.telemetry.getTelemetryByNode(node.nodeId, perNodeLimit, sinceTimestamp, beforeTimestamp);
+        const nodeTelemetry = await databaseService.telemetry.getTelemetryByNode(node.nodeId, perNodeLimit, sinceTimestamp, beforeTimestamp, 0, undefined, sourceIdStr ?? ALL_SOURCES);
         telemetry.push(...nodeTelemetry);
       }
       // Mask records from channels the user cannot access
@@ -148,8 +148,8 @@ router.get('/:nodeId', async (req: Request, res: Response) => {
     const beforeTimestamp = before ? parseInt(before as string) : undefined;
 
     const typeStr = type ? type as string : undefined;
-    const telemetry = await databaseService.telemetry.getTelemetryByNode(nodeId, maxLimit, sinceTimestamp, beforeTimestamp, offsetNum, typeStr);
-    const total = await databaseService.telemetry.getTelemetryCountByNode(nodeId, sinceTimestamp, beforeTimestamp, typeStr);
+    const telemetry = await databaseService.telemetry.getTelemetryByNode(nodeId, maxLimit, sinceTimestamp, beforeTimestamp, offsetNum, typeStr, sourceIdParam ?? ALL_SOURCES);
+    const total = await databaseService.telemetry.getTelemetryCountByNode(nodeId, sinceTimestamp, beforeTimestamp, typeStr, sourceIdParam ?? ALL_SOURCES);
 
     res.json({
       success: true,

--- a/src/server/routes/v1/traceroutes.ts
+++ b/src/server/routes/v1/traceroutes.ts
@@ -6,6 +6,7 @@
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { maskTraceroutesByChannel } from '../../utils/nodeEnhancer.js';
 
@@ -34,7 +35,7 @@ router.get('/', async (req: Request, res: Response) => {
     const sourceIdStr = getScopedSourceId(req);
     const maxLimit = parseInt(limit as string) || 100;
 
-    let traceroutes = databaseService.getAllTraceroutes(maxLimit, sourceIdStr);
+    let traceroutes = databaseService.getAllTraceroutes(maxLimit, sourceIdStr ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
 
     // Apply filters
     if (fromNodeId) {
@@ -73,7 +74,7 @@ router.get('/:fromNodeId/:toNodeId', async (req: Request, res: Response) => {
   try {
     const { fromNodeId, toNodeId } = req.params;
     const sourceIdParam = getScopedSourceId(req);
-    const allTraceroutes = databaseService.getAllTraceroutes(100, sourceIdParam);
+    const allTraceroutes = databaseService.getAllTraceroutes(100, sourceIdParam ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
     const traceroute = allTraceroutes.find(t => t.fromNodeId === fromNodeId && t.toNodeId === toNodeId);
 
     if (!traceroute) {

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 
 // Token constants
 const VALID_TEST_TOKEN = 'mm_v1_test_token_12345678901234567890';
@@ -1395,7 +1396,7 @@ describe('GET /api/v1/nodes/:nodeId/position-history', () => {
       '2882400001',
       5000, // 1000 * 5 internal limit
       1500, // since parameter
-      undefined // sourceId (no scope in legacy root call)
+      ALL_SOURCES // sourceId (no scope in legacy root call -> intentional cross-source)
     );
   });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 import databaseService, { DbMessage } from '../services/database.js';
+import { ALL_SOURCES } from '../db/repositories/index.js';
 import { MeshMessage } from '../types/message.js';
 import meshtasticManager from './meshtasticManager.js';
 import { MeshtasticManager } from './meshtasticManager.js';
@@ -3125,7 +3126,8 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
 
     // 5. Channels (filtered based on per-channel read permissions)
     try {
-      const allChannels = await databaseService.channels.getAllChannels(pollSourceId);
+      // intentional cross-source: omitting sourceId on the poll route returns channels from all sources
+      const allChannels = await databaseService.channels.getAllChannels(pollSourceId ?? ALL_SOURCES);
 
       // Filter channels async
       const filteredChannels: typeof allChannels = [];
@@ -3186,7 +3188,8 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
     try {
       if (hasInfoRead) {
         // Use DB nodes for telemetry (has telemetryTypes), filtered by channel permissions
-        const allDbNodes = await databaseService.nodes.getAllNodes(pollSourceId);
+        // intentional cross-source: omitting sourceId on the poll route returns nodes from all sources
+        const allDbNodes = await databaseService.nodes.getAllNodes(pollSourceId ?? ALL_SOURCES);
         const dbNodes = await filterNodesByChannelPermission(allDbNodes, req.user, pollSourceId);
 
         const nodesWithTelemetry: string[] = [];
@@ -3440,9 +3443,11 @@ apiRouter.post('/nodes/refresh', requirePermission('nodes', 'write'), async (req
     // Trigger full node database refresh
     await refreshManager.refreshNodeDatabase();
 
-    const nodeCount = await databaseService.nodes.getNodeCount();
+    const nodeCount = await databaseService.nodes.getNodeCount(
+      typeof refreshSourceId === 'string' && refreshSourceId.length > 0 ? refreshSourceId : ALL_SOURCES,
+    );
     const channelCount = await databaseService.channels.getChannelCount(
-      typeof refreshSourceId === 'string' && refreshSourceId.length > 0 ? refreshSourceId : undefined,
+      typeof refreshSourceId === 'string' && refreshSourceId.length > 0 ? refreshSourceId : ALL_SOURCES,
     );
 
     logger.debug(`✅ Node refresh complete: ${nodeCount} nodes, ${channelCount} channels`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1264,7 +1264,7 @@ apiRouter.get('/nodes/active', optionalAuth(), async (req, res) => {
     const activeNodesSourceId = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
       ? (req.query.sourceId as string)
       : undefined;
-    const allDbNodes = await databaseService.nodes.getActiveNodes(days, activeNodesSourceId);
+    const allDbNodes = await databaseService.nodes.getActiveNodes(days, activeNodesSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
 
     // Filter nodes based on channel read permissions (source-scoped, #3745)
     const dbNodes = await filterNodesByChannelPermission(allDbNodes, (req as any).user, activeNodesSourceId);
@@ -2603,7 +2603,7 @@ apiRouter.get('/messages/direct/:nodeId1/:nodeId2', requirePermission('messages'
       ? req.query.sourceId
       : undefined;
     // Fetch limit+1 to accurately detect if more messages exist
-    const dbMessages = await databaseService.messages.getDirectMessages(nodeId1, nodeId2, limit + 1, offset, sourceIdParam) as DbMessage[];
+    const dbMessages = await databaseService.messages.getDirectMessages(nodeId1, nodeId2, limit + 1, offset, sourceIdParam ?? ALL_SOURCES) as DbMessage[]; // intentional cross-source when sourceId omitted
     const hasMore = dbMessages.length > limit;
     // Return only the requested limit
     const messages = dbMessages.slice(0, limit).map(transformDbMessageToMeshMessage);
@@ -2735,7 +2735,7 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
     // Get channel unread counts if user has channels permission
     // Only count incoming messages (exclude messages sent by our node)
     if (hasChannelsRead) {
-      const rawCounts = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, unreadSourceId, excludeMqtt);
+      const rawCounts = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, unreadSourceId ?? ALL_SOURCES, excludeMqtt); // intentional cross-source when sourceId omitted
 
       // MM-SEC-3: filter by per-channel read permission as well as mute prefs.
       // The bare `channel_0:read` gate above lets a viewer reach this handler
@@ -2758,7 +2758,7 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
 
     // Get DM unread counts if user has messages permission (batch query)
     if (hasMessagesRead && localNodeInfo) {
-      const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId, unreadSourceId);
+      const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId, unreadSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
       const allNodes = await unreadManager.getAllNodesAsync(unreadSourceId);
       const visibleNodes = await filterNodesByChannelPermission(allNodes, req.user, unreadSourceId);
       const visibleNodeIds = new Set(visibleNodes.map(n => n.user?.id).filter(Boolean));
@@ -3091,7 +3091,7 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       // Scope to the requesting source so per-source tabs only count messages
       // their own source ingested (issue: badge stays lit for messages that
       // aren't visible in the current tab).
-      const allUnreadChannels = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, pollSourceId);
+      const allUnreadChannels = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, pollSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
 
       // Filter channels based on per-channel read permission
       const filteredUnreadChannels: { [channelId: number]: number } = {};
@@ -3108,7 +3108,7 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
 
       // Batch DM unread counts (single query instead of N+1)
       if (hasMessagesRead && localNodeInfo) {
-        const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId, pollSourceId);
+        const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId, pollSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
         const visibleNodeIds = new Set(filteredMemoryNodes.map(n => n.user?.id).filter(Boolean));
         const directMessages: { [nodeId: string]: number } = {};
         for (const [nodeId, count] of Object.entries(allUnreadDMs)) {
@@ -3337,7 +3337,7 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       let limit = Math.ceil(traceroutesPerHour * maxNodeAgeHours * 1.1);
       limit = Math.max(limit, 100);
 
-      const allTraceroutes = await databaseService.traceroutes.getAllTraceroutes(limit, pollSourceId);
+      const allTraceroutes = await databaseService.traceroutes.getAllTraceroutes(limit, pollSourceId ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
       const recentTraceroutes = allTraceroutes.filter(tr => tr.timestamp >= cutoffTime);
 
       // Add hopCount for each traceroute

--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { calculateDistance } from '../../utils/distance.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
@@ -78,8 +79,8 @@ class AutoDeleteByDistanceService {
       const localNodeNum = localNodeNumStr ? Number(localNodeNumStr) : null;
 
       // Get all nodes (must use async for PostgreSQL/MySQL)
-      // If sourceId provided, scope to that source; otherwise scan all sources
-      const allNodes = await databaseService.nodes.getAllNodes(sourceId);
+      // intentional cross-source: when sourceId is omitted, scan all sources
+      const allNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
 
       // Throttle device syncs so firmware admin queue doesn't back up on
       // large MQTT meshes with hundreds of nodes to ignore per cycle.

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -4,6 +4,7 @@
  * returns null and the condition resolves to false rather than throwing.
  */
 import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import type { NodeDataProvider, NodeFacts } from './engineContext.js';
 import { sourceProtocol } from './channelUnify.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
@@ -44,7 +45,8 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
 
     async getChannels(sourceId) {
       try {
-        const chans = await databaseService.channels.getAllChannels(sourceId ?? undefined);
+        // intentional cross-source: omitting sourceId returns channels from all sources
+        const chans = await databaseService.channels.getAllChannels(sourceId ?? ALL_SOURCES);
         return chans.map((c) => ({ id: c.id, name: c.name, psk: c.psk ?? null, role: c.role ?? null }));
       } catch {
         return [];

--- a/src/server/services/deviceBackupService.ts
+++ b/src/server/services/deviceBackupService.ts
@@ -4,6 +4,7 @@
  */
 
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
 
@@ -214,7 +215,8 @@ class DeviceBackupService {
       const localNodeInfo = meshtasticManager.getLocalNodeInfo();
       const deviceConfig = meshtasticManager.getActualDeviceConfig();
       const moduleConfig = meshtasticManager.getActualModuleConfig();
-      const channels = await databaseService.channels.getAllChannels();
+      // intentional cross-source: device backup exports all channels across all sources
+      const channels = await databaseService.channels.getAllChannels(ALL_SOURCES);
 
       // Build backup object in the same structure as Meshtastic CLI
       // Field order matters for official format compatibility

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -15,6 +15,7 @@ import { logger } from '../../utils/logger.js';
 import { getEnvironmentConfig } from '../config/environment.js';
 import type { DbMessage } from '../../services/database.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { canonicalMessageTime, messageReceivedAt } from '../utils/messageTime.js';
 import { automationTraceBus, MAX_TRACE_MS } from './automation/automationTraceBus.js';
 
@@ -201,7 +202,8 @@ export function initializeWebSocket(
             msgSourceId !== joinedSourceId &&
             outgoing.channel !== -1
           ) {
-            const allChannels = await databaseService.channels.getAllChannels();
+            // intentional cross-source: channel map covers all sources to find equivalent slots on the joined source
+            const allChannels = await databaseService.channels.getAllChannels(ALL_SOURCES);
             const myChannels = allChannels.filter(
               (c: any) => c.sourceId === joinedSourceId
             );

--- a/src/server/test-helpers/testDb.test.ts
+++ b/src/server/test-helpers/testDb.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { createTestDb, type TestDb } from './testDb.js';
 import { TelemetryRepository } from '../../db/repositories/telemetry.js';
+import { ALL_SOURCES } from '../../db/repositories/base.js';
 
 describe('createTestDb', () => {
   let t: TestDb | null = null;
@@ -36,7 +37,7 @@ describe('createTestDb', () => {
       nodeId: '!aabbccdd', nodeNum: 0xaabbccdd, telemetryType: 'battery',
       timestamp: Date.now(), value: 88, createdAt: Date.now(),
     });
-    const rows = await repo.getTelemetryByNode('!aabbccdd', 10);
+    const rows = await repo.getTelemetryByNode('!aabbccdd', 10, undefined, undefined, 0, undefined, ALL_SOURCES);
     expect(rows).toHaveLength(1);
     expect(rows[0].value).toBe(88);
   });

--- a/src/server/utils/dbNodeMapper.ts
+++ b/src/server/utils/dbNodeMapper.ts
@@ -13,6 +13,7 @@
  */
 
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { mergeNodesAcrossSources } from './mergeNodesAcrossSources.js';
 import type { DeviceInfo } from '../meshtasticManager.js';
 import { logger } from '../../utils/logger.js';
@@ -138,7 +139,8 @@ export async function loadAllNodesAsDeviceInfo(sourceId?: string): Promise<Devic
     'uptimeSeconds',
     sourceId,
   );
-  const dbNodes = await databaseService.nodes.getAllNodes(sourceId);
+  // intentional cross-source when sourceId omitted: caller wants unified view across all sources
+  const dbNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
   const effective = sourceId ? dbNodes : mergeNodesAcrossSources(dbNodes);
   return effective.map(node => mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId)));
 }

--- a/src/services/database.service.test.ts
+++ b/src/services/database.service.test.ts
@@ -177,6 +177,7 @@ const mockEmbedProfileRepo = vi.hoisted(() => ({
 
 // Use classes (not mockReturnValue) since they're called with `new`
 vi.mock('../db/repositories/index.js', () => ({
+  ALL_SOURCES: Symbol('ALL_SOURCES'),
   SettingsRepository: class { getSetting = mockSettingsRepo.getSetting; setSetting = mockSettingsRepo.setSetting; deleteSetting = mockSettingsRepo.deleteSetting; getAllSettings = mockSettingsRepo.getAllSettings; getSettingSync = mockSettingsRepo.getSettingSync; setSettingSync = mockSettingsRepo.setSettingSync; setSettingsSync = mockSettingsRepo.setSettingsSync; getAllSettingsSync = mockSettingsRepo.getAllSettingsSync; deleteAllSettingsSync = mockSettingsRepo.deleteAllSettingsSync; },
   ChannelsRepository: class { getChannels = mockChannelsRepo.getChannels; getChannelById = mockChannelsRepo.getChannelById; upsertChannel = mockChannelsRepo.upsertChannel; },
   NodesRepository: class { getAllNodes = mockNodesRepo.getAllNodes; getNodeByNum = mockNodesRepo.getNodeByNum; upsertNode = mockNodesRepo.upsertNode; deleteNode = mockNodesRepo.deleteNode; getNodesWithKeySecurityIssues = mockNodesRepo.getNodesWithKeySecurityIssues; },

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -44,8 +44,9 @@ import {
   AutomationsRepository,
   AutomationVariablesRepository,
   SavedRegionsRepository,
+  ALL_SOURCES,
 } from '../db/repositories/index.js';
-import type { EstimatedPosition, EstimatedPositionInput } from '../db/repositories/index.js';
+import type { EstimatedPosition, EstimatedPositionInput, SourceScope } from '../db/repositories/index.js';
 import type { DatabaseType, DbPacketLog as DbTypesPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../db/types.js';
 
 // Configuration constants for traceroute history
@@ -394,9 +395,10 @@ class DatabaseService {
   /**
    * Phase 3B: Iterate cache, optionally filtered by sourceId.
    */
-  private *iterateCache(sourceId?: string): IterableIterator<DbNode> {
+  private *iterateCache(sourceId?: SourceScope): IterableIterator<DbNode> {
     for (const node of this.nodesCache.values()) {
-      if (sourceId && node.sourceId !== sourceId) continue;
+      // ALL_SOURCES or undefined → yield all; concrete string → filter by source.
+      if (typeof sourceId === 'string' && sourceId !== '' && node.sourceId !== sourceId) continue;
       yield node;
     }
   }
@@ -959,7 +961,8 @@ class DatabaseService {
 
       // Load all nodes into cache
       if (this.nodesRepo) {
-        const nodes = await this.nodesRepo.getAllNodes();
+        // intentional cross-source: init cache warm-up loads all sources at once
+        const nodes = await this.nodesRepo.getAllNodes(ALL_SOURCES);
         this.nodesCache.clear();
         for (const node of nodes) {
           // Convert from repo DbNode to local DbNode (null -> undefined conversion is safe)
@@ -1029,7 +1032,8 @@ class DatabaseService {
 
       // Load all channels into cache
       if (this.channelsRepo) {
-        const channels = await this.channelsRepo.getAllChannels();
+        // intentional cross-source: init cache warm-up loads all sources at once
+        const channels = await this.channelsRepo.getAllChannels(ALL_SOURCES);
         this.channelsCache.clear();
         for (const channel of channels) {
           this.channelsCache.set(channel.id, channel);
@@ -1039,14 +1043,16 @@ class DatabaseService {
 
       // Load recent messages into cache for delivery state updates
       if (this.messagesRepo) {
-        const messages = await this.messagesRepo.getMessages(500);
+        // intentional cross-source: init cache warm-up loads all sources at once
+        const messages = await this.messagesRepo.getMessages(500, 0, ALL_SOURCES);
         this._messagesCache = messages.map(m => this.convertRepoMessage(m));
         logger.info(`[DatabaseService] Loaded ${this._messagesCache.length} messages into cache`);
       }
 
       // Load neighbor info into cache
       if (this.neighborsRepo) {
-        const neighbors = await this.neighborsRepo.getAllNeighborInfo();
+        // intentional cross-source: init cache warm-up loads all sources at once
+        const neighbors = await this.neighborsRepo.getAllNeighborInfo(ALL_SOURCES);
         this._neighborsCache = neighbors.map(n => this.convertRepoNeighborInfo(n));
         logger.info(`[DatabaseService] Loaded ${this._neighborsCache.length} neighbor records into cache`);
       }
@@ -2459,7 +2465,7 @@ class DatabaseService {
     return this.nodesRepo!.getNodeSqlite(nodeNum, sourceId) as unknown as DbNode | null;
   }
 
-  getAllNodes(sourceId?: string): DbNode[] {
+  getAllNodes(sourceId?: SourceScope): DbNode[] {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (!this.cacheInitialized) {
@@ -2476,7 +2482,7 @@ class DatabaseService {
    * @deprecated Use databaseService.nodes.getAllNodes() directly. Kept for internal/test compatibility.
    */
   async getAllNodesAsync(): Promise<DbNode[]> {
-    return this.nodes.getAllNodes() as unknown as DbNode[];
+    return this.nodes.getAllNodes(ALL_SOURCES) as unknown as DbNode[]; // intentional cross-source: deprecated compat shim returns all sources
   }
 
   getActiveNodes(sinceDays: number = 7): DbNode[] {
@@ -3090,12 +3096,12 @@ class DatabaseService {
     };
   }
 
-  getMessages(limit: number = 100, offset: number = 0): DbMessage[] {
+  getMessages(limit: number = 100, offset: number = 0, sourceId?: SourceScope): DbMessage[] {
     // For PostgreSQL/MySQL, use async repo and cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.messagesRepo) {
         // Fire async query and update cache in background
-        this.messagesRepo.getMessages(limit, offset).then(messages => {
+        this.messagesRepo.getMessages(limit, offset, sourceId).then(messages => {
           // Build a map of current delivery states to preserve local updates
           // (async DB update may not have completed yet)
           const currentDeliveryStates = new Map<number, { deliveryState: string; ackFailed: boolean }>();
@@ -3127,7 +3133,7 @@ class DatabaseService {
     }
     // SQLite: delegate to Drizzle sync variant
     if (this.messagesRepo) {
-      const rows = this.messagesRepo.getMessagesSqlite(limit, offset);
+      const rows = this.messagesRepo.getMessagesSqlite(limit, offset, sourceId);
       return rows.map(msg => this.convertRepoMessage(msg as any));
     }
     return [];
@@ -3728,8 +3734,8 @@ class DatabaseService {
   // Export/Import functionality
   exportData(): { nodes: DbNode[]; messages: DbMessage[] } {
     return {
-      nodes: this.getAllNodes(),
-      messages: this.getMessages(10000) // Export last 10k messages
+      nodes: this.getAllNodes(ALL_SOURCES), // intentional cross-source: full backup export spans all sources
+      messages: this.getMessages(10000, 0, ALL_SOURCES) // Export last 10k messages across all sources
     };
   }
 
@@ -7124,7 +7130,8 @@ class DatabaseService {
   getAllNeighborInfo(): DbNeighborInfo[] {
     // All backends: fire async repo refresh, return cached data immediately
     if (this.neighborsRepo) {
-      this.neighborsRepo.getAllNeighborInfo().then(neighbors => {
+      // intentional cross-source: neighbor cache is global across all sources
+      this.neighborsRepo.getAllNeighborInfo(ALL_SOURCES).then(neighbors => {
         this._neighborsCache = neighbors.map(n => this.convertRepoNeighborInfo(n));
       }).catch(err => logger.debug('Failed to get all neighbor info:', err));
     }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3051,7 +3051,7 @@ class DatabaseService {
     // For PostgreSQL/MySQL, use async repo
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.messagesRepo) {
-        const messages = await this.messagesRepo.getMessages(limit, offset);
+        const messages = await this.messagesRepo.getMessages(limit, offset, ALL_SOURCES); // intentional cross-source: legacy facade has no sourceId
         return messages.map(msg => this.convertRepoMessage(msg));
       }
       return [];
@@ -3144,7 +3144,8 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.messagesRepo) {
         // Fire async query and update cache in background
-        this.messagesRepo.getMessagesByChannel(channel, limit, offset).then(messages => {
+        // (intentional cross-source: legacy facade has no sourceId)
+        this.messagesRepo.getMessagesByChannel(channel, limit, offset, ALL_SOURCES).then(messages => {
           // Build a map of current delivery states to preserve local updates
           const currentCache = this._messagesCacheChannel.get(channel) || [];
           const currentDeliveryStates = new Map<number, { deliveryState: string; ackFailed: boolean }>();
@@ -3271,7 +3272,7 @@ class DatabaseService {
     beforeTimestamp?: number,
     telemetryType?: string
   ): Promise<number> {
-    return this.telemetry.getTelemetryCountByNode(nodeId, sinceTimestamp, beforeTimestamp, telemetryType);
+    return this.telemetry.getTelemetryCountByNode(nodeId, sinceTimestamp, beforeTimestamp, telemetryType, ALL_SOURCES); // intentional cross-source: deprecated shim has no sourceId
   }
 
   /**
@@ -3345,7 +3346,7 @@ class DatabaseService {
       // Using a larger limit ensures we capture movement over a longer time period
       // (50 was too small - nodes parked for a while would show only recent stationary positions)
       const positionTelemetry = this.telemetryRepo
-        ? await this.telemetryRepo.getPositionTelemetryByNode(nodeId, 500)
+        ? await this.telemetryRepo.getPositionTelemetryByNode(nodeId, 500, undefined, ALL_SOURCES) // intentional cross-source: mobility check pools all sources' positions
         : this.getPositionTelemetryByNode(nodeId, 500);
 
       const latitudes = positionTelemetry.filter(t => t.telemetryType === 'latitude');
@@ -3514,7 +3515,7 @@ class DatabaseService {
     // For PostgreSQL/MySQL, fire-and-forget async delete
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.traceroutesRepo) {
-        this.traceroutesRepo.deleteTraceroutesForNode(nodeNum).catch(err => {
+        this.traceroutesRepo.deleteTraceroutesForNode(nodeNum, ALL_SOURCES).catch(err => { // intentional cross-source: legacy facade has no sourceId
           logger.debug('Failed to purge node traceroutes:', err);
         });
       }
@@ -3529,7 +3530,7 @@ class DatabaseService {
     // For PostgreSQL/MySQL, fire-and-forget async delete
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.telemetryRepo) {
-        this.telemetryRepo.deleteTelemetryByNode(nodeNum).catch(err => {
+        this.telemetryRepo.deleteTelemetryByNode(nodeNum, ALL_SOURCES).catch(err => { // intentional cross-source: legacy facade has no sourceId
           logger.debug('Failed to purge node telemetry:', err);
         });
       }
@@ -3590,9 +3591,10 @@ class DatabaseService {
     // Delete route segments where this node is involved
     this.traceroutes.deleteRouteSegmentsInvolvingNodeSync(nodeNum);
 
-    // Delete neighbor_info records where this node is involved (either as source or neighbor)
+    // Delete neighbor_info records where this node is involved (either as source or neighbor).
+    // Scoped to this source (leak fix): matches deleteNodeAsync, which already passes sourceId.
     if (this.neighborsRepo) {
-      this.neighborsRepo.deleteNeighborInfoInvolvingNode(nodeNum).catch(err =>
+      this.neighborsRepo.deleteNeighborInfoInvolvingNode(nodeNum, sourceId).catch(err =>
         logger.debug('Failed to delete neighbor info involving node:', err)
       );
     }
@@ -3922,7 +3924,7 @@ class DatabaseService {
     telemetryType?: string
   ): Promise<DbTelemetry[]> {
     // Cast to local DbTelemetry type (they have compatible structure)
-    return this.telemetry.getTelemetryByNode(nodeId, limit, sinceTimestamp, beforeTimestamp, offset, telemetryType) as unknown as DbTelemetry[];
+    return this.telemetry.getTelemetryByNode(nodeId, limit, sinceTimestamp, beforeTimestamp, offset, telemetryType, ALL_SOURCES) as unknown as DbTelemetry[]; // intentional cross-source: deprecated shim has no sourceId
   }
 
   /**
@@ -3965,7 +3967,7 @@ class DatabaseService {
   /** @deprecated Use databaseService.telemetry.getPositionTelemetryByNode() instead */
   async getPositionTelemetryByNodeAsync(nodeId: string, limit: number = 1500, sinceTimestamp?: number, beforeTimestamp?: number): Promise<DbTelemetry[]> {
     // Cast to local DbTelemetry type (they have compatible structure)
-    return this.telemetry.getPositionTelemetryByNode(nodeId, limit, sinceTimestamp, undefined, beforeTimestamp) as unknown as Promise<DbTelemetry[]>;
+    return this.telemetry.getPositionTelemetryByNode(nodeId, limit, sinceTimestamp, ALL_SOURCES, beforeTimestamp) as unknown as Promise<DbTelemetry[]>; // intentional cross-source: deprecated shim has no sourceId
   }
 
   /**
@@ -4463,7 +4465,7 @@ class DatabaseService {
       if (this.traceroutesRepo) {
         // Fire async query and update cache in background
         const cacheKey = `${fromNodeNum}_${toNodeNum}`;
-        this.traceroutesRepo.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit).then(traceroutes => {
+        this.traceroutesRepo.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit, ALL_SOURCES).then(traceroutes => { // intentional cross-source: legacy facade has no sourceId
           this._traceroutesByNodesCache.set(cacheKey, traceroutes.map(t => ({
             ...t,
             route: t.route || '',
@@ -4482,7 +4484,7 @@ class DatabaseService {
     return this.traceroutes.getTraceroutesByNodesSync(fromNodeNum, toNodeNum, limit) as unknown as DbTraceroute[];
   }
 
-  getAllTraceroutes(limit: number = 100, sourceId?: string): DbTraceroute[] {
+  getAllTraceroutes(limit: number = 100, sourceId?: SourceScope): DbTraceroute[] {
     // For PostgreSQL/MySQL, use cached traceroutes or return empty
     // Traceroute data is primarily real-time from mesh traffic
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
@@ -6293,7 +6295,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.telemetryRepo) {
         // Fire async query and update cache in background
-        this.telemetryRepo.getAllNodesTelemetryTypes(sourceId).then(map => {
+        this.telemetryRepo.getAllNodesTelemetryTypes(sourceId ?? ALL_SOURCES).then(map => { // undefined = global cache key — intentional cross-source
           this.telemetryTypesCacheBySource.set(cacheKey, { map, time: Date.now() });
         }).catch(err => logger.debug('Failed to fetch telemetry types:', err));
       }
@@ -6320,7 +6322,7 @@ class DatabaseService {
 
     // For PostgreSQL/MySQL, use async repository
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const map = await this.telemetry.getAllNodesTelemetryTypes(sourceId);
+      const map = await this.telemetry.getAllNodesTelemetryTypes(sourceId ?? ALL_SOURCES); // undefined = global cache key — intentional cross-source
       this.telemetryTypesCacheBySource.set(cacheKey, { map, time: Date.now() });
       return map;
     }
@@ -6824,7 +6826,8 @@ class DatabaseService {
       }
       if (this.traceroutesRepo) {
         await this.traceroutesRepo.deleteAllTraceroutes(sourceId);
-        await this.traceroutesRepo.deleteAllRouteSegments(sourceId);
+        // undefined sourceId = admin global purge across every source — intentional cross-source
+        await this.traceroutesRepo.deleteAllRouteSegments(sourceId ?? ALL_SOURCES);
       }
       if (this.neighborsRepo) {
         await this.neighborsRepo.deleteAllNeighborInfo(sourceId);
@@ -7090,7 +7093,7 @@ class DatabaseService {
       this._neighborsByNodeCache.delete(nodeNum);
 
       if (this.neighborsRepo) {
-        this.neighborsRepo.deleteNeighborInfoForNode(nodeNum).catch(err =>
+        this.neighborsRepo.deleteNeighborInfoForNode(nodeNum, ALL_SOURCES).catch(err => // intentional cross-source: legacy facade has no sourceId
           logger.debug('Failed to clear neighbor info:', err)
         );
       }
@@ -7099,7 +7102,7 @@ class DatabaseService {
 
     // SQLite: use repo
     if (this.neighborsRepo) {
-      this.neighborsRepo.deleteNeighborInfoForNode(nodeNum).catch(err =>
+      this.neighborsRepo.deleteNeighborInfoForNode(nodeNum, ALL_SOURCES).catch(err => // intentional cross-source: legacy facade has no sourceId
         logger.debug('Failed to clear neighbor info for node:', err)
       );
     }
@@ -7120,7 +7123,7 @@ class DatabaseService {
   getNeighborsForNode(nodeNum: number): DbNeighborInfo[] {
     // All backends: fire async repo refresh, return cached data immediately
     if (this.neighborsRepo) {
-      this.neighborsRepo.getNeighborsForNode(nodeNum).then(neighbors => {
+      this.neighborsRepo.getNeighborsForNode(nodeNum, ALL_SOURCES).then(neighbors => { // intentional cross-source: legacy facade has no sourceId
         this._neighborsByNodeCache.set(nodeNum, neighbors.map(n => this.convertRepoNeighborInfo(n)));
       }).catch(err => logger.debug('Failed to get neighbors for node:', err));
     }
@@ -8211,10 +8214,12 @@ class DatabaseService {
    * Async version of getUnreadCountsByChannel for PostgreSQL/MySQL.
    * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
-  async getUnreadCountsByChannelAsync(userId: number | null, localNodeId?: string, sourceId?: string, excludeMqtt?: boolean): Promise<{[channelId: number]: number}> {
-    // For SQLite, use sync version (legacy compatibility)
+  async getUnreadCountsByChannelAsync(userId: number | null, localNodeId?: string, sourceId?: SourceScope, excludeMqtt?: boolean): Promise<{[channelId: number]: number}> {
+    // For SQLite, use sync version (legacy compatibility).
+    // The raw-SQL sync twin binds sourceId as a parameter, so the ALL_SOURCES
+    // symbol must be normalized to undefined (its legacy "all sources" spelling).
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
-      return this.getUnreadCountsByChannel(userId, localNodeId, sourceId, excludeMqtt);
+      return this.getUnreadCountsByChannel(userId, localNodeId, typeof sourceId === 'string' ? sourceId : undefined, excludeMqtt);
     }
     if (!this.notificationsRepo) return {};
     return this.notificationsRepo.getUnreadCountsByChannelAsync(userId, localNodeId, sourceId, excludeMqtt);
@@ -8274,10 +8279,12 @@ class DatabaseService {
    * Async version of getBatchUnreadDMCounts for PostgreSQL/MySQL support.
    * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
-  async getBatchUnreadDMCountsAsync(localNodeId: string, userId: number | null, sourceId?: string): Promise<{ [fromNodeId: string]: number }> {
-    // For SQLite, use sync version
+  async getBatchUnreadDMCountsAsync(localNodeId: string, userId: number | null, sourceId?: SourceScope): Promise<{ [fromNodeId: string]: number }> {
+    // For SQLite, use sync version.
+    // The raw-SQL sync twin binds sourceId as a parameter, so the ALL_SOURCES
+    // symbol must be normalized to undefined (its legacy "all sources" spelling).
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
-      return this.getBatchUnreadDMCounts(localNodeId, userId, sourceId);
+      return this.getBatchUnreadDMCounts(localNodeId, userId, typeof sourceId === 'string' ? sourceId : undefined);
     }
     if (!this.notificationsRepo) return {};
     return this.notificationsRepo.getBatchUnreadDMCountsAsync(localNodeId, userId, sourceId);
@@ -8767,7 +8774,7 @@ class DatabaseService {
 
   /** @deprecated Use databaseService.telemetry.purgeNodeTelemetry() instead */
   async purgeNodeTelemetryAsync(nodeNum: number): Promise<number> {
-    return this.telemetry.purgeNodeTelemetry(nodeNum);
+    return this.telemetry.purgeNodeTelemetry(nodeNum, ALL_SOURCES); // intentional cross-source: deprecated shim has no sourceId
   }
 
   /** @deprecated Use databaseService.telemetry.purgePositionHistory() instead */
@@ -9174,7 +9181,7 @@ class DatabaseService {
 
   async cleanupOldRouteSegmentsAsync(days: number = 30): Promise<number> {
     if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.traceroutesRepo) {
-      return this.traceroutesRepo.cleanupOldRouteSegments(days);
+      return this.traceroutesRepo.cleanupOldRouteSegments(days, ALL_SOURCES); // intentional cross-source: scheduled cleanup spans every source
     }
     return this.cleanupOldRouteSegments(days);
   }


### PR DESCRIPTION
## Summary

Task **1.1** of the remediation plan (#3962, Phase 1). Converts the #1 hard rule (per-source isolation) from caller-discipline into runtime + compile-time enforcement.

**Before:** `withSourceScope(table, sourceId?)` silently returned `undefined` when `sourceId` was falsy — Drizzle's `and()` dropped it and the query returned **rows from every source** (fail-open).

**Now:**
- `withSourceScope` **throws** on `undefined`/`null`/`''`.
- New `ALL_SOURCES` unique-symbol sentinel (exported from the repositories barrel) is the only way to express an intentional cross-source query — it can't arrive off the wire or from JSON, and must be explicitly imported.
- Tier-2 compile-time hardening: leading-param aggregates (`getAllNodes`, `getNodeCount`, `getChannelCount`, …) now have **required** `sourceId: SourceScope` (omission is a compile error, proven by `@ts-expect-error` tests).
- Write/ID-building methods (`insertMessage`, `upsertNode`, …) deliberately NOT widened so the symbol can never corrupt `${sourceId}` templates; raw-SQL SQLite twins normalize the sentinel before parameter binding.
- Every omitting call site was resolved **explicitly at the caller**: `ALL_SOURCES` + comment for intentional cross-source paths (system stats, global purge, cache warm-up, backup export, v1 API "all sources when unfiltered" semantics), or a real `sourceId`.

**Three genuine cross-source leaks found and fixed** (with regression coverage):
1. `server.ts` node-refresh `getNodeCount()` ignored `refreshSourceId` (adjacent `getChannelCount` passed it).
2. `database.ts` `deleteNode()` → `deleteNeighborInfoInvolvingNode()` dropped the sourceId (async twin passed it).
3. `meshtasticManager.ts` pending-DM fetch omitted `this.sourceId`.

Note for reviewers: the CLAUDE.md global-by-design exceptions (channel decryption, estimated_positions, automations) never call `withSourceScope` — the sentinel's consumers are the aggregation/purge/cache paths, not those.

## Testing

- New `withSourceScope.test.ts` (throw on undefined/null/empty; scope on string; undefined-clause on `ALL_SOURCES`) and `withSourceScope.perSource.test.ts` (two-source isolation + leak regression + compile-error proof).
- ~70 test call-site updates to pass explicit scope.
- Full suite (independent orchestrator run): **8068 passed, 0 failed, 0 suite failures** (`success: true`). Typecheck clean.

## Follow-ups filed in the epic (out of scope here)

Hand-rolled `if (sourceId)` fail-open filters that bypass this helper (all of `meshcore.ts`, parts of `notifications.ts`/`channels.ts`/`nodes.ts:getAllNodesSqlite`), legacy `*Sync`/`*Sqlite` twins (Phase 3.4), and the facade `getNode(nodeNum)` single-source assumption chain (revisit with Phase 2).

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n