### PR TITLE
fix(meshcore): populate fromName on DM automation triggers, clarify trigger.from vs fromName

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -158,14 +158,14 @@ Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the
   sender.
 - **Reply to the triggering message** — on **Meshtastic** this threads the reply as a tapback (via
   the triggering packet id). MeshCore has no packet-id/thread concept on the wire, so on **MeshCore**
-  this instead **auto-prepends the sender mention** `@[<sender name>]: ` to the outgoing text — the same
+  this instead **auto-prepends the sender mention** `@[<senderLabel>]: ` to the outgoing text — the same
   `@[Name]:` markup the in-app reply button uses — so an automation can reply to whoever sent the
-  triggering message without hand-writing the mention. The sender name comes from
-  `{{ trigger.fromName }}`; if it can't be resolved (e.g. an anonymous channel post with no name
-  prefix) nothing is prepended, and if your text already begins with an `@[…]` mention it is left as-is
-  (no double mention). Note that on MeshCore `{{ trigger.from }}` / `{{ trigger.fromId }}` resolve to a
-  synthetic `channel-<idx>` key for channel messages, not an identity — always reference the sender via
-  `{{ trigger.fromName }}` (or just enable this checkbox).
+  triggering message without hand-writing the mention. The label comes from
+  `{{ trigger.senderLabel }}` (sender name → channel name → id), so even an anonymous channel post
+  still gets a sensible mention; if nothing at all can be resolved nothing is prepended, and if your
+  text already begins with an `@[…]` mention it is left as-is (no double mention). See
+  [Universal message tokens](#universal-message-tokens-meshtastic--meshcore) — reference the sender via
+  `{{ trigger.senderLabel }}` / `{{ trigger.fromName }}`, not the raw `{{ trigger.from }}`.
 - **MeshCore scope** *(advanced; MeshCore sources only — ignored by Meshtastic)* — which region a
   MeshCore message floods to: **Inherit (channel / source default)**, **Match the triggering
   message's scope** (reply on the same region it arrived on), **Unscoped (flood, no region)**, or
@@ -292,6 +292,26 @@ values, the set-variable value) accept **double-brace tokens**:
 | `{{ trigger.sourceId }}` / `{{ trigger.timestamp }}` | Available for every trigger; `timestamp` renders as a local date/time |
 | `{{ var.name }}` | A user-defined variable; `{{ var.name.field }}` for nested `json` access |
 | `{{ NOW }}` | The current time, rendered as a local `YYYY-MM-DD HH:mm:ss` |
+
+### Universal message tokens (Meshtastic + MeshCore)
+
+A **message** trigger (`trigger.message`) fires on both protocols, so these tokens are **standardized**
+to mean the same thing on each — use them and your automation is portable:
+
+| Token | Meshtastic | MeshCore |
+| --- | --- | --- |
+| `{{ trigger.senderLabel }}` | Node long/short name, else `!hex` id | Parsed sender name, else channel name, else pubkey/`channel-<idx>` |
+| `{{ trigger.fromName }}` | Node long name → short name → id | Parsed sender name (from the `Name:` body prefix / resolved contact) |
+| `{{ trigger.channelName }}` | Channel name (empty on a DM) | Channel name (empty on a DM / room post) |
+| `{{ trigger.isDM }}` / `{{ trigger.isChannel }}` | Direct message / channel broadcast | Direct message / channel post |
+| `{{ trigger.protocol }}` | `meshtastic` | `meshcore` |
+
+`{{ trigger.senderLabel }}` is the **"just works" label for addressing a reply** — it always resolves
+to something usable. Prefer it (or `{{ trigger.fromName }}`) over the **raw identity** tokens:
+
+- `{{ trigger.from }}` / `{{ trigger.fromId }}` are **raw identity**: on Meshtastic the node number /
+  `!hex` id; on MeshCore the sender's public key — or, for a channel message (which carries no
+  per-sender key on the wire), the synthetic `channel-<idx>` slot key, **not** a sender identity.
 
 ### In-builder validation
 

--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -153,9 +153,14 @@ Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the
   shown with **MC / MT badges**. The correct local slot is resolved per source, and a Meshtastic
   channel is never sent to a MeshCore source (and vice-versa). Disabled channel slots are excluded.
   Raw channel PSKs are never sent to the browser.
-- **DM to node #** — send as a direct message instead of to a channel. `{{ trigger.from }}` replies
-  to the sender.
-- **Reply to the triggering message** — thread the reply to the message that fired the automation.
+- **DM to node #** — send as a direct message instead of to a channel (Meshtastic only — MeshCore
+  sends always go to a channel/region, never a DM-by-node). `{{ trigger.from }}` replies to the
+  sender.
+- **Reply to the triggering message** — threads the reply as a tapback on Meshtastic. **MeshCore has
+  no reply/thread concept, so this checkbox has no effect there.** MeshCore messages also carry no
+  per-sender packet id, so `{{ trigger.from }}` / `{{ trigger.fromId }}` resolve to a synthetic
+  `channel-<idx>` key for channel messages, not an identity — use `{{ trigger.fromName }}` (the
+  sender's display name) to reference the sender in MeshCore automations instead.
 - **MeshCore scope** *(advanced; MeshCore sources only — ignored by Meshtastic)* — which region a
   MeshCore message floods to: **Inherit (channel / source default)**, **Match the triggering
   message's scope** (reply on the same region it arrived on), **Unscoped (flood, no region)**, or

--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -156,11 +156,16 @@ Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the
 - **DM to node #** — send as a direct message instead of to a channel (Meshtastic only — MeshCore
   sends always go to a channel/region, never a DM-by-node). `{{ trigger.from }}` replies to the
   sender.
-- **Reply to the triggering message** — threads the reply as a tapback on Meshtastic. **MeshCore has
-  no reply/thread concept, so this checkbox has no effect there.** MeshCore messages also carry no
-  per-sender packet id, so `{{ trigger.from }}` / `{{ trigger.fromId }}` resolve to a synthetic
-  `channel-<idx>` key for channel messages, not an identity — use `{{ trigger.fromName }}` (the
-  sender's display name) to reference the sender in MeshCore automations instead.
+- **Reply to the triggering message** — on **Meshtastic** this threads the reply as a tapback (via
+  the triggering packet id). MeshCore has no packet-id/thread concept on the wire, so on **MeshCore**
+  this instead **auto-prepends the sender mention** `@[<sender name>]: ` to the outgoing text — the same
+  `@[Name]:` markup the in-app reply button uses — so an automation can reply to whoever sent the
+  triggering message without hand-writing the mention. The sender name comes from
+  `{{ trigger.fromName }}`; if it can't be resolved (e.g. an anonymous channel post with no name
+  prefix) nothing is prepended, and if your text already begins with an `@[…]` mention it is left as-is
+  (no double mention). Note that on MeshCore `{{ trigger.from }}` / `{{ trigger.fromId }}` resolve to a
+  synthetic `channel-<idx>` key for channel messages, not an identity — always reference the sender via
+  `{{ trigger.fromName }}` (or just enable this checkbox).
 - **MeshCore scope** *(advanced; MeshCore sources only — ignored by Meshtastic)* — which region a
   MeshCore message floods to: **Inherit (channel / source default)**, **Match the triggering
   message's scope** (reply on the same region it arrived on), **Unscoped (flood, no region)**, or

--- a/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
+++ b/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
@@ -221,16 +221,30 @@ in `src/services/database.ts`). **Resolution rules (apply to every field):**
 >   sender identity. For DMs/room posts it's the sender's/author's resolved public key.
 > - `trigger.fromName` = the sender's display name — parsed from the "Name: " body prefix for channel
 >   messages, or the resolved contact's `advName`/`name` for DMs and room posts (#3973 fixed this for
->   DMs, which previously left `fromName` empty). **This is the correct token to reference "who sent
->   this" in a MeshCore automation**, not `trigger.from`.
-> - `trigger.packetId` is never set, so on MeshCore `action.sendMessage`'s `replyToTrigger` produces no
->   Meshtastic-style `replyId` tapback. Instead (#3973) the executor auto-prepends the app's
->   `@[<fromName>]: ` mention to the outgoing text when `replyToTrigger` is set on a `trigger.message`
->   that carries a `fromName` — matching the in-app reply composer (`MeshCoreMessageStream.handleReply`).
->   Guards: no `fromName` → no prepend; text already starting with `@[` → left as-is (no double mention).
->   Meshtastic triggers have no `fromName`, so the same code path leaves them untouched and their
->   packetId tapback stands. Implemented in `actionExecutor.ts` `case 'action.sendMessage'`.
+>   DMs, which previously left `fromName` empty).
 > - `trigger.scopeName` / `trigger.scopeCode` / `trigger.scoped` are MeshCore-only (region/scope).
+>
+> **Universal message-token standardization (#3978).** `trigger.message` fires on both protocols, so the
+> sender/channel tokens are standardized to mean the same thing on each. Both `buildMessageContext`
+> (Meshtastic) and `buildMeshCoreMessageContext` (MeshCore) now emit:
+> - `fromName` — **universal**. Meshtastic: sender node display name (long → short → `fromId`), resolved
+>   by the engine via `NodeDataProvider.getNode` and threaded into the pure builder as a `labels` arg
+>   (no DB in the builder). MeshCore: unchanged (`msg.fromName`).
+> - `channelName` — **new, both protocols**. Engine resolves slot→name via `getChannelName` (self-contained
+>   here; **overlaps PR #3974's resolver in `onMessage`/`onMeshCoreMessage` — reconcile at merge**) and
+>   threads it in; the builder suppresses it for DMs.
+> - `senderLabel` — **new, both protocols**. `fromName || channelName || fromId` — the "just works" reply
+>   label. `action.sendMessage`'s MeshCore auto-mention (#3973) now consumes **`senderLabel`** so a nameless
+>   channel post degrades to the channel name / id instead of an empty `@[]`. The auto-mention is gated on
+>   `fields.protocol === 'meshcore'` (was previously "has `fromName`", which no longer discriminates now
+>   that `fromName` is universal); Meshtastic keeps its `packetId` tapback and no `@[ ]` mention.
+> - `isChannel` — **new, both protocols** (symmetry with `isDM`). Meshtastic: `isBroadcast`. MeshCore: the
+>   existing channel-vs-DM/room discriminator.
+> - `protocol` — now set on **both** (`'meshtastic'` | `'meshcore'`).
+>
+> Resolution is gated on "a `trigger.message` automation is loaded" (not the old "a channelName filter is
+> used") so the tokens are always populated when any message automation exists, while the hot path stays
+> DB-free when none is.
 
 **`trigger.nodeDiscovered` / `trigger.nodeUpdated`** — payload `NodeUpdateData {nodeNum, node: Partial<DbNode>}` (event `node:updated`).
 > ⚠️ The emitter has **no separate "discovered" event** and `node` is a **partial** (changed fields only). Engine must: (a) **hydrate the full `DbNode`** from the DB for conditions; (b) expose the partial as `trigger.changed` (which fields changed — for "role changed" style triggers); (c) derive `trigger.isNew` (first-ever `node:updated` for that nodeNum, tracked by the engine, or `createdAt === updatedAt` heuristic). `nodeDiscovered` = `node:updated` where `isNew`; `nodeUpdated` = the rest.

--- a/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
+++ b/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
@@ -213,6 +213,21 @@ in `src/services/database.ts`). **Resolution rules (apply to every field):**
 | `trigger.decryptedBy` | `'node'｜'server'｜null` | |
 | `trigger.node.*` | hydrated `DbNode` for `fromNodeNum` | full sender record (role, hwModel, position, …) |
 
+> **MeshCore addendum (post #3833/#3914, `buildMeshCoreMessageContext` in `triggerContext.ts`):** MeshCore
+> messages have no numeric `packetId`/node-num identity, so the table above only applies verbatim to
+> Meshtastic. For MeshCore triggers:
+> - `trigger.from` / `trigger.fromId` = `fromPublicKey`. For **channel** messages this is a synthetic
+>   `channel-<idx>` key (MeshCore channel packets carry no per-sender pubkey on the wire) — **not** a
+>   sender identity. For DMs/room posts it's the sender's/author's resolved public key.
+> - `trigger.fromName` = the sender's display name — parsed from the "Name: " body prefix for channel
+>   messages, or the resolved contact's `advName`/`name` for DMs and room posts (#3973 fixed this for
+>   DMs, which previously left `fromName` empty). **This is the correct token to reference "who sent
+>   this" in a MeshCore automation**, not `trigger.from`.
+> - `trigger.packetId` is never set, so `action.sendMessage`'s `replyToTrigger` (which reads
+>   `trigger.fields.packetId`) always resolves to a no-op for MeshCore sends — MeshCore has no
+>   reply/tapback concept on the wire.
+> - `trigger.scopeName` / `trigger.scopeCode` / `trigger.scoped` are MeshCore-only (region/scope).
+
 **`trigger.nodeDiscovered` / `trigger.nodeUpdated`** — payload `NodeUpdateData {nodeNum, node: Partial<DbNode>}` (event `node:updated`).
 > ⚠️ The emitter has **no separate "discovered" event** and `node` is a **partial** (changed fields only). Engine must: (a) **hydrate the full `DbNode`** from the DB for conditions; (b) expose the partial as `trigger.changed` (which fields changed — for "role changed" style triggers); (c) derive `trigger.isNew` (first-ever `node:updated` for that nodeNum, tracked by the engine, or `createdAt === updatedAt` heuristic). `nodeDiscovered` = `node:updated` where `isNew`; `nodeUpdated` = the rest.
 | field | source |

--- a/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
+++ b/docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md
@@ -223,9 +223,13 @@ in `src/services/database.ts`). **Resolution rules (apply to every field):**
 >   messages, or the resolved contact's `advName`/`name` for DMs and room posts (#3973 fixed this for
 >   DMs, which previously left `fromName` empty). **This is the correct token to reference "who sent
 >   this" in a MeshCore automation**, not `trigger.from`.
-> - `trigger.packetId` is never set, so `action.sendMessage`'s `replyToTrigger` (which reads
->   `trigger.fields.packetId`) always resolves to a no-op for MeshCore sends — MeshCore has no
->   reply/tapback concept on the wire.
+> - `trigger.packetId` is never set, so on MeshCore `action.sendMessage`'s `replyToTrigger` produces no
+>   Meshtastic-style `replyId` tapback. Instead (#3973) the executor auto-prepends the app's
+>   `@[<fromName>]: ` mention to the outgoing text when `replyToTrigger` is set on a `trigger.message`
+>   that carries a `fromName` — matching the in-app reply composer (`MeshCoreMessageStream.handleReply`).
+>   Guards: no `fromName` → no prepend; text already starting with `@[` → left as-is (no double mention).
+>   Meshtastic triggers have no `fromName`, so the same code path leaves them untouched and their
+>   packetId tapback stands. Implemented in `actionExecutor.ts` `case 'action.sendMessage'`.
 > - `trigger.scopeName` / `trigger.scopeCode` / `trigger.scoped` are MeshCore-only (region/scope).
 
 **`trigger.nodeDiscovered` / `trigger.nodeUpdated`** — payload `NodeUpdateData {nodeNum, node: Partial<DbNode>}` (event `node:updated`).

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -12,7 +12,7 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
     ['text', 'Message body'], ['from', 'Sender node number (Meshtastic) — for MeshCore channel messages this is a synthetic "channel-<idx>" key, not an identity; use fromName instead'],
     ['fromId', 'Sender node id (!hex) — same MeshCore caveat as from'],
     ['to', 'Recipient node number'], ['toId', 'Recipient node id'], ['channel', 'Channel index'],
-    ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId) — Meshtastic only; unset for MeshCore, so replyToTrigger has no effect on MeshCore sends'],
+    ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId) — Meshtastic only; unset for MeshCore, where replyToTrigger instead auto-prepends the @[fromName] mention'],
     ['hops', 'Hop count (hopStart − hopLimit)'], ['hopStart', 'Hop start'], ['hopLimit', 'Hop limit'],
     ['snr', 'Receive SNR — RF-received messages only'], ['rssi', 'Receive RSSI dBm — RF only'],
     ['isDM', 'true if a direct message'], ['isBroadcast', 'true if broadcast'],

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -9,16 +9,17 @@
 // All `{{ trigger.* }}` tokens, by trigger type. `sourceId`/`timestamp` are added to every group.
 export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.message': [
-    ['text', 'Message body'], ['from', 'Sender node number'], ['fromId', 'Sender node id (!hex)'],
+    ['text', 'Message body'], ['from', 'Sender node number (Meshtastic) — for MeshCore channel messages this is a synthetic "channel-<idx>" key, not an identity; use fromName instead'],
+    ['fromId', 'Sender node id (!hex) — same MeshCore caveat as from'],
     ['to', 'Recipient node number'], ['toId', 'Recipient node id'], ['channel', 'Channel index'],
-    ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId)'],
+    ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId) — Meshtastic only; unset for MeshCore, so replyToTrigger has no effect on MeshCore sends'],
     ['hops', 'Hop count (hopStart − hopLimit)'], ['hopStart', 'Hop start'], ['hopLimit', 'Hop limit'],
     ['snr', 'Receive SNR — RF-received messages only'], ['rssi', 'Receive RSSI dBm — RF only'],
     ['isDM', 'true if a direct message'], ['isBroadcast', 'true if broadcast'],
     ['wantAck', 'Sender requested an ack'], ['replyId', 'Replied-to packet id'],
     ['emoji', 'Tapback/reaction emoji flag'], ['viaMqtt', 'true if it arrived via MQTT'],
     ['decryptedBy', 'Channel/key that decrypted it'],
-    ['fromName', 'Sender name (MeshCore)'], ['scopeName', 'Region/scope name (MeshCore)'],
+    ['fromName', 'Sender display name (MeshCore only) — use this instead of from/fromId to reference the sender'], ['scopeName', 'Region/scope name (MeshCore)'],
     ['scopeCode', 'Region/scope code — 0 = unscoped (MeshCore)'], ['scoped', 'true if sent with a region (MeshCore)'],
   ],
   'trigger.telemetry': [['nodeNum', 'Node number'], ['telemetryType', 'Metric name'], ['value', 'Reading value'], ['unit', 'Unit']],

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -9,17 +9,24 @@
 // All `{{ trigger.* }}` tokens, by trigger type. `sourceId`/`timestamp` are added to every group.
 export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.message': [
-    ['text', 'Message body'], ['from', 'Sender node number (Meshtastic) — for MeshCore channel messages this is a synthetic "channel-<idx>" key, not an identity; use fromName instead'],
-    ['fromId', 'Sender node id (!hex) — same MeshCore caveat as from'],
+    ['text', 'Message body'],
+    // ── Universal sender/channel tokens (work the same on Meshtastic & MeshCore) ──
+    ['senderLabel', 'Best label for the sender (name → channel name → id) — the "just works" token for addressing a reply on either protocol'],
+    ['fromName', 'Sender display name — Meshtastic node long/short name (falls back to the id); MeshCore parsed sender name'],
+    ['channelName', 'Channel name (both protocols); empty on a DM'],
+    ['isDM', 'true if a direct message'], ['isChannel', 'true if a channel/broadcast message'],
+    // ── Raw identity (protocol-specific) ──
+    ['from', 'Raw sender identity: Meshtastic node number; MeshCore sender pubkey, or a synthetic "channel-<idx>" key for channel messages (not an identity — use senderLabel/fromName)'],
+    ['fromId', 'Raw sender id: Meshtastic !hex; MeshCore pubkey / channel-<idx> (same caveat as from)'],
     ['to', 'Recipient node number'], ['toId', 'Recipient node id'], ['channel', 'Channel index'],
-    ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId) — Meshtastic only; unset for MeshCore, where replyToTrigger instead auto-prepends the @[fromName] mention'],
+    ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId) — Meshtastic only; unset for MeshCore, where replyToTrigger instead auto-prepends the @[senderLabel] mention'],
     ['hops', 'Hop count (hopStart − hopLimit)'], ['hopStart', 'Hop start'], ['hopLimit', 'Hop limit'],
     ['snr', 'Receive SNR — RF-received messages only'], ['rssi', 'Receive RSSI dBm — RF only'],
-    ['isDM', 'true if a direct message'], ['isBroadcast', 'true if broadcast'],
+    ['isBroadcast', 'true if broadcast (alias of isChannel)'],
     ['wantAck', 'Sender requested an ack'], ['replyId', 'Replied-to packet id'],
     ['emoji', 'Tapback/reaction emoji flag'], ['viaMqtt', 'true if it arrived via MQTT'],
-    ['decryptedBy', 'Channel/key that decrypted it'],
-    ['fromName', 'Sender display name (MeshCore only) — use this instead of from/fromId to reference the sender'], ['scopeName', 'Region/scope name (MeshCore)'],
+    ['decryptedBy', 'Channel/key that decrypted it'], ['protocol', 'meshtastic or meshcore'],
+    ['scopeName', 'Region/scope name (MeshCore)'],
     ['scopeCode', 'Region/scope code — 0 = unscoped (MeshCore)'], ['scoped', 'true if sent with a region (MeshCore)'],
   ],
   'trigger.telemetry': [['nodeNum', 'Node number'], ['telemetryType', 'Metric name'], ['value', 'Reading value'], ['unit', 'Unit']],

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -318,7 +318,7 @@ export const ACTIONS: BlockDef[] = [
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios to send through (MQTT sources are receive-only and excluded). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
-      { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true, help: 'Threads as a tapback reply on Meshtastic. MeshCore has no reply/thread concept, so this has no effect there — use {{ trigger.fromName }} in the text to reference the sender instead.' },
+      { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true, help: 'Meshtastic: threads the reply as a tapback. MeshCore has no tapback, so instead it auto-prepends the @[sender name]: mention to your text (the same markup the reply button uses), so you don’t have to write @[{{ trigger.fromName }}] yourself. No sender name / an existing @[…] mention in your text = no change.' },
       {
         name: 'scopeMode', label: 'MeshCore scope', kind: 'select', advanced: true,
         options: [

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -318,7 +318,7 @@ export const ACTIONS: BlockDef[] = [
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios to send through (MQTT sources are receive-only and excluded). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
-      { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true },
+      { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true, help: 'Threads as a tapback reply on Meshtastic. MeshCore has no reply/thread concept, so this has no effect there — use {{ trigger.fromName }} in the text to reference the sender instead.' },
       {
         name: 'scopeMode', label: 'MeshCore scope', kind: 'select', advanced: true,
         options: [

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -314,11 +314,11 @@ export const ACTIONS: BlockDef[] = [
     label: 'Send a message',
     description: 'Send text to a channel or as a DM.',
     fields: [
-      { name: 'text', label: 'Message', kind: 'textarea', tokens: true, placeholder: 'Hello {{ trigger.fromId }}!', help: 'Use {{ trigger.field }} or {{ var.name }} to insert values.' },
+      { name: 'text', label: 'Message', kind: 'textarea', tokens: true, placeholder: 'Hello {{ trigger.senderLabel }}!', help: 'Use {{ trigger.field }} or {{ var.name }} to insert values. {{ trigger.senderLabel }} is the universal "who sent this" label (works on Meshtastic and MeshCore).' },
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios to send through (MQTT sources are receive-only and excluded). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
-      { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true, help: 'Meshtastic: threads the reply as a tapback. MeshCore has no tapback, so instead it auto-prepends the @[sender name]: mention to your text (the same markup the reply button uses), so you don’t have to write @[{{ trigger.fromName }}] yourself. No sender name / an existing @[…] mention in your text = no change.' },
+      { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true, help: 'Meshtastic: threads the reply as a tapback. MeshCore has no tapback, so instead it auto-prepends the @[sender]: mention (using {{ trigger.senderLabel }} — sender name, else channel name, else id) to your text, so you don’t have to write it yourself. An existing @[…] mention in your text = no change.' },
       {
         name: 'scopeMode', label: 'MeshCore scope', kind: 'select', advanced: true,
         options: [

--- a/src/server/meshcoreManager.dmFromName.test.ts
+++ b/src/server/meshcoreManager.dmFromName.test.ts
@@ -10,7 +10,7 @@ import databaseService from '../services/database.js';
 
 function makeManager(opts?: {
   contacts?: Array<{ publicKey: string; advType?: number; advName?: string; name?: string }>;
-}): { manager: MeshCoreManager; emittedMessages: MeshCoreMessage[] } {
+}): { manager: MeshCoreManager; emittedMessages: MeshCoreMessage[]; insertMessage: ReturnType<typeof vi.spyOn> } {
   const m = new MeshCoreManager('test-source');
   (m as any).deviceType = MeshCoreDeviceType.COMPANION;
   (m as any).connected = true;
@@ -30,9 +30,9 @@ function makeManager(opts?: {
   }
 
   m.on('message', (msg: MeshCoreMessage) => emittedMessages.push(msg));
-  vi.spyOn(databaseService.meshcore, 'insertMessage').mockResolvedValue(undefined as any);
+  const insertMessage = vi.spyOn(databaseService.meshcore, 'insertMessage').mockResolvedValue(undefined as any);
 
-  return { manager: m, emittedMessages };
+  return { manager: m, emittedMessages, insertMessage };
 }
 
 describe('MeshCoreManager contact_message fromName (#3973)', () => {
@@ -42,7 +42,7 @@ describe('MeshCoreManager contact_message fromName (#3973)', () => {
 
   it('populates fromName from the resolved contact advName', () => {
     const senderPubkey = 'cc'.repeat(32);
-    const { manager, emittedMessages } = makeManager({
+    const { manager, emittedMessages, insertMessage } = makeManager({
       contacts: [{ publicKey: senderPubkey, advName: 'Alice' }],
     });
 
@@ -57,6 +57,7 @@ describe('MeshCoreManager contact_message fromName (#3973)', () => {
 
     expect(emittedMessages).toHaveLength(1);
     expect(emittedMessages[0].fromName).toBe('Alice');
+    expect(insertMessage).toHaveBeenCalledWith(expect.objectContaining({ fromName: 'Alice' }), expect.anything());
   });
 
   it('falls back to the contact name when advName is unset', () => {

--- a/src/server/meshcoreManager.dmFromName.test.ts
+++ b/src/server/meshcoreManager.dmFromName.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for issue #3973: MeshCore DM (contact_message) events did not populate
+ * `fromName`, even though the sender contact is resolved right there — leaving
+ * `{{ trigger.fromName }}` empty for MeshCore DM automations (unlike channel and
+ * room-post messages, which already carried a sender name).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType, MeshCoreMessage } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+
+function makeManager(opts?: {
+  contacts?: Array<{ publicKey: string; advType?: number; advName?: string; name?: string }>;
+}): { manager: MeshCoreManager; emittedMessages: MeshCoreMessage[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+  (m as any).localNode = { publicKey: 'aa'.repeat(32) };
+
+  const emittedMessages: MeshCoreMessage[] = [];
+
+  if (opts?.contacts) {
+    for (const c of opts.contacts) {
+      (m as any).contacts.set(c.publicKey, {
+        publicKey: c.publicKey,
+        advType: c.advType ?? 1,
+        advName: c.advName,
+        name: c.name,
+      });
+    }
+  }
+
+  m.on('message', (msg: MeshCoreMessage) => emittedMessages.push(msg));
+  vi.spyOn(databaseService.meshcore, 'insertMessage').mockResolvedValue(undefined as any);
+
+  return { manager: m, emittedMessages };
+}
+
+describe('MeshCoreManager contact_message fromName (#3973)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('populates fromName from the resolved contact advName', () => {
+    const senderPubkey = 'cc'.repeat(32);
+    const { manager, emittedMessages } = makeManager({
+      contacts: [{ publicKey: senderPubkey, advName: 'Alice' }],
+    });
+
+    (manager as any).handleBridgeEvent({
+      event_type: 'contact_message',
+      data: {
+        pubkey_prefix: senderPubkey,
+        text: 'hello there',
+        sender_timestamp: 1700000000,
+      },
+    });
+
+    expect(emittedMessages).toHaveLength(1);
+    expect(emittedMessages[0].fromName).toBe('Alice');
+  });
+
+  it('falls back to the contact name when advName is unset', () => {
+    const senderPubkey = 'dd'.repeat(32);
+    const { manager, emittedMessages } = makeManager({
+      contacts: [{ publicKey: senderPubkey, name: 'Bob' }],
+    });
+
+    (manager as any).handleBridgeEvent({
+      event_type: 'contact_message',
+      data: {
+        pubkey_prefix: senderPubkey,
+        text: 'hi',
+        sender_timestamp: 1700000001,
+      },
+    });
+
+    expect(emittedMessages[0].fromName).toBe('Bob');
+  });
+
+  it('leaves fromName undefined when the sender contact is unknown', () => {
+    const { manager, emittedMessages } = makeManager();
+
+    (manager as any).handleBridgeEvent({
+      event_type: 'contact_message',
+      data: {
+        pubkey_prefix: 'deadbeef',
+        text: 'orphan dm',
+        sender_timestamp: 1700000002,
+      },
+    });
+
+    expect(emittedMessages[0].fromName).toBeUndefined();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -387,8 +387,9 @@ export interface MeshCoreSendResult {
 export interface MeshCoreMessage {
   id: string;
   fromPublicKey: string;
-  /** Display name parsed from the message body (channel messages only — MeshCore
-   *  channel packets carry no per-sender identity; the sender prefixes their name). */
+  /** Sender display name. For channel messages, parsed from the "Name: " prefix
+   *  MeshCore devices add to the body (channel packets carry no per-sender identity
+   *  on the wire). For DMs and room posts, taken from the resolved contact. */
   fromName?: string;
   toPublicKey?: string; // null for broadcast
   text: string;
@@ -1157,6 +1158,7 @@ class MeshCoreManager extends EventEmitter {
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
         fromPublicKey: data.pubkey_prefix,
+        fromName: senderContact?.advName ?? senderContact?.name ?? undefined,
         toPublicKey: this.localNode?.publicKey || 'local',
         text: data.text,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -64,6 +64,66 @@ describe('executeAction', () => {
     expect(calls[0].args).toMatchObject({ destination: 777, replyId: 42, channel: 0 });
   });
 
+  // ── replyToTrigger auto-mention for MeshCore (#3973) ────────────────────────
+  it('sendMessage: replyToTrigger prepends @[name] mention for a MeshCore channel trigger', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'see https://example.com', replyToTrigger: true }),
+      // MeshCore channel message: `from` is the synthetic channel-slot key,
+      // the real sender is in `fromName`. No `packetId` on the wire.
+      ctx({ from: 'channel-13', fromId: 'channel-13', fromName: 'Alice', channel: 13, isBroadcast: true }),
+      deps,
+    );
+    expect(calls[0].args.text).toBe('@[Alice]: see https://example.com');
+    // No packetId → no Meshtastic tapback replyId.
+    expect(calls[0].args.replyId).toBeUndefined();
+  });
+
+  it('sendMessage: replyToTrigger prepends @[name] mention for a MeshCore DM trigger', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'got it', replyToTrigger: true }),
+      // MeshCore DM: fromName now populated from the resolved contact (#3973).
+      ctx({ from: 'abc123', fromId: 'abc123', fromName: 'Bob', isDM: true }),
+      deps,
+    );
+    expect(calls[0].args.text).toBe('@[Bob]: got it');
+  });
+
+  it('sendMessage: replyToTrigger does not double-prepend when the text already starts with a mention', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      // User hand-wrote the mention (the pre-fix workaround) — must not be doubled.
+      node('action.sendMessage', { text: '@[{{ trigger.fromName }}] hi', replyToTrigger: true }),
+      ctx({ from: 'channel-9', fromName: 'Carol', channel: 9, isBroadcast: true }),
+      deps,
+    );
+    expect(calls[0].args.text).toBe('@[Carol] hi');
+  });
+
+  it('sendMessage: replyToTrigger does not prepend when the sender name is missing', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'anonymous reply', replyToTrigger: true }),
+      // MeshCore channel message with no parsed sender name — nothing to mention.
+      ctx({ from: 'channel-4', channel: 4, isBroadcast: true }),
+      deps,
+    );
+    expect(calls[0].args.text).toBe('anonymous reply');
+  });
+
+  it('sendMessage: replyToTrigger leaves a Meshtastic reply unchanged (packetId tapback, no mention)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'pong', to: '{{ trigger.from }}', replyToTrigger: true, channel: 0 }),
+      // Meshtastic message trigger: has packetId, no fromName → tapback, no @[ ] mention.
+      ctx({ from: 777, channel: 0, packetId: 42, isDM: true }),
+      deps,
+    );
+    expect(calls[0].args.text).toBe('pong');
+    expect(calls[0].args.replyId).toBe(42);
+  });
+
   // ── MeshCore scope/region (#3833) ──────────────────────────────────────────
   it('sendMessage: inherit scope omits scopeOverride (default call shape unchanged)', async () => {
     const { calls, deps } = recorder();

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -64,14 +64,13 @@ describe('executeAction', () => {
     expect(calls[0].args).toMatchObject({ destination: 777, replyId: 42, channel: 0 });
   });
 
-  // ── replyToTrigger auto-mention for MeshCore (#3973) ────────────────────────
-  it('sendMessage: replyToTrigger prepends @[name] mention for a MeshCore channel trigger', async () => {
+  // ── replyToTrigger auto-mention for MeshCore (#3973 / #3978) ────────────────
+  it('sendMessage: replyToTrigger prepends @[senderLabel] for a MeshCore channel trigger', async () => {
     const { calls, deps } = recorder();
     await executeAction(
       node('action.sendMessage', { text: 'see https://example.com', replyToTrigger: true }),
-      // MeshCore channel message: `from` is the synthetic channel-slot key,
-      // the real sender is in `fromName`. No `packetId` on the wire.
-      ctx({ from: 'channel-13', fromId: 'channel-13', fromName: 'Alice', channel: 13, isBroadcast: true }),
+      // MeshCore channel message: senderLabel = the parsed sender name. No packetId.
+      ctx({ from: 'channel-13', fromId: 'channel-13', fromName: 'Alice', senderLabel: 'Alice', channel: 13, isChannel: true, isBroadcast: true, protocol: 'meshcore' }),
       deps,
     );
     expect(calls[0].args.text).toBe('@[Alice]: see https://example.com');
@@ -79,45 +78,57 @@ describe('executeAction', () => {
     expect(calls[0].args.replyId).toBeUndefined();
   });
 
-  it('sendMessage: replyToTrigger prepends @[name] mention for a MeshCore DM trigger', async () => {
+  it('sendMessage: replyToTrigger prepends @[senderLabel] for a MeshCore DM trigger', async () => {
     const { calls, deps } = recorder();
     await executeAction(
       node('action.sendMessage', { text: 'got it', replyToTrigger: true }),
-      // MeshCore DM: fromName now populated from the resolved contact (#3973).
-      ctx({ from: 'abc123', fromId: 'abc123', fromName: 'Bob', isDM: true }),
+      // MeshCore DM: fromName populated from the resolved contact (#3973) → senderLabel.
+      ctx({ from: 'abc123', fromId: 'abc123', fromName: 'Bob', senderLabel: 'Bob', isDM: true, protocol: 'meshcore' }),
       deps,
     );
     expect(calls[0].args.text).toBe('@[Bob]: got it');
+  });
+
+  it('sendMessage: replyToTrigger falls back to channelName via senderLabel when no sender name', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      // No name prefix on the channel post, but senderLabel degrades to the channel name (#3978).
+      node('action.sendMessage', { text: 'anonymous reply', replyToTrigger: true }),
+      ctx({ from: 'channel-4', fromId: 'channel-4', channelName: 'gauntlet', senderLabel: 'gauntlet', channel: 4, isChannel: true, isBroadcast: true, protocol: 'meshcore' }),
+      deps,
+    );
+    expect(calls[0].args.text).toBe('@[gauntlet]: anonymous reply');
   });
 
   it('sendMessage: replyToTrigger does not double-prepend when the text already starts with a mention', async () => {
     const { calls, deps } = recorder();
     await executeAction(
       // User hand-wrote the mention (the pre-fix workaround) — must not be doubled.
-      node('action.sendMessage', { text: '@[{{ trigger.fromName }}] hi', replyToTrigger: true }),
-      ctx({ from: 'channel-9', fromName: 'Carol', channel: 9, isBroadcast: true }),
+      node('action.sendMessage', { text: '@[{{ trigger.senderLabel }}] hi', replyToTrigger: true }),
+      ctx({ from: 'channel-9', fromName: 'Carol', senderLabel: 'Carol', channel: 9, isChannel: true, isBroadcast: true, protocol: 'meshcore' }),
       deps,
     );
     expect(calls[0].args.text).toBe('@[Carol] hi');
   });
 
-  it('sendMessage: replyToTrigger does not prepend when the sender name is missing', async () => {
+  it('sendMessage: replyToTrigger does not prepend when senderLabel is entirely missing', async () => {
     const { calls, deps } = recorder();
     await executeAction(
       node('action.sendMessage', { text: 'anonymous reply', replyToTrigger: true }),
-      // MeshCore channel message with no parsed sender name — nothing to mention.
-      ctx({ from: 'channel-4', channel: 4, isBroadcast: true }),
+      // No name, no channel name, no usable id → senderLabel undefined → nothing to mention.
+      ctx({ from: 'channel-4', channel: 4, isChannel: true, isBroadcast: true, protocol: 'meshcore' }),
       deps,
     );
     expect(calls[0].args.text).toBe('anonymous reply');
   });
 
-  it('sendMessage: replyToTrigger leaves a Meshtastic reply unchanged (packetId tapback, no mention)', async () => {
+  it('sendMessage: replyToTrigger leaves a Meshtastic reply unchanged (packetId tapback, no @[ ] mention)', async () => {
     const { calls, deps } = recorder();
     await executeAction(
       node('action.sendMessage', { text: 'pong', to: '{{ trigger.from }}', replyToTrigger: true, channel: 0 }),
-      // Meshtastic message trigger: has packetId, no fromName → tapback, no @[ ] mention.
-      ctx({ from: 777, channel: 0, packetId: 42, isDM: true }),
+      // Meshtastic message trigger: protocol meshtastic + packetId → tapback, no mention,
+      // even though senderLabel is now populated (a nodeNum/id) universally.
+      ctx({ from: 777, fromId: '!00000309', fromName: '!00000309', senderLabel: '!00000309', channel: 0, packetId: 42, isDM: true, protocol: 'meshtastic' }),
       deps,
     );
     expect(calls[0].args.text).toBe('pong');

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -155,9 +155,28 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
     }
 
     case 'action.sendMessage': {
-      const text = await interpolateAsync(String(p.text ?? ''), ctx);
+      let text = await interpolateAsync(String(p.text ?? ''), ctx);
       const destination = await num(ctx, p.to);
       const replyId = p.replyToTrigger ? (ctx.trigger.fields.packetId as number | undefined) : await num(ctx, p.replyId);
+
+      // #3973: "Reply to the triggering message" auto-mention for MeshCore.
+      // MeshCore carries no per-packet id, so `replyId` is always undefined for a
+      // MeshCore trigger and the packetId tapback below is a no-op. A reply is
+      // instead expressed by prepending the app's `@[Name]: ` mention — matching
+      // the in-app reply composer (MeshCoreMessageStream `handleReply`). This only
+      // fires when the trigger is a message that carries a sender display name
+      // (`fromName`, populated only for MeshCore message triggers) and the user
+      // hasn't already written a leading `@[ ]` mention. Meshtastic message
+      // triggers have no `fromName` and keep their packetId tapback, so they are
+      // left untouched (no `@[ ]` convention on Meshtastic).
+      if (p.replyToTrigger && ctx.trigger.triggerType === 'trigger.message') {
+        const senderName = typeof ctx.trigger.fields.fromName === 'string'
+          ? ctx.trigger.fields.fromName.trim()
+          : '';
+        if (senderName && !text.trimStart().startsWith('@[')) {
+          text = `@[${senderName}]: ${text}`;
+        }
+      }
       const fallbackChannel = p.channel != null ? Number(p.channel) : triggerChannel;
 
       // MeshCore scope/region (#3833). Translate the selected mode into the

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -163,18 +163,22 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       // MeshCore carries no per-packet id, so `replyId` is always undefined for a
       // MeshCore trigger and the packetId tapback below is a no-op. A reply is
       // instead expressed by prepending the app's `@[Name]: ` mention — matching
-      // the in-app reply composer (MeshCoreMessageStream `handleReply`). This only
-      // fires when the trigger is a message that carries a sender display name
-      // (`fromName`, populated only for MeshCore message triggers) and the user
-      // hasn't already written a leading `@[ ]` mention. Meshtastic message
-      // triggers have no `fromName` and keep their packetId tapback, so they are
-      // left untouched (no `@[ ]` convention on Meshtastic).
-      if (p.replyToTrigger && ctx.trigger.triggerType === 'trigger.message') {
-        const senderName = typeof ctx.trigger.fields.fromName === 'string'
-          ? ctx.trigger.fields.fromName.trim()
+      // the in-app reply composer (MeshCoreMessageStream `handleReply`). We use the
+      // universal `senderLabel` (#3978: fromName → channelName → id) so a channel
+      // post with no name prefix still degrades to the channel name / id rather
+      // than an empty `@[]`. Gated to `protocol === 'meshcore'`: Meshtastic has no
+      // `@[ ]` convention and keeps its packetId tapback (its senderLabel is a
+      // nodeNum/id that would be a meaningless mention).
+      if (
+        p.replyToTrigger
+        && ctx.trigger.triggerType === 'trigger.message'
+        && ctx.trigger.fields.protocol === 'meshcore'
+      ) {
+        const label = typeof ctx.trigger.fields.senderLabel === 'string'
+          ? ctx.trigger.fields.senderLabel.trim()
           : '';
-        if (senderName && !text.trimStart().startsWith('@[')) {
-          text = `@[${senderName}]: ${text}`;
+        if (label && !text.trimStart().startsWith('@[')) {
+          text = `@[${label}]: ${text}`;
         }
       }
       const fallbackChannel = p.channel != null ? Number(p.channel) : triggerChannel;

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -33,6 +33,7 @@ import {
   meshCoreMessageMatchesFilter,
   describeMessageFilterMiss,
   describeMeshCoreFilterMiss,
+  parseMeshCoreChannelIdx,
   type TriggerContext,
   type SystemEvent,
 } from './triggerContext.js';
@@ -377,18 +378,23 @@ export class AutomationEngineService {
 
   async onMessage(msg: DbMessage, sourceId: string | null): Promise<number> {
     if (await this.isSelfMeshtastic(sourceId, msg.fromNodeNum)) return 0; // #3914: ignore our own sends
-    const ctx = buildMessageContext(msg, sourceId, this.now());
-    // Resolve the message's channel NAME once (per-source slot→name), but only
-    // when a loaded message automation actually filters by channelName — keeps
-    // the hot path DB-free when nobody uses name matching.
+    // Resolve the universal sender/channel labels once (per-source slot→name and
+    // sender node name), but only when a message automation is actually loaded —
+    // keeps the hot path DB-free when nobody listens for messages. `channelName`
+    // also feeds the channel-by-name filter (unchanged behavior).
+    const hasMessageAutomations = (this.index.get('trigger.message') ?? []).length > 0;
     let channelName: string | null | undefined;
-    const usesChannelName = (this.index.get('trigger.message') ?? []).some((a) => {
-      const p = a.triggerNode.params as Record<string, unknown> | undefined;
-      return typeof p?.channelName === 'string' && p.channelName.length > 0;
-    });
-    if (usesChannelName && this.data.getChannelName) {
-      channelName = await this.data.getChannelName(sourceId, Number(msg.channel));
+    let fromName: string | undefined;
+    if (hasMessageAutomations) {
+      if (this.data.getChannelName) {
+        channelName = await this.data.getChannelName(sourceId, Number(msg.channel));
+      }
+      // Sender display name resolved the same way the UI does (long → short name);
+      // the builder falls back to the node id when the node is unknown.
+      const node = await this.data.getNode(sourceId, Number(msg.fromNodeNum));
+      fromName = node?.longName || node?.shortName || undefined;
     }
+    const ctx = buildMessageContext(msg, sourceId, this.now(), { channelName, fromName });
     return this.runTrigger(
       ctx,
       (a) => messageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
@@ -404,17 +410,16 @@ export class AutomationEngineService {
    */
   async onMeshCoreMessage(msg: MeshCoreMessage, sourceId: string | null): Promise<number> {
     if (await this.isSelfMeshCore(sourceId, msg.fromPublicKey)) return 0; // #3914: ignore our own sends
-    const ctx = buildMeshCoreMessageContext(msg, sourceId, this.now());
+    // Resolve the channel name once for the universal `channelName`/`senderLabel`
+    // tokens (and the channel-by-name filter), only when a message automation is
+    // loaded. A received channel message stores its slot in `from` as `channel-<idx>`.
+    const hasMessageAutomations = (this.index.get('trigger.message') ?? []).length > 0;
+    const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
     let channelName: string | null | undefined;
-    const usesChannelName = (this.index.get('trigger.message') ?? []).some((a) => {
-      const p = a.triggerNode.params as Record<string, unknown> | undefined;
-      return typeof p?.channelName === 'string' && p.channelName.length > 0;
-    });
-    // A received channel message stores its slot index in `from` as `channel-<idx>`.
-    const channelIdx = ctx.fields.channel;
-    if (usesChannelName && this.data.getChannelName && typeof channelIdx === 'number') {
+    if (hasMessageAutomations && this.data.getChannelName && typeof channelIdx === 'number') {
       channelName = await this.data.getChannelName(sourceId, channelIdx);
     }
+    const ctx = buildMeshCoreMessageContext(msg, sourceId, this.now(), { channelName });
     return this.runTrigger(
       ctx,
       (a) => meshCoreMessageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),

--- a/src/server/services/automation/automationSimulator.ts
+++ b/src/server/services/automation/automationSimulator.ts
@@ -225,8 +225,15 @@ function buildContext(graph: AutomationGraph, ev: SimEventInput, node: Partial<N
     case 'message': {
       const msg = synthMessage(ev, sourceId);
       // Dry-run: the tester supplies the channel name directly (no per-source DB
-      // lookup), so name-based filters can be previewed.
-      return { ctx: buildMessageContext(msg, sourceId, now), matched: messageMatchesFilter(msg, params, ev.channelName) };
+      // lookup), so name-based filters and the universal channelName/senderLabel
+      // tokens can be previewed. fromName is best-effort from the supplied node.
+      return {
+        ctx: buildMessageContext(msg, sourceId, now, {
+          channelName: ev.channelName,
+          fromName: node?.longName || node?.shortName || undefined,
+        }),
+        matched: messageMatchesFilter(msg, params, ev.channelName),
+      };
     }
     case 'nodeDiscovered':
     case 'nodeUpdated': {

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -77,6 +77,33 @@ describe('buildMessageContext', () => {
     expect(ctx.fields.isBroadcast).toBe(true);
     expect(ctx.fields.isDM).toBe(false);
   });
+
+  // Universal cross-protocol tokens (#3978)
+  it('populates fromName from the resolved node display name (long → short → id)', () => {
+    // Long name wins.
+    expect(buildMessageContext(msg(), 'default', 1, { fromName: 'Alice' }).fields.fromName).toBe('Alice');
+    // No resolved name → falls back to the node id.
+    expect(buildMessageContext(msg(), 'default', 1).fields.fromName).toBe('!0000006f');
+    expect(buildMessageContext(msg(), 'default', 1, { fromName: '  ' }).fields.fromName).toBe('!0000006f');
+  });
+
+  it('exposes channelName for a broadcast but not for a DM', () => {
+    // Broadcast on a named channel.
+    const bcast = buildMessageContext(msg({ toNodeNum: BROADCAST_ADDR }), 'default', 1, { channelName: 'Gauntlet' });
+    expect(bcast.fields.channelName).toBe('Gauntlet');
+    expect(bcast.fields.isChannel).toBe(true);
+    // DM: channelName suppressed even if a name was resolved.
+    const dm = buildMessageContext(msg(), 'default', 1, { channelName: 'Gauntlet' });
+    expect(dm.fields.channelName).toBeUndefined();
+    expect(dm.fields.isChannel).toBe(false);
+  });
+
+  it('senderLabel prefers the name, and protocol is meshtastic', () => {
+    expect(buildMessageContext(msg(), 'default', 1, { fromName: 'Alice' }).fields.senderLabel).toBe('Alice');
+    // No name → senderLabel is the id (fromName already degraded to the id).
+    expect(buildMessageContext(msg(), 'default', 1).fields.senderLabel).toBe('!0000006f');
+    expect(buildMessageContext(msg(), 'default', 1).fields.protocol).toBe('meshtastic');
+  });
 });
 
 describe('other trigger contexts', () => {
@@ -183,6 +210,48 @@ describe('buildMeshCoreMessageContext (#3833)', () => {
     expect(ctx.fields.channel).toBeUndefined();
     expect(ctx.fields.isDM).toBe(false);
     expect(ctx.fields.isBroadcast).toBe(false);
+  });
+
+  // Universal cross-protocol tokens (#3978)
+  it('channel post: channelName from label, isChannel true, senderLabel = fromName', () => {
+    const ctx = buildMeshCoreMessageContext(
+      mcMsg({ fromPublicKey: 'channel-3', fromName: 'Alice' }),
+      'default',
+      1,
+      { channelName: 'gauntlet' },
+    );
+    expect(ctx.fields.channelName).toBe('gauntlet');
+    expect(ctx.fields.isChannel).toBe(true);
+    expect(ctx.fields.senderLabel).toBe('Alice');
+  });
+
+  it('channel post with no name prefix: senderLabel degrades to channelName', () => {
+    const ctx = buildMeshCoreMessageContext(
+      mcMsg({ fromPublicKey: 'channel-3' }),
+      'default',
+      1,
+      { channelName: 'gauntlet' },
+    );
+    expect(ctx.fields.fromName).toBeUndefined();
+    expect(ctx.fields.senderLabel).toBe('gauntlet');
+  });
+
+  it('channel post with neither name nor resolved channel: senderLabel degrades to the synthetic id', () => {
+    const ctx = buildMeshCoreMessageContext(mcMsg({ fromPublicKey: 'channel-3' }), 'default', 1);
+    expect(ctx.fields.channelName).toBeUndefined();
+    expect(ctx.fields.senderLabel).toBe('channel-3');
+  });
+
+  it('DM: no channelName, isChannel false, senderLabel = sender pubkey', () => {
+    const ctx = buildMeshCoreMessageContext(
+      mcMsg({ fromPublicKey: 'aabbcc', toPublicKey: 'localkey' }),
+      'default',
+      1,
+      { channelName: 'ignored' },
+    );
+    expect(ctx.fields.channelName).toBeUndefined();
+    expect(ctx.fields.isChannel).toBe(false);
+    expect(ctx.fields.senderLabel).toBe('aabbcc');
   });
 });
 

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -32,26 +32,57 @@ export function deriveHops(msg: Pick<DbMessage, 'hopStart' | 'hopLimit'>): numbe
   return undefined;
 }
 
+/**
+ * Optional pre-resolved labels the caller (engine service) looks up from the DB
+ * and threads into the builder, so the pure builder stays DB-free. Populate the
+ * universal `fromName` / `channelName` / `senderLabel` tokens (#3978).
+ */
+export interface MessageContextLabels {
+  /** Sender's display name (long name → short name). The builder falls back to `fromId`. */
+  fromName?: string | null;
+  /** The message's channel slot name for its source. Ignored for DMs. */
+  channelName?: string | null;
+}
+
 /** Build the trigger context for a `message:new` event. */
-export function buildMessageContext(msg: DbMessage, sourceId: string | null, timestamp: number): TriggerContext {
+export function buildMessageContext(
+  msg: DbMessage,
+  sourceId: string | null,
+  timestamp: number,
+  labels?: MessageContextLabels,
+): TriggerContext {
   const to = Number(msg.toNodeNum);
   // Message ids are `${sourceId}_${fromNum}_${packetId}` (load-bearing format);
   // the trailing segment is the Meshtastic packet id used as a tapback replyId.
   const parsedPacketId = Number(String(msg.id).split('_').pop());
+  const isDM = to !== BROADCAST_ADDR;
+  const isBroadcast = to === BROADCAST_ADDR;
+  const fromId = msg.fromNodeId != null ? String(msg.fromNodeId) : undefined;
+  // Universal, cross-protocol tokens (#3978). `fromName` is the sender's display
+  // name degrading long → short → id; `channelName` is the channel's name (no
+  // meaningful channel label on a DM); `senderLabel` is the "just works" label
+  // for addressing a reply, preferring the name, then the channel, then the id.
+  const fromName = (labels?.fromName && String(labels.fromName).trim()) || fromId;
+  const channelName = isDM ? undefined : (labels?.channelName ?? undefined);
+  const senderLabel = fromName || channelName || fromId;
   const fields: Record<string, unknown> = {
     from: Number(msg.fromNodeNum),
     fromId: msg.fromNodeId,
+    fromName,
     to,
     toId: msg.toNodeId,
     text: msg.text,
     channel: msg.channel,
+    channelName,
+    senderLabel,
     portnum: msg.portnum,
     packetId: Number.isFinite(parsedPacketId) ? parsedPacketId : undefined,
     hops: deriveHops(msg),
     hopStart: msg.hopStart,
     hopLimit: msg.hopLimit,
-    isDM: to !== BROADCAST_ADDR,
-    isBroadcast: to === BROADCAST_ADDR,
+    isDM,
+    isChannel: isBroadcast,
+    isBroadcast,
     wantAck: msg.wantAck,
     replyId: msg.replyId,
     emoji: msg.emoji,
@@ -59,6 +90,7 @@ export function buildMessageContext(msg: DbMessage, sourceId: string | null, tim
     rssi: msg.rxRssi,
     viaMqtt: msg.viaMqtt,
     decryptedBy: msg.decryptedBy,
+    protocol: 'meshtastic',
     sourceId,
     timestamp,
   };
@@ -77,7 +109,7 @@ export function buildMessageContext(msg: DbMessage, sourceId: string | null, tim
  * (see `MeshCoreManager.channelPublicKey`). Parse that back to the slot index;
  * returns undefined for DMs/room posts (a real/author pubkey, not a channel).
  */
-function parseMeshCoreChannelIdx(fromPublicKey: string | undefined): number | undefined {
+export function parseMeshCoreChannelIdx(fromPublicKey: string | undefined): number | undefined {
   const m = /^channel-(\d+)$/.exec(fromPublicKey ?? '');
   return m ? Number(m[1]) : undefined;
 }
@@ -95,6 +127,7 @@ export function buildMeshCoreMessageContext(
   msg: MeshCoreMessage,
   sourceId: string | null,
   timestamp: number,
+  labels?: { channelName?: string | null },
 ): TriggerContext {
   const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
   const isChannel = channelIdx !== undefined;
@@ -102,18 +135,29 @@ export function buildMeshCoreMessageContext(
   // DM = addressed to us (recipient pubkey set) and not a channel/room post.
   const isDM = !isChannel && !isRoom && msg.toPublicKey != null;
   const scopeCode = msg.scopeCode ?? undefined;
+  const fromName = msg.fromName ?? undefined;
+  const fromId = msg.fromPublicKey != null ? String(msg.fromPublicKey) : undefined;
+  // channelName is only meaningful for a channel post; DMs/room posts have none.
+  const channelName = isChannel ? (labels?.channelName ?? undefined) : undefined;
+  // Universal "just works" reply label (#3978): the sender's name if we have one
+  // (channel posts may carry no name prefix), else the channel name, else the raw
+  // id (a pubkey for DMs/rooms, or the synthetic `channel-<idx>` key).
+  const senderLabel = fromName || channelName || fromId;
   const fields: Record<string, unknown> = {
     // MeshCore senders are pubkey strings; channel messages have no per-sender
     // pubkey, so `from` is the synthetic `channel-<idx>` key. `fromName` carries
     // the display name a channel sender prefixed onto the body, when present.
     from: msg.fromPublicKey,
     fromId: msg.fromPublicKey,
-    fromName: msg.fromName,
+    fromName,
+    channelName,
+    senderLabel,
     to: msg.toPublicKey,
     toId: msg.toPublicKey,
     text: msg.text,
     channel: channelIdx,
     isDM,
+    isChannel,
     isBroadcast: isChannel,
     hops: msg.hopCount ?? undefined,
     snr: msg.snr,


### PR DESCRIPTION
## Summary

Fully closes #3973 — "MeshCore: Automation Engine: `trigger.from` does not contain sender's name". Three parts: (1) a DM `fromName` bug fix, (2) a real `replyToTrigger` auto-mention implementation, and (3) a **universal trigger-token standardization** so message automations are portable across Meshtastic and MeshCore.

**Root cause of the report:** `{{ trigger.from }}` resolving to `channel-13` for MeshCore channel messages is intentional — MeshCore channel packets carry no per-sender public key on the wire, so MeshMonitor synthesizes a `channel-<idx>` slot key. The sender's name comes from `{{ trigger.fromName }}`. That token was *also* silently empty for MeshCore **DMs**: `contact_message` events resolve the sender's contact but never attached it as `fromName` (unlike the channel/room-post handlers).

## 1. DM `fromName` fix

- `src/server/meshcoreManager.ts` — `contact_message` (DM) handler attaches `fromName` from the resolved contact's `advName`/`name`, matching the `room_message` handler.
- `src/server/meshcoreManager.dmFromName.test.ts` (new) — `advName`, `name` fallback, `undefined` on unknown contact, and the DB persist call.

## 2. `replyToTrigger` auto-mention (MeshCore)

The reporter's real ask: "Reply to the triggering message" should address the sender automatically. MeshCore has no packet-id tapback, so it was a no-op. Now, on a MeshCore message trigger, `action.sendMessage` with `replyToTrigger` **auto-prepends `@[<sender>]: `** — the exact markup the in-app reply composer (`MeshCoreMessageStream.handleReply`) uses. Meshtastic keeps its `packetId` tapback and gets no `@[ ]` mention.

## 3. Universal trigger-token standardization (additive)

`trigger.message` fires on both protocols, so the sender/channel tokens are standardized to mean the same thing on each. **Additive** — `from`/`fromId` keep their raw-identity meaning (backward compatible).

| Token | Meshtastic | MeshCore |
| --- | --- | --- |
| `senderLabel` *(new)* | node long/short name → `!hex` id | parsed sender name → channel name → pubkey/`channel-<idx>` |
| `fromName` *(now universal)* | node long → short → id | parsed sender name (unchanged) |
| `channelName` *(new)* | channel name (empty on DM) | channel name (empty on DM/room) |
| `isChannel` *(new)* | `isBroadcast` | channel-vs-DM/room |
| `protocol` *(now on both)* | `meshtastic` | `meshcore` |
| `from` / `fromId` *(unchanged)* | node number / `!hex` | pubkey, or synthetic `channel-<idx>` for channel messages |

`senderLabel` = `fromName || channelName || fromId` is the "just works" reply label. The MeshCore auto-mention now consumes `senderLabel`, so a nameless channel post degrades to the channel name / id rather than an empty `@[]`. The auto-mention is now gated on `protocol === 'meshcore'` (the old "has `fromName`" guard no longer discriminates, since `fromName` is universal).

**Resolution approach:** the pure builders stay DB-free — the engine (`automationEngineService.onMessage`/`onMeshCoreMessage`) resolves `channelName` (via `NodeDataProvider.getChannelName`) and the Meshtastic sender name (via `getNode` → long/short name) and threads them into the builders as a `labels` arg. Resolution is gated on "a `trigger.message` automation is loaded", so the hot path stays DB-free when nothing listens.

> ⚠️ **Overlap with #3974:** PR #3974 (`feat/3974-multichannel-trigger`, unmerged) also adds a per-source slot→name resolver in `onMessage`/`onMeshCoreMessage`. This PR is branched from `origin/main` (without it) and implements `channelName` resolution self-contained. **Reconcile the two resolvers at merge time.**

## Changed files (beyond §1)

- `src/server/services/automation/triggerContext.ts` — universal `fromName`/`channelName`/`senderLabel`/`isChannel`/`protocol` in both builders; `labels` arg; export `parseMeshCoreChannelIdx`.
- `src/server/services/automation/automationEngineService.ts` — resolve + thread the labels.
- `src/server/services/automation/actionExecutor.ts` — auto-mention via `senderLabel`, gated to MeshCore.
- `src/server/services/automation/automationSimulator.ts` — thread labels into the dry-run preview.
- `src/components/automations/{SubstitutionsHelp.tsx,catalog.ts}`, `docs/features/automation-engine.md`, `docs/internal/dev-notes/AUTOMATION_ENGINE_PLAN.md` — document the universal token set; clarify `from`/`fromId` as raw identity.
- `src/server/services/automation/{triggerContext,actionExecutor}.test.ts` — fromName fallbacks, channelName (DM-suppressed), senderLabel precedence, isChannel, auto-mention senderLabel fallback + MeshCore gating + Meshtastic unregressed.

## Test plan

- [x] Full Vitest suite: **8074 passed, 0 failed** (`--reporter=json` `success: true`; 2660 suites, 0 failed suites, 607 skipped, 21 todo).
- [x] `tsc --noEmit`: no new errors from this diff (verified via stash + cross-branch; the 57 pre-existing frontend errors are an environment quirk of bare local `tsc` on the dev machine and are present on unrelated branches too — CI is green).
- [x] ESLint clean on all touched files (only pre-existing warnings).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub

---
_Generated with [Claude Code](https://claude.com/claude-code)_
