### PR TITLE
fix(meshcore): auto-retry DM via same-path + flood cadence on ack timeout

### DIFF
--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -590,6 +590,50 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       ));
     };
 
+    // DM ack-timeout retry update (#3977): the server re-sent a DM on a new
+    // path (same-path resend, or flood after reset) and re-points this message
+    // to the new attempt's ack CRC, or marks it failed once all retries are
+    // exhausted. Keep a SINGLE bubble — update the existing message in place
+    // rather than appending a new one, and follow the fail timer to the new CRC.
+    const onMessageUpdated = (evt: {
+      sourceId: string;
+      id: string;
+      previousAckCrc?: number;
+      expectedAckCrc?: number;
+      estTimeout?: number;
+      deliveryStatus?: MessageDeliveryStatus;
+    }) => {
+      if (evt.sourceId !== sourceId) return;
+      // Cancel the fail timer armed for the prior attempt's CRC — the new
+      // attempt (or terminal status) supersedes it.
+      if (evt.previousAckCrc != null) {
+        const prevTimer = ackTimers.get(evt.previousAckCrc);
+        if (prevTimer) {
+          clearTimeout(prevTimer);
+          ackTimers.delete(evt.previousAckCrc);
+        }
+      }
+      setMessages(prev => prev.map(m => {
+        if (m.id !== evt.id) return m;
+        return {
+          ...m,
+          ...(evt.expectedAckCrc != null ? { expectedAckCrc: evt.expectedAckCrc } : {}),
+          ...(evt.estTimeout != null ? { estTimeout: evt.estTimeout } : {}),
+          ...(evt.deliveryStatus ? { deliveryStatus: evt.deliveryStatus } : {}),
+        };
+      }));
+      // Arm a fresh fail timer for the new attempt unless this was a terminal
+      // status (delivered/failed).
+      if (
+        evt.expectedAckCrc != null &&
+        evt.estTimeout != null &&
+        evt.deliveryStatus !== 'failed' &&
+        evt.deliveryStatus !== 'delivered'
+      ) {
+        startAckTimeout(evt.expectedAckCrc, evt.estTimeout);
+      }
+    };
+
     // Channel "heard repeaters" (#3700): a repeater re-flooded one of our
     // outgoing channel messages and the server correlated the self-echo. The
     // event carries the current full heard-by set, so we replace state by id.
@@ -609,6 +653,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     socket.on('meshcore:status:updated', onStatusUpdated);
     socket.on('meshcore:local-node:updated', onLocalNodeUpdated);
     socket.on('meshcore:send-confirmed', onSendConfirmed);
+    socket.on('meshcore:message:updated', onMessageUpdated);
     socket.on('meshcore:channel-heard', onChannelHeard);
     socket.io.on('reconnect', onReconnect);
 
@@ -621,6 +666,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       socket.off('meshcore:status:updated', onStatusUpdated);
       socket.off('meshcore:local-node:updated', onLocalNodeUpdated);
       socket.off('meshcore:send-confirmed', onSendConfirmed);
+      socket.off('meshcore:message:updated', onMessageUpdated);
       socket.off('meshcore:channel-heard', onChannelHeard);
       socket.io.off('reconnect', onReconnect);
     };

--- a/src/server/meshcoreManager.dmRetry.test.ts
+++ b/src/server/meshcoreManager.dmRetry.test.ts
@@ -121,6 +121,17 @@ describe('MeshCoreManager — DM ack-timeout auto-retry (#3977)', () => {
     expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(2);
   });
 
+  it('does not resend when reset_path itself fails', async () => {
+    const { manager, bridgeCalls } = makeManager({ resetPathOk: false });
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(bridgeCalls.filter(c => c.cmd === 'reset_path')).toHaveLength(1);
+    // Only the original send — the resend never fires since reset_path failed.
+    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(1);
+  });
+
   it('cancels the retry if the ack for the flood resend arrives', async () => {
     const { manager, bridgeCalls } = makeManager();
 

--- a/src/server/meshcoreManager.dmRetry.test.ts
+++ b/src/server/meshcoreManager.dmRetry.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for MeshCore DM auto-retry-via-flood on ack timeout (#3977).
+ *
+ * A DM sent on a stale cached path just goes out once today and is never
+ * retried, so it silently never arrives. This automates exactly what the
+ * existing "Reset Path" button already does by hand: if no `SendConfirmed`
+ * ack arrives within the firmware's own `estTimeout` (+margin), reset the
+ * contact's cached path and resend once via flood. The retry's own send is
+ * not itself tracked — a second miss is left to the frontend's existing
+ * per-message ack timer, exactly as any other unacked send today.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+
+interface BridgeCall { cmd: string; params: Record<string, unknown>; }
+
+function makeManager(opts: {
+  /** expectedAckCrc/estTimeout to hand back for each successive send_message call */
+  sends?: Array<{ ackCrc: number; estTimeout: number }>;
+  /** whether reset_path succeeds (default true) */
+  resetPathOk?: boolean;
+} = {}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+  (m as any).contacts = new Map([
+    ['bob'.padEnd(64, '0'), { publicKey: 'bob'.padEnd(64, '0'), advName: 'Bob' }],
+  ]);
+
+  const bridgeCalls: BridgeCall[] = [];
+  let sendIdx = 0;
+  const sends = opts.sends ?? [{ ackCrc: 111, estTimeout: 8000 }, { ackCrc: 222, estTimeout: 8000 }];
+
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'send_message') {
+      // Channel/broadcast sends (no `to`) are unacked — no ackCrc/estTimeout.
+      if (!params.to) return { id: '1', success: true, data: {} };
+      const next = sends[Math.min(sendIdx, sends.length - 1)];
+      sendIdx += 1;
+      return { id: '1', success: true, data: { expectedAckCrc: next.ackCrc, estTimeout: next.estTimeout } };
+    }
+    if (cmd === 'reset_path') {
+      return { id: '1', success: opts.resetPathOk ?? true };
+    }
+    return { id: '1', success: true, data: {} };
+  };
+
+  vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
+    getChannelById: vi.fn(async () => null),
+    updateChannelScope: vi.fn(async () => {}),
+    upsertChannel: vi.fn(async () => {}),
+    getAllChannels: vi.fn(async () => []),
+    deleteChannel: vi.fn(async () => {}),
+  } as any);
+
+  vi.spyOn(databaseService, 'settings', 'get').mockReturnValue({
+    getSettingForSource: vi.fn(async () => null),
+    setSourceSetting: vi.fn(async () => {}),
+  } as any);
+
+  return { manager: m, bridgeCalls };
+}
+
+function sendConfirmed(m: MeshCoreManager, ackCode: number): void {
+  // @ts-expect-error - exercising private method
+  m.handleBridgeEvent({ event_type: 'send_confirmed', data: { ack_code: ackCode, round_trip_ms: 500 } });
+}
+
+const PUBKEY = 'bob'.padEnd(64, '0');
+
+describe('MeshCoreManager — DM ack-timeout auto-retry (#3977)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not retry when the ack arrives before the timeout', async () => {
+    const { manager, bridgeCalls } = makeManager();
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    sendConfirmed(manager, 111);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const sendCalls = bridgeCalls.filter(c => c.cmd === 'send_message');
+    expect(sendCalls).toHaveLength(1);
+    expect(bridgeCalls.some(c => c.cmd === 'reset_path')).toBe(false);
+  });
+
+  it('resets the path and resends once via flood when no ack arrives in time', async () => {
+    const { manager, bridgeCalls } = makeManager();
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    // No send_confirmed dispatched — let the ack timeout (estTimeout=8000, +20% margin) fire.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const resetCalls = bridgeCalls.filter(c => c.cmd === 'reset_path');
+    expect(resetCalls).toHaveLength(1);
+    expect(resetCalls[0].params.public_key).toBe(PUBKEY);
+
+    const sendCalls = bridgeCalls.filter(c => c.cmd === 'send_message');
+    expect(sendCalls).toHaveLength(2);
+    expect(sendCalls[1].params.text).toBe('hello');
+    expect(sendCalls[1].params.to).toBe(PUBKEY);
+  });
+
+  it('gives up silently if the flood retry also goes unacked (no second retry)', async () => {
+    const { manager, bridgeCalls } = makeManager();
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000); // first timeout -> retry fires
+    await vi.advanceTimersByTimeAsync(10_000); // retry's own timeout -> should NOT retry again
+
+    expect(bridgeCalls.filter(c => c.cmd === 'reset_path')).toHaveLength(1);
+    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(2);
+  });
+
+  it('cancels the retry if the ack for the flood resend arrives', async () => {
+    const { manager, bridgeCalls } = makeManager();
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000); // first timeout -> retry fires with ackCrc=222
+    sendConfirmed(manager, 222);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(2);
+  });
+
+  it('does not schedule a retry for channel/broadcast sends', async () => {
+    const { manager, bridgeCalls } = makeManager();
+
+    await manager.sendMessageWithResult('hello', undefined, 0);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(1);
+    expect(bridgeCalls.some(c => c.cmd === 'reset_path')).toBe(false);
+  });
+
+  it('clears pending retry timers on disconnect so a torn-down manager cannot retry', async () => {
+    const { manager, bridgeCalls } = makeManager();
+    vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    expect((manager as any).pendingDmRetries.size).toBe(1);
+
+    await manager.disconnect();
+    expect((manager as any).pendingDmRetries.size).toBe(0);
+
+    const callsBefore = bridgeCalls.length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(bridgeCalls.length).toBe(callsBefore);
+  });
+});

--- a/src/server/meshcoreManager.dmRetry.test.ts
+++ b/src/server/meshcoreManager.dmRetry.test.ts
@@ -1,17 +1,20 @@
 /**
- * Tests for MeshCore DM auto-retry-via-flood on ack timeout (#3977).
+ * Tests for MeshCore DM auto-retry on ack timeout (#3977).
  *
- * A DM sent on a stale cached path just goes out once today and is never
- * retried, so it silently never arrives. This automates exactly what the
- * existing "Reset Path" button already does by hand: if no `SendConfirmed`
- * ack arrives within the firmware's own `estTimeout` (+margin), reset the
- * contact's cached path and resend once via flood. The retry's own send is
- * not itself tracked — a second miss is left to the frontend's existing
- * per-message ack timer, exactly as any other unacked send today.
+ * A DM sent on a stale cached path used to go out once and never retry, so it
+ * silently never arrived. This replicates the official MeshCore app cadence
+ * (MeshCore FAQ §5.3): on each ack timeout, resend on the CURRENT cached path
+ * `DM_SAME_PATH_RETRIES` (2) times, then reset the path and resend via flood
+ * `DM_FLOOD_RETRIES` (1) time, then give up and mark the message failed. The
+ * whole sequence reuses the ORIGINAL message — it never creates a second bubble
+ * / DB row; instead it re-points the message's tracked ack CRC via
+ * `emitMeshCoreMessageUpdated` and settles on `delivered` (any ACK) or `failed`
+ * (all retries exhausted).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
 import databaseService from '../services/database.js';
+import { dataEventEmitter } from './services/dataEventEmitter.js';
 
 interface BridgeCall { cmd: string; params: Record<string, unknown>; }
 
@@ -30,7 +33,13 @@ function makeManager(opts: {
 
   const bridgeCalls: BridgeCall[] = [];
   let sendIdx = 0;
-  const sends = opts.sends ?? [{ ackCrc: 111, estTimeout: 8000 }, { ackCrc: 222, estTimeout: 8000 }];
+  // Distinct CRC per attempt so the retry sequence re-points cleanly.
+  const sends = opts.sends ?? [
+    { ackCrc: 111, estTimeout: 8000 },
+    { ackCrc: 222, estTimeout: 8000 },
+    { ackCrc: 333, estTimeout: 8000 },
+    { ackCrc: 444, estTimeout: 8000 },
+  ];
 
   (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
     bridgeCalls.push({ cmd, params });
@@ -69,6 +78,8 @@ function sendConfirmed(m: MeshCoreManager, ackCode: number): void {
 }
 
 const PUBKEY = 'bob'.padEnd(64, '0');
+const sends = (calls: BridgeCall[]) => calls.filter(c => c.cmd === 'send_message');
+const resets = (calls: BridgeCall[]) => calls.filter(c => c.cmd === 'reset_path');
 
 describe('MeshCoreManager — DM ack-timeout auto-retry (#3977)', () => {
   beforeEach(() => {
@@ -88,83 +99,173 @@ describe('MeshCoreManager — DM ack-timeout auto-retry (#3977)', () => {
 
     await vi.advanceTimersByTimeAsync(20_000);
 
-    const sendCalls = bridgeCalls.filter(c => c.cmd === 'send_message');
-    expect(sendCalls).toHaveLength(1);
-    expect(bridgeCalls.some(c => c.cmd === 'reset_path')).toBe(false);
+    expect(sends(bridgeCalls)).toHaveLength(1);
+    expect(resets(bridgeCalls)).toHaveLength(0);
+    expect((manager as any).pendingDmRetries.size).toBe(0);
   });
 
-  it('resets the path and resends once via flood when no ack arrives in time', async () => {
+  it('resends on the CURRENT path (no reset) for the first same-path retries', async () => {
     const { manager, bridgeCalls } = makeManager();
 
     await manager.sendMessageWithResult('hello', PUBKEY);
-    // No send_confirmed dispatched — let the ack timeout (estTimeout=8000, +20% margin) fire.
+
+    // First timeout -> same-path retry #1 (no reset).
     await vi.advanceTimersByTimeAsync(10_000);
+    expect(sends(bridgeCalls)).toHaveLength(2);
+    expect(resets(bridgeCalls)).toHaveLength(0);
+    expect(sends(bridgeCalls)[1].params.to).toBe(PUBKEY);
 
-    const resetCalls = bridgeCalls.filter(c => c.cmd === 'reset_path');
-    expect(resetCalls).toHaveLength(1);
-    expect(resetCalls[0].params.public_key).toBe(PUBKEY);
-
-    const sendCalls = bridgeCalls.filter(c => c.cmd === 'send_message');
-    expect(sendCalls).toHaveLength(2);
-    expect(sendCalls[1].params.text).toBe('hello');
-    expect(sendCalls[1].params.to).toBe(PUBKEY);
+    // Second timeout -> same-path retry #2 (still no reset).
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sends(bridgeCalls)).toHaveLength(3);
+    expect(resets(bridgeCalls)).toHaveLength(0);
   });
 
-  it('gives up silently if the flood retry also goes unacked (no second retry)', async () => {
+  it('falls back to flood (reset path) only after same-path retries are exhausted', async () => {
     const { manager, bridgeCalls } = makeManager();
 
     await manager.sendMessageWithResult('hello', PUBKEY);
-    await vi.advanceTimersByTimeAsync(10_000); // first timeout -> retry fires
-    await vi.advanceTimersByTimeAsync(10_000); // retry's own timeout -> should NOT retry again
+    await vi.advanceTimersByTimeAsync(10_000); // same-path retry #1
+    await vi.advanceTimersByTimeAsync(10_000); // same-path retry #2
+    expect(resets(bridgeCalls)).toHaveLength(0);
 
-    expect(bridgeCalls.filter(c => c.cmd === 'reset_path')).toHaveLength(1);
-    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(2);
+    // Third timeout -> path is reset and the message floods.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(resets(bridgeCalls)).toHaveLength(1);
+    expect(resets(bridgeCalls)[0].params.public_key).toBe(PUBKEY);
+    expect(sends(bridgeCalls)).toHaveLength(4);
+    expect(sends(bridgeCalls)[3].params.to).toBe(PUBKEY);
   });
 
-  it('does not resend when reset_path itself fails', async () => {
+  it('marks the message failed after all same-path + flood retries are exhausted', async () => {
+    const { manager, bridgeCalls } = makeManager();
+    const updated = vi.spyOn(dataEventEmitter, 'emitMeshCoreMessageUpdated');
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000); // same-path #1
+    await vi.advanceTimersByTimeAsync(10_000); // same-path #2
+    await vi.advanceTimersByTimeAsync(10_000); // flood
+    await vi.advanceTimersByTimeAsync(10_000); // exhausted -> failed
+
+    // 1 initial + 2 same-path + 1 flood = 4 total, exactly one reset.
+    expect(sends(bridgeCalls)).toHaveLength(4);
+    expect(resets(bridgeCalls)).toHaveLength(1);
+
+    // A terminal 'failed' status was emitted for the single message.
+    const failedCalls = updated.mock.calls.filter(c => (c[0] as any).deliveryStatus === 'failed');
+    expect(failedCalls).toHaveLength(1);
+    expect((manager as any).pendingDmRetries.size).toBe(0);
+
+    // No further sends after exhaustion.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(sends(bridgeCalls)).toHaveLength(4);
+  });
+
+  it('keeps a SINGLE bubble: retries update the original message, never emit a new one', async () => {
+    const { manager } = makeManager();
+    const newMessage = vi.spyOn(dataEventEmitter, 'emitMeshCoreMessage');
+    const updated = vi.spyOn(dataEventEmitter, 'emitMeshCoreMessageUpdated');
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    const originalId = (manager as any).messages[0].id;
+
+    // Exactly one new-message emit — the original send.
+    expect(newMessage).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000); // same-path retry #1
+
+    // Still only one new-message emit; the retry updated the original instead.
+    expect(newMessage).toHaveBeenCalledTimes(1);
+    // No second message row was persisted.
+    expect((manager as any).messages).toHaveLength(1);
+
+    // The update re-points the SAME message id from CRC 111 -> 222.
+    const call = updated.mock.calls.at(-1)![0] as any;
+    expect(call.id).toBe(originalId);
+    expect(call.previousAckCrc).toBe(111);
+    expect(call.expectedAckCrc).toBe(222);
+    expect(call.deliveryStatus).toBe('sent');
+
+    // The in-memory message tracks the latest attempt's CRC.
+    expect((manager as any).messages[0].expectedAckCrc).toBe(222);
+  });
+
+  it('settles delivered (cancels the sequence) when a later attempt is acked', async () => {
+    const { manager, bridgeCalls } = makeManager();
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000); // same-path retry #1 -> CRC 222
+    sendConfirmed(manager, 222);               // ack for the retry
+    await vi.advanceTimersByTimeAsync(30_000); // no further retries should fire
+
+    expect(sends(bridgeCalls)).toHaveLength(2);
+    expect((manager as any).pendingDmRetries.size).toBe(0);
+  });
+
+  it('does not resend when reset_path itself fails (flood impossible)', async () => {
     const { manager, bridgeCalls } = makeManager({ resetPathOk: false });
+    const updated = vi.spyOn(dataEventEmitter, 'emitMeshCoreMessageUpdated');
 
     await manager.sendMessageWithResult('hello', PUBKEY);
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(10_000); // same-path #1
+    await vi.advanceTimersByTimeAsync(10_000); // same-path #2
+    await vi.advanceTimersByTimeAsync(10_000); // flood attempt -> reset_path fails
 
-    expect(bridgeCalls.filter(c => c.cmd === 'reset_path')).toHaveLength(1);
-    // Only the original send — the resend never fires since reset_path failed.
-    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(1);
-  });
-
-  it('cancels the retry if the ack for the flood resend arrives', async () => {
-    const { manager, bridgeCalls } = makeManager();
-
-    await manager.sendMessageWithResult('hello', PUBKEY);
-    await vi.advanceTimersByTimeAsync(10_000); // first timeout -> retry fires with ackCrc=222
-    sendConfirmed(manager, 222);
-    await vi.advanceTimersByTimeAsync(10_000);
-
-    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(2);
+    expect(resets(bridgeCalls)).toHaveLength(1);
+    // 1 initial + 2 same-path only; the flood resend never fires.
+    expect(sends(bridgeCalls)).toHaveLength(3);
+    // The failed flood marks the message failed.
+    expect(updated.mock.calls.some(c => (c[0] as any).deliveryStatus === 'failed')).toBe(true);
   });
 
   it('does not schedule a retry for channel/broadcast sends', async () => {
     const { manager, bridgeCalls } = makeManager();
 
     await manager.sendMessageWithResult('hello', undefined, 0);
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(40_000);
 
-    expect(bridgeCalls.filter(c => c.cmd === 'send_message')).toHaveLength(1);
-    expect(bridgeCalls.some(c => c.cmd === 'reset_path')).toBe(false);
+    expect(sends(bridgeCalls)).toHaveLength(1);
+    expect(resets(bridgeCalls)).toHaveLength(0);
+    expect((manager as any).pendingDmRetries.size).toBe(0);
   });
 
-  it('clears pending retry timers on disconnect so a torn-down manager cannot retry', async () => {
+  it('learns/persists the new path when a flood ack arrives (contact_path_updated)', async () => {
+    const { manager, bridgeCalls } = makeManager();
+    // schedulePathRefresh is the existing entry point that re-reads and
+    // persists the firmware-learned route (debounced); assert the flood-ack
+    // push still drives it (path persistence "exactly like PathUpdated").
+    const refresh = vi.spyOn(manager as any, 'schedulePathRefresh').mockImplementation(() => {});
+
+    await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000); // same-path #1
+    await vi.advanceTimersByTimeAsync(10_000); // same-path #2
+    await vi.advanceTimersByTimeAsync(10_000); // flood (reset + resend)
+    expect(resets(bridgeCalls)).toHaveLength(1);
+
+    // Firmware auto-emits contact_path_updated after the flood ACK teaches the
+    // route; the existing handler persists it onto the contact.
+    // @ts-expect-error - exercising private handler
+    manager.handleBridgeEvent({
+      event_type: 'contact_path_updated',
+      data: { public_key: PUBKEY },
+    });
+
+    expect(refresh).toHaveBeenCalledWith(PUBKEY);
+  });
+
+  it('clears pending retry timers on disconnect mid-sequence so a torn-down manager cannot retry', async () => {
     const { manager, bridgeCalls } = makeManager();
     vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
 
     await manager.sendMessageWithResult('hello', PUBKEY);
+    await vi.advanceTimersByTimeAsync(10_000); // one same-path retry, mid-sequence
     expect((manager as any).pendingDmRetries.size).toBe(1);
 
     await manager.disconnect();
     expect((manager as any).pendingDmRetries.size).toBe(0);
 
     const callsBefore = bridgeCalls.length;
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(40_000);
     expect(bridgeCalls.length).toBe(callsBefore);
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -657,6 +657,18 @@ class MeshCoreManager extends EventEmitter {
    */
   private pendingChannelSends: Map<string, { channelIdx: number; sentAt: number }> = new Map();
 
+  /**
+   * Pending DM sends awaiting a `SendConfirmed` ack, keyed by the firmware's
+   * `expectedAckCrc` (#3977). If the ack doesn't arrive within `estTimeout`
+   * (+margin), the cached path is likely stale — reset it and resend once via
+   * flood, mirroring what the "Reset Path" button already does manually. Only
+   * ever holds *first-attempt* entries: the retry's own ack isn't re-tracked
+   * here, so a second timeout is a silent no-op (no retry loop) and the
+   * frontend's own per-message ack timer flips that message to "failed",
+   * same as it does for any other unacked send today.
+   */
+  private pendingDmRetries: Map<number, { toPublicKey: string; text: string; timer: NodeJS.Timeout }> = new Map();
+
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
 
@@ -1050,6 +1062,13 @@ class MeshCoreManager extends EventEmitter {
     }
     this.pendingCommands.clear();
 
+    // Clear pending DM ack-retry timers (#3977) — a torn-down connection
+    // can't reset a path or resend, so don't let a stray timer try.
+    for (const [, retry] of this.pendingDmRetries) {
+      clearTimeout(retry.timer);
+    }
+    this.pendingDmRetries.clear();
+
     this.connected = false;
     this.connectionState = 'disconnected';
     this.deviceType = MeshCoreDeviceType.UNKNOWN;
@@ -1333,6 +1352,13 @@ class MeshCoreManager extends EventEmitter {
         );
       }
     } else if (event_type === 'send_confirmed') {
+      // Ack arrived in time — cancel the auto-retry timer (#3977) so a
+      // stale-path resend doesn't fire after the fact.
+      const retryPending = this.pendingDmRetries.get(data.ack_code);
+      if (retryPending) {
+        clearTimeout(retryPending.timer);
+        this.pendingDmRetries.delete(data.ack_code);
+      }
       this.emit('send_confirmed', {
         sourceId: this.sourceId,
         ackCode: data.ack_code,
@@ -2591,7 +2617,13 @@ class MeshCoreManager extends EventEmitter {
     }
   }
 
-  private async performScopedSend(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<MeshCoreSendResult> {
+  private async performScopedSend(
+    text: string,
+    toPublicKey?: string,
+    channelIdx?: number,
+    scopeOverride?: string | null,
+    isAutoRetry: boolean = false,
+  ): Promise<MeshCoreSendResult> {
     try {
       const isChannelSend = !toPublicKey && channelIdx !== undefined;
 
@@ -2654,6 +2686,14 @@ class MeshCoreManager extends EventEmitter {
         this.emit('message', sentMessage);
         dataEventEmitter.emitMeshCoreMessage(sentMessage, this.sourceId);
 
+        // Auto-retry a DM once via flood if no ack arrives in time (#3977).
+        // Not for channel sends (unacked) and not for the retry's own send
+        // (isAutoRetry) — a second miss is left to the frontend's existing
+        // per-message ack timer, which already flips it to "failed".
+        if (!isChannelSend && toPublicKey && !isAutoRetry && ackCrc != null && estTimeout != null) {
+          this.scheduleDmAckTimeout(ackCrc, toPublicKey, text, estTimeout);
+        }
+
         // Register this channel send for self-echo correlation (#3700): a
         // nearby repeater that re-floods our packet will be heard back as an
         // inbound GRP_TXT OTA packet within HEARD_WINDOW_MS, naming the
@@ -2672,6 +2712,47 @@ class MeshCoreManager extends EventEmitter {
       logger.error('[MeshCore] Failed to send message:', error);
       return { ok: false };
     }
+  }
+
+  /**
+   * Arm the auto-retry timer for a just-sent DM (#3977). `estTimeout` is the
+   * firmware's own estimate for this send; a 20% margin absorbs normal jitter
+   * before treating it as a miss. Cleared early by the `send_confirmed`
+   * handler if the ack arrives first, and cleared in bulk on disconnect.
+   */
+  private scheduleDmAckTimeout(ackCrc: number, toPublicKey: string, text: string, estTimeout: number): void {
+    const timer = setTimeout(() => {
+      void this.handleDmAckTimeout(ackCrc);
+    }, Math.round(estTimeout * 1.2));
+    this.pendingDmRetries.set(ackCrc, { toPublicKey, text, timer });
+  }
+
+  /**
+   * No ack arrived for a DM within its estimated timeout (#3977). The cached
+   * path is presumably stale, so reset it (same effect as the manual "Reset
+   * Path" button) and resend once via flood — mirrors the official app's
+   * fallback behavior. This is a one-shot retry: the resend is not itself
+   * tracked here, so if it also goes unacked, nothing further happens
+   * automatically and the frontend's existing per-message ack timer marks it
+   * failed, same as any other unacked send.
+   */
+  private async handleDmAckTimeout(ackCrc: number): Promise<void> {
+    const pending = this.pendingDmRetries.get(ackCrc);
+    if (!pending) return; // already acked (or manager torn down) — nothing to do
+    this.pendingDmRetries.delete(ackCrc);
+
+    if (!this.connected) return;
+
+    logger.info(
+      `[MeshCore:${this.sourceId}] No ack for DM to ${pending.toPublicKey.substring(0, 16)}… within timeout; ` +
+      `resetting path and retrying via flood`,
+    );
+    const reset = await this.resetContactPath(pending.toPublicKey);
+    if (!reset) return;
+
+    await this.runSerialized(() =>
+      this.performScopedSend(pending.text, pending.toPublicKey, undefined, undefined, true),
+    );
   }
 
   /**

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2715,15 +2715,26 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Margin applied to the firmware's `estTimeout` before a DM send is treated
+   * as missed (#3977). Absorbs normal jitter; not itself a protocol constant.
+   */
+  private static readonly DM_ACK_TIMEOUT_MARGIN = 1.2;
+
+  /**
    * Arm the auto-retry timer for a just-sent DM (#3977). `estTimeout` is the
-   * firmware's own estimate for this send; a 20% margin absorbs normal jitter
-   * before treating it as a miss. Cleared early by the `send_confirmed`
-   * handler if the ack arrives first, and cleared in bulk on disconnect.
+   * firmware's own estimate for this send. Cleared early by the
+   * `send_confirmed` handler if the ack arrives first, and cleared in bulk
+   * on disconnect. If an entry already exists for this `ackCrc` (the
+   * firmware's CRC space is only 16 bits, so a collision between two
+   * in-flight DMs is unlikely but possible), its timer is cancelled first so
+   * it can't fire later with the wrong pending state.
    */
   private scheduleDmAckTimeout(ackCrc: number, toPublicKey: string, text: string, estTimeout: number): void {
+    const existing = this.pendingDmRetries.get(ackCrc);
+    if (existing) clearTimeout(existing.timer);
     const timer = setTimeout(() => {
       void this.handleDmAckTimeout(ackCrc);
-    }, Math.round(estTimeout * 1.2));
+    }, Math.round(estTimeout * MeshCoreManager.DM_ACK_TIMEOUT_MARGIN));
     this.pendingDmRetries.set(ackCrc, { toPublicKey, text, timer });
   }
 
@@ -2735,6 +2746,13 @@ class MeshCoreManager extends EventEmitter {
    * tracked here, so if it also goes unacked, nothing further happens
    * automatically and the frontend's existing per-message ack timer marks it
    * failed, same as any other unacked send.
+   *
+   * The reset+resend pair runs inside `runSerialized` (the same per-source
+   * lock `sendMessageWithResult` uses) so it can't interleave with a
+   * concurrent user-initiated send's scope-assert→send pair (#3667).
+   * `performScopedSend` is called directly rather than via
+   * `sendMessageWithResult`/another `runSerialized` — it's already
+   * serialized by this call.
    */
   private async handleDmAckTimeout(ackCrc: number): Promise<void> {
     const pending = this.pendingDmRetries.get(ackCrc);
@@ -2747,12 +2765,11 @@ class MeshCoreManager extends EventEmitter {
       `[MeshCore:${this.sourceId}] No ack for DM to ${pending.toPublicKey.substring(0, 16)}… within timeout; ` +
       `resetting path and retrying via flood`,
     );
-    const reset = await this.resetContactPath(pending.toPublicKey);
-    if (!reset) return;
-
-    await this.runSerialized(() =>
-      this.performScopedSend(pending.text, pending.toPublicKey, undefined, undefined, true),
-    );
+    await this.runSerialized(async () => {
+      const reset = await this.resetContactPath(pending.toPublicKey);
+      if (!reset || !this.connected) return;
+      await this.performScopedSend(pending.text, pending.toPublicKey, undefined, undefined, true);
+    });
   }
 
   /**

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -658,16 +658,32 @@ class MeshCoreManager extends EventEmitter {
   private pendingChannelSends: Map<string, { channelIdx: number; sentAt: number }> = new Map();
 
   /**
-   * Pending DM sends awaiting a `SendConfirmed` ack, keyed by the firmware's
-   * `expectedAckCrc` (#3977). If the ack doesn't arrive within `estTimeout`
-   * (+margin), the cached path is likely stale — reset it and resend once via
-   * flood, mirroring what the "Reset Path" button already does manually. Only
-   * ever holds *first-attempt* entries: the retry's own ack isn't re-tracked
-   * here, so a second timeout is a silent no-op (no retry loop) and the
-   * frontend's own per-message ack timer flips that message to "failed",
-   * same as it does for any other unacked send today.
+   * In-flight DM sends awaiting a `SendConfirmed` ack, keyed by the *current*
+   * attempt's firmware `expectedAckCrc` (#3977). If the ack doesn't arrive
+   * within `estTimeout` (+margin), the send is retried following the official
+   * MeshCore app's cadence (MeshCore FAQ §5.3): resend on the current cached
+   * path {@link DM_SAME_PATH_RETRIES} times, then reset the path and resend via
+   * flood {@link DM_FLOOD_RETRIES} time(s); learn the new path from whichever
+   * ACK arrives (firmware auto-emits `contact_path_updated`, persisted by the
+   * existing handler). A single logical send is represented by exactly one
+   * entry at a time — the map key is re-pointed to each new attempt's CRC and
+   * the original message row is *updated* (not duplicated) so the UI shows one
+   * bubble that ends `delivered` on any ACK or `failed` only after all attempts
+   * are exhausted.
    */
-  private pendingDmRetries: Map<number, { toPublicKey: string; text: string; timer: NodeJS.Timeout }> = new Map();
+  private pendingDmRetries: Map<
+    number,
+    {
+      messageId: string;
+      toPublicKey: string;
+      text: string;
+      /** Remaining same-path (current cached route) resends. */
+      samePathRetriesLeft: number;
+      /** Remaining flood (reset-path) resends after same-path exhausts. */
+      floodRetriesLeft: number;
+      timer: NodeJS.Timeout;
+    }
+  > = new Map();
 
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
@@ -2682,16 +2698,29 @@ class MeshCoreManager extends EventEmitter {
           // unscoped send leaves `scopeName` null, so it shows no scope row.
           scopeName: region ?? null,
         };
-        this.addMessage(sentMessage);
-        this.emit('message', sentMessage);
-        dataEventEmitter.emitMeshCoreMessage(sentMessage, this.sourceId);
+        // An auto-retry resend (#3977) must NOT create a second message row or
+        // re-emit a `message` event — that would produce a duplicate bubble in
+        // the UI and a duplicate DB row. The retry reuses the ORIGINAL message;
+        // `handleDmAckTimeout` updates that message's tracked ack CRC instead.
+        if (!isAutoRetry) {
+          this.addMessage(sentMessage);
+          this.emit('message', sentMessage);
+          dataEventEmitter.emitMeshCoreMessage(sentMessage, this.sourceId);
 
-        // Auto-retry a DM once via flood if no ack arrives in time (#3977).
-        // Not for channel sends (unacked) and not for the retry's own send
-        // (isAutoRetry) — a second miss is left to the frontend's existing
-        // per-message ack timer, which already flips it to "failed".
-        if (!isChannelSend && toPublicKey && !isAutoRetry && ackCrc != null && estTimeout != null) {
-          this.scheduleDmAckTimeout(ackCrc, toPublicKey, text, estTimeout);
+          // Arm the DM ack-timeout retry state machine for the first attempt
+          // (#3977). Not for channel sends (unacked). Subsequent attempts are
+          // armed directly by `handleDmAckTimeout`, not here.
+          if (!isChannelSend && toPublicKey && ackCrc != null && estTimeout != null) {
+            this.scheduleDmAckTimeout(
+              ackCrc,
+              msgId,
+              toPublicKey,
+              text,
+              estTimeout,
+              MeshCoreManager.DM_SAME_PATH_RETRIES,
+              MeshCoreManager.DM_FLOOD_RETRIES,
+            );
+          }
         }
 
         // Register this channel send for self-echo correlation (#3700): a
@@ -2721,55 +2750,184 @@ class MeshCoreManager extends EventEmitter {
   private static readonly DM_ACK_TIMEOUT_MARGIN = 1.2;
 
   /**
-   * Arm the auto-retry timer for a just-sent DM (#3977). `estTimeout` is the
-   * firmware's own estimate for this send. Cleared early by the
-   * `send_confirmed` handler if the ack arrives first, and cleared in bulk
-   * on disconnect. If an entry already exists for this `ackCrc` (the
-   * firmware's CRC space is only 16 bits, so a collision between two
-   * in-flight DMs is unlikely but possible), its timer is cancelled first so
-   * it can't fire later with the wrong pending state.
+   * Number of DM resends on the *current cached path* before falling back to
+   * flood (#3977). Matches the official MeshCore app / firmware default
+   * documented in MeshCore FAQ §5.3 ("the message will fail after 3 retries,
+   * and the app will reset the path and send the message as flood on the last
+   * retry"): 2 same-path retries + {@link DM_FLOOD_RETRIES} flood retry = 3
+   * retries total (≈4 transmissions including the initial send).
    */
-  private scheduleDmAckTimeout(ackCrc: number, toPublicKey: string, text: string, estTimeout: number): void {
+  private static readonly DM_SAME_PATH_RETRIES = 2;
+
+  /**
+   * Number of flood (reset-path) DM resends after the same-path retries are
+   * exhausted (#3977). Per MeshCore FAQ §5.3 the app floods on the last retry
+   * only, so the default is 1. The flood carries the source's default scope
+   * (see {@link performScopedSend}); the recipient's ACK teaches the new path,
+   * which the firmware auto-persists via the `contact_path_updated` push.
+   */
+  private static readonly DM_FLOOD_RETRIES = 1;
+
+  /**
+   * Arm (or re-arm) the ack-timeout retry timer for an in-flight DM attempt
+   * (#3977). `ackCrc` is the firmware's expected-ack CRC for *this* attempt and
+   * `estTimeout` its own timeout estimate; `samePathRetriesLeft` /
+   * `floodRetriesLeft` carry the remaining budget forward across attempts.
+   * Cleared early by the `send_confirmed` handler when the ack arrives, and in
+   * bulk on disconnect. If an entry already exists for this `ackCrc` (the
+   * firmware's CRC space is only 16 bits, so a collision between two in-flight
+   * DMs is unlikely but possible) its timer is cancelled first so it can't fire
+   * later with the wrong pending state.
+   */
+  private scheduleDmAckTimeout(
+    ackCrc: number,
+    messageId: string,
+    toPublicKey: string,
+    text: string,
+    estTimeout: number,
+    samePathRetriesLeft: number,
+    floodRetriesLeft: number,
+  ): void {
     const existing = this.pendingDmRetries.get(ackCrc);
     if (existing) clearTimeout(existing.timer);
     const timer = setTimeout(() => {
       void this.handleDmAckTimeout(ackCrc);
     }, Math.round(estTimeout * MeshCoreManager.DM_ACK_TIMEOUT_MARGIN));
-    this.pendingDmRetries.set(ackCrc, { toPublicKey, text, timer });
+    this.pendingDmRetries.set(ackCrc, {
+      messageId,
+      toPublicKey,
+      text,
+      samePathRetriesLeft,
+      floodRetriesLeft,
+      timer,
+    });
   }
 
   /**
-   * No ack arrived for a DM within its estimated timeout (#3977). The cached
-   * path is presumably stale, so reset it (same effect as the manual "Reset
-   * Path" button) and resend once via flood — mirrors the official app's
-   * fallback behavior. This is a one-shot retry: the resend is not itself
-   * tracked here, so if it also goes unacked, nothing further happens
-   * automatically and the frontend's existing per-message ack timer marks it
-   * failed, same as any other unacked send.
+   * No ack arrived for a DM attempt within its estimated timeout (#3977).
+   * Drives the official MeshCore retry cadence (FAQ §5.3):
+   *   1. While same-path retries remain → resend on the current cached path.
+   *   2. Once those exhaust, while flood retries remain → reset the cached path
+   *      (same effect as the manual "Reset Path" button) and resend via flood
+   *      with the default scope, letting the ACK teach a fresh path.
+   *   3. When all retries are exhausted → mark the message failed.
    *
-   * The reset+resend pair runs inside `runSerialized` (the same per-source
-   * lock `sendMessageWithResult` uses) so it can't interleave with a
-   * concurrent user-initiated send's scope-assert→send pair (#3667).
-   * `performScopedSend` is called directly rather than via
-   * `sendMessageWithResult`/another `runSerialized` — it's already
-   * serialized by this call.
+   * The resend reuses the ORIGINAL message (no new bubble / DB row): on success
+   * the original message's tracked ack CRC is updated and the retry timer is
+   * re-armed against the new CRC. The reset+resend pair runs inside
+   * `runSerialized` (the same per-source lock `sendMessageWithResult` uses) so
+   * it can't interleave with a concurrent user-initiated send's
+   * scope-assert→send pair (#3667). `performScopedSend` is called directly
+   * (already serialized by this call) with `isAutoRetry=true` so it neither
+   * creates a new message nor re-arms the timer itself.
    */
   private async handleDmAckTimeout(ackCrc: number): Promise<void> {
     const pending = this.pendingDmRetries.get(ackCrc);
     if (!pending) return; // already acked (or manager torn down) — nothing to do
     this.pendingDmRetries.delete(ackCrc);
 
-    if (!this.connected) return;
+    if (!this.connected) {
+      this.failDmDelivery(pending.messageId, ackCrc);
+      return;
+    }
+
+    const useFlood = pending.samePathRetriesLeft <= 0;
+    if (useFlood && pending.floodRetriesLeft <= 0) {
+      // All same-path and flood retries exhausted — give up.
+      logger.info(
+        `[MeshCore:${this.sourceId}] DM to ${pending.toPublicKey.substring(0, 16)}… still unacked after ` +
+        `all retries; marking failed`,
+      );
+      this.failDmDelivery(pending.messageId, ackCrc);
+      return;
+    }
 
     logger.info(
       `[MeshCore:${this.sourceId}] No ack for DM to ${pending.toPublicKey.substring(0, 16)}… within timeout; ` +
-      `resetting path and retrying via flood`,
+      `retrying via ${useFlood ? 'flood (reset path)' : 'current path'} ` +
+      `(samePathLeft=${pending.samePathRetriesLeft}, floodLeft=${pending.floodRetriesLeft})`,
     );
+
     await this.runSerialized(async () => {
-      const reset = await this.resetContactPath(pending.toPublicKey);
-      if (!reset || !this.connected) return;
-      await this.performScopedSend(pending.text, pending.toPublicKey, undefined, undefined, true);
+      if (!this.connected) {
+        this.failDmDelivery(pending.messageId, ackCrc);
+        return;
+      }
+      if (useFlood) {
+        const reset = await this.resetContactPath(pending.toPublicKey);
+        if (!reset) {
+          // Can't clear the path → can't flood; nothing more to try.
+          this.failDmDelivery(pending.messageId, ackCrc);
+          return;
+        }
+      }
+      const result = await this.performScopedSend(
+        pending.text,
+        pending.toPublicKey,
+        undefined,
+        undefined,
+        true,
+      );
+      if (!result.ok || result.expectedAckCrc == null || result.estTimeout == null) {
+        this.failDmDelivery(pending.messageId, ackCrc);
+        return;
+      }
+      // Re-point tracking to this attempt's CRC and update the single bubble.
+      this.updateDmAttempt(pending.messageId, ackCrc, result.expectedAckCrc, result.estTimeout);
+      this.scheduleDmAckTimeout(
+        result.expectedAckCrc,
+        pending.messageId,
+        pending.toPublicKey,
+        pending.text,
+        result.estTimeout,
+        useFlood ? pending.samePathRetriesLeft : pending.samePathRetriesLeft - 1,
+        useFlood ? pending.floodRetriesLeft - 1 : pending.floodRetriesLeft,
+      );
     });
+  }
+
+  /**
+   * A DM retry attempt was sent (#3977). Update the ORIGINAL message so the UI
+   * keeps a single bubble that now tracks the new attempt's ack CRC — a later
+   * `send_confirmed` for `newAckCrc` flips it to `delivered`, and the frontend
+   * re-arms its own per-message fail timer against the new CRC (clearing the
+   * previous one). Keeps the in-memory copy's CRC in sync too, so a reconnect
+   * snapshot / a `send_confirmed` correlates against the current attempt.
+   */
+  private updateDmAttempt(
+    messageId: string,
+    previousAckCrc: number,
+    newAckCrc: number,
+    newEstTimeout: number,
+  ): void {
+    const msg = this.messages.find((m) => m.id === messageId);
+    if (msg) {
+      msg.expectedAckCrc = newAckCrc;
+      msg.estTimeout = newEstTimeout;
+    }
+    dataEventEmitter.emitMeshCoreMessageUpdated(
+      {
+        id: messageId,
+        previousAckCrc,
+        expectedAckCrc: newAckCrc,
+        estTimeout: newEstTimeout,
+        deliveryStatus: 'sent',
+      },
+      this.sourceId,
+    );
+  }
+
+  /**
+   * All DM retries for a message are exhausted (or the send couldn't be made) —
+   * mark it failed in the UI (#3977). Clears the frontend's fail timer for the
+   * last attempt's CRC so the single bubble settles on `failed` deterministically
+   * rather than relying on that timer to eventually fire.
+   */
+  private failDmDelivery(messageId: string, lastAckCrc: number): void {
+    dataEventEmitter.emitMeshCoreMessageUpdated(
+      { id: messageId, previousAckCrc: lastAckCrc, deliveryStatus: 'failed' },
+      this.sourceId,
+    );
   }
 
   /**

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -26,6 +26,7 @@ export type DataEventType =
   | 'waypoint:deleted'
   | 'waypoint:expired'
   | 'meshcore:message'
+  | 'meshcore:message:updated'
   | 'meshcore:contact:updated'
   | 'meshcore:status:updated'
   | 'meshcore:local-node:updated'
@@ -315,6 +316,34 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] MeshCore message from ${message.fromPublicKey}`);
+  }
+
+  /**
+   * Emit a MeshCore DM delivery-tracking update for an existing message (#3977).
+   * Fired as the ack-timeout retry state machine re-sends a DM: it re-points the
+   * message's tracked `expectedAckCrc`/`estTimeout` to the latest attempt (so the
+   * single bubble keeps resolving on the current CRC) or marks it `failed` once
+   * all retries are exhausted. `previousAckCrc` lets the client cancel the fail
+   * timer it armed for the prior attempt's CRC.
+   */
+  emitMeshCoreMessageUpdated(
+    data: {
+      id: string;
+      previousAckCrc?: number;
+      expectedAckCrc?: number;
+      estTimeout?: number;
+      deliveryStatus?: 'sending' | 'sent' | 'delivered' | 'failed';
+    },
+    sourceId: string,
+  ): void {
+    const event: DataEvent = {
+      type: 'meshcore:message:updated',
+      data: { sourceId, ...data },
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] MeshCore message updated: ${data.id} (status=${data.deliveryStatus ?? 'sent'})`);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixes #3977 — MeshCore DMs sent on a stale cached path went out once and were never retried, so they silently never arrived.
- Implements the official MeshCore app's retry cadence (MeshCore FAQ §5.3): on ack timeout, resend on the **current cached path** up to `DM_SAME_PATH_RETRIES` (2) times; once those are exhausted, reset the cached path (same effect as the existing manual "Reset Path" button) and resend via **flood** up to `DM_FLOOD_RETRIES` (1) time; if still unacked, mark the message failed. That's 2 same-path + 1 flood = 3 retries, 4 transmissions total including the initial send.
- **Single bubble, not a duplicate**: an auto-retry resend reuses the *original* message row — it does not create a new message or re-emit a `message` event. Instead, each retry re-points the original message's tracked `expectedAckCrc`/`estTimeout` via a new `meshcore:message:updated` event, so the UI shows one message bubble that ends in `delivered` (any ACK) or `failed` (all retries exhausted) — never a duplicated/contradictory pair of bubbles.
- Channel/broadcast sends are unaffected (unacked by design, never register a retry).
- Pending retry timers are cleared on `disconnect()`, alongside the existing `pendingCommands` cleanup.
- Went through two rounds of automated PR review; all flagged issues (ackCrc-collision timer leak, `reset_path` running outside the serialized send queue, a redundant-but-cheap `connected` re-check, and test coverage for the `reset_path` failure path) were fixed and verified. See PR comments for details, including a documented analysis of one review suggestion that turned out to be a false positive on closer trace-through of the CRC hand-off between attempts.

## Changes

- `src/server/meshcoreManager.ts`:
  - `pendingDmRetries` map keyed by the firmware's `expectedAckCrc`, carrying remaining same-path/flood retry budget per in-flight DM.
  - `performScopedSend` arms the initial retry timer for DM sends (not channel sends, not retry resends themselves — gated by `isAutoRetry`).
  - The `send_confirmed` bridge-event handler cancels the timer when the ack matches.
  - `scheduleDmAckTimeout` / `handleDmAckTimeout` drive the same-path → flood → fail cadence; `updateDmAttempt` / `failDmDelivery` re-point or terminate the tracked message via `emitMeshCoreMessageUpdated`.
  - `disconnect()` clears any pending retry timers.
- `src/server/services/dataEventEmitter.ts`: new `emitMeshCoreMessageUpdated` event.
- `src/components/MeshCore/hooks/useMeshCore.ts`: `onMessageUpdated` handler keeps a single message bubble in sync across retries, re-arming its own client-side fail-safe timer against each new CRC.
- `src/server/meshcoreManager.dmRetry.test.ts`: covers ack-before-timeout, same-path retries, flood fallback after same-path exhaustion, terminal failure after all retries, single-bubble behavior (no duplicate emits), `reset_path` failure, channel-send exclusion, and timer cleanup on disconnect.

## Test plan

- [x] `npx vitest run src/server/meshcoreManager` — 251 tests passing (existing + new).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint src/server/meshcoreManager.ts` — no new errors (pre-existing repo-wide findings confirmed present on `main` independent of this change).
- [ ] Full `npx vitest run` — only pre-existing failures unrelated to MeshCore (missing `protobufs/meshtastic/*.proto` asset in this sandbox, confirmed present on `main` before this branch).
- [ ] Not yet verified against real hardware exhibiting a broken path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9S9qVAj7jW912hpYscXJW