### PR TITLE
feat(automations): multi-channel message trigger OR-list (#3974)

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -56,7 +56,7 @@ Every automation has exactly one trigger (the **WHEN**). Each trigger exposes a 
 
 | Trigger | Fires when… | Notable options |
 | --- | --- | --- |
-| **A message is received** | A text/packet message arrives | `Text contains` (case-insensitive substring), `Text matches regex`, channel match, `From node #` |
+| **A message is received** | A text/packet message arrives | `Text contains` (case-insensitive substring), `Text matches regex`, multi-channel match (`On channels` OR-list), legacy `On channel (name)`/`On channel #`, `From node #` |
 | **A new node is discovered** | A node is seen for the first time | — |
 | **A node is updated** | A node record changes (name, role, position, …) | — |
 | **Telemetry is received** | A telemetry reading arrives | `Metric` filter (battery, voltage, temperature, channel utilization, air util TX, …) |
@@ -67,9 +67,23 @@ Every automation has exactly one trigger (the **WHEN**). Each trigger exposes a 
 ### Message trigger & channel-name matching
 
 The message trigger can filter on text (substring or regex) and on the **channel**. Prefer matching
-by **channel name** (`On channel (name)`) rather than raw slot index: the same logical channel can
-sit in a different slot on different sources, so a name match is portable across your whole mesh.
-The raw `On channel #` index is still available for single-source cases.
+by **channel name** rather than raw slot index: the same logical channel can sit in a different slot
+on different sources, so a name match is portable across your whole mesh.
+
+- **On channels** *(multi-select)* — pick one or more channels (unified by name across your
+  sources). The trigger fires when a message arrives on **any** of the selected channels — an
+  OR-list — so a single automation can cover "channel A **or** channel C" without a separate copy
+  per channel. Leave none selected to match any channel. When set, this **overrides** the two
+  single-channel fields below. Matching is by channel name and works for both Meshtastic and
+  MeshCore messages.
+- **On channel (name)** — legacy single-channel name match (case-insensitive). Kept for
+  backward compatibility with existing automations; the multi-select `On channels` above is
+  preferred. Ignored when `On channels` is set.
+- **On channel #** — the raw slot index, still available for single-source cases. Ignored when
+  `On channels` is set.
+
+Saved automations that used the old single-channel fields keep working unchanged — no migration
+is needed.
 
 ### Schedule trigger (live cron)
 

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -47,8 +47,9 @@ export const TRIGGERS: BlockDef[] = [
     fields: [
       { name: 'textContains', label: 'Text contains', kind: 'text', placeholder: 'e.g. ping', help: 'Case-insensitive substring match. Leave blank to match any text.' },
       { name: 'regex', label: 'Text matches regex', kind: 'text', placeholder: 'e.g. ^(test|ping)', advanced: true, help: 'A regular expression matched against the message text.' },
-      { name: 'channelName', label: 'On channel (name)', kind: 'text', placeholder: 'any', advanced: true, help: 'Match by channel name (case-insensitive) — portable across sources where the same channel sits in a different slot. Preferred over the channel # below.' },
-      { name: 'channel', label: 'On channel #', kind: 'number', placeholder: 'any', advanced: true, help: 'Match by raw channel index. Note: the same channel can be a different index on different sources — use the name above for cross-source automations.' },
+      { name: 'channels', label: 'On channels', kind: 'channelMulti', advanced: true, help: 'Match messages that arrive on ANY of these channels (unified by name across your sources). An OR-list — leave none to match any channel. When set, this overrides the single-channel fields below.' },
+      { name: 'channelName', label: 'On channel (name)', kind: 'text', placeholder: 'any', advanced: true, help: 'Match by channel name (case-insensitive) — portable across sources where the same channel sits in a different slot. Preferred over the channel # below. Ignored when "On channels" above is set.' },
+      { name: 'channel', label: 'On channel #', kind: 'number', placeholder: 'any', advanced: true, help: 'Match by raw channel index. Note: the same channel can be a different index on different sources — use the name above for cross-source automations. Ignored when "On channels" above is set.' },
       { name: 'from', label: 'From node #', kind: 'number', placeholder: 'any', advanced: true, help: 'Only fire for messages from this node number.' },
       COOLDOWN,
     ],

--- a/src/components/automations/compile.test.ts
+++ b/src/components/automations/compile.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { compile, decompile, type WorkflowForm } from './compile.js';
 import { validateAutomationGraph } from '../../types/automation.js';
+import { TRIGGERS } from './catalog.js';
 
 const trig = { type: 'trigger.message', params: { textContains: 'ping' } };
 const cond = (value: number) => ({ type: 'condition.numeric', params: { field: 'hops', op: '==', value } });
@@ -161,5 +162,32 @@ describe('decompile — fall-back to null', () => {
     expect(back!.rules).toHaveLength(1);
     expect(back!.rules[0].conditions).toHaveLength(0);
     expect(back!.rules[0].actions[0].type).toBe('action.tapback');
+  });
+});
+
+describe('trigger.message catalog — multi-channel field (#3974)', () => {
+  const trigMsg = TRIGGERS.find((t) => t.type === 'trigger.message')!;
+
+  it('exposes a channelMulti "channels" field', () => {
+    const f = trigMsg.fields.find((x) => x.name === 'channels');
+    expect(f).toBeDefined();
+    expect(f!.kind).toBe('channelMulti');
+  });
+
+  it('keeps the legacy scalar channelName/channel fields for backward compat', () => {
+    expect(trigMsg.fields.some((x) => x.name === 'channelName' && x.kind === 'text')).toBe(true);
+    expect(trigMsg.fields.some((x) => x.name === 'channel' && x.kind === 'number')).toBe(true);
+  });
+
+  it('round-trips a channels array through compile/decompile', () => {
+    const channels = [{ name: 'gauntlet', protocol: 'meshtastic' }, { name: 'ops', protocol: 'meshtastic' }];
+    const form: WorkflowForm = {
+      trigger: { type: 'trigger.message', params: { channels } },
+      rules: [{ conditions: [], actions: [{ type: 'action.tapback', params: { emoji: '👍' } }] }],
+      combine: null,
+    };
+    const back = decompile(compile(form));
+    expect(back).not.toBeNull();
+    expect(back!.trigger.params).toEqual({ channels });
   });
 });

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -145,6 +145,31 @@ describe('AutomationEngineService', () => {
     expect(calls.map((c) => c.fn)).toEqual(['sendTapback']);
   });
 
+  it('matches a message trigger by the multi-channel OR-list, resolving slot→name (#3974)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('on-gauntlet-or-ops', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { channels: [{ name: 'gauntlet', protocol: 'meshtastic' }, { name: 'ops', protocol: 'meshtastic' }] } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    // Slot 2 = "Gauntlet", slot 3 = "Ops", everything else "Primary".
+    const chData = {
+      getNode: async () => null,
+      getTelemetry: async () => null,
+      getChannelName: async (_sourceId: string | null, idx: number) => (idx === 2 ? 'Gauntlet' : idx === 3 ? 'Ops' : 'Primary'),
+    };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: chData, now: () => clock });
+    await engine.load();
+
+    expect(await engine.onMessage(message({ channel: 2 }), 'default')).toBe(1); // matches "gauntlet"
+    expect(await engine.onMessage(message({ channel: 3 }), 'default')).toBe(1); // matches "ops"
+    expect(await engine.onMessage(message({ channel: 0 }), 'default')).toBe(0); // "Primary" in neither
+    expect(calls.map((c) => c.fn)).toEqual(['sendTapback', 'sendTapback']);
+  });
+
   it('fires a message automation on a MeshCore message and replies on the trigger scope (#3833)', async () => {
     const { calls, deps } = recorder();
     await createEnabled('mc-ping', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -33,6 +33,7 @@ import {
   meshCoreMessageMatchesFilter,
   describeMessageFilterMiss,
   describeMeshCoreFilterMiss,
+  messageFilterUsesChannelName,
   type TriggerContext,
   type SystemEvent,
 } from './triggerContext.js';
@@ -384,7 +385,7 @@ export class AutomationEngineService {
     let channelName: string | null | undefined;
     const usesChannelName = (this.index.get('trigger.message') ?? []).some((a) => {
       const p = a.triggerNode.params as Record<string, unknown> | undefined;
-      return typeof p?.channelName === 'string' && p.channelName.length > 0;
+      return messageFilterUsesChannelName(p ?? {});
     });
     if (usesChannelName && this.data.getChannelName) {
       channelName = await this.data.getChannelName(sourceId, Number(msg.channel));
@@ -408,7 +409,7 @@ export class AutomationEngineService {
     let channelName: string | null | undefined;
     const usesChannelName = (this.index.get('trigger.message') ?? []).some((a) => {
       const p = a.triggerNode.params as Record<string, unknown> | undefined;
-      return typeof p?.channelName === 'string' && p.channelName.length > 0;
+      return messageFilterUsesChannelName(p ?? {});
     });
     // A received channel message stores its slot index in `from` as `channel-<idx>`.
     const channelIdx = ctx.fields.channel;

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -11,6 +11,8 @@ import {
   meshCoreMessageMatchesFilter,
   describeMessageFilterMiss,
   describeMeshCoreFilterMiss,
+  messageFilterChannelNames,
+  messageFilterUsesChannelName,
   resolveTriggerPath,
   BROADCAST_ADDR,
 } from './triggerContext.js';
@@ -137,6 +139,103 @@ describe('messageMatchesFilter', () => {
   });
   it('an empty channelName does not constrain', () => {
     expect(messageMatchesFilter(msg(), { channelName: '' }, null)).toBe(true);
+  });
+});
+
+describe('multi-channel trigger filter (#3974)', () => {
+  const chans = (...names: string[]) => names.map((name) => ({ name, protocol: 'meshtastic' }));
+
+  describe('messageFilterChannelNames', () => {
+    it('extracts non-empty names from the channels array', () => {
+      expect(messageFilterChannelNames({ channels: chans('gauntlet', 'ops') })).toEqual(['gauntlet', 'ops']);
+    });
+    it('drops blank names and ignores non-object entries', () => {
+      expect(messageFilterChannelNames({ channels: [{ name: '' }, { name: 'ops' }, 'x', null, {}] })).toEqual(['ops']);
+    });
+    it('returns [] when channels is absent or not an array', () => {
+      expect(messageFilterChannelNames({})).toEqual([]);
+      expect(messageFilterChannelNames({ channels: 'nope' })).toEqual([]);
+    });
+  });
+
+  describe('messageFilterUsesChannelName', () => {
+    it('is true for a scalar channelName', () => {
+      expect(messageFilterUsesChannelName({ channelName: 'gauntlet' })).toBe(true);
+    });
+    it('is true for a populated channels array', () => {
+      expect(messageFilterUsesChannelName({ channels: chans('gauntlet') })).toBe(true);
+    });
+    it('is false when neither is set / all blank', () => {
+      expect(messageFilterUsesChannelName({})).toBe(false);
+      expect(messageFilterUsesChannelName({ channelName: '' })).toBe(false);
+      expect(messageFilterUsesChannelName({ channels: [{ name: '' }] })).toBe(false);
+    });
+  });
+
+  describe('messageMatchesFilter OR-list (Meshtastic)', () => {
+    it('fires when the resolved name matches ANY entry (case-insensitive)', () => {
+      expect(messageMatchesFilter(msg(), { channels: chans('gauntlet', 'ops') }, 'Gauntlet')).toBe(true);
+      expect(messageMatchesFilter(msg(), { channels: chans('gauntlet', 'ops') }, 'OPS')).toBe(true);
+    });
+    it('does not fire when the resolved name matches no entry', () => {
+      expect(messageMatchesFilter(msg(), { channels: chans('gauntlet', 'ops') }, 'Primary')).toBe(false);
+    });
+    it('never matches when the name could not be resolved', () => {
+      expect(messageMatchesFilter(msg(), { channels: chans('gauntlet') }, null)).toBe(false);
+      expect(messageMatchesFilter(msg(), { channels: chans('gauntlet') })).toBe(false);
+    });
+    it('an empty channels array is a legacy fallback (does not constrain)', () => {
+      expect(messageMatchesFilter(msg(), { channels: [] }, null)).toBe(true);
+      // empty array + legacy scalar channelName still honors the scalar
+      expect(messageMatchesFilter(msg(), { channels: [], channelName: 'ops' }, 'Ops')).toBe(true);
+      expect(messageMatchesFilter(msg(), { channels: [], channelName: 'ops' }, 'Primary')).toBe(false);
+    });
+    it('channels takes precedence over the legacy scalar channel/channelName', () => {
+      // channels wins: the mismatched legacy scalar channelName is ignored.
+      expect(messageMatchesFilter(msg(), { channels: chans('ops'), channelName: 'gauntlet' }, 'Ops')).toBe(true);
+      // channels wins: the legacy numeric channel is ignored (msg.channel = 0, would fail on channel:2).
+      expect(messageMatchesFilter(msg(), { channels: chans('ops'), channel: 2 }, 'Ops')).toBe(true);
+    });
+    it('still applies text/regex checks alongside the channel OR-list', () => {
+      expect(messageMatchesFilter(msg({ text: 'ping' }), { channels: chans('ops'), textContains: 'ping' }, 'Ops')).toBe(true);
+      expect(messageMatchesFilter(msg({ text: 'pong' }), { channels: chans('ops'), textContains: 'ping' }, 'Ops')).toBe(false);
+    });
+  });
+
+  describe('meshCoreMessageMatchesFilter OR-list (MeshCore)', () => {
+    it('fires when the resolved name matches ANY entry', () => {
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('gauntlet', 'ops') }, 'Ops')).toBe(true);
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('gauntlet', 'ops') }, 'Primary')).toBe(false);
+    });
+    it('never matches when the name could not be resolved', () => {
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('ops') }, null)).toBe(false);
+    });
+    it('empty channels array falls back to legacy scalar behavior', () => {
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: [] }, null)).toBe(true);
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: [], channelName: 'ops' }, 'Ops')).toBe(true);
+    });
+    it('channels precedence ignores the legacy numeric channel', () => {
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('ops'), channel: 5 }, 'Ops')).toBe(true);
+    });
+    it('Meshtastic-only filters (from/to/portnum) still force a non-match', () => {
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('ops'), from: 5 }, 'Ops')).toBe(false);
+    });
+  });
+
+  describe('describeMessageFilterMiss / describeMeshCoreFilterMiss OR-list reasons', () => {
+    it('explains a Meshtastic multi-channel miss', () => {
+      expect(describeMessageFilterMiss(msg(), { channels: chans('gauntlet', 'ops') }, 'Primary'))
+        .toBe('channel name "Primary" not in [gauntlet, ops]');
+      expect(describeMessageFilterMiss(msg(), { channels: chans('ops') }, null))
+        .toBe('channel name "(unresolved)" not in [ops]');
+    });
+    it('returns undefined for a Meshtastic multi-channel hit', () => {
+      expect(describeMessageFilterMiss(msg(), { channels: chans('gauntlet', 'ops') }, 'Ops')).toBeUndefined();
+    });
+    it('explains a MeshCore multi-channel miss', () => {
+      expect(describeMeshCoreFilterMiss(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('ops') }, 'Primary'))
+        .toBe('channel name "Primary" not in [ops]');
+    });
   });
 });
 

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -238,19 +238,54 @@ export function buildScheduleContext(sourceId: string | null, timestamp: number)
  * graph evaluation. Unset params don't constrain. Returns true on match.
  */
 /**
+ * Extract the channel names a `trigger.message` filter targets via the multi-select
+ * `channels` field (#3974). Entries are `{ name, protocol? }` — the same shape the
+ * builder's `channelMulti` renderer emits and `action.sendMessage` resolves. Matching
+ * is name-based (protocol is a UI hint only), mirroring the legacy scalar `channelName`
+ * check. Empty/blank names are dropped (Primary can't be name-matched, same as legacy).
+ */
+export function messageFilterChannelNames(params: Record<string, unknown> = {}): string[] {
+  if (!Array.isArray(params.channels)) return [];
+  return (params.channels as unknown[])
+    .map((c) => (c && typeof c === 'object' && typeof (c as Record<string, unknown>).name === 'string'
+      ? ((c as Record<string, unknown>).name as string)
+      : ''))
+    .filter((n) => n.length > 0);
+}
+
+/**
+ * True when a `trigger.message` params object constrains by channel name — either the
+ * legacy scalar `channelName` or the multi-select `channels` array (#3974). The engine
+ * uses this to decide whether it must resolve the per-source slot→name before filtering.
+ */
+export function messageFilterUsesChannelName(params: Record<string, unknown> = {}): boolean {
+  if (typeof params.channelName === 'string' && params.channelName.length > 0) return true;
+  return messageFilterChannelNames(params).length > 0;
+}
+
+/**
  * @param channelName Pre-resolved name of `msg.channel` for its source (the engine
  *   resolves the per-source slot→name once before filtering). Required for the
- *   `params.channelName` check to match; when absent, a channelName filter fails.
+ *   `params.channelName`/`params.channels` checks to match; when absent, a name
+ *   filter fails.
  */
 export function messageMatchesFilter(msg: DbMessage, params: Record<string, unknown> = {}, channelName?: string | null): boolean {
   if (params.portnum != null && Number(msg.portnum) !== Number(params.portnum)) return false;
   if (params.from != null && Number(msg.fromNodeNum) !== Number(params.from)) return false;
   if (params.to != null && Number(msg.toNodeNum) !== Number(params.to)) return false;
-  if (params.channel != null && Number(msg.channel) !== Number(params.channel)) return false;
-  // Channel-by-name: portable across sources where the channel sits in a
-  // different slot. Case-insensitive; a non-resolving channel never matches.
-  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
-    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return false;
+  // Multi-channel OR-list (#3974) takes precedence over the legacy scalar
+  // channel/channelName fields: fire if the resolved name matches ANY entry.
+  const channelNames = messageFilterChannelNames(params);
+  if (channelNames.length > 0) {
+    const resolved = channelName?.toLowerCase();
+    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) return false;
+  } else {
+    if (params.channel != null && Number(msg.channel) !== Number(params.channel)) return false;
+    // Channel-by-name: portable across sources where the channel sits in a
+    // different slot. Case-insensitive; a non-resolving channel never matches.
+    if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+      if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return false;
+    }
   }
   const text = msg.text ?? '';
   if (typeof params.textContains === 'string' && params.textContains.length > 0) {
@@ -286,9 +321,15 @@ export function meshCoreMessageMatchesFilter(
 ): boolean {
   if (params.portnum != null || params.from != null || params.to != null) return false;
   const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
-  if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return false;
-  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
-    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return false;
+  const channelNames = messageFilterChannelNames(params);
+  if (channelNames.length > 0) {
+    const resolved = channelName?.toLowerCase();
+    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) return false;
+  } else {
+    if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return false;
+    if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+      if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return false;
+    }
   }
   const text = msg.text ?? '';
   if (typeof params.textContains === 'string' && params.textContains.length > 0) {
@@ -321,9 +362,17 @@ export function describeMessageFilterMiss(
   if (params.portnum != null && Number(msg.portnum) !== Number(params.portnum)) return `portnum ${msg.portnum} ≠ ${params.portnum}`;
   if (params.from != null && Number(msg.fromNodeNum) !== Number(params.from)) return `sender #${msg.fromNodeNum} ≠ from #${params.from}`;
   if (params.to != null && Number(msg.toNodeNum) !== Number(params.to)) return `recipient #${msg.toNodeNum} ≠ to #${params.to}`;
-  if (params.channel != null && Number(msg.channel) !== Number(params.channel)) return `channel ${msg.channel} ≠ ${params.channel}`;
-  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
-    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return `channel name "${channelName ?? '(unresolved)'}" ≠ "${params.channelName}"`;
+  const channelNames = messageFilterChannelNames(params);
+  if (channelNames.length > 0) {
+    const resolved = channelName?.toLowerCase();
+    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) {
+      return `channel name "${channelName ?? '(unresolved)'}" not in [${channelNames.join(', ')}]`;
+    }
+  } else {
+    if (params.channel != null && Number(msg.channel) !== Number(params.channel)) return `channel ${msg.channel} ≠ ${params.channel}`;
+    if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+      if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return `channel name "${channelName ?? '(unresolved)'}" ≠ "${params.channelName}"`;
+    }
   }
   const text = msg.text ?? '';
   if (typeof params.textContains === 'string' && params.textContains.length > 0) {
@@ -349,9 +398,17 @@ export function describeMeshCoreFilterMiss(
     return 'rule uses Meshtastic-only filters (from/to/portnum) — never matches MeshCore';
   }
   const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
-  if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return `channel ${channelIdx ?? '(DM)'} ≠ ${params.channel}`;
-  if (typeof params.channelName === 'string' && params.channelName.length > 0) {
-    if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return `channel name "${channelName ?? '(unresolved)'}" ≠ "${params.channelName}"`;
+  const channelNames = messageFilterChannelNames(params);
+  if (channelNames.length > 0) {
+    const resolved = channelName?.toLowerCase();
+    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) {
+      return `channel name "${channelName ?? '(unresolved)'}" not in [${channelNames.join(', ')}]`;
+    }
+  } else {
+    if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return `channel ${channelIdx ?? '(DM)'} ≠ ${params.channel}`;
+    if (typeof params.channelName === 'string' && params.channelName.length > 0) {
+      if (!channelName || channelName.toLowerCase() !== params.channelName.toLowerCase()) return `channel name "${channelName ?? '(unresolved)'}" ≠ "${params.channelName}"`;
+    }
   }
   const text = msg.text ?? '';
   if (typeof params.textContains === 'string' && params.textContains.length > 0) {


### PR DESCRIPTION
## Summary

Closes #3974.

The Automation `trigger.message` block previously exposed only two single-value channel filters (`On channel (name)` and `On channel #`), so matching "channel A **or** channel C" required a separate automation per channel. This adds an **`On channels`** multi-select — an OR-list that fires when the message's resolved channel name matches **any** selected entry.

It mirrors the existing `action.sendMessage` `channels` field (`channelMulti`, name-based, unified across sources) and works for **both Meshtastic and MeshCore** messages.

## Changes

- **catalog** (`src/components/automations/catalog.ts`): add a `channels` (`channelMulti`) field to `trigger.message`, **alongside** the legacy scalar `channelName` (text) and `channel` (number) fields — kept for backward compatibility with saved automation JSON.
- **builder** (`AutomationBuilder.tsx`): no code change needed — the trigger already receives the shared `channels` prop, so the existing `channelMulti` renderer wires up automatically.
- **matching** (`src/server/services/automation/triggerContext.ts`): all four functions — `messageMatchesFilter`, `meshCoreMessageMatchesFilter`, `describeMessageFilterMiss`, `describeMeshCoreFilterMiss` — treat a populated `channels` array as an OR-list (case-insensitive name match), taking **precedence** over the legacy scalar `channelName`/`channel` checks. Absent/empty array falls back to legacy behavior. New helpers: `messageFilterChannelNames`, `messageFilterUsesChannelName`.
- **engine** (`automationEngineService.ts`): `onMessage`/`onMeshCoreMessage` now resolve the per-source slot→name when a `channels` array is present (previously only the scalar `channelName` triggered resolution).
- **docs** (`docs/features/automation-engine.md`): document the multi-channel OR-list trigger.

**No DB migration** — old automations keep working unchanged.

## Tests

- `triggerContext.test.ts`: OR-matching, empty-array/legacy fallback, `channels` precedence over legacy scalar `channel`/`channelName`, text/regex alongside channel filter, miss-reason strings, both Meshtastic and MeshCore paths.
- `automationEngineService.test.ts`: end-to-end engine test verifying the array triggers slot→name resolution and OR-fires on matching channels only.
- `compile.test.ts`: catalog exposes the `channelMulti` field + legacy fields retained + params round-trip through compile/decompile.

Full Vitest suite: **8082 passed, 0 failed, 0 suite failures**. Typecheck clean, lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub