### PR TITLE
feat(map): add polar grid overlay to Map Analysis and Unified maps (#3971)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -43,7 +43,19 @@ vi.mock('../../contexts/MapContext', () => ({
     setShowNeighborInfo: vi.fn(),
     showWaypoints: false,
     setShowWaypoints: vi.fn(),
+    showPolarGrid: false,
+    setShowPolarGrid: vi.fn(),
   }),
+}));
+
+// Polar grid (#3971) pulls the source list + per-source status to resolve each
+// source's own-node position. Mock the data hooks so the bare component renders
+// without a QueryClient/AuthProvider; empty data ⇒ no grid, existing assertions
+// (marker/polyline counts) are unaffected.
+vi.mock('../../hooks/useDashboardData', () => ({
+  useDashboardSources: () => ({ data: [] }),
+  useSourceStatuses: () => new Map(),
+  UNIFIED_SOURCE_ID: '__unified__',
 }));
 
 // CSRF + api are provided by the app shell in production; mock them so the bare

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -24,11 +24,20 @@ import DashboardWaypoints from './DashboardWaypoints';
 import DashboardNodePopup, { type NodeSourceRef } from './DashboardNodePopup';
 import DashboardNeighborPopup from './DashboardNeighborPopup';
 import GeoJsonOverlay from '../GeoJsonOverlay';
+import PolarGridOverlay from '../PolarGridOverlay';
 import { TilesetSelector } from '../TilesetSelector';
 import MapLegend from '../MapLegend';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { useMapContext } from '../../contexts/MapContext';
 import { useSettings } from '../../contexts/SettingsContext';
+import {
+  useDashboardSources,
+  useSourceStatuses,
+  UNIFIED_SOURCE_ID,
+  type DashboardSource,
+} from '../../hooks/useDashboardData';
+import { getSourceColor, resolveSourceColor } from '../../utils/sourceColors';
+import { getOwnNodePositions } from '../../utils/ownNodePositions';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 import { isNullIsland } from '../../utils/nullIsland';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
@@ -161,6 +170,21 @@ export default function DashboardMap({
   const tileset = getTilesetById(tilesetId, customTilesets);
   const { mapPinStyle, setMapTileset } = useSettings();
 
+  // Polar grid (#3971): draw a grid centered on each source's own-node position.
+  // On the Unified map (sourceId === UNIFIED_SOURCE_ID) that's every source, each
+  // in its own color with a legend; on a single-source map it's just that source.
+  const { data: allSources = [] } = useDashboardSources();
+  const allSourceIds = allSources.map((s: DashboardSource) => s.id);
+  // Stable, sorted id list drives per-source color assignment so a source keeps
+  // the same color here as on the other Unified views.
+  const colorSourceIds = [...allSourceIds].sort();
+  const sourceNameById = new Map<string, string>(
+    allSources.map((s: DashboardSource) => [s.id, s.name] as [string, string]),
+  );
+  const isUnified = sourceId === UNIFIED_SOURCE_ID;
+  const polarSourceIds = isUnified ? allSourceIds : sourceId ? [sourceId] : [];
+  const sourceStatuses = useSourceStatuses(polarSourceIds);
+
   // Spiderfier: fan out co-located markers so each node (incl. estimated-position
   // nodes that collapse onto the same anchor) is individually selectable (#3612).
   // Reuses the SAME shared SpiderfierController + tuning as the per-source NodesTab
@@ -259,6 +283,8 @@ export default function DashboardMap({
     setShowNeighborInfo,
     showWaypoints,
     setShowWaypoints,
+    showPolarGrid,
+    setShowPolarGrid,
     mapMaxAgeHours,
     setMapMaxAgeHours,
   } = useMapContext();
@@ -316,6 +342,16 @@ export default function DashboardMap({
     .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
 
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
+
+  // Own-node position per source for the polar grid. Resolved from the raw
+  // `nodes` prop (not the age/transport-filtered marker list) so the grid center
+  // survives even when the local node is stale or filtered off the map.
+  const localNodeNumBySource = new Map<string, number | null | undefined>();
+  for (const id of polarSourceIds) {
+    localNodeNumBySource.set(id, sourceStatuses.get(id)?.nodeNum ?? null);
+  }
+  const ownNodePositions = getOwnNodePositions(nodes, localNodeNumBySource);
+  const hasOwnNode = ownNodePositions.length > 0;
 
   // Genuine removals (a node aged out / filtered away) are reconciled here
   // rather than from the ref `null` bounce (see getMarkerRef): drop any tracked
@@ -470,6 +506,16 @@ export default function DashboardMap({
         {showLegend && <MapLegend />}
 
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
+
+        {/* Polar grid — one per source with a known own-node position, each in
+            that source's color so overlapping grids stay distinguishable (#3971). */}
+        {showPolarGrid && ownNodePositions.map((op) => (
+          <PolarGridOverlay
+            key={`polar-${op.sourceId}`}
+            center={{ lat: op.lat, lng: op.lng }}
+            color={resolveSourceColor(op.sourceId, colorSourceIds)}
+          />
+        ))}
 
         {showWaypoints && <DashboardWaypoints sourceId={sourceId} />}
 
@@ -653,6 +699,25 @@ export default function DashboardMap({
         />
       )}
 
+      {/* Polar grid legend — names each source whose grid is drawn, with its
+          color swatch, so overlapping grids on the Unified map aren't confused. */}
+      {showPolarGrid && ownNodePositions.length > 0 && (
+        <div className="dashboard-polar-grid-legend" role="note" aria-label="Polar grid sources">
+          <div className="dashboard-polar-grid-legend__title">Polar Grid</div>
+          {ownNodePositions.map((op) => (
+            <div key={`legend-${op.sourceId}`} className="dashboard-polar-grid-legend__row">
+              <span
+                className="dashboard-polar-grid-legend__swatch"
+                style={{ background: getSourceColor(op.sourceId, colorSourceIds) }}
+              />
+              <span className="dashboard-polar-grid-legend__name">
+                {sourceNameById.get(op.sourceId) ?? op.sourceId}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Map Features control panel — mirrors NodesTab's "Features" panel but
           trimmed to the toggles meaningful on a cross-source map. */}
       <div className={`map-controls dashboard-map-controls ${isMapControlsCollapsed ? 'collapsed' : ''}`}>
@@ -769,6 +834,17 @@ export default function DashboardMap({
               onChange={(e) => setShowWaypoints(e.target.checked)}
             />
             <span>Show Waypoints</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showPolarGrid && hasOwnNode}
+              disabled={!hasOwnNode}
+              onChange={(e) => setShowPolarGrid(e.target.checked)}
+            />
+            <span title={!hasOwnNode ? 'No source has a known own-node position' : undefined}>
+              Show Polar Grid
+            </span>
           </label>
           <label className="map-control-item">
             <input

--- a/src/components/MapAnalysis/LayerToggleButton.tsx
+++ b/src/components/MapAnalysis/LayerToggleButton.tsx
@@ -9,6 +9,10 @@ export interface LayerToggleButtonProps {
   onLookbackChange?: (h: number | null) => void;
   loading?: boolean;
   errored?: boolean;
+  /** When true the toggle can't be clicked (e.g. no own-node position, #3971). */
+  disabled?: boolean;
+  /** Tooltip shown on the button — useful to explain a disabled state. */
+  title?: string;
 }
 
 export default function LayerToggleButton({
@@ -20,6 +24,8 @@ export default function LayerToggleButton({
   onLookbackChange,
   loading,
   errored,
+  disabled,
+  title,
 }: LayerToggleButtonProps) {
   const [popOpen, setPopOpen] = useState(false);
   const showChevron = !!lookbackOptions && !!onLookbackChange;
@@ -29,6 +35,8 @@ export default function LayerToggleButton({
       <button
         type="button"
         onClick={() => onToggle(!enabled)}
+        disabled={disabled}
+        title={title}
         className={`map-analysis-layer-btn ${enabled ? 'active' : ''}`}
       >
         {label}

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -12,6 +12,7 @@ import PositionTrailsLayer from './layers/PositionTrailsLayer';
 import CoverageHeatmapLayer from './layers/CoverageHeatmapLayer';
 import SnrOverlayLayer from './layers/SnrOverlayLayer';
 import WaypointsLayer from './layers/WaypointsLayer';
+import PolarGridLayer from './layers/PolarGridLayer';
 import TimeSliderControl from './TimeSliderControl';
 import MapLegend from './MapLegend';
 
@@ -66,6 +67,11 @@ export default function MapAnalysisCanvas() {
         </Pane>
         <Pane name="heatmap" style={{ zIndex: 350 }}>
           {config.layers.heatmap.enabled && <CoverageHeatmapLayer />}
+        </Pane>
+        {/* Polar grid sits just below the node markers (z600) so its labels don't
+            paint over them, but above the data layers so the range rings read. */}
+        <Pane name="polarGrid" style={{ zIndex: 550 }}>
+          {config.layers.polarGrid.enabled && <PolarGridLayer />}
         </Pane>
       </MapContainer>
       <TilesetSelector selectedTilesetId={mapTileset} onTilesetChange={setMapTileset} />

--- a/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
@@ -10,6 +10,9 @@ import { MapAnalysisProvider } from './MapAnalysisContext';
 
 vi.mock('../../hooks/useDashboardData', () => ({
   useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }] }),
+  // The Polar Grid toggle resolves own-node positions via these hooks (#3971).
+  useDashboardUnifiedData: () => ({ nodes: [] }),
+  useSourceStatuses: () => new Map(),
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
@@ -31,6 +34,13 @@ describe('MapAnalysisToolbar', () => {
     for (const label of ['Markers', 'Traceroutes', 'Neighbors', 'Heatmap', 'Trails', 'Hop Shading', 'SNR Overlay']) {
       expect(screen.getByRole('button', { name: new RegExp(label, 'i') })).toBeInTheDocument();
     }
+  });
+
+  it('renders the Polar Grid toggle disabled when no source has an own-node position (#3971)', () => {
+    render(<MapAnalysisToolbar />, { wrapper });
+    const btn = screen.getByRole('button', { name: /polar grid/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeDisabled();
   });
 
   it('toggles a layer and persists to localStorage', () => {

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -6,6 +6,7 @@ import NodeTypeFilterControl from './NodeTypeFilterControl';
 import NodeSearchControl from './NodeSearchControl';
 import TracerouteControls from './TracerouteControls';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { useOwnNodePositions } from '../../hooks/useOwnNodePositions';
 import { LayerKey } from '../../hooks/useMapAnalysisConfig';
 import {
   usePositions,
@@ -34,6 +35,11 @@ export default function MapAnalysisToolbar() {
   const navigate = useNavigate();
   const { config, setLayerEnabled, setLayerLookback, setSources, setTimeSlider, reset } = useMapAnalysisCtx();
   const { data: sources = [] } = useDashboardSources();
+
+  // Polar grid (#3971): centered on each active source's own-node position.
+  // Disable the toggle when no active source has a resolvable own node.
+  const ownNodePositions = useOwnNodePositions(config.sources);
+  const hasOwnNode = ownNodePositions.length > 0;
 
   const sourceIds = config.sources.length === 0
     ? sources.map((s: { id: string }) => s.id)
@@ -120,6 +126,13 @@ export default function MapAnalysisToolbar() {
           onToggle={(next) => setLayerEnabled(key, next)}
         />
       ))}
+      <LayerToggleButton
+        label="Polar Grid"
+        enabled={config.layers.polarGrid.enabled && hasOwnNode}
+        onToggle={(next) => setLayerEnabled('polarGrid', next)}
+        disabled={!hasOwnNode}
+        title={hasOwnNode ? undefined : 'No source has a known own-node position'}
+      />
       {TIMED_LAYERS.map(({ key, label, options }) => (
         <LayerToggleButton
           key={key}

--- a/src/components/MapAnalysis/layers/PolarGridLayer.tsx
+++ b/src/components/MapAnalysis/layers/PolarGridLayer.tsx
@@ -1,0 +1,28 @@
+/**
+ * PolarGridLayer — renders the polar grid overlay (range rings + azimuth
+ * sectors, #2307) on the Map Analysis canvas (#3971).
+ *
+ * Map Analysis is scoped per source, so one grid is drawn per active source
+ * that has a resolvable own-node position, centered on that node. The theme-
+ * aware `overlayColors.polarGrid` palette is used (matching NodesTab); the
+ * per-source coloring is reserved for the Unified/Dashboard map where several
+ * grids routinely overlap.
+ */
+import { useMapAnalysisCtx } from '../MapAnalysisContext';
+import { useOwnNodePositions } from '../../../hooks/useOwnNodePositions';
+import PolarGridOverlay from '../../PolarGridOverlay';
+
+export default function PolarGridLayer() {
+  const { config } = useMapAnalysisCtx();
+  // config.sources empty = "all sources" (unified semantics), matching the
+  // marker/source filters elsewhere in Map Analysis.
+  const ownPositions = useOwnNodePositions(config.sources);
+
+  return (
+    <>
+      {ownPositions.map((op) => (
+        <PolarGridOverlay key={op.sourceId} center={{ lat: op.lat, lng: op.lng }} />
+      ))}
+    </>
+  );
+}

--- a/src/components/PolarGridOverlay.test.tsx
+++ b/src/components/PolarGridOverlay.test.tsx
@@ -7,8 +7,15 @@ import React from 'react';
 import { PolarGridOverlay } from './PolarGridOverlay';
 
 vi.mock('react-leaflet', () => ({
-  Circle: ({ center, radius }: any) => (
-    <div data-testid="circle" data-radius={radius} data-lat={center[0]} data-lng={center[1]} />
+  Circle: ({ center, radius, pathOptions }: any) => (
+    <div
+      data-testid="circle"
+      data-radius={radius}
+      data-lat={center[0]}
+      data-lng={center[1]}
+      data-color={pathOptions?.color}
+      data-opacity={pathOptions?.opacity}
+    />
   ),
   Polyline: ({ positions }: any) => <div data-testid="polyline" />,
   Marker: ({ position }: any) => (
@@ -94,5 +101,24 @@ describe('PolarGridOverlay', () => {
     for (let i = 1; i < radii.length; i++) {
       expect(radii[i]).toBeGreaterThan(radii[i - 1]);
     }
+  });
+
+  it('uses the theme ring color at full opacity by default', () => {
+    render(<PolarGridOverlay center={CENTER} />);
+    const circle = screen.getAllByTestId('circle')[0];
+    expect(circle.getAttribute('data-color')).toBe('rgba(0,200,255,0.3)');
+    // No explicit opacity override (undefined) — the rgba alpha carries the
+    // transparency, so the attribute is absent.
+    expect(circle.getAttribute('data-opacity')).toBeNull();
+  });
+
+  it('overrides every ring with the per-source color at reduced opacity (#3971)', () => {
+    render(<PolarGridOverlay center={CENTER} color="#89b4fa" />);
+    const circles = screen.getAllByTestId('circle');
+    circles.forEach((circle) => {
+      expect(circle.getAttribute('data-color')).toBe('#89b4fa');
+      expect(Number(circle.getAttribute('data-opacity'))).toBeLessThan(1);
+      expect(Number(circle.getAttribute('data-opacity'))).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/components/PolarGridOverlay.tsx
+++ b/src/components/PolarGridOverlay.tsx
@@ -6,13 +6,23 @@ import { getPolarGridRings, getSectorEndpoint } from '../utils/polarGrid.js';
 
 interface PolarGridOverlayProps {
   center: { lat: number; lng: number };
+  /**
+   * Optional literal (hex/rgb) color override for the whole grid. When set,
+   * rings/sectors/labels all render in this color at reduced opacity — used on
+   * the Unified/Dashboard map (#3971) to draw one grid per source in that
+   * source's color so overlapping grids stay distinguishable. When omitted the
+   * grid uses the theme-aware `overlayColors.polarGrid` palette (NodesTab / Map
+   * Analysis). Must be a resolved literal, not a `var(--…)` — Leaflet paints SVG
+   * strokes via the presentation attribute, which does not evaluate CSS vars.
+   */
+  color?: string;
 }
 
 const SECTOR_BEARINGS = Array.from({ length: 12 }, (_, i) => i * 30);
 const CARDINAL_BEARINGS = new Set([0, 90, 180, 270]);
 const DEGREE_LABELS = ['0', '30', '60', '90', '120', '150', '180', '210', '240', '270', '300', '330'];
 
-export const PolarGridOverlay: React.FC<PolarGridOverlayProps> = ({ center }) => {
+export const PolarGridOverlay: React.FC<PolarGridOverlayProps> = ({ center, color }) => {
   const map = useMap();
   const { distanceUnit, overlayColors } = useSettings();
   const [zoom, setZoom] = useState(map.getZoom());
@@ -23,7 +33,16 @@ export const PolarGridOverlay: React.FC<PolarGridOverlayProps> = ({ center }) =>
     return () => { map.off('zoomend', onZoomEnd); };
   }, [map]);
 
-  const colors = overlayColors;
+  // When a per-source color override is provided, use it for every grid element
+  // (the theme palette bakes opacity into rgba() values; a solid override gets
+  // opacity via pathOptions instead). Otherwise fall back to the theme palette.
+  const gridColors = color
+    ? { rings: color, sectors: color, cardinalSectors: color, labels: color }
+    : overlayColors.polarGrid;
+  const ringOpacity = color ? 0.5 : undefined;
+  const cardinalOpacity = color ? 0.55 : undefined;
+  const sectorOpacity = color ? 0.35 : undefined;
+  const colors = { polarGrid: gridColors };
   const centerLatLng: [number, number] = [center.lat, center.lng];
 
   const rings = useMemo(
@@ -76,6 +95,7 @@ export const PolarGridOverlay: React.FC<PolarGridOverlayProps> = ({ center }) =>
           pathOptions={{
             color: colors.polarGrid.rings,
             weight: 2,
+            opacity: ringOpacity,
             fill: false,
             interactive: false,
           }}
@@ -91,6 +111,7 @@ export const PolarGridOverlay: React.FC<PolarGridOverlayProps> = ({ center }) =>
               ? colors.polarGrid.cardinalSectors
               : colors.polarGrid.sectors,
             weight: 2,
+            opacity: sector.isCardinal ? cardinalOpacity : sectorOpacity,
             dashArray: sector.isCardinal ? undefined : '6 6',
             interactive: false,
           }}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -31,6 +31,13 @@ export interface SourceStatus {
   sourceName?: string;
   sourceType?: string;
   connected: boolean;
+  /**
+   * The source's own (local) node number, surfaced by the manager's
+   * `getStatus()`. Used to center the polar grid overlay on the local node
+   * across the multi-source Map Analysis / Unified maps (#3971). Absent for
+   * MeshCore sources (no meshtastic nodeNum) and while disconnected.
+   */
+  nodeNum?: number;
   /** Total nodes heard by this source — populated by GET /api/sources/:id/status. */
   nodeCount?: number;
   /**

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -9,7 +9,8 @@ export type LayerKey =
   | 'trails'
   | 'hopShading'
   | 'snrOverlay'
-  | 'waypoints';
+  | 'waypoints'
+  | 'polarGrid';
 
 export interface LayerConfig {
   enabled: boolean;
@@ -65,6 +66,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
     hopShading: { enabled: false, lookbackHours: null },
     snrOverlay: { enabled: false, lookbackHours: null },
     waypoints:  { enabled: true,  lookbackHours: null },
+    polarGrid:  { enabled: false, lookbackHours: null },
   },
   nodeTypes: { ...ALL_NODE_TYPES_VISIBLE },
   sources: [],

--- a/src/hooks/useOwnNodePositions.ts
+++ b/src/hooks/useOwnNodePositions.ts
@@ -1,0 +1,50 @@
+/**
+ * Hook that resolves each source's own (local) node position for the polar grid
+ * overlay on the Map Analysis view (#3971).
+ *
+ * It reuses the same cross-source data the Map Analysis markers already fetch
+ * (`useDashboardUnifiedData`) plus each source's status (`useSourceStatuses`,
+ * which carries the local `nodeNum`), so no extra network round-trips are added
+ * beyond what TanStack Query already caches for the canvas.
+ */
+import { useMemo } from 'react';
+import {
+  useDashboardSources,
+  useDashboardUnifiedData,
+  useSourceStatuses,
+} from './useDashboardData';
+import { getOwnNodePositions, type OwnNodePosition } from '../utils/ownNodePositions';
+
+/**
+ * @param activeSourceIds  sources to resolve own-node positions for. An empty
+ *                         array means "all configured sources" (Map Analysis's
+ *                         `config.sources` uses the same empty = all convention).
+ */
+export function useOwnNodePositions(activeSourceIds: string[]): OwnNodePosition[] {
+  const { data: sources = [] } = useDashboardSources();
+  const allSourceIds = (sources as Array<{ id: string }>).map((s) => s.id);
+
+  // Full source objects so the merge keys nodes by nodeNum across sources.
+  const { nodes } = useDashboardUnifiedData(sources, allSourceIds.length > 0);
+  const statuses = useSourceStatuses(allSourceIds);
+
+  return useMemo(() => {
+    const ids = activeSourceIds.length > 0 ? activeSourceIds : allSourceIds;
+    const localNumBySource = new Map<string, number | null | undefined>();
+    for (const id of ids) {
+      const status = statuses.get(id);
+      localNumBySource.set(id, (status as { nodeNum?: number } | null)?.nodeNum ?? null);
+    }
+    return getOwnNodePositions(nodes as Parameters<typeof getOwnNodePositions>[0], localNumBySource);
+    // `statuses` is a fresh Map each render; key its contents instead so we don't
+    // recompute on every poll when nothing relevant changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodes, activeSourceIds.join(','), allSourceIds.join(','), statusKey(statuses)]);
+}
+
+/** Stable signature of the local nodeNum per source so useMemo can dedupe. */
+function statusKey(statuses: Map<string, { nodeNum?: number } | null>): string {
+  const parts: string[] = [];
+  for (const [id, s] of statuses) parts.push(`${id}:${s?.nodeNum ?? ''}`);
+  return parts.join('|');
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -598,6 +598,50 @@
   opacity: 0.7;
 }
 
+/* ── Polar grid legend (#3971) ───────────────────────────────────────────── */
+.dashboard-polar-grid-legend {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  z-index: 1000;
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--ctp-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  pointer-events: none;
+  max-width: 220px;
+}
+
+.dashboard-polar-grid-legend__title {
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--ctp-subtext0);
+}
+
+.dashboard-polar-grid-legend__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.5;
+}
+
+.dashboard-polar-grid-legend__swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.dashboard-polar-grid-legend__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
 
 .dashboard-signin-btn {

--- a/src/utils/ownNodePositions.test.ts
+++ b/src/utils/ownNodePositions.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getOwnNodePositions } from './ownNodePositions';
+
+describe('getOwnNodePositions', () => {
+  it('resolves a source own-node position from a nested position record', () => {
+    const nodes = [
+      { nodeNum: 100, position: { latitude: 35, longitude: -80 } },
+      { nodeNum: 200, position: { latitude: 36, longitude: -81 } },
+    ];
+    const out = getOwnNodePositions(nodes, new Map([['src-a', 100]]));
+    expect(out).toEqual([{ sourceId: 'src-a', lat: 35, lng: -80 }]);
+  });
+
+  it('resolves from a flat lat/lng record', () => {
+    const nodes = [{ nodeNum: 100, latitude: 40, longitude: -70 }];
+    const out = getOwnNodePositions(nodes, new Map([['s', 100]]));
+    expect(out).toEqual([{ sourceId: 's', lat: 40, lng: -70 }]);
+  });
+
+  it('returns one entry per source that has a local nodeNum with a position', () => {
+    const nodes = [
+      { nodeNum: 1, position: { latitude: 10, longitude: 10 } },
+      { nodeNum: 2, position: { latitude: 20, longitude: 20 } },
+    ];
+    const out = getOwnNodePositions(
+      nodes,
+      new Map([
+        ['a', 1],
+        ['b', 2],
+      ]),
+    );
+    expect(out).toHaveLength(2);
+    expect(out).toContainEqual({ sourceId: 'a', lat: 10, lng: 10 });
+    expect(out).toContainEqual({ sourceId: 'b', lat: 20, lng: 20 });
+  });
+
+  it('skips a source whose local nodeNum is null/undefined (MeshCore / disconnected)', () => {
+    const nodes = [{ nodeNum: 1, position: { latitude: 10, longitude: 10 } }];
+    const out = getOwnNodePositions(
+      nodes,
+      new Map<string, number | null | undefined>([
+        ['a', null],
+        ['b', undefined],
+      ]),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('skips a source whose local node has no resolvable position', () => {
+    const nodes = [{ nodeNum: 1, position: null }];
+    const out = getOwnNodePositions(nodes, new Map([['a', 1]]));
+    expect(out).toEqual([]);
+  });
+
+  it('rejects a Null Island (0,0) local-node position', () => {
+    const nodes = [{ nodeNum: 1, position: { latitude: 0, longitude: 0 } }];
+    const out = getOwnNodePositions(nodes, new Map([['a', 1]]));
+    expect(out).toEqual([]);
+  });
+
+  it('coerces string nodeNum values (BIGINT-backed rows) before matching', () => {
+    const nodes = [{ nodeNum: '100', position: { latitude: 1, longitude: 2 } }];
+    const out = getOwnNodePositions(nodes, new Map([['a', 100]]));
+    expect(out).toEqual([{ sourceId: 'a', lat: 1, lng: 2 }]);
+  });
+
+  it('returns empty when no node matches the local nodeNum', () => {
+    const nodes = [{ nodeNum: 999, position: { latitude: 1, longitude: 2 } }];
+    const out = getOwnNodePositions(nodes, new Map([['a', 100]]));
+    expect(out).toEqual([]);
+  });
+});

--- a/src/utils/ownNodePositions.ts
+++ b/src/utils/ownNodePositions.ts
@@ -1,0 +1,73 @@
+/**
+ * Resolve each source's own (local) node position from a node list.
+ *
+ * The polar grid overlay (#2307, #3971) is centered on the local node. On the
+ * per-source NodesTab map the local node is known from the device config
+ * (`currentNodeId`), but the Map Analysis and Unified/Dashboard maps aggregate
+ * several sources at once and have no single "current node". Instead we pair
+ * each source's local `nodeNum` (surfaced by `GET /api/sources/:id/status` via
+ * the manager's `getStatus()`) with that node's position from the shared node
+ * list. `nodeNum` is globally unique per physical node, so a single position
+ * lookup table resolves every source's own node.
+ *
+ * MeshCore sources carry no meshtastic `nodeNum` (their status omits it), so
+ * they naturally yield no entry here and the grid is disabled for them —
+ * matching the issue's "disabled when the source has no own-node position".
+ */
+import { isNullIsland } from './nullIsland';
+
+export interface OwnNodePosition {
+  sourceId: string;
+  lat: number;
+  lng: number;
+}
+
+/** A node record carrying a nodeNum and either flat or nested lat/lng. */
+interface PositionedNode {
+  nodeNum?: number | string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  position?: { latitude?: number | null; longitude?: number | null } | null;
+}
+
+function resolveLatLng(node: PositionedNode): { lat: number; lng: number } | null {
+  const lat = node?.latitude ?? node?.position?.latitude;
+  const lng = node?.longitude ?? node?.position?.longitude;
+  if (lat == null || lng == null) return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (isNullIsland(lat, lng)) return null;
+  return { lat, lng };
+}
+
+/**
+ * Build the list of own-node positions for the given sources.
+ *
+ * @param nodes                 node records (flat or nested position; carry nodeNum)
+ * @param localNodeNumBySource  sourceId → local nodeNum (from source status;
+ *                              null/undefined when the source has no known local node)
+ */
+export function getOwnNodePositions(
+  nodes: PositionedNode[],
+  localNodeNumBySource: Map<string, number | null | undefined>,
+): OwnNodePosition[] {
+  // Index the newest resolvable position per nodeNum. Callers pass merged/unified
+  // nodes (one record per nodeNum), so first-wins is sufficient and cheap.
+  const posByNodeNum = new Map<number, { lat: number; lng: number }>();
+  for (const n of nodes ?? []) {
+    const num = typeof n?.nodeNum === 'number' ? n.nodeNum : Number(n?.nodeNum);
+    if (!Number.isFinite(num)) continue;
+    if (posByNodeNum.has(num)) continue;
+    const pos = resolveLatLng(n);
+    if (pos) posByNodeNum.set(num, pos);
+  }
+
+  const out: OwnNodePosition[] = [];
+  for (const [sourceId, localNum] of localNodeNumBySource) {
+    if (localNum == null) continue;
+    const num = Number(localNum);
+    if (!Number.isFinite(num)) continue;
+    const pos = posByNodeNum.get(num);
+    if (pos) out.push({ sourceId, lat: pos.lat, lng: pos.lng });
+  }
+  return out;
+}

--- a/src/utils/sourceColors.ts
+++ b/src/utils/sourceColors.ts
@@ -25,3 +25,35 @@ export function getSourceColor(sourceId: string, sourceIds: string[]): string {
   const idx = sourceIds.indexOf(sourceId);
   return SOURCE_COLORS[(idx < 0 ? 0 : idx) % SOURCE_COLORS.length];
 }
+
+/**
+ * Resolve a color value to a literal (hex/rgb) string.
+ *
+ * The palette in {@link SOURCE_COLORS} is expressed as CSS custom properties
+ * (`var(--ctp-blue)`). CSS variables resolve fine when set on an element's
+ * `style` (backgrounds, borders, legend swatches), but Leaflet paints SVG
+ * strokes via the presentation *attribute* (`setAttribute('stroke', color)`),
+ * which does NOT evaluate `var()`. Leaflet overlays (e.g. the polar grid on the
+ * Unified map) therefore need the computed literal. This reads the variable off
+ * `:root` via getComputedStyle; non-var values pass through unchanged, and it is
+ * a no-op fallback when there is no `document` (SSR/tests without a DOM).
+ */
+export function resolveCssColor(value: string): string {
+  const match = value.match(/^var\((--[a-z0-9-]+)\)$/i);
+  if (match && typeof document !== 'undefined') {
+    const resolved = getComputedStyle(document.documentElement)
+      .getPropertyValue(match[1])
+      .trim();
+    if (resolved) return resolved;
+  }
+  return value;
+}
+
+/**
+ * Like {@link getSourceColor} but resolved to a literal color usable as a
+ * Leaflet stroke. See {@link resolveCssColor} for why the raw `var(...)` form
+ * cannot be handed directly to Leaflet.
+ */
+export function resolveSourceColor(sourceId: string, sourceIds: string[]): string {
+  return resolveCssColor(getSourceColor(sourceId, sourceIds));
+}


### PR DESCRIPTION
Closes #3971.

Extends the polar grid overlay (range rings + azimuth sectors centered on the own-node position, from #2307) — previously only in `NodesTab` — to two more map surfaces. Reuses the existing `PolarGridOverlay` component and `getPolarGridRings()` utility rather than duplicating logic.

## 1. Map Analysis view
- New `PolarGridLayer` (`src/components/MapAnalysis/layers/PolarGridLayer.tsx`) draws a polar grid centered on each active source's own-node position, resolved per `sourceId`. Uses the theme-aware `overlayColors.polarGrid` palette (matching NodesTab).
- New **Polar Grid** toggle in `MapAnalysisToolbar`, **disabled** when no active source has a known own-node position (`LayerToggleButton` gained `disabled`/`title` props).
- Rendered in a dedicated low-z `Pane` in `MapAnalysisCanvas` so its labels sit below node markers.
- Persisted as a new `polarGrid` layer in the localStorage-backed `MapAnalysisConfig`.

## 2. Unified / Dashboard map
- Since the Dashboard map aggregates several sources, it renders **one grid per source** that has an own-node position, each in that source's per-source color (`resolveSourceColor`), with a **legend** so overlapping grids aren't confused.
- Toggle reuses the existing `MapContext.showPolarGrid` (already shared across map surfaces and round-tripped to `/api/user/map-preferences`), **disabled** when no source has a position.
- Works for both the single-source and Unified dashboard views.

## Shared plumbing
- `getOwnNodePositions` util + `useOwnNodePositions` hook resolve each source's own node from its local `nodeNum` (surfaced by `GET /api/sources/:id/status` via the manager's `getStatus()`) paired with that node's position in the shared node list. MeshCore sources (no meshtastic `nodeNum`) naturally yield no grid.
- `PolarGridOverlay` gains an optional `color` prop; when set it recolors the whole grid at reduced opacity. Omitted ⇒ unchanged theme behavior (NodesTab / Map Analysis). The Dashboard passes a resolved literal color because Leaflet paints SVG strokes via the presentation attribute, which does not evaluate CSS `var()`.

## Tests
- New `ownNodePositions.test.ts` (8 cases: nested/flat position, multi-source, null/MeshCore skip, Null Island, string nodeNum coercion).
- Extended `PolarGridOverlay.test.tsx` with a color-override case.
- New Map Analysis toolbar test asserting the Polar Grid toggle is disabled with no own-node position.
- Full Vitest suite green (0 failures), `tsc` adds no new errors, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub