### PR TITLE
feat(meshcore): delete/purge messages — per-message, per-conversation, purge-all (#3981)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -469,6 +469,19 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   const selfKey = status?.localNode?.publicKey;
   const connected = status?.connected ?? false;
 
+  // Per-message delete + whole-channel clear (#3981). Both confirm first.
+  const handleDeleteMessage = useCallback(async (m: MeshCoreMessage) => {
+    if (!window.confirm(t('meshcore.confirm_delete_message', 'Delete this message?'))) return;
+    await actions.deleteMessage(m.id);
+  }, [actions, t]);
+  const handleClearChannel = useCallback(async () => {
+    if (!window.confirm(t(
+      'meshcore.confirm_clear_channel',
+      'Clear all messages on this channel? This cannot be undone.',
+    ))) return;
+    await actions.clearChannelMessages(active.id);
+  }, [actions, active, t]);
+
   const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
 
   return (
@@ -616,12 +629,25 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
             )}
           </div>
         )}
+        {canSend && filtered.length > 0 && (
+          <div className="meshcore-conversation-toolbar">
+            <button
+              type="button"
+              className="meshcore-clear-conversation-btn"
+              onClick={() => void handleClearChannel()}
+              title={t('meshcore.clear_channel', 'Clear channel messages')}
+            >
+              🗑️ {t('meshcore.clear_channel', 'Clear channel messages')}
+            </button>
+          </div>
+        )}
         <MeshCoreMessageStream
           messages={filtered}
           contacts={contacts}
           selfPublicKey={selfKey}
           disabled={!connected || !canSend}
           emptyText={t('meshcore.no_messages', 'No messages on this channel yet')}
+          onDeleteMessage={canSend ? handleDeleteMessage : undefined}
           onSend={async text => {
             // Pass the one-off scope override only when the operator has opened
             // the control AND typed a value (incl. '' to mean unscoped). When

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -305,6 +305,22 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     if (isMobileViewport()) setMobileShowContent(true);
   };
 
+  // Per-message delete + whole-conversation clear (#3981). Both confirm first
+  // (destructive, no undo); the hook prunes local state and the server
+  // broadcasts a deletion event so other clients converge.
+  const handleDeleteMessage = async (m: MeshCoreMessage) => {
+    if (!window.confirm(t('meshcore.confirm_delete_message', 'Delete this message?'))) return;
+    await actions.deleteMessage(m.id);
+  };
+  const handleClearConversation = async () => {
+    if (!selected) return;
+    if (!window.confirm(t(
+      'meshcore.confirm_clear_conversation',
+      'Clear the entire conversation with this contact? This cannot be undone.',
+    ))) return;
+    await actions.clearConversation(selected);
+  };
+
   const selectedContactName = selected
     ? (contactsByKey.get(selected)?.advName || contactsByKey.get(selected)?.name || `${selected.substring(0, 8)}…`)
     : '';
@@ -480,16 +496,31 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 {t('meshcore.repeater_no_messaging', 'Repeaters cannot receive direct messages — showing node details only.')}
               </div>
             ) : (
-              <MeshCoreMessageStream
-                messages={filtered}
-                contacts={contacts}
-                selfPublicKey={selfKey}
-                disabled={!connected || !canSend}
-                emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
-                onSend={text => actions.sendMessage(text, selected)}
-                conversationKey={`dm-${selected}`}
-                maxBytes={150}
-              />
+              <>
+                {canSend && filtered.length > 0 && (
+                  <div className="meshcore-conversation-toolbar">
+                    <button
+                      type="button"
+                      className="meshcore-clear-conversation-btn"
+                      onClick={() => void handleClearConversation()}
+                      title={t('meshcore.clear_conversation', 'Clear conversation')}
+                    >
+                      🗑️ {t('meshcore.clear_conversation', 'Clear conversation')}
+                    </button>
+                  </div>
+                )}
+                <MeshCoreMessageStream
+                  messages={filtered}
+                  contacts={contacts}
+                  selfPublicKey={selfKey}
+                  disabled={!connected || !canSend}
+                  emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
+                  onSend={text => actions.sendMessage(text, selected)}
+                  onDeleteMessage={canSend ? handleDeleteMessage : undefined}
+                  conversationKey={`dm-${selected}`}
+                  maxBytes={150}
+                />
+              </>
             )}
             <div className="meshcore-detail-pane">
               <MeshCoreContactDetailPanel

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -18,6 +18,9 @@ interface MeshCoreMessageStreamProps {
    *  stream prefills the composer with the `@[Sender]:` mention + focuses it;
    *  the parent uses this callback to send the reply on the message's scope. */
   onReply?: (message: MeshCoreMessage) => void;
+  /** When provided, each message row shows a delete (🗑️) action (#3981). The
+   *  parent is responsible for confirmation and the actual delete call. */
+  onDeleteMessage?: (message: MeshCoreMessage) => void | Promise<void>;
   /** Stable key identifying the current conversation. When it changes, the
    *  stream re-runs its entry scroll (to the first-unread row, or the bottom). */
   conversationKey?: string;
@@ -67,6 +70,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   onSend,
   onNodeNameClick,
   onReply,
+  onDeleteMessage,
   conversationKey,
   maxBytes = 130,
 }) => {
@@ -362,6 +366,17 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                       onClick={() => handleReply(m)}
                     >
                       ↩
+                    </button>
+                  )}
+                  {onDeleteMessage && (
+                    <button
+                      type="button"
+                      className="mc-message-delete"
+                      title={t('meshcore.delete_message', 'Delete this message')}
+                      aria-label={t('meshcore.delete_message', 'Delete this message')}
+                      onClick={() => { void onDeleteMessage(m); }}
+                    >
+                      🗑️
                     </button>
                   )}
                 </span>

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -766,6 +766,54 @@
 .mc-message-row:hover .mc-message-reply { opacity: 1; }
 .mc-message-reply:hover { color: var(--ctp-mauve); opacity: 1; }
 @media (hover: none) { .mc-message-reply { opacity: 1; } }
+/* Per-message delete affordance (#3981). Same subtle-until-hover treatment as
+   the reply button; turns red on hover to signal it's destructive. */
+.mc-message-delete {
+  background: none;
+  border: none;
+  color: var(--ctp-subtext0);
+  cursor: pointer;
+  padding: 0 0.15rem;
+  font-size: 0.8rem;
+  opacity: 0.55;
+  transition: opacity 0.15s, color 0.15s;
+}
+.mc-message-row:hover .mc-message-delete { opacity: 1; }
+.mc-message-delete:hover { color: var(--ctp-red); opacity: 1; }
+@media (hover: none) { .mc-message-delete { opacity: 1; } }
+/* Conversation / channel "clear" toolbar above the message stream (#3981). */
+.meshcore-conversation-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.35rem 0.5rem 0;
+}
+.meshcore-clear-conversation-btn {
+  background: none;
+  border: 1px solid var(--ctp-surface1);
+  color: var(--ctp-subtext0);
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.78rem;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.meshcore-clear-conversation-btn:hover {
+  color: var(--ctp-red);
+  border-color: var(--ctp-red);
+}
+/* Prominent destructive action: purge every message for the source (#3981). */
+.meshcore-purge-all-btn {
+  background: var(--ctp-red);
+  color: var(--ctp-base);
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.meshcore-purge-all-btn:hover:not(:disabled) { filter: brightness(1.1); }
+.meshcore-purge-all-btn:disabled { opacity: 0.6; cursor: default; }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
 .mc-message-route { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionStatus, MeshCoreActions, SavedRegion } from './hooks/useMeshCore';
 import { useToast } from '../ToastContainer';
+import { useAuth } from '../../contexts/AuthContext';
 
 // MeshCoreDeviceType.COMPANION — active discovery is companion-only.
 const DEVICE_TYPE_COMPANION = 1;
@@ -19,6 +20,9 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canPurgeMessages = hasPermission('messages', 'write');
+  const [purgingMessages, setPurgingMessages] = useState(false);
   const connected = status?.connected ?? false;
   const isCompanion = status?.deviceType === DEVICE_TYPE_COMPANION;
   // Which discovery (if any) is currently running, so we can disable both
@@ -55,6 +59,27 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
     const rows = await fetchSavedRegions();
     if (rows) setSavedRegions(rows);
   }, [fetchSavedRegions]);
+
+  // Purge every MeshCore message (channel + DM) for this source (#3981).
+  // Destructive and irreversible — double-confirm and surface the result.
+  const handlePurgeAllMessages = useCallback(async () => {
+    if (!window.confirm(t(
+      'meshcore.settings.confirm_purge_all_messages',
+      'Delete ALL MeshCore messages (every channel and DM) for this source? This cannot be undone.',
+    ))) return;
+    setPurgingMessages(true);
+    try {
+      const ok = await actions.purgeAllMessages();
+      showToast(
+        ok
+          ? t('meshcore.settings.purge_all_messages_done', 'All MeshCore messages purged')
+          : t('meshcore.settings.purge_all_messages_failed', 'Failed to purge messages'),
+        ok ? 'success' : 'error',
+      );
+    } finally {
+      setPurgingMessages(false);
+    }
+  }, [actions, showToast, t]);
 
   useEffect(() => {
     if (connected && isCompanion) {
@@ -443,6 +468,28 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
               </div>
             )}
           </div>
+        </div>
+      )}
+
+      {canPurgeMessages && (
+        <div className="form-section">
+          <h3>{t('meshcore.settings.message_data', 'Message data')}</h3>
+          <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', lineHeight: 1.6 }}>
+            {t(
+              'meshcore.settings.purge_all_messages_desc',
+              'Permanently delete every stored MeshCore message (all channels and direct messages) for this source.',
+            )}
+          </p>
+          <button
+            type="button"
+            className="meshcore-purge-all-btn"
+            onClick={() => void handlePurgeAllMessages()}
+            disabled={purgingMessages}
+          >
+            🗑️ {purgingMessages
+              ? t('meshcore.settings.purging', 'Purging…')
+              : t('meshcore.settings.purge_all_messages', 'Purge all messages')}
+          </button>
         </div>
       )}
     </div>

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -195,6 +195,14 @@ export interface MeshCoreActions {
    *  send re-asserts the channel/default scope. Omit (or pass `undefined`) for
    *  the normal channel/default resolution. */
   sendMessage: (text: string, toPublicKey?: string, channelIdx?: number, scope?: string | null) => Promise<boolean>;
+  /** Delete a single stored message by id (#3981). Resolves `true` on success. */
+  deleteMessage: (id: string) => Promise<boolean>;
+  /** Clear a whole DM conversation with a peer (by pubkey/prefix) (#3981). */
+  clearConversation: (publicKey: string) => Promise<boolean>;
+  /** Clear every message on a channel index (#3981). */
+  clearChannelMessages: (channelIdx: number) => Promise<boolean>;
+  /** Purge every MeshCore message (channel + DM) for this source (#3981). */
+  purgeAllMessages: () => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
   setRadioParams: (params: { freq: number; bw: number; sf: number; cr: number }) => Promise<boolean>;
   setTxPower: (power: number) => Promise<boolean>;
@@ -604,7 +612,40 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       ));
     };
 
+    // Message deletion (#3981): the server broadcasts the deletion scope and
+    // each client prunes its own view. Source-room filtering happens at the
+    // socket layer, so (like onMessage) the payload carries no sourceId.
+    const onMessagesDeleted = (evt: {
+      ids?: string[];
+      conversationPublicKey?: string;
+      channelIdx?: number;
+      all?: boolean;
+    }) => {
+      setMessages(prev => {
+        if (evt.all) return [];
+        if (evt.ids && evt.ids.length > 0) {
+          const del = new Set(evt.ids);
+          return prev.filter(m => !del.has(m.id));
+        }
+        if (typeof evt.channelIdx === 'number') {
+          const key = `channel-${evt.channelIdx}`;
+          return prev.filter(m => {
+            if (m.fromPublicKey === key || m.toPublicKey === key) return false;
+            if (evt.channelIdx === 0 && !m.toPublicKey && !m.fromPublicKey.startsWith('channel-')) return false;
+            return true;
+          });
+        }
+        if (evt.conversationPublicKey) {
+          const pk = evt.conversationPublicKey;
+          const matches = (a?: string) => !!a && (a === pk || a.startsWith(pk) || pk.startsWith(a));
+          return prev.filter(m => !(matches(m.fromPublicKey) || matches(m.toPublicKey)));
+        }
+        return prev;
+      });
+    };
+
     socket.on('meshcore:message', onMessage);
+    socket.on('meshcore:messages:deleted', onMessagesDeleted);
     socket.on('meshcore:contact:updated', onContactUpdated);
     socket.on('meshcore:status:updated', onStatusUpdated);
     socket.on('meshcore:local-node:updated', onLocalNodeUpdated);
@@ -617,6 +658,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       ackTimers.clear();
       socket.off('connect', joinRoom);
       socket.off('meshcore:message', onMessage);
+      socket.off('meshcore:messages:deleted', onMessagesDeleted);
       socket.off('meshcore:contact:updated', onContactUpdated);
       socket.off('meshcore:status:updated', onStatusUpdated);
       socket.off('meshcore:local-node:updated', onLocalNodeUpdated);
@@ -1314,6 +1356,87 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch, fetchMessages]);
 
+  // ----- Message deletion / purge (#3981) -----
+  // Each does an optimistic local prune; the server also broadcasts a
+  // meshcore:messages:deleted event so other clients (and this one) converge.
+  // Both prunes are idempotent filters, so the double-apply is harmless.
+
+  const deleteMessage = useCallback(async (id: string): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/messages/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      });
+      const data = await response.json();
+      if (data.success) {
+        setMessages(prev => prev.filter(m => m.id !== id));
+        return true;
+      }
+      setError(data.error || 'Failed to delete message');
+      return false;
+    } catch (_err) {
+      setError('Failed to delete message');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const clearConversation = useCallback(async (publicKey: string): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/messages/conversation/${encodeURIComponent(publicKey)}`, {
+        method: 'DELETE',
+      });
+      const data = await response.json();
+      if (data.success) {
+        const matches = (a?: string) => !!a && (a === publicKey || a.startsWith(publicKey) || publicKey.startsWith(a));
+        setMessages(prev => prev.filter(m => !(matches(m.fromPublicKey) || matches(m.toPublicKey))));
+        return true;
+      }
+      setError(data.error || 'Failed to clear conversation');
+      return false;
+    } catch (_err) {
+      setError('Failed to clear conversation');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const clearChannelMessages = useCallback(async (channelIdx: number): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/messages/channel/${channelIdx}`, {
+        method: 'DELETE',
+      });
+      const data = await response.json();
+      if (data.success) {
+        const key = `channel-${channelIdx}`;
+        setMessages(prev => prev.filter(m => {
+          if (m.fromPublicKey === key || m.toPublicKey === key) return false;
+          if (channelIdx === 0 && !m.toPublicKey && !m.fromPublicKey.startsWith('channel-')) return false;
+          return true;
+        }));
+        return true;
+      }
+      setError(data.error || 'Failed to clear channel messages');
+      return false;
+    } catch (_err) {
+      setError('Failed to clear channel messages');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const purgeAllMessages = useCallback(async (): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/messages`, { method: 'DELETE' });
+      const data = await response.json();
+      if (data.success) {
+        setMessages([]);
+        return true;
+      }
+      setError(data.error || 'Failed to purge messages');
+      return false;
+    } catch (_err) {
+      setError('Failed to purge messages');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const setDeviceName = useCallback(async (name: string): Promise<boolean> => {
     try {
       const response = await csrfFetch(`${mcPrefix}/config/name`, {
@@ -1578,6 +1701,10 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       importPrivateKey,
       sendAdvert,
       sendMessage,
+      deleteMessage,
+      clearConversation,
+      clearChannelMessages,
+      purgeAllMessages,
       setDeviceName,
       setRadioParams,
       setTxPower,

--- a/src/db/repositories/meshcore.messagePurge.perSource.test.ts
+++ b/src/db/repositories/meshcore.messagePurge.perSource.test.ts
@@ -1,0 +1,137 @@
+/**
+ * MeshCore message-deletion / purge — per-source isolation tests (#3981).
+ *
+ * The `meshcore_messages` table carries a `sourceId` on every row. The delete
+ * helpers added for the message-purge feature MUST scope every operation to a
+ * single source so one source's purge can never remove another's history.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MeshCoreRepository, type DbMeshCoreMessage } from './meshcore.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+let idSeq = 0;
+function makeMessage(sourceId: string, overrides: Partial<DbMeshCoreMessage> = {}): DbMeshCoreMessage {
+  const now = 1_700_000_000_000;
+  return {
+    id: `msg-${++idSeq}`,
+    fromPublicKey: 'aa'.repeat(32),
+    toPublicKey: 'bb'.repeat(32),
+    text: 'hello',
+    timestamp: now,
+    messageType: 'text',
+    sourceId,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+describe('MeshCoreRepository — message purge per-source isolation (#3981)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MeshCoreRepository;
+
+  beforeEach(() => {
+    idSeq = 0;
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MeshCoreRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('every delete helper rejects a missing sourceId', async () => {
+    await expect(repo.deleteMessageForSource('x', '')).rejects.toThrow(/sourceId/);
+    await expect(repo.deleteMessagesByIds(['x'], '')).rejects.toThrow(/sourceId/);
+    await expect(repo.getMessageEndpointsForSource('')).rejects.toThrow(/sourceId/);
+    await expect(repo.deleteChannelMessagesForSource(0, '')).rejects.toThrow(/sourceId/);
+    await expect(repo.deleteAllMessagesForSource('')).rejects.toThrow(/sourceId/);
+  });
+
+  it('deleteMessageForSource refuses to delete another source\'s message', async () => {
+    // `id` is the global primary key, so an id belongs to exactly one source.
+    // Deleting under the wrong source id must be a no-op (defends against a
+    // client guessing an id owned by a different source).
+    await repo.insertMessage(makeMessage('src-a', { id: 'a-id' }), 'src-a');
+    await repo.insertMessage(makeMessage('src-b', { id: 'b-id' }), 'src-b');
+
+    // Scoped to src-a but targeting src-b's message → no-op, row survives.
+    expect(await repo.deleteMessageForSource('b-id', 'src-a')).toBe(false);
+    expect(await repo.getMessageCount()).toBe(2);
+
+    // Correct source → deletes, leaving the other source untouched.
+    expect(await repo.deleteMessageForSource('a-id', 'src-a')).toBe(true);
+    const survivors = await repo.getRecentMessages(10, 'src-b');
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0].sourceId).toBe('src-b');
+
+    // Deleting a non-existent row returns false.
+    expect(await repo.deleteMessageForSource('missing', 'src-a')).toBe(false);
+  });
+
+  it('deleteMessagesByIds ignores ids that belong to a different source', async () => {
+    await repo.insertMessage(makeMessage('src-a', { id: 'a1' }), 'src-a');
+    await repo.insertMessage(makeMessage('src-a', { id: 'a2' }), 'src-a');
+    await repo.insertMessage(makeMessage('src-b', { id: 'b1' }), 'src-b');
+
+    // Ask to delete one src-a id and one src-b id, but scoped to src-a.
+    const removed = await repo.deleteMessagesByIds(['a1', 'b1'], 'src-a');
+    expect(removed).toBe(1);
+    expect(await repo.getMessageCount()).toBe(2); // a2 + b1 remain
+    expect(await repo.getRecentMessages(10, 'src-b')).toHaveLength(1);
+  });
+
+  it('deleteMessagesByIds chunks large id lists without leaking across sources', async () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 1200; i++) {
+      const id = `bulk-${i}`;
+      ids.push(id);
+      await repo.insertMessage(makeMessage('src-a', { id }), 'src-a');
+    }
+    await repo.insertMessage(makeMessage('src-b', { id: 'keep' }), 'src-b');
+
+    const removed = await repo.deleteMessagesByIds(ids, 'src-a');
+    expect(removed).toBe(1200);
+    expect(await repo.getRecentMessages(10, 'src-a')).toHaveLength(0);
+    expect(await repo.getRecentMessages(10, 'src-b')).toHaveLength(1);
+  });
+
+  it('deleteChannelMessagesForSource clears one channel in one source only', async () => {
+    // Channel 3 messages use the synthetic `channel-3` key.
+    await repo.insertMessage(makeMessage('src-a', { id: 'a-c3', fromPublicKey: 'channel-3', toPublicKey: null }), 'src-a');
+    await repo.insertMessage(makeMessage('src-a', { id: 'a-c4', fromPublicKey: 'channel-4', toPublicKey: null }), 'src-a');
+    await repo.insertMessage(makeMessage('src-b', { id: 'b-c3', fromPublicKey: 'channel-3', toPublicKey: null }), 'src-b');
+
+    const removed = await repo.deleteChannelMessagesForSource(3, 'src-a');
+    expect(removed).toBe(1);
+    // src-a channel 4 untouched, src-b channel 3 untouched.
+    expect(await repo.getMessageCount()).toBe(2);
+    const bRows = await repo.getRecentMessages(10, 'src-b');
+    expect(bRows.map(m => m.id)).toEqual(['b-c3']);
+  });
+
+  it('deleteAllMessagesForSource wipes one source and leaves the other intact', async () => {
+    await repo.insertMessage(makeMessage('src-a', { id: 'a1' }), 'src-a');
+    await repo.insertMessage(makeMessage('src-a', { id: 'a2' }), 'src-a');
+    await repo.insertMessage(makeMessage('src-b', { id: 'b1' }), 'src-b');
+
+    const removed = await repo.deleteAllMessagesForSource('src-a');
+    expect(removed).toBe(2);
+    expect(await repo.getRecentMessages(10, 'src-a')).toHaveLength(0);
+    expect(await repo.getRecentMessages(10, 'src-b')).toHaveLength(1);
+  });
+
+  it('getMessageEndpointsForSource returns only the source rows needed for DM matching', async () => {
+    await repo.insertMessage(makeMessage('src-a', { id: 'a1', fromPublicKey: 'cc'.repeat(6), toPublicKey: 'aa'.repeat(32) }), 'src-a');
+    await repo.insertMessage(makeMessage('src-b', { id: 'b1' }), 'src-b');
+
+    const rows = await repo.getMessageEndpointsForSource('src-a');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: 'a1', fromPublicKey: 'cc'.repeat(6) });
+  });
+});

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -1005,6 +1005,133 @@ export class MeshCoreRepository extends BaseRepository {
     return count;
   }
 
+  // ============ Scoped message deletion (#3981) ============
+  //
+  // Every method below is REQUIRED to take a sourceId — a MeshCore purge must
+  // never leak across sources. Deletion by DM conversation is computed on the
+  // manager side (see meshcoreManager.purgeConversation) because inbound DMs
+  // store a pubkey *prefix* in fromPublicKey while outbound store the full key,
+  // so matching needs the same prefix semantics the frontend uses — the manager
+  // resolves the id set and calls deleteMessagesByIds here.
+
+  /**
+   * Delete a single message by id, scoped to a source (#3981). Returns true if
+   * a row was removed. The sourceId guard means a client can't delete another
+   * source's message even if it guesses the id.
+   */
+  async deleteMessageForSource(id: string, sourceId: string): Promise<boolean> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.deleteMessageForSource requires a sourceId');
+    }
+    const { meshcoreMessages } = this.tables;
+    const condition = and(eq(meshcoreMessages.id, id), eq(meshcoreMessages.sourceId, sourceId));
+    const existing = await this.db
+      .select({ id: meshcoreMessages.id })
+      .from(meshcoreMessages)
+      .where(condition)
+      .limit(1);
+    if (existing.length === 0) return false;
+    await this.db.delete(meshcoreMessages).where(condition);
+    return true;
+  }
+
+  /**
+   * Delete a set of messages by id, scoped to a source (#3981). Chunks the id
+   * list so it never exceeds a backend's bind-variable ceiling (SQLite ~999).
+   * Returns the number of rows deleted.
+   */
+  async deleteMessagesByIds(ids: string[], sourceId: string): Promise<number> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.deleteMessagesByIds requires a sourceId');
+    }
+    if (ids.length === 0) return 0;
+    const { meshcoreMessages } = this.tables;
+    let deleted = 0;
+    const CHUNK = 500;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const batch = ids.slice(i, i + CHUNK);
+      const condition = and(
+        eq(meshcoreMessages.sourceId, sourceId),
+        inArray(meshcoreMessages.id, batch),
+      );
+      const present = await this.db
+        .select({ id: meshcoreMessages.id })
+        .from(meshcoreMessages)
+        .where(condition);
+      if (present.length === 0) continue;
+      await this.db.delete(meshcoreMessages).where(condition);
+      deleted += present.length;
+    }
+    return deleted;
+  }
+
+  /**
+   * Lightweight (id + endpoint keys + type) scan of a source's messages, used
+   * by the manager to resolve which rows belong to a DM conversation before a
+   * conversation purge (#3981). Only the columns needed for matching are
+   * selected so this stays cheap on low-volume MeshCore meshes.
+   */
+  async getMessageEndpointsForSource(
+    sourceId: string,
+  ): Promise<{ id: string; fromPublicKey: string; toPublicKey: string | null; messageType: string | null }[]> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.getMessageEndpointsForSource requires a sourceId');
+    }
+    const { meshcoreMessages } = this.tables;
+    const rows = await this.db
+      .select({
+        id: meshcoreMessages.id,
+        fromPublicKey: meshcoreMessages.fromPublicKey,
+        toPublicKey: meshcoreMessages.toPublicKey,
+        messageType: meshcoreMessages.messageType,
+      })
+      .from(meshcoreMessages)
+      .where(eq(meshcoreMessages.sourceId, sourceId));
+    return rows as { id: string; fromPublicKey: string; toPublicKey: string | null; messageType: string | null }[];
+  }
+
+  /**
+   * Delete every message on a MeshCore channel index, scoped to a source
+   * (#3981). Reuses channelWhereClause so it stays in lockstep with the channel
+   * read queries (incl. the channel-0 legacy null-recipient rule). Returns the
+   * number of rows deleted.
+   */
+  async deleteChannelMessagesForSource(channelIdx: number, sourceId: string): Promise<number> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.deleteChannelMessagesForSource requires a sourceId');
+    }
+    const { meshcoreMessages } = this.tables;
+    const condition = this.channelWhereClause(channelIdx, sourceId);
+    const toDelete = await this.db
+      .select({ id: meshcoreMessages.id })
+      .from(meshcoreMessages)
+      .where(condition);
+    if (toDelete.length === 0) return 0;
+    await this.db.delete(meshcoreMessages).where(condition);
+    return toDelete.length;
+  }
+
+  /**
+   * Delete every message owned by a source (#3981). Unlike deleteAllMessages
+   * (which wipes the whole table across all sources), this is source-scoped so
+   * one source's purge never touches another's history. Returns the number of
+   * rows deleted.
+   */
+  async deleteAllMessagesForSource(sourceId: string): Promise<number> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.deleteAllMessagesForSource requires a sourceId');
+    }
+    const { meshcoreMessages } = this.tables;
+    const condition = eq(meshcoreMessages.sourceId, sourceId);
+    const toDelete = await this.db
+      .select({ id: meshcoreMessages.id })
+      .from(meshcoreMessages)
+      .where(condition);
+    if (toDelete.length === 0) return 0;
+    await this.db.delete(meshcoreMessages).where(condition);
+    return toDelete.length;
+  }
+
   // ============ Heard-Repeater Methods (#3700) ============
 
   /**

--- a/src/server/meshcoreManager.messagePurge.test.ts
+++ b/src/server/meshcoreManager.messagePurge.test.ts
@@ -1,0 +1,119 @@
+/**
+ * MeshCoreManager message deletion / purge (#3981).
+ *
+ * Focus: the manager-side logic that the route tests can't reach with a stub —
+ * the DM prefix-matching in purgeConversation (inbound rows key the peer by a
+ * pubkey *prefix*, outbound by the full key), the in-memory pool prune, and the
+ * broadcast event. DB access is stubbed; per-source SQL scoping is covered by
+ * meshcore.messagePurge.perSource.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreMessage } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+import { dataEventEmitter } from './services/dataEventEmitter.js';
+
+const SELF = 'aa'.repeat(32);
+const PEER = 'cc'.repeat(32);
+const PEER_PREFIX = 'cc'.repeat(6); // 12-hex inbound prefix
+const OTHER = 'dd'.repeat(32);
+
+function makeManager(): MeshCoreManager {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+  (m as any).localNode = { publicKey: SELF };
+  return m;
+}
+
+function msg(id: string, from: string, to: string | null, extra: Partial<MeshCoreMessage> = {}): MeshCoreMessage {
+  return { id, fromPublicKey: from, toPublicKey: to ?? undefined, text: 't', timestamp: 1, ...extra };
+}
+
+describe('MeshCoreManager message purge (#3981)', () => {
+  let deleteMessagesByIds: any;
+  let deleteChannel: any;
+  let deleteAll: any;
+  let getEndpoints: any;
+  let emitDeleted: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEndpoints = vi.spyOn(databaseService.meshcore, 'getMessageEndpointsForSource');
+    deleteMessagesByIds = vi.spyOn(databaseService.meshcore, 'deleteMessagesByIds').mockImplementation(async (ids: string[]) => ids.length);
+    deleteChannel = vi.spyOn(databaseService.meshcore, 'deleteChannelMessagesForSource').mockResolvedValue(2);
+    deleteAll = vi.spyOn(databaseService.meshcore, 'deleteAllMessagesForSource').mockResolvedValue(4);
+    vi.spyOn(databaseService.meshcore, 'deleteMessageForSource').mockResolvedValue(true);
+    emitDeleted = vi.spyOn(dataEventEmitter, 'emitMeshCoreMessagesDeleted').mockImplementation(() => {});
+  });
+
+  it('purgeConversation matches inbound (prefix) + outbound (full) rows, excludes channels/rooms/other peers', async () => {
+    const m = makeManager();
+    // Rows across the source: two belong to the PEER conversation.
+    getEndpoints.mockResolvedValue([
+      { id: 'in', fromPublicKey: PEER_PREFIX, toPublicKey: SELF, messageType: 'text' }, // inbound DM
+      { id: 'out', fromPublicKey: SELF, toPublicKey: PEER, messageType: 'text' },        // outbound DM
+      { id: 'other', fromPublicKey: OTHER, toPublicKey: SELF, messageType: 'text' },     // different peer
+      { id: 'chan', fromPublicKey: 'channel-0', toPublicKey: null, messageType: 'text' },// channel
+      { id: 'room', fromPublicKey: PEER_PREFIX, toPublicKey: SELF, messageType: 'room_post' },
+    ]);
+    (m as any).messages = [
+      msg('in', PEER_PREFIX, SELF),
+      msg('out', SELF, PEER),
+      msg('other', OTHER, SELF),
+    ];
+
+    const count = await m.purgeConversation(PEER);
+    expect(count).toBe(2);
+    // Only the two conversation rows are targeted.
+    const [ids] = deleteMessagesByIds.mock.calls[0];
+    expect([...ids].sort()).toEqual(['in', 'out']);
+    // In-memory pool keeps only the unrelated row.
+    expect((m as any).messages.map((x: MeshCoreMessage) => x.id)).toEqual(['other']);
+    expect(emitDeleted).toHaveBeenCalledWith({ conversationPublicKey: PEER }, 'test-source');
+  });
+
+  it('purgeConversation with no matches deletes nothing and emits nothing', async () => {
+    const m = makeManager();
+    getEndpoints.mockResolvedValue([
+      { id: 'other', fromPublicKey: OTHER, toPublicKey: SELF, messageType: 'text' },
+    ]);
+    (m as any).messages = [msg('other', OTHER, SELF)];
+    const count = await m.purgeConversation(PEER);
+    expect(count).toBe(0);
+    expect(deleteMessagesByIds).not.toHaveBeenCalled();
+    expect(emitDeleted).not.toHaveBeenCalled();
+  });
+
+  it('purgeChannelMessages prunes the channel from the pool and broadcasts', async () => {
+    const m = makeManager();
+    (m as any).messages = [
+      msg('c3a', 'channel-3', null),
+      msg('c3b', SELF, 'channel-3'),
+      msg('c4', 'channel-4', null),
+    ];
+    const count = await m.purgeChannelMessages(3);
+    expect(count).toBe(2);
+    expect(deleteChannel).toHaveBeenCalledWith(3, 'test-source');
+    expect((m as any).messages.map((x: MeshCoreMessage) => x.id)).toEqual(['c4']);
+    expect(emitDeleted).toHaveBeenCalledWith({ channelIdx: 3 }, 'test-source');
+  });
+
+  it('purgeAllMessages clears the pool and broadcasts an all:true event', async () => {
+    const m = makeManager();
+    (m as any).messages = [msg('a', SELF, PEER), msg('b', PEER_PREFIX, SELF)];
+    const count = await m.purgeAllMessages();
+    expect(count).toBe(4);
+    expect(deleteAll).toHaveBeenCalledWith('test-source');
+    expect((m as any).messages).toEqual([]);
+    expect(emitDeleted).toHaveBeenCalledWith({ all: true }, 'test-source');
+  });
+
+  it('deleteStoredMessage prunes a single row and broadcasts its id', async () => {
+    const m = makeManager();
+    (m as any).messages = [msg('keep', SELF, PEER), msg('gone', PEER_PREFIX, SELF)];
+    const ok = await m.deleteStoredMessage('gone');
+    expect(ok).toBe(true);
+    expect((m as any).messages.map((x: MeshCoreMessage) => x.id)).toEqual(['keep']);
+    expect(emitDeleted).toHaveBeenCalledWith({ ids: ['gone'] }, 'test-source');
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4939,6 +4939,100 @@ class MeshCoreManager extends EventEmitter {
     return databaseService.meshcore.getChannelLatestTimestamps(channelIndices, this.sourceId);
   }
 
+  // ============ Message deletion / purge (#3981) ============
+  //
+  // Every path deletes from the DB scoped to THIS source, prunes the in-memory
+  // pool (so getRecentMessages / the reconnect catch-up don't resurrect a
+  // deleted row), and broadcasts a meshcore:messages:deleted event so every
+  // connected client prunes its view immediately.
+
+  /**
+   * Two keys refer to the same MeshCore peer when either is a prefix of the
+   * other — inbound DMs are stored under a pubkey *prefix* while outbound and
+   * contacts use the full key. Mirrors the frontend `keysMatch`.
+   */
+  private static keysMatch(a: string | null | undefined, b: string | null | undefined): boolean {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    return a.startsWith(b) || b.startsWith(a);
+  }
+
+  /**
+   * Delete a single stored message (#3981). Returns true if a row was deleted.
+   */
+  async deleteStoredMessage(id: string): Promise<boolean> {
+    const deleted = await databaseService.meshcore.deleteMessageForSource(id, this.sourceId);
+    if (deleted) {
+      this.messages = this.messages.filter(m => m.id !== id);
+      dataEventEmitter.emitMeshCoreMessagesDeleted({ ids: [id] }, this.sourceId);
+    }
+    return deleted;
+  }
+
+  /**
+   * Clear a whole DM conversation with `publicKey` (#3981). Because inbound and
+   * outbound rows key the peer differently (prefix vs full key), the id set is
+   * resolved in JS with the same prefix match the frontend uses, then deleted
+   * by id. Channel pseudo-messages and room posts are never swept up. Returns
+   * the number of rows deleted.
+   */
+  async purgeConversation(publicKey: string): Promise<number> {
+    const rows = await databaseService.meshcore.getMessageEndpointsForSource(this.sourceId);
+    const selfKey = this.localNode?.publicKey;
+    const ids = rows
+      .filter(r => {
+        if (r.messageType === 'room_post') return false;
+        if (r.fromPublicKey.startsWith('channel-')) return false;
+        if (r.toPublicKey && r.toPublicKey.startsWith('channel-')) return false;
+        // A row belongs to this conversation when the peer appears on either
+        // endpoint. When we know our own key, exclude it so a self-key match
+        // doesn't drag in unrelated peers' rows.
+        const fromPeer = !MeshCoreManager.keysMatch(r.fromPublicKey, selfKey)
+          && MeshCoreManager.keysMatch(r.fromPublicKey, publicKey);
+        const toPeer = !MeshCoreManager.keysMatch(r.toPublicKey, selfKey)
+          && MeshCoreManager.keysMatch(r.toPublicKey, publicKey);
+        return fromPeer || toPeer;
+      })
+      .map(r => r.id);
+    if (ids.length === 0) return 0;
+    const count = await databaseService.meshcore.deleteMessagesByIds(ids, this.sourceId);
+    if (count > 0) {
+      const deleted = new Set(ids);
+      this.messages = this.messages.filter(m => !deleted.has(m.id));
+      dataEventEmitter.emitMeshCoreMessagesDeleted({ conversationPublicKey: publicKey }, this.sourceId);
+    }
+    return count;
+  }
+
+  /**
+   * Clear every message on a channel index (#3981). Returns rows deleted.
+   */
+  async purgeChannelMessages(channelIdx: number): Promise<number> {
+    const count = await databaseService.meshcore.deleteChannelMessagesForSource(channelIdx, this.sourceId);
+    if (count > 0) {
+      const key = `channel-${channelIdx}`;
+      this.messages = this.messages.filter(m => {
+        // Mirror channelWhereClause: synthetic channel key on either side, plus
+        // the channel-0 legacy broadcast rows (no recipient, non-synthetic sender).
+        if (m.fromPublicKey === key || m.toPublicKey === key) return false;
+        if (channelIdx === 0 && !m.toPublicKey && !m.fromPublicKey.startsWith('channel-')) return false;
+        return true;
+      });
+      dataEventEmitter.emitMeshCoreMessagesDeleted({ channelIdx }, this.sourceId);
+    }
+    return count;
+  }
+
+  /**
+   * Purge every message for this source (#3981). Returns rows deleted.
+   */
+  async purgeAllMessages(): Promise<number> {
+    const count = await databaseService.meshcore.deleteAllMessagesForSource(this.sourceId);
+    this.messages = [];
+    dataEventEmitter.emitMeshCoreMessagesDeleted({ all: true }, this.sourceId);
+    return count;
+  }
+
   isConnected(): boolean {
     return this.connected;
   }

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -43,6 +43,11 @@ const meshcoreManager = {
   getContacts: vi.fn().mockReturnValue([]),
   getContact: vi.fn().mockReturnValue(undefined),
   getRecentMessages: vi.fn().mockReturnValue([]),
+  // Message deletion / purge (#3981)
+  deleteStoredMessage: vi.fn().mockResolvedValue(true),
+  purgeConversation: vi.fn().mockResolvedValue(3),
+  purgeChannelMessages: vi.fn().mockResolvedValue(5),
+  purgeAllMessages: vi.fn().mockResolvedValue(9),
   connect: vi.fn().mockResolvedValue(true),
   disconnect: vi.fn().mockResolvedValue(undefined),
   sendMessage: vi.fn().mockResolvedValue(true),
@@ -545,6 +550,87 @@ describe('MeshCore Routes', () => {
         .send({ text: 'Hello', toPublicKey: validKey });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
+    });
+  });
+
+  // Message deletion / purge (#3981). Every route requires auth + messages:write
+  // and is scoped to the source in the URL. The manager is stubbed, so these
+  // assert routing/permission/validation and that the right manager method is
+  // invoked with the source-scoped arguments.
+  describe('MeshCore message deletion / purge (#3981)', () => {
+    const VALID_PK = 'a'.repeat(64);
+
+    it('DELETE /messages/:id requires authentication', async () => {
+      const response = await request(app)
+        .delete('/api/sources/test-source/meshcore/messages/abc-123');
+      expect(response.status).toBe(401);
+    });
+
+    it('DELETE /messages/:id deletes a single message', async () => {
+      const response = await authenticatedAgent
+        .delete('/api/sources/test-source/meshcore/messages/abc-123');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(meshcoreManager.deleteStoredMessage).toHaveBeenCalledWith('abc-123');
+    });
+
+    it('DELETE /messages/:id returns 404 when the message is missing', async () => {
+      meshcoreManager.deleteStoredMessage.mockResolvedValueOnce(false);
+      const response = await authenticatedAgent
+        .delete('/api/sources/test-source/meshcore/messages/nope');
+      expect(response.status).toBe(404);
+    });
+
+    it('DELETE /messages/conversation/:publicKey clears a DM conversation', async () => {
+      const response = await authenticatedAgent
+        .delete(`/api/sources/test-source/meshcore/messages/conversation/${VALID_PK}`);
+      expect(response.status).toBe(200);
+      expect(response.body.deletedCount).toBe(3);
+      expect(meshcoreManager.purgeConversation).toHaveBeenCalledWith(VALID_PK);
+    });
+
+    it('DELETE /messages/conversation/:publicKey rejects a non-hex key', async () => {
+      const response = await authenticatedAgent
+        .delete('/api/sources/test-source/meshcore/messages/conversation/not-hex!!');
+      expect(response.status).toBe(400);
+      expect(meshcoreManager.purgeConversation).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /messages/channel/:idx clears a channel', async () => {
+      const response = await authenticatedAgent
+        .delete('/api/sources/test-source/meshcore/messages/channel/3');
+      expect(response.status).toBe(200);
+      expect(response.body.deletedCount).toBe(5);
+      expect(meshcoreManager.purgeChannelMessages).toHaveBeenCalledWith(3);
+    });
+
+    it('DELETE /messages/channel/:idx rejects a bad index', async () => {
+      const response = await authenticatedAgent
+        .delete('/api/sources/test-source/meshcore/messages/channel/-1');
+      expect(response.status).toBe(400);
+      expect(meshcoreManager.purgeChannelMessages).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /messages purges every message for the source', async () => {
+      const response = await authenticatedAgent
+        .delete('/api/sources/test-source/meshcore/messages');
+      expect(response.status).toBe(200);
+      expect(response.body.deletedCount).toBe(9);
+      expect(meshcoreManager.purgeAllMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('DELETE /messages requires authentication', async () => {
+      const response = await request(app)
+        .delete('/api/sources/test-source/meshcore/messages');
+      expect(response.status).toBe(401);
+      expect(meshcoreManager.purgeAllMessages).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 for an unregistered source (no cross-source leak)', async () => {
+      const response = await authenticatedAgent
+        .delete('/api/sources/no-such-source/meshcore/messages');
+      expect(response.status).toBe(404);
+      expect(meshcoreManager.purgeAllMessages).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -136,7 +136,7 @@ function isValidPublicKey(key: string | undefined): boolean {
 function auditMeshcoreEvent(
   req: Request,
   action: string,
-  resource: 'remote_admin' | 'configuration',
+  resource: 'remote_admin' | 'configuration' | 'messages',
   details: Record<string, unknown>,
 ): void {
   const userId = req.session?.userId ?? null;
@@ -1434,6 +1434,103 @@ router.get('/messages/channel-counts', optionalAuth(), requirePermission('messag
   } catch (error) {
     logger.error('[API] Error getting channel message counts:', error);
     res.status(500).json({ success: false, error: 'Failed to get channel message counts' });
+  }
+});
+
+/**
+ * DELETE /api/sources/:id/meshcore/messages
+ * Purge EVERY MeshCore message (channel + DM) for this source (#3981). The
+ * MeshCore analogue of the Meshtastic "purge all messages" admin action.
+ * Scoped to `:id` via requirePermission — never touches other sources.
+ */
+router.delete('/messages', requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const deletedCount = await managerFor(req).purgeAllMessages();
+    auditMeshcoreEvent(req, 'meshcore_messages_purged', 'messages', {
+      sourceId: req.params.id,
+      deletedCount,
+    });
+    res.json({ success: true, message: 'All MeshCore messages purged', deletedCount });
+  } catch (error) {
+    logger.error('[API] Error purging MeshCore messages:', error);
+    res.status(500).json({ success: false, error: 'Failed to purge messages' });
+  }
+});
+
+/**
+ * DELETE /api/sources/:id/meshcore/messages/channel/:idx
+ * Clear every message on a channel index for this source (#3981). Registered
+ * before /messages/:id so the two-segment path wins the route match.
+ */
+router.delete('/messages/channel/:idx', requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const idx = parseInt(req.params.idx, 10);
+    if (isNaN(idx) || idx < 0) {
+      return res.status(400).json({ success: false, error: 'idx must be a non-negative integer' });
+    }
+    const deletedCount = await managerFor(req).purgeChannelMessages(idx);
+    auditMeshcoreEvent(req, 'meshcore_channel_messages_cleared', 'messages', {
+      sourceId: req.params.id,
+      channelIdx: idx,
+      deletedCount,
+    });
+    res.json({ success: true, message: 'Channel messages cleared', channelIdx: idx, deletedCount });
+  } catch (error) {
+    logger.error('[API] Error clearing MeshCore channel messages:', error);
+    res.status(500).json({ success: false, error: 'Failed to clear channel messages' });
+  }
+});
+
+/**
+ * DELETE /api/sources/:id/meshcore/messages/conversation/:publicKey
+ * Clear a whole DM conversation for this source (#3981). `publicKey` may be a
+ * pubkey prefix or full 64-hex key; the manager resolves the id set with the
+ * same prefix match the UI uses. Registered before /messages/:id.
+ */
+router.delete('/messages/conversation/:publicKey', requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const publicKey = String(req.params.publicKey || '').toLowerCase();
+    if (!/^[0-9a-f]{2,64}$/.test(publicKey)) {
+      return res.status(400).json({ success: false, error: 'publicKey must be a hex string' });
+    }
+    const deletedCount = await managerFor(req).purgeConversation(publicKey);
+    auditMeshcoreEvent(req, 'meshcore_dm_conversation_cleared', 'messages', {
+      sourceId: req.params.id,
+      publicKey,
+      deletedCount,
+    });
+    res.json({ success: true, message: 'Conversation cleared', publicKey, deletedCount });
+  } catch (error) {
+    logger.error('[API] Error clearing MeshCore conversation:', error);
+    res.status(500).json({ success: false, error: 'Failed to clear conversation' });
+  }
+});
+
+/**
+ * DELETE /api/sources/:id/meshcore/messages/:messageId
+ * Delete a single MeshCore message by id, scoped to this source (#3981).
+ * NB: the path param is `:messageId`, NOT `:id` — the router is mounted under
+ * `/api/sources/:id/meshcore`, so a `:id` here would shadow the source id in
+ * `req.params.id` (breaking manager lookup and permission scoping).
+ */
+router.delete('/messages/:messageId', requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const messageId = String(req.params.messageId || '');
+    if (!messageId) {
+      return res.status(400).json({ success: false, error: 'message id is required' });
+    }
+    const deleted = await managerFor(req).deleteStoredMessage(messageId);
+    if (!deleted) {
+      return res.status(404).json({ success: false, error: 'Message not found' });
+    }
+    auditMeshcoreEvent(req, 'meshcore_message_deleted', 'messages', {
+      sourceId: req.params.id,
+      messageId,
+    });
+    res.json({ success: true, message: 'Message deleted', id: messageId });
+  } catch (error) {
+    logger.error('[API] Error deleting MeshCore message:', error);
+    res.status(500).json({ success: false, error: 'Failed to delete message' });
   }
 });
 

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -26,6 +26,7 @@ export type DataEventType =
   | 'waypoint:deleted'
   | 'waypoint:expired'
   | 'meshcore:message'
+  | 'meshcore:messages:deleted'
   | 'meshcore:contact:updated'
   | 'meshcore:status:updated'
   | 'meshcore:local-node:updated'
@@ -315,6 +316,28 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] MeshCore message from ${message.fromPublicKey}`);
+  }
+
+  /**
+   * Emit a MeshCore message-deletion event (#3981) so connected clients prune
+   * the deleted messages from their view. The payload describes the deletion
+   * scope; the client applies the same match locally (single ids, a whole DM
+   * conversation, a channel index, or every message for the source). The event
+   * is source-room-filtered by the socket layer, so the payload carries no
+   * sourceId (mirroring emitMeshCoreMessage).
+   */
+  emitMeshCoreMessagesDeleted(
+    data: { ids?: string[]; conversationPublicKey?: string; channelIdx?: number; all?: boolean },
+    sourceId: string,
+  ): void {
+    const event: DataEvent = {
+      type: 'meshcore:messages:deleted',
+      data,
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] MeshCore messages deleted (source ${sourceId})`);
   }
 
   /**


### PR DESCRIPTION
Closes #3981.

## Summary
MeshCore messages (channel and DM) had no way to be deleted or purged from the UI, unlike Meshtastic sources. This PR adds the full stack — per-message delete, per-conversation/channel clear, and "purge all MeshCore messages for this source" — mirroring the existing Meshtastic purge patterns and honouring per-source scoping end to end.

## Storage model note
All MeshCore messages live in one `meshcore_messages` table; channel identity is synthesised into `channel-N` pubkey columns and DMs use real pubkeys. Inbound DMs store the sender as a **pubkey prefix** while outbound store the full key, so DM conversation matching needs the same prefix semantics the frontend `keysMatch` uses — resolved in the manager, then deleted by id.

## Backend
- **Repository** (`src/db/repositories/meshcore.ts`): source-scoped deletes — `deleteMessageForSource`, `deleteMessagesByIds` (chunked to stay under SQLite's bind-variable ceiling), `deleteChannelMessagesForSource` (reuses the existing `channelWhereClause`), `deleteAllMessagesForSource`, plus a lightweight `getMessageEndpointsForSource`. Every method requires a `sourceId`.
- **Manager** (`src/server/meshcoreManager.ts`): `deleteStoredMessage`, `purgeConversation`, `purgeChannelMessages`, `purgeAllMessages`. Each deletes scoped to its own source, prunes the in-memory message pool, and broadcasts a new `meshcore:messages:deleted` event.
- **Routes** (`src/server/routes/meshcoreRoutes.ts`): `DELETE /messages`, `/messages/channel/:idx`, `/messages/conversation/:publicKey`, `/messages/:messageId` — all `requireAuth()` + `requirePermission('messages','write',{ sourceIdFrom: 'params.id' })` and audit-logged. (The single-message route param is `:messageId`, not `:id`, so it doesn't shadow the mount's source id.)

## Frontend / UI approach
- **Per-message delete**: an optional `onDeleteMessage` callback on the shared `MeshCoreMessageStream`, rendering a hover-revealed 🗑️ next to the existing reply affordance — wired into **both** the DM view and the channel view (one component, both surfaces).
- **Per-conversation / per-channel clear**: a small "Clear conversation" / "Clear channel messages" toolbar button above the stream in each view.
- **Purge all**: a "Message data" danger section in `MeshCoreSettingsView` with a "Purge all messages" button. Chosen because the settings view is the natural home for a source-wide destructive action and already receives `actions` (no sourceId threading needed).
- The `useMeshCore` hook gains the four actions and a `meshcore:messages:deleted` socket handler that prunes local state; all destructive UI paths `window.confirm` first, matching the Meshtastic idiom.

## Tests
- `meshcore.messagePurge.perSource.test.ts` — repository source-isolation (incl. chunking + refusing another source's id).
- `meshcoreManager.messagePurge.test.ts` — DM prefix matching, pool prune, event emit.
- `meshcoreRoutes.test.ts` — auth (401), permission-scoped routing, validation (400), 404s, and no cross-source leak.

## Verification
- `tsc --noEmit`: clean.
- Full Vitest suite: **8080 passed, 0 failed** (2 skipped files, 607 skipped, 21 todo).
- Lint: no new errors introduced (pre-existing `NodeJS`/`no-undef` noise from `eslint .` is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub