### PR TITLE
ci(types): type-check test files via tsconfig.tests.json, non-blocking first (#3962)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,14 @@ jobs:
       - name: Run type checking
         run: npm run typecheck
 
+      - name: Type-check tests (non-blocking)
+        if: matrix.node-version == '24.x'
+        run: npm run typecheck:tests
+        # NON-BLOCKING: ~283 pre-existing test-type errors (mock/signature drift).
+        # Flip to blocking (remove continue-on-error) once `npm run typecheck:tests` is clean (0 errors).
+        # Tracking: remediation epic #3962 Task 1.2.
+        continue-on-error: true
+
       - name: Run tests
         run: npm run test:run
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -90,6 +90,12 @@ jobs:
           echo "Running TypeScript compiler..."
           npm run typecheck
 
+      - name: Type-check tests (non-blocking)
+        run: npm run typecheck:tests
+        # NON-BLOCKING: ~283 pre-existing test-type errors. Flip to blocking (drop continue-on-error)
+        # when `npm run typecheck:tests` reports 0. Tracking: #3962 Task 1.2.
+        continue-on-error: true
+
       - name: Run unit tests
         run: |
           echo "Running test suite..."

--- a/docs/internal/dev-notes/REMEDIATION_EPIC.md
+++ b/docs/internal/dev-notes/REMEDIATION_EPIC.md
@@ -16,12 +16,12 @@ Each unchecked phase = one worktree → architect spec → implementation → re
 
 - [x] **P0-docs** — Merge `docs/remediation-plan` (REMEDIATION_PLAN.md + this file) to main.
 - [x] **0.1** — Process-level safety net: `unhandledRejection`/`uncaughtException` handlers in `server.ts`, logging with full context and routing through `gracefulShutdown()`. Exit: deliberate `Promise.reject()` in dev logs and shuts down gracefully.
-- [ ] **0.2** — Trust-proxy default → `false` when `TRUST_PROXY` unset; keep startup warning; release-notes/README documentation for proxied deployments.
-- [ ] **0.3** — Pin `meshcore.js` fork dependency to a commit SHA; lockfile regenerated; `npm ci` reproducible.
-- [ ] **0.4** — Strip/gate the hot-path `console.log`s in `src/services/api.ts` (CSRF token status + token prefix on every mutation); kept diagnostics behind a debug flag.
-- [ ] **0.5** — `@typescript-eslint/no-floating-promises` as `error` for non-test code; violations fixed or explicitly `void`/`.catch()`ed.
-- [ ] **1.1** — `withSourceScope` fails closed: omitting `sourceId` throws; explicit `ALL_SOURCES` sentinel for the documented global-by-design consumers (channel decryption, estimated positions, automations); full call-site audit.
-- [ ] **1.2** — Type-check the tests: `tsconfig.tests.json` (strict, `noImplicitAny` off initially), wired into CI non-blocking first; flip to blocking once clean.
+- [x] **0.2** — Trust-proxy default → `false` when `TRUST_PROXY` unset; keep startup warning; release-notes/README documentation for proxied deployments.
+- [x] **0.3** — Pin `meshcore.js` fork dependency to a commit SHA; lockfile regenerated; `npm ci` reproducible.
+- [x] **0.4** — Strip/gate the hot-path `console.log`s in `src/services/api.ts` (CSRF token status + token prefix on every mutation); kept diagnostics behind a debug flag.
+- [x] **0.5** — `@typescript-eslint/no-floating-promises` as `error` for non-test code; violations fixed or explicitly `void`/`.catch()`ed.
+- [x] **1.1** — `withSourceScope` fails closed: omitting `sourceId` throws; explicit `ALL_SOURCES` sentinel for the documented global-by-design consumers (channel decryption, estimated positions, automations); full call-site audit.
+- [x] **1.2** — Type-check the tests: `tsconfig.tests.json` (full strict — see phase log deviation), wired into CI non-blocking first; flip to blocking once clean.
 - [ ] **1.3** — Integration-grade route-test harness: in-memory SQLite + real Express app with real `requirePermission`/session/auth wiring; 3–5 representative route test files converted (source-scoped permission coverage); no mass conversion.
 - [ ] **1.4** — Lint ratchets: `no-explicit-any` → `error` with checked-in baseline; forbid raw `fetch(` in `src/components/**`/`src/pages/**` (baselined); `react-hooks/exhaustive-deps` + `prefer-const` → `error`.
 - [ ] **1.5** — Response-envelope convention: `ok(res, data)` / `fail(res, status, code, msg)` helper for the `{ success, error, code }` envelope; documented in CLAUDE.md; new/modified handlers must use it.
@@ -39,3 +39,10 @@ Record per-phase: PR link, deviations from plan, follow-ups.
 
 - **P0-docs** — PR #3966 merged (plan + epic doc on main). No deviations.
 - **0.1** — PR #3967 merged (processSafetyNet.ts + idempotent gracefulShutdown with exitCode param). Deviation: NodeJS.* type annotations replaced with inference/unknown due to ESLint no-undef.
+- **0.2** — PR #3968 merged (trust-proxy default → false + docs/CHANGELOG BREAKING entry). No deviations.
+- **0.3** — PR #3969 merged (SHA pin b98fc338, matched existing lockfile resolution). No deviations.
+- **0.4** — PR #3970 merged (token-prefix leak removed; diagnostics → logger.warn/debug). No guard test added (no api.test.ts exists; nothing asserted on the removed lines).
+- **0.5** — PR #3972 merged (418 violations: 409 `void`, 9 `.catch(logger.error)`; rule scoped to src non-test). Deviation: "npm run lint exits 0" unmet — 367 pre-existing errors in tests/-dir files; CI lint is non-blocking (continue-on-error) — make blocking in 1.4. mqttBridgeManager "deferred parent broker attach" test observed flaky in CI (passes on rerun).
+- **1.1** — PR #3976 merged (ALL_SOURCES unique-symbol sentinel; runtime throw + Tier-2 required params; 3 real leaks fixed: server.ts getNodeCount refresh, deleteNode→deleteNeighborInfoInvolvingNode, meshtasticManager pending-DM fetch). Review-loop correction: implementer's repo-body `?? ALL_SOURCES` normalization (silent fail-open) reverted; explicit per-call-site decisions instead. CI: Quick Tests outgrew its 15-min cap (#3385 redux) → raised to 25 min in this PR.
+  **Follow-up findings (1.1 architect §10, epic backlog):** hand-rolled fail-open `if (sourceId)` filters bypass the helper — all of `meshcore.ts`, `notifications.ts` subscriptions, parts of `channels.ts`, `nodes.ts:getAllNodesSqlite`; legacy `*Sync`/`*Sqlite` twins partially covered (Phase 3.4 deletes them); facade `getNode(nodeNum)` single-source-assumption chain (revisit with Phase 2).
+- **1.2** — PR TBD (tsconfig.tests.json + `typecheck:tests` script + non-blocking CI steps in ci.yml/pr-tests.yml). Deviations: (a) kept FULL strict incl. noImplicitAny — plan's "noImplicitAny off" injects ~50 false-positive errors into prod src via evolving-any inference; (b) top-level `tests/` dir NOT included — its files pull @types/node into the program and poison frontend inference (~60 spurious errors). Baseline: 283 errors, all in src test files, 0 prod. Flip-to-blocking when count reaches 0 (burndown is a follow-up; top ~8 files hold ~150 errors).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,19 @@
+{
+  // Type-checks the Vitest test files alongside the production sources they
+  // import, so mock shapes can't silently drift from real signatures
+  // (remediation epic #3962, Task 1.2). Run via `npm run typecheck:tests`.
+  //
+  // NOTE: deliberately does NOT include the top-level `tests/` directory —
+  // adding those files pulls @types/node into the whole program and changes
+  // inference inside production frontend files (~60 spurious implicit-any
+  // errors in src/components). If `tests/` should ever be type-checked, give
+  // it its own config with its own `types` set.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Task **1.2** of the remediation plan (#3962, Phase 1).

~557 test files currently get zero type-checking (`tsconfig.json` excludes `**/*.test.ts*`), so mock shapes silently drift from real signatures. This adds:

- **`tsconfig.tests.json`** — extends the root config, adds `src/**/*.test.ts(x)` to the program, relaxes only `noUnusedLocals`/`noUnusedParameters`.
- **`npm run typecheck:tests`** script.
- **Non-blocking CI steps** in `ci.yml` (gated to the 24.x leg to avoid 4× matrix cost) and `pr-tests.yml`, each with an inline comment stating the flip-to-blocking condition (error count = 0).
- Epic status doc updated through Task 1.2.

**Baseline: 283 errors, all in test files, zero in production sources** — real drift (e.g. mock `checkPermission` signatures that no longer match, properties read off mocks that the real type doesn't have). Top ~8 files hold ~150 of them; burndown + flip-to-blocking is follow-up work.

## Deviations from the plan (measured, documented in the epic doc)

1. **Full `strict` kept — `noImplicitAny` stays ON.** The plan suggested turning it off initially; measured, that *adds* ~50 false-positive errors in production files (disabling evolving-any inference) while hiding real test drift. Strict-on is better on every axis: 283/0 test/prod vs 345/50.
2. **Top-level `tests/` dir excluded** — including it pulls `@types/node` into the whole program and poisons frontend inference (~60 spurious implicit-any errors in `src/components`). Documented in the config header; it can get its own config later if wanted.

## Verification

- Baseline reproducible: `npm run typecheck:tests` → 283 errors, 0 in prod files.
- Negative test: a deliberate `string`-into-`number` mock error was caught at its exact location, then reverted (283 → 284 → 283).
- `npm run typecheck` (prod) unaffected: clean. Builds and vitest untouched.
- Full suite: **8068 passed, 0 failed, 0 suite failures** (`success: true`).

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n