### PR TITLE
test(routes): integration-grade route-test harness with real auth middleware (#3962)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,23 @@ Mock async methods used by `authMiddleware`:
 ```
 For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceId)` to return source-specific resource maps.
 
+### Route Test Harness (preferred for new/changed route tests)
+For route tests that exercise `requirePermission` / `optionalAuth`, use `createRouteTestApp()` (`src/server/test-helpers/routeTestApp.ts`) instead of monkey-patching `checkPermissionAsync` or mocking the whole `services/database.js` module. The harness wires real express-session (MemoryStore) + real auth middleware against the singleton's `:memory:` SQLite DB, and seeds per-test permission rows so that real SQL enforces isolation.
+
+```typescript
+let harness: RouteTestHarness;
+beforeEach(async () => {
+  harness = await createRouteTestApp({ mount: app => app.use('/', myRouter) });
+  await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+});
+afterEach(() => harness.cleanup());
+```
+
+- **New or changed route tests MUST use the harness.** Legacy tests using `vi.mock('../../services/database.js', ...)` convert opportunistically when the file is touched.
+- The monkey-patch pattern (`vi.mock(...)` + fake `checkPermissionAsync` lambda) is deprecated for route tests. A fake that re-implements the logic under test cannot catch regressions in that logic.
+- See `src/server/routes/sourceRoutes.permissions.test.ts` as the canonical template.
+- Non-DB mocks (`sourceManagerRegistry`, `meshtasticManager`, service mocks) are still correct and must remain.
+
 ### Raw SQL Ban
 - `src/services/database.ts` is raw-SQL-free. All domain queries live in `src/db/repositories/*`.
 - ESLint rule (`no-restricted-syntax` in `eslint.config.mjs`) forbids `this.db.prepare`, `this.db.exec`, `postgresPool.query`, `mysqlPool.query` outside `src/server/migrations/**` and test files.

--- a/src/server/routes/channelDatabaseRoutes.permissions.test.ts
+++ b/src/server/routes/channelDatabaseRoutes.permissions.test.ts
@@ -1,44 +1,31 @@
 /**
- * Legacy session-mount channel-database — permission model tests (PR-B mirror)
+ * Legacy session-mount channel-database — permission model tests
  *
- * Parity coverage for the `/api/channel-database` mount. Both v1 (Bearer-token)
- * and legacy (browser-session) mounts share `_channelDatabaseHandlers.ts`, so
- * the same permission logic must hold here.
+ * Converted from the monkey-patch pattern (vi.mock('../../services/database.js')
+ * + vi.mock('../auth/authMiddleware.js')) to the real-middleware harness
+ * (createRouteTestApp). The harness uses the live DatabaseService singleton with
+ * real session + requireAuth + real checkPermissionAsync, seeding per-test
+ * permission rows instead of hand-rolling fake implementations.
  *
- * The `requireAuth()` middleware is mocked to a passthrough — these tests
- * exercise handler logic, not auth-token validation.
+ * Permission model (global resource — channel_database is NOT source-scoped):
+ *   channel_database:read  → list / get (PSK masked) + retroactive-decrypt progress
+ *   channel_database:write → create / update / delete / reorder + ACL management
+ *
+ * Source-isolation note: channel_database is a global-by-design resource
+ * (no sourceId column on its permissions). The isolation assertion below
+ * therefore proves that the REAL checkPermissionAsync enforces a global
+ * grant/no-grant boundary rather than a per-source row boundary.
+ * For per-source resource isolation see sourceRoutes.permissions.test.ts.
+ *
+ * Non-DB service mocks stay: channelDecryptionService and
+ * retroactiveDecryptionService would attempt real file/network I/O.
+ *
+ * See src/server/test-helpers/routeTestApp.ts for the design rationale.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import express, { Express } from 'express';
-import request from 'supertest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-vi.mock('../auth/authMiddleware.js', () => ({
-  requireAuth: () => (_req: any, _res: any, next: any) => next(),
-}));
-
-vi.mock('../../services/database.js', () => ({
-  default: {
-    channelDatabase: {
-      getAllAsync: vi.fn(),
-      getByIdAsync: vi.fn(),
-      getPermissionsForUserAsync: vi.fn(),
-      getPermissionAsync: vi.fn(),
-      getPermissionsForChannelAsync: vi.fn(),
-      createAsync: vi.fn(),
-      updateAsync: vi.fn(),
-      deleteAsync: vi.fn(),
-      reorderAsync: vi.fn(),
-      setPermissionAsync: vi.fn(),
-      deletePermissionAsync: vi.fn(),
-    },
-    findUserByIdAsync: vi.fn(),
-    checkPermissionAsync: vi.fn(),
-    getDistinctEncryptedPacketSourceIdsAsync: vi.fn(),
-    drizzleDbType: 'sqlite',
-  },
-}));
-
+// Non-DB service mocks: keep these to avoid real I/O in tests.
 vi.mock('../services/channelDecryptionService.js', () => ({
   channelDecryptionService: { invalidateCache: vi.fn() },
 }));
@@ -53,13 +40,9 @@ vi.mock('../services/retroactiveDecryptionService.js', () => ({
 
 import channelDatabaseRoutes from './channelDatabaseRoutes.js';
 import databaseService from '../../services/database.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 
-const mockDb = databaseService as any;
-
-const adminUser = { id: 1, username: 'admin', isAdmin: true, isActive: true };
-const writerUser = { id: 50, username: 'writer', isAdmin: false, isActive: true };
-const readerUser = { id: 60, username: 'reader', isAdmin: false, isActive: true };
-const noPermsUser = { id: 70, username: 'nobody', isAdmin: false, isActive: true };
+// ── shared test fixtures ──────────────────────────────────────────────────────
 
 const fakePsk = Buffer.alloc(16, 0xab).toString('base64');
 const channel1 = {
@@ -78,42 +61,81 @@ const channel1 = {
   updatedAt: 1000,
 };
 
-const createApp = (user: any): Express => {
-  const app = express();
-  app.use(express.json());
-  app.use((req: any, _res, next) => {
-    req.user = user;
-    next();
-  });
-  app.use('/api/channel-database', channelDatabaseRoutes);
-  return app;
-};
+// ── harness wiring ────────────────────────────────────────────────────────────
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockDb.channelDatabase.getAllAsync.mockResolvedValue([channel1]);
-  mockDb.channelDatabase.getByIdAsync.mockResolvedValue(channel1);
-  mockDb.channelDatabase.getPermissionsForUserAsync.mockResolvedValue([]);
-  mockDb.channelDatabase.getPermissionAsync.mockResolvedValue(null);
-  mockDb.checkPermissionAsync.mockResolvedValue(false);
+let harness: RouteTestHarness;
+
+beforeEach(async () => {
+  harness = await createRouteTestApp({
+    // channelDatabaseRoutes apply requireAuth() internally; the harness mounts
+    // optionalAuth() before the router so the session is available, and
+    // requireAuth() reads req.session.userId set by loginAs().
+    mount: (app) => app.use('/api/channel-database', channelDatabaseRoutes),
+  });
+
+  // Spy on channelDatabase repo data methods so tests control returned rows
+  // while real checkPermissionAsync enforces access gates.
+  vi.spyOn(databaseService.channelDatabase, 'getAllAsync').mockResolvedValue([channel1 as any]);
+  vi.spyOn(databaseService.channelDatabase, 'getByIdAsync').mockResolvedValue(channel1 as any);
+  vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([]);
+  vi.spyOn(databaseService.channelDatabase, 'getPermissionAsync').mockResolvedValue(null);
+  vi.spyOn(databaseService.channelDatabase, 'createAsync').mockResolvedValue(42);
+
+  // No channel_database permission grants by default — tests add what they need.
 });
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await harness.cleanup();
+});
+
+// ── describe 1: permission isolation (global-resource proof) ─────────────────
+//
+// channel_database is global — no sourceId scoping on the resource itself.
+// The assertions below prove the real checkPermissionAsync enforces the
+// grant/no-grant boundary correctly.
+
+describe('permission isolation — global resource (real checkPermissionAsync)', () => {
+  it('user WITH global channel_database:read grant can list channels (200)', async () => {
+    // Global grant (no sourceId arg → sourceId=NULL row)
+    await harness.grant(harness.limited.id, 'channel_database', 'read');
+    // Per-entry permission: canRead=true for channel 1
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([
+      { userId: harness.limited.id, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any,
+    ]);
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database');
+    expect(res.status).toBe(200);
+  });
+
+  it('user WITHOUT channel_database:read grant is denied (403 — real checkPermissionAsync)', async () => {
+    // No grant seeded — real checkPermissionAsync finds no row → false → 403.
+    // Previously a `mockResolvedValue(false)` hid any real implementation bug.
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database');
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── describe 2: GET / permission filtering ───────────────────────────────────
 
 describe('Legacy mount — GET / permission filtering', () => {
   it('admin: returns channels with full PSK', async () => {
-    const res = await request(createApp(adminUser)).get('/api/channel-database');
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/api/channel-database');
     expect(res.status).toBe(200);
     expect(res.body.data[0].psk).toBeDefined();
   });
 
   it('non-admin with :read + per-entry canRead: returns entry with masked PSK', async () => {
-    mockDb.checkPermissionAsync.mockImplementation(
-      async (_uid: number, resource: string, action: string) =>
-        resource === 'channel_database' && action === 'read'
-    );
-    mockDb.channelDatabase.getPermissionsForUserAsync.mockResolvedValue([
-      { userId: 60, channelDatabaseId: 1, canViewOnMap: false, canRead: true },
+    await harness.grant(harness.limited.id, 'channel_database', 'read');
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([
+      { userId: harness.limited.id, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any,
     ]);
-    const res = await request(createApp(readerUser)).get('/api/channel-database');
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database');
     expect(res.status).toBe(200);
     expect(res.body.count).toBe(1);
     expect(res.body.data[0].psk).toBeUndefined();
@@ -121,66 +143,80 @@ describe('Legacy mount — GET / permission filtering', () => {
   });
 
   it('non-admin without :read: returns 403', async () => {
-    const res = await request(createApp(noPermsUser)).get('/api/channel-database');
+    // No grants for limited — real checkPermissionAsync returns false.
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database');
     expect(res.status).toBe(403);
   });
 });
 
+// ── describe 3: GET /:id permission filtering ─────────────────────────────────
+
 describe('Legacy mount — GET /:id permission filtering', () => {
   it('non-admin with :read + per-entry canRead: returns channel with masked PSK', async () => {
-    mockDb.checkPermissionAsync.mockImplementation(
-      async (_uid: number, resource: string, action: string) =>
-        resource === 'channel_database' && action === 'read'
+    await harness.grant(harness.limited.id, 'channel_database', 'read');
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionAsync').mockResolvedValue(
+      { userId: harness.limited.id, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any
     );
-    mockDb.channelDatabase.getPermissionAsync.mockResolvedValue({
-      userId: 60,
-      channelDatabaseId: 1,
-      canViewOnMap: false,
-      canRead: true,
-    });
-    const res = await request(createApp(readerUser)).get('/api/channel-database/1');
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database/1');
     expect(res.status).toBe(200);
     expect(res.body.data.psk).toBeUndefined();
     expect(res.body.data.pskPreview).toMatch(/\.\.\.$/);
   });
 
   it('non-admin with :read but no per-entry row: returns 404', async () => {
-    mockDb.checkPermissionAsync.mockImplementation(
-      async (_uid: number, resource: string, action: string) =>
-        resource === 'channel_database' && action === 'read'
-    );
-    const res = await request(createApp(readerUser)).get('/api/channel-database/1');
+    await harness.grant(harness.limited.id, 'channel_database', 'read');
+    // getPermissionAsync already mocked to null (beforeEach default)
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database/1');
     expect(res.status).toBe(404);
   });
 
   it('non-admin without :read: returns 403', async () => {
-    const res = await request(createApp(noPermsUser)).get('/api/channel-database/1');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database/1');
     expect(res.status).toBe(403);
   });
 });
 
+// ── describe 4: Write endpoints require channel_database:write ────────────────
+
 describe('Legacy mount — Write endpoints require channel_database:write', () => {
   it('POST / → 403 for :read-only user', async () => {
-    mockDb.checkPermissionAsync.mockImplementation(
-      async (_uid: number, resource: string, action: string) =>
-        resource === 'channel_database' && action === 'read'
-    );
-    const res = await request(createApp(readerUser))
+    await harness.grant(harness.limited.id, 'channel_database', 'read');
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent
       .post('/api/channel-database')
       .send({ name: 'X', psk: fakePsk });
     expect(res.status).toBe(403);
   });
 
   it('POST / → 201 for non-admin with :write', async () => {
-    mockDb.checkPermissionAsync.mockImplementation(
-      async (_uid: number, resource: string, action: string) =>
-        resource === 'channel_database' && action === 'write'
+    await harness.grant(harness.limited.id, 'channel_database', 'write');
+    vi.spyOn(databaseService.channelDatabase, 'getByIdAsync').mockResolvedValue(
+      { ...channel1, id: 42 } as any
     );
-    mockDb.channelDatabase.createAsync.mockResolvedValue(42);
-    mockDb.channelDatabase.getByIdAsync.mockResolvedValue({ ...channel1, id: 42 });
-    const res = await request(createApp(writerUser))
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent
       .post('/api/channel-database')
       .send({ name: 'X', psk: fakePsk });
+    expect(res.status).toBe(201);
+  });
+
+  it('admin bypasses write check (real admin bypass via resolveCallerScope)', async () => {
+    vi.spyOn(databaseService.channelDatabase, 'getByIdAsync').mockResolvedValue(
+      { ...channel1, id: 42 } as any
+    );
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .post('/api/channel-database')
+      .send({ name: 'AdminChannel', psk: fakePsk });
     expect(res.status).toBe(201);
   });
 });

--- a/src/server/routes/sourceRoutes.permissions.test.ts
+++ b/src/server/routes/sourceRoutes.permissions.test.ts
@@ -1,188 +1,190 @@
 /**
  * Source Routes — per-source permission isolation tests
+ *
+ * Converted from the monkey-patch pattern (vi.mock('../../services/database.js', ...))
+ * to the real-middleware harness (createRouteTestApp). The harness uses the live
+ * DatabaseService singleton with real session + optionalAuth + requirePermission,
+ * seeding per-test permission rows so that `checkPermissionAsync` exercises actual
+ * SQL logic rather than a hand-rolled lambda.
+ *
+ * See src/server/test-helpers/routeTestApp.ts for the design rationale.
+ * Template for new and converted route tests.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import express, { Express } from 'express';
-import session from 'express-session';
-import request from 'supertest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sourceRoutes from './sourceRoutes.js';
-import databaseService from '../../services/database.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 
-vi.mock('../../services/database.js', () => ({
-  default: {
-    sources: {
-      getSource: vi.fn(),
-      getAllSources: vi.fn(),
-    },
-    nodes: {
-      getNode: vi.fn(),
-      getAllNodes: vi.fn().mockResolvedValue([]),
-      getNodesByNums: vi.fn().mockResolvedValue(new Map()),
-    },
-    messages: {
-      getMessages: vi.fn().mockResolvedValue([]),
-    },
-    traceroutes: {
-      getAllTraceroutes: vi.fn().mockResolvedValue([]),
-    },
-    neighbors: {
-      getAllNeighborInfo: vi.fn().mockResolvedValue([]),
-    },
-    channels: {
-      getAllChannels: vi.fn().mockResolvedValue([]),
-    },
-    settings: {
-      getSetting: vi.fn().mockResolvedValue(null),
-    },
-    checkPermissionAsync: vi.fn(),
-    findUserByIdAsync: vi.fn(),
-    findUserByUsernameAsync: vi.fn(),
-    getUserPermissionSetAsync: vi.fn(),
-    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn().mockResolvedValue({}),
-  }
-}));
-
+// Non-DB mocks stay: sourceRoutes.ts / sourceDashboardData.ts call these at
+// request time and they must not attempt real TCP connections in tests.
 vi.mock('../sourceManagerRegistry.js', () => ({
   sourceManagerRegistry: {
     getManager: vi.fn().mockReturnValue(null),
     startManager: vi.fn(),
     stopManager: vi.fn(),
-  }
+  },
 }));
 
 vi.mock('../meshtasticManager.js', () => ({
   MeshtasticManager: vi.fn().mockImplementation(() => ({
     start: vi.fn(),
     stop: vi.fn(),
-  }))
+  })),
 }));
 
-const mockDb = databaseService as any;
-
-const normalUser = { id: 7, username: 'scoped', isActive: true, isAdmin: false };
-
-const createApp = (): Express => {
-  const app = express();
-  app.use(express.json());
-  app.use(session({
-    secret: 'test-secret',
-    resave: false,
-    saveUninitialized: false,
-    cookie: { secure: false }
-  }));
-  app.use((req: any, _res, next) => {
-    req.session.userId = normalUser.id;
-    next();
-  });
-  app.use('/', sourceRoutes);
-  return app;
-};
+// ── describe 1: per-source permission isolation ───────────────────────────────
+//
+// The limited user holds grants on sourceA only. This exercises the real
+// checkPermissionAsync + permissions.sourceId SQL path — previously a hand-rolled
+// `(_u,_r,_a,sourceId) => sourceId === 'sourceA'` lambda that could pass while
+// the real implementation was broken (issue #3745).
 
 describe('sourceRoutes — per-source permission isolation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDb.findUserByIdAsync.mockResolvedValue(normalUser);
-    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
-    mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
-    // User has access ONLY to sourceA — implements per-source grant simulation
-    mockDb.checkPermissionAsync.mockImplementation(
-      (_uid: number, _r: string, _a: string, sourceId?: string) => Promise.resolve(sourceId === 'sourceA')
-    );
-    mockDb.sources.getSource.mockImplementation((id: string) =>
-      Promise.resolve({ id, name: id, type: 'meshtastic_tcp', enabled: true })
-    );
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+
+    // Grant limited user access on sourceA only.
+    // neighbor-info uses the 'nodes' resource, so nodes:read covers both endpoints.
+    await harness.grant(harness.limited.id, 'messages',   'read', harness.sourceA);
+    await harness.grant(harness.limited.id, 'nodes',      'read', harness.sourceA);
+    await harness.grant(harness.limited.id, 'traceroute', 'read', harness.sourceA);
+    // No grants at all for sourceB.
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
   });
 
   // /channels deliberately excluded from this loop — see MM-SEC-7.
-  // After MM-SEC-7 the route is `optionalAuth()` + per-row `channel_${id}:read`,
-  // so the "other source denied" case returns 200 with `[]` rather than 403.
-  // Dedicated coverage lives in `sourceRoutes.security.test.ts`.
+  // After MM-SEC-7 the route uses optionalAuth() + per-row channel_${id}:read,
+  // so the "other source denied" case returns 200 with [] rather than 403.
+  // Dedicated coverage lives in the dedicated assertion below.
   const endpoints = ['/messages', '/nodes', '/traceroutes', '/neighbor-info'];
 
   for (const ep of endpoints) {
-    it(`GET /sourceA${ep} → 200 (allowed source)`, async () => {
-      const res = await request(createApp()).get(`/sourceA${ep}`);
+    it(`GET /rt-source-a${ep} → 200 (allowed source)`, async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/${harness.sourceA}${ep}`);
       expect(res.status).toBe(200);
     });
 
-    it(`GET /sourceB${ep} → 403 (other source denied)`, async () => {
-      const res = await request(createApp()).get(`/sourceB${ep}`);
+    it(`GET /rt-source-b${ep} → 403 (other source denied — real checkPermissionAsync)`, async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/${harness.sourceB}${ep}`);
       expect(res.status).toBe(403);
     });
   }
 
-  it('GET /sourceB/channels → 200 with [] (MM-SEC-7: per-channel filter, not source-level 403)', async () => {
-    const res = await request(createApp()).get('/sourceB/channels');
+  it('GET /rt-source-b/channels → 200 with [] (MM-SEC-7: per-channel filter, not source-level 403)', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${harness.sourceB}/channels`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual([]);
   });
+
+  it('admin → 200 on both sources without explicit grants (real admin bypass)', async () => {
+    const agentA = await harness.loginAs(harness.admin);
+    const resA = await agentA.get(`/${harness.sourceA}/messages`);
+    expect(resA.status).toBe(200);
+
+    const agentB = await harness.loginAs(harness.admin);
+    const resB = await agentB.get(`/${harness.sourceB}/messages`);
+    expect(resB.status).toBe(200);
+  });
+
+  it('anonymous → 403 on per-source endpoint (real findUserByUsernameAsync path)', async () => {
+    // loginAs(null) → no session cookie → optionalAuth falls back to the real
+    // anonymous user row. Anonymous has nodes:read with sourceId=null (global),
+    // but checkPermissionAsync with a specific sourceId requires an exact-match row,
+    // so it returns false → 403.
+    const agent = await harness.loginAs(null);
+    const res = await agent.get(`/${harness.sourceA}/messages`);
+    expect(res.status).toBe(403);
+  });
 });
 
+// ── describe 2: cross-source channel filtering regression ─────────────────────
+//
+// The user can access both sources at the source level (nodes:read on A + B),
+// but holds channel_0:viewOnMap only for sourceA.
+//
+// The real filterNodesByChannelPermission calls getUserPermissionSetAsync(userId, sourceId),
+// which returns the permission set scoped to that sourceId. Without the channel
+// permission for sourceB the node is filtered from the response body even though
+// the HTTP status is still 200 — this is the MM-SEC-7 / #3745 regression pattern.
+
 describe('sourceRoutes — cross-source channel filtering (regression)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDb.findUserByIdAsync.mockResolvedValue(normalUser);
-    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+  let harness: RouteTestHarness;
 
-    // User can access both sources at the source level
-    mockDb.checkPermissionAsync.mockResolvedValue(true);
-
-    // Channel permissions differ by source:
-    // sourceA: channel_0 viewOnMap granted
-    // sourceB: NO channel permissions
-    // getUserPermissionSetAsync returns a flat PermissionSet (Record<ResourceType, {...}>)
-    mockDb.getUserPermissionSetAsync.mockImplementation((_uid: number, sourceId?: string) => {
-      if (sourceId === 'sourceA') {
-        return Promise.resolve({
-          channel_0: { read: true, write: false, viewOnMap: true },
-          nodes: { read: true, write: false, viewOnMap: false },
-        });
-      }
-      // sourceB or no sourceId: no channel_0 permission
-      return Promise.resolve({
-        nodes: { read: true, write: false, viewOnMap: false },
-      });
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
     });
 
-    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+    // Pass the requirePermission('nodes','read') gate for BOTH sources.
+    await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+    await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceB);
 
-    mockDb.sources.getSource.mockImplementation((id: string) =>
-      Promise.resolve({ id, name: id, type: 'meshtastic_tcp', enabled: true })
-    );
+    // Channel permissions differ by source:
+    //   sourceA: channel_0 viewOnMap granted → node visible
+    //   sourceB: no channel_0 permission    → node filtered
+    await harness.grant(harness.limited.id, 'channel_0', 'viewOnMap', harness.sourceA);
 
-    // Return a node on channel 0 for both sources
-    mockDb.nodes.getAllNodes.mockResolvedValue([
-      { nodeId: '!aabbccdd', nodeNum: 2864434397, longName: 'TestNode', shortName: 'TN', channel: 0, lastHeard: Date.now() },
-    ]);
+    // Seed the same node on BOTH sources. This replicates the regression scenario:
+    // a bug could make a node from source A bleed into source B's response.
+    // With the real per-source getUserPermissionSetAsync the channel filter is
+    // applied independently per source, so the node appears on A but not B.
+    const nodeData = {
+      nodeNum: 2864434397,
+      nodeId: '!aabbccdd',
+      longName: 'TestNode',
+      shortName: 'TN',
+      channel: 0,
+      lastHeard: Math.floor(Date.now() / 1000),
+    };
+    await harness.db.nodes.upsertNode(nodeData, harness.sourceA);
+    await harness.db.nodes.upsertNode(nodeData, harness.sourceB);
   });
 
-  it('nodes on channel_0 visible on sourceA (granted)', async () => {
-    const res = await request(createApp()).get('/sourceA/nodes');
-    expect(res.status).toBe(200);
-    expect(res.body.length).toBe(1);
+  afterEach(async () => {
+    await harness.cleanup();
+    // Note: cleanup() removes permissions and sources but not the seeded node rows.
+    // The node rows remain in the in-memory DB (keyed by nodeNum+sourceId). On the
+    // next beforeEach, upsertNode() updates them in-place — this is safe because
+    // vitest's fork isolation resets the entire process between files.
   });
 
-  it('nodes on channel_0 filtered on sourceB (no grant — regression)', async () => {
-    const res = await request(createApp()).get('/sourceB/nodes');
+  it('nodes on channel_0 visible on sourceA (channel_0:viewOnMap granted)', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${harness.sourceA}/nodes`);
     expect(res.status).toBe(200);
-    // Node should be filtered out because sourceB has no channel_0 permissions
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('nodes on channel_0 filtered on sourceB (no channel grant — regression)', async () => {
+    // Real getUserPermissionSetAsync(limitedId, 'rt-source-b') returns {} (no
+    // channel_0 row with sourceId='rt-source-b'), so filterNodesByChannelPermission
+    // strips the node. Previously the mock made this pass while the real SQL was broken.
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${harness.sourceB}/nodes`);
+    expect(res.status).toBe(200);
     expect(res.body.length).toBe(0);
   });
 
-  it('admin sees nodes on all sources regardless of grants', async () => {
-    const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
-    mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
-    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
-
-    const app = createApp();
-
-    const resA = await request(app).get('/sourceA/nodes');
+  it('admin sees nodes on all sources regardless of channel grants (admin bypass)', async () => {
+    // Admin → filterNodesByChannelPermission returns all nodes immediately (user.isAdmin guard).
+    const agentA = await harness.loginAs(harness.admin);
+    const resA = await agentA.get(`/${harness.sourceA}/nodes`);
     expect(resA.status).toBe(200);
-    expect(resA.body.length).toBe(1);
+    expect(resA.body.length).toBeGreaterThanOrEqual(1);
 
-    const resB = await request(app).get('/sourceB/nodes');
+    const agentB = await harness.loginAs(harness.admin);
+    const resB = await agentB.get(`/${harness.sourceB}/nodes`);
     expect(resB.status).toBe(200);
-    expect(resB.body.length).toBe(1);
+    expect(resB.body.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/server/routes/v1/messages.permissions.test.ts
+++ b/src/server/routes/v1/messages.permissions.test.ts
@@ -1,91 +1,134 @@
 /**
  * v1 messages — sourceId permission scoping tests
  *
- * Verifies that GET /api/v1/messages?sourceId=A enforces per-source permission
- * via checkPermissionAsync(... sourceId), and GET without sourceId falls back
- * to getUserPermissionSetAsync (global behavior).
+ * Converted from the monkey-patch pattern (vi.mock('.../services/database.js'))
+ * to the real-middleware harness (createRouteTestApp). Uses vi.spyOn passthrough
+ * on checkPermissionAsync / getUserPermissionSetAsync to assert call routing
+ * while the real permission logic runs against actual DB rows.
+ *
+ * Route profile: GET /api/v1/messages?sourceId=...
+ *   - No requirePermission middleware — handler calls databaseService.checkPermissionAsync
+ *     inline (getAccessibleChannels) when sourceId is provided, or calls
+ *     getUserPermissionSetAsync for the global (no-sourceId) path.
+ *   - Sets req.user from requireAPIToken in production; simulated via a mount
+ *     middleware here (useOptionalAuth: false).
+ *
+ * See src/server/test-helpers/routeTestApp.ts for the design rationale.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import express, { Express } from 'express';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 
-vi.mock('../../../services/database.js', () => ({
-  default: {
-    checkPermissionAsync: vi.fn(),
-    getUserPermissionSetAsync: vi.fn(),
-    messages: {
-      getMessages: vi.fn().mockResolvedValue([]),
-      getMessagesByChannel: vi.fn().mockResolvedValue([]),
-      getMessagesAfterTimestamp: vi.fn().mockResolvedValue([]),
-    },
-  }
-}));
-
+// Non-DB mocks stay: these modules make external node connections or require
+// hardware state that must not run in unit tests.
 vi.mock('../../meshtasticManager.js', () => ({ default: {} }));
 vi.mock('../../meshcoreManager.js', () => ({ default: {} }));
-vi.mock('../../sourceManagerRegistry.js', () => ({ sourceManagerRegistry: { getManager: vi.fn() } }));
+vi.mock('../../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: vi.fn() },
+}));
 vi.mock('../../messageQueueService.js', () => ({ messageQueueService: {} }));
 vi.mock('../../middleware/rateLimiters.js', () => ({
   messageLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 import databaseService from '../../../services/database.js';
+import { createRouteTestApp, type RouteTestHarness } from '../../test-helpers/routeTestApp.js';
 import v1Messages from './messages.js';
 
-const mockDb = databaseService as any;
-
-const normalUser = { id: 99, username: 'u', isActive: true, isAdmin: false };
-
-const buildApp = (): Express => {
-  const app = express();
-  app.use(express.json());
-  app.use((req: any, _res, next) => {
-    req.user = normalUser;
-    next();
-  });
-  app.use('/v1/messages', v1Messages);
-  return app;
-};
-
 describe('v1 messages — sourceId scoping', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDb.checkPermissionAsync.mockResolvedValue(true);
-    mockDb.getUserPermissionSetAsync.mockResolvedValue({
-      messages: { read: true, write: false },
-      channel_0: { read: true },
+  let harness: RouteTestHarness;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let permSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let globalPermSpy: any;
+
+  beforeEach(async () => {
+    // useOptionalAuth: false — v1 routes authenticate via requireAPIToken, not
+    // session. We simulate that by injecting req.user in the mount closure.
+    // The closure captures the `harness` binding by reference, so harness.limited
+    // is resolved at request time (after the createRouteTestApp call below).
+    harness = await createRouteTestApp({
+      useOptionalAuth: false,
+      mount: (app) => {
+        // Simulate requireAPIToken: set req.user so the handler can read
+        // userId / isAdmin without touching the session.
+        app.use((req: any, _res: any, next: any) => {
+          req.user = harness.limited;
+          next();
+        });
+        app.use('/v1/messages', v1Messages);
+      },
     });
+
+    // Grant messages:read + channel_0:read on sourceA only.
+    // No grants for sourceB — this is the source-isolation baseline.
+    await harness.grant(harness.limited.id, 'messages',  'read', harness.sourceA);
+    await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+
+    // Passthrough spies: record calls while running the real implementation so
+    // we can assert both routing behaviour AND actual permission enforcement.
+    permSpy       = vi.spyOn(databaseService, 'checkPermissionAsync');
+    globalPermSpy = vi.spyOn(databaseService, 'getUserPermissionSetAsync');
   });
 
-  it('GET ?sourceId=A → checkPermissionAsync called with sourceId=A, no global lookup', async () => {
-    const res = await request(buildApp()).get('/v1/messages').query({ sourceId: 'A' });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await harness.cleanup();
+  });
+
+  // ── source-isolation assertion ─────────────────────────────────────────────
+  //
+  // The limited user holds grants on sourceA only. The pair below drives the
+  // real checkPermissionAsync SQL against permissions.sourceId rows, proving
+  // that source isolation is enforced by actual DB logic — not a hand-rolled
+  // lambda (the regression class exposed by issue #3745).
+
+  it('GET ?sourceId=sourceA → checkPermissionAsync called with sourceA, 200 returned', async () => {
+    const res = await request(harness.app)
+      .get('/v1/messages')
+      .query({ sourceId: harness.sourceA });
+
     expect(res.status).toBe(200);
-    // All checkPermissionAsync calls must include sourceId='A'
-    const calls = mockDb.checkPermissionAsync.mock.calls;
+
+    // Every call inside getAccessibleChannels must be scoped to sourceA
+    const calls = permSpy.mock.calls;
     expect(calls.length).toBeGreaterThan(0);
     for (const call of calls) {
-      expect(call[3]).toBe('A');
+      expect(call[3]).toBe(harness.sourceA);
     }
-    expect(mockDb.getUserPermissionSetAsync).not.toHaveBeenCalled();
+    // Global getUserPermissionSetAsync must NOT be invoked in the per-source path
+    expect(globalPermSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET ?sourceId=sourceB → empty accessible channels, count 0 (source isolation — real checkPermissionAsync)', async () => {
+    // Limited user has NO grants on sourceB.  getAccessibleChannels loops
+    // channels 0-7 + messages:read — all checkPermissionAsync calls return false.
+    // accessibleChannels is an empty Set → every message is filtered → count 0.
+    // Previously a `() => sourceId === 'sourceA'` lambda would hide this;
+    // here the real SQL enforces it.
+    const res = await request(harness.app)
+      .get('/v1/messages')
+      .query({ sourceId: harness.sourceB });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(0);
+
+    // All calls scoped to sourceB (no accidental sourceA bleed)
+    const calls = permSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[3]).toBe(harness.sourceB);
+    }
   });
 
   it('GET without sourceId → uses global getUserPermissionSetAsync, no per-source checks', async () => {
-    const res = await request(buildApp()).get('/v1/messages');
-    expect(res.status).toBe(200);
-    expect(mockDb.getUserPermissionSetAsync).toHaveBeenCalledWith(99);
-    expect(mockDb.checkPermissionAsync).not.toHaveBeenCalled();
-  });
+    // No sourceId → getAccessibleChannels falls through to the global path:
+    // getUserPermissionSetAsync(userId) merges permissions across all sources
+    // (most-permissive wins). checkPermissionAsync is NOT called in this path.
+    const res = await request(harness.app).get('/v1/messages');
 
-  it('GET ?sourceId=B with no per-source grant → empty accessible channels (no leaked messages)', async () => {
-    // Per-source: deny everything
-    mockDb.checkPermissionAsync.mockResolvedValue(false);
-    mockDb.messages.getMessages.mockResolvedValue([
-      { id: 'm1', channel: 0, sourceId: 'B' },
-      { id: 'm2', channel: 1, sourceId: 'B' },
-    ]);
-    const res = await request(buildApp()).get('/v1/messages').query({ sourceId: 'B' });
     expect(res.status).toBe(200);
-    expect(res.body.count).toBe(0);
+    expect(globalPermSpy).toHaveBeenCalledWith(harness.limited.id);
+    expect(permSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -121,12 +121,12 @@ router.get('/', async (req: Request, res: Response) => {
     let messages;
 
     if (channelNum !== undefined) {
-      messages = await databaseService.messages.getMessagesByChannel(channelNum, maxLimit, 0, sourceIdStr);
+      messages = await databaseService.messages.getMessagesByChannel(channelNum, maxLimit, 0, sourceIdStr ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
     } else if (sinceTimestamp) {
       messages = await databaseService.messages.getMessagesAfterTimestamp(sinceTimestamp, sourceIdStr ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
       messages = messages.slice(0, maxLimit);
     } else {
-      messages = await databaseService.messages.getMessages(maxLimit, 0, sourceIdStr, [PortNum.TRACEROUTE_APP]);
+      messages = await databaseService.messages.getMessages(maxLimit, 0, sourceIdStr ?? ALL_SOURCES, [PortNum.TRACEROUTE_APP]); // intentional cross-source when sourceId omitted
     }
 
     // Filter messages by accessible channels (unless admin)

--- a/src/server/routes/waypoints.test.ts
+++ b/src/server/routes/waypoints.test.ts
@@ -1,38 +1,41 @@
 /**
  * Waypoint route tests
  *
- * Mounts the router with a parent /api/sources/:id/waypoints prefix so
- * `requirePermission('waypoints', …, sourceIdFrom: 'params.id')` resolves
- * the same way it does in production via sourceRoutes.
+ * Converted from the monkey-patch pattern (vi.mock('../../services/database.js'))
+ * to the real-middleware harness (createRouteTestApp). The harness uses the live
+ * DatabaseService singleton with real session + requirePermission so that
+ * checkPermissionAsync exercises actual SQL logic against permissions.sourceId rows.
+ *
+ * Route profile:
+ *   Mounted at /api/sources/:id/waypoints via a parent sourceRouter.
+ *   Every endpoint is gated by requirePermission('waypoints', …, { sourceIdFrom: 'params.id' }).
+ *   'waypoints' IS a sourcey resource (SOURCEY_RESOURCES in types/permission.ts) so
+ *   checkPermissionAsync does an exact-match on permissions.sourceId when a sourceId is
+ *   provided by the middleware.
+ *
+ * Source-isolation assertion:
+ *   Limited user receives waypoints:read on harness.sourceA ONLY (canWrite=false on
+ *   the same row). GET sourceA → 200. GET/POST sourceB → 403 (real checkPermissionAsync,
+ *   no row for sourceB). POST sourceA → 403 (canWrite=false, proves column-level check).
+ *
+ * Grant strategy note:
+ *   The permissions schema has a UNIQUE constraint on (userId, resource, sourceId).
+ *   A single grant() call creates one row with canRead XOR canWrite set.  Tests that
+ *   need write-success use harness.admin (admin bypass in requirePermission) rather
+ *   than stacking two grant() calls that would violate the unique constraint.
+ *
+ * Non-DB mocks stay: sourceManagerRegistry and waypointService are kept so
+ * routes do not attempt real TCP connections or file I/O.
+ * databaseService.waypoints.getAsync is spied on per-test for DELETE scenarios
+ * since no waypoint rows are seeded in the in-memory test DB.
+ *
+ * See src/server/test-helpers/routeTestApp.ts for the design rationale.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import express, { Express, Router } from 'express';
-import session from 'express-session';
-import request from 'supertest';
-import waypointRoutes from './waypoints.js';
-import databaseService from '../../services/database.js';
 
-vi.mock('../../services/database.js', () => ({
-  default: {
-    drizzleDbType: 'sqlite',
-    findUserByIdAsync: vi.fn(),
-    findUserByUsernameAsync: vi.fn(),
-    checkPermissionAsync: vi.fn(),
-    getUserPermissionSetAsync: vi.fn(),
-    sources: {
-      getSource: vi.fn(),
-    },
-    waypoints: {
-      getAsync: vi.fn(),
-      listAsync: vi.fn(),
-      upsertAsync: vi.fn(),
-      deleteAsync: vi.fn(),
-      getExistingIdsAsync: vi.fn(),
-      sweepExpiredAsync: vi.fn(),
-    },
-  },
-}));
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Router } from 'express';
 
+// Non-DB mocks stay.
 vi.mock('../sourceManagerRegistry.js', () => ({
   sourceManagerRegistry: {
     getManager: vi.fn(),
@@ -50,56 +53,11 @@ vi.mock('../services/waypointService.js', () => ({
   },
 }));
 
-const mockDb = databaseService as unknown as {
-  findUserByIdAsync: ReturnType<typeof vi.fn>;
-  findUserByUsernameAsync: ReturnType<typeof vi.fn>;
-  checkPermissionAsync: ReturnType<typeof vi.fn>;
-  sources: { getSource: ReturnType<typeof vi.fn> };
-  waypoints: {
-    getAsync: ReturnType<typeof vi.fn>;
-    listAsync: ReturnType<typeof vi.fn>;
-    upsertAsync: ReturnType<typeof vi.fn>;
-    deleteAsync: ReturnType<typeof vi.fn>;
-    getExistingIdsAsync: ReturnType<typeof vi.fn>;
-    sweepExpiredAsync: ReturnType<typeof vi.fn>;
-  };
-};
-
-const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
-const regularUser = { id: 2, username: 'user', isActive: true, isAdmin: false };
-
-function createApp(opts: { authenticated?: boolean; admin?: boolean } = {}): Express {
-  const { authenticated = true, admin = true } = opts;
-  const app = express();
-  app.use(express.json());
-  app.use(
-    session({
-      secret: 'test-secret',
-      resave: false,
-      saveUninitialized: false,
-      cookie: { secure: false },
-    }),
-  );
-
-  if (authenticated) {
-    app.use((req, _res, next) => {
-      req.session.userId = admin ? adminUser.id : regularUser.id;
-      req.session.username = admin ? adminUser.username : regularUser.username;
-      next();
-    });
-  }
-
-  mockDb.findUserByIdAsync.mockResolvedValue(admin ? adminUser : regularUser);
-  mockDb.findUserByUsernameAsync.mockResolvedValue(null);
-
-  // Match production wiring: parent router with :id, child waypoints router.
-  const sourceRouter = Router();
-  sourceRouter.use('/:id/waypoints', waypointRoutes);
-  app.use('/api/sources', sourceRouter);
-  return app;
-}
-
+import databaseService from '../../services/database.js';
+import waypointRoutes from './waypoints.js';
 import { waypointService } from '../services/waypointService.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
 const mockWaypointService = waypointService as unknown as {
   list: ReturnType<typeof vi.fn>;
   get: ReturnType<typeof vi.fn>;
@@ -109,60 +67,102 @@ const mockWaypointService = waypointService as unknown as {
 };
 
 describe('Waypoint routes', () => {
-  beforeEach(() => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      // Match production wiring: parent router with :id, child waypoints router.
+      // mergeParams on the waypoints router lets requirePermission read :id.
+      mount: (app) => {
+        const sourceRouter = Router();
+        sourceRouter.use('/:id/waypoints', waypointRoutes);
+        app.use('/api/sources', sourceRouter);
+      },
+    });
+
+    // Grant waypoints:read on sourceA ONLY for the limited user (canWrite stays false
+    // in the same row — only one row per (user, resource, sourceId) is allowed by the
+    // UNIQUE constraint).  Tests needing write-success use harness.admin instead.
+    await harness.grant(harness.limited.id, 'waypoints', 'read', harness.sourceA);
+    // No grants for sourceB.
+
     vi.clearAllMocks();
-    mockDb.checkPermissionAsync.mockResolvedValue(true);
-    mockDb.sources.getSource.mockResolvedValue({ id: 'src-1', name: 'Default' });
   });
 
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await harness.cleanup();
+  });
+
+  // ── GET /api/sources/:id/waypoints ──────────────────────────────────────────
+
   describe('GET /api/sources/:id/waypoints', () => {
-    it('returns the list for an authorised user', async () => {
+    it('returns the list for an authorised user (sourceA — real waypoints:read grant)', async () => {
       const sample = [
-        { sourceId: 'src-1', waypointId: 1, name: 'A', latitude: 30, longitude: -90 },
+        { sourceId: harness.sourceA, waypointId: 1, name: 'A', latitude: 30, longitude: -90 },
       ];
       mockWaypointService.list.mockResolvedValue(sample);
-      const app = createApp({ admin: false });
 
-      const res = await request(app).get('/api/sources/src-1/waypoints');
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/api/sources/${harness.sourceA}/waypoints`);
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true, data: sample });
-      expect(mockWaypointService.list).toHaveBeenCalledWith('src-1', expect.any(Object));
+      expect(mockWaypointService.list).toHaveBeenCalledWith(harness.sourceA, expect.any(Object));
     });
 
-    it('returns 401 when unauthenticated', async () => {
-      const app = createApp({ authenticated: false });
-      const res = await request(app).get('/api/sources/src-1/waypoints');
-      expect(res.status).toBe(401);
-    });
-
-    it('returns 403 when permission check fails', async () => {
-      mockDb.checkPermissionAsync.mockResolvedValue(false);
-      const app = createApp({ admin: false });
-      const res = await request(app).get('/api/sources/src-1/waypoints');
+    it('returns 403 when unauthenticated (anonymous user has no waypoints:read — real requirePermission)', async () => {
+      // loginAs(null) → no session → requirePermission falls back to the real
+      // anonymous user (seeded by DatabaseService.seedInitialData). Anonymous
+      // has no waypoints:read grant → checkPermissionAsync returns false → 403.
+      // (The old test expected 401 because findUserByUsernameAsync was mocked to
+      // return null; with the real anonymous user always present, 403 is correct.)
+      const agent = await harness.loginAs(null);
+      const res = await agent.get(`/api/sources/${harness.sourceA}/waypoints`);
       expect(res.status).toBe(403);
     });
 
+    it('returns 403 for sourceB (source isolation — no grant row for sourceB, real checkPermissionAsync)', async () => {
+      // Limited has waypoints:read only on sourceA. requirePermission extracts
+      // the sourceId from params.id, then calls checkPermissionAsync(userId,
+      // 'waypoints', 'read', 'rt-source-b') — no matching row → false → 403.
+      // Previously a `mockResolvedValue(false)` hid any real implementation bug.
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/api/sources/${harness.sourceB}/waypoints`);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 200 for sourceA (source isolation — granted)', async () => {
+      mockWaypointService.list.mockResolvedValue([]);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/api/sources/${harness.sourceA}/waypoints`);
+      expect(res.status).toBe(200);
+    });
+
     it('returns 404 when the source does not exist', async () => {
-      mockDb.sources.getSource.mockResolvedValue(null);
-      const app = createApp();
-      const res = await request(app).get('/api/sources/src-1/waypoints');
+      // Admin bypasses requirePermission; handler then calls sources.getSource()
+      // on the real DB — 'nonexistent-source-xyz' was never created → 404.
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/api/sources/nonexistent-source-xyz/waypoints');
       expect(res.status).toBe(404);
     });
   });
 
+  // ── POST /api/sources/:id/waypoints ─────────────────────────────────────────
+
   describe('POST /api/sources/:id/waypoints', () => {
     it('creates a waypoint with valid input', async () => {
+      // Admin user bypasses requirePermission — no grant setup needed.
       mockWaypointService.createLocal.mockResolvedValue({
-        sourceId: 'src-1',
+        sourceId: harness.sourceA,
         waypointId: 99,
         latitude: 30,
         longitude: -90,
         name: 'Test',
       });
-      const app = createApp();
 
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 30, lon: -90, name: 'Test', virtual: true });
 
       expect(res.status).toBe(201);
@@ -171,88 +171,110 @@ describe('Waypoint routes', () => {
     });
 
     it('rejects invalid coordinates with 400', async () => {
-      const app = createApp();
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 999, lon: -90 });
       expect(res.status).toBe(400);
     });
 
     it('rejects missing coordinates with 400', async () => {
-      const app = createApp();
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ name: 'no coords' });
       expect(res.status).toBe(400);
     });
 
-    it('returns 403 for users without write permission', async () => {
-      mockDb.checkPermissionAsync.mockResolvedValue(false);
-      const app = createApp({ admin: false });
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+    it('returns 403 for read-only limited user on sourceA (canWrite=false — real column-level check)', async () => {
+      // Limited user has a waypoints row with canRead=true, canWrite=false on sourceA.
+      // requirePermission('waypoints','write',...) calls checkPermissionAsync with action
+      // 'write' → looks up canWrite field → false → 403. This proves the real row-level
+      // write gate, not just a mock.
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 30, lon: -90 });
       expect(res.status).toBe(403);
     });
 
-    it('rejects a rebroadcast interval below the 600s (10-min) airtime floor', async () => {
-      const app = createApp();
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+    it('returns 403 for limited user on sourceB (source isolation — no grant)', async () => {
+      // Limited has no waypoints grant on sourceB at all.
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceB}/waypoints`)
+        .send({ lat: 30, lon: -90 });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects a rebroadcast interval below the 600 s (10-min) airtime floor', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 30, lon: -90, rebroadcast_interval_s: 300 });
       expect(res.status).toBe(400);
       expect(res.body.error).toMatch(/at least 600 seconds/);
     });
 
     it('rejects a non-integer rebroadcast interval', async () => {
-      const app = createApp();
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 30, lon: -90, rebroadcast_interval_s: 700.5 });
       expect(res.status).toBe(400);
     });
 
     it('accepts a rebroadcast interval at the 10-min floor', async () => {
       mockWaypointService.createLocal.mockResolvedValue({
-        sourceId: 'src-1', waypointId: 1, latitude: 30, longitude: -90,
+        sourceId: harness.sourceA, waypointId: 1, latitude: 30, longitude: -90,
       });
-      const app = createApp();
-      const res = await request(app)
-        .post('/api/sources/src-1/waypoints')
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 30, lon: -90, rebroadcast_interval_s: 600 });
       expect(res.status).toBe(201);
     });
   });
 
+  // ── PATCH /api/sources/:id/waypoints/:waypointId ────────────────────────────
+
   describe('PATCH /api/sources/:id/waypoints/:waypointId', () => {
     it('returns 403 when waypoint is locked to another node', async () => {
       mockWaypointService.update.mockRejectedValue(new Error('waypoint 1 is locked to 999'));
-      const app = createApp();
-      const res = await request(app)
-        .patch('/api/sources/src-1/waypoints/1')
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .patch(`/api/sources/${harness.sourceA}/waypoints/1`)
         .send({ name: 'edit' });
       expect(res.status).toBe(403);
     });
   });
 
+  // ── DELETE /api/sources/:id/waypoints/:waypointId ───────────────────────────
+
   describe('DELETE /api/sources/:id/waypoints/:waypointId', () => {
     it('deletes when waypoint exists', async () => {
-      mockDb.waypoints.getAsync.mockResolvedValue({
-        sourceId: 'src-1',
+      // The DELETE handler calls databaseService.waypoints.getAsync directly
+      // before delegating to waypointService.deleteLocal. Spy on the repo method
+      // since no waypoint rows are seeded in the in-memory test DB.
+      vi.spyOn(databaseService.waypoints, 'getAsync').mockResolvedValue({
+        sourceId: harness.sourceA,
         waypointId: 1,
         isVirtual: true,
-      });
+      } as any);
       mockWaypointService.deleteLocal.mockResolvedValue(true);
-      const app = createApp();
-      const res = await request(app).delete('/api/sources/src-1/waypoints/1');
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.delete(`/api/sources/${harness.sourceA}/waypoints/1`);
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
     });
 
     it('returns 404 when waypoint missing', async () => {
-      mockDb.waypoints.getAsync.mockResolvedValue(null);
-      const app = createApp();
-      const res = await request(app).delete('/api/sources/src-1/waypoints/1');
+      // Real databaseService.waypoints.getAsync returns null for an unknown
+      // waypointId in the empty in-memory DB → handler returns 404.
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.delete(`/api/sources/${harness.sourceA}/waypoints/99999`);
       expect(res.status).toBe(404);
     });
   });

--- a/src/server/test-helpers/routeTestApp.ts
+++ b/src/server/test-helpers/routeTestApp.ts
@@ -177,7 +177,20 @@ export async function createRouteTestApp(
   });
 
   // Fetch the real anonymous row (guaranteed by DatabaseService.seedInitialData).
-  const anonRow = await databaseService.auth.getUserByUsername('anonymous');
+  //
+  // DatabaseService resolves readyPromise synchronously (for SQLite) but fires
+  // ensureAnonymousUser() as a fire-and-forget async task.  Under vitest
+  // singleFork+isolate a new module instance is created for each file, and the
+  // test's beforeEach may run before that background task commits the anonymous
+  // row.  Poll with a 2-second timeout to let the seeding complete.
+  let anonRow = await databaseService.auth.getUserByUsername('anonymous');
+  if (!anonRow) {
+    const deadline = Date.now() + 2000;
+    while (!anonRow && Date.now() < deadline) {
+      await new Promise<void>(resolve => setTimeout(resolve, 25));
+      anonRow = await databaseService.auth.getUserByUsername('anonymous');
+    }
+  }
   if (!anonRow) {
     throw new Error(
       'routeTestApp: anonymous user not found — seedInitialData must have run before createRouteTestApp()'

--- a/src/server/test-helpers/routeTestApp.ts
+++ b/src/server/test-helpers/routeTestApp.ts
@@ -1,0 +1,277 @@
+/**
+ * Integration-grade route test harness.
+ *
+ * ## Why this exists
+ * The previous pattern for route tests mocked the entire DatabaseService singleton
+ * (`vi.mock('../../services/database.js', ...)`), hand-rolling fake implementations
+ * of `checkPermissionAsync`, `findUserByIdAsync`, etc. That approach lets tests pass
+ * while the real middleware chain is broken — the mock re-implements the logic under
+ * test, so a regression in `checkPermissionAsync` silently passes.
+ *
+ * ## Singleton DB decision (load-bearing — read before changing)
+ * Under vitest `DATABASE_PATH=:memory:`, `src/services/database.ts` exports
+ * `new DatabaseService()` at module level. The constructor opens a fresh `:memory:`
+ * better-sqlite3 database, runs all registered migrations, and seeds the admin +
+ * anonymous users. `authMiddleware.ts` imports this exact singleton, so the
+ * middleware and the harness always see the same data.
+ *
+ * A separate `createTestDb()` connection is invisible to the middleware without an
+ * invasive singleton rebind across ~35 repositories. This is why the harness uses
+ * `databaseService` directly rather than a second `createTestDb()` connection.
+ * `createTestDb()` remains correct for pure repository / service unit tests.
+ *
+ * ## Usage
+ * ```ts
+ * let harness: RouteTestHarness;
+ * beforeEach(async () => {
+ *   harness = await createRouteTestApp({ mount: app => app.use('/', myRouter) });
+ *   await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+ * });
+ * afterEach(() => harness.cleanup());
+ *
+ * it('allows access to sourceA', async () => {
+ *   const agent = await harness.loginAs(harness.limited);
+ *   const res = await agent.get('/rt-source-a/nodes');
+ *   expect(res.status).toBe(200);
+ * });
+ * ```
+ */
+
+import express, { type Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import databaseService from '../../services/database.js';
+import { optionalAuth } from '../auth/authMiddleware.js';
+
+/**
+ * Monotonic counter ensuring unique usernames across repeated `createRouteTestApp()`
+ * calls within the same test file. The in-memory DB persists for the entire file
+ * (vitest fork isolation = one process per file), so unique usernames sidestep
+ * duplicate-username errors without needing a hard user delete.
+ */
+let _rtCounter = 0;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/** Minimal user shape returned by the harness. */
+export interface SeededUser {
+  id: number;
+  username: string;
+  isAdmin: boolean;
+}
+
+export interface RouteTestHarness {
+  /** The Express app with real session + optionalAuth mounted, and the router under test. */
+  app: Express;
+  /**
+   * The live singleton (already :memory: + migrations + seeded users).
+   * Use for extra seeding or assertions: `harness.db.nodes.upsertNode(...)`.
+   */
+  db: typeof databaseService;
+  /** Fixed source id 'rt-source-a' — seeded in the DB. */
+  sourceA: string;
+  /** Fixed source id 'rt-source-b' — seeded in the DB. */
+  sourceB: string;
+  /** Admin user (isAdmin: true) — bypasses all permission checks. */
+  admin: SeededUser;
+  /** Non-admin user — grants applied per-test via `grant()`. */
+  limited: SeededUser;
+  /** The real 'anonymous' row seeded by DatabaseService.seedInitialData. */
+  anonymous: SeededUser;
+  /**
+   * Return a supertest agent whose cookie jar carries a real express-session for
+   * the given user (session.userId set exactly as the real login does after
+   * password verification). Pass `null` / `undefined` for an unauthenticated
+   * agent — exercises the `findUserByUsernameAsync('anonymous')` fallback path.
+   */
+  loginAs(user?: SeededUser | number | null): Promise<ReturnType<typeof request.agent>>;
+  /**
+   * Insert one permission row scoped to `sourceId` (or global when omitted).
+   * One call per action: call twice for read + write.
+   *
+   * @example
+   * await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+   * await harness.grant(harness.limited.id, 'channel_0', 'viewOnMap', harness.sourceA);
+   */
+  grant(
+    userId: number,
+    resource: string,
+    action: 'read' | 'write' | 'viewOnMap',
+    sourceId?: string
+  ): Promise<void>;
+  /** Delete all permission rows for a user (useful between sub-scenarios in one test). */
+  revokeAll(userId: number): Promise<void>;
+  /**
+   * Delete seeded permissions + sources. Call in `afterEach`.
+   * Users are left in place (inactive-safe, unique names).
+   */
+  cleanup(): Promise<void>;
+}
+
+export interface CreateRouteTestAppOptions {
+  /**
+   * Called after the session middleware and optionalAuth are mounted.
+   * Mount your router under test here, e.g. `app => app.use('/api/sources', sourceRoutes)`.
+   */
+  mount: (app: Express) => void;
+  /**
+   * Set `false` to skip `optionalAuth()`, e.g. for routes that authenticate via
+   * `requireAPIToken()` and set `req.user` themselves. Default: `true`.
+   */
+  useOptionalAuth?: boolean;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export async function createRouteTestApp(
+  opts: CreateRouteTestAppOptions
+): Promise<RouteTestHarness> {
+  // Must await before touching any repo — `initializeDrizzleRepositoriesAsync`
+  // is fire-and-forget from the constructor; repos throw "Database not initialized"
+  // until readyPromise resolves.
+  await databaseService.waitForReady();
+
+  const n = ++_rtCounter;
+  const SOURCE_A = 'rt-source-a';
+  const SOURCE_B = 'rt-source-b';
+
+  // Seed sources idempotently: delete first (ignoring "not found"), then create.
+  // This handles the case where a previous test run left rows behind (singleton
+  // DB persists for the whole file). deleteSource returns false on not-found rather
+  // than throwing, but the `.catch(() => {})` is a belt-and-suspenders guard.
+  await databaseService.sources.deleteSource(SOURCE_A).catch(() => {});
+  await databaseService.sources.deleteSource(SOURCE_B).catch(() => {});
+  await databaseService.sources.createSource({
+    id: SOURCE_A,
+    name: 'Source A',
+    type: 'meshtastic_tcp',
+    config: {},
+    enabled: true,
+  });
+  await databaseService.sources.createSource({
+    id: SOURCE_B,
+    name: 'Source B',
+    type: 'meshtastic_tcp',
+    config: {},
+    enabled: true,
+  });
+
+  // Seed users. Unique usernames (rt-admin-N, rt-limited-N) prevent collision
+  // across repeated createRouteTestApp() calls in the same file. No bcrypt —
+  // tests log in programmatically via the /__test__/login route.
+  const adminId = await databaseService.auth.createUser({
+    username: `rt-admin-${n}`,
+    passwordHash: null,
+    authMethod: 'local',
+    isAdmin: true,
+    isActive: true,
+    createdAt: Date.now(),
+  });
+  const limitedId = await databaseService.auth.createUser({
+    username: `rt-limited-${n}`,
+    passwordHash: null,
+    authMethod: 'local',
+    isAdmin: false,
+    isActive: true,
+    createdAt: Date.now(),
+  });
+
+  // Fetch the real anonymous row (guaranteed by DatabaseService.seedInitialData).
+  const anonRow = await databaseService.auth.getUserByUsername('anonymous');
+  if (!anonRow) {
+    throw new Error(
+      'routeTestApp: anonymous user not found — seedInitialData must have run before createRouteTestApp()'
+    );
+  }
+
+  const admin: SeededUser = { id: adminId, username: `rt-admin-${n}`, isAdmin: true };
+  const limited: SeededUser = { id: limitedId, username: `rt-limited-${n}`, isAdmin: false };
+  const anonymous: SeededUser = { id: anonRow.id, username: 'anonymous', isAdmin: false };
+
+  // ── Build the Express app ─────────────────────────────────────────────────
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'route-test',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+      // Cookie name must match requireAuth()'s cookie sniff (authMiddleware.ts L232)
+      // so requireAuth-guarded routes receive the session correctly.
+      name: 'meshmonitor.sid',
+    })
+  );
+
+  // Test-only login route: sets session.userId exactly as the real login does
+  // after successful password verification, but skips bcrypt for speed.
+  app.post('/__test__/login', (req, res) => {
+    req.session.userId = req.body.userId ?? undefined;
+    req.session.save(() => res.status(204).end());
+  });
+
+  if (opts.useOptionalAuth !== false) {
+    app.use(optionalAuth());
+  }
+
+  opts.mount(app);
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  const grant = async (
+    userId: number,
+    resource: string,
+    action: 'read' | 'write' | 'viewOnMap',
+    sourceId?: string
+  ): Promise<void> => {
+    await databaseService.auth.createPermission({
+      userId,
+      resource,
+      canRead: action === 'read',
+      canWrite: action === 'write',
+      canViewOnMap: action === 'viewOnMap',
+      sourceId: sourceId ?? null,
+      grantedAt: Date.now(),
+      grantedBy: null,
+    });
+  };
+
+  const revokeAll = async (userId: number): Promise<void> => {
+    await databaseService.auth.deletePermissionsForUser(userId);
+  };
+
+  const cleanup = async (): Promise<void> => {
+    await databaseService.auth.deletePermissionsForUser(limited.id).catch(() => {});
+    await databaseService.auth.deletePermissionsForUser(admin.id).catch(() => {});
+    await databaseService.sources.deleteSource(SOURCE_A).catch(() => {});
+    await databaseService.sources.deleteSource(SOURCE_B).catch(() => {});
+  };
+
+  const loginAs = async (
+    user?: SeededUser | number | null
+  ): Promise<ReturnType<typeof request.agent>> => {
+    const agent = request.agent(app);
+    if (user != null) {
+      const userId = typeof user === 'number' ? user : user.id;
+      await agent.post('/__test__/login').send({ userId });
+    }
+    // loginAs(null) → unauthenticated agent → optionalAuth() falls through to
+    // findUserByUsernameAsync('anonymous') → anonymous user.
+    return agent;
+  };
+
+  return {
+    app,
+    db: databaseService,
+    sourceA: SOURCE_A,
+    sourceB: SOURCE_B,
+    admin,
+    limited,
+    anonymous,
+    loginAs,
+    grant,
+    revokeAll,
+    cleanup,
+  };
+}


### PR DESCRIPTION
## Summary

Task **1.3** of the remediation plan (#3962, Phase 1).

Route tests previously monkey-patched the permission layer (`(databaseService as any).checkPermissionAsync = vi.fn()...`), so the real middleware chain was never exercised. This adds the shared fixture and converts 4 representative files as the template:

- **New `src/server/test-helpers/routeTestApp.ts`** — `createRouteTestApp({ mount })` boots a real Express app with real `express-session` (MemoryStore), real `optionalAuth()`/`requireAuth`/`requirePermission`, against the live in-memory-SQLite `databaseService` singleton (full migration chain — the vitest env already points the singleton at `:memory:`). Returns seeded `admin`/`limited`/`anonymous` users, two sources, `loginAs()` (session minted via a test-only login route — no bcrypt), per-source `grant()`, and `cleanup()`.
- **Converted:** `sourceRoutes.permissions` (14 tests), `v1/messages.permissions` (3), `channelDatabaseRoutes.permissions` (11), `waypoints` (16). Each keeps its original scenarios and gains genuine source-isolation assertions — granted on source A → 200, denied on source B → 403/filtered — driven by real permission rows and real `getUserPermissionSetAsync` scoping, not mock lambdas.
- **CLAUDE.md** documents the harness as the standard for new/changed route tests; the monkey-patch pattern is deprecated for routes. No mass conversion (per plan) — 64 files with the old pattern convert opportunistically.

**The conversion immediately paid for itself:** exercising the real route code surfaced a production bug — `GET /api/v1/messages` without a `sourceId` param 500'd against the Task-1.1 fail-closed guard (two call sites in `v1/messages.ts` missing the `?? ALL_SOURCES` disposition their sibling line already had). Fixed here with the intentional-cross-source comment.

Also includes a harness-robustness fix: poll for the fire-and-forget `ensureAnonymousUser()` seeding after `waitForReady()` (constructor race under fresh per-file module instances).

## Verification (independent orchestrator run)

- `npm run typecheck`: clean. `npm run typecheck:tests`: 283 (== baseline, no increase).
- Full suite: **8120 passed, 0 failed, 0 suite failures** (`success: true`).
- Harness and converted files contain zero `.prepare/.exec/.query` raw SQL and zero monkey-patched permission fakes.

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n