### PR TITLE
fix(meshcore): exact decrypt-and-match for channel 'repeaters relayed' echo (#3979 pt1)

### DIFF
--- a/src/server/meshcoreManager.channelHeard.test.ts
+++ b/src/server/meshcoreManager.channelHeard.test.ts
@@ -1,30 +1,42 @@
 /**
  * Tests for MeshCoreManager's channel "heard repeaters" self-echo correlation
- * (#3700).
+ * (#3700, exact-match hardening #3979).
  *
  * When a nearby repeater re-floods one of OUR outgoing channel messages, the
  * device hears it as an inbound GRP_TXT OTA packet whose relay-hash chain names
- * the relaying repeaters. We correlate that echo (best-effort, window-bounded)
- * to the most recent matching outgoing channel send, dedup repeaters by hash,
- * track max SNR, and broadcast the heard-by set.
+ * the relaying repeaters. We hold the channel PSK, so we DECRYPT the echoed
+ * payload and attribute it to the SPECIFIC send whose plaintext is exactly
+ * `"<ourNodeName>: <textWeSent>"`. This rejects unrelated third-party chatter on
+ * the same channel and cross-attribution between two of our own near-
+ * simultaneous sends. Each echoed packet is attributed at most once.
+ *
+ * Fixtures are built by encrypting known plaintext with a known channel secret
+ * (AES-128-ECB) via `encodeGroupTextPayload` — the real inverse of the decrypt
+ * path — so the crypto is exercised end-to-end.
  *
  * Two layers are covered:
- *  - `findEchoMatch` (pure): matching, window expiry, dedup, type/path gating.
+ *  - `findEchoMatch` (pure): exact match, oldest-wins tie-break, window expiry,
+ *    third-party / wrong-channel / garbage rejection, dedup, type/path gating.
  *  - `handleBridgeEvent('ota_packet')` (integration): records repeaters and
  *    emits `meshcore:channel-heard`, independent of the packet-monitor gate.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { encodeGroupTextPayload } from './utils/meshcoreGroupEcho.js';
 
 const recordHeardRepeater = vi.fn();
 const getHeardRepeatersForMessage = vi.fn();
 const isEnabled = vi.fn().mockResolvedValue(false);
 const emitMeshCoreChannelHeard = vi.fn();
+const getChannelById = vi.fn();
 
 vi.mock('../services/database.js', () => ({
   default: {
     meshcore: {
       recordHeardRepeater: (...args: unknown[]) => recordHeardRepeater(...args),
       getHeardRepeatersForMessage: (...args: unknown[]) => getHeardRepeatersForMessage(...args),
+    },
+    channels: {
+      getChannelById: (...args: unknown[]) => getChannelById(...args),
     },
   },
 }));
@@ -48,112 +60,231 @@ vi.mock('./services/meshcorePacketLogService.js', () => ({
 import { MeshCoreManager } from './meshcoreManager.js';
 
 const GRP_TXT = 0x05;
+const SELF_NAME = 'MyNode';
 
-function dispatch(m: MeshCoreManager, evt: { event_type: string; data: Record<string, unknown> }): void {
+/** Deterministic 16-byte AES-128 channel secret keyed by a seed. */
+function secretBytes(seed: number): Uint8Array {
+  const s = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) s[i] = (seed + i * 7) & 0xff;
+  return s;
+}
+function secretBase64(seed: number): string {
+  return Buffer.from(secretBytes(seed)).toString('base64');
+}
+
+/**
+ * Build a raw MeshCore OTA frame (hex) that `decodeMeshCorePacket` can parse:
+ * header (FLOOD + GRP_TXT) + packed path-len + 1-byte relay hashes + payload.
+ */
+function buildOtaFrame(payloadHex: string, hopHashes: string[] = []): string {
+  const header = 0x01 | (GRP_TXT << 2); // FLOOD (0x01) + payload type 0x05 => 0x15
+  const hopCount = hopHashes.length & 0x3f; // hashSize=1 => top 2 bits zero
+  const bytes = [header, hopCount];
+  for (const h of hopHashes) bytes.push(parseInt(h, 16) & 0xff);
+  return Buffer.concat([Buffer.from(bytes), Buffer.from(payloadHex, 'hex')]).toString('hex');
+}
+
+/**
+ * Build an `ota_packet` bridge payload for a GRP_TXT echo of `text` sent by
+ * `senderName` on the channel with `secret`, carried by `hops`.
+ */
+function makeEcho(opts: {
+  secret: Uint8Array;
+  senderName?: string;
+  text: string;
+  hops: string[];
+  snr?: number;
+  timestamp?: number;
+}): Record<string, unknown> {
+  const payloadHex = encodeGroupTextPayload(
+    opts.secret,
+    opts.senderName ?? SELF_NAME,
+    opts.text,
+    opts.timestamp ?? 1_700_000_000,
+  );
+  return {
+    payload_type: GRP_TXT,
+    path_hops: opts.hops,
+    snr: opts.snr,
+    raw_hex: buildOtaFrame(payloadHex, opts.hops),
+  };
+}
+
+function dispatch(m: MeshCoreManager, data: Record<string, unknown>): void {
   // @ts-expect-error - exercising private method
-  m.handleBridgeEvent(evt);
+  m.handleBridgeEvent({ event_type: 'ota_packet', data });
 }
 
 /** Seed a pending channel send on a manager (mirrors performScopedSend). */
-function registerSend(m: MeshCoreManager, messageId: string, channelIdx: number): void {
+function registerSend(m: MeshCoreManager, messageId: string, channelIdx: number, text: string): void {
   // @ts-expect-error - exercising private method
-  m.registerPendingChannelSend(messageId, channelIdx);
+  m.registerPendingChannelSend(messageId, channelIdx, text);
 }
 
 async function flush(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let i = 0; i < 6; i++) await Promise.resolve();
 }
 
-describe('MeshCoreManager.findEchoMatch (pure)', () => {
+describe('MeshCoreManager.findEchoMatch (pure, exact decrypt-match)', () => {
   const WINDOW = 30_000;
+  const secret0 = secretBytes(0);
+  const secret1 = secretBytes(1);
 
-  it('matches a GRP_TXT packet to the most recent pending send within window', () => {
+  function opts(secretByIdx: Record<number, Uint8Array>, selfName: string | null = SELF_NAME) {
+    return {
+      selfName,
+      resolveChannelSecret: (idx: number) => secretByIdx[idx] ?? null,
+    };
+  }
+
+  it('attributes an own-message echo to the correct pending send', () => {
     const now = 1_000_000;
     const pending = new Map([
-      ['msg-old', { channelIdx: 0, sentAt: now - 5_000 }],
-      ['msg-new', { channelIdx: 1, sentAt: now - 1_000 }],
+      ['msg-a', { channelIdx: 0, sentAt: now - 2_000, text: 'hello world' }],
     ]);
-    const match = MeshCoreManager.findEchoMatch(
-      { payload_type: GRP_TXT, path_hops: ['a3', '7f'] },
-      pending,
-      now,
-      WINDOW,
-    );
+    const data = makeEcho({ secret: secret0, text: 'hello world', hops: ['a3', '7f'] });
+    const match = MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }));
     expect(match).not.toBeNull();
-    expect(match!.messageId).toBe('msg-new');
-    expect(match!.channelIdx).toBe(1);
+    expect(match!.messageId).toBe('msg-a');
+    expect(match!.channelIdx).toBe(0);
     expect(match!.pathHops).toEqual(['a3', '7f']);
+    expect(typeof match!.echoKey).toBe('string');
+  });
+
+  it('attributes two own-sends-in-window each to the RIGHT message (not most-recent)', () => {
+    const now = 1_000_000;
+    // Two sends within the window on the same channel, different text.
+    const pending = new Map([
+      ['msg-old', { channelIdx: 0, sentAt: now - 8_000, text: 'first message' }],
+      ['msg-new', { channelIdx: 0, sentAt: now - 1_000, text: 'second message' }],
+    ]);
+
+    // Echo of the OLDER message must attribute to msg-old, NOT the most recent.
+    const echoOld = makeEcho({ secret: secret0, text: 'first message', hops: ['a3'] });
+    const matchOld = MeshCoreManager.findEchoMatch(echoOld, pending, now, WINDOW, opts({ 0: secret0 }));
+    expect(matchOld!.messageId).toBe('msg-old');
+
+    // Echo of the NEWER message attributes to msg-new.
+    const echoNew = makeEcho({ secret: secret0, text: 'second message', hops: ['7f'] });
+    const matchNew = MeshCoreManager.findEchoMatch(echoNew, pending, now, WINDOW, opts({ 0: secret0 }));
+    expect(matchNew!.messageId).toBe('msg-new');
+  });
+
+  it('does NOT attribute a third-party message with the same text on the same channel', () => {
+    const now = 1_000_000;
+    const pending = new Map([
+      ['msg-a', { channelIdx: 0, sentAt: now - 1_000, text: 'hello world' }],
+    ]);
+    // Same channel secret + same text, but a DIFFERENT sender name.
+    const data = makeEcho({ secret: secret0, senderName: 'SomeoneElse', text: 'hello world', hops: ['a3'] });
+    const match = MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }));
+    expect(match).toBeNull();
+  });
+
+  it('ignores an echo on a different channel (wrong secret / channel hash)', () => {
+    const now = 1_000_000;
+    const pending = new Map([
+      ['msg-a', { channelIdx: 0, sentAt: now - 1_000, text: 'hello world' }],
+    ]);
+    // Echo was encrypted with channel 1's secret, but the pending send is on
+    // channel 0 (resolver returns channel 0's secret) → hash/MAC reject.
+    const data = makeEcho({ secret: secret1, text: 'hello world', hops: ['a3'] });
+    const match = MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }));
+    expect(match).toBeNull();
+  });
+
+  it('ignores a MAC-failing / garbage frame without throwing', () => {
+    const now = 1_000_000;
+    const pending = new Map([
+      ['msg-a', { channelIdx: 0, sentAt: now - 1_000, text: 'hello world' }],
+    ]);
+    // Tamper the payload after the header+path so MAC verification fails.
+    const good = makeEcho({ secret: secret0, text: 'hello world', hops: ['a3'] });
+    const bytes = Buffer.from(good.raw_hex as string, 'hex');
+    bytes[bytes.length - 1] ^= 0xff; // corrupt ciphertext tail
+    const tampered = { ...good, raw_hex: bytes.toString('hex') };
+    expect(() =>
+      MeshCoreManager.findEchoMatch(tampered, pending, now, WINDOW, opts({ 0: secret0 })),
+    ).not.toThrow();
+    expect(MeshCoreManager.findEchoMatch(tampered, pending, now, WINDOW, opts({ 0: secret0 }))).toBeNull();
+
+    // Structurally broken raw_hex.
+    expect(
+      MeshCoreManager.findEchoMatch(
+        { payload_type: GRP_TXT, path_hops: ['a3'], raw_hex: 'zzzz' },
+        pending,
+        now,
+        WINDOW,
+        opts({ 0: secret0 }),
+      ),
+    ).toBeNull();
   });
 
   it('returns null when no pending send is within the window', () => {
     const now = 1_000_000;
-    const pending = new Map([['msg-stale', { channelIdx: 0, sentAt: now - (WINDOW + 1) }]]);
-    const match = MeshCoreManager.findEchoMatch(
-      { payload_type: GRP_TXT, path_hops: ['a3'] },
-      pending,
-      now,
-      WINDOW,
-    );
-    expect(match).toBeNull();
+    const pending = new Map([
+      ['msg-stale', { channelIdx: 0, sentAt: now - (WINDOW + 1), text: 'hello world' }],
+    ]);
+    const data = makeEcho({ secret: secret0, text: 'hello world', hops: ['a3'] });
+    expect(MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }))).toBeNull();
   });
 
   it('ignores non-GRP_TXT payload types', () => {
     const now = 1_000_000;
-    const pending = new Map([['msg', { channelIdx: 0, sentAt: now }]]);
-    const match = MeshCoreManager.findEchoMatch(
-      { payload_type: 0x02, path_hops: ['a3'] },
-      pending,
-      now,
-      WINDOW,
-    );
-    expect(match).toBeNull();
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now, text: 'hi' }]]);
+    const data = makeEcho({ secret: secret0, text: 'hi', hops: ['a3'] });
+    expect(
+      MeshCoreManager.findEchoMatch({ ...data, payload_type: 0x02 }, pending, now, WINDOW, opts({ 0: secret0 })),
+    ).toBeNull();
   });
 
   it('ignores direct/zero-hop packets with no relay chain', () => {
     const now = 1_000_000;
-    const pending = new Map([['msg', { channelIdx: 0, sentAt: now }]]);
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now, text: 'hi' }]]);
+    const data = makeEcho({ secret: secret0, text: 'hi', hops: [] });
+    expect(MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }))).toBeNull();
     expect(
-      MeshCoreManager.findEchoMatch({ payload_type: GRP_TXT, path_hops: [] }, pending, now, WINDOW),
-    ).toBeNull();
-    expect(
-      MeshCoreManager.findEchoMatch({ payload_type: GRP_TXT }, pending, now, WINDOW),
+      MeshCoreManager.findEchoMatch(
+        { payload_type: GRP_TXT, raw_hex: data.raw_hex },
+        pending,
+        now,
+        WINDOW,
+        opts({ 0: secret0 }),
+      ),
     ).toBeNull();
   });
 
+  it('returns null when the local node name is unknown (can\'t confirm self-origin)', () => {
+    const now = 1_000_000;
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now, text: 'hi' }]]);
+    const data = makeEcho({ secret: secret0, text: 'hi', hops: ['a3'] });
+    expect(MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }, null))).toBeNull();
+  });
+
   it('returns null when there are no pending sends', () => {
-    const match = MeshCoreManager.findEchoMatch(
-      { payload_type: GRP_TXT, path_hops: ['a3'] },
-      new Map(),
-      1_000_000,
-      WINDOW,
-    );
-    expect(match).toBeNull();
+    const data = makeEcho({ secret: secret0, text: 'hi', hops: ['a3'] });
+    expect(MeshCoreManager.findEchoMatch(data, new Map(), 1_000_000, WINDOW, opts({ 0: secret0 }))).toBeNull();
   });
 
   it('dedups repeated relay hashes and normalises to lowercase', () => {
     const now = 1_000_000;
-    const pending = new Map([['msg', { channelIdx: 0, sentAt: now }]]);
-    const match = MeshCoreManager.findEchoMatch(
-      { payload_type: GRP_TXT, path_hops: ['A3', 'a3', '7F', '7f', 'A3'] },
-      pending,
-      now,
-      WINDOW,
-    );
+    const pending = new Map([['msg', { channelIdx: 0, sentAt: now, text: 'hi' }]]);
+    const data = makeEcho({ secret: secret0, text: 'hi', hops: ['A3', 'a3', '7F', '7f', 'A3'] });
+    const match = MeshCoreManager.findEchoMatch(data, pending, now, WINDOW, opts({ 0: secret0 }));
     expect(match!.pathHops).toEqual(['a3', '7f']);
   });
 });
 
 describe('MeshCoreManager — channel-heard correlation (integration)', () => {
+  const secret0 = secretBytes(0);
+
   beforeEach(() => {
     recordHeardRepeater.mockReset();
     getHeardRepeatersForMessage.mockReset();
     emitMeshCoreChannelHeard.mockReset();
+    getChannelById.mockReset();
     isEnabled.mockResolvedValue(false); // packet monitor OFF — correlation must still run
-  });
-
-  it('records repeaters and emits channel-heard for a self-echo (monitor off)', async () => {
+    getChannelById.mockResolvedValue({ id: 0, psk: secretBase64(0) });
     recordHeardRepeater.mockImplementation(async (r: any) => ({
       sourceId: r.sourceId,
       messageId: r.messageId,
@@ -163,18 +294,24 @@ describe('MeshCoreManager — channel-heard correlation (integration)', () => {
       heardAt: r.heardAt,
       createdAt: r.heardAt,
     }));
+  });
+
+  /** Build a manager with a known local node name so self-origin resolves. */
+  function makeManager(sourceId = 'src-a'): MeshCoreManager {
+    const m = new MeshCoreManager(sourceId);
+    (m as any).localNode = { publicKey: 'mypk', name: SELF_NAME };
+    return m;
+  }
+
+  it('records repeaters and emits channel-heard for a decrypted self-echo (monitor off)', async () => {
     getHeardRepeatersForMessage.mockResolvedValue([
       { repeaterHash: 'a3', repeaterName: null, snr: 6 },
       { repeaterHash: '7f', repeaterName: null, snr: 4 },
     ]);
 
-    const m = new MeshCoreManager('src-a');
-    registerSend(m, 'sent-123', 1);
-
-    dispatch(m, {
-      event_type: 'ota_packet',
-      data: { payload_type: GRP_TXT, path_hops: ['a3', '7f'], snr: 6 },
-    });
+    const m = makeManager();
+    registerSend(m, 'sent-123', 0, 'hello world');
+    dispatch(m, makeEcho({ secret: secret0, text: 'hello world', hops: ['a3', '7f'], snr: 6 }));
     await flush();
 
     expect(recordHeardRepeater).toHaveBeenCalledTimes(2);
@@ -184,7 +321,6 @@ describe('MeshCoreManager — channel-heard correlation (integration)', () => {
     expect(recordHeardRepeater).toHaveBeenCalledWith(
       expect.objectContaining({ sourceId: 'src-a', messageId: 'sent-123', repeaterHash: '7f' }),
     );
-
     expect(emitMeshCoreChannelHeard).toHaveBeenCalledTimes(1);
     expect(emitMeshCoreChannelHeard).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -198,31 +334,37 @@ describe('MeshCoreManager — channel-heard correlation (integration)', () => {
     );
   });
 
-  it('updates the in-memory message pool with heardBy so getRecentMessages reflects relay info (#3813)', async () => {
-    recordHeardRepeater.mockImplementation(async (r: any) => ({
-      sourceId: r.sourceId,
-      messageId: r.messageId,
-      repeaterHash: r.repeaterHash,
-      repeaterName: r.repeaterName ?? null,
-      snr: r.snr ?? null,
-      heardAt: r.heardAt,
-      createdAt: r.heardAt,
-    }));
-    getHeardRepeatersForMessage.mockResolvedValue([
-      { repeaterHash: 'a3', repeaterName: 'Relay1', snr: 7 },
-    ]);
+  it('attributes an echo at most once even if the same frame is heard twice', async () => {
+    getHeardRepeatersForMessage.mockResolvedValue([{ repeaterHash: 'a3', repeaterName: null, snr: 5 }]);
+    const m = makeManager();
+    registerSend(m, 'sent-1', 0, 'once only');
+    const echo = makeEcho({ secret: secret0, text: 'once only', hops: ['a3'], snr: 5 });
 
-    const m = new MeshCoreManager('src-a');
-    // Seed the in-memory pool with an outgoing message (no heardBy yet).
-    (m as any).messages = [
-      { id: 'sent-abc', fromPublicKey: 'mypk', text: 'hello', timestamp: 1000 },
-    ];
-    registerSend(m, 'sent-abc', 0);
+    dispatch(m, echo);
+    await flush();
+    dispatch(m, echo); // exact same frame again
+    await flush();
 
-    dispatch(m, {
-      event_type: 'ota_packet',
-      data: { payload_type: GRP_TXT, path_hops: ['a3'], snr: 7 },
-    });
+    // Only the first dispatch attributes; the second is a no-op.
+    expect(recordHeardRepeater).toHaveBeenCalledTimes(1);
+    expect(emitMeshCoreChannelHeard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT record a third-party same-channel GRP_TXT echo', async () => {
+    const m = makeManager();
+    registerSend(m, 'sent-1', 0, 'hello world');
+    dispatch(m, makeEcho({ secret: secret0, senderName: 'Stranger', text: 'hello world', hops: ['a3'], snr: 5 }));
+    await flush();
+    expect(recordHeardRepeater).not.toHaveBeenCalled();
+    expect(emitMeshCoreChannelHeard).not.toHaveBeenCalled();
+  });
+
+  it('updates the in-memory message pool with heardBy (#3813)', async () => {
+    getHeardRepeatersForMessage.mockResolvedValue([{ repeaterHash: 'a3', repeaterName: 'Relay1', snr: 7 }]);
+    const m = makeManager();
+    (m as any).messages = [{ id: 'sent-abc', fromPublicKey: 'mypk', text: 'hello', timestamp: 1000 }];
+    registerSend(m, 'sent-abc', 0, 'hello');
+    dispatch(m, makeEcho({ secret: secret0, text: 'hello', hops: ['a3'], snr: 7 }));
     await flush();
 
     const msgs = m.getRecentMessages(10);
@@ -231,24 +373,17 @@ describe('MeshCoreManager — channel-heard correlation (integration)', () => {
   });
 
   it('does not record anything when no pending channel send matches', async () => {
-    const m = new MeshCoreManager('src-a');
-    // No registerSend — nothing pending.
-    dispatch(m, {
-      event_type: 'ota_packet',
-      data: { payload_type: GRP_TXT, path_hops: ['a3'], snr: 5 },
-    });
+    const m = makeManager();
+    dispatch(m, makeEcho({ secret: secret0, text: 'orphan', hops: ['a3'], snr: 5 }));
     await flush();
     expect(recordHeardRepeater).not.toHaveBeenCalled();
     expect(emitMeshCoreChannelHeard).not.toHaveBeenCalled();
   });
 
   it('ignores inbound DM (non-GRP_TXT) packets', async () => {
-    const m = new MeshCoreManager('src-a');
-    registerSend(m, 'sent-123', 0);
-    dispatch(m, {
-      event_type: 'ota_packet',
-      data: { payload_type: 0x02, path_hops: ['a3'], snr: 5 },
-    });
+    const m = makeManager();
+    registerSend(m, 'sent-123', 0, 'hi');
+    dispatch(m, { payload_type: 0x02, path_hops: ['a3'], snr: 5 });
     await flush();
     expect(recordHeardRepeater).not.toHaveBeenCalled();
     expect(emitMeshCoreChannelHeard).not.toHaveBeenCalled();

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -28,6 +28,9 @@ import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import { notificationService } from './services/notificationService.js';
 import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
 import type { DbMeshCorePacket } from '../db/repositories/meshcore.js';
+import { decodeMeshCorePacket } from '../utils/meshcorePacketDecode.js';
+import { MESHCORE_SECRET_BYTES } from '../utils/meshcoreHelpers.js';
+import { tryDecodeGroupTextPayload } from './utils/meshcoreGroupEcho.js';
 
 // Dynamic imports for optional serialport dependency
 // These are loaded only when MeshCore is enabled to avoid requiring native build tools
@@ -650,13 +653,22 @@ class MeshCoreManager extends EventEmitter {
   private commandId: number = 0;
 
   /**
-   * Pending outgoing channel sends awaiting self-echo correlation (#3700).
-   * Keyed by message id. Each entry remembers the channel index and send time
-   * so an inbound GRP_TXT OTA packet arriving within HEARD_WINDOW_MS can be
-   * attributed (best-effort) to the most recent matching channel send. Pruned
-   * lazily on each inbound packet and on each new send.
+   * Pending outgoing channel sends awaiting self-echo correlation (#3700,
+   * #3979). Keyed by message id. Each entry remembers the channel index, send
+   * time, and the exact `text` we sent, so an inbound GRP_TXT OTA packet
+   * arriving within HEARD_WINDOW_MS can be attributed to the SPECIFIC send whose
+   * decrypted plaintext matches — not merely the most recent send. Pruned lazily
+   * on each inbound packet and on each new send.
    */
-  private pendingChannelSends: Map<string, { channelIdx: number; sentAt: number }> = new Map();
+  private pendingChannelSends: Map<string, { channelIdx: number; sentAt: number; text: string }> = new Map();
+
+  /**
+   * De-dup guard so a single echoed channel packet is attributed at most ONCE
+   * (#3979). Keyed by the GRP_TXT payload hex (channel_hash + MAC + ciphertext)
+   * — the MeshCore dedup identity, invariant across re-floods — mapped to the
+   * time it was attributed, so entries can be pruned by the heard window.
+   */
+  private attributedChannelEchoes: Map<string, number> = new Map();
 
   /**
    * In-flight DM sends awaiting a `SendConfirmed` ack, keyed by the *current*
@@ -1579,18 +1591,42 @@ class MeshCoreManager extends EventEmitter {
    * (#3700). Prunes entries older than HEARD_WINDOW_MS so the map never grows
    * unbounded on a chatty channel.
    */
-  private registerPendingChannelSend(messageId: string, channelIdx: number): void {
+  private registerPendingChannelSend(messageId: string, channelIdx: number, text: string): void {
     const now = Date.now();
     this.prunePendingChannelSends(now);
-    this.pendingChannelSends.set(messageId, { channelIdx, sentAt: now });
+    this.pendingChannelSends.set(messageId, { channelIdx, sentAt: now, text });
   }
 
-  /** Drop pending channel sends older than the heard window. */
+  /** Drop pending channel sends (and stale attribution guards) older than the
+   *  heard window. */
   private prunePendingChannelSends(now: number): void {
     for (const [id, entry] of this.pendingChannelSends) {
       if (now - entry.sentAt > MeshCoreManager.HEARD_WINDOW_MS) {
         this.pendingChannelSends.delete(id);
       }
+    }
+    for (const [key, heardAt] of this.attributedChannelEchoes) {
+      if (now - heardAt > MeshCoreManager.HEARD_WINDOW_MS) {
+        this.attributedChannelEchoes.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Load the 16-byte AES-128 secret for a MeshCore channel slot from the
+   * channels repository (base64 `psk`). Returns null when the channel is
+   * unknown, has no PSK, or the PSK is not a valid 16-byte key. Never throws —
+   * a DB hiccup must not break the packet pipeline.
+   */
+  private async loadChannelSecret(channelIdx: number): Promise<Uint8Array | null> {
+    try {
+      const channel = await databaseService.channels.getChannelById(channelIdx, this.sourceId);
+      if (!channel?.psk) return null;
+      const buf = Buffer.from(channel.psk, 'base64');
+      if (buf.length !== MESHCORE_SECRET_BYTES) return null;
+      return new Uint8Array(buf);
+    } catch {
+      return null;
     }
   }
 
@@ -1599,12 +1635,15 @@ class MeshCoreManager extends EventEmitter {
    *
    * When a nearby repeater re-floods one of OUR channel messages, our device
    * hears it as an inbound GRP_TXT OTA packet whose relay-hash chain
-   * (`path_hops`) names the repeaters that carried it. We can't prove the echo
-   * is ours (the bridge doesn't return our outgoing payload bytes), so we bound
-   * the attribution: only GRP_TXT, only within HEARD_WINDOW_MS of one of our
-   * channel sends, attributed to the most recent such send. Each relay hash is
-   * resolved to a known contact name when possible (raw hash otherwise), the
-   * max SNR is tracked per repeater, and the merged heard-by set is broadcast.
+   * (`path_hops`) names the repeaters that carried it. We PROVE the echo is ours
+   * (#3979): we hold the channel PSK, so we decrypt the echoed payload and
+   * require the recovered plaintext to be exactly `"<ourNodeName>: <textWeSent>"`
+   * for one of our pending channel sends. This rejects both unrelated
+   * third-party chatter on the same channel and cross-attribution between two of
+   * our own near-simultaneous sends. Each relay hash is resolved to a known
+   * contact name when possible (raw hash otherwise), the max SNR is tracked per
+   * repeater, and the merged heard-by set is broadcast. Each echoed packet is
+   * attributed at most once (guarded by the invariant payload identity).
    *
    * Failures are swallowed — correlation must never break the packet pipeline.
    */
@@ -1613,13 +1652,35 @@ class MeshCoreManager extends EventEmitter {
       const now = Date.now();
       this.prunePendingChannelSends(now);
 
+      // Hot-path early-outs: only GRP_TXT frames with at least one pending
+      // channel send can ever match — skip the decrypt attempt otherwise.
+      if (!data || data.payload_type !== MeshCoreManager.PAYLOAD_TYPE_GRP_TXT) return;
+      if (this.pendingChannelSends.size === 0) return;
+
+      // Pre-load the channel secret for every distinct pending channel so the
+      // pure matcher can stay synchronous (no DB in the unit-testable core).
+      const secretByChannel = new Map<number, Uint8Array | null>();
+      for (const [, entry] of this.pendingChannelSends) {
+        if (!secretByChannel.has(entry.channelIdx)) {
+          secretByChannel.set(entry.channelIdx, await this.loadChannelSecret(entry.channelIdx));
+        }
+      }
+
       const match = MeshCoreManager.findEchoMatch(
         data,
         this.pendingChannelSends,
         now,
         MeshCoreManager.HEARD_WINDOW_MS,
+        {
+          selfName: this.localNode?.name ?? null,
+          resolveChannelSecret: (idx) => secretByChannel.get(idx) ?? null,
+        },
       );
       if (!match) return;
+
+      // Attribute each distinct echoed packet at most once (#3979).
+      if (this.attributedChannelEchoes.has(match.echoKey)) return;
+      this.attributedChannelEchoes.set(match.echoKey, now);
 
       const snr = typeof data.snr === 'number' ? Math.round(data.snr) : null;
       const heardBy: Array<{ hash: string; name?: string | null; snr?: number | null }> = [];
@@ -1674,20 +1735,36 @@ class MeshCoreManager extends EventEmitter {
 
   /**
    * Decide whether an inbound OTA packet is a self-echo of a pending channel
-   * send (#3700). Pure (no I/O) so it can be unit-tested directly. Returns the
-   * matched message id and the de-duplicated relay-hash chain, or null.
+   * send (#3700, #3979). Pure (no I/O) so it can be unit-tested directly against
+   * real encrypted fixtures. Returns the matched message id, the de-duplicated
+   * relay-hash chain, and the echo's invariant payload identity (`echoKey`), or
+   * null.
    *
-   * A match requires: payload_type === GRP_TXT, a non-empty `path_hops` relay
-   * chain (a direct/zero-hop packet names no repeaters), and at least one
-   * pending channel send within the window. Attribution goes to the MOST RECENT
-   * pending send (best-effort; the window + type bound the risk).
+   * A match requires ALL of:
+   *  - `payload_type === GRP_TXT`;
+   *  - a non-empty `path_hops` relay chain (a direct/zero-hop packet names no
+   *    repeaters);
+   *  - a known local node name (`selfName`) — needed to confirm self-origin;
+   *  - a decodable `raw_hex`; and
+   *  - a pending channel send, WITHIN the window, whose channel secret both
+   *    MAC-verifies and AES-decrypts the echoed payload to exactly
+   *    `"<selfName>: <that send's text>"`.
+   *
+   * When several pending sends satisfy the exact match (identical text on the
+   * same channel), the OLDEST is chosen for deterministic attribution — never
+   * "most recent". A third-party message (whose decrypted sender name differs)
+   * or a re-flood of a different channel simply never matches.
    */
   static findEchoMatch(
     data: any,
-    pendingChannelSends: Map<string, { channelIdx: number; sentAt: number }>,
+    pendingChannelSends: Map<string, { channelIdx: number; sentAt: number; text: string }>,
     now: number,
     windowMs: number,
-  ): { messageId: string; channelIdx: number; pathHops: string[] } | null {
+    opts: {
+      selfName: string | null;
+      resolveChannelSecret: (channelIdx: number) => Uint8Array | null;
+    },
+  ): { messageId: string; channelIdx: number; pathHops: string[]; echoKey: string } | null {
     if (!data || data.payload_type !== MeshCoreManager.PAYLOAD_TYPE_GRP_TXT) return null;
 
     const rawHops: unknown = data.path_hops;
@@ -1704,16 +1781,34 @@ class MeshCoreManager extends EventEmitter {
     }
     if (pathHops.length === 0) return null;
 
-    let best: { messageId: string; channelIdx: number; sentAt: number } | null = null;
-    for (const [messageId, entry] of pendingChannelSends) {
-      if (now - entry.sentAt > windowMs) continue;
-      if (!best || entry.sentAt > best.sentAt) {
-        best = { messageId, channelIdx: entry.channelIdx, sentAt: entry.sentAt };
-      }
-    }
-    if (!best) return null;
+    // Without our own node name we can't confirm self-origin — bail rather than
+    // risk crediting a third-party message.
+    const selfName = opts.selfName;
+    if (!selfName) return null;
 
-    return { messageId: best.messageId, channelIdx: best.channelIdx, pathHops };
+    // Recover the GRP_TXT payload (`[channel_hash:1][MAC:2][ciphertext]`) from
+    // the raw OTA frame; `path_hops` above already gives the relay chain.
+    const decoded = decodeMeshCorePacket(typeof data.raw_hex === 'string' ? data.raw_hex : null);
+    const payloadHex = decoded?.payload?.hex;
+    if (!payloadHex) return null;
+
+    // Try each in-window pending send OLDEST-first so attribution is
+    // deterministic (never "most recent").
+    const candidates = Array.from(pendingChannelSends.entries())
+      .filter(([, entry]) => now - entry.sentAt <= windowMs)
+      .sort((a, b) => a[1].sentAt - b[1].sentAt);
+
+    for (const [messageId, entry] of candidates) {
+      const secret = opts.resolveChannelSecret(entry.channelIdx);
+      if (!secret) continue;
+      const plaintext = tryDecodeGroupTextPayload(payloadHex, secret);
+      if (!plaintext) continue;
+      // Self-origin + exact-text check in one comparison: MeshCore prefixes the
+      // sender name, so our own echo decrypts to `"<selfName>: <text>"`.
+      if (plaintext.body !== `${selfName}: ${entry.text}`) continue;
+      return { messageId, channelIdx: entry.channelIdx, pathHops, echoKey: payloadHex };
+    }
+    return null;
   }
 
   /**
@@ -2731,7 +2826,7 @@ class MeshCoreManager extends EventEmitter {
         // relaying repeaters in its path. DMs are excluded — they already get
         // a real ACK (send-confirmed).
         if (isChannelSend) {
-          this.registerPendingChannelSend(msgId, channelIdx!);
+          this.registerPendingChannelSend(msgId, channelIdx!, text);
         }
 
         return { ok: true, expectedAckCrc: ackCrc ?? undefined, estTimeout: estTimeout ?? undefined };

--- a/src/server/utils/meshcoreGroupEcho.test.ts
+++ b/src/server/utils/meshcoreGroupEcho.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the MeshCore GRP_TXT self-echo crypto (#3979).
+ *
+ * These exercise the decrypt path end-to-end against fixtures built with the
+ * real inverse (`encodeGroupTextPayload`), so the AES-128-ECB / HMAC / channel-
+ * hash logic is validated as a matched pair. Defensive behaviour (wrong
+ * channel, MAC tamper, garbage) must return null and never throw.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  deriveMeshCoreChannelHash,
+  encodeGroupTextPayload,
+  tryDecodeGroupTextPayload,
+} from './meshcoreGroupEcho.js';
+
+/** Deterministic 16-byte AES-128 channel secret. */
+function secretBytes(seed = 0): Uint8Array {
+  const s = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) s[i] = (seed + i * 7) & 0xff;
+  return s;
+}
+
+describe('meshcoreGroupEcho crypto', () => {
+  it('round-trips sender + text through encode → decode', () => {
+    const secret = secretBytes(3);
+    const payloadHex = encodeGroupTextPayload(secret, 'MyNode', 'hello world', 1_700_000_000);
+    const decoded = tryDecodeGroupTextPayload(payloadHex, secret);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.body).toBe('MyNode: hello world');
+    expect(decoded!.timestamp).toBe(1_700_000_000);
+  });
+
+  it('preserves leading/trailing whitespace in the text exactly', () => {
+    const secret = secretBytes(9);
+    const text = '  spaced out  ';
+    const payloadHex = encodeGroupTextPayload(secret, 'N', text);
+    const decoded = tryDecodeGroupTextPayload(payloadHex, secret);
+    // Body is "<name>: <text>"; slicing off "N: " must return the exact text.
+    expect(decoded!.body).toBe(`N: ${text}`);
+    expect(decoded!.body.slice('N: '.length)).toBe(text);
+  });
+
+  it('handles a text whose buffer length is an exact multiple of 16 (no padding NUL)', () => {
+    const secret = secretBytes(1);
+    // header(5) + "N: " (3) => 8; add 8 chars => 16 exactly.
+    const payloadHex = encodeGroupTextPayload(secret, 'N', '12345678');
+    const decoded = tryDecodeGroupTextPayload(payloadHex, secret);
+    expect(decoded!.body).toBe('N: 12345678');
+  });
+
+  it('channel hash matches SHA-256(secret)[0]', () => {
+    const secret = secretBytes(5);
+    const payloadHex = encodeGroupTextPayload(secret, 'A', 'x');
+    const firstByte = parseInt(payloadHex.slice(0, 2), 16);
+    expect(firstByte).toBe(deriveMeshCoreChannelHash(secret));
+  });
+
+  it('returns null for the WRONG channel secret (channel-hash / MAC reject)', () => {
+    const secret = secretBytes(2);
+    const other = secretBytes(42);
+    const payloadHex = encodeGroupTextPayload(secret, 'MyNode', 'hi', 1);
+    expect(tryDecodeGroupTextPayload(payloadHex, other)).toBeNull();
+  });
+
+  it('returns null when the MAC is tampered (same channel hash, bad MAC)', () => {
+    const secret = secretBytes(7);
+    const payloadHex = encodeGroupTextPayload(secret, 'MyNode', 'hi', 1);
+    // Flip a MAC byte (bytes 1-2), leaving the channel hash (byte 0) intact.
+    const bytes = Buffer.from(payloadHex, 'hex');
+    bytes[1] ^= 0xff;
+    expect(tryDecodeGroupTextPayload(bytes.toString('hex'), secret)).toBeNull();
+  });
+
+  it('returns null (never throws) for garbage / truncated payloads', () => {
+    const secret = secretBytes(0);
+    expect(tryDecodeGroupTextPayload('', secret)).toBeNull();
+    expect(tryDecodeGroupTextPayload('00', secret)).toBeNull();
+    expect(tryDecodeGroupTextPayload('deadbeef', secret)).toBeNull();
+    // A payload with correct length but random bytes must not throw.
+    expect(tryDecodeGroupTextPayload('ab'.repeat(19), secret)).toBeNull();
+  });
+
+  it('returns null for a too-short secret', () => {
+    const payloadHex = encodeGroupTextPayload(secretBytes(0), 'A', 'x');
+    expect(tryDecodeGroupTextPayload(payloadHex, new Uint8Array(8))).toBeNull();
+  });
+});

--- a/src/server/utils/meshcoreGroupEcho.ts
+++ b/src/server/utils/meshcoreGroupEcho.ts
@@ -1,0 +1,170 @@
+/**
+ * MeshCore GRP_TXT (channel/broadcast text) self-echo crypto (#3979).
+ *
+ * When a nearby repeater re-floods one of OUR channel messages, our device
+ * hears it back as an inbound `PAYLOAD_TYPE_GRP_TXT` (0x05) OTA packet whose
+ * relay-hash chain names the repeaters that carried it. To attribute that echo
+ * to the SPECIFIC message we sent — and to reject unrelated third-party channel
+ * chatter on the same channel — we hold the channel PSK and decrypt the echoed
+ * payload, then match the recovered plaintext against what we sent.
+ *
+ * Wire format (verified against ripplebiz/MeshCore `main`):
+ *   GRP_TXT payload = [channel_hash : 1B][MAC : 2B][ciphertext]
+ *     - channel_hash = SHA-256(secret)[0]            (Utils/BaseChatMesh.addChannel)
+ *     - MAC          = HMAC-SHA256(secret32, ciphertext)[0:2]   (Utils.encryptThenMAC)
+ *                      where secret32 = 16-byte PSK zero-padded to 32 bytes
+ *     - ciphertext   = AES-128-ECB(secret[0:16], plaintext), zero-padded to 16B
+ *   plaintext = timestamp(4 LE) || flags(1, =0x00 for PLAIN group text)
+ *               || "<senderName>: <text>"   (NUL-terminated / zero-padded)
+ *
+ * Repeaters forward the payload byte-for-byte (only `path[]` mutates), so the
+ * ciphertext we hear back is identical to what we sent and the decrypt is exact.
+ *
+ * Server-only (Node `crypto`). Every function is defensive: a malformed,
+ * wrong-channel, MAC-failing, or otherwise undecodable frame returns null and
+ * NEVER throws, so this can run on the hot inbound-packet path safely.
+ */
+import { createHash, createHmac, createCipheriv, createDecipheriv } from 'node:crypto';
+import { hexToBytes } from '../../utils/meshcorePacketDecode.js';
+import { MESHCORE_SECRET_BYTES } from '../../utils/meshcoreHelpers.js';
+
+/** Bytes of channel_hash prefixing a GRP_TXT payload (PATH_HASH_SIZE = 1). */
+const CHANNEL_HASH_SIZE = 1;
+/** Bytes of MAC (CIPHER_MAC_SIZE = 2). */
+const CIPHER_MAC_SIZE = 2;
+/** AES block size — the firmware zero-pads ciphertext to a multiple of this. */
+const AES_BLOCK_SIZE = 16;
+/** Plaintext header: timestamp(4 LE) + flags(1). */
+const GROUP_TEXT_HEADER_SIZE = 5;
+/**
+ * Firmware `GroupChannel.secret` is a PUB_KEY_SIZE = 32-byte buffer; the HMAC
+ * key is the whole buffer (a 16-byte PSK is zero-padded to 32), while AES uses
+ * only the first CIPHER_KEY_SIZE = 16 bytes.
+ */
+const SECRET_BUFFER_SIZE = 32;
+
+/**
+ * Derive the 1-byte MeshCore channel hash from a channel secret: the first byte
+ * of SHA-256 over the secret (`BaseChatMesh::addChannel`). For MeshMonitor's
+ * 16-byte AES-128 PSKs this hashes the 16 stored bytes.
+ */
+export function deriveMeshCoreChannelHash(secret: Uint8Array): number {
+  return createHash('sha256').update(Buffer.from(secret)).digest()[0];
+}
+
+/**
+ * Split a channel secret into the AES key (first 16 bytes) and the HMAC key
+ * (the secret zero-padded to 32 bytes). Returns null for a too-short secret.
+ */
+function secretToKeys(secret: Uint8Array): { aesKey: Buffer; hmacKey: Buffer } | null {
+  if (secret.length < MESHCORE_SECRET_BYTES) return null;
+  const aesKey = Buffer.from(secret.subarray(0, MESHCORE_SECRET_BYTES));
+  const hmacKey = Buffer.alloc(SECRET_BUFFER_SIZE);
+  Buffer.from(secret).copy(hmacKey, 0, 0, Math.min(secret.length, SECRET_BUFFER_SIZE));
+  return { aesKey, hmacKey };
+}
+
+export interface DecodedGroupText {
+  /** Firmware send-time timestamp (unix seconds, LE) recovered from plaintext. */
+  timestamp: number;
+  /**
+   * The recovered `"<senderName>: <text>"` body. MeshCore prefixes every group
+   * message with the sender's node name and a `": "` separator, so a self-echo
+   * of our own send decrypts to `"<ourNodeName>: <textWeSent>"`.
+   */
+  body: string;
+}
+
+/**
+ * MAC-verify and AES-128-ECB decrypt a raw GRP_TXT payload
+ * (`[channel_hash:1][MAC:2][ciphertext]` hex) with a candidate 16-byte channel
+ * secret. Returns the recovered `{ timestamp, body }` or null on ANY failure
+ * (wrong channel hash, MAC mismatch, malformed structure, non-PLAIN group text,
+ * no `": "` separator). NEVER throws.
+ */
+export function tryDecodeGroupTextPayload(
+  payloadHex: string | null | undefined,
+  secret: Uint8Array,
+): DecodedGroupText | null {
+  try {
+    if (!payloadHex) return null;
+    const keys = secretToKeys(secret);
+    if (!keys) return null;
+
+    const payload = hexToBytes(payloadHex);
+    if (payload.length < CHANNEL_HASH_SIZE + CIPHER_MAC_SIZE + AES_BLOCK_SIZE) return null;
+
+    // (1) Channel-hash pre-filter — cheap reject for the wrong channel.
+    if (payload[0] !== deriveMeshCoreChannelHash(secret)) return null;
+
+    const mac = payload.subarray(CHANNEL_HASH_SIZE, CHANNEL_HASH_SIZE + CIPHER_MAC_SIZE);
+    const ciphertext = payload.subarray(CHANNEL_HASH_SIZE + CIPHER_MAC_SIZE);
+    if (ciphertext.length === 0 || ciphertext.length % AES_BLOCK_SIZE !== 0) return null;
+
+    // (2) MAC verify: HMAC-SHA256(secret32, ciphertext)[0:2].
+    const expected = createHmac('sha256', keys.hmacKey).update(Buffer.from(ciphertext)).digest();
+    if (expected[0] !== mac[0] || expected[1] !== mac[1]) return null;
+
+    // (3) AES-128-ECB decrypt. Firmware zero-pads (not PKCS), so no auto-padding.
+    const decipher = createDecipheriv('aes-128-ecb', keys.aesKey, null);
+    decipher.setAutoPadding(false);
+    const plain = Buffer.concat([decipher.update(Buffer.from(ciphertext)), decipher.final()]);
+    if (plain.length < GROUP_TEXT_HEADER_SIZE + 1) return null;
+
+    // Group text is TXT_TYPE_PLAIN — the receiver drops anything with the type
+    // bits set (`onGroupDataRecv` rejects `(flags >> 2) != 0`). Mirror that.
+    if ((plain[GROUP_TEXT_HEADER_SIZE - 1] >> 2) !== 0) return null;
+
+    const timestamp = plain.readUInt32LE(0);
+    // Text is NUL-terminated inside the buffer (or ends at the zero padding).
+    let end = plain.indexOf(0, GROUP_TEXT_HEADER_SIZE);
+    if (end < 0) end = plain.length;
+    const body = plain.subarray(GROUP_TEXT_HEADER_SIZE, end).toString('utf8');
+    return { timestamp, body };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the wire GRP_TXT payload (`[channel_hash:1][MAC:2][ciphertext]`) for a
+ * channel message. This is the exact inverse of {@link tryDecodeGroupTextPayload}
+ * — the production decode path is validated end-to-end against fixtures built
+ * with this. Returns the payload as a lowercase hex string.
+ *
+ * @param secret      16-byte AES-128 channel secret.
+ * @param senderName  Sender node name (prefixed to the text on the wire).
+ * @param text        Message text.
+ * @param timestamp   Firmware send timestamp (unix seconds); defaults to now.
+ */
+export function encodeGroupTextPayload(
+  secret: Uint8Array,
+  senderName: string,
+  text: string,
+  timestamp: number = Math.floor(Date.now() / 1000),
+): string {
+  const keys = secretToKeys(secret);
+  if (!keys) throw new Error('channel secret too short');
+
+  const bodyBytes = Buffer.from(`${senderName}: ${text}`, 'utf8');
+  const rawLen = GROUP_TEXT_HEADER_SIZE + bodyBytes.length;
+  const paddedLen = Math.ceil(rawLen / AES_BLOCK_SIZE) * AES_BLOCK_SIZE;
+  const plain = Buffer.alloc(paddedLen); // zero-filled → zero padding
+  plain.writeUInt32LE(timestamp >>> 0, 0);
+  plain[4] = 0x00; // TXT_TYPE_PLAIN, attempt 0
+  bodyBytes.copy(plain, GROUP_TEXT_HEADER_SIZE);
+
+  const cipher = createCipheriv('aes-128-ecb', keys.aesKey, null);
+  cipher.setAutoPadding(false);
+  const ciphertext = Buffer.concat([cipher.update(plain), cipher.final()]);
+
+  const mac = createHmac('sha256', keys.hmacKey).update(ciphertext).digest();
+  const channelHash = deriveMeshCoreChannelHash(secret);
+
+  const payload = Buffer.concat([
+    Buffer.from([channelHash]),
+    mac.subarray(0, CIPHER_MAC_SIZE),
+    ciphertext,
+  ]);
+  return payload.toString('hex');
+}


### PR DESCRIPTION
## Summary

Part 1 of #3979 (echo-attribution correctness); Part 2 (auto-retry) tracked separately.

The MeshCore channel **"X repeaters relayed this message"** indicator used a self-echo *heuristic*: it matched any inbound `GRP_TXT` packet within a 30 s window to the **most recent** pending channel send, comparing nothing about channel, sender, payload, or text. Two real false-positives resulted:

1. **Two own-sends within 30 s** → the earlier message's echo was credited to the later message.
2. **Any third-party channel re-flood** on an active mesh was counted as *our* message being relayed.

## The fix — exact decrypt-and-match

MeshMonitor holds the channel PSK, so instead of guessing we now **decrypt the echo and match it**:

- **Send side:** the pending-send record now stores the exact `text` we sent (plus channel/messageId/sentAt).
- **Echo side** (`correlateChannelEcho` → `findEchoMatch`, both in `meshcoreManager.ts`): decode the raw OTA frame, slice the GRP_TXT payload `[channel_hash:1][MAC:2][ciphertext]`, then for each in-window pending send:
  - require the echoed `channel_hash` to equal `SHA-256(secret)[0]`;
  - MAC-verify `HMAC-SHA256(secret32, ciphertext)[0:2]` (16-byte PSK zero-padded to 32 for the HMAC key; first 16 bytes as the AES key);
  - AES-128-**ECB** decrypt and recover `"<senderName>: <text>"`;
  - attribute to the pending send whose plaintext is **exactly** `"<ourNodeName>: <textWeSent>"` (self-origin **and** exact text), **oldest-first on ties — never "most recent"**.

**The exact-match key:** decrypted body `=== \`${localNodeName}: ${sentText}\`` on the channel whose derived `channel_hash` matches and whose MAC verifies.

A third-party message (different sender name), a wrong-channel echo, or a MAC-failing/garbage frame **never matches**. Decryption is fully defensive — any malformed/undecodable frame returns `null`, never throws. Each echoed packet is attributed **at most once** (keyed by the invariant payload identity). The heard-repeater persistence/broadcast path (`recordHeardRepeater`, `getHeardRepeatersForMessage`, `meshcore:channel-heard`) is unchanged — only the *matching* became exact.

## Wire-format source of truth

Verified byte-for-byte against **ripplebiz/MeshCore `main`** firmware: `Utils.encryptThenMAC`/`MACThenDecrypt`, `BaseChatMesh.addChannel` (channel hash = `SHA256(secret)[0]`), `BaseChatMesh.sendGroupMessage` (plaintext = `timestamp(4 LE) || flags(1) || "name: text"`, zero-padded to 16), and `Mesh.routeRecvPacket` (payload forwarded byte-for-byte).

## New file

`src/server/utils/meshcoreGroupEcho.ts` — server-only Node-crypto helper: `tryDecodeGroupTextPayload` (defensive decrypt) + `deriveMeshCoreChannelHash` + `encodeGroupTextPayload` (the exact inverse, used to build encrypted fixtures so the decrypt path is exercised end-to-end).

## Tests

- `meshcoreGroupEcho.test.ts` (8): encode→decode round-trip, whitespace preservation, 16-byte-aligned buffer, channel-hash correctness, wrong-secret / tampered-MAC / garbage / short-secret rejection.
- `meshcoreManager.channelHeard.test.ts` (17, rewritten): own-echo attributed correctly; **two own-sends each attributed to the RIGHT message**; third-party same-channel echo NOT attributed; wrong-channel ignored; MAC-fail/garbage ignored without throwing; each echo attributed at most once; plus window/type/path gating and dedup. Fixtures built by encrypting known plaintext with a known channel secret.

Full Vitest suite: **8166 passed, 0 failed** (`--reporter=json` `success: true`). `tsc --noEmit`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub