### PR TITLE
feat(meshcore): opt-in auto-retry for automated channel sends (#3979 Part 2)

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -189,6 +189,14 @@ Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the
 The overall send is a **source × channel matrix**: each selected source posts to the matching local
 slot of each selected channel.
 
+> **MeshCore channel-send auto-retry** — because a MeshCore channel/broadcast send is an unacked
+> flood, the `Send message` action (like every automated MeshCore channel sender) can optionally be
+> resent once if no repeater is heard re-flooding it within 30 seconds. This is a global, opt-in,
+> one-shot behavior (off by default) configured in **Settings → MeshCore Messaging**; it never
+> retries user-typed messages, never retries direct messages (those have their own always-on ACK
+> retry), and the resend can never trigger a fresh automation. See
+> [Automated Channel-Send Auto-Retry](/features/meshcore#automated-channel-send-auto-retry).
+
 ### Manage the node
 
 Runs an admin/management operation on the subject node: **Favorite / Unfavorite**, **Ignore /

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -429,6 +429,20 @@ Timer Triggers schedule recurring actions independent of incoming traffic:
 - **Three actions** — send a **text** message (token expansion supported) to a channel or contact, fire a MeshCore **advert**, or **run a script** (token-expanded args).
 - **Last-run telemetry** — the UI surfaces the last fire time and outcome per trigger.
 
+## Automated Channel-Send Auto-Retry
+
+MeshCore channel (broadcast) messages are unacked, fire-and-forget floods — unlike a direct message, there is no firmware ACK to confirm delivery. MeshMonitor instead listens for nearby repeaters re-flooding your own packet (the "heard repeaters" signal, see [Message route line](#message-route-line)). When **no** repeater is heard, the message likely reached no one.
+
+The **MeshCore Messaging** section of global **Settings** hosts an opt-in toggle, **Auto-retry automated MeshCore channel sends** (default **off**). When enabled:
+
+- An **automated** channel send that hears **zero** repeaters within **30 seconds** is resent **exactly once**.
+- It applies only to automated senders: the [Automation Engine](/features/automation-engine) `Send message` action, Auto-Acknowledge, the [Auto-Responder](#auto-responder), [Auto-Announce](#auto-announce), and [Timer Triggers](#timer-triggers).
+- **User-initiated sends are never retried** — a message you type into the send bar goes out once regardless of this setting.
+- It is **one-shot**: the resend is never itself retried, so at most one extra transmission ever occurs per logical send.
+- The resend does **not** create a second message bubble and does **not** re-enter the automation event bus, so it can never trigger a fresh automation.
+
+This is **distinct from the direct-message retry**, which is always on and follows the firmware's own same-path/flood ACK cadence. Because a channel send has no delivery ACK, the retry can only guess from the heard-repeater signal — so with this enabled you may occasionally see a duplicate on the mesh if a late echo arrives right around the 30-second mark. Leave it off if duplicates are unacceptable for your deployment.
+
 ## Room Servers
 
 Room servers (advType=3) are BBS-style MeshCore nodes that store posts and push-sync them to connected clients. The **Rooms** view in the MeshCore page lists discovered room servers and provides:

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -94,7 +94,7 @@ interface SettingsTabProps {
 }
 
 const GLOBAL_SECTIONS = new Set([
-  'settings-language', 'settings-units', 'settings-appearance', 'settings-link-previews', 'settings-map',
+  'settings-language', 'settings-units', 'settings-appearance', 'settings-link-previews', 'settings-meshcore-messaging', 'settings-map',
   'settings-security',
   'settings-apprise-server', 'settings-backup', 'settings-channel-database',
   'settings-maintenance', 'settings-auto-upgrade', 'settings-analytics',
@@ -179,6 +179,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setEnableAudioNotifications,
     linkPreviewsEnabled,
     setLinkPreviewsEnabled,
+    meshcoreChannelRetryEnabled,
+    setMeshcoreChannelRetryEnabled,
     nodeDimmingEnabled,
     setNodeDimmingEnabled,
     nodeDimmingStartHours,
@@ -240,6 +242,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localPacketLogMaxCount, setLocalPacketLogMaxCount] = useState(1000);
   const [localPacketLogMaxAgeHours, setLocalPacketLogMaxAgeHours] = useState(24);
   const [localLinkPreviewsEnabled, setLocalLinkPreviewsEnabled] = useState(linkPreviewsEnabled);
+  const [localMeshcoreChannelRetryEnabled, setLocalMeshcoreChannelRetryEnabled] = useState(meshcoreChannelRetryEnabled);
   const [localSolarMonitoringEnabled, setLocalSolarMonitoringEnabled] = useState(solarMonitoringEnabled);
   const [localSolarMonitoringLatitude, setLocalSolarMonitoringLatitude] = useState(solarMonitoringLatitude);
   const [localSolarMonitoringLongitude, setLocalSolarMonitoringLongitude] = useState(solarMonitoringLongitude);
@@ -337,6 +340,10 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           const linkPreviewsOn = !(settings.linkPreviewsEnabled === '0' || settings.linkPreviewsEnabled === 'false');
           setLocalLinkPreviewsEnabled(linkPreviewsOn);
 
+          // Load MeshCore channel-send auto-retry (#3979). Absent key => disabled.
+          const meshcoreChannelRetryOn = settings.meshcoreChannelRetryEnabled === '1' || settings.meshcoreChannelRetryEnabled === 'true';
+          setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryOn);
+
           // Load LocalStats interval setting
           const statsInterval = parseInt(settings.localStatsIntervalMinutes || '15', 10);
           setLocalLocalStatsIntervalMinutes(statsInterval);
@@ -407,13 +414,14 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalNodeHopsCalculation(nodeHopsCalculation);
     setLocalDashboardSortOption(preferredDashboardSortOption);
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
+    setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryEnabled);
     setLocalSolarMonitoringEnabled(solarMonitoringEnabled);
     setLocalSolarMonitoringLatitude(solarMonitoringLatitude);
     setLocalSolarMonitoringLongitude(solarMonitoringLongitude);
     setLocalSolarMonitoringAzimuth(solarMonitoringAzimuth);
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
-  }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, nodeHopsCalculation, preferredDashboardSortOption, linkPreviewsEnabled, solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme]);
+  }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, nodeHopsCalculation, preferredDashboardSortOption, linkPreviewsEnabled, meshcoreChannelRetryEnabled, solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme]);
 
   // Default solar monitoring lat/long to device position if still at 0
   useEffect(() => {
@@ -475,6 +483,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringAzimuth !== solarMonitoringAzimuth ||
       localSolarMonitoringDeclination !== solarMonitoringDeclination ||
       localLinkPreviewsEnabled !== linkPreviewsEnabled ||
+      localMeshcoreChannelRetryEnabled !== meshcoreChannelRetryEnabled ||
       localHideIncompleteNodes !== !showIncompleteNodes ||
       localHomoglyphEnabled !== initialHomoglyphEnabled ||
       localLocalStatsIntervalMinutes !== initialLocalStatsIntervalMinutes ||
@@ -491,6 +500,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
       localLinkPreviewsEnabled, linkPreviewsEnabled,
+      localMeshcoreChannelRetryEnabled, meshcoreChannelRetryEnabled,
       localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
       localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity, initialNodeDimmingSettings,
@@ -533,6 +543,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringAzimuth(solarMonitoringAzimuth);
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
+    setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryEnabled);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
     setLocalHomoglyphEnabled(initialHomoglyphEnabled);
     setLocalLocalStatsIntervalMinutes(initialLocalStatsIntervalMinutes);
@@ -548,7 +559,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
-      linkPreviewsEnabled,
+      linkPreviewsEnabled, meshcoreChannelRetryEnabled,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl]);
@@ -601,6 +612,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringAzimuth: localSolarMonitoringAzimuth.toString(),
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
         linkPreviewsEnabled: localLinkPreviewsEnabled ? '1' : '0',
+        meshcoreChannelRetryEnabled: localMeshcoreChannelRetryEnabled ? '1' : '0',
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
         homoglyphEnabled: String(localHomoglyphEnabled),
         localStatsIntervalMinutes: localLocalStatsIntervalMinutes.toString(),
@@ -653,6 +665,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringAzimuthChange(localSolarMonitoringAzimuth);
       onSolarMonitoringDeclinationChange(localSolarMonitoringDeclination);
       setLinkPreviewsEnabled(localLinkPreviewsEnabled);
+      setMeshcoreChannelRetryEnabled(localMeshcoreChannelRetryEnabled);
       setShowIncompleteNodes(!localHideIncompleteNodes);
 
       // Update initial packet monitor settings after successful save
@@ -683,7 +696,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, getLocalEffectiveTheme,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
-      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes,
+      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localMeshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes,
       onMaxNodeAgeChange, onInactiveNodeThresholdHoursChange, onInactiveNodeCheckIntervalMinutesChange,
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
@@ -824,6 +837,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       setLocalSolarMonitoringAzimuth(0);
       setLocalSolarMonitoringDeclination(30);
       setLocalLinkPreviewsEnabled(true);
+      setLocalMeshcoreChannelRetryEnabled(false);
 
       // Update parent component with defaults
       onMaxNodeAgeChange(24);
@@ -849,6 +863,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringAzimuthChange(0);
       onSolarMonitoringDeclinationChange(30);
       setLinkPreviewsEnabled(true);
+      setMeshcoreChannelRetryEnabled(false);
 
       // Update initial packet monitor settings
       setInitialPacketMonitorSettings({ enabled: false, maxCount: 1000, maxAgeHours: 24 });
@@ -1076,6 +1091,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         { id: 'settings-sorting', label: t('settings.sorting') },
         { id: 'settings-appearance', label: t('settings.appearance') },
         { id: 'settings-link-previews', label: t('settings.link_previews', 'Link Previews') },
+        { id: 'settings-meshcore-messaging', label: t('settings.meshcore_messaging', 'MeshCore Messaging') },
         { id: 'settings-map', label: t('settings.map') },
         { id: 'settings-node-display', label: t('settings.node_display') },
         { id: 'settings-telemetry', label: t('settings.telemetry') },
@@ -1375,6 +1391,23 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           </h3>
           <p className="setting-description">
             {t('settings.link_previews_description', 'When enabled, MeshMonitor fetches and displays a preview card (title, description, image) for the first URL in a message. The fetch is performed server-side. Disable this to stop all outbound requests to link targets — URLs still render as clickable text.')}
+          </p>
+        </div>}
+
+        {show('settings-meshcore-messaging') && <div id="settings-meshcore-messaging" className="settings-section">
+          <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={localMeshcoreChannelRetryEnabled}
+                onChange={(e) => setLocalMeshcoreChannelRetryEnabled(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>{t('settings.meshcore_channel_retry_enabled', 'Auto-retry automated MeshCore channel sends')}</span>
+            </label>
+          </h3>
+          <p className="setting-description">
+            {t('settings.meshcore_channel_retry_description', 'When enabled, an AUTOMATED MeshCore channel/broadcast message (Automation Engine, Auto-Acknowledge, auto-responder, auto-announce and timer triggers) that hears no repeaters within 30 seconds is resent exactly once. User-initiated sends are never retried. This is opt-in, channel-only, and one-shot — distinct from the always-on retry for direct messages. You may occasionally see a duplicate on the mesh.')}
           </p>
         </div>}
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -106,6 +106,12 @@ interface SettingsContextType {
   enableAudioNotifications: boolean;
   /** Global toggle: fetch & render OpenGraph link preview cards for URLs in messages. */
   linkPreviewsEnabled: boolean;
+  /**
+   * Global opt-in (issue #3979, default false): auto-retry an AUTOMATED MeshCore
+   * channel send once, 30s later, when zero repeaters were heard. Automated
+   * senders only; never user-initiated sends. Distinct from the DM ack-retry.
+   */
+  meshcoreChannelRetryEnabled: boolean;
   nodeDimmingEnabled: boolean;
   nodeDimmingStartHours: number;
   nodeDimmingMinOpacity: number;
@@ -154,6 +160,7 @@ interface SettingsContextType {
   setSolarMonitoringDeclination: (declination: number) => void;
   setEnableAudioNotifications: (enabled: boolean) => void;
   setLinkPreviewsEnabled: (enabled: boolean) => void;
+  setMeshcoreChannelRetryEnabled: (enabled: boolean) => void;
   mutedChannels: MutedChannel[];
   mutedDMs: MutedDM[];
   muteChannel: (channelId: number, muteUntil: number | null) => Promise<void>;
@@ -417,6 +424,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   // Link preview setting - server-backed (global). Defaults to true to preserve
   // the previous always-on behavior; loaded from the server in loadServerSettings.
   const [linkPreviewsEnabled, setLinkPreviewsEnabledState] = useState<boolean>(true);
+
+  // MeshCore automated-channel-send auto-retry (issue #3979) - server-backed
+  // (global). Defaults to false (opt-in); loaded from the server in
+  // loadServerSettings.
+  const [meshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabledState] = useState<boolean>(false);
 
   // Node dimming settings - localStorage only
   const [nodeDimmingEnabled, setNodeDimmingEnabledState] = useState<boolean>(() => {
@@ -820,6 +832,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   // Link preview setter updates state only - value is persisted server-side
   const setLinkPreviewsEnabled = (enabled: boolean) => {
     setLinkPreviewsEnabledState(enabled);
+  };
+
+  // MeshCore channel-retry setter updates state only - persisted server-side
+  const setMeshcoreChannelRetryEnabled = (enabled: boolean) => {
+    setMeshcoreChannelRetryEnabledState(enabled);
   };
 
   // Solar monitoring setters update state only - values are persisted server-side
@@ -1328,6 +1345,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             setLinkPreviewsEnabledState(enabled);
           }
 
+          // MeshCore channel-send auto-retry (#3979) - database-only. Absent key
+          // means default (disabled); only an explicit '1'/'true' turns it on.
+          if (settings.meshcoreChannelRetryEnabled !== undefined) {
+            const enabled = settings.meshcoreChannelRetryEnabled === '1' || settings.meshcoreChannelRetryEnabled === 'true';
+            setMeshcoreChannelRetryEnabledState(enabled);
+          }
+
           // Solar monitoring settings - database-only, no localStorage persistence
           if (settings.solarMonitoringEnabled !== undefined) {
             const enabled = settings.solarMonitoringEnabled === '1' || settings.solarMonitoringEnabled === 'true';
@@ -1533,6 +1557,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     customTilesets,
     isLoadingThemes,
     linkPreviewsEnabled,
+    meshcoreChannelRetryEnabled,
     solarMonitoringEnabled,
     solarMonitoringLatitude,
     solarMonitoringLongitude,
@@ -1581,6 +1606,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     updateCustomTileset,
     deleteCustomTileset,
     setLinkPreviewsEnabled,
+    setMeshcoreChannelRetryEnabled,
     setSolarMonitoringEnabled,
     setSolarMonitoringLatitude,
     setSolarMonitoringLongitude,

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -160,6 +160,12 @@ export const VALID_SETTINGS_KEYS = [
   // Global privacy toggle (issue #3416): when '0'/'false', the /api/link-preview
   // endpoint refuses to fetch external URLs and the UI renders no preview cards.
   'linkPreviewsEnabled',
+  // Global opt-in (issue #3979, default OFF): when enabled, an AUTOMATED MeshCore
+  // channel/broadcast send that hears ZERO repeaters within 30s is resent exactly
+  // once. Applies only to automated senders (Automation Engine action.sendMessage,
+  // Auto-Acknowledge, auto-responder, auto-announce, timer triggers) — never to
+  // user-initiated sends. Distinct from the always-on DM ack-retry (#3977/#3980).
+  'meshcoreChannelRetryEnabled',
   'localStatsIntervalMinutes',
   'nodeHopsCalculation',
   'nodeDimmingEnabled',

--- a/src/server/meshcoreManager.channelRetry.test.ts
+++ b/src/server/meshcoreManager.channelRetry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for MeshCore AUTOMATED channel-send auto-retry on a zero-heard miss
+ * (#3979 Part 2). Builds on the Part 1 echo-attribution (#3987): a channel /
+ * broadcast send is an unacked fire-and-forget flood, so we can't tell delivery
+ * from a firmware ACK. Instead, if NO repeater is heard re-flooding our packet
+ * within CHANNEL_RETRY_WINDOW_MS (30s), the send likely reached no one, so we
+ * resend it exactly ONCE.
+ *
+ * The feature is:
+ *  - opt-in via the global `meshcoreChannelRetryEnabled` setting (default off);
+ *  - armed ONLY for automated senders (which pass `autoRetryOnMiss=true`) — a
+ *    user-initiated send never arms it;
+ *  - one-shot — the resend never re-arms, so at most ONE retry ever fires;
+ *  - self-loop-safe — the resend goes out with `isAutoRetry=true`, so it emits
+ *    no `message` event and never re-enters the data bus (can't spawn a fresh
+ *    automation trigger);
+ *  - DISTINCT from and non-colliding with the DM ack-retry (#3977/#3980): the
+ *    channel path keys on the echo-heard signal, the DM path on the firmware ACK.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+import { dataEventEmitter } from './services/dataEventEmitter.js';
+
+interface BridgeCall { cmd: string; params: Record<string, unknown>; }
+
+function makeManager(opts: {
+  /** whether the global opt-in setting is on (default true for these tests) */
+  retryEnabled?: boolean;
+  /** heard-repeater set returned at the 30s mark (default [] = zero heard) */
+  heardRepeaters?: Array<{ repeaterHash: string }>;
+} = {}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[]; heardFn: ReturnType<typeof vi.fn> } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'send_message') {
+      // Channel/broadcast sends (no `to`) are unacked — no ackCrc/estTimeout.
+      if (!params.to) return { id: '1', success: true, data: {} };
+      return { id: '1', success: true, data: { expectedAckCrc: 111, estTimeout: 8000 } };
+    }
+    return { id: '1', success: true, data: {} };
+  };
+
+  vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
+    getChannelById: vi.fn(async () => null),
+  } as any);
+
+  vi.spyOn(databaseService, 'settings', 'get').mockReturnValue({
+    getSettingForSource: vi.fn(async () => null),
+    setSourceSetting: vi.fn(async () => {}),
+    getSettingAsBoolean: vi.fn(async (_key: string, def: boolean) => opts.retryEnabled ?? def ?? false),
+  } as any);
+
+  const heardFn = vi.fn(async () => opts.heardRepeaters ?? []);
+  // Leave the rest of the meshcore repo real (insertMessage fails gracefully via
+  // its own .catch when no DB is wired); only stub the heard-count read.
+  vi.spyOn(databaseService.meshcore, 'getHeardRepeatersForMessage').mockImplementation(heardFn as any);
+
+  return { manager: m, bridgeCalls, heardFn };
+}
+
+const sends = (calls: BridgeCall[]) => calls.filter(c => c.cmd === 'send_message');
+
+describe('MeshCoreManager — automated channel-send auto-retry (#3979 Part 2)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('(a) zero repeaters heard within 30s → exactly ONE resend fires', async () => {
+    const { manager, bridgeCalls } = makeManager({ retryEnabled: true, heardRepeaters: [] });
+
+    // autoRetryOnMiss=true simulates an automated sender.
+    await manager.sendMessage('hi', undefined, 0, undefined, true);
+    expect(sends(bridgeCalls)).toHaveLength(1);
+    expect((manager as any).pendingChannelRetries.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(sends(bridgeCalls)).toHaveLength(2);
+    // The resend went out on the same channel (no `to`).
+    expect(sends(bridgeCalls)[1].params.to).toBeFalsy();
+    expect(sends(bridgeCalls)[1].params.channel_idx).toBe(0);
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+  });
+
+  it('(b) at least one repeater heard within 30s → NO resend', async () => {
+    const { manager, bridgeCalls } = makeManager({
+      retryEnabled: true,
+      heardRepeaters: [{ repeaterHash: 'ab' }],
+    });
+
+    await manager.sendMessage('hi', undefined, 0, undefined, true);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(sends(bridgeCalls)).toHaveLength(1);
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+  });
+
+  it('(c) the resend emits NO message event (cannot re-enter the automation bus)', async () => {
+    const { manager, bridgeCalls } = makeManager({ retryEnabled: true, heardRepeaters: [] });
+    const busEmit = vi.spyOn(dataEventEmitter, 'emitMeshCoreMessage');
+    const localEmit = vi.spyOn(manager, 'emit');
+
+    await manager.sendMessage('hi', undefined, 0, undefined, true);
+    // Initial send emits exactly once onto the bus + the local emitter.
+    expect(busEmit).toHaveBeenCalledTimes(1);
+    const localMessageEmitsAfterInitial = localEmit.mock.calls.filter(c => c[0] === 'message').length;
+    expect(localMessageEmitsAfterInitial).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // The resend fired on the wire...
+    expect(sends(bridgeCalls)).toHaveLength(2);
+    // ...but did NOT re-emit onto the data bus (no second automation trigger)...
+    expect(busEmit).toHaveBeenCalledTimes(1);
+    // ...nor onto the local emitter, and created no second message row.
+    const localMessageEmits = localEmit.mock.calls.filter(c => c[0] === 'message').length;
+    expect(localMessageEmits).toBe(1);
+    expect((manager as any).messages).toHaveLength(1);
+  });
+
+  it('(d) only ONE retry ever — a resend that also hears zero repeaters does not retry again', async () => {
+    const { manager, bridgeCalls } = makeManager({ retryEnabled: true, heardRepeaters: [] });
+
+    await manager.sendMessage('hi', undefined, 0, undefined, true);
+    await vi.advanceTimersByTimeAsync(30_000); // resend #1
+    expect(sends(bridgeCalls)).toHaveLength(2);
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+
+    // Even though the resend also heard zero repeaters, no further retry is armed.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(sends(bridgeCalls)).toHaveLength(2);
+  });
+
+  it('(e) a user-initiated send never arms a retry (autoRetryOnMiss defaults false)', async () => {
+    const { manager, bridgeCalls } = makeManager({ retryEnabled: true, heardRepeaters: [] });
+
+    // No 5th arg → user-initiated path (as meshcoreRoutes.ts calls it).
+    await manager.sendMessage('hi', undefined, 0);
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(sends(bridgeCalls)).toHaveLength(1);
+  });
+
+  it('(f) setting OFF → an automated send never arms a retry', async () => {
+    const { manager, bridgeCalls } = makeManager({ retryEnabled: false, heardRepeaters: [] });
+
+    await manager.sendMessage('hi', undefined, 0, undefined, true);
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(sends(bridgeCalls)).toHaveLength(1);
+  });
+
+  it('(g) disconnect mid-window clears the pending retry so a torn-down manager cannot resend', async () => {
+    const { manager, bridgeCalls } = makeManager({ retryEnabled: true, heardRepeaters: [] });
+    vi.spyOn(manager as any, 'stopVirtualNodeServer').mockResolvedValue(undefined);
+
+    await manager.sendMessage('hi', undefined, 0, undefined, true);
+    await vi.advanceTimersByTimeAsync(10_000); // mid-window
+    expect((manager as any).pendingChannelRetries.size).toBe(1);
+
+    await manager.disconnect();
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+
+    const callsBefore = bridgeCalls.length;
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(bridgeCalls.length).toBe(callsBefore);
+  });
+
+  it('does not arm a channel retry for a DM send (mutually exclusive with the DM machine)', async () => {
+    const { manager } = makeManager({ retryEnabled: true, heardRepeaters: [] });
+    const PUBKEY = 'bob'.padEnd(64, '0');
+    (manager as any).contacts = new Map([[PUBKEY, { publicKey: PUBKEY, advName: 'Bob' }]]);
+
+    // A DM send with the automated flag set: the channel machine must not arm
+    // (no channelIdx / toPublicKey present); the DM ack-retry machine handles it.
+    await manager.sendMessage('hi', PUBKEY, undefined, undefined, true);
+
+    expect((manager as any).pendingChannelRetries.size).toBe(0);
+    expect((manager as any).pendingDmRetries.size).toBe(1);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -698,8 +698,47 @@ class MeshCoreManager extends EventEmitter {
     }
   > = new Map();
 
+  /**
+   * In-flight AUTOMATED channel sends awaiting a heard-repeater signal (#3979,
+   * Part 2). Keyed by the outgoing message id. A channel/broadcast send is an
+   * unacked fire-and-forget flood, so we can't tell delivery from a firmware
+   * ACK; instead we lean on the Part 1 echo-attribution (#3987): if NO repeater
+   * has been heard re-flooding our packet within {@link CHANNEL_RETRY_WINDOW_MS},
+   * the message likely reached no one, so we resend it exactly ONCE.
+   *
+   * This machine is armed ONLY for automated senders (Automation Engine
+   * `action.sendMessage`, Auto-Acknowledge, auto-responder, auto-announce, timer
+   * triggers) that pass `autoRetryOnMiss=true` AND only when the global
+   * {@link meshcoreChannelRetryEnabled} opt-in setting is on. User-initiated
+   * sends never arm it. It is DISTINCT from and non-colliding with the DM
+   * ack-retry ({@link pendingDmRetries}): the DM path has `toPublicKey` set and
+   * keys on the firmware ACK CRC; the channel path has `channelIdx` set (no
+   * `toPublicKey`) and keys on the echo-heard signal — mutually exclusive
+   * branches of {@link performScopedSend}. Cleared in bulk on disconnect.
+   */
+  private pendingChannelRetries: Map<
+    string,
+    {
+      text: string;
+      channelIdx: number;
+      scopeOverride: string | null | undefined;
+      /** Remaining resends. Starts at 1 (one-shot); the resend itself never re-arms. */
+      retriesLeft: number;
+      timer: NodeJS.Timeout;
+    }
+  > = new Map();
+
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
+
+  /**
+   * How long after an automated channel send we wait for a heard-repeater
+   * signal before treating the send as a likely miss and resending once
+   * (#3979). Matches {@link HEARD_WINDOW_MS} — the echo-attribution window —
+   * so the heard-repeater set is fully populated for genuine echoes by the
+   * time the timer reads it.
+   */
+  private static readonly CHANNEL_RETRY_WINDOW_MS = 30_000;
 
   /**
    * MeshCore GRP_TXT (channel/broadcast text) payload type (0x05). Inbound OTA
@@ -1097,6 +1136,13 @@ class MeshCoreManager extends EventEmitter {
       clearTimeout(retry.timer);
     }
     this.pendingDmRetries.clear();
+
+    // Clear pending channel-send auto-retry timers (#3979) — a torn-down
+    // connection can't resend, so don't let a stray timer try.
+    for (const [, retry] of this.pendingChannelRetries) {
+      clearTimeout(retry.timer);
+    }
+    this.pendingChannelRetries.clear();
 
     this.connected = false;
     this.connectionState = 'disconnected';
@@ -2560,8 +2606,8 @@ class MeshCoreManager extends EventEmitter {
    * channel 1" from "I sent this to channel 0" — both used to be indistinguishable
    * when only channel 0 was supported (issue follow-up to MeshCore channels plan).
    */
-  async sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<boolean> {
-    return (await this.sendMessageWithResult(text, toPublicKey, channelIdx, scopeOverride)).ok;
+  async sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null, autoRetryOnMiss: boolean = false): Promise<boolean> {
+    return (await this.sendMessageWithResult(text, toPublicKey, channelIdx, scopeOverride, autoRetryOnMiss)).ok;
   }
 
   /**
@@ -2571,7 +2617,7 @@ class MeshCoreManager extends EventEmitter {
    * to forward the later `SendConfirmed` push when the DM is acked (#3869).
    * `sendMessage` delegates here and discards the extra fields.
    */
-  async sendMessageWithResult(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<MeshCoreSendResult> {
+  async sendMessageWithResult(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null, autoRetryOnMiss: boolean = false): Promise<MeshCoreSendResult> {
     if (!this.connected) {
       logger.error('[MeshCore] Not connected');
       return { ok: false };
@@ -2586,7 +2632,12 @@ class MeshCoreManager extends EventEmitter {
     // flood scope is a single global setting; two concurrent sends with
     // different scopes must not interleave, or a message could ship under the
     // wrong region.
-    return this.runSerialized(() => this.performScopedSend(text, toPublicKey, channelIdx, scopeOverride));
+    //
+    // `autoRetryOnMiss` (#3979) is a caller opt-in: automated senders pass it so
+    // a zero-heard channel send is resent once. It is inert for DM sends and
+    // when the global opt-in setting is off. This is NOT an auto-retry itself
+    // (isAutoRetry=false) — that flag marks the resend leg only.
+    return this.runSerialized(() => this.performScopedSend(text, toPublicKey, channelIdx, scopeOverride, false, autoRetryOnMiss));
   }
 
   /**
@@ -2736,6 +2787,7 @@ class MeshCoreManager extends EventEmitter {
     channelIdx?: number,
     scopeOverride?: string | null,
     isAutoRetry: boolean = false,
+    autoRetryOnMiss: boolean = false,
   ): Promise<MeshCoreSendResult> {
     try {
       const isChannelSend = !toPublicKey && channelIdx !== undefined;
@@ -2827,6 +2879,15 @@ class MeshCoreManager extends EventEmitter {
         // a real ACK (send-confirmed).
         if (isChannelSend) {
           this.registerPendingChannelSend(msgId, channelIdx!, text);
+
+          // Arm the automated channel-send auto-retry (#3979 Part 2) when the
+          // caller opted in AND this is not itself a resend. Gated on the global
+          // opt-in setting (default off). A resend (isAutoRetry=true) is
+          // re-registered above for echo correlation but never re-armed, so at
+          // most ONE retry ever fires per logical send.
+          if (autoRetryOnMiss && !isAutoRetry) {
+            await this.maybeArmChannelRetry(msgId, text, channelIdx!, scopeOverride);
+          }
         }
 
         return { ok: true, expectedAckCrc: ackCrc ?? undefined, estTimeout: estTimeout ?? undefined };
@@ -3025,6 +3086,104 @@ class MeshCoreManager extends EventEmitter {
       { id: messageId, previousAckCrc: lastAckCrc, deliveryStatus: 'failed' },
       this.sourceId,
     );
+  }
+
+  /**
+   * Arm the automated channel-send auto-retry timer for a just-sent channel
+   * message (#3979 Part 2), IFF the global opt-in setting is enabled. Reads the
+   * setting here (not at the call site) so the check is co-located with the
+   * arming and stays consistent across all automated senders. One entry per
+   * outgoing message id; a 30s timer that, on fire, resends once only when zero
+   * repeaters were heard.
+   */
+  private async maybeArmChannelRetry(
+    messageId: string,
+    text: string,
+    channelIdx: number,
+    scopeOverride: string | null | undefined,
+  ): Promise<void> {
+    let enabled: boolean;
+    try {
+      enabled = await databaseService.settings.getSettingAsBoolean('meshcoreChannelRetryEnabled', false);
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] channel-retry setting read failed: ${(err as Error).message}`);
+      return;
+    }
+    if (!enabled) return;
+
+    const existing = this.pendingChannelRetries.get(messageId);
+    if (existing) clearTimeout(existing.timer);
+    const timer = setTimeout(() => {
+      void this.handleChannelRetryTimeout(messageId);
+    }, MeshCoreManager.CHANNEL_RETRY_WINDOW_MS);
+    this.pendingChannelRetries.set(messageId, {
+      text,
+      channelIdx,
+      scopeOverride,
+      retriesLeft: 1,
+      timer,
+    });
+  }
+
+  /**
+   * The channel-send retry window elapsed (#3979 Part 2). If NO repeater was
+   * heard re-flooding this message (per the Part 1 echo-attribution, #3987),
+   * the send likely reached no one, so resend it exactly ONCE. The resend goes
+   * through `performScopedSend` with `isAutoRetry=true` (no new message row / no
+   * `message` event / no re-entry onto the data bus, so it can't spawn a fresh
+   * automation trigger) and `autoRetryOnMiss=false` (so it re-registers for echo
+   * correlation but never arms a second retry — one-shot). Runs inside
+   * `runSerialized` so the scope-assert→send pair can't interleave with a
+   * concurrent send (#3667).
+   */
+  private async handleChannelRetryTimeout(messageId: string): Promise<void> {
+    const pending = this.pendingChannelRetries.get(messageId);
+    if (!pending) return; // already cleared (disconnect) — nothing to do
+    this.pendingChannelRetries.delete(messageId);
+
+    if (!this.connected) return; // torn-down connection can't resend
+
+    // Point-in-time read of the heard-repeater set for this message. The echo
+    // handler (`correlateChannelEcho`) awaits its DB write before returning, and
+    // the retry window equals the echo-attribution window, so any repeater heard
+    // for a genuine echo is already persisted by now. A repeater heard AFTER
+    // this read (extremely-late echo) at worst yields one accepted duplicate,
+    // which the opt-in explicitly tolerates.
+    let heardCount: number;
+    try {
+      const heard = await databaseService.meshcore.getHeardRepeatersForMessage(messageId, this.sourceId);
+      heardCount = heard.length;
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] channel-retry heard-count read failed: ${(err as Error).message}`);
+      return; // can't confirm a miss → don't risk a needless duplicate
+    }
+
+    if (heardCount > 0) {
+      logger.debug(
+        `[MeshCore:${this.sourceId}] Channel send ${messageId} heard by ${heardCount} repeater(s) within window; no retry`,
+      );
+      return;
+    }
+    if (pending.retriesLeft <= 0) return; // defensive: one-shot already spent
+
+    logger.info(
+      `[MeshCore:${this.sourceId}] Channel send ${messageId} heard ZERO repeaters within ` +
+      `${MeshCoreManager.CHANNEL_RETRY_WINDOW_MS / 1000}s; resending once (auto-retry #3979)`,
+    );
+
+    await this.runSerialized(async () => {
+      if (!this.connected) return;
+      // isAutoRetry=true: no new bubble / no bus re-entry / no automation re-trigger.
+      // autoRetryOnMiss=false: re-register for echo correlation but never re-arm.
+      await this.performScopedSend(
+        pending.text,
+        undefined,
+        pending.channelIdx,
+        pending.scopeOverride,
+        true,
+        false,
+      );
+    });
   }
 
   /**
@@ -5867,7 +6026,8 @@ class MeshCoreManager extends EventEmitter {
     let sent = 0;
     for (const idx of channelIndexes) {
       try {
-        const ok = await this.sendMessage(rendered, undefined, idx, scopeOverride);
+        // Automated sender → opt into channel-send auto-retry (#3979).
+        const ok = await this.sendMessage(rendered, undefined, idx, scopeOverride, true);
         if (ok) sent += 1;
       } catch (err) {
         logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: send to channel ${idx} threw: ${(err as Error).message}`);
@@ -6010,7 +6170,8 @@ class MeshCoreManager extends EventEmitter {
         return this.sendMessage(text, trigger.contactPublicKey, undefined, scopeOverride);
       }
       if (typeof trigger.channelIndex === 'number') {
-        return this.sendMessage(text, undefined, trigger.channelIndex, scopeOverride);
+        // Automated sender → opt into channel-send auto-retry (#3979).
+        return this.sendMessage(text, undefined, trigger.channelIndex, scopeOverride, true);
       }
       return false;
     };
@@ -6280,7 +6441,8 @@ class MeshCoreManager extends EventEmitter {
             return this.sendMessage(text, targetKey, undefined, scopeOverride);
           }
           if (typeof channelIdx === 'number') {
-            return this.sendMessage(text, undefined, channelIdx, scopeOverride);
+            // Automated sender → opt into channel-send auto-retry (#3979).
+            return this.sendMessage(text, undefined, channelIdx, scopeOverride, true);
           }
           return false;
         };
@@ -6568,7 +6730,8 @@ class MeshCoreManager extends EventEmitter {
         await this.sendMessage(replyText, contact.publicKey, undefined, scopeOverride);
       } else {
         logger.info(`[MeshCore:${sourceId}] Auto-ack channel ${channelIdx} → "${replyText}"`);
-        await this.sendMessage(replyText, undefined, channelIdx, scopeOverride);
+        // Automated sender → opt into channel-send auto-retry (#3979).
+        await this.sendMessage(replyText, undefined, channelIdx, scopeOverride, true);
       }
     } catch (err) {
       logger.error(`[MeshCore:${this.sourceId}] Auto-ack handler threw: ${(err as Error).message}`);

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -28,8 +28,10 @@ describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
 
     await deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 2, scopeOverride: 'paris' });
 
-    // raw.sendMessage(text, toPublicKey=undefined, channelIdx, scopeOverride)
-    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 2, 'paris');
+    // raw.sendMessage(text, toPublicKey=undefined, channelIdx, scopeOverride, autoRetryOnMiss)
+    // The Automation Engine is an automated sender, so it opts into the
+    // channel-send auto-retry (#3979) with the trailing `true`.
+    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 2, 'paris', true);
   });
 
   it('passes an empty-string (unscoped) override through unchanged', async () => {
@@ -39,7 +41,7 @@ describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
 
     await deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 0, scopeOverride: '' });
 
-    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 0, '');
+    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 0, '', true);
   });
 
   it('drops scopeOverride for a Meshtastic manager (no scope concept)', async () => {
@@ -69,7 +71,7 @@ describe('createMeshActionDeps — MeshCore source resolved from meshcoreManager
 
     await deps.sendMessage({ sourceId: 'mc', text: 'PINGTEST received!', channel: 1, scopeOverride: '' });
 
-    expect(sendMessage).toHaveBeenCalledWith('PINGTEST received!', undefined, 1, '');
+    expect(sendMessage).toHaveBeenCalledWith('PINGTEST received!', undefined, 1, '', true);
   });
 
   it('requestData reaches a MeshCore manager that is only in meshcoreManagerRegistry', async () => {

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -34,7 +34,7 @@ interface MeshSendManager {
 
 /** MeshCore companion managers send via a different method signature. */
 interface MeshCoreSendManager {
-  sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<boolean>;
+  sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null, autoRetryOnMiss?: boolean): Promise<boolean>;
   // Request/operation senders (#3835).
   requestRemoteTelemetry(publicKey: string, timeoutSecs?: number): Promise<unknown>;
   traceContactPath(publicKey: string): Promise<unknown>;
@@ -90,7 +90,10 @@ async function sendTextVia(
     // `sendMessage` resolves `false` (not throw) when the node is disconnected
     // or the send fails — surface that as a thrown error so the run-log records
     // a failed step instead of a silent success.
-    const ok = await raw.sendMessage(text, undefined, channel, scopeOverride);
+    // Automation Engine action.sendMessage is an AUTOMATED sender → opt into the
+    // channel-send auto-retry (#3979). Inert unless the global opt-in setting is
+    // on; user-initiated sends go through the route, not here.
+    const ok = await raw.sendMessage(text, undefined, channel, scopeOverride, true);
     if (ok === false) {
       throw new Error(`source "${sourceId}" failed to send the MeshCore message (node not connected or send rejected)`);
     }


### PR DESCRIPTION
## Summary

Part 2 (final) of #3979 — an **opt-in, one-shot auto-retry** for **automated** MeshCore channel/broadcast sends when **zero repeaters** were heard within 30s. Builds directly on the now-merged **Part 1 (PR #3987)**, which made the "heard repeaters" echo-attribution signal trustworthy.

A MeshCore channel send is an unacked, fire-and-forget flood — there is no firmware ACK. When Part 1's echo signal reports that no repeater re-flooded our packet within 30s, the message likely reached no one, so we resend it exactly once.

## Behavior

- **New global setting** `meshcoreChannelRetryEnabled`, **default OFF**. Toggle lives in a new **MeshCore Messaging** section of global **Settings** (`SettingsTab`).
- Applies to **automated senders only**: Automation Engine `action.sendMessage`, Auto-Acknowledge, auto-responder, auto-announce, and timer triggers. Threaded via a new `autoRetryOnMiss` opt-in flag.
- **User-initiated sends never retry** — the `meshcoreRoutes.ts` send route does not opt in.
- **One-shot**: the resend is `isAutoRetry=true` (no new bubble, no `message`/data-bus emit — so it can't trigger a fresh automation) and `autoRetryOnMiss=false` (re-registered for echo correlation but never re-armed).
- Pending retries cleared in the `disconnect()` bulk cleanup.

## Non-collision with the DM retry (#3977/#3980)

The DM ack-retry keys on the firmware ACK CRC (`toPublicKey` set); the channel retry keys on the echo-heard signal (`channelIdx` set). They are mutually exclusive branches of `performScopedSend` — a test asserts a DM send arms only `pendingDmRetries` and a channel send arms only `pendingChannelRetries`.

## Heard-count read race

The 30s retry window equals the echo-attribution window (`HEARD_WINDOW_MS`), and `correlateChannelEcho` awaits its DB write before returning, so any repeater heard for a genuine echo is persisted before the timer reads it. A repeater heard *after* the read (extremely-late echo) yields at most one accepted duplicate — which the opt-in explicitly tolerates. A failed heard-count read aborts the retry (no needless duplicate).

## Tests

New `src/server/meshcoreManager.channelRetry.test.ts` (8 tests, fake timers): zero-heard → one resend; heard → no resend; resend emits no message event / no bus re-entry; one-shot; user send never arms; setting-off never arms; disconnect clears; DM/channel non-collision. Full suite green (8181 passed, 0 failed); tsc clean.

## Docs

`docs/features/meshcore.md` (new "Automated Channel-Send Auto-Retry" section) and a note in `docs/features/automation-engine.md` — opt-in, channel-only, one-shot, distinct from the DM retry.

Closes #3979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub