### PR TITLE
feat(meshcore-vn): relay GetNeighbours via SendBinaryReq(50) to the physical node (#3904)

### DIFF
--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -96,6 +96,17 @@ export const PushCodes = {
   LogRxData: 0x88,
   TraceData: 0x89,
   TelemetryResponse: 0x8b,
+  BinaryResponse: 0x8c,
+} as const;
+
+/**
+ * Inner sub-type of a SendBinaryReq(50) generic binary request (mirrors
+ * meshcore.js `Constants.BinaryRequestTypes`, which mirror the firmware
+ * `REQ_TYPE_*` defines). `req_data[0]` selects the request.
+ */
+export const BinaryRequestTypes = {
+  GetTelemetryData: 0x03, // REQ_TYPE_GET_TELEMETRY_DATA
+  GetNeighbours: 0x06, // REQ_TYPE_GET_NEIGHBOURS
 } as const;
 
 /** Error codes carried by an Err(1) response. */
@@ -244,6 +255,29 @@ export interface SendLoginCmd { publicKey: string; password: string; }
 export interface SendTracePathCmd { tag: number; auth: number; flags: number; path: Buffer; }
 export interface SendTelemetryReqCmd { publicKey: string; }
 export interface SendStatusReqCmd { publicKey: string; }
+/**
+ * A decoded SendBinaryReq(50): the target public key plus the inner request
+ * blob. `reqType` is `reqData[0]` (a `BinaryRequestTypes` value); the caller
+ * dispatches on it and re-parses `reqData` with the matching sub-parser.
+ */
+export interface SendBinaryReqCmd { publicKey: string; reqType: number; reqData: Buffer; }
+/** Parsed GetNeighbours(0x06) request parameters (inner sub-type of SendBinaryReq). */
+export interface GetNeighboursReq {
+  count: number;
+  offset: number;
+  orderBy: number;
+  pubkeyPrefixLen: number;
+  /** The app's random blob (`req_data[7..10]`); echoed back as the correlation tag. */
+  tag: number;
+}
+/** One neighbour entry for the GetNeighbours response payload. */
+export interface NeighbourEntry {
+  /** Public-key prefix as a lowercase hex string (may be longer than requested). */
+  publicKeyPrefix: string;
+  heardSecondsAgo: number;
+  /** SNR in dB (already /4, as MeshCoreManager returns it). */
+  snr: number;
+}
 export interface SetRadioParamsCmd { freq: number; bw: number; sf: number; cr: number; }
 export interface SetTxPowerCmd { power: number; }
 export interface SetAdvertLatLonCmd { lat: number; lon: number; }
@@ -318,6 +352,44 @@ export function parseSendTelemetryReq(payload: Buffer): SendTelemetryReqCmd {
 export function parseSendStatusReq(payload: Buffer): SendStatusReqCmd {
   if (payload.length < 1 + 32) throw new Error('SendStatusReq: short payload');
   return { publicKey: payload.subarray(1, 33).toString('hex') };
+}
+
+/**
+ * SendBinaryReq(50): `[code][targetPublicKey:32][reqData…]` (see meshcore.js
+ * `sendCommandSendBinaryReq`). A generic binary-request envelope; the inner
+ * `reqData[0]` byte selects the request (a `BinaryRequestTypes` value). Returns
+ * the target public key (lowercase hex), the sub-type, and the full inner blob
+ * for the matching sub-parser. Requires at least one inner byte so `reqType` is
+ * always defined.
+ */
+export function parseSendBinaryReq(payload: Buffer): SendBinaryReqCmd {
+  if (payload.length < 1 + 32 + 1) throw new Error('SendBinaryReq: short payload');
+  const reqData = Buffer.from(payload.subarray(33));
+  return {
+    publicKey: payload.subarray(1, 33).toString('hex'),
+    reqType: reqData[0],
+    reqData,
+  };
+}
+
+/**
+ * Parse the GetNeighbours(0x06) inner request blob (mirrors meshcore.js
+ * `getNeighbours`):
+ *   `[type:u8][request_version:u8][count:u8][offset:u16LE][order_by:u8]`
+ *   `[pubkey_prefix_len:u8][random_tag:u32LE]` — 11 bytes.
+ * `random_tag` is the app's correlation blob (echoed back as the BinaryResponse
+ * tag). Throws on a short buffer so the dispatcher can reply Err(IllegalArg).
+ */
+export function parseGetNeighboursReq(reqData: Buffer): GetNeighboursReq {
+  if (reqData.length < 1 + 1 + 1 + 2 + 1 + 1 + 4) throw new Error('GetNeighbours: short payload');
+  return {
+    // reqData[0] = type, reqData[1] = request_version (ignored)
+    count: reqData[2],
+    offset: reqData.readUInt16LE(3),
+    orderBy: reqData[5],
+    pubkeyPrefixLen: reqData[6],
+    tag: reqData.readUInt32LE(7),
+  };
 }
 
 /**
@@ -759,6 +831,58 @@ export function encodeStatusResponsePush(
   head[1] = 0; // reserved
   Buffer.from(pubKeyPrefix).copy(head, 2, 0, 6);
   return Buffer.concat([head, encodeRepeaterStatusData(status)]);
+}
+
+/**
+ * Encode a BinaryResponse(0x8C) push — the reply to a SendBinaryReq the app
+ * initiated. Layout mirrors meshcore.js `onBinaryResponsePush`:
+ * `[0x8C][reserved:1][tag:u32LE][responseData:rest]`.
+ *
+ * The client correlates this push to its pending request by comparing `tag` to
+ * the `expectedAckCrc` it received in the preceding Sent(6) response (see
+ * meshcore.js `sendBinaryRequest`), so the caller MUST have echoed this same
+ * `tag` value into that Sent frame.
+ */
+export function encodeBinaryResponsePush(tag: number, responseData: Buffer | Uint8Array): Buffer {
+  const head = Buffer.alloc(1 + 1 + 4);
+  head[0] = PushCodes.BinaryResponse;
+  head[1] = 0; // reserved
+  head.writeUInt32LE(tag >>> 0, 2);
+  return Buffer.concat([head, Buffer.from(responseData)]);
+}
+
+/**
+ * Serialize the GetNeighbours(0x06) response payload (inverse of meshcore.js
+ * `getNeighbours`'s response decode):
+ *   `[totalCount:u16LE][resultsCount:u16LE]` then `resultsCount` ×
+ *   `[prefix:pubkeyPrefixLen][heardSecondsAgo:u32LE][snr:int8]`.
+ *
+ * - `pubkeyPrefixLen` sets the per-entry prefix STRIDE and MUST equal the value
+ *   the app sent in its request (it slices exactly that many bytes back out).
+ *   Each entry's hex prefix is truncated/zero-padded to that length; the manager
+ *   fetches an 8-byte prefix, so requests for a longer prefix are zero-padded.
+ * - `snr` is a dB value; the wire carries `snr×4` (int8), matching how the app
+ *   divides the byte by 4 on decode.
+ */
+export function encodeNeighboursPayload(
+  total: number,
+  neighbours: NeighbourEntry[],
+  pubkeyPrefixLen: number,
+): Buffer {
+  const stride = Math.max(0, pubkeyPrefixLen);
+  const b = Buffer.alloc(2 + 2 + neighbours.length * (stride + 4 + 1));
+  let o = 0;
+  b.writeUInt16LE(total & 0xffff, o); o += 2;
+  b.writeUInt16LE(neighbours.length & 0xffff, o); o += 2;
+  for (const n of neighbours) {
+    const prefixBytes = pubKeyHexToBytes(n.publicKeyPrefix); // hex → bytes (zero-fills short/undefined)
+    const prefix = Buffer.alloc(stride); // zero-padded to the requested stride
+    prefixBytes.copy(prefix, 0, 0, Math.min(stride, prefixBytes.length));
+    prefix.copy(b, o); o += stride;
+    b.writeUInt32LE((n.heardSecondsAgo ?? 0) >>> 0, o); o += 4;
+    b.writeInt8(clampInt8(Math.round((n.snr ?? 0) * 4)), o); o += 1;
+  }
+  return b;
 }
 
 /**

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -8,6 +8,7 @@ import {
   ResponseCodes,
   ErrorCodes,
   PushCodes,
+  BinaryRequestTypes,
   FRAME_APP_TO_NODE,
   FRAME_NODE_TO_APP,
   SUPPORTED_COMPANION_PROTOCOL_VERSION,
@@ -129,6 +130,19 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   }
   requestNodeStatus(publicKey: string) {
     return this.requestNodeStatusMock(publicKey) as Promise<Record<string, number> | null>;
+  }
+  getNeighboursMock = vi.fn().mockResolvedValue({
+    total: 3,
+    neighbours: [
+      { publicKeyPrefix: 'aabbccddeeff0011', heardSecondsAgo: 42, snr: 5.25 },
+      { publicKeyPrefix: '1122334455667788', heardSecondsAgo: 3600, snr: -2.5 },
+    ],
+  });
+  getNeighbours(publicKey: string, opts?: { count?: number; offset?: number; orderBy?: number }) {
+    return this.getNeighboursMock(publicKey, opts) as Promise<{
+      total: number;
+      neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+    } | null>;
   }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
@@ -1007,5 +1021,170 @@ describe('MeshCoreVirtualNodeServer — SendStatusReq relay (#3904)', () => {
     expect(res[0]).toBe(ResponseCodes.Err);
     expect(res[1]).toBe(ErrorCodes.IllegalArg);
     expect(manager.requestNodeStatusMock).not.toHaveBeenCalled();
+  });
+});
+
+// SendBinaryReq(50)/GetNeighbours(0x06): reply Sent (with the request's
+// random_tag echoed as expectedAckCrc), then push BinaryResponse(0x8C) carrying
+// the re-serialized neighbour list correlated by the same tag (#3904 final gap).
+// The neighbours protocol is SendBinaryReq(50)/GetNeighbours(0x06), NOT
+// SendRawData(25) as the issue originally inferred.
+describe('MeshCoreVirtualNodeServer — SendBinaryReq/GetNeighbours relay (#3904)', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let client: TestClient;
+  let manager: FakeManager;
+
+  const REMOTE_KEY = 'e5'.repeat(32);
+  const REMOTE_KEY_BYTES = Buffer.from(REMOTE_KEY, 'hex');
+  const TAG = 0x11223344;
+
+  async function startWith(allowAdminCommands: boolean): Promise<void> {
+    manager = new FakeManager();
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, allowAdminCommands, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+  }
+  afterEach(async () => { client?.close(); await server?.stop(); });
+
+  // [50][pubkey:32][0x06][version:0][count][offset:u16LE][orderBy][prefixLen][tag:u32LE]
+  function neighboursFrame(
+    publicKeyHex: string,
+    opts: { count?: number; offset?: number; orderBy?: number; prefixLen?: number; tag?: number } = {},
+  ): number[] {
+    const { count = 10, offset = 0, orderBy = 0, prefixLen = 8, tag = TAG } = opts;
+    const req = Buffer.alloc(11);
+    req[0] = BinaryRequestTypes.GetNeighbours;
+    req[1] = 0; // request_version
+    req[2] = count;
+    req.writeUInt16LE(offset, 3);
+    req[5] = orderBy;
+    req[6] = prefixLen;
+    req.writeUInt32LE(tag >>> 0, 7);
+    return [CommandCodes.SendBinaryReq, ...Buffer.from(publicKeyHex, 'hex'), ...req];
+  }
+
+  it('replies Sent (tag echoed) then pushes a tag-correlated BinaryResponse with the neighbour list', async () => {
+    await startWith(false); // ungated
+    const frames = client.expectFrames(2);
+    client.send(neighboursFrame(REMOTE_KEY, { count: 5, offset: 2, orderBy: 1, prefixLen: 8 }));
+    const [sent, push] = await frames;
+
+    // Sent(6): [code][result:i8][expectedAckCrc:u32LE][estTimeout:u32LE]
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(sent.readUInt32LE(2)).toBe(TAG); // expectedAckCrc echoes the request tag
+
+    // BinaryResponse(0x8C): [code][reserved:1][tag:u32LE][total:u16LE][count:u16LE][entries…]
+    expect(push[0]).toBe(PushCodes.BinaryResponse);
+    expect(push[1]).toBe(0); // reserved
+    expect(push.readUInt32LE(2)).toBe(TAG); // tag correlates to the Sent's expectedAckCrc
+    const body = push.subarray(6);
+    expect(body.readUInt16LE(0)).toBe(3); // totalCount (from manager.total)
+    expect(body.readUInt16LE(2)).toBe(2); // resultsCount (neighbours.length)
+
+    // stride = prefixLen(8) + heard(4) + snr(1) = 13 bytes per entry
+    const e0 = body.subarray(4, 4 + 13);
+    expect(e0.subarray(0, 8)).toEqual(Buffer.from('aabbccddeeff0011', 'hex'));
+    expect(e0.readUInt32LE(8)).toBe(42); // heardSecondsAgo
+    expect(e0.readInt8(12)).toBe(21); // snr 5.25 dB → round(5.25*4)=21
+
+    const e1 = body.subarray(4 + 13, 4 + 26);
+    expect(e1.subarray(0, 8)).toEqual(Buffer.from('1122334455667788', 'hex'));
+    expect(e1.readUInt32LE(8)).toBe(3600);
+    expect(e1.readInt8(12)).toBe(-10); // snr -2.5 dB → round(-2.5*4)=-10
+
+    expect(push.length).toBe(6 + 4 + 2 * 13);
+    expect(manager.getNeighboursMock).toHaveBeenCalledWith(REMOTE_KEY, { count: 5, offset: 2, orderBy: 1 });
+  });
+
+  it('respects the requested pubkey_prefix_len for the entry stride', async () => {
+    await startWith(false);
+    const frames = client.expectFrames(2);
+    client.send(neighboursFrame(REMOTE_KEY, { prefixLen: 6 }));
+    const [, push] = await frames;
+    const body = push.subarray(6);
+    expect(body.readUInt16LE(2)).toBe(2); // 2 entries
+    // stride now 6 + 4 + 1 = 11 bytes/entry
+    expect(push.length).toBe(6 + 4 + 2 * 11);
+    const e0 = body.subarray(4, 4 + 11);
+    expect(e0.subarray(0, 6)).toEqual(Buffer.from('aabbccddeeff', 'hex')); // first 6 prefix bytes
+    expect(e0.readUInt32LE(6)).toBe(42);
+    expect(e0.readInt8(10)).toBe(21);
+  });
+
+  it('relays neighbours even when allowAdminCommands is off (read-only follow-up to login)', async () => {
+    await startWith(true);
+    const frames = client.expectFrames(2);
+    client.send(neighboursFrame(REMOTE_KEY));
+    const [sent, push] = await frames;
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(push[0]).toBe(PushCodes.BinaryResponse);
+  });
+
+  it('pushes an empty BinaryResponse (total=0/count=0) when there are no neighbours', async () => {
+    await startWith(false);
+    manager.getNeighboursMock.mockResolvedValueOnce({ total: 0, neighbours: [] });
+    const frames = client.expectFrames(2);
+    client.send(neighboursFrame(REMOTE_KEY));
+    const [sent, push] = await frames;
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(push[0]).toBe(PushCodes.BinaryResponse);
+    expect(push.readUInt32LE(2)).toBe(TAG);
+    const body = push.subarray(6);
+    expect(body.readUInt16LE(0)).toBe(0); // total
+    expect(body.readUInt16LE(2)).toBe(0); // count
+    expect(push.length).toBe(6 + 4); // header + [total][count] only
+  });
+
+  it('pushes an empty BinaryResponse when the manager returns null (non-repeater / disconnected)', async () => {
+    await startWith(false);
+    manager.getNeighboursMock.mockResolvedValueOnce(null);
+    const frames = client.expectFrames(2);
+    client.send(neighboursFrame(REMOTE_KEY));
+    const [sent, push] = await frames;
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(push[0]).toBe(PushCodes.BinaryResponse);
+    const body = push.subarray(6);
+    expect(body.readUInt16LE(0)).toBe(0);
+    expect(body.readUInt16LE(2)).toBe(0);
+  });
+
+  it('replies Sent but pushes nothing when the manager throws', async () => {
+    await startWith(false);
+    manager.getNeighboursMock.mockRejectedValueOnce(new Error('bridge down'));
+    const sent = await client.request(neighboursFrame(REMOTE_KEY));
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    const second = await Promise.race([
+      client.expectFrames(1).then((f) => f[0]),
+      new Promise<null>((r) => setTimeout(() => r(null), 100)),
+    ]);
+    expect(second).toBeNull();
+  });
+
+  it('replies Err(IllegalArg) on a short SendBinaryReq envelope, without querying the node', async () => {
+    await startWith(false);
+    // [50][pubkey:32] with no inner req_data byte → too short.
+    const res = await client.request([CommandCodes.SendBinaryReq, ...REMOTE_KEY_BYTES]);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.IllegalArg);
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+  });
+
+  it('replies Err(IllegalArg) on a short GetNeighbours inner blob, without querying the node', async () => {
+    await startWith(false);
+    // Valid envelope + sub-type but truncated params (< 11 inner bytes).
+    const res = await client.request([CommandCodes.SendBinaryReq, ...REMOTE_KEY_BYTES, BinaryRequestTypes.GetNeighbours, 0, 5]);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.IllegalArg);
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+  });
+
+  it('replies Err(UnsupportedCmd) for an unknown inner sub-type, without querying the node', async () => {
+    await startWith(false);
+    // Envelope + an unimplemented sub-type (0x03 GetTelemetryData is not handled here).
+    const res = await client.request([CommandCodes.SendBinaryReq, ...REMOTE_KEY_BYTES, BinaryRequestTypes.GetTelemetryData, 0, 0]);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.UnsupportedCmd);
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -47,7 +47,13 @@ import {
   parseSendTelemetryReq,
   parseSendStatusReq,
   encodeStatusResponsePush,
+  BinaryRequestTypes,
+  parseSendBinaryReq,
+  parseGetNeighboursReq,
+  encodeBinaryResponsePush,
+  encodeNeighboursPayload,
   type ParsedCommand,
+  type SendBinaryReqCmd,
 } from './meshcoreCompanionCodec.js';
 
 /**
@@ -117,6 +123,19 @@ export interface MeshCoreVirtualNodeManager {
    * wire status blob for the StatusResponse push.
    */
   requestNodeStatus(publicKey: string): Promise<MeshCoreStatus | null>;
+  /**
+   * Query the neighbour list from a remote repeater (issue #3904). Returns the
+   * total known count and the requested page of entries (pubkey-prefix hex,
+   * last-heard age in seconds, dB SNR), or null on failure / non-repeater /
+   * disconnected. Used to relay the app's SendBinaryReq→GetNeighbours.
+   */
+  getNeighbours(
+    publicKey: string,
+    opts?: { count?: number; offset?: number; orderBy?: number },
+  ): Promise<{
+    total: number;
+    neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+  } | null>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -470,6 +489,13 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
           // a status request based on the session, not on our admin flag).
           void this.handleSendStatusReq(clientId, command);
           break;
+        case CommandCodes.SendBinaryReq:
+          // Generic binary request (issue #3904); dispatched on an inner sub-type.
+          // Implemented sub-types (e.g. GetNeighbours) are read-only follow-ups to
+          // a login, so — like SendTelemetryReq/SendStatusReq — NOT gated on
+          // allowAdminCommands (the real node answers based on the session).
+          void this.handleSendBinaryReq(clientId, command);
+          break;
         // Config-mutating commands (issue #3904): forwarded to the real node
         // only when `allowAdminCommands` is enabled; otherwise the app gets an
         // explicit Err (UnsupportedCmd) instead of a silent hang.
@@ -601,6 +627,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   private readonly TRACE_EST_TIMEOUT_MS = 30000;
   private readonly TELEMETRY_EST_TIMEOUT_MS = 30000;
   private readonly STATUS_EST_TIMEOUT_MS = 30000;
+  private readonly NEIGHBOURS_EST_TIMEOUT_MS = 30000;
 
   /**
    * SendLogin(26): authenticate the physical node to a remote node with a
@@ -750,6 +777,90 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       logger.info(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} → status relayed`);
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * SendBinaryReq(50): the app's GENERIC binary-request command (issue #3904).
+   * Frame: `[50][targetPubkey:32][reqData…]` where `reqData[0]` is a
+   * `BinaryRequestTypes` sub-type. We parse the envelope, then dispatch on the
+   * sub-type. GetNeighbours(0x06) is implemented (repeater neighbour list);
+   * every other sub-type gets an explicit Err(UnsupportedCmd) so future ones are
+   * obvious rather than silently dropped.
+   *
+   * A malformed envelope (can't read pubkey/sub-type) → Err(IllegalArg) with no
+   * Sent, mirroring the sibling req handlers.
+   */
+  private async handleSendBinaryReq(clientId: string, command: ParsedCommand): Promise<void> {
+    let parsed: SendBinaryReqCmd;
+    try {
+      parsed = parseSendBinaryReq(command.payload);
+    } catch (err) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] SendBinaryReq bad payload from ${clientId}: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.IllegalArg));
+      return;
+    }
+    switch (parsed.reqType) {
+      case BinaryRequestTypes.GetNeighbours:
+        await this.handleGetNeighboursReq(clientId, parsed);
+        break;
+      default:
+        logger.debug(
+          `[MeshCore VN ${this.sourceId}] SendBinaryReq unknown sub-type 0x${parsed.reqType.toString(16)} from ${clientId}`,
+        );
+        this.send(clientId, encodeErr(ErrorCodes.UnsupportedCmd));
+        break;
+    }
+  }
+
+  /**
+   * GetNeighbours(0x06) sub-request of SendBinaryReq: relay a remote repeater's
+   * neighbour list (issue #3904 — the final gap; the neighbours protocol is
+   * SendBinaryReq(50)/GetNeighbours(0x06), NOT SendRawData(25) as the issue
+   * inferred). Flow mirrors the sibling req handlers: reply Sent, fetch from the
+   * real node via `manager.getNeighbours`, then push a BinaryResponse(0x8C).
+   *
+   * Tag correlation (verified against meshcore.js `sendBinaryRequest`): the
+   * client matches the push to its request by comparing the push's `tag` to the
+   * `expectedAckCrc` of the preceding Sent(6) — NOT the request's random_tag. We
+   * echo the request's random_tag as BOTH the Sent `expectedAckCrc` AND the
+   * BinaryResponse `tag`, so either interpretation matches.
+   *
+   * Graceful handling: a null result (non-repeater / no session / disconnected)
+   * resolves the app's request cleanly with an EMPTY neighbour list
+   * (total=0/count=0) rather than a timeout — the client tolerates it. An
+   * unexpected throw logs and emits nothing (the app times out, matching the
+   * sibling handlers and real-node behaviour). A malformed inner blob →
+   * Err(IllegalArg) with no Sent.
+   */
+  private async handleGetNeighboursReq(clientId: string, parsed: SendBinaryReqCmd): Promise<void> {
+    let req;
+    try {
+      req = parseGetNeighboursReq(parsed.reqData);
+    } catch (err) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] GetNeighbours bad payload from ${clientId}: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.IllegalArg));
+      return;
+    }
+    const keyShort = parsed.publicKey.substring(0, 12);
+    // Echo the request's random_tag as the Sent expectedAckCrc — the client
+    // stores it and later matches the BinaryResponse push's tag against it.
+    this.send(clientId, encodeSent(0, req.tag, this.NEIGHBOURS_EST_TIMEOUT_MS));
+    try {
+      const result = await this.options.manager.getNeighbours(parsed.publicKey, {
+        count: req.count,
+        offset: req.offset,
+        orderBy: req.orderBy,
+      });
+      const total = result?.total ?? 0;
+      const neighbours = result?.neighbours ?? [];
+      const payload = encodeNeighboursPayload(total, neighbours, req.pubkeyPrefixLen);
+      this.send(clientId, encodeBinaryResponsePush(req.tag, payload));
+      logger.info(
+        `[MeshCore VN ${this.sourceId}] GetNeighbours to ${keyShort}… from ${clientId} → ${neighbours.length}/${total} neighbours`,
+      );
+    } catch (err) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] GetNeighbours to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Implements the **final gap of #3904**: relaying a remote repeater's **neighbours** list through the MeshCore Virtual Node (VN). After a remote login, the meshcore-flutter app's "neighbours" action fell through to `default:` in `dispatchCommand` and returned `Err(UnsupportedCmd)`.

Builds on the Sent-ack → async-push transaction template established by #3959 (login/trace), #3961 (telemetry), and #3991 (status).

## Corrects the record: neighbours = SendBinaryReq(50)/GetNeighbours(0x06), NOT SendRawData(25)

The issue *inferred* neighbours flowed via `SendRawData(25)`. That is wrong. Verified against the vendored reference lib `@liamcottle/meshcore.js` (the **same** companion protocol meshcore-flutter speaks — `getNeighbours`, `sendCommandSendBinaryReq`, `onBinaryResponsePush`, `sendBinaryRequest`):

- Neighbours is **`SendBinaryReq(50)`** — a *generic* binary-request command dispatched on an inner sub-type — with sub-type **`GetNeighbours(0x06)`**, answered by an async **`BinaryResponse(0x8C)`** push.

### Confirmed wire protocol
- **App→VN:** `[50][targetPubkey:32][reqData]` where `reqData = [0x06][request_version=0][count:u8][offset:u16LE][order_by:u8][pubkey_prefix_len:u8][random_tag:u32LE]`.
- **VN→App:** async `BinaryResponse(0x8C)` = `[0x8C][reserved:1][tag:u32LE][totalCount:u16LE][resultsCount:u16LE]` then `resultsCount` × `[prefix:pubkey_prefix_len][heardSecondsAgo:u32LE][snr:int8 = snr×4]`.
- **Tag correlation:** the client matches the push by `BinaryResponse.tag == Sent.expectedAckCrc` — **not** the request's `random_tag`. So we echo the request's `random_tag` into **both** the `Sent(6)` `expectedAckCrc` and the `BinaryResponse` tag; either interpretation matches.

## Implementation
- `dispatchCommand` → new `handleSendBinaryReq`: parses the envelope and dispatches on the inner sub-type. `GetNeighbours(0x06)` is implemented; any **other** sub-type returns an explicit `Err(UnsupportedCmd)` so future sub-types are obvious rather than silently dropped.
- `handleGetNeighboursReq`: reply `Sent` (tag echoed), call the existing `manager.getNeighbours(publicKey, {count, offset, orderBy})` (already works on live hardware — not reimplemented), then push a `BinaryResponse` re-serialized with the **requested** `pubkey_prefix_len` stride and `snr` as `round(snr×4)` int8.
- **Ungated** by `allowAdminCommands` — read-only follow-up to login, consistent with `SendTelemetryReq`/`SendStatusReq` (the real node answers based on the session, not our admin flag).
- **Graceful handling:** bad envelope / inner blob → `Err(IllegalArg)`; null result (non-repeater / no session / disconnected) → an **empty** `BinaryResponse` (`total=0/count=0`, which the client tolerates) rather than a timeout; manager throw → log and emit nothing (app times out, matching the sibling handlers).
- **Codec** additions: `parseSendBinaryReq`, `parseGetNeighboursReq`, `encodeBinaryResponsePush`, `encodeNeighboursPayload`, `PushCodes.BinaryResponse = 0x8C`, and a `BinaryRequestTypes` const.

## ✅ VALIDATED END-TO-END against a live repeater (through the VN)

Drove the **real** `@liamcottle/meshcore.js` client (as the app) over TCP against the running VN on `:5000`, performed the AppStart handshake (`SelfInfo` = *"Yeraze MC BLE Sandbox"*), then called `getNeighbours('661b0674…')` ("Yeraze Repeater"). The VN relayed the request to the physical node via `SendBinaryReq(50)` and pushed back `BinaryResponse(0x8C)` — the client decoded **total=16 / 10 returned real neighbours**, tag-correlated (`Sent.expectedAckCrc == BinaryResponse.tag == 0x38ef5cf1`):

```
neighbour prefix=151aa6a1a8097bf0 heard=505s   snr=-1.25dB
neighbour prefix=8e73f5a4854964ac heard=3326s  snr=10dB
neighbour prefix=1d0b87707ec63410 heard=4051s  snr=-1.75dB
neighbour prefix=382465497a0d8d3a heard=5930s  snr=1dB
neighbour prefix=06a88476a349927a heard=8654s  snr=-5dB
neighbour prefix=55b7c6dd5e44f5f1 heard=8803s  snr=-4.25dB
neighbour prefix=0c02cb5ed940621e heard=10130s snr=9.75dB
neighbour prefix=5c3a39cf57e24f2e heard=15948s snr=8.75dB
neighbour prefix=0f773e2cf4f51985 heard=41637s snr=4.75dB
neighbour prefix=b634fa015528fcf0 heard=44033s snr=6dB
```

(total known = 16 matches the REST-path result; page of 20 requested, node returned 10 in the first response.)

## Tests
- New `SendBinaryReq/GetNeighbours` suite mirroring the sibling VN suites: happy path (Sent tag-echo + correct `BinaryResponse` bytes + tag correlation + prefix stride + snr×4), respects `pubkey_prefix_len`, ungated behaviour, empty-neighbours, null result, manager-throws (Sent then no push), bad envelope → `IllegalArg`, bad inner blob → `IllegalArg`, unknown sub-type → `UnsupportedCmd`.
- Full Vitest suite: **8213 passed / 0 failed / 0 suites failed** (`--reporter=json` `success: true`). `tsc --noEmit` clean. No new lint errors (the 4 baselined `no-useless-assignment` findings pre-exist on `main`).

Closes #3904. References #3959, #3961, #3991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub