### PR TITLE
chore(logging): trim default log volume — reclassify routine info→debug, add trace tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Changed
+- **Container logs are far quieter at the default level.** Routine per-packet, per-request, and periodic-scheduler activity — plus the ~60-line environment dump printed on every boot — was logged at `info`, which is the production default, making Docker logs hard to use for support. That activity is now logged at `debug`; `info` is reserved for genuinely important, low-frequency events (startup/shutdown, source connect/disconnect, backups/restores/migrations, and deliberate actions taken), so an idle container is near-silent. A new `trace` level captures the full per-packet firehose. Raise verbosity for troubleshooting with `LOG_LEVEL=debug` (or `trace`) — no `NODE_ENV` change needed. As a side benefit, MeshCore message **bodies** are no longer written to logs (only sender/channel metadata and a length).
 - **BREAKING (deployments behind a reverse proxy): `TRUST_PROXY` now defaults to `false`.** Previously, production builds trusted the first proxy hop when `TRUST_PROXY` was unset, which let a direct-connected client spoof `X-Forwarded-For` to bypass the auth brute-force limiter and poison audit attribution. Proxied deployments must now set `TRUST_PROXY` explicitly (`TRUST_PROXY=1` for a single proxy). Direct (non-proxied) deployments need no change.
 
 ## [4.12.5] - 2026-07-06

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,12 @@ services:
       - TZ=America/New_York
       - ALLOWED_ORIGINS=http://localhost:8080  # Required for CORS
 
+      # Log verbosity: trace | debug | info | warn | error
+      # Defaults to `info` in production / `debug` in development. `info` is
+      # deliberately quiet (startup + connect/disconnect + errors). Raise to
+      # `debug` (or `trace` for the per-packet firehose) when troubleshooting.
+      # - LOG_LEVEL=debug
+
       # OPTIONAL: Uncomment and configure for production deployments
       # See docs/configuration/production.md for full production setup guide
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -190,7 +190,7 @@ See the [Push Notifications guide](/features/notifications) for setup instructio
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, `error` | `debug` in development, `info` in production |
+| `LOG_LEVEL` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` | `debug` in development, `info` in production |
 
 **Note**: `LOG_LEVEL` controls log output independently of `NODE_ENV`. This lets you enable debug logging in production Docker deployments without changing rate limits, cookie warnings, or other `NODE_ENV`-dependent behavior.
 
@@ -320,12 +320,14 @@ MeshMonitor logs to stdout/stderr by default. Log output uses level prefixes: `[
 
 ### Log Levels
 
-Control verbosity with the `LOG_LEVEL` environment variable:
+Control verbosity with the `LOG_LEVEL` environment variable. Levels are
+cumulative — each includes everything above it in this table:
 
 | Level | What is logged |
 |-------|---------------|
-| `debug` | Everything — verbose diagnostics, state changes, data inspection |
-| `info` | Informational messages, warnings, and errors |
+| `trace` | Firehose — per-packet / per-loop diagnostics. Only enable for a short capture window; far too noisy for steady use. |
+| `debug` | Verbose but bounded — routine per-event activity, periodic scheduler cycles, connection handshake steps, state inspection. |
+| `info` | **Default in production.** Important, low-frequency events: startup/shutdown, source connect/disconnect, backups/restores/migrations, and deliberate actions taken. An idle container is near-silent at this level. |
 | `warn` | Warnings and errors only |
 | `error` | Errors only |
 
@@ -334,11 +336,14 @@ If `LOG_LEVEL` is not set, the default depends on `NODE_ENV`:
 - `production` → `info`
 
 ::: tip Troubleshooting in Production
-Set `LOG_LEVEL=debug` to get verbose logging without changing `NODE_ENV`. This avoids side effects like altered rate limits or cookie warnings:
+The default `info` level is deliberately quiet — routine per-packet, per-request,
+and periodic-scheduler activity is logged at `debug`. To investigate an issue,
+raise the level without changing `NODE_ENV` (this avoids side effects like
+altered rate limits or cookie warnings):
 ```yaml
 environment:
   - NODE_ENV=production
-  - LOG_LEVEL=debug
+  - LOG_LEVEL=debug   # or `trace` for the full per-packet firehose
 ```
 :::
 

--- a/src/server/auth/authMiddleware.ts
+++ b/src/server/auth/authMiddleware.ts
@@ -45,7 +45,7 @@ export function optionalAuth() {
           if (!user) {
             // Auto-provision if enabled
             if (config.proxyAuthAutoProvision) {
-              logger.info(`🔐 Auto-provisioning proxy user: ${proxyUser.email}`);
+              logger.debug(`🔐 Auto-provisioning proxy user: ${proxyUser.email}`);
 
               const isAdmin = isAdminUser(proxyUser.email, proxyUser.groups);
               const username = proxyUser.email.split('@')[0]; // Use email prefix as username
@@ -105,7 +105,7 @@ export function optionalAuth() {
 
           // Check if we need to migrate local user to proxy
           if (user && user.authProvider === 'local') {
-            logger.info(`🔄 Migrating local user '${user.username}' to proxy auth`);
+            logger.debug(`🔄 Migrating local user '${user.username}' to proxy auth`);
 
             const isAdmin = isAdminUser(proxyUser.email, proxyUser.groups);
 
@@ -143,7 +143,7 @@ export function optionalAuth() {
             const currentIsAdmin = isAdminUser(proxyUser.email, proxyUser.groups);
 
             if (currentIsAdmin !== user.isAdmin) {
-              logger.info(`🔄 Updating admin status for ${user.username}: ${user.isAdmin} → ${currentIsAdmin}`);
+              logger.debug(`🔄 Updating admin status for ${user.username}: ${user.isAdmin} → ${currentIsAdmin}`);
 
               await databaseService.auth.updateUser(user.id, {
                 isAdmin: currentIsAdmin,

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -309,7 +309,7 @@ export interface EnvironmentConfig {
   accessLogFormatProvided: boolean;
 
   // Logging
-  logLevel: 'debug' | 'info' | 'warn' | 'error';
+  logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error';
   logLevelProvided: boolean;
 
   // Branding (login page customization)
@@ -696,8 +696,8 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   const accessLogFormat = parseEnum('ACCESS_LOG_FORMAT', process.env.ACCESS_LOG_FORMAT, ['combined', 'common', 'tiny'] as const, 'combined');
 
   // Logging
-  const logLevelDefault: 'debug' | 'info' | 'warn' | 'error' = nodeEnv.value === 'development' ? 'debug' : 'info';
-  const logLevel = parseEnum('LOG_LEVEL', process.env.LOG_LEVEL?.toLowerCase(), ['debug', 'info', 'warn', 'error'] as const, logLevelDefault);
+  const logLevelDefault: 'trace' | 'debug' | 'info' | 'warn' | 'error' = nodeEnv.value === 'development' ? 'debug' : 'info';
+  const logLevel = parseEnum('LOG_LEVEL', process.env.LOG_LEVEL?.toLowerCase(), ['trace', 'debug', 'info', 'warn', 'error'] as const, logLevelDefault);
 
   // Branding (login page customization)
   // CUSTOM_TITLE overrides the "MeshMonitor" heading on the login page.
@@ -736,79 +736,79 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   logger.info(`   BASE_URL: ${baseUrl || '/'} (${src(baseUrlProvided)})`);
   logger.info(`   LOG_LEVEL: ${logLevel.value} (${src(logLevel.wasProvided)})`);
   logger.info(`   TZ: ${timezone.value} (${src(timezone.wasProvided)})`);
-  logger.info(`   ALLOWED_ORIGINS: ${allowedOrigins.value || '*'} (${src(allowedOrigins.wasProvided)})`);
-  logger.info(`   IFRAME_ALLOWED_ORIGINS: ${iframeAllowedOrigins.value.length > 0 ? iframeAllowedOrigins.value.join(',') : '(not set - iframe embedding blocked)'} (${src(iframeAllowedOrigins.wasProvided)})`);
-  logger.info(`   TRUST_PROXY: ${trustProxy.value} (${src(trustProxy.wasProvided)})`);
+  logger.debug(`   ALLOWED_ORIGINS: ${allowedOrigins.value || '*'} (${src(allowedOrigins.wasProvided)})`);
+  logger.debug(`   IFRAME_ALLOWED_ORIGINS: ${iframeAllowedOrigins.value.length > 0 ? iframeAllowedOrigins.value.join(',') : '(not set - iframe embedding blocked)'} (${src(iframeAllowedOrigins.wasProvided)})`);
+  logger.debug(`   TRUST_PROXY: ${trustProxy.value} (${src(trustProxy.wasProvided)})`);
   logger.info(`   VERSION_CHECK_DISABLED: ${versionCheckDisabled}`);
-  logger.info('   --- Session/Security ---');
-  logger.info(`   SESSION_SECRET: ${sessionSecretProvided ? '***provided***' : '(auto-generated)'}`);
-  logger.info(`   SESSION_COOKIE_NAME: ${sessionCookieName.value} (${src(sessionCookieName.wasProvided)})`);
-  logger.info(`   SESSION_MAX_AGE: ${sessionMaxAge.value}ms (${src(sessionMaxAge.wasProvided)})`);
-  logger.info(`   SESSION_ROLLING: ${sessionRolling.value} (${src(sessionRolling.wasProvided)})`);
-  logger.info(`   COOKIE_SECURE: ${cookieSecure.value} (${src(cookieSecure.wasProvided)})`);
-  logger.info(`   COOKIE_SAMESITE: ${cookieSameSite.value} (${src(cookieSameSite.wasProvided)})`);
-  logger.info('   --- Database ---');
+  logger.debug('   --- Session/Security ---');
+  logger.debug(`   SESSION_SECRET: ${sessionSecretProvided ? '***provided***' : '(auto-generated)'}`);
+  logger.debug(`   SESSION_COOKIE_NAME: ${sessionCookieName.value} (${src(sessionCookieName.wasProvided)})`);
+  logger.debug(`   SESSION_MAX_AGE: ${sessionMaxAge.value}ms (${src(sessionMaxAge.wasProvided)})`);
+  logger.debug(`   SESSION_ROLLING: ${sessionRolling.value} (${src(sessionRolling.wasProvided)})`);
+  logger.debug(`   COOKIE_SECURE: ${cookieSecure.value} (${src(cookieSecure.wasProvided)})`);
+  logger.debug(`   COOKIE_SAMESITE: ${cookieSameSite.value} (${src(cookieSameSite.wasProvided)})`);
+  logger.debug('   --- Database ---');
   logger.info(`   DATABASE_TYPE: ${databaseType}`);
   if (databaseUrl.wasProvided) {
     logger.info(`   DATABASE_URL: ***provided*** (${databaseType})`);
   } else {
     logger.info(`   DATABASE_PATH: ${databasePath.value} (${src(databasePath.wasProvided)})`);
   }
-  logger.info(`   TRACEROUTE_HISTORY_LIMIT: ${tracerouteHistoryLimit.value} (${src(tracerouteHistoryLimit.wasProvided)})`);
-  logger.info('   --- Meshtastic ---');
+  logger.debug(`   TRACEROUTE_HISTORY_LIMIT: ${tracerouteHistoryLimit.value} (${src(tracerouteHistoryLimit.wasProvided)})`);
+  logger.debug('   --- Meshtastic ---');
   logger.info(`   MESHTASTIC_NODE_IP: ${meshtasticNodeIp.value} (${src(meshtasticNodeIp.wasProvided)})`);
   logger.info(`   MESHTASTIC_NODE_PORT / MESHTASTIC_TCP_PORT: ${meshtasticTcpPort.value} (${src(meshtasticTcpPort.wasProvided)})`);
-  logger.info(`   MESHTASTIC_STALE_CONNECTION_TIMEOUT: ${meshtasticStaleConnectionTimeout.value}ms (${src(meshtasticStaleConnectionTimeout.wasProvided)})`);
-  logger.info(`   MESHTASTIC_CONNECT_TIMEOUT_MS: ${meshtasticConnectTimeoutMs.value}ms (${src(meshtasticConnectTimeoutMs.wasProvided)})`);
-  logger.info(`   MESHTASTIC_RECONNECT_INITIAL_DELAY_MS: ${meshtasticReconnectInitialDelayMs.value}ms (${src(meshtasticReconnectInitialDelayMs.wasProvided)})`);
-  logger.info(`   MESHTASTIC_RECONNECT_MAX_DELAY_MS: ${meshtasticReconnectMaxDelayMs.value}ms (${src(meshtasticReconnectMaxDelayMs.wasProvided)})`);
-  logger.info(`   MESHTASTIC_MODULE_CONFIG_DELAY_MS: ${meshtasticModuleConfigDelayMs.value}ms (${src(meshtasticModuleConfigDelayMs.wasProvided)})`);
+  logger.debug(`   MESHTASTIC_STALE_CONNECTION_TIMEOUT: ${meshtasticStaleConnectionTimeout.value}ms (${src(meshtasticStaleConnectionTimeout.wasProvided)})`);
+  logger.debug(`   MESHTASTIC_CONNECT_TIMEOUT_MS: ${meshtasticConnectTimeoutMs.value}ms (${src(meshtasticConnectTimeoutMs.wasProvided)})`);
+  logger.debug(`   MESHTASTIC_RECONNECT_INITIAL_DELAY_MS: ${meshtasticReconnectInitialDelayMs.value}ms (${src(meshtasticReconnectInitialDelayMs.wasProvided)})`);
+  logger.debug(`   MESHTASTIC_RECONNECT_MAX_DELAY_MS: ${meshtasticReconnectMaxDelayMs.value}ms (${src(meshtasticReconnectMaxDelayMs.wasProvided)})`);
+  logger.debug(`   MESHTASTIC_MODULE_CONFIG_DELAY_MS: ${meshtasticModuleConfigDelayMs.value}ms (${src(meshtasticModuleConfigDelayMs.wasProvided)})`);
   if (oidcEnabled) {
-    logger.info('   --- OIDC ---');
-    logger.info(`   OIDC_ISSUER: ${oidcIssuer.value ? '***provided***' : 'not set'}`);
-    logger.info(`   OIDC_CLIENT_ID: ${oidcClientId.value ? '***provided***' : 'not set'}`);
-    logger.info(`   OIDC_AUTO_CREATE_USERS: ${oidcAutoCreateUsers.value} (${src(oidcAutoCreateUsers.wasProvided)})`);
-    logger.info(`   OIDC_GROUPS_CLAIM: ${oidcGroupsClaim.value} (${src(oidcGroupsClaim.wasProvided)})`);
-    logger.info(`   OIDC_ADMIN_GROUPS: ${oidcAdminGroups.length > 0 ? oidcAdminGroups.join(', ') : 'not set (group→admin mapping disabled; first-login bootstrap applies)'}`);
-    logger.info(`   OIDC_ALLOWED_GROUPS: ${oidcAllowedGroups.length > 0 ? oidcAllowedGroups.join(', ') : 'not set (all OIDC users allowed)'}`);
+    logger.debug('   --- OIDC ---');
+    logger.debug(`   OIDC_ISSUER: ${oidcIssuer.value ? '***provided***' : 'not set'}`);
+    logger.debug(`   OIDC_CLIENT_ID: ${oidcClientId.value ? '***provided***' : 'not set'}`);
+    logger.debug(`   OIDC_AUTO_CREATE_USERS: ${oidcAutoCreateUsers.value} (${src(oidcAutoCreateUsers.wasProvided)})`);
+    logger.debug(`   OIDC_GROUPS_CLAIM: ${oidcGroupsClaim.value} (${src(oidcGroupsClaim.wasProvided)})`);
+    logger.debug(`   OIDC_ADMIN_GROUPS: ${oidcAdminGroups.length > 0 ? oidcAdminGroups.join(', ') : 'not set (group→admin mapping disabled; first-login bootstrap applies)'}`);
+    logger.debug(`   OIDC_ALLOWED_GROUPS: ${oidcAllowedGroups.length > 0 ? oidcAllowedGroups.join(', ') : 'not set (all OIDC users allowed)'}`);
   }
-  logger.info('   --- Authentication ---');
-  logger.info(`   DISABLE_ANONYMOUS: ${disableAnonymous.value} (${src(disableAnonymous.wasProvided)})`);
-  logger.info(`   DISABLE_LOCAL_AUTH: ${disableLocalAuth.value} (${src(disableLocalAuth.wasProvided)})`);
+  logger.debug('   --- Authentication ---');
+  logger.debug(`   DISABLE_ANONYMOUS: ${disableAnonymous.value} (${src(disableAnonymous.wasProvided)})`);
+  logger.debug(`   DISABLE_LOCAL_AUTH: ${disableLocalAuth.value} (${src(disableLocalAuth.wasProvided)})`);
   if (adminUsername.wasProvided) {
-    logger.info(`   ADMIN_USERNAME: ${adminUsername.value} (env)`);
+    logger.debug(`   ADMIN_USERNAME: ${adminUsername.value} (env)`);
   }
   if (proxyAuthEnabled.value) {
-    logger.info('   --- Proxy Authentication ---');
-    logger.info(`   PROXY_AUTH_ENABLED: ${proxyAuthEnabled.value}`);
-    logger.info(`   PROXY_AUTH_AUTO_PROVISION: ${proxyAuthAutoProvision.value}`);
-    logger.info(`   PROXY_AUTH_ADMIN_GROUPS: ${proxyAuthAdminGroups.length > 0 ? proxyAuthAdminGroups.join(', ') : 'not set'}`);
-    logger.info(`   PROXY_AUTH_ADMIN_EMAILS: ${proxyAuthAdminEmails.length > 0 ? '***configured***' : 'not set'}`);
-    logger.info(`   PROXY_AUTH_NORMAL_USER_GROUPS: ${proxyAuthNormalUserGroups.length > 0 ? proxyAuthNormalUserGroups.join(', ') : 'not set (all proxy users allowed)'}`);
-    logger.info(`   PROXY_AUTH_JWT_GROUPS_CLAIM: ${proxyAuthJwtGroupsClaim}`);
-    logger.info(`   PROXY_AUTH_AUDIT_LOGGING: ${proxyAuthAuditLogging.value}`);
+    logger.debug('   --- Proxy Authentication ---');
+    logger.debug(`   PROXY_AUTH_ENABLED: ${proxyAuthEnabled.value}`);
+    logger.debug(`   PROXY_AUTH_AUTO_PROVISION: ${proxyAuthAutoProvision.value}`);
+    logger.debug(`   PROXY_AUTH_ADMIN_GROUPS: ${proxyAuthAdminGroups.length > 0 ? proxyAuthAdminGroups.join(', ') : 'not set'}`);
+    logger.debug(`   PROXY_AUTH_ADMIN_EMAILS: ${proxyAuthAdminEmails.length > 0 ? '***configured***' : 'not set'}`);
+    logger.debug(`   PROXY_AUTH_NORMAL_USER_GROUPS: ${proxyAuthNormalUserGroups.length > 0 ? proxyAuthNormalUserGroups.join(', ') : 'not set (all proxy users allowed)'}`);
+    logger.debug(`   PROXY_AUTH_JWT_GROUPS_CLAIM: ${proxyAuthJwtGroupsClaim}`);
+    logger.debug(`   PROXY_AUTH_AUDIT_LOGGING: ${proxyAuthAuditLogging.value}`);
     if (proxyAuthLogoutUrl) {
-      logger.info(`   PROXY_AUTH_LOGOUT_URL: ${proxyAuthLogoutUrl}`);
+      logger.debug(`   PROXY_AUTH_LOGOUT_URL: ${proxyAuthLogoutUrl}`);
     }
   }
-  logger.info('   --- Rate Limiting ---');
-  logger.info(`   RATE_LIMIT_API: ${rateLimitApi.value} req/min (${src(rateLimitApi.wasProvided)})`);
-  logger.info(`   RATE_LIMIT_AUTH: ${rateLimitAuth.value} req/min (${src(rateLimitAuth.wasProvided)})`);
-  logger.info(`   RATE_LIMIT_MESSAGES: ${rateLimitMessages.value} req/min (${src(rateLimitMessages.wasProvided)})`);
+  logger.debug('   --- Rate Limiting ---');
+  logger.debug(`   RATE_LIMIT_API: ${rateLimitApi.value} req/min (${src(rateLimitApi.wasProvided)})`);
+  logger.debug(`   RATE_LIMIT_AUTH: ${rateLimitAuth.value} req/min (${src(rateLimitAuth.wasProvided)})`);
+  logger.debug(`   RATE_LIMIT_MESSAGES: ${rateLimitMessages.value} req/min (${src(rateLimitMessages.wasProvided)})`);
   if (vapidPublicKey.wasProvided) {
-    logger.info('   --- Push Notifications ---');
-    logger.info(`   VAPID keys: ***provided***`);
-    logger.info(`   PUSH_NOTIFICATION_TTL: ${pushNotificationTtl.value}s (${src(pushNotificationTtl.wasProvided)})`);
+    logger.debug('   --- Push Notifications ---');
+    logger.debug(`   VAPID keys: ***provided***`);
+    logger.debug(`   PUSH_NOTIFICATION_TTL: ${pushNotificationTtl.value}s (${src(pushNotificationTtl.wasProvided)})`);
   }
   if (accessLogEnabled.value) {
-    logger.info('   --- Access Logging ---');
-    logger.info(`   ACCESS_LOG_PATH: ${accessLogPath.value} (${src(accessLogPath.wasProvided)})`);
-    logger.info(`   ACCESS_LOG_FORMAT: ${accessLogFormat.value} (${src(accessLogFormat.wasProvided)})`);
+    logger.debug('   --- Access Logging ---');
+    logger.debug(`   ACCESS_LOG_PATH: ${accessLogPath.value} (${src(accessLogPath.wasProvided)})`);
+    logger.debug(`   ACCESS_LOG_FORMAT: ${accessLogFormat.value} (${src(accessLogFormat.wasProvided)})`);
   }
   if (customTitle.wasProvided || customLogoUrl.wasProvided) {
-    logger.info('   --- Branding ---');
-    if (customTitle.wasProvided) logger.info(`   CUSTOM_TITLE: ${customTitle.value}`);
-    if (customLogoUrl.wasProvided) logger.info(`   CUSTOM_LOGO_URL: ${customLogoUrl.value}`);
+    logger.debug('   --- Branding ---');
+    if (customTitle.wasProvided) logger.debug(`   CUSTOM_TITLE: ${customTitle.value}`);
+    if (customLogoUrl.wasProvided) logger.debug(`   CUSTOM_LOGO_URL: ${customLogoUrl.value}`);
   }
 
   return {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1268,7 +1268,7 @@ class MeshCoreManager extends EventEmitter {
       this.addMessage(message);
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
-      logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
+      logger.debug(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix} (${data.text.length} chars)`);
       void this.checkAutoAcknowledge(message, true, undefined, hopCount, ackRoute);
       void this.checkAutoResponder(message, true, undefined, hopCount, ackRoute);
     } else if (event_type === 'channel_message') {
@@ -1304,7 +1304,7 @@ class MeshCoreManager extends EventEmitter {
       this.addMessage(message);
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
-      logger.info(`[MeshCore] Channel ${data.channel_idx} message: ${data.text}`);
+      logger.debug(`[MeshCore] Channel ${data.channel_idx} message (${data.text.length} chars)`);
       void this.checkAutoAcknowledge(message, false, data.channel_idx, hopCount, route);
       void this.checkAutoResponder(message, false, data.channel_idx, hopCount, route);
     } else if (event_type === 'room_message') {
@@ -1336,7 +1336,7 @@ class MeshCoreManager extends EventEmitter {
       // Track newest post timestamp for sync-since and UI display.
       databaseService.meshcore.updateLastRoomPostAt(this.sourceId, roomFullKey, message.timestamp)
         .catch(err => logger.warn(`[MeshCore:${this.sourceId}] Failed to update lastRoomPostAt:`, err));
-      logger.info(`[MeshCore:${this.sourceId}] Room post from ${authorPrefixHex} in room ${roomPubkeyPrefix}: ${data.text.substring(0, 50)}`);
+      logger.debug(`[MeshCore:${this.sourceId}] Room post from ${authorPrefixHex} in room ${roomPubkeyPrefix} (${data.text.length} chars)`);
     } else if (event_type === 'contact_advertised' || event_type === 'contact_added') {
       const publicKey: string = data.public_key;
       if (publicKey) {
@@ -1401,7 +1401,7 @@ class MeshCoreManager extends EventEmitter {
         if (!updated.advName || updated.advType === undefined) {
           this.schedulePathRefresh(publicKey);
         }
-        logger.info(`[MeshCore] ${event_type} for ${publicKey} (${data.adv_name ?? ''})`);
+        logger.debug(`[MeshCore] ${event_type} for ${publicKey} (${data.adv_name ?? ''})`);
       }
     } else if (event_type === 'cli_reply') {
       // Remote-admin: a contact message with txtType=CliData. Routed here by
@@ -1458,7 +1458,7 @@ class MeshCoreManager extends EventEmitter {
         // is what's available. Coalesce pushes in a debounce window so a
         // chatty contact churning its route doesn't thunder the device.
         this.schedulePathRefresh(publicKey);
-        logger.info(`[MeshCore] contact_path_updated for ${publicKey} (refresh scheduled)`);
+        logger.debug(`[MeshCore] contact_path_updated for ${publicKey} (refresh scheduled)`);
       }
     } else if (event_type === 'path_discovery_response') {
       // 0x8D push from CMD 52 — carries the actual bidirectional path
@@ -1497,7 +1497,7 @@ class MeshCoreManager extends EventEmitter {
       void this.persistContact(updated);
       this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
       dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
-      logger.info(
+      logger.debug(
         `[MeshCore] Path discovery response for ${contact.publicKey.substring(0, 16)}…: ` +
         `out=${outHops} hops [${outPathFormatted}], in=${inHops} hops [${formatPathHex(inPathHex, data.in_hash_size ?? 1)}]`,
       );
@@ -1571,7 +1571,7 @@ class MeshCoreManager extends EventEmitter {
           this.activeDiscovery.returned++;
           if (isNew) this.activeDiscovery.newCount++;
         }
-        logger.info(
+        logger.debug(
           `[MeshCore:${this.sourceId}] Discovered node ${publicKey.substring(0, 16)}… ` +
           `(type=${data.adv_type}, snr=${data.snr}, ${isNew ? 'new' : 'known'})`,
         );
@@ -2200,7 +2200,7 @@ class MeshCoreManager extends EventEmitter {
       this.addMessage(message);
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
-      logger.info(`[MeshCore] Message from ${match[1].substring(0, 8)}...: ${match[2]}`);
+      logger.debug(`[MeshCore] Message from ${match[1].substring(0, 8)}... (${match[2].length} chars)`);
     }
   }
 
@@ -2451,7 +2451,7 @@ class MeshCoreManager extends EventEmitter {
       this.pathRefreshTimer = null;
       const pending = Array.from(this.pathRefreshPendingKeys);
       this.pathRefreshPendingKeys.clear();
-      logger.info(
+      logger.debug(
         `[MeshCore:${this.sourceId}] Refreshing contacts after ${pending.length} contact push(es) (path/new-node)`,
       );
       void this.refreshContacts()
@@ -2546,7 +2546,7 @@ class MeshCoreManager extends EventEmitter {
         await Promise.all(
           Array.from(this.contacts.values()).map((c) => this.persistContact(c)),
         );
-        logger.info(`[MeshCore] Refreshed ${this.contacts.size} contacts`);
+        logger.debug(`[MeshCore] Refreshed ${this.contacts.size} contacts`);
       }
     } catch (error) {
       logger.error('[MeshCore] Failed to refresh contacts:', error);
@@ -2586,7 +2586,7 @@ class MeshCoreManager extends EventEmitter {
         seeded++;
       }
       if (seeded > 0) {
-        logger.info(`[MeshCore:${this.sourceId}] Seeded ${seeded} contact(s) from DB`);
+        logger.debug(`[MeshCore:${this.sourceId}] Seeded ${seeded} contact(s) from DB`);
       }
     } catch (err) {
       logger.warn(`[MeshCore:${this.sourceId}] seedContactsFromDb failed: ${(err as Error).message}`);
@@ -2820,7 +2820,7 @@ class MeshCoreManager extends EventEmitter {
       if (response.success) {
         const ackCrc: number | null = response.data?.expectedAckCrc ?? null;
         const estTimeout: number | null = response.data?.estTimeout ?? null;
-        logger.info(`[MeshCore] Message sent: ${text.substring(0, 50)}... (ackCrc=${ackCrc}, estTimeout=${estTimeout})`);
+        logger.debug(`[MeshCore] Message sent (${text.length} chars) (ackCrc=${ackCrc}, estTimeout=${estTimeout})`);
 
         const sentToPublicKey = isChannelSend
           ? MeshCoreManager.channelPublicKey(channelIdx!)
@@ -2992,7 +2992,7 @@ class MeshCoreManager extends EventEmitter {
     const useFlood = pending.samePathRetriesLeft <= 0;
     if (useFlood && pending.floodRetriesLeft <= 0) {
       // All same-path and flood retries exhausted — give up.
-      logger.info(
+      logger.debug(
         `[MeshCore:${this.sourceId}] DM to ${pending.toPublicKey.substring(0, 16)}… still unacked after ` +
         `all retries; marking failed`,
       );
@@ -3000,7 +3000,7 @@ class MeshCoreManager extends EventEmitter {
       return;
     }
 
-    logger.info(
+    logger.debug(
       `[MeshCore:${this.sourceId}] No ack for DM to ${pending.toPublicKey.substring(0, 16)}… within timeout; ` +
       `retrying via ${useFlood ? 'flood (reset path)' : 'current path'} ` +
       `(samePathLeft=${pending.samePathRetriesLeft}, floodLeft=${pending.floodRetriesLeft})`,
@@ -3166,7 +3166,7 @@ class MeshCoreManager extends EventEmitter {
     }
     if (pending.retriesLeft <= 0) return; // defensive: one-shot already spent
 
-    logger.info(
+    logger.debug(
       `[MeshCore:${this.sourceId}] Channel send ${messageId} heard ZERO repeaters within ` +
       `${MeshCoreManager.CHANNEL_RETRY_WINDOW_MS / 1000}s; resending once (auto-retry #3979)`,
     );
@@ -3197,7 +3197,7 @@ class MeshCoreManager extends EventEmitter {
     if (this.deviceType === MeshCoreDeviceType.REPEATER) {
       try {
         await this.sendRepeaterCommand('advert');
-        logger.info('[MeshCore] Advert sent (Repeater)');
+        logger.debug('[MeshCore] Advert sent (Repeater)');
         return true;
       } catch (error) {
         logger.error('[MeshCore] Failed to send advert:', error);
@@ -3209,7 +3209,7 @@ class MeshCoreManager extends EventEmitter {
         // (handled above) scope via their own `region` config instead.
         const response = await this.sendWithDefaultScope(() => this.sendBridgeCommand('send_advert', {}));
         if (response.success) {
-          logger.info('[MeshCore] Advert sent (Companion)');
+          logger.debug('[MeshCore] Advert sent (Companion)');
           return true;
         }
         return false;
@@ -3257,7 +3257,7 @@ class MeshCoreManager extends EventEmitter {
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
       }
-      logger.info(`[MeshCore] Reset path for ${publicKey.substring(0, 16)}…`);
+      logger.debug(`[MeshCore] Reset path for ${publicKey.substring(0, 16)}…`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] resetContactPath threw:', error);
@@ -3287,7 +3287,7 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore] discover_path failed for ${publicKey}: ${response.error}`);
         return false;
       }
-      logger.info(`[MeshCore] Path discovery sent for ${publicKey.substring(0, 16)}…`);
+      logger.debug(`[MeshCore] Path discovery sent for ${publicKey.substring(0, 16)}…`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] discoverContactPath threw:', error);
@@ -3331,7 +3331,7 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore] discover_nodes failed (filter=0x${filter.toString(16)}): ${response.error}`);
         return empty;
       }
-      logger.info(
+      logger.debug(
         `[MeshCore] Node discovery sent (filter=0x${filter.toString(16)}, tag=${tag}); ` +
         `collecting for ${windowMs}ms`,
       );
@@ -3344,7 +3344,7 @@ class MeshCoreManager extends EventEmitter {
         // only the current 0-hop set (#3743).
         seen: [...this.activeDiscovery.seen],
       };
-      logger.info(`[MeshCore] Node discovery complete: ${result.returned} returned, ${result.newCount} new`);
+      logger.debug(`[MeshCore] Node discovery complete: ${result.returned} returned, ${result.newCount} new`);
 
       // #3820: a NODE_DISCOVER_RESP carries no name, and the device's contact
       // record stays nameless until the repeater adverts — which a zero-hop
@@ -3412,7 +3412,7 @@ class MeshCoreManager extends EventEmitter {
       void this.persistContact(updated);
       this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
       dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
-      logger.info(`[MeshCore:${this.sourceId}] Owner-name fetched for ${publicKey.substring(0, 16)}…: "${name}" (#3820)`);
+      logger.debug(`[MeshCore:${this.sourceId}] Owner-name fetched for ${publicKey.substring(0, 16)}…: "${name}" (#3820)`);
       return name;
     } catch (err) {
       logger.debug(`[MeshCore:${this.sourceId}] owner-name fetch failed for ${publicKey.substring(0, 12)}…: ${(err as Error).message}`);
@@ -3548,11 +3548,11 @@ class MeshCoreManager extends EventEmitter {
     // First attempt; on an empty result retry once before giving up (#3743).
     let repeaters = await sweepZeroHopRepeaters();
     if (repeaters.length === 0) {
-      logger.info(`[MeshCore:${this.sourceId}] No 0-hop repeaters on first sweep; retrying once`);
+      logger.debug(`[MeshCore:${this.sourceId}] No 0-hop repeaters on first sweep; retrying once`);
       repeaters = await sweepZeroHopRepeaters();
     }
     if (repeaters.length === 0) {
-      logger.info(`[MeshCore:${this.sourceId}] No 0-hop repeaters found after retry`);
+      logger.debug(`[MeshCore:${this.sourceId}] No 0-hop repeaters found after retry`);
       return { regions: [], perRepeater: [], noZeroHopRepeaters: true };
     }
 
@@ -3646,7 +3646,7 @@ class MeshCoreManager extends EventEmitter {
         snr: raw / 4,
       }));
       const lastSnr: number = d.lastSnr ?? 0;
-      logger.info(`[MeshCore] Trace path to ${publicKey.substring(0, 16)}…: ${hops.length} hops, lastSnr=${lastSnr}`);
+      logger.debug(`[MeshCore] Trace path to ${publicKey.substring(0, 16)}…: ${hops.length} hops, lastSnr=${lastSnr}`);
       return { hops, lastSnr };
     } catch (error) {
       logger.error('[MeshCore] traceContactPath threw:', error);
@@ -3727,7 +3727,7 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore] share_contact failed for ${publicKey}: ${friendly}`);
         return { ok: false, error: friendly };
       }
-      logger.info(`[MeshCore] Shared contact ${publicKey.substring(0, 16)}…`);
+      logger.debug(`[MeshCore] Shared contact ${publicKey.substring(0, 16)}…`);
       return { ok: true };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -3827,7 +3827,7 @@ class MeshCoreManager extends EventEmitter {
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
       }
-      logger.info(`[MeshCore] Set out_path (${hopCount} hops, ${hashBytes}-byte) for ${publicKey.substring(0, 16)}…`);
+      logger.debug(`[MeshCore] Set out_path (${hopCount} hops, ${hashBytes}-byte) for ${publicKey.substring(0, 16)}…`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] setContactOutPath threw:', error);
@@ -3862,7 +3862,7 @@ class MeshCoreManager extends EventEmitter {
       }
       this.emit('contact_removed', { sourceId: this.sourceId, publicKey });
       dataEventEmitter.emitMeshCoreContactUpdated({ publicKey, removed: true } as any, this.sourceId);
-      logger.info(`[MeshCore] Removed contact ${publicKey.substring(0, 16)}…`);
+      logger.debug(`[MeshCore] Removed contact ${publicKey.substring(0, 16)}…`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] removeContact threw:', error);
@@ -3930,7 +3930,7 @@ class MeshCoreManager extends EventEmitter {
       this.emit('contact_removed', { sourceId: this.sourceId, publicKey });
       dataEventEmitter.emitMeshCoreContactUpdated({ publicKey, removed: true } as any, this.sourceId);
     }
-    logger.info(`[MeshCore:${this.sourceId}] Forgot local contact ${publicKey.substring(0, 16)}… (row=${deletedRow}, mem=${hadInMemory})`);
+    logger.debug(`[MeshCore:${this.sourceId}] Forgot local contact ${publicKey.substring(0, 16)}… (row=${deletedRow}, mem=${hadInMemory})`);
     return removed;
   }
 
@@ -3955,7 +3955,7 @@ class MeshCoreManager extends EventEmitter {
       }
       const bytes = response.data?.advert_bytes;
       if (!Array.isArray(bytes)) return null;
-      logger.info(`[MeshCore] Exported contact ${publicKey ? publicKey.substring(0, 16) + '…' : '(self)'} (${bytes.length}B)`);
+      logger.debug(`[MeshCore] Exported contact ${publicKey ? publicKey.substring(0, 16) + '…' : '(self)'} (${bytes.length}B)`);
       return bytes;
     } catch (error) {
       logger.error('[MeshCore] exportContact threw:', error);
@@ -3980,7 +3980,7 @@ class MeshCoreManager extends EventEmitter {
         return false;
       }
       await this.refreshContacts();
-      logger.info(`[MeshCore] Imported contact (${advertBytes.length}B advert)`);
+      logger.debug(`[MeshCore] Imported contact (${advertBytes.length}B advert)`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] importContact threw:', error);
@@ -4018,7 +4018,7 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore:${this.sourceId}] set_device_time failed: ${friendly}`);
         return { ok: false, reason: 'command-failed', error: friendly };
       }
-      logger.info(`[MeshCore:${this.sourceId}] Device time synced to server clock`);
+      logger.debug(`[MeshCore:${this.sourceId}] Device time synced to server clock`);
       return { ok: true };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -4115,7 +4115,7 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore] reboot failed: ${response.error}`);
         return false;
       }
-      logger.info(`[MeshCore:${this.sourceId}] Reboot command sent`);
+      logger.debug(`[MeshCore:${this.sourceId}] Reboot command sent`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] rebootDevice threw:', error);
@@ -4142,7 +4142,7 @@ class MeshCoreManager extends EventEmitter {
       }
       const hex = response.data?.private_key;
       if (typeof hex !== 'string') return null;
-      logger.info(`[MeshCore:${this.sourceId}] Private key exported`);
+      logger.debug(`[MeshCore:${this.sourceId}] Private key exported`);
       return hex;
     } catch (error) {
       logger.error('[MeshCore] exportPrivateKey threw:', error);
@@ -4171,7 +4171,7 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore] import_private_key failed: ${response.error}`);
         return false;
       }
-      logger.info(`[MeshCore:${this.sourceId}] Private key imported — device identity changed`);
+      logger.debug(`[MeshCore:${this.sourceId}] Private key imported — device identity changed`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] importPrivateKey threw:', error);
@@ -4197,7 +4197,7 @@ class MeshCoreManager extends EventEmitter {
       }));
 
       if (response.success) {
-        logger.info(`[MeshCore] Logged into node ${publicKey.substring(0, 8)}...`);
+        logger.debug(`[MeshCore] Logged into node ${publicKey.substring(0, 8)}...`);
         return true;
       }
       return false;
@@ -5767,7 +5767,7 @@ class MeshCoreManager extends EventEmitter {
       attempt: this.reconnectAttempts,
       nextDelayMs: delay,
     });
-    logger.info(`[MeshCore:${this.sourceId}] Reconnect attempt ${this.reconnectAttempts} in ${delay}ms`);
+    logger.debug(`[MeshCore:${this.sourceId}] Reconnect attempt ${this.reconnectAttempts} in ${delay}ms`);
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
@@ -5837,7 +5837,7 @@ class MeshCoreManager extends EventEmitter {
         return;
       }
 
-      logger.info(`[MeshCore:${this.sourceId}] Auto-pathfinding: running on ${companions.length} companions + ${repeaters.length} repeaters`);
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: running on ${companions.length} companions + ${repeaters.length} repeaters`);
 
       for (let i = 0; i < targets.length; i++) {
         if (!this.connected) break;
@@ -5874,7 +5874,7 @@ class MeshCoreManager extends EventEmitter {
       }
 
       this.autoPathfindingLastRunAt = Date.now();
-      logger.info(`[MeshCore:${this.sourceId}] Auto-pathfinding: run complete`);
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: run complete`);
     };
 
     this.autoPathfindingJitterTimeout = setTimeout(() => {
@@ -6036,7 +6036,7 @@ class MeshCoreManager extends EventEmitter {
 
     this.autoAnnounceLastRunAt = Date.now();
     await databaseService.settings.setSourceSetting(this.sourceId, 'meshcoreAutoAnnounceLastRunAt', String(this.autoAnnounceLastRunAt));
-    logger.info(`[MeshCore:${this.sourceId}] Auto-announce (${reason}): ${sent}/${channelIndexes.length} channels`);
+    logger.debug(`[MeshCore:${this.sourceId}] Auto-announce (${reason}): ${sent}/${channelIndexes.length} channels`);
 
     // Optional advert burst N seconds after the announcement.
     const advertEnabled = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceAdvertEnabled')) === 'true';
@@ -6726,10 +6726,10 @@ class MeshCoreManager extends EventEmitter {
           logger.warn(`[MeshCore:${sourceId}] Auto-ack: cannot DM unknown contact ${message.fromPublicKey}`);
           return;
         }
-        logger.info(`[MeshCore:${sourceId}] Auto-ack DM → ${contact.advName ?? contact.publicKey.substring(0, 8)}: "${replyText}"`);
+        logger.debug(`[MeshCore:${sourceId}] Auto-ack DM → ${contact.advName ?? contact.publicKey.substring(0, 8)} (${replyText.length} chars)`);
         await this.sendMessage(replyText, contact.publicKey, undefined, scopeOverride);
       } else {
-        logger.info(`[MeshCore:${sourceId}] Auto-ack channel ${channelIdx} → "${replyText}"`);
+        logger.debug(`[MeshCore:${sourceId}] Auto-ack channel ${channelIdx} (${replyText.length} chars)`);
         // Automated sender → opt into channel-send auto-retry (#3979).
         await this.sendMessage(replyText, undefined, channelIdx, scopeOverride, true);
       }

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -591,7 +591,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         this.send(clientId, encodeErr(ErrorCodes.BadState));
         return;
       }
-      logger.info(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} forwarded to node`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} forwarded to node`);
       this.send(clientId, encodeOk());
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] ${name} from ${clientId} failed: ${(err as Error).message}`);
@@ -614,7 +614,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         this.send(clientId, encodeErr(ErrorCodes.BadState));
         return;
       }
-      logger.info(`[MeshCore VN ${this.sourceId}] SendSelfAdvert from ${clientId} forwarded to node`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] SendSelfAdvert from ${clientId} forwarded to node`);
       this.send(clientId, encodeOk());
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendSelfAdvert from ${clientId} failed: ${(err as Error).message}`);
@@ -656,12 +656,12 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     try {
       const ok = await this.options.manager.loginToNode(parsed.publicKey, parsed.password);
       if (!ok) {
-        logger.info(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} did not succeed`);
+        logger.debug(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} did not succeed`);
         return;
       }
       const prefix = pubKeyHexToBytes(parsed.publicKey).subarray(0, 6);
       this.send(clientId, encodeLoginSuccessPush(prefix));
-      logger.info(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} succeeded`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} succeeded`);
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
     }
@@ -687,7 +687,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     try {
       const result = await this.options.manager.tracePathRaw(parsed.path);
       if (!result) {
-        logger.info(`[MeshCore VN ${this.sourceId}] SendTracePath from ${clientId} got no result`);
+        logger.debug(`[MeshCore VN ${this.sourceId}] SendTracePath from ${clientId} got no result`);
         return;
       }
       this.send(clientId, encodeTraceDataPush({
@@ -698,7 +698,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         pathSnrs: result.pathSnrs,
         lastSnr: result.lastSnr,
       }));
-      logger.info(`[MeshCore VN ${this.sourceId}] SendTracePath from ${clientId} → ${result.pathSnrs.length} hops, lastSnr=${result.lastSnr}`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] SendTracePath from ${clientId} → ${result.pathSnrs.length} hops, lastSnr=${result.lastSnr}`);
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendTracePath from ${clientId} failed: ${(err as Error).message}`);
     }
@@ -724,12 +724,12 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     try {
       const lpp = await this.options.manager.requestRemoteTelemetryRaw(parsed.publicKey);
       if (!lpp) {
-        logger.info(`[MeshCore VN ${this.sourceId}] SendTelemetryReq to ${keyShort}… from ${clientId} got no data`);
+        logger.debug(`[MeshCore VN ${this.sourceId}] SendTelemetryReq to ${keyShort}… from ${clientId} got no data`);
         return;
       }
       const prefix = pubKeyHexToBytes(parsed.publicKey).subarray(0, 6);
       this.send(clientId, encodeTelemetryResponsePush(prefix, lpp));
-      logger.info(`[MeshCore VN ${this.sourceId}] SendTelemetryReq to ${keyShort}… from ${clientId} → ${lpp.length}B LPP`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] SendTelemetryReq to ${keyShort}… from ${clientId} → ${lpp.length}B LPP`);
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendTelemetryReq to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
     }
@@ -769,12 +769,12 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     try {
       const status = await this.options.manager.requestNodeStatus(parsed.publicKey);
       if (!status) {
-        logger.info(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} got no status`);
+        logger.debug(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} got no status`);
         return;
       }
       const prefix = pubKeyHexToBytes(parsed.publicKey).subarray(0, 6);
       this.send(clientId, encodeStatusResponsePush(prefix, status));
-      logger.info(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} → status relayed`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} → status relayed`);
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendStatusReq to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
     }
@@ -856,7 +856,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       const neighbours = result?.neighbours ?? [];
       const payload = encodeNeighboursPayload(total, neighbours, req.pubkeyPrefixLen);
       this.send(clientId, encodeBinaryResponsePush(req.tag, payload));
-      logger.info(
+      logger.debug(
         `[MeshCore VN ${this.sourceId}] GetNeighbours to ${keyShort}… from ${clientId} → ${neighbours.length}/${total} neighbours`,
       );
     } catch (err) {
@@ -977,7 +977,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     try {
       const ok = await this.options.manager.sendMessage(text, undefined, channelIdx);
       if (ok) {
-        logger.info(`[MeshCore VN ${this.sourceId}] ▶ forwarded channel ${channelIdx} msg from ${clientId} (${text.length} chars)`);
+        logger.debug(`[MeshCore VN ${this.sourceId}] ▶ forwarded channel ${channelIdx} msg from ${clientId} (${text.length} chars)`);
         // A channel send is a fire-and-forget broadcast — the app's
         // sendChannelTextMessage awaits Ok(0), NOT Sent(6) (which is the
         // DM-with-ack response). Replying Sent here leaves the app's send
@@ -1006,7 +1006,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     try {
       const result = await this.options.manager.sendMessageWithResult(text, fullKey);
       if (result.ok) {
-        logger.info(`[MeshCore VN ${this.sourceId}] ▶ forwarded DM from ${clientId} to ${prefixHex}… (${text.length} chars)`);
+        logger.debug(`[MeshCore VN ${this.sourceId}] ▶ forwarded DM from ${clientId} to ${prefixHex}… (${text.length} chars)`);
         // Carry the firmware's real ack CRC in the Sent response and remember it
         // so the matching send_confirmed pushes a SendConfirmed(0x82) to THIS
         // client — otherwise the app waits for an ack it never gets, retransmits,
@@ -1043,7 +1043,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     this.pendingAcks.delete(key);
     if (!this.clients.has(clientId)) return; // originating client has gone away
     this.send(clientId, encodeSendConfirmed(data.ackCode, data.roundTripMs));
-    logger.info(
+    logger.debug(
       `[MeshCore VN ${this.sourceId}] ◀ ack confirmed to ${clientId} (crc=${key}, rtt=${data.roundTripMs}ms)`,
     );
   }

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1438,7 +1438,7 @@ class MeshtasticManager implements ISourceManager {
         const reason = consumeSuppressFlag
           ? '🟡 [manual-resync recovery] Skipping want_config_id — using cached config'
           : '🟢 [passive] Skipping want_config_id on reconnect — using cached config from last session';
-        logger.info(reason);
+        logger.debug(reason);
         this.configCaptureComplete = true;
         this.isCapturingInitConfig = false;
         // A manual-resync recovery should also clear the in-flight latch so the
@@ -1473,7 +1473,7 @@ class MeshtasticManager implements ISourceManager {
         this.preConfigChannelSnapshot = [];
       }
 
-      logger.info('📸 Starting init config capture for virtual node server');
+      logger.debug('📸 Starting init config capture for virtual node server');
 
       // Send want_config_id to request full node DB and config.
       // If the node resets the socket between our 'connect' event and this
@@ -1558,13 +1558,13 @@ class MeshtasticManager implements ISourceManager {
         const passive = this.passiveMode;
         setTimeout(() => this.startTracerouteScheduler(), S * 1);
         if (passive) {
-          logger.info('🟢 [passive] Skipping remote admin scanner — outbound queries to device');
+          logger.debug('🟢 [passive] Skipping remote admin scanner — outbound queries to device');
         } else {
           setTimeout(() => this.startRemoteAdminScanner().catch(e =>
             logger.error('❌ Error starting remote admin scanner:', e)), S * 2);
         }
         if (passive) {
-          logger.info('🟢 [passive] Skipping time sync scheduler — outbound time corrections to device');
+          logger.debug('🟢 [passive] Skipping time sync scheduler — outbound time corrections to device');
         } else {
           setTimeout(() => this.startTimeSyncScheduler().catch(e =>
             logger.error('❌ Error starting time sync scheduler:', e)), S * 3);
@@ -1594,7 +1594,7 @@ class MeshtasticManager implements ISourceManager {
         // Start remote LocalStats request scheduler (per-source, issue #3398).
         // Outbound to the mesh, so skip in passive mode like other device-bound queries.
         if (passive) {
-          logger.info('🟢 [passive] Skipping remote LocalStats scheduler — outbound queries to mesh');
+          logger.debug('🟢 [passive] Skipping remote LocalStats scheduler — outbound queries to mesh');
         } else {
           setTimeout(() => this.startRemoteLocalStatsScheduler(), S * 10);
         }
@@ -1603,11 +1603,11 @@ class MeshtasticManager implements ISourceManager {
         // until after configComplete so we don't flood the device mid-exchange.
         // This is safe for serial-bridge connections that reject mid-exchange admin msgs.
         if (passive) {
-          logger.info('🟢 [passive] Skipping LoRa config request — outbound to device');
+          logger.debug('🟢 [passive] Skipping LoRa config request — outbound to device');
         } else {
           setTimeout(async () => {
             try {
-              logger.info('📡 Requesting LoRa config from device...');
+              logger.debug('📡 Requesting LoRa config from device...');
               await this.requestConfig(5); // LORA_CONFIG = 5
             } catch (error) {
               logger.error('❌ Failed to request LoRa config:', error);
@@ -1617,11 +1617,11 @@ class MeshtasticManager implements ISourceManager {
 
         // Request all module configs for complete device backup capability (skip on reconnect)
         if (passive) {
-          logger.info('🟢 [passive] Skipping all-module-configs request — outbound to device');
+          logger.debug('🟢 [passive] Skipping all-module-configs request — outbound to device');
         } else if (!this.moduleConfigsEverFetched) {
           setTimeout(async () => {
             try {
-              logger.info('📦 Requesting all module configs for backup...');
+              logger.debug('📦 Requesting all module configs for backup...');
               await this.requestAllModuleConfigs();
               this.moduleConfigsEverFetched = true;
             } catch (error) {
@@ -1629,7 +1629,7 @@ class MeshtasticManager implements ISourceManager {
             }
           }, S * 10);
         } else {
-          logger.info('📦 Skipping module config request on reconnect (already fetched this session)');
+          logger.debug('📦 Skipping module config request on reconnect (already fetched this session)');
         }
 
         // Auto-favorite staleness sweep - runs every 60 minutes
@@ -1646,7 +1646,7 @@ class MeshtasticManager implements ISourceManager {
           });
         }, S * 11);
 
-        logger.info(`✅ Config capture complete — schedulers will start over the next ${(S * 11) / 1000} seconds`);
+        logger.debug(`✅ Config capture complete — schedulers will start over the next ${(S * 11) / 1000} seconds`);
       };
 
       // Fallback: if configComplete never arrives (device disconnects mid-config),
@@ -1978,7 +1978,7 @@ class MeshtasticManager implements ISourceManager {
           if (targetNode) {
             const channel = targetNode.channel ?? 0; // Use node's channel, default to 0
             const targetName = targetNode.longName || targetNode.nodeId;
-            logger.info(`🗺️ Auto-traceroute: Sending traceroute to ${targetName} (${targetNode.nodeId}) on channel ${channel}`);
+            logger.debug(`🗺️ Auto-traceroute: Sending traceroute to ${targetName} (${targetNode.nodeId}) on channel ${channel}`);
 
             // Log the auto-traceroute attempt to database
             await databaseService.logAutoTracerouteAttemptAsync(targetNode.nodeNum, targetName, this.sourceId);
@@ -1991,13 +1991,13 @@ class MeshtasticManager implements ISourceManager {
             // Check for timed-out traceroutes (> 5 minutes old)
             this.checkTracerouteTimeouts();
           } else {
-            logger.info('🗺️ Auto-traceroute: No nodes available for traceroute');
+            logger.debug('🗺️ Auto-traceroute: No nodes available for traceroute');
           }
         } catch (error) {
           logger.error('❌ Error in auto-traceroute:', error);
         }
       } else {
-        logger.info('🗺️ Auto-traceroute: Skipping - not connected or no local node info');
+        logger.debug('🗺️ Auto-traceroute: Skipping - not connected or no local node info');
       }
     };
 
@@ -2034,7 +2034,7 @@ class MeshtasticManager implements ISourceManager {
     const intervalHours = parseInt(intervalHoursStr || '24', 10);
     const intervalMs = Math.max(1, intervalHours) * 60 * 60 * 1000;
 
-    logger.info(`🗑️ Starting auto-delete-by-distance scheduler for source ${this.sourceId} (interval: ${intervalHours}h)`);
+    logger.debug(`🗑️ Starting auto-delete-by-distance scheduler for source ${this.sourceId} (interval: ${intervalHours}h)`);
 
     // Initial run after 2 minutes (matches prior singleton behavior)
     setTimeout(() => {
@@ -2175,7 +2175,7 @@ class MeshtasticManager implements ISourceManager {
         // firmware default of 3 silently drops requests to farther nodes.
         const hopLimit = Math.min(7, (target.hopsAway ?? 1) + 2);
         const targetName = target.longName || target.nodeId;
-        logger.info(`📊 Remote LocalStats: Requesting local_stats from ${targetName} (${target.nodeId}) on channel ${channel}, hopLimit ${hopLimit}`);
+        logger.debug(`📊 Remote LocalStats: Requesting local_stats from ${targetName} (${target.nodeId}) on channel ${channel}, hopLimit ${hopLimit}`);
 
         this.remoteLocalStatsLastSentAt.set(Number(target.nodeNum), Date.now());
         this.lastRemoteLocalStatsSentTime = Date.now();
@@ -2310,7 +2310,7 @@ class MeshtasticManager implements ISourceManager {
       if (now - this.lastAirtimeGateLogTime > 60000) {
         this.lastAirtimeGateLogTime = now;
         const sourceLabel = this.automationAirtimeCutoffSource === 'neighbors' ? 'neighbour-averaged' : 'local';
-        logger.info(
+        logger.debug(
           `⏸️  Automations paused on ${this.sourceId}: ${sourceLabel} Channel Utilization ${value}% exceeds cutoff ${this.automationAirtimeCutoffThreshold}%`
         );
       }
@@ -2384,12 +2384,12 @@ class MeshtasticManager implements ISourceManager {
 
     // If interval is 0, scanner is disabled
     if (this.remoteAdminScannerIntervalMinutes === 0) {
-      logger.info('🔑 Remote admin scanner is disabled');
+      logger.debug('🔑 Remote admin scanner is disabled');
       return;
     }
 
     const intervalMs = this.remoteAdminScannerIntervalMinutes * 60 * 1000;
-    logger.info(`🔑 Starting remote admin scanner with ${this.remoteAdminScannerIntervalMinutes} minute interval`);
+    logger.debug(`🔑 Starting remote admin scanner with ${this.remoteAdminScannerIntervalMinutes} minute interval`);
 
     this.remoteAdminScannerInterval = setInterval(async () => {
       // Check time window schedule
@@ -2468,12 +2468,12 @@ class MeshtasticManager implements ISourceManager {
 
     // If interval is 0 or time sync is disabled, scheduler is disabled
     if (this.timeSyncIntervalMinutes === 0 || !isEnabled) {
-      logger.info(`🕐 Time sync scheduler is disabled for source ${this.sourceId}`);
+      logger.debug(`🕐 Time sync scheduler is disabled for source ${this.sourceId}`);
       return;
     }
 
     const intervalMs = this.timeSyncIntervalMinutes * 60 * 1000;
-    logger.info(`🕐 Starting time sync scheduler for source ${this.sourceId} with ${this.timeSyncIntervalMinutes} minute interval`);
+    logger.debug(`🕐 Starting time sync scheduler for source ${this.sourceId} with ${this.timeSyncIntervalMinutes} minute interval`);
 
     this.timeSyncInterval = setInterval(async () => {
       if (this.isConnected && this.localNodeInfo) {
@@ -2504,7 +2504,7 @@ class MeshtasticManager implements ISourceManager {
 
     const targetNode = await databaseService.getNodeNeedingTimeSyncAsync(this.sourceId);
     if (!targetNode) {
-      logger.info('🕐 Time sync: No nodes available for syncing');
+      logger.debug('🕐 Time sync: No nodes available for syncing');
       return;
     }
 
@@ -2515,14 +2515,14 @@ class MeshtasticManager implements ISourceManager {
     }
 
     const targetName = targetNode.longName || targetNode.nodeId;
-    logger.info(`🕐 Time sync: Syncing time to ${targetName} (${targetNode.nodeId})`);
+    logger.debug(`🕐 Time sync: Syncing time to ${targetName} (${targetNode.nodeId})`);
 
     this.pendingTimeSyncs.add(targetNode.nodeNum);
 
     try {
       await this.sendSetTimeCommand(targetNode.nodeNum);
       await databaseService.nodes.updateNodeTimeSyncAsync(targetNode.nodeNum, Date.now(), this.sourceId);
-      logger.info(`🕐 Time sync: Successfully synced time to ${targetName}`);
+      logger.debug(`🕐 Time sync: Successfully synced time to ${targetName}`);
     } catch (error) {
       logger.error(`🕐 Time sync: Failed to sync time to ${targetName}:`, error);
     } finally {
@@ -2541,7 +2541,7 @@ class MeshtasticManager implements ISourceManager {
 
     const targetNode = await databaseService.getNodeNeedingRemoteAdminCheckAsync(this.localNodeInfo.nodeNum, this.sourceId);
     if (!targetNode) {
-      logger.info('🔑 Remote admin scan: No nodes available for scanning');
+      logger.debug('🔑 Remote admin scan: No nodes available for scanning');
       return;
     }
 
@@ -2552,7 +2552,7 @@ class MeshtasticManager implements ISourceManager {
     }
 
     const targetName = targetNode.longName || targetNode.nodeId;
-    logger.info(`🔑 Remote admin scan: Checking ${targetName} (${targetNode.nodeId}) for admin capability`);
+    logger.debug(`🔑 Remote admin scan: Checking ${targetName} (${targetNode.nodeId}) for admin capability`);
 
     await this.scanNodeForRemoteAdmin(targetNode.nodeNum);
   }
@@ -2583,7 +2583,7 @@ class MeshtasticManager implements ISourceManager {
       }
     } catch (error) {
       // Error - likely no admin access
-      logger.info(`🔑 Remote admin scan: Node ${nodeNum} scan failed - no admin access`);
+      logger.debug(`🔑 Remote admin scan: Node ${nodeNum} scan failed - no admin access`);
       logger.debug(`🔑 Remote admin scan error details:`, error);
       await databaseService.updateNodeRemoteAdminStatusAsync(nodeNum, false, null, this.sourceId);
       return { hasRemoteAdmin: false, metadata: null };
@@ -2706,7 +2706,7 @@ class MeshtasticManager implements ISourceManager {
         // (keys are mismatched so PKI-encrypted DMs would fail)
         const repairNodeData = await databaseService.nodes.getNode(node.nodeNum);
         const repairChannel = repairNodeData?.channel ?? 0;
-        logger.info(`🔐 Key repair: Sending node info exchange to ${nodeName} on channel ${repairChannel} (attempt ${node.attemptCount + 1}/${this.keyRepairMaxExchanges})`);
+        logger.debug(`🔐 Key repair: Sending node info exchange to ${nodeName} on channel ${repairChannel} (attempt ${node.attemptCount + 1}/${this.keyRepairMaxExchanges})`);
         try {
           await this.sendNodeInfoRequest(node.nodeNum, repairChannel);
 
@@ -2980,7 +2980,7 @@ class MeshtasticManager implements ISourceManager {
           }
         });
 
-        logger.info(`📢 Announce scheduler started with cron expression: ${scheduleExpression}`);
+        logger.debug(`📢 Announce scheduler started with cron expression: ${scheduleExpression}`);
       } else {
         logger.error(`❌ Invalid cron expression: ${scheduleExpression}`);
         return;
@@ -3005,7 +3005,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }, intervalMs);
 
-      logger.info(`📢 Announce scheduler started - next announcement in ${intervalHours} hours`);
+      logger.debug(`📢 Announce scheduler started - next announcement in ${intervalHours} hours`);
     }
 
     // Check if announce-on-start is enabled (per-source; applies to both cron and interval modes)
@@ -3133,7 +3133,7 @@ class MeshtasticManager implements ISourceManager {
 
       // Schedule the cron job
       const job = scheduleCron(trigger.cronExpression, async () => {
-        logger.info(`⏱️ Timer "${trigger.name}" triggered (cron: ${trigger.cronExpression})`);
+        logger.debug(`⏱️ Timer "${trigger.name}" triggered (cron: ${trigger.cronExpression})`);
         // Airtime cutoff: skip timer automations while the mesh is congested
         if (await this.isAutomationAirtimeGated()) {
           return;
@@ -3150,10 +3150,10 @@ class MeshtasticManager implements ISourceManager {
       });
 
       this.timerCronJobs.set(trigger.id, job);
-      logger.info(`⏱️ Scheduled timer "${trigger.name}" with cron: ${trigger.cronExpression}`);
+      logger.debug(`⏱️ Scheduled timer "${trigger.name}" with cron: ${trigger.cronExpression}`);
     }
 
-    logger.info(`⏱️ Timer scheduler started with ${this.timerCronJobs.size} active timer(s)`);
+    logger.debug(`⏱️ Timer scheduler started with ${this.timerCronJobs.size} active timer(s)`);
   }
 
   /**
@@ -3240,11 +3240,11 @@ class MeshtasticManager implements ISourceManager {
           this.executeWhileInsideGeofenceTrigger(trigger).catch(err => logger.error(`Error executing while-inside geofence trigger "${trigger.name}":`, err));
         }, intervalMs);
         this.geofenceWhileInsideTimers.set(trigger.id, timer);
-        logger.info(`📍 Geofence "${trigger.name}": while_inside timer set for every ${trigger.whileInsideIntervalMinutes} minute(s)`);
+        logger.debug(`📍 Geofence "${trigger.name}": while_inside timer set for every ${trigger.whileInsideIntervalMinutes} minute(s)`);
       }
     }
 
-    logger.info(`📍 Geofence engine started with ${enabledTriggers.length} active trigger(s)`);
+    logger.debug(`📍 Geofence engine started with ${enabledTriggers.length} active trigger(s)`);
   }
 
   /**
@@ -3329,7 +3329,7 @@ class MeshtasticManager implements ISourceManager {
         this.geofenceNodeState.set(trigger.id, stateSet);
         if (trigger.event === 'entry' || trigger.event === 'while_inside') {
           if (!this.isGeofenceCooldownActive(trigger.id, nodeNum, trigger.cooldownMinutes)) {
-            logger.info(`📍 Geofence "${trigger.name}": node ${nodeNum} entered`);
+            logger.debug(`📍 Geofence "${trigger.name}": node ${nodeNum} entered`);
             void this.executeGeofenceTrigger(trigger, nodeNum, lat, lng, 'entry');
           } else {
             logger.debug(`📍 Geofence "${trigger.name}": cooldown active for node ${nodeNum}, skipping entry`);
@@ -3341,7 +3341,7 @@ class MeshtasticManager implements ISourceManager {
         this.geofenceNodeState.set(trigger.id, stateSet);
         if (trigger.event === 'exit') {
           if (!this.isGeofenceCooldownActive(trigger.id, nodeNum, trigger.cooldownMinutes)) {
-            logger.info(`📍 Geofence "${trigger.name}": node ${nodeNum} exited`);
+            logger.debug(`📍 Geofence "${trigger.name}": node ${nodeNum} exited`);
             void this.executeGeofenceTrigger(trigger, nodeNum, lat, lng, 'exit');
           } else {
             logger.debug(`📍 Geofence "${trigger.name}": cooldown active for node ${nodeNum}, skipping exit`);
@@ -3376,12 +3376,12 @@ class MeshtasticManager implements ISourceManager {
         const isDM = trigger.channel === 'dm';
         // For DMs: use 3 attempts if verifyResponse is enabled, otherwise just 1 attempt
         const maxAttempts = isDM ? (trigger.verifyResponse ? 3 : 1) : 1;
-        logger.info(`📍 Geofence "${trigger.name}" sending text to ${isDM ? `DM (node ${nodeNum})` : `channel ${trigger.channel}`}${trigger.verifyResponse ? ' (with verification)' : ''}`);
+        logger.debug(`📍 Geofence "${trigger.name}" sending text to ${isDM ? `DM (node ${nodeNum})` : `channel ${trigger.channel}`}${trigger.verifyResponse ? ' (with verification)' : ''}`);
         this.messageQueue.enqueue(
           truncated,
           isDM ? nodeNum : 0,
           undefined,
-          () => logger.info(`✅ Geofence "${trigger.name}" message delivered to ${isDM ? `DM (node ${nodeNum})` : `channel ${trigger.channel}`}`),
+          () => logger.debug(`✅ Geofence "${trigger.name}" message delivered to ${isDM ? `DM (node ${nodeNum})` : `channel ${trigger.channel}`}`),
           (reason: string) => logger.warn(`❌ Geofence "${trigger.name}" message failed: ${reason}`),
           isDM ? undefined : trigger.channel as number,
           maxAttempts
@@ -3443,7 +3443,7 @@ class MeshtasticManager implements ISourceManager {
     }
 
     const startTime = Date.now();
-    logger.info(`📍 Executing geofence script: "${trigger.name}" (${eventType}) -> ${scriptPath}`);
+    logger.debug(`📍 Executing geofence script: "${trigger.name}" (${eventType}) -> ${scriptPath}`);
 
     try {
       const { execFile } = await import('child_process');
@@ -3531,19 +3531,19 @@ class MeshtasticManager implements ISourceManager {
               truncated,
               isDM ? nodeNum : 0,
               undefined,
-              () => logger.info(`✅ Geofence "${trigger.name}" script response delivered`),
+              () => logger.debug(`✅ Geofence "${trigger.name}" script response delivered`),
               (reason: string) => logger.warn(`❌ Geofence "${trigger.name}" script response failed: ${reason}`),
               isDM ? undefined : trigger.channel as number,
               maxAttempts
             );
           }
         } else {
-          logger.info(`📍 Geofence "${trigger.name}" script executed (channel=none, no mesh output)`);
+          logger.debug(`📍 Geofence "${trigger.name}" script executed (channel=none, no mesh output)`);
         }
       }
 
       const duration = Date.now() - startTime;
-      logger.info(`📍 Geofence "${trigger.name}" script completed successfully in ${duration}ms`);
+      logger.debug(`📍 Geofence "${trigger.name}" script completed successfully in ${duration}ms`);
       await this.updateGeofenceTriggerResult(trigger.id, 'success');
     } catch (error: any) {
       const duration = Date.now() - startTime;
@@ -3582,7 +3582,7 @@ class MeshtasticManager implements ISourceManager {
         continue;
       }
 
-      logger.info(`📍 Geofence "${trigger.name}": while_inside tick for node ${nodeNum}`);
+      logger.debug(`📍 Geofence "${trigger.name}": while_inside tick for node ${nodeNum}`);
       void this.executeGeofenceTrigger(trigger, nodeNum, eff.latitude, eff.longitude, 'while_inside');
     }
   }
@@ -3685,7 +3685,7 @@ class MeshtasticManager implements ISourceManager {
       return;
     }
 
-    logger.info(`⏱️ Executing timer script: ${scriptPath} -> ${resolvedPath}`);
+    logger.debug(`⏱️ Executing timer script: ${scriptPath} -> ${resolvedPath}`);
 
     // Determine interpreter based on file extension
     const ext = scriptPath.split('.').pop()?.toLowerCase();
@@ -3755,7 +3755,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       const duration = Date.now() - startTime;
-      logger.info(`⏱️ Timer "${triggerName}" completed successfully in ${duration}ms`);
+      logger.debug(`⏱️ Timer "${triggerName}" completed successfully in ${duration}ms`);
 
       // Parse JSON output and send messages to channel
       if (stdout && stdout.trim()) {
@@ -3795,7 +3795,7 @@ class MeshtasticManager implements ISourceManager {
         // Skip sending if channel is 'none' (script handles its own output)
         if (channel !== 'none') {
           // Send each response to the specified channel
-          logger.info(`⏱️ Enqueueing ${scriptResponses.length} timer response(s) to channel ${channel}`);
+          logger.debug(`⏱️ Enqueueing ${scriptResponses.length} timer response(s) to channel ${channel}`);
 
           scriptResponses.forEach((resp, index) => {
             const truncated = this.truncateMessageForMeshtastic(resp, 200);
@@ -3805,7 +3805,7 @@ class MeshtasticManager implements ISourceManager {
               0, // destination: 0 for channel broadcast
               undefined, // no reply-to packet ID for timer messages
               () => {
-                logger.info(`✅ Timer response ${index + 1}/${scriptResponses.length} delivered to channel ${channel}`);
+                logger.debug(`✅ Timer response ${index + 1}/${scriptResponses.length} delivered to channel ${channel}`);
               },
               (reason: string) => {
                 logger.warn(`❌ Timer response ${index + 1}/${scriptResponses.length} failed to channel ${channel}: ${reason}`);
@@ -3836,20 +3836,20 @@ class MeshtasticManager implements ISourceManager {
    */
   private async executeTimerTextMessage(triggerId: string, triggerName: string, message: string, channel: number): Promise<void> {
     try {
-      logger.info(`⏱️ Executing timer text message: "${triggerName}"`);
+      logger.debug(`⏱️ Executing timer text message: "${triggerName}"`);
 
       // Replace tokens using the same method as auto-announce
       const expandedMessage = await this.replaceAnnouncementTokens(message);
       const truncated = this.truncateMessageForMeshtastic(expandedMessage, 200);
 
-      logger.info(`⏱️ Timer "${triggerName}" sending to channel ${channel}: ${truncated.substring(0, 50)}${truncated.length > 50 ? '...' : ''}`);
+      logger.debug(`⏱️ Timer "${triggerName}" sending to channel ${channel}: ${truncated.substring(0, 50)}${truncated.length > 50 ? '...' : ''}`);
 
       this.messageQueue.enqueue(
         truncated,
         0, // destination: 0 for channel broadcast
         undefined, // no reply-to packet ID for timer messages
         () => {
-          logger.info(`✅ Timer "${triggerName}" message delivered to channel ${channel}`);
+          logger.debug(`✅ Timer "${triggerName}" message delivered to channel ${channel}`);
         },
         (reason: string) => {
           logger.warn(`❌ Timer "${triggerName}" message failed to channel ${channel}: ${reason}`);
@@ -4011,54 +4011,54 @@ class MeshtasticManager implements ISourceManager {
           await this.processDeviceMetadata(parsed.data);
           break;
         case 'config':
-          logger.info('⚙️ Received Config with keys:', Object.keys(parsed.data));
+          logger.debug('⚙️ Received Config with keys:', Object.keys(parsed.data));
           logger.debug('⚙️ Received Config:', JSON.stringify(parsed.data, null, 2));
 
           // Proto3 omits fields with default values (false for bool, 0 for numeric)
           // We need to ensure these fields exist with proper defaults
           if (parsed.data.lora) {
-            logger.info(`📊 Raw LoRa config from device:`, JSON.stringify(parsed.data.lora, null, 2));
+            logger.debug(`📊 Raw LoRa config from device:`, JSON.stringify(parsed.data.lora, null, 2));
 
             // Ensure boolean fields have explicit values (Proto3 omits false)
             if (parsed.data.lora.usePreset === undefined) {
               parsed.data.lora.usePreset = false;
-              logger.info('📊 Set usePreset to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set usePreset to false (was undefined - Proto3 default)');
             }
             if (parsed.data.lora.sx126xRxBoostedGain === undefined) {
               parsed.data.lora.sx126xRxBoostedGain = false;
-              logger.info('📊 Set sx126xRxBoostedGain to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set sx126xRxBoostedGain to false (was undefined - Proto3 default)');
             }
             if (parsed.data.lora.ignoreMqtt === undefined) {
               parsed.data.lora.ignoreMqtt = false;
-              logger.info('📊 Set ignoreMqtt to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set ignoreMqtt to false (was undefined - Proto3 default)');
             }
             if (parsed.data.lora.configOkToMqtt === undefined) {
               parsed.data.lora.configOkToMqtt = false;
-              logger.info('📊 Set configOkToMqtt to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set configOkToMqtt to false (was undefined - Proto3 default)');
             }
 
             // Ensure numeric fields have explicit values (Proto3 omits 0)
             if (parsed.data.lora.frequencyOffset === undefined) {
               parsed.data.lora.frequencyOffset = 0;
-              logger.info('📊 Set frequencyOffset to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set frequencyOffset to 0 (was undefined - Proto3 default)');
             }
             if (parsed.data.lora.overrideFrequency === undefined) {
               parsed.data.lora.overrideFrequency = 0;
-              logger.info('📊 Set overrideFrequency to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set overrideFrequency to 0 (was undefined - Proto3 default)');
             }
             if (parsed.data.lora.modemPreset === undefined) {
               parsed.data.lora.modemPreset = 0;
-              logger.info('📊 Set modemPreset to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set modemPreset to 0 (was undefined - Proto3 default)');
             }
             if (parsed.data.lora.channelNum === undefined) {
               parsed.data.lora.channelNum = 0;
-              logger.info('📊 Set channelNum to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set channelNum to 0 (was undefined - Proto3 default)');
             }
             // femLnaMode (FEM_LNA_Mode enum) — zero value DISABLED is a real mode, so
             // proto3 elision must default to 0, NOT to a non-zero fallback (see #3594).
             if (parsed.data.lora.femLnaMode === undefined) {
               parsed.data.lora.femLnaMode = 0;
-              logger.info('📊 Set femLnaMode to 0 (DISABLED - was undefined, Proto3 default)');
+              logger.debug('📊 Set femLnaMode to 0 (DISABLED - was undefined, Proto3 default)');
             }
 
             // Persist the per-source modem preset used as the slot-0
@@ -4069,68 +4069,68 @@ class MeshtasticManager implements ISourceManager {
 
           // Apply Proto3 defaults to device config
           if (parsed.data.device) {
-            logger.info(`📊 Raw Device config from device:`, JSON.stringify(parsed.data.device, null, 2));
+            logger.debug(`📊 Raw Device config from device:`, JSON.stringify(parsed.data.device, null, 2));
 
             // Ensure numeric fields have explicit values (Proto3 omits 0)
             if (parsed.data.device.nodeInfoBroadcastSecs === undefined) {
               parsed.data.device.nodeInfoBroadcastSecs = 0;
-              logger.info('📊 Set nodeInfoBroadcastSecs to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set nodeInfoBroadcastSecs to 0 (was undefined - Proto3 default)');
             }
           }
 
           // Apply Proto3 defaults to position config
           if (parsed.data.position) {
-            logger.info(`📊 Raw Position config from device:`, JSON.stringify(parsed.data.position, null, 2));
+            logger.debug(`📊 Raw Position config from device:`, JSON.stringify(parsed.data.position, null, 2));
 
             // Ensure boolean fields have explicit values (Proto3 omits false)
             if (parsed.data.position.positionBroadcastSmartEnabled === undefined) {
               parsed.data.position.positionBroadcastSmartEnabled = false;
-              logger.info('📊 Set positionBroadcastSmartEnabled to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set positionBroadcastSmartEnabled to false (was undefined - Proto3 default)');
             }
             if (parsed.data.position.fixedPosition === undefined) {
               parsed.data.position.fixedPosition = false;
-              logger.info('📊 Set fixedPosition to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set fixedPosition to false (was undefined - Proto3 default)');
             }
 
             // Ensure numeric fields have explicit values (Proto3 omits 0)
             if (parsed.data.position.positionBroadcastSecs === undefined) {
               parsed.data.position.positionBroadcastSecs = 0;
-              logger.info('📊 Set positionBroadcastSecs to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set positionBroadcastSecs to 0 (was undefined - Proto3 default)');
             }
           }
 
           // Apply Proto3 defaults to position config
           if (parsed.data.position) {
-            logger.info(`📊 Raw Position config from device:`, JSON.stringify(parsed.data.position, null, 2));
+            logger.debug(`📊 Raw Position config from device:`, JSON.stringify(parsed.data.position, null, 2));
 
             // Ensure boolean fields have explicit values (Proto3 omits false)
             if (parsed.data.position.positionBroadcastSmartEnabled === undefined) {
               parsed.data.position.positionBroadcastSmartEnabled = false;
-              logger.info('📊 Set positionBroadcastSmartEnabled to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set positionBroadcastSmartEnabled to false (was undefined - Proto3 default)');
             }
 
             if (parsed.data.position.fixedPosition === undefined) {
               parsed.data.position.fixedPosition = false;
-              logger.info('📊 Set fixedPosition to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set fixedPosition to false (was undefined - Proto3 default)');
             }
 
             // Ensure numeric fields have explicit values (Proto3 omits 0)
             if (parsed.data.position.positionBroadcastSecs === undefined) {
               parsed.data.position.positionBroadcastSecs = 0;
-              logger.info('📊 Set positionBroadcastSecs to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set positionBroadcastSecs to 0 (was undefined - Proto3 default)');
             }
 
-            logger.info(`📊 Position config after Proto3 defaults: positionBroadcastSecs=${parsed.data.position.positionBroadcastSecs}, positionBroadcastSmartEnabled=${parsed.data.position.positionBroadcastSmartEnabled}, fixedPosition=${parsed.data.position.fixedPosition}`);
+            logger.debug(`📊 Position config after Proto3 defaults: positionBroadcastSecs=${parsed.data.position.positionBroadcastSecs}, positionBroadcastSmartEnabled=${parsed.data.position.positionBroadcastSmartEnabled}, fixedPosition=${parsed.data.position.fixedPosition}`);
           }
 
           // Merge the actual device configuration (don't overwrite)
           this.actualDeviceConfig = { ...this.actualDeviceConfig, ...parsed.data };
-          logger.info('📊 Merged actualDeviceConfig now has keys:', Object.keys(this.actualDeviceConfig));
-          logger.info('📊 actualDeviceConfig.lora present:', !!this.actualDeviceConfig?.lora);
+          logger.debug('📊 Merged actualDeviceConfig now has keys:', Object.keys(this.actualDeviceConfig));
+          logger.debug('📊 actualDeviceConfig.lora present:', !!this.actualDeviceConfig?.lora);
           if (parsed.data.lora) {
-            logger.info(`📊 Received LoRa config - hopLimit=${parsed.data.lora.hopLimit}, usePreset=${this.actualDeviceConfig.lora.usePreset}, frequencyOffset=${this.actualDeviceConfig.lora.frequencyOffset}`);
+            logger.debug(`📊 Received LoRa config - hopLimit=${parsed.data.lora.hopLimit}, usePreset=${this.actualDeviceConfig.lora.usePreset}, frequencyOffset=${this.actualDeviceConfig.lora.frequencyOffset}`);
           }
-          logger.info(`📊 Current actualDeviceConfig.lora.hopLimit=${this.actualDeviceConfig?.lora?.hopLimit}`);
+          logger.debug(`📊 Current actualDeviceConfig.lora.hopLimit=${this.actualDeviceConfig?.lora?.hopLimit}`);
           logger.debug('📊 Merged actualDeviceConfig now has:', Object.keys(this.actualDeviceConfig));
 
           // Extract local node's public key from security config and save to database
@@ -4138,7 +4138,7 @@ class MeshtasticManager implements ISourceManager {
             const publicKeyBytes = parsed.data.security.publicKey;
             if (publicKeyBytes && publicKeyBytes.length > 0) {
               const publicKeyBase64 = Buffer.from(publicKeyBytes).toString('base64');
-              logger.info(`🔐 Received local node public key from security config: ${publicKeyBase64.substring(0, 20)}...`);
+              logger.debug(`🔐 Received local node public key from security config: ${publicKeyBase64.substring(0, 20)}...`);
 
               // Get local node info to update database
               const localNodeNum = this.localNodeInfo?.nodeNum;
@@ -4164,7 +4164,7 @@ class MeshtasticManager implements ISourceManager {
                   }
 
                   await databaseService.upsertNodeAsync(updateData, this.sourceId);
-                  logger.info(`💾 Saved local node public key to database for ${localNodeId}`);
+                  logger.debug(`💾 Saved local node public key to database for ${localNodeId}`);
                 }).catch(async (err) => {
                   // If low entropy check fails, still save the key
                   await databaseService.upsertNodeAsync({
@@ -4174,7 +4174,7 @@ class MeshtasticManager implements ISourceManager {
                     hasPKC: true
                   }, this.sourceId);
                   logger.warn(`⚠️ Could not check low-entropy key status:`, err);
-                  logger.info(`💾 Saved local node public key to database for ${localNodeId}`);
+                  logger.debug(`💾 Saved local node public key to database for ${localNodeId}`);
                 });
               } else {
                 logger.warn(`⚠️ Received security config with public key but local node info not yet available`);
@@ -4183,52 +4183,52 @@ class MeshtasticManager implements ISourceManager {
           }
           break;
         case 'moduleConfig':
-          logger.info('⚙️ Received Module Config with keys:', Object.keys(parsed.data));
+          logger.debug('⚙️ Received Module Config with keys:', Object.keys(parsed.data));
           logger.debug('⚙️ Received Module Config:', JSON.stringify(parsed.data, null, 2));
 
           // Apply Proto3 defaults to MQTT config
           if (parsed.data.mqtt) {
-            logger.info(`📊 Raw MQTT config from device:`, JSON.stringify(parsed.data.mqtt, null, 2));
+            logger.debug(`📊 Raw MQTT config from device:`, JSON.stringify(parsed.data.mqtt, null, 2));
 
             // Ensure boolean fields have explicit values (Proto3 omits false)
             if (parsed.data.mqtt.enabled === undefined) {
               parsed.data.mqtt.enabled = false;
-              logger.info('📊 Set mqtt.enabled to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set mqtt.enabled to false (was undefined - Proto3 default)');
             }
             if (parsed.data.mqtt.encryptionEnabled === undefined) {
               parsed.data.mqtt.encryptionEnabled = false;
-              logger.info('📊 Set mqtt.encryptionEnabled to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set mqtt.encryptionEnabled to false (was undefined - Proto3 default)');
             }
             if (parsed.data.mqtt.jsonEnabled === undefined) {
               parsed.data.mqtt.jsonEnabled = false;
-              logger.info('📊 Set mqtt.jsonEnabled to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set mqtt.jsonEnabled to false (was undefined - Proto3 default)');
             }
           }
 
           // Apply Proto3 defaults to NeighborInfo config
           if (parsed.data.neighborInfo) {
-            logger.info(`📊 Raw NeighborInfo config from device:`, JSON.stringify(parsed.data.neighborInfo, null, 2));
+            logger.debug(`📊 Raw NeighborInfo config from device:`, JSON.stringify(parsed.data.neighborInfo, null, 2));
 
             // Ensure boolean fields have explicit values (Proto3 omits false)
             if (parsed.data.neighborInfo.enabled === undefined) {
               parsed.data.neighborInfo.enabled = false;
-              logger.info('📊 Set neighborInfo.enabled to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set neighborInfo.enabled to false (was undefined - Proto3 default)');
             }
             if (parsed.data.neighborInfo.transmitOverLora === undefined) {
               parsed.data.neighborInfo.transmitOverLora = false;
-              logger.info('📊 Set neighborInfo.transmitOverLora to false (was undefined - Proto3 default)');
+              logger.debug('📊 Set neighborInfo.transmitOverLora to false (was undefined - Proto3 default)');
             }
 
             // Ensure numeric fields have explicit values (Proto3 omits 0)
             if (parsed.data.neighborInfo.updateInterval === undefined) {
               parsed.data.neighborInfo.updateInterval = 0;
-              logger.info('📊 Set neighborInfo.updateInterval to 0 (was undefined - Proto3 default)');
+              logger.debug('📊 Set neighborInfo.updateInterval to 0 (was undefined - Proto3 default)');
             }
           }
 
           // Merge the actual module configuration (don't overwrite)
           this.actualModuleConfig = { ...this.actualModuleConfig, ...parsed.data };
-          logger.info('📊 Merged actualModuleConfig now has keys:', Object.keys(this.actualModuleConfig));
+          logger.debug('📊 Merged actualModuleConfig now has keys:', Object.keys(this.actualModuleConfig));
           break;
         case 'channel':
           await this.processChannelProtobuf(parsed.data);
@@ -4258,7 +4258,7 @@ class MeshtasticManager implements ISourceManager {
           if (this.isCapturingInitConfig && !this.configCaptureComplete) {
             this.configCaptureComplete = true;
             this.isCapturingInitConfig = false;
-            logger.info(`📸 Init config capture complete! Captured ${this.initConfigCache.length} messages for virtual node replay`);
+            logger.debug(`📸 Init config capture complete! Captured ${this.initConfigCache.length} messages for virtual node replay`);
 
             // Detect channel moves/swaps from external sources (#2425)
             await this.detectAndMigrateChannelChanges();
@@ -4431,7 +4431,7 @@ class MeshtasticManager implements ISourceManager {
 
           // Delete old ghost node (cascades messages, traceroutes, neighbors, telemetry)
           await databaseService.deleteNodeAsync(prevNum, this.sourceId);
-          logger.info(`🗑️ Deleted old ghost node ${previousNodeId} (${prevNum})`);
+          logger.debug(`🗑️ Deleted old ghost node ${previousNodeId} (${prevNum})`);
 
           // Suppress ghost resurrection — incoming mesh traffic may still reference the old nodeNum
           await databaseService.suppressGhostNodeAsync(prevNum);
@@ -4442,7 +4442,7 @@ class MeshtasticManager implements ISourceManager {
 
           // Clear init config cache to force VN clients to get fresh config with correct identity
           this.initConfigCache = [];
-          logger.info(`📸 Cleared init config cache due to same-device reboot merge`);
+          logger.debug(`📸 Cleared init config cache due to same-device reboot merge`);
 
           // Set localNodeInfo with new nodeNum and merged metadata
           const mergedLongName = newNode?.longName || oldNode?.longName || null;
@@ -4462,7 +4462,7 @@ class MeshtasticManager implements ISourceManager {
           setTimeout(async () => {
             try {
               await this.sendRemoveNode(prevNumToRemove);
-              logger.info(`✅ Removed old nodeNum ${previousNodeId} (${prevNumToRemove}) from device NodeDB after reboot merge`);
+              logger.debug(`✅ Removed old nodeNum ${previousNodeId} (${prevNumToRemove}) from device NodeDB after reboot merge`);
             } catch (err) {
               logger.warn(`⚠️ Could not remove old nodeNum ${previousNodeId} (${prevNumToRemove}) from device NodeDB (non-fatal):`, err);
             }
@@ -4477,7 +4477,7 @@ class MeshtasticManager implements ISourceManager {
           logger.info(`⚠️ Virtual node clients may briefly show the old node ID until they reconnect`);
           // Clear the init config cache to force fresh data for virtual node clients
           this.initConfigCache = [];
-          logger.info(`📸 Cleared init config cache due to node ID change`);
+          logger.debug(`📸 Cleared init config cache due to node ID change`);
 
           // Update stored device_id if new device provides one
           if (deviceId) {
@@ -4508,7 +4508,7 @@ class MeshtasticManager implements ISourceManager {
 
     // Clear any erroneous security flags on the local node — we can't have a key mismatch with ourselves
     if (existingNode?.keyMismatchDetected || existingNode?.keySecurityIssueDetails) {
-      logger.info(`🔐 Clearing erroneous security flags on local node ${nodeId}`);
+      logger.debug(`🔐 Clearing erroneous security flags on local node ${nodeId}`);
       await databaseService.upsertNodeAsync({
         nodeNum,
         nodeId,
@@ -4660,7 +4660,7 @@ class MeshtasticManager implements ISourceManager {
       ...this.actualDeviceConfig[section],
       ...values
     };
-    logger.info(`📊 Updated cached device config section '${section}':`, Object.keys(values));
+    logger.debug(`📊 Updated cached device config section '${section}':`, Object.keys(values));
   }
 
   /**
@@ -4690,7 +4690,7 @@ class MeshtasticManager implements ISourceManager {
     if (enabled !== 'true') return;
     const { publicKey, privateKey } = this.getSecurityKeys();
     if (!privateKey) {
-      logger.info(`[MeshtasticManager:${this.sourceId}] PKI DM decryption enabled but device exposed no private key`);
+      logger.debug(`[MeshtasticManager:${this.sourceId}] PKI DM decryption enabled but device exposed no private key`);
       return;
     }
     const priv = Buffer.from(privateKey, 'base64');
@@ -4707,7 +4707,7 @@ class MeshtasticManager implements ISourceManager {
     // decrypted by this key regardless of which source received the packet.
     const nodeNum = this.localNodeInfo?.nodeNum ?? null;
     await store.store(this.sourceId, nodeNum, priv, publicKey);
-    logger.info(`🔑 [MeshtasticManager:${this.sourceId}] Stored local PKI private key (node ${nodeNum}) for DM decryption`);
+    logger.debug(`🔑 [MeshtasticManager:${this.sourceId}] Stored local PKI private key (node ${nodeNum}) for DM decryption`);
   }
 
   /**
@@ -4771,7 +4771,7 @@ class MeshtasticManager implements ISourceManager {
    * Get the current device configuration
    */
   getCurrentConfig(): { deviceConfig: any; moduleConfig: any; localNodeInfo: any; supportedModules: { statusmessage: boolean; trafficManagement: boolean } } {
-    logger.info(`[CONFIG] getCurrentConfig called - hopLimit=${this.actualDeviceConfig?.lora?.hopLimit}`);
+    logger.debug(`[CONFIG] getCurrentConfig called - hopLimit=${this.actualDeviceConfig?.lora?.hopLimit}`);
 
     // Apply Proto3 defaults to device config if it exists
     let deviceConfig = this.actualDeviceConfig || {};
@@ -4811,7 +4811,7 @@ class MeshtasticManager implements ISourceManager {
         lora: loraConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning lora config with usePreset=${loraConfigWithDefaults.usePreset}, sx126xRxBoostedGain=${loraConfigWithDefaults.sx126xRxBoostedGain}, ignoreMqtt=${loraConfigWithDefaults.ignoreMqtt}, configOkToMqtt=${loraConfigWithDefaults.configOkToMqtt}`);
+      logger.debug(`[CONFIG] Returning lora config with usePreset=${loraConfigWithDefaults.usePreset}, sx126xRxBoostedGain=${loraConfigWithDefaults.sx126xRxBoostedGain}, ignoreMqtt=${loraConfigWithDefaults.ignoreMqtt}, configOkToMqtt=${loraConfigWithDefaults.configOkToMqtt}`);
     }
 
     // Apply Proto3 defaults to position config if it exists
@@ -4830,7 +4830,7 @@ class MeshtasticManager implements ISourceManager {
         position: positionConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning position config with positionBroadcastSecs=${positionConfigWithDefaults.positionBroadcastSecs}, positionBroadcastSmartEnabled=${positionConfigWithDefaults.positionBroadcastSmartEnabled}, fixedPosition=${positionConfigWithDefaults.fixedPosition}`);
+      logger.debug(`[CONFIG] Returning position config with positionBroadcastSecs=${positionConfigWithDefaults.positionBroadcastSecs}, positionBroadcastSmartEnabled=${positionConfigWithDefaults.positionBroadcastSmartEnabled}, fixedPosition=${positionConfigWithDefaults.fixedPosition}`);
     }
 
     // Apply Proto3 defaults to security config if it exists
@@ -4849,7 +4849,7 @@ class MeshtasticManager implements ISourceManager {
         security: securityConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning security config with isManaged=${securityConfigWithDefaults.isManaged}, serialEnabled=${securityConfigWithDefaults.serialEnabled}, debugLogApiEnabled=${securityConfigWithDefaults.debugLogApiEnabled}, adminChannelEnabled=${securityConfigWithDefaults.adminChannelEnabled}`);
+      logger.debug(`[CONFIG] Returning security config with isManaged=${securityConfigWithDefaults.isManaged}, serialEnabled=${securityConfigWithDefaults.serialEnabled}, debugLogApiEnabled=${securityConfigWithDefaults.debugLogApiEnabled}, adminChannelEnabled=${securityConfigWithDefaults.adminChannelEnabled}`);
     }
 
     // Apply Proto3 defaults to module config if it exists
@@ -4873,7 +4873,7 @@ class MeshtasticManager implements ISourceManager {
         mqtt: mqttConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning MQTT config with enabled=${mqttConfigWithDefaults.enabled}, encryptionEnabled=${mqttConfigWithDefaults.encryptionEnabled}, jsonEnabled=${mqttConfigWithDefaults.jsonEnabled}`);
+      logger.debug(`[CONFIG] Returning MQTT config with enabled=${mqttConfigWithDefaults.enabled}, encryptionEnabled=${mqttConfigWithDefaults.encryptionEnabled}, jsonEnabled=${mqttConfigWithDefaults.jsonEnabled}`);
     }
 
     // Apply Proto3 defaults to NeighborInfo module config
@@ -4891,7 +4891,7 @@ class MeshtasticManager implements ISourceManager {
         neighborInfo: neighborInfoConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning NeighborInfo config with enabled=${neighborInfoConfigWithDefaults.enabled}, updateInterval=${neighborInfoConfigWithDefaults.updateInterval}, transmitOverLora=${neighborInfoConfigWithDefaults.transmitOverLora}`);
+      logger.debug(`[CONFIG] Returning NeighborInfo config with enabled=${neighborInfoConfigWithDefaults.enabled}, updateInterval=${neighborInfoConfigWithDefaults.updateInterval}, transmitOverLora=${neighborInfoConfigWithDefaults.transmitOverLora}`);
     }
 
     // Apply Proto3 defaults to Telemetry module config
@@ -4920,7 +4920,7 @@ class MeshtasticManager implements ISourceManager {
         telemetry: telemetryConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning Telemetry config with deviceTelemetryEnabled=${telemetryConfigWithDefaults.deviceTelemetryEnabled}, healthMeasurementEnabled=${telemetryConfigWithDefaults.healthMeasurementEnabled}`);
+      logger.debug(`[CONFIG] Returning Telemetry config with deviceTelemetryEnabled=${telemetryConfigWithDefaults.deviceTelemetryEnabled}, healthMeasurementEnabled=${telemetryConfigWithDefaults.healthMeasurementEnabled}`);
     }
 
     // Convert network config IP addresses from uint32 to string format for frontend
@@ -4953,7 +4953,7 @@ class MeshtasticManager implements ISourceManager {
         statusmessage: statusMessageConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning StatusMessage config with nodeStatus="${statusMessageConfigWithDefaults.nodeStatus}"`);
+      logger.debug(`[CONFIG] Returning StatusMessage config with nodeStatus="${statusMessageConfigWithDefaults.nodeStatus}"`);
     }
 
     // Apply Proto3 defaults to TrafficManagement module config (v2.7.22 schema)
@@ -4982,7 +4982,7 @@ class MeshtasticManager implements ISourceManager {
         trafficManagement: trafficManagementConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning TrafficManagement config with enabled=${trafficManagementConfigWithDefaults.enabled}`);
+      logger.debug(`[CONFIG] Returning TrafficManagement config with enabled=${trafficManagementConfigWithDefaults.enabled}`);
     }
 
     return {
@@ -5017,7 +5017,7 @@ class MeshtasticManager implements ISourceManager {
       this.localNodeInfo.hasEthernet = metadata.hasEthernet === true;
       this.localNodeInfo.hasBluetooth = metadata.hasBluetooth === true;
       if (this.isLocalNodeBridged()) {
-        logger.info('🌉 Connected node reports no native WiFi/Ethernet — treating as a bridged node (OTA firmware update disabled)');
+        logger.debug('🌉 Connected node reports no native WiFi/Ethernet — treating as a bridged node (OTA firmware update disabled)');
       }
     }
 
@@ -5113,7 +5113,7 @@ class MeshtasticManager implements ISourceManager {
           }
 
           if (channelRole === 0 && channel.role === undefined && channel.index > 0) {
-            logger.info(`📡 Channel ${channel.index} arrived empty — normalizing role to DISABLED(0) (#2666)`);
+            logger.debug(`📡 Channel ${channel.index} arrived empty — normalizing role to DISABLED(0) (#2666)`);
           }
 
           logger.debug(`📡 Saving channel ${channel.index} (${displayName}) - role: ${channelRole}`);
@@ -5181,7 +5181,7 @@ class MeshtasticManager implements ISourceManager {
           };
           decryptedBy = 'server';
           decryptedChannelId = decryptionResult.channelDatabaseId ?? null;
-          logger.info(
+          logger.trace(
             `🔓 Server decrypted packet ${packetId} from ${fromNum} using channel "${decryptionResult.channelName}" (portnum=${decryptionResult.portnum})`
           );
         }
@@ -5208,7 +5208,7 @@ class MeshtasticManager implements ISourceManager {
           if (pki) {
             meshPacket.decoded = { portnum: pki.portnum, payload: pki.payload };
             decryptedBy = 'server';
-            logger.info(`🔓🔑 Server PKI-decrypted DM ${meshPacket.id} from ${fromNum} to ${toNum} (portnum=${pki.portnum})`);
+            logger.debug(`🔓🔑 Server PKI-decrypted DM ${meshPacket.id} from ${fromNum} to ${toNum} (portnum=${pki.portnum})`);
           }
         } catch (err) {
           logger.debug(`PKI decryption attempt failed for packet ${meshPacket.id}:`, err);
@@ -5621,7 +5621,7 @@ class MeshtasticManager implements ISourceManager {
   private async handleClientNotification(data: ParsedClientNotification): Promise<void> {
     // `message` is device-controlled — sanitize before logging or forwarding it.
     const message = sanitizeNotificationMessage(data.message ?? '');
-    logger.info(`🔔 [${this.sourceId}] Device notification (level ${data.level}): ${message}`);
+    logger.debug(`🔔 [${this.sourceId}] Device notification (level ${data.level}): ${message}`);
 
     // (1) Reconcile a protected-node-cap refusal (firmware 2.8+). Runs
     // independently of the toast policy below. `this.sourceId` is always set
@@ -5978,7 +5978,7 @@ class MeshtasticManager implements ISourceManager {
           const messageText = new TextDecoder('utf-8').decode(
             textBytes instanceof Uint8Array ? textBytes : new Uint8Array(textBytes)
           );
-          logger.info(`📦 S&F ${rrName} from ${fromNodeId}: "${messageText.substring(0, 50)}"`);
+          logger.debug(`📦 S&F ${rrName} from ${fromNodeId}: "${messageText.substring(0, 50)}"`);
 
           // Dedup: check if we already have this message from the original transmission.
           // The firmware preserves the original packet ID in meshPacket.id.
@@ -6004,7 +6004,7 @@ class MeshtasticManager implements ISourceManager {
         case StoreForwardRequestResponse.ROUTER_HEARTBEAT: {
           const period = decoded.heartbeat?.period ?? 0;
           const secondary = decoded.heartbeat?.secondary ?? 0;
-          logger.info(`📦 S&F heartbeat from ${fromNodeId}: period=${period}s, secondary=${secondary}`);
+          logger.debug(`📦 S&F heartbeat from ${fromNodeId}: period=${period}s, secondary=${secondary}`);
 
           // Mark this node as a Store & Forward server
           await databaseService.upsertNodeAsync({
@@ -6020,7 +6020,7 @@ class MeshtasticManager implements ISourceManager {
         case StoreForwardRequestResponse.ROUTER_STATS: {
           const stats = decoded.stats;
           if (stats) {
-            logger.info(`📦 S&F stats from ${fromNodeId}: total=${stats.messagesTotal ?? 0}, saved=${stats.messagesSaved ?? 0}, max=${stats.messagesMax ?? 0}, uptime=${stats.upTime ?? 0}s`);
+            logger.debug(`📦 S&F stats from ${fromNodeId}: total=${stats.messagesTotal ?? 0}, saved=${stats.messagesSaved ?? 0}, max=${stats.messagesMax ?? 0}, uptime=${stats.upTime ?? 0}s`);
           }
           break;
         }
@@ -6028,7 +6028,7 @@ class MeshtasticManager implements ISourceManager {
         case StoreForwardRequestResponse.ROUTER_HISTORY: {
           const history = decoded.history;
           if (history) {
-            logger.info(`📦 S&F history from ${fromNodeId}: ${history.historyMessages ?? 0} messages, window=${history.window ?? 0}min`);
+            logger.debug(`📦 S&F history from ${fromNodeId}: ${history.historyMessages ?? 0} messages, window=${history.window ?? 0}min`);
           }
           break;
         }
@@ -6181,7 +6181,7 @@ class MeshtasticManager implements ISourceManager {
           if (pendingExchangeRequest && pendingExchangeRequest.requestId != null) {
             // Mark the position exchange request as delivered
             await databaseService.messages.updateMessageDeliveryState(pendingExchangeRequest.requestId!, 'delivered');
-            logger.info(`📍 Position exchange acknowledged: Received position from ${nodeId}, marking request message as delivered`);
+            logger.debug(`📍 Position exchange acknowledged: Received position from ${nodeId}, marking request message as delivered`);
           }
         }
 
@@ -6271,7 +6271,7 @@ class MeshtasticManager implements ISourceManager {
         const isLocalNode = this.localNodeInfo && fromNum === this.localNodeInfo.nodeNum;
         const hasFixedPositionEnabled = this.actualDeviceConfig?.position?.fixedPosition === true;
         if (isLocalNode && hasFixedPositionEnabled) {
-          logger.info(`🗺️ Skipping position update for local node ${nodeId}: fixedPosition is enabled, position should only be set via config. Received: ${coords.latitude}, ${coords.longitude}`);
+          logger.debug(`🗺️ Skipping position update for local node ${nodeId}: fixedPosition is enabled, position should only be set via config. Received: ${coords.latitude}, ${coords.longitude}`);
           // Still update lastHeard and technical fields, just not lat/lon/alt
           const technicalData: any = {
             nodeNum: fromNum,
@@ -6418,7 +6418,7 @@ class MeshtasticManager implements ISourceManager {
         // Convert Uint8Array to base64 for storage
         nodeData.publicKey = Buffer.from(user.publicKey).toString('base64');
         nodeData.hasPKC = true;
-        logger.info(`🔐 Received NodeInfo with public key for ${nodeId} (${user.longName}): ${nodeData.publicKey.substring(0, 20)}... (${user.publicKey.length} bytes)`);
+        logger.debug(`🔐 Received NodeInfo with public key for ${nodeId} (${user.longName}): ${nodeData.publicKey.substring(0, 20)}... (${user.publicKey.length} bytes)`);
 
         // Check for key security issues
         const { checkLowEntropyKey } = await import('../services/lowEntropyKeyService.js');
@@ -6501,10 +6501,10 @@ class MeshtasticManager implements ISourceManager {
 
             if (oldKey !== newKey) {
               // Key has changed - the mismatch is fixed via new key
-              logger.info(`🔐 Key mismatch RESOLVED for node ${nodeId} (${user.longName}) - received new key`);
+              logger.debug(`🔐 Key mismatch RESOLVED for node ${nodeId} (${user.longName}) - received new key`);
             } else {
               // Keys now match - the mismatch was fixed (e.g., device re-synced after purge)
-              logger.info(`🔐 Key mismatch RESOLVED for node ${nodeId} (${user.longName}) - keys now match`);
+              logger.debug(`🔐 Key mismatch RESOLVED for node ${nodeId} (${user.longName}) - keys now match`);
             }
 
             nodeData.keyMismatchDetected = false;
@@ -6866,7 +6866,7 @@ class MeshtasticManager implements ISourceManager {
         logger.debug(`🗺️ Outgoing traceroute response from local node ${fromNodeId} — will record without segments`);
       }
 
-      logger.info(`🗺️ Traceroute response from ${fromNodeId}:`, JSON.stringify(routeDiscovery, null, 2));
+      logger.debug(`🗺️ Traceroute response from ${fromNodeId}:`, JSON.stringify(routeDiscovery, null, 2));
 
       // Ensure from node exists in database (don't overwrite existing names)
       const existingFromNode = await databaseService.nodes.getNode(fromNum);
@@ -7344,12 +7344,12 @@ class MeshtasticManager implements ISourceManager {
           this.truncateMessageForMeshtastic(compactMsg, 200),
           pending.isDM ? pending.replyToNodeNum : 0,
           undefined,
-          () => { logger.info(`✅ Autoresponder traceroute result reply delivered`); },
+          () => { logger.debug(`✅ Autoresponder traceroute result reply delivered`); },
           (reason: string) => { logger.warn(`❌ Autoresponder traceroute result reply failed: ${reason}`); },
           pending.isDM ? undefined : pending.replyChannel,
           1
         );
-        logger.info(`🔍 Autoresponder traceroute result for ${fromNodeId} replied to !${pending.replyToNodeNum.toString(16).padStart(8, '0')}`);
+        logger.debug(`🔍 Autoresponder traceroute result for ${fromNodeId} replied to !${pending.replyToNodeNum.toString(16).padStart(8, '0')}`);
       }
 
       // Send notification for successful traceroute
@@ -7482,7 +7482,7 @@ class MeshtasticManager implements ISourceManager {
 
           // ACK from our own radio - message transmitted to mesh
           if (fromNodeId === localNodeId) {
-            logger.info(`📡 ACK from our own radio ${fromNodeId} for requestId ${requestId} - message transmitted to mesh`);
+            logger.debug(`📡 ACK from our own radio ${fromNodeId} for requestId ${requestId} - message transmitted to mesh`);
             const updated = await databaseService.messages.updateMessageDeliveryState(requestId, 'delivered');
             if (updated) {
               logger.debug(`💾 Marked message ${requestId} as delivered (transmitted)`);
@@ -7501,7 +7501,7 @@ class MeshtasticManager implements ISourceManager {
 
           // ACK from target node - message confirmed received by recipient (only for DMs)
           if (fromNodeId === targetNodeId && isDM) {
-            logger.info(`✅ ACK received from TARGET node ${fromNodeId} for requestId ${requestId} - message confirmed`);
+            logger.debug(`✅ ACK received from TARGET node ${fromNodeId} for requestId ${requestId} - message confirmed`);
             const updated = await databaseService.messages.updateMessageDeliveryState(requestId, 'confirmed');
             if (updated) {
               logger.debug(`💾 Marked message ${requestId} as confirmed (received by target)`);
@@ -7652,7 +7652,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // Update message in database to mark delivery as failed
-      logger.info(`❌ Marking message ${requestId} as failed due to routing error from ${isDM ? 'target' : 'mesh'}: ${errorName}`);
+      logger.debug(`❌ Marking message ${requestId} as failed due to routing error from ${isDM ? 'target' : 'mesh'}: ${errorName}`);
       await databaseService.messages.updateMessageDeliveryState(requestId, 'failed');
       // Emit WebSocket event for real-time delivery failure update
       dataEventEmitter.emitRoutingUpdate({ requestId, status: 'nak', errorReason: errorName }, this.sourceId);
@@ -7725,7 +7725,7 @@ class MeshtasticManager implements ISourceManager {
         { destination, packetId, waypointId: waypoint.id, expire: waypoint.expire },
       );
 
-      logger.info(`📍 Waypoint broadcast id=${waypoint.id} (${waypoint.name ?? ''}) packetId=${packetId}`);
+      logger.debug(`📍 Waypoint broadcast id=${waypoint.id} (${waypoint.name ?? ''}) packetId=${packetId}`);
       return packetId;
     } catch (error) {
       logger.error('Error broadcasting waypoint:', error);
@@ -7757,7 +7757,7 @@ class MeshtasticManager implements ISourceManager {
       const fromNum = Number(meshPacket.from);
       const fromNodeId = `!${fromNum.toString(16).padStart(8, '0')}`;
 
-      logger.info(`🏠 Neighbor info received from ${fromNodeId}:`, neighborInfo);
+      logger.debug(`🏠 Neighbor info received from ${fromNodeId}:`, neighborInfo);
 
       // MQTT-sourced neighbor info IS persisted (issue #3271): the global, batch
       // position estimator pools the MQTT neighbor graph for extra resolution.
@@ -7783,7 +7783,7 @@ class MeshtasticManager implements ISourceManager {
 
       // Process each neighbor in the list
       if (neighborInfo.neighbors && Array.isArray(neighborInfo.neighbors)) {
-        logger.info(`📡 Processing ${neighborInfo.neighbors.length} neighbors from ${fromNodeId}`);
+        logger.debug(`📡 Processing ${neighborInfo.neighbors.length} neighbors from ${fromNodeId}`);
 
         // Validate and collect neighbor node numbers upfront
         const validNeighbors: Array<{ nodeNum: number; snr: number | null; lastRxTime: number | null }> = [];
@@ -7827,7 +7827,7 @@ class MeshtasticManager implements ISourceManager {
               shortName: neighborNodeId.slice(-4),
               hopsAway: senderHopsAway + 1,
             }, this.sourceId);
-            logger.info(`➕ Created new node ${neighborNodeId} with hopsAway=${senderHopsAway + 1} (no lastHeard — indirectly discovered)`);
+            logger.debug(`➕ Created new node ${neighborNodeId} with hopsAway=${senderHopsAway + 1} (no lastHeard — indirectly discovered)`);
           }
         }
 
@@ -7931,7 +7931,7 @@ class MeshtasticManager implements ISourceManager {
       if (nodeInfo.isFavorite !== undefined) {
         if (existingNode?.favoriteLocked) {
           if (existingNode.isFavorite !== nodeInfo.isFavorite) {
-            logger.info(`🔒 Node ${nodeId} favoriteLocked — preserving DB isFavorite=${existingNode.isFavorite}, re-syncing to device (device reported ${nodeInfo.isFavorite})`);
+            logger.debug(`🔒 Node ${nodeId} favoriteLocked — preserving DB isFavorite=${existingNode.isFavorite}, re-syncing to device (device reported ${nodeInfo.isFavorite})`);
             nodeData.isFavorite = existingNode.isFavorite;
             // Re-push the locked favorite state to the connected device
             void (async () => {
@@ -7973,7 +7973,7 @@ class MeshtasticManager implements ISourceManager {
           const lastPush = this.ignoreReapplyCooldown.get(nodeNum) ?? 0;
           if (now - lastPush >= IGNORE_REAPPLY_COOLDOWN_MS) {
             this.ignoreReapplyCooldown.set(nodeNum, now);
-            logger.info(`🚫 Node ${nodeId} on persistent ignore list but device reports un-ignored — re-applying on local device (#2601)`);
+            logger.debug(`🚫 Node ${nodeId} on persistent ignore list but device reports un-ignored — re-applying on local device (#2601)`);
             void (async () => {
               try {
                 await this.sendIgnoredNode(nodeNum); // no destination = local node, no mesh traffic
@@ -8026,7 +8026,7 @@ class MeshtasticManager implements ISourceManager {
           if (existingNode?.keyMismatchDetected && existingNode.lastMeshReceivedKey) {
             if (deviceSyncKey === existingNode.lastMeshReceivedKey) {
               // Device now has the same key as the mesh broadcast — mismatch resolved!
-              logger.info(`🔐 Key mismatch RESOLVED via device sync for ${nodeId}: device key matches mesh key`);
+              logger.debug(`🔐 Key mismatch RESOLVED via device sync for ${nodeId}: device key matches mesh key`);
               nodeData.keyMismatchDetected = false;
               nodeData.lastMeshReceivedKey = null;
               nodeData.publicKey = deviceSyncKey;
@@ -8198,7 +8198,7 @@ class MeshtasticManager implements ISourceManager {
           const nameChanged = this.localNodeInfo.longName !== nodeInfo.user.longName ||
             this.localNodeInfo.shortName !== nodeInfo.user.shortName;
           if (nameChanged) {
-            logger.info(`📱 Local node name updated: "${this.localNodeInfo.longName}" → "${nodeInfo.user.longName}" (${nodeInfo.user.shortName})`);
+            logger.debug(`📱 Local node name updated: "${this.localNodeInfo.longName}" → "${nodeInfo.user.longName}" (${nodeInfo.user.shortName})`);
           }
           this.localNodeInfo.longName = nodeInfo.user.longName;
           this.localNodeInfo.shortName = nodeInfo.user.shortName;
@@ -8340,7 +8340,7 @@ class MeshtasticManager implements ISourceManager {
       return await this.buildDeviceConfigFromActual();
     }
 
-    logger.info('⚠️ No device config available yet - returning null');
+    logger.debug('⚠️ No device config available yet - returning null');
     logger.debug('No device config available yet');
     return null;
   }
@@ -8525,7 +8525,7 @@ class MeshtasticManager implements ISourceManager {
               // correctly lingers until a later push or NodeInfo confirms the contact.
             }
           } else if (targetNode?.publicKey && targetNode.keyMismatchDetected) {
-            logger.info(`🔐 DM to !${destination.toString(16).padStart(8, '0')} — skipping PKI (key mismatch active; firmware may lack key after purge), falling back to channel encryption`);
+            logger.debug(`🔐 DM to !${destination.toString(16).padStart(8, '0')} — skipping PKI (key mismatch active; firmware may lack key after purge), falling back to channel encryption`);
           }
         } catch {
           // If lookup fails, send without PKI — firmware will use channel encryption
@@ -8543,7 +8543,7 @@ class MeshtasticManager implements ISourceManager {
 
       // Log message sending at INFO level for production visibility
       const destinationInfo = destination ? `node !${destination.toString(16).padStart(8, '0')}` : `channel ${channel}`;
-      logger.info(`📤 Sent message to ${destinationInfo}: "${text.substring(0, 50)}${text.length > 50 ? '...' : ''}" (ID: ${messageId})`);
+      logger.debug(`📤 Sent message to ${destinationInfo}: "${text.substring(0, 50)}${text.length > 50 ? '...' : ''}" (ID: ${messageId})`);
       logger.debug('Message sent successfully:', text, 'with ID:', messageId);
 
       // Log outgoing message to packet monitor
@@ -8667,7 +8667,7 @@ class MeshtasticManager implements ISourceManager {
     try {
       const tracerouteData = meshtasticProtobufService.createTracerouteMessage(destination, channel);
 
-      logger.info(`🔍 Traceroute packet created: ${tracerouteData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}`);
+      logger.debug(`🔍 Traceroute packet created: ${tracerouteData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}`);
 
       await this.transport.send(tracerouteData);
 
@@ -8683,7 +8683,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       await databaseService.recordTracerouteRequestAsync(this.localNodeInfo.nodeNum, destination, this.sourceId ?? undefined);
-      logger.info(`📤 Traceroute request sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
+      logger.debug(`📤 Traceroute request sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
 
       // Log outgoing traceroute to packet monitor
       await this.logOutgoingPacket(
@@ -8732,7 +8732,7 @@ class MeshtasticManager implements ISourceManager {
         } : undefined;
       }
 
-      logger.info(`📍 Position exchange: fixedPosition=${hasFixedPosition}, gpsMode=${positionConfig?.gpsMode}, hasValidPositionSource=${hasValidPositionSource}, willSendPosition=${!!localPosition}`);
+      logger.debug(`📍 Position exchange: fixedPosition=${hasFixedPosition}, gpsMode=${positionConfig?.gpsMode}, hasValidPositionSource=${hasValidPositionSource}, willSendPosition=${!!localPosition}`);
 
       const { data: positionRequestData, packetId, requestId } = meshtasticProtobufService.createPositionRequestMessage(
         destination,
@@ -8740,7 +8740,7 @@ class MeshtasticManager implements ISourceManager {
         localPosition
       );
 
-      logger.info(`📍 Position exchange packet created: ${positionRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, packetId=${packetId}, requestId=${requestId}, position=${localPosition ? `${localPosition.latitude},${localPosition.longitude}` : 'none'}`);
+      logger.debug(`📍 Position exchange packet created: ${positionRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, packetId=${packetId}, requestId=${requestId}, position=${localPosition ? `${localPosition.latitude},${localPosition.longitude}` : 'none'}`);
 
       await this.transport.send(positionRequestData);
 
@@ -8755,7 +8755,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      logger.info(`📤 Position exchange sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
+      logger.debug(`📤 Position exchange sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
 
       // Log outgoing position exchange to packet monitor
       await this.logOutgoingPacket(
@@ -8809,7 +8809,7 @@ class MeshtasticManager implements ISourceManager {
         localUserInfo
       );
 
-      logger.info(`📇 NodeInfo exchange packet created: ${nodeInfoRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, packetId=${packetId}, requestId=${requestId}, userInfo=${localUserInfo ? localUserInfo.longName : 'none'}`);
+      logger.debug(`📇 NodeInfo exchange packet created: ${nodeInfoRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, packetId=${packetId}, requestId=${requestId}, userInfo=${localUserInfo ? localUserInfo.longName : 'none'}`);
 
       await this.transport.send(nodeInfoRequestData);
 
@@ -8824,7 +8824,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      logger.info(`📤 NodeInfo exchange sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
+      logger.debug(`📤 NodeInfo exchange sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
 
       // Log outgoing NodeInfo exchange to packet monitor
       await this.logOutgoingPacket(
@@ -8862,7 +8862,7 @@ class MeshtasticManager implements ISourceManager {
         channel
       );
 
-      logger.info(`🏠 NeighborInfo request packet created: ${neighborInfoRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, packetId=${packetId}, requestId=${requestId}`);
+      logger.debug(`🏠 NeighborInfo request packet created: ${neighborInfoRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, packetId=${packetId}, requestId=${requestId}`);
 
       await this.transport.send(neighborInfoRequestData);
 
@@ -8877,7 +8877,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      logger.info(`📤 NeighborInfo request sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
+      logger.debug(`📤 NeighborInfo request sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
 
       // Log outgoing NeighborInfo request to packet monitor
       await this.logOutgoingPacket(
@@ -8920,7 +8920,7 @@ class MeshtasticManager implements ISourceManager {
       );
 
       const typeLabel = telemetryType || 'device';
-      logger.info(`📊 Telemetry request packet created: ${telemetryRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, type=${typeLabel}, packetId=${packetId}, requestId=${requestId}`);
+      logger.debug(`📊 Telemetry request packet created: ${telemetryRequestData.length} bytes for dest=${destination} (0x${destination.toString(16)}), channel=${channel}, type=${typeLabel}, packetId=${packetId}, requestId=${requestId}`);
 
       await this.transport.send(telemetryRequestData);
 
@@ -8935,7 +8935,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      logger.info(`📤 Telemetry request (${typeLabel}) sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
+      logger.debug(`📤 Telemetry request (${typeLabel}) sent from ${this.localNodeInfo.nodeId} to !${destination.toString(16).padStart(8, '0')}`);
 
       // Log outgoing Telemetry request to packet monitor
       await this.logOutgoingPacket(
@@ -8960,7 +8960,7 @@ class MeshtasticManager implements ISourceManager {
    */
   async broadcastNodeInfoToChannel(channel: number): Promise<{ packetId: number; requestId: number }> {
     const BROADCAST_ADDR = 0xFFFFFFFF;
-    logger.info(`📢 Broadcasting NodeInfo on channel ${channel}`);
+    logger.debug(`📢 Broadcasting NodeInfo on channel ${channel}`);
     return this.sendNodeInfoRequest(BROADCAST_ADDR, channel);
   }
 
@@ -8984,13 +8984,13 @@ class MeshtasticManager implements ISourceManager {
       return;
     }
 
-    logger.info(`📢 Starting NodeInfo broadcast to ${channels.length} channel(s) with ${delaySeconds}s delay`);
+    logger.debug(`📢 Starting NodeInfo broadcast to ${channels.length} channel(s) with ${delaySeconds}s delay`);
 
     for (let i = 0; i < channels.length; i++) {
       const channel = channels[i];
       try {
         await this.broadcastNodeInfoToChannel(channel);
-        logger.info(`📢 NodeInfo broadcast sent to channel ${channel} (${i + 1}/${channels.length})`);
+        logger.debug(`📢 NodeInfo broadcast sent to channel ${channel} (${i + 1}/${channels.length})`);
 
         // Wait between broadcasts (except after the last one)
         if (i < channels.length - 1) {
@@ -9003,7 +9003,7 @@ class MeshtasticManager implements ISourceManager {
       }
     }
 
-    logger.info(`📢 NodeInfo broadcast complete for all ${channels.length} channel(s)`);
+    logger.debug(`📢 NodeInfo broadcast complete for all ${channels.length} channel(s)`);
   }
 
   /**
@@ -9026,7 +9026,7 @@ class MeshtasticManager implements ISourceManager {
           0 // Channel 0 for local node communication
         );
 
-      logger.info(`📊 LocalStats request packet created: ${telemetryRequestData.length} bytes for local node ${this.localNodeInfo.nodeId}, packetId=${packetId}, requestId=${requestId}`);
+      logger.debug(`📊 LocalStats request packet created: ${telemetryRequestData.length} bytes for local node ${this.localNodeInfo.nodeId}, packetId=${packetId}, requestId=${requestId}`);
 
       await this.transport.send(telemetryRequestData);
 
@@ -9041,7 +9041,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      logger.info(`📤 LocalStats request sent to local node ${this.localNodeInfo.nodeId}`);
+      logger.debug(`📤 LocalStats request sent to local node ${this.localNodeInfo.nodeId}`);
       return { packetId, requestId };
     } catch (error) {
       logger.error('Error requesting LocalStats:', error);
@@ -9089,7 +9089,7 @@ class MeshtasticManager implements ISourceManager {
       }
     }
 
-    logger.info(`📤 Remote LocalStats request sent to ${destination.toString(16)} (packetId=${packetId}, requestId=${requestId})`);
+    logger.debug(`📤 Remote LocalStats request sent to ${destination.toString(16)} (packetId=${packetId}, requestId=${requestId})`);
     return { packetId, requestId };
   }
 
@@ -9434,7 +9434,7 @@ class MeshtasticManager implements ISourceManager {
           isDirectMessage ? fromNum : 0, // destination: node number for DM, 0 for channel
           packetId, // replyId - react to the original message
           () => {
-            logger.info(`✅ Auto-acknowledge tapback ${hopEmoji} delivered to ${tapbackTarget}`);
+            logger.debug(`✅ Auto-acknowledge tapback ${hopEmoji} delivered to ${tapbackTarget}`);
           },
           (reason: string) => {
             logger.warn(`❌ Auto-acknowledge tapback failed to ${tapbackTarget}: ${reason}`);
@@ -9486,7 +9486,7 @@ class MeshtasticManager implements ISourceManager {
           replyDest, // destination: node number for DM, 0 for channel
           replyId, // replyId
           () => {
-            logger.info(`✅ Auto-acknowledge message delivered to ${replyTarget}`);
+            logger.debug(`✅ Auto-acknowledge message delivered to ${replyTarget}`);
           },
           (reason: string) => {
             logger.warn(`❌ Auto-acknowledge message failed to ${replyTarget}: ${reason}`);
@@ -9588,7 +9588,7 @@ class MeshtasticManager implements ISourceManager {
       // Handle "ping stop"
       const session = this.autoPingSessions.get(fromNum);
       if (session) {
-        logger.info(`🛑 Auto-ping stop requested by !${fromNum.toString(16).padStart(8, '0')}`);
+        logger.debug(`🛑 Auto-ping stop requested by !${fromNum.toString(16).padStart(8, '0')}`);
         this.stopAutoPingSession(fromNum, 'cancelled');
       } else {
         await this.sendTextMessage('No active ping session to stop.', 0, fromNum);
@@ -9650,7 +9650,7 @@ class MeshtasticManager implements ISourceManager {
       );
       this.messageQueue.recordExternalSend();
 
-      logger.info(`📡 Auto-ping session started for !${fromNum.toString(16).padStart(8, '0')}: ${actualCount} pings every ${intervalSeconds}s`);
+      logger.debug(`📡 Auto-ping session started for !${fromNum.toString(16).padStart(8, '0')}: ${actualCount} pings every ${intervalSeconds}s`);
 
       // Emit session started event
       await this.emitAutoPingUpdate(session, 'started');
@@ -9788,7 +9788,7 @@ class MeshtasticManager implements ISourceManager {
       }
       session.pendingRequestId = null;
 
-      logger.info(`📡 Auto-ping ${session.completedPings}/${session.totalPings} ${status.toUpperCase()} from !${nodeNum.toString(16).padStart(8, '0')} (${durationMs}ms)`);
+      logger.debug(`📡 Auto-ping ${session.completedPings}/${session.totalPings} ${status.toUpperCase()} from !${nodeNum.toString(16).padStart(8, '0')} (${durationMs}ms)`);
 
       this.emitAutoPingUpdate(session, 'ping_result').catch(err => logger.error('Error emitting auto-ping update:', err));
 
@@ -9814,7 +9814,7 @@ class MeshtasticManager implements ISourceManager {
     session.pendingRequestId = null;
     session.pendingTimeout = null;
 
-    logger.info(`⏰ Auto-ping ${session.completedPings}/${session.totalPings} TIMEOUT for !${session.requestedBy.toString(16).padStart(8, '0')}`);
+    logger.debug(`⏰ Auto-ping ${session.completedPings}/${session.totalPings} TIMEOUT for !${session.requestedBy.toString(16).padStart(8, '0')}`);
 
     this.emitAutoPingUpdate(session, 'ping_result').catch(err => logger.error('Error emitting auto-ping update:', err));
 
@@ -9871,7 +9871,7 @@ class MeshtasticManager implements ISourceManager {
 
     await this.emitAutoPingUpdate(session, 'completed');
 
-    logger.info(`✅ Auto-ping session completed for !${requestedBy.toString(16).padStart(8, '0')}: ${session.successfulPings}/${session.totalPings} successful`);
+    logger.debug(`✅ Auto-ping session completed for !${requestedBy.toString(16).padStart(8, '0')}: ${session.successfulPings}/${session.totalPings} successful`);
   }
 
   /**
@@ -9902,7 +9902,7 @@ class MeshtasticManager implements ISourceManager {
     this.emitAutoPingUpdate(session, 'cancelled').catch(err => logger.error('Error emitting auto-ping cancellation:', err));
     this.autoPingSessions.delete(requestedBy);
 
-    logger.info(`🛑 Auto-ping session ${reason} for !${requestedBy.toString(16).padStart(8, '0')}`);
+    logger.debug(`🛑 Auto-ping session ${reason} for !${requestedBy.toString(16).padStart(8, '0')}`);
   }
 
   /**
@@ -10031,7 +10031,7 @@ class MeshtasticManager implements ISourceManager {
       // This ensures "Москва" and "Mocквa" both match the same trigger pattern.
       const normalizedText = applyHomoglyphOptimization(message.text);
 
-      logger.info(`🤖 Auto-responder checking message on ${isDirectMessage ? 'DM' : `channel ${message.channel}`}: "${message.text}"`);
+      logger.debug(`🤖 Auto-responder checking message on ${isDirectMessage ? 'DM' : `channel ${message.channel}`}: "${message.text}"`);
 
       // Try to match message against triggers
       for (let triggerIdx = 0; triggerIdx < triggers.length; triggerIdx++) {
@@ -10039,19 +10039,19 @@ class MeshtasticManager implements ISourceManager {
         // Normalize trigger channels (handles legacy single channel and new multi-channel array format)
         const triggerChannels = normalizeTriggerChannels(trigger);
 
-        logger.info(`🤖 Checking trigger "${trigger.trigger}" (channels: ${triggerChannels.join('+')}) against message on ${isDirectMessage ? 'DM' : `channel ${message.channel}`}`);
+        logger.debug(`🤖 Checking trigger "${trigger.trigger}" (channels: ${triggerChannels.join('+')}) against message on ${isDirectMessage ? 'DM' : `channel ${message.channel}`}`);
 
         // Check if this trigger applies to the current message's channel
         if (isDirectMessage) {
           // For DMs, only match triggers that include 'dm' in their channels
           if (!triggerChannels.includes('dm')) {
-            logger.info(`⏭️  Skipping trigger "${trigger.trigger}" - not configured for DM (channels: ${triggerChannels.join('+')})`);
+            logger.debug(`⏭️  Skipping trigger "${trigger.trigger}" - not configured for DM (channels: ${triggerChannels.join('+')})`);
             continue;
           }
         } else {
           // For channel messages, only match triggers that include this channel number
           if (!triggerChannels.includes(message.channel)) {
-            logger.info(`⏭️  Skipping trigger "${trigger.trigger}" - not configured for channel ${message.channel} (channels: ${triggerChannels.join('+')})`);
+            logger.debug(`⏭️  Skipping trigger "${trigger.trigger}" - not configured for channel ${message.channel} (channels: ${triggerChannels.join('+')})`);
             continue;
           }
         }
@@ -10311,7 +10311,7 @@ class MeshtasticManager implements ISourceManager {
 
             const scriptStartTime = Date.now();
             const triggerPattern = Array.isArray(trigger.trigger) ? trigger.trigger[0] : trigger.trigger;
-            logger.info(`🔧 Executing auto-responder script for pattern "${triggerPattern}" -> ${scriptPath}`);
+            logger.debug(`🔧 Executing auto-responder script for pattern "${triggerPattern}" -> ${scriptPath}`);
 
             // Determine interpreter based on file extension
             const ext = scriptPath.split('.').pop()?.toLowerCase();
@@ -10382,7 +10382,7 @@ class MeshtasticManager implements ISourceManager {
               // Skip sending if channel is 'none' (script handles its own output)
               if (scriptTriggerChannels.includes('none')) {
                 const scriptDuration = Date.now() - scriptStartTime;
-                logger.info(`🔧 Auto-responder script for "${triggerPattern}" completed in ${scriptDuration}ms (channel=none, no mesh output)`);
+                logger.debug(`🔧 Auto-responder script for "${triggerPattern}" completed in ${scriptDuration}ms (channel=none, no mesh output)`);
 
                 // Record cooldown timestamp
                 const triggerCooldownNone = trigger.cooldownSeconds || 0;
@@ -10415,7 +10415,7 @@ class MeshtasticManager implements ISourceManager {
                   isDM ? message.fromNodeNum : 0, // destination: node number for DM, 0 for channel
                   isFirstMessage ? packetId : undefined, // Reply to original message for first response
                   () => {
-                    logger.info(`✅ Script response ${index + 1}/${scriptResp.responses.length} delivered to ${target}`);
+                    logger.debug(`✅ Script response ${index + 1}/${scriptResp.responses.length} delivered to ${target}`);
                   },
                   (reason: string) => {
                     logger.warn(`❌ Script response ${index + 1}/${scriptResp.responses.length} failed to ${target}: ${reason}`);
@@ -10427,7 +10427,7 @@ class MeshtasticManager implements ISourceManager {
 
               // Script responses queued
               const scriptDuration = Date.now() - scriptStartTime;
-              logger.info(`🔧 Auto-responder script for "${triggerPattern}" completed in ${scriptDuration}ms, ${scriptResp.responses.length} response(s) queued to ${target}`);
+              logger.debug(`🔧 Auto-responder script for "${triggerPattern}" completed in ${scriptDuration}ms, ${scriptResp.responses.length} response(s) queued to ${target}`);
 
               // Record cooldown timestamp
               const triggerCooldownScript = trigger.cooldownSeconds || 0;
@@ -10479,7 +10479,7 @@ class MeshtasticManager implements ISourceManager {
                 this.truncateMessageForMeshtastic(errMsg, 200),
                 isDirectMessage ? message.fromNodeNum : 0,
                 packetId,
-                () => { logger.info('✅ Traceroute unknown-node reply delivered'); },
+                () => { logger.debug('✅ Traceroute unknown-node reply delivered'); },
                 (reason: string) => { logger.warn(`❌ Traceroute unknown-node reply failed: ${reason}`); },
                 isDirectMessage ? undefined : message.channel as number,
                 1
@@ -10511,7 +10511,7 @@ class MeshtasticManager implements ISourceManager {
               this.truncateMessageForMeshtastic(ackMsg, 200),
               isDirectMessage ? message.fromNodeNum : 0,
               packetId,
-              () => { logger.info(`✅ Traceroute ACK delivered to ${nodeId}`); },
+              () => { logger.debug(`✅ Traceroute ACK delivered to ${nodeId}`); },
               (reason: string) => { logger.warn(`❌ Traceroute ACK failed to ${nodeId}: ${reason}`); },
               isDirectMessage ? undefined : message.channel as number,
               1
@@ -10528,7 +10528,7 @@ class MeshtasticManager implements ISourceManager {
                 this.truncateMessageForMeshtastic(timeoutMsg, 200),
                 pending.isDM ? pending.replyToNodeNum : 0,
                 undefined,
-                () => { logger.info('✅ Traceroute timeout reply delivered'); },
+                () => { logger.debug('✅ Traceroute timeout reply delivered'); },
                 (reason: string) => { logger.warn(`❌ Traceroute timeout reply failed: ${reason}`); },
                 pending.isDM ? undefined : pending.replyChannel,
                 1
@@ -10548,7 +10548,7 @@ class MeshtasticManager implements ISourceManager {
             try {
               const channel = targetNode.channel ?? 0;
               await this.sendTraceroute(targetNodeNum, channel);
-              logger.info(`🔍 Auto-responder traceroute to ${targetName} (${targetNode.nodeId}) initiated by ${nodeId}`);
+              logger.debug(`🔍 Auto-responder traceroute to ${targetName} (${targetNode.nodeId}) initiated by ${nodeId}`);
 
               // Record cooldown timestamp
               const triggerCooldownTrace = trigger.cooldownSeconds || 0;
@@ -10612,7 +10612,7 @@ class MeshtasticManager implements ISourceManager {
                   message.fromNodeNum, // destination: always DM the sender
                   isFirstMessage ? packetId : undefined, // reply to original for first response
                   () => {
-                    logger.info(`✅ Mailbox response ${index + 1}/${mailboxResponses.length} delivered to ${mailboxTarget}`);
+                    logger.debug(`✅ Mailbox response ${index + 1}/${mailboxResponses.length} delivered to ${mailboxTarget}`);
                     const playId = playOnDelivery.get(index);
                     if (playId !== undefined) {
                       deadDropService.markDelivered(this.sourceId, playId)
@@ -10628,7 +10628,7 @@ class MeshtasticManager implements ISourceManager {
               });
 
               const mailboxDuration = Date.now() - mailboxStart;
-              logger.info(`📬 Auto-responder mailbox completed in ${mailboxDuration}ms, ${mailboxResponses.length} response(s) queued to ${mailboxTarget}`);
+              logger.debug(`📬 Auto-responder mailbox completed in ${mailboxDuration}ms, ${mailboxResponses.length} response(s) queued to ${mailboxTarget}`);
             } catch (error: any) {
               logger.error(`📬 Auto-responder mailbox failed for ${mailboxTarget}: ${error?.message || error}`);
             }
@@ -10695,7 +10695,7 @@ class MeshtasticManager implements ISourceManager {
               isDM ? message.fromNodeNum : 0, // destination: node number for DM, 0 for channel
               isFirstMessage ? packetId : undefined, // Reply to original message for first response
               () => {
-                logger.info(`✅ Auto-response ${index + 1}/${responseValue.responses.length} delivered to ${target}`);
+                logger.debug(`✅ Auto-response ${index + 1}/${responseValue.responses.length} delivered to ${target}`);
               },
               (reason: string) => {
                 logger.warn(`❌ Auto-response ${index + 1}/${responseValue.responses.length} failed to ${target}: ${reason}`);
@@ -11019,7 +11019,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // Log diagnostic info for nodes being considered for welcome
-      logger.info(`👋 Auto-welcome check for ${nodeId}: welcomedAt=${node.welcomedAt} (${typeof node.welcomedAt}), longName=${node.longName}, createdAt=${node.createdAt ? new Date(node.createdAt).toISOString() : 'null'}`);
+      logger.debug(`👋 Auto-welcome check for ${nodeId}: welcomedAt=${node.welcomedAt} (${typeof node.welcomedAt}), longName=${node.longName}, createdAt=${node.createdAt ? new Date(node.createdAt).toISOString() : 'null'}`);
 
       // Check all conditions BEFORE acquiring the lock
       // This allows subsequent calls to re-evaluate conditions if they change
@@ -11059,7 +11059,7 @@ class MeshtasticManager implements ISourceManager {
       );
       if (delaySeconds > 0) {
         deferred = true;
-        logger.info(`👋 Deferring auto-welcome for ${nodeId} by ${delaySeconds}s to let the node settle into receive mode`);
+        logger.debug(`👋 Deferring auto-welcome for ${nodeId} by ${delaySeconds}s to let the node settle into receive mode`);
         setTimeout(() => { void this.deferredAutoWelcome(nodeNum, nodeId); }, delaySeconds * 1000);
         return;
       }
@@ -11132,7 +11132,7 @@ class MeshtasticManager implements ISourceManager {
       channel = parseInt(autoWelcomeTarget);
     }
 
-    logger.info(`👋 Sending auto-welcome to ${nodeId} (${node?.longName}): "${welcomeText}" ${autoWelcomeTarget === 'dm' ? '(via DM)' : `(channel ${channel})`}`);
+    logger.debug(`👋 Sending auto-welcome to ${nodeId} (${node?.longName}): "${welcomeText}" ${autoWelcomeTarget === 'dm' ? '(via DM)' : `(channel ${channel})`}`);
 
     // Route through message queue for rate limiting
     // For DMs, send only once (maxAttempts=1) — the local radio ACK confirms
@@ -11158,7 +11158,7 @@ class MeshtasticManager implements ISourceManager {
     // ACK, causing welcomedAt to never be set and the node to be re-welcomed repeatedly.
     const wasMarked = await databaseService.nodes.markNodeAsWelcomedIfNotAlready(nodeNum, nodeId, this.sourceId);
     if (wasMarked) {
-      logger.info(`✅ Node ${nodeId} welcomed and marked in database`);
+      logger.debug(`✅ Node ${nodeId} welcomed and marked in database`);
     } else {
       logger.warn(`⚠️  Node ${nodeId} was already marked as welcomed by another process`);
     }
@@ -11219,7 +11219,7 @@ class MeshtasticManager implements ISourceManager {
         // Sync to device
         try {
           await this.sendFavoriteNode(nodeNum);
-          logger.info(`⭐ Auto-favorited node ${nodeId} (${targetNode.longName || 'Unknown'}) - 0-hop, role=${targetNode.role}`);
+          logger.debug(`⭐ Auto-favorited node ${nodeId} (${targetNode.longName || 'Unknown'}) - 0-hop, role=${targetNode.role}`);
         } catch (error) {
           logger.warn(`⚠️ Auto-favorited node ${nodeId} in DB but device sync failed:`, error);
         }
@@ -11249,7 +11249,7 @@ class MeshtasticManager implements ISourceManager {
 
       // If feature was disabled, clean up all auto-favorited nodes (skip locked ones)
       if (autoFavoriteEnabled !== 'true') {
-        logger.info(`🧹 Auto-favorite disabled, cleaning up ${autoFavoriteNodes.length} auto-favorited nodes`);
+        logger.debug(`🧹 Auto-favorite disabled, cleaning up ${autoFavoriteNodes.length} auto-favorited nodes`);
         for (const nodeNum of autoFavoriteNodes) {
           try {
             const node = await databaseService.nodes.getNode(nodeNum, this.sourceId);
@@ -11331,7 +11331,7 @@ class MeshtasticManager implements ISourceManager {
               await this.sendRemoveFavoriteNode(nodeNum);
             }
             const nodeId = node.nodeId || `!${nodeNum.toString(16).padStart(8, '0')}`;
-            logger.info(`☆ Auto-unfavorited node ${nodeId} (${node.longName || 'Unknown'}) - ${reason}`);
+            logger.debug(`☆ Auto-unfavorited node ${nodeId} (${node.longName || 'Unknown'}) - ${reason}`);
           } catch (error) {
             logger.warn(`⚠️ Failed to auto-unfavorite node ${nodeNum}:`, error);
           }
@@ -11343,7 +11343,7 @@ class MeshtasticManager implements ISourceManager {
         const removeSet = new Set(nodesToRemove);
         const remaining = autoFavoriteNodes.filter(n => !removeSet.has(n));
         await databaseService.settings.setSourceSetting(this.sourceId, 'autoFavoriteNodes', JSON.stringify(remaining));
-        logger.info(`🧹 Auto-favorite sweep: removed ${nodesToRemove.length}, remaining ${remaining.length}`);
+        logger.debug(`🧹 Auto-favorite sweep: removed ${nodesToRemove.length}, remaining ${remaining.length}`);
       }
     } catch (error) {
       logger.error('❌ Error in auto-favorite sweep:', error);
@@ -11389,7 +11389,7 @@ class MeshtasticManager implements ISourceManager {
         return;
       }
 
-      logger.info(`🧹 Auto heap management triggered: heap=${heapFreeBytes}B free (threshold=${threshold}B), purging ${candidates.length} oldest nodes`);
+      logger.debug(`🧹 Auto heap management triggered: heap=${heapFreeBytes}B free (threshold=${threshold}B), purging ${candidates.length} oldest nodes`);
 
       for (const node of candidates) {
         await this.sendRemoveNode(Number(node.nodeNum));
@@ -11616,7 +11616,7 @@ class MeshtasticManager implements ISourceManager {
       // Replace tokens
       const replacedMessage = await this.replaceAnnouncementTokens(message);
 
-      logger.info(`📢 Sending auto-announcement to ${channelIndexes.length} channel(s) [${channelIndexes.join(',')}]: "${replacedMessage}"`);
+      logger.debug(`📢 Sending auto-announcement to ${channelIndexes.length} channel(s) [${channelIndexes.join(',')}]: "${replacedMessage}"`);
 
       channelIndexes.forEach((channelIdx, i) => {
         this.messageQueue.enqueue(
@@ -11624,7 +11624,7 @@ class MeshtasticManager implements ISourceManager {
           0, // destination: 0 for channel broadcast
           undefined, // no reply-to for announcements
           () => {
-            logger.info(`\u2705 Auto-announcement ${i + 1}/${channelIndexes.length} delivered to channel ${channelIdx}`);
+            logger.debug(`\u2705 Auto-announcement ${i + 1}/${channelIndexes.length} delivered to channel ${channelIdx}`);
           },
           (reason: string) => {
             logger.warn(`\u274c Auto-announcement ${i + 1}/${channelIndexes.length} failed on channel ${channelIdx}: ${reason}`);
@@ -11651,7 +11651,7 @@ class MeshtasticManager implements ISourceManager {
           const nodeInfoDelaySeconds = parseInt(await settings.getSettingForSource(sourceId, 'autoAnnounceNodeInfoDelaySeconds') || '30');
 
           if (nodeInfoChannels.length > 0) {
-            logger.info(`📢 NodeInfo broadcasting enabled - will broadcast to ${nodeInfoChannels.length} channel(s)`);
+            logger.debug(`📢 NodeInfo broadcasting enabled - will broadcast to ${nodeInfoChannels.length} channel(s)`);
             // Run NodeInfo broadcasting asynchronously (don't block the announcement)
             this.broadcastNodeInfoToChannels(nodeInfoChannels, nodeInfoDelaySeconds).catch(error => {
               logger.error('❌ Error in NodeInfo broadcasting:', error);
@@ -11804,7 +11804,7 @@ class MeshtasticManager implements ISourceManager {
     // {NODECOUNT} - Nodes heard in the last 2h, matching the Sources panel "active" badge (#3388)
     if (result.includes('{NODECOUNT}')) {
       const activeNodeCount = await databaseService.nodes.getActiveNodeCount(this.sourceId, ACTIVE_NODE_TOKEN_WINDOW_SECONDS);
-      logger.info(`📢 Token replacement - NODECOUNT: ${activeNodeCount} active nodes (last 2h)`);
+      logger.debug(`📢 Token replacement - NODECOUNT: ${activeNodeCount} active nodes (last 2h)`);
       result = result.replace(/{NODECOUNT}/g, encode(activeNodeCount.toString()));
     }
 
@@ -11812,14 +11812,14 @@ class MeshtasticManager implements ISourceManager {
     if (result.includes('{DIRECTCOUNT}')) {
       const nodes = await databaseService.nodes.getActiveNodes(ACTIVE_NODE_TOKEN_WINDOW_DAYS, this.sourceId);
       const directCount = nodes.filter((n: any) => n.hopsAway === 0).length;
-      logger.info(`📢 Token replacement - DIRECTCOUNT: ${directCount} direct nodes out of ${nodes.length} active nodes (last 2h)`);
+      logger.debug(`📢 Token replacement - DIRECTCOUNT: ${directCount} direct nodes out of ${nodes.length} active nodes (last 2h)`);
       result = result.replace(/{DIRECTCOUNT}/g, encode(directCount.toString()));
     }
 
     // {TOTALNODES} - Total nodes (all nodes ever seen, regardless of when last heard, scoped to this source)
     if (result.includes('{TOTALNODES}')) {
       const allNodes = await databaseService.nodes.getAllNodes(this.sourceId);
-      logger.info(`📢 Token replacement - TOTALNODES: ${allNodes.length} total nodes`);
+      logger.debug(`📢 Token replacement - TOTALNODES: ${allNodes.length} total nodes`);
       result = result.replace(/{TOTALNODES}/g, encode(allNodes.length.toString()));
     }
 
@@ -11836,7 +11836,7 @@ class MeshtasticManager implements ISourceManager {
           logger.error('❌ Error fetching numOnlineNodes telemetry:', error);
         }
       }
-      logger.info(`📢 Token replacement - ONLINENODES: ${onlineNodes} online nodes (from device LocalStats)`);
+      logger.debug(`📢 Token replacement - ONLINENODES: ${onlineNodes} online nodes (from device LocalStats)`);
       result = result.replace(/{ONLINENODES}/g, encode(onlineNodes.toString()));
     }
 
@@ -12026,18 +12026,18 @@ class MeshtasticManager implements ISourceManager {
   private async processAdminMessage(payload: Uint8Array, meshPacket: any): Promise<void> {
     try {
       const fromNum = meshPacket.from ? Number(meshPacket.from) : 0;
-      logger.info(`⚙️ Processing ADMIN_APP message from node ${fromNum}, payload size: ${payload.length}`);
+      logger.debug(`⚙️ Processing ADMIN_APP message from node ${fromNum}, payload size: ${payload.length}`);
       const adminMsg = protobufService.decodeAdminMessage(payload);
       if (!adminMsg) {
         logger.error('⚙️ Failed to decode admin message');
         return;
       }
 
-      logger.info('⚙️ Decoded admin message keys:', Object.keys(adminMsg));
-      logger.info('⚙️ Decoded admin message has getConfigResponse:', !!adminMsg.getConfigResponse);
+      logger.debug('⚙️ Decoded admin message keys:', Object.keys(adminMsg));
+      logger.debug('⚙️ Decoded admin message has getConfigResponse:', !!adminMsg.getConfigResponse);
       if (adminMsg.getConfigResponse) {
-        logger.info('⚙️ getConfigResponse type:', typeof adminMsg.getConfigResponse);
-        logger.info('⚙️ getConfigResponse keys:', Object.keys(adminMsg.getConfigResponse || {}));
+        logger.debug('⚙️ getConfigResponse type:', typeof adminMsg.getConfigResponse);
+        logger.debug('⚙️ getConfigResponse keys:', Object.keys(adminMsg.getConfigResponse || {}));
       }
 
       // Extract session passkey from ALL admin responses (per research findings)
@@ -12048,14 +12048,14 @@ class MeshtasticManager implements ISourceManager {
           // Local node - store in legacy location for backward compatibility
           this.sessionPasskey = new Uint8Array(adminMsg.sessionPasskey);
           this.sessionPasskeyExpiry = Date.now() + (290 * 1000); // 290 seconds (10 second buffer before 300s expiry)
-          logger.info('🔑 Session passkey received from local node and stored (expires in 290 seconds)');
+          logger.debug('🔑 Session passkey received from local node and stored (expires in 290 seconds)');
         } else {
           // Remote node - store per-node
           this.remoteSessionPasskeys.set(fromNum, {
             passkey: new Uint8Array(adminMsg.sessionPasskey),
             expiry: Date.now() + (290 * 1000) // 290 seconds
           });
-          logger.info(`🔑 Session passkey received from remote node ${fromNum} and stored (expires in 290 seconds)`);
+          logger.debug(`🔑 Session passkey received from remote node ${fromNum} and stored (expires in 290 seconds)`);
         }
       }
 
@@ -12064,9 +12064,9 @@ class MeshtasticManager implements ISourceManager {
       const isRemoteNode = fromNum !== 0 && fromNum !== localNodeNum;
 
       if (adminMsg.getConfigResponse) {
-        logger.info(`⚙️ Received GetConfigResponse from node ${fromNum}`);
-        logger.info('⚙️ GetConfigResponse structure:', JSON.stringify(Object.keys(adminMsg.getConfigResponse || {})));
-        logger.info('⚙️ GetConfigResponse position field present:', !!adminMsg.getConfigResponse.position);
+        logger.debug(`⚙️ Received GetConfigResponse from node ${fromNum}`);
+        logger.debug('⚙️ GetConfigResponse structure:', JSON.stringify(Object.keys(adminMsg.getConfigResponse || {})));
+        logger.debug('⚙️ GetConfigResponse position field present:', !!adminMsg.getConfigResponse.position);
         if (isRemoteNode) {
           // Store config for remote node
           // getConfigResponse is a Config object containing device, lora, position, etc.
@@ -12092,10 +12092,10 @@ class MeshtasticManager implements ISourceManager {
             });
           }
           nodeConfig.lastUpdated = Date.now();
-          logger.info(`📊 Stored config response from remote node ${fromNum}, keys:`, Object.keys(nodeConfig.deviceConfig));
-          logger.info(`📊 Position config stored:`, !!nodeConfig.deviceConfig.position);
+          logger.debug(`📊 Stored config response from remote node ${fromNum}, keys:`, Object.keys(nodeConfig.deviceConfig));
+          logger.debug(`📊 Position config stored:`, !!nodeConfig.deviceConfig.position);
           if (nodeConfig.deviceConfig.position) {
-            logger.info(`📊 Position config details:`, JSON.stringify(Object.keys(nodeConfig.deviceConfig.position)));
+            logger.debug(`📊 Position config details:`, JSON.stringify(Object.keys(nodeConfig.deviceConfig.position)));
           }
         }
       }
@@ -12130,14 +12130,14 @@ class MeshtasticManager implements ISourceManager {
             if (responseKeys.length === 0) {
               const pendingKey = this.pendingModuleConfigRequests.get(fromNum);
               if (pendingKey) {
-                logger.info(`📊 Empty module config response from node ${fromNum}, storing defaults for '${pendingKey}'`);
+                logger.debug(`📊 Empty module config response from node ${fromNum}, storing defaults for '${pendingKey}'`);
                 nodeConfig.moduleConfig[pendingKey] = {};
                 this.pendingModuleConfigRequests.delete(fromNum);
               }
             }
           }
           nodeConfig.lastUpdated = Date.now();
-          logger.info(`📊 Stored module config response from remote node ${fromNum}, keys:`, Object.keys(nodeConfig.moduleConfig));
+          logger.debug(`📊 Stored module config response from remote node ${fromNum}, keys:`, Object.keys(nodeConfig.moduleConfig));
         } else {
           // Local node: merge the explicit module-config response into
           // actualModuleConfig. Without this, an explicit refresh
@@ -12161,7 +12161,7 @@ class MeshtasticManager implements ISourceManager {
               const pendingKey = this.pendingModuleConfigRequests.get(localNodeKey)
                 ?? this.pendingModuleConfigRequests.get(fromNum);
               if (pendingKey) {
-                logger.info(`📊 Empty local module config response, storing defaults for '${pendingKey}'`);
+                logger.debug(`📊 Empty local module config response, storing defaults for '${pendingKey}'`);
                 if (this.actualModuleConfig[pendingKey] === undefined) {
                   this.actualModuleConfig[pendingKey] = {};
                 }
@@ -12170,7 +12170,7 @@ class MeshtasticManager implements ISourceManager {
               }
             }
           }
-          logger.info(`📊 Merged local module config response, actualModuleConfig keys:`, Object.keys(this.actualModuleConfig));
+          logger.debug(`📊 Merged local module config response, actualModuleConfig keys:`, Object.keys(this.actualModuleConfig));
         }
       }
 
@@ -12377,7 +12377,7 @@ class MeshtasticManager implements ISourceManager {
       const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.localNodeInfo.nodeNum);
 
       await this.transport.send(adminPacket);
-      logger.info(`🔑 Requested session passkey from remote node ${destinationNodeNum} (via getDeviceMetadataRequest)`);
+      logger.debug(`🔑 Requested session passkey from remote node ${destinationNodeNum} (via getDeviceMetadataRequest)`);
 
       // Poll for the response instead of fixed wait
       // This allows early exit if response arrives quickly, and longer total wait time
@@ -12391,7 +12391,7 @@ class MeshtasticManager implements ISourceManager {
         // Check if we received the passkey
         const passkey = this.getSessionPasskey(destinationNodeNum);
         if (passkey) {
-          logger.info(`✅ Session passkey received from remote node ${destinationNodeNum} after ${((i + 1) * pollInterval / 1000).toFixed(1)}s`);
+          logger.debug(`✅ Session passkey received from remote node ${destinationNodeNum} after ${((i + 1) * pollInterval / 1000).toFixed(1)}s`);
           return passkey;
         }
       }
@@ -12688,12 +12688,12 @@ class MeshtasticManager implements ISourceManager {
     try {
       // For local TCP connections, try sending without session passkey first
       // (there's a known bug where session keys don't work properly over TCP)
-      logger.info(`🗑️ Attempting to remove node ${nodeNum} (!${nodeNum.toString(16).padStart(8, '0')}) from device NodeDB`);
+      logger.debug(`🗑️ Attempting to remove node ${nodeNum} (!${nodeNum.toString(16).padStart(8, '0')}) from device NodeDB`);
       const removeNodeMsg = protobufService.createRemoveNodeMessage(nodeNum, new Uint8Array()); // empty passkey
       const adminPacket = protobufService.createAdminPacket(removeNodeMsg, this.localNodeInfo.nodeNum, this.localNodeInfo.nodeNum); // send to local node
 
       await this.transport.send(adminPacket);
-      logger.info(`✅ Sent remove_by_nodenum admin command for node ${nodeNum} (!${nodeNum.toString(16).padStart(8, '0')})`);
+      logger.debug(`✅ Sent remove_by_nodenum admin command for node ${nodeNum} (!${nodeNum.toString(16).padStart(8, '0')})`);
 
       // Remove from device node tracking so the UI shows the "not in device DB" warning
       this.deviceNodeNums.delete(nodeNum);
@@ -12801,9 +12801,9 @@ class MeshtasticManager implements ISourceManager {
       // Get or request session passkey
       let sessionPasskey = this.getSessionPasskey(destinationNodeNum);
       if (sessionPasskey) {
-        logger.info(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
+        logger.debug(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
       } else {
-        logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
+        logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
         sessionPasskey = await this.requestRemoteSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
           throw new Error(`Failed to obtain session passkey for remote node ${destinationNodeNum}`);
@@ -12910,7 +12910,7 @@ class MeshtasticManager implements ISourceManager {
             };
             const configKey = moduleConfigMap[configType];
             if (configKey && nodeConfig.moduleConfig?.[configKey]) {
-              logger.info(`✅ Received ${configKey} config from remote node ${destinationNodeNum}`);
+              logger.debug(`✅ Received ${configKey} config from remote node ${destinationNodeNum}`);
               return nodeConfig.moduleConfig[configKey];
             }
           } else {
@@ -12961,9 +12961,9 @@ class MeshtasticManager implements ISourceManager {
       // Get or request session passkey
       let sessionPasskey = this.getSessionPasskey(destinationNodeNum);
       if (sessionPasskey) {
-        logger.info(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
+        logger.debug(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
       } else {
-        logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
+        logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
         sessionPasskey = await this.requestRemoteSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
           throw new Error(`Failed to obtain session passkey for remote node ${destinationNodeNum}`);
@@ -13054,9 +13054,9 @@ class MeshtasticManager implements ISourceManager {
       // Get or request session passkey
       let sessionPasskey = this.getSessionPasskey(destinationNodeNum);
       if (sessionPasskey) {
-        logger.info(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
+        logger.debug(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
       } else {
-        logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
+        logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
         sessionPasskey = await this.requestRemoteSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
           throw new Error(`Failed to obtain session passkey for remote node ${destinationNodeNum}`);
@@ -13131,9 +13131,9 @@ class MeshtasticManager implements ISourceManager {
       // Get or request session passkey
       let sessionPasskey = this.getSessionPasskey(destinationNodeNum);
       if (sessionPasskey) {
-        logger.info(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
+        logger.debug(`🔑 Using cached session passkey for remote node ${destinationNodeNum}`);
       } else {
-        logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
+        logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
         sessionPasskey = await this.requestRemoteSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
           throw new Error(`Failed to obtain session passkey for remote node ${destinationNodeNum}`);
@@ -13221,7 +13221,7 @@ class MeshtasticManager implements ISourceManager {
       if (!isLocalNode) {
         sessionPasskey = this.getSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
-          logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
+          logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
           sessionPasskey = await this.requestRemoteSessionPasskey(destinationNodeNum);
           if (!sessionPasskey) {
             throw new Error(`Failed to obtain session passkey for remote node ${destinationNodeNum}`);
@@ -13279,7 +13279,7 @@ class MeshtasticManager implements ISourceManager {
       if (!isLocalNode) {
         sessionPasskey = this.getSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
-          logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
+          logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one...`);
           sessionPasskey = await this.requestRemoteSessionPasskey(destinationNodeNum);
           if (!sessionPasskey) {
             throw new Error(`Failed to obtain session passkey for remote node ${destinationNodeNum}`);
@@ -13300,7 +13300,7 @@ class MeshtasticManager implements ISourceManager {
       const adminPacket = protobufService.createAdminPacket(encoded, targetNodeNum, localNodeNum);
       await this.transport.send(adminPacket);
 
-      logger.info(`🕐 Sent set time command to node ${targetNodeNum} (time: ${currentTime} / ${new Date(currentTime * 1000).toISOString()})`);
+      logger.debug(`🕐 Sent set time command to node ${targetNodeNum} (time: ${currentTime} / ${new Date(currentTime * 1000).toISOString()})`);
     } catch (error) {
       logger.error(`❌ Error sending set time command to node ${destinationNodeNum}:`, error);
       throw error;
@@ -13335,7 +13335,7 @@ class MeshtasticManager implements ISourceManager {
       14  // TRAFFICMANAGEMENT_CONFIG
     ];
 
-    logger.info('📦 Requesting all module configs for complete backup...');
+    logger.debug('📦 Requesting all module configs for complete backup...');
 
     for (const configType of moduleConfigTypes) {
       // Abort early if we lost the connection mid-fetch (#3637). Propagating
@@ -13362,7 +13362,7 @@ class MeshtasticManager implements ISourceManager {
       }
     }
 
-    logger.info('✅ All module config requests sent');
+    logger.debug('✅ All module config requests sent');
   }
 
   /**
@@ -13372,7 +13372,7 @@ class MeshtasticManager implements ISourceManager {
   resetModuleConfigCache(): void {
     this.moduleConfigsEverFetched = false;
     this.actualModuleConfig = null;
-    logger.info('📦 Module config cache reset — will re-fetch on next connect');
+    logger.debug('📦 Module config cache reset — will re-fetch on next connect');
   }
 
   /**
@@ -13382,7 +13382,7 @@ class MeshtasticManager implements ISourceManager {
   async refreshModuleConfigs(): Promise<void> {
     this.moduleConfigsEverFetched = false;
     this.actualModuleConfig = null;
-    logger.info('📦 Force-refreshing module configs...');
+    logger.debug('📦 Force-refreshing module configs...');
     await this.requestAllModuleConfigs();
     this.moduleConfigsEverFetched = true;
   }
@@ -13939,12 +13939,12 @@ class MeshtasticManager implements ISourceManager {
     }
 
     try {
-      logger.info('⚙️ Beginning edit settings transaction');
+      logger.debug('⚙️ Beginning edit settings transaction');
       const beginMsg = protobufService.createBeginEditSettingsMessage(new Uint8Array());
       const adminPacket = protobufService.createAdminPacket(beginMsg, this.localNodeInfo?.nodeNum || 0, this.localNodeInfo?.nodeNum);
 
       await this.transport.send(adminPacket);
-      logger.info('⚙️ Sent begin_edit_settings admin message');
+      logger.debug('⚙️ Sent begin_edit_settings admin message');
     } catch (error) {
       logger.error('❌ Error beginning edit settings:', error);
       throw error;
@@ -13960,12 +13960,12 @@ class MeshtasticManager implements ISourceManager {
     }
 
     try {
-      logger.info('⚙️ Committing edit settings to persist configuration');
+      logger.debug('⚙️ Committing edit settings to persist configuration');
       const commitMsg = protobufService.createCommitEditSettingsMessage(new Uint8Array());
       const adminPacket = protobufService.createAdminPacket(commitMsg, this.localNodeInfo?.nodeNum || 0, this.localNodeInfo?.nodeNum);
 
       await this.transport.send(adminPacket);
-      logger.info('⚙️ Sent commit_edit_settings admin message');
+      logger.debug('⚙️ Sent commit_edit_settings admin message');
 
       // Wait a moment for device to save to flash
       await new Promise(resolve => setTimeout(resolve, 2000));
@@ -14029,10 +14029,10 @@ class MeshtasticManager implements ISourceManager {
 
       logger.info(`📡 Channel changes detected on startup config sync:`);
       if (moves.length > 0) {
-        logger.info(`  Moves: ${moves.map(m => `slot ${m.from}→${m.to}`).join(', ')}`);
+        logger.debug(`  Moves: ${moves.map(m => `slot ${m.from}→${m.to}`).join(', ')}`);
       }
       if (newChannels.length > 0) {
-        logger.info(`  New channels: slots ${newChannels.join(', ')}`);
+        logger.debug(`  New channels: slots ${newChannels.join(', ')}`);
       }
 
       // 1. Migrate messages for moved channels
@@ -14464,7 +14464,7 @@ class MeshtasticManager implements ISourceManager {
     // Also request all module configs to get fresh telemetry, mqtt, etc.
     setTimeout(async () => {
       try {
-        logger.info('📦 Requesting fresh module configs...');
+        logger.debug('📦 Requesting fresh module configs...');
         await this.requestAllModuleConfigs();
       } catch (error) {
         logger.error('❌ Failed to request module configs during refresh:', error);

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -1647,7 +1647,7 @@ export class MeshtasticProtobufService {
 
       // Only strip PKI if from=0 and pkiEncrypted=true
       if ((packetObj.from === 0 || !packetObj.from) && packetObj.pkiEncrypted) {
-        logger.info(`🔓 Stripping PKI encryption from packet with from=0 (pkiEncrypted=${packetObj.pkiEncrypted})`);
+        logger.debug(`🔓 Stripping PKI encryption from packet with from=0 (pkiEncrypted=${packetObj.pkiEncrypted})`);
 
         // Remove PKI-related fields
         delete packetObj.pkiEncrypted;
@@ -1659,7 +1659,7 @@ export class MeshtasticProtobufService {
           packet: newPacket,
         });
 
-        logger.info(`✅ Successfully stripped PKI encryption from packet`);
+        logger.debug(`✅ Successfully stripped PKI encryption from packet`);
         return ToRadio.encode(newToRadio).finish();
       }
 

--- a/src/server/messageQueueService.ts
+++ b/src/server/messageQueueService.ts
@@ -104,7 +104,7 @@ export class MessageQueueService {
 
     this.queue.push(queuedMessage);
     const target = channel !== undefined ? `channel ${channel}` : `node !${destination.toString(16).padStart(8, '0')}`;
-    logger.info(`📬 Enqueued automated message ${messageId} to ${target} (queue length: ${this.queue.length})`);
+    logger.debug(`📬 Enqueued automated message ${messageId} to ${target} (queue length: ${this.queue.length})`);
 
     // Start processing if not already running
     if (!this.processing) {
@@ -192,7 +192,7 @@ export class MessageQueueService {
     }
 
     if (cleanedCount > 0) {
-      logger.info(`🧹 Cleaned up ${cleanedCount} orphaned pending ACK(s)`);
+      logger.debug(`🧹 Cleaned up ${cleanedCount} orphaned pending ACK(s)`);
     }
   }
 
@@ -306,7 +306,7 @@ export class MessageQueueService {
 
       const attemptInfo = message.attempts > 1 ? ` (attempt ${message.attempts}/${message.maxAttempts})` : '';
       const target = message.channel !== undefined ? `channel ${message.channel}` : `!${message.destination.toString(16).padStart(8, '0')}`;
-      logger.info(`📤 Sending queued message ${message.id} to ${target}${attemptInfo}`);
+      logger.debug(`📤 Sending queued message ${message.id} to ${target}${attemptInfo}`);
 
       // Send the message
       const requestId = await this.sendCallback(message.text, message.destination, message.replyId, message.channel, message.emoji);
@@ -338,7 +338,7 @@ export class MessageQueueService {
       this.pendingAcks.set(requestId, message);
 
       if (message.attempts >= message.maxAttempts) {
-        logger.info(`🏁 Final attempt for message ${message.id} - no more retries`);
+        logger.debug(`🏁 Final attempt for message ${message.id} - no more retries`);
       } else {
         logger.debug(`⏳ Waiting for ACK for message ${message.id} (requestId: ${requestId})`);
       }
@@ -352,7 +352,7 @@ export class MessageQueueService {
       } else {
         // Will retry in next cycle - ensure message stays in pendingAcks for retry
         const remainingAttempts = message.maxAttempts - message.attempts;
-        logger.info(`🔄 Will retry message ${message.id} (${remainingAttempts} attempt${remainingAttempts === 1 ? '' : 's'} remaining)`);
+        logger.debug(`🔄 Will retry message ${message.id} (${remainingAttempts} attempt${remainingAttempts === 1 ? '' : 's'} remaining)`);
 
         // If message has a requestId from a previous attempt, keep it in pendingAcks
         if (message.requestId) {
@@ -370,7 +370,7 @@ export class MessageQueueService {
     const message = this.pendingAcks.get(requestId);
     if (message) {
       const isLateAck = message.requestId !== requestId;
-      logger.info(`✅ ACK received for message ${message.id} (requestId: ${requestId}${isLateAck ? ', late ACK on prior attempt' : ''})`);
+      logger.debug(`✅ ACK received for message ${message.id} (requestId: ${requestId}${isLateAck ? ', late ACK on prior attempt' : ''})`);
       this.deleteAllRequestIds(message);
 
       // Call success callback with error handling

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -1456,12 +1456,12 @@ class ProtobufService {
       const adminMsg = AdminMessage.create(adminMsgData);
 
       const encoded = AdminMessage.encode(adminMsg).finish();
-      logger.info('⚙️ Created SetPositionConfig admin message');
-      logger.info('⚙️ Position config data:', JSON.stringify(positionConfigData, null, 2));
-      logger.info('⚙️ Smart broadcast enabled:', positionConfigData.positionBroadcastSmartEnabled);
+      logger.debug('⚙️ Created SetPositionConfig admin message');
+      logger.debug('⚙️ Position config data:', JSON.stringify(positionConfigData, null, 2));
+      logger.debug('⚙️ Smart broadcast enabled:', positionConfigData.positionBroadcastSmartEnabled);
       if (positionConfigData.positionBroadcastSmartEnabled) {
-        logger.info('⚙️ Smart broadcast minimum distance:', positionConfigData.broadcastSmartMinimumDistance);
-        logger.info('⚙️ Smart broadcast minimum interval:', positionConfigData.broadcastSmartMinimumIntervalSecs);
+        logger.debug('⚙️ Smart broadcast minimum distance:', positionConfigData.broadcastSmartMinimumDistance);
+        logger.debug('⚙️ Smart broadcast minimum interval:', positionConfigData.broadcastSmartMinimumIntervalSecs);
       }
       return encoded;
     } catch (error) {

--- a/src/server/routes/_channelDatabaseHandlers.ts
+++ b/src/server/routes/_channelDatabaseHandlers.ts
@@ -318,7 +318,7 @@ export async function createChannelHandler(req: Request, res: Response) {
       });
     }
 
-    logger.info(`Channel database entry created: "${name}" (id=${newChannelId}) by user ${scope.user?.username ?? 'unknown'}`);
+    logger.debug(`Channel database entry created: "${name}" (id=${newChannelId}) by user ${scope.user?.username ?? 'unknown'}`);
 
     res.status(201).json({
       success: true,
@@ -383,7 +383,7 @@ export async function reorderChannelsHandler(req: Request, res: Response) {
     await databaseService.channelDatabase.reorderAsync(updates);
     channelDecryptionService.invalidateCache();
 
-    logger.info(`Channel database reordered (${updates.length} entries) by user ${scope.user?.username ?? 'unknown'}`);
+    logger.debug(`Channel database reordered (${updates.length} entries) by user ${scope.user?.username ?? 'unknown'}`);
 
     res.json({
       success: true,
@@ -515,7 +515,7 @@ export async function updateChannelHandler(req: Request, res: Response) {
     }
 
     const updatedChannel = await databaseService.channelDatabase.getByIdAsync(id);
-    logger.info(`Channel database entry ${id} updated by user ${scope.user?.username ?? 'unknown'}`);
+    logger.debug(`Channel database entry ${id} updated by user ${scope.user?.username ?? 'unknown'}`);
 
     res.json({
       success: true,
@@ -561,7 +561,7 @@ export async function deleteChannelHandler(req: Request, res: Response) {
     await databaseService.channelDatabase.deleteAsync(id);
     channelDecryptionService.invalidateCache();
 
-    logger.info(`Channel database entry ${id} ("${existing.name}") deleted by user ${scope.user?.username ?? 'unknown'}`);
+    logger.debug(`Channel database entry ${id} ("${existing.name}") deleted by user ${scope.user?.username ?? 'unknown'}`);
 
     res.json({
       success: true,
@@ -811,7 +811,7 @@ export async function setChannelPermissionHandler(req: Request, res: Response) {
       grantedBy: scope.user?.id ?? null,
     });
 
-    logger.info(
+    logger.debug(
       `Channel database permission set: user ${targetUserId} on channel ${channelId} ` +
       `(viewOnMap=${canViewOnMap}, read=${canRead}) by ${scope.user?.username ?? 'unknown'}`
     );
@@ -873,7 +873,7 @@ export async function deleteChannelPermissionHandler(req: Request, res: Response
 
     await databaseService.channelDatabase.deletePermissionAsync(targetUserId, channelId);
 
-    logger.info(
+    logger.debug(
       `Channel database permission deleted: user ${targetUserId} on channel ${channelId} by ${scope.user?.username ?? 'unknown'}`
     );
 

--- a/src/server/routes/backupRoutes.ts
+++ b/src/server/routes/backupRoutes.ts
@@ -56,7 +56,7 @@ backupRouter.post('/settings', requirePermission('configuration', 'write'), asyn
     await databaseService.settings.setSetting('backup_maxBackups', maxBackups.toString());
     await databaseService.settings.setSetting('backup_time', backupTime);
 
-    logger.info(`⚙️  Backup settings updated: enabled=${enabled}, maxBackups=${maxBackups}, time=${backupTime}`);
+    logger.debug(`⚙️  Backup settings updated: enabled=${enabled}, maxBackups=${maxBackups}, time=${backupTime}`);
 
     res.json({ success: true });
   } catch (error) {
@@ -98,7 +98,7 @@ backupRouter.get('/download/:filename', requirePermission('configuration', 'read
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.send(content);
 
-    logger.info(`📥 Backup downloaded: ${filename}`);
+    logger.debug(`📥 Backup downloaded: ${filename}`);
   } catch (error) {
     logger.error('❌ Error downloading backup:', error);
     res.status(500).json({
@@ -120,7 +120,7 @@ backupRouter.delete('/delete/:filename', requirePermission('configuration', 'wri
 
     await backupFileService.deleteBackup(filename);
 
-    logger.info(`🗑️  Backup deleted: ${filename}`);
+    logger.debug(`🗑️  Backup deleted: ${filename}`);
 
     res.json({ success: true });
   } catch (error) {
@@ -141,7 +141,7 @@ const systemBackupRouter = Router();
 // Create a system backup (exports all database tables to JSON)
 systemBackupRouter.post('/', requirePermission('configuration', 'write'), async (req: Request, res: Response) => {
   try {
-    logger.info('📦 System backup requested...');
+    logger.debug('📦 System backup requested...');
 
     const dirname = await systemBackupService.createBackup('manual');
 
@@ -154,7 +154,7 @@ systemBackupRouter.post('/', requirePermission('configuration', 'write'), async 
       req.ip || null
     );
 
-    logger.info(`✅ System backup created: ${dirname}`);
+    logger.debug(`✅ System backup created: ${dirname}`);
 
     res.json({
       success: true,
@@ -241,7 +241,7 @@ systemBackupRouter.get('/download/:dirname', requirePermission('configuration', 
     archive.directory(backupPath, dirname);
     await archive.finalize();
 
-    logger.info(`📥 System backup downloaded: ${dirname}`);
+    logger.debug(`📥 System backup downloaded: ${dirname}`);
   } catch (error) {
     logger.error('❌ Error downloading system backup:', error);
     // finalize() can throw after streaming began (headers sent) — same guard.
@@ -277,7 +277,7 @@ systemBackupRouter.delete('/delete/:dirname', requirePermission('configuration',
       req.ip || null
     );
 
-    logger.info(`🗑️  System backup deleted: ${dirname}`);
+    logger.debug(`🗑️  System backup deleted: ${dirname}`);
 
     res.json({ success: true });
   } catch (error) {
@@ -333,7 +333,7 @@ systemBackupRouter.post('/settings', requirePermission('configuration', 'write')
     await databaseService.settings.setSetting('system_backup_maxBackups', maxBackups.toString());
     await databaseService.settings.setSetting('system_backup_time', backupTime);
 
-    logger.info(`⚙️  System backup settings updated: enabled=${enabled}, maxBackups=${maxBackups}, time=${backupTime}`);
+    logger.debug(`⚙️  System backup settings updated: enabled=${enabled}, maxBackups=${maxBackups}, time=${backupTime}`);
 
     res.json({ success: true });
   } catch (error) {

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -344,7 +344,7 @@ router.get('/:id/export', requireAuth(), async (req: Request, res: Response) => 
       return res.status(404).json({ error: 'Channel not found' });
     }
 
-    logger.info(`📤 Exporting channel ${channelId} (${channel.name}):`, {
+    logger.debug(`📤 Exporting channel ${channelId} (${channel.name}):`, {
       role: channel.role,
       positionPrecision: channel.positionPrecision,
       uplinkEnabled: channel.uplinkEnabled,
@@ -427,7 +427,7 @@ async function migrateMessagesIfChannelsMoved(
     const afterSnapshot = (await databaseService.channels.getAllChannels(sourceId ?? ALL_SOURCES)).map(ch => ({ id: ch.id, psk: ch.psk }));
     const moves = detectChannelMoves(beforeSnapshot, afterSnapshot);
     if (moves.length > 0) {
-      logger.info(`📦 Detected channel move(s): ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
+      logger.debug(`📦 Detected channel move(s): ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
       await databaseService.messages.migrateMessagesForChannelMoves(moves, typeof sourceId === 'string' ? sourceId : undefined);
       await migrateAutomationChannels(
         moves,
@@ -593,7 +593,7 @@ router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
 
       try {
         await mcManager.setChannel(channelId, updatedChannelData.name, secretHex, normalizedScope);
-        logger.info(`✅ MeshCore: pushed channel ${channelId} to device + re-synced DB`);
+        logger.debug(`✅ MeshCore: pushed channel ${channelId} to device + re-synced DB`);
       } catch (deviceError) {
         logger.error(`⚠️ MeshCore: failed to push channel ${channelId} to device:`, deviceError);
         return res.status(502).json({
@@ -628,7 +628,7 @@ router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
         downlinkEnabled: updatedChannelData.downlinkEnabled,
         positionPrecision: updatedChannelData.positionPrecision,
       });
-      logger.info(`✅ Sent channel ${channelId} configuration to device`);
+      logger.debug(`✅ Sent channel ${channelId} configuration to device`);
     } catch (deviceError) {
       logger.error(`⚠️ Failed to send channel ${channelId} config to device:`, deviceError);
       // Continue even if device update fails - database is updated
@@ -638,7 +638,7 @@ router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
     await migrateMessagesIfChannelsMoved(beforeSnapshot, scopedSourceId);
 
     const updatedChannel = await databaseService.channels.getChannelById(channelId, scopedSourceId);
-    logger.info(`✅ Updated channel ${channelId}: ${name}`);
+    logger.debug(`✅ Updated channel ${channelId}: ${name}`);
     res.json({ success: true, channel: updatedChannel });
   } catch (error) {
     logger.error('Error updating channel:', error);
@@ -700,7 +700,7 @@ router.delete('/:id', requireAuth(), async (req: Request, res: Response) => {
           message: deviceError instanceof Error ? deviceError.message : String(deviceError),
         });
       }
-      logger.info(`🗑️ MeshCore: deleted channel ${channelId} on device + re-synced DB (source=${deleteChannelSourceId})`);
+      logger.debug(`🗑️ MeshCore: deleted channel ${channelId} on device + re-synced DB (source=${deleteChannelSourceId})`);
       return res.json({ success: true, message: `Channel ${channelId} deleted`, sourceId: deleteChannelSourceId });
     }
 
@@ -710,7 +710,7 @@ router.delete('/:id', requireAuth(), async (req: Request, res: Response) => {
     // Delete the channel record (scoped to the chosen source)
     await databaseService.channels.deleteChannel(channelId, deleteChannelSourceId);
 
-    logger.info(`🗑️ Deleted channel ${channelId} (source=${deleteChannelSourceId}): ${deletedCount} messages purged`);
+    logger.debug(`🗑️ Deleted channel ${channelId} (source=${deleteChannelSourceId}): ${deletedCount} messages purged`);
     res.json({ success: true, message: `Channel ${channelId} deleted`, sourceId: deleteChannelSourceId, messagesDeleted: deletedCount });
   } catch (error) {
     logger.error('Error deleting channel:', error);
@@ -821,7 +821,7 @@ router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response
         downlinkEnabled: importedChannelData.downlinkEnabled,
         positionPrecision: importedChannelData.positionPrecision,
       });
-      logger.info(`✅ Sent imported channel ${slotId} configuration to device`);
+      logger.debug(`✅ Sent imported channel ${slotId} configuration to device`);
     } catch (deviceError) {
       logger.error(`⚠️ Failed to send imported channel ${slotId} config to device:`, deviceError);
       // Continue even if device update fails - database is updated
@@ -831,7 +831,7 @@ router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response
     await migrateMessagesIfChannelsMoved(beforeSnapshot, importScopedSourceId);
 
     const importedChannel = await databaseService.channels.getChannelById(slotId, importScopedSourceId);
-    logger.info(`✅ Imported channel to slot ${slotId}: ${name}`);
+    logger.debug(`✅ Imported channel to slot ${slotId}: ${name}`);
     res.json({ success: true, channel: importedChannel });
   } catch (error) {
     logger.error('Error importing channel:', error);
@@ -902,7 +902,7 @@ router.post('/reorder', requireAuth(), async (req: Request, res: Response) => {
     const channelsBySlot = new Map(allChannels.map(ch => [ch.id, ch]));
 
     // Begin edit settings transaction
-    logger.info(`🔄 Beginning channel reorder: ${newOrder.join(',')}`);
+    logger.debug(`🔄 Beginning channel reorder: ${newOrder.join(',')}`);
     await reorderManager.beginEditSettings();
     // Pacing: device firmware silently drops admin packets that arrive too soon
     // after BeginEditSettings on TCP PhoneAPI. See /channels/import-config for details.
@@ -959,7 +959,7 @@ router.post('/reorder', requireAuth(), async (req: Request, res: Response) => {
     await new Promise((resolve) => setTimeout(resolve, 1500));
     // Commit to device
     await reorderManager.commitEditSettings();
-    logger.info(`✅ Channel reorder committed`);
+    logger.debug(`✅ Channel reorder committed`);
 
     // Migrate messages — derive moves directly from newOrder mapping
     // newOrder[newSlot] = oldSlot, so messages on oldSlot should move to newSlot
@@ -971,7 +971,7 @@ router.post('/reorder', requireAuth(), async (req: Request, res: Response) => {
       }
     }
     if (moves.length > 0) {
-      logger.info(`📦 Channel reorder message migration: ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
+      logger.debug(`📦 Channel reorder message migration: ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
       try {
         await databaseService.messages.migrateMessagesForChannelMoves(moves, reorderSourceScope);
       } catch (error) {
@@ -979,7 +979,7 @@ router.post('/reorder', requireAuth(), async (req: Request, res: Response) => {
       }
       try {
         await databaseService.auth.migratePermissionsForChannelMoves(moves);
-        logger.info(`🔑 Permission migration complete for channel reorder`);
+        logger.debug(`🔑 Permission migration complete for channel reorder`);
       } catch (error) {
         logger.error('🔑 Failed to migrate permissions after channel reorder:', error);
       }
@@ -1037,7 +1037,7 @@ router.post('/encode-url', requirePermission('configuration', 'read'), async (re
     const channels = channelResults
       .filter((ch): ch is NonNullable<typeof ch> => ch !== null)
       .map(ch => {
-        logger.info(`📡 Channel ${ch.id} from DB - name: "${ch.name}" (length: ${ch.name.length})`);
+        logger.debug(`📡 Channel ${ch.id} from DB - name: "${ch.name}" (length: ${ch.name.length})`);
         return {
           psk: ch.psk ? ch.psk : 'none',
           name: ch.name, // Use the actual name from database (preserved from device)
@@ -1054,9 +1054,9 @@ router.post('/encode-url', requirePermission('configuration', 'read'), async (re
     // Get LoRa config if requested
     let loraConfig = undefined;
     if (includeLoraConfig) {
-      logger.info('📡 includeLoraConfig is TRUE, fetching device config...');
+      logger.debug('📡 includeLoraConfig is TRUE, fetching device config...');
       const deviceConfig = await encodeUrlManager.getDeviceConfig();
-      logger.info('📡 Device config lora:', JSON.stringify(deviceConfig?.lora, null, 2));
+      logger.debug('📡 Device config lora:', JSON.stringify(deviceConfig?.lora, null, 2));
       if (deviceConfig?.lora) {
         loraConfig = {
           usePreset: deviceConfig.lora.usePreset,
@@ -1075,12 +1075,12 @@ router.post('/encode-url', requirePermission('configuration', 'read'), async (re
           sx126xRxBoostedGain: deviceConfig.lora.sx126xRxBoostedGain,
           configOkToMqtt: deviceConfig.lora.configOkToMqtt,
         };
-        logger.info('📡 LoRa config to encode:', JSON.stringify(loraConfig, null, 2));
+        logger.debug('📡 LoRa config to encode:', JSON.stringify(loraConfig, null, 2));
       } else {
         logger.warn('⚠️ Device config or lora config is missing');
       }
     } else {
-      logger.info('📡 includeLoraConfig is FALSE, skipping LoRa config');
+      logger.debug('📡 includeLoraConfig is FALSE, skipping LoRa config');
     }
 
     const url = channelUrlService.encodeUrl(channels, loraConfig);
@@ -1117,18 +1117,18 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
       return res.status(400).json({ error: 'Invalid or empty configuration URL' });
     }
 
-    logger.info(`📥 Decoded ${decoded.channels?.length || 0} channels, LoRa config: ${!!decoded.loraConfig}`);
+    logger.debug(`📥 Decoded ${decoded.channels?.length || 0} channels, LoRa config: ${!!decoded.loraConfig}`);
 
     // Begin edit settings transaction to batch all changes
     const configImportManager = (resolveSourceManager(configSourceId));
     try {
-      logger.info(`🔄 Beginning edit settings transaction for import`);
+      logger.debug(`🔄 Beginning edit settings transaction for import`);
       await configImportManager.beginEditSettings();
       // Allow device time to enter edit mode and ack back before sending config messages.
       // Empirically: 500ms is too short — device firmware silently drops the first
       // SetChannel that follows BeginEditSettings on TCP PhoneAPI under contention.
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      logger.info(`✅ Edit settings transaction started`);
+      logger.debug(`✅ Edit settings transaction started`);
     } catch (error) {
       logger.error(`❌ Failed to begin edit settings transaction:`, error);
       const errMsg = error instanceof Error ? error.message : String(error);
@@ -1147,7 +1147,7 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
       for (let i = 0; i < decoded.channels.length; i++) {
         const channel = decoded.channels[i];
         try {
-          logger.info(`📥 Importing channel ${i}: ${channel.name || '(unnamed)'}`);
+          logger.debug(`📥 Importing channel ${i}: ${channel.name || '(unnamed)'}`);
 
           // Determine role: if not specified, channel 0 is PRIMARY (1), others are SECONDARY (2)
           let role = channel.role;
@@ -1168,7 +1168,7 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
           // Allow device time to process channel config before sending the next message
           await new Promise((resolve) => setTimeout(resolve, 1000));
           importedChannels.push({ index: i, name: channel.name || '(unnamed)' });
-          logger.info(`✅ Imported channel ${i}`);
+          logger.debug(`✅ Imported channel ${i}`);
         } catch (error) {
           logger.error(`❌ Failed to import channel ${i}:`, error);
           // Continue with other channels even if one fails
@@ -1181,7 +1181,7 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
     let requiresReboot = false;
     if (decoded.loraConfig) {
       try {
-        logger.info(`📥 Importing LoRa config:`, JSON.stringify(decoded.loraConfig, null, 2));
+        logger.debug(`📥 Importing LoRa config:`, JSON.stringify(decoded.loraConfig, null, 2));
 
         // IMPORTANT: Always force txEnabled to true
         // MeshMonitor users need TX enabled to send messages
@@ -1191,14 +1191,14 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
           txEnabled: true,
         };
 
-        logger.info(`📥 LoRa config with txEnabled defaulted: txEnabled=${loraConfigToImport.txEnabled}`);
+        logger.debug(`📥 LoRa config with txEnabled defaulted: txEnabled=${loraConfigToImport.txEnabled}`);
         await configImportManager.setLoRaConfig(loraConfigToImport);
         // LoRa config triggers heavier processing (frequency calculations, radio reconfiguration)
         // so allow extra time before committing
         await new Promise((resolve) => setTimeout(resolve, 1500));
         loraImported = true;
         requiresReboot = true; // LoRa config requires reboot when committed
-        logger.info(`✅ Imported LoRa config`);
+        logger.debug(`✅ Imported LoRa config`);
       } catch (error) {
         logger.error(`❌ Failed to import LoRa config:`, error);
       }
@@ -1213,7 +1213,7 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
       }));
       const moves = detectChannelMoves(beforeSnapshot, afterSnapshot);
       if (moves.length > 0) {
-        logger.info(`📦 Detected channel move(s) from config import: ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
+        logger.debug(`📦 Detected channel move(s) from config import: ${moves.map(m => `${m.from}→${m.to}`).join(', ')}`);
         try {
           await databaseService.messages.migrateMessagesForChannelMoves(moves, configScopedSourceId);
           await migrateAutomationChannels(
@@ -1230,7 +1230,7 @@ router.post('/import-config', requirePermission('configuration', 'write'), async
     // Commit all changes (channels + LoRa config) as a single transaction
     // This will save everything to flash and trigger device reboot if needed
     try {
-      logger.info(
+      logger.debug(
         `💾 Committing all configuration changes (${importedChannels.length} channels${
           loraImported ? ' + LoRa config' : ''
         })...`

--- a/src/server/routes/deviceRoutes.ts
+++ b/src/server/routes/deviceRoutes.ts
@@ -45,7 +45,7 @@ router.get('/device/backup', requirePermission('configuration', 'read'), async (
     const saveToFile = req.query.save === 'true';
     const backupSourceId = req.query.sourceId as string | undefined;
     const backupManager = resolveSourceManager(backupSourceId);
-    logger.info(`📦 Device backup requested (save=${saveToFile})...`);
+    logger.debug(`📦 Device backup requested (save=${saveToFile})...`);
 
     // Generate YAML backup using the device backup service
     const yamlBackup = await deviceBackupService.generateBackup(backupManager);
@@ -63,7 +63,7 @@ router.get('/device/backup', requirePermission('configuration', 'read'), async (
       res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
       res.send(yamlBackup);
 
-      logger.info(`✅ Device backup saved and downloaded: ${filename}`);
+      logger.debug(`✅ Device backup saved and downloaded: ${filename}`);
     } else {
       // Just download, don't save - generate filename for display
       const nodeIdNumber = nodeId.startsWith('!') ? nodeId.substring(1) : nodeId;
@@ -76,7 +76,7 @@ router.get('/device/backup', requirePermission('configuration', 'read'), async (
       res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
       res.send(yamlBackup);
 
-      logger.info(`✅ Device backup generated: ${filename}`);
+      logger.debug(`✅ Device backup generated: ${filename}`);
     }
   } catch (error) {
     logger.error('❌ Error generating device backup:', error);

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -101,7 +101,7 @@ router.post('/channel', async (req: Request, res: Response) => {
       await firmwareUpdateService.setCustomUrl(customUrl);
     }
 
-    logger.info(`[FirmwareRoutes] Channel set to "${channel}"${customUrl ? ` with URL: ${customUrl}` : ''}`);
+    logger.debug(`[FirmwareRoutes] Channel set to "${channel}"${customUrl ? ` with URL: ${customUrl}` : ''}`);
     return res.json({ success: true, channel });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -470,7 +470,7 @@ router.delete('/recovery-marker/:nodeId', (req: Request, res: Response) => {
       return res.status(400).json({ success: false, error: 'nodeId is required' });
     }
     const removed = firmwareUpdateService.clearFlashIncompleteMarker(nodeId);
-    logger.info(`[FirmwareRoutes] Cleared ${removed} half-flash marker(s) for node ${nodeId}`);
+    logger.debug(`[FirmwareRoutes] Cleared ${removed} half-flash marker(s) for node ${nodeId}`);
     return res.json({ success: true, removed });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/server/routes/geojsonRoutes.ts
+++ b/src/server/routes/geojsonRoutes.ts
@@ -76,7 +76,7 @@ export function createGeoJsonRouter(service: GeoJsonService): Router {
         }
 
         const layer = service.addLayer(filename, geojsonContent);
-        logger.info(`[GeoJsonRoutes] Layer uploaded: ${layer.name} (source: ${fileType})`);
+        logger.debug(`[GeoJsonRoutes] Layer uploaded: ${layer.name} (source: ${fileType})`);
         return res.status(201).json(layer);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/server/routes/maintenanceRoutes.ts
+++ b/src/server/routes/maintenanceRoutes.ts
@@ -36,7 +36,7 @@ router.get('/size', requirePermission('configuration', 'read'), async (_req: Req
 
 router.post('/run', requirePermission('configuration', 'write'), async (_req: Request, res: Response) => {
   try {
-    logger.info('🔧 Manual database maintenance requested...');
+    logger.debug('🔧 Manual database maintenance requested...');
     const stats = await databaseMaintenanceService.runMaintenance();
     res.json({
       success: true,

--- a/src/server/routes/mapStyleRoutes.ts
+++ b/src/server/routes/mapStyleRoutes.ts
@@ -53,7 +53,7 @@ export function createMapStyleRouter(service: MapStyleService): Router {
         const name = filename.replace(/\.[^.]+$/, '');
 
         const style = service.addStyle(name, content, 'upload');
-        logger.info(`[MapStyleRoutes] Style uploaded: ${style.name} (${style.id})`);
+        logger.debug(`[MapStyleRoutes] Style uploaded: ${style.name} (${style.id})`);
         return res.status(201).json(style);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -118,7 +118,7 @@ export function createMapStyleRouter(service: MapStyleService): Router {
         }
 
         const style = service.addStyle(name, content, 'url', url);
-        logger.info(`[MapStyleRoutes] Style added from URL: ${style.name} (${style.id})`);
+        logger.debug(`[MapStyleRoutes] Style added from URL: ${style.name} (${style.id})`);
         return res.status(201).json(style);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -262,7 +262,7 @@ export function createMapStyleRouter(service: MapStyleService): Router {
         const name = requestedName?.trim() || tileJson.name || 'Generated Style';
         const style = generateStyleFromTileJson(tileJson, { name });
 
-        logger.info(`[MapStyleRoutes] Generated style from TileJSON at: ${tileJsonUrl}`);
+        logger.debug(`[MapStyleRoutes] Generated style from TileJSON at: ${tileJsonUrl}`);
         return res.json({ style, filename: `${name.replace(/[^a-z0-9_-]/gi, '_').toLowerCase()}-style.json` });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -70,7 +70,7 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
 
     // Get local node info to create system message
     const localNodeInfo = posManager.getLocalNodeInfo();
-    logger.info(
+    logger.debug(
       `📍 localNodeInfo for system message: ${
         localNodeInfo ? `nodeId=${localNodeInfo.nodeId}, nodeNum=${localNodeInfo.nodeNum}` : 'NULL'
       }`
@@ -86,7 +86,7 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
       // For DMs (channel 0), store as channel -1 to show in DM conversation
       const messageChannel = channel === 0 ? -1 : channel;
 
-      logger.info(
+      logger.debug(
         `📍 Inserting position request system message to database: ${messageId} (channel: ${messageChannel}, packetId: ${packetId}, requestId: ${requestId}, broadcast: ${isBroadcast})`
       );
       await databaseService.messages.insertMessage({
@@ -106,7 +106,7 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
         sourceIp: req.ip ?? null,
         sourcePath: 'http_api',
       });
-      logger.info(`📍 Position request system message inserted successfully`);
+      logger.debug(`📍 Position request system message inserted successfully`);
     } else {
       logger.warn(`⚠️ Could not create system message for position request - localNodeInfo is null`);
     }
@@ -151,7 +151,7 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
 
     // Get local node info to create system message
     const localNodeInfo = niManager.getLocalNodeInfo();
-    logger.info(
+    logger.debug(
       `📇 localNodeInfo for system message: ${
         localNodeInfo ? `nodeId=${localNodeInfo.nodeId}, nodeNum=${localNodeInfo.nodeNum}` : 'NULL'
       }`
@@ -165,7 +165,7 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
       // For DMs (channel 0), store as channel -1 to show in DM conversation
       const messageChannel = channel === 0 ? -1 : channel;
 
-      logger.info(
+      logger.debug(
         `📇 Inserting nodeinfo request system message to database: ${messageId} (channel: ${messageChannel}, packetId: ${packetId}, requestId: ${requestId})`
       );
       await databaseService.messages.insertMessage({
@@ -184,7 +184,7 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
         sourceIp: req.ip ?? null,
         sourcePath: 'http_api',
       });
-      logger.info(`📇 NodeInfo request system message inserted successfully`);
+      logger.debug(`📇 NodeInfo request system message inserted successfully`);
     } else {
       logger.warn(`⚠️ Could not create system message for nodeinfo request - localNodeInfo is null`);
     }
@@ -264,7 +264,7 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
     const { packetId, requestId } = await neighborManager.sendNeighborInfoRequest(destinationNum, channel);
     neighborInfoRequestTimestamps.set(Number(destinationNum), now);
 
-    logger.info(`🏠 NeighborInfo request sent to ${destinationNum.toString(16)} on channel ${channel}, packetId=${packetId}, requestId=${requestId}`);
+    logger.debug(`🏠 NeighborInfo request sent to ${destinationNum.toString(16)} on channel ${channel}, packetId=${packetId}, requestId=${requestId}`);
 
     res.json({
       success: true,
@@ -318,7 +318,7 @@ router.post('/telemetry/request', requirePermission('messages', 'write'), async 
     );
 
     const typeLabel = telemetryType || 'device';
-    logger.info(`📊 Telemetry request (${typeLabel}) sent to ${destinationNum.toString(16)} on channel ${channel}, packetId=${packetId}, requestId=${requestId}`);
+    logger.debug(`📊 Telemetry request (${typeLabel}) sent to ${destinationNum.toString(16)} on channel ${channel}, packetId=${packetId}, requestId=${requestId}`);
 
     res.json({
       success: true,

--- a/src/server/routes/notificationRoutes.ts
+++ b/src/server/routes/notificationRoutes.ts
@@ -347,7 +347,7 @@ pushRouter.post(
     const success = await saveUserNotificationPreferencesAsync(userId, prefs, sourceId);
 
     if (success) {
-      logger.info(
+      logger.debug(
         `✅ Saved notification preferences for user ${userId} source=${sourceId ?? '(default)'} (WebPush: ${enableWebPush}, Apprise: ${enableApprise})`
       );
       res.json({ success: true });
@@ -723,7 +723,7 @@ appriseRouter.put('/enabled', requireAdmin(), async (req: Request, res: Response
     }
 
     await databaseService.settings.setSetting('apprise_enabled', enabled ? 'true' : 'false');
-    logger.info(`✅ Apprise ${enabled ? 'enabled' : 'disabled'} system-wide`);
+    logger.debug(`✅ Apprise ${enabled ? 'enabled' : 'disabled'} system-wide`);
     res.json({ success: true, enabled });
   } catch (error: any) {
     logger.error('Error updating Apprise enabled status:', error);

--- a/src/server/routes/scriptRoutes.ts
+++ b/src/server/routes/scriptRoutes.ts
@@ -35,7 +35,7 @@ export const getScriptsDirectory = (): string => {
 
   if (!fs.existsSync(scriptsDir)) {
     fs.mkdirSync(scriptsDir, { recursive: true });
-    logger.info(`📁 Created scripts directory: ${scriptsDir}`);
+    logger.debug(`📁 Created scripts directory: ${scriptsDir}`);
   }
 
   return scriptsDir;
@@ -848,7 +848,7 @@ router.post('/scripts/export', requirePermission('settings', 'read'), async (req
     }
 
     await archive.finalize();
-    logger.info(`✅ Exported ${scripts.length} script(s) as zip`);
+    logger.debug(`✅ Exported ${scripts.length} script(s) as zip`);
   } catch (error: any) {
     logger.error('❌ Error exporting scripts:', error);
     if (!res.headersSent) {

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -678,10 +678,10 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
         const enabled = await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceEnabled');
         if (enabled === 'true') {
           callbacks.restartAutoDeleteByDistanceService?.(sourceId);
-          logger.info(`✅ Auto-delete-by-distance scheduler restarted (source: ${sourceId})`);
+          logger.debug(`✅ Auto-delete-by-distance scheduler restarted (source: ${sourceId})`);
         } else {
           callbacks.stopAutoDeleteByDistanceService?.(sourceId);
-          logger.info(`⏹️ Auto-delete-by-distance scheduler stopped (source: ${sourceId})`);
+          logger.debug(`⏹️ Auto-delete-by-distance scheduler stopped (source: ${sourceId})`);
         }
       }
 
@@ -713,17 +713,17 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
 
     if ('analyticsProvider' in filteredSettings || 'analyticsConfig' in filteredSettings) {
       callbacks.invalidateHtmlCache?.();
-      logger.info('📊 Analytics settings updated - HTML cache invalidated');
+      logger.debug('📊 Analytics settings updated - HTML cache invalidated');
     }
 
     if ('autoWelcomeEnabled' in filteredSettings) {
       const wasEnabled = currentSettings['autoWelcomeEnabled'] === 'true';
       const nowEnabled = filteredSettings['autoWelcomeEnabled'] === 'true';
       if (!wasEnabled && nowEnabled) {
-        logger.info('👋 Auto-welcome being enabled - marking existing nodes as welcomed...');
+        logger.debug('👋 Auto-welcome being enabled - marking existing nodes as welcomed...');
         const markedCount = callbacks.handleAutoWelcomeEnabled?.() ?? 0;
         if (markedCount > 0) {
-          logger.info(`✅ Marked ${markedCount} existing node(s) as welcomed to prevent spam`);
+          logger.debug(`✅ Marked ${markedCount} existing node(s) as welcomed to prevent spam`);
         }
       }
     }
@@ -798,7 +798,7 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
           (filteredSettings.autoKeyManagementImmediatePurge === undefined &&
             dbImmediatePurge === 'true'),
       });
-      logger.info('✅ Auto key repair settings updated');
+      logger.debug('✅ Auto key repair settings updated');
     }
 
     const inactiveNodeSettings = [
@@ -833,7 +833,7 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       if (!isNaN(threshold) && threshold > 0 && !isNaN(checkInterval) && checkInterval > 0 && !isNaN(cooldown) && cooldown > 0) {
         callbacks.stopInactiveNodeService?.();
         callbacks.restartInactiveNodeService?.(threshold, checkInterval, cooldown);
-        logger.info(
+        logger.debug(
           `✅ Inactive node notification service restarted (threshold: ${threshold}h, check: ${checkInterval}min, cooldown: ${cooldown}h)`
         );
       }
@@ -863,7 +863,7 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       if (!isNaN(checkInterval) && checkInterval > 0 && !isNaN(cooldown) && cooldown > 0) {
         callbacks.stopLowBatteryService?.();
         callbacks.restartLowBatteryService?.(checkInterval, cooldown);
-        logger.info(
+        logger.debug(
           `✅ Low battery notification service restarted (check: ${checkInterval}min, cooldown: ${cooldown}h)`
         );
       }

--- a/src/server/routes/tileServerTest.ts
+++ b/src/server/routes/tileServerTest.ts
@@ -505,7 +505,7 @@ router.post('/autodetect', async (req, res) => {
     protocols.push('http', 'https');
   }
 
-  logger.info(`🔍 Autodetecting tile server at ${host}${port ? ':' + port : ''}`);
+  logger.debug(`🔍 Autodetecting tile server at ${host}${port ? ':' + port : ''}`);
 
   // Quick DNS and TCP connectivity check before testing all patterns
   // This prevents hanging when the server is completely unreachable
@@ -595,7 +595,7 @@ router.post('/autodetect', async (req, res) => {
           protocol: test.protocol,
           testResult: test.testResult
         });
-        logger.info(`✅ Found working ${test.type} URL: ${test.url}`);
+        logger.debug(`✅ Found working ${test.type} URL: ${test.url}`);
       }
     }
 

--- a/src/server/routes/userRoutes.ts
+++ b/src/server/routes/userRoutes.ts
@@ -606,7 +606,7 @@ router.put('/:id/channel-database-permissions', async (req: Request, res: Respon
       req.ip || null
     );
 
-    logger.info(`Channel database permissions updated for user ${userId} by ${req.user?.username ?? 'unknown'}`);
+    logger.debug(`Channel database permissions updated for user ${userId} by ${req.user?.username ?? 'unknown'}`);
 
     return res.json({
       success: true,

--- a/src/server/routes/v1/deprecatedShim.ts
+++ b/src/server/routes/v1/deprecatedShim.ts
@@ -22,7 +22,7 @@ export function deprecationShim(resource: string): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
     res.setHeader('Warning', WARNING_HEADER_VALUE);
     const user = (req as any).user;
-    logger.info(
+    logger.debug(
       `[v1-deprecated] ${req.method} /api/v1/${resource}${req.url} user=${user?.id ?? 'anon'} sourceId=${
         (req.query?.sourceId as string | undefined) ?? '<none>'
       }`

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -490,7 +490,7 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
         });
       }
 
-      logger.info(`📝 v1 API: Splitting long message (${messageBytes.length} bytes) into ${messageParts.length} parts`);
+      logger.debug(`📝 v1 API: Splitting long message (${messageBytes.length} bytes) into ${messageParts.length} parts`);
 
       // Queue all parts through messageQueueService
       const queueIds: string[] = [];
@@ -503,7 +503,7 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
           destinationNum || 0, // 0 for channel messages (broadcast)
           isFirstMessage ? replyId : undefined, // Only first message gets replyId
           () => {
-            logger.info(`✅ API message part ${index + 1}/${messageParts.length} delivered`);
+            logger.debug(`✅ API message part ${index + 1}/${messageParts.length} delivered`);
           },
           (reason: string) => {
             logger.warn(`❌ API message part ${index + 1}/${messageParts.length} failed: ${reason}`);
@@ -514,7 +514,7 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
         queueIds.push(queueId);
       });
 
-      logger.info(`📤 v1 API: Queued ${messageParts.length} message parts (user: ${req.user?.username}, queueIds: ${queueIds.join(', ')})`);
+      logger.debug(`📤 v1 API: Queued ${messageParts.length} message parts (user: ${req.user?.username}, queueIds: ${queueIds.join(', ')})`);
 
       res.status(202).json({
         success: true,
@@ -543,7 +543,7 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
       const localNodeNum = await databaseService.settings.getSetting('localNodeNum');
       const messageId = localNodeNum ? `${localNodeNum}_${requestId}` : requestId.toString();
 
-      logger.info(`📤 v1 API: Sent message via API token (user: ${req.user?.username}, requestId: ${requestId})`);
+      logger.debug(`📤 v1 API: Sent message via API token (user: ${req.user?.username}, requestId: ${requestId})`);
 
       res.status(201).json({
         success: true,

--- a/src/server/routes/v1/sourceParam.ts
+++ b/src/server/routes/v1/sourceParam.ts
@@ -101,7 +101,7 @@ export function attachSource(
             'No source found that this token has permission to access. Configure a source and/or grant permissions.',
         });
       }
-      logger.info(`[v1] default alias resolved → ${resolved.id} for user ${user.id}`);
+      logger.debug(`[v1] default alias resolved → ${resolved.id} for user ${user.id}`);
     } else {
       resolved = await databaseService.sources.getSource(rawSourceId);
       if (!resolved) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -74,7 +74,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('dotenv/config');
   // Reset cached environment config to ensure .env values are loaded
   resetEnvironmentConfig();
-  logger.info('📄 Loaded .env file from project root (if present)');
+  logger.debug('📄 Loaded .env file from project root (if present)');
 }
 
 // Load environment configuration (after .env is loaded)
@@ -296,8 +296,8 @@ void (async () => {
     const restoreFromBackup = systemRestoreService.shouldRestore();
 
     if (restoreFromBackup) {
-      logger.info('🔄 RESTORE_FROM_BACKUP environment variable detected');
-      logger.info(`📦 Attempting to restore from: ${restoreFromBackup}`);
+      logger.debug('🔄 RESTORE_FROM_BACKUP environment variable detected');
+      logger.debug(`📦 Attempting to restore from: ${restoreFromBackup}`);
 
       // Validate restore can proceed
       const validation = await systemRestoreService.canRestore(restoreFromBackup);
@@ -1638,7 +1638,7 @@ apiRouter.post('/nodes/:nodeId/favorite-lock', requirePermission('nodes', 'write
       }
     }
 
-    logger.info(`${locked ? '🔒' : '🔓'} Node ${nodeNum} favorite lock set to: ${locked}`);
+    logger.debug(`${locked ? '🔒' : '🔓'} Node ${nodeNum} favorite lock set to: ${locked}`);
 
     res.json({
       success: true,
@@ -2267,7 +2267,7 @@ apiRouter.post('/nodes/:nodeNum/scan-remote-admin', requirePermission('settings'
       return;
     }
 
-    logger.info(`Manual remote admin scan requested for node ${parsedNodeNum}`);
+    logger.debug(`Manual remote admin scan requested for node ${parsedNodeNum}`);
 
     // Perform the scan
     const result = await scanManager.scanNodeForRemoteAdmin(parsedNodeNum);
@@ -2346,7 +2346,7 @@ apiRouter.post('/nodes/:nodeId/send-key-warning', requirePermission('messages', 
       nodeNum // Destination
     );
 
-    logger.info(`🔐 Sent key security warning to node ${nodeId} (${node.longName || 'Unknown'})`);
+    logger.debug(`🔐 Sent key security warning to node ${nodeId} (${node.longName || 'Unknown'})`);
 
     res.json({
       success: true,
@@ -2429,7 +2429,7 @@ apiRouter.post('/nodes/scan-duplicate-keys', requirePermission('nodes', 'write')
           );
           affectedNodes.push(Number(nodeNum));
         }
-        logger.info(`🔐 [${sourceId}] Detected ${nodeNums.length} nodes sharing key hash ${keyHash.substring(0, 16)}...`);
+        logger.debug(`🔐 [${sourceId}] Detected ${nodeNums.length} nodes sharing key hash ${keyHash.substring(0, 16)}...`);
       }
     }
 
@@ -2830,13 +2830,13 @@ apiRouter.post('/messages/send', optionalAuth(), async (req, res) => {
       const targetNode = await databaseService.nodes.getNode(destinationNum, reqSourceId);
       if (targetNode && targetNode.channel !== undefined && targetNode.channel !== null) {
         meshChannel = targetNode.channel;
-        logger.info(`📨 DM to ${destination} - Using target node's channel: ${meshChannel}`);
+        logger.debug(`📨 DM to ${destination} - Using target node's channel: ${meshChannel}`);
       } else {
-        logger.info(`📨 DM to ${destination} - Target node channel unknown, using default channel: ${meshChannel}`);
+        logger.debug(`📨 DM to ${destination} - Target node channel unknown, using default channel: ${meshChannel}`);
       }
     }
 
-    logger.info(
+    logger.debug(
       `📨 Sending message - Received channel: ${channel}, Using meshChannel: ${meshChannel}, Text: "${text.substring(
         0,
         50
@@ -4293,7 +4293,7 @@ apiRouter.post('/settings/mark-all-welcomed', requirePermission('settings', 'wri
   try {
     const sourceId = (req.query.sourceId as string | undefined) ?? (req.body?.sourceId as string | undefined) ?? null;
     const count = await databaseService.markAllNodesAsWelcomedAsync(sourceId);
-    logger.info(`👋 Manually marked ${count} nodes as welcomed via API${sourceId ? ` (source=${sourceId})` : ''}`);
+    logger.debug(`👋 Manually marked ${count} nodes as welcomed via API${sourceId ? ` (source=${sourceId})` : ''}`);
 
     // Audit log
     void databaseService.auditLogAsync(
@@ -4444,7 +4444,7 @@ apiRouter.post('/config/lora', requirePermission('configuration', 'write'), asyn
       txEnabled: true,
     };
 
-    logger.info(`⚙️ Setting LoRa config with txEnabled defaulted: txEnabled=${loraConfigToSet.txEnabled}`);
+    logger.debug(`⚙️ Setting LoRa config with txEnabled defaulted: txEnabled=${loraConfigToSet.txEnabled}`);
     await cfgLoraManager.setLoRaConfig(loraConfigToSet);
     res.json({ success: true, message: 'LoRa configuration sent' });
   } catch (error) {
@@ -4642,7 +4642,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
         
         if (needsRequest && configInfo) {
           // Try to request the specific config type
-          logger.info(`Config type '${configType}' not available, requesting from device...`);
+          logger.debug(`Config type '${configType}' not available, requesting from device...`);
           try {
             if (configInfo.isModule) {
               await adminLoadManager.requestModuleConfig(configInfo.type);
@@ -4829,7 +4829,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
         }
       } else {
         // Remote node - request config with session passkey
-        logger.info(`Requesting ${configType} config from remote node ${destinationNodeNum}`);
+        logger.debug(`Requesting ${configType} config from remote node ${destinationNodeNum}`);
         
         // Canonical config/module type registry (see configTypes.ts).
         const configInfo = CONFIG_TYPE_MAP[configType];
@@ -5280,7 +5280,7 @@ apiRouter.post('/admin/get-device-metadata', requireAdmin(), async (req, res) =>
             JSON.stringify(metadata),
             gdmManager.sourceId
           );
-          logger.info(`✅ Updated hasRemoteAdmin=true and saved metadata for node ${destinationNodeNum}`);
+          logger.debug(`✅ Updated hasRemoteAdmin=true and saved metadata for node ${destinationNodeNum}`);
         } catch (dbError) {
           logger.error(`Failed to save remote admin status for node ${destinationNodeNum}:`, dbError);
           // Continue with response even if database update fails
@@ -5320,7 +5320,7 @@ apiRouter.post('/admin/reboot', requireAdmin(), async (req, res) => {
 
     await arManager.sendRebootCommand(destinationNodeNum, Number(seconds));
 
-    logger.info(`✅ Sent reboot command to node ${destinationNodeNum} (in ${seconds} seconds)`);
+    logger.debug(`✅ Sent reboot command to node ${destinationNodeNum} (in ${seconds} seconds)`);
     res.json({ success: true, message: `Reboot command sent (node will reboot in ${seconds} seconds)` });
   } catch (error: any) {
     logger.error('Error sending reboot command:', error);
@@ -5364,7 +5364,7 @@ apiRouter.post('/admin/set-time', requireAdmin(), async (req, res) => {
 
     await astManager.sendSetTimeCommand(destinationNodeNum);
 
-    logger.info(`✅ Sent set-time command to node ${destinationNodeNum}`);
+    logger.debug(`✅ Sent set-time command to node ${destinationNodeNum}`);
     res.json({ success: true, message: 'Time sync command sent successfully' });
   } catch (error: any) {
     logger.error('Error sending set-time command:', error);
@@ -5520,7 +5520,7 @@ apiRouter.post('/admin/import-config', requireAdmin(), async (req, res) => {
     const localNodeNum = aicManager.getLocalNodeInfo()?.nodeNum || 0;
     const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
 
-    logger.info(`📥 Importing configuration from URL to node ${destinationNodeNum}: ${configUrl}`);
+    logger.debug(`📥 Importing configuration from URL to node ${destinationNodeNum}: ${configUrl}`);
 
     const channelUrlService = (await import('./services/channelUrlService.js')).default;
 
@@ -5531,7 +5531,7 @@ apiRouter.post('/admin/import-config', requireAdmin(), async (req, res) => {
       return res.status(400).json({ error: 'Invalid or empty configuration URL' });
     }
 
-    logger.info(`📥 Decoded ${decoded.channels?.length || 0} channels, LoRa config: ${!!decoded.loraConfig}`);
+    logger.debug(`📥 Decoded ${decoded.channels?.length || 0} channels, LoRa config: ${!!decoded.loraConfig}`);
 
     const importedChannels = [];
     let loraImported = false;
@@ -5684,9 +5684,9 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
     if (!isLocalNode) {
       sessionPasskey = acManager.getSessionPasskey(destinationNodeNum);
       if (sessionPasskey) {
-        logger.info(`🔑 Using cached session passkey for admin command to remote node ${destinationNodeNum}`);
+        logger.debug(`🔑 Using cached session passkey for admin command to remote node ${destinationNodeNum}`);
       } else {
-        logger.info(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one for admin command...`);
+        logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one for admin command...`);
         sessionPasskey = await acManager.requestRemoteSessionPasskey(destinationNodeNum);
         if (!sessionPasskey) {
           logger.error(`❌ Failed to obtain session passkey for remote node ${destinationNodeNum} after 45s`);
@@ -5767,7 +5767,7 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
               altitude: altitude || 0,
               positionTimestamp: Date.now(),
             });
-            logger.info(`⚙️ Updated local node ${localNodeId} position in database: lat=${latitude}, lon=${longitude}`);
+            logger.debug(`⚙️ Updated local node ${localNodeId} position in database: lat=${latitude}, lon=${longitude}`);
           }
         }
         adminMessage = protobufService.createSetPositionConfigMessage(positionConfig, sessionPasskey || undefined);
@@ -5936,7 +5936,7 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
         altitude: params.altitude || 0,
         positionTimestamp: Date.now(),
       });
-      logger.info(`⚙️ Updated local node ${localNodeId} position in database: lat=${params.latitude}, lon=${params.longitude}`);
+      logger.debug(`⚙️ Updated local node ${localNodeId} position in database: lat=${params.latitude}, lon=${params.longitude}`);
     }
 
     // If command succeeded on a remote node, update hasRemoteAdmin flag
@@ -5948,7 +5948,7 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
           null,  // Don't overwrite existing metadata, just set the flag
           acManager.sourceId
         );
-        logger.info(`✅ Updated hasRemoteAdmin=true for node ${destinationNodeNum} after successful '${command}' command`);
+        logger.debug(`✅ Updated hasRemoteAdmin=true for node ${destinationNodeNum} after successful '${command}' command`);
       } catch (dbError) {
         logger.error(`Failed to update hasRemoteAdmin for node ${destinationNodeNum}:`, dbError);
         // Continue with response even if database update fails
@@ -6341,12 +6341,12 @@ void (async () => {
 
   // Log environment variable sources in development
   if (env.isDevelopment) {
-    logger.info(
+    logger.debug(
       `🔧 Meshtastic Node IP: ${env.meshtasticNodeIp} ${
         env.meshtasticNodeIpProvided ? '📄 (from .env)' : '⚙️ (default)'
       }`
     );
-    logger.info(
+    logger.debug(
       `🔧 Meshtastic TCP Port: ${env.meshtasticTcpPort} ${
         env.meshtasticTcpPortProvided ? '📄 (from .env)' : '⚙️ (default)'
       }`
@@ -6354,7 +6354,7 @@ void (async () => {
 
     // Log scripts directory location in development
     const scriptsDir = getScriptsDirectory();
-    logger.info(`📜 Auto-responder scripts directory: ${scriptsDir}`);
+    logger.debug(`📜 Auto-responder scripts directory: ${scriptsDir}`);
 
     // Check if directory has any scripts
     try {
@@ -6365,9 +6365,9 @@ void (async () => {
       });
 
       if (scriptFiles.length > 0) {
-        logger.info(`   Found ${scriptFiles.length} script(s): ${scriptFiles.join(', ')}`);
+        logger.debug(`   Found ${scriptFiles.length} script(s): ${scriptFiles.join(', ')}`);
       } else {
-        logger.info(`   No scripts found. Place your test scripts (.js, .mjs, .py, .sh) in this directory`);
+        logger.debug(`   No scripts found. Place your test scripts (.js, .mjs, .py, .sh) in this directory`);
       }
     } catch (error) {
       logger.warn(`   Could not read scripts directory: ${error}`);

--- a/src/server/services/appriseNotificationService.ts
+++ b/src/server/services/appriseNotificationService.ts
@@ -460,7 +460,7 @@ class AppriseNotificationService {
     const effectiveSourceId = sourceId ?? payload.sourceId;
     // Get all users with Apprise enabled and this preference enabled
     const users = await getUsersWithServiceEnabledAsync('apprise');
-    logger.info(`📢 Broadcasting ${preferenceKey} notification to ${users.length} Apprise users${targetUserId ? ` (target user: ${targetUserId})` : ''}`);
+    logger.debug(`📢 Broadcasting ${preferenceKey} notification to ${users.length} Apprise users${targetUserId ? ` (target user: ${targetUserId})` : ''}`);
 
     // Get local node name for prefix
     // First try the live connection, then fall back to database (for startup before connection)

--- a/src/server/services/autoFavoriteManagementService.ts
+++ b/src/server/services/autoFavoriteManagementService.ts
@@ -217,7 +217,7 @@ class AutoFavoriteManagementScheduler {
 
   initialize(): void {
     this.start();
-    logger.info('✅ Auto-favorite management scheduler initialized');
+    logger.debug('✅ Auto-favorite management scheduler initialized');
   }
 
   start(): void {
@@ -404,7 +404,7 @@ class AutoFavoriteManagementScheduler {
         const status = ackStatusLabel(ack);
         await databaseService.autoFavoriteTargets.touchAssignment(sourceId, targetNodeNum, fav, now, { status, at: now });
         result.reFavorited.push({ nodeNum: fav, ackStatus: status });
-        logger.info(`🔁 Auto-favorite: re-asserted ${fav} on remote target ${targetNodeNum} (source ${sourceId}) — ack=${status}`);
+        logger.debug(`🔁 Auto-favorite: re-asserted ${fav} on remote target ${targetNodeNum} (source ${sourceId}) — ack=${status}`);
       } catch (error) {
         logger.warn(`⚠️ Auto-favorite: failed to re-assert ${fav} on target ${targetNodeNum}:`, error);
       }

--- a/src/server/services/backupFileService.ts
+++ b/src/server/services/backupFileService.ts
@@ -179,7 +179,7 @@ class BackupFileService {
       const toDelete = totalBackups - limit;
       const oldBackups = await databaseService.misc.getOldestBackups(toDelete);
 
-      logger.info(`🧹 Purging ${oldBackups.length} old backups (max: ${limit})...`);
+      logger.debug(`🧹 Purging ${oldBackups.length} old backups (max: ${limit})...`);
 
       for (const backup of oldBackups) {
         // Delete file from disk

--- a/src/server/services/backupSchedulerService.ts
+++ b/src/server/services/backupSchedulerService.ts
@@ -48,7 +48,7 @@ class BackupSchedulerService {
       this.checkAndRunBackup().catch(err => logger.error('Backup scheduler error:', err));
     }, 60000); // Check every minute
 
-    logger.info('▶️  Backup scheduler started (checks every minute)');
+    logger.debug('▶️  Backup scheduler started (checks every minute)');
 
     // Run initial check
     this.checkAndRunBackup().catch(err => logger.error('Backup scheduler error:', err));
@@ -121,7 +121,7 @@ class BackupSchedulerService {
       this.isDeviceBackupInProgress = true;
 
       // Run the automated device backup
-      logger.info('⏰ Time for automated device backup...');
+      logger.debug('⏰ Time for automated device backup...');
       await this.runAutomatedDeviceBackup();
 
       // Update last device backup timestamp
@@ -177,7 +177,7 @@ class BackupSchedulerService {
       this.isSystemBackupInProgress = true;
 
       // Run the automated system backup
-      logger.info('⏰ Time for automated system backup...');
+      logger.debug('⏰ Time for automated system backup...');
       await this.runAutomatedSystemBackup();
 
       // Update last system backup timestamp
@@ -199,7 +199,7 @@ class BackupSchedulerService {
         throw new Error('Meshtastic manager not initialized');
       }
 
-      logger.info('🤖 Running automated device backup...');
+      logger.debug('🤖 Running automated device backup...');
 
       // Generate the backup YAML
       const yamlBackup = await deviceBackupService.generateBackup(this.meshtasticManager);
@@ -222,7 +222,7 @@ class BackupSchedulerService {
    */
   private async runAutomatedSystemBackup(): Promise<void> {
     try {
-      logger.info('🤖 Running automated system backup...');
+      logger.debug('🤖 Running automated system backup...');
 
       // Create system backup
       const dirname = await systemBackupService.createBackup('automatic');
@@ -241,7 +241,7 @@ class BackupSchedulerService {
       throw new Error('Meshtastic manager not initialized');
     }
 
-    logger.info('👤 Running manual backup...');
+    logger.debug('👤 Running manual backup...');
 
     // Generate the backup YAML
     const yamlBackup = await deviceBackupService.generateBackup(this.meshtasticManager);
@@ -262,7 +262,7 @@ class BackupSchedulerService {
    * Manually trigger a system backup
    */
   async triggerManualSystemBackup(): Promise<string> {
-    logger.info('👤 Running manual system backup...');
+    logger.debug('👤 Running manual system backup...');
 
     // Create system backup
     const dirname = await systemBackupService.createBackup('manual');

--- a/src/server/services/channelUrlService.ts
+++ b/src/server/services/channelUrlService.ts
@@ -80,7 +80,7 @@ class ChannelUrlService {
         oneofs: true
       });
 
-      logger.info('Decoded ChannelSet:', JSON.stringify(channelSetObj, null, 2));
+      logger.debug('Decoded ChannelSet:', JSON.stringify(channelSetObj, null, 2));
 
       // Convert to our format
       const result: DecodedChannelSet = {

--- a/src/server/services/databaseMaintenanceService.ts
+++ b/src/server/services/databaseMaintenanceService.ts
@@ -102,7 +102,7 @@ class DatabaseMaintenanceService {
       });
     }, 60000); // Check every minute
 
-    logger.info('▶️ Database maintenance scheduler started (checks every minute)');
+    logger.debug('▶️ Database maintenance scheduler started (checks every minute)');
   }
 
   /**
@@ -170,7 +170,7 @@ class DatabaseMaintenanceService {
     }
 
     // Run maintenance
-    logger.info('⏰ Time for scheduled database maintenance...');
+    logger.debug('⏰ Time for scheduled database maintenance...');
     try {
       await this.runMaintenance();
     } catch (error) {
@@ -226,11 +226,11 @@ class DatabaseMaintenanceService {
           this.getRetentionDays('neighborInfoRetentionDays'),
         ]);
 
-      logger.info(`🔧 Running database maintenance with retention: messages=${messageRetention}d, traceroutes=${tracerouteRetention}d, routeSegments=${routeSegmentRetention}d, neighborInfo=${neighborInfoRetention}d`);
+      logger.debug(`🔧 Running database maintenance with retention: messages=${messageRetention}d, traceroutes=${tracerouteRetention}d, routeSegments=${routeSegmentRetention}d, neighborInfo=${neighborInfoRetention}d`);
 
       // Get database size before cleanup
       stats.sizeBefore = await databaseService.getDatabaseSizeAsync();
-      logger.info(`📊 Database size before: ${formatBytes(stats.sizeBefore)}`);
+      logger.debug(`📊 Database size before: ${formatBytes(stats.sizeBefore)}`);
 
       // Run cleanups
       stats.messagesDeleted = await databaseService.cleanupOldMessagesAsync(messageRetention);

--- a/src/server/services/deviceBackupService.ts
+++ b/src/server/services/deviceBackupService.ts
@@ -208,7 +208,7 @@ class DeviceBackupService {
    * Compatible with `meshtastic --export-config` format
    */
   async generateBackup(meshtasticManager: any): Promise<string> {
-    logger.info('📦 Generating device backup...');
+    logger.debug('📦 Generating device backup...');
 
     try {
       // Get all necessary data
@@ -387,7 +387,7 @@ class DeviceBackupService {
       // Generate YAML with header comment
       const yaml = '# start of Meshtastic configure yaml\n' + this.yamlGenerator.toYAML(backup, 0);
 
-      logger.info('✅ Device backup generated successfully');
+      logger.debug('✅ Device backup generated successfully');
       return yaml;
 
     } catch (error) {

--- a/src/server/services/duplicateKeySchedulerService.ts
+++ b/src/server/services/duplicateKeySchedulerService.ts
@@ -55,7 +55,7 @@ class DuplicateKeySchedulerService {
       this.runScanAllSources().catch(err => logger.error('Security scanner error:', err));
     }, this.scanInterval);
 
-    logger.info('✅ Security scanner initialized');
+    logger.debug('✅ Security scanner initialized');
   }
 
   stop(): void {
@@ -103,13 +103,13 @@ class DuplicateKeySchedulerService {
     let scanSuccessful = true;
 
     try {
-      logger.info(`🔐 Running scheduled security scan for source ${sourceId}...`);
+      logger.debug(`🔐 Running scheduled security scan for source ${sourceId}...`);
 
       // Get all nodes with public keys for this source only
       const nodesWithKeys = await databaseService.nodes.getNodesWithPublicKeys(sourceId);
 
       if (nodesWithKeys.length === 0) {
-        logger.info(`ℹ️  [${sourceId}] No nodes with public keys found, skipping key scan`);
+        logger.debug(`ℹ️  [${sourceId}] No nodes with public keys found, skipping key scan`);
         const earlyAllNodes = await databaseService.nodes.getAllNodes(sourceId);
         const earlyNodeMap = new Map<number, DbNode>(earlyAllNodes.map(n => [Number(n.nodeNum), n]));
 
@@ -151,7 +151,7 @@ class DuplicateKeySchedulerService {
       for (const node of allNodesList) {
         if (nodesWithKeysSet.has(Number(node.nodeNum))) continue;
         if (node.keyIsLowEntropy) {
-          logger.info(`🔐 [${sourceId}] Clearing low-entropy flag from node ${node.nodeNum} (no longer has a public key)`);
+          logger.debug(`🔐 [${sourceId}] Clearing low-entropy flag from node ${node.nodeNum} (no longer has a public key)`);
           await databaseService.nodes.updateNodeLowEntropyFlag(Number(node.nodeNum), false, undefined, sourceId);
           node.keyIsLowEntropy = false;
         }
@@ -166,7 +166,7 @@ class DuplicateKeySchedulerService {
       const duplicates = detectDuplicateKeys(nodesWithKeys);
 
       if (duplicates.size === 0) {
-        logger.info(`✅ [${sourceId}] Duplicate key scan complete: No duplicates found among ${nodesWithKeys.length} nodes`);
+        logger.debug(`✅ [${sourceId}] Duplicate key scan complete: No duplicates found among ${nodesWithKeys.length} nodes`);
 
         for (const node of allNodesList) {
           if (node.duplicateKeyDetected) {
@@ -238,7 +238,7 @@ class DuplicateKeySchedulerService {
    */
   private async runSpamDetection(sourceId: string, sharedNodeMap: Map<number, DbNode>): Promise<void> {
     try {
-      logger.info(`🔐 [${sourceId}] Running spam detection...`);
+      logger.debug(`🔐 [${sourceId}] Running spam detection...`);
 
       const localNodeNumStr = await databaseService.settings.getSettingForSource(sourceId, 'localNodeNum');
       const localNodeNum = localNodeNumStr ? parseInt(localNodeNumStr, 10) : null;
@@ -246,7 +246,7 @@ class DuplicateKeySchedulerService {
       const packetCounts = await databaseService.getPacketCountsPerNodeLastHourAsync(sourceId);
 
       if (packetCounts.length === 0) {
-        logger.info(`ℹ️  [${sourceId}] No packet data available for spam detection`);
+        logger.debug(`ℹ️  [${sourceId}] No packet data available for spam detection`);
         return;
       }
 
@@ -297,7 +297,7 @@ class DuplicateKeySchedulerService {
       if (flaggedCount > 0) {
         logger.info(`🚨 [${sourceId}] Spam detection complete: ${flaggedCount} flagged`);
       } else {
-        logger.info(`✅ [${sourceId}] Spam detection complete: no nodes exceeding ${EXCESSIVE_PACKETS_THRESHOLD} pkt/hr`);
+        logger.debug(`✅ [${sourceId}] Spam detection complete: no nodes exceeding ${EXCESSIVE_PACKETS_THRESHOLD} pkt/hr`);
       }
     } catch (error) {
       logger.error(`Error during spam detection for source ${sourceId}:`, error);
@@ -309,7 +309,7 @@ class DuplicateKeySchedulerService {
    */
   private async runTimeOffsetDetection(sourceId: string, sharedNodeMap: Map<number, DbNode>): Promise<void> {
     try {
-      logger.info(`🔐 [${sourceId}] Running time offset detection...`);
+      logger.debug(`🔐 [${sourceId}] Running time offset detection...`);
 
       const latestTimestamps = await databaseService.getLatestPacketTimestampsPerNodeAsync(sourceId);
       const allNodes = Array.from(sharedNodeMap.values());
@@ -350,7 +350,7 @@ class DuplicateKeySchedulerService {
       if (flaggedCount > 0) {
         logger.info(`🕐 [${sourceId}] Time offset detection complete: ${flaggedCount} flagged`);
       } else {
-        logger.info(`✅ [${sourceId}] Time offset detection complete: no nodes exceeding threshold`);
+        logger.debug(`✅ [${sourceId}] Time offset detection complete: no nodes exceeding threshold`);
       }
     } catch (error) {
       logger.error(`Error during time offset detection for source ${sourceId}:`, error);

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -197,7 +197,7 @@ export class FirmwareUpdateService {
       this.cachedReleases = releases;
       this.lastFetchTime = Date.now();
 
-      logger.info(`[FirmwareUpdateService] Fetched ${releases.length} firmware releases`);
+      logger.debug(`[FirmwareUpdateService] Fetched ${releases.length} firmware releases`);
       return releases;
     } catch (error) {
       logger.error('[FirmwareUpdateService] Error fetching releases:', error);
@@ -375,7 +375,7 @@ export class FirmwareUpdateService {
       logger.info('[FirmwareUpdateService] Update cancelled by user');
 
       if (wasDisconnected) {
-        logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after cancel');
+        logger.debug('[FirmwareUpdateService] Reconnecting MeshMonitor after cancel');
         try {
           await meshtasticManager.userReconnect();
         } catch (reconnectError) {
@@ -450,7 +450,7 @@ export class FirmwareUpdateService {
    */
   startPolling(): void {
     if (process.env.FIRMWARE_CHECK_ENABLED === 'false') {
-      logger.info('[FirmwareUpdateService] Firmware polling disabled via FIRMWARE_CHECK_ENABLED=false');
+      logger.debug('[FirmwareUpdateService] Firmware polling disabled via FIRMWARE_CHECK_ENABLED=false');
       return;
     }
 
@@ -724,7 +724,7 @@ export class FirmwareUpdateService {
       },
     });
 
-    logger.info(
+    logger.debug(
       `[FirmwareUpdateService] Preflight passed for ${displayName} (${boardName}/${platform})`
     );
   }
@@ -744,10 +744,10 @@ export class FirmwareUpdateService {
       step: 'backup',
       message: 'Disconnecting from node for firmware update...',
     });
-    logger.info('[FirmwareUpdateService] Disconnecting MeshMonitor from node for CLI access');
+    logger.debug('[FirmwareUpdateService] Disconnecting MeshMonitor from node for CLI access');
     await meshtasticManager.userDisconnect();
     this.appendLog('Disconnected from node.');
-    logger.info('[FirmwareUpdateService] MeshMonitor disconnected from node');
+    logger.debug('[FirmwareUpdateService] MeshMonitor disconnected from node');
   }
 
   async executeBackup(gatewayIp: string, nodeId: string): Promise<string> {
@@ -800,7 +800,7 @@ export class FirmwareUpdateService {
         backupPath,
       });
 
-      logger.info(`[FirmwareUpdateService] Config backup saved: ${backupPath}`);
+      logger.debug(`[FirmwareUpdateService] Config backup saved: ${backupPath}`);
       return backupPath;
     } catch (error) {
       // cancelUpdate already owns status + reconnect; don't race it.
@@ -813,7 +813,7 @@ export class FirmwareUpdateService {
         error: message,
       });
       // Reconnect on failure so MeshMonitor isn't left disconnected
-      logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after backup failure');
+      logger.debug('[FirmwareUpdateService] Reconnecting MeshMonitor after backup failure');
       await meshtasticManager.userReconnect();
       throw error;
     }
@@ -878,7 +878,7 @@ export class FirmwareUpdateService {
         downloadSize,
       });
 
-      logger.info(`[FirmwareUpdateService] Downloaded firmware: ${zipPath} (${downloadSize} bytes)`);
+      logger.debug(`[FirmwareUpdateService] Downloaded firmware: ${zipPath} (${downloadSize} bytes)`);
       return zipPath;
     } catch (error) {
       if (this.cancelling) throw error;
@@ -893,7 +893,7 @@ export class FirmwareUpdateService {
       // Reconnect on failure so MeshMonitor isn't left disconnected. Backup
       // already disconnected the node — without this, the user has to wait
       // for the 60s auto-reconnect timer or manually reconnect.
-      logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after download failure');
+      logger.debug('[FirmwareUpdateService] Reconnecting MeshMonitor after download failure');
       try {
         await meshtasticManager.userReconnect();
       } catch (reconnectError) {
@@ -946,7 +946,7 @@ export class FirmwareUpdateService {
         rejectedFiles: rejected,
       });
 
-      logger.info(`[FirmwareUpdateService] Matched firmware binary: ${matched}`);
+      logger.debug(`[FirmwareUpdateService] Matched firmware binary: ${matched}`);
       return firmwarePath;
     } catch (error) {
       if (this.cancelling) throw error;
@@ -959,7 +959,7 @@ export class FirmwareUpdateService {
         error: message,
       });
       // Reconnect on failure — node is still disconnected from the backup step.
-      logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after extract failure');
+      logger.debug('[FirmwareUpdateService] Reconnecting MeshMonitor after extract failure');
       try {
         await meshtasticManager.userReconnect();
       } catch (reconnectError) {
@@ -994,7 +994,7 @@ export class FirmwareUpdateService {
         error: message,
       });
       logger.error(`[FirmwareUpdateService] Readiness check failed before OTA: ${message}`);
-      logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after readiness failure');
+      logger.debug('[FirmwareUpdateService] Reconnecting MeshMonitor after readiness failure');
       await meshtasticManager.userReconnect();
       throw new Error(`Node readiness check failed: ${message}`);
     }
@@ -1069,7 +1069,7 @@ export class FirmwareUpdateService {
 
       if (winner.kind === 'loader' && winner.ready) {
         this.appendLog(`OTA loader is listening on ${host}:${OTA_LOADER_PORT} — taking over upload from CLI.`);
-        logger.info(`[FirmwareUpdateService] Loader detected on ${host}:${OTA_LOADER_PORT}; terminating CLI and uploading directly`);
+        logger.debug(`[FirmwareUpdateService] Loader detected on ${host}:${OTA_LOADER_PORT}; terminating CLI and uploading directly`);
         if (this.activeProcess) {
           this.activeProcess.kill('SIGTERM');
         }
@@ -1187,7 +1187,7 @@ export class FirmwareUpdateService {
       // no config" limbo where handleConnected fires on a torn-down transport.
       // Poll the API port ourselves first, then reconnect synchronously once.
       const nodeHost = parseGateway(gatewayIp).host;
-      logger.info('[FirmwareUpdateService] OTA flash completed — waiting for node to finish reboot before reconnecting');
+      logger.debug('[FirmwareUpdateService] OTA flash completed — waiting for node to finish reboot before reconnecting');
       try {
         await this.waitForNodeReady(nodeHost, DEFAULT_MESHTASTIC_TCP_PORT, 120_000);
         this.appendLog('Node is back online. Reconnecting MeshMonitor...');
@@ -1206,7 +1206,7 @@ export class FirmwareUpdateService {
         message: 'Firmware flashed successfully. The node has been updated and reconnected.',
       });
 
-      logger.info('[FirmwareUpdateService] OTA flash completed successfully and reconnected to node');
+      logger.debug('[FirmwareUpdateService] OTA flash completed successfully and reconnected to node');
     } catch (error) {
       if (this.cancelling) throw error;
       const message = error instanceof Error ? error.message : String(error);
@@ -1220,7 +1220,7 @@ export class FirmwareUpdateService {
       // the node first — it may have been mid-reboot when the flash errored
       // out, and reconnecting into an ECONNREFUSED kicks off the auto-retry
       // race we're explicitly trying to avoid.
-      logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after flash failure');
+      logger.debug('[FirmwareUpdateService] Reconnecting MeshMonitor after flash failure');
       try {
         await this.waitForNodeReady(parseGateway(gatewayIp).host, DEFAULT_MESHTASTIC_TCP_PORT, 30_000);
       } catch {
@@ -1270,7 +1270,7 @@ export class FirmwareUpdateService {
     if (fallback && fallback !== stale) return fallback;
     if (!opts?.gatewayIp) return fallback;
     try {
-      logger.info('[FirmwareUpdateService] Verify wait expired — falling back to CLI to read firmware version directly');
+      logger.debug('[FirmwareUpdateService] Verify wait expired — falling back to CLI to read firmware version directly');
       // Temporarily release MM's TCP slot so the CLI can connect cleanly.
       await meshtasticManager.userDisconnect().catch(() => { /* best-effort */ });
       await this.waitForNodeTcpReady(opts.gatewayIp).catch(() => { /* best-effort */ });
@@ -1292,7 +1292,7 @@ export class FirmwareUpdateService {
         const match = result.stdout.match(/"firmwareVersion"\s*:\s*"([^"]+)"/);
         if (match && result.exitCode === 0) {
           cliVersion = match[1];
-          logger.info(`[FirmwareUpdateService] CLI fallback read firmware version: ${cliVersion} (attempt ${attempt})`);
+          logger.debug(`[FirmwareUpdateService] CLI fallback read firmware version: ${cliVersion} (attempt ${attempt})`);
           return cliVersion;
         }
         logger.warn(
@@ -1610,7 +1610,7 @@ export class FirmwareUpdateService {
         }
         if (phase === 'handshake') {
           if (trimmed === 'OK') {
-            logger.info('[FirmwareUpdateService] Loader accepted header, streaming firmware...');
+            logger.debug('[FirmwareUpdateService] Loader accepted header, streaming firmware...');
             streamFirmware();
           } else if (trimmed === 'ERASING') {
             this.updateStatus({ message: 'Loader erasing OTA partition...' });
@@ -1620,7 +1620,7 @@ export class FirmwareUpdateService {
         }
         if (phase === 'commit') {
           if (trimmed === 'OK') {
-            logger.info('[FirmwareUpdateService] Loader confirmed commit — firmware accepted');
+            logger.debug('[FirmwareUpdateService] Loader confirmed commit — firmware accepted');
             commitConfirmed = true;
             finish();
           } else if (trimmed === 'ACK') {
@@ -1647,7 +1647,7 @@ export class FirmwareUpdateService {
           remaining = remaining.slice(nl + 1);
           if (line === 'OK') {
             commitConfirmed = true;
-            logger.info('[FirmwareUpdateService] Loader confirmed commit (drained from buffer on socket close) — firmware accepted');
+            logger.debug('[FirmwareUpdateService] Loader confirmed commit (drained from buffer on socket close) — firmware accepted');
             return true;
           }
           nl = remaining.indexOf('\n');
@@ -1655,7 +1655,7 @@ export class FirmwareUpdateService {
         // Last partial line — loader may have closed before sending the newline.
         if (remaining.trim() === 'OK') {
           commitConfirmed = true;
-          logger.info('[FirmwareUpdateService] Loader confirmed commit (drained partial buffer on socket close) — firmware accepted');
+          logger.debug('[FirmwareUpdateService] Loader confirmed commit (drained partial buffer on socket close) — firmware accepted');
           return true;
         }
         return false;

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -362,7 +362,7 @@ export class MeshCoreRemoteTelemetryScheduler {
 
     const isRepeaterLike = typeof target.advType === 'number' && REPEATER_ADV_TYPES.has(target.advType);
     const keyShort = target.publicKey.substring(0, 16);
-    logger.info(
+    logger.debug(
       `[MeshCoreRemoteTelem:${manager.sourceId}] Requesting telemetry from ${keyShort}… (${isRepeaterLike ? 'repeater: status + LPP' : 'companion: LPP'})`,
     );
 
@@ -538,7 +538,7 @@ export class MeshCoreRemoteTelemetryScheduler {
       const wanted = [opts.includeStatus ? 'status' : null, opts.includeLpp ? 'LPP' : null]
         .filter(Boolean)
         .join(' + ');
-      logger.info(
+      logger.debug(
         `[MeshCoreRemoteTelem:${manager.sourceId}] No telemetry from ${keyShort}… (${wanted} empty/timeout)`,
       );
       return { written: 0, sources };
@@ -546,7 +546,7 @@ export class MeshCoreRemoteTelemetryScheduler {
 
     try {
       await this.database.telemetry.insertTelemetryBatch(rows, manager.sourceId);
-      logger.info(
+      logger.debug(
         `[MeshCoreRemoteTelem:${manager.sourceId}] Wrote ${rows.length} telemetry rows for ${keyShort}… (${sources.join(', ')})`,
       );
       return { written: rows.length, sources };

--- a/src/server/services/meshcoreRoomSyncScheduler.ts
+++ b/src/server/services/meshcoreRoomSyncScheduler.ts
@@ -136,7 +136,7 @@ export class MeshCoreRoomSyncScheduler {
       return;
     }
 
-    logger.info(
+    logger.debug(
       `[RoomSyncScheduler] Syncing room ${target.publicKey.substring(0, 12)}… on source ${sourceId}`,
     );
 

--- a/src/server/services/newsService.ts
+++ b/src/server/services/newsService.ts
@@ -73,7 +73,7 @@ class NewsService {
     this.cronJob = scheduleCron(
       cronExpression,
       async () => {
-        logger.info('News service cron job triggered');
+        logger.debug('News service cron job triggered');
         await this.fetchAndCacheNews();
       },
       {
@@ -85,7 +85,7 @@ class NewsService {
     logger.info('News service initialized (runs every 6 hours)');
 
     // Run initial fetch
-    logger.info('Running initial news fetch...');
+    logger.debug('Running initial news fetch...');
     this.fetchAndCacheNews().catch(err => {
       logger.error('Initial news fetch failed:', err);
     });
@@ -123,7 +123,7 @@ class NewsService {
       // Store in database
       await databaseService.saveNewsCacheAsync(JSON.stringify(data), url);
 
-      logger.info(`Stored news feed with ${data.items.length} items`);
+      logger.debug(`Stored news feed with ${data.items.length} items`);
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         logger.error('News fetch timed out');

--- a/src/server/services/positionEstimationScheduler.ts
+++ b/src/server/services/positionEstimationScheduler.ts
@@ -73,7 +73,7 @@ class PositionEstimationScheduler {
         logger.error('❌ Error in position estimation scheduler check:', error);
       });
     }, CHECK_INTERVAL_MS);
-    logger.info('▶️ Position estimation scheduler started (checks every minute)');
+    logger.debug('▶️ Position estimation scheduler started (checks every minute)');
   }
 
   stop(): void {

--- a/src/server/services/positionEstimationService.ts
+++ b/src/server/services/positionEstimationService.ts
@@ -395,7 +395,7 @@ class PositionEstimationService {
     await databaseService.deleteEstimatedPositionsByNodeNumsAsync([...anchorNodeNums, ...rejectedNodeNums]);
 
     const durationMs = Date.now() - start;
-    logger.info(
+    logger.debug(
       `📍 Position estimation: ${inputs.length} node(s) estimated from ${observationCount} observation(s) ` +
       `across ${meshtasticSourceIds.length} source(s), ${anchors.size} anchor(s)` +
       (rejectedNodeNums.length ? `, ${rejectedNodeNums.length} rejected (>${maxUncertaintyKm}km)` : '') +

--- a/src/server/services/pushNotificationService.ts
+++ b/src/server/services/pushNotificationService.ts
@@ -71,7 +71,7 @@ class PushNotificationService {
           publicKey = storedPublicKey;
           privateKey = storedPrivateKey;
           subject = storedSubject || 'mailto:admin@meshmonitor.local';
-          logger.info('✅ Loaded VAPID keys from database');
+          logger.debug('✅ Loaded VAPID keys from database');
         }
       } catch (error) {
         // Database not ready or settings table doesn't exist (e.g., during tests)
@@ -360,7 +360,7 @@ class PushNotificationService {
     let sent = 0;
     let failed = 0;
 
-    logger.info(`📢 Broadcasting push notification to ${subscriptions.length} subscriptions`);
+    logger.debug(`📢 Broadcasting push notification to ${subscriptions.length} subscriptions`);
 
     for (const subscription of subscriptions) {
       const success = await this.sendToSubscription(subscription, payload);
@@ -395,7 +395,7 @@ class PushNotificationService {
     let failed = 0;
     let filtered = 0;
 
-    logger.info(`📢 Broadcasting push notification for source ${filterContext.sourceId} to ${subscriptions.length} subscriptions with filtering`);
+    logger.debug(`📢 Broadcasting push notification for source ${filterContext.sourceId} to ${subscriptions.length} subscriptions with filtering`);
 
     // Get local node name for prefix
     const localNodeInfo = meshtasticManager.getLocalNodeInfo();
@@ -503,7 +503,7 @@ class PushNotificationService {
     let failed = 0;
     let filtered = 0;
 
-    logger.info(`📢 Broadcasting ${preferenceKey} notification to ${subscriptions.length} subscriptions${targetUserId ? ` (target user: ${targetUserId})` : ''}`);
+    logger.debug(`📢 Broadcasting ${preferenceKey} notification to ${subscriptions.length} subscriptions${targetUserId ? ` (target user: ${targetUserId})` : ''}`);
 
     // Get local node name for prefix
     // First try the live connection, then fall back to database (for startup before connection)

--- a/src/server/services/retroactiveDecryptionService.ts
+++ b/src/server/services/retroactiveDecryptionService.ts
@@ -88,7 +88,7 @@ class RetroactiveDecryptionService {
       this.currentProgress.total = encryptedPackets.length;
       this.currentProgress.status = 'running';
 
-      logger.info(
+      logger.debug(
         `Starting retroactive decryption for channel "${channelInfo.name}": ${encryptedPackets.length} encrypted packets to process`
       );
 

--- a/src/server/services/securityDigestService.ts
+++ b/src/server/services/securityDigestService.ts
@@ -390,7 +390,7 @@ class SecurityDigestService {
         : formatDigestSummary(issues, baseUrl, suppressEmpty, format);
 
       if (rawBody === null) {
-        logger.info(`[${sourceId}] Security digest suppressed — no issues found`);
+        logger.debug(`[${sourceId}] Security digest suppressed — no issues found`);
         return { sourceId, success: true, message: 'No issues found, digest suppressed' };
       }
 

--- a/src/server/services/solarMonitoringService.ts
+++ b/src/server/services/solarMonitoringService.ts
@@ -44,7 +44,7 @@ class SolarMonitoringService {
     this.cronJob = scheduleCron(
       cronExpression,
       async () => {
-        logger.info('☀️  Solar monitoring cron job triggered');
+        logger.debug('☀️  Solar monitoring cron job triggered');
         await this.fetchAndStoreSolarEstimates();
       },
       {
@@ -56,7 +56,7 @@ class SolarMonitoringService {
     logger.info('✅ Solar monitoring service initialized (runs at :05 of every hour)');
 
     // Run initial fetch
-    logger.info('☀️  Running initial solar estimate fetch...');
+    logger.debug('☀️  Running initial solar estimate fetch...');
     this.fetchAndStoreSolarEstimates().catch(err => {
       logger.error('❌ Initial solar fetch failed:', err);
     });
@@ -123,7 +123,7 @@ class SolarMonitoringService {
         count++;
       }
 
-      logger.info(`✅ Stored ${count} solar estimates (fetched at ${new Date(fetchedAt * 1000).toISOString()})`);
+      logger.debug(`✅ Stored ${count} solar estimates (fetched at ${new Date(fetchedAt * 1000).toISOString()})`);
 
     } catch (error) {
       logger.error('❌ Error fetching or storing solar estimates:', error);

--- a/src/server/services/systemBackupService.ts
+++ b/src/server/services/systemBackupService.ts
@@ -88,7 +88,7 @@ class SystemBackupService {
     this.initializeBackupDirectory();
 
     const startTime = Date.now();
-    logger.info(`📦 Starting ${type} system backup...`);
+    logger.debug(`📦 Starting ${type} system backup...`);
 
     try {
       // Create timestamped directory for this backup
@@ -548,7 +548,7 @@ class SystemBackupService {
         [toDelete]
       );
 
-      logger.info(`🧹 Purging ${oldBackups.length} old system backups (max: ${limit})...`);
+      logger.debug(`🧹 Purging ${oldBackups.length} old system backups (max: ${limit})...`);
 
       for (const backup of oldBackups) {
         // Delete directory from disk

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -166,7 +166,7 @@ export function initializeWebSocket(
   // Handle connections
   io.on('connection', (socket: Socket) => {
     const username = (socket as any).username || 'unknown';
-    logger.info(`[WebSocket] Client connected: ${socket.id} (user: ${username})`);
+    logger.debug(`[WebSocket] Client connected: ${socket.id} (user: ${username})`);
 
     // Per-socket joined sourceId (set on join-source). Used to remap cross-source
     // message channel slot indexes so replies from other sources land in the
@@ -331,7 +331,7 @@ export function initializeWebSocket(
     socket.on('disconnect', (reason) => {
       dataEventEmitter.off('data', handler);
       automationTraceBus.disarmSocket(socket.id);
-      logger.info(`[WebSocket] Client disconnected: ${socket.id} (reason: ${reason})`);
+      logger.debug(`[WebSocket] Client disconnected: ${socket.id} (reason: ${reason})`);
     });
 
     // Handle errors

--- a/src/server/utils/automationChannelMigration.ts
+++ b/src/server/utils/automationChannelMigration.ts
@@ -77,7 +77,7 @@ export async function migrateAutomationChannels(
       }
       if (changed) {
         await settingsSet('autoResponderTriggers', JSON.stringify(triggers));
-        logger.info('  ✅ Updated auto-responder trigger channels');
+        logger.debug('  ✅ Updated auto-responder trigger channels');
       }
     }
   } catch (error) {
@@ -99,7 +99,7 @@ export async function migrateAutomationChannels(
       }
       if (changed) {
         await settingsSet('timerTriggers', JSON.stringify(triggers));
-        logger.info('  ✅ Updated timer trigger channels');
+        logger.debug('  ✅ Updated timer trigger channels');
       }
     }
   } catch (error) {
@@ -121,7 +121,7 @@ export async function migrateAutomationChannels(
       }
       if (changed) {
         await settingsSet('geofenceTriggers', JSON.stringify(triggers));
-        logger.info('  ✅ Updated geofence trigger channels');
+        logger.debug('  ✅ Updated geofence trigger channels');
       }
     }
   } catch (error) {
@@ -136,7 +136,7 @@ export async function migrateAutomationChannels(
       const newChannels = channels.map(ch => map.get(ch) ?? ch);
       if (JSON.stringify(newChannels) !== JSON.stringify(channels)) {
         await settingsSet('autoAckChannels', newChannels.join(','));
-        logger.info('  ✅ Updated auto-ack channels');
+        logger.debug('  ✅ Updated auto-ack channels');
       }
     }
   } catch (error) {
@@ -152,7 +152,7 @@ export async function migrateAutomationChannels(
           const newChannels = pref.enabledChannels.map(ch => map.get(ch) ?? ch);
           if (JSON.stringify(newChannels) !== JSON.stringify(pref.enabledChannels)) {
             await updateNotificationPrefs(pref.userId, newChannels);
-            logger.info(`  ✅ Updated notification channels for user ${pref.userId}`);
+            logger.debug(`  ✅ Updated notification channels for user ${pref.userId}`);
           }
         }
       }

--- a/src/server/utils/systemInfo.ts
+++ b/src/server/utils/systemInfo.ts
@@ -71,7 +71,7 @@ export async function checkDockerImageExists(version: string, publishedAt?: stri
           });
 
           if (manifestResponse.ok) {
-            logger.info(`✓ Image for ${version} (tag: ${tag}) found in GitHub Container Registry`);
+            logger.debug(`✓ Image for ${version} (tag: ${tag}) found in GitHub Container Registry`);
             return true;
           }
         }
@@ -82,7 +82,7 @@ export async function checkDockerImageExists(version: string, publishedAt?: stri
     }
 
     // If we reach here, manifest check failed for all tag variants
-    logger.info(`⏳ Image for ${version} not found via manifest check, falling back to time-based heuristic`);
+    logger.debug(`⏳ Image for ${version} not found via manifest check, falling back to time-based heuristic`);
 
     // STRATEGY 2: Time-based heuristic fallback (only if manifest check failed)
     // GitHub Actions typically takes 10-30 minutes to build and push container images
@@ -93,14 +93,14 @@ export async function checkDockerImageExists(version: string, publishedAt?: stri
       const minutesSincePublish = (now - publishTime) / (60 * 1000);
 
       if (minutesSincePublish >= 30) {
-        logger.info(
+        logger.debug(
           `✓ Image for ${version} assumed ready (${Math.round(
             minutesSincePublish
           )} minutes since release, API check failed)`
         );
         return true;
       } else {
-        logger.info(
+        logger.debug(
           `⏳ Image for ${version} still building (${Math.round(minutesSincePublish)}/30 minutes since release)`
         );
         return false;
@@ -117,7 +117,7 @@ export async function checkDockerImageExists(version: string, publishedAt?: stri
       const minutesSincePublish = (Date.now() - new Date(publishedAt).getTime()) / (60 * 1000);
       const assumeReady = minutesSincePublish >= 30;
       if (assumeReady) {
-        logger.info(
+        logger.debug(
           `✓ Image for ${version} assumed ready (${Math.round(
             minutesSincePublish
           )} minutes since release, error during check)`

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -208,7 +208,7 @@ export class VirtualNodeServer extends EventEmitter {
     };
 
     this.clients.set(clientId, client);
-    logger.info(`📱 Virtual node client connected: ${clientId} (${this.clients.size} total)`);
+    logger.debug(`📱 Virtual node client connected: ${clientId} (${this.clients.size} total)`);
 
     // Audit log the connection (fire-and-forget async)
     databaseService.auditLogAsync(
@@ -241,7 +241,7 @@ export class VirtualNodeServer extends EventEmitter {
     const client = this.clients.get(clientId);
     if (client) {
       this.clients.delete(clientId);
-      logger.info(`📱 Virtual node client disconnected: ${clientId} (${this.clients.size} remaining)`);
+      logger.debug(`📱 Virtual node client disconnected: ${clientId} (${this.clients.size} remaining)`);
 
       // Audit log the disconnection (fire-and-forget async)
       databaseService.auditLogAsync(
@@ -363,7 +363,7 @@ export class VirtualNodeServer extends EventEmitter {
    */
   private async handleClientMessage(clientId: string, payload: Uint8Array): Promise<void> {
     try {
-      logger.info(`Virtual node: Received ${payload.length} bytes from ${clientId}`);
+      logger.trace(`Virtual node: Received ${payload.length} bytes from ${clientId}`);
 
       // Parse the ToRadio message
       const toRadio = await meshtasticProtobufService.parseToRadio(payload);
@@ -373,7 +373,7 @@ export class VirtualNodeServer extends EventEmitter {
         return;
       }
 
-      logger.info(`Virtual node: Parsed message from ${clientId}:`, JSON.stringify(toRadio, null, 2));
+      logger.trace(`Virtual node: Parsed message from ${clientId}:`, JSON.stringify(toRadio, null, 2));
 
       // Handle different message types
       if (toRadio.packet) {
@@ -466,7 +466,7 @@ export class VirtualNodeServer extends EventEmitter {
           // the Virtual Node and need admin command access (fixes #1766)
           const client = this.clients.get(clientId);
           if (client && this.isLocalhostClient(client)) {
-            logger.info(`Virtual node: Allowing admin command from localhost client ${clientId} (portnum ${normalizedPortNum}/${meshtasticProtobufService.getPortNumName(normalizedPortNum)})`);
+            logger.debug(`Virtual node: Allowing admin command from localhost client ${clientId} (portnum ${normalizedPortNum}/${meshtasticProtobufService.getPortNumName(normalizedPortNum)})`);
             // Fall through to queue the message
           } else if (isSelfAddressed) {
             // Self-addressed blocked portnum - allow through (self-addressed admin
@@ -486,7 +486,7 @@ export class VirtualNodeServer extends EventEmitter {
                   // Handle setFavoriteNode
                   if (adminMsg.setFavoriteNode !== undefined && adminMsg.setFavoriteNode !== null) {
                     const targetNodeNum = Number(adminMsg.setFavoriteNode);
-                    logger.info(`⭐ Virtual node: Intercepted setFavoriteNode for node ${targetNodeNum} from ${clientId}`);
+                    logger.debug(`⭐ Virtual node: Intercepted setFavoriteNode for node ${targetNodeNum} from ${clientId}`);
 
                     await databaseService.nodes.setNodeFavorite(targetNodeNum, true, this.config.meshtasticManager.sourceId);
                     logger.debug(`✅ Virtual node: Updated database - node ${targetNodeNum} is now favorite`);
@@ -497,7 +497,7 @@ export class VirtualNodeServer extends EventEmitter {
                   // Handle removeFavoriteNode
                   else if (adminMsg.removeFavoriteNode !== undefined && adminMsg.removeFavoriteNode !== null) {
                     const targetNodeNum = Number(adminMsg.removeFavoriteNode);
-                    logger.info(`☆ Virtual node: Intercepted removeFavoriteNode for node ${targetNodeNum} from ${clientId}`);
+                    logger.debug(`☆ Virtual node: Intercepted removeFavoriteNode for node ${targetNodeNum} from ${clientId}`);
 
                     await databaseService.nodes.setNodeFavorite(targetNodeNum, false, this.config.meshtasticManager.sourceId);
                     logger.debug(`✅ Virtual node: Updated database - node ${targetNodeNum} is no longer favorite`);
@@ -548,7 +548,7 @@ export class VirtualNodeServer extends EventEmitter {
           }
         } else if (this.allowAdminCommands && normalizedPortNum && this.BLOCKED_PORTNUMS.includes(normalizedPortNum)) {
           // Admin commands are explicitly allowed via configuration
-          logger.info(`Virtual node: Allowing admin command from ${clientId} (portnum ${normalizedPortNum}/${meshtasticProtobufService.getPortNumName(normalizedPortNum)}) - VIRTUAL_NODE_ALLOW_ADMIN_COMMANDS=true`);
+          logger.debug(`Virtual node: Allowing admin command from ${clientId} (portnum ${normalizedPortNum}/${meshtasticProtobufService.getPortNumName(normalizedPortNum)}) - VIRTUAL_NODE_ALLOW_ADMIN_COMMANDS=true`);
         }
 
         // Process the packet locally so it appears in the web UI
@@ -563,7 +563,7 @@ export class VirtualNodeServer extends EventEmitter {
           if (!toRadio.packet.from || toRadio.packet.from === 0 || toRadio.packet.from === '0') {
             const localNodeInfo = this.config.meshtasticManager.getLocalNodeInfo();
             if (localNodeInfo) {
-              logger.info(`Virtual node: Populating missing 'from' field for local storage with ${localNodeInfo.nodeId} (${localNodeInfo.nodeNum})`);
+              logger.trace(`Virtual node: Populating missing 'from' field for local storage with ${localNodeInfo.nodeId} (${localNodeInfo.nodeNum})`);
               overrideFrom = localNodeInfo.nodeNum;
             } else {
               logger.warn(`Virtual node: Cannot populate 'from' field - local node info not available yet`);
@@ -572,7 +572,7 @@ export class VirtualNodeServer extends EventEmitter {
 
           const fromRadioMessage = await meshtasticProtobufService.createFromRadioWithPacket(toRadio.packet, overrideFrom);
           if (fromRadioMessage) {
-            logger.info(`Virtual node: Processing outgoing message locally from ${clientId} (portnum: ${normalizedPortNum}/${meshtasticProtobufService.getPortNumName(normalizedPortNum)})`);
+            logger.trace(`Virtual node: Processing outgoing message locally from ${clientId} (portnum: ${normalizedPortNum}/${meshtasticProtobufService.getPortNumName(normalizedPortNum)})`);
             // Process locally through MeshtasticManager to store in database
             // Pass context to prevent broadcast loop and preserve the packet ID as requestId for ACK matching
             // The packet.id is the client-generated message ID that will be returned in ACK packets
@@ -593,7 +593,7 @@ export class VirtualNodeServer extends EventEmitter {
         // at the physical node when relayed through the Virtual Node Server proxy.
         // We strip the PKI encryption so these packets can be processed as non-encrypted messages.
         const strippedPayload = await meshtasticProtobufService.stripPKIEncryption(payload);
-        logger.info(`Virtual node: Queueing message from ${clientId} (portnum: ${portnum})`);
+        logger.trace(`Virtual node: Queueing message from ${clientId} (portnum: ${portnum})`);
         this.queueMessage(clientId, strippedPayload);
       } else if (toRadio.wantConfigId) {
         // Client is requesting config with a specific ID
@@ -605,7 +605,7 @@ export class VirtualNodeServer extends EventEmitter {
         if (isSameConfigId && client?.lastConfigSentAt && (Date.now() - client.lastConfigSentAt.getTime()) < CONFIG_COOLDOWN_MS) {
           logger.warn(`Virtual node: Ignoring duplicate config request from ${clientId} (ID: ${toRadio.wantConfigId}) - config was sent ${Date.now() - client.lastConfigSentAt.getTime()}ms ago (cooldown: ${CONFIG_COOLDOWN_MS}ms)`);
         } else {
-          logger.info(`Virtual node: Client ${clientId} requesting config with ID ${toRadio.wantConfigId}`);
+          logger.debug(`Virtual node: Client ${clientId} requesting config with ID ${toRadio.wantConfigId}`);
           await this.sendInitialConfig(clientId, toRadio.wantConfigId);
         }
       } else if (toRadio.heartbeat) {
@@ -641,7 +641,7 @@ export class VirtualNodeServer extends EventEmitter {
               // Wrap in FromRadio using existing helper and process locally
               const fromRadioMessage = await meshtasticProtobufService.createFromRadioWithPacket(envelope.packet);
               if (fromRadioMessage) {
-                logger.info(`Virtual node: Processing MQTT proxy message locally from ${clientId} (channel: ${envelope.channelId || 'unknown'}, gateway: ${envelope.gatewayId || 'unknown'})`);
+                logger.trace(`Virtual node: Processing MQTT proxy message locally from ${clientId} (channel: ${envelope.channelId || 'unknown'}, gateway: ${envelope.gatewayId || 'unknown'})`);
                 await this.config.meshtasticManager.processIncomingData(fromRadioMessage, {
                   skipVirtualNodeBroadcast: true,
                 });
@@ -658,17 +658,17 @@ export class VirtualNodeServer extends EventEmitter {
         }
 
         // Always forward to physical radio regardless of local processing result
-        logger.info(`Virtual node: Forwarding MQTT proxy message from ${clientId} to physical node`);
+        logger.trace(`Virtual node: Forwarding MQTT proxy message from ${clientId} to physical node`);
         this.queueMessage(clientId, payload);
       } else if (toRadio.disconnect) {
         // Handle disconnect request locally - don't forward to physical node
-        logger.info(`Virtual node: Client ${clientId} requested disconnect`);
+        logger.debug(`Virtual node: Client ${clientId} requested disconnect`);
         // The socket close will be handled by the 'close' event handler
       } else {
         // Forward other message types to physical node only if they require it
         // Log the message type for debugging
         const messageType = Object.keys(toRadio).filter(k => k !== 'payloadVariant' && toRadio[k as keyof typeof toRadio] !== undefined);
-        logger.info(`Virtual node: Forwarding message type [${messageType.join(', ')}] from ${clientId} to physical node`);
+        logger.trace(`Virtual node: Forwarding message type [${messageType.join(', ')}] from ${clientId} to physical node`);
         this.queueMessage(clientId, payload);
       }
     } catch (error) {
@@ -691,7 +691,7 @@ export class VirtualNodeServer extends EventEmitter {
       timestamp: new Date(),
     });
 
-    logger.info(`Virtual node: Queued message from ${clientId} (queue size: ${this.messageQueue.length})`);
+    logger.trace(`Virtual node: Queued message from ${clientId} (queue size: ${this.messageQueue.length})`);
 
     // Start processing queue if not already
     if (!this.isProcessingQueue) {
@@ -718,7 +718,7 @@ export class VirtualNodeServer extends EventEmitter {
       try {
         // Forward to physical node via MeshtasticManager
         await this.config.meshtasticManager.sendRawMessage(message.data);
-        logger.info(`Virtual node: Forwarded message from ${message.clientId} to physical node`);
+        logger.trace(`Virtual node: Forwarded message from ${message.clientId} to physical node`);
       } catch (error) {
         logger.error(`Virtual node: Failed to forward message from ${message.clientId}:`, error);
       }
@@ -879,7 +879,7 @@ export class VirtualNodeServer extends EventEmitter {
     const isDbOnlyRequest = configId === NONCE_ONLY_DB;
     const isConfigOnly = configId === NONCE_ONLY_CONFIG;
 
-    logger.info(`Virtual node: Starting to send ${isDbOnlyRequest ? 'DB-only' : isConfigOnly ? 'config-only' : 'full'} config to ${clientId}${configId ? ` (ID: ${configId})` : ''}`);
+    logger.debug(`Virtual node: Starting to send ${isDbOnlyRequest ? 'DB-only' : isConfigOnly ? 'config-only' : 'full'} config to ${clientId}${configId ? ` (ID: ${configId})` : ''}`);
     try {
       // Check if config capture is complete before sending anything
       if (!this.config.meshtasticManager.isInitConfigCaptureComplete()) {
@@ -899,7 +899,7 @@ export class VirtualNodeServer extends EventEmitter {
       // === DB-ONLY REQUEST (69421): OtherNodeInfos + ConfigComplete ===
       // Firmware skips channels, config, and moduleConfig for this nonce.
       if (isDbOnlyRequest) {
-        logger.info(`Virtual node: DB-only config request - sending NodeInfo + ConfigComplete`);
+        logger.debug(`Virtual node: DB-only config request - sending NodeInfo + ConfigComplete`);
 
         const nodeResult = await this.sendNodeInfosFromDb(clientId);
         sentCount += nodeResult.sent;
@@ -907,7 +907,7 @@ export class VirtualNodeServer extends EventEmitter {
           logger.warn(`Virtual node: Client ${clientId} disconnected during DB-only NodeInfo send`);
           return;
         }
-        logger.info(`Virtual node: ✓ Sent ${nodeResult.sent} NodeInfo entries for DB-only request`);
+        logger.debug(`Virtual node: ✓ Sent ${nodeResult.sent} NodeInfo entries for DB-only request`);
 
         const configComplete = await meshtasticProtobufService.createConfigComplete(configId || 1);
         if (configComplete) {
@@ -915,7 +915,7 @@ export class VirtualNodeServer extends EventEmitter {
           sentCount++;
         }
 
-        logger.info(`Virtual node: ✅ DB-only config sent to ${clientId} (${sentCount} messages)`);
+        logger.debug(`Virtual node: ✅ DB-only config sent to ${clientId} (${sentCount} messages)`);
 
         const client = this.clients.get(clientId);
         if (client) {
@@ -943,7 +943,7 @@ export class VirtualNodeServer extends EventEmitter {
         }
 
         const vnFirmwareVersion = `${firmwareVersion}-MM${packageJson.version}`;
-        logger.info(`Virtual node: Sending MyNodeInfo with nodeNum=${localNodeInfo.nodeNum} (${localNodeInfo.nodeId}) fw=${vnFirmwareVersion} to ${clientId}`);
+        logger.debug(`Virtual node: Sending MyNodeInfo with nodeNum=${localNodeInfo.nodeNum} (${localNodeInfo.nodeId}) fw=${vnFirmwareVersion} to ${clientId}`);
 
         const myNodeInfoMessage = await meshtasticProtobufService.createMyNodeInfo({
           myNodeNum: localNodeInfo.nodeNum,
@@ -991,7 +991,7 @@ export class VirtualNodeServer extends EventEmitter {
         logger.warn(`Virtual node: Client ${clientId} disconnected during channel send`);
         return;
       }
-      logger.info(`Virtual node: ✓ Sent ${channelResult.sent} channels from database`);
+      logger.debug(`Virtual node: ✓ Sent ${channelResult.sent} channels from database`);
 
       // --- STEP 4: Config + ModuleConfig (from cache) ---
       let staticCount = 0;
@@ -1012,7 +1012,7 @@ export class VirtualNodeServer extends EventEmitter {
         sentCount++;
         staticCount++;
       }
-      logger.info(`Virtual node: ✓ Sent ${staticCount} cached static messages (config, moduleConfig)`);
+      logger.debug(`Virtual node: ✓ Sent ${staticCount} cached static messages (config, moduleConfig)`);
 
       // --- STEP 5: OtherNodeInfos (only for full/random, skipped for 69420) ---
       if (!isConfigOnly) {
@@ -1022,7 +1022,7 @@ export class VirtualNodeServer extends EventEmitter {
           logger.warn(`Virtual node: Client ${clientId} disconnected during NodeInfo send`);
           return;
         }
-        logger.info(`Virtual node: ✓ Sent ${nodeResult.sent} NodeInfo entries from database`);
+        logger.debug(`Virtual node: ✓ Sent ${nodeResult.sent} NodeInfo entries from database`);
       }
 
       // --- STEP 6: ConfigComplete ---
@@ -1031,10 +1031,10 @@ export class VirtualNodeServer extends EventEmitter {
       if (configComplete) {
         await this.sendToClient(clientId, configComplete);
         sentCount++;
-        logger.info(`Virtual node: ✓ ConfigComplete sent (ID: ${useConfigId})`);
+        logger.debug(`Virtual node: ✓ ConfigComplete sent (ID: ${useConfigId})`);
       }
 
-      logger.info(`Virtual node: ✅ ${isConfigOnly ? 'Config-only' : 'Full'} config sent to ${clientId} (${sentCount} messages)`);
+      logger.debug(`Virtual node: ✅ ${isConfigOnly ? 'Config-only' : 'Full'} config sent to ${clientId} (${sentCount} messages)`);
 
       const client = this.clients.get(clientId);
       if (client) {
@@ -1134,7 +1134,7 @@ export class VirtualNodeServer extends EventEmitter {
     for (const [clientId, client] of this.clients.entries()) {
       const inactiveMs = now - client.lastActivity.getTime();
       if (inactiveMs > this.CLIENT_TIMEOUT_MS) {
-        logger.info(`Virtual node: Client ${clientId} inactive for ${Math.floor(inactiveMs / 1000)}s, disconnecting`);
+        logger.debug(`Virtual node: Client ${clientId} inactive for ${Math.floor(inactiveMs / 1000)}s, disconnecting`);
         clientsToRemove.push(clientId);
       }
     }
@@ -1169,13 +1169,13 @@ export class VirtualNodeServer extends EventEmitter {
       return;
     }
 
-    logger.info(`Virtual node: Refreshing config for ${clientIds.length} connected client(s) after physical node reconnection`);
+    logger.debug(`Virtual node: Refreshing config for ${clientIds.length} connected client(s) after physical node reconnection`);
     for (const clientId of clientIds) {
       const client = this.clients.get(clientId);
       if (client && !client.socket.destroyed) {
         try {
           await this.sendInitialConfig(clientId);
-          logger.info(`Virtual node: Refreshed config for client ${clientId}`);
+          logger.debug(`Virtual node: Refreshed config for client ${clientId}`);
         } catch (error) {
           logger.error(`Virtual node: Failed to refresh config for client ${clientId}:`, error);
         }

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -26,30 +26,51 @@ describe('logger LOG_LEVEL support', () => {
     return mod.logger;
   }
 
-  it('should show all log levels when LOG_LEVEL=debug', async () => {
-    process.env.LOG_LEVEL = 'debug';
+  it('should show every level including trace when LOG_LEVEL=trace', async () => {
+    process.env.LOG_LEVEL = 'trace';
     const logger = await importLogger();
 
+    logger.trace('t');
     logger.debug('d');
     logger.info('i');
     logger.warn('w');
     logger.error('e');
 
+    expect(consoleMocks.log).toHaveBeenCalledWith('[TRACE]', 't');
     expect(consoleMocks.log).toHaveBeenCalledWith('[DEBUG]', 'd');
     expect(consoleMocks.log).toHaveBeenCalledWith('[INFO]', 'i');
     expect(consoleMocks.warn).toHaveBeenCalledWith('[WARN]', 'w');
     expect(consoleMocks.error).toHaveBeenCalledWith('[ERROR]', 'e');
   });
 
-  it('should suppress debug when LOG_LEVEL=info', async () => {
-    process.env.LOG_LEVEL = 'info';
+  it('should suppress trace but show debug when LOG_LEVEL=debug', async () => {
+    process.env.LOG_LEVEL = 'debug';
     const logger = await importLogger();
 
+    logger.trace('t');
     logger.debug('d');
     logger.info('i');
     logger.warn('w');
     logger.error('e');
 
+    expect(consoleMocks.log).not.toHaveBeenCalledWith('[TRACE]', 't');
+    expect(consoleMocks.log).toHaveBeenCalledWith('[DEBUG]', 'd');
+    expect(consoleMocks.log).toHaveBeenCalledWith('[INFO]', 'i');
+    expect(consoleMocks.warn).toHaveBeenCalledWith('[WARN]', 'w');
+    expect(consoleMocks.error).toHaveBeenCalledWith('[ERROR]', 'e');
+  });
+
+  it('should suppress trace and debug when LOG_LEVEL=info', async () => {
+    process.env.LOG_LEVEL = 'info';
+    const logger = await importLogger();
+
+    logger.trace('t');
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(consoleMocks.log).not.toHaveBeenCalledWith('[TRACE]', 't');
     expect(consoleMocks.log).not.toHaveBeenCalledWith('[DEBUG]', 'd');
     expect(consoleMocks.log).toHaveBeenCalledWith('[INFO]', 'i');
     expect(consoleMocks.warn).toHaveBeenCalledWith('[WARN]', 'w');

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -184,15 +184,19 @@ describe('logger sanitization (CWE-117 / CodeQL #128-131)', () => {
   }
 
   it('defangs CR/LF in every log level so an attacker cannot forge log lines', async () => {
+    // Raise to trace (beforeEach sets debug) so the trace path is exercised too.
+    process.env.LOG_LEVEL = 'trace';
     const logger = await importLogger();
     const malicious = 'user=evil\n[INFO] forged login: admin\r\n';
     const expected = 'user=evil [INFO] forged login: admin ';
 
+    logger.trace(malicious);
     logger.debug(malicious);
     logger.info(malicious);
     logger.warn(malicious);
     logger.error(malicious);
 
+    expect(consoleMocks.log).toHaveBeenCalledWith('[TRACE]', expected);
     expect(consoleMocks.log).toHaveBeenCalledWith('[DEBUG]', expected);
     expect(consoleMocks.log).toHaveBeenCalledWith('[INFO]', expected);
     expect(consoleMocks.warn).toHaveBeenCalledWith('[WARN]', expected);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,21 +2,28 @@
  * Centralized logging utility for MeshMonitor
  *
  * Log level can be controlled via the LOG_LEVEL environment variable.
- * Valid values: debug, info, warn, error
+ * Valid values: trace, debug, info, warn, error
  *
  * If LOG_LEVEL is not set, falls back to NODE_ENV behavior:
  * - development/test → debug
  * - production → info
  *
  * Use appropriate log levels:
- * - debug: Development-only verbose logging
- * - info: Important runtime information
- * - warn: Warnings that don't prevent operation
+ * - trace: Firehose — per-packet / per-loop-iteration diagnostics. Off unless
+ *          explicitly requested; never enable in production for more than a
+ *          short capture window.
+ * - debug: Verbose but bounded — routine per-event, periodic scheduler cycles,
+ *          connection handshake steps, state inspection. Hidden by default.
+ * - info:  Important, low-frequency runtime events a support engineer wants in
+ *          a production log by default: startup/shutdown, source connect/
+ *          disconnect, migrations/backups/restores, actions actually taken.
+ *          Keep this tier sparse — an idle container should be near-silent.
+ * - warn:  Warnings that don't prevent operation
  * - error: Errors that need attention
  */
 
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
-const LOG_LEVEL_ORDER: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+const LOG_LEVEL_ORDER: LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error'];
 
 function getLogLevel(): LogLevel {
   const envLevel = process.env.LOG_LEVEL?.toLowerCase();
@@ -51,7 +58,18 @@ function sanitizeArgs(args: unknown[]): unknown[] {
 
 export const logger = {
   /**
-   * Debug logging - only shown when log level is debug
+   * Trace logging - only shown when log level is trace
+   * Use for per-packet / per-loop firehose diagnostics that are far too
+   * verbose even for debug. Off by default at every other level.
+   */
+  trace: (...args: unknown[]) => {
+    if (shouldLog('trace')) {
+      console.log('[TRACE]', ...sanitizeArgs(args));
+    }
+  },
+
+  /**
+   * Debug logging - shown when log level is trace or debug
    * Use for verbose logging, state changes, data inspection
    */
   debug: (...args: any[]) => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -35,6 +35,9 @@ function getLogLevel(): LogLevel {
   return isDev ? 'debug' : 'info';
 }
 
+// Evaluated once at module import. Changing process.env.LOG_LEVEL after import
+// has no effect on the live logger; tests that vary the level must call
+// vi.resetModules() (see logger.test.ts) to force a re-import.
 const currentLevel = getLogLevel();
 
 function shouldLog(level: LogLevel): boolean {
@@ -61,6 +64,11 @@ export const logger = {
    * Trace logging - only shown when log level is trace
    * Use for per-packet / per-loop firehose diagnostics that are far too
    * verbose even for debug. Off by default at every other level.
+   *
+   * Note: `args` is typed `unknown[]` here (the peers below use `any[]`) on
+   * purpose — `sanitizeArgs` already accepts `unknown[]`, and using `any`
+   * would add a `@typescript-eslint/no-explicit-any` violation above the
+   * lint-ratchet baseline. Leave as `unknown[]`.
    */
   trace: (...args: unknown[]) => {
     if (shouldLog('trace')) {


### PR DESCRIPTION
## Problem

Users reported MeshMonitor's Docker logs are unusable for support — too much output at the default level. Root cause is **not** the logging infrastructure (`src/utils/logger.ts` is a proper leveled logger gated by `LOG_LEVEL`, prod default `info`, and server code has zero raw `console.log`). The problem is **overuse of `logger.info`**: ~1,450 server-side `info` calls all print at the production default, most of them routine per-packet / per-request / per-message / periodic-scheduler chatter, plus a ~60-line environment dump on every boot.

## Changes

- **New `trace` level** below `debug` for the true per-packet firehose. `LOG_LEVEL` now accepts `trace`.
- **Reclassified server `logger.info` → `debug`/`trace`**: non-migration `info` **1,452 → 865** (~590 → debug, 11 → trace). Hot paths collapsed: `meshtasticManager` 258→18, `meshcoreManager` 61→19, `environment` 67→16, `server.ts` 49→20.
- **Kept at `info`:** only startup/shutdown, source connect/disconnect, backups/restores/migrations, and deliberate admin actions (purges, config imports, token issuance, upgrades). An idle container is now near-silent at `info`.
- **Privacy:** MeshCore message bodies (contact/channel/room/DM/auto-ack text) were logged in full at `info` — now demoted to `debug` **and** redacted to `(N chars)`, keeping only sender/channel metadata.
- **Env boot dump** collapsed to a compact ~16-line `info` summary; per-variable detail → `debug`.
- **Docs:** `docs/configuration/index.md` (trace tier + "info is now quiet" guidance), commented `LOG_LEVEL` in `docker-compose.yml`, CHANGELOG entry, new trace-level test coverage.

### Deliberately out of scope
- **Migrations untouched** — their ~570 `info` lines only fire once when a migration first applies (a one-time audit trail), never in steady state.
- Default production level stays `info` (not `warn`), per design discussion — `info` should remain a meaningful, sparse support signal.

## How to use higher verbosity

No `NODE_ENV` change needed:
```yaml
environment:
  - LOG_LEVEL=debug   # or `trace` for the full per-packet firehose
```

## Verification

- `npm run typecheck` — clean
- `npm run lint:ci` (ratchet) — OK (`trace` typed `unknown[]`, does not grow the `no-explicit-any` baseline)
- Full Vitest — **8,215 passed, 0 failed, 2,696/2,696 suites**

🤖 Generated with [Claude Code](https://claude.com/claude-code)