### PR TITLE
feat(automation): add "Send via sources" selector to the tapback action

### DIFF
--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -308,7 +308,10 @@ export const ACTIONS: BlockDef[] = [
     type: 'action.tapback',
     label: 'Send a tapback (reaction)',
     description: 'React to the triggering message.',
-    fields: [{ name: 'emoji', label: 'Emoji', kind: 'emoji', placeholder: '👍' }],
+    fields: [
+      { name: 'emoji', label: 'Emoji', kind: 'emoji', placeholder: '👍' },
+      { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios send the reaction (MeshCore sources are skipped — tapbacks are Meshtastic-only). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
+    ],
   },
   {
     type: 'action.sendMessage',

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -250,6 +250,9 @@ describe('executeAction', () => {
       fn: 'sendTapback',
       args: { sourceId: 'default', emoji: '👍', channel: undefined, destination: 5, replyId: 99 },
     });
+    // #3996: with no explicit sourceIds the reaction fires exactly once — from
+    // the triggering source only — never fanned out to every connected source.
+    expect(calls).toHaveLength(1);
   });
 
   it('tapback: channel message routes back to the channel', async () => {

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -302,6 +302,17 @@ describe('executeAction', () => {
     expect(results).toEqual([2, { skipped: true, reason: 'tapback is not supported on MeshCore' }]);
   });
 
+  it('tapback: a single-entry explicit sourceIds still unwraps to a scalar result, not a one-element array', async () => {
+    const { deps } = recorder();
+    const result = await executeAction(
+      node('action.tapback', { emoji: '👍', sourceIds: ['radioA'] }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false }),
+      deps,
+    );
+    expect(result).toBe(2);
+    expect(Array.isArray(result)).toBe(false);
+  });
+
   it('nodeManage: defaults to the subject node and validates op', async () => {
     const { calls, deps } = recorder();
     await executeAction(node('action.nodeManage', { op: 'favorite' }), ctx({ from: 222 }), deps);

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -273,6 +273,35 @@ describe('executeAction', () => {
     expect(calls).toHaveLength(0); // deps never invoked
   });
 
+  // ── source selection (#3996) ────────────────────────────────────────────
+  it('tapback: explicit sourceIds fans out to each selected source', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.tapback', { emoji: '👍', sourceIds: ['radioA', 'radioB'] }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false }),
+      deps,
+    );
+    expect(calls.map((c) => c.args.sourceId)).toEqual(['radioA', 'radioB']);
+    expect(calls[0].args).toMatchObject({ emoji: '👍', channel: 3, destination: undefined, replyId: 99 });
+  });
+
+  it('tapback: a MeshCore source within an explicit selection is skipped, Meshtastic sources still fire', async () => {
+    const { calls, deps } = recorder();
+    const data = {
+      getNode: async () => null,
+      getTelemetry: async () => null,
+      getSourceProtocol: async (sid: string) => (sid === 'mc' ? 'meshcore' : 'meshtastic'),
+    };
+    const c = { ...ctx({ from: 5, channel: 3, packetId: 99, isDM: false }), data };
+    const results = await executeAction(
+      node('action.tapback', { emoji: '👍', sourceIds: ['radioA', 'mc'] }),
+      c,
+      deps,
+    );
+    expect(calls.map((c2) => c2.args.sourceId)).toEqual(['radioA']);
+    expect(results).toEqual([2, { skipped: true, reason: 'tapback is not supported on MeshCore' }]);
+  });
+
   it('nodeManage: defaults to the subject node and validates op', async () => {
     const { calls, deps } = recorder();
     await executeAction(node('action.nodeManage', { op: 'favorite' }), ctx({ from: 222 }), deps);

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -262,18 +262,32 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
     }
 
     case 'action.tapback': {
-      // MeshCore has no tapback / emoji-reaction concept. Skip as a recorded
-      // no-op rather than letting the deps throw, which would log a failed run
-      // for every MeshCore message a tapback automation happens to match.
-      if (await isMeshCoreSource(ctx, sourceId)) {
-        return { skipped: true, reason: 'tapback is not supported on MeshCore' };
-      }
       const emoji = String(p.emoji ?? '👍');
       // Default replyId is the triggering packet; route the way the trigger arrived.
       const replyId = p.replyId != null ? await num(ctx, p.replyId) : (ctx.trigger.fields.packetId as number | undefined);
       const destination = isDM ? (ctx.trigger.fields.from as number | undefined) : undefined;
       const channel = isDM ? undefined : triggerChannel;
-      return deps.sendTapback({ sourceId, emoji, channel, destination, replyId });
+
+      // Target sources: explicit multi-select, else the legacy single source /
+      // the triggering source (mirrors action.sendMessage / action.requestData, #3996).
+      const sourceIds = Array.isArray(p.sourceIds) && p.sourceIds.length > 0
+        ? (p.sourceIds as unknown[]).map(String)
+        : [sourceId];
+
+      const results: unknown[] = [];
+      for (const sid of sourceIds) {
+        // MeshCore has no tapback / emoji-reaction concept. Skip as a recorded
+        // no-op rather than letting the deps throw, which would log a failed run
+        // for every MeshCore message a tapback automation happens to match.
+        if (await isMeshCoreSource(ctx, sid)) {
+          results.push({ skipped: true, reason: 'tapback is not supported on MeshCore' });
+          continue;
+        }
+        results.push(await deps.sendTapback({ sourceId: sid, emoji, channel, destination, replyId }));
+      }
+      // Unwrap the single-target case so the result shape (and run-log
+      // resolvedParams) matches the original one-target behavior.
+      return results.length === 1 ? results[0] : results;
     }
 
     case 'action.nodeManage': {


### PR DESCRIPTION
## Summary

- `action.tapback` (the Automation Engine's "Send a tapback (reaction)" action) always sent through the triggering source. With multiple connected Meshtastic sources hearing the same broadcast, one matching message could produce a reaction from every radio.
- Adds the same `sourceIds` "Send via sources" selector that `action.sendMessage` and `action.requestData` already have, so a user can pin the reaction to one or more specific radios instead. Leaving it empty preserves the existing behavior (use the triggering source).
- MeshCore sources within an explicit selection are still skipped as a recorded no-op (MeshCore has no tapback concept), same as the prior single-source behavior.

## Changes

- `src/server/services/automation/actionExecutor.ts`: `action.tapback` now reads `p.sourceIds`, defaulting to `[sourceId]`, and fans out to each selected source (mirrors the existing `action.requestData` pattern). Single-target calls still return an unwrapped result so existing run-log shapes are unchanged.
- `src/components/automations/catalog.ts`: adds the `sourceIds` (`sendSourceMulti`) field to the tapback action definition, matching the wording/UX already used on `action.sendMessage`.
- `src/server/services/automation/actionExecutor.test.ts`: adds tests for multi-source fan-out and for a mixed Meshtastic/MeshCore selection (MeshCore entries skipped, Meshtastic entries still fire).

## Testing

- `npx vitest run src/server/services/automation/ src/db/repositories/automations.test.ts src/components/automations/` — 286 passed.
- Full `npx vitest run` — 8170 passed, 3 failed / 9 suites failed, all pre-existing and unrelated: the `protobufs` git submodule isn't checked out in this environment (`ENOENT: .../protobufs/meshtastic/mesh.proto`), which cascades into a few MQTT/protobuf test files. None touch automation/tapback/catalog code.
- `tsc -p tsconfig.server.json --noEmit` and `tsc -p tsconfig.json --noEmit`: no new errors on changed files.
- `eslint` on changed files: clean.

Closes #3996

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_018RQGM9noweopCenjvxkLAP)_