### PR TITLE
Fix Virtual Node Server boot race and listen-error zombie state

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -749,7 +749,11 @@ class MeshtasticManager implements ISourceManager {
   }
 
   async start(): Promise<void> {
-    await this.connect();
+    try {
+      await this.connect();
+    } catch (err) {
+      logger.error(`Source ${this.sourceId} initial connect failed (auto-reconnect will retry):`, err);
+    }
     try {
       await this.virtualNodeServer?.start();
     } catch (err) {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -759,8 +759,10 @@ class MeshtasticManager implements ISourceManager {
     } catch (err) {
       logger.error(`Failed to start VirtualNodeServer for source ${this.sourceId}:`, err);
     }
-    // Wire up the MQTT proxy bridge if this source has an mqttLink. Done
-    // after connect() so the transport is ready to receive injected ToRadio.
+    // Wire up the MQTT proxy bridge if this source has an mqttLink. Attempted
+    // after connect(); note the transport may not yet be ready if the initial
+    // connect failed above — injected ToRadio sends are try/catch-guarded and
+    // the background reconnect will re-establish the transport.
     if (this.mqttLink?.enabled && this.mqttLink.mqttBrokerSourceId) {
       this.setupMqttLink();
     }

--- a/src/server/meshtasticManager.virtualNodeBootRace.test.ts
+++ b/src/server/meshtasticManager.virtualNodeBootRace.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression test for issue #4000 — Virtual Node Server never starts if the
+ * source's initial connect fails (boot race).
+ *
+ * Prior to the fix, `start()` awaited `connect()` unguarded: a rejected
+ * initial connect (e.g. ECONNREFUSED while a companion container is still
+ * booting) unwound `start()` before `virtualNodeServer.start()` ever ran.
+ * The transport's own background reconnect brought the source back, but
+ * nothing re-ran the VN-start sequence, leaving the VN permanently
+ * "Running: No" until a manual disable/enable.
+ *
+ * `start()` must now start the VirtualNodeServer regardless of whether the
+ * initial `connect()` succeeds or throws.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { startMock, stopMock, VNConstructor } = vi.hoisted(() => {
+  const startMock = vi.fn().mockResolvedValue(undefined);
+  const stopMock = vi.fn().mockResolvedValue(undefined);
+  const VNConstructor = vi.fn(function (this: any, _opts: any) {
+    this.start = startMock;
+    this.stop = stopMock;
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  });
+  return { startMock, stopMock, VNConstructor };
+});
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+// The transport's connect() rejects to simulate a boot-race ECONNREFUSED.
+const { transportConnectMock } = vi.hoisted(() => ({
+  transportConnectMock: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED 172.x.0.2:4403')),
+}));
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = transportConnectMock;
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    removeAllListeners = vi.fn();
+    isConnected = () => false;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+    setHeartbeatInterval = vi.fn();
+    setStartupGraceReconnect = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    upsertNodeAsync: vi.fn().mockResolvedValue(undefined),
+    sources: {
+      getSource: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array([4, 5, 6])),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+
+vi.mock('./services/packetLogService.js', () => {
+  const svc = { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() };
+  return { default: svc, packetLogService: svc };
+});
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+describe('MeshtasticManager.start() — issue #4000 boot race', () => {
+  beforeEach(() => {
+    VNConstructor.mockClear();
+    startMock.mockClear();
+    stopMock.mockClear();
+    transportConnectMock.mockClear();
+  });
+
+  it('still starts the VirtualNodeServer when the initial connect() rejects', async () => {
+    const mgr = new MeshtasticManager('src-1', {
+      host: '127.0.0.1',
+      port: 4403,
+      virtualNode: { enabled: true, port: 4503, allowAdminCommands: false },
+    });
+
+    // start() must not throw even though connect() rejects — the caller
+    // (sourceManagerRegistry.addManager) treats a thrown start() as a
+    // failed-to-start source and never emits 'manager-started'.
+    await expect(mgr.start()).resolves.toBeUndefined();
+
+    expect(transportConnectMock).toHaveBeenCalled();
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still starts the VirtualNodeServer when the initial connect() succeeds', async () => {
+    transportConnectMock.mockResolvedValueOnce(undefined);
+    const mgr = new MeshtasticManager('src-1', {
+      host: '127.0.0.1',
+      port: 4403,
+      virtualNode: { enabled: true, port: 4503, allowAdminCommands: false },
+    });
+
+    await expect(mgr.start()).resolves.toBeUndefined();
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/virtualNodeServer.listenErrorRecovery.test.ts
+++ b/src/server/virtualNodeServer.listenErrorRecovery.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression test for issue #4000 (secondary bug) — VirtualNodeServer.start()
+ * left `this.server` non-null after a `listen` error (e.g. EADDRINUSE),
+ * so a later start() attempt silently no-op'ed with "Virtual node server
+ * already started" instead of retrying the bind. This left the VN
+ * permanently unrecoverable once one bind attempt failed.
+ *
+ * `start()` must now clear `this.server` on a listen error so a subsequent
+ * start() call can rebind once the port is free.
+ *
+ * `net.Server` is mocked so the error/listening transitions are driven
+ * deterministically instead of racing a real OS-level port conflict.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('net', () => {
+  class FakeServer {
+    static instances: FakeServer[] = [];
+    private listeners: Record<string, Array<(...args: any[]) => void>> = {};
+    listenCb: (() => void) | undefined;
+
+    constructor(private connectionListener: (socket: unknown) => void) {
+      FakeServer.instances.push(this);
+    }
+    on(event: string, cb: (...args: any[]) => void) {
+      (this.listeners[event] ??= []).push(cb);
+      return this;
+    }
+    emit(event: string, ...args: unknown[]) {
+      (this.listeners[event] ?? []).forEach((cb) => cb(...args));
+    }
+    listen(_port: number, cb: () => void) {
+      this.listenCb = cb;
+      return this;
+    }
+    close(cb?: () => void) {
+      cb?.();
+    }
+  }
+  return { Server: FakeServer, Socket: class {} };
+});
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    nodes: {
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      setNodeFavorite: vi.fn().mockResolvedValue(undefined),
+    },
+    getSettingAsync: vi.fn().mockResolvedValue(null),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+import { Server } from 'net';
+import { VirtualNodeServer } from './virtualNodeServer.js';
+
+type FakeServerInstance = InstanceType<typeof Server> & {
+  emit: (event: string, ...args: unknown[]) => void;
+  listenCb?: () => void;
+};
+
+function latestFakeServer(): FakeServerInstance {
+  const instances = (Server as unknown as { instances: FakeServerInstance[] }).instances;
+  return instances[instances.length - 1];
+}
+
+function makeFakeManager(sourceId: string = 'src-1') {
+  return {
+    sourceId,
+    getLocalNodeInfo: () => ({ nodeNum: 0x11223344, nodeId: '!11223344' }),
+    processIncomingData: vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+describe('VirtualNodeServer.start() — issue #4000 listen-error recovery', () => {
+  it('clears this.server on a listen error, allowing a later start() to retry', async () => {
+    const vn = new VirtualNodeServer({ port: 4503, meshtasticManager: makeFakeManager() });
+
+    const firstStart = vn.start();
+    const failedServer = latestFakeServer();
+    failedServer.emit('error', new Error('listen EADDRINUSE: address already in use 0.0.0.0:4503'));
+
+    await expect(firstStart).rejects.toThrow(/EADDRINUSE/);
+    expect((vn as any).server).toBeNull();
+
+    // Before the fix, this would hit the `if (this.server) { ...; return; }`
+    // short-circuit and resolve without ever attempting a new bind.
+    const secondStart = vn.start();
+    const retriedServer = latestFakeServer();
+    expect(retriedServer).not.toBe(failedServer);
+    retriedServer.listenCb?.();
+
+    await expect(secondStart).resolves.toBeUndefined();
+    expect((vn as any).server).not.toBeNull();
+
+    await vn.stop();
+  });
+
+  it('successive listen errors keep this.server clearable (no permanent zombie)', async () => {
+    const vn = new VirtualNodeServer({ port: 4503, meshtasticManager: makeFakeManager() });
+
+    for (let i = 0; i < 3; i++) {
+      const attempt = vn.start();
+      latestFakeServer().emit('error', new Error(`listen EADDRINUSE attempt ${i}`));
+      await expect(attempt).rejects.toThrow();
+      expect((vn as any).server).toBeNull();
+    }
+
+    const finalStart = vn.start();
+    latestFakeServer().listenCb?.();
+    await expect(finalStart).resolves.toBeUndefined();
+
+    await vn.stop();
+  });
+
+  it('does not throw a synchronous uncaught exception when nothing listens for "error" (EventEmitter self-emit guard)', async () => {
+    // No production caller currently attaches vn.on('error', ...). Node's
+    // EventEmitter throws synchronously when 'error' is emitted with zero
+    // listeners, which would otherwise turn a routine bind failure into an
+    // uncaught exception from inside net.Server's async error dispatch.
+    const vn = new VirtualNodeServer({ port: 4503, meshtasticManager: makeFakeManager() });
+    expect(vn.listenerCount('error')).toBe(0);
+
+    const start = vn.start();
+    expect(() => {
+      latestFakeServer().emit('error', new Error('listen EADDRINUSE'));
+    }).not.toThrow();
+
+    await expect(start).rejects.toThrow(/EADDRINUSE/);
+  });
+
+  it('still emits "error" to a caller that does listen', async () => {
+    const vn = new VirtualNodeServer({ port: 4503, meshtasticManager: makeFakeManager() });
+    const errorListener = vi.fn();
+    vn.on('error', errorListener);
+
+    const start = vn.start();
+    const err = new Error('listen EADDRINUSE');
+    latestFakeServer().emit('error', err);
+    await expect(start).rejects.toThrow(/EADDRINUSE/);
+
+    expect(errorListener).toHaveBeenCalledWith(err);
+  });
+});

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -140,8 +140,18 @@ export class VirtualNodeServer extends EventEmitter {
       this.server = new Server((socket) => this.handleNewClient(socket));
 
       this.server.on('error', (error) => {
+        const failed = this.server;
+        this.server = null; // allow a future start() to retry instead of no-op'ing
+        failed?.close();
         logger.error('Virtual node server error:', error);
-        this.emit('error', error);
+        // EventEmitter throws synchronously when 'error' is emitted with no
+        // listeners attached — no caller currently listens for it on a
+        // VirtualNodeServer instance, so an unconditional emit here would
+        // turn a recoverable bind failure (e.g. EADDRINUSE) into an
+        // uncaught exception. Only emit if someone is actually listening.
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', error);
+        }
         reject(error);
       });
 


### PR DESCRIPTION
## Summary

Fixes #4000.

- `MeshtasticManager.start()` previously awaited `connect()` **unguarded** before starting the `VirtualNodeServer`. When the initial TCP connect fails (e.g. `ECONNREFUSED` because a companion container like `meshtastic-ble-bridge` hasn't finished booting yet — a common `docker compose` `restart:` race on host reboot), the thrown error unwound `start()` and the VN server was never started. The background transport reconnect brings the source itself back to "connected" in the UI, but nothing re-runs the VN-start sequence, so the VN panel is stuck at **Status: Enabled / Server Running: No** until a manual disable→enable or container restart. `start()` now catches the initial `connect()` failure (auto-reconnect already retries it in the background) and always proceeds to start the VN server.
- `VirtualNodeServer.start()` left `this.server` non-null after a `listen` error (e.g. `EADDRINUSE`), so a later `start()` attempt hit the `if (this.server) { ...; return; }` short-circuit and silently no-op'ed instead of retrying the bind — a second, independent path to the same permanently-stuck VN.
- While adding a regression test for the listen-error path, found a third, more serious bug in the same handler: it unconditionally called `this.emit('error', error)` on the `VirtualNodeServer` instance, but no caller anywhere in the codebase attaches an `'error'` listener to it. Node's `EventEmitter` throws synchronously when `'error'` is emitted with zero listeners, so a routine VN port bind failure (the exact scenario this issue is about) would actually crash the whole MeshMonitor process rather than just leaving the VN in a zombie state. Fixed by only emitting when `listenerCount('error') > 0`.

## Changes

- `src/server/meshtasticManager.ts`: guard the initial `connect()` call in `start()` so a failed connect no longer skips `virtualNodeServer.start()`.
- `src/server/virtualNodeServer.ts`: clear `this.server` on a listen error (allowing retry), and guard the self-`emit('error', ...)` against the zero-listener throw.
- `src/server/meshtasticManager.virtualNodeBootRace.test.ts` (new): VN still starts whether the initial `connect()` resolves or rejects.
- `src/server/virtualNodeServer.listenErrorRecovery.test.ts` (new): a listen error clears `this.server` so a later `start()` retries the bind; repeated errors never leave a permanent zombie; the self-emit no longer throws synchronously when unlistened, but still fires for a caller that does listen.

## Test plan

- [x] `npx vitest run` — full suite green (8174 passed / 0 failed once the `protobufs` git submodule is initialized; the 9 files that appear to fail without it are all pre-existing protobuf-fixture dependents unrelated to this change)
- [x] `npm run lint:ci` — clean
- [x] `npx tsc --noEmit` — clean
- [x] New regression tests cover all three fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjmRN72QHYGPHMxGXFauou

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjmRN72QHYGPHMxGXFauou)_