### PR TITLE
feat(automation): add scheduled device-reboot action (#3995)

### DIFF
--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -282,6 +282,8 @@ function ActionView({ a }: { a: SimResult['actions'][number] }) {
     // advert announces broadly (and MeshCore adverts carry no channel) — omit the target/channel.
     const tgt = op === 'advert' ? '' : ` → ${p.target ? `node ${p.target}` : '(triggering node)'} on ch ${p.channel ?? 0}`;
     headline = `Request ${op}${tt}${tgt}`;
+  } else if (a.type === 'action.deviceReboot') {
+    headline = `Reboot device${p.seconds != null ? ` (delay ${String(p.seconds)}s)` : ''}`;
   }
   return (
     <div className={`ae-test-action ${a.ok ? '' : 'is-err'}`}>

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -384,6 +384,15 @@ export const ACTIONS: BlockDef[] = [
     ],
   },
   {
+    type: 'action.deviceReboot',
+    label: 'Reboot the node',
+    description: 'Reboot the physical device — e.g. reinitialize a flaky BLE bridge or MQTT proxy on a daily schedule.',
+    fields: [
+      { name: 'sourceIds', label: 'Reboot which node(s)', kind: 'sendSourceMulti', help: 'The connected node(s) to reboot. Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like Schedules and System events. (MQTT sources have no physical device and are excluded.)' },
+      { name: 'seconds', label: 'Reboot delay (seconds)', kind: 'number', advanced: true, placeholder: '10', help: 'Meshtastic: how long the device waits before rebooting (default 10s). Ignored by MeshCore.' },
+    ],
+  },
+  {
     type: 'action.notify',
     label: 'Send a notification',
     description: 'Send an external notification (Apprise).',

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -12,6 +12,7 @@ function recorder() {
     sendTapback: async (a) => { calls.push({ fn: 'sendTapback', args: a }); return 2; },
     manageNode: async (a) => { calls.push({ fn: 'manageNode', args: a }); return 3; },
     requestData: async (a) => { calls.push({ fn: 'requestData', args: a }); return 5; },
+    rebootDevice: async (a) => { calls.push({ fn: 'rebootDevice', args: a }); return 6; },
     notify: async (a) => { calls.push({ fn: 'notify', args: a }); return 4; },
     runScript: async (a) => { calls.push({ fn: 'runScript', args: a }); return { success: true, stdout: '', returnValue: { ok: 1 } }; },
   };
@@ -291,6 +292,49 @@ describe('executeAction', () => {
     // delete is DB-level → runs on any source, MeshCore included.
     await executeAction(node('action.nodeManage', { op: 'delete' }), ctx({ from: 7 }, 'mc', 'meshcore'), deps);
     expect(calls).toEqual([{ fn: 'manageNode', args: { sourceId: 'mc', nodeNum: 7, op: 'delete' } }]);
+  });
+
+  // ── deviceReboot (#3995) ───────────────────────────────────────────────────
+  it('deviceReboot: reboots the trigger source and passes the seconds delay', async () => {
+    const { calls, deps } = recorder();
+    const result = await executeAction(
+      node('action.deviceReboot', { seconds: 30 }),
+      ctx({ from: 1 }, 'default'),
+      deps,
+    );
+    expect(calls).toEqual([{ fn: 'rebootDevice', args: { sourceId: 'default', seconds: 30 } }]);
+    expect(result).toBe(6);
+  });
+
+  it('deviceReboot: a scheduled (source-less) trigger reboots the selected source(s)', async () => {
+    const { calls, deps } = recorder();
+    // A schedule trigger carries no sourceId; the action must reboot the
+    // source(s) the user selected in the builder (multi-select), NOT the null
+    // trigger source. This is the core #3995 use case (daily scheduled reboot).
+    const scheduleCtx: EngineEvalContext = {
+      trigger: { triggerType: 'trigger.schedule', sourceId: null, timestamp: 1000, fields: {} },
+      vars: { getValue: async () => null } as unknown as VariableResolver,
+      data: { getNode: async () => null, getTelemetry: async () => null },
+      varCtx: { sourceId: null, nodeNum: undefined },
+      now: 1000,
+    };
+    await executeAction(
+      node('action.deviceReboot', { sourceIds: ['radioA', 'radioB'] }),
+      scheduleCtx,
+      deps,
+    );
+    expect(calls).toEqual([
+      { fn: 'rebootDevice', args: { sourceId: 'radioA', seconds: undefined } },
+      { fn: 'rebootDevice', args: { sourceId: 'radioB', seconds: undefined } },
+    ]);
+  });
+
+  it('deviceReboot: ignores a non-numeric/negative seconds (falls back to manager default)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(node('action.deviceReboot', { seconds: -5 }), ctx({ from: 1 }, 'default'), deps);
+    await executeAction(node('action.deviceReboot', { seconds: 'soon' }), ctx({ from: 1 }, 'default'), deps);
+    expect(calls[0].args).toEqual({ sourceId: 'default', seconds: undefined });
+    expect(calls[1].args).toEqual({ sourceId: 'default', seconds: undefined });
   });
 
   // ── requestData (#3835) ────────────────────────────────────────────────────

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -43,6 +43,10 @@ export interface ActionDeps {
     channel: number;
     telemetryType?: TelemetryKind;
   }): Promise<unknown>;
+  /** Reboot the physical device behind a source (#3995). `seconds` is the
+   *  Meshtastic reboot delay; MeshCore ignores it. Throws on an unreachable/
+   *  unsupported source so the run-log records a failed step. */
+  rebootDevice(a: { sourceId: string | null; seconds?: number }): Promise<unknown>;
   notify(a: { sourceId: string | null; title: string; body: string; type?: string; urls?: string[] }): Promise<unknown>;
   /** Run a user script file (in $DATA_DIR/scripts) with the given env. Never throws — returns the outcome. */
   runScript(a: { scriptPath: string; env: Record<string, string>; timeoutMs?: number }):
@@ -327,6 +331,25 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           if (!target) throw new Error(`action.requestData: no target node for "${op}"`);
         }
         results.push(await deps.requestData({ sourceId: sid, op, target, channel, telemetryType: op === 'telemetry' ? telemetryType : undefined }));
+      }
+      return results.length === 1 ? results[0] : results;
+    }
+
+    case 'action.deviceReboot': {
+      // Reboot the physical device (#3995). Targets a SOURCE's local node, not a
+      // subject node — so there's no nodeNum. `seconds` is the Meshtastic reboot
+      // delay (default handled by the manager); MeshCore ignores it. Supports the
+      // same multi-source select as sendMessage/requestData so a source-less
+      // schedule trigger can pick which radio(s) to reboot.
+      const secondsRaw = p.seconds != null ? Number(p.seconds) : undefined;
+      const seconds = secondsRaw != null && Number.isFinite(secondsRaw) && secondsRaw >= 0
+        ? Math.floor(secondsRaw) : undefined;
+      const sourceIds = Array.isArray(p.sourceIds) && p.sourceIds.length > 0
+        ? (p.sourceIds as unknown[]).map(String)
+        : [sourceId];
+      const results: unknown[] = [];
+      for (const sid of sourceIds) {
+        results.push(await deps.rebootDevice({ sourceId: sid, seconds }));
       }
       return results.length === 1 ? results[0] : results;
     }

--- a/src/server/services/automation/automationSimulator.ts
+++ b/src/server/services/automation/automationSimulator.ts
@@ -115,6 +115,8 @@ function recordingDeps(): ActionDeps {
     async sendTapback(a) { return { action: 'tapback', ...a }; },
     async manageNode(a) { return { action: 'nodeManage', ...a }; },
     async requestData(a) { return { action: 'requestData', ...a }; },
+    // Dry-run must never actually reboot a device — report the resolved params.
+    async rebootDevice(a) { return { action: 'deviceReboot', ...a }; },
     async notify(a) { return { action: 'notify', ...a }; },
     // Dry-run must never spawn a process — report success without executing.
     async runScript() { return { success: true, stdout: '' }; },

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -188,3 +188,52 @@ describe('createMeshActionDeps requestData — node operations (#3835)', () => {
     expect(m.sendTelemetryRequest).not.toHaveBeenCalled();
   });
 });
+
+describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', () => {
+  beforeEach(() => { getManager.mockReset(); meshcoreGet.mockReset(); });
+
+  it('calls a Meshtastic manager rebootDevice with the seconds delay', async () => {
+    const rebootDevice = vi.fn().mockResolvedValue(undefined); // void
+    getManager.mockReturnValue({ sendTextMessage: vi.fn(), rebootDevice });
+    const deps = createMeshActionDeps();
+
+    const result = await deps.rebootDevice({ sourceId: 'mt', seconds: 30 });
+
+    expect(rebootDevice).toHaveBeenCalledWith(30);
+    // void return → normalized to a success marker so the run-log records success.
+    expect(result).toEqual({ rebooted: true });
+  });
+
+  it('reaches a MeshCore manager only present in meshcoreManagerRegistry', async () => {
+    const rebootDevice = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue(undefined);
+    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
+    const deps = createMeshActionDeps();
+
+    const result = await deps.rebootDevice({ sourceId: 'mc' });
+
+    expect(rebootDevice).toHaveBeenCalledWith(undefined); // MeshCore ignores seconds
+    expect(result).toBe(true);
+  });
+
+  it('surfaces a MeshCore reboot failure (resolves false) as a thrown error', async () => {
+    const rebootDevice = vi.fn().mockResolvedValue(false); // repeater fw / disconnected
+    getManager.mockReturnValue(undefined);
+    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
+    const deps = createMeshActionDeps();
+
+    await expect(deps.rebootDevice({ sourceId: 'mc' })).rejects.toThrow(/failed to reboot/);
+  });
+
+  it('throws when the source has no manager / no rebootDevice method', async () => {
+    getManager.mockReturnValue(undefined);
+    meshcoreGet.mockReturnValue(undefined);
+    const deps = createMeshActionDeps();
+    await expect(deps.rebootDevice({ sourceId: 'ghost' })).rejects.toThrow(/cannot reboot/);
+  });
+
+  it('throws when no source is provided', async () => {
+    const deps = createMeshActionDeps();
+    await expect(deps.rebootDevice({ sourceId: null })).rejects.toThrow(/requires a target source/);
+  });
+});

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -166,6 +166,27 @@ export function createMeshActionDeps(): ActionDeps {
       throw new Error(`source "${sourceId}" cannot perform node requests`);
     },
 
+    async rebootDevice({ sourceId, seconds }) {
+      // Reboot the physical device (#3995). Both protocol managers expose a
+      // `rebootDevice` method: Meshtastic `rebootDevice(seconds)` (void), MeshCore
+      // `rebootDevice()` (Companion-only; resolves `false` on failure / repeater
+      // firmware, ignores the seconds arg). Calling with `seconds` is safe for
+      // both — MeshCore drops the extra argument.
+      if (!sourceId) throw new Error('automation reboot action requires a target source');
+      const raw = resolveManager(sourceId) as { rebootDevice?: (seconds?: number) => Promise<unknown> } | undefined;
+      if (!raw || typeof raw.rebootDevice !== 'function') {
+        throw new Error(`source "${sourceId}" cannot reboot (no connected device)`);
+      }
+      const result = await raw.rebootDevice(seconds);
+      // Surface an explicit MeshCore `false` as a thrown error so the run-log
+      // records a failed step instead of a silent success. Meshtastic returns
+      // void (undefined), which is not false → treated as success.
+      if (result === false) {
+        throw new Error(`source "${sourceId}" failed to reboot (node not connected or unsupported firmware)`);
+      }
+      return result ?? { rebooted: true };
+    },
+
     async notify({ sourceId, title, body, type, urls }) {
       const r = await appriseNotificationService.notifyDirect({ sourceId, title, body, type }, urls);
       if (!r.ok) throw new Error(`notify failed: ${r.message}`);

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -40,6 +40,7 @@ export type ActionType =
   | 'action.tapback'
   | 'action.nodeManage'
   | 'action.requestData'
+  | 'action.deviceReboot'
   | 'action.notify'
   | 'action.runScript'
   | 'action.delay';
@@ -84,6 +85,7 @@ export const ACTION_TYPES: readonly ActionType[] = [
   'action.tapback',
   'action.nodeManage',
   'action.requestData',
+  'action.deviceReboot',
   'action.notify',
   'action.runScript',
   'action.delay',
@@ -365,6 +367,15 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
         case 'action.requestData':
           if (p.op != null && !REQUEST_OPS.includes(p.op as RequestOp)) {
             errors.push(`action.requestData "${n.id}" requires a valid params.op`);
+          }
+          break;
+        case 'action.deviceReboot':
+          // `seconds` is optional (Meshtastic reboot delay; MeshCore ignores it).
+          if (p.seconds != null) {
+            const secs = Number(p.seconds);
+            if (!Number.isFinite(secs) || secs < 0) {
+              errors.push(`action.deviceReboot "${n.id}" requires params.seconds ≥ 0`);
+            }
           }
           break;
         case 'action.delay': {


### PR DESCRIPTION
Closes #3995.

## What
Adds a new `action.deviceReboot` Automation Engine action so a `trigger.schedule` (cron) automation can reboot the local device on a schedule — the requested use case is a daily reboot to reinitialize a flaky BLE bridge / non-self-healing MQTT proxy.

## Design
Chose a **new action type** over a new `nodeManage` op:
- `nodeManage` ops act on a *subject node* and throw `no target node` when none resolves; reboot targets the source's **own local device** (no node target).
- Reboot maps to the device-level `rebootDevice(seconds)`, not a node-admin sender — a dedicated deps method is cleaner.
- Distinct "Reboot the node" builder block instead of overloading the "Manage the node" dropdown.
- Bonus: works for both Meshtastic and MeshCore sources with one deps impl.

The executor calls the manager method **directly** via the deps layer (`resolveManager(sourceId).rebootDevice(seconds)`) — no HTTP round-trip, no auth-token workaround. Server path confirmed: `POST /device/reboot` → `resolveSourceManager(sourceId).rebootDevice(seconds)` (`deviceRoutes.ts:90`); Meshtastic `rebootDevice(seconds=10)` (`meshtasticManager.ts:13573`); MeshCore Companion-only `rebootDevice()` returning `false` on repeater/disconnect (`meshcoreManager.ts:4106`).

## Source targeting
Mirrors `sendMessage`/`requestData`: optional `sourceIds` multi-select, falling back to the trigger source. Because `trigger.schedule` is source-less, a scheduled reboot **requires** an explicit source selection in the builder — a missing source records a failed run rather than rebooting an ambiguous target. (Maintainer-confirmed UX.)

## Files (8)
- `src/types/automation.ts` — action type union + `ACTION_TYPES` + validation (optional `seconds ≥ 0`)
- `src/server/services/automation/actionExecutor.ts` — `case 'action.deviceReboot'` + `rebootDevice` dep
- `src/server/services/automation/meshActionDeps.ts` — resolves manager across both registries, calls `rebootDevice` directly
- `src/server/services/automation/automationSimulator.ts` — dry-run recording dep (never reboots)
- `src/components/automations/catalog.ts` — "Reboot the node" builder block (source multi-select + `seconds`)
- `src/components/automations/AutomationTester.tsx` — dry-run preview headline
- `actionExecutor.test.ts` + `meshActionDeps.test.ts` — new tests

## Tests
295/295 pass across `automation/`, `components/automations/`, `types/` (verified via JSON reporter). Covers: reboot trigger source with seconds delay; the core case (source-less schedule reboots user-selected `sourceIds`); ignores invalid seconds; MeshCore fallback + `false`→error + missing-manager→error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub