### PR TITLE
fix(meshcore): match-scope replies unscoped for unnameable trigger scope (#3998)

### DIFF
--- a/src/server/meshcoreManager.autoAckScope.test.ts
+++ b/src/server/meshcoreManager.autoAckScope.test.ts
@@ -105,10 +105,13 @@ describe('MeshCoreManager — Auto-Ack "trigger" scope mode (#3887)', () => {
     expect(scopeOf(bridgeCalls)).toEqual(['lyon']);
   });
 
-  it('falls back to the channel default scope for a known-but-unmapped scope code', async () => {
+  it('replies unscoped for a known-but-unmapped scope code (#3998)', async () => {
+    // scopeCode > 0 but no resolved region name: scoped to a region we can't name,
+    // so it can't be reproduced. "Match the trigger scope" degrades to unscoped
+    // rather than substituting the node's unrelated default (was: 'berlin', #3887).
     const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
     const msg = triggerMessage({ scopeCode: 456, scopeName: null });
     await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
-    expect(scopeOf(bridgeCalls)).toEqual(['berlin']);
+    expect(scopeOf(bridgeCalls)).toEqual([null]);
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2669,19 +2669,22 @@ class MeshCoreManager extends EventEmitter {
    * `''` = explicit unscoped, a non-empty string = a named region.
    *
    * `trigger` mode replies on the triggering message's own scope — its resolved
-   * `scopeName` when known; `''` when the trigger's scope resolved to unscoped
-   * (`scopeCode === 0`) OR when scope resolution simply couldn't tell
-   * (`scopeCode == null`, #3887); inherit only when the trigger's `scopeCode`
-   * resolved to a real transport code with no matching known region (an
-   * unrecognised scope, not an unresolvable one).
-   *
-   * The `scopeCode == null` case is common in practice: `scopeCode`/`scopeName`
-   * are only recoverable when the raw OTA packet bytes were correlated from a
-   * preceding LogRxData event (best-effort, see meshcoreNativeBackend.ts), so a
-   * genuinely unscoped message often can't be distinguished from "unknown" —
-   * treating both as unscoped matches the dominant real-world case (a mesh with
-   * no scopes configured at all) rather than silently falling back to the
-   * channel default, which the far side's own unscoped repeater won't forward.
+   * `scopeName` when known; otherwise `''` (unscoped). "Match the scope" can only
+   * faithfully reproduce a scope we can name: the transport code is an HMAC keyed
+   * by the region NAME, so without the name we cannot re-derive the code. Every
+   * case where the region name is unavailable therefore degrades to unscoped
+   * (#3998):
+   *   - `scopeCode === 0`   → the trigger was confirmed unscoped.
+   *   - `scopeCode == null` → scope resolution couldn't tell (no raw OTA bytes;
+   *     `scopeCode`/`scopeName` are only recoverable when the packet was
+   *     correlated from a preceding LogRxData event — best-effort, see
+   *     meshcoreNativeBackend.ts), so a genuinely unscoped message is common here.
+   *   - `scopeCode > 0` but no matching known region → the trigger WAS scoped, but
+   *     to a region we can't name (e.g. a flood re-scoped by a repeater whose
+   *     region isn't in our known set). We cannot reproduce it, and substituting
+   *     the node's own DEFAULT scope is NOT "matching the trigger" — it floods
+   *     under an unrelated region the original (unscoped) sender may not hear.
+   *     Reply unscoped instead (#3998; previously inherited the default, #3887).
    */
   private static resolveAutomationScopeOverride(
     cfg: MeshCoreAutomationScopeConfig | undefined,
@@ -2695,9 +2698,12 @@ class MeshCoreManager extends EventEmitter {
       case 'trigger': {
         if (!triggerMsg) return undefined; // no trigger message → inherit
         const name = (triggerMsg.scopeName ?? '').trim();
-        if (name) return name;
-        if (triggerMsg.scopeCode != null && triggerMsg.scopeCode > 0) return undefined; // known-but-unmapped scope → inherit
-        return ''; // scopeCode === 0 (confirmed unscoped) or null (unresolvable) → reply unscoped
+        if (name) return name; // resolved region name → match it exactly
+        // No resolvable region name: confirmed unscoped (scopeCode 0), unresolvable
+        // (scopeCode null), OR scoped to a region we can't name (scopeCode > 0, no
+        // known match) — none can be reproduced, so reply unscoped rather than
+        // substitute the node's unrelated default scope (#3998).
+        return '';
       }
       default:
         return undefined; // inherit

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -219,14 +219,19 @@ describe('executeAction', () => {
     expect(calls[0].args.scopeOverride).toBe('');
   });
 
-  it('sendMessage: trigger scope on a known-but-unmapped scope code inherits', async () => {
+  it('sendMessage: trigger scope on a known-but-unmapped scope code sends unscoped (#3998)', async () => {
+    // scopeCode > 0 but no resolved region name: the trigger WAS scoped, but to a
+    // region we can't name (e.g. a flood re-scoped by a repeater whose region isn't
+    // in our known set). We can't reproduce an unnameable scope (the transport code
+    // is an HMAC keyed by the region name), so "match the trigger scope" must degrade
+    // to unscoped — NOT the node's unrelated default scope (was: inherit, #3887).
     const { calls, deps } = recorder();
     await executeAction(
       node('action.sendMessage', { text: 'hi', channel: 1, scopeMode: 'trigger' }),
       ctx({ from: 5, channel: 1, isDM: false, scopeName: null, scopeCode: 456 }),
       deps,
     );
-    expect('scopeOverride' in calls[0].args).toBe(false);
+    expect(calls[0].args.scopeOverride).toBe('');
   });
 
   it('sendMessage: DM send never carries a scope override', async () => {

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -199,15 +199,19 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
         }
         case 'trigger': {
           const tn = ctx.trigger.fields.scopeName;
-          const tc = ctx.trigger.fields.scopeCode;
           // `scopeCode` is only present in fields at all for a MeshCore message
           // trigger (buildMeshCoreMessageContext) — a schedule/telemetry/Meshtastic
           // trigger has no such key, and must inherit rather than be forced unscoped.
           const hasTriggerScope = 'scopeCode' in ctx.trigger.fields;
-          if (typeof tn === 'string' && tn.length > 0) scopeOverride = tn;
-          else if (!hasTriggerScope) scopeOverride = undefined; // no MeshCore message trigger → inherit
-          else if (typeof tc === 'number' && tc > 0) scopeOverride = undefined; // known-but-unmapped scope → inherit
-          else scopeOverride = ''; // scopeCode 0 (unscoped) or unresolvable (#3887) → reply unscoped
+          if (typeof tn === 'string' && tn.length > 0) scopeOverride = tn; // resolved region name → match it
+          else if (!hasTriggerScope) scopeOverride = undefined; // non-MeshCore trigger (no scope concept) → inherit
+          // MeshCore message trigger with no resolvable region name: confirmed
+          // unscoped (scopeCode 0), unresolvable (scopeCode null), OR scoped to a
+          // region we can't name (scopeCode > 0, no known match). None can be
+          // reproduced — the transport code is an HMAC keyed by the region name —
+          // so reply unscoped rather than substitute the node's unrelated default
+          // scope (#3998; previously inherited the default for the unmapped case, #3887).
+          else scopeOverride = '';
           break;
         }
         default:


### PR DESCRIPTION
Closes #3998.

## Bug
With **"Match the triggering message's scope"** enabled, a MeshCore reply to an *unscoped* message went out with the node's **default scope** instead of unscoped.

## Root cause
MeshMonitor already degrades the obvious unscoped cases (`scopeCode === 0` and `null` → unscoped). The remaining offender is the **"known-but-unmapped scope code → inherit default"** fallback added in #3887, at `actionExecutor.ts:209` and `meshcoreManager.ts:2699`. When an inbound message resolves to a **positive transport code with no matching known region name** (`scopeCode > 0`, `scopeName === null`), both paths returned `undefined` (= inherit), which the send path turns into the node's configured default scope.

In practice an unscoped flood re-emitted by a region-configured repeater arrives as `TRANSPORT_FLOOD` carrying that region's code; MeshMonitor decodes a positive code but can't match the region name → falls into this branch.

## Why unscoped is correct
An unnameable scope **cannot be reproduced** — the transport code is `HMAC(sha256("#"+name)[:16], payload)`, so without the region name there's no way to re-derive it. Substituting the node's own default region isn't "matching the trigger" — it floods under an unrelated region the original sender likely can't hear. Unscoped is the only faithful degrade, and it makes the unnameable case consistent with the null/0 cases. (Maintainer-confirmed: this intentionally reverses the unmatched→inherit half of #3887.)

## Fix
Both `trigger`-mode branches now degrade **every** case without a resolvable region name (code 0, null, or unmatched > 0) to unscoped (`''`); a resolved region name still matches exactly, and a non-MeshCore trigger still inherits. Doc comments updated to explain the #3998 rationale.

## Tests
Affected suites pass (71/71); full run of the four scope-related test files 105/105; `tsc --noEmit` clean. The two tests that asserted the old inherit-default behavior were flipped to expect unscoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub