### PR TITLE
test(automation): fix rebootDevice tests broken by #4004/#4002 merge race

### DIFF
--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -181,7 +181,7 @@ describe('createMeshActionDeps requestData — node operations (#3835)', () => {
 });
 
 describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', () => {
-  beforeEach(() => { getManager.mockReset(); meshcoreGet.mockReset(); });
+  beforeEach(() => { getManager.mockReset(); });
 
   it('calls a Meshtastic manager rebootDevice with the seconds delay', async () => {
     const rebootDevice = vi.fn().mockResolvedValue(undefined); // void
@@ -195,10 +195,9 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
     expect(result).toEqual({ rebooted: true });
   });
 
-  it('reaches a MeshCore manager only present in meshcoreManagerRegistry', async () => {
+  it('reaches a MeshCore manager via the unified registry', async () => {
     const rebootDevice = vi.fn().mockResolvedValue(true);
-    getManager.mockReturnValue(undefined);
-    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
+    getManager.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
     const deps = createMeshActionDeps();
 
     const result = await deps.rebootDevice({ sourceId: 'mc' });
@@ -209,8 +208,7 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
 
   it('surfaces a MeshCore reboot failure (resolves false) as a thrown error', async () => {
     const rebootDevice = vi.fn().mockResolvedValue(false); // repeater fw / disconnected
-    getManager.mockReturnValue(undefined);
-    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
+    getManager.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
     const deps = createMeshActionDeps();
 
     await expect(deps.rebootDevice({ sourceId: 'mc' })).rejects.toThrow(/failed to reboot/);
@@ -218,7 +216,6 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
 
   it('throws when the source has no manager / no rebootDevice method', async () => {
     getManager.mockReturnValue(undefined);
-    meshcoreGet.mockReturnValue(undefined);
     const deps = createMeshActionDeps();
     await expect(deps.rebootDevice({ sourceId: 'ghost' })).rejects.toThrow(/cannot reboot/);
   });


### PR DESCRIPTION
## Summary

**Main is currently red** (5 test failures): PR #4002 (scheduled device-reboot action) was authored before PR #4004 (unified registry) merged, and its `rebootDevice` tests mock the old dual-registry world (`meshcoreGet`) that #4004 removed. Both PRs were green individually — classic merge race; the combination never ran in CI.

- Production code is unaffected — `rebootDevice` duck-types through the unified `resolveManager` and works for both protocols.
- Tests rewritten to the unified-registry mock pattern used by the rest of the file (meshcore manager now returned by `getManager`, not a second registry).
- Also restores the test-typecheck picture (the `meshcoreGet` references were type errors too).

## Verification

- `meshActionDeps.test.ts`: 16/16 green (was 22 pass / 5 fail on main).
- Full suite on main+fix: **8294 passed, 0 failed, 0 suite failures** (`success: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n