### PR TITLE
fix(test): repair reboot deps tests after unified-registry refactor

### DIFF
--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -181,7 +181,7 @@ describe('createMeshActionDeps requestData — node operations (#3835)', () => {
 });
 
 describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', () => {
-  beforeEach(() => { getManager.mockReset(); meshcoreGet.mockReset(); });
+  beforeEach(() => { getManager.mockReset(); });
 
   it('calls a Meshtastic manager rebootDevice with the seconds delay', async () => {
     const rebootDevice = vi.fn().mockResolvedValue(undefined); // void
@@ -195,10 +195,11 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
     expect(result).toEqual({ rebooted: true });
   });
 
-  it('reaches a MeshCore manager only present in meshcoreManagerRegistry', async () => {
+  it('resolves a MeshCore manager from the unified source registry', async () => {
+    // Post-#3962 Ph2 (#4004) MeshCore managers live in sourceManagerRegistry too,
+    // so the reboot deps resolve them via the same getManager as Meshtastic.
     const rebootDevice = vi.fn().mockResolvedValue(true);
-    getManager.mockReturnValue(undefined);
-    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
+    getManager.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
     const deps = createMeshActionDeps();
 
     const result = await deps.rebootDevice({ sourceId: 'mc' });
@@ -209,8 +210,7 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
 
   it('surfaces a MeshCore reboot failure (resolves false) as a thrown error', async () => {
     const rebootDevice = vi.fn().mockResolvedValue(false); // repeater fw / disconnected
-    getManager.mockReturnValue(undefined);
-    meshcoreGet.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
+    getManager.mockReturnValue({ sendMessage: vi.fn(), rebootDevice });
     const deps = createMeshActionDeps();
 
     await expect(deps.rebootDevice({ sourceId: 'mc' })).rejects.toThrow(/failed to reboot/);
@@ -218,7 +218,6 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
 
   it('throws when the source has no manager / no rebootDevice method', async () => {
     getManager.mockReturnValue(undefined);
-    meshcoreGet.mockReturnValue(undefined);
     const deps = createMeshActionDeps();
     await expect(deps.rebootDevice({ sourceId: 'ghost' })).rejects.toThrow(/cannot reboot/);
   });


### PR DESCRIPTION
## Problem
`main` is red — `src/server/services/automation/meshActionDeps.test.ts` throws `ReferenceError: meshcoreGet is not defined` (5 failing tests).

## Cause
Two PRs collided:
- #4002 (#3995, scheduled device-reboot action) added reboot tests that mocked the **`meshcoreManagerRegistry`** via a `meshcoreGet` fn.
- #4004 (#3962 Ph2, unified source registry) **removed `meshcoreManagerRegistry`** — all managers (incl. MeshCore) now resolve through `sourceManagerRegistry`.

The reconciliation updated the test's top mock block and the reboot **impl** (`meshActionDeps.ts` resolves MeshCore via `resolveManager` → `sourceManagerRegistry`), but left the reboot **test block** referencing the deleted `meshcoreGet`.

## Fix
Test-only. Rewrite the MeshCore reboot cases to inject the fake manager through the unified `getManager` mock (matching the impl and the rest of the file). Production reboot path unchanged.

Verified: `meshActionDeps.test.ts` → 16/16 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub