### PR TITLE
feat(map): node selection & emphasis on Map Analysis (#3788 Phase 1)

### DIFF
--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -34,6 +34,7 @@ The toolbar runs across the top of the canvas. From left to right:
 | --- | --- |
 | **Source multi-select** | Pick which sources contribute to every layer. "All sources" is the default. |
 | **Search box** | Filter visible markers (and traceroute link endpoints) by name or node number. See [Node search](#node-search). |
+| **Node multi-select** | Pick specific nodes to emphasize. Selected nodes render at full opacity; everything else dims. "All nodes" (empty selection) is the default. See [Node selection & emphasis](#node-selection-emphasis). |
 | **Time slider toggle** | Show/hide the floating time-window slider. |
 | **Layer buttons (×8)** | Toggle each visualization layer on/off. The right-edge chevron opens a popover for layer-specific options (lookback window, sub-options). |
 | **Progress bar** | Shows aggregate loading state while any layer is fetching. |
@@ -62,6 +63,23 @@ The toolbar **search box** hides every marker that doesn't match the term and co
 - its `nodeNum` in **hex or decimal**.
 
 Clear the box to restore the full map. The search term lives in the workspace state alongside the other toolbar controls, so it composes with the source filter and every layer toggle.
+
+### Node selection & emphasis
+
+The toolbar **node multi-select** ("All nodes") lets you pin a specific set of
+nodes. The picker lists every node currently on the map — so it already
+reflects the source, node-type, and search filters — with **Select all** and
+**Clear** shortcuts.
+
+With one or more nodes selected, the map keeps *every* node visible but
+**dims the unselected ones** (both their markers and their position trails),
+so your chosen nodes stand out without losing surrounding context. An empty
+selection is the default and dims nothing.
+
+Selection is keyed on a node's stable cross-source identity (Meshtastic
+`nodeNum`, MeshCore public key), so a node reported by several sources stays a
+single entry. The set persists per-browser in the workspace config alongside
+the other toolbar controls.
 
 ## Layers
 
@@ -153,7 +171,7 @@ Map Analysis introduces **no new permission resource**. Page access is public (m
 
 ## Persistence
 
-All toolbar state — layer toggles, lookback selections, source filter, time slider window, inspector visibility — is persisted to a single versioned `localStorage` key (`mapAnalysis.config.v1`). It's per-browser, not per-account. The schema is versioned for future migration to server-persisted defaults.
+All toolbar state — layer toggles, lookback selections, source filter, node selection, time slider window, inspector visibility — is persisted to a single versioned `localStorage` key (`mapAnalysis.config.v1`). It's per-browser, not per-account. The schema is versioned for future migration to server-persisted defaults.
 
 ## Limitations (v1)
 

--- a/docs/internal/dev-notes/MAP_FOLLOW_AUTOZOOM_EPIC.md
+++ b/docs/internal/dev-notes/MAP_FOLLOW_AUTOZOOM_EPIC.md
@@ -1,0 +1,115 @@
+# Epic — Follow Nodes on the Map (Auto-center / Auto-zoom)
+
+**Issue:** #3788 — "[FEAT] Ability to follow nodes on the map"
+**Orchestrator model:** Opus 4.8
+**Started:** 2026-07-08
+
+## Goal
+
+Let a user pick a set of sources & nodes on the existing **Map Analysis**
+workspace (`/analysis`) and have the map keep them in view as they move:
+
+- **Follow mode** — on each position update, recenter the map to the *average
+  center* of the selected nodes' current positions, preserving zoom.
+- **Auto-zoom** — on each update, fit the map to the bounding box of the
+  selected nodes' current positions with a **15% margin**.
+- Selection also drives visual emphasis: selected nodes render at full
+  emphasis, unselected nodes are **dimmed but still visible**.
+- Multi-source by design: current positions come from the cross-source merge
+  (`useDashboardUnifiedData` → `mergeUnifiedSourceData`, dedup by
+  `mt:<nodeNum>` / `mc:<publicKey>`), so a node's position is the freshest fix
+  seen by any source (incl. MQTT).
+
+## Interview decisions (2026-07-08)
+
+1. **Home:** Extend the existing `/analysis` `MapAnalysisPage` workspace — NOT a
+   new Dashboard panel or standalone page. Maximum reuse of `MapAnalysisContext`,
+   `SourceMultiSelect`, `PositionTrailsLayer`, `NodeMarkersLayer`,
+   `useMapAnalysisConfig` (localStorage persistence).
+2. **Selection semantics:** **Dim unselected, keep visible.** When the selection
+   is non-empty, unselected node markers + trails are de-emphasized (reduced
+   opacity); selected nodes stay full-emphasis. Follow/Auto-zoom operate on the
+   selected set only. (An empty selection = today's behavior, nothing dimmed.)
+3. **Manual-pan conflict:** While Follow is active, a manual pan/zoom **pauses**
+   Follow and surfaces a "Resume follow" affordance; the map does not yank back
+   on the next update until the user resumes.
+4. **Phase split:** 2 phases (below).
+
+## Reuse anchors (from Stage-0 survey — do not rebuild these)
+
+- **Workspace shell:** `src/pages/MapAnalysisPage.tsx` (`ToastProvider > SettingsProvider > MapAnalysisProvider > [MapAnalysisToolbar, MapAnalysisCanvas, AnalysisInspectorPanel]`).
+- **Config + selection state:** `src/components/MapAnalysis/MapAnalysisContext.tsx` (`useMapAnalysisCtx`) spreads `useMapAnalysisConfig()` and adds `selected`/`nodeFilter`. Config persisted to `localStorage['mapAnalysis.config.v1']` via `src/hooks/useMapAnalysisConfig.ts` (`MapAnalysisConfig` at :40-52).
+- **Toolbar + source multi-select:** `src/components/MapAnalysis/MapAnalysisToolbar.tsx`, `SourceMultiSelect.tsx`, `NodeSearchControl.tsx`, `NodeTypeFilterControl.tsx`.
+- **Canvas + layers:** `src/components/MapAnalysis/MapAnalysisCanvas.tsx` (`MapContainer` at :43, pane stack :49-75). Markers: `layers/NodeMarkersLayer.tsx` (live positions via `useDashboardUnifiedData`, :145). Trails: `layers/PositionTrailsLayer.tsx` (one `Polyline` per `sourceId:nodeNum`, fed by `usePositions`).
+- **View controllers to mirror:** `MapBoundsUpdater` (one-shot `fitBounds`, `DashboardMap.tsx:136-155`), `src/components/MapCenterController.tsx` (`setView` to target), `src/components/ZoomHandler.tsx`, `MapPositionHandler.tsx`. All are `useMap()` children returning `null` — droppable into the Analysis `MapContainer`.
+- **Live position feed:** `useDashboardUnifiedData(sources, enabled)` (`src/hooks/useDashboardData.ts:436`), `refetchInterval: DASHBOARD_POLL_INTERVAL = 15_000`. Merge: `mergeUnifiedSourceData` (:332), position = newest record with both lat+lng.
+- **History/trajectory:** `GET /api/analysis/positions` (cross-source, cursor-paginated, `since` window) via `analysisApi.fetchPositionsPage` + `useMapAnalysisData.usePositions`.
+- **No backend change expected** — all data endpoints already exist. This is a frontend-only epic unless a phase surfaces a real gap.
+
+## Node identity note
+
+Selected-node set must key on the same identity the merge uses:
+`mt:<nodeNum>` for Meshtastic, `mc:<publicKey>` for MeshCore (see
+`mergeUnifiedSourceData`). Do NOT assume a bare `nodeNum` is unique across
+protocols.
+
+---
+
+## Phases
+
+### Phase 1 — Node selection & emphasis  ✅ (browser-validated; PR pending)
+Add an explicit node multi-select to the Analysis toolbar (scoped to the chosen
+sources), stored as `selectedNodeIds` in `MapAnalysisConfig` (persisted).
+`NodeMarkersLayer` + `PositionTrailsLayer` dim unselected nodes when the
+selection is non-empty; selected nodes stay full-emphasis. Empty selection =
+unchanged behavior.
+
+**Exit criteria:**
+- A node multi-select control in the toolbar lists nodes from the currently
+  selected sources (respects existing source/type/search filters), with
+  select-all / clear.
+- Selecting nodes dims unselected markers **and** trails; deselecting restores.
+- `selectedNodeIds` persists across reload (localStorage config).
+- Keyed on `mt:`/`mc:` identity; MeshCore + Meshtastic both selectable.
+- New/extended Vitest coverage green; typecheck clean; browser-validated.
+- Ships as a standalone, useful feature ("pick and highlight nodes").
+
+### Phase 2 — Follow & Auto-zoom  ⬜
+Add "Follow" and "Auto-zoom" toggles to the toolbar. New `useMap()` view
+controller(s) that, on each 15s position update, compute the selected nodes'
+current positions and:
+- **Follow:** `map.setView(averageCenter, currentZoom)`.
+- **Auto-zoom:** `map.fitBounds(L.latLngBounds(points).pad(0.15))`.
+- **Both on:** auto-zoom governs center+zoom (fitBounds implies its own center);
+  Follow is a no-op while Auto-zoom is on.
+- **Manual pan/zoom** while Follow active → pause; show "Resume follow".
+- Toggles persist in `MapAnalysisConfig`.
+
+**Exit criteria:**
+- Toggles present, persisted, independently operable.
+- Follow recenters to average center on update, keeps zoom.
+- Auto-zoom fits selected nodes' current positions + 15% margin on update.
+- Manual pan pauses Follow with a working Resume affordance.
+- Empty selection or single node handled sanely (no NaN bounds, single-point =
+  center at current zoom).
+- Rate-limited so rapid multi-node updates don't cause jitter.
+- New/extended Vitest coverage green; typecheck clean; browser-validated.
+
+---
+
+## Status log
+
+- 2026-07-08 — Stage 0 complete: issue read, code surveyed (2 Explore agents),
+  interview done, plan written. Next: Phase 1 Stage 1 (worktree).
+- 2026-07-08 — Phase 1 implemented across WP-A/B+C/D (identity helper +
+  `selectedNodeIds` config; shared `useAnalysisNodes` hook + `NodeMultiSelect`
+  picker + marker dimming; trail dimming). Full Vitest suite green after a
+  side-hotfix (PR #4008) repaired unrelated reboot-deps tests broken by the
+  #4004 unified-registry refactor on main. Browser-validated on the deployed
+  build: picker renders in the toolbar; selecting 2 nodes drove
+  `selectedNodeIds:["mt:4134514556","mt:3274688221"]`, dimmed 1528 markers to
+  0.3 while keeping selected at 1.0, and the selection + dimming persisted
+  across reload (pill "2 selected"). No Phase-1 console errors.
+  Deviation from plan: interview chose **dim-unselected (keep visible)** over
+  hide-unselected, so Phase 1 emphasizes rather than filters. Next: ship
+  Phase 1 PR after #4008 merges + rebase; then Phase 2 (Follow & Auto-zoom).

--- a/docs/internal/dev-notes/PHASE1_NODE_SELECTION_SPEC.md
+++ b/docs/internal/dev-notes/PHASE1_NODE_SELECTION_SPEC.md
@@ -1,0 +1,222 @@
+# Phase 1 Implementation Spec — Node Selection & Emphasis (issue #3788)
+
+**Branch/worktree:** `feature/3788-node-select` @ `/home/yeraze/Development/meshmonitor-3788-p1`
+**Scope:** Frontend only. No backend, schema, migration, or API change. No new `any`. No raw `fetch()` in components/pages.
+**Goal:** Add a node multi-select to the `/analysis` toolbar; store `selectedNodeIds: string[]` in `MapAnalysisConfig` (persisted); when non-empty, dim unselected markers **and** trails; selection keyed on `mt:<nodeNum>` / `mc:<publicKey>` — the exact identity `mergeUnifiedSourceData` uses.
+
+---
+
+## 1. Reuse inventory (verified in worktree)
+
+| Symbol | File:line | How Phase 1 uses it |
+|---|---|---|
+| `MapAnalysisConfig` (type) | `src/hooks/useMapAnalysisConfig.ts:40-52` | **Extend** with `selectedNodeIds: string[]`. |
+| `DEFAULT_CONFIG` | `src/hooks/useMapAnalysisConfig.ts:58-75` | **Extend** with `selectedNodeIds: []`. |
+| `load()` | `src/hooks/useMapAnalysisConfig.ts:87-103` | **Extend** to coerce a missing/garbage `selectedNodeIds` to `[]` (old-config safety). |
+| `useMapAnalysisConfig()` | `src/hooks/useMapAnalysisConfig.ts:113-179` | **Add** setter `setSelectedNodeIds`; expose in return object. `reset()` already clears via `DEFAULT_CONFIG`. |
+| `useMapAnalysisCtx()` / `MapAnalysisProvider` | `src/components/MapAnalysis/MapAnalysisContext.tsx:39-54` | **No edit needed.** Ctx type is `ReturnType<typeof useMapAnalysisConfig> & {…}`, so `config.selectedNodeIds` + `setSelectedNodeIds` propagate automatically. |
+| `MapAnalysisToolbar` | `src/components/MapAnalysis/MapAnalysisToolbar.tsx:34-170` | **Edit** to mount the new `NodeMultiSelect` next to `NodeSearchControl`. |
+| `SourceMultiSelect` (pattern) | `src/components/MapAnalysis/SourceMultiSelect.tsx:1-43` | **Template** for the new control (pill + `.map-analysis-source-popover` + Clear). Reuses existing CSS classes — no new CSS required. |
+| `NodeTypeFilterControl` (pattern) | `src/components/MapAnalysis/NodeTypeFilterControl.tsx` | Secondary pattern (Show-all button, `useState(open)`). |
+| `useDashboardUnifiedData(sources, enabled)` | `src/hooks/useDashboardData.ts:436-499` | Node feed for the picker + markers (already used by markers layer). Pass **full source objects** so merged `sources[]` is stamped. |
+| `mergeUnifiedSourceData` | `src/hooks/useDashboardData.ts:332-427` | **Refactor** its inline `mt:`/`mc:` keying (lines 359-374) to call the new `unifiedNodeKey` helper — single source of truth. |
+| `useDashboardSources()` | `src/hooks/useDashboardData.ts` | Source list (already used by toolbar + markers + trails). |
+| `resolveNodeLatLng` / `MaybePositionedNode` | `src/components/MapAnalysis/nodePositionUtil` | Position resolution for the shared node hook. |
+| `nodeMatchesSearch` | `src/components/MapAnalysis/nodeSearch` | Search filter (reused by shared node hook). |
+| `getNodeTypeCategory` | `src/utils/nodeTypeCategory` | Type filter (reused by shared node hook). |
+| `NodeMarkersLayer` filter block | `src/components/MapAnalysis/layers/NodeMarkersLayer.tsx:160-179` | **Extract** into `useAnalysisNodes()` so picker + markers share one filter; then **apply dimming** (opacity multiply) at the `<Marker opacity>` prop (:261). |
+| `markerAgeOpacity` / `MIN_MARKER_OPACITY` | `src/utils/markerAgeOpacity` | Existing marker opacity; dimming multiplies on top (no conflict). |
+| `PositionTrailsLayer` | `src/components/MapAnalysis/layers/PositionTrailsLayer.tsx:26-109` | **Apply dimming** at the `<Polyline pathOptions.opacity>` (:93). |
+
+**Genuinely new files (justified):**
+- `src/utils/nodeIdentity.ts` — no identity-key helper exists today; keying is inlined in the merge and cannot be imported. A neutral `utils` home lets both the hook (`useDashboardData`) and the MapAnalysis components import it without an inverted dependency (component-dir → hook).
+- `src/components/MapAnalysis/useAnalysisNodes.ts` — extracts the duplicated markers filter so the picker and the map agree on identity/visibility (reuse, not duplication).
+- `src/components/MapAnalysis/NodeMultiSelect.tsx` — the toolbar control (mirrors `SourceMultiSelect`).
+
+---
+
+## 2. Canonical node-identity helper
+
+**There is NO existing reusable helper.** Verified:
+- `mergeUnifiedSourceData` inlines the keying (`useDashboardData.ts:359-374`): MeshCore → `mc:${publicKey}` (fallback `mc:${nodeId}`); Meshtastic → `mt:${nodeNum}`.
+- `NodeMarkersLayer.keyOf` (`:136-137`) is a **different** *spiderfier* key (`mc:${nodeId}` / `${sourceId}:${nodeNum}`) — **do NOT reuse it for selection.**
+
+**Add** `src/utils/nodeIdentity.ts`:
+
+```ts
+export interface IdentifiableNode {
+  nodeNum?: number | null;
+  isMeshCore?: boolean | null;
+  publicKey?: string | null;
+  nodeId?: string | null;
+}
+
+/** Canonical cross-source node key — MUST match mergeUnifiedSourceData's keying. */
+export function unifiedNodeKey(n: IdentifiableNode): string | null {
+  if (n.isMeshCore) {
+    if (typeof n.publicKey === 'string' && n.publicKey.length > 0) return `mc:${n.publicKey}`;
+    if (typeof n.nodeId === 'string' && n.nodeId.length > 0) return `mc:${n.nodeId}`;
+    return null;
+  }
+  if (typeof n.nodeNum === 'number') return `mt:${n.nodeNum}`;
+  return null;
+}
+
+/** Dim factor applied to unselected markers/trails when a selection is active. */
+export const SELECTION_DIM_OPACITY = 0.3;
+
+/** With an empty selection everything is full-emphasis; otherwise only members are. */
+export function isNodeEmphasized(key: string | null, selectedNodeIds: readonly string[]): boolean {
+  if (selectedNodeIds.length === 0) return true;
+  return key != null && selectedNodeIds.includes(key);
+}
+
+/** Base opacity scaled down when the node is not emphasized. */
+export function selectionOpacity(base: number, emphasized: boolean): number {
+  return emphasized ? base : base * SELECTION_DIM_OPACITY;
+}
+```
+
+**Refactor** `mergeUnifiedSourceData` (`useDashboardData.ts:359-374`) to call `unifiedNodeKey(n)` instead of the inline block, so the two can never drift. (The raw per-source node record carries `isMeshCore`/`publicKey`/`nodeNum`/`nodeId`; `mergeNodeRecords` at :257-291 copies all of those onto the merged record, so `unifiedNodeKey` works identically on raw and merged nodes.)
+
+---
+
+## 3. File-by-file changes
+
+### 3a. `src/hooks/useMapAnalysisConfig.ts` (modify)
+- `MapAnalysisConfig`: add `selectedNodeIds: string[];`.
+- `DEFAULT_CONFIG`: add `selectedNodeIds: [],`.
+- `load()`: after the existing spreads, add an explicit coercion so an old persisted config (no field) or garbage does not crash:
+  ```ts
+  selectedNodeIds: Array.isArray(parsed.selectedNodeIds) ? parsed.selectedNodeIds : [],
+  ```
+  (Placed inside the returned object literal, after `timeSlider: …`.) The `{ ...DEFAULT_CONFIG, ...parsed }` already backfills it to `[]`; this line hardens against a non-array value.
+- Add setter, mirroring `setSources` (:154-156):
+  ```ts
+  const setSelectedNodeIds = useCallback((ids: string[]) => {
+    setConfig((prev) => ({ ...prev, selectedNodeIds: ids }));
+  }, []);
+  ```
+- Add `setSelectedNodeIds` to the returned object (:168-178).
+
+**No migration needed** — persistence is localStorage; old configs load safely (see exit criteria "persists across reload").
+
+### 3b. `src/utils/nodeIdentity.ts` (new) — see §2.
+
+### 3c. `src/hooks/useDashboardData.ts` (modify) — refactor merge keying to `unifiedNodeKey` (see §2).
+
+### 3d. `src/components/MapAnalysis/useAnalysisNodes.ts` (new)
+Extract the markers filter so picker and map share identity + visibility. Returns positioned, filtered nodes (position required — these are the nodes that can be emphasized/followed, keeping picker ⇄ map in agreement).
+
+```ts
+// Signature (implementation mirrors NodeMarkersLayer.tsx:139-179 exactly)
+export interface AnalysisNode { node: NodeRecord; latLng: [number, number]; key: string; }
+export function useAnalysisNodes(): AnalysisNode[]
+```
+- Internally: `useDashboardSources()` → full source objects; `useDashboardUnifiedData(sources, sourceIds.length > 0)`; then the same predicate as markers (`hideFromMap`, `nodeMatchesSearch(node, nodeFilter)`, `config.nodeTypes[getNodeTypeCategory(node)] !== false`, and the `config.sources` allow-list over `node.sources[]`). Attach `key = unifiedNodeKey(node)`; drop nodes whose `key` is `null`.
+- `NodeRecord` type: reuse the interface currently declared in `NodeMarkersLayer.tsx:21-35` — **move it into this hook file and re-export**, so the markers layer imports it from here (avoids duplication). Add `publicKey?: string | null;` to it (needed by `unifiedNodeKey`; safe additive field).
+
+### 3e. `src/components/MapAnalysis/layers/NodeMarkersLayer.tsx` (modify)
+- Replace the inline `filteredNodes` computation (:160-179) with `const analysisNodes = useAnalysisNodes();`. Keep all spiderfy machinery unchanged (it still iterates the returned `{node, latLng}` list; `keyOf` for the spiderfier stays as-is — that is a separate concern from selection identity).
+- Read selection: `const { config } = useMapAnalysisCtx();` → `config.selectedNodeIds`.
+- At the `<Marker>` (:255-261), dim: compute
+  ```ts
+  const emphasized = isNodeEmphasized(unifiedNodeKey(n), config.selectedNodeIds);
+  const finalOpacity = selectionOpacity(markerOpacity, emphasized);
+  ```
+  and pass `opacity={finalOpacity}`. **Dimming is via the leaflet `opacity` prop only** — do NOT fold it into `iconSig`/the divIcon, so the spiderfy fan and icon cache do not churn (react-leaflet applies opacity via `setOpacity`, no marker recreation). Empty selection → `emphasized` always true → `finalOpacity === markerOpacity` (today's behavior).
+
+### 3f. `src/components/MapAnalysis/layers/PositionTrailsLayer.tsx` (modify)
+- Read `config.selectedNodeIds` from `useMapAnalysisCtx()` (already destructures `config`).
+- Trail rows carry only `{sourceId, nodeNum}` (the `/api/analysis/positions` feed is Meshtastic lat/lon telemetry keyed by `nodeNum` — `analysis.ts` getPositions; MeshCore does not populate this layer). So the trail identity is `unifiedNodeKey({ nodeNum: t.nodeNum, isMeshCore: false })` → `mt:${nodeNum}`. A `mc:` selection correctly never matches a trail (MeshCore has no trail here) — graceful.
+- At the `<Polyline>` (:90-93): `const emphasized = isNodeEmphasized(\`mt:${t.nodeNum}\`, config.selectedNodeIds);` and set `pathOptions={{ color: t.color, weight: 2, opacity: selectionOpacity(0.7, emphasized) }}`. `pathOptions` is already recomputed inline each render — no caching concern.
+
+### 3g. `src/components/MapAnalysis/NodeMultiSelect.tsx` (new)
+Mirror `SourceMultiSelect` (pill + `.map-analysis-source-popover`, reuse existing classes). Props:
+```ts
+interface NodeMultiSelectProps {
+  nodes: Array<{ key: string; label: string }>;  // deduped, sorted
+  value: string[];
+  onChange: (next: string[]) => void;
+}
+```
+- Pill label: `value.length === 0 ? 'All nodes' : \`${value.length} selected\`` (only counts keys still present optional; keep simple).
+- Popover: one checkbox per node (`checked={value.includes(n.key)}`, toggle like SourceMultiSelect:15-17).
+- **Select all**: `onChange(nodes.map(n => n.key))`. **Clear**: `onChange([])` (shown when `value.length > 0`).
+- Long lists: include an internal text filter input inside the popover (optional; the global `NodeSearchControl` already narrows `nodes` upstream — acceptable to ship without it).
+
+### 3h. `src/components/MapAnalysis/MapAnalysisToolbar.tsx` (modify)
+- `const { config, …, setSelectedNodeIds } = useMapAnalysisCtx();`
+- `const analysisNodes = useAnalysisNodes();`
+- Build deduped, sorted options:
+  ```ts
+  const nodeOptions = useMemo(() => {
+    const byKey = new Map<string, string>();
+    for (const { key, node } of analysisNodes) {
+      if (!byKey.has(key)) byKey.set(key, node.longName || node.shortName || node.nodeId || key);
+    }
+    return [...byKey].map(([key, label]) => ({ key, label })).sort((a, b) => a.label.localeCompare(b.label));
+  }, [analysisNodes]);
+  ```
+- Mount after `<NodeSearchControl />` (:113):
+  ```tsx
+  <NodeMultiSelect nodes={nodeOptions} value={config.selectedNodeIds} onChange={setSelectedNodeIds} />
+  ```
+
+---
+
+## 4. Test plan (Vitest, standard suite — no standalone scripts)
+
+1. **`src/utils/nodeIdentity.test.ts` (new)**
+   - `unifiedNodeKey`: Meshtastic `{nodeNum:5}` → `mt:5`; MeshCore `{isMeshCore:true, publicKey:'ab'}` → `mc:ab`; MeshCore `{isMeshCore:true, nodeId:'mc:x'}` (no key) → `mc:mc:x`; MeshCore with neither → `null`; Meshtastic missing `nodeNum` → `null`.
+   - **Drift guard:** feed a small `perSource` array through `mergeUnifiedSourceData` and assert each merged node's key (recomputed via `unifiedNodeKey`) is what the merge bucketed on (one Meshtastic, one MeshCore across two sources → 2 nodes, keys `mt:*`/`mc:*`).
+   - `isNodeEmphasized`: empty selection → `true` for any key incl. `null`; non-empty → `true` only for members; `null` key with non-empty selection → `false`.
+   - `selectionOpacity`: `(1, true) === 1`; `(1, false) === SELECTION_DIM_OPACITY`; `(0.7, false) === 0.7 * SELECTION_DIM_OPACITY`.
+
+2. **`src/hooks/useMapAnalysisConfig.test.ts` (extend)**
+   - `DEFAULT_CONFIG.selectedNodeIds` is `[]`; fresh hook returns `[]`.
+   - `setSelectedNodeIds(['mt:1','mc:ab'])` updates `config.selectedNodeIds` and persists (assert `JSON.parse(localStorage[KEY]).selectedNodeIds`).
+   - **Old-config load:** seed `localStorage` with a valid `version:1` config JSON that omits `selectedNodeIds`; assert hook loads with `selectedNodeIds === []` and does not throw.
+   - **Garbage coercion:** seed with `selectedNodeIds: "oops"`; assert coerced to `[]`.
+   - `reset()` clears `selectedNodeIds` back to `[]`.
+
+3. **`src/components/MapAnalysis/useAnalysisNodes.test.tsx` (new)** — mock `useDashboardUnifiedData` + `useDashboardSources` (pattern from `PositionTrailsLayer.test.tsx:25-27`). Provide a Meshtastic node (positioned), a MeshCore node (positioned, `isMeshCore`+`publicKey`), one unpositioned, one `hideFromMap`. Assert: returns only positioned+visible nodes; `key` values are `mt:*` / `mc:*`; source/type/search filters exclude as expected.
+
+4. **`src/components/MapAnalysis/NodeMultiSelect.test.tsx` (new)** — render with 3 options + spy `onChange`. Assert: checking a box calls `onChange` with the `mt:`/`mc:` key added; unchecking removes it; **Select all** calls `onChange` with all keys; **Clear** calls `onChange([])` and only shows when `value` non-empty.
+
+5. **`src/components/MapAnalysis/layers/PositionTrailsLayer.test.tsx` (extend)** — change the `Polyline` mock to capture opacity: `Polyline: (p) => <div data-testid="poly" data-opacity={p.pathOptions?.opacity} />`. With mock trails for nodeNum 1 & 2 and `selectedNodeIds:['mt:1']` (seed via localStorage config), assert the `mt:1` polyline has `data-opacity === "0.7"` and the `mt:2` polyline has the dimmed value (`0.7 * SELECTION_DIM_OPACITY`). Empty selection → both `0.7` (existing test still green).
+
+6. **Marker dimming** — proven at the pure-helper level (`isNodeEmphasized` + `selectionOpacity` in test #1). No `NodeMarkersLayer.test.tsx` exists today and the layer is spiderfy/leaflet-heavy; a full render test is out of scope. (Optional stretch: a thin render test mocking react-leaflet `Marker` to capture the `opacity` prop, same pattern as the trails test — include only if cheap.)
+
+**Also:** `npm run typecheck` clean; `npm run lint:ci` exits 0 (no new `any`, no raw `fetch()` — all data via existing hooks).
+
+---
+
+## 5. Work-package decomposition
+
+Sized for one Sonnet agent each. **WP-A is the foundation; WP-B/WP-C/WP-D depend on it and may run in parallel with each other.**
+
+### WP-A — Identity helper + config field (foundation, do FIRST)
+- Create `src/utils/nodeIdentity.ts` (§2) + `src/utils/nodeIdentity.test.ts` (test #1).
+- Refactor `mergeUnifiedSourceData` keying to `unifiedNodeKey`; run `useDashboardData.test.ts` — must stay green.
+- Extend `MapAnalysisConfig`/`DEFAULT_CONFIG`/`load()`/`useMapAnalysisConfig` with `selectedNodeIds` + `setSelectedNodeIds` (§3a) + extend `useMapAnalysisConfig.test.ts` (test #2).
+- **Accept:** new + existing config/merge tests green; typecheck clean; `unifiedNodeKey` drift-guard passes.
+
+### WP-B — Shared node hook + picker + toolbar wiring (depends on WP-A)
+- Create `useAnalysisNodes.ts` (move/extend `NodeRecord`, add `publicKey`) + refactor `NodeMarkersLayer` to consume it (no behavior change to markers yet) (§3d/§3e-first-half).
+- Create `NodeMultiSelect.tsx` (§3g); wire into toolbar (§3h).
+- Tests #3 (`useAnalysisNodes`) + #4 (`NodeMultiSelect`).
+- **Accept:** picker lists nodes from selected sources with select-all/clear; `NodeMarkersLayer.test`-adjacent suites + spiderfy tests still green; typecheck clean.
+
+### WP-C — Marker dimming (depends on WP-A; parallel with WP-B, but touches NodeMarkersLayer → sequence after WP-B's markers refactor to avoid conflict, OR fold WP-C into WP-B)
+- In `NodeMarkersLayer`, apply `selectionOpacity(markerOpacity, isNodeEmphasized(unifiedNodeKey(n), config.selectedNodeIds))` at the `opacity` prop only (§3e).
+- **Accept:** with a non-empty `selectedNodeIds`, unselected markers render reduced opacity, selected full; empty selection unchanged; spiderfy fan intact; typecheck clean.
+
+> **Sequencing note:** WP-B and WP-C both edit `NodeMarkersLayer.tsx`. Recommended: **merge WP-B and WP-C into a single agent** (the markers-layer refactor and its dimming land together), running in parallel with WP-D. If split, WP-C runs strictly after WP-B.
+
+### WP-D — Trail dimming (depends on WP-A only; fully parallel)
+- Apply trail dimming in `PositionTrailsLayer` (§3f); extend its test (test #5).
+- **Accept:** selected trail full opacity, unselected dimmed; empty selection unchanged; existing trails tests green; typecheck clean.
+
+**Final integration gate (after all WPs):** full Vitest suite 0 failures; `npm run typecheck` clean; `npm run lint:ci` exits 0; browser-validate on `/analysis` (pick Meshtastic + MeshCore nodes → unselected markers & trails dim, reload persists selection).
+```

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -1,10 +1,13 @@
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDashboardSources } from '../../hooks/useDashboardData';
 import LayerToggleButton from './LayerToggleButton';
 import SourceMultiSelect from './SourceMultiSelect';
 import NodeTypeFilterControl from './NodeTypeFilterControl';
 import NodeSearchControl from './NodeSearchControl';
+import NodeMultiSelect from './NodeMultiSelect';
 import TracerouteControls from './TracerouteControls';
+import { useAnalysisNodes } from './useAnalysisNodes';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { useOwnNodePositions } from '../../hooks/useOwnNodePositions';
 import { LayerKey } from '../../hooks/useMapAnalysisConfig';
@@ -33,8 +36,23 @@ const UNTIMED_LAYERS: { key: LayerKey; label: string }[] = [
 
 export default function MapAnalysisToolbar() {
   const navigate = useNavigate();
-  const { config, setLayerEnabled, setLayerLookback, setSources, setTimeSlider, reset } = useMapAnalysisCtx();
+  const { config, setLayerEnabled, setLayerLookback, setSources, setSelectedNodeIds, setTimeSlider, reset } =
+    useMapAnalysisCtx();
   const { data: sources = [] } = useDashboardSources();
+
+  // Node picker (issue #3788): deduped/sorted options built from the same
+  // shared node hook the markers layer uses, so the picker never lists a node
+  // the map itself wouldn't render.
+  const analysisNodes = useAnalysisNodes();
+  const nodeOptions = useMemo(() => {
+    const byKey = new Map<string, string>();
+    for (const { key, node } of analysisNodes) {
+      if (!byKey.has(key)) byKey.set(key, node.longName || node.shortName || node.nodeId || key);
+    }
+    return [...byKey]
+      .map(([key, label]) => ({ key, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [analysisNodes]);
 
   // Polar grid (#3971): centered on each active source's own-node position.
   // Disable the toggle when no active source has a resolvable own node.
@@ -111,6 +129,7 @@ export default function MapAnalysisToolbar() {
       />
       <NodeTypeFilterControl />
       <NodeSearchControl />
+      <NodeMultiSelect nodes={nodeOptions} value={config.selectedNodeIds} onChange={setSelectedNodeIds} />
       <button
         type="button"
         className={`map-analysis-layer-btn ${config.timeSlider.enabled ? 'active' : ''}`}

--- a/src/components/MapAnalysis/NodeMultiSelect.test.tsx
+++ b/src/components/MapAnalysis/NodeMultiSelect.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NodeMultiSelect from './NodeMultiSelect';
+
+const NODES = [
+  { key: 'mt:1', label: 'Alpha' },
+  { key: 'mt:2', label: 'Bravo' },
+  { key: 'mc:deadbeef', label: 'Charlie' },
+];
+
+describe('NodeMultiSelect', () => {
+  it('shows "All nodes" when value is empty and no Clear button', () => {
+    render(<NodeMultiSelect nodes={NODES} value={[]} onChange={vi.fn()} />);
+    expect(screen.getByText('All nodes')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('All nodes'));
+    expect(screen.queryByText('Clear')).not.toBeInTheDocument();
+  });
+
+  it('shows "N selected" and a Clear button when value is non-empty', () => {
+    render(<NodeMultiSelect nodes={NODES} value={['mt:1']} onChange={vi.fn()} />);
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('1 selected'));
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+  });
+
+  it('checking a box adds the key via onChange', () => {
+    const onChange = vi.fn();
+    render(<NodeMultiSelect nodes={NODES} value={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByText('All nodes'));
+    fireEvent.click(screen.getByLabelText('Bravo'));
+    expect(onChange).toHaveBeenCalledWith(['mt:2']);
+  });
+
+  it('unchecking a box removes the key via onChange', () => {
+    const onChange = vi.fn();
+    render(<NodeMultiSelect nodes={NODES} value={['mt:1', 'mt:2']} onChange={onChange} />);
+    fireEvent.click(screen.getByText('2 selected'));
+    fireEvent.click(screen.getByLabelText('Alpha'));
+    expect(onChange).toHaveBeenCalledWith(['mt:2']);
+  });
+
+  it('Select all calls onChange with every key', () => {
+    const onChange = vi.fn();
+    render(<NodeMultiSelect nodes={NODES} value={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByText('All nodes'));
+    fireEvent.click(screen.getByText('Select all'));
+    expect(onChange).toHaveBeenCalledWith(['mt:1', 'mt:2', 'mc:deadbeef']);
+  });
+
+  it('Clear calls onChange with an empty array', () => {
+    const onChange = vi.fn();
+    render(<NodeMultiSelect nodes={NODES} value={['mt:1']} onChange={onChange} />);
+    fireEvent.click(screen.getByText('1 selected'));
+    fireEvent.click(screen.getByText('Clear'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/MapAnalysis/NodeMultiSelect.tsx
+++ b/src/components/MapAnalysis/NodeMultiSelect.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+export interface NodeMultiSelectProps {
+  nodes: Array<{ key: string; label: string }>;
+  value: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Node picker for the Map Analysis toolbar (issue #3788 WP-B/C). Mirrors
+ * {@link SourceMultiSelect}'s pill + popover pattern — same CSS classes, no
+ * new styling. `value`/`onChange` hold the `mt:`/`mc:` unified node keys
+ * (see `src/utils/nodeIdentity.ts`); a non-empty selection dims unselected
+ * markers/trails elsewhere on the map.
+ */
+export default function NodeMultiSelect({ nodes, value, onChange }: NodeMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+  const label = value.length === 0 ? 'All nodes' : `${value.length} selected`;
+
+  function toggle(key: string) {
+    onChange(value.includes(key) ? value.filter((v) => v !== key) : [...value, key]);
+  }
+
+  return (
+    <div className="map-analysis-source-select">
+      <button type="button" onClick={() => setOpen((o) => !o)} className="map-analysis-pill">
+        {label}
+      </button>
+      {open && (
+        <div className="map-analysis-source-popover" role="dialog">
+          {nodes.map((n) => (
+            <label key={n.key} className="map-analysis-source-row">
+              <input
+                type="checkbox"
+                checked={value.includes(n.key)}
+                onChange={() => toggle(n.key)}
+              />
+              {n.label}
+            </label>
+          ))}
+          <button type="button" onClick={() => onChange(nodes.map((n) => n.key))}>
+            Select all
+          </button>
+          {value.length > 0 && (
+            <button type="button" onClick={() => onChange([])}>Clear</button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Thin render test for selection dimming (issue #3788 WP-C, spec test #6).
+ * `NodeMarkersLayer` is spiderfy/leaflet-heavy, so everything except the
+ * opacity computation under test is mocked out — this only proves the
+ * `isNodeEmphasized`/`selectionOpacity` wiring at the `<Marker opacity>` prop,
+ * not marker/spiderfy behavior (already covered by other suites).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MapAnalysisProvider } from '../MapAnalysisContext';
+import NodeMarkersLayer from './NodeMarkersLayer';
+
+vi.mock('react-leaflet', () => ({
+  Marker: (p: { opacity?: number; children?: React.ReactNode }) => (
+    <div data-testid="marker" data-opacity={p.opacity}>
+      {p.children}
+    </div>
+  ),
+  Popup: () => null,
+}));
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+vi.mock('../../../hooks/useMarkerSpiderfier', () => ({
+  useMarkerSpiderfier: () => ({ addMarker: vi.fn(), removeMarker: vi.fn() }),
+  SHARED_SPIDERFIER_OPTIONS: {},
+}));
+vi.mock('../../../hooks/useMapAnalysisData', () => ({
+  useHopCounts: () => ({ data: undefined }),
+}));
+vi.mock('../../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ mapPinStyle: 'pin' }),
+}));
+vi.mock('../../../hooks/useDashboardData', () => ({
+  useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }] }),
+}));
+vi.mock('../../Dashboard/DashboardNodePopup', () => ({
+  default: () => null,
+}));
+
+const MOCK_ANALYSIS_NODES = [
+  { node: { nodeNum: 1, sourceId: 'a', isMeshCore: false }, latLng: [30, -90] as [number, number], key: 'mt:1' },
+  { node: { nodeNum: 2, sourceId: 'a', isMeshCore: false }, latLng: [31, -91] as [number, number], key: 'mt:2' },
+];
+vi.mock('../useAnalysisNodes', () => ({
+  useAnalysisNodes: () => MOCK_ANALYSIS_NODES,
+}));
+
+function renderLayer() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MapAnalysisProvider>
+        <NodeMarkersLayer />
+      </MapAnalysisProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('NodeMarkersLayer selection dimming', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('renders both markers at full opacity with an empty selection', () => {
+    renderLayer();
+    const markers = screen.getAllByTestId('marker');
+    expect(markers).toHaveLength(2);
+    expect(markers.map((m) => m.getAttribute('data-opacity'))).toEqual(['1', '1']);
+  });
+
+  it('dims the unselected marker and keeps the selected one at full opacity', () => {
+    localStorage.setItem(
+      'mapAnalysis.config.v1',
+      JSON.stringify({
+        version: 1,
+        layers: {
+          markers: { enabled: true, lookbackHours: null },
+          traceroutes: { enabled: false, lookbackHours: 24 },
+          neighbors: { enabled: false, lookbackHours: 24 },
+          heatmap: { enabled: false, lookbackHours: 24 },
+          trails: { enabled: false, lookbackHours: 24 },
+          hopShading: { enabled: false, lookbackHours: null },
+          snrOverlay: { enabled: false, lookbackHours: null },
+          waypoints: { enabled: true, lookbackHours: null },
+          polarGrid: { enabled: false, lookbackHours: null },
+        },
+        sources: [],
+        timeSlider: { enabled: false },
+        inspectorOpen: true,
+        selectedNodeIds: ['mt:1'],
+      }),
+    );
+    renderLayer();
+    const markers = screen.getAllByTestId('marker');
+    expect(markers).toHaveLength(2);
+    const opacities = markers.map((m) => m.getAttribute('data-opacity'));
+    expect(opacities).toEqual(['1', String(0.3)]);
+  });
+});

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -2,37 +2,18 @@ import { Marker, Popup } from 'react-leaflet';
 import { useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Marker as LeafletMarker } from 'leaflet';
-import {
-  useDashboardSources,
-  useDashboardUnifiedData,
-} from '../../../hooks/useDashboardData';
+import { useDashboardSources } from '../../../hooks/useDashboardData';
 import { useHopCounts } from '../../../hooks/useMapAnalysisData';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
 import { useMarkerSpiderfier, SHARED_SPIDERFIER_OPTIONS } from '../../../hooks/useMarkerSpiderfier';
-import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
-import { nodeMatchesSearch } from '../nodeSearch';
+import { useAnalysisNodes, type NodeRecord } from '../useAnalysisNodes';
 import { createNodeIcon } from '../../../utils/mapIcons';
 import { getNodeTypeCategory } from '../../../utils/nodeTypeCategory';
 import { markerAgeOpacity, MIN_MARKER_OPACITY } from '../../../utils/markerAgeOpacity';
+import { isNodeEmphasized, selectionOpacity } from '../../../utils/nodeIdentity';
 import DashboardNodePopup, { type NodeSourceRef } from '../../Dashboard/DashboardNodePopup';
 import '../../../styles/nodes.css'; // `.node-popup-*` classes used by DashboardNodePopup
-
-interface NodeRecord extends MaybePositionedNode {
-  nodeNum: number;
-  sourceId?: string;
-  nodeId?: string | null;
-  longName?: string | null;
-  shortName?: string | null;
-  hideFromMap?: boolean | null;
-  user?: { role?: string | number | null } | null;
-  isMeshCore?: boolean;
-  advType?: number | null;
-  /** Unix seconds of last reception; drives time-slider opacity fade (#3886). */
-  lastHeard?: number | null;
-  /** Every configured source that reported this node (unified merge, #2805). */
-  sources?: NodeSourceRef[];
-}
 
 interface HopEntry {
   sourceId: string;
@@ -52,7 +33,7 @@ interface HopEntry {
  * inspector panel can react.
  */
 export default function NodeMarkersLayer() {
-  const { config, selected, setSelected, nodeFilter } = useMapAnalysisCtx();
+  const { config, selected, setSelected } = useMapAnalysisCtx();
   const { mapPinStyle } = useSettings();
   const navigate = useNavigate();
 
@@ -139,10 +120,6 @@ export default function NodeMarkersLayer() {
   const { data: sources = [] } = useDashboardSources();
   const sourceList = sources as Array<{ id: string; name: string }>;
   const sourceIds = sourceList.map((s) => s.id);
-  // Pass the FULL source objects (not bare ids) so the unified merge stamps the
-  // per-node `sources` array used by the popup's "Seen by N sources" list and by
-  // the multi-source filter. Bare-string callers get no `sources` field.
-  const { nodes } = useDashboardUnifiedData(sources, sourceIds.length > 0);
   const hop = useHopCounts({
     enabled: config.layers.hopShading.enabled,
     sources: config.sources.length === 0 ? sourceIds : config.sources,
@@ -157,26 +134,10 @@ export default function NodeMarkersLayer() {
     return m;
   }, [hop.data]);
 
-  const filteredNodes = ((nodes ?? []) as NodeRecord[])
-    .map((n) => ({ node: n, latLng: resolveNodeLatLng(n) }))
-    .filter(({ node, latLng }) => {
-      if (!latLng) return false;
-      // #3549: per-node "Hide from Map" suppresses the marker on every map surface.
-      if (node.hideFromMap) return false;
-      // Node search (issue #3399): hide non-matches.
-      if (!nodeMatchesSearch(node, nodeFilter)) return false;
-      // Node-type filter (issue #3546): hide categories the user toggled off.
-      if (config.nodeTypes[getNodeTypeCategory(node)] === false) return false;
-      if (config.sources.length === 0) return true;
-      // Source filter: a unified-merged node can be reported by several sources
-      // (node.sources). It must stay visible if ANY of those is enabled — not
-      // just its primary sourceId — so multi-source nodes don't vanish when only
-      // one of their sources is selected. Fall back to sourceId for unmerged rows.
-      const sourceIds = node.sources && node.sources.length > 0
-        ? node.sources.map((s) => s.sourceId)
-        : (node.sourceId ? [node.sourceId] : []);
-      return sourceIds.some((id) => config.sources.includes(id));
-    });
+  // Shared identity + visibility computation (issue #3788 WP-B) — the same
+  // predicate the node picker (NodeMultiSelect) uses, so the two surfaces
+  // never disagree about which nodes exist/are shown.
+  const filteredNodes = useAnalysisNodes();
 
   // Genuine removals (a node aged out / filtered away) are reconciled here
   // rather than from the ref `null` bounce — drop any tracked marker whose key
@@ -208,8 +169,8 @@ export default function NodeMarkersLayer() {
 
   return (
     <>
-      {filteredNodes.map(({ node: n, latLng }) => {
-        const [lat, lon] = latLng!;
+      {filteredNodes.map(({ node: n, latLng, key: unifiedKey }) => {
+        const [lat, lon] = latLng;
         const sourceId = n.sourceId ?? '';
         const hopVal = hopByKey.get(`${sourceId}:${Number(n.nodeNum)}`);
         const hops =
@@ -252,13 +213,20 @@ export default function NodeMarkersLayer() {
           : n.lastHeard != null
             ? markerAgeOpacity(windowEndMs, windowStartMs, n.lastHeard * 1000)
             : MIN_MARKER_OPACITY;
+        // Selection dimming (issue #3788 WP-C): applied via the leaflet `opacity`
+        // prop only — NOT folded into `iconSig`/the divIcon — so the spiderfy fan
+        // and icon cache don't churn when the selection changes. Empty selection
+        // ⇒ isNodeEmphasized always true ⇒ finalOpacity === markerOpacity (today's
+        // behavior, unchanged).
+        const emphasized = isNodeEmphasized(unifiedKey, config.selectedNodeIds);
+        const finalOpacity = selectionOpacity(markerOpacity, emphasized);
         return (
           <Marker
             key={markerKey}
             ref={getMarkerRef(markerKey)}
             position={stablePosition(markerKey, lat, lon)}
             icon={icon}
-            opacity={markerOpacity}
+            opacity={finalOpacity}
             eventHandlers={{
               click: () =>
                 setSelected({

--- a/src/components/MapAnalysis/layers/PositionTrailsLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/PositionTrailsLayer.test.tsx
@@ -8,7 +8,9 @@ import { MapAnalysisProvider } from '../MapAnalysisContext';
 import PositionTrailsLayer from './PositionTrailsLayer';
 
 vi.mock('react-leaflet', () => ({
-  Polyline: () => <div data-testid="poly" />,
+  Polyline: (p: { pathOptions?: { opacity?: number } }) => (
+    <div data-testid="poly" data-opacity={p.pathOptions?.opacity} />
+  ),
 }));
 vi.mock('../../../hooks/useMapAnalysisData', () => ({
   usePositions: () => ({
@@ -73,5 +75,40 @@ describe('PositionTrailsLayer', () => {
       </QueryClientProvider>,
     );
     expect(screen.queryAllByTestId('poly')).toHaveLength(0);
+  });
+
+  it('dims trails for nodes not in selectedNodeIds', () => {
+    localStorage.setItem(
+      'mapAnalysis.config.v1',
+      JSON.stringify({
+        version: 1,
+        layers: {
+          markers: { enabled: false, lookbackHours: null },
+          traceroutes: { enabled: false, lookbackHours: 24 },
+          neighbors: { enabled: false, lookbackHours: 24 },
+          heatmap: { enabled: false, lookbackHours: 24 },
+          trails: { enabled: true, lookbackHours: 24 },
+          hopShading: { enabled: false, lookbackHours: null },
+          snrOverlay: { enabled: false, lookbackHours: 24 },
+        },
+        sources: [],
+        timeSlider: { enabled: false },
+        inspectorOpen: true,
+        selectedNodeIds: ['mt:1'],
+      }),
+    );
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <MapAnalysisProvider>
+          <PositionTrailsLayer />
+        </MapAnalysisProvider>
+      </QueryClientProvider>,
+    );
+    const polys = screen.getAllByTestId('poly');
+    expect(polys).toHaveLength(2);
+    const opacities = polys.map((p) => p.getAttribute('data-opacity'));
+    expect(opacities).toContain('0.7');
+    expect(opacities).toContain(String(0.7 * 0.3));
   });
 });

--- a/src/components/MapAnalysis/layers/PositionTrailsLayer.tsx
+++ b/src/components/MapAnalysis/layers/PositionTrailsLayer.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useDashboardSources } from '../../../hooks/useDashboardData';
 import { usePositions } from '../../../hooks/useMapAnalysisData';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
+import { isNodeEmphasized, selectionOpacity } from '../../../utils/nodeIdentity';
 
 function colorForKey(key: string): string {
   let h = 0;
@@ -90,7 +91,14 @@ export default function PositionTrailsLayer() {
         <Polyline
           key={t.key}
           positions={t.positions}
-          pathOptions={{ color: t.color, weight: 2, opacity: 0.7 }}
+          pathOptions={{
+            color: t.color,
+            weight: 2,
+            opacity: selectionOpacity(
+              0.7,
+              isNodeEmphasized(`mt:${t.nodeNum}`, config.selectedNodeIds),
+            ),
+          }}
           eventHandlers={{
             click: () =>
               setSelected({

--- a/src/components/MapAnalysis/useAnalysisNodes.test.tsx
+++ b/src/components/MapAnalysis/useAnalysisNodes.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MapAnalysisProvider } from './MapAnalysisContext';
+import { useAnalysisNodes } from './useAnalysisNodes';
+
+const MOCK_NODES = [
+  {
+    // Meshtastic, positioned, visible.
+    nodeNum: 1,
+    sourceId: 'a',
+    nodeId: '!00000001',
+    longName: 'Alpha',
+    shortName: 'ALP',
+    latitude: 30,
+    longitude: -90,
+    isMeshCore: false,
+    sources: [{ sourceId: 'a', sourceName: 'A', protocol: 'Meshtastic' }],
+  },
+  {
+    // MeshCore, positioned, visible.
+    nodeNum: 0,
+    sourceId: 'b',
+    nodeId: 'mc-node',
+    publicKey: 'deadbeef',
+    longName: 'Bravo',
+    shortName: 'BRV',
+    latitude: 31,
+    longitude: -91,
+    isMeshCore: true,
+    sources: [{ sourceId: 'b', sourceName: 'B', protocol: 'MeshCore' }],
+  },
+  {
+    // Meshtastic, unpositioned — should be dropped.
+    nodeNum: 2,
+    sourceId: 'a',
+    nodeId: '!00000002',
+    longName: 'Charlie',
+    shortName: 'CHR',
+    isMeshCore: false,
+    sources: [{ sourceId: 'a', sourceName: 'A', protocol: 'Meshtastic' }],
+  },
+  {
+    // Meshtastic, positioned, hideFromMap — should be dropped.
+    nodeNum: 3,
+    sourceId: 'a',
+    nodeId: '!00000003',
+    longName: 'Delta',
+    shortName: 'DLT',
+    latitude: 32,
+    longitude: -92,
+    hideFromMap: true,
+    isMeshCore: false,
+    sources: [{ sourceId: 'a', sourceName: 'A', protocol: 'Meshtastic' }],
+  },
+];
+
+const mockUseDashboardUnifiedData = vi.fn();
+
+vi.mock('../../hooks/useDashboardData', () => ({
+  useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }] }),
+  useDashboardUnifiedData: (...args: unknown[]) => mockUseDashboardUnifiedData(...args),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MapAnalysisProvider>{children}</MapAnalysisProvider>;
+}
+
+describe('useAnalysisNodes', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUseDashboardUnifiedData.mockReturnValue({ nodes: MOCK_NODES });
+  });
+
+  it('returns only positioned+visible nodes with mt:/mc: keys', () => {
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    expect(result.current).toHaveLength(2);
+    const keys = result.current.map((n) => n.key).sort();
+    expect(keys).toEqual(['mc:deadbeef', 'mt:1']);
+  });
+
+  it('drops nodes with no position', () => {
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    expect(result.current.some((n) => n.node.nodeNum === 2)).toBe(false);
+  });
+
+  it('drops nodes with hideFromMap', () => {
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    expect(result.current.some((n) => n.node.nodeNum === 3)).toBe(false);
+  });
+
+  it('applies the config.sources allow-list', () => {
+    localStorage.setItem(
+      'mapAnalysis.config.v1',
+      JSON.stringify({
+        version: 1,
+        layers: {
+          markers: { enabled: true, lookbackHours: null },
+          traceroutes: { enabled: false, lookbackHours: 24 },
+          neighbors: { enabled: false, lookbackHours: 24 },
+          heatmap: { enabled: false, lookbackHours: 24 },
+          trails: { enabled: false, lookbackHours: 24 },
+          hopShading: { enabled: false, lookbackHours: null },
+          snrOverlay: { enabled: false, lookbackHours: null },
+          waypoints: { enabled: true, lookbackHours: null },
+          polarGrid: { enabled: false, lookbackHours: null },
+        },
+        sources: ['a'],
+        timeSlider: { enabled: false },
+        inspectorOpen: true,
+        selectedNodeIds: [],
+      }),
+    );
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].key).toBe('mt:1');
+  });
+});

--- a/src/components/MapAnalysis/useAnalysisNodes.ts
+++ b/src/components/MapAnalysis/useAnalysisNodes.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+import {
+  useDashboardSources,
+  useDashboardUnifiedData,
+} from '../../hooks/useDashboardData';
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+import { nodeMatchesSearch } from './nodeSearch';
+import { getNodeTypeCategory } from '../../utils/nodeTypeCategory';
+import { unifiedNodeKey } from '../../utils/nodeIdentity';
+import type { NodeSourceRef } from '../Dashboard/DashboardNodePopup';
+
+/**
+ * Node shape consumed across the Map Analysis surface (markers, picker,
+ * inspector). Originally declared inline in `NodeMarkersLayer`; moved here
+ * (issue #3788 WP-B) so `useAnalysisNodes` and its consumers share one
+ * definition instead of drifting copies.
+ */
+export interface NodeRecord extends MaybePositionedNode {
+  nodeNum: number;
+  sourceId?: string;
+  nodeId?: string | null;
+  longName?: string | null;
+  shortName?: string | null;
+  hideFromMap?: boolean | null;
+  user?: { role?: string | number | null } | null;
+  isMeshCore?: boolean;
+  advType?: number | null;
+  /** Unix seconds of last reception; drives time-slider opacity fade (#3886). */
+  lastHeard?: number | null;
+  /** Every configured source that reported this node (unified merge, #2805). */
+  sources?: NodeSourceRef[];
+  /** MeshCore public key; needed by `unifiedNodeKey` for cross-source selection identity (#3788). */
+  publicKey?: string | null;
+}
+
+export interface AnalysisNode {
+  node: NodeRecord;
+  latLng: [number, number];
+  key: string;
+}
+
+/**
+ * Shared positioned+visible node list for the Map Analysis surface (issue
+ * #3788 WP-B). Applies the SAME predicate `NodeMarkersLayer` used to apply
+ * inline: hideFromMap, node search, node-type category, and the
+ * `config.sources` allow-list — so the node picker and the map markers layer
+ * can never disagree about which nodes exist/are visible.
+ *
+ * Only positioned nodes are returned (a node can't be "followed"/emphasized
+ * on the map if it has no coordinates to plot), and nodes whose
+ * `unifiedNodeKey` is null (no stable cross-source identity) are dropped.
+ */
+export function useAnalysisNodes(): AnalysisNode[] {
+  const { config, nodeFilter } = useMapAnalysisCtx();
+  const { data: sources = [] } = useDashboardSources();
+  const sourceList = sources as Array<{ id: string; name: string }>;
+  const sourceIds = sourceList.map((s) => s.id);
+  // Pass the FULL source objects (not bare ids) so the unified merge stamps the
+  // per-node `sources` array used by the multi-source filter below and by the
+  // popup's "Seen by N sources" list.
+  const { nodes } = useDashboardUnifiedData(sources, sourceIds.length > 0);
+
+  return useMemo(() => {
+    return ((nodes ?? []) as NodeRecord[])
+      .map((n) => ({ node: n, latLng: resolveNodeLatLng(n) }))
+      .filter(
+        (
+          entry,
+        ): entry is { node: NodeRecord; latLng: [number, number] } => {
+          const { node, latLng } = entry;
+          if (!latLng) return false;
+          // #3549: per-node "Hide from Map" suppresses the marker on every map surface.
+          if (node.hideFromMap) return false;
+          // Node search (issue #3399): hide non-matches.
+          if (!nodeMatchesSearch(node, nodeFilter)) return false;
+          // Node-type filter (issue #3546): hide categories the user toggled off.
+          if (config.nodeTypes[getNodeTypeCategory(node)] === false) return false;
+          if (config.sources.length === 0) return true;
+          // Source filter: a unified-merged node can be reported by several sources
+          // (node.sources). It must stay visible if ANY of those is enabled — not
+          // just its primary sourceId — so multi-source nodes don't vanish when only
+          // one of their sources is selected. Fall back to sourceId for unmerged rows.
+          const nodeSourceIds = node.sources && node.sources.length > 0
+            ? node.sources.map((s) => s.sourceId)
+            : (node.sourceId ? [node.sourceId] : []);
+          return nodeSourceIds.some((id) => config.sources.includes(id));
+        },
+      )
+      .map(({ node, latLng }) => ({ node, latLng, key: unifiedNodeKey(node) }))
+      .filter((entry): entry is AnalysisNode => entry.key !== null);
+  }, [nodes, nodeFilter, config.nodeTypes, config.sources]);
+}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -9,6 +9,7 @@ import { useQuery, useQueries } from '@tanstack/react-query';
 import { appBasename } from '../init';
 import { useAuth } from '../contexts/AuthContext';
 import { classifyNodeTransport, type NodeTransportClass } from '../utils/nodeTransport';
+import { unifiedNodeKey } from '../utils/nodeIdentity';
 
 /**
  * A data source configured in MeshMonitor
@@ -356,22 +357,16 @@ export function mergeUnifiedSourceData(
       : null;
     for (const n of ps.nodes as any[]) {
       if (n == null) continue;
-      let key: string | null = null;
-      if (n.isMeshCore) {
-        // A MeshCore contact's identity is its public key — stable across
-        // sources. The server-built `nodeId` embeds the reporting source
-        // (`mc:<sourceId>:<pubkeyPrefix>`), so keying on it would put the same
-        // physical node into a separate bucket per source and it would always
-        // show as "seen by 1 source". Key on publicKey so the same node merges
-        // across MeshCore sources; fall back to nodeId only when no key exists.
-        if (typeof n.publicKey === 'string' && n.publicKey.length > 0) {
-          key = `mc:${n.publicKey}`;
-        } else if (typeof n.nodeId === 'string' && n.nodeId.length > 0) {
-          key = `mc:${n.nodeId}`;
-        }
-      } else if (typeof n.nodeNum === 'number') {
-        key = `mt:${n.nodeNum}`;
-      }
+      // A MeshCore contact's identity is its public key — stable across
+      // sources. The server-built `nodeId` embeds the reporting source
+      // (`mc:<sourceId>:<pubkeyPrefix>`), so keying on it would put the same
+      // physical node into a separate bucket per source and it would always
+      // show as "seen by 1 source". Key on publicKey so the same node merges
+      // across MeshCore sources; fall back to nodeId only when no key exists.
+      // `unifiedNodeKey` is the single source of truth for this bucketing —
+      // it must stay in sync with the node-selection feature (#3788), which
+      // keys markers/trails identically.
+      const key = unifiedNodeKey(n);
       if (key == null) continue;
       const entry = { node: n, source };
       const bucket = recordsByKey.get(key);

--- a/src/hooks/useMapAnalysisConfig.test.ts
+++ b/src/hooks/useMapAnalysisConfig.test.ts
@@ -39,4 +39,37 @@ describe('useMapAnalysisConfig', () => {
     const { result } = renderHook(() => useMapAnalysisConfig());
     expect(result.current.config).toEqual(DEFAULT_CONFIG);
   });
+
+  it('defaults selectedNodeIds to an empty array', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.selectedNodeIds).toEqual([]);
+  });
+
+  it('updates selectedNodeIds and persists to localStorage', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setSelectedNodeIds(['mt:1', 'mc:ab']));
+    expect(result.current.config.selectedNodeIds).toEqual(['mt:1', 'mc:ab']);
+    expect(JSON.parse(localStorage.getItem(KEY)!).selectedNodeIds).toEqual(['mt:1', 'mc:ab']);
+  });
+
+  it('loads an old config missing selectedNodeIds as an empty array without throwing', () => {
+    const { selectedNodeIds: _omit, ...oldConfig } = DEFAULT_CONFIG;
+    localStorage.setItem(KEY, JSON.stringify(oldConfig));
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.selectedNodeIds).toEqual([]);
+  });
+
+  it('coerces a non-array selectedNodeIds to an empty array', () => {
+    localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_CONFIG, selectedNodeIds: 'oops' }));
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.selectedNodeIds).toEqual([]);
+  });
+
+  it('reset() clears selectedNodeIds back to an empty array', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setSelectedNodeIds(['mt:1']));
+    expect(result.current.config.selectedNodeIds).toEqual(['mt:1']);
+    act(() => result.current.reset());
+    expect(result.current.config.selectedNodeIds).toEqual([]);
+  });
 });

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -49,6 +49,8 @@ export interface MapAnalysisConfig {
     windowEndMs?: number;
   };
   inspectorOpen: boolean;
+  /** Unified node keys (`mt:<nodeNum>` / `mc:<publicKey>`) currently selected/followed; empty = no selection (issue #3788). */
+  selectedNodeIds: string[];
 }
 
 const ALL_NODE_TYPES_VISIBLE = Object.fromEntries(
@@ -72,6 +74,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
   sources: [],
   timeSlider: { enabled: false },
   inspectorOpen: true,
+  selectedNodeIds: [],
 };
 
 /** Read the traceroute options off a config, layering stored values over defaults. */
@@ -96,6 +99,7 @@ function load(): MapAnalysisConfig {
       layers: { ...DEFAULT_CONFIG.layers, ...(parsed.layers ?? {}) },
       nodeTypes: { ...ALL_NODE_TYPES_VISIBLE, ...(parsed.nodeTypes ?? {}) },
       timeSlider: { ...DEFAULT_CONFIG.timeSlider, ...(parsed.timeSlider ?? {}) },
+      selectedNodeIds: Array.isArray(parsed.selectedNodeIds) ? parsed.selectedNodeIds : [],
     };
   } catch {
     return DEFAULT_CONFIG;
@@ -155,6 +159,10 @@ export function useMapAnalysisConfig() {
     setConfig((prev) => ({ ...prev, sources }));
   }, []);
 
+  const setSelectedNodeIds = useCallback((ids: string[]) => {
+    setConfig((prev) => ({ ...prev, selectedNodeIds: ids }));
+  }, []);
+
   const setTimeSlider = useCallback((ts: Partial<MapAnalysisConfig['timeSlider']>) => {
     setConfig((prev) => ({ ...prev, timeSlider: { ...prev.timeSlider, ...ts } }));
   }, []);
@@ -172,6 +180,7 @@ export function useMapAnalysisConfig() {
     setLayerOptions,
     setNodeTypeEnabled,
     setSources,
+    setSelectedNodeIds,
     setTimeSlider,
     setInspectorOpen,
     reset,

--- a/src/utils/nodeIdentity.test.ts
+++ b/src/utils/nodeIdentity.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { unifiedNodeKey, isNodeEmphasized, selectionOpacity, SELECTION_DIM_OPACITY } from './nodeIdentity';
+import { mergeUnifiedSourceData, type UnifiedSourceBundle } from '../hooks/useDashboardData';
+
+describe('unifiedNodeKey', () => {
+  it('keys a Meshtastic node on nodeNum', () => {
+    expect(unifiedNodeKey({ nodeNum: 5 })).toBe('mt:5');
+  });
+
+  it('keys a MeshCore node on publicKey', () => {
+    expect(unifiedNodeKey({ isMeshCore: true, publicKey: 'ab' })).toBe('mc:ab');
+  });
+
+  it('falls back to nodeId when a MeshCore node has no publicKey', () => {
+    expect(unifiedNodeKey({ isMeshCore: true, nodeId: 'mc:x' })).toBe('mc:mc:x');
+  });
+
+  it('returns null for a MeshCore node with neither publicKey nor nodeId', () => {
+    expect(unifiedNodeKey({ isMeshCore: true })).toBeNull();
+  });
+
+  it('returns null for a Meshtastic node missing nodeNum', () => {
+    expect(unifiedNodeKey({})).toBeNull();
+  });
+});
+
+describe('unifiedNodeKey drift guard', () => {
+  it('matches the bucketing that mergeUnifiedSourceData performs internally', () => {
+    const perSource: UnifiedSourceBundle[] = [
+      {
+        sourceId: 'src-1',
+        sourceName: 'Source One',
+        protocol: 'Meshtastic',
+        nodes: [{ nodeNum: 42, lastHeard: 1000, longName: 'Meshtastic Node' }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        sourceId: 'src-2',
+        sourceName: 'Source Two',
+        protocol: 'MeshCore',
+        nodes: [
+          {
+            isMeshCore: true,
+            nodeNum: 0,
+            nodeId: 'mc:src-2:abc123',
+            publicKey: 'abc123',
+            lastHeard: 2000,
+            longName: 'MeshCore Node',
+          },
+        ],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ];
+
+    const merged = mergeUnifiedSourceData(perSource);
+    expect(merged.nodes).toHaveLength(2);
+
+    const keys = merged.nodes.map((n) => unifiedNodeKey(n as any)).sort();
+    expect(keys).toEqual(['mc:abc123', 'mt:42']);
+
+    // Every merged node's recomputed key must be non-null — mergeUnifiedSourceData
+    // only ever buckets nodes for which unifiedNodeKey returns a real key.
+    for (const n of merged.nodes) {
+      expect(unifiedNodeKey(n as any)).not.toBeNull();
+    }
+  });
+});
+
+describe('isNodeEmphasized', () => {
+  it('treats every key as emphasized when the selection is empty', () => {
+    expect(isNodeEmphasized('mt:1', [])).toBe(true);
+    expect(isNodeEmphasized(null, [])).toBe(true);
+  });
+
+  it('emphasizes only member keys when the selection is non-empty', () => {
+    expect(isNodeEmphasized('mt:1', ['mt:1', 'mc:ab'])).toBe(true);
+    expect(isNodeEmphasized('mt:2', ['mt:1', 'mc:ab'])).toBe(false);
+  });
+
+  it('never emphasizes a null key when the selection is non-empty', () => {
+    expect(isNodeEmphasized(null, ['mt:1'])).toBe(false);
+  });
+});
+
+describe('selectionOpacity', () => {
+  it('returns the base opacity unchanged when emphasized', () => {
+    expect(selectionOpacity(1, true)).toBe(1);
+  });
+
+  it('scales down by SELECTION_DIM_OPACITY when not emphasized', () => {
+    expect(selectionOpacity(1, false)).toBe(SELECTION_DIM_OPACITY);
+    expect(selectionOpacity(0.7, false)).toBeCloseTo(0.7 * SELECTION_DIM_OPACITY);
+  });
+});

--- a/src/utils/nodeIdentity.ts
+++ b/src/utils/nodeIdentity.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical cross-source node identity helpers (issue #3788, Phase 1 WP-A).
+ *
+ * `unifiedNodeKey` is the single source of truth for how a physical node is
+ * keyed across Meshtastic and MeshCore sources. It MUST match the bucketing
+ * logic in `mergeUnifiedSourceData` (src/hooks/useDashboardData.ts) — that
+ * function calls this helper directly so the two can never drift.
+ */
+export interface IdentifiableNode {
+  nodeNum?: number | null;
+  isMeshCore?: boolean | null;
+  publicKey?: string | null;
+  nodeId?: string | null;
+}
+
+/** Canonical cross-source node key — MUST match mergeUnifiedSourceData's keying. */
+export function unifiedNodeKey(n: IdentifiableNode): string | null {
+  if (n.isMeshCore) {
+    if (typeof n.publicKey === 'string' && n.publicKey.length > 0) return `mc:${n.publicKey}`;
+    if (typeof n.nodeId === 'string' && n.nodeId.length > 0) return `mc:${n.nodeId}`;
+    return null;
+  }
+  if (typeof n.nodeNum === 'number') return `mt:${n.nodeNum}`;
+  return null;
+}
+
+/** Dim factor applied to unselected markers/trails when a selection is active. */
+export const SELECTION_DIM_OPACITY = 0.3;
+
+/** With an empty selection everything is full-emphasis; otherwise only members are. */
+export function isNodeEmphasized(key: string | null, selectedNodeIds: readonly string[]): boolean {
+  if (selectedNodeIds.length === 0) return true;
+  return key != null && selectedNodeIds.includes(key);
+}
+
+/** Base opacity scaled down when the node is not emphasized. */
+export function selectionOpacity(base: number, emphasized: boolean): number {
+  return emphasized ? base : base * SELECTION_DIM_OPACITY;
+}


### PR DESCRIPTION
**Epic #3788 — "Follow nodes on the map", Phase 1 of 2.** Plan: `docs/internal/dev-notes/MAP_FOLLOW_AUTOZOOM_EPIC.md`.

## What
Adds an explicit **node multi-select** and **selection-driven emphasis** to the existing `/analysis` Map Analysis workspace. Pick a set of nodes; the map keeps everything visible but **dims the unselected** markers *and* trails so your chosen nodes stand out. This lays the selection foundation for Phase 2 (Follow & Auto-zoom).

Per the issue interview (maintainer decisions, recorded in the epic plan): home = extend `/analysis` (not a new Dashboard panel); selection **dims unselected, keeps visible** (rather than hiding them).

## How (frontend-only, max reuse)
- **`src/utils/nodeIdentity.ts`** (new) — `unifiedNodeKey` (canonical `mt:<nodeNum>` / `mc:<publicKey>` identity), `isNodeEmphasized`, `selectionOpacity`, `SELECTION_DIM_OPACITY`. `mergeUnifiedSourceData` is refactored to call `unifiedNodeKey` so the merge and the selection can never drift (behavior-preserving; verified against existing edge-case tests + a drift-guard test).
- **`MapAnalysisConfig`** gains `selectedNodeIds: string[]`, persisted in the existing `localStorage['mapAnalysis.config.v1']` (old configs load safely → `[]`).
- **`src/components/MapAnalysis/useAnalysisNodes.ts`** (new) — extracts the markers filter so the picker and the map share one identity+visibility computation (no duplicate logic).
- **`NodeMultiSelect.tsx`** (new) — toolbar picker mirroring `SourceMultiSelect` (reuses its CSS), with Select all / Clear.
- **`NodeMarkersLayer` / `PositionTrailsLayer`** — apply dimming via the leaflet `opacity` / `pathOptions.opacity` only (kept out of `iconSig` so the spiderfy fan & icon cache don't churn).

## Tests
New/extended Vitest coverage: `nodeIdentity.test.ts` (identity + drift guard + emphasis/opacity helpers), `useMapAnalysisConfig.test.ts` (persistence + old-config safety), `useAnalysisNodes.test.tsx`, `NodeMultiSelect.test.tsx`, and marker/trail dimming assertions. **Full suite: 2734/2734 suites, 8951 tests, 0 failures**; typecheck clean; `lint:ci` green.

## Browser-validated on the deployed build
Selecting 2 nodes drove `selectedNodeIds:["mt:4134514556","mt:3274688221"]`, dimmed 1528 markers to 0.3 while keeping selected at 1.0, and the selection + dimming **persisted across reload** (pill "2 selected"). No Phase-1 console errors.

Closes part of #3788 (Phase 1; Phase 2 = Follow & Auto-zoom to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub