### PR TITLE
feat(map): Follow & Auto-zoom on Map Analysis (#3788 Phase 2)

### DIFF
--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -35,6 +35,7 @@ The toolbar runs across the top of the canvas. From left to right:
 | **Source multi-select** | Pick which sources contribute to every layer. "All sources" is the default. |
 | **Search box** | Filter visible markers (and traceroute link endpoints) by name or node number. See [Node search](#node-search). |
 | **Node multi-select** | Pick specific nodes to emphasize. Selected nodes render at full opacity; everything else dims. "All nodes" (empty selection) is the default. See [Node selection & emphasis](#node-selection-emphasis). |
+| **Follow / Auto-zoom** | Keep the selected nodes framed as they move — recenter (Follow) and/or fit-to-bounds (Auto-zoom) on each update. See [Follow & Auto-zoom](#follow-auto-zoom). |
 | **Time slider toggle** | Show/hide the floating time-window slider. |
 | **Layer buttons (×8)** | Toggle each visualization layer on/off. The right-edge chevron opens a popover for layer-specific options (lookback window, sub-options). |
 | **Progress bar** | Shows aggregate loading state while any layer is fetching. |
@@ -80,6 +81,28 @@ Selection is keyed on a node's stable cross-source identity (Meshtastic
 `nodeNum`, MeshCore public key), so a node reported by several sources stays a
 single entry. The set persists per-browser in the workspace config alongside
 the other toolbar controls.
+
+### Follow & Auto-zoom
+
+Two toolbar toggles keep the selected nodes framed as their positions update
+(the map polls every 15 s, cross-source, so a node's position is the freshest
+fix any source reported):
+
+- **Follow** — recenters the map on the **average position** of the selected
+  nodes on each update, preserving your current zoom.
+- **Auto-zoom** — fits the map to the **bounding box** of the selected nodes'
+  current positions with a 15% margin on each update. When both are on,
+  Auto-zoom governs the view (its fit implies a center).
+
+Both operate only on the selected set, so pick your nodes first; with an empty
+selection they do nothing. A single selected node (or several at the same spot)
+centers without zooming all the way in.
+
+**Manual override:** panning or zooming the map by hand **pauses** Follow/Auto-zoom
+so you can look around without the map snapping back on the next update. A
+**⟳ Resume follow** button appears while paused; click it (or change the node
+selection) to re-engage. The toggles persist across reloads; the paused state
+does not (a reload starts following again).
 
 ## Layers
 
@@ -171,7 +194,7 @@ Map Analysis introduces **no new permission resource**. Page access is public (m
 
 ## Persistence
 
-All toolbar state — layer toggles, lookback selections, source filter, node selection, time slider window, inspector visibility — is persisted to a single versioned `localStorage` key (`mapAnalysis.config.v1`). It's per-browser, not per-account. The schema is versioned for future migration to server-persisted defaults.
+All toolbar state — layer toggles, lookback selections, source filter, node selection, Follow/Auto-zoom toggles, time slider window, inspector visibility — is persisted to a single versioned `localStorage` key (`mapAnalysis.config.v1`). It's per-browser, not per-account. The schema is versioned for future migration to server-persisted defaults.
 
 ## Limitations (v1)
 

--- a/docs/internal/dev-notes/MAP_FOLLOW_AUTOZOOM_EPIC.md
+++ b/docs/internal/dev-notes/MAP_FOLLOW_AUTOZOOM_EPIC.md
@@ -74,7 +74,7 @@ unchanged behavior.
 - New/extended Vitest coverage green; typecheck clean; browser-validated.
 - Ships as a standalone, useful feature ("pick and highlight nodes").
 
-### Phase 2 — Follow & Auto-zoom  ⬜
+### Phase 2 — Follow & Auto-zoom  ✅ (browser-validated; PR pending)
 Add "Follow" and "Auto-zoom" toggles to the toolbar. New `useMap()` view
 controller(s) that, on each 15s position update, compute the selected nodes'
 current positions and:
@@ -113,3 +113,18 @@ current positions and:
   Deviation from plan: interview chose **dim-unselected (keep visible)** over
   hide-unselected, so Phase 1 emphasizes rather than filters. Next: ship
   Phase 1 PR after #4008 merges + rebase; then Phase 2 (Follow & Auto-zoom).
+- 2026-07-08 — Phase 1 shipped: PR #4010 merged to main (`5bcb4ffc`). (Aside: the
+  main-red hotfix I opened, #4008, was superseded by the maintainer's #4007 —
+  closed as dup; Phase 1 rebased onto the fixed main, full suite green.)
+- 2026-07-08 — Phase 2 implemented across WP-A/B/C/D (config `followMode`/`autoZoom`
+  + transient `followPaused`; pure `followMath.ts`; `FollowController` useMap child
+  with moveend-gated manual-pan pause + `{animate:false}`/rAF programmatic-flag
+  lifecycle + `planAutoZoom`; toolbar toggles + `FollowResumeButton` overlay). Full
+  Vitest suite green (2744/2744 suites, 0 failures); typecheck + lint:ci clean.
+  Browser-validated on the deployed build: Follow recentered [25,-95]z9 →
+  [25.978,-80.137]z9 (avg of selection, zoom preserved); Auto-zoom fit a wide
+  select-all from z14 → z0; near-coincident pair correctly stayed put (single-case,
+  no zoom-to-max); a user zoom paused + showed "Resume follow" + did NOT yank back;
+  Resume re-engaged (refit to z0); toggles persisted across reload. No feature
+  console errors. Note: implementers WP-C left work uncommitted once (committed by
+  orchestrator) — no correctness impact. Next: ship Phase 2 PR; epic complete after merge.

--- a/docs/internal/dev-notes/PHASE2_FOLLOW_AUTOZOOM_SPEC.md
+++ b/docs/internal/dev-notes/PHASE2_FOLLOW_AUTOZOOM_SPEC.md
@@ -1,0 +1,367 @@
+# Phase 2 Implementation Spec — Follow & Auto-zoom (issue #3788)
+
+**Branch/worktree:** `feature/3788-follow-autozoom` @ `/home/yeraze/Development/meshmonitor-3788-p2`
+**Scope:** Frontend only. No backend, schema, migration, or API change. No new `any`. No raw `fetch()` in components/pages.
+**Goal:** Add **Follow** and **Auto-zoom** toggles to the `/analysis` toolbar. On each live position update (the 15s `useDashboardUnifiedData` poll), operate on the **selected nodes' current positions** (Phase 1's `config.selectedNodeIds`):
+- **Follow** → `map.setView(averageCenter, currentZoom)` (recenter, keep zoom).
+- **Auto-zoom** → `map.fitBounds(paddedBounds, …)` (fit + 15% margin).
+- **Both on** → Auto-zoom governs; Follow is a no-op.
+- **Manual pan/zoom while active → PAUSE** + a "Resume follow" affordance; no yank-back until resumed.
+- Toggles persist in `MapAnalysisConfig`. Pause is transient (not persisted).
+
+Builds directly on merged **Phase 1** (`useAnalysisNodes`, `unifiedNodeKey`, `selectedNodeIds`). Reuse over duplication is a hard requirement.
+
+---
+
+## 1. Reuse inventory (verified in worktree)
+
+| Symbol | File:line | How Phase 2 uses it |
+|---|---|---|
+| `useAnalysisNodes()` → `AnalysisNode[]` (`{ node, latLng, key }`) | `src/components/MapAnalysis/useAnalysisNodes.ts:54-93` | **Reuse as-is.** The source of "selected nodes' current positions." Controller + toolbar both call it; identical react-query key ⇒ shared cache, no double fetch. Filter by `key ∈ config.selectedNodeIds`. |
+| `config.selectedNodeIds: string[]` | `src/hooks/useMapAnalysisConfig.ts:52-53,77` | **Reuse.** The follow/auto-zoom target set (already persisted, load-safe). |
+| `MapAnalysisConfig` type / `DEFAULT_CONFIG` / `load()` / setters | `src/hooks/useMapAnalysisConfig.ts:40-107,158-188` | **Extend** with `followMode`/`autoZoom` booleans + `setFollowMode`/`setAutoZoom`, mirroring the `selectedNodeIds`/`setSources` pattern exactly (§2). |
+| `useMapAnalysisCtx()` / `MapAnalysisProvider` | `src/components/MapAnalysis/MapAnalysisContext.tsx:29-54` | Ctx is `ReturnType<typeof useMapAnalysisConfig> & {…transient…}`. Config additions propagate automatically. **Add** transient `followPaused`/`setFollowPaused` here (mirrors `selected`/`nodeFilter`), NOT in the persisted config (§3a). |
+| `useDashboardUnifiedData(...)` `refetchInterval: DASHBOARD_POLL_INTERVAL = 15_000` | `src/hooks/useDashboardData.ts:68,456` | The 15s cadence that drives updates; consumed transitively via `useAnalysisNodes`. No direct use. |
+| **`MapBoundsUpdater`** (`useMap()` child, `hasFittedRef`, `L.latLngBounds(...).fitBounds`) | `src/components/Dashboard/DashboardMap.tsx:128-152` | **Template** for the new `FollowController` (a `useMap()` child returning `null`). |
+| `MapCenterController` (`useMap()` + `map.setView`) | `src/components/MapCenterController.tsx:16-51` | **Template** for the Follow `setView` call. |
+| `ZoomHandler` / `MapPositionHandler` (`map.on('…') / map.off('…')` in an effect with cleanup) | `src/components/ZoomHandler.tsx:8-26`, `src/components/MapPositionHandler.tsx:8-30` | **Template** for the `moveend` listener + cleanup lifecycle. |
+| `MapAnalysisCanvas` `<MapContainer>` + overlay siblings (`MapLegend`, `TilesetSelector`, `TimeSliderControl`) | `src/components/MapAnalysis/MapAnalysisCanvas.tsx:43-79` | **Wire** `<FollowController/>` inside `<MapContainer>`; **wire** `<FollowResumeButton/>` as an overlay sibling (like `MapLegend`). |
+| Time-Slider toggle button (`className={\`map-analysis-layer-btn ${…?'active':''}\`}`) | `src/components/MapAnalysis/MapAnalysisToolbar.tsx:133-139` | **Template** for the two new toggle buttons (plain toggles, not `LayerToggleButton`). |
+| `.map-analysis-layer-btn(.active)` / `.map-analysis-legend` (overlay positioning) | `src/styles/map-analysis.css:105-129,369-382` | **Reuse** button styling for toggles; **template** for one small new `.map-analysis-follow-resume` overlay rule. |
+
+**Genuinely new files (justified):**
+- `src/components/MapAnalysis/followMath.ts` — pure, leaflet-free average-center + padded-bounds math. No such helper exists; extracting it keeps the branching (empty/single/coincident/multi) unit-testable instead of buried in an effect. (Mirrors the prompt's `averageLatLng`/`boundsWithPad` ask.)
+- `src/components/MapAnalysis/FollowController.tsx` — the `useMap()` view controller. No existing controller does live-recenter/fit against a selection; the Dashboard ones are one-shot (`hasFittedRef`) or single-target. New behavior, built on their patterns.
+- `src/components/MapAnalysis/FollowResumeButton.tsx` — the pause overlay affordance. Small, but a distinct concern from the controller (renders outside `<MapContainer>`); kept separate so the controller stays a pure `null`-rendering `useMap` child.
+
+**Reused, not rebuilt:** live feed (`useAnalysisNodes`/`useDashboardUnifiedData`), identity keying (`unifiedNodeKey`), selection persistence (`selectedNodeIds`), toggle-button chrome, overlay-positioning CSS.
+
+---
+
+## 2. Config changes — `src/hooks/useMapAnalysisConfig.ts` (modify)
+
+Mirror the existing `selectedNodeIds` treatment precisely.
+
+- **`MapAnalysisConfig`** (after `selectedNodeIds`):
+  ```ts
+  /** Follow: recenter to the selected nodes' average position each update, keep zoom (issue #3788 P2). */
+  followMode: boolean;
+  /** Auto-zoom: fit the selected nodes' bounds (+15% margin) each update (issue #3788 P2). */
+  autoZoom: boolean;
+  ```
+- **`DEFAULT_CONFIG`** (after `selectedNodeIds: []`): `followMode: false,` and `autoZoom: false,`.
+- **`load()`** — add explicit coercion inside the returned object literal (old-config / garbage safety; `{ ...DEFAULT_CONFIG, ...parsed }` already backfills, this hardens against non-boolean):
+  ```ts
+  followMode: typeof parsed.followMode === 'boolean' ? parsed.followMode : false,
+  autoZoom: typeof parsed.autoZoom === 'boolean' ? parsed.autoZoom : false,
+  ```
+- **Setters** (mirror `setSelectedNodeIds`, :162-164):
+  ```ts
+  const setFollowMode = useCallback((v: boolean) => {
+    setConfig((prev) => ({ ...prev, followMode: v }));
+  }, []);
+  const setAutoZoom = useCallback((v: boolean) => {
+    setConfig((prev) => ({ ...prev, autoZoom: v }));
+  }, []);
+  ```
+- Add `setFollowMode, setAutoZoom` to the returned object (:176-187). `reset()` already restores `DEFAULT_CONFIG` (both → false).
+
+**No migration** — localStorage persistence; old configs load safely.
+
+---
+
+## 3. File-by-file changes
+
+### 3a. `src/components/MapAnalysis/MapAnalysisContext.tsx` (modify) — transient pause state
+
+Pause is **session-transient**, not persisted (reload starts unpaused). Put it beside the existing transient `selected`/`nodeFilter` state so both the controller (inside `<MapContainer>`) and the resume overlay (sibling) read it via `useMapAnalysisCtx()`.
+
+- Extend `CtxShape`:
+  ```ts
+  /** Follow/Auto-zoom paused by a manual pan/zoom; cleared by Resume or retargeting (issue #3788 P2). */
+  followPaused: boolean;
+  setFollowPaused: (p: boolean) => void;
+  ```
+- In `MapAnalysisProvider`: `const [followPaused, setFollowPaused] = useState(false);` and add `followPaused, setFollowPaused` to the provider `value`.
+
+### 3b. `src/components/MapAnalysis/followMath.ts` (new) — pure helpers
+
+Leaflet-free. Replicates Leaflet's `LatLngBounds.pad(ratio)` (each side extended by `ratio × span`) so `fitBounds` can be handed an already-padded 2-corner tuple (Leaflet accepts `[[lat,lng],[lat,lng]]` as a `LatLngBoundsExpression`, so **no `L` import needed** in the controller either).
+
+```ts
+export type LatLng = [number, number];
+
+/** Arithmetic mean of the points, or null for an empty set (Follow target). */
+export function averageLatLng(points: LatLng[]): LatLng | null {
+  if (points.length === 0) return null;
+  let lat = 0, lng = 0;
+  for (const [a, b] of points) { lat += a; lng += b; }
+  return [lat / points.length, lng / points.length];
+}
+
+export const AUTOZOOM_PAD = 0.15;
+
+export type FitPlan =
+  | { kind: 'none' }                              // empty selection ⇒ no-op
+  | { kind: 'single'; center: LatLng }            // 1 point OR all-coincident ⇒ center @ current zoom
+  | { kind: 'multi'; bounds: [LatLng, LatLng] };  // padded [SW, NE] for fitBounds
+
+/** Classify the auto-zoom action for a set of points (pad defaults to 15%). */
+export function planAutoZoom(points: LatLng[], pad: number = AUTOZOOM_PAD): FitPlan {
+  if (points.length === 0) return { kind: 'none' };
+  let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+  for (const [lat, lng] of points) {
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+  }
+  // 1 point, or every point identical ⇒ no meaningful box: center, don't zoom-to-max.
+  if (minLat === maxLat && minLng === maxLng) return { kind: 'single', center: [minLat, minLng] };
+  const dLat = (maxLat - minLat) * pad;
+  const dLng = (maxLng - minLng) * pad;
+  return { kind: 'multi', bounds: [[minLat - dLat, minLng - dLng], [maxLat + dLat, maxLng + dLng]] };
+}
+```
+
+> **Scope note:** naive lat/lng mean; correct for co-located mesh nodes, not antimeridian-spanning sets — out of scope (same simplification the rest of the map uses).
+
+### 3c. `src/components/MapAnalysis/FollowController.tsx` (new) — the `useMap()` view controller
+
+A `useMap()` child rendering `null`, dropped inside `<MapContainer>`. Reads `useAnalysisNodes()` + `useMapAnalysisCtx()`.
+
+**Selected points + change signature (rate-limit / act-only-on-change):**
+```ts
+const map = useMap();
+const { config, followPaused, setFollowPaused } = useMapAnalysisCtx();
+const analysisNodes = useAnalysisNodes();
+
+const points = useMemo<LatLng[]>(() => {
+  const sel = new Set(config.selectedNodeIds);
+  return analysisNodes.filter((n) => sel.has(n.key)).map((n) => n.latLng);
+}, [analysisNodes, config.selectedNodeIds]);
+
+// Position signature — the apply effect keys on THIS, so it fires only when a
+// coordinate actually changes, not on every render/poll that returns identical data.
+const sig = useMemo(() => points.map((p) => `${p[0]},${p[1]}`).join('|'), [points]);
+// Selection-membership signature — position-independent, used to reset pause.
+const selKey = config.selectedNodeIds.join('|');
+```
+
+**Programmatic-move flag lifecycle (distinguishes our moves from the user's):**
+
+All programmatic moves use `{ animate: false }` so `setView`/`fitBounds` fire their `moveend` **synchronously** within the call — no animation race. `moveend` is the single gate: it fires for pan **and** zoom (a zoom also moves the view), so one listener covers drag, wheel-zoom, double-click, box-zoom, keyboard, and zoom-control buttons uniformly. None of those set the flag.
+
+```ts
+const programmaticRef = useRef(false);
+
+const applyView = useCallback((fn: () => void) => {
+  programmaticRef.current = true;
+  fn(); // animate:false ⇒ moveend fires synchronously and consumes the flag below
+  // Safety net: if the move was a no-op (setView to the current center/zoom fires
+  // NO moveend in Leaflet), clear the stuck flag before any user interaction can
+  // occur (a frame is far shorter than any human gesture).
+  const raf = typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : (cb: () => void) => setTimeout(cb, 0);
+  raf(() => { programmaticRef.current = false; });
+}, []);
+
+useEffect(() => {
+  const onMoveEnd = () => {
+    if (programmaticRef.current) { programmaticRef.current = false; return; } // our move — consume
+    setFollowPaused(true); // genuine user pan/zoom ⇒ pause
+  };
+  map.on('moveend', onMoveEnd);
+  return () => { map.off('moveend', onMoveEnd); };
+}, [map, setFollowPaused]);
+```
+
+**Apply effect (Follow / Auto-zoom / both) — with no-op epsilon guard:**
+```ts
+useEffect(() => {
+  if (followPaused) return;
+  if (!config.followMode && !config.autoZoom) return;
+
+  if (config.autoZoom) {
+    const plan = planAutoZoom(points);           // Auto-zoom governs when both on
+    if (plan.kind === 'none') return;
+    if (plan.kind === 'single') {
+      applyView(() => map.setView(plan.center, map.getZoom(), { animate: false }));
+      return;
+    }
+    applyView(() => map.fitBounds(plan.bounds, { animate: false }));
+    return;
+  }
+
+  // Follow only
+  const center = averageLatLng(points);
+  if (!center) return;
+  const cur = map.getCenter();
+  const EPS = 1e-6; // ~0.1 m; skip redundant setView (avoids churn + Leaflet no-op-move quirk)
+  if (Math.abs(cur.lat - center[0]) < EPS && Math.abs(cur.lng - center[1]) < EPS) return;
+  applyView(() => map.setView(center, map.getZoom(), { animate: false }));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [sig, followPaused, config.followMode, config.autoZoom, map]);
+```
+`points` is read through the `sig`-gated effect (stable while `sig` stable); the `exhaustive-deps` disable is deliberate and documented — depending on `points`/`applyView` object identity would defeat the change-only gate.
+
+**Pause auto-reset (re-engage on retarget / re-enable — but NOT on position drift):**
+```ts
+// Selection SET changed (not positions) ⇒ user retargeted ⇒ re-engage.
+useEffect(() => { setFollowPaused(false); }, [selKey, setFollowPaused]);
+// Toggling either mode ⇒ re-engage (turning on follows immediately; turning off is harmless).
+useEffect(() => { setFollowPaused(false); }, [config.followMode, config.autoZoom, setFollowPaused]);
+```
+Critically, pause reset keys on `selKey` (membership), **never on `sig`** (positions) — otherwise every 15s poll that moves a node would silently un-pause and yank the map, defeating the pause. Clicking **Resume** (§3d) also sets `followPaused = false`, which re-runs the apply effect and snaps to the current view.
+
+Returns `null`.
+
+### 3d. `src/components/MapAnalysis/FollowResumeButton.tsx` (new) — pause affordance
+
+Overlay button (sibling of `<MapContainer>`, like `MapLegend`). Shown only while a mode is active **and** paused:
+```tsx
+export default function FollowResumeButton() {
+  const { config, followPaused, setFollowPaused } = useMapAnalysisCtx();
+  const active = config.followMode || config.autoZoom;
+  if (!active || !followPaused) return null;
+  return (
+    <button
+      type="button"
+      className="map-analysis-follow-resume"
+      onClick={() => setFollowPaused(false)}
+    >
+      ⟳ Resume follow
+    </button>
+  );
+}
+```
+
+### 3e. `src/components/MapAnalysis/MapAnalysisCanvas.tsx` (modify) — wiring
+
+- Import `FollowController` and `FollowResumeButton`.
+- Inside `<MapContainer>` (e.g. right after `<TileLayer/>`, alongside the panes): `<FollowController />`.
+- As an overlay sibling after `<MapLegend />` (:79): `<FollowResumeButton />`.
+
+### 3f. `src/components/MapAnalysis/MapAnalysisToolbar.tsx` (modify) — toggles
+
+- Destructure the new setters: `const { config, …, setSelectedNodeIds, setFollowMode, setAutoZoom, … } = useMapAnalysisCtx();`
+- Mount two plain toggle buttons after `<NodeMultiSelect … />` (:132), mirroring the Time-Slider button (:133-139):
+  ```tsx
+  <button
+    type="button"
+    className={`map-analysis-layer-btn ${config.followMode ? 'active' : ''}`}
+    onClick={() => setFollowMode(!config.followMode)}
+    title="Recenter on the selected nodes as they move (keeps zoom)"
+  >
+    Follow
+  </button>
+  <button
+    type="button"
+    className={`map-analysis-layer-btn ${config.autoZoom ? 'active' : ''}`}
+    onClick={() => setAutoZoom(!config.autoZoom)}
+    title="Zoom to fit the selected nodes as they move"
+  >
+    Auto-zoom
+  </button>
+  ```
+Independently operable (each writes its own flag); "both on" precedence lives in the controller.
+
+### 3g. `src/styles/map-analysis.css` (modify) — one overlay rule
+
+Add near `.map-analysis-legend` (:369), reusing legend colors; position top-center so it's clearly the "map is paused" prompt:
+```css
+.map-analysis-follow-resume {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2000;
+  background: #2563eb;
+  color: #fff;
+  border: 1px solid #2563eb;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+}
+.map-analysis-follow-resume:hover { background: #1d4ed8; border-color: #1d4ed8; }
+```
+
+---
+
+## 4. Pure helpers to extract & unit-test
+
+- `averageLatLng(points)` — Follow center; `null` on empty (§3b).
+- `planAutoZoom(points, pad=0.15)` — discriminated union `none` | `single` | `multi{bounds}`; encodes empty/single/coincident/multi + the 15% pad math (§3b).
+
+All branching lives in these two pure functions; the controller effect just dispatches on the result and calls `map.setView`/`map.fitBounds`.
+
+---
+
+## 5. Test plan (Vitest, standard suite — no standalone scripts)
+
+1. **`src/components/MapAnalysis/followMath.test.ts` (new)**
+   - `averageLatLng([])` → `null`; `[[10,20]]` → `[10,20]`; `[[0,0],[10,20]]` → `[5,10]`.
+   - `planAutoZoom([])` → `{kind:'none'}`.
+   - `planAutoZoom([[10,20]])` → `{kind:'single',center:[10,20]}`.
+   - Coincident: `planAutoZoom([[5,5],[5,5]])` → `{kind:'single',center:[5,5]}`.
+   - Multi + exact pad: `planAutoZoom([[0,0],[10,20]])` → `{kind:'multi',bounds:[[-1.5,-3],[11.5,23]]}` (span 10×20, 0.15 pad = 1.5 / 3 each side).
+   - Custom pad arg respected.
+
+2. **`src/hooks/useMapAnalysisConfig.test.ts` (extend)**
+   - `DEFAULT_CONFIG.followMode === false` && `.autoZoom === false`; fresh hook returns both false.
+   - `setFollowMode(true)` / `setAutoZoom(true)` update config **and** persist (assert `JSON.parse(localStorage[KEY]).followMode/autoZoom`).
+   - Old-config load: seed a `version:1` JSON omitting both keys ⇒ hook loads them as `false`, no throw.
+   - Garbage coercion: seed `followMode:"yes"`, `autoZoom:1` ⇒ both coerced to `false`.
+   - `reset()` returns both to `false`.
+
+3. **`src/components/MapAnalysis/FollowController.test.tsx` (new)**
+   Mock `react-leaflet`'s `useMap` to return a fake map: `on`/`off` recording handlers by event; `setView`/`fitBounds` as spies where **`setView`/`fitBounds` synchronously invoke the recorded `moveend` handler** (emulating `animate:false`); `getZoom()` → e.g. `10`; `getCenter()` → `{lat:0,lng:0}`. Mock `useAnalysisNodes` (return chosen `{key,latLng}` set) and `useMapAnalysisCtx` (config + `followPaused` + spy `setFollowPaused`). Assert:
+   - **Follow, 2 selected points** → `setView` called with `averageLatLng` center and `getZoom()` zoom; `fitBounds` NOT called.
+   - **Auto-zoom, 2 points** → `fitBounds` called with the `planAutoZoom` padded bounds; `setView` NOT called.
+   - **Both on** → `fitBounds` called, `setView` NOT (Follow suppressed).
+   - **Single selected point, Auto-zoom** → `setView(center, 10)` (NOT `fitBounds`) — no zoom-to-max.
+   - **Empty selection** (or none of the selected keys positioned) → neither `setView` nor `fitBounds` called.
+   - **Programmatic move doesn't self-pause:** after the mode-driven `setView`/`fitBounds` fires the synchronous `moveend`, `setFollowPaused` was NOT called with `true`.
+   - **User move pauses:** invoke the recorded `moveend` handler directly (flag false) → `setFollowPaused(true)` called once.
+   - **Paused ⇒ inert:** with `followPaused=true`, no `setView`/`fitBounds`.
+   - **Follow no-op guard:** `getCenter()` already equal to the average ⇒ `setView` NOT called.
+
+4. **`src/components/MapAnalysis/FollowResumeButton.test.tsx` (new)**
+   Render inside a mocked ctx. Assert: hidden when no mode active; hidden when active but not paused; **visible** when `(followMode||autoZoom) && followPaused`; click calls `setFollowPaused(false)`.
+
+5. **`src/components/MapAnalysis/MapAnalysisToolbar.test.tsx` (extend, or thin new)** *(optional but recommended)*
+   With mocked hooks, assert the **Follow** and **Auto-zoom** buttons render, carry `active` class per config, and clicking calls `setFollowMode`/`setAutoZoom` with the toggled value.
+
+**Also:** `npm run typecheck` clean; `npm run lint:ci` exits 0 (no new `any`; no raw `fetch()` — all data via existing hooks); full Vitest suite 0 failures.
+
+---
+
+## 6. Work-package decomposition
+
+Sized for one Sonnet agent each. **WP-A and WP-B are independent foundations (parallel).** WP-C depends on both; WP-D depends on WP-A (and lands with/after WP-C for end-to-end resume).
+
+### WP-A — Config flags + transient pause state (foundation)
+- Extend `MapAnalysisConfig`/`DEFAULT_CONFIG`/`load()`/setters with `followMode`,`autoZoom` (§2).
+- Add transient `followPaused`/`setFollowPaused` to `MapAnalysisContext` (§3a).
+- Extend `useMapAnalysisConfig.test.ts` (test #2).
+- **Accept:** config + existing tests green; typecheck clean; defaults false; old-config/garbage coerce to false.
+
+### WP-B — Pure follow math (foundation, parallel with WP-A)
+- Create `followMath.ts` (§3b) + `followMath.test.ts` (test #1).
+- **Accept:** average + all `planAutoZoom` branches (empty/single/coincident/multi) pass incl. exact 15% pad math; no leaflet import; typecheck clean.
+
+### WP-C — Controller + canvas wiring (depends on WP-A + WP-B)
+- Create `FollowController.tsx` (§3c): selected-points/`sig` derivation, `moveend`-gated manual-pan detection with the `programmaticRef` + `animate:false` + rAF safety-net lifecycle, apply effect (Follow/Auto-zoom/both, epsilon guard), pause auto-reset on `selKey`/toggles.
+- Wire `<FollowController/>` into `MapAnalysisCanvas` `<MapContainer>` (§3e).
+- `FollowController.test.tsx` (test #3).
+- **Accept:** all controller assertions pass — programmatic move never self-pauses, user move pauses, both-on precedence, single/empty handled; typecheck clean.
+
+### WP-D — Toolbar toggles + Resume overlay (depends on WP-A)
+- Add Follow/Auto-zoom toggle buttons to `MapAnalysisToolbar` (§3f).
+- Create `FollowResumeButton.tsx` (§3d) + `.map-analysis-follow-resume` CSS (§3g); wire as canvas overlay sibling (§3e).
+- Tests #4 (+ optional #5).
+- **Accept:** toggles render/persist/independently operable; Resume shows only while active+paused and clears pause; typecheck clean.
+
+**Final integration gate (after all WPs):** full Vitest suite 0 failures; `npm run typecheck` clean; `npm run lint:ci` exits 0; browser-validate on `/analysis`: select ≥2 nodes → **Follow** recenters to average, keeps zoom; **Auto-zoom** fits + margin; manual pan shows "Resume follow" and stops yanking; Resume re-engages; single-node selection centers without zoom-to-max; empty selection = no-op; toggles persist across reload.

--- a/src/components/MapAnalysis/FollowController.test.tsx
+++ b/src/components/MapAnalysis/FollowController.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * FollowController (issue #3788 P2 WP-C, spec test #3). Mocks react-leaflet's
+ * useMap with a fake map whose setView/fitBounds synchronously invoke the
+ * recorded moveend handler (emulating `{ animate: false }`), plus
+ * useAnalysisNodes and useMapAnalysisCtx so each case can drive the effect
+ * directly without a real Leaflet map or react-query cache.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import FollowController from './FollowController';
+import type { AnalysisNode } from './useAnalysisNodes';
+import type { MapAnalysisConfig } from '../../hooks/useMapAnalysisConfig';
+import { DEFAULT_CONFIG } from '../../hooks/useMapAnalysisConfig';
+
+type MoveEndHandler = () => void;
+
+let moveEndHandler: MoveEndHandler | null = null;
+let setViewSpy: ReturnType<typeof vi.fn>;
+let fitBoundsSpy: ReturnType<typeof vi.fn>;
+let onSpy: ReturnType<typeof vi.fn>;
+let offSpy: ReturnType<typeof vi.fn>;
+
+function makeFakeMap() {
+  onSpy = vi.fn((event: string, handler: MoveEndHandler) => {
+    if (event === 'moveend') moveEndHandler = handler;
+  });
+  offSpy = vi.fn();
+  setViewSpy = vi.fn(() => {
+    // Emulate animate:false — moveend fires synchronously.
+    moveEndHandler?.();
+  });
+  fitBoundsSpy = vi.fn(() => {
+    moveEndHandler?.();
+  });
+  return {
+    on: onSpy,
+    off: offSpy,
+    setView: setViewSpy,
+    fitBounds: fitBoundsSpy,
+    getZoom: () => 10,
+    getCenter: () => ({ lat: 0, lng: 0 }),
+  };
+}
+
+let fakeMap: ReturnType<typeof makeFakeMap>;
+
+vi.mock('react-leaflet', () => ({
+  useMap: () => fakeMap,
+}));
+
+let mockAnalysisNodes: AnalysisNode[] = [];
+vi.mock('./useAnalysisNodes', () => ({
+  useAnalysisNodes: () => mockAnalysisNodes,
+}));
+
+let mockConfig: MapAnalysisConfig;
+let mockFollowPaused: boolean;
+let setFollowPausedSpy: ReturnType<typeof vi.fn>;
+vi.mock('./MapAnalysisContext', () => ({
+  useMapAnalysisCtx: () => ({
+    config: mockConfig,
+    followPaused: mockFollowPaused,
+    setFollowPaused: setFollowPausedSpy,
+  }),
+}));
+
+function node(key: string, latLng: [number, number]): AnalysisNode {
+  return { node: { nodeNum: 1 } as AnalysisNode['node'], latLng, key };
+}
+
+function setup(overrides: {
+  nodes: AnalysisNode[];
+  selectedNodeIds: string[];
+  followMode?: boolean;
+  autoZoom?: boolean;
+  followPaused?: boolean;
+}) {
+  mockAnalysisNodes = overrides.nodes;
+  mockConfig = {
+    ...DEFAULT_CONFIG,
+    selectedNodeIds: overrides.selectedNodeIds,
+    followMode: overrides.followMode ?? false,
+    autoZoom: overrides.autoZoom ?? false,
+  };
+  mockFollowPaused = overrides.followPaused ?? false;
+  setFollowPausedSpy = vi.fn();
+  fakeMap = makeFakeMap();
+  moveEndHandler = null;
+  return render(<FollowController />);
+}
+
+describe('FollowController', () => {
+  beforeEach(() => {
+    moveEndHandler = null;
+  });
+
+  it('Follow with 2 selected points: setView to average center at current zoom, no fitBounds', () => {
+    setup({
+      nodes: [node('mt:1', [0, 0]), node('mt:2', [10, 20])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      followMode: true,
+    });
+    expect(setViewSpy).toHaveBeenCalledWith([5, 10], 10, { animate: false });
+    expect(fitBoundsSpy).not.toHaveBeenCalled();
+  });
+
+  it('Auto-zoom with 2 points: fitBounds with padded bounds, no setView', () => {
+    setup({
+      nodes: [node('mt:1', [0, 0]), node('mt:2', [10, 20])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      autoZoom: true,
+    });
+    expect(fitBoundsSpy).toHaveBeenCalledWith(
+      [
+        [-1.5, -3],
+        [11.5, 23],
+      ],
+      { animate: false },
+    );
+    expect(setViewSpy).not.toHaveBeenCalled();
+  });
+
+  it('Both on: fitBounds only, setView (Follow) suppressed', () => {
+    setup({
+      nodes: [node('mt:1', [0, 0]), node('mt:2', [10, 20])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      followMode: true,
+      autoZoom: true,
+    });
+    expect(fitBoundsSpy).toHaveBeenCalledTimes(1);
+    expect(setViewSpy).not.toHaveBeenCalled();
+  });
+
+  it('Single selected point with Auto-zoom: setView(center, currentZoom), no fitBounds (no zoom-to-max)', () => {
+    setup({
+      nodes: [node('mt:1', [5, 5])],
+      selectedNodeIds: ['mt:1'],
+      autoZoom: true,
+    });
+    expect(setViewSpy).toHaveBeenCalledWith([5, 5], 10, { animate: false });
+    expect(fitBoundsSpy).not.toHaveBeenCalled();
+  });
+
+  it('Empty selection: neither setView nor fitBounds called', () => {
+    setup({
+      nodes: [node('mt:1', [5, 5])],
+      selectedNodeIds: [], // no keys match
+      followMode: true,
+      autoZoom: true,
+    });
+    expect(setViewSpy).not.toHaveBeenCalled();
+    expect(fitBoundsSpy).not.toHaveBeenCalled();
+  });
+
+  it('a programmatic move does not self-pause', () => {
+    setup({
+      nodes: [node('mt:1', [0, 0]), node('mt:2', [10, 20])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      followMode: true,
+    });
+    // setView already fired synchronously via the mocked moveend during setup.
+    expect(setViewSpy).toHaveBeenCalled();
+    expect(setFollowPausedSpy).not.toHaveBeenCalledWith(true);
+  });
+
+  it('a genuine user move (flag not set) pauses exactly once', () => {
+    setup({
+      nodes: [node('mt:1', [0, 0]), node('mt:2', [10, 20])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      followMode: false,
+      autoZoom: false,
+    });
+    expect(moveEndHandler).not.toBeNull();
+    // The pause-auto-reset effects (selKey / mode toggles) also call
+    // setFollowPaused(false) on mount — filter to `true` calls, i.e. actual pauses.
+    const pauseCallsBefore = setFollowPausedSpy.mock.calls.filter((c) => c[0] === true).length;
+    moveEndHandler?.();
+    const pauseCallsAfter = setFollowPausedSpy.mock.calls.filter((c) => c[0] === true).length;
+    expect(pauseCallsAfter - pauseCallsBefore).toBe(1);
+    expect(setFollowPausedSpy).toHaveBeenLastCalledWith(true);
+  });
+
+  it('paused: no setView/fitBounds even with a mode active', () => {
+    setup({
+      nodes: [node('mt:1', [0, 0]), node('mt:2', [10, 20])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      followMode: true,
+      autoZoom: true,
+      followPaused: true,
+    });
+    expect(setViewSpy).not.toHaveBeenCalled();
+    expect(fitBoundsSpy).not.toHaveBeenCalled();
+  });
+
+  it('Follow no-op guard: setView not called when the map center already equals the average', () => {
+    // getCenter() is mocked to {lat:0,lng:0}; select points whose average is [0,0].
+    setup({
+      nodes: [node('mt:1', [-5, -5]), node('mt:2', [5, 5])],
+      selectedNodeIds: ['mt:1', 'mt:2'],
+      followMode: true,
+    });
+    expect(setViewSpy).not.toHaveBeenCalled();
+    expect(fitBoundsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MapAnalysis/FollowController.tsx
+++ b/src/components/MapAnalysis/FollowController.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { useAnalysisNodes } from './useAnalysisNodes';
+import { averageLatLng, planAutoZoom, type LatLng } from './followMath';
+
+/**
+ * `useMap()` view controller for Follow/Auto-zoom (issue #3788 P2 WP-C).
+ * Renders nothing; recenters/fits the map onto the selected nodes' current
+ * positions on each live update, and pauses on manual pan/zoom until the
+ * user hits Resume (WP-D) or retargets the selection.
+ */
+export default function FollowController() {
+  const map = useMap();
+  const { config, followPaused, setFollowPaused } = useMapAnalysisCtx();
+  const analysisNodes = useAnalysisNodes();
+
+  const points = useMemo<LatLng[]>(() => {
+    const sel = new Set(config.selectedNodeIds);
+    return analysisNodes.filter((n) => sel.has(n.key)).map((n) => n.latLng);
+  }, [analysisNodes, config.selectedNodeIds]);
+
+  // Position signature — the apply effect keys on THIS, so it fires only when a
+  // coordinate actually changes, not on every render/poll that returns identical data.
+  const sig = useMemo(() => points.map((p) => `${p[0]},${p[1]}`).join('|'), [points]);
+  // Selection-membership signature — position-independent, used to reset pause.
+  const selKey = config.selectedNodeIds.join('|');
+
+  const programmaticRef = useRef(false);
+
+  const applyView = useCallback((fn: () => void) => {
+    programmaticRef.current = true;
+    fn(); // animate:false ⇒ moveend fires synchronously and consumes the flag below
+    // Safety net: if the move was a no-op (setView to the current center/zoom fires
+    // NO moveend in Leaflet), clear the stuck flag before any user interaction can
+    // occur (a frame is far shorter than any human gesture).
+    const raf =
+      typeof requestAnimationFrame !== 'undefined'
+        ? requestAnimationFrame
+        : (cb: () => void) => setTimeout(cb, 0);
+    raf(() => {
+      programmaticRef.current = false;
+    });
+  }, []);
+
+  useEffect(() => {
+    const onMoveEnd = () => {
+      if (programmaticRef.current) {
+        programmaticRef.current = false; // our move — consume
+        return;
+      }
+      setFollowPaused(true); // genuine user pan/zoom ⇒ pause
+    };
+    map.on('moveend', onMoveEnd);
+    return () => {
+      map.off('moveend', onMoveEnd);
+    };
+  }, [map, setFollowPaused]);
+
+  useEffect(() => {
+    if (followPaused) return;
+    if (!config.followMode && !config.autoZoom) return;
+
+    if (config.autoZoom) {
+      const plan = planAutoZoom(points); // Auto-zoom governs when both on
+      if (plan.kind === 'none') return;
+      if (plan.kind === 'single') {
+        applyView(() => map.setView(plan.center, map.getZoom(), { animate: false }));
+        return;
+      }
+      applyView(() => map.fitBounds(plan.bounds, { animate: false }));
+      return;
+    }
+
+    // Follow only
+    const center = averageLatLng(points);
+    if (!center) return;
+    const cur = map.getCenter();
+    const EPS = 1e-6; // ~0.1 m; skip redundant setView (avoids churn + Leaflet no-op-move quirk)
+    if (Math.abs(cur.lat - center[0]) < EPS && Math.abs(cur.lng - center[1]) < EPS) return;
+    applyView(() => map.setView(center, map.getZoom(), { animate: false }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- #3788 keyed on sig to fire only on coordinate change
+  }, [sig, followPaused, config.followMode, config.autoZoom, map]);
+
+  // Selection SET changed (not positions) ⇒ user retargeted ⇒ re-engage.
+  useEffect(() => {
+    setFollowPaused(false);
+  }, [selKey, setFollowPaused]);
+  // Toggling either mode ⇒ re-engage (turning on follows immediately; turning off is harmless).
+  useEffect(() => {
+    setFollowPaused(false);
+  }, [config.followMode, config.autoZoom, setFollowPaused]);
+
+  return null;
+}

--- a/src/components/MapAnalysis/FollowResumeButton.test.tsx
+++ b/src/components/MapAnalysis/FollowResumeButton.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * FollowResumeButton (issue #3788 P2 WP-D, spec test #4). Mocks
+ * useMapAnalysisCtx so each case can drive config/followPaused directly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FollowResumeButton from './FollowResumeButton';
+import { DEFAULT_CONFIG } from '../../hooks/useMapAnalysisConfig';
+import type { MapAnalysisConfig } from '../../hooks/useMapAnalysisConfig';
+
+let mockConfig: MapAnalysisConfig;
+let mockFollowPaused: boolean;
+let setFollowPausedSpy: ReturnType<typeof vi.fn>;
+vi.mock('./MapAnalysisContext', () => ({
+  useMapAnalysisCtx: () => ({
+    config: mockConfig,
+    followPaused: mockFollowPaused,
+    setFollowPaused: setFollowPausedSpy,
+  }),
+}));
+
+function setup(overrides: { followMode?: boolean; autoZoom?: boolean; followPaused?: boolean }) {
+  mockConfig = {
+    ...DEFAULT_CONFIG,
+    followMode: overrides.followMode ?? false,
+    autoZoom: overrides.autoZoom ?? false,
+  };
+  mockFollowPaused = overrides.followPaused ?? false;
+  setFollowPausedSpy = vi.fn();
+  return render(<FollowResumeButton />);
+}
+
+describe('FollowResumeButton', () => {
+  it('renders nothing when no mode is active, even if paused', () => {
+    const { container } = setup({ followMode: false, autoZoom: false, followPaused: true });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when a mode is active but not paused', () => {
+    const { container } = setup({ followMode: true, autoZoom: false, followPaused: false });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the button when Follow is active and paused', () => {
+    setup({ followMode: true, autoZoom: false, followPaused: true });
+    expect(screen.getByRole('button', { name: /resume follow/i })).toBeInTheDocument();
+  });
+
+  it('renders the button when Auto-zoom is active and paused', () => {
+    setup({ followMode: false, autoZoom: true, followPaused: true });
+    expect(screen.getByRole('button', { name: /resume follow/i })).toBeInTheDocument();
+  });
+
+  it('calls setFollowPaused(false) on click', () => {
+    setup({ followMode: true, autoZoom: true, followPaused: true });
+    fireEvent.click(screen.getByRole('button', { name: /resume follow/i }));
+    expect(setFollowPausedSpy).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/MapAnalysis/FollowResumeButton.tsx
+++ b/src/components/MapAnalysis/FollowResumeButton.tsx
@@ -1,0 +1,23 @@
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+
+/**
+ * Overlay affordance shown while Follow/Auto-zoom is active but paused by a
+ * manual pan/zoom (issue #3788 P2 WP-D). Sibling of `<MapContainer>`, like
+ * `MapLegend` — not rendered inside the map so it isn't affected by Leaflet's
+ * pane stacking. Clicking it clears the pause, which re-runs FollowController's
+ * apply effect and snaps back to the current follow/auto-zoom view.
+ */
+export default function FollowResumeButton() {
+  const { config, followPaused, setFollowPaused } = useMapAnalysisCtx();
+  const active = config.followMode || config.autoZoom;
+  if (!active || !followPaused) return null;
+  return (
+    <button
+      type="button"
+      className="map-analysis-follow-resume"
+      onClick={() => setFollowPaused(false)}
+    >
+      ⟳ Resume follow
+    </button>
+  );
+}

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -34,6 +34,13 @@ vi.mock('react-leaflet', () => ({
   useMap: () => null,
 }));
 
+// FollowController's own behavior (Follow/Auto-zoom/pause) is covered by its
+// dedicated FollowController.test.tsx; here it's a no-op so this suite can
+// keep useMap() -> null (required by the spiderfier no-op path above).
+vi.mock('./FollowController', () => ({
+  default: () => null,
+}));
+
 vi.mock('../../hooks/useMapAnalysisData', () => ({
   useTraceroutes: () => ({
     items: [],

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -16,6 +16,7 @@ import PolarGridLayer from './layers/PolarGridLayer';
 import TimeSliderControl from './TimeSliderControl';
 import MapLegend from './MapLegend';
 import FollowController from './FollowController';
+import FollowResumeButton from './FollowResumeButton';
 
 const FALLBACK_CENTER: [number, number] = [30, -90];
 const FALLBACK_ZOOM = 10;
@@ -79,6 +80,7 @@ export default function MapAnalysisCanvas() {
       <TilesetSelector selectedTilesetId={mapTileset} onTilesetChange={setMapTileset} />
       <TimeSliderControl />
       <MapLegend />
+      <FollowResumeButton />
     </div>
   );
 }

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -15,6 +15,7 @@ import WaypointsLayer from './layers/WaypointsLayer';
 import PolarGridLayer from './layers/PolarGridLayer';
 import TimeSliderControl from './TimeSliderControl';
 import MapLegend from './MapLegend';
+import FollowController from './FollowController';
 
 const FALLBACK_CENTER: [number, number] = [30, -90];
 const FALLBACK_ZOOM = 10;
@@ -46,6 +47,7 @@ export default function MapAnalysisCanvas() {
           attribution={tileset.attribution}
           maxZoom={tileset.maxZoom}
         />
+        <FollowController />
         <Pane name="waypoints" style={{ zIndex: 650 }}>
           {config.layers.waypoints.enabled && <WaypointsLayer />}
         </Pane>

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -32,6 +32,9 @@ type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
   /** Free-text node search term; empty = no filter (issue #3399). */
   nodeFilter: string;
   setNodeFilter: (s: string) => void;
+  /** Follow/Auto-zoom paused by a manual pan/zoom; cleared by Resume or retargeting (issue #3788 P2). */
+  followPaused: boolean;
+  setFollowPaused: (p: boolean) => void;
 };
 
 const Ctx = createContext<CtxShape | null>(null);
@@ -40,8 +43,19 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const config = useMapAnalysisConfig();
   const [selected, setSelected] = useState<SelectedTarget | null>(null);
   const [nodeFilter, setNodeFilter] = useState('');
+  const [followPaused, setFollowPaused] = useState(false);
   return (
-    <Ctx.Provider value={{ ...config, selected, setSelected, nodeFilter, setNodeFilter }}>
+    <Ctx.Provider
+      value={{
+        ...config,
+        selected,
+        setSelected,
+        nodeFilter,
+        setNodeFilter,
+        followPaused,
+        setFollowPaused,
+      }}
+    >
       {children}
     </Ctx.Provider>
   );

--- a/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
@@ -49,4 +49,31 @@ describe('MapAnalysisToolbar', () => {
     const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
     expect(stored.layers.traceroutes.enabled).toBe(true);
   });
+
+  // issue #3788 P2 WP-D, spec test #5 (optional).
+  it('renders Follow and Auto-zoom toggles, inactive by default', () => {
+    render(<MapAnalysisToolbar />, { wrapper });
+    expect(screen.getByRole('button', { name: 'Follow' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'Auto-zoom' })).not.toHaveClass('active');
+  });
+
+  it('toggles Follow independently of Auto-zoom, carries the active class, and persists', () => {
+    render(<MapAnalysisToolbar />, { wrapper });
+    fireEvent.click(screen.getByRole('button', { name: 'Follow' }));
+    expect(screen.getByRole('button', { name: 'Follow' })).toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'Auto-zoom' })).not.toHaveClass('active');
+    const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+    expect(stored.followMode).toBe(true);
+    expect(stored.autoZoom).toBe(false);
+  });
+
+  it('toggles Auto-zoom independently of Follow, carries the active class, and persists', () => {
+    render(<MapAnalysisToolbar />, { wrapper });
+    fireEvent.click(screen.getByRole('button', { name: 'Auto-zoom' }));
+    expect(screen.getByRole('button', { name: 'Auto-zoom' })).toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'Follow' })).not.toHaveClass('active');
+    const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+    expect(stored.autoZoom).toBe(true);
+    expect(stored.followMode).toBe(false);
+  });
 });

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -36,8 +36,17 @@ const UNTIMED_LAYERS: { key: LayerKey; label: string }[] = [
 
 export default function MapAnalysisToolbar() {
   const navigate = useNavigate();
-  const { config, setLayerEnabled, setLayerLookback, setSources, setSelectedNodeIds, setTimeSlider, reset } =
-    useMapAnalysisCtx();
+  const {
+    config,
+    setLayerEnabled,
+    setLayerLookback,
+    setSources,
+    setSelectedNodeIds,
+    setTimeSlider,
+    setFollowMode,
+    setAutoZoom,
+    reset,
+  } = useMapAnalysisCtx();
   const { data: sources = [] } = useDashboardSources();
 
   // Node picker (issue #3788): deduped/sorted options built from the same
@@ -130,6 +139,22 @@ export default function MapAnalysisToolbar() {
       <NodeTypeFilterControl />
       <NodeSearchControl />
       <NodeMultiSelect nodes={nodeOptions} value={config.selectedNodeIds} onChange={setSelectedNodeIds} />
+      <button
+        type="button"
+        className={`map-analysis-layer-btn ${config.followMode ? 'active' : ''}`}
+        onClick={() => setFollowMode(!config.followMode)}
+        title="Recenter on the selected nodes as they move (keeps zoom)"
+      >
+        Follow
+      </button>
+      <button
+        type="button"
+        className={`map-analysis-layer-btn ${config.autoZoom ? 'active' : ''}`}
+        onClick={() => setAutoZoom(!config.autoZoom)}
+        title="Zoom to fit the selected nodes as they move"
+      >
+        Auto-zoom
+      </button>
       <button
         type="button"
         className={`map-analysis-layer-btn ${config.timeSlider.enabled ? 'active' : ''}`}

--- a/src/components/MapAnalysis/followMath.test.ts
+++ b/src/components/MapAnalysis/followMath.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { averageLatLng, planAutoZoom, AUTOZOOM_PAD } from './followMath';
+
+describe('averageLatLng', () => {
+  it('returns null for an empty set', () => {
+    expect(averageLatLng([])).toBeNull();
+  });
+
+  it('returns the point itself for a single point', () => {
+    expect(averageLatLng([[10, 20]])).toEqual([10, 20]);
+  });
+
+  it('returns the arithmetic mean for multiple points', () => {
+    expect(averageLatLng([[0, 0], [10, 20]])).toEqual([5, 10]);
+  });
+});
+
+describe('planAutoZoom', () => {
+  it('returns none for an empty set', () => {
+    expect(planAutoZoom([])).toEqual({ kind: 'none' });
+  });
+
+  it('returns single for a single point', () => {
+    expect(planAutoZoom([[10, 20]])).toEqual({ kind: 'single', center: [10, 20] });
+  });
+
+  it('returns single for coincident points', () => {
+    expect(planAutoZoom([[5, 5], [5, 5]])).toEqual({ kind: 'single', center: [5, 5] });
+  });
+
+  it('returns multi with an exact 15% pad for a spread of points', () => {
+    // span: lat 0..10 (10), lng 0..20 (20); pad 0.15 => 1.5 / 3 each side
+    expect(planAutoZoom([[0, 0], [10, 20]])).toEqual({
+      kind: 'multi',
+      bounds: [[-1.5, -3], [11.5, 23]],
+    });
+  });
+
+  it('respects a custom pad argument', () => {
+    // span: lat 0..10 (10), lng 0..20 (20); pad 0.5 => 5 / 10 each side
+    expect(planAutoZoom([[0, 0], [10, 20]], 0.5)).toEqual({
+      kind: 'multi',
+      bounds: [[-5, -10], [15, 30]],
+    });
+  });
+
+  it('exports the default pad as 0.15', () => {
+    expect(AUTOZOOM_PAD).toBe(0.15);
+  });
+});

--- a/src/components/MapAnalysis/followMath.ts
+++ b/src/components/MapAnalysis/followMath.ts
@@ -1,0 +1,33 @@
+export type LatLng = [number, number];
+
+/** Arithmetic mean of the points, or null for an empty set (Follow target). */
+export function averageLatLng(points: LatLng[]): LatLng | null {
+  if (points.length === 0) return null;
+  let lat = 0, lng = 0;
+  for (const [a, b] of points) { lat += a; lng += b; }
+  return [lat / points.length, lng / points.length];
+}
+
+export const AUTOZOOM_PAD = 0.15;
+
+export type FitPlan =
+  | { kind: 'none' }                              // empty selection ⇒ no-op
+  | { kind: 'single'; center: LatLng }            // 1 point OR all-coincident ⇒ center @ current zoom
+  | { kind: 'multi'; bounds: [LatLng, LatLng] };  // padded [SW, NE] for fitBounds
+
+/** Classify the auto-zoom action for a set of points (pad defaults to 15%). */
+export function planAutoZoom(points: LatLng[], pad: number = AUTOZOOM_PAD): FitPlan {
+  if (points.length === 0) return { kind: 'none' };
+  let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+  for (const [lat, lng] of points) {
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+  }
+  // 1 point, or every point identical ⇒ no meaningful box: center, don't zoom-to-max.
+  if (minLat === maxLat && minLng === maxLng) return { kind: 'single', center: [minLat, minLng] };
+  const dLat = (maxLat - minLat) * pad;
+  const dLng = (maxLng - minLng) * pad;
+  return { kind: 'multi', bounds: [[minLat - dLat, minLng - dLng], [maxLat + dLat, maxLng + dLng]] };
+}

--- a/src/hooks/useMapAnalysisConfig.test.ts
+++ b/src/hooks/useMapAnalysisConfig.test.ts
@@ -72,4 +72,55 @@ describe('useMapAnalysisConfig', () => {
     act(() => result.current.reset());
     expect(result.current.config.selectedNodeIds).toEqual([]);
   });
+
+  it('defaults followMode and autoZoom to false', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.followMode).toBe(false);
+    expect(result.current.config.autoZoom).toBe(false);
+    expect(DEFAULT_CONFIG.followMode).toBe(false);
+    expect(DEFAULT_CONFIG.autoZoom).toBe(false);
+  });
+
+  it('updates followMode and persists to localStorage', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setFollowMode(true));
+    expect(result.current.config.followMode).toBe(true);
+    expect(JSON.parse(localStorage.getItem(KEY)!).followMode).toBe(true);
+  });
+
+  it('updates autoZoom and persists to localStorage', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setAutoZoom(true));
+    expect(result.current.config.autoZoom).toBe(true);
+    expect(JSON.parse(localStorage.getItem(KEY)!).autoZoom).toBe(true);
+  });
+
+  it('loads an old config missing followMode/autoZoom as false without throwing', () => {
+    const { followMode: _fm, autoZoom: _az, ...oldConfig } = DEFAULT_CONFIG;
+    localStorage.setItem(KEY, JSON.stringify(oldConfig));
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.followMode).toBe(false);
+    expect(result.current.config.autoZoom).toBe(false);
+  });
+
+  it('coerces garbage followMode/autoZoom values to false', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ ...DEFAULT_CONFIG, followMode: 'yes', autoZoom: 1 }),
+    );
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.followMode).toBe(false);
+    expect(result.current.config.autoZoom).toBe(false);
+  });
+
+  it('reset() clears followMode and autoZoom back to false', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setFollowMode(true));
+    act(() => result.current.setAutoZoom(true));
+    expect(result.current.config.followMode).toBe(true);
+    expect(result.current.config.autoZoom).toBe(true);
+    act(() => result.current.reset());
+    expect(result.current.config.followMode).toBe(false);
+    expect(result.current.config.autoZoom).toBe(false);
+  });
 });

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -51,6 +51,10 @@ export interface MapAnalysisConfig {
   inspectorOpen: boolean;
   /** Unified node keys (`mt:<nodeNum>` / `mc:<publicKey>`) currently selected/followed; empty = no selection (issue #3788). */
   selectedNodeIds: string[];
+  /** Follow: recenter to the selected nodes' average position each update, keep zoom (issue #3788 P2). */
+  followMode: boolean;
+  /** Auto-zoom: fit the selected nodes' bounds (+15% margin) each update (issue #3788 P2). */
+  autoZoom: boolean;
 }
 
 const ALL_NODE_TYPES_VISIBLE = Object.fromEntries(
@@ -75,6 +79,8 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
   timeSlider: { enabled: false },
   inspectorOpen: true,
   selectedNodeIds: [],
+  followMode: false,
+  autoZoom: false,
 };
 
 /** Read the traceroute options off a config, layering stored values over defaults. */
@@ -100,6 +106,8 @@ function load(): MapAnalysisConfig {
       nodeTypes: { ...ALL_NODE_TYPES_VISIBLE, ...(parsed.nodeTypes ?? {}) },
       timeSlider: { ...DEFAULT_CONFIG.timeSlider, ...(parsed.timeSlider ?? {}) },
       selectedNodeIds: Array.isArray(parsed.selectedNodeIds) ? parsed.selectedNodeIds : [],
+      followMode: typeof parsed.followMode === 'boolean' ? parsed.followMode : false,
+      autoZoom: typeof parsed.autoZoom === 'boolean' ? parsed.autoZoom : false,
     };
   } catch {
     return DEFAULT_CONFIG;
@@ -163,6 +171,14 @@ export function useMapAnalysisConfig() {
     setConfig((prev) => ({ ...prev, selectedNodeIds: ids }));
   }, []);
 
+  const setFollowMode = useCallback((v: boolean) => {
+    setConfig((prev) => ({ ...prev, followMode: v }));
+  }, []);
+
+  const setAutoZoom = useCallback((v: boolean) => {
+    setConfig((prev) => ({ ...prev, autoZoom: v }));
+  }, []);
+
   const setTimeSlider = useCallback((ts: Partial<MapAnalysisConfig['timeSlider']>) => {
     setConfig((prev) => ({ ...prev, timeSlider: { ...prev.timeSlider, ...ts } }));
   }, []);
@@ -181,6 +197,8 @@ export function useMapAnalysisConfig() {
     setNodeTypeEnabled,
     setSources,
     setSelectedNodeIds,
+    setFollowMode,
+    setAutoZoom,
     setTimeSlider,
     setInspectorOpen,
     reset,

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -365,6 +365,25 @@
   word-break: break-word;
 }
 
+/* ===== Follow resume overlay (issue #3788 P2 WP-D) ===== */
+.map-analysis-follow-resume {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2000;
+  background: #2563eb;
+  color: #fff;
+  border: 1px solid #2563eb;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+}
+.map-analysis-follow-resume:hover { background: #1d4ed8; border-color: #1d4ed8; }
+
 /* ===== Legend ===== */
 .map-analysis-legend {
   position: absolute;


### PR DESCRIPTION
**Epic #3788 — "Follow nodes on the map", Phase 2 of 2** (builds on Phase 1's node selection, merged in #4010). Plan: `docs/internal/dev-notes/MAP_FOLLOW_AUTOZOOM_EPIC.md`.

## What
Adds **Follow** and **Auto-zoom** toggles to the `/analysis` toolbar that keep the selected nodes framed as their positions update (15s cross-source poll):
- **Follow** → recenter to the selected nodes' **average** position, preserving zoom.
- **Auto-zoom** → `fitBounds` of the selection **+15% margin**. When both on, Auto-zoom governs.
- A manual pan/zoom **pauses** and shows a **⟳ Resume follow** overlay; no yank-back until you resume or retarget the selection.

## How (frontend-only, builds on Phase 1)
- **`followMath.ts`** (new) — pure, leaflet-free `averageLatLng` + `planAutoZoom` (discriminated `none`/`single`/`multi` union encoding empty/single/coincident + the 15% pad). All edge-case branching is here and unit-tested.
- **`FollowController.tsx`** (new) — `useMap()` child. Derives the selected points from Phase 1's `useAnalysisNodes()`/`selectedNodeIds` (shared query cache, no refetch). Applies Follow/Auto-zoom on each position-signature change. **Manual-pan detection:** a single `moveend` gate + `programmaticRef` flag + `{animate:false}` (programmatic `moveend` fires synchronously and is consumed) + a `requestAnimationFrame` safety-net for no-op moves. Pause auto-resets on selection **membership** change or toggle change — **never** on position drift (so the 15s poll can't silently un-pause).
- **`FollowResumeButton.tsx`** (new) — overlay shown only while a mode is active **and** paused.
- **Config:** `followMode`/`autoZoom` added to `MapAnalysisConfig` (persisted, load-safe); `followPaused` is transient context state (not persisted).
- Toolbar toggles mirror the existing layer-toggle chrome.

## Tests
New/extended: `followMath.test.ts`, `FollowController.test.tsx` (all Follow/Auto-zoom/both/single/empty cases + programmatic-move-doesn't-self-pause + user-move-pauses + paused-inert + no-op guard), `FollowResumeButton.test.tsx`, `useMapAnalysisConfig.test.ts`, `MapAnalysisToolbar.test.tsx`. **Full suite: 2744/2744 suites, 0 failures**; typecheck + `lint:ci` clean.

## Browser-validated on the deployed build
Follow recentered `[25,-95]z9 → [25.978,-80.137]z9` (selection average, zoom preserved); Auto-zoom fit a wide select-all from `z14 → z0`; a near-coincident pair correctly stayed put (single-case, no zoom-to-max); a user zoom **paused** + surfaced "Resume follow" + **did not yank back**; Resume **re-engaged** (refit to z0); toggles **persisted across reload**. No feature console errors.

Closes #3788 (completes the epic: Phase 1 selection #4010 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub