### PR TITLE
feat(map): node-to-node LOS distance measurement tool on all maps (#3636)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -27,6 +27,8 @@ import GeoJsonOverlay from '../GeoJsonOverlay';
 import PolarGridOverlay from '../PolarGridOverlay';
 import { TilesetSelector } from '../TilesetSelector';
 import MapLegend from '../MapLegend';
+import MeasureDistanceController from '../MeasureDistanceController';
+import type { MeasurePoint } from '../../utils/measureDistance';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { useMapContext } from '../../contexts/MapContext';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -266,6 +268,9 @@ export default function DashboardMap({
     localStorage.setItem('isMapControlsCollapsed', String(isMapControlsCollapsed));
   }, [isMapControlsCollapsed]);
 
+  // #3636: node-to-node LOS distance measurement tool.
+  const [measureActive, setMeasureActive] = useState(false);
+
   const {
     showPaths,
     setShowPaths,
@@ -342,6 +347,14 @@ export default function DashboardMap({
     .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
 
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
+
+  // #3636: measurement endpoints — nearest-node snapping picks from these.
+  const measurePoints: MeasurePoint[] = nodesWithPosition.map(({ node, pos }) => ({
+    id: String(node.nodeId ?? node.user?.id ?? node.nodeNum),
+    lat: pos.lat,
+    lng: pos.lng,
+    label: node.shortName ?? node.user?.shortName,
+  }));
 
   // Own-node position per source for the polar grid. Resolved from the raw
   // `nodes` prop (not the age/transport-filtered marker list) so the grid center
@@ -500,6 +513,14 @@ export default function DashboardMap({
         />
 
         <SpiderfierController ref={spiderfierRef} />
+
+        {measureActive && (
+          <MeasureDistanceController
+            active={measureActive}
+            points={measurePoints}
+            onExit={() => setMeasureActive(false)}
+          />
+        )}
 
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} />
 
@@ -734,6 +755,17 @@ export default function DashboardMap({
           </div>
           {!isMapControlsCollapsed && (
           <>
+          {/* #3636: node-to-node LOS distance measurement toggle. Needs at least
+              two positioned nodes to be meaningful. */}
+          <label className="map-control-item" title="Measure straight-line distance between two nodes">
+            <input
+              type="checkbox"
+              checked={measureActive}
+              disabled={measurePoints.length < 2}
+              onChange={(e) => setMeasureActive(e.target.checked)}
+            />
+            <span>Measure Distance</span>
+          </label>
           {/* Map Features age slider (#3322): hides node markers, traceroutes,
               and route segments older than the chosen age. Ranges 1h–maxNodeAge. */}
           {(() => {

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -1,7 +1,11 @@
+import { useMemo } from 'react';
 import { MapContainer, TileLayer, Pane } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { useAnalysisNodes } from './useAnalysisNodes';
+import MeasureDistanceController from '../MeasureDistanceController';
+import type { MeasurePoint } from '../../utils/measureDistance';
 import { getTilesetById } from '../../config/tilesets';
 import { TilesetSelector } from '../TilesetSelector';
 import NodeMarkersLayer from './layers/NodeMarkersLayer';
@@ -30,7 +34,20 @@ export default function MapAnalysisCanvas() {
     customTilesets,
     setMapTileset,
   } = useSettings();
-  const { config } = useMapAnalysisCtx();
+  const { config, measureMode, setMeasureMode } = useMapAnalysisCtx();
+
+  // #3636: measurement endpoints, from the same visible+positioned node list
+  // the markers layer uses so the two never disagree.
+  const analysisNodes = useAnalysisNodes();
+  const measurePoints: MeasurePoint[] = useMemo(
+    () => analysisNodes.map((a) => ({
+      id: a.key,
+      lat: a.latLng[0],
+      lng: a.latLng[1],
+      label: a.node.shortName ?? undefined,
+    })),
+    [analysisNodes],
+  );
 
   const center: [number, number] = [
     defaultMapCenterLat ?? FALLBACK_CENTER[0],
@@ -49,6 +66,13 @@ export default function MapAnalysisCanvas() {
           maxZoom={tileset.maxZoom}
         />
         <FollowController />
+        {measureMode && (
+          <MeasureDistanceController
+            active={measureMode}
+            points={measurePoints}
+            onExit={() => setMeasureMode(false)}
+          />
+        )}
         <Pane name="waypoints" style={{ zIndex: 650 }}>
           {config.layers.waypoints.enabled && <WaypointsLayer />}
         </Pane>

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -35,6 +35,9 @@ type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
   /** Follow/Auto-zoom paused by a manual pan/zoom; cleared by Resume or retargeting (issue #3788 P2). */
   followPaused: boolean;
   setFollowPaused: (p: boolean) => void;
+  /** Node-to-node LOS distance measurement tool active (issue #3636); transient, not persisted. */
+  measureMode: boolean;
+  setMeasureMode: (m: boolean) => void;
 };
 
 const Ctx = createContext<CtxShape | null>(null);
@@ -44,6 +47,7 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const [selected, setSelected] = useState<SelectedTarget | null>(null);
   const [nodeFilter, setNodeFilter] = useState('');
   const [followPaused, setFollowPaused] = useState(false);
+  const [measureMode, setMeasureMode] = useState(false);
   return (
     <Ctx.Provider
       value={{
@@ -54,6 +58,8 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
         setNodeFilter,
         followPaused,
         setFollowPaused,
+        measureMode,
+        setMeasureMode,
       }}
     >
       {children}

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -164,12 +164,16 @@ export default function MapAnalysisToolbar() {
       >
         Time Slider
       </button>
-      {/* #3636: node-to-node LOS distance measurement tool. */}
+      {/* #3636: node-to-node LOS distance measurement tool. Disabled until at
+          least two positioned nodes exist, matching the "Features"-panel maps. */}
       <button
         type="button"
         className={`map-analysis-layer-btn ${measureMode ? 'active' : ''}`}
         onClick={() => setMeasureMode(!measureMode)}
-        title="Measure straight-line distance between two nodes"
+        disabled={analysisNodes.length < 2}
+        title={analysisNodes.length < 2
+          ? 'Need at least two positioned nodes to measure'
+          : 'Measure straight-line distance between two nodes'}
       >
         Measure
       </button>

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -45,6 +45,8 @@ export default function MapAnalysisToolbar() {
     setTimeSlider,
     setFollowMode,
     setAutoZoom,
+    measureMode,
+    setMeasureMode,
     reset,
   } = useMapAnalysisCtx();
   const { data: sources = [] } = useDashboardSources();
@@ -161,6 +163,15 @@ export default function MapAnalysisToolbar() {
         onClick={() => setTimeSlider({ enabled: !config.timeSlider.enabled })}
       >
         Time Slider
+      </button>
+      {/* #3636: node-to-node LOS distance measurement tool. */}
+      <button
+        type="button"
+        className={`map-analysis-layer-btn ${measureMode ? 'active' : ''}`}
+        onClick={() => setMeasureMode(!measureMode)}
+        title="Measure straight-line distance between two nodes"
+      >
+        Measure
       </button>
       {UNTIMED_LAYERS.map(({ key, label }) => (
         <LayerToggleButton

--- a/src/components/MeasureDistanceController.css
+++ b/src/components/MeasureDistanceController.css
@@ -1,0 +1,19 @@
+/* #3636: distance label for the node-to-node LOS measurement tool.
+   Applied to the permanent Leaflet tooltip anchored at the measurement line's
+   midpoint. Styled as a high-contrast pill so it reads over any tile layer. */
+.leaflet-tooltip.measure-distance-label {
+  background: #0f172a;
+  color: #e2e8f0;
+  border: 1px solid #38bdf8;
+  border-radius: 10px;
+  padding: 2px 8px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  white-space: nowrap;
+}
+
+/* Center-direction tooltips have no callout arrow; hide any pseudo just in case. */
+.leaflet-tooltip.measure-distance-label::before {
+  display: none;
+}

--- a/src/components/MeasureDistanceController.test.tsx
+++ b/src/components/MeasureDistanceController.test.tsx
@@ -1,22 +1,21 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import type { MeasurePoint } from '../utils/measureDistance';
 
-// Capture the click handler registered via useMapEvents so the test can fire
-// synthetic map clicks. Stub the leaflet primitives to plain DOM so we can
-// assert what the controller renders without a real map.
-let clickHandler: ((e: { latlng: { lat: number; lng: number } }) => void) | null = null;
-const containerStyle: { cursor: string } = { cursor: '' };
+// Real container element the controller attaches its capture-phase listener to.
+// `mouseEventToLatLng` maps clientX/clientY straight to lng/lat so a synthetic
+// click at (x,y) resolves to { lat: y, lng: x }.
+const container = document.createElement('div');
+container.style.cursor = '';
 
 vi.mock('react-leaflet', () => ({
-  useMap: () => ({ getContainer: () => ({ style: containerStyle }) }),
-  useMapEvents: (handlers: { click: (e: { latlng: { lat: number; lng: number } }) => void }) => {
-    clickHandler = handlers.click;
-    return {};
-  },
+  useMap: () => ({
+    getContainer: () => container,
+    mouseEventToLatLng: (e: MouseEvent) => ({ lat: e.clientY, lng: e.clientX }),
+  }),
   CircleMarker: ({ center }: { center: [number, number] }) => (
     <div data-testid="measure-ring" data-lat={center[0]} data-lng={center[1]} />
   ),
@@ -35,21 +34,30 @@ vi.mock('../contexts/SettingsContext', () => ({
 
 import MeasureDistanceController from './MeasureDistanceController';
 
+// Points laid out along one latitude so nearest-by-distance ≈ nearest clientX.
 const POINTS: MeasurePoint[] = [
-  { id: 'a', lat: 40.0, lng: -105.0, label: 'A' },
-  { id: 'b', lat: 40.5, lng: -105.0, label: 'B' },
-  { id: 'c', lat: 41.0, lng: -105.0, label: 'C' },
+  { id: 'a', lat: 100, lng: 100, label: 'A' },
+  { id: 'b', lat: 100, lng: 500, label: 'B' },
+  { id: 'c', lat: 100, lng: 900, label: 'C' },
 ];
 
-function click(lat: number, lng: number) {
-  act(() => clickHandler?.({ latlng: { lat, lng } }));
+// Click at pixel (x,y) on a given element inside the container (defaults to the
+// container itself). Capture-phase listener picks it up regardless of target.
+function clickAt(x: number, y: number, target: EventTarget = container) {
+  act(() => {
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  });
 }
 
 describe('MeasureDistanceController', () => {
   beforeEach(() => {
-    clickHandler = null;
-    containerStyle.cursor = '';
+    container.style.cursor = '';
     unit = 'km';
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    container.remove();
+    container.innerHTML = '';
   });
 
   it('renders nothing when inactive', () => {
@@ -64,52 +72,80 @@ describe('MeasureDistanceController', () => {
 
   it('snaps two clicks to nearest nodes and draws a labeled line', () => {
     render(<MeasureDistanceController active points={POINTS} />);
-    // Click near A, then near C -> line A..C, ~111 km.
-    click(39.9, -105.0);
-    click(41.1, -105.0);
+    clickAt(110, 100); // nearest A
+    clickAt(890, 100); // nearest C
 
     const line = screen.getByTestId('measure-line');
     expect(JSON.parse(line.getAttribute('data-positions')!)).toEqual([
-      [40.0, -105.0],
-      [41.0, -105.0],
+      [100, 100],
+      [100, 900],
     ]);
-    const label = screen.getByTestId('measure-label').textContent ?? '';
-    expect(label).toMatch(/km$/);
-    expect(parseFloat(label)).toBeCloseTo(111.2, 0);
+    expect(screen.getByTestId('measure-label').textContent).toMatch(/km$/);
+  });
+
+  it('registers a click that lands on a marker element (not just the background)', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    // Simulate a click whose DOM target is a marker icon nested in the container.
+    const marker = document.createElement('div');
+    marker.className = 'leaflet-marker-icon';
+    container.appendChild(marker);
+    clickAt(110, 100, marker);
+    clickAt(510, 100, marker); // nearest B
+    const line = screen.getByTestId('measure-line');
+    expect(JSON.parse(line.getAttribute('data-positions')!)).toEqual([
+      [100, 100],
+      [100, 500],
+    ]);
+  });
+
+  it('ignores clicks on leaflet controls', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    const zoom = document.createElement('div');
+    zoom.className = 'leaflet-control';
+    container.appendChild(zoom);
+    clickAt(110, 100, zoom);
+    expect(screen.queryByTestId('measure-ring')).toBeNull();
   });
 
   it('honors the miles preference', () => {
     unit = 'mi';
     render(<MeasureDistanceController active points={POINTS} />);
-    click(39.9, -105.0);
-    click(40.6, -105.0); // nearest to B
+    clickAt(110, 100);
+    clickAt(510, 100);
     expect(screen.getByTestId('measure-label').textContent).toMatch(/mi$/);
   });
 
   it('a third click restarts the measurement from a new anchor', () => {
     render(<MeasureDistanceController active points={POINTS} />);
-    click(39.9, -105.0); // A
-    click(41.1, -105.0); // C -> completed pair
+    clickAt(110, 100); // A
+    clickAt(890, 100); // C -> completed pair
     expect(screen.queryByTestId('measure-line')).not.toBeNull();
 
-    click(40.6, -105.0); // restart with B as the new anchor A
+    clickAt(510, 100); // restart with B as the new anchor A
     expect(screen.queryByTestId('measure-line')).toBeNull();
-    // one ring for the new anchor
+    expect(screen.getAllByTestId('measure-ring')).toHaveLength(1);
+  });
+
+  it('ignores re-picking the same node as the first anchor', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    clickAt(110, 100); // A
+    clickAt(120, 100); // still nearest A -> ignored, no pair
+    expect(screen.queryByTestId('measure-line')).toBeNull();
     expect(screen.getAllByTestId('measure-ring')).toHaveLength(1);
   });
 
   it('sets a crosshair cursor while active and restores it on exit', () => {
     const { rerender } = render(<MeasureDistanceController active points={POINTS} />);
-    expect(containerStyle.cursor).toBe('crosshair');
+    expect(container.style.cursor).toBe('crosshair');
     rerender(<MeasureDistanceController active={false} points={POINTS} />);
-    expect(containerStyle.cursor).toBe('');
+    expect(container.style.cursor).toBe('');
   });
 
   it('Escape clears the measurement and calls onExit', () => {
     const onExit = vi.fn();
     render(<MeasureDistanceController active points={POINTS} onExit={onExit} />);
-    click(39.9, -105.0);
-    click(41.1, -105.0);
+    clickAt(110, 100);
+    clickAt(890, 100);
     expect(screen.queryByTestId('measure-line')).not.toBeNull();
 
     act(() => {

--- a/src/components/MeasureDistanceController.test.tsx
+++ b/src/components/MeasureDistanceController.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import type { MeasurePoint } from '../utils/measureDistance';
+
+// Capture the click handler registered via useMapEvents so the test can fire
+// synthetic map clicks. Stub the leaflet primitives to plain DOM so we can
+// assert what the controller renders without a real map.
+let clickHandler: ((e: { latlng: { lat: number; lng: number } }) => void) | null = null;
+const containerStyle: { cursor: string } = { cursor: '' };
+
+vi.mock('react-leaflet', () => ({
+  useMap: () => ({ getContainer: () => ({ style: containerStyle }) }),
+  useMapEvents: (handlers: { click: (e: { latlng: { lat: number; lng: number } }) => void }) => {
+    clickHandler = handlers.click;
+    return {};
+  },
+  CircleMarker: ({ center }: { center: [number, number] }) => (
+    <div data-testid="measure-ring" data-lat={center[0]} data-lng={center[1]} />
+  ),
+  Polyline: ({ positions, children }: { positions: [number, number][]; children?: React.ReactNode }) => (
+    <div data-testid="measure-line" data-positions={JSON.stringify(positions)}>{children}</div>
+  ),
+  Tooltip: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="measure-label">{children}</div>
+  ),
+}));
+
+let unit: 'km' | 'mi' = 'km';
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => ({ distanceUnit: unit }),
+}));
+
+import MeasureDistanceController from './MeasureDistanceController';
+
+const POINTS: MeasurePoint[] = [
+  { id: 'a', lat: 40.0, lng: -105.0, label: 'A' },
+  { id: 'b', lat: 40.5, lng: -105.0, label: 'B' },
+  { id: 'c', lat: 41.0, lng: -105.0, label: 'C' },
+];
+
+function click(lat: number, lng: number) {
+  act(() => clickHandler?.({ latlng: { lat, lng } }));
+}
+
+describe('MeasureDistanceController', () => {
+  beforeEach(() => {
+    clickHandler = null;
+    containerStyle.cursor = '';
+    unit = 'km';
+  });
+
+  it('renders nothing when inactive', () => {
+    render(<MeasureDistanceController active={false} points={POINTS} />);
+    expect(screen.queryByTestId('measure-ring')).toBeNull();
+  });
+
+  it('renders nothing with fewer than two points', () => {
+    render(<MeasureDistanceController active points={[POINTS[0]]} />);
+    expect(screen.queryByTestId('measure-ring')).toBeNull();
+  });
+
+  it('snaps two clicks to nearest nodes and draws a labeled line', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    // Click near A, then near C -> line A..C, ~111 km.
+    click(39.9, -105.0);
+    click(41.1, -105.0);
+
+    const line = screen.getByTestId('measure-line');
+    expect(JSON.parse(line.getAttribute('data-positions')!)).toEqual([
+      [40.0, -105.0],
+      [41.0, -105.0],
+    ]);
+    const label = screen.getByTestId('measure-label').textContent ?? '';
+    expect(label).toMatch(/km$/);
+    expect(parseFloat(label)).toBeCloseTo(111.2, 0);
+  });
+
+  it('honors the miles preference', () => {
+    unit = 'mi';
+    render(<MeasureDistanceController active points={POINTS} />);
+    click(39.9, -105.0);
+    click(40.6, -105.0); // nearest to B
+    expect(screen.getByTestId('measure-label').textContent).toMatch(/mi$/);
+  });
+
+  it('a third click restarts the measurement from a new anchor', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    click(39.9, -105.0); // A
+    click(41.1, -105.0); // C -> completed pair
+    expect(screen.queryByTestId('measure-line')).not.toBeNull();
+
+    click(40.6, -105.0); // restart with B as the new anchor A
+    expect(screen.queryByTestId('measure-line')).toBeNull();
+    // one ring for the new anchor
+    expect(screen.getAllByTestId('measure-ring')).toHaveLength(1);
+  });
+
+  it('sets a crosshair cursor while active and restores it on exit', () => {
+    const { rerender } = render(<MeasureDistanceController active points={POINTS} />);
+    expect(containerStyle.cursor).toBe('crosshair');
+    rerender(<MeasureDistanceController active={false} points={POINTS} />);
+    expect(containerStyle.cursor).toBe('');
+  });
+
+  it('Escape clears the measurement and calls onExit', () => {
+    const onExit = vi.fn();
+    render(<MeasureDistanceController active points={POINTS} onExit={onExit} />);
+    click(39.9, -105.0);
+    click(41.1, -105.0);
+    expect(screen.queryByTestId('measure-line')).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('measure-line')).toBeNull();
+  });
+});

--- a/src/components/MeasureDistanceController.tsx
+++ b/src/components/MeasureDistanceController.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { CircleMarker, Polyline, Tooltip, useMap, useMapEvents } from 'react-leaflet';
+import React, { useEffect, useRef, useState } from 'react';
+import { CircleMarker, Polyline, Tooltip, useMap } from 'react-leaflet';
 import { useSettings } from '../contexts/SettingsContext';
 import { nearestPoint, measureLabel, type MeasurePoint } from '../utils/measureDistance';
 import './MeasureDistanceController.css';
@@ -16,12 +16,16 @@ export interface MeasureDistanceControllerProps {
 /**
  * Node-to-node line-of-sight (LOS) distance measurement tool (issue #3636).
  *
- * Rendered as a child of a react-leaflet `<MapContainer>`. While `active`, each
- * map click snaps to the nearest node in `points` (Leaflet map-background clicks
- * don't fire on marker hits, so snapping keeps this map-agnostic — clicking near
- * a node selects it). First click sets anchor A, second sets anchor B and draws
- * the line + distance label, a third click restarts from a new A. Escape or
- * toggling the tool off clears the measurement.
+ * Rendered as a child of a react-leaflet `<MapContainer>`. While `active`, it
+ * intercepts clicks anywhere on the map — including directly on node markers —
+ * via a **capture-phase** listener on the map container. That fires before the
+ * marker's own click handler, so we can convert the click to a lat/lng, snap to
+ * the nearest node in `points`, and suppress the marker popup while measuring.
+ * (A plain `useMapEvents` click never fires for marker hits, so clicking on a
+ * node used to just open its popup.)
+ *
+ * First pick sets anchor A, second sets B and draws the line + distance label,
+ * a third pick restarts from a new A. Escape or toggling the tool off clears it.
  *
  * This one component serves every map view; the activation toggle and the
  * `points` array are supplied per-map.
@@ -33,10 +37,14 @@ const MeasureDistanceController: React.FC<MeasureDistanceControllerProps> = ({
 }) => {
   const { distanceUnit } = useSettings();
   const map = useMap();
-  const [anchorA, setAnchorA] = useState<MeasurePoint | null>(null);
-  const [anchorB, setAnchorB] = useState<MeasurePoint | null>(null);
+  const [anchors, setAnchors] = useState<MeasurePoint[]>([]);
 
   const enabled = active && points.length >= 2;
+
+  // Keep the latest points reachable from the (stable) click listener without
+  // re-subscribing on every poll that returns a fresh array.
+  const pointsRef = useRef(points);
+  pointsRef.current = points;
 
   // Crosshair affordance while measuring; always restore on cleanup.
   useEffect(() => {
@@ -51,46 +59,53 @@ const MeasureDistanceController: React.FC<MeasureDistanceControllerProps> = ({
 
   // Clear anchors whenever the tool is switched off (or loses enough nodes).
   useEffect(() => {
-    if (!enabled) {
-      setAnchorA(null);
-      setAnchorB(null);
-    }
+    if (!enabled) setAnchors([]);
   }, [enabled]);
+
+  // Capture-phase click interception. Registered on the map container so it
+  // fires before Leaflet's marker/map click handlers — letting a click land on
+  // a node marker without opening its popup.
+  useEffect(() => {
+    if (!enabled) return;
+    const container = map.getContainer();
+    const onClick = (e: MouseEvent) => {
+      // Let map controls (zoom, attribution, tileset toggle) work normally.
+      const target = e.target as HTMLElement | null;
+      if (target && target.closest('.leaflet-control')) return;
+      // Stop the marker popup / map click from also handling this event.
+      e.stopPropagation();
+      e.preventDefault();
+      const latlng = map.mouseEventToLatLng(e);
+      const picked = nearestPoint(pointsRef.current, latlng.lat, latlng.lng);
+      if (!picked) return;
+      setAnchors((prev) => {
+        if (prev.length === 0) return [picked];
+        if (prev.length === 1) {
+          // Ignore re-picking the same node as the first anchor.
+          return prev[0].id === picked.id ? prev : [prev[0], picked];
+        }
+        return [picked]; // completed pair -> restart from a new A
+      });
+    };
+    container.addEventListener('click', onClick, true);
+    return () => container.removeEventListener('click', onClick, true);
+  }, [enabled, map]);
 
   // Escape clears / exits.
   useEffect(() => {
     if (!enabled) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      setAnchorA(null);
-      setAnchorB(null);
+      setAnchors([]);
       onExit?.();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [enabled, onExit]);
 
-  useMapEvents({
-    click: (e) => {
-      if (!enabled) return;
-      const picked = nearestPoint(points, e.latlng.lat, e.latlng.lng);
-      if (!picked) return;
-      setAnchorA((prevA) => {
-        // No A yet, or a completed pair -> start fresh with this pick as A.
-        if (!prevA || anchorB) {
-          setAnchorB(null);
-          return picked;
-        }
-        // Have A, no B -> this pick becomes B (ignore re-picking the same node).
-        if (picked.id === prevA.id) return prevA;
-        setAnchorB(picked);
-        return prevA;
-      });
-    },
-  });
-
   if (!enabled) return null;
 
+  const [anchorA, anchorB] = anchors;
   const ringStyle = { color: '#38bdf8', weight: 3, fillColor: '#38bdf8', fillOpacity: 0.15 };
 
   return (

--- a/src/components/MeasureDistanceController.tsx
+++ b/src/components/MeasureDistanceController.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import { CircleMarker, Polyline, Tooltip, useMap, useMapEvents } from 'react-leaflet';
+import { useSettings } from '../contexts/SettingsContext';
+import { nearestPoint, measureLabel, type MeasurePoint } from '../utils/measureDistance';
+import './MeasureDistanceController.css';
+
+export interface MeasureDistanceControllerProps {
+  /** When false the tool is inert (no cursor change, no listeners fire visibly). */
+  active: boolean;
+  /** Candidate endpoints — each map maps its positioned-node memo into these. */
+  points: MeasurePoint[];
+  /** Called when the user presses Escape so the parent can flip `active` off. */
+  onExit?: () => void;
+}
+
+/**
+ * Node-to-node line-of-sight (LOS) distance measurement tool (issue #3636).
+ *
+ * Rendered as a child of a react-leaflet `<MapContainer>`. While `active`, each
+ * map click snaps to the nearest node in `points` (Leaflet map-background clicks
+ * don't fire on marker hits, so snapping keeps this map-agnostic — clicking near
+ * a node selects it). First click sets anchor A, second sets anchor B and draws
+ * the line + distance label, a third click restarts from a new A. Escape or
+ * toggling the tool off clears the measurement.
+ *
+ * This one component serves every map view; the activation toggle and the
+ * `points` array are supplied per-map.
+ */
+const MeasureDistanceController: React.FC<MeasureDistanceControllerProps> = ({
+  active,
+  points,
+  onExit,
+}) => {
+  const { distanceUnit } = useSettings();
+  const map = useMap();
+  const [anchorA, setAnchorA] = useState<MeasurePoint | null>(null);
+  const [anchorB, setAnchorB] = useState<MeasurePoint | null>(null);
+
+  const enabled = active && points.length >= 2;
+
+  // Crosshair affordance while measuring; always restore on cleanup.
+  useEffect(() => {
+    if (!enabled) return;
+    const container = map.getContainer();
+    const prev = container.style.cursor;
+    container.style.cursor = 'crosshair';
+    return () => {
+      container.style.cursor = prev;
+    };
+  }, [enabled, map]);
+
+  // Clear anchors whenever the tool is switched off (or loses enough nodes).
+  useEffect(() => {
+    if (!enabled) {
+      setAnchorA(null);
+      setAnchorB(null);
+    }
+  }, [enabled]);
+
+  // Escape clears / exits.
+  useEffect(() => {
+    if (!enabled) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      setAnchorA(null);
+      setAnchorB(null);
+      onExit?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [enabled, onExit]);
+
+  useMapEvents({
+    click: (e) => {
+      if (!enabled) return;
+      const picked = nearestPoint(points, e.latlng.lat, e.latlng.lng);
+      if (!picked) return;
+      setAnchorA((prevA) => {
+        // No A yet, or a completed pair -> start fresh with this pick as A.
+        if (!prevA || anchorB) {
+          setAnchorB(null);
+          return picked;
+        }
+        // Have A, no B -> this pick becomes B (ignore re-picking the same node).
+        if (picked.id === prevA.id) return prevA;
+        setAnchorB(picked);
+        return prevA;
+      });
+    },
+  });
+
+  if (!enabled) return null;
+
+  const ringStyle = { color: '#38bdf8', weight: 3, fillColor: '#38bdf8', fillOpacity: 0.15 };
+
+  return (
+    <>
+      {anchorA && (
+        <CircleMarker center={[anchorA.lat, anchorA.lng]} radius={12} pathOptions={ringStyle} />
+      )}
+      {anchorB && (
+        <CircleMarker center={[anchorB.lat, anchorB.lng]} radius={12} pathOptions={ringStyle} />
+      )}
+      {anchorA && anchorB && (
+        <Polyline
+          positions={[
+            [anchorA.lat, anchorA.lng],
+            [anchorB.lat, anchorB.lng],
+          ]}
+          pathOptions={{ color: '#38bdf8', weight: 3, dashArray: '8 8' }}
+        >
+          <Tooltip permanent direction="center" className="measure-distance-label">
+            {measureLabel(anchorA, anchorB, distanceUnit)}
+          </Tooltip>
+        </Polyline>
+      )}
+    </>
+  );
+};
+
+export default MeasureDistanceController;

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -24,6 +24,8 @@ import GeoJsonOverlay from '../GeoJsonOverlay';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { TilesetSelector } from '../TilesetSelector';
 import MapLegend from '../MapLegend';
+import MeasureDistanceController from '../MeasureDistanceController';
+import type { MeasurePoint } from '../../utils/measureDistance';
 
 const MESHCORE_COLOR = '#cba6f7';
 const NEIGHBOR_COLOR = '#06b6d4';
@@ -120,6 +122,8 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const tileset = getTilesetById(mapTileset, customTilesets);
   const [showPaths, setShowPaths] = useState(true);
   const [showNeighbors, setShowNeighbors] = useState(true);
+  // #3636: node-to-node LOS distance measurement tool.
+  const [measureActive, setMeasureActive] = useState(false);
   const [neighborEdges, setNeighborEdges] = useState<NeighborEdge[]>([]);
 
   // Spiderfier: fan out co-located MeshCore contacts so each is selectable
@@ -298,6 +302,17 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     [positioned, nodeTypeFilter],
   );
 
+  // #3636: measurement endpoints — nearest-node snapping picks from these.
+  const measurePoints: MeasurePoint[] = useMemo(
+    () => visibleContacts.map(c => ({
+      id: c.publicKey,
+      lat: c.latitude as number,
+      lng: c.longitude as number,
+      label: c.advName || c.name,
+    })),
+    [visibleContacts],
+  );
+
   // Unregister markers whose contact is no longer rendered (filtered out / gone),
   // keyed off the rendered publicKey set — genuine removals only, never the
   // ref null-bounce.
@@ -452,6 +467,13 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           maxZoom={tileset.maxZoom}
         />
         <SpiderfierController ref={spiderfierRef} />
+        {measureActive && (
+          <MeasureDistanceController
+            active={measureActive}
+            points={measurePoints}
+            onExit={() => setMeasureActive(false)}
+          />
+        )}
         {showLegend && <MapLegend showNodeTypes />}
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
         {visibleContacts.map(c => {
@@ -560,6 +582,16 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
       <div className="map-controls dashboard-map-controls">
         <div className="map-controls-body">
           <div className="map-controls-title">Features</div>
+          {/* #3636: node-to-node LOS distance measurement toggle. */}
+          <label className="map-control-item" title="Measure straight-line distance between two nodes">
+            <input
+              type="checkbox"
+              checked={measureActive}
+              disabled={measurePoints.length < 2}
+              onChange={(e) => setMeasureActive(e.target.checked)}
+            />
+            <span>Measure Distance</span>
+          </label>
           <label className="map-control-item">
             <input
               type="checkbox"

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1379,10 +1379,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         } as MeasurePoint;
       })
       .filter((p): p is MeasurePoint => p !== null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on position signature, matching nodePositions above
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on a position+label signature; label included so tooltip names refresh
     [nodesWithPosition.map(n => {
       const pos = getEffectivePosition(n);
-      return `${n.nodeNum}-${pos.latitude}-${pos.longitude}`;
+      return `${n.nodeNum}-${pos.latitude}-${pos.longitude}-${n.user?.shortName ?? ''}`;
     }).join(',')],
   );
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -35,6 +35,8 @@ import MapPositionHandler from './MapPositionHandler';
 import PolarGridOverlay from './PolarGridOverlay.js';
 import GeoJsonOverlay from './GeoJsonOverlay';
 import { SpiderfierController, SpiderfierControllerRef } from './SpiderfierController';
+import MeasureDistanceController from './MeasureDistanceController';
+import type { MeasurePoint } from '../utils/measureDistance';
 import { TilesetSelector } from './TilesetSelector';
 import { MapCenterController } from './MapCenterController';
 import PacketMonitorPanel from './PacketMonitorPanel';
@@ -696,6 +698,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     const saved = localStorage.getItem('meshmonitor-showLegend');
     return saved === null ? false : saved === 'true';
   });
+
+  // #3636: node-to-node LOS distance measurement tool.
+  const [measureActive, setMeasureActive] = useState(false);
 
   const sidebarRef = useRef<HTMLDivElement>(null);
 
@@ -1360,6 +1365,27 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     return `${n.nodeNum}-${pos.latitude}-${pos.longitude}`;
   }).join(',')]);
 
+  // #3636: measurement endpoints — nearest-node snapping picks from these.
+  const measurePoints: MeasurePoint[] = React.useMemo(
+    () => nodesWithPosition
+      .map(node => {
+        const pos = getEffectivePosition(node);
+        if (pos.latitude == null || pos.longitude == null) return null;
+        return {
+          id: String(node.user?.id ?? node.nodeNum),
+          lat: pos.latitude,
+          lng: pos.longitude,
+          label: node.user?.shortName,
+        } as MeasurePoint;
+      })
+      .filter((p): p is MeasurePoint => p !== null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on position signature, matching nodePositions above
+    [nodesWithPosition.map(n => {
+      const pos = getEffectivePosition(n);
+      return `${n.nodeNum}-${pos.latitude}-${pos.longitude}`;
+    }).join(',')],
+  );
+
   // Memoize marker icons to prevent unnecessary Leaflet DOM rebuilds
   // React-Leaflet calls setIcon() whenever the icon prop reference changes, which
   // destroys and recreates the entire icon DOM element. By memoizing icons, we ensure
@@ -1850,6 +1876,16 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               </div>
               {!isMapControlsCollapsed && (
                 <>
+                  {/* #3636: node-to-node LOS distance measurement toggle. */}
+                  <label className="map-control-item" title="Measure straight-line distance between two nodes">
+                    <input
+                      type="checkbox"
+                      checked={measureActive}
+                      disabled={measurePoints.length < 2}
+                      onChange={(e) => setMeasureActive(e.target.checked)}
+                    />
+                    <span>Measure Distance</span>
+                  </label>
                   {/* Map Features age slider (#3322): hides node markers,
                       traceroutes, and route segments older than the chosen age.
                       Ranges 1h–maxNodeAgeHours (settings); default = max ("All"). */}
@@ -2200,6 +2236,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               />
               <MapResizeHandler trigger={`${showPacketMonitor}-${isNodeListCollapsed}-${packetMonitorHeight}`} />
               <SpiderfierController ref={spiderfierRef} zoomLevel={mapZoom} />
+          {measureActive && (
+            <MeasureDistanceController
+              active={measureActive}
+              points={measurePoints}
+              onExit={() => setMeasureActive(false)}
+            />
+          )}
               {showLegend && (
               <MapLegend
                 positionHistory={positionHistoryLegendData}

--- a/src/utils/measureDistance.test.ts
+++ b/src/utils/measureDistance.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { nearestPoint, measureLabel, midpoint, type MeasurePoint } from './measureDistance';
+
+const A: MeasurePoint = { id: 'a', lat: 40.0, lng: -105.0, label: 'A' };
+const B: MeasurePoint = { id: 'b', lat: 40.5, lng: -105.0, label: 'B' };
+const C: MeasurePoint = { id: 'c', lat: 41.0, lng: -105.0, label: 'C' };
+
+describe('nearestPoint', () => {
+  it('returns null for an empty list', () => {
+    expect(nearestPoint([], 40, -105)).toBeNull();
+  });
+
+  it('returns the only point when the list has one', () => {
+    expect(nearestPoint([A], 0, 0)?.id).toBe('a');
+  });
+
+  it('picks the closest point by great-circle distance', () => {
+    // Click just south of A — A should win over B and C which are further north.
+    expect(nearestPoint([C, B, A], 39.9, -105.0)?.id).toBe('a');
+    // Click near C.
+    expect(nearestPoint([A, B, C], 41.1, -105.0)?.id).toBe('c');
+  });
+
+  it('breaks ties in favor of the earlier point', () => {
+    const left: MeasurePoint = { id: 'left', lat: 0, lng: -1 };
+    const right: MeasurePoint = { id: 'right', lat: 0, lng: 1 };
+    // Equidistant click at the origin -> first listed wins.
+    expect(nearestPoint([left, right], 0, 0)?.id).toBe('left');
+    expect(nearestPoint([right, left], 0, 0)?.id).toBe('right');
+  });
+});
+
+describe('measureLabel', () => {
+  it('formats in km by default', () => {
+    // ~0.5 degrees latitude ≈ 55.6 km
+    const label = measureLabel(A, B, 'km');
+    expect(label).toMatch(/km$/);
+    expect(parseFloat(label)).toBeCloseTo(55.6, 0);
+  });
+
+  it('formats in miles when requested', () => {
+    const label = measureLabel(A, B, 'mi');
+    expect(label).toMatch(/mi$/);
+    expect(parseFloat(label)).toBeCloseTo(34.5, 0);
+  });
+
+  it('reports zero distance for identical points', () => {
+    expect(measureLabel(A, A, 'km')).toBe('0.0 km');
+  });
+});
+
+describe('midpoint', () => {
+  it('averages the two coordinates', () => {
+    expect(midpoint(A, C)).toEqual([40.5, -105.0]);
+  });
+});

--- a/src/utils/measureDistance.ts
+++ b/src/utils/measureDistance.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the node-to-node line-of-sight (LOS) distance measurement
+ * tool (issue #3636). Kept free of react-leaflet so they can be unit tested in
+ * isolation; the interactive UI lives in
+ * `src/components/MeasureDistanceController.tsx`.
+ */
+import { calculateDistance, formatDistance } from './distance';
+
+/**
+ * A candidate endpoint for a measurement. Each map builds these from its own
+ * positioned-node memo, so `id`/`label` shapes vary — only lat/lng matter for
+ * the geometry.
+ */
+export interface MeasurePoint {
+  id: string;
+  lat: number;
+  lng: number;
+  label?: string;
+}
+
+/**
+ * Find the point nearest to (lat, lng) by great-circle distance.
+ * Returns null for an empty list. On a tie the earlier point wins.
+ */
+export function nearestPoint(
+  points: MeasurePoint[],
+  lat: number,
+  lng: number
+): MeasurePoint | null {
+  let best: MeasurePoint | null = null;
+  let bestKm = Infinity;
+  for (const p of points) {
+    const km = calculateDistance(lat, lng, p.lat, p.lng);
+    if (km < bestKm) {
+      bestKm = km;
+      best = p;
+    }
+  }
+  return best;
+}
+
+/**
+ * Format the straight-line distance between two measured points, honoring the
+ * user's km/mi preference.
+ */
+export function measureLabel(
+  a: MeasurePoint,
+  b: MeasurePoint,
+  unit: 'km' | 'mi'
+): string {
+  const km = calculateDistance(a.lat, a.lng, b.lat, b.lng);
+  return formatDistance(km, unit);
+}
+
+/**
+ * Midpoint (simple average) of two points, used to anchor the distance label.
+ * Adequate for the short LOS spans typical of a mesh network.
+ */
+export function midpoint(a: MeasurePoint, b: MeasurePoint): [number, number] {
+  return [(a.lat + b.lat) / 2, (a.lng + b.lng) / 2];
+}


### PR DESCRIPTION
Closes #3636.

Adds a **Measure Distance** tool to every interactive map view so a user can measure the straight-line (line-of-sight) distance between two nodes.

## Behavior
- Toggle **Measure Distance** on, then click near two nodes. Each click **snaps to the nearest node**, a dashed line is drawn between them, and the LOS distance is labeled at the midpoint — respecting the km/mi setting.
- A third click restarts from a new anchor. **Escape** or toggling off clears the measurement. A crosshair cursor signals the mode is active.
- The toggle is disabled until a map has at least two positioned nodes.

## Where it lives (all 4 interactive maps)
| Map | Toggle location |
|-----|-----------------|
| Unified / Map Analysis | toolbar **Measure** button (transient context flag) |
| Dashboard (per-source + Unified) | "Features" panel |
| MeshCore | "Features" panel |
| Nodes tab (per-source Meshtastic) | "Features" panel |

The public read-only EmbedMap is intentionally out of scope.

## Implementation
- **`MeasureDistanceController`** — one reusable react-leaflet child renders the picks (`CircleMarker` rings), the dashed `Polyline`, and the distance `Tooltip`. Nearest-node snapping (via map clicks) keeps it map-agnostic, so a single component serves every map; only the toggle + a `points` array are wired per-map.
- **`measureDistance.ts`** — pure `nearestPoint` / `measureLabel` helpers built on the existing Haversine `calculateDistance` / `formatDistance` utils (`src/utils/distance.ts`).
- Each map builds `points` from its existing positioned-node memo. The controller is only **mounted while active**, so existing partial `react-leaflet` test mocks are unaffected.

**Frontend-only** — no backend, DB, or migration changes (coordinates are already loaded into the maps).

## Testing
- New unit tests (`measureDistance.test.ts`) — nearest-point selection, tie-breaking, km/mi formatting.
- New component tests (`MeasureDistanceController.test.tsx`) — snap-to-nearest, line + label, km/mi, third-click restart, Escape clears + `onExit`, crosshair cursor.
- Full Vitest suite green (**success=true**, 0 failures), typecheck adds zero new errors, lint ratchet passes, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub