### PR TITLE
fix(automation): resolve MeshCore DM destination as a pubkey string, not Number()

### DIFF
--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -65,6 +65,29 @@ describe('executeAction', () => {
     expect(calls[0].args).toMatchObject({ destination: 777, replyId: 42, channel: 0 });
   });
 
+  // ── MeshCore DM destination resolution (#4018) ──────────────────────────────
+  it('sendMessage: DM to a MeshCore pubkey resolves destination as a string, not NaN', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'pong', to: '{{ trigger.from }}' }),
+      ctx({ from: '3745442c10a1', channel: undefined, isDM: true, protocol: 'meshcore' }, 'mc', 'meshcore'),
+      deps,
+    );
+    // Must NOT fall back to a channel broadcast (the pre-fix bug): a real
+    // destination is set, so the send is a DM, not `channel: 0`.
+    expect(calls[0].args).toMatchObject({ destination: '3745442c10a1', sourceId: 'mc' });
+  });
+
+  it('sendMessage: a Meshtastic DM target still resolves as a number on a MeshCore-aware context', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'pong', to: '{{ trigger.from }}' }),
+      ctx({ from: 777, isDM: true }, 'mt', 'meshtastic'),
+      deps,
+    );
+    expect(calls[0].args).toMatchObject({ destination: 777, sourceId: 'mt' });
+  });
+
   // ── replyToTrigger auto-mention for MeshCore (#3973 / #3978) ────────────────
   it('sendMessage: replyToTrigger prepends @[senderLabel] for a MeshCore channel trigger', async () => {
     const { calls, deps } = recorder();

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -20,7 +20,8 @@ export interface ActionDeps {
     sourceId: string | null;
     text: string;
     channel: number;
-    destination?: number;
+    /** Meshtastic: a node number. MeshCore: a contact public-key string (#4018). */
+    destination?: number | string;
     replyId?: number;
     /** MeshCore scope/region override (#3833). undefined = inherit channel/default;
      *  '' = explicit unscoped; non-empty = that region. Ignored by Meshtastic. */
@@ -101,6 +102,14 @@ async function num(ctx: EngineEvalContext, raw: unknown): Promise<number | undef
   return Number.isFinite(n) ? n : undefined;
 }
 
+/** Like `num`, but resolves to a trimmed string — for MeshCore pubkey targets (#4018). */
+async function str(ctx: EngineEvalContext, raw: unknown): Promise<string | undefined> {
+  if (raw == null) return undefined;
+  const v = await resolveOperand(ctx, raw);
+  const s = String(v).trim();
+  return s.length > 0 ? s : undefined;
+}
+
 /**
  * True when the action's target source speaks MeshCore. Best-effort: when the
  * data provider can't report a protocol (older callers / tests), returns false
@@ -160,7 +169,11 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
 
     case 'action.sendMessage': {
       let text = await interpolateAsync(String(p.text ?? ''), ctx);
-      const destination = await num(ctx, p.to);
+      // Destination resolution is deferred into the per-source loop below (#4018):
+      // a MeshCore DM target is a pubkey string, a Meshtastic DM target is a node
+      // number, and which applies depends on each target source's protocol —
+      // unconditionally coercing via Number() left MeshCore destinations always NaN.
+      const rawTo = p.to;
       const replyId = p.replyToTrigger ? (ctx.trigger.fields.packetId as number | undefined) : await num(ctx, p.replyId);
 
       // #3973: "Reply to the triggering message" auto-mention for MeshCore.
@@ -241,17 +254,22 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
 
       const results: unknown[] = [];
       for (const sid of sourceIds) {
+        const proto = (await ctx.data.getSourceProtocol?.(sid)) ?? null;
+        const meshcore = proto === 'meshcore';
+        // MeshCore DM targets are contact public-key strings; Meshtastic DM
+        // targets are node numbers (#4018) — resolve per the target source's
+        // own protocol, not the trigger's.
+        const destination = rawTo == null ? undefined : meshcore ? await str(ctx, rawTo) : await num(ctx, rawTo);
+
         if (destination != null || channelSel.length === 0) {
           // DM, or no unified-channel selection → single send on the fallback channel.
-          // A numeric-`to` DM keeps inherit scope: MeshCore reply scope only applies
-          // to flooded channel broadcasts, and MeshCore pubkey DMs don't route through
-          // this path anyway — so dropping the override on a DM is correct, not a leak.
+          // A DM keeps inherit scope: MeshCore reply scope only applies to flooded
+          // channel broadcasts, so dropping the override on a DM is correct, not a leak.
           // A channel-only fallback send (no `to`) still honors the scope override.
           const fallbackScope = destination != null ? {} : scopeArg;
           results.push(await deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope }));
           continue;
         }
-        const proto = (await ctx.data.getSourceProtocol?.(sid)) ?? null;
         const srcChannels = (await ctx.data.getChannels?.(sid)) ?? [];
         for (const sel of channelSel) {
           if (sel.protocol && proto && sel.protocol !== proto) continue; // wrong-protocol channel
@@ -261,7 +279,10 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
         }
       }
 
-      if (channelSel.length > 0 && destination == null && results.length === 0) {
+      // `results` only stays empty when every target source produced neither a DM
+      // send nor a channel match — equivalent to (and simpler than) checking the
+      // old single outer `destination`, now that resolution is per-source.
+      if (channelSel.length > 0 && results.length === 0) {
         throw new Error('action.sendMessage: none of the selected channels exist on the selected source(s)');
       }
       // Unwrap the single-send case so the result shape (and run-log

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -258,7 +258,10 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
         const meshcore = proto === 'meshcore';
         // MeshCore DM targets are contact public-key strings; Meshtastic DM
         // targets are node numbers (#4018) — resolve per the target source's
-        // own protocol, not the trigger's.
+        // own protocol, not the trigger's. A `to` value can't be valid for both
+        // at once, so a mixed-protocol multi-select whose `to` only makes sense
+        // for one protocol falls back to a channel broadcast on the others —
+        // a pre-existing per-source-multi-select design consequence, not new here.
         const destination = rawTo == null ? undefined : meshcore ? await str(ctx, rawTo) : await num(ctx, rawTo);
 
         if (destination != null || channelSel.length === 0) {

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -52,6 +52,43 @@ describe('createMeshActionDeps sendMessage — MeshCore scope (#3833)', () => {
   });
 });
 
+// Regression tests for #4018: a MeshCore DM destination is a pubkey string, and
+// must reach the manager as `toPublicKey`, not be silently dropped.
+describe('createMeshActionDeps sendMessage — MeshCore DM destination (#4018)', () => {
+  beforeEach(() => { getManager.mockReset(); });
+
+  it('forwards a string destination as the MeshCore toPublicKey', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue({ sendMessage }); // MeshCore-shaped manager
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mc', text: 'pong', channel: 0, destination: '3745442c10a1' });
+
+    // raw.sendMessage(text, toPublicKey, channelIdx, scopeOverride, autoRetryOnMiss)
+    expect(sendMessage).toHaveBeenCalledWith('pong', '3745442c10a1', 0, undefined, true);
+  });
+
+  it('a numeric destination reaching a MeshCore manager is dropped, not miscoerced', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue({ sendMessage });
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 0, destination: 777 });
+
+    expect(sendMessage).toHaveBeenCalledWith('hi', undefined, 0, undefined, true);
+  });
+
+  it('a string destination reaching a Meshtastic manager is dropped, not sent as NaN', async () => {
+    const sendTextMessage = vi.fn().mockResolvedValue(1);
+    getManager.mockReturnValue({ sendTextMessage });
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mt', text: 'hi', channel: 0, destination: 'not-a-node' as unknown as number });
+
+    expect(sendTextMessage).toHaveBeenCalledWith('hi', 0, undefined, undefined, 0);
+  });
+});
+
 // Regression tests for #3915 (updated for #3962 Ph2): MeshCore managers now
 // live in the unified sourceManagerRegistry — automation actions targeting a
 // MeshCore source must resolve and use them (no separate registry fallback).

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -68,7 +68,7 @@ async function sendTextVia(
   sourceId: string | null,
   text: string,
   channel: number,
-  destination?: number,
+  destination?: number | string,
   replyId?: number,
   emoji = 0,
   scopeOverride?: string | null,
@@ -78,18 +78,22 @@ async function sendTextVia(
     (Partial<MeshSendManager> & Partial<MeshCoreSendManager>) | undefined;
   if (raw && typeof raw.sendTextMessage === 'function') {
     // Meshtastic has no scope/region concept — scopeOverride is dropped.
-    return raw.sendTextMessage(text, channel, destination, replyId, emoji);
+    const dest = typeof destination === 'number' ? destination : undefined;
+    return raw.sendTextMessage(text, channel, dest, replyId, emoji);
   }
   if (raw && typeof raw.sendMessage === 'function') {
-    // MeshCore: channel send only (DM-by-nodeNum / tapbacks not supported here).
-    // `scopeOverride` (#3833) controls which region the message floods to.
+    // MeshCore: `destination`, when a string, is the contact's public key (#4018)
+    // — routes as a DM instead of always falling back to a channel broadcast.
+    // `scopeOverride` (#3833) controls which region a channel/broadcast send
+    // floods to; the caller already omits it for a DM.
     // `sendMessage` resolves `false` (not throw) when the node is disconnected
     // or the send fails — surface that as a thrown error so the run-log records
     // a failed step instead of a silent success.
     // Automation Engine action.sendMessage is an AUTOMATED sender → opt into the
     // channel-send auto-retry (#3979). Inert unless the global opt-in setting is
     // on; user-initiated sends go through the route, not here.
-    const ok = await raw.sendMessage(text, undefined, channel, scopeOverride, true);
+    const toPublicKey = typeof destination === 'string' ? destination : undefined;
+    const ok = await raw.sendMessage(text, toPublicKey, channel, scopeOverride, true);
     if (ok === false) {
       throw new Error(`source "${sourceId}" failed to send the MeshCore message (node not connected or send rejected)`);
     }


### PR DESCRIPTION
## Summary

Fixes #4018. `action.sendMessage` in the Automation Engine silently downgraded a MeshCore DM reply into a public channel-0 broadcast whenever the destination (`to`) was a MeshCore contact pubkey string.

- **`actionExecutor.ts`**: destination resolution for `action.sendMessage` was hoisted out of the per-target-source loop and unconditionally run through `Number()`. A pubkey string like `"3745442c10a1"` becomes `NaN`, so `destination` was always `undefined` for MeshCore — falling through to the channel-broadcast fallback path (channel 0, since a MeshCore DM trigger carries no channel index). Destination resolution is now deferred into the per-source loop and resolves as a trimmed string (new `str()` helper, mirroring the existing `num()`) when the target source's protocol is `meshcore`, and as a number otherwise — matching the pattern `action.requestData` already uses for MeshCore string targets.
- **`meshActionDeps.ts`**: independently of the above, `sendTextVia`'s MeshCore branch hardcoded `raw.sendMessage(text, undefined, ...)` — the `toPublicKey` argument was dropped on the floor regardless of what was passed in. Now forwards a string destination through as `toPublicKey`; a Meshtastic manager only accepts a numeric destination and a MeshCore manager only accepts a string one (each protocol's non-matching type is dropped rather than miscoerced).

Both fixes were needed — either alone would still produce a channel-0 broadcast.

## Test plan

- [x] Added regression tests in `actionExecutor.test.ts`: a MeshCore DM resolves `destination` as the pubkey string (not `NaN`/`undefined`), while a Meshtastic DM in the same code path still resolves as a number.
- [x] Added regression tests in `meshActionDeps.test.ts`: a string destination reaches a MeshCore manager as `toPublicKey`; a numeric destination reaching a MeshCore manager (or a string destination reaching a Meshtastic manager) is dropped rather than miscoerced.
- [x] `npx vitest run src/server/services/automation/` — 264/264 passed.
- [x] `npx tsc --noEmit` — clean on the changed files.
- [x] `npx eslint` on changed files — clean.
- [x] Full `npx vitest run` — 8389 passed, 3 pre-existing failures unrelated to this change (missing `protobufs/*.proto` files in this container's environment — reproduces identically on `main` with no changes applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8RZLFjSSCqMv22aYyHDpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8RZLFjSSCqMv22aYyHDpU)_