### PR TITLE
diag(low-battery): surface the three silent early-exit gates at INFO level

### DIFF
--- a/src/server/services/lowBatteryNotificationService.test.ts
+++ b/src/server/services/lowBatteryNotificationService.test.ts
@@ -102,6 +102,19 @@ describe('LowBatteryNotificationService', () => {
       expect(mockLoggerInfo).toHaveBeenCalledWith(expect.stringContaining('No users have notifyOnLowBattery enabled'));
     });
 
+    it('should log the "no subscribed users" diagnostic only once per process', async () => {
+      mockGetUsersWithLowBatteryNotifications.mockResolvedValue([]);
+
+      await service.checkLowBatteryNodes();
+      await service.checkLowBatteryNodes();
+      await service.checkLowBatteryNodes();
+
+      const matchingCalls = mockLoggerInfo.mock.calls.filter((call: unknown[]) =>
+        typeof call[0] === 'string' && call[0].includes('No users have notifyOnLowBattery enabled')
+      );
+      expect(matchingCalls).toHaveLength(1);
+    });
+
     it('should skip users with no monitored nodes', async () => {
       mockGetUsersWithLowBatteryNotifications.mockResolvedValue([
         { userId: 1, monitoredNodes: null, lowBatteryThreshold: 20 },

--- a/src/server/services/lowBatteryNotificationService.test.ts
+++ b/src/server/services/lowBatteryNotificationService.test.ts
@@ -50,9 +50,10 @@ vi.mock('./notificationService.js', () => ({
   },
 }));
 
+const mockLoggerInfo = vi.fn();
 vi.mock('../../utils/logger.js', () => ({
   logger: {
-    info: vi.fn(),
+    info: mockLoggerInfo,
     warn: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
@@ -77,6 +78,10 @@ describe('LowBatteryNotificationService', () => {
     // Reset internal state
     service.lastNotifiedNodes = new Map();
     service.currentCooldownHours = 24;
+    service.loggedNoSubscribedUsers = false;
+    service.loggedEmptyMonitoredNodes = new Set();
+    service.loggedPermissionDenied = new Set();
+    service.loggedMeshCoreDiagnostic = new Set();
   });
 
   afterEach(() => {
@@ -92,6 +97,9 @@ describe('LowBatteryNotificationService', () => {
 
       expect(mockGetUsersWithLowBatteryNotifications).toHaveBeenCalled();
       expect(mockGetLowBatteryMonitoredNodes).not.toHaveBeenCalled();
+      // #4020: this early exit must be visible at default (INFO) log level —
+      // it previously logged nothing above debug, indistinguishable from "working fine".
+      expect(mockLoggerInfo).toHaveBeenCalledWith(expect.stringContaining('No users have notifyOnLowBattery enabled'));
     });
 
     it('should skip users with no monitored nodes', async () => {
@@ -103,6 +111,8 @@ describe('LowBatteryNotificationService', () => {
 
       expect(mockGetLowBatteryMonitoredNodes).not.toHaveBeenCalled();
       expect(mockBroadcastToPreferenceUsers).not.toHaveBeenCalled();
+      // #4020: previously silent — no monitored nodes selected is now surfaced at INFO.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(expect.stringContaining('no monitored nodes selected'));
     });
 
     it('should query using the user threshold', async () => {
@@ -184,6 +194,8 @@ describe('LowBatteryNotificationService', () => {
 
       expect(mockGetLowBatteryMonitoredNodes).not.toHaveBeenCalled();
       expect(mockBroadcastToPreferenceUsers).not.toHaveBeenCalled();
+      // #4020: previously silent — a denied permission check is now surfaced at INFO.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(expect.stringContaining('lacks nodes:read permission'));
     });
 
     it('should handle malformed monitored_nodes JSON gracefully', async () => {

--- a/src/server/services/lowBatteryNotificationService.test.ts
+++ b/src/server/services/lowBatteryNotificationService.test.ts
@@ -79,9 +79,13 @@ describe('LowBatteryNotificationService', () => {
     service.lastNotifiedNodes = new Map();
     service.currentCooldownHours = 24;
     service.loggedNoSubscribedUsers = false;
-    service.loggedEmptyMonitoredNodes = new Set();
-    service.loggedPermissionDenied = new Set();
-    service.loggedMeshCoreDiagnostic = new Set();
+    // These four are `readonly Set`s on the class — clear in place rather than
+    // reassigning the reference, since a reassignment only "works" here because
+    // the test accesses them through an `any`-typed handle that bypasses the
+    // readonly check the real type would enforce.
+    (service.loggedEmptyMonitoredNodes as Set<number>).clear();
+    (service.loggedPermissionDenied as Set<string>).clear();
+    (service.loggedMeshCoreDiagnostic as Set<string>).clear();
   });
 
   afterEach(() => {

--- a/src/server/services/lowBatteryNotificationService.ts
+++ b/src/server/services/lowBatteryNotificationService.ts
@@ -44,6 +44,15 @@ class LowBatteryNotificationService {
   // three prior fixes each landed without any log evidence they actually
   // took effect for the reporter's setup.
   private readonly loggedMeshCoreDiagnostic = new Set<string>();
+  // The three gates below (no subscribed users, empty monitored-node list,
+  // failed permission check) all `continue`/`return` *before* reaching the
+  // diagnostic above, and previously logged nothing at all (or debug-only) —
+  // so a report of "nothing in the log" was indistinguishable from "the
+  // service is fine and just hasn't matched anything yet". One-shot INFO
+  // diagnostics here close that gap — see #4020 (5th report of this symptom).
+  private loggedNoSubscribedUsers = false;
+  private readonly loggedEmptyMonitoredNodes = new Set<number>();
+  private readonly loggedPermissionDenied = new Set<string>();
 
   /**
    * Start the low-battery monitoring service
@@ -107,6 +116,13 @@ class LowBatteryNotificationService {
       const users = await databaseService.notifications.getUsersWithLowBatteryNotifications();
 
       if (users.length === 0) {
+        if (!this.loggedNoSubscribedUsers) {
+          this.loggedNoSubscribedUsers = true;
+          logger.info(
+            '🔋 [low-battery] No users have notifyOnLowBattery enabled with an active delivery channel ' +
+            '(notifyOnMessage or appriseEnabled) — the check loop exits here every cycle until that changes.'
+          );
+        }
         logger.debug('✅ No users have low battery notifications enabled');
         return;
       }
@@ -145,13 +161,30 @@ class LowBatteryNotificationService {
           }
 
           if (monitoredNodeIds.length === 0) {
+            if (!this.loggedEmptyMonitoredNodes.has(user.userId)) {
+              this.loggedEmptyMonitoredNodes.add(user.userId);
+              logger.info(
+                `🔋 [low-battery] User ${user.userId} has notifyOnLowBattery enabled but no monitored nodes selected — ` +
+                `nothing to check until at least one node is added to the monitored-nodes list.`
+              );
+            }
             continue;
           }
 
           // Permission check — skip user if they lack nodes:read on this source
           try {
             const allowed = await databaseService.checkPermissionAsync(user.userId, 'nodes', 'read', sourceId);
-            if (!allowed) continue;
+            if (!allowed) {
+              const permKey = `${user.userId}:${sourceId}`;
+              if (!this.loggedPermissionDenied.has(permKey)) {
+                this.loggedPermissionDenied.add(permKey);
+                logger.info(
+                  `🔋 [low-battery] User ${user.userId} lacks nodes:read permission on source ${sourceId} — ` +
+                  `low-battery checks for this source are skipped for that user until permission is granted.`
+                );
+              }
+              continue;
+            }
           } catch (err) {
             logger.error(`Permission check failed for user ${user.userId} on source ${sourceId}:`, err);
             continue;


### PR DESCRIPTION
## Summary

Continuation of #3417 / #3462 / #3671 / #3884 / #4020 — the recurring "MeshCore Notify on Low Battery still doesn't work" report, now on its 5th round from the same user.

PR #3896 added a one-shot diagnostic (`🔋 [MeshCore low-battery] source=…`) inside `collectMeshCoreLowBatteryAlerts()`, specifically so the next report of this symptom would carry log evidence instead of another guess. #4020's "I see nothing related to Notify on Low Battery" in the log is itself new information: that diagnostic logs at INFO (default level, no `LOG_LEVEL=debug` needed), so if it truly never appears, the check must be exiting somewhere upstream of it.

Reading `checkLowBatteryNodes()`, there are three earlier exit points that previously logged **nothing above debug**:

1. No subscribed user (`notifyOnLowBattery` enabled + an active delivery channel) — whole check returns immediately.
2. A subscribed user's monitored-nodes list is empty for a given source — skipped silently.
3. A subscribed user fails the `nodes:read` permission check on a source — skipped silently.

Any of these would produce zero log output, matching the report exactly, and would mean the #3896 diagnostic can't help because the code path never reaches it.

## Changes

- `lowBatteryNotificationService.ts`: add one-shot-per-process INFO diagnostics at each of the three gates above, mirroring the existing `loggedMeshCoreDiagnostic` pattern (`Set`/boolean dedup so it doesn't spam every hourly cycle).
- `lowBatteryNotificationService.test.ts`: assert the new diagnostic lines fire in the corresponding existing "should skip…" test cases; reset the new dedup state in `beforeEach`.

This is observability-only — it does not change any check logic, thresholds, or notification behavior. It closes the gap that let #4020 happen without evidence, so the next log excerpt from the reporter will be conclusive about which gate (if any) is the actual root cause.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/server/services/lowBatteryNotificationService.ts src/server/services/lowBatteryNotificationService.test.ts` — no warnings/errors
- [x] `npx vitest run src/server/services/lowBatteryNotificationService.test.ts src/server/services/inactiveNodeNotificationService.test.ts` — 27/27 passed
- [ ] Full `vitest run` suite — running; will report back if anything regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGQgXiE4G3BcFJVQWemxxm)_