### PR TITLE
fix(map): decouple popup from spiderfy + declutter obscured markers (#4015, #4016)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -29,6 +29,7 @@ import { TilesetSelector } from '../TilesetSelector';
 import MapLegend from '../MapLegend';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
+import { precisionCellBounds, hasAccuracyCell } from '../../utils/precisionOffset';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { useMapContext } from '../../contexts/MapContext';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -425,6 +426,11 @@ export default function DashboardMap({
   // (via the declarative <Popup> child), so a pile click doesn't plant a popup on
   // the pre-spread stacked marker. Runs after the child <Popup> bind effects;
   // `off` is idempotent. Popup content stays bound for the OMS-driven open above.
+  //
+  // NOTE: `_openPopup` is Leaflet's private handler (verified against
+  // leaflet@1.9.4 `Popup.js` bindPopup). Undocumented — if a future Leaflet
+  // renames/removes it, the strip no-ops and we degrade to the old double-fire
+  // (annoying, not a crash). Re-verify when bumping Leaflet.
   useEffect(() => {
     for (const m of markerByKey.current.values()) {
       const mm = m as LeafletMarker & { _openPopup?: (e: unknown) => void };
@@ -635,30 +641,12 @@ export default function DashboardMap({
           );
         })}
 
-        {/* Position accuracy regions — drawn from precision_bits, mirroring NodesTab. */}
+        {/* Position accuracy regions — drawn from precision_bits, mirroring NodesTab.
+            Shares the cell geometry with Map Analysis via `precisionCellBounds`. */}
         {showAccuracyRegions && nodesWithPosition
-          .filter(({ node }) => {
-            const bits = node.positionPrecisionBits;
-            if (bits === undefined || bits === null) return false;
-            if (bits <= 0 || bits >= 32) return false;
-            // Don't show accuracy region for nodes with user-overridden positions
-            if (node.positionIsOverride) return false;
-            return true;
-          })
+          .filter(({ node }) => hasAccuracyCell(node.positionPrecisionBits, node.positionIsOverride))
           .map(({ node, pos }) => {
-            // Meshtastic encodes lat/lon as int32 (1 unit = 1e-7 degrees).
-            // With N precision bits, the grid cell side = 2^(32-N) * 1e-7 * 111111 m.
-            // Accuracy (max deviation) is half the grid cell.
-            const metersPerDegree = 111_111;
-            const sizeMeters = Math.pow(2, 32 - node.positionPrecisionBits) * 1e-7 * metersPerDegree;
-            const halfSizeMeters = sizeMeters / 2;
-            const latOffset = halfSizeMeters / metersPerDegree;
-            const metersPerDegreeLng = metersPerDegree * Math.cos(pos.lat * Math.PI / 180);
-            const lngOffset = halfSizeMeters / metersPerDegreeLng;
-            const bounds: [[number, number], [number, number]] = [
-              [pos.lat - latOffset, pos.lng - lngOffset],
-              [pos.lat + latOffset, pos.lng + lngOffset],
-            ];
+            const bounds = precisionCellBounds(pos.lat, pos.lng, node.positionPrecisionBits as number);
             return (
               <Rectangle
                 key={`accuracy-${node.nodeNum ?? node.nodeId ?? node.user?.id}`}

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -394,6 +394,44 @@ export default function DashboardMap({
     }
   }, [renderedKeysSig]);
 
+  // #4015: open the popup ONLY via the OMS 'click' event (which fires solely for
+  // an already-spiderfied or standalone marker — never for the click that fans
+  // out a pile). The SpiderfierController's OMS is created in its own effect;
+  // retry briefly until it exists, then register.
+  useEffect(() => {
+    const onOmsClick = (marker: LeafletMarker) => marker.openPopup();
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Capture the controller we register on so cleanup detaches from the same
+    // one (avoids reading spiderfierRef.current in cleanup).
+    let registered: SpiderfierControllerRef | null = null;
+    const tryRegister = () => {
+      const controller = spiderfierRef.current;
+      if (controller?.getSpiderfier()) {
+        controller.addListener('click', onOmsClick);
+        registered = controller;
+        return;
+      }
+      if (attempts++ < 20) timer = setTimeout(tryRegister, 50);
+    };
+    tryRegister();
+    return () => {
+      if (timer) clearTimeout(timer);
+      registered?.removeListener('click', onOmsClick);
+    };
+  }, []);
+
+  // #4015: strip Leaflet's auto-open-on-click handler that `bindPopup` installs
+  // (via the declarative <Popup> child), so a pile click doesn't plant a popup on
+  // the pre-spread stacked marker. Runs after the child <Popup> bind effects;
+  // `off` is idempotent. Popup content stays bound for the OMS-driven open above.
+  useEffect(() => {
+    for (const m of markerByKey.current.values()) {
+      const mm = m as LeafletMarker & { _openPopup?: (e: unknown) => void };
+      if (mm._openPopup) mm.off('click', mm._openPopup, mm);
+    }
+  }, [renderedKeysSig]);
+
   // nodeNum → [lat, lng] map used to resolve traceroute hop positions. The
   // unified view merges per-source node rows by nodeNum (see mergeUnifiedSourceData
   // in useDashboardData.ts), so a single lookup table works across sources.

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -17,6 +17,7 @@ import CoverageHeatmapLayer from './layers/CoverageHeatmapLayer';
 import SnrOverlayLayer from './layers/SnrOverlayLayer';
 import WaypointsLayer from './layers/WaypointsLayer';
 import PolarGridLayer from './layers/PolarGridLayer';
+import AccuracyRegionsLayer from './layers/AccuracyRegionsLayer';
 import TimeSliderControl from './TimeSliderControl';
 import MapLegend from './MapLegend';
 import FollowController from './FollowController';
@@ -75,6 +76,11 @@ export default function MapAnalysisCanvas() {
         )}
         <Pane name="waypoints" style={{ zIndex: 650 }}>
           {config.layers.waypoints.enabled && <WaypointsLayer />}
+        </Pane>
+        {/* #4016: obscured-position accuracy squares, beneath the markers so the
+            offset marker reads as sitting inside its uncertainty cell. */}
+        <Pane name="accuracyRegions" style={{ zIndex: 580 }}>
+          {config.layers.accuracyRegions.enabled && <AccuracyRegionsLayer />}
         </Pane>
         <Pane name="markers" style={{ zIndex: 600 }}>
           {config.layers.markers.enabled && <NodeMarkersLayer />}

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -32,6 +32,7 @@ const UNTIMED_LAYERS: { key: LayerKey; label: string }[] = [
   { key: 'markers',     label: 'Markers' },
   { key: 'hopShading',  label: 'Hop Shading' },
   { key: 'waypoints',   label: 'Waypoints' },
+  { key: 'accuracyRegions', label: 'Accuracy Regions' },
 ];
 
 export default function MapAnalysisToolbar() {

--- a/src/components/MapAnalysis/layers/AccuracyRegionsLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/AccuracyRegionsLayer.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AccuracyRegionsLayer from './AccuracyRegionsLayer';
+import type { AnalysisNode } from '../useAnalysisNodes';
+
+vi.mock('react-leaflet', () => ({
+  Rectangle: ({ bounds }: { bounds: [[number, number], [number, number]] }) => (
+    <div data-testid="accuracy-rect" data-bounds={JSON.stringify(bounds)} />
+  ),
+}));
+
+const mockNodes = vi.fn<() => AnalysisNode[]>();
+vi.mock('../useAnalysisNodes', () => ({
+  useAnalysisNodes: () => mockNodes(),
+}));
+
+function node(partial: Partial<AnalysisNode['node']> & { nodeNum: number }): AnalysisNode {
+  return {
+    node: { latitude: 30, longitude: -90, ...partial },
+    // latLng is the (possibly offset) marker position; the layer must ignore it
+    // and recompute the rectangle center from the node's own coordinates.
+    latLng: [99, 99],
+    key: `mt:${partial.nodeNum}`,
+  };
+}
+
+describe('AccuracyRegionsLayer', () => {
+  it('draws a rectangle only for obscured (1..31 bits, non-override) nodes', () => {
+    mockNodes.mockReturnValue([
+      node({ nodeNum: 1, positionPrecisionBits: 16 }),           // obscured -> rect
+      node({ nodeNum: 2, positionPrecisionBits: 32 }),           // full precision -> none
+      node({ nodeNum: 3 }),                                      // missing bits -> none
+      node({ nodeNum: 4, positionPrecisionBits: 0 }),            // zero -> none
+      node({ nodeNum: 5, positionPrecisionBits: 16, positionIsOverride: true }), // override -> none
+    ]);
+    render(<AccuracyRegionsLayer />);
+    expect(screen.getAllByTestId('accuracy-rect')).toHaveLength(1);
+  });
+
+  it('centers the rectangle on the node position, not the offset marker latLng', () => {
+    mockNodes.mockReturnValue([node({ nodeNum: 1, latitude: 30, longitude: -90, positionPrecisionBits: 16 })]);
+    render(<AccuracyRegionsLayer />);
+    const bounds = JSON.parse(screen.getByTestId('accuracy-rect').getAttribute('data-bounds')!);
+    const centerLat = (bounds[0][0] + bounds[1][0]) / 2;
+    const centerLng = (bounds[0][1] + bounds[1][1]) / 2;
+    expect(centerLat).toBeCloseTo(30, 6);   // NOT 99 (the latLng)
+    expect(centerLng).toBeCloseTo(-90, 6);
+  });
+
+  it('renders nothing when there are no obscured nodes', () => {
+    mockNodes.mockReturnValue([node({ nodeNum: 1, positionPrecisionBits: 32 })]);
+    render(<AccuracyRegionsLayer />);
+    expect(screen.queryByTestId('accuracy-rect')).toBeNull();
+  });
+});

--- a/src/components/MapAnalysis/layers/AccuracyRegionsLayer.tsx
+++ b/src/components/MapAnalysis/layers/AccuracyRegionsLayer.tsx
@@ -11,14 +11,7 @@ import { useMemo } from 'react';
 import { Rectangle } from 'react-leaflet';
 import { useAnalysisNodes } from '../useAnalysisNodes';
 import { resolveNodeLatLng } from '../nodePositionUtil';
-import { precisionCellBounds } from '../../../utils/precisionOffset';
-
-/** Obscured-position nodes: a defined, non-full precision that isn't a user override. */
-function isObscured(bits: number | null | undefined, isOverride: boolean | null | undefined): boolean {
-  if (isOverride) return false;
-  if (bits == null) return false;
-  return bits > 0 && bits < 32;
-}
+import { precisionCellBounds, hasAccuracyCell } from '../../../utils/precisionOffset';
 
 export default function AccuracyRegionsLayer() {
   const analysisNodes = useAnalysisNodes();
@@ -26,7 +19,7 @@ export default function AccuracyRegionsLayer() {
   const regions = useMemo(() => {
     return analysisNodes
       .map(({ node, key }) => {
-        if (!isObscured(node.positionPrecisionBits, node.positionIsOverride)) return null;
+        if (!hasAccuracyCell(node.positionPrecisionBits, node.positionIsOverride)) return null;
         // Center on the un-offset reported position, not the jittered marker.
         const center = resolveNodeLatLng(node);
         if (!center) return null;

--- a/src/components/MapAnalysis/layers/AccuracyRegionsLayer.tsx
+++ b/src/components/MapAnalysis/layers/AccuracyRegionsLayer.tsx
@@ -1,0 +1,56 @@
+/**
+ * AccuracyRegionsLayer — draws the Meshtastic obscured-position accuracy square
+ * for each node reporting a low `precision_bits` (issue #4016).
+ *
+ * Mirrors the Dashboard map's "Show Accuracy Regions" rectangle. The rectangle is
+ * centered on the node's TRUE reported position (`resolveNodeLatLng`), NOT the
+ * #4016 within-cell offset applied to the marker in `useAnalysisNodes` — so an
+ * offset marker visibly sits inside its own uncertainty square.
+ */
+import { useMemo } from 'react';
+import { Rectangle } from 'react-leaflet';
+import { useAnalysisNodes } from '../useAnalysisNodes';
+import { resolveNodeLatLng } from '../nodePositionUtil';
+import { precisionCellBounds } from '../../../utils/precisionOffset';
+
+/** Obscured-position nodes: a defined, non-full precision that isn't a user override. */
+function isObscured(bits: number | null | undefined, isOverride: boolean | null | undefined): boolean {
+  if (isOverride) return false;
+  if (bits == null) return false;
+  return bits > 0 && bits < 32;
+}
+
+export default function AccuracyRegionsLayer() {
+  const analysisNodes = useAnalysisNodes();
+
+  const regions = useMemo(() => {
+    return analysisNodes
+      .map(({ node, key }) => {
+        if (!isObscured(node.positionPrecisionBits, node.positionIsOverride)) return null;
+        // Center on the un-offset reported position, not the jittered marker.
+        const center = resolveNodeLatLng(node);
+        if (!center) return null;
+        const bounds = precisionCellBounds(center[0], center[1], node.positionPrecisionBits as number);
+        return { key, bounds };
+      })
+      .filter((r): r is { key: string; bounds: [[number, number], [number, number]] } => r !== null);
+  }, [analysisNodes]);
+
+  return (
+    <>
+      {regions.map(({ key, bounds }) => (
+        <Rectangle
+          key={`accuracy-${key}`}
+          bounds={bounds}
+          pathOptions={{
+            color: '#888',
+            fillColor: '#888',
+            fillOpacity: 0.08,
+            opacity: 0.5,
+            weight: 1,
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.test.tsx
@@ -25,7 +25,13 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
 }));
 vi.mock('../../../hooks/useMarkerSpiderfier', () => ({
-  useMarkerSpiderfier: () => ({ addMarker: vi.fn(), removeMarker: vi.fn() }),
+  useMarkerSpiderfier: () => ({
+    addMarker: vi.fn(),
+    removeMarker: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    getSpiderfier: vi.fn(),
+  }),
   SHARED_SPIDERFIER_OPTIONS: {},
 }));
 vi.mock('../../../hooks/useMapAnalysisData', () => ({

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -55,7 +55,7 @@ export default function NodeMarkersLayer() {
   // markers in. Uses the SHARED tuning (50px nearbyDistance etc.) so every map
   // surface fans out identically — the prior default 20px radius missed
   // near-but-not-identical co-located nodes.
-  const { addMarker, removeMarker } = useMarkerSpiderfier(SHARED_SPIDERFIER_OPTIONS);
+  const { addMarker, removeMarker, addListener, removeListener } = useMarkerSpiderfier(SHARED_SPIDERFIER_OPTIONS);
   const markerByKey = useRef<Map<string, LeafletMarker>>(new Map());
   const refHandlers = useRef<Map<string, (m: LeafletMarker | null) => void>>(new Map());
   // Stable position/icon refs keyed by the spiderfier key — fixes the fan
@@ -156,6 +156,29 @@ export default function NodeMarkersLayer() {
       iconCacheRef.current.delete(key);
     }
   }, [renderedKeysSig, removeMarker]);
+
+  // #4015: open the popup ONLY via the OMS 'click' event, which fires solely for
+  // a marker that is already spiderfied or standalone — never for the click that
+  // fans out a pile. This runs after the hook's OMS-init effect (registered
+  // earlier in this component), so the spiderfier is ready.
+  useEffect(() => {
+    const onOmsClick = (marker: LeafletMarker) => marker.openPopup();
+    addListener('click', onOmsClick);
+    return () => removeListener('click', onOmsClick);
+  }, [addListener, removeListener]);
+
+  // #4015: strip Leaflet's own auto-open-on-click handler that `bindPopup`
+  // installs (via the declarative <Popup> child). Without this, a pile click
+  // both fans out AND opens the popup on the pre-spread stacked marker, covering
+  // the markers that just spread. This parent effect runs after the child
+  // <Popup> bind effects; `off` is idempotent. Popup content stays bound, so the
+  // OMS-driven openPopup() above still works.
+  useEffect(() => {
+    for (const m of markerByKey.current.values()) {
+      const mm = m as LeafletMarker & { _openPopup?: (e: unknown) => void };
+      if (mm._openPopup) mm.off('click', mm._openPopup, mm);
+    }
+  }, [renderedKeysSig]);
 
   // #3886: when the time slider is on, fade markers by recency across its
   // window — fully opaque at the window's newest edge, fading toward a floor as

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -173,6 +173,12 @@ export default function NodeMarkersLayer() {
   // the markers that just spread. This parent effect runs after the child
   // <Popup> bind effects; `off` is idempotent. Popup content stays bound, so the
   // OMS-driven openPopup() above still works.
+  //
+  // NOTE: `_openPopup` is Leaflet's private handler (verified against
+  // leaflet@1.9.4 `Popup.js` bindPopup: `this.on({ click: this._openPopup })`).
+  // It's undocumented; if a future Leaflet renames/removes it, the strip becomes
+  // a no-op and we degrade to the old double-fire — annoying, not a crash — so
+  // re-verify this when bumping Leaflet.
   useEffect(() => {
     for (const m of markerByKey.current.values()) {
       const mm = m as LeafletMarker & { _openPopup?: (e: unknown) => void };

--- a/src/components/MapAnalysis/useAnalysisNodes.test.tsx
+++ b/src/components/MapAnalysis/useAnalysisNodes.test.tsx
@@ -92,6 +92,43 @@ describe('useAnalysisNodes', () => {
     expect(result.current.some((n) => n.node.nodeNum === 3)).toBe(false);
   });
 
+  it('offsets a low-precision node within its cell but leaves others centered (#4016)', () => {
+    mockUseDashboardUnifiedData.mockReturnValue({
+      nodes: [
+        // Low precision (16 bits) -> marker offset from the reported center.
+        { ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
+        // Full precision -> unchanged.
+        { ...MOCK_NODES[0], nodeNum: 11, nodeId: '!0000000b', latitude: 40, longitude: -100, positionPrecisionBits: 32 },
+        // Missing precision -> unchanged.
+        { ...MOCK_NODES[0], nodeNum: 12, nodeId: '!0000000c', latitude: 41, longitude: -101 },
+        // Low precision but user-overridden position -> unchanged.
+        { ...MOCK_NODES[0], nodeNum: 13, nodeId: '!0000000d', latitude: 42, longitude: -102, positionPrecisionBits: 16, positionIsOverride: true },
+      ],
+    });
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    const byNum = (num: number) => result.current.find((n) => n.node.nodeNum === num)!;
+
+    // Offset node: moved off the exact center, but still within the ~728m cell (~0.0065deg).
+    const offset = byNum(10).latLng;
+    expect(offset[0]).not.toBe(30);
+    expect(offset[1]).not.toBe(-90);
+    expect(Math.abs(offset[0] - 30)).toBeLessThan(0.01);
+
+    // Full-precision, missing-precision, and overridden nodes stay dead-center.
+    expect(byNum(11).latLng).toEqual([40, -100]);
+    expect(byNum(12).latLng).toEqual([41, -101]);
+    expect(byNum(13).latLng).toEqual([42, -102]);
+  });
+
+  it('offset is deterministic across renders (#4016)', () => {
+    mockUseDashboardUnifiedData.mockReturnValue({
+      nodes: [{ ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 }],
+    });
+    const first = renderHook(() => useAnalysisNodes(), { wrapper }).result.current[0].latLng;
+    const second = renderHook(() => useAnalysisNodes(), { wrapper }).result.current[0].latLng;
+    expect(first).toEqual(second);
+  });
+
   it('applies the config.sources allow-list', () => {
     localStorage.setItem(
       'mapAnalysis.config.v1',

--- a/src/components/MapAnalysis/useAnalysisNodes.ts
+++ b/src/components/MapAnalysis/useAnalysisNodes.ts
@@ -8,6 +8,7 @@ import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil'
 import { nodeMatchesSearch } from './nodeSearch';
 import { getNodeTypeCategory } from '../../utils/nodeTypeCategory';
 import { unifiedNodeKey } from '../../utils/nodeIdentity';
+import { shouldOffsetForPrecision, offsetWithinPrecisionCell } from '../../utils/precisionOffset';
 import type { NodeSourceRef } from '../Dashboard/DashboardNodePopup';
 
 /**
@@ -32,6 +33,10 @@ export interface NodeRecord extends MaybePositionedNode {
   sources?: NodeSourceRef[];
   /** MeshCore public key; needed by `unifiedNodeKey` for cross-source selection identity (#3788). */
   publicKey?: string | null;
+  /** Meshtastic obscured-position precision (0–32 bits); drives the #4016 within-cell offset. */
+  positionPrecisionBits?: number | null;
+  /** True when the position is a user override — excluded from the #4016 offset. */
+  positionIsOverride?: boolean | null;
 }
 
 export interface AnalysisNode {
@@ -87,7 +92,18 @@ export function useAnalysisNodes(): AnalysisNode[] {
           return nodeSourceIds.some((id) => config.sources.includes(id));
         },
       )
-      .map(({ node, latLng }) => ({ node, latLng, key: unifiedNodeKey(node) }))
+      .map(({ node, latLng }) => {
+        const key = unifiedNodeKey(node);
+        // #4016: obscured low-precision nodes are deterministically offset within
+        // their accuracy cell so they don't imply false precision or stack on one
+        // point. Applied here (the single latLng source) so markers, Follow,
+        // bounds, the measurement tool, and the popup all use the same position.
+        const bits = node.positionPrecisionBits;
+        const finalLatLng = shouldOffsetForPrecision(bits, node.positionIsOverride)
+          ? offsetWithinPrecisionCell(latLng[0], latLng[1], bits as number, key ?? String(node.nodeNum))
+          : latLng;
+        return { node, latLng: finalLatLng, key };
+      })
       .filter((entry): entry is AnalysisNode => entry.key !== null);
   }, [nodes, nodeFilter, config.nodeTypes, config.sources]);
 }

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -10,7 +10,8 @@ export type LayerKey =
   | 'hopShading'
   | 'snrOverlay'
   | 'waypoints'
-  | 'polarGrid';
+  | 'polarGrid'
+  | 'accuracyRegions';
 
 export interface LayerConfig {
   enabled: boolean;
@@ -73,6 +74,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
     snrOverlay: { enabled: false, lookbackHours: null },
     waypoints:  { enabled: true,  lookbackHours: null },
     polarGrid:  { enabled: false, lookbackHours: null },
+    accuracyRegions: { enabled: false, lookbackHours: null },
   },
   nodeTypes: { ...ALL_NODE_TYPES_VISIBLE },
   sources: [],

--- a/src/utils/precisionOffset.test.ts
+++ b/src/utils/precisionOffset.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  precisionCellSizeMeters,
+  precisionCellSizeDegrees,
+  shouldOffsetForPrecision,
+  offsetWithinPrecisionCell,
+  OBSCURED_PRECISION_MAX_BITS,
+} from './precisionOffset';
+
+describe('precisionCellSizeMeters', () => {
+  it('matches the accuracy-region formula at representative bit widths', () => {
+    // 18 bits → ~182m cell side.
+    expect(precisionCellSizeMeters(18)).toBeCloseTo(182.0, 0);
+    // 16 bits → ~728m.
+    expect(precisionCellSizeMeters(16)).toBeCloseTo(728.2, 0);
+    // Each bit lost doubles the cell.
+    expect(precisionCellSizeMeters(17) / precisionCellSizeMeters(18)).toBeCloseTo(2, 5);
+  });
+
+  it('degrees and meters agree via 111111 m/deg', () => {
+    expect(precisionCellSizeDegrees(18) * 111_111).toBeCloseTo(precisionCellSizeMeters(18), 6);
+  });
+});
+
+describe('shouldOffsetForPrecision', () => {
+  it('offsets only defined low precision (1..18) that is not overridden', () => {
+    expect(shouldOffsetForPrecision(16, false)).toBe(true);
+    expect(shouldOffsetForPrecision(1, false)).toBe(true);
+    expect(shouldOffsetForPrecision(OBSCURED_PRECISION_MAX_BITS, false)).toBe(true);
+  });
+
+  it('does not offset fine precision, missing, zero, or overridden nodes', () => {
+    expect(shouldOffsetForPrecision(19, false)).toBe(false); // just above threshold
+    expect(shouldOffsetForPrecision(32, false)).toBe(false); // full precision
+    expect(shouldOffsetForPrecision(0, false)).toBe(false);  // disabled/unknown cell
+    expect(shouldOffsetForPrecision(null, false)).toBe(false);
+    expect(shouldOffsetForPrecision(undefined, false)).toBe(false);
+    expect(shouldOffsetForPrecision(16, true)).toBe(false);  // user-overridden position
+  });
+});
+
+describe('offsetWithinPrecisionCell', () => {
+  const lat = 40;
+  const lng = -105;
+  const bits = 16;
+
+  it('is deterministic for a given id', () => {
+    const a = offsetWithinPrecisionCell(lat, lng, bits, 'node-a');
+    const b = offsetWithinPrecisionCell(lat, lng, bits, 'node-a');
+    expect(a).toEqual(b);
+  });
+
+  it('produces different offsets for different ids', () => {
+    const a = offsetWithinPrecisionCell(lat, lng, bits, 'node-a');
+    const b = offsetWithinPrecisionCell(lat, lng, bits, 'node-b');
+    expect(a).not.toEqual(b);
+  });
+
+  it('keeps the marker inside the ± half-cell accuracy rectangle', () => {
+    const halfLat = precisionCellSizeDegrees(bits) / 2;
+    const halfLng = halfLat / Math.cos((lat * Math.PI) / 180);
+    for (const id of ['a', 'b', 'c', 'd', 'e', 'long-node-id-123', '']) {
+      const [oLat, oLng] = offsetWithinPrecisionCell(lat, lng, bits, id);
+      expect(Math.abs(oLat - lat)).toBeLessThanOrEqual(halfLat);
+      expect(Math.abs(oLng - lng)).toBeLessThanOrEqual(halfLng);
+    }
+  });
+
+  it('larger cells (fewer bits) produce larger offsets', () => {
+    const near = offsetWithinPrecisionCell(lat, lng, 18, 'same-id');
+    const far = offsetWithinPrecisionCell(lat, lng, 10, 'same-id');
+    const dNear = Math.abs(near[0] - lat);
+    const dFar = Math.abs(far[0] - lat);
+    expect(dFar).toBeGreaterThan(dNear);
+  });
+});

--- a/src/utils/precisionOffset.test.ts
+++ b/src/utils/precisionOffset.test.ts
@@ -3,6 +3,7 @@ import {
   precisionCellSizeMeters,
   precisionCellSizeDegrees,
   shouldOffsetForPrecision,
+  hasAccuracyCell,
   offsetWithinPrecisionCell,
   OBSCURED_PRECISION_MAX_BITS,
 } from './precisionOffset';
@@ -36,6 +37,29 @@ describe('shouldOffsetForPrecision', () => {
     expect(shouldOffsetForPrecision(null, false)).toBe(false);
     expect(shouldOffsetForPrecision(undefined, false)).toBe(false);
     expect(shouldOffsetForPrecision(16, true)).toBe(false);  // user-overridden position
+  });
+});
+
+describe('hasAccuracyCell', () => {
+  it('is true for any defined non-full precision (1..31), excluding overrides', () => {
+    expect(hasAccuracyCell(31, false)).toBe(true);   // medium precision still has a cell
+    expect(hasAccuracyCell(19, false)).toBe(true);   // above the offset threshold but still drawn
+    expect(hasAccuracyCell(16, false)).toBe(true);
+    expect(hasAccuracyCell(1, false)).toBe(true);
+  });
+
+  it('is false for full precision, zero, missing, or overridden nodes', () => {
+    expect(hasAccuracyCell(32, false)).toBe(false);
+    expect(hasAccuracyCell(0, false)).toBe(false);
+    expect(hasAccuracyCell(null, false)).toBe(false);
+    expect(hasAccuracyCell(undefined, false)).toBe(false);
+    expect(hasAccuracyCell(16, true)).toBe(false);
+  });
+
+  it('is a superset of shouldOffsetForPrecision', () => {
+    for (const bits of [1, 10, 18, 19, 25, 31]) {
+      if (shouldOffsetForPrecision(bits, false)) expect(hasAccuracyCell(bits, false)).toBe(true);
+    }
   });
 });
 

--- a/src/utils/precisionOffset.ts
+++ b/src/utils/precisionOffset.ts
@@ -1,0 +1,96 @@
+/**
+ * Deterministic within-cell offset for obscured (low-precision) GPS node markers
+ * on the Map Analysis map (issue #4016).
+ *
+ * Meshtastic's `precision_bits` snaps a reported position to a grid cell; the
+ * true position could be anywhere inside that cell. Rendering the marker at the
+ * dead-center of the cell implies precision the node never reported and stacks
+ * same-cell nodes on one point. Instead we deterministically jitter each such
+ * marker to a stable spot *within* its own cell — more honest, and it declutters
+ * same-cell piles without a click.
+ *
+ * The cell-size math mirrors the accuracy-region rectangle drawn on the Dashboard
+ * map (`DashboardMap.tsx`) and `formatPrecisionAccuracy` (`utils/distance.ts`),
+ * so an offset marker always lands inside the drawn rectangle.
+ */
+import { djb2Hash } from './loraFrequency';
+
+/** Meters per degree of latitude (matches DashboardMap / distance.ts). */
+const METERS_PER_DEGREE = 111_111;
+
+/**
+ * Precision bits at/below which the accuracy cell is large enough (~180m+) that
+ * centering is misleading and offsetting is worthwhile. At 18 bits the cell side
+ * is `2^(32-18) * 1e-7 * 111111 ≈ 182m`.
+ */
+export const OBSCURED_PRECISION_MAX_BITS = 18;
+
+/** Full accuracy-cell side length in meters for a given precision. */
+export function precisionCellSizeMeters(bits: number): number {
+  return Math.pow(2, 32 - bits) * 1e-7 * METERS_PER_DEGREE;
+}
+
+/** Full accuracy-cell side length in degrees of latitude. */
+export function precisionCellSizeDegrees(bits: number): number {
+  return Math.pow(2, 32 - bits) * 1e-7;
+}
+
+/**
+ * Whether a node's marker should be offset within its precision cell.
+ * Only nodes with a *defined* low precision (1..MAX bits) qualify; nodes with a
+ * user-overridden position, missing/zero precision, or fine GPS are left at their
+ * exact reported point.
+ */
+export function shouldOffsetForPrecision(
+  bits: number | null | undefined,
+  isOverride: boolean | null | undefined,
+): boolean {
+  if (isOverride) return false;
+  if (bits == null) return false;
+  return bits >= 1 && bits <= OBSCURED_PRECISION_MAX_BITS;
+}
+
+/**
+ * Accuracy-region rectangle bounds `[[latMin, lngMin], [latMax, lngMax]]` for a
+ * position at (lat, lng) with the given precision. The reported position is the
+ * cell center; the rectangle spans ± half a cell. Mirrors the Dashboard map's
+ * accuracy-region math so both maps draw the identical square.
+ */
+export function precisionCellBounds(
+  lat: number,
+  lng: number,
+  bits: number,
+): [[number, number], [number, number]] {
+  const halfMeters = precisionCellSizeMeters(bits) / 2;
+  const latOffset = halfMeters / METERS_PER_DEGREE;
+  const metersPerDegreeLng = METERS_PER_DEGREE * Math.cos((lat * Math.PI) / 180);
+  const lngOffset = metersPerDegreeLng !== 0 ? halfMeters / metersPerDegreeLng : halfMeters / METERS_PER_DEGREE;
+  return [
+    [lat - latOffset, lng - lngOffset],
+    [lat + latOffset, lng + lngOffset],
+  ];
+}
+
+/**
+ * Deterministically offset (lat, lng) to a stable point within the node's
+ * accuracy cell. The offset is a pure function of `id`, so it is identical across
+ * re-renders/polls (the marker never jumps). The result stays within
+ * `± halfCell` of the input — i.e. inside the accuracy rectangle.
+ */
+export function offsetWithinPrecisionCell(
+  lat: number,
+  lng: number,
+  bits: number,
+  id: string,
+): [number, number] {
+  const sizeDeg = precisionCellSizeDegrees(bits);
+  // Two independent fractions in [0,1) from one id.
+  const fx = (djb2Hash(id) % 1_000_000) / 1_000_000;
+  const fy = (djb2Hash(`${id}:y`) % 1_000_000) / 1_000_000;
+  const latOffset = (fx - 0.5) * sizeDeg;
+  const cosLat = Math.cos((lat * Math.PI) / 180);
+  // Longitude degrees shrink with latitude; guard the poles (cos→0).
+  const lngSizeDeg = cosLat !== 0 ? sizeDeg / cosLat : sizeDeg;
+  const lngOffset = (fy - 0.5) * lngSizeDeg;
+  return [lat + latOffset, lng + lngOffset];
+}

--- a/src/utils/precisionOffset.ts
+++ b/src/utils/precisionOffset.ts
@@ -36,6 +36,21 @@ export function precisionCellSizeDegrees(bits: number): number {
 }
 
 /**
+ * Whether a node has a meaningful accuracy cell to draw a rectangle for: a
+ * defined, non-full precision (1..31 bits) that isn't a user override. Broader
+ * than {@link shouldOffsetForPrecision} — the marker is only *offset* for large
+ * cells (≤18 bits), but the accuracy square is drawn for any imprecise fix.
+ */
+export function hasAccuracyCell(
+  bits: number | null | undefined,
+  isOverride: boolean | null | undefined,
+): boolean {
+  if (isOverride) return false;
+  if (bits == null) return false;
+  return bits > 0 && bits < 32;
+}
+
+/**
  * Whether a node's marker should be offset within its precision cell.
  * Only nodes with a *defined* low precision (1..MAX bits) qualify; nodes with a
  * user-overridden position, missing/zero precision, or fine GPS are left at their


### PR DESCRIPTION
Combined workstream for two related Map Analysis marker-overlap issues.

Closes #4015. Closes #4016.

## #4015 — popup opens on the spiderfy click, covering spread markers
On Map Analysis and the Dashboard/Unified map, clicking a pile of overlapping markers opened the marker's popup **and** fanned the pile out simultaneously — the popup rendered at the stacked position and covered the markers that just spread.

**Root cause:** Leaflet's `bindPopup` registers its own `click → _openPopup` listener that is unaware of the OverlappingMarkerSpiderfier (OMS). OMS's public `'click'` event only fires for a marker that is **already** spiderfied or standalone — never for the click that fans out a pile — but Leaflet's popup listener fires on every click regardless.

**Fix:** there's no react-leaflet prop to bind popup content but suppress auto-open, and removing `<Popup>` unbinds the React-rendered `DashboardNodePopup`. So: keep `<Popup>`, **strip Leaflet's auto-open listener** (`marker.off('click', marker._openPopup, marker)` in a parent effect that runs after the child popup binds), and open the popup **only** from the OMS `'click'` listener. A popup can now only open on a marker the user can already see distinctly.

Applied to `NodeMarkersLayer` (via the `useMarkerSpiderfier` hook's `addListener`) and `DashboardMap` (via the `SpiderfierController` ref).

## #4016 — declutter obscured low-precision markers on Map Analysis
Nodes reporting a low `precision_bits` were drawn dead-center in their snapped grid cell, implying precision the node never reported and stacking same-cell nodes on one point.

**Fix:** new pure `src/utils/precisionOffset.ts` deterministically jitters a marker to a stable point **within** its accuracy cell (djb2 hash of the node key), for **defined precision 1–18 bits** only — excluding user-overridden, full-precision, and missing-precision nodes (those stay at their exact point). Applied in `useAnalysisNodes` so markers, Follow, bounds, the measurement tool, and the popup all use the same position. Also ports Dashboard's accuracy-region rectangle to Map Analysis as a new **Accuracy Regions** layer (toolbar toggle), centered on the true reported position so the offset marker visibly sits inside its uncertainty square.

The two fixes complement each other: #4016 declutters obscured nodes at normal zoom; #4015 makes the residual click-to-spiderfy behave correctly.

## Notes
- **Frontend-only** — no backend/DB changes; `positionPrecisionBits`/`positionIsOverride` already reach the frontend (just added to the Map Analysis `NodeRecord` type).
- Offset scope + accuracy-rectangle inclusion were confirmed decisions for the issues' open questions (offset only known low-precision; also draw the rectangle).

## Testing
- New `precisionOffset.test.ts` (cell size, offset determinism/bounds, predicate), `AccuracyRegionsLayer.test.tsx`, and extended `useAnalysisNodes.test.tsx` (offset applied only for low-precision, non-override).
- The #4015 popup/OMS interaction requires real Leaflet/OMS (jsdom can't exercise it) — validated in-browser on the dev container.
- Full Vitest suite green (**success: true**, 0 failures), typecheck adds zero new errors, lint ratchet passes, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub