### PR TITLE
fix(meshcore): danger-command guard no longer fires on dotted config-path args

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
+++ b/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
@@ -168,7 +168,14 @@ DB by design, because the server uses those PSKs to decrypt packets).
 
 ## The danger guard
 
-Pattern: `/(reboot|erase|clkreboot|factory)/i`.
+Pattern: `/\b(reboot|erase|clkreboot|factory)\b(?!\.)/i`.
+
+The `(?!\.)` after the word boundary exists because these firmwares expose
+config keys as dotted paths that legitimately contain the danger words as
+a namespace prefix — e.g. `get reboot.interval` or `set clkreboot.retries
+3` — which are read/write config operations, not the destructive verb
+itself. Without the exclusion, any command referencing such a key (even a
+plain `get`) trips the confirmation prompt. See #4025.
 
 **Two independent enforcement points**, intentionally duplicated:
 

--- a/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
+++ b/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
@@ -192,8 +192,11 @@ still gets the prompt-as-requirement.
 
 **If you change the regex on one side, change it on the other.** The
 test `it.each([['reboot'],['Reboot'],['erase'],['clkreboot'],['factory reset'],['set factory mode']])`
-in `meshcoreRoutes.test.ts` catches a missed update on the server side;
-no equivalent test exists client-side, so be careful with the React file.
+in `meshcoreRoutes.test.ts` catches a missed update on the server side.
+`CliConsoleBody.test.tsx` mirrors the same cases (plus the dotted-path
+negatives from #4025) directly against the exported
+`DANGER_COMMAND_PATTERN` constant, so a drift between the two copies now
+fails on the client side too.
 
 ## Local vs remote dispatch
 

--- a/src/components/MeshCore/CliConsoleBody.test.tsx
+++ b/src/components/MeshCore/CliConsoleBody.test.tsx
@@ -8,7 +8,35 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { CliConsoleBody } from './CliConsoleBody';
+import { CliConsoleBody, DANGER_COMMAND_PATTERN } from './CliConsoleBody';
+
+// Mirrors the server-side DANGER_COMMAND_PATTERN suite in meshcoreRoutes.test.ts.
+// If this drifts from the server pattern, the client's confirm modal and the
+// server's defense-in-depth guard can disagree about what's destructive (#4025).
+describe('CliConsoleBody — DANGER_COMMAND_PATTERN', () => {
+  it.each([
+    ['reboot'],
+    ['Reboot'],
+    ['erase'],
+    ['clkreboot'],
+    ['factory reset'],
+    ['set factory mode'],
+  ])('flags danger command %s', (cmd) => {
+    expect(DANGER_COMMAND_PATTERN.test(cmd)).toBe(true);
+  });
+
+  it.each([
+    ['get reboot.interval'],
+    ['get erase.enabled'],
+    ['get clkreboot.retries'],
+    ['get factory.mode'],
+    ['set reboot.interval 30'],
+    ['ver'],
+    ['stats'],
+  ])('does not flag non-danger command %s', (cmd) => {
+    expect(DANGER_COMMAND_PATTERN.test(cmd)).toBe(false);
+  });
+});
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({

--- a/src/components/MeshCore/CliConsoleBody.tsx
+++ b/src/components/MeshCore/CliConsoleBody.tsx
@@ -42,8 +42,10 @@ export interface ActionCommand {
 }
 
 /** Server-enforced regex for danger commands. Mirrored from
- *  meshcoreRoutes.ts:DANGER_COMMAND_PATTERN; keep in sync. */
-export const DANGER_COMMAND_PATTERN = /(reboot|erase|clkreboot|factory)/i;
+ *  meshcoreRoutes.ts:DANGER_COMMAND_PATTERN; keep in sync. The trailing
+ *  `(?!\.)` excludes danger words used as the prefix of a dotted config
+ *  key (e.g. `get reboot.interval`), which are not the standalone verb. */
+export const DANGER_COMMAND_PATTERN = /\b(reboot|erase|clkreboot|factory)\b(?!\.)/i;
 
 export type CliRunResult =
   | { ok: true; reply: string; elapsedMs?: number }

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -787,6 +787,22 @@ describe('MeshCore Routes', () => {
         .send({ publicKey: validKey, command: 'stats' });
       expect(response.status).toBe(200);
     });
+
+    it.each([
+      ['get reboot.interval'],
+      ['get erase.enabled'],
+      ['get clkreboot.retries'],
+      ['get factory.mode'],
+      ['set reboot.interval 30'],
+    ])('does not require confirm for dotted config-path command %s (#4025)', async (cmd) => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/cli')
+        .send({ publicKey: validKey, command: cmd });
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.sendCliCommand).toHaveBeenCalledWith(validKey, cmd, {
+        timeoutMs: undefined,
+      });
+    });
   });
 
   describe('GET /api/sources/test-source/meshcore/admin/credentials-capability', () => {
@@ -894,6 +910,22 @@ describe('MeshCore Routes', () => {
         .send({ command: 'reboot', confirm: true });
       expect(response.status).toBe(200);
       expect(meshcoreManager.sendLocalCliCommand).toHaveBeenCalledWith('reboot', {
+        timeoutMs: undefined,
+      });
+    });
+
+    it.each([
+      ['get reboot.interval'],
+      ['get erase.enabled'],
+      ['get clkreboot.retries'],
+      ['get factory.mode'],
+      ['set reboot.interval 30'],
+    ])('does not require confirm for dotted config-path command %s (#4025)', async (cmd) => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: cmd });
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.sendLocalCliCommand).toHaveBeenCalledWith(cmd, {
         timeoutMs: undefined,
       });
     });

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -895,6 +895,7 @@ describe('MeshCore Routes', () => {
       ['erase'],
       ['clkreboot'],
       ['factory reset'],
+      ['set factory mode'],
     ])('rejects danger command %s without confirm', async (cmd) => {
       const response = await authenticatedAgent
         .post('/api/sources/test-source/meshcore/cli')

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2098,7 +2098,7 @@ router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermissio
     // confirmation modal for these commands, but server-side enforcement
     // means scripts and direct API calls cannot bypass the prompt by
     // simply not rendering it. Keep the pattern in sync with the
-    // client-side DANGER_COMMAND_PATTERN in MeshCoreRemoteConsole.tsx.
+    // client-side DANGER_COMMAND_PATTERN in CliConsoleBody.tsx.
     if (DANGER_COMMAND_PATTERN.test(command) && confirm !== true) {
       auditMeshcoreEvent(req, 'meshcore_remote_cli_blocked', 'remote_admin', {
         sourceId: req.params.id,

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -111,10 +111,14 @@ const VALIDATION = {
  * Destructive MeshCore CLI commands. Requests targeting any matching
  * command must carry `confirm: true` in the body or the /admin/cli route
  * rejects with DANGER_CONFIRM_REQUIRED. Keep in sync with the matching
- * pattern in MeshCoreRemoteConsole.tsx so the client knows which commands
- * to route through its typed-name confirmation modal.
+ * pattern in CliConsoleBody.tsx so the client knows which commands to
+ * route through its typed-name confirmation modal.
+ *
+ * The trailing `(?!\.)` excludes danger words used as the prefix of a
+ * dotted config key (e.g. `get reboot.interval`, `set clkreboot.retries 3`)
+ * — those are read/write config-path operations, not the standalone verb.
  */
-const DANGER_COMMAND_PATTERN = /(reboot|erase|clkreboot|factory)/i;
+const DANGER_COMMAND_PATTERN = /\b(reboot|erase|clkreboot|factory)\b(?!\.)/i;
 
 /**
  * Validation helper functions


### PR DESCRIPTION
## Summary

- Fixes #4025 — the MeshCore "Confirm destructive command" prompt fired for non-destructive commands like `get reboot.interval`, because `DANGER_COMMAND_PATTERN` (`/(reboot|erase|clkreboot|factory)/i`) did an unanchored substring match anywhere in the command string.
- MeshCore repeater/room-server CLIs expose config values as dotted paths (e.g. `reboot.interval`, `clkreboot.retries`), so any `get`/`set` against such a key — not just the standalone destructive verb — tripped the guard.
- Anchored the regex to a word boundary and excluded matches immediately followed by `.` (`/\b(reboot|erase|clkreboot|factory)\b(?!\.)/i`), since that shape only ever occurs as a dotted config-key namespace prefix, never the bare destructive verb.
- Applied identically to both enforcement points per `docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`: the server-side guard in `src/server/routes/meshcoreRoutes.ts` (`/admin/cli` and `/cli`) and the mirrored client-side regex in `src/components/MeshCore/CliConsoleBody.tsx` that gates the typed-name confirmation modal.
- Updated the dev-notes doc to explain the exclusion.

## Test plan

- [x] Added `it.each` regression cases to `meshcoreRoutes.test.ts` for both the remote (`/admin/cli`) and local (`/cli`) routes, covering `get reboot.interval`, `get erase.enabled`, `get clkreboot.retries`, `get factory.mode`, and `set reboot.interval 30` — all now pass through without requiring `confirm:true`.
- [x] Existing danger-command coverage (`reboot`, `Reboot`, `erase`, `clkreboot`, `factory reset`, `set factory mode`) still requires confirmation — unchanged behavior.
- [x] `npx vitest run src/server/routes/meshcoreRoutes.test.ts` — 206/206 passed.
- [x] `npx vitest run src/components/MeshCore/CliConsoleBody.test.tsx` — passed.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8ZQoFymAWbNkF3WXVyHhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8ZQoFymAWbNkF3WXVyHhe)_