### PR TITLE
fix(meshcore): remove non-functional Stats quick-action from remote console

### DIFF
--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -31,10 +31,15 @@ import './MeshCoreRemoteConsole.css';
  * Clicking a button pre-fills the command input — it does NOT auto-send,
  * so the user can edit before pressing Send and danger commands route
  * through the typed-name confirmation modal naturally.
+ *
+ * No `stats` entry: there is no bare `stats` verb in the firmware's CLI —
+ * only `stats-core`/`stats-radio`/`stats-packets`, all serial-only (same
+ * class of restriction as `get acl`, see MESHCORE_REMOTE_ADMIN.md). The
+ * working equivalent for a remote node is `MeshCoreRemoteStatsPanel` below,
+ * which fetches via the binary SendStatusReq instead of CLI text (#4026).
  */
 const REMOTE_ACTION_CATALOG: ActionCommand[] = [
   { key: 'ver',       labelKey: 'meshcore.remoteConsole.action.ver',       defaultLabel: 'Version',  command: 'ver' },
-  { key: 'stats',     labelKey: 'meshcore.remoteConsole.action.stats',     defaultLabel: 'Stats',    command: 'stats' },
   { key: 'neighbors', labelKey: 'meshcore.remoteConsole.action.neighbors', defaultLabel: 'Neighbors', command: 'neighbors' },
   { key: 'clock',     labelKey: 'meshcore.remoteConsole.action.clock',     defaultLabel: 'Clock',    command: 'clock' },
   { key: 'clock_sync', labelKey: 'meshcore.remoteConsole.action.clock_sync', defaultLabel: 'Sync clock', command: 'clock sync' },


### PR DESCRIPTION
## Summary
- Fixes #4026: the "Stats" quick-action button on the MeshCore remote-admin console pre-filled the literal CLI text `stats`, but MeshCore firmware has no bare `stats` verb — only `stats-core`/`stats-radio`/`stats-packets`, all documented as [Serial Only](https://docs.meshcore.io/cli_commands/). The button could never succeed over the mesh (encrypted `CliData` DM to a Repeater/Room Server).
- `MeshCoreRemoteStatsPanel` (mounted below the CLI box) already provides working remote stats via the binary `SendStatusReq`, so the broken CLI shortcut in `REMOTE_ACTION_CATALOG` (`src/components/MeshCore/MeshCoreRemoteConsole.tsx`) is simply removed, matching the existing precedent for `get acl` (also serial-only, deliberately never exposed as a remote quick-action — see `docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`).
- Scope is limited to the reported remote-console button. The local-console "Stats" quick actions are unaffected: the Companion device's synthetic CLI implements `stats` for real (`meshcoreManager.ts` `runSyntheticLocalCli`, `verb === 'stats'`), and the serial-connected Repeater/Room Server local console was not reported and is left out of scope for this fix.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/MeshCore/MeshCoreRemoteConsole.tsx` — clean
- [x] `npx vitest run` (full suite) — 8400 passed, 3 pre-existing failures in `mqttBrokerManager.test.ts` unrelated to this change (missing `protobufs/meshtastic/mesh.proto` in this sandbox; confirmed failing identically with the fix stashed out)
- [x] Targeted `MeshCoreRemoteConsole.test.tsx` / `CliConsoleBody.test.tsx` — pass, no test depended on the removed catalog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkfLGsjxynswefUgp9mMsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkfLGsjxynswefUgp9mMsE)_