### PR TITLE
chore(migrations): shared idempotency helpers + registry-derived count test (#3962)

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,13 +1,37 @@
+/**
+ * Registry-derived migration invariants.
+ *
+ * All structural assertions are derived from the registry at runtime — no
+ * hardcoded count or last-migration name.  Adding a new migration to
+ * migrations.ts does NOT require any changes to this file.
+ *
+ * Note: MigrationRegistry.register() already throws at module-load time if
+ * a migration is registered with a duplicate number or out of sequential
+ * order, so simply importing `registry` exercises those constraints.
+ */
 import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 112 migrations registered', () => {
-    expect(registry.count()).toBe(112);
+  it('highest migration number equals registry count (no gaps)', () => {
+    const all = registry.getAll();
+    expect(all.length).toBeGreaterThan(0);
+    expect(all[all.length - 1].number).toBe(all.length);
   });
 
-  // Bumping these counts: when adding a new migration, increment to <N>+1 and
-  // update the "last migration is …" assertion below.
+  it('migration names are unique', () => {
+    const all = registry.getAll();
+    const names = all.map((m) => m.name);
+    const uniqueNames = new Set(names);
+    expect(uniqueNames.size).toBe(names.length);
+  });
+
+  it('migrations are sequentially numbered from 1 to N', () => {
+    const all = registry.getAll();
+    for (let i = 0; i < all.length; i++) {
+      expect(all[i].number).toBe(i + 1);
+    }
+  });
 
   it('first migration is v37 baseline', () => {
     const all = registry.getAll();
@@ -15,24 +39,19 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_notes_to_nodes', () => {
-    const all = registry.getAll();
-    const last = all[all.length - 1];
-    expect(last.number).toBe(112);
-    expect(last.name).toContain('add_notes_to_nodes');
-  });
-
-  it('migrations are sequentially numbered from 1 to 112', () => {
-    const all = registry.getAll();
-    for (let i = 0; i < all.length; i++) {
-      expect(all[i].number).toBe(i + 1);
-    }
-  });
-
   it('all migrations have at least one function', () => {
     for (const m of registry.getAll()) {
       const hasFn = m.sqlite || m.postgres || m.mysql;
       expect(hasFn, `Migration ${m.number} (${m.name}) has no functions`).toBeTruthy();
+    }
+  });
+
+  it('all migrations have sqlite, postgres, and mysql functions', () => {
+    const all = registry.getAll();
+    for (const m of all) {
+      expect(m.sqlite, `Migration ${m.number} should have sqlite function`).toBeTruthy();
+      expect(m.postgres, `Migration ${m.number} should have postgres function`).toBeTruthy();
+      expect(m.mysql, `Migration ${m.number} should have mysql function`).toBeTruthy();
     }
   });
 
@@ -49,19 +68,10 @@ describe('migrations registry', () => {
     }
   });
 
-  it('migrations 002-013 all have settingsKey', () => {
+  it('migrations 002+ all have settingsKey', () => {
     const all = registry.getAll();
     for (let i = 1; i < all.length; i++) {
       expect(all[i].settingsKey, `Migration ${all[i].number} should have settingsKey`).toBeTruthy();
-    }
-  });
-
-  it('all migrations have sqlite, postgres, and mysql functions', () => {
-    const all = registry.getAll();
-    for (const m of all) {
-      expect(m.sqlite, `Migration ${m.number} should have sqlite function`).toBeTruthy();
-      expect(m.postgres, `Migration ${m.number} should have postgres function`).toBeTruthy();
-      expect(m.mysql, `Migration ${m.number} should have mysql function`).toBeTruthy();
     }
   });
 });

--- a/src/server/migrations/helpers.test.ts
+++ b/src/server/migrations/helpers.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for migration idempotency helpers.
+ *
+ * SQLite tests use an in-memory Database instance so they exercise real SQL.
+ * PostgreSQL and MySQL tests use minimal mock objects and assert on the SQL
+ * emitted, since spinning up live engines is out-of-scope for unit tests.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+  createTableIfMissingMysql,
+} from './helpers.js';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function columnNames(db: Database.Database, table: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+/**
+ * Builds a mysql2-Pool-alike mock.
+ *
+ * @param existingColumns - column names that the information_schema mock
+ *   should report as already present (for COLUMNS queries).
+ * @param existingTables  - table names that the information_schema mock
+ *   should report as already present (for TABLES queries).
+ */
+function makeMysqlPool(
+  existingColumns: string[] = [],
+  existingTables: string[] = [],
+): { pool: any; conn: any } {
+  const conn = {
+    query: vi.fn().mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('information_schema.COLUMNS')) {
+        const col = Array.isArray(params) ? (params[1] as string) : '';
+        return [existingColumns.includes(col) ? [{ COLUMN_NAME: col }] : []];
+      }
+      if (sql.includes('information_schema.TABLES')) {
+        const tbl = Array.isArray(params) ? (params[0] as string) : '';
+        return [existingTables.includes(tbl) ? [{ TABLE_NAME: tbl }] : []];
+      }
+      return [{ affectedRows: 0 }];
+    }),
+    release: vi.fn(),
+  };
+  const pool = { getConnection: vi.fn().mockResolvedValue(conn) };
+  return { pool, conn };
+}
+
+// ─── addColumnIfMissing (SQLite) ──────────────────────────────────────────────
+
+describe('addColumnIfMissing (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`CREATE TABLE nodes (id INTEGER PRIMARY KEY, name TEXT)`);
+  });
+
+  it('adds the column when it does not exist', () => {
+    expect(columnNames(db, 'nodes')).not.toContain('notes');
+    addColumnIfMissing(db, 'nodes', 'notes', 'notes TEXT');
+    expect(columnNames(db, 'nodes')).toContain('notes');
+  });
+
+  it('is idempotent — second call is a no-op', () => {
+    addColumnIfMissing(db, 'nodes', 'notes', 'notes TEXT');
+    expect(() => addColumnIfMissing(db, 'nodes', 'notes', 'notes TEXT')).not.toThrow();
+    expect(columnNames(db, 'nodes')).toContain('notes');
+  });
+
+  it('adds a column with a DEFAULT value', () => {
+    addColumnIfMissing(db, 'nodes', 'count', 'count INTEGER DEFAULT 0');
+    db.prepare(`INSERT INTO nodes (name) VALUES ('test')`).run();
+    const row = db.prepare(`SELECT count FROM nodes WHERE name = 'test'`).get() as { count: number };
+    expect(row.count).toBe(0);
+  });
+
+  it('re-throws errors that are not duplicate-column', () => {
+    expect(() =>
+      addColumnIfMissing(db, 'nonexistent_table', 'col', 'col TEXT'),
+    ).toThrow();
+  });
+});
+
+// ─── addColumnIfMissingPostgres ───────────────────────────────────────────────
+
+describe('addColumnIfMissingPostgres', () => {
+  it('issues ADD COLUMN IF NOT EXISTS with the provided DDL', async () => {
+    const client = { query: vi.fn().mockResolvedValue(undefined) };
+    await addColumnIfMissingPostgres(client, 'nodes', 'notes', '"notes" TEXT');
+    expect(client.query).toHaveBeenCalledWith(
+      'ALTER TABLE nodes ADD COLUMN IF NOT EXISTS "notes" TEXT',
+    );
+  });
+
+  it('propagates query errors', async () => {
+    const client = { query: vi.fn().mockRejectedValue(new Error('pg error')) };
+    await expect(
+      addColumnIfMissingPostgres(client, 'nodes', 'notes', '"notes" TEXT'),
+    ).rejects.toThrow('pg error');
+  });
+});
+
+// ─── addColumnIfMissingMysql ──────────────────────────────────────────────────
+
+describe('addColumnIfMissingMysql', () => {
+  it('issues ALTER TABLE when the column is absent', async () => {
+    const { pool, conn } = makeMysqlPool(/* no existing columns */);
+    await addColumnIfMissingMysql(pool, 'nodes', 'notes', 'notes VARCHAR(2000)');
+
+    // information_schema check
+    expect(conn.query).toHaveBeenCalledWith(
+      expect.stringContaining('information_schema.COLUMNS'),
+      ['nodes', 'notes'],
+    );
+    // ALTER TABLE issued
+    expect(conn.query).toHaveBeenCalledWith(
+      'ALTER TABLE nodes ADD COLUMN notes VARCHAR(2000)',
+    );
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('skips ALTER TABLE when the column already exists', async () => {
+    const { pool, conn } = makeMysqlPool(['notes']);
+    await addColumnIfMissingMysql(pool, 'nodes', 'notes', 'notes VARCHAR(2000)');
+
+    // Only one query: the information_schema check
+    expect(conn.query).toHaveBeenCalledTimes(1);
+    expect(conn.query).toHaveBeenCalledWith(
+      expect.stringContaining('information_schema.COLUMNS'),
+      ['nodes', 'notes'],
+    );
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('releases the connection even when ALTER TABLE throws', async () => {
+    const conn = {
+      query: vi.fn().mockImplementation(async (sql: string) => {
+        if (sql.includes('information_schema')) return [[]];
+        throw new Error('alter failed');
+      }),
+      release: vi.fn(),
+    };
+    const pool = { getConnection: vi.fn().mockResolvedValue(conn) };
+
+    await expect(
+      addColumnIfMissingMysql(pool, 'nodes', 'notes', 'notes VARCHAR(2000)'),
+    ).rejects.toThrow('alter failed');
+    expect(conn.release).toHaveBeenCalled();
+  });
+});
+
+// ─── createTableIfMissingMysql ────────────────────────────────────────────────
+
+describe('createTableIfMissingMysql', () => {
+  const DDL = `CREATE TABLE my_events (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    sourceId VARCHAR(255) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    INDEX my_events_src_idx (sourceId, timestamp)
+  )`;
+
+  it('issues CREATE TABLE when the table is absent', async () => {
+    const { pool, conn } = makeMysqlPool([], /* no existing tables */ []);
+    await createTableIfMissingMysql(pool, 'my_events', DDL);
+
+    expect(conn.query).toHaveBeenCalledWith(
+      expect.stringContaining('information_schema.TABLES'),
+      ['my_events'],
+    );
+    expect(conn.query).toHaveBeenCalledWith(DDL);
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('skips CREATE TABLE when the table already exists', async () => {
+    const { pool, conn } = makeMysqlPool([], ['my_events']);
+    await createTableIfMissingMysql(pool, 'my_events', DDL);
+
+    // Only one query: the information_schema check
+    expect(conn.query).toHaveBeenCalledTimes(1);
+    expect(conn.query).toHaveBeenCalledWith(
+      expect.stringContaining('information_schema.TABLES'),
+      ['my_events'],
+    );
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('releases the connection even when CREATE TABLE throws', async () => {
+    const conn = {
+      query: vi.fn().mockImplementation(async (sql: string) => {
+        if (sql.includes('information_schema')) return [[]];
+        throw new Error('create failed');
+      }),
+      release: vi.fn(),
+    };
+    const pool = { getConnection: vi.fn().mockResolvedValue(conn) };
+
+    await expect(
+      createTableIfMissingMysql(pool, 'my_events', DDL),
+    ).rejects.toThrow('create failed');
+    expect(conn.release).toHaveBeenCalled();
+  });
+});

--- a/src/server/migrations/helpers.ts
+++ b/src/server/migrations/helpers.ts
@@ -1,0 +1,195 @@
+/**
+ * Migration idempotency helpers.
+ *
+ * Use these in NEW migrations instead of hand-rolling the three-idiom
+ * per-dialect try/catch / IF NOT EXISTS / information_schema patterns.
+ * Do NOT apply to existing migrations — history must stay intact.
+ *
+ * # SQLite
+ *   `addColumnIfMissing(db, table, column, ddl)` — catches the
+ *   "duplicate column" error that SQLite raises when the column already
+ *   exists; re-throws anything else.
+ *
+ * # PostgreSQL
+ *   `addColumnIfMissingPostgres(client, table, column, ddl)` — delegates to
+ *   the native `ADD COLUMN IF NOT EXISTS` clause; one round-trip, no
+ *   information_schema pre-check needed.
+ *   SQLite and PostgreSQL both support `CREATE TABLE IF NOT EXISTS` and
+ *   `CREATE INDEX IF NOT EXISTS` natively, so no table/index helpers are
+ *   provided for those dialects.
+ *
+ * # MySQL
+ *   `addColumnIfMissingMysql(pool, table, column, ddl)` — queries
+ *   `information_schema.COLUMNS` before issuing `ALTER TABLE`.
+ *   `createTableIfMissingMysql(pool, table, createDdl)` — queries
+ *   `information_schema.TABLES` before issuing `CREATE TABLE`.
+ *   MySQL has no `CREATE INDEX IF NOT EXISTS` syntax; add indexes inline
+ *   in the `CREATE TABLE` DDL passed to `createTableIfMissingMysql` (the
+ *   same technique used by existing migrations 108 / 110).
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ─── SQLite ────────────────────────────────────────────────────────────────────
+
+/**
+ * Idempotently adds a column to an existing SQLite table.
+ *
+ * SQLite does not support `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, so this
+ * helper catches the "duplicate column" error and treats it as a no-op.
+ * All other errors are re-thrown.
+ *
+ * @param db     - better-sqlite3 Database instance
+ * @param table  - Table name
+ * @param column - Column name (used in log messages only)
+ * @param ddl    - Full column definition **including** the column name,
+ *                 e.g. `'notes TEXT'`, `'positionSource TEXT'`,
+ *                 `'count INTEGER DEFAULT 0'`
+ *
+ * @example
+ * addColumnIfMissing(db, 'nodes', 'notes', 'notes TEXT');
+ * addColumnIfMissing(db, 'nodes', 'isUnmessagable', 'isUnmessagable INTEGER DEFAULT 0');
+ */
+export function addColumnIfMissing(
+  db: Database,
+  table: string,
+  column: string,
+  ddl: string,
+): void {
+  try {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${ddl}`);
+    logger.debug(`Migration helper (SQLite): added ${table}.${column}`);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- caught error shape unknown
+  } catch (e: any) {
+    if (e.message?.includes('duplicate column')) {
+      logger.debug(`Migration helper (SQLite): ${table}.${column} already present, skipping`);
+    } else {
+      throw e;
+    }
+  }
+}
+
+// ─── PostgreSQL ────────────────────────────────────────────────────────────────
+
+/**
+ * Idempotently adds a column to an existing PostgreSQL table.
+ *
+ * Delegates to the native `ADD COLUMN IF NOT EXISTS` syntax — a single
+ * round-trip with no information_schema pre-check required.
+ *
+ * @param client - pg PoolClient (within a transaction or direct)
+ * @param table  - Table name
+ * @param column - Column name (used in log messages only)
+ * @param ddl    - Full column definition **including** the (quoted) column
+ *                 name, e.g. `'"notes" TEXT'`, `'"positionSource" TEXT'`,
+ *                 `'"count" INTEGER DEFAULT 0'`
+ *
+ * @example
+ * await addColumnIfMissingPostgres(client, 'nodes', 'notes', '"notes" TEXT');
+ */
+export async function addColumnIfMissingPostgres(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pg PoolClient: tight coupling to pg package not warranted in helpers
+  client: any,
+  table: string,
+  column: string,
+  ddl: string,
+): Promise<void> {
+  await client.query(`ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS ${ddl}`);
+  logger.debug(`Migration helper (PostgreSQL): ensured ${table}.${column}`);
+}
+
+// ─── MySQL ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Idempotently adds a column to an existing MySQL table.
+ *
+ * MySQL lacks `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, so this helper
+ * queries `information_schema.COLUMNS` first and skips the `ALTER TABLE`
+ * if the column is already present.  The connection is always released in a
+ * `finally` block.
+ *
+ * @param pool   - mysql2 Pool
+ * @param table  - Table name
+ * @param column - Column name (used in the information_schema query and logs)
+ * @param ddl    - Full column definition **including** the column name,
+ *                 e.g. `'notes VARCHAR(2000)'`, `'positionSource VARCHAR(16)'`,
+ *                 `'count INT DEFAULT 0'`
+ *
+ * @example
+ * await addColumnIfMissingMysql(pool, 'nodes', 'notes', 'notes VARCHAR(2000)');
+ */
+export async function addColumnIfMissingMysql(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mysql2 Pool: tight coupling not warranted in helpers
+  pool: any,
+  table: string,
+  column: string,
+  ddl: string,
+): Promise<void> {
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [table, column],
+    );
+    if (Array.isArray(rows) && rows.length === 0) {
+      await conn.query(`ALTER TABLE ${table} ADD COLUMN ${ddl}`);
+      logger.debug(`Migration helper (MySQL): added ${table}.${column}`);
+    } else {
+      logger.debug(`Migration helper (MySQL): ${table}.${column} already present, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}
+
+/**
+ * Idempotently creates a MySQL table only if it does not already exist.
+ *
+ * Queries `information_schema.TABLES` before issuing `CREATE TABLE` so the
+ * outcome is logged clearly.  The connection is always released in a
+ * `finally` block.
+ *
+ * Because MySQL has no `CREATE INDEX IF NOT EXISTS` syntax, add any required
+ * indexes as inline `INDEX` / `UNIQUE KEY` clauses inside the `CREATE TABLE`
+ * DDL (the same technique used by existing migrations 108 and 110).
+ *
+ * @param pool      - mysql2 Pool
+ * @param table     - Table name (used in the information_schema query and logs)
+ * @param createDdl - Full `CREATE TABLE tableName (…)` statement.
+ *                    Include inline `INDEX` / `UNIQUE KEY` clauses here.
+ *
+ * @example
+ * await createTableIfMissingMysql(pool, 'my_events', `
+ *   CREATE TABLE my_events (
+ *     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+ *     sourceId VARCHAR(255) NOT NULL,
+ *     timestamp BIGINT NOT NULL,
+ *     INDEX my_events_source_idx (sourceId, timestamp)
+ *   )
+ * `);
+ */
+export async function createTableIfMissingMysql(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mysql2 Pool: tight coupling not warranted in helpers
+  pool: any,
+  table: string,
+  createDdl: string,
+): Promise<void> {
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT TABLE_NAME FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+      [table],
+    );
+    if (Array.isArray(rows) && rows.length === 0) {
+      await conn.query(createDdl);
+      logger.debug(`Migration helper (MySQL): created table ${table}`);
+    } else {
+      logger.debug(`Migration helper (MySQL): table ${table} already exists, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}


### PR DESCRIPTION
## Summary

Task **3.5** of the remediation plan (#3962, Phase 3). Sequenced before 3.3 so its schema-bootstrap migrations use these helpers.

- **New `src/server/migrations/helpers.ts`** — four per-dialect idempotency helpers encoding the exact idioms extracted from recent migrations (108–112): `addColumnIfMissing` (SQLite try/catch duplicate-column), `addColumnIfMissingPostgres` (native `IF NOT EXISTS`), `addColumnIfMissingMysql` (information_schema pre-check, parameterized, connection released in finally), `createTableIfMissingMysql` (information_schema TABLES pre-check). For NEW migrations only — history untouched. 13 unit tests.
- **The migration-count merge magnet is dead**: `migrations.test.ts` no longer hardcodes a count or last-migration name. Registry-derived invariants (highest number == count, sequential from 1, unique names) mean the file never needs editing when a migration is added — and `register()` already throws at module load for duplicates/gaps.
- CLAUDE.md migration recipe updated (helpers documented; the "update the count test" step removed; hardcoded count line de-load-beared).
- Epic doc: 3.5 checked; 3.1 PR3 recorded as #4032.

## Verification

Independent orchestrator run: full suite **8513 passed, 0 failed, 0 suite failures**; typecheck clean; test-typecheck at 283 baseline; lint ratchet green; build verified.

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n