### PR TITLE
fix(virtual-node): fall back to persisted modem preset for slot-0 channel name

### DIFF
--- a/src/server/virtualNodeServer.channelPresetFallback.test.ts
+++ b/src/server/virtualNodeServer.channelPresetFallback.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for issue #4037 — Virtual Node clients briefly lost the
+ * slot-0 channel display name ("Long Fast" -> generic "Channel 0") whenever
+ * config was requested in the window right after a physical-node disconnect.
+ *
+ * `sendChannelsFromDb()` derives the slot-0 name fallback from
+ * `meshtasticManager.getActualDeviceConfig()?.lora?.modemPreset`, an
+ * in-memory value that `handleDisconnected()` nulls out on every physical
+ * disconnect (non-passive mode) until the device re-sends LoRa config on
+ * reconnect. A Virtual Node client requesting config during that window used
+ * to get slot 0 with no name at all. It must now fall back to the durable
+ * per-source `lora.preset.<sourceId>` setting (the same one channelRoutes.ts,
+ * unifiedRoutes.ts, and sourceDashboardData.ts already use for this exact
+ * fallback) so the name survives the gap.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    channels: {
+      getAllChannels: vi.fn(),
+    },
+    nodes: {
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+    },
+    getSettingAsync: vi.fn(),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    createChannel: vi.fn(async (opts: any) => new Uint8Array([opts.settings?.name ? 1 : 0])),
+  },
+}));
+
+import databaseService from '../services/database.js';
+import meshtasticProtobufService from './meshtasticProtobufService.js';
+import { VirtualNodeServer } from './virtualNodeServer.js';
+
+function makeFakeManager(sourceId: string, actualDeviceConfig: any) {
+  return {
+    sourceId,
+    getLocalNodeInfo: () => ({ nodeNum: 0x11223344, nodeId: '!11223344' }),
+    getActualDeviceConfig: () => actualDeviceConfig,
+  } as any;
+}
+
+function attachFakeClient(vn: VirtualNodeServer, clientId: string) {
+  const socket = { destroyed: false, writable: true, write: (_frame: unknown, cb: (err?: Error) => void) => cb() };
+  (vn as any).clients.set(clientId, {
+    socket,
+    id: clientId,
+    buffer: Buffer.alloc(0),
+    connectedAt: new Date(),
+    lastActivity: new Date(),
+  });
+}
+
+describe('VirtualNodeServer.sendChannelsFromDb() — issue #4037 preset-name fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('falls back to the persisted lora.preset.<sourceId> setting when live device config is unavailable (post-disconnect)', async () => {
+    const sourceId = 'src-1';
+    (databaseService.channels.getAllChannels as any).mockResolvedValue([
+      { id: 0, name: '', role: 1, psk: null, uplinkEnabled: false, downlinkEnabled: false, positionPrecision: undefined },
+    ]);
+    // Simulates the persisted setting written by persistModemPreset() —
+    // durable across the actualDeviceConfig=null gap left by handleDisconnected().
+    (databaseService.getSettingAsync as any).mockImplementation((key: string) =>
+      Promise.resolve(key === `lora.preset.${sourceId}` ? '0' /* LONG_FAST */ : null)
+    );
+
+    // actualDeviceConfig is null — mirrors the state right after a physical
+    // disconnect, before the device has re-sent LoRa config.
+    const manager = makeFakeManager(sourceId, null);
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    const result = await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(result).toEqual({ sent: 1, disconnected: false });
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: 'LongFast' }) })
+    );
+  });
+
+  it('prefers the live device config over the persisted setting when both are available', async () => {
+    const sourceId = 'src-1';
+    (databaseService.channels.getAllChannels as any).mockResolvedValue([
+      { id: 0, name: '', role: 1, psk: null, uplinkEnabled: false, downlinkEnabled: false, positionPrecision: undefined },
+    ]);
+    (databaseService.getSettingAsync as any).mockImplementation((key: string) =>
+      Promise.resolve(key === `lora.preset.${sourceId}` ? '0' /* LongFast */ : null)
+    );
+
+    // Live config says MediumFast (4) — should win over the persisted LongFast (0).
+    const manager = makeFakeManager(sourceId, { lora: { modemPreset: 4 } });
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: 'MediumFast' }) })
+    );
+  });
+
+  it('leaves the name undefined when neither live config nor a persisted preset is known', async () => {
+    const sourceId = 'src-1';
+    (databaseService.channels.getAllChannels as any).mockResolvedValue([
+      { id: 0, name: '', role: 1, psk: null, uplinkEnabled: false, downlinkEnabled: false, positionPrecision: undefined },
+    ]);
+    (databaseService.getSettingAsync as any).mockResolvedValue(null);
+
+    const manager = makeFakeManager(sourceId, null);
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: undefined }) })
+    );
+  });
+});

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -7,6 +7,7 @@ import protobufService from './protobufService.js';
 import { MeshtasticManager } from './meshtasticManager.js';
 import databaseService from '../services/database.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
+import { modemPresetChannelName } from './constants/meshtastic.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
@@ -761,7 +762,26 @@ export class VirtualNodeServer extends EventEmitter {
     // channel entries (otherwise uplink_enabled defaults to false and every
     // packet is dropped).
     const deviceConfig = this.config.meshtasticManager.getActualDeviceConfig?.();
-    const presetFallback = getPrimaryChannelNameFallback(deviceConfig?.lora?.modemPreset);
+    let presetFallback = getPrimaryChannelNameFallback(deviceConfig?.lora?.modemPreset);
+
+    // getActualDeviceConfig() is in-memory only and is cleared to null on
+    // every physical-node disconnect (meshtasticManager.ts handleDisconnected,
+    // non-passive mode) until the device re-sends LoRa config on reconnect.
+    // A client requesting config during that window would otherwise get slot
+    // 0 with no name at all (not even the preset fallback), which the
+    // Meshtastic app displays as the placeholder "Channel 0" (#4037). Fall
+    // back to the durable per-source `lora.preset.<sourceId>` setting that
+    // every other consumer of this fallback already uses (channelRoutes.ts,
+    // unifiedRoutes.ts, sourceDashboardData.ts).
+    if (!presetFallback) {
+      try {
+        const raw = await databaseService.getSettingAsync(`lora.preset.${sourceId}`);
+        const n = raw != null ? Number(raw) : NaN;
+        if (Number.isFinite(n)) presetFallback = modemPresetChannelName(n) ?? undefined;
+      } catch (err) {
+        logger.debug(`Virtual node: Failed to load persisted modem preset for source ${sourceId}:`, err);
+      }
+    }
 
     let sent = 0;
     for (const ch of dbChannels) {


### PR DESCRIPTION
## Summary

Fixes the channel-name-loss half of #4037 ("Virtual Node issues (MQTT conn rejected, channel info lost)").

- `VirtualNodeServer.sendChannelsFromDb()` derives the slot-0 channel-name fallback (e.g. `"LongFast"`) from `meshtasticManager.getActualDeviceConfig()?.lora?.modemPreset` — an **in-memory** value.
- `handleDisconnected()` (`src/server/meshtasticManager.ts:1691`) nulls `actualDeviceConfig` on every physical-node disconnect (non-passive mode) and only repopulates it once the device re-sends LoRa `config` on reconnect.
- A Virtual Node client (e.g. the Meshtastic Android app) that requests config in that window gets slot 0 with **no name at all** — not even the preset fallback — which the app renders as the generic placeholder `"Channel 0"` instead of the real name.
- This is consistent with the reporter's `ble-bridge` connection type, which is more prone to brief reconnects than a direct WiFi/TCP link, matching the "happens multiple times daily" pattern.
- The codebase already persists exactly this fallback durably, per-source, as the `lora.preset.<sourceId>` setting (`persistModemPreset()`), and every *other* consumer of this fallback (`channelRoutes.ts`, `unifiedRoutes.ts`, `sourceDashboardData.ts`) already reads it that way — `virtualNodeServer.ts` was the one holdout still reading the volatile in-memory value with no fallback.

## Fix

`sendChannelsFromDb()` now falls back to the persisted `lora.preset.<sourceId>` setting (via the shared `modemPresetChannelName()` helper) whenever the live in-memory device config doesn't have a modem preset available — matching the pattern used elsewhere in the codebase. The live value is still preferred when present (freshest).

## Test plan

- [x] Added `src/server/virtualNodeServer.channelPresetFallback.test.ts` — covers: (1) live config unavailable → falls back to persisted setting, (2) live config available → takes precedence, (3) neither available → name stays undefined (existing "Primary" placeholder behavior in the app, no regression).
- [x] `npx vitest run` on `virtualNodeServer*.test.ts`, `meshtasticManager.virtualNode*.test.ts`, `meshtasticManager.modemPreset.test.ts`, `channelRoutes.test.ts`, `unifiedRoutes.test.ts` — all passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — no new violations (2 pre-existing baselined errors in `virtualNodeServer.ts`, unrelated to this change, confirmed present before this diff too).

## Note

This PR addresses the **channel-name-loss** symptom only. The **"MQTT connection rejected (check credentials)"** symptom in #4037 needs more investigation (it may be the physical radio's own MQTT client status relayed as-is, or a related stale-cache issue during the same reconnect window) — following up separately on the issue.

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01F9xjPMz4TCpibuypWBJ1ND)_