### PR TITLE
refactor(db): migrate last sync-facade callers; extract node cache, mobility, traceroute-selection, packet-rate services (#3962)

### DIFF
--- a/src/db/repositories/telemetry.packetRates.test.ts
+++ b/src/db/repositories/telemetry.packetRates.test.ts
@@ -1,0 +1,154 @@
+/**
+ * TelemetryRepository.getPacketRates / computePacketRates tests
+ *
+ * Covers the packet-rate computation extracted from
+ * DatabaseService.getPacketRatesAsync (Phase 3.4, #3962):
+ *  - pure rate-delta edge cases (counter reset, stale gap, tiny interval)
+ *  - the Drizzle-backed repo query on SQLite (source scoping + since filter)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { TelemetryRepository } from './telemetry.js';
+import { ALL_SOURCES } from './base.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+const MINUTE = 60 * 1000;
+
+describe('TelemetryRepository.computePacketRates (pure)', () => {
+  const T0 = 1_700_000_000_000;
+
+  it('computes per-minute rates between consecutive samples', () => {
+    const rows = [
+      { telemetryType: 'packetsTx', timestamp: T0, value: 100 },
+      { telemetryType: 'packetsTx', timestamp: T0 + 10 * MINUTE, value: 150 },
+      { telemetryType: 'packetsTx', timestamp: T0 + 20 * MINUTE, value: 250 },
+    ];
+    const result = TelemetryRepository.computePacketRates(rows, ['packetsTx']);
+    expect(result.packetsTx).toHaveLength(2);
+    expect(result.packetsTx[0]).toEqual({ timestamp: T0 + 10 * MINUTE, ratePerMinute: 5 });
+    expect(result.packetsTx[1]).toEqual({ timestamp: T0 + 20 * MINUTE, ratePerMinute: 10 });
+  });
+
+  it('skips negative deltas (counter reset)', () => {
+    const rows = [
+      { telemetryType: 'packetsTx', timestamp: T0, value: 500 },
+      { telemetryType: 'packetsTx', timestamp: T0 + 10 * MINUTE, value: 20 }, // reboot reset
+      { telemetryType: 'packetsTx', timestamp: T0 + 20 * MINUTE, value: 120 },
+    ];
+    const result = TelemetryRepository.computePacketRates(rows, ['packetsTx']);
+    expect(result.packetsTx).toHaveLength(1);
+    expect(result.packetsTx[0].ratePerMinute).toBe(10);
+  });
+
+  it('skips gaps longer than 60 minutes', () => {
+    const rows = [
+      { telemetryType: 'packetsTx', timestamp: T0, value: 100 },
+      { telemetryType: 'packetsTx', timestamp: T0 + 61 * MINUTE, value: 200 }, // stale gap
+      { telemetryType: 'packetsTx', timestamp: T0 + 71 * MINUTE, value: 300 },
+    ];
+    const result = TelemetryRepository.computePacketRates(rows, ['packetsTx']);
+    expect(result.packetsTx).toHaveLength(1);
+    expect(result.packetsTx[0].timestamp).toBe(T0 + 71 * MINUTE);
+  });
+
+  it('skips intervals shorter than 0.1 minutes', () => {
+    const rows = [
+      { telemetryType: 'packetsTx', timestamp: T0, value: 100 },
+      { telemetryType: 'packetsTx', timestamp: T0 + 5_000, value: 105 }, // 5s — too small
+      { telemetryType: 'packetsTx', timestamp: T0 + 10 * MINUTE, value: 205 },
+    ];
+    const result = TelemetryRepository.computePacketRates(rows, ['packetsTx']);
+    expect(result.packetsTx).toHaveLength(1);
+    expect(result.packetsTx[0].timestamp).toBe(T0 + 10 * MINUTE);
+  });
+
+  it('returns empty arrays for requested types with no samples', () => {
+    const result = TelemetryRepository.computePacketRates([], ['packetsTx', 'packetsRx']);
+    expect(result).toEqual({ packetsTx: [], packetsRx: [] });
+  });
+
+  it('groups by telemetry type independently', () => {
+    const rows = [
+      { telemetryType: 'packetsTx', timestamp: T0, value: 100 },
+      { telemetryType: 'packetsRx', timestamp: T0, value: 10 },
+      { telemetryType: 'packetsTx', timestamp: T0 + 10 * MINUTE, value: 200 },
+      { telemetryType: 'packetsRx', timestamp: T0 + 10 * MINUTE, value: 40 },
+    ];
+    const result = TelemetryRepository.computePacketRates(rows, ['packetsTx', 'packetsRx']);
+    expect(result.packetsTx[0].ratePerMinute).toBe(10);
+    expect(result.packetsRx[0].ratePerMinute).toBe(3);
+  });
+});
+
+describe('TelemetryRepository.getPacketRates (SQLite)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: TelemetryRepository;
+
+  const NODE = '!aabbccdd';
+  const NODE_NUM = 0xaabbccdd;
+  const T0 = 1_700_000_000_000;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new TelemetryRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const insert = async (
+    telemetryType: string,
+    timestamp: number,
+    value: number,
+    sourceId: string
+  ) => {
+    await repo.insertTelemetry(
+      {
+        nodeId: NODE,
+        nodeNum: NODE_NUM,
+        telemetryType,
+        timestamp,
+        value,
+        unit: 'packets',
+        createdAt: timestamp,
+      },
+      sourceId
+    );
+  };
+
+  it('computes rates for a concrete sourceId, excluding other sources', async () => {
+    await insert('packetsTx', T0, 100, 'src-a');
+    await insert('packetsTx', T0 + 10 * MINUTE, 150, 'src-a');
+    // Same node via another source — must not pollute src-a's series
+    await insert('packetsTx', T0 + 5 * MINUTE, 9999, 'src-b');
+
+    const result = await repo.getPacketRates(NODE, ['packetsTx'], undefined, 'src-a');
+    expect(result.packetsTx).toHaveLength(1);
+    expect(result.packetsTx[0]).toEqual({ timestamp: T0 + 10 * MINUTE, ratePerMinute: 5 });
+  });
+
+  it('pools every source with ALL_SOURCES (legacy facade behavior)', async () => {
+    await insert('packetsTx', T0, 100, 'src-a');
+    await insert('packetsTx', T0 + 10 * MINUTE, 150, 'src-a');
+
+    const result = await repo.getPacketRates(NODE, ['packetsTx'], undefined, ALL_SOURCES);
+    expect(result.packetsTx).toHaveLength(1);
+  });
+
+  it('honors the sinceTimestamp lower bound', async () => {
+    await insert('packetsTx', T0, 100, 'src-a');
+    await insert('packetsTx', T0 + 10 * MINUTE, 150, 'src-a');
+    await insert('packetsTx', T0 + 20 * MINUTE, 250, 'src-a');
+
+    // Excluding the first sample leaves a single consecutive pair
+    const result = await repo.getPacketRates(NODE, ['packetsTx'], T0 + 10 * MINUTE, 'src-a');
+    expect(result.packetsTx).toHaveLength(1);
+    expect(result.packetsTx[0].timestamp).toBe(T0 + 20 * MINUTE);
+  });
+});

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -1524,4 +1524,97 @@ export class TelemetryRepository extends BaseRepository {
 
     return { nonFavoritesDeleted, favoritesDeleted };
   }
+
+  /**
+   * Compute per-type "packets per minute" rates from raw telemetry samples.
+   *
+   * Fetches the raw counter samples for `nodeId` across the given telemetry
+   * `types` (ordered oldest-first per type) and derives the rate between each
+   * consecutive pair. Backend-agnostic via Drizzle — replaces the raw-SQL
+   * getPacketRates that used to live on DatabaseService.
+   */
+  async getPacketRates(
+    nodeId: string,
+    types: string[],
+    sinceTimestamp?: number,
+    sourceId?: SourceScope
+  ): Promise<Record<string, Array<{ timestamp: number; ratePerMinute: number }>>> {
+    const { telemetry } = this.tables;
+
+    const conditions: SQL[] = [
+      eq(telemetry.nodeId, nodeId),
+      inArray(telemetry.telemetryType, types),
+    ];
+
+    if (sinceTimestamp !== undefined) {
+      conditions.push(gte(telemetry.timestamp, sinceTimestamp));
+    }
+
+    const sourceScope = this.withSourceScope(telemetry, sourceId);
+    if (sourceScope) conditions.push(sourceScope);
+
+    const rows = await this.db
+      .select({
+        telemetryType: telemetry.telemetryType,
+        timestamp: telemetry.timestamp,
+        value: telemetry.value,
+      })
+      .from(telemetry)
+      .where(and(...conditions))
+      .orderBy(sql`${telemetry.telemetryType} ASC, ${telemetry.timestamp} ASC`);
+
+    return TelemetryRepository.computePacketRates(
+      (rows as Array<{ telemetryType: unknown; timestamp: unknown; value: unknown }>).map((r) => ({
+        telemetryType: r.telemetryType as string,
+        timestamp: Number(r.timestamp),
+        value: Number(r.value),
+      })),
+      types
+    );
+  }
+
+  /**
+   * Pure rate calculation over pre-fetched, per-type-ordered samples. Groups
+   * rows by telemetry type, then computes the delta rate between consecutive
+   * samples. Skips counter resets (negative delta), stale gaps (> 60 min), and
+   * too-small intervals (< 0.1 min) to avoid division artifacts.
+   */
+  static computePacketRates(
+    rows: Array<{ telemetryType: string; timestamp: number; value: number }>,
+    types: string[]
+  ): Record<string, Array<{ timestamp: number; ratePerMinute: number }>> {
+    const result: Record<string, Array<{ timestamp: number; ratePerMinute: number }>> = {};
+    for (const type of types) {
+      result[type] = [];
+    }
+
+    const groupedByType: Record<string, Array<{ timestamp: number; value: number }>> = {};
+    for (const row of rows) {
+      if (!groupedByType[row.telemetryType]) {
+        groupedByType[row.telemetryType] = [];
+      }
+      groupedByType[row.telemetryType].push({
+        timestamp: Number(row.timestamp),
+        value: Number(row.value),
+      });
+    }
+
+    for (const [type, samples] of Object.entries(groupedByType)) {
+      const rates: Array<{ timestamp: number; ratePerMinute: number }> = [];
+      for (let i = 1; i < samples.length; i++) {
+        const deltaValue = samples[i].value - samples[i - 1].value;
+        const deltaTimeMs = samples[i].timestamp - samples[i - 1].timestamp;
+        const deltaTimeMinutes = deltaTimeMs / 60000;
+        if (deltaValue < 0) continue;
+        if (deltaTimeMinutes > 60) continue;
+        if (deltaTimeMinutes < 0.1) continue;
+        rates.push({
+          timestamp: samples[i].timestamp,
+          ratePerMinute: deltaValue / deltaTimeMinutes,
+        });
+      }
+      result[type] = rates;
+    }
+    return result;
+  }
 }

--- a/src/server/meshtasticManager.traceroute-hops.test.ts
+++ b/src/server/meshtasticManager.traceroute-hops.test.ts
@@ -42,6 +42,7 @@ vi.mock('../services/database.js', () => ({
     upsertNodeAsync: mockUpsertNode,
     insertMessage: mockInsertMessage,
     insertTraceroute: mockInsertTraceroute,
+    insertTracerouteAsync: mockInsertTraceroute,
     findUserByIdAsync: vi.fn(),
     findUserByUsernameAsync: vi.fn(),
     checkPermissionAsync: vi.fn(),

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7235,7 +7235,7 @@ class MeshtasticManager implements ISourceManager {
 
       // Use DatabaseService.insertTraceroute() (not repo directly) for deduplication:
       // It checks for pending traceroute requests and updates them instead of inserting duplicates
-      databaseService.insertTraceroute(tracerouteRecord, this.sourceId ?? undefined);
+      await databaseService.insertTracerouteAsync(tracerouteRecord, this.sourceId ?? undefined);
 
       // Store traceroute hop count as telemetry for Smart Hops tracking
       // Hop count is route.length + 1 (intermediate hops + final hop to destination)

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7233,7 +7233,7 @@ class MeshtasticManager implements ISourceManager {
         createdAt: Date.now()
       };
 
-      // Use DatabaseService.insertTraceroute() (not repo directly) for deduplication:
+      // Use DatabaseService.insertTracerouteAsync() (not repo directly) for deduplication:
       // It checks for pending traceroute requests and updates them instead of inserting duplicates
       await databaseService.insertTracerouteAsync(tracerouteRecord, this.sourceId ?? undefined);
 

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -10,8 +10,12 @@ const insertTelemetry = vi.fn();
 vi.mock('../services/database.js', () => ({
   default: {
     upsertNode: (...a: unknown[]) => upsertNode(...a),
+    upsertNodeAsync: async (...a: unknown[]) => upsertNode(...a),
     insertMessage: (...a: unknown[]) => insertMessage(...a),
     insertTelemetry: (...a: unknown[]) => insertTelemetry(...a),
+    insertTelemetryAsync: async (...a: unknown[]) => insertTelemetry(...a),
+    insertTracerouteAsync: vi.fn(async () => undefined),
+    insertRouteSegmentAsync: vi.fn(async () => undefined),
   },
 }));
 

--- a/src/server/mqttBrokerManager.test.ts
+++ b/src/server/mqttBrokerManager.test.ts
@@ -8,8 +8,12 @@ const insertTelemetry = vi.fn();
 vi.mock('../services/database.js', () => ({
   default: {
     upsertNode: (...a: unknown[]) => upsertNode(...a),
+    upsertNodeAsync: async (...a: unknown[]) => upsertNode(...a),
     insertMessage: (...a: unknown[]) => insertMessage(...a),
     insertTelemetry: (...a: unknown[]) => insertTelemetry(...a),
+    insertTelemetryAsync: async (...a: unknown[]) => insertTelemetry(...a),
+    insertTracerouteAsync: vi.fn(async () => undefined),
+    insertRouteSegmentAsync: vi.fn(async () => undefined),
   },
 }));
 

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -12,10 +12,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../services/database.js', () => ({
   default: {
     upsertNode: vi.fn(),
+    upsertNodeAsync: vi.fn(async () => undefined),
     insertMessage: vi.fn(),
     insertTelemetry: vi.fn(),
+    insertTelemetryAsync: vi.fn(async () => undefined),
     insertTraceroute: vi.fn(),
+    insertTracerouteAsync: vi.fn(async () => undefined),
     insertRouteSegment: vi.fn(),
+    insertRouteSegmentAsync: vi.fn(async () => undefined),
     nodes: {
       getNode: vi.fn(async () => null),
       getNodesByNums: vi.fn(async () => new Map()),
@@ -118,7 +122,7 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     expect(result.ingested).toBe(false);
     expect(result.reason).toBe('geo-filtered');
     expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
-    expect(databaseService.upsertNode).not.toHaveBeenCalled();
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
     expect(filter.getDropCounters().geo).toBe(1);
   });
 
@@ -131,7 +135,7 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     });
     expect(result.ingested).toBe(false);
     expect(result.reason).toBe('geo-filtered');
-    expect(databaseService.upsertNode).not.toHaveBeenCalled();
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
   });
 
   it('drops TELEMETRY from an unknown sender when bbox is enabled', async () => {
@@ -143,7 +147,7 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     });
     expect(result.ingested).toBe(false);
     expect(result.reason).toBe('geo-filtered');
-    expect(databaseService.insertTelemetry).not.toHaveBeenCalled();
+    expect(databaseService.insertTelemetryAsync).not.toHaveBeenCalled();
   });
 
   it('allows a TEXT_MESSAGE after the same sender posted an in-bbox POSITION', async () => {
@@ -356,14 +360,14 @@ describe('ingestServiceEnvelope — TRACEROUTE_APP', () => {
       envelope: envFor(NODE_IN, 70 /* TRACEROUTE_APP */),
     });
     expect(result.ingested).toBe(true);
-    expect(databaseService.insertTraceroute).toHaveBeenCalledTimes(1);
-    const [record, sourceId] = (databaseService.insertTraceroute as any).mock.calls[0];
+    expect(databaseService.insertTracerouteAsync).toHaveBeenCalledTimes(1);
+    const [record, sourceId] = (databaseService.insertTracerouteAsync as any).mock.calls[0];
     expect(record.fromNodeNum).toBe(NODE_IN);
     expect(record.route).toBe('[]');
     expect(record.snrTowards).toBe('[40]');
     expect(sourceId).toBe('bridge-1');
 
-    const telemetryCall = (databaseService.insertTelemetry as any).mock.calls
+    const telemetryCall = (databaseService.insertTelemetryAsync as any).mock.calls
       .find((c: any[]) => c[0].telemetryType === 'messageHops');
     expect(telemetryCall).toBeDefined();
     expect(telemetryCall[0].value).toBe(1); // route.length + 1
@@ -432,10 +436,10 @@ describe('ingestServiceEnvelope — PAXCOUNTER_APP', () => {
       envelope: envFor(NODE_IN, 34 /* PAXCOUNTER_APP */),
     });
     expect(result.ingested).toBe(true);
-    const types = (databaseService.insertTelemetry as any).mock.calls.map((c: any[]) => c[0].telemetryType);
+    const types = (databaseService.insertTelemetryAsync as any).mock.calls.map((c: any[]) => c[0].telemetryType);
     expect(types).toEqual(expect.arrayContaining(['paxcounterWifi', 'paxcounterBle', 'paxcounterUptime']));
     // All three carry the bridge's sourceId.
-    for (const call of (databaseService.insertTelemetry as any).mock.calls) {
+    for (const call of (databaseService.insertTelemetryAsync as any).mock.calls) {
       expect(call[1]).toBe('bridge-1');
     }
   });
@@ -490,8 +494,8 @@ describe('ingestServiceEnvelope — STORE_FORWARD_APP', () => {
       envelope: envFor(NODE_IN, 65),
     });
     expect(result.ingested).toBe(true);
-    expect(databaseService.upsertNode).toHaveBeenCalledTimes(1);
-    const upserted = (databaseService.upsertNode as any).mock.calls[0][0];
+    expect(databaseService.upsertNodeAsync).toHaveBeenCalledTimes(1);
+    const upserted = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
     expect(upserted.nodeNum).toBe(NODE_IN);
     expect(upserted.isStoreForwardServer).toBe(true);
   });
@@ -506,7 +510,7 @@ describe('ingestServiceEnvelope — STORE_FORWARD_APP', () => {
     expect(result.ingested).toBe(false);
     expect(result.reason).toBe('unsupported-portnum');
     expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
-    expect(databaseService.upsertNode).not.toHaveBeenCalled();
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
   });
 });
 
@@ -663,7 +667,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
       envelope: envFor(NODE_IN, 70 /* TRACEROUTE_APP */),
     });
     expect(result.ingested).toBe(true);
-    const [record] = (databaseService.insertTraceroute as any).mock.calls[0];
+    const [record] = (databaseService.insertTracerouteAsync as any).mock.calls[0];
     expect(record.channel).toBe(CHANNEL_DB_OFFSET + 5);
   });
 
@@ -682,7 +686,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     });
 
     expect(result.ingested).toBe(true);
-    const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
+    const [insertedNode] = (databaseService.upsertNodeAsync as any).mock.calls[0];
     expect(insertedNode.channel).toBe(CHANNEL_DB_OFFSET + 9);
   });
 
@@ -695,7 +699,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     });
 
     expect(result.ingested).toBe(true);
-    const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
+    const [insertedNode] = (databaseService.upsertNodeAsync as any).mock.calls[0];
     expect(insertedNode.channel).toBe(CHANNEL_DB_OFFSET + 4);
   });
 
@@ -711,7 +715,7 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     });
 
     expect(result.ingested).toBe(true);
-    const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
+    const [insertedNode] = (databaseService.upsertNodeAsync as any).mock.calls[0];
     expect(insertedNode.channel).toBe(0); // raw slot from the envelope
   });
 });
@@ -722,7 +726,7 @@ describe('ingestServiceEnvelope — TELEMETRY_APP key normalization (#3314)', ()
   });
 
   const telemetryRows = () =>
-    (databaseService.insertTelemetry as any).mock.calls.map((c: any[]) => c[0]);
+    (databaseService.insertTelemetryAsync as any).mock.calls.map((c: any[]) => c[0]);
   const rowByType = (type: string) => telemetryRows().find((r: any) => r.telemetryType === type);
 
   it('stores device metrics under canonical short keys', async () => {
@@ -801,7 +805,7 @@ describe('ingestServiceEnvelope — lastHeard refresh must not clobber NodeInfo'
   });
 
   const senderUpsert = () =>
-    (databaseService.upsertNode as any).mock.calls
+    (databaseService.upsertNodeAsync as any).mock.calls
       .map((c: any[]) => c[0])
       .find((n: any) => n.nodeNum === NODE_IN);
 
@@ -895,7 +899,7 @@ describe('ingestServiceEnvelope — replay guard for lastHeard', () => {
   });
 
   const telemetryUpsert = () =>
-    (databaseService.upsertNode as any).mock.calls
+    (databaseService.upsertNodeAsync as any).mock.calls
       .map((c: any[]) => c[0])
       .find((n: any) => n.nodeNum === NODE_IN);
 

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -254,7 +254,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         createdAt: nowMs,
         updatedAt: nowMs,
       };
-      databaseService.upsertNode(node);
+      void databaseService.upsertNodeAsync(node).catch(err => logger.error('MQTT upsertNode failed:', err));
       return { ingested: true, portnum };
     }
 
@@ -288,7 +288,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         createdAt: nowMs,
         updatedAt: nowMs,
       };
-      databaseService.upsertNode(node);
+      void databaseService.upsertNodeAsync(node).catch(err => logger.error('MQTT upsertNode failed:', err));
       return { ingested: true, portnum };
     }
 
@@ -351,7 +351,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
       // and invisible to source-scoped queries like /api/unified/messages.
       databaseService.messages.insertMessage(msg, sourceId).catch(err => logger.error('Failed to insert MQTT message:', err));
       // Refresh lastHeard for the sender.
-      databaseService.upsertNode({
+      void databaseService.upsertNodeAsync({
         nodeNum: fromNum,
         nodeId: fromNodeId,
         // Intentionally omit longName/shortName/hwModel: this upsert only
@@ -362,10 +362,9 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         lastHeard: lastHeardSec,
         viaMqtt: true,
         transportMechanism: TransportMechanism.MQTT,
-        sourceId,
         createdAt: nowMs,
         updatedAt: nowMs,
-      });
+      }, sourceId).catch(err => logger.error('MQTT upsertNode failed:', err));
       return { ingested: true, portnum };
     }
 
@@ -400,11 +399,11 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
             packetId,
             packetTimestamp: typeof t.time === 'number' ? t.time * 1000 : undefined,
           };
-          databaseService.insertTelemetry(tel, sourceId);
+          void databaseService.insertTelemetryAsync(tel, sourceId).catch(err => logger.error('MQTT insertTelemetry failed:', err));
           any = true;
         }
       }
-      databaseService.upsertNode({
+      void databaseService.upsertNodeAsync({
         nodeNum: fromNum,
         nodeId: fromNodeId,
         // Intentionally omit longName/shortName/hwModel: this upsert only
@@ -415,10 +414,9 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         lastHeard: lastHeardSec,
         viaMqtt: true,
         transportMechanism: TransportMechanism.MQTT,
-        sourceId,
         createdAt: nowMs,
         updatedAt: nowMs,
-      });
+      }, sourceId).catch(err => logger.error('MQTT upsertNode failed:', err));
       return any ? { ingested: true, portnum } : { ingested: false, reason: 'decode-error', portnum };
     }
 
@@ -433,7 +431,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
     }
 
     case PortNum.PAXCOUNTER_APP: {
-      const ok = ingestPaxcounter(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, nowMs);
+      const ok = await ingestPaxcounter(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, nowMs);
       return ok ? { ingested: true, portnum } : { ingested: false, reason: 'decode-error', portnum };
     }
 
@@ -600,7 +598,7 @@ async function ingestTraceroute(
     createdAt: nowMs,
   };
   if (effectiveChannel >= 0) (record as any).channel = effectiveChannel;
-  databaseService.insertTraceroute(record, sourceId);
+  await databaseService.insertTracerouteAsync(record, sourceId);
 
   // Hop count → telemetry, matches TCP's Smart Hops feed.
   const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : undefined;
@@ -615,7 +613,7 @@ async function ingestTraceroute(
     packetId,
     ...({ unit: 'hops' } as any),
   };
-  databaseService.insertTelemetry(hopTel, sourceId);
+  void databaseService.insertTelemetryAsync(hopTel, sourceId).catch(err => logger.error('MQTT insertTelemetry (hops) failed:', err));
 
   // Route segments — one row per adjacent pair with known positions.
   if (toNum !== null) {
@@ -654,7 +652,7 @@ async function persistRouteSegments(sourceId: string, fullRoute: number[], times
         toLongitude: n2.longitude,
       } as any),
     };
-    databaseService.insertRouteSegment(seg, sourceId);
+    await databaseService.insertRouteSegmentAsync(seg, sourceId);
   }
 }
 
@@ -754,17 +752,17 @@ async function ingestNeighborInfo(
  * PAXCOUNTER_APP — three telemetry rows (wifi, ble, uptime) plus a
  * lastHeard refresh. Same shape as TCP's processPaxcounterMessageProtobuf.
  */
-function ingestPaxcounter(
+async function ingestPaxcounter(
   sourceId: string,
   packet: any,
   paxcount: Record<string, any>,
   fromNum: number,
   fromNodeId: string,
   nowMs: number,
-): boolean {
+): Promise<boolean> {
   const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : undefined;
   let any = false;
-  const tryInsert = (telemetryType: string, value: unknown, unit: string): void => {
+  const tryInsert = async (telemetryType: string, value: unknown, unit: string): Promise<void> => {
     if (typeof value !== 'number' || !Number.isFinite(value)) return;
     const tel: DbTelemetry = {
       nodeId: fromNodeId,
@@ -776,16 +774,16 @@ function ingestPaxcounter(
       packetId,
       ...({ unit } as any),
     };
-    databaseService.insertTelemetry(tel, sourceId);
+    await databaseService.insertTelemetryAsync(tel, sourceId);
     any = true;
   };
-  tryInsert('paxcounterWifi', paxcount.wifi, 'devices');
-  tryInsert('paxcounterBle', paxcount.ble, 'devices');
-  tryInsert('paxcounterUptime', paxcount.uptime, 's');
+  await tryInsert('paxcounterWifi', paxcount.wifi, 'devices');
+  await tryInsert('paxcounterBle', paxcount.ble, 'devices');
+  await tryInsert('paxcounterUptime', paxcount.uptime, 's');
 
   // Replay guard (see utils/replayGuard.ts): undefined for a stale replay.
   const lastHeardSec = resolveLastHeardSec(packet.rxTime, nowMs);
-  databaseService.upsertNode({
+  await databaseService.upsertNodeAsync({
     nodeNum: fromNum,
     nodeId: fromNodeId,
     // Omit longName/shortName/hwModel — lastHeard refresh only. Passing '' / 0
@@ -794,10 +792,9 @@ function ingestPaxcounter(
     lastHeard: lastHeardSec,
     viaMqtt: true,
     transportMechanism: TransportMechanism.MQTT,
-    sourceId,
     createdAt: nowMs,
     updatedAt: nowMs,
-  });
+  }, sourceId);
   return any;
 }
 
@@ -878,7 +875,7 @@ async function ingestStoreForward(
   if (rr === StoreForwardRequestResponse.ROUTER_HEARTBEAT) {
     // Replay guard (see utils/replayGuard.ts): undefined for a stale replay.
     const lastHeardSec = resolveLastHeardSec(packet.rxTime, nowMs);
-    databaseService.upsertNode({
+    void databaseService.upsertNodeAsync({
       nodeNum: fromNum,
       nodeId: fromNodeId,
       // Omit longName/shortName/hwModel — lastHeard refresh only. Passing '' / 0
@@ -892,7 +889,7 @@ async function ingestStoreForward(
       updatedAt: nowMs,
       // isStoreForwardServer is in the schema but not on DbNode (Migration 056-ish).
       ...({ isStoreForwardServer: true } as any),
-    } as Partial<DbNode>);
+    } as Partial<DbNode>).catch(err => logger.error('MQTT upsertNode failed:', err));
     return true;
   }
 

--- a/src/server/routes/neighborInfoRoutes.test.ts
+++ b/src/server/routes/neighborInfoRoutes.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../services/database.js', () => ({
       getNode: vi.fn(),
     },
     getLatestNeighborInfoPerNodeScoped: vi.fn(),
+    getLatestNeighborInfoPerNodeScopedAsync: vi.fn(),
     getNeighborsForNodeAsync: vi.fn(),
   },
 }));
@@ -43,7 +44,7 @@ describe('GET /', () => {
       timestamp: now * 1000,
       lastRxTime: now,
     };
-    (databaseService.getLatestNeighborInfoPerNodeScoped as any).mockReturnValue([ni]);
+    (databaseService.getLatestNeighborInfoPerNodeScopedAsync as any).mockResolvedValue([ni]);
     (databaseService.nodes.getNode as any)
       .mockResolvedValueOnce({ nodeId: '!0000006f', longName: 'Alpha', lastHeard: now })
       .mockResolvedValueOnce({ nodeId: '!000000de', longName: 'Beta', lastHeard: now });
@@ -65,7 +66,7 @@ describe('GET /', () => {
       timestamp: oldTime * 1000,
       lastRxTime: oldTime,
     };
-    (databaseService.getLatestNeighborInfoPerNodeScoped as any).mockReturnValue([ni]);
+    (databaseService.getLatestNeighborInfoPerNodeScopedAsync as any).mockResolvedValue([ni]);
     (databaseService.nodes.getNode as any)
       .mockResolvedValueOnce({ nodeId: '!0000006f', longName: 'Old', lastHeard: oldTime })
       .mockResolvedValueOnce({ nodeId: '!000000de', longName: 'Beta', lastHeard: now });
@@ -80,7 +81,7 @@ describe('GET /', () => {
     (databaseService.settings.getSetting as any).mockResolvedValue('24');
     const ni1 = { nodeNum: 111, neighborNodeNum: 222, timestamp: now * 1000, lastRxTime: now };
     const ni2 = { nodeNum: 222, neighborNodeNum: 111, timestamp: now * 1000, lastRxTime: now };
-    (databaseService.getLatestNeighborInfoPerNodeScoped as any).mockReturnValue([ni1, ni2]);
+    (databaseService.getLatestNeighborInfoPerNodeScopedAsync as any).mockResolvedValue([ni1, ni2]);
     (databaseService.nodes.getNode as any).mockResolvedValue({
       nodeId: '!0000006f', longName: 'Node', lastHeard: now,
     });
@@ -93,7 +94,7 @@ describe('GET /', () => {
 
   it('returns 500 on database error', async () => {
     (databaseService.settings.getSetting as any).mockRejectedValue(new Error('db error'));
-    (databaseService.getLatestNeighborInfoPerNodeScoped as any).mockReturnValue([]);
+    (databaseService.getLatestNeighborInfoPerNodeScopedAsync as any).mockResolvedValue([]);
 
     const res = await request(app).get('/');
 

--- a/src/server/routes/neighborInfoRoutes.ts
+++ b/src/server/routes/neighborInfoRoutes.ts
@@ -9,7 +9,7 @@ const router = Router();
 router.get('/', requirePermission('info', 'read'), async (req: Request, res: Response) => {
   try {
     const neighborInfoSourceId = req.query.sourceId as string | undefined;
-    const neighborInfo = databaseService.getLatestNeighborInfoPerNodeScoped(neighborInfoSourceId);
+    const neighborInfo = await databaseService.getLatestNeighborInfoPerNodeScopedAsync(neighborInfoSourceId);
 
     const maxNodeAgeStr = await databaseService.settings.getSetting('maxNodeAge');
     const maxNodeAgeHours = maxNodeAgeStr ? parseInt(maxNodeAgeStr, 10) : 24;

--- a/src/server/routes/v1/traceroutes.ts
+++ b/src/server/routes/v1/traceroutes.ts
@@ -35,7 +35,7 @@ router.get('/', async (req: Request, res: Response) => {
     const sourceIdStr = getScopedSourceId(req);
     const maxLimit = parseInt(limit as string) || 100;
 
-    let traceroutes = databaseService.getAllTraceroutes(maxLimit, sourceIdStr ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
+    let traceroutes = await databaseService.getAllTraceroutesAsync(maxLimit, sourceIdStr ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
 
     // Apply filters
     if (fromNodeId) {
@@ -74,7 +74,7 @@ router.get('/:fromNodeId/:toNodeId', async (req: Request, res: Response) => {
   try {
     const { fromNodeId, toNodeId } = req.params;
     const sourceIdParam = getScopedSourceId(req);
-    const allTraceroutes = databaseService.getAllTraceroutes(100, sourceIdParam ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
+    const allTraceroutes = await databaseService.getAllTraceroutesAsync(100, sourceIdParam ?? ALL_SOURCES); // intentional cross-source when sourceId omitted
     const traceroute = allTraceroutes.find(t => t.fromNodeId === fromNodeId && t.toNodeId === toNodeId);
 
     if (!traceroute) {

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -226,7 +226,8 @@ vi.mock('../../../services/database.js', () => {
       }),
       getPositionTelemetryByNodeAsync: vi.fn(async () => testPositionTelemetry),
       // Traceroutes methods
-      getAllTraceroutes: vi.fn(() => testTraceroutes)
+      getAllTraceroutes: vi.fn(() => testTraceroutes),
+      getAllTraceroutesAsync: vi.fn(async () => testTraceroutes)
     }
   };
 });

--- a/src/server/services/autoTracerouteSelectionService.ts
+++ b/src/server/services/autoTracerouteSelectionService.ts
@@ -1,0 +1,207 @@
+/**
+ * Auto-Traceroute Selection Service
+ *
+ * Extracted from DatabaseService.getNodeNeedingTracerouteAsync. Given the
+ * resolved (per-source) traceroute filter configuration, picks the next node
+ * that should receive an automatic traceroute — applying the last-heard / hop
+ * AND-filters, the union of node/channel/role/hwModel/regex filters, and the
+ * sort-by-hops-or-random selection strategy.
+ */
+import type { NodesRepository } from '../../db/repositories/nodes.js';
+import type { DbNode } from '../../db/types.js';
+import { compileUserRegex } from '../../utils/safeRegex.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Resolved traceroute filter configuration. Mirrors the return type of
+ * DatabaseService.getTracerouteFilterSettingsAsync.
+ */
+export interface TracerouteFilterConfig {
+  enabled: boolean;
+  nodeNums: number[];
+  filterChannels: number[];
+  filterRoles: number[];
+  filterHwModels: number[];
+  filterNameRegex: string;
+  filterNodesEnabled: boolean;
+  filterChannelsEnabled: boolean;
+  filterRolesEnabled: boolean;
+  filterHwModelsEnabled: boolean;
+  filterRegexEnabled: boolean;
+  expirationHours: number;
+  sortByHops: boolean;
+  filterLastHeardEnabled: boolean;
+  filterLastHeardHours: number;
+  filterHopsEnabled: boolean;
+  filterHopsMin: number;
+  filterHopsMax: number;
+}
+
+export interface AutoTracerouteSelectionDeps {
+  filterCfg: TracerouteFilterConfig;
+  maxNodeAgeHours: number;
+  nodesRepo: NodesRepository;
+  normalizeBigInts: (node: DbNode) => DbNode;
+}
+
+/**
+ * Select a node that needs a traceroute based on the configured filters and
+ * timing windows. Returns the (BigInt-normalized) node, or null when none is
+ * eligible.
+ */
+export async function selectNodeNeedingTraceroute(
+  localNodeNum: number,
+  sourceId: string | undefined,
+  deps: AutoTracerouteSelectionDeps
+): Promise<DbNode | null> {
+  const { filterCfg, maxNodeAgeHours, nodesRepo, normalizeBigInts } = deps;
+
+  const now = Date.now();
+  const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
+  const EXPIRATION_MS = filterCfg.expirationHours * 60 * 60 * 1000;
+
+  // lastHeard is stored in seconds (Unix timestamp), so convert cutoff to seconds
+  const activeNodeCutoff = Math.floor(Date.now() / 1000) - maxNodeAgeHours * 60 * 60;
+
+  try {
+    // Get eligible nodes from repository
+    let eligibleNodes = await nodesRepo.getEligibleNodesForTraceroute(
+      localNodeNum,
+      activeNodeCutoff,
+      now - THREE_HOURS_MS,
+      now - EXPIRATION_MS,
+      sourceId
+    );
+
+    // Last heard and hop range filters (AND logic, applied before OR union filters)
+    const filterLastHeardEnabled = filterCfg.filterLastHeardEnabled;
+    const filterLastHeardHours = filterCfg.filterLastHeardHours;
+    const filterHopsEnabled = filterCfg.filterHopsEnabled;
+    const filterHopsMin = filterCfg.filterHopsMin;
+    const filterHopsMax = filterCfg.filterHopsMax;
+
+    // Apply last-heard filter (AND logic — applied before OR union filters)
+    if (filterLastHeardEnabled) {
+      const lastHeardCutoff = Math.floor(Date.now() / 1000) - filterLastHeardHours * 3600;
+      eligibleNodes = eligibleNodes.filter((node) => {
+        // Exclude nodes with no lastHeard or lastHeard older than cutoff
+        return node.lastHeard != null && node.lastHeard >= lastHeardCutoff;
+      });
+    }
+
+    // Apply hop range filter (AND logic)
+    if (filterHopsEnabled) {
+      eligibleNodes = eligibleNodes.filter((node) => {
+        // Treat NULL hopsAway as 1 (direct neighbor)
+        const hops = node.hopsAway ?? 1;
+        return hops >= filterHopsMin && hops <= filterHopsMax;
+      });
+    }
+
+    // Check if node filter is enabled (per-source when scoped)
+    const filterEnabled = filterCfg.enabled;
+
+    if (filterEnabled) {
+      const specificNodes = filterCfg.nodeNums;
+      const filterChannels = filterCfg.filterChannels;
+      const filterRoles = filterCfg.filterRoles;
+      const filterHwModels = filterCfg.filterHwModels;
+      const filterNameRegex = filterCfg.filterNameRegex;
+
+      const filterNodesEnabled = filterCfg.filterNodesEnabled;
+      const filterChannelsEnabled = filterCfg.filterChannelsEnabled;
+      const filterRolesEnabled = filterCfg.filterRolesEnabled;
+      const filterHwModelsEnabled = filterCfg.filterHwModelsEnabled;
+      const filterRegexEnabled = filterCfg.filterRegexEnabled;
+
+      // Build regex matcher if enabled
+      let regexMatcher: RegExp | null = null;
+      if (filterRegexEnabled && filterNameRegex && filterNameRegex !== '.*') {
+        try {
+          regexMatcher = compileUserRegex(filterNameRegex, 'i');
+        } catch (e) {
+          logger.warn(`Invalid traceroute filter regex: ${filterNameRegex}`, e);
+        }
+      }
+
+      // Check if ANY filter is actually configured
+      const hasAnyFilter =
+        (filterNodesEnabled && specificNodes.length > 0) ||
+        (filterChannelsEnabled && filterChannels.length > 0) ||
+        (filterRolesEnabled && filterRoles.length > 0) ||
+        (filterHwModelsEnabled && filterHwModels.length > 0) ||
+        (filterRegexEnabled && regexMatcher !== null);
+
+      // Only filter if at least one filter is configured
+      if (hasAnyFilter) {
+        eligibleNodes = eligibleNodes.filter((node) => {
+          // UNION logic: node passes if it matches ANY enabled filter
+          // Check specific nodes filter
+          if (filterNodesEnabled && specificNodes.length > 0) {
+            if (specificNodes.includes(node.nodeNum)) {
+              return true;
+            }
+          }
+
+          // Check channel filter
+          if (filterChannelsEnabled && filterChannels.length > 0) {
+            if (node.channel != null && filterChannels.includes(node.channel)) {
+              return true;
+            }
+          }
+
+          // Check role filter
+          if (filterRolesEnabled && filterRoles.length > 0) {
+            if (node.role != null && filterRoles.includes(node.role)) {
+              return true;
+            }
+          }
+
+          // Check hardware model filter
+          if (filterHwModelsEnabled && filterHwModels.length > 0) {
+            if (node.hwModel != null && filterHwModels.includes(node.hwModel)) {
+              return true;
+            }
+          }
+
+          // Check regex name filter
+          if (filterRegexEnabled && regexMatcher !== null) {
+            const name = node.longName || node.shortName || node.nodeId || '';
+            if (regexMatcher.test(name)) {
+              return true;
+            }
+          }
+
+          // Node didn't match any enabled filter
+          return false;
+        });
+      }
+      // If hasAnyFilter is false, all nodes pass (no filtering applied)
+    }
+
+    if (eligibleNodes.length === 0) {
+      return null;
+    }
+
+    // Check if sort by hops is enabled (per-source when scoped)
+    const sortByHops = filterCfg.sortByHops;
+
+    if (sortByHops) {
+      // Sort by hopsAway ascending (closer nodes first), with undefined hops at the end
+      eligibleNodes.sort((a, b) => {
+        const hopsA = a.hopsAway ?? Infinity;
+        const hopsB = b.hopsAway ?? Infinity;
+        return hopsA - hopsB;
+      });
+      // Take the first (closest) node
+      return normalizeBigInts(eligibleNodes[0]);
+    }
+
+    // Randomly select one node from the eligible nodes
+    const randomIndex = Math.floor(Math.random() * eligibleNodes.length);
+    return normalizeBigInts(eligibleNodes[randomIndex]);
+  } catch (error) {
+    logger.error('Error in selectNodeNeedingTraceroute:', error);
+    return null;
+  }
+}

--- a/src/server/services/nodeCacheService.test.ts
+++ b/src/server/services/nodeCacheService.test.ts
@@ -1,0 +1,174 @@
+/**
+ * NodeCacheService tests
+ *
+ * Covers the in-memory node cache extracted from DatabaseService (Phase 3.4,
+ * #3962): composite-key accessors, source-scoped iteration, mobility patching,
+ * repo warm-up, and the NodesRepository cache-hook contract (upsert / delete /
+ * cross-source replace / by-nodeId replace / clear).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NodeCacheService } from './nodeCacheService.js';
+import { ALL_SOURCES } from '../../db/repositories/base.js';
+import type { DbNode } from '../../services/database.js';
+
+const makeNode = (nodeNum: number, sourceId: string, overrides: Partial<DbNode> = {}): DbNode =>
+  ({
+    nodeNum,
+    nodeId: `!${nodeNum.toString(16).padStart(8, '0')}`,
+    longName: `Node ${nodeNum}`,
+    shortName: `N${nodeNum}`,
+    hwModel: 1,
+    sourceId,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  }) as DbNode;
+
+describe('NodeCacheService', () => {
+  let cache: NodeCacheService;
+
+  beforeEach(() => {
+    cache = new NodeCacheService();
+  });
+
+  describe('composite-key accessors', () => {
+    it('keys entries by nodeNum + sourceId', () => {
+      expect(cache.cacheKey(123, 'src-a')).toBe('123:src-a');
+      cache.set(123, 'src-a', makeNode(123, 'src-a'));
+      cache.set(123, 'src-b', makeNode(123, 'src-b'));
+
+      expect(cache.size).toBe(2);
+      expect(cache.get(123, 'src-a')?.sourceId).toBe('src-a');
+      expect(cache.get(123, 'src-b')?.sourceId).toBe('src-b');
+      expect(cache.has(123, 'src-c')).toBe(false);
+    });
+
+    it('delete removes only the addressed source row', () => {
+      cache.set(123, 'src-a', makeNode(123, 'src-a'));
+      cache.set(123, 'src-b', makeNode(123, 'src-b'));
+      cache.delete(123, 'src-a');
+      expect(cache.has(123, 'src-a')).toBe(false);
+      expect(cache.has(123, 'src-b')).toBe(true);
+    });
+  });
+
+  describe('iterate (source scoping)', () => {
+    beforeEach(() => {
+      cache.set(1, 'src-a', makeNode(1, 'src-a'));
+      cache.set(2, 'src-a', makeNode(2, 'src-a'));
+      cache.set(3, 'src-b', makeNode(3, 'src-b'));
+    });
+
+    it('filters by concrete sourceId', () => {
+      const nodes = Array.from(cache.iterate('src-a'));
+      expect(nodes.map(n => n.nodeNum).sort()).toEqual([1, 2]);
+    });
+
+    it('yields everything for ALL_SOURCES and undefined', () => {
+      expect(Array.from(cache.iterate(ALL_SOURCES))).toHaveLength(3);
+      expect(Array.from(cache.iterate())).toHaveLength(3);
+    });
+  });
+
+  describe('fromRepoNode', () => {
+    it('converts repo nulls to cache-shape undefined/defaults', () => {
+      const converted = cache.fromRepoNode(
+        {
+          nodeNum: 7,
+          nodeId: '!00000007',
+          longName: null,
+          shortName: null,
+          hwModel: null,
+          batteryLevel: null,
+          sourceId: null,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        'src-a'
+      );
+      expect(converted.longName).toBe('');
+      expect(converted.shortName).toBe('');
+      expect(converted.hwModel).toBe(0);
+      expect(converted.batteryLevel).toBeUndefined();
+      expect(converted.sourceId).toBe('src-a'); // falls back to the hook's sourceId
+    });
+  });
+
+  describe('patchMobility', () => {
+    it('patches the mobile flag for cached rows matching the nodeId', () => {
+      cache.set(1, 'src-a', makeNode(1, 'src-a', { mobile: 0 }));
+      cache.patchMobility('!00000001', 1);
+      expect(cache.get(1, 'src-a')?.mobile).toBe(1);
+    });
+
+    it('leaves non-matching rows untouched', () => {
+      cache.set(2, 'src-a', makeNode(2, 'src-a', { mobile: 0 }));
+      cache.patchMobility('!00000001', 1);
+      expect(cache.get(2, 'src-a')?.mobile).toBe(0);
+    });
+  });
+
+  describe('warmFromRepo', () => {
+    it('replaces contents from the repo across all sources', async () => {
+      cache.set(99, 'stale', makeNode(99, 'stale'));
+      const nodesRepo = {
+        getAllNodes: vi.fn().mockResolvedValue([
+          { nodeNum: 1, nodeId: '!00000001', sourceId: 'src-a', createdAt: 1, updatedAt: 1 },
+          { nodeNum: 2, nodeId: '!00000002', sourceId: null, createdAt: 1, updatedAt: 1 },
+        ]),
+      };
+
+      await cache.warmFromRepo(nodesRepo as any);
+
+      expect(nodesRepo.getAllNodes).toHaveBeenCalledWith(ALL_SOURCES);
+      expect(cache.size).toBe(2);
+      expect(cache.has(99, 'stale')).toBe(false);
+      expect(cache.get(1, 'src-a')).toBeDefined();
+      // null sourceId falls back to 'default'
+      expect(cache.get(2, 'default')?.sourceId).toBe('default');
+    });
+  });
+
+  describe('buildHook (NodesRepository cache-hook contract)', () => {
+    it('setNode upserts and deletes', () => {
+      const hook = cache.buildHook();
+
+      hook.setNode(5, 'src-a', makeNode(5, 'src-a'));
+      expect(cache.has(5, 'src-a')).toBe(true);
+
+      hook.setNode(5, 'src-a', null);
+      expect(cache.has(5, 'src-a')).toBe(false);
+    });
+
+    it('setNodeAcrossSources drops rows for sources missing from the fresh set', () => {
+      const hook = cache.buildHook();
+      cache.set(5, 'src-a', makeNode(5, 'src-a'));
+      cache.set(5, 'src-b', makeNode(5, 'src-b'));
+      cache.set(6, 'src-b', makeNode(6, 'src-b')); // unrelated nodeNum — untouched
+
+      hook.setNodeAcrossSources(5, [makeNode(5, 'src-a', { longName: 'fresh' })]);
+
+      expect(cache.get(5, 'src-a')?.longName).toBe('fresh');
+      expect(cache.has(5, 'src-b')).toBe(false);
+      expect(cache.has(6, 'src-b')).toBe(true);
+    });
+
+    it('setNodeByNodeId replaces all rows carrying the nodeId', () => {
+      const hook = cache.buildHook();
+      cache.set(5, 'src-a', makeNode(5, 'src-a'));
+      cache.set(5, 'src-b', makeNode(5, 'src-b'));
+
+      hook.setNodeByNodeId('!00000005', [makeNode(5, 'src-b', { longName: 'kept' })]);
+
+      expect(cache.has(5, 'src-a')).toBe(false);
+      expect(cache.get(5, 'src-b')?.longName).toBe('kept');
+    });
+
+    it('clear empties the cache', () => {
+      const hook = cache.buildHook();
+      cache.set(1, 'src-a', makeNode(1, 'src-a'));
+      hook.clear();
+      expect(cache.size).toBe(0);
+    });
+  });
+});

--- a/src/server/services/nodeCacheService.ts
+++ b/src/server/services/nodeCacheService.ts
@@ -1,0 +1,229 @@
+/**
+ * Node Cache Service
+ *
+ * Wraps the in-memory node cache that DatabaseService maintains for
+ * PostgreSQL/MySQL sync-method compatibility (e.g. getNode()/getAllNodes()
+ * called from sync code paths). Previously this lived as a bare
+ * `Map<string, DbNode>` plus a handful of private helpers on DatabaseService;
+ * extracting it keeps the cache key scheme, repo→cache conversion, and the
+ * NodesRepository cache-hook wiring in one cohesive, testable place.
+ *
+ * The cache is keyed by `${nodeNum}:${sourceId}` — the nodes table PK is
+ * (nodeNum, sourceId) post-migration 029.
+ */
+import type { DbNode } from '../../services/database.js';
+import type { NodesRepository, NodesCacheHook } from '../../db/repositories/nodes.js';
+import { ALL_SOURCES, SourceScope } from '../../db/repositories/base.js';
+
+export class NodeCacheService {
+  private readonly cache: Map<string, DbNode> = new Map();
+
+  /** Build composite cache key from nodeNum + sourceId. */
+  cacheKey(nodeNum: number, sourceId: string): string {
+    return `${nodeNum}:${sourceId}`;
+  }
+
+  /**
+   * Convert a repository-shaped node row (with `null` for missing fields and a
+   * `sourceId` column) into the local cache shape (with `undefined` for
+   * optional fields). Keeps cache-hook writes structurally identical to the
+   * startup warm-load entries.
+   */
+  fromRepoNode(node: any, sourceId: string): DbNode {
+    return {
+      nodeNum: node.nodeNum,
+      nodeId: node.nodeId,
+      longName: node.longName ?? '',
+      shortName: node.shortName ?? '',
+      hwModel: node.hwModel ?? 0,
+      role: node.role ?? undefined,
+      hopsAway: node.hopsAway ?? undefined,
+      lastMessageHops: node.lastMessageHops ?? undefined,
+      viaMqtt: node.viaMqtt ?? undefined,
+      macaddr: node.macaddr ?? undefined,
+      latitude: node.latitude ?? undefined,
+      longitude: node.longitude ?? undefined,
+      altitude: node.altitude ?? undefined,
+      batteryLevel: node.batteryLevel ?? undefined,
+      voltage: node.voltage ?? undefined,
+      channelUtilization: node.channelUtilization ?? undefined,
+      airUtilTx: node.airUtilTx ?? undefined,
+      lastHeard: node.lastHeard ?? undefined,
+      snr: node.snr ?? undefined,
+      rssi: node.rssi ?? undefined,
+      lastTracerouteRequest: node.lastTracerouteRequest ?? undefined,
+      firmwareVersion: node.firmwareVersion ?? undefined,
+      channel: node.channel ?? undefined,
+      isFavorite: node.isFavorite ?? undefined,
+      favoriteLocked: node.favoriteLocked ?? undefined,
+      isIgnored: node.isIgnored ?? undefined,
+      mobile: node.mobile ?? undefined,
+      rebootCount: node.rebootCount ?? undefined,
+      publicKey: node.publicKey ?? undefined,
+      hasPKC: node.hasPKC ?? undefined,
+      lastPKIPacket: node.lastPKIPacket ?? undefined,
+      keyIsLowEntropy: node.keyIsLowEntropy ?? undefined,
+      duplicateKeyDetected: node.duplicateKeyDetected ?? undefined,
+      keyMismatchDetected: node.keyMismatchDetected ?? undefined,
+      keySecurityIssueDetails: node.keySecurityIssueDetails ?? undefined,
+      welcomedAt: node.welcomedAt ?? undefined,
+      positionChannel: node.positionChannel ?? undefined,
+      positionPrecisionBits: node.positionPrecisionBits ?? undefined,
+      positionGpsAccuracy: node.positionGpsAccuracy ?? undefined,
+      positionHdop: node.positionHdop ?? undefined,
+      positionTimestamp: node.positionTimestamp ?? undefined,
+      positionOverrideEnabled: node.positionOverrideEnabled ?? undefined,
+      latitudeOverride: node.latitudeOverride ?? undefined,
+      longitudeOverride: node.longitudeOverride ?? undefined,
+      altitudeOverride: node.altitudeOverride ?? undefined,
+      positionOverrideIsPrivate: node.positionOverrideIsPrivate ?? undefined,
+      hideFromMap: node.hideFromMap ?? undefined,
+      notes: node.notes ?? undefined,
+      hasRemoteAdmin: node.hasRemoteAdmin ?? undefined,
+      lastRemoteAdminCheck: node.lastRemoteAdminCheck ?? undefined,
+      remoteAdminMetadata: node.remoteAdminMetadata ?? undefined,
+      sourceId: node.sourceId ?? sourceId,
+      createdAt: node.createdAt,
+      updatedAt: node.updatedAt,
+    } as DbNode;
+  }
+
+  get(nodeNum: number, sourceId: string): DbNode | undefined {
+    return this.cache.get(this.cacheKey(nodeNum, sourceId));
+  }
+
+  has(nodeNum: number, sourceId: string): boolean {
+    return this.cache.has(this.cacheKey(nodeNum, sourceId));
+  }
+
+  set(nodeNum: number, sourceId: string, node: DbNode): void {
+    this.cache.set(this.cacheKey(nodeNum, sourceId), node);
+  }
+
+  setByKey(key: string, node: DbNode): void {
+    this.cache.set(key, node);
+  }
+
+  delete(nodeNum: number, sourceId: string): void {
+    this.cache.delete(this.cacheKey(nodeNum, sourceId));
+  }
+
+  deleteByKey(key: string): void {
+    this.cache.delete(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  values(): IterableIterator<DbNode> {
+    return this.cache.values();
+  }
+
+  keys(): IterableIterator<string> {
+    return this.cache.keys();
+  }
+
+  entries(): IterableIterator<[string, DbNode]> {
+    return this.cache.entries();
+  }
+
+  rawGet(key: string): DbNode | undefined {
+    return this.cache.get(key);
+  }
+
+  /**
+   * Iterate cached nodes, optionally filtered by sourceId. ALL_SOURCES (or
+   * undefined / empty) yields every entry; a concrete sourceId filters.
+   */
+  *iterate(sourceId?: SourceScope): Generator<DbNode> {
+    for (const node of this.cache.values()) {
+      if (typeof sourceId === 'string' && sourceId !== '' && node.sourceId !== sourceId) continue;
+      yield node;
+    }
+  }
+
+  /**
+   * Patch the `mobile` flag in place for every cached row matching the given
+   * string node id (e.g. `!abcd1234`). Used by the mobility service after a
+   * mobility recompute so sync reads reflect the new value immediately.
+   */
+  patchMobility(nodeId: string, mobile: number): void {
+    for (const [key, cachedNode] of this.cache.entries()) {
+      if (cachedNode.nodeId === nodeId) {
+        cachedNode.mobile = mobile;
+        this.cache.set(key, cachedNode);
+      }
+    }
+  }
+
+  /**
+   * Warm the cache from the repository — loads all nodes across all sources
+   * (intentional cross-source init warm-up) and replaces the cache contents.
+   */
+  async warmFromRepo(nodesRepo: NodesRepository): Promise<void> {
+    // intentional cross-source: init cache warm-up loads all sources at once
+    const nodes = await nodesRepo.getAllNodes(ALL_SOURCES);
+    this.cache.clear();
+    for (const node of nodes) {
+      const sid = (node as any).sourceId ?? 'default';
+      this.setByKey(this.cacheKey(node.nodeNum, sid), this.fromRepoNode(node, sid));
+    }
+  }
+
+  /**
+   * Build the object implementing NodesRepository's cache-hook contract so the
+   * in-memory cache stays coherent with DB writes made through the repo
+   * (fixes #2858). Semantics mirror {@link NodesCacheHook}.
+   */
+  buildHook(): NodesCacheHook {
+    return {
+      setNode: (nodeNum: number, sourceId: string, node: DbNode | null) => {
+        const key = this.cacheKey(nodeNum, sourceId);
+        if (!node) {
+          this.cache.delete(key);
+          return;
+        }
+        this.cache.set(key, this.fromRepoNode(node, sourceId));
+      },
+      setNodeAcrossSources: (nodeNum: number, freshNodes: DbNode[]) => {
+        // Remove existing cache entries for this nodeNum that aren't in
+        // freshNodes, then upsert each fresh row.
+        const keepSourceIds = new Set(freshNodes.map((n) => (n as any).sourceId ?? 'default'));
+        for (const key of Array.from(this.cache.keys())) {
+          const cached = this.cache.get(key);
+          if (cached && cached.nodeNum === nodeNum && !keepSourceIds.has(cached.sourceId ?? 'default')) {
+            this.cache.delete(key);
+          }
+        }
+        for (const fresh of freshNodes) {
+          const sid = (fresh as any).sourceId ?? 'default';
+          this.cache.set(this.cacheKey(nodeNum, sid), this.fromRepoNode(fresh, sid));
+        }
+      },
+      setNodeByNodeId: (nodeId: string, freshNodes: DbNode[]) => {
+        // Replace all cache entries for this nodeId with the fresh set.
+        const keepKeys = new Set(
+          freshNodes.map((n) => this.cacheKey(n.nodeNum, (n as any).sourceId ?? 'default'))
+        );
+        for (const key of Array.from(this.cache.keys())) {
+          const cached = this.cache.get(key);
+          if (cached && cached.nodeId === nodeId && !keepKeys.has(key)) {
+            this.cache.delete(key);
+          }
+        }
+        for (const fresh of freshNodes) {
+          const sid = (fresh as any).sourceId ?? 'default';
+          this.cache.set(this.cacheKey(fresh.nodeNum, sid), this.fromRepoNode(fresh, sid));
+        }
+      },
+      clear: () => {
+        this.cache.clear();
+      },
+    };
+  }
+}

--- a/src/server/services/nodeCacheService.ts
+++ b/src/server/services/nodeCacheService.ts
@@ -15,6 +15,18 @@ import type { DbNode } from '../../services/database.js';
 import type { NodesRepository, NodesCacheHook } from '../../db/repositories/nodes.js';
 import { ALL_SOURCES, SourceScope } from '../../db/repositories/base.js';
 
+/**
+ * Repository-shaped node row: DbNode fields but with `null` allowed for
+ * missing values (the repo layer returns SQL NULLs), plus the `sourceId`
+ * column present on multi-source rows. Structurally compatible with both
+ * the repo-layer DbNode (src/db/types.ts) and the service-layer DbNode.
+ */
+type RepoNodeInput = { [K in keyof DbNode]?: DbNode[K] | null } & {
+  nodeNum: number;
+  nodeId: string;
+  sourceId?: string | null;
+};
+
 export class NodeCacheService {
   private readonly cache: Map<string, DbNode> = new Map();
 
@@ -29,7 +41,7 @@ export class NodeCacheService {
    * optional fields). Keeps cache-hook writes structurally identical to the
    * startup warm-load entries.
    */
-  fromRepoNode(node: any, sourceId: string): DbNode {
+  fromRepoNode(node: RepoNodeInput, sourceId: string): DbNode {
     return {
       nodeNum: node.nodeNum,
       nodeId: node.nodeId,
@@ -167,10 +179,10 @@ export class NodeCacheService {
    */
   async warmFromRepo(nodesRepo: NodesRepository): Promise<void> {
     // intentional cross-source: init cache warm-up loads all sources at once
-    const nodes = await nodesRepo.getAllNodes(ALL_SOURCES);
+    const nodes = (await nodesRepo.getAllNodes(ALL_SOURCES)) as RepoNodeInput[];
     this.cache.clear();
     for (const node of nodes) {
-      const sid = (node as any).sourceId ?? 'default';
+      const sid = node.sourceId ?? 'default';
       this.setByKey(this.cacheKey(node.nodeNum, sid), this.fromRepoNode(node, sid));
     }
   }
@@ -193,7 +205,7 @@ export class NodeCacheService {
       setNodeAcrossSources: (nodeNum: number, freshNodes: DbNode[]) => {
         // Remove existing cache entries for this nodeNum that aren't in
         // freshNodes, then upsert each fresh row.
-        const keepSourceIds = new Set(freshNodes.map((n) => (n as any).sourceId ?? 'default'));
+        const keepSourceIds = new Set(freshNodes.map((n) => n.sourceId ?? 'default'));
         for (const key of Array.from(this.cache.keys())) {
           const cached = this.cache.get(key);
           if (cached && cached.nodeNum === nodeNum && !keepSourceIds.has(cached.sourceId ?? 'default')) {
@@ -201,14 +213,14 @@ export class NodeCacheService {
           }
         }
         for (const fresh of freshNodes) {
-          const sid = (fresh as any).sourceId ?? 'default';
+          const sid = fresh.sourceId ?? 'default';
           this.cache.set(this.cacheKey(nodeNum, sid), this.fromRepoNode(fresh, sid));
         }
       },
       setNodeByNodeId: (nodeId: string, freshNodes: DbNode[]) => {
         // Replace all cache entries for this nodeId with the fresh set.
         const keepKeys = new Set(
-          freshNodes.map((n) => this.cacheKey(n.nodeNum, (n as any).sourceId ?? 'default'))
+          freshNodes.map((n) => this.cacheKey(n.nodeNum, n.sourceId ?? 'default'))
         );
         for (const key of Array.from(this.cache.keys())) {
           const cached = this.cache.get(key);
@@ -217,7 +229,7 @@ export class NodeCacheService {
           }
         }
         for (const fresh of freshNodes) {
-          const sid = (fresh as any).sourceId ?? 'default';
+          const sid = fresh.sourceId ?? 'default';
           this.cache.set(this.cacheKey(fresh.nodeNum, sid), this.fromRepoNode(fresh, sid));
         }
       },

--- a/src/server/services/nodeMobilityService.test.ts
+++ b/src/server/services/nodeMobilityService.test.ts
@@ -1,0 +1,85 @@
+/**
+ * NodeMobilityService tests
+ *
+ * Covers the mobility heuristic extracted from
+ * DatabaseService.updateNodeMobilityAsync (Phase 3.4, #3962):
+ * bounding-box haversine >100m boundary, insufficient-history and error paths,
+ * plus the persist + cache-patch side effects.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateNodeMobility, NodeMobilityDeps } from './nodeMobilityService.js';
+import { ALL_SOURCES } from '../../db/repositories/base.js';
+
+const NODE_ID = '!aabbccdd';
+
+// ~0.002° of latitude ≈ 222 m; ~0.0005° ≈ 56 m (well either side of the 100 m threshold)
+const positionRows = (latSpanDeg: number) => [
+  { telemetryType: 'latitude', value: 30.0, timestamp: 1 },
+  { telemetryType: 'longitude', value: -90.0, timestamp: 1 },
+  { telemetryType: 'latitude', value: 30.0 + latSpanDeg, timestamp: 2 },
+  { telemetryType: 'longitude', value: -90.0, timestamp: 2 },
+];
+
+describe('nodeMobilityService.updateNodeMobility', () => {
+  let deps: NodeMobilityDeps;
+  let getPositionTelemetryByNode: ReturnType<typeof vi.fn>;
+  let updateNodeMobilityRepo: ReturnType<typeof vi.fn>;
+  let patchCache: ReturnType<typeof vi.fn<(nodeId: string, mobile: number) => void>>;
+
+  beforeEach(() => {
+    getPositionTelemetryByNode = vi.fn().mockResolvedValue([]);
+    updateNodeMobilityRepo = vi.fn().mockResolvedValue(undefined);
+    patchCache = vi.fn<(nodeId: string, mobile: number) => void>();
+    deps = {
+      telemetryRepo: { getPositionTelemetryByNode } as any,
+      nodesRepo: { updateNodeMobility: updateNodeMobilityRepo } as any,
+      patchCache,
+    };
+  });
+
+  it('marks a node mobile when its position box spans more than 100 m', async () => {
+    getPositionTelemetryByNode.mockResolvedValue(positionRows(0.002)); // ~222 m
+
+    const result = await updateNodeMobility(NODE_ID, deps);
+
+    expect(result).toBe(1);
+    expect(updateNodeMobilityRepo).toHaveBeenCalledWith(NODE_ID, 1);
+    expect(patchCache).toHaveBeenCalledWith(NODE_ID, 1);
+  });
+
+  it('keeps a node stationary when movement stays under 100 m', async () => {
+    getPositionTelemetryByNode.mockResolvedValue(positionRows(0.0005)); // ~56 m
+
+    const result = await updateNodeMobility(NODE_ID, deps);
+
+    expect(result).toBe(0);
+    expect(updateNodeMobilityRepo).toHaveBeenCalledWith(NODE_ID, 0);
+    expect(patchCache).toHaveBeenCalledWith(NODE_ID, 0);
+  });
+
+  it('returns 0 (and still persists) with fewer than 2 position pairs', async () => {
+    getPositionTelemetryByNode.mockResolvedValue([
+      { telemetryType: 'latitude', value: 30.0, timestamp: 1 },
+      { telemetryType: 'longitude', value: -90.0, timestamp: 1 },
+    ]);
+
+    const result = await updateNodeMobility(NODE_ID, deps);
+
+    expect(result).toBe(0);
+    expect(updateNodeMobilityRepo).toHaveBeenCalledWith(NODE_ID, 0);
+  });
+
+  it('reads position history cross-source (ALL_SOURCES) with a 500 limit', async () => {
+    await updateNodeMobility(NODE_ID, deps);
+    expect(getPositionTelemetryByNode).toHaveBeenCalledWith(NODE_ID, 500, undefined, ALL_SOURCES);
+  });
+
+  it('swallows errors and reports non-mobile', async () => {
+    getPositionTelemetryByNode.mockRejectedValue(new Error('db down'));
+
+    const result = await updateNodeMobility(NODE_ID, deps);
+
+    expect(result).toBe(0);
+    expect(patchCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/nodeMobilityService.ts
+++ b/src/server/services/nodeMobilityService.ts
@@ -1,0 +1,92 @@
+/**
+ * Node Mobility Service
+ *
+ * Extracted from DatabaseService.updateNodeMobilityAsync so the mobility
+ * detection heuristic lives in one testable place, decoupled from the
+ * database facade. A node is considered "mobile" when the bounding box of its
+ * recent position history spans more than 100 meters.
+ */
+import type { TelemetryRepository } from '../../db/repositories/telemetry.js';
+import type { NodesRepository } from '../../db/repositories/nodes.js';
+import { ALL_SOURCES } from '../../db/repositories/base.js';
+import { logger } from '../../utils/logger.js';
+
+export interface NodeMobilityDeps {
+  telemetryRepo: TelemetryRepository;
+  nodesRepo: NodesRepository;
+  /**
+   * Patch the in-memory node cache (if any) so subsequent sync reads reflect
+   * the freshly-computed mobility flag. The `nodeId` is the string node id
+   * (e.g. `!abcd1234`), matching how the cache stores node rows.
+   */
+  patchCache: (nodeId: string, mobile: number) => void;
+}
+
+/**
+ * Detect whether a node has moved more than 100 meters based on its last 500
+ * position telemetry records, update the persisted mobile flag, patch the
+ * in-memory cache, and return the resulting mobility status (0 = stationary,
+ * 1 = mobile). Errors are swallowed and reported as non-mobile (0).
+ */
+export async function updateNodeMobility(nodeId: string, deps: NodeMobilityDeps): Promise<number> {
+  try {
+    // Get last 500 position telemetry records for this node. Using a larger
+    // limit ensures we capture movement over a longer time period (50 was too
+    // small — nodes parked for a while would show only recent stationary
+    // positions).
+    // intentional cross-source: mobility check pools all sources' positions
+    const positionTelemetry = await deps.telemetryRepo.getPositionTelemetryByNode(
+      nodeId,
+      500,
+      undefined,
+      ALL_SOURCES
+    );
+
+    const latitudes = positionTelemetry.filter((t) => t.telemetryType === 'latitude');
+    const longitudes = positionTelemetry.filter((t) => t.telemetryType === 'longitude');
+
+    let isMobile = 0;
+
+    // Need at least 2 position records to detect movement
+    if (latitudes.length >= 2 && longitudes.length >= 2) {
+      const latValues = latitudes.map((t) => t.value);
+      const lonValues = longitudes.map((t) => t.value);
+
+      const minLat = Math.min(...latValues);
+      const maxLat = Math.max(...latValues);
+      const minLon = Math.min(...lonValues);
+      const maxLon = Math.max(...lonValues);
+
+      // Calculate distance between min/max corners using Haversine formula
+      const R = 6371; // Earth's radius in km
+      const dLat = ((maxLat - minLat) * Math.PI) / 180;
+      const dLon = ((maxLon - minLon) * Math.PI) / 180;
+      const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos((minLat * Math.PI) / 180) *
+          Math.cos((maxLat * Math.PI) / 180) *
+          Math.sin(dLon / 2) *
+          Math.sin(dLon / 2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      const distance = R * c;
+
+      // If movement is greater than 100 meters (0.1 km), mark as mobile
+      isMobile = distance > 0.1 ? 1 : 0;
+
+      logger.debug(
+        `📍 Node ${nodeId} mobility check: ${latitudes.length} positions, distance=${distance.toFixed(3)}km, mobile=${isMobile}`
+      );
+    }
+
+    // Update the mobile flag in the database using the repository
+    await deps.nodesRepo.updateNodeMobility(nodeId, isMobile);
+
+    // Patch the in-memory cache so getAllNodes() returns the updated value
+    deps.patchCache(nodeId, isMobile);
+
+    return isMobile;
+  } catch (error) {
+    logger.error(`Failed to update mobility for node ${nodeId}:`, error);
+    return 0; // Default to non-mobile on error
+  }
+}

--- a/src/server/services/packetLogService.test.ts
+++ b/src/server/services/packetLogService.test.ts
@@ -9,9 +9,9 @@ import packetLogService from './packetLogService.js';
 import databaseService from '../../services/database.js';
 
 describe('PacketLogService', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // Clear packet logs and reset settings before each test
-    packetLogService.clearPackets();
+    await packetLogService.clearPackets();
     databaseService.setSetting('packet_log_enabled', '0');
     databaseService.setSetting('packet_log_max_count', '1000');
     databaseService.setSetting('packet_log_max_age_hours', '24');
@@ -317,7 +317,7 @@ describe('PacketLogService', () => {
 
       expect(await packetLogService.getPacketCount()).toBe(10);
 
-      const deletedCount = packetLogService.clearPackets();
+      const deletedCount = await packetLogService.clearPackets();
       expect(deletedCount).toBe(10);
       expect(await packetLogService.getPacketCount()).toBe(0);
     });

--- a/src/server/services/packetLogService.ts
+++ b/src/server/services/packetLogService.ts
@@ -138,12 +138,13 @@ class PacketLogService {
   /**
    * Clear all packet logs
    */
-  clearPackets(): number {
-    return databaseService.clearPacketLogs();
+  async clearPackets(): Promise<number> {
+    return databaseService.clearPacketLogsAsync();
   }
 
   /**
    * Clear all packet logs - async version for all backends
+   * @deprecated Use clearPackets() directly — it is now async.
    */
   async clearPacketsAsync(): Promise<number> {
     return databaseService.clearPacketLogsAsync();

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3392,7 +3392,10 @@ class DatabaseService {
     // Backend-agnostic path: the telemetry repository computes rates via Drizzle
     // for SQLite/PostgreSQL/MySQL alike (see TelemetryRepository.getPacketRates).
     if (this.telemetryRepo) {
-      return this.telemetryRepo.getPacketRates(nodeId, types, sinceTimestamp, sourceId);
+      // intentional cross-source when sourceId omitted: the legacy facade
+      // (raw SQL) skipped the source filter entirely for undefined sourceId,
+      // and withSourceScope throws on undefined — preserve that behavior.
+      return this.telemetryRepo.getPacketRates(nodeId, types, sinceTimestamp, sourceId ?? ALL_SOURCES);
     }
     // Fallback to the legacy sync SQLite implementation when no repo is wired.
     return this.getPacketRates(nodeId, types, sinceTimestamp, sourceId);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -59,6 +59,9 @@ import {
 } from '../db/repositories/index.js';
 import type { EstimatedPosition, EstimatedPositionInput, SourceScope } from '../db/repositories/index.js';
 import type { DatabaseType, DbPacketLog as DbTypesPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../db/types.js';
+import { updateNodeMobility } from '../server/services/nodeMobilityService.js';
+import { selectNodeNeedingTraceroute } from '../server/services/autoTracerouteSelectionService.js';
+import { NodeCacheService } from '../server/services/nodeCacheService.js';
 
 // Configuration constants for traceroute history
 const TRACEROUTE_HISTORY_LIMIT = getEnvironmentConfig().tracerouteHistoryLimit;
@@ -353,92 +356,12 @@ class DatabaseService {
   // These caches allow sync methods like getSetting() and getNode() to work
   // with async databases by caching data loaded at startup
   private settingsCache: Map<string, string> = new Map();
-  private nodesCache: Map<string, DbNode> = new Map();
-
   /**
-   * Phase 3B: Build composite cache key from nodeNum + sourceId.
-   * The nodes table PK is (nodeNum, sourceId) post-migration 029.
+   * In-memory node cache (PostgreSQL/MySQL sync-method compatibility). Extracted
+   * into NodeCacheService, which owns the `${nodeNum}:${sourceId}` key scheme,
+   * repo→cache conversion, and the NodesRepository cache-hook wiring.
    */
-  private cacheKey(nodeNum: number, sourceId: string): string {
-    return `${nodeNum}:${sourceId}`;
-  }
-
-  /**
-   * Convert a repository-shaped node row (with `null` for missing fields and a
-   * `sourceId` column) into the local DatabaseService cache shape (with
-   * `undefined` for optional fields). Mirrors the conversion in
-   * loadCachesFromDatabase so cache writes from the repo cache hook stay
-   * structurally identical to the startup-loaded entries.
-   */
-  private repoNodeToCacheNode(node: any, sourceId: string): DbNode {
-    return {
-      nodeNum: node.nodeNum,
-      nodeId: node.nodeId,
-      longName: node.longName ?? '',
-      shortName: node.shortName ?? '',
-      hwModel: node.hwModel ?? 0,
-      role: node.role ?? undefined,
-      hopsAway: node.hopsAway ?? undefined,
-      lastMessageHops: node.lastMessageHops ?? undefined,
-      viaMqtt: node.viaMqtt ?? undefined,
-      macaddr: node.macaddr ?? undefined,
-      latitude: node.latitude ?? undefined,
-      longitude: node.longitude ?? undefined,
-      altitude: node.altitude ?? undefined,
-      batteryLevel: node.batteryLevel ?? undefined,
-      voltage: node.voltage ?? undefined,
-      channelUtilization: node.channelUtilization ?? undefined,
-      airUtilTx: node.airUtilTx ?? undefined,
-      lastHeard: node.lastHeard ?? undefined,
-      snr: node.snr ?? undefined,
-      rssi: node.rssi ?? undefined,
-      lastTracerouteRequest: node.lastTracerouteRequest ?? undefined,
-      firmwareVersion: node.firmwareVersion ?? undefined,
-      channel: node.channel ?? undefined,
-      isFavorite: node.isFavorite ?? undefined,
-      favoriteLocked: node.favoriteLocked ?? undefined,
-      isIgnored: node.isIgnored ?? undefined,
-      mobile: node.mobile ?? undefined,
-      rebootCount: node.rebootCount ?? undefined,
-      publicKey: node.publicKey ?? undefined,
-      hasPKC: node.hasPKC ?? undefined,
-      lastPKIPacket: node.lastPKIPacket ?? undefined,
-      keyIsLowEntropy: node.keyIsLowEntropy ?? undefined,
-      duplicateKeyDetected: node.duplicateKeyDetected ?? undefined,
-      keyMismatchDetected: node.keyMismatchDetected ?? undefined,
-      keySecurityIssueDetails: node.keySecurityIssueDetails ?? undefined,
-      welcomedAt: node.welcomedAt ?? undefined,
-      positionChannel: node.positionChannel ?? undefined,
-      positionPrecisionBits: node.positionPrecisionBits ?? undefined,
-      positionGpsAccuracy: node.positionGpsAccuracy ?? undefined,
-      positionHdop: node.positionHdop ?? undefined,
-      positionTimestamp: node.positionTimestamp ?? undefined,
-      positionOverrideEnabled: node.positionOverrideEnabled ?? undefined,
-      latitudeOverride: node.latitudeOverride ?? undefined,
-      longitudeOverride: node.longitudeOverride ?? undefined,
-      altitudeOverride: node.altitudeOverride ?? undefined,
-      positionOverrideIsPrivate: node.positionOverrideIsPrivate ?? undefined,
-      hideFromMap: node.hideFromMap ?? undefined,
-      notes: node.notes ?? undefined,
-      hasRemoteAdmin: node.hasRemoteAdmin ?? undefined,
-      lastRemoteAdminCheck: node.lastRemoteAdminCheck ?? undefined,
-      remoteAdminMetadata: node.remoteAdminMetadata ?? undefined,
-      sourceId: node.sourceId ?? sourceId,
-      createdAt: node.createdAt,
-      updatedAt: node.updatedAt,
-    } as DbNode;
-  }
-
-  /**
-   * Phase 3B: Iterate cache, optionally filtered by sourceId.
-   */
-  private *iterateCache(sourceId?: SourceScope): IterableIterator<DbNode> {
-    for (const node of this.nodesCache.values()) {
-      // ALL_SOURCES or undefined → yield all; concrete string → filter by source.
-      if (typeof sourceId === 'string' && sourceId !== '' && node.sourceId !== sourceId) continue;
-      yield node;
-    }
-  }
+  public readonly nodeCache: NodeCacheService = new NodeCacheService();
   private channelsCache: Map<number, DbChannel> = new Map();
   private _traceroutesCache: DbTraceroute[] = [];
   private _traceroutesByNodesCache: Map<string, DbTraceroute[]> = new Map();
@@ -956,54 +879,11 @@ class DatabaseService {
       this.settingsRepo = new SettingsRepository(drizzleDb, this.drizzleDbType);
       this.channelsRepo = new ChannelsRepository(drizzleDb, this.drizzleDbType);
       this.nodesRepo = new NodesRepository(drizzleDb, this.drizzleDbType);
-      // Wire the in-memory nodesCache to repository writes so PG/MySQL caches
+      // Wire the in-memory node cache to repository writes so PG/MySQL caches
       // stay coherent with DB state — fixes #2858 where bypassing the facade
       // (e.g. via `databaseService.nodes.upsertNode(...)`) left newly-discovered
       // nodes invisible to sync cache readers like setNodePositionOverride.
-      this.nodesRepo.setCacheHook({
-        setNode: (nodeNum, sourceId, node) => {
-          const key = this.cacheKey(nodeNum, sourceId);
-          if (!node) {
-            this.nodesCache.delete(key);
-            return;
-          }
-          this.nodesCache.set(key, this.repoNodeToCacheNode(node, sourceId));
-        },
-        setNodeAcrossSources: (nodeNum, freshNodes) => {
-          // Remove existing cache entries for this nodeNum that aren't in freshNodes,
-          // then upsert each fresh row.
-          const keepSourceIds = new Set(freshNodes.map(n => (n as any).sourceId ?? 'default'));
-          for (const key of Array.from(this.nodesCache.keys())) {
-            const cached = this.nodesCache.get(key);
-            if (cached && cached.nodeNum === nodeNum && !keepSourceIds.has(cached.sourceId ?? 'default')) {
-              this.nodesCache.delete(key);
-            }
-          }
-          for (const fresh of freshNodes) {
-            const sid = (fresh as any).sourceId ?? 'default';
-            this.nodesCache.set(this.cacheKey(nodeNum, sid), this.repoNodeToCacheNode(fresh, sid));
-          }
-        },
-        setNodeByNodeId: (nodeId, freshNodes) => {
-          // Replace all cache entries for this nodeId with the fresh set.
-          const keepKeys = new Set(
-            freshNodes.map(n => this.cacheKey(n.nodeNum, (n as any).sourceId ?? 'default'))
-          );
-          for (const key of Array.from(this.nodesCache.keys())) {
-            const cached = this.nodesCache.get(key);
-            if (cached && cached.nodeId === nodeId && !keepKeys.has(key)) {
-              this.nodesCache.delete(key);
-            }
-          }
-          for (const fresh of freshNodes) {
-            const sid = (fresh as any).sourceId ?? 'default';
-            this.nodesCache.set(this.cacheKey(fresh.nodeNum, sid), this.repoNodeToCacheNode(fresh, sid));
-          }
-        },
-        clear: () => {
-          this.nodesCache.clear();
-        },
-      });
+      this.nodesRepo.setCacheHook(this.nodeCache.buildHook());
       this.messagesRepo = new MessagesRepository(drizzleDb, this.drizzleDbType);
       this.telemetryRepo = new TelemetryRepository(drizzleDb, this.drizzleDbType);
       // Auth repo for all backends - Migration 012 aligned SQLite schema with Drizzle definitions
@@ -1073,75 +953,13 @@ class DatabaseService {
         logger.info(`[DatabaseService] Loaded ${this.settingsCache.size} settings into cache`);
       }
 
-      // Load all nodes into cache
+      // Load all nodes into cache (NodeCacheService handles the repo→cache
+      // conversion and cross-source warm-up).
       if (this.nodesRepo) {
-        // intentional cross-source: init cache warm-up loads all sources at once
-        const nodes = await this.nodesRepo.getAllNodes(ALL_SOURCES);
-        this.nodesCache.clear();
-        for (const node of nodes) {
-          // Convert from repo DbNode to local DbNode (null -> undefined conversion is safe)
-          // The types only differ in null vs undefined for optional fields
-          const localNode: DbNode = {
-            nodeNum: node.nodeNum,
-            nodeId: node.nodeId,
-            longName: node.longName ?? '',
-            shortName: node.shortName ?? '',
-            hwModel: node.hwModel ?? 0,
-            role: node.role ?? undefined,
-            hopsAway: node.hopsAway ?? undefined,
-            lastMessageHops: node.lastMessageHops ?? undefined,
-            viaMqtt: node.viaMqtt ?? undefined,
-            macaddr: node.macaddr ?? undefined,
-            latitude: node.latitude ?? undefined,
-            longitude: node.longitude ?? undefined,
-            altitude: node.altitude ?? undefined,
-            batteryLevel: node.batteryLevel ?? undefined,
-            voltage: node.voltage ?? undefined,
-            channelUtilization: node.channelUtilization ?? undefined,
-            airUtilTx: node.airUtilTx ?? undefined,
-            lastHeard: node.lastHeard ?? undefined,
-            snr: node.snr ?? undefined,
-            rssi: node.rssi ?? undefined,
-            lastTracerouteRequest: node.lastTracerouteRequest ?? undefined,
-            firmwareVersion: node.firmwareVersion ?? undefined,
-            channel: node.channel ?? undefined,
-            isFavorite: node.isFavorite ?? undefined,
-            favoriteLocked: node.favoriteLocked ?? undefined,
-            isIgnored: node.isIgnored ?? undefined,
-            mobile: node.mobile ?? undefined,
-            rebootCount: node.rebootCount ?? undefined,
-            publicKey: node.publicKey ?? undefined,
-            hasPKC: node.hasPKC ?? undefined,
-            lastPKIPacket: node.lastPKIPacket ?? undefined,
-            keyIsLowEntropy: node.keyIsLowEntropy ?? undefined,
-            duplicateKeyDetected: node.duplicateKeyDetected ?? undefined,
-            keyMismatchDetected: node.keyMismatchDetected ?? undefined,
-            keySecurityIssueDetails: node.keySecurityIssueDetails ?? undefined,
-            welcomedAt: node.welcomedAt ?? undefined,
-            positionChannel: node.positionChannel ?? undefined,
-            positionPrecisionBits: node.positionPrecisionBits ?? undefined,
-            positionGpsAccuracy: node.positionGpsAccuracy ?? undefined,
-            positionHdop: node.positionHdop ?? undefined,
-            positionTimestamp: node.positionTimestamp ?? undefined,
-            positionOverrideEnabled: node.positionOverrideEnabled ?? undefined,
-            latitudeOverride: node.latitudeOverride ?? undefined,
-            longitudeOverride: node.longitudeOverride ?? undefined,
-            altitudeOverride: node.altitudeOverride ?? undefined,
-            positionOverrideIsPrivate: node.positionOverrideIsPrivate ?? undefined,
-            hideFromMap: node.hideFromMap ?? undefined,
-            notes: node.notes ?? undefined,
-            hasRemoteAdmin: node.hasRemoteAdmin ?? undefined,
-            lastRemoteAdminCheck: node.lastRemoteAdminCheck ?? undefined,
-            remoteAdminMetadata: node.remoteAdminMetadata ?? undefined,
-            sourceId: (node as any).sourceId ?? 'default',
-            createdAt: node.createdAt,
-            updatedAt: node.updatedAt,
-          };
-          this.nodesCache.set(this.cacheKey(localNode.nodeNum, localNode.sourceId ?? 'default'), localNode);
-        }
+        await this.nodeCache.warmFromRepo(this.nodesRepo);
         // Count nodes with welcomedAt set for auto-welcome diagnostics
-        const nodesWithWelcome = Array.from(this.nodesCache.values()).filter(n => n.welcomedAt !== null && n.welcomedAt !== undefined);
-        logger.info(`[DatabaseService] Loaded ${this.nodesCache.size} nodes into cache (${nodesWithWelcome.length} previously welcomed)`);
+        const nodesWithWelcome = Array.from(this.nodeCache.values()).filter(n => n.welcomedAt !== null && n.welcomedAt !== undefined);
+        logger.info(`[DatabaseService] Loaded ${this.nodeCache.size} nodes into cache (${nodesWithWelcome.length} previously welcomed)`);
       }
 
       // Load all channels into cache
@@ -1524,7 +1342,7 @@ class DatabaseService {
       // Check if this node already exists (in cache for Postgres/MySQL, in DB for SQLite)
       const suppressedSourceId = (nodeData as any).sourceId ?? 'default';
       const existsInCache = (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql')
-        ? this.nodesCache.has(this.cacheKey(nodeData.nodeNum, suppressedSourceId))
+        ? this.nodeCache.has(nodeData.nodeNum, suppressedSourceId)
         : !!this.getNode(nodeData.nodeNum);
       if (!existsInCache) {
         logger.debug(`👻 Suppressed ghost node creation for !${nodeData.nodeNum.toString(16).padStart(8, '0')}`);
@@ -1537,7 +1355,7 @@ class DatabaseService {
       if (this.nodesRepo) {
         // Update cache optimistically
         const upsertSourceId = (nodeData as any).sourceId ?? 'default';
-        const existingNode = this.nodesCache.get(this.cacheKey(nodeData.nodeNum, upsertSourceId));
+        const existingNode = this.nodeCache.get(nodeData.nodeNum, upsertSourceId);
         const now = Date.now();
         const updatedNode: DbNode = {
           nodeNum: nodeData.nodeNum,
@@ -1614,7 +1432,7 @@ class DatabaseService {
           updatedNode.isIgnored = true;
         }
 
-        this.nodesCache.set(this.cacheKey(nodeData.nodeNum, upsertSourceId), updatedNode);
+        this.nodeCache.set(nodeData.nodeNum, upsertSourceId, updatedNode);
 
         // Fire and forget async version - pass the full merged node to avoid race conditions
         // where a subsequent update (like welcomedAt) could be overwritten. Pass sourceId
@@ -1760,11 +1578,11 @@ class DatabaseService {
       }
       // When sourceId is provided, use the composite cache key directly.
       if (sourceId) {
-        return this.nodesCache.get(this.cacheKey(nodeNum, sourceId)) ?? null;
+        return this.nodeCache.get(nodeNum, sourceId) ?? null;
       }
       // Legacy fallback: iterate cache to find first match by nodeNum
       // (used by callers that haven't been threaded through Phase 3 yet).
-      for (const node of this.nodesCache.values()) {
+      for (const node of this.nodeCache.values()) {
         if (node.nodeNum === nodeNum) return node;
       }
       return null;
@@ -1780,7 +1598,7 @@ class DatabaseService {
         logger.debug('getAllNodes() called before cache initialized');
         return [];
       }
-      return Array.from(this.iterateCache(sourceId));
+      return Array.from(this.nodeCache.iterate(sourceId));
     }
     // SQLite: delegate to Drizzle sync variant
     return this.nodesRepo!.getAllNodesSqlite(sourceId) as unknown as DbNode[];
@@ -1801,7 +1619,7 @@ class DatabaseService {
         return [];
       }
       const cutoff = Math.floor(Date.now() / 1000) - (sinceDays * 24 * 60 * 60);
-      return Array.from(this.iterateCache())
+      return Array.from(this.nodeCache.iterate())
         .filter(node => node.lastHeard !== undefined && node.lastHeard !== null && node.lastHeard > cutoff)
         .sort((a, b) => (b.lastHeard ?? 0) - (a.lastHeard ?? 0));
     }
@@ -1818,7 +1636,7 @@ class DatabaseService {
     const now = Date.now();
     // Update cache for PostgreSQL/MySQL
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         cachedNode.lastMessageHops = hops;
         cachedNode.updatedAt = now;
@@ -1844,7 +1662,7 @@ class DatabaseService {
     // Update cache for PostgreSQL/MySQL
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       let count = 0;
-      for (const node of this.iterateCache(sourceId ?? undefined)) {
+      for (const node of this.nodeCache.iterate(sourceId ?? undefined)) {
         if (node.welcomedAt === undefined || node.welcomedAt === null) {
           node.welcomedAt = now;
           node.updatedAt = now;
@@ -1872,7 +1690,7 @@ class DatabaseService {
     const now = Date.now();
     // Update cache for PostgreSQL/MySQL
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode && cachedNode.nodeId === nodeId && (cachedNode.welcomedAt === undefined || cachedNode.welcomedAt === null)) {
         cachedNode.welcomedAt = now;
         cachedNode.updatedAt = now;
@@ -1948,7 +1766,7 @@ class DatabaseService {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       const result: Array<{ nodeNum: number; publicKey: string | null }> = [];
-      for (const node of this.iterateCache()) {
+      for (const node of this.nodeCache.iterate()) {
         if (node.publicKey && node.publicKey !== '') {
           result.push({ nodeNum: node.nodeNum, publicKey: node.publicKey });
         }
@@ -1968,7 +1786,7 @@ class DatabaseService {
    */
   updateNodeSecurityFlags(nodeNum: number, duplicateKeyDetected: boolean, keySecurityIssueDetails: string | undefined, sourceId: string): void {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         cachedNode.duplicateKeyDetected = duplicateKeyDetected;
         cachedNode.keySecurityIssueDetails = keySecurityIssueDetails;
@@ -2023,7 +1841,7 @@ class DatabaseService {
 
     // For PostgreSQL/MySQL, update cache and fire-and-forget
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         cachedNode.keyIsLowEntropy = keyIsLowEntropy;
         cachedNode.keySecurityIssueDetails = combinedDetails || undefined;
@@ -2115,7 +1933,7 @@ class DatabaseService {
 
     // For PostgreSQL/MySQL, update cache and fire-and-forget
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         (cachedNode as any).isExcessivePackets = isExcessivePackets;
         (cachedNode as any).packetRatePerHour = packetRatePerHour;
@@ -2160,7 +1978,7 @@ class DatabaseService {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       const result: DbNode[] = [];
-      for (const node of this.iterateCache()) {
+      for (const node of this.nodeCache.iterate()) {
         if ((node as any).isExcessivePackets) {
           result.push(node);
         }
@@ -2177,7 +1995,7 @@ class DatabaseService {
   async getNodesWithExcessivePacketsAsync(sourceId?: string): Promise<DbNode[]> {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       const result: DbNode[] = [];
-      for (const node of this.iterateCache(sourceId)) {
+      for (const node of this.nodeCache.iterate(sourceId)) {
         if ((node as any).isExcessivePackets) {
           result.push(node);
         }
@@ -2198,7 +2016,7 @@ class DatabaseService {
   updateNodeTimeOffsetFlags(nodeNum: number, isTimeOffsetIssue: boolean, timeOffsetSeconds: number | null, sourceId: string): void {
     // For PostgreSQL/MySQL, update cache and fire-and-forget
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         (cachedNode as any).isTimeOffsetIssue = isTimeOffsetIssue;
         (cachedNode as any).timeOffsetSeconds = timeOffsetSeconds;
@@ -2242,7 +2060,7 @@ class DatabaseService {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       const result: DbNode[] = [];
-      for (const node of this.iterateCache()) {
+      for (const node of this.nodeCache.iterate()) {
         if ((node as any).isTimeOffsetIssue) {
           result.push(node);
         }
@@ -2259,7 +2077,7 @@ class DatabaseService {
   async getNodesWithTimeOffsetIssuesAsync(sourceId?: string): Promise<DbNode[]> {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       const result: DbNode[] = [];
-      for (const node of this.iterateCache(sourceId)) {
+      for (const node of this.nodeCache.iterate(sourceId)) {
         if ((node as any).isTimeOffsetIssue) {
           result.push(node);
         }
@@ -2546,7 +2364,7 @@ class DatabaseService {
         logger.debug(`getNodeCount() called before cache initialized`);
         return 0;
       }
-      return this.nodesCache.size;
+      return this.nodeCache.size;
     }
     return this.nodesRepo!.getNodeCountSqlite();
   }
@@ -2649,64 +2467,15 @@ class DatabaseService {
    * @returns The updated mobility status (0 = stationary, 1 = mobile)
    */
   async updateNodeMobilityAsync(nodeId: string): Promise<number> {
-    try {
-      // Get last 500 position telemetry records for this node
-      // Using a larger limit ensures we capture movement over a longer time period
-      // (50 was too small - nodes parked for a while would show only recent stationary positions)
-      const positionTelemetry = this.telemetryRepo
-        ? await this.telemetryRepo.getPositionTelemetryByNode(nodeId, 500, undefined, ALL_SOURCES) // intentional cross-source: mobility check pools all sources' positions
-        : this.getPositionTelemetryByNode(nodeId, 500);
-
-      const latitudes = positionTelemetry.filter(t => t.telemetryType === 'latitude');
-      const longitudes = positionTelemetry.filter(t => t.telemetryType === 'longitude');
-
-      let isMobile = 0;
-
-      // Need at least 2 position records to detect movement
-      if (latitudes.length >= 2 && longitudes.length >= 2) {
-        const latValues = latitudes.map(t => t.value);
-        const lonValues = longitudes.map(t => t.value);
-
-        const minLat = Math.min(...latValues);
-        const maxLat = Math.max(...latValues);
-        const minLon = Math.min(...lonValues);
-        const maxLon = Math.max(...lonValues);
-
-        // Calculate distance between min/max corners using Haversine formula
-        const R = 6371; // Earth's radius in km
-        const dLat = (maxLat - minLat) * Math.PI / 180;
-        const dLon = (maxLon - minLon) * Math.PI / 180;
-        const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                  Math.cos(minLat * Math.PI / 180) * Math.cos(maxLat * Math.PI / 180) *
-                  Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        const distance = R * c;
-
-        // If movement is greater than 100 meters (0.1 km), mark as mobile
-        isMobile = distance > 0.1 ? 1 : 0;
-
-        logger.debug(`📍 Node ${nodeId} mobility check: ${latitudes.length} positions, distance=${distance.toFixed(3)}km, mobile=${isMobile}`);
-      }
-
-      // Update the mobile flag in the database using repository
-      if (this.nodesRepo) {
-        await this.nodesRepo.updateNodeMobility(nodeId, isMobile);
-      }
-
-      // Also update the cache so getAllNodes() returns the updated value
-      for (const [key, cachedNode] of this.nodesCache.entries()) {
-        if (cachedNode.nodeId === nodeId) {
-          cachedNode.mobile = isMobile;
-          this.nodesCache.set(key, cachedNode);
-          break;
-        }
-      }
-
-      return isMobile;
-    } catch (error) {
-      logger.error(`Failed to update mobility for node ${nodeId}:`, error);
-      return 0; // Default to non-mobile on error
-    }
+    // Delegates the movement heuristic to NodeMobilityService; the cache patch
+    // stays here so the service has no direct dependency on the facade's cache.
+    return updateNodeMobility(nodeId, {
+      telemetryRepo: this.telemetryRepo!,
+      nodesRepo: this.nodesRepo!,
+      patchCache: (nid, mobile) => {
+        this.nodeCache.patchMobility(nid, mobile);
+      },
+    });
   }
 
   getMessagesByDay(days: number = 7): Array<{ date: string; count: number }> {
@@ -2858,10 +2627,9 @@ class DatabaseService {
     // For PostgreSQL/MySQL, update cache and fire-and-forget async delete
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       // Remove from cache immediately (scoped lookup)
-      const key = this.cacheKey(nodeNum, sourceId);
-      const existed = this.nodesCache.has(key);
+      const existed = this.nodeCache.has(nodeNum, sourceId);
       if (existed) {
-        this.nodesCache.delete(key);
+        this.nodeCache.delete(nodeNum, sourceId);
       }
 
       // Fire-and-forget async deletion of all associated data
@@ -3621,90 +3389,13 @@ class DatabaseService {
     sinceTimestamp?: number,
     sourceId?: string
   ): Promise<Record<string, Array<{ timestamp: number; ratePerMinute: number }>>> {
-    const result: Record<string, Array<{ timestamp: number; ratePerMinute: number }>> = {};
-    for (const type of types) {
-      result[type] = [];
+    // Backend-agnostic path: the telemetry repository computes rates via Drizzle
+    // for SQLite/PostgreSQL/MySQL alike (see TelemetryRepository.getPacketRates).
+    if (this.telemetryRepo) {
+      return this.telemetryRepo.getPacketRates(nodeId, types, sinceTimestamp, sourceId);
     }
-
-    if (this.drizzleDbType === 'postgres') {
-      const client = await this.postgresPool!.connect();
-      try {
-        const typePlaceholders = types.map((_, i) => `$${i + 2}`).join(', ');
-        const params: (string | number)[] = [nodeId, ...types];
-        let query = `SELECT "telemetryType", timestamp, value FROM telemetry
-                      WHERE "nodeId" = $1 AND "telemetryType" IN (${typePlaceholders})`;
-        if (sinceTimestamp !== undefined) {
-          params.push(sinceTimestamp);
-          query += ` AND timestamp >= $${params.length}`;
-        }
-        if (sourceId !== undefined) {
-          params.push(sourceId);
-          query += ` AND "sourceId" = $${params.length}`;
-        }
-        query += ` ORDER BY "telemetryType", timestamp ASC`;
-        const queryResult = await client.query(query, params);
-        return this.calculatePacketRates(queryResult.rows, types);
-      } finally {
-        client.release();
-      }
-    } else if (this.drizzleDbType === 'mysql') {
-      const pool = this.mysqlPool!;
-      const typePlaceholders = types.map(() => '?').join(', ');
-      const params: (string | number)[] = [nodeId, ...types];
-      let query = `SELECT telemetryType, timestamp, value FROM telemetry
-                    WHERE nodeId = ? AND telemetryType IN (${typePlaceholders})`;
-      if (sinceTimestamp !== undefined) {
-        params.push(sinceTimestamp);
-        query += ` AND timestamp >= ?`;
-      }
-      if (sourceId !== undefined) {
-        params.push(sourceId);
-        query += ` AND sourceId = ?`;
-      }
-      query += ` ORDER BY telemetryType, timestamp ASC`;
-      const [rows] = await pool.query(query, params);
-      return this.calculatePacketRates(rows as any[], types);
-    }
+    // Fallback to the legacy sync SQLite implementation when no repo is wired.
     return this.getPacketRates(nodeId, types, sinceTimestamp, sourceId);
-  }
-
-  private calculatePacketRates(
-    rows: Array<{ telemetryType: string; timestamp: number; value: number }>,
-    types: string[]
-  ): Record<string, Array<{ timestamp: number; ratePerMinute: number }>> {
-    const result: Record<string, Array<{ timestamp: number; ratePerMinute: number }>> = {};
-    for (const type of types) {
-      result[type] = [];
-    }
-
-    const groupedByType: Record<string, Array<{ timestamp: number; value: number }>> = {};
-    for (const row of rows) {
-      if (!groupedByType[row.telemetryType]) {
-        groupedByType[row.telemetryType] = [];
-      }
-      groupedByType[row.telemetryType].push({
-        timestamp: Number(row.timestamp),
-        value: Number(row.value),
-      });
-    }
-
-    for (const [type, samples] of Object.entries(groupedByType)) {
-      const rates: Array<{ timestamp: number; ratePerMinute: number }> = [];
-      for (let i = 1; i < samples.length; i++) {
-        const deltaValue = samples[i].value - samples[i - 1].value;
-        const deltaTimeMs = samples[i].timestamp - samples[i - 1].timestamp;
-        const deltaTimeMinutes = deltaTimeMs / 60000;
-        if (deltaValue < 0) continue;
-        if (deltaTimeMinutes > 60) continue;
-        if (deltaTimeMinutes < 0.1) continue;
-        rates.push({
-          timestamp: samples[i].timestamp,
-          ratePerMinute: deltaValue / deltaTimeMinutes,
-        });
-      }
-      result[type] = rates;
-    }
-    return result;
   }
 
   insertTraceroute(tracerouteData: DbTraceroute, sourceId?: string): void {
@@ -3767,6 +3458,68 @@ class DatabaseService {
     );
   }
 
+  /**
+   * Async version of insertTraceroute — carries the FULL pending-response
+   * deduplication logic for all backends (not a delegation to the sync form).
+   * For PG/MySQL it awaits the async repo dedup path; for SQLite it runs the
+   * transactional sync upsert (which is itself synchronous under the hood).
+   */
+  async insertTracerouteAsync(tracerouteData: DbTraceroute, sourceId?: string): Promise<void> {
+    // For PostgreSQL/MySQL, use async repository with full dedup logic
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      if (this.traceroutesRepo) {
+        const now = Date.now();
+        const pendingTimeoutAgo = now - PENDING_TRACEROUTE_TIMEOUT_MS;
+        try {
+          // Check for pending traceroute (reversed direction - see note below)
+          // NOTE: When a traceroute response comes in, fromNum is the destination (responder) and toNum is the local node (requester)
+          // But when we created the pending record, fromNodeNum was the local node and toNodeNum was the destination
+          const pendingRecord = await this.traceroutesRepo.findPendingTraceroute(
+            tracerouteData.toNodeNum,    // Reversed: response's toNum is the requester
+            tracerouteData.fromNodeNum,  // Reversed: response's fromNum is the destination
+            pendingTimeoutAgo,
+            sourceId
+          );
+
+          if (pendingRecord) {
+            // Update existing pending record
+            await this.traceroutesRepo.updateTracerouteResponse(
+              pendingRecord.id,
+              tracerouteData.route || null,
+              tracerouteData.routeBack || null,
+              tracerouteData.snrTowards || null,
+              tracerouteData.snrBack || null,
+              tracerouteData.timestamp,
+              tracerouteData.packetId ?? null
+            );
+          } else {
+            // Insert new traceroute
+            await this.traceroutesRepo.insertTraceroute(tracerouteData, sourceId);
+          }
+
+          // Cleanup old traceroutes
+          await this.traceroutesRepo.cleanupOldTraceroutesForPair(
+            tracerouteData.fromNodeNum,
+            tracerouteData.toNodeNum,
+            TRACEROUTE_HISTORY_LIMIT,
+            sourceId
+          );
+        } catch (error) {
+          logger.error('[DatabaseService] Failed to insert traceroute:', error);
+        }
+      }
+      return;
+    }
+
+    // SQLite: delegate to repository sync upsert (runs in a transaction)
+    this.traceroutes.upsertTracerouteSync(
+      tracerouteData,
+      PENDING_TRACEROUTE_TIMEOUT_MS,
+      TRACEROUTE_HISTORY_LIMIT,
+      sourceId
+    );
+  }
+
   getTraceroutesByNodes(fromNodeNum: number, toNodeNum: number, limit: number = 10): DbTraceroute[] {
     // For PostgreSQL/MySQL, use async repo with cache pattern
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
@@ -3815,6 +3568,14 @@ class DatabaseService {
     }
 
     return this.traceroutes.getAllTraceroutesRecentSync(limit, sourceId) as unknown as DbTraceroute[];
+  }
+
+  /**
+   * Async version of getAllTraceroutes — works across all backends by awaiting
+   * the repository directly instead of relying on the sync fire-and-cache path.
+   */
+  async getAllTraceroutesAsync(limit: number = 100, sourceId?: SourceScope): Promise<DbTraceroute[]> {
+    return (await this.traceroutes.getAllTraceroutes(limit, sourceId)) as unknown as DbTraceroute[];
   }
 
   getNodeNeedingTraceroute(localNodeNum: number): DbNode | null {
@@ -3985,167 +3746,26 @@ class DatabaseService {
    * Returns a node that needs a traceroute based on configured filters and timing
    */
   async getNodeNeedingTracerouteAsync(localNodeNum: number, sourceId?: string): Promise<DbNode | null> {
-    const now = Date.now();
-    const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
+    // For SQLite (or before the repo is wired) with no sourceId, use the legacy
+    // sync selection path. The repo path handles SQLite when a sourceId is set.
+    if (this.drizzleDbType === 'sqlite' || !this.nodesRepo) {
+      if (!sourceId) return this.getNodeNeedingTraceroute(localNodeNum);
+    }
 
     // Read ALL filter configuration per-source (falls back to global when
     // no per-source override exists). This is what makes Auto-Traceroute
     // filters honor the Source that the scheduler tick is running on.
     const filterCfg = await this.getTracerouteFilterSettingsAsync(sourceId);
-    const EXPIRATION_MS = filterCfg.expirationHours * 60 * 60 * 1000;
 
-    // Get maxNodeAgeHours setting to filter only active nodes
-    // lastHeard is stored in seconds (Unix timestamp), so convert cutoff to seconds
+    // Get maxNodeAgeHours setting to filter only active nodes.
     const maxNodeAgeHours = parseInt(this.getSetting('maxNodeAgeHours') || '24');
-    const activeNodeCutoff = Math.floor(Date.now() / 1000) - (maxNodeAgeHours * 60 * 60);
 
-    // For SQLite, use repository (which now supports sourceId)
-    if (this.drizzleDbType === 'sqlite' || !this.nodesRepo) {
-      if (!sourceId) return this.getNodeNeedingTraceroute(localNodeNum);
-      // Use repo path for SQLite when sourceId is needed
-    }
-
-    try {
-      // Get eligible nodes from repository
-      let eligibleNodes = await this.nodesRepo!.getEligibleNodesForTraceroute(
-        localNodeNum,
-        activeNodeCutoff,
-        now - THREE_HOURS_MS,
-        now - EXPIRATION_MS,
-        sourceId
-      );
-
-      // Last heard and hop range filters (AND logic, applied before OR union filters)
-      const filterLastHeardEnabled = filterCfg.filterLastHeardEnabled;
-      const filterLastHeardHours = filterCfg.filterLastHeardHours;
-      const filterHopsEnabled = filterCfg.filterHopsEnabled;
-      const filterHopsMin = filterCfg.filterHopsMin;
-      const filterHopsMax = filterCfg.filterHopsMax;
-
-      // Apply last-heard filter (AND logic — applied before OR union filters)
-      if (filterLastHeardEnabled) {
-        const lastHeardCutoff = Math.floor(Date.now() / 1000) - (filterLastHeardHours * 3600);
-        eligibleNodes = eligibleNodes.filter(node => {
-          // Exclude nodes with no lastHeard or lastHeard older than cutoff
-          return node.lastHeard != null && node.lastHeard >= lastHeardCutoff;
-        });
-      }
-
-      // Apply hop range filter (AND logic)
-      if (filterHopsEnabled) {
-        eligibleNodes = eligibleNodes.filter(node => {
-          // Treat NULL hopsAway as 1 (direct neighbor)
-          const hops = node.hopsAway ?? 1;
-          return hops >= filterHopsMin && hops <= filterHopsMax;
-        });
-      }
-
-      // Check if node filter is enabled (per-source when scoped)
-      const filterEnabled = filterCfg.enabled;
-
-      if (filterEnabled) {
-        const specificNodes = filterCfg.nodeNums;
-        const filterChannels = filterCfg.filterChannels;
-        const filterRoles = filterCfg.filterRoles;
-        const filterHwModels = filterCfg.filterHwModels;
-        const filterNameRegex = filterCfg.filterNameRegex;
-
-        const filterNodesEnabled = filterCfg.filterNodesEnabled;
-        const filterChannelsEnabled = filterCfg.filterChannelsEnabled;
-        const filterRolesEnabled = filterCfg.filterRolesEnabled;
-        const filterHwModelsEnabled = filterCfg.filterHwModelsEnabled;
-        const filterRegexEnabled = filterCfg.filterRegexEnabled;
-
-        // Build regex matcher if enabled
-        let regexMatcher: RegExp | null = null;
-        if (filterRegexEnabled && filterNameRegex && filterNameRegex !== '.*') {
-          try {
-            regexMatcher = compileUserRegex(filterNameRegex, 'i');
-          } catch (e) {
-            logger.warn(`Invalid traceroute filter regex: ${filterNameRegex}`, e);
-          }
-        }
-
-        // Check if ANY filter is actually configured
-        const hasAnyFilter =
-          (filterNodesEnabled && specificNodes.length > 0) ||
-          (filterChannelsEnabled && filterChannels.length > 0) ||
-          (filterRolesEnabled && filterRoles.length > 0) ||
-          (filterHwModelsEnabled && filterHwModels.length > 0) ||
-          (filterRegexEnabled && regexMatcher !== null);
-
-        // Only filter if at least one filter is configured
-        if (hasAnyFilter) {
-          eligibleNodes = eligibleNodes.filter(node => {
-            // UNION logic: node passes if it matches ANY enabled filter
-            // Check specific nodes filter
-            if (filterNodesEnabled && specificNodes.length > 0) {
-              if (specificNodes.includes(node.nodeNum)) {
-                return true;
-              }
-            }
-
-            // Check channel filter
-            if (filterChannelsEnabled && filterChannels.length > 0) {
-              if (node.channel != null && filterChannels.includes(node.channel)) {
-                return true;
-              }
-            }
-
-            // Check role filter
-            if (filterRolesEnabled && filterRoles.length > 0) {
-              if (node.role != null && filterRoles.includes(node.role)) {
-                return true;
-              }
-            }
-
-            // Check hardware model filter
-            if (filterHwModelsEnabled && filterHwModels.length > 0) {
-              if (node.hwModel != null && filterHwModels.includes(node.hwModel)) {
-                return true;
-              }
-            }
-
-            // Check regex name filter
-            if (filterRegexEnabled && regexMatcher !== null) {
-              const name = node.longName || node.shortName || node.nodeId || '';
-              if (regexMatcher.test(name)) {
-                return true;
-              }
-            }
-
-            // Node didn't match any enabled filter
-            return false;
-          });
-        }
-        // If hasAnyFilter is false, all nodes pass (no filtering applied)
-      }
-
-      if (eligibleNodes.length === 0) {
-        return null;
-      }
-
-      // Check if sort by hops is enabled (per-source when scoped)
-      const sortByHops = filterCfg.sortByHops;
-
-      if (sortByHops) {
-        // Sort by hopsAway ascending (closer nodes first), with undefined hops at the end
-        eligibleNodes.sort((a, b) => {
-          const hopsA = a.hopsAway ?? Infinity;
-          const hopsB = b.hopsAway ?? Infinity;
-          return hopsA - hopsB;
-        });
-        // Take the first (closest) node
-        return this.normalizeBigInts(eligibleNodes[0]);
-      }
-
-      // Randomly select one node from the eligible nodes
-      const randomIndex = Math.floor(Math.random() * eligibleNodes.length);
-      return this.normalizeBigInts(eligibleNodes[randomIndex]);
-    } catch (error) {
-      logger.error('Error in getNodeNeedingTracerouteAsync:', error);
-      return null;
-    }
+    return selectNodeNeedingTraceroute(localNodeNum, sourceId, {
+      filterCfg,
+      maxNodeAgeHours,
+      nodesRepo: this.nodesRepo!,
+      normalizeBigInts: (node) => this.normalizeBigInts(node),
+    }) as unknown as Promise<DbNode | null>;
   }
 
   /**
@@ -4359,7 +3979,7 @@ class DatabaseService {
 
       // Update cache for PostgreSQL/MySQL
       if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-        const existingNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+        const existingNode = this.nodeCache.get(nodeNum, sourceId);
         if (existingNode) {
           existingNode.hasRemoteAdmin = hasRemoteAdmin;
           existingNode.lastRemoteAdminCheck = Date.now();
@@ -5353,14 +4973,14 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       // Clear the nodes cache immediately (scoped clear when sourceId is provided)
       if (sourceId) {
-        for (const key of Array.from(this.nodesCache.keys())) {
-          const cached = this.nodesCache.get(key);
+        for (const key of Array.from(this.nodeCache.keys())) {
+          const cached = this.nodeCache.rawGet(key);
           if (cached && (cached as any).sourceId === sourceId) {
-            this.nodesCache.delete(key);
+            this.nodeCache.deleteByKey(key);
           }
         }
       } else {
-        this.nodesCache.clear();
+        this.nodeCache.clear();
       }
 
       // Fire-and-forget async purge
@@ -5777,7 +5397,7 @@ class DatabaseService {
       }
 
       // Also remove from cache (scoped lookup)
-      this.nodesCache.delete(this.cacheKey(nodeNum, sourceId));
+      this.nodeCache.delete(nodeNum, sourceId);
 
       logger.debug(`Deleted node ${nodeNum}@${sourceId}: messages=${messagesDeleted}, traceroutes=${traceroutesDeleted}, telemetry=${telemetryDeleted}, node=${nodeDeleted}`);
     } catch (error) {
@@ -5842,14 +5462,14 @@ class DatabaseService {
 
       // Clear the cache (scoped if a sourceId was provided)
       if (sourceId) {
-        for (const key of Array.from(this.nodesCache.keys())) {
-          const cached = this.nodesCache.get(key);
+        for (const key of Array.from(this.nodeCache.keys())) {
+          const cached = this.nodeCache.rawGet(key);
           if (cached && (cached as any).sourceId === sourceId) {
-            this.nodesCache.delete(key);
+            this.nodeCache.deleteByKey(key);
           }
         }
       } else {
-        this.nodesCache.clear();
+        this.nodeCache.clear();
       }
 
       logger.debug('✅ Successfully purged nodes and related data (async)');
@@ -5873,6 +5493,14 @@ class DatabaseService {
 
     // SQLite path
     this.traceroutesRepo!.insertRouteSegmentSync(segmentData, sourceId);
+  }
+
+  /**
+   * Async version of insertRouteSegment — awaits the repository insert directly
+   * so callers can surface/await failures instead of fire-and-forget.
+   */
+  async insertRouteSegmentAsync(segmentData: DbRouteSegment, sourceId?: string): Promise<void> {
+    await this.traceroutesRepo!.insertRouteSegment(segmentData, sourceId);
   }
 
   getLongestActiveRouteSegment(sourceId?: string): DbRouteSegment | null {
@@ -6148,6 +5776,16 @@ class DatabaseService {
   }
 
   /**
+   * Async version of getLatestNeighborInfoPerNodeScoped — queries the repository
+   * for the latest neighbor info per node, then filters by sourceId when scoped.
+   */
+  async getLatestNeighborInfoPerNodeScopedAsync(sourceId?: string): Promise<DbNeighborInfo[]> {
+    const all = await this.neighbors.getLatestNeighborInfoPerNode();
+    if (!sourceId) return all as unknown as DbNeighborInfo[];
+    return (all as any[]).filter((ni: any) => ni.sourceId === sourceId) as unknown as DbNeighborInfo[];
+  }
+
+  /**
    * Get direct neighbor RSSI statistics from zero-hop packets
    *
    * Queries packet_log for packets received directly (hop_start == hop_limit),
@@ -6193,7 +5831,7 @@ class DatabaseService {
   setNodeFavorite(nodeNum: number, isFavorite: boolean, sourceId: string, favoriteLocked?: boolean): void {
     // For PostgreSQL/MySQL, update cache and fire-and-forget
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         cachedNode.isFavorite = isFavorite;
         if (favoriteLocked !== undefined) {
@@ -6251,7 +5889,7 @@ class DatabaseService {
   setNodeFavoriteLocked(nodeNum: number, favoriteLocked: boolean, sourceId: string): void {
     // For PostgreSQL/MySQL, update cache and fire-and-forget
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         cachedNode.favoriteLocked = favoriteLocked;
         cachedNode.updatedAt = Date.now();
@@ -6308,7 +5946,7 @@ class DatabaseService {
 
     // For PostgreSQL/MySQL, update cache and fire-and-forget
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const cachedNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const cachedNode = this.nodeCache.get(nodeNum, sourceId);
       if (cachedNode) {
         cachedNode.isIgnored = isIgnored;
         cachedNode.updatedAt = Date.now();
@@ -6436,7 +6074,7 @@ class DatabaseService {
 
     // For PostgreSQL/MySQL, use cache and async repo
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const existingNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const existingNode = this.nodeCache.get(nodeNum, sourceId);
       if (!existingNode) {
         const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
         logger.warn(`⚠️ Failed to update position override for node ${nodeId} (${nodeNum}) source ${sourceId}: node not found in cache`);
@@ -6505,7 +6143,7 @@ class DatabaseService {
   } | null {
     // For PostgreSQL/MySQL, use cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const node = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const node = this.nodeCache.get(nodeNum, sourceId);
       if (!node) {
         return null;
       }
@@ -6561,7 +6199,7 @@ class DatabaseService {
 
     // For PostgreSQL/MySQL, use cache and async repo
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const existingNode = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+      const existingNode = this.nodeCache.get(nodeNum, sourceId);
       if (!existingNode) {
         const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
         logger.warn(`⚠️ Failed to update hideFromMap for node ${nodeId} (${nodeNum}) source ${sourceId}: node not found in cache`);
@@ -6598,7 +6236,7 @@ class DatabaseService {
     }
 
     // Keep the in-memory cache consistent for sync readers.
-    const cached = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+    const cached = this.nodeCache.get(nodeNum, sourceId);
     if (cached) {
       cached.hideFromMap = hidden;
       cached.updatedAt = now;
@@ -6623,7 +6261,7 @@ class DatabaseService {
     await this.nodesRepo.setNodeNotes(nodeNum, notes, sourceId);
 
     // Keep the in-memory cache consistent for sync readers.
-    const cached = this.nodesCache.get(this.cacheKey(nodeNum, sourceId));
+    const cached = this.nodeCache.get(nodeNum, sourceId);
     if (cached) {
       cached.notes = notes;
       cached.updatedAt = now;


### PR DESCRIPTION
## Summary

Task **3.4, PR 1 of 2** (remediation plan #3962, Phase 3 finale). The logic-review-heavy half; PR 2 is the bulk deletion.

- **The last ~21 sync-facade call sites migrated to async** (upsertNode, insertTelemetry, clearPacketLogs, insertTraceroute, insertRouteSegment, getAllTraceroutes, getLatestNeighborInfoPerNodeScoped) — census-proof: **zero production sync-facade callers remain**; every sync twin is now an orphan awaiting PR 2's sweep. Fire-and-forget writes use `.catch(logger.error)` per the 0.5 convention; the mqttIngestion interleaving question was assessed (idempotent per-row upserts make the new yield points safe).
- **Compute-heavy stragglers extracted from the facade**: `nodeMobilityService` (haversine + telemetry-based mobility), `autoTracerouteSelectionService` (the 170-line node-selection filter graph), `getPacketRates` → telemetry repo — each with new unit tests.
- **`NodeCacheService` extracted** (the 435-line node cache; write-hook wiring into NodesRepository preserved exactly) — the mandatory piece for 3.4's <4k target.
- Review fixes already folded in: NodeCacheService input typed (no `any` — the ratchet actually improved, one raw-SQL baseline violation eliminated), and a fail-closed regression caught in `getPacketRates` (omitted sourceId now explicitly `ALL_SOURCES`, matching pre-move semantics).
- `database.ts` down 703 lines so far; deliberately no twin deletions here (PR 2, in domain batches) so this diff stays reviewable.
- Retention ruling documented: `getSetting`/`getAllSettings`/`setSetting` stay sync — genuinely synchronous cache-backed reads on the `dynamicCsp` hot path, not legacy.

## Verification

Independent orchestrator run: full suite **8650 passed, 0 failed, 0 suite failures** (`success: true`); typecheck clean; test-typecheck at 283 baseline; lint ratchet green (improved); build verified.

Refs #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n