### PR TITLE
fix(notifications): drop inline autoindex UNIQUE(user_id) missed by migration 079

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -129,6 +129,7 @@ import { migration as meshcoreNodePositionSourceMigration, runMigration111Postgr
 import { migration as nodeNotesMigration, runMigration112Postgres as runNodeNotesPostgres, runMigration112Mysql as runNodeNotesMysql } from '../server/migrations/112_add_notes_to_nodes.js';
 import { migration as bootstrapOnlyIndexesMigration, runMigration113Postgres as runBootstrapOnlyIndexesPostgres, runMigration113Mysql as runBootstrapOnlyIndexesMysql } from '../server/migrations/113_add_bootstrap_only_indexes.js';
 import { migration as meshcorePathfindingTargetsMigration, runMigration114Postgres as runMeshcorePathfindingTargetsPostgres, runMigration114Mysql as runMeshcorePathfindingTargetsMysql } from '../server/migrations/114_create_meshcore_pathfinding_targets.js';
+import { migration as dropInlineNotifPrefsUserIdUniqueMigration, runMigration115Postgres as runDropInlineNotifPrefsUserIdUniquePostgres, runMigration115Mysql as runDropInlineNotifPrefsUserIdUniqueMysql } from '../server/migrations/115_drop_inline_notif_prefs_user_id_unique.js';
 
 // ============================================================================
 // Registry
@@ -1817,4 +1818,19 @@ registry.register({
   sqlite: (db) => meshcorePathfindingTargetsMigration.up(db),
   postgres: (client) => runMeshcorePathfindingTargetsPostgres(client),
   mysql: (pool) => runMeshcorePathfindingTargetsMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 115: Drop an inline (autoindex) single-column UNIQUE constraint
+// on user_notification_preferences.user_id that migration 079 can't see
+// (issue #4044, recurrence of #3324).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 115,
+  name: 'drop_inline_notif_prefs_user_id_unique',
+  settingsKey: 'migration_115_drop_inline_notif_prefs_user_id_unique',
+  sqlite: (db) => dropInlineNotifPrefsUserIdUniqueMigration.up(db),
+  postgres: (client) => runDropInlineNotifPrefsUserIdUniquePostgres(client),
+  mysql: (pool) => runDropInlineNotifPrefsUserIdUniqueMysql(pool),
 });

--- a/src/server/migrations/115_drop_inline_notif_prefs_user_id_unique.test.ts
+++ b/src/server/migrations/115_drop_inline_notif_prefs_user_id_unique.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Migration 115 — Drop an inline (autoindex) unique constraint on
+ * user_notification_preferences.user_id that migration 079 cannot see.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './115_drop_inline_notif_prefs_user_id_unique.js';
+
+function createUsersTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL
+    );
+  `);
+}
+
+function createTableWithInlineUnique(db: Database.Database) {
+  // Mirrors what an early `drizzle-kit push` (before the migration system
+  // existed) would have produced: a UNIQUE constraint declared inline on the
+  // column, which SQLite implements as an autoindex with no `sql` text in
+  // sqlite_master — invisible to migration 079's sqlite_master query.
+  db.exec(`
+    CREATE TABLE user_notification_preferences (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL UNIQUE,
+      source_id TEXT,
+      enable_apprise INTEGER DEFAULT 1,
+      apprise_urls TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function createTableWithCompositeUniqueOnly(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE user_notification_preferences (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      source_id TEXT NOT NULL,
+      enable_apprise INTEGER DEFAULT 1,
+      apprise_urls TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE UNIQUE INDEX idx_user_notification_preferences_user_source
+      ON user_notification_preferences(user_id, source_id);
+  `);
+}
+
+describe('Migration 115 — drop inline autoindex unique(user_id)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    createUsersTable(db);
+  });
+
+  it('rebuilds the table to drop an inline UNIQUE(user_id) autoindex', () => {
+    createTableWithInlineUnique(db);
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'alice')`).run();
+
+    // Sanity check: reproduce the bug before the migration runs — a second
+    // source's row for the same user hits the inline unique constraint.
+    const now = Date.now();
+    db.prepare(`
+      INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at)
+      VALUES (1, 'source-a', ?, ?)
+    `).run(now, now);
+    expect(() => {
+      db.prepare(`
+        INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at)
+        VALUES (1, 'source-b', ?, ?)
+      `).run(now, now);
+    }).toThrow(/UNIQUE constraint failed: user_notification_preferences\.user_id/);
+
+    migration.up(db);
+
+    // The autoindex is gone — a second source's row for the same user now inserts cleanly.
+    expect(() => {
+      db.prepare(`
+        INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at)
+        VALUES (1, 'source-b', ?, ?)
+      `).run(now, now);
+    }).not.toThrow();
+
+    const rows = db.prepare(`SELECT user_id, source_id FROM user_notification_preferences ORDER BY source_id`).all();
+    expect(rows).toEqual([
+      { user_id: 1, source_id: 'source-a' },
+      { user_id: 1, source_id: 'source-b' },
+    ]);
+
+    const indexList = db.prepare(`PRAGMA index_list('user_notification_preferences')`).all() as Array<{
+      name: string;
+      unique: number;
+      origin: string;
+    }>;
+    const singleColumnUserIdUnique = indexList.filter((idx) => {
+      if (!idx.unique) return false;
+      const cols = db.prepare(`PRAGMA index_info("${idx.name}")`).all() as Array<{ name: string }>;
+      return cols.length === 1 && cols[0].name === 'user_id';
+    });
+    expect(singleColumnUserIdUnique).toEqual([]);
+  });
+
+  it('preserves the composite (user_id, source_id) unique constraint after rebuild', () => {
+    createTableWithInlineUnique(db);
+
+    migration.up(db);
+
+    const now = Date.now();
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'alice')`).run();
+    db.prepare(`
+      INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at)
+      VALUES (1, 'source-a', ?, ?)
+    `).run(now, now);
+
+    // Duplicate (user_id, source_id) must still be rejected.
+    expect(() => {
+      db.prepare(`
+        INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at)
+        VALUES (1, 'source-a', ?, ?)
+      `).run(now, now);
+    }).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it('preserves existing data across the rebuild', () => {
+    createTableWithInlineUnique(db);
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'alice')`).run();
+    const now = Date.now();
+    db.prepare(`
+      INSERT INTO user_notification_preferences (user_id, source_id, enable_apprise, apprise_urls, created_at, updated_at)
+      VALUES (1, 'source-a', 1, '["https://example.com/hook"]', ?, ?)
+    `).run(now, now);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT user_id, source_id, enable_apprise, apprise_urls FROM user_notification_preferences`).get();
+    expect(row).toEqual({
+      user_id: 1,
+      source_id: 'source-a',
+      enable_apprise: 1,
+      apprise_urls: '["https://example.com/hook"]',
+    });
+  });
+
+  it('is a no-op when only the composite unique index is present', () => {
+    createTableWithCompositeUniqueOnly(db);
+
+    expect(() => migration.up(db)).not.toThrow();
+
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_notification_preferences'
+    `).all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain('idx_user_notification_preferences_user_source');
+  });
+
+  it('is a no-op when the table does not exist', () => {
+    expect(() => migration.up(db)).not.toThrow();
+  });
+
+  it('restores foreign_keys=ON after running', () => {
+    createTableWithInlineUnique(db);
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+
+    migration.up(db);
+
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+});

--- a/src/server/migrations/115_drop_inline_notif_prefs_user_id_unique.ts
+++ b/src/server/migrations/115_drop_inline_notif_prefs_user_id_unique.ts
@@ -1,0 +1,173 @@
+/**
+ * Migration 115: Drop an inline (autoindex) single-column UNIQUE constraint
+ * on user_notification_preferences.user_id that migration 079 cannot see.
+ *
+ * Migration 079 (issue #3324) introspects `sqlite_master` for indexes with
+ * `sql IS NOT NULL` to find and drop residual single-column unique indexes on
+ * user_id. That query only matches indexes created via an explicit
+ * `CREATE [UNIQUE] INDEX` statement — it structurally cannot see a UNIQUE
+ * constraint declared inline on the column (`user_id INTEGER UNIQUE`), which
+ * SQLite implements as an autoindex (`sqlite_autoindex_*`) with `sql = NULL`
+ * in `sqlite_master`. Some databases carry exactly this kind of constraint
+ * (e.g. from an early `drizzle-kit push` before the migration system existed),
+ * so migration 079 silently left it in place and the per-source upsert in
+ * `saveUserPreferences` continues to fail with:
+ *
+ *   SqliteError: UNIQUE constraint failed: user_notification_preferences.user_id
+ *
+ * on the second source a user configures notifications for (issue #4044,
+ * a recurrence of #3324).
+ *
+ * SQLite refuses to `DROP INDEX` an autoindex directly ("index associated
+ * with UNIQUE or PRIMARY KEY constraint cannot be dropped"), so removing it
+ * requires the standard table-rebuild procedure: recreate the table from its
+ * live column list (which never re-states the inline UNIQUE), copy the data,
+ * and reinstate the composite (user_id, source_id) index.
+ *
+ * Idempotent — the PRAGMA index_list check is a no-op if the inline
+ * constraint isn't present, which is the common case (fresh installs and any
+ * database that only ever had the named indexes migrations 015/079 handled).
+ *
+ * PostgreSQL/MySQL: an inline UNIQUE column constraint there produces a
+ * normal, introspectable constraint/index (no autoindex quirk), so migration
+ * 079's PG/MySQL paths already catch it. No-op here.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+interface IndexListRow {
+  name: string;
+  unique: number;
+  origin: string;
+}
+
+interface IndexInfoRow {
+  name: string;
+}
+
+interface TableInfoRow {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const hasTable = db
+      .prepare("SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name='user_notification_preferences'")
+      .get() as { count: number };
+    if (hasTable.count === 0) {
+      logger.debug('Migration 115 (SQLite): user_notification_preferences does not exist, skipping');
+      return;
+    }
+
+    const indexList = db.prepare(`PRAGMA index_list('user_notification_preferences')`).all() as IndexListRow[];
+    const inlineUniqueOnUserId = indexList.find((idx) => {
+      if (!idx.unique || idx.origin !== 'u') return false;
+      const cols = db.prepare(`PRAGMA index_info("${idx.name}")`).all() as IndexInfoRow[];
+      return cols.length === 1 && cols[0].name === 'user_id';
+    });
+
+    if (!inlineUniqueOnUserId) {
+      logger.debug('Migration 115 (SQLite): no inline unique(user_id) on user_notification_preferences, skipping');
+      return;
+    }
+
+    logger.info(
+      `Migration 115 (SQLite): found inline autoindex unique "${inlineUniqueOnUserId.name}" on user_notification_preferences.user_id — rebuilding table to remove it`
+    );
+
+    // Column defs are read live from the table rather than hardcoded so the
+    // rebuild can't drift from whatever ADD COLUMN migrations (012/018/076/080/028)
+    // have already applied by the time migration 115 runs.
+    const columns = db.prepare(`PRAGMA table_info('user_notification_preferences')`).all() as TableInfoRow[];
+    const colDefs = columns
+      .map((c) => {
+        let def = `"${c.name}" ${c.type}`;
+        if (c.pk) {
+          def += ' PRIMARY KEY AUTOINCREMENT';
+        } else {
+          if (c.notnull) def += ' NOT NULL';
+          if (c.dflt_value !== null) def += ` DEFAULT ${c.dflt_value}`;
+        }
+        return def;
+      })
+      .join(',\n        ');
+    const colNames = columns.map((c) => `"${c.name}"`).join(', ');
+
+    // Snapshot named (non-autoindex) indexes so they can be recreated after
+    // the rebuild. The inline-unique autoindex we're removing has no `sql`
+    // text and is deliberately excluded — that's what drops it.
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'user_notification_preferences' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) db.pragma('foreign_keys = OFF');
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) db.pragma('legacy_alter_table = ON');
+
+    const tx = db.transaction(() => {
+      db.exec(`
+        CREATE TABLE user_notification_preferences_rebuild_115 (
+        ${colDefs},
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+      db.exec(`
+        INSERT INTO user_notification_preferences_rebuild_115 (${colNames})
+        SELECT ${colNames} FROM user_notification_preferences
+      `);
+      db.exec(`DROP TABLE user_notification_preferences`);
+      db.exec(`ALTER TABLE user_notification_preferences_rebuild_115 RENAME TO user_notification_preferences`);
+
+      for (const idx of existingIndexes) {
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 115 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+
+      // Belt-and-suspenders: make sure the composite unique exists even if
+      // the snapshot above found nothing to recreate (e.g. an even older
+      // database that never had it named as expected).
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_user_notification_preferences_user_source
+        ON user_notification_preferences(user_id, source_id)
+      `);
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) db.pragma('foreign_keys = ON');
+      if (!prevLegacyAlter) db.pragma('legacy_alter_table = OFF');
+    }
+
+    logger.info('Migration 115 (SQLite): rebuilt user_notification_preferences without inline unique(user_id)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration115Postgres(_client: import('pg').PoolClient): Promise<void> {
+  // An inline UNIQUE column constraint in PostgreSQL produces a regular,
+  // introspectable constraint — migration 079's pg_constraint-based sweep
+  // already catches it regardless of how it was declared. No-op.
+  logger.debug('Migration 115 (PostgreSQL): no-op (079 already covers inline unique constraints on PG)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration115Mysql(_pool: import('mysql2/promise').Pool): Promise<void> {
+  // Same reasoning as PostgreSQL: MySQL surfaces inline UNIQUE columns as
+  // ordinary indexes in information_schema.STATISTICS, already handled by 079.
+  logger.debug('Migration 115 (MySQL): no-op (079 already covers inline unique constraints on MySQL)');
+}

--- a/src/server/migrations/115_drop_inline_notif_prefs_user_id_unique.ts
+++ b/src/server/migrations/115_drop_inline_notif_prefs_user_id_unique.ts
@@ -83,8 +83,9 @@ export const migration = {
     );
 
     // Column defs are read live from the table rather than hardcoded so the
-    // rebuild can't drift from whatever ADD COLUMN migrations (012/018/076/080/028)
-    // have already applied by the time migration 115 runs.
+    // rebuild can't drift from whatever ADD COLUMN migrations (012, 018, 028,
+    // 076, 080 — listed here in ascending migration order) have already
+    // applied by the time migration 115 runs.
     const columns = db.prepare(`PRAGMA table_info('user_notification_preferences')`).all() as TableInfoRow[];
     const colDefs = columns
       .map((c) => {


### PR DESCRIPTION
## Summary

- Fixes #4044, a recurrence of #3324 ("Can't configure AppRise Notifications for a second source").
- Root cause: migration 079 finds residual single-column `UNIQUE(user_id)` indexes on `user_notification_preferences` via `sqlite_master WHERE sql IS NOT NULL`. A `UNIQUE` constraint declared **inline** on the column (`user_id INTEGER UNIQUE`) is implemented by SQLite as an autoindex (`sqlite_autoindex_*`) with `sql = NULL` — invisible to that query. SQLite also refuses to `DROP INDEX` an autoindex directly, so it needs a different cleanup path than 079 uses for named indexes. Databases carrying this flavor of the constraint sailed through 079 untouched, so `saveUserPreferences`'s per-source `INSERT` still fails with `UNIQUE constraint failed: user_notification_preferences.user_id` when configuring a second source.
- Adds migration 115: detects the inline-autoindex case via `PRAGMA index_list` (`origin = 'u'`, single column `user_id`) and rebuilds `user_notification_preferences` from its live column list (no hardcoded schema — avoids drift across the 012/018/076/080/028 column-add migrations) to drop it, reinstating the composite `(user_id, source_id)` unique. No-op when 079 already fully cleaned up — verified by replaying the entire migration registry against a fresh DB and confirming only the composite index survives.
- PostgreSQL/MySQL are unaffected: an inline `UNIQUE` column constraint there is a normal, introspectable constraint/index already covered by 079's PG/MySQL sweeps, so their migration 115 functions are no-ops.

## Test plan

- [x] New `115_drop_inline_notif_prefs_user_id_unique.test.ts` (6 tests): reproduces the bug against a table with an inline `UNIQUE(user_id)`, confirms the migration fixes it, preserves the composite unique and existing data, and no-ops both when only the composite index is present and when the table doesn't exist.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint:ci` passes (no new baseline violations).
- [x] Targeted suite green: `src/db/migrations.test.ts`, `src/db/migrationRegistry.test.ts`, `src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.test.ts`, `src/db/repositories/notifications.test.ts`, `src/db/repositories/notifications.perSource.test.ts`.
- [ ] Full Vitest suite (in progress in CI — will monitor and report back).

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01CNVZoDGEkMizWoyjUtCGhq)_