### PR TITLE
refactor(map): Phase 1 — shared BaseMap shell; migrate pickers and editors (#4047)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 | Routes | `src/server/routes/*` |
 | Packet monitors | Meshtastic: `packet_log` table + `packetLogService.ts` + `packetRoutes.ts` + `PacketMonitorPanel.tsx`. MeshCore (OTA via `LogRxData`): `meshcore_packet_log` table + `meshcorePacketLogService.ts` + `/packets` routes in `meshcoreRoutes.ts` + `MeshCorePacketMonitorView.tsx`. Both opt-in (`*_packet_log_enabled`). |
 | Frontend pages | `src/pages/*` (`Unified*Page` = multi-source aware) |
+| Shared map shell | `src/components/map/` — `BaseMap` (MapContainer + raster/vector tile branch + optional TilesetSelector/resize). New map surfaces MUST compose `BaseMap` instead of hand-rolling `MapContainer`; shared layers land here during epic #4047. |
 | ESLint config | `eslint.config.mjs` (raw-SQL ban lives here) |
 
 ## Hard rules

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
@@ -40,7 +40,7 @@ markers, popups, spiderfy, tiles, and traceroute rendering land everywhere by co
 
 ## Phases
 
-### [ ] Phase 1 — `BaseMap` shell (`feature/4047-p1-basemap-shell`)
+### [x] Phase 1 — `BaseMap` shell (`feature/4047-p1-basemap-shell`)
 Create `src/components/map/BaseMap.tsx`: `MapContainer` + raster `TileLayer` /
 `VectorTileLayer` selection via `tilesets.ts` + optional `TilesetSelector` + resize/center
 handling + Leaflet default-icon fix, theme-aware defaults. Migrate the four simple maps
@@ -104,3 +104,24 @@ map view; suite green.
 ## Phase log
 
 (Per-phase: PR link, deviations, decisions — appended as phases complete.)
+
+### Phase 1 (2026-07-10) — BaseMap shell
+- Delivered: `src/components/map/BaseMap.tsx` + `leafletDefaultIcon.ts` + tests; migrated
+  DefaultMapCenterPicker, EmbedSettings preview picker, BBoxMapEditor, GeofenceMapEditor.
+  Big-map shell adoption deferred to later phases per spec (`MAP_CONSOLIDATION_P1_SPEC.md`).
+- **Decision — theme-aware default deferred:** no theme→tileset mapping exists in the
+  codebase; wiring one into BaseMap would have visibly changed the four OSM editors
+  (Phase-1 violation). BaseMap defaults to `DEFAULT_TILESET_ID` unconditionally; a future
+  opt-in `themeAwareDefault` prop is documented in the spec for big-map adoption.
+- **Decision — canonical default marker = Leaflet PNG.** The two deleted icon-fix copies
+  fought over the global `L.Icon.Default`; due to ES module eval order (EmbedSettings
+  evaluates before App.tsx top-level code), the App.tsx SVG teardrop actually won at
+  runtime. The only bare default `<Marker>` in the codebase (EmbedSettings preview)
+  therefore visibly changed from the 24px SVG teardrop to the standard 25×41 Leaflet PNG
+  pin — verified in browser; accepted as corrective under the canonical-look decision.
+- TilesetSelector renders as a SIBLING outside MapContainer (matches NodesTab ground
+  truth); BaseMap returns a fragment and must never own a wrapper div.
+- Validation: full Vitest suite success:true (2,866 suites / 9,325 tests / 0 failed);
+  typecheck + lint:ci clean; browser-validated all four surfaces (tiles, click-to-place,
+  circle draw + handles, two-corner bbox draw + hint transitions) with no new console
+  errors.

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
@@ -4,6 +4,13 @@
 **Tracking issue:** https://github.com/Yeraze/meshmonitor/issues/4047
 **Orchestration:** /epic harness — one phase = one merged PR, phases strictly sequential.
 
+**Branch strategy (user decision 2026-07-10):** all phase PRs target the long-lived
+integration branch **`4049-map-refactor`** (cut from main at 3e3d50f8), NOT main.
+Phase worktrees branch FROM `origin/4049-map-refactor` (so each phase builds on the
+merged prior phases). Main receives ONE final PR merging the combined integration
+branch after all phases complete and are validated together. Keep `4049-map-refactor`
+periodically synced with main (merge main INTO it) to avoid a giant final conflict.
+
 ## Goal
 
 Consolidate MeshMonitor's 10 independent Leaflet map implementations (~8,000 LOC) into a

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
@@ -1,0 +1,106 @@
+# Map Consolidation Epic — Issue #4047
+
+**Status:** In progress (started 2026-07-10)
+**Tracking issue:** https://github.com/Yeraze/meshmonitor/issues/4047
+**Orchestration:** /epic harness — one phase = one merged PR, phases strictly sequential.
+
+## Goal
+
+Consolidate MeshMonitor's 10 independent Leaflet map implementations (~8,000 LOC) into a
+shared `BaseMap` shell + composable layer library under `src/components/map/`, so fixes to
+markers, popups, spiderfy, tiles, and traceroute rendering land everywhere by construction.
+
+## Interview decisions (2026-07-10)
+
+| Decision | Answer |
+|---|---|
+| Scope/order | As filed: shell first, then forks, traceroutes, popups, layer library. Follow/fit-bounds controller (old "Phase 6") **deferred to a future issue** — not in this epic. |
+| Canonical SNR→color scale | **4-band** (≥5 green / ≥0 yellow / ≥-5 orange / <-5 red), made **theme-aware** (hex values move into the theme palette, not hardcoded). Nodes map changes from its 3-band scale. |
+| Embed map | **Align fully** — extend the embed traceroute API to carry SNR/leg data and render through the shared layer. (Own phase, due to backend scope.) |
+| Visual convergence | **One canonical look per feature** everywhere. Per-map differences survive only as deliberate layer parameters (Map Analysis occurrence weighting, widget hover-highlight, arrows on/off). No case-by-case appearance approvals needed. |
+
+## Ground-truth survey (2026-07-10)
+
+- 10 `MapContainer` instances: NodesTab (~1,500 LOC map code), DashboardMap (977),
+  MeshCoreMap (756), MapAnalysisCanvas + 10 layers (~1,600), TracerouteWidget (641),
+  EmbedMap (660), GeofenceMapEditor (541), BBoxMapEditor (362), DefaultMapCenterPicker (114),
+  EmbedSettings inline picker (~120).
+- Shared today: `MeasureDistanceController`, `SpiderfierController`/`useMarkerSpiderfier`,
+  `TilesetSelector`, `GeoJsonOverlay`, `MapLegend`, `PolarGridOverlay`, `mapIcons.ts`,
+  `mapHelpers.tsx`, `tilesets.ts`, `useTraceroutePaths`.
+- Forks: `MapAnalysis/MapLegend.tsx`, `MapAnalysis/layers/PolarGridLayer.tsx`,
+  `PositionTrailsLayer` (reimplements position-history rendering).
+- Traceroutes: 5 independent renderers, 3 SNR color scales, 4 dash conventions,
+  3 weight formulas; DashboardMap never renders the return leg; EmbedMap segments are
+  server-computed (`/api/embed/:id/traceroutes`).
+- Popups: 3 families — `NodePopup`, `DashboardNodePopup` (Dashboard + Map Analysis since
+  #3692), `MapNodePopupContent` (NodesTab only).
+- Only NodesTab supports MapLibre vector tiles (`VectorTileLayer`).
+- Leaflet default-icon fix duplicated in `App.tsx` and `EmbedSettings.tsx`.
+
+## Phases
+
+### [ ] Phase 1 — `BaseMap` shell (`feature/4047-p1-basemap-shell`)
+Create `src/components/map/BaseMap.tsx`: `MapContainer` + raster `TileLayer` /
+`VectorTileLayer` selection via `tilesets.ts` + optional `TilesetSelector` + resize/center
+handling + Leaflet default-icon fix, theme-aware defaults. Migrate the four simple maps
+(DefaultMapCenterPicker, EmbedSettings inline picker, BBoxMapEditor, GeofenceMapEditor);
+architect may include the big maps' shells if low-risk, else they adopt in later phases as
+each is touched.
+**Exit criteria:** BaseMap exists with tests; ≥4 maps migrated; every migrated map still
+renders tiles/markers/draw tools identically (browser-validated); typecheck + full Vitest
+suite green; vector-tile support works through the shell.
+
+### [ ] Phase 2 — Delete the Map Analysis forks (`feature/4047-p2-unfork-analysis`)
+Re-merge `MapAnalysis/MapLegend.tsx` → shared `MapLegend.tsx`;
+`layers/PolarGridLayer.tsx` → `PolarGridOverlay.tsx`; `PositionTrailsLayer` → shared
+position-history rendering (`generatePositionHistoryArrows`/`mapHelpers`), parameterized
+where Analysis genuinely differs.
+**Exit criteria:** the three fork files deleted; Map Analysis renders equivalent legend /
+polar grid / trails through shared components (browser-validated); suite green.
+
+### [ ] Phase 3 — Traceroute unification, app maps (`feature/4047-p3-traceroute-unify`)
+(a) Canonical 4-band theme-aware SNR→color scale + one weight + one dash convention in
+`mapHelpers`; delete `DashboardMap.snrToColor`, `MapAnalysis.snrQualityColor`, hardcoded
+palettes. (b) Shared `src/components/map/layers/TraceroutePathsLayer.tsx` owning geometry,
+curvature, arrows, forward/return legs, MQTT/unknown-SNR dashing — parameterized for weight
+strategy (usage/occurrence/SNR), arrows, direction-vs-SNR color mode, hover-highlight.
+Consumed by NodesTab (base + selected route via `useTraceroutePaths` data),
+DashboardMap (gains return legs), Map Analysis, TracerouteWidget.
+**Exit criteria:** one SNR scale everywhere; all four app maps render traceroutes through
+the shared layer; #1862/#2051/#2931 behaviors preserved in one place with tests;
+browser-validated on all four views; suite green.
+
+### [ ] Phase 4 — Embed traceroute alignment (`feature/4047-p4-embed-traceroutes`)
+Extend `/api/embed/:id/traceroutes` to carry per-segment SNR + leg/direction data
+(backward-compatible envelope), and render EmbedMap traceroutes through the shared
+TraceroutePathsLayer with the canonical SNR scale.
+**Exit criteria:** public embeds show the same traceroute visuals as the app; old embed
+clients don't break; API + rendering tests; browser-validated via an embed iframe; suite green.
+
+### [ ] Phase 5 — Popup convergence (`feature/4047-p5-popup-converge`)
+Migrate NodesTab off `MapNodePopupContent` onto the `NodePopup`/`DashboardNodePopup`
+family (continuation of #3692); delete `MapNodePopupContent`. Fold any NodesTab-only popup
+capabilities into the shared family as options.
+**Exit criteria:** `MapNodePopupContent` deleted; NodesTab popups render the canonical card
+with no capability loss (browser-validated); suite green.
+
+### [ ] Phase 6 — Shared layer library (`feature/4047-p6-layer-library`)
+Promote/generalize layers into `src/components/map/layers/`: node markers (spiderfy + icon
+cache built in), neighbor links, position trails, waypoints, accuracy regions. DashboardMap,
+MeshCoreMap, MapAnalysis, and NodesTab compose them, retiring inline marker/polyline code.
+Fold MeshCoreMap's custom `L.divIcon` into `mapIcons.ts`. All big maps on the BaseMap shell
+by end of phase. NodesTab migrates **last** (largest, most entangled). Architect may split
+this phase into multiple PRs if decomposition demands it — flag to orchestrator first.
+**Exit criteria:** no inline marker/polyline reimplementations in the big four; all maps on
+BaseMap; per-map visuals preserved or deliberately converged; browser-validated on every
+map view; suite green.
+
+## Deferred (future issues, not this epic)
+
+- Shared follow/fit-bounds controller (generalize `FollowController`/`followMath` + five
+  hand-rolled fit-bounds implementations).
+
+## Phase log
+
+(Per-phase: PR link, deviations, decisions — appended as phases complete.)

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_P1_SPEC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_P1_SPEC.md
@@ -1,0 +1,374 @@
+# Map Consolidation — Phase 1 Implementation Spec (`BaseMap` shell)
+
+**Epic:** #4047 (see `MAP_CONSOLIDATION_EPIC.md`)
+**Branch:** `feature/4047-p1-basemap-shell`
+**Deliverable of this phase:** `src/components/map/BaseMap.tsx` (shared map shell) + migrate the four simple maps onto it.
+**Author:** Phase 1 Architect. Implementers are Sonnet agents — follow the work packages in §5 exactly.
+
+> **Prime directive for Phase 1: pure refactor.** BaseMap is created, four maps adopt it, and **none of the four maps changes visibly** (same tiles, same markers, same draw tools, same click behavior). Any change a reviewer can see on screen is a bug in this phase. Convergence of appearance happens in later phases.
+
+---
+
+## 0. TL;DR for implementers
+
+- Create `src/components/map/BaseMap.tsx` — a thin wrapper around react-leaflet `MapContainer` that owns exactly three things: (1) the tile layer (raster `TileLayer` **or** MapLibre `VectorTileLayer`, chosen via `tilesets.ts`), (2) an optional `TilesetSelector` overlay, (3) an optional resize-invalidate handler. Everything else (markers, draw handlers, overlays, controllers) is passed as `children`.
+- Extract the duplicated Leaflet default-icon fix into `src/components/map/leafletDefaultIcon.ts` (side-effect module). BaseMap imports it. `App.tsx` and `EmbedSettings.tsx` drop their copies.
+- Migrate the 4 maps by replacing their `<MapContainer><TileLayer/>…children</MapContainer>` block with `<BaseMap …>…children</BaseMap>`. Keep every caller's outer wrapper `<div>` (height/border) exactly as-is.
+- The 4 maps stay on **hardcoded OSM raster**. Do **not** wire them to the user's selected tileset — that would be a visible change and is out of scope for Phase 1.
+
+---
+
+## 1. Reuse inventory (use these; do NOT duplicate)
+
+Verified against the code in this worktree. Line numbers are current-tree references.
+
+### 1.1 Tileset config — `src/config/tilesets.ts`
+- `DEFAULT_TILESET_ID: PredefinedTilesetId = 'osm'` (`:86`). **Unconditional** — there is *no* theme→tileset mapping anywhere in the codebase (confirmed: no `ThemeContext`; theme lives in `SettingsContext`). See §2.6.
+- `getTilesetById(id, customTilesets = []) : TilesetConfig` (`:100`) — resolves predefined → custom → falls back to `osm`. Computes `.isVector` for customs.
+- `isVectorTileUrl(url) : boolean` (`:138`) — url contains `.pbf`/`.mvt`.
+- `validateTileUrl(url)` (`:147`) — not needed by BaseMap (used by custom-tileset admin UI); listed for completeness.
+- `TilesetConfig` exposes `{ id, name, url, attribution, maxZoom, description, isCustom?, isVector? }`.
+- `CustomTileset`, `TilesetId` (`= PredefinedTilesetId | string`), `getAllTilesets(customTilesets)` also exported.
+
+### 1.2 `src/components/VectorTileLayer.tsx`
+- `VectorTileLayer({ url, attribution?, maxZoom = 14, styleJson? })` — a `useMap()` child that mounts a MapLibre GL layer via `L.maplibreGL`. **Must be rendered inside a `MapContainer`.** Imports `maplibre-gl` + `@maplibre/maplibre-gl-leaflet` at module scope (relevant to tests — §4.5). BaseMap renders this component for the vector branch; do not reimplement.
+
+### 1.3 `src/components/TilesetSelector.tsx`
+- `TilesetSelector({ selectedTilesetId, onTilesetChange })` — draggable overlay listing tilesets. Reads `useSettings().customTilesets` internally; it does not need `useMap`. **Ground truth: NodesTab renders it OUTSIDE the `MapContainer`** — `</MapContainer>` closes at `NodesTab.tsx:2663` and `<TilesetSelector>` follows at `:2665-2668` as a **sibling**, absolutely positioned against the caller's map wrapper div. BaseMap renders it optionally (`showTilesetSelector`, default off) **as a sibling after `MapContainer`, never inside it** (see §2.2 render sketch and gotcha §6.10).
+
+### 1.4 Resize / center / position helpers (existing)
+- `src/components/MapResizeHandler.tsx` — `MapResizeHandler({ trigger })`: on `trigger` change, `setTimeout(300)` → `map.invalidateSize()`. BaseMap mounts this **only when `resizeTrigger` prop is provided**. **None of the 4 maps pass one today**, so BaseMap must not mount it for them (mounting it would be a behavior change — extra invalidateSize).
+- `src/components/MapCenterController.tsx` — popup-centering controller hardcoded to zoom 15. **NodesTab/big-map specific; NOT for the 4 simple maps.** Do not pull into BaseMap.
+- `src/components/MapPositionHandler.tsx` — writes map center into `MapContext`. **NodesTab-specific** (depends on `useMapContext`). Not for BaseMap.
+- `src/components/ZoomHandler.tsx` — `ZoomHandler({ onZoomChange })`. Generic, but only used by big maps today. Not needed by the 4; leave as-is. (EmbedSettings has its own inline `zoomend` handler — keep it as a child, don't swap.)
+
+> These four helpers are inventory context, not things BaseMap wires. BaseMap only *directly* uses `MapResizeHandler` (gated). The rest remain callers' children in later phases.
+
+### 1.5 The reference wiring pattern — `src/components/NodesTab.tsx`
+The raster-vs-vector branch BaseMap centralizes already exists here and is the canonical pattern to copy:
+- `MapContainer` at `:2232`; tile branch at `:2242-2255`:
+  ```tsx
+  getTilesetById(activeTileset, customTilesets).isVector
+    ? <VectorTileLayer url={..} attribution={..} maxZoom={..} styleJson={activeStyleJson ?? undefined} />
+    : <TileLayer attribution={..} url={..} maxZoom={..} />
+  ```
+  All of `url`/`attribution`/`maxZoom` come from `getTilesetById(activeTileset, customTilesets)`; `.isVector` selects the branch.
+- `TilesetSelector` at `:2665-2668`: `selectedTilesetId={activeTileset}` / `onTilesetChange={setMapTileset}`.
+- **Do not migrate NodesTab in Phase 1** (deferred to Phase 6). It is listed only so BaseMap's tile-branch matches the pattern NodesTab will later adopt.
+
+### 1.6 Tileset persistence (canonical mechanism — for later phases, NOT the 4 editors)
+- Source of truth is `useSettings()` → `mapTileset: TilesetId` + `setMapTileset(id)` (`src/contexts/SettingsContext.tsx:346-354, 592-613`). localStorage key `'mapTileset'` is a context implementation detail — **do not read/write it directly from BaseMap or any picker.**
+- BaseMap is **persistence-agnostic**: it takes a controlled `tilesetId` + `onTilesetChange` and does not itself read `useSettings().mapTileset`. Callers wire persistence. (The 4 editors pass nothing → default OSM.)
+
+### 1.7 The duplicated default-icon fix (the one thing Phase 1 de-duplicates)
+Two copies mutate the **global** `L.Icon.Default`:
+- `src/App.tsx:113-125` — inline **SVG data-URI teardrop pins** (red retina / blue / shadow).
+- `src/components/settings/EmbedSettings.tsx:14-24` — real **Leaflet PNG** marker images (`leaflet/dist/images/marker-icon*.png` + shadow).
+
+Because both run `L.Icon.Default.mergeOptions(...)` at module-eval time, whichever module loads last wins **globally**. See §2.5 + §6.1 for the canonical-icon decision and why it is PNG.
+
+---
+
+## 2. BaseMap API design
+
+### 2.1 Props interface (authoritative — type it exactly, no `any`)
+
+```tsx
+// src/components/map/BaseMap.tsx
+import type { ReactNode, CSSProperties, Ref } from 'react';
+import type { Map as LeafletMap } from 'leaflet';
+import type { TilesetId, CustomTileset } from '../../config/tilesets';
+
+export interface BaseMapProps {
+  /** Initial center. Like react-leaflet, this is applied once at mount and is
+   *  NOT reactive — view changes after mount are the caller's job (child
+   *  controllers / fitBounds). See §6.2. */
+  center: [number, number];
+  /** Initial zoom (mount-only, same non-reactivity as `center`). */
+  zoom: number;
+
+  // ---- Tile layer selection ----------------------------------------------
+  /** Tileset id. Omitted ⇒ DEFAULT_TILESET_ID ('osm', raster). The 4 Phase-1
+   *  editors omit it. */
+  tilesetId?: TilesetId;
+  /** Needed only to resolve `custom-*` ids. Default []. */
+  customTilesets?: CustomTileset[];
+  /** MapLibre style JSON passthrough for vector tilesets (ignored for raster). */
+  styleJson?: Record<string, unknown>;
+
+  // ---- Optional tileset selector overlay ---------------------------------
+  /** Render the TilesetSelector overlay. Default false. */
+  showTilesetSelector?: boolean;
+  /** Required to be useful when showTilesetSelector is true. */
+  onTilesetChange?: (id: TilesetId) => void;
+
+  // ---- MapContainer passthroughs (explicit, type-safe) -------------------
+  scrollWheelZoom?: boolean;      // default: leaflet default (true) unless caller overrides
+  doubleClickZoom?: boolean;
+  zoomControl?: boolean;
+  attributionControl?: boolean;
+  /** Merged into MapContainer style; default { height: '100%', width: '100%' }. */
+  mapStyle?: CSSProperties;
+  /** className on the MapContainer element. */
+  className?: string;
+
+  // ---- Resize handling ----------------------------------------------------
+  /** When this value changes, BaseMap calls map.invalidateSize() (via
+   *  MapResizeHandler). Omit ⇒ handler NOT mounted (no behavior change). */
+  resizeTrigger?: unknown;
+
+  // ---- Map instance access ------------------------------------------------
+  /** Forwarded to MapContainer's ref → resolves to the Leaflet map. */
+  mapRef?: Ref<LeafletMap>;
+
+  // ---- Composition --------------------------------------------------------
+  /** Markers, draw handlers, overlays, useMap-based controllers. Rendered
+   *  inside MapContainer, after the tile layer. */
+  children?: ReactNode;
+}
+```
+
+**Match the exact prop defaults to avoid visible drift.** The four editors currently pass to `MapContainer`: `center`, `zoom`, `style={{height:'100%',width:'100%'}}`, and some pass `scrollWheelZoom`. BaseMap must reproduce these 1:1 (see per-map notes in §3).
+
+### 2.2 What the shell owns vs. what is `children`
+
+| Owned by BaseMap | Passed as `children` by caller |
+|---|---|
+| `MapContainer` element + its mount props | Node/marker layers, `<Marker>`, `L.*` imperative draw layers |
+| Raster `TileLayer` **or** `VectorTileLayer` (branch on `getTilesetById(...).isVector`) | Click/move/zoom event handlers (`useMapEvents` children) |
+| Optional `TilesetSelector` overlay (sibling **after** `MapContainer` — §6.10) | Fit-bounds / view-setting controllers (`useMap` children) |
+| Optional `MapResizeHandler` (gated on `resizeTrigger`) | Everything feature-specific |
+| Importing the shared default-icon fix (§1.7) | — |
+
+BaseMap returns a **fragment** (conceptually):
+```tsx
+<>
+  <MapContainer center={center} zoom={zoom} ref={mapRef} className={className}
+                style={{ height:'100%', width:'100%', ...mapStyle }}
+                scrollWheelZoom={scrollWheelZoom} doubleClickZoom={doubleClickZoom}
+                zoomControl={zoomControl} attributionControl={attributionControl}>
+    {tileset.isVector
+      ? <VectorTileLayer url={tileset.url} attribution={tileset.attribution}
+                         maxZoom={tileset.maxZoom} styleJson={styleJson} />
+      : <TileLayer url={tileset.url} attribution={tileset.attribution} maxZoom={tileset.maxZoom} />}
+    {resizeTrigger !== undefined && <MapResizeHandler trigger={resizeTrigger} />}
+    {children}
+  </MapContainer>
+  {showTilesetSelector && <TilesetSelector selectedTilesetId={resolvedId}
+                                           onTilesetChange={onTilesetChange ?? (() => {})} />}
+</>
+```
+`TilesetSelector` is a **sibling rendered after `MapContainer`, not a child inside it** — this matches NodesTab today (`</MapContainer>` at `:2663`, selector at `:2665`). Its absolute positioning resolves against the caller's positioned map wrapper div, exactly as it does now. Rendering it inside the Leaflet container would change its positioning ancestor and put its drag/click events inside Leaflet's event surface — a behavior change. For the same reason, **BaseMap must NOT introduce its own wrapper `<div>`** around the fragment: callers size the map via their existing wrapper (`height: 100%` on the MapContainer resolves against it), and an extra div would break those height/layout assumptions.
+
+where
+```tsx
+const resolvedId = tilesetId ?? DEFAULT_TILESET_ID;
+const tileset = getTilesetById(resolvedId, customTilesets ?? []);
+```
+`getTilesetById` already falls back to `osm` for unknown ids, so BaseMap never renders a broken tile layer.
+
+> Only pass MapContainer props you were given — don't spread arbitrary `...rest`. Explicit props keep the type surface clean and prevent no-`any` violations.
+
+### 2.3 Tileset-selection state (controlled, not persisted by BaseMap)
+- **Controlled.** `tilesetId` in, `onTilesetChange` out. BaseMap keeps no internal tileset state and does **not** call `useSettings()`. Persistence is the caller's concern (§1.6). This keeps BaseMap testable and lets the 4 editors stay on OSM by simply omitting `tilesetId`.
+
+### 2.4 How the four editors' interactions attach (confirmed compatible)
+All four editors implement their map behavior as **child components that call `useMap()` / `useMapEvents()`** inside the `MapContainer`. Those children are unchanged and become BaseMap `children`, so they still resolve the react-leaflet context BaseMap provides:
+- `DefaultMapCenterPicker` — `MapPositionTracker` (`useMapEvents`) + `MapInitializer` (`useMap`).
+- `EmbedSettings` picker — `MapClickHandler` (`useMapEvents`) + `MapCenterUpdater` (`useMap`) + a bare `<Marker>`.
+- `BBoxMapEditor` — `<Layer>` (`useMap` + `useMapEvents`, imperative `L.rectangle`/`L.marker`).
+- `GeofenceMapEditor` — `<MapDrawingLayer>` (`useMap` + `useMapEvents`, imperative `L.circle`/`L.polygon`/`L.marker`, and it imperatively toggles `map.doubleClickZoom` — that stays in the child and is unaffected).
+
+No editor reads the map instance at the `MapContainer` level, so `mapRef` is not required by any of them (it exists for future big-map adopters).
+
+### 2.5 Where the default-icon fix moves
+- New side-effect module `src/components/map/leafletDefaultIcon.ts`:
+  ```ts
+  import L from 'leaflet';
+  import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+  import iconUrl from 'leaflet/dist/images/marker-icon.png';
+  import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+  // Applied once at import; idempotent (re-running mergeOptions is harmless).
+  delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: unknown })._getIconUrl;
+  L.Icon.Default.mergeOptions({ iconRetinaUrl, iconUrl, shadowUrl });
+  ```
+  Uses the **Leaflet PNG** images — the canonical default (see §6.1 for why PNG, not the App.tsx SVG). Note: avoid `as any` — use the narrowed cast shown to satisfy the no-`any` ratchet.
+- `BaseMap.tsx` imports it for side effect: `import './leafletDefaultIcon';`.
+- `App.tsx` (`:113-125`): **delete** the inline block. Add a top-level side-effect import `import './components/map/leafletDefaultIcon';` so the app-wide default is applied at root even before any BaseMap mounts.
+- `EmbedSettings.tsx` (`:14-24`): **delete** the inline block and the three `markerIcon*` PNG imports (they move into the shared module). EmbedSettings no longer needs them directly.
+
+### 2.6 Theme-aware defaults — explicit Phase-1 decision
+The epic lists "theme-aware defaults." **Ground truth: no theme→tileset mapping exists today** and the 4 editors are hardcoded OSM. Making BaseMap read `useSettings().theme` and swap the default to `cartoDark` would **visibly change all four editors** — a Phase-1 violation. Therefore:
+- **Phase 1:** BaseMap's default tileset is `DEFAULT_TILESET_ID` ('osm'), theme-independent. "Theme-aware default" is satisfied by *callers* choosing `tilesetId` (as NodesTab already resolves its own). No theme read inside BaseMap.
+- **Future hook (documented, not built now):** a later phase may add an opt-in `themeAwareDefault?: boolean` that, when true and `tilesetId` is omitted, picks `cartoDark`/`cartoLight` from `useSettings().theme`. Left unimplemented so it can't regress the editors. Note this in the phase log when big maps adopt.
+
+### 2.7 SSR / test considerations
+- BaseMap is client-only (leaflet touches `window`); the app has no SSR. No guard needed beyond what react-leaflet already requires.
+- Under Vitest, there is **no global react-leaflet mock** (`src/test/setup.ts` mocks only i18n/emoji/localStorage/matchMedia). Real leaflet does not render usefully in jsdom, so **BaseMap unit tests mock `react-leaflet` + the tile components** (§4). Migrated-map tests mock **BaseMap itself** as a passthrough (§4.2) so they never pull in maplibre.
+
+---
+
+## 3. File-by-file changes
+
+### Created
+1. **`src/components/map/BaseMap.tsx`** — the shell, per §2.
+2. **`src/components/map/leafletDefaultIcon.ts`** — shared default-icon side-effect module, per §2.5.
+3. **`src/components/map/BaseMap.test.tsx`** — unit tests, per §4.1.
+
+### Modified
+4. **`src/App.tsx`** — delete inline icon block (`:113-125`); add `import './components/map/leafletDefaultIcon';` near the other top-level imports. Leave the existing `import L from 'leaflet'` / `import 'leaflet/dist/leaflet.css'` (still used elsewhere in the file).
+5. **`src/components/settings/EmbedSettings.tsx`** — delete inline icon block + the 3 `markerIcon*` PNG imports (`:14-24`); replace the picker's `<MapContainer><TileLayer/>…</MapContainer>` (`:493-509`) with `<BaseMap center={[form.defaultLat, form.defaultLng]} zoom={form.defaultZoom} scrollWheelZoom>` wrapping the existing `MapClickHandler`, `MapCenterUpdater`, and `<Marker>` children. Keep the `.embed-map-picker` wrapper div and hardcoded OSM (omit `tilesetId`). Keep `import 'leaflet/dist/leaflet.css'` and `import L from 'leaflet'` only if still referenced after removing the icon block — **remove `L` import if it becomes unused** (it likely does; verify to avoid an unused-import lint error).
+6. **`src/components/configuration/DefaultMapCenterPicker.tsx`** — replace `<MapContainer><TileLayer/>…</MapContainer>` (`:79-93`) with `<BaseMap center={initialCenter} zoom={initialZoom} scrollWheelZoom>` wrapping the existing `MapPositionTracker` + conditional `MapInitializer`. Keep the outer `<div style={{height:'300px'}}>`. `MapContainer`/`TileLayer` imports from react-leaflet are removed; keep `useMap`/`useMapEvents` imports (children use them).
+7. **`src/components/configuration/DefaultMapCenterPicker.test.tsx`** — update mock surface, per §4.2.
+8. **`src/components/BBoxMapEditor.tsx`** — replace `<MapContainer><TileLayer/><Layer/></MapContainer>` (`:298-316`) with `<BaseMap center={initialCenter} zoom={bbox ? 5 : 2}>` wrapping the existing `<Layer>`. Keep the wrapper div + border. Drop `MapContainer`/`TileLayer` from the react-leaflet import; keep `useMap`/`useMapEvents` (used by `Layer`).
+9. **`src/components/GeofenceMapEditor.tsx`** — replace `<MapContainer><TileLayer/><MapDrawingLayer/></MapContainer>` (`:408-423`) with `<BaseMap center={[30, 0]} zoom={3}>` wrapping the existing `<MapDrawingLayer>`. Keep wrapper div + border. Drop `MapContainer`/`TileLayer` from the react-leaflet import; keep `useMap`/`useMapEvents`.
+
+> **Do not** change any editor's outer wrapper `<div>`, its height, borders, hints, buttons, numeric inputs, or its child components' logic. Only the `<MapContainer>…</MapContainer>` element is replaced by `<BaseMap>…</BaseMap>`.
+
+---
+
+## 4. Test plan
+
+All tests live in the standard Vitest suite (`*.test.tsx`, `// @vitest-environment jsdom`). No standalone scripts.
+
+### 4.1 New: `src/components/map/BaseMap.test.tsx`
+Mock strategy (mirrors `Dashboard/DashboardMap.test.tsx`):
+- `vi.mock('react-leaflet', …)`: `MapContainer` → `({children, ...props}) => <div data-testid="map-container" data-scrollwheel={String(props.scrollWheelZoom)}>{children}</div>`; `TileLayer` → `(props) => <div data-testid="raster-tile" data-url={props.url} data-maxzoom={String(props.maxZoom)} />`; `useMap`/`useMapEvents` → stubs.
+- `vi.mock('../VectorTileLayer', () => ({ VectorTileLayer: (p) => <div data-testid="vector-tile" data-url={p.url} /> }))`.
+- `vi.mock('../TilesetSelector', () => ({ TilesetSelector: (p) => <div data-testid="tileset-selector" data-selected={p.selectedTilesetId} /> }))`.
+- `vi.mock('../MapResizeHandler', () => ({ default: () => <div data-testid="resize-handler" /> }))`.
+- `vi.mock('leaflet/dist/leaflet.css', () => ({}))` and for the icon module either let it run or `vi.mock('./leafletDefaultIcon', () => ({}))`.
+
+Assertions:
+1. **Raster branch:** default props (no `tilesetId`) → `getByTestId('raster-tile')` present with `data-url` = the osm url; `queryByTestId('vector-tile')` is null.
+2. **Vector branch:** mock `../../config/tilesets` `getTilesetById` to return `{ …, url:'https://x/{z}/{x}/{y}.pbf', isVector:true }` (mirrors DashboardMap.test) → `getByTestId('vector-tile')` present with that url; `queryByTestId('raster-tile')` null. (This is the exit-criterion "a map given a MapLibre style URL renders VectorTileLayer" at unit level; real maplibre rendering is browser-validated, not jsdom — §4.5.)
+3. **Unknown-id fallback:** `tilesetId="does-not-exist"` (no matching custom) → falls back to raster osm (via `getTilesetById` fallback). Assert raster tile with osm url.
+4. **Selector gating (sibling, not child):** `showTilesetSelector` absent → no `tileset-selector`; `showTilesetSelector` + `tilesetId="osm"` → `tileset-selector` present with `data-selected="osm"`. Assert **presence in the render tree** (`getByTestId`), and additionally assert it is **NOT a descendant of `map-container`** (`expect(getByTestId('map-container')).not.toContainElement(getByTestId('tileset-selector'))`) — it must render as a sibling after `MapContainer` per §2.2/§6.10.
+5. **Resize gating:** no `resizeTrigger` → no `resize-handler`; with `resizeTrigger={1}` → `resize-handler` present.
+6. **Children passthrough:** a child `<div data-testid="child" />` renders inside the container.
+7. **Prop passthrough:** `scrollWheelZoom` reaches MapContainer (`data-scrollwheel`).
+8. **Icon fix applied (unmocked icon module):** in a separate test that imports `./leafletDefaultIcon` and real `leaflet`, assert `(L.Icon.Default.prototype as any)._getIconUrl === undefined` and that `L.Icon.Default.mergeOptions` result includes a PNG `iconUrl`; assert importing the module twice does not throw (idempotent). (Use a local `as any` **only in test files** — allowed by the raw-SQL/`any` ratchet's test-file exemption; production code uses the narrowed cast from §2.5.)
+
+### 4.2 Update: `src/components/configuration/DefaultMapCenterPicker.test.tsx`
+The picker now renders `<BaseMap>` instead of `<MapContainer>`. To keep the test isolated from BaseMap internals (and maplibre), **add a BaseMap passthrough mock** and keep the existing react-leaflet mock (the picker's own children still use `useMap`/`useMapEvents`):
+```tsx
+vi.mock('../map/BaseMap', () => ({
+  BaseMap: ({ children }: { children?: React.ReactNode }) =>
+    <div data-testid="minimap">{children}</div>,
+}));
+```
+Keep the existing `vi.mock('react-leaflet', …)` (still needed for `useMap`/`useMapEvents`/`TileLayer`) and `vi.mock('leaflet/dist/leaflet.css')`. All existing text assertions ("No default center configured", "Default: 40.7128, -74.0060 (zoom 12)", "Clear", "Save as Default", `onSave` called with 3 numbers) must still pass unchanged — they assert on the picker's own JSX, which is untouched.
+
+### 4.3 Unchanged: `src/components/GeofenceTriggersSection.test.tsx`
+Fully stubs `./GeofenceMapEditor` as a div and never touches react-leaflet. **Preserve GeofenceMapEditor's `default` export and its `onShapeChange`/`shapeType`/`shape`/`nodePositions` prop contract** (they are unchanged by this refactor) and this test needs no edits. Do not alter it.
+
+### 4.4 No existing tests: BBoxMapEditor, EmbedSettings
+Neither has tests today (verified: 0 hits). Exit criteria do not require new per-map tests — browser validation covers rendering. **Optional (nice-to-have, WP3):** a light `BBoxMapEditor.test.tsx` that mocks `../map/BaseMap` as passthrough + mocks `react-leaflet` `useMap`/`useMapEvents` and asserts the hint text transitions (no bbox → "Click two corners…"). Keep it minimal; skip if it risks flakiness with the imperative `L.*` calls (those need `useMap` returning a functional stub).
+
+### 4.5 Vector under jsdom — do not attempt real maplibre
+`VectorTileLayer` needs WebGL/canvas (`L.maplibreGL`) which jsdom lacks. Every vector-capable map test in the repo stubs it. BaseMap tests therefore assert **branch selection only** (§4.1 #2) by mocking `VectorTileLayer` + `getTilesetById`. Real vector rendering is a browser-validation item for the phase, not a unit test.
+
+### 4.6 Suite gate
+Run the **full** Vitest suite + `tsc` (typecheck) — both must be green. Run `npm run lint:ci` (baseline ratchet) — must exit 0; do not grow any rule count (watch for stray `any`, unused imports after removing `MapContainer`/`TileLayer`/`L`).
+
+---
+
+## 5. Work packages (Sonnet-sized, disjoint files)
+
+Dependency order: **WP1 → then WP2 ‖ WP3 in parallel** (WP2 and WP3 touch disjoint files).
+
+### WP1 — BaseMap + icon module + BaseMap tests  *(no dependencies; start immediately)*
+**Files (all new; no overlap with WP2/WP3):**
+- `src/components/map/BaseMap.tsx`
+- `src/components/map/leafletDefaultIcon.ts`
+- `src/components/map/BaseMap.test.tsx`
+
+**Do:** implement §2 API exactly; icon module per §2.5; tests per §4.1.
+**Acceptance:**
+- BaseMap renders raster `TileLayer` by default and `VectorTileLayer` when the resolved tileset `.isVector` (assert via mocks).
+- Unknown tileset id falls back to osm raster.
+- `showTilesetSelector` and `resizeTrigger` gate their components correctly.
+- Children render inside the container; `mapRef`/`scrollWheelZoom` forwarded.
+- Icon module applies the PNG default once, idempotently; no `any` in production code.
+- `tsc` + BaseMap.test green; `lint:ci` clean.
+
+### WP2 — Picker migrations + icon-fix consolidation
+**Files (disjoint from WP3):**
+- `src/components/configuration/DefaultMapCenterPicker.tsx`
+- `src/components/configuration/DefaultMapCenterPicker.test.tsx`
+- `src/components/settings/EmbedSettings.tsx`
+- `src/App.tsx`  *(icon block removal only — the single, isolated edit)*
+
+**Do:** §3 items 4, 5, 6, 7. Migrate both pickers to `<BaseMap>` keeping OSM + wrappers; delete App.tsx and EmbedSettings inline icon blocks; add App.tsx side-effect import; update the picker test mock.
+**Acceptance:**
+- DefaultMapCenterPicker and EmbedSettings picker render identically (OSM tiles, same wrapper size/border, EmbedSettings center `<Marker>` shows the same PNG marker as before).
+- App.tsx has no inline icon block and imports the shared module; grep confirms no default-marker regression (§6.1).
+- No unused imports left (`MapContainer`/`TileLayer`; `L`/PNG imports in EmbedSettings).
+- DefaultMapCenterPicker.test green with the new BaseMap mock; full suite + `tsc` + `lint:ci` green.
+- **Browser-validate:** open the Default Map Center picker (Configuration) and the Embed profile editor map — pan/zoom/click still set values; markers/tiles look unchanged.
+
+### WP3 — Editor migrations (BBox + Geofence)
+**Files (disjoint from WP2):**
+- `src/components/BBoxMapEditor.tsx`
+- `src/components/GeofenceMapEditor.tsx`
+- *(optional)* `src/components/BBoxMapEditor.test.tsx` — light smoke, per §4.4
+
+**Do:** §3 items 8, 9. Swap the `MapContainer` block for `<BaseMap>`; keep the imperative draw `children`, wrappers, borders, and all draw/drag/click logic untouched.
+**Acceptance:**
+- BBox two-corner draw + corner-drag resize works exactly as before; OSM tiles; `--ctp-*` colors intact.
+- Geofence circle (click + center/radius drag) and polygon (click-to-add, dbl-click finalize, vertex drag) all work; node-position dots + tooltips render; `map.doubleClickZoom` toggle still fires (it's inside the child).
+- `GeofenceTriggersSection.test.tsx` still green untouched (GeofenceMapEditor contract preserved).
+- Full suite + `tsc` + `lint:ci` green.
+- **Browser-validate:** the mqtt-bridge bbox editor and the auto-responder geofence editor.
+
+---
+
+## 6. Risks & gotchas
+
+### 6.1 Global icon mutation — pick PNG as canonical, verify no regression *(highest-risk item)*
+`L.Icon.Default` is a global; whichever icon-fix module loaded last currently wins app-wide. **Only one thing renders a bare default `<Marker>`: `EmbedSettings.tsx:508`** (verified — every other `<Marker>`/`L.marker` in the codebase passes an explicit `icon`). EmbedSettings' own module sets the **PNG** default before it renders, so its marker is PNG today. The App.tsx **SVG teardrop** default has **no rendered consumer**. Therefore:
+- **Canonical = Leaflet PNG** (matches the only visible consumer). The shared module uses the PNG images; the App.tsx SVG pins are dropped with no visible effect.
+- **Verification step (WP2):** `grep -rn "<Marker" src --include=*.tsx | grep -v icon=` and `grep -rn "L.marker(" src` — confirm EmbedSettings' bare `<Marker>` remains the only default-icon consumer, so dropping the SVG changes nothing. If a new bare marker is found, it must be given an explicit icon or accept the PNG.
+
+### 6.2 react-leaflet v5 `center`/`zoom` are mount-only (not reactive)
+Changing `center`/`zoom` props after mount does nothing in react-leaflet — every editor already relies on child controllers (`MapInitializer`, `MapCenterUpdater`, `map.fitBounds`) for post-mount view changes. BaseMap must **not** try to make them reactive (e.g. no `map.setView` effect on prop change) — that would alter behavior. Pass them straight through.
+
+### 6.3 Children require the react-leaflet context — preserved
+All editor draw layers call `useMap()`/`useMapEvents()`. They must remain **descendants of the `MapContainer`** BaseMap renders. Since they're passed as `children` and BaseMap renders `{children}` inside `MapContainer`, the context is intact. Do not hoist any child above BaseMap.
+
+### 6.4 EmbedSettings imports marker PNGs + `L` directly
+After removing the inline icon block, the three `markerIcon*` imports and possibly the `import L from 'leaflet'` become unused → **unused-import lint errors**. Remove them. Keep `import 'leaflet/dist/leaflet.css'` (harmless; BaseMap also imports it — duplicate CSS import is a no-op).
+
+### 6.5 Do NOT wire the editors to the user's tileset
+Tempting to pass `tilesetId={mapTileset}` "for consistency." That would flip the four editors from OSM to whatever the user picked (e.g. satellite/dark) — a visible change and a Phase-1 violation. Editors stay on hardcoded OSM (omit `tilesetId`). Cross-editor tileset adoption, if ever wanted, is a separate future decision.
+
+### 6.6 EmbedSettings has two unrelated "tileset" concerns
+`EmbedSettings` has a per-profile `tileset` **dropdown** (config data for the published embed output, `getAllTilesets(...)`). That is **not** the preview map's tiles and must stay untouched. Only the preview `<MapContainer>` (`:493-509`) migrates, and it keeps OSM.
+
+### 6.7 `MapResizeHandler` default import
+`MapResizeHandler` is a **default** export. BaseMap imports it `import MapResizeHandler from '../MapResizeHandler'`. Mount only when `resizeTrigger !== undefined` so the 4 editors (which pass none) get zero behavioral change.
+
+### 6.8 No new `any`; test-file `any` is fine
+Production code (BaseMap, icon module) must be `any`-free — use the narrowed cast in §2.5 for the `_getIconUrl` delete. Test files may use `any` (baseline exempts tests). `VectorTileLayer`'s internal `any` is pre-existing/baselined — don't touch it.
+
+### 6.9 No backend/API/DB surface
+Phase 1 is frontend-only. No routes, migrations, repositories, or `sourceId` plumbing. The "frontend never talks to nodes" rule is trivially satisfied (no data fetching added). Raw-`fetch` ban is irrelevant (no fetch introduced).
+
+### 6.10 `TilesetSelector` must be a SIBLING of `MapContainer`, and BaseMap must not add a wrapper div
+NodesTab (the only current consumer) renders `TilesetSelector` **outside** the `MapContainer` (`</MapContainer>` at `NodesTab.tsx:2663`, selector at `:2665`) — its absolute positioning resolves against the caller's positioned map wrapper div, and its drag/click events live outside Leaflet's event surface. Two failure modes to avoid:
+- **Rendering it inside `MapContainer`** changes its positioning ancestor to the Leaflet container and routes its pointer events through Leaflet's handlers (map pans/zooms while dragging the selector) — a behavior change.
+- **Wrapping the fragment in a BaseMap-owned `<div>`** breaks callers' layout: every migrated map sizes the `MapContainer` via `height: 100%` against the caller's own wrapper (300px/400px divs with borders), and an interposed div both collapses that height chain and becomes an unintended positioning ancestor for the selector.
+BaseMap therefore returns a fragment: `<MapContainer>…</MapContainer>` followed by the optional `<TilesetSelector>` sibling (§2.2). §4.1 assertion #4 pins this structurally.
+
+---
+
+## 7. Exit-criteria checklist (map to epic)
+
+- [ ] `src/components/map/BaseMap.tsx` exists with tests (WP1).
+- [ ] 4 simple maps migrated (WP2 + WP3), rendering **identically** (tiles, markers, draw tools, click handling) — browser-validated.
+- [ ] Default-icon fix lives in one shared module; App.tsx + EmbedSettings copies removed; no marker regression.
+- [ ] Vector-tile support works through the shell: a vector (`.pbf`) tileset renders `VectorTileLayer` (unit-asserted via branch; real render browser-checked).
+- [ ] `tsc` typecheck green.
+- [ ] Full Vitest suite green (0 failures).
+- [ ] `npm run lint:ci` exits 0 (no baseline growth).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import './App.css';
+import './components/map/leafletDefaultIcon';
 
 import InfoTab from './components/InfoTab';
 import SettingsTab from './components/SettingsTab';
@@ -109,20 +110,6 @@ const pendingIgnoredRequests = new Map<string, boolean>();
 const pendingHideFromMapRequests = new Map<string, boolean>();
 import TracerouteHistoryModal from './components/TracerouteHistoryModal';
 import RouteSegmentTraceroutesModal from './components/RouteSegmentTraceroutesModal';
-
-// Fix for default markers in React-Leaflet
-delete (L.Icon.Default.prototype as any)._getIconUrl;
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl:
-    'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJDOS4yNCAyIDcgNC4yNCA3IDdDNyAxMy40NyAxMiAyMiAxMiAyMkMxMiAyMiAxNyAxMy40NyAxNyA3QzE3IDQuMjQgMTQuNzYgMiAxMiAyWk0xMiA5LjVDMTAuNjIgOS41IDkuNSA4LjM4IDkuNSA3UzkuNTEgNC41IDExIDQuNVMxNS41IDUuNjIgMTUuNSA3UzE0LjM4IDkuNSAxMiA5LjVaIiBmaWxsPSIjZmY2NjY2Ii8+Cjwvc3ZnPg==',
-  iconUrl:
-    'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJDOS4yNCAyIDcgNC4yNCA3IDdDNyAxMy40NyAxMiAyMiAxMiAyMkMxMiAyMiAxNyAxMy40NyAxNyA3QzE3IDQuMjQgMTQuNzYgMiAxMiAyWk0xMiA5LjVDMTAuNjIgOS41IDkuNSA4LjM4IDkuNSA3UzkuNTEgNC41IDExIDQuNVMxNS41IDUuNjIgMTUuNSA7UzE0LjM4IDkuNSAxMiA5LjVaIiBmaWxsPSIjNjY5OGY1Ii8+Cjwvc3ZnPg==',
-  shadowUrl:
-    'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJDOS4yNCAyIDcgNC4yNCA3IDdDNyAxMy40NyAxMiAyMiAxMiAyMkMxMiAyMiAxNyAxMy40NyAxNyA3QzE3IDQuMjQgMTQuNzYgMiAxMiAyWk0xMiA5LjVDMTAuNjIgOS41IDkuNSA4LjM4IDkuNSA3UzkuNTEgNC41IDExIDQuNVMxNS41IDUuNjIgMTUuNSA3UzE0LjM4IDkuNSAxMiA5LjVaIiBmaWxsPSIjMDAwIiBmaWxsLW9wYWNpdHk9IjAuMyIvPgo8L3N2Zz4K',
-  iconSize: [24, 24],
-  iconAnchor: [12, 24],
-  popupAnchor: [0, -24],
-});
 
 // Icons and helpers are now imported from utils/
 

--- a/src/components/BBoxMapEditor.test.tsx
+++ b/src/components/BBoxMapEditor.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BBoxMapEditor from './BBoxMapEditor';
+
+// BaseMap is mocked as a passthrough so this test stays isolated from
+// BaseMap internals (and never pulls in maplibre) — mirrors
+// DefaultMapCenterPicker.test.tsx's mock pattern.
+vi.mock('./map/BaseMap', () => ({
+  BaseMap: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="minimap">{children}</div>
+  ),
+}));
+
+// The Layer child calls useMap()/useMapEvents() directly (not through
+// BaseMap). Stub useMap with no-op layer methods so the imperative L.*
+// `.addTo(map)` calls in BBoxMapEditor's Layer don't touch a real Leaflet
+// map instance. useMapEvents just needs to accept a handlers object.
+vi.mock('react-leaflet', () => ({
+  useMap: () => ({
+    addLayer: vi.fn(),
+    removeLayer: vi.fn(),
+    fitBounds: vi.fn(),
+  }),
+  useMapEvents: () => ({}),
+}));
+
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+
+// The global react-i18next mock (src/test/setup.ts) returns the translation
+// key itself rather than the fallback English string, so assertions target
+// the keys used in BBoxMapEditor.tsx.
+describe('BBoxMapEditor', () => {
+  it('shows the "click two corners" hint when no bbox is set', () => {
+    render(<BBoxMapEditor bbox={null} onChange={vi.fn()} />);
+    expect(screen.getByText('bbox.hint.click_first')).toBeTruthy();
+  });
+
+  it('shows the "drag any corner" hint when a bbox is set', () => {
+    render(
+      <BBoxMapEditor
+        bbox={{ minLat: 0, maxLat: 1, minLng: 0, maxLng: 1 }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('bbox.hint.drag_corners')).toBeTruthy();
+  });
+
+  it('renders the Clear button once a bbox is set', () => {
+    render(
+      <BBoxMapEditor
+        bbox={{ minLat: 0, maxLat: 1, minLng: 0, maxLng: 1 }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('common.clear')).toBeTruthy();
+  });
+});

--- a/src/components/BBoxMapEditor.tsx
+++ b/src/components/BBoxMapEditor.tsx
@@ -20,8 +20,9 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import L from 'leaflet';
-import { MapContainer, TileLayer, useMap, useMapEvents } from 'react-leaflet';
+import { useMap, useMapEvents } from 'react-leaflet';
 import { useTranslation } from 'react-i18next';
+import { BaseMap } from './map/BaseMap';
 
 export interface BBoxValue {
   minLat: number;
@@ -295,15 +296,7 @@ const BBoxMapEditor: React.FC<BBoxMapEditorProps> = ({ bbox, onChange, height = 
           overflow: 'hidden',
         }}
       >
-        <MapContainer
-          center={initialCenter}
-          zoom={bbox ? 5 : 2}
-          style={{ height: '100%', width: '100%' }}
-        >
-          <TileLayer
-            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          />
+        <BaseMap center={initialCenter} zoom={bbox ? 5 : 2}>
           <Layer
             bbox={bbox}
             pending={pending}
@@ -313,7 +306,7 @@ const BBoxMapEditor: React.FC<BBoxMapEditorProps> = ({ bbox, onChange, height = 
               onChange(next);
             }}
           />
-        </MapContainer>
+        </BaseMap>
       </div>
       <div
         style={{

--- a/src/components/GeofenceMapEditor.tsx
+++ b/src/components/GeofenceMapEditor.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import L from 'leaflet';
-import { MapContainer, TileLayer, useMap, useMapEvents } from 'react-leaflet';
+import { useMap, useMapEvents } from 'react-leaflet';
 import { useTranslation } from 'react-i18next';
 import type { GeofenceShape } from './auto-responder/types';
+import { BaseMap } from './map/BaseMap';
 
 interface NodePosition {
   nodeNum: number;
@@ -405,22 +406,14 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       <div style={{ height: '400px', border: '1px solid var(--ctp-surface2)', borderRadius: '8px', overflow: 'hidden' }}>
-        <MapContainer
-          center={[30, 0]}
-          zoom={3}
-          style={{ height: '100%', width: '100%' }}
-        >
-          <TileLayer
-            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          />
+        <BaseMap center={[30, 0]} zoom={3}>
           <MapDrawingLayer
             shapeType={shapeType}
             shape={shape}
             onShapeChange={onShapeChange}
             nodePositions={nodePositions}
           />
-        </MapContainer>
+        </BaseMap>
       </div>
 
       {shapeType === 'circle' && (

--- a/src/components/configuration/DefaultMapCenterPicker.test.tsx
+++ b/src/components/configuration/DefaultMapCenterPicker.test.tsx
@@ -17,6 +17,11 @@ vi.mock('react-leaflet', () => ({
     }),
 }));
 
+vi.mock('../map/BaseMap', () => ({
+    BaseMap: ({ children }: { children?: React.ReactNode }) =>
+        <div data-testid="minimap">{children}</div>,
+}));
+
 // Mock leaflet CSS import
 vi.mock('leaflet/dist/leaflet.css', () => ({}));
 

--- a/src/components/configuration/DefaultMapCenterPicker.tsx
+++ b/src/components/configuration/DefaultMapCenterPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
-import { MapContainer, TileLayer, useMapEvents, useMap } from 'react-leaflet';
+import { useMapEvents, useMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
+import { BaseMap } from '../map/BaseMap';
 
 export interface DefaultMapCenterPickerProps {
     lat: number | null;
@@ -76,21 +77,16 @@ export const DefaultMapCenterPicker: React.FC<DefaultMapCenterPickerProps> = ({
     return (
         <div>
             <div style={{ height: '300px', width: '100%' }}>
-                <MapContainer
+                <BaseMap
                     center={initialCenter}
                     zoom={initialZoom}
-                    style={{ height: '100%', width: '100%' }}
-                    scrollWheelZoom={true}
+                    scrollWheelZoom
                 >
-                    <TileLayer
-                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                    />
                     <MapPositionTracker positionRef={positionRef} />
                     {isConfigured && (
                         <MapInitializer lat={lat!} lon={lon!} zoom={zoom!} />
                     )}
-                </MapContainer>
+                </BaseMap>
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
                 <button className="save-button" onClick={handleSave} style={{ minWidth: 'auto', padding: '0.5rem 1rem', fontSize: '0.85rem' }}>

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BaseMap } from './BaseMap';
+import { getTilesetById } from '../../config/tilesets';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors src/components/Dashboard/DashboardMap.test.tsx)
+// ---------------------------------------------------------------------------
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children, ...props }: { children?: ReactNode; scrollWheelZoom?: boolean }) => (
+    <div data-testid="map-container" data-scrollwheel={String(props.scrollWheelZoom)}>
+      {children}
+    </div>
+  ),
+  TileLayer: (props: { url?: string; maxZoom?: number }) => (
+    <div data-testid="raster-tile" data-url={props.url} data-maxzoom={String(props.maxZoom)} />
+  ),
+  useMap: () => ({ invalidateSize: vi.fn() }),
+  useMapEvents: () => ({ invalidateSize: vi.fn() }),
+}));
+
+vi.mock('../VectorTileLayer', () => ({
+  VectorTileLayer: (p: { url?: string }) => <div data-testid="vector-tile" data-url={p.url} />,
+}));
+
+vi.mock('../TilesetSelector', () => ({
+  TilesetSelector: (p: { selectedTilesetId?: string }) => (
+    <div data-testid="tileset-selector" data-selected={p.selectedTilesetId} />
+  ),
+}));
+
+vi.mock('../MapResizeHandler', () => ({
+  default: () => <div data-testid="resize-handler" />,
+}));
+
+// leafletDefaultIcon is a side-effect module (mutates the global L.Icon.Default);
+// stub it out for the mocked-react-leaflet tests so they don't depend on real leaflet.
+vi.mock('./leafletDefaultIcon', () => ({}));
+
+// Wrap the real getTilesetById in a vi.fn so individual tests can override its
+// return value (vector-branch test) while everything else uses the real
+// implementation (raster/fallback tests, which must reflect the actual osm URL).
+vi.mock('../../config/tilesets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config/tilesets')>();
+  return {
+    ...actual,
+    getTilesetById: vi.fn(actual.getTilesetById),
+  };
+});
+
+const OSM_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+describe('BaseMap', () => {
+  // 1. Raster branch (default props)
+  it('renders a raster TileLayer by default (no tilesetId)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} />);
+    const rasterTile = screen.getByTestId('raster-tile');
+    expect(rasterTile).toBeInTheDocument();
+    expect(rasterTile.getAttribute('data-url')).toBe(OSM_URL);
+    expect(screen.queryByTestId('vector-tile')).not.toBeInTheDocument();
+  });
+
+  // 2. Vector branch
+  it('renders VectorTileLayer when the resolved tileset is a vector tileset', () => {
+    vi.mocked(getTilesetById).mockReturnValueOnce({
+      id: 'custom-vector',
+      name: 'Vector',
+      url: 'https://x/{z}/{x}/{y}.pbf',
+      attribution: '',
+      maxZoom: 14,
+      isVector: true,
+    });
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="custom-vector" />);
+    const vectorTile = screen.getByTestId('vector-tile');
+    expect(vectorTile).toBeInTheDocument();
+    expect(vectorTile.getAttribute('data-url')).toBe('https://x/{z}/{x}/{y}.pbf');
+    expect(screen.queryByTestId('raster-tile')).not.toBeInTheDocument();
+  });
+
+  // 3. Unknown-id fallback
+  it('falls back to raster osm when given an unknown tileset id', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="does-not-exist" />);
+    const rasterTile = screen.getByTestId('raster-tile');
+    expect(rasterTile).toBeInTheDocument();
+    expect(rasterTile.getAttribute('data-url')).toBe(OSM_URL);
+  });
+
+  // 4. Selector gating (sibling, not child)
+  it('does not render the TilesetSelector by default', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} />);
+    expect(screen.queryByTestId('tileset-selector')).not.toBeInTheDocument();
+  });
+
+  it('renders the TilesetSelector as a sibling of MapContainer, not a descendant, when enabled', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" showTilesetSelector />);
+    const selector = screen.getByTestId('tileset-selector');
+    expect(selector).toBeInTheDocument();
+    expect(selector.getAttribute('data-selected')).toBe('osm');
+    expect(screen.getByTestId('map-container')).not.toContainElement(selector);
+  });
+
+  // 5. Resize gating
+  it('does not mount MapResizeHandler when resizeTrigger is omitted', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} />);
+    expect(screen.queryByTestId('resize-handler')).not.toBeInTheDocument();
+  });
+
+  it('mounts MapResizeHandler when resizeTrigger is provided', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} resizeTrigger={1} />);
+    expect(screen.getByTestId('resize-handler')).toBeInTheDocument();
+  });
+
+  // 6. Children passthrough
+  it('renders children inside the map container', () => {
+    render(
+      <BaseMap center={[0, 0]} zoom={3}>
+        <div data-testid="child" />
+      </BaseMap>,
+    );
+    const child = screen.getByTestId('child');
+    expect(child).toBeInTheDocument();
+    expect(screen.getByTestId('map-container')).toContainElement(child);
+  });
+
+  // 7. Prop passthrough
+  it('forwards scrollWheelZoom to MapContainer', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} scrollWheelZoom />);
+    expect(screen.getByTestId('map-container').getAttribute('data-scrollwheel')).toBe('true');
+  });
+
+  // 8. Icon fix applied (unmocked icon module, real leaflet)
+  it('applies the shared default-icon fix once and idempotently', async () => {
+    vi.doUnmock('./leafletDefaultIcon');
+    vi.resetModules();
+    const L = (await import('leaflet')).default;
+    await import('./leafletDefaultIcon');
+    // Leaflet's base `Icon.prototype` also defines `_getIconUrl`, so after
+    // deleting the `Icon.Default.prototype` OWN override, a simple property
+    // read still resolves through the prototype chain to the inherited base
+    // method (that inheritance fallback is the actual mechanism of the fix —
+    // the base method just reads `options.iconUrl` directly, unlike the
+    // overridden version which prepends a CDN-detected `imagePath`). Assert
+    // the own property was removed rather than that the resolved value is
+    // undefined.
+    expect(
+      Object.prototype.hasOwnProperty.call(L.Icon.Default.prototype, '_getIconUrl'),
+    ).toBe(false);
+    expect((L.Icon.Default.prototype.options as any).iconUrl).toEqual(
+      expect.stringContaining('.png'),
+    );
+    // Re-importing (simulating a second module evaluation) must not throw.
+    await expect(import('./leafletDefaultIcon')).resolves.toBeDefined();
+  });
+});

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -1,0 +1,131 @@
+import type { CSSProperties, ReactNode, Ref } from 'react';
+import type { Map as LeafletMap } from 'leaflet';
+import { MapContainer, TileLayer } from 'react-leaflet';
+import { getTilesetById, DEFAULT_TILESET_ID, type TilesetId, type CustomTileset } from '../../config/tilesets';
+import { VectorTileLayer } from '../VectorTileLayer';
+import { TilesetSelector } from '../TilesetSelector';
+import MapResizeHandler from '../MapResizeHandler';
+import './leafletDefaultIcon';
+
+export interface BaseMapProps {
+  /** Initial center. Like react-leaflet, this is applied once at mount and is
+   *  NOT reactive — view changes after mount are the caller's job (child
+   *  controllers / fitBounds). */
+  center: [number, number];
+  /** Initial zoom (mount-only, same non-reactivity as `center`). */
+  zoom: number;
+
+  // ---- Tile layer selection ----------------------------------------------
+  /** Tileset id. Omitted ⇒ DEFAULT_TILESET_ID ('osm', raster). The 4 Phase-1
+   *  editors omit it. */
+  tilesetId?: TilesetId;
+  /** Needed only to resolve `custom-*` ids. Default []. */
+  customTilesets?: CustomTileset[];
+  /** MapLibre style JSON passthrough for vector tilesets (ignored for raster). */
+  styleJson?: Record<string, unknown>;
+
+  // ---- Optional tileset selector overlay ---------------------------------
+  /** Render the TilesetSelector overlay. Default false. */
+  showTilesetSelector?: boolean;
+  /** Required to be useful when showTilesetSelector is true. */
+  onTilesetChange?: (id: TilesetId) => void;
+
+  // ---- MapContainer passthroughs (explicit, type-safe) -------------------
+  scrollWheelZoom?: boolean;      // default: leaflet default (true) unless caller overrides
+  doubleClickZoom?: boolean;
+  zoomControl?: boolean;
+  attributionControl?: boolean;
+  /** Merged into MapContainer style; default { height: '100%', width: '100%' }. */
+  mapStyle?: CSSProperties;
+  /** className on the MapContainer element. */
+  className?: string;
+
+  // ---- Resize handling ----------------------------------------------------
+  /** When this value changes, BaseMap calls map.invalidateSize() (via
+   *  MapResizeHandler). Omit ⇒ handler NOT mounted (no behavior change). */
+  resizeTrigger?: unknown;
+
+  // ---- Map instance access ------------------------------------------------
+  /** Forwarded to MapContainer's ref → resolves to the Leaflet map. */
+  mapRef?: Ref<LeafletMap>;
+
+  // ---- Composition --------------------------------------------------------
+  /** Markers, draw handlers, overlays, useMap-based controllers. Rendered
+   *  inside MapContainer, after the tile layer. */
+  children?: ReactNode;
+}
+
+/**
+ * Shared map shell (Map Consolidation epic #4047, Phase 1).
+ *
+ * Owns: the MapContainer element, the raster-vs-vector tile layer branch, an
+ * optional TilesetSelector overlay (rendered as a sibling AFTER MapContainer
+ * — never inside it, see docs/internal/dev-notes/MAP_CONSOLIDATION_P1_SPEC.md
+ * §2.2/§6.10), and an optional gated MapResizeHandler.
+ *
+ * Everything else (markers, draw handlers, view controllers) is the caller's
+ * `children`. BaseMap is persistence-agnostic: it takes a controlled
+ * `tilesetId`/`onTilesetChange` pair and never reads `useSettings()` itself.
+ */
+export function BaseMap({
+  center,
+  zoom,
+  tilesetId,
+  customTilesets,
+  styleJson,
+  showTilesetSelector = false,
+  onTilesetChange,
+  scrollWheelZoom,
+  doubleClickZoom,
+  zoomControl,
+  attributionControl,
+  mapStyle,
+  className,
+  resizeTrigger,
+  mapRef,
+  children,
+}: BaseMapProps) {
+  const resolvedId = tilesetId ?? DEFAULT_TILESET_ID;
+  const tileset = getTilesetById(resolvedId, customTilesets ?? []);
+
+  return (
+    <>
+      <MapContainer
+        center={center}
+        zoom={zoom}
+        ref={mapRef}
+        className={className}
+        style={{ height: '100%', width: '100%', ...mapStyle }}
+        scrollWheelZoom={scrollWheelZoom}
+        doubleClickZoom={doubleClickZoom}
+        zoomControl={zoomControl}
+        attributionControl={attributionControl}
+      >
+        {tileset.isVector
+          ? (
+            <VectorTileLayer
+              url={tileset.url}
+              attribution={tileset.attribution}
+              maxZoom={tileset.maxZoom}
+              styleJson={styleJson}
+            />
+          )
+          : (
+            <TileLayer
+              url={tileset.url}
+              attribution={tileset.attribution}
+              maxZoom={tileset.maxZoom}
+            />
+          )}
+        {resizeTrigger !== undefined && <MapResizeHandler trigger={resizeTrigger} />}
+        {children}
+      </MapContainer>
+      {showTilesetSelector && (
+        <TilesetSelector
+          selectedTilesetId={resolvedId}
+          onTilesetChange={onTilesetChange ?? (() => {})}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/map/leafletDefaultIcon.ts
+++ b/src/components/map/leafletDefaultIcon.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared Leaflet default-marker-icon fix.
+ *
+ * Leaflet's bundled default icon resolves image URLs relative to the CSS file,
+ * which breaks under most bundlers (Vite included). The conventional fix is to
+ * delete the built-in `_getIconUrl` resolver and re-point `L.Icon.Default` at
+ * bundler-resolved PNG asset URLs.
+ *
+ * This is a side-effect module: importing it applies the fix once (and is
+ * idempotent — re-importing / re-running is harmless, see BaseMap.test.tsx).
+ *
+ * See docs/internal/dev-notes/MAP_CONSOLIDATION_P1_SPEC.md §2.5 / §6.1 for why
+ * this is the canonical (PNG) fix, replacing the App.tsx SVG teardrop variant
+ * that had no rendered consumer.
+ */
+import L from 'leaflet';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+// Narrowed cast (no `any`) to delete the private `_getIconUrl` method Leaflet
+// uses to derive image paths from the CSS file location.
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: unknown })._getIconUrl;
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl,
+  iconUrl,
+  shadowUrl,
+});

--- a/src/components/settings/EmbedSettings.tsx
+++ b/src/components/settings/EmbedSettings.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MapContainer, TileLayer, useMapEvents, Marker, useMap } from 'react-leaflet';
-import L from 'leaflet';
+import { useMapEvents, Marker, useMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
+import { BaseMap } from '../map/BaseMap';
 import apiService from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useToast } from '../ToastContainer';
@@ -10,18 +10,6 @@ import { getAllTilesets } from '../../config/tilesets';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useDashboardSources } from '../../hooks/useDashboardData';
 import './EmbedSettings.css';
-
-// Fix default marker icon for Leaflet in bundled builds
-import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
-import markerIcon from 'leaflet/dist/images/marker-icon.png';
-import markerShadow from 'leaflet/dist/images/marker-shadow.png';
-
-delete (L.Icon.Default.prototype as any)._getIconUrl;
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: markerIcon2x,
-  iconUrl: markerIcon,
-  shadowUrl: markerShadow,
-});
 
 /** Shape matching the backend EmbedProfile */
 interface EmbedProfile {
@@ -490,23 +478,18 @@ const EmbedSettings = () => {
                   {t('settings.embed.map_center_help', 'Click the map to set the center. Zoom with scroll or controls.')}
                 </p>
                 <div className="embed-map-picker">
-                  <MapContainer
+                  <BaseMap
                     center={[form.defaultLat, form.defaultLng]}
                     zoom={form.defaultZoom}
-                    style={{ height: '100%', width: '100%' }}
                     scrollWheelZoom
                   >
-                    <TileLayer
-                      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                      attribution="&copy; OpenStreetMap contributors"
-                    />
                     <MapClickHandler
                       onLocationPick={(lat, lng) => setForm(prev => ({ ...prev, defaultLat: lat, defaultLng: lng }))}
                       onZoomChange={(zoom) => setForm(prev => ({ ...prev, defaultZoom: zoom }))}
                     />
                     <MapCenterUpdater lat={form.defaultLat} lng={form.defaultLng} />
                     <Marker position={[form.defaultLat, form.defaultLng]} />
-                  </MapContainer>
+                  </BaseMap>
                 </div>
                 <div className="embed-map-coords">
                   <span>{t('settings.embed.lat', 'Lat')}: <strong>{form.defaultLat}</strong></span>


### PR DESCRIPTION
## Summary

Phase 1 of the Map Consolidation epic (#4047). MeshMonitor has 10 independent Leaflet map implementations; fixes repeatedly land on one map and miss the others. This PR creates the shared shell — `src/components/map/BaseMap.tsx` — that owns the `MapContainer`, the raster-vs-vector tile branch, an optional `TilesetSelector`, and gated resize handling, and migrates the four simple maps onto it. Pure refactor: no visible change to any migrated map (one deliberate exception noted below).

## Changes

- **New `src/components/map/BaseMap.tsx`** — shared map shell: `MapContainer` + raster `TileLayer`/MapLibre `VectorTileLayer` branch via `tilesets.ts`, optional `TilesetSelector` (rendered as a *sibling* outside the MapContainer, matching NodesTab's layout), gated `MapResizeHandler`, explicit typed props, no `any`, persistence-agnostic (controlled `tilesetId`/`onTilesetChange`).
- **New `src/components/map/leafletDefaultIcon.ts`** — single home for the Leaflet default-marker icon fix, replacing duplicated copies in `App.tsx` and `EmbedSettings.tsx`.
- **Migrated 4 maps to BaseMap** (children/draw layers untouched): `DefaultMapCenterPicker`, the `EmbedSettings` preview picker, `BBoxMapEditor`, `GeofenceMapEditor`.
- **New tests**: `BaseMap.test.tsx` (10 tests — raster/vector branch, tileset fallback, selector/resize gating, sibling placement, icon-fix idempotency), `BBoxMapEditor.test.tsx` (smoke), updated `DefaultMapCenterPicker.test.tsx` mock surface.
- **Docs**: epic plan (`MAP_CONSOLIDATION_EPIC.md`) + Phase 1 spec committed; CLAUDE.md notes the new shared map home.

### Deliberate visual exception
The embed-settings preview marker changes from a 24px SVG teardrop to the standard 25×41 Leaflet PNG pin. The two deleted icon-fix copies fought over the global `L.Icon.Default` and the SVG won only by module-eval-order accident; PNG is now canonical (browser-verified; this is the only bare default `<Marker>` in the codebase).

### Explicitly deferred
- Theme-aware default tileset (no theme→tileset mapping exists today; wiring one in would visibly change the editors) — documented opt-in hook for later phases.
- Big-map (NodesTab/Dashboard/MeshCore/Analysis) shell adoption — later epic phases.

## Issues Resolved

Relates to #4047 (Phase 1 of 6).

## Documentation Updates

- `docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md` — epic plan + Phase 1 log (decisions, validation record).
- `docs/internal/dev-notes/MAP_CONSOLIDATION_P1_SPEC.md` — implementation spec.
- `CLAUDE.md` — added the shared map shell row to "Where things live"; new map surfaces must compose `BaseMap`.
- No user-facing feature docs affected (internal refactor).

## Testing

- [x] Full Vitest suite passes: success:true — 2,866 suites / 9,325 tests / 0 failures (JSON reporter, not the summary line)
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0 (no baseline growth)
- [x] Browser-validated on the dev container (all four surfaces): Default Map Center picker renders + Save as Default intact; embed preview click-to-place updates lat/lng and the marker follows; geofence circle draw produces circle + center/radius handles and populates coordinates; bbox two-corner draw produces rectangle + 4 draggable corner handles with correct hint transitions. No new console errors/warnings.
- [ ] Reviewer: confirm the embed preview marker (Settings → Embed → profile editor) — standard Leaflet pin is the intended new appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub