### PR TITLE
chore: bump version to 4.13.0-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.12.5",
+  "version": "4.13.0-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.12.5",
+  "version": "4.13.0-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.12.5
-appVersion: "4.12.5"
+version: 4.13.0-rc1
+appVersion: "4.13.0-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.5",
+  "version": "4.13.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.12.5",
+      "version": "4.13.0-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.12.5",
+  "version": "4.13.0-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps the version to **4.13.0-rc1** — release candidate for 4.13.0.

Updates all five version-tracked files per the project's versioning rule:

- `package.json`
- `package-lock.json` (regenerated via `npm install --package-lock-only`)
- `desktop/package.json`
- `desktop/src-tauri/tauri.conf.json`
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)

## Notes

- No functional code changes — version metadata only.
- `-rc1` is valid SemVer 2 (accepted by Helm chart `version`, Tauri, and npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)