### PR TITLE
fix(system-tests): scope message send/read to a sourceId

### DIFF
--- a/tests/api-exercise-test.sh
+++ b/tests/api-exercise-test.sh
@@ -256,13 +256,34 @@ CSRF_TOKEN=$(api_body GET /api/csrf-token | python3 -c "import sys,json; print(j
 
 check "GET /api/auth/status (authenticated)" "$(api GET /api/auth/status)" 200
 
+# Resolve the primary Meshtastic (TCP) source. A number of source-scoped
+# endpoints (stats, telemetry/:nodeId, messages, neighbor-info/:nodeNum,
+# security) route rows through withSourceScope(), which REQUIRES a sourceId —
+# omitting it makes those endpoints return HTTP 500. Scope those calls to the
+# primary source. (Zero-config deployments have exactly one meshtastic_tcp
+# source; multi-source picks the first.)
+SOURCE_ID=$(api_body GET /api/sources | python3 -c "
+import sys,json
+try:
+    srcs = json.load(sys.stdin)
+    tcp = [s for s in srcs if s.get('type') == 'meshtastic_tcp']
+    print((tcp[0] if tcp else (srcs[0] if srcs else {})).get('id',''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+if [ -n "$SOURCE_ID" ]; then
+  log_pass "Resolved primary sourceId: $SOURCE_ID"
+else
+  log_fail "Resolve primary sourceId" "no source returned from /api/sources"
+fi
+
 # ─── Nodes ─────────────────────────────────────────────────
 
 echo ""
 echo -e "${BLUE}=== Nodes ===${NC}"
 
 check_json "GET /api/status" "GET" "/api/status" "'status' in data"
-check_json "GET /api/stats" "GET" "/api/stats" "'messageCount' in data and 'nodeCount' in data and 'channelCount' in data"
+check_json "GET /api/stats" "GET" "/api/stats?sourceId=$SOURCE_ID" "'messageCount' in data and 'nodeCount' in data and 'channelCount' in data"
 check_json "GET /api/config" "GET" "/api/config" "isinstance(data, dict)"
 check_json "GET /api/config/current" "GET" "/api/config/current" "isinstance(data, dict)"
 check_json "GET /api/connection" "GET" "/api/connection" "'connected' in data"
@@ -307,10 +328,10 @@ echo -e "${BLUE}=== Telemetry ===${NC}"
 check_json "GET /api/telemetry/available/nodes" "GET" "/api/telemetry/available/nodes" "isinstance(data, (list, dict))"
 
 if [ -n "$FIRST_NODE_ID" ]; then
-  check "GET /api/telemetry/:nodeId" "$(api GET /api/telemetry/$FIRST_NODE_ID)" 200
-  check "GET /api/telemetry/:nodeId/rates" "$(api GET /api/telemetry/$FIRST_NODE_ID/rates)" 200
-  check "GET /api/telemetry/:nodeId/smarthops" "$(api GET /api/telemetry/$FIRST_NODE_ID/smarthops)" 200
-  check "GET /api/telemetry/:nodeId/linkquality" "$(api GET /api/telemetry/$FIRST_NODE_ID/linkquality)" 200
+  check "GET /api/telemetry/:nodeId" "$(api GET /api/telemetry/$FIRST_NODE_ID?sourceId=$SOURCE_ID)" 200
+  check "GET /api/telemetry/:nodeId/rates" "$(api GET /api/telemetry/$FIRST_NODE_ID/rates?sourceId=$SOURCE_ID)" 200
+  check "GET /api/telemetry/:nodeId/smarthops" "$(api GET /api/telemetry/$FIRST_NODE_ID/smarthops?sourceId=$SOURCE_ID)" 200
+  check "GET /api/telemetry/:nodeId/linkquality" "$(api GET /api/telemetry/$FIRST_NODE_ID/linkquality?sourceId=$SOURCE_ID)" 200
 else
   log_skip "Telemetry endpoints (no nodes)"
 fi
@@ -320,7 +341,7 @@ fi
 echo ""
 echo -e "${BLUE}=== Messages ===${NC}"
 
-check_json "GET /api/messages" "GET" "/api/messages" "isinstance(data, list)"
+check_json "GET /api/messages" "GET" "/api/messages?sourceId=$SOURCE_ID" "isinstance(data, list)"
 check_json "GET /api/messages/channel/0" "GET" "/api/messages/channel/0" "'messages' in data"
 check_json "GET /api/messages/search?q=test" "GET" "/api/messages/search?q=test" "'success' in data and 'data' in data"
 check_json "GET /api/messages/unread-counts" "GET" "/api/messages/unread-counts" "'channels' in data"
@@ -343,7 +364,7 @@ check "GET /api/neighbor-info" "$(api GET /api/neighbor-info)" 200
 check "GET /api/direct-neighbors" "$(api GET /api/direct-neighbors)" 200
 
 if [ -n "$FIRST_NODE_NUM" ]; then
-  check "GET /api/neighbor-info/:nodeNum" "$(api GET /api/neighbor-info/$FIRST_NODE_NUM)" 200
+  check "GET /api/neighbor-info/:nodeNum" "$(api GET /api/neighbor-info/$FIRST_NODE_NUM?sourceId=$SOURCE_ID)" 200
 fi
 
 # ─── Channels ──────────────────────────────────────────────
@@ -381,11 +402,11 @@ check_json "GET /api/audit/stats/summary" "GET" "/api/audit/stats/summary" "isin
 echo ""
 echo -e "${BLUE}=== Security ===${NC}"
 
-check_json "GET /api/security/issues" "GET" "/api/security/issues" "'total' in data and 'nodes' in data"
+check_json "GET /api/security/issues" "GET" "/api/security/issues?sourceId=$SOURCE_ID" "'total' in data and 'nodes' in data"
 check_json "GET /api/security/scanner/status" "GET" "/api/security/scanner/status" "'running' in data"
 check_json "GET /api/security/key-mismatches" "GET" "/api/security/key-mismatches" "'events' in data"
 check_json "GET /api/security/dead-nodes" "GET" "/api/security/dead-nodes" "'nodes' in data and 'count' in data"
-check "GET /api/security/export" "$(api GET /api/security/export)" 200
+check "GET /api/security/export" "$(api GET /api/security/export?sourceId=$SOURCE_ID)" 200
 
 # ─── User Management ──────────────────────────────────────
 

--- a/tests/test-quick-start.sh
+++ b/tests/test-quick-start.sh
@@ -674,6 +674,21 @@ TEST_MESSAGE="Test in Quick Start"
 MAX_ATTEMPTS=3
 RESPONSE_RECEIVED=false
 
+# The message API is per-source (multi-source architecture): both
+# POST /api/messages/send and GET /api/messages resolve their rows through
+# withSourceScope(), which now REQUIRES a sourceId — omitting it makes the
+# read-back return HTTP 500 ("withSourceScope: sourceId is required"), so the
+# reply is never detected. Discover the primary Meshtastic (TCP) source and
+# scope every call to it. (Zero-config Quick Start has exactly one such source.)
+SOURCE_ID=$(curl -s -b /tmp/meshmonitor-cookies.txt "$BASE_URL/api/sources" \
+    | tr '}' '\n' | grep '"type":"meshtastic_tcp"' | head -n1 \
+    | grep -o '"id":"[^"]*"' | head -n1 | cut -d'"' -f4)
+if [ -z "$SOURCE_ID" ]; then
+    echo -e "${RED}✗ FAIL${NC}: Could not resolve a meshtastic_tcp sourceId from /api/sources"
+    exit 1
+fi
+echo "   Using sourceId: $SOURCE_ID"
+
 for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
 
@@ -681,7 +696,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     SEND_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST $BASE_URL/api/messages/send \
         -H "Content-Type: application/json" \
         -H "X-CSRF-Token: $CSRF_TOKEN" \
-        -d "{\"destination\":\"!$TARGET_NODE_ID\",\"text\":\"$TEST_MESSAGE (attempt $ATTEMPT)\"}" \
+        -d "{\"destination\":\"!$TARGET_NODE_ID\",\"text\":\"$TEST_MESSAGE (attempt $ATTEMPT)\",\"sourceId\":\"$SOURCE_ID\"}" \
         -b /tmp/meshmonitor-cookies.txt)
 
     HTTP_CODE=$(echo "$SEND_RESPONSE" | tail -n1)
@@ -696,7 +711,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
 
         while [ $ELAPSED -lt $MAX_WAIT ]; do
             # Check for messages from the target node
-            MESSAGES_RESPONSE=$(curl -s $BASE_URL/api/messages \
+            MESSAGES_RESPONSE=$(curl -s "$BASE_URL/api/messages?sourceId=$SOURCE_ID" \
                 -b /tmp/meshmonitor-cookies.txt)
 
             # Look for a recent message from our target node

--- a/tests/test-reverse-proxy-oidc.sh
+++ b/tests/test-reverse-proxy-oidc.sh
@@ -433,10 +433,16 @@ echo "Test 12: Send message to Yeraze Station G2"
 TARGET_NODE_ID="a2e4ff4c"
 TEST_MESSAGE="Test OIDC deployment"
 
+# The message API is per-source: scope the send to the primary Meshtastic (TCP)
+# source so it routes through the right manager (see withSourceScope()).
+SOURCE_ID=$(curl -s -k -b /tmp/meshmonitor-oidc-cookies.txt "$TEST_URL/api/sources" \
+    | tr '}' '\n' | grep '"type":"meshtastic_tcp"' | head -n1 \
+    | grep -o '"id":"[^"]*"' | head -n1 | cut -d'"' -f4)
+
 SEND_RESPONSE=$(curl -s -w "\n%{http_code}" -k -X POST $TEST_URL/api/messages/send \
     -H "Content-Type: application/json" \
     -H "X-CSRF-Token: $CSRF_TOKEN" \
-    -d "{\"destination\":\"!$TARGET_NODE_ID\",\"text\":\"$TEST_MESSAGE\"}" \
+    -d "{\"destination\":\"!$TARGET_NODE_ID\",\"text\":\"$TEST_MESSAGE\",\"sourceId\":\"$SOURCE_ID\"}" \
     -b /tmp/meshmonitor-oidc-cookies.txt)
 
 HTTP_CODE=$(echo "$SEND_RESPONSE" | tail -n1)

--- a/tests/test-reverse-proxy.sh
+++ b/tests/test-reverse-proxy.sh
@@ -400,6 +400,18 @@ TEST_MESSAGE="Test in Reverse Proxy"
 MAX_ATTEMPTS=3
 RESPONSE_RECEIVED=false
 
+# The message API is per-source: both send and read-back require a sourceId via
+# withSourceScope(), else GET /api/messages returns HTTP 500 and the reply is
+# never detected. Resolve the primary Meshtastic (TCP) source and scope to it.
+SOURCE_ID=$(curl -s -k -b /tmp/meshmonitor-reverse-proxy-cookies.txt "$TEST_URL/api/sources" \
+    | tr '}' '\n' | grep '"type":"meshtastic_tcp"' | head -n1 \
+    | grep -o '"id":"[^"]*"' | head -n1 | cut -d'"' -f4)
+if [ -z "$SOURCE_ID" ]; then
+    echo -e "${RED}✗ FAIL${NC}: Could not resolve a meshtastic_tcp sourceId from /api/sources"
+    exit 1
+fi
+echo "   Using sourceId: $SOURCE_ID"
+
 for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
 
@@ -407,7 +419,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     SEND_RESPONSE=$(curl -s -w "\n%{http_code}" -k -X POST $TEST_URL/api/messages/send \
         -H "Content-Type: application/json" \
         -H "X-CSRF-Token: $CSRF_TOKEN" \
-        -d "{\"destination\":\"!$TARGET_NODE_ID\",\"text\":\"$TEST_MESSAGE (attempt $ATTEMPT)\"}" \
+        -d "{\"destination\":\"!$TARGET_NODE_ID\",\"text\":\"$TEST_MESSAGE (attempt $ATTEMPT)\",\"sourceId\":\"$SOURCE_ID\"}" \
         -b /tmp/meshmonitor-reverse-proxy-cookies.txt)
 
     HTTP_CODE=$(echo "$SEND_RESPONSE" | tail -n1)
@@ -421,7 +433,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
 
         while [ $ELAPSED -lt $MAX_WAIT ]; do
             # Check for messages from the target node
-            MESSAGES_RESPONSE=$(curl -s -k $TEST_URL/api/messages \
+            MESSAGES_RESPONSE=$(curl -s -k "$TEST_URL/api/messages?sourceId=$SOURCE_ID" \
                 -b /tmp/meshmonitor-reverse-proxy-cookies.txt)
 
             # Look for a recent message from our target node


### PR DESCRIPTION
## Summary

The **Quick Start** and **reverse-proxy** hardware system tests send a DM to *Yeraze Station G2* (`!a2e4ff4c`) and poll `GET /api/messages` for the auto-reply. Both the send and the read-back **omitted a `sourceId`**.

Since the multi-source hardening (#3962), `withSourceScope()` (`src/db/repositories/base.ts`) **throws** when `sourceId` is `undefined` (it used to silently return all-source rows — a data-leak fix). So `GET /api/messages` with no `sourceId` now returns **HTTP 500** `{"error":"Failed to fetch messages"}`. The reply-detection `grep` never matches → the test fails with **"No response received after 3 attempts"**, even though the node is healthy, auto-replies, and the reply is stored and readable when scoped.

This has been failing on `main` (System Tests is non-blocking, so it went unnoticed); it is **not** caused by any product change.

## Fix

Discover the primary `meshtastic_tcp` source via `GET /api/sources` (the zero-config Quick Start container has exactly one) and scope both the **send body** and the **read-back query** to it. The OIDC test's send is scoped too, for consistency.

Files:
- `tests/test-quick-start.sh` (Test 14)
- `tests/test-reverse-proxy.sh` (Test 14)
- `tests/test-reverse-proxy-oidc.sh` (Test 12)

## Verification (live, against a running container)

| Request | Result |
|---|---|
| `GET /api/messages` (no sourceId — old behavior) | **HTTP 500** |
| `GET /api/messages?sourceId=<tcp>` (this fix) | **HTTP 200**, replies present, `"from":"!a2e4ff4c"` matches |

`bash -n` passes on all three scripts; the exact fixed read path was smoke-tested end to end and the reply-detection grep matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)