### PR TITLE
fix(api): scope telemetry-delete & channel-export to a required sourceId (2/N)

### DIFF
--- a/docs/internal/dev-notes/SOURCEID_ENFORCEMENT_PLAN.md
+++ b/docs/internal/dev-notes/SOURCEID_ENFORCEMENT_PLAN.md
@@ -39,12 +39,14 @@ Driven by an audit (2026-07-10) of every handler touching source-scoped data.
 - [ ] `GET /api/telemetry/:nodeId/linkquality` — always-500, same cause. (telemetryRoutes.ts:214)
 - [ ] `DELETE /api/nodes/:nodeId/neighbors` — always-500 (handler has no
       sourceId). Thread + require. (server.ts:2047)
-- [ ] `DELETE /api/telemetry/:nodeId/:telemetryType` — **data-loss**: deletes
-      across every source. Require + scope. (telemetryRoutes.ts:248)
-- [ ] `GET /api/channels/:id/export` — **PSK leak** across sources on omitted
-      sourceId. Require. (channelRoutes.ts:320)
+- [x] `DELETE /api/telemetry/:nodeId/:telemetryType` — **data-loss**: deletes
+      across every source. Require + scope. (telemetryRoutes.ts:248) — PR #4053+1
+- [x] `GET /api/channels/:id/export` — **PSK leak** across sources on omitted
+      sourceId. Require. (channelRoutes.ts:320) — PR #4053+1
 - [ ] `GET /api/v1/.../packets/:id` — cross-source read by id. Scope. (v1/packets.ts:97)
+      — **deferred to Phase 4** (needs the v1 attachSource/getScopedSourceId pattern).
 - [ ] `POST /api/security/nodes/:nodeNum/clear` — unscoped getNode/upsertNode. (securityRoutes.ts:281)
+      — **moves to Phase 2** (security group).
 
 ## Phase 2 — accidental SILENT_ALL_SOURCES → 400
 

--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -54,7 +54,8 @@ describe('TelemetryRepository (expanded)', () => {
     nodeNum: number,
     telemetryType: string,
     timestamp: number,
-    value: number = 50
+    value: number = 50,
+    sourceId?: string
   ) => {
     await repo.insertTelemetry({
       nodeId,
@@ -64,7 +65,7 @@ describe('TelemetryRepository (expanded)', () => {
       value,
       unit: '%',
       createdAt: NOW,
-    });
+    }, sourceId);
   };
 
   // -------------------------------------------------------------------------
@@ -574,13 +575,13 @@ describe('TelemetryRepository (expanded)', () => {
   // -------------------------------------------------------------------------
   describe('deleteTelemetryByNodeAndType', () => {
     it('returns false when no matching records exist', async () => {
-      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery');
+      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery', ALL_SOURCES);
       expect(result).toBe(false);
     });
 
     it('returns false when the node exists but the type does not', async () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'voltage', NOW - HOUR);
-      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery');
+      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery', ALL_SOURCES);
       expect(result).toBe(false);
     });
 
@@ -589,7 +590,7 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - 1 * HOUR);
       await insertTelemetry(NODE1, NODE1_NUM, 'voltage', NOW - HOUR); // should remain
 
-      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery');
+      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery', ALL_SOURCES);
       expect(result).toBe(true);
 
       const remaining = await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
@@ -601,10 +602,22 @@ describe('TelemetryRepository (expanded)', () => {
       await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - HOUR);
       await insertTelemetry(NODE2, NODE2_NUM, 'battery', NOW - HOUR);
 
-      await repo.deleteTelemetryByNodeAndType(NODE1, 'battery');
+      await repo.deleteTelemetryByNodeAndType(NODE1, 'battery', ALL_SOURCES);
 
       const node2Records = await repo.getTelemetryByNode(NODE2, 100, undefined, undefined, 0, undefined, ALL_SOURCES);
       expect(node2Records).toHaveLength(1);
+    });
+
+    it('scoped delete leaves other sources intact (no cross-source wipe)', async () => {
+      await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - HOUR, 50, 'source-A');
+      await insertTelemetry(NODE1, NODE1_NUM, 'battery', NOW - HOUR, 50, 'source-B');
+
+      const result = await repo.deleteTelemetryByNodeAndType(NODE1, 'battery', 'source-A');
+      expect(result).toBe(true);
+
+      // source-A wiped, source-B preserved
+      expect(await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, undefined, 'source-A')).toHaveLength(0);
+      expect(await repo.getTelemetryByNode(NODE1, 100, undefined, undefined, 0, undefined, 'source-B')).toHaveLength(1);
     });
   });
 

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -467,9 +467,13 @@ export class TelemetryRepository extends BaseRepository {
    * Delete telemetry by node and type.
    * Keeps branching: MySQL doesn't support .returning().
    */
-  async deleteTelemetryByNodeAndType(nodeId: string, telemetryType: string): Promise<boolean> {
+  async deleteTelemetryByNodeAndType(nodeId: string, telemetryType: string, sourceId?: SourceScope): Promise<boolean> {
     const { telemetry } = this.tables;
-    const condition = and(eq(telemetry.nodeId, nodeId), eq(telemetry.telemetryType, telemetryType));
+    const condition = and(
+      eq(telemetry.nodeId, nodeId),
+      eq(telemetry.telemetryType, telemetryType),
+      this.withSourceScope(telemetry, sourceId),
+    );
 
     if (this.isMySQL()) {
       const countResult = await this.db

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -245,30 +245,38 @@ describe('GET /channels/collisions (#3644)', () => {
 });
 
 describe('GET /channels/:id/export', () => {
+  it('400s MISSING_SOURCE_ID when sourceId omitted (no cross-source PSK export)', async () => {
+    const res = await request(app).get('/channels/2/export');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
+  });
+
   it('rejects a non-numeric channel id', async () => {
-    const res = await request(app).get('/channels/abc/export');
+    const res = await request(app).get('/channels/abc/export?sourceId=src-A');
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Invalid channel ID');
   });
 
   it('404s when the channel does not exist', async () => {
     mockDb.channels.getChannelById.mockResolvedValue(null);
-    const res = await request(app).get('/channels/3/export');
+    const res = await request(app).get('/channels/3/export?sourceId=src-A');
     expect(res.status).toBe(404);
   });
 
-  it('exports the channel JSON with a filename header', async () => {
+  it('exports the channel JSON scoped to the required source', async () => {
     mockDb.channels.getChannelById.mockResolvedValue({
       id: 2, name: 'Test Chan', psk: 'AQ==', role: 2,
       uplinkEnabled: 1, downlinkEnabled: 0, positionPrecision: 16,
     });
-    const res = await request(app).get('/channels/2/export');
+    const res = await request(app).get('/channels/2/export?sourceId=src-A');
     expect(res.status).toBe(200);
     expect(res.headers['content-disposition']).toContain('meshmonitor-channel-test_chan-');
     const body = JSON.parse(res.text);
     expect(body.channel.id).toBe(2);
     expect(body.channel.uplinkEnabled).toBe(true);   // normalized 1 -> true
     expect(body.channel.downlinkEnabled).toBe(false); // normalized 0 -> false
+    // scoped to the supplied source, not a first-match across sources
+    expect(mockDb.channels.getChannelById).toHaveBeenCalledWith(2, 'src-A');
   });
 });
 

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -36,6 +36,7 @@ import { getEncryptionStatus, getRoleName } from '../utils/channelView.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../sourceManagerTypes.js';
 import { fail } from '../utils/apiResponse.js';
+import { requireSourceId } from '../utils/requireSourceId.js';
 
 const router: Router = Router();
 
@@ -317,7 +318,7 @@ router.get('/collisions', optionalAuth(), async (req: Request, res: Response) =>
 });
 
 // Export a specific channel configuration
-router.get('/:id/export', requireAuth(), async (req: Request, res: Response) => {
+router.get('/:id/export', requireAuth(), requireSourceId('query'), async (req: Request, res: Response) => {
   try {
     const channelId = parseInt(req.params.id);
     if (isNaN(channelId)) {
@@ -336,11 +337,10 @@ router.get('/:id/export', requireAuth(), async (req: Request, res: Response) => 
       });
     }
 
-    // Scope to a source when supplied (#3712) so a multi-source install can't
+    // Scope to the required source (#3712) so a multi-source install can't
     // export the PSK from a different source's channel that shares this slot.
-    const exportSourceId = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
-      ? req.query.sourceId
-      : undefined;
+    // Presence is validated by requireSourceId('query').
+    const exportSourceId = req.query.sourceId as string;
     const channel = await databaseService.channels.getChannelById(channelId, exportSourceId);
     if (!channel) {
       return res.status(404).json({ error: 'Channel not found' });

--- a/src/server/routes/telemetryRoutes.test.ts
+++ b/src/server/routes/telemetryRoutes.test.ts
@@ -134,17 +134,24 @@ describe('GET /telemetry/:nodeId/linkquality', () => {
 });
 
 describe('DELETE /telemetry/:nodeId/:telemetryType', () => {
-  it('returns 200 when deleted', async () => {
+  it('returns 200 when deleted and scopes to the required source', async () => {
     (databaseService.telemetry.deleteTelemetryByNodeAndType as any).mockResolvedValue(true);
-    const res = await request(app).delete('/telemetry/!12345678/temperature');
+    const res = await request(app).delete('/telemetry/!12345678/temperature?sourceId=src-A');
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+    expect(databaseService.telemetry.deleteTelemetryByNodeAndType).toHaveBeenCalledWith('!12345678', 'temperature', 'src-A');
   });
 
   it('returns 404 when nothing deleted', async () => {
     (databaseService.telemetry.deleteTelemetryByNodeAndType as any).mockResolvedValue(false);
-    const res = await request(app).delete('/telemetry/!12345678/temperature');
+    const res = await request(app).delete('/telemetry/!12345678/temperature?sourceId=src-A');
     expect(res.status).toBe(404);
+  });
+
+  it('400s when sourceId is omitted (no cross-source wipe)', async () => {
+    const res = await request(app).delete('/telemetry/!12345678/temperature');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
   });
 });
 

--- a/src/server/routes/telemetryRoutes.ts
+++ b/src/server/routes/telemetryRoutes.ts
@@ -246,13 +246,16 @@ router.get('/telemetry/:nodeId/linkquality', optionalAuth(), requireSourceId('qu
 });
 
 // Delete telemetry data for a specific node and type
-router.delete('/telemetry/:nodeId/:telemetryType', requireAuth(), requirePermission('info', 'write'), async (req: Request, res: Response) => {
+router.delete('/telemetry/:nodeId/:telemetryType', requireAuth(), requirePermission('info', 'write'), requireSourceId('query'), async (req: Request, res: Response) => {
   try {
     const { nodeId, telemetryType } = req.params;
+    // sourceId presence validated by requireSourceId; scope the delete so it
+    // never wipes another source's telemetry for this node.
+    const purgeSourceId = req.query.sourceId as string;
 
-    logger.info(`Purging telemetry data for node ${nodeId}, type ${telemetryType}`);
+    logger.info(`Purging telemetry data for node ${nodeId}, type ${telemetryType}, source ${purgeSourceId}`);
 
-    const deleted = await databaseService.telemetry.deleteTelemetryByNodeAndType(nodeId, telemetryType);
+    const deleted = await databaseService.telemetry.deleteTelemetryByNodeAndType(nodeId, telemetryType, purgeSourceId);
 
     if (deleted) {
       logger.info(`Successfully purged ${telemetryType} telemetry for node ${nodeId}`);


### PR DESCRIPTION
## Summary

Second increment of the source-scoping remediation (`docs/internal/dev-notes/SOURCEID_ENFORCEMENT_PLAN.md`). Fixes the two **highest-severity cross-source leaks** found in the audit.

### 🚨 Data-loss — `DELETE /api/telemetry/:nodeId/:telemetryType`
Deleted a node's telemetry across **every source** (the repo delete condition had no source scope). Now `requireSourceId('query')` rejects a missing sourceId (400) and `withSourceScope` is woven into the delete so it only wipes the named source.

### 🚨 Secret exposure — `GET /api/channels/:id/export`
Exported another source's **raw PSK** via a first-match read when `sourceId` was omitted. Now requires `sourceId` (400) and scopes the `getChannelById` read.

## Tests
- Repo: scoped delete leaves other sources' telemetry intact (no cross-source wipe).
- Routes: 400 `MISSING_SOURCE_ID` when omitted; correct scoping when present.
- **Full Vitest suite green (16,881 passed, 0 failed);** server TSC clean; lint ratchet unaffected.

## Deferred (documented in the plan)
- `GET /api/v1/.../packets/:id` (cross-source read) → **Phase 4**, needs the v1 `attachSource`/`getScopedSourceId` pattern.
- `POST /api/security/nodes/:nodeNum/clear` → **Phase 2** (security group).

## Note
Uses the standalone `requireSourceId('query')` middleware (from PR #4053) rather than the `requirePermission` flag, since these routes' test files mock `requirePermission` pass-through — the standalone middleware is real under test and matches the smarthops/linkquality pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)