### PR TITLE
fix(api): require sourceId on telemetry + position-override, wire frontend (Phase 2a)

### DIFF
--- a/src/components/PositionOverrideModal/PositionOverrideModal.tsx
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Modal from '../common/Modal';
-import { useSource } from '../../contexts/SourceContext';
+import { useResolvedSourceId } from '../../hooks/useResolvedSourceId';
 import './PositionOverrideModal.css';
 
 interface Node {
@@ -39,7 +39,7 @@ export const PositionOverrideModal: React.FC<PositionOverrideModalProps> = ({
   baseUrl,
 }) => {
   const { t } = useTranslation();
-  const { sourceId } = useSource();
+  const sourceId = useResolvedSourceId();
   const [enabled, setEnabled] = useState(false);
   const [isPrivate, setIsPrivate] = useState(false);
   const [latitude, setLatitude] = useState<string>('');
@@ -61,11 +61,12 @@ export const PositionOverrideModal: React.FC<PositionOverrideModalProps> = ({
 
   // Load current override when modal opens (only once per modal session)
   useEffect(() => {
-    if (isOpen && nodeId && loadedForNodeRef.current !== nodeId) {
+    // Defer until the sourceId resolves — the endpoint now requires it.
+    if (isOpen && nodeId && sourceId && loadedForNodeRef.current !== nodeId) {
       loadedForNodeRef.current = nodeId;
       setLoading(true);
       setError(null);
-      const sourceQuery = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+      const sourceQuery = `?sourceId=${encodeURIComponent(sourceId)}`;
       fetch(`${baseUrl}/api/nodes/${nodeId}/position-override${sourceQuery}`, {
         credentials: 'include',
       })

--- a/src/components/TelemetryGraphs.test.tsx
+++ b/src/components/TelemetryGraphs.test.tsx
@@ -52,6 +52,10 @@ vi.mock('../contexts/AuthContext', () => ({
   }),
 }));
 
+// Telemetry endpoints now require a sourceId; the hooks resolve a fallback via
+// useResolvedSourceId. Pin it so URL assertions stay deterministic.
+vi.mock('../hooks/useResolvedSourceId', () => ({ useResolvedSourceId: () => 'src-test' }));
+
 // Mock Recharts components to avoid rendering issues in tests
 vi.mock('recharts', () => ({
   ComposedChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
@@ -147,7 +151,7 @@ describe('TelemetryGraphs Component', () => {
     renderWithProviders(<TelemetryGraphs nodeId={mockNodeId} />);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=24`);
+      expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=24&sourceId=src-test`);
     });
   });
 
@@ -263,7 +267,7 @@ describe('TelemetryGraphs Component', () => {
     const { rerender } = renderWithProviders(<TelemetryGraphs nodeId={mockNodeId} />);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=24`);
+      expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=24&sourceId=src-test`);
     });
 
     const newNodeId = '!newNode';
@@ -271,7 +275,7 @@ describe('TelemetryGraphs Component', () => {
     rerender(<TelemetryGraphs nodeId={newNodeId} />);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${newNodeId}?hours=24`);
+      expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${newNodeId}?hours=24&sourceId=src-test`);
     });
   });
 
@@ -991,7 +995,7 @@ describe('TelemetryGraphs Component', () => {
       );
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=24`);
+        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=24&sourceId=src-test`);
       });
 
       // findByRole retries until the buttons have rendered (the data query may
@@ -999,7 +1003,7 @@ describe('TelemetryGraphs Component', () => {
       fireEvent.click(await screen.findByRole('button', { name: '1h' }));
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=1`);
+        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=1&sourceId=src-test`);
       });
 
       expect(window.localStorage.getItem('deviceInfoTelemetryHours')).toBe('1');
@@ -1017,7 +1021,7 @@ describe('TelemetryGraphs Component', () => {
       fireEvent.click(screen.getByRole('button', { name: '15m' }));
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=0.25`);
+        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=0.25&sourceId=src-test`);
       });
 
       expect(screen.getByText('telemetry.title_minutes')).toBeInTheDocument();
@@ -1031,7 +1035,7 @@ describe('TelemetryGraphs Component', () => {
       );
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=48`);
+        expect(global.fetch).toHaveBeenCalledWith(`/api/telemetry/${mockNodeId}?hours=48&sourceId=src-test`);
       });
 
       // findByRole retries until the data query renders the selector buttons,

--- a/src/hooks/useLinkQuality.ts
+++ b/src/hooks/useLinkQuality.ts
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useResolvedSourceId } from './useResolvedSourceId';
 
 /**
  * Link quality data point from the backend
@@ -65,10 +66,13 @@ export function useLinkQuality({
   baseUrl = '',
   enabled = true,
 }: UseLinkQualityOptions) {
+  const sourceId = useResolvedSourceId();
   return useQuery({
-    queryKey: ['linkQuality', nodeId, hours],
+    queryKey: ['linkQuality', nodeId, hours, sourceId],
     queryFn: async (): Promise<LinkQualityData[]> => {
-      const response = await fetch(`${baseUrl}/api/telemetry/${nodeId}/linkquality?hours=${hours}`);
+      const response = await fetch(
+        `${baseUrl}/api/telemetry/${nodeId}/linkquality?hours=${hours}&sourceId=${encodeURIComponent(sourceId!)}`
+      );
 
       if (!response.ok) {
         throw new Error(`Failed to fetch link quality: ${response.status} ${response.statusText}`);
@@ -77,7 +81,8 @@ export function useLinkQuality({
       const result: LinkQualityResponse = await response.json();
       return result.data;
     },
-    enabled: enabled && !!nodeId,
+    // sourceId is required by the endpoint — defer until it resolves.
+    enabled: enabled && !!nodeId && !!sourceId,
     refetchInterval: 60000, // Refetch every 60 seconds
     staleTime: 55000, // Data considered fresh for 55 seconds
     gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes

--- a/src/hooks/useResolvedSourceId.test.ts
+++ b/src/hooks/useResolvedSourceId.test.ts
@@ -33,6 +33,11 @@ describe('pickPrimarySource', () => {
     expect(pickPrimarySource([{ id: 'x', type: 'meshcore', enabled: false }])).toBeUndefined();
     expect(pickPrimarySource([])).toBeUndefined();
   });
+
+  it('tolerates a non-array response (e.g. an error envelope) without throwing', () => {
+    // A stubbed/error /api/sources may return an object, not an array.
+    expect(pickPrimarySource({ success: true } as never)).toBeUndefined();
+  });
 });
 
 // --- hook ------------------------------------------------------------------

--- a/src/hooks/useResolvedSourceId.test.ts
+++ b/src/hooks/useResolvedSourceId.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { pickPrimarySource, useResolvedSourceId } from './useResolvedSourceId';
+
+// --- pure picker ----------------------------------------------------------
+
+describe('pickPrimarySource', () => {
+  it('prefers the earliest-created enabled meshtastic_tcp source', () => {
+    const sources = [
+      { id: 'mqtt', type: 'mqtt_bridge', enabled: true, createdAt: 1 },
+      { id: 'tcp-late', type: 'meshtastic_tcp', enabled: true, createdAt: 30 },
+      { id: 'tcp-early', type: 'meshtastic_tcp', enabled: true, createdAt: 20 },
+    ];
+    expect(pickPrimarySource(sources)?.id).toBe('tcp-early');
+  });
+
+  it('falls back to the earliest enabled source when no tcp source exists', () => {
+    const sources = [
+      { id: 'mc-late', type: 'meshcore', enabled: true, createdAt: 40 },
+      { id: 'mqtt-early', type: 'mqtt_bridge', enabled: true, createdAt: 10 },
+    ];
+    expect(pickPrimarySource(sources)?.id).toBe('mqtt-early');
+  });
+
+  it('ignores disabled sources', () => {
+    const sources = [
+      { id: 'tcp-disabled', type: 'meshtastic_tcp', enabled: false, createdAt: 1 },
+      { id: 'tcp-enabled', type: 'meshtastic_tcp', enabled: true, createdAt: 5 },
+    ];
+    expect(pickPrimarySource(sources)?.id).toBe('tcp-enabled');
+  });
+
+  it('returns undefined when there are no enabled sources', () => {
+    expect(pickPrimarySource([{ id: 'x', type: 'meshcore', enabled: false }])).toBeUndefined();
+    expect(pickPrimarySource([])).toBeUndefined();
+  });
+});
+
+// --- hook ------------------------------------------------------------------
+
+const mockUseSource = vi.fn();
+const mockUseQuery = vi.fn();
+vi.mock('../contexts/SourceContext', () => ({ useSource: () => mockUseSource() }));
+vi.mock('@tanstack/react-query', () => ({ useQuery: (opts: unknown) => mockUseQuery(opts) }));
+vi.mock('../init', () => ({ appBasename: '' }));
+
+describe('useResolvedSourceId', () => {
+  beforeEach(() => {
+    mockUseSource.mockReset();
+    mockUseQuery.mockReset();
+    mockUseQuery.mockReturnValue({ data: undefined });
+  });
+
+  it('returns the context sourceId when present (no fallback fetch)', () => {
+    mockUseSource.mockReturnValue({ sourceId: 'ctx-src' });
+    expect(useResolvedSourceId()).toBe('ctx-src');
+    // fallback query is disabled when a context source exists
+    expect(mockUseQuery.mock.calls[0][0].enabled).toBe(false);
+  });
+
+  it('returns undefined while the fallback list is loading', () => {
+    mockUseSource.mockReturnValue({ sourceId: null });
+    mockUseQuery.mockReturnValue({ data: undefined });
+    expect(useResolvedSourceId()).toBeUndefined();
+  });
+
+  it('resolves the primary source when context is null', () => {
+    mockUseSource.mockReturnValue({ sourceId: null });
+    mockUseQuery.mockReturnValue({
+      data: [
+        { id: 'mqtt', type: 'mqtt_bridge', enabled: true, createdAt: 1 },
+        { id: 'tcp', type: 'meshtastic_tcp', enabled: true, createdAt: 2 },
+      ],
+    });
+    expect(useResolvedSourceId()).toBe('tcp');
+    expect(mockUseQuery.mock.calls[0][0].enabled).toBe(true);
+  });
+});

--- a/src/hooks/useResolvedSourceId.ts
+++ b/src/hooks/useResolvedSourceId.ts
@@ -26,6 +26,7 @@ export interface ResolvableSource {
 
 /** Pure primary-source picker (exported for testing). */
 export function pickPrimarySource<T extends ResolvableSource>(sources: T[]): T | undefined {
+  if (!Array.isArray(sources)) return undefined;
   const enabled = sources.filter((s) => s.enabled);
   const byCreated = [...enabled].sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
   return byCreated.find((s) => s.type === 'meshtastic_tcp') ?? byCreated[0];

--- a/src/hooks/useResolvedSourceId.ts
+++ b/src/hooks/useResolvedSourceId.ts
@@ -1,0 +1,56 @@
+/**
+ * useResolvedSourceId — resolve a CONCRETE sourceId for API calls.
+ *
+ * Many source-scoped endpoints now REQUIRE a sourceId (they 400 with
+ * MISSING_SOURCE_ID otherwise — see the source-id enforcement remediation).
+ * In source-specific views `useSource()` already provides one, but in
+ * legacy / single-source views it is `null`. This hook fills that gap by
+ * falling back to the primary source — the first enabled `meshtastic_tcp`
+ * source, else the first enabled source — mirroring the backend's
+ * `resolveDefaultSourceForUser`.
+ *
+ * Returns `undefined` while the source list is still loading; callers should
+ * treat that as "not ready yet" and defer the request (e.g. TanStack `enabled`,
+ * or an early return) rather than firing without a sourceId.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useSource } from '../contexts/SourceContext';
+import { appBasename } from '../init';
+
+export interface ResolvableSource {
+  id: string;
+  type: string;
+  enabled: boolean;
+  createdAt?: number;
+}
+
+/** Pure primary-source picker (exported for testing). */
+export function pickPrimarySource<T extends ResolvableSource>(sources: T[]): T | undefined {
+  const enabled = sources.filter((s) => s.enabled);
+  const byCreated = [...enabled].sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
+  return byCreated.find((s) => s.type === 'meshtastic_tcp') ?? byCreated[0];
+}
+
+/**
+ * @returns the active/context sourceId, or the resolved primary sourceId, or
+ *          `undefined` while the fallback source list is still loading.
+ */
+export function useResolvedSourceId(): string | undefined {
+  const { sourceId } = useSource();
+
+  // Only fetch the source list when we actually need a fallback.
+  const { data: sources } = useQuery<ResolvableSource[]>({
+    queryKey: ['sources', 'resolve-primary'],
+    queryFn: async () => {
+      const res = await fetch(`${appBasename}/api/sources`, { credentials: 'include' });
+      if (!res.ok) throw new Error(`Failed to fetch sources: ${res.status}`);
+      return res.json();
+    },
+    staleTime: 60_000,
+    enabled: sourceId == null,
+  });
+
+  if (sourceId) return sourceId;
+  if (!sources) return undefined; // still loading the fallback list
+  return pickPrimarySource(sources)?.id;
+}

--- a/src/hooks/useSmartHops.ts
+++ b/src/hooks/useSmartHops.ts
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useResolvedSourceId } from './useResolvedSourceId';
 
 /**
  * Smart hops data point from the backend
@@ -69,10 +70,13 @@ export function useSmartHops({
   baseUrl = '',
   enabled = true,
 }: UseSmartHopsOptions) {
+  const sourceId = useResolvedSourceId();
   return useQuery({
-    queryKey: ['smartHops', nodeId, hours],
+    queryKey: ['smartHops', nodeId, hours, sourceId],
     queryFn: async (): Promise<SmartHopsData[]> => {
-      const response = await fetch(`${baseUrl}/api/telemetry/${nodeId}/smarthops?hours=${hours}`);
+      const response = await fetch(
+        `${baseUrl}/api/telemetry/${nodeId}/smarthops?hours=${hours}&sourceId=${encodeURIComponent(sourceId!)}`
+      );
 
       if (!response.ok) {
         throw new Error(`Failed to fetch smart hops: ${response.status} ${response.statusText}`);
@@ -81,7 +85,8 @@ export function useSmartHops({
       const result: SmartHopsResponse = await response.json();
       return result.data;
     },
-    enabled: enabled && !!nodeId,
+    // sourceId is required by the endpoint — defer until it resolves.
+    enabled: enabled && !!nodeId && !!sourceId,
     refetchInterval: 60000, // Refetch every 60 seconds
     staleTime: 55000, // Data considered fresh for 55 seconds
     gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes

--- a/src/hooks/useTelemetry.test.ts
+++ b/src/hooks/useTelemetry.test.ts
@@ -16,6 +16,10 @@ import {
   type TelemetryData,
 } from './useTelemetry';
 
+// The telemetry endpoint requires a sourceId; the hook resolves a fallback via
+// useResolvedSourceId. Pin it so URL assertions are deterministic.
+vi.mock('./useResolvedSourceId', () => ({ useResolvedSourceId: () => 'src-test' }));
+
 // Helper to create a wrapper with QueryClient
 function createWrapper(queryClient?: QueryClient) {
   const client = queryClient ?? new QueryClient({
@@ -90,7 +94,7 @@ describe('useTelemetry hooks', () => {
       renderHook(() => useTelemetry({ nodeId: '!abc123' }), { wrapper });
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith('/api/telemetry/!abc123?hours=24');
+        expect(global.fetch).toHaveBeenCalledWith('/api/telemetry/!abc123?hours=24&sourceId=src-test');
       });
     });
 
@@ -104,7 +108,7 @@ describe('useTelemetry hooks', () => {
       renderHook(() => useTelemetry({ nodeId: '!abc123', hours: 48 }), { wrapper });
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith('/api/telemetry/!abc123?hours=48');
+        expect(global.fetch).toHaveBeenCalledWith('/api/telemetry/!abc123?hours=48&sourceId=src-test');
       });
     });
 
@@ -121,7 +125,7 @@ describe('useTelemetry hooks', () => {
       );
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith('http://localhost:3000/api/telemetry/!abc123?hours=24');
+        expect(global.fetch).toHaveBeenCalledWith('http://localhost:3000/api/telemetry/!abc123?hours=24&sourceId=src-test');
       });
     });
 

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -8,6 +8,7 @@
  */
 
 import { useQuery, useQueries, keepPreviousData } from '@tanstack/react-query';
+import { useResolvedSourceId } from './useResolvedSourceId';
 
 /**
  * Telemetry data point from the backend
@@ -85,12 +86,14 @@ interface UseTelemetryOptions {
  * ```
  */
 export function useTelemetry({ nodeId, hours = 24, baseUrl = '', sourceId, enabled = true }: UseTelemetryOptions) {
+  // The endpoint now requires a sourceId; fall back to the primary source when
+  // the caller didn't supply one (legacy/single-source views).
+  const fallbackSourceId = useResolvedSourceId();
+  const effectiveSourceId = sourceId ?? fallbackSourceId;
   return useQuery({
-    queryKey: ['telemetry', nodeId, hours, sourceId],
+    queryKey: ['telemetry', nodeId, hours, effectiveSourceId],
     queryFn: async (): Promise<TelemetryData[]> => {
-      const url = sourceId
-        ? `${baseUrl}/api/telemetry/${nodeId}?hours=${hours}&sourceId=${encodeURIComponent(sourceId)}`
-        : `${baseUrl}/api/telemetry/${nodeId}?hours=${hours}`;
+      const url = `${baseUrl}/api/telemetry/${nodeId}?hours=${hours}&sourceId=${encodeURIComponent(effectiveSourceId!)}`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -99,7 +102,8 @@ export function useTelemetry({ nodeId, hours = 24, baseUrl = '', sourceId, enabl
 
       return response.json();
     },
-    enabled: enabled && !!nodeId,
+    // Defer until a sourceId is available (required by the endpoint).
+    enabled: enabled && !!nodeId && !!effectiveSourceId,
     // Keep showing the prior result while a new window/node loads so the time
     // range selector and charts don't flash a loading state on every change.
     placeholderData: keepPreviousData,

--- a/src/server/routes/telemetryRoutes.test.ts
+++ b/src/server/routes/telemetryRoutes.test.ts
@@ -73,9 +73,15 @@ describe('GET /telemetry/:nodeId', () => {
     (databaseService.getTelemetryByNodeAveragedAsync as any).mockResolvedValue([
       { telemetryType: 'temperature', value: 20 },
     ]);
-    const res = await request(app).get('/telemetry/!12345678');
+    const res = await request(app).get('/telemetry/!12345678?sourceId=src-A');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
+  });
+
+  it('400s when sourceId is omitted', async () => {
+    const res = await request(app).get('/telemetry/!12345678');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
   });
 
   it('skips the node lookup for a 64-hex MeshCore pubkey (no out-of-range nodeNum) (#3677)', async () => {
@@ -85,7 +91,7 @@ describe('GET /telemetry/:nodeId', () => {
       { telemetryType: 'temperature', value: 20 },
     ]);
     const pubkey = 'a'.repeat(64);
-    const res = await request(app).get(`/telemetry/${pubkey}`);
+    const res = await request(app).get(`/telemetry/${pubkey}?sourceId=src-A`);
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(databaseService.nodes.getNode).not.toHaveBeenCalled();

--- a/src/server/routes/telemetryRoutes.ts
+++ b/src/server/routes/telemetryRoutes.ts
@@ -32,7 +32,7 @@ router.get('/direct-neighbors', requirePermission('info', 'read'), async (req: R
 });
 
 // Get telemetry data for a node
-router.get('/telemetry/:nodeId', optionalAuth(), async (req: Request, res: Response) => {
+router.get('/telemetry/:nodeId', optionalAuth(), requireSourceId('query'), async (req: Request, res: Response) => {
   try {
     // Allow users with info read OR dashboard read (dashboard needs telemetry data)
     if (
@@ -53,7 +53,8 @@ router.get('/telemetry/:nodeId', optionalAuth(), async (req: Request, res: Respo
     // from the Device Info time-range selector survive the round-trip.
     const rawHours = req.query.hours ? parseFloat(req.query.hours as string) : 24;
     const hoursParam = Number.isFinite(rawHours) && rawHours > 0 ? rawHours : 24;
-    const telSourceId = req.query.sourceId as string | undefined;
+    // sourceId presence validated by requireSourceId('query')
+    const telSourceId = req.query.sourceId as string;
 
     // Calculate cutoff timestamp for filtering
     const cutoffTime = Date.now() - hoursParam * 60 * 60 * 1000;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -808,6 +808,7 @@ import scriptRoutes, { scriptsEndpoint, getScriptsDirectory } from './routes/scr
 import deviceRoutes from './routes/deviceRoutes.js';
 import systemRoutes, { setSystemCallbacks } from './routes/systemRoutes.js';
 import channelRoutes from './routes/channelRoutes.js';
+import { requireSourceId } from './utils/requireSourceId.js';
 
 // CSRF token endpoint (must be before CSRF protection middleware)
 apiRouter.get('/csrf-token', csrfTokenEndpoint);
@@ -1679,7 +1680,7 @@ apiRouter.post('/nodes/:nodeId/ignored', requirePermission('nodes', 'write', { s
 });
 
 // Get node position override
-apiRouter.get('/nodes/:nodeId/position-override', optionalAuth(), async (req, res) => {
+apiRouter.get('/nodes/:nodeId/position-override', optionalAuth(), requireSourceId('query'), async (req, res) => {
   try {
     const { nodeId } = req.params;
 
@@ -1703,9 +1704,8 @@ apiRouter.get('/nodes/:nodeId/position-override', optionalAuth(), async (req, re
     }
 
     const nodeNum = parseInt(nodeNumStr, 16);
-    const poGetSourceId = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
-      ? (req.query.sourceId as string)
-      : 'default';
+    // sourceId presence validated by requireSourceId('query')
+    const poGetSourceId = req.query.sourceId as string;
     const override = await databaseService.getNodePositionOverrideAsync(nodeNum, poGetSourceId);
 
     if (!override) {


### PR DESCRIPTION
## Summary

Phase 2a of the source-scoping remediation — the first **coordinated frontend + backend** slice (`docs/internal/dev-notes/SOURCEID_ENFORCEMENT_PLAN.md`). Converts accidental all-source / 500 endpoints to a clean **400 `MISSING_SOURCE_ID`**, and updates the frontend so legacy/single-source views send a resolved sourceId instead of omitting it.

### Backend — now require `sourceId`
- `GET /api/telemetry/:nodeId` — was backend-divergent (SQLite silently leaked all sources; PG/MySQL threw 500).
- `GET /api/nodes/:nodeId/position-override` — was silently coerced to the `'default'` source; its POST/DELETE siblings already scope.

### Frontend — send a resolved sourceId
- **New `useResolvedSourceId()`** — returns the context sourceId, else the primary source (first enabled `meshtastic_tcp`, else first enabled), mirroring the backend's `resolveDefaultSourceForUser`. Tolerates non-array responses.
- `useTelemetry` / `useSmartHops` / `useLinkQuality` now resolve + always send a sourceId and defer until it's available. **This also fixes the Smart Hops & Link Quality graphs**, which were silently broken (always-500 before #4053, 400 after) because the hooks never sent a sourceId.
- `PositionOverrideModal` sends a resolved sourceId.

## Tests
- `useResolvedSourceId` unit tests (incl. non-array guard); telemetry route 400-on-missing + scoping; updated hook/component URL assertions.
- Server TSC clean. All suites touching the changed code pass (**479 tests** across 22 files). Full-suite runs were completing green earlier; the machine is currently under load from concurrent sessions, so I verified via the exhaustive affected-file set instead.

## Follow-ups (tracked in the plan)
Remaining Phase 2 groups — security (`issues`/`export`/`key-mismatches` + `nodes/:nodeNum/clear`), `neighbor-info/:nodeNum`, the 5 channel-write routes, `embed/:profileId/neighborinfo` — plus Phase 3 (device ops) and Phase 4 (v1 legacy + `packets/:id`). Landing incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)