### PR TITLE
feat(map): Phase 3 — unified traceroute rendering across all app maps (#4047)

### DIFF
--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
@@ -45,6 +45,13 @@ markers, popups, spiderfy, tiles, and traceroute rendering land everywhere by co
 - Only NodesTab supports MapLibre vector tiles (`VectorTileLayer`).
 - Leaflet default-icon fix duplicated in `App.tsx` and `EmbedSettings.tsx`.
 
+**Phase restructure (user directive 2026-07-10):** rendering unification broadened beyond
+traceroutes — node markers and node popups are pulled forward as their own phases. Data
+shown in popups and role icons legitimately differ by source technology (Meshtastic vs
+MeshCore); those differences become explicit parameters/composition of ONE system, never
+parallel implementations. New order: P3 traceroutes → P4 node markers → P5 popups →
+P6 embed traceroute alignment → P7 residual layers + big maps on BaseMap.
+
 ## Phases
 
 ### [x] Phase 1 — `BaseMap` shell (`feature/4047-p1-basemap-shell`)
@@ -78,39 +85,49 @@ comments; suite green.
 ### [ ] Phase 3 — Traceroute unification, app maps (`feature/4047-p3-traceroute-unify`)
 (a) Canonical 4-band theme-aware SNR→color scale + one weight + one dash convention in
 `mapHelpers`; delete `DashboardMap.snrToColor`, `MapAnalysis.snrQualityColor`, hardcoded
-palettes. (b) Shared `src/components/map/layers/TraceroutePathsLayer.tsx` owning geometry,
-curvature, arrows, forward/return legs, MQTT/unknown-SNR dashing — parameterized for weight
-strategy (usage/occurrence/SNR), arrows, direction-vs-SNR color mode, hover-highlight.
-Consumed by NodesTab (base + selected route via `useTraceroutePaths` data),
-DashboardMap (gains return legs), Map Analysis, TracerouteWidget.
+palettes; the Map Analysis legend SNR section consumes the canonical mapping. (b) Shared
+`src/components/map/layers/TraceroutePathsLayer.tsx` owning geometry, curvature, arrows,
+forward/return legs, MQTT/unknown-SNR dashing — parameterized for weight strategy
+(usage/occurrence/SNR), arrows, direction-vs-SNR color mode, hover-highlight. Consumed by
+NodesTab (base + selected route), DashboardMap (gains return legs), Map Analysis,
+TracerouteWidget.
 **Exit criteria:** one SNR scale everywhere; all four app maps render traceroutes through
 the shared layer; #1862/#2051/#2931 behaviors preserved in one place with tests;
 browser-validated on all four views; suite green.
 
-### [ ] Phase 4 — Embed traceroute alignment (`feature/4047-p4-embed-traceroutes`)
+### [ ] Phase 4 — Node marker unification (`feature/4047-p4-marker-unify`)
+One icon factory in `src/components/map/` unifying `createNodeIcon` (Meshtastic
+hop-colored) and MeshCoreMap's hand-rolled `L.divIcon` around `roleGlyphMarkerSvg`
+(MeshCore role glyphs) behind one API; one shared `NodeMarkersLayer` (spiderfy + icon
+cache built in, generalized from MapAnalysis's) consumed by NodesTab, DashboardMap,
+MeshCoreMap, MapAnalysis. Source-tech icon differences are parameters of the one factory.
+**Exit criteria:** no hand-rolled node-marker divIcon outside the factory; the four maps
+render markers through the shared layer; spiderfy behavior preserved (incl. the
+obscured-marker fix, commits 40b6b1e6/ade691b1); browser-validated; suite green.
+
+### [ ] Phase 5 — Popup unification (`feature/4047-p5-popup-unify`)
+One popup family: shared card chrome + composable data sections. Meshtastic sections
+(hops/SNR/battery/hardware) vs MeshCore sections (path length/scope/etc.) become section
+composition, not separate components. NodesTab migrates off `MapNodePopupContent` (delete
+it); MeshCore popup content joins the family; `NodePopup`/`DashboardNodePopup` reconciled.
+**Exit criteria:** `MapNodePopupContent` deleted; one popup family renders all maps'
+popups with no capability loss; browser-validated per source tech; suite green.
+
+### [ ] Phase 6 — Embed traceroute alignment (`feature/4047-p6-embed-traceroutes`)
 Extend `/api/embed/:id/traceroutes` to carry per-segment SNR + leg/direction data
-(backward-compatible envelope), and render EmbedMap traceroutes through the shared
+(backward-compatible), render EmbedMap traceroutes through the shared
 TraceroutePathsLayer with the canonical SNR scale.
 **Exit criteria:** public embeds show the same traceroute visuals as the app; old embed
-clients don't break; API + rendering tests; browser-validated via an embed iframe; suite green.
+clients don't break; API + rendering tests; browser-validated via an embed iframe;
+suite green.
 
-### [ ] Phase 5 — Popup convergence (`feature/4047-p5-popup-converge`)
-Migrate NodesTab off `MapNodePopupContent` onto the `NodePopup`/`DashboardNodePopup`
-family (continuation of #3692); delete `MapNodePopupContent`. Fold any NodesTab-only popup
-capabilities into the shared family as options.
-**Exit criteria:** `MapNodePopupContent` deleted; NodesTab popups render the canonical card
-with no capability loss (browser-validated); suite green.
-
-### [ ] Phase 6 — Shared layer library (`feature/4047-p6-layer-library`)
-Promote/generalize layers into `src/components/map/layers/`: node markers (spiderfy + icon
-cache built in), neighbor links, position trails, waypoints, accuracy regions. DashboardMap,
-MeshCoreMap, MapAnalysis, and NodesTab compose them, retiring inline marker/polyline code.
-Fold MeshCoreMap's custom `L.divIcon` into `mapIcons.ts`. All big maps on the BaseMap shell
-by end of phase. NodesTab migrates **last** (largest, most entangled). Architect may split
-this phase into multiple PRs if decomposition demands it — flag to orchestrator first.
-**Exit criteria:** no inline marker/polyline reimplementations in the big four; all maps on
-BaseMap; per-map visuals preserved or deliberately converged; browser-validated on every
-map view; suite green.
+### [ ] Phase 7 — Residual layer library + big maps on BaseMap (`feature/4047-p7-layer-library`)
+Promote neighbor links, waypoints, accuracy regions, position trails into
+`src/components/map/layers/`; DashboardMap, MeshCoreMap, MapAnalysis, NodesTab compose
+them and adopt the BaseMap shell; NodesTab migrates **last**. May split into multiple PRs
+— flag to orchestrator first.
+**Exit criteria:** no inline layer reimplementations in the big four; all maps on BaseMap;
+browser-validated on every map view; suite green.
 
 ## Deferred (future issues, not this epic)
 

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
@@ -82,7 +82,7 @@ three files + this epic-doc correction. See `MAP_CONSOLIDATION_P2_SPEC.md` (Opti
 shared helper (browser-validated); the three files carry not-a-fork/deliberate-divergence
 comments; suite green.
 
-### [ ] Phase 3 — Traceroute unification, app maps (`feature/4047-p3-traceroute-unify`)
+### [x] Phase 3 — Traceroute unification, app maps (`feature/4047-p3-traceroute-unify`)
 (a) Canonical 4-band theme-aware SNR→color scale + one weight + one dash convention in
 `mapHelpers`; delete `DashboardMap.snrToColor`, `MapAnalysis.snrQualityColor`, hardcoded
 palettes; the Map Analysis legend SNR section consumes the canonical mapping. (b) Shared
@@ -137,6 +137,32 @@ browser-validated on every map view; suite green.
 ## Phase log
 
 (Per-phase: PR link, deviations, decisions — appended as phases complete.)
+
+### Phase 3 (2026-07-10) — Traceroute unification, app maps
+- Delivered: canonical 4-band theme-aware SNR scale (WCAG-AA-verified light palette);
+  `src/utils/tracerouteSegments.ts` (leaflet-free single home for #1862/#2051/#2931 +
+  sentinel constants + `isValidRouteNode` + `buildLiveNodePositionMap` +
+  `averageNonSentinelSnr`); shared `src/components/map/layers/TraceroutePathsLayer.tsx`
+  (4 color modes incl. `mqttColor`, 3 weight strategies, canonical `'3,6'` dash,
+  curvature number-or-fn, arrows, temporal fade, highlight, React.memo). All four app
+  renderers migrated: NodesTab (base+selected), DashboardMap (return legs + /4 SNR
+  scaling fix + MQTT dash), TracerouteWidget (theme legs), MapAnalysis (thin adapter,
+  legend on canonical palette).
+- Latent bugs fixed along the way: Dashboard colored by UN-scaled SNR; snapshot
+  positions dropped at lat/lng exactly 0 (truthy checks); live positions same (now
+  shared helper, Null-Island guard retained); Dashboard never rendered return legs.
+- 8-angle review + verify found 2 introduced regressions (return-only traceroutes;
+  widget MQTT weight) and 1 unapproved visual change (MQTT color distinction lost) —
+  all fixed; MQTT color is now canonical on ALL maps via `mqttColor` (previously
+  NodesTab-only). 10 findings total, all fixed (see PR).
+- Visible changes shipped: NodesTab 3→4 band; no-data segments noData-gray dashed
+  (was solid mauve); Dashboard gains return legs + MQTT color/dash; widget legs use
+  theme traceroute pink (direction via arrows); Analysis dash '4,6'→'3,6'.
+- Browser-validated on all four surfaces against pre-migration baselines (screenshots
+  in session scratchpad); suite 9,431 tests green; lint ratchet clean.
+- Note for Phase 6 (embed): EmbedMap still fixed-mauve server-computed segments.
+- Deferred (parity, not regressions): eager per-segment popup construction (recharts
+  trees built for all segments); popup laziness would be a perf follow-up.
 
 ### Phase 2 (2026-07-10) — Reconcile the Map Analysis "forks"
 - **Premise corrected (user-approved retarget):** PolarGridLayer was never a fork (#3971

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_P3_SPEC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_P3_SPEC.md
@@ -1,0 +1,467 @@
+# Map Consolidation — Phase 3 Spec: Traceroute Rendering Unification
+
+**Epic:** #4047 · **Phase:** 3 · **Branch:** `feature/4047-p3-traceroute-unify` (from `origin/4049-map-refactor`)
+**Status:** Spec — no feature code written yet.
+**Scope:** app maps only (NodesTab, DashboardMap, TracerouteWidget, MapAnalysis). EmbedMap is Phase 6.
+
+## 0. TL;DR for implementers
+
+Today there are **5 traceroute renderers, 3 SNR color scales, 4 dash conventions, 3 weight
+formulas**, and the #1862/#2051/#2931 behaviors are re-implemented per renderer. Phase 3:
+
+1. **One canonical SNR→color scale** — 4-band (`≥5 / ≥0 / ≥-5 / <-5` = green/yellow/orange/red)
+   + `noData`, **theme-aware** (hex moves into `overlayColors.snrColors`, expanded 3→4 bands).
+2. **One shared render layer** `src/components/map/layers/TraceroutePathsLayer.tsx` owning geometry,
+   curvature, arrows, forward/return legs, MQTT/unknown-SNR dashing — parameterized for weight
+   strategy, arrows, color mode, hover-highlight. Consumed by all four app maps.
+3. **One shared decomposition util** `src/utils/tracerouteSegments.ts` that is the SINGLE home for
+   #1862 (snapshot positions), #2051 (empty-routeBack guard), #2931 (unknown-SNR sentinel), with tests.
+4. Consumer-specific **data** logic (dedup, usage/occurrence counting, weak-link filtering, direction
+   classification, zoom-adaptive filtering) STAYS in each consumer's hook — only rendering unifies.
+
+Approved appearance changes: NodesTab base layer 3-band → 4-band; DashboardMap gains return legs
+(and MQTT dashing on its paths pass — C2); TracerouteWidget leg colors converge to the theme
+`tracerouteForward`/`tracerouteReturn` palette (C1).
+
+## 0.1 Orchestrator decisions — RESOLVED (gate review 2026-07-10)
+
+| # | Question | Resolution |
+|---|---|---|
+| D1 | Rename `snrColors` fields `{good,medium,poor,noData}` → `{excellent,good,fair,poor,noData}` (semantic shift + 4th band)? | **YES** — rename, lockstep across all readers (§7 lockstep note). |
+| D2 | Canonical dash = `'3,6'` applied **iff MQTT/all-unknown-SNR**. NodesTab selected route currently dashes `'3,6'` **always**; Widget `'5,10'` on unknown; MapAnalysis `'4,6'` on MQTT. Converge all to `'3,6'` on MQTT/unknown, dropping NodesTab's always-dash? | **YES** — converge to `'mqtt-unknown'`; keep `'always'` as an escape-hatch prop value. |
+| D3 | Light-theme 4-band hexes need a WCAG-AA-on-cream check (Phase 1/2 established this bar). | **YES — binding on WP1:** the implementer must run the WCAG AA (≥4.0 on cream ~#F2EFE9) check on the light hexes and adjust any that fail. §2.1 table is a starting point, not final. |
+| D4 | NodesTab node-popup SNR swatch (`NodesTab.tsx:2584`) is **node** SNR (not segment) but reads `overlayColors.snrColors` with an inline 3-band. Adopt canonical `snrToColor` there too? | **YES**. |
+| D5 | DashboardMap gains return-leg rendering. | **YES** — epic-approved; the `/4` SNR-scaling note is **binding on WP4**. |
+
+**Gate-review convergence corrections (orchestrator-directed, 2026-07-10):**
+- **C1 — Widget leg colors converge to theme.** The Widget's hardcoded `#4CAF50`/`#2196F3` legs vs
+  NodesTab-selected's theme `tracerouteForward`/`tracerouteReturn` are two fixed-leg palettes for the
+  identical concept — drift, not a deliberate parameter. The Widget now passes
+  `legColors={{ forward: overlayColors.tracerouteForward, return: overlayColors.tracerouteReturn }}`
+  sourced from **`useSettings().overlayColors`** (the Widget does not receive App.tsx's
+  `mergedThemeColors`; `useSettings()` is the same underlying palette). **Approved visible change.**
+  Note: in both current palettes `tracerouteForward === tracerouteReturn` (pink; "direction shown by
+  arrows") — the widget's legs become same-colored, with direction conveyed by arrows and the existing
+  hover-highlight; its legend swatches should read the same theme tokens so they stay truthful.
+- **C2 — Dashboard paths pass uses the canonical dash.** Because Dashboard's segment build moves to
+  `decomposeTraceroute` (§4), per-hop sentinel data IS available — the paths pass uses the default
+  `dashMode: 'mqtt-unknown'` so MQTT segments dash there like everywhere else. Only the fixed-yellow
+  overlay pass stays `'never'` (it is a highlight, not a data encoding).
+
+---
+
+## 1. Reuse inventory (serena-verified 2026-07-10)
+
+All epic-survey premises **verified accurate**. Line numbers are current on this branch.
+
+### 1.1 Shared primitives — `src/utils/mapHelpers.tsx`
+| Symbol | Line | Behavior (current) |
+|---|---|---|
+| `UNKNOWN_SNR_SENTINEL` | 16 | `-32` (firmware INT8_MIN/4). #2931. |
+| `isUnknownSnr(snr)` | 19 | `snr === -32`. |
+| `generateCurvedPath(start,end,curvature=0.15,segments=20,normalizeDirection=false)` | 105 | quadratic bézier; perpendicular offset `curvature*length`; `normalizeDirection` flips sign so A→B and B→A bow opposite ways. |
+| `getSegmentSnrColor(snrData, snrColors, defaultColor)` | 164 | **3-band**: avg non-sentinel SNR; `>0→good`, `>=-10→medium`, else `poor`; empty→defaultColor. **Only caller: useTraceroutePaths:573.** |
+| `getSegmentSnrOpacity(snrData, isMqtt)` | 182 | MQTT/empty→`0.5`; else avg clamped [-20,15] → `0.4+((n+20)/35)*0.45`. |
+| `getLineWeight(snr)` | 199 | `undefined→3`; clamp [-20,10] → `2+((n+20)/30)*4` (2..6). |
+| `generateCurvedArrowMarkers(positions,pathKey,color,snrs,curvature,normalizeDirection=true)` | 223 | one arrow at curve midpoint/segment; tooltip `?`/`${snr} dB`. |
+| `getTemporalOpacityMultiplier(timestamp)` | 268 | `<1h→1.0`, `>24h→0.2`, sqrt decay; none→0.5. |
+| `generateArrowMarkers` (legacy straight) | 38 | **no live consumers** (App.tsx:68 comment only). |
+
+**Consumer blast radius** (imports):
+- `getSegmentSnrColor` → **useTraceroutePaths only**.
+- `getSegmentSnrOpacity` → useTraceroutePaths:575, MapAnalysis layer:129.
+- `getLineWeight` → useTraceroutePaths:812,917; TracerouteWidget:513,547.
+- `generateCurvedPath` → useTraceroutePaths, TracerouteWidget, MapAnalysis layer.
+- `generateCurvedArrowMarkers` → same three.
+- `isUnknownSnr`/`UNKNOWN_SNR_SENTINEL` → useTraceroutePaths, MapAnalysis layer; **useTracerouteAnalysis.ts:5-9 re-declares its own private copy** (duplication to fix under #2931-once).
+- `.snrColors` reads: mapHelpers:166 (param type), useTraceroutePaths (`ThemeColors.snrColors`), **NodesTab:2584** (inline node-SNR swatch, 3-band), App.tsx:444 (merge). The shared `MapLegend.tsx` has **no** SNR section (0 matches).
+
+### 1.2 Theme mechanism (concrete design target for "theme-aware")
+Two layered systems:
+
+**(a) Overlay palette — `src/config/overlayColors.ts`** — THE home for the canonical SNR tokens.
+Plain TS module. `interface OverlayColors` (L3-28) includes `snrColors: {good,medium,poor,noData}`
+(L16-21) with `darkOverlayColors` (Catppuccin Mocha, L43-48) and `lightOverlayColors` (darkened Latte,
+WCAG-AA-on-cream, L74-79). `getOverlayColors(scheme)` → chosen by `getSchemeForTileset(tilesetId)`.
+Consumed via **`useSettings().overlayColors`** (`SettingsContext.tsx:10,85,475,1543`), which memoizes
+`getOverlayColors(overlayScheme)`.
+
+**(b) CSS custom properties `--ctp-*`** (Catppuccin) — Leaflet Polylines can't read CSS vars, so
+`App.tsx:412-445` resolves `--ctp-mauve/red/blue/overlay0` at runtime via `getComputedStyle` and
+`useMemo`s `mergedThemeColors = {...cssVarHexes, tracerouteForward, tracerouteReturn, mqttSegment,
+neighborLine, snrColors}` (merging `overlayColors` on top), passed as `themeColors` to useTraceroutePaths.
+
+**Design consequence:** the canonical SNR scale lives in `overlayColors.snrColors` (expanded to 4 bands),
+read through `useSettings().overlayColors` by all four consumers. NodesTab already threads it via
+`mergedThemeColors`; the other three read `useSettings()` directly. No CSS-var work needed for SNR.
+
+### 1.3 `src/components/map/` (Phase 1/2 output)
+`BaseMap.tsx` + `BaseMap.test.tsx` + `leafletDefaultIcon.ts`. **No `layers/` subdir yet** — Phase 3
+creates `src/components/map/layers/`. BaseMap conventions: named export, typed props interface, no
+`any`, returns a fragment, persistence-agnostic (never calls `useSettings()` itself — caller owns
+state). The new layer follows the same conventions but, being an overlay, MAY read `useSettings()`
+for the palette (consumers already do) OR take `snrColors` as a prop — spec chooses **prop** (see §3)
+to keep it pure/testable, matching BaseMap's "no useSettings" ethos.
+
+### 1.4 The five renderers (current behavior — what each maps onto the shared layer)
+
+**useTraceroutePaths.tsx (1076 LOC) — NodesTab, TWO layers.** Returns **plain data** (arrays of ready
+React elements), not a component:
+```ts
+interface UseTraceroutePathsResult {
+  traceroutePathsElements: React.ReactElement[] | null;  // base "all paths"
+  selectedNodeTraceroute: React.ReactElement[] | null;   // selected route
+  tracerouteNodeNums: Set<number> | null;                // marker filter
+  tracerouteBounds: [[number,number],[number,number]] | null;
+}
+```
+Wired App.tsx:4607-4620 (`themeColors=mergedThemeColors`, `mapZoom`, `visibleNodeNums`, …); NodesTab
+splats the arrays through `React.memo` pass-throughs (`<>{paths}</>`).
+- **Base layer** (useMemo L293-714): age cutoff → **dedup most-recent per bidirectional pair** → aggregate
+  per-segment usage count + SNR samples(+ts) + MQTT(per-hop sentinel, NOT node.viaMqtt) + latest ts.
+  **STRAIGHT, no arrows.** `visibleNodeNums` both-endpoints filter (L464). **Zoom-adaptive filter**
+  (`mapZoom<8` drops no-SNR/MQTT/avg<-10, L472). Weight `min(2+usage,8)` (usage-based). Color: MQTT→
+  `mqttSegment`, else `getSegmentSnrColor` (3-band). Opacity `max(0.15, getSegmentSnrOpacity*temporal)`.
+  Dash `'3,6'` iff MQTT. Rich `<Popup>` with SNR stats + **recharts `SegmentSnrChart`** (≥3 samples).
+- **Selected layer** (useMemo L718-981): single trace, snapshot positions (#1862), empty-route guard.
+  Forward `generateCurvedPath(...,0.2,20,true)`, weight `getLineWeight(snr)`, color `tracerouteForward`,
+  opacity **0.9**, dash **`'3,6'` always**, arrows. Return leg curvature **-0.2**, color `tracerouteReturn`.
+  `tracerouteBounds` from snapshot positions + 10% pad.
+
+**TracerouteWidget.tsx (641 LOC)** — `mapData` useMemo L214-317: snapshot positions (#1862 L217);
+**#2051 empty-routeBack guard L233-248** (`hasReturnPath = backHops>0 || hasSnrBack`). Curved ±0.2,
+arrows, **fixed leg colors `#4CAF50`/`#2196F3`**, weight `getLineWeight`. Dash `'5,10'` iff `snr===undefined`.
+**Hover highlight/dim** (legend `onMouseEnter/Leave` → `highlightedPath: 'forward'|'back'|null`,
+opacity 0.9/0.2; arrows only for highlighted leg).
+
+**DashboardMap.tsx (977 LOC)** — local `snrToColor` **4-band** L86-92 (`>=5 #22c55e / >=0 #eab308 /
+>=-5 #f97316 / else #ef4444`); local `parseRoutePositions` L117 (snapshot #1862). `tracerouteSegments`
+L518: age cutoff; **forward leg ONLY, no routeBack** (gains it in P3); STRAIGHT; `snr=snrTowards[i]`
+**un-scaled (no /4)** default 0. **Two stacked passes**: `showPaths` (weight 2, opacity 0.85, per-seg
+color) + `showRoute` (fixed **yellow `#facc15`, weight 4, opacity 0.6** overlay). No dash/fade/arrows/hover.
+
+**MapAnalysis — two halves:**
+- **DATA (PRESERVE) `useTracerouteAnalysis.ts` (379 LOC):** pure `analyzeTraceroutes` → `AnalyzedSegment[]`
+  `{key,sourceId,from,to,fromPos,toPos,direction,neighborNum,avgSnr(number|null),occurrences,isMqtt}`.
+  Forward `snrTowards[i]/4`; **#2051 back guard L155** (`routeBack.length>0 || snrBack.length>0`); time/
+  source/membership filters; occurrence + non-sentinel SNR aggregation; **weak-link filters**
+  `occurrences<minOccurrences`, `avgSnr<minSnr`; direction only when focused; `isMqtt=hasUnknown&&snrCount===0`.
+  **Own sentinel copy L5-9 (fold into mapHelpers under #2931).** Positions **live only, no snapshot**.
+- **RENDER (REPLACE) `MapAnalysis/layers/TraceroutePathsLayer.tsx` (170 LOC):** `showArrows =
+  selectedNodeNum!==null`. Hardcoded `OUTBOUND='#3b82f6'`, `INBOUND='#f43f5e'`; `snrQualityColor` **4-band**
+  (`null→#94a3b8`, `≥5→#22c55e`, `≥0→#eab308`, `≥-5→#f97316`, else `#ef4444`). curvature `neutral?0.12:0.2`;
+  weight `2+min(occ-1,5)*0.8` (occurrence-based); opacity `getSegmentSnrOpacity`; dash `'4,6'` iff MQTT;
+  Polyline click → select (no popup).
+
+### 1.5 Issue-behavior locations (to consolidate)
+| Issue | Behavior | Current homes |
+|---|---|---|
+| #1862 | snapshot route positions | useTraceroutePaths (`getNodePositionWithSnapshot`/`parseRoutePositions`), Widget L217, Dashboard `parseRoutePositions` L117. **MapAnalysis omits (live only).** |
+| #2051 | empty-routeBack guard | Widget L233-248, useTracerouteAnalysis L150-165, RouteSegmentTraceroutesModal L51. |
+| #2931 | unknown-SNR sentinel + per-hop MQTT | mapHelpers (canonical), useTracerouteAnalysis (**dup copy L5-9**), useTraceroutePaths, MapAnalysis layer. |
+
+### 1.6 Existing tests encoding current behavior
+- `src/utils/mapHelpers.test.tsx` — `getSegmentSnrColor` **3-band** cases (L96-123: good `>0`, medium
+  `>=-10`, poor); `getLineWeight` range (L153-172); sentinel/opacity/curve. **Updates on 4-band change.**
+- `src/hooks/useTraceroutePaths.test.tsx` — visibleNodeNums / channel / MQTT filtering (data logic;
+  survives, may need element-shape tweaks after render swap).
+- `src/hooks/useTracerouteAnalysis.test.ts` + `.emptyBack.test.ts` — data/dedup/#2051/#2931 (PRESERVE;
+  only sentinel-import change).
+- `src/components/MapAnalysis/layers/TraceroutePathsLayer.test.tsx` — "one polyline per segment", time-
+  window exclusion (updates when render swaps to shared layer).
+
+---
+
+## 2. Canonical conventions design
+
+### 2.1 SNR → color (one scale, 4-band, theme-aware)
+Thresholds (canonical, binding): `avg ≥ 5` excellent · `≥ 0` good · `≥ -5` fair · `< -5` poor · `null/empty` noData.
+SNR values are **/4-scaled dB** (already scaled by every data producer; DashboardMap's un-scaled `snrTowards`
+**must be /4'd** when building segments — see §4).
+
+Expand `overlayColors.snrColors` to `{ excellent, good, fair, poor, noData }` in **both** palettes.
+Starting hex table (D3 — verify light against WCAG AA ≥4.0 on cream):
+| band | dark (Mocha) | light (Latte, AA-on-cream) |
+|---|---|---|
+| excellent (≥5) | `#22c55e` | `#15803d` |
+| good (≥0) | `#eab308` | `#8f5200` |
+| fair (≥-5) | `#f97316` | `#b45309` |
+| poor (<-5) | `#ef4444` | `#d20f39` |
+| noData | `#6c7086` | `#6c6f7e` |
+
+New mapHelpers export:
+```ts
+export interface SnrColorScale { excellent: string; good: string; fair: string; poor: string; noData: string; }
+export function snrToColor(avgSnr: number | null | undefined, scale: SnrColorScale): string {
+  if (avgSnr == null || isUnknownSnr(avgSnr)) return scale.noData;
+  if (avgSnr >= 5) return scale.excellent;
+  if (avgSnr >= 0) return scale.good;
+  if (avgSnr >= -5) return scale.fair;
+  return scale.poor;
+}
+```
+Rewrite `getSegmentSnrColor(snrData, scale, defaultColor)` to average non-sentinel then delegate to
+`snrToColor` (4-band; `defaultColor` still returned for all-empty to preserve the "no data uses
+neighbor/mauve" caller intent — OR drop `defaultColor` and always use `scale.noData`; **recommend keep
+`defaultColor` param** to avoid churn at the one caller). No separate 3-band survivor — the 3-band scale
+is deleted app-wide (approved: NodesTab base layer changes 3→4 band).
+
+### 2.2 Line weight (one API, three named strategies)
+The three formulas are legitimately different data axes; keep all three as **explicit parameters**.
+Export canonical strategy helpers from mapHelpers:
+```ts
+export const weightBySnr = getLineWeight;                              // existing 2..6 (keep name/behavior)
+export function weightByUsage(usage: number): number { return Math.min(2 + usage, 8); }
+export function weightByOccurrence(occ: number): number { return 2 + Math.min(occ - 1, 5) * 0.8; }
+```
+Layer `weight` prop = `number | ((seg) => number)`. NodesTab base → `weightByUsage(seg.usageCount)`;
+NodesTab selected & Widget → `weightBySnr(seg.avgSnr)`; MapAnalysis → `weightByOccurrence(seg.occurrences)`;
+Dashboard → fixed `2` (paths) / `4` (overlay pass).
+
+### 2.3 Dash (one convention)
+Canonical `MQTT_DASH = '3,6'`, applied iff segment is **MQTT OR all-SNR-unknown** (`isMqtt || avgSnr==null`).
+Replaces `'5,10'` (Widget) and `'4,6'` (MapAnalysis) and NodesTab-base MQTT dash. Layer prop
+`dashMode?: 'mqtt-unknown' | 'always' | 'never'` (default `'mqtt-unknown'`). Per D2 (resolved YES),
+NodesTab selected route converges from `'always'` to `'mqtt-unknown'`; `'always'` stays available as an
+escape hatch only. Per C2, the Dashboard **paths** pass also uses `'mqtt-unknown'` (sentinel data is
+available once it builds via `decomposeTraceroute`); only its fixed-yellow overlay pass is `'never'`
+(highlight, not a data encoding).
+
+### 2.4 Opacity + temporal fade
+Opacity is per-consumer → layer prop `opacity?: number | ((seg) => number)` with `getSegmentSnrOpacity`
+available as the SNR-scaled default. Temporal fade (`getTemporalOpacityMultiplier`) is ONLY the NodesTab
+base layer → gate behind `temporalFade?: boolean` (default false); when true the layer multiplies the
+resolved opacity by `getTemporalOpacityMultiplier(seg.timestamp)` and floors at `0.15` (matches L575).
+
+### 2.5 Curvature / arrows
+`curvature?: number` (default 0 = straight). Forward legs use `+curvature`, return `-curvature`
+(via `generateCurvedPath(..., normalizeDirection=true)`); `neutralCurvature?: number` for MapAnalysis
+neutral segments (0.12). `showArrows?: boolean` (consumer computes: MapAnalysis `selectedNodeNum!==null`).
+Arrows drawn with `generateCurvedArrowMarkers`; for straight layers (curvature 0) arrows are simply off.
+
+### 2.6 What happens to the 3-band `getSegmentSnrColor`
+**Deleted as a 3-band function** — repurposed to 4-band (single canonical). No non-traceroute caller
+exists (verified: only useTraceroutePaths). The `noData` semantic previously split across `defaultColor`
+arg and (absent) 4th band is now unified in `snrToColor`.
+
+---
+
+## 3. Shared modules — API design
+
+### 3.1 `src/utils/tracerouteSegments.ts` (NEW — the single home for #1862/#2051/#2931)
+Pure, React-free, fully unit-testable. Consolidates the per-traceroute decomposition common denominator;
+consumer hooks call these then apply their own aggregation/filtering ON TOP.
+```ts
+export interface TracerouteRenderSegment {
+  key: string;
+  from: [number, number];              // lat,lng — already snapshot-resolved
+  to: [number, number];
+  leg: 'forward' | 'return' | 'neutral';
+  direction?: 'inbound' | 'outbound' | 'neutral'; // MapAnalysis relative-to-selection
+  avgSnr: number | null;               // /4-scaled dB; null = no data
+  isMqtt: boolean;                      // per-hop sentinel (#2931), NOT node.viaMqtt
+  usageCount?: number;                  // weightByUsage
+  occurrences?: number;                 // weightByOccurrence
+  timestamp?: number;                   // temporal fade
+  snrSamples?: { snr: number; timestamp?: number }[]; // popup/chart + array color/opacity
+}
+
+// #1862 — parse the traceroute's stored position snapshot (nodeNum → latlng).
+export function parseSnapshotRoutePositions(traceroute): Map<number, [number, number]>;
+// snapshot-then-live resolution.
+export function resolveSegmentPosition(nodeNum, snapshot, liveNodes): [number,number] | null;
+// #2051 — true only when a return path genuinely exists.
+export function hasReturnPath(routeBack: number[], snrBack: string | number[] | null): boolean;
+// per-traceroute forward+return decomposition; sentinel→isMqtt/avgSnr(#2931); omits fictitious return (#2051).
+export function decomposeTraceroute(traceroute, opts: { resolvePosition: (n:number)=>[number,number]|null }): TracerouteRenderSegment[];
+```
+`isUnknownSnr`/`UNKNOWN_SNR_SENTINEL` stay in mapHelpers; `useTracerouteAnalysis.ts` **imports them**
+(removes its dup copy) so #2931 lives once.
+
+> **Migration nuance:** MapAnalysis currently omits snapshot positions (live only). Its data hook
+> `useTracerouteAnalysis` already decomposes and aggregates; it need not adopt `decomposeTraceroute`
+> wholesale. Minimum to satisfy "#2051 once" = have `useTracerouteAnalysis` call `hasReturnPath`, and
+> "#2931 once" = import the sentinel. Full `decomposeTraceroute` adoption is used by NodesTab / Widget /
+> Dashboard (which all share snapshot + forward/return build). MapAnalysis keeps its live-position path
+> but shares the guard + sentinel. This keeps the biggest hook's data logic untouched while still
+> centralizing the three behaviors.
+
+### 3.2 `src/components/map/layers/TraceroutePathsLayer.tsx` (NEW — the render layer)
+```ts
+export interface TraceroutePathsLayerProps {
+  segments: TracerouteRenderSegment[];
+  snrColors: SnrColorScale;                          // theme palette (prop, not useSettings)
+  colorMode: 'snr' | 'direction' | 'fixed-leg' | 'fixed';
+  legColors?: { forward: string; return: string };   // 'fixed-leg'
+  directionColors?: { outbound: string; inbound: string; neutral: string }; // 'direction'
+  fixedColor?: string;                                // 'fixed' (Dashboard yellow overlay)
+  curvature?: number;                                 // 0 = straight; default 0
+  neutralCurvature?: number;                          // MapAnalysis neutral 0.12
+  weight: number | ((seg: TracerouteRenderSegment) => number);
+  opacity?: number | ((seg: TracerouteRenderSegment) => number);
+  dashMode?: 'mqtt-unknown' | 'always' | 'never';    // default 'mqtt-unknown'
+  showArrows?: boolean;
+  temporalFade?: boolean;                             // multiplies opacity, floor 0.15
+  highlight?: { group: 'forward' | 'return' | 'neutral' | null; dimmedOpacity: number }; // Widget hover
+  onSegmentClick?: (seg: TracerouteRenderSegment) => void;   // MapAnalysis click-select
+  renderPopup?: (seg: TracerouteRenderSegment) => React.ReactNode; // NodesTab recharts / DraggablePopup
+  segmentClassName?: (seg: TracerouteRenderSegment) => string;     // NodesTab 'route-segment node-X'
+}
+```
+Rendering: for each segment, resolve color (by `colorMode`), weight, opacity (× temporalFade if set,
+× dim if `highlight` and segment not in highlighted group), dash (`dashMode`), geometry
+(`curvature===0` → straight `[from,to]`; else `generateCurvedPath` with leg-signed curvature). Emit
+`<Polyline>` (+ optional `<Popup>` from `renderPopup`, + `onClick={onSegmentClick}`), then arrows via
+`generateCurvedArrowMarkers` when `showArrows`. Returns a fragment (BaseMap convention). **No `any`.**
+
+**Consumer → props mapping:**
+| Consumer | colorMode | curvature | weight | opacity | dashMode | arrows | extras |
+|---|---|---|---|---|---|---|---|
+| NodesTab base | `snr` | 0 | `weightByUsage` | `getSegmentSnrOpacity` | mqtt-unknown | off | `temporalFade`, `renderPopup` (recharts), `segmentClassName` |
+| NodesTab selected | `fixed-leg` (theme fwd/ret) | 0.2 | `weightBySnr` | 0.9 | mqtt-unknown (was always — D2) | on | `renderPopup` (DraggablePopup) |
+| Widget | `fixed-leg` (theme fwd/ret via `useSettings().overlayColors` — C1) | 0.2 | `weightBySnr` | 0.9 | mqtt-unknown | on | `highlight` (hover) |
+| Dashboard paths | `snr` | 0 | `2` | 0.85 | mqtt-unknown (C2) | off | gains return legs |
+| Dashboard overlay | `fixed` (`#facc15`) | 0 | `4` | 0.6 | never (highlight, not data) | off | 2nd layer instance |
+| MapAnalysis | `direction` (focused) / `snr` (unfocused) | 0.2 / neutral 0.12 | `weightByOccurrence` | `getSegmentSnrOpacity` | mqtt-unknown | `selectedNodeNum!==null` | `onSegmentClick` |
+
+MapAnalysis colorMode is dynamic: when a node is focused use `'direction'` (`directionColors` blue/rose),
+else `'snr'`. Implement as consumer passing `colorMode={focused ? 'direction' : 'snr'}`.
+
+---
+
+## 4. File-by-file changes
+
+### Created
+- `src/utils/tracerouteSegments.ts` — §3.1. (+ `.test.ts`)
+- `src/components/map/layers/TraceroutePathsLayer.tsx` — §3.2. (+ `.test.tsx`)
+
+### Modified
+- `src/config/overlayColors.ts` — expand `OverlayColors.snrColors` to `{excellent,good,fair,poor,noData}`;
+  update both palettes (§2.1 table).
+- `src/utils/mapHelpers.tsx` — add `SnrColorScale`, `snrToColor`, `weightByUsage`, `weightByOccurrence`,
+  `weightBySnr` alias, `MQTT_DASH`; rewrite `getSegmentSnrColor` to 4-band delegate.
+- `src/utils/mapHelpers.test.tsx` — 4-band assertions for `getSegmentSnrColor`; add `snrToColor` +
+  weight-strategy tests.
+- `src/hooks/useTracerouteAnalysis.ts` — import `isUnknownSnr`/`UNKNOWN_SNR_SENTINEL` from mapHelpers
+  (delete dup L5-9); call `hasReturnPath` for the #2051 guard.
+- `src/hooks/useTraceroutePaths.tsx` — `ThemeColors.snrColors` type → 4-band; replace hand-built
+  Polyline/arrow construction in BOTH memos with `TracerouteRenderSegment[]` + `<TraceroutePathsLayer/>`
+  (base + selected). Keep dedup/usage/zoom-adaptive/visibleNodeNums/bounds DATA logic. Recharts popup
+  moves into a `renderPopup` callback.
+- `src/components/NodesTab.tsx` — the `React.memo` pass-throughs render arrays unchanged; node-SNR swatch
+  L2584 → `snrToColor` (D4).
+- `src/components/TracerouteWidget.tsx` — replace inline render L507-573 with `<TraceroutePathsLayer/>`;
+  keep `mapData`/#2051 (or delegate to `decomposeTraceroute`); wire hover via `highlight` prop; delete
+  local fixed-color/dash inline logic.
+- `src/components/Dashboard/DashboardMap.tsx` — **delete local `snrToColor` L86-92** and use canonical;
+  **/4-scale** the SNR when building segments; add return-leg decomposition (via `decomposeTraceroute`
+  or extend `tracerouteSegments`); replace the two stacked passes with two `<TraceroutePathsLayer/>`
+  instances (paths `colorMode:'snr'` + overlay `colorMode:'fixed'`).
+- `src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx` — **delete local `snrQualityColor` +
+  hardcoded OUTBOUND/INBOUND**; map `AnalyzedSegment[]` → `TracerouteRenderSegment[]` and render the
+  shared `src/components/map/layers/TraceroutePathsLayer`. File remains a thin MapAnalysis adapter
+  (preserves its test location); `useTracerouteAnalysis` untouched except §above.
+- `src/components/MapAnalysis/MapLegend.tsx` — SNR section L127-131 hardcoded hex → read canonical
+  `useSettings().overlayColors.snrColors` (excellent/good/fair/poor). Labels already match.
+- `src/App.tsx` — L444 `snrColors: schemeColors.snrColors` now carries 4 bands (no logic change; type flows).
+
+### Deleted (local implementations)
+- `DashboardMap.snrToColor`, `MapAnalysis.snrQualityColor` + its `OUTBOUND_COLOR`/`INBOUND_COLOR`,
+  `useTracerouteAnalysis` private sentinel copy, `mapHelpers.getSegmentSnrColor` 3-band body, hardcoded
+  leg palettes inline in Widget/NodesTab-selected/Dashboard-overlay (moved to `legColors`/`fixedColor`).
+
+---
+
+## 5. Test plan
+
+### Updated (encode OLD behavior)
+- `src/utils/mapHelpers.test.tsx` — rewrite `getSegmentSnrColor` cases to 4-band thresholds; keep
+  `getLineWeight`/opacity/sentinel/curve cases.
+- `src/components/MapAnalysis/layers/TraceroutePathsLayer.test.tsx` — "one polyline per segment" and
+  time-window exclusion still valid; update any color/weight assertions to shared-layer output.
+- `src/hooks/useTraceroutePaths.test.tsx` — filtering tests survive (data logic); adjust element-shape
+  expectations if they assert raw Polyline props now produced by the shared layer.
+
+### Unchanged / preserve
+- `src/hooks/useTracerouteAnalysis.test.ts` + `.emptyBack.test.ts` — data/dedup/#2051/#2931 unchanged
+  (only sentinel now imported; behavior identical).
+
+### New
+- `tracerouteSegments.test.ts` — **#1862** (snapshot beats live position), **#2051**
+  (`hasReturnPath`/`decomposeTraceroute` omit fictitious return for empty routeBack+snrBack; DRAW when
+  snrBack has data), **#2931** (sentinel → `isMqtt`/`avgSnr=null`; per-hop, not node.viaMqtt), forward/
+  return leg + `/4` scaling.
+- `TraceroutePathsLayer.test.tsx` (map/layers) — color modes (snr 4-band / direction / fixed-leg /
+  fixed), weight strategies (usage/occurrence/snr/fixed), dash logic (mqtt-unknown vs always vs never),
+  curvature 0=straight vs curved, arrows on/off, temporalFade opacity floor 0.15, hover dim, popup/click
+  render-props. Assert polyline count = segment count.
+
+**Gate:** full Vitest suite `success:true`, 0 failures (verify via `--reporter=json`, per memory —
+the rtk summary line masks suite-collection failures). `npm run lint:ci` exits 0 (no baseline growth;
+no new `any`). typecheck clean.
+
+---
+
+## 6. Work packages (Sonnet-sized, disjoint, ordered)
+
+### WP1 — Canonical conventions + theme palette *(no deps)*
+Files: `overlayColors.ts`, `mapHelpers.tsx`, `mapHelpers.test.tsx`, `useTracerouteAnalysis.ts` (sentinel
+import only), `NodesTab.tsx:2584`, `useTraceroutePaths.tsx` (`ThemeColors.snrColors` type only), `App.tsx`
+(type flow). **Acceptance:** 4-band `snrColors` in both palettes; `snrToColor`/weight strategies/`MQTT_DASH`
+exported + tested; `getSegmentSnrColor` 4-band; useTracerouteAnalysis uses shared sentinel; suite+lint green.
+No visual change yet except NodesTab node-SNR swatch (D4).
+
+### WP2 — Shared decomposition util + render layer + tests *(deps: WP1)*
+Files: `src/utils/tracerouteSegments.ts` (+test), `src/components/map/layers/TraceroutePathsLayer.tsx`
+(+test). **Acceptance:** util encapsulates #1862/#2051/#2931 with tests; layer renders all color modes /
+weight strategies / dash / curvature / arrows / temporalFade / hover / popup+click render-props; no
+consumer wired yet; suite+lint green.
+
+### WP3 — NodesTab / useTraceroutePaths migration *(deps: WP2)*
+Files: `useTraceroutePaths.tsx`, `NodesTab.tsx` (pass-throughs). **Acceptance:** both base + selected
+layers render via shared `TraceroutePathsLayer`; dedup/usage/zoom-adaptive/visibleNodeNums/bounds/recharts
+popup preserved; base layer now 4-band (approved); browser-validated on Nodes map; suite green.
+
+### WP4 — DashboardMap + TracerouteWidget migration *(deps: WP2; parallel to WP3)*
+Files: `DashboardMap.tsx`, `TracerouteWidget.tsx`. **Acceptance:** Dashboard uses canonical scale
+(+/4 scaling), **gains return legs**, two-pass via two layer instances; Widget renders via shared layer
+with hover-highlight preserved and #2051 guard intact; local `snrToColor` + fixed palettes deleted;
+browser-validated on Dashboard + widget; suite green.
+
+### WP5 — MapAnalysis render migration + legend SNR *(deps: WP2; parallel to WP3/WP4)*
+Files: `MapAnalysis/layers/TraceroutePathsLayer.tsx`, `MapAnalysis/MapLegend.tsx`,
+`MapAnalysis/layers/TraceroutePathsLayer.test.tsx`. **Acceptance:** analysis layer renders via shared
+layer (occurrence weight, direction/snr color modes, neutral curvature, click-select preserved); legend
+SNR section consumes canonical `overlayColors.snrColors`; `snrQualityColor`/hardcoded direction hex
+deleted; `useTracerouteAnalysis` data logic untouched; browser-validated on Map Analysis; suite green.
+
+**Dependency graph:** WP1 → WP2 → {WP3 ∥ WP4 ∥ WP5}. (WP3-5 touch disjoint files; safe in parallel,
+but each must re-run full suite before its PR-slice.)
+
+---
+
+## 7. Risks & gotchas
+
+- **useTraceroutePaths is 1076 LOC feeding NodesTab via App.tsx props (`mergedThemeColors`, `mapZoom`,
+  `visibleNodeNums`).** The DATA logic (dedup-per-pair, usage aggregation, zoom-adaptive `<8` filter,
+  visibleNodeNums, snapshot bounds, recharts SNR chart) must survive intact — WP3 only swaps the
+  element-construction tail, not the memo bodies. The recharts `SegmentSnrChart` (≥3 samples) must move
+  into `renderPopup` verbatim.
+- **DashboardMap's two stacked passes** (`showPaths` weight-2 base + `showRoute` fixed-yellow weight-4
+  overlay) are TWO layers over the same segment set — model as two `<TraceroutePathsLayer>` instances,
+  not one. Also: Dashboard SNR is **un-scaled** today; must `/4` when building segments or colors shift.
+- **MapAnalysis `useTracerouteAnalysis` dedup/filtering is data-side and must stay** — do NOT push its
+  aggregation into the shared layer. It keeps live positions (no snapshot); only shares the sentinel +
+  #2051 guard. Direction coloring is only active when a node is focused (`colorMode` toggles).
+- **Widget hover state** (`highlightedPath` driven by legend mouse events) → the `highlight` prop; arrows
+  currently draw only for the highlighted leg — preserve via arrows honoring `highlight`.
+- **Zoom-adaptive filtering** (NodesTab base, `mapZoom<8`) stays in the hook (data decision), not the layer.
+- **No new `any`; lint baseline must not grow** (CLAUDE.md ratchet). Type the layer/util fully.
+- **`snrColors` field rename (D1)** touches every reader — WP1 must update mapHelpers, useTraceroutePaths
+  `ThemeColors`, NodesTab:2584, App.tsx merge, MapAnalysis legend (WP5) in lockstep or typecheck breaks.
+- **Verify suite via `--reporter=json`** (`success:true`) — the rtk summary line masks suite-collection
+  failures (project memory).
+- **Snapshot-position parity:** three current `parseRoutePositions` copies (useTraceroutePaths, Widget,
+  Dashboard) may differ subtly in field names of the stored snapshot — WP2's `parseSnapshotRoutePositions`
+  must reproduce each; diff them during WP2 to avoid a regression where a route silently falls back to live.
+```

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_P3_SPEC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_P3_SPEC.md
@@ -351,12 +351,16 @@ else `'snr'`. Implement as consumer passing `colorMode={focused ? 'direction' : 
 - `src/components/NodesTab.tsx` — the `React.memo` pass-throughs render arrays unchanged; node-SNR swatch
   L2584 → `snrToColor` (D4).
 - `src/components/TracerouteWidget.tsx` — replace inline render L507-573 with `<TraceroutePathsLayer/>`;
-  keep `mapData`/#2051 (or delegate to `decomposeTraceroute`); wire hover via `highlight` prop; delete
-  local fixed-color/dash inline logic.
+  keep `mapData`/#2051 (or delegate to `decomposeTraceroute`); wire hover via `highlight` prop; **delete
+  hardcoded `#4CAF50`/`#2196F3` leg palette — legs converge to theme `tracerouteForward`/`tracerouteReturn`
+  read from `useSettings().overlayColors` (C1, approved visible change);** legend swatches read the same
+  tokens; delete local dash inline logic.
 - `src/components/Dashboard/DashboardMap.tsx` — **delete local `snrToColor` L86-92** and use canonical;
   **/4-scale** the SNR when building segments; add return-leg decomposition (via `decomposeTraceroute`
   or extend `tracerouteSegments`); replace the two stacked passes with two `<TraceroutePathsLayer/>`
-  instances (paths `colorMode:'snr'` + overlay `colorMode:'fixed'`).
+  instances — paths `colorMode:'snr'` with `dashMode:'mqtt-unknown'` (C2 — sentinel data now flows from
+  `decomposeTraceroute`, so MQTT segments dash here like everywhere else) + overlay `colorMode:'fixed'`
+  with `dashMode:'never'`.
 - `src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx` — **delete local `snrQualityColor` +
   hardcoded OUTBOUND/INBOUND**; map `AnalyzedSegment[]` → `TracerouteRenderSegment[]` and render the
   shared `src/components/map/layers/TraceroutePathsLayer`. File remains a thin MapAnalysis adapter
@@ -424,9 +428,11 @@ popup preserved; base layer now 4-band (approved); browser-validated on Nodes ma
 
 ### WP4 — DashboardMap + TracerouteWidget migration *(deps: WP2; parallel to WP3)*
 Files: `DashboardMap.tsx`, `TracerouteWidget.tsx`. **Acceptance:** Dashboard uses canonical scale
-(+/4 scaling), **gains return legs**, two-pass via two layer instances; Widget renders via shared layer
-with hover-highlight preserved and #2051 guard intact; local `snrToColor` + fixed palettes deleted;
-browser-validated on Dashboard + widget; suite green.
+(**/4 scaling — binding, D5**), **gains return legs**, two-pass via two layer instances with paths pass
+`dashMode:'mqtt-unknown'` and overlay pass `'never'` (C2 — MQTT segments visibly dash on the Dashboard);
+Widget renders via shared layer with hover-highlight preserved, #2051 guard intact, and **leg colors from
+theme `tracerouteForward`/`tracerouteReturn` via `useSettings().overlayColors`** (C1 — hardcoded
+`#4CAF50`/`#2196F3` deleted; legend swatches match); browser-validated on Dashboard + widget; suite green.
 
 ### WP5 — MapAnalysis render migration + legend SNR *(deps: WP2; parallel to WP3/WP4)*
 Files: `MapAnalysis/layers/TraceroutePathsLayer.tsx`, `MapAnalysis/MapLegend.tsx`,
@@ -464,4 +470,7 @@ but each must re-run full suite before its PR-slice.)
 - **Snapshot-position parity:** three current `parseRoutePositions` copies (useTraceroutePaths, Widget,
   Dashboard) may differ subtly in field names of the stored snapshot — WP2's `parseSnapshotRoutePositions`
   must reproduce each; diff them during WP2 to avoid a regression where a route silently falls back to live.
-```
+- **Widget node-marker colors (C1 side-effect):** the Widget also colors its from/to node icons
+  `#4CAF50`/`#2196F3` to match its old leg palette (createNodeIcon call around L322). Marker icon
+  unification is **Phase 4 scope** — WP4 must NOT restyle the markers, but should note the temporary
+  leg/marker color mismatch in a code comment referencing Phase 4.

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_P3_SPEC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_P3_SPEC.md
@@ -244,6 +244,19 @@ Arrows drawn with `generateCurvedArrowMarkers`; for straight layers (curvature 0
 exists (verified: only useTraceroutePaths). The `noData` semantic previously split across `defaultColor`
 arg and (absent) 4th band is now unified in `snrToColor`.
 
+**Amendment (post-implementation review, 2026-07-10):** `getSegmentSnrColor` itself was fully deleted
+(not just its 3-band body) — its one caller (`useTraceroutePaths` base layer) had already inlined the
+same non-sentinel-average-then-`snrToColor` computation directly, making the wrapper dead code; the
+averaging step was extracted instead into `averageNonSentinelSnr` in `tracerouteSegments.ts` for reuse.
+The `defaultColor`-vs-mauve "no data" intent described above is **superseded**: every `colorMode: 'snr'`
+segment with no SNR data now renders `scale.noData` (gray) — there is no longer a separate
+mauve/neighbor-line fallback color for "no data" on a traceroute segment. The MQTT/IP-bridged visual
+distinction that `defaultColor` was partly standing in for is instead handled explicitly by the shared
+layer's `mqttColor` prop (`colorMode: 'snr'` only): when set and `seg.isMqtt`, it takes precedence over
+`snrToColor` so MQTT segments keep their own distinguishable color instead of collapsing into the same
+gray as genuine no-data segments. All four traceroute-segment consumers now pass `mqttColor` sourced
+from the same `overlayColors.mqttSegment` token.
+
 ---
 
 ## 3. Shared modules — API design

--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import DashboardMap from './DashboardMap';
+import { darkOverlayColors } from '../../config/overlayColors';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -72,7 +73,7 @@ vi.mock('../../services/api', () => ({
 // SettingsProvider.
 vi.mock('../../contexts/SettingsContext', () => ({
   useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
-  useSettings: () => ({ mapPinStyle: 'official' }),
+  useSettings: () => ({ mapPinStyle: 'official', overlayColors: darkOverlayColors }),
 }));
 
 vi.mock('leaflet', () => ({

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -50,6 +50,7 @@ import { TraceroutePathsLayer } from '../map/layers/TraceroutePathsLayer';
 import {
   parseSnapshotRoutePositions,
   resolveSegmentPosition,
+  buildLiveNodePositionMap,
   decomposeTraceroute,
   type TracerouteRenderSegment,
 } from '../../utils/tracerouteSegments';
@@ -428,15 +429,13 @@ export default function DashboardMap({
   // traceroute polylines deliberately terminate at the (jittered) marker pin —
   // keeping edges visually attached to the markers. Only the accuracy Rectangle
   // re-derives the true center (getNodeLatLng) so the cell box stays put.
-  const positionByNodeNum = useMemo(() => {
-    const map = new Map<number, [number, number]>();
-    for (const { node, pos } of nodesWithPosition) {
-      if (typeof node.nodeNum === 'number') {
-        map.set(node.nodeNum, [pos.lat, pos.lng]);
-      }
-    }
-    return map;
-  }, [nodesWithPosition]);
+  const positionByNodeNum = useMemo(
+    () =>
+      buildLiveNodePositionMap(nodesWithPosition, ({ node, pos }) =>
+        typeof node.nodeNum === 'number' ? { nodeNum: node.nodeNum, lat: pos.lat, lng: pos.lng } : null,
+      ),
+    [nodesWithPosition],
+  );
 
   // publicKey → [lat, lng] for resolving MeshCore neighbor-link endpoints.
   // MeshCore nodes carry no meshtastic nodeNum; their stable identity (and the
@@ -476,15 +475,14 @@ export default function DashboardMap({
     return segs;
   }, [meshcoreNeighbors, positionByPublicKey, showNeighborInfo]);
 
-  // Traceroute render segments: one TracerouteRenderSegment per hop (forward
-  // AND return leg — Dashboard gains return-leg rendering in P3, approved
-  // visible change, D5), built via the shared `decomposeTraceroute` (#4047
-  // P3 WP4). `decomposeTraceroute` internally /4-scales `snrTowards`/`snrBack`
-  // (D5 — binding: this Dashboard's raw traceroute rows carry un-scaled SNR,
-  // unlike every other consumer of this data), resolves #1862 snapshot
-  // positions ahead of live `positionByNodeNum`, and gates the return leg on
-  // the #2051 guard. Empty unless "Show Route Segments" or "Show Traceroute"
-  // is on. Each traceroute's own key is prefixed onto the util's per-hop key
+  // Traceroute render segments: one TracerouteRenderSegment per hop, forward
+  // AND return leg, built via the shared `decomposeTraceroute`.
+  // `decomposeTraceroute` internally /4-scales `snrTowards`/`snrBack` — this
+  // Dashboard's raw traceroute rows carry un-scaled SNR, unlike every other
+  // consumer of this data — resolves #1862 snapshot positions ahead of live
+  // `positionByNodeNum`, and gates the return leg on the #2051 guard. Empty
+  // unless "Show Route Segments" or "Show Traceroute" is on. Each
+  // traceroute's own key is prefixed onto the util's per-hop key
   // (`"forward:123-456"`) since multiple traceroute records can repeat the
   // same node pair and the util itself only decomposes one record at a time.
   const tracerouteRenderSegments = useMemo<TracerouteRenderSegment[]>(() => {
@@ -650,14 +648,14 @@ export default function DashboardMap({
             );
           })}
 
-        {/* Route segments — thin SNR-colored hop polylines (shared render layer,
-            #4047 P3 WP4). MQTT/unknown-SNR hops dash here (C2 — decomposeTraceroute
-            now supplies per-hop sentinel data, so the Dashboard gets the canonical
-            dashing every other traceroute renderer already has). */}
+        {/* Route segments — thin SNR-colored hop polylines (shared render
+            layer). MQTT/unknown-SNR hops dash and get the distinguishing
+            mqttColor, matching every other traceroute renderer. */}
         {showPaths && (
           <TraceroutePathsLayer
             segments={tracerouteRenderSegments}
             snrColors={overlayColors.snrColors}
+            mqttColor={overlayColors.mqttSegment}
             colorMode="snr"
             weight={2}
             opacity={0.85}

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -46,6 +46,13 @@ import { isNullIsland } from '../../utils/nullIsland';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { TraceroutePathsLayer } from '../map/layers/TraceroutePathsLayer';
+import {
+  parseSnapshotRoutePositions,
+  resolveSegmentPosition,
+  decomposeTraceroute,
+  type TracerouteRenderSegment,
+} from '../../utils/tracerouteSegments';
 
 export interface DashboardMapProps {
   nodes: any[];
@@ -83,48 +90,10 @@ function getNodeLatLng(node: any): { lat: number; lng: number } | null {
   return null;
 }
 
-/** SNR → color, matching the per-hop coloring used in MapAnalysis/TraceroutePathsLayer. */
-function snrToColor(snr: number): string {
-  if (snr >= 5) return '#22c55e';
-  if (snr >= 0) return '#eab308';
-  if (snr >= -5) return '#f97316';
-  return '#ef4444';
-}
-
 /** SNR → line opacity for MeshCore neighbor links, matching MeshCoreNeighborLinksLayer. */
 function snrToOpacity(snr: number | null | undefined): number {
   if (snr == null) return 0.4;
   return Math.max(0.2, Math.min(1, (snr + 10) / 20));
-}
-
-/** Safe JSON.parse that yields [] on bad/empty input. */
-function parseJsonArray(value: unknown): number[] {
-  if (typeof value !== 'string' || value.length === 0) return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Parse the `routePositions` JSON snapshot stored on a traceroute row.
- * Shape: `{ [nodeNum]: { lat, lng, alt? } }`. Backend emits this so the
- * frontend can draw the route even if a hop's node has gone stale and
- * been filtered out of the live nodes list.
- */
-function parseRoutePositions(value: unknown): Record<number, { lat: number; lng: number }> {
-  if (typeof value !== 'string' || value.length === 0) return {};
-  try {
-    const parsed = JSON.parse(value);
-    if (parsed && typeof parsed === 'object') {
-      return parsed as Record<number, { lat: number; lng: number }>;
-    }
-  } catch {
-    /* ignore */
-  }
-  return {};
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +140,7 @@ export default function DashboardMap({
   onNodeSourceSelect,
 }: DashboardMapProps) {
   const tileset = getTilesetById(tilesetId, customTilesets);
-  const { mapPinStyle, setMapTileset } = useSettings();
+  const { mapPinStyle, setMapTileset, overlayColors } = useSettings();
 
   // Polar grid (#3971): draw a grid centered on each source's own-node position.
   // On the Unified map (sourceId === UNIFIED_SOURCE_ID) that's every source, each
@@ -507,51 +476,48 @@ export default function DashboardMap({
     return segs;
   }, [meshcoreNeighbors, positionByPublicKey, showNeighborInfo]);
 
-  // Traceroute segments: one Polyline per hop, colored by snrTowards. Empty
-  // unless the user has enabled "Show Route Segments" or "Show Traceroute".
-  //
-  // Position resolution order for each hop:
-  //   1. `tr.routePositions` — JSON snapshot of positions at traceroute time.
-  //      Backend stamps this so the line still draws even when a hop's node
-  //      has aged out of the live nodes list.
-  //   2. live `positionByNodeNum` — current node positions.
-  const tracerouteSegments = useMemo(() => {
+  // Traceroute render segments: one TracerouteRenderSegment per hop (forward
+  // AND return leg — Dashboard gains return-leg rendering in P3, approved
+  // visible change, D5), built via the shared `decomposeTraceroute` (#4047
+  // P3 WP4). `decomposeTraceroute` internally /4-scales `snrTowards`/`snrBack`
+  // (D5 — binding: this Dashboard's raw traceroute rows carry un-scaled SNR,
+  // unlike every other consumer of this data), resolves #1862 snapshot
+  // positions ahead of live `positionByNodeNum`, and gates the return leg on
+  // the #2051 guard. Empty unless "Show Route Segments" or "Show Traceroute"
+  // is on. Each traceroute's own key is prefixed onto the util's per-hop key
+  // (`"forward:123-456"`) since multiple traceroute records can repeat the
+  // same node pair and the util itself only decomposes one record at a time.
+  const tracerouteRenderSegments = useMemo<TracerouteRenderSegment[]>(() => {
     if (!showPaths && !showRoute) return [];
     // Map Features age slider (#3322): hide traceroutes/route segments older
     // than the chosen age. Default (slider at max) keeps the prior behavior.
     const trCutoffMs = Date.now() - effectiveMaxAge * 60 * 60 * 1000;
-    const segs: Array<{
-      key: string;
-      positions: [number, number][];
-      color: string;
-    }> = [];
+    const segs: TracerouteRenderSegment[] = [];
     for (const tr of (traceroutes ?? [])) {
       const trTimestamp = Number(tr?.timestamp ?? tr?.createdAt ?? 0);
       if (trTimestamp && trTimestamp < trCutoffMs) continue;
-      const route = parseJsonArray(tr?.route);
-      const snrTowards = parseJsonArray(tr?.snrTowards);
       const fromNum = Number(tr?.fromNodeNum);
       const toNum = Number(tr?.toNodeNum);
       if (!Number.isFinite(fromNum) || !Number.isFinite(toNum)) continue;
-      const snapshot = parseRoutePositions(tr?.routePositions);
-      const lookup = (nodeNum: number): [number, number] | undefined => {
-        const snap = snapshot[nodeNum];
-        if (snap && typeof snap.lat === 'number' && typeof snap.lng === 'number') {
-          return [snap.lat, snap.lng];
-        }
-        return positionByNodeNum.get(nodeNum);
-      };
-      const path = [fromNum, ...route.map((n) => Number(n)), toNum];
-      for (let i = 0; i < path.length - 1; i++) {
-        const a = lookup(path[i]);
-        const b = lookup(path[i + 1]);
-        if (!a || !b) continue;
-        const snr = typeof snrTowards[i] === 'number' ? snrTowards[i] : 0;
-        segs.push({
-          key: `tr-${tr.sourceId ?? 'x'}-${tr.id}-${i}`,
-          positions: [a, b],
-          color: snrToColor(snr),
-        });
+      const snapshot = parseSnapshotRoutePositions(tr?.routePositions);
+      const resolvePosition = (nodeNum: number): [number, number] | null =>
+        resolveSegmentPosition(nodeNum, snapshot, positionByNodeNum);
+      const keyPrefix = `tr-${tr.sourceId ?? 'x'}-${tr.id}`;
+      const decomposed = decomposeTraceroute(
+        {
+          fromNodeNum: fromNum,
+          toNodeNum: toNum,
+          route: tr?.route,
+          routeBack: tr?.routeBack,
+          snrTowards: tr?.snrTowards,
+          snrBack: tr?.snrBack,
+          timestamp: tr?.timestamp,
+          createdAt: tr?.createdAt,
+        },
+        { resolvePosition },
+      );
+      for (const seg of decomposed) {
+        segs.push({ ...seg, key: `${keyPrefix}-${seg.key}` });
       }
     }
     return segs;
@@ -684,23 +650,34 @@ export default function DashboardMap({
             );
           })}
 
-        {/* Route segments — thin SNR-colored hop polylines. */}
-        {showPaths && tracerouteSegments.map((s) => (
-          <Polyline
-            key={`seg-${s.key}`}
-            positions={s.positions}
-            pathOptions={{ color: s.color, weight: 2, opacity: 0.85 }}
+        {/* Route segments — thin SNR-colored hop polylines (shared render layer,
+            #4047 P3 WP4). MQTT/unknown-SNR hops dash here (C2 — decomposeTraceroute
+            now supplies per-hop sentinel data, so the Dashboard gets the canonical
+            dashing every other traceroute renderer already has). */}
+        {showPaths && (
+          <TraceroutePathsLayer
+            segments={tracerouteRenderSegments}
+            snrColors={overlayColors.snrColors}
+            colorMode="snr"
+            weight={2}
+            opacity={0.85}
+            dashMode="mqtt-unknown"
           />
-        ))}
+        )}
 
-        {/* Traceroute overlay — thicker highlight on top of segments. */}
-        {showRoute && tracerouteSegments.map((s) => (
-          <Polyline
-            key={`route-${s.key}`}
-            positions={s.positions}
-            pathOptions={{ color: '#facc15', weight: 4, opacity: 0.6 }}
+        {/* Traceroute overlay — thicker fixed-yellow highlight on top of the
+            segments above. Highlight, not a data encoding, so it never dashes. */}
+        {showRoute && (
+          <TraceroutePathsLayer
+            segments={tracerouteRenderSegments}
+            snrColors={overlayColors.snrColors}
+            colorMode="fixed"
+            fixedColor="#facc15"
+            weight={4}
+            opacity={0.6}
+            dashMode="never"
           />
-        ))}
+        )}
 
         {/* MeshCore neighbor links — cyan dashed, resolved by public key. */}
         {meshcoreSegments.map((s) => (

--- a/src/components/MapAnalysis/MapLegend.test.tsx
+++ b/src/components/MapAnalysis/MapLegend.test.tsx
@@ -18,6 +18,20 @@ vi.mock('./MapAnalysisContext', () => ({
   useMapAnalysisCtx: () => mockCtx(),
 }));
 
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    overlayColors: {
+      snrColors: {
+        excellent: '#22c55e',
+        good: '#eab308',
+        fair: '#f97316',
+        poor: '#ef4444',
+        noData: '#6c7086',
+      },
+    },
+  }),
+}));
+
 const mockVisibleCategories = vi.fn();
 vi.mock('./useVisibleNodeTypeCategories', () => ({
   useVisibleNodeTypeCategories: () => mockVisibleCategories(),

--- a/src/components/MapAnalysis/MapLegend.tsx
+++ b/src/components/MapAnalysis/MapLegend.tsx
@@ -21,6 +21,7 @@ import {
   categoryGlyphFamily,
   NODE_TYPE_CATEGORY_META,
 } from '../../utils/nodeTypeCategory';
+import { useSettings } from '../../contexts/SettingsContext';
 
 interface SwatchProps {
   color: string;
@@ -53,6 +54,7 @@ function GradientBar({ stops }: { stops: string[] }) {
 export default function MapLegend() {
   const { config } = useMapAnalysisCtx();
   const { t } = useTranslation();
+  const { overlayColors } = useSettings();
   const [collapsed, setCollapsed] = useState(false);
   const visibleCategories = useVisibleNodeTypeCategories();
   // Only categories with a distinct glyph deserve a legend row; client/standard
@@ -125,12 +127,12 @@ export default function MapLegend() {
           {(showTraceroutes || showSnr) && (
             <section>
               <h4>SNR (dB)</h4>
-              <div className="row"><Swatch color="#22c55e" /> ≥ 5 (excellent)</div>
-              <div className="row"><Swatch color="#eab308" /> 0 to 5 (good)</div>
-              <div className="row"><Swatch color="#f97316" /> -5 to 0 (fair)</div>
-              <div className="row"><Swatch color="#ef4444" /> &lt; -5 (poor)</div>
+              <div className="row"><Swatch color={overlayColors.snrColors.excellent} /> ≥ 5 (excellent)</div>
+              <div className="row"><Swatch color={overlayColors.snrColors.good} /> 0 to 5 (good)</div>
+              <div className="row"><Swatch color={overlayColors.snrColors.fair} /> -5 to 0 (fair)</div>
+              <div className="row"><Swatch color={overlayColors.snrColors.poor} /> &lt; -5 (poor)</div>
               {showSnr && (
-                <div className="row"><Swatch color="#888" /> Unknown</div>
+                <div className="row"><Swatch color={overlayColors.snrColors.noData} /> Unknown</div>
               )}
             </section>
           )}

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.test.tsx
@@ -11,6 +11,19 @@ import TraceroutePathsLayer from './TraceroutePathsLayer';
 vi.mock('react-leaflet', () => ({
   Polyline: () => <div data-testid="polyline" />,
 }));
+vi.mock('../../../contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    overlayColors: {
+      snrColors: {
+        excellent: '#22c55e',
+        good: '#eab308',
+        fair: '#f97316',
+        poor: '#ef4444',
+        noData: '#6c7086',
+      },
+    },
+  }),
+}));
 vi.mock('../../../hooks/useMapAnalysisData', () => ({
   useTraceroutes: () => ({
     items: [

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
@@ -1,4 +1,3 @@
-import { Polyline } from 'react-leaflet';
 import { useMemo } from 'react';
 import {
   useDashboardSources,
@@ -14,32 +13,18 @@ import {
 } from '../../../hooks/useTracerouteAnalysis';
 import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
 import { visibleNodeNumSet, type SearchableNode } from '../nodeSearch';
-import {
-  generateCurvedPath,
-  generateCurvedArrowMarkers,
-  getSegmentSnrOpacity,
-  UNKNOWN_SNR_SENTINEL,
-} from '../../../utils/mapHelpers';
+import { weightByOccurrence, getSegmentSnrOpacity } from '../../../utils/mapHelpers';
+import type { TracerouteRenderSegment } from '../../../utils/tracerouteSegments';
+import { TraceroutePathsLayer as SharedTraceroutePathsLayer } from '../../map/layers/TraceroutePathsLayer';
+import { useSettings } from '../../../contexts/SettingsContext';
 
 // Direction colours (issue #3399): outbound = the selected node transmitting,
-// inbound = the selected node receiving.
+// inbound = the selected node receiving. These are Analysis-specific-by-design
+// (not part of the canonical theme palette) — kept as the same hardcoded
+// VALUES as before, now threaded through the shared layer's `directionColors`
+// prop instead of a local `segmentColor`/`snrQualityColor` implementation.
 const OUTBOUND_COLOR = '#3b82f6'; // blue
 const INBOUND_COLOR = '#f43f5e'; // rose
-
-/** SNR → quality colour for the global (no node selected) view. */
-function snrQualityColor(avgSnr: number | null): string {
-  if (avgSnr === null) return '#94a3b8'; // slate — unknown SNR
-  if (avgSnr >= 5) return '#22c55e';
-  if (avgSnr >= 0) return '#eab308';
-  if (avgSnr >= -5) return '#f97316';
-  return '#ef4444';
-}
-
-function segmentColor(s: AnalyzedSegment): string {
-  if (s.direction === 'outbound') return OUTBOUND_COLOR;
-  if (s.direction === 'inbound') return INBOUND_COLOR;
-  return snrQualityColor(s.avgSnr);
-}
 
 interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
@@ -50,13 +35,43 @@ interface NodeRecord extends MaybePositionedNode {
 }
 
 /**
+ * Maps one {@link AnalyzedSegment} to a {@link TracerouteRenderSegment} for
+ * the shared render layer. `leg` is 'neutral' for the unfocused (SNR-colored)
+ * view and 'forward' for the focused (direction-colored) view — this
+ * reproduces the pre-migration curvature exactly: unfocused segments always
+ * used the flat 0.12 neutral curvature, while focused in/outbound segments
+ * always used a positive (never leg-signed/negative) 0.2 curvature. Using
+ * 'forward' (not 'return') for focused segments avoids the shared layer's
+ * leg-signed negation, which the old renderer never applied here.
+ */
+function toRenderSegment(s: AnalyzedSegment): TracerouteRenderSegment {
+  return {
+    key: s.key,
+    from: s.fromPos,
+    to: s.toPos,
+    leg: s.direction === 'neutral' ? 'neutral' : 'forward',
+    direction: s.direction,
+    avgSnr: s.avgSnr,
+    isMqtt: s.isMqtt,
+    occurrences: s.occurrences,
+  };
+}
+
+/**
  * Renders deduplicated traceroute links via {@link useTracerouteAnalysis}. When
  * a node is selected, links are scoped to that node and coloured by direction
  * (outbound vs inbound) with arrows; otherwise links are coloured by SNR. Weak
  * links are removed per the persisted min-occurrences / min-SNR options.
+ *
+ * Thin adapter (#4047 P3 WP5): owns MapAnalysis-specific data wiring
+ * (`useTracerouteAnalysis`) and maps its output onto the shared
+ * `src/components/map/layers/TraceroutePathsLayer` for rendering. Geometry,
+ * color-mode resolution, weight/opacity/dash strategies, and arrows all live
+ * in the shared layer now — this file stays free of hardcoded SNR hex.
  */
 export default function TraceroutePathsLayer() {
   const { config, selected, nodeFilter, setSelected } = useMapAnalysisCtx();
+  const { overlayColors } = useSettings();
   const layer = config.layers.traceroutes;
   const options = useMemo(
     () => getTracerouteOptions(config),
@@ -118,53 +133,49 @@ export default function TraceroutePathsLayer() {
   // Arrows are only drawn in the directional (node-selected) view to keep the
   // global view light.
   const showArrows = selectedNodeNum !== null;
+  // colorMode is dynamic: focused segments carry inbound/outbound direction
+  // (colored by directionColors); unfocused segments are all 'neutral' and
+  // colored by SNR instead (see useTracerouteAnalysis's `focus` gating).
+  const colorMode = showArrows ? 'direction' : 'snr';
+
+  const renderSegments = useMemo(() => segments.map(toRenderSegment), [segments]);
+  const analyzedByKey = useMemo(
+    () => new Map(segments.map((s) => [s.key, s])),
+    [segments],
+  );
 
   return (
-    <>
-      {segments.map((s) => {
-        const color = segmentColor(s);
-        const curvature = s.direction === 'neutral' ? 0.12 : 0.2;
-        const path = generateCurvedPath(s.fromPos, s.toPos, curvature, 20, true);
-        const weight = 2 + Math.min(s.occurrences - 1, 5) * 0.8;
-        const opacity = getSegmentSnrOpacity(
-          s.avgSnr === null ? undefined : [{ snr: s.avgSnr }],
-          s.isMqtt,
-        );
-        return (
-          <Polyline
-            key={s.key}
-            positions={path}
-            pathOptions={{
-              color,
-              weight,
-              opacity,
-              dashArray: s.isMqtt ? '4,6' : undefined,
-            }}
-            eventHandlers={{
-              click: () =>
-                setSelected({
-                  type: 'segment',
-                  fromNodeNum: s.from,
-                  toNodeNum: s.to,
-                  direction: s.direction,
-                  occurrences: s.occurrences,
-                  avgSnr: s.avgSnr,
-                }),
-            }}
-          />
-        );
-      })}
-      {showArrows &&
-        segments.flatMap((s) =>
-          generateCurvedArrowMarkers(
-            [s.fromPos, s.toPos],
-            s.key,
-            segmentColor(s),
-            [s.avgSnr === null ? UNKNOWN_SNR_SENTINEL : s.avgSnr],
-            s.direction === 'neutral' ? 0.12 : 0.2,
-            true,
-          ),
-        )}
-    </>
+    <SharedTraceroutePathsLayer
+      segments={renderSegments}
+      snrColors={overlayColors.snrColors}
+      colorMode={colorMode}
+      directionColors={{
+        outbound: OUTBOUND_COLOR,
+        inbound: INBOUND_COLOR,
+        // Unreachable in practice: focused segments are always in/outbound
+        // (never 'neutral') and unfocused segments use colorMode 'snr', which
+        // ignores directionColors entirely.
+        neutral: overlayColors.snrColors.noData,
+      }}
+      neutralCurvature={0.12}
+      curvature={0.2}
+      weight={(seg) => weightByOccurrence(seg.occurrences ?? 1)}
+      opacity={(seg) =>
+        getSegmentSnrOpacity(seg.avgSnr === null ? undefined : [{ snr: seg.avgSnr }], seg.isMqtt)
+      }
+      showArrows={showArrows}
+      onSegmentClick={(seg) => {
+        const s = analyzedByKey.get(seg.key);
+        if (!s) return;
+        setSelected({
+          type: 'segment',
+          fromNodeNum: s.from,
+          toNodeNum: s.to,
+          direction: s.direction,
+          occurrences: s.occurrences,
+          avgSnr: s.avgSnr,
+        });
+      }}
+    />
   );
 }

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
@@ -19,10 +19,9 @@ import { TraceroutePathsLayer as SharedTraceroutePathsLayer } from '../../map/la
 import { useSettings } from '../../../contexts/SettingsContext';
 
 // Direction colours (issue #3399): outbound = the selected node transmitting,
-// inbound = the selected node receiving. These are Analysis-specific-by-design
-// (not part of the canonical theme palette) — kept as the same hardcoded
-// VALUES as before, now threaded through the shared layer's `directionColors`
-// prop instead of a local `segmentColor`/`snrQualityColor` implementation.
+// inbound = the selected node receiving. Analysis-specific-by-design (not
+// part of the canonical theme palette) — threaded through the shared layer's
+// `directionColors` prop.
 const OUTBOUND_COLOR = '#3b82f6'; // blue
 const INBOUND_COLOR = '#f43f5e'; // rose
 
@@ -36,20 +35,20 @@ interface NodeRecord extends MaybePositionedNode {
 
 /**
  * Maps one {@link AnalyzedSegment} to a {@link TracerouteRenderSegment} for
- * the shared render layer. `leg` is 'neutral' for the unfocused (SNR-colored)
- * view and 'forward' for the focused (direction-colored) view — this
- * reproduces the pre-migration curvature exactly: unfocused segments always
- * used the flat 0.12 neutral curvature, while focused in/outbound segments
- * always used a positive (never leg-signed/negative) 0.2 curvature. Using
- * 'forward' (not 'return') for focused segments avoids the shared layer's
- * leg-signed negation, which the old renderer never applied here.
+ * the shared render layer. There is no true forward/return leg in this data
+ * model (segments are classified by direction relative to the selected node,
+ * not by traceroute leg), so `leg` is always 'neutral'; curvature is instead
+ * supplied to the shared layer as a function of `direction` (see below),
+ * which is evaluated as-is with no leg-based sign negation.
  */
 function toRenderSegment(s: AnalyzedSegment): TracerouteRenderSegment {
   return {
     key: s.key,
     from: s.fromPos,
     to: s.toPos,
-    leg: s.direction === 'neutral' ? 'neutral' : 'forward',
+    fromNodeNum: s.from,
+    toNodeNum: s.to,
+    leg: 'neutral',
     direction: s.direction,
     avgSnr: s.avgSnr,
     isMqtt: s.isMqtt,
@@ -63,8 +62,8 @@ function toRenderSegment(s: AnalyzedSegment): TracerouteRenderSegment {
  * (outbound vs inbound) with arrows; otherwise links are coloured by SNR. Weak
  * links are removed per the persisted min-occurrences / min-SNR options.
  *
- * Thin adapter (#4047 P3 WP5): owns MapAnalysis-specific data wiring
- * (`useTracerouteAnalysis`) and maps its output onto the shared
+ * Thin adapter: owns MapAnalysis-specific data wiring (`useTracerouteAnalysis`)
+ * and maps its output onto the shared
  * `src/components/map/layers/TraceroutePathsLayer` for rendering. Geometry,
  * color-mode resolution, weight/opacity/dash strategies, and arrows all live
  * in the shared layer now — this file stays free of hardcoded SNR hex.
@@ -139,41 +138,32 @@ export default function TraceroutePathsLayer() {
   const colorMode = showArrows ? 'direction' : 'snr';
 
   const renderSegments = useMemo(() => segments.map(toRenderSegment), [segments]);
-  const analyzedByKey = useMemo(
-    () => new Map(segments.map((s) => [s.key, s])),
-    [segments],
-  );
 
   return (
     <SharedTraceroutePathsLayer
       segments={renderSegments}
       snrColors={overlayColors.snrColors}
       colorMode={colorMode}
-      directionColors={{
-        outbound: OUTBOUND_COLOR,
-        inbound: INBOUND_COLOR,
-        // Unreachable in practice: focused segments are always in/outbound
-        // (never 'neutral') and unfocused segments use colorMode 'snr', which
-        // ignores directionColors entirely.
-        neutral: overlayColors.snrColors.noData,
-      }}
-      neutralCurvature={0.12}
-      curvature={0.2}
+      mqttColor={overlayColors.mqttSegment}
+      directionColors={{ outbound: OUTBOUND_COLOR, inbound: INBOUND_COLOR }}
+      // Honest curvature: unfocused ('neutral' direction) segments use the
+      // flat 0.12 curve, focused in/outbound segments use 0.2 — both always
+      // positive, regardless of direction (the function form is used as-is,
+      // with no leg-based sign negation).
+      curvature={(seg) => (seg.direction === 'neutral' ? 0.12 : 0.2)}
       weight={(seg) => weightByOccurrence(seg.occurrences ?? 1)}
       opacity={(seg) =>
         getSegmentSnrOpacity(seg.avgSnr === null ? undefined : [{ snr: seg.avgSnr }], seg.isMqtt)
       }
       showArrows={showArrows}
       onSegmentClick={(seg) => {
-        const s = analyzedByKey.get(seg.key);
-        if (!s) return;
         setSelected({
           type: 'segment',
-          fromNodeNum: s.from,
-          toNodeNum: s.to,
-          direction: s.direction,
-          occurrences: s.occurrences,
-          avgSnr: s.avgSnr,
+          fromNodeNum: seg.fromNodeNum,
+          toNodeNum: seg.toNodeNum,
+          direction: seg.direction,
+          occurrences: seg.occurrences,
+          avgSnr: seg.avgSnr,
         });
       }}
     />

--- a/src/components/MapLegend.test.tsx
+++ b/src/components/MapLegend.test.tsx
@@ -39,8 +39,9 @@ vi.mock('../contexts/SettingsContext', () => ({
         gradient: ['#0000FF', '#3300CC', '#660099', '#990066', '#CC0033', '#FF0000'],
       },
       snrColors: {
+        excellent: '#22c55e',
         good: '#a6e3a1',
-        medium: '#f9e2af',
+        fair: '#f9e2af',
         poor: '#f38ba8',
         noData: '#6c7086',
       },

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -9,7 +9,7 @@ import { TabType } from '../types/ui';
 import { nodePassesTransportFilter } from '../utils/nodeTransport';
 import { effectiveMapMaxAgeHours } from '../utils/mapAge';
 import { createNodeIcon, getHopColor } from '../utils/mapIcons';
-import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, createArrowIcon } from '../utils/mapHelpers.tsx';
+import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, createArrowIcon, snrToColor } from '../utils/mapHelpers.tsx';
 import { convertSpeed } from '../utils/speedConversion';
 import { getEffectivePosition, getRoleName, hasValidEffectivePosition, isNodeComplete, parseNodeId, resolveMapEndpoint } from '../utils/nodeHelpers';
 import { shouldOffsetForPrecision, offsetWithinPrecisionCell } from '../utils/precisionOffset';
@@ -2579,9 +2579,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 const ageMin = Math.floor(ageMs / 60000);
                 const ageStr = ageMin < 60 ? `${ageMin}m ago` : `${Math.floor(ageMin / 60)}h ago`;
 
-                // SNR text color for popup
+                // SNR text color for popup (canonical 4-band scale, #4047 P3 D4)
                 const snrTextColor = ni.snr != null
-                  ? ni.snr > 10 ? overlayColors.snrColors.good : ni.snr >= 0 ? overlayColors.snrColors.medium : overlayColors.snrColors.poor
+                  ? snrToColor(ni.snr, overlayColors.snrColors)
                   : undefined;
 
                 // Calculate bearing for unidirectional arrow (degrees from north)

--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -9,12 +9,20 @@ import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { MapContainer, TileLayer, Polyline, Marker, Tooltip, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Tooltip, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import { useSettings } from '../contexts/SettingsContext';
 import { getTilesetById } from '../config/tilesets';
 import { useTraceroutes } from '../hooks/useTraceroutes';
-import { generateCurvedPath, getLineWeight, generateCurvedArrowMarkers, isUnknownSnr } from '../utils/mapHelpers';
+import { isUnknownSnr, weightBySnr } from '../utils/mapHelpers';
+import { TraceroutePathsLayer } from './map/layers/TraceroutePathsLayer';
+import {
+  parseSnapshotRoutePositions,
+  resolveSegmentPosition,
+  hasReturnPath,
+  decomposeTraceroute,
+  type TracerouteRenderSegment,
+} from '../utils/tracerouteSegments';
 import 'leaflet/dist/leaflet.css';
 
 // Component to fit map bounds
@@ -40,6 +48,9 @@ import type { MapNodeInfo } from '../types/device';
  */
 type NodeInfo = MapNodeInfo;
 
+/** Stable empty snapshot map — default for `getNodePosition`'s live-only callers (e.g. the text route view). */
+const EMPTY_SNAPSHOT: Map<number, [number, number]> = new Map();
+
 interface TracerouteWidgetProps {
   id: string;
   targetNodeId: string | null;
@@ -60,7 +71,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
   canEdit = true,
 }) => {
   const { t } = useTranslation();
-  const { mapTileset, customTilesets } = useSettings();
+  const { mapTileset, customTilesets, overlayColors } = useSettings();
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
   const [showMap, setShowMap] = useState(false); // Map hidden by default
@@ -183,44 +194,46 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
     }
   };
 
-  // Get node position by nodeNum, optionally preferring snapshot positions
+  // Live node positions, keyed by nodeNum, normalized to [lat, lng] — the
+  // widget's own live-node shape (position.latitudeI/longitudeI integer OR
+  // position.latitude/longitude float) pre-normalized into the flat
+  // `Map<number,[number,number]>` `resolveSegmentPosition` (#4047 P3 WP2)
+  // expects for its live-position fallback. Presence check intentionally
+  // stays truthy (matching the pre-existing live-position behavior) — only
+  // the #1862 *snapshot* check below adopts the util's typeof fix.
+  const liveNodePositions = useMemo(() => {
+    const map = new Map<number, [number, number]>();
+    for (const node of nodes.values()) {
+      if (typeof node.nodeNum !== 'number' || !node.position) continue;
+      if (node.position.latitudeI && node.position.longitudeI) {
+        map.set(node.nodeNum, [node.position.latitudeI / 1e7, node.position.longitudeI / 1e7]);
+      } else if (node.position.latitude && node.position.longitude) {
+        map.set(node.nodeNum, [node.position.latitude, node.position.longitude]);
+      }
+    }
+    return map;
+  }, [nodes]);
+
+  // Get node position by nodeNum, optionally preferring a snapshot map
+  // (#1862 — resolveSegmentPosition prefers `snapshot` over `liveNodePositions`).
   const getNodePosition = useCallback(
-    (nodeNum: number, snapshotPositions?: Record<number, { lat: number; lng: number; alt?: number }>): [number, number] | null => {
-      // Prefer historical snapshot position if available
-      if (snapshotPositions) {
-        const snapshot = snapshotPositions[nodeNum];
-        if (snapshot?.lat && snapshot?.lng) {
-          return [snapshot.lat, snapshot.lng];
-        }
-      }
-      // Fall back to current position
-      const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
-      const node = nodes.get(nodeId);
-      // Check for both formats: latitudeI/longitudeI (integer) or latitude/longitude (float)
-      if (node?.position) {
-        if (node.position.latitudeI && node.position.longitudeI) {
-          return [node.position.latitudeI / 1e7, node.position.longitudeI / 1e7];
-        }
-        if (node.position.latitude && node.position.longitude) {
-          return [node.position.latitude, node.position.longitude];
-        }
-      }
-      return null;
-    },
-    [nodes]
+    (nodeNum: number, snapshotPositions?: Map<number, [number, number]>): [number, number] | null =>
+      resolveSegmentPosition(nodeNum, snapshotPositions ?? EMPTY_SNAPSHOT, liveNodePositions),
+    [liveNodePositions]
   );
 
   // Build map data for visualization
   const mapData = useMemo(() => {
     if (!traceroute) return null;
 
-    // Parse snapshot positions (Issue #1862) - prefer historical positions over current
-    let snapshotPositions: Record<number, { lat: number; lng: number; alt?: number }> = {};
-    if (traceroute.routePositions) {
-      try { snapshotPositions = JSON.parse(traceroute.routePositions); } catch { /* ignore */ }
-    }
+    // Parse snapshot positions (#1862) via the shared util — prefers historical
+    // positions over current. Adopts the canonical `typeof`-based presence
+    // check (fixes the widget's old truthy check silently dropping snapshots
+    // at exactly lat/lng 0 — #4047 P3 WP2 finding).
+    const snapshotPositions = parseSnapshotRoutePositions(traceroute.routePositions);
 
-    // Parse routes
+    // Parse routes (filters reserved/invalid node numbers; keeps BROADCAST_ADDR
+    // as a renderable "Unknown" hop for the text route view below).
     const forwardHops =
       traceroute.route && traceroute.route !== 'null' && traceroute.route !== ''
         ? parseRoute(traceroute.route, traceroute.snrTowards)
@@ -230,24 +243,21 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
         ? parseRoute(traceroute.routeBack, traceroute.snrBack)
         : [];
 
-    // Check if the return path has real data — an empty routeBack with no SNR data
-    // means the return path is unknown (not that it's a direct connection).
-    // Without this check, an empty routeBack creates a false direct-line segment
-    // between the two endpoints on the map. (Issue #2051)
-    const hasSnrBack = traceroute.snrBack && traceroute.snrBack !== 'null' && traceroute.snrBack !== '' && traceroute.snrBack !== '[]';
-    const hasReturnPath = backHops.length > 0 || hasSnrBack;
+    // #2051 — delegate the empty-routeBack guard to the shared util instead
+    // of a local re-implementation.
+    const hasReturn = hasReturnPath(backHops.map(h => h.nodeNum), traceroute.snrBack);
 
-    // Build complete forward path: from -> hops -> to (with SNR for each segment)
+    // Build complete forward path: from -> hops -> to
     const forwardPath = [traceroute.fromNodeNum, ...forwardHops.map(h => h.nodeNum), traceroute.toNodeNum];
-    const forwardSnrs = forwardHops.map(h => h.snr);
 
     // Build complete back path only if we have actual return data
-    const backPath = hasReturnPath
+    const backPath = hasReturn
       ? [traceroute.toNodeNum, ...backHops.map(h => h.nodeNum), traceroute.fromNodeNum]
       : [];
-    const backSnrs = hasReturnPath ? backHops.map(h => h.snr) : [];
 
-    // Collect unique nodes with positions (prefer snapshot positions)
+    // Collect unique nodes with positions (prefer snapshot positions) — feeds
+    // the from/to/intermediate-hop MARKERS below (marker icon styling is
+    // Phase 4 scope; untouched here beyond the snapshot-resolution fix above).
     const uniqueNodes = new Map<number, { nodeNum: number; position: [number, number]; name: string }>();
     [...forwardPath, ...backPath].forEach(nodeNum => {
       if (!uniqueNodes.has(nodeNum)) {
@@ -262,35 +272,15 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
       }
     });
 
-    // Build path positions for forward route with SNR for each segment
-    const forwardPositions: [number, number][] = [];
-    const forwardSegmentSnrs: (number | undefined)[] = [];
-    forwardPath.forEach((nodeNum, idx) => {
-      const node = uniqueNodes.get(nodeNum);
-      if (node) {
-        forwardPositions.push(node.position);
-        // SNR is for the segment arriving at this hop (index - 1)
-        // For direct routes (no hops), we still need one undefined SNR for the single segment
-        if (idx > 0) {
-          forwardSegmentSnrs.push(idx <= forwardSnrs.length ? forwardSnrs[idx - 1] : undefined);
-        }
-      }
-    });
-
-    // Build path positions for back route with SNR for each segment
-    const backPositions: [number, number][] = [];
-    const backSegmentSnrs: (number | undefined)[] = [];
-    backPath.forEach((nodeNum, idx) => {
-      const node = uniqueNodes.get(nodeNum);
-      if (node) {
-        backPositions.push(node.position);
-        // SNR is for the segment arriving at this hop
-        // For direct routes (no hops), we still need one undefined SNR for the single segment
-        if (idx > 0) {
-          backSegmentSnrs.push(idx <= backSnrs.length ? backSnrs[idx - 1] : undefined);
-        }
-      }
-    });
+    // Path-entry position counts (including duplicate hops), used only for
+    // the "missing position" warning-icon heuristic below — NOT for drawing
+    // (drawing now goes through `segments`/`decomposeTraceroute`).
+    const forwardPositions: [number, number][] = forwardPath
+      .map(nodeNum => uniqueNodes.get(nodeNum)?.position)
+      .filter((p): p is [number, number] => p !== undefined);
+    const backPositions: [number, number][] = backPath
+      .map(nodeNum => uniqueNodes.get(nodeNum)?.position)
+      .filter((p): p is [number, number] => p !== undefined);
 
     // Calculate bounds if we have positions
     if (uniqueNodes.size < 2) return null;
@@ -304,21 +294,42 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
       [Math.max(...lats) + 0.01, Math.max(...lngs) + 0.01],
     ];
 
+    // Forward + return render segments via the shared decomposition util
+    // (#4047 P3 WP4) — replaces the widget's own curved-path/dash/color
+    // construction. Internally /4-scales SNR, applies the #2931 sentinel,
+    // and re-derives the same #2051 return-leg gate as `hasReturn` above.
+    const segments: TracerouteRenderSegment[] = decomposeTraceroute(
+      {
+        fromNodeNum: traceroute.fromNodeNum,
+        toNodeNum: traceroute.toNodeNum,
+        route: traceroute.route,
+        routeBack: traceroute.routeBack,
+        snrTowards: traceroute.snrTowards,
+        snrBack: traceroute.snrBack,
+        timestamp: traceroute.timestamp,
+        createdAt: traceroute.createdAt,
+      },
+      { resolvePosition: (n) => resolveSegmentPosition(n, snapshotPositions, liveNodePositions) },
+    );
+
     return {
       nodes: Array.from(uniqueNodes.values()),
       forwardPositions,
       backPositions,
-      forwardSegmentSnrs,
-      backSegmentSnrs,
+      segments,
       bounds,
       fromNodeNum: traceroute.fromNodeNum,
       toNodeNum: traceroute.toNodeNum,
     };
-  }, [traceroute, getNodePosition, getNodeName]);
+  }, [traceroute, getNodePosition, getNodeName, liveNodePositions]);
 
 
 
   // Create node marker icon
+  // TODO(#4047 Phase 4): these from/to marker colors are hardcoded and no
+  // longer match the leg colors above (which converged to the theme
+  // tracerouteForward/tracerouteReturn palette in C1). Marker icon
+  // unification is Phase 4 scope — left as-is here on purpose.
   const createNodeIcon = useCallback((isEndpoint: boolean, isFrom: boolean, isTo: boolean) => {
     let color = '#888'; // intermediate hop
     if (isFrom) color = '#4CAF50'; // green for source
@@ -504,73 +515,28 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                       maxZoom={tileset.maxZoom}
                     />
 
-                    {/* Forward path (green) - render curved segments with variable weight based on SNR */}
-                    {mapData.forwardPositions.length >= 2 && (
-                      <>
-                        {mapData.forwardPositions.slice(0, -1).map((pos, idx) => {
-                          const nextPos = mapData.forwardPositions[idx + 1];
-                          const snr = mapData.forwardSegmentSnrs[idx];
-                          const weight = getLineWeight(snr);
-                          const isHighlighted = highlightedPath === null || highlightedPath === 'forward';
-                          const curvedPath = generateCurvedPath(pos, nextPos, 0.2, 20, true);
-                          return (
-                            <Polyline
-                              key={`forward-segment-${idx}`}
-                              positions={curvedPath}
-                              pathOptions={{
-                                color: '#4CAF50',
-                                weight,
-                                opacity: isHighlighted ? 0.9 : 0.2,
-                                dashArray: snr === undefined ? '5, 10' : undefined,
-                              }}
-                            />
-                          );
-                        })}
-                        {(highlightedPath === null || highlightedPath === 'forward') &&
-                          generateCurvedArrowMarkers(
-                            mapData.forwardPositions,
-                            'forward',
-                            '#4CAF50',
-                            mapData.forwardSegmentSnrs,
-                            0.2,
-                            true
-                          )}
-                      </>
-                    )}
-
-                    {/* Back path (blue) - render curved segments (opposite side) with variable weight based on SNR */}
-                    {mapData.backPositions.length >= 2 && (
-                      <>
-                        {mapData.backPositions.slice(0, -1).map((pos, idx) => {
-                          const nextPos = mapData.backPositions[idx + 1];
-                          const snr = mapData.backSegmentSnrs[idx];
-                          const weight = getLineWeight(snr);
-                          const isHighlighted = highlightedPath === null || highlightedPath === 'back';
-                          const curvedPath = generateCurvedPath(pos, nextPos, -0.2, 20, true);
-                          return (
-                            <Polyline
-                              key={`back-segment-${idx}`}
-                              positions={curvedPath}
-                              pathOptions={{
-                                color: '#2196F3',
-                                weight,
-                                opacity: isHighlighted ? 0.9 : 0.2,
-                                dashArray: snr === undefined ? '5, 10' : undefined,
-                              }}
-                            />
-                          );
-                        })}
-                        {(highlightedPath === null || highlightedPath === 'back') &&
-                          generateCurvedArrowMarkers(
-                            mapData.backPositions,
-                            'back',
-                            '#2196F3',
-                            mapData.backSegmentSnrs,
-                            -0.2,
-                            true
-                          )}
-                      </>
-                    )}
+                    {/* Forward + return legs — shared render layer (#4047 P3
+                        WP4). Leg colors converge to the theme
+                        tracerouteForward/tracerouteReturn palette (C1,
+                        approved visible change — replaces the old hardcoded
+                        #4CAF50/#2196F3). Hover-highlight (dim 0.9/0.2,
+                        arrows limited to the highlighted leg) is preserved
+                        via the `highlight` prop. */}
+                    <TraceroutePathsLayer
+                      segments={mapData.segments}
+                      snrColors={overlayColors.snrColors}
+                      colorMode="fixed-leg"
+                      legColors={{ forward: overlayColors.tracerouteForward, return: overlayColors.tracerouteReturn }}
+                      curvature={0.2}
+                      weight={(seg) => weightBySnr(seg.avgSnr ?? undefined)}
+                      opacity={0.9}
+                      dashMode="mqtt-unknown"
+                      showArrows
+                      highlight={{
+                        group: highlightedPath === 'back' ? 'return' : highlightedPath,
+                        dimmedOpacity: 0.2,
+                      }}
+                    />
 
                     {/* Node markers */}
                     {mapData.nodes.map(node => (
@@ -595,7 +561,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                       onMouseEnter={() => setHighlightedPath('forward')}
                       onMouseLeave={() => setHighlightedPath(null)}
                     >
-                      <span className="legend-color" style={{ background: '#4CAF50' }}></span>{' '}
+                      <span className="legend-color" style={{ background: overlayColors.tracerouteForward }}></span>{' '}
                       {t('dashboard.widget.traceroute.forward_path')}
                     </span>
                     <span
@@ -603,7 +569,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                       onMouseEnter={() => setHighlightedPath('back')}
                       onMouseLeave={() => setHighlightedPath(null)}
                     >
-                      <span className="legend-color" style={{ background: '#2196F3' }}></span>{' '}
+                      <span className="legend-color" style={{ background: overlayColors.tracerouteReturn }}></span>{' '}
                       {t('dashboard.widget.traceroute.return_path')}
                     </span>
                   </div>

--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -14,11 +14,12 @@ import L from 'leaflet';
 import { useSettings } from '../contexts/SettingsContext';
 import { getTilesetById } from '../config/tilesets';
 import { useTraceroutes } from '../hooks/useTraceroutes';
-import { isUnknownSnr, weightBySnr } from '../utils/mapHelpers';
+import { isUnknownSnr, tracerouteSegmentWeight } from '../utils/mapHelpers';
 import { TraceroutePathsLayer } from './map/layers/TraceroutePathsLayer';
 import {
   parseSnapshotRoutePositions,
   resolveSegmentPosition,
+  buildLiveNodePositionMap,
   hasReturnPath,
   decomposeTraceroute,
   type TracerouteRenderSegment,
@@ -194,25 +195,21 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
     }
   };
 
-  // Live node positions, keyed by nodeNum, normalized to [lat, lng] — the
-  // widget's own live-node shape (position.latitudeI/longitudeI integer OR
-  // position.latitude/longitude float) pre-normalized into the flat
-  // `Map<number,[number,number]>` `resolveSegmentPosition` (#4047 P3 WP2)
-  // expects for its live-position fallback. Presence check intentionally
-  // stays truthy (matching the pre-existing live-position behavior) — only
-  // the #1862 *snapshot* check below adopts the util's typeof fix.
-  const liveNodePositions = useMemo(() => {
-    const map = new Map<number, [number, number]>();
-    for (const node of nodes.values()) {
-      if (typeof node.nodeNum !== 'number' || !node.position) continue;
-      if (node.position.latitudeI && node.position.longitudeI) {
-        map.set(node.nodeNum, [node.position.latitudeI / 1e7, node.position.longitudeI / 1e7]);
-      } else if (node.position.latitude && node.position.longitude) {
-        map.set(node.nodeNum, [node.position.latitude, node.position.longitude]);
-      }
-    }
-    return map;
-  }, [nodes]);
+  // Live node positions, keyed by nodeNum, normalized to [lat, lng] via the
+  // shared `buildLiveNodePositionMap` — the widget's own live-node shape
+  // carries position as EITHER `latitudeI/longitudeI` (integer) OR
+  // `latitude/longitude` (float); the integer form is preferred when present.
+  const liveNodePositions = useMemo(
+    () =>
+      buildLiveNodePositionMap(nodes.values(), (node) => {
+        if (typeof node.nodeNum !== 'number' || !node.position) return null;
+        if (node.position.latitudeI && node.position.longitudeI) {
+          return { nodeNum: node.nodeNum, lat: node.position.latitudeI / 1e7, lng: node.position.longitudeI / 1e7 };
+        }
+        return { nodeNum: node.nodeNum, lat: node.position.latitude, lng: node.position.longitude };
+      }),
+    [nodes],
+  );
 
   // Get node position by nodeNum, optionally preferring a snapshot map
   // (#1862 — resolveSegmentPosition prefers `snapshot` over `liveNodePositions`).
@@ -227,9 +224,8 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
     if (!traceroute) return null;
 
     // Parse snapshot positions (#1862) via the shared util — prefers historical
-    // positions over current. Adopts the canonical `typeof`-based presence
-    // check (fixes the widget's old truthy check silently dropping snapshots
-    // at exactly lat/lng 0 — #4047 P3 WP2 finding).
+    // positions over current. Uses a `typeof`-based presence check (fixes a
+    // truthy-check bug that silently dropped snapshots at exactly lat/lng 0).
     const snapshotPositions = parseSnapshotRoutePositions(traceroute.routePositions);
 
     // Parse routes (filters reserved/invalid node numbers; keeps BROADCAST_ADDR
@@ -294,10 +290,10 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
       [Math.max(...lats) + 0.01, Math.max(...lngs) + 0.01],
     ];
 
-    // Forward + return render segments via the shared decomposition util
-    // (#4047 P3 WP4) — replaces the widget's own curved-path/dash/color
-    // construction. Internally /4-scales SNR, applies the #2931 sentinel,
-    // and re-derives the same #2051 return-leg gate as `hasReturn` above.
+    // Forward + return render segments via the shared decomposition util —
+    // replaces the widget's own curved-path/dash/color construction.
+    // Internally /4-scales SNR, applies the #2931 sentinel, and re-derives
+    // the same #2051 return-leg gate as `hasReturn` above.
     const segments: TracerouteRenderSegment[] = decomposeTraceroute(
       {
         fromNodeNum: traceroute.fromNodeNum,
@@ -515,20 +511,19 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                       maxZoom={tileset.maxZoom}
                     />
 
-                    {/* Forward + return legs — shared render layer (#4047 P3
-                        WP4). Leg colors converge to the theme
-                        tracerouteForward/tracerouteReturn palette (C1,
-                        approved visible change — replaces the old hardcoded
-                        #4CAF50/#2196F3). Hover-highlight (dim 0.9/0.2,
-                        arrows limited to the highlighted leg) is preserved
-                        via the `highlight` prop. */}
+                    {/* Forward + return legs — shared render layer. Leg
+                        colors read the theme tracerouteForward/
+                        tracerouteReturn tokens (legend swatches below use the
+                        same tokens, so they stay truthful). Hover-highlight
+                        (dim 0.9/0.2, arrows limited to the highlighted leg)
+                        is preserved via the `highlight` prop. */}
                     <TraceroutePathsLayer
                       segments={mapData.segments}
                       snrColors={overlayColors.snrColors}
                       colorMode="fixed-leg"
                       legColors={{ forward: overlayColors.tracerouteForward, return: overlayColors.tracerouteReturn }}
                       curvature={0.2}
-                      weight={(seg) => weightBySnr(seg.avgSnr ?? undefined)}
+                      weight={tracerouteSegmentWeight}
                       opacity={0.9}
                       dashMode="mqtt-unknown"
                       showArrows

--- a/src/components/map/layers/TraceroutePathsLayer.test.tsx
+++ b/src/components/map/layers/TraceroutePathsLayer.test.tsx
@@ -129,6 +129,38 @@ describe('TraceroutePathsLayer', () => {
     });
   });
 
+  describe('colorMode: snr, mqttColor', () => {
+    it('uses mqttColor for an MQTT segment when provided', () => {
+      renderLayer({
+        segments: [seg({ isMqtt: true, avgSnr: null })],
+        weight: 3,
+        colorMode: 'snr',
+        mqttColor: '#999999',
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe('#999999');
+    });
+
+    it('falls through to snrToColor for an MQTT segment when mqttColor is absent', () => {
+      renderLayer({
+        segments: [seg({ isMqtt: true, avgSnr: null })],
+        weight: 3,
+        colorMode: 'snr',
+      });
+      // avgSnr null -> noData, same as any other no-data segment.
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe('#555555');
+    });
+
+    it('does not use mqttColor for a non-MQTT segment even when provided', () => {
+      renderLayer({
+        segments: [seg({ isMqtt: false, avgSnr: 7 })],
+        weight: 3,
+        colorMode: 'snr',
+        mqttColor: '#999999',
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe('#111111');
+    });
+  });
+
   describe('colorMode: fixed', () => {
     it('colors every segment with fixedColor regardless of SNR/leg/direction', () => {
       renderLayer({
@@ -316,6 +348,29 @@ describe('TraceroutePathsLayer', () => {
       });
       const el = screen.getByTestId('polyline');
       expect(Number(el.getAttribute('data-point-count'))).toBeGreaterThan(2);
+    });
+
+    it('accepts a per-segment function, used as-is with no leg-sign negation', () => {
+      const fnRender = renderLayer({
+        segments: [seg({ key: 'a', leg: 'return', direction: 'outbound' })],
+        weight: 3,
+        colorMode: 'snr',
+        curvature: (s) => (s.direction === 'outbound' ? 0.2 : 0.12),
+      });
+      const el = fnRender.container.querySelector('[data-testid="polyline"]')!;
+      const positions = JSON.parse(el.getAttribute('data-positions')!);
+      // A 'return' leg would be negated (-0.2) under the number form; the
+      // function form must produce the SAME curve as passing +0.2 directly
+      // regardless of `leg`.
+      const straightRender = renderLayer({
+        segments: [seg({ key: 'b', leg: 'forward' })],
+        weight: 3,
+        colorMode: 'snr',
+        curvature: 0.2,
+      });
+      const expectedEl = straightRender.container.querySelector('[data-testid="polyline"]')!;
+      const expectedPositions = JSON.parse(expectedEl.getAttribute('data-positions')!);
+      expect(positions).toEqual(expectedPositions);
     });
   });
 

--- a/src/components/map/layers/TraceroutePathsLayer.test.tsx
+++ b/src/components/map/layers/TraceroutePathsLayer.test.tsx
@@ -1,0 +1,403 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TraceroutePathsLayer, type TraceroutePathsLayerProps } from './TraceroutePathsLayer';
+import type { TracerouteRenderSegment } from '../../../utils/tracerouteSegments';
+import type { SnrColorScale } from '../../../utils/mapHelpers';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors BaseMap.test.tsx / MapAnalysis TraceroutePathsLayer.test.tsx)
+// ---------------------------------------------------------------------------
+
+interface MockPolylineProps {
+  positions: [number, number][];
+  pathOptions?: { color?: string; weight?: number; opacity?: number; dashArray?: string };
+  className?: string;
+  eventHandlers?: { click?: () => void };
+  children?: ReactNode;
+}
+
+vi.mock('react-leaflet', () => ({
+  Polyline: (props: MockPolylineProps) => (
+    <div
+      data-testid="polyline"
+      data-color={props.pathOptions?.color}
+      data-weight={props.pathOptions?.weight}
+      data-opacity={props.pathOptions?.opacity}
+      data-dash={props.pathOptions?.dashArray ?? ''}
+      data-classname={props.className ?? ''}
+      data-point-count={props.positions.length}
+      data-positions={JSON.stringify(props.positions)}
+      onClick={props.eventHandlers?.click}
+    >
+      {props.children}
+    </div>
+  ),
+  Marker: (props: { children?: ReactNode }) => <div data-testid="arrow-marker">{props.children}</div>,
+  Tooltip: (props: { children?: ReactNode }) => <div data-testid="tooltip">{props.children}</div>,
+  Popup: (props: { children?: ReactNode }) => <div data-testid="popup">{props.children}</div>,
+  CircleMarker: (props: { children?: ReactNode }) => <div data-testid="circle-marker">{props.children}</div>,
+}));
+
+const snrColors: SnrColorScale = {
+  excellent: '#111111',
+  good: '#222222',
+  fair: '#333333',
+  poor: '#444444',
+  noData: '#555555',
+};
+
+function seg(overrides: Partial<TracerouteRenderSegment> = {}): TracerouteRenderSegment {
+  return {
+    key: 'forward:1-2',
+    from: [10, 10],
+    to: [20, 20],
+    leg: 'forward',
+    avgSnr: 5,
+    isMqtt: false,
+    ...overrides,
+  };
+}
+
+function renderLayer(props: Partial<TraceroutePathsLayerProps> & Pick<TraceroutePathsLayerProps, 'segments' | 'weight' | 'colorMode'>) {
+  return render(<TraceroutePathsLayer snrColors={snrColors} {...props} />);
+}
+
+describe('TraceroutePathsLayer', () => {
+  describe('polyline count', () => {
+    it('renders exactly one Polyline per segment', () => {
+      renderLayer({
+        segments: [seg({ key: 'a' }), seg({ key: 'b' }), seg({ key: 'c' })],
+        weight: 3,
+        colorMode: 'snr',
+      });
+      expect(screen.getAllByTestId('polyline')).toHaveLength(3);
+    });
+
+    it('renders zero Polylines for an empty segment list', () => {
+      renderLayer({ segments: [], weight: 3, colorMode: 'snr' });
+      expect(screen.queryAllByTestId('polyline')).toHaveLength(0);
+    });
+  });
+
+  describe('colorMode: snr (4-band)', () => {
+    it.each([
+      [7, '#111111'], // excellent >= 5
+      [2, '#222222'], // good >= 0
+      [-3, '#333333'], // fair >= -5
+      [-10, '#444444'], // poor
+      [null, '#555555'], // noData
+    ] as const)('avgSnr=%s -> %s', (avgSnr, expected) => {
+      renderLayer({ segments: [seg({ avgSnr })], weight: 3, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe(expected);
+    });
+  });
+
+  describe('colorMode: direction', () => {
+    const directionColors = { outbound: '#aaa', inbound: '#bbb', neutral: '#ccc' };
+
+    it.each([
+      ['outbound', '#aaa'],
+      ['inbound', '#bbb'],
+      ['neutral', '#ccc'],
+      [undefined, '#ccc'], // defaults to neutral
+    ] as const)('direction=%s -> %s', (direction, expected) => {
+      renderLayer({
+        segments: [seg({ direction })],
+        weight: 3,
+        colorMode: 'direction',
+        directionColors,
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe(expected);
+    });
+  });
+
+  describe('colorMode: fixed-leg', () => {
+    const legColors = { forward: '#f0f0f0', return: '#0f0f0f' };
+
+    it('colors forward-leg segments with legColors.forward', () => {
+      renderLayer({ segments: [seg({ leg: 'forward' })], weight: 3, colorMode: 'fixed-leg', legColors });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe('#f0f0f0');
+    });
+
+    it('colors return-leg segments with legColors.return', () => {
+      renderLayer({ segments: [seg({ leg: 'return' })], weight: 3, colorMode: 'fixed-leg', legColors });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe('#0f0f0f');
+    });
+  });
+
+  describe('colorMode: fixed', () => {
+    it('colors every segment with fixedColor regardless of SNR/leg/direction', () => {
+      renderLayer({
+        segments: [seg({ avgSnr: -99, leg: 'return', direction: 'inbound' })],
+        weight: 3,
+        colorMode: 'fixed',
+        fixedColor: '#facc15',
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-color')).toBe('#facc15');
+    });
+  });
+
+  describe('weight', () => {
+    it('accepts a fixed number', () => {
+      renderLayer({ segments: [seg()], weight: 4, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').getAttribute('data-weight')).toBe('4');
+    });
+
+    it('accepts a per-segment function', () => {
+      renderLayer({
+        segments: [seg({ occurrences: 3 })],
+        weight: (s) => 2 + (s.occurrences ?? 0),
+        colorMode: 'snr',
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-weight')).toBe('5');
+    });
+  });
+
+  describe('opacity', () => {
+    it('defaults to 1 when omitted', () => {
+      renderLayer({ segments: [seg()], weight: 3, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('1');
+    });
+
+    it('accepts a fixed number', () => {
+      renderLayer({ segments: [seg()], weight: 3, colorMode: 'snr', opacity: 0.6 });
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('0.6');
+    });
+
+    it('accepts a per-segment function', () => {
+      renderLayer({
+        segments: [seg({ isMqtt: true })],
+        weight: 3,
+        colorMode: 'snr',
+        opacity: (s) => (s.isMqtt ? 0.5 : 0.9),
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('0.5');
+    });
+
+    it('temporalFade floors the multiplied opacity at 0.15 for very old segments', () => {
+      const veryOld = Date.now() - 1000 * 60 * 60 * 24 * 30; // 30 days
+      renderLayer({
+        segments: [seg({ timestamp: veryOld })],
+        weight: 3,
+        colorMode: 'snr',
+        opacity: 0.4,
+        temporalFade: true,
+      });
+      // 0.4 * 0.2 (>24h floor multiplier) = 0.08, floored to 0.15
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('0.15');
+    });
+
+    it('does not apply temporal fade when the flag is unset', () => {
+      const veryOld = Date.now() - 1000 * 60 * 60 * 24 * 30;
+      renderLayer({
+        segments: [seg({ timestamp: veryOld })],
+        weight: 3,
+        colorMode: 'snr',
+        opacity: 0.4,
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('0.4');
+    });
+  });
+
+  describe('highlight (Widget hover)', () => {
+    it('uses full resolved opacity for the highlighted leg', () => {
+      renderLayer({
+        segments: [seg({ leg: 'forward' })],
+        weight: 3,
+        colorMode: 'snr',
+        opacity: 0.9,
+        highlight: { group: 'forward', dimmedOpacity: 0.2 },
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('0.9');
+    });
+
+    it('replaces opacity with dimmedOpacity for a non-highlighted leg', () => {
+      renderLayer({
+        segments: [seg({ leg: 'return' })],
+        weight: 3,
+        colorMode: 'snr',
+        opacity: 0.9,
+        highlight: { group: 'forward', dimmedOpacity: 0.2 },
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-opacity')).toBe('0.2');
+    });
+
+    it('treats group=null as "nothing highlighted" — full opacity for every leg', () => {
+      renderLayer({
+        segments: [seg({ leg: 'forward' }), seg({ key: 'b', leg: 'return' })],
+        weight: 3,
+        colorMode: 'snr',
+        opacity: 0.9,
+        highlight: { group: null, dimmedOpacity: 0.2 },
+      });
+      for (const el of screen.getAllByTestId('polyline')) {
+        expect(el.getAttribute('data-opacity')).toBe('0.9');
+      }
+    });
+  });
+
+  describe('dashMode', () => {
+    it('mqtt-unknown (default): dashes MQTT segments', () => {
+      renderLayer({ segments: [seg({ isMqtt: true, avgSnr: null })], weight: 3, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').getAttribute('data-dash')).toBe('3,6');
+    });
+
+    it('mqtt-unknown (default): dashes segments with no SNR data even if not flagged isMqtt', () => {
+      renderLayer({ segments: [seg({ isMqtt: false, avgSnr: null })], weight: 3, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').getAttribute('data-dash')).toBe('3,6');
+    });
+
+    it('mqtt-unknown (default): does not dash segments with real SNR data', () => {
+      renderLayer({ segments: [seg({ isMqtt: false, avgSnr: 5 })], weight: 3, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').getAttribute('data-dash')).toBe('');
+    });
+
+    it('always: dashes every segment regardless of SNR/MQTT', () => {
+      renderLayer({
+        segments: [seg({ isMqtt: false, avgSnr: 5 })],
+        weight: 3,
+        colorMode: 'snr',
+        dashMode: 'always',
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-dash')).toBe('3,6');
+    });
+
+    it('never: dashes nothing even for MQTT segments', () => {
+      renderLayer({
+        segments: [seg({ isMqtt: true, avgSnr: null })],
+        weight: 3,
+        colorMode: 'snr',
+        dashMode: 'never',
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-dash')).toBe('');
+    });
+  });
+
+  describe('curvature', () => {
+    it('curvature 0 (default) renders a straight 2-point line', () => {
+      renderLayer({ segments: [seg()], weight: 3, colorMode: 'snr' });
+      const el = screen.getByTestId('polyline');
+      expect(el.getAttribute('data-point-count')).toBe('2');
+      expect(JSON.parse(el.getAttribute('data-positions')!)).toEqual([
+        [10, 10],
+        [20, 20],
+      ]);
+    });
+
+    it('curvature > 0 renders a multi-point curved path', () => {
+      renderLayer({ segments: [seg()], weight: 3, colorMode: 'snr', curvature: 0.2 });
+      const el = screen.getByTestId('polyline');
+      expect(Number(el.getAttribute('data-point-count'))).toBeGreaterThan(2);
+    });
+
+    it('forward and return legs (same endpoints) curve to opposite sides', () => {
+      renderLayer({
+        segments: [seg({ key: 'fwd', leg: 'forward' }), seg({ key: 'ret', leg: 'return' })],
+        weight: 3,
+        colorMode: 'snr',
+        curvature: 0.2,
+      });
+      const [fwd, ret] = screen.getAllByTestId('polyline');
+      // Same endpoints, opposite sign curvature -> different midpoints.
+      expect(fwd.getAttribute('data-positions')).not.toBe(ret.getAttribute('data-positions'));
+    });
+
+    it('neutralCurvature applies to neutral-leg segments independent of curvature', () => {
+      renderLayer({
+        segments: [seg({ leg: 'neutral' })],
+        weight: 3,
+        colorMode: 'snr',
+        curvature: 0.2,
+        neutralCurvature: 0.12,
+      });
+      const el = screen.getByTestId('polyline');
+      expect(Number(el.getAttribute('data-point-count'))).toBeGreaterThan(2);
+    });
+  });
+
+  describe('arrows', () => {
+    it('does not render arrows when showArrows is false/unset', () => {
+      renderLayer({ segments: [seg()], weight: 3, colorMode: 'snr' });
+      expect(screen.queryAllByTestId('arrow-marker')).toHaveLength(0);
+    });
+
+    it('renders one arrow marker per segment when showArrows is true', () => {
+      renderLayer({
+        segments: [seg({ key: 'a' }), seg({ key: 'b' })],
+        weight: 3,
+        colorMode: 'snr',
+        showArrows: true,
+      });
+      expect(screen.getAllByTestId('arrow-marker')).toHaveLength(2);
+    });
+
+    it('limits arrows to the highlighted leg when highlight is active', () => {
+      renderLayer({
+        segments: [seg({ key: 'a', leg: 'forward' }), seg({ key: 'b', leg: 'return' })],
+        weight: 3,
+        colorMode: 'snr',
+        showArrows: true,
+        highlight: { group: 'forward', dimmedOpacity: 0.2 },
+      });
+      expect(screen.getAllByTestId('arrow-marker')).toHaveLength(1);
+    });
+
+    it('draws arrows for every leg when highlight.group is null', () => {
+      renderLayer({
+        segments: [seg({ key: 'a', leg: 'forward' }), seg({ key: 'b', leg: 'return' })],
+        weight: 3,
+        colorMode: 'snr',
+        showArrows: true,
+        highlight: { group: null, dimmedOpacity: 0.2 },
+      });
+      expect(screen.getAllByTestId('arrow-marker')).toHaveLength(2);
+    });
+  });
+
+  describe('render-props', () => {
+    it('renders renderPopup output as a Polyline child', () => {
+      renderLayer({
+        segments: [seg()],
+        weight: 3,
+        colorMode: 'snr',
+        renderPopup: (s) => <div data-testid="custom-popup">{s.key}</div>,
+      });
+      expect(screen.getByTestId('custom-popup')).toBeInTheDocument();
+      expect(screen.getByTestId('custom-popup').textContent).toBe('forward:1-2');
+    });
+
+    it('renders nothing extra when renderPopup is omitted', () => {
+      renderLayer({ segments: [seg()], weight: 3, colorMode: 'snr' });
+      expect(screen.getByTestId('polyline').children.length).toBe(0);
+    });
+
+    it('invokes onSegmentClick with the clicked segment', () => {
+      const onSegmentClick = vi.fn();
+      renderLayer({
+        segments: [seg({ key: 'clickme' })],
+        weight: 3,
+        colorMode: 'snr',
+        onSegmentClick,
+      });
+      fireEvent.click(screen.getByTestId('polyline'));
+      expect(onSegmentClick).toHaveBeenCalledTimes(1);
+      expect(onSegmentClick.mock.calls[0][0]).toMatchObject({ key: 'clickme' });
+    });
+
+    it('applies segmentClassName to the Polyline', () => {
+      renderLayer({
+        segments: [seg({ key: 'node-1 node-2' })],
+        weight: 3,
+        colorMode: 'snr',
+        segmentClassName: (s) => `route-segment ${s.key}`,
+      });
+      expect(screen.getByTestId('polyline').getAttribute('data-classname')).toBe(
+        'route-segment node-1 node-2',
+      );
+    });
+  });
+});

--- a/src/components/map/layers/TraceroutePathsLayer.tsx
+++ b/src/components/map/layers/TraceroutePathsLayer.tsx
@@ -1,0 +1,179 @@
+import type { ReactElement, ReactNode } from 'react';
+import { Polyline } from 'react-leaflet';
+import {
+  generateCurvedPath,
+  generateCurvedArrowMarkers,
+  getTemporalOpacityMultiplier,
+  snrToColor,
+  MQTT_DASH,
+  type SnrColorScale,
+} from '../../../utils/mapHelpers';
+import { UNKNOWN_SNR_SENTINEL, type TracerouteRenderSegment } from '../../../utils/tracerouteSegments';
+
+const CURVE_SEGMENTS = 20;
+
+export interface TraceroutePathsLayerProps {
+  segments: TracerouteRenderSegment[];
+  snrColors: SnrColorScale;                          // theme palette (prop, not useSettings)
+  colorMode: 'snr' | 'direction' | 'fixed-leg' | 'fixed';
+  legColors?: { forward: string; return: string };   // 'fixed-leg'
+  directionColors?: { outbound: string; inbound: string; neutral: string }; // 'direction'
+  fixedColor?: string;                                // 'fixed' (Dashboard yellow overlay)
+  curvature?: number;                                 // 0 = straight; default 0
+  neutralCurvature?: number;                          // MapAnalysis neutral 0.12
+  weight: number | ((seg: TracerouteRenderSegment) => number);
+  opacity?: number | ((seg: TracerouteRenderSegment) => number);
+  dashMode?: 'mqtt-unknown' | 'always' | 'never';    // default 'mqtt-unknown'
+  showArrows?: boolean;
+  temporalFade?: boolean;                             // multiplies opacity, floor 0.15
+  highlight?: { group: 'forward' | 'return' | 'neutral' | null; dimmedOpacity: number }; // Widget hover
+  onSegmentClick?: (seg: TracerouteRenderSegment) => void;   // MapAnalysis click-select
+  renderPopup?: (seg: TracerouteRenderSegment) => ReactNode; // NodesTab recharts / DraggablePopup
+  segmentClassName?: (seg: TracerouteRenderSegment) => string;     // NodesTab 'route-segment node-X'
+}
+
+/** Resolve a segment's stroke color for the configured `colorMode`. */
+function resolveColor(seg: TracerouteRenderSegment, props: TraceroutePathsLayerProps): string {
+  switch (props.colorMode) {
+    case 'snr':
+      return snrToColor(seg.avgSnr, props.snrColors);
+    case 'direction': {
+      const dc = props.directionColors;
+      if (!dc) return props.snrColors.noData;
+      return dc[seg.direction ?? 'neutral'];
+    }
+    case 'fixed-leg': {
+      const lc = props.legColors;
+      if (!lc) return props.snrColors.noData;
+      return seg.leg === 'return' ? lc.return : lc.forward;
+    }
+    case 'fixed':
+      return props.fixedColor ?? props.snrColors.noData;
+    default:
+      return props.snrColors.noData;
+  }
+}
+
+function resolveWeight(seg: TracerouteRenderSegment, weight: TraceroutePathsLayerProps['weight']): number {
+  return typeof weight === 'function' ? weight(seg) : weight;
+}
+
+/**
+ * Base opacity (number or per-segment fn, default 1 when omitted) — then, if
+ * `temporalFade` is set, multiplied by `getTemporalOpacityMultiplier` and
+ * floored at 0.15 (matches the pre-existing NodesTab base-layer behavior) —
+ * then, if `highlight` is active and this segment's leg isn't the
+ * highlighted group, REPLACED (not multiplied) by `highlight.dimmedOpacity`,
+ * matching the Widget's pre-existing hover behavior
+ * (`opacity: isHighlighted ? 0.9 : 0.2`).
+ */
+function resolveOpacity(seg: TracerouteRenderSegment, props: TraceroutePathsLayerProps): number {
+  const base = props.opacity === undefined
+    ? 1
+    : typeof props.opacity === 'function'
+      ? props.opacity(seg)
+      : props.opacity;
+
+  let value = props.temporalFade
+    ? Math.max(0.15, base * getTemporalOpacityMultiplier(seg.timestamp))
+    : base;
+
+  if (props.highlight && props.highlight.group !== null && seg.leg !== props.highlight.group) {
+    value = props.highlight.dimmedOpacity;
+  }
+
+  return value;
+}
+
+/** MQTT/unknown-SNR dashing (#2931 visual), canonical `MQTT_DASH` (§2.3). */
+function resolveDash(seg: TracerouteRenderSegment, dashMode: TraceroutePathsLayerProps['dashMode']): string | undefined {
+  const mode = dashMode ?? 'mqtt-unknown';
+  if (mode === 'never') return undefined;
+  if (mode === 'always') return MQTT_DASH;
+  return seg.isMqtt || seg.avgSnr == null ? MQTT_DASH : undefined;
+}
+
+/** Forward legs curve +curvature, return legs -curvature (leg-signed);
+ *  'neutral' legs (MapAnalysis, un-focused view) use `neutralCurvature` when
+ *  provided, falling back to the signed `curvature` otherwise. */
+function resolveCurvature(
+  seg: TracerouteRenderSegment,
+  curvature: number | undefined,
+  neutralCurvature: number | undefined,
+): number {
+  if (seg.leg === 'neutral') {
+    return neutralCurvature ?? curvature ?? 0;
+  }
+  const base = curvature ?? 0;
+  return seg.leg === 'return' ? -base : base;
+}
+
+function resolvePositions(seg: TracerouteRenderSegment, effectiveCurvature: number): [number, number][] {
+  return effectiveCurvature === 0
+    ? [seg.from, seg.to]
+    : generateCurvedPath(seg.from, seg.to, effectiveCurvature, CURVE_SEGMENTS, true);
+}
+
+/** Arrows are gated by `showArrows` overall, and — when `highlight` is
+ *  active — further limited to the highlighted leg (matches the Widget's
+ *  pre-existing "arrows only for the highlighted path" behavior). */
+function shouldDrawArrow(seg: TracerouteRenderSegment, props: TraceroutePathsLayerProps): boolean {
+  if (!props.showArrows) return false;
+  if (props.highlight && props.highlight.group !== null) {
+    return seg.leg === props.highlight.group;
+  }
+  return true;
+}
+
+/**
+ * Shared traceroute render layer (#4047 P3 WP2, `src/components/map/layers/`
+ * per the Phase-1 `BaseMap` convention: named export, typed props, no `any`,
+ * returns a fragment). Owns geometry (straight vs curved), color-mode
+ * resolution, weight/opacity strategies, MQTT/unknown-SNR dashing, arrows,
+ * temporal fade, and hover-highlight dimming for a pre-decomposed
+ * `TracerouteRenderSegment[]` (see `utils/tracerouteSegments.ts`). Consumed
+ * by NodesTab/useTraceroutePaths, TracerouteWidget, DashboardMap, and
+ * MapAnalysis (WP3-5) — not wired to any consumer yet.
+ */
+export function TraceroutePathsLayer(props: TraceroutePathsLayerProps): ReactElement {
+  const { segments, showArrows = false } = props;
+
+  return (
+    <>
+      {segments.map((seg) => {
+        const color = resolveColor(seg, props);
+        const weight = resolveWeight(seg, props.weight);
+        const opacity = resolveOpacity(seg, props);
+        const dashArray = resolveDash(seg, props.dashMode);
+        const curvature = resolveCurvature(seg, props.curvature, props.neutralCurvature);
+        const positions = resolvePositions(seg, curvature);
+        const className = props.segmentClassName?.(seg);
+
+        return (
+          <Polyline
+            key={seg.key}
+            positions={positions}
+            pathOptions={{ color, weight, opacity, dashArray }}
+            className={className}
+            eventHandlers={
+              props.onSegmentClick
+                ? { click: () => props.onSegmentClick?.(seg) }
+                : undefined
+            }
+          >
+            {props.renderPopup ? props.renderPopup(seg) : null}
+          </Polyline>
+        );
+      })}
+      {showArrows &&
+        segments
+          .filter((seg) => shouldDrawArrow(seg, props))
+          .flatMap((seg) => {
+            const color = resolveColor(seg, props);
+            const curvature = resolveCurvature(seg, props.curvature, props.neutralCurvature);
+            const snr = seg.avgSnr === null ? UNKNOWN_SNR_SENTINEL : seg.avgSnr;
+            return generateCurvedArrowMarkers([seg.from, seg.to], seg.key, color, [snr], curvature, true);
+          })}
+    </>
+  );
+}

--- a/src/components/map/layers/TraceroutePathsLayer.tsx
+++ b/src/components/map/layers/TraceroutePathsLayer.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import { memo, type ReactElement, type ReactNode } from 'react';
 import { Polyline } from 'react-leaflet';
 import {
   generateCurvedPath,
@@ -16,17 +16,22 @@ export interface TraceroutePathsLayerProps {
   segments: TracerouteRenderSegment[];
   snrColors: SnrColorScale;                          // theme palette (prop, not useSettings)
   colorMode: 'snr' | 'direction' | 'fixed-leg' | 'fixed';
+  /** `colorMode: 'snr'` only — when set, an `isMqtt` segment uses this color
+   *  instead of `snrToColor(seg.avgSnr, snrColors)` (which would resolve to
+   *  `noData` gray, losing the MQTT/IP-bridged distinction). Omit to fall
+   *  through to `snrToColor` for every segment regardless of `isMqtt`. */
+  mqttColor?: string;
   legColors?: { forward: string; return: string };   // 'fixed-leg'
-  directionColors?: { outbound: string; inbound: string; neutral: string }; // 'direction'
+  directionColors?: { outbound: string; inbound: string; neutral?: string }; // 'direction'
   fixedColor?: string;                                // 'fixed' (Dashboard yellow overlay)
-  curvature?: number;                                 // 0 = straight; default 0
-  neutralCurvature?: number;                          // MapAnalysis neutral 0.12
+  curvature?: number | ((seg: TracerouteRenderSegment) => number); // 0 = straight; default 0. Function form is used as-is (no leg-sign negation).
+  neutralCurvature?: number;                          // MapAnalysis neutral 0.12 (number `curvature` form only)
   weight: number | ((seg: TracerouteRenderSegment) => number);
   opacity?: number | ((seg: TracerouteRenderSegment) => number);
   dashMode?: 'mqtt-unknown' | 'always' | 'never';    // default 'mqtt-unknown'
   showArrows?: boolean;
   temporalFade?: boolean;                             // multiplies opacity, floor 0.15
-  highlight?: { group: 'forward' | 'return' | 'neutral' | null; dimmedOpacity: number }; // Widget hover
+  highlight?: { group: 'forward' | 'return' | null; dimmedOpacity: number }; // Widget hover
   onSegmentClick?: (seg: TracerouteRenderSegment) => void;   // MapAnalysis click-select
   renderPopup?: (seg: TracerouteRenderSegment) => ReactNode; // NodesTab recharts / DraggablePopup
   segmentClassName?: (seg: TracerouteRenderSegment) => string;     // NodesTab 'route-segment node-X'
@@ -36,11 +41,13 @@ export interface TraceroutePathsLayerProps {
 function resolveColor(seg: TracerouteRenderSegment, props: TraceroutePathsLayerProps): string {
   switch (props.colorMode) {
     case 'snr':
+      if (seg.isMqtt && props.mqttColor) return props.mqttColor;
       return snrToColor(seg.avgSnr, props.snrColors);
     case 'direction': {
       const dc = props.directionColors;
       if (!dc) return props.snrColors.noData;
-      return dc[seg.direction ?? 'neutral'];
+      const key = seg.direction ?? 'neutral';
+      return key === 'neutral' ? (dc.neutral ?? props.snrColors.noData) : dc[key];
     }
     case 'fixed-leg': {
       const lc = props.legColors;
@@ -93,14 +100,21 @@ function resolveDash(seg: TracerouteRenderSegment, dashMode: TraceroutePathsLaye
   return seg.isMqtt || seg.avgSnr == null ? MQTT_DASH : undefined;
 }
 
-/** Forward legs curve +curvature, return legs -curvature (leg-signed);
- *  'neutral' legs (MapAnalysis, un-focused view) use `neutralCurvature` when
- *  provided, falling back to the signed `curvature` otherwise. */
+/**
+ * Resolve a segment's curvature. `curvature` as a function is used AS-IS —
+ * the caller owns direction/sign entirely and the leg-based negation below
+ * does not apply (e.g. MapAnalysis's honest in/outbound curvature, which
+ * isn't a forward/return leg at all). `curvature` as a number applies the
+ * leg-signed convention: forward legs curve `+curvature`, return legs
+ * `-curvature`; 'neutral' legs use `neutralCurvature` when provided, falling
+ * back to the signed `curvature` otherwise.
+ */
 function resolveCurvature(
   seg: TracerouteRenderSegment,
-  curvature: number | undefined,
+  curvature: TraceroutePathsLayerProps['curvature'],
   neutralCurvature: number | undefined,
 ): number {
+  if (typeof curvature === 'function') return curvature(seg);
   if (seg.leg === 'neutral') {
     return neutralCurvature ?? curvature ?? 0;
   }
@@ -125,55 +139,74 @@ function shouldDrawArrow(seg: TracerouteRenderSegment, props: TraceroutePathsLay
   return true;
 }
 
+interface ResolvedSegment {
+  seg: TracerouteRenderSegment;
+  color: string;
+  weight: number;
+  opacity: number;
+  dashArray: string | undefined;
+  curvature: number;
+  positions: [number, number][];
+  className: string | undefined;
+}
+
 /**
- * Shared traceroute render layer (#4047 P3 WP2, `src/components/map/layers/`
- * per the Phase-1 `BaseMap` convention: named export, typed props, no `any`,
- * returns a fragment). Owns geometry (straight vs curved), color-mode
- * resolution, weight/opacity strategies, MQTT/unknown-SNR dashing, arrows,
- * temporal fade, and hover-highlight dimming for a pre-decomposed
+ * Shared traceroute render layer (`src/components/map/layers/`, per the
+ * Phase-1 `BaseMap` convention: named export, typed props, no `any`, returns
+ * a fragment). Owns geometry (straight vs curved), color-mode resolution,
+ * weight/opacity strategies, MQTT/unknown-SNR dashing, arrows, temporal
+ * fade, and hover-highlight dimming for a pre-decomposed
  * `TracerouteRenderSegment[]` (see `utils/tracerouteSegments.ts`). Consumed
  * by NodesTab/useTraceroutePaths, TracerouteWidget, DashboardMap, and
- * MapAnalysis (WP3-5) — not wired to any consumer yet.
+ * MapAnalysis.
  */
-export function TraceroutePathsLayer(props: TraceroutePathsLayerProps): ReactElement {
+function TraceroutePathsLayerImpl(props: TraceroutePathsLayerProps): ReactElement {
   const { segments, showArrows = false } = props;
+
+  // Resolve each segment's color/weight/opacity/dash/curvature/positions
+  // exactly once and reuse the result for both the Polyline pass and the
+  // arrow pass below (arrows share the same color/curvature).
+  const resolved: ResolvedSegment[] = segments.map((seg) => {
+    const color = resolveColor(seg, props);
+    const curvature = resolveCurvature(seg, props.curvature, props.neutralCurvature);
+    return {
+      seg,
+      color,
+      weight: resolveWeight(seg, props.weight),
+      opacity: resolveOpacity(seg, props),
+      dashArray: resolveDash(seg, props.dashMode),
+      curvature,
+      positions: resolvePositions(seg, curvature),
+      className: props.segmentClassName?.(seg),
+    };
+  });
 
   return (
     <>
-      {segments.map((seg) => {
-        const color = resolveColor(seg, props);
-        const weight = resolveWeight(seg, props.weight);
-        const opacity = resolveOpacity(seg, props);
-        const dashArray = resolveDash(seg, props.dashMode);
-        const curvature = resolveCurvature(seg, props.curvature, props.neutralCurvature);
-        const positions = resolvePositions(seg, curvature);
-        const className = props.segmentClassName?.(seg);
-
-        return (
-          <Polyline
-            key={seg.key}
-            positions={positions}
-            pathOptions={{ color, weight, opacity, dashArray }}
-            className={className}
-            eventHandlers={
-              props.onSegmentClick
-                ? { click: () => props.onSegmentClick?.(seg) }
-                : undefined
-            }
-          >
-            {props.renderPopup ? props.renderPopup(seg) : null}
-          </Polyline>
-        );
-      })}
+      {resolved.map(({ seg, color, weight, opacity, dashArray, positions, className }) => (
+        <Polyline
+          key={seg.key}
+          positions={positions}
+          pathOptions={{ color, weight, opacity, dashArray }}
+          className={className}
+          eventHandlers={
+            props.onSegmentClick
+              ? { click: () => props.onSegmentClick?.(seg) }
+              : undefined
+          }
+        >
+          {props.renderPopup ? props.renderPopup(seg) : null}
+        </Polyline>
+      ))}
       {showArrows &&
-        segments
-          .filter((seg) => shouldDrawArrow(seg, props))
-          .flatMap((seg) => {
-            const color = resolveColor(seg, props);
-            const curvature = resolveCurvature(seg, props.curvature, props.neutralCurvature);
+        resolved
+          .filter(({ seg }) => shouldDrawArrow(seg, props))
+          .flatMap(({ seg, color, curvature }) => {
             const snr = seg.avgSnr === null ? UNKNOWN_SNR_SENTINEL : seg.avgSnr;
             return generateCurvedArrowMarkers([seg.from, seg.to], seg.key, color, [snr], curvature, true);
           })}
     </>
   );
 }
+
+export const TraceroutePathsLayer = memo(TraceroutePathsLayerImpl);

--- a/src/config/overlayColors.ts
+++ b/src/config/overlayColors.ts
@@ -14,10 +14,11 @@ export interface OverlayColors {
     gradient: string[];
   };
   snrColors: {
-    good: string;    // SNR > 10dB
-    medium: string;  // SNR 0 to 10dB
-    poor: string;    // SNR < 0dB
-    noData: string;  // No SNR data
+    excellent: string; // SNR >= 5dB
+    good: string;      // SNR 0 to <5dB
+    fair: string;       // SNR -5 to <0dB
+    poor: string;       // SNR < -5dB
+    noData: string;     // No SNR data
   };
   polarGrid: {
     rings: string;
@@ -41,10 +42,11 @@ export const darkOverlayColors: OverlayColors = {
     gradient: ['#0000FF', '#3300CC', '#660099', '#990066', '#CC0033', '#FF0000'],
   },
   snrColors: {
-    good: '#a6e3a1',    // Catppuccin Mocha green (--ctp-green)
-    medium: '#f9e2af',  // Catppuccin Mocha yellow (--ctp-yellow)
-    poor: '#f38ba8',    // Catppuccin Mocha red (--ctp-red)
-    noData: '#6c7086',  // Catppuccin Mocha overlay0 (--ctp-overlay0)
+    excellent: '#22c55e', // Vivid green — SNR >= 5dB
+    good: '#eab308',      // Vivid yellow — SNR 0 to <5dB
+    fair: '#f97316',      // Vivid orange — SNR -5 to <0dB
+    poor: '#ef4444',      // Vivid red — SNR < -5dB
+    noData: '#6c7086',    // Catppuccin Mocha overlay0 (--ctp-overlay0)
   },
   polarGrid: {
     rings: 'rgba(0, 200, 255, 0.3)',
@@ -72,10 +74,13 @@ export const lightOverlayColors: OverlayColors = {
     gradient: ['#1d4ed8', '#4338ca', '#6d28d9', '#a21caf', '#be123c', '#b91c1c'],
   },
   snrColors: {
-    good: '#2f7a1e',    // darkened Latte green — AA on cream (contrast 4.7)
-    medium: '#8f5200',  // darkened Latte amber — AA on cream (contrast 5.4)
-    poor: '#d20f39',    // Catppuccin Latte red — AA on cream (contrast 4.7)
-    noData: '#6c6f7e',  // darkened Latte overlay0 — AA on cream (contrast 4.3)
+    // Verified against OSM HOT cream (#F2EFE9) via WCAG 2.1 relative-luminance
+    // contrast ratio; all bands clear the project's >=4.0 AA-on-cream bar (#4047 P3).
+    excellent: '#15803d', // darkened Latte green — AA on cream (contrast 4.37)
+    good: '#8f5200',      // darkened Latte amber — AA on cream (contrast 5.42)
+    fair: '#b45309',      // darkened Latte orange — AA on cream (contrast 4.38)
+    poor: '#d20f39',      // Catppuccin Latte red — AA on cream (contrast 4.73)
+    noData: '#6c6f7e',    // darkened Latte overlay0 — AA on cream (contrast 4.34)
   },
   polarGrid: {
     rings: 'rgba(0, 80, 130, 0.3)',

--- a/src/config/overlayColors.ts
+++ b/src/config/overlayColors.ts
@@ -75,7 +75,7 @@ export const lightOverlayColors: OverlayColors = {
   },
   snrColors: {
     // Verified against OSM HOT cream (#F2EFE9) via WCAG 2.1 relative-luminance
-    // contrast ratio; all bands clear the project's >=4.0 AA-on-cream bar (#4047 P3).
+    // contrast ratio; all bands clear the project's >=4.0 AA-on-cream bar.
     excellent: '#15803d', // darkened Latte green — AA on cream (contrast 4.37)
     good: '#8f5200',      // darkened Latte amber — AA on cream (contrast 5.42)
     fair: '#b45309',      // darkened Latte orange — AA on cream (contrast 4.38)

--- a/src/hooks/useTracerouteAnalysis.emptyBack.test.ts
+++ b/src/hooks/useTracerouteAnalysis.emptyBack.test.ts
@@ -1,10 +1,12 @@
 /**
- * @vitest-environment jsdom
- *
- * jsdom is required because useTracerouteAnalysis now imports isUnknownSnr/
- * UNKNOWN_SNR_SENTINEL from utils/mapHelpers.tsx (#4047 P3 WP1, folding the
- * previously-duplicated sentinel into its single canonical home), and
- * mapHelpers.tsx pulls in `leaflet`, which touches `window` at module scope.
+ * Runs in the default node environment. useTracerouteAnalysis imports
+ * isUnknownSnr/UNKNOWN_SNR_SENTINEL from utils/tracerouteSegments.ts (#4047
+ * P3 WP2) — a pure, leaflet-free module — rather than utils/mapHelpers.tsx
+ * (which pulls in `leaflet` and touches `window` at module scope). WP1
+ * temporarily routed the shared sentinel through mapHelpers.tsx and forced
+ * this file onto @vitest-environment jsdom; WP2 re-homes the sentinel
+ * definition itself into tracerouteSegments.ts so this test can go back to
+ * node env.
  *
  * Tests for issue #3622 — fictitious direct-connection line from empty routeBack.
  *

--- a/src/hooks/useTracerouteAnalysis.emptyBack.test.ts
+++ b/src/hooks/useTracerouteAnalysis.emptyBack.test.ts
@@ -1,4 +1,11 @@
 /**
+ * @vitest-environment jsdom
+ *
+ * jsdom is required because useTracerouteAnalysis now imports isUnknownSnr/
+ * UNKNOWN_SNR_SENTINEL from utils/mapHelpers.tsx (#4047 P3 WP1, folding the
+ * previously-duplicated sentinel into its single canonical home), and
+ * mapHelpers.tsx pulls in `leaflet`, which touches `window` at module scope.
+ *
  * Tests for issue #3622 — fictitious direct-connection line from empty routeBack.
  *
  * When MeshMonitor is connected to the TARGET node (L) of a traceroute:

--- a/src/hooks/useTracerouteAnalysis.test.ts
+++ b/src/hooks/useTracerouteAnalysis.test.ts
@@ -1,10 +1,12 @@
 /**
- * @vitest-environment jsdom
- *
- * jsdom is required because useTracerouteAnalysis now imports isUnknownSnr/
- * UNKNOWN_SNR_SENTINEL from utils/mapHelpers.tsx (#4047 P3 WP1, folding the
- * previously-duplicated sentinel into its single canonical home), and
- * mapHelpers.tsx pulls in `leaflet`, which touches `window` at module scope.
+ * Runs in the default node environment. useTracerouteAnalysis imports
+ * isUnknownSnr/UNKNOWN_SNR_SENTINEL from utils/tracerouteSegments.ts (#4047
+ * P3 WP2) — a pure, leaflet-free module — rather than utils/mapHelpers.tsx
+ * (which pulls in `leaflet` and touches `window` at module scope). WP1
+ * temporarily routed the shared sentinel through mapHelpers.tsx and forced
+ * this file onto @vitest-environment jsdom; WP2 re-homes the sentinel
+ * definition itself into tracerouteSegments.ts so this test can go back to
+ * node env.
  */
 import { describe, it, expect } from 'vitest';
 import {

--- a/src/hooks/useTracerouteAnalysis.test.ts
+++ b/src/hooks/useTracerouteAnalysis.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * jsdom is required because useTracerouteAnalysis now imports isUnknownSnr/
+ * UNKNOWN_SNR_SENTINEL from utils/mapHelpers.tsx (#4047 P3 WP1, folding the
+ * previously-duplicated sentinel into its single canonical home), and
+ * mapHelpers.tsx pulls in `leaflet`, which touches `window` at module scope.
+ */
 import { describe, it, expect } from 'vitest';
 import {
   analyzeTraceroutes,

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 // WP1, then re-homed to the leaflet-free tracerouteSegments.ts under WP2 so
 // this hook (and its tests) don't have to pull in mapHelpers.tsx's
 // leaflet/react-leaflet imports just for the sentinel (#4047 P3).
-import { isUnknownSnr } from '../utils/tracerouteSegments';
+import { isUnknownSnr, hasReturnPath } from '../utils/tracerouteSegments';
 
 /**
  * Traceroute analysis for the Map Analysis view (issue #3399).
@@ -149,8 +149,9 @@ function segmentsForTraceroute(tr: TracerouteAnalysisInput): RawSegment[] {
   // When routeBack AND snrBack are both empty the return path has not been
   // recorded yet (e.g. MeshMonitor sees its own outgoing response before relay
   // nodes populate routeBack). Skip rather than drawing a fictitious direct
-  // responder→requester line. (Issues #1140, #3622)
-  if (routeBack.length > 0 || snrBack.length > 0) {
+  // responder→requester line. (Issues #1140, #3622, #2051 — shared guard,
+  // #4047 P3 WP5.)
+  if (hasReturnPath(routeBack, snrBack)) {
     const backPath = [responder, ...routeBack, requester];
     for (let i = 0; i < backPath.length - 1; i++) {
       out.push({

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -1,12 +1,8 @@
 import { useMemo } from 'react';
-
-/**
- * Scaled SNR sentinel for unknown hops (raw firmware INT8_MIN -128 / 4 = -32).
- * Mirrors `UNKNOWN_SNR_SENTINEL` in utils/mapHelpers.tsx — duplicated here so
- * the analysis core stays free of the Leaflet import (keeps it node-testable).
- */
-const UNKNOWN_SNR_SENTINEL = -32;
-const isUnknownSnr = (snr: number | undefined): boolean => snr === UNKNOWN_SNR_SENTINEL;
+// #2931 — shared unknown-hop sentinel (raw firmware INT8_MIN -128 / 4 = -32).
+// Previously duplicated here as a private copy; now imported from the single
+// canonical home in mapHelpers so the definition lives once (#4047 P3 WP1).
+import { isUnknownSnr } from '../utils/mapHelpers';
 
 /**
  * Traceroute analysis for the Map Analysis view (issue #3399).

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
-// #2931 — shared unknown-hop sentinel (raw firmware INT8_MIN -128 / 4 = -32).
-// Previously duplicated here as a private copy; folded into mapHelpers under
-// WP1, then re-homed to the leaflet-free tracerouteSegments.ts under WP2 so
-// this hook (and its tests) don't have to pull in mapHelpers.tsx's
-// leaflet/react-leaflet imports just for the sentinel (#4047 P3).
+// #2931 — shared unknown-hop sentinel (raw firmware INT8_MIN -128 / 4 = -32),
+// imported from the leaflet-free tracerouteSegments.ts so this hook (and its
+// tests) don't have to pull in mapHelpers.tsx's leaflet/react-leaflet
+// imports just for the sentinel.
 import { isUnknownSnr, hasReturnPath } from '../utils/tracerouteSegments';
 
 /**
@@ -149,8 +148,7 @@ function segmentsForTraceroute(tr: TracerouteAnalysisInput): RawSegment[] {
   // When routeBack AND snrBack are both empty the return path has not been
   // recorded yet (e.g. MeshMonitor sees its own outgoing response before relay
   // nodes populate routeBack). Skip rather than drawing a fictitious direct
-  // responder→requester line. (Issues #1140, #3622, #2051 — shared guard,
-  // #4047 P3 WP5.)
+  // responder→requester line. (Issues #1140, #3622, #2051 — shared guard.)
   if (hasReturnPath(routeBack, snrBack)) {
     const backPath = [responder, ...routeBack, requester];
     for (let i = 0; i < backPath.length - 1; i++) {

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 // #2931 — shared unknown-hop sentinel (raw firmware INT8_MIN -128 / 4 = -32).
-// Previously duplicated here as a private copy; now imported from the single
-// canonical home in mapHelpers so the definition lives once (#4047 P3 WP1).
-import { isUnknownSnr } from '../utils/mapHelpers';
+// Previously duplicated here as a private copy; folded into mapHelpers under
+// WP1, then re-homed to the leaflet-free tracerouteSegments.ts under WP2 so
+// this hook (and its tests) don't have to pull in mapHelpers.tsx's
+// leaflet/react-leaflet imports just for the sentinel (#4047 P3).
+import { isUnknownSnr } from '../utils/tracerouteSegments';
 
 /**
  * Traceroute analysis for the Map Analysis view (issue #3399).

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -11,11 +11,19 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { Popup, Polyline } from 'react-leaflet';
+import { Popup } from 'react-leaflet';
 import { DraggablePopup } from '../components/DraggablePopup';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { calculateDistance, formatDistance } from '../utils/distance';
-import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isUnknownSnr, type SnrColorScale } from '../utils/mapHelpers';
+import { getSegmentSnrOpacity, isUnknownSnr, weightByUsage, weightBySnr, type SnrColorScale } from '../utils/mapHelpers';
+import {
+  parseSnapshotRoutePositions,
+  resolveSegmentPosition,
+  decomposeTraceroute,
+  UNKNOWN_SNR_SENTINEL,
+  type TracerouteRenderSegment,
+} from '../utils/tracerouteSegments';
+import { TraceroutePathsLayer } from '../components/map/layers/TraceroutePathsLayer';
 import { logger } from '../utils/logger';
 import type { DistanceUnit } from '../contexts/SettingsContext';
 
@@ -216,6 +224,21 @@ export interface UseTraceroutePathsResult {
 const BROADCAST_ADDR = 4294967295;
 
 /**
+ * Fallback SNR color scale for the (structurally optional) `ThemeColors.snrColors`
+ * field. In practice App.tsx always supplies a real scheme-derived scale
+ * (`schemeColors.snrColors`); this only guards the type-level `undefined`
+ * case so the shared `TraceroutePathsLayer`'s required `snrColors` prop
+ * always has a value. Values match `darkOverlayColors.snrColors` (#4047 P3 WP1).
+ */
+const FALLBACK_SNR_COLORS: SnrColorScale = {
+  excellent: '#22c55e',
+  good: '#eab308',
+  fair: '#f97316',
+  poor: '#ef4444',
+  noData: '#6c7086',
+};
+
+/**
  * Filter function to remove invalid/reserved node numbers from route arrays
  * This provides frontend safety for any invalid data that may exist in the database
  * Invalid values:
@@ -284,13 +307,25 @@ export function useTraceroutePaths({
   visibleNodeNums,
   mapZoom,
 }: UseTraceroutePathsParams): UseTraceroutePathsResult {
+  // Shared live-node position map for the #1862 snapshot-then-live fallback.
+  // Kept as a truthy-presence check (matching the pre-existing live-position
+  // fallback semantics) — the WP2 latent-bug fix for lat/lng===0 only applies
+  // to the *snapshot* half via `parseSnapshotRoutePositions`, which both
+  // memos below now use for the historical-position lookup.
+  const liveNodePositions = useMemo(() => {
+    const map = new Map<number, [number, number]>();
+    for (const n of nodesPositionDigest) {
+      if (n.position?.latitude && n.position?.longitude) {
+        map.set(n.nodeNum, [n.position.latitude, n.position.longitude]);
+      }
+    }
+    return map;
+  }, [nodesPositionDigest]);
+
   // Memoize base traceroute paths (showPaths) - doesn't depend on selectedNodeId
   // This prevents re-rendering markers when clicking to select a node
   const traceroutePathsElements = useMemo(() => {
     if (!showPaths) return null;
-
-    // Collect all map elements to return
-    const allElements: React.ReactElement[] = [];
 
     // Calculate segment usage counts and collect SNR values with timestamps
     const segmentUsage = new Map<string, number>();
@@ -302,7 +337,7 @@ export function useTraceroutePaths({
     const segmentsList: Array<{
       key: string;
       positions: [number, number][];
-      nodeNums: number[];
+      nodeNums: [number, number];
     }> = [];
 
     // Filter traceroutes by age using the same maxNodeAgeHours setting
@@ -356,8 +391,11 @@ export function useTraceroutePaths({
           tr.snrTowards && tr.snrTowards !== 'null' && tr.snrTowards !== '' ? JSON.parse(tr.snrTowards) : [];
         const timestamp = tr.timestamp || tr.createdAt || Date.now();
 
-        // Parse snapshot positions (Issue #1862) - prefer historical positions over current
-        const snapshotPositions = parseRoutePositions(tr.routePositions);
+        // #1862 — snapshot positions via the shared util (fixes the
+        // lat/lng===0 truthy-check bug — WP2 finding, deliberate).
+        const snapshotPositions = parseSnapshotRoutePositions(tr.routePositions);
+        const resolvePosition = (nodeNum: number): [number, number] | null =>
+          resolveSegmentPosition(nodeNum, snapshotPositions, liveNodePositions);
 
         // Build forward path: responder -> route -> requester (fromNodeNum -> toNodeNum)
         const forwardSequence: number[] = [tr.fromNodeNum, ...routeForward, tr.toNodeNum];
@@ -365,7 +403,7 @@ export function useTraceroutePaths({
 
         // Build forward sequence with positions (prefer snapshot positions)
         forwardSequence.forEach(nodeNum => {
-          const pos = getNodePositionWithSnapshot(nodeNum, snapshotPositions, nodesPositionDigest);
+          const pos = resolvePosition(nodeNum);
           if (pos) {
             forwardPositions.push({ nodeNum, pos });
           }
@@ -412,7 +450,7 @@ export function useTraceroutePaths({
 
         // Build back sequence with positions (prefer snapshot positions)
         backSequence.forEach(nodeNum => {
-          const pos = getNodePositionWithSnapshot(nodeNum, snapshotPositions, nodesPositionDigest);
+          const pos = resolvePosition(nodeNum);
           if (pos) {
             backPositions.push({ nodeNum, pos });
           }
@@ -478,16 +516,15 @@ export function useTraceroutePaths({
       });
     }
 
-    // Render segments with weighted lines
-    const segmentElements = filteredSegments.map(segment => {
+    // Build shared render segments. TracerouteRenderSegment intentionally has
+    // no nodeNums field (§3.1 of the P3 spec) — keep a side-table of each raw
+    // occurrence's *unsorted* hop nodeNums (needed by the popup/className,
+    // which preserve per-hop node identity/order) keyed by the per-occurrence
+    // `key` (`tr-${idx}-fwd-seg-${i}` / `-back-seg-${i}`, still unique).
+    const nodeNumsByKey = new Map<string, [number, number]>();
+    const renderSegments: TracerouteRenderSegment[] = filteredSegments.map(segment => {
       const segmentKey = segment.nodeNums.slice().sort().join('-');
       const usage = segmentUsage.get(segmentKey) || 1;
-      // Base weight 2, add 1 per usage, max 8
-      const weight = Math.min(2 + usage, 8);
-      // Get node names for popup
-      const node1 = nodesPositionDigest.find(n => n.nodeNum === segment.nodeNums[0]);
-      const node2 = nodesPositionDigest.find(n => n.nodeNum === segment.nodeNums[1]);
-
       // A segment is MQTT/IP only when the firmware reported the unknown-SNR
       // sentinel for that specific hop (issue #2931). Don't infer from
       // `node.viaMqtt` — that flag tracks how the node's own NodeInfo last
@@ -496,14 +533,52 @@ export function useTraceroutePaths({
       // cascade the dashed style across an entire route that's actually
       // mostly radio.
       const isMqttSegment = segmentHasMqtt.get(segmentKey) === true;
+      const snrSamples = segmentSNRs.get(segmentKey) || [];
+      // Average of non-sentinel samples — the same computation the shared
+      // layer's `snrToColor`/`getSegmentSnrColor` perform internally, so the
+      // color this drives matches what the old `getSegmentSnrColor` call
+      // would have produced for the "has RF data" case (4-band, approved).
+      const rfSnrs = snrSamples.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
+      const avgSnr = rfSnrs.length > 0 ? rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length : null;
+      const latestTimestamp = segmentLatestTimestamp.get(segmentKey);
+
+      nodeNumsByKey.set(segment.key, segment.nodeNums);
+
+      return {
+        key: segment.key,
+        from: segment.positions[0],
+        to: segment.positions[1],
+        // Aggregated bidirectionally across (possibly many) traceroutes —
+        // not a single forward/return leg, so 'neutral' (curvature 0 either
+        // way for this layer, per the consumer table).
+        leg: 'neutral',
+        avgSnr,
+        isMqtt: isMqttSegment,
+        usageCount: usage,
+        timestamp: latestTimestamp,
+        snrSamples,
+      };
+    });
+
+    // Popup content (recharts SegmentSnrChart moves in verbatim) — a single
+    // render-prop looked up per segment via the side-table above.
+    const renderBasePopup = (seg: TracerouteRenderSegment): React.ReactNode => {
+      const nodeNums = nodeNumsByKey.get(seg.key);
+      if (!nodeNums) return null;
+      const [nodeNum1, nodeNum2] = nodeNums;
+      const segmentKey = [nodeNum1, nodeNum2].sort().join('-');
+      const usage = segmentUsage.get(segmentKey) || 1;
+      const node1 = nodesPositionDigest.find(n => n.nodeNum === nodeNum1);
+      const node2 = nodesPositionDigest.find(n => n.nodeNum === nodeNum2);
+      const isMqttSegment = seg.isMqtt;
       const node1Name =
-        segment.nodeNums[0] === BROADCAST_ADDR
+        nodeNum1 === BROADCAST_ADDR
           ? '(unknown)'
-          : node1?.user?.longName || node1?.user?.shortName || `!${segment.nodeNums[0].toString(16)}`;
+          : node1?.user?.longName || node1?.user?.shortName || `!${nodeNum1.toString(16)}`;
       const node2Name =
-        segment.nodeNums[1] === BROADCAST_ADDR
+        nodeNum2 === BROADCAST_ADDR
           ? '(unknown)'
-          : node2?.user?.longName || node2?.user?.shortName || `!${segment.nodeNums[1].toString(16)}`;
+          : node2?.user?.longName || node2?.user?.shortName || `!${nodeNum2.toString(16)}`;
 
       // Calculate distance if both nodes have position data
       let segmentDistanceKm = 0;
@@ -522,7 +597,7 @@ export function useTraceroutePaths({
       }
 
       // Calculate SNR statistics
-      const snrData = segmentSNRs.get(segmentKey) || [];
+      const snrData = seg.snrSamples ?? [];
       let snrStats: { min: string; max: string; avg: string; count: number } | null = null;
       let chartData: Array<{
         timeDecimal: number;
@@ -543,11 +618,16 @@ export function useTraceroutePaths({
           count: snrData.length,
         };
 
-        // Prepare chart data for 3+ samples (sorted by time of day)
+        // Prepare chart data for 3+ samples (sorted by time of day). Every
+        // base-layer sample is pushed with a timestamp (see the aggregation
+        // loop above) — the `?? 0` only satisfies `snrSamples`' structurally
+        // optional `timestamp` field (shared across all `TracerouteRenderSegment`
+        // consumers, some of which don't always have one).
         if (snrData.length >= 3) {
           chartData = snrData
             .map(d => {
-              const date = new Date(d.timestamp);
+              const ts = d.timestamp ?? 0;
+              const date = new Date(ts);
               const hours = date.getHours();
               const minutes = date.getMinutes();
               // Convert to decimal hours (0-24) for continuous time axis
@@ -556,158 +636,152 @@ export function useTraceroutePaths({
                 timeDecimal,
                 timeLabel: `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`,
                 snr: parseFloat(d.snr.toFixed(1)),
-                fullTimestamp: d.timestamp,
+                fullTimestamp: ts,
               };
             })
             .sort((a, b) => a.timeDecimal - b.timeDecimal);
         }
       }
 
-      const segmentColor = isMqttSegment
-        ? (themeColors.mqttSegment ?? themeColors.overlay0)
-        : themeColors.snrColors
-          ? getSegmentSnrColor(snrData, themeColors.snrColors, themeColors.neighborLine ?? themeColors.mauve)
-          : (themeColors.neighborLine ?? themeColors.mauve);
-      const baseOpacity = getSegmentSnrOpacity(snrData, isMqttSegment);
-      const latestTimestamp = segmentLatestTimestamp.get(segmentKey);
-      const temporalMultiplier = getTemporalOpacityMultiplier(latestTimestamp);
-      const segmentOpacity = Math.max(0.15, baseOpacity * temporalMultiplier);
-
-      const polylineElement = (
-        <Polyline
-          key={segment.key}
-          positions={segment.positions}
-          pathOptions={{
-            color: segmentColor,
-            weight,
-            opacity: segmentOpacity,
-            dashArray: isMqttSegment ? '3,6' : undefined,
-          }}
-          className={`route-segment node-${segment.nodeNums[0]} node-${segment.nodeNums[1]}`}
-        >
-          <Popup>
-            <div className="route-popup">
-              <h4>Route Segment</h4>
-              {isMqttSegment && (
-                <div className="mqtt-badge">via IP</div>
-              )}
-              <div className="route-endpoints">
-                <strong
-                  className={node1?.user?.id ? 'route-node-link' : undefined}
-                  onClick={e => {
-                    e.stopPropagation();
-                    const freshNode = nodesPositionDigest.find(n => n.nodeNum === segment.nodeNums[0]);
-                    if (freshNode?.user?.id && freshNode?.position?.latitude && freshNode?.position?.longitude) {
-                      callbacks.onSelectNode(freshNode.user.id, [
-                        freshNode.position.latitude,
-                        freshNode.position.longitude,
-                      ]);
-                    }
-                  }}
-                  title={node1?.user?.id ? 'Click to select and center on this node' : ''}
-                >
-                  {node1Name}
-                </strong>
-                {' ↔ '}
-                <strong
-                  className={node2?.user?.id ? 'route-node-link' : undefined}
-                  onClick={e => {
-                    e.stopPropagation();
-                    const freshNode = nodesPositionDigest.find(n => n.nodeNum === segment.nodeNums[1]);
-                    if (freshNode?.user?.id && freshNode?.position?.latitude && freshNode?.position?.longitude) {
-                      callbacks.onSelectNode(freshNode.user.id, [
-                        freshNode.position.latitude,
-                        freshNode.position.longitude,
-                      ]);
-                    }
-                  }}
-                  title={node2?.user?.id ? 'Click to select and center on this node' : ''}
-                >
-                  {node2Name}
-                </strong>
-              </div>
-              <div className="route-usage">
-                Used in{' '}
-                <strong
-                  onClick={e => {
-                    e.stopPropagation();
-                    callbacks.onSelectRouteSegment(segment.nodeNums[0], segment.nodeNums[1]);
-                  }}
-                  style={{ cursor: 'pointer', color: 'var(--ctp-blue)', textDecoration: 'underline' }}
-                  title="Click to view all traceroutes using this segment"
-                >
-                  {usage}
-                </strong>{' '}
-                traceroute{usage !== 1 ? 's' : ''}
-              </div>
-              {segmentDistanceKm > 0 && (
-                <div className="route-usage">
-                  Distance: <strong>{formatDistance(segmentDistanceKm, distanceUnit)}</strong>
-                </div>
-              )}
-              {snrStats && (
-                <div className="route-snr-stats">
-                  {snrStats.count === 1 ? (
-                    <>
-                      <h5>SNR:</h5>
-                      <div className="snr-stat-row">
-                        <span className="stat-value">{snrStats.min} dB</span>
-                      </div>
-                    </>
-                  ) : snrStats.count === 2 ? (
-                    <>
-                      <h5>SNR Statistics:</h5>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Min:</span>
-                        <span className="stat-value">{snrStats.min} dB</span>
-                      </div>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Max:</span>
-                        <span className="stat-value">{snrStats.max} dB</span>
-                      </div>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Samples:</span>
-                        <span className="stat-value">{snrStats.count}</span>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <h5>SNR Statistics:</h5>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Min:</span>
-                        <span className="stat-value">{snrStats.min} dB</span>
-                      </div>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Max:</span>
-                        <span className="stat-value">{snrStats.max} dB</span>
-                      </div>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Average:</span>
-                        <span className="stat-value">{snrStats.avg} dB</span>
-                      </div>
-                      <div className="snr-stat-row">
-                        <span className="stat-label">Samples:</span>
-                        <span className="stat-value">{snrStats.count}</span>
-                      </div>
-                      {chartData && (
-                        <SegmentSnrChart chartData={chartData} />
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
+      return (
+        <Popup>
+          <div className="route-popup">
+            <h4>Route Segment</h4>
+            {isMqttSegment && (
+              <div className="mqtt-badge">via IP</div>
+            )}
+            <div className="route-endpoints">
+              <strong
+                className={node1?.user?.id ? 'route-node-link' : undefined}
+                onClick={e => {
+                  e.stopPropagation();
+                  const freshNode = nodesPositionDigest.find(n => n.nodeNum === nodeNum1);
+                  if (freshNode?.user?.id && freshNode?.position?.latitude && freshNode?.position?.longitude) {
+                    callbacks.onSelectNode(freshNode.user.id, [
+                      freshNode.position.latitude,
+                      freshNode.position.longitude,
+                    ]);
+                  }
+                }}
+                title={node1?.user?.id ? 'Click to select and center on this node' : ''}
+              >
+                {node1Name}
+              </strong>
+              {' ↔ '}
+              <strong
+                className={node2?.user?.id ? 'route-node-link' : undefined}
+                onClick={e => {
+                  e.stopPropagation();
+                  const freshNode = nodesPositionDigest.find(n => n.nodeNum === nodeNum2);
+                  if (freshNode?.user?.id && freshNode?.position?.latitude && freshNode?.position?.longitude) {
+                    callbacks.onSelectNode(freshNode.user.id, [
+                      freshNode.position.latitude,
+                      freshNode.position.longitude,
+                    ]);
+                  }
+                }}
+                title={node2?.user?.id ? 'Click to select and center on this node' : ''}
+              >
+                {node2Name}
+              </strong>
             </div>
-          </Popup>
-        </Polyline>
+            <div className="route-usage">
+              Used in{' '}
+              <strong
+                onClick={e => {
+                  e.stopPropagation();
+                  callbacks.onSelectRouteSegment(nodeNum1, nodeNum2);
+                }}
+                style={{ cursor: 'pointer', color: 'var(--ctp-blue)', textDecoration: 'underline' }}
+                title="Click to view all traceroutes using this segment"
+              >
+                {usage}
+              </strong>{' '}
+              traceroute{usage !== 1 ? 's' : ''}
+            </div>
+            {segmentDistanceKm > 0 && (
+              <div className="route-usage">
+                Distance: <strong>{formatDistance(segmentDistanceKm, distanceUnit)}</strong>
+              </div>
+            )}
+            {snrStats && (
+              <div className="route-snr-stats">
+                {snrStats.count === 1 ? (
+                  <>
+                    <h5>SNR:</h5>
+                    <div className="snr-stat-row">
+                      <span className="stat-value">{snrStats.min} dB</span>
+                    </div>
+                  </>
+                ) : snrStats.count === 2 ? (
+                  <>
+                    <h5>SNR Statistics:</h5>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Min:</span>
+                      <span className="stat-value">{snrStats.min} dB</span>
+                    </div>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Max:</span>
+                      <span className="stat-value">{snrStats.max} dB</span>
+                    </div>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Samples:</span>
+                      <span className="stat-value">{snrStats.count}</span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <h5>SNR Statistics:</h5>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Min:</span>
+                      <span className="stat-value">{snrStats.min} dB</span>
+                    </div>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Max:</span>
+                      <span className="stat-value">{snrStats.max} dB</span>
+                    </div>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Average:</span>
+                      <span className="stat-value">{snrStats.avg} dB</span>
+                    </div>
+                    <div className="snr-stat-row">
+                      <span className="stat-label">Samples:</span>
+                      <span className="stat-value">{snrStats.count}</span>
+                    </div>
+                    {chartData && (
+                      <SegmentSnrChart chartData={chartData} />
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </Popup>
       );
+    };
 
-      return polylineElement;
-    });
+    const baseSegmentClassName = (seg: TracerouteRenderSegment): string => {
+      const nodeNums = nodeNumsByKey.get(seg.key);
+      if (!nodeNums) return 'route-segment';
+      return `route-segment node-${nodeNums[0]} node-${nodeNums[1]}`;
+    };
 
-    allElements.push(...segmentElements);
-
-    return allElements;
-  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.mauve, themeColors.overlay0, themeColors.neighborLine, themeColors.mqttSegment, themeColors.snrColors, callbacks, visibleNodeNums, mapZoom]);
+    return [
+      <TraceroutePathsLayer
+        key="base-traceroute-layer"
+        segments={renderSegments}
+        snrColors={themeColors.snrColors ?? FALLBACK_SNR_COLORS}
+        colorMode="snr"
+        curvature={0}
+        weight={seg => weightByUsage(seg.usageCount ?? 1)}
+        opacity={seg => getSegmentSnrOpacity(seg.snrSamples, seg.isMqtt)}
+        dashMode="mqtt-unknown"
+        temporalFade
+        renderPopup={renderBasePopup}
+        segmentClassName={baseSegmentClassName}
+      />,
+    ];
+  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, callbacks, visibleNodeNums, mapZoom, liveNodePositions]);
 
   // Separate memoization for selected node traceroute (showRoute)
   // This can change independently without re-rendering the base map markers
@@ -715,266 +789,155 @@ export function useTraceroutePaths({
     // Skip rendering traceroute if the selected node is the current/local node
     if (!showRoute || !selectedNodeId || selectedNodeId === currentNodeId) return null;
 
-    const allElements: React.ReactElement[] = [];
-
     const selectedTrace = traceroutesDigest.find(
       tr => tr.toNodeId === selectedNodeId || tr.fromNodeId === selectedNodeId
     );
 
     if (!selectedTrace) return null;
 
-    // Skip if the traceroute has null or invalid route data (failed traceroute)
-    if (
-      !selectedTrace.route ||
-      selectedTrace.route === 'null' ||
-      selectedTrace.route === '' ||
-      !selectedTrace.routeBack ||
-      selectedTrace.routeBack === 'null' ||
-      selectedTrace.routeBack === ''
-    ) {
-      return null;
-    }
-
     try {
-      // Route arrays are stored exactly as Meshtastic provides them (no backend reversal)
-      // Filter out invalid node numbers for safety
-      const rawRouteForward = JSON.parse(selectedTrace.route);
-      const rawRouteBack = JSON.parse(selectedTrace.routeBack);
-      const routeForward = rawRouteForward.filter(isValidRouteNode);
-      const routeBack = rawRouteBack.filter(isValidRouteNode);
+      // Route arrays are stored exactly as Meshtastic provides them (no backend
+      // reversal). Filter out invalid/reserved node numbers (isValidRouteNode)
+      // BEFORE handing off to the shared `decomposeTraceroute` util — the
+      // shared util has no equivalent safety filter, so the route/routeBack
+      // JSON is sanitized here to preserve this hook's pre-existing
+      // defensive behavior (dropping reserved/broadcast placeholder nodes
+      // from the middle of a route).
+      const sanitizeRouteJson = (json: string | undefined | null): string | undefined => {
+        if (!json || json === 'null' || json === '') return json ?? undefined;
+        try {
+          const parsed = JSON.parse(json);
+          if (!Array.isArray(parsed)) return json;
+          return JSON.stringify(parsed.filter(isValidRouteNode));
+        } catch {
+          return json;
+        }
+      };
 
-      // Parse SNR data
-      const snrForward = selectedTrace.snrTowards && selectedTrace.snrTowards !== 'null' ? JSON.parse(selectedTrace.snrTowards) : [];
-      const snrBack = selectedTrace.snrBack && selectedTrace.snrBack !== 'null' ? JSON.parse(selectedTrace.snrBack) : [];
+      // #1862 — snapshot positions via the shared util.
+      const snapshotPositions = parseSnapshotRoutePositions(selectedTrace.routePositions);
+      const resolvePosition = (nodeNum: number): [number, number] | null =>
+        resolveSegmentPosition(nodeNum, snapshotPositions, liveNodePositions);
 
-      // Parse snapshot positions (Issue #1862) - prefer historical positions over current
-      const snapshotPositions = parseRoutePositions(selectedTrace.routePositions);
+      // #1862/#2051/#2931 — per-traceroute decomposition (shared util). Only
+      // `route` gates the whole decomposition (matching `decomposeTraceroute`'s
+      // contract); the return leg is gated solely by `hasReturnPath` (#2051
+      // unified fix) — see the WP3 report for the resulting NodesTab-visible
+      // delta versus the old "skip the whole traceroute unless routeBack is
+      // also present" guard, which never had a #2051 guard at all.
+      const segments = decomposeTraceroute(
+        {
+          fromNodeNum: selectedTrace.fromNodeNum,
+          toNodeNum: selectedTrace.toNodeNum,
+          route: sanitizeRouteJson(selectedTrace.route),
+          routeBack: sanitizeRouteJson(selectedTrace.routeBack),
+          snrTowards: selectedTrace.snrTowards,
+          snrBack: selectedTrace.snrBack,
+          timestamp: selectedTrace.timestamp,
+          createdAt: selectedTrace.createdAt,
+        },
+        { resolvePosition }
+      );
+
+      if (segments.length === 0) return null;
 
       const fromNode = nodesPositionDigest.find(n => n.nodeNum === selectedTrace.fromNodeNum);
       const toNode = nodesPositionDigest.find(n => n.nodeNum === selectedTrace.toNodeNum);
       const fromName = fromNode?.user?.longName || fromNode?.user?.shortName || selectedTrace.fromNodeId;
       const toName = toNode?.user?.longName || toNode?.user?.shortName || selectedTrace.toNodeId;
 
-      // Forward path: responder -> requester
-      if (routeForward.length >= 0) {
-        const forwardSequence: number[] = [selectedTrace.fromNodeNum, ...routeForward, selectedTrace.toNodeNum];
-        const forwardPositions: [number, number][] = [];
+      const nameForNode = (num: number): string => {
+        const n = nodesPositionDigest.find(nd => nd.nodeNum === num);
+        return n?.user?.longName || n?.user?.shortName || `!${num.toString(16)}`;
+      };
 
-        forwardSequence.forEach(nodeNum => {
-          const pos = getNodePositionWithSnapshot(nodeNum, snapshotPositions, nodesPositionDigest);
-          if (pos) {
-            forwardPositions.push(pos);
-          }
+      // Leg-level popup metadata (distance, path listing) — computed once per
+      // leg and reused across all of that leg's per-hop popups, matching the
+      // pre-existing behavior where these were leg-level constants reused
+      // inside the per-hop render loop.
+      const legDistanceKm = (leg: 'forward' | 'return'): number =>
+        segments
+          .filter(s => s.leg === leg)
+          .reduce((sum, s) => sum + calculateDistance(s.from[0], s.from[1], s.to[0], s.to[1]), 0);
+
+      const legPathLabel = (leg: 'forward' | 'return'): string => {
+        const legSegments = segments.filter(s => s.leg === leg);
+        if (legSegments.length === 0) return '';
+        // Reconstruct the hop sequence from each segment's node numbers,
+        // parsed back out of `key` ("forward:123-456"/"return:123-456") per
+        // the shared util's documented convention for consumers that need
+        // their own cross-segment node-pair info.
+        const nums: number[] = [];
+        legSegments.forEach((s, i) => {
+          const pair = s.key.split(':')[1] ?? '';
+          const [a, b] = pair.split('-').map(Number);
+          if (i === 0) nums.push(a);
+          nums.push(b);
         });
+        return nums.map(nameForNode).join(' → ');
+      };
 
-        if (forwardPositions.length >= 2) {
-          // Calculate total distance for forward path (use snapshot positions)
-          let forwardTotalDistanceKm = 0;
-          for (let i = 0; i < forwardSequence.length - 1; i++) {
-            const pos1 = getNodePositionWithSnapshot(forwardSequence[i], snapshotPositions, nodesPositionDigest);
-            const pos2 = getNodePositionWithSnapshot(forwardSequence[i + 1], snapshotPositions, nodesPositionDigest);
-            if (pos1 && pos2) {
-              forwardTotalDistanceKm += calculateDistance(pos1[0], pos1[1], pos2[0], pos2[1]);
-            }
-          }
+      const forwardDistanceKm = legDistanceKm('forward');
+      const backDistanceKm = legDistanceKm('return');
+      const forwardPathLabel = legPathLabel('forward');
+      const backPathLabel = legPathLabel('return');
 
-          // Build SNR array for segments
-          const forwardSegmentSnrs: (number | undefined)[] = [];
-          if (forwardSequence.length > 1) {
-             // For each segment (node i -> node i+1), the SNR is usually recorded at the receiving end
-             // The snrForward array corresponds to hops.
-             // We map them to segments.
-             for (let i = 0; i < forwardSequence.length - 1; i++) {
-                // SNR at index i corresponds to the link arriving at node i+1
-                // For the first segment (0 -> 1), use index 0.
-                if (i < snrForward.length) {
-                   forwardSegmentSnrs.push(snrForward[i] / 4);
-                } else {
-                   forwardSegmentSnrs.push(undefined);
-                }
-             }
-          }
+      const renderSelectedPopup = (seg: TracerouteRenderSegment): React.ReactNode => {
+        const isForward = seg.leg === 'forward';
+        const legDistance = isForward ? forwardDistanceKm : backDistanceKm;
+        return (
+          <DraggablePopup>
+            <div className="route-popup">
+              <h4>{isForward ? 'Forward Path' : 'Return Path'}</h4>
+              <div className="route-endpoints">
+                {isForward ? (
+                  <><strong>{fromName}</strong> → <strong>{toName}</strong></>
+                ) : (
+                  <><strong>{toName}</strong> → <strong>{fromName}</strong></>
+                )}
+              </div>
+              <div className="route-usage">
+                Path:{' '}{isForward ? forwardPathLabel : backPathLabel}
+              </div>
+              {legDistance > 0 && (
+                <div className="route-usage">
+                  Distance: <strong>{formatDistance(legDistance, distanceUnit)}</strong>
+                </div>
+              )}
+              {(seg.avgSnr !== null || seg.isMqtt) && (
+                <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '4px' }}>
+                  Segment SNR: <strong>{seg.avgSnr !== null ? `${seg.avgSnr.toFixed(1)} dB` : 'Unknown'}</strong>
+                  {seg.isMqtt && ' (IP)'}
+                </div>
+              )}
+            </div>
+          </DraggablePopup>
+        );
+      };
 
-          // Render individual curved segments
-          for (let i = 0; i < forwardPositions.length - 1; i++) {
-             const segmentPoints = generateCurvedPath(
-               forwardPositions[i],
-               forwardPositions[i + 1],
-               0.2, // Positive curvature for forward
-               20,
-               true
-             );
-             
-             const weight = getLineWeight(forwardSegmentSnrs[i]);
-             const isMqtt = isUnknownSnr(forwardSegmentSnrs[i]);
-
-             allElements.push(
-               <Polyline
-                 key={`selected-traceroute-forward-seg-${i}`}
-                 positions={segmentPoints}
-                 pathOptions={{
-                   color: themeColors.tracerouteForward ?? themeColors.blue,
-                   weight,
-                   opacity: 0.9,
-                   dashArray: '3,6',
-                 }}
-                 className={`route-segment node-${forwardSequence[i]} node-${forwardSequence[i + 1]}`}
-               >
-                 <DraggablePopup>
-                   <div className="route-popup">
-                     <h4>Forward Path</h4>
-                     <div className="route-endpoints">
-                       <strong>{fromName}</strong> → <strong>{toName}</strong>
-                     </div>
-                     <div className="route-usage">
-                       Path:{' '}
-                       {forwardSequence
-                         .map(num => {
-                           const n = nodesPositionDigest.find(nd => nd.nodeNum === num);
-                           return n?.user?.longName || n?.user?.shortName || `!${num.toString(16)}`;
-                         })
-                         .join(' → ')}
-                     </div>
-                     {forwardTotalDistanceKm > 0 && (
-                       <div className="route-usage">
-                         Distance: <strong>{formatDistance(forwardTotalDistanceKm, distanceUnit)}</strong>
-                       </div>
-                     )}
-                     {forwardSegmentSnrs[i] !== undefined && (
-                        <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '4px' }}>
-                          Segment SNR: <strong>{forwardSegmentSnrs[i]?.toFixed(1)} dB</strong>
-                          {isMqtt && ' (IP)'}
-                        </div>
-                     )}
-                   </div>
-                 </DraggablePopup>
-               </Polyline>
-             );
-          }
-
-          // Generate arrow markers for forward path
-          const forwardArrows = generateCurvedArrowMarkers(
-            forwardPositions,
-            'forward',
-            themeColors.tracerouteForward ?? themeColors.blue,
-            forwardSegmentSnrs,
-            0.2,
-            true
-          );
-          allElements.push(...forwardArrows);
-        }
-      }
-
-      // Return path: requester -> responder (using routeBack array)
-      if (routeBack.length >= 0) {
-        const backSequence: number[] = [selectedTrace.toNodeNum, ...routeBack, selectedTrace.fromNodeNum];
-        const backPositions: [number, number][] = [];
-
-        backSequence.forEach(nodeNum => {
-          const pos = getNodePositionWithSnapshot(nodeNum, snapshotPositions, nodesPositionDigest);
-          if (pos) {
-            backPositions.push(pos);
-          }
-        });
-
-        if (backPositions.length >= 2) {
-          // Calculate total distance for back path (use snapshot positions)
-          let backTotalDistanceKm = 0;
-          for (let i = 0; i < backSequence.length - 1; i++) {
-            const pos1 = getNodePositionWithSnapshot(backSequence[i], snapshotPositions, nodesPositionDigest);
-            const pos2 = getNodePositionWithSnapshot(backSequence[i + 1], snapshotPositions, nodesPositionDigest);
-            if (pos1 && pos2) {
-              backTotalDistanceKm += calculateDistance(pos1[0], pos1[1], pos2[0], pos2[1]);
-            }
-          }
-
-          // Build SNR array for segments
-          const backSegmentSnrs: (number | undefined)[] = [];
-          if (backSequence.length > 1) {
-             for (let i = 0; i < backSequence.length - 1; i++) {
-                if (i < snrBack.length) {
-                   backSegmentSnrs.push(snrBack[i] / 4);
-                } else {
-                   backSegmentSnrs.push(undefined);
-                }
-             }
-          }
-
-          // Render individual curved segments
-          for (let i = 0; i < backPositions.length - 1; i++) {
-             const segmentPoints = generateCurvedPath(
-               backPositions[i],
-               backPositions[i + 1],
-               -0.2, // Negative curvature
-               20,
-               true
-             );
-             
-             const weight = getLineWeight(backSegmentSnrs[i]);
-             const isMqtt = isUnknownSnr(backSegmentSnrs[i]);
-
-             allElements.push(
-               <Polyline
-                 key={`selected-traceroute-back-seg-${i}`}
-                 positions={segmentPoints}
-                 pathOptions={{
-                   color: themeColors.tracerouteReturn ?? themeColors.red,
-                   weight,
-                   opacity: 0.9,
-                   dashArray: '3,6',
-                 }}
-                 className={`route-segment node-${backSequence[i]} node-${backSequence[i + 1]}`}
-               >
-                 <DraggablePopup>
-                   <div className="route-popup">
-                     <h4>Return Path</h4>
-                     <div className="route-endpoints">
-                       <strong>{toName}</strong> → <strong>{fromName}</strong>
-                     </div>
-                     <div className="route-usage">
-                       Path:{' '}
-                       {backSequence
-                         .map(num => {
-                           const n = nodesPositionDigest.find(nd => nd.nodeNum === num);
-                           return n?.user?.longName || n?.user?.shortName || `!${num.toString(16)}`;
-                         })
-                         .join(' → ')}
-                     </div>
-                     {backTotalDistanceKm > 0 && (
-                       <div className="route-usage">
-                         Distance: <strong>{formatDistance(backTotalDistanceKm, distanceUnit)}</strong>
-                       </div>
-                     )}
-                     {backSegmentSnrs[i] !== undefined && (
-                        <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '4px' }}>
-                          Segment SNR: <strong>{backSegmentSnrs[i]?.toFixed(1)} dB</strong>
-                          {isMqtt && ' (IP)'}
-                        </div>
-                     )}
-                   </div>
-                 </DraggablePopup>
-               </Polyline>
-             );
-          }
-
-          // Generate arrow markers for back path
-          const backArrows = generateCurvedArrowMarkers(
-            backPositions, 
-            'back', 
-            themeColors.tracerouteReturn ?? themeColors.red,
-            backSegmentSnrs,
-            -0.2,
-            true
-          );
-          allElements.push(...backArrows);
-        }
-      }
+      return [
+        <TraceroutePathsLayer
+          key="selected-traceroute-layer"
+          segments={segments}
+          snrColors={themeColors.snrColors ?? FALLBACK_SNR_COLORS}
+          colorMode="fixed-leg"
+          legColors={{
+            forward: themeColors.tracerouteForward ?? themeColors.blue,
+            return: themeColors.tracerouteReturn ?? themeColors.red,
+          }}
+          curvature={0.2}
+          weight={seg => weightBySnr(seg.isMqtt ? UNKNOWN_SNR_SENTINEL : (seg.avgSnr ?? undefined))}
+          opacity={0.9}
+          dashMode="mqtt-unknown"
+          showArrows
+          renderPopup={renderSelectedPopup}
+        />,
+      ];
     } catch (error) {
       logger.error('Error rendering selected node traceroute:', error);
+      return null;
     }
-
-    return allElements.length > 0 ? allElements : null;
-  }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.red, themeColors.blue, themeColors.tracerouteForward, themeColors.tracerouteReturn]);
+  }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.red, themeColors.blue, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions]);
 
   // Compute the set of node numbers involved in the selected traceroute
   // Used for filtering map markers to only show nodes in the active traceroute

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -15,7 +15,7 @@ import { Popup, Polyline } from 'react-leaflet';
 import { DraggablePopup } from '../components/DraggablePopup';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { calculateDistance, formatDistance } from '../utils/distance';
-import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isUnknownSnr } from '../utils/mapHelpers';
+import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isUnknownSnr, type SnrColorScale } from '../utils/mapHelpers';
 import { logger } from '../utils/logger';
 import type { DistanceUnit } from '../contexts/SettingsContext';
 
@@ -168,11 +168,7 @@ export interface ThemeColors {
   tracerouteReturn?: string;
   mqttSegment?: string;
   neighborLine?: string;
-  snrColors?: {
-    good: string;
-    medium: string;
-    poor: string;
-  };
+  snrColors?: SnrColorScale;
 }
 
 /**

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -15,16 +15,20 @@ import { Popup } from 'react-leaflet';
 import { DraggablePopup } from '../components/DraggablePopup';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { calculateDistance, formatDistance } from '../utils/distance';
-import { getSegmentSnrOpacity, isUnknownSnr, weightByUsage, weightBySnr, type SnrColorScale } from '../utils/mapHelpers';
+import { getSegmentSnrOpacity, weightByUsage, tracerouteSegmentWeight, type SnrColorScale } from '../utils/mapHelpers';
 import {
   parseSnapshotRoutePositions,
   resolveSegmentPosition,
+  buildLiveNodePositionMap,
   decomposeTraceroute,
   hasReturnPath,
-  UNKNOWN_SNR_SENTINEL,
+  isUnknownSnr,
+  isValidRouteNode,
+  averageNonSentinelSnr,
   type TracerouteRenderSegment,
 } from '../utils/tracerouteSegments';
 import { TraceroutePathsLayer } from '../components/map/layers/TraceroutePathsLayer';
+import { darkOverlayColors } from '../config/overlayColors';
 import { logger } from '../utils/logger';
 import type { DistanceUnit } from '../contexts/SettingsContext';
 
@@ -229,38 +233,15 @@ const BROADCAST_ADDR = 4294967295;
  * field. In practice App.tsx always supplies a real scheme-derived scale
  * (`schemeColors.snrColors`); this only guards the type-level `undefined`
  * case so the shared `TraceroutePathsLayer`'s required `snrColors` prop
- * always has a value. Values match `darkOverlayColors.snrColors` (#4047 P3 WP1).
+ * always has a value.
  */
-const FALLBACK_SNR_COLORS: SnrColorScale = {
-  excellent: '#22c55e',
-  good: '#eab308',
-  fair: '#f97316',
-  poor: '#ef4444',
-  noData: '#6c7086',
-};
+const FALLBACK_SNR_COLORS: SnrColorScale = darkOverlayColors.snrColors;
 
-/**
- * Filter function to remove invalid/reserved node numbers from route arrays
- * This provides frontend safety for any invalid data that may exist in the database
- * Invalid values:
- * - 0-3: Reserved per Meshtastic protocol
- * - 255 (0xff): Reserved for broadcast in some contexts
- * - 65535 (0xffff): Invalid placeholder value that causes display issues
- * - 4294967295 (0xffffffff): Broadcast address
- */
-const isValidRouteNode = (nodeNum: number): boolean => {
-  if (nodeNum <= 3) return false;  // Reserved
-  if (nodeNum === 255) return false;  // 0xff reserved
-  if (nodeNum === 65535) return false;  // 0xffff invalid placeholder
-  if (nodeNum === BROADCAST_ADDR) return false;  // Broadcast
-  return true;
-};
-
-// #1862 snapshot parsing + snapshot-then-live position resolution now go
-// through the shared `parseSnapshotRoutePositions`/`resolveSegmentPosition`
-// utils (src/utils/tracerouteSegments.ts) — the local `parseRoutePositions`/
-// `getNodePositionWithSnapshot` helpers (which had the lat/lng===0
-// truthy-check bug on the snapshot half) were deleted in #4047 P3 WP3.
+// `isValidRouteNode` (reserved/broadcast node-number filtering) is imported
+// from `tracerouteSegments.ts` — that's the single home; see its doc comment.
+// #1862 snapshot parsing + snapshot-then-live position resolution likewise go
+// through the shared `parseSnapshotRoutePositions`/`resolveSegmentPosition`/
+// `buildLiveNodePositionMap` utils.
 
 /**
  * Hook for computing and rendering traceroute paths on the map
@@ -279,20 +260,18 @@ export function useTraceroutePaths({
   visibleNodeNums,
   mapZoom,
 }: UseTraceroutePathsParams): UseTraceroutePathsResult {
-  // Shared live-node position map for the #1862 snapshot-then-live fallback.
-  // Kept as a truthy-presence check (matching the pre-existing live-position
-  // fallback semantics) — the WP2 latent-bug fix for lat/lng===0 only applies
-  // to the *snapshot* half via `parseSnapshotRoutePositions`, which both
-  // memos below now use for the historical-position lookup.
-  const liveNodePositions = useMemo(() => {
-    const map = new Map<number, [number, number]>();
-    for (const n of nodesPositionDigest) {
-      if (n.position?.latitude && n.position?.longitude) {
-        map.set(n.nodeNum, [n.position.latitude, n.position.longitude]);
-      }
-    }
-    return map;
-  }, [nodesPositionDigest]);
+  // Shared live-node position map for the #1862 snapshot-then-live fallback,
+  // built via the shared `buildLiveNodePositionMap` (also fixes the
+  // lat/lng===0 falsy-zero bug on the live side, not just the snapshot side).
+  const liveNodePositions = useMemo(
+    () =>
+      buildLiveNodePositionMap(nodesPositionDigest, (n) => ({
+        nodeNum: n.nodeNum,
+        lat: n.position?.latitude,
+        lng: n.position?.longitude,
+      })),
+    [nodesPositionDigest],
+  );
 
   // Memoize base traceroute paths (showPaths) - doesn't depend on selectedNodeId
   // This prevents re-rendering markers when clicking to select a node
@@ -363,8 +342,8 @@ export function useTraceroutePaths({
           tr.snrTowards && tr.snrTowards !== 'null' && tr.snrTowards !== '' ? JSON.parse(tr.snrTowards) : [];
         const timestamp = tr.timestamp || tr.createdAt || Date.now();
 
-        // #1862 — snapshot positions via the shared util (fixes the
-        // lat/lng===0 truthy-check bug — WP2 finding, deliberate).
+        // #1862 — snapshot positions via the shared util (fixes a
+        // lat/lng===0 truthy-check bug in the old per-consumer copy).
         const snapshotPositions = parseSnapshotRoutePositions(tr.routePositions);
         const resolvePosition = (nodeNum: number): [number, number] | null =>
           resolveSegmentPosition(nodeNum, snapshotPositions, liveNodePositions);
@@ -488,12 +467,10 @@ export function useTraceroutePaths({
       });
     }
 
-    // Build shared render segments. TracerouteRenderSegment intentionally has
-    // no nodeNums field (§3.1 of the P3 spec) — keep a side-table of each raw
-    // occurrence's *unsorted* hop nodeNums (needed by the popup/className,
-    // which preserve per-hop node identity/order) keyed by the per-occurrence
-    // `key` (`tr-${idx}-fwd-seg-${i}` / `-back-seg-${i}`, still unique).
-    const nodeNumsByKey = new Map<string, [number, number]>();
+    // Build shared render segments, carrying each occurrence's hop node
+    // numbers directly on the segment (`fromNodeNum`/`toNodeNum`) so the
+    // popup/className below can read them straight off `seg` instead of a
+    // side-table lookup.
     const renderSegments: TracerouteRenderSegment[] = filteredSegments.map(segment => {
       const segmentKey = segment.nodeNums.slice().sort().join('-');
       const usage = segmentUsage.get(segmentKey) || 1;
@@ -506,20 +483,15 @@ export function useTraceroutePaths({
       // mostly radio.
       const isMqttSegment = segmentHasMqtt.get(segmentKey) === true;
       const snrSamples = segmentSNRs.get(segmentKey) || [];
-      // Average of non-sentinel samples — the same computation the shared
-      // layer's `snrToColor`/`getSegmentSnrColor` perform internally, so the
-      // color this drives matches what the old `getSegmentSnrColor` call
-      // would have produced for the "has RF data" case (4-band, approved).
-      const rfSnrs = snrSamples.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
-      const avgSnr = rfSnrs.length > 0 ? rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length : null;
+      const avgSnr = averageNonSentinelSnr(snrSamples);
       const latestTimestamp = segmentLatestTimestamp.get(segmentKey);
-
-      nodeNumsByKey.set(segment.key, segment.nodeNums);
 
       return {
         key: segment.key,
         from: segment.positions[0],
         to: segment.positions[1],
+        fromNodeNum: segment.nodeNums[0],
+        toNodeNum: segment.nodeNums[1],
         // Aggregated bidirectionally across (possibly many) traceroutes —
         // not a single forward/return leg, so 'neutral' (curvature 0 either
         // way for this layer, per the consumer table).
@@ -532,16 +504,20 @@ export function useTraceroutePaths({
       };
     });
 
+    // O(1) node lookup by nodeNum for the popup render-prop below, built
+    // once per memo recomputation instead of a linear `.find()` per segment.
+    const nodeByNum = new Map<number, NodePositionDigest>();
+    for (const n of nodesPositionDigest) nodeByNum.set(n.nodeNum, n);
+
     // Popup content (recharts SegmentSnrChart moves in verbatim) — a single
-    // render-prop looked up per segment via the side-table above.
+    // render-prop reading hop identity straight off the segment.
     const renderBasePopup = (seg: TracerouteRenderSegment): React.ReactNode => {
-      const nodeNums = nodeNumsByKey.get(seg.key);
-      if (!nodeNums) return null;
-      const [nodeNum1, nodeNum2] = nodeNums;
+      const nodeNum1 = seg.fromNodeNum;
+      const nodeNum2 = seg.toNodeNum;
       const segmentKey = [nodeNum1, nodeNum2].sort().join('-');
       const usage = segmentUsage.get(segmentKey) || 1;
-      const node1 = nodesPositionDigest.find(n => n.nodeNum === nodeNum1);
-      const node2 = nodesPositionDigest.find(n => n.nodeNum === nodeNum2);
+      const node1 = nodeByNum.get(nodeNum1);
+      const node2 = nodeByNum.get(nodeNum2);
       const isMqttSegment = seg.isMqtt;
       const node1Name =
         nodeNum1 === BROADCAST_ADDR
@@ -732,11 +708,8 @@ export function useTraceroutePaths({
       );
     };
 
-    const baseSegmentClassName = (seg: TracerouteRenderSegment): string => {
-      const nodeNums = nodeNumsByKey.get(seg.key);
-      if (!nodeNums) return 'route-segment';
-      return `route-segment node-${nodeNums[0]} node-${nodeNums[1]}`;
-    };
+    const baseSegmentClassName = (seg: TracerouteRenderSegment): string =>
+      `route-segment node-${seg.fromNodeNum} node-${seg.toNodeNum}`;
 
     return [
       <TraceroutePathsLayer
@@ -744,6 +717,7 @@ export function useTraceroutePaths({
         segments={renderSegments}
         snrColors={themeColors.snrColors ?? FALLBACK_SNR_COLORS}
         colorMode="snr"
+        mqttColor={themeColors.mqttSegment ?? themeColors.overlay0}
         curvature={0}
         weight={seg => weightByUsage(seg.usageCount ?? 1)}
         opacity={seg => getSegmentSnrOpacity(seg.snrSamples, seg.isMqtt)}
@@ -753,7 +727,7 @@ export function useTraceroutePaths({
         segmentClassName={baseSegmentClassName}
       />,
     ];
-  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, callbacks, visibleNodeNums, mapZoom, liveNodePositions]);
+  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, themeColors.mqttSegment, themeColors.overlay0, callbacks, visibleNodeNums, mapZoom, liveNodePositions]);
 
   // Separate memoization for selected node traceroute (showRoute)
   // This can change independently without re-rendering the base map markers
@@ -768,41 +742,26 @@ export function useTraceroutePaths({
     if (!selectedTrace) return null;
 
     try {
-      // Route arrays are stored exactly as Meshtastic provides them (no backend
-      // reversal). Filter out invalid/reserved node numbers (isValidRouteNode)
-      // BEFORE handing off to the shared `decomposeTraceroute` util — the
-      // shared util has no equivalent safety filter, so the route/routeBack
-      // JSON is sanitized here to preserve this hook's pre-existing
-      // defensive behavior (dropping reserved/broadcast placeholder nodes
-      // from the middle of a route).
-      const sanitizeRouteJson = (json: string | undefined | null): string | undefined => {
-        if (!json || json === 'null' || json === '') return json ?? undefined;
-        try {
-          const parsed = JSON.parse(json);
-          if (!Array.isArray(parsed)) return json;
-          return JSON.stringify(parsed.filter(isValidRouteNode));
-        } catch {
-          return json;
-        }
-      };
-
+      // Route arrays are stored exactly as Meshtastic provides them (no
+      // backend reversal). `decomposeTraceroute` filters reserved/broadcast
+      // placeholder node numbers out of the route internally, so the raw
+      // JSON is passed straight through.
+      //
       // #1862 — snapshot positions via the shared util.
       const snapshotPositions = parseSnapshotRoutePositions(selectedTrace.routePositions);
       const resolvePosition = (nodeNum: number): [number, number] | null =>
         resolveSegmentPosition(nodeNum, snapshotPositions, liveNodePositions);
 
-      // #1862/#2051/#2931 — per-traceroute decomposition (shared util). Only
-      // `route` gates the whole decomposition (matching `decomposeTraceroute`'s
-      // contract); the return leg is gated solely by `hasReturnPath` (#2051
-      // unified fix) — see the WP3 report for the resulting NodesTab-visible
-      // delta versus the old "skip the whole traceroute unless routeBack is
-      // also present" guard, which never had a #2051 guard at all.
+      // #1862/#2051/#2931 — per-traceroute decomposition (shared util). The
+      // forward and return legs are gated independently: `route` gates the
+      // forward leg, `hasReturnPath` gates the return leg (#2051) — a
+      // traceroute can render one leg without the other.
       const segments = decomposeTraceroute(
         {
           fromNodeNum: selectedTrace.fromNodeNum,
           toNodeNum: selectedTrace.toNodeNum,
-          route: sanitizeRouteJson(selectedTrace.route),
-          routeBack: sanitizeRouteJson(selectedTrace.routeBack),
+          route: selectedTrace.route,
+          routeBack: selectedTrace.routeBack,
           snrTowards: selectedTrace.snrTowards,
           snrBack: selectedTrace.snrBack,
           timestamp: selectedTrace.timestamp,
@@ -835,16 +794,12 @@ export function useTraceroutePaths({
       const legPathLabel = (leg: 'forward' | 'return'): string => {
         const legSegments = segments.filter(s => s.leg === leg);
         if (legSegments.length === 0) return '';
-        // Reconstruct the hop sequence from each segment's node numbers,
-        // parsed back out of `key` ("forward:123-456"/"return:123-456") per
-        // the shared util's documented convention for consumers that need
-        // their own cross-segment node-pair info.
+        // Reconstruct the hop sequence directly from each segment's
+        // fromNodeNum/toNodeNum (segments are in traversal order).
         const nums: number[] = [];
         legSegments.forEach((s, i) => {
-          const pair = s.key.split(':')[1] ?? '';
-          const [a, b] = pair.split('-').map(Number);
-          if (i === 0) nums.push(a);
-          nums.push(b);
+          if (i === 0) nums.push(s.fromNodeNum);
+          nums.push(s.toNodeNum);
         });
         return nums.map(nameForNode).join(' → ');
       };
@@ -898,7 +853,7 @@ export function useTraceroutePaths({
             return: themeColors.tracerouteReturn ?? themeColors.red,
           }}
           curvature={0.2}
-          weight={seg => weightBySnr(seg.isMqtt ? UNKNOWN_SNR_SENTINEL : (seg.avgSnr ?? undefined))}
+          weight={tracerouteSegmentWeight}
           opacity={0.9}
           dashMode="mqtt-unknown"
           showArrows
@@ -911,12 +866,14 @@ export function useTraceroutePaths({
     }
   }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.red, themeColors.blue, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions]);
 
-  // Compute the set of node numbers involved in the selected traceroute
-  // Used for filtering map markers to only show nodes in the active traceroute.
-  // Guards/semantics deliberately mirror the selectedNodeTraceroute memo above
-  // (route-only presence guard; return-leg nodes gated by hasReturnPath —
-  // #2051; isValidRouteNode-sanitized hop arrays) so the marker filter always
-  // covers exactly the nodes whose segments the shared layer actually draws.
+  // Compute the set of node numbers involved in the selected traceroute.
+  // Used for filtering map markers to only show nodes in the active
+  // traceroute. Guards/semantics mirror the selectedNodeTraceroute memo
+  // above: forward and return legs are gated independently (a return-only
+  // traceroute — empty `route`, populated `routeBack`/`snrBack` — still
+  // frames/filters its return-leg nodes, matching that it still renders
+  // return segments), so the marker filter always covers exactly the nodes
+  // whose segments the shared layer actually draws.
   const tracerouteNodeNums = useMemo(() => {
     // Only compute when showRoute is enabled and there's a selected node
     if (!showRoute || !selectedNodeId || selectedNodeId === currentNodeId) return null;
@@ -927,35 +884,31 @@ export function useTraceroutePaths({
 
     if (!selectedTrace) return null;
 
-    // Route-only presence guard — matches decomposeTraceroute's contract
-    // (the return leg is gated separately below; a forward-only traceroute
-    // renders and must therefore be framed/filtered too).
-    if (!selectedTrace.route || selectedTrace.route === 'null' || selectedTrace.route === '') {
-      return null;
-    }
+    const hasForwardRoute =
+      !!selectedTrace.route && selectedTrace.route !== 'null' && selectedTrace.route !== '';
 
     try {
-      const nodeNums = new Set<number>();
-
-      // Add the endpoints
-      nodeNums.add(selectedTrace.fromNodeNum);
-      nodeNums.add(selectedTrace.toNodeNum);
-
-      // Add intermediate nodes from forward route
-      const rawRouteForward = JSON.parse(selectedTrace.route);
-      const routeForward = (Array.isArray(rawRouteForward) ? rawRouteForward : []).filter(isValidRouteNode);
-      routeForward.forEach((num: number) => nodeNums.add(num));
-
-      // Add intermediate nodes from back route — only when a return path
-      // genuinely exists (#2051), matching the rendered return leg. The
-      // sanitized array is passed so the guard sees the same hops the
-      // renderer decomposes.
       let rawRouteBack: unknown = [];
       if (selectedTrace.routeBack && selectedTrace.routeBack !== 'null' && selectedTrace.routeBack !== '') {
         rawRouteBack = JSON.parse(selectedTrace.routeBack);
       }
       const routeBack = (Array.isArray(rawRouteBack) ? rawRouteBack : []).filter(isValidRouteNode);
-      if (hasReturnPath(routeBack, selectedTrace.snrBack)) {
+      const hasReturn = hasReturnPath(routeBack, selectedTrace.snrBack);
+
+      // Neither leg has data — decomposeTraceroute would render nothing.
+      if (!hasForwardRoute && !hasReturn) return null;
+
+      const nodeNums = new Set<number>();
+      nodeNums.add(selectedTrace.fromNodeNum);
+      nodeNums.add(selectedTrace.toNodeNum);
+
+      if (hasForwardRoute) {
+        const rawRouteForward = JSON.parse(selectedTrace.route);
+        const routeForward = (Array.isArray(rawRouteForward) ? rawRouteForward : []).filter(isValidRouteNode);
+        routeForward.forEach((num: number) => nodeNums.add(num));
+      }
+
+      if (hasReturn) {
         routeBack.forEach((num: number) => nodeNums.add(num));
       }
 

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -20,6 +20,7 @@ import {
   parseSnapshotRoutePositions,
   resolveSegmentPosition,
   decomposeTraceroute,
+  hasReturnPath,
   UNKNOWN_SNR_SENTINEL,
   type TracerouteRenderSegment,
 } from '../utils/tracerouteSegments';
@@ -255,40 +256,11 @@ const isValidRouteNode = (nodeNum: number): boolean => {
   return true;
 };
 
-/**
- * Parse routePositions JSON string into a position map
- * Returns empty object if parsing fails or data is missing
- */
-const parseRoutePositions = (routePositions?: string): Record<number, { lat: number; lng: number; alt?: number }> => {
-  if (!routePositions) return {};
-  try {
-    return JSON.parse(routePositions);
-  } catch {
-    return {};
-  }
-};
-
-/**
- * Get node position, preferring snapshot positions over current positions
- * This ensures historical traceroutes render where nodes were at the time
- */
-const getNodePositionWithSnapshot = (
-  nodeNum: number,
-  snapshotPositions: Record<number, { lat: number; lng: number; alt?: number }>,
-  nodesPositionDigest: NodePositionDigest[]
-): [number, number] | null => {
-  // Prefer historical snapshot position
-  const snapshot = snapshotPositions[nodeNum];
-  if (snapshot?.lat && snapshot?.lng) {
-    return [snapshot.lat, snapshot.lng];
-  }
-  // Fall back to current position
-  const node = nodesPositionDigest.find(n => n.nodeNum === nodeNum);
-  if (node?.position?.latitude && node?.position?.longitude) {
-    return [node.position.latitude, node.position.longitude];
-  }
-  return null;
-};
+// #1862 snapshot parsing + snapshot-then-live position resolution now go
+// through the shared `parseSnapshotRoutePositions`/`resolveSegmentPosition`
+// utils (src/utils/tracerouteSegments.ts) — the local `parseRoutePositions`/
+// `getNodePositionWithSnapshot` helpers (which had the lat/lng===0
+// truthy-check bug on the snapshot half) were deleted in #4047 P3 WP3.
 
 /**
  * Hook for computing and rendering traceroute paths on the map
@@ -940,7 +912,11 @@ export function useTraceroutePaths({
   }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.red, themeColors.blue, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions]);
 
   // Compute the set of node numbers involved in the selected traceroute
-  // Used for filtering map markers to only show nodes in the active traceroute
+  // Used for filtering map markers to only show nodes in the active traceroute.
+  // Guards/semantics deliberately mirror the selectedNodeTraceroute memo above
+  // (route-only presence guard; return-leg nodes gated by hasReturnPath —
+  // #2051; isValidRouteNode-sanitized hop arrays) so the marker filter always
+  // covers exactly the nodes whose segments the shared layer actually draws.
   const tracerouteNodeNums = useMemo(() => {
     // Only compute when showRoute is enabled and there's a selected node
     if (!showRoute || !selectedNodeId || selectedNodeId === currentNodeId) return null;
@@ -951,15 +927,10 @@ export function useTraceroutePaths({
 
     if (!selectedTrace) return null;
 
-    // Skip if the traceroute has null or invalid route data
-    if (
-      !selectedTrace.route ||
-      selectedTrace.route === 'null' ||
-      selectedTrace.route === '' ||
-      !selectedTrace.routeBack ||
-      selectedTrace.routeBack === 'null' ||
-      selectedTrace.routeBack === ''
-    ) {
+    // Route-only presence guard — matches decomposeTraceroute's contract
+    // (the return leg is gated separately below; a forward-only traceroute
+    // renders and must therefore be framed/filtered too).
+    if (!selectedTrace.route || selectedTrace.route === 'null' || selectedTrace.route === '') {
       return null;
     }
 
@@ -972,13 +943,21 @@ export function useTraceroutePaths({
 
       // Add intermediate nodes from forward route
       const rawRouteForward = JSON.parse(selectedTrace.route);
-      const routeForward = rawRouteForward.filter(isValidRouteNode);
+      const routeForward = (Array.isArray(rawRouteForward) ? rawRouteForward : []).filter(isValidRouteNode);
       routeForward.forEach((num: number) => nodeNums.add(num));
 
-      // Add intermediate nodes from back route
-      const rawRouteBack = JSON.parse(selectedTrace.routeBack);
-      const routeBack = rawRouteBack.filter(isValidRouteNode);
-      routeBack.forEach((num: number) => nodeNums.add(num));
+      // Add intermediate nodes from back route — only when a return path
+      // genuinely exists (#2051), matching the rendered return leg. The
+      // sanitized array is passed so the guard sees the same hops the
+      // renderer decomposes.
+      let rawRouteBack: unknown = [];
+      if (selectedTrace.routeBack && selectedTrace.routeBack !== 'null' && selectedTrace.routeBack !== '') {
+        rawRouteBack = JSON.parse(selectedTrace.routeBack);
+      }
+      const routeBack = (Array.isArray(rawRouteBack) ? rawRouteBack : []).filter(isValidRouteNode);
+      if (hasReturnPath(routeBack, selectedTrace.snrBack)) {
+        routeBack.forEach((num: number) => nodeNums.add(num));
+      }
 
       return nodeNums.size > 0 ? nodeNums : null;
     } catch (error) {
@@ -987,15 +966,18 @@ export function useTraceroutePaths({
     }
   }, [showRoute, selectedNodeId, currentNodeId, traceroutesDigest]);
 
-  // Compute bounding box of the selected traceroute for zoom-to-fit
+  // Compute bounding box of the selected traceroute for zoom-to-fit.
+  // Position resolution goes through the shared snapshot-then-live utils
+  // (typeof-based #1862 snapshot checks) — the same resolution the rendered
+  // segments use — so zoom-to-fit frames exactly what is drawn.
   const tracerouteBounds = useMemo((): [[number, number], [number, number]] | null => {
     if (!tracerouteNodeNums || tracerouteNodeNums.size === 0) return null;
 
-    // Parse snapshot positions from the selected traceroute
+    // Parse snapshot positions from the selected traceroute (#1862, shared util)
     const selectedTrace = traceroutesDigest.find(
       tr => tr.toNodeId === selectedNodeId || tr.fromNodeId === selectedNodeId
     );
-    const snapshotPositions = parseRoutePositions(selectedTrace?.routePositions);
+    const snapshotPositions = parseSnapshotRoutePositions(selectedTrace?.routePositions);
 
     let minLat = Infinity;
     let maxLat = -Infinity;
@@ -1004,7 +986,7 @@ export function useTraceroutePaths({
     let hasValidPositions = false;
 
     tracerouteNodeNums.forEach(nodeNum => {
-      const pos = getNodePositionWithSnapshot(nodeNum, snapshotPositions, nodesPositionDigest);
+      const pos = resolveSegmentPosition(nodeNum, snapshotPositions, liveNodePositions);
       if (pos) {
         hasValidPositions = true;
         minLat = Math.min(minLat, pos[0]);
@@ -1024,7 +1006,7 @@ export function useTraceroutePaths({
       [minLat - latPadding, minLng - lngPadding],
       [maxLat + latPadding, maxLng + lngPadding]
     ];
-  }, [tracerouteNodeNums, nodesPositionDigest, traceroutesDigest, selectedNodeId]);
+  }, [tracerouteNodeNums, liveNodePositions, traceroutesDigest, selectedNodeId]);
 
   return {
     traceroutePathsElements,

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -24,12 +24,17 @@ import {
   MQTT_DASH,
   type SnrColorScale,
 } from './mapHelpers';
+import { UNKNOWN_SNR_SENTINEL as CANONICAL_UNKNOWN_SNR_SENTINEL } from './tracerouteSegments';
 
 describe('mapHelpers', () => {
   describe('isUnknownSnr (issue #2859)', () => {
     it('returns true for the firmware INT8_MIN sentinel (-32 after /4 scaling)', () => {
       expect(isUnknownSnr(UNKNOWN_SNR_SENTINEL)).toBe(true);
       expect(isUnknownSnr(-32)).toBe(true);
+    });
+
+    it('mapHelpers.UNKNOWN_SNR_SENTINEL stays equal to the canonical tracerouteSegments.ts value (#4047 P3 WP2 — see mapHelpers.tsx comment for why this is a literal re-declaration, not a re-export)', () => {
+      expect(UNKNOWN_SNR_SENTINEL).toBe(CANONICAL_UNKNOWN_SNR_SENTINEL);
     });
 
     it('returns false for SNR=0 (protobuf default — was a false positive in 4.1.0)', () => {

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -10,7 +10,6 @@ import {
   UNKNOWN_SNR_SENTINEL,
   interpolateColor,
   getPositionHistoryColor,
-  getSegmentSnrColor,
   getSegmentSnrOpacity,
   getLineWeight,
   getTemporalOpacityMultiplier,
@@ -21,10 +20,15 @@ import {
   weightBySnr,
   weightByUsage,
   weightByOccurrence,
+  tracerouteSegmentWeight,
   MQTT_DASH,
   type SnrColorScale,
 } from './mapHelpers';
-import { UNKNOWN_SNR_SENTINEL as CANONICAL_UNKNOWN_SNR_SENTINEL } from './tracerouteSegments';
+import {
+  UNKNOWN_SNR_SENTINEL as CANONICAL_UNKNOWN_SNR_SENTINEL,
+  averageNonSentinelSnr,
+  type TracerouteRenderSegment,
+} from './tracerouteSegments';
 
 describe('mapHelpers', () => {
   describe('isUnknownSnr (issue #2859)', () => {
@@ -104,45 +108,23 @@ describe('mapHelpers', () => {
     });
   });
 
-  describe('getSegmentSnrColor (4-band, #4047 P3)', () => {
-    const colors: SnrColorScale = {
-      excellent: 'darkgreen',
-      good: 'green',
-      fair: 'orange',
-      poor: 'red',
-      noData: 'gray',
-    };
-
-    it('returns default when no SNR data', () => {
-      expect(getSegmentSnrColor(undefined, colors, 'default')).toBe('default');
-      expect(getSegmentSnrColor([], colors, 'default')).toBe('default');
+  describe('averageNonSentinelSnr', () => {
+    it('returns null when there are no samples', () => {
+      expect(averageNonSentinelSnr(undefined)).toBeNull();
+      expect(averageNonSentinelSnr([])).toBeNull();
     });
 
-    it('ignores unknown-SNR values when computing average', () => {
-      // All entries are unknown-sentinel; should fall back to default
-      expect(
-        getSegmentSnrColor([{ snr: UNKNOWN_SNR_SENTINEL }], colors, 'default')
-      ).toBe('default');
+    it('ignores unknown-SNR sentinel values when averaging', () => {
+      expect(averageNonSentinelSnr([{ snr: UNKNOWN_SNR_SENTINEL }])).toBeNull();
+      expect(averageNonSentinelSnr([{ snr: UNKNOWN_SNR_SENTINEL }, { snr: 10 }])).toBe(10);
     });
 
-    it('returns excellent color for avg SNR >= 5', () => {
-      expect(getSegmentSnrColor([{ snr: 5 }, { snr: 7 }], colors, 'default')).toBe('darkgreen');
-    });
-
-    it('returns good color for avg SNR in [0, 5)', () => {
-      expect(getSegmentSnrColor([{ snr: 3 }], colors, 'default')).toBe('green');
-    });
-
-    it('returns fair color for avg SNR in [-5, 0)', () => {
-      expect(getSegmentSnrColor([{ snr: -3 }], colors, 'default')).toBe('orange');
-    });
-
-    it('returns poor color for avg SNR < -5', () => {
-      expect(getSegmentSnrColor([{ snr: -15 }, { snr: -18 }], colors, 'default')).toBe('red');
+    it('averages multiple RF samples', () => {
+      expect(averageNonSentinelSnr([{ snr: 5 }, { snr: 7 }])).toBe(6);
     });
   });
 
-  describe('snrToColor (canonical 4-band SNR scale, #4047 P3)', () => {
+  describe('snrToColor (canonical 4-band SNR scale)', () => {
     const scale: SnrColorScale = {
       excellent: '#22c55e',
       good: '#eab308',
@@ -181,7 +163,7 @@ describe('mapHelpers', () => {
     });
   });
 
-  describe('weight strategies (#4047 P3 §2.2)', () => {
+  describe('weight strategies', () => {
     it('weightBySnr is the same function as getLineWeight', () => {
       expect(weightBySnr).toBe(getLineWeight);
       expect(weightBySnr(10)).toBeCloseTo(6, 5);
@@ -200,7 +182,33 @@ describe('mapHelpers', () => {
     });
   });
 
-  describe('MQTT_DASH (#4047 P3 §2.3)', () => {
+  describe('tracerouteSegmentWeight', () => {
+    const seg = (overrides: Partial<TracerouteRenderSegment> = {}): TracerouteRenderSegment => ({
+      key: 'forward:1-2',
+      from: [0, 0],
+      to: [1, 1],
+      fromNodeNum: 1,
+      toNodeNum: 2,
+      leg: 'forward',
+      avgSnr: null,
+      isMqtt: false,
+      ...overrides,
+    });
+
+    it('routes an MQTT segment through the sentinel (weight 2), not the "undefined" default (weight 3)', () => {
+      expect(tracerouteSegmentWeight(seg({ isMqtt: true, avgSnr: null }))).toBeCloseTo(2, 5);
+    });
+
+    it('uses weightBySnr(avgSnr) for a non-MQTT segment with real SNR', () => {
+      expect(tracerouteSegmentWeight(seg({ isMqtt: false, avgSnr: 10 }))).toBeCloseTo(6, 5);
+    });
+
+    it('falls back to the "no data" default (weight 3) for a non-MQTT segment with no SNR', () => {
+      expect(tracerouteSegmentWeight(seg({ isMqtt: false, avgSnr: null }))).toBe(3);
+    });
+  });
+
+  describe('MQTT_DASH', () => {
     it('is the canonical "3,6" dash pattern', () => {
       expect(MQTT_DASH).toBe('3,6');
     });

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -17,6 +17,12 @@ import {
   generateCurvedPath,
   generateHeadingAwarePath,
   generatePositionHistoryArrows,
+  snrToColor,
+  weightBySnr,
+  weightByUsage,
+  weightByOccurrence,
+  MQTT_DASH,
+  type SnrColorScale,
 } from './mapHelpers';
 
 describe('mapHelpers', () => {
@@ -93,31 +99,105 @@ describe('mapHelpers', () => {
     });
   });
 
-  describe('getSegmentSnrColor', () => {
-    const colors = { good: 'green', medium: 'yellow', poor: 'red' };
+  describe('getSegmentSnrColor (4-band, #4047 P3)', () => {
+    const colors: SnrColorScale = {
+      excellent: 'darkgreen',
+      good: 'green',
+      fair: 'orange',
+      poor: 'red',
+      noData: 'gray',
+    };
 
     it('returns default when no SNR data', () => {
-      expect(getSegmentSnrColor(undefined, colors, 'gray')).toBe('gray');
-      expect(getSegmentSnrColor([], colors, 'gray')).toBe('gray');
+      expect(getSegmentSnrColor(undefined, colors, 'default')).toBe('default');
+      expect(getSegmentSnrColor([], colors, 'default')).toBe('default');
     });
 
     it('ignores unknown-SNR values when computing average', () => {
       // All entries are unknown-sentinel; should fall back to default
       expect(
-        getSegmentSnrColor([{ snr: UNKNOWN_SNR_SENTINEL }], colors, 'gray')
-      ).toBe('gray');
+        getSegmentSnrColor([{ snr: UNKNOWN_SNR_SENTINEL }], colors, 'default')
+      ).toBe('default');
     });
 
-    it('returns good color for positive average SNR', () => {
-      expect(getSegmentSnrColor([{ snr: 5 }, { snr: 3 }], colors, 'gray')).toBe('green');
+    it('returns excellent color for avg SNR >= 5', () => {
+      expect(getSegmentSnrColor([{ snr: 5 }, { snr: 7 }], colors, 'default')).toBe('darkgreen');
     });
 
-    it('returns medium color for slightly negative SNR', () => {
-      expect(getSegmentSnrColor([{ snr: -5 }], colors, 'gray')).toBe('yellow');
+    it('returns good color for avg SNR in [0, 5)', () => {
+      expect(getSegmentSnrColor([{ snr: 3 }], colors, 'default')).toBe('green');
     });
 
-    it('returns poor color for very negative SNR', () => {
-      expect(getSegmentSnrColor([{ snr: -15 }, { snr: -18 }], colors, 'gray')).toBe('red');
+    it('returns fair color for avg SNR in [-5, 0)', () => {
+      expect(getSegmentSnrColor([{ snr: -3 }], colors, 'default')).toBe('orange');
+    });
+
+    it('returns poor color for avg SNR < -5', () => {
+      expect(getSegmentSnrColor([{ snr: -15 }, { snr: -18 }], colors, 'default')).toBe('red');
+    });
+  });
+
+  describe('snrToColor (canonical 4-band SNR scale, #4047 P3)', () => {
+    const scale: SnrColorScale = {
+      excellent: '#22c55e',
+      good: '#eab308',
+      fair: '#f97316',
+      poor: '#ef4444',
+      noData: '#6c7086',
+    };
+
+    it('returns noData for null/undefined', () => {
+      expect(snrToColor(null, scale)).toBe(scale.noData);
+      expect(snrToColor(undefined, scale)).toBe(scale.noData);
+    });
+
+    it('returns noData for the unknown-SNR sentinel', () => {
+      expect(snrToColor(UNKNOWN_SNR_SENTINEL, scale)).toBe(scale.noData);
+    });
+
+    it('returns excellent at and above the 5dB threshold', () => {
+      expect(snrToColor(5, scale)).toBe(scale.excellent);
+      expect(snrToColor(10, scale)).toBe(scale.excellent);
+    });
+
+    it('returns good in [0, 5)', () => {
+      expect(snrToColor(0, scale)).toBe(scale.good);
+      expect(snrToColor(4.9, scale)).toBe(scale.good);
+    });
+
+    it('returns fair in [-5, 0)', () => {
+      expect(snrToColor(-5, scale)).toBe(scale.fair);
+      expect(snrToColor(-0.1, scale)).toBe(scale.fair);
+    });
+
+    it('returns poor below -5', () => {
+      expect(snrToColor(-5.1, scale)).toBe(scale.poor);
+      expect(snrToColor(-20, scale)).toBe(scale.poor);
+    });
+  });
+
+  describe('weight strategies (#4047 P3 §2.2)', () => {
+    it('weightBySnr is the same function as getLineWeight', () => {
+      expect(weightBySnr).toBe(getLineWeight);
+      expect(weightBySnr(10)).toBeCloseTo(6, 5);
+    });
+
+    it('weightByUsage maps usage count to 2..8, capped at 8', () => {
+      expect(weightByUsage(0)).toBe(2);
+      expect(weightByUsage(3)).toBe(5);
+      expect(weightByUsage(100)).toBe(8);
+    });
+
+    it('weightByOccurrence maps occurrence count starting at 2, capped at 6', () => {
+      expect(weightByOccurrence(1)).toBeCloseTo(2, 5);
+      expect(weightByOccurrence(2)).toBeCloseTo(2.8, 5);
+      expect(weightByOccurrence(100)).toBeCloseTo(6, 5);
+    });
+  });
+
+  describe('MQTT_DASH (#4047 P3 §2.3)', () => {
+    it('is the canonical "3,6" dash pattern', () => {
+      expect(MQTT_DASH).toBe('3,6');
     });
   });
 

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -158,21 +158,47 @@ export const generateCurvedPath = (
 };
 
 /**
- * Get color for a route segment based on average SNR
- * Returns the appropriate color from the SNR gradient
+ * Canonical 4-band SNR color scale (theme-aware; hex values live in
+ * `overlayColors.snrColors`). Bands: excellent >=5dB, good >=0dB,
+ * fair >=-5dB, poor <-5dB, noData when unavailable/unknown. See #4047 P3.
+ */
+export interface SnrColorScale {
+  excellent: string;
+  good: string;
+  fair: string;
+  poor: string;
+  noData: string;
+}
+
+/**
+ * Map a single (already /4-scaled dB) average SNR value to its canonical
+ * 4-band color. `null`/`undefined`/the unknown-hop sentinel all resolve to
+ * `scale.noData`.
+ */
+export function snrToColor(avgSnr: number | null | undefined, scale: SnrColorScale): string {
+  if (avgSnr == null || isUnknownSnr(avgSnr)) return scale.noData;
+  if (avgSnr >= 5) return scale.excellent;
+  if (avgSnr >= 0) return scale.good;
+  if (avgSnr >= -5) return scale.fair;
+  return scale.poor;
+}
+
+/**
+ * Get color for a route segment based on average SNR (4-band, canonical).
+ * Averages non-sentinel samples then delegates to `snrToColor`. `defaultColor`
+ * is returned (rather than `scale.noData`) when there is no SNR data at all,
+ * preserving each caller's "no data" fallback (e.g. neighbor/mauve line color).
  */
 export const getSegmentSnrColor = (
   snrData: Array<{ snr: number }> | undefined,
-  snrColors: { good: string; medium: string; poor: string },
+  snrColors: SnrColorScale,
   defaultColor: string
 ): string => {
   if (!snrData || snrData.length === 0) return defaultColor;
   const rfSnrs = snrData.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
   if (rfSnrs.length === 0) return defaultColor;
   const avgSnr = rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length;
-  if (avgSnr > 0) return snrColors.good;
-  if (avgSnr >= -10) return snrColors.medium;
-  return snrColors.poor;
+  return snrToColor(avgSnr, snrColors);
 };
 
 /**
@@ -202,6 +228,31 @@ export const getLineWeight = (snr: number | undefined): number => {
   const normalized = Math.max(-20, Math.min(10, snr));
   return 2 + ((normalized + 20) / 30) * 4;
 };
+
+/**
+ * Canonical line-weight strategies (#4047 P3 §2.2). The three formulas are
+ * legitimately different data axes (SNR quality, usage count, occurrence
+ * count) — keep them as separate named exports rather than unifying.
+ */
+/** Weight by SNR quality (2..6). Alias of `getLineWeight` — same name/behavior. */
+export const weightBySnr = getLineWeight;
+
+/** Weight by per-segment usage count (NodesTab base layer). */
+export function weightByUsage(usage: number): number {
+  return Math.min(2 + usage, 8);
+}
+
+/** Weight by observed occurrence count (MapAnalysis). */
+export function weightByOccurrence(occ: number): number {
+  return 2 + Math.min(occ - 1, 5) * 0.8;
+}
+
+/**
+ * Canonical dash pattern for MQTT-bridged or all-unknown-SNR segments
+ * (#4047 P3 §2.3). Replaces the previously divergent `'5,10'` (Widget) and
+ * `'4,6'` (MapAnalysis) conventions.
+ */
+export const MQTT_DASH = '3,6';
 
 /**
  * Create arrow icon for direction indicators

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -5,19 +5,27 @@ import { PositionHistoryItem } from '../contexts/MapContext';
 import { convertSpeed } from './speedConversion';
 export { convertSpeed };
 
+// #2931 — the unknown-hop SNR sentinel now lives in the pure, leaflet-free
+// `tracerouteSegments.ts` (so useTracerouteAnalysis.ts and its tests don't
+// have to pull in this file's `leaflet`/`react-leaflet` imports). Re-exported
+// here for backward compatibility with existing importers (#4047 P3 WP2).
+import { isUnknownSnr } from './tracerouteSegments';
+export { isUnknownSnr };
+
 /**
- * Scaled SNR sentinel for unknown hops.
- * Raw Meshtastic value is INT8_MIN (-128), divided by 4 = -32.
- * Firmware writes this in TraceRouteModule::insertUnknownHops when a hop's
- * SNR can't be filled in: MQTT-bridged leg, decrypt failure, relay-role node,
- * or pre-snr-array firmware. It is NOT specifically an MQTT marker — the
- * firmware uses it as a generic "unknown SNR" sentinel.
+ * Scaled SNR sentinel for unknown hops. Canonical definition (with the full
+ * firmware-semantics doc comment) lives in `tracerouteSegments.ts`'s
+ * `UNKNOWN_SNR_SENTINEL` — this is a literal re-declaration, NOT
+ * `export { UNKNOWN_SNR_SENTINEL } from './tracerouteSegments'` or
+ * `export const UNKNOWN_SNR_SENTINEL = <imported identifier>`: both of those
+ * forms defeat eslint-plugin-react-refresh's `allowConstantExport` exception
+ * (which only recognizes an in-place *literal* initializer) and cascade into
+ * 18 false-positive `react-refresh/only-export-components` warnings across
+ * this file — verified empirically; re-exporting a *function* like
+ * `isUnknownSnr` above is unaffected. `mapHelpers.test.tsx` asserts this
+ * literal stays equal to the canonical value so the two can't silently drift.
  */
 export const UNKNOWN_SNR_SENTINEL = -32;
-
-/** Returns true if the scaled SNR value is the firmware unknown-hop sentinel */
-export const isUnknownSnr = (snr: number | undefined): boolean =>
-  snr === UNKNOWN_SNR_SENTINEL;
 
 // Constants for arrow generation
 const ARROW_DISTANCE_THRESHOLD = 0.05; // One arrow per 0.05 degrees

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -5,12 +5,12 @@ import { PositionHistoryItem } from '../contexts/MapContext';
 import { convertSpeed } from './speedConversion';
 export { convertSpeed };
 
-// #2931 — the unknown-hop SNR sentinel now lives in the pure, leaflet-free
+// #2931 — the unknown-hop SNR sentinel lives in the pure, leaflet-free
 // `tracerouteSegments.ts` (so useTracerouteAnalysis.ts and its tests don't
 // have to pull in this file's `leaflet`/`react-leaflet` imports). Re-exported
-// here for backward compatibility with existing importers (#4047 P3 WP2).
-import { isUnknownSnr } from './tracerouteSegments';
-export { isUnknownSnr };
+// here for backward compatibility with existing importers.
+import { isUnknownSnr, averageNonSentinelSnr, type TracerouteRenderSegment } from './tracerouteSegments';
+export { isUnknownSnr, averageNonSentinelSnr };
 
 /**
  * Scaled SNR sentinel for unknown hops. Canonical definition (with the full
@@ -168,7 +168,7 @@ export const generateCurvedPath = (
 /**
  * Canonical 4-band SNR color scale (theme-aware; hex values live in
  * `overlayColors.snrColors`). Bands: excellent >=5dB, good >=0dB,
- * fair >=-5dB, poor <-5dB, noData when unavailable/unknown. See #4047 P3.
+ * fair >=-5dB, poor <-5dB, noData when unavailable/unknown.
  */
 export interface SnrColorScale {
   excellent: string;
@@ -190,24 +190,6 @@ export function snrToColor(avgSnr: number | null | undefined, scale: SnrColorSca
   if (avgSnr >= -5) return scale.fair;
   return scale.poor;
 }
-
-/**
- * Get color for a route segment based on average SNR (4-band, canonical).
- * Averages non-sentinel samples then delegates to `snrToColor`. `defaultColor`
- * is returned (rather than `scale.noData`) when there is no SNR data at all,
- * preserving each caller's "no data" fallback (e.g. neighbor/mauve line color).
- */
-export const getSegmentSnrColor = (
-  snrData: Array<{ snr: number }> | undefined,
-  snrColors: SnrColorScale,
-  defaultColor: string
-): string => {
-  if (!snrData || snrData.length === 0) return defaultColor;
-  const rfSnrs = snrData.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
-  if (rfSnrs.length === 0) return defaultColor;
-  const avgSnr = rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length;
-  return snrToColor(avgSnr, snrColors);
-};
 
 /**
  * Get opacity for a route segment based on SNR quality
@@ -238,9 +220,9 @@ export const getLineWeight = (snr: number | undefined): number => {
 };
 
 /**
- * Canonical line-weight strategies (#4047 P3 §2.2). The three formulas are
- * legitimately different data axes (SNR quality, usage count, occurrence
- * count) — keep them as separate named exports rather than unifying.
+ * Canonical line-weight strategies. The three formulas are legitimately
+ * different data axes (SNR quality, usage count, occurrence count) — keep
+ * them as separate named exports rather than unifying.
  */
 /** Weight by SNR quality (2..6). Alias of `getLineWeight` — same name/behavior. */
 export const weightBySnr = getLineWeight;
@@ -256,9 +238,19 @@ export function weightByOccurrence(occ: number): number {
 }
 
 /**
- * Canonical dash pattern for MQTT-bridged or all-unknown-SNR segments
- * (#4047 P3 §2.3). Replaces the previously divergent `'5,10'` (Widget) and
- * `'4,6'` (MapAnalysis) conventions.
+ * Canonical SNR-based weight for a decomposed traceroute segment (NodesTab
+ * selected layer, TracerouteWidget). An MQTT/unknown-SNR segment is routed
+ * through the sentinel value rather than `undefined` so it gets the "known
+ * unknown" weight `weightBySnr` produces for the sentinel, not the different
+ * weight it produces for its "no data supplied at all" default.
+ */
+export function tracerouteSegmentWeight(seg: TracerouteRenderSegment): number {
+  return weightBySnr(seg.isMqtt ? UNKNOWN_SNR_SENTINEL : (seg.avgSnr ?? undefined));
+}
+
+/**
+ * Canonical dash pattern for MQTT-bridged or all-unknown-SNR segments.
+ * Applied by the shared render layer's `dashMode: 'mqtt-unknown'` (default).
  */
 export const MQTT_DASH = '3,6';
 

--- a/src/utils/tracerouteSegments.test.ts
+++ b/src/utils/tracerouteSegments.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Runs in the default node environment — tracerouteSegments.ts is pure and
+ * leaflet-free (#4047 P3 WP2).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  UNKNOWN_SNR_SENTINEL,
+  isUnknownSnr,
+  parseSnapshotRoutePositions,
+  resolveSegmentPosition,
+  hasReturnPath,
+  decomposeTraceroute,
+  type TracerouteDecomposeInput,
+} from './tracerouteSegments';
+
+describe('isUnknownSnr / UNKNOWN_SNR_SENTINEL (#2931, re-homed from mapHelpers)', () => {
+  it('is -32 (firmware INT8_MIN / 4)', () => {
+    expect(UNKNOWN_SNR_SENTINEL).toBe(-32);
+  });
+
+  it('treats -32 as unknown', () => {
+    expect(isUnknownSnr(-32)).toBe(true);
+  });
+
+  it('treats 0 (protobuf default) as NOT unknown', () => {
+    expect(isUnknownSnr(0)).toBe(false);
+  });
+
+  it('treats undefined as NOT unknown', () => {
+    expect(isUnknownSnr(undefined)).toBe(false);
+  });
+});
+
+describe('parseSnapshotRoutePositions (#1862)', () => {
+  it('returns an empty map for null/undefined/empty input', () => {
+    expect(parseSnapshotRoutePositions(undefined).size).toBe(0);
+    expect(parseSnapshotRoutePositions(null).size).toBe(0);
+    expect(parseSnapshotRoutePositions('').size).toBe(0);
+  });
+
+  it('returns an empty map for malformed JSON', () => {
+    expect(parseSnapshotRoutePositions('{not json').size).toBe(0);
+  });
+
+  it('parses a valid snapshot into a nodeNum -> [lat,lng] map', () => {
+    const snap = JSON.stringify({
+      100: { lat: 10.5, lng: 20.5 },
+      200: { lat: -5, lng: -10, alt: 123 },
+    });
+    const result = parseSnapshotRoutePositions(snap);
+    expect(result.get(100)).toEqual([10.5, 20.5]);
+    expect(result.get(200)).toEqual([-5, -10]);
+  });
+
+  it('skips entries missing lat or lng', () => {
+    const snap = JSON.stringify({
+      100: { lat: 10.5 }, // missing lng
+      200: { lng: 20.5 }, // missing lat
+      300: { lat: 1, lng: 2 },
+    });
+    const result = parseSnapshotRoutePositions(snap);
+    expect(result.has(100)).toBe(false);
+    expect(result.has(200)).toBe(false);
+    expect(result.get(300)).toEqual([1, 2]);
+  });
+
+  it('handles lat/lng of exactly 0 correctly (typeof-number check, not truthy)', () => {
+    // Regression guard for the 3-way diff finding: two of the three
+    // pre-existing implementations used a truthy `snapshot?.lat && snapshot?.lng`
+    // check that silently dropped nodes sitting exactly on lat=0 or lng=0.
+    const snap = JSON.stringify({ 100: { lat: 0, lng: 0 } });
+    const result = parseSnapshotRoutePositions(snap);
+    expect(result.get(100)).toEqual([0, 0]);
+  });
+});
+
+describe('resolveSegmentPosition', () => {
+  it('prefers the snapshot position over the live position', () => {
+    const snapshot = new Map<number, [number, number]>([[1, [1, 1]]]);
+    const live = new Map<number, [number, number]>([[1, [9, 9]]]);
+    expect(resolveSegmentPosition(1, snapshot, live)).toEqual([1, 1]);
+  });
+
+  it('falls back to the live position when the snapshot has no entry', () => {
+    const snapshot = new Map<number, [number, number]>();
+    const live = new Map<number, [number, number]>([[1, [9, 9]]]);
+    expect(resolveSegmentPosition(1, snapshot, live)).toEqual([9, 9]);
+  });
+
+  it('returns null when neither has an entry', () => {
+    const snapshot = new Map<number, [number, number]>();
+    const live = new Map<number, [number, number]>();
+    expect(resolveSegmentPosition(1, snapshot, live)).toBeNull();
+  });
+});
+
+describe('hasReturnPath (#2051)', () => {
+  it('is true when routeBack has hops, regardless of snrBack', () => {
+    expect(hasReturnPath([123], null)).toBe(true);
+    expect(hasReturnPath([123], '[]')).toBe(true);
+    expect(hasReturnPath([123], [])).toBe(true);
+  });
+
+  it('is false for empty routeBack and no snrBack data (string form)', () => {
+    expect(hasReturnPath([], null)).toBe(false);
+    expect(hasReturnPath([], undefined)).toBe(false);
+    expect(hasReturnPath([], '')).toBe(false);
+    expect(hasReturnPath([], 'null')).toBe(false);
+    expect(hasReturnPath([], '[]')).toBe(false);
+  });
+
+  it('is true for empty routeBack but non-empty snrBack (string form) — genuine direct RF hop', () => {
+    expect(hasReturnPath([], '[32]')).toBe(true);
+  });
+
+  it('is false for empty routeBack and empty snrBack (array form)', () => {
+    expect(hasReturnPath([], [])).toBe(false);
+  });
+
+  it('is true for empty routeBack but non-empty snrBack (array form)', () => {
+    expect(hasReturnPath([], [32])).toBe(true);
+  });
+});
+
+describe('decomposeTraceroute', () => {
+  const resolvePosition = (nodeNum: number): [number, number] | null => {
+    const table: Record<number, [number, number]> = {
+      100: [10, 10],
+      150: [15, 15],
+      200: [20, 20],
+    };
+    return table[nodeNum] ?? null;
+  };
+
+  it('returns [] when route data is entirely absent (failed traceroute)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: null,
+      routeBack: '[]',
+    };
+    expect(decomposeTraceroute(tr, { resolvePosition })).toEqual([]);
+  });
+
+  it('builds a direct forward-only segment when there is no return path', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40]), // 10 dB
+      snrBack: '[]',
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      key: 'forward:100-200',
+      from: [10, 10],
+      to: [20, 20],
+      leg: 'forward',
+      avgSnr: 10,
+      isMqtt: false,
+    });
+  });
+
+  it('omits the fictitious return segment for empty routeBack + empty snrBack (#2051)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: JSON.stringify([150]),
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40, 32]),
+      snrBack: '[]',
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    // Forward: 100->150, 150->200. No return segments at all.
+    expect(segments.every((s) => s.leg === 'forward')).toBe(true);
+    expect(segments.map((s) => s.key)).toEqual(['forward:100-150', 'forward:150-200']);
+  });
+
+  it('draws the return segment when snrBack has data despite empty routeBack (#2051)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40]),
+      snrBack: JSON.stringify([28]), // 7 dB
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    const ret = segments.find((s) => s.leg === 'return');
+    expect(ret).toBeDefined();
+    expect(ret).toMatchObject({
+      key: 'return:200-100',
+      from: [20, 20],
+      to: [10, 10],
+      avgSnr: 7,
+      isMqtt: false,
+    });
+  });
+
+  it('draws the return leg when routeBack is populated, walking it in reverse order', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: JSON.stringify([150]),
+      routeBack: JSON.stringify([150]),
+      snrTowards: JSON.stringify([40, 32]),
+      snrBack: JSON.stringify([36, 24]),
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    const returnSegs = segments.filter((s) => s.leg === 'return');
+    expect(returnSegs.map((s) => s.key)).toEqual(['return:200-150', 'return:150-100']);
+    expect(returnSegs[0].avgSnr).toBe(9); // 36/4
+    expect(returnSegs[1].avgSnr).toBe(6); // 24/4
+  });
+
+  it('maps the firmware unknown-SNR sentinel (raw -128) to isMqtt=true and avgSnr=null (#2931)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: JSON.stringify([-128]),
+      snrBack: JSON.stringify([-128]),
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments).toHaveLength(2);
+    for (const seg of segments) {
+      expect(seg.avgSnr).toBeNull();
+      expect(seg.isMqtt).toBe(true);
+    }
+  });
+
+  it('distinguishes a missing SNR sample (avgSnr=null, isMqtt=false) from the sentinel (avgSnr=null, isMqtt=true)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: '[]', // no SNR sample at all for the one hop
+      snrBack: '[]',
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments).toHaveLength(1);
+    expect(segments[0].avgSnr).toBeNull();
+    expect(segments[0].isMqtt).toBe(false);
+  });
+
+  it('/4-scales raw firmware SNR values', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: JSON.stringify([20]), // raw 20 -> 5 dB
+      snrBack: '[]',
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments[0].avgSnr).toBe(5);
+  });
+
+  it('skips a hop segment when either endpoint fails to resolve a position', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 999, // not in the resolvePosition table
+      route: '[]',
+      routeBack: '[]',
+    };
+    expect(decomposeTraceroute(tr, { resolvePosition })).toEqual([]);
+  });
+
+  it('carries the traceroute timestamp (or createdAt fallback) onto every segment', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrBack: '[1]',
+      timestamp: 12345,
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments.every((s) => s.timestamp === 12345)).toBe(true);
+
+    const trFallback: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      createdAt: 999,
+    };
+    const segmentsFallback = decomposeTraceroute(trFallback, { resolvePosition });
+    expect(segmentsFallback[0].timestamp).toBe(999);
+  });
+});

--- a/src/utils/tracerouteSegments.test.ts
+++ b/src/utils/tracerouteSegments.test.ts
@@ -6,8 +6,10 @@ import { describe, it, expect } from 'vitest';
 import {
   UNKNOWN_SNR_SENTINEL,
   isUnknownSnr,
+  isValidRouteNode,
   parseSnapshotRoutePositions,
   resolveSegmentPosition,
+  buildLiveNodePositionMap,
   hasReturnPath,
   decomposeTraceroute,
   type TracerouteDecomposeInput,
@@ -291,5 +293,123 @@ describe('decomposeTraceroute', () => {
     };
     const segmentsFallback = decomposeTraceroute(trFallback, { resolvePosition });
     expect(segmentsFallback[0].timestamp).toBe(999);
+  });
+
+  it('builds return-only segments when the forward route is absent but a return path exists (review F1)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: null,
+      routeBack: JSON.stringify([150]),
+      snrBack: JSON.stringify([36, 24]),
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments.every((s) => s.leg === 'return')).toBe(true);
+    expect(segments.map((s) => s.key)).toEqual(['return:200-150', 'return:150-100']);
+  });
+
+  it('returns [] when both the forward route and the return path are absent', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: null,
+      routeBack: null,
+    };
+    expect(decomposeTraceroute(tr, { resolvePosition })).toEqual([]);
+  });
+
+  it('filters reserved/placeholder node numbers out of the route, joining adjacent segments across the removed hop (review F2)', () => {
+    const resolveWithExtra = (nodeNum: number): [number, number] | null =>
+      nodeNum === 175 ? [17, 17] : resolvePosition(nodeNum);
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      // 4 hops: 100->150, 150->65535 (placeholder), 65535->175, 175->200
+      route: JSON.stringify([150, 65535, 175]),
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40, -128, 28, 20]),
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition: resolveWithExtra });
+    expect(segments.map((s) => s.key)).toEqual([
+      'forward:100-150',
+      'forward:150-175',
+      'forward:175-200',
+    ]);
+    // The dropped hop's own arrival SNR (-128, index 1) is discarded with it —
+    // the surviving joined segment keeps 175's OWN arrival SNR (28, index 2),
+    // not the removed node's.
+    const joined = segments.find((s) => s.key === 'forward:150-175');
+    expect(joined).toMatchObject({ fromNodeNum: 150, toNodeNum: 175, avgSnr: 7, isMqtt: false });
+  });
+
+  it('carries fromNodeNum/toNodeNum hop identity on every segment (review F5)', () => {
+    const tr: TracerouteDecomposeInput = {
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: JSON.stringify([150]),
+      routeBack: JSON.stringify([150]),
+      snrTowards: JSON.stringify([40, 32]),
+      snrBack: JSON.stringify([36, 24]),
+    };
+    const segments = decomposeTraceroute(tr, { resolvePosition });
+    expect(segments.map((s) => [s.fromNodeNum, s.toNodeNum])).toEqual([
+      [100, 150],
+      [150, 200],
+      [200, 150],
+      [150, 100],
+    ]);
+  });
+});
+
+describe('isValidRouteNode (single home, review F2)', () => {
+  it.each([0, 1, 2, 3, 255, 65535, 4294967295])('rejects reserved/broadcast node %i', (n) => {
+    expect(isValidRouteNode(n)).toBe(false);
+  });
+
+  it.each([4, 100, 65534, 4294967294])('accepts real node numbers %i', (n) => {
+    expect(isValidRouteNode(n)).toBe(true);
+  });
+});
+
+describe('buildLiveNodePositionMap (review F9)', () => {
+  it('builds a nodeNum -> [lat,lng] map via the extractor', () => {
+    const items = [
+      { id: 1, lat: 10, lng: 20 },
+      { id: 2, lat: -5, lng: 15 },
+    ];
+    const map = buildLiveNodePositionMap(items, (i) => ({ nodeNum: i.id, lat: i.lat, lng: i.lng }));
+    expect(map.get(1)).toEqual([10, 20]);
+    expect(map.get(2)).toEqual([-5, 15]);
+  });
+
+  it('skips entries the extractor returns null for', () => {
+    const items = [{ id: 1, lat: 10, lng: 20 }];
+    const map = buildLiveNodePositionMap(items, () => null);
+    expect(map.size).toBe(0);
+  });
+
+  it('skips non-numeric or missing coordinates', () => {
+    const items: Array<{ id: number; lat: number | null | undefined; lng: number | null | undefined }> = [
+      { id: 1, lat: undefined, lng: 20 },
+      { id: 2, lat: null, lng: null },
+    ];
+    const map = buildLiveNodePositionMap(items, (i) => ({ nodeNum: i.id, lat: i.lat, lng: i.lng }));
+    expect(map.size).toBe(0);
+  });
+
+  it('keeps a legitimate single-axis-zero position (equator or prime meridian)', () => {
+    const items = [
+      { id: 1, lat: 0, lng: 20 },
+      { id: 2, lat: 10, lng: 0 },
+    ];
+    const map = buildLiveNodePositionMap(items, (i) => ({ nodeNum: i.id, lat: i.lat, lng: i.lng }));
+    expect(map.get(1)).toEqual([0, 20]);
+    expect(map.get(2)).toEqual([10, 0]);
+  });
+
+  it('drops the (0,0) Null Island placeholder', () => {
+    const items = [{ id: 1, lat: 0, lng: 0 }];
+    const map = buildLiveNodePositionMap(items, (i) => ({ nodeNum: i.id, lat: i.lat, lng: i.lng }));
+    expect(map.has(1)).toBe(false);
   });
 });

--- a/src/utils/tracerouteSegments.ts
+++ b/src/utils/tracerouteSegments.ts
@@ -1,0 +1,298 @@
+/**
+ * Shared traceroute decomposition utilities (#4047 P3 WP2).
+ *
+ * Pure, React-free, leaflet-free — safe to import from anywhere (including
+ * node-env tests) without pulling in `window`/`leaflet`. This is the SINGLE
+ * home for three previously-duplicated behaviors:
+ *   - #1862 — snapshot route positions (render historical traceroutes where
+ *     nodes were at capture time, not where they are now).
+ *   - #2051 — the empty-routeBack guard (don't draw a fictitious direct
+ *     return line when the return path hasn't been recorded yet).
+ *   - #2931 — the firmware unknown-SNR sentinel (MQTT-bridged / relay-role /
+ *     decrypt-failure hops report a sentinel value, not a real SNR reading).
+ *
+ * `src/utils/mapHelpers.tsx` re-exports `UNKNOWN_SNR_SENTINEL`/`isUnknownSnr`
+ * from here for backward compatibility with existing importers — this file
+ * is the canonical definition site (moved out of mapHelpers.tsx in WP2 so
+ * that `useTracerouteAnalysis.ts` and its tests don't have to pull in
+ * mapHelpers.tsx's leaflet import just for the sentinel).
+ */
+
+// ---------------------------------------------------------------------------
+// #2931 — unknown-hop SNR sentinel (canonical home, re-exported by mapHelpers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scaled SNR sentinel for unknown hops.
+ * Raw Meshtastic value is INT8_MIN (-128), divided by 4 = -32.
+ * Firmware writes this in TraceRouteModule::insertUnknownHops when a hop's
+ * SNR can't be filled in: MQTT-bridged leg, decrypt failure, relay-role node,
+ * or pre-snr-array firmware. It is NOT specifically an MQTT marker — the
+ * firmware uses it as a generic "unknown SNR" sentinel.
+ */
+export const UNKNOWN_SNR_SENTINEL = -32;
+
+/** Returns true if the scaled SNR value is the firmware unknown-hop sentinel */
+export const isUnknownSnr = (snr: number | undefined): boolean =>
+  snr === UNKNOWN_SNR_SENTINEL;
+
+// ---------------------------------------------------------------------------
+// #1862 — snapshot route positions
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `routePositions` JSON snapshot stored on a traceroute row.
+ * Shape: `{ [nodeNum]: { lat, lng, alt? } }`.
+ *
+ * **Three-way diff (#4047 P3 WP2, serena-verified 2026-07-10)** against the
+ * pre-existing per-consumer copies this replaces:
+ *   - `useTraceroutePaths.tsx` `parseRoutePositions`/`getNodePositionWithSnapshot`
+ *   - `TracerouteWidget.tsx` inline snapshot parse + `getNodePosition`
+ *   - `DashboardMap.tsx` `parseRoutePositions` + inline `lookup`
+ *
+ * Findings:
+ *   1. **Stored field names are identical everywhere** — `{lat, lng, alt?}`.
+ *      No field-name divergence in the snapshot JSON itself.
+ *   2. **Presence-check divergence (behavior difference, fixed here):**
+ *      useTraceroutePaths and the Widget test snapshot presence with
+ *      `snapshot?.lat && snapshot?.lng` (truthy check) — a node sitting
+ *      exactly on the equator or prime meridian (`lat===0` or `lng===0`)
+ *      would silently fail that check and fall through to the live position
+ *      instead of its stored snapshot. DashboardMap uses
+ *      `typeof snap.lat === 'number' && typeof snap.lng === 'number'`, which
+ *      handles `0` correctly. This function adopts DashboardMap's (correct)
+ *      `typeof`-based check — a deliberate latent-bug fix, not a silent
+ *      regression, but callers should be aware the two truthy-check
+ *      consumers (NodesTab base+selected via useTraceroutePaths, Widget)
+ *      will very slightly change behavior for nodes at exactly lat/lng 0
+ *      once WP3/WP4 adopt this function.
+ *   3. **Live-position fallback source differs per consumer** (out of scope
+ *      for this function — it only resolves the snapshot half). Each
+ *      consumer's live-node shape differs (a pre-built digest array, a raw
+ *      `Map`/node lookup supporting both `latitudeI/longitudeI` integer and
+ *      `latitude/longitude` float forms, or an already-normalized position
+ *      map) so `resolveSegmentPosition` below deliberately takes an
+ *      already-normalized `Map<number,[number,number]>` for the live side —
+ *      callers pre-normalize their own node source into that shape.
+ */
+export function parseSnapshotRoutePositions(
+  routePositions: string | null | undefined,
+): Map<number, [number, number]> {
+  const result = new Map<number, [number, number]>();
+  if (!routePositions) return result;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(routePositions);
+  } catch {
+    return result;
+  }
+  if (!parsed || typeof parsed !== 'object') return result;
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    const nodeNum = Number(key);
+    if (!Number.isFinite(nodeNum)) continue;
+    const entry = value as { lat?: unknown; lng?: unknown } | null;
+    if (entry && typeof entry.lat === 'number' && typeof entry.lng === 'number') {
+      result.set(nodeNum, [entry.lat, entry.lng]);
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolve a hop's render position, preferring the historical snapshot
+ * (#1862) over the live position. Both maps are expected to already be
+ * normalized to `[lat, lng]` tuples — normalizing a consumer's own live-node
+ * shape (digest array, raw node map with `latitudeI/longitudeI` vs
+ * `latitude/longitude`, etc.) is the caller's job, not this function's.
+ */
+export function resolveSegmentPosition(
+  nodeNum: number,
+  snapshot: Map<number, [number, number]>,
+  liveNodes: Map<number, [number, number]>,
+): [number, number] | null {
+  return snapshot.get(nodeNum) ?? liveNodes.get(nodeNum) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// #2051 — empty-routeBack guard
+// ---------------------------------------------------------------------------
+
+/**
+ * True only when a return path genuinely exists — i.e. either `routeBack`
+ * has intermediate hops, or `snrBack` carries actual data. When
+ * MeshMonitor is connected to the traceroute's target node, it can observe
+ * its own outgoing RESPONSE before relay nodes have populated `routeBack`;
+ * naively building `[to, ...routeBack, from]` in that window draws a
+ * fictitious direct return line. (Issues #1140, #3622, #2051.)
+ *
+ * `snrBack` accepts either the raw JSON string as stored on the traceroute
+ * row (checked against `''`/`'null'`/`'[]'`) or an already-parsed array
+ * (checked by length) — the two pre-existing per-consumer implementations
+ * this replaces (Widget: string form; useTracerouteAnalysis: parsed-array
+ * form) used one or the other, so this accepts both. Widened to also accept
+ * `undefined` (not just `null`) since traceroute rows commonly type
+ * `snrBack` as optional.
+ */
+export function hasReturnPath(
+  routeBack: number[],
+  snrBack: string | number[] | null | undefined,
+): boolean {
+  if (routeBack.length > 0) return true;
+  if (snrBack == null) return false;
+  if (typeof snrBack === 'string') {
+    return snrBack !== '' && snrBack !== 'null' && snrBack !== '[]';
+  }
+  return snrBack.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Per-traceroute decomposition
+// ---------------------------------------------------------------------------
+
+export interface TracerouteRenderSegment {
+  key: string;
+  from: [number, number];              // lat,lng — already snapshot-resolved
+  to: [number, number];
+  leg: 'forward' | 'return' | 'neutral';
+  direction?: 'inbound' | 'outbound' | 'neutral'; // MapAnalysis relative-to-selection
+  avgSnr: number | null;               // /4-scaled dB; null = no data
+  isMqtt: boolean;                      // per-hop sentinel (#2931), NOT node.viaMqtt
+  usageCount?: number;                  // weightByUsage
+  occurrences?: number;                 // weightByOccurrence
+  timestamp?: number;                   // temporal fade
+  snrSamples?: { snr: number; timestamp?: number }[]; // popup/chart + array color/opacity
+}
+
+/**
+ * Minimal traceroute row shape `decomposeTraceroute` needs. A structural
+ * subset of `TracerouteDigest` (useTraceroutePaths.tsx) so callers can pass
+ * their existing traceroute records without an adapter.
+ */
+export interface TracerouteDecomposeInput {
+  fromNodeNum: number;
+  toNodeNum: number;
+  route?: string | null;
+  routeBack?: string | null;
+  snrTowards?: string | null;
+  snrBack?: string | null;
+  timestamp?: number;
+  createdAt?: number;
+}
+
+export interface DecomposeTracerouteOptions {
+  /** Resolve a hop's node number to a render position, or null if unknown
+   *  (the segment touching that hop is skipped, matching all three
+   *  pre-existing renderers' "only push a segment when both endpoints
+   *  resolve" behavior). Typically `(n) => resolveSegmentPosition(n, snapshot, liveNodes)`. */
+  resolvePosition: (nodeNum: number) => [number, number] | null;
+}
+
+/** `JSON.parse` a route/hop array, tolerating null/'null'/'' (all -> []). */
+function parseHopArray(json: string | null | undefined): number[] {
+  if (!json || json === 'null' || json === '') return [];
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.map((n) => Number(n)) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** True when `route` carries actual (possibly empty-array) route data, as
+ *  opposed to being entirely absent/failed. */
+function hasRouteData(route: string | null | undefined): boolean {
+  return route != null && route !== 'null' && route !== '';
+}
+
+function buildLegSegments(
+  leg: 'forward' | 'return',
+  sequence: number[],
+  snrRaw: number[],
+  timestamp: number | undefined,
+  resolvePosition: (nodeNum: number) => [number, number] | null,
+): TracerouteRenderSegment[] {
+  const segments: TracerouteRenderSegment[] = [];
+  for (let i = 0; i < sequence.length - 1; i++) {
+    const fromNum = sequence[i];
+    const toNum = sequence[i + 1];
+    const fromPos = resolvePosition(fromNum);
+    const toPos = resolvePosition(toNum);
+    if (!fromPos || !toPos) continue;
+
+    // SNR at index i is measured at the receiver of hop i (fullPath[i+1]).
+    const rawSnr = i < snrRaw.length ? snrRaw[i] : undefined;
+    const scaledSnr = rawSnr === undefined ? undefined : rawSnr / 4;
+    const isMqtt = scaledSnr !== undefined && isUnknownSnr(scaledSnr);
+    const avgSnr = scaledSnr === undefined || isMqtt ? null : scaledSnr;
+
+    segments.push({
+      key: `${leg}:${fromNum}-${toNum}`,
+      from: fromPos,
+      to: toPos,
+      leg,
+      avgSnr,
+      isMqtt,
+      timestamp,
+    });
+  }
+  return segments;
+}
+
+/**
+ * Decompose one traceroute record into per-hop forward + return render
+ * segments. Consumers (NodesTab base/selected, Widget, Dashboard) call this
+ * once per traceroute then apply their own cross-traceroute aggregation
+ * (dedup, usage counting, zoom-adaptive filtering — data-side, per §4 of the
+ * P3 spec) on top; this function does NOT aggregate across multiple
+ * traceroute records.
+ *
+ * - Forward leg: `[fromNodeNum, ...route, toNodeNum]` with `snrTowards`,
+ *   matching the existing convention shared by useTraceroutePaths/Widget/
+ *   DashboardMap (NOT the `useTracerouteAnalysis` requester/responder
+ *   convention, which is a separate, untouched data hook — see #4047 P3 §3.1
+ *   migration nuance).
+ * - Return leg: only emitted when `hasReturnPath` is true (#2051); sequence
+ *   `[toNodeNum, ...routeBack, fromNodeNum]` with `snrBack`.
+ * - A whole-traceroute guard mirrors the pre-existing "skip if route is
+ *   entirely absent" behavior (`!tr.route`/`'null'`/`''`) — but, unlike
+ *   useTraceroutePaths' current top-level guard, does NOT also require
+ *   `routeBack` to be a valid non-empty string; the return leg is gated
+ *   solely by `hasReturnPath`. This is intentional: it's the correct,
+ *   unified fix for #2051 (the old NodesTab renderer had no `hasReturnPath`
+ *   guard at all and could draw a fictitious direct return line; the old
+ *   "skip whole traceroute if routeBack missing" guard was a blunt
+ *   workaround for a related but distinct case).
+ *
+ * `key` embeds the leg + hop node numbers (`"forward:123-456"`) since
+ * `TracerouteRenderSegment` intentionally has no separate node-num fields
+ * (per spec §3.1) — consumers that need to build their own cross-traceroute
+ * node-pair aggregation key can parse it back out of `key`.
+ */
+export function decomposeTraceroute(
+  traceroute: TracerouteDecomposeInput,
+  opts: DecomposeTracerouteOptions,
+): TracerouteRenderSegment[] {
+  if (!hasRouteData(traceroute.route)) return [];
+
+  const route = parseHopArray(traceroute.route);
+  const routeBack = parseHopArray(traceroute.routeBack);
+  const snrTowards = parseHopArray(traceroute.snrTowards);
+  const snrBack = parseHopArray(traceroute.snrBack);
+  const timestamp = traceroute.timestamp ?? traceroute.createdAt;
+
+  const segments: TracerouteRenderSegment[] = [];
+
+  const forwardSequence = [traceroute.fromNodeNum, ...route, traceroute.toNodeNum];
+  segments.push(
+    ...buildLegSegments('forward', forwardSequence, snrTowards, timestamp, opts.resolvePosition),
+  );
+
+  if (hasReturnPath(routeBack, traceroute.snrBack)) {
+    const backSequence = [traceroute.toNodeNum, ...routeBack, traceroute.fromNodeNum];
+    segments.push(
+      ...buildLegSegments('return', backSequence, snrBack, timestamp, opts.resolvePosition),
+    );
+  }
+
+  return segments;
+}

--- a/src/utils/tracerouteSegments.ts
+++ b/src/utils/tracerouteSegments.ts
@@ -1,21 +1,24 @@
 /**
- * Shared traceroute decomposition utilities (#4047 P3 WP2).
+ * Shared traceroute decomposition utilities.
  *
  * Pure, React-free, leaflet-free — safe to import from anywhere (including
  * node-env tests) without pulling in `window`/`leaflet`. This is the SINGLE
- * home for three previously-duplicated behaviors:
+ * home for four previously-duplicated behaviors:
  *   - #1862 — snapshot route positions (render historical traceroutes where
  *     nodes were at capture time, not where they are now).
  *   - #2051 — the empty-routeBack guard (don't draw a fictitious direct
  *     return line when the return path hasn't been recorded yet).
  *   - #2931 — the firmware unknown-SNR sentinel (MQTT-bridged / relay-role /
  *     decrypt-failure hops report a sentinel value, not a real SNR reading).
+ *   - reserved/broadcast node-number filtering (route arrays can contain
+ *     firmware placeholder values for a relay-role hop that never resolved
+ *     its identity; segments touching them join across, not gap).
  *
  * `src/utils/mapHelpers.tsx` re-exports `UNKNOWN_SNR_SENTINEL`/`isUnknownSnr`
- * from here for backward compatibility with existing importers — this file
- * is the canonical definition site (moved out of mapHelpers.tsx in WP2 so
- * that `useTracerouteAnalysis.ts` and its tests don't have to pull in
- * mapHelpers.tsx's leaflet import just for the sentinel).
+ * from here for backward compatibility with existing importers. This file
+ * stays leaflet-free on purpose so `useTracerouteAnalysis.ts` and its tests
+ * don't have to pull in `mapHelpers.tsx`'s leaflet import just for the
+ * sentinel — don't add a leaflet/react-leaflet import here.
  */
 
 // ---------------------------------------------------------------------------
@@ -36,6 +39,42 @@ export const UNKNOWN_SNR_SENTINEL = -32;
 export const isUnknownSnr = (snr: number | undefined): boolean =>
   snr === UNKNOWN_SNR_SENTINEL;
 
+/**
+ * Average SNR across samples, ignoring the unknown-hop sentinel (#2931).
+ * Returns `null` when there are no samples, or every sample was the
+ * sentinel (no real RF data to average).
+ */
+export function averageNonSentinelSnr(samples: Array<{ snr: number }> | undefined): number | null {
+  if (!samples || samples.length === 0) return null;
+  const rfSnrs = samples.filter((s) => !isUnknownSnr(s.snr)).map((s) => s.snr);
+  if (rfSnrs.length === 0) return null;
+  return rfSnrs.reduce((sum, v) => sum + v, 0) / rfSnrs.length;
+}
+
+// ---------------------------------------------------------------------------
+// Reserved/broadcast node-number filtering
+// ---------------------------------------------------------------------------
+
+const BROADCAST_ADDR = 4294967295;
+
+/**
+ * True for a real, renderable node number — false for firmware reserved or
+ * placeholder values that can appear inside a route/routeBack hop array:
+ *   - `<= 3` — reserved
+ *   - `255` (0xff) — reserved
+ *   - `65535` (0xffff) — invalid placeholder
+ *   - `4294967295` (0xffffffff) — broadcast address
+ * Single home for this predicate — hop-array filtering lives inside
+ * `decomposeTraceroute`/`buildLegSegments` below.
+ */
+export function isValidRouteNode(nodeNum: number): boolean {
+  if (nodeNum <= 3) return false;
+  if (nodeNum === 255) return false;
+  if (nodeNum === 65535) return false;
+  if (nodeNum === BROADCAST_ADDR) return false;
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // #1862 — snapshot route positions
 // ---------------------------------------------------------------------------
@@ -44,36 +83,10 @@ export const isUnknownSnr = (snr: number | undefined): boolean =>
  * Parse the `routePositions` JSON snapshot stored on a traceroute row.
  * Shape: `{ [nodeNum]: { lat, lng, alt? } }`.
  *
- * **Three-way diff (#4047 P3 WP2, serena-verified 2026-07-10)** against the
- * pre-existing per-consumer copies this replaces:
- *   - `useTraceroutePaths.tsx` `parseRoutePositions`/`getNodePositionWithSnapshot`
- *   - `TracerouteWidget.tsx` inline snapshot parse + `getNodePosition`
- *   - `DashboardMap.tsx` `parseRoutePositions` + inline `lookup`
- *
- * Findings:
- *   1. **Stored field names are identical everywhere** — `{lat, lng, alt?}`.
- *      No field-name divergence in the snapshot JSON itself.
- *   2. **Presence-check divergence (behavior difference, fixed here):**
- *      useTraceroutePaths and the Widget test snapshot presence with
- *      `snapshot?.lat && snapshot?.lng` (truthy check) — a node sitting
- *      exactly on the equator or prime meridian (`lat===0` or `lng===0`)
- *      would silently fail that check and fall through to the live position
- *      instead of its stored snapshot. DashboardMap uses
- *      `typeof snap.lat === 'number' && typeof snap.lng === 'number'`, which
- *      handles `0` correctly. This function adopts DashboardMap's (correct)
- *      `typeof`-based check — a deliberate latent-bug fix, not a silent
- *      regression, but callers should be aware the two truthy-check
- *      consumers (NodesTab base+selected via useTraceroutePaths, Widget)
- *      will very slightly change behavior for nodes at exactly lat/lng 0
- *      once WP3/WP4 adopt this function.
- *   3. **Live-position fallback source differs per consumer** (out of scope
- *      for this function — it only resolves the snapshot half). Each
- *      consumer's live-node shape differs (a pre-built digest array, a raw
- *      `Map`/node lookup supporting both `latitudeI/longitudeI` integer and
- *      `latitude/longitude` float forms, or an already-normalized position
- *      map) so `resolveSegmentPosition` below deliberately takes an
- *      already-normalized `Map<number,[number,number]>` for the live side —
- *      callers pre-normalize their own node source into that shape.
+ * Presence is checked with `typeof === 'number'`, not a truthy check — a
+ * node sitting exactly on the equator or prime meridian (`lat===0` or
+ * `lng===0`) must still resolve to its stored snapshot position rather than
+ * silently falling through to the live position.
  */
 export function parseSnapshotRoutePositions(
   routePositions: string | null | undefined,
@@ -111,6 +124,34 @@ export function resolveSegmentPosition(
   liveNodes: Map<number, [number, number]>,
 ): [number, number] | null {
   return snapshot.get(nodeNum) ?? liveNodes.get(nodeNum) ?? null;
+}
+
+/**
+ * Build a `nodeNum -> [lat, lng]` map from a consumer's live node list.
+ * `extract` returns the node number and raw (possibly missing) coordinates
+ * for one item, or `null` to skip it entirely.
+ *
+ * Validity rule: coordinates must both be numbers AND must not be exactly
+ * `(0, 0)` — a single axis at exactly 0 (equator or prime meridian) is a
+ * legitimate position and is kept; the `(0, 0)` pair specifically is treated
+ * as an uninitialized/Null-Island placeholder and dropped. This deliberately
+ * differs from (and fixes) a truthy `lat && lng` check, which would also
+ * drop the legitimate single-axis-zero case.
+ */
+export function buildLiveNodePositionMap<T>(
+  items: Iterable<T>,
+  extract: (item: T) => { nodeNum: number; lat: number | null | undefined; lng: number | null | undefined } | null,
+): Map<number, [number, number]> {
+  const map = new Map<number, [number, number]>();
+  for (const item of items) {
+    const entry = extract(item);
+    if (!entry) continue;
+    const { nodeNum, lat, lng } = entry;
+    if (typeof lat !== 'number' || typeof lng !== 'number') continue;
+    if (lat === 0 && lng === 0) continue;
+    map.set(nodeNum, [lat, lng]);
+  }
+  return map;
 }
 
 // ---------------------------------------------------------------------------
@@ -153,6 +194,9 @@ export interface TracerouteRenderSegment {
   key: string;
   from: [number, number];              // lat,lng — already snapshot-resolved
   to: [number, number];
+  /** Hop node numbers this segment connects, in traversal order (from -> to). */
+  fromNodeNum: number;
+  toNodeNum: number;
   leg: 'forward' | 'return' | 'neutral';
   direction?: 'inbound' | 'outbound' | 'neutral'; // MapAnalysis relative-to-selection
   avgSnr: number | null;               // /4-scaled dB; null = no data
@@ -187,7 +231,12 @@ export interface DecomposeTracerouteOptions {
   resolvePosition: (nodeNum: number) => [number, number] | null;
 }
 
-/** `JSON.parse` a route/hop array, tolerating null/'null'/'' (all -> []). */
+/** `JSON.parse` a route/hop/SNR array, tolerating null/'null'/'' (all -> []).
+ *  Deliberately does NOT filter node validity — this parses both node-number
+ *  arrays (route/routeBack) and SNR-sample arrays (snrTowards/snrBack), and
+ *  filtering only applies to the former. Node filtering happens in
+ *  `buildLegSegments`, where it can stay index-aligned with the paired SNR
+ *  sample instead of shifting it. */
 function parseHopArray(json: string | null | undefined): number[] {
   if (!json || json === 'null' || json === '') return [];
   try {
@@ -204,23 +253,58 @@ function hasRouteData(route: string | null | undefined): boolean {
   return route != null && route !== 'null' && route !== '';
 }
 
+/** One raw hop paired with the SNR observed arriving at it, before any
+ *  node-validity filtering — keeping the pairing lets a hop be dropped
+ *  without shifting its neighbors' SNR samples out of alignment. */
+interface HopEntry {
+  nodeNum: number;
+  /** Already-scaled by caller? No — raw firmware int (dB x4); undefined for
+   *  the leg's start (nothing "arrives" there) or a missing array entry. */
+  snr: number | undefined;
+}
+
 function buildLegSegments(
   leg: 'forward' | 'return',
-  sequence: number[],
+  startNum: number,
+  intermediateHops: number[],
+  endNum: number,
   snrRaw: number[],
   timestamp: number | undefined,
   resolvePosition: (nodeNum: number) => [number, number] | null,
 ): TracerouteRenderSegment[] {
+  // Pair every raw hop (including the end endpoint) with its own arrival SNR
+  // by index BEFORE filtering, then drop invalid/reserved intermediate hops.
+  // Endpoints (index 0 and the last index) are never filtered — they're real
+  // device node numbers, not raw route placeholders. This preserves index
+  // alignment between a hop and its SNR sample even when hops in between are
+  // dropped: adjacent segments join across the removed hop, carrying the
+  // correct arrival SNR for the surviving side.
+  const hops: HopEntry[] = [
+    { nodeNum: startNum, snr: undefined },
+    ...intermediateHops.map((nodeNum, idx): HopEntry => ({
+      nodeNum,
+      snr: idx < snrRaw.length ? snrRaw[idx] : undefined,
+    })),
+    {
+      nodeNum: endNum,
+      snr: intermediateHops.length < snrRaw.length ? snrRaw[intermediateHops.length] : undefined,
+    },
+  ];
+  const filtered = hops.filter(
+    (h, idx) => idx === 0 || idx === hops.length - 1 || isValidRouteNode(h.nodeNum),
+  );
+
   const segments: TracerouteRenderSegment[] = [];
-  for (let i = 0; i < sequence.length - 1; i++) {
-    const fromNum = sequence[i];
-    const toNum = sequence[i + 1];
+  for (let i = 0; i < filtered.length - 1; i++) {
+    const fromNum = filtered[i].nodeNum;
+    const toNum = filtered[i + 1].nodeNum;
     const fromPos = resolvePosition(fromNum);
     const toPos = resolvePosition(toNum);
     if (!fromPos || !toPos) continue;
 
-    // SNR at index i is measured at the receiver of hop i (fullPath[i+1]).
-    const rawSnr = i < snrRaw.length ? snrRaw[i] : undefined;
+    // SNR arriving at the segment's `to` end is what firmware recorded for
+    // this hop (see HopEntry above).
+    const rawSnr = filtered[i + 1].snr;
     const scaledSnr = rawSnr === undefined ? undefined : rawSnr / 4;
     const isMqtt = scaledSnr !== undefined && isUnknownSnr(scaledSnr);
     const avgSnr = scaledSnr === undefined || isMqtt ? null : scaledSnr;
@@ -229,6 +313,8 @@ function buildLegSegments(
       key: `${leg}:${fromNum}-${toNum}`,
       from: fromPos,
       to: toPos,
+      fromNodeNum: fromNum,
+      toNodeNum: toNum,
       leg,
       avgSnr,
       isMqtt,
@@ -242,55 +328,59 @@ function buildLegSegments(
  * Decompose one traceroute record into per-hop forward + return render
  * segments. Consumers (NodesTab base/selected, Widget, Dashboard) call this
  * once per traceroute then apply their own cross-traceroute aggregation
- * (dedup, usage counting, zoom-adaptive filtering — data-side, per §4 of the
- * P3 spec) on top; this function does NOT aggregate across multiple
- * traceroute records.
+ * (dedup, usage counting, zoom-adaptive filtering — data-side) on top; this
+ * function does NOT aggregate across multiple traceroute records.
  *
  * - Forward leg: `[fromNodeNum, ...route, toNodeNum]` with `snrTowards`,
  *   matching the existing convention shared by useTraceroutePaths/Widget/
  *   DashboardMap (NOT the `useTracerouteAnalysis` requester/responder
- *   convention, which is a separate, untouched data hook — see #4047 P3 §3.1
- *   migration nuance).
+ *   convention, which is a separate, untouched data hook). Gated solely by
+ *   `hasRouteData(traceroute.route)`.
  * - Return leg: only emitted when `hasReturnPath` is true (#2051); sequence
- *   `[toNodeNum, ...routeBack, fromNodeNum]` with `snrBack`.
- * - A whole-traceroute guard mirrors the pre-existing "skip if route is
- *   entirely absent" behavior (`!tr.route`/`'null'`/`''`) — but, unlike
- *   useTraceroutePaths' current top-level guard, does NOT also require
- *   `routeBack` to be a valid non-empty string; the return leg is gated
- *   solely by `hasReturnPath`. This is intentional: it's the correct,
- *   unified fix for #2051 (the old NodesTab renderer had no `hasReturnPath`
- *   guard at all and could draw a fictitious direct return line; the old
- *   "skip whole traceroute if routeBack missing" guard was a blunt
- *   workaround for a related but distinct case).
+ *   `[toNodeNum, ...routeBack, fromNodeNum]` with `snrBack`. Gated
+ *   independently of the forward leg — a traceroute with no forward `route`
+ *   but a populated `routeBack`/`snrBack` still yields return segments (and
+ *   vice versa); the two legs are not coupled to a single whole-traceroute
+ *   guard.
  *
- * `key` embeds the leg + hop node numbers (`"forward:123-456"`) since
- * `TracerouteRenderSegment` intentionally has no separate node-num fields
- * (per spec §3.1) — consumers that need to build their own cross-traceroute
- * node-pair aggregation key can parse it back out of `key`.
+ * `key` embeds the leg + hop node numbers (`"forward:123-456"`).
  */
 export function decomposeTraceroute(
   traceroute: TracerouteDecomposeInput,
   opts: DecomposeTracerouteOptions,
 ): TracerouteRenderSegment[] {
-  if (!hasRouteData(traceroute.route)) return [];
-
-  const route = parseHopArray(traceroute.route);
-  const routeBack = parseHopArray(traceroute.routeBack);
-  const snrTowards = parseHopArray(traceroute.snrTowards);
-  const snrBack = parseHopArray(traceroute.snrBack);
   const timestamp = traceroute.timestamp ?? traceroute.createdAt;
-
   const segments: TracerouteRenderSegment[] = [];
 
-  const forwardSequence = [traceroute.fromNodeNum, ...route, traceroute.toNodeNum];
-  segments.push(
-    ...buildLegSegments('forward', forwardSequence, snrTowards, timestamp, opts.resolvePosition),
-  );
-
-  if (hasReturnPath(routeBack, traceroute.snrBack)) {
-    const backSequence = [traceroute.toNodeNum, ...routeBack, traceroute.fromNodeNum];
+  if (hasRouteData(traceroute.route)) {
+    const route = parseHopArray(traceroute.route);
+    const snrTowards = parseHopArray(traceroute.snrTowards);
     segments.push(
-      ...buildLegSegments('return', backSequence, snrBack, timestamp, opts.resolvePosition),
+      ...buildLegSegments(
+        'forward',
+        traceroute.fromNodeNum,
+        route,
+        traceroute.toNodeNum,
+        snrTowards,
+        timestamp,
+        opts.resolvePosition,
+      ),
+    );
+  }
+
+  const routeBack = parseHopArray(traceroute.routeBack);
+  if (hasReturnPath(routeBack, traceroute.snrBack)) {
+    const snrBack = parseHopArray(traceroute.snrBack);
+    segments.push(
+      ...buildLegSegments(
+        'return',
+        traceroute.toNodeNum,
+        routeBack,
+        traceroute.fromNodeNum,
+        snrBack,
+        timestamp,
+        opts.resolvePosition,
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary

Phase 3 of the Map Consolidation epic (#4047), targeting `4049-map-refactor`. Replaces the **five independent traceroute renderers** (3 SNR color scales, 4 dash conventions, 3 weight formulas) with one canonical convention set and one shared render layer. This was the epic's headline divergence — fixes like #1862/#2051/#2931 previously had to be hand-copied into up to three files each; they now live once, with tests.

## Changes

**New shared modules**
- `src/utils/tracerouteSegments.ts` — leaflet-free, node-testable single home for the traceroute decomposition invariants: snapshot positions (#1862, now `typeof`-safe at lat/lng 0), fictitious-return guard (#2051, forward/return gated independently), unknown-SNR sentinel (#2931), reserved-node filtering, `/4` SNR scaling, live-position map builder, non-sentinel averaging.
- `src/components/map/layers/TraceroutePathsLayer.tsx` — the one render layer: 4 color modes (SNR / direction / fixed-leg / fixed, + `mqttColor`), 3 weight strategies (usage / SNR / occurrence), canonical `'3,6'` MQTT-or-unknown dash, straight/curved geometry (number-or-function curvature), arrows, temporal fade, hover highlight, popup/click render-props. `React.memo`'d, single-pass resolution.

**Canonical conventions** — 4-band theme-aware SNR scale (≥5/≥0/≥-5, WCAG-AA-checked light palette) in `overlayColors.snrColors`; one weight API; one dash convention; MQTT segments get the `mqttSegment` theme color on **every** map (previously NodesTab-only).

**All four renderers migrated** — NodesTab base+selected (data logic — dedup, usage aggregation, zoom-adaptive filtering, recharts popups — preserved verbatim), DashboardMap (two-pass over the shared layer), TracerouteWidget, MapAnalysis (thin adapter; legend SNR section now reads the canonical palette).

**Latent bugs fixed** — Dashboard colored segments by **un-scaled** SNR (÷4 missing) and never rendered return legs; snapshot/live positions silently dropped nodes at exactly lat 0 or lng 0.

**Review hardening** — an 8-angle review + verification pass produced 10 findings (2 introduced regressions caught and fixed before merge: return-only traceroutes rendering nothing; widget MQTT hop weight); all 10 fixed. Segments now carry `fromNodeNum`/`toNodeNum` (no stringly-typed key parsing); dead `getSegmentSnrColor` deleted; duplicated fallback palette and live-position builders consolidated.

### Approved visible changes
- Nodes map: 3-band → 4-band SNR colors; no-data segments render noData-gray dashed (was solid mauve); selected-route dash now MQTT/unknown-only.
- Dashboard: gains return legs; MQTT segments colored + dashed; colors corrected by the ÷4 fix.
- Widget: legs use the theme traceroute color (direction via arrows) instead of hardcoded green/blue.
- Map Analysis: dash `'4,6'` → `'3,6'`; MQTT segments get the canonical color.

## Issues Resolved
Relates to #4047 (Phase 3 of 7). Consolidates the fix-sites of #1862, #2051, #2931.

## Documentation Updates
- `MAP_CONSOLIDATION_P3_SPEC.md` (design + gate amendments), epic doc Phase 3 log.

## Testing
- [x] Full Vitest suite: success:true — 9,431 tests / 0 failures (JSON reporter); 60 new tests across `tracerouteSegments.test.ts` + `TraceroutePathsLayer.test.tsx`
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] Browser-validated on the dev container against pre-migration baseline screenshots, all four surfaces: Nodes map (328 segments, canonical palette, usage weights, live `mqttSegment` color), Dashboard (canonical palette + overlay pass), Map Analysis (1,555 paths, curved, legend matches map, click-select resolves endpoints/SNR), widget (theme legs, SNR weights, arrows). No new console errors.
- [ ] Reviewer: the visible-changes list above is the intended new canonical look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub