### PR TITLE
fix(api): require sourceId on security reads, wire SecurityTab (Phase 2c)

### DIFF
--- a/src/components/SecurityTab.tsx
+++ b/src/components/SecurityTab.tsx
@@ -5,7 +5,7 @@ import api from '../services/api';
 import { TabType } from '../types/ui';
 import { getHardwareModelName } from '../utils/hardwareModel';
 import { logger } from '../utils/logger';
-import { useSource } from '../contexts/SourceContext';
+import { useResolvedSourceId } from '../hooks/useResolvedSourceId';
 import '../styles/SecurityTab.css';
 
 interface SecurityNode {
@@ -79,7 +79,9 @@ interface SecurityTabProps {
 export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectDMNode, setNewMessage }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
-  const { sourceId } = useSource();
+  // Resolve a concrete sourceId (context source, else the primary) — the
+  // security endpoints are source-scoped and now require one.
+  const sourceId = useResolvedSourceId();
   const [issues, setIssues] = useState<SecurityIssuesResponse | null>(null);
   const [scannerStatus, setScannerStatus] = useState<ScannerStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -106,8 +108,10 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
   const canWrite = hasPermission('security', 'write');
 
   const fetchSecurityData = async () => {
+    // Defer until a sourceId resolves — the security endpoints require one.
+    if (!sourceId) return;
     try {
-      const srcParam = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+      const srcParam = `?sourceId=${encodeURIComponent(sourceId)}`;
       const [issuesData, statusData, mismatchData, deadNodesData] = await Promise.all([
         api.get<SecurityIssuesResponse>(`/api/security/issues${srcParam}`),
         api.get<ScannerStatus>(`/api/security/scanner/status${srcParam}`),

--- a/src/server/routes/securityRoutes.test.ts
+++ b/src/server/routes/securityRoutes.test.ts
@@ -202,6 +202,18 @@ describe('securityRoutes — per-source scanner', () => {
     });
   });
 
+  describe('source-scoped reads require a sourceId', () => {
+    it.each(['/api/security/issues', '/api/security/export', '/api/security/key-mismatches'])(
+      '%s 400s MISSING_SOURCE_ID when sourceId omitted',
+      async (path) => {
+        const app = createApp();
+        const res = await request(app).get(path);
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('MISSING_SOURCE_ID');
+      }
+    );
+  });
+
   describe('INVALID_SOURCE_TYPE guards', () => {
     beforeEach(() => {
       // Register both a meshtastic and a meshcore source stub.

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -11,6 +11,7 @@ import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { isMeshtasticManager } from '../sourceManagerTypes.js';
 import type { MeshtasticManager } from '../meshtasticManager.js';
 import { fail } from '../utils/apiResponse.js';
+import { requireSourceId } from '../utils/requireSourceId.js';
 import { duplicateKeySchedulerService } from '../services/duplicateKeySchedulerService.js';
 import { securityDigestService } from '../services/securityDigestService.js';
 import { logger } from '../../utils/logger.js';
@@ -21,7 +22,7 @@ const router = Router();
 router.use(requirePermission('security', 'read'));
 
 // Get all nodes with security issues
-router.get('/issues', async (req: Request, res: Response) => {
+router.get('/issues', requireSourceId('query'), async (req: Request, res: Response) => {
   try {
     const secSourceId = req.query.sourceId as string | undefined;
     const nodesWithKeyIssues = await databaseService.getNodesWithKeySecurityIssuesAsync(secSourceId);
@@ -196,7 +197,7 @@ router.post(
 );
 
 // Export security issues
-router.get('/export', async (req: Request, res: Response) => {
+router.get('/export', requireSourceId('query'), async (req: Request, res: Response) => {
   try {
     const format = req.query.format as string || 'csv';
     const exportSourceId = req.query.sourceId as string | undefined;
@@ -333,7 +334,7 @@ router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), asy
  * GET /api/security/key-mismatches
  * Returns recent key mismatch events from the repair log
  */
-router.get('/key-mismatches', async (req: Request, res: Response) => {
+router.get('/key-mismatches', requireSourceId('query'), async (req: Request, res: Response) => {
   try {
     // Scope to the requested source so the repair log doesn't leak events from
     // every source into one source's view (same class as the dead-nodes bug).


### PR DESCRIPTION
## Summary

Phase 2c — the Security dashboard is source-scoped (it only applies to Meshtastic/MQTT sources), so make it *sourcey like everything else*.

### Backend — require `sourceId` (400 `MISSING_SOURCE_ID`)
The source-scoped security reads used hand-rolled `sourceId ? eq(...) : <no filter>` ternaries that silently span all sources when omitted. Now require it:
- `GET /api/security/issues`
- `GET /api/security/export`
- `GET /api/security/key-mismatches`

`GET /api/security/scanner/status` **stays global** — it intentionally returns a per-source map when no sourceId is supplied.

### Frontend — SecurityTab
Now resolves a concrete sourceId via `useResolvedSourceId` (context source, else primary) and always sends it; the fetch is deferred until it resolves. One hook swap flows through every security call the tab makes (it already gated dead-nodes/scan on sourceId — this completes the pattern).

## Tests
- Parametrized 400-on-missing for issues/export/key-mismatches; existing scoped key-mismatches test unchanged. Server TSC clean; no new frontend TS errors.

## Follow-ups
- Channel writes (5 routes + components + ApiService), `security/nodes/:nodeNum/clear` (unscoped-write bug), Phase 3 (device ops), Phase 4 (v1 legacy + packets/:id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)