### PR TITLE
fix(api): require sourceId on channel-write routes, wire config callers (Phase 2d)

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next';
 import apiService from '../services/api';
 import { useToast } from './ToastContainer';
-import { useSource } from '../contexts/SourceContext';
+import { useResolvedSourceId } from '../hooks/useResolvedSourceId';
 import { MODEM_PRESET_OPTIONS, REGION_OPTIONS, FEM_LNA_MODE_OPTIONS } from './configuration/constants';
 import type { Channel } from '../types/device';
 import { ImportConfigModal } from './configuration/ImportConfigModal';
@@ -28,7 +28,9 @@ interface AdminCommandsTabProps {
 const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeId, channels: _channels = [], onChannelsUpdated: _onChannelsUpdated }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
-  const { sourceId } = useSource();
+  // Resolve a concrete sourceId (context source, else primary) — channel-write
+  // admin actions require one; other admin calls default to primary anyway.
+  const sourceId = useResolvedSourceId();
 
   // Use consolidated state hook for config-related state
   const {
@@ -3542,7 +3544,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       {/* Automatic Favorites Management Section (issue #2608) */}
       <AutoFavoriteManagementSection
         selectedNodeNum={selectedNodeNum}
-        sourceId={sourceId}
+        sourceId={sourceId ?? null}
         nodes={nodes}
       />
 

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -24,7 +24,7 @@ import { useToast } from '../ToastContainer';
 import { Channel } from '../../types/device';
 import { logger } from '../../utils/logger';
 import { useSettings } from '../../contexts/SettingsContext';
-import { useSource } from '../../contexts/SourceContext';
+import { useResolvedSourceId } from '../../hooks/useResolvedSourceId';
 import { formatPrecisionAccuracy } from '../../utils/distance';
 
 // Default public PSK (base64 encoded value of single byte 0x01)
@@ -145,7 +145,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { distanceUnit } = useSettings();
-  const { sourceId } = useSource();
+  // Channel writes require a concrete sourceId; resolve context source or primary.
+  const sourceId = useResolvedSourceId();
 
   // #3644: device channels whose PSK matches a server-side decryption (Channel
   // Database) entry under a DIFFERENT name. Messages on such a channel get filed

--- a/src/components/configuration/ExportConfigModal.tsx
+++ b/src/components/configuration/ExportConfigModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import QRCode from 'qrcode';
 import apiService from '../../services/api';
 import type { Channel } from '../../types/device';
-import { useSource } from '../../contexts/SourceContext';
+import { useResolvedSourceId } from '../../hooks/useResolvedSourceId';
 
 interface ExportConfigModalProps {
   isOpen: boolean;
@@ -25,7 +25,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
   isLoadingChannels = false
 }) => {
   const { t } = useTranslation();
-  const { sourceId } = useSource();
+  const sourceId = useResolvedSourceId();
   const [channels, setChannels] = useState<Channel[]>([]);
   const [selectedChannels, setSelectedChannels] = useState<Set<number>>(new Set());
   const [includeLoraConfig, setIncludeLoraConfig] = useState(true);

--- a/src/components/configuration/ImportConfigModal.tsx
+++ b/src/components/configuration/ImportConfigModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import apiService from '../../services/api';
-import { useSource } from '../../contexts/SourceContext';
+import { useResolvedSourceId } from '../../hooks/useResolvedSourceId';
 
 interface ImportConfigModalProps {
   isOpen: boolean;
@@ -58,7 +58,7 @@ const regionNames: { [key: number]: string } = {
 
 export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, onClose, onImportSuccess, nodeNum }) => {
   const { t } = useTranslation();
-  const { sourceId } = useSource();
+  const sourceId = useResolvedSourceId();
   const [url, setUrl] = useState('');
   const [decoded, setDecoded] = useState<DecodedConfig | null>(null);
   const [selectedChannels, setSelectedChannels] = useState<Set<number>>(new Set());

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -280,29 +280,52 @@ describe('GET /channels/:id/export', () => {
   });
 });
 
+describe('channel-write routes require a sourceId', () => {
+  it('PUT /channels/:id 400s MISSING_SOURCE_ID without sourceId', async () => {
+    const res = await request(app).put('/channels/1').send({ name: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
+  });
+  it('POST /channels/:slotId/import 400s MISSING_SOURCE_ID without sourceId', async () => {
+    const res = await request(app).post('/channels/1/import').send({ channel: { name: 'x' } });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
+  });
+  it('POST /channels/reorder 400s MISSING_SOURCE_ID without sourceId', async () => {
+    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 1, 2, 3, 4, 5, 6, 7] });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
+  });
+  it('POST /channels/import-config 400s MISSING_SOURCE_ID without sourceId', async () => {
+    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#x' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_SOURCE_ID');
+  });
+});
+
 describe('PUT /channels/:id', () => {
   it('rejects an out-of-range Meshtastic channel id', async () => {
-    const res = await request(app).put('/channels/9').send({ name: 'x' });
+    const res = await request(app).put('/channels/9').send({ name: 'x', sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('0-7');
   });
 
   it('rejects an over-long Meshtastic name (>11)', async () => {
     mockDb.channels.getChannelById.mockResolvedValue({ id: 1, name: 'old', psk: null });
-    const res = await request(app).put('/channels/1').send({ name: 'this-name-is-way-too-long' });
+    const res = await request(app).put('/channels/1').send({ name: 'this-name-is-way-too-long', sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('11 characters');
   });
 
   it('404s when updating a missing Meshtastic channel', async () => {
     mockDb.channels.getChannelById.mockResolvedValue(null);
-    const res = await request(app).put('/channels/1').send({ name: 'ok' });
+    const res = await request(app).put('/channels/1').send({ name: 'ok', sourceId: 'src-1' });
     expect(res.status).toBe(404);
   });
 
   it('updates an existing channel and pushes config to the device', async () => {
     mockDb.channels.getChannelById.mockResolvedValue({ id: 1, name: 'old', psk: 'AQ==', role: 2 });
-    const res = await request(app).put('/channels/1').send({ name: 'newname' });
+    const res = await request(app).put('/channels/1').send({ name: 'newname', sourceId: 'src-1' });
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(mockDb.channels.upsertChannel).toHaveBeenCalled();
@@ -371,20 +394,20 @@ describe('DELETE /channels/:id', () => {
 
 describe('POST /channels/:slotId/import', () => {
   it('rejects an invalid slot id', async () => {
-    const res = await request(app).post('/channels/9/import').send({ channel: { name: 'x' } });
+    const res = await request(app).post('/channels/9/import').send({ channel: { name: 'x' }, sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('0-7');
   });
 
   it('requires a channel object', async () => {
-    const res = await request(app).post('/channels/1/import').send({});
+    const res = await request(app).post('/channels/1/import').send({ sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Expected channel object');
   });
 
   it('imports a channel into the slot', async () => {
     mockDb.channels.getChannelById.mockResolvedValue({ id: 1, name: 'Imported' });
-    const res = await request(app).post('/channels/1/import').send({ channel: { name: 'Imported', psk: 'AQ==' } });
+    const res = await request(app).post('/channels/1/import').send({ channel: { name: 'Imported', psk: 'AQ==' }, sourceId: 'src-1' });
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(mockDb.channels.upsertChannel).toHaveBeenCalled();
@@ -393,18 +416,18 @@ describe('POST /channels/:slotId/import', () => {
 
 describe('POST /channels/reorder', () => {
   it('rejects a newOrder that is not 8 entries', async () => {
-    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 1, 2] });
+    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 1, 2], sourceId: 'src-1' });
     expect(res.status).toBe(400);
   });
 
   it('rejects a newOrder that is not a permutation of 0-7', async () => {
-    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 0, 1, 2, 3, 4, 5, 6] });
+    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 0, 1, 2, 3, 4, 5, 6], sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('exactly once');
   });
 
   it('returns requiresReboot:false for the identity order without touching the device', async () => {
-    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 1, 2, 3, 4, 5, 6, 7] });
+    const res = await request(app).post('/channels/reorder').send({ newOrder: [0, 1, 2, 3, 4, 5, 6, 7], sourceId: 'src-1' });
     expect(res.status).toBe(200);
     expect(res.body.requiresReboot).toBe(false);
     expect(mockManager.beginEditSettings).not.toHaveBeenCalled();
@@ -501,14 +524,14 @@ describe('POST /channels/decode-url', () => {
 
 describe('POST /channels/encode-url', () => {
   it('rejects a non-array channelIds', async () => {
-    const res = await request(app).post('/channels/encode-url').send({ channelIds: 'nope' });
+    const res = await request(app).post('/channels/encode-url').send({ channelIds: 'nope', sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('channelIds must be an array');
   });
 
   it('400s when no valid channels are selected', async () => {
     mockDb.channels.getChannelById.mockResolvedValue(null);
-    const res = await request(app).post('/channels/encode-url').send({ channelIds: [3] });
+    const res = await request(app).post('/channels/encode-url').send({ channelIds: [3], sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('No valid channels');
   });
@@ -516,7 +539,7 @@ describe('POST /channels/encode-url', () => {
   it('encodes the selected channels into a url', async () => {
     mockDb.channels.getChannelById.mockResolvedValue({ id: 0, name: 'Primary', psk: 'AQ==' });
     mockChannelUrlService.encodeUrl.mockReturnValue('https://meshtastic.org/e/#encoded');
-    const res = await request(app).post('/channels/encode-url').send({ channelIds: [0] });
+    const res = await request(app).post('/channels/encode-url').send({ channelIds: [0], sourceId: 'src-1' });
     expect(res.status).toBe(200);
     expect(res.body.url).toContain('meshtastic.org');
   });
@@ -524,14 +547,14 @@ describe('POST /channels/encode-url', () => {
 
 describe('POST /channels/import-config', () => {
   it('requires a url', async () => {
-    const res = await request(app).post('/channels/import-config').send({});
+    const res = await request(app).post('/channels/import-config').send({ sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('URL is required');
   });
 
   it('400s on an empty/invalid config url', async () => {
     mockChannelUrlService.decodeUrl.mockReturnValue(null);
-    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#x' });
+    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#x', sourceId: 'src-1' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Invalid or empty');
   });
@@ -541,7 +564,7 @@ describe('POST /channels/import-config', () => {
       channels: [{ name: 'A', psk: 'AQ==' }],
       loraConfig: { region: 1 },
     });
-    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#ok' });
+    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#ok', sourceId: 'src-1' });
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.imported.channels).toBe(1);

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -444,7 +444,7 @@ async function migrateMessagesIfChannelsMoved(
 }
 
 // Update a channel configuration
-router.put('/:id', requireAuth(), async (req: Request, res: Response) => {
+router.put('/:id', requireAuth(), requireSourceId('body'), async (req: Request, res: Response) => {
   try {
     const channelId = parseInt(req.params.id);
     if (isNaN(channelId) || channelId < 0) {
@@ -713,7 +713,7 @@ router.delete('/:id', requireAuth(), async (req: Request, res: Response) => {
 });
 
 // Import a channel configuration to a specific slot
-router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response) => {
+router.post('/:slotId/import', requireAuth(), requireSourceId('body'), async (req: Request, res: Response) => {
   try {
     const slotId = parseInt(req.params.slotId);
     if (isNaN(slotId) || slotId < 0 || slotId > 7) {
@@ -834,7 +834,7 @@ router.post('/:slotId/import', requireAuth(), async (req: Request, res: Response
 });
 
 // Reorder device channel slots (drag-and-drop)
-router.post('/reorder', requireAuth(), async (req: Request, res: Response) => {
+router.post('/reorder', requireAuth(), requireSourceId('body'), async (req: Request, res: Response) => {
   try {
     const { newOrder, sourceId: reorderSourceId } = req.body;
 
@@ -1010,7 +1010,7 @@ router.post('/decode-url', requirePermission('configuration', 'read'), async (re
 });
 
 // Encode current configuration to Meshtastic URL
-router.post('/encode-url', requirePermission('configuration', 'read'), async (req: Request, res: Response) => {
+router.post('/encode-url', requirePermission('configuration', 'read'), requireSourceId('body'), async (req: Request, res: Response) => {
   try {
     const { channelIds, includeLoraConfig, sourceId: encodeUrlSourceId } = req.body;
     const encodeUrlManager = resolveSourceManager(encodeUrlSourceId);
@@ -1091,7 +1091,7 @@ router.post('/encode-url', requirePermission('configuration', 'read'), async (re
 });
 
 // Import configuration from URL
-router.post('/import-config', requirePermission('configuration', 'write'), async (req: Request, res: Response) => {
+router.post('/import-config', requirePermission('configuration', 'write'), requireSourceId('body'), async (req: Request, res: Response) => {
   try {
     const { url: configUrl, sourceId: configSourceId } = req.body;
 


### PR DESCRIPTION
## Summary

Phase 2d — channel-config writes target a specific source's device, so require a `sourceId` (400 `MISSING_SOURCE_ID`) instead of silently defaulting to the primary source.

### Backend — require `sourceId('body')` on the five write routes
`PUT /api/channels/:id`, `POST /api/channels/:slotId/import`, `POST /api/channels/reorder`, `POST /api/channels/encode-url`, `POST /api/channels/import-config`. Uses the standalone middleware because `channelRoutes` tests mock `requirePermission` pass-through.

### Frontend — always send a resolved sourceId
Swapped `useSource → useResolvedSourceId` in the callers:
- `ChannelsConfigSection`, `ImportConfigModal`, `ExportConfigModal` (fully channel-scoped)
- `AdminCommandsTab` — all its `sourceId` uses are `...(sourceId ? {sourceId} : {})`, and the backend already defaulted a missing one to primary via `resolveSourceManager`, so the whole-swap only makes the target explicit (no behavior change beyond the now-required channel writes). Fixed one `string|null` prop typing.

## Tests
- `MISSING_SOURCE_ID` 400 coverage for the write routes; existing write-route payloads updated to send a sourceId.
- **Full Vitest suite green (16,898 passed, 0 failed);** server + my frontend files TSC clean; lint ratchet unaffected.

## Remaining
- `security/nodes/:nodeNum/clear` (unscoped-write bug), Phase 3 (device send-ops), Phase 4 (v1 legacy mounts + `packets/:id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)