### PR TITLE
fix(api): scope security node-clear to a required sourceId

### DIFF
--- a/src/server/routes/securityRoutes.test.ts
+++ b/src/server/routes/securityRoutes.test.ts
@@ -18,9 +18,10 @@ vi.mock('../../services/database.js', () => ({
     getNodesWithExcessivePacketsAsync: vi.fn().mockResolvedValue([]),
     getNodesWithTimeOffsetIssuesAsync: vi.fn().mockResolvedValue([]),
     getTopBroadcastersAsync: vi.fn().mockResolvedValue([]),
-    nodes: { getAllNodes: vi.fn().mockResolvedValue([]), getNode: vi.fn() },
+    nodes: { getAllNodes: vi.fn().mockResolvedValue([]), getNode: vi.fn(), upsertNode: vi.fn().mockResolvedValue(undefined) },
     settings: { getSetting: vi.fn().mockResolvedValue(null) },
     getKeyRepairLogAsync: vi.fn().mockResolvedValue([]),
+    updateNodeTimeOffsetFlagsAsync: vi.fn().mockResolvedValue(undefined),
   }
 }));
 
@@ -212,6 +213,27 @@ describe('securityRoutes — per-source scanner', () => {
         expect(res.body.code).toBe('MISSING_SOURCE_ID');
       }
     );
+  });
+
+  describe('POST /nodes/:nodeNum/clear', () => {
+    it('400s MISSING_SOURCE_ID when sourceId omitted', async () => {
+      const app = createApp();
+      const res = await request(app).post('/api/security/nodes/123/clear').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('MISSING_SOURCE_ID');
+    });
+
+    it('scopes the node lookup and clear-write to the requested source', async () => {
+      mockDb.nodes.getNode.mockResolvedValue({ nodeNum: 123, nodeId: '!7b', shortName: 'X', sourceId: 'src-1' });
+      const app = createApp();
+      const res = await request(app).post('/api/security/nodes/123/clear').send({ sourceId: 'src-1' });
+      expect(res.status).toBe(200);
+      // getNode + upsertNode + time-offset clear all scoped to src-1, not a
+      // cross-source first match or the 'default' source.
+      expect(mockDb.nodes.getNode).toHaveBeenCalledWith(123, 'src-1');
+      expect(mockDb.nodes.upsertNode).toHaveBeenCalledWith(expect.objectContaining({ nodeNum: 123 }), 'src-1');
+      expect(mockDb.updateNodeTimeOffsetFlagsAsync).toHaveBeenCalledWith(123, false, null, 'src-1');
+    });
   });
 
   describe('INVALID_SOURCE_TYPE guards', () => {

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -279,7 +279,7 @@ router.get('/export', requireSourceId('query'), async (req: Request, res: Respon
 });
 
 // Clear security issues for a specific node (requires write permission)
-router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), async (req: Request, res: Response) => {
+router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), requireSourceId('body'), async (req: Request, res: Response) => {
   try {
     const nodeNum = parseInt(req.params.nodeNum, 10);
 
@@ -287,7 +287,12 @@ router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), asy
       return res.status(400).json({ error: 'Invalid node number' });
     }
 
-    const node = await databaseService.nodes.getNode(nodeNum);
+    // sourceId presence validated by requireSourceId('body'); scope the node
+    // lookup + write so we clear/rewrite the correct source's row (not a
+    // cross-source first match, and not the 'default' source).
+    const clearSourceId = req.body.sourceId as string;
+
+    const node = await databaseService.nodes.getNode(nodeNum, clearSourceId);
     if (!node) {
       return res.status(404).json({ error: 'Node not found' });
     }
@@ -302,10 +307,10 @@ router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), asy
       duplicateKeyDetected: false,
       keyMismatchDetected: false,
       keySecurityIssueDetails: null, // null explicitly clears the field (undefined would preserve existing value)
-    });
+    }, clearSourceId);
 
-    // Clear time offset flags (scoped to the node's source per migration 029)
-    await databaseService.updateNodeTimeOffsetFlagsAsync(nodeNum, false, null, (node as any).sourceId);
+    // Clear time offset flags (scoped to the requested source per migration 029)
+    await databaseService.updateNodeTimeOffsetFlagsAsync(nodeNum, false, null, clearSourceId);
 
     // Log the action
     void databaseService.auditLogAsync(


### PR DESCRIPTION
## Summary

`POST /api/security/nodes/:nodeNum/clear` was an `UNSCOPED_BUG` from the audit: it looked up the node with `getNode(nodeNum)` (a non-deterministic **cross-source first match**) and cleared flags via `upsertNode(...)` with **no sourceId** — writing to the `'default'` source.

Now requires a `sourceId` (400 `MISSING_SOURCE_ID`) and scopes `getNode` + `upsertNode` + the time-offset clear to it, so the correct source's node row is read and rewritten.

No frontend caller exists for this endpoint → backend-only, no UI coordination.

## Tests
- 400-on-missing + scoped `getNode`/`upsertNode`/time-offset assertions. Server TSC clean.

## Remaining
- Phase 3 (device "send-to-device" ops), Phase 4 (v1 legacy mounts + `packets/:id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)