### PR TITLE
fix(api): scope v1 GET /packets/:id to the caller's source

### DIFF
--- a/src/server/routes/v1/packets.ts
+++ b/src/server/routes/v1/packets.ts
@@ -105,8 +105,22 @@ router.get('/:id', async (req, res) => {
       });
     }
 
+    // Packet IDs are a global primary key, so scope the read to the caller's
+    // source: require a sourceId and treat a packet from a different source as
+    // Not Found — otherwise a caller on source A could read source B's packet
+    // by guessing its id.
+    const sourceId = getScopedSourceId(req);
+    if (!sourceId) {
+      return res.status(400).json({
+        success: false,
+        error: 'Bad Request',
+        code: 'MISSING_SOURCE_ID',
+        message: 'sourceId is required'
+      });
+    }
+
     const packet = await packetLogService.getPacketByIdAsync(id);
-    if (!packet) {
+    if (!packet || packet.sourceId !== sourceId) {
       return res.status(404).json({
         success: false,
         error: 'Not Found',

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -39,8 +39,8 @@ const testTraceroutes = [
 ];
 
 const testPackets = [
-  { id: 1, packet_id: 1001, from_node: 2882400001, to_node: 2882400002, channel: 0, portnum: 1, encrypted: 0, timestamp: Date.now() },
-  { id: 2, packet_id: 1002, from_node: 2882400002, to_node: 2882400001, channel: 0, portnum: 3, encrypted: 1, timestamp: Date.now() - 1000 }
+  { id: 1, packet_id: 1001, from_node: 2882400001, to_node: 2882400002, channel: 0, portnum: 1, encrypted: 0, timestamp: Date.now(), sourceId: 'test-source' },
+  { id: 2, packet_id: 1002, from_node: 2882400002, to_node: 2882400001, channel: 0, portnum: 3, encrypted: 1, timestamp: Date.now() - 1000, sourceId: 'test-source' }
 ];
 
 const testPositionTelemetry = [
@@ -527,9 +527,9 @@ describe('GET /api/v1/packets', () => {
 });
 
 describe('GET /api/v1/packets/:id', () => {
-  it('should return single packet by ID', async () => {
+  it('should return single packet by ID scoped to the source', async () => {
     const response = await request(app)
-      .get('/api/v1/packets/1')
+      .get('/api/v1/packets/1?sourceId=test-source')
       .set('Authorization', `Bearer ${VALID_TEST_TOKEN}`)
       .expect(200);
 
@@ -537,9 +537,27 @@ describe('GET /api/v1/packets/:id', () => {
     expect(response.body).toHaveProperty('data');
   });
 
+  it('should 400 MISSING_SOURCE_ID when sourceId is omitted', async () => {
+    const response = await request(app)
+      .get('/api/v1/packets/1')
+      .set('Authorization', `Bearer ${VALID_TEST_TOKEN}`)
+      .expect(400);
+
+    expect(response.body).toHaveProperty('code', 'MISSING_SOURCE_ID');
+  });
+
+  it('should 404 for a packet belonging to a different source (no cross-source read)', async () => {
+    const response = await request(app)
+      .get('/api/v1/packets/1?sourceId=other-source')
+      .set('Authorization', `Bearer ${VALID_TEST_TOKEN}`)
+      .expect(404);
+
+    expect(response.body).toHaveProperty('success', false);
+  });
+
   it('should return 404 for non-existent packet', async () => {
     const response = await request(app)
-      .get('/api/v1/packets/999999')
+      .get('/api/v1/packets/999999?sourceId=test-source')
       .set('Authorization', `Bearer ${VALID_TEST_TOKEN}`)
       .expect(404);
 


### PR DESCRIPTION
## Summary

Closes an `UNSCOPED_BUG` from the audit: packet IDs are a **global** primary key, so `GET /api/v1/.../packets/:id` let a caller scoped to source A **read source B's packet by guessing its id**.

Now requires a `sourceId` (400 `MISSING_SOURCE_ID`) and returns **404** when the fetched packet's `sourceId` doesn't match the caller's — closing the cross-source read without changing the repo signature (verify-after-fetch).

Works for both the canonical `/api/v1/sources/:sourceId/packets/:id` (path source) and the deprecated legacy `/api/v1/packets/:id?sourceId=` mount.

## Tests
- Scoped 200, 400-on-missing, cross-source 404, non-existent 404. Server TSC clean.

## Remaining
- Phase 3 (device "send-to-device" ops), Phase 4 remainder (harden the deprecated v1 legacy mounts more broadly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)