### PR TITLE
feat(embed): Phase 6 — embeds adopt canonical traceroute rendering (#4047)

### DIFF
--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_EPIC.md
@@ -113,7 +113,7 @@ it); MeshCore popup content joins the family; `NodePopup`/`DashboardNodePopup` r
 **Exit criteria:** `MapNodePopupContent` deleted; one popup family renders all maps'
 popups with no capability loss; browser-validated per source tech; suite green.
 
-### [ ] Phase 6 — Embed traceroute alignment (`feature/4047-p6-embed-traceroutes`)
+### [x] Phase 6 — Embed traceroute alignment (`feature/4047-p6-embed-traceroutes`)
 Extend `/api/embed/:id/traceroutes` to carry per-segment SNR + leg/direction data
 (backward-compatible), render EmbedMap traceroutes through the shared
 TraceroutePathsLayer with the canonical SNR scale.
@@ -137,6 +137,25 @@ browser-validated on every map view; suite green.
 ## Phase log
 
 (Per-phase: PR link, deviations, decisions — appended as phases complete.)
+
+### Phase 6 (2026-07-10) — Embed traceroute alignment
+- Delivered: `GET /api/embed/:id/traceroutes` now decomposes via the shared
+  `decomposeTraceroute` server-side with an ADDITIVE wire shape (legacy fields kept +
+  `leg`/`avgSnr`/`isMqtt`; `snr` now correctly /4-scaled — old clients get the right
+  value). EmbedMap renders through the shared TraceroutePathsLayer with the FLAT
+  all-segments preset (D3 orchestrator override: arrows are canonical only for
+  single-route views); palette via `getSchemeForTileset(config.tileset)` (embed bundle
+  is context-free). Old-shape resilience pinned by test.
+- **Security fix found by the leak-boundary tests:** the embed traceroutes handler was
+  missing the `hideFromMap` filter the nodes handler applies — hidden nodes' positions
+  could leak into public embed segments. Fixed + 5 leak-boundary tests.
+- Net-new test coverage: embedPublicRoutes route tests (14) and EmbedMap render tests
+  (9) — neither file existed.
+- Browser-validated via a real embed profile/iframe: 60 segments in the canonical light
+  4-band palette, 25 MQTT/unknown-dashed, popup with corrected SNR; console clean.
+  Gotcha for future validators: the embed traceroute fetch is gated on the profile's
+  `showPaths` flag, not `showTraceroutes`.
+- Suite: 9,585 tests / 0 failures. BaseMap adoption for EmbedMap deferred to Phase 7.
 
 ### Phase 5 (2026-07-10) — Popup unification
 - Delivered: popup family at `src/components/map/popups/` (NodeCard chrome + 8 section

--- a/docs/internal/dev-notes/MAP_CONSOLIDATION_P6_SPEC.md
+++ b/docs/internal/dev-notes/MAP_CONSOLIDATION_P6_SPEC.md
@@ -1,0 +1,499 @@
+# Map Consolidation — Phase 6 Spec: Embed Traceroute Alignment
+
+**Epic:** #4047 · **Phase:** 6 · **Branch:** `feature/4047-p6-embed-traceroutes` (from `origin/4049-map-refactor`)
+**Status:** Spec — no feature code written yet.
+**Scope:** the public embed map only (`src/components/EmbedMap.tsx` + `src/embed.tsx` bundle,
+`GET /api/embed/:profileId/traceroutes`). This is the ONE phase with a backend/API surface.
+
+## 0. TL;DR for implementers
+
+Today the public embed renders traceroutes as **server-computed straight fixed-mauve (`#cba6f7`)
+weight-3 lines**, one `snr` per segment, no legs / no direction / no MQTT distinction / no theme
+awareness. The app (post-Phase-3) renders traceroutes through the shared
+`TraceroutePathsLayer` + `decomposeTraceroute` with the canonical 4-band theme-aware SNR scale,
+forward/return legs, arrows, and MQTT/unknown dashing. Phase 6 makes the embed match.
+
+**Decision (binding, from the epic interview — "Align fully"):** extend the embed traceroute API to
+carry SNR + leg data **backward-compatibly**, and render the embed through the shared
+`TraceroutePathsLayer` with the canonical SNR palette chosen from the profile's tileset scheme.
+
+**The two load-bearing architecture calls this spec makes (justified in §2):**
+
+1. **Decompose with the shared util `decomposeTraceroute`, invoked SERVER-SIDE, and return an
+   ADDITIVE SUPERSET of the existing wire segment shape** — NOT raw rows + a new endpoint, and NOT
+   a re-implemented server decomposition. The bespoke hand-rolled decomposition loop in
+   `embedPublicRoutes.ts` (parse `route`, build `fullPath`, per-pair dedup) is **deleted** and
+   replaced by `decomposeTraceroute` (the ONE decomposition), which the app already uses. Old cached
+   embed clients keep working because every field they read is still present; new fields are ignored
+   by them.
+2. **The embed bundle has no `SettingsContext`** (`src/embed.tsx` renders `<EmbedMap>` bare — no
+   `SettingsProvider`). So the SNR palette CANNOT come from `useSettings()`. It is computed directly
+   from the profile's tileset: `getOverlayColors(getSchemeForTileset(config.tileset))`. This is the
+   canonical answer to "which palette (light vs dark) and how is it chosen" for the embed.
+   `TraceroutePathsLayer` already takes `snrColors` as a **prop** (Phase-3 design choice, context-
+   free) so it drops into the isolated embed bundle with no provider.
+
+Two work packages: **WP1 server** (rewrite the endpoint via the shared util, additive fields, tests) →
+**WP2 client** (EmbedMap renders via the shared layer, palette from tileset scheme, tests + iframe
+validation).
+
+**Explicitly OUT of scope (do NOT touch — flag to orchestrator if tempted):** BaseMap adoption for
+EmbedMap (its isolated bundle + custom zoom/attribution/URL-param center logic — Phase 7 or a later
+follow-up); the embed's node markers (already use the Phase-4 `createNodeIcon` factory) and its
+bespoke node popup (Phase-5 popup-family alignment for the embed is not this phase); the
+`showPaths`/`showTraceroutes` gate quirk (§6.4); the neighbor-info lines (unrelated feature).
+
+---
+
+## 1. Reuse inventory (serena/grep-verified 2026-07-10)
+
+### 1.1 Server side — `src/server/routes/embedPublicRoutes.ts`
+
+| Element | Fact |
+|---|---|
+| Route | `GET /:profileId/traceroutes` (L196-304), mounted **outside** the API router — no CSRF, no rate limiter, no session/auth. |
+| Auth model | **Anonymous, gated by profile-ID-as-token.** `createEmbedCspMiddleware()` (`embedMiddleware.ts`) looks up the profile by ID, 404s if missing/disabled, attaches `req.embedProfile`. No `requirePermission`. |
+| Opt-in gate | Returns `404 { error: 'Traceroutes not enabled for this profile' }` unless `profile.showTraceroutes` (default false — avoids leaking mesh topology). **Keep this gate unchanged.** |
+| Response shape | **Bare JSON array** `res.json(Array.from(segmentMap.values()))` — NOT the `ok()`/`fail()` envelope (see §3.1). |
+| Data available | `getAllTraceroutes(100, profile.sourceId ?? ALL_SOURCES)` → full `DbTraceroute[]` incl. `route`, `routeBack`, `snrTowards`, `snrBack`, `routePositions` (the #1862 snapshot), `timestamp`. |
+| Position filter | Builds `nodePositions: Map<nodeNum → {lat,lng,name}>` from `getActiveNodes(7, …)` with the SAME filters as `/nodes`: effective position (`getEffectiveDbNodePosition`, #2847), drop `(0,0)`, drop `hideFromMap` (#3549), MQTT filter (`!showMqttNodes && viaMqtt`), channel filter. A segment is emitted **only when BOTH endpoints resolve** in this filtered map. This is the leak boundary — hidden/filtered nodes never leave the server. |
+| Current SNR | `snr: snrValues[i] ?? null` where `snrValues = JSON.parse(tr.snrTowards)` — the **raw firmware int (dB×4), UN-scaled** (a latent bug, same class as Dashboard's pre-P3 un-scaled SNR). The old client popup prints `{seg.snr} dB` (wrong magnitude). |
+| Cross-source | `profile.sourceId ?? ALL_SOURCES` — a source-less profile intentionally spans all sources (established by commit 45f7e7be / 64081b6f; `withSourceScope` fails closed, `ALL_SOURCES` is the sanctioned cross-source sentinel). **Preserve verbatim.** |
+| Route-level tests | **NONE.** `embedPublicRoutes.test.ts` does not exist. `embedProfileRoutes.test.ts` covers only the ADMIN profile-CRUD routes. The public traceroute endpoint is currently untested. |
+
+### 1.2 Current wire shape (the backward-compat contract) — `EmbedTracerouteSegment`
+
+`EmbedMap.tsx` L61-72 and the server's `segmentMap` value type agree on:
+```ts
+{ fromNum, toNum, fromLat, fromLng, fromName, toLat, toLng, toName, snr: number|null, timestamp }
+```
+The old client reads ONLY: `fromLat/fromLng/toLat/toLng` (positions), `fromName/toName` + `snr`
+(popup text). It renders `<Polyline color="#cba6f7" weight={3} opacity={0.8}>` per segment (L324-355).
+**Any new response MUST keep these fields populated and correctly typed** or an open/cached old
+iframe breaks.
+
+### 1.3 Client side — `src/components/EmbedMap.tsx` + `src/embed.tsx`
+
+| Element | Fact |
+|---|---|
+| Bundle isolation | `src/embed.tsx` mounts `<EmbedMap>` with **NO** `SettingsProvider`/`SettingsContext`/`ThemeProvider`. `EmbedMap` calls no `useSettings()`. It CANNOT read `overlayColors` from context. |
+| Map shell | Raw `MapContainer` + `TileLayer` (Phase 1 deliberately left EmbedMap un-migrated). Custom center/zoom logic incl. URL-param overrides `?lat=&lon=&zoom=` (#2668). **Do NOT adopt BaseMap here (out of scope).** |
+| Node markers | `createNodeIcon(...)` via `../utils/mapIcons` (the Phase-4 shim → `src/components/map/markerIcons.ts`). Already canonical — leave as-is. |
+| Traceroute block | L324-355: `config.showPaths && tracerouteSegments.map(seg => <Polyline color="#cba6f7" weight={3} …>)` with a `<Popup>` showing `{seg.snr} dB`. **This block is what P6 replaces.** |
+| Fetch | Raw `fetch(`${baseUrl}/api/embed/${profileId}/traceroutes`)` (L182-192), gated `config.showPaths`, polled every `pollIntervalSeconds`. Reads bare JSON directly (no `ApiService`, no envelope unwrap). |
+| Tileset | `config.tileset` (per-profile, chosen in `EmbedSettings`), resolved by `getEmbedTileset` → `TILESETS[...]`. |
+| Popup CSS | Inline `embedPopupCss` (Catppuccin dark, hardcoded — the embed doesn't load app CSS vars). Reused for the new traceroute popup. |
+
+### 1.4 Shared modules P6 consumes (Phase-3 output — verified present on this branch)
+
+| Symbol | File | Relevance |
+|---|---|---|
+| `decomposeTraceroute(tr, {resolvePosition})` | `src/utils/tracerouteSegments.ts` | The ONE decomposition. Pure/React-free/leaflet-free — **importable server-side** (see §2.2). Input `TracerouteDecomposeInput` is a structural subset of `DbTraceroute`. Emits `TracerouteRenderSegment[]` with `leg`, `avgSnr` (**/4-scaled**, null=no data), `isMqtt` (per-hop #2931 sentinel), `fromNodeNum`/`toNodeNum`, `timestamp`. |
+| `TracerouteRenderSegment` | `src/utils/tracerouteSegments.ts` | The layer's segment type. |
+| `TraceroutePathsLayer` | `src/components/map/layers/TraceroutePathsLayer.tsx` | The ONE renderer. Named export, `memo`, takes `snrColors` as a **prop** (no `useSettings` — embed-safe). Imports only `mapHelpers` + `tracerouteSegments` + `react-leaflet` (no context). |
+| `snrToColor`, `weightBySnr`, `MQTT_DASH`, `SnrColorScale` | `src/utils/mapHelpers.tsx` | Canonical scale/weight/dash. |
+| `getOverlayColors`, `getSchemeForTileset`, `OverlayColors.snrColors {excellent,good,fair,poor,noData}` | `src/config/overlayColors.ts` | 4-band theme palette + tileset→scheme map (`osm/osmHot/cartoLight/openTopo`→light; `cartoDark/esriSatellite`→dark; custom→dark). Plain TS module (no context) — embed imports it directly. |
+
+### 1.5 Server import boundary (verified)
+
+`tsconfig.server.json` `include` lists `src/utils/**/*`. Server routes already import root `src/utils/*`
+(`meshcoreRoutes.ts` imports `../../utils/nullIsland.js`, `../../utils/meshcorePacketDecode.js`,
+`../../utils/safeRegex.js`). So `import { decomposeTraceroute } from '../../utils/tracerouteSegments.js'`
+in `embedPublicRoutes.ts` is precedented and compiles. `tracerouteSegments.ts` is explicitly documented
+leaflet-free/React-free for exactly this cross-boundary reuse.
+
+---
+
+## 2. API design
+
+### 2.1 Backward-compat strategy — ADDITIVE SUPERSET on the existing endpoint (chosen)
+
+The wire response of `GET /api/embed/:profileId/traceroutes` stays a **bare JSON array** whose element
+type is a **superset** of the current `EmbedTracerouteSegment`:
+
+```ts
+interface EmbedTracerouteSegmentV2 {
+  // --- existing fields (UNCHANGED — old cached clients read these) ---
+  fromNum: number;
+  toNum: number;
+  fromLat: number;
+  fromLng: number;
+  fromName: string;
+  toLat: number;
+  toLng: number;
+  toName: string;
+  snr: number | null;   // see §2.3 — now the /4-scaled value (was raw dB×4)
+  timestamp: number;
+  // --- additive fields (NEW — old clients ignore; new client renders from these) ---
+  leg: 'forward' | 'return';
+  avgSnr: number | null; // canonical /4-scaled dB; null = no data / MQTT sentinel
+  isMqtt: boolean;       // per-hop #2931 sentinel, NOT node.viaMqtt
+}
+```
+
+**Why additive-superset and NOT a versioned endpoint or raw-rows:**
+
+| Option | Backward-compat | "One decomposition" | Leak surface | Server code | Verdict |
+|---|---|---|---|---|---|
+| **Additive superset, shared util server-side** (chosen) | ✅ old clients read the same fields | ✅ uses `decomposeTraceroute` verbatim (server-side invocation of the ONE util) | ✅ unchanged — still filters to visible-node positions | ✅ net simpler (delete bespoke loop) | **Chosen** |
+| Raw rows on same endpoint + client decomposition | ❌ **breaks** old clients (they map `seg.fromLat` → undefined) | ✅ | ⚠️ must ship raw `route`/`routeBack` arrays; snapshot leak risk if `routePositions` shipped | ➖ needs client position plumbing | Rejected (breaks compat) |
+| Versioned `/traceroutes/v2` raw rows + client decomposition | ✅ old `/v1` untouched | ✅ | ⚠️ same raw-array concern | ❌ **TWO endpoints** to carry; v1 still does bespoke decomposition | Rejected (more surface, not less) |
+| Additive superset but re-implement leg/isMqtt logic server-side | ✅ | ❌ re-implements decomposition (drift) | ✅ | ➖ | Rejected (violates epic spirit) |
+
+The decisive points: (a) client-side decomposition **necessarily requires raw route arrays**, which
+on the shared endpoint breaks old clients, and via a v2 endpoint doubles the server surface while
+leaving the bespoke v1 loop alive; (b) "one decomposition" is satisfied by invoking the **shared
+`decomposeTraceroute` util server-side** — this is NOT "fattening a bespoke server segment builder,"
+it is deleting the bespoke builder and calling the same pure util the app calls; (c) additive-superset
+is the only option that is *both* backward-compatible on a single endpoint *and* least total code.
+
+No new endpoint. No `?format=` param. No version field. The response is a strict superset — an old
+bundle rendering against the new server is unaffected.
+
+### 2.2 Server handler rewrite (`GET /:profileId/traceroutes`)
+
+Replace the L232-299 hand-rolled decomposition with:
+
+1. Keep the existing preamble unchanged: profile 404, `showTraceroutes` 404 gate, `getActiveNodes` +
+   the `nodePositions: Map<nodeNum → {lat,lng,name}>` build (all filters intact), `getAllTraceroutes(100, sourceId ?? ALL_SOURCES)`, and the 24h `cutoffMs` window.
+2. Build a **live-only** `resolvePosition`:
+   ```ts
+   const resolvePosition = (n: number): [number, number] | null => {
+     const p = nodePositions.get(n);
+     return p ? [p.lat, p.lng] : null;
+   };
+   ```
+   **Deliberately no snapshot** (`routePositions`) — see §5 (leak avoidance + parity with the embed's
+   current live-only behavior). `decomposeTraceroute` skips any segment whose endpoint resolves to
+   `null`, so hidden/filtered nodes never appear and never leak, exactly as today.
+3. For each traceroute within the window (`tsMs >= cutoffMs`), call
+   `decomposeTraceroute(tr, { resolvePosition })` → `TracerouteRenderSegment[]`.
+4. **Dedup across traceroutes by `seg.key`** (the util's key is `` `${leg}:${fromNum}-${toNum}` `` —
+   forward and return legs are distinct keys, so both survive), keeping the segment with the newest
+   `timestamp`. (Directional-within-leg dedup is fine and matches app behavior; do NOT collapse
+   forward+return into one bidirectional key — that would drop the return leg the epic wants shown.)
+5. Map each surviving `TracerouteRenderSegment` → `EmbedTracerouteSegmentV2`, pulling `fromName`/
+   `toName` from `nodePositions` (`.get(fromNodeNum)!.name`), setting `snr = avgSnr` (§2.3),
+   `avgSnr`, `isMqtt`, `leg`, positions from `seg.from`/`seg.to`.
+6. **Cap the output** at `MAX_EMBED_TR_SEGMENTS = 500` (response-size guard; public/cacheable
+   endpoint) — sort by `timestamp` desc before slicing so the freshest survive. In practice 100
+   traceroutes over 24h rarely approach this, but the cap is a hard ceiling.
+7. `res.json(segments)` — bare array, unchanged envelope posture.
+
+Net: the handler gets **shorter** (the parse/fullPath/segment-loop is gone) and gains correct
+forward/return legs + per-hop MQTT/unknown handling for free from the shared util.
+
+### 2.3 The legacy `snr` field
+
+The old server populated `snr` with the **raw un-scaled** `snrTowards[i]` (dB×4). The shared util
+exposes `avgSnr` (/4-scaled, sentinel→null). Set the legacy `snr = avgSnr`. Effect on an old cached
+client: its popup `{seg.snr} dB` now shows the **correct scaled** dB instead of the former ×4 value —
+a strict fix, non-breaking (still a number-or-null, still renders). Listed in §7 as an accepted
+incidental change to stale clients. The new client ignores `snr` entirely and reads `avgSnr`.
+
+### 2.4 Permission / envelope — UNCHANGED
+
+- **No permission change.** Still anonymous, still gated by `showTraceroutes` + profile-ID-as-token.
+  No `requirePermission`, no session. Do not introduce the envelope: these routes are consumed by raw
+  `fetch()` reading a bare array; wrapping in `ok(res, …)` would break both old AND new clients (per
+  the CLAUDE.md `ApiService` unwrap gotcha — and here there's no `ApiService` at all). `fail()` is not
+  introduced either; the existing bare `{ error }` 404/500 bodies stay (the client's `catch`/`!res.ok`
+  paths already handle them).
+
+---
+
+## 3. Client render design
+
+### 3.1 Palette selection (the canonical theme answer)
+
+EmbedMap computes the palette once from the profile tileset — no context, no `useSettings`:
+```ts
+import { getOverlayColors, getSchemeForTileset } from '../config/overlayColors';
+// after config loads:
+const overlay = getOverlayColors(getSchemeForTileset(config.tileset));
+const snrColors = overlay.snrColors;      // 4-band {excellent,good,fair,poor,noData}
+const mqttColor = overlay.mqttSegment;    // MQTT/IP-bridged distinction
+```
+`getSchemeForTileset` maps built-in tilesets to light/dark and defaults **custom tilesets → dark**
+(matches the app). This is the sole palette signal for the embed (EmbedSettings has no per-profile
+overlay-scheme override; if one is ever added it would thread here). Memoize on `config.tileset`.
+
+### 3.2 The render block (replaces `EmbedMap.tsx` L324-355)
+
+Map the wire segments → `TracerouteRenderSegment[]` (positions already resolved server-side; this is a
+trivial field rename, no decomposition on the client) and render through the shared layer:
+
+```tsx
+const renderSegments: TracerouteRenderSegment[] = tracerouteSegments.map(s => ({
+  key: `${s.leg}:${s.fromNum}-${s.toNum}`,
+  from: [s.fromLat, s.fromLng],
+  to: [s.toLat, s.toLng],
+  fromNodeNum: s.fromNum,
+  toNodeNum: s.toNum,
+  leg: s.leg,
+  avgSnr: s.avgSnr,
+  isMqtt: s.isMqtt,
+  timestamp: s.timestamp,
+}));
+
+{config.showPaths && (
+  <TraceroutePathsLayer
+    segments={renderSegments}
+    snrColors={snrColors}
+    colorMode="snr"
+    mqttColor={mqttColor}
+    curvature={0.2}
+    weight={weightBySnr}
+    opacity={0.85}
+    dashMode="mqtt-unknown"
+    showArrows
+    renderPopup={config.showPopups ? renderTraceroutedPopup : undefined}
+  />
+)}
+```
+
+**Props rationale (per the P3 §3.2 consumer-table pattern):**
+
+| Prop | Value | Why |
+|---|---|---|
+| `colorMode` | `'snr'` | Canonical 4-band coloring — the core alignment goal. |
+| `snrColors` | tileset-derived (§3.1) | Theme-aware light/dark, no context. |
+| `mqttColor` | `overlay.mqttSegment` | Keeps MQTT/unknown segments distinct from no-data gray (P3 amendment). |
+| `curvature` | `0.2` | Bows forward/return legs opposite ways so both are visible (straight would draw them coincident). |
+| `weight` | `weightBySnr` | Canonical SNR-scaled weight (2..6). |
+| `opacity` | `0.85` | Matches the app paths presentation. |
+| `dashMode` | `'mqtt-unknown'` | Canonical MQTT/unknown-SNR dashing (`3,6`). |
+| `showArrows` | `true` | Direction cue for forward vs return; the embed's dedup'd segment count is modest. |
+| `renderPopup` | callback (if `showPopups`) | Keeps the embed popup, now band/MQTT-aware (§3.3). |
+| `temporalFade` | *(omitted)* | Not used by the embed (no per-sample timestamps beyond the segment ts; keep simple). |
+
+This mirrors the app's richest traceroute presentation (NodesTab selected-route styling) applied
+across the embed's recent-traceroute set — delivering legs + direction + bands + MQTT dashing, i.e.
+"the same traceroute visuals as the app." The exact numbers (`curvature 0.2`, `showArrows`, `weight`)
+are the recommended default; see §8 D3 for the orchestrator toggle to the flatter Dashboard-paths
+preset (`curvature 0`, arrows off, `weight 2`) if arrow noise is judged too busy in browser validation.
+
+### 3.3 Popup
+
+`renderTraceroutedPopup(seg)` returns a `<Popup>` reusing the existing `embed-popup` CSS classes,
+showing `fromName ↔ toName`, the scaled SNR (`seg.avgSnr` → `{avgSnr.toFixed(1)} dB`, hidden when
+null), and a "via MQTT" indicator when `seg.isMqtt`. Names come from a `Map<nodeNum → name>` built
+from the current `nodes` state (the client already has visible-node names) OR — simpler — keep the
+raw wire segments around and index the popup by `key`, reading `fromName`/`toName` off the wire object
+(they're already on it). Prefer the latter (zero extra plumbing).
+
+### 3.4 Bundle impact
+
+Importing `TraceroutePathsLayer` (+ `mapHelpers`, `tracerouteSegments`, `overlayColors`) into the
+embed bundle adds modest weight; `leaflet`/`react-leaflet` are already in the bundle. `mapHelpers`
+imports `leaflet` (already present). No `SettingsContext`/`ThemeProvider` is pulled in (the layer and
+palette functions are context-free) — verified by reading the layer's imports. Acceptable.
+
+---
+
+## 4. File-by-file changes
+
+### Modified — server
+- `src/server/routes/embedPublicRoutes.ts` — rewrite the `/:profileId/traceroutes` handler body
+  (§2.2): import `decomposeTraceroute` from `../../utils/tracerouteSegments.js`; delete the bespoke
+  parse/`fullPath`/segment loop; build `resolvePosition` (live-only); decompose + dedup-by-key +
+  cap-500; map to `EmbedTracerouteSegmentV2` (`snr = avgSnr`, plus `leg`/`avgSnr`/`isMqtt`). Preamble
+  (profile 404, `showTraceroutes` gate, `nodePositions` build, `ALL_SOURCES`) unchanged.
+
+### Modified — client
+- `src/components/EmbedMap.tsx` —
+  - Extend the `EmbedTracerouteSegment` interface to `EmbedTracerouteSegmentV2` (add `leg`, `avgSnr`,
+    `isMqtt`).
+  - Import `getOverlayColors`/`getSchemeForTileset` from `../config/overlayColors`, `weightBySnr` from
+    `../utils/mapHelpers`, `TraceroutePathsLayer` from `./map/layers/TraceroutePathsLayer`, and
+    `TracerouteRenderSegment` type from `../utils/tracerouteSegments`.
+  - Compute `snrColors`/`mqttColor` from `config.tileset` (memoized).
+  - Replace the L324-355 `tracerouteSegments.map(<Polyline color="#cba6f7"…>)` block with the
+    `<TraceroutePathsLayer>` render (§3.2) + `renderTraceroutedPopup` (§3.3).
+  - Delete the inline fixed-mauve Polyline + old segment popup.
+
+### Created — tests
+- `src/server/routes/embedPublicRoutes.test.ts` — **NEW** (§5.1).
+- `src/components/EmbedMap.traceroutes.test.tsx` — **NEW** (§5.2).
+
+### NOT changed (guardrails)
+- `src/embed.tsx`, the map shell / node markers / node popup / neighbor lines in `EmbedMap.tsx`, the
+  `/config`, `/nodes`, `/neighborinfo`, `/geojson` handlers, `embedMiddleware.ts`, the embed profile
+  schema/migrations, `overlayColors.ts` (already 4-band from P3), `TraceroutePathsLayer.tsx`,
+  `tracerouteSegments.ts`, `mapHelpers.tsx` (all Phase-3 shared code — consumed, not modified).
+
+---
+
+## 5. Test plan
+
+### 5.1 Server — `embedPublicRoutes.test.ts` (NEW)
+These are public routes with **no `requirePermission`/`optionalAuth`** — the `createRouteTestApp`
+harness (CLAUDE.md) targets auth routes and is **not the right fit here**. Instead mount the router on
+a bare `express()` app and seed the singleton `:memory:` SQLite DB directly (an embed profile via
+`databaseService.embedProfiles`, nodes via the nodes repo, traceroutes via
+`databaseService.traceroutes.insertTraceroute`), following the DB-seeding style of
+`embedProfileRoutes.test.ts` (minus the auth/session wiring). Assert:
+- **Bare array** (not enveloped) — response is an array, not `{success,data}`.
+- **Additive fields present**: each element has `leg`, `avgSnr`, `isMqtt` AND all legacy fields
+  (`fromLat`,`fromLng`,`toLat`,`toLng`,`fromName`,`toName`,`snr`,`timestamp`,`fromNum`,`toNum`).
+- **Legacy fields still populated** (backward-compat): positions + names present and correct.
+- **`snr === avgSnr`** and **`avgSnr` is /4-scaled** (feed `snrTowards=[20]` → expect `avgSnr=5`,
+  band=excellent) — pins the un-scaled→scaled fix.
+- **Forward + return legs**: a traceroute with populated `route` AND `routeBack`/`snrBack` yields both
+  `leg:'forward'` and `leg:'return'` segments (#2051 guard flows through the util).
+- **`isMqtt` from sentinel** (#2931): a hop with `snrTowards` element `-128` (raw sentinel) →
+  `isMqtt:true`, `avgSnr:null`.
+- **Filtering/leak**: a traceroute hop that is `hideFromMap`, off-channel, MQTT-when-`!showMqttNodes`,
+  or positionless produces **no segment revealing it** (endpoint unresolved → segment skipped).
+- **`showTraceroutes` gate**: profile with `showTraceroutes:false` → 404.
+- **Cross-source**: source-less profile (`sourceId` null) returns segments across sources
+  (`ALL_SOURCES` path) without throwing.
+- **Cap**: > 500 candidate segments → response length ≤ 500.
+
+### 5.2 Client — `EmbedMap.traceroutes.test.tsx` (NEW)
+EmbedMap has no test today. Mock `fetch` (config + nodes + the new traceroute wire shape) and mock
+`react-leaflet` the way `src/components/map/layers/TraceroutePathsLayer.test.tsx` already does (or
+spy on `TraceroutePathsLayer`). Assert:
+- With `showPaths:true`, `TraceroutePathsLayer` is rendered with `colorMode:'snr'`, the tileset-derived
+  `snrColors`, `mqttColor`, and the segment array mapped from the wire response.
+- **Palette selection**: `config.tileset:'cartoDark'` → dark `snrColors`; `'osm'`/`'osmHot'` → light
+  `snrColors` (assert a band hex differs between the two).
+- A wire segment with `leg:'return'` maps to a render segment with `leg:'return'` (both legs pass
+  through).
+- `showPaths:false` → no `TraceroutePathsLayer`.
+- Old-shape resilience (optional): a wire segment lacking the additive fields still yields a rendered
+  polyline (defensive — the client tolerates a stale server, mirror of the server tolerating a stale
+  client).
+
+### 5.3 Gate
+Full Vitest suite `success:true` via `--reporter=json` (project memory: the rtk summary line masks
+suite-collection failures). `npm run lint:ci` exits 0 (no baseline growth, no new `any` — type the
+wire shape and the mapping fully). `tsc` server + client clean. Browser-validate an actual embed
+iframe (§8 D4).
+
+---
+
+## 6. Notes / pre-existing quirks (do NOT "fix" in P6)
+
+### 6.1 `#1862` snapshot positions are intentionally NOT adopted for the embed
+The app's `decomposeTraceroute` can prefer `routePositions` snapshots; the embed's `resolvePosition`
+is **live-only** (§2.2). Reasons: (a) it matches the embed's current behavior (it already resolves
+from live `getActiveNodes` positions); (b) shipping/resolving snapshots would risk leaking historical
+positions of nodes that are currently hidden/filtered (a NEW leak the live-only filter structurally
+prevents). "Same visuals as the app" here means the SNR bands / legs / dashing, not historical
+snapshot placement. Document this in a code comment at the handler.
+
+### 6.2 The leak boundary is the visible-node position filter — preserve it exactly
+Only segments whose BOTH endpoints resolve in the filtered `nodePositions` map are emitted. A hidden
+intermediate hop breaks the chain (both adjacent segments skipped) and is never revealed. `avgSnr`,
+`leg`, and `isMqtt` are non-sensitive RF/topology metadata about already-visible node pairs — no new
+data class is exposed.
+
+### 6.3 Response is public and cacheable — mind size
+Keep the 24h / 100-traceroute window and add the 500-segment cap (§2.2). Additive fields are ~3 small
+values/segment.
+
+### 6.4 `showPaths` (client gate) vs `showTraceroutes` (server gate)
+Pre-existing: the client fetches/renders traceroutes gated on `config.showPaths`, while the server
+404s unless `profile.showTraceroutes`. Both must effectively be on. This is a pre-existing gate quirk;
+**leave it unchanged** in P6 (aligning it is scope creep — flag to orchestrator if a user reports it).
+
+---
+
+## 7. Approved visible changes (this IS the phase's purpose — enumerated)
+
+Per the epic "one canonical look per feature, no case-by-case appearance approvals," the embed's
+traceroute appearance changes as follows (all intended):
+
+1. **Segment color**: fixed mauve `#cba6f7` → **canonical 4-band SNR** (`excellent`/`good`/`fair`/
+   `poor`/`noData`), scheme-derived: dark palette on dark tilesets, **light palette on light tilesets**
+   (previously mauve regardless of tileset). MQTT/unknown-SNR segments render in `mqttSegment` color.
+2. **Legs / direction**: single straight line per node pair → **forward + return legs** curved
+   opposite ways (curvature 0.2) with **direction arrows**.
+3. **Weight**: fixed 3 → **SNR-scaled** `weightBySnr` (2..6).
+4. **Dashing**: none → **MQTT/unknown-SNR segments dashed** (`3,6`).
+5. **Popup**: SNR now **/4-scaled (correct)** and band-consistent; gains a "via MQTT" indicator.
+6. **Stale old clients** (open/cached old bundles hitting the new server): their popup `{snr} dB` now
+   shows the correct scaled value instead of the former raw ×4 — strict fix, non-breaking; positions/
+   lines unchanged. No other old-client change (additive superset).
+
+Unchanged: node markers, node popup, neighbor lines, legend, tiles, center/zoom/URL-param behavior.
+
+---
+
+## 8. Orchestrator decisions
+
+| # | Question | Recommended resolution |
+|---|---|---|
+| **D1** | Additive-superset vs versioned endpoint vs raw-rows? | **Additive superset + shared `decomposeTraceroute` invoked server-side** (§2.1). Only option that is backward-compatible on one endpoint, honors "one decomposition" (shared util, not re-implemented), keeps the leak boundary, and reduces server code. Confirm. |
+| **D2** | Decompose server-side (util invoked in the route) vs ship raw rows and decompose client-side? | **Server-side** (§2.1/§2.2). Client-side needs raw route arrays → breaks old clients on the shared endpoint or forces a v2 endpoint (double surface); and the client lacks snapshots. Server-side reuses the exact same pure util. Confirm. |
+| **D3** | Embed render preset: rich (curvature 0.2 + arrows + `weightBySnr`, mirrors NodesTab-selected) vs flat (curvature 0 + no arrows + weight 2, mirrors Dashboard-paths)? | **Rich preset** (§3.2) as default — it actually surfaces forward/return legs (flat draws them coincident). Fall back to flat if browser validation finds arrow density too busy on a dense mesh. Orchestrator confirms after D4. |
+| **D4** | Browser validation via a real embed iframe (exit criterion). | Create/enable a profile with `showTraceroutes` + `showPaths` on both a **dark** tileset (cartoDark) and a **light** tileset (osmHot); load `/embed/:id` in an iframe; confirm 4-band colors, light-vs-dark palette switch, legs+arrows, MQTT dashing, and a working popup. Required before merge. |
+| **D5** | Snapshot #1862 for the embed? | **No** (§6.1) — live-only resolve; leak-avoidance + parity with current embed. Confirm. |
+| **D6** | BaseMap adoption / node-popup-family alignment for EmbedMap in P6? | **No** — out of scope; defer to Phase 7 / follow-up (§0). Confirm the boundary. |
+| **D7** | Align the `showPaths`/`showTraceroutes` gate quirk (§6.4)? | **No** — leave pre-existing behavior; scope creep. Confirm. |
+
+---
+
+## 9. Work packages (Sonnet-sized, ordered)
+
+### WP1 — Server: shared-util decomposition + additive fields + tests
+Files: `src/server/routes/embedPublicRoutes.ts`, `src/server/routes/embedPublicRoutes.test.ts` (new).
+**Acceptance:** `/traceroutes` returns the additive-superset bare array via `decomposeTraceroute`
+(bespoke loop deleted); legacy fields preserved; `snr==avgSnr` scaled; forward+return legs; `isMqtt`
+from sentinel; visible-node leak boundary intact; `showTraceroutes` gate + `ALL_SOURCES` cross-source
+unchanged; 500-cap; new route test green; server `tsc` + `lint:ci` clean.
+
+### WP2 — Client: EmbedMap renders via the shared layer + tests + iframe validation *(deps: WP1 wire contract)*
+Files: `src/components/EmbedMap.tsx`, `src/components/EmbedMap.traceroutes.test.tsx` (new).
+**Acceptance:** EmbedMap maps wire→`TracerouteRenderSegment[]`, derives `snrColors`/`mqttColor` from
+`config.tileset`, renders `<TraceroutePathsLayer colorMode="snr" …>` (§3.2) with the new popup; the
+fixed-mauve block is deleted; render test asserts canonical props + light/dark palette switch + both
+legs; browser-validated in an embed iframe on a dark AND a light tileset (D4); full suite `success:true`;
+`lint:ci` clean (no new `any`, no baseline growth).
+
+**Dependency:** WP1 → WP2 (WP2 consumes the WP1 wire shape). WP2 may start against the agreed §2.1
+contract in parallel, but must integrate/validate against the real WP1 endpoint before its PR slice.
+
+---
+
+## 10. Risks & gotchas
+
+- **Old-client compat (primary risk):** the response MUST stay a bare array whose elements keep every
+  legacy field. Do not envelope it, do not rename/drop legacy fields. Test 5.1 pins this.
+- **Anonymous leak surface:** preserve the visible-node position filter as the leak boundary; do NOT
+  ship `routePositions` snapshots or raw hop arrays; live-only `resolvePosition` (§6.1/§6.2).
+- **Embed bundle isolation:** no `useSettings`/`SettingsProvider` exists in `src/embed.tsx` — palette
+  MUST come from `getOverlayColors(getSchemeForTileset(config.tileset))`, and `TraceroutePathsLayer`
+  MUST be fed `snrColors` as a prop (it is context-free by P3 design — verified). Do not add a
+  provider to the embed bundle.
+- **Server importing `src/utils/`:** precedented + `tsconfig.server.json` includes `src/utils/**`
+  (§1.5); `tracerouteSegments.ts` is leaflet/React-free by design. Safe.
+- **SNR scaling:** the util's `avgSnr` is /4-scaled; the old server field was raw. Set `snr=avgSnr`
+  and assert the scaling in tests (feed raw ×4, expect scaled) — a silent regression here would
+  mis-color every band.
+- **Directional dedup:** dedup by the util's `leg:from-to` key, NOT a bidirectional pair key —
+  collapsing legs would drop the return leg the epic requires.
+- **Response size:** 500-segment cap + existing 24h/100-tr window; public/cacheable endpoint.
+- **No route-level test exists today** — WP1 stands up `embedPublicRoutes.test.ts` from scratch
+  (bare-express + seeded singleton DB; the auth harness does not apply).
+- **Verify suite via `--reporter=json`** (`success:true`) — the rtk summary line masks suite-collection
+  failures (project memory).
+</content>
+</invoke>
+
+
+---
+
+## Orchestrator resolutions (gate review 2026-07-10)
+
+- D1–D2, D4–D7: architect recommendations ACCEPTED as written (additive superset wire
+  shape; server-side decomposeTraceroute; palette via getSchemeForTileset; live-only
+  position resolution preserving the leak boundary; bare-express route tests for the
+  anonymous endpoint; snr=avgSnr correction shipped as non-breaking).
+- **D3 → FLAT preset (overriding the 'rich' recommendation).** Embeds render an
+  all-segments overview; the app's canonical look for all-segments views (NodesTab base
+  layer, Dashboard paths pass) is straight/flat, SNR-colored, MQTT/unknown-dashed, no
+  arrows. Arrows are canonical only for single-route views (selected route, widget).
+  Embed consumer props: colorMode 'snr' + mqttColor, curvature 0, weight 2, opacity
+  0.85, dashMode default. This is consistency, not taste.

--- a/src/components/EmbedMap.test.tsx
+++ b/src/components/EmbedMap.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * EmbedMap traceroute rendering (#4047 P6 WP2). The embed bundle has no
+ * SettingsProvider, so this suite pins the palette-from-tileset contract
+ * (§3.1), the wire→TracerouteRenderSegment mapping including old-shape
+ * (pre-WP1) resilience (§3.2), and that the popup capability survives the
+ * fixed-mauve→shared-layer swap (§3.3). `TraceroutePathsLayer` is mocked so
+ * assertions target the exact props EmbedMap computes and passes to it,
+ * rather than re-deriving colors/geometry through the real layer (that
+ * layer's own behavior is covered by TraceroutePathsLayer.test.tsx).
+ */
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { EmbedMap } from './EmbedMap';
+import type { TraceroutePathsLayerProps } from './map/layers/TraceroutePathsLayer';
+import { getOverlayColors, getSchemeForTileset } from '../config/overlayColors';
+
+// ---------------------------------------------------------------------------
+// react-leaflet mock (mirrors TraceroutePathsLayer.test.tsx / NodeMarkersLayer.test.tsx)
+// ---------------------------------------------------------------------------
+
+interface MockChildProps {
+  children?: ReactNode;
+}
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: (props: MockChildProps) => <div data-testid="map-container">{props.children}</div>,
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: (props: MockChildProps) => <div data-testid="marker">{props.children}</div>,
+  Tooltip: (props: MockChildProps) => <div data-testid="tooltip">{props.children}</div>,
+  Popup: (props: MockChildProps) => <div data-testid="popup">{props.children}</div>,
+  Polyline: (props: MockChildProps) => <div data-testid="polyline">{props.children}</div>,
+  GeoJSON: () => <div data-testid="geojson" />,
+}));
+
+// ---------------------------------------------------------------------------
+// TraceroutePathsLayer mock — spy on the exact props EmbedMap passes.
+// ---------------------------------------------------------------------------
+
+const tracerouteLayerSpy = vi.fn();
+
+vi.mock('./map/layers/TraceroutePathsLayer', () => ({
+  TraceroutePathsLayer: (props: TraceroutePathsLayerProps) => {
+    tracerouteLayerSpy(props);
+    return <div data-testid="traceroute-paths-layer" />;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+interface WireSegmentFixture {
+  fromNum: number;
+  toNum: number;
+  fromLat: number;
+  fromLng: number;
+  fromName: string;
+  toLat: number;
+  toLng: number;
+  toName: string;
+  snr: number | null;
+  timestamp: number;
+  leg?: 'forward' | 'return';
+  avgSnr?: number | null;
+  isMqtt?: boolean;
+}
+
+function baseConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'profile-1',
+    channels: [0],
+    tileset: 'cartoDark',
+    defaultLat: 40,
+    defaultLng: -105,
+    defaultZoom: 10,
+    showTooltips: true,
+    showPopups: true,
+    showLegend: true,
+    showPaths: true,
+    showNeighborInfo: false,
+    showMqttNodes: true,
+    pollIntervalSeconds: 300,
+    ...overrides,
+  };
+}
+
+const forwardSegment: WireSegmentFixture = {
+  fromNum: 111,
+  toNum: 222,
+  fromLat: 40.0,
+  fromLng: -105.0,
+  fromName: 'Alpha',
+  toLat: 40.1,
+  toLng: -105.1,
+  toName: 'Bravo',
+  snr: 6,
+  timestamp: 1_700_000_000,
+  leg: 'forward',
+  avgSnr: 6,
+  isMqtt: false,
+};
+
+const returnSegment: WireSegmentFixture = {
+  fromNum: 222,
+  toNum: 111,
+  fromLat: 40.1,
+  fromLng: -105.1,
+  fromName: 'Bravo',
+  toLat: 40.0,
+  toLng: -105.0,
+  toName: 'Alpha',
+  snr: -8,
+  timestamp: 1_700_000_100,
+  leg: 'return',
+  avgSnr: -8,
+  isMqtt: false,
+};
+
+/** Pre-WP1 legacy wire shape — no leg/avgSnr/isMqtt at all. */
+const legacyOnlySegment: WireSegmentFixture = {
+  fromNum: 333,
+  toNum: 444,
+  fromLat: 41.0,
+  fromLng: -106.0,
+  fromName: 'Charlie',
+  toLat: 41.1,
+  toLng: -106.1,
+  toName: 'Delta',
+  snr: 3,
+  timestamp: 1_700_000_200,
+};
+
+function mockFetchSequence(opts: {
+  config?: Record<string, unknown>;
+  nodes?: unknown[];
+  neighborInfo?: unknown[];
+  traceroutes?: WireSegmentFixture[];
+  geojsonLayers?: unknown[];
+}) {
+  const {
+    config = baseConfig(),
+    nodes = [],
+    neighborInfo = [],
+    traceroutes = [],
+    geojsonLayers = [],
+  } = opts;
+
+  global.fetch = vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const respond = (body: unknown) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(body),
+      } as Response);
+
+    if (url.endsWith('/config')) return respond(config);
+    if (url.endsWith('/nodes')) return respond(nodes);
+    if (url.endsWith('/neighborinfo')) return respond(neighborInfo);
+    if (url.endsWith('/traceroutes')) return respond(traceroutes);
+    if (url.endsWith('/geojson/layers')) return respond(geojsonLayers);
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'not found' }) } as Response);
+  }) as unknown as typeof fetch;
+}
+
+async function renderEmbedMap() {
+  render(<EmbedMap profileId="profile-1" />);
+  await waitFor(() => {
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+  });
+}
+
+beforeEach(() => {
+  tracerouteLayerSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EmbedMap traceroute rendering (#4047 P6 WP2)', () => {
+  it('renders TraceroutePathsLayer with the flat consumer preset when showPaths is true', async () => {
+    mockFetchSequence({ traceroutes: [forwardSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+
+    expect(props.colorMode).toBe('snr');
+    expect(props.curvature).toBe(0);
+    expect(props.weight).toBe(2);
+    expect(props.opacity).toBe(0.85);
+    expect(props.dashMode).toBe('mqtt-unknown');
+    expect(props.showArrows).toBeFalsy();
+    expect(props.mqttColor).toBe(getOverlayColors(getSchemeForTileset('cartoDark')).mqttSegment);
+    expect(props.snrColors).toEqual(getOverlayColors(getSchemeForTileset('cartoDark')).snrColors);
+  });
+
+  it('does not render TraceroutePathsLayer when showPaths is false', async () => {
+    mockFetchSequence({ config: baseConfig({ showPaths: false }), traceroutes: [forwardSegment] });
+    await renderEmbedMap();
+
+    // Give any stray async fetch/render a tick, then assert it never rendered.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(tracerouteLayerSpy).not.toHaveBeenCalled();
+  });
+
+  it('maps a new-shape wire response (forward + return legs) onto render segments', async () => {
+    mockFetchSequence({ traceroutes: [forwardSegment, returnSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => {
+      const props = tracerouteLayerSpy.mock.calls.at(-1)?.[0] as TraceroutePathsLayerProps | undefined;
+      expect(props?.segments.length).toBe(2);
+    });
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+
+    const forward = props.segments.find((s) => s.leg === 'forward');
+    const back = props.segments.find((s) => s.leg === 'return');
+
+    expect(forward).toBeDefined();
+    expect(back).toBeDefined();
+    expect(forward!.key).toBe('forward:111-222');
+    expect(back!.key).toBe('return:222-111');
+    expect(forward!.avgSnr).toBe(6);
+    expect(back!.avgSnr).toBe(-8);
+    expect(forward!.from).toEqual([40.0, -105.0]);
+    expect(forward!.to).toEqual([40.1, -105.1]);
+  });
+
+  it('marks a segment MQTT via isMqtt and still renders (dashed, not dropped)', async () => {
+    const mqttSegment: WireSegmentFixture = { ...forwardSegment, fromNum: 555, toNum: 666, leg: 'forward', avgSnr: null, isMqtt: true, snr: null };
+    mockFetchSequence({ traceroutes: [mqttSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+    expect(props.segments).toHaveLength(1);
+    expect(props.segments[0].isMqtt).toBe(true);
+    expect(props.segments[0].avgSnr).toBeNull();
+  });
+
+  it('old-shape resilience: a wire segment lacking leg/avgSnr/isMqtt still yields a render segment', async () => {
+    mockFetchSequence({ traceroutes: [legacyOnlySegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+    expect(props.segments).toHaveLength(1);
+    const seg = props.segments[0];
+    // Defaults: leg -> 'forward', avgSnr falls back to the legacy `snr` field,
+    // isMqtt -> false (old server never sent per-hop MQTT sentinels).
+    expect(seg.leg).toBe('forward');
+    expect(seg.avgSnr).toBe(legacyOnlySegment.snr);
+    expect(seg.isMqtt).toBe(false);
+    expect(seg.key).toBe('forward:333-444');
+    expect(seg.from).toEqual([41.0, -106.0]);
+    expect(seg.to).toEqual([41.1, -106.1]);
+  });
+
+  it('selects the dark palette for a dark tileset (cartoDark)', async () => {
+    mockFetchSequence({ config: baseConfig({ tileset: 'cartoDark' }), traceroutes: [forwardSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+    expect(props.snrColors).toEqual(getOverlayColors('dark').snrColors);
+  });
+
+  it('selects the light palette for a light tileset (osmHot) — differs from dark', async () => {
+    mockFetchSequence({ config: baseConfig({ tileset: 'osmHot' }), traceroutes: [forwardSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+    const lightColors = getOverlayColors('light').snrColors;
+    const darkColors = getOverlayColors('dark').snrColors;
+    expect(props.snrColors).toEqual(lightColors);
+    expect(props.snrColors.excellent).not.toBe(darkColors.excellent);
+  });
+
+  it('passes a renderPopup callback when showPopups is true, and it preserves fromName/toName + scaled SNR', async () => {
+    mockFetchSequence({ traceroutes: [forwardSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+    expect(typeof props.renderPopup).toBe('function');
+
+    const seg = props.segments[0];
+    const popup = props.renderPopup!(seg);
+    render(<>{popup}</>);
+    expect(screen.getByText(/Alpha ↔ Bravo/)).toBeInTheDocument();
+    expect(screen.getByText('6.0 dB')).toBeInTheDocument();
+  });
+
+  it('omits renderPopup when showPopups is false', async () => {
+    mockFetchSequence({ config: baseConfig({ showPopups: false }), traceroutes: [forwardSegment] });
+    await renderEmbedMap();
+
+    await waitFor(() => expect(tracerouteLayerSpy).toHaveBeenCalled());
+    const props = tracerouteLayerSpy.mock.calls.at(-1)![0] as TraceroutePathsLayerProps;
+    expect(props.renderPopup).toBeUndefined();
+  });
+});

--- a/src/components/EmbedMap.tsx
+++ b/src/components/EmbedMap.tsx
@@ -8,6 +8,9 @@ import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getHardwareModelName, getRoleName } from '../utils/nodeHelpers';
 import GeoJsonOverlay from './GeoJsonOverlay';
 import type { GeoJsonLayer } from '../server/services/geojsonService.js';
+import { getOverlayColors, getSchemeForTileset } from '../config/overlayColors';
+import { TraceroutePathsLayer } from './map/layers/TraceroutePathsLayer';
+import type { TracerouteRenderSegment } from '../utils/tracerouteSegments';
 
 interface EmbedConfig {
   id: string;
@@ -69,6 +72,13 @@ interface EmbedTracerouteSegment {
   toName: string;
   snr: number | null;
   timestamp: number;
+  // Additive fields (#4047 P6 WP1) — the server now emits these on every
+  // response, but they're typed optional here so a stale/cached response
+  // from a not-yet-upgraded server (old shape) is tolerated defensively,
+  // mirroring the server's own tolerance of old (pre-WP1) embed clients.
+  leg?: 'forward' | 'return';
+  avgSnr?: number | null;
+  isMqtt?: boolean;
 }
 
 interface EmbedMapProps {
@@ -256,6 +266,83 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filteredNodes.map(n => `${n.nodeNum}-${n.hopsAway}-${n.role}-${n.user?.shortName}`).join(',')]);
 
+  // Traceroute palette (#4047 P6 §3.1) — the embed bundle has no
+  // SettingsProvider, so the SNR palette is derived directly from the
+  // profile's tileset rather than useSettings(). Falls back to the default
+  // tileset id before config loads (getSchemeForTileset defaults unknown
+  // tileset ids to 'dark' anyway).
+  const overlay = useMemo(
+    () => getOverlayColors(getSchemeForTileset(config?.tileset ?? DEFAULT_TILESET_ID)),
+    [config?.tileset],
+  );
+  const snrColors = overlay.snrColors;
+  const mqttColor = overlay.mqttSegment;
+
+  // Wire segment -> shared TracerouteRenderSegment mapping (#4047 P6 §3.2).
+  // Positions are already resolved server-side; this is a pure field rename,
+  // no client-side decomposition. `leg` defaults to 'forward' for a stale
+  // pre-WP1 response (old shape has no leg — everything it sent was a single
+  // forward-only line).
+  const renderSegments: TracerouteRenderSegment[] = useMemo(
+    () => tracerouteSegments.map((s) => {
+      const leg = s.leg ?? 'forward';
+      return {
+        key: `${leg}:${s.fromNum}-${s.toNum}`,
+        from: [s.fromLat, s.fromLng] as [number, number],
+        to: [s.toLat, s.toLng] as [number, number],
+        fromNodeNum: s.fromNum,
+        toNodeNum: s.toNum,
+        leg,
+        avgSnr: s.avgSnr !== undefined ? s.avgSnr : s.snr,
+        isMqtt: s.isMqtt ?? false,
+        timestamp: s.timestamp,
+      };
+    }),
+    [tracerouteSegments],
+  );
+
+  // Popup lookup by the same key so the popup can show fromName/toName
+  // (already on the wire object — zero extra plumbing per §3.3).
+  const tracerouteSegmentsByKey = useMemo(() => {
+    const map = new Map<string, EmbedTracerouteSegment>();
+    for (const s of tracerouteSegments) {
+      const leg = s.leg ?? 'forward';
+      map.set(`${leg}:${s.fromNum}-${s.toNum}`, s);
+    }
+    return map;
+  }, [tracerouteSegments]);
+
+  const renderTraceroutePopup = useCallback((seg: TracerouteRenderSegment) => {
+    const wire = tracerouteSegmentsByKey.get(seg.key);
+    return (
+      <Popup>
+        <div className="embed-popup">
+          <div className="embed-popup-header">Traceroute Segment</div>
+          <div className="embed-popup-grid">
+            <div className="embed-popup-item embed-popup-item-full">
+              <span className="embed-popup-icon">📡</span>
+              <span className="embed-popup-value">
+                {wire ? `${wire.fromName} ↔ ${wire.toName}` : `Node ${seg.fromNodeNum} ↔ Node ${seg.toNodeNum}`}
+              </span>
+            </div>
+            {seg.avgSnr != null && (
+              <div className="embed-popup-item">
+                <span className="embed-popup-icon">📶</span>
+                <span className="embed-popup-value">{seg.avgSnr.toFixed(1)} dB</span>
+              </div>
+            )}
+            {seg.isMqtt && (
+              <div className="embed-popup-item embed-popup-item-full">
+                <span className="embed-popup-icon">🌐</span>
+                <span className="embed-popup-value">via MQTT</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </Popup>
+    );
+  }, [tracerouteSegmentsByKey]);
+
   if (loading) {
     return (
       <div style={{
@@ -320,39 +407,24 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
           />
         )}
 
-        {/* Traceroute path segments */}
-        {config.showPaths && tracerouteSegments.map((seg, idx) => (
-          <Polyline
-            key={`tr-${idx}`}
-            positions={[
-              [seg.fromLat, seg.fromLng],
-              [seg.toLat, seg.toLng],
-            ]}
-            color="#cba6f7"
-            weight={3}
-            opacity={0.8}
-          >
-            {config.showPopups && (
-              <Popup>
-                <div className="embed-popup">
-                  <div className="embed-popup-header">Traceroute Segment</div>
-                  <div className="embed-popup-grid">
-                    <div className="embed-popup-item embed-popup-item-full">
-                      <span className="embed-popup-icon">📡</span>
-                      <span className="embed-popup-value">{seg.fromName} &harr; {seg.toName}</span>
-                    </div>
-                    {seg.snr != null && (
-                      <div className="embed-popup-item">
-                        <span className="embed-popup-icon">📶</span>
-                        <span className="embed-popup-value">{seg.snr} dB</span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </Popup>
-            )}
-          </Polyline>
-        ))}
+        {/* Traceroute path segments — rendered through the shared layer
+            (#4047 P6) with the flat consumer preset (D3): SNR-colored,
+            MQTT/unknown-dashed, no arrows — matching the app's canonical
+            all-segments-overview look (NodesTab base layer / Dashboard
+            paths pass), not the single-route arrowed preset. */}
+        {config.showPaths && (
+          <TraceroutePathsLayer
+            segments={renderSegments}
+            snrColors={snrColors}
+            colorMode="snr"
+            mqttColor={mqttColor}
+            curvature={0}
+            weight={2}
+            opacity={0.85}
+            dashMode="mqtt-unknown"
+            renderPopup={config.showPopups ? renderTraceroutePopup : undefined}
+          />
+        )}
 
         {/* Neighbor info connection lines */}
         {config.showNeighborInfo && neighborSegments.map((seg, idx) => (

--- a/src/server/routes/embedPublicRoutes.test.ts
+++ b/src/server/routes/embedPublicRoutes.test.ts
@@ -1,0 +1,392 @@
+/**
+ * embedPublicRoutes — GET /:profileId/traceroutes (#4047 Phase 6 WP1)
+ *
+ * This is a public/anonymous route (profile-ID-as-token, no session, no
+ * requirePermission) so the `createRouteTestApp` harness — which targets
+ * requirePermission/optionalAuth-protected routes — does not apply
+ * (docs/internal/dev-notes/MAP_CONSOLIDATION_P6_SPEC.md §5.1). Instead this
+ * mounts the router on a bare express() app and seeds the live singleton
+ * `:memory:` SQLite `databaseService` directly, following the DB-seeding
+ * style of embedProfileRoutes.test.ts (minus the auth/session wiring).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import embedPublicRoutes from './embedPublicRoutes.js';
+import databaseService from '../../services/database.js';
+import type { DbTraceroute } from '../../db/types.js';
+
+const createApp = (): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/embed', embedPublicRoutes);
+  return app;
+};
+
+let seq = 0;
+/** Unique-ish node number per test so parallel `it` blocks never collide. */
+const nextNodeNum = () => 0x10000000 + (seq += 1);
+/**
+ * Each `it` block gets its OWN sourceId. The DB singleton persists for the
+ * whole test file (isolate mode resets it only between files), so without
+ * per-test source scoping a later test's `getAllTraceroutes`/`getActiveNodes`
+ * calls would also see nodes/traceroutes seeded by earlier tests — this
+ * mirrors real multi-source isolation (CLAUDE.md "per-source scoping is
+ * mandatory") rather than fighting cross-test contamination with sleeps or
+ * DB resets.
+ */
+const nextSourceId = () => `rt-embed-src-${(seq += 1)}`;
+
+async function seedNode(sourceId: string, overrides: {
+  nodeNum: number;
+  lat?: number | null;
+  lng?: number | null;
+  channel?: number;
+  viaMqtt?: boolean;
+  hideFromMap?: boolean;
+  name?: string;
+}) {
+  await databaseService.nodes.upsertNode(
+    {
+      nodeNum: overrides.nodeNum,
+      nodeId: `!${overrides.nodeNum.toString(16)}`,
+      longName: overrides.name ?? `Node ${overrides.nodeNum}`,
+      shortName: 'ND',
+      latitude: overrides.lat === undefined ? 40.0 : overrides.lat,
+      longitude: overrides.lng === undefined ? -70.0 : overrides.lng,
+      lastHeard: Math.floor(Date.now() / 1000),
+      channel: overrides.channel ?? 0,
+      viaMqtt: overrides.viaMqtt ?? false,
+      hideFromMap: overrides.hideFromMap ?? false,
+    },
+    sourceId,
+  );
+}
+
+async function seedTraceroute(sourceId: string, overrides: Partial<DbTraceroute> & { fromNodeNum: number; toNodeNum: number }) {
+  const now = Date.now();
+  const row: DbTraceroute = {
+    fromNodeNum: overrides.fromNodeNum,
+    toNodeNum: overrides.toNodeNum,
+    fromNodeId: `!${overrides.fromNodeNum.toString(16)}`,
+    toNodeId: `!${overrides.toNodeNum.toString(16)}`,
+    route: overrides.route ?? '[]',
+    routeBack: overrides.routeBack ?? null,
+    snrTowards: overrides.snrTowards ?? null,
+    snrBack: overrides.snrBack ?? null,
+    timestamp: overrides.timestamp ?? now,
+    createdAt: overrides.createdAt ?? now,
+  };
+  await databaseService.traceroutes.insertTraceroute(row, sourceId);
+}
+
+async function createProfile(overrides: {
+  id: string;
+  showTraceroutes?: boolean;
+  channels?: number[];
+  showMqttNodes?: boolean;
+  sourceId: string | null;
+}) {
+  await databaseService.embedProfiles.createAsync({
+    id: overrides.id,
+    name: overrides.id,
+    enabled: true,
+    channels: overrides.channels ?? [],
+    tileset: 'osm',
+    defaultLat: 0,
+    defaultLng: 0,
+    defaultZoom: 10,
+    showTooltips: true,
+    showPopups: true,
+    showLegend: true,
+    showPaths: true,
+    showNeighborInfo: false,
+    showTraceroutes: overrides.showTraceroutes ?? true,
+    showMqttNodes: overrides.showMqttNodes ?? true,
+    pollIntervalSeconds: 30,
+    allowedOrigins: [],
+    sourceId: overrides.sourceId,
+  });
+}
+
+describe('GET /api/embed/:profileId/traceroutes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  it('returns a bare JSON array, not the {success,data} envelope', async () => {
+    const profileId = 'p-bare-array';
+    const sourceId = nextSourceId();
+    const a = nextNodeNum();
+    const b = nextNodeNum();
+    await seedNode(sourceId, { nodeNum: a });
+    await seedNode(sourceId, { nodeNum: b, lat: 40.01, lng: -70.01 });
+    await seedTraceroute(sourceId, { fromNodeNum: a, toNodeNum: b, snrTowards: '[20]' });
+    await createProfile({ id: profileId, sourceId });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).not.toHaveProperty('success');
+    expect(res.body).not.toHaveProperty('data');
+  });
+
+  it('preserves every legacy field and adds the additive fields', async () => {
+    const profileId = 'p-legacy-and-additive';
+    const sourceId = nextSourceId();
+    const a = nextNodeNum();
+    const b = nextNodeNum();
+    await seedNode(sourceId, { nodeNum: a, lat: 41.0, lng: -71.0, name: 'Alpha' });
+    await seedNode(sourceId, { nodeNum: b, lat: 41.01, lng: -71.01, name: 'Bravo' });
+    await seedTraceroute(sourceId, { fromNodeNum: a, toNodeNum: b, snrTowards: '[20]' });
+    await createProfile({ id: profileId, sourceId });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    const seg = res.body[0];
+
+    // Legacy fields (backward-compat contract — old cached clients read these)
+    expect(seg).toMatchObject({
+      fromNum: a,
+      toNum: b,
+      fromLat: 41.0,
+      fromLng: -71.0,
+      fromName: 'Alpha',
+      toLat: 41.01,
+      toLng: -71.01,
+      toName: 'Bravo',
+    });
+    expect(typeof seg.snr).toBe('number');
+    expect(typeof seg.timestamp).toBe('number');
+
+    // Additive fields (new — ignored by old clients)
+    expect(seg).toHaveProperty('leg', 'forward');
+    expect(seg).toHaveProperty('avgSnr');
+    expect(seg).toHaveProperty('isMqtt', false);
+  });
+
+  it('scales legacy snr to match avgSnr (/4 correction — §2.3)', async () => {
+    const profileId = 'p-snr-scaling';
+    const sourceId = nextSourceId();
+    const a = nextNodeNum();
+    const b = nextNodeNum();
+    await seedNode(sourceId, { nodeNum: a });
+    await seedNode(sourceId, { nodeNum: b, lat: 40.01, lng: -70.01 });
+    // Raw firmware int (dB x4) = 20 -> scaled avgSnr = 5
+    await seedTraceroute(sourceId, { fromNodeNum: a, toNodeNum: b, snrTowards: '[20]' });
+    await createProfile({ id: profileId, sourceId });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].avgSnr).toBe(5);
+    expect(res.body[0].snr).toBe(5);
+    expect(res.body[0].snr).toBe(res.body[0].avgSnr);
+  });
+
+  it('yields both forward and return legs when route and routeBack/snrBack are populated (#2051)', async () => {
+    const profileId = 'p-forward-return';
+    const sourceId = nextSourceId();
+    const a = nextNodeNum();
+    const b = nextNodeNum();
+    await seedNode(sourceId, { nodeNum: a });
+    await seedNode(sourceId, { nodeNum: b, lat: 40.01, lng: -70.01 });
+    await seedTraceroute(sourceId, {
+      fromNodeNum: a,
+      toNodeNum: b,
+      route: '[]',
+      snrTowards: '[20]',
+      routeBack: '[]',
+      snrBack: '[16]',
+    });
+    await createProfile({ id: profileId, sourceId });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    const legs = res.body.map((s: { leg: string }) => s.leg).sort();
+    expect(legs).toEqual(['forward', 'return']);
+
+    const forward = res.body.find((s: { leg: string }) => s.leg === 'forward');
+    const back = res.body.find((s: { leg: string }) => s.leg === 'return');
+    expect(forward).toMatchObject({ fromNum: a, toNum: b, avgSnr: 5 });
+    expect(back).toMatchObject({ fromNum: b, toNum: a, avgSnr: 4 });
+  });
+
+  it('marks a sentinel-SNR hop as isMqtt with a null avgSnr (#2931)', async () => {
+    const profileId = 'p-mqtt-sentinel';
+    const sourceId = nextSourceId();
+    const a = nextNodeNum();
+    const b = nextNodeNum();
+    await seedNode(sourceId, { nodeNum: a });
+    await seedNode(sourceId, { nodeNum: b, lat: 40.01, lng: -70.01 });
+    // Raw sentinel INT8_MIN = -128 -> scaled -32 (UNKNOWN_SNR_SENTINEL)
+    await seedTraceroute(sourceId, { fromNodeNum: a, toNodeNum: b, snrTowards: '[-128]' });
+    await createProfile({ id: profileId, sourceId });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ isMqtt: true, avgSnr: null, snr: null });
+  });
+
+  describe('leak boundary — hidden/filtered nodes never appear', () => {
+    it('drops a segment whose endpoint has hideFromMap set (#3549)', async () => {
+      const profileId = 'p-leak-hidefrommap';
+      const sourceId = nextSourceId();
+      const visible = nextNodeNum();
+      const hidden = nextNodeNum();
+      await seedNode(sourceId, { nodeNum: visible });
+      await seedNode(sourceId, { nodeNum: hidden, lat: 40.01, lng: -70.01, hideFromMap: true });
+      await seedTraceroute(sourceId, { fromNodeNum: visible, toNodeNum: hidden, snrTowards: '[20]' });
+      await createProfile({ id: profileId, sourceId });
+
+      const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('drops a segment whose endpoint is off the profile channel list', async () => {
+      const profileId = 'p-leak-channel';
+      const sourceId = nextSourceId();
+      const inChannel = nextNodeNum();
+      const offChannel = nextNodeNum();
+      await seedNode(sourceId, { nodeNum: inChannel, channel: 0 });
+      await seedNode(sourceId, { nodeNum: offChannel, lat: 40.01, lng: -70.01, channel: 5 });
+      await seedTraceroute(sourceId, { fromNodeNum: inChannel, toNodeNum: offChannel, snrTowards: '[20]' });
+      await createProfile({ id: profileId, sourceId, channels: [0] });
+
+      const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('drops a segment whose endpoint is MQTT-bridged when showMqttNodes is off', async () => {
+      const profileId = 'p-leak-mqtt';
+      const sourceId = nextSourceId();
+      const direct = nextNodeNum();
+      const viaMqtt = nextNodeNum();
+      await seedNode(sourceId, { nodeNum: direct });
+      await seedNode(sourceId, { nodeNum: viaMqtt, lat: 40.01, lng: -70.01, viaMqtt: true });
+      await seedTraceroute(sourceId, { fromNodeNum: direct, toNodeNum: viaMqtt, snrTowards: '[20]' });
+      await createProfile({ id: profileId, sourceId, showMqttNodes: false });
+
+      const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('drops a segment whose endpoint has no resolvable position', async () => {
+      const profileId = 'p-leak-positionless';
+      const sourceId = nextSourceId();
+      const withPos = nextNodeNum();
+      const noPos = nextNodeNum();
+      await seedNode(sourceId, { nodeNum: withPos });
+      await seedNode(sourceId, { nodeNum: noPos, lat: null, lng: null });
+      await seedTraceroute(sourceId, { fromNodeNum: withPos, toNodeNum: noPos, snrTowards: '[20]' });
+      await createProfile({ id: profileId, sourceId });
+
+      const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('control: a fully-visible pair on the same setup DOES appear', async () => {
+      const profileId = 'p-leak-control';
+      const sourceId = nextSourceId();
+      const a = nextNodeNum();
+      const b = nextNodeNum();
+      await seedNode(sourceId, { nodeNum: a, channel: 0 });
+      await seedNode(sourceId, { nodeNum: b, lat: 40.01, lng: -70.01, channel: 0 });
+      await seedTraceroute(sourceId, { fromNodeNum: a, toNodeNum: b, snrTowards: '[20]' });
+      await createProfile({ id: profileId, sourceId, channels: [0] });
+
+      const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+  });
+
+  it('404s when showTraceroutes is disabled for the profile', async () => {
+    const profileId = 'p-gate-disabled';
+    const sourceId = nextSourceId();
+    await createProfile({ id: profileId, sourceId, showTraceroutes: false });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: 'Traceroutes not enabled for this profile' });
+  });
+
+  it('404s for an unknown profile id', async () => {
+    const res = await request(app).get('/api/embed/does-not-exist/traceroutes');
+    expect(res.status).toBe(404);
+  });
+
+  it('spans all sources without throwing when the profile has no sourceId (ALL_SOURCES)', async () => {
+    const profileId = 'p-cross-source';
+    const sourceId = nextSourceId();
+    const a = nextNodeNum();
+    const b = nextNodeNum();
+    await seedNode(sourceId, { nodeNum: a });
+    await seedNode(sourceId, { nodeNum: b, lat: 40.01, lng: -70.01 });
+    await seedTraceroute(sourceId, { fromNodeNum: a, toNodeNum: b, snrTowards: '[20]' });
+    await createProfile({ id: profileId, sourceId: null });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('caps the response at 500 segments', async () => {
+    const profileId = 'p-cap-500';
+    const sourceId = nextSourceId();
+    // 24 nodes -> 24*23 = 552 unique ordered pairs, well over the 500 cap,
+    // each traceroute (no intermediate hops) yields exactly one forward
+    // segment on a distinct key so none collapse via dedup.
+    const nodeCount = 24;
+    const nums: number[] = [];
+    for (let i = 0; i < nodeCount; i++) {
+      const n = nextNodeNum();
+      nums.push(n);
+      await seedNode(sourceId, { nodeNum: n, lat: 42 + i * 0.001, lng: -72 + i * 0.001 });
+    }
+
+    const pairs: Array<[number, number]> = [];
+    for (const from of nums) {
+      for (const to of nums) {
+        if (from === to) continue;
+        pairs.push([from, to]);
+        if (pairs.length >= 501) break;
+      }
+      if (pairs.length >= 501) break;
+    }
+    expect(pairs.length).toBeGreaterThanOrEqual(501);
+
+    let ts = Date.now();
+    for (const [from, to] of pairs) {
+      await seedTraceroute(sourceId, { fromNodeNum: from, toNodeNum: to, snrTowards: '[20]', timestamp: ts, createdAt: ts });
+      ts -= 1;
+    }
+    await createProfile({ id: profileId, sourceId });
+
+    const res = await request(app).get(`/api/embed/${profileId}/traceroutes`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeLessThanOrEqual(500);
+  }, 30000);
+});

--- a/src/server/routes/embedPublicRoutes.ts
+++ b/src/server/routes/embedPublicRoutes.ts
@@ -16,8 +16,37 @@ import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { logger } from '../../utils/logger.js';
 import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
 import geojsonService from '../services/geojsonService.js';
+import { decomposeTraceroute } from '../../utils/tracerouteSegments.js';
 
 const router = Router();
+
+// Public/cacheable endpoint — hard ceiling on segment count regardless of how
+// many traceroutes fall inside the 24h/100-row window (#4047 P6 §2.2 step 6).
+const MAX_EMBED_TR_SEGMENTS = 500;
+
+// Wire shape for GET /:profileId/traceroutes — an ADDITIVE SUPERSET of the
+// pre-#4047-P6 shape. Legacy fields (fromNum..timestamp) are UNCHANGED so
+// stale/cached embed bundles keep working; `leg`/`avgSnr`/`isMqtt` are new
+// and ignored by old clients. See docs/internal/dev-notes/MAP_CONSOLIDATION_P6_SPEC.md §2.1.
+interface EmbedTracerouteSegmentV2 {
+  fromNum: number;
+  toNum: number;
+  fromLat: number;
+  fromLng: number;
+  fromName: string;
+  toLat: number;
+  toLng: number;
+  toName: string;
+  // CONSTRAINT (#4047 P6 §2.3): previously the raw un-scaled firmware int
+  // (dB x4) — now carries the same /4-scaled value as `avgSnr`. This is an
+  // intentional, non-breaking correction: an old cached client's popup
+  // `{seg.snr} dB` now shows the CORRECT magnitude instead of 4x too large.
+  snr: number | null;
+  timestamp: number;
+  leg: 'forward' | 'return';
+  avgSnr: number | null;
+  isMqtt: boolean;
+}
 
 // GET /:profileId/config — return public config for the embed profile
 // The CSP middleware is applied per-route so it can access req.params.profileId
@@ -210,10 +239,14 @@ router.get('/:profileId/traceroutes', createEmbedCspMiddleware(), async (req: Re
     const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? ALL_SOURCES); // intentional cross-source: profile without a sourceId spans all sources
     const profileChannels = new Set(profile.channels as number[]);
 
-    // Build position lookup for visible nodes. Use effective position so a
-    // user-set override is what anchors traceroute path segments (issue #2847).
+    // Build position lookup for visible nodes — this is the leak boundary
+    // (#4047 P6 §6.2): a segment is emitted below only when BOTH endpoints
+    // resolve here, so hidden/filtered nodes never leave the server. Same
+    // filters as GET /:profileId/nodes: effective position (#2847), drop
+    // (0,0), drop hideFromMap (#3549), MQTT filter, channel filter.
     const nodePositions = new Map<number, { lat: number; lng: number; name: string }>();
     for (const node of allNodes) {
+      if (node.hideFromMap) continue;
       const eff = getEffectiveDbNodePosition(node);
       if (eff.latitude == null || eff.longitude == null) continue;
       if (eff.latitude === 0 && eff.longitude === 0) continue;
@@ -229,74 +262,74 @@ router.get('/:profileId/traceroutes', createEmbedCspMiddleware(), async (req: Re
       });
     }
 
-    // Get recent traceroutes and decompose into point-to-point segments
+    // Live-only position resolution — deliberately NO snapshot (#1862's
+    // routePositions is not consulted here). This matches the embed's
+    // pre-existing live-only behavior and avoids a new leak: a historical
+    // snapshot could reveal where a now-hidden/filtered node used to be
+    // (#4047 P6 §6.1). decomposeTraceroute skips any segment whose endpoint
+    // resolves to null, so the visible-node filter above is the sole gate.
+    const resolvePosition = (n: number): [number, number] | null => {
+      const p = nodePositions.get(n);
+      return p ? [p.lat, p.lng] : null;
+    };
+
+    // Get recent traceroutes and decompose via the shared util (the ONE
+    // decomposition — also used by the app's TraceroutePathsLayer).
     const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, profile.sourceId ?? ALL_SOURCES); // intentional cross-source: profile without a sourceId spans all sources
     // Traceroute timestamps can be in ms or seconds — normalize to ms
     const cutoffMs = Date.now() - (24 * 60 * 60 * 1000); // last 24h
 
-    // Deduplicate segments by pair (keep most recent)
-    const segmentMap = new Map<string, {
-      fromNum: number; toNum: number;
-      fromLat: number; fromLng: number; fromName: string;
-      toLat: number; toLng: number; toName: string;
-      snr: number | null; timestamp: number;
-    }>();
+    // Dedup by the util's leg-scoped key (`${leg}:${fromNum}-${toNum}`) —
+    // forward and return legs are distinct keys so both survive; keep the
+    // newest timestamp per key. Do NOT collapse to a bidirectional pair key,
+    // that would drop the return leg.
+    const segmentMap = new Map<string, EmbedTracerouteSegmentV2>();
 
     for (const tr of traceroutes) {
-      // Normalize timestamp: if < 1e12 it's in seconds, convert to ms
       const tsMs = tr.timestamp < 1e12 ? tr.timestamp * 1000 : tr.timestamp;
       if (tsMs < cutoffMs) continue;
-      if (!tr.route || tr.route === 'null') continue;
 
-      // Parse the route string — stored as JSON array e.g. "[123,456]"
-      let routeNums: number[];
-      try {
-        const parsed = JSON.parse(tr.route);
-        routeNums = Array.isArray(parsed) ? parsed : [];
-      } catch {
-        continue;
-      }
+      const renderSegments = decomposeTraceroute(tr, { resolvePosition });
+      for (const seg of renderSegments) {
+        const fromInfo = nodePositions.get(seg.fromNodeNum);
+        const toInfo = nodePositions.get(seg.toNodeNum);
+        // Both endpoints resolved (decomposeTraceroute already guarantees
+        // this via resolvePosition), so the names are always present.
+        if (!fromInfo || !toInfo) continue;
 
-      // Build full path: from -> route hops -> to
-      const fullPath = [tr.fromNodeNum, ...routeNums, tr.toNodeNum];
+        const timestamp = seg.timestamp ?? tr.timestamp;
+        const existing = segmentMap.get(seg.key);
+        if (existing && existing.timestamp >= timestamp) continue;
 
-      // Parse SNR values if available — also stored as JSON array
-      let snrValues: number[] = [];
-      if (tr.snrTowards) {
-        try {
-          const parsed = JSON.parse(tr.snrTowards);
-          snrValues = Array.isArray(parsed) ? parsed : [];
-        } catch {
-          // ignore
-        }
-      }
-
-      // Create segments between consecutive nodes in the path
-      for (let i = 0; i < fullPath.length - 1; i++) {
-        const fromNum = fullPath[i];
-        const toNum = fullPath[i + 1];
-        if (!fromNum || !toNum || fromNum === toNum) continue;
-
-        const fromPos = nodePositions.get(fromNum);
-        const toPos = nodePositions.get(toNum);
-        if (!fromPos || !toPos) continue;
-
-        // Canonical key — always lower nodeNum first for dedup
-        const key = fromNum < toNum ? `${fromNum}-${toNum}` : `${toNum}-${fromNum}`;
-        const existing = segmentMap.get(key);
-        if (!existing || tr.timestamp > existing.timestamp) {
-          segmentMap.set(key, {
-            fromNum, toNum,
-            fromLat: fromPos.lat, fromLng: fromPos.lng, fromName: fromPos.name,
-            toLat: toPos.lat, toLng: toPos.lng, toName: toPos.name,
-            snr: snrValues[i] ?? null,
-            timestamp: tr.timestamp,
-          });
-        }
+        segmentMap.set(seg.key, {
+          fromNum: seg.fromNodeNum,
+          toNum: seg.toNodeNum,
+          fromLat: seg.from[0],
+          fromLng: seg.from[1],
+          fromName: fromInfo.name,
+          toLat: seg.to[0],
+          toLng: seg.to[1],
+          toName: toInfo.name,
+          // §2.3: legacy `snr` now carries the /4-scaled `avgSnr` (was the
+          // raw un-scaled dB x4 value) — intentional, non-breaking fix.
+          snr: seg.avgSnr,
+          timestamp,
+          // decomposeTraceroute only ever assigns 'forward'/'return' to
+          // segments it builds (the 'neutral' leg variant is unused here).
+          leg: seg.leg as 'forward' | 'return',
+          avgSnr: seg.avgSnr,
+          isMqtt: seg.isMqtt,
+        });
       }
     }
 
-    res.json(Array.from(segmentMap.values()));
+    // Cap the response — sort newest-first before slicing so the freshest
+    // segments survive the cap (§2.2 step 6; public/cacheable endpoint).
+    const segments = Array.from(segmentMap.values())
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, MAX_EMBED_TR_SEGMENTS);
+
+    res.json(segments);
   } catch (error) {
     logger.error('Error fetching embed traceroutes:', error);
     res.status(500).json({ error: 'Failed to fetch traceroutes' });


### PR DESCRIPTION
## Summary

Phase 6 of the Map Consolidation epic (#4047), targeting `4049-map-refactor`. Public embed maps now render traceroutes with the same canonical visuals as the app — 4-band SNR colors, MQTT/unknown dashing, return legs — via the shared decomposition util and render layer. The API change is strictly additive so cached/old embed clients keep working (and actually get a *corrected* SNR value).

## Changes

- **Server** (`embedPublicRoutes.ts`): the traceroutes handler's bespoke segment loop is replaced by the shared `decomposeTraceroute` (leaflet-free, server-importable by design). Wire shape is an additive superset: all legacy fields preserved + `leg`/`avgSnr`/`isMqtt`. The legacy `snr` field was emitting raw ×4 values — it now carries the correctly /4-scaled average (non-breaking correction). Live-only position resolution — segments emit only when both endpoints are embed-visible, preserving the leak boundary (no historical snapshot positions).
- **🔒 Security fix (found by the new leak-boundary tests):** the traceroutes handler was missing the `hideFromMap` filter that the nodes handler applies — positions of hidden nodes could leak into public embed traceroute segments. Fixed; pinned by 5 leak-boundary tests.
- **Client** (`EmbedMap.tsx`): the fixed-mauve polyline block is deleted; traceroutes render through the shared `TraceroutePathsLayer` with the flat all-segments preset (SNR colors + `mqttSegment` color, straight, weight 2, canonical dash, no arrows — matching the app's all-segments views). Palette derives from the profile's tileset scheme (the embed bundle is context-free). Popups preserved (names + corrected SNR + "via MQTT"). Old-shape API responses still render (fields optional with fallbacks — test-pinned).
- **Net-new test coverage**: 14 route tests + 9 render tests for an endpoint/component that had none.

### Approved visible changes
Embeds change from uniform mauve lines to the canonical SNR-colored + dashed rendering — that is the phase's purpose. Displayed SNR values correct from raw ×4 to scaled dB.

## Issues Resolved
Relates to #4047 (Phase 6 of 7).

## Documentation Updates
- `MAP_CONSOLIDATION_P6_SPEC.md` + epic-doc Phase 6 log (includes the `showPaths`-gates-traceroutes gotcha for future validators).

## Testing
- [x] Full Vitest suite: success:true — 9,585 tests / 0 failures
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] Browser-validated via a real embed profile iframe on the dev container: 60 segments in the canonical light 4-band palette (scheme correctly derived from the OSM tileset), 25 MQTT/unknown-dashed, segment popup shows corrected SNR; markers/GeoJSON overlays unaffected; console clean.
- [ ] Reviewer: note the `hideFromMap` leak fix — worth a quick independent look given it's security-adjacent on a public endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub