### PR TITLE
test(system): send sourceId to endpoints hardened by the sourceid remediation

### DIFF
--- a/tests/api-exercise-test.sh
+++ b/tests/api-exercise-test.sh
@@ -315,7 +315,7 @@ if nodes: print(nodes[0].get('nodeNum',''))
 if [ -n "$FIRST_NODE_ID" ]; then
   check "GET /api/nodes/:nodeId/position-history" "$(api GET /api/nodes/$FIRST_NODE_ID/position-history)" 200
   check "GET /api/nodes/:nodeId/positions" "$(api GET /api/nodes/$FIRST_NODE_ID/positions)" 200
-  check "GET /api/nodes/:nodeId/position-override" "$(api GET /api/nodes/$FIRST_NODE_ID/position-override)" 200 404
+  check "GET /api/nodes/:nodeId/position-override" "$(api GET /api/nodes/$FIRST_NODE_ID/position-override?sourceId=$SOURCE_ID)" 200 404
 else
   log_skip "Node-specific endpoints (no nodes found)"
 fi
@@ -404,7 +404,7 @@ echo -e "${BLUE}=== Security ===${NC}"
 
 check_json "GET /api/security/issues" "GET" "/api/security/issues?sourceId=$SOURCE_ID" "'total' in data and 'nodes' in data"
 check_json "GET /api/security/scanner/status" "GET" "/api/security/scanner/status" "'running' in data"
-check_json "GET /api/security/key-mismatches" "GET" "/api/security/key-mismatches" "'events' in data"
+check_json "GET /api/security/key-mismatches" "GET" "/api/security/key-mismatches?sourceId=$SOURCE_ID" "'events' in data"
 check_json "GET /api/security/dead-nodes" "GET" "/api/security/dead-nodes" "'nodes' in data and 'count' in data"
 check "GET /api/security/export" "$(api GET /api/security/export?sourceId=$SOURCE_ID)" 200
 

--- a/tests/test-config-import.sh
+++ b/tests/test-config-import.sh
@@ -206,6 +206,18 @@ else
 fi
 echo ""
 
+# POST /api/channels/import-config now requires a sourceId (source-scoping
+# remediation). Resolve the primary Meshtastic (TCP) source and send it.
+SOURCE_ID=$(curl -s -b /tmp/meshmonitor-config-import-cookies.txt "http://localhost:$TEST_PORT/api/sources" \
+    | tr '}' '\n' | grep '"type":"meshtastic_tcp"' | head -n1 \
+    | grep -o '"id":"[^"]*"' | head -n1 | cut -d'"' -f4)
+if [ -z "$SOURCE_ID" ]; then
+    echo -e "${RED}✗ FAIL${NC}: Could not resolve a meshtastic_tcp sourceId from /api/sources"
+    exit 1
+fi
+echo -e "${GREEN}✓${NC} Using sourceId: $SOURCE_ID"
+echo ""
+
 # Function to decode URL and extract expected values
 decode_url() {
     local url="$1"
@@ -225,7 +237,7 @@ import_config() {
         -H "Content-Type: application/json" \
         -H "X-CSRF-Token: $CSRF_TOKEN" \
         -b /tmp/meshmonitor-config-import-cookies.txt \
-        -d "{\"url\":\"$url\"}")
+        -d "{\"url\":\"$url\",\"sourceId\":\"$SOURCE_ID\"}")
 
     echo "$response"
 }

--- a/tests/test-v1-api.sh
+++ b/tests/test-v1-api.sh
@@ -352,15 +352,18 @@ run_test "GET /api/v1/packets with filter - Filter by encrypted" \
     '${BASE_URL}/api/v1/packets?encrypted=true&limit=10' \
     | jq -e '.success == true and (.data | type) == \"array\"'"
 
-# Test 12: Get specific packet (if any exist)
-PACKET_ID=$(curl -sS -H "Authorization: Bearer $API_TOKEN" \
-    "${BASE_URL}/api/v1/packets?limit=1" \
-    | jq -r '.data[0].id // empty')
+# Test 12: Get specific packet (if any exist). GET /api/v1/packets/:id now
+# requires a sourceId (packet IDs are a global PK), so grab the packet's own
+# sourceId from the list and scope the by-id read to it.
+FIRST_PACKET=$(curl -sS -H "Authorization: Bearer $API_TOKEN" \
+    "${BASE_URL}/api/v1/packets?limit=1")
+PACKET_ID=$(echo "$FIRST_PACKET" | jq -r '.data[0].id // empty')
+PACKET_SRC=$(echo "$FIRST_PACKET" | jq -r '.data[0].sourceId // empty')
 
 if [ -n "$PACKET_ID" ] && [ "$PACKET_ID" != "null" ]; then
     run_test "GET /api/v1/packets/:id - Get specific packet" \
         "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-        '${BASE_URL}/api/v1/packets/${PACKET_ID}' \
+        '${BASE_URL}/api/v1/packets/${PACKET_ID}?sourceId=${PACKET_SRC}' \
         | jq -e '.success == true and .data.id == $PACKET_ID'"
 fi
 


### PR DESCRIPTION
## Summary

The source-scoping PRs (#4056/#4059/#4061/#4063) made several endpoints **require** a `sourceId`, but system tests were held during those merges — so the breakage only surfaces now (e.g. Configuration Import → HTTP 400). Update the scripts to send one:

- **`test-config-import.sh`** — `POST /api/channels/import-config`: resolve the primary `meshtastic_tcp` source and include `sourceId` in the body.
- **`api-exercise-test.sh`** — `GET /api/nodes/:nodeId/position-override` and `GET /api/security/key-mismatches`: append `?sourceId=$SOURCE_ID`.
- **`test-v1-api.sh`** — `GET /api/v1/packets/:id`: scope to the packet's own `sourceId` taken from the list response.

Verified no other system-test call hits a now-required endpoint without a sourceId. `bash -n` clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)