### PR TITLE
fix: resolve Dashboard neighbor-line endpoints to rendered marker positions (#4042)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -204,6 +204,8 @@ const staleFavoriteNodeWithPosition = {
 };
 
 const neighborLinkWithPositions = {
+  nodeNum: 1,
+  neighborNodeNum: 2,
   nodeLatitude: 35.0,
   nodeLongitude: -80.0,
   neighborLatitude: 36.0,
@@ -213,6 +215,8 @@ const neighborLinkWithPositions = {
 };
 
 const neighborLinkMissingPositions = {
+  nodeNum: 3,
+  neighborNodeNum: 4,
   nodeLatitude: null,
   nodeLongitude: null,
   neighborLatitude: 36.0,

--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -40,7 +40,12 @@ vi.mock('react-leaflet', () => ({
     return <div data-testid="map-marker" data-opacity={opacity}>{children}</div>;
   },
   Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
-  Polyline: () => <div data-testid="map-polyline" />,
+  // #4042: expose resolved positions so tests can assert a neighbor line
+  // terminates at a node's rendered marker position (not the link's raw
+  // embedded lat/lng) — mirrors NeighborLinksLayer.test.tsx's mock.
+  Polyline: ({ positions }: any) => (
+    <div data-testid="map-polyline" data-positions={JSON.stringify(positions)} />
+  ),
   Rectangle: () => <div data-testid="map-rectangle" />,
   useMap: () => ({ fitBounds: vi.fn(), setView: vi.fn() }),
 }));
@@ -214,6 +219,34 @@ const neighborLinkWithPositions = {
   snr: 5,
 };
 
+// #4042 fixtures: a node whose rendered marker position (100) DIFFERS from
+// the neighbor-link's own embedded coordinates, to prove endpoint resolution
+// prefers the marker. neighborNum 999 has no corresponding node/marker, so
+// its endpoint must fall back to the link's embedded coordinates.
+const nodeWithMergedPosition = {
+  user: { id: 'node-7', shortName: 'N7', longName: 'Merged Position Node' },
+  position: { latitude: 40.0, longitude: -90.0 },
+  hopsAway: 1,
+  role: 1,
+  lastHeard: recent,
+  nodeNum: 100,
+};
+
+const neighborLinkStaleEmbeddedCoords = {
+  nodeNum: 100,
+  neighborNodeNum: 999,
+  // Stale/source-specific coordinates for nodeNum 100 — should be ignored in
+  // favor of its rendered marker position (40.0, -90.0) above.
+  nodeLatitude: 10.0,
+  nodeLongitude: -20.0,
+  // neighborNodeNum 999 has no node/marker on the map, so this embedded
+  // fallback coordinate IS expected to be used.
+  neighborLatitude: 50.0,
+  neighborLongitude: -100.0,
+  bidirectional: true,
+  snr: 5,
+};
+
 const neighborLinkMissingPositions = {
   nodeNum: 3,
   neighborNodeNum: 4,
@@ -350,6 +383,25 @@ describe('DashboardMap', () => {
     const polylines = screen.getAllByTestId('map-polyline');
     // Only the link with valid positions should be rendered
     expect(polylines.length).toBe(1);
+  });
+
+  it('resolves a neighbor-link endpoint to the rendered marker position when present, falling back to the embedded coordinate otherwise (#4042)', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithMergedPosition]}
+        neighborInfo={[neighborLinkStaleEmbeddedCoords]}
+      />,
+    );
+    const polyline = screen.getByTestId('map-polyline');
+    const positions = JSON.parse(polyline.getAttribute('data-positions') ?? 'null');
+    // nodeNum 100 has a rendered marker at [40.0, -90.0] — the resolved
+    // endpoint uses that marker position, NOT the link's stale embedded
+    // [10.0, -20.0].
+    expect(positions[0]).toEqual([40.0, -90.0]);
+    // neighborNodeNum 999 has no node/marker on the map — its endpoint falls
+    // back to the link's embedded coordinate.
+    expect(positions[1]).toEqual([50.0, -100.0]);
   });
 
   it('shows empty state overlay when no nodes have positions', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -272,19 +272,6 @@ export default function DashboardMap({
     })
     .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
 
-  // Build a map of nodeNum → marker position for resolving neighbor-info endpoints (#4042).
-  // When a node appears on multiple sources at different positions, the marker uses the
-  // merged position (from useDashboardData), but neighbor records carry source-specific
-  // coordinates. Using resolveMapEndpoint ensures lines connect to the rendered marker
-  // position rather than floating to a stale source-specific coordinate.
-  const nodePositionsMap = useMemo(() => {
-    const posMap = new Map<number, [number, number]>();
-    nodesWithPosition.forEach(({ node, pos }) => {
-      posMap.set(node.nodeNum, [pos.lat, pos.lng]);
-    });
-    return posMap;
-  }, [nodesWithPosition]);
-
   // Array form of node positions for MapBoundsUpdater (fit bounds).
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
 
@@ -343,6 +330,13 @@ export default function DashboardMap({
   // #4047 Phase 7 WP7) so the same link reported by multiple sources (Unified
   // view) draws once. Emits descriptors for the shared `NeighborLinksLayer` —
   // fixed cyan/dashed look preserved verbatim, no `children` (no popup).
+  //
+  // #4042 note: unlike the Meshtastic `neighborInfo` links below, MeshCore
+  // neighbor edges (`meshcoreNeighbors`) carry no embedded per-edge lat/lng at
+  // all — only `publicKey`/`neighborPublicKey`/`snr` (see meshcore_neighbor_info
+  // schema + getNeighbors() repo query). Endpoints are already resolved
+  // exclusively through `positionByPublicKey` (the rendered-marker-position
+  // map below), so there is no stale-embedded-coordinate fallback to fix here.
   const meshcoreNeighborLinks = useMemo<NeighborLinkDescriptor[]>(() => {
     if (!showNeighborInfo) return [];
     // Untyped intermediate (publicKey/neighborPublicKey/positions/snr only —
@@ -515,6 +509,16 @@ export default function DashboardMap({
   // Emits descriptors for the shared `NeighborLinksLayer` (#4047 Phase 7 WP7) —
   // bidirectional solid vs unidirectional dashed transport-colored look and the
   // `DashboardNeighborPopup` popup preserved verbatim.
+  //
+  // #4042: endpoints are resolved through `resolveMapEndpoint` against
+  // `positionByNodeNum` (the same rendered-marker-position map traceroute
+  // hops use, built above from `nodesWithPosition`) rather than the link's
+  // own embedded lat/lng. When a node appears on multiple sources at
+  // different GPS coordinates, the marker renders at the merged position,
+  // but the neighbor record carries source-specific coordinates — preferring
+  // the rendered marker position keeps the line's end attached to the pin.
+  // The embedded coordinates remain a fallback for a node that currently has
+  // no marker on the map (filtered off by age/transport/etc).
   const meshtasticNeighborLinks: NeighborLinkDescriptor[] = showNeighborInfo
     ? neighborInfo
         .filter((link: any) => {
@@ -525,24 +529,18 @@ export default function DashboardMap({
           return true;
         })
         .map((link: any, idx: number): NeighborLinkDescriptor | null => {
-          const { nodeLatitude, nodeLongitude, neighborLatitude, neighborLongitude, bidirectional, transportClass } = link;
-          if (
-            nodeLatitude == null ||
-            nodeLongitude == null ||
-            neighborLatitude == null ||
-            neighborLongitude == null
-          ) {
+          const nodeEndpoint = resolveMapEndpoint(positionByNodeNum, link.nodeNum, link.nodeLatitude, link.nodeLongitude);
+          const neighborEndpoint = resolveMapEndpoint(positionByNodeNum, link.neighborNodeNum, link.neighborLatitude, link.neighborLongitude);
+          // Skip if either endpoint has no resolvable position (no marker AND no embedded coords).
+          if (!nodeEndpoint || !neighborEndpoint) {
             return null;
           }
 
-          const positions: [[number, number], [number, number]] = [
-            [nodeLatitude, nodeLongitude],
-            [neighborLatitude, neighborLongitude],
-          ];
+          const positions: [[number, number], [number, number]] = [nodeEndpoint, neighborEndpoint];
 
-          const tc = transportClass ?? 'rf';
+          const tc = link.transportClass ?? 'rf';
           const colorByTransport = tc === 'mqtt' ? '#22c55e' : tc === 'udp' ? '#f97316' : 'blue';
-          const pathOptions: PathOptions = bidirectional
+          const pathOptions: PathOptions = link.bidirectional
             ? { color: colorByTransport, weight: 2, opacity: 0.6 }
             : { color: colorByTransport, weight: 1, opacity: 0.6, dashArray: '5, 5' };
 

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -43,6 +43,7 @@ import { getOwnNodePositions } from '../../utils/ownNodePositions';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 import { isNullIsland } from '../../utils/nullIsland';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
+import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { BaseMap } from '../map/BaseMap';
@@ -271,6 +272,20 @@ export default function DashboardMap({
     })
     .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
 
+  // Build a map of nodeNum → marker position for resolving neighbor-info endpoints (#4042).
+  // When a node appears on multiple sources at different positions, the marker uses the
+  // merged position (from useDashboardData), but neighbor records carry source-specific
+  // coordinates. Using resolveMapEndpoint ensures lines connect to the rendered marker
+  // position rather than floating to a stale source-specific coordinate.
+  const nodePositionsMap = useMemo(() => {
+    const posMap = new Map<number, [number, number]>();
+    nodesWithPosition.forEach(({ node, pos }) => {
+      posMap.set(node.nodeNum, [pos.lat, pos.lng]);
+    });
+    return posMap;
+  }, [nodesWithPosition]);
+
+  // Array form of node positions for MapBoundsUpdater (fit bounds).
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
 
   // #3636: measurement endpoints — nearest-node snapping picks from these.


### PR DESCRIPTION
## Summary

Rebase of #4055 (@temalo) onto the Map Consolidation epic (#4047), which merged while that PR was open and replaced the inline neighbor rendering it patched.

- Commit 1 is temalo's original fix, authorship preserved, replayed through the rebase.
- Commit 2 ports its semantics onto the shared `NeighborLinksLayer` descriptor code: both endpoints of each Dashboard meshtastic neighbor link now resolve through `resolveMapEndpoint` against `positionByNodeNum` (the same rendered-marker-position map the traceroute resolver uses, which also filters null-island entries), falling back to embedded coordinates only when the node has no marker. Links with no resolvable endpoint are skipped.
- The MeshCore neighbor memo needed no change — its rows carry no embedded coordinates, so no stale-coordinate path exists (now documented in-code).
- New test pins the #4042 behavior: endpoint snaps to the marker position when one exists, falls back when not.

Fixes #4042. Supersedes #4055.

## Testing
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] `npx vitest run src/components/Dashboard/ src/components/map/` — 247/247 passing (JSON-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub