### PR TITLE
fix(map): post-epic fixes — wheel zoom, zoom-to-node, chunk-reload self-heal; MeshCore polar grid + map loading states (#4047)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -371,6 +371,44 @@ describe('DashboardMap', () => {
     expect(screen.queryByText('No node positions')).not.toBeInTheDocument();
   });
 
+  // --- Loading overlay (initial-fetch spinner) --------------------------------
+
+  it('shows the loading overlay instead of the empty state while isLoading is true', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithoutPosition, nodeWithZeroPosition]}
+        isLoading
+      />,
+    );
+    expect(screen.getByTestId('map-loading-overlay')).toBeInTheDocument();
+    expect(screen.queryByText('No node positions')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state (not the loading overlay) once loading resolves with no positioned nodes', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithoutPosition, nodeWithZeroPosition]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.queryByTestId('map-loading-overlay')).not.toBeInTheDocument();
+    expect(screen.getByText('No node positions')).toBeInTheDocument();
+  });
+
+  it('shows neither overlay once loading resolves with positioned nodes', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithPosition]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.queryByTestId('map-loading-overlay')).not.toBeInTheDocument();
+    expect(screen.queryByText('No node positions')).not.toBeInTheDocument();
+  });
+
   it('does not render markers for ignored nodes even when they have a position', () => {
     render(
       <DashboardMap

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -46,6 +46,7 @@ import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { BaseMap } from '../map/BaseMap';
+import { MapLoadingOverlay } from '../map/MapLoadingOverlay';
 import { TraceroutePathsLayer } from '../map/layers/TraceroutePathsLayer';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from '../map/layers/NeighborLinksLayer';
 import { AccuracyRegionsLayer, type AccuracyRegionDescriptor } from '../map/layers/AccuracyRegionsLayer';
@@ -80,6 +81,14 @@ export interface DashboardMapProps {
    * page can navigate to that source's Node Details view for the node.
    */
   onNodeSourceSelect?: (source: NodeSourceRef, nodeId: string | undefined) => void;
+  /**
+   * True while the FIRST fetch of `nodes` for the current selection is still
+   * in flight (from `useDashboardSourceData`/`useDashboardUnifiedData`'s
+   * `isLoading`). Shows a loading overlay instead of the "No node positions"
+   * empty state so a slow initial load doesn't flash a false-empty map.
+   * Defaults to false so existing callers/tests are unaffected.
+   */
+  isLoading?: boolean;
 }
 
 /** Extract lat/lng from a node — handles both flat (API) and nested (position) shapes. */
@@ -136,6 +145,7 @@ export default function DashboardMap({
   sourceId,
   maxNodeAgeHours,
   onNodeSourceSelect,
+  isLoading = false,
 }: DashboardMapProps) {
   const { mapPinStyle, setMapTileset, overlayColors } = useSettings();
 
@@ -826,7 +836,9 @@ export default function DashboardMap({
         </div>
       </div>
 
-      {!hasNodes && (
+      {isLoading && <MapLoadingOverlay />}
+
+      {!isLoading && !hasNodes && (
         <div className="dashboard-map-empty">
           <div className="dashboard-map-empty-content">
             <h3>No node positions</h3>

--- a/src/components/MeshCore/MeshCoreMap.test.tsx
+++ b/src/components/MeshCore/MeshCoreMap.test.tsx
@@ -103,3 +103,29 @@ describe('MeshCoreMap polar grid toggle', () => {
     expect(localStorage.getItem('meshmonitor-meshcore-showPolarGrid')).toBe('true');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Loading overlay (initial contacts-snapshot fetch spinner)
+// ---------------------------------------------------------------------------
+
+describe('MeshCoreMap loading overlay', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+  });
+
+  it('shows the loading overlay while isLoading is true, even with no contacts', () => {
+    render(<MeshCoreMap contacts={[]} selectedPublicKey={null} isLoading />);
+    expect(screen.getByTestId('map-loading-overlay')).toBeInTheDocument();
+  });
+
+  it('hides the loading overlay once isLoading resolves to false', () => {
+    render(<MeshCoreMap contacts={[]} selectedPublicKey={null} isLoading={false} />);
+    expect(screen.queryByTestId('map-loading-overlay')).not.toBeInTheDocument();
+  });
+
+  it('omits the loading overlay by default (isLoading not passed)', () => {
+    render(<MeshCoreMap contacts={[]} selectedPublicKey={null} />);
+    expect(screen.queryByTestId('map-loading-overlay')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MeshCore/MeshCoreMap.test.tsx
+++ b/src/components/MeshCore/MeshCoreMap.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Light smoke test for the MeshCore map's "Show Polar Grid" toggle (#4047
+ * follow-up). Heavy map internals (BaseMap/react-leaflet, the marker/neighbor
+ * layers, GeoJSON overlay, legend, measure controller) are stubbed out —
+ * this suite only proves the toggle's persistence + disabled/gating contract
+ * and that `PolarGridOverlay` is centered on the local node position, not
+ * real Leaflet rendering (mirrors the DashboardMap.test.tsx mocking style).
+ */
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MeshCoreMap } from './MeshCoreMap';
+
+vi.mock('../map/BaseMap', () => ({
+  BaseMap: ({ children }: { children: ReactNode }) => <div data-testid="base-map">{children}</div>,
+}));
+
+vi.mock('../map/layers/NodeMarkersLayer', () => ({
+  NodeMarkersLayer: () => <div data-testid="node-markers-layer" />,
+}));
+
+vi.mock('../map/layers/NeighborLinksLayer', () => ({
+  NeighborLinksLayer: () => <div data-testid="neighbor-links-layer" />,
+}));
+
+vi.mock('../GeoJsonOverlay', () => ({
+  default: () => <div data-testid="geojson-overlay" />,
+}));
+
+vi.mock('../MapLegend', () => ({
+  default: () => <div data-testid="map-legend" />,
+}));
+
+vi.mock('../MeasureDistanceController', () => ({
+  default: () => null,
+}));
+
+vi.mock('../PolarGridOverlay', () => ({
+  default: (props: { center: { lat: number; lng: number } }) => (
+    <div data-testid="polar-grid-overlay" data-center={JSON.stringify(props.center)} />
+  ),
+}));
+
+vi.mock('react-leaflet', () => ({
+  Popup: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Polyline: () => null,
+}));
+
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ mapTileset: 'osm', customTilesets: [], setMapTileset: vi.fn() }),
+  useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
+vi.mock('../../contexts/SourceContext', () => ({
+  useSource: () => ({ sourceId: 'src-1' }),
+}));
+
+vi.mock('../../services/api', () => ({
+  default: {
+    getBaseUrl: vi.fn().mockResolvedValue(''),
+    get: vi.fn().mockResolvedValue({ success: true, data: { items: [] } }),
+  },
+}));
+
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+describe('MeshCoreMap polar grid toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+  });
+
+  it('is disabled with a tooltip when the local node has no position', () => {
+    render(<MeshCoreMap contacts={[]} selectedPublicKey={null} localNodePosition={null} />);
+
+    const checkbox = screen.getByLabelText('map.showPolarGrid') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(true);
+    expect(screen.queryByTestId('polar-grid-overlay')).not.toBeInTheDocument();
+  });
+
+  it('renders the shared PolarGridOverlay centered on the local node position when toggled on', () => {
+    render(
+      <MeshCoreMap
+        contacts={[]}
+        selectedPublicKey={null}
+        localNodePosition={{ lat: 40.1, lng: -105.2 }}
+      />,
+    );
+
+    const checkbox = screen.getByLabelText('map.showPolarGrid') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(false);
+    expect(screen.queryByTestId('polar-grid-overlay')).not.toBeInTheDocument();
+
+    fireEvent.click(checkbox);
+
+    const overlay = screen.getByTestId('polar-grid-overlay');
+    expect(JSON.parse(overlay.getAttribute('data-center')!)).toEqual({ lat: 40.1, lng: -105.2 });
+    expect(localStorage.getItem('meshmonitor-meshcore-showPolarGrid')).toBe('true');
+  });
+});

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -14,6 +14,7 @@ import { createNodeIcon } from '../map/markerIcons';
 import { BaseMap } from '../map/BaseMap';
 import { NodeMarkersLayer, type NodeMarkerDescriptor } from '../map/layers/NodeMarkersLayer';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from '../map/layers/NeighborLinksLayer';
+import PolarGridOverlay from '../PolarGridOverlay';
 import { useSource } from '../../contexts/SourceContext';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { isNullIsland } from '../../utils/nullIsland';
@@ -135,6 +136,18 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   }, [positionHistoryHours]);
   // publicKey -> ordered (oldest→newest) [lat, lng] trail points.
   const [positionHistory, setPositionHistory] = useState<Map<string, [number, number][]>>(new Map());
+
+  // Polar grid overlay (#4047 follow-up) — the same shared range-ring/azimuth-
+  // sector grid NodesTab/DashboardMap/Map Analysis draw, centered on the LOCAL
+  // MeshCore node's position. Persisted per-browser like the other MeshCore
+  // map toggles above (MeshCoreMap doesn't sit inside a `MapProvider`, so it
+  // can't reuse MapContext's server-persisted `showPolarGrid`).
+  const [showPolarGrid, setShowPolarGrid] = useState(
+    () => localStorage.getItem('meshmonitor-meshcore-showPolarGrid') === 'true',
+  );
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-meshcore-showPolarGrid', String(showPolarGrid));
+  }, [showPolarGrid]);
 
   // Server-side rolling retention window (days) for stored trail points. This
   // is a global setting (`meshcore_position_history_retention_days`, default 7)
@@ -460,6 +473,9 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         )}
         {showLegend && <MapLegend showNodeTypes />}
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
+        {showPolarGrid && localPos && (
+          <PolarGridOverlay center={{ lat: localPos[0], lng: localPos[1] }} />
+        )}
         <NodeMarkersLayer markers={markers} />
 
         {historySegments.map(s => (
@@ -555,6 +571,17 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
               />
             </div>
           )}
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showPolarGrid}
+              onChange={(e) => setShowPolarGrid(e.target.checked)}
+              disabled={!localPos}
+            />
+            <span title={!localPos ? t('map.polarGridDisabledTooltip', 'Requires own node position') : undefined}>
+              {t('map.showPolarGrid', 'Show Polar Grid')}
+            </span>
+          </label>
           <label className="map-control-item">
             <input
               type="checkbox"

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../utils/nodeTypeCategory';
 import { createNodeIcon } from '../map/markerIcons';
 import { BaseMap } from '../map/BaseMap';
+import { MapLoadingOverlay } from '../map/MapLoadingOverlay';
 import { NodeMarkersLayer, type NodeMarkerDescriptor } from '../map/layers/NodeMarkersLayer';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from '../map/layers/NeighborLinksLayer';
 import PolarGridOverlay from '../PolarGridOverlay';
@@ -68,9 +69,17 @@ interface MeshCoreMapProps {
   selectedPublicKey: string | null;
   localNodePosition?: { lat: number; lng: number } | null;
   onNavigateToDm?: (publicKey: string) => void;
+  /**
+   * True while the FIRST contacts snapshot fetch is still in flight (see
+   * `useMeshCore`'s `hasLoadedOnce`). Shows a loading overlay so a slow
+   * initial connect doesn't render an apparently-empty world map before
+   * contacts have a chance to arrive. Defaults to false so existing
+   * callers/tests are unaffected.
+   */
+  isLoading?: boolean;
 }
 
-export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm }) => {
+export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm, isLoading = false }) => {
   const { t } = useTranslation();
   const { mapTileset, customTilesets, setMapTileset } = useSettings();
   const { timeFormat, dateFormat } = useDisplaySettings();
@@ -503,6 +512,8 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
 
         <NeighborLinksLayer links={neighborLinks} />
       </BaseMap>
+
+      {isLoading && <MapLoadingOverlay />}
 
       <div className="map-controls dashboard-map-controls">
         <div className="map-controls-body">

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -28,6 +28,12 @@ interface MeshCoreNodesViewProps {
   onDiscoverNodes?: (mode: DiscoverMode) => Promise<{ returned: number; newCount: number } | null>;
   /** Gate for the Discover menu — connected companion device. */
   canDiscover?: boolean;
+  /**
+   * True while the FIRST contacts snapshot fetch is still in flight.
+   * Forwarded to the embedded `MeshCoreMap` to show a loading overlay
+   * instead of an apparently-empty map during initial connect.
+   */
+  mapIsLoading?: boolean;
 }
 
 interface MergedRow {
@@ -117,6 +123,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   onToggleFavorite,
   onDiscoverNodes,
   canDiscover,
+  mapIsLoading,
 }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
@@ -417,7 +424,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
             )}
           </div>
         )}
-        <MeshCoreMap contacts={contacts} selectedPublicKey={selected} onNavigateToDm={onNavigateToDm} />
+        <MeshCoreMap contacts={contacts} selectedPublicKey={selected} onNavigateToDm={onNavigateToDm} isLoading={mapIsLoading} />
       </div>
       {importDialogOpen && (
         <div

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -61,7 +61,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
   const { authStatus } = useAuth();
   const isAdmin = authStatus?.user?.isAdmin ?? false;
   const meshCore = useMeshCore({ baseUrl, sourceId, enabled });
-  const { status, nodes, contacts, messages, loading, error, actions } = meshCore;
+  const { status, nodes, contacts, messages, loading, hasLoadedOnce, error, actions } = meshCore;
 
   const [view, setView] = useState<MeshCoreView>('nodes');
   const [toolbarExpanded, setToolbarExpanded] = useState(false);
@@ -128,6 +128,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               onToggleFavorite={actions.setNodeFavorite}
               onDiscoverNodes={actions.discoverNodes}
               canDiscover={(status?.connected ?? false) && status?.deviceType === DEVICE_TYPE_COMPANION}
+              mapIsLoading={!hasLoadedOnce}
             />
           )}
           {view === 'channels' && (

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -325,6 +325,14 @@ export interface UseMeshCoreState {
   contacts: MeshCoreContact[];
   messages: MeshCoreMessage[];
   loading: boolean;
+  /**
+   * True once the first contacts/nodes snapshot fetch has resolved (success
+   * or failure). False only before that — unlike `loading`, this does not
+   * flip back on subsequent connect/disconnect/refresh calls. Intended for
+   * "is the initial load still pending" UI (e.g. MeshCoreMap's loading
+   * overlay), not general busy-state.
+   */
+  hasLoadedOnce: boolean;
   error: string | null;
   actions: MeshCoreActions;
 }
@@ -359,6 +367,13 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
   const [messages, setMessages] = useState<MeshCoreMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // True once the FIRST snapshot fetch (mount-time loadSnapshot below) has
+  // resolved — success or failure, so a permanently-erroring source doesn't
+  // block the UI forever. Distinct from `loading` (which also flips true/
+  // false on every connect/disconnect/refresh) — consumers that need "is the
+  // very first load still pending" (e.g. MeshCoreMap's loading overlay) want
+  // this, not `loading`.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
   const connectedRef = useRef(false);
   // Per-source push-event bookkeeping. seqCursorRef tracks the newest message
@@ -468,12 +483,21 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
   }, [status?.connected]);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      // No fetch will run while disabled — don't leave a loading-overlay
+      // consumer waiting forever for a snapshot that will never come.
+      setHasLoadedOnce(true);
+      return;
+    }
     // Snapshot on mount, then 30s status-only safety poll. Live updates ride
     // in over Socket.io (see the push-events effect below).
-    void loadSnapshot();
+    let cancelled = false;
+    void loadSnapshot().finally(() => {
+      if (!cancelled) setHasLoadedOnce(true);
+    });
     const interval = setInterval(() => { void fetchStatus(); }, STATUS_SAFETY_POLL_MS);
     return () => {
+      cancelled = true;
       clearInterval(interval);
     };
   }, [enabled, loadSnapshot, fetchStatus]);
@@ -1717,6 +1741,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     contacts,
     messages,
     loading,
+    hasLoadedOnce,
     error,
     actions: {
       connect,

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -42,6 +42,7 @@ import PacketMonitorPanel from './PacketMonitorPanel';
 import { getPacketStats } from '../services/packetApi';
 
 import { BaseMap } from './map/BaseMap';
+import { MapLoadingOverlay } from './map/MapLoadingOverlay';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from './map/layers/NeighborLinksLayer';
 import { AccuracyRegionsLayer, type AccuracyRegionDescriptor } from './map/layers/AccuracyRegionsLayer';
 import { NodeCard } from './map/popups/NodeCard';
@@ -379,7 +380,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   } = useMapContext();
 
   const { currentNodeId } = useDeviceConfig();
-  const { nodes } = useNodes();
+  // `isLoading` reflects TanStack Query's pending state for the shared poll
+  // query — true only until the FIRST poll response resolves (success or
+  // error), regardless of how many nodes come back. That's exactly "first
+  // fetch unresolved", so no new plumbing is needed beyond reading it here.
+  const { nodes, isLoading: nodesIsLoading } = useNodes();
 
   // Compute own node position for polar grid overlay (needs to be at component scope)
   const ownHomeNode = nodes.find(n => n.user?.id === currentNodeId);
@@ -2646,7 +2651,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               {positionHistoryElements}
 
           </BaseMap>
-          {shouldShowData() && nodesWithPosition.length === 0 && (
+          {shouldShowData() && nodesIsLoading && <MapLoadingOverlay />}
+          {shouldShowData() && !nodesIsLoading && nodesWithPosition.length === 0 && (
             <div className="map-overlay">
               <div className="overlay-content">
                 <h3>📍 No Node Locations</h3>

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -13,7 +13,13 @@ import { getTilesetById } from '../../config/tilesets';
 
 vi.mock('react-leaflet', () => ({
   MapContainer: ({ children, ...props }: { children?: ReactNode; scrollWheelZoom?: boolean }) => (
-    <div data-testid="map-container" data-scrollwheel={String(props.scrollWheelZoom)}>
+    <div
+      data-testid="map-container"
+      data-scrollwheel={String(props.scrollWheelZoom)}
+      data-own-option-keys={['scrollWheelZoom', 'doubleClickZoom', 'zoomControl', 'attributionControl']
+        .filter((k) => k in props)
+        .join(',')}
+    >
       {children}
     </div>
   ),
@@ -158,6 +164,16 @@ describe('BaseMap', () => {
   it('forwards scrollWheelZoom to MapContainer', () => {
     render(<BaseMap center={[0, 0]} zoom={3} scrollWheelZoom />);
     expect(screen.getByTestId('map-container').getAttribute('data-scrollwheel')).toBe('true');
+  });
+
+  it('omits interaction options entirely when not passed — an explicit undefined would override Leaflet defaults and disable the handlers (#4047 wheel-zoom regression)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} />);
+    expect(screen.getByTestId('map-container').getAttribute('data-own-option-keys')).toBe('');
+  });
+
+  it('includes only the interaction options that were explicitly passed', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} scrollWheelZoom={false} zoomControl />);
+    expect(screen.getByTestId('map-container').getAttribute('data-own-option-keys')).toBe('scrollWheelZoom,zoomControl');
   });
 
   // 8. Icon fix applied (unmocked icon module, real leaflet)

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -96,6 +96,24 @@ export function BaseMap({
   const resolvedId = tilesetId ?? DEFAULT_TILESET_ID;
   const tileset = getTilesetById(resolvedId, customTilesets ?? []);
 
+  // Leaflet's setOptions copies EVERY own key of the options object, so an
+  // explicit `scrollWheelZoom: undefined` OVERRIDES the prototype default
+  // (true) and disables the handler — react-leaflet does no undefined
+  // filtering before `new LeafletMap(node, options)`. Omitted props must
+  // therefore not appear in the options object at all (#4047 regression:
+  // wheel zoom / double-click zoom died on every consumer that relied on
+  // Leaflet defaults).
+  const interactionOptions: {
+    scrollWheelZoom?: boolean;
+    doubleClickZoom?: boolean;
+    zoomControl?: boolean;
+    attributionControl?: boolean;
+  } = {};
+  if (scrollWheelZoom !== undefined) interactionOptions.scrollWheelZoom = scrollWheelZoom;
+  if (doubleClickZoom !== undefined) interactionOptions.doubleClickZoom = doubleClickZoom;
+  if (zoomControl !== undefined) interactionOptions.zoomControl = zoomControl;
+  if (attributionControl !== undefined) interactionOptions.attributionControl = attributionControl;
+
   return (
     <>
       <MapContainer
@@ -104,10 +122,7 @@ export function BaseMap({
         ref={mapRef}
         className={className}
         style={{ height: '100%', width: '100%', ...mapStyle }}
-        scrollWheelZoom={scrollWheelZoom}
-        doubleClickZoom={doubleClickZoom}
-        zoomControl={zoomControl}
-        attributionControl={attributionControl}
+        {...interactionOptions}
       >
         {tileset.isVector
           ? (

--- a/src/components/map/MapLoadingOverlay.test.tsx
+++ b/src/components/map/MapLoadingOverlay.test.tsx
@@ -1,0 +1,18 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MapLoadingOverlay } from './MapLoadingOverlay';
+
+describe('MapLoadingOverlay', () => {
+  it('renders a status region with the loading label and a spinner', () => {
+    render(<MapLoadingOverlay />);
+    const overlay = screen.getByTestId('map-loading-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveAttribute('role', 'status');
+    // Reuses the shared .loading-spinner CSS/animation rather than a new one.
+    expect(overlay.querySelector('.loading-spinner')).not.toBeNull();
+    expect(screen.getByText('common.loading_indicator')).toBeInTheDocument();
+  });
+});

--- a/src/components/map/MapLoadingOverlay.tsx
+++ b/src/components/map/MapLoadingOverlay.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Shared "map data is loading" overlay.
+ *
+ * Rendered as a `BaseMap` sibling (same relatively-positioned wrapper the
+ * "no nodes" empty-state overlays already use) while the FIRST fetch for a
+ * map's node data is still unresolved. Without this, a map whose data hasn't
+ * arrived yet is indistinguishable from one that genuinely has no positioned
+ * nodes — the "No Node Locations" / "No node positions" empty states would
+ * flash on-screen before a slow initial fetch even completes.
+ *
+ * Reuses the existing `.loading-spinner` spin animation (see
+ * `src/styles/messages.css`) rather than inventing a new one, and the
+ * existing `common.loading_indicator` i18n key rather than adding a new one.
+ */
+export function MapLoadingOverlay() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="map-loading-overlay" data-testid="map-loading-overlay" role="status" aria-live="polite">
+      <div className="map-loading-overlay-content">
+        <div className="loading-spinner" aria-hidden="true" />
+        <p>{t('common.loading_indicator', 'Loading...')}</p>
+      </div>
+    </div>
+  );
+}
+
+export default MapLoadingOverlay;

--- a/src/hooks/useTraceroutePaths.test.tsx
+++ b/src/hooks/useTraceroutePaths.test.tsx
@@ -1,5 +1,14 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { describe, it, expect } from 'vitest';
-import { NodePositionDigest, TracerouteDigest } from './useTraceroutePaths';
+import { renderHook } from '@testing-library/react';
+import {
+  useTraceroutePaths,
+  NodePositionDigest,
+  TracerouteDigest,
+  ThemeColors,
+} from './useTraceroutePaths';
 
 /**
  * Tests for useTraceroutePaths hook filtering functionality
@@ -197,6 +206,110 @@ describe('useTraceroutePaths - Route Segment Filtering', () => {
       });
 
       expect(filteredSegments).toHaveLength(0);
+    });
+  });
+
+  // #4047 regression — Phase 3 aligned `tracerouteNodeNums` (used for marker
+  // filtering) to gate the forward/return legs independently, so a
+  // forward-only or return-only traceroute still produces a non-null set.
+  // `tracerouteBounds` (consumed only by NodesTab's TracerouteBoundsController
+  // for zoom-to-fit) derived directly from that same set, so it started
+  // producing bounds for partial traceroutes too. NodesTab's click handlers
+  // still gate their `centerMapOnNode` fallback on a "both legs present"
+  // check (unchanged), so for a partial traceroute both `centerMapOnNode`
+  // (zoom-to-node) AND `TracerouteBoundsController.fitBounds` (zoom-to-route)
+  // fired — the fitBounds call, running slightly after, silently overrode the
+  // node-centering. Symptom: "zoom to node doesn't work", intermittent
+  // because it only reproduced for nodes whose latest traceroute was one-way.
+  describe('tracerouteBounds — #4047 zoom-to-node regression', () => {
+    const nodes: NodePositionDigest[] = [
+      { nodeNum: 100, position: { latitude: 40.0, longitude: -75.0 }, user: { id: '!64', longName: 'Node A' } },
+      { nodeNum: 200, position: { latitude: 40.2, longitude: -75.2 }, user: { id: '!c8', longName: 'Node B' } },
+    ];
+
+    const themeColors: ThemeColors = { mauve: '#c6a0f6', red: '#ed8796', blue: '#8aadf4', overlay0: '#6e738d' };
+    const callbacks = { onSelectNode: () => {}, onSelectRouteSegment: () => {} };
+
+    const baseParams = {
+      showPaths: false,
+      showRoute: true,
+      currentNodeId: '!local',
+      nodesPositionDigest: nodes,
+      distanceUnit: 'metric' as const,
+      maxNodeAgeHours: 24,
+      themeColors,
+      callbacks,
+    };
+
+    it('produces bounds AND nodeNums for a complete (both-leg) traceroute', () => {
+      const traceroutes: TracerouteDigest[] = [
+        {
+          fromNodeNum: 100,
+          toNodeNum: 200,
+          fromNodeId: '!64',
+          toNodeId: '!c8',
+          route: '[]',
+          routeBack: '[]',
+          timestamp: Date.now(),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useTraceroutePaths({ ...baseParams, selectedNodeId: '!c8', traceroutesDigest: traceroutes })
+      );
+
+      expect(result.current.tracerouteNodeNums).not.toBeNull();
+      expect(result.current.tracerouteBounds).not.toBeNull();
+    });
+
+    it('produces nodeNums (marker filter) but NO bounds (no zoom-fit) for a forward-only traceroute', () => {
+      const traceroutes: TracerouteDigest[] = [
+        {
+          fromNodeNum: 100,
+          toNodeNum: 200,
+          fromNodeId: '!64',
+          toNodeId: '!c8',
+          route: '[]', // forward leg present
+          routeBack: '', // no return leg
+          timestamp: Date.now(),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useTraceroutePaths({ ...baseParams, selectedNodeId: '!c8', traceroutesDigest: traceroutes })
+      );
+
+      // Phase 3 (#4047) deliberately keeps the marker filter populated for a
+      // partial traceroute.
+      expect(result.current.tracerouteNodeNums).not.toBeNull();
+      expect(result.current.tracerouteNodeNums?.has(100)).toBe(true);
+      expect(result.current.tracerouteNodeNums?.has(200)).toBe(true);
+      // But zoom-to-fit must stay disabled so NodesTab's centerMapOnNode
+      // fallback (which also requires both legs) isn't fought by a
+      // subsequent fitBounds call.
+      expect(result.current.tracerouteBounds).toBeNull();
+    });
+
+    it('produces nodeNums (marker filter) but NO bounds (no zoom-fit) for a return-only traceroute', () => {
+      const traceroutes: TracerouteDigest[] = [
+        {
+          fromNodeNum: 100,
+          toNodeNum: 200,
+          fromNodeId: '!64',
+          toNodeId: '!c8',
+          route: '', // no forward leg
+          routeBack: '[]', // return leg present (direct, zero intermediate hops)
+          snrBack: '[10]', // gives hasReturnPath a signal even with an empty routeBack array
+          timestamp: Date.now(),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useTraceroutePaths({ ...baseParams, selectedNodeId: '!c8', traceroutesDigest: traceroutes })
+      );
+
+      expect(result.current.tracerouteNodeNums).not.toBeNull();
+      expect(result.current.tracerouteBounds).toBeNull();
     });
   });
 });

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -930,6 +930,26 @@ export function useTraceroutePaths({
     const selectedTrace = traceroutesDigest.find(
       tr => tr.toNodeId === selectedNodeId || tr.fromNodeId === selectedNodeId
     );
+    if (!selectedTrace) return null;
+
+    // Zoom-to-fit only kicks in for a *complete* (both-leg) traceroute. This
+    // intentionally does NOT reuse tracerouteNodeNums' Phase-3 (#4047)
+    // independent-leg gate: that gate was a deliberate change so the marker
+    // filter above still shows exactly the nodes a forward-only/return-only
+    // route renders. But NodesTab's node-click handlers (`onOmsClick`,
+    // `handleNodeClick`) fall back to `centerMapOnNode` precisely when a
+    // traceroute isn't "complete" by this same both-legs test - if bounds
+    // were emitted for a partial route too, `TracerouteBoundsController`
+    // would fire `fitBounds` right after `centerMapOnNode`'s `setView`,
+    // silently overriding the node-centering (#4047 regression: "zoom to
+    // node doesn't work" for nodes whose latest traceroute is one-way).
+    // Keeping this gate identical to NodesTab's `hasTraceroute` check (and to
+    // the pre-Phase-3 gate here) keeps the two decision points in sync.
+    const hasCompleteRoute =
+      !!selectedTrace.route && selectedTrace.route !== 'null' && selectedTrace.route !== '' &&
+      !!selectedTrace.routeBack && selectedTrace.routeBack !== 'null' && selectedTrace.routeBack !== '';
+    if (!hasCompleteRoute) return null;
+
     const snapshotPositions = parseSnapshotRoutePositions(selectedTrace?.routePositions);
 
     let minLat = Infinity;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,24 @@
 // CRITICAL: This must be the FIRST import to ensure API base URL is set
 // before any other modules are loaded
 import { appBasename } from './init';
+
+// Self-heal stale-deploy chunk failures (#4047 investigation): after a redeploy
+// rotates hashed chunk names, a browser holding cached HTML 404s on lazy
+// chunks — the dynamic import rejects and the affected subtree wedges (seen
+// as a dead map + unresponsive controls). Vite surfaces these as
+// `vite:preloadError`; reload once to pick up coherent HTML + chunks, with a
+// sessionStorage guard so a genuinely broken deploy can't reload-loop.
+if (typeof window !== 'undefined') {
+  window.addEventListener('vite:preloadError', (event) => {
+    const KEY = 'mm-chunk-reload-at';
+    const last = Number(sessionStorage.getItem(KEY) ?? 0);
+    if (Date.now() - last > 30_000) {
+      sessionStorage.setItem(KEY, String(Date.now()));
+      event.preventDefault();
+      window.location.reload();
+    }
+  });
+}
 // Initialize i18n after init.ts sets the base URL
 import './config/i18n';
 import React, { Suspense } from 'react';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,24 +1,6 @@
 // CRITICAL: This must be the FIRST import to ensure API base URL is set
 // before any other modules are loaded
 import { appBasename } from './init';
-
-// TEMP DEBUG (#4047 mobile-admin investigation) — surfaces uncaught errors as an
-// on-screen banner so they can be read on mobile browsers with no devtools.
-// REMOVE BEFORE PR.
-if (typeof window !== 'undefined') {
-  const showErr = (label: string, msg: string) => {
-    let el = document.getElementById('mm-debug-errors');
-    if (!el) {
-      el = document.createElement('div');
-      el.id = 'mm-debug-errors';
-      el.style.cssText = 'position:fixed;top:0;left:0;right:0;z-index:99999;background:#b91c1c;color:#fff;font:12px monospace;padding:6px 8px;white-space:pre-wrap;max-height:40vh;overflow:auto;';
-      document.body.appendChild(el);
-    }
-    el.textContent += `[${label}] ${msg}\n`;
-  };
-  window.addEventListener('error', (e) => showErr('error', `${e.message} @ ${e.filename?.split('/').pop()}:${e.lineno}\n${e.error?.stack?.split('\n').slice(0, 4).join('\n') ?? ''}`));
-  window.addEventListener('unhandledrejection', (e) => showErr('promise', String(e.reason?.stack ?? e.reason).slice(0, 500)));
-}
 // Initialize i18n after init.ts sets the base URL
 import './config/i18n';
 import React, { Suspense } from 'react';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,24 @@
 // CRITICAL: This must be the FIRST import to ensure API base URL is set
 // before any other modules are loaded
 import { appBasename } from './init';
+
+// TEMP DEBUG (#4047 mobile-admin investigation) — surfaces uncaught errors as an
+// on-screen banner so they can be read on mobile browsers with no devtools.
+// REMOVE BEFORE PR.
+if (typeof window !== 'undefined') {
+  const showErr = (label: string, msg: string) => {
+    let el = document.getElementById('mm-debug-errors');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'mm-debug-errors';
+      el.style.cssText = 'position:fixed;top:0;left:0;right:0;z-index:99999;background:#b91c1c;color:#fff;font:12px monospace;padding:6px 8px;white-space:pre-wrap;max-height:40vh;overflow:auto;';
+      document.body.appendChild(el);
+    }
+    el.textContent += `[${label}] ${msg}\n`;
+  };
+  window.addEventListener('error', (e) => showErr('error', `${e.message} @ ${e.filename?.split('/').pop()}:${e.lineno}\n${e.error?.stack?.split('\n').slice(0, 4).join('\n') ?? ''}`));
+  window.addEventListener('unhandledrejection', (e) => showErr('promise', String(e.reason?.stack ?? e.reason).slice(0, 500)));
+}
 // Initialize i18n after init.ts sets the base URL
 import './config/i18n';
 import React, { Suspense } from 'react';

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1021,6 +1021,7 @@ function DashboardInner() {
           sourceId={selectedSourceId}
           maxNodeAgeHours={maxNodeAgeHours}
           onNodeSourceSelect={handleNodeSourceSelect}
+          isLoading={sourceData.isLoading}
         />
       </div>
 

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1068,6 +1068,45 @@
   line-height: 1.4;
 }
 
+/* Map loading overlay (#4047 follow-up) — shared across NodesTab/
+   DashboardMap/MeshCoreMap. Shown while a map's first node-data fetch is
+   still in flight, so a slow initial load doesn't flash the "no nodes"
+   empty state before data has a chance to arrive. Mirrors .map-overlay/
+   .overlay-content's positioning and card styling. */
+.map-loading-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.map-loading-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(30, 30, 46, 0.95);
+  border: 2px solid var(--ctp-surface2);
+  border-radius: var(--radius-xl);
+  padding: 2rem;
+  text-align: center;
+  color: var(--ctp-subtext1);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.map-loading-overlay-content .loading-spinner {
+  width: 28px;
+  height: 28px;
+}
+
+.map-loading-overlay-content p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
 /* Leaflet popup customization */
 .leaflet-popup-content-wrapper {
   background: var(--ctp-surface0);


### PR DESCRIPTION
## Summary

Follow-up batch from live user testing of the Map Consolidation epic (#4047): two epic regressions fixed, one deploy-hygiene failure mode hardened, and two small user-requested features. All found/requested by @Yeraze testing on the dev container (desktop + iOS).

## Fixes

- **Wheel zoom / double-click zoom dead on every map** — BaseMap passed its optional interaction props even when unset; Leaflet's `setOptions` copies every own key, so an explicit `undefined` *overrides* the prototype default `true` and disables the handler (react-leaflet does no undefined-filtering before `new LeafletMap()`). Verified against Leaflet's exact merge semantics. BaseMap now omits unset options entirely; regression tests pin the own-key behavior.
- **Zoom-to-node intermittently hijacked** — Phase 3 deliberately loosened the traceroute *marker-filter* gate to handle one-way traceroutes, and the zoom-fit `tracerouteBounds` silently inherited the looser gate; for nodes with a one-way traceroute, the route-fit animation ran in the same window as center-on-node and won. `tracerouteBounds` gets its own complete-traceroute (forward+return) gate matching the pre-epic behavior and NodesTab's click predicate; the intentional marker-filter improvement is preserved. 3 regression tests.
- **Stale-deploy chunk wedge (self-heal)** — after a redeploy rotates hashed chunk names, a browser holding cached HTML 404s on lazy chunks; the dynamic import rejects and the affected subtree wedges (observed on mobile as a dead map with unresponsive controls — only under login, because per-user prefs pull extra lazy layer chunks). Added a `vite:preloadError` handler that reloads once, sessionStorage-guarded against loops. This also protects production users mid-upgrade.

## Features (user-requested)

- **MeshCore map: polar grid** — "Show Polar Grid" toggle (persisted like the map's other toggles), rendering the shared `PolarGridOverlay` centered on the local node; disabled with a tooltip when no local position. First test file for MeshCoreMap.
- **Map loading states** — new shared `MapLoadingOverlay`; NodesTab/Dashboard/MeshCore maps now show "Loading..." during the initial fetch instead of prematurely claiming no nodes exist (Dashboard/NodesTab reuse their TanStack loading state; MeshCore gained a minimal `hasLoadedOnce` that settles on success *or* failure so an erroring source can't spin forever; EmbedMap already had a first-load gate).

## Issues Resolved
Follow-ups to #4047. None standalone.

## Testing
- [x] Full Vitest suite: success:true — 9,651 tests / 0 failures (13 new tests across the batch)
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] Live-validated by the maintainer on the dev container (desktop + iOS): wheel zoom restored, MeshCore polar grid rendering with connected serial nodes, loading overlay visible on cold load, and the mobile chunk-wedge resolved after rebuild
- [x] Wheel-zoom fix additionally verified programmatically (WheelEvent → zoom 4→7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub