### PR TITLE
feat(map): pan/zoom/spiderfy interaction polish — zoom clamp, scaled animations, zoom-gated spiderfy, re-spiderfy on zoom (#4046)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1468,6 +1468,8 @@
   "settings.position_history_line_style_spline": "Spline (curved based on heading)",
   "settings.neighbor_info_min_zoom_label": "Neighbor Info Minimum Zoom Level",
   "settings.neighbor_info_min_zoom_description": "Neighbor info lines are hidden on the map when zoomed out below this level (1-18). Lower values show lines at wider zoom levels.",
+  "settings.map_center_target_zoom_label": "Center-on-Node Target Zoom",
+  "settings.map_center_target_zoom_description": "Zoom level used when centering the map on a single node (1-18). The map only ever zooms IN to reach this level — it never zooms out if you're already closer.",
   "settings.telemetry_hours_label": "Telemetry Visualization (Hours)",
   "settings.telemetry_hours_description": "How many hours of telemetry data to display in graphs (1-168)",
   "settings.fav_telemetry_label": "Favorite Telemetry Storage Length (Days)",

--- a/src/components/MapCenterController.test.tsx
+++ b/src/components/MapCenterController.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MapCenterController: zoom clamp (#4046 item 2) + duration scaling (item 3).
+ * The pure math itself is covered by mapZoomAnimation.test.ts — this suite
+ * proves the component wires that math into `map.setView` correctly and
+ * respects the configurable `targetZoom` prop.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import L from 'leaflet';
+import {
+  DEFAULT_TARGET_ZOOM,
+  computeZoomAnimationDuration,
+} from '../utils/mapZoomAnimation';
+
+let currentZoom = 10;
+const setViewMock = vi.fn();
+
+vi.mock('react-leaflet', () => ({
+  useMap: () => ({
+    getContainer: () => ({ clientHeight: 800 }),
+    getZoom: () => currentZoom,
+    project: () => L.point(100, 100),
+    unproject: (point: L.Point) => L.latLng(point.y, point.x),
+    setView: setViewMock,
+  }),
+}));
+
+import { MapCenterController } from './MapCenterController';
+
+describe('MapCenterController (#4046 items 2 + 3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setViewMock.mockClear();
+    currentZoom = 10;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('zooms in to the default target (17) when further out', () => {
+    currentZoom = 5;
+    render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={vi.fn()} />);
+
+    expect(setViewMock).toHaveBeenCalledTimes(1);
+    const [, zoom] = setViewMock.mock.calls[0];
+    expect(zoom).toBe(DEFAULT_TARGET_ZOOM);
+  });
+
+  it('never zooms out when already closer than the target', () => {
+    currentZoom = 18;
+    render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={vi.fn()} />);
+
+    const [, zoom] = setViewMock.mock.calls[0];
+    expect(zoom).toBe(18); // clamp keeps the current (closer) zoom
+  });
+
+  it('respects a configured targetZoom prop instead of the default', () => {
+    currentZoom = 5;
+    render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={vi.fn()} targetZoom={12} />);
+
+    const [, zoom] = setViewMock.mock.calls[0];
+    expect(zoom).toBe(12);
+  });
+
+  it('scales the animation duration by the zoom delta', () => {
+    currentZoom = 3;
+    render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={vi.fn()} targetZoom={17} />);
+
+    const [, , options] = setViewMock.mock.calls[0];
+    const expectedDuration = computeZoomAnimationDuration(3, 17);
+    expect(options.duration).toBeCloseTo(expectedDuration, 5);
+    expect(options.animate).toBe(true);
+  });
+
+  it('calls onCenterComplete after the (scaled) animation duration elapses', () => {
+    currentZoom = 3;
+    const onCenterComplete = vi.fn();
+    render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={onCenterComplete} targetZoom={17} />);
+
+    const duration = computeZoomAnimationDuration(3, 17);
+    act(() => {
+      vi.advanceTimersByTime(duration * 1000 + 49);
+    });
+    expect(onCenterComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(5);
+    });
+    expect(onCenterComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when centerTarget is null', () => {
+    render(<MapCenterController centerTarget={null} onCenterComplete={vi.fn()} />);
+    expect(setViewMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MapCenterController.tsx
+++ b/src/components/MapCenterController.tsx
@@ -1,9 +1,21 @@
 import React, { useEffect } from 'react';
 import { useMap } from 'react-leaflet';
+import {
+  DEFAULT_TARGET_ZOOM,
+  computeClampedTargetZoom,
+  computeZoomAnimationDuration,
+} from '../utils/mapZoomAnimation';
 
 interface MapCenterControllerProps {
   centerTarget: [number, number] | null;
   onCenterComplete: () => void;
+  /**
+   * User-configurable target zoom (issue #4046 item 2, `mapCenterTargetZoom`
+   * setting). The actual zoom used is `Math.max(map.getZoom(), targetZoom)`
+   * — this only ever zooms IN, never forces a zoom-out when the user is
+   * already closer than `targetZoom`. Defaults to DEFAULT_TARGET_ZOOM (17).
+   */
+  targetZoom?: number;
 }
 
 /**
@@ -15,7 +27,8 @@ interface MapCenterControllerProps {
  */
 export const MapCenterController: React.FC<MapCenterControllerProps> = ({
   centerTarget,
-  onCenterComplete
+  onCenterComplete,
+  targetZoom = DEFAULT_TARGET_ZOOM,
 }) => {
   const map = useMap();
 
@@ -31,21 +44,38 @@ export const MapCenterController: React.FC<MapCenterControllerProps> = ({
       // So to move the target point UP in screen space, we SUBTRACT from Y
       const panOffset = Math.floor(mapHeight / 4);
 
+      const currentZoom = map.getZoom();
+      // #4046 item 2: clamp so we only ever zoom IN — never force a
+      // disorienting zoom-out when the user is already closer than
+      // targetZoom. When the clamp results in no zoom change, Leaflet's
+      // `_tryAnimatedPan` path runs (pure pan, no 'zoomend'), so an open
+      // spiderfy fan is left undisturbed.
+      const clampedZoom = computeClampedTargetZoom(currentZoom, targetZoom);
+
       // Calculate the pixel point to pan to
-      const targetPoint = map.project(centerTarget, 15);
+      const targetPoint = map.project(centerTarget, clampedZoom);
       const offsetPoint = targetPoint.subtract([0, panOffset]);
-      const offsetLatLng = map.unproject(offsetPoint, 15);
+      const offsetLatLng = map.unproject(offsetPoint, clampedZoom);
+
+      // #4046 item 3: scale the animation duration by the size of the zoom
+      // jump — a big zoomed-out-to-street jump gets a proportionally longer,
+      // smoother animation instead of a jarring snap; a small adjustment
+      // stays quick.
+      const duration = computeZoomAnimationDuration(currentZoom, clampedZoom);
 
       // Use setView with the offset position in a single operation
       // This avoids multiple move events and competing animations
-      map.setView(offsetLatLng, 15, { animate: true, duration: 0.5 });
+      map.setView(offsetLatLng, clampedZoom, { animate: true, duration });
 
-      // Reset target after animation completes
-      setTimeout(() => {
+      // Reset target after animation completes (slightly longer than the
+      // actual animation duration, which now varies with the zoom jump).
+      const timer = setTimeout(() => {
         onCenterComplete();
-      }, 550); // Slightly longer than animation duration
+      }, duration * 1000 + 50);
+
+      return () => clearTimeout(timer);
     }
-  }, [centerTarget, onCenterComplete, map]);
+  }, [centerTarget, onCenterComplete, map, targetZoom]);
 
   return null;
 };

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -449,6 +449,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     defaultMapCenterLat,
     defaultMapCenterLon,
     defaultMapCenterZoom,
+    mapCenterTargetZoom,
   } = useSettings();
 
   // Effective map age cap from the Map Features age slider (#3322), clamped to
@@ -2546,6 +2547,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               <MapCenterController
                 centerTarget={mapCenterTarget}
                 onCenterComplete={handleCenterComplete}
+                targetZoom={mapCenterTargetZoom}
               />
               <TracerouteBoundsController bounds={tracerouteBounds} />
               <ZoomHandler onZoomChange={setMapZoom} />

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -199,6 +199,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setDefaultMapCenterLat,
     setDefaultMapCenterLon,
     setDefaultMapCenterZoom,
+    mapCenterTargetZoom,
+    setMapCenterTargetZoom,
     defaultLandingPage,
     setDefaultLandingPage,
     appearanceMode,
@@ -232,6 +234,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localDefaultMapCenterLat, setLocalDefaultMapCenterLat] = useState<number | null>(defaultMapCenterLat);
   const [localDefaultMapCenterLon, setLocalDefaultMapCenterLon] = useState<number | null>(defaultMapCenterLon);
   const [localDefaultMapCenterZoom, setLocalDefaultMapCenterZoom] = useState<number | null>(defaultMapCenterZoom);
+  const [localMapCenterTargetZoom, setLocalMapCenterTargetZoom] = useState(mapCenterTargetZoom);
   const [localDefaultLandingPage, setLocalDefaultLandingPage] = useState<string>(defaultLandingPage);
   const [localAppearanceMode, setLocalAppearanceMode] = useState<AppearanceMode>(appearanceMode);
   const [localDarkTheme, setLocalDarkTheme] = useState<Theme>(darkTheme);
@@ -417,6 +420,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalDefaultMapCenterLat(defaultMapCenterLat);
     setLocalDefaultMapCenterLon(defaultMapCenterLon);
     setLocalDefaultMapCenterZoom(defaultMapCenterZoom);
+    setLocalMapCenterTargetZoom(mapCenterTargetZoom);
     setLocalDefaultLandingPage(defaultLandingPage);
     setLocalAppearanceMode(appearanceMode);
     setLocalDarkTheme(darkTheme);
@@ -431,7 +435,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringAzimuth(solarMonitoringAzimuth);
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
-  }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, nodeHopsCalculation, preferredDashboardSortOption, linkPreviewsEnabled, meshcoreChannelRetryEnabled, solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme]);
+  }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, nodeHopsCalculation, preferredDashboardSortOption, linkPreviewsEnabled, meshcoreChannelRetryEnabled, solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme]);
 
   // Default solar monitoring lat/long to device position if still at 0
   useEffect(() => {
@@ -478,6 +482,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localDefaultMapCenterLat !== defaultMapCenterLat ||
       localDefaultMapCenterLon !== defaultMapCenterLon ||
       localDefaultMapCenterZoom !== defaultMapCenterZoom ||
+      localMapCenterTargetZoom !== mapCenterTargetZoom ||
       localDefaultLandingPage !== defaultLandingPage ||
       localAppearanceMode !== appearanceMode ||
       localDarkTheme !== darkTheme ||
@@ -505,8 +510,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       JSON.stringify(localAnalyticsConfig) !== initialAnalyticsConfig ||
       localAppriseApiServerUrl !== initialAppriseApiServerUrl;
     setHasChanges(changed);
-  }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, localNodeHopsCalculation, localDashboardSortOption,
-      maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
+  }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localMapCenterTargetZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, localNodeHopsCalculation, localDashboardSortOption,
+      maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
       localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours, initialPacketMonitorSettings,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
@@ -540,6 +545,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalDefaultMapCenterLat(defaultMapCenterLat);
     setLocalDefaultMapCenterLon(defaultMapCenterLon);
     setLocalDefaultMapCenterZoom(defaultMapCenterZoom);
+    setLocalMapCenterTargetZoom(mapCenterTargetZoom);
     setLocalDefaultLandingPage(defaultLandingPage);
     setLocalAppearanceMode(appearanceMode);
     setLocalDarkTheme(darkTheme);
@@ -569,7 +575,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
-      dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
+      dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
       linkPreviewsEnabled, meshcoreChannelRetryEnabled,
@@ -611,6 +617,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         defaultMapCenterLat: localDefaultMapCenterLat !== null ? localDefaultMapCenterLat.toString() : '',
         defaultMapCenterLon: localDefaultMapCenterLon !== null ? localDefaultMapCenterLon.toString() : '',
         defaultMapCenterZoom: localDefaultMapCenterZoom !== null ? localDefaultMapCenterZoom.toString() : '',
+        mapCenterTargetZoom: localMapCenterTargetZoom.toString(),
         defaultLandingPage: localDefaultLandingPage,
         theme: localEffectiveTheme,
         appearanceMode: localAppearanceMode,
@@ -667,6 +674,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       setDefaultMapCenterLat(localDefaultMapCenterLat);
       setDefaultMapCenterLon(localDefaultMapCenterLon);
       setDefaultMapCenterZoom(localDefaultMapCenterZoom);
+      setMapCenterTargetZoom(localMapCenterTargetZoom);
       setDefaultLandingPage(localDefaultLandingPage);
       setAppearanceMode(localAppearanceMode);
       setDarkTheme(localDarkTheme);
@@ -708,7 +716,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours,
       localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours,
       localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection,
-      localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, getLocalEffectiveTheme,
+      localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localMapCenterTargetZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, getLocalEffectiveTheme,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
       localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localMeshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes, localMeshcoreCliTimeoutSeconds,
@@ -716,7 +724,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
       onPreferredSortDirectionChange, onTimeFormatChange, onDateFormatChange, onMapTilesetChange,
-      onMapPinStyleChange, setNeighborInfoMinZoom, setDefaultMapCenterLat, setDefaultMapCenterLon, setDefaultMapCenterZoom, setDefaultLandingPage, setAppearanceMode, setDarkTheme, setLightTheme, setNodeHopsCalculation, setPreferredDashboardSortOption, onSolarMonitoringEnabledChange,
+      onMapPinStyleChange, setNeighborInfoMinZoom, setDefaultMapCenterLat, setDefaultMapCenterLon, setDefaultMapCenterZoom, setMapCenterTargetZoom, setDefaultLandingPage, setAppearanceMode, setDarkTheme, setLightTheme, setNodeHopsCalculation, setPreferredDashboardSortOption, onSolarMonitoringEnabledChange,
       onSolarMonitoringLatitudeChange, onSolarMonitoringLongitudeChange, onSolarMonitoringAzimuthChange,
       onSolarMonitoringDeclinationChange, setShowIncompleteNodes, showToast, t,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity,
@@ -1498,6 +1506,27 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 const value = parseInt(e.target.value);
                 if (value >= 1 && value <= 18) {
                   setLocalNeighborInfoMinZoom(value);
+                }
+              }}
+              className="setting-input"
+              style={{ width: '100px' }}
+            />
+          </div>
+          <div className="setting-item">
+            <label htmlFor="mapCenterTargetZoom">
+              {t('settings.map_center_target_zoom_label')}
+              <span className="setting-description">{t('settings.map_center_target_zoom_description')}</span>
+            </label>
+            <input
+              id="mapCenterTargetZoom"
+              type="number"
+              min="1"
+              max="18"
+              value={localMapCenterTargetZoom}
+              onChange={(e) => {
+                const value = parseInt(e.target.value);
+                if (value >= 1 && value <= 18) {
+                  setLocalMapCenterTargetZoom(value);
                 }
               }}
               className="setting-input"

--- a/src/components/map/layers/NodeMarkersLayer.test.tsx
+++ b/src/components/map/layers/NodeMarkersLayer.test.tsx
@@ -41,6 +41,7 @@ interface RenderLogEntry {
   position: [number, number];
   icon: unknown;
   opacity?: number;
+  eventHandlers?: Record<string, (...args: unknown[]) => void>;
 }
 let renderLog: RenderLogEntry[] = [];
 let mountedMarkers: FakeMarker[] = [];
@@ -59,7 +60,7 @@ vi.mock('react-leaflet', () => ({
   Marker: (props: MockMarkerProps) => {
     const instRef = useRef<FakeMarker | null>(null);
     if (!instRef.current) instRef.current = createFakeMarker();
-    renderLog.push({ position: props.position, icon: props.icon, opacity: props.opacity });
+    renderLog.push({ position: props.position, icon: props.icon, opacity: props.opacity, eventHandlers: props.eventHandlers });
     useEffect(() => {
       props.ref?.(instRef.current);
       mountedMarkers.push(instRef.current!);
@@ -73,6 +74,12 @@ vi.mock('react-leaflet', () => ({
   },
 }));
 
+// #4046 item 2/4: NodeMarkersLayer reads `mapCenterTargetZoom` from
+// SettingsContext to feed the below-threshold "zoom in first" target.
+vi.mock('../../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ mapCenterTargetZoom: 17 }),
+}));
+
 // ---------------------------------------------------------------------------
 // useMarkerSpiderfier mock
 // ---------------------------------------------------------------------------
@@ -81,6 +88,11 @@ const addMarkerMock = vi.fn();
 const removeMarkerMock = vi.fn();
 const addListenerMock = vi.fn();
 const removeListenerMock = vi.fn();
+const handleGatedClickMock = vi.fn();
+// #4046 item 4: mutable so individual tests can simulate being below the
+// zoom-gate threshold. Read fresh on every `useMarkerSpiderfier()` call
+// (i.e. every render), matching the real hook's re-render-on-cross behavior.
+let isAboveGateThresholdMock = true;
 
 vi.mock('../../../hooks/useMarkerSpiderfier', () => ({
   useMarkerSpiderfier: () => ({
@@ -88,6 +100,8 @@ vi.mock('../../../hooks/useMarkerSpiderfier', () => ({
     removeMarker: removeMarkerMock,
     addListener: addListenerMock,
     removeListener: removeListenerMock,
+    isAboveGateThreshold: isAboveGateThresholdMock,
+    handleGatedClick: handleGatedClickMock,
   }),
   SHARED_SPIDERFIER_OPTIONS: {},
 }));
@@ -114,6 +128,8 @@ beforeEach(() => {
   removeMarkerMock.mockClear();
   addListenerMock.mockClear();
   removeListenerMock.mockClear();
+  handleGatedClickMock.mockClear();
+  isAboveGateThresholdMock = true;
 });
 afterEach(() => cleanup());
 
@@ -230,5 +246,46 @@ describe('NodeMarkersLayer', () => {
     const marker = mountedMarkers[0];
     expect(marker.off).not.toHaveBeenCalled();
     expect(marker._meshPopupStripped).toBeUndefined();
+  });
+
+  // #4046 item 4: below the zoom-gate threshold, a marker's own click
+  // eventHandler is replaced with the "zoom in first" flow instead of the
+  // descriptor's normal click behavior (e.g. MapAnalysis's setSelected, or
+  // NodesTab's `add`-only handlers relying purely on the OMS 'click' event,
+  // which never fires for an unregistered marker).
+  describe('zoom-gated click routing (#4046 item 4)', () => {
+    it('above the threshold: uses the descriptor eventHandlers.click unchanged', () => {
+      isAboveGateThresholdMock = true;
+      const clickSpy = vi.fn();
+      render(<NodeMarkersLayer markers={[descriptor({ key: 'n1', eventHandlers: { click: clickSpy } })]} />);
+
+      const handlers = renderLog.at(-1)?.eventHandlers;
+      expect(handlers?.click).toBe(clickSpy);
+      expect(handleGatedClickMock).not.toHaveBeenCalled();
+    });
+
+    it('below the threshold: click is routed to handleGatedClick instead of the descriptor handler', () => {
+      isAboveGateThresholdMock = false;
+      const clickSpy = vi.fn();
+      render(<NodeMarkersLayer markers={[descriptor({ key: 'n1', eventHandlers: { click: clickSpy } })]} />);
+
+      const handlers = renderLog.at(-1)?.eventHandlers;
+      expect(handlers?.click).not.toBe(clickSpy);
+
+      const marker = mountedMarkers[0];
+      handlers?.click({ target: marker });
+      expect(handleGatedClickMock).toHaveBeenCalledWith(marker);
+      expect(clickSpy).not.toHaveBeenCalled();
+    });
+
+    it('below the threshold: non-click eventHandlers (e.g. add/mouseover) are preserved', () => {
+      isAboveGateThresholdMock = false;
+      const addSpy = vi.fn();
+      render(<NodeMarkersLayer markers={[descriptor({ key: 'n1', eventHandlers: { add: addSpy } })]} />);
+
+      const handlers = renderLog.at(-1)?.eventHandlers;
+      expect(handlers?.add).toBe(addSpy);
+      expect(typeof handlers?.click).toBe('function'); // gated click still wired in
+    });
   });
 });

--- a/src/components/map/layers/NodeMarkersLayer.tsx
+++ b/src/components/map/layers/NodeMarkersLayer.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { Marker } from 'react-leaflet';
 import type L from 'leaflet';
-import type { Marker as LeafletMarker, LeafletEventHandlerFnMap } from 'leaflet';
+import type { Marker as LeafletMarker, LeafletEventHandlerFnMap, LeafletMouseEvent } from 'leaflet';
 import {
   useMarkerSpiderfier,
   SHARED_SPIDERFIER_OPTIONS,
   type SpiderfierOptions,
 } from '../../../hooks/useMarkerSpiderfier';
+import { useSettings } from '../../../contexts/SettingsContext';
 
 /**
  * One node marker's render inputs, resolved consumer-side. `key` doubles as
@@ -95,7 +96,21 @@ export function NodeMarkersLayer({
   onOmsClick,
   stripLeafletAutoPopup = true,
 }: NodeMarkersLayerProps) {
-  const { addMarker, removeMarker, addListener, removeListener } = useMarkerSpiderfier(spiderfierOptions);
+  // #4046 item 4's below-threshold "zoom in first" click target reuses the
+  // same user-configurable `mapCenterTargetZoom` setting as
+  // `MapCenterController` (item 2), so a marker click at low zoom on ANY map
+  // surface (Nodes/Dashboard/MeshCore/Map Analysis, all go through this
+  // shared layer) lands on the same target zoom as clicking a node in a list.
+  // Only applied when the caller's own `spiderfierOptions` didn't already set
+  // one explicitly.
+  const { mapCenterTargetZoom } = useSettings();
+  const effectiveSpiderfierOptions = useMemo<SpiderfierOptions>(() => ({
+    ...spiderfierOptions,
+    zoomGateTargetZoom: spiderfierOptions.zoomGateTargetZoom ?? mapCenterTargetZoom,
+  }), [spiderfierOptions, mapCenterTargetZoom]);
+
+  const { addMarker, removeMarker, addListener, removeListener, isAboveGateThreshold, handleGatedClick } =
+    useMarkerSpiderfier(effectiveSpiderfierOptions);
 
   const markerByKey = useRef<Map<string, LeafletMarker>>(new Map());
   const keyByMarker = useRef<WeakMap<LeafletMarker, string>>(new WeakMap());
@@ -222,6 +237,25 @@ export function NodeMarkersLayer({
     }
   });
 
+  // #4046 item 4: below the zoom-gate threshold, markers aren't registered
+  // with the spiderfier at all (see `useMarkerSpiderfier`'s `zoomGateThreshold`
+  // gating), so their native Leaflet 'click' never reaches OMS — the OMS
+  // 'click' listener above (onOmsClick / openPopup) simply never fires. That
+  // means BELOW the threshold, a marker's `click` eventHandler is the only
+  // thing that runs. We replace it with the "zoom in first" flow — never the
+  // consumer's own click behavior (selection/centering/popup) — so a click
+  // on a large low-zoom pile isn't ambiguous about which node was meant;
+  // once zoomed in enough to cross back above the threshold, a further click
+  // resumes normal spiderfy/select/popup behavior. Non-click handlers (e.g.
+  // NodesTab's `add`/`mouseover`/`mouseout`) are preserved either way.
+  const resolveEventHandlers = (d: NodeMarkerDescriptor): LeafletEventHandlerFnMap | undefined => {
+    if (isAboveGateThreshold) return d.eventHandlers;
+    return {
+      ...d.eventHandlers,
+      click: (e: LeafletMouseEvent) => handleGatedClick(e.target as LeafletMarker),
+    };
+  };
+
   return (
     <>
       {markers.map((d) => (
@@ -232,7 +266,7 @@ export function NodeMarkersLayer({
           icon={stableIcon(d.key, d.iconSig, d.buildIcon)}
           opacity={d.opacity}
           zIndexOffset={d.zIndexOffset}
-          eventHandlers={d.eventHandlers}
+          eventHandlers={resolveEventHandlers(d)}
         >
           {d.children}
         </Marker>

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -636,6 +636,91 @@ describe('SettingsProvider', () => {
     expect(contextValue.distanceUnit).toBe('km');
   });
 
+  it('should default mapCenterTargetZoom to 17 when not in localStorage (#4046 item 2)', async () => {
+    localStorage.removeItem('mapCenterTargetZoom');
+    mockFetch.mockReset();
+    createFetchMock({});
+    const { SettingsProvider, useSettings } = await import('./SettingsContext');
+
+    let contextValue: any;
+
+    const Consumer = () => {
+      contextValue = useSettings();
+      return <div data-testid="consumer">loaded</div>;
+    };
+
+    await act(async () => {
+      render(
+        <SettingsProvider>
+          <Consumer />
+        </SettingsProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('consumer')).toBeDefined();
+    });
+
+    expect(contextValue.mapCenterTargetZoom).toBe(17);
+  });
+
+  it('should initialize mapCenterTargetZoom from localStorage', async () => {
+    localStorage.setItem('mapCenterTargetZoom', '14');
+    mockFetch.mockReset();
+    createFetchMock({});
+    const { SettingsProvider, useSettings } = await import('./SettingsContext');
+
+    let contextValue: any;
+
+    const Consumer = () => {
+      contextValue = useSettings();
+      return <div data-testid="consumer">loaded</div>;
+    };
+
+    await act(async () => {
+      render(
+        <SettingsProvider>
+          <Consumer />
+        </SettingsProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('consumer')).toBeDefined();
+    });
+
+    expect(contextValue.mapCenterTargetZoom).toBe(14);
+  });
+
+  it('should update localStorage when setMapCenterTargetZoom is called', async () => {
+    const { SettingsProvider, useSettings } = await import('./SettingsContext');
+
+    let contextValue: any;
+
+    const Consumer = () => {
+      contextValue = useSettings();
+      return <div data-testid="consumer">loaded</div>;
+    };
+
+    await act(async () => {
+      render(
+        <SettingsProvider>
+          <Consumer />
+        </SettingsProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('consumer')).toBeDefined();
+    });
+
+    await act(async () => {
+      contextValue.setMapCenterTargetZoom(12);
+    });
+
+    expect(localStorage.getItem('mapCenterTargetZoom')).toBe('12');
+  });
+
   it('should initialize preferredSortField from localStorage', async () => {
     localStorage.setItem('preferredSortField', 'battery');
     const { SettingsProvider, useSettings } = await import('./SettingsContext');

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_TILESET_ID, type TilesetId, type CustomTileset } from '../confi
 import { type OverlayScheme, getSchemeForTileset, getOverlayColors, type OverlayColors } from '../config/overlayColors';
 import i18n from '../config/i18n';
 import { type TapbackEmoji, DEFAULT_TAPBACK_EMOJIS } from '../components/EmojiPickerModal/EmojiPickerModal';
+import { DEFAULT_TARGET_ZOOM } from '../utils/mapZoomAnimation';
 
 /** A per-channel mute rule. muteUntil = null means indefinite. */
 export interface MutedChannel {
@@ -89,6 +90,11 @@ interface SettingsContextType {
   defaultMapCenterLat: number | null;
   defaultMapCenterLon: number | null;
   defaultMapCenterZoom: number | null;
+  /** Target zoom when centering on a single node — MapCenterController
+   *  clamps to `Math.max(currentZoom, mapCenterTargetZoom)`, so this only
+   *  ever zooms IN, never forces a zoom-out (issue #4046 item 2). Also feeds
+   *  the zoom-gated spiderfier's below-threshold click flow (item 4). */
+  mapCenterTargetZoom: number;
   defaultLandingPage: string;
   theme: Theme;
   appearanceMode: AppearanceMode;
@@ -143,6 +149,7 @@ interface SettingsContextType {
   setDefaultMapCenterLat: (lat: number | null) => void;
   setDefaultMapCenterLon: (lon: number | null) => void;
   setDefaultMapCenterZoom: (zoom: number | null) => void;
+  setMapCenterTargetZoom: (zoom: number) => void;
   setDefaultLandingPage: (value: string) => void;
   setTheme: (theme: Theme) => void;
   setAppearanceMode: (mode: AppearanceMode) => void;
@@ -379,6 +386,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const [defaultMapCenterZoom, setDefaultMapCenterZoomState] = useState<number | null>(() => {
     const saved = localStorage.getItem('defaultMapCenterZoom');
     return saved ? parseInt(saved, 10) : null;
+  });
+
+  const [mapCenterTargetZoom, setMapCenterTargetZoomState] = useState<number>(() => {
+    const saved = localStorage.getItem('mapCenterTargetZoom');
+    return saved ? parseInt(saved, 10) : DEFAULT_TARGET_ZOOM;
   });
 
   // Default landing page when visiting root URL: 'unified' or a sourceId UUID.
@@ -661,6 +673,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     } else {
       localStorage.removeItem('defaultMapCenterZoom');
     }
+  };
+
+  const setMapCenterTargetZoom = (zoom: number) => {
+    setMapCenterTargetZoomState(zoom);
+    localStorage.setItem('mapCenterTargetZoom', String(zoom));
   };
 
   const setDefaultLandingPage = (value: string) => {
@@ -1290,6 +1307,14 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             }
           }
 
+          if (settings.mapCenterTargetZoom !== undefined) {
+            const zoom = parseInt(settings.mapCenterTargetZoom, 10);
+            if (!isNaN(zoom) && zoom >= 1 && zoom <= 18) {
+              setMapCenterTargetZoomState(zoom);
+              localStorage.setItem('mapCenterTargetZoom', String(zoom));
+            }
+          }
+
           if (typeof settings.defaultLandingPage === 'string' && settings.defaultLandingPage.length > 0) {
             setDefaultLandingPageState(settings.defaultLandingPage);
             localStorage.setItem('defaultLandingPage', settings.defaultLandingPage);
@@ -1547,6 +1572,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     defaultMapCenterLat,
     defaultMapCenterLon,
     defaultMapCenterZoom,
+    mapCenterTargetZoom,
     defaultLandingPage,
     theme,
     appearanceMode,
@@ -1595,6 +1621,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     setDefaultMapCenterLat,
     setDefaultMapCenterLon,
     setDefaultMapCenterZoom,
+    setMapCenterTargetZoom,
     setDefaultLandingPage,
     setTheme,
     setAppearanceMode,

--- a/src/hooks/useMarkerSpiderfier.test.tsx
+++ b/src/hooks/useMarkerSpiderfier.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 /**
- * Regression test for the spiderfier marker-registration timing bug
- * (issue #3612 follow-up: spiderfy not working on Map Analysis / Unified maps).
+ * Tests for useMarkerSpiderfier:
+ *  - issue #3612 follow-up: pre-init marker-registration buffering.
+ *  - issue #4046 item 4: zoom-gated spiderfier registration (below a
+ *    threshold, markers are withheld and clicks fall through to the
+ *    "zoom in first" flow instead of spiderfying a large low-zoom pile).
+ *  - issue #4046 item 1: re-spiderfy after zoom settles (tracks the
+ *    last-spiderfied group and recomputes it fresh on zoomend).
  *
  * React invokes a <Marker ref> callback during the commit phase, which runs
  * BEFORE the hook's init `useEffect` that creates the OverlappingMarkerSpiderfier.
@@ -13,18 +18,28 @@
  * We register the marker in a `useLayoutEffect`, which runs before the hook's
  * passive `useEffect` — reproducing the exact commit-phase ordering a real
  * <Marker ref> produces. A lightweight fake spiderfier records the markers it
- * receives (the fix under test is the hook's buffer/flush, not OMS internals).
+ * receives (the fix under test is the hook's buffer/flush, not OMS internals)
+ * but does implement enough of the real event-listener/`spiderListener`
+ * surface for the gating/respiderfy tests below.
+ *
+ * NOTE (documented mock limitation): this fake OMS can't prove real fan
+ * geometry (circle/spiral foot placement) — it only proves the hook's own
+ * bookkeeping (which markers get registered/withheld, and that a recompute
+ * is triggered). Real fan behavior needs browser validation.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useLayoutEffect, useRef } from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
-// Fake OverlappingMarkerSpiderfier — records what it's handed, no Leaflet map
-// needed. Defined via vi.hoisted so the hoisted vi.mock factory can reference it.
+// Fake OverlappingMarkerSpiderfier — records what it's handed and supports
+// the subset of the real event/listener API the hook depends on. Defined via
+// vi.hoisted so the hoisted vi.mock factory can reference it.
 const { FakeOMS } = vi.hoisted(() => {
   class FakeOMS {
     markers: unknown[] = [];
     nearbyDistance = 0;
+    listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+    spiderListenerCalls: unknown[] = [];
     constructor(
       public map: unknown,
       public opts: unknown,
@@ -36,26 +51,73 @@ const { FakeOMS } = vi.hoisted(() => {
       const i = this.markers.indexOf(m);
       if (i >= 0) this.markers.splice(i, 1);
     }
-    addListener() {}
-    removeListener() {}
+    addListener(event: string, handler: (...args: unknown[]) => void) {
+      (this.listeners[event] ??= []).push(handler);
+    }
+    removeListener(event: string, handler: (...args: unknown[]) => void) {
+      this.listeners[event] = (this.listeners[event] ?? []).filter(h => h !== handler);
+    }
+    trigger(event: string, ...args: unknown[]) {
+      (this.listeners[event] ?? []).forEach(h => h(...args));
+    }
     clearMarkers() {
       this.markers = [];
+    }
+    // Private in the real library, but this is exactly what its own
+    // per-marker click handler calls — the hook reaches into it (via a
+    // typed cast) for #4046 item 1's re-spiderfy. Recorded here so tests can
+    // assert it was invoked with the expected anchor.
+    spiderListener(marker: unknown) {
+      this.spiderListenerCalls.push(marker);
     }
   }
   return { FakeOMS };
 });
 
-// A stable, truthy stub map is all the hook needs (it only checks `if (!map)`).
-vi.mock('react-leaflet', () => {
-  const stub = {};
-  return { useMap: () => stub };
+// A minimal but functional fake Leaflet Map: tracks zoom and dispatches
+// 'zoomstart'/'zoomend' listeners so tests can simulate a zoom change the
+// same way the hook observes it in the browser.
+const { createFakeMap } = vi.hoisted(() => {
+  function createFakeMap(initialZoom: number) {
+    let zoom = initialZoom;
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    return {
+      getZoom: () => zoom,
+      setZoomSilently: (z: number) => { zoom = z; },
+      setView: vi.fn((_latlng: unknown, z: number) => { zoom = z; }),
+      on: (event: string, handler: (...args: unknown[]) => void) => {
+        if (!listeners.has(event)) listeners.set(event, new Set());
+        listeners.get(event)!.add(handler);
+      },
+      off: (event: string, handler: (...args: unknown[]) => void) => {
+        listeners.get(event)?.delete(handler);
+      },
+      fire: (event: string, ...args: unknown[]) => {
+        listeners.get(event)?.forEach(h => h(...args));
+      },
+      // Simulates a full zoom transition: fires zoomstart, updates zoom,
+      // then fires zoomend — mirroring real Leaflet's event order.
+      zoomTo: (z: number) => {
+        listeners.get('zoomstart')?.forEach(h => h());
+        zoom = z;
+        listeners.get('zoomend')?.forEach(h => h());
+      },
+    };
+  }
+  return { createFakeMap };
 });
+
+let currentFakeMap: ReturnType<typeof createFakeMap> = createFakeMap(15);
+
+vi.mock('react-leaflet', () => ({
+  useMap: () => currentFakeMap,
+}));
 vi.mock('ts-overlapping-marker-spiderfier-leaflet', () => ({
   OverlappingMarkerSpiderfier: FakeOMS,
 }));
 
 import L from 'leaflet';
-import { useMarkerSpiderfier, SHARED_SPIDERFIER_OPTIONS } from './useMarkerSpiderfier';
+import { useMarkerSpiderfier, SHARED_SPIDERFIER_OPTIONS, DEFAULT_ZOOM_GATE_THRESHOLD } from './useMarkerSpiderfier';
 
 let api: ReturnType<typeof useMarkerSpiderfier> | null = null;
 
@@ -63,10 +125,15 @@ let api: ReturnType<typeof useMarkerSpiderfier> | null = null;
  * Mirrors the real consumers: registers a marker in a layout effect (pre-init
  * timing) just as react-leaflet's <Marker ref> fires during commit.
  */
-function Harness({ nodeId }: { nodeId: string }) {
-  const hook = useMarkerSpiderfier(SHARED_SPIDERFIER_OPTIONS);
+function Harness({ nodeId, lat = 0.0005, lon = 0.0005, options = SHARED_SPIDERFIER_OPTIONS }: {
+  nodeId: string;
+  lat?: number;
+  lon?: number;
+  options?: typeof SHARED_SPIDERFIER_OPTIONS;
+}) {
+  const hook = useMarkerSpiderfier(options);
   api = hook;
-  const markerRef = useRef<L.Marker>(L.marker([0.0005, 0.0005]));
+  const markerRef = useRef<L.Marker>(L.marker([lat, lon]));
   useLayoutEffect(() => {
     hook.addMarker(markerRef.current, nodeId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -77,6 +144,7 @@ function Harness({ nodeId }: { nodeId: string }) {
 describe('useMarkerSpiderfier registration timing (#3612)', () => {
   beforeEach(() => {
     api = null;
+    currentFakeMap = createFakeMap(15); // above the default z13 gate
   });
   afterEach(() => {
     api = null;
@@ -102,5 +170,154 @@ describe('useMarkerSpiderfier registration timing (#3612)', () => {
     rerender(<Harness nodeId="node-1" />);
 
     expect(oms.markers.length).toBe(1);
+  });
+});
+
+describe('useMarkerSpiderfier zoom-gated registration (#4046 item 4)', () => {
+  beforeEach(() => {
+    api = null;
+  });
+  afterEach(() => {
+    api = null;
+  });
+
+  it('withholds a marker from the spiderfier when mounted below the threshold', () => {
+    currentFakeMap = createFakeMap(DEFAULT_ZOOM_GATE_THRESHOLD - 1);
+    render(<Harness nodeId="node-1" />);
+
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    expect(oms.markers.length).toBe(0);
+    expect(api!.isAboveGateThreshold).toBe(false);
+  });
+
+  it('registers markers with the spiderfier when mounted at/above the threshold', () => {
+    currentFakeMap = createFakeMap(DEFAULT_ZOOM_GATE_THRESHOLD);
+    render(<Harness nodeId="node-1" />);
+
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    expect(oms.markers.length).toBe(1);
+    expect(api!.isAboveGateThreshold).toBe(true);
+  });
+
+  it('registers withheld markers once zoom crosses back above the threshold', () => {
+    currentFakeMap = createFakeMap(DEFAULT_ZOOM_GATE_THRESHOLD - 1);
+    render(<Harness nodeId="node-1" />);
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    expect(oms.markers.length).toBe(0);
+
+    act(() => {
+      currentFakeMap.zoomTo(DEFAULT_ZOOM_GATE_THRESHOLD);
+    });
+
+    expect(oms.markers.length).toBe(1);
+    expect(api!.isAboveGateThreshold).toBe(true);
+  });
+
+  it('deregisters markers once zoom crosses below the threshold', () => {
+    currentFakeMap = createFakeMap(DEFAULT_ZOOM_GATE_THRESHOLD);
+    render(<Harness nodeId="node-1" />);
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    expect(oms.markers.length).toBe(1);
+
+    act(() => {
+      currentFakeMap.zoomTo(DEFAULT_ZOOM_GATE_THRESHOLD - 1);
+    });
+
+    expect(oms.markers.length).toBe(0);
+    expect(api!.isAboveGateThreshold).toBe(false);
+  });
+
+  it('handleGatedClick centers and zooms in on the clicked marker (clamped, never zooms out)', () => {
+    currentFakeMap = createFakeMap(5); // far zoomed out
+    render(<Harness nodeId="node-1" options={{ ...SHARED_SPIDERFIER_OPTIONS, zoomGateTargetZoom: 17 }} />);
+
+    const marker = L.marker([1, 2]);
+    act(() => {
+      api!.handleGatedClick(marker);
+    });
+
+    expect(currentFakeMap.setView).toHaveBeenCalledTimes(1);
+    const [latlng, zoom] = currentFakeMap.setView.mock.calls[0];
+    expect(latlng).toEqual(marker.getLatLng());
+    expect(zoom).toBe(17); // clamped up from 5
+  });
+
+  it('handleGatedClick never zooms out below the current zoom', () => {
+    currentFakeMap = createFakeMap(18); // already closer than the default target
+    render(<Harness nodeId="node-1" />);
+
+    const marker = L.marker([1, 2]);
+    act(() => {
+      api!.handleGatedClick(marker);
+    });
+
+    const [, zoom] = currentFakeMap.setView.mock.calls[0];
+    expect(zoom).toBe(18); // clamp keeps current (already-closer) zoom
+  });
+});
+
+describe('useMarkerSpiderfier re-spiderfy after zoom settles (#4046 item 1)', () => {
+  beforeEach(() => {
+    api = null;
+    currentFakeMap = createFakeMap(15);
+  });
+  afterEach(() => {
+    api = null;
+  });
+
+  it('re-triggers a fresh spiderfy computation for the last-spiderfied group on zoomend', () => {
+    render(<Harness nodeId="node-1" />);
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    const marker = oms.markers[0];
+
+    // Simulate OMS having spiderfied this marker's group.
+    act(() => {
+      oms.trigger('spiderfy', [marker], []);
+    });
+
+    act(() => {
+      currentFakeMap.zoomTo(16);
+    });
+
+    // The vendored OMS's own zoomend listener would have called unspiderfy()
+    // first in the real library; our fake doesn't model that internal wiring,
+    // but the hook's zoomend handler should still re-invoke spiderListener
+    // for the tracked anchor once above the gate.
+    expect(oms.spiderListenerCalls).toEqual([marker]);
+  });
+
+  it('does not re-spiderfy after a deliberate (non-zoom) unspiderfy', () => {
+    render(<Harness nodeId="node-1" />);
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    const marker = oms.markers[0];
+
+    act(() => {
+      oms.trigger('spiderfy', [marker], []);
+      // A click-away unspiderfy — NOT preceded by our zoomstart handler.
+      oms.trigger('unspiderfy', [marker], []);
+    });
+
+    act(() => {
+      currentFakeMap.zoomTo(16);
+    });
+
+    expect(oms.spiderListenerCalls).toEqual([]);
+  });
+
+  it('does not re-spiderfy once the zoom has dropped below the gate threshold', () => {
+    render(<Harness nodeId="node-1" />);
+    const oms = api!.getSpiderfier() as unknown as FakeOMS;
+    const marker = oms.markers[0];
+
+    act(() => {
+      oms.trigger('spiderfy', [marker], []);
+    });
+
+    act(() => {
+      currentFakeMap.zoomTo(DEFAULT_ZOOM_GATE_THRESHOLD - 1);
+    });
+
+    expect(oms.spiderListenerCalls).toEqual([]);
+    expect(oms.markers.length).toBe(0); // also deregistered per item 4
   });
 });

--- a/src/hooks/useMarkerSpiderfier.ts
+++ b/src/hooks/useMarkerSpiderfier.ts
@@ -3,10 +3,33 @@
  * Handles spreading of overlapping markers in a "peacock fan" pattern
  */
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { useMap } from 'react-leaflet';
 import { Marker as LeafletMarker } from 'leaflet';
 import { OverlappingMarkerSpiderfier, type SpiderfierEventMap, type SpiderfierEventHandler } from 'ts-overlapping-marker-spiderfier-leaflet';
+import {
+  DEFAULT_TARGET_ZOOM,
+  DEFAULT_ZOOM_GATE_THRESHOLD,
+  computeClampedTargetZoom,
+  computeZoomAnimationDuration,
+} from '../utils/mapZoomAnimation';
+
+export { DEFAULT_ZOOM_GATE_THRESHOLD };
+
+/**
+ * Minimal shape of `OverlappingMarkerSpiderfier`'s PRIVATE `spiderListener`
+ * method that we deliberately reach into for issue #4046 item 1 (re-spiderfy
+ * after zoom settles). The vendored library exposes no public "recompute the
+ * fan for this marker" API — `spiderListener` is exactly what its own
+ * per-marker 'click' handler calls (`ts-overlapping-marker-spiderfier-leaflet
+ * @1.0.5`, `dist/index.cjs.js`): it searches for nearby markers around the
+ * given marker AT THE CURRENT ZOOM and re-spiderfies them, which is exactly
+ * "fresh geometry, never reused stale foot positions." A typed cast (not
+ * `any`) — see the call site below for the full rationale.
+ */
+interface SpiderfierInternals {
+  spiderListener(marker: LeafletMarker): void;
+}
 
 /**
  * Shared spiderfier tuning used by every map surface (per-source NodesTab map,
@@ -40,6 +63,13 @@ export const SHARED_SPIDERFIER_OPTIONS: SpiderfierOptions = {
     usual: 'rgba(100, 100, 100, 0.6)', // Semi-transparent gray
     highlighted: 'rgba(50, 50, 50, 0.8)', // Darker when hovering
   },
+  /** Issue #4046 item 4: below z13, don't register markers with the
+   *  spiderfier at all — a click falls through to the native marker click,
+   *  which `NodeMarkersLayer` wires to a "zoom in first" flow instead of
+   *  spiderfying a large, hard-to-parse low-zoom pile. Applies to every
+   *  surface that uses the shared layer (NodesTab, Dashboard, MeshCore,
+   *  Map Analysis). */
+  zoomGateThreshold: DEFAULT_ZOOM_GATE_THRESHOLD,
 };
 
 export interface SpiderfierOptions {
@@ -95,6 +125,22 @@ export interface SpiderfierOptions {
     usual: string;
     highlighted: string;
   };
+
+  /**
+   * Issue #4046 item 4: zoom level at/above which markers are registered
+   * with the spiderfier. Below this, `addMarker` withholds registration
+   * (the marker is still tracked, just not handed to OMS) and
+   * `isAboveGateThreshold` / `handleGatedClick` let the consumer wire a
+   * "zoom in first" click flow instead. Default: DEFAULT_ZOOM_GATE_THRESHOLD (13).
+   */
+  zoomGateThreshold?: number;
+
+  /**
+   * Target zoom used by `handleGatedClick`'s "zoom in first" flow (issue
+   * #4046 items 2/4) — same clamp-never-zoom-out semantics as
+   * `MapCenterController`'s `targetZoom`. Default: DEFAULT_TARGET_ZOOM (17).
+   */
+  zoomGateTargetZoom?: number;
 }
 
 /**
@@ -119,6 +165,54 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
   // These get flushed into the spiderfier the moment it's created.
   const pendingRef = useRef<Map<string, LeafletMarker>>(new Map());
 
+  // #4046 item 4: markers withheld from the spiderfier because the zoom is
+  // below `zoomGateThreshold`. Distinct from `pendingRef` (which is a
+  // one-time pre-init buffer) — markers can move in and out of this set
+  // repeatedly as the zoom crosses the gate.
+  const gatedMarkersRef = useRef<Map<string, LeafletMarker>>(new Map());
+  // Mirrors whether we're currently above the gate. A ref for synchronous
+  // reads inside effect callbacks, plus `isAboveGateThreshold` state so
+  // `NodeMarkersLayer` re-renders (to swap marker eventHandlers) when it
+  // crosses.
+  const aboveThresholdRef = useRef(true);
+  const [isAboveGateThreshold, setIsAboveGateThreshold] = useState(true);
+
+  // #4046 item 1: the last marker-group spiderfy'd, tracked so a fresh
+  // zoomend can re-trigger the fan at the new zoom's geometry. Any marker
+  // from the group works as the recompute anchor (spiderListener searches
+  // for markers near IT, at the current zoom).
+  const lastSpiderfiedAnchorRef = useRef<LeafletMarker | null>(null);
+  // True between 'zoomstart' and our own 'zoomend' handler running. Lets the
+  // 'unspiderfy' listener below tell a zoom-triggered collapse (OMS's own
+  // unconditional zoomend->unspiderfy — keep the anchor, we're about to
+  // re-spiderfy it) apart from a deliberate one (click-away, or clicking a
+  // different marker — drop the anchor, nothing to re-spiderfy).
+  const zoomChangeInProgressRef = useRef(false);
+
+  // `addMarker`/`removeMarker`/`handleGatedClick` are deliberately
+  // referentially stable (`[]` deps — see the comment above `addMarker`'s
+  // definition), because `NodeMarkersLayer` caches its per-marker ref
+  // callback once per key and never rebinds it. That means those callbacks
+  // can only read *current* option values through a ref, not through the
+  // `options` closure directly (which would go stale, or — worse — force us
+  // to break referential stability by adding `options.x` to their deps).
+  // Synced on every render (no dependency array) rather than only when
+  // `options` changes, since callers may pass a fresh object literal each
+  // render even when the underlying values are unchanged.
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+  // Same rationale as `optionsRef` — `map` is stable in practice (one
+  // `useMap()` context per mounted MapContainer), but capturing it directly
+  // in a `[]`-dep callback trips `react-hooks/exhaustive-deps`. Route through
+  // a ref instead of adding `map` to addMarker's deps (which would break its
+  // required referential stability).
+  const mapRef = useRef(map);
+  useEffect(() => {
+    mapRef.current = map;
+  });
+
   // Initialize spiderfier instance (only once when map is available)
   useEffect(() => {
     if (!map) return;
@@ -141,12 +235,43 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
 
     spiderfierRef.current = spiderfier;
 
+    // #4046 item 1: track the last-spiderfied group so a subsequent zoomend
+    // can recompute a fresh fan for it (see the zoomend handler below).
+    const handleSpiderfy = (spiderfiedMarkers: LeafletMarker[]) => {
+      lastSpiderfiedAnchorRef.current = spiderfiedMarkers[0] ?? null;
+    };
+    const handleUnspiderfy = () => {
+      // Only drop the tracked anchor when this collapse was NOT caused by a
+      // zoom change (e.g. the user clicked empty map space to close the fan,
+      // or clicked a different marker — OMS unspiderfies any existing fan
+      // before spiderfying a new one). A zoom-triggered collapse leaves the
+      // anchor in place so the zoomend handler can re-spiderfy the same
+      // group at the new zoom.
+      if (!zoomChangeInProgressRef.current) {
+        lastSpiderfiedAnchorRef.current = null;
+      }
+    };
+    spiderfier.addListener('spiderfy', handleSpiderfy);
+    spiderfier.addListener('unspiderfy', handleUnspiderfy);
+
+    // Initialize the zoom-gate state from the current zoom (#4046 item 4).
+    const threshold = options.zoomGateThreshold;
+    const initiallyAbove = threshold == null || map.getZoom() >= threshold;
+    aboveThresholdRef.current = initiallyAbove;
+    setIsAboveGateThreshold(initiallyAbove);
+
     // Flush any markers that registered before the spiderfier existed (their
     // ref callbacks ran during the commit phase, before this effect). Without
     // this, markers present at first mount are never handed to the spiderfier
     // and clicking their pile never spreads them apart.
     if (pendingRef.current.size > 0) {
       pendingRef.current.forEach((marker, key) => {
+        if (!initiallyAbove) {
+          // Below the gate at first mount — withhold registration, matching
+          // the steady-state addMarker() behavior.
+          gatedMarkersRef.current.set(key, marker);
+          return;
+        }
         try {
           spiderfier.addMarker(marker);
           markersRef.current.add(marker);
@@ -172,6 +297,9 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
         markersRef.current.clear();
         markerByIdRef.current.clear();
         pendingRef.current.clear();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- #4046 mirrors the pre-existing markersRef/markerByIdRef/pendingRef cleanup lines above (baselined): these are plain Map/Set refs, not DOM nodes, so the "ref may have changed by cleanup time" warning is a false positive here.
+        gatedMarkersRef.current.clear();
+        lastSpiderfiedAnchorRef.current = null;
         spiderfierRef.current = null;
       }
     };
@@ -183,6 +311,93 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
       spiderfierRef.current.nearbyDistance = options.nearbyDistance;
     }
   }, [options.nearbyDistance]);
+
+  // #4046 items 1 + 4: on 'zoomstart', snapshot that a zoom is in progress
+  // (read by the 'unspiderfy' listener above to distinguish a zoom-triggered
+  // collapse from a deliberate one). On 'zoomend':
+  //   - if the zoom-gate threshold was just crossed, (de)register every
+  //     tracked marker accordingly (item 4);
+  //   - if a fan was open immediately before this zoom change and we're
+  //     still above the gate, recompute it fresh at the new zoom (item 1) —
+  //     the vendored OMS unconditionally unspiderfies on its own 'zoomend'
+  //     listener (registered first, inside its constructor), so by the time
+  //     this handler runs the fan is already collapsed; we're re-triggering
+  //     a brand new spiderfy computation, never reusing the stale geometry.
+  useEffect(() => {
+    if (!map) return;
+
+    const handleZoomStart = () => {
+      zoomChangeInProgressRef.current = true;
+    };
+
+    const handleZoomEnd = () => {
+      zoomChangeInProgressRef.current = false;
+
+      const spiderfier = spiderfierRef.current;
+      if (!spiderfier) return;
+
+      const threshold = options.zoomGateThreshold;
+      if (threshold != null) {
+        const nowAbove = map.getZoom() >= threshold;
+        if (nowAbove !== aboveThresholdRef.current) {
+          aboveThresholdRef.current = nowAbove;
+          setIsAboveGateThreshold(nowAbove);
+
+          if (nowAbove) {
+            // Crossed up: register every withheld marker.
+            gatedMarkersRef.current.forEach((marker, key) => {
+              try {
+                spiderfier.addMarker(marker);
+                markersRef.current.add(marker);
+                markerByIdRef.current.set(key, marker);
+              } catch {
+                // Ignore — marker may have been unmounted while gated.
+              }
+            });
+            gatedMarkersRef.current.clear();
+          } else {
+            // Crossed down: deregister everything so a low-zoom click falls
+            // through to the native marker click (zoom-in-first flow, #4046
+            // item 4) instead of spiderfying a large pile.
+            markersRef.current.forEach(marker => {
+              try {
+                spiderfier.removeMarker(marker);
+              } catch {
+                // Ignore
+              }
+            });
+            markerByIdRef.current.forEach((marker, key) => {
+              gatedMarkersRef.current.set(key, marker);
+            });
+            markersRef.current.clear();
+            markerByIdRef.current.clear();
+            // Nothing can be spiderfied below the gate — drop the tracked
+            // anchor so crossing back up later doesn't resurrect a stale fan.
+            lastSpiderfiedAnchorRef.current = null;
+          }
+        }
+      }
+
+      const anchor = lastSpiderfiedAnchorRef.current;
+      if (anchor && markersRef.current.has(anchor)) {
+        // Reach into the vendored library's private `spiderListener` — the
+        // exact method its own marker 'click' handler calls. There's no
+        // public "recompute this fan" API; this typed cast (not `any`) is
+        // the documented, deliberate exception (see SpiderfierInternals
+        // above). Calling it re-derives the nearby-marker group from the
+        // anchor's position AT THE CURRENT (new) ZOOM and re-spiderfies —
+        // fresh foot positions, never the stale pre-zoom ones.
+        (spiderfier as unknown as SpiderfierInternals).spiderListener(anchor);
+      }
+    };
+
+    map.on('zoomstart', handleZoomStart);
+    map.on('zoomend', handleZoomEnd);
+    return () => {
+      map.off('zoomstart', handleZoomStart);
+      map.off('zoomend', handleZoomEnd);
+    };
+  }, [map, options.zoomGateThreshold]);
 
   /**
    * Add a marker to the spiderfier
@@ -203,6 +418,18 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
       pendingRef.current.set(trackingKey, marker);
       return;
     }
+
+    // #4046 item 4: below the zoom-gate threshold, track the marker but
+    // withhold it from the spiderfier entirely — no live OMS registration to
+    // dedupe/replace, so this is a simple upsert. The zoomend handler above
+    // registers it once the zoom crosses back above the threshold.
+    const threshold = optionsRef.current.zoomGateThreshold;
+    if (threshold != null && mapRef.current && mapRef.current.getZoom() < threshold) {
+      gatedMarkersRef.current.set(trackingKey, marker);
+      return;
+    }
+    gatedMarkersRef.current.delete(trackingKey);
+
     const existingMarker = markerByIdRef.current.get(trackingKey);
 
     // If the existing marker is the same object, we're done (already added)
@@ -281,6 +508,17 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
       }
     }
 
+    // #4046 item 4: also purge the zoom-gate withheld set — a node that
+    // ages out/filters away while below the gate must not be resurrected
+    // (pointing at a stale, unmounted marker) when the zoom later crosses
+    // back above the threshold.
+    for (const [key, value] of gatedMarkersRef.current.entries()) {
+      if (value === marker) {
+        gatedMarkersRef.current.delete(key);
+        break;
+      }
+    }
+
     if (!spiderfierRef.current) return;
 
     if (!markersRef.current.has(marker)) return;
@@ -342,11 +580,39 @@ export function useMarkerSpiderfier(options: SpiderfierOptions = {}) {
     spiderfierRef.current.removeListener(event, handler);
   }, []);
 
+  /**
+   * Issue #4046 item 4: the "zoom in first" click handler for a marker that
+   * is below the zoom-gate threshold (and therefore NOT registered with the
+   * spiderfier — its native Leaflet click never reaches OMS). Consumers
+   * (`NodeMarkersLayer`) wire this as the marker's `click` eventHandler
+   * while `isAboveGateThreshold` is false, in place of the marker's normal
+   * click behavior — no selection, no popup, just center-and-zoom so the
+   * pile is sparse enough to click precisely on a follow-up click. Reuses
+   * the same clamp-never-zoom-out + duration-scaling math as
+   * `MapCenterController` (items 2/3), invoked directly against the map
+   * rather than through each consumer's own center-on-node plumbing, so
+   * every map surface gets identical below-threshold behavior for free.
+   */
+  const handleGatedClick = useCallback((marker: LeafletMarker) => {
+    if (!map) return;
+    const currentZoom = map.getZoom();
+    const targetZoom = optionsRef.current.zoomGateTargetZoom ?? DEFAULT_TARGET_ZOOM;
+    const clampedZoom = computeClampedTargetZoom(currentZoom, targetZoom);
+    const duration = computeZoomAnimationDuration(currentZoom, clampedZoom);
+    map.setView(marker.getLatLng(), clampedZoom, { animate: true, duration });
+  }, [map]);
+
   return {
     addMarker,
     removeMarker,
     getSpiderfier,
     addListener,
     removeListener,
+    /** True when at/above `zoomGateThreshold` (or gating is disabled) —
+     *  markers are registered with the spiderfier and click normally. False
+     *  below the threshold — markers are withheld and `NodeMarkersLayer`
+     *  should route clicks through `handleGatedClick` instead (#4046 item 4). */
+    isAboveGateThreshold,
+    handleGatedClick,
   };
 }

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -183,6 +183,10 @@ export const VALID_SETTINGS_KEYS = [
   'defaultMapCenterLat',
   'defaultMapCenterLon',
   'defaultMapCenterZoom',
+  // Target zoom when centering on a single node — clamped to never zoom out
+  // (issue #4046 item 2). Also feeds the zoom-gated spiderfier's "zoom in
+  // first" click flow (item 4).
+  'mapCenterTargetZoom',
   'securityDigestEnabled',
   'securityDigestAppriseUrl',
   'securityDigestTime',

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -32,6 +32,8 @@ export type ConnectionStatus =
 export interface MapCenterControllerProps {
   centerTarget: [number, number] | null;
   onCenterComplete: () => void;
+  /** User-configurable target zoom (issue #4046 item 2). Defaults to 17. */
+  targetZoom?: number;
 }
 
 export interface ChartData {

--- a/src/utils/mapZoomAnimation.test.ts
+++ b/src/utils/mapZoomAnimation.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_TARGET_ZOOM,
+  DEFAULT_ZOOM_GATE_THRESHOLD,
+  ZOOM_ANIMATION_DURATION_BASE_SECONDS,
+  ZOOM_ANIMATION_DURATION_MAX_SECONDS,
+  computeClampedTargetZoom,
+  computeZoomAnimationDuration,
+} from './mapZoomAnimation';
+
+describe('mapZoomAnimation constants (#4046)', () => {
+  it('exposes the documented defaults', () => {
+    expect(DEFAULT_TARGET_ZOOM).toBe(17);
+    expect(DEFAULT_ZOOM_GATE_THRESHOLD).toBe(13);
+  });
+});
+
+describe('computeClampedTargetZoom (#4046 item 2)', () => {
+  it('zooms in when the current zoom is further out than the target', () => {
+    expect(computeClampedTargetZoom(10, 17)).toBe(17);
+    expect(computeClampedTargetZoom(1, 17)).toBe(17);
+  });
+
+  it('never zooms out when the current zoom is already at or past the target', () => {
+    expect(computeClampedTargetZoom(18, 17)).toBe(18);
+    expect(computeClampedTargetZoom(17, 17)).toBe(17);
+  });
+
+  it('handles a target of 0 and negative deltas correctly (still just Math.max)', () => {
+    expect(computeClampedTargetZoom(5, 0)).toBe(5);
+  });
+});
+
+describe('computeZoomAnimationDuration (#4046 item 3)', () => {
+  it('returns the base duration for a zero zoom delta', () => {
+    expect(computeZoomAnimationDuration(15, 15)).toBeCloseTo(ZOOM_ANIMATION_DURATION_BASE_SECONDS, 5);
+  });
+
+  it('is symmetric in the sign of the delta (zooming in vs out by the same amount)', () => {
+    const a = computeZoomAnimationDuration(10, 15);
+    const b = computeZoomAnimationDuration(15, 10);
+    expect(a).toBeCloseTo(b, 10);
+  });
+
+  it('grows monotonically with the size of the zoom delta, up to the cap', () => {
+    const d1 = computeZoomAnimationDuration(15, 16); // delta 1
+    const d2 = computeZoomAnimationDuration(15, 17); // delta 2
+    const d5 = computeZoomAnimationDuration(15, 20); // delta 5
+    expect(d2).toBeGreaterThan(d1);
+    expect(d5).toBeGreaterThan(d2);
+  });
+
+  it('never exceeds the documented cap, even for a huge zoom delta', () => {
+    const duration = computeZoomAnimationDuration(1, 18); // delta 17
+    expect(duration).toBeLessThanOrEqual(ZOOM_ANIMATION_DURATION_MAX_SECONDS);
+    expect(duration).toBe(ZOOM_ANIMATION_DURATION_MAX_SECONDS);
+  });
+
+  it('never returns less than the base duration', () => {
+    const duration = computeZoomAnimationDuration(15, 15.5);
+    expect(duration).toBeGreaterThanOrEqual(ZOOM_ANIMATION_DURATION_BASE_SECONDS);
+  });
+});

--- a/src/utils/mapZoomAnimation.ts
+++ b/src/utils/mapZoomAnimation.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure zoom/animation math shared by `MapCenterController` and
+ * `useMarkerSpiderfier`'s zoom-gated "click to zoom in" flow (issue #4046,
+ * items 2/3/4). Kept dependency-free (no Leaflet/React imports) so it's
+ * trivially unit-testable and reusable from both call sites.
+ */
+
+/**
+ * Default target zoom used when centering on a single node (issue #4046
+ * item 2). Tighter than the old hardcoded 15 since the user is selecting one
+ * specific node. User-configurable via the `mapCenterTargetZoom` setting —
+ * see `SettingsContext`/`SettingsTab`.
+ */
+export const DEFAULT_TARGET_ZOOM = 17;
+
+/**
+ * Zoom level at/above which markers are registered with the spiderfier
+ * (issue #4046 item 4). Below this, a marker click zooms in first instead of
+ * spiderfying a large, hard-to-parse low-zoom pile.
+ */
+export const DEFAULT_ZOOM_GATE_THRESHOLD = 13;
+
+/** Base animation duration (seconds) for a zero/near-zero zoom-delta pan. */
+export const ZOOM_ANIMATION_DURATION_BASE_SECONDS = 0.5;
+
+/**
+ * Growth factor applied per zoom level of delta — `duration = base *
+ * factor^delta`, capped at ZOOM_ANIMATION_DURATION_MAX_SECONDS. Tuned so a
+ * 1-2 level nudge stays snappy (~0.56-0.63s) while a full zoomed-out-to-street
+ * jump (delta 10+) saturates at the cap rather than dragging on:
+ *   delta 1  -> 0.56s
+ *   delta 2  -> 0.63s
+ *   delta 5  -> 0.88s
+ *   delta 10 -> 1.55s
+ *   delta 15 -> capped at 2.0s
+ */
+export const ZOOM_ANIMATION_DURATION_GROWTH_FACTOR = 1.12;
+
+/** Upper bound (seconds) on the scaled animation duration — keeps even a
+ *  world-to-street jump feeling snappy rather than sluggish. */
+export const ZOOM_ANIMATION_DURATION_MAX_SECONDS = 2.0;
+
+/**
+ * Clamp a target zoom so centering on a node never forces a zoom-*out*
+ * (issue #4046 item 2). Zooms in when the user is further out than
+ * `targetZoom`; leaves the current zoom untouched (pure pan) when already
+ * closer.
+ */
+export function computeClampedTargetZoom(currentZoom: number, targetZoom: number): number {
+  return Math.max(currentZoom, targetZoom);
+}
+
+/**
+ * Scale the pan/zoom animation duration by the size of the zoom jump (issue
+ * #4046 item 3) so a big jump doesn't feel like a jarring snap while a small
+ * nudge stays quick.
+ */
+export function computeZoomAnimationDuration(currentZoom: number, targetZoom: number): number {
+  const delta = Math.abs(targetZoom - currentZoom);
+  const duration = ZOOM_ANIMATION_DURATION_BASE_SECONDS * Math.pow(ZOOM_ANIMATION_DURATION_GROWTH_FACTOR, delta);
+  return Math.min(duration, ZOOM_ANIMATION_DURATION_MAX_SECONDS);
+}


### PR DESCRIPTION
## Summary

Implements all four items of #4046 — the map pan/zoom/centering/spiderfy UX bundle (credit @huntchak via Discord for item 4's observation). Thanks to the #4047 consolidation, each fix lives in exactly one shared component and applies to every map surface at once.

## Changes

1. **Re-spiderfy after zoom** (`useMarkerSpiderfier`): the vendored spiderfier unconditionally collapses fans on `zoomend` (its foot geometry is zoom-specific). We now track the last-fanned group's anchor and re-trigger a fresh spiderfy at the new zoom — fresh geometry, never stale foot positions; deliberate collapses (click-away) don't re-trigger. Uses a narrowly-typed, documented reach into the vendored lib's `spiderListener` (no public recompute API; version-pinned dependency).
2. **Center-on-node zoom clamp + configurable target** (`MapCenterController` + settings): target zoom is now `max(currentZoom, target)` — never forces a zoom-out — with the target user-configurable (Settings → Map, default 17; full VALID_SETTINGS_KEYS/SettingsContext/SettingsTab wiring incl. the handleSave dependency-array gotcha).
3. **Animation duration scales with zoom distance** (`mapZoomAnimation.ts`, pure + unit-tested): `0.5s × 1.12^delta` capped at 2s, so a world→street jump animates smoothly instead of snapping, while small adjustments stay quick.
4. **Zoom-gated spiderfy (threshold z13)** (`useMarkerSpiderfier`/`NodeMarkersLayer`): below the gate, marker clicks don't detonate 10+-marker fans — they center + zoom in (via items 2/3's math, same configurable target) so the user can pick precisely once markers separate. Crossing above the gate (re-)registers markers for normal fan behavior. Popups stay closed below the gate (the existing #4015 strip already covers unregistered markers).

## Issues Resolved
Fixes #4046.

## Testing
- [x] Full Vitest suite: success:true — 9,688 tests / 0 failures (37 new: pure math, controller, gating/re-spiderfy bookkeeping with a functional fake OMS, settings round-trip, click routing)
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] Browser-validated on the dev container (served-bundle-hash verified): zoom-0 marker click zooms to 17 with no fan; above-gate pile click fans; a 6-marker exact-coordinate stack stays fanned across a zoom step (previously collapsed permanently); at zoom 19 a marker click does not zoom out; settings field present with default 17. No console errors.
- [ ] Reviewer: item 4's below-threshold behavior (click = zoom-in-first, no selection/popup until above the gate) is the intended UX per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub