### PR TITLE
chore: bump version to 4.13.0-rc2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.0-rc1",
+  "version": "4.13.0-rc2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.0-rc1",
+  "version": "4.13.0-rc2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.0-rc1
-appVersion: "4.13.0-rc1"
+version: 4.13.0-rc2
+appVersion: "4.13.0-rc2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.0-rc1",
+  "version": "4.13.0-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.0-rc1",
+      "version": "4.13.0-rc2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.0-rc1",
+  "version": "4.13.0-rc2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump for the v4.13.0-rc2 pre-release: the map consolidation epic (#4047), post-epic fixes (#4071), Dashboard neighbor-line fix (#4055/#4042), and map interaction polish (#4072/#4046). All five version files updated per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub