### PR TITLE
fix(map): ROUTER_LATE renders as repeater tower on NodesTab + Dashboard maps (#4075)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -18,6 +18,7 @@ import type { PathOptions } from 'leaflet';
 import L from 'leaflet';
 import { createNodeIcon } from '../../utils/mapIcons';
 import { markerAgeOpacity } from '../../utils/markerAgeOpacity';
+import { getNodeTypeCategory } from '../../utils/nodeTypeCategory';
 import { NodeMarkersLayer, type NodeMarkerDescriptor } from '../map/layers/NodeMarkersLayer';
 import type { CustomTileset } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
@@ -449,6 +450,10 @@ export default function DashboardMap({
     const shortName = node.shortName ?? node.user?.shortName;
     const nodeId = node.nodeId ?? node.user?.id;
     const isRouter = node.role === 2;
+    // #4075: role category drives the repeater-tower glyph for ROUTER_LATE
+    // (and REPEATER), not just ROUTER. Included in iconSig below so the icon
+    // cache distinguishes it from a plain client with the same hops/name.
+    const roleCategory = getNodeTypeCategory(node);
     const markerKey = String(
       node.sourceId != null && node.nodeNum != null
         ? `${node.sourceId}:${node.nodeNum}`
@@ -473,13 +478,14 @@ export default function DashboardMap({
     return {
       key: markerKey,
       position: [pos.lat, pos.lng],
-      iconSig: `${hops}|${shortName ?? ''}|${isRouter ? 1 : 0}|${mapPinStyle}`,
+      iconSig: `${hops}|${shortName ?? ''}|${isRouter ? 1 : 0}|${roleCategory}|${mapPinStyle}`,
       buildIcon: () =>
         createNodeIcon({
           variant: 'meshtastic',
           hops,
           isSelected: false,
           isRouter,
+          roleCategory,
           shortName,
           showLabel: true,
           pinStyle: mapPinStyle,

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -7,6 +7,7 @@ import type { Marker as LeafletMarker } from 'leaflet';
 import { DeviceInfo } from '../types/device';
 import { TabType } from '../types/ui';
 import { nodePassesTransportFilter } from '../utils/nodeTransport';
+import { getNodeTypeCategory } from '../utils/nodeTypeCategory';
 import { effectiveMapMaxAgeHours } from '../utils/mapAge';
 import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, snrToColor } from '../utils/mapHelpers.tsx';
@@ -1423,6 +1424,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         ? parseInt(node.user.role, 10)
         : (typeof node.user?.role === 'number' ? node.user.role : 0);
       const isRouter = roleNum === 2;
+      // #4075: pass the role category so ROUTER_LATE (and REPEATER) get the
+      // repeater-tower glyph like ROUTER, matching MapAnalysis. isRouter alone
+      // is role===2 only, so ROUTER_LATE would fall through to the generic pin.
+      const roleCategory = getNodeTypeCategory(node);
       const isSelected = selectedNodeId === node.user?.id;
       const isLocalNode = node.user?.id === currentNodeId;
       const hops = isLocalNode ? 0 : getEffectiveHops(node, nodeHopsCalculation, traceroutes, currentNodeNum);
@@ -1457,6 +1462,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
             hops,
             isSelected,
             isRouter,
+            roleCategory,
             shortName: node.user?.shortName,
             showLabel: showLabel || shouldAnimate,
             animate: shouldAnimate,

--- a/src/components/map/markerIcons.test.ts
+++ b/src/components/map/markerIcons.test.ts
@@ -295,3 +295,35 @@ describe('createTracerouteEndpointIcon', () => {
     expect(icon.className).toBe('traceroute-node-icon');
   });
 });
+
+describe('createNodeIcon — Meshtastic ROUTER_LATE renders as repeater tower (#4075)', () => {
+  const iconHtml = (roleCategory: NodeTypeCategory | undefined, isRouter: boolean) =>
+    (createNodeIcon({
+      variant: 'meshtastic',
+      hops: 1,
+      isRouter,
+      roleCategory,
+      shortName: 'X',
+    }) as unknown as { html: string }).html;
+
+  it('ROUTER_LATE (mtRouterLate) produces the same glyph as ROUTER (mtRouter)', () => {
+    // Both roles map to the "repeater" glyph family via categoryGlyphFamily;
+    // passing roleCategory must make them render identically.
+    expect(iconHtml('mtRouterLate', false)).toBe(iconHtml('mtRouter', false));
+  });
+
+  it('ROUTER_LATE does NOT render as the generic client pin', () => {
+    // The bug: a ROUTER_LATE node (isRouter=false, role 11) with no roleCategory
+    // fell through to the plain pin. With its category it must diverge from a
+    // standard client icon.
+    expect(iconHtml('mtRouterLate', false)).not.toBe(iconHtml('mtClient', false));
+  });
+
+  it('ROUTER and ROUTER_LATE render identically once both pass roleCategory (roleCategory wins over the legacy isRouter branch)', () => {
+    // #4075 fix: the call sites now pass roleCategory. Because roleCategory
+    // takes precedence over the legacy hand-drawn isRouter tower, a ROUTER node
+    // (isRouter=true + mtRouter) and a ROUTER_LATE node (mtRouterLate) resolve
+    // to the same category glyph — the same one MapAnalysis already used.
+    expect(iconHtml('mtRouter', true)).toBe(iconHtml('mtRouterLate', false));
+  });
+});


### PR DESCRIPTION
## Summary

`ROUTER_LATE` nodes rendered as a generic pin on the NodesTab and Dashboard maps instead of the repeater-tower icon `ROUTER` nodes get — while Map Analysis showed them correctly. Root cause and fix are exactly as diagnosed in #4075: those two call sites passed only `isRouter` (strictly `role === 2`) into `createNodeIcon`, so `ROUTER_LATE` (role 11) fell through to the generic pin; Map Analysis already passes `roleCategory`, which routes through `categoryGlyphFamily` (mtRouter/mtRouterLate/mtRepeater → `repeater`).

## Changes

- `NodesTab.tsx` and `Dashboard/DashboardMap.tsx`: compute `roleCategory` via `getNodeTypeCategory(node)` (same as Map Analysis) and pass it into `createNodeIcon`. No changes to `markerIcons.ts` or `nodeTypeCategory.ts`.
- `DashboardMap` `iconSig` gains `roleCategory` so the marker icon cache distinguishes a `ROUTER_LATE` from a same-hops/same-name client (NodesTab's sig already includes `role`, so it was covered).
- Regression tests in `markerIcons.test.ts` pinning: ROUTER_LATE and ROUTER render identically; ROUTER_LATE is not the generic client pin.

### Intended visual convergence (worth a reviewer's eye)
Because `roleCategory` takes precedence over the legacy hand-drawn `isRouter` glyph branch in the factory, plain `ROUTER` nodes on NodesTab/Dashboard also shift from the old hand-drawn tower to the **same canonical category glyph Map Analysis already used**. This is intended cross-map consistency (the whole point of #4047's shared factory), not a regression — but it means `ROUTER` markers on those two maps change glyph slightly, converging to what Map Analysis shows.

## Issues Resolved
Fixes #4075.

## Testing
- [x] Full Vitest suite: success:true — 9,691 tests / 0 failures (3 new #4075 cases)
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [ ] Not browser-validated: the dev-container dataset currently has no `ROUTER_LATE` (role 11) nodes to view. The fix is a deterministic icon-selection change fully covered at the factory decision point by unit tests (the asserted divIcon HTML is exactly what renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub