### PR TITLE
fix(map): widen Null Island radius + skip it in unified merge (Jupiter Dad !02ecd5e0)

### DIFF
--- a/src/hooks/useDashboardData.test.ts
+++ b/src/hooks/useDashboardData.test.ts
@@ -246,6 +246,40 @@ describe('mergeUnifiedSourceData', () => {
     expect((merged.nodes[0] as any).lastHeard).toBe(5000);
   });
 
+  it('ignores a Null-Island position from the freshest source and uses a real one (#02ecd5e0 Jupiter Dad)', () => {
+    // Two MQTT sources report the node most recently with the 2^15 garbage
+    // default (0.0032768, 0.0032768) — just outside the old 0.001 radius — while
+    // an older source has the true position. The merge must reject the garbage
+    // and land the node at its real location, carrying its precision along.
+    const merged = mergeUnifiedSourceData([
+      {
+        nodes: [{
+          nodeNum: 49075680,
+          lastHeard: 5000,
+          latitude: 0.0032768,
+          longitude: 0.0032768,
+          positionPrecisionBits: null,
+        }],
+        traceroutes: [], neighborInfo: [], channels: [],
+      },
+      {
+        nodes: [{
+          nodeNum: 49075680,
+          lastHeard: 3000,
+          latitude: 26.9221888,
+          longitude: -80.1374208,
+          positionPrecisionBits: 13,
+        }],
+        traceroutes: [], neighborInfo: [], channels: [],
+      },
+    ]);
+    const n = merged.nodes[0] as any;
+    expect(n.latitude).toBe(26.9221888);
+    expect(n.longitude).toBe(-80.1374208);
+    expect(n.positionPrecisionBits).toBe(13); // precision from the same real record, not the garbage one
+    expect(n.lastHeard).toBe(5000);
+  });
+
   it('only marks merged node as ignored when EVERY source has it ignored', () => {
     const oneIgnored = mergeUnifiedSourceData([
       {

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -8,6 +8,7 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { appBasename } from '../init';
 import { useAuth } from '../contexts/AuthContext';
+import { isNullIsland } from '../utils/nullIsland';
 import { classifyNodeTransport, type NodeTransportClass } from '../utils/nodeTransport';
 import { unifiedNodeKey } from '../utils/nodeIdentity';
 
@@ -263,19 +264,45 @@ function mergeNodeRecords(records: any[]): any {
   const merged: any = {};
   for (const r of sortedNewestFirst) {
     for (const [k, v] of Object.entries(r)) {
-      if (k === 'position' || k === 'isFavorite' || k === 'isIgnored' || k === 'lastHeard') continue;
+      // Position fields are selected together below so a stale/garbage reading
+      // from one source can't splice onto another's — and so a Null-Island
+      // reading never wins just for being newest.
+      if (
+        k === 'position' ||
+        k === 'latitude' ||
+        k === 'longitude' ||
+        k === 'positionPrecisionBits' ||
+        k === 'isFavorite' ||
+        k === 'isIgnored' ||
+        k === 'lastHeard'
+      ) {
+        continue;
+      }
       if ((merged[k] === undefined || merged[k] === null) && v !== undefined && v !== null) {
         merged[k] = v;
       }
     }
   }
 
-  // Position: take the newest record that has both lat and lng (don't mix
-  // halves from different sources).
-  const withPosition = sortedNewestFirst.find(
-    (r) => r?.position?.latitude != null && r?.position?.longitude != null,
-  );
-  if (withPosition) merged.position = withPosition.position;
+  // Position: take the newest record with a REAL fix — both lat and lng present
+  // on the same record and NOT at Null Island (#3763; e.g. Jupiter Dad !02ecd5e0
+  // reporting the 2^15 garbage default 0.0032768 from an MQTT source while other
+  // sources have the true position). Flat (API) and nested position shapes are
+  // both supported; lat/lng/nested-position/precision are carried from the SAME
+  // record so the marker and its accuracy cell stay consistent.
+  const withPosition = sortedNewestFirst.find((r) => {
+    const lat = r?.latitude ?? r?.position?.latitude;
+    const lng = r?.longitude ?? r?.position?.longitude;
+    return lat != null && lng != null && !isNullIsland(lat, lng);
+  });
+  if (withPosition) {
+    if (withPosition.latitude != null) merged.latitude = withPosition.latitude;
+    if (withPosition.longitude != null) merged.longitude = withPosition.longitude;
+    if (withPosition.position != null) merged.position = withPosition.position;
+    if (withPosition.positionPrecisionBits != null) {
+      merged.positionPrecisionBits = withPosition.positionPrecisionBits;
+    }
+  }
 
   merged.lastHeard = sortedNewestFirst.reduce(
     (acc: number | null, r) => {

--- a/src/utils/nullIsland.ts
+++ b/src/utils/nullIsland.ts
@@ -9,10 +9,16 @@
  *
  * A small radius (rather than exact equality) is used because firmware rounding
  * or floating-point serialization can yield values like 0.000001 instead of
- * exactly 0.0, which an equality check would miss. ~0.001° is roughly 111 m at
- * the equator — well inside any realistic GPS error, and far from any deployment.
+ * exactly 0.0, which an equality check would miss. It also catches integer
+ * "garbage default" fixes: a Meshtastic position of latitudeI = longitudeI =
+ * 2^15 (32768) serializes to 0.0032768°, and 2^16 to 0.0065536° — both are
+ * bogus default readings that sit just outside a tighter radius. ~0.01° is
+ * roughly 1.1 km at the equator: still absurdly tiny (Null Island is open ocean
+ * in the Gulf of Guinea, ~600 km from the nearest land), and it only rejects a
+ * coordinate near BOTH 0° lat AND 0° lng, so real prime-meridian/equator nodes
+ * (whose other coordinate is far from 0) are never affected.
  */
-export const NULL_ISLAND_EPSILON = 0.001;
+export const NULL_ISLAND_EPSILON = 0.01;
 
 /**
  * True when a coordinate is at or within {@link NULL_ISLAND_EPSILON} degrees of


### PR DESCRIPTION
## Summary

The Unified/main map was getting dragged out to the Atlantic by node `!02ecd5e0` ("Jupiter Dad"). It reported the **2¹⁵ integer garbage default** position (`latitudeI = longitudeI = 32768` → `0.0032768°`) from two MQTT sources as its *newest* records, while other sources carried its true Jupiter, FL position. Two gaps let the garbage win:

1. **`NULL_ISLAND_EPSILON` was 0.001°** (~111 m). The garbage value `0.0032768°` is ~364 m out, so `isNullIsland()` didn't catch it. Widened to **0.01°** (~1.1 km) — still absurdly tiny (Null Island is open ocean ~600 km from land), and it only rejects a coordinate near **both** 0° lat **and** 0° lng, so real prime-meridian/equator nodes (whose *other* coordinate is far from 0) are unaffected. Catches the 2¹⁵/2¹⁶ garbage-default family. Applies at server ingest and on every client map.
2. **The unified merge (`mergeNodeRecords`) had no Null-Island check** and merged flat `latitude`/`longitude` field-by-field, so a garbage newest reading won. It now selects `latitude`/`longitude`/`position`/`positionPrecisionBits` **together** from the newest record with a **real** (non-Null-Island) fix — so the node lands at its true location from a good source instead of at (0,0).

## Issues Resolved
Reported live: Unified map trashed by `!02ecd5e0`'s bad position.

## Testing
- [x] Full Vitest suite green; `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] New regression tests: `nullIsland.test` (0.0032768 now caught), `useDashboardData.test` (Jupiter-Dad scenario — garbage newest + real older → merged uses the real position and its precision)
- [x] Verified against live data: `!02ecd5e0` has 5 records — 2 MQTT at 0.0032768, 3 (Sandbox/BLE/Official) at the real 26.92,−80.14; the merge now picks the real one
- Existing Null Island tests unchanged and still green (values <0.001 stay rejected; Greenwich/equator cases stay accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub