### PR TITLE
fix(map): null-island filter for line endpoints (routes + neighbors no longer run to 0,0)

### DIFF
--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -22,6 +22,16 @@ describe('resolveMapEndpoint (#3642)', () => {
     expect(resolveMapEndpoint(markers, 1, null, null)).toBeNull();
     expect(resolveMapEndpoint(markers, 1, 40.5, undefined)).toBeNull();
   });
+
+  it('does not fall back to a Null-Island embedded position (#02ecd5e0)', () => {
+    // The node isn't on the map and its neighbor record embeds the 2^15 garbage
+    // default — the line must be omitted, not drawn out to (0, 0).
+    const markers = new Map<number, [number, number]>();
+    expect(resolveMapEndpoint(markers, 0x02ecd5e0, 0.0032768, 0.0032768)).toBeNull();
+    // But the rendered marker still wins even if the record embeds garbage.
+    const onMap = new Map<number, [number, number]>([[0x02ecd5e0, [26.9221888, -80.1374208]]]);
+    expect(resolveMapEndpoint(onMap, 0x02ecd5e0, 0.0032768, 0.0032768)).toEqual([26.9221888, -80.1374208]);
+  });
 });
 
 describe('Node Helpers', () => {

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -1,5 +1,6 @@
 import { DeviceInfo } from '../types/device';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
+import { isNullIsland } from './nullIsland.js';
 
 /**
  * Infrastructure node roles (Router, Router Client, Repeater, Router Late)
@@ -127,7 +128,13 @@ export const resolveMapEndpoint = (
 ): [number, number] | null => {
   const marker = markerPositions.get(nodeNum);
   if (marker) return marker;
-  if (embeddedLat != null && embeddedLng != null) return [embeddedLat, embeddedLng];
+  // Fall back to the record's embedded coords, but never to a Null-Island
+  // garbage default (e.g. the 2^15 value 0.0032768) — that would draw a
+  // neighbor/route line out to (0, 0) for a node not currently on the map
+  // (#02ecd5e0 "Jupiter Dad"). Skip it so the caller omits the line instead.
+  if (embeddedLat != null && embeddedLng != null && !isNullIsland(embeddedLat, embeddedLng)) {
+    return [embeddedLat, embeddedLng];
+  }
   return null;
 };
 

--- a/src/utils/tracerouteSegments.test.ts
+++ b/src/utils/tracerouteSegments.test.ts
@@ -66,13 +66,25 @@ describe('parseSnapshotRoutePositions (#1862)', () => {
     expect(result.get(300)).toEqual([1, 2]);
   });
 
-  it('handles lat/lng of exactly 0 correctly (typeof-number check, not truthy)', () => {
+  it('keeps a single-axis-zero position (typeof-number check, not truthy)', () => {
     // Regression guard for the 3-way diff finding: two of the three
     // pre-existing implementations used a truthy `snapshot?.lat && snapshot?.lng`
     // check that silently dropped nodes sitting exactly on lat=0 or lng=0.
-    const snap = JSON.stringify({ 100: { lat: 0, lng: 0 } });
+    // A single axis at 0 (with the other far from 0) is a real position.
+    const snap = JSON.stringify({ 100: { lat: 0, lng: 20.5 }, 200: { lat: 51.5, lng: 0 } });
     const result = parseSnapshotRoutePositions(snap);
-    expect(result.get(100)).toEqual([0, 0]);
+    expect(result.get(100)).toEqual([0, 20.5]);
+    expect(result.get(200)).toEqual([51.5, 0]);
+  });
+
+  it('drops a Null-Island snapshot so it does not anchor a route at (0,0) (#02ecd5e0)', () => {
+    // A snapshot captured while the node held a garbage GPS default — the exact
+    // (0,0) pair or the 2^15 value 0.0032768 — must be skipped so the segment
+    // falls through to the live position instead of shooting out to Null Island.
+    const snap = JSON.stringify({ 100: { lat: 0, lng: 0 }, 200: { lat: 0.0032768, lng: 0.0032768 } });
+    const result = parseSnapshotRoutePositions(snap);
+    expect(result.has(100)).toBe(false);
+    expect(result.has(200)).toBe(false);
   });
 });
 
@@ -409,6 +421,12 @@ describe('buildLiveNodePositionMap (review F9)', () => {
 
   it('drops the (0,0) Null Island placeholder', () => {
     const items = [{ id: 1, lat: 0, lng: 0 }];
+    const map = buildLiveNodePositionMap(items, (i) => ({ nodeNum: i.id, lat: i.lat, lng: i.lng }));
+    expect(map.has(1)).toBe(false);
+  });
+
+  it('drops a near-(0,0) garbage default (2^15 value 0.0032768) (#02ecd5e0)', () => {
+    const items = [{ id: 1, lat: 0.0032768, lng: 0.0032768 }];
     const map = buildLiveNodePositionMap(items, (i) => ({ nodeNum: i.id, lat: i.lat, lng: i.lng }));
     expect(map.has(1)).toBe(false);
   });

--- a/src/utils/tracerouteSegments.ts
+++ b/src/utils/tracerouteSegments.ts
@@ -21,6 +21,10 @@
  * sentinel — don't add a leaflet/react-leaflet import here.
  */
 
+// `nullIsland` is pure (no leaflet) — safe to import without breaking the
+// leaflet-free guarantee above.
+import { isNullIsland } from './nullIsland.js';
+
 // ---------------------------------------------------------------------------
 // #2931 — unknown-hop SNR sentinel (canonical home, re-exported by mapHelpers)
 // ---------------------------------------------------------------------------
@@ -105,6 +109,11 @@ export function parseSnapshotRoutePositions(
     if (!Number.isFinite(nodeNum)) continue;
     const entry = value as { lat?: unknown; lng?: unknown } | null;
     if (entry && typeof entry.lat === 'number' && typeof entry.lng === 'number') {
+      // A snapshot captured while the node was at Null Island (a garbage GPS
+      // default, e.g. the 2^15 value 0.0032768) must NOT anchor a route
+      // segment there — skip it so resolveSegmentPosition falls through to the
+      // live position (#02ecd5e0 "Jupiter Dad" routes shooting to 0,0).
+      if (isNullIsland(entry.lat, entry.lng)) continue;
       result.set(nodeNum, [entry.lat, entry.lng]);
     }
   }
@@ -131,12 +140,13 @@ export function resolveSegmentPosition(
  * `extract` returns the node number and raw (possibly missing) coordinates
  * for one item, or `null` to skip it entirely.
  *
- * Validity rule: coordinates must both be numbers AND must not be exactly
- * `(0, 0)` — a single axis at exactly 0 (equator or prime meridian) is a
- * legitimate position and is kept; the `(0, 0)` pair specifically is treated
- * as an uninitialized/Null-Island placeholder and dropped. This deliberately
- * differs from (and fixes) a truthy `lat && lng` check, which would also
- * drop the legitimate single-axis-zero case.
+ * Validity rule: coordinates must both be numbers AND must not be at Null
+ * Island — a coordinate within {@link isNullIsland}'s radius of `(0, 0)` is an
+ * uninitialized/garbage GPS default and is dropped, while a single axis at
+ * exactly 0 (equator or prime meridian, with the other axis far from 0) is a
+ * legitimate position and is kept. This uses the shared Null-Island radius
+ * (not an exact `(0,0)` check) so garbage defaults like the 2^15 value
+ * 0.0032768 don't anchor neighbor/route line endpoints at (0, 0).
  */
 export function buildLiveNodePositionMap<T>(
   items: Iterable<T>,
@@ -148,7 +158,7 @@ export function buildLiveNodePositionMap<T>(
     if (!entry) continue;
     const { nodeNum, lat, lng } = entry;
     if (typeof lat !== 'number' || typeof lng !== 'number') continue;
-    if (lat === 0 && lng === 0) continue;
+    if (isNullIsland(lat, lng)) continue;
     map.set(nodeNum, [lat, lng]);
   }
   return map;


### PR DESCRIPTION
## Summary

Follow-up to the Null Island node fix (#4077). That stopped Jupiter Dad `!02ecd5e0`'s **marker** landing at (0,0), but his route and neighbor **lines** still ran out to Null Island — because the line-endpoint resolvers checked only exact `(0,0)`, not the `2¹⁵` garbage default `0.0032768`. Fixed all three to use the shared `isNullIsland` radius:

- **`buildLiveNodePositionMap`** — skip null-island (was `lat===0 && lng===0`), so a garbage-position node never anchors a neighbor/route endpoint.
- **`parseSnapshotRoutePositions`** — skip null-island snapshot entries, so a traceroute captured while the node held the garbage position falls through to its live (now-corrected) position instead of anchoring the segment at (0,0).
- **`resolveMapEndpoint`** — reject a null-island embedded-coords fallback, so an off-map node omits the neighbor line rather than drawing it to (0,0).

MapAnalysis and MeshCore already call `isNullIsland` directly, so they were covered by the wider radius from #4077.

## Issues Resolved
Reported live: routes/neighbor lines still running to (0,0) after the node fix.

## Testing
- [x] `npm run typecheck` clean; targeted suites green (112 tests)
- [x] New regression tests for each resolver, including the exact `0.0032768` value; updated one existing test that asserted the old exact-`(0,0)`-kept snapshot behavior (its typeof-not-truthy intent preserved with a single-axis-zero case)
- [x] Browser-verified on the dev container: unified map traceroutes + neighbor lines no longer run to (0,0) for `!02ecd5e0`

Note: `tracerouteSegments.ts`'s new `nullIsland` import uses the `.js` extension — that module is imported server-side (`embedPublicRoutes`), and Node ESM requires it (vitest/typecheck don't, which is why the extension matters for the Docker build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub