### PR TITLE
feat(meshcore): collapsible node list — reach the map on mobile without selecting a node

### DIFF
--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -77,9 +77,19 @@ interface MeshCoreMapProps {
    * callers/tests are unaffected.
    */
   isLoading?: boolean;
+  /**
+   * Forwarded to `BaseMap`'s `resizeTrigger` (issue: mobile node-list
+   * collapse toggle). When this value changes, the underlying Leaflet map
+   * calls `invalidateSize()` so the canvas fills its new container size
+   * after the list pane collapses/expands or the mobile list↔map pane swap
+   * fires — otherwise the map can render at its stale size (grey/blank
+   * edges) until the next manual resize. Omit ⇒ no resize handler mounted
+   * (matches BaseMap's own opt-in default).
+   */
+  resizeTrigger?: unknown;
 }
 
-export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm, isLoading = false }) => {
+export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm, isLoading = false, resizeTrigger }) => {
   const { t } = useTranslation();
   const { mapTileset, customTilesets, setMapTileset } = useSettings();
   const { timeFormat, dateFormat } = useDisplaySettings();
@@ -472,6 +482,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         customTilesets={customTilesets}
         showTilesetSelector={showTileSelector}
         onTilesetChange={setMapTileset}
+        resizeTrigger={resizeTrigger}
       >
         {measureActive && (
           <MeasureDistanceController

--- a/src/components/MeshCore/MeshCoreNodesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.test.tsx
@@ -186,92 +186,55 @@ describe('MeshCoreNodesView — Discover menu (#3351)', () => {
   });
 });
 
-describe('MeshCoreNodesView — node-details quick access (#3350)', () => {
-  it('renders a details button per row that navigates to the node detail screen', () => {
-    const onNavigateToDm = vi.fn();
-    render(
-      <MeshCoreNodesView nodes={nodes} contacts={contacts} onNavigateToDm={onNavigateToDm} />,
-    );
-    const detailButtons = screen.getAllByLabelText('More details');
-    expect(detailButtons).toHaveLength(3);
-    fireEvent.click(detailButtons[0]);
-    // Default sort is lastHeard desc, so the first row is alpha (PK_B).
-    expect(onNavigateToDm).toHaveBeenCalledWith(PK_B);
-  });
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+}
 
-  it('double-clicking a row navigates to the node detail screen', () => {
-    const onNavigateToDm = vi.fn();
-    render(
-      <MeshCoreNodesView nodes={nodes} contacts={contacts} onNavigateToDm={onNavigateToDm} />,
-    );
-    const main = document.querySelectorAll('.mc-node-row-main')[1] as HTMLElement;
-    fireEvent.doubleClick(main);
-    expect(onNavigateToDm).toHaveBeenCalledWith(PK_C); // Bravo, second by lastHeard desc
-  });
-
-  it('single click still selects the row (does not navigate)', () => {
-    const onNavigateToDm = vi.fn();
-    render(
-      <MeshCoreNodesView nodes={nodes} contacts={contacts} onNavigateToDm={onNavigateToDm} />,
-    );
-    const main = document.querySelectorAll('.mc-node-row-main')[0] as HTMLElement;
-    fireEvent.click(main);
-    expect(onNavigateToDm).not.toHaveBeenCalled();
-    expect(document.querySelector('.mc-node-row.selected')).not.toBeNull();
-  });
-
-  it('omits the details button when no navigation handler is provided', () => {
-    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
-    expect(screen.queryByLabelText('More details')).toBeNull();
-  });
-});
-
-describe('MeshCoreNodesView — Discover menu (#3351)', () => {
+describe('MeshCoreNodesView — list collapse toggle (mobile map access)', () => {
   beforeEach(() => {
-    showToast.mockReset();
+    localStorage.clear();
+    setViewportWidth(1024); // desktop by default
   });
 
-  it('hides the Discover button when canDiscover is false', () => {
-    render(
-      <MeshCoreNodesView
-        nodes={nodes}
-        contacts={contacts}
-        onDiscoverNodes={vi.fn()}
-        canDiscover={false}
-      />,
-    );
-    expect(screen.queryByText('Discover')).toBeNull();
+  it('collapses the list pane on desktop and hides header/list controls', () => {
+    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
+    expect(document.querySelector('.meshcore-list-pane.collapsed')).toBeNull();
+    fireEvent.click(screen.getByTitle('Collapse node list'));
+    expect(document.querySelector('.meshcore-list-pane.collapsed')).not.toBeNull();
+    // Header content (title/search/list rows) is gone; only the toggle remains.
+    expect(screen.queryByText('Nodes')).toBeNull();
+    expect(screen.queryByPlaceholderText('Search nodes…')).toBeNull();
+    expect(screen.getByTitle('Expand node list')).toBeTruthy();
   });
 
-  it('opens the menu and fires the chosen discovery mode, then toasts the result', async () => {
-    const onDiscoverNodes = vi.fn().mockResolvedValue({ returned: 2, newCount: 1 });
-    render(
-      <MeshCoreNodesView
-        nodes={nodes}
-        contacts={contacts}
-        onDiscoverNodes={onDiscoverNodes}
-        canDiscover
-      />,
-    );
-    fireEvent.click(screen.getByText('Discover'));
-    fireEvent.click(screen.getByText('Discover Sensors'));
-    expect(onDiscoverNodes).toHaveBeenCalledWith('sensors');
-    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.any(String), 'success'));
+  it('expanding again restores the header/list controls', () => {
+    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
+    fireEvent.click(screen.getByTitle('Collapse node list'));
+    fireEvent.click(screen.getByTitle('Expand node list'));
+    expect(document.querySelector('.meshcore-list-pane.collapsed')).toBeNull();
+    expect(screen.getByText('Nodes')).toBeTruthy();
   });
 
-  it('toasts an error when discovery fails', async () => {
-    const onDiscoverNodes = vi.fn().mockResolvedValue(null);
-    render(
-      <MeshCoreNodesView
-        nodes={nodes}
-        contacts={contacts}
-        onDiscoverNodes={onDiscoverNodes}
-        canDiscover
-      />,
-    );
-    fireEvent.click(screen.getByText('Discover'));
-    fireEvent.click(screen.getByText('Discover Repeaters'));
-    expect(onDiscoverNodes).toHaveBeenCalledWith('repeaters');
-    await waitFor(() => expect(showToast).toHaveBeenCalledWith('Discovery failed', 'error'));
+  it('persists the desktop collapse preference to localStorage', () => {
+    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
+    fireEvent.click(screen.getByTitle('Collapse node list'));
+    expect(localStorage.getItem('meshcore-list-collapsed')).toBe('true');
+  });
+
+  it('restores the collapsed state from localStorage on mount', () => {
+    localStorage.setItem('meshcore-list-collapsed', 'true');
+    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
+    expect(document.querySelector('.meshcore-list-pane.collapsed')).not.toBeNull();
+  });
+
+  it('on mobile, the toggle reveals the map instead of collapsing to a thin bar', () => {
+    setViewportWidth(500);
+    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
+    expect(document.querySelector('.meshcore-two-pane.mobile-show-list')).not.toBeNull();
+    fireEvent.click(screen.getByTitle('Collapse node list'));
+    // Reveals the map pane via the existing mobile pane-swap mechanism...
+    expect(document.querySelector('.meshcore-two-pane.mobile-show-content')).not.toBeNull();
+    // ...rather than the desktop thin-bar collapsed state.
+    expect(document.querySelector('.meshcore-list-pane.collapsed')).toBeNull();
   });
 });

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -14,6 +14,12 @@ const MOBILE_BREAKPOINT = 768;
 const isMobileViewport = (): boolean =>
   typeof window !== 'undefined' && window.innerWidth <= MOBILE_BREAKPOINT;
 
+/** localStorage key for the desktop list-pane collapse preference (mirrors
+ *  the Meshtastic `collapse-nodes-btn` toggle, but MeshCore's is per-browser
+ *  persisted rather than session-only — see MeshCoreNodesView collapse
+ *  toggle below). */
+const LIST_COLLAPSED_STORAGE_KEY = 'meshcore-list-collapsed';
+
 interface MeshCoreNodesViewProps {
   nodes: MeshCoreNode[];
   contacts: MeshCoreContact[];
@@ -148,6 +154,19 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   const [sortField, setSortField] = useState<SortField>('lastHeard');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [mobileShowContent, setMobileShowContent] = useState(false);
+  // Desktop list-pane collapse toggle (mirrors NodesTab's `collapse-nodes-btn`
+  // / MeshCoreDirectMessagesView's `meshcore-collapse-btn`). Persisted so the
+  // preference survives reloads on desktop; always false on mobile — the
+  // mobile layout doesn't have a "thin bar" collapsed state, it swaps the
+  // whole pane via `mobileShowContent` instead (see handleToggleListCollapse).
+  const [isListCollapsed, setIsListCollapsed] = useState<boolean>(() => {
+    if (isMobileViewport()) return false;
+    try {
+      return localStorage.getItem(LIST_COLLAPSED_STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
   const [searchQuery, setSearchQuery] = useState('');
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [importHex, setImportHex] = useState('');
@@ -182,15 +201,45 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
 
   useEffect(() => {
     const onResize = () => {
-      if (!isMobileViewport()) setMobileShowContent(false);
+      if (!isMobileViewport()) {
+        setMobileShowContent(false);
+      } else {
+        // Mobile has no "thin bar" collapsed state — force the list content
+        // back on so a desktop-collapsed preference doesn't leave the pane
+        // blank after resizing/rotating into the mobile breakpoint.
+        setIsListCollapsed(false);
+      }
     };
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
+  // Persist the desktop collapse preference. Skipped while at the mobile
+  // breakpoint so the forced reset above (mobile always uncollapsed) never
+  // clobbers the saved desktop preference.
+  useEffect(() => {
+    if (isMobileViewport()) return;
+    try {
+      localStorage.setItem(LIST_COLLAPSED_STORAGE_KEY, String(isListCollapsed));
+    } catch {
+      // best-effort — ignore storage errors (e.g. private browsing quota)
+    }
+  }, [isListCollapsed]);
+
   const handleSelectNode = useCallback((key: string) => {
     setSelected(key);
     if (isMobileViewport()) setMobileShowContent(true);
+  }, []);
+
+  const handleToggleListCollapse = useCallback(() => {
+    if (isMobileViewport()) {
+      // No thin-bar concept on mobile — reveal the full map (all contacts,
+      // no node selected) instead, matching the desktop "shrink the sidebar"
+      // intent as closely as the mobile single-pane layout allows.
+      setMobileShowContent(true);
+      return;
+    }
+    setIsListCollapsed((c) => !c);
   }, []);
 
   // Same toast contract as the Settings-view discovery buttons — results
@@ -234,8 +283,24 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
 
   return (
     <div className={`meshcore-two-pane ${mobileClass}`}>
-      <div className="meshcore-list-pane">
+      <div className={`meshcore-list-pane ${isListCollapsed ? 'collapsed' : ''}`}>
         <div className="meshcore-list-pane-header">
+          <button
+            type="button"
+            className="meshcore-collapse-btn"
+            onClick={handleToggleListCollapse}
+            title={isListCollapsed
+              ? t('nodes.expand_node_list', 'Expand node list')
+              : t('nodes.collapse_node_list', 'Collapse node list')}
+            aria-label={isListCollapsed
+              ? t('nodes.expand_node_list', 'Expand node list')
+              : t('nodes.collapse_node_list', 'Collapse node list')}
+            aria-expanded={!isListCollapsed}
+          >
+            {isListCollapsed ? '▶' : '◀'}
+          </button>
+          {!isListCollapsed && (
+          <>
           <span>{t('meshcore.nav.nodes', 'Nodes')}</span>
           <span className="pane-count">{rows.length}</span>
           {onImportContact && (
@@ -309,7 +374,11 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
               {sortDirection === 'asc' ? '↑' : '↓'}
             </button>
           </div>
+          </>
+          )}
         </div>
+        {!isListCollapsed && (
+        <>
         <div className="meshcore-search-bar">
           <input
             type="text"
@@ -408,6 +477,8 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
             );
           })}
         </div>
+        </>
+        )}
       </div>
       <div className="meshcore-main-pane">
         {mobileShowContent && (
@@ -424,7 +495,13 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
             )}
           </div>
         )}
-        <MeshCoreMap contacts={contacts} selectedPublicKey={selected} onNavigateToDm={onNavigateToDm} isLoading={mapIsLoading} />
+        <MeshCoreMap
+          contacts={contacts}
+          selectedPublicKey={selected}
+          onNavigateToDm={onNavigateToDm}
+          isLoading={mapIsLoading}
+          resizeTrigger={`${isListCollapsed}-${mobileShowContent}`}
+        />
       </div>
       {importDialogOpen && (
         <div


### PR DESCRIPTION
## Summary

On the MeshCore source view, the node list filled the whole screen on mobile and the only way to reach the map was to tap a specific node. This adds a **collapse/expand toggle** to the node-list header, mirroring the Meshtastic (NodesTab) view.

- **Desktop:** the `◀` button collapses the list pane to a thin bar so the map fills the reclaimed width; `▶` restores it. State persists to `localStorage['meshcore-list-collapsed']`.
- **Mobile (≤768px):** the same button switches straight to the **full map** (all nodes, none selected) via the existing `mobileShowContent` mechanism — no need to tap a node first. The existing "◀ Back" header returns to the list. A resize listener resets the collapsed state when crossing into mobile so a stale desktop preference never leaves the mobile list blank.
- `MeshCoreMap` gains a `resizeTrigger` prop (forwarded to `BaseMap` → `MapResizeHandler`) so the map `invalidateSize()`s after the pane transition instead of rendering blank/grey.

Reused the pre-existing `.meshcore-collapse-btn` / `.meshcore-list-pane.collapsed` CSS and `nodes.collapse_node_list` / `nodes.expand_node_list` i18n keys (originally added for an incomplete toggle elsewhere) — no new CSS.

## Testing
- [x] `npm run typecheck` clean; `npm run lint:ci` exit 0
- [x] `src/components/MeshCore/` suite green — 165 tests (5 new for the toggle; also de-duplicated two accidentally-duplicated describe blocks in the test file)
- [x] Browser-validated on the dev container, both layouts:
  - Desktop: collapse shrinks list 320px→42px, map widens 1024px→1302px, tiles stay loaded (no grey-out), expand restores 320px, state persists across reload.
  - Mobile (390px): list fills screen → tap `◀` → full-width map with 117 markers and tiles loaded (no grey) → "◀ Back" returns to the list. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub