### PR TITLE
fix(map): map snaps back to node on click and freezes interaction

### DIFF
--- a/src/components/MapCenterController.test.tsx
+++ b/src/components/MapCenterController.test.tsx
@@ -95,4 +95,38 @@ describe('MapCenterController (#4046 items 2 + 3)', () => {
     render(<MapCenterController centerTarget={null} onCenterComplete={vi.fn()} />);
     expect(setViewMock).not.toHaveBeenCalled();
   });
+
+  it('does NOT re-fire setView when re-rendered with an unstable callback but the SAME target (snap-back guard)', () => {
+    // Reproduces the map-snaps-back bug: a consumer passing a fresh
+    // onCenterComplete each render would otherwise re-run setView on every
+    // re-render while centerTarget is still set.
+    const { rerender } = render(
+      <MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />,
+    );
+    expect(setViewMock).toHaveBeenCalledTimes(1);
+
+    // Re-render several times with a NEW callback identity each time, same target.
+    rerender(<MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />);
+    rerender(<MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />);
+    expect(setViewMock).toHaveBeenCalledTimes(1); // still once — no snap-back
+  });
+
+  it('re-centers when the target changes to a genuinely new node', () => {
+    const { rerender } = render(
+      <MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />,
+    );
+    expect(setViewMock).toHaveBeenCalledTimes(1);
+    rerender(<MapCenterController centerTarget={[3, 4]} onCenterComplete={() => {}} />);
+    expect(setViewMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows re-centering the SAME target after it is cleared to null', () => {
+    const { rerender } = render(
+      <MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />,
+    );
+    expect(setViewMock).toHaveBeenCalledTimes(1);
+    rerender(<MapCenterController centerTarget={null} onCenterComplete={() => {}} />);
+    rerender(<MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />);
+    expect(setViewMock).toHaveBeenCalledTimes(2); // cleared then re-selected → centers again
+  });
 });

--- a/src/components/MapCenterController.tsx
+++ b/src/components/MapCenterController.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useMap } from 'react-leaflet';
 import {
   DEFAULT_TARGET_ZOOM,
@@ -32,8 +32,27 @@ export const MapCenterController: React.FC<MapCenterControllerProps> = ({
 }) => {
   const map = useMap();
 
+  // Defensive: center exactly once per distinct target. Without this, any
+  // consumer that passes an unstable `onCenterComplete` (a dependency below)
+  // would re-run this effect on every render and re-fire setView while
+  // `centerTarget` is still set — snapping the map back so the user can't pan
+  // (regression made severe by the #4046 variable animation duration widening
+  // the reset window). Tracking the last-centered target makes this robust
+  // regardless of callback stability.
+  const lastCenteredRef = useRef<[number, number] | null>(null);
+
   useEffect(() => {
     if (centerTarget) {
+      // Skip if we've already centered on this exact target — only a genuinely
+      // new target should move the map.
+      if (
+        lastCenteredRef.current &&
+        lastCenteredRef.current[0] === centerTarget[0] &&
+        lastCenteredRef.current[1] === centerTarget[1]
+      ) {
+        return;
+      }
+      lastCenteredRef.current = centerTarget;
       // Get the map container height to calculate the center offset
       const mapContainer = map.getContainer();
       const mapHeight = mapContainer.clientHeight;
@@ -74,6 +93,10 @@ export const MapCenterController: React.FC<MapCenterControllerProps> = ({
       }, duration * 1000 + 50);
 
       return () => clearTimeout(timer);
+    } else {
+      // Target cleared — allow the next selection (even of the same node) to
+      // center again.
+      lastCenteredRef.current = null;
     }
   }, [centerTarget, onCenterComplete, map, targetZoom]);
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1185,10 +1185,15 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // Use the map tileset from settings
   const activeTileset = mapTileset;
 
-  // Handle center complete
-  const handleCenterComplete = () => {
+  // Handle center complete. MUST be stable: it's a dependency of
+  // MapCenterController's effect, and a new reference every render would
+  // re-run that effect and re-fire map.setView() while mapCenterTarget is
+  // still set — snapping the map back to the node on every re-render (poll,
+  // websocket, etc.) so the user can't pan away. `setMapCenterTarget` is a
+  // stable useState setter.
+  const handleCenterComplete = useCallback(() => {
     setMapCenterTarget(null);
-  };
+  }, [setMapCenterTarget]);
 
   // Handle node click from packet monitor
   const handlePacketNodeClick = (nodeId: string) => {


### PR DESCRIPTION
## Summary

Clicking a node made the map snap back to it repeatedly (couldn't pan away) and then froze all interaction. Reported live after today's deploys.

**Root cause:** NodesTab's `handleCenterComplete` was a fresh function every render (not `useCallback`'d, unlike its siblings). It's a dependency of `MapCenterController`'s effect, so every re-render (node poll, websocket) re-ran the effect and re-fired `map.setView()` while `mapCenterTarget` was still set — snapping the map back to the selected node. **#4046 made it catastrophic:** its variable animation duration (up to 2s vs the old fixed 0.5s) widened the "target still set" window ~4×, and each re-fired zoom animation drove repeated re-spiderfy churn that ended in a Leaflet drag crash (`Cannot read 'baseVal' of undefined` in `Draggable.finishDrag`) — the "everything freezes."

## Fix
1. `useCallback` the handler so `MapCenterController`'s effect dependency is stable.
2. Defensively guard `MapCenterController` to center only once per **distinct** target (tracks last-centered in a ref), so no consumer's unstable callback can ever cause a re-center. Cleared-to-null resets the guard so re-selecting the same node still works.

## Testing
- [x] `npm run typecheck` clean; full Vitest suite green (9,032 passed / 0 failed); `npm run lint:ci` exit 0
- [x] New MapCenterController tests: re-render with unstable callback + same target → `setView` called once (snap-back guard); new target → re-centers; cleared-to-null → re-selectable
- [x] Browser-validated on the dev container: clicking a node fires `setView` exactly once (was re-firing), panning the map afterward HOLDS (no snap-back), no console errors — confirmed across fresh loads incl. a clustered marker that spiderfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub