### PR TITLE
fix(map): click pans to node marker, not raw center, for obscured nodes

### DIFF
--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -10,6 +10,15 @@
 
 import { describe, it, expect } from 'vitest';
 import { computeNeighborLinkStyle } from './NodesTab';
+import {
+  getEffectivePosition,
+  resolveMarkerCenterTarget,
+} from '../utils/nodeHelpers';
+import {
+  shouldOffsetForPrecision,
+  offsetWithinPrecisionCell,
+} from '../utils/precisionOffset';
+import type { DeviceInfo } from '../types/device';
 
 describe('NodesTab', () => {
   // #4047 Phase 7 WP11 — pins NodesTab's neighbor-link adapter: the 4-tier
@@ -52,6 +61,56 @@ describe('NodesTab', () => {
     });
   });
 
+
+  // Regression for the "clicking a node pans to a random location, not the
+  // node" bug: markers for low-precision/obscured nodes are rendered at an
+  // in-cell OFFSET position (#4016), but the click handler used to pan to the
+  // raw reported cell-center — up to half an accuracy cell (km-scale) away.
+  // resolveMarkerCenterTarget must hand back the same offset position the
+  // marker uses so the map pans exactly to the marker the user clicked.
+  describe('resolveMarkerCenterTarget (click pans to the marker, not the raw center)', () => {
+    const NODE_NUM = 0x1234abcd;
+    const RAW_LAT = 40.0;
+    const RAW_LNG = -74.0;
+    const OBSCURED_BITS = 13; // town-level: a multi-km accuracy cell
+
+    // Build the offset marker position exactly as NodesTab's nodePositions memo does.
+    const buildMarkerPos = (): [number, number] => {
+      const node = {
+        nodeNum: NODE_NUM,
+        user: { id: '!1234abcd' },
+        position: { latitude: RAW_LAT, longitude: RAW_LNG },
+        positionPrecisionBits: OBSCURED_BITS,
+      } as unknown as DeviceInfo;
+      const eff = getEffectivePosition(node);
+      expect(shouldOffsetForPrecision(OBSCURED_BITS, node.positionIsOverride)).toBe(true);
+      return offsetWithinPrecisionCell(
+        eff.latitude as number,
+        eff.longitude as number,
+        OBSCURED_BITS,
+        String(node.user?.id ?? node.nodeNum),
+      );
+    };
+
+    it('returns the offset marker position, which differs materially from the raw center', () => {
+      const markerPos = buildMarkerPos();
+      const nodePositions = new Map<number, [number, number]>([[NODE_NUM, markerPos]]);
+
+      const target = resolveMarkerCenterTarget(NODE_NUM, nodePositions);
+      expect(target).toEqual(markerPos);
+
+      // The whole point of the fix: this is NOT the raw reported center.
+      expect(target).not.toEqual([RAW_LAT, RAW_LNG]);
+      const dLat = Math.abs((target as [number, number])[0] - RAW_LAT);
+      const dLng = Math.abs((target as [number, number])[1] - RAW_LNG);
+      expect(dLat + dLng).toBeGreaterThan(0.001); // ~>100m of divergence at 13 bits
+    });
+
+    it('returns null when the node has no rendered marker (caller falls back to raw center)', () => {
+      const nodePositions = new Map<number, [number, number]>();
+      expect(resolveMarkerCenterTarget(NODE_NUM, nodePositions)).toBeNull();
+    });
+  });
 
   describe('Helper Functions', () => {
     describe('isToday', () => {

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -12,7 +12,7 @@ import { effectiveMapMaxAgeHours } from '../utils/mapAge';
 import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, snrToColor } from '../utils/mapHelpers.tsx';
 import { convertSpeed } from '../utils/speedConversion';
-import { getEffectivePosition, getRoleName, hasValidEffectivePosition, isNodeComplete, parseNodeId, resolveMapEndpoint, TRACEROUTE_DISPLAY_HOURS } from '../utils/nodeHelpers';
+import { getEffectivePosition, getRoleName, hasValidEffectivePosition, isNodeComplete, parseNodeId, resolveMapEndpoint, resolveMarkerCenterTarget, TRACEROUTE_DISPLAY_HOURS } from '../utils/nodeHelpers';
 import { shouldOffsetForPrecision, offsetWithinPrecisionCell, hasAccuracyCell, precisionCellBounds } from '../utils/precisionOffset';
 import MapLegend from './MapLegend';
 import { formatTime, formatDateTime } from '../utils/datetime';
@@ -926,6 +926,25 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   const centerMapOnNodeRef = useRef(centerMapOnNode);
   const showRouteRef = useRef(showRoute);
   const traceroutesRef = useRef(traceroutes);
+  // Kept fresh in the "Update refs" effect below. Lets the stable click
+  // handlers read the current offset-inclusive marker position map.
+  const nodePositionsRef = useRef<Map<number, [number, number]>>(new Map());
+
+  // Center the map on the position the node's MARKER is actually rendered at.
+  // For low-precision/obscured nodes `nodePositions` includes the deterministic
+  // in-cell offset (#4016); `centerMapOnNode`/getEffectivePosition uses the raw
+  // reported cell-center, so panning there jumped up to half an accuracy cell
+  // (km-scale for obscured nodes) away from the marker the user clicked. Prefer
+  // the rendered marker position; fall back to the raw center only for a node
+  // that isn't currently on the map (no entry in nodePositions).
+  const centerOnNodeMarker = useCallback((node: DeviceInfo) => {
+    const markerPos = resolveMarkerCenterTarget(node.nodeNum, nodePositionsRef.current);
+    if (markerPos) {
+      setMapCenterTarget(markerPos);
+    } else {
+      centerMapOnNodeRef.current(node);
+    }
+  }, [setMapCenterTarget]);
 
   // Rich OMS click handler (#4047 Phase 4 WP6) — moved onto the shared
   // NodeMarkersLayer's `onOmsClick(marker, key)`. Replaces the old
@@ -949,7 +968,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     // But if the node has no valid traceroute, fall back to centering on it.
     if (!showRouteRef.current) {
       const node = findNode();
-      if (node) centerMapOnNodeRef.current(node);
+      if (node) centerOnNodeMarker(node);
     } else {
       const hasTraceroute = traceroutesRef.current.some(tr => {
         const matches = tr.toNodeId === nodeId || tr.fromNodeId === nodeId;
@@ -960,7 +979,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       // If no valid traceroute, still center on the node
       if (!hasTraceroute) {
         const node = findNode();
-        if (node) centerMapOnNodeRef.current(node);
+        if (node) centerOnNodeMarker(node);
       }
     }
 
@@ -978,7 +997,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       popup.options.autoPan = false;
     }
     currentMarker.openPopup();
-  }, []); // Empty deps - reads latest values via refs
+    // Reads latest state via refs; centerOnNodeMarker is the one referenced
+    // dependency and is itself referentially stable, so onOmsClick stays stable
+    // and the shared layer's OMS listener effect isn't re-registered.
+  }, [centerOnNodeMarker]);
 
   // Stable callback factories for node item interactions
   const handleNodeClick = useCallback((node: DeviceInfo) => {
@@ -994,7 +1016,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       // to fit the entire traceroute path instead of just centering on the node.
       // But if the node has no valid traceroute, fall back to centering on it.
       if (!showRoute) {
-        centerMapOnNode(node);
+        centerOnNodeMarker(node);
       } else {
         const hasTraceroute = traceroutes.some(tr => {
           const matches = tr.toNodeId === nodeId || tr.fromNodeId === nodeId;
@@ -1003,7 +1025,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                  tr.routeBack && tr.routeBack !== 'null' && tr.routeBack !== '';
         });
         if (!hasTraceroute) {
-          centerMapOnNode(node);
+          centerOnNodeMarker(node);
         }
       }
       // Auto-collapse node list on mobile when a node with position is clicked
@@ -1016,7 +1038,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         }
       }
     };
-  }, [selectedNodeId, setSelectedNodeId, centerMapOnNode, setIsNodeListCollapsed, showRoute, traceroutes]);
+  }, [selectedNodeId, setSelectedNodeId, centerOnNodeMarker, setIsNodeListCollapsed, showRoute, traceroutes]);
 
   const handleFavoriteClick = useCallback((node: DeviceInfo) => {
     return (e: React.MouseEvent) => toggleFavorite(node, e);
@@ -1151,6 +1173,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     centerMapOnNodeRef.current = centerMapOnNode;
     showRouteRef.current = showRoute;
     traceroutesRef.current = traceroutes;
+    nodePositionsRef.current = nodePositions;
   });
 
   // Track previous nodes to detect updates and trigger animations
@@ -1202,7 +1225,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     if (node) {
       // Select and center on the node
       setSelectedNodeId(nodeId);
-      centerMapOnNode(node);
+      centerOnNodeMarker(node);
     }
   };
 

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -138,6 +138,22 @@ export const resolveMapEndpoint = (
   return null;
 };
 
+/**
+ * Resolve the map-center target for a node click. The map must pan to the point
+ * the node's MARKER is actually rendered at — for low-precision/obscured nodes
+ * that is the deterministic in-cell offset position (#4016), NOT the raw
+ * reported cell-center. Centering on the raw center jumped the map up to half an
+ * accuracy cell (km-scale for obscured nodes) away from the marker the user
+ * clicked. Returns the marker position from `nodePositions`, or `null` when the
+ * node isn't currently on the map (caller falls back to the raw center).
+ */
+export const resolveMarkerCenterTarget = (
+  nodeNum: number,
+  nodePositions: Map<number, [number, number]>,
+): [number, number] | null => {
+  return nodePositions.get(nodeNum) ?? null;
+};
+
 export const getRoleName = (role: number | string | undefined): string | null => {
   if (role === undefined || role === null) return null;
   const roleNum = typeof role === 'string' ? parseInt(role) : role;


### PR DESCRIPTION
## Summary

Clicking a low-precision/obscured node on the Meshtastic map panned the map to a spot *away from the marker* — reported as "clicking a node pans to some random location, maybe a position history, not the current node."

**Root cause:** Since #4016, markers for low-precision nodes render at a deterministic **in-cell offset** position (`nodePositions`, via `offsetWithinPrecisionCell`) so same-cell nodes declutter. But the click-to-center handlers pan via `centerMapOnNode` → `getEffectivePosition` — the **raw reported cell-center**. Those two diverge by up to half an accuracy cell: **~2.9 km at 13-bit (town) precision, ~23 km at 10-bit**. So the map jumped well away from the marker the user clicked. Precise-GPS nodes have a zero offset, which is why it looked intermittent (only obscured nodes misbehaved).

## Changes
- Add `resolveMarkerCenterTarget(nodeNum, nodePositions)` to `utils/nodeHelpers.ts` — returns the node's rendered marker position, or `null` when it isn't on the map.
- Add a NodesTab `centerOnNodeMarker` helper that pans to the marker position, falling back to the raw center (`centerMapOnNode`) only when the node has no rendered marker.
- Route **all four** click-to-center paths through it: OMS marker click (×2, with/without active route), node-list item click, and packet-monitor node click.

## Issues Resolved
Fixes the "click pans to wrong/random location" regression from #4016. Relates to the map-consolidation epic #4047.

## Documentation Updates
No documentation changes needed.

## Testing
- [x] Full Vitest suite green (9,034 passed / 0 failed, `success: true`)
- [x] `npm run lint:ci` — Lint ratchet OK
- [x] Server typecheck clean (only the pre-existing TelemetryChart frontend-noise errors)
- [x] New regression tests: `resolveMarkerCenterTarget` returns the offset marker position (materially different from the raw center at 13-bit precision) and `null` when the node has no marker
- [ ] Reviewer: on the Meshtastic map, click an obscured/low-precision node marker — the map should center on the marker itself, not jump km away

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub