### PR TITLE
fix(meshcore): relay admin flag + firmware level in Virtual Node login (#4094)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#b98fc338be5b4c01894da711de98348516c294aa",
+        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-virtual": "^3.14.5",
@@ -3092,7 +3092,8 @@
     },
     "node_modules/@liamcottle/meshcore.js": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/Yeraze/meshcore.js.git#b98fc338be5b4c01894da711de98348516c294aa",
+      "resolved": "git+ssh://git@github.com/Yeraze/meshcore.js.git#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
+      "integrity": "sha512-yaeSODX3PM21x7pYWkw43+++Vp4zdwLo3b2JEjKhmcowgLOfBuTpPBH8dFTctPxD3DFYS77+Y5gWhyigKrVu1Q==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#b98fc338be5b4c01894da711de98348516c294aa",
+    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
     "@maplibre/maplibre-gl-leaflet": "^0.1.3",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-virtual": "^3.14.5",

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -23,6 +23,7 @@ import {
   encodeChannelMsgRecv,
   encodeSent,
   encodeSendConfirmed,
+  encodeLoginSuccessPush,
   encodeLogRxData,
   encodeNoMoreMessages,
   PushCodes,
@@ -77,6 +78,56 @@ describe('meshcoreCompanionCodec — constants stay in sync with meshcore.js', (
 
   it('LogRxData push code matches the library (#3963)', () => {
     expect(PushCodes.LogRxData).toBe(Constants.PushCodes.LogRxData);
+  });
+});
+
+// LoginSuccess relay for firmware >= 1.16 (#4094). The app reads is_admin (byte 1)
+// to grant admin access and fw_ver_level (byte 13) to unlock neighbours/owner-info;
+// a truncated 8-byte frame leaves the app as guest with "Firmware update required".
+describe('meshcoreCompanionCodec — encodeLoginSuccessPush (#4094)', () => {
+  const PREFIX = Buffer.from('a1b2c3d4e5f6', 'hex');
+
+  it('emits the legacy 8-byte frame when no firmware version is known', () => {
+    const frame = encodeLoginSuccessPush(PREFIX);
+    expect(frame.length).toBe(8);
+    expect(frame[0]).toBe(PushCodes.LoginSuccess);
+    expect(frame[1]).toBe(0); // is_admin defaults to guest
+    expect(frame.subarray(2, 8)).toEqual(PREFIX);
+  });
+
+  it('emits a 14-byte admin frame carrying is_admin, timestamp, acl and version', () => {
+    const frame = encodeLoginSuccessPush(PREFIX, {
+      isAdmin: true,
+      firmwareVerLevel: 2,
+      serverTimestamp: 0x01020304,
+      aclPermissions: 7,
+    });
+    expect(frame.length).toBe(14);
+    expect(frame[0]).toBe(PushCodes.LoginSuccess);
+    expect(frame[1]).toBe(1); // is_admin
+    expect(frame.subarray(2, 8)).toEqual(PREFIX);
+    expect(frame.readUInt32LE(8)).toBe(0x01020304);
+    expect(frame[12]).toBe(7); // acl_permissions
+    expect(frame[13]).toBe(2); // fw_ver_level
+  });
+
+  it('round-trips through meshcore.js: admin frame decodes to isAdmin + firmwareVerLevel', async () => {
+    const decoded = await decodeWithMeshcore(
+      PushCodes.LoginSuccess,
+      encodeLoginSuccessPush(PREFIX, { isAdmin: true, firmwareVerLevel: 2, serverTimestamp: 42, aclPermissions: 3 }),
+    );
+    expect(Buffer.from(decoded.pubKeyPrefix)).toEqual(PREFIX);
+    expect(decoded.isAdmin).toBe(1);
+    expect(decoded.serverTimestamp).toBe(42);
+    expect(decoded.aclPermissions).toBe(3);
+    expect(decoded.firmwareVerLevel).toBe(2);
+  });
+
+  it('round-trips through meshcore.js: legacy frame decodes with no version fields', async () => {
+    const decoded = await decodeWithMeshcore(PushCodes.LoginSuccess, encodeLoginSuccessPush(PREFIX));
+    expect(Buffer.from(decoded.pubKeyPrefix)).toEqual(PREFIX);
+    expect(decoded.isAdmin).toBe(0);
+    expect(decoded.firmwareVerLevel).toBeUndefined();
   });
 });
 

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -704,14 +704,47 @@ export function encodeSendConfirmed(ackCode: number, roundTripMs = 0): Buffer {
  * Encode a LoginSuccess(0x85) push — the node telling the app that a login it
  * initiated (SendLogin) succeeded. `pubKeyPrefix` is the first 6 bytes of the
  * remote node's public key, which is how the app correlates the push to its
- * pending login request. Layout mirrors meshcore.js `onLoginSuccessPush`:
- * `[0x85][reserved:1][pubKeyPrefix:6]`.
+ * pending login request.
+ *
+ * MeshCore firmware >= 1.16 returns a 14-byte frame carrying the remote's admin
+ * flag and firmware version level; the app reads byte 1 to grant admin (vs
+ * guest) access and byte 13 (`fw_ver_level`) to unlock version-gated features
+ * such as neighbours and owner-info (#4094). When those fields are supplied
+ * (i.e. `firmwareVerLevel` is known) we emit the full new-format frame:
+ *   `[0x85][is_admin:1][pubKeyPrefix:6][server_timestamp:u32LE][acl:1][fw_ver_level:1]`
+ * Otherwise (legacy firmware, no version reported) we emit the historical
+ * 8-byte frame `[0x85][is_admin:1][pubKeyPrefix:6]` — matching what pre-1.16
+ * firmware sends, where the app defaults to guest with no version gating.
+ * Layout mirrors meshcore.js `onLoginSuccessPush`.
  */
-export function encodeLoginSuccessPush(pubKeyPrefix: Buffer | Uint8Array): Buffer {
-  const b = Buffer.alloc(1 + 1 + 6);
+export function encodeLoginSuccessPush(
+  pubKeyPrefix: Buffer | Uint8Array,
+  opts?: {
+    isAdmin?: boolean;
+    firmwareVerLevel?: number;
+    serverTimestamp?: number;
+    aclPermissions?: number;
+  },
+): Buffer {
+  const isAdminByte = opts?.isAdmin ? 1 : 0;
+
+  // Legacy 8-byte frame when the remote firmware didn't report a version level.
+  if (opts?.firmwareVerLevel === undefined) {
+    const b = Buffer.alloc(1 + 1 + 6);
+    b[0] = PushCodes.LoginSuccess;
+    b[1] = isAdminByte;
+    Buffer.from(pubKeyPrefix).copy(b, 2, 0, 6);
+    return b;
+  }
+
+  // New 14-byte frame (firmware >= 1.16). Fixed layout → explicit offsets.
+  const b = Buffer.alloc(1 + 1 + 6 + 4 + 1 + 1);
   b[0] = PushCodes.LoginSuccess;
-  b[1] = 0; // reserved
+  b[1] = isAdminByte;
   Buffer.from(pubKeyPrefix).copy(b, 2, 0, 6);
+  b.writeUInt32LE((opts.serverTimestamp ?? 0) >>> 0, 8);
+  b[12] = (opts.aclPermissions ?? 0) & 0xff;
+  b[13] = opts.firmwareVerLevel & 0xff;
   return b;
 }
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -630,6 +630,23 @@ interface BridgeResponse {
 }
 
 /**
+ * Result of a successful remote-node login (#4094). Firmware >= 1.16 reports the
+ * remote's admin permission and firmware version level in the LoginSuccess
+ * frame; older firmware omits them (fields left `undefined`). A `null` return
+ * from `loginToNode` means the login itself did not succeed.
+ */
+export interface MeshCoreLoginResult {
+  /** Whether the remote node granted admin access. Undefined on legacy firmware. */
+  isAdmin?: boolean;
+  /** Remote node's FIRMWARE_VER_LEVEL; gates version-locked features in the app. */
+  firmwareVerLevel?: number;
+  /** Remote node's server timestamp echoed in the login response. */
+  serverTimestamp?: number;
+  /** Granular ACL-permissions byte (firmware v7+). */
+  aclPermissions?: number;
+}
+
+/**
  * MeshCore Manager class
  * Handles connection and communication with MeshCore devices
  */
@@ -4330,10 +4347,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   /**
    * Login to a remote node for admin access
    */
-  async loginToNode(publicKey: string, password: string): Promise<boolean> {
+  async loginToNode(publicKey: string, password: string): Promise<MeshCoreLoginResult | null> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       logger.warn('[MeshCore] Admin login requires Companion firmware');
-      return false;
+      return null;
     }
 
     try {
@@ -4346,12 +4363,22 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
 
       if (response.success) {
         logger.debug(`[MeshCore] Logged into node ${publicKey.substring(0, 8)}...`);
-        return true;
+        // Firmware >= 1.16 reports the remote's admin flag and version level in
+        // the LoginSuccess frame (#4094). Surface them for the Virtual Node to
+        // relay; on older firmware they are undefined and callers fall back to
+        // the legacy guest/no-version behaviour.
+        const d = response.data ?? {};
+        return {
+          isAdmin: typeof d.is_admin === 'number' ? d.is_admin !== 0 : undefined,
+          firmwareVerLevel: typeof d.firmware_ver_level === 'number' ? d.firmware_ver_level : undefined,
+          serverTimestamp: typeof d.server_timestamp === 'number' ? d.server_timestamp : undefined,
+          aclPermissions: typeof d.acl_permissions === 'number' ? d.acl_permissions : undefined,
+        };
       }
-      return false;
+      return null;
     } catch (error) {
       logger.error('[MeshCore] Login failed:', error);
-      return false;
+      return null;
     }
   }
 
@@ -4430,7 +4457,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (this.guestLoggedInNodes.has(publicKey)) return true;
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return false;
     if (!this.connected) return false;
-    const ok = await this.loginToNode(publicKey, '');
+    const ok = (await this.loginToNode(publicKey, '')) !== null;
     if (ok) {
       this.guestLoggedInNodes.add(publicKey);
     }

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1451,8 +1451,24 @@ export class MeshCoreNativeBackend extends EventEmitter {
       case 'login': {
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Login target not found');
-        await c.login(publicKey, String(params.password ?? ''));
-        return { ok: true };
+        // meshcore.js resolves login() with the parsed LoginSuccess push. On
+        // firmware >= 1.16 that carries the remote's is_admin flag and firmware
+        // version level, which the Virtual Node must relay so the app grants
+        // admin access and unlocks version-gated features (neighbours / owner
+        // info). Legacy firmware omits the trailing fields (undefined here).
+        const login = await c.login(publicKey, String(params.password ?? '')) as {
+          isAdmin?: number;
+          serverTimestamp?: number;
+          aclPermissions?: number;
+          firmwareVerLevel?: number;
+        };
+        return {
+          ok: true,
+          is_admin: login?.isAdmin,
+          server_timestamp: login?.serverTimestamp,
+          acl_permissions: login?.aclPermissions,
+          firmware_ver_level: login?.firmwareVerLevel,
+        };
       }
 
       case 'get_status': {

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -14,7 +14,7 @@ import {
   SUPPORTED_COMPANION_PROTOCOL_VERSION,
   degreesToFixed,
 } from './meshcoreCompanionCodec.js';
-import type { MeshCoreNode, MeshCoreContact, MeshCoreMessage } from './meshcoreManager.js';
+import type { MeshCoreNode, MeshCoreContact, MeshCoreMessage, MeshCoreLoginResult } from './meshcoreManager.js';
 
 // Audit logging is fire-and-forget; stub it so the test doesn't touch the DB.
 vi.mock('../services/database.js', () => ({
@@ -70,7 +70,10 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   setChannelMock = vi.fn().mockResolvedValue(undefined);
   setOtherParamsMock = vi.fn().mockResolvedValue(true);
   sendAdvertMock = vi.fn().mockResolvedValue(true);
-  loginToNodeMock = vi.fn().mockResolvedValue(true);
+  // Default: a successful login on legacy firmware (no admin flag / version) →
+  // empty result object. Per-test overrides supply isAdmin/firmwareVerLevel to
+  // exercise the firmware >= 1.16 relay (#4094).
+  loginToNodeMock = vi.fn().mockResolvedValue({});
   tracePathRawMock = vi.fn().mockResolvedValue({ pathSnrs: [8, 12], lastSnr: 5.5, pathLen: 2, flags: 0 });
   requestRemoteTelemetryRawMock = vi.fn().mockResolvedValue(Buffer.from([0x01, 0x67, 0x00, 0xdc]));
   requestNodeStatusMock = vi.fn().mockResolvedValue({
@@ -120,7 +123,7 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
   }
   sendAdvert() { return this.sendAdvertMock() as Promise<boolean>; }
   loginToNode(publicKey: string, password: string) {
-    return this.loginToNodeMock(publicKey, password) as Promise<boolean>;
+    return this.loginToNodeMock(publicKey, password) as Promise<MeshCoreLoginResult | null>;
   }
   tracePathRaw(path: Uint8Array) {
     return this.tracePathRawMock(path) as Promise<{ pathSnrs: number[]; lastSnr: number; pathLen: number; flags: number } | null>;
@@ -781,9 +784,58 @@ describe('MeshCoreVirtualNodeServer — SendLogin relay (#3904)', () => {
     expect(manager.loginToNodeMock).toHaveBeenCalledWith(REMOTE_KEY, '');
   });
 
+  it('relays the remote admin flag + firmware version in a 14-byte frame (fw >=1.16, #4094)', async () => {
+    await startWith(false);
+    // Firmware >= 1.16 reports is_admin + fw_ver_level; the VN must forward both
+    // so the app grants admin access and unlocks neighbours/owner-info.
+    manager.loginToNodeMock.mockResolvedValueOnce({
+      isAdmin: true,
+      firmwareVerLevel: 2,
+      serverTimestamp: 0x01020304,
+      aclPermissions: 7,
+    });
+    const frames = client.expectFrames(2);
+    client.send(loginFrame(REMOTE_KEY, 'hunter2'));
+    const [sent, push] = await frames;
+
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(push[0]).toBe(PushCodes.LoginSuccess);
+    // [0x85][is_admin:1][pubKeyPrefix:6][server_timestamp:u32LE][acl:1][fw_ver_level:1]
+    expect(push.length).toBe(14);
+    expect(push[1]).toBe(1); // is_admin
+    expect(push.subarray(2, 8)).toEqual(REMOTE_KEY_BYTES.subarray(0, 6));
+    expect(push.readUInt32LE(8)).toBe(0x01020304); // server_timestamp
+    expect(push[12]).toBe(7); // acl_permissions
+    expect(push[13]).toBe(2); // fw_ver_level — drives the app's feature gating
+  });
+
+  it('reports guest (is_admin=0) but still forwards the version when fw is known (#4094)', async () => {
+    await startWith(false);
+    manager.loginToNodeMock.mockResolvedValueOnce({ isAdmin: false, firmwareVerLevel: 2 });
+    const frames = client.expectFrames(2);
+    client.send(loginFrame(REMOTE_KEY, ''));
+    const [, push] = await frames;
+    expect(push[0]).toBe(PushCodes.LoginSuccess);
+    expect(push.length).toBe(14);
+    expect(push[1]).toBe(0); // guest
+    expect(push[13]).toBe(2); // version still unlocks version-gated features
+  });
+
+  it('falls back to the legacy 8-byte frame when the remote reports no version (#4094)', async () => {
+    await startWith(false);
+    // Default mock resolves {} → legacy firmware, no version/admin fields.
+    const frames = client.expectFrames(2);
+    client.send(loginFrame(REMOTE_KEY, 'hunter2'));
+    const [, push] = await frames;
+    expect(push[0]).toBe(PushCodes.LoginSuccess);
+    expect(push.length).toBe(8); // [0x85][is_admin=0][pubKeyPrefix:6]
+    expect(push[1]).toBe(0);
+    expect(push.subarray(2, 8)).toEqual(REMOTE_KEY_BYTES.subarray(0, 6));
+  });
+
   it('replies Sent but pushes nothing when the login fails (app times out on its own)', async () => {
     await startWith(true);
-    manager.loginToNodeMock.mockResolvedValueOnce(false);
+    manager.loginToNodeMock.mockResolvedValueOnce(null);
     const sent = await client.request(loginFrame(REMOTE_KEY, 'bad'));
     expect(sent[0]).toBe(ResponseCodes.Sent);
     // Give the (resolved-false) login a tick; assert no second frame arrived.

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -2,7 +2,7 @@ import { Server, Socket } from 'net';
 import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
 import databaseService from '../services/database.js';
-import type { MeshCoreNode, TelemetryMode, MeshCoreContact, MeshCoreMessage, MeshCoreStatus } from './meshcoreManager.js';
+import type { MeshCoreNode, TelemetryMode, MeshCoreContact, MeshCoreMessage, MeshCoreStatus, MeshCoreLoginResult } from './meshcoreManager.js';
 import {
   CommandCodes,
   ErrorCodes,
@@ -97,11 +97,12 @@ export interface MeshCoreVirtualNodeManager {
   /** Broadcast a self-advertisement from the physical node (flood). */
   sendAdvert(): Promise<boolean>;
   /**
-   * Log in to a remote node with a password (issue #3904). Resolves true when
-   * the remote acknowledged the login, false on timeout/failure. An empty
-   * password is a valid guest login.
+   * Log in to a remote node with a password (issue #3904). Resolves a
+   * `MeshCoreLoginResult` (carrying the remote's admin flag + firmware version
+   * level on firmware >= 1.16, #4094) when the remote acknowledged the login,
+   * or `null` on timeout/failure. An empty password is a valid guest login.
    */
-  loginToNode(publicKey: string, password: string): Promise<boolean>;
+  loginToNode(publicKey: string, password: string): Promise<MeshCoreLoginResult | null>;
   /**
    * Trace an explicit path (raw hop hashes) and return the raw SNR results, or
    * null on failure. `lastSnr` is in dB (already /4). Used to relay the app's
@@ -654,14 +655,24 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     // Ack first so the app arms its login timeout, then do the round-trip.
     this.send(clientId, encodeSent(0, 0, this.LOGIN_EST_TIMEOUT_MS));
     try {
-      const ok = await this.options.manager.loginToNode(parsed.publicKey, parsed.password);
-      if (!ok) {
+      const result = await this.options.manager.loginToNode(parsed.publicKey, parsed.password);
+      if (!result) {
         logger.debug(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} did not succeed`);
         return;
       }
+      // Relay the remote's admin flag and firmware version level (firmware
+      // >= 1.16, #4094) so the app grants admin access and unlocks the
+      // version-gated neighbours / owner-info features instead of falling back
+      // to guest + "Firmware update required". Legacy firmware leaves these
+      // undefined and the legacy 8-byte frame is emitted.
       const prefix = pubKeyHexToBytes(parsed.publicKey).subarray(0, 6);
-      this.send(clientId, encodeLoginSuccessPush(prefix));
-      logger.debug(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} succeeded`);
+      this.send(clientId, encodeLoginSuccessPush(prefix, {
+        isAdmin: result.isAdmin,
+        firmwareVerLevel: result.firmwareVerLevel,
+        serverTimestamp: result.serverTimestamp,
+        aclPermissions: result.aclPermissions,
+      }));
+      logger.debug(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} succeeded (admin=${result.isAdmin ?? 'legacy'}, fwLevel=${result.firmwareVerLevel ?? 'legacy'})`);
     } catch (err) {
       logger.warn(`[MeshCore VN ${this.sourceId}] SendLogin to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
     }


### PR DESCRIPTION
## Summary

Fixes #4094 (recurrence of the symptoms in #3975). When the official MeshCore app connects to MeshMonitor's **Virtual Node** and logs into a remote **repeater** as admin, the app was:
1. shown as **guest, not admin** (admin commands unavailable), and
2. given **"Firmware update required"** for **neighbours** and **owner-info**.

Both are the **same bug**: the Virtual Node emitted a truncated **8-byte** `LoginSuccess` (`0x85`) frame.

## Root cause

MeshCore firmware ≥ 1.16 returns a **14-byte** login-success frame (verified against ripplebiz/MeshCore `examples/companion_radio/MyMesh.cpp` `onContactResponse`):

| offset | field | drives |
|--------|-------|--------|
| 1 | `is_admin` | admin vs **guest** |
| 2–7 | pubkey_prefix | correlation |
| 8–11 | server_timestamp | — |
| 12 | acl_permissions | granular ACL |
| 13 | `fw_ver_level` | **neighbours + owner-info unlock** (< 2 ⇒ "Firmware update required") |

The app version-gates neighbours/owner-info on `fw_ver_level` learned **at login** and never even sends the request when it's absent — which is why the (correctly-wired, #3904) `GetNeighbours`/`SendStatusReq` handlers never fired.

The data was dropped at three MeshMonitor layers (`encodeLoginSuccessPush` hardcoded 8 bytes; the native backend's `login` case returned `{ok:true}`; `loginToNode` returned a bare boolean), **and** the vendored meshcore.js fork's `onLoginSuccessPush` parsed only the 6-byte prefix.

## Changes

- **meshcore.js fork** (Yeraze/meshcore.js#1, repinned here): `onLoginSuccessPush` now parses the full 14-byte frame (`isAdmin`/`serverTimestamp`/`aclPermissions`/`firmwareVerLevel`), backward-compatible with legacy 8-byte frames.
- **`meshcoreNativeBackend`** `login` case returns the parsed fields instead of `{ok:true}`.
- **`loginToNode`** returns `MeshCoreLoginResult | null` (new exported type) instead of `boolean`; all truthiness callers unchanged.
- **`handleSendLogin`** forwards the fields; **`encodeLoginSuccessPush`** emits the real 14-byte frame when the remote reports a version, else the legacy 8-byte frame (pre-1.16 firmware).

## Test plan

- [x] New/updated tests: VN relay (admin 14-byte / guest-with-version / legacy 8-byte / failure), codec byte-layout, and meshcore.js round-trip decode of both frame shapes.
- [x] `npx tsc --noEmit` — no new errors over baseline.
- [x] `npm run lint:ci` — passes.
- [x] Full Vitest suite green: **9041 passed, 0 failed**.
- [ ] **Live hardware validation deferred to an RC.** This can only be fully confirmed against real firmware **>= 1.16** nodes: a physical companion (which builds the 14-byte frame) **and** a remote repeater to log into as admin (which supplies `is_admin` / `fw_ver_level`). The local sandbox nodes are 1.15 companions with no repeater, so they exercise only the legacy 8-byte fallback path. Plan: cut an RC and ask the #4094 reporter (on 1.16) to confirm admin login + neighbours/owner-info against their hardware.

## Dependencies

Merge Yeraze/meshcore.js#1 first (or confirm the pinned fork commit `c5900ec` is durable); this PR pins that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n
