### PR TITLE
fix(map): stop raster tile layer remounting on tileset change (abort/flicker)

### DIFF
--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -96,18 +96,34 @@ describe('BaseMap', () => {
     expect(rasterTile.getAttribute('data-url')).toBe(OSM_URL);
   });
 
-  // 3b. Tile-key remount (Phase 7 §2.1): the tile layer must remount (fresh
-  // DOM node) when the resolved tileset id changes, and must NOT remount for
-  // an unrelated re-render that leaves the tileset id unchanged.
-  it('remounts the raster tile layer when tilesetId changes', () => {
+  // 3b. Raster tile-layer keying (tile-loading regression fix): the raster
+  // TileLayer is keyed by `maxZoom`, NOT the tileset id. A same-maxZoom tileset
+  // swap must refresh its URL IN PLACE (react-leaflet 5 calls layer.setUrl),
+  // NOT remount — a remount tears the layer down and aborts the in-flight tile
+  // batch (net::ERR_ABORTED), i.e. a blank/flickering map on the once-per-load
+  // global→user mapTileset flip. It must still remount when maxZoom differs
+  // (the one option setUrl/updateGridLayer don't patch).
+  it('refreshes the raster URL in place (no remount) for a same-maxZoom tileset swap (osm↔osmHot, both z19)', () => {
     const { rerender, getByTestId } = render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" />);
     const before = getByTestId('raster-tile');
+    expect(before.getAttribute('data-url')).toBe(OSM_URL);
     rerender(<BaseMap center={[0, 0]} zoom={3} tilesetId="osmHot" />);
     const after = getByTestId('raster-tile');
-    expect(after).not.toBe(before);
+    expect(after).toBe(before); // same DOM node — swapped in place, not remounted
+    expect(after.getAttribute('data-url')).toBe('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png');
   });
 
-  it('does not remount the raster tile layer on an unrelated re-render (tilesetId unchanged)', () => {
+  it('remounts the raster tile layer when maxZoom changes (osm z19 → openTopo z17)', () => {
+    const { rerender, getByTestId } = render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" />);
+    const before = getByTestId('raster-tile');
+    expect(before.getAttribute('data-maxzoom')).toBe('19');
+    rerender(<BaseMap center={[0, 0]} zoom={3} tilesetId="openTopo" />);
+    const after = getByTestId('raster-tile');
+    expect(after).not.toBe(before);
+    expect(after.getAttribute('data-maxzoom')).toBe('17');
+  });
+
+  it('does not remount the raster tile layer on an unrelated re-render (tileset unchanged)', () => {
     const { rerender, getByTestId } = render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" />);
     const before = getByTestId('raster-tile');
     rerender(<BaseMap center={[0, 0]} zoom={4} tilesetId="osm" />);

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -63,13 +63,26 @@ export interface BaseMapProps {
  * — never inside it, see docs/internal/dev-notes/MAP_CONSOLIDATION_P1_SPEC.md
  * §2.2/§6.10), and an optional gated MapResizeHandler.
  *
- * The tile layer (both the raster `TileLayer` and vector `VectorTileLayer`
- * branches) is keyed by the resolved tileset id (Phase 7, §2.1) so a tileset
- * swap force-remounts a clean layer instead of react-leaflet patching props
- * onto the old one in place — matches DashboardMap's pre-BaseMap
- * `key={tilesetId}` remount semantics. For the 4 Phase-1 editors, which omit
- * `tilesetId`, the resolved id is the constant `DEFAULT_TILESET_ID`, so the
- * key never changes and there is no remount/behavior change.
+ * Tile-layer keys differ by branch on purpose:
+ *
+ * - **Raster `TileLayer`** is keyed by `maxZoom`, NOT the tileset id. In
+ *   react-leaflet 5's `updateTileLayer`, a `url` change already calls
+ *   `layer.setUrl(url)` for a graceful in-place tile refresh (old tiles stay
+ *   until the new ones load). Keying on the id instead force-remounted the
+ *   layer on every tileset change — including the once-per-load global→user
+ *   `mapTileset` flip — which tore the layer down and left the in-flight tile
+ *   batch `net::ERR_ABORTED`, i.e. a blank/flickering map while loading
+ *   (regression vs NodesTab's pre-BaseMap keyless `TileLayer`). The only
+ *   option `updateGridLayer`/`setUrl` do NOT patch is `maxZoom`, so we remount
+ *   only when the zoom ceiling genuinely changes; same-`maxZoom` swaps (the
+ *   common case, e.g. osm↔carto↔osmHot, all 19) refresh in place.
+ * - **Vector `VectorTileLayer`** is keyed by the resolved tileset id: a
+ *   MapLibre style/url change needs a clean remount, and raster↔vector swaps
+ *   remount anyway (different component type).
+ *
+ * For the 4 Phase-1 editors, which omit `tilesetId`, the resolved id is the
+ * constant `DEFAULT_TILESET_ID` (raster, maxZoom 19), so neither key ever
+ * changes and there is no remount/behavior change.
  *
  * Everything else (markers, draw handlers, view controllers) is the caller's
  * `children`. BaseMap is persistence-agnostic: it takes a controlled
@@ -136,7 +149,7 @@ export function BaseMap({
           )
           : (
             <TileLayer
-              key={resolvedId}
+              key={`raster-${tileset.maxZoom}`}
               url={tileset.url}
               attribution={tileset.attribution}
               maxZoom={tileset.maxZoom}


### PR DESCRIPTION
## Summary

Reported as **"lots of issues loading map tiles."** On every page load the map fetched **two full tilesets** — the global `mapTileset`, then the per-user preference (e.g. `cartoDark` → `osmHot`) — and the second batch **aborted the first** (`net::ERR_ABORTED`), blanking/flickering the map while it loaded. Confirmed live via DevTools network capture.

**Root cause:** `BaseMap` keyed the raster `<TileLayer>` on the resolved tileset id (copied from DashboardMap's pre-BaseMap key, added in #2948 against an older react-leaflet). In **react-leaflet 5**, `updateTileLayer` already calls `layer.setUrl(url)` on a URL change — a graceful **in-place** tile refresh (old tiles stay until the new ones load). Keying on the id force-**remounted** the whole layer on every tileset change, tearing it down and aborting the in-flight tile batch. NodesTab's pre-BaseMap `<TileLayer>` had **no key** and swapped in place; the epic regressed that.

## Fix
Key the raster `TileLayer` on **`maxZoom`** instead of the tileset id:
- Same-`maxZoom` swaps — the common case; `osm`/`carto*`/`osmHot` are all z19, **including the once-per-load global→user flip** — now refresh in place via `setUrl`, no remount, no abort.
- Still remounts when `maxZoom` differs (`osm` z19 → `openTopo` z17) — the one option `updateGridLayer`/`setUrl` don't patch.
- `VectorTileLayer` keeps its id key (a MapLibre style/url change needs a clean remount; raster↔vector swaps remount anyway via component-type change).

## Issues Resolved
Fixes the "tiles fail/flicker on load" regression introduced when maps adopted `BaseMap` (epic #4047).

## Documentation Updates
Updated the BaseMap keying rationale comment. No user-facing docs needed.

## Testing
- [x] BaseMap suite green incl. 2 new tests: same-`maxZoom` swap refreshes URL in place (same DOM node), differing-`maxZoom` swap remounts
- [x] Full Vitest suite green (protobuf suites require `git submodule update --init`; CI does this)
- [x] `npm run lint:ci` — Lint ratchet OK; server typecheck clean
- [ ] Reviewer: load the map, switch tilesets in the selector — tiles should refresh without the map going blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub