### PR TITLE
fix(map): user gesture cancels node-centering (zoom no longer snaps back)

### DIFF
--- a/src/components/MapCenterController.test.tsx
+++ b/src/components/MapCenterController.test.tsx
@@ -16,14 +16,19 @@ import {
 
 let currentZoom = 10;
 const setViewMock = vi.fn();
+const stopMock = vi.fn();
+// A real DOM element so the controller can add/remove real gesture listeners.
+const containerEl = document.createElement('div');
+Object.defineProperty(containerEl, 'clientHeight', { value: 800, configurable: true });
 
 vi.mock('react-leaflet', () => ({
   useMap: () => ({
-    getContainer: () => ({ clientHeight: 800 }),
+    getContainer: () => containerEl,
     getZoom: () => currentZoom,
     project: () => L.point(100, 100),
     unproject: (point: L.Point) => L.latLng(point.y, point.x),
     setView: setViewMock,
+    stop: stopMock,
   }),
 }));
 
@@ -33,6 +38,7 @@ describe('MapCenterController (#4046 items 2 + 3)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     setViewMock.mockClear();
+    stopMock.mockClear();
     currentZoom = 10;
   });
   afterEach(() => {
@@ -128,5 +134,64 @@ describe('MapCenterController (#4046 items 2 + 3)', () => {
     rerender(<MapCenterController centerTarget={null} onCenterComplete={() => {}} />);
     rerender(<MapCenterController centerTarget={[1, 2]} onCenterComplete={() => {}} />);
     expect(setViewMock).toHaveBeenCalledTimes(2); // cleared then re-selected → centers again
+  });
+
+  // "Any attempt to adjust zoom resets to the node": a real user gesture during
+  // the (up to ~2s) center window must cancel the centering so the user's
+  // zoom/pan wins, instead of the in-flight animation pulling the view back.
+  describe('user-gesture abort', () => {
+    for (const evt of ['wheel', 'touchstart', 'pointerdown']) {
+      it(`a ${evt} gesture stops the animation and finishes centering immediately (before the timer)`, () => {
+        currentZoom = 3;
+        const onCenterComplete = vi.fn();
+        render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={onCenterComplete} targetZoom={17} />);
+        expect(setViewMock).toHaveBeenCalledTimes(1);
+        expect(onCenterComplete).not.toHaveBeenCalled();
+
+        act(() => {
+          containerEl.dispatchEvent(new Event(evt, { bubbles: true }));
+        });
+
+        // The gesture halts our animation and ends the armed window at once —
+        // no waiting for the duration timer.
+        expect(stopMock).toHaveBeenCalledTimes(1);
+        expect(onCenterComplete).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    it('does not fire onCenterComplete twice when a gesture is followed by the timer', () => {
+      currentZoom = 3;
+      const onCenterComplete = vi.fn();
+      render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={onCenterComplete} targetZoom={17} />);
+
+      act(() => {
+        containerEl.dispatchEvent(new Event('wheel', { bubbles: true }));
+      });
+      expect(onCenterComplete).toHaveBeenCalledTimes(1);
+
+      // Advancing past the (now-cleared) timer must not double-fire.
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(onCenterComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes gesture listeners after the timer completes (no abort post-window)', () => {
+      currentZoom = 3;
+      const onCenterComplete = vi.fn();
+      render(<MapCenterController centerTarget={[1, 2]} onCenterComplete={onCenterComplete} targetZoom={17} />);
+
+      const duration = computeZoomAnimationDuration(3, 17);
+      act(() => {
+        vi.advanceTimersByTime(duration * 1000 + 60);
+      });
+      expect(onCenterComplete).toHaveBeenCalledTimes(1);
+
+      // A gesture after the window closed must not call stop() again.
+      act(() => {
+        containerEl.dispatchEvent(new Event('wheel', { bubbles: true }));
+      });
+      expect(stopMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/MapCenterController.tsx
+++ b/src/components/MapCenterController.tsx
@@ -86,13 +86,47 @@ export const MapCenterController: React.FC<MapCenterControllerProps> = ({
       // This avoids multiple move events and competing animations
       map.setView(offsetLatLng, clampedZoom, { animate: true, duration });
 
-      // Reset target after animation completes (slightly longer than the
-      // actual animation duration, which now varies with the zoom jump).
-      const timer = setTimeout(() => {
+      // A real user gesture during the center window must WIN. The animated
+      // setView keeps the map "arriving" at the node for the whole `duration`
+      // (up to ~2s for a big zoom jump, #4046), and `centerTarget` stays armed
+      // until the timer below fires. A wheel/pinch/drag in that window would
+      // otherwise be fought by the in-flight animation continuing to the node —
+      // i.e. "any attempt to adjust zoom resets to the node." On the first
+      // genuine user input we `map.stop()` (cancel our animation so it can't
+      // pull the view back) and finish immediately (clear the armed target).
+      // These DOM events fire ONLY for real interaction — our programmatic
+      // setView never dispatches them — and the selecting click/tap's own
+      // events have already fired by the time this effect runs, so we never
+      // self-abort the very selection that started the centering.
+      const container = map.getContainer();
+      let timer = 0;
+      let finished = false;
+      const cleanup = () => {
+        clearTimeout(timer);
+        container.removeEventListener('wheel', onUserGesture);
+        container.removeEventListener('touchstart', onUserGesture);
+        container.removeEventListener('pointerdown', onUserGesture);
+      };
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        cleanup();
         onCenterComplete();
-      }, duration * 1000 + 50);
+      };
+      function onUserGesture() {
+        map.stop(); // halt the in-flight center animation so it can't pull back
+        finish();
+      }
+      container.addEventListener('wheel', onUserGesture, { passive: true });
+      container.addEventListener('touchstart', onUserGesture, { passive: true });
+      container.addEventListener('pointerdown', onUserGesture, { passive: true });
 
-      return () => clearTimeout(timer);
+      // Reset target after animation completes (slightly longer than the
+      // actual animation duration, which now varies with the zoom jump) unless
+      // a user gesture finished it first.
+      timer = window.setTimeout(finish, duration * 1000 + 50);
+
+      return cleanup;
     } else {
       // Target cleared — allow the next selection (even of the same node) to
       // center again.


### PR DESCRIPTION
## Summary

Reported: **"once the map pans/zooms to a selected node, any attempt to adjust zoom resets the zoom/position back to the node"** — on desktop scroll wheel *and* mobile pinch.

**Cause:** selecting a node runs an animated `map.setView` to the node, and #4046 scaled that animation up to ~2s for a big zoom jump. `MapCenterController` keeps `centerTarget` armed until a timer (`duration + 50ms`) fires. A wheel/pinch/drag **inside that window** is fought by the in-flight animation continuing to the node, so the user's zoom appears to "reset." (This is the gesture-timing variant of the earlier snap-back; the per-render guard from #4080 doesn't cover an in-flight animation fighting live input.)

## Fix
On the **first genuine user gesture** (`wheel` / `touchstart` / `pointerdown` on the map container) during the center window:
1. `map.stop()` — cancel our in-flight center animation so it can't pull the view back.
2. Finish immediately — clear the armed target so nothing re-centers.

User input always wins. These DOM events fire **only** for real interaction (our programmatic `setView` never dispatches them), and the selecting click/tap's own events have already fired by the time the effect registers listeners, so it never self-aborts the selection that started the centering. The duration timer stays as the fallback when the user doesn't touch the map.

## Issues Resolved
Fixes the "zoom resets to node after selecting" report (desktop wheel + mobile pinch). Follow-up to the snap-back fix #4080 and #4046's variable animation duration.

## Documentation Updates
Inline rationale comment only.

## Testing
- [x] `MapCenterController` suite green incl. 5 new tests: wheel/touchstart/pointerdown each `stop()` + finish immediately (before the timer); no double-finish; listeners removed after the window closes
- [x] Server typecheck clean; `npm run lint:ci` — Lint ratchet OK
- [x] Full suite: only 2 unrelated `meshcoreCompanionCodec` failures from a local meshcore.js native-binding artifact (pass on CI's clean env — same base is green on #4097); map change is isolated to 2 files
- [ ] Reviewer: select a node, then immediately scroll/pinch — the map should zoom from where it is, not snap back to the node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub