### PR TITLE
fix(map): detect and trim out-of-range (invalid) node positions

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -42,7 +42,7 @@ import {
 import { getSourceColor, resolveSourceColor } from '../../utils/sourceColors';
 import { getOwnNodePositions } from '../../utils/ownNodePositions';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
-import { isNullIsland } from '../../utils/nullIsland';
+import { isBogusPosition } from '../../utils/nullIsland';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
 import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
@@ -99,7 +99,7 @@ function getNodeLatLng(node: any): { lat: number; lng: number } | null {
   const lat = node?.latitude ?? node?.position?.latitude;
   const lng = node?.longitude ?? node?.position?.longitude;
   // Skip "Null Island" (0,0) — uninitialized/stale GPS default (issue #3763).
-  if (lat != null && lng != null && !isNullIsland(lat, lng)) {
+  if (lat != null && lng != null && !isBogusPosition(lat, lng)) {
     return { lat, lng };
   }
   return null;

--- a/src/components/MapAnalysis/nodePositionUtil.ts
+++ b/src/components/MapAnalysis/nodePositionUtil.ts
@@ -1,4 +1,4 @@
-import { isNullIsland } from '../../utils/nullIsland';
+import { isBogusPosition } from '../../utils/nullIsland';
 
 /**
  * Resolve a node's lat/lng from either the flat API shape (`{latitude, longitude}`)
@@ -22,6 +22,6 @@ export function resolveNodeLatLng(
   const lat = node.latitude ?? node.position?.latitude;
   const lng = node.longitude ?? node.position?.longitude;
   if (lat == null || lng == null) return null;
-  if (isNullIsland(lat, lng)) return null;
+  if (isBogusPosition(lat, lng)) return null;
   return [lat, lng];
 }

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -18,7 +18,7 @@ import { NeighborLinksLayer, type NeighborLinkDescriptor } from '../map/layers/N
 import PolarGridOverlay from '../PolarGridOverlay';
 import { useSource } from '../../contexts/SourceContext';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
-import { isNullIsland } from '../../utils/nullIsland';
+import { isBogusPosition } from '../../utils/nullIsland';
 import { getPositionHistoryColor } from '../../utils/mapHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
@@ -235,10 +235,12 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     () => contacts.filter(c =>
       typeof c.latitude === 'number' && isFinite(c.latitude)
       && typeof c.longitude === 'number' && isFinite(c.longitude)
-      // Skip "Null Island" (0,0) — uninitialized/stale GPS default (issue #3763).
-      // The DB store filters this too, but live in-memory contacts can still
-      // carry a (0,0) fix that reaches the map via getAllNodes().
-      && !isNullIsland(c.latitude, c.longitude)),
+      // Skip bogus positions: "Null Island" (0,0) GPS defaults (issue #3763)
+      // AND out-of-range junk MeshCore adverts carry (e.g. lat 1853, lng -1598)
+      // that would blow the map's fit-bounds out to nothing. The DB store
+      // filters these too, but live in-memory contacts reaching the map via
+      // getAllNodes() can still carry them.
+      && !isBogusPosition(c.latitude, c.longitude)),
     [contacts],
   );
 
@@ -384,7 +386,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             // real points to draw a segment (a 2-point response that's all
             // Null Island would otherwise store a degenerate 1-point trail).
             const pts = resp.data
-              .filter(p => !isNullIsland(p.latitude, p.longitude))
+              .filter(p => !isBogusPosition(p.latitude, p.longitude))
               .map(p => [p.latitude, p.longitude] as [number, number]);
             if (pts.length >= 2) next.set(publicKey, pts);
           }

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -130,6 +130,7 @@ import { migration as nodeNotesMigration, runMigration112Postgres as runNodeNote
 import { migration as bootstrapOnlyIndexesMigration, runMigration113Postgres as runBootstrapOnlyIndexesPostgres, runMigration113Mysql as runBootstrapOnlyIndexesMysql } from '../server/migrations/113_add_bootstrap_only_indexes.js';
 import { migration as meshcorePathfindingTargetsMigration, runMigration114Postgres as runMeshcorePathfindingTargetsPostgres, runMigration114Mysql as runMeshcorePathfindingTargetsMysql } from '../server/migrations/114_create_meshcore_pathfinding_targets.js';
 import { migration as dropInlineNotifPrefsUserIdUniqueMigration, runMigration115Postgres as runDropInlineNotifPrefsUserIdUniquePostgres, runMigration115Mysql as runDropInlineNotifPrefsUserIdUniqueMysql } from '../server/migrations/115_drop_inline_notif_prefs_user_id_unique.js';
+import { migration as trimOutOfRangeNodePositionsMigration, runMigration116Postgres as runTrimOutOfRangeNodePositionsPostgres, runMigration116Mysql as runTrimOutOfRangeNodePositionsMysql } from '../server/migrations/116_trim_out_of_range_node_positions.js';
 
 // ============================================================================
 // Registry
@@ -1833,4 +1834,19 @@ registry.register({
   sqlite: (db) => dropInlineNotifPrefsUserIdUniqueMigration.up(db),
   postgres: (client) => runDropInlineNotifPrefsUserIdUniquePostgres(client),
   mysql: (pool) => runDropInlineNotifPrefsUserIdUniqueMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 116: One-shot cleanup of pre-existing out-of-range node positions
+// (e.g. MeshCore advert junk like lat 1853 / lng -1598) that predate the
+// isBogusPosition ingestion guard and blow the map's fit-bounds out to nothing.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 116,
+  name: 'trim_out_of_range_node_positions',
+  settingsKey: 'migration_116_trim_out_of_range_node_positions',
+  sqlite: (db) => trimOutOfRangeNodePositionsMigration.up(db),
+  postgres: (client) => runTrimOutOfRangeNodePositionsPostgres(client),
+  mysql: (pool) => runTrimOutOfRangeNodePositionsMysql(pool),
 });

--- a/src/db/repositories/analysis.ts
+++ b/src/db/repositories/analysis.ts
@@ -21,7 +21,7 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
 import { and, desc, gte, inArray, lt, or, eq } from 'drizzle-orm';
-import { isNullIsland } from '../../utils/nullIsland.js';
+import { isBogusPosition } from '../../utils/nullIsland.js';
 import {
   telemetrySqlite,
   telemetryPostgres,
@@ -385,7 +385,7 @@ export class AnalysisRepository {
       // and /coverage-grid (the grid reuses this pivot). New (0,0) fixes are
       // blocked at ingestion and migration 107 purges the historical rows; this
       // guard also hides any that pre-date the migration run.
-      if (isNullIsland(lat.value, lon)) continue;
+      if (isBogusPosition(lat.value, lon)) continue;
       const alt = altByKey.get(key);
       pivots.push({
         nodeNum: lat.nodeNum,

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -8,7 +8,7 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { appBasename } from '../init';
 import { useAuth } from '../contexts/AuthContext';
-import { isNullIsland } from '../utils/nullIsland';
+import { isBogusPosition } from '../utils/nullIsland';
 import { classifyNodeTransport, type NodeTransportClass } from '../utils/nodeTransport';
 import { unifiedNodeKey } from '../utils/nodeIdentity';
 
@@ -293,7 +293,7 @@ function mergeNodeRecords(records: any[]): any {
   const withPosition = sortedNewestFirst.find((r) => {
     const lat = r?.latitude ?? r?.position?.latitude;
     const lng = r?.longitude ?? r?.position?.longitude;
-    return lat != null && lng != null && !isNullIsland(lat, lng);
+    return lat != null && lng != null && !isBogusPosition(lat, lng);
   });
   if (withPosition) {
     if (withPosition.latitude != null) merged.latitude = withPosition.latitude;

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -10,7 +10,7 @@
 
 import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
-import { isNullIsland } from '../utils/nullIsland.js';
+import { isBogusPosition } from '../utils/nullIsland.js';
 import databaseService from '../services/database.js';
 import type { MeshcorePathfindingFilterSettings } from '../services/database.js';
 import { compileUserRegex } from '../utils/safeRegex.js';
@@ -2045,10 +2045,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         this.contacts.delete(contact.publicKey);
         return;
       }
-      // Drop "Null Island" (0,0) fixes — the GPS default before a lock — so a
-      // bogus position never lands in the node row (issue #3763).
-      const atNullIsland = isNullIsland(contact.latitude, contact.longitude);
-      const hasContactPosition = !atNullIsland
+      // Drop bogus positions before they land in the node row: "Null Island"
+      // (0,0) GPS defaults (issue #3763) AND out-of-range junk that MeshCore
+      // adverts sometimes carry — e.g. latitude 1853.45, longitude -1598.75 —
+      // which would otherwise blow the map's auto-fit bounds out to nothing.
+      const bogusPosition = isBogusPosition(contact.latitude, contact.longitude);
+      const hasContactPosition = !bogusPosition
         && typeof contact.latitude === 'number'
         && typeof contact.longitude === 'number';
       await databaseService.meshcore.upsertNode(
@@ -2058,8 +2060,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           // persisting "" into the node row (#3756).
           name: contact.advName || contact.name || null,
           advType: contact.advType ?? null,
-          latitude: atNullIsland ? null : (contact.latitude ?? null),
-          longitude: atNullIsland ? null : (contact.longitude ?? null),
+          latitude: bogusPosition ? null : (contact.latitude ?? null),
+          longitude: bogusPosition ? null : (contact.longitude ?? null),
           // Tag this as the static/advert-cached position (#3908) so
           // upsertNode won't let it clobber an established telemetry GNSS
           // fix. Only tagged when we're actually writing a real coordinate —

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -10,7 +10,7 @@ import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import { getPrimaryMeshtasticManager } from './sourceManagerTypes.js';
 import { calculateDistance } from '../utils/distance.js';
-import { isNullIsland } from '../utils/nullIsland.js';
+import { isBogusPosition } from '../utils/nullIsland.js';
 import { isPointInGeofence, distanceToGeofenceCenter } from '../utils/geometry.js';
 import { formatTime, formatDate } from '../utils/datetime.js';
 import { logger } from '../utils/logger.js';
@@ -6014,7 +6014,7 @@ class MeshtasticManager implements ISourceManager {
     // mesh infrastructure there (issue #3763). This gate fronts both the
     // POSITION_APP path and the NodeInfo position exchange, so a bogus (0,0)
     // never reaches the node row or the position-history telemetry.
-    if (isNullIsland(latitude, longitude)) {
+    if (isBogusPosition(latitude, longitude)) {
       return false;
     }
 

--- a/src/server/migrations/116_trim_out_of_range_node_positions.test.ts
+++ b/src/server/migrations/116_trim_out_of_range_node_positions.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration 116 — Trim out-of-range node positions (SQLite path).
+ *
+ * Verifies the one-shot cleanup NULLs junk coordinates (the observed MeshCore
+ * advert garbage), leaves valid and already-null positions untouched, and is
+ * idempotent.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './116_trim_out_of_range_node_positions.js';
+
+function createNodesTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeId TEXT PRIMARY KEY,
+      latitude REAL,
+      longitude REAL,
+      longName TEXT
+    );
+  `);
+}
+
+function insert(db: Database.Database, nodeId: string, lat: number | null, lng: number | null) {
+  db.prepare('INSERT INTO nodes (nodeId, latitude, longitude, longName) VALUES (?, ?, ?, ?)')
+    .run(nodeId, lat, lng, nodeId);
+}
+
+function pos(db: Database.Database, nodeId: string) {
+  return db.prepare('SELECT latitude, longitude FROM nodes WHERE nodeId = ?').get(nodeId) as {
+    latitude: number | null;
+    longitude: number | null;
+  };
+}
+
+describe('Migration 116: trim out-of-range node positions (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createNodesTable(db);
+    insert(db, 'valid-fl', 26.331349, -80.268578); // real South Florida node
+    insert(db, 'extreme-lat', 1853.453892, 1819.635571); // both out of range
+    insert(db, 'neg-lat', -471.156916, 595.308254);
+    insert(db, 'lat-just-over', 90.62051, -1598.745966); // lat barely > 90, lng far out
+    insert(db, 'lng-only', 26.33, 540.16); // valid lat, out-of-range lng
+    insert(db, 'edge-valid', 90, -180); // exact extremes are valid
+    insert(db, 'null-island', 0, 0); // in-range (left to runtime filters)
+    insert(db, 'no-position', null, null);
+  });
+
+  it('NULLs both coordinates of every out-of-range row', () => {
+    migration.up(db);
+    for (const id of ['extreme-lat', 'neg-lat', 'lat-just-over', 'lng-only']) {
+      expect(pos(db, id)).toEqual({ latitude: null, longitude: null });
+    }
+  });
+
+  it('leaves valid, edge-valid, null-island, and positionless rows untouched', () => {
+    migration.up(db);
+    expect(pos(db, 'valid-fl')).toEqual({ latitude: 26.331349, longitude: -80.268578 });
+    expect(pos(db, 'edge-valid')).toEqual({ latitude: 90, longitude: -180 });
+    expect(pos(db, 'null-island')).toEqual({ latitude: 0, longitude: 0 });
+    expect(pos(db, 'no-position')).toEqual({ latitude: null, longitude: null });
+  });
+
+  it('is idempotent — a second run changes nothing', () => {
+    migration.up(db);
+    const snapshot = db.prepare('SELECT nodeId, latitude, longitude FROM nodes ORDER BY nodeId').all();
+    migration.up(db);
+    const after = db.prepare('SELECT nodeId, latitude, longitude FROM nodes ORDER BY nodeId').all();
+    expect(after).toEqual(snapshot);
+  });
+});

--- a/src/server/migrations/116_trim_out_of_range_node_positions.ts
+++ b/src/server/migrations/116_trim_out_of_range_node_positions.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration 116: Trim out-of-range node positions.
+ *
+ * MeshCore adverts (and, rarely, corrupt Meshtastic fixes) can carry wildly
+ * out-of-range junk coordinates — e.g. latitude 1853.45, longitude -1598.75 —
+ * that pre-date the {@link isBogusPosition} ingestion guard. A single such row
+ * blows the map's auto-fit bounds out to nothing, so this one-shot data cleanup
+ * NULLs `nodes.latitude`/`longitude` wherever either value is outside the valid
+ * WGS-84 range (latitude ∈ [-90, 90], longitude ∈ [-180, 180]). The node keeps
+ * all its other data and simply shows no position until it re-acquires a valid
+ * fix.
+ *
+ * NULL rows are never matched (a NULL comparison yields NULL, not true), so
+ * positionless nodes are untouched. Null Island (0,0) is intentionally left to
+ * the existing runtime filters — it is a valid-range coordinate, just a bogus
+ * default, and nulling it here is unnecessary. `latitudeOverride`/
+ * `longitudeOverride` (user-set) are deliberately left alone.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL: after it runs, no row matches
+ * the range predicate, so a re-run is a no-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 116';
+
+// A single dialect-agnostic UPDATE. `latitude`/`longitude` are single-word
+// column names identical across all three backends' schemas.
+const UPDATE_SQL = `UPDATE nodes SET latitude = NULL, longitude = NULL
+  WHERE latitude < -90 OR latitude > 90 OR longitude < -180 OR longitude > 180`;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): trimming out-of-range node positions...`);
+    const info = db.prepare(UPDATE_SQL).run();
+    if (info.changes > 0) {
+      logger.info(`${LABEL} (SQLite): cleared ${info.changes} out-of-range node position(s)`);
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (the discarded junk coordinates are unrecoverable)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pg client is untyped in the migration runner (matches all sibling migrations)
+export async function runMigration116Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): trimming out-of-range node positions...`);
+  const res = await client.query(
+    `UPDATE nodes SET "latitude" = NULL, "longitude" = NULL
+     WHERE "latitude" < -90 OR "latitude" > 90 OR "longitude" < -180 OR "longitude" > 180`,
+  );
+  if (res?.rowCount) {
+    logger.info(`${LABEL} (PostgreSQL): cleared ${res.rowCount} out-of-range node position(s)`);
+  }
+}
+
+// ============ MySQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mysql pool is untyped in the migration runner (matches all sibling migrations)
+export async function runMigration116Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): trimming out-of-range node positions...`);
+  const [res] = await pool.query(UPDATE_SQL);
+  const affected = (res as { affectedRows?: number } | undefined)?.affectedRows ?? 0;
+  if (affected > 0) {
+    logger.info(`${LABEL} (MySQL): cleared ${affected} out-of-range node position(s)`);
+  }
+}

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -27,7 +27,7 @@ import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.
 import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
 import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
 import { resolveAutoAckPreSendDelaySeconds } from '../autoAckDelay.js';
-import { isNullIsland } from '../../utils/nullIsland.js';
+import { isBogusPosition } from '../../utils/nullIsland.js';
 import { decodeMeshCorePacket } from '../../utils/meshcorePacketDecode.js';
 import { compileUserRegex } from '../../utils/safeRegex.js';
 import { ok, fail } from '../utils/apiResponse.js';
@@ -2872,7 +2872,7 @@ router.patch(
               // default is never tagged as a real 'contact' position.
               positionSource: (typeof contact.latitude === 'number'
                 && typeof contact.longitude === 'number'
-                && !isNullIsland(contact.latitude, contact.longitude))
+                && !isBogusPosition(contact.latitude, contact.longitude))
                 ? 'contact'
                 : undefined,
               lastHeard: contact.lastSeen ?? null,
@@ -2955,7 +2955,7 @@ router.post(
               // default is never tagged as a real 'contact' position.
               positionSource: (typeof contact.latitude === 'number'
                 && typeof contact.longitude === 'number'
-                && !isNullIsland(contact.latitude, contact.longitude))
+                && !isBogusPosition(contact.latitude, contact.longitude))
                 ? 'contact'
                 : undefined,
               lastHeard: contact.lastSeen ?? null,

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -31,7 +31,7 @@ import type {
 import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../sourceManagerTypes.js';
 import { MC_TELEMETRY_PREFIX, nodeNumFromPubkey } from './meshcoreTelemetryPoller.js';
-import { isNullIsland } from '../../utils/nullIsland.js';
+import { isBogusPosition } from '../../utils/nullIsland.js';
 
 /**
  * `adv_type` values for MeshCore contacts. Matches the `MeshCoreDeviceType`
@@ -507,7 +507,7 @@ export class MeshCoreRemoteTelemetryScheduler {
           const gpsVal = gpsRecord.value as Record<string, number>;
           const lat = typeof gpsVal.latitude === 'number' ? gpsVal.latitude : null;
           const lon = typeof gpsVal.longitude === 'number' ? gpsVal.longitude : null;
-          if (lat !== null && lon !== null && !isNullIsland(lat, lon)) {
+          if (lat !== null && lon !== null && !isBogusPosition(lat, lon)) {
             try {
               await this.database.meshcore.upsertNode(
                 {

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -1,6 +1,6 @@
 import { DeviceInfo } from '../types/device';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
-import { isNullIsland } from './nullIsland.js';
+import { isBogusPosition } from './nullIsland.js';
 
 /**
  * Infrastructure node roles (Router, Router Client, Repeater, Router Late)
@@ -132,7 +132,7 @@ export const resolveMapEndpoint = (
   // garbage default (e.g. the 2^15 value 0.0032768) — that would draw a
   // neighbor/route line out to (0, 0) for a node not currently on the map
   // (#02ecd5e0 "Jupiter Dad"). Skip it so the caller omits the line instead.
-  if (embeddedLat != null && embeddedLng != null && !isNullIsland(embeddedLat, embeddedLng)) {
+  if (embeddedLat != null && embeddedLng != null && !isBogusPosition(embeddedLat, embeddedLng)) {
     return [embeddedLat, embeddedLng];
   }
   return null;

--- a/src/utils/nullIsland.test.ts
+++ b/src/utils/nullIsland.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isNullIsland, NULL_ISLAND_EPSILON } from './nullIsland.js';
+import { isNullIsland, isValidLatLng, isBogusPosition, NULL_ISLAND_EPSILON } from './nullIsland.js';
 
 describe('isNullIsland', () => {
   it('flags exactly (0, 0)', () => {
@@ -36,5 +36,52 @@ describe('isNullIsland', () => {
     expect(isNullIsland(undefined, 0)).toBe(false);
     expect(isNullIsland(NaN, 0)).toBe(false);
     expect(isNullIsland(0, Infinity)).toBe(false);
+  });
+});
+
+describe('isValidLatLng', () => {
+  it('accepts in-range real-world coordinates (including exact extremes)', () => {
+    expect(isValidLatLng(26.33, -80.27)).toBe(true); // South Florida
+    expect(isValidLatLng(0, 0)).toBe(true); // valid range (Null Island is in-range but bogus)
+    expect(isValidLatLng(90, 180)).toBe(true);
+    expect(isValidLatLng(-90, -180)).toBe(true);
+  });
+
+  it('rejects out-of-range coordinates (the observed MeshCore advert junk)', () => {
+    expect(isValidLatLng(1853.453892, 1819.635571)).toBe(false);
+    expect(isValidLatLng(-471.156916, 595.308254)).toBe(false);
+    expect(isValidLatLng(90.62051, -1598.745966)).toBe(false); // lat just over 90
+    expect(isValidLatLng(540.096308, 4.408389)).toBe(false);
+    expect(isValidLatLng(0, 180.0001)).toBe(false);
+    expect(isValidLatLng(90.0001, 0)).toBe(false);
+  });
+
+  it('rejects missing / non-finite coordinates', () => {
+    expect(isValidLatLng(null, 0)).toBe(false);
+    expect(isValidLatLng(0, undefined)).toBe(false);
+    expect(isValidLatLng(NaN, 0)).toBe(false);
+    expect(isValidLatLng(0, Infinity)).toBe(false);
+  });
+});
+
+describe('isBogusPosition', () => {
+  it('rejects BOTH null-island and out-of-range coordinates (superset of isNullIsland)', () => {
+    expect(isBogusPosition(0, 0)).toBe(true); // null island
+    expect(isBogusPosition(0.0005, -0.0009)).toBe(true); // near null island
+    expect(isBogusPosition(1853.453892, 1819.635571)).toBe(true); // out of range
+    expect(isBogusPosition(90.62051, -1598.745966)).toBe(true);
+    expect(isBogusPosition(NaN, 0)).toBe(true); // non-finite is bogus when present
+  });
+
+  it('accepts legitimate in-range positions', () => {
+    expect(isBogusPosition(26.33, -80.27)).toBe(false);
+    expect(isBogusPosition(-33.8688, 151.2093)).toBe(false);
+    expect(isBogusPosition(51.4778, 0.0001)).toBe(false); // Greenwich — near-zero lng, real lat
+  });
+
+  it('treats a missing position as not-bogus (no coordinate to reject)', () => {
+    expect(isBogusPosition(null, null)).toBe(false);
+    expect(isBogusPosition(26.33, null)).toBe(false);
+    expect(isBogusPosition(undefined, -80.27)).toBe(false);
   });
 });

--- a/src/utils/nullIsland.ts
+++ b/src/utils/nullIsland.ts
@@ -33,3 +33,40 @@ export function isNullIsland(
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return false;
   return Math.abs(latitude) < NULL_ISLAND_EPSILON && Math.abs(longitude) < NULL_ISLAND_EPSILON;
 }
+
+/**
+ * True when a coordinate pair is a geographically valid WGS-84 point: both
+ * values are finite and within range (latitude ∈ [-90, 90], longitude ∈
+ * [-180, 180]). Null/undefined inputs are NOT valid (there is no position).
+ *
+ * MeshCore adverts (and, rarely, corrupt Meshtastic fixes) can carry wildly
+ * out-of-range junk — e.g. latitude 1853.45, longitude -1598.75 — that a plain
+ * null check accepts. A single such node blows the map's auto-fit bounds out to
+ * nothing. See {@link isBogusPosition} for the "should we reject this" gate.
+ */
+export function isValidLatLng(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+): boolean {
+  if (latitude == null || longitude == null) return false;
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return false;
+  return latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180;
+}
+
+/**
+ * True when a coordinate should be rejected before it is stored or rendered:
+ * it is either out of valid WGS-84 range / non-finite, OR sits on Null Island
+ * (see {@link isNullIsland}). This is the canonical "trim invalid positions"
+ * predicate — a strict superset of {@link isNullIsland}.
+ *
+ * Null/undefined inputs return `false` (there is simply no position to reject —
+ * callers handle "missing" separately, exactly as {@link isNullIsland} does),
+ * so `!isBogusPosition(lat, lng)` alone does not assert a position exists.
+ */
+export function isBogusPosition(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+): boolean {
+  if (latitude == null || longitude == null) return false;
+  return !isValidLatLng(latitude, longitude) || isNullIsland(latitude, longitude);
+}

--- a/src/utils/ownNodePositions.ts
+++ b/src/utils/ownNodePositions.ts
@@ -14,7 +14,7 @@
  * they naturally yield no entry here and the grid is disabled for them —
  * matching the issue's "disabled when the source has no own-node position".
  */
-import { isNullIsland } from './nullIsland';
+import { isBogusPosition } from './nullIsland';
 
 export interface OwnNodePosition {
   sourceId: string;
@@ -35,7 +35,7 @@ function resolveLatLng(node: PositionedNode): { lat: number; lng: number } | nul
   const lng = node?.longitude ?? node?.position?.longitude;
   if (lat == null || lng == null) return null;
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-  if (isNullIsland(lat, lng)) return null;
+  if (isBogusPosition(lat, lng)) return null;
   return { lat, lng };
 }
 

--- a/src/utils/tracerouteSegments.ts
+++ b/src/utils/tracerouteSegments.ts
@@ -23,7 +23,7 @@
 
 // `nullIsland` is pure (no leaflet) — safe to import without breaking the
 // leaflet-free guarantee above.
-import { isNullIsland } from './nullIsland.js';
+import { isBogusPosition } from './nullIsland.js';
 
 // ---------------------------------------------------------------------------
 // #2931 — unknown-hop SNR sentinel (canonical home, re-exported by mapHelpers)
@@ -113,7 +113,7 @@ export function parseSnapshotRoutePositions(
       // default, e.g. the 2^15 value 0.0032768) must NOT anchor a route
       // segment there — skip it so resolveSegmentPosition falls through to the
       // live position (#02ecd5e0 "Jupiter Dad" routes shooting to 0,0).
-      if (isNullIsland(entry.lat, entry.lng)) continue;
+      if (isBogusPosition(entry.lat, entry.lng)) continue;
       result.set(nodeNum, [entry.lat, entry.lng]);
     }
   }
@@ -141,7 +141,7 @@ export function resolveSegmentPosition(
  * for one item, or `null` to skip it entirely.
  *
  * Validity rule: coordinates must both be numbers AND must not be at Null
- * Island — a coordinate within {@link isNullIsland}'s radius of `(0, 0)` is an
+ * Island — a coordinate within {@link isBogusPosition}'s radius of `(0, 0)` is an
  * uninitialized/garbage GPS default and is dropped, while a single axis at
  * exactly 0 (equator or prime meridian, with the other axis far from 0) is a
  * legitimate position and is kept. This uses the shared Null-Island radius
@@ -158,7 +158,7 @@ export function buildLiveNodePositionMap<T>(
     if (!entry) continue;
     const { nodeNum, lat, lng } = entry;
     if (typeof lat !== 'number' || typeof lng !== 'number') continue;
-    if (isNullIsland(lat, lng)) continue;
+    if (isBogusPosition(lat, lng)) continue;
     map.set(nodeNum, [lat, lng]);
   }
   return map;


### PR DESCRIPTION
## Summary

The MeshCore **MC-Sandbox** source had several nodes reporting wildly out-of-range coordinates — e.g. `lat 1853.45 / lng -1598.75`, `lat -471 / lng 595`, `lat 90.62 / lng -1598` — that a plain null check accepts. A single such node blows every map's auto-fit bounds out to nothing. Only Null Island `(0,0)` was being filtered; genuinely invalid coordinates outside the WGS-84 range slipped through to storage and the map.

## Changes
- **`utils/nullIsland.ts`** — add `isValidLatLng(lat, lng)` (finite + `lat∈[-90,90]`, `lng∈[-180,180]`) and `isBogusPosition(lat, lng)` (out-of-range/non-finite **or** null-island). `isBogusPosition` is the canonical "trim invalid positions" predicate — a strict superset of `isNullIsland`.
- **Swap every `isNullIsland` filter/ingestion call → `isBogusPosition`**: MeshCore + Meshtastic ingestion guards, MeshCore map markers + trails, Dashboard map, traceroute/neighbor endpoint resolvers, MapAnalysis, meshcore routes, own-node positions, remote-telemetry scheduler, analysis repo. Each site already meant "reject a bad position"; now it also rejects out-of-range junk. (Superset behavior — in-range coords are unaffected.)
- **Migration 116** — one-shot cleanup NULLing pre-existing out-of-range `nodes.latitude/longitude` across SQLite/PostgreSQL/MySQL. Idempotent; positionless and in-range rows untouched; Null Island `(0,0)` left to the runtime filters (it's in-range, just a bogus default). User-set `*Override` columns left alone.

## Issues Resolved
Trims invalid/garbage node positions (reported on the "Yeraze MC Sandbox" MeshCore source). Extends the Null Island filtering (#3763).

## Documentation Updates
Inline rationale only.

## Testing
- [x] Full Vitest suite green (9,056 passed / 0 failed, `success: true`)
- [x] `npm run lint:ci` — Lint ratchet OK; server + frontend typecheck clean (only pre-existing TelemetryChart noise)
- [x] New units: `isValidLatLng` / `isBogusPosition` (incl. the exact observed junk coords)
- [x] Migration 116 SQLite test: NULLs junk rows, preserves valid/edge-of-range/null-island/positionless, idempotent
- [ ] Reviewer: on the MeshCore MC-Sandbox source map, the out-of-range nodes no longer appear and the map fits to the real Florida cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub