### PR TITLE
fix(meshcore): trim invalid positions from getAllNodes live-contact overlay

### DIFF
--- a/src/server/meshcoreManager.getAllNodes.test.ts
+++ b/src/server/meshcoreManager.getAllNodes.test.ts
@@ -127,6 +127,40 @@ describe('MeshCoreManager.getAllNodes (node-list-collapses-to-1 regression)', ()
     expect(nodes.filter((n) => n.publicKey === KEY_LOCAL)).toHaveLength(1);
   });
 
+  it('drops a live contact\'s out-of-range/junk position (e.g. lat 1853, lng -1598) — reads as no position', async () => {
+    const m = new MeshCoreManager('src-a');
+    // Seed a live contact carrying the observed MeshCore advert garbage directly
+    // into the private map (as a device contact-list sync would).
+    // @ts-expect-error - poke the private in-memory contact map
+    m.contacts.set(KEY_B, {
+      publicKey: KEY_B,
+      advName: 'Junk Node',
+      advType: MeshCoreDeviceType.REPEATER,
+      latitude: 1853.453892,
+      longitude: -1598.745966,
+    });
+    // A second contact with a valid Florida position — must be preserved.
+    // @ts-expect-error - poke the private in-memory contact map
+    m.contacts.set(KEY_C, {
+      publicKey: KEY_C,
+      advName: 'Real Node',
+      advType: MeshCoreDeviceType.REPEATER,
+      latitude: 26.331349,
+      longitude: -80.268578,
+    });
+
+    const nodes = await m.getAllNodes();
+    const junk = nodes.find((n) => n.publicKey === KEY_B);
+    const real = nodes.find((n) => n.publicKey === KEY_C);
+
+    expect(junk).toBeDefined();
+    expect(junk?.latitude).toBeUndefined();
+    expect(junk?.longitude).toBeUndefined();
+    // Valid coordinates are untouched.
+    expect(real?.latitude).toBe(26.331349);
+    expect(real?.longitude).toBe(-80.268578);
+  });
+
   it('falls back to in-memory contacts when the DB read throws', async () => {
     getNodesBySource.mockRejectedValue(new Error('db down'));
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5535,6 +5535,18 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // over any persisted row so DB-only fields aren't lost.
     for (const contact of this.contacts.values()) {
       const base = byKey.get(contact.publicKey);
+      let latitude = contact.latitude ?? base?.latitude;
+      let longitude = contact.longitude ?? base?.longitude;
+      // The DB store + migration 116 trim bogus coordinates, but a live
+      // in-memory contact can still carry out-of-range junk (e.g. lat 1853,
+      // lng -1598) or a Null Island default straight from the device's contact
+      // list, and this overlay would otherwise surface it to the node list /
+      // map bounds via getAllNodes(). Drop it so a bad fix reads as "no
+      // position" rather than blowing the map out to nothing (#3763 follow-up).
+      if (isBogusPosition(latitude ?? null, longitude ?? null)) {
+        latitude = undefined;
+        longitude = undefined;
+      }
       byKey.set(contact.publicKey, {
         ...base,
         publicKey: contact.publicKey,
@@ -5543,8 +5555,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         lastHeard: contact.lastSeen ?? base?.lastHeard,
         rssi: contact.rssi ?? base?.rssi,
         snr: contact.snr ?? base?.snr,
-        latitude: contact.latitude ?? base?.latitude,
-        longitude: contact.longitude ?? base?.longitude,
+        latitude,
+        longitude,
       });
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #4099. After that PR, the out-of-range MeshCore coordinates (e.g. `lat 1853 / lng -1598`) were **still** returned by `/api/sources/:id/nodes` and shown in the node list / Unified map — even though migration 116 and the ingestion guard had cleaned the DB.

**Why:** `getAllNodes()` overlays **live in-memory contacts** on top of the persisted rows, and the contact map still holds the raw junk straight from the device's contact list (`contact.latitude ?? base?.latitude`). The DB was clean; the live overlay re-introduced the garbage. (This is why the MeshCoreMap — which filters `contacts` directly — looked fine, but the API/list/Unified path did not.)

## Fix
Sanitize the merged position in the overlay: when the resolved `lat/lng` is bogus (out-of-range/non-finite or Null Island, via `isBogusPosition`), drop it so the node reads as "no position" instead of blowing the map bounds out to nothing. Valid coordinates are untouched.

## Issues Resolved
Completes the invalid-position trimming from #4099 for the MeshCore live-serving path.

## Testing
- [x] Full Vitest suite green (9,057 passed / 0 failed)
- [x] `npm run lint:ci` OK; server typecheck clean
- [x] New regression test in `meshcoreManager.getAllNodes.test.ts`: a live contact with `lat 1853 / lng -1598` comes back with `latitude`/`longitude` undefined; a valid Florida contact is preserved
- [ ] Reviewer: `/api/sources/<mc>/nodes` no longer returns out-of-range coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub