### PR TITLE
ci(docker): tag pre-releases :dev, keep :latest for stable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -266,23 +266,30 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-armv7
 
       - name: Create and push manifest for minor version tag
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.check_prerelease.outputs.is_prerelease == 'false'
         run: |
           docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.minor }} \
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-main \
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-armv7
 
       - name: Create and push manifest for major version tag
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.check_prerelease.outputs.is_prerelease == 'false'
         run: |
           docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.major }} \
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-main \
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-armv7
 
-      - name: Create and push manifest for latest tag
+      - name: Create and push manifest for latest tag (stable release only)
         if: github.event_name == 'release' && steps.check_prerelease.outputs.is_prerelease == 'false'
         run: |
           docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:latest \
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-main \
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-armv7
+
+      - name: Create and push manifest for dev tag (pre-release only)
+        if: github.event_name == 'release' && steps.check_prerelease.outputs.is_prerelease == 'true'
+        run: |
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:dev \
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-main \
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-armv7
 


### PR DESCRIPTION
## What

Adjusts the Docker publish workflow (`.github/workflows/docker-publish.yml`, `create-manifest` job) so pre-releases and stable releases move different rolling tags:

| Release type | Rolling tags moved | Also gets |
|---|---|---|
| **Pre-release** (RC/DEV, `prerelease=true`) | `:dev` | `:<version>` (e.g. `:4.13.0-rc3`) |
| **Stable** (`prerelease=false`) | `:latest`, `:<minor>` (`:4.13`), `:<major>` (`:4`) | `:<version>` |

## Why

- Requested: pre-releases should publish a rolling **`:dev`** tag; stable releases keep **`:latest`**. Early testers can now track `:dev` without pinning an exact RC version.
- While here, gated the `:<minor>` and `:<major>` tags to **stable releases only**. Previously they moved on *every* release, so a pre-release would repoint the `:4.13`/`:4` stable channels at an RC image — contradicting the goal of keeping pre-releases off stable tags. The exact `:<version>` tag is still published for every release, so nothing becomes unpullable.

## Notes

- No change to the build/smoke-test jobs; only manifest tagging conditions.
- `workflow_dispatch` behavior unchanged (only ever pushed the `:<version>-main`/`-armv7` + combined `:<version>` tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n