### PR TITLE
fix(meshcore): guard invalid positions at repository write + getAllNodes read

### DIFF
--- a/src/db/repositories/meshcore.positionHistory.test.ts
+++ b/src/db/repositories/meshcore.positionHistory.test.ts
@@ -55,6 +55,27 @@ describe('MeshCoreRepository — position history', () => {
     expect(points).toHaveLength(0);
   });
 
+  it('never persists an out-of-range position, and does not clobber a stored valid fix', async () => {
+    // Establish a valid fix.
+    await repo.upsertNode({ publicKey: 'pk-guard', latitude: 26.331349, longitude: -80.268578, lastHeard: 1000 }, 'src-a');
+    // A junk advert (out of range) must NOT overwrite it.
+    await repo.upsertNode({ publicKey: 'pk-guard', latitude: 1853.453892, longitude: -1598.745966, lastHeard: 2000 }, 'src-a');
+
+    const kept = await repo.getNodeByPublicKeyAndSource('pk-guard', 'src-a');
+    expect(kept?.latitude).toBeCloseTo(26.331349);
+    expect(kept?.longitude).toBeCloseTo(-80.268578);
+    // The junk fix is not recorded in the movement trail either.
+    expect(await repo.getPositionHistory('src-a', 'pk-guard')).toHaveLength(1);
+  });
+
+  it('a brand-new node reporting only an out-of-range position is stored with no position', async () => {
+    await repo.upsertNode({ publicKey: 'pk-junk-only', name: 'Junk', latitude: 540.096308, longitude: 4.408389, lastHeard: 1000 }, 'src-a');
+    const row = await repo.getNodeByPublicKeyAndSource('pk-junk-only', 'src-a');
+    expect(row).toBeDefined();
+    expect(row?.latitude ?? null).toBeNull();
+    expect(row?.longitude ?? null).toBeNull();
+  });
+
   it('getPositionHistory honors the `since` window', async () => {
     await repo.upsertNode({ publicKey: 'pk3', latitude: 10, longitude: 10, lastHeard: 1000 }, 'src-a');
     await repo.upsertNode({ publicKey: 'pk3', latitude: 11, longitude: 11, lastHeard: 5000 }, 'src-a');

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -7,6 +7,7 @@
 import { eq, desc, sql, isNull, isNotNull, and, or, lt, gte, inArray, type SQL } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
+import { isBogusPosition } from '../../utils/nullIsland.js';
 
 /**
  * meshcore_nodes columns where an incoming `null` in upsertNode means "clear
@@ -311,6 +312,18 @@ export class MeshCoreRepository extends BaseRepository {
     const now = this.now();
     const { meshcoreNodes } = this.tables;
     const existing = await this.getNodeByPublicKeyAndSource(node.publicKey, sourceId);
+
+    // Never persist a bogus coordinate. MeshCore adverts/info syncs sometimes
+    // carry out-of-range junk (e.g. lat 1853, lng -1598) or a Null Island
+    // default; this is the single write choke point for every ingest path
+    // (contact sync, path/info, telemetry), so dropping it here keeps garbage
+    // out of the DB regardless of caller. Undefined (not null) means "not
+    // observed" so the merge PRESERVES any valid stored fix rather than
+    // clobbering it on a transient bad report (#3763 follow-up).
+    if (isBogusPosition(node.latitude ?? null, node.longitude ?? null)) {
+      const { latitude: _blat, longitude: _blon, ...rest } = node;
+      node = rest as typeof node;
+    }
 
     // A telemetry-derived GNSS fix (Cayenne-LPP poll) always wins over the
     // static contact/advert position once one has been recorded — otherwise

--- a/src/server/meshcoreManager.getAllNodes.test.ts
+++ b/src/server/meshcoreManager.getAllNodes.test.ts
@@ -161,6 +161,25 @@ describe('MeshCoreManager.getAllNodes (node-list-collapses-to-1 regression)', ()
     expect(real?.longitude).toBe(-80.268578);
   });
 
+  it('drops an out-of-range position on a DB-only row with no live contact (read-side backstop)', async () => {
+    // The row an unguarded historical write left in the DB; no live contact
+    // overlays it, so only the read-side final guard can trim it.
+    getNodesBySource.mockResolvedValue([
+      { publicKey: KEY_B, name: 'DB Junk', advType: MeshCoreDeviceType.REPEATER, latitude: 1853.453892, longitude: -1598.745966, isLocalNode: false },
+      { publicKey: KEY_C, name: 'DB Real', advType: MeshCoreDeviceType.REPEATER, latitude: 26.33, longitude: -80.27, isLocalNode: false },
+    ]);
+
+    const m = new MeshCoreManager('src-a');
+    const nodes = await m.getAllNodes();
+
+    const junk = nodes.find((n) => n.publicKey === KEY_B);
+    const real = nodes.find((n) => n.publicKey === KEY_C);
+    expect(junk?.latitude).toBeUndefined();
+    expect(junk?.longitude).toBeUndefined();
+    expect(real?.latitude).toBe(26.33);
+    expect(real?.longitude).toBe(-80.27);
+  });
+
   it('falls back to in-memory contacts when the DB read throws', async () => {
     getNodesBySource.mockRejectedValue(new Error('db down'));
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5535,18 +5535,6 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // over any persisted row so DB-only fields aren't lost.
     for (const contact of this.contacts.values()) {
       const base = byKey.get(contact.publicKey);
-      let latitude = contact.latitude ?? base?.latitude;
-      let longitude = contact.longitude ?? base?.longitude;
-      // The DB store + migration 116 trim bogus coordinates, but a live
-      // in-memory contact can still carry out-of-range junk (e.g. lat 1853,
-      // lng -1598) or a Null Island default straight from the device's contact
-      // list, and this overlay would otherwise surface it to the node list /
-      // map bounds via getAllNodes(). Drop it so a bad fix reads as "no
-      // position" rather than blowing the map out to nothing (#3763 follow-up).
-      if (isBogusPosition(latitude ?? null, longitude ?? null)) {
-        latitude = undefined;
-        longitude = undefined;
-      }
       byKey.set(contact.publicKey, {
         ...base,
         publicKey: contact.publicKey,
@@ -5555,8 +5543,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         lastHeard: contact.lastSeen ?? base?.lastHeard,
         rssi: contact.rssi ?? base?.rssi,
         snr: contact.snr ?? base?.snr,
-        latitude,
-        longitude,
+        latitude: contact.latitude ?? base?.latitude,
+        longitude: contact.longitude ?? base?.longitude,
       });
     }
 
@@ -5573,6 +5561,20 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       byKey.delete(this.localNode.publicKey);
     }
     nodes.push(...byKey.values());
+
+    // Final guard: never surface a bogus position (out-of-range junk like
+    // lat 1853 / lng -1598, or a Null Island default) to the node list / map
+    // bounds — no matter whether it came from a live in-memory contact or a
+    // stale DB row an unguarded historical write left behind. A bad fix reads
+    // as "no position" instead of blowing the map out to nothing (#3763
+    // follow-up). The write path (repository upsertNode) keeps new garbage out
+    // of the DB; this is the read-side backstop for anything already there.
+    for (const n of nodes) {
+      if (isBogusPosition(n.latitude ?? null, n.longitude ?? null)) {
+        n.latitude = undefined;
+        n.longitude = undefined;
+      }
+    }
     return nodes;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #4099 / #4101. After those, **4** out-of-range MeshCore nodes *still* appeared in `/api/sources/:id/nodes` (verified live). They were **DB rows with no live contact** whose garbage coordinates were re-stored after migration 116 by an ingest path that bypassed the single contact-sync guard — and `getAllNodes()` served that DB branch unsanitized (my earlier fix only covered the live-contact overlay).

## Fix — both choke points
- **Repository `upsertNode`** (the single write path every MeshCore ingest route passes through — contact sync, path/info, telemetry): drop a bogus incoming `latitude`/`longitude` (`isBogusPosition`) as "not observed". No store path can persist out-of-range / Null-Island junk, and — because it drops rather than nulls — a transient bad report never clobbers a valid stored fix.
- **`getAllNodes`**: replace the contact-overlay-only check with a **final read-side pass** that nulls any bogus position on the served list — covering live contacts, DB-only rows, and the local node alike. Guaranteed-clean output regardless of DB state.

## Issues Resolved
Completes the invalid-position trimming (#4099/#4101) for the MeshCore DB-served path.

## Testing
- [x] Full Vitest suite green (9,060 passed / 0 failed)
- [x] `npm run lint:ci` OK; server typecheck clean
- [x] Repository write-guard tests: junk never overwrites a valid fix; a junk-only node stores no position; junk isn't recorded in the movement trail
- [x] `getAllNodes` read-side backstop test: a DB-only garbage row is served with `latitude`/`longitude` undefined; valid coords preserved
- [ ] Reviewer / post-deploy: `/api/sources/<mc>/nodes` returns **zero** out-of-range coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub