### PR TITLE
docs: 4.13 website refresh — source-scoped API, release tracks, blog posts

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -1,5 +1,15 @@
 # MeshMonitor API Documentation
 
+::: warning This document is outdated — use REST_API.md or API_REFERENCE.md instead
+This file predates the v1 API and the per-source architecture. The endpoint paths listed here (`/api/nodes`, `/api/messages`, etc.) may be partially stale.
+
+**For current API documentation:**
+- [REST API overview and v1 endpoint reference](./REST_API.md)
+- [Full API Reference](./API_REFERENCE.md)
+
+**As of 4.13**, the canonical v1 paths are `/api/v1/sources/{sourceId}/nodes`, `/api/v1/sources/{sourceId}/messages`, etc. All v1 requests require `Authorization: Bearer mm_v1_...`. The old root paths (`/api/v1/nodes`, `/api/v1/messages`, …) are deprecated and will be removed in 4.14.
+:::
+
 This document provides comprehensive documentation for the MeshMonitor REST API.
 
 ## Base URL

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -8,10 +8,16 @@ This document provides comprehensive documentation for all MeshMonitor API endpo
 
 **Content Type:** `application/json`
 
-::: warning MeshMonitor 4.0 — Per-Source API
-Endpoints listed in this reference without a `sourceId` segment (e.g. `GET /api/nodes`, `GET /api/messages`) are **legacy root-path endpoints**. They still work but now emit an HTTP `Warning: 299` header: `"v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"` and will be removed in a future release.
+::: warning Breaking change in 4.13 — migrate before upgrading to 4.14
+**As of 4.13, the canonical v1 API shape is `/api/v1/sources/{sourceId}/...`.**
 
-New integrations should use the **per-source v1 API**: `/api/v1/sources/{sourceId}/nodes`, `/api/v1/sources/{sourceId}/messages`, `/api/v1/sources/{sourceId}/telemetry`, etc. Get the list of sources from `GET /api/v1/sources`.
+The old v1 root paths (`/api/v1/nodes`, `/api/v1/messages`, etc.) are kept alive for **one release only**. Every response on those paths carries:
+
+```
+Warning: 299 - "v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"
+```
+
+**These paths will be REMOVED in 4.14.** New integrations must use the per-source v1 API. Get the list of sources from `GET /api/v1/sources`.
 :::
 
 ## Table of Contents
@@ -55,19 +61,33 @@ List all configured sources. Authentication required.
 
 ### Per-source resource endpoints
 
-Replace `{sourceId}` with the `id` returned above.
+Replace `{sourceId}` with the `id` returned above, or use the literal string `"default"` to target the primary source.
 
-| Legacy (deprecated)   | Per-source v1 (recommended)                    |
-| --------------------- | ---------------------------------------------- |
-| `GET /api/nodes`      | `GET /api/v1/sources/{sourceId}/nodes`         |
-| `GET /api/messages`   | `GET /api/v1/sources/{sourceId}/messages`      |
-| `GET /api/channels`   | `GET /api/v1/sources/{sourceId}/channels`      |
-| `GET /api/telemetry`  | `GET /api/v1/sources/{sourceId}/telemetry`     |
-| `GET /api/traceroutes`| `GET /api/v1/sources/{sourceId}/traceroutes`   |
-| `GET /api/network`    | `GET /api/v1/sources/{sourceId}/network`       |
-| `GET /api/packets`    | `GET /api/v1/sources/{sourceId}/packets`       |
+| Legacy v1 path (≤ 4.12, deprecated)              | Canonical v1 path (4.13+)                              |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| `GET /api/v1/nodes?sourceId={id}`                | `GET /api/v1/sources/{sourceId}/nodes`                 |
+| `GET /api/v1/messages?sourceId={id}`             | `GET /api/v1/sources/{sourceId}/messages`              |
+| `GET /api/v1/channels?sourceId={id}`             | `GET /api/v1/sources/{sourceId}/channels`              |
+| `GET /api/v1/telemetry?sourceId={id}`            | `GET /api/v1/sources/{sourceId}/telemetry`             |
+| `GET /api/v1/traceroutes?sourceId={id}`          | `GET /api/v1/sources/{sourceId}/traceroutes`           |
+| `GET /api/v1/network?sourceId={id}`              | `GET /api/v1/sources/{sourceId}/network`               |
+| `GET /api/v1/packets?sourceId={id}`              | `GET /api/v1/sources/{sourceId}/packets`               |
+| `GET /api/v1/status?sourceId={id}`               | `GET /api/v1/sources/{sourceId}/status`                |
+| `GET /api/v1/nodes/{nId}/position-history?sourceId={id}` | `GET /api/v1/sources/{sourceId}/nodes/{nId}/position-history` |
 
-Legacy endpoints return the above `Warning: 299` header and will be removed in a future release.
+Legacy v1 root paths return the `Warning: 299` header above and **will be removed in 4.14**.
+
+#### Missing sourceId response
+
+Per-source endpoints return `400` when `sourceId` is absent — there is no silent fallback to the primary source:
+
+```json
+{
+  "success": false,
+  "error": "sourceId is required",
+  "code": "MISSING_SOURCE_ID"
+}
+```
 
 ---
 
@@ -1055,9 +1075,19 @@ All endpoints may return error responses in this format:
 }
 ```
 
+v1 API endpoints use the envelope format:
+
+```json
+{
+  "success": false,
+  "error": "sourceId is required",
+  "code": "MISSING_SOURCE_ID"
+}
+```
+
 **Common Status Codes:**
 - `200` - Success
-- `400` - Bad Request (invalid parameters)
+- `400` - Bad Request (invalid parameters, or missing `sourceId` on a per-source v1 endpoint)
 - `404` - Not Found
 - `500` - Internal Server Error
 - `503` - Service Unavailable (Meshtastic not connected)

--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -17,20 +17,70 @@ Most endpoints require authentication. MeshMonitor supports:
 
 Public endpoints are limited to health checks and the optional anonymous read-only mode (`DISABLE_ANONYMOUS=false`).
 
-## API Versioning & Per-Source Scoping (4.0)
+## API Versioning & Per-Source Scoping
 
-MeshMonitor 4.0 reshaped the REST API to scope resources by **source** (a mesh node connection). New code should use the v1 per-source paths:
+::: warning Breaking change in 4.13 — v1 root paths are deprecated
+**As of 4.13 the canonical v1 shape is `/api/v1/sources/{sourceId}/...`.**
 
-- `GET /api/v1/sources` — list sources
-- `GET /api/v1/sources/{sourceId}/nodes` — nodes for a specific source
-- `GET /api/v1/sources/{sourceId}/messages` — messages for a specific source
-- `GET /api/v1/sources/{sourceId}/telemetry` — telemetry for a specific source
-- `GET /api/v1/sources/{sourceId}/traceroutes` — traceroutes for a specific source
-- `GET /api/v1/sources/{sourceId}/channels` — channels for a specific source
+The old v1 root paths (`/api/v1/nodes`, `/api/v1/messages`, etc.) are **deprecated for one release only**. Every response on those paths carries:
 
-::: warning Deprecated root-path endpoints
-The legacy root-scoped endpoints below (`GET /api/nodes`, `GET /api/messages`, `GET /api/channels`, `GET /api/telemetry`, `GET /api/traceroutes`, `GET /api/network`, `GET /api/packets`) still work but respond with an HTTP `Warning: 299` header: `"v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"`. They will be removed in a future release.
+```
+Warning: 299 - "v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"
+```
+
+**These paths will be REMOVED in 4.14. Migrate before upgrading.**
 :::
+
+### Canonical v1 endpoints (4.13+)
+
+All v1 requests require `Authorization: Bearer mm_v1_...` except `GET /api/v1/docs`.
+
+Use `"default"` as the `{sourceId}` to target the primary source without looking up its ID.
+
+Per-source resources:
+- `GET /api/v1/sources` — list sources the token can read
+- `GET /api/v1/sources/{sourceId}/nodes`
+- `GET /api/v1/sources/{sourceId}/messages`
+- `GET /api/v1/sources/{sourceId}/channels`
+- `GET /api/v1/sources/{sourceId}/telemetry`
+- `GET /api/v1/sources/{sourceId}/traceroutes`
+- `GET /api/v1/sources/{sourceId}/network`
+- `GET /api/v1/sources/{sourceId}/packets`
+- `GET /api/v1/sources/{sourceId}/status`
+- `GET /api/v1/sources/{sourceId}/nodes/{nodeId}/position-history`
+
+Deployment-global (no sourceId):
+- `GET /api/v1/solar`
+- `GET /api/v1/channel-database`
+
+### Migration table
+
+| Legacy v1 path (≤ 4.12)                               | Canonical v1 path (4.13+)                         |
+| ------------------------------------------------------ | -------------------------------------------------- |
+| `GET /api/v1/nodes?sourceId=X`                        | `GET /api/v1/sources/X/nodes`                     |
+| `GET /api/v1/messages?sourceId=X`                     | `GET /api/v1/sources/X/messages`                  |
+| `GET /api/v1/channels?sourceId=X`                     | `GET /api/v1/sources/X/channels`                  |
+| `GET /api/v1/telemetry?sourceId=X`                    | `GET /api/v1/sources/X/telemetry`                 |
+| `GET /api/v1/traceroutes?sourceId=X`                  | `GET /api/v1/sources/X/traceroutes`               |
+| `GET /api/v1/network?sourceId=X`                      | `GET /api/v1/sources/X/network`                   |
+| `GET /api/v1/packets?sourceId=X`                      | `GET /api/v1/sources/X/packets`                   |
+| `GET /api/v1/status?sourceId=X`                       | `GET /api/v1/sources/X/status`                    |
+| `GET /api/v1/nodes/{id}/position-history?sourceId=X`  | `GET /api/v1/sources/X/nodes/{id}/position-history` |
+
+### Migration curl example
+
+```bash
+TOKEN="mm_v1_your_token_here"
+SOURCE="01J3ABCDEFG"  # or use "default" for the primary source
+
+# Legacy (≤ 4.12) — DEPRECATED, removed in 4.14
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/v1/nodes?sourceId=$SOURCE"
+
+# Canonical (4.13+)
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/v1/sources/$SOURCE/nodes"
+```
 
 ## Error Handling
 
@@ -43,9 +93,21 @@ The API uses standard HTTP status codes and returns error responses in the follo
 }
 ```
 
+v1 API errors use the envelope format:
+
+```json
+{
+  "success": false,
+  "error": "sourceId is required",
+  "code": "MISSING_SOURCE_ID"
+}
+```
+
+Per-source v1 endpoints return `400 MISSING_SOURCE_ID` when `sourceId` is absent from a request that requires it. There is no silent fallback to the primary source.
+
 **Common Status Codes:**
 - `200` - Success
-- `400` - Bad Request (invalid parameters)
+- `400` - Bad Request (invalid parameters, or missing `sourceId` on a per-source endpoint)
 - `404` - Not Found
 - `500` - Internal Server Error
 

--- a/docs/blog/2026-07-13-release-tracks.md
+++ b/docs/blog/2026-07-13-release-tracks.md
@@ -1,0 +1,50 @@
+---
+id: news-2026-07-13-release-tracks
+title: Two Release Tracks — Choose Your Cadence
+date: '2026-07-13T18:00:00Z'
+category: release
+priority: important
+---
+For a while now, MeshMonitor has shipped *fast* — often a new release every day or two. If you're an enthusiast who likes to ride the edge, that's been great. But a lot of you told us the same thing, in different words: MeshMonitor "releases too often." A near-daily stream of updates meant constant upgrade churn and a steady low hum of maintenance for people who just want a stable dashboard on the wall that keeps working.
+
+We heard you. Starting today, MeshMonitor publishes on **two tracks**, and you get to pick the one that fits how you run it.
+
+## The two tracks
+
+**Fast track — `ghcr.io/yeraze/meshmonitor:dev`**
+
+The `:dev` tag moves with **every pre-release (RC)**. That's a near-**daily** cadence — the newest features and fixes land here first, at RC-grade stability. If you're an enthusiast, a tester, or you just like being early, this is your track. It's the same firehose MeshMonitor has always been, now on its own clearly labelled tag.
+
+**Stable track — `ghcr.io/yeraze/meshmonitor:latest`**
+
+The `:latest` tag moves **only when a stable release ships** — a near-**weekly** cadence. Changes are batched up and get more testing time on `:dev` before they graduate here. This is the calm, dependable track, and it's the **default recommendation for most users**.
+
+## Details worth knowing
+
+- **Rolling major/minor tags follow stable only.** The `:4` and `:4.13` convenience tags track the **stable** release train, just like `:latest`. They will not jump ahead to an RC.
+- **Exact versions are always pinnable.** Every release — RC or stable — still publishes its precise version tag: `:4.13.0-rc3`, `:4.12.5`, and so on. If you want to lock to one specific build, pin the exact tag and nothing will move under you.
+- **Already on `:latest`? Nothing changes** — except your upgrades get fewer and calmer. You'll keep receiving stable releases on the same tag you already use.
+- **One caveat on `:dev`.** Right after a stable release ships, `:dev` may briefly point at an image that's *older* than `:latest` — the most recent RC that preceded the stable cut — until the next RC is published. This is expected and self-corrects the moment the next RC lands.
+- **Desktop, LXC, and Helm users:** the tag mechanics above are Docker-specific, but the **stable release cadence applies to you too**. You'll see the same near-weekly rhythm of stable releases; there's simply no separate `:dev` firehose to opt into.
+
+## Which track should I choose?
+
+- **You run MeshMonitor as a set-and-forget dashboard, or in production for others.** → Stay on **`:latest`** (or pin `:4` / `:4.13`). Fewer, better-tested upgrades.
+- **You love new features the day they exist, you help us shake out bugs, or you're chasing a fix that just merged.** → Switch to **`:dev`** and ride the edge with us.
+- **You need absolute reproducibility.** → Pin an exact version tag like `:4.12.5` and upgrade on your own schedule.
+
+When in doubt, `:latest` is the right answer.
+
+## Switching to the fast track
+
+If you want the fast track, it's a one-line change in your `docker-compose.yml`:
+
+```yaml
+image: ghcr.io/yeraze/meshmonitor:dev
+```
+
+Then `docker compose pull && docker compose up -d`. To go back to the stable track, point `image:` back at `ghcr.io/yeraze/meshmonitor:latest`.
+
+## Thank you
+
+This change came straight from your feedback, and it's the kind of feedback that makes MeshMonitor better for everyone — the folks who want the newest bits *and* the folks who want a quiet, reliable dashboard. Both are first-class now. Keep it coming.

--- a/docs/blog/2026-07-13-v1-api-source-scoping.md
+++ b/docs/blog/2026-07-13-v1-api-source-scoping.md
@@ -1,0 +1,139 @@
+---
+id: news-2026-07-13-v1-api-source-scoping
+title: 'MeshMonitor 4.13.0 — Breaking: the v1 API is now source-scoped'
+date: '2026-07-13T17:00:00Z'
+category: release
+priority: important
+minVersion: 4.13.0
+---
+Heads up if you drive MeshMonitor over its REST API. In 4.13.0 the v1 API becomes **source-scoped**: every endpoint that reads nodes, messages, telemetry, and friends now takes an explicit **Source ID** in the path. The old root paths (`/api/v1/nodes`, `/api/v1/messages`, …) that silently defaulted to "the primary source" still work for **one more release**, but they're deprecated and go away in 4.14.
+
+## TL;DR — who's affected
+
+- **Anyone calling the REST API** with an API token — scripts, cron jobs, Home Assistant/Node-RED flows, dashboards, anything hitting `/api/v1/...`.
+- **The web UI is not affected.** It already talks to the internal, per-source endpoints. If you only use MeshMonitor in the browser, there is nothing to do.
+- If your integration calls `/api/v1/nodes`, `/api/v1/messages`, `/api/v1/telemetry`, etc. **without** naming a source, it keeps working *today* on 4.13.0 (with a deprecation warning) and **breaks on 4.14** unless you migrate.
+
+## Why this changed
+
+MeshMonitor 4.x runs **N concurrent sources** — several Meshtastic TCP radios, MQTT bridges, and MeshCore nodes, all at once. The old v1 API predates that: with no source in the request, it quietly answered from "the primary" source.
+
+In a single-radio deployment that was fine. In a multi-source deployment it's actively wrong — "the primary" is ambiguous, and a script that thinks it's reading your MQTT gateway's nodes could silently get a different radio's data. Rather than keep guessing, 4.13.0 makes the source explicit. No source, no guessing.
+
+## The new shape
+
+Per-source data lives under `/api/v1/sources/{sourceId}/...`:
+
+```
+/api/v1/sources/{sourceId}/nodes
+/api/v1/sources/{sourceId}/messages
+/api/v1/sources/{sourceId}/channels
+/api/v1/sources/{sourceId}/telemetry
+/api/v1/sources/{sourceId}/traceroutes
+/api/v1/sources/{sourceId}/packets
+/api/v1/sources/{sourceId}/network
+/api/v1/sources/{sourceId}/status
+/api/v1/sources/{sourceId}/nodes/{nodeId}/position-history
+```
+
+Discover the sources your token can read with:
+
+```bash
+curl -H "Authorization: Bearer mm_v1_..." \
+  https://your-host/api/v1/sources
+```
+
+Each entry has an `id` you drop into the path. Don't want to look it up? The alias **`default`** resolves to the default source:
+
+```bash
+curl -H "Authorization: Bearer mm_v1_..." \
+  https://your-host/api/v1/sources/default/nodes
+```
+
+**Deployment-global endpoints are unchanged** — they were never per-source and stay put:
+
+```
+/api/v1/solar
+/api/v1/channel-database
+```
+
+## Migration guide
+
+The change is mechanical: move the source out of the query string and into the path.
+
+**Before (deprecated):**
+
+```bash
+curl -H "Authorization: Bearer mm_v1_..." \
+  "https://your-host/api/v1/nodes?sourceId=meshtastic-1"
+
+curl -H "Authorization: Bearer mm_v1_..." \
+  "https://your-host/api/v1/messages?sourceId=meshtastic-1"
+```
+
+**After (canonical):**
+
+```bash
+curl -H "Authorization: Bearer mm_v1_..." \
+  "https://your-host/api/v1/sources/meshtastic-1/nodes"
+
+curl -H "Authorization: Bearer mm_v1_..." \
+  "https://your-host/api/v1/sources/meshtastic-1/messages"
+```
+
+If you were relying on the old default-to-primary behavior and don't care which specific source ID you name, `default` is the drop-in replacement:
+
+```bash
+curl -H "Authorization: Bearer mm_v1_..." \
+  "https://your-host/api/v1/sources/default/nodes"
+```
+
+### No more silent default
+
+The strict per-source endpoints will **not** guess a source for you. Call one without a resolvable source and you get a clean 400 instead of wrong-source data:
+
+```json
+{
+  "success": false,
+  "error": "sourceId is required",
+  "code": "MISSING_SOURCE_ID"
+}
+```
+
+### MeshCore admin routes moved too
+
+The MeshCore remote-admin routes are now source-scoped as well:
+
+```
+/api/meshcore/*   →   /api/sources/:id/meshcore/*
+```
+
+## The grace period, and how to spot stragglers
+
+- **4.13.0 (now):** legacy root paths (`/api/v1/nodes?sourceId=...`) still work. Every legacy response carries a warning header:
+
+  ```
+  Warning: 299 - "v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"
+  ```
+
+  and the server logs one `[v1-deprecated]` line per legacy request.
+- **4.14 (next release):** the legacy root paths are **removed**. Requests to them will 404.
+
+To find integrations that still need migrating, watch for either signal:
+
+- **Client side:** check for the `Warning: 299` header on your API responses. Curl shows it with `-i`:
+
+  ```bash
+  curl -i -H "Authorization: Bearer mm_v1_..." \
+    "https://your-host/api/v1/nodes?sourceId=meshtastic-1" | grep -i '^warning:'
+  ```
+
+- **Server side:** grep your MeshMonitor logs for `[v1-deprecated]` (emitted at debug level) to see exactly which method/path/user is still on the old shape.
+
+If neither shows up, you're already clean.
+
+## Full reference
+
+The complete, interactive endpoint list — with the source-scoped paths, request/response schemas, and a **Try it out** button against your own instance — is in the [API Reference](/development/api-reference). The same Swagger UI is served live by your deployment at `/api/v1/docs`.
+
+Migrate your scripts before 4.14 and you'll never notice the cutover. Miss it and you'll get a 404 — but now you know where to look.

--- a/docs/configuration/auto-upgrade.md
+++ b/docs/configuration/auto-upgrade.md
@@ -82,10 +82,27 @@ services:
     environment:
       - CHECK_INTERVAL=5            # Check for triggers every 5 seconds
       - CONTAINER_NAME=meshmonitor  # Name of container to upgrade
-      - IMAGE_NAME=ghcr.io/yeraze/meshmonitor  # Image to pull
+      - IMAGE_NAME=ghcr.io/yeraze/meshmonitor  # Image to pull (tag selects your release train — see below)
       - COMPOSE_PROJECT_NAME=meshmonitor  # Docker Compose project name (optional)
       - COMPOSE_PROJECT_DIR=/compose  # Path to docker-compose files
 ```
+
+#### Release trains and IMAGE_NAME
+
+The tag appended to `IMAGE_NAME` determines how frequently the watchdog receives updates:
+
+| IMAGE_NAME value | Track | Cadence |
+|-----------------|-------|---------|
+| `ghcr.io/yeraze/meshmonitor` (no tag, defaults to `:latest`) | Stable | ~weekly |
+| `ghcr.io/yeraze/meshmonitor:latest` | Stable | ~weekly |
+| `ghcr.io/yeraze/meshmonitor:dev` | RC / fast-track | ~daily |
+| `ghcr.io/yeraze/meshmonitor:4.13.0` | Pinned | Never (the watchdog always upgrades to that exact image) |
+
+To switch tracks, update `IMAGE_NAME` in `docker-compose.upgrade.yml` and restart the stack with `docker compose -f docker-compose.yml -f docker-compose.upgrade.yml up -d`.
+
+::: warning :dev is a pre-release track
+`:dev` follows release candidates. It may be briefly older than `:latest` right after a stable release ships, until the next RC is published. Use `:latest` or a pinned version for production.
+:::
 
 ### Disabling Version Check
 

--- a/docs/configuration/production.md
+++ b/docs/configuration/production.md
@@ -27,12 +27,16 @@ Before deploying to production, ensure:
 
 For single-server deployments:
 
+::: tip Choosing an image tag for production
+Use `ghcr.io/yeraze/meshmonitor:latest` (stable, ~weekly updates) or a pinned version such as `ghcr.io/yeraze/meshmonitor:4.13.0` for full control over when you update. **Do not use `:dev` in production** — it tracks release candidates and may be updated daily with pre-release builds. See the [FAQ](/faq#how-often-does-meshmonitor-release) for a full comparison.
+:::
+
 ```yaml
 version: '3.8'
 
 services:
   meshmonitor:
-    image: meshmonitor:latest
+    image: ghcr.io/yeraze/meshmonitor:latest
     restart: unless-stopped
     environment:
       - MESHTASTIC_NODE_IP=192.168.1.100

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -62,6 +62,10 @@ volumes:
     driver: local
 ```
 
+::: tip Choosing an image tag
+The example above uses `:latest` — the stable release track, updated roughly weekly. To follow release candidates instead, switch to `:dev` (~daily updates). For fully reproducible deployments, pin an exact version such as `:4.13.0`. See [Choosing an image tag](/getting-started#quick-start-with-docker-compose) in the Getting Started guide, or the [FAQ](/faq#how-often-does-meshmonitor-release) for a comparison of the two tracks.
+:::
+
 ```bash
 docker compose up -d
 ```

--- a/docs/development/api-reference.md
+++ b/docs/development/api-reference.md
@@ -19,7 +19,9 @@ The Swagger UI rendered below is identical to the one served by your running Mes
 
 ## Versioning
 
-All endpoints are prefixed with `/api/v1/`. Breaking changes will ship as `/api/v2/` and keep `/api/v1/` working for at least one major release.
+All endpoints are prefixed with `/api/v1/`. When endpoint shapes change within v1, the old shape is kept working for at least one release with a deprecation `Warning` header before removal; larger overhauls would ship as `/api/v2/`.
+
+**4.13 shape change:** mesh-data resources (nodes, messages, channels, telemetry, traceroutes, network, packets, status, position-history) are now served under `/api/v1/sources/{sourceId}/...`. The old root-scoped v1 paths (`/api/v1/nodes?sourceId=...` etc.) still respond with a `Warning: 299` header but are removed in 4.14. Use `"default"` as `{sourceId}` to target the primary source. See the [v1 source-scoping announcement](/blog/2026-07-13-v1-api-source-scoping) for the full migration guide, or [REST_API.md](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/REST_API.md) in the repository for the endpoint-by-endpoint table.
 
 ## Interactive documentation
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -383,6 +383,27 @@ npm start
 
 ## 🔄 Updates & Maintenance
 
+### How often does MeshMonitor release? What's the difference between :dev and :latest? {#how-often-does-meshmonitor-release}
+
+MeshMonitor publishes two rolling Docker image tags, letting you choose your upgrade cadence:
+
+| Tag | Track | Typical cadence | Stability |
+|-----|-------|-----------------|-----------|
+| `ghcr.io/yeraze/meshmonitor:latest` | **Stable** | ~weekly | Production-ready releases |
+| `ghcr.io/yeraze/meshmonitor:dev` | **RC / fast-track** | ~daily | Release candidates — may include work-in-progress |
+
+**`:latest`** is the default and is recommended for most users. It moves only when a stable version ships, so you get a tested build and fewer surprise updates.
+
+**`:dev`** moves with every pre-release (release candidate). It's useful if you want new features or fixes immediately and are comfortable with RC stability. Note that `:dev` can briefly lag behind `:latest` right after a stable release ships — there is a short window where `:dev` points to the last RC while `:latest` has already moved to the new stable build. This resolves once the next RC is published.
+
+In addition to these rolling tags, every release (stable and RC) gets an **exact version tag** (e.g. `:4.13.0`, `:4.13.0-rc3`) for pinning, and stable releases also move the **major** (`:4`) and **major.minor** (`:4.13`) tags for Kubernetes-style rolling upgrades within a version line.
+
+**Why two tracks?** Earlier versions of MeshMonitor released frequently, which created maintenance burden for users on automated upgrade tools. The two-track strategy lets you explicitly opt in to fast updates (`:dev`) or stay on a quieter stable cadence (`:latest`).
+
+To switch tracks on a Docker Compose deployment, update the `image:` tag in your `docker-compose.yml` and restart the container. If you use the [auto-upgrade](/configuration/auto-upgrade) watchdog, update `IMAGE_NAME` in `docker-compose.upgrade.yml` instead.
+
+---
+
 ### How do I update MeshMonitor to the latest version?
 
 #### For Docker Deployments:

--- a/docs/features/embed-maps.md
+++ b/docs/features/embed-maps.md
@@ -122,7 +122,7 @@ Each node is displayed with a color-coded marker indicating its hop count from y
 | 6 | Red | 6 hops |
 | Unknown | Gray | Hop count unavailable |
 
-Router nodes display a tower icon; all other roles use a pin marker.
+Router and ROUTER_LATE nodes display a tower icon; all other roles use a pin marker.
 
 ### Node Popups
 
@@ -145,7 +145,7 @@ When **Show Neighbor Info** is enabled, dashed orange lines connect nodes that r
 
 ### Traceroute Paths
 
-When **Show Paths** is enabled, solid purple lines show traceroute path segments between nodes. MeshMonitor decomposes multi-hop traceroutes into individual point-to-point segments and deduplicates them, keeping the most recent instance. Only traceroutes from the last 24 hours are displayed.
+When **Show Paths** is enabled, traceroute path segments between nodes are drawn with the canonical SNR color scale — green (excellent), yellow (good), orange (fair), red (poor), and dashed gray for unknown SNR. MeshMonitor decomposes multi-hop traceroutes into individual point-to-point segments and deduplicates them, keeping the most recent instance. Only traceroutes from the last 24 hours are displayed.
 
 ### Hop Count Legend
 

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -24,9 +24,10 @@ The interactive map is the primary visualization tool in MeshMonitor, displaying
 Each node is represented on the map with a marker that provides visual information:
 
 - **Color Coding by SNR (Signal-to-Noise Ratio)**:
-  - 🟢 Green: Excellent signal (SNR > 10 dB)
-  - 🟡 Yellow: Good signal (SNR 0-10 dB)
-  - 🔴 Red: Poor signal (SNR < 0 dB)
+  - 🟢 Green: Excellent signal (SNR ≥ 5 dB)
+  - 🟡 Yellow: Good signal (SNR ≥ 0 dB, < 5 dB)
+  - 🟠 Orange: Fair signal (SNR ≥ -5 dB, < 0 dB)
+  - 🔴 Red: Poor signal (SNR < -5 dB)
   - ⚫ Gray: No signal data available
 
 - **Security Indicators**:
@@ -68,7 +69,7 @@ Click any node marker to view detailed information:
 #### Map Navigation
 
 - **Pan**: Click and drag to move the map
-- **Center on Node**: Click a node in the sidebar to center the map on that node
+- **Center on Node**: Click a node in the sidebar to center the map on that node. The map zooms in to a configurable target level (default 17, adjustable in **Settings → Map**) when the node is far away, but never zooms *out* below your current zoom level.
 - **Fit to Network**: Automatically adjusts zoom to show all active nodes
 
 ### Traceroute Visualization

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -120,6 +120,8 @@ Each MeshCore source has its own multi-pane page accessible by clicking the sour
 
 A map of every contact with valid coordinates, plus a styled row list aligned to the same visual vocabulary as the Meshtastic nodes view. The map honours zoom-based label visibility and falls through to the dashboard map when the source is selected at the dashboard level. A search/filter bar lets you quickly find contacts by name or public key prefix.
 
+On **mobile**, the node list and the map occupy the same area; a toggle button switches between them so the map is always reachable without first selecting a node. On desktop, a collapse button collapses the list to a thin sidebar (preference persisted to `localStorage`).
+
 ### Channels
 
 The device's channels with the most recent message stream. Channel-message senders are now extracted from the `"Name: body"` prefix that MeshCore embeds in the text body, so the sender column and the message body are no longer collapsed into one string.
@@ -505,6 +507,23 @@ Changing radio parameters will disconnect you from nodes using different setting
 :::
 
 Saved radio params are now persisted authoritatively: the backend propagates device-side errors back instead of silently returning success, and the manager optimistically updates `localNode.radio*` then refreshes from the device so the next snapshot reflects the real device state.
+
+## Packet Monitor
+
+The MeshCore page includes a **Packet Monitor** tab (sub-toolbar: **Packets**) that surfaces raw OTA frames captured from the companion's `LogRxData` (0x88) push. This is the MeshCore analogue of the Meshtastic [Packet Monitor](/features/packet-monitor).
+
+Capture is opt-in. The view exposes an **Enable** toggle and retention controls (max packet count, max age in hours) inline; no separate settings page is required. Once enabled, the monitor shows:
+
+- **Timestamp** — when the packet was received
+- **Route type** — direct / flood / etc. (decoded from the OTA frame)
+- **Payload type** — message type in human-readable form where known, raw hex otherwise
+- **Relay chain** — the relay-hash sequence from the packet
+- **Hop count**, **SNR**, and **RSSI**
+- **Raw hex dump** — the full OTA frame, accessible via the detail modal
+
+New packets stream in live over the existing Socket.io connection (no separate subscription is needed). The view can be **paused** and **exported** (`.jsonl` format) for offline analysis. Filtering by payload type and route type narrows the display.
+
+The `packetmonitor:write` permission is required to clear the log; `settings:write` is required to toggle capture on/off and adjust retention.
 
 ## Still Early
 

--- a/docs/features/multi-source.md
+++ b/docs/features/multi-source.md
@@ -10,7 +10,7 @@ Multi-Source lets a single MeshMonitor deployment talk to **multiple meshes at o
 
 A **source** is one upstream connection MeshMonitor speaks to. Each source has:
 
-- A **type** — `meshtastic_tcp`, `meshcore`, `mqtt_broker` (embedded MQTT broker hosting locally-connected clients), or `mqtt_bridge` (MQTT client to one upstream broker, optionally attached to a sibling `mqtt_broker` for fan-out — see [Embedded MQTT Broker & Bridge](/features/mqtt-broker)). Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB through the UI, TCP via the legacy env-var bootstrap path. No sidecar either way.
+- A **type** — `meshtastic_tcp`, `meshcore`, `mqtt_broker` (embedded MQTT broker hosting locally-connected clients), or `mqtt_bridge` (MQTT client to one upstream broker, optionally attached to a sibling `mqtt_broker` for fan-out — see [Embedded MQTT Broker & Bridge](/features/mqtt-broker)). Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB or TCP through the UI. No sidecar either way.
 - Its own **connection settings** (host, port, device path, credentials)
 - Its own **scheduler** (auto-responder, auto-announce, auto-traceroute, auto-ack)
 - Its own **Virtual Node** endpoint (TCP sources only)
@@ -142,6 +142,24 @@ If you're upgrading from 3.x:
 3. **Re-enable VN per source** — Dashboard → Edit Source → Virtual Node on each TCP source you want to expose
 4. **Review permissions** — the per-source permission matrix may need admin review for non-admin users
 5. **Back up first** — use System Backup from the Settings page before upgrading. The sources table is included.
+
+## REST API
+
+The v1 API reflects the per-source model directly. All mesh-data resources are scoped under `/api/v1/sources/{sourceId}/...`:
+
+```
+GET /api/v1/sources                              # list sources
+GET /api/v1/sources/{sourceId}/nodes
+GET /api/v1/sources/{sourceId}/messages
+GET /api/v1/sources/{sourceId}/channels
+GET /api/v1/sources/{sourceId}/telemetry
+GET /api/v1/sources/{sourceId}/traceroutes
+GET /api/v1/sources/{sourceId}/network
+GET /api/v1/sources/{sourceId}/packets
+GET /api/v1/sources/{sourceId}/status
+```
+
+Use `"default"` as `{sourceId}` to target the primary source. All v1 requests require `Authorization: Bearer mm_v1_...`. See the [API Reference](/development/api-reference) for complete documentation.
 
 ## Related
 

--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -2,6 +2,10 @@
 
 The Packet Monitor is a diagnostic tool that displays raw Meshtastic packets as they are received from the mesh network. It provides visibility into the low-level packet traffic for debugging and analysis purposes.
 
+::: tip MeshCore Packet Monitor
+MeshCore sources have their own equivalent — the **OTA Packet Monitor** accessible from the **Packets** tab in the MeshCore source page. It captures raw OTA frames from the companion's `LogRxData` push (route type, payload type, relay chain, SNR/RSSI, and a full hex dump). See the [MeshCore documentation](/features/meshcore#packet-monitor) for details.
+:::
+
 ![Packet Monitor](/images/features/packet-monitor.png)
 
 ## Accessing the Packet Monitor

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,6 +120,17 @@ volumes:
     driver: local
 ```
 
+::: tip Choosing an image tag
+| Tag | Track | Cadence | When to use |
+|-----|-------|---------|-------------|
+| `:latest` | Stable | ~weekly | **Default.** Recommended for most users |
+| `:dev` | RC / fast-track | ~daily | You want the newest features immediately and accept RC stability |
+| `:<major>.<minor>` e.g. `:4.13` | Stable line | Each stable in that series | Rolling upgrades pinned to a minor version |
+| `:<version>` e.g. `:4.13.0` | Pinned | Never (immutable) | Full control over exactly which version runs |
+
+`:dev` can briefly lag behind `:latest` right after a stable release ships, until the next RC is published. See the [FAQ](/faq#how-often-does-meshmonitor-release) for more details.
+:::
+
 **That's it!** No need for SESSION_SECRET, COOKIE_SECURE, or other complex settings for basic usage.
 
 ### 2. Start MeshMonitor


### PR DESCRIPTION
Full review of the website documentation (meshmonitor.org) against the 4.13.0 release cycle, plus two new blog posts.

## API documentation — v1 source-scoping breaking change
- **REST_API.md / API_REFERENCE.md**: canonical 4.13 shape (`/api/v1/sources/{sourceId}/...`), endpoint-by-endpoint migration tables, exact `Warning: 299` header, explicit **removal in 4.14**, `400 MISSING_SOURCE_ID` envelope, `"default"` source alias.
- **API.md** (legacy): outdated-document banner pointing at the current references.
- **development/api-reference.md** (published site page): 4.13 shape-change note; versioning-policy sentence updated to match actual practice (in-place v1 deprecation window, not v2-only).
- **features/multi-source.md**: new REST API section.

## Release-track documentation (`:dev` / `:latest`)
- **getting-started / DEPLOYMENT_GUIDE / auto-upgrade / production**: image-tag choice tables — `:dev` = RC track (~daily), `:latest` = stable (~weekly), `:4`/`:4.13` stable-only, exact tags for pinning; production explicitly warned off `:dev`.
- **faq.md**: new entry — "How often does MeshMonitor release? What's the difference between :dev and :latest?"

## Feature staleness pass vs 4.13
- **maps.md**: 4-band SNR color scale (was stale 3-band), center-on-node zoom semantics.
- **embed-maps.md**: SNR-colored traceroute segments (was "solid purple"), ROUTER_LATE tower icon.
- **meshcore.md**: mobile node-list/map toggle (#4079), new OTA Packet Monitor section (permissions verified against meshcoreRoutes.ts).
- **multi-source.md**: MeshCore TCP now via UI (env-var bootstrap removed in 4.6).
- **packet-monitor.md**: cross-link to the MeshCore OTA monitor.

## New blog posts
- **`2026-07-13-v1-api-source-scoping.md`** — breaking-change announcement: who's affected, why, migration guide with curl before/after, grace-period timeline (Warning: 299 now → 404 in 4.14), how to find straggler integrations. `priority: important`, `minVersion: 4.13.0`.
- **`2026-07-13-release-tracks.md`** — two-track release strategy: `:dev` (near-daily RCs) vs `:latest` (near-weekly stable), in response to release-frequency feedback; includes "which track should I choose?" and the one-line switch.

## Validation
- `node scripts/blog-to-news.mjs` runs clean — both posts land at the top of news.json (a YAML-breaking unquoted colon in one title was caught and fixed).
- `npm run docs:build` passes, including the dead-link check (two links into the unpublished `docs/api/` tree were caught by the build and repointed at published pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n