### PR TITLE
fix(meshcore): relay SendTxtMsg(txtType=CliData) via CLI, not chat DM (#4106)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
+++ b/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
@@ -201,7 +201,11 @@ is **always** refused regardless of the gate. All connects/admin-forwards are au
   console uses, see `MESHCORE_REMOTE_ADMIN.md`) instead of `sendMessageWithResult`; the reply is
   queued through the normal `MsgWaiting`→`SyncNextMessage` path, tagged `txtType=CliData` on the
   way back out so the app renders it as a CLI reply. Gated on `allowAdminCommands` like the other
-  config-mutating commands, since CLI text can include `set`/`reboot`/`setperm`.
+  config-mutating commands, since CLI text can include `set`/`reboot`/`setperm`. The effective
+  reply-timeout honors the operator's `meshcoreCliTimeoutSeconds` setting (#4027) — the same
+  setting the remote-admin console routes respect — and the resolved value is passed to **both**
+  the `Sent` estimate and `sendCliCommand`, so a distant multi-hop repeater's reply isn't cut off
+  at the 15s default the app was told to wait.
 
 ### Protocol subtleties found in testing (don't regress these)
 - **Channel send acks `Ok`, DM send acks `Sent`.** meshcore.js's `sendChannelTextMessage`

--- a/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
+++ b/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
@@ -193,6 +193,15 @@ is **always** refused regardless of the gate. All connects/admin-forwards are au
   pubkey prefix or the app's own trace tag); and the node's raw RX feed bridged to apps as a
   `LogRxData`(0x88) push (#3964). Login/trace/telemetry/advert are **not** gated on
   `allowAdminCommands` — a real node accepts them unconditionally; only config *writes* are gated.
+- **Phase 5 — CLI relay for remote-admin. ✅ IMPLEMENTED (#4106).** `SendTxtMsg` with
+  `txtType=CliData` (the app issuing a CLI command to a node it logged into via `SendLogin`,
+  #4094) is a **different wire operation from a plain chat DM** despite sharing command code 2 —
+  it must go out with `txt_type=CliData` so the remote's `CommonCLI` handles it, not the chat
+  handler. Routed to `meshcoreManager.sendCliCommand` (the same primitive the remote-admin CLI
+  console uses, see `MESHCORE_REMOTE_ADMIN.md`) instead of `sendMessageWithResult`; the reply is
+  queued through the normal `MsgWaiting`→`SyncNextMessage` path, tagged `txtType=CliData` on the
+  way back out so the app renders it as a CLI reply. Gated on `allowAdminCommands` like the other
+  config-mutating commands, since CLI text can include `set`/`reboot`/`setperm`.
 
 ### Protocol subtleties found in testing (don't regress these)
 - **Channel send acks `Ok`, DM send acks `Sent`.** meshcore.js's `sendChannelTextMessage`
@@ -202,6 +211,11 @@ is **always** refused regardless of the gate. All connects/admin-forwards are au
   messages with the synthetic `channel-N` key in `toPublicKey` for messages we *sent* but in
   `fromPublicKey` for messages we *received* (`toPublicKey` unset on RX). Detect it in both
   fields, or incoming channel replies get mis-encoded as a `ContactMsgRecv` and dropped.
+- **`SendTxtMsg`'s `txtType` byte selects the wire operation, not just metadata.** Code 2
+  covers both a plain chat DM (`txtType=Plain`) and a CLI/admin command to a logged-in node
+  (`txtType=CliData`) — same frame shape, different handling entirely (#4106). Ignoring the
+  byte and always treating it as chat means the remote's CLI handler never sees the command
+  and the app times out waiting for a reply that will never come.
 
 ## 6. Key risks & how the plan retires them
 

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -109,6 +109,18 @@ export const BinaryRequestTypes = {
   GetNeighbours: 0x06, // REQ_TYPE_GET_NEIGHBOURS
 } as const;
 
+/**
+ * `txt_type` byte carried by SendTxtMsg/SendChannelTxtMsg and ContactMsgRecv
+ * (mirrors meshcore.js `Constants.TxtType`). CliData distinguishes a CLI
+ * command/reply from a normal chat DM — same PAYLOAD_TYPE_TXT_MSG packet,
+ * one byte flipped.
+ */
+export const TxtType = {
+  Plain: 0,
+  CliData: 1,
+  SignedPlain: 2,
+} as const;
+
 /** Error codes carried by an Err(1) response. */
 export const ErrorCodes = {
   UnsupportedCmd: 1,

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -1310,6 +1310,17 @@ describe('MeshCoreVirtualNodeServer — SendTxtMsg CLI relay (#4106)', () => {
     await new Promise((r) => setTimeout(r, 20));
   });
 
+  it('replies Err(NotFound) for a CLI command to an unknown contact prefix, without calling the manager', async () => {
+    await startWith(true);
+    const unknownPrefix = Buffer.from('ff'.repeat(6), 'hex'); // no matching contact
+    const frame = [CommandCodes.SendTxtMsg, 1, 0, 0, 0, 0, 0, ...unknownPrefix, ...Buffer.from('get name', 'utf8')];
+    const res = await client.request(frame);
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.NotFound);
+    expect(manager.sendCliCommandMock).not.toHaveBeenCalled();
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+  });
+
   it('replies Err(UnsupportedCmd) and never calls the manager when allowAdminCommands is off', async () => {
     await startWith(false);
     const res = await client.request(cliFrame('reboot'));

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -147,6 +147,10 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
       neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
     } | null>;
   }
+  sendCliCommandMock = vi.fn().mockResolvedValue({ reply: 'ok', elapsedMs: 42 });
+  sendCliCommand(publicKey: string, command: string) {
+    return this.sendCliCommandMock(publicKey, command) as Promise<{ reply: string; elapsedMs: number }>;
+  }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
   emitOtaPacket(data: { snr?: number | null; rssi?: number | null; raw_hex?: string | null }) {
@@ -1238,5 +1242,84 @@ describe('MeshCoreVirtualNodeServer — SendBinaryReq/GetNeighbours relay (#3904
     expect(res[0]).toBe(ResponseCodes.Err);
     expect(res[1]).toBe(ErrorCodes.UnsupportedCmd);
     expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+  });
+});
+
+// SendTxtMsg(txtType=CliData): a plain-DM send never reaches the remote's CLI
+// handler, so an app that just logged in as admin (#4095) got no reply and
+// timed out on every follow-up admin action (#4106). Gated on
+// allowAdminCommands like the local Set* config commands (#3904), since a CLI
+// string can mutate remote config.
+describe('MeshCoreVirtualNodeServer — SendTxtMsg CLI relay (#4106)', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let client: TestClient;
+  let manager: FakeManager;
+
+  const REMOTE_KEY = 'b1'.repeat(32); // matches SAMPLE_CONTACTS
+  const REMOTE_PREFIX = Buffer.from(REMOTE_KEY, 'hex').subarray(0, 6);
+
+  async function startWith(allowAdminCommands: boolean): Promise<void> {
+    manager = new FakeManager();
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, allowAdminCommands, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+  }
+  afterEach(async () => { client?.close(); await server?.stop(); });
+
+  // [2][txtType=1(CliData)][attempt=0][senderTimestamp:u32=0][prefix:6][text]
+  function cliFrame(text: string): number[] {
+    return [CommandCodes.SendTxtMsg, 1, 0, 0, 0, 0, 0, ...REMOTE_PREFIX, ...Buffer.from(text, 'utf8')];
+  }
+
+  it('replies Sent, then delivers the CLI reply as ContactMsgRecv(txtType=CliData) via SyncNextMessage', async () => {
+    await startWith(true);
+    manager.sendCliCommandMock.mockResolvedValueOnce({ reply: 'name: MyRepeater', elapsedMs: 120 });
+    const sentPush = client.expectFrames(2);
+    client.send(cliFrame('get name'));
+    const [sent, waiting] = await sentPush;
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(waiting[0]).toBe(PushCodes.MsgWaiting);
+    expect(manager.sendCliCommandMock).toHaveBeenCalledWith(REMOTE_KEY, 'get name');
+    // Plain-DM send must NOT have been used for a CLI-typed frame.
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+
+    const recv = await client.request([CommandCodes.SyncNextMessage]);
+    expect(recv[0]).toBe(ResponseCodes.ContactMsgRecv);
+    expect(recv.subarray(1, 7)).toEqual(REMOTE_PREFIX);
+    expect(recv[8]).toBe(1); // txtType byte = CliData, not Plain
+    expect(recv.subarray(-'name: MyRepeater'.length).toString('utf8')).toBe('name: MyRepeater');
+  });
+
+  it('replies Err(UnsupportedCmd) and never calls the manager when allowAdminCommands is off', async () => {
+    await startWith(false);
+    const res = await client.request(cliFrame('reboot'));
+    expect(res[0]).toBe(ResponseCodes.Err);
+    expect(res[1]).toBe(ErrorCodes.UnsupportedCmd);
+    expect(manager.sendCliCommandMock).not.toHaveBeenCalled();
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+  });
+
+  it('replies Sent but pushes nothing when the CLI command rejects (timeout / not Companion)', async () => {
+    await startWith(true);
+    manager.sendCliCommandMock.mockRejectedValueOnce(new Error('CLI command timed out after 15000ms'));
+    const sent = await client.request(cliFrame('get name'));
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    const second = await Promise.race([
+      client.expectFrames(1).then((f) => f[0]),
+      new Promise<null>((r) => setTimeout(() => r(null), 100)),
+    ]);
+    expect(second).toBeNull();
+  });
+
+  it('still resolves a plain-chat SendTxtMsg (txtType=Plain) via sendMessageWithResult, not the CLI path', async () => {
+    await startWith(true);
+    manager.sendMessageWithResultMock.mockResolvedValueOnce({ ok: true, expectedAckCrc: 0x55, estTimeout: 9000 });
+    // [2][txtType=0][attempt=0][ts:4][prefix:6][text]
+    const frame = [CommandCodes.SendTxtMsg, 0, 0, 0, 0, 0, 0, ...REMOTE_PREFIX, ...Buffer.from('hi', 'utf8')];
+    const sent = await client.request(frame);
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    expect(manager.sendMessageWithResultMock).toHaveBeenCalledWith('hi', REMOTE_KEY, undefined);
+    expect(manager.sendCliCommandMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -1287,8 +1287,27 @@ describe('MeshCoreVirtualNodeServer — SendTxtMsg CLI relay (#4106)', () => {
     const recv = await client.request([CommandCodes.SyncNextMessage]);
     expect(recv[0]).toBe(ResponseCodes.ContactMsgRecv);
     expect(recv.subarray(1, 7)).toEqual(REMOTE_PREFIX);
-    expect(recv[8]).toBe(1); // txtType byte = CliData, not Plain
+    // ContactMsgRecv layout: [code:1][prefix:6][pathLen:1][txtType:1]… → byte
+    // index 8 is txtType. Must be CliData(1), not Plain(0), so the app routes
+    // the reply to its CLI console instead of the chat thread.
+    expect(recv[8]).toBe(1);
     expect(recv.subarray(-'name: MyRepeater'.length).toString('utf8')).toBe('name: MyRepeater');
+  });
+
+  it('drops the CLI reply silently when the client disconnected mid-round-trip', async () => {
+    await startWith(true);
+    let resolveCli!: (v: { reply: string; elapsedMs: number }) => void;
+    manager.sendCliCommandMock.mockReturnValueOnce(new Promise((resolve) => { resolveCli = resolve; }));
+    client.send(cliFrame('get name'));
+    const sent = await client.expectFrames(1);
+    expect(sent[0][0]).toBe(ResponseCodes.Sent);
+
+    client.close(); // client goes away while the CLI round-trip is still in flight
+    await new Promise((r) => setTimeout(r, 20));
+    // Resolving after disconnect must not throw or leak a queued message onto
+    // a client map entry that no longer exists.
+    expect(() => resolveCli({ reply: 'name: MyRepeater', elapsedMs: 5 })).not.toThrow();
+    await new Promise((r) => setTimeout(r, 20));
   });
 
   it('replies Err(UnsupportedCmd) and never calls the manager when allowAdminCommands is off', async () => {

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -17,8 +17,15 @@ import {
 import type { MeshCoreNode, MeshCoreContact, MeshCoreMessage, MeshCoreLoginResult } from './meshcoreManager.js';
 
 // Audit logging is fire-and-forget; stub it so the test doesn't touch the DB.
+// `settings.getSetting` backs the configurable CLI reply-timeout (#4027); default
+// to null (unset) so most tests exercise the built-in 15s fallback. Declared via
+// vi.hoisted so the hoisted vi.mock factory can reference it without a TDZ error.
+const { getSettingMock } = vi.hoisted(() => ({ getSettingMock: vi.fn().mockResolvedValue(null) }));
 vi.mock('../services/database.js', () => ({
-  default: { auditLogAsync: vi.fn().mockResolvedValue(undefined) },
+  default: {
+    auditLogAsync: vi.fn().mockResolvedValue(undefined),
+    settings: { getSetting: (key: string) => getSettingMock(key) },
+  },
 }));
 
 const LOCAL_NODE: MeshCoreNode = {
@@ -148,8 +155,8 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
     } | null>;
   }
   sendCliCommandMock = vi.fn().mockResolvedValue({ reply: 'ok', elapsedMs: 42 });
-  sendCliCommand(publicKey: string, command: string) {
-    return this.sendCliCommandMock(publicKey, command) as Promise<{ reply: string; elapsedMs: number }>;
+  sendCliCommand(publicKey: string, command: string, opts?: { timeoutMs?: number }) {
+    return this.sendCliCommandMock(publicKey, command, opts) as Promise<{ reply: string; elapsedMs: number }>;
   }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
   emitSendConfirmed(data: { ackCode: number; roundTripMs: number }) { this.emit('send_confirmed', data); }
@@ -1280,7 +1287,9 @@ describe('MeshCoreVirtualNodeServer — SendTxtMsg CLI relay (#4106)', () => {
     const [sent, waiting] = await sentPush;
     expect(sent[0]).toBe(ResponseCodes.Sent);
     expect(waiting[0]).toBe(PushCodes.MsgWaiting);
-    expect(manager.sendCliCommandMock).toHaveBeenCalledWith(REMOTE_KEY, 'get name');
+    // With no meshcoreCliTimeoutSeconds set (getSettingMock → null), the built-in
+    // 15s default is passed through as the sendCliCommand timeout.
+    expect(manager.sendCliCommandMock).toHaveBeenCalledWith(REMOTE_KEY, 'get name', { timeoutMs: 15_000 });
     // Plain-DM send must NOT have been used for a CLI-typed frame.
     expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
 
@@ -1292,6 +1301,30 @@ describe('MeshCoreVirtualNodeServer — SendTxtMsg CLI relay (#4106)', () => {
     // the reply to its CLI console instead of the chat thread.
     expect(recv[8]).toBe(1);
     expect(recv.subarray(-'name: MyRepeater'.length).toString('utf8')).toBe('name: MyRepeater');
+  });
+
+  it('honors the operator-configured meshcoreCliTimeoutSeconds (#4027) for both the Sent estimate and sendCliCommand', async () => {
+    await startWith(true);
+    // Operator raised the CLI timeout to 30s for a slow multi-hop repeater.
+    getSettingMock.mockResolvedValueOnce('30');
+    manager.sendCliCommandMock.mockResolvedValueOnce({ reply: 'ok', elapsedMs: 10 });
+    const sent = await client.request(cliFrame('get name'));
+    expect(sent[0]).toBe(ResponseCodes.Sent);
+    // Sent(6): [code][result:i8][expectedAckCrc:u32LE][estTimeout:u32LE] — the
+    // estimate the app waits on must match the configured 30s, not the 15s default.
+    expect(sent.readUInt32LE(6)).toBe(30_000);
+    // …and the same effective timeout must be handed to the manager, so a distant
+    // repeater's reply isn't cut off at 15s (the exact #4106 multi-hop case).
+    expect(manager.sendCliCommandMock).toHaveBeenCalledWith(REMOTE_KEY, 'get name', { timeoutMs: 30_000 });
+  });
+
+  it('falls back to the 15s default when meshcoreCliTimeoutSeconds is out of range', async () => {
+    await startWith(true);
+    getSettingMock.mockResolvedValueOnce('999'); // > 60s clamp → invalid, ignored
+    manager.sendCliCommandMock.mockResolvedValueOnce({ reply: 'ok', elapsedMs: 10 });
+    const sent = await client.request(cliFrame('get name'));
+    expect(sent.readUInt32LE(6)).toBe(15_000);
+    expect(manager.sendCliCommandMock).toHaveBeenCalledWith(REMOTE_KEY, 'get name', { timeoutMs: 15_000 });
   });
 
   it('drops the CLI reply silently when the client disconnected mid-round-trip', async () => {

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -1211,7 +1211,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       return encodeChannelMsgRecv({
         channelIdx: Number(channelMatch[1]),
         pathLen: wirePathLen,
-        txtType: 0,
+        txtType: TxtType.Plain,
         senderTimestamp,
         text,
       });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -142,8 +142,10 @@ export interface MeshCoreVirtualNodeManager {
    * Send a CLI/admin command to a remote node the app has already logged into
    * and return its text reply (issue #4106). Used to relay the app's
    * SendTxtMsg(txtType=CliData) — distinct from a plain chat DM, which uses
-   * `sendMessageWithResult` instead. Throws if the local device isn't a
-   * Companion or the command times out.
+   * `sendMessageWithResult` instead. Rejects if the local device isn't a
+   * Companion or the command times out; `handleSendCliTxtMsg` catches this
+   * and simply pushes nothing further (mirrors a real node's silence on a
+   * failed CLI round-trip).
    */
   sendCliCommand(publicKey: string, command: string): Promise<{ reply: string; elapsedMs: number }>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
@@ -1025,7 +1027,8 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     const prefixHex = (cmd.pubKeyPrefix ?? Buffer.alloc(0)).toString('hex');
     const fullKey = this.resolveContactKey(prefixHex);
     if (!fullKey) {
-      logger.warn(`[MeshCore VN ${this.sourceId}] DM from ${clientId} to unknown contact prefix ${prefixHex}`);
+      const kind = cmd.txtType === TxtType.CliData ? 'CLI command' : 'DM';
+      logger.warn(`[MeshCore VN ${this.sourceId}] ${kind} from ${clientId} to unknown contact prefix ${prefixHex}`);
       this.send(clientId, encodeErr(ErrorCodes.NotFound));
       return;
     }
@@ -1058,8 +1061,18 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     }
   }
 
-  /** Default reply-timeout hint (ms) returned in Sent responses for CLI commands. */
+  /**
+   * Default reply-timeout hint (ms) returned in Sent responses for CLI
+   * commands. Matches `MeshCoreManager.sendCliCommand`'s own default
+   * `timeoutMs` (15_000) — keep these in sync: if the manager's internal
+   * timeout ever grows past this value, a reply could arrive and queue a
+   * MsgWaiting push after the app has already given up waiting on the Sent
+   * response's estimated timeout.
+   */
   private readonly CLI_REPLY_EST_TIMEOUT_MS = 15_000;
+
+  /** Monotonic counter for synthetic CLI-reply message IDs (avoids a same-millisecond collision). */
+  private nextCliReplyId = 1;
 
   /**
    * SendTxtMsg(txtType=CliData) → relay a CLI/admin command to a remote node
@@ -1092,7 +1105,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       const client = this.clients.get(clientId);
       if (!client) return; // client disconnected while the CLI round-trip was in flight
       client.pendingMessages.push({
-        id: `cli-${targetPublicKey}-${Date.now()}`,
+        id: `cli-${targetPublicKey}-${this.nextCliReplyId++}`,
         fromPublicKey: targetPublicKey,
         text: reply,
         timestamp: Math.floor(Date.now() / 1000),

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -47,6 +47,7 @@ import {
   parseSendTelemetryReq,
   parseSendStatusReq,
   encodeStatusResponsePush,
+  TxtType,
   BinaryRequestTypes,
   parseSendBinaryReq,
   parseGetNeighboursReq,
@@ -137,6 +138,14 @@ export interface MeshCoreVirtualNodeManager {
     total: number;
     neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
   } | null>;
+  /**
+   * Send a CLI/admin command to a remote node the app has already logged into
+   * and return its text reply (issue #4106). Used to relay the app's
+   * SendTxtMsg(txtType=CliData) — distinct from a plain chat DM, which uses
+   * `sendMessageWithResult` instead. Throws if the local device isn't a
+   * Companion or the command times out.
+   */
+  sendCliCommand(publicKey: string, command: string): Promise<{ reply: string; elapsedMs: number }>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -1004,7 +1013,13 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     }
   }
 
-  /** SendTxtMsg → resolve the 6-byte prefix to a contact, forward a DM, reply Sent. */
+  /**
+   * SendTxtMsg → resolve the 6-byte prefix to a contact, forward a DM, reply
+   * Sent. A `txtType=CliData` frame is a CLI/admin command to a node the app
+   * has already logged into (issue #4106) — routed to `handleSendCliTxtMsg`
+   * instead of the plain-DM path, since a normal chat send never reaches the
+   * remote's CLI handler and the app would just time out waiting for a reply.
+   */
   private async handleSendTxtMsg(clientId: string, cmd: ParsedCommand): Promise<void> {
     const text = cmd.text ?? '';
     const prefixHex = (cmd.pubKeyPrefix ?? Buffer.alloc(0)).toString('hex');
@@ -1012,6 +1027,10 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     if (!fullKey) {
       logger.warn(`[MeshCore VN ${this.sourceId}] DM from ${clientId} to unknown contact prefix ${prefixHex}`);
       this.send(clientId, encodeErr(ErrorCodes.NotFound));
+      return;
+    }
+    if (cmd.txtType === TxtType.CliData) {
+      await this.handleSendCliTxtMsg(clientId, fullKey, text);
       return;
     }
     try {
@@ -1036,6 +1055,53 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     } catch (err) {
       logger.error(`[MeshCore VN ${this.sourceId}] DM from ${clientId} threw: ${(err as Error).message}`);
       this.send(clientId, encodeErr(ErrorCodes.BadState));
+    }
+  }
+
+  /** Default reply-timeout hint (ms) returned in Sent responses for CLI commands. */
+  private readonly CLI_REPLY_EST_TIMEOUT_MS = 15_000;
+
+  /**
+   * SendTxtMsg(txtType=CliData) → relay a CLI/admin command to a remote node
+   * the app has already logged into, and push its text reply back (issue
+   * #4106). Gated on `allowAdminCommands` like the local Set* config commands
+   * (issue #3904) — a CLI string can mutate remote config (`set name`,
+   * `reboot`, `setperm`, …), and MeshMonitor's admin toggle is the single
+   * point of control over whether Virtual Node clients can issue ANY
+   * mutating command through this instance, independent of what the remote's
+   * own ACL would otherwise allow.
+   *
+   * On success the reply is queued exactly like an incoming DM (MsgWaiting +
+   * SyncNextMessage) rather than pushed directly, mirroring how a real node
+   * delivers a CLI reply — same ContactMsgRecv frame, `txtType=CliData`
+   * instead of `Plain` so the app renders it in the CLI console, not the chat
+   * thread. On failure/timeout we emit nothing further, mirroring
+   * SendStatusReq/SendTelemetryReq: a real node that never got a CLI reply
+   * doesn't push anything either, so the app's own timeout takes over.
+   */
+  private async handleSendCliTxtMsg(clientId: string, targetPublicKey: string, command: string): Promise<void> {
+    if (!this.allowAdminCommands) {
+      logger.debug(`[MeshCore VN ${this.sourceId}] CLI command blocked from ${clientId} (allowAdminCommands off)`);
+      this.send(clientId, encodeErr(ErrorCodes.UnsupportedCmd));
+      return;
+    }
+    const keyShort = targetPublicKey.substring(0, 12);
+    this.send(clientId, encodeSent(0, 0, this.CLI_REPLY_EST_TIMEOUT_MS));
+    try {
+      const { reply } = await this.options.manager.sendCliCommand(targetPublicKey, command);
+      const client = this.clients.get(clientId);
+      if (!client) return; // client disconnected while the CLI round-trip was in flight
+      client.pendingMessages.push({
+        id: `cli-${targetPublicKey}-${Date.now()}`,
+        fromPublicKey: targetPublicKey,
+        text: reply,
+        timestamp: Math.floor(Date.now() / 1000),
+        messageType: 'cli_reply',
+      });
+      this.send(clientId, encodeMsgWaitingPush());
+      logger.debug(`[MeshCore VN ${this.sourceId}] CLI reply from ${keyShort}… queued for ${clientId} (${reply.length} chars)`);
+    } catch (err) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] CLI command to ${keyShort}… from ${clientId} failed: ${(err as Error).message}`);
     }
   }
 
@@ -1140,7 +1206,10 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     return encodeContactMsgRecv({
       pubKeyPrefix: hexToBytes(msg.fromPublicKey).subarray(0, 6),
       pathLen: wirePathLen,
-      txtType: 0,
+      // A CLI reply we queued ourselves (issue #4106) must round-trip as
+      // CliData, not Plain, so the app routes it to the CLI console instead
+      // of the chat thread — mirroring how a real node tags the reply.
+      txtType: msg.messageType === 'cli_reply' ? TxtType.CliData : TxtType.Plain,
       senderTimestamp,
       text: msg.text,
     });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -145,9 +145,14 @@ export interface MeshCoreVirtualNodeManager {
    * `sendMessageWithResult` instead. Rejects if the local device isn't a
    * Companion or the command times out; `handleSendCliTxtMsg` catches this
    * and simply pushes nothing further (mirrors a real node's silence on a
-   * failed CLI round-trip).
+   * failed CLI round-trip). `opts.timeoutMs` lets the caller honor the
+   * operator's configurable CLI timeout (#4027) instead of the built-in 15s.
    */
-  sendCliCommand(publicKey: string, command: string): Promise<{ reply: string; elapsedMs: number }>;
+  sendCliCommand(
+    publicKey: string,
+    command: string,
+    opts?: { timeoutMs?: number },
+  ): Promise<{ reply: string; elapsedMs: number }>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -1062,14 +1067,36 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   }
 
   /**
-   * Default reply-timeout hint (ms) returned in Sent responses for CLI
-   * commands. Matches `MeshCoreManager.sendCliCommand`'s own default
-   * `timeoutMs` (15_000) — keep these in sync: if the manager's internal
-   * timeout ever grows past this value, a reply could arrive and queue a
-   * MsgWaiting push after the app has already given up waiting on the Sent
-   * response's estimated timeout.
+   * Fallback reply-timeout hint (ms) for CLI commands when the operator hasn't
+   * configured `meshcoreCliTimeoutSeconds` (#4027). Matches
+   * `MeshCoreManager.sendCliCommand`'s own default `timeoutMs` (15_000). The
+   * effective value flows through `resolveCliReplyTimeoutMs()` into BOTH the
+   * Sent response's estimate AND the `sendCliCommand` call, so a reply can
+   * never arrive after the app has stopped waiting on the estimate.
    */
   private readonly CLI_REPLY_EST_TIMEOUT_MS = 15_000;
+
+  /**
+   * Resolve the effective CLI reply-timeout (ms), honoring the operator's
+   * global `meshcoreCliTimeoutSeconds` setting (#4027) — the same setting the
+   * remote-admin console routes respect via `resolveCliTimeoutMs`. Clamped to
+   * 1..60s; any unset/out-of-range/invalid value (or a settings read failure)
+   * falls back to the built-in 15s default so the pre-#4027 behavior is
+   * preserved. The app doesn't send a per-call override on this path, so only
+   * the global setting is consulted.
+   */
+  private async resolveCliReplyTimeoutMs(): Promise<number> {
+    try {
+      const raw = await databaseService.settings.getSetting('meshcoreCliTimeoutSeconds');
+      const seconds = raw == null ? NaN : parseInt(raw, 10);
+      if (Number.isFinite(seconds) && seconds >= 1 && seconds <= 60) {
+        return seconds * 1000;
+      }
+    } catch (err) {
+      logger.debug(`[MeshCore VN ${this.sourceId}] CLI timeout setting read failed, using default: ${(err as Error).message}`);
+    }
+    return this.CLI_REPLY_EST_TIMEOUT_MS;
+  }
 
   /** Monotonic counter for synthetic CLI-reply message IDs (avoids a same-millisecond collision). */
   private nextCliReplyId = 1;
@@ -1099,9 +1126,10 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       return;
     }
     const keyShort = targetPublicKey.substring(0, 12);
-    this.send(clientId, encodeSent(0, 0, this.CLI_REPLY_EST_TIMEOUT_MS));
+    const timeoutMs = await this.resolveCliReplyTimeoutMs();
+    this.send(clientId, encodeSent(0, 0, timeoutMs));
     try {
-      const { reply } = await this.options.manager.sendCliCommand(targetPublicKey, command);
+      const { reply } = await this.options.manager.sendCliCommand(targetPublicKey, command, { timeoutMs });
       const client = this.clients.get(clientId);
       if (!client) return; // client disconnected while the CLI round-trip was in flight
       client.pendingMessages.push({


### PR DESCRIPTION
## Summary

Fixes #4106. On `4.13.0-rc3`, after #4095 fixed the Virtual Node's admin-login relay, the MeshCore app can now log in to a remote repeater as admin — but every admin command sent afterward (`set name`, `reboot`, etc.) times out. Only read-only structured requests that go through dedicated wire commands (stats, telemetry, neighbours) work, because those never depended on this path.

## Root cause

The companion protocol reuses `SendTxtMsg` (command code 2) for **two different operations**, distinguished only by the `txt_type` byte in the frame: a normal chat DM (`Plain`) and a CLI/admin command to a node the app is logged into (`CliData`).

`MeshCoreVirtualNodeServer.handleSendTxtMsg` decoded `cmd.txtType` (already parsed by `meshcoreCompanionCodec.decodeCommand`) but never read it — every `SendTxtMsg` was unconditionally forwarded via `manager.sendMessageWithResult`, MeshMonitor's plain-DM send path. A CLI command sent that way reaches the remote node tagged `txt_type=Plain`, so the remote's `CommonCLI` handler never sees it (only the chat handler does), and the app waits forever for a reply that firmware will never send.

## Fix

- `SendTxtMsg` frames with `txtType=CliData` now route to a new `handleSendCliTxtMsg`, which calls `MeshCoreManager.sendCliCommand` — the same primitive MeshMonitor's own remote-admin CLI console uses (see `docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`) — instead of the plain-DM path.
- Gated on `allowAdminCommands`, consistent with the other config-mutating VN commands from #3904 (`SetRadioParams`, `SetAdvertName`, …): a CLI string can mutate remote config or trigger `reboot`/`setperm`, so MeshMonitor's admin toggle remains the single point of control over mutating commands issued through a Virtual Node client.
- On success, the CLI reply is queued through the existing `MsgWaiting` → `SyncNextMessage` path (same mechanism as an incoming chat DM) and re-tagged `txtType=CliData` on the way out, so the app routes it to its CLI console instead of the chat thread.
- On failure/timeout, nothing further is pushed — mirrors the existing `SendStatusReq`/`SendTelemetryReq` behavior, where a real node that never replies doesn't push anything either, so the app's own timeout takes over.
- Added a shared `TxtType` constant (`Plain`/`CliData`/`SignedPlain`) to `meshcoreCompanionCodec.ts` for reuse.

## Changes

- `src/server/meshcoreVirtualNodeServer.ts` — CLI branch in `handleSendTxtMsg`, new `handleSendCliTxtMsg`, `sendCliCommand` added to the `MeshCoreVirtualNodeManager` interface, `encodeIncomingMessage` tags queued CLI replies as `CliData`.
- `src/server/meshcoreCompanionCodec.ts` — new exported `TxtType` constant.
- `src/server/meshcoreVirtualNodeServer.test.ts` — new `SendTxtMsg CLI relay (#4106)` suite: Sent→MsgWaiting→ContactMsgRecv(CliData) happy path, `allowAdminCommands=false` blocks with `Err(UnsupportedCmd)`, failure/timeout pushes nothing, and a regression check that plain-chat `SendTxtMsg` still goes through `sendMessageWithResult` unchanged.
- `docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md` — documents the new Phase 5 behavior and the `txt_type`-selects-the-operation gotcha.

## Test plan

- [x] New/updated unit tests: `src/server/meshcoreVirtualNodeServer.test.ts` (73/73 passing in the file, including 4 new cases).
- [x] `npx tsc --noEmit` — no new errors.
- [x] `npm run lint:ci` — passes (lint ratchet OK).
- [ ] **Live hardware validation deferred**, same caveat as #4095: this needs a real Companion + a repeater to admin-login into. Once this ships in an RC, worth asking the #4106 reporter to confirm CLI/admin commands now get a reply through the Virtual Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6v9zVefx43XhjnShZJesX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6v9zVefx43XhjnShZJesX)_