### PR TITLE
fix(config): expose UDP Broadcast network setting (enabled_protocols)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3017,6 +3017,8 @@
   "network_config.ntp_server_description": "Custom NTP server address (default: meshtastic.pool.ntp.org). Maximum 33 characters.",
   "network_config.rsyslog_server": "Rsyslog Server",
   "network_config.rsyslog_server_description": "Remote syslog server address (e.g., 192.168.1.100:514). Leave blank to disable.",
+  "network_config.udp_broadcast": "UDP Broadcast",
+  "network_config.udp_broadcast_description": "Broadcast node info and telemetry over UDP on the local network, so other software (e.g. Meshtastic clients on the same LAN) can discover this node without a direct connection.",
   "network_config.save_button": "Save Network Config",
 
   "config.network_saved": "Network configuration saved",

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -138,6 +138,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [ipv4Gateway, setIpv4Gateway] = useState('');
   const [ipv4Subnet, setIpv4Subnet] = useState('');
   const [ipv4Dns, setIpv4Dns] = useState('');
+  const [enabledProtocols, setEnabledProtocols] = useState(0);
   const [fullNetworkConfig, setFullNetworkConfig] = useState<any>(null);
 
   // Power Config State
@@ -501,6 +502,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           setNtpServer(config.deviceConfig.network.ntpServer || '');
           setRsyslogServer(config.deviceConfig.network.rsyslogServer || '');
           setAddressMode(config.deviceConfig.network.addressMode ?? 0);
+          setEnabledProtocols(config.deviceConfig.network.enabledProtocols || 0);
           // Static IP config
           if (config.deviceConfig.network.ipv4Config) {
             setIpv4Address(config.deviceConfig.network.ipv4Config.ip || '');
@@ -1030,6 +1032,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         ntpServer,
         rsyslogServer,
         addressMode,
+        enabledProtocols,
         // Static IP config - only include if using static address mode
         ipv4Config: addressMode === 1 ? {
           ip: ipv4Address,
@@ -1718,6 +1721,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         if (net.wifiPsk !== undefined) setWifiPsk(net.wifiPsk);
         if (net.ntpServer !== undefined) setNtpServer(net.ntpServer);
         if (net.rsyslogServer !== undefined) setRsyslogServer(net.rsyslogServer);
+        if (net.enabledProtocols !== undefined) setEnabledProtocols(net.enabledProtocols);
         if (net.ipv4Config) {
           if (net.ipv4Config.ip !== undefined) setIpv4Address(net.ipv4Config.ip);
           if (net.ipv4Config.gateway !== undefined) setIpv4Gateway(net.ipv4Config.gateway);
@@ -2317,6 +2321,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             setRsyslogServer={setRsyslogServer}
             addressMode={addressMode}
             setAddressMode={setAddressMode}
+            enabledProtocols={enabledProtocols}
+            setEnabledProtocols={setEnabledProtocols}
             ipv4Address={ipv4Address}
             setIpv4Address={setIpv4Address}
             ipv4Gateway={ipv4Gateway}

--- a/src/components/configuration/NetworkConfigSection.test.tsx
+++ b/src/components/configuration/NetworkConfigSection.test.tsx
@@ -34,6 +34,8 @@ const baseProps = {
   setRsyslogServer: vi.fn(),
   addressMode: 0,
   setAddressMode: vi.fn(),
+  enabledProtocols: 0,
+  setEnabledProtocols: vi.fn(),
   ipv4Address: '',
   setIpv4Address: vi.fn(),
   ipv4Gateway: '',
@@ -62,5 +64,31 @@ describe('NetworkConfigSection — bridged-node inert notice', () => {
   it('does not render the notice when isBridged is omitted', () => {
     render(<NetworkConfigSection {...baseProps} />);
     expect(screen.queryByTestId('network-bridged-note')).toBeNull();
+  });
+});
+
+describe('NetworkConfigSection — UDP broadcast', () => {
+  it('renders unchecked when the UDP_BROADCAST bit (0x0001) is not set', () => {
+    const { container } = render(<NetworkConfigSection {...baseProps} enabledProtocols={0} />);
+    expect(container.querySelector('#udpBroadcastEnabled')).not.toBeChecked();
+  });
+
+  it('renders checked when the UDP_BROADCAST bit is set', () => {
+    const { container } = render(<NetworkConfigSection {...baseProps} enabledProtocols={1} />);
+    expect(container.querySelector('#udpBroadcastEnabled')).toBeChecked();
+  });
+
+  it('preserves other bits when toggling the UDP_BROADCAST bit on', () => {
+    const setEnabledProtocols = vi.fn();
+    const { container } = render(<NetworkConfigSection {...baseProps} enabledProtocols={0x0100} setEnabledProtocols={setEnabledProtocols} />);
+    container.querySelector<HTMLInputElement>('#udpBroadcastEnabled')!.click();
+    expect(setEnabledProtocols).toHaveBeenCalledWith(0x0101);
+  });
+
+  it('preserves other bits when toggling the UDP_BROADCAST bit off', () => {
+    const setEnabledProtocols = vi.fn();
+    const { container } = render(<NetworkConfigSection {...baseProps} enabledProtocols={0x0101} setEnabledProtocols={setEnabledProtocols} />);
+    container.querySelector<HTMLInputElement>('#udpBroadcastEnabled')!.click();
+    expect(setEnabledProtocols).toHaveBeenCalledWith(0x0100);
   });
 });

--- a/src/components/configuration/NetworkConfigSection.tsx
+++ b/src/components/configuration/NetworkConfigSection.tsx
@@ -8,6 +8,9 @@ const ADDRESS_MODE_OPTIONS = [
   { value: 1, label: 'STATIC' },
 ];
 
+// Config.NetworkConfig.ProtocolFlags — currently defines only the UDP_BROADCAST bit
+const UDP_BROADCAST_FLAG = 0x0001;
+
 interface NetworkConfigSectionProps {
   wifiEnabled: boolean;
   setWifiEnabled: (value: boolean) => void;
@@ -21,6 +24,9 @@ interface NetworkConfigSectionProps {
   setRsyslogServer: (value: string) => void;
   addressMode: number;
   setAddressMode: (value: number) => void;
+  // enabled_protocols bitmask (Config.NetworkConfig.ProtocolFlags) — UDP_BROADCAST is the only defined bit
+  enabledProtocols: number;
+  setEnabledProtocols: (value: number) => void;
   // Static IP config
   ipv4Address: string;
   setIpv4Address: (value: string) => void;
@@ -51,6 +57,8 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
   setRsyslogServer,
   addressMode,
   setAddressMode,
+  enabledProtocols,
+  setEnabledProtocols,
   ipv4Address,
   setIpv4Address,
   ipv4Gateway,
@@ -68,7 +76,7 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
 
   // Track initial values for change detection
   const initialValuesRef = useRef({
-    wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
+    wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode, enabledProtocols,
     ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns
   });
 
@@ -82,12 +90,13 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
       ntpServer !== initial.ntpServer ||
       rsyslogServer !== initial.rsyslogServer ||
       addressMode !== initial.addressMode ||
+      enabledProtocols !== initial.enabledProtocols ||
       ipv4Address !== initial.ipv4Address ||
       ipv4Gateway !== initial.ipv4Gateway ||
       ipv4Subnet !== initial.ipv4Subnet ||
       ipv4Dns !== initial.ipv4Dns
     );
-  }, [wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
+  }, [wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode, enabledProtocols,
       ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns]);
 
   // Reset to initial values (for SaveBar dismiss)
@@ -99,21 +108,22 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
     setNtpServer(initial.ntpServer);
     setRsyslogServer(initial.rsyslogServer);
     setAddressMode(initial.addressMode);
+    setEnabledProtocols(initial.enabledProtocols);
     setIpv4Address(initial.ipv4Address);
     setIpv4Gateway(initial.ipv4Gateway);
     setIpv4Subnet(initial.ipv4Subnet);
     setIpv4Dns(initial.ipv4Dns);
-  }, [setWifiEnabled, setWifiSsid, setWifiPsk, setNtpServer, setRsyslogServer, setAddressMode,
+  }, [setWifiEnabled, setWifiSsid, setWifiPsk, setNtpServer, setRsyslogServer, setAddressMode, setEnabledProtocols,
       setIpv4Address, setIpv4Gateway, setIpv4Subnet, setIpv4Dns]);
 
   // Update initial values after successful save
   const handleSave = useCallback(async () => {
     await onSave();
     initialValuesRef.current = {
-      wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
+      wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode, enabledProtocols,
       ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns
     };
-  }, [onSave, wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
+  }, [onSave, wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode, enabledProtocols,
       ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns]);
 
   // Register with SaveBar
@@ -379,6 +389,25 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
           maxLength={33}
           className="setting-input"
           style={{ width: '400px' }}
+        />
+      </div>
+
+      {/* UDP Broadcast */}
+      <div className="setting-item">
+        <label htmlFor="udpBroadcastEnabled">
+          {t('network_config.udp_broadcast')}
+          <span className="setting-description">{t('network_config.udp_broadcast_description')}</span>
+        </label>
+        <input
+          id="udpBroadcastEnabled"
+          type="checkbox"
+          checked={(enabledProtocols & UDP_BROADCAST_FLAG) !== 0}
+          onChange={(e) => setEnabledProtocols(
+            e.target.checked
+              ? enabledProtocols | UDP_BROADCAST_FLAG
+              : enabledProtocols & ~UDP_BROADCAST_FLAG
+          )}
+          className="setting-checkbox"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `Config.NetworkConfig.enabled_protocols` — the bitmask field behind the official app's "UDP Broadcast" toggle under Network settings (currently just the `UDP_BROADCAST` bit, `0x0001`) — was already read from the device into `fullNetworkConfig` (`ConfigurationTab.tsx`) but never surfaced as its own piece of state, so it had no checkbox in MeshMonitor's Configuration → Network section and could not be viewed or changed there.
- Adds `enabledProtocols` as tracked state in `ConfigurationTab.tsx` (load from device, include on save, handle in the config-import diff view) and a new "UDP Broadcast" checkbox in `NetworkConfigSection.tsx` that toggles the `UDP_BROADCAST` bit while preserving any other bits in the mask.
- Adds an `en.json` i18n entry pair (`network_config.udp_broadcast[_description]`); other locales fall back to English (`fallbackLng: 'en'`) until translated upstream via Weblate.

## Root cause
`NetworkConfigSection.tsx` never had a prop/field for `enabled_protocols`, and `ConfigurationTab.tsx`'s network-config load/save/import-diff logic only destructured the fields it explicitly modeled (`wifiEnabled`, `wifiSsid`, `wifiPsk`, `ntpServer`, `rsyslogServer`, `addressMode`, `ipv4Config`) — `enabledProtocols` was simply never added to that list, even though `NetworkConfig` protobuf pass-through in `protobufService.ts` already supported it end-to-end.

## Test plan
- [x] `npx vitest run src/components/configuration/NetworkConfigSection.test.tsx` — 7/7 passing (4 new tests covering unchecked/checked render + bit preservation on toggle on/off)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:ci` — ratchet OK, no new violations
- [ ] Full `npx vitest run` — in progress, will confirm in CI

Fixes #4112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNmJkhaAbNfcFVFg14et2h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNmJkhaAbNfcFVFg14et2h)_