### PR TITLE
fix(permissions): honor virtual-channel canRead grants on per-source surfaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -444,13 +444,24 @@ const location = useLocation();
     snrColors: schemeColors.snrColors,
   }), [themeColors, schemeColors]);
 
-  // Channel Database entries for displaying names of server-decrypted channels
+  // Channel Database entries for displaying names of server-decrypted channels.
+  // For non-admins the backend filters this to entries they may read, so a
+  // non-empty list also means "the user can read at least one virtual channel".
   const [channelDatabaseEntries, setChannelDatabaseEntries] = useState<ChannelDatabaseEntry[]>([]);
+  // Whether the channel-database fetch has completed at least once. Used to
+  // defer the Channels-tab permission redirect until virtual-channel access is
+  // known, so a virtual-channel-only user isn't bounced off #channels during
+  // the async load.
+  const [channelDatabaseLoaded, setChannelDatabaseLoaded] = useState(false);
 
-  // Fetch Channel Database entries when authenticated
+  // Fetch Channel Database entries (names for server-decrypted / virtual
+  // channels). Anonymous is a real permissioned account too: the backend
+  // honors its per-entry virtual-channel `canRead` grants and returns the
+  // PSK-masked list, so fetch regardless of login state (fails silently with
+  // 403 for users who have no virtual-channel access).
   useEffect(() => {
     const fetchChannelDatabaseEntries = async () => {
-      if (!authStatus?.authenticated) return;
+      if (!authStatus) return;
       try {
         const response = await api.getChannelDatabaseEntries();
         if (response.success && response.data) {
@@ -459,10 +470,12 @@ const location = useLocation();
       } catch (err) {
         // Channel database might not be accessible to all users, fail silently
         logger.debug('Failed to fetch channel database entries:', err);
+      } finally {
+        setChannelDatabaseLoaded(true);
       }
     };
     void fetchChannelDatabaseEntries();
-  }, [authStatus?.authenticated]);
+  }, [authStatus]);
 
   // Show news popup when authenticated user has unread news
   useEffect(() => {
@@ -641,14 +654,19 @@ const location = useLocation();
     const isAuthenticated = authStatus?.authenticated || false;
 
     // Mirrors Sidebar.tsx hasAnyChannelPermission — channels tab is reachable
-    // if the user can read at least one channel (channel_0..channel_7).
+    // if the user can read at least one channel: a physical slot
+    // (channel_0..channel_7) OR a virtual (Channel Database) channel. The
+    // backend filters channelDatabaseEntries to entries this user may read, so
+    // any entry present authorizes the Channels surface. This is what makes the
+    // tab reachable for virtual-channel-only users (e.g. anonymous on an MQTT
+    // source with per-entry canRead grants).
     const hasAnyChannelPermission = () => {
       for (let i = 0; i < 8; i++) {
         if (hasPermission(`channel_${i}` as ResourceType, 'read')) {
           return true;
         }
       }
-      return false;
+      return channelDatabaseEntries.length > 0;
     };
 
     // Define permission requirements for each protected tab.
@@ -680,11 +698,18 @@ const location = useLocation();
       ? (tabPermissions as Record<string, () => boolean>)[activeTab]
       : undefined;
     if (typeof permissionCheck === 'function' && !permissionCheck()) {
+      // The Channels tab may be authorized purely by virtual-channel access,
+      // which isn't known until the channel-database fetch resolves. Defer the
+      // redirect until then so a virtual-channel-only user isn't bounced off
+      // #channels during the async load.
+      if (activeTab === 'channels' && !channelDatabaseLoaded) {
+        return;
+      }
       // User doesn't have permission - redirect to nodes tab
       logger.info(`[Auth] Redirecting from '${activeTab}' tab - insufficient permissions`);
       setActiveTab('nodes');
     }
-  }, [activeTab, authStatus, authLoading, hasPermission, setActiveTab, packetLogEnabled, isMqttBridge]);
+  }, [activeTab, authStatus, authLoading, hasPermission, setActiveTab, packetLogEnabled, isMqttBridge, channelDatabaseEntries, channelDatabaseLoaded]);
 
   // Helper function to safely parse node IDs to node numbers
   const parseNodeId = useCallback((nodeId: string): number => {
@@ -4834,6 +4859,7 @@ const location = useLocation();
         connectedNodeName={connectedNodeName}
         packetLogEnabled={packetLogEnabled}
         onSearchClick={() => setIsSearchOpen(true)}
+        hasReadableVirtualChannels={channelDatabaseEntries.length > 0}
         mqttReadOnly={isMqttBridge}
       />
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -71,6 +71,13 @@ interface SidebarProps {
   connectedNodeName?: string;
   packetLogEnabled?: boolean;
   /**
+   * True when the user can read at least one virtual (Channel Database)
+   * channel. Lets the Channels entry appear for virtual-channel-only users
+   * (e.g. anonymous on an MQTT source with per-entry canRead grants) who hold
+   * no physical channel_0..7 permission.
+   */
+  hasReadableVirtualChannels?: boolean;
+  /**
    * When true (MQTT Bridge dashboard), hides Device Configuration and Remote
    * Administration entries. These device-level controls don't apply to data
    * sourced from an MQTT bridge.
@@ -92,6 +99,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   baseUrl,
   connectedNodeName,
   packetLogEnabled,
+  hasReadableVirtualChannels = false,
   mqttReadOnly = false,
 }) => {
   const { t } = useTranslation();
@@ -127,14 +135,15 @@ const Sidebar: React.FC<SidebarProps> = ({
     }
   };
 
-  // Check if user has permission to read ANY channel
+  // Check if user has permission to read ANY channel — a physical slot
+  // (channel_0..7) or a virtual (Channel Database) channel.
   const hasAnyChannelPermission = () => {
     for (let i = 0; i < 8; i++) {
       if (hasPermission(`channel_${i}` as ResourceType, 'read')) {
         return true;
       }
     }
-    return false;
+    return hasReadableVirtualChannels;
   };
 
   // Check if user has permission to search anything (DMs, channels, or meshcore)

--- a/src/components/Sidebar.virtualChannels.test.tsx
+++ b/src/components/Sidebar.virtualChannels.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression: the Channels nav entry must be reachable for users whose only
+ * channel access is to virtual (Channel Database) channels — e.g. an anonymous
+ * viewer granted per-entry `canRead` on an MQTT source. Previously
+ * `hasAnyChannelPermission` only checked physical slots `channel_0..7`, so such
+ * a user saw no Channels entry at all ("no Channels display").
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Sidebar from './Sidebar';
+import type { ResourceType } from '../types/permission';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => ({ iconStyle: 'lucide' }),
+}));
+
+const baseProps = {
+  activeTab: 'nodes' as const,
+  setActiveTab: vi.fn(),
+  isAdmin: false,
+  isAuthenticated: false, // anonymous
+  unreadCounts: {},
+  unreadCountsData: null,
+  onMessagesClick: vi.fn(),
+  onChannelsClick: vi.fn(),
+  baseUrl: '',
+};
+
+/** hasPermission that denies everything (no physical channel_0..7 grants). */
+const denyAll = () => false;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Sidebar — Channels entry visibility for virtual-channel-only users', () => {
+  it('hides Channels when the user has no physical and no virtual channel access', () => {
+    render(<Sidebar {...baseProps} hasPermission={denyAll} hasReadableVirtualChannels={false} />);
+    expect(screen.queryByTitle('nav.channels')).toBeNull();
+  });
+
+  it('shows Channels when the user can read a virtual channel (no physical grants)', () => {
+    render(<Sidebar {...baseProps} hasPermission={denyAll} hasReadableVirtualChannels={true} />);
+    expect(screen.queryByTitle('nav.channels')).not.toBeNull();
+  });
+
+  it('still shows Channels for a physical channel_0 grant (baseline unchanged)', () => {
+    const allowChannel0 = (resource: ResourceType, action: 'read' | 'write') =>
+      resource === 'channel_0' && action === 'read';
+    render(
+      <Sidebar {...baseProps} hasPermission={allowChannel0} hasReadableVirtualChannels={false} />,
+    );
+    expect(screen.queryByTitle('nav.channels')).not.toBeNull();
+  });
+});

--- a/src/server/routes/_channelDatabaseHandlers.ts
+++ b/src/server/routes/_channelDatabaseHandlers.ts
@@ -119,22 +119,27 @@ function forbidden(res: Response, message: string) {
 export async function getAllChannelsHandler(req: Request, res: Response) {
   try {
     const scope = await resolveCallerScope(req);
-    if (!scope.hasRead) {
-      return forbidden(res, 'channel_database:read permission required');
-    }
-
-    const allChannels = await databaseService.channelDatabase.getAllAsync();
     const includeFullPsk = scope.isAdmin || scope.hasWrite;
+    const allChannels = await databaseService.channelDatabase.getAllAsync();
 
     let visible = allChannels;
     if (!includeFullPsk) {
-      // Filter by per-entry canRead via channel_database_permissions
+      // Filter by per-entry canRead via channel_database_permissions.
       const perms = scope.userId !== null
         ? await databaseService.channelDatabase.getPermissionsForUserAsync(scope.userId)
         : [];
       const readable = new Set(
         perms.filter((p: any) => p.canRead === true).map((p: any) => p.channelDatabaseId)
       );
+      // A per-entry `canRead` grant is sufficient on its own to list the
+      // (PSK-masked) entry. The "Virtual Channel Permissions" UI writes only
+      // these per-entry grants, and MQTT channel access is defined entirely by
+      // them, so requiring the separate resource-level `channel_database:read`
+      // here would silently turn every such grant into a no-op. Only 403 when
+      // the caller has neither the resource read nor any per-entry grant.
+      if (!scope.hasRead && readable.size === 0) {
+        return forbidden(res, 'channel_database:read permission required');
+      }
       visible = allChannels.filter((ch: any) => readable.has(ch.id));
     }
 

--- a/src/server/routes/_channelDatabaseHandlers.ts
+++ b/src/server/routes/_channelDatabaseHandlers.ts
@@ -194,9 +194,11 @@ export async function getChannelByIdHandler(req: Request, res: Response) {
     }
 
     const scope = await resolveCallerScope(req);
-    if (!scope.hasRead) {
-      return forbidden(res, 'channel_database:read permission required');
-    }
+    // No resource-level `channel_database:read` gate here: consistent with the
+    // list endpoint, a per-entry `canRead` grant on this specific entry is
+    // sufficient to read it (the "Virtual Channel Permissions" UI writes only
+    // those per-entry grants). Non-writers without a canRead row fall through to
+    // the 404 below, which also masks the entry's existence.
 
     const channel = await databaseService.channelDatabase.getByIdAsync(id);
     if (!channel) {

--- a/src/server/routes/channelDatabaseRoutes.permissions.test.ts
+++ b/src/server/routes/channelDatabaseRoutes.permissions.test.ts
@@ -206,10 +206,27 @@ describe('Legacy mount — GET /:id permission filtering', () => {
     expect(res.status).toBe(404);
   });
 
-  it('non-admin without :read: returns 403', async () => {
+  it('non-admin WITHOUT resource :read but WITH per-entry canRead: returns entry (200, masked PSK)', async () => {
+    // Regression (consistency with GET /): a per-entry canRead grant alone is
+    // enough to read the specific entry — no resource-level channel_database:read
+    // required. No :read grant seeded here.
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionAsync').mockResolvedValue(
+      { userId: harness.limited.id, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any
+    );
+
     const agent = await harness.loginAs(harness.limited);
     const res = await agent.get('/api/channel-database/1');
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    expect(res.body.data.psk).toBeUndefined();
+    expect(res.body.data.pskPreview).toMatch(/\.\.\.$/);
+  });
+
+  it('non-admin with neither :read nor per-entry canRead: returns 404 (masks existence)', async () => {
+    // No grants; getPermissionAsync returns null (beforeEach default). The entry
+    // is hidden as 404 rather than 403 so its existence isn't revealed.
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database/1');
+    expect(res.status).toBe(404);
   });
 });
 

--- a/src/server/routes/channelDatabaseRoutes.permissions.test.ts
+++ b/src/server/routes/channelDatabaseRoutes.permissions.test.ts
@@ -148,6 +148,37 @@ describe('Legacy mount — GET / permission filtering', () => {
     const res = await agent.get('/api/channel-database');
     expect(res.status).toBe(403);
   });
+
+  it('non-admin without resource :read but WITH per-entry canRead: returns filtered list (200, masked PSK)', async () => {
+    // Regression: the "Virtual Channel Permissions" UI writes only per-entry
+    // canRead — it does NOT grant the resource-level channel_database:read. A
+    // user granted read on every virtual channel must still be able to list
+    // them, otherwise the grant is a silent no-op (the anonymous-MQTT bug).
+    // No channel_database:read grant seeded here.
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([
+      { userId: harness.limited.id, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any,
+    ]);
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.data[0].id).toBe(1);
+    // PSK stays masked — per-entry read never exposes the raw key.
+    expect(res.body.data[0].psk).toBeUndefined();
+    expect(res.body.data[0].pskPreview).toMatch(/\.\.\.$/);
+  });
+
+  it('non-admin with neither resource :read nor any per-entry canRead: returns 403', async () => {
+    // Per-entry row exists but canRead=false → not readable → still 403.
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([
+      { userId: harness.limited.id, channelDatabaseId: 1, canViewOnMap: false, canRead: false } as any,
+    ]);
+
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/api/channel-database');
+    expect(res.status).toBe(403);
+  });
 });
 
 // ── describe 3: GET /:id permission filtering ─────────────────────────────────

--- a/src/server/routes/channelDatabaseRoutes.permissions.test.ts
+++ b/src/server/routes/channelDatabaseRoutes.permissions.test.ts
@@ -179,6 +179,29 @@ describe('Legacy mount — GET / permission filtering', () => {
     const res = await agent.get('/api/channel-database');
     expect(res.status).toBe(403);
   });
+
+  it('ANONYMOUS (unauthenticated) with per-entry canRead: lists entries (200, not 401)', async () => {
+    // The read route uses optionalAuth, not requireAuth — an anonymous account
+    // with per-entry grants must reach the handler and get its filtered list,
+    // not hit a 401 auth wall. This is what populates the frontend Channels tab
+    // for anonymous viewers on an MQTT source.
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([
+      { userId: harness.anonymous.id, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any,
+    ]);
+
+    const agent = await harness.loginAs(null); // unauthenticated → anonymous user
+    const res = await agent.get('/api/channel-database');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.data[0].psk).toBeUndefined();
+  });
+
+  it('ANONYMOUS with no grants: GET / reaches the handler (403), not a 401 auth wall', async () => {
+    // getPermissionsForUserAsync default mock returns [] (beforeEach).
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/api/channel-database');
+    expect(res.status).toBe(403);
+  });
 });
 
 // ── describe 3: GET /:id permission filtering ─────────────────────────────────

--- a/src/server/routes/channelDatabaseRoutes.retroactiveDecrypt.test.ts
+++ b/src/server/routes/channelDatabaseRoutes.retroactiveDecrypt.test.ts
@@ -12,6 +12,7 @@ import request from 'supertest';
 
 vi.mock('../auth/authMiddleware.js', () => ({
   requireAuth: () => (_req: any, _res: any, next: any) => next(),
+  optionalAuth: () => (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock('../../services/database.js', () => ({

--- a/src/server/routes/channelDatabaseRoutes.ts
+++ b/src/server/routes/channelDatabaseRoutes.ts
@@ -8,7 +8,11 @@
  * `_channelDatabaseHandlers.ts` so the v1 (Bearer-token) and legacy
  * (browser-session) mounts stay in sync.
  *
- * Auth: `requireAuth()` (browser session) is applied below; per-endpoint
+ * Auth: read endpoints (`GET /`, `GET /:id`) use `optionalAuth()` so an
+ * anonymous — but real, permissioned — account can list/read the virtual
+ * channels it holds per-entry `canRead` on (the handlers enforce that access
+ * and mask PSKs). Mutations and the admin-only retroactive-decrypt progress
+ * require a real authenticated session via `requireAuth()`. Per-endpoint
  * permission checks happen inline inside each handler.
  *
  * NOTE: do NOT delete this file or its mount in `server.ts`. The UI is
@@ -17,7 +21,7 @@
  */
 
 import express from 'express';
-import { requireAuth } from '../auth/authMiddleware.js';
+import { requireAuth, optionalAuth } from '../auth/authMiddleware.js';
 import {
   getAllChannelsHandler,
   getRetroactiveDecryptProgressHandler,
@@ -34,23 +38,23 @@ import {
 
 const router = express.Router();
 
-// All routes require authentication
-router.use(requireAuth());
-
 // IMPORTANT: order matters — /retroactive-decrypt/progress and /reorder must
 // be defined before the `:id` and `:id/...` matches to avoid being shadowed.
-router.get('/', getAllChannelsHandler);
-router.get('/retroactive-decrypt/progress', getRetroactiveDecryptProgressHandler);
-router.get('/:id', getChannelByIdHandler);
-router.post('/', createChannelHandler);
-router.put('/reorder', reorderChannelsHandler);
-router.put('/:id', updateChannelHandler);
-router.delete('/:id', deleteChannelHandler);
-router.post('/:id/retroactive-decrypt', triggerRetroactiveDecryptHandler);
+//
+// Read routes use optionalAuth (anonymous may hold per-entry canRead grants);
+// every mutating/admin route requires a real authenticated session.
+router.get('/', optionalAuth(), getAllChannelsHandler);
+router.get('/retroactive-decrypt/progress', requireAuth(), getRetroactiveDecryptProgressHandler);
+router.get('/:id', optionalAuth(), getChannelByIdHandler);
+router.post('/', requireAuth(), createChannelHandler);
+router.put('/reorder', requireAuth(), reorderChannelsHandler);
+router.put('/:id', requireAuth(), updateChannelHandler);
+router.delete('/:id', requireAuth(), deleteChannelHandler);
+router.post('/:id/retroactive-decrypt', requireAuth(), triggerRetroactiveDecryptHandler);
 
 // Permission-management endpoints (channel_database:write)
-router.get('/:id/permissions', getChannelPermissionsHandler);
-router.put('/:id/permissions/:userId', setChannelPermissionHandler);
-router.delete('/:id/permissions/:userId', deleteChannelPermissionHandler);
+router.get('/:id/permissions', requireAuth(), getChannelPermissionsHandler);
+router.put('/:id/permissions/:userId', requireAuth(), setChannelPermissionHandler);
+router.delete('/:id/permissions/:userId', requireAuth(), deleteChannelPermissionHandler);
 
 export default router;

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -14,6 +14,10 @@ import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
 import { isMeshCoreManager } from '../sourceManagerTypes.js';
+import {
+  getUserReadableVirtualChannelIds,
+  canReadVirtualChannel,
+} from '../utils/virtualChannelPermissions.js';
 import { buildSourceDashboard, getMaxNodeAgeHours } from '../services/sourceDashboardData.js';
 import type { DbChannelDatabase, DbPacketLog } from '../../db/types.js';
 import type { DbMeshCorePacket } from '../../db/repositories/meshcore.js';
@@ -161,41 +165,6 @@ async function loadSourcePresetNames(sourceIds: string[]): Promise<Map<string, s
  *
  * Returns `null` when the id cannot be parsed to a valid packet id.
  */
-/**
- * Virtual channel read access.
- *
- * Virtual channels (MeshMonitor server-side PSKs stored in `channel_database`)
- * use a parallel permission table (`channel_database_permissions`) rather than
- * the generic `checkPermissionAsync` resource/action system used by physical
- * channels. Admins bypass the table; everyone else needs an explicit row with
- * `canRead = true`. The sentinel `'all'` avoids building a full-id set for
- * admins who can read every entry regardless.
- */
-type ReadableVirtualIds = Set<number> | 'all';
-
-async function getUserReadableVirtualChannelIds(
-  user: { id: number } | undefined,
-  isAdmin: boolean,
-): Promise<ReadableVirtualIds> {
-  if (isAdmin) return 'all';
-  if (!user) return new Set();
-  try {
-    const perms = await databaseService.channelDatabase.getPermissionsForUserAsync(user.id);
-    return new Set(
-      perms
-        .filter((p) => p.canRead)
-        .map((p) => p.channelDatabaseId),
-    );
-  } catch (err) {
-    logger.warn('Failed to load virtual channel permissions:', err);
-    return new Set();
-  }
-}
-
-function canReadVirtualChannel(vcId: number, readable: ReadableVirtualIds): boolean {
-  return readable === 'all' || readable.has(vcId);
-}
-
 async function loadEnabledVirtualChannels(): Promise<DbChannelDatabase[]> {
   try {
     const all = await databaseService.channelDatabase.getAllAsync();

--- a/src/server/routes/v1/channelDatabase.permissions.test.ts
+++ b/src/server/routes/v1/channelDatabase.permissions.test.ts
@@ -217,9 +217,27 @@ describe('GET /:id — single-entry permission filtering', () => {
     expect(res.status).toBe(404);
   });
 
-  it('non-admin without :read: returns 403', async () => {
+  it('non-admin WITHOUT resource :read but WITH per-entry canRead: returns channel, PSK masked', async () => {
+    // Consistency with GET / — a per-entry canRead grant alone is sufficient to
+    // read the specific entry; no resource-level channel_database:read required.
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    mockDb.channelDatabase.getPermissionAsync.mockResolvedValue({
+      userId: 60,
+      channelDatabaseId: 1,
+      canViewOnMap: false,
+      canRead: true,
+    });
+    const res = await request(createApp(readerUser)).get('/api/v1/channel-database/1');
+    expect(res.status).toBe(200);
+    expect(res.body.data.psk).toBeUndefined();
+    expect(res.body.data.pskPreview).toMatch(/\.\.\.$/);
+  });
+
+  it('non-admin with neither :read nor per-entry canRead: returns 404 (masks existence)', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    mockDb.channelDatabase.getPermissionAsync.mockResolvedValue(null);
     const res = await request(createApp(noPermsUser)).get('/api/v1/channel-database/1');
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 });
 

--- a/src/server/routes/v1/channelDatabase.test.ts
+++ b/src/server/routes/v1/channelDatabase.test.ts
@@ -151,9 +151,12 @@ describe('GET /api/v1/channel-database/:id', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 403 for non-admin', async () => {
+  it('returns 404 for non-admin without a per-entry canRead grant (masks existence)', async () => {
+    // GET /:id no longer requires resource-level channel_database:read — a
+    // per-entry canRead grant alone suffices (consistent with GET /). A caller
+    // with no grant gets 404 so the entry's existence isn't revealed.
     const res = await request(createApp(regularUser)).get('/api/v1/channel-database/1');
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it('returns 404 when channel not found', async () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -24,6 +24,13 @@ import { getSessionMiddleware } from './auth/sessionConfig.js';
 import { initializeWebSocket } from './services/webSocketService.js';
 import { initializeOIDC } from './auth/oidcAuth.js';
 import { optionalAuth, requireAuth, requirePermission, requireAdmin, hasPermission } from './auth/authMiddleware.js';
+import {
+  getUserReadableVirtualChannelIds,
+  canReadVirtualChannelNumber,
+  isVirtualChannelNumber,
+  virtualChannelDbId,
+  hasAnyReadableVirtualChannel,
+} from './utils/virtualChannelPermissions.js';
 import { transformChannel } from './utils/channelView.js';
 import { apiLimiter } from './middleware/rateLimiters.js';
 import { setupAccessLogger } from './middleware/accessLogger.js';
@@ -2309,10 +2316,16 @@ apiRouter.post('/nodes/scan-duplicate-keys', requirePermission('nodes', 'write')
 apiRouter.get('/messages', optionalAuth(), async (req, res) => {
   try {
     // Check if user has either any channel permission or messages permission
-    const hasChannelsRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
-    const hasMessagesRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
+    const isAdmin = req.user?.isAdmin === true;
+    const hasChannelsRead = isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
+    const hasMessagesRead = isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
+    // Virtual (Channel Database) channels are gated by per-entry `canRead`
+    // grants, not the channel_0..7 RBAC resources. Load them so virtual-channel
+    // readers — including MQTT-bridge and anonymous users — can see their
+    // messages instead of getting a blanket 403 / empty list.
+    const readableVirtual = await getUserReadableVirtualChannelIds(req.user, isAdmin);
 
-    if (!hasChannelsRead && !hasMessagesRead) {
+    if (!hasChannelsRead && !hasMessagesRead && !hasAnyReadableVirtualChannel(readableVirtual)) {
       return res.status(403).json({
         error: 'Insufficient permissions',
         code: 'FORBIDDEN',
@@ -2327,7 +2340,6 @@ apiRouter.get('/messages', optionalAuth(), async (req, res) => {
     // MM-SEC-3: pre-compute the channels this caller may read so we can
     // strip messages from hidden channels even when the caller has the
     // generic `channel_0:read` permission.
-    const isAdmin = req.user?.isAdmin === true;
     const authorizedChannelIds = new Set<number>();
     if (isAdmin) {
       for (let id = 0; id <= 7; id++) authorizedChannelIds.add(id);
@@ -2340,11 +2352,17 @@ apiRouter.get('/messages', optionalAuth(), async (req, res) => {
 
     // Filter messages based on permissions.
     // - DMs (channel -1) require `messages:read`.
-    // - Channel messages require BOTH the legacy `channel_0:read` gate
-    //   above AND a per-channel `channel_${id}:read` for the message's
-    //   actual channel.
+    // - Virtual (Channel Database) channels require a per-entry `canRead`
+    //   grant — the channel_0..7 gate can never authorize a >= CHANNEL_DB_OFFSET
+    //   slot.
+    // - Physical channel messages require BOTH the legacy `channel_0:read` gate
+    //   above AND a per-channel `channel_${id}:read` for the message's actual
+    //   channel.
     messages = messages.filter(msg => {
       if (msg.channel === -1) return hasMessagesRead;
+      if (isVirtualChannelNumber(msg.channel)) {
+        return isAdmin || canReadVirtualChannelNumber(msg.channel, readableVirtual);
+      }
       return hasChannelsRead && (isAdmin || authorizedChannelIds.has(msg.channel));
     });
 
@@ -2421,14 +2439,29 @@ apiRouter.get('/messages/channel/:channel', optionalAuth(), async (req, res) => 
       messageChannel = 0;
     }
 
-    // Check per-channel read permission
-    const channelResource = `channel_${messageChannel}` as import('../types/permission.js').ResourceType;
-    if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'read') : false)) {
-      return res.status(403).json({
-        error: 'Insufficient permissions',
-        code: 'FORBIDDEN',
-        required: { resource: channelResource, action: 'read' },
-      });
+    // Check per-channel read permission. Virtual (Channel Database) channels
+    // live at >= CHANNEL_DB_OFFSET and are gated by per-entry `canRead` grants
+    // rather than a `channel_${n}` RBAC resource (which is only defined for
+    // slots 0..7).
+    if (isVirtualChannelNumber(messageChannel)) {
+      const isAdmin = req.user?.isAdmin === true;
+      const readableVirtual = await getUserReadableVirtualChannelIds(req.user, isAdmin);
+      if (!isAdmin && !canReadVirtualChannelNumber(messageChannel, readableVirtual)) {
+        return res.status(403).json({
+          error: 'Insufficient permissions',
+          code: 'FORBIDDEN',
+          required: { resource: `channel_database:${virtualChannelDbId(messageChannel)}`, action: 'read' },
+        });
+      }
+    } else {
+      const channelResource = `channel_${messageChannel}` as import('../types/permission.js').ResourceType;
+      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'read') : false)) {
+        return res.status(403).json({
+          error: 'Insufficient permissions',
+          code: 'FORBIDDEN',
+          required: { resource: channelResource, action: 'read' },
+        });
+      }
     }
 
     // Fetch limit+1 to accurately detect if more messages exist. When a sourceId
@@ -2476,15 +2509,29 @@ apiRouter.post('/messages/mark-read', optionalAuth(), async (req, res) => {
     const { messageIds, channelId, nodeId, beforeTimestamp, allDMs, sourceId: markReadSourceId } = req.body;
     const markReadManager = resolveSourceManager(markReadSourceId);
 
-    // If marking by channelId, check per-channel read permission
+    // If marking by channelId, check per-channel read permission. Virtual
+    // (Channel Database) channels use per-entry `canRead` grants rather than a
+    // `channel_${n}` RBAC resource.
     if (channelId !== undefined && channelId !== null && channelId !== -1) {
-      const channelResource = `channel_${channelId}` as import('../types/permission.js').ResourceType;
-      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'read') : false)) {
-        return res.status(403).json({
-          error: 'Insufficient permissions',
-          code: 'FORBIDDEN',
-          required: { resource: channelResource, action: 'read' },
-        });
+      if (isVirtualChannelNumber(channelId)) {
+        const isAdmin = req.user?.isAdmin === true;
+        const readableVirtual = await getUserReadableVirtualChannelIds(req.user, isAdmin);
+        if (!isAdmin && !canReadVirtualChannelNumber(channelId, readableVirtual)) {
+          return res.status(403).json({
+            error: 'Insufficient permissions',
+            code: 'FORBIDDEN',
+            required: { resource: `channel_database:${virtualChannelDbId(channelId)}`, action: 'read' },
+          });
+        }
+      } else {
+        const channelResource = `channel_${channelId}` as import('../types/permission.js').ResourceType;
+        if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'read') : false)) {
+          return res.status(403).json({
+            error: 'Insufficient permissions',
+            code: 'FORBIDDEN',
+            required: { resource: channelResource, action: 'read' },
+          });
+        }
       }
     }
 
@@ -2539,10 +2586,16 @@ apiRouter.post('/messages/mark-read', optionalAuth(), async (req, res) => {
 apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
   try {
     // Check if user has either any channel permission or messages permission
-    const hasChannelsRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
-    const hasMessagesRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
+    const isAdmin = req.user?.isAdmin === true;
+    const hasChannelsRead = isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
+    const hasMessagesRead = isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
+    // Virtual (Channel Database) channels are gated by per-entry `canRead`
+    // grants; a virtual-channel-only reader still needs to reach the unread
+    // counts for those channels.
+    const readableVirtual = await getUserReadableVirtualChannelIds(req.user, isAdmin);
+    const hasVirtualRead = hasAnyReadableVirtualChannel(readableVirtual);
 
-    if (!hasChannelsRead && !hasMessagesRead) {
+    if (!hasChannelsRead && !hasMessagesRead && !hasVirtualRead) {
       return res.status(403).json({
         error: 'Insufficient permissions',
         code: 'FORBIDDEN',
@@ -2588,20 +2641,24 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
       }
     }
 
-    // Get channel unread counts if user has channels permission
-    // Only count incoming messages (exclude messages sent by our node)
-    if (hasChannelsRead) {
+    // Get channel unread counts if user can read any channel (physical or
+    // virtual). Only count incoming messages (exclude messages sent by our node).
+    if (hasChannelsRead || hasVirtualRead) {
       const rawCounts = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, unreadSourceId ?? ALL_SOURCES, excludeMqtt); // intentional cross-source when sourceId omitted
 
       // MM-SEC-3: filter by per-channel read permission as well as mute prefs.
       // The bare `channel_0:read` gate above lets a viewer reach this handler
       // but they must not learn unread counts for channels they cannot read.
-      const isAdmin = req.user?.isAdmin === true;
+      // Virtual (Channel Database) channels use per-entry `canRead` grants.
       const channels: { [channelId: number]: number } = {};
       for (const [channelIdStr, count] of Object.entries(rawCounts)) {
         const channelId = Number(channelIdStr);
         if (mutedChannelIds.has(channelId)) continue;
-        if (!isAdmin && req.user) {
+        if (isVirtualChannelNumber(channelId)) {
+          if (!isAdmin && !canReadVirtualChannelNumber(channelId, readableVirtual)) continue;
+        } else if (!hasChannelsRead) {
+          continue;
+        } else if (!isAdmin && req.user) {
           const channelResource = `channel_${channelId}` as import('../types/permission.js').ResourceType;
           if (!(await hasPermission(req.user, channelResource, 'read'))) continue;
         } else if (!req.user && !isAdmin) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2361,7 +2361,9 @@ apiRouter.get('/messages', optionalAuth(), async (req, res) => {
     messages = messages.filter(msg => {
       if (msg.channel === -1) return hasMessagesRead;
       if (isVirtualChannelNumber(msg.channel)) {
-        return isAdmin || canReadVirtualChannelNumber(msg.channel, readableVirtual);
+        // readableVirtual resolves to 'all' for admins, so this already grants
+        // them every virtual channel — no separate isAdmin short-circuit needed.
+        return canReadVirtualChannelNumber(msg.channel, readableVirtual);
       }
       return hasChannelsRead && (isAdmin || authorizedChannelIds.has(msg.channel));
     });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2905,6 +2905,12 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
     const hasMessagesRead = checkPerm('messages', 'read');
     const hasInfoRead = checkPerm('info', 'read');
     const canViewPrivate = checkPerm('nodes_private', 'read');
+    // Virtual (Channel Database) channels are gated by per-entry `canRead`
+    // grants, not the channel_0..7 RBAC resources. Load them so a
+    // virtual-channel-only caller (e.g. anonymous on an MQTT bridge) sees the
+    // messages/channels feeding the per-source Channels tab.
+    const readableVirtual = await getUserReadableVirtualChannelIds(user, user?.isAdmin === true);
+    const hasVirtualRead = hasAnyReadableVirtualChannel(readableVirtual);
 
     // 1. Connection status (always available)
     // If the caller named a sourceId but the registry has no manager for it
@@ -2945,9 +2951,10 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       result.nodes = [];
     }
 
-    // 3. Messages (requires any channel permission OR messages permission)
+    // 3. Messages (requires any channel permission OR messages permission OR
+    //    a readable virtual channel)
     try {
-      if (hasChannelsRead || hasMessagesRead) {
+      if (hasChannelsRead || hasMessagesRead || hasVirtualRead) {
         // Scope messages to the requesting source. Per-source tabs must only
         // see messages their own source actually ingested — cross-source
         // visibility belongs in the dedicated unified views (/unified/messages).
@@ -2985,6 +2992,10 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
         //   per-channel `channel_${id}:read` for the message's actual channel.
         messages = messages.filter(msg => {
           if (msg.channel === -1) return hasMessagesRead;
+          // Virtual channels use per-entry canRead, independent of channel_0..7.
+          if (isVirtualChannelNumber(msg.channel)) {
+            return canReadVirtualChannelNumber(msg.channel, readableVirtual);
+          }
           return hasChannelsRead && (isAdminCaller || authorizedChannelIds.has(msg.channel));
         });
 
@@ -3012,8 +3023,10 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       const filteredUnreadChannels: { [channelId: number]: number } = {};
       for (const [channelIdStr, count] of Object.entries(allUnreadChannels)) {
         const channelId = parseInt(channelIdStr);
-        const channelResource = `channel_${channelId}` as import('../types/permission.js').ResourceType;
-        const hasChannelRead = checkPerm(channelResource, 'read');
+        // Virtual channels use per-entry canRead; physical channels use RBAC.
+        const hasChannelRead = isVirtualChannelNumber(channelId)
+          ? canReadVirtualChannelNumber(channelId, readableVirtual)
+          : checkPerm(`channel_${channelId}` as import('../types/permission.js').ResourceType, 'read');
 
         if (hasChannelRead) {
           filteredUnreadChannels[channelId] = count;

--- a/src/server/utils/virtualChannelPermissions.test.ts
+++ b/src/server/utils/virtualChannelPermissions.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the shared virtual-channel (Channel Database) read-permission
+ * helpers. These are the single source of truth consulted by the unified
+ * routes, the legacy per-source `/api/messages*` endpoints, and the
+ * channel-database list handler, so their correctness gates every surface that
+ * decides whether a virtual channel is readable.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import databaseService from '../../services/database.js';
+import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+import {
+  getUserReadableVirtualChannelIds,
+  canReadVirtualChannel,
+  canReadVirtualChannelNumber,
+  isVirtualChannelNumber,
+  virtualChannelDbId,
+  hasAnyReadableVirtualChannel,
+} from './virtualChannelPermissions.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isVirtualChannelNumber / virtualChannelDbId', () => {
+  it('treats slots >= CHANNEL_DB_OFFSET as virtual and maps back to the db id', () => {
+    expect(isVirtualChannelNumber(0)).toBe(false);
+    expect(isVirtualChannelNumber(7)).toBe(false);
+    expect(isVirtualChannelNumber(-1)).toBe(false); // DM sentinel
+    expect(isVirtualChannelNumber(CHANNEL_DB_OFFSET)).toBe(true);
+    expect(isVirtualChannelNumber(CHANNEL_DB_OFFSET + 5)).toBe(true);
+    expect(virtualChannelDbId(CHANNEL_DB_OFFSET + 5)).toBe(5);
+    expect(virtualChannelDbId(CHANNEL_DB_OFFSET)).toBe(0);
+  });
+});
+
+describe('canReadVirtualChannel / canReadVirtualChannelNumber', () => {
+  it('admin sentinel "all" reads everything', () => {
+    expect(canReadVirtualChannel(3, 'all')).toBe(true);
+    expect(canReadVirtualChannelNumber(CHANNEL_DB_OFFSET + 99, 'all')).toBe(true);
+  });
+
+  it('a Set grants only the ids it contains', () => {
+    const readable = new Set([2, 5]);
+    expect(canReadVirtualChannel(2, readable)).toBe(true);
+    expect(canReadVirtualChannel(3, readable)).toBe(false);
+    // by synthetic channel number
+    expect(canReadVirtualChannelNumber(CHANNEL_DB_OFFSET + 5, readable)).toBe(true);
+    expect(canReadVirtualChannelNumber(CHANNEL_DB_OFFSET + 3, readable)).toBe(false);
+  });
+
+  it('an empty Set grants nothing', () => {
+    expect(canReadVirtualChannel(0, new Set())).toBe(false);
+    expect(canReadVirtualChannelNumber(CHANNEL_DB_OFFSET, new Set())).toBe(false);
+  });
+});
+
+describe('hasAnyReadableVirtualChannel', () => {
+  it('is true for "all" and non-empty sets, false for empty', () => {
+    expect(hasAnyReadableVirtualChannel('all')).toBe(true);
+    expect(hasAnyReadableVirtualChannel(new Set([1]))).toBe(true);
+    expect(hasAnyReadableVirtualChannel(new Set())).toBe(false);
+  });
+});
+
+describe('getUserReadableVirtualChannelIds', () => {
+  it('returns "all" for admins without touching the DB', async () => {
+    const spy = vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync');
+    const result = await getUserReadableVirtualChannelIds({ id: 1 }, true);
+    expect(result).toBe('all');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty set for anonymous/undefined user', async () => {
+    const result = await getUserReadableVirtualChannelIds(undefined, false);
+    expect(result).toEqual(new Set());
+  });
+
+  it('returns only the ids with canRead=true', async () => {
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockResolvedValue([
+      { userId: 7, channelDatabaseId: 1, canViewOnMap: false, canRead: true } as any,
+      { userId: 7, channelDatabaseId: 2, canViewOnMap: true, canRead: false } as any,
+      { userId: 7, channelDatabaseId: 3, canViewOnMap: false, canRead: true } as any,
+    ]);
+    const result = await getUserReadableVirtualChannelIds({ id: 7 }, false);
+    expect(result).toEqual(new Set([1, 3]));
+  });
+
+  it('fails safe (empty set) when the permission lookup throws', async () => {
+    vi.spyOn(databaseService.channelDatabase, 'getPermissionsForUserAsync').mockRejectedValue(
+      new Error('db down'),
+    );
+    const result = await getUserReadableVirtualChannelIds({ id: 7 }, false);
+    expect(result).toEqual(new Set());
+  });
+});

--- a/src/server/utils/virtualChannelPermissions.ts
+++ b/src/server/utils/virtualChannelPermissions.ts
@@ -1,0 +1,74 @@
+/**
+ * Virtual channel (Channel Database) read-permission helpers.
+ *
+ * Virtual channels are MeshMonitor server-side PSKs stored in `channel_database`
+ * and surfaced on the synthetic channel number `CHANNEL_DB_OFFSET + id`. Unlike
+ * physical channels (`channel_0..7`, gated by the generic resource/action RBAC),
+ * their read access lives in a parallel per-entry table
+ * (`channel_database_permissions.canRead`). Admins bypass the table.
+ *
+ * These helpers are the single source of truth for that check, shared by the
+ * unified routes, the legacy per-source `/api/messages*` endpoints, and the
+ * channel-database list handler so every surface honors the same grants.
+ */
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+
+/**
+ * Set of channel-database ids the caller may read, or the sentinel `'all'` for
+ * admins (avoids materializing every id).
+ */
+export type ReadableVirtualIds = Set<number> | 'all';
+
+/**
+ * Resolve the set of virtual-channel ids the user may read. Admins → `'all'`,
+ * anonymous/unknown users → empty set, everyone else → their `canRead=true`
+ * rows from `channel_database_permissions`.
+ */
+export async function getUserReadableVirtualChannelIds(
+  user: { id: number } | undefined | null,
+  isAdmin: boolean,
+): Promise<ReadableVirtualIds> {
+  if (isAdmin) return 'all';
+  if (!user) return new Set();
+  try {
+    const perms = await databaseService.channelDatabase.getPermissionsForUserAsync(user.id);
+    return new Set(perms.filter((p) => p.canRead).map((p) => p.channelDatabaseId));
+  } catch (err) {
+    logger.warn('Failed to load virtual channel permissions:', err);
+    return new Set();
+  }
+}
+
+/** True if the caller may read the virtual channel with database id `vcId`. */
+export function canReadVirtualChannel(vcId: number, readable: ReadableVirtualIds): boolean {
+  return readable === 'all' || readable.has(vcId);
+}
+
+/** True if `channelNumber` refers to a virtual (channel-database) channel. */
+export function isVirtualChannelNumber(channelNumber: number): boolean {
+  return channelNumber >= CHANNEL_DB_OFFSET;
+}
+
+/** Map a synthetic virtual channel number back to its `channel_database` id. */
+export function virtualChannelDbId(channelNumber: number): number {
+  return channelNumber - CHANNEL_DB_OFFSET;
+}
+
+/**
+ * Whether the caller may read a message on `channelNumber`, where
+ * `channelNumber` is a virtual channel (>= `CHANNEL_DB_OFFSET`). Maps the
+ * synthetic number back to its database id before consulting `readable`.
+ */
+export function canReadVirtualChannelNumber(
+  channelNumber: number,
+  readable: ReadableVirtualIds,
+): boolean {
+  return canReadVirtualChannel(channelNumber - CHANNEL_DB_OFFSET, readable);
+}
+
+/** True if the caller can read at least one virtual channel. */
+export function hasAnyReadableVirtualChannel(readable: ReadableVirtualIds): boolean {
+  return readable === 'all' || readable.size > 0;
+}


### PR DESCRIPTION
## Problem

On an MQTT source, granting a user **Read Messages for every virtual channel** (the *Virtual Channel Permissions* section in User admin) had no effect — opening that source as that user (e.g. **anonymous**) showed **no Channels display at all**.

Virtual (Channel Database) channels are gated by per-entry `canRead` rows in `channel_database_permissions`, surfaced at synthetic channel numbers `CHANNEL_DB_OFFSET + id`. Those grants were honored by the newer `/api/unified/*` routes, but **ignored** by the legacy per-source message endpoints and the frontend tab-gating, across four independent gates:

| Gate | Where | Effect |
|------|-------|--------|
| A | `App.tsx` fetch skipped for anonymous | virtual-channel names/entries never loaded |
| B | `GET /api/channel-database` required resource-level `channel_database:read` | per-entry `canRead` alone → 403, so the UI toggle was a no-op |
| C | `/api/messages*` checked `channel_${100+}` (never a real resource) | virtual-channel messages stripped / 403 |
| D | `hasAnyChannelPermission` (App + Sidebar) only checked `channel_0..7` | **Channels tab hidden and redirected away** — the visible symptom |

## Fix

**Backend**
- New shared helper `src/server/utils/virtualChannelPermissions.ts`, extracted from the private copies in `unifiedRoutes.ts` (which now imports them — single source of truth).
- `GET /api/messages`, `/api/messages/channel/:channel`, `/api/messages/unread-counts`, `POST /api/messages/mark-read` now consult per-entry `canRead` for channels `>= CHANNEL_DB_OFFSET`.
- `GET /api/channel-database` lists the **PSK-masked** entries for a caller holding only per-entry `canRead` (no resource-level read required). PSK is still only revealed to admins / `channel_database:write`.

**Frontend**
- `App.tsx`: anonymous (a real permissioned account) fetches channel-database entries; `hasAnyChannelPermission` and the tab-redirect guard count readable virtual channels, deferred until the fetch resolves to avoid a redirect race.
- `Sidebar.tsx`: Channels nav entry appears for virtual-channel-only users via a new `hasReadableVirtualChannels` prop.

## Tests
- `virtualChannelPermissions.test.ts` — helper unit tests (admin sentinel, empty/anon, `canRead` filtering, fail-safe).
- `channelDatabaseRoutes.permissions.test.ts` — regression: per-entry-only caller lists masked entries (200); neither grant → 403.
- `Sidebar.virtualChannels.test.tsx` — Channels entry visible for virtual-channel-only users, baseline (physical grant) unchanged.

Full Vitest suite green (9738 tests, 0 failures); typecheck + `lint:ci` ratchet pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)