### PR TITLE
fix(auth): drop legacy auth_provider CHECK constraint on SQLite upgrades

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -132,6 +132,7 @@ import { migration as meshcorePathfindingTargetsMigration, runMigration114Postgr
 import { migration as dropInlineNotifPrefsUserIdUniqueMigration, runMigration115Postgres as runDropInlineNotifPrefsUserIdUniquePostgres, runMigration115Mysql as runDropInlineNotifPrefsUserIdUniqueMysql } from '../server/migrations/115_drop_inline_notif_prefs_user_id_unique.js';
 import { migration as trimOutOfRangeNodePositionsMigration, runMigration116Postgres as runTrimOutOfRangeNodePositionsPostgres, runMigration116Mysql as runTrimOutOfRangeNodePositionsMysql } from '../server/migrations/116_trim_out_of_range_node_positions.js';
 import { migration as dropUpgradeHistoryMigration, runMigration117Postgres as runDropUpgradeHistoryPostgres, runMigration117Mysql as runDropUpgradeHistoryMysql } from '../server/migrations/117_drop_upgrade_history.js';
+import { migration as dropLegacyAuthProviderCheckMigration, runMigration118Postgres as runDropLegacyAuthProviderCheckPostgres, runMigration118Mysql as runDropLegacyAuthProviderCheckMysql } from '../server/migrations/118_drop_legacy_auth_provider_check.js';
 
 // ============================================================================
 // Registry
@@ -1864,4 +1865,18 @@ registry.register({
   sqlite: (db) => dropUpgradeHistoryMigration.up(db),
   postgres: (client) => runDropUpgradeHistoryPostgres(client),
   mysql: (pool) => runDropUpgradeHistoryMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 118: Drop legacy CHECK (auth_provider IN ('local', 'oidc'))
+// from SQLite `users` so proxy auth (#4119) can insert authProvider='proxy'.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 118,
+  name: 'drop_legacy_auth_provider_check',
+  settingsKey: 'migration_118_drop_legacy_auth_provider_check',
+  sqlite: (db) => dropLegacyAuthProviderCheckMigration.up(db),
+  postgres: (client) => runDropLegacyAuthProviderCheckPostgres(client),
+  mysql: (pool) => runDropLegacyAuthProviderCheckMysql(pool),
 });

--- a/src/server/migrations/118_drop_legacy_auth_provider_check.test.ts
+++ b/src/server/migrations/118_drop_legacy_auth_provider_check.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Migration 118 — Drop legacy `CHECK (auth_provider IN ('local', 'oidc'))`
+ * from SQLite `users`.
+ *
+ * Asserts:
+ *   - on a database created with the legacy CHECK, the migration rebuilds
+ *     the table and the constraint is gone (authMethod = 'proxy' now inserts).
+ *   - existing rows + ids are preserved across the rebuild.
+ *   - on a database without the CHECK (v3.7+ baseline), the migration is a
+ *     no-op and leaves the table untouched.
+ *   - re-running is idempotent (second pass is a no-op).
+ *   - PG / MySQL paths are no-ops (no constraint to drop there).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  migration,
+  runMigration118Postgres,
+  runMigration118Mysql,
+} from './118_drop_legacy_auth_provider_check.js';
+
+// Mirrors a pre-v3.7 `users` schema, including the legacy CHECK constraint
+// removed by the v3.7 baseline.
+function createLegacyUsersTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      password_hash TEXT,
+      email TEXT,
+      display_name TEXT,
+      auth_provider TEXT NOT NULL DEFAULT 'local',
+      oidc_subject TEXT,
+      is_admin INTEGER NOT NULL DEFAULT 0,
+      is_active INTEGER NOT NULL DEFAULT 1,
+      password_locked INTEGER DEFAULT 0,
+      mfa_enabled INTEGER NOT NULL DEFAULT 0,
+      mfa_secret TEXT,
+      mfa_backup_codes TEXT,
+      created_at INTEGER NOT NULL,
+      last_login_at INTEGER,
+      created_by INTEGER,
+      updated_at INTEGER,
+      CHECK (auth_provider IN ('local', 'oidc'))
+    );
+  `);
+}
+
+// Mirrors the v3.7 baseline shape — no CHECK constraint on auth_provider.
+function createBaselineUsersTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      password_hash TEXT,
+      email TEXT,
+      display_name TEXT,
+      auth_provider TEXT NOT NULL DEFAULT 'local',
+      oidc_subject TEXT,
+      is_admin INTEGER NOT NULL DEFAULT 0,
+      is_active INTEGER NOT NULL DEFAULT 1,
+      password_locked INTEGER DEFAULT 0,
+      mfa_enabled INTEGER NOT NULL DEFAULT 0,
+      mfa_secret TEXT,
+      mfa_backup_codes TEXT,
+      created_at INTEGER NOT NULL,
+      last_login_at INTEGER,
+      created_by INTEGER,
+      updated_at INTEGER
+    );
+  `);
+}
+
+function getUsersSql(db: Database.Database): string {
+  const row = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='users'`)
+    .get() as { sql?: string } | undefined;
+  return row?.sql ?? '';
+}
+
+describe('Migration 118 — drop legacy auth_provider CHECK constraint', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  it('rebuilds a legacy table and removes the CHECK constraint', () => {
+    createLegacyUsersTable(db);
+
+    // Sanity check: legacy table rejects authProvider = 'proxy' before the migration.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO users (username, auth_provider, created_at)
+             VALUES ('proxyuser', 'proxy', 0)`,
+        )
+        .run(),
+    ).toThrow(/CHECK constraint failed/);
+
+    migration.up(db);
+
+    const sql = getUsersSql(db);
+    expect(sql).not.toMatch(/auth_provider IN \('local', 'oidc'\)/);
+    expect(sql).not.toMatch(/CHECK\s*\([^)]*auth_provider/i);
+
+    // Now the proxy auto-provisioning insert succeeds.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO users (username, auth_provider, created_at)
+             VALUES ('proxyuser', 'proxy', 0)`,
+        )
+        .run(),
+    ).not.toThrow();
+
+    const row = db
+      .prepare(`SELECT username, auth_provider FROM users WHERE username = 'proxyuser'`)
+      .get() as { username: string; auth_provider: string };
+    expect(row).toEqual({ username: 'proxyuser', auth_provider: 'proxy' });
+  });
+
+  it('preserves existing rows + ids across the rebuild', () => {
+    createLegacyUsersTable(db);
+
+    db.prepare(
+      `INSERT INTO users (id, username, auth_provider, created_at)
+         VALUES (?, ?, ?, ?)`,
+    ).run(5, 'admin', 'local', 0);
+    db.prepare(
+      `INSERT INTO users (id, username, auth_provider, created_at)
+         VALUES (?, ?, ?, ?)`,
+    ).run(8, 'ssouser', 'oidc', 0);
+
+    migration.up(db);
+
+    const rows = db
+      .prepare(`SELECT id, username, auth_provider FROM users ORDER BY id`)
+      .all() as Array<{ id: number; username: string; auth_provider: string }>;
+    expect(rows).toEqual([
+      { id: 5, username: 'admin', auth_provider: 'local' },
+      { id: 8, username: 'ssouser', auth_provider: 'oidc' },
+    ]);
+  });
+
+  it('is a no-op on a v3.7 baseline table', () => {
+    createBaselineUsersTable(db);
+    const before = getUsersSql(db);
+
+    migration.up(db);
+
+    const after = getUsersSql(db);
+    expect(after).toBe(before);
+  });
+
+  it('is idempotent — second run after a rebuild is a no-op', () => {
+    createLegacyUsersTable(db);
+    migration.up(db);
+    const afterFirst = getUsersSql(db);
+
+    migration.up(db);
+    const afterSecond = getUsersSql(db);
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('handles legacy schemas missing later-added columns', () => {
+    // Some very early pre-v3.7 schemas lacked updated_at / created_by (added
+    // by later migrations whose work is now folded into the baseline).
+    db.exec(`
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE NOT NULL,
+        password_hash TEXT,
+        email TEXT,
+        display_name TEXT,
+        auth_provider TEXT NOT NULL DEFAULT 'local',
+        oidc_subject TEXT,
+        is_admin INTEGER NOT NULL DEFAULT 0,
+        is_active INTEGER NOT NULL DEFAULT 1,
+        mfa_enabled INTEGER NOT NULL DEFAULT 0,
+        mfa_secret TEXT,
+        mfa_backup_codes TEXT,
+        created_at INTEGER NOT NULL,
+        last_login_at INTEGER,
+        CHECK (auth_provider IN ('local', 'oidc'))
+      );
+    `);
+    db.prepare(
+      `INSERT INTO users (id, username, auth_provider, created_at)
+         VALUES (?, ?, ?, ?)`,
+    ).run(1, 'old', 'local', 0);
+
+    expect(() => migration.up(db)).not.toThrow();
+
+    const row = db
+      .prepare(`SELECT id, username, auth_provider, is_active FROM users`)
+      .get() as Record<string, number | string>;
+    expect(row.id).toBe(1);
+    expect(row.username).toBe('old');
+    expect(row.auth_provider).toBe('local');
+    expect(row.is_active).toBe(1);
+  });
+
+  it('PostgreSQL and MySQL paths are no-ops', async () => {
+    await expect(runMigration118Postgres({} as unknown as never)).resolves.toBeUndefined();
+    await expect(runMigration118Mysql({} as unknown as never)).resolves.toBeUndefined();
+  });
+});

--- a/src/server/migrations/118_drop_legacy_auth_provider_check.ts
+++ b/src/server/migrations/118_drop_legacy_auth_provider_check.ts
@@ -1,0 +1,129 @@
+/**
+ * Migration 118: Drop the legacy `CHECK (auth_provider IN ('local', 'oidc'))`
+ * constraint from `users` on SQLite installs that pre-date the v3.7 baseline.
+ *
+ * Proxy auth (`PROXY_AUTH_ENABLED=true`, issue #4119) auto-provisions/migrates
+ * users with `authMethod: 'proxy'`, which Drizzle writes to the `auth_provider`
+ * column. On databases created before the v3.7 baseline (migration 001), the
+ * `users` table carries an old CHECK constraint that only permits `local` or
+ * `oidc`, so the insert/update fails:
+ *
+ *   SqliteError: CHECK constraint failed: auth_provider IN ('local', 'oidc')
+ *
+ * The v3.7 baseline `CREATE TABLE IF NOT EXISTS users` (migration 001) has no
+ * such constraint, but `IF NOT EXISTS` leaves pre-existing tables untouched,
+ * so upgraded installs keep the legacy constraint forever without an explicit
+ * rebuild.
+ *
+ * This migration:
+ *   - SQLite: detects the legacy CHECK by inspecting `sqlite_master.sql`,
+ *     and if present rebuilds the table without it (preserves rows + ids).
+ *   - PostgreSQL / MySQL: no-op. The constraint only ever lived in SQLite.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 118';
+const TABLE = 'users';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const row = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(TABLE) as { sql?: string } | undefined;
+    const sql = row?.sql ?? '';
+
+    const hasLegacyCheck = /CHECK\s*\([^)]*auth_provider[^)]*\)/i.test(sql);
+    if (!hasLegacyCheck) {
+      logger.debug(`${LABEL} (SQLite): no legacy auth_provider CHECK on ${TABLE}, skipping`);
+      return;
+    }
+
+    logger.info(`${LABEL} (SQLite): rebuilding ${TABLE} to drop legacy auth_provider CHECK constraint`);
+
+    // SQLite cannot drop a CHECK constraint in place. Standard table-rebuild
+    // dance: create a new table with the desired schema, copy rows, drop the
+    // old table, rename. FK enforcement is toggled off so dropping the table
+    // doesn't trip references from permissions/audit_log/etc, then re-enabled.
+    const fkOn = (db.pragma('foreign_keys', { simple: true }) as 0 | 1) === 1;
+    if (fkOn) db.pragma('foreign_keys = OFF');
+
+    try {
+      db.exec(`
+        CREATE TABLE users_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          username TEXT UNIQUE NOT NULL,
+          password_hash TEXT,
+          email TEXT,
+          display_name TEXT,
+          auth_provider TEXT NOT NULL DEFAULT 'local',
+          oidc_subject TEXT,
+          is_admin INTEGER NOT NULL DEFAULT 0,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          password_locked INTEGER DEFAULT 0,
+          mfa_enabled INTEGER NOT NULL DEFAULT 0,
+          mfa_secret TEXT,
+          mfa_backup_codes TEXT,
+          created_at INTEGER NOT NULL,
+          last_login_at INTEGER,
+          created_by INTEGER,
+          updated_at INTEGER
+        )
+      `);
+
+      // Build the column list from the legacy table's actual columns so the
+      // copy works against any historical shape (some very old schemas may
+      // be missing later-added columns like updated_at or created_by).
+      const legacyCols = (
+        db.prepare(`PRAGMA table_info(${TABLE})`).all() as Array<{ name: string }>
+      ).map((c) => c.name);
+      const newCols = [
+        'id',
+        'username',
+        'password_hash',
+        'email',
+        'display_name',
+        'auth_provider',
+        'oidc_subject',
+        'is_admin',
+        'is_active',
+        'password_locked',
+        'mfa_enabled',
+        'mfa_secret',
+        'mfa_backup_codes',
+        'created_at',
+        'last_login_at',
+        'created_by',
+        'updated_at',
+      ];
+      const shared = newCols.filter((c) => legacyCols.includes(c));
+      const colList = shared.join(', ');
+      db.exec(`INSERT INTO users_new (${colList}) SELECT ${colList} FROM ${TABLE}`);
+
+      db.exec(`DROP TABLE ${TABLE}`);
+      db.exec(`ALTER TABLE users_new RENAME TO ${TABLE}`);
+
+      logger.debug(`${LABEL} (SQLite): rebuild complete`);
+    } finally {
+      if (fkOn) db.pragma('foreign_keys = ON');
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (re-adding the legacy CHECK would re-break proxy auth)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration118Postgres(_client: import('pg').PoolClient): Promise<void> {
+  logger.debug(`${LABEL} (PostgreSQL): no-op (auth_provider CHECK constraint never existed in PG schema)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration118Mysql(_pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.debug(`${LABEL} (MySQL): no-op (auth_provider CHECK constraint never existed in MySQL schema)`);
+}


### PR DESCRIPTION
## Summary

Fixes #4119.

Databases created before the v3.7 baseline (migration 001) had a `CHECK (auth_provider IN ('local', 'oidc'))` constraint on `users` — `CREATE TABLE IF NOT EXISTS` in the baseline migration never touches pre-existing tables, so any pre-v4.13 SQLite install keeps this constraint forever. Proxy auth auto-provisioning (`PROXY_AUTH_ENABLED=true`) writes `authMethod: 'proxy'` (`src/server/auth/authMiddleware.ts:58,113`), which trips the stale constraint:

```
SqliteError: CHECK constraint failed: auth_provider IN ('local', 'oidc')
```

The current baseline schema and Drizzle schema (`src/db/schema/auth.ts`) have no such constraint — this only affects installs upgraded from before the baseline. There's precedent for the exact same class of bug: migration 071 fixed an analogous stale `CHECK (psk_length IN (16, 32))` constraint on `channel_database` the same way.

## Changes

- **`src/server/migrations/118_drop_legacy_auth_provider_check.ts`** (new): detects the legacy CHECK via `sqlite_master.sql` and, if present, rebuilds the `users` table without it — preserving rows/ids. No-op on PostgreSQL/MySQL (the constraint only ever existed in SQLite) and no-op on databases that never had it (idempotent, safe to re-run).
- **`src/server/migrations/118_drop_legacy_auth_provider_check.test.ts`** (new): covers legacy-table rebuild + constraint removal, row/id preservation, no-op on baseline schema, idempotency, legacy schemas missing later-added columns, and PG/MySQL no-ops.
- **`src/db/migrations.ts`**: registers migration 118.

## Test plan

- [x] New migration unit tests (`118_drop_legacy_auth_provider_check.test.ts`) — 15 assertions, all pass
- [x] `src/db/migrations.test.ts` (registry structural invariants) — pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:ci` — ratchet OK, no new violations
- [x] Full `vitest run` — 640 files / 9063 tests passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTUyEYMkdSHYQAuPwdJWPA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTUyEYMkdSHYQAuPwdJWPA)_