### PR TITLE
fix(docker): drop deleted watchdog scripts from Dockerfile.armv7

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -86,11 +86,6 @@ COPY --from=builder /app/protobufs ./protobufs
 # Fix ownership of dist directory for node user
 RUN chown -R node:node ./dist
 
-# Copy upgrade-related scripts into container
-COPY scripts/upgrade-watchdog.sh /app/scripts/upgrade-watchdog.sh
-COPY scripts/test-docker-socket.sh /app/scripts/test-docker-socket.sh
-RUN chmod +x /app/scripts/upgrade-watchdog.sh /app/scripts/test-docker-socket.sh
-
 # Create data directory for SQLite database and Apprise configs
 RUN mkdir -p /data/apprise-config /data/scripts && chown -R node:node /data
 


### PR DESCRIPTION
## Summary

The auto-upgrade retirement (#4108) deleted `scripts/upgrade-watchdog.sh` and `scripts/test-docker-socket.sh` and removed their `COPY` lines from the main `Dockerfile` — but missed the same block in `Dockerfile.armv7`. That Dockerfile only builds during the release workflow, so nothing caught it until the v4.13.0 release: the `build-armv7` job failed with `"/scripts/test-docker-socket.sh": not found`, which skipped `create-manifest`, so no stable Docker tags were published.

This removes the stale 4-line block, mirroring the #4108 change to the main Dockerfile.

After merge, the v4.13.0 release will be recreated on the fixed commit to re-trigger the Docker publish from a tag that contains the fix.

## Test plan

- [x] `grep -rn "upgrade-watchdog\|test-docker-socket"` — no remaining references outside git history
- [x] Matches the exact block #4108 removed from `Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AphLfgUJWaFNAgU5UXdJ4n