### PR TITLE
fix(map): honor Default Map Center on Unified/Dashboard map (#4125)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -7,6 +7,20 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import DashboardMap from './DashboardMap';
 import { darkOverlayColors } from '../../config/overlayColors';
 
+// Shared, mutable mocks for the map instance and settings so individual tests
+// can assert fitBounds behavior and toggle the Default Map Center (issue #4125).
+const mocks = vi.hoisted(() => ({
+  fitBounds: vi.fn(),
+  settings: {
+    mapPinStyle: 'official' as string,
+    overlayColors: undefined as unknown,
+    setMapTileset: undefined as unknown,
+    defaultMapCenterLat: null as number | null,
+    defaultMapCenterLon: null as number | null,
+    defaultMapCenterZoom: null as number | null,
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -47,7 +61,7 @@ vi.mock('react-leaflet', () => ({
     <div data-testid="map-polyline" data-positions={JSON.stringify(positions)} />
   ),
   Rectangle: () => <div data-testid="map-rectangle" />,
-  useMap: () => ({ fitBounds: vi.fn(), setView: vi.fn() }),
+  useMap: () => ({ fitBounds: mocks.fitBounds, setView: vi.fn() }),
 }));
 
 // MapContext is normally provided by DashboardPage; in tests we mock the hook
@@ -101,7 +115,7 @@ vi.mock('../../services/api', () => ({
 // SettingsProvider.
 vi.mock('../../contexts/SettingsContext', () => ({
   useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
-  useSettings: () => ({ mapPinStyle: 'official', overlayColors: darkOverlayColors }),
+  useSettings: () => mocks.settings,
 }));
 
 vi.mock('leaflet', () => ({
@@ -279,6 +293,30 @@ describe('DashboardMap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    // Reset the shared settings mock to "no Default Map Center configured".
+    mocks.settings.mapPinStyle = 'official';
+    mocks.settings.overlayColors = darkOverlayColors;
+    mocks.settings.setMapTileset = vi.fn();
+    mocks.settings.defaultMapCenterLat = null;
+    mocks.settings.defaultMapCenterLon = null;
+    mocks.settings.defaultMapCenterZoom = null;
+  });
+
+  // --- Default Map Center vs auto-fit (issue #4125) ---------------------------
+
+  it('auto-fits bounds to node positions when no Default Map Center is configured', () => {
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition]} />);
+    expect(mocks.fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not auto-fit bounds when a Default Map Center is configured (issue #4125)', () => {
+    mocks.settings.defaultMapCenterLat = 27.5;
+    mocks.settings.defaultMapCenterLon = -82.5;
+    mocks.settings.defaultMapCenterZoom = 8;
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition]} />);
+    // A configured default center must win over auto-fit — otherwise the map
+    // pans/zooms out to include stray out-of-region nodes (the reported bug).
+    expect(mocks.fitBounds).not.toHaveBeenCalled();
   });
 
   // --- Features panel collapse (#3912) ---------------------------------------

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -112,13 +112,21 @@ function getNodeLatLng(node: any): { lat: number; lng: number } | null {
 interface MapBoundsUpdaterProps {
   positions: [number, number][];
   sourceId: string | null;
+  /**
+   * When true, an admin has configured a Default Map Center (lat/lon/zoom), so
+   * the map should open there and we must NOT auto-fit to node bounds. Mirrors
+   * the per-source classic map priority in NodesTab (issue #4125).
+   */
+  skip: boolean;
 }
 
-function MapBoundsUpdater({ positions, sourceId }: MapBoundsUpdaterProps) {
+function MapBoundsUpdater({ positions, sourceId, skip }: MapBoundsUpdaterProps) {
   const map = useMap();
   const hasFittedRef = useRef(false);
 
   useEffect(() => {
+    // A configured Default Map Center wins over auto-fit (issue #4125).
+    if (skip) return;
     // Only auto-fit once on initial load, then let the user control the view
     if (hasFittedRef.current) return;
     if (positions.length === 0) return;
@@ -149,7 +157,22 @@ export default function DashboardMap({
   onNodeSourceSelect,
   isLoading = false,
 }: DashboardMapProps) {
-  const { mapPinStyle, setMapTileset, overlayColors } = useSettings();
+  const {
+    mapPinStyle,
+    setMapTileset,
+    overlayColors,
+    defaultMapCenterLat,
+    defaultMapCenterLon,
+    defaultMapCenterZoom,
+  } = useSettings();
+
+  // A Default Map Center is only "configured" when all three parts are set.
+  // When configured, the map opens there and auto-fit-to-nodes is suppressed
+  // (issue #4125 — parity with NodesTab.tsx's classic per-source map).
+  const hasConfiguredDefaultCenter =
+    defaultMapCenterLat != null &&
+    defaultMapCenterLon != null &&
+    defaultMapCenterZoom != null;
 
   // Polar grid (#3971): draw a grid centered on each source's own-node position.
   // On the Unified map (sourceId === UNIFIED_SOURCE_ID) that's every source, each
@@ -584,7 +607,7 @@ export default function DashboardMap({
     <div className="dashboard-map-container" style={{ position: 'relative' }}>
       <BaseMap
         center={[defaultCenter.lat, defaultCenter.lng]}
-        zoom={10}
+        zoom={hasConfiguredDefaultCenter ? defaultMapCenterZoom : 10}
         tilesetId={tilesetId}
         customTilesets={customTilesets}
         zoomControl
@@ -599,7 +622,7 @@ export default function DashboardMap({
           />
         )}
 
-        <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} />
+        <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} skip={hasConfiguredDefaultCenter} />
 
         {showLegend && <MapLegend />}
 

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -135,7 +135,7 @@ function MapBoundsUpdater({ positions, sourceId, skip }: MapBoundsUpdaterProps) 
       map.fitBounds(bounds, { padding: [40, 40] });
       hasFittedRef.current = true;
     }
-  }, [map, positions, sourceId]);
+  }, [map, positions, sourceId, skip]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes #4125 — the Unified/Dashboard map ignored the **Default Map Center** setting (regression from the #4047 map consolidation).

Root cause, as diagnosed in the issue:
- `DashboardMap`'s `MapBoundsUpdater` unconditionally called `map.fitBounds(...)` on initial load whenever any node had a position — with no check for a configured Default Map Center, so auto-fit always won.
- `BaseMap` was passed a hardcoded `zoom={10}`, dropping the configured zoom.

With the geo/ROI filter relaxed, a few out-of-region nodes (e.g. one in Mexico, one in New York for a Florida instance) caused the map to zoom/pan out to fit them all instead of opening at the configured center.

## Fix

`DashboardMap` now reads `defaultMapCenterLat`/`Lon`/`Zoom` from settings. When all three are configured:
- the configured **zoom** is passed to `BaseMap` instead of the hardcoded `10`, and
- `MapBoundsUpdater` **skips** `fitBounds`, so the map opens at the configured center.

This mirrors the three-tier priority `NodesTab.tsx` already uses for the classic per-source map. When no Default Map Center is configured, auto-fit-to-nodes behaves exactly as before.

## Tests

Added a regression pair to `DashboardMap.test.tsx`:
- auto-fits bounds when **no** Default Map Center is configured;
- does **not** auto-fit when one **is** configured.

The `useMap`/`useSettings` mocks were refactored to a shared `vi.hoisted` object so tests can toggle the default center and assert `fitBounds` calls. Full suite (44 tests) passes; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnxzF15PmWZNDnaNKFec4Y