### PR TITLE
feat(mqtt): fail-open geo filter with per-source ignore list + retroactive purge (geo-ignore epic Phase 2, #4115)

### DIFF
--- a/docs/internal/dev-notes/MQTT_GEO_IGNORE_EPIC.md
+++ b/docs/internal/dev-notes/MQTT_GEO_IGNORE_EPIC.md
@@ -64,18 +64,18 @@ pre-decryption in `handleDownlink`.
 ## Phases
 
 ### Phase 1 — Data layer: ignore reasons + full-purge cascade
-- [ ] Migration (all 3 backends, idempotent, registry-registered): add
+- [x] Migration (all 3 backends, idempotent, registry-registered): add
   `reason TEXT NOT NULL DEFAULT 'manual'` to `ignored_nodes`.
-- [ ] `IgnoredNodesRepository`: reason-aware add/list; `addGeoIgnoreAsync`,
+- [x] `IgnoredNodesRepository`: reason-aware add/list; `addGeoIgnoreAsync`,
   `liftGeoIgnoreAsync` (removes only `reason='geo'` rows); records expose reason.
-- [ ] Messages repo: `purgeMessagesFromNode(nodeNum, sourceId)` (channel
+- [x] Messages repo: `purgeMessagesFromNode(nodeNum, sourceId)` (channel
   broadcasts); wire into `deleteNodeAsync` cascade.
-- [ ] `ignoredNodeRoutes` + `IgnoredNodesSection.tsx`: surface reason (badge),
+- [x] `ignoredNodeRoutes` + `IgnoredNodesSection.tsx`: surface reason (badge),
   manual unignore allowed for geo entries.
-- [ ] Tests: repo unit + perSource isolation + migration + route tests
+- [x] Tests: repo unit + perSource isolation + migration + route tests
   (route-test harness).
 - **Exit:** primitives shipped inert (no behavior change to ingestion); suite
-  green; PR merged.
+  green. **PR #4123 MERGED** 2026-07-15 (squash 2f828caa; migration renumbered 119→120 after #4118 took 119; review fixes: TOCTOU cache-eviction in liftGeoIgnoreAsync, source-qualified UI key, harness teardown guard; also shipped watch-ci.sh merge-conflict detection exit 3).
 
 ### Phase 2 — Core gating rearchitecture (the behavior flip)
 - [ ] `MqttBridgeManager.handleDownlink`: remove fail-closed

--- a/src/db/repositories/ignoredNodes.test.ts
+++ b/src/db/repositories/ignoredNodes.test.ts
@@ -325,6 +325,46 @@ function runIgnoredNodesTests(getBackend: () => TestBackend) {
     expect(repo.isIgnoredCached(12345, SRC_A)).toBe(true);
   });
 
+  it('addGeoIgnoreAsync - returns true when a new geo-ignore row is inserted', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const inserted = await repo.addGeoIgnoreAsync(12345, SRC_A, '!abcd1234', 'Far Node', 'FN');
+    expect(inserted).toBe(true);
+  });
+
+  it('addGeoIgnoreAsync - returns false on a second call against an already geo-ignored node', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const first = await repo.addGeoIgnoreAsync(12345, SRC_A, '!abcd1234', 'Far Node', 'FN');
+    const second = await repo.addGeoIgnoreAsync(12345, SRC_A, '!abcd1234', 'Far Node', 'FN');
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it('addGeoIgnoreAsync - returns false against a manually-ignored node and leaves it manual', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'Test Node', 'TN', 'admin');
+    const inserted = await repo.addGeoIgnoreAsync(12345, SRC_A, '!abcd1234', 'Test Node', 'TN');
+    expect(inserted).toBe(false);
+
+    const nodes = await repo.getIgnoredNodesAsync(SRC_A);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].reason).toBe('manual');
+  });
+
   it('addGeoIgnoreAsync - does not downgrade an existing manual ignore', async () => {
     const backend = getBackend();
     if (!backend.available) {

--- a/src/db/repositories/ignoredNodes.ts
+++ b/src/db/repositories/ignoredNodes.ts
@@ -181,6 +181,12 @@ export class IgnoredNodesRepository extends BaseRepository {
    * a human already blocklisted manually (`reason: 'manual'`) stays manual;
    * re-running the geo filter against an already-geo-ignored node is a
    * harmless no-op (idempotent).
+   *
+   * Returns whether a NEW geo-ignore row was actually inserted. `false` on
+   * conflict — the node was already ignored (either `reason: 'geo'` or
+   * `reason: 'manual'`) and the insert was a no-op. Callers use this to
+   * purge-once on the geo transition (Phase 2): only act on the true→false
+   * edge, not on every repeated geo-filter pass over an already-ignored node.
    */
   async addGeoIgnoreAsync(
     nodeNum: number,
@@ -188,7 +194,7 @@ export class IgnoredNodesRepository extends BaseRepository {
     nodeId: string,
     longName?: string,
     shortName?: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const { ignoredNodes } = this.tables;
     const insertData = {
       nodeNum,
@@ -208,9 +214,14 @@ export class IgnoredNodesRepository extends BaseRepository {
     // set (or is being correctly set for the very first time here).
     this.ignoredCache.add(this.cacheKey(nodeNum, sourceId));
 
-    await this.insertIgnore(ignoredNodes, insertData);
+    const result = await this.insertIgnore(ignoredNodes, insertData);
+    const inserted = this.getAffectedRows(result) > 0;
 
-    logger.debug(`Geo-ignored node ${nodeNum} (${nodeId}) for source ${sourceId}`);
+    if (inserted) {
+      logger.debug(`Geo-ignored node ${nodeNum} (${nodeId}) for source ${sourceId}`);
+    }
+
+    return inserted;
   }
 
   /**

--- a/src/server/mqttBridgeManager.mode.test.ts
+++ b/src/server/mqttBridgeManager.mode.test.ts
@@ -4,7 +4,12 @@ import { Aedes } from 'aedes';
 import { createServer, type Server } from 'net';
 
 vi.mock('../services/database.js', () => ({
-  default: {},
+  default: {
+    // Phase 2 gating consults the ignore-list cache on every downlink packet
+    // (handleDownlink + ingestServiceEnvelope) — an empty mock crashes with
+    // "Cannot read properties of undefined (reading 'isIgnoredCached')".
+    ignoredNodes: { isIgnoredCached: () => false },
+  },
 }));
 
 import { MqttBrokerManager } from './mqttBrokerManager.js';

--- a/src/server/mqttBridgeManager.permission.test.ts
+++ b/src/server/mqttBridgeManager.permission.test.ts
@@ -12,7 +12,12 @@ import { Aedes } from 'aedes';
 import { createServer, type Server } from 'net';
 
 vi.mock('../services/database.js', () => ({
-  default: {},
+  default: {
+    // Phase 2 gating consults the ignore-list cache on every downlink packet
+    // (handleDownlink + ingestServiceEnvelope) — an empty mock crashes with
+    // "Cannot read properties of undefined (reading 'isIgnoredCached')".
+    ignoredNodes: { isIgnoredCached: () => false },
+  },
 }));
 
 import { MqttBrokerClient } from './transports/mqttBrokerClient.js';

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -46,8 +46,15 @@ const getIgnoredNodesAsync = vi.fn(async (sourceId?: string) =>
   Array.from(ignoredRecords.entries())
     .filter(([key]) => !sourceId || key.startsWith(`${sourceId}:`))
     .map(([key, rec]) => {
-      const [sid, numStr] = key.split(':');
-      return { nodeNum: Number(numStr), sourceId: sid, reason: rec.reason };
+      // Split on the LAST colon — nodeNum is the trailing numeric segment
+      // (mirrors the real cacheKey contract), so a colon-bearing sourceId
+      // can't skew the parse.
+      const colon = key.lastIndexOf(':');
+      return {
+        nodeNum: Number(key.slice(colon + 1)),
+        sourceId: key.slice(0, colon),
+        reason: rec.reason,
+      };
     }));
 
 vi.mock('../services/database.js', () => ({

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -5,6 +5,50 @@ import { createServer, type Server } from 'net';
 
 const upsertNode = vi.fn();
 const insertTelemetry = vi.fn();
+const insertMessage = vi.fn(async () => true);
+const deleteNode = vi.fn(async () => ({
+  messagesDeleted: 0,
+  broadcastMessagesDeleted: 0,
+  traceroutesDeleted: 0,
+  telemetryDeleted: 0,
+  nodeDeleted: true,
+}));
+const getNode = vi.fn(async () => null);
+
+// Stateful fake for ignored_nodes (Phase 2 geo-ignore). Mirrors the real
+// IgnoredNodesRepository's cache-key shape (`${sourceId}:${nodeNum}`) and its
+// reason semantics (geo-ignore is insert-if-absent; lift only removes
+// reason='geo', never 'manual') closely enough for the bridge-path coverage
+// below. See src/server/mqttBrokerManager.test.ts for the sibling fake used
+// by the broker-path (manual-ignore-only) tests.
+const ignoredRecords = new Map<string, { reason: 'manual' | 'geo' }>();
+function ignoreKey(nodeNum: number, sourceId: string): string {
+  return `${sourceId}:${nodeNum}`;
+}
+const isIgnoredCached = vi.fn((nodeNum: number, sourceId: string) =>
+  ignoredRecords.has(ignoreKey(nodeNum, sourceId)));
+const addGeoIgnoreAsync = vi.fn(async (nodeNum: number, sourceId: string) => {
+  const key = ignoreKey(nodeNum, sourceId);
+  if (ignoredRecords.has(key)) return false;
+  ignoredRecords.set(key, { reason: 'geo' });
+  return true;
+});
+const liftGeoIgnoreAsync = vi.fn(async (nodeNum: number, sourceId: string) => {
+  const key = ignoreKey(nodeNum, sourceId);
+  const rec = ignoredRecords.get(key);
+  if (!rec || rec.reason !== 'geo') return false;
+  ignoredRecords.delete(key);
+  return true;
+});
+const isNodeIgnoredAsync = vi.fn(async (nodeNum: number, sourceId: string) =>
+  ignoredRecords.has(ignoreKey(nodeNum, sourceId)));
+const getIgnoredNodesAsync = vi.fn(async (sourceId?: string) =>
+  Array.from(ignoredRecords.entries())
+    .filter(([key]) => !sourceId || key.startsWith(`${sourceId}:`))
+    .map(([key, rec]) => {
+      const [sid, numStr] = key.split(':');
+      return { nodeNum: Number(numStr), sourceId: sid, reason: rec.reason };
+    }));
 
 vi.mock('../services/database.js', () => ({
   default: {
@@ -12,6 +56,21 @@ vi.mock('../services/database.js', () => ({
     insertTelemetryAsync: async (...a: unknown[]) => insertTelemetry(...a),
     insertTracerouteAsync: vi.fn(async () => undefined),
     insertRouteSegmentAsync: vi.fn(async () => undefined),
+    deleteNodeAsync: async (...a: unknown[]) => deleteNode(...a),
+    nodes: {
+      getNode: async (...a: unknown[]) => getNode(...a),
+    },
+    messages: {
+      insertMessage: async (...a: unknown[]) => insertMessage(...a),
+      getMessage: vi.fn(async () => null),
+    },
+    ignoredNodes: {
+      isIgnoredCached: (...a: unknown[]) => isIgnoredCached(...(a as [number, string])),
+      addGeoIgnoreAsync: async (...a: unknown[]) => addGeoIgnoreAsync(...(a as [number, string])),
+      liftGeoIgnoreAsync: async (...a: unknown[]) => liftGeoIgnoreAsync(...(a as [number, string])),
+      isNodeIgnoredAsync: async (...a: unknown[]) => isNodeIgnoredAsync(...(a as [number, string])),
+      getIgnoredNodesAsync: async (...a: unknown[]) => getIgnoredNodesAsync(...(a as [string | undefined])),
+    },
   },
 }));
 
@@ -19,6 +78,7 @@ import { MqttBrokerManager } from './mqttBrokerManager.js';
 import { MqttBridgeManager } from './mqttBridgeManager.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
+import databaseService from '../services/database.js';
 import { PortNum } from './constants/meshtastic.js';
 import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
 
@@ -96,6 +156,58 @@ function buildPositionEnvelope(opts: {
   return Buffer.from(bytes);
 }
 
+function buildNodeInfoEnvelope(opts: {
+  from: number;
+  longName: string;
+  shortName: string;
+  channelId: string;
+  gatewayId: string;
+  packetId?: number;
+}): Buffer {
+  const r = getProtobufRoot();
+  if (!r) throw new Error('protobuf root not loaded');
+  const User = r.lookupType('meshtastic.User');
+  const userPayload = User.encode(
+    User.create({ longName: opts.longName, shortName: opts.shortName, hwModel: 9 }),
+  ).finish();
+  const bytes = meshtasticProtobufService.encodeServiceEnvelope({
+    packet: {
+      from: opts.from,
+      to: 0xffffffff,
+      channel: 0,
+      id: opts.packetId ?? 0xabcdef02,
+      decoded: { portnum: PortNum.NODEINFO_APP, payload: userPayload, bitfield: 1 },
+    },
+    channelId: opts.channelId,
+    gatewayId: opts.gatewayId,
+  });
+  if (!bytes) throw new Error('encode failed');
+  return Buffer.from(bytes);
+}
+
+function buildTextEnvelope(opts: {
+  from: number;
+  text: string;
+  channelId: string;
+  gatewayId: string;
+  packetId?: number;
+}): Buffer {
+  const textPayload = new TextEncoder().encode(opts.text);
+  const bytes = meshtasticProtobufService.encodeServiceEnvelope({
+    packet: {
+      from: opts.from,
+      to: 0xffffffff,
+      channel: 0,
+      id: opts.packetId ?? 0xabcdef03,
+      decoded: { portnum: PortNum.TEXT_MESSAGE_APP, payload: textPayload, bitfield: 1 },
+    },
+    channelId: opts.channelId,
+    gatewayId: opts.gatewayId,
+  });
+  if (!bytes) throw new Error('encode failed');
+  return Buffer.from(bytes);
+}
+
 describe('MqttBridgeManager', () => {
   let upstreamPort: number;
   let localPort: number;
@@ -111,6 +223,15 @@ describe('MqttBridgeManager', () => {
   beforeEach(async () => {
     upsertNode.mockClear();
     insertTelemetry.mockClear();
+    insertMessage.mockClear();
+    deleteNode.mockClear();
+    getNode.mockClear();
+    isIgnoredCached.mockClear();
+    addGeoIgnoreAsync.mockClear();
+    liftGeoIgnoreAsync.mockClear();
+    isNodeIgnoredAsync.mockClear();
+    getIgnoredNodesAsync.mockClear();
+    ignoredRecords.clear();
 
     upstreamPort = await ephemeralPort();
     localPort = await ephemeralPort();
@@ -136,18 +257,17 @@ describe('MqttBridgeManager', () => {
     await stopUpstream(upstream);
   });
 
-  it('passes downlink packets through filter and ingests + republishes to local broker', async () => {
-    bridge = new MqttBridgeManager('test-bridge', 'Bridge', {
-      brokerSourceId: 'local-broker',
-      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
-      subscriptions: ['msh/CA/#'],
-      downlinkFilters: {
-        topics: { block: ['msh/CA/QC/#'] },
-        geo: { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 },
-      },
-    });
-    await sourceManagerRegistry.addManager(bridge);
+  // ---------------------------------------------------------------------------
+  // Geo-ignore gating (MQTT Geo-Ignore epic, Phase 2, #4115). MqttPacketFilter
+  // no longer tracks node membership — handleDownlink instead consults
+  // databaseService.ignoredNodes (isIgnoredCached / addGeoIgnoreAsync /
+  // liftGeoIgnoreAsync / isNodeIgnoredAsync), which ingestServiceEnvelope
+  // populates on POSITION evaluation. These tests replace the old
+  // "fail-closed membership" coverage with the new fail-open-by-default +
+  // ignore-list model.
+  // ---------------------------------------------------------------------------
 
+  async function connectUpstream(): Promise<void> {
     upstreamClient = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
     await new Promise<void>((resolve, reject) => {
       const t = setTimeout(() => reject(new Error('upstream connect timeout')), 3000);
@@ -156,75 +276,192 @@ describe('MqttBridgeManager', () => {
         resolve();
       });
     });
+  }
 
-    // Subscribe to the local broker so we can confirm republish.
-    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+  async function connectLocalSubscriber(): Promise<{
+    client: MqttClient;
+    messages: Array<{ topic: string; payload: Buffer }>;
+  }> {
+    const client = connect(`mqtt://127.0.0.1:${localPort}`, {
       username: 'u',
       password: 'p',
       reconnectPeriod: 0,
     });
-    const localMessages: Array<{ topic: string; payload: Buffer }> = [];
+    const messages: Array<{ topic: string; payload: Buffer }> = [];
     await new Promise<void>((resolve, reject) => {
       const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
-      localClient.once('connect', () => {
+      client.once('connect', () => {
         clearTimeout(t);
         resolve();
       });
     });
     await new Promise<void>((resolve, reject) => {
-      localClient.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+      client.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
     });
-    localClient.on('message', (topic, payload) => {
-      localMessages.push({ topic, payload });
+    client.on('message', (topic, payload) => {
+      messages.push({ topic, payload });
     });
+    return { client, messages };
+  }
 
-    // Inside the bbox, allowed by topic → should pass.
+  const GEO_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+
+  it('#4115: with a bbox configured, a NODEINFO from a never-seen sender still ingests (fail-open)', async () => {
+    bridge = new MqttBridgeManager('test-bridge', 'Bridge', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/CA/#'],
+      downlinkFilters: { geo: GEO_BBOX },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+    await connectUpstream();
+
+    const NEVER_SEEN = 0xf68f52d8;
+    const envelope = buildNodeInfoEnvelope({
+      from: NEVER_SEEN,
+      longName: 'New Node',
+      shortName: 'NEW',
+      channelId: 'LongFast',
+      gatewayId: '!f68f52d8',
+      packetId: 0x50000001,
+    });
+    upstreamClient!.publish('msh/CA/ON/PTBO', envelope);
+
+    await vi.waitFor(() => {
+      expect(bridge.getStatus().downlinkIngested).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+    expect(upsertNode).toHaveBeenCalled();
+  });
+
+  it('drops an out-of-bbox POSITION, geo-ignores the sender (reason: geo), and does not republish', async () => {
+    bridge = new MqttBridgeManager('test-bridge', 'Bridge', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/CA/#'],
+      downlinkFilters: { geo: GEO_BBOX },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+    await connectUpstream();
+    const { client: localClient, messages: localMessages } = await connectLocalSubscriber();
+
+    const OUT_NODE = 0x22222222;
+    const outBboxEnvelope = buildPositionEnvelope({
+      from: OUT_NODE,
+      latI: 420_000_000, // outside GEO_BBOX (minLat 43)
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!22222222',
+      packetId: 0x10000002,
+    });
+    upstreamClient!.publish('msh/CA/ON/PTBO', outBboxEnvelope);
+
+    await vi.waitFor(async () => {
+      expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(OUT_NODE, 'test-bridge')).toBe(true);
+    }, { timeout: 3000 });
+
+    const records = await databaseService.ignoredNodes.getIgnoredNodesAsync('test-bridge');
+    const rec = records.find((r) => r.nodeNum === OUT_NODE);
+    expect(rec?.reason).toBe('geo');
+
+    expect(bridge.getStatus().downlinkDrops.geo).toBe(1);
+
+    // Give any (incorrect) republish a moment to land before asserting absence.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(localMessages.some((m) => m.topic === 'msh/CA/ON/PTBO')).toBe(false);
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  it('ingests and republishes an in-bbox POSITION normally', async () => {
+    bridge = new MqttBridgeManager('test-bridge', 'Bridge', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/CA/#'],
+      downlinkFilters: { geo: GEO_BBOX },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+    await connectUpstream();
+    const { client: localClient, messages: localMessages } = await connectLocalSubscriber();
+
+    const IN_NODE = 0x11111111;
     const inBboxEnvelope = buildPositionEnvelope({
-      from: 0x11111111,
+      from: IN_NODE,
       latI: 440_000_000,
       lngI: -780_000_000,
       channelId: 'LongFast',
       gatewayId: '!11111111',
       packetId: 0x10000001,
     });
+    upstreamClient!.publish('msh/CA/ON/PTBO', inBboxEnvelope);
 
-    // Outside the bbox → should drop on postFilterPosition.
+    await vi.waitFor(() => {
+      expect(bridge.getStatus().downlinkIngested).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+    await vi.waitFor(() => {
+      expect(localMessages.some((m) => m.topic === 'msh/CA/ON/PTBO')).toBe(true);
+    }, { timeout: 3000 });
+    expect(bridge.getStatus().downlinkDrops.geo).toBe(0);
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  it('drops subsequent TEXT from a geo-ignored sender: not ingested, not republished, no local-packet emit', async () => {
+    bridge = new MqttBridgeManager('test-bridge', 'Bridge', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/CA/#'],
+      downlinkFilters: { geo: GEO_BBOX },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+    await connectUpstream();
+    const { client: localClient, messages: localMessages } = await connectLocalSubscriber();
+
+    const localPackets: Array<{ topic: string }> = [];
+    bridge.on('local-packet', (p: { topic: string }) => {
+      localPackets.push({ topic: p.topic });
+    });
+
+    const OUT_NODE = 0x22222222;
     const outBboxEnvelope = buildPositionEnvelope({
-      from: 0x22222222,
+      from: OUT_NODE,
       latI: 420_000_000,
       lngI: -780_000_000,
       channelId: 'LongFast',
       gatewayId: '!22222222',
       packetId: 0x10000002,
     });
+    upstreamClient!.publish('msh/CA/ON/PTBO', outBboxEnvelope);
 
-    // Blocked topic → should drop in preFilter.
-    const blockedEnvelope = buildPositionEnvelope({
-      from: 0x33333333,
-      latI: 440_000_000,
-      lngI: -780_000_000,
+    // Wait for the POSITION to actually land the geo-ignore (async) so the
+    // subsequent TEXT packet's synchronous isIgnoredCached() check sees it.
+    await vi.waitFor(async () => {
+      expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(OUT_NODE, 'test-bridge')).toBe(true);
+    }, { timeout: 3000 });
+
+    // Snapshot counters after the (already-ignored-by-the-time-it-lands)
+    // POSITION packet — its own local-packet emission raced the async
+    // ignore write and may have already fired once; what matters is that
+    // the FOLLOWING TEXT packet adds nothing further.
+    const ingestedBefore = bridge.getStatus().downlinkIngested;
+    const localPacketsBefore = localPackets.length;
+    const localMessagesBefore = localMessages.length;
+
+    const textEnvelope = buildTextEnvelope({
+      from: OUT_NODE,
+      text: 'hello from an ignored sender',
       channelId: 'LongFast',
-      gatewayId: '!33333333',
-      packetId: 0x10000003,
+      gatewayId: '!22222222',
+      packetId: 0x10000010,
     });
+    upstreamClient!.publish('msh/CA/ON/PTBO', textEnvelope);
 
-    upstreamClient.publish('msh/CA/ON/PTBO', inBboxEnvelope);
-    upstreamClient.publish('msh/CA/ON/PTBO', outBboxEnvelope);
-    upstreamClient.publish('msh/CA/QC/MTL', blockedEnvelope);
+    // Let the (non-)flow settle.
+    await new Promise((r) => setTimeout(r, 300));
 
-    // Let the messages flow.
-    await new Promise((r) => setTimeout(r, 500));
-
-    const status = bridge.getStatus();
-    expect(status.downlinkIn).toBeGreaterThanOrEqual(3);
-    // Only the in-bbox passes filtering AND ingests.
-    expect(status.downlinkIngested).toBe(1);
-    expect(status.downlinkDrops.topic).toBeGreaterThanOrEqual(1);
-    expect(status.downlinkDrops.geo).toBeGreaterThanOrEqual(1);
-
-    // Republish: only the in-bbox should make it to the local broker.
-    const republishedFromBridge = localMessages.filter((m) => m.topic === 'msh/CA/ON/PTBO');
-    expect(republishedFromBridge.length).toBe(1);
+    expect(bridge.getStatus().downlinkIngested).toBe(ingestedBefore);
+    expect(localPackets.length).toBe(localPacketsBefore);
+    expect(localMessages.length).toBe(localMessagesBefore);
+    expect(insertMessage).not.toHaveBeenCalled();
 
     await new Promise<void>((r) => localClient.end(true, {}, () => r()));
   });

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -651,6 +651,16 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     // postFilterPosition increments drops.geo on the out case — run it for
     // every plaintext position (even already-ignored senders) so the counter
     // reflects all out-of-bbox position arrivals.
+    // TODO(Phase 4): drops.geo only sees plaintext positions here; encrypted
+    // out-of-bbox positions are classified post-decrypt in ingestion and are
+    // not counted until per-reason counters land.
+    //
+    // Known one-packet window: `isIgnored` is the cached state at pre-gate
+    // time, and ingestion (which inserts/lifts the geo-ignore) runs
+    // fire-and-forget below. A node's very first out-of-bbox POSITION is
+    // therefore emitted/republished once before the ignore takes effect;
+    // every subsequent packet sees the updated cache. Accepted trade-off of
+    // not blocking the packet loop on ingestion.
     let republishAllowed = !isIgnored;
     if (isPosition) {
       const position = decodePosition(envelope.packet!.decoded!.payload);

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -39,7 +39,6 @@ import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import type { MqttBrokerManager, MqttBrokerLocalPacket } from './mqttBrokerManager.js';
 import type { Source } from '../db/repositories/sources.js';
 import databaseService from '../services/database.js';
-import { ALL_SOURCES } from '../db/repositories/index.js';
 import { logger } from '../utils/logger.js';
 import { loadAllNodesAsDeviceInfo } from './utils/dbNodeMapper.js';
 import type { DeviceInfo } from './meshtasticManager.js';
@@ -306,7 +305,6 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
   async start(): Promise<void> {
     this.attachParentBroker();
     await bootstrapMqttChannelDatabase(this.sourceId);
-    await this.seedDownlinkMembership();
 
     // Per-source auto-delete-by-distance (#3901). Started up front so the
     // publish_only early-return below doesn't skip it. Background concern —
@@ -405,58 +403,6 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       this.reconnectCoordinator = null;
     }
     this.brokerGatewayNum = null;
-  }
-
-  /**
-   * Pre-seed the downlink filter's geo-membership cache with:
-   *   1. Any node our local (non-MQTT) sources have heard directly —
-   *      "trusted" because the operator clearly considers them part of
-   *      their mesh. These pass the bbox filter regardless of whether we
-   *      have a stored position for them. Without this, a node attached
-   *      to a TCP source whose GPS hasn't reported a position yet would
-   *      have its MQTT-relayed text/telemetry silently geo-dropped.
-   *   2. Any node from any source whose stored position is inside the bbox.
-   *
-   * Without this seed the fail-closed filter drops every non-POSITION
-   * packet from a node until that node next broadcasts a position — which
-   * can be hours and is reset on every restart.
-   */
-  private async seedDownlinkMembership(): Promise<void> {
-    try {
-      const allSources = await databaseService.sources.getAllSources();
-      const localSourceIds = allSources
-        .filter((s) => s.type !== 'mqtt_bridge' && s.type !== 'mqtt_broker')
-        .map((s) => s.id);
-
-      // Trusted local-mesh nodes (any source we operate directly).
-      const trustedNums = new Set<number>();
-      for (const sid of localSourceIds) {
-        const localNodes = await databaseService.nodes.getAllNodes(sid);
-        for (const n of localNodes) trustedNums.add(n.nodeNum);
-      }
-      const trustedSeeded = this.downlinkFilter.seedTrustedNodes(trustedNums);
-
-      // intentional cross-source: in-bbox positions are pooled from all sources to seed the downlink filter
-      const allNodes = await databaseService.nodes.getAllNodes(ALL_SOURCES);
-      const entries = allNodes
-        .filter((n) => typeof n.latitude === 'number' && typeof n.longitude === 'number')
-        .map((n) => ({
-          nodeNum: n.nodeNum,
-          latitudeDeg: n.latitude as number,
-          longitudeDeg: n.longitude as number,
-        }));
-      const positionSeeded = this.downlinkFilter.seedMembership(entries);
-
-      if (trustedSeeded > 0 || positionSeeded > 0) {
-        logger.info(
-          `MQTT bridge ${this.sourceId} seeded ${trustedSeeded} trusted local-mesh node(s) + ` +
-            `${positionSeeded} in-bbox position(s) into downlink membership cache`,
-        );
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn(`MQTT bridge ${this.sourceId} membership seed failed: ${message}`);
-    }
   }
 
   getStatus(): MqttBridgeStatus {
@@ -686,23 +632,30 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
 
     if (!this.downlinkFilter.preFilter(topic, envelope)) return;
 
-    // Apply geo filter early — position packets outside the bbox must
-    // not be republished to the local broker, otherwise they'd pollute
-    // the nodeDBs of devices connected to it. Passing `from` to
-    // postFilterPosition lets the filter cache this node's membership
-    // so non-position packets can be gated by `passesMembership` below.
     const fromNum = typeof envelope.packet?.from === 'number' ? envelope.packet.from >>> 0 : null;
-    if (envelope.packet?.decoded?.portnum === PortNum.POSITION_APP) {
-      const position = decodePosition(envelope.packet.decoded.payload);
-      if (!this.downlinkFilter.postFilterPosition(position, fromNum ?? undefined)) return;
-    } else {
-      // Fail-closed: drop non-position traffic from senders we haven't
-      // already classified as inside the bbox. Encrypted packets (no
-      // decoded portnum) also flow through here — `decoded` would be
-      // undefined, the strict equality above is false, and we end up
-      // gated on membership too. That's intentional: an encrypted
-      // packet from an unknown sender should also be dropped.
-      if (!this.downlinkFilter.passesMembership(fromNum)) return;
+    const decodedPortnum = envelope.packet?.decoded?.portnum;
+    const hasDecoded = envelope.packet?.decoded != null && typeof decodedPortnum === 'number';
+    const isPosition = decodedPortnum === PortNum.POSITION_APP;
+    const isIgnored = fromNum !== null &&
+      databaseService.ignoredNodes.isIgnoredCached(fromNum, this.sourceId);
+
+    // Early-drop provably-non-position decoded traffic from ignored senders.
+    // Encrypted packets (no decoded portnum) can't be proven non-position, so
+    // they flow to ingestion, which re-drops non-position payloads from ignored
+    // senders after decrypt. POSITION always flows so post-decrypt evaluation
+    // can lift/re-ignore (reappearance path).
+    if (isIgnored && hasDecoded && !isPosition) return;
+
+    // Republish decision: never republish an ignored sender's traffic; never
+    // republish an out-of-bbox plaintext position (pollutes local nodeDBs).
+    // postFilterPosition increments drops.geo on the out case — run it for
+    // every plaintext position (even already-ignored senders) so the counter
+    // reflects all out-of-bbox position arrivals.
+    let republishAllowed = !isIgnored;
+    if (isPosition) {
+      const position = decodePosition(envelope.packet!.decoded!.payload);
+      const inside = this.downlinkFilter.postFilterPosition(position);
+      if (!inside) republishAllowed = false;
     }
 
     ingestServiceEnvelope({
@@ -722,16 +675,21 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     // this bridge as its `mqttLink` client-proxy target — issue #3134) can
     // relay the upstream packet to their device. Shape matches
     // MqttBrokerLocalPacket so listeners can target either source type.
-    this.emit('local-packet', {
-      topic,
-      payload,
-      retained,
-      envelope,
-      clientId: null,
-    });
+    // Gated on !isIgnored — an ignored sender's traffic must not reach
+    // client-proxy devices either.
+    if (!isIgnored) {
+      this.emit('local-packet', {
+        topic,
+        payload,
+        retained,
+        envelope,
+        clientId: null,
+      });
+    }
 
-    // Republish to local broker so devices see it. Skip if no parent attached.
-    if (this.parentBroker) {
+    // Republish to local broker so devices see it. Skip if no parent attached
+    // or if this packet failed the ignore/geo republish gate above.
+    if (this.parentBroker && republishAllowed) {
       // Apply downlink topic rewrite (#3166) right at the publish boundary —
       // ingestion, filters, and the local-packet event all stay on the
       // original topic. Echo recorded under the post-rewrite topic so the

--- a/src/server/mqttBrokerManager.test.ts
+++ b/src/server/mqttBrokerManager.test.ts
@@ -3,6 +3,21 @@ import { connect, type MqttClient } from 'mqtt';
 
 const upsertNode = vi.fn();
 const insertTelemetry = vi.fn();
+const insertMessage = vi.fn(async () => true);
+
+// Stateful fake for the manual-ignore gate (mqttIngestion.ts's defense-in-depth
+// check: `databaseService.ignoredNodes.isIgnoredCached(fromNum, sourceId)`).
+// Mirrors the real IgnoredNodesRepository's cache-key shape (`${sourceId}:${nodeNum}`)
+// closely enough for `addIgnoredNodeAsync` to make `isIgnoredCached` true, which is
+// all the Phase 2 broker-path coverage below needs.
+const ignoredCache = new Set<string>();
+function ignoreKey(nodeNum: number, sourceId: string): string {
+  return `${sourceId}:${nodeNum}`;
+}
+const addIgnoredNodeAsync = vi.fn(async (nodeNum: number, sourceId: string) => {
+  ignoredCache.add(ignoreKey(nodeNum, sourceId));
+});
+const isIgnoredCached = vi.fn((nodeNum: number, sourceId: string) => ignoredCache.has(ignoreKey(nodeNum, sourceId)));
 
 vi.mock('../services/database.js', () => ({
   default: {
@@ -10,11 +25,19 @@ vi.mock('../services/database.js', () => ({
     insertTelemetryAsync: async (...a: unknown[]) => insertTelemetry(...a),
     insertTracerouteAsync: vi.fn(async () => undefined),
     insertRouteSegmentAsync: vi.fn(async () => undefined),
+    messages: {
+      insertMessage: async (...a: unknown[]) => insertMessage(...a),
+    },
+    ignoredNodes: {
+      addIgnoredNodeAsync: async (...a: unknown[]) => addIgnoredNodeAsync(...(a as [number, string])),
+      isIgnoredCached: (...a: unknown[]) => isIgnoredCached(...(a as [number, string])),
+    },
   },
 }));
 
 import { MqttBrokerManager } from './mqttBrokerManager.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
+import databaseService from '../services/database.js';
 import { PortNum } from './constants/meshtastic.js';
 import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
 
@@ -92,6 +115,10 @@ describe('MqttBrokerManager', () => {
   beforeEach(async () => {
     upsertNode.mockClear();
     insertTelemetry.mockClear();
+    insertMessage.mockClear();
+    addIgnoredNodeAsync.mockClear();
+    isIgnoredCached.mockClear();
+    ignoredCache.clear();
     port = await ephemeralPort();
     manager = new MqttBrokerManager('test-broker', 'Test Broker', {
       listener: { port, host: '127.0.0.1' },
@@ -200,6 +227,81 @@ describe('MqttBrokerManager', () => {
     const status = manager.getStatus();
     expect(status.packetsDropped).toBeGreaterThanOrEqual(1);
     expect(status.packetsIngested).toBe(0);
+  });
+
+  // Phase 2 (MQTT Geo-Ignore epic, #4115/#4123): mqttIngestion.ts now applies
+  // a defense-in-depth ignore gate — `databaseService.ignoredNodes.isIgnoredCached`
+  // — to every non-POSITION packet, regardless of caller. This is a DELIBERATE
+  // broker-path behavior change: previously a manually-ignored node's packets
+  // published to a mqtt_broker source were never dropped at ingestion (the
+  // ignore list only affected the TCP/serial path). As of Phase 2, a manual
+  // ignore now suppresses MQTT ingestion too.
+  it('drops packets from a manually-ignored sender at ingestion (Phase 2 behavior change), while a non-ignored sender still ingests', async () => {
+    const IGNORED_NODE = 0x7ff80a49;
+    const OK_NODE = 0x7ff80a4a;
+
+    await databaseService.ignoredNodes.addIgnoredNodeAsync(
+      IGNORED_NODE, 'test-broker', '!7ff80a49', 'Ignored Node', 'IGN', 'admin',
+    );
+    expect(databaseService.ignoredNodes.isIgnoredCached(IGNORED_NODE, 'test-broker')).toBe(true);
+
+    client = connect(`mqtt://127.0.0.1:${port}`, {
+      username: 'mm',
+      password: 's3cret',
+      reconnectPeriod: 0,
+    });
+    await waitForEvent(client, 'connect');
+
+    const ignoredEnvelope = buildNodeInfoEnvelope({
+      from: IGNORED_NODE,
+      channelId: 'LongFast',
+      gatewayId: '!7ff80a49',
+      longName: 'Ignored Node',
+      shortName: 'IGN',
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      client!.publish(
+        'msh/US/2/e/LongFast/!7ff80a49',
+        ignoredEnvelope,
+        { qos: 0 },
+        (err) => (err ? reject(err) : resolve()),
+      );
+    });
+
+    // ingestServiceEnvelope resolves the 'ignored' result asynchronously —
+    // poll for the drop counter instead of asserting on the immediate tick.
+    await vi.waitFor(() => {
+      const s = manager.getStatus();
+      expect(s.packetsIn).toBeGreaterThanOrEqual(1);
+      expect(s.packetsDropped).toBeGreaterThanOrEqual(1);
+    });
+    expect(manager.getStatus().packetsIngested).toBe(0);
+    expect(upsertNode).not.toHaveBeenCalled();
+
+    // A non-ignored sender's packet on the same broker still ingests normally.
+    const okEnvelope = buildNodeInfoEnvelope({
+      from: OK_NODE,
+      channelId: 'LongFast',
+      gatewayId: '!7ff80a4a',
+      longName: 'OK Node',
+      shortName: 'OK',
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      client!.publish(
+        'msh/US/2/e/LongFast/!7ff80a4a',
+        okEnvelope,
+        { qos: 0 },
+        (err) => (err ? reject(err) : resolve()),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(manager.getStatus().packetsIngested).toBeGreaterThanOrEqual(1);
+    });
+    const okUpsert = upsertNode.mock.calls.find((c) => (c[0] as Record<string, unknown>).nodeNum === OK_NODE);
+    expect(okUpsert).toBeDefined();
   });
 });
 

--- a/src/server/mqttIngestion.perSource.test.ts
+++ b/src/server/mqttIngestion.perSource.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Per-source isolation tests for the MQTT geo-ignore flow (MQTT Geo-Ignore
+ * epic, Phase 2 / WP4).
+ *
+ * Unlike `mqttIngestion.test.ts` (which mocks `../services/database.js`
+ * wholesale to pin the wiring/branching of `ingestServiceEnvelope`), this
+ * file exercises the REAL singleton `databaseService` against its
+ * `:memory:` SQLite backend (see `src/server/test-helpers/routeTestApp.ts`
+ * for the same singleton-DB rationale). Per-source isolation is exactly
+ * the kind of thing a database mock can't prove — only a real repository,
+ * scoped by `sourceId`, can demonstrate that a geo-ignore/purge on one
+ * source never leaks to another.
+ *
+ * `meshtasticProtobufService` IS still mocked here (as in
+ * `mqttIngestion.test.ts`) — that module's protobuf decoding isn't what's
+ * under test, and mocking it lets each case control the decoded
+ * lat/lng deterministically.
+ *
+ * IMPORTANT: several of the DB writes exercised here are fire-and-forget
+ * inside `ingestServiceEnvelope` (`void databaseService.upsertNodeAsync(...)`,
+ * `void databaseService.deleteNodeAsync(...)` for the geo-purge). Tests that
+ * assert on those rows must `vi.waitFor(...)` rather than read immediately
+ * after `await ingestServiceEnvelope(...)` resolves. The `ignored_nodes`
+ * row itself IS awaited synchronously (`addGeoIgnoreAsync`/`liftGeoIgnoreAsync`
+ * are awaited directly in the POSITION_APP branch), so those checks don't
+ * need polling.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+// Only the protobuf decode step is mocked — real singleton databaseService
+// backs everything else. See file header.
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    processPayload: vi.fn((portnum: number, _payload: Uint8Array) => {
+      if (portnum === 3 /* POSITION_APP */) {
+        // Default: inside ON_BBOX (43.7, -79.3). Individual tests override
+        // with mockImplementationOnce/mockReturnValueOnce for out-of-bbox.
+        return { latitudeI: 437_000_000, longitudeI: -793_000_000 };
+      }
+      if (portnum === 1 /* TEXT_MESSAGE_APP */) {
+        return 'hello';
+      }
+      if (portnum === 67 /* TELEMETRY_APP */) {
+        return { deviceMetrics: { batteryLevel: 88 } };
+      }
+      return null;
+    }),
+  },
+}));
+
+import { ingestServiceEnvelope } from './mqttIngestion.js';
+import { MqttPacketFilter, nodeNumToId, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
+import databaseService, { type DbMessage, type DbTelemetry } from '../services/database.js';
+
+const SRC_A = 'geo-ps-src-a';
+const SRC_B = 'geo-ps-src-b';
+
+// Bounding box used across every case — matches mqttIngestion.test.ts's ON_BBOX.
+const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+
+// Vancouver — well outside ON_BBOX.
+const OUT_POSITION = { latitudeI: 492_000_000, longitudeI: -1_230_000_000 };
+
+function envFor(from: number, portnum: number, packetId = 0x12345678): ServiceEnvelopeShape {
+  return {
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: packetId,
+      from,
+      to: 0xffffffff,
+      channel: 0,
+      decoded: { portnum, payload: new Uint8Array([0]) },
+    },
+  };
+}
+
+describe('ingestServiceEnvelope — geo-ignore per-source isolation', () => {
+  beforeAll(async () => {
+    await databaseService.waitForReady();
+    // Idempotent: clear out any leftovers from a prior run of this same file
+    // (singleton DB persists for the whole test file — see routeTestApp.ts).
+    await databaseService.sources.deleteSource(SRC_A).catch(() => {});
+    await databaseService.sources.deleteSource(SRC_B).catch(() => {});
+    await databaseService.sources.createSource({ id: SRC_A, name: 'Source A', type: 'meshtastic_tcp', config: {}, enabled: true });
+    await databaseService.sources.createSource({ id: SRC_B, name: 'Source B', type: 'meshtastic_tcp', config: {}, enabled: true });
+  });
+
+  afterAll(async () => {
+    // FK ON DELETE CASCADE (migration 048) takes ignored_nodes/nodes/messages/
+    // telemetry rows scoped to these sources with them.
+    await databaseService.sources.deleteSource(SRC_A).catch(() => {});
+    await databaseService.sources.deleteSource(SRC_B).catch(() => {});
+  });
+
+  it('geo-ignores (nodeNum, sourceA) on an out-of-bbox POSITION while (nodeNum, sourceB) stays un-ignored and its node row survives the purge', async () => {
+    const NODE = 0x10000001;
+    const NODE_ID = nodeNumToId(NODE);
+
+    // Seed a node row on sourceB for the SAME physical nodeNum, so we can
+    // prove the sourceA-scoped purge never touches it.
+    await databaseService.upsertNodeAsync({
+      nodeNum: NODE,
+      nodeId: NODE_ID,
+      longName: 'Node One B',
+      shortName: 'N1B',
+      hwModel: 1,
+      lastHeard: Math.floor(Date.now() / 1000),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }, SRC_B);
+    expect(await databaseService.nodes.getNode(NODE, SRC_B)).not.toBeNull();
+
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => OUT_POSITION);
+
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+    const result = await ingestServiceEnvelope({
+      sourceId: SRC_A,
+      envelope: envFor(NODE, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('geo-ignored');
+
+    // addGeoIgnoreAsync is awaited synchronously inside the POSITION_APP
+    // branch, so the ignore row + cache are visible immediately.
+    expect(databaseService.ignoredNodes.isIgnoredCached(NODE, SRC_A)).toBe(true);
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_A)).toBe(true);
+    expect(databaseService.ignoredNodes.isIgnoredCached(NODE, SRC_B)).toBe(false);
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(false);
+
+    const onA = await databaseService.ignoredNodes.getIgnoredNodesAsync(SRC_A);
+    expect(onA.find((r) => r.nodeNum === NODE)?.reason).toBe('geo');
+    const onB = await databaseService.ignoredNodes.getIgnoredNodesAsync(SRC_B);
+    expect(onB.find((r) => r.nodeNum === NODE)).toBeUndefined();
+
+    // The purge itself is fire-and-forget (`void databaseService.deleteNodeAsync(...)`).
+    // Wait for sourceA's node row to disappear, which proves the purge ran.
+    await vi.waitFor(async () => {
+      expect(await databaseService.nodes.getNode(NODE, SRC_A)).toBeNull();
+    });
+
+    // sourceB's node row must be completely untouched by the sourceA purge.
+    const nodeB = await databaseService.nodes.getNode(NODE, SRC_B);
+    expect(nodeB).not.toBeNull();
+    expect(nodeB?.longName).toBe('Node One B');
+  });
+
+  it('still ingests non-POSITION traffic from the same nodeNum on sourceB — the ignore gate is per-source', async () => {
+    // Reuses the nodeNum geo-ignored on sourceA in the previous case; that
+    // ignore must have zero effect on sourceB.
+    const NODE = 0x10000001;
+    const PACKET_ID = 0x22223333;
+
+    const resultA = await ingestServiceEnvelope({
+      sourceId: SRC_A,
+      envelope: envFor(NODE, 1 /* TEXT_MESSAGE_APP */, PACKET_ID),
+    });
+    expect(resultA.ingested).toBe(false);
+    expect(resultA.reason).toBe('ignored');
+
+    const resultB = await ingestServiceEnvelope({
+      sourceId: SRC_B,
+      envelope: envFor(NODE, 1 /* TEXT_MESSAGE_APP */, PACKET_ID),
+    });
+    expect(resultB.ingested).toBe(true);
+
+    // insertMessage is fire-and-forget in the TEXT_MESSAGE_APP branch.
+    await vi.waitFor(async () => {
+      const msg = await databaseService.messages.getMessage(`${SRC_B}_${NODE}_${PACKET_ID}`);
+      expect(msg).not.toBeNull();
+    });
+    // Confirm sourceA never got a matching row for the dropped packet.
+    const msgA = await databaseService.messages.getMessage(`${SRC_A}_${NODE}_${PACKET_ID}`);
+    expect(msgA).toBeNull();
+  });
+
+  it('an in-bbox POSITION on sourceA lifts only sourceA\'s geo-ignore; a geo row manually seeded on sourceB stays', async () => {
+    const NODE = 0x10000003;
+    const NODE_ID = nodeNumToId(NODE);
+
+    // Manually seed geo-ignore rows on BOTH sources via the real repo.
+    await databaseService.ignoredNodes.addGeoIgnoreAsync(NODE, SRC_A, NODE_ID, 'Node3A', 'N3A');
+    await databaseService.ignoredNodes.addGeoIgnoreAsync(NODE, SRC_B, NODE_ID, 'Node3B', 'N3B');
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_A)).toBe(true);
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(true);
+
+    // Default mock POSITION_APP payload is inside ON_BBOX.
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+    const result = await ingestServiceEnvelope({
+      sourceId: SRC_A,
+      envelope: envFor(NODE, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    // liftGeoIgnoreAsync is awaited synchronously before the re-check, so the
+    // node reappears and ingestion proceeds in the same call.
+    expect(result.ingested).toBe(true);
+
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_A)).toBe(false);
+    expect(databaseService.ignoredNodes.isIgnoredCached(NODE, SRC_A)).toBe(false);
+
+    // sourceB's manually-seeded geo row must be completely untouched.
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(true);
+    const onB = await databaseService.ignoredNodes.getIgnoredNodesAsync(SRC_B);
+    expect(onB.find((r) => r.nodeNum === NODE)?.reason).toBe('geo');
+  });
+
+  it('purge scoping: a geo-ignore transition on sourceA purges only sourceA\'s node/message/telemetry rows, leaving sourceB\'s intact', async () => {
+    const NODE = 0x10000004;
+    const NODE_ID = nodeNumToId(NODE);
+    const PACKET_ID_A = 0xaaaa0001;
+    const PACKET_ID_B = 0xbbbb0001;
+
+    // Seed node + message + telemetry on BOTH sources for this nodeNum.
+    for (const [sourceId, packetId] of [[SRC_A, PACKET_ID_A], [SRC_B, PACKET_ID_B]] as const) {
+      await databaseService.upsertNodeAsync({
+        nodeNum: NODE,
+        nodeId: NODE_ID,
+        longName: 'Node Four',
+        shortName: 'N4',
+        hwModel: 1,
+        lastHeard: Math.floor(Date.now() / 1000),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }, sourceId);
+
+      await databaseService.messages.insertMessage({
+        id: `${sourceId}_${NODE}_${packetId}`,
+        fromNodeNum: NODE,
+        toNodeNum: 0xffffffff,
+        fromNodeId: NODE_ID,
+        toNodeId: '!ffffffff',
+        text: 'seed message',
+        channel: 0,
+        portnum: 1,
+        timestamp: Date.now(),
+        createdAt: Date.now(),
+      } as DbMessage, sourceId);
+
+      await databaseService.insertTelemetryAsync({
+        nodeId: NODE_ID,
+        nodeNum: NODE,
+        telemetryType: 'batteryLevel',
+        timestamp: Date.now(),
+        value: 77,
+        unit: '%',
+        createdAt: Date.now(),
+      } as DbTelemetry, sourceId);
+    }
+
+    // Confirm the seed actually landed on both sources before triggering.
+    expect(await databaseService.nodes.getNode(NODE, SRC_A)).not.toBeNull();
+    expect(await databaseService.nodes.getNode(NODE, SRC_B)).not.toBeNull();
+    expect(await databaseService.messages.getMessage(`${SRC_A}_${NODE}_${PACKET_ID_A}`)).not.toBeNull();
+    expect(await databaseService.messages.getMessage(`${SRC_B}_${NODE}_${PACKET_ID_B}`)).not.toBeNull();
+
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => OUT_POSITION);
+
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+    const result = await ingestServiceEnvelope({
+      sourceId: SRC_A,
+      envelope: envFor(NODE, 3 /* POSITION_APP */),
+      filter,
+    });
+    expect(result.reason).toBe('geo-ignored');
+
+    // The full-purge cascade (deleteNodeAsync) is fire-and-forget — poll for
+    // sourceA's node row to disappear, which proves the cascade completed.
+    await vi.waitFor(async () => {
+      expect(await databaseService.nodes.getNode(NODE, SRC_A)).toBeNull();
+    });
+
+    // sourceA's message + telemetry are gone too (same cascade).
+    expect(await databaseService.messages.getMessage(`${SRC_A}_${NODE}_${PACKET_ID_A}`)).toBeNull();
+    const telA = await databaseService.telemetry.getTelemetryByNode(NODE_ID, 100, undefined, undefined, 0, undefined, SRC_A);
+    expect(telA).toHaveLength(0);
+
+    // sourceB's node + message + telemetry must be completely intact.
+    const nodeB = await databaseService.nodes.getNode(NODE, SRC_B);
+    expect(nodeB).not.toBeNull();
+    const msgB = await databaseService.messages.getMessage(`${SRC_B}_${NODE}_${PACKET_ID_B}`);
+    expect(msgB).not.toBeNull();
+    const telB = await databaseService.telemetry.getTelemetryByNode(NODE_ID, 100, undefined, undefined, 0, undefined, SRC_B);
+    expect(telB.length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -20,6 +20,13 @@ vi.mock('../services/database.js', () => ({
     insertTracerouteAsync: vi.fn(async () => undefined),
     insertRouteSegment: vi.fn(),
     insertRouteSegmentAsync: vi.fn(async () => undefined),
+    deleteNodeAsync: vi.fn(async () => ({
+      messagesDeleted: 0,
+      broadcastMessagesDeleted: 0,
+      traceroutesDeleted: 0,
+      telemetryDeleted: 0,
+      nodeDeleted: true,
+    })),
     nodes: {
       getNode: vi.fn(async () => null),
       getNodesByNums: vi.fn(async () => new Map()),
@@ -45,6 +52,11 @@ vi.mock('../services/database.js', () => ({
       // method is kept mocked too for any other callers.
       findOrCreatePassiveByNameAsync: vi.fn(async () => undefined),
       findOrCreateByNameAndHashAsync: vi.fn(async () => undefined),
+    },
+    ignoredNodes: {
+      isIgnoredCached: vi.fn(() => false),
+      addGeoIgnoreAsync: vi.fn(async () => true),
+      liftGeoIgnoreAsync: vi.fn(async () => true),
     },
   },
 }));
@@ -107,100 +119,12 @@ function envFor(from: number, portnum: number): ServiceEnvelopeShape {
   };
 }
 
-describe('ingestServiceEnvelope — fail-closed membership', () => {
+describe('ingestServiceEnvelope — fail-open back-compat (#4115)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it('drops a TEXT_MESSAGE from an unknown sender when bbox is enabled', async () => {
-    const filter = new MqttPacketFilter({ geo: ON_BBOX });
-    const result = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_UNKNOWN, 1 /* TEXT_MESSAGE_APP */),
-      filter,
-    });
-    expect(result.ingested).toBe(false);
-    expect(result.reason).toBe('geo-filtered');
-    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
-    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
-    expect(filter.getDropCounters().geo).toBe(1);
-  });
-
-  it('drops NODEINFO from an unknown sender when bbox is enabled', async () => {
-    const filter = new MqttPacketFilter({ geo: ON_BBOX });
-    const result = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_UNKNOWN, 4 /* NODEINFO_APP */),
-      filter,
-    });
-    expect(result.ingested).toBe(false);
-    expect(result.reason).toBe('geo-filtered');
-    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
-  });
-
-  it('drops TELEMETRY from an unknown sender when bbox is enabled', async () => {
-    const filter = new MqttPacketFilter({ geo: ON_BBOX });
-    const result = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_UNKNOWN, 67 /* TELEMETRY_APP */),
-      filter,
-    });
-    expect(result.ingested).toBe(false);
-    expect(result.reason).toBe('geo-filtered');
-    expect(databaseService.insertTelemetryAsync).not.toHaveBeenCalled();
-  });
-
-  it('allows a TEXT_MESSAGE after the same sender posted an in-bbox POSITION', async () => {
-    const filter = new MqttPacketFilter({ geo: ON_BBOX });
-
-    // Step 1: position learns NODE_IN as 'in'.
-    const posResult = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
-      filter,
-    });
-    expect(posResult.ingested).toBe(true);
-    expect(filter.getMembershipSize()).toBe(1);
-
-    // Step 2: text message from the same sender now passes the gate.
-    vi.clearAllMocks();
-    const txtResult = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
-      filter,
-    });
-    expect(txtResult.ingested).toBe(true);
-    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it('blocks TEXT_MESSAGE after the same sender posted an out-of-bbox POSITION', async () => {
-    // Override processPayload for this test to return an out-of-bbox position.
-    const { default: protobuf } = await import('./meshtasticProtobufService.js');
-    (protobuf.processPayload as any).mockImplementationOnce(() => ({
-      latitudeI: 492_000_000, // Vancouver — outside ON_BBOX
-      longitudeI: -1_230_000_000,
-    }));
-
-    const filter = new MqttPacketFilter({ geo: ON_BBOX });
-
-    // Position is out → bbox rejects, cache marks NODE_OUT as 'out'.
-    const posResult = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_OUT, 3 /* POSITION_APP */),
-      filter,
-    });
-    expect(posResult.ingested).toBe(false);
-    expect(posResult.reason).toBe('geo-filtered');
-
-    // Subsequent text from the same sender — known-out → drop.
-    const txtResult = await ingestServiceEnvelope({
-      sourceId: 'bridge-1',
-      envelope: envFor(NODE_OUT, 1 /* TEXT_MESSAGE_APP */),
-      filter,
-    });
-    expect(txtResult.ingested).toBe(false);
-    expect(txtResult.reason).toBe('geo-filtered');
-    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    (databaseService.ignoredNodes.addGeoIgnoreAsync as any).mockResolvedValue(true);
+    (databaseService.ignoredNodes.liftGeoIgnoreAsync as any).mockResolvedValue(true);
   });
 
   it('passes everything when no filter is supplied (back-compat)', async () => {
@@ -213,6 +137,17 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('passes non-position packets when a filter without bbox is supplied', async () => {
+    const filter = new MqttPacketFilter({});
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_UNKNOWN, 1 /* TEXT_MESSAGE_APP */),
+      filter,
+    });
+    expect(result.ingested).toBe(true);
+    expect(filter.getDropCounters().geo).toBe(0);
+  });
+
   it('passes non-position packets when bbox is configured with empty bounds', async () => {
     const filter = new MqttPacketFilter({ geo: {} });
     const result = await ingestServiceEnvelope({
@@ -222,6 +157,226 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     });
     expect(result.ingested).toBe(true);
     expect(filter.getDropCounters().geo).toBe(0);
+  });
+
+  // #4115: ingestion-level gating is fail-open by construction. A bbox being
+  // configured no longer causes non-position traffic from an unknown/never-
+  // seen sender to be dropped — MqttPacketFilter carries no membership state
+  // anymore, and ignore/lift/purge decisions are made solely off the
+  // ignored_nodes table, keyed off actual POSITION observations.
+  it('ingests a NODEINFO from an unknown sender even when a bbox IS configured', async () => {
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_UNKNOWN, 4 /* NODEINFO_APP */),
+      filter,
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.upsertNodeAsync).toHaveBeenCalled();
+  });
+
+  it('ingests a TEXT_MESSAGE from an unknown sender even when a bbox IS configured', async () => {
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_UNKNOWN, 1 /* TEXT_MESSAGE_APP */),
+      filter,
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ingestServiceEnvelope — ignore gate (defense-in-depth)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    (databaseService.ignoredNodes.addGeoIgnoreAsync as any).mockResolvedValue(true);
+    (databaseService.ignoredNodes.liftGeoIgnoreAsync as any).mockResolvedValue(true);
+  });
+
+  it('drops a TEXT_MESSAGE from an ignored sender without touching insertMessage/upsertNode', async () => {
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_OUT, 1 /* TEXT_MESSAGE_APP */),
+    });
+    expect(result).toMatchObject({ ingested: false, reason: 'ignored' });
+    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('drops TELEMETRY from an ignored sender without touching insertTelemetryAsync/upsertNode', async () => {
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_OUT, 67 /* TELEMETRY_APP */),
+    });
+    expect(result).toMatchObject({ ingested: false, reason: 'ignored' });
+    expect(databaseService.insertTelemetryAsync).not.toHaveBeenCalled();
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('drops NODEINFO from an ignored sender without touching upsertNode', async () => {
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_OUT, 4 /* NODEINFO_APP */),
+    });
+    expect(result).toMatchObject({ ingested: false, reason: 'ignored' });
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('ingests non-position traffic from a non-ignored sender', async () => {
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ingestServiceEnvelope — POSITION geo evaluation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    (databaseService.ignoredNodes.addGeoIgnoreAsync as any).mockResolvedValue(true);
+    (databaseService.ignoredNodes.liftGeoIgnoreAsync as any).mockResolvedValue(true);
+  });
+
+  const outOfBboxOnce = async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({
+      latitudeI: 492_000_000, // Vancouver — outside ON_BBOX
+      longitudeI: -1_230_000_000,
+    }));
+  };
+
+  it('geo-ignores an out-of-bbox position and purges once (addGeoIgnoreAsync → true)', async () => {
+    await outOfBboxOnce();
+    (databaseService.ignoredNodes.addGeoIgnoreAsync as any).mockResolvedValueOnce(true);
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_OUT, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(result).toMatchObject({ ingested: false, reason: 'geo-ignored' });
+    expect(databaseService.ignoredNodes.addGeoIgnoreAsync).toHaveBeenCalledWith(
+      NODE_OUT,
+      'bridge-1',
+      expect.any(String),
+      undefined,
+      undefined,
+    );
+    // Fire-and-forget purge — await a microtask tick so the .then() lands.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(databaseService.deleteNodeAsync).toHaveBeenCalledTimes(1);
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not re-purge an already geo-ignored node (addGeoIgnoreAsync → false)', async () => {
+    await outOfBboxOnce();
+    (databaseService.ignoredNodes.addGeoIgnoreAsync as any).mockResolvedValueOnce(false);
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_OUT, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(result).toMatchObject({ ingested: false, reason: 'geo-ignored' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(databaseService.deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('lifts a geo-ignore and ingests on reappearance (in-bbox position)', async () => {
+    // Sender starts geo-ignored; lift succeeds and clears the cached flag —
+    // mirrors the real repository behavior of isIgnoredCached flipping after
+    // a successful liftGeoIgnoreAsync.
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
+    (databaseService.ignoredNodes.liftGeoIgnoreAsync as any).mockImplementationOnce(async () => {
+      (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+      return true;
+    });
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(databaseService.ignoredNodes.liftGeoIgnoreAsync).toHaveBeenCalledWith(NODE_IN, 'bridge-1');
+    expect(result.ingested).toBe(true);
+    expect(databaseService.upsertNodeAsync).toHaveBeenCalled();
+  });
+
+  it('does not lift a MANUAL ignore, and the in-bbox position still does not ingest', async () => {
+    // liftGeoIgnoreAsync is TOCTOU-safe and never touches a manual reason —
+    // it returns false and isIgnoredCached stays true.
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
+    (databaseService.ignoredNodes.liftGeoIgnoreAsync as any).mockResolvedValueOnce(false);
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(databaseService.ignoredNodes.liftGeoIgnoreAsync).toHaveBeenCalledWith(NODE_IN, 'bridge-1');
+    expect(result).toMatchObject({ ingested: false, reason: 'ignored' });
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('drops a coordless position from an ignored sender as "ignored"', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({}));
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_OUT, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(result).toMatchObject({ ingested: false, reason: 'ignored' });
+    expect(databaseService.upsertNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('ingests a coordless position from a non-ignored sender (fail-open, classifies unknown)', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({}));
+    const filter = new MqttPacketFilter({ geo: ON_BBOX });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_UNKNOWN, 3 /* POSITION_APP */),
+      filter,
+    });
+
+    expect(result.ingested).toBe(true);
+    expect(databaseService.upsertNodeAsync).toHaveBeenCalled();
+  });
+
+  it('ingests a position normally with no geo filter configured, without touching ignore/lift/purge', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+      // No filter → classifyPosition treats it as 'no-geo'.
+    });
+
+    expect(result.ingested).toBe(true);
+    expect(databaseService.ignoredNodes.addGeoIgnoreAsync).not.toHaveBeenCalled();
+    expect(databaseService.ignoredNodes.liftGeoIgnoreAsync).not.toHaveBeenCalled();
+    expect(databaseService.deleteNodeAsync).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -266,12 +266,14 @@ describe('ingestServiceEnvelope — POSITION geo evaluation', () => {
     });
 
     expect(result).toMatchObject({ ingested: false, reason: 'geo-ignored' });
+    // No stored NodeInfo for this sender — the ignore entry falls back to the
+    // traceroute-style stub name so the ignore-list UI never shows a blank.
     expect(databaseService.ignoredNodes.addGeoIgnoreAsync).toHaveBeenCalledWith(
       NODE_OUT,
       'bridge-1',
-      expect.any(String),
-      undefined,
-      undefined,
+      expect.stringMatching(/^![0-9a-f]{8}$/),
+      expect.stringMatching(/^Node ![0-9a-f]{8}$/),
+      expect.stringMatching(/^[0-9a-f]{4}$/),
     );
     // Fire-and-forget purge — await a microtask tick so the .then() lands.
     await new Promise((r) => setTimeout(r, 0));

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -274,13 +274,20 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         const existing = await databaseService.nodes.getNode(fromNum, sourceId);
         const inserted = await databaseService.ignoredNodes.addGeoIgnoreAsync(
           fromNum, sourceId, fromNodeId,
-          existing?.longName ?? undefined,
-          existing?.shortName ?? undefined,
+          // A node whose first-ever packet is an out-of-bbox POSITION has no
+          // stored NodeInfo — fall back to the same stub naming the
+          // traceroute path uses so the ignore-list UI never shows a blank.
+          existing?.longName ?? `Node ${fromNodeId}`,
+          existing?.shortName ?? fromNodeId.slice(-4),
         );
         if (inserted) {
           // Fire-and-forget full purge (messages incl. broadcasts, telemetry,
           // traceroutes, neighbors, packet logs, node row). Ingestion must not
-          // block the packet loop on a multi-table cascade.
+          // block the packet loop on a multi-table cascade. The ignore-cache
+          // entry is already live (awaited above), so the gate drops the
+          // node's subsequent traffic while the purge runs; a write racing
+          // the cascade is last-writer-wins on the node row, which the next
+          // packet's gate makes moot.
           void databaseService.deleteNodeAsync(fromNum, sourceId).catch((err) =>
             logger.warn(`Geo-purge failed for ${fromNodeId}@${sourceId}: ${err}`));
         }

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -103,16 +103,19 @@ export interface MqttIngestionInput {
   sourceId: string;
   envelope: ServiceEnvelopeShape;
   /**
-   * Geo filter applied to POSITION_APP payloads after decode. Pass the
-   * same MqttPacketFilter instance used for preFilter so its drop counter
-   * stays consistent.
+   * Geo filter used to classify POSITION_APP payloads after decode. Pass the
+   * same MqttPacketFilter instance used for preFilter. `filter.classifyPosition`
+   * performs a pure bbox classification ('in' | 'out' | 'unknown' | 'no-geo')
+   * against the decoded position — it no longer tracks membership or drop
+   * counters; ignore/lift/purge state lives in the `ignored_nodes` table via
+   * `databaseService.ignoredNodes` instead.
    */
   filter?: MqttPacketFilter;
 }
 
 export interface MqttIngestionResult {
   ingested: boolean;
-  reason?: 'no-packet' | 'no-decoded' | 'encrypted' | 'unsupported-portnum' | 'geo-filtered' | 'decode-error';
+  reason?: 'no-packet' | 'no-decoded' | 'encrypted' | 'unsupported-portnum' | 'ignored' | 'geo-ignored' | 'decode-error';
   portnum?: number;
 }
 
@@ -209,13 +212,15 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
   const effectiveChannel =
     channelDatabaseId !== null ? CHANNEL_DB_OFFSET + channelDatabaseId : rawSlot;
 
-  // Fail-closed geo membership: when a bbox is configured on the filter,
-  // only allow packets from senders we've previously decoded a position
-  // for AND that position was inside the bbox. POSITION_APP is exempt
-  // here because the bbox check on the position payload (below) is what
-  // populates the membership cache in the first place.
-  if (filter && portnum !== PortNum.POSITION_APP && !filter.passesMembership(fromNum)) {
-    return { ingested: false, reason: 'geo-filtered', portnum };
+  // Defense-in-depth ignore gate. Ignored senders' non-POSITION traffic never
+  // ingests — covers the broker-manager caller (which shares this function and
+  // has no handleDownlink pre-gate) and any encrypted packet that decrypted to
+  // a non-position payload. POSITION flows through to its case below so the
+  // node can reappear (lift) or be re-evaluated. Applies to BOTH reasons
+  // (manual + geo).
+  if (portnum !== PortNum.POSITION_APP &&
+      databaseService.ignoredNodes.isIgnoredCached(fromNum, sourceId)) {
+    return { ingested: false, reason: 'ignored', portnum };
   }
 
   switch (portnum) {
@@ -260,9 +265,43 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
 
     case PortNum.POSITION_APP: {
       const position = payload as PositionShape & Record<string, any>;
-      if (filter && !filter.postFilterPosition(position, fromNum)) {
-        return { ingested: false, reason: 'geo-filtered', portnum };
+      const geo = filter ? filter.classifyPosition(position) : 'no-geo';
+
+      if (geo === 'out') {
+        // Outside the boundary. Capture display names before purge so the
+        // ignore-list UI shows a real name, then geo-ignore (insert-if-absent)
+        // and purge ONCE on the transition. Never clobbers a manual ignore.
+        const existing = await databaseService.nodes.getNode(fromNum, sourceId);
+        const inserted = await databaseService.ignoredNodes.addGeoIgnoreAsync(
+          fromNum, sourceId, fromNodeId,
+          existing?.longName ?? undefined,
+          existing?.shortName ?? undefined,
+        );
+        if (inserted) {
+          // Fire-and-forget full purge (messages incl. broadcasts, telemetry,
+          // traceroutes, neighbors, packet logs, node row). Ingestion must not
+          // block the packet loop on a multi-table cascade.
+          void databaseService.deleteNodeAsync(fromNum, sourceId).catch((err) =>
+            logger.warn(`Geo-purge failed for ${fromNodeId}@${sourceId}: ${err}`));
+        }
+        return { ingested: false, reason: 'geo-ignored', portnum };
       }
+
+      if (geo === 'in') {
+        // Inside → node reappears. Lift a geo-ignore if one exists (no-op for
+        // manual / absent). liftGeoIgnoreAsync is TOCTOU-safe.
+        await databaseService.ignoredNodes.liftGeoIgnoreAsync(fromNum, sourceId);
+      }
+
+      // After any lift attempt, a still-ignored sender must NOT ingest — this
+      // catches manual ignores with an in-bounds position, a geo lift that lost
+      // the race to a manual upgrade, and coordless ('unknown') positions from
+      // an ignored node. A never-ignored node (or one just lifted) passes.
+      if (databaseService.ignoredNodes.isIgnoredCached(fromNum, sourceId)) {
+        return { ingested: false, reason: 'ignored', portnum };
+      }
+
+      // Fail-open ingest ('in' reappearance, 'unknown', or 'no-geo').
       const latI = position.latitudeI ?? position.latitude_i;
       const lngI = position.longitudeI ?? position.longitude_i;
       const alt = position.altitude;

--- a/src/server/mqttPacketFilter.test.ts
+++ b/src/server/mqttPacketFilter.test.ts
@@ -159,20 +159,22 @@ describe('MqttPacketFilter.preFilter — portnum', () => {
   });
 });
 
-describe('MqttPacketFilter.postFilterPosition — geo bbox', () => {
-  it('passes when no bbox configured', () => {
+describe('MqttPacketFilter.postFilterPosition — geo bbox republish gate', () => {
+  it('passes when no bbox configured (no-geo)', () => {
     const f = new MqttPacketFilter({});
     expect(f.postFilterPosition({ latitudeI: 44_300_000, longitudeI: -78_300_000 })).toBe(true);
+    expect(f.getDropCounters().geo).toBe(0);
   });
 
-  it('passes position inside the bbox', () => {
+  it('passes position inside the bbox, no drop counted', () => {
     const f = new MqttPacketFilter({
       geo: { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 },
     });
     expect(f.postFilterPosition({ latitudeI: 440_000_000, longitudeI: -780_000_000 })).toBe(true);
+    expect(f.getDropCounters().geo).toBe(0);
   });
 
-  it('drops position south of minLat', () => {
+  it('drops position south of minLat and increments drops.geo', () => {
     const f = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45 } });
     expect(f.postFilterPosition({ latitudeI: 420_000_000, longitudeI: 0 })).toBe(false);
     expect(f.getDropCounters().geo).toBe(1);
@@ -200,259 +202,89 @@ describe('MqttPacketFilter.postFilterPosition — geo bbox', () => {
     expect(f.postFilterPosition({ latitude_i: 440_000_000, longitude_i: 0 })).toBe(true);
   });
 
-  it('passes when position lacks lat/lon (cannot filter)', () => {
+  it('passes (no drop) when position lacks lat/lon (unknown)', () => {
     const f = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45 } });
     expect(f.postFilterPosition({})).toBe(true);
+    expect(f.getDropCounters().geo).toBe(0);
+  });
+
+  it('passes (no drop) when position is null (unknown)', () => {
+    const f = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45 } });
+    expect(f.postFilterPosition(null)).toBe(true);
+    expect(f.getDropCounters().geo).toBe(0);
   });
 });
 
-describe('MqttPacketFilter.passesMembership — fail-closed geo membership', () => {
-  // Bbox approximately covering southern Ontario for these tests.
+describe('MqttPacketFilter.classifyPosition — pure bbox classifier', () => {
   const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
-  const NODE_IN = 0x7ff80a48;
-  const NODE_OUT = 0x11111111;
-  const NODE_UNKNOWN = 0x22222222;
 
-  it('no-op (passes everything) when no bbox is configured', () => {
+  it("returns 'no-geo' when no bbox is configured", () => {
     const f = new MqttPacketFilter({});
-    expect(f.passesMembership(NODE_UNKNOWN)).toBe(true);
-    expect(f.passesMembership(null)).toBe(true);
-    expect(f.passesMembership(undefined)).toBe(true);
-    expect(f.getDropCounters().geo).toBe(0);
+    expect(f.classifyPosition({ latitudeI: 440_000_000, longitudeI: -780_000_000 })).toBe(
+      'no-geo',
+    );
   });
 
-  it('no-op when geo object exists but has no actual bounds set', () => {
+  it("returns 'no-geo' when geo object exists but has no actual bounds set", () => {
     // {} is truthy but has no min/max — should behave like "no bbox".
     const f = new MqttPacketFilter({ geo: {} });
-    expect(f.passesMembership(NODE_UNKNOWN)).toBe(true);
-    expect(f.getDropCounters().geo).toBe(0);
+    expect(f.classifyPosition({ latitudeI: 440_000_000, longitudeI: -780_000_000 })).toBe(
+      'no-geo',
+    );
   });
 
-  it('drops unknown senders when bbox is enabled (fail-closed)', () => {
+  it("returns 'unknown' for a null position", () => {
     const f = new MqttPacketFilter({ geo: ON_BBOX });
-    expect(f.passesMembership(NODE_UNKNOWN)).toBe(false);
-    expect(f.getDropCounters().geo).toBe(1);
+    expect(f.classifyPosition(null)).toBe('unknown');
   });
 
-  it('drops when fromNum is missing entirely', () => {
+  it("returns 'unknown' when coordinates are missing", () => {
     const f = new MqttPacketFilter({ geo: ON_BBOX });
-    expect(f.passesMembership(null)).toBe(false);
-    expect(f.passesMembership(undefined)).toBe(false);
-    expect(f.getDropCounters().geo).toBe(2);
+    expect(f.classifyPosition({})).toBe('unknown');
   });
 
-  it('learns membership from a position inside the bbox', () => {
+  it("returns 'in' for a position inside the bbox", () => {
     const f = new MqttPacketFilter({ geo: ON_BBOX });
-    // Toronto-ish — clearly inside.
-    expect(
-      f.postFilterPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 }, NODE_IN),
-    ).toBe(true);
-    // Subsequent non-position packets pass.
-    expect(f.passesMembership(NODE_IN)).toBe(true);
-    expect(f.getMembershipSize()).toBe(1);
+    // Toronto-ish.
+    expect(f.classifyPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 })).toBe('in');
   });
 
-  it('learns and drops a sender whose position is outside the bbox', () => {
+  it("returns 'out' for a position outside the bbox", () => {
     const f = new MqttPacketFilter({ geo: ON_BBOX });
-    // Vancouver — clearly outside.
-    expect(
-      f.postFilterPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }, NODE_OUT),
-    ).toBe(false);
-    // Even though we now "know" this node, it's known-out → still drops.
-    expect(f.passesMembership(NODE_OUT)).toBe(false);
-    // Both the position itself AND the subsequent membership check increment geo.
-    expect(f.getDropCounters().geo).toBe(2);
-  });
-
-  it('refreshes membership when a node moves across the boundary', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    const NODE = 0x7ff80a48;
-
-    // First seen inside.
-    f.postFilterPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 }, NODE);
-    expect(f.passesMembership(NODE)).toBe(true);
-
-    // Then moves outside — membership should flip to 'out'.
-    f.postFilterPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }, NODE);
-    expect(f.passesMembership(NODE)).toBe(false);
-
-    // ...and back inside.
-    f.postFilterPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 }, NODE);
-    expect(f.passesMembership(NODE)).toBe(true);
-
-    // Cache should still have a single entry for this node, not three.
-    expect(f.getMembershipSize()).toBe(1);
-  });
-
-  it('does NOT record membership when fromNum is omitted', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    // Position decode-only path (e.g. from older callers that didn't pass fromNum).
-    f.postFilterPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 });
-    expect(f.getMembershipSize()).toBe(0);
-  });
-
-  it('does NOT record membership when position lacks lat/lon', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    // Position-shaped payload with no coords — can't decide.
-    expect(f.postFilterPosition({}, NODE_IN)).toBe(true);
-    // No coords were learned, so the node stays unknown → fail-closed drop.
-    expect(f.passesMembership(NODE_IN)).toBe(false);
-    expect(f.getMembershipSize()).toBe(0);
-  });
-
-  it('does NOT record membership when no bbox is set even if fromNum provided', () => {
-    const f = new MqttPacketFilter({});
-    f.postFilterPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 }, NODE_IN);
-    // No bbox in use → membership cache should remain empty.
-    expect(f.getMembershipSize()).toBe(0);
+    // Vancouver.
+    expect(f.classifyPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 })).toBe(
+      'out',
+    );
   });
 
   it('respects half-open bboxes (only one axis bounded)', () => {
-    // Only minLat set: anything below latitude 43 is "out", everything else is "in".
     const f = new MqttPacketFilter({ geo: { minLat: 43 } });
-    f.postFilterPosition({ latitudeI: 440_000_000, longitudeI: -793_000_000 }, NODE_IN); // 44.0 → in
-    f.postFilterPosition({ latitudeI: 420_000_000, longitudeI: -793_000_000 }, NODE_OUT); // 42.0 → out
-    expect(f.passesMembership(NODE_IN)).toBe(true);
-    expect(f.passesMembership(NODE_OUT)).toBe(false);
+    expect(f.classifyPosition({ latitudeI: 440_000_000, longitudeI: -793_000_000 })).toBe('in');
+    expect(f.classifyPosition({ latitudeI: 420_000_000, longitudeI: -793_000_000 })).toBe('out');
   });
 
-  it('different filter instances do not share membership state', () => {
-    const a = new MqttPacketFilter({ geo: ON_BBOX });
-    const b = new MqttPacketFilter({ geo: ON_BBOX });
-    a.postFilterPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 }, NODE_IN);
-    expect(a.passesMembership(NODE_IN)).toBe(true);
-    // Filter b never saw the position → still drops.
-    expect(b.passesMembership(NODE_IN)).toBe(false);
-  });
-});
-
-describe('MqttPacketFilter.seedMembership — pre-seeded geo membership', () => {
-  // Bbox approximately covering southern Ontario.
-  const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
-  const NODE_IN = 0x7ff80a48;
-  const NODE_OUT = 0x11111111;
-  const NODE_OTHER = 0x33333333;
-
-  it('seeds in-region nodes so non-position packets pass without a prior POSITION_APP', () => {
+  it('accepts snake_case field names from raw protobuf decode', () => {
     const f = new MqttPacketFilter({ geo: ON_BBOX });
-    // Pre-load with Toronto-ish coordinates.
-    const count = f.seedMembership([
-      { nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 },
-    ]);
-    expect(count).toBe(1);
-    // Right out of the gate, before any POSITION_APP packet — node passes.
-    expect(f.passesMembership(NODE_IN)).toBe(true);
-    expect(f.getDropCounters().geo).toBe(0);
+    expect(f.classifyPosition({ latitude_i: 437_000_000, longitude_i: -793_000_000 })).toBe('in');
+    expect(
+      f.classifyPosition({ latitude_i: 492_000_000, longitude_i: -1_230_000_000 }),
+    ).toBe('out');
   });
 
-  it('does NOT seed out-of-region nodes (only seeds "in")', () => {
+  it('never mutates drop counters, regardless of classification', () => {
     const f = new MqttPacketFilter({ geo: ON_BBOX });
-    // Vancouver — clearly outside.
-    const count = f.seedMembership([
-      { nodeNum: NODE_OUT, latitudeDeg: 49.2, longitudeDeg: -123.0 },
-    ]);
-    expect(count).toBe(0);
-    // Node remains unknown — fail-closed drops, but cache stays empty so the
-    // next POSITION_APP can still flip the verdict either way.
-    expect(f.passesMembership(NODE_OUT)).toBe(false);
-    expect(f.getMembershipSize()).toBe(0);
+    f.classifyPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 }); // in
+    f.classifyPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }); // out
+    f.classifyPosition(null); // unknown
+    f.classifyPosition({}); // unknown
+    expect(f.getDropCounters()).toEqual({ topic: 0, channel: 0, node: 0, portnum: 0, geo: 0 });
   });
 
-  it('partitions a mixed batch into in/out and only seeds the in-region ones', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    const count = f.seedMembership([
-      { nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 },
-      { nodeNum: NODE_OUT, latitudeDeg: 49.2, longitudeDeg: -123.0 },
-      { nodeNum: NODE_OTHER, latitudeDeg: 44.0, longitudeDeg: -78.5 },
-    ]);
-    expect(count).toBe(2);
-    expect(f.getMembershipSize()).toBe(2);
-    expect(f.passesMembership(NODE_IN)).toBe(true);
-    expect(f.passesMembership(NODE_OTHER)).toBe(true);
-    expect(f.passesMembership(NODE_OUT)).toBe(false);
-  });
-
-  it('skips entries with non-finite coordinates without throwing', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    const count = f.seedMembership([
-      { nodeNum: NODE_IN, latitudeDeg: NaN, longitudeDeg: -79.3 },
-      { nodeNum: NODE_OTHER, latitudeDeg: 43.7, longitudeDeg: Infinity },
-    ]);
-    expect(count).toBe(0);
-    expect(f.getMembershipSize()).toBe(0);
-  });
-
-  it('treats 0,0 as "no position" sentinel and skips it', () => {
-    const f = new MqttPacketFilter({ geo: { minLat: -1, maxLat: 1, minLng: -1, maxLng: 1 } });
-    // 0,0 is technically inside the bbox here, but it's our codebase-wide
-    // sentinel for "node has no real position yet" — must not be seeded.
-    const count = f.seedMembership([
-      { nodeNum: NODE_IN, latitudeDeg: 0, longitudeDeg: 0 },
-    ]);
-    expect(count).toBe(0);
-    expect(f.passesMembership(NODE_IN)).toBe(false);
-  });
-
-  it('is a no-op when the filter has no bbox configured', () => {
+  it('is a no-op classifier when the filter has no bbox, even across repeated calls', () => {
     const f = new MqttPacketFilter({});
-    const count = f.seedMembership([
-      { nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 },
-    ]);
-    expect(count).toBe(0);
-    expect(f.getMembershipSize()).toBe(0);
-  });
-
-  it('lets a subsequent POSITION_APP outside the bbox override the seed', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    f.seedMembership([{ nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 }]);
-    expect(f.passesMembership(NODE_IN)).toBe(true);
-
-    // Node sends a new position — Vancouver, outside the bbox.
-    f.postFilterPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }, NODE_IN);
-    expect(f.passesMembership(NODE_IN)).toBe(false);
-    // Still a single entry — refreshed, not duplicated.
-    expect(f.getMembershipSize()).toBe(1);
-  });
-});
-
-describe('MqttPacketFilter.seedTrustedNodes — bypasses bbox check', () => {
-  const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
-  const NODE_A = 0xa2e4ff4c;
-  const NODE_B = 0x11111111;
-
-  it('marks nodes as in-cache without a position check', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    const seeded = f.seedTrustedNodes([NODE_A, NODE_B]);
-    expect(seeded).toBe(2);
-    expect(f.passesMembership(NODE_A)).toBe(true);
-    expect(f.passesMembership(NODE_B)).toBe(true);
-    expect(f.getDropCounters().geo).toBe(0);
-  });
-
-  it('skips non-finite node numbers', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    const seeded = f.seedTrustedNodes([NaN, Infinity, NODE_A] as any);
-    expect(seeded).toBe(1);
-    expect(f.passesMembership(NODE_A)).toBe(true);
-  });
-
-  it('is a no-op when no bbox is configured', () => {
-    const f = new MqttPacketFilter({});
-    const seeded = f.seedTrustedNodes([NODE_A]);
-    expect(seeded).toBe(0);
-    expect(f.getMembershipSize()).toBe(0);
-  });
-
-  it('lets a subsequent out-of-bbox POSITION_APP downgrade a trusted seed', () => {
-    const f = new MqttPacketFilter({ geo: ON_BBOX });
-    f.seedTrustedNodes([NODE_A]);
-    expect(f.passesMembership(NODE_A)).toBe(true);
-
-    // Trusted node sends a position outside the bbox — membership flips.
-    // Same refresh semantics as `seedMembership` lets POSITION_APP override.
-    f.postFilterPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }, NODE_A);
-    expect(f.passesMembership(NODE_A)).toBe(false);
-    expect(f.getMembershipSize()).toBe(1);
+    f.classifyPosition({ latitudeI: 437_000_000, longitudeI: -793_000_000 });
+    f.classifyPosition(null);
+    expect(f.getDropCounters()).toEqual({ topic: 0, channel: 0, node: 0, portnum: 0, geo: 0 });
   });
 });
 

--- a/src/server/mqttPacketFilter.ts
+++ b/src/server/mqttPacketFilter.ts
@@ -4,7 +4,16 @@
  * Pure filter functions that decide whether a Meshtastic ServiceEnvelope
  * (decoded from an MQTT message) should pass through a bridge or be
  * dropped. Supports topic patterns (MQTT wildcards), channel/node/portnum
- * allow-block lists, and geographic bounding boxes for position payloads.
+ * allow-block lists, and a geographic bounding box for position payloads.
+ *
+ * The geo filter is a pure bbox classifier + republish gate: it classifies
+ * a decoded Position payload as inside/outside/unknown/unconfigured
+ * (`classifyPosition`) and gates republish of POSITION_APP packets on that
+ * classification (`postFilterPosition`). It has no memory of nodes and no
+ * side effects beyond the `drops.geo` counter. Persistent ignore-list
+ * gating for a node's *other* traffic (TEXT, TELEMETRY, NODEINFO, ...)
+ * lives downstream in the MQTT bridge/ingestion layer, keyed off the
+ * `ignored_nodes` table (MQTT Geo-Ignore epic, Phase 2) — not here.
  */
 
 import { PortNum } from './constants/meshtastic.js';
@@ -52,18 +61,6 @@ export interface PositionShape {
   longitude_i?: number;
 }
 
-/**
- * Per-node bbox membership decision, cached the first time we see a
- * position for that nodeNum and refreshed on every subsequent position.
- *
- * Used by `passesMembership` to apply the bbox to *all* portnums (not just
- * POSITION_APP). Nodes we've never seen a position for are treated as
- * unknown and rejected — see "fail-closed" semantics in the class doc.
- */
-type GeoMembership = 'in' | 'out';
-
-const MEMBERSHIP_MAX = 10_000;
-
 export class MqttPacketFilter {
   private readonly topicAllow: RegExp[];
   private readonly topicBlock: RegExp[];
@@ -74,7 +71,6 @@ export class MqttPacketFilter {
   private readonly portAllow: Set<number> | null;
   private readonly portBlock: Set<number>;
   private readonly geo: MqttFilterConfig['geo'] | null;
-  private readonly membership = new Map<number, GeoMembership>();
   private readonly drops: MqttFilterDropCounters = {
     topic: 0,
     channel: 0,
@@ -162,123 +158,50 @@ export class MqttPacketFilter {
   }
 
   /**
-   * Geographic bounding box filter applied after decoding a Position
-   * payload. Returns true if the position is inside the configured
-   * bbox (or no bbox configured), false to drop.
+   * Pure bbox classification of a decoded Position payload. Never touches
+   * the drop counters or any other state — safe to call speculatively.
    *
-   * If `fromNum` is provided AND the bbox is enabled AND the position
-   * carries valid coordinates, the result is cached as the node's
-   * membership (in / out). `passesMembership` then uses that cache to
-   * decide non-position portnums.
+   * - `'no-geo'` — no bbox is configured (nothing to classify against).
+   * - `'unknown'` — bbox is configured but the position is null, or lacks
+   *   usable coordinates (camelCase `latitudeI`/`longitudeI` or snake_case
+   *   `latitude_i`/`longitude_i`).
+   * - `'in'` / `'out'` — the decoded coordinates relative to the bbox.
    */
-  postFilterPosition(position: PositionShape | null, fromNum?: number): boolean {
-    if (!this.geo || !position) return true;
+  classifyPosition(position: PositionShape | null): 'in' | 'out' | 'unknown' | 'no-geo' {
+    if (!this.hasGeoBounds()) return 'no-geo';
+    if (!position) return 'unknown';
     const latI = position.latitudeI ?? position.latitude_i;
     const lngI = position.longitudeI ?? position.longitude_i;
-    if (typeof latI !== 'number' || typeof lngI !== 'number') return true;
+    if (typeof latI !== 'number' || typeof lngI !== 'number') return 'unknown';
     const lat = latI / 1e7;
     const lng = lngI / 1e7;
-    const { minLat, maxLat, minLng, maxLng } = this.geo;
+    const { minLat, maxLat, minLng, maxLng } = this.geo!;
     const inside =
       (typeof minLat !== 'number' || lat >= minLat) &&
       (typeof maxLat !== 'number' || lat <= maxLat) &&
       (typeof minLng !== 'number' || lng >= minLng) &&
       (typeof maxLng !== 'number' || lng <= maxLng);
+    return inside ? 'in' : 'out';
+  }
 
-    if (typeof fromNum === 'number' && this.hasGeoBounds()) {
-      this.recordMembership(fromNum >>> 0, inside ? 'in' : 'out');
-    }
-
-    if (!inside) {
+  /**
+   * Geographic bounding box republish gate applied after decoding a
+   * Position payload. Returns true if the packet should pass through
+   * (position is inside the bbox, position is unclassifiable, or no bbox
+   * is configured), false to drop. Increments `drops.geo` only when the
+   * position classifies as `'out'`.
+   *
+   * Delegates entirely to `classifyPosition` — this method carries no
+   * membership/caching state of its own. Ignore-list gating of a node's
+   * non-position traffic lives in the bridge/ingestion layer.
+   */
+  postFilterPosition(position: PositionShape | null): boolean {
+    const classification = this.classifyPosition(position);
+    if (classification === 'out') {
       this.drops.geo++;
       return false;
     }
     return true;
-  }
-
-  /**
-   * Non-position fail-closed membership check.
-   *
-   * When the bbox is enabled, every packet (TEXT, TELEMETRY, NODEINFO,
-   * NEIGHBORINFO, encrypted, ...) is gated on the sender having a
-   * known-inside-the-bbox membership. Senders we've never decoded a
-   * position for, or that last reported a position outside the bbox,
-   * are dropped — increments `drops.geo`.
-   *
-   * No-op (passes everything) when the bbox is not configured.
-   */
-  passesMembership(fromNum: number | null | undefined): boolean {
-    if (!this.hasGeoBounds()) return true;
-    if (typeof fromNum !== 'number') {
-      this.drops.geo++;
-      return false;
-    }
-    const status = this.membership.get(fromNum >>> 0);
-    if (status === 'in') return true;
-    this.drops.geo++;
-    return false;
-  }
-
-  /** Test/debug helper — current membership cache size. */
-  getMembershipSize(): number {
-    return this.membership.size;
-  }
-
-  /**
-   * Pre-seed the membership cache with "trusted" nodes — those we know
-   * belong to the operator's mesh regardless of whether we have a stored
-   * position for them. Used to flow MQTT-relayed packets from nodes that
-   * our TCP/Meshcore sources have heard directly but whose position
-   * hasn't been decoded yet (e.g. a base station with GPS disabled).
-   *
-   * Bypasses the bbox check on purpose: if a node is part of the local
-   * mesh, its MQTT-relayed traffic should land regardless of geometry.
-   * No-op when no bbox is configured (everything already passes).
-   */
-  seedTrustedNodes(nodeNums: Iterable<number>): number {
-    if (!this.hasGeoBounds()) return 0;
-    let seeded = 0;
-    for (const num of nodeNums) {
-      if (!Number.isFinite(num)) continue;
-      this.recordMembership(num >>> 0, 'in');
-      seeded++;
-    }
-    return seeded;
-  }
-
-  /**
-   * Pre-seed the membership cache with nodes whose persisted positions are
-   * inside the bbox. Used by MqttBridgeManager on start so that nodes
-   * already known to be in-region don't have to re-broadcast a POSITION_APP
-   * packet before their TEXT/TELEMETRY/NODEINFO traffic is accepted.
-   *
-   * Only seeds 'in' — never 'out'. An out-of-region node may have moved,
-   * so we leave it unknown and let the next POSITION_APP packet update it.
-   * Returns the number of entries actually marked. No-op when no bbox is
-   * configured or for entries with invalid/zero coords.
-   */
-  seedMembership(
-    entries: Array<{ nodeNum: number; latitudeDeg: number; longitudeDeg: number }>,
-  ): number {
-    if (!this.hasGeoBounds()) return 0;
-    const { minLat, maxLat, minLng, maxLng } = this.geo!;
-    let seeded = 0;
-    for (const e of entries) {
-      const lat = e.latitudeDeg;
-      const lng = e.longitudeDeg;
-      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
-      // 0,0 is the sentinel for "no position" elsewhere in the codebase.
-      if (lat === 0 && lng === 0) continue;
-      const inside =
-        (typeof minLat !== 'number' || lat >= minLat) &&
-        (typeof maxLat !== 'number' || lat <= maxLat) &&
-        (typeof minLng !== 'number' || lng >= minLng) &&
-        (typeof maxLng !== 'number' || lng <= maxLng);
-      if (!inside) continue;
-      this.recordMembership(e.nodeNum >>> 0, 'in');
-      seeded++;
-    }
-    return seeded;
   }
 
   getDropCounters(): MqttFilterDropCounters {
@@ -301,18 +224,6 @@ export class MqttPacketFilter {
       typeof this.geo.minLng === 'number' ||
       typeof this.geo.maxLng === 'number'
     );
-  }
-
-  private recordMembership(nodeNum: number, status: GeoMembership): void {
-    // FIFO eviction at MEMBERSHIP_MAX. Re-inserting a key bumps it to the
-    // end of insertion order, which makes refreshed nodes effectively MRU.
-    if (this.membership.has(nodeNum)) {
-      this.membership.delete(nodeNum);
-    } else if (this.membership.size >= MEMBERSHIP_MAX) {
-      const oldest = this.membership.keys().next().value;
-      if (oldest !== undefined) this.membership.delete(oldest);
-    }
-    this.membership.set(nodeNum, status);
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the MQTT Geo-Ignore rearchitecture (#4115, epic plan in `docs/internal/dev-notes/MQTT_GEO_IGNORE_EPIC.md`) — **the behavior flip**. The `mqtt_bridge` geo filter moves from fail-closed membership (which permanently blackholed GPS-less nodes and froze membership on encrypted feeds — the #4115 root cause) to **fail-open + per-source ignore-list with retroactive purge**, built on Phase 1's primitives (PR #4123).

### New model

- **Fail-open:** packets from nodes with no known position are accepted. The two #4115 nodes (`!f68f52d8`, `!49dac1a0` — GPS-less base stations) now ingest via their NODEINFO/TEXT.
- **POSITION evaluated post-decrypt** in `ingestServiceEnvelope` (fixes the encrypted-position bootstrap hole): outside the bbox → add to the source's ignore list (`reason: 'geo'`) + **one-time full purge** of the node and all its data (messages incl. broadcasts, telemetry, traceroutes, neighbors, packet logs, node row); inside the bbox → lift a geo-ignore so the node **reappears**. Manual ignores are never auto-lifted.
- **Ignore gating:** the bridge early-drops provably-non-position decoded traffic from ignored senders; encrypted packets flow to ingestion (can't be proven non-position pre-decrypt — required for reappearance) where a defense-in-depth gate re-drops non-position payloads. Ignored senders are excluded from `local-packet` emission and local-broker republish.
- **Purge-once:** `addGeoIgnoreAsync` now returns whether a new row was inserted; the purge fires only on the geo-ignore transition, not on every out-of-bbox position.
- **Membership machinery deleted:** `passesMembership`, `seedTrustedNodes`, `seedMembership`, the membership Map, and `seedDownlinkMembership` are gone. `MqttPacketFilter` keeps a pure `classifyPosition` + single-arg `postFilterPosition` republish gate; `drops.geo` now counts out-of-bbox POSITION arrivals only.

### Deliberate behavior changes to note

1. **Broker sources:** manually-ignored senders' packets are now dropped at MQTT ingestion (previously a manual ignore only hid the node). Covered by a dedicated test.
2. On upgrade, bbox'd bridge sources flip to fail-open: previously-hidden in-region nodes appear as their next packets arrive; out-of-region nodes are ignored+purged on their next POSITION (Phase 3 adds the retroactive sweep for stored data).
3. Encrypted out-of-bbox positions don't increment the bridge `drops.geo` counter (classified post-decrypt, after the counter's site) — Phase 4 adds proper per-reason counters.

### Tests

- `mqttIngestion.test.ts` — fail-open back-compat, ignore-gate, POSITION geo-evaluation blocks (geo-ignore+purge-once, lift/reappear, manual-ignore precedence, coordless positions).
- `mqttBridgeManager.test.ts` — end-to-end broker tests incl. the #4115 GPS-less scenario, out-of-bbox ignore+no-republish, reappearance.
- `mqttIngestion.perSource.test.ts` (new) — geo-ignore/lift/purge isolation across sources against the real DB.
- `mqttBrokerManager.test.ts` — broker-path manual-ignore drop (intended change #1).
- `mqttPacketFilter.test.ts` — rewritten for the pure classifier; membership blocks deleted.

Full suite: **9,124 passed / 0 failed** (`success: true` via JSON reporter). `tsc` clean, `lint:ci` ratchet OK.

Part of #4115 (Phase 2 of 4 — do not close the issue on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1
