### PR TITLE
feat(mqtt): retroactive geo sweep on bridge start + bbox config change (geo-ignore epic Phase 3, #4115)

### DIFF
--- a/docs/internal/dev-notes/MQTT_GEO_IGNORE_EPIC.md
+++ b/docs/internal/dev-notes/MQTT_GEO_IGNORE_EPIC.md
@@ -78,25 +78,25 @@ pre-decryption in `handleDownlink`.
   green. **PR #4123 MERGED** 2026-07-15 (squash 2f828caa; migration renumbered 119→120 after #4118 took 119; review fixes: TOCTOU cache-eviction in liftGeoIgnoreAsync, source-qualified UI key, harness teardown guard; also shipped watch-ci.sh merge-conflict detection exit 3).
 
 ### Phase 2 — Core gating rearchitecture (the behavior flip)
-- [ ] `MqttBridgeManager.handleDownlink`: remove fail-closed
+- [x] `MqttBridgeManager.handleDownlink`: remove fail-closed
   `passesMembership` ingestion gating + membership seeding
   (`seedDownlinkMembership`); add early drop of **non-POSITION** packets from
   ignored senders via `isIgnoredCached`; POSITION always flows to ingestion.
-- [ ] `ingestServiceEnvelope` POSITION_APP case: post-decrypt geo evaluation —
+- [x] `ingestServiceEnvelope` POSITION_APP case: post-decrypt geo evaluation —
   outside → `addGeoIgnoreAsync` + async purge + drop position; inside →
   `liftGeoIgnoreAsync` (reappear) + normal ingest.
-- [ ] Also early-drop ignored senders inside `ingestServiceEnvelope`
+- [x] Also early-drop ignored senders inside `ingestServiceEnvelope`
   (defense-in-depth for the broker-manager caller which shares this path).
-- [ ] Republish-to-local-broker path: skip packets from ignored senders;
+- [x] Republish-to-local-broker path: skip packets from ignored senders;
   plaintext out-of-bbox positions still not republished.
-- [ ] Remove/retire membership machinery in `MqttPacketFilter`
+- [x] Remove/retire membership machinery in `MqttPacketFilter`
   (`passesMembership`, `seedTrustedNodes`, `seedMembership`, membership map)
   — keep bbox math + other filters. Geo drop counter stays.
-- [ ] Rewrite affected tests (bridge fail-closed tests become fail-open +
+- [x] Rewrite affected tests (bridge fail-closed tests become fail-open +
   ignore-list tests); new perSource tests for geo-ignore/lift/purge.
 - **Exit:** the #4115 scenario passes in tests (GPS-less node's NODEINFO/TEXT
   ingested; out-of-bounds node purged+ignored; in-bounds position lifts);
-  suite green; PR merged.
+  suite green. **PR #4131 MERGED** 2026-07-15 (squash 0a9b7e27; review adds: stub display names for never-seen geo-ignored nodes, one-packet-window docs, purge-once via addGeoIgnoreAsync boolean; CI fix: ignoredNodes stub in empty database mocks of mode/permission bridge suites).
 
 ### Phase 3 — Retroactive sweep on config change + bridge start
 - [ ] Sweep service (new, small): for a bridge source with a bbox — stored

--- a/src/db/repositories/mqttPacketLog.ts
+++ b/src/db/repositories/mqttPacketLog.ts
@@ -15,7 +15,8 @@ import { BaseRepository } from './base.js';
 export type MqttIngestOutcome =
   | 'ingested'
   | 'encrypted'
-  | 'geo-filtered'
+  | 'ignored'
+  | 'geo-ignored'
   | 'unsupported-portnum'
   | 'decode-error';
 

--- a/src/db/schema/mqttPacketLog.ts
+++ b/src/db/schema/mqttPacketLog.ts
@@ -50,7 +50,7 @@ export const mqttPacketLogSqlite = sqliteTable('mqtt_packet_log', {
   encrypted: integer('encrypted').notNull().default(0),
   /** 'server' when MeshMonitor decrypted an encrypted copy server-side, else null. */
   decryptedBy: text('decryptedBy'),
-  /** 'ingested' | 'encrypted' | 'geo-filtered' | 'unsupported-portnum' | 'decode-error'. */
+  /** 'ingested' | 'encrypted' | 'ignored' | 'geo-ignored' | 'unsupported-portnum' | 'decode-error'. */
   ingestOutcome: text('ingestOutcome').notNull(),
   payloadSize: integer('payloadSize'),
   /** Text preview (TEXT_MESSAGE_APP only in Phase 1) or null. */

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -81,12 +81,33 @@ vi.mock('../services/database.js', () => ({
   },
 }));
 
+// mqttGeoSweepService is mocked at the module level (rather than let a real
+// sweep run) because `start()` now fires a sweep on every single test in
+// this file via `sourceManagerRegistry.addManager()`, and the database mock
+// above has no `nodes.getAllNodes` — a real sweep would throw on every test.
+// The dedicated "geo sweep integration" block below asserts on this mock's
+// call args instead of on sweep side effects.
+const runSweep = vi.fn(async () => ({
+  sourceId: 'unset',
+  timestamp: Date.now(),
+  scanned: 0,
+  ignored: 0,
+  purged: 0,
+  lifted: 0,
+  durationMs: 0,
+}));
+
+vi.mock('./services/mqttGeoSweepService.js', () => ({
+  mqttGeoSweepService: { runSweep: (...a: unknown[]) => runSweep(...a) },
+}));
+
 import { MqttBrokerManager } from './mqttBrokerManager.js';
 import { MqttBridgeManager } from './mqttBridgeManager.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import databaseService from '../services/database.js';
 import { PortNum } from './constants/meshtastic.js';
+import type { GeoSweepStats } from './services/mqttGeoSweepService.js';
 import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
 
 async function ephemeralPort(): Promise<number> {
@@ -239,6 +260,7 @@ describe('MqttBridgeManager', () => {
     isNodeIgnoredAsync.mockClear();
     getIgnoredNodesAsync.mockClear();
     ignoredRecords.clear();
+    runSweep.mockClear();
 
     upstreamPort = await ephemeralPort();
     localPort = await ephemeralPort();
@@ -1121,5 +1143,62 @@ describe('MqttBridgeManager', () => {
     expect(bridge.getStatus().uplinkOkToMqttDrops).toBe(0);
 
     await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  // ---------------------------------------------------------------------------
+  // Geo sweep integration (MQTT Geo-Ignore epic, Phase 3, WP2). WP1 built
+  // mqttGeoSweepService.runSweep in isolation; these tests cover the bridge
+  // manager's wiring — start() kicks off an add-only sweep, and getStatus()
+  // surfaces the most recent sweep's stats via the GeoSweepStatsSink duck
+  // type (recordGeoSweepStats). runSweep itself is mocked module-wide above
+  // (the database mock has no nodes.getAllNodes), so these assert on the
+  // call args / sink plumbing rather than sweep side effects.
+  // ---------------------------------------------------------------------------
+
+  it('#4115 Phase 3: getStatus().lastGeoSweep is null before any sweep completes', () => {
+    bridge = new MqttBridgeManager('geo-sweep-status', 'GeoSweepStatus', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+    });
+    expect(bridge.getStatus().lastGeoSweep).toBeNull();
+  });
+
+  it('#4115 Phase 3: start() runs an add-only geo sweep scoped to this source and its configured bbox', async () => {
+    const geo = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+    bridge = new MqttBridgeManager('geo-sweep-start', 'GeoSweepStart', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+      downlinkFilters: { geo },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    expect(runSweep).toHaveBeenCalledWith(
+      'geo-sweep-start',
+      geo,
+      expect.objectContaining({ lift: false }),
+    );
+  });
+
+  it('#4115 Phase 3: recordGeoSweepStats (the GeoSweepStatsSink callback) updates getStatus().lastGeoSweep', () => {
+    bridge = new MqttBridgeManager('geo-sweep-record', 'GeoSweepRecord', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+    });
+    const stats: GeoSweepStats = {
+      sourceId: 'geo-sweep-record',
+      timestamp: 123456,
+      scanned: 4,
+      ignored: 2,
+      purged: 2,
+      lifted: 0,
+      durationMs: 5,
+    };
+
+    bridge.recordGeoSweepStats(stats);
+
+    expect(bridge.getStatus().lastGeoSweep).toEqual(stats);
   });
 });

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -49,6 +49,7 @@ import {
 } from './mqttBridgePublisherPool.js';
 import { channelDecryptionService } from './services/channelDecryptionService.js';
 import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
+import { mqttGeoSweepService, type GeoSweepStats } from './services/mqttGeoSweepService.js';
 
 /**
  * Direction the bridge is permitted to operate in against the upstream
@@ -219,6 +220,11 @@ export interface MqttBridgeStatus extends SourceStatus {
    * mode or when no `local-packet` traffic has been seen yet.
    */
   publishers: Record<string, PublisherStatus>;
+  /**
+   * Stats from the most recent MQTT Geo-Ignore retroactive sweep (Phase 3),
+   * or `null` before the first sweep completes. See `mqttGeoSweepService`.
+   */
+  lastGeoSweep: GeoSweepStats | null;
 }
 
 interface EchoEntry { topic: string; packetId: number; expiresAt: number }
@@ -276,6 +282,8 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
    */
   private brokerGatewayNum: number | null = null;
   private readonly distanceDeleteScheduler: DistanceDeleteScheduler;
+  /** Stats from the most recent geo sweep (MQTT Geo-Ignore epic, Phase 3). */
+  private lastGeoSweep: GeoSweepStats | null = null;
 
   constructor(sourceId: string, sourceName: string, config: MqttBridgeSourceConfig) {
     super();
@@ -297,6 +305,14 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     this.distanceDeleteScheduler.stop();
   }
 
+  /**
+   * Sink for `mqttGeoSweepService.runSweep` (MQTT Geo-Ignore epic, Phase 3).
+   * Satisfies `GeoSweepStatsSink` via duck typing.
+   */
+  recordGeoSweepStats(stats: GeoSweepStats): void {
+    this.lastGeoSweep = stats;
+  }
+
   /** Resolves the configured forwarding mode, defaulting to `'per_gateway'`. */
   private getForwardingMode(): MqttBridgeForwardingMode {
     return this.config.forwardingMode ?? 'per_gateway';
@@ -311,6 +327,16 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     // a settings-read hiccup must not stop the bridge from coming up.
     this.distanceDeleteScheduler.start().catch((err) =>
       logger.error(`Failed to start distance-delete scheduler for source ${this.sourceId}:`, err));
+
+    // Retroactive geo sweep (MQTT Geo-Ignore epic, Phase 3). Add-only
+    // (`lift: false`): a plain restart has no previous bbox to diff against,
+    // so lifting on every boot would permanently readmit nodes that were
+    // silently purged under a still-current bbox. Lifting only happens on
+    // the config-save path, which knows the bbox actually changed. Fire-
+    // and-forget — a background concern that must not delay bridge startup.
+    mqttGeoSweepService
+      .runSweep(this.sourceId, this.config.downlinkFilters?.geo, { lift: false, sink: this })
+      .catch(err => logger.error(`Geo sweep failed for source ${this.sourceId}:`, err));
 
     const mode = this.getMode();
     const forwardingMode = this.getForwardingMode();
@@ -434,6 +460,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       forwardingMode: this.getForwardingMode(),
       publishers: this.publisherPool?.getStatus() ?? {},
       uplinkOkToMqttDrops: this.uplinkOkToMqttDrops,
+      lastGeoSweep: this.lastGeoSweep,
     };
   }
 

--- a/src/server/mqttPacketLogService.ingestHook.test.ts
+++ b/src/server/mqttPacketLogService.ingestHook.test.ts
@@ -30,6 +30,16 @@ vi.mock('../services/database.js', () => ({
       getNodesByNums: vi.fn(async () => new Map()),
       upsertNode: vi.fn(async () => undefined),
     },
+    // Phase 2 geo-ignore gating consults these on every packet.
+    ignoredNodes: {
+      isIgnoredCached: vi.fn(() => false),
+      addGeoIgnoreAsync: vi.fn(async () => true),
+      liftGeoIgnoreAsync: vi.fn(async () => false),
+    },
+    deleteNodeAsync: vi.fn(async () => ({
+      messagesDeleted: 0, broadcastMessagesDeleted: 0, traceroutesDeleted: 0,
+      telemetryDeleted: 0, nodeDeleted: true,
+    })),
     neighbors: {
       deleteNeighborInfoForNode: vi.fn(async () => undefined),
       insertNeighborInfoBatch: vi.fn(async () => undefined),
@@ -79,6 +89,7 @@ import { channelDecryptionService } from './services/channelDecryptionService.js
 import mqttPacketLogService from './services/mqttPacketLogService.js';
 import * as protobufLoader from './protobufLoader.js';
 import { PortNum } from './constants/meshtastic.js';
+import meshtasticProtobufService from './meshtasticProtobufService.js';
 
 const NODE_A = 0x11111111;
 
@@ -162,21 +173,43 @@ describe('MQTT Packet Monitor — ingestion hook', () => {
     expect(row.portnum).toBeNull();
   });
 
-  it('logs a geo-filtered copy with portnum still populated (decode happened before the gate)', async () => {
-    const filter = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 } });
+  it('logs an ignored-sender copy with portnum still populated (decode happened before the gate)', async () => {
+    // Fail-open model (geo-ignore epic Phase 2): unknown senders pass; only
+    // ignore-listed senders' non-position traffic is dropped.
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValueOnce(true);
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
-      envelope: envFor({ from: 0x22222222, portnum: 1 }), // unknown sender, non-position
-      filter,
+      envelope: envFor({ from: 0x22222222, portnum: 1 }),
     });
     expect(result.ingested).toBe(false);
-    expect(result.reason).toBe('geo-filtered');
+    expect(result.reason).toBe('ignored');
 
     await flush();
     expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
     const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
-    expect(row.ingestOutcome).toBe('geo-filtered');
+    expect(row.ingestOutcome).toBe('ignored');
     expect(row.portnum).toBe(1);
+  });
+
+  it('logs a geo-ignored copy for an out-of-bbox POSITION', async () => {
+    const filter = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 } });
+    // POSITION_APP decode → coordinates far outside the bbox.
+    (meshtasticProtobufService.processPayload as any).mockReturnValueOnce({
+      latitudeI: Math.round(25.0 * 1e7),
+      longitudeI: Math.round(-80.2 * 1e7),
+    });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor({ from: 0x33333333, portnum: 3, decoded: { portnum: 3, payload: new Uint8Array([1]) } }),
+      filter,
+    });
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('geo-ignored');
+
+    await flush();
+    expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.ingestOutcome).toBe('geo-ignored');
   });
 
   it('logs an unsupported-portnum copy', async () => {

--- a/src/server/routes/sourceRoutes.geoSweep.test.ts
+++ b/src/server/routes/sourceRoutes.geoSweep.test.ts
@@ -1,0 +1,311 @@
+/**
+ * PUT /api/sources/:id — config-change geo sweep trigger (MQTT Geo-Ignore
+ * epic, Phase 3, WP3).
+ *
+ * Uses the real-middleware harness (createRouteTestApp) against the live
+ * :memory: singleton DB — see src/server/test-helpers/routeTestApp.ts for
+ * the design rationale, and src/server/routes/sourceRoutes.permissions.test.ts
+ * for the template this file follows.
+ *
+ * `sourceManagerRegistry` is mocked (non-DB, allowed per CLAUDE.md) so
+ * addManager/removeManager no-op and getManager returns a fake sink object —
+ * the route's config-change branch is the thing under test, not the real
+ * MQTT connection lifecycle. `mqttGeoSweepService` itself is NOT mocked: it
+ * runs for real against the harness DB so the assertions prove actual
+ * ignore/purge/lift behavior, not a mocked call.
+ *
+ * Config semantics (read from the PUT handler, sourceRoutes.ts ~L446-511):
+ * `updates.config = preserveSourceCredentials(existing.type, existing.config,
+ * config)` — `config` in the request body WHOLESALE REPLACES the stored
+ * config (preserveSourceCredentials only round-trips the upstream password
+ * when omitted). Every PUT body below therefore sends a complete mqtt_bridge
+ * config object, not a partial patch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import databaseService, { type DbMessage, type DbTelemetry } from '../../services/database.js';
+
+// ── Non-DB mocks (allowed per CLAUDE.md) ───────────────────────────────────
+
+const mockGetManager = vi.fn();
+const mockAddManager = vi.fn();
+const mockRemoveManager = vi.fn();
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: (...args: unknown[]) => mockGetManager(...args),
+    addManager: (...args: unknown[]) => mockAddManager(...args),
+    removeManager: (...args: unknown[]) => mockRemoveManager(...args),
+  },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  MeshtasticManager: vi.fn().mockImplementation(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+// Matches the ON_BBOX convention used across the geo-ignore test suite
+// (mqttGeoSweepService.test.ts, mqttIngestion.perSource.test.ts).
+const OLD_BBOX = { minLat: 10, maxLat: 20, minLng: 10, maxLng: 20 };
+const NEW_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+
+const NODE_IN = { num: 0x40000001, lat: 44, lng: -78 }; // inside NEW_BBOX
+const NODE_OUT = { num: 0x40000002, lat: 49.2, lng: -123 }; // outside both bboxes
+const NODE_MANUAL = { num: 0x40000003, lat: 49.2, lng: -123 }; // outside; manually ignored
+const STALE_GEO_NODE_NUM = 0x40000099; // geo-ignored under OLD_BBOX; no live node row
+
+function nodeIdFor(num: number): string {
+  return `!${num.toString(16).padStart(8, '0')}`;
+}
+
+function bridgeConfig(
+  geo: typeof NEW_BBOX | null,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    upstream: { url: 'mqtt://upstream.example:1883' },
+    subscriptions: ['msh/#'],
+    downlinkFilters: geo ? { geo } : {},
+    ...extra,
+  };
+}
+
+describe('PUT /api/sources/:id — mqtt_bridge geo sweep on config change', () => {
+  let harness: RouteTestHarness;
+  const BRIDGE_ID = 'rt-geo-bridge';
+  let fakeManager: { recordGeoSweepStats: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+
+    // PUT /:id uses requirePermission('sources', 'write') with no
+    // sourceIdFrom option, so this is a GLOBAL permission check
+    // (scopedSourceId stays undefined) — grant without a sourceId.
+    await harness.grant(harness.limited.id, 'sources', 'write');
+
+    fakeManager = { recordGeoSweepStats: vi.fn() };
+    mockGetManager.mockReset().mockReturnValue(fakeManager);
+    mockAddManager.mockReset().mockResolvedValue(undefined);
+    mockRemoveManager.mockReset().mockResolvedValue(undefined);
+
+    await databaseService.sources.deleteSource(BRIDGE_ID).catch(() => {});
+    await databaseService.sources.createSource({
+      id: BRIDGE_ID,
+      name: 'Geo Bridge',
+      type: 'mqtt_bridge',
+      config: bridgeConfig(OLD_BBOX),
+      enabled: true,
+    });
+
+    // NODE_IN: inside NEW_BBOX, never ignored.
+    await databaseService.upsertNodeAsync(
+      {
+        nodeNum: NODE_IN.num,
+        nodeId: nodeIdFor(NODE_IN.num),
+        longName: 'Node In',
+        shortName: 'NIN',
+        latitude: NODE_IN.lat,
+        longitude: NODE_IN.lng,
+        hwModel: 1,
+        lastHeard: Math.floor(Date.now() / 1000),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any,
+      BRIDGE_ID,
+    );
+
+    // NODE_OUT: outside NEW_BBOX, not yet ignored — plus a message + telemetry
+    // row to prove the purge cascade actually runs.
+    await databaseService.upsertNodeAsync(
+      {
+        nodeNum: NODE_OUT.num,
+        nodeId: nodeIdFor(NODE_OUT.num),
+        longName: 'Node Out',
+        shortName: 'NOUT',
+        latitude: NODE_OUT.lat,
+        longitude: NODE_OUT.lng,
+        hwModel: 1,
+        lastHeard: Math.floor(Date.now() / 1000),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any,
+      BRIDGE_ID,
+    );
+    await databaseService.messages.insertMessage(
+      {
+        id: `${BRIDGE_ID}_${NODE_OUT.num}_0xaaaa0001`,
+        fromNodeNum: NODE_OUT.num,
+        toNodeNum: 0xffffffff,
+        fromNodeId: nodeIdFor(NODE_OUT.num),
+        toNodeId: '!ffffffff',
+        text: 'seed message',
+        channel: 0,
+        portnum: 1,
+        timestamp: Date.now(),
+        createdAt: Date.now(),
+      } as DbMessage,
+      BRIDGE_ID,
+    );
+    await databaseService.insertTelemetryAsync(
+      {
+        nodeId: nodeIdFor(NODE_OUT.num),
+        nodeNum: NODE_OUT.num,
+        telemetryType: 'batteryLevel',
+        timestamp: Date.now(),
+        value: 77,
+        unit: '%',
+        createdAt: Date.now(),
+      } as DbTelemetry,
+      BRIDGE_ID,
+    );
+
+    // NODE_MANUAL: outside NEW_BBOX, but a human already blocklisted it —
+    // the sweep must never lift or purge a manual entry.
+    await databaseService.upsertNodeAsync(
+      {
+        nodeNum: NODE_MANUAL.num,
+        nodeId: nodeIdFor(NODE_MANUAL.num),
+        longName: 'Node Manual',
+        shortName: 'NMAN',
+        latitude: NODE_MANUAL.lat,
+        longitude: NODE_MANUAL.lng,
+        hwModel: 1,
+        lastHeard: Math.floor(Date.now() / 1000),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any,
+      BRIDGE_ID,
+    );
+    await databaseService.ignoredNodes.addIgnoredNodeAsync(
+      NODE_MANUAL.num,
+      BRIDGE_ID,
+      nodeIdFor(NODE_MANUAL.num),
+      'Node Manual',
+      'NMAN',
+    );
+
+    // Pre-existing geo-ignore entry from a previous (OLD_BBOX) sweep, for a
+    // node that's already been purged (no live node row). Only a LIFT pass
+    // can remove this — it proves the config-change sweep actually runs
+    // with lift:true, not just the add-only start()-sweep shape.
+    await databaseService.ignoredNodes.addGeoIgnoreAsync(
+      STALE_GEO_NODE_NUM,
+      BRIDGE_ID,
+      nodeIdFor(STALE_GEO_NODE_NUM),
+      'Stale Geo Node',
+      'SGN',
+    );
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+    await databaseService.sources.deleteSource(BRIDGE_ID).catch(() => {});
+  });
+
+  it('bbox changed: purges/ignores newly-out node, lifts stale geo entry, leaves manual + in-bbox untouched', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent
+      .put(`/${BRIDGE_ID}`)
+      .send({ enabled: true, config: bridgeConfig(NEW_BBOX) });
+
+    expect(res.status).toBe(200);
+
+    const ignored = await databaseService.ignoredNodes.getIgnoredNodesAsync(BRIDGE_ID);
+
+    // NODE_OUT: newly geo-ignored + purged (node row, message, telemetry).
+    const nodeOutEntry = ignored.find((r) => r.nodeNum === NODE_OUT.num);
+    expect(nodeOutEntry?.reason).toBe('geo');
+    expect(await databaseService.nodes.getNode(NODE_OUT.num, BRIDGE_ID)).toBeNull();
+    expect(
+      await databaseService.messages.getMessage(`${BRIDGE_ID}_${NODE_OUT.num}_0xaaaa0001`),
+    ).toBeNull();
+    const telOut = await databaseService.telemetry.getTelemetryByNode(
+      nodeIdFor(NODE_OUT.num),
+      100,
+      undefined,
+      undefined,
+      0,
+      undefined,
+      BRIDGE_ID,
+    );
+    expect(telOut).toHaveLength(0);
+
+    // NODE_IN: untouched.
+    expect(ignored.find((r) => r.nodeNum === NODE_IN.num)).toBeUndefined();
+    expect(await databaseService.nodes.getNode(NODE_IN.num, BRIDGE_ID)).not.toBeNull();
+
+    // NODE_MANUAL: still present, still reason 'manual' — never lifted/purged.
+    const manualEntry = ignored.find((r) => r.nodeNum === NODE_MANUAL.num);
+    expect(manualEntry?.reason).toBe('manual');
+    expect(await databaseService.nodes.getNode(NODE_MANUAL.num, BRIDGE_ID)).not.toBeNull();
+
+    // Stale geo entry: lifted (gone).
+    expect(ignored.find((r) => r.nodeNum === STALE_GEO_NODE_NUM)).toBeUndefined();
+
+    // Sink wiring: the (fake) live manager received the sweep stats.
+    expect(fakeManager.recordGeoSweepStats).toHaveBeenCalledTimes(1);
+    expect(fakeManager.recordGeoSweepStats).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: BRIDGE_ID, ignored: 1, purged: 1, lifted: 1 }),
+    );
+  });
+
+  it('geo removed entirely: all remaining geo entries lifted, no new ignores', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent
+      .put(`/${BRIDGE_ID}`)
+      .send({ enabled: true, config: bridgeConfig(null) });
+
+    expect(res.status).toBe(200);
+
+    const ignored = await databaseService.ignoredNodes.getIgnoredNodesAsync(BRIDGE_ID);
+
+    // No geo bbox → classifyPosition never returns 'out' → no new ignores.
+    expect(ignored.find((r) => r.nodeNum === NODE_OUT.num)).toBeUndefined();
+    expect(await databaseService.nodes.getNode(NODE_OUT.num, BRIDGE_ID)).not.toBeNull();
+    expect(ignored.find((r) => r.nodeNum === NODE_IN.num)).toBeUndefined();
+
+    // Stale geo entry lifted.
+    expect(ignored.find((r) => r.nodeNum === STALE_GEO_NODE_NUM)).toBeUndefined();
+
+    // Manual entry survives — the lift pass only touches reason='geo' rows.
+    const manualEntry = ignored.find((r) => r.nodeNum === NODE_MANUAL.num);
+    expect(manualEntry?.reason).toBe('manual');
+
+    expect(fakeManager.recordGeoSweepStats).toHaveBeenCalledTimes(1);
+    expect(fakeManager.recordGeoSweepStats).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: BRIDGE_ID, ignored: 0, lifted: 1 }),
+    );
+  });
+
+  it('non-geo field changed only: no sweep runs, stale geo entry survives', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent
+      .put(`/${BRIDGE_ID}`)
+      // Same OLD_BBOX geo as the seeded config — only `mode` differs.
+      .send({ enabled: true, config: bridgeConfig(OLD_BBOX, { mode: 'publish_only' }) });
+
+    expect(res.status).toBe(200);
+
+    const ignored = await databaseService.ignoredNodes.getIgnoredNodesAsync(BRIDGE_ID);
+
+    // Stale geo entry survives — geo config was unchanged, so no lift pass ran.
+    const staleEntry = ignored.find((r) => r.nodeNum === STALE_GEO_NODE_NUM);
+    expect(staleEntry?.reason).toBe('geo');
+
+    // Manual entry untouched too.
+    expect(ignored.find((r) => r.nodeNum === NODE_MANUAL.num)?.reason).toBe('manual');
+
+    // No sweep triggered by this PUT, so the sink was never invoked from the
+    // config-change branch (still the beforeEach's fresh mock — nothing else
+    // in this test path calls recordGeoSweepStats).
+    expect(fakeManager.recordGeoSweepStats).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -20,6 +20,8 @@ import {
   buildSourceDashboard,
 } from '../services/sourceDashboardData.js';
 import { getSourcePkiKeyStore, isPkiDmDecryptionGloballyEnabled } from '../services/sourcePkiKeyStore.js';
+import { mqttGeoSweepService, type GeoSweepStats } from '../services/mqttGeoSweepService.js';
+import type { MqttFilterConfig } from '../mqttPacketFilter.js';
 
 const router = Router();
 
@@ -685,6 +687,37 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
         await sourceManagerRegistry.addManager(manager);
       } catch (err) {
         logger.warn(`Could not restart MQTT manager for source ${source.id}:`, err);
+      }
+
+      // Config-change geo sweep (MQTT Geo-Ignore epic, Phase 3, WP3).
+      // The bridge's own start() sweep above (buildMqttManagerForSource →
+      // addManager) always runs with lift:false — it has no old bbox to diff
+      // against. When the geo bbox itself changed, run an explicit LIFT+ADD
+      // sweep here so nodes the new bbox no longer excludes reappear
+      // immediately instead of waiting for their next POSITION packet.
+      if (source.type === 'mqtt_bridge') {
+        const oldGeo =
+          (existing.config as { downlinkFilters?: MqttFilterConfig }).downlinkFilters?.geo ?? null;
+        const newGeo =
+          (source.config as { downlinkFilters?: MqttFilterConfig }).downlinkFilters?.geo ?? null;
+        const geoChanged = JSON.stringify(oldGeo) !== JSON.stringify(newGeo);
+        if (geoChanged) {
+          const mgr = sourceManagerRegistry.getManager(source.id);
+          const sink = mgr && 'recordGeoSweepStats' in mgr
+            ? (mgr as unknown as { recordGeoSweepStats: (s: GeoSweepStats) => void })
+            : undefined;
+          // Connect-independent DB convergence with lift:true — the ONLY path
+          // allowed to lift geo-ignores (it alone knows the bbox changed). Bbox
+          // removal/any change readmits geo-ignored nodes; still-outside ones
+          // self-correct on their next POSITION via the realtime path. The
+          // restarted manager's own start() sweep (lift:false) is an idempotent
+          // add-pass repeat, serialized by the service's per-source guard.
+          try {
+            await mqttGeoSweepService.runSweep(source.id, newGeo ?? undefined, { lift: true, sink });
+          } catch (err) {
+            logger.warn(`Geo sweep after config change failed for source ${source.id}:`, err);
+          }
+        }
       }
     } else if (wasEnabled && isNowEnabled && source.type === 'meshcore' && newAutoConnect && config !== undefined) {
       // MeshCore source config changed while enabled and autoConnect on —

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -20,7 +20,7 @@ import {
   buildSourceDashboard,
 } from '../services/sourceDashboardData.js';
 import { getSourcePkiKeyStore, isPkiDmDecryptionGloballyEnabled } from '../services/sourcePkiKeyStore.js';
-import { mqttGeoSweepService, type GeoSweepStats } from '../services/mqttGeoSweepService.js';
+import { mqttGeoSweepService, type GeoSweepStatsSink } from '../services/mqttGeoSweepService.js';
 import type { MqttFilterConfig } from '../mqttPacketFilter.js';
 
 const router = Router();
@@ -700,12 +700,18 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
           (existing.config as { downlinkFilters?: MqttFilterConfig }).downlinkFilters?.geo ?? null;
         const newGeo =
           (source.config as { downlinkFilters?: MqttFilterConfig }).downlinkFilters?.geo ?? null;
-        const geoChanged = JSON.stringify(oldGeo) !== JSON.stringify(newGeo);
+        // Field-by-field comparison — immune to JSON key-order differences
+        // between the stored config and the request body (a false "changed"
+        // would only cost a no-op sweep, but there's no reason to pay it).
+        const bboxField = (g: MqttFilterConfig['geo'] | null, k: 'minLat' | 'maxLat' | 'minLng' | 'maxLng') =>
+          typeof g?.[k] === 'number' ? g[k] : null;
+        const geoChanged = (['minLat', 'maxLat', 'minLng', 'maxLng'] as const).some(
+          (k) => bboxField(oldGeo, k) !== bboxField(newGeo, k),
+        );
         if (geoChanged) {
           const mgr = sourceManagerRegistry.getManager(source.id);
-          const sink = mgr && 'recordGeoSweepStats' in mgr
-            ? (mgr as unknown as { recordGeoSweepStats: (s: GeoSweepStats) => void })
-            : undefined;
+          const sink: GeoSweepStatsSink | undefined =
+            mgr && 'recordGeoSweepStats' in mgr ? (mgr as unknown as GeoSweepStatsSink) : undefined;
           // Connect-independent DB convergence with lift:true — the ONLY path
           // allowed to lift geo-ignores (it alone knows the bbox changed). Bbox
           // removal/any change readmits geo-ignored nodes; still-outside ones

--- a/src/server/services/mqttGeoSweepService.perSource.test.ts
+++ b/src/server/services/mqttGeoSweepService.perSource.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-source isolation tests for mqttGeoSweepService (MQTT Geo-Ignore epic,
+ * Phase 3, WP1).
+ *
+ * Unlike `mqttGeoSweepService.test.ts` (which mocks `../../services/
+ * database.js` wholesale to pin the sweep's branching logic), this file
+ * exercises the REAL singleton `databaseService` against its `:memory:`
+ * SQLite backend — the same rationale as `mqttIngestion.perSource.test.ts`:
+ * per-source isolation is exactly the kind of thing a database mock can't
+ * prove. Every assertion here demonstrates that a sweep run against source A
+ * never reads, ignores, purges, or lifts anything belonging to source B.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mqttGeoSweepService } from './mqttGeoSweepService.js';
+import databaseService from '../../services/database.js';
+
+// Matches the ON_BBOX convention used across the geo-ignore test suite.
+const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+
+function seedNode(nodeNum: number, sourceId: string, overrides: Record<string, unknown> = {}) {
+  const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
+  return databaseService.upsertNodeAsync({
+    nodeNum,
+    nodeId,
+    longName: `Node ${nodeNum}`,
+    shortName: `N${nodeNum}`,
+    hwModel: 1,
+    lastHeard: Math.floor(Date.now() / 1000),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  } as any, sourceId);
+}
+
+describe('mqttGeoSweepService — per-source isolation', () => {
+  // Each test gets its own fresh source pair (rather than one shared pair
+  // reused across the whole file) so a prior test's geo-ignore rows can
+  // never leak into a later test's lift-pass count — the lift pass sweeps
+  // EVERY reason='geo' row on a source, so a shared source would make
+  // `stats.lifted` depend on test execution order.
+  let SRC_A: string;
+  let SRC_B: string;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    await databaseService.waitForReady();
+    const suffix = ++testCounter;
+    SRC_A = `geo-sweep-ps-a-${suffix}`;
+    SRC_B = `geo-sweep-ps-b-${suffix}`;
+    await databaseService.sources.createSource({ id: SRC_A, name: 'Source A', type: 'meshtastic_tcp', config: {}, enabled: true });
+    await databaseService.sources.createSource({ id: SRC_B, name: 'Source B', type: 'meshtastic_tcp', config: {}, enabled: true });
+  });
+
+  afterEach(async () => {
+    // FK ON DELETE CASCADE (migration 048) takes ignored_nodes/nodes rows
+    // scoped to these sources with them.
+    await databaseService.sources.deleteSource(SRC_A).catch(() => {});
+    await databaseService.sources.deleteSource(SRC_B).catch(() => {});
+  });
+
+  it('a sweep on source A ignores + purges only A; source B keeps its node for the same nodeNum', async () => {
+    const NODE = 0x20000001;
+
+    // Both sources have the SAME nodeNum sitting outside ON_BBOX.
+    await seedNode(NODE, SRC_A, { latitude: 49.2, longitude: -123 });
+    await seedNode(NODE, SRC_B, { latitude: 49.2, longitude: -123 });
+
+    expect(await databaseService.nodes.getNode(NODE, SRC_A)).not.toBeNull();
+    expect(await databaseService.nodes.getNode(NODE, SRC_B)).not.toBeNull();
+
+    const stats = await mqttGeoSweepService.runSweep(SRC_A, ON_BBOX, { lift: false });
+
+    expect(stats).toMatchObject({ sourceId: SRC_A, scanned: 1, ignored: 1, purged: 1, lifted: 0 });
+
+    // Source A: geo-ignored + purged.
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_A)).toBe(true);
+    const ignoredOnA = await databaseService.ignoredNodes.getIgnoredNodesAsync(SRC_A);
+    expect(ignoredOnA.find((r) => r.nodeNum === NODE)?.reason).toBe('geo');
+    expect(await databaseService.nodes.getNode(NODE, SRC_A)).toBeNull();
+
+    // Source B: completely untouched by the A-scoped sweep.
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(false);
+    const ignoredOnB = await databaseService.ignoredNodes.getIgnoredNodesAsync(SRC_B);
+    expect(ignoredOnB.find((r) => r.nodeNum === NODE)).toBeUndefined();
+    const nodeB = await databaseService.nodes.getNode(NODE, SRC_B);
+    expect(nodeB).not.toBeNull();
+    expect(nodeB?.longName).toBe(`Node ${NODE}`);
+  });
+
+  it('a lift sweep on source A lifts only A\'s geo entry; B\'s geo entry for the same nodeNum survives', async () => {
+    const NODE = 0x20000002;
+    const NODE_ID = `!${NODE.toString(16).padStart(8, '0')}`;
+
+    // Manually seed geo-ignore rows on BOTH sources for the same nodeNum.
+    await databaseService.ignoredNodes.addGeoIgnoreAsync(NODE, SRC_A, NODE_ID, 'Geo A', 'GA');
+    await databaseService.ignoredNodes.addGeoIgnoreAsync(NODE, SRC_B, NODE_ID, 'Geo B', 'GB');
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_A)).toBe(true);
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(true);
+
+    // No node rows exist for this nodeNum, so the add pass is a no-op; only
+    // the lift pass is exercised here.
+    const stats = await mqttGeoSweepService.runSweep(SRC_A, ON_BBOX, { lift: true });
+
+    expect(stats.lifted).toBe(1);
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_A)).toBe(false);
+
+    // Source B's geo-ignore entry for the same nodeNum must survive untouched.
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(true);
+    const ignoredOnB = await databaseService.ignoredNodes.getIgnoredNodesAsync(SRC_B);
+    expect(ignoredOnB.find((r) => r.nodeNum === NODE)?.reason).toBe('geo');
+  });
+
+  it('an in-bbox node on source B is never scanned/ignored by a sweep run against source A', async () => {
+    const NODE = 0x20000003;
+    // Only seed the node on source B, inside the bbox.
+    await seedNode(NODE, SRC_B, { latitude: 44, longitude: -78 });
+
+    const stats = await mqttGeoSweepService.runSweep(SRC_A, ON_BBOX, { lift: false });
+
+    // Source A has nothing to scan for this nodeNum.
+    expect(stats.ignored).toBe(0);
+    expect(stats.purged).toBe(0);
+
+    // Source B's node is completely unaffected.
+    const nodeB = await databaseService.nodes.getNode(NODE, SRC_B);
+    expect(nodeB).not.toBeNull();
+    expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC_B)).toBe(false);
+  });
+});

--- a/src/server/services/mqttGeoSweepService.test.ts
+++ b/src/server/services/mqttGeoSweepService.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for mqttGeoSweepService (MQTT Geo-Ignore epic, Phase 3, WP1).
+ *
+ * `../../services/database.js` is mocked wholesale (mockResolvedValue on
+ * every async method) — this file exercises the sweep's branching logic in
+ * isolation from any real database. Per-source isolation is covered
+ * separately in `mqttGeoSweepService.perSource.test.ts` against the real
+ * singleton DB.
+ *
+ * `getEffectiveDbNodePosition` (nodeEnhancer.ts) and `MqttPacketFilter`
+ * (mqttPacketFilter.ts) are used UNMOCKED — both are small pure functions,
+ * and the override/bbox-classification behavior under test is exactly what
+ * they implement.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getAllNodes = vi.fn();
+const isIgnoredCached = vi.fn();
+const addGeoIgnoreAsync = vi.fn();
+const getIgnoredNodesAsync = vi.fn();
+const liftGeoIgnoreAsync = vi.fn();
+const deleteNodeAsync = vi.fn();
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    nodes: { getAllNodes: (...a: unknown[]) => getAllNodes(...a) },
+    ignoredNodes: {
+      isIgnoredCached: (...a: unknown[]) => isIgnoredCached(...a),
+      addGeoIgnoreAsync: (...a: unknown[]) => addGeoIgnoreAsync(...a),
+      getIgnoredNodesAsync: (...a: unknown[]) => getIgnoredNodesAsync(...a),
+      liftGeoIgnoreAsync: (...a: unknown[]) => liftGeoIgnoreAsync(...a),
+    },
+    deleteNodeAsync: (...a: unknown[]) => deleteNodeAsync(...a),
+  },
+}));
+
+import { logger } from '../../utils/logger.js';
+import { mqttGeoSweepService, type GeoSweepStatsSink } from './mqttGeoSweepService.js';
+
+// Matches the ON_BBOX convention used across the geo-ignore test suite.
+const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+
+function makeNode(overrides: Record<string, unknown> = {}) {
+  return {
+    nodeNum: 100,
+    nodeId: '!00000064',
+    longName: 'Node 100',
+    shortName: 'N100',
+    latitude: 44,
+    longitude: -78,
+    positionOverrideEnabled: false,
+    latitudeOverride: null,
+    longitudeOverride: null,
+    ...overrides,
+  };
+}
+
+describe('mqttGeoSweepService', () => {
+  beforeEach(() => {
+    getAllNodes.mockReset().mockResolvedValue([]);
+    isIgnoredCached.mockReset().mockReturnValue(false);
+    addGeoIgnoreAsync.mockReset().mockResolvedValue(true);
+    getIgnoredNodesAsync.mockReset().mockResolvedValue([]);
+    liftGeoIgnoreAsync.mockReset().mockResolvedValue(true);
+    deleteNodeAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('ignores and purges an out-of-bbox node', async () => {
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 49.2, longitude: -123 })]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats).toMatchObject({ sourceId: 'S1', scanned: 1, ignored: 1, purged: 1, lifted: 0 });
+    expect(addGeoIgnoreAsync).toHaveBeenCalledWith(100, 'S1', '!00000064', 'Node 100', 'N100');
+    expect(deleteNodeAsync).toHaveBeenCalledWith(100, 'S1');
+  });
+
+  it('leaves an in-bbox node untouched', async () => {
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 44, longitude: -78 })]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats).toMatchObject({ scanned: 1, ignored: 0, purged: 0 });
+    expect(addGeoIgnoreAsync).not.toHaveBeenCalled();
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('excludes position-less nodes from scanned', async () => {
+    getAllNodes.mockResolvedValue([makeNode({ latitude: null, longitude: null })]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats.scanned).toBe(0);
+    expect(addGeoIgnoreAsync).not.toHaveBeenCalled();
+  });
+
+  it('honors an override that pushes an in-GPS node out of bounds', async () => {
+    getAllNodes.mockResolvedValue([
+      makeNode({
+        latitude: 44, longitude: -78, // GPS is inside the bbox
+        positionOverrideEnabled: true,
+        latitudeOverride: 49.2, longitudeOverride: -123, // override is outside
+      }),
+    ]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats.ignored).toBe(1);
+    expect(deleteNodeAsync).toHaveBeenCalledWith(100, 'S1');
+  });
+
+  it('honors an override that pulls an out-of-GPS node back in bounds', async () => {
+    getAllNodes.mockResolvedValue([
+      makeNode({
+        latitude: 49.2, longitude: -123, // GPS is outside the bbox
+        positionOverrideEnabled: true,
+        latitudeOverride: 44, longitudeOverride: -78, // override is inside
+      }),
+    ]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats.ignored).toBe(0);
+    expect(addGeoIgnoreAsync).not.toHaveBeenCalled();
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not purge when addGeoIgnoreAsync returns false (purge-once contract)', async () => {
+    addGeoIgnoreAsync.mockResolvedValue(false);
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 49.2, longitude: -123 })]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats.ignored).toBe(0);
+    expect(stats.purged).toBe(0);
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips an already-ignored node in the add pass (excluded from scanned)', async () => {
+    isIgnoredCached.mockReturnValue(true);
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 49.2, longitude: -123 })]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(stats.scanned).toBe(0);
+    expect(addGeoIgnoreAsync).not.toHaveBeenCalled();
+  });
+
+  it('lift pass lifts only reason=geo entries and counts only true returns', async () => {
+    getIgnoredNodesAsync.mockResolvedValue([
+      { nodeNum: 1, reason: 'geo' },
+      { nodeNum: 2, reason: 'manual' },
+      { nodeNum: 3, reason: 'geo' },
+    ]);
+    liftGeoIgnoreAsync.mockImplementation((nodeNum: number) => Promise.resolve(nodeNum === 1));
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: true });
+
+    expect(liftGeoIgnoreAsync).toHaveBeenCalledTimes(2);
+    expect(liftGeoIgnoreAsync).toHaveBeenCalledWith(1, 'S1');
+    expect(liftGeoIgnoreAsync).toHaveBeenCalledWith(3, 'S1');
+    expect(liftGeoIgnoreAsync).not.toHaveBeenCalledWith(2, 'S1');
+    expect(stats.lifted).toBe(1);
+  });
+
+  it('lift:false never calls getIgnoredNodesAsync or liftGeoIgnoreAsync', async () => {
+    await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+
+    expect(getIgnoredNodesAsync).not.toHaveBeenCalled();
+    expect(liftGeoIgnoreAsync).not.toHaveBeenCalled();
+  });
+
+  it('geo:undefined with lift:true still lifts, while the add pass no-ops', async () => {
+    getIgnoredNodesAsync.mockResolvedValue([{ nodeNum: 1, reason: 'geo' }]);
+    liftGeoIgnoreAsync.mockResolvedValue(true);
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 49.2, longitude: -123 })]);
+
+    const stats = await mqttGeoSweepService.runSweep('S1', undefined, { lift: true });
+
+    expect(stats.lifted).toBe(1);
+    expect(stats.ignored).toBe(0);
+    expect(stats.purged).toBe(0);
+    expect(addGeoIgnoreAsync).not.toHaveBeenCalled();
+  });
+
+  it('logs at info level when anything changed, debug otherwise', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 49.2, longitude: -123 })]);
+    await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('geo sweep [S1]: ignored 1, purged 1, lifted 0, scanned 1'));
+    expect(debugSpy).not.toHaveBeenCalledWith(expect.stringContaining('geo sweep'));
+
+    infoSpy.mockClear();
+    debugSpy.mockClear();
+
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 44, longitude: -78 })]);
+    await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false });
+    expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('geo sweep'));
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('geo sweep [S1]'));
+
+    infoSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('calls the stats sink exactly once with the final stats', async () => {
+    getAllNodes.mockResolvedValue([makeNode({ latitude: 49.2, longitude: -123 })]);
+    const recordGeoSweepStats = vi.fn();
+    const sink: GeoSweepStatsSink = { recordGeoSweepStats };
+
+    const stats = await mqttGeoSweepService.runSweep('S1', ON_BBOX, { lift: false, sink });
+
+    expect(recordGeoSweepStats).toHaveBeenCalledTimes(1);
+    expect(recordGeoSweepStats).toHaveBeenCalledWith(stats);
+  });
+
+  it('serializes two overlapping calls for the same source', async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    let firstCallSeen = false;
+
+    getAllNodes.mockImplementation(async () => {
+      if (!firstCallSeen) {
+        firstCallSeen = true;
+        order.push('first-start');
+        await new Promise<void>((res) => { releaseFirst = res; });
+        order.push('first-end');
+        return [];
+      }
+      order.push('second-start');
+      return [];
+    });
+
+    const p1 = mqttGeoSweepService.runSweep('SAME', ON_BBOX, { lift: false });
+    // Let p1 reach its getAllNodes await point.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const p2 = mqttGeoSweepService.runSweep('SAME', ON_BBOX, { lift: false });
+    // p2 must not have started scanning yet — it's chained behind p1.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['first-start']);
+
+    releaseFirst();
+    await p1;
+    await p2;
+
+    expect(order).toEqual(['first-start', 'first-end', 'second-start']);
+  });
+});

--- a/src/server/services/mqttGeoSweepService.ts
+++ b/src/server/services/mqttGeoSweepService.ts
@@ -1,0 +1,184 @@
+import { logger } from '../../utils/logger.js';
+import databaseService from '../../services/database.js';
+import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
+import { MqttPacketFilter, type MqttFilterConfig } from '../mqttPacketFilter.js';
+
+export interface GeoSweepStats {
+  sourceId: string;
+  timestamp: number; // Date.now() at completion
+  scanned: number; // position-bearing, not-already-ignored node rows evaluated
+  ignored: number; // addGeoIgnoreAsync returned true (new geo rows)
+  purged: number; // deleteNodeAsync calls that succeeded
+  lifted: number; // geo entries lifted (lift pass); 0 when lift:false
+  durationMs: number;
+}
+
+export interface GeoSweepStatsSink {
+  recordGeoSweepStats(stats: GeoSweepStats): void;
+}
+
+export interface RunSweepOptions {
+  lift: boolean;
+  sink?: GeoSweepStatsSink;
+}
+
+/**
+ * Retroactive geo sweep (MQTT Geo-Ignore epic, Phase 3, WP1).
+ *
+ * The realtime geo filter (`mqttIngestion.ts` POSITION_APP branch) is
+ * fail-open by design: it only classifies a node against the configured bbox
+ * when a fresh POSITION packet arrives for that node. A node that already has
+ * a stored position (from before the bbox was configured, or from before this
+ * bridge started) sits in the database unclassified until its next POSITION
+ * update — which may be minutes or hours away, or may never come again if the
+ * node is dead. This service closes that gap by retroactively classifying
+ * every stored node against the current bbox in one pass.
+ *
+ * Two call sites, two different sweep shapes:
+ *   - **Bridge/source start**: there is no "old bbox" to diff against, so the
+ *     sweep only ever needs to ADD new geo-ignores (`lift: false`) — any node
+ *     that was previously lifted is already un-ignored and stays that way.
+ *   - **Config save**: the bbox may have grown, shrunk, or moved, so the
+ *     sweep runs a LIFT pass first (nodes geo-ignored under the old bbox that
+ *     the new bbox would no longer exclude become un-ignored and reappear)
+ *     followed by the ADD pass (nodes newly outside the new bbox get
+ *     geo-ignored and purged).
+ *
+ * Lifted nodes are not actively re-verified against live position data here
+ * — they simply become eligible again, and the realtime POSITION path
+ * (`mqttIngestion.ts`) self-corrects them on their next packet: a lifted node
+ * still outside the (possibly changed) bbox gets re-ignored the moment it
+ * reports a position, exactly like any other node. This keeps the sweep itself
+ * simple and side-effect-free beyond the ignore-list and node-purge state.
+ *
+ * The sweep does a single unpaginated `getAllNodes(sourceId)` scan. This is
+ * deliberate: per-source node counts are expected to stay in the low
+ * thousands, and sweeps are rare (source start, config save) rather than a
+ * hot/frequent path — the simplicity of one full scan outweighs the
+ * complexity of pagination for this access pattern.
+ */
+class MqttGeoSweepService {
+  /**
+   * Per-source serialization. A second `runSweep` call for a source already
+   * in flight is chained onto the tail of the first via `.then`, so sweeps
+   * for the same source never run concurrently (which could double-count
+   * stats or race the ignore-list cache). `.catch(() => undefined)` isolates
+   * a prior sweep's failure from the chain — one failed sweep must not sink
+   * every subsequent sweep for that source. The map entry is cleared in
+   * `.finally` only when this call is still the tail, mirroring the
+   * `cliCommandLocks` pattern in `meshcoreManager.ts`.
+   */
+  private readonly inFlight = new Map<string, Promise<GeoSweepStats>>();
+
+  async runSweep(
+    sourceId: string,
+    geo: MqttFilterConfig['geo'] | undefined,
+    opts: RunSweepOptions,
+  ): Promise<GeoSweepStats> {
+    const prior = this.inFlight.get(sourceId) ?? Promise.resolve();
+    const runNext = prior.catch(() => undefined).then(() => this.runSweepLocked(sourceId, geo, opts));
+    this.inFlight.set(sourceId, runNext);
+    try {
+      return await runNext;
+    } finally {
+      if (this.inFlight.get(sourceId) === runNext) {
+        this.inFlight.delete(sourceId);
+      }
+    }
+  }
+
+  private async runSweepLocked(
+    sourceId: string,
+    geo: MqttFilterConfig['geo'] | undefined,
+    opts: RunSweepOptions,
+  ): Promise<GeoSweepStats> {
+    const start = Date.now();
+    let scanned = 0;
+    let ignored = 0;
+    let purged = 0;
+    let lifted = 0;
+
+    // LIFT PASS — only when requested (config-save sweeps). Manual entries
+    // are never touched: liftGeoIgnoreAsync itself is reason='geo'-guarded,
+    // but we also pre-filter here so we never even attempt a lift on a
+    // manual row.
+    if (opts.lift) {
+      const ignoredEntries = await databaseService.ignoredNodes.getIgnoredNodesAsync(sourceId);
+      for (const entry of ignoredEntries) {
+        if (entry.reason !== 'geo') continue;
+        const didLift = await databaseService.ignoredNodes.liftGeoIgnoreAsync(Number(entry.nodeNum), sourceId);
+        if (didLift) lifted++;
+      }
+    }
+
+    // ADD PASS — always runs. With no bbox configured, classifyPosition
+    // returns 'no-geo' for every node, so this naturally no-ops.
+    const filter = new MqttPacketFilter({ geo });
+    const allNodes = await databaseService.nodes.getAllNodes(sourceId);
+
+    for (const node of allNodes) {
+      const nodeNum = Number(node.nodeNum); // BIGINT coercion (PostgreSQL/MySQL)
+
+      // Already-ignored nodes (geo or manual) are skipped — nothing to do.
+      if (databaseService.ignoredNodes.isIgnoredCached(nodeNum, sourceId)) continue;
+
+      // Effective position honors a user-set override (issue #2847), same as
+      // autoDeleteByDistanceService.
+      const eff = getEffectiveDbNodePosition(node);
+      if (eff.latitude == null || eff.longitude == null) continue; // fail-open: no position, no opinion
+
+      scanned++;
+
+      const classification = filter.classifyPosition({
+        latitudeI: Math.round(eff.latitude * 1e7),
+        longitudeI: Math.round(eff.longitude * 1e7),
+      });
+
+      if (classification !== 'out') continue;
+
+      const nodeId = node.nodeId || `!${nodeNum.toString(16).padStart(8, '0')}`;
+      const inserted = await databaseService.ignoredNodes.addGeoIgnoreAsync(
+        nodeNum,
+        sourceId,
+        nodeId,
+        node.longName ?? undefined,
+        node.shortName ?? undefined,
+      );
+
+      if (inserted) {
+        ignored++;
+        // Purge-once: only the true→false transition (a NEW geo-ignore row)
+        // purges. If addGeoIgnoreAsync returned false the node was already
+        // ignored (e.g. a manual row raced in) and must not be purged again.
+        try {
+          await databaseService.deleteNodeAsync(nodeNum, sourceId);
+          purged++;
+        } catch (err) {
+          logger.warn(`⚠️ geo sweep [${sourceId}]: failed to purge node ${nodeNum} after geo-ignore:`, err);
+        }
+      }
+    }
+
+    const durationMs = Date.now() - start;
+    const stats: GeoSweepStats = {
+      sourceId,
+      timestamp: Date.now(),
+      scanned,
+      ignored,
+      purged,
+      lifted,
+      durationMs,
+    };
+
+    if (ignored > 0 || purged > 0 || lifted > 0) {
+      logger.info(`geo sweep [${sourceId}]: ignored ${ignored}, purged ${purged}, lifted ${lifted}, scanned ${scanned}`);
+    } else {
+      logger.debug(`geo sweep [${sourceId}]: no changes (scanned ${scanned})`);
+    }
+
+    opts.sink?.recordGeoSweepStats(stats);
+    return stats;
+  }
+}
+
+export const mqttGeoSweepService = new MqttGeoSweepService();

--- a/src/server/services/mqttGeoSweepService.ts
+++ b/src/server/services/mqttGeoSweepService.ts
@@ -5,7 +5,7 @@ import { MqttPacketFilter, type MqttFilterConfig } from '../mqttPacketFilter.js'
 
 export interface GeoSweepStats {
   sourceId: string;
-  timestamp: number; // Date.now() at completion
+  timestamp: number; // completion time; start time = timestamp - durationMs
   scanned: number; // position-bearing, not-already-ignored node rows evaluated
   ignored: number; // addGeoIgnoreAsync returned true (new geo rows)
   purged: number; // deleteNodeAsync calls that succeeded
@@ -120,6 +120,10 @@ class MqttGeoSweepService {
       const nodeNum = Number(node.nodeNum); // BIGINT coercion (PostgreSQL/MySQL)
 
       // Already-ignored nodes (geo or manual) are skipped — nothing to do.
+      // In-memory cache lookup only (primed at server boot); on a cold cache
+      // an already-ignored node falls through harmlessly: addGeoIgnoreAsync
+      // is insert-if-absent and returns false, so no re-purge — the miss only
+      // inflates `scanned`.
       if (databaseService.ignoredNodes.isIgnoredCached(nodeNum, sourceId)) continue;
 
       // Effective position honors a user-set override (issue #2847), same as

--- a/src/server/services/mqttPacketLogService.buildRow.test.ts
+++ b/src/server/services/mqttPacketLogService.buildRow.test.ts
@@ -44,7 +44,8 @@ describe('buildMqttPacketLogRow', () => {
     const cases: Array<[MqttIngestionResult, string]> = [
       [{ ingested: true, portnum: 1 }, 'ingested'],
       [{ ingested: false, reason: 'encrypted' }, 'encrypted'],
-      [{ ingested: false, reason: 'geo-filtered' }, 'geo-filtered'],
+      [{ ingested: false, reason: 'ignored' }, 'ignored'],
+      [{ ingested: false, reason: 'geo-ignored' }, 'geo-ignored'],
       [{ ingested: false, reason: 'unsupported-portnum' }, 'unsupported-portnum'],
       [{ ingested: false, reason: 'decode-error' }, 'decode-error'],
       [{ ingested: false, reason: 'no-decoded' }, 'decode-error'],
@@ -59,7 +60,7 @@ describe('buildMqttPacketLogRow', () => {
     it('ingested:true always wins even if a reason is also set', () => {
       const row = buildMqttPacketLogRow('src-a', envelope(), {
         ingested: true,
-        reason: 'geo-filtered' as any,
+        reason: 'geo-ignored' as any,
         portnum: 1,
       });
       expect(row?.ingestOutcome).toBe('ingested');

--- a/src/server/services/mqttPacketLogService.ts
+++ b/src/server/services/mqttPacketLogService.ts
@@ -160,8 +160,10 @@ function mapOutcome(result: MqttIngestionResult): MqttIngestOutcome {
   switch (result.reason) {
     case 'encrypted':
       return 'encrypted';
-    case 'geo-filtered':
-      return 'geo-filtered';
+    case 'ignored':
+      return 'ignored';
+    case 'geo-ignored':
+      return 'geo-ignored';
     case 'unsupported-portnum':
       return 'unsupported-portnum';
     case 'decode-error':


### PR DESCRIPTION
## Summary

Phase 3 of the MQTT Geo-Ignore rearchitecture (#4115, epic plan in `docs/internal/dev-notes/MQTT_GEO_IGNORE_EPIC.md`) — the **retroactive sweep**. Phases 1 (#4123) and 2 (#4131) made the realtime path fail-open with geo-ignore/purge/lift on live POSITION packets; this phase converges **stored** data when the bridge starts or its bbox config changes, instead of waiting for each node's next transmission.

### New: `mqttGeoSweepService`

A small standalone service (prior art: `autoDeleteByDistanceService`) with two passes:
- **ADD pass (always):** scan this source's node rows; any node whose stored *effective* position (user overrides honored via `getEffectiveDbNodePosition`) is outside the bbox → geo-ignore + one-time full purge (same purge-once contract as the realtime path, keyed on `addGeoIgnoreAsync`'s insert boolean). Position-less nodes untouched (fail-open). Manual ignores never touched.
- **LIFT pass (config-save only):** lift **all** `reason='geo'` entries for the source. Purged nodes have no stored position to re-evaluate, so lift-all + realtime self-correction is the only sound semantics: still-outside nodes are re-ignored+purged on their next POSITION.

Per-source in-flight chaining makes overlapping sweeps serialize (config save racing a start sweep). One unpaginated `getAllNodes(sourceId)` scan per sweep is deliberate — sources are ≤ a few thousand rows and sweeps are rare.

### Triggers

- **Bridge `start()`**: fire-and-forget `lift:false` sweep (a plain restart has no old bbox to diff — lifting on every boot would permanently readmit silently-purged nodes).
- **Source config save** (`PUT /api/sources/:id`, `mqtt_bridge`, `downlinkFilters.geo` actually changed): awaited `lift:true` sweep, connect-independent — bbox removal lifts everything even if the restarted bridge can't reach its upstream.

### Observability

`getStatus()` now exposes `lastGeoSweep` (`{scanned, ignored, purged, lifted, timestamp, durationMs}`); summary logged at info when anything changed. Phase 4 surfaces this in the UI.

### Notes for reviewers

- **Favorites are deliberately NOT protected** (diverges from `autoDeleteByDistanceService`): the Phase 2 realtime path geo-ignores any out-of-bbox POSITION regardless of favorite status, and the sweep must match it — retroactive and realtime behavior stay identical.
- Editing the bbox (including narrowing) transiently readmits geo-ignored nodes; each still-outside node re-purges on its next POSITION. A pure-narrowing lift-skip is a noted future refinement.

### Tests

- `mqttGeoSweepService.test.ts` — 13 unit cases (in/out/position-less/override-position both directions, purge-once idempotency, lift semantics incl. manual exclusion, re-entrancy serialization, log levels, sink).
- `mqttGeoSweepService.perSource.test.ts` — real-DB source isolation.
- `sourceRoutes.geoSweep.test.ts` — route-harness end-to-end: bbox change (ignore+purge+lift+manual-survives), bbox removal (lift-all), non-geo change (no sweep).
- `mqttBridgeManager.test.ts` — start() sweep invocation + `lastGeoSweep` status plumbing.

Full suite: **9,146 passed / 0 failed** (`success: true` via JSON reporter). `tsc` clean, `lint:ci` ratchet OK.

Part of #4115 (Phase 3 of 4 — do not close the issue on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1
