### PR TITLE
fix(mqtt): align packet-log ingest outcomes with geo-ignore reasons

### DIFF
--- a/src/db/repositories/mqttPacketLog.ts
+++ b/src/db/repositories/mqttPacketLog.ts
@@ -15,7 +15,8 @@ import { BaseRepository } from './base.js';
 export type MqttIngestOutcome =
   | 'ingested'
   | 'encrypted'
-  | 'geo-filtered'
+  | 'ignored' // sender on the per-source ignore list (#4115 geo-ignore epic)
+  | 'geo-ignored' // geo-fence auto-ignore triggered by an out-of-bbox position
   | 'unsupported-portnum'
   | 'decode-error';
 

--- a/src/db/schema/mqttPacketLog.ts
+++ b/src/db/schema/mqttPacketLog.ts
@@ -50,7 +50,7 @@ export const mqttPacketLogSqlite = sqliteTable('mqtt_packet_log', {
   encrypted: integer('encrypted').notNull().default(0),
   /** 'server' when MeshMonitor decrypted an encrypted copy server-side, else null. */
   decryptedBy: text('decryptedBy'),
-  /** 'ingested' | 'encrypted' | 'geo-filtered' | 'unsupported-portnum' | 'decode-error'. */
+  /** 'ingested' | 'encrypted' | 'ignored' | 'geo-ignored' | 'unsupported-portnum' | 'decode-error'. */
   ingestOutcome: text('ingestOutcome').notNull(),
   payloadSize: integer('payloadSize'),
   /** Text preview (TEXT_MESSAGE_APP only in Phase 1) or null. */

--- a/src/server/mqttPacketLogService.ingestHook.test.ts
+++ b/src/server/mqttPacketLogService.ingestHook.test.ts
@@ -53,6 +53,14 @@ vi.mock('../services/database.js', () => ({
     mqttPacketLog: {
       insertPacket: vi.fn(async () => undefined),
     },
+    // Geo-ignore epic (#4115): the ingest pipeline gates on the per-source
+    // ignore list and auto-ignores out-of-bbox positions.
+    ignoredNodes: {
+      isIgnoredCached: vi.fn(() => false),
+      addGeoIgnoreAsync: vi.fn(async () => true),
+      liftGeoIgnoreAsync: vi.fn(async () => true),
+    },
+    deleteNodeAsync: vi.fn(async () => undefined),
   },
 }));
 
@@ -119,6 +127,9 @@ async function flush(): Promise<void> {
 describe('MQTT Packet Monitor — ingestion hook', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks does not remove implementations set via mockReturnValue —
+    // re-pin the ignore gate to "not ignored" so per-test overrides don't leak.
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
     _resetMqttIngestCachesForTest();
     channelDecryptionService.invalidateCache();
     channelDecryptionService.setEnabled(true);
@@ -162,21 +173,42 @@ describe('MQTT Packet Monitor — ingestion hook', () => {
     expect(row.portnum).toBeNull();
   });
 
-  it('logs a geo-filtered copy with portnum still populated (decode happened before the gate)', async () => {
-    const filter = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 } });
+  it('logs an ignored-sender copy with portnum still populated (decode happened before the gate)', async () => {
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(true);
     const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
-      envelope: envFor({ from: 0x22222222, portnum: 1 }), // unknown sender, non-position
-      filter,
+      envelope: envFor({ from: 0x22222222, portnum: 1 }), // ignored sender, non-position
     });
     expect(result.ingested).toBe(false);
-    expect(result.reason).toBe('geo-filtered');
+    expect(result.reason).toBe('ignored');
 
     await flush();
     expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
     const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
-    expect(row.ingestOutcome).toBe('geo-filtered');
+    expect(row.ingestOutcome).toBe('ignored');
     expect(row.portnum).toBe(1);
+  });
+
+  it('logs a geo-ignored copy when an out-of-bbox POSITION triggers the auto-ignore', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({
+      latitudeI: 492_000_000, // Vancouver — far outside the Ontario bbox below
+      longitudeI: -1_230_000_000,
+    }));
+    const filter = new MqttPacketFilter({ geo: { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 } });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor({ from: 0x22222222, portnum: PortNum.POSITION_APP }),
+      filter,
+    });
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('geo-ignored');
+
+    await flush();
+    expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.ingestOutcome).toBe('geo-ignored');
+    expect(row.portnum).toBe(PortNum.POSITION_APP);
   });
 
   it('logs an unsupported-portnum copy', async () => {

--- a/src/server/services/mqttPacketLogService.buildRow.test.ts
+++ b/src/server/services/mqttPacketLogService.buildRow.test.ts
@@ -44,7 +44,8 @@ describe('buildMqttPacketLogRow', () => {
     const cases: Array<[MqttIngestionResult, string]> = [
       [{ ingested: true, portnum: 1 }, 'ingested'],
       [{ ingested: false, reason: 'encrypted' }, 'encrypted'],
-      [{ ingested: false, reason: 'geo-filtered' }, 'geo-filtered'],
+      [{ ingested: false, reason: 'ignored' }, 'ignored'],
+      [{ ingested: false, reason: 'geo-ignored' }, 'geo-ignored'],
       [{ ingested: false, reason: 'unsupported-portnum' }, 'unsupported-portnum'],
       [{ ingested: false, reason: 'decode-error' }, 'decode-error'],
       [{ ingested: false, reason: 'no-decoded' }, 'decode-error'],
@@ -59,7 +60,7 @@ describe('buildMqttPacketLogRow', () => {
     it('ingested:true always wins even if a reason is also set', () => {
       const row = buildMqttPacketLogRow('src-a', envelope(), {
         ingested: true,
-        reason: 'geo-filtered' as any,
+        reason: 'geo-ignored' as any,
         portnum: 1,
       });
       expect(row?.ingestOutcome).toBe('ingested');

--- a/src/server/services/mqttPacketLogService.ts
+++ b/src/server/services/mqttPacketLogService.ts
@@ -160,8 +160,10 @@ function mapOutcome(result: MqttIngestionResult): MqttIngestOutcome {
   switch (result.reason) {
     case 'encrypted':
       return 'encrypted';
-    case 'geo-filtered':
-      return 'geo-filtered';
+    case 'ignored':
+      return 'ignored';
+    case 'geo-ignored':
+      return 'geo-ignored';
     case 'unsupported-portnum':
       return 'unsupported-portnum';
     case 'decode-error':


### PR DESCRIPTION
## Summary
**Main is currently red** (typecheck + 7 test failures): the geo-ignore epic (#4123/#4126) replaced the `'geo-filtered'` MQTT ingest reason with `'ignored'` / `'geo-ignored'` while the MQTT Packet Monitor backend (#4127) was in flight, and the two merged within hours of each other — a semantic conflict git couldn't flag. This aligns the packet monitor's outcome union and tests with the new reasons.

## Changes
- `MqttIngestOutcome`: `'geo-filtered'` → `'ignored'` (per-source ignore list) + `'geo-ignored'` (bbox auto-ignore); schema comment updated.
- `mapOutcome`: maps the two new reasons through 1:1.
- Ingest-hook tests: added the `ignoredNodes`/`deleteNodeAsync` mock surface the ingest pipeline now requires; replaced the geo-filtered scenario with ignored-sender and out-of-bbox-position scenarios; re-pin `isIgnoredCached` in `beforeEach` (sticky mockReturnValue).
- buildRow tests: outcome-mapping cases updated.

## Issues Resolved
Relates to #4124 and #4115 (cross-epic integration).

## Documentation Updates
No documentation changes needed.

## Testing
- [x] `mqttPacketLogService` hook/buildRow + `mqttIngestion` tests: 91/91 green
- [x] `npm run typecheck` — 0 errors (was 1 on main)
- [x] `npm run lint:ci` — ratchet OK
- [x] Full local Vitest suite re-run in progress; CI validates independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub