### PR TITLE
fix(nodes): reliably un-hide nodes from the map across sources (#4137)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -418,6 +418,7 @@
   "messages.traceroute_channel": "Choose channel for traceroute",
   "messages.show_on_map": "Show on Map",
   "messages.show_on_map_title": "Show this node on the map",
+  "messages.center_on_map": "Center on Map",
   "messages.history_button": "Show History",
   "messages.history_title": "View traceroute history for this node",
   "messages.exchange_position": "Exchange Position",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4237,6 +4237,19 @@ const location = useLocation();
   // Toggle the per-node "Hide from Map" flag (issue #3549). Display-only: the
   // node stays visible everywhere except map markers. Mirrors toggleIgnored's
   // optimistic-update + per-source pending-request pattern, minus device sync.
+  //
+  // #4137: App.tsx is only ever mounted per-source (via SourceProvider under
+  // /source/:sourceId/*) — there is no separate "unified" caller of this
+  // toggle today. But since mergeNodesAcrossSources now ORs hideFromMap across
+  // sources for every cross-source consumer (Dashboard, Map Analysis, the
+  // unified node list — see mergeNodesAcrossSources.ts), a node stays hidden
+  // there forever unless EVERY source that ever hid it gets cleared. A
+  // per-source-only clear reproduces the exact "can't un-hide" bug reported
+  // in #4137. This is the only hide/show entry point in the UI, so it always
+  // converges the flag across every source for this nodeNum (allSources:
+  // true) rather than only the row for the currently-viewed source.
+  // sourceId is still sent and still required server-side — it remains the
+  // permission anchor for the write, just not the update scope.
   const toggleHideFromMap = async (node: DeviceInfo, event: React.MouseEvent) => {
     event.stopPropagation();
 
@@ -4270,6 +4283,7 @@ const location = useLocation();
         body: JSON.stringify({
           hideFromMap: newStatus,
           sourceId,
+          allSources: true,
         }),
       });
 

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1290,7 +1290,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               setShowActionsMenu(false);
                             }}
                           >
-                            🗺️ {t('messages.show_on_map')}
+                            {/* #4137: distinct icon/label from the hide/show toggle below
+                                ("Show on Map" is the un-hide label) so this pure pan action
+                                is never mistaken for the toggle. */}
+                            🎯 {t('messages.center_on_map', 'Center on Map')}
                           </button>
                         )}
                         {hasPermission('nodes', 'write') && (
@@ -1871,7 +1874,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               marginTop: '1rem',
               marginBottom: '1rem'
             }}>
-              {/* Show on Map */}
+              {/* Center on Map (#4137: renamed from "Show on Map" — distinct from the
+                  hide/show toggle's un-hide label of the same former text) */}
               {selectedNode?.position?.latitude != null && selectedNode?.position?.longitude != null && (
                 <button
                   onClick={() => handleShowOnMap(selectedDMNode)}
@@ -1887,7 +1891,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     fontSize: '0.9rem'
                   }}
                 >
-                  🗺️ {t('messages.show_on_map')}
+                  🎯 {t('messages.center_on_map', 'Center on Map')}
                 </button>
               )}
 

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -136,6 +136,7 @@ import { migration as dropLegacyAuthProviderCheckMigration, runMigration118Postg
 import { migration as themeTilesetsMigration, runMigration119Postgres as runThemeTilesetsPostgres, runMigration119Mysql as runThemeTilesetsMysql } from '../server/migrations/119_add_theme_tilesets.js';
 import { migration as addReasonToIgnoredNodesMigration, runMigration120Postgres as runAddReasonToIgnoredNodesPostgres, runMigration120Mysql as runAddReasonToIgnoredNodesMysql } from '../server/migrations/120_add_reason_to_ignored_nodes.js';
 import { migration as mqttPacketLogMigration, runMigration121Postgres, runMigration121Mysql } from '../server/migrations/121_mqtt_packet_log.js';
+import { migration as cleanupOrphanedSourceNodesMigration, runMigration122Postgres, runMigration122Mysql } from '../server/migrations/122_cleanup_orphaned_source_nodes.js';
 
 // ============================================================================
 // Registry
@@ -1926,4 +1927,20 @@ registry.register({
   sqlite: (db) => mqttPacketLogMigration.up(db),
   postgres: (client) => runMigration121Postgres(client),
   mysql: (pool) => runMigration121Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 122: One-shot cleanup of `nodes` rows orphaned by a previously
+// deleted source (issue #4137). DELETE /api/sources/:id now purges a
+// source's node rows at delete time going forward — this sweeps rows left
+// behind by every deletion that happened before that fix landed.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 122,
+  name: 'cleanup_orphaned_source_nodes',
+  settingsKey: 'migration_122_cleanup_orphaned_source_nodes',
+  sqlite: (db) => cleanupOrphanedSourceNodesMigration.up(db),
+  postgres: (client) => runMigration122Postgres(client),
+  mysql: (pool) => runMigration122Mysql(pool),
 });

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -982,6 +982,57 @@ function runNodesTests(getBackend: () => TestBackend) {
     expect(node!.lastMessageHops).toBe(3);
   });
 
+  // --- setNodeHideFromMapAllSourcesAsync (#4137) ---
+
+  it('setNodeHideFromMapAllSourcesAsync - sets hideFromMap on every source row for the nodeNum', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(1600, { hideFromMap: true }), 'src-a');
+    await repo.upsertNode(makeNode(1600, { hideFromMap: false }), 'src-b');
+
+    const affected = await repo.setNodeHideFromMapAllSourcesAsync(1600, false);
+    expect(affected).toBe(2);
+
+    const nodeA = await repo.getNode(1600, 'src-a');
+    const nodeB = await repo.getNode(1600, 'src-b');
+    expect(nodeA!.hideFromMap).toBe(false);
+    expect(nodeB!.hideFromMap).toBe(false);
+  });
+
+  it('setNodeHideFromMapAllSourcesAsync - only touches rows for the target nodeNum (per-source isolation)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(1601, { hideFromMap: false }), 'src-a');
+    await repo.upsertNode(makeNode(1602, { hideFromMap: false }), 'src-a');
+
+    const affected = await repo.setNodeHideFromMapAllSourcesAsync(1601, true);
+    expect(affected).toBe(1);
+
+    const node1601 = await repo.getNode(1601, 'src-a');
+    const node1602 = await repo.getNode(1602, 'src-a');
+    expect(node1601!.hideFromMap).toBe(true);
+    expect(node1602!.hideFromMap).toBe(false);
+  });
+
+  it('setNodeHideFromMapAllSourcesAsync - returns 0 for a nodeNum with no rows', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const affected = await repo.setNodeHideFromMapAllSourcesAsync(999999, true);
+    expect(affected).toBe(0);
+  });
+
   // --- getNodesWithPublicKeys ---
 
   it('getNodesWithPublicKeys - returns only nodes with non-empty publicKey', async () => {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -556,6 +556,37 @@ export class NodesRepository extends BaseRepository {
   }
 
   /**
+   * Set `hideFromMap` on EVERY row for this nodeNum, regardless of sourceId
+   * (issue #4137). The per-source setNodeHideFromMapAsync (database.ts) only
+   * flips the row for one sourceId; since mergeNodesAcrossSources now ORs
+   * hideFromMap across sources (hidden-anywhere -> hidden), un-hiding from a
+   * unified/cross-source view has to clear every source's row, or a stale
+   * `true` on another source's row keeps the node hidden forever.
+   *
+   * Returns the number of rows affected (cheap: driven by a row count select,
+   * not a database-specific affected-rows API — those differ across
+   * SQLite/PostgreSQL/MySQL drivers).
+   */
+  async setNodeHideFromMapAllSourcesAsync(nodeNum: number, hidden: boolean): Promise<number> {
+    const { nodes } = this.tables;
+
+    const existing = await this.db
+      .select({ sourceId: nodes.sourceId })
+      .from(nodes)
+      .where(eq(nodes.nodeNum, nodeNum));
+    const affected = existing.length;
+
+    if (affected > 0) {
+      // Reuses updateNode's cross-source update + cache sync (avoids a second
+      // `.set(... as any)` site — Drizzle's update-builder typing needs the
+      // cast, and updateNode already carries it).
+      await this.updateNode(nodeNum, { hideFromMap: hidden, updatedAt: this.now() });
+    }
+
+    return affected;
+  }
+
+  /**
    * Update the lastMessageHops for a node, scoped per-source.
    *
    * After migration 029 (nodeNum, sourceId) is the composite PK, so packet

--- a/src/server/migrations/122_cleanup_orphaned_source_nodes.test.ts
+++ b/src/server/migrations/122_cleanup_orphaned_source_nodes.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Migration 122 — Clean up orphaned `nodes` rows (SQLite path, issue #4137).
+ *
+ * Verifies the one-shot sweep deletes node rows whose sourceId no longer
+ * matches any row in `sources`, leaves rows for live sources untouched, and
+ * is idempotent.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './122_cleanup_orphaned_source_nodes.js';
+
+function createTables(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT
+    );
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      longName TEXT,
+      hideFromMap INTEGER DEFAULT 0,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+  `);
+}
+
+function insertNode(db: Database.Database, nodeNum: number, sourceId: string, hideFromMap = 0) {
+  db.prepare('INSERT INTO nodes (nodeNum, sourceId, longName, hideFromMap) VALUES (?, ?, ?, ?)')
+    .run(nodeNum, sourceId, `Node ${nodeNum}`, hideFromMap);
+}
+
+function nodeCount(db: Database.Database): number {
+  return (db.prepare('SELECT COUNT(*) AS c FROM nodes').get() as { c: number }).c;
+}
+
+function nodeExists(db: Database.Database, nodeNum: number, sourceId: string): boolean {
+  return db.prepare('SELECT 1 FROM nodes WHERE nodeNum = ? AND sourceId = ?').get(nodeNum, sourceId) != null;
+}
+
+describe('Migration 122: cleanup orphaned source nodes (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createTables(db);
+    db.prepare('INSERT INTO sources (id, name) VALUES (?, ?)').run('live-source', 'Live Source');
+
+    // Live rows — sourceId matches a real `sources` row.
+    insertNode(db, 1, 'live-source');
+    insertNode(db, 2, 'live-source', 1);
+
+    // Orphaned rows — sourceId points at a source that no longer exists
+    // (the exact scenario from #4137: a deleted source's stale hideFromMap
+    // leaking into the unified merge forever).
+    insertNode(db, 3, 'deleted-source-a', 1);
+    insertNode(db, 4, 'deleted-source-b');
+  });
+
+  it('deletes every node row whose sourceId has no matching sources row', () => {
+    migration.up(db);
+    expect(nodeExists(db, 3, 'deleted-source-a')).toBe(false);
+    expect(nodeExists(db, 4, 'deleted-source-b')).toBe(false);
+  });
+
+  it('leaves rows for live sources untouched', () => {
+    migration.up(db);
+    expect(nodeExists(db, 1, 'live-source')).toBe(true);
+    expect(nodeExists(db, 2, 'live-source')).toBe(true);
+  });
+
+  it('is idempotent — a second run changes nothing further', () => {
+    migration.up(db);
+    const countAfterFirst = nodeCount(db);
+    migration.up(db);
+    expect(nodeCount(db)).toBe(countAfterFirst);
+    expect(countAfterFirst).toBe(2);
+  });
+});

--- a/src/server/migrations/122_cleanup_orphaned_source_nodes.ts
+++ b/src/server/migrations/122_cleanup_orphaned_source_nodes.ts
@@ -1,0 +1,77 @@
+/**
+ * Migration 122: Clean up orphaned `nodes` rows left behind by a deleted source.
+ *
+ * Background (issue #4137): `DELETE /api/sources/:id` only ever removed the
+ * `sources` row itself — it never cascaded to that source's `nodes` rows.
+ * Those orphaned rows lived on forever with no UI path to clean them up
+ * (there's no source left to target a per-source purge at), and since
+ * `mergeNodesAcrossSources` groups purely by `nodeNum` with no check that a
+ * row's `sourceId` still corresponds to a configured source, an orphan could
+ * leak a stale `hideFromMap: true` (or any other flag) into the unified merge
+ * permanently — the node could never be un-hidden from the unified/
+ * cross-source views. `DELETE /api/sources/:id` now purges a source's node
+ * rows at delete time going forward (see sourceRoutes.ts); this migration is
+ * the one-shot sweep for rows orphaned by every *prior* source deletion.
+ *
+ * Scope: only the `nodes` table. Orphaned messages/telemetry/traceroutes/etc.
+ * for a deleted source are a wider pre-existing issue, out of scope here —
+ * purgeAllNodesAsync (used going forward) already cascades those for future
+ * deletions, but backfilling the historical orphans in those tables is left
+ * for a follow-up if it proves necessary.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL: once no `nodes.sourceId`
+ * references a missing source, a re-run matches zero rows.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 122';
+
+// SQLite / MySQL: bare identifiers (both dialects use camelCase `sourceId`
+// unquoted for the `nodes` table, matching every other nodes.* migration).
+const DELETE_SQL = `DELETE FROM nodes
+  WHERE sourceId IS NOT NULL
+    AND sourceId NOT IN (SELECT id FROM sources)`;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): deleting orphaned node rows...`);
+    const info = db.prepare(DELETE_SQL).run();
+    if (info.changes > 0) {
+      logger.info(`${LABEL} (SQLite): deleted ${info.changes} orphaned node row(s)`);
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (the deleted orphan rows are unrecoverable)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pg client is untyped in the migration runner (matches all sibling migrations)
+export async function runMigration122Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): deleting orphaned node rows...`);
+  const res = await client.query(
+    `DELETE FROM nodes
+     WHERE "sourceId" IS NOT NULL
+       AND "sourceId" NOT IN (SELECT id FROM sources)`,
+  );
+  if (res?.rowCount) {
+    logger.info(`${LABEL} (PostgreSQL): deleted ${res.rowCount} orphaned node row(s)`);
+  }
+}
+
+// ============ MySQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mysql pool is untyped in the migration runner (matches all sibling migrations)
+export async function runMigration122Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): deleting orphaned node rows...`);
+  const [res] = await pool.query(DELETE_SQL);
+  const affected = (res as { affectedRows?: number } | undefined)?.affectedRows ?? 0;
+  if (affected > 0) {
+    logger.info(`${LABEL} (MySQL): deleted ${affected} orphaned node row(s)`);
+  }
+}

--- a/src/server/routes/sourceRoutes.deleteCleanup.test.ts
+++ b/src/server/routes/sourceRoutes.deleteCleanup.test.ts
@@ -1,0 +1,105 @@
+/**
+ * DELETE /api/sources/:id — orphaned node cleanup (issue #4137).
+ *
+ * Background: deleteSource() only removes the `sources` row. Historically it
+ * left that source's `nodes` rows (and hence their `hideFromMap` flag) behind
+ * forever, with no UI path to clean them up once the owning source was gone.
+ * Since mergeNodesAcrossSources ORs hideFromMap across every row for a
+ * nodeNum (including orphans), those stale rows could keep a node hidden in
+ * every cross-source/unified consumer permanently. The route now
+ * best-effort purges that source's node rows via purgeAllNodesAsync
+ * immediately after a successful delete.
+ *
+ * Uses the real-middleware harness (createRouteTestApp) against the live
+ * :memory: singleton DB — see src/server/test-helpers/routeTestApp.ts for
+ * the design rationale, and src/server/routes/sourceRoutes.permissions.test.ts
+ * for the template this file follows. purgeAllNodesAsync is NOT mocked: it
+ * runs for real so the assertions prove the actual purge, not a mocked call.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import databaseService from '../../services/database.js';
+
+function nodeIdFor(num: number): string {
+  return `!${num.toString(16).padStart(8, '0')}`;
+}
+
+describe('DELETE /api/sources/:id — orphaned node cleanup (#4137)', () => {
+  let harness: RouteTestHarness;
+
+  const NODE_A = 0x50000001; // seeded on sourceA — should be purged
+  const NODE_B = 0x50000002; // seeded on sourceB — must survive sourceA's deletion
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+
+    // DELETE /:id uses requirePermission('sources', 'write') with no
+    // sourceIdFrom option — a GLOBAL permission check.
+    await harness.grant(harness.limited.id, 'sources', 'write');
+
+    await databaseService.upsertNodeAsync(
+      {
+        nodeNum: NODE_A,
+        nodeId: nodeIdFor(NODE_A),
+        longName: 'Node A',
+        shortName: 'NDA',
+        hwModel: 1,
+        hideFromMap: true,
+        lastHeard: Math.floor(Date.now() / 1000),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any,
+      harness.sourceA,
+    );
+
+    await databaseService.upsertNodeAsync(
+      {
+        nodeNum: NODE_B,
+        nodeId: nodeIdFor(NODE_B),
+        longName: 'Node B',
+        shortName: 'NDB',
+        hwModel: 1,
+        lastHeard: Math.floor(Date.now() / 1000),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any,
+      harness.sourceB,
+    );
+  });
+
+  afterEach(async () => {
+    await databaseService.nodes.deleteAllNodes(harness.sourceB).catch(() => {});
+    await harness.cleanup();
+  });
+
+  it('purges node rows for the deleted source, leaving other sources untouched', async () => {
+    const agent = await harness.loginAs(harness.limited);
+
+    const res = await agent.delete(`/${harness.sourceA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    // sourceA's node row is gone — no longer able to leak a stale hideFromMap
+    // into the unified merge.
+    expect(await databaseService.nodes.getNode(NODE_A, harness.sourceA)).toBeNull();
+
+    // sourceB is untouched: the purge must be scoped to the deleted source only.
+    const nodeB = await databaseService.nodes.getNode(NODE_B, harness.sourceB);
+    expect(nodeB).not.toBeNull();
+    expect(nodeB!.nodeNum).toBe(NODE_B);
+  });
+
+  it('still deletes the source even if the purge is skipped for an already-clean source', async () => {
+    // sourceB has no orphan risk here — deleting it should succeed and the
+    // purge call (0 rows affected) must not fail the request.
+    const agent = await harness.loginAs(harness.limited);
+
+    const res = await agent.delete(`/${harness.sourceB}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -786,6 +786,19 @@ router.delete('/:id', requirePermission('sources', 'write'), async (req: Request
     if (!deleted) {
       return res.status(404).json({ error: 'Source not found' });
     }
+
+    // #4137: deleteSource only removes the `sources` row — it does not cascade
+    // to `nodes` (or messages/telemetry/etc). Left behind, those orphaned node
+    // rows keep contributing a stale hideFromMap (and other flags) to the
+    // unified merge forever, with no UI path left to clean them up since the
+    // owning source no longer exists. Best-effort: don't fail the delete
+    // request if this cleanup has a problem.
+    try {
+      await databaseService.purgeAllNodesAsync(req.params.id);
+    } catch (purgeError) {
+      logger.warn(`Failed to purge nodes for deleted source ${req.params.id}:`, purgeError);
+    }
+
     res.json({ success: true });
   } catch (error) {
     logger.error('Error deleting source:', error);

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -107,6 +107,7 @@ const databaseMock = {
   setNodeFavorite: vi.fn((_nodeNum: number, _isFavorite: boolean, _sourceId: string, _favoriteLocked?: boolean) => undefined),
   setNodeFavoriteLocked: vi.fn((_nodeNum: number, _favoriteLocked: boolean, _sourceId: string) => undefined),
   setNodeHideFromMapAsync: vi.fn(async (_nodeNum: number, _hidden: boolean, _sourceId: string) => undefined),
+  setNodeHideFromMapAllSourcesAsync: vi.fn(async (_nodeNum: number, _hidden: boolean) => 2),
   setNodeNotesAsync: vi.fn(async (_nodeNum: number, _notes: string, _sourceId: string) => undefined),
   purgeAllNodes: vi.fn(),
   purgeAllTelemetry: vi.fn(),
@@ -236,11 +237,11 @@ describe('Server API Endpoints', () => {
       }
     });
 
-    // Mirrors apiRouter.post('/nodes/:nodeId/hide-from-map') validation contract (#3549)
+    // Mirrors apiRouter.post('/nodes/:nodeId/hide-from-map') validation contract (#3549, allSources added for #4137)
     app.post('/api/nodes/:nodeId/hide-from-map', async (req, res) => {
       try {
         const { nodeId } = req.params;
-        const { hideFromMap, sourceId } = req.body;
+        const { hideFromMap, sourceId, allSources } = req.body;
 
         if (typeof hideFromMap !== 'boolean') {
           res.status(400).json({ error: 'hideFromMap must be a boolean' });
@@ -259,7 +260,11 @@ describe('Server API Endpoints', () => {
         }
         const nodeNum = parseInt(nodeNumStr, 16);
 
-        await databaseMock.setNodeHideFromMapAsync(nodeNum, hideFromMap, sourceId);
+        if (allSources === true) {
+          await databaseMock.setNodeHideFromMapAllSourcesAsync(nodeNum, hideFromMap);
+        } else {
+          await databaseMock.setNodeHideFromMapAsync(nodeNum, hideFromMap, sourceId);
+        }
         res.json({ success: true, nodeNum, hideFromMap });
       } catch (error) {
         res.status(500).json({ error: 'Failed to set node hideFromMap' });
@@ -698,6 +703,37 @@ describe('Server API Endpoints', () => {
         .expect(400);
 
       expect(response.body.error).toBe('Invalid nodeId format');
+    });
+
+    it('POST /api/nodes/:nodeId/hide-from-map with allSources:true clears every source\'s row (#4137)', async () => {
+      const response = await request(app)
+        .post('/api/nodes/!00000001/hide-from-map')
+        .send({ hideFromMap: false, sourceId: 'default', allSources: true })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.hideFromMap).toBe(false);
+      expect(databaseMock.setNodeHideFromMapAllSourcesAsync).toHaveBeenCalledWith(1, false);
+      expect(databaseMock.setNodeHideFromMapAsync).not.toHaveBeenCalled();
+    });
+
+    it('POST /api/nodes/:nodeId/hide-from-map still requires sourceId even with allSources:true (#4137)', async () => {
+      const response = await request(app)
+        .post('/api/nodes/!00000001/hide-from-map')
+        .send({ hideFromMap: false, allSources: true })
+        .expect(400);
+
+      expect(response.body.error).toBe('sourceId is required');
+    });
+
+    it('POST /api/nodes/:nodeId/hide-from-map without allSources still targets a single source (#4137)', async () => {
+      const response = await request(app)
+        .post('/api/nodes/!00000001/hide-from-map')
+        .send({ hideFromMap: true, sourceId: 'default' })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(databaseMock.setNodeHideFromMapAsync).toHaveBeenCalledWith(1, true, 'default');
     });
 
     it('POST /api/nodes/:nodeId/notes should set the note (#3921)', async () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1811,7 +1811,7 @@ apiRouter.delete('/nodes/:nodeId/position-override', requirePermission('nodes', 
 apiRouter.post('/nodes/:nodeId/hide-from-map', requirePermission('nodes', 'write', { sourceIdFrom: 'body' }), async (req, res) => {
   try {
     const { nodeId } = req.params;
-    const { hideFromMap, sourceId: hfmSourceId } = req.body;
+    const { hideFromMap, sourceId: hfmSourceId, allSources } = req.body;
 
     if (typeof hideFromMap !== 'boolean') {
       const errorResponse: ApiErrorResponse = {
@@ -1849,7 +1849,17 @@ apiRouter.post('/nodes/:nodeId/hide-from-map', requirePermission('nodes', 'write
 
     const nodeNum = parseInt(nodeNumStr, 16);
 
-    await databaseService.setNodeHideFromMapAsync(nodeNum, hideFromMap, hfmSourceId);
+    // #4137: unified/cross-source views toggle the logical node, not one
+    // source's row. hideFromMap is map-visibility metadata (not a
+    // security-sensitive field), so requiring write permission on the
+    // request's anchor sourceId is a sufficient permission check even
+    // though the write fans out to every source's row for this nodeNum —
+    // sourceId above remains required and stays the RBAC anchor either way.
+    if (allSources === true) {
+      await databaseService.setNodeHideFromMapAllSourcesAsync(nodeNum, hideFromMap);
+    } else {
+      await databaseService.setNodeHideFromMapAsync(nodeNum, hideFromMap, hfmSourceId);
+    }
 
     res.json({
       success: true,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1823,6 +1823,20 @@ apiRouter.post('/nodes/:nodeId/hide-from-map', requirePermission('nodes', 'write
       return;
     }
 
+    // `allSources` is optional, but if present it must be a real boolean —
+    // otherwise a stray `"true"` string would silently fall through to the
+    // per-source path (the branch below tests `=== true`). Reject the
+    // ambiguity rather than guess.
+    if (allSources !== undefined && typeof allSources !== 'boolean') {
+      const errorResponse: ApiErrorResponse = {
+        error: 'allSources must be a boolean',
+        code: 'INVALID_PARAMETER_TYPE',
+        details: 'Expected boolean value for optional allSources parameter',
+      };
+      res.status(400).json(errorResponse);
+      return;
+    }
+
     if (typeof hfmSourceId !== 'string' || hfmSourceId.length === 0) {
       const errorResponse: ApiErrorResponse = {
         error: 'sourceId is required',

--- a/src/server/utils/mergeNodesAcrossSources.test.ts
+++ b/src/server/utils/mergeNodesAcrossSources.test.ts
@@ -101,6 +101,24 @@ describe('mergeNodesAcrossSources (issue #3135)', () => {
     expect(merged.isIgnored).toBe(true);
   });
 
+  it('ORs hideFromMap across sources (#4137): winner false + older true -> merged true', () => {
+    const rows: DbNode[] = [
+      makeNode(401, { hideFromMap: false, lastHeard: 2000 }),
+      makeNode(401, { hideFromMap: true, lastHeard: 1000 }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.hideFromMap).toBe(true);
+  });
+
+  it('#4137: hideFromMap stays false when every source has it false', () => {
+    const rows: DbNode[] = [
+      makeNode(402, { hideFromMap: false, lastHeard: 2000 }),
+      makeNode(402, { hideFromMap: false, lastHeard: 1000 }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.hideFromMap).toBe(false);
+  });
+
   it('exposes the max lastHeard / updatedAt across the group', () => {
     const rows: DbNode[] = [
       makeNode(500, { lastHeard: 5000, updatedAt: 5500 }),

--- a/src/server/utils/mergeNodesAcrossSources.ts
+++ b/src/server/utils/mergeNodesAcrossSources.ts
@@ -12,8 +12,9 @@
  *
  * The merge picks the newest row by `lastHeard` (then `updatedAt` as a
  * tiebreaker) and back-fills any empty fields from older rows. The two
- * user-intent booleans (`isFavorite`, `isIgnored`) are OR'd across sources
- * so a flag set in any source is honored in the unified view.
+ * user-intent booleans (`isFavorite`, `isIgnored`, `favoriteLocked`, and
+ * `hideFromMap`) are OR'd across sources so a flag set in any source is
+ * honored in the unified view.
  */
 import type { DbNode } from '../../db/types.js';
 

--- a/src/server/utils/mergeNodesAcrossSources.ts
+++ b/src/server/utils/mergeNodesAcrossSources.ts
@@ -57,6 +57,12 @@ export function mergeNodesAcrossSources(rows: DbNode[]): DbNode[] {
     winner.isFavorite = group.some((n) => n.isFavorite === true);
     winner.isIgnored = group.some((n) => n.isIgnored === true);
     winner.favoriteLocked = group.some((n) => n.favoriteLocked === true);
+    // #4137: hidden-anywhere -> hidden in the unified view (matches
+    // isFavorite/isIgnored semantics above), instead of winner-takes-all by
+    // lastHeard. This alone doesn't fully fix stale hides from a since-removed
+    // source's orphaned rows — see the all-sources toggle (setNodeHideFromMapAllSourcesAsync)
+    // and the source-delete cleanup (purgeAllNodesAsync + migration 122) for that.
+    winner.hideFromMap = group.some((n) => n.hideFromMap === true);
 
     const maxLastHeard = group.reduce(
       (max, n) => Math.max(max, n.lastHeard ?? 0),

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -5244,6 +5244,33 @@ class DatabaseService {
     logger.debug(`🗺️ Node ${nodeNum}@${sourceId} hideFromMap ${hidden ? 'enabled' : 'disabled'}`);
   }
 
+  /**
+   * Set `hideFromMap` across EVERY source's row for this nodeNum (issue #4137).
+   * Used when toggling map visibility from a unified/cross-source view, where
+   * "un-hide" needs to converge every source's row — not just the single
+   * winning row that mergeNodesAcrossSources happened to pick — or a stale
+   * `true` on another source keeps the node hidden in the unified view forever.
+   * Delegates to the Drizzle-based NodesRepository so it works identically
+   * across SQLite/PostgreSQL/MySQL (unlike the per-source method above, which
+   * still branches on backend for legacy reasons).
+   */
+  async setNodeHideFromMapAllSourcesAsync(nodeNum: number, hidden: boolean): Promise<number> {
+    if (!this.nodesRepo) {
+      throw new Error('Nodes repository not initialized');
+    }
+
+    const affected = await this.nodesRepo.setNodeHideFromMapAllSourcesAsync(nodeNum, hidden);
+
+    if (affected === 0) {
+      const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
+      logger.warn(`⚠️ Failed to update hideFromMap (all sources) for node ${nodeId} (${nodeNum}): node not found in database`);
+      throw new Error(`Node ${nodeId} not found`);
+    }
+
+    logger.debug(`🗺️ Node ${nodeNum} hideFromMap ${hidden ? 'enabled' : 'disabled'} across ${affected} source row(s) (#4137)`);
+    return affected;
+  }
+
   async handleAutoWelcomeEnabledAsync(): Promise<number> {
     const migrationKey = 'auto_welcome_first_enabled';
     const migrationCompleted = this.getSetting(migrationKey);


### PR DESCRIPTION
## Summary

Fixes #4137 — once a node was hidden from the map, users couldn't reliably un-hide it. Root cause is three compounding issues (all diagnosed in the issue thread); this PR addresses all of them.

### 1. Menu label collision (the reported symptom)
The node actions menu had **two** buttons that both read "Show on Map": the always-present pan-to-map action, and the hide/show toggle's un-hide label. Users clicked the pan button expecting to un-hide, and nothing happened. The pan action is renamed **"Center on Map" (🎯)** at both sites, so it can never be confused with the toggle.

### 2. Unified merge dropped `hideFromMap`
`mergeNodesAcrossSources` explicitly OR'd `isFavorite`/`isIgnored`/`favoriteLocked` across a node's per-source rows but let `hideFromMap` fall through winner-takes-all. It now ORs `hideFromMap` too (hidden-on-any-source → hidden in the unified view), consistent with the other flags.

### 3. Un-hide couldn't converge across sources
With the OR-merge, clearing only one source's row leaves the node hidden if any other source's row still has `hideFromMap: true`. The toggle endpoint (`POST /nodes/:id/hide-from-map`) gains an `allSources` mode, and the toggle UI uses it, so hide/show converges every source row for the node. `sourceId` remains required as the RBAC anchor (hide-state is map-visibility metadata, not security-sensitive).

**Behavior note for review:** the app's hide/show toggle only ever renders inside a per-source context (there is no unified caller), but because the merge now ORs across sources, a per-source-only write would strand the node hidden in Dashboard/Analysis. So the single toggle **always** sends `allSources: true` — i.e. hide/show is now a global per-node preference rather than per-source. This is the consistent choice given the OR-merge; flagging it explicitly in case per-source hiding was intended.

### 4. Orphaned rows from removed sources (the permanent stale-hide)
Deleting a source never cascaded to its `nodes` rows, so an orphaned row from a long-removed source kept leaking a stale `hideFromMap: true` into the unified merge forever, with no UI left to clear it. `DELETE /api/sources/:id` now best-effort purges the source's node data, and **migration 122** sweeps rows orphaned by prior deletions (nodes table; all three backends; idempotent).

### Tests / validation
New coverage: merge OR cases, `setNodeHideFromMapAllSourcesAsync` repo tests (convergence + per-nodeNum isolation), endpoint `allSources` + permission tests, source-delete purge test, migration 122 test. Full suite: **9,264 passed / 0 failed**; `tsc` clean; `lint:ci` OK; `build` succeeds.

Closes #4137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1
