### PR TITLE
fix(db): migration 122 illegal collation mix on MySQL 8

### DIFF
--- a/src/server/migrations/122_cleanup_orphaned_source_nodes.ts
+++ b/src/server/migrations/122_cleanup_orphaned_source_nodes.ts
@@ -27,8 +27,9 @@ import { logger } from '../../utils/logger.js';
 
 const LABEL = 'Migration 122';
 
-// SQLite / MySQL: bare identifiers (both dialects use camelCase `sourceId`
-// unquoted for the `nodes` table, matching every other nodes.* migration).
+// SQLite: bare identifiers (camelCase `sourceId` unquoted for the `nodes`
+// table, matching every other nodes.* migration). SQLite has no cross-column
+// collation conflict, so the simple `NOT IN` subquery is fine here.
 const DELETE_SQL = `DELETE FROM nodes
   WHERE sourceId IS NOT NULL
     AND sourceId NOT IN (SELECT id FROM sources)`;
@@ -69,7 +70,19 @@ export async function runMigration122Postgres(client: any): Promise<void> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mysql pool is untyped in the migration runner (matches all sibling migrations)
 export async function runMigration122Mysql(pool: any): Promise<void> {
   logger.info(`${LABEL} (MySQL): deleting orphaned node rows...`);
-  const [res] = await pool.query(DELETE_SQL);
+  // `nodes.sourceId` and `sources.id` can carry different collations on
+  // MySQL 8 (e.g. utf8mb4_unicode_ci vs the server-default utf8mb4_0900_ai_ci),
+  // so a plain `sourceId NOT IN (SELECT id FROM sources)` throws
+  // "Illegal mix of collations" on the implicit `=`. Use a LEFT JOIN anti-join
+  // and force BOTH sides of the join to a common explicit collation so the
+  // comparison is well-defined regardless of each column's declared collation.
+  const [res] = await pool.query(
+    `DELETE n FROM nodes n
+     LEFT JOIN sources s
+       ON n.sourceId COLLATE utf8mb4_general_ci = s.id COLLATE utf8mb4_general_ci
+     WHERE n.sourceId IS NOT NULL
+       AND s.id IS NULL`,
+  );
   const affected = (res as { affectedRows?: number } | undefined)?.affectedRows ?? 0;
   if (affected > 0) {
     logger.info(`${LABEL} (MySQL): deleted ${affected} orphaned node row(s)`);


### PR DESCRIPTION
## Summary

Migration 122 (`cleanup_orphaned_source_nodes`, merged in #4141) aborts on **MySQL 8**, blocking startup for MySQL deployments.

It shared a single `DELETE FROM nodes WHERE sourceId NOT IN (SELECT id FROM sources)` across all three backends. On MySQL 8, `nodes.sourceId` (`utf8mb4_unicode_ci`) and `sources.id` (server-default `utf8mb4_0900_ai_ci`) have different collations, so the implicit `=` in the `NOT IN` subquery throws:

```
Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT) for operation '='
```

**Why it slipped through:** this only reproduces on MySQL, and the MySQL migration run lives in the hardware **System Tests** suite, which doesn't execute on every PR — so #4141 merged with the bug latent. It surfaced on the 4.13.1-rc1 bump PR (which is system-test-labeled).

## Fix

Give the MySQL path its own anti-join DELETE with an explicit `COLLATE utf8mb4_general_ci` on **both** sides of the join condition, so the comparison is well-defined regardless of each column's declared collation:

```sql
DELETE n FROM nodes n
LEFT JOIN sources s
  ON n.sourceId COLLATE utf8mb4_general_ci = s.id COLLATE utf8mb4_general_ci
WHERE n.sourceId IS NOT NULL AND s.id IS NULL
```

SQLite and PostgreSQL paths are unchanged. Fixing the migration in place is safe: it never ran to completion on any MySQL instance (it errored, so it's unmarked), and it's only been on `main` a few hours in an RC — no tagged release shipped it.

## Validation

Against a real **MySQL 8** container, with the tables created in the mismatched collations that reproduce production:
- Old SQL → reproduces the exact `Illegal mix of collations` error.
- New SQL → runs clean, `affectedRows: 1`, deletes only the orphan and keeps the live-source node and the NULL-`sourceId` node.

Plus: `typecheck` clean, migration test suites 21/21, migration-file lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1