### PR TITLE
fix(startup): keep global schedulers alive on MeshCore-only installs (#4020)

### DIFF
--- a/src/server/bootstrapSources.test.ts
+++ b/src/server/bootstrapSources.test.ts
@@ -570,6 +570,29 @@ describe('bootstrapSources — startup pin-test matrix (WP1)', () => {
       }));
       expect(ensureMeshCoreManagerStarted).toHaveBeenCalledOnce();
     });
+
+    // #4020 regression: on a MeshCore-only install the S4 fallback connect has
+    // no real Meshtastic node to reach and rejects. Before the fix that
+    // rejection escaped bootstrapSources and aborted the startup try/catch in
+    // server.ts, so every scheduler started AFTER bootstrapSources (low-battery
+    // + inactive-node notifications, backup scheduler, ...) never started —
+    // which is why MeshCore-only users never got low-battery alerts and saw no
+    // `[low-battery]` diagnostics. bootstrapSources must swallow the failure
+    // and resolve so the caller keeps starting those schedulers.
+    it('(#4020) resolves (does NOT throw) when the S4 fallback connect rejects', async () => {
+      const row = makeMeshCoreSource('mc-1');
+      const db = makeDbStub([row]);
+      fallbackManager.connect.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      await expect(
+        bootstrapSources(makeDeps({
+          db, registry, fallbackManager: fallbackManager as any,
+          makeMeshtastic: meshFactory.factory,
+        })),
+      ).resolves.toBeUndefined();
+      // The MeshCore source still came up — startup was not aborted mid-way.
+      expect(ensureMeshCoreManagerStarted).toHaveBeenCalledOnce();
+      expect(fallbackManager.connect).toHaveBeenCalledOnce();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/server/bootstrapSources.ts
+++ b/src/server/bootstrapSources.ts
@@ -251,8 +251,28 @@ export async function bootstrapSources(deps: BootstrapDeps): Promise<void> {
     // with env-var config. This covers all-MeshCore, all-disabled-tcp, and
     // autoConnect:false installs. Disposition (open Q1): keep unless explicitly
     // decided to drop in WP3 (recommendation: keep, it's the behavior-preserving choice).
-    await deps.fallbackManager.connect();
-    logger.debug('Meshtastic manager connected (legacy mode, no sources configured)');
+    //
+    // #4020: this connect MUST NOT be allowed to reject out of bootstrapSources.
+    // On a MeshCore-only install there is no real Meshtastic node, so this
+    // fallback connect fails (ECONNREFUSED/timeout) and — before this guard —
+    // the rejection propagated all the way up to the startup try/catch in
+    // server.ts, aborting every scheduler started AFTER bootstrapSources
+    // (low-battery notifications, inactive-node notifications, backup scheduler,
+    // etc.). That is why MeshCore-only users never saw low-battery alerts fire
+    // and never got any `[low-battery]` diagnostics: the service was never
+    // started, so no code in it ran. The manager's own retry logic reconnects
+    // if a node ever appears, so swallow the initial failure — mirroring the
+    // per-source try/catch above ("don't let one failed source block others").
+    try {
+      await deps.fallbackManager.connect();
+      logger.debug('Meshtastic manager connected (legacy mode, no sources configured)');
+    } catch (err) {
+      logger.warn(
+        'Fallback Meshtastic connect failed (expected on MeshCore-only or node-down-at-boot installs); ' +
+          'continuing startup so global schedulers still start:',
+        err,
+      );
+    }
   } else {
     logger.debug(`Started ${enabledSources.length} source manager(s)`);
   }


### PR DESCRIPTION
## Summary
On a MeshCore-only deployment there is no real Meshtastic node, so the S4 env-IP fallback connect in `bootstrapSources()` rejects (ECONNREFUSED/timeout). That rejection was **unguarded**, so it escaped `bootstrapSources`, propagated to the single startup `try` in `server.ts`, and aborted every scheduler started *after* bootstrap — including the low-battery and inactive-node notification services, the backup scheduler, and the duplicate-key scanner.

This is the real reason issue #4020 has been reported **six times** and five prior low-battery fixes had no effect: `lowBatteryNotificationService.start()` was never called, so `checkLowBatteryNodes()` never ran and none of its diagnostics (including the #4035 hourly `[low-battery]` lines) could ever appear. Battery persistence and "server event"/"new node" apprise kept working because the MeshCore manager starts earlier in `bootstrapSources`, before the fatal fallback connect.

## Changes
- Wrap the S4 fallback `fallbackManager.connect()` in try/catch in `src/server/bootstrapSources.ts`, mirroring the per-source TCP-connect guard already above it ("don't let one failed source block others"). A failed initial connect is logged at WARN and startup continues; the manager's own retry logic reconnects if a node later appears.
- Add a Scenario 6 regression test in `bootstrapSources.test.ts` asserting `bootstrapSources` resolves (does not throw) when the fallback connect rejects, and that the MeshCore source still comes up.

## Issues Resolved
Fixes #4020 (and the root cause behind the #3417 → #3462 → #3671 → #3884 → #4035 chain).

## Documentation Updates
No documentation changes needed — internal startup-ordering fix with no user-facing config or API surface.

## Testing
- [x] `bootstrapSources` suite: 39 passed, 0 failed (`success: true` via JSON reporter)
- [x] New regression test verified to FAIL without the fix (`promise rejected "ECONNREFUSED" instead of resolving`) and pass with it
- [x] `tsc -p tsconfig.server.json --noEmit`: no errors
- [ ] Reviewer: confirm a MeshCore-only (no meshtastic_tcp source) install now logs `🔔 Starting low battery notification service` at boot and emits hourly `[low-battery]` diagnostics
- [ ] Reviewer: confirm existing Meshtastic-node deployments are unaffected (fallback path only runs when no TCP source is configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)