### PR TITLE
feat(map-analysis): terrain Link Profile tool with Fresnel zone + link budget (#4111 Phase 2)

### DIFF
--- a/docs/internal/dev-notes/LINK_PROFILE_TOOL_SPEC.md
+++ b/docs/internal/dev-notes/LINK_PROFILE_TOOL_SPEC.md
@@ -1,0 +1,413 @@
+# Link Profile Tool — Implementation Spec (Terrain Link Profile Epic #4111, Phase 2)
+
+**Branch:** `feature/link-profile-tool` (worktree `../meshmonitor-link-profile`, based on `origin/main` incl. Phase 1 elevation backend).
+**Scope:** Frontend only. Pure math utils, a two-point picker controller, a bottom drawer chart + link-budget panel, a toolbar button gated on `elevationEnabled`, an ApiService method, and tests. **No backend changes** — Phase 1's `POST /api/elevation/profile` is frozen and consumed as-is.
+
+**Exit criteria (from epic):** end-to-end in browser: pick two nodes → drawer shows terrain profile + Fresnel + budget verdict; matches site.meshtastic.org for a reference link; full Vitest suite green; `npm run lint:ci` exits 0; merged.
+
+---
+
+## 0. Key decisions (interview + design)
+
+1. **Elevation model = DEM terrain + antenna height AGL (site.meshtastic.org model).** The LOS baseline at each endpoint is `terrainElevation(endpoint) + antennaHeightAGL`, where `terrainElevation` is the Phase‑1 DEM sample at the endpoint. **Node GPS altitude is deliberately NOT used** for the LOS geometry. Rationale: node GPS altitude is frequently WGS‑84 ellipsoidal (or absent/noisy) while the DEM returns orthometric terrain height; mixing them injects tens of metres of datum error. Terrain + AGL is self-consistent, matches site.meshtastic.org, and is simpler. (Phase 3 may optionally surface node GPS altitude as an alternate baseline; out of scope here.)
+2. **Bottom drawer chart** (not a modal/side panel), rendered as an absolutely-positioned overlay inside `.map-analysis-canvas` so the map stays usable above it — mirrors how `TimeSliderControl` / `MapLegend` already sit over the canvas.
+3. **FULL link budget** readout: FSPL, RX power, margin, and a geometry verdict (clear / marginal / obstructed) shown together.
+4. **Picker UX:** click snaps to the nearest node when the click lands within a pixel threshold of one; otherwise the raw clicked map point becomes an arbitrary (non-node) endpoint. No modifier key required. Mirrors `MeasureDistanceController`'s capture-phase click interception exactly.
+5. **Recompute-without-refetch:** the elevation profile is geometry-only (depends solely on the two coordinates + sample count). Budget-input edits (frequency, heights, power, gains, cable loss, RX sensitivity, k-factor) recompute the analysis client-side from the already-fetched samples — no new elevation request. Frequency and antenna heights change the *analysis* (Fresnel radius, LOS baseline), not the elevation samples, so they also do **not** refetch.
+6. **Frequency default 915 MHz**, manual editable field. Phase 3 wires per-source auto-detection.
+7. **Documented default budget constants** (all editable in the drawer): antenna height 2 m AGL each end, TX power 20 dBm, TX/RX gain 2.15 dBi each, cable loss 0 dB, RX sensitivity −129 dBm (LongFast SF11/BW125), earth k-factor 4/3, sample count 256 (backend default).
+
+### Verified reference values (independently computed — use as test fixtures)
+
+| Quantity | Formula | Inputs | Value |
+|---|---|---|---|
+| FSPL | `20log10(d_km)+20log10(f_MHz)+32.44` | 33.3 km, 915 MHz | **122.117 dB** |
+| FSPL | same | 1 km, 100 MHz | **72.440 dB** (clean: 0+40+32.44) |
+| FSPL | same | 10 km, 915 MHz | 111.668 dB |
+| Wavelength | `c/f` | 915 MHz | **0.32764 m** |
+| Fresnel r₁ (midpoint) | `sqrt(λ·d1·d2/(d1+d2))`, d1=d2=D/2 = `0.5·sqrt(λD)` | 10 km link, 915 MHz | **28.620 m** |
+| Fresnel r₁ | general | d1=3000, d2=7000, 915 MHz | 26.231 m |
+| Earth bulge (mid) | `d1·d2/(2·k·R)`, R=6371000 | 33.3 km, k=4/3 | 16.317 m |
+| Earth bulge (mid) | same, k=1 | 33.3 km | 21.757 m |
+| RX power | `Ptx+Gtx+Grx−Lcable−FSPL` | 20+2.15+2.15−0−122.117 | **−97.817 dBm** |
+| Margin | `Prx−RXsens` | −97.817 − (−129) | **+31.183 dB** |
+
+---
+
+## 1. Reuse inventory (verified against the tree)
+
+| What | Where | Reuse |
+|---|---|---|
+| Two-point picker UX (capture-phase click, snap-to-nearest, Escape-to-exit, CircleMarker/Polyline render) | `src/components/MeasureDistanceController.tsx` (click handler L68–91; render L107–133) | **Clone the structure** into `LinkProfileController`. Same `map.getContainer()` capture listener, `.leaflet-control` guard, `map.mouseEventToLatLng(e)`. |
+| Pure picker geometry, `MeasurePoint`, `nearestPoint` | `src/utils/measureDistance.ts` (`MeasurePoint` L20‑25, `nearestPoint` L31‑46) | **Reuse `nearestPoint`**; extend `MeasurePoint` for `LinkEndpoint`. |
+| Great-circle + LatLng (Phase‑1, **already shared/react-free in `src/utils/`**) | `src/utils/greatCircle.ts` (`LatLng` L14‑17, `interpolateGreatCircle`) | **Reuse `LatLng`** for endpoint coords; server already samples the great circle, so the client does not re-interpolate. |
+| Haversine distance | `src/utils/distance.ts` (`calculateDistance`) | Reuse for pixel-vs-node snap fallback and any km math. |
+| recharts `ComposedChart` composition (Area + Line + XAxis/YAxis/Tooltip/CartesianGrid/ResponsiveContainer) | `src/components/TelemetryChart.tsx` (imports L18; chart L~330+) | **Mirror** for the profile chart; add `ReferenceDot`/`ReferenceLine` from recharts (same package). |
+| Toolbar tool-button + transient mode state | `MapAnalysisToolbar.tsx` "Measure" button (`disabled={analysisNodes.length < 2}`, active class); `MapAnalysisContext.tsx` `measureMode`/`setMeasureMode` | **Clone** the button + a `linkProfileMode` context slice. |
+| Canvas controller + overlay wiring | `MapAnalysisCanvas.tsx`: `{measureMode && <MeasureDistanceController .../>}` inside `<BaseMap>` (L~150); `TimeSliderControl`/`MapLegend` siblings after `</BaseMap>` inside `.map-analysis-canvas` (`position: relative`) | **Clone**: controller inside `<BaseMap>`, drawer as a post-`BaseMap` sibling. |
+| Shared positioned-node list (drives markers + measure points) | `useAnalysisNodes()` → `AnalysisNode { node, latLng:[lat,lng], key }` (`src/components/MapAnalysis/useAnalysisNodes.ts`); mapped to `MeasurePoint[]` in `MapAnalysisCanvas.tsx` L60‑68 | **Reuse the same memo** to build `LinkEndpoint[]` candidates. |
+| ApiService request/get/post (raw JSON body, **does not unwrap `data`**) | `src/services/api.ts` (`request`/`get`/`post`, `ApiError`) | **Add `getElevationProfile`**; it must unwrap `.data` from the `{success,data}` envelope. |
+| Elevation route (frozen) | `POST /api/elevation/profile` — body `{ pointA:{lat,lng}, pointB:{lat,lng}, samples? }`; envelope `ok(res,{ distanceMeters, provider, samples:[{distance,lat,lng,elevation}] })`; codes `ELEVATION_DISABLED`(403)/`INVALID_BODY`(400) | Consume as-is. **CSRF:** apiRouter applies `csrfProtection` to all POST `/api/*` (`server.ts` L5847/5849); `csrfTokenMiddleware` issues a token to every session incl. anonymous, and `ApiService.post` attaches `X-CSRF-Token`. Anonymous POST works — no backend change needed. |
+| Availability flag source | `GET /api/settings` returns a **bare settings map** (not enveloped — `SettingsContext` reads `settings.maxNodeAgeHours` directly, L1199‑1205). `elevationEnabled` is non-secret and present. | **New `useElevationEnabled` TanStack hook** reads it; do **not** touch the giant `SettingsContext` handleSave dep-array. |
+| TanStack Query is the established data-fetch pattern | `src/hooks/useMapAnalysisData.ts`, `src/hooks/useDashboardData.ts` | New hooks use `useQuery` + `ApiService`. |
+| Node position resolution + `altitude` availability | `nodePositionUtil.ts` `resolveNodeLatLng` (lat/lng only); `src/types/device.ts` has `altitude?` (L14/L141/L167) | Confirms altitude *exists* but per decision #1 we **do not** consume it. |
+| Picker/controller test harness (mock react-leaflet, synthetic capture-phase click) | `src/components/MeasureDistanceController.test.tsx` | **Clone** for `LinkProfileController.test.tsx`. |
+| Leaflet-label CSS pattern | `src/components/MeasureDistanceController.css` | Clone for the controller's endpoint label. |
+| Page stylesheet convention | `src/styles/map-analysis.css` (`.map-analysis-canvas` L21, `.map-analysis-layer-btn` L105) | Append drawer + button styles here (page convention); tiny leaflet-label CSS in a dedicated `LinkProfileController.css`. |
+
+**Greenfield:** no Fresnel/link-budget/FSPL/obstruction code exists anywhere. All math is new.
+
+---
+
+## 2. File-by-file changes
+
+### NEW pure utils (react-free, unit-tested)
+
+#### 2.1 `src/utils/linkBudget.ts` — scalar radio math
+```ts
+export const SPEED_OF_LIGHT_MPS = 299_792_458;
+export const EARTH_RADIUS_M = 6_371_000;
+export const DEFAULT_K_FACTOR = 4 / 3;
+
+/** Wavelength in metres for a frequency in MHz. */
+export function wavelengthMeters(freqMhz: number): number;
+
+/**
+ * nth Fresnel-zone radius (metres) at a point d1/d2 metres from each endpoint.
+ * r = sqrt(n · λ · d1 · d2 / (d1 + d2)). Returns 0 when d1 or d2 is 0 (endpoints).
+ */
+export function fresnelRadiusMeters(n: number, freqMhz: number, d1M: number, d2M: number): number;
+
+/** Free-space path loss (dB): 20log10(d_km) + 20log10(f_MHz) + 32.44. */
+export function fsplDb(distanceKm: number, freqMhz: number): number;
+
+/** Earth-curvature bulge (metres): d1·d2 / (2·k·R). k default 4/3. */
+export function earthBulgeMeters(d1M: number, d2M: number, kFactor?: number, earthRadiusM?: number): number;
+
+export interface LinkBudgetInputs {
+  txPowerDbm: number;
+  txGainDbi: number;
+  rxGainDbi: number;
+  cableLossDb: number;      // total, both ends
+  rxSensitivityDbm: number; // negative
+}
+export interface LinkBudgetResult {
+  fsplDb: number;
+  rxPowerDbm: number;       // txPower + txGain + rxGain − cableLoss − FSPL
+  marginDb: number;         // rxPower − rxSensitivity  (rxSensitivity is negative)
+}
+/** Combine FSPL (from distance+freq) with the budget inputs. Sign conventions above. */
+export function computeLinkBudget(distanceKm: number, freqMhz: number, inputs: LinkBudgetInputs): LinkBudgetResult;
+```
+**Sign conventions (documented in JSDoc):** gains/power add, cable loss and FSPL subtract, `marginDb = rxPowerDbm − rxSensitivityDbm`. Because `rxSensitivityDbm` is negative, subtracting it increases margin (equivalent to `…− FSPL − rxSensitivity` when the latter is written with its sign). Positive margin ⇒ link closes.
+
+#### 2.2 `src/utils/linkProfile.ts` — obstruction analysis (chart-ready)
+```ts
+import type { LatLng } from './greatCircle';
+import type { MeasurePoint } from './measureDistance';
+import { fresnelRadiusMeters, earthBulgeMeters, fsplDb, computeLinkBudget, type LinkBudgetInputs, type LinkBudgetResult, DEFAULT_K_FACTOR, EARTH_RADIUS_M } from './linkBudget';
+
+/** A picked endpoint. `isNode=false` ⇒ arbitrary map point. */
+export interface LinkEndpoint extends MeasurePoint { isNode: boolean; }
+
+/** One elevation sample from the backend profile (client mirror of server ProfileSample). */
+export interface ElevationSample { distance: number; lat: number; lng: number; elevation: number | null; }
+
+export type LinkVerdict = 'clear' | 'marginal' | 'obstructed';
+
+export interface LinkProfileOptions {
+  freqMhz: number;
+  antennaHeightAglAM: number;   // AGL metres at endpoint A
+  antennaHeightAglBM: number;   // AGL metres at endpoint B
+  kFactor?: number;             // default 4/3
+  earthRadiusM?: number;        // default 6_371_000
+  fresnelClearThreshold?: number; // default 0.6 (60% of first Fresnel)
+}
+
+/** Per-sample plot row (all elevations in metres, distance in km for the X axis). */
+export interface LinkProfilePoint {
+  distanceKm: number;
+  terrain: number | null;          // raw DEM elevation
+  effectiveTerrain: number | null; // terrain + curvature bulge (what LOS is judged against)
+  los: number;                     // straight line between antenna tops
+  fresnelLower: number;            // los − first-Fresnel radius
+  obstructed: boolean;             // effectiveTerrain > los at this sample
+}
+
+export interface LinkProfileAnalysis {
+  points: LinkProfilePoint[];
+  totalDistanceKm: number;
+  verdict: LinkVerdict;
+  /** Tightest interior sample (min clearance ratio). null if no usable interior samples. */
+  worst: { distanceKm: number; clearanceM: number; clearanceRatio: number } | null;
+  /** min(clearance / fresnelRadius) across interior samples, as a percent (may be negative). */
+  fresnelClearancePct: number;
+  antennaTopAM: number; // ground(A) + AGL
+  antennaTopBM: number;
+}
+
+/**
+ * Pure geometry/obstruction analysis. Antenna tops = terrain at each endpoint + AGL
+ * (node GPS altitude intentionally ignored — see spec §0.1). Curvature raises terrain
+ * toward the straight LOS chord (effectiveTerrain = terrain + bulge). Endpoints and
+ * null-elevation samples are excluded from worst-case classification.
+ *
+ * Classification (first match wins):
+ *   obstructed  — some interior effectiveTerrain > los  (clearance < 0)
+ *   marginal    — LOS clear but min(clearance/fresnelR) < threshold (default 0.6)
+ *   clear       — min(clearance/fresnelR) ≥ threshold
+ */
+export function analyzeLinkProfile(samples: ElevationSample[], opts: LinkProfileOptions): LinkProfileAnalysis;
+```
+**Math details for the implementer** (all lengths in metres unless noted):
+- `total = samples[last].distance`; `d1 = samples[i].distance`, `d2 = total − d1`.
+- `groundA = samples[0].elevation ?? 0`, `groundB = samples[last].elevation ?? 0`; `antennaTopA/B = ground + AGL`.
+- `los[i] = antennaTopA + (antennaTopB − antennaTopA) · (d1/total)`.
+- `bulge[i] = earthBulgeMeters(d1, d2, k)` (0 at endpoints).
+- `effectiveTerrain[i] = terrain[i] + bulge[i]` (null when `terrain[i]` null).
+- `fresnelR[i] = fresnelRadiusMeters(1, freq, d1, d2)`; `fresnelLower[i] = los[i] − fresnelR[i]`.
+- `clearance[i] = los[i] − effectiveTerrain[i]`; `ratio[i] = fresnelR[i] > 0 ? clearance/fresnelR : +Infinity`.
+- Worst = interior, non-null sample minimising `ratio`. `fresnelClearancePct = min ratio · 100`.
+- Guard divide-by-zero at endpoints (fresnelR=0) and the whole-null profile (worst=null, verdict `'clear'`, but the drawer surfaces a "no terrain data" note).
+
+### NEW types + API client
+
+#### 2.3 `src/types/elevation.ts` — client mirror of the backend envelope payload
+```ts
+export interface ElevationSample { distance: number; lat: number; lng: number; elevation: number | null; }
+export interface ElevationProfile { distanceMeters: number; provider: string; samples: ElevationSample[]; }
+```
+(Keep `ElevationSample` defined once — `linkProfile.ts` imports it from here rather than redefining. Adjust §2.2 import accordingly.)
+
+#### 2.4 `src/services/api.ts` — add method (EDIT)
+```ts
+/**
+ * Terrain elevation profile between two coords (#4111). POST is CSRF-guarded;
+ * ApiService.post attaches the token. Unwraps the { success, data } envelope —
+ * request() returns the raw body, so read .data here (matches the MQTT-monitor
+ * unwrap gotcha in CLAUDE.md).
+ */
+async getElevationProfile(
+  pointA: { lat: number; lng: number },
+  pointB: { lat: number; lng: number },
+  samples?: number,
+): Promise<ElevationProfile> {
+  const res = await this.post<{ success: boolean; data: ElevationProfile }>(
+    '/api/elevation/profile',
+    samples != null ? { pointA, pointB, samples } : { pointA, pointB },
+  );
+  return res.data;
+}
+```
+Import `ElevationProfile` from `../types/elevation`. On `ApiError` with `code === 'ELEVATION_DISABLED'` the caller (hook) treats it as "feature off"; other errors surface a generic message.
+
+### NEW hooks
+
+#### 2.5 `src/hooks/useElevationEnabled.ts`
+```ts
+import { useQuery } from '@tanstack/react-query';
+import apiService from '../services/api';
+/** True unless the server explicitly set elevationEnabled='false'. Anonymous-readable. */
+export function useElevationEnabled(): boolean {
+  const { data } = useQuery({
+    queryKey: ['settings', 'elevationEnabled'],
+    queryFn: () => apiService.get<{ elevationEnabled?: string }>('/api/settings'),
+    staleTime: 5 * 60_000,
+  });
+  return data?.elevationEnabled !== 'false';
+}
+```
+(Confirm the singleton export name/shape of `ApiService` in `src/services/api.ts` and match it; if it exports a class instance under a different identifier, use that.)
+
+#### 2.6 `src/hooks/useElevationProfile.ts`
+```ts
+import { useQuery } from '@tanstack/react-query';
+import apiService from '../services/api';
+import type { LinkEndpoint } from '../utils/linkProfile';
+import type { ElevationProfile } from '../types/elevation';
+
+/**
+ * Fetch the elevation profile for a full endpoint pair. Keyed on rounded coords
+ * so budget-input edits never refetch (geometry-only). Disabled until both set.
+ * samples defaults to backend DEFAULT_SAMPLES (256) — omit from the body.
+ */
+export function useElevationProfile(a: LinkEndpoint | undefined, b: LinkEndpoint | undefined) {
+  const enabled = !!a && !!b;
+  return useQuery<ElevationProfile>({
+    queryKey: ['elevation-profile',
+      a ? [round(a.lat), round(a.lng)] : null,
+      b ? [round(b.lat), round(b.lng)] : null],
+    queryFn: () => apiService.getElevationProfile(
+      { lat: a!.lat, lng: a!.lng }, { lat: b!.lat, lng: b!.lng }),
+    enabled,
+    staleTime: 30 * 60_000, // terrain is static
+  });
+}
+// round to ~6 dp so identical picks share cache
+```
+
+### NEW components
+
+#### 2.7 `src/components/MapAnalysis/LinkProfileController.tsx` (prop-driven, like MeasureDistanceController)
+```ts
+export interface LinkProfileControllerProps {
+  active: boolean;
+  /** Candidate node endpoints (from useAnalysisNodes → LinkEndpoint w/ isNode:true). */
+  points: LinkEndpoint[];
+  endpoints: LinkEndpoint[];               // 0..2, from context
+  onPick: (next: LinkEndpoint[]) => void;  // controller pushes the new endpoint array
+  onExit?: () => void;
+}
+```
+Behaviour (clone MeasureDistanceController):
+- Capture-phase `click` on `map.getContainer()`, guard `.leaflet-control`, `stopPropagation`/`preventDefault`, `map.mouseEventToLatLng(e)`.
+- **Snap decision:** nearest node = `nearestPoint(points, lat, lng)`; if it exists and its screen distance `map.latLngToContainerPoint(nearest) → e.clientX/Y` is `< SNAP_PX` (24), use it as `{ ...nearest, isNode:true }`; else `{ id:'pt-<lat>,<lng>', lat, lng, isNode:false }`.
+- Pick sequence identical: 0 → [A]; 1 → [A,B] (ignore re-pick of same node id as A); 2 → restart from [new A]. Emit via `onPick`.
+- Render `CircleMarker` for each endpoint (node = filled, arbitrary = hollow), a **solid** `Polyline` between A and B in a distinct colour (amber `#f59e0b`) with a permanent `Tooltip` showing straight-line distance (`measureLabel` reuse) so it's visually different from the Measure tool's dashed cyan line.
+- Escape → `onPick([])` + `onExit?.()`. `enabled = active && points.length >= 0` (arbitrary points allowed even with 0 nodes, but the toolbar still gates on ≥2 positioned nodes for parity — see §2.10).
+- Tiny CSS: `src/components/MapAnalysis/LinkProfileController.css` (clone `.measure-distance-label` → `.link-profile-label`, amber border).
+
+#### 2.8 `src/components/MapAnalysis/LinkProfileDrawer.tsx` — bottom drawer
+- Reads `linkEndpoints` from `useMapAnalysisCtx()`. Returns `null` when `linkProfileMode` is off **and** no endpoints.
+- `const { data: profile, isLoading, error } = useElevationProfile(a, b)`.
+- **Local budget-input state** (`useState`) seeded from documented defaults (§0.7): `freqMhz`, `aglA`, `aglB`, `txPowerDbm`, `txGainDbi`, `rxGainDbi`, `cableLossDb`, `rxSensitivityDbm`, `kFactor`.
+- `const analysis = useMemo(() => profile ? analyzeLinkProfile(profile.samples, { freqMhz, antennaHeightAglAM:aglA, antennaHeightAglBM:aglB, kFactor }) : null, [profile, freqMhz, aglA, aglB, kFactor])` — recompute on input change, **no refetch**.
+- `const budget = useMemo(() => analysis ? computeLinkBudget(analysis.totalDistanceKm, freqMhz, { txPowerDbm, txGainDbi, rxGainDbi, cableLossDb, rxSensitivityDbm }) : null, [...])`.
+- **Layout:** flex row — left = `<ResponsiveContainer>` chart; right = stats readout + collapsible budget-input form.
+- **Chart (`ComposedChart`, mirror TelemetryChart):**
+  - data = `analysis.points`; `XAxis dataKey="distanceKm" type="number"` (km); `YAxis` metres.
+  - `<Area dataKey="effectiveTerrain">` filled (brown `#8d6e63`), `connectNulls={false}` so DEM voids show as gaps.
+  - `<Line dataKey="los">` (green `#22c55e`, dashed when `verdict==='obstructed'`).
+  - `<Line dataKey="fresnelLower">` (orange `#f59e0b`), the 1st-Fresnel lower bound.
+  - Obstruction highlight: `<ReferenceDot>` at `analysis.worst` (red when obstructed/marginal) + optional `<ReferenceLine x={worst.distanceKm}>`. (`ReferenceDot`/`ReferenceLine` from `recharts`.)
+  - `Tooltip` formats terrain/LOS/Fresnel at the hovered distance.
+- **Stats readout:** distance (km/mi via `useSettings().distanceUnit`), frequency, FSPL (dB), RX power (dBm), margin (dB, colour-coded ≥0 green / <0 red), Fresnel clearance %, and a **verdict pill**: `Clear` / `Marginal` / `Obstructed` (green/amber/red) — combined line e.g. `Clear · +31.2 dB margin`. When `profile` all-null: "No terrain data for this path".
+- **Budget-input form:** number inputs for every field above, each `onChange` updating local state (recompute only). Frequency default 915. Loading → skeleton/spinner; `error` (non-`ELEVATION_DISABLED`) → inline message.
+- **Close/clear:** an ✕ button calls `setLinkProfileMode(false)` + `setLinkEndpoints([])`. Re-picking a new pair while open updates in place.
+- Uses `ApiService` via the hook — **no raw `fetch`** in the component (ESLint ratchet).
+
+### EDIT — context / canvas / toolbar
+
+#### 2.9 `src/components/MapAnalysis/MapAnalysisContext.tsx` (EDIT)
+Add to `CtxShape` + provider (transient, not persisted — mirror `measureMode`):
+```ts
+/** Link Profile tool active (#4111 Phase 2); transient. Mutually exclusive with measureMode. */
+linkProfileMode: boolean;
+setLinkProfileMode: (m: boolean) => void;
+/** Picked endpoints (0..2) for the Link Profile tool; transient. */
+linkEndpoints: LinkEndpoint[];
+setLinkEndpoints: (e: LinkEndpoint[]) => void;
+```
+`import type { LinkEndpoint } from '../../utils/linkProfile';` + two `useState`s.
+
+#### 2.10 `src/components/MapAnalysis/MapAnalysisToolbar.tsx` (EDIT)
+- `const elevationEnabled = useElevationEnabled();`
+- Pull `linkProfileMode, setLinkProfileMode, measureMode, setMeasureMode` from ctx.
+- Add a "Link Profile" button beside "Measure":
+  - **Hidden** when `!elevationEnabled` (`{elevationEnabled && (<button .../>) }`).
+  - `disabled={analysisNodes.length < 2}` with the same title-hint pattern as Measure.
+  - `className={... linkProfileMode ? 'active' : ''}`.
+  - onClick toggles `linkProfileMode`; when turning it **on**, also `setMeasureMode(false)` (mutually exclusive). Symmetrically, the Measure onClick sets `setLinkProfileMode(false)`.
+
+#### 2.11 `src/components/MapAnalysis/MapAnalysisCanvas.tsx` (EDIT)
+- Build `linkEndpointCandidates: LinkEndpoint[]` from the same `analysisNodes` memo (add `isNode:true`); reuse or extend the existing `measurePoints` memo.
+- Inside `<BaseMap>`, after the measure controller:
+```tsx
+{linkProfileMode && (
+  <LinkProfileController
+    active={linkProfileMode}
+    points={linkEndpointCandidates}
+    endpoints={linkEndpoints}
+    onPick={setLinkEndpoints}
+    onExit={() => setLinkProfileMode(false)}
+  />
+)}
+```
+- After `</BaseMap>` (sibling of `TimeSliderControl`/`MapLegend`, inside `.map-analysis-canvas`):
+```tsx
+<LinkProfileDrawer />
+```
+- Pull `linkProfileMode, setLinkProfileMode, linkEndpoints, setLinkEndpoints` from ctx.
+
+#### 2.12 `src/styles/map-analysis.css` (EDIT — append)
+- `.map-analysis-link-drawer`: `position:absolute; left:0; right:0; bottom:0; height:min(42vh,340px); z-index:1000;` (above leaflet panes, matching how the legend/time-slider float; verify it clears the attribution control) `background:#0f172a; border-top:1px solid #334155; display:flex; overflow:hidden;`. Chart pane `flex:1; min-width:0;`; stats/inputs pane fixed width (`~300px`) with `overflow-y:auto`.
+- Verdict pill classes `.link-verdict-clear|marginal|obstructed` (green/amber/red). Number-input grid for the budget form. Follow this page's dark palette; **do not** put mobile overrides in an earlier `@media` block (the nodes.css cascade-order gotcha does not apply to map-analysis.css, but keep base rules before any media query for safety).
+
+---
+
+## 3. Test plan
+
+All Vitest; jsdom for component tests. No standalone scripts.
+
+#### 3.1 `src/utils/linkBudget.test.ts`
+- `wavelengthMeters(915)` ≈ 0.32764 (±1e-4).
+- `fsplDb(33.3, 915)` ≈ 122.117 (±0.01); `fsplDb(1, 100)` ≈ 72.440; `fsplDb(10, 915)` ≈ 111.668.
+- `fresnelRadiusMeters(1, 915, 5000, 5000)` ≈ 28.620; `(1,915,3000,7000)` ≈ 26.231; endpoint `(1,915,0,10000)` === 0.
+- `earthBulgeMeters(16650,16650)` ≈ 16.317 (k=4/3 default); with `k=1` ≈ 21.757; endpoint (d2=0) === 0.
+- `computeLinkBudget(33.3, 915, {txPowerDbm:20,txGainDbi:2.15,rxGainDbi:2.15,cableLossDb:0,rxSensitivityDbm:-129})` → `rxPowerDbm` ≈ −97.817, `marginDb` ≈ +31.183, `fsplDb` ≈ 122.117.
+- Sign checks: raising cable loss lowers margin; raising RX sensitivity toward 0 lowers margin.
+
+#### 3.2 `src/utils/linkProfile.test.ts`
+- **Clear:** flat terrain well below LOS, tall masts → `verdict:'clear'`, `fresnelClearancePct ≥ 60`, `worst` set to the tightest interior sample.
+- **Marginal:** terrain that stays below LOS everywhere but pokes into the Fresnel zone at one sample → `verdict:'marginal'` (clearance ≥ 0 but ratio < 0.6).
+- **Obstructed:** a mid-path hill above LOS → `verdict:'obstructed'`, `worst.clearanceM < 0`.
+- **AGL applied at endpoints:** raising `antennaHeightAglAM/BM` lifts `los` and flips an obstructed case to clear.
+- **Curvature applied:** with a long path, non-zero `earthBulgeMeters` raises `effectiveTerrain` vs raw terrain; asserting a mid-path point's `effectiveTerrain > terrain` and that a larger k lowers the bulge.
+- **Null handling:** samples with `elevation:null` are excluded from `worst`/verdict; all-null → `worst:null`, no throw.
+- `points` length === input length; `distanceKm` monotonic; `totalDistanceKm` matches last sample.
+
+#### 3.3 `src/components/MapAnalysis/LinkProfileController.test.tsx` (clone MeasureDistanceController.test.tsx)
+- Mock `react-leaflet` (`useMap` with `getContainer`/`mouseEventToLatLng`/`latLngToContainerPoint`), `CircleMarker`/`Polyline`/`Tooltip` as test doubles.
+- Inactive / <픽 renders nothing.
+- Click near a node (within SNAP_PX) → endpoint `isNode:true` with that node's coords; click far from any node → `isNode:false` raw point.
+- A→B sequence emits `[A]` then `[A,B]`; third click restarts to `[newA]`; re-pick same node as A is ignored.
+- Escape emits `onPick([])` + `onExit`.
+
+#### 3.4 `src/components/MapAnalysis/LinkProfileDrawer.test.tsx`
+- `vi.mock('../../hooks/useElevationProfile', ...)` returning a canned `ElevationProfile` (obstructed fixture) + `useSettings` for `distanceUnit`; mock `recharts` primitives to simple divs (as Telemetry/Measure tests do) so assertions target stats, not SVG.
+- Renders verdict pill text (`Obstructed`), FSPL, RX power, margin (sign-coloured), distance in the user's unit.
+- Changing a budget input (e.g. RX sensitivity) updates margin **without** a new `useElevationProfile` call (assert the mocked query fn call count is unchanged).
+- `isLoading` → spinner; all-null profile → "No terrain data" copy.
+
+#### 3.5 `src/hooks/useElevationEnabled.test.tsx` (light)
+- With a mocked `ApiService.get` returning `{elevationEnabled:'false'}` → hook false; `{}`/`{elevationEnabled:'true'}`/undefined → true. Wrap in a `QueryClientProvider`.
+
+#### 3.6 Toolbar gate (extend existing MapAnalysisToolbar test or add one)
+- `elevationEnabled=false` → no "Link Profile" button. `true` + `<2` nodes → button present but `disabled`. `true` + ≥2 → enabled; clicking sets `linkProfileMode` and clears `measureMode`.
+
+**Final gate:** full `npx vitest run` (not targeted) + `npm run lint:ci` exit 0 before PR (CLAUDE.md). No new `any`, no raw `fetch()` in `src/components/**`/`src/pages/**`, respect `react-hooks/exhaustive-deps` (no auto-fix suppressions — write correct dep arrays).
+
+---
+
+## 4. Work packages
+
+Dependency graph: **WP-A** and **WP-C** are parallel (no shared files); **WP-B** depends on WP-A (needs the math API); **WP-D** integrates everything and depends on A+B+C.
+
+### WP-A — Pure math + types + API client *(no deps; start immediately)*
+**Files:** `src/utils/linkBudget.ts`, `src/utils/linkProfile.ts`, `src/types/elevation.ts`, edit `src/services/api.ts` (add `getElevationProfile`), `src/hooks/useElevationProfile.ts`, `src/hooks/useElevationEnabled.ts`; tests `linkBudget.test.ts`, `linkProfile.test.ts`, `useElevationEnabled.test.tsx`.
+**Acceptance:** every §3.1/§3.2/§3.5 case passes against the verified reference values; `getElevationProfile` unwraps `.data`; hooks typed with no `any`; `npm run lint:ci` clean for touched files. Pure utils import nothing from React/leaflet.
+
+### WP-B — Drawer + chart + budget panel *(depends WP-A)*
+**Files:** `src/components/MapAnalysis/LinkProfileDrawer.tsx`, drawer styles appended to `src/styles/map-analysis.css`; test `LinkProfileDrawer.test.tsx`.
+**Acceptance:** renders a ComposedChart (terrain Area + LOS Line + Fresnel Line + worst-point marker) and a full stats readout + budget form from a mocked profile; budget edits recompute via `useMemo` with **zero** extra elevation fetches (§3.4); verdict/margin colour logic correct; no raw `fetch`; drawer overlays without breaking the map (manual note for WP-D browser check).
+
+### WP-C — Controller + context slice + toolbar button *(parallel with WP-A/WP-B; controller math-independent)*
+**Files:** `src/components/MapAnalysis/LinkProfileController.tsx` + `LinkProfileController.css`, edit `MapAnalysisContext.tsx` (context slice), edit `MapAnalysisToolbar.tsx` (button + gate); test `LinkProfileController.test.tsx` (+ toolbar gate §3.6).
+**Note:** WP-C imports the `LinkEndpoint` type from `src/utils/linkProfile.ts` (WP-A). If truly parallel, WP-A should land the type first, or WP-C defines `LinkEndpoint` in a tiny `src/utils/linkProfileTypes.ts` merged by WP-A. Prefer: WP-A publishes the type early.
+**Acceptance:** §3.3 + §3.6 pass; snap-vs-raw threshold works; mutual exclusion with Measure; button hidden when `elevationEnabled===false`, disabled with <2 nodes.
+
+### WP-D — Canvas integration + browser validation *(sequential; depends A+B+C)*
+**Files:** edit `MapAnalysisCanvas.tsx` (wire controller inside `<BaseMap>`, drawer sibling, build `LinkEndpoint` candidates from `useAnalysisNodes`).
+**Acceptance:** end-to-end in the dev container — toggle Link Profile, pick two nodes → drawer opens, fetches once, shows terrain + LOS + Fresnel + verdict + margin; pick an arbitrary map point as one endpoint; edit frequency/heights and watch the analysis recompute with no network call; compare a reference link (e.g. the issue's ~33.3 km @ 915 MHz) against site.meshtastic.org and confirm FSPL/verdict agree; Escape and ✕ both clear; map remains pannable above the drawer. **Final gate:** full Vitest suite + `npm run lint:ci` green, then PR.
+
+---
+
+## 5. Invariants honoured / non-goals
+
+- **No backend changes** — Phase‑1 route/envelope consumed as-is; CSRF handled by existing `ApiService.post` token flow.
+- **No raw `fetch()`** in components/pages — all IO via `ApiService` + TanStack hooks.
+- **No `any`; TS strict; exhaustive-deps** honoured with correct arrays (no suppressions).
+- **Transient state only** — `linkProfileMode`/`linkEndpoints` are not persisted, mirroring `measureMode`; no settings writes, no migration.
+- **Node GPS altitude intentionally unused** (§0.1) — documented so a reviewer doesn't flag the missing consumption of `device.altitude`.
+- **Per-source N/A** — elevation/link-profile is source-agnostic geometry (same rationale as the Phase‑1 elevation exception); no `sourceId`.
+- **Phase 3 (out of scope):** per-source frequency auto-detection, RX-sensitivity preset dropdown, map path colouring by obstruction, missing-DEM/antimeridian edge polish, elevation-source settings UI.

--- a/docs/internal/dev-notes/TERRAIN_LINK_PROFILE_EPIC.md
+++ b/docs/internal/dev-notes/TERRAIN_LINK_PROFILE_EPIC.md
@@ -60,7 +60,7 @@ Branch: `feature/elevation-backend` (worktree ../meshmonitor-elevation-backend)
 - **Exit criteria:** API returns correct profiles for known coordinates (unit-tested with mocked
   fetches); custom-source test endpoint works; suite green; merged.
 
-### Phase 2 — Link Profile tool in Map Analysis ⬜
+### Phase 2 — Link Profile tool in Map Analysis ✅
 Branch: `feature/link-profile-tool` (worktree ../meshmonitor-link-profile)
 
 - Pure math utils (`src/utils/` mirroring measureDistance.ts): Fresnel zone radius (n=1),
@@ -86,6 +86,9 @@ Branch: `feature/link-profile-polish`
 - Map overlay: picked path colored by obstruction result.
 - Edge cases: missing DEM data (ocean/voids), antimeridian crossing, same-point selection,
   very long paths (sample-count clamp).
+- **From Phase 2 browser validation:** Terrarium void/bathymetry artifacts (extreme negatives,
+  e.g. −12000 m spike observed over Lake Pontchartrain) blow out the chart Y-domain — clamp or
+  null-out absurd DEM values (e.g. < −500 m) in the provider or the chart domain.
 - Elevation-source settings UI (SettingsTab) w/ test button, if not landed in Ph1/2.
 - Docs: README/docs feature section; CLAUDE.md/dev-notes updates if invariants added.
 - **Exit criteria:** frequency auto-populates per source; graceful degradation on missing data;
@@ -100,3 +103,12 @@ Branch: `feature/link-profile-polish`
   (may embed API keys; server-only); `/profile` public via optionalAuth + dedicated
   elevationLimiter (20/min prod, private-IP exempt); `/test` behind settings:write; testSource
   default probe = Everest summit (distinguishes a working provider from ocean-0 responses).
+- 2026-07-16: Phase 1 merged: PR #4143 (squash 8b68ac2e).
+- 2026-07-16: Phase 2 implemented (WP-A math/hooks/API 108bf9f3, WP-B drawer f056d8e3,
+  WP-C picker/context/toolbar dab7f1c5, WP-D canvas wiring e7c4f809). Full suite 9,400 passed /
+  0 failed; lint:ci + vite build clean. Browser-validated on live Terrarium data: pick → drawer →
+  verdict (math hand-checked: 89.4 km @ 915 MHz → FSPL 130.7 dB, RX −106.4 dBm, margin +22.6 dB);
+  budget edits recompute with zero refetch; Escape fully exits. Decisions: DEM+AGL model (node GPS
+  altitude ignored — datum mismatch); snap-within-24px else raw point (no modifier key); drawer =
+  absolute overlay in canvas; useElevationEnabled gates the toolbar button. Known issue punted to
+  Phase 3: Terrarium void/bathymetry extreme negatives distort the chart Y-domain.

--- a/src/components/MapAnalysis/LinkProfileController.css
+++ b/src/components/MapAnalysis/LinkProfileController.css
@@ -1,0 +1,21 @@
+/* #4111 Phase 2: distance label for the Terrain Link Profile two-point
+   picker. Applied to the permanent Leaflet tooltip anchored at the picked
+   line's midpoint. Amber to stay visually distinct from the cyan Measure
+   tool label (`.measure-distance-label`) while the two share the same pill
+   styling convention. */
+.leaflet-tooltip.link-profile-label {
+  background: #0f172a;
+  color: #e2e8f0;
+  border: 1px solid #f59e0b;
+  border-radius: 10px;
+  padding: 2px 8px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  white-space: nowrap;
+}
+
+/* Center-direction tooltips have no callout arrow; hide any pseudo just in case. */
+.leaflet-tooltip.link-profile-label::before {
+  display: none;
+}

--- a/src/components/MapAnalysis/LinkProfileController.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileController.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { useState } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import type { LinkEndpoint } from '../../utils/linkProfile';
+
+// Real container element the controller attaches its capture-phase listener to.
+// `mouseEventToLatLng` maps clientX/clientY straight to lng/lat so a synthetic
+// click at (x,y) resolves to { lat: y, lng: x }. `latLngToContainerPoint` maps
+// a [lat,lng] pair straight back to a container-space {x,y} point (inverse of
+// the above), so a node at lat=100,lng=100 sits at screen (100,100) — letting
+// the SNAP_PX threshold tests use plain pixel offsets.
+const container = document.createElement('div');
+container.style.cursor = '';
+// jsdom's getBoundingClientRect() defaults to all-zero, matching the (0,0)
+// origin `mouseEventToLatLng`/`latLngToContainerPoint` assume below.
+
+vi.mock('react-leaflet', () => ({
+  useMap: () => ({
+    getContainer: () => container,
+    mouseEventToLatLng: (e: MouseEvent) => ({ lat: e.clientY, lng: e.clientX }),
+    latLngToContainerPoint: ([lat, lng]: [number, number]) => ({ x: lng, y: lat }),
+  }),
+  CircleMarker: ({ center, pathOptions }: { center: [number, number]; pathOptions: { fillOpacity: number } }) => (
+    <div
+      data-testid="link-ring"
+      data-lat={center[0]}
+      data-lng={center[1]}
+      data-filled={pathOptions.fillOpacity > 0}
+    />
+  ),
+  Polyline: ({ positions, children }: { positions: [number, number][]; children?: React.ReactNode }) => (
+    <div data-testid="link-line" data-positions={JSON.stringify(positions)}>{children}</div>
+  ),
+  Tooltip: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="link-label">{children}</div>
+  ),
+}));
+
+let unit: 'km' | 'mi' = 'km';
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ distanceUnit: unit }),
+}));
+
+import LinkProfileController, { type LinkProfileControllerProps } from './LinkProfileController';
+
+// Candidate node endpoints laid out along one latitude so nearest-by-distance
+// (great-circle) agrees with nearest-by-clientX for these test coordinates.
+const POINTS: LinkEndpoint[] = [
+  { id: 'a', lat: 100, lng: 100, label: 'A', isNode: true },
+  { id: 'b', lat: 100, lng: 500, label: 'B', isNode: true },
+  { id: 'c', lat: 100, lng: 900, label: 'C', isNode: true },
+];
+
+/** Controlled-component harness mirroring how MapAnalysisCanvas (WP-D) wires
+ * the controller to `linkEndpoints`/`setLinkEndpoints` in MapAnalysisContext. */
+function Harness(props: Partial<LinkProfileControllerProps> & { points?: LinkEndpoint[] }) {
+  const [endpoints, setEndpoints] = useState<LinkEndpoint[]>(props.endpoints ?? []);
+  return (
+    <LinkProfileController
+      active={props.active ?? true}
+      points={props.points ?? POINTS}
+      endpoints={endpoints}
+      onPick={(next) => {
+        setEndpoints(next);
+        props.onPick?.(next);
+      }}
+      onExit={props.onExit}
+    />
+  );
+}
+
+function clickAt(x: number, y: number, target: EventTarget = container) {
+  act(() => {
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  });
+}
+
+describe('LinkProfileController', () => {
+  beforeEach(() => {
+    container.style.cursor = '';
+    unit = 'km';
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    container.remove();
+    container.innerHTML = '';
+  });
+
+  it('renders nothing when inactive', () => {
+    render(<Harness active={false} />);
+    expect(screen.queryByTestId('link-ring')).toBeNull();
+  });
+
+  it('renders nothing (but is still active) with zero candidate nodes — arbitrary points still work', () => {
+    render(<Harness points={[]} />);
+    expect(screen.queryByTestId('link-ring')).toBeNull();
+    clickAt(300, 300);
+    expect(screen.getAllByTestId('link-ring')).toHaveLength(1);
+  });
+
+  it('snaps a click within SNAP_PX of a node to that node (isNode:true, filled marker)', () => {
+    render(<Harness />);
+    clickAt(105, 100); // 5px from node "a" at (100,100) — inside the 24px threshold
+    const ring = screen.getByTestId('link-ring');
+    expect(ring.getAttribute('data-lat')).toBe('100');
+    expect(ring.getAttribute('data-lng')).toBe('100');
+    expect(ring.getAttribute('data-filled')).toBe('true');
+  });
+
+  it('treats a click far from any node as an arbitrary point (isNode:false, hollow marker)', () => {
+    render(<Harness />);
+    clickAt(300, 300); // >24px from every candidate node
+    const ring = screen.getByTestId('link-ring');
+    expect(ring.getAttribute('data-lat')).toBe('300');
+    expect(ring.getAttribute('data-lng')).toBe('300');
+    expect(ring.getAttribute('data-filled')).toBe('false');
+  });
+
+  it('A-then-B sequence draws a connecting line and label', () => {
+    render(<Harness />);
+    clickAt(105, 100); // near A
+    clickAt(895, 100); // near C
+    const line = screen.getByTestId('link-line');
+    expect(JSON.parse(line.getAttribute('data-positions')!)).toEqual([
+      [100, 100],
+      [100, 900],
+    ]);
+    expect(screen.getByTestId('link-label').textContent).toMatch(/km$/);
+  });
+
+  it('a third click restarts the pair from a new endpoint A', () => {
+    render(<Harness />);
+    clickAt(105, 100); // A
+    clickAt(895, 100); // C -> completed pair
+    expect(screen.queryByTestId('link-line')).not.toBeNull();
+
+    clickAt(505, 100); // restart with B as the new anchor A
+    expect(screen.queryByTestId('link-line')).toBeNull();
+    expect(screen.getAllByTestId('link-ring')).toHaveLength(1);
+  });
+
+  it('ignores re-picking the same node as the first endpoint', () => {
+    render(<Harness />);
+    clickAt(105, 100); // A (node "a")
+    clickAt(110, 100); // still snaps to node "a" -> ignored, no pair
+    expect(screen.queryByTestId('link-line')).toBeNull();
+    expect(screen.getAllByTestId('link-ring')).toHaveLength(1);
+  });
+
+  it('honors the miles preference in the connecting line label', () => {
+    unit = 'mi';
+    render(<Harness />);
+    clickAt(105, 100);
+    clickAt(505, 100);
+    expect(screen.getByTestId('link-label').textContent).toMatch(/mi$/);
+  });
+
+  it('sets a crosshair cursor while active and restores it on exit', () => {
+    const { rerender } = render(<Harness active />);
+    expect(container.style.cursor).toBe('crosshair');
+    rerender(<Harness active={false} />);
+    expect(container.style.cursor).toBe('');
+  });
+
+  it('ignores clicks on leaflet controls', () => {
+    render(<Harness />);
+    const zoom = document.createElement('div');
+    zoom.className = 'leaflet-control';
+    container.appendChild(zoom);
+    clickAt(105, 100, zoom);
+    expect(screen.queryByTestId('link-ring')).toBeNull();
+  });
+
+  it('Escape clears the pair and calls onExit', () => {
+    const onExit = vi.fn();
+    render(<Harness onExit={onExit} />);
+    clickAt(105, 100);
+    clickAt(895, 100);
+    expect(screen.queryByTestId('link-line')).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('link-line')).toBeNull();
+    expect(screen.queryByTestId('link-ring')).toBeNull();
+  });
+
+  it('calls onPick with the same shape the parent context expects', () => {
+    const onPick = vi.fn();
+    render(<Harness onPick={onPick} />);
+    clickAt(105, 100);
+    expect(onPick).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'a', lat: 100, lng: 100, isNode: true }),
+    ]);
+  });
+});

--- a/src/components/MapAnalysis/LinkProfileController.tsx
+++ b/src/components/MapAnalysis/LinkProfileController.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useRef } from 'react';
+import { CircleMarker, Polyline, Tooltip, useMap } from 'react-leaflet';
+import { useSettings } from '../../contexts/SettingsContext';
+import { nearestPoint, measureLabel } from '../../utils/measureDistance';
+import type { LinkEndpoint } from '../../utils/linkProfile';
+import './LinkProfileController.css';
+
+/** Screen-space snap threshold (px) for treating a click as "on" a node. */
+const SNAP_PX = 24;
+
+export interface LinkProfileControllerProps {
+  /** When false the tool is inert (no cursor change, no listeners fire visibly). */
+  active: boolean;
+  /** Candidate node endpoints — positioned nodes eligible for snapping. */
+  points: LinkEndpoint[];
+  /** Currently picked endpoints (0..2), owned by the parent (MapAnalysisContext). */
+  endpoints: LinkEndpoint[];
+  /** Called with the next endpoint array whenever a pick changes it. */
+  onPick: (next: LinkEndpoint[]) => void;
+  /** Called when the user presses Escape so the parent can flip `active` off. */
+  onExit?: () => void;
+}
+
+/**
+ * Two-point picker for the Terrain Link Profile tool (epic #4111 Phase 2).
+ *
+ * Clones `MeasureDistanceController`'s capture-phase click interception
+ * (fires before marker/map click handlers so a click on a node doesn't open
+ * its popup) but differs in two ways per the spec
+ * (`docs/internal/dev-notes/LINK_PROFILE_TOOL_SPEC.md` §2.7):
+ *
+ *  - It is a **controlled** component: picked endpoints live in
+ *    `MapAnalysisContext` (`linkEndpoints`), not local state, so the bottom
+ *    drawer can read them too. Every pick is emitted via `onPick`.
+ *  - A click that doesn't land within `SNAP_PX` screen pixels of the nearest
+ *    candidate node still picks — as an arbitrary (non-node) endpoint at the
+ *    raw clicked lat/lng. This lets the tool profile a link to/from a point
+ *    that has no node, unlike the node-only Measure tool.
+ *
+ * First pick sets endpoint A, second sets B and draws the connecting line +
+ * distance label, a third pick restarts from a new A. Escape (or the parent
+ * toggling `active` off) clears the pair.
+ */
+const LinkProfileController: React.FC<LinkProfileControllerProps> = ({
+  active,
+  points,
+  endpoints,
+  onPick,
+  onExit,
+}) => {
+  const { distanceUnit } = useSettings();
+  const map = useMap();
+
+  // Arbitrary (non-node) endpoints are always pickable, so the tool doesn't
+  // need >=2 candidate nodes to function — the toolbar button gates that for
+  // UX parity with Measure, but the controller itself only cares about
+  // `active` (spec §2.7: "arbitrary points allowed even with 0 nodes").
+  const enabled = active;
+
+  // Keep the latest points/endpoints reachable from the (stable) click
+  // listener without re-subscribing on every render that returns fresh arrays.
+  const pointsRef = useRef(points);
+  pointsRef.current = points;
+  const endpointsRef = useRef(endpoints);
+  endpointsRef.current = endpoints;
+
+  // Crosshair affordance while picking; always restore on cleanup.
+  useEffect(() => {
+    if (!enabled) return;
+    const container = map.getContainer();
+    const prev = container.style.cursor;
+    container.style.cursor = 'crosshair';
+    return () => {
+      container.style.cursor = prev;
+    };
+  }, [enabled, map]);
+
+  // Capture-phase click interception. Registered on the map container so it
+  // fires before Leaflet's marker/map click handlers — letting a click land
+  // on a node marker without opening its popup.
+  useEffect(() => {
+    if (!enabled) return;
+    const container = map.getContainer();
+    const onClick = (e: MouseEvent) => {
+      // Let map controls (zoom, attribution, tileset toggle) work normally.
+      const target = e.target as HTMLElement | null;
+      if (target && target.closest('.leaflet-control')) return;
+      // Stop the marker popup / map click from also handling this event.
+      e.stopPropagation();
+      e.preventDefault();
+      const latlng = map.mouseEventToLatLng(e);
+      const nearest = nearestPoint(pointsRef.current, latlng.lat, latlng.lng);
+
+      let picked: LinkEndpoint | null = null;
+      if (nearest) {
+        const rect = container.getBoundingClientRect();
+        const clickPx = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+        const nearestPx = map.latLngToContainerPoint([nearest.lat, nearest.lng]);
+        const distPx = Math.hypot(clickPx.x - nearestPx.x, clickPx.y - nearestPx.y);
+        if (distPx < SNAP_PX) {
+          picked = { ...nearest, isNode: true };
+        }
+      }
+      if (!picked) {
+        picked = { id: `pt-${latlng.lat},${latlng.lng}`, lat: latlng.lat, lng: latlng.lng, isNode: false };
+      }
+
+      const prev = endpointsRef.current;
+      let next: LinkEndpoint[];
+      if (prev.length === 0) {
+        next = [picked];
+      } else if (prev.length === 1) {
+        // Ignore re-picking the same node as the first endpoint.
+        if (prev[0].id === picked.id) return;
+        next = [prev[0], picked];
+      } else {
+        next = [picked]; // completed pair -> restart from a new A
+      }
+      onPick(next);
+    };
+    container.addEventListener('click', onClick, true);
+    return () => container.removeEventListener('click', onClick, true);
+  }, [enabled, map, onPick]);
+
+  // Escape clears / exits.
+  useEffect(() => {
+    if (!enabled) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      onPick([]);
+      onExit?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [enabled, onPick, onExit]);
+
+  if (!enabled) return null;
+
+  const [endpointA, endpointB] = endpoints;
+  const ringStyle = (endpoint: LinkEndpoint) => ({
+    color: '#f59e0b',
+    weight: 3,
+    fillColor: '#f59e0b',
+    // Filled for a snapped node, hollow for an arbitrary map point — visually
+    // distinguishes the two endpoint kinds (spec §2.7).
+    fillOpacity: endpoint.isNode ? 0.6 : 0,
+  });
+
+  return (
+    <>
+      {endpointA && (
+        <CircleMarker center={[endpointA.lat, endpointA.lng]} radius={12} pathOptions={ringStyle(endpointA)} />
+      )}
+      {endpointB && (
+        <CircleMarker center={[endpointB.lat, endpointB.lng]} radius={12} pathOptions={ringStyle(endpointB)} />
+      )}
+      {endpointA && endpointB && (
+        <Polyline
+          positions={[
+            [endpointA.lat, endpointA.lng],
+            [endpointB.lat, endpointB.lng],
+          ]}
+          pathOptions={{ color: '#f59e0b', weight: 3 }}
+        >
+          <Tooltip permanent direction="center" className="link-profile-label">
+            {measureLabel(endpointA, endpointB, distanceUnit)}
+          </Tooltip>
+        </Polyline>
+      )}
+    </>
+  );
+};
+
+export default LinkProfileController;

--- a/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * LinkProfileDrawer (Terrain Link Profile epic #4111 Phase 2, WP-B). Mocks:
+ *  - `recharts` to simple divs (assertions target stats, not SVG internals —
+ *    mirrors TelemetryGraphs.test.tsx).
+ *  - `../../contexts/SettingsContext` for `distanceUnit`.
+ *  - `./MapAnalysisContext` so `linkProfileMode`/`linkEndpoints` are driven
+ *    directly by each test, without needing a real picker interaction.
+ *  - `../../services/api`'s `getElevationProfile` — this is the "query fn"
+ *    boundary the recompute-without-refetch test asserts against; the real
+ *    `useElevationProfile` hook (WP-A) and a real `QueryClient` are used
+ *    on top of it so budget-input edits are proven not to touch the network.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import LinkProfileDrawer from './LinkProfileDrawer';
+import type { LinkEndpoint } from '../../utils/linkProfile';
+import type { ElevationProfile } from '../../types/elevation';
+
+vi.mock('recharts', () => ({
+  ComposedChart: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="composed-chart">{children}</div>
+  ),
+  Area: () => null,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ReferenceDot: () => null,
+  ReferenceLine: () => null,
+}));
+
+let mockDistanceUnit: 'km' | 'mi' = 'km';
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ distanceUnit: mockDistanceUnit }),
+}));
+
+let mockLinkProfileMode = true;
+let mockLinkEndpoints: LinkEndpoint[] = [];
+let setLinkProfileModeSpy: ReturnType<typeof vi.fn>;
+let setLinkEndpointsSpy: ReturnType<typeof vi.fn>;
+vi.mock('./MapAnalysisContext', () => ({
+  useMapAnalysisCtx: () => ({
+    linkProfileMode: mockLinkProfileMode,
+    linkEndpoints: mockLinkEndpoints,
+    setLinkProfileMode: setLinkProfileModeSpy,
+    setLinkEndpoints: setLinkEndpointsSpy,
+  }),
+}));
+
+const getElevationProfileMock = vi.fn();
+vi.mock('../../services/api', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/api')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      getElevationProfile: (...args: unknown[]) => getElevationProfileMock(...args),
+    },
+  };
+});
+
+const endpointA: LinkEndpoint = { id: 'node-a', lat: 0, lng: 0, isNode: true };
+const endpointB: LinkEndpoint = { id: 'node-b', lat: 0.3, lng: 0, isNode: true };
+
+// Obstructed fixture: 33.3km @ default 915MHz/2m-AGL — the total distance
+// (33300m) matches the spec's locked FSPL/RX-power/margin reference values
+// (122.117dB / -97.817dBm / +31.183dB) so the stats readout can assert exact
+// rounded text. Flat 100m ground at both ends (antenna tops = 102m, so LOS is
+// flat at 102m); a 90m mid-path sample plus the ~16.317m curvature bulge at
+// the midpoint (d1=d2=16650m, k=4/3) raises effective terrain to ~106.3m,
+// above the 102m LOS -> obstructed.
+const OBSTRUCTED_PROFILE: ElevationProfile = {
+  distanceMeters: 33300,
+  provider: 'test',
+  samples: [
+    { distance: 0, lat: 0, lng: 0, elevation: 100 },
+    { distance: 16650, lat: 0.15, lng: 0, elevation: 90 },
+    { distance: 33300, lat: 0.3, lng: 0, elevation: 100 },
+  ],
+};
+
+const ALL_NULL_PROFILE: ElevationProfile = {
+  distanceMeters: 33300,
+  provider: 'test',
+  samples: [
+    { distance: 0, lat: 0, lng: 0, elevation: null },
+    { distance: 16650, lat: 0.15, lng: 0, elevation: null },
+    { distance: 33300, lat: 0.3, lng: 0, elevation: null },
+  ],
+};
+
+function renderDrawer() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LinkProfileDrawer />
+    </QueryClientProvider>
+  );
+}
+
+describe('LinkProfileDrawer', () => {
+  beforeEach(() => {
+    mockDistanceUnit = 'km';
+    mockLinkProfileMode = true;
+    mockLinkEndpoints = [];
+    setLinkProfileModeSpy = vi.fn();
+    setLinkEndpointsSpy = vi.fn();
+    getElevationProfileMock.mockReset();
+  });
+
+  it('renders nothing when the tool is off and no endpoints were picked', () => {
+    mockLinkProfileMode = false;
+    mockLinkEndpoints = [];
+    const { container } = renderDrawer();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a prompt while only one endpoint is picked', () => {
+    mockLinkEndpoints = [endpointA];
+    renderDrawer();
+    expect(screen.getByText(/pick a second point/i)).toBeInTheDocument();
+  });
+
+  it('shows a loading state while the elevation profile is fetching', () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockReturnValue(new Promise(() => {})); // never resolves
+    renderDrawer();
+    expect(screen.getByText(/loading elevation profile/i)).toBeInTheDocument();
+  });
+
+  it('shows a "no terrain data" message for an all-null profile', async () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(ALL_NULL_PROFILE);
+    renderDrawer();
+    expect(await screen.findByText(/no terrain data/i)).toBeInTheDocument();
+  });
+
+  it('renders verdict, FSPL, RX power, margin and distance for an obstructed link', async () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+    renderDrawer();
+
+    expect(await screen.findByText(/Obstructed/)).toBeInTheDocument();
+    expect(screen.getByText('122.1 dB')).toBeInTheDocument(); // FSPL
+    expect(screen.getByText('-97.8 dBm')).toBeInTheDocument(); // RX power
+    expect(screen.getByText('+31.2 dB')).toBeInTheDocument(); // margin (positive)
+    expect(screen.getByText('33.3 km')).toBeInTheDocument(); // distance
+
+    const marginDd = screen.getByText('+31.2 dB');
+    expect(marginDd.className).toContain('link-margin-positive');
+  });
+
+  it('renders distance in miles when the user prefers miles', async () => {
+    mockDistanceUnit = 'mi';
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+    renderDrawer();
+    expect(await screen.findByText('20.7 mi')).toBeInTheDocument();
+  });
+
+  it('recomputes the margin from a budget-input edit without an extra elevation fetch', async () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+    renderDrawer();
+
+    await screen.findByText('+31.2 dB');
+    const callsAfterLoad = getElevationProfileMock.mock.calls.length;
+    expect(callsAfterLoad).toBeGreaterThan(0);
+
+    const rxSensInput = screen.getByLabelText(/RX sensitivity/i);
+    fireEvent.change(rxSensInput, { target: { value: '-140' } });
+
+    // margin = rxPower(-97.817) - (-140) = +42.183 -> "+42.2 dB"
+    await waitFor(() => expect(screen.getByText('+42.2 dB')).toBeInTheDocument());
+    expect(getElevationProfileMock.mock.calls.length).toBe(callsAfterLoad);
+  });
+
+  it('colours a negative margin red', async () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+    renderDrawer();
+
+    await screen.findByText('+31.2 dB');
+    const rxSensInput = screen.getByLabelText(/RX sensitivity/i);
+    // Raise RX sensitivity toward 0 (worse) until the margin goes negative.
+    fireEvent.change(rxSensInput, { target: { value: '-50' } });
+
+    const marginDd = await screen.findByText('-47.8 dB');
+    expect(marginDd.className).toContain('link-margin-negative');
+  });
+
+  it('calls setLinkProfileMode(false) and clears endpoints when closed', async () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+    renderDrawer();
+    await screen.findByText('+31.2 dB');
+
+    fireEvent.click(screen.getByRole('button', { name: /close link profile/i }));
+    expect(setLinkProfileModeSpy).toHaveBeenCalledWith(false);
+    expect(setLinkEndpointsSpy).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/MapAnalysis/LinkProfileDrawer.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.tsx
@@ -1,0 +1,416 @@
+/**
+ * Bottom-drawer overlay for the Terrain Link Profile tool (epic #4111, Phase
+ * 2, WP-B). Renders a recharts terrain/LOS/Fresnel chart plus a full
+ * link-budget readout and an editable budget-input form for a picked
+ * endpoint pair.
+ *
+ * Reads `linkProfileMode`/`linkEndpoints` straight from `MapAnalysisContext`
+ * (LINK_PROFILE_TOOL_SPEC.md §2.8) — WP-D mounts it unconditionally
+ * (`<LinkProfileDrawer />`) alongside `<BaseMap>` in `MapAnalysisCanvas.tsx`;
+ * this component returns `null` itself once both `linkProfileMode` is off
+ * and there are no picked endpoints. Elevation samples are fetched once per
+ * endpoint pair via `useElevationProfile` (geometry-only, WP-A). Every
+ * budget-input edit (frequency, antenna heights, power, gains, cable loss,
+ * RX sensitivity, k-factor) recomputes `analyzeLinkProfile`/
+ * `computeLinkBudget` client-side via `useMemo` — no refetch.
+ */
+import React, { useMemo, useState, useCallback } from 'react';
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceDot,
+  ReferenceLine,
+} from 'recharts';
+import { useSettings } from '../../contexts/SettingsContext';
+import { ApiError } from '../../services/api';
+import { useElevationProfile } from '../../hooks/useElevationProfile';
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { analyzeLinkProfile, type LinkVerdict } from '../../utils/linkProfile';
+import { computeLinkBudget, DEFAULT_K_FACTOR } from '../../utils/linkBudget';
+import { formatDistance } from '../../utils/distance';
+
+// Documented defaults (LINK_PROFILE_TOOL_SPEC.md §0.7).
+const DEFAULT_FREQ_MHZ = 915;
+const DEFAULT_AGL_M = 2;
+const DEFAULT_TX_POWER_DBM = 20;
+const DEFAULT_GAIN_DBI = 2.15;
+const DEFAULT_CABLE_LOSS_DB = 0;
+const DEFAULT_RX_SENSITIVITY_DBM = -129;
+
+const VERDICT_LABEL: Record<LinkVerdict, string> = {
+  clear: 'Clear',
+  marginal: 'Marginal',
+  obstructed: 'Obstructed',
+};
+
+const VERDICT_COLOR: Record<LinkVerdict, string> = {
+  clear: '#22c55e',
+  marginal: '#f59e0b',
+  obstructed: '#ef4444',
+};
+
+interface ChartTooltipPayloadItem {
+  dataKey?: string;
+  value?: number | null;
+  color?: string;
+}
+
+/** Custom tooltip content — formats terrain/LOS/Fresnel at the hovered distance. */
+const ChartTooltip: React.FC<{
+  active?: boolean;
+  label?: number;
+  payload?: ChartTooltipPayloadItem[];
+}> = ({ active, label, payload }) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const rows: Array<{ key: string; label: string }> = [
+    { key: 'effectiveTerrain', label: 'Terrain' },
+    { key: 'los', label: 'Line of sight' },
+    { key: 'fresnelLower', label: 'Fresnel lower bound' },
+  ];
+  return (
+    <div
+      style={{
+        backgroundColor: '#1e1e2e',
+        border: '1px solid #45475a',
+        borderRadius: '4px',
+        color: '#cdd6f4',
+        padding: '6px 10px',
+        fontSize: 12,
+      }}
+    >
+      <div>{typeof label === 'number' ? `${label.toFixed(2)} km` : ''}</div>
+      {rows.map(row => {
+        const item = payload.find(p => p.dataKey === row.key);
+        if (!item || item.value == null) return null;
+        return (
+          <div key={row.key} style={{ color: item.color }}>
+            {row.label}: {item.value.toFixed(1)} m
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const LinkProfileDrawer: React.FC = () => {
+  const { distanceUnit } = useSettings();
+  const { linkProfileMode, linkEndpoints, setLinkProfileMode, setLinkEndpoints } = useMapAnalysisCtx();
+  const [endpointA, endpointB] = linkEndpoints;
+
+  const onClose = useCallback(() => {
+    setLinkProfileMode(false);
+    setLinkEndpoints([]);
+  }, [setLinkProfileMode, setLinkEndpoints]);
+
+  // Local budget-input state, seeded from documented defaults. Edits
+  // recompute the analysis client-side — they never trigger a refetch.
+  const [freqMhz, setFreqMhz] = useState(DEFAULT_FREQ_MHZ);
+  const [aglA, setAglA] = useState(DEFAULT_AGL_M);
+  const [aglB, setAglB] = useState(DEFAULT_AGL_M);
+  const [txPowerDbm, setTxPowerDbm] = useState(DEFAULT_TX_POWER_DBM);
+  const [txGainDbi, setTxGainDbi] = useState(DEFAULT_GAIN_DBI);
+  const [rxGainDbi, setRxGainDbi] = useState(DEFAULT_GAIN_DBI);
+  const [cableLossDb, setCableLossDb] = useState(DEFAULT_CABLE_LOSS_DB);
+  const [rxSensitivityDbm, setRxSensitivityDbm] = useState(DEFAULT_RX_SENSITIVITY_DBM);
+  const [kFactor, setKFactor] = useState(DEFAULT_K_FACTOR);
+
+  const { data: profile, isLoading, error } = useElevationProfile(endpointA, endpointB);
+
+  const analysis = useMemo(
+    () =>
+      profile
+        ? analyzeLinkProfile(profile.samples, {
+            freqMhz,
+            antennaHeightAglAM: aglA,
+            antennaHeightAglBM: aglB,
+            kFactor,
+          })
+        : null,
+    [profile, freqMhz, aglA, aglB, kFactor]
+  );
+
+  const budget = useMemo(
+    () =>
+      analysis
+        ? computeLinkBudget(analysis.totalDistanceKm, freqMhz, {
+            txPowerDbm,
+            txGainDbi,
+            rxGainDbi,
+            cableLossDb,
+            rxSensitivityDbm,
+          })
+        : null,
+    [analysis, freqMhz, txPowerDbm, txGainDbi, rxGainDbi, cableLossDb, rxSensitivityDbm]
+  );
+
+  const allTerrainNull = profile ? profile.samples.every(s => s.elevation === null) : false;
+
+  const worstPoint = useMemo(() => {
+    if (!analysis?.worst) return undefined;
+    return analysis.points.find(p => p.distanceKm === analysis.worst!.distanceKm);
+  }, [analysis]);
+
+  const isElevationDisabled = error instanceof ApiError && error.code === 'ELEVATION_DISABLED';
+
+  // Nothing to show: tool is off and no endpoints were ever picked. Hooks
+  // above are still called unconditionally (react-hooks rule) — this guard
+  // runs after them.
+  if (!linkProfileMode && linkEndpoints.length === 0) return null;
+
+  return (
+    <div className="map-analysis-link-drawer">
+      <div className="map-analysis-link-drawer-chart">
+        {!endpointA || !endpointB ? (
+          <div className="map-analysis-link-drawer-empty">
+            {!endpointA
+              ? 'Pick two points on the map to build a link profile.'
+              : 'Pick a second point to build a link profile.'}
+          </div>
+        ) : isLoading ? (
+          <div className="map-analysis-link-drawer-loading">Loading elevation profile…</div>
+        ) : isElevationDisabled ? (
+          <div className="map-analysis-link-drawer-error">
+            Terrain elevation is disabled on this server.
+          </div>
+        ) : error ? (
+          <div className="map-analysis-link-drawer-error">
+            Failed to load the elevation profile. Please try again.
+          </div>
+        ) : allTerrainNull ? (
+          <div className="map-analysis-link-drawer-empty">No terrain data for this path.</div>
+        ) : analysis ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={analysis.points} margin={{ top: 10, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+              <XAxis
+                dataKey="distanceKm"
+                type="number"
+                domain={['dataMin', 'dataMax']}
+                tick={{ fontSize: 11, fill: '#aaa' }}
+                tickFormatter={(v: number) => v.toFixed(1)}
+                label={{ value: 'Distance (km)', position: 'insideBottom', offset: -2, fill: '#888', fontSize: 11 }}
+              />
+              <YAxis
+                domain={['auto', 'auto']}
+                tick={{ fontSize: 11, fill: '#aaa' }}
+                label={{ value: 'Elevation (m)', angle: -90, position: 'insideLeft', fill: '#888', fontSize: 11 }}
+              />
+              <Tooltip content={<ChartTooltip />} />
+              <Area
+                type="monotone"
+                dataKey="effectiveTerrain"
+                name="Terrain"
+                fill="#8d6e63"
+                fillOpacity={0.5}
+                stroke="#8d6e63"
+                strokeWidth={1}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+              <Line
+                type="linear"
+                dataKey="los"
+                name="Line of sight"
+                stroke="#22c55e"
+                strokeWidth={2}
+                strokeDasharray={analysis.verdict === 'obstructed' ? '6 4' : undefined}
+                dot={false}
+                isAnimationActive={false}
+              />
+              <Line
+                type="linear"
+                dataKey="fresnelLower"
+                name="Fresnel lower bound"
+                stroke="#f59e0b"
+                strokeWidth={1.5}
+                strokeDasharray="4 3"
+                dot={false}
+                isAnimationActive={false}
+              />
+              {analysis.worst && worstPoint && (
+                <>
+                  <ReferenceLine
+                    x={analysis.worst.distanceKm}
+                    stroke={VERDICT_COLOR[analysis.verdict]}
+                    strokeDasharray="2 2"
+                  />
+                  <ReferenceDot
+                    x={analysis.worst.distanceKm}
+                    y={worstPoint.effectiveTerrain ?? worstPoint.los}
+                    r={5}
+                    fill={VERDICT_COLOR[analysis.verdict]}
+                    stroke="#fff"
+                  />
+                </>
+              )}
+            </ComposedChart>
+          </ResponsiveContainer>
+        ) : null}
+      </div>
+
+      <div className="map-analysis-link-drawer-side">
+        <div className="map-analysis-link-drawer-header">
+          <span className="map-analysis-link-drawer-title">Link Profile</span>
+          <button
+            className="map-analysis-link-drawer-close"
+            onClick={onClose}
+            aria-label="Close link profile"
+            title="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {analysis && budget && endpointA && endpointB && !isLoading && !error && (
+          <div className="map-analysis-link-drawer-stats">
+            <div className={`link-verdict-pill link-verdict-${analysis.verdict}`}>
+              {VERDICT_LABEL[analysis.verdict]} · {budget.marginDb >= 0 ? '+' : ''}
+              {budget.marginDb.toFixed(1)} dB margin
+            </div>
+            <dl className="map-analysis-link-drawer-statlist">
+              <dt>Distance</dt>
+              <dd>{formatDistance(analysis.totalDistanceKm, distanceUnit)}</dd>
+              <dt>Frequency</dt>
+              <dd>{freqMhz.toFixed(0)} MHz</dd>
+              <dt>FSPL</dt>
+              <dd>{budget.fsplDb.toFixed(1)} dB</dd>
+              <dt>RX power</dt>
+              <dd>{budget.rxPowerDbm.toFixed(1)} dBm</dd>
+              <dt>Margin</dt>
+              <dd className={budget.marginDb >= 0 ? 'link-margin-positive' : 'link-margin-negative'}>
+                {budget.marginDb >= 0 ? '+' : ''}
+                {budget.marginDb.toFixed(1)} dB
+              </dd>
+              <dt>Fresnel clearance</dt>
+              <dd>
+                {Number.isFinite(analysis.fresnelClearancePct)
+                  ? `${analysis.fresnelClearancePct.toFixed(0)}%`
+                  : 'N/A'}
+              </dd>
+            </dl>
+          </div>
+        )}
+
+        <div className="map-analysis-link-drawer-form">
+          <label>
+            Frequency (MHz)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={freqMhz}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setFreqMhz(v);
+              }}
+            />
+          </label>
+          <label>
+            Antenna A height AGL (m)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={aglA}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setAglA(v);
+              }}
+            />
+          </label>
+          <label>
+            Antenna B height AGL (m)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={aglB}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setAglB(v);
+              }}
+            />
+          </label>
+          <label>
+            TX power (dBm)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={txPowerDbm}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setTxPowerDbm(v);
+              }}
+            />
+          </label>
+          <label>
+            TX gain (dBi)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={txGainDbi}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setTxGainDbi(v);
+              }}
+            />
+          </label>
+          <label>
+            RX gain (dBi)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={rxGainDbi}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setRxGainDbi(v);
+              }}
+            />
+          </label>
+          <label>
+            Cable loss (dB)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={cableLossDb}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setCableLossDb(v);
+              }}
+            />
+          </label>
+          <label>
+            RX sensitivity (dBm)
+            <input
+              type="number"
+              className="map-analysis-tr-num"
+              value={rxSensitivityDbm}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setRxSensitivityDbm(v);
+              }}
+            />
+          </label>
+          <label>
+            Earth k-factor
+            <input
+              type="number"
+              step="0.01"
+              className="map-analysis-tr-num"
+              value={kFactor}
+              onChange={e => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) setKFactor(v);
+              }}
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkProfileDrawer;

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -6,6 +6,9 @@ import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { useAnalysisNodes } from './useAnalysisNodes';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
+import LinkProfileController from './LinkProfileController';
+import LinkProfileDrawer from './LinkProfileDrawer';
+import type { LinkEndpoint } from '../../utils/linkProfile';
 import { BaseMap } from '../map/BaseMap';
 import NodeMarkersLayer from './layers/NodeMarkersLayer';
 import TraceroutePathsLayer from './layers/TraceroutePathsLayer';
@@ -34,7 +37,15 @@ export default function MapAnalysisCanvas() {
     customTilesets,
     setMapTileset,
   } = useSettings();
-  const { config, measureMode, setMeasureMode } = useMapAnalysisCtx();
+  const {
+    config,
+    measureMode,
+    setMeasureMode,
+    linkProfileMode,
+    setLinkProfileMode,
+    linkEndpoints,
+    setLinkEndpoints,
+  } = useMapAnalysisCtx();
 
   // #3636: measurement endpoints, from the same visible+positioned node list
   // the markers layer uses so the two never disagree.
@@ -47,6 +58,13 @@ export default function MapAnalysisCanvas() {
       label: a.node.shortName ?? undefined,
     })),
     [analysisNodes],
+  );
+
+  // #4111 Phase 2 (WP-D): Link Profile picker candidates — same underlying
+  // node list as `measurePoints`, tagged `isNode:true` per `LinkEndpoint`.
+  const linkEndpointCandidates: LinkEndpoint[] = useMemo(
+    () => measurePoints.map((p) => ({ ...p, isNode: true })),
+    [measurePoints],
   );
 
   const center: [number, number] = [
@@ -71,6 +89,15 @@ export default function MapAnalysisCanvas() {
             active={measureMode}
             points={measurePoints}
             onExit={() => setMeasureMode(false)}
+          />
+        )}
+        {linkProfileMode && (
+          <LinkProfileController
+            active={linkProfileMode}
+            points={linkEndpointCandidates}
+            endpoints={linkEndpoints}
+            onPick={setLinkEndpoints}
+            onExit={() => setLinkProfileMode(false)}
           />
         )}
         <Pane name="waypoints" style={{ zIndex: 650 }}>
@@ -109,6 +136,7 @@ export default function MapAnalysisCanvas() {
       <TimeSliderControl />
       <MapLegend />
       <FollowResumeButton />
+      <LinkProfileDrawer />
     </div>
   );
 }

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
 import { useMapAnalysisConfig } from '../../hooks/useMapAnalysisConfig';
+import type { LinkEndpoint } from '../../utils/linkProfile';
 
 export interface SelectedTarget {
   type: 'node' | 'segment' | 'neighbor' | 'trail';
@@ -38,6 +39,16 @@ type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
   /** Node-to-node LOS distance measurement tool active (issue #3636); transient, not persisted. */
   measureMode: boolean;
   setMeasureMode: (m: boolean) => void;
+  /**
+   * Terrain Link Profile two-point picker active (#4111 Phase 2); transient,
+   * not persisted. Mutually exclusive with `measureMode` — enforced by the
+   * toolbar's button handlers, not here (see `MapAnalysisToolbar.tsx`).
+   */
+  linkProfileMode: boolean;
+  setLinkProfileMode: (m: boolean) => void;
+  /** Picked endpoints (0..2) for the Link Profile tool; transient, not persisted. */
+  linkEndpoints: LinkEndpoint[];
+  setLinkEndpoints: (e: LinkEndpoint[]) => void;
 };
 
 const Ctx = createContext<CtxShape | null>(null);
@@ -48,6 +59,8 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const [nodeFilter, setNodeFilter] = useState('');
   const [followPaused, setFollowPaused] = useState(false);
   const [measureMode, setMeasureMode] = useState(false);
+  const [linkProfileMode, setLinkProfileMode] = useState(false);
+  const [linkEndpoints, setLinkEndpoints] = useState<LinkEndpoint[]>([]);
   return (
     <Ctx.Provider
       value={{
@@ -60,6 +73,10 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
         setFollowPaused,
         measureMode,
         setMeasureMode,
+        linkProfileMode,
+        setLinkProfileMode,
+        linkEndpoints,
+        setLinkEndpoints,
       }}
     >
       {children}

--- a/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
@@ -11,9 +11,21 @@ import { MapAnalysisProvider } from './MapAnalysisContext';
 vi.mock('../../hooks/useDashboardData', () => ({
   useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }] }),
   // The Polar Grid toggle resolves own-node positions via these hooks (#3971).
-  useDashboardUnifiedData: () => ({ nodes: [] }),
+  useDashboardUnifiedData: () => ({ nodes: unifiedNodes }),
   useSourceStatuses: () => new Map(),
 }));
+
+// #4111 Phase 2: Link Profile button gate. Mutable per-test so a single mock
+// factory can serve both the "feature off" and "feature on" cases.
+let elevationEnabled = true;
+vi.mock('../../hooks/useElevationEnabled', () => ({
+  useElevationEnabled: () => elevationEnabled,
+}));
+
+// Two positioned nodes so `analysisNodes.length >= 2` (both Measure and Link
+// Profile buttons require this to enable). Empty by default so the existing
+// "0 nodes" tests above keep exercising the disabled state.
+let unifiedNodes: Array<{ nodeNum: number; latitude: number; longitude: number }> = [];
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const qc = new QueryClient();
@@ -27,7 +39,11 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
 };
 
 describe('MapAnalysisToolbar', () => {
-  beforeEach(() => localStorage.clear());
+  beforeEach(() => {
+    localStorage.clear();
+    elevationEnabled = true;
+    unifiedNodes = [];
+  });
 
   it('renders all 7 layer toggles', () => {
     render(<MapAnalysisToolbar />, { wrapper });
@@ -75,5 +91,51 @@ describe('MapAnalysisToolbar', () => {
     const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
     expect(stored.autoZoom).toBe(true);
     expect(stored.followMode).toBe(false);
+  });
+
+  // #4111 Phase 2: Terrain Link Profile toolbar button.
+  describe('Link Profile button (#4111)', () => {
+    it('is hidden entirely when elevationEnabled is false', () => {
+      elevationEnabled = false;
+      render(<MapAnalysisToolbar />, { wrapper });
+      expect(screen.queryByRole('button', { name: /link profile/i })).toBeNull();
+    });
+
+    it('is present but disabled when elevationEnabled is true with fewer than two positioned nodes', () => {
+      elevationEnabled = true;
+      unifiedNodes = [];
+      render(<MapAnalysisToolbar />, { wrapper });
+      const btn = screen.getByRole('button', { name: /link profile/i });
+      expect(btn).toBeInTheDocument();
+      expect(btn).toBeDisabled();
+    });
+
+    it('is enabled with two positioned nodes and toggles linkProfileMode, clearing measureMode', () => {
+      elevationEnabled = true;
+      unifiedNodes = [
+        { nodeNum: 1, latitude: 10, longitude: 20 },
+        { nodeNum: 2, latitude: 11, longitude: 21 },
+      ];
+      render(<MapAnalysisToolbar />, { wrapper });
+      const measureBtn = screen.getByRole('button', { name: 'Measure' });
+      const linkBtn = screen.getByRole('button', { name: 'Link Profile' });
+      expect(measureBtn).not.toBeDisabled();
+      expect(linkBtn).not.toBeDisabled();
+
+      // Turn Measure on first.
+      fireEvent.click(measureBtn);
+      expect(measureBtn).toHaveClass('active');
+      expect(linkBtn).not.toHaveClass('active');
+
+      // Turning Link Profile on must clear Measure (mutual exclusivity).
+      fireEvent.click(linkBtn);
+      expect(linkBtn).toHaveClass('active');
+      expect(measureBtn).not.toHaveClass('active');
+
+      // Turning Measure back on must clear Link Profile.
+      fireEvent.click(measureBtn);
+      expect(measureBtn).toHaveClass('active');
+      expect(linkBtn).not.toHaveClass('active');
+    });
   });
 });

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -11,6 +11,7 @@ import TracerouteControls from './TracerouteControls';
 import { useAnalysisNodes } from './useAnalysisNodes';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { useOwnNodePositions } from '../../hooks/useOwnNodePositions';
+import { useElevationEnabled } from '../../hooks/useElevationEnabled';
 import { LayerKey } from '../../hooks/useMapAnalysisConfig';
 import {
   usePositions,
@@ -49,9 +50,12 @@ export default function MapAnalysisToolbar() {
     setAutoZoom,
     measureMode,
     setMeasureMode,
+    linkProfileMode,
+    setLinkProfileMode,
     reset,
   } = useMapAnalysisCtx();
   const { data: sources = [] } = useDashboardSources();
+  const elevationEnabled = useElevationEnabled();
 
   // Node picker (issue #3788): deduped/sorted options built from the same
   // shared node hook the markers layer uses, so the picker never lists a node
@@ -172,7 +176,11 @@ export default function MapAnalysisToolbar() {
       <button
         type="button"
         className={`map-analysis-layer-btn ${measureMode ? 'active' : ''}`}
-        onClick={() => setMeasureMode(!measureMode)}
+        onClick={() => {
+          setMeasureMode(!measureMode);
+          // Mutually exclusive with the Link Profile picker (#4111 Phase 2).
+          if (!measureMode) setLinkProfileMode(false);
+        }}
         disabled={analysisNodes.length < 2}
         title={analysisNodes.length < 2
           ? 'Need at least two positioned nodes to measure'
@@ -180,6 +188,28 @@ export default function MapAnalysisToolbar() {
       >
         Measure
       </button>
+      {/* #4111 Phase 2: terrain link profile two-point picker. Hidden entirely
+          when the server has elevation sampling disabled (nothing to profile);
+          disabled until at least two positioned nodes exist for UX parity
+          with Measure, even though the controller itself also accepts an
+          arbitrary (non-node) map point as either endpoint. */}
+      {elevationEnabled && (
+        <button
+          type="button"
+          className={`map-analysis-layer-btn ${linkProfileMode ? 'active' : ''}`}
+          onClick={() => {
+            setLinkProfileMode(!linkProfileMode);
+            // Mutually exclusive with the Measure tool.
+            if (!linkProfileMode) setMeasureMode(false);
+          }}
+          disabled={analysisNodes.length < 2}
+          title={analysisNodes.length < 2
+            ? 'Need at least two positioned nodes for a link profile'
+            : 'Profile terrain, Fresnel clearance, and link budget between two points'}
+        >
+          Link Profile
+        </button>
+      )}
       {UNTIMED_LAYERS.map(({ key, label }) => (
         <LayerToggleButton
           key={key}

--- a/src/hooks/useElevationEnabled.test.tsx
+++ b/src/hooks/useElevationEnabled.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useElevationEnabled } from './useElevationEnabled';
+import apiService from '../services/api';
+
+vi.mock('../services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+describe('useElevationEnabled', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns false when the server sets elevationEnabled to "false"', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ elevationEnabled: 'false' });
+    const { result } = renderHook(() => useElevationEnabled(), { wrapper });
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('returns true when elevationEnabled is "true"', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ elevationEnabled: 'true' });
+    const { result } = renderHook(() => useElevationEnabled(), { wrapper });
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('returns true when elevationEnabled is absent from the settings map', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({});
+    const { result } = renderHook(() => useElevationEnabled(), { wrapper });
+    await waitFor(() => expect(apiService.get).toHaveBeenCalled());
+    expect(result.current).toBe(true);
+  });
+
+  it('defaults to true before the query resolves (undefined data)', () => {
+    vi.mocked(apiService.get).mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useElevationEnabled(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('requests /api/settings', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ elevationEnabled: 'true' });
+    renderHook(() => useElevationEnabled(), { wrapper });
+    await waitFor(() => expect(apiService.get).toHaveBeenCalledWith('/api/settings'));
+  });
+});

--- a/src/hooks/useElevationEnabled.ts
+++ b/src/hooks/useElevationEnabled.ts
@@ -1,0 +1,18 @@
+/**
+ * Availability flag for the Terrain Link Profile tool (#4111, Phase 2).
+ * `GET /api/settings` returns a bare settings map (not `{success,data}`
+ * enveloped — see `SettingsContext.tsx`), and `elevationEnabled` is
+ * non-secret so it is readable anonymously.
+ */
+import { useQuery } from '@tanstack/react-query';
+import apiService from '../services/api';
+
+/** True unless the server explicitly set `elevationEnabled` to `'false'`. */
+export function useElevationEnabled(): boolean {
+  const { data } = useQuery({
+    queryKey: ['settings', 'elevationEnabled'],
+    queryFn: () => apiService.get<{ elevationEnabled?: string }>('/api/settings'),
+    staleTime: 5 * 60_000,
+  });
+  return data?.elevationEnabled !== 'false';
+}

--- a/src/hooks/useElevationProfile.test.tsx
+++ b/src/hooks/useElevationProfile.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useElevationProfile } from './useElevationProfile';
+import apiService from '../services/api';
+import type { LinkEndpoint } from '../utils/linkProfile';
+import type { ElevationProfile } from '../types/elevation';
+
+vi.mock('../services/api', () => ({
+  default: {
+    getElevationProfile: vi.fn(),
+  },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+const pointA: LinkEndpoint = { id: 'a', lat: 40.0, lng: -105.0, isNode: true };
+const pointB: LinkEndpoint = { id: 'b', lat: 40.3, lng: -104.7, isNode: false };
+
+const profile: ElevationProfile = {
+  distanceMeters: 33300,
+  provider: 'terrarium',
+  samples: [
+    { distance: 0, lat: 40.0, lng: -105.0, elevation: 1500 },
+    { distance: 33300, lat: 40.3, lng: -104.7, elevation: 1520 },
+  ],
+};
+
+describe('useElevationProfile', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does NOT fetch when either endpoint is undefined', () => {
+    vi.mocked(apiService.getElevationProfile).mockResolvedValue(profile);
+    renderHook(() => useElevationProfile(pointA, undefined), { wrapper });
+    expect(apiService.getElevationProfile).not.toHaveBeenCalled();
+  });
+
+  it('fetches once both endpoints are set', async () => {
+    vi.mocked(apiService.getElevationProfile).mockResolvedValue(profile);
+    const { result } = renderHook(() => useElevationProfile(pointA, pointB), { wrapper });
+    await waitFor(() => expect(result.current.data).toEqual(profile));
+    expect(apiService.getElevationProfile).toHaveBeenCalledWith(
+      { lat: pointA.lat, lng: pointA.lng },
+      { lat: pointB.lat, lng: pointB.lng },
+    );
+  });
+
+  it('does not refetch when endpoint objects are recreated with the same rounded coords', async () => {
+    vi.mocked(apiService.getElevationProfile).mockResolvedValue(profile);
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const localWrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      ({ a, b }: { a: LinkEndpoint; b: LinkEndpoint }) => useElevationProfile(a, b),
+      { wrapper: localWrapper, initialProps: { a: pointA, b: pointB } },
+    );
+    await waitFor(() => expect(result.current.data).toEqual(profile));
+    expect(apiService.getElevationProfile).toHaveBeenCalledTimes(1);
+
+    // New object identities, same lat/lng values -> same query key -> no refetch.
+    rerender({ a: { ...pointA }, b: { ...pointB } });
+    await waitFor(() => expect(result.current.data).toEqual(profile));
+    expect(apiService.getElevationProfile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useElevationProfile.ts
+++ b/src/hooks/useElevationProfile.ts
@@ -1,0 +1,36 @@
+/**
+ * Fetch the elevation profile for a Link Profile endpoint pair (#4111, Phase
+ * 2). The profile is geometry-only — it depends solely on the two
+ * coordinates (and sample count), never on link-budget inputs like
+ * frequency or antenna height — so it is keyed on rounded coordinates and
+ * cached for a long stale time. Budget-input edits recompute client-side via
+ * `analyzeLinkProfile`/`computeLinkBudget` without touching this hook.
+ */
+import { useQuery } from '@tanstack/react-query';
+import apiService from '../services/api';
+import type { LinkEndpoint } from '../utils/linkProfile';
+import type { ElevationProfile } from '../types/elevation';
+
+/** Round to ~6 decimal places (~11cm) so repeated picks of "the same" point share cache. */
+function round(n: number): number {
+  return Math.round(n * 1_000_000) / 1_000_000;
+}
+
+/**
+ * Disabled until both endpoints are set. `queryKey` is built from rounded
+ * coordinates so budget-input edits elsewhere never trigger a refetch.
+ */
+export function useElevationProfile(a: LinkEndpoint | undefined, b: LinkEndpoint | undefined) {
+  const enabled = !!a && !!b;
+  return useQuery<ElevationProfile>({
+    queryKey: [
+      'elevation-profile',
+      a ? [round(a.lat), round(a.lng)] : null,
+      b ? [round(b.lat), round(b.lng)] : null,
+    ],
+    queryFn: () =>
+      apiService.getElevationProfile({ lat: a!.lat, lng: a!.lng }, { lat: b!.lat, lng: b!.lng }),
+    enabled,
+    staleTime: 30 * 60_000, // terrain is static
+  });
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import { DeviceInfo, Channel } from '../types/device';
 import { MeshMessage } from '../types/message';
+import type { ElevationProfile } from '../types/elevation';
 import {
   sanitizeTextInput,
   validateChannel,
@@ -1537,6 +1538,25 @@ class ApiService {
     }>;
   }> {
     return this.get('/api/news/unread');
+  }
+
+  /**
+   * Terrain elevation profile between two coordinates (#4111). POST is
+   * CSRF-guarded; `post()` attaches the token automatically. Unwraps the
+   * `{ success, data }` envelope — `request()` returns the raw body, so
+   * `.data` must be read explicitly here (see the MQTT-monitor unwrap
+   * gotcha documented in CLAUDE.md).
+   */
+  async getElevationProfile(
+    pointA: { lat: number; lng: number },
+    pointB: { lat: number; lng: number },
+    samples?: number,
+  ): Promise<ElevationProfile> {
+    const res = await this.post<{ success: boolean; data: ElevationProfile }>(
+      '/api/elevation/profile',
+      samples != null ? { pointA, pointB, samples } : { pointA, pointB },
+    );
+    return res.data;
   }
 }
 

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -592,3 +592,128 @@
   color: #fff;
   border-color: #555;
 }
+
+/* ===== Link Profile drawer (issue #4111 Phase 2, WP-B) ===== */
+.map-analysis-link-drawer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: min(42vh, 340px);
+  z-index: 1000;
+  background: #0f172a;
+  border-top: 1px solid #334155;
+  display: flex;
+  overflow: hidden;
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.45);
+}
+.map-analysis-link-drawer-chart {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+}
+.map-analysis-link-drawer-empty,
+.map-analysis-link-drawer-loading,
+.map-analysis-link-drawer-error {
+  color: #94a3b8;
+  font-size: 13px;
+  text-align: center;
+  padding: 0 24px;
+}
+.map-analysis-link-drawer-error {
+  color: #f87171;
+}
+.map-analysis-link-drawer-side {
+  flex: 0 0 300px;
+  width: 300px;
+  border-left: 1px solid #334155;
+  overflow-y: auto;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.map-analysis-link-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.map-analysis-link-drawer-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e2e8f0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.map-analysis-link-drawer-close {
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  width: 24px;
+  height: 24px;
+  line-height: 1;
+  cursor: pointer;
+  font-size: 12px;
+}
+.map-analysis-link-drawer-close:hover {
+  background: #1e293b;
+  color: #fff;
+  border-color: #475569;
+}
+
+/* Verdict pill */
+.link-verdict-pill {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #0f172a;
+  width: fit-content;
+}
+.link-verdict-clear { background: #22c55e; }
+.link-verdict-marginal { background: #f59e0b; }
+.link-verdict-obstructed { background: #ef4444; }
+
+.map-analysis-link-drawer-statlist {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 10px;
+  margin: 0;
+  font-size: 12px;
+}
+.map-analysis-link-drawer-statlist dt {
+  color: #94a3b8;
+}
+.map-analysis-link-drawer-statlist dd {
+  margin: 0;
+  color: #e2e8f0;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.link-margin-positive { color: #22c55e; }
+.link-margin-negative { color: #ef4444; }
+
+/* Budget-input form */
+.map-analysis-link-drawer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid #334155;
+  padding-top: 10px;
+}
+.map-analysis-link-drawer-form label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11px;
+  color: #94a3b8;
+}
+.map-analysis-link-drawer-form input.map-analysis-tr-num {
+  width: 90px;
+}

--- a/src/types/elevation.ts
+++ b/src/types/elevation.ts
@@ -1,0 +1,21 @@
+/**
+ * Client mirror of the Phase-1 elevation backend's response payload
+ * (Terrain Link Profile epic #4111). Kept in sync with
+ * `src/server/services/elevationService.ts`'s `ProfileSample`/`ProfileResult`
+ * but defined independently since the frontend never imports server code.
+ */
+
+/** One elevation sample from `POST /api/elevation/profile`. */
+export interface ElevationSample {
+  distance: number;
+  lat: number;
+  lng: number;
+  elevation: number | null;
+}
+
+/** Full profile payload returned (post-envelope-unwrap) by the elevation route. */
+export interface ElevationProfile {
+  distanceMeters: number;
+  provider: string;
+  samples: ElevationSample[];
+}

--- a/src/utils/linkBudget.test.ts
+++ b/src/utils/linkBudget.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  wavelengthMeters,
+  fresnelRadiusMeters,
+  fsplDb,
+  earthBulgeMeters,
+  computeLinkBudget,
+} from './linkBudget';
+
+describe('wavelengthMeters', () => {
+  it('computes wavelength for 915 MHz', () => {
+    expect(wavelengthMeters(915)).toBeCloseTo(0.32764, 4);
+  });
+});
+
+describe('fsplDb', () => {
+  it('matches the locked reference: 33.3 km @ 915 MHz', () => {
+    expect(fsplDb(33.3, 915)).toBeCloseTo(122.117, 2);
+  });
+
+  it('matches the locked reference: 1 km @ 100 MHz (clean 0+40+32.44)', () => {
+    expect(fsplDb(1, 100)).toBeCloseTo(72.44, 2);
+  });
+
+  it('matches the locked reference: 10 km @ 915 MHz', () => {
+    expect(fsplDb(10, 915)).toBeCloseTo(111.668, 2);
+  });
+
+  it('returns 0 for zero distance (degenerate/coincident points)', () => {
+    expect(fsplDb(0, 915)).toBe(0);
+  });
+
+  it('returns 0 for negative distance', () => {
+    expect(fsplDb(-5, 915)).toBe(0);
+  });
+
+  it('returns 0 for non-positive frequency', () => {
+    expect(fsplDb(10, 0)).toBe(0);
+    expect(fsplDb(10, -915)).toBe(0);
+  });
+});
+
+describe('fresnelRadiusMeters', () => {
+  it('matches the locked reference: midpoint of a 10km link @ 915 MHz', () => {
+    expect(fresnelRadiusMeters(1, 915, 5000, 5000)).toBeCloseTo(28.62, 2);
+  });
+
+  it('matches the locked reference: asymmetric point, d1=3000 d2=7000 @ 915 MHz', () => {
+    expect(fresnelRadiusMeters(1, 915, 3000, 7000)).toBeCloseTo(26.231, 2);
+  });
+
+  it('is 0 exactly at an endpoint (d1=0)', () => {
+    expect(fresnelRadiusMeters(1, 915, 0, 10000)).toBe(0);
+  });
+
+  it('is 0 exactly at an endpoint (d2=0)', () => {
+    expect(fresnelRadiusMeters(1, 915, 10000, 0)).toBe(0);
+  });
+
+  it('does not throw / returns 0 for coincident points (d1=d2=0)', () => {
+    expect(fresnelRadiusMeters(1, 915, 0, 0)).toBe(0);
+  });
+
+  it('handles negative distances without producing NaN', () => {
+    expect(Number.isNaN(fresnelRadiusMeters(1, 915, -100, 5000))).toBe(false);
+    expect(fresnelRadiusMeters(1, 915, -100, 5000)).toBe(0);
+  });
+});
+
+describe('earthBulgeMeters', () => {
+  it('matches the locked reference: 33.3km link, default k=4/3', () => {
+    // d1=d2=16650 sums to the 33.3km path
+    expect(earthBulgeMeters(16650, 16650)).toBeCloseTo(16.317, 2);
+  });
+
+  it('matches the locked reference: k=1', () => {
+    expect(earthBulgeMeters(16650, 16650, 1)).toBeCloseTo(21.757, 2);
+  });
+
+  it('is 0 exactly at an endpoint (d1=0)', () => {
+    expect(earthBulgeMeters(0, 33300)).toBe(0);
+  });
+
+  it('is 0 exactly at an endpoint (d2=0)', () => {
+    expect(earthBulgeMeters(33300, 0)).toBe(0);
+  });
+
+  it('a larger k-factor produces a smaller bulge', () => {
+    const bulgeSmallK = earthBulgeMeters(16650, 16650, 1);
+    const bulgeLargeK = earthBulgeMeters(16650, 16650, 4 / 3);
+    expect(bulgeLargeK).toBeLessThan(bulgeSmallK);
+  });
+
+  it('does not throw for negative distances', () => {
+    expect(Number.isNaN(earthBulgeMeters(-100, 5000))).toBe(false);
+    expect(earthBulgeMeters(-100, 5000)).toBe(0);
+  });
+});
+
+describe('computeLinkBudget', () => {
+  it('matches the locked reference values for 33.3km @ 915MHz', () => {
+    const result = computeLinkBudget(33.3, 915, {
+      txPowerDbm: 20,
+      txGainDbi: 2.15,
+      rxGainDbi: 2.15,
+      cableLossDb: 0,
+      rxSensitivityDbm: -129,
+    });
+    expect(result.fsplDb).toBeCloseTo(122.117, 2);
+    expect(result.rxPowerDbm).toBeCloseTo(-97.817, 2);
+    expect(result.marginDb).toBeCloseTo(31.183, 2);
+  });
+
+  it('raising cable loss lowers margin', () => {
+    const base = computeLinkBudget(33.3, 915, {
+      txPowerDbm: 20,
+      txGainDbi: 2.15,
+      rxGainDbi: 2.15,
+      cableLossDb: 0,
+      rxSensitivityDbm: -129,
+    });
+    const withCableLoss = computeLinkBudget(33.3, 915, {
+      txPowerDbm: 20,
+      txGainDbi: 2.15,
+      rxGainDbi: 2.15,
+      cableLossDb: 3,
+      rxSensitivityDbm: -129,
+    });
+    expect(withCableLoss.marginDb).toBeLessThan(base.marginDb);
+    expect(withCableLoss.rxPowerDbm).toBeLessThan(base.rxPowerDbm);
+  });
+
+  it('raising RX sensitivity toward 0 lowers margin', () => {
+    const base = computeLinkBudget(33.3, 915, {
+      txPowerDbm: 20,
+      txGainDbi: 2.15,
+      rxGainDbi: 2.15,
+      cableLossDb: 0,
+      rxSensitivityDbm: -129,
+    });
+    const worseSensitivity = computeLinkBudget(33.3, 915, {
+      txPowerDbm: 20,
+      txGainDbi: 2.15,
+      rxGainDbi: 2.15,
+      cableLossDb: 0,
+      rxSensitivityDbm: -100, // less negative = worse (less sensitive) receiver
+    });
+    expect(worseSensitivity.marginDb).toBeLessThan(base.marginDb);
+  });
+
+  it('handles zero distance without throwing', () => {
+    const result = computeLinkBudget(0, 915, {
+      txPowerDbm: 20,
+      txGainDbi: 2.15,
+      rxGainDbi: 2.15,
+      cableLossDb: 0,
+      rxSensitivityDbm: -129,
+    });
+    expect(result.fsplDb).toBe(0);
+    expect(Number.isFinite(result.rxPowerDbm)).toBe(true);
+    expect(Number.isFinite(result.marginDb)).toBe(true);
+  });
+});

--- a/src/utils/linkBudget.ts
+++ b/src/utils/linkBudget.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure scalar radio-link math for the Terrain Link Profile tool
+ * (Terrain Link Profile epic #4111, Phase 2, WP-A). React/leaflet-free so it
+ * is trivially unit-testable and reusable outside the map UI, mirroring the
+ * style of `src/utils/measureDistance.ts` and `src/utils/greatCircle.ts`.
+ *
+ * Sign conventions (see LINK_PROFILE_TOOL_SPEC.md §0 for the locked reference
+ * values these formulas must reproduce):
+ *   - FSPL is a loss, expressed as a positive dB value that is *subtracted*
+ *     from the transmitted signal to get received power.
+ *   - Antenna/cable gains and losses: TX power, TX gain, and RX gain add;
+ *     cable loss and FSPL subtract.
+ *   - `rxSensitivityDbm` is conventionally negative (e.g. -129 dBm). Margin
+ *     is `rxPowerDbm - rxSensitivityDbm`, so a more negative (better)
+ *     sensitivity increases the margin. Positive margin means the link
+ *     closes.
+ */
+
+/** Speed of light, metres per second. */
+export const SPEED_OF_LIGHT_MPS = 299_792_458;
+
+/** Mean Earth radius, metres. */
+export const EARTH_RADIUS_M = 6_371_000;
+
+/** Standard "4/3 Earth" refraction k-factor used for radio LOS planning. */
+export const DEFAULT_K_FACTOR = 4 / 3;
+
+/**
+ * Wavelength in metres for a frequency given in MHz.
+ * `λ = c / f`, with f converted from MHz to Hz.
+ */
+export function wavelengthMeters(freqMhz: number): number {
+  return SPEED_OF_LIGHT_MPS / (freqMhz * 1_000_000);
+}
+
+/**
+ * nth Fresnel-zone radius (metres) at a point `d1` metres from one endpoint
+ * and `d2` metres from the other (`d1 + d2` = total path length).
+ *
+ * `r_n = sqrt(n * λ * d1 * d2 / (d1 + d2))`.
+ *
+ * Returns 0 at the endpoints themselves (`d1 === 0` or `d2 === 0`), where the
+ * Fresnel zone radius is mathematically zero, and also guards the
+ * `d1 + d2 === 0` degenerate case (coincident points) to avoid a NaN from
+ * division by zero.
+ */
+export function fresnelRadiusMeters(n: number, freqMhz: number, d1M: number, d2M: number): number {
+  if (d1M <= 0 || d2M <= 0) return 0;
+  const total = d1M + d2M;
+  if (total <= 0) return 0;
+  const lambda = wavelengthMeters(freqMhz);
+  return Math.sqrt((n * lambda * d1M * d2M) / total);
+}
+
+/**
+ * Free-space path loss in dB for a link of `distanceKm` at `freqMhz`.
+ * `FSPL(dB) = 20*log10(d_km) + 20*log10(f_MHz) + 32.44`.
+ *
+ * The classic FSPL formula is undefined (log of 0/negative) at zero or
+ * negative distance; callers pass distanceKm === 0 only for a degenerate
+ * (coincident-point) link, so this returns 0 dB loss in that case rather
+ * than -Infinity/NaN. Negative distances are treated as their absolute
+ * value's mirror is not meaningful either — also clamped to 0 dB.
+ */
+export function fsplDb(distanceKm: number, freqMhz: number): number {
+  if (distanceKm <= 0 || freqMhz <= 0) return 0;
+  return 20 * Math.log10(distanceKm) + 20 * Math.log10(freqMhz) + 32.44;
+}
+
+/**
+ * Earth-curvature bulge (metres) at a point `d1` metres from one endpoint and
+ * `d2` metres from the other, for refraction factor `kFactor` (default 4/3)
+ * and Earth radius `earthRadiusM` (default mean Earth radius).
+ *
+ * `bulge = d1 * d2 / (2 * k * R)`. Zero at either endpoint (`d1 === 0` or
+ * `d2 === 0`), consistent with the geometric definition (no rise directly
+ * under either antenna).
+ */
+export function earthBulgeMeters(
+  d1M: number,
+  d2M: number,
+  kFactor: number = DEFAULT_K_FACTOR,
+  earthRadiusM: number = EARTH_RADIUS_M,
+): number {
+  if (d1M <= 0 || d2M <= 0 || kFactor <= 0 || earthRadiusM <= 0) return 0;
+  return (d1M * d2M) / (2 * kFactor * earthRadiusM);
+}
+
+/** Inputs to a full link-budget calculation, independent of path geometry. */
+export interface LinkBudgetInputs {
+  txPowerDbm: number;
+  txGainDbi: number;
+  rxGainDbi: number;
+  /** Total cable/connector loss across both ends, dB (positive). */
+  cableLossDb: number;
+  /** Receiver sensitivity, dBm (conventionally negative). */
+  rxSensitivityDbm: number;
+}
+
+/** Computed link-budget outputs. */
+export interface LinkBudgetResult {
+  fsplDb: number;
+  /** txPower + txGain + rxGain - cableLoss - FSPL. */
+  rxPowerDbm: number;
+  /** rxPower - rxSensitivity. Positive means the link closes. */
+  marginDb: number;
+}
+
+/**
+ * Combine free-space path loss (derived from `distanceKm`/`freqMhz`) with the
+ * budget inputs to get received power and link margin. See module-level
+ * doc comment for the sign conventions.
+ */
+export function computeLinkBudget(
+  distanceKm: number,
+  freqMhz: number,
+  inputs: LinkBudgetInputs,
+): LinkBudgetResult {
+  const loss = fsplDb(distanceKm, freqMhz);
+  const rxPowerDbm =
+    inputs.txPowerDbm + inputs.txGainDbi + inputs.rxGainDbi - inputs.cableLossDb - loss;
+  const marginDb = rxPowerDbm - inputs.rxSensitivityDbm;
+  return { fsplDb: loss, rxPowerDbm, marginDb };
+}

--- a/src/utils/linkProfile.test.ts
+++ b/src/utils/linkProfile.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeLinkProfile } from './linkProfile';
+import { earthBulgeMeters } from './linkBudget';
+import type { ElevationSample } from '../types/elevation';
+
+const FREQ_MHZ = 915;
+
+/** Build a flat 0..totalM path with `count` evenly spaced samples and the given elevation profile. */
+function makeSamples(totalM: number, count: number, elevationAt: (i: number, distanceM: number) => number | null): ElevationSample[] {
+  const samples: ElevationSample[] = [];
+  for (let i = 0; i < count; i++) {
+    const distance = (totalM * i) / (count - 1);
+    samples.push({ distance, lat: 0, lng: i, elevation: elevationAt(i, distance) });
+  }
+  return samples;
+}
+
+describe('analyzeLinkProfile', () => {
+  it('produces one output point per input sample, monotonic distanceKm, totalDistanceKm from last sample', () => {
+    const samples = makeSamples(10000, 11, () => 0);
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(analysis.points).toHaveLength(samples.length);
+    expect(analysis.totalDistanceKm).toBeCloseTo(10, 6);
+    for (let i = 1; i < analysis.points.length; i++) {
+      expect(analysis.points[i].distanceKm).toBeGreaterThanOrEqual(analysis.points[i - 1].distanceKm);
+    }
+  });
+
+  it('classifies a clear link: flat terrain well below LOS, tall masts', () => {
+    // Flat 0m terrain, 10km path, 30m masts both ends (well above the ~28.6m
+    // Fresnel radius at the midpoint) -> minimal Fresnel intrusion.
+    const samples = makeSamples(10000, 11, () => 0);
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 30,
+      antennaHeightAglBM: 30,
+    });
+    expect(analysis.verdict).toBe('clear');
+    expect(analysis.worst).not.toBeNull();
+    expect(analysis.fresnelClearancePct).toBeGreaterThanOrEqual(60);
+  });
+
+  it('classifies a marginal link: LOS clear everywhere but pokes into the Fresnel zone', () => {
+    // Same flat terrain/path, but short 10m masts -> LOS clears the flat
+    // terrain (clearance >= 0) yet the curvature bulge eats deep into the
+    // Fresnel zone at the midpoint (ratio < 0.6).
+    const samples = makeSamples(10000, 11, () => 0);
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(analysis.verdict).toBe('marginal');
+    expect(analysis.worst).not.toBeNull();
+    expect(analysis.worst!.clearanceM).toBeGreaterThanOrEqual(0);
+    expect(analysis.worst!.clearanceRatio).toBeLessThan(0.6);
+  });
+
+  it('classifies an obstructed link: a mid-path hill pokes above the LOS', () => {
+    const samples = makeSamples(10000, 11, (i) => (i === 5 ? 50 : 0));
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(analysis.verdict).toBe('obstructed');
+    expect(analysis.worst).not.toBeNull();
+    expect(analysis.worst!.clearanceM).toBeLessThan(0);
+  });
+
+  it('raising antenna AGL at both endpoints flips an obstructed link to clear', () => {
+    const samples = makeSamples(10000, 11, (i) => (i === 5 ? 50 : 0));
+    const obstructed = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(obstructed.verdict).toBe('obstructed');
+
+    const raised = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 100,
+      antennaHeightAglBM: 100,
+    });
+    expect(raised.verdict).toBe('clear');
+    expect(raised.worst!.clearanceM).toBeGreaterThan(0);
+  });
+
+  it('applies earth-curvature bulge: mid-path effectiveTerrain > raw terrain, and a larger k lowers the bulge', () => {
+    // 33.3km path matching the locked earthBulgeMeters reference fixtures
+    // (d1=d2=16650m at the midpoint).
+    const samples = makeSamples(33300, 3, () => 0);
+
+    const defaultK = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 1,
+      antennaHeightAglBM: 1,
+    });
+    const midDefault = defaultK.points[1];
+    expect(midDefault.terrain).toBe(0);
+    expect(midDefault.effectiveTerrain).not.toBeNull();
+    expect(midDefault.effectiveTerrain!).toBeGreaterThan(midDefault.terrain!);
+    expect(midDefault.effectiveTerrain!).toBeCloseTo(earthBulgeMeters(16650, 16650), 2);
+
+    const kEqualsOne = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 1,
+      antennaHeightAglBM: 1,
+      kFactor: 1,
+    });
+    const midKEqualsOne = kEqualsOne.points[1];
+    expect(midKEqualsOne.effectiveTerrain!).toBeCloseTo(earthBulgeMeters(16650, 16650, 1), 2);
+
+    // Larger k (the default 4/3) produces a smaller bulge than k=1.
+    expect(midDefault.effectiveTerrain!).toBeLessThan(midKEqualsOne.effectiveTerrain!);
+  });
+
+  it('excludes null-elevation samples from worst-case/verdict classification', () => {
+    // A very obstructive hill sits under a null-elevation sample; a much
+    // smaller (non-obstructive) bump sits at another interior sample. The
+    // null sample must not be selected as `worst`, and must not force an
+    // obstructed verdict.
+    const samples = makeSamples(10000, 11, (i) => {
+      if (i === 3) return null; // would otherwise dominate the worst-case
+      if (i === 7) return 5; // small bump, still under a 30m LOS
+      return 0;
+    });
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 30,
+      antennaHeightAglBM: 30,
+    });
+    expect(analysis.worst).not.toBeNull();
+    expect(analysis.worst!.distanceKm).not.toBeCloseTo(samples[3].distance / 1000, 6);
+    expect(analysis.points[3].terrain).toBeNull();
+    expect(analysis.points[3].effectiveTerrain).toBeNull();
+    expect(analysis.points[3].obstructed).toBe(false);
+    expect(Number.isNaN(analysis.fresnelClearancePct)).toBe(false);
+  });
+
+  it('handles an all-null profile without throwing: worst null, verdict clear', () => {
+    const samples = makeSamples(10000, 11, () => null);
+    expect(() => analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    })).not.toThrow();
+
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(analysis.worst).toBeNull();
+    expect(analysis.verdict).toBe('clear');
+    expect(analysis.points).toHaveLength(samples.length);
+    for (const p of analysis.points) {
+      expect(p.terrain).toBeNull();
+      expect(p.effectiveTerrain).toBeNull();
+      expect(p.obstructed).toBe(false);
+    }
+  });
+
+  it('handles an empty sample array without throwing', () => {
+    expect(() => analyzeLinkProfile([], {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    })).not.toThrow();
+    const analysis = analyzeLinkProfile([], {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(analysis.points).toHaveLength(0);
+    expect(analysis.totalDistanceKm).toBe(0);
+    expect(analysis.worst).toBeNull();
+    expect(analysis.verdict).toBe('clear');
+  });
+
+  it('handles zero/negative total distance (coincident endpoints) without NaN', () => {
+    const samples: ElevationSample[] = [
+      { distance: 0, lat: 0, lng: 0, elevation: 0 },
+      { distance: 0, lat: 0, lng: 0, elevation: 0 },
+    ];
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 10,
+      antennaHeightAglBM: 10,
+    });
+    expect(analysis.totalDistanceKm).toBe(0);
+    for (const p of analysis.points) {
+      expect(Number.isNaN(p.los)).toBe(false);
+      expect(Number.isNaN(p.fresnelLower)).toBe(false);
+    }
+  });
+
+  it('applies AGL at the endpoints to compute antennaTopAM/antennaTopBM', () => {
+    const samples = makeSamples(10000, 3, (i) => (i === 0 ? 100 : i === 2 ? 200 : 150));
+    const analysis = analyzeLinkProfile(samples, {
+      freqMhz: FREQ_MHZ,
+      antennaHeightAglAM: 5,
+      antennaHeightAglBM: 15,
+    });
+    expect(analysis.antennaTopAM).toBeCloseTo(105, 6);
+    expect(analysis.antennaTopBM).toBeCloseTo(215, 6);
+  });
+});

--- a/src/utils/linkProfile.ts
+++ b/src/utils/linkProfile.ts
@@ -1,0 +1,183 @@
+/**
+ * Obstruction / clearance analysis over an elevation profile for the Terrain
+ * Link Profile tool (epic #4111, Phase 2, WP-A). Pure and react-free —
+ * consumes the samples already fetched from `POST /api/elevation/profile`
+ * (via `useElevationProfile`) and derives a chart-ready point series plus a
+ * link verdict. No network IO here.
+ *
+ * See `docs/internal/dev-notes/LINK_PROFILE_TOOL_SPEC.md` §0/§2.2 for the
+ * design rationale (terrain + AGL baseline, not node GPS altitude) and the
+ * locked math walkthrough this file implements.
+ */
+import type { MeasurePoint } from './measureDistance';
+import type { ElevationSample } from '../types/elevation';
+import {
+  fresnelRadiusMeters,
+  earthBulgeMeters,
+  DEFAULT_K_FACTOR,
+  EARTH_RADIUS_M,
+} from './linkBudget';
+
+/** A picked endpoint for the Link Profile tool. `isNode=false` = arbitrary map point. */
+export interface LinkEndpoint extends MeasurePoint {
+  isNode: boolean;
+}
+
+// Client mirror of the backend `ProfileSample` (kept in `types/elevation.ts`
+// as the single definition — re-exported here since most consumers of this
+// module reach for the type via `linkProfile.ts`).
+export type { ElevationSample };
+
+export type LinkVerdict = 'clear' | 'marginal' | 'obstructed';
+
+/** Fraction of the first Fresnel zone that must remain clear to call a link "clear" (not just "marginal"). */
+export const DEFAULT_FRESNEL_CLEAR_THRESHOLD = 0.6;
+
+export interface LinkProfileOptions {
+  freqMhz: number;
+  /** AGL antenna height in metres at endpoint A (start of the profile). */
+  antennaHeightAglAM: number;
+  /** AGL antenna height in metres at endpoint B (end of the profile). */
+  antennaHeightAglBM: number;
+  /** Earth-curvature refraction k-factor. Default 4/3. */
+  kFactor?: number;
+  /** Earth radius in metres. Default mean Earth radius. */
+  earthRadiusM?: number;
+  /** Minimum fraction of the first Fresnel zone that must be clear for `verdict:'clear'`. Default 0.6. */
+  fresnelClearThreshold?: number;
+}
+
+/** One chart-ready row for the profile. Elevations in metres, `distanceKm` for the X axis. */
+export interface LinkProfilePoint {
+  distanceKm: number;
+  /** Raw DEM elevation for this sample; null when the DEM had no data. */
+  terrain: number | null;
+  /** terrain + earth-curvature bulge — what LOS clearance is judged against. Null when `terrain` is null. */
+  effectiveTerrain: number | null;
+  /** Straight line between the two antenna tops at this sample's distance. */
+  los: number;
+  /** los - first-Fresnel-zone radius (lower bound of the Fresnel ellipse). */
+  fresnelLower: number;
+  /** true when effectiveTerrain exceeds los at this sample (clearance < 0). Always false when terrain is null. */
+  obstructed: boolean;
+}
+
+export interface LinkProfileAnalysis {
+  points: LinkProfilePoint[];
+  totalDistanceKm: number;
+  verdict: LinkVerdict;
+  /** Tightest interior (non-endpoint, non-null) sample by clearance ratio. Null if no usable interior samples. */
+  worst: { distanceKm: number; clearanceM: number; clearanceRatio: number } | null;
+  /** min(clearance / fresnelRadius) across interior samples, as a percent (may be negative). Infinity when `worst` is null. */
+  fresnelClearancePct: number;
+  /** ground(A) + AGL(A). */
+  antennaTopAM: number;
+  /** ground(B) + AGL(B). */
+  antennaTopBM: number;
+}
+
+/**
+ * Pure geometry/obstruction analysis over already-fetched elevation samples.
+ * Antenna tops = terrain at each endpoint + AGL (node GPS altitude
+ * intentionally not used — see spec §0.1). Earth curvature raises the
+ * effective terrain height toward the straight LOS chord
+ * (`effectiveTerrain = terrain + bulge`).
+ *
+ * Endpoints (first/last sample) and any sample with a null `elevation` are
+ * excluded from the worst-case/verdict classification, but every input
+ * sample still produces one output point (for continuous chart rendering).
+ *
+ * Classification (first match wins):
+ *   'obstructed' — some interior sample has effectiveTerrain > los (clearance < 0)
+ *   'marginal'   — LOS is clear everywhere, but min(clearance/fresnelRadius) < threshold
+ *   'clear'      — min(clearance/fresnelRadius) >= threshold (or no interior samples at all)
+ */
+export function analyzeLinkProfile(
+  samples: ElevationSample[],
+  opts: LinkProfileOptions,
+): LinkProfileAnalysis {
+  const kFactor = opts.kFactor ?? DEFAULT_K_FACTOR;
+  const earthRadiusM = opts.earthRadiusM ?? EARTH_RADIUS_M;
+  const threshold = opts.fresnelClearThreshold ?? DEFAULT_FRESNEL_CLEAR_THRESHOLD;
+
+  if (samples.length === 0) {
+    return {
+      points: [],
+      totalDistanceKm: 0,
+      verdict: 'clear',
+      worst: null,
+      fresnelClearancePct: Infinity,
+      antennaTopAM: opts.antennaHeightAglAM,
+      antennaTopBM: opts.antennaHeightAglBM,
+    };
+  }
+
+  const total = samples[samples.length - 1].distance;
+  const groundA = samples[0].elevation ?? 0;
+  const groundB = samples[samples.length - 1].elevation ?? 0;
+  const antennaTopA = groundA + opts.antennaHeightAglAM;
+  const antennaTopB = groundB + opts.antennaHeightAglBM;
+
+  const lastIndex = samples.length - 1;
+  const points: LinkProfilePoint[] = [];
+  let worst: { distanceKm: number; clearanceM: number; clearanceRatio: number } | null = null;
+  let anyObstructed = false;
+
+  for (let i = 0; i < samples.length; i++) {
+    const sample = samples[i];
+    const d1 = sample.distance;
+    const d2 = total - d1;
+    const frac = total > 0 ? d1 / total : 0;
+
+    const los = antennaTopA + (antennaTopB - antennaTopA) * frac;
+    const bulge = earthBulgeMeters(d1, d2, kFactor, earthRadiusM);
+    const terrain = sample.elevation;
+    const effectiveTerrain = terrain === null ? null : terrain + bulge;
+    const fresnelR = fresnelRadiusMeters(1, opts.freqMhz, d1, d2);
+    const fresnelLower = los - fresnelR;
+
+    const obstructed = effectiveTerrain !== null && effectiveTerrain > los;
+
+    points.push({
+      distanceKm: d1 / 1000,
+      terrain,
+      effectiveTerrain,
+      los,
+      fresnelLower,
+      obstructed,
+    });
+
+    // Interior, non-null samples only feed the worst-case/verdict classification.
+    const isInterior = i > 0 && i < lastIndex;
+    if (isInterior && effectiveTerrain !== null) {
+      const clearanceM = los - effectiveTerrain;
+      const clearanceRatio = fresnelR > 0 ? clearanceM / fresnelR : Number.POSITIVE_INFINITY;
+      if (clearanceM < 0) anyObstructed = true;
+      if (worst === null || clearanceRatio < worst.clearanceRatio) {
+        worst = { distanceKm: d1 / 1000, clearanceM, clearanceRatio };
+      }
+    }
+  }
+
+  let verdict: LinkVerdict;
+  const fresnelClearancePct = worst ? worst.clearanceRatio * 100 : Infinity;
+  if (worst === null) {
+    verdict = 'clear';
+  } else if (anyObstructed) {
+    verdict = 'obstructed';
+  } else if (worst.clearanceRatio < threshold) {
+    verdict = 'marginal';
+  } else {
+    verdict = 'clear';
+  }
+
+  return {
+    points,
+    totalDistanceKm: total / 1000,
+    verdict,
+    worst,
+    fresnelClearancePct,
+    antennaTopAM: antennaTopA,
+    antennaTopBM: antennaTopB,
+  };
+}


### PR DESCRIPTION
## Summary
Phase 2 of the Terrain Link Profile epic (#4111): the user-facing link-planning tool in Map Analysis, consuming Phase 1's elevation API (#4143). A new **Link Profile** toolbar tool lets you pick two points on the map (snap to a node within 24 px, or any arbitrary map point), then a bottom drawer renders the terrain elevation profile with earth-curvature adjustment, the line of sight between antenna tops, the first-Fresnel-zone lower bound, and a full editable link budget (TX power, gains, cable loss, RX sensitivity) with a clear/marginal/obstructed verdict — the same class of output as site.meshtastic.org.

## Changes
- `src/utils/linkBudget.ts` — FSPL, first-Fresnel radius, earth-curvature bulge (k-factor, default 4/3), link-budget margin math with documented sign conventions; unit-tested against independently computed reference values (33.3 km @ 915 MHz → FSPL 122.117 dB, etc.)
- `src/utils/linkProfile.ts` — obstruction/clearance analysis over profile samples (terrain + AGL model; node GPS altitude deliberately ignored to avoid WGS-84 vs orthometric datum mixing); verdict = obstructed (LOS blocked) / marginal (<60% first-Fresnel clear) / clear
- `src/components/MapAnalysis/LinkProfileController.tsx` — two-point picker cloned from MeasureDistanceController (capture-phase click, crosshair, Escape exits); controlled via context so the drawer shares the picked pair; filled ring = snapped node, hollow = arbitrary point
- `src/components/MapAnalysis/LinkProfileDrawer.tsx` — bottom-drawer overlay: recharts ComposedChart (terrain Area, LOS line, Fresnel lower bound, worst-clearance marker), verdict pill + stats (distance, FSPL, RX power, margin, Fresnel clearance %), and a 9-field budget form; edits recompute client-side via useMemo with **zero** elevation refetches
- `MapAnalysisContext/Toolbar/Canvas` — transient `linkProfileMode`/`linkEndpoints` state (mutually exclusive with Measure), toolbar button gated on the public `elevationEnabled` flag, canvas wiring mirroring the Measure tool
- `src/hooks/useElevationProfile.ts` (TanStack query keyed on rounded coords, 30 min stale time) + `useElevationEnabled.ts`; `ApiService.getElevationProfile` (unwraps the `{success,data}` envelope)
- No backend changes; no new dependencies

## Issues Resolved
Relates to #4111 (Phase 2 of 3 — do not close)

## Documentation Updates
Internal dev-notes (epic plan updated with validation results; `LINK_PROFILE_TOOL_SPEC.md` committed). User-facing docs land in Phase 3 per the epic plan.

## Testing
- [x] Unit tests pass — full suite 9,400 passed / 0 failed / 651 skipped (`success: true` via JSON reporter); 82 new tests (math fixtures, hooks, controller, drawer, toolbar)
- [x] TypeScript compiles cleanly; `npm run lint:ci` ratchet OK; production `vite build` succeeds
- [x] Browser-validated on the dev container against **live** Terrarium DEM data: picked two points across Lake Pontchartrain (89.4 km) → drawer showed Obstructed · +22.6 dB margin, FSPL 130.7 dB, RX −106.4 dBm (hand-verified against the FSPL formula); raising antennas to 120 m flipped the verdict to Marginal with no refetch; Escape fully exits (drawer, cursor, toolbar state); no new console errors
- [ ] Reviewer: on Map Analysis, click **Link Profile**, click two nodes → drawer appears with profile chart + verdict; edit any budget field and watch the verdict/stats update instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFBA76hsjqhsXe1BdnYub