### PR TITLE
fix(position): reject precision-obscured Null Island fixes on ingest (#3763)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5990,13 +5990,13 @@ class MeshtasticManager implements ISourceManager {
   /**
    * Validate position coordinates.
    *
-   * When the fix is position-precision obscured (a Meshtastic POSITION_APP fix
-   * carries `precision_bits`), pass `precisionBits` so a re-centered (0,0) fix —
-   * which arrives as `(offset, offset)` and would otherwise clear the Null Island
-   * box — is still rejected (issue #3763 follow-up). Callers without precision
-   * (e.g. the NodeInfo position exchange) omit it, preserving prior behavior.
+   * When the fix is position-precision obscured (both POSITION_APP and NodeInfo
+   * embedded positions carry `precision_bits`), pass `precisionBits` so a
+   * re-centered (0,0) fix — which arrives as `(offset, offset)` and would
+   * otherwise clear the Null Island box — is still rejected (issue #3763
+   * follow-up). Callers without precision omit it, preserving prior behavior.
    */
-  private isValidPosition(latitude: number, longitude: number, precisionBits?: number): boolean {
+  private isValidPosition(latitude: number, longitude: number, precisionBits?: number | null): boolean {
     // Check for valid numbers
     if (typeof latitude !== 'number' || typeof longitude !== 'number') {
       return false;
@@ -8056,15 +8056,20 @@ class MeshtasticManager implements ISourceManager {
           nodeInfo.position.longitudeI
         );
 
+        // Extract position precision if present in NodeInfo's embedded Position.
+        // The protobuf decoder normalizes a missing precision_bits field to 0, so we
+        // treat 0 as "absent" here and leave any existing positionPrecisionBits intact.
+        // We must NOT fall back to the local channel's positionPrecision — that record
+        // reflects this MeshMonitor instance's channel config, not the remote node's,
+        // and was causing every node's accuracy box to track the local node (issue #3030).
+        // Read before validation so the Null Island check can back out the firmware's
+        // precision re-centering offset for an obscured (0,0) fix (issue #3763), matching
+        // the POSITION_APP path — otherwise a true-(0,0) node that only sends NodeInfo
+        // (no POSITION_APP) would slip past the box as (offset, offset).
+        const precisionBits = nodeInfo.position.precisionBits ?? nodeInfo.position.precision_bits;
+
         // Validate coordinates before saving
-        if (this.isValidPosition(coords.latitude, coords.longitude)) {
-          // Extract position precision if present in NodeInfo's embedded Position.
-          // The protobuf decoder normalizes a missing precision_bits field to 0, so we
-          // treat 0 as "absent" here and leave any existing positionPrecisionBits intact.
-          // We must NOT fall back to the local channel's positionPrecision — that record
-          // reflects this MeshMonitor instance's channel config, not the remote node's,
-          // and was causing every node's accuracy box to track the local node (issue #3030).
-          const precisionBits = nodeInfo.position.precisionBits ?? nodeInfo.position.precision_bits;
+        if (this.isValidPosition(coords.latitude, coords.longitude, precisionBits)) {
           const channelIndex = nodeInfo.channel !== undefined ? nodeInfo.channel : 0;
 
           // Guard against precision downgrade (issue #3513): only update lat/lon from NodeInfo

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5988,9 +5988,15 @@ class MeshtasticManager implements ISourceManager {
   }
 
   /**
-   * Validate position coordinates
+   * Validate position coordinates.
+   *
+   * When the fix is position-precision obscured (a Meshtastic POSITION_APP fix
+   * carries `precision_bits`), pass `precisionBits` so a re-centered (0,0) fix —
+   * which arrives as `(offset, offset)` and would otherwise clear the Null Island
+   * box — is still rejected (issue #3763 follow-up). Callers without precision
+   * (e.g. the NodeInfo position exchange) omit it, preserving prior behavior.
    */
-  private isValidPosition(latitude: number, longitude: number): boolean {
+  private isValidPosition(latitude: number, longitude: number, precisionBits?: number): boolean {
     // Check for valid numbers
     if (typeof latitude !== 'number' || typeof longitude !== 'number') {
       return false;
@@ -6014,7 +6020,10 @@ class MeshtasticManager implements ISourceManager {
     // mesh infrastructure there (issue #3763). This gate fronts both the
     // POSITION_APP path and the NodeInfo position exchange, so a bogus (0,0)
     // never reaches the node row or the position-history telemetry.
-    if (isBogusPosition(latitude, longitude)) {
+    // When precisionBits is supplied the check backs out the firmware's
+    // position-precision re-centering offset first, so an obscured (0,0) fix
+    // (which arrives as e.g. (0.0131, 0.0131) at 14 bits) is still caught.
+    if (isBogusPosition(latitude, longitude, precisionBits)) {
       return false;
     }
 
@@ -6078,8 +6087,16 @@ class MeshtasticManager implements ISourceManager {
         // Convert coordinates from integer format to decimal degrees
         const coords = meshtasticProtobufService.convertCoordinates(position.latitudeI, position.longitudeI);
 
+        // precision_bits is set by the sending node's firmware to reflect ITS own channel
+        // precision setting. We must NOT fall back to the local channel's positionPrecision —
+        // that record reflects this MeshMonitor instance's channel config, not the remote
+        // node's, and using it caused accuracy boxes to all match the local node (issue #3030).
+        // It is read here (before validation) so the Null Island check can back out the
+        // firmware's precision re-centering offset for obscured (0,0) fixes (issue #3763).
+        const precisionBits = position.precisionBits ?? position.precision_bits ?? undefined;
+
         // Validate coordinates
-        if (!this.isValidPosition(coords.latitude, coords.longitude)) {
+        if (!this.isValidPosition(coords.latitude, coords.longitude, precisionBits)) {
           logger.warn(`⚠️ Invalid position coordinates: lat=${coords.latitude}, lon=${coords.longitude}. Skipping position update.`);
           return;
         }
@@ -6093,19 +6110,14 @@ class MeshtasticManager implements ISourceManager {
         const packetTimestamp = position.time ? Number(position.time) * 1000 : undefined;
         const packetId = meshPacket.id ? Number(meshPacket.id) : undefined;
 
-        // Extract position precision metadata.
-        // precision_bits is set by the sending node's firmware to reflect ITS own channel
-        // precision setting. We must NOT fall back to the local channel's positionPrecision —
-        // that record reflects this MeshMonitor instance's channel config, not the remote
-        // node's, and using it caused accuracy boxes to all match the local node (issue #3030).
         // Resolve the channel slot from the decryption context — NOT the raw
         // meshPacket.channel, which is the on-wire LoRa hash (e.g. "channel 39")
         // for packets decrypted server-side on a secondary channel (issue #3682).
         // This mirrors the TEXT_MESSAGE_APP path so positions show the same
         // channel as text messages on the same channel. Falls back to the raw
         // meshPacket.channel only for unencrypted/primary packets.
+        // (precisionBits is extracted above, before position validation.)
         const channelIndex = await this.resolveBroadcastChannelIndex(meshPacket, context);
-        const precisionBits = position.precisionBits ?? position.precision_bits ?? undefined;
         const gpsAccuracy = position.gpsAccuracy ?? position.gps_accuracy ?? undefined;
         const hdop = position.HDOP ?? position.hdop ?? undefined;
 

--- a/src/utils/nullIsland.test.ts
+++ b/src/utils/nullIsland.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { isNullIsland, isValidLatLng, isBogusPosition, NULL_ISLAND_EPSILON } from './nullIsland.js';
+import {
+  isNullIsland,
+  isValidLatLng,
+  isBogusPosition,
+  isNullIslandWithPrecision,
+  precisionOffsetDegrees,
+  NULL_ISLAND_EPSILON,
+} from './nullIsland.js';
 
 describe('isNullIsland', () => {
   it('flags exactly (0, 0)', () => {
@@ -83,5 +90,71 @@ describe('isBogusPosition', () => {
     expect(isBogusPosition(null, null)).toBe(false);
     expect(isBogusPosition(26.33, null)).toBe(false);
     expect(isBogusPosition(undefined, -80.27)).toBe(false);
+  });
+
+  it('rejects a position-precision-obscured (0,0) fix only when precisionBits is supplied', () => {
+    // A node truly at (0,0) on a 14-bit-precision channel transmits (offset, offset).
+    const offset14 = precisionOffsetDegrees(14); // 0.0131072°
+    // Without precision context it clears the plain box (regression the fix addresses)...
+    expect(isBogusPosition(offset14, offset14)).toBe(false);
+    // ...but with the sender's precisionBits it is correctly rejected.
+    expect(isBogusPosition(offset14, offset14, 14)).toBe(true);
+  });
+
+  it('still accepts a real position when precisionBits is supplied', () => {
+    expect(isBogusPosition(26.33, -80.27, 14)).toBe(false);
+    expect(isBogusPosition(-33.8688, 151.2093, 10)).toBe(false);
+  });
+});
+
+describe('precisionOffsetDegrees', () => {
+  it('computes 2^(31 - bits) * 1e-7 for obscured precision', () => {
+    expect(precisionOffsetDegrees(16)).toBeCloseTo(0.0032768, 12); // 2^15 * 1e-7
+    expect(precisionOffsetDegrees(14)).toBeCloseTo(0.0131072, 12); // 2^17 * 1e-7 — the ~0.013 reports
+    expect(precisionOffsetDegrees(12)).toBeCloseTo(0.0524288, 12); // 2^19 * 1e-7
+  });
+
+  it('returns 0 for full precision, disabled precision, or unknown values', () => {
+    expect(precisionOffsetDegrees(32)).toBe(0); // full precision
+    expect(precisionOffsetDegrees(0)).toBe(0);  // disabled
+    expect(precisionOffsetDegrees(undefined)).toBe(0);
+    expect(precisionOffsetDegrees(null)).toBe(0);
+    expect(precisionOffsetDegrees(NaN)).toBe(0);
+  });
+});
+
+describe('isNullIslandWithPrecision', () => {
+  it('rejects a true-(0,0) fix re-centered by any obscured precision level', () => {
+    // For a masked origin of 0, the received coordinate is exactly the offset.
+    for (const bits of [16, 15, 14, 13, 12, 11, 10]) {
+      const offset = precisionOffsetDegrees(bits);
+      expect(isNullIslandWithPrecision(offset, offset, bits)).toBe(true);
+    }
+  });
+
+  it('handles the realistic decoded coordinate (latitudeI/1e7), not just the exact offset', () => {
+    // latitudeI = longitudeI = 2^17 for a true-(0,0) node at 14-bit precision.
+    const decoded = 131072 / 1e7; // how meshtasticProtobufService.convertCoordinates yields it
+    expect(isNullIslandWithPrecision(decoded, decoded, 14)).toBe(true);
+  });
+
+  it('is identical to the plain box when precision is undefined / full / disabled', () => {
+    expect(isNullIslandWithPrecision(0, 0, undefined)).toBe(true);
+    expect(isNullIslandWithPrecision(0.0131072, 0.0131072, undefined)).toBe(false);
+    expect(isNullIslandWithPrecision(0.0131072, 0.0131072, 32)).toBe(false); // full precision, no offset
+    expect(isNullIslandWithPrecision(0.0131072, 0.0131072, 0)).toBe(false);  // disabled, no offset
+  });
+
+  it('never flags a real position after backing out the (small) offset', () => {
+    expect(isNullIslandWithPrecision(37.7749, -122.4194, 14)).toBe(false); // San Francisco
+    expect(isNullIslandWithPrecision(51.4778, 0.0001, 14)).toBe(false);    // Greenwich, real lat
+    // Coarsest offset is ~0.21° (10 bits) — still nowhere near a populated coordinate.
+    expect(isNullIslandWithPrecision(1.0, 1.0, 10)).toBe(false);
+  });
+
+  it('returns false for missing / non-finite coordinates', () => {
+    expect(isNullIslandWithPrecision(null, 0, 14)).toBe(false);
+    expect(isNullIslandWithPrecision(0, undefined, 14)).toBe(false);
+    expect(isNullIslandWithPrecision(NaN, 0, 14)).toBe(false);
   });
 });

--- a/src/utils/nullIsland.test.ts
+++ b/src/utils/nullIsland.test.ts
@@ -145,6 +145,15 @@ describe('isNullIslandWithPrecision', () => {
     expect(isNullIslandWithPrecision(0.0131072, 0.0131072, 0)).toBe(false);  // disabled, no offset
   });
 
+  it('does not flag when only one axis sits at the offset (defensive — firmware cannot emit this)', () => {
+    // Meshtastic applies the same precision to both axes, so an asymmetric offset
+    // can't occur on the wire; asserting it documents that a single near-origin axis
+    // is not Null Island (the other axis is a real, far-from-zero coordinate).
+    const offset14 = precisionOffsetDegrees(14);
+    expect(isNullIslandWithPrecision(offset14, 20, 14)).toBe(false);
+    expect(isNullIslandWithPrecision(20, offset14, 14)).toBe(false);
+  });
+
   it('never flags a real position after backing out the (small) offset', () => {
     expect(isNullIslandWithPrecision(37.7749, -122.4194, 14)).toBe(false); // San Francisco
     expect(isNullIslandWithPrecision(51.4778, 0.0001, 14)).toBe(false);    // Greenwich, real lat

--- a/src/utils/nullIsland.ts
+++ b/src/utils/nullIsland.ts
@@ -35,6 +35,49 @@ export function isNullIsland(
 }
 
 /**
+ * The additive re-centering offset, in degrees, that Meshtastic firmware applies
+ * to an obscured position when the channel has a reduced "position precision".
+ * The firmware masks the low bits and re-centers the fix to its cell:
+ * `latitudeI = (latitudeI & mask) + 2^(31 - precisionBits)`. So the offset is
+ * `2^(31 - precisionBits) * 1e-7` degrees.
+ *
+ * Returns 0 for full precision (`>= 32` bits), disabled/zero precision, or an
+ * unknown/non-finite value, so callers can subtract it unconditionally.
+ */
+export function precisionOffsetDegrees(precisionBits: number | null | undefined): number {
+  if (precisionBits == null || !Number.isFinite(precisionBits)) return 0;
+  // Only 1..31 bits are "obscured"; 0 (disabled) and >=32 (full) carry no offset.
+  if (precisionBits <= 0 || precisionBits >= 32) return 0;
+  return Math.pow(2, 31 - precisionBits) * 1e-7;
+}
+
+/**
+ * {@link isNullIsland}, but aware of Meshtastic position-precision obscuring
+ * (issue #3763 follow-up). A node truly at (0, 0) whose channel uses reduced
+ * precision does NOT transmit (0, 0): the firmware re-centers it to the cell
+ * center, so it arrives as `(offset, offset)` where `offset =
+ * 2^(31 - precisionBits) * 1e-7` — e.g. 0.0131° at 14 bits, which sails past
+ * {@link NULL_ISLAND_EPSILON} and defeats the plain box check.
+ *
+ * We back the firmware offset out of the received coordinate before applying the
+ * box, recovering the masked cell ORIGIN (exactly 0 for a true-(0,0) fix, at any
+ * precision level). With undefined/full/disabled precision `offset` is 0 and this
+ * is identical to {@link isNullIsland}. Subtracting a ≤0.21° offset can only pull
+ * coordinates already adjacent to Null Island's open-ocean cell into the box, so
+ * no real node is affected.
+ */
+export function isNullIslandWithPrecision(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+  precisionBits: number | null | undefined,
+): boolean {
+  if (latitude == null || longitude == null) return false;
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return false;
+  const offset = precisionOffsetDegrees(precisionBits);
+  return isNullIsland(latitude - offset, longitude - offset);
+}
+
+/**
  * True when a coordinate pair is a geographically valid WGS-84 point: both
  * values are finite and within range (latitude ∈ [-90, 90], longitude ∈
  * [-180, 180]). Null/undefined inputs are NOT valid (there is no position).
@@ -59,6 +102,13 @@ export function isValidLatLng(
  * (see {@link isNullIsland}). This is the canonical "trim invalid positions"
  * predicate — a strict superset of {@link isNullIsland}.
  *
+ * Pass the sender's `precisionBits` when it is known (e.g. a Meshtastic
+ * POSITION_APP fix carries `precision_bits`) so a position-precision-obscured
+ * (0, 0) fix — which arrives re-centered as `(offset, offset)` and would slip
+ * past the plain Null Island box — is still rejected. See
+ * {@link isNullIslandWithPrecision}. Omitting it preserves the exact prior
+ * behavior (offset 0).
+ *
  * Null/undefined inputs return `false` (there is simply no position to reject —
  * callers handle "missing" separately, exactly as {@link isNullIsland} does),
  * so `!isBogusPosition(lat, lng)` alone does not assert a position exists.
@@ -66,7 +116,8 @@ export function isValidLatLng(
 export function isBogusPosition(
   latitude: number | null | undefined,
   longitude: number | null | undefined,
+  precisionBits?: number | null | undefined,
 ): boolean {
   if (latitude == null || longitude == null) return false;
-  return !isValidLatLng(latitude, longitude) || isNullIsland(latitude, longitude);
+  return !isValidLatLng(latitude, longitude) || isNullIslandWithPrecision(latitude, longitude, precisionBits);
 }

--- a/src/utils/nullIsland.ts
+++ b/src/utils/nullIsland.ts
@@ -73,6 +73,10 @@ export function isNullIslandWithPrecision(
 ): boolean {
   if (latitude == null || longitude == null) return false;
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return false;
+  // The firmware masks/re-centers latitudeI and longitudeI independently with the
+  // SAME precisionBits, so both axes carry the identical offset — subtract it from
+  // each. (An asymmetric offset can't occur on the wire; if it somehow did, only a
+  // coordinate near BOTH recovered origins would flag, which is the intended box.)
   const offset = precisionOffsetDegrees(precisionBits);
   return isNullIsland(latitude - offset, longitude - offset);
 }


### PR DESCRIPTION
## Problem

Users reported bogus nodes appearing near Null Island at coordinates like **~0.013, 0.013** — just outside the `NULL_ISLAND_EPSILON = 0.01` reject box.

Root cause: a Meshtastic node truly at (0,0) whose channel uses a reduced **position precision** does not transmit (0,0). The sending firmware masks the low bits and re-centers the fix to its cell center:

```
latitudeI = (latitudeI & mask) + 2^(31 - precisionBits)
```

So a true-(0,0) fix arrives as `(offset, offset)` where `offset = 2^(31 - precisionBits) × 1e-7` degrees:

| precisionBits | offset (°) | caught by 0.01 box? |
|---|---|---|
| 16 | 0.00328 | ✅ |
| 15 | 0.00655 | ✅ |
| **14** | **0.01311** | ❌ ← the ~0.013 reports |
| 13 | 0.02621 | ❌ |
| 12 | 0.05243 | ❌ |
| 11 | 0.10486 | ❌ |

MeshMonitor's ingest does a bare `latitudeI / 1e7` and runs the Null Island box on the raw offset coordinate, so anything ≥14-bit-obscured slips through.

## Fix

Rather than widen the epsilon (which still leaks at 11-bit and coarser, and would grow the reject box for **every** node), **back the firmware offset out** of the received coordinate before the box check — recovering the masked cell origin, which is exactly `0` for a true-(0,0) fix at **any** precision level.

- `src/utils/nullIsland.ts`:
  - `precisionOffsetDegrees(precisionBits)` — the firmware offset; `0` for full (`≥32`), disabled (`0`), or unknown precision (safe to subtract unconditionally).
  - `isNullIslandWithPrecision(lat, lon, precisionBits)` — subtracts the offset, then applies the existing 0.01° box.
  - `isBogusPosition(lat, lon, precisionBits?)` — new **optional** third arg; all existing 2-arg callers are unchanged (offset 0).
- `src/server/meshtasticManager.ts` — the POSITION_APP ingest reads `precision_bits` before validation and threads it through `isValidPosition` → `isBogusPosition`.

### Why this over bumping the epsilon
- Catches obscured (0,0) at **every** precision level, not just 12–14.
- **Zero widening** for full-precision nodes — box stays 0.01° for everyone else.
- Only false-positives a real node inside Null Island's own origin cell — empty Gulf of Guinea open ocean.

## Scope
- MeshCore and MQTT position ingestion are unaffected: MQTT uses a geo-bbox filter (`classifyPosition`), not the null-island gate.
- Migration 107 already purged historical (0,0) rows; this only affects new ingestion. Existing near-(0,0) rows age out / get overwritten.

## Tests
- New coverage in `nullIsland.test.ts`: offset math, all obscured precision levels (16→10 bits), the realistic `latitudeI/1e7` decode path, undefined/full/disabled no-op cases, and real-position safety.
- Verified: 6 null-island-dependent suites (analysis, migrations 107/116, ownNodePositions, nodeHelpers, tracerouteSegments) — **237 pass, 0 fail**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1