### PR TITLE
fix(mqtt): guard MQTT POSITION ingestion against Null Island fixes (#3763)

### DIFF
--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -403,11 +403,14 @@ describe('ingestServiceEnvelope — POSITION Null Island guard (#3763)', () => {
     });
     expect(result.ingested).toBe(true);
     expect(databaseService.upsertNodeAsync).toHaveBeenCalledTimes(1);
-    // lastHeard still refreshes, but the (0,0) coords are dropped so upsertNode's
-    // `?? existing` merge preserves any previously stored good position.
+    // lastHeard still refreshes (node was heard), but the (0,0) coords AND
+    // altitude are dropped so upsertNode's `?? existing` merge preserves any
+    // previously stored good position.
     const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.lastHeard).toBeDefined();
     expect(arg.latitude).toBeUndefined();
     expect(arg.longitude).toBeUndefined();
+    expect(arg.altitude).toBeUndefined(); // even though the payload carried altitude: 0
   });
 
   it('strips a precision-obscured (0,0) fix that arrives re-centered as (offset, offset)', async () => {

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -382,6 +382,76 @@ describe('ingestServiceEnvelope — POSITION geo evaluation', () => {
   });
 });
 
+describe('ingestServiceEnvelope — POSITION Null Island guard (#3763)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    (databaseService.ignoredNodes.addGeoIgnoreAsync as any).mockResolvedValue(true);
+    (databaseService.ignoredNodes.liftGeoIgnoreAsync as any).mockResolvedValue(true);
+  });
+
+  const positionOnce = async (pos: Record<string, unknown>) => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => pos);
+  };
+
+  it('strips a Null Island (0,0) fix but still refreshes the node (no geo filter → no-geo path)', async () => {
+    await positionOnce({ latitudeI: 0, longitudeI: 0, altitude: 0 });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.upsertNodeAsync).toHaveBeenCalledTimes(1);
+    // lastHeard still refreshes, but the (0,0) coords are dropped so upsertNode's
+    // `?? existing` merge preserves any previously stored good position.
+    const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.latitude).toBeUndefined();
+    expect(arg.longitude).toBeUndefined();
+  });
+
+  it('strips a precision-obscured (0,0) fix that arrives re-centered as (offset, offset)', async () => {
+    // A true-(0,0) node on a 14-bit-precision channel transmits latitudeI = longitudeI = 2^17.
+    await positionOnce({ latitudeI: 131072, longitudeI: 131072, precisionBits: 14 });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.latitude).toBeUndefined();
+    expect(arg.longitude).toBeUndefined();
+  });
+
+  it('strips (0,0) even when it falls INSIDE a configured bbox spanning the origin (geo-filter gap)', async () => {
+    // The geo-bbox classifier would pass (0,0) as 'in' here — the Null Island
+    // guard is what actually rejects it.
+    await positionOnce({ latitudeI: 0, longitudeI: 0 });
+    const filter = new MqttPacketFilter({ geo: { minLat: -1, maxLat: 1, minLng: -1, maxLng: 1 } });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+      filter,
+    });
+    expect(result.ingested).toBe(true);
+    const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.latitude).toBeUndefined();
+    expect(arg.longitude).toBeUndefined();
+  });
+
+  it('stores a legitimate position unchanged (guard does not over-reject)', async () => {
+    // Default POSITION mock: latitudeI 437_000_000 / lngI -793_000_000 → (43.7, -79.3).
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.latitude).toBeCloseTo(43.7, 5);
+    expect(arg.longitude).toBeCloseTo(-79.3, 5);
+  });
+});
+
 describe('ingestServiceEnvelope — TEXT_MESSAGE_APP tapbacks', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -92,6 +92,7 @@ import { calculateDistance } from '../utils/distance.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
+import { isBogusPosition } from '../utils/nullIsland.js';
 import { logger } from '../utils/logger.js';
 import {
   nodeNumToId,
@@ -347,6 +348,22 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
       const latI = position.latitudeI ?? position.latitude_i;
       const lngI = position.longitudeI ?? position.longitude_i;
       const alt = position.altitude;
+      const lat = typeof latI === 'number' ? latI / 1e7 : undefined;
+      const lng = typeof lngI === 'number' ? lngI / 1e7 : undefined;
+      // Reject bogus fixes before they reach the node row — Null Island (0,0),
+      // a position-precision-obscured (0,0) that arrives re-centered as
+      // (offset, offset), and out-of-range junk (issue #3763). The geo-bbox
+      // classifier above does NOT catch these: with no bbox configured ('no-geo')
+      // or a bbox spanning the equator/prime meridian, (0,0) sails through. MQTT
+      // relays Meshtastic packets, so pass the sender's precision_bits to enable
+      // the de-offset in isBogusPosition. A bogus fix still refreshes lastHeard;
+      // undefined lat/lon is preserved by upsertNode's `?? existing` merge, so it
+      // never overwrites a previously stored good position with garbage.
+      const precisionBits = position.precisionBits ?? position.precision_bits ?? undefined;
+      const positionIsBogus = isBogusPosition(lat ?? null, lng ?? null, precisionBits);
+      if (positionIsBogus) {
+        logger.debug(`MQTT: dropping bogus position (${lat}, ${lng}) precisionBits=${precisionBits} from ${fromNodeId}`);
+      }
       const node: Partial<DbNode> = {
         nodeNum: fromNum,
         nodeId: fromNodeId,
@@ -359,8 +376,8 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
         // CHANNEL_DB_OFFSET-encoded virtual-channel id for the map
         // filter to honor Virtual Channel Permissions.
         channel: effectiveChannel,
-        latitude: typeof latI === 'number' ? latI / 1e7 : undefined,
-        longitude: typeof lngI === 'number' ? lngI / 1e7 : undefined,
+        latitude: positionIsBogus ? undefined : lat,
+        longitude: positionIsBogus ? undefined : lng,
         altitude: typeof alt === 'number' ? alt : undefined,
         viaMqtt: true,
         transportMechanism: TransportMechanism.MQTT,

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -360,7 +360,7 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
       // undefined lat/lon is preserved by upsertNode's `?? existing` merge, so it
       // never overwrites a previously stored good position with garbage.
       const precisionBits = position.precisionBits ?? position.precision_bits ?? undefined;
-      const positionIsBogus = isBogusPosition(lat ?? null, lng ?? null, precisionBits);
+      const positionIsBogus = isBogusPosition(lat, lng, precisionBits);
       if (positionIsBogus) {
         logger.debug(`MQTT: dropping bogus position (${lat}, ${lng}) precisionBits=${precisionBits} from ${fromNodeId}`);
       }
@@ -378,7 +378,9 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
         channel: effectiveChannel,
         latitude: positionIsBogus ? undefined : lat,
         longitude: positionIsBogus ? undefined : lng,
-        altitude: typeof alt === 'number' ? alt : undefined,
+        // Drop altitude too on a bogus fix — an altitude with no trustworthy
+        // horizontal position is not worth persisting.
+        altitude: positionIsBogus ? undefined : (typeof alt === 'number' ? alt : undefined),
         viaMqtt: true,
         transportMechanism: TransportMechanism.MQTT,
         lastHeard: lastHeardSec,


### PR DESCRIPTION
## Problem

Follow-up to #4149. That PR fixed precision-obscured Null Island fixes on the **Meshtastic** ingest path, but investigation of the MeshCore/MQTT coverage surfaced that **MQTT POSITION_APP ingestion has no Null Island guard at all**.

`mqttIngestion.ts` applied only the geo-bbox classifier (`classifyPosition`) and never `isBogusPosition`. So a `(0,0)` fix — or a position-precision-obscured `(0,0)` that arrives re-centered as `(offset, offset)` — was written straight to the `nodes` table (via the unguarded `NodesRepository.upsertNode`) whenever:

- no bbox is configured (the default `'no-geo'` path), or
- the configured bbox spans the equator/prime meridian, so `(0,0)` classifies as `'in'`.

This was the one runtime ingest path lacking the guard the Meshtastic and MeshCore paths already have. (Migration 107 already purged historical rows, but nothing stopped new ones.)

## Fix

Add `isBogusPosition(lat, lon, precisionBits)` before the node upsert in the POSITION_APP case. Since MQTT relays Meshtastic packets, `precision_bits` is threaded through to enable the de-offset added in #4149.

- A bogus fix **still refreshes `lastHeard`** (the node was heard), but its coordinates are set to `undefined` so `upsertNode`'s `?? existing` merge never overwrites a previously stored good position with garbage — mirroring the MeshCore choke-point behavior.

## Coverage matrix (after this PR)

| Source | One-time purge (mig. 107) | Runtime ingest guard |
|---|---|---|
| Meshtastic | ✅ | ✅ (#4149, precision-aware) |
| MeshCore | ✅ | ✅ (`meshcore.ts` upsert choke point) |
| **MQTT** | ✅ | ✅ **(this PR, precision-aware)** |

## Tests

New `POSITION Null Island guard` block in `mqttIngestion.test.ts`:
- strips plain `(0,0)` (no-geo path), asserting `lastHeard` still refreshes but lat/lon are dropped
- strips a precision-obscured `(0,0)` at 14 bits (`latitudeI = longitudeI = 2^17`)
- strips `(0,0)` even when it falls **inside** a configured origin-spanning bbox — the case the geo-filter passes
- leaves a legitimate position untouched (no over-rejection)

Verified: MQTT ingestion suites **111 pass, 0 fail** (`success=true`); server `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1