### PR TITLE
feat(link-profile): auto-frequency, verdict coloring, DEM-void fix, settings UI + docs (#4111 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to MeshMonitor will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Map Analysis: Terrain Link Profile tool** — pick two points (nodes or arbitrary map locations) to get a terrain elevation profile, line-of-sight, and Fresnel-zone chart, plus a full RF link budget (FSPL, antenna gains/heights, cable loss, RX sensitivity) with a clear/marginal/obstructed verdict, comparable to site.meshtastic.org's link-planning view. Frequency and RX sensitivity auto-fill per source (Meshtastic region/modem-preset, MeshCore radio config) with a "from &lt;source&gt;" provenance hint, always overridable by hand; the picked link on the map recolors to match the verdict once computed. (#4111, #4143, #4147)
+- **Elevation source settings** — a new admin-only **Elevation / Terrain** settings section enables/disables the Link Profile tool's terrain data and lets you point it at a custom DEM source (tile-template or Open-Topo-Data-compatible JSON API), with a Test button reporting the detected source type, sample elevation, and latency. Defaults to the public AWS Terrarium (SRTM-derived) tile set; all fetches happen server-side through the existing SSRF-guarded outbound path. (#4111)
+
+### Fixed
+- **Map Analysis: implausible DEM elevation values no longer distort the Link Profile chart** — open-water/void artifacts in some elevation tile sources (observed as extreme negative spikes, e.g. −12000 m over Lake Pontchartrain) are now discarded server-side instead of blowing out the chart's vertical scale. (#4111)
+
 ## [4.13.0] - 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ MeshMonitor supports multiple deployment methods:
 - **Real-time Mesh Monitoring** - Live node discovery, telemetry, and message tracking across every connected source
 - **Modern UI** - Catppuccin theme with message reactions and threading
 - **Interactive Maps** - Unified node positions and network topology visualization across all sources
+- **Terrain Link Profile** - Two-point terrain elevation, line-of-sight, and Fresnel-zone link-budget planning tool in Map Analysis, with per-source frequency/RX-sensitivity auto-detection and a configurable DEM source
 - **Multi-Database Support** - SQLite (default), PostgreSQL, and MySQL via Drizzle ORM
 - **Notifications** - Web Push and Apprise integration for 100+ services, with inactive-node and low-battery alerts
 - **Automation** - Autoresponders, scheduled announcements, timers, and geofence triggers with rich message templates, plus an airtime-utilization cutoff that automatically pauses bot traffic when the mesh is busy

--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -157,6 +157,73 @@ Tints node markers by hop count from each source's local node. Adjacent (0-hop) 
 
 Drops a colored dot at each position fix, colored by the SNR recorded for that packet. Distinct from trails: trails show *where* a node went, SNR overlay shows *how well it was heard* at each point.
 
+## Terrain Link Profile
+
+The **Link Profile** tool answers a different question than the layers above: *would a link between these two specific points actually close?* Pick two points — nodes or arbitrary spots on the map — and it fetches a terrain elevation profile between them, renders a line-of-sight/Fresnel-zone chart, and computes a full RF link budget with a clear/marginal/obstructed verdict. It's comparable to [site.meshtastic.org](https://site.meshtastic.org)'s link-planning view, but source-agnostic (works for both Meshtastic and MeshCore nodes) and driven by your own map data.
+
+### Availability
+
+The **Link Profile** toolbar button only appears when your server administrator has enabled terrain elevation (see [Elevation / Terrain settings](/features/settings#elevation-terrain-link-profile)). It's disabled (grayed out) until at least two positioned nodes exist on the map, for the same reason the Measure tool is — though the picker itself accepts arbitrary map points too, once it's active.
+
+### Picking two points
+
+1. Click **Link Profile** in the toolbar. The cursor becomes a crosshair and any active Measure session is cancelled (the two tools are mutually exclusive).
+2. Click a point on the map:
+   - Clicking within about 24 pixels of a node marker **snaps** to that node — its live position, source, and radio identity are captured for auto-frequency detection (see below).
+   - Clicking anywhere else drops an **arbitrary point** at the exact clicked coordinates, with a hollow marker ring instead of a filled one.
+3. Click a second point the same way. The two points are connected by a line on the map and the profile drawer slides up from the bottom.
+4. Clicking a third time restarts the pick from a new first point (A), so you can explore several links without reopening the tool.
+5. Press **Escape** at any point to clear the current pick and exit the tool.
+
+### Reading the drawer
+
+The bottom drawer has two halves:
+
+- **Chart** — a terrain profile plotted against distance: a filled brown area for the DEM terrain (adjusted for Earth curvature), a green line-of-sight (LOS) line between the two antenna tops (dashed where the path is obstructed), and an amber dashed line marking the lower bound of the first Fresnel zone. The tightest clearance point along the path is marked with a colored dot matching the verdict.
+- **Stats + inputs** — a verdict pill (**Clear** / **Marginal** / **Obstructed**) with the computed link margin in dB, a stat list (distance, frequency, FSPL, RX power, margin, Fresnel clearance %), and the editable link-budget inputs described below.
+
+The **verdict** is computed from Fresnel-zone clearance along the path:
+
+| Verdict | Meaning |
+| --- | --- |
+| **Clear** | At least 60% of the first Fresnel zone is unobstructed everywhere along the path. |
+| **Marginal** | Line of sight is unobstructed, but less than 60% of the first Fresnel zone is clear at the tightest point. |
+| **Obstructed** | Terrain (plus Earth-curvature bulge) crosses the direct line-of-sight line somewhere along the path. |
+
+Once a verdict is available, the connecting line on the map itself recolors to match (green/amber/red) — so you can see the result without having the drawer's chart in view. It reverts to a neutral amber while no verdict is available yet (still loading, or the pair was just cleared).
+
+### Link budget inputs
+
+Nine inputs drive the analysis; editing any of them recomputes instantly with no refetch (only the terrain samples require a network round-trip — everything else is client-side math):
+
+| Input | Default | Notes |
+| --- | --- | --- |
+| Frequency | 915 MHz | Auto-fills from the picked node's radio config when available (see below) |
+| Antenna height AGL (A and B) | 2 m | Above-ground-level height at each endpoint; node GPS altitude is intentionally **not** used (see [Limitations](#limitations-v1)) |
+| TX power | 20 dBm | |
+| TX / RX antenna gain | 2.15 dBi each | Standard dipole reference gain |
+| Cable loss | 0 dB | |
+| RX sensitivity | −129 dBm | Auto-fills from the picked node's modem preset when known (see below) |
+| Earth k-factor | 4/3 | Standard atmospheric-refraction curvature factor |
+
+**Per-source auto-detection:** when one of your picked points snapped to a node, the tool looks up that node's source and auto-fills:
+
+- **Frequency** — the source's configured center frequency (derived from the Meshtastic region + channel + modem preset, or the MeshCore radio's configured frequency), shown with a small provenance hint like *"from Home Base (US)"* under the field.
+- **RX sensitivity** — for Meshtastic sources with a known modem preset, computed from the standard LoRa link-budget formula (`S = -174 + 10·log10(BW) + noise figure + SNR floor for the preset's spreading factor`) rather than a hardcoded table.
+
+If both points are arbitrary (non-node) locations, or the source doesn't expose radio config, the fields keep their 915 MHz / −129 dBm defaults. **Manual edits always win** — once you type into a field, auto-fill stops touching it for that endpoint pair. Picking a *new* pair resets that and re-seeds from the new pair's source, if any.
+
+### Graceful degradation
+
+- **Open water or a DEM gap** — if every sample along the path has no elevation data, the drawer shows "No terrain data for this path" instead of a broken chart.
+- **Same point picked twice, a path over 500 km, or invalid coordinates** — the drawer shows a plain-language message instead of a raw error.
+- **Elevation disabled server-side** — the drawer explains that terrain elevation is turned off, rather than failing silently.
+- **Antimeridian-crossing links** (e.g. one endpoint near +179° longitude, the other near −179°) draw the short way across the map instead of wrapping all the way around.
+
+### Limitations
+
+The terrain data (SRTM-derived, roughly 90 m per pixel) is a bare-earth elevation model — it does **not** account for buildings, trees, or other vegetation, so a "Clear" verdict is a first-pass estimate of geometric line-of-sight, not a guarantee of a working RF link. Node GPS altitude is not factored into antenna height; only the DEM terrain height plus your entered AGL value is used.
+
 ## Time slider
 
 The slider appears bottom-center when enabled. It has two handles defining a `[start, end]` window inside the loaded lookback range. Movement is purely client-side — no refetch — and applies only to time-bounded layers (trails, heatmap, SNR overlay, traceroutes, neighbors). Markers, rings, and hop shading always reflect the current state.

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -425,6 +425,26 @@ Description: Offline OpenStreetMap tiles via TileServer GL
 
 **Learn More**: See [Custom Tile Servers](/configuration/custom-tile-servers) for detailed setup instructions, TileServer GL integration, and troubleshooting.
 
+## Elevation / Terrain (Link Profile) {#elevation-terrain-link-profile}
+
+**Description**: Controls the digital elevation model (DEM) source that powers the [Map Analysis Link Profile tool](/features/map-analysis#terrain-link-profile) — the two-point terrain/line-of-sight/Fresnel-zone link-planning tool. Admin-only settings; visible under **Settings → Elevation / Terrain**.
+
+**Fields**:
+- **Enable terrain elevation** — turns the Link Profile tool's terrain chart on or off. When disabled, the toolbar button disappears from Map Analysis for every user and any in-flight request returns an explicit "disabled" message rather than failing silently. Enabled by default.
+- **Elevation Source URL** — an optional custom DEM source. Leave empty to use the default: the public AWS/Mapzen "Terrarium" tile set (`elevation-tiles-prod.s3.amazonaws.com`), a free, no-API-key, SRTM-derived dataset. Treated as a server-side secret (like the Apprise API Server URL) — it's never sent to the browser except back to an admin who already has `settings:write`, since it may embed an API key.
+
+**Source auto-detection**: the URL you enter is auto-detected as one of two shapes:
+- A **tile-template** URL containing `{z}`, `{x}`, and `{y}` placeholders — sampled and decoded the same way as the default Terrarium source.
+- An **[Open-Topo-Data](https://www.opentopodata.org/)-compatible JSON** point API — queried in batches instead of tiles.
+
+**Test button**: probes the configured URL server-side and reports the detected source type, a sample elevation (queried near Mount Everest's summit by default, to distinguish a working provider from a source that just returns 0 for everything), and the round-trip latency — without needing to pick two points on the map first.
+
+**Notes**:
+- All elevation fetches happen **server-side** through the same SSRF-guarded outbound-request path used elsewhere in MeshMonitor — the browser never talks to the DEM source directly, and a custom source URL can't be used to probe your internal network.
+- Elevation data is source-agnostic: it isn't tied to any particular Meshtastic/MeshCore/MQTT source, so this is a single server-wide setting, not a per-source one.
+- Implausible DEM samples (below −500 m or above 9000 m — an artifact of open-water/void pixels in some tile sets, not real terrain) are discarded server-side and shown as gaps in the Link Profile chart rather than distorting it.
+- The `POST /api/elevation/profile` endpoint used by the tool is public (unauthenticated) but rate-limited to 20 requests/minute per IP in production (requests from private/internal IPs are exempt); the Test button's endpoint requires `settings:write`.
+
 ## Display Preferences
 
 ### Default Landing Page {#default-landing-page}

--- a/docs/internal/dev-notes/LINK_PROFILE_POLISH_SPEC.md
+++ b/docs/internal/dev-notes/LINK_PROFILE_POLISH_SPEC.md
@@ -1,0 +1,462 @@
+# Link Profile Polish — Implementation Spec (Terrain Link Profile Epic #4111, Phase 3, final)
+
+**Branch:** `feature/link-profile-polish` (worktree `../meshmonitor-link-profile-polish`, based on `origin/main` incl. Phases 1+2 — merged PRs #4143 elevation backend + #4147 link-profile tool).
+
+**Scope:** Frontend polish + one minimal, additive, non-secret backend field. Per-source frequency + RX-sensitivity auto-detection, DEM void handling, edge-case UX, map path verdict coloring, elevation-source settings UI, and user docs.
+
+**Exit criteria (from epic):** frequency auto-populates per source; graceful degradation on missing data; docs published; full Vitest suite green; `npm run lint:ci` exits 0; merged.
+
+---
+
+## 0. Key decisions (read first)
+
+1. **Auto-frequency mechanism = one minimal public backend field, not per-endpoint gated fetches.**
+   The Map Analysis page is anonymous/public. The only per-source radio config reachable today is
+   permission-gated: `GET /api/config/current` requires `configuration:read` (server.ts:4243) and
+   `GET /api/sources/:id/meshcore/status` requires `connection:read` (meshcoreRoutes.ts:314). Neither
+   is readable anonymously, and MeshCore has **no** ApiService client method at all. Rather than wire
+   two divergent gated fetches (one needing a brand-new MeshCore client method) and accept "anonymous
+   users never get auto-freq", we add **one additive, non-secret `radio` summary field to the already
+   public `GET /api/sources` list** (`sourceRoutes.ts:242`, `optionalAuth`). Center frequency / region
+   is inherently public RF information (it is broadcast over the air and printed on every node's config
+   screen), so exposing it on the public sources payload carries no secret. The frontend already fetches
+   this list via `useDashboardSources()` (used by `useAnalysisNodes`), so the client cost is ~0.
+   - **Rejected alternative (no-backend, gated fetches):** does not satisfy "frequency auto-populates
+     per source" on the tool's own public home; needs a new MeshCore client method anyway; splits into
+     two permission paths that both 403 for the common anonymous embed viewer. Documented here so the
+     orchestrator may downgrade to it if they explicitly prefer zero backend delta — in that case
+     auto-freq works only for signed-in users with `configuration:read`/`connection:read` and the
+     `radio` field / its route test are dropped.
+
+2. **RX sensitivity is computed, not a magic table.** Meshtastic modem preset → (SF, BW) → sensitivity
+   via the standard Semtech LoRa link-budget formula `S = -174 + 10·log10(BW_Hz) + NF + SNR_min(SF)`
+   (NF ≈ 6 dB for SX1262). This is defensible, unit-testable, and avoids transcription errors. The
+   editable number input stays; a preset dropdown is **out of scope** (cheap-only clause not met — the
+   value already auto-seeds from the picked node).
+
+3. **DEM void clamp lives in the backend provider** (cleanest — benefits `/profile` and `/test` and any
+   future consumer). Terrarium bathymetry/void pixels decode to extreme negatives (−12000 m observed
+   over Lake Pontchartrain). Values `< -500 m` (and a defensive `> 9000 m`) become `null` at the
+   provider boundary. A defensive chart-domain guard in the drawer is redundant once the backend nulls
+   them, so we add only a one-line comment there, not new logic.
+
+4. **Map path verdict coloring reuses the existing Polyline.** `LinkProfileController` already draws a
+   static amber `<Polyline pathOptions={{ color: '#f59e0b', weight: 3 }}>` (controller L158-168). We lift
+   the computed verdict into `MapAnalysisContext`, the drawer writes it, and the Canvas passes it down as
+   a prop so the controller stays prop-driven/testable.
+
+5. **Edge-case UX is mostly already scaffolded.** The drawer already branches on `isLoading`,
+   `isElevationDisabled`, generic `error`, and `allTerrainNull` (L175-185). Phase 3 only *refines* the
+   generic error branch into friendly per-code messages (`IDENTICAL_POINTS`, `PATH_TOO_LONG`,
+   `INVALID_COORDINATES`) — the server already rejects same-point picks with `IDENTICAL_POINTS`.
+
+6. **Manual edit always wins.** Auto-seed writes `freqMhz`/`rxSensitivityDbm` only when (a) a *new*
+   endpoint pair is picked and (b) the user has not manually edited that field for the current pair.
+
+---
+
+## 1. Reuse inventory (verified against the tree)
+
+| Need | Reuse (file:line) |
+|---|---|
+| Region → center MHz math | `src/utils/loraFrequency.ts` `calculateLoRaFrequency(region, channelNum, overrideFrequency, frequencyOffset, bandwidth?, channelName?, modemPreset?)` — honors `overrideFrequency`, returns a **string** ("906.875 MHz"/"Unknown"). Region bounds table + DJB2 slot math already correct. Add a **numeric** sibling. |
+| Modem preset enum → name/params | `loraFrequency.ts` `MODEM_PRESET_CHANNEL_NAMES` (0-13); `src/components/configuration/constants.ts` `MODEM_PRESET_OPTIONS` (SF/BW per preset in `params`). |
+| Live per-source LoRa config (server) | `manager.getCurrentConfig().deviceConfig.lora` → `{ region, modemPreset, channelNum, overrideFrequency, frequencyOffset, bandwidth }` (meshtasticManager.ts:4737-4755). Reachable server-side via `resolveSourceManager(sourceId)`. |
+| MeshCore per-source freq (server) | `isMeshCoreManager(m)` → `m.localNode?.radioFreq` (meshcoreManager.ts:328/5011). |
+| Public sources list handler | `src/server/routes/sourceRoutes.ts:242` `router.get('/', optionalAuth(), …)`. |
+| Sources list (frontend) | `useDashboardSources()` in `src/hooks/useDashboardData.ts` (already used by `useAnalysisNodes`). |
+| Node → sourceId/nodeNum/isMeshCore | `AnalysisNode.node` (`NodeRecord`) has `sourceId?`, `nodeNum`, `isMeshCore?` (`useAnalysisNodes.ts`). Currently dropped when building `linkEndpointCandidates` from `measurePoints`. |
+| Link-budget math | `src/utils/linkBudget.ts` `computeLinkBudget`, `fsplDb`, constants. |
+| Verdict labels/colors | Currently **local** to `LinkProfileDrawer.tsx` (`VERDICT_LABEL`, `VERDICT_COLOR`). Promote to `src/utils/linkProfile.ts`. |
+| Endpoint picker + Polyline | `src/components/MapAnalysis/LinkProfileController.tsx` (Polyline L158-168). |
+| Transient tool state | `MapAnalysisContext.tsx` (`linkProfileMode`, `linkEndpoints`, setters). |
+| Elevation provider decode | `src/server/services/elevationProvider.ts` (`decodeTerrariumTile`, `TerrariumTileProvider.sample`, `JsonPointProvider.fetchBatch`). |
+| Elevation `/test` route | `elevationRoutes.ts:82` `POST /test` (`settings:write`), body `{ url, lat?, lng? }`, returns envelope `ok(res, TestResult)` where `TestResult = { success, detectedType, sampleElevation, latencyMs, httpStatus?, error? }`. **No client method yet.** |
+| ApiService envelope unwrap | `api.getElevationProfile` (api.ts:1550) — the `.data` unwrap precedent. |
+| Secret-URL settings UI precedent | `SettingsTab.tsx` Apprise API Server: plain-text `<input id="appriseApiServerUrl" autoComplete="off">` (L1979-1992) + Test button (L1998) calling `csrfFetch(.../test-apprise)` (L761) + colored result span (L2007-2015). `elevationSourceUrl` is in `SECRET_SETTINGS_KEYS` but `stripSecretSettings` returns the **unmasked** value to admins — identical handling to Apprise. |
+| Settings save pattern | `SettingsTab` `handleSave` (L607) posts a body of `localFoo` values to `/api/settings` (L658-660); dep array at L729 lists every `localFoo`. `elevationEnabled`/`elevationSourceUrl` are already in `VALID_SETTINGS_KEYS` (Phase 1) — no constants change. |
+| Availability gate (frontend) | `useElevationEnabled()` already reads `elevationEnabled` from public `/api/settings`. |
+| Route test harness | `createRouteTestApp()` per CLAUDE.md (for the sources-radio route test). |
+| Docs | `docs/features/map-analysis.md`, `docs/features/settings.md`, `docs/features/maps.md`, `docs/.vitepress/config.mts` sidebar, `README.md` "Key Features" (L243), `CHANGELOG.md` (Keep-a-Changelog). |
+
+---
+
+## 2. File-by-file changes
+
+### Backend + shared pure utils
+
+#### 2.1 `src/utils/loraFrequency.ts` (EDIT — add numeric export)
+```ts
+/**
+ * Numeric center frequency (MHz) for a Meshtastic LoRa config, or null when it
+ * can't be computed (region unset/unknown, invalid channel). Honors
+ * overrideFrequency (delegates to calculateLoRaFrequency, which already does).
+ */
+export function loRaCenterFrequencyMhz(
+  region: number,
+  channelNum: number,
+  overrideFrequency: number,
+  frequencyOffset: number,
+  bandwidth = 250,
+  channelName?: string,
+  modemPreset?: number,
+): number | null {
+  const s = calculateLoRaFrequency(region, channelNum, overrideFrequency, frequencyOffset, bandwidth, channelName, modemPreset);
+  const f = parseFloat(s);
+  return Number.isFinite(f) ? f : null;
+}
+```
+Reuses the battle-tested string function so the region table/DJB2 math is not duplicated. Also export a
+region-code → short name map for provenance display, or reuse `REGION_OPTIONS` label prefix:
+```ts
+/** RegionCode → short name (e.g. 1 → "US"), for provenance hints. Values mirror config.proto. */
+export const REGION_SHORT_NAME: Record<number, string> = { 1: 'US', 2: 'EU_433', 3: 'EU_868', /* … */ };
+```
+(Transcribe from the existing `regionFrequencyBounds` comments in this file; keep it a thin lookup.)
+
+#### 2.2 `src/utils/linkBudget.ts` (EDIT — RX sensitivity from SF/BW/preset)
+```ts
+/** Demodulator SNR floor (dB) per LoRa spreading factor (Semtech SX1262 datasheet Table). */
+export const LORA_SNR_LIMIT_DB: Record<number, number> = { 7: -7.5, 8: -10, 9: -12.5, 10: -15, 11: -17.5, 12: -20 };
+
+/** SX1262 receiver noise figure (dB). */
+export const DEFAULT_NOISE_FIGURE_DB = 6;
+
+/**
+ * LoRa receiver sensitivity (dBm): S = -174 + 10·log10(BW_Hz) + NF + SNR_min(SF).
+ * Standard thermal-noise link-budget formula; documented so values are derived, not magic.
+ */
+export function loRaSensitivityDbm(spreadingFactor: number, bandwidthKhz: number, noiseFigureDb = DEFAULT_NOISE_FIGURE_DB): number | null {
+  const snr = LORA_SNR_LIMIT_DB[spreadingFactor];
+  if (snr === undefined || bandwidthKhz <= 0) return null;
+  return -174 + 10 * Math.log10(bandwidthKhz * 1000) + noiseFigureDb + snr;
+}
+
+/** Meshtastic modem-preset enum → (SF, BW kHz). Mirrors MODEM_PRESET_OPTIONS params. */
+export const MODEM_PRESET_PARAMS: Record<number, { sf: number; bwKhz: number }> = {
+  0: { sf: 11, bwKhz: 250 },  // LONG_FAST
+  1: { sf: 12, bwKhz: 125 },  // LONG_SLOW
+  /* … transcribe all 0-13 from src/components/configuration/constants.ts MODEM_PRESET_OPTIONS … */
+};
+
+/** RX sensitivity (dBm) for a Meshtastic modem preset, or null if unknown. */
+export function rxSensitivityForModemPreset(modemPreset: number, noiseFigureDb = DEFAULT_NOISE_FIGURE_DB): number | null {
+  const p = MODEM_PRESET_PARAMS[modemPreset];
+  return p ? loRaSensitivityDbm(p.sf, p.bwKhz, noiseFigureDb) : null;
+}
+```
+
+#### 2.3 `src/utils/linkProfile.ts` (EDIT — shared verdict styling + endpoint radio identity)
+- Extend `LinkEndpoint`:
+```ts
+export interface LinkEndpoint {
+  id: string; lat: number; lng: number; label?: string; isNode: boolean;
+  sourceId?: string;   // #4111 P3: source that reported the node endpoint (for auto-freq)
+  nodeNum?: number;    // #4111 P3
+  isMeshCore?: boolean;// #4111 P3
+}
+```
+- Move `VERDICT_LABEL` and `VERDICT_COLOR` here as exported consts (react-free module both the drawer and
+  controller import):
+```ts
+export const VERDICT_LABEL: Record<LinkVerdict, string> = { clear: 'Clear', marginal: 'Marginal', obstructed: 'Obstructed' };
+export const VERDICT_COLOR: Record<LinkVerdict, string> = { clear: '#22c55e', marginal: '#f59e0b', obstructed: '#ef4444' };
+```
+  Drawer imports them instead of its local copies (delete the local consts).
+
+#### 2.4 `src/server/services/elevationProvider.ts` (EDIT — DEM void clamp)
+```ts
+/** Below this metres a Terrarium/DEM sample is a void/bathymetry artifact, not real terrain (#4111 P3). */
+const MIN_VALID_ELEVATION_M = -500;
+const MAX_VALID_ELEVATION_M = 9000;
+function sanitizeElevation(v: number | null): number | null {
+  if (v == null || !Number.isFinite(v) || v < MIN_VALID_ELEVATION_M || v > MAX_VALID_ELEVATION_M) return null;
+  return v;
+}
+```
+Apply `sanitizeElevation(...)` at every point the providers produce an elevation:
+- `TerrariumTileProvider.sample` — wrap the decoded per-pixel value before it enters the result array
+  and before it is written to `tileCache`/returned.
+- `JsonPointProvider.fetchBatch` — wrap `items[j]?.elevation ?? null` before caching/returning.
+Keep it a single shared helper so both providers agree. Void samples continue to surface as `elevation: null`
+(the service and `analyzeLinkProfile` already exclude nulls from verdict/worst).
+
+#### 2.5 `src/server/routes/sourceRoutes.ts` (EDIT — additive public `radio` summary)
+In the `router.get('/', optionalAuth(), …)` handler (L242), for each source object returned, attach:
+```ts
+radio: computeSourceRadioSummary(sourceId) // : SourceRadioSummary | null
+```
+Add a local helper (near the top of the file, server-only, imports the pure client util — pure TS, already
+imported server-side elsewhere, e.g. `elevationService` imports `../../utils/distance.js`):
+```ts
+import { loRaCenterFrequencyMhz, REGION_SHORT_NAME } from '../../utils/loraFrequency.js';
+import { isMeshtasticManager, isMeshCoreManager } from '../sourceManagerTypes.js';
+
+interface SourceRadioSummary {
+  frequencyMhz: number | null;
+  regionName?: string;   // meshtastic only
+  modemPreset?: number;  // meshtastic only (drives RX-sensitivity auto-seed)
+}
+
+function computeSourceRadioSummary(sourceId: string): SourceRadioSummary | null {
+  const mgr = sourceManagerRegistry.getManager(sourceId);
+  if (!mgr) return null;
+  if (isMeshtasticManager(mgr)) {
+    const lora = mgr.getCurrentConfig()?.deviceConfig?.lora;
+    if (!lora) return null;
+    const freq = loRaCenterFrequencyMhz(
+      Number(lora.region ?? 0), Number(lora.channelNum ?? 0),
+      Number(lora.overrideFrequency ?? 0), Number(lora.frequencyOffset ?? 0),
+      Number(lora.bandwidth ?? 250), undefined, Number(lora.modemPreset ?? 0),
+    );
+    return { frequencyMhz: freq, regionName: REGION_SHORT_NAME[Number(lora.region ?? 0)], modemPreset: Number(lora.modemPreset ?? 0) };
+  }
+  if (isMeshCoreManager(mgr)) {
+    const f = mgr.localNode?.radioFreq;
+    return { frequencyMhz: typeof f === 'number' && Number.isFinite(f) ? f : null };
+  }
+  return null; // MQTT / bridge sources have no local radio
+}
+```
+Wrap the whole thing in `try/catch → null` so a manager that throws from `getCurrentConfig()` can never
+break the sources list. **Permission reasoning:** `radio` is a public center frequency / region name —
+non-secret RF info broadcast over the air; safe on the existing `optionalAuth` payload. No new route,
+no secret exposure, additive only.
+
+#### 2.6 `src/types/elevation.ts` (EDIT — test-result mirror)
+```ts
+/** Mirror of elevationService `TestResult` for the settings Test button (#4111 P3). */
+export interface ElevationTestResult {
+  success: boolean;
+  detectedType: string;
+  sampleElevation: number | null;
+  latencyMs: number;
+  httpStatus?: number;
+  error?: string;
+}
+```
+
+#### 2.7 `src/services/api.ts` (EDIT — elevation test method)
+```ts
+async testElevationSource(url: string, probe?: { lat: number; lng: number }): Promise<ElevationTestResult> {
+  const res = await this.post<{ success: boolean; data: ElevationTestResult }>(
+    '/api/elevation/test',
+    probe ? { url, lat: probe.lat, lng: probe.lng } : { url },
+  );
+  return res.data; // unwrap envelope (same gotcha as getElevationProfile)
+}
+```
+(Also extend the frontend sources type used by `useDashboardSources` to carry the optional
+`radio?: SourceRadioSummary` — define `SourceRadioSummary` client-side in `src/types/elevation.ts` or a
+`src/types/source.ts`; keep it a pure interface.)
+
+### Frontend — auto-detect + edge UX
+
+#### 2.8 `src/components/MapAnalysis/MapAnalysisCanvas.tsx` (EDIT)
+Build `linkEndpointCandidates` from `analysisNodes` (not `measurePoints`) so radio identity survives:
+```ts
+const linkEndpointCandidates: LinkEndpoint[] = useMemo(
+  () => analysisNodes.map((a) => ({
+    id: a.key, lat: a.latLng[0], lng: a.latLng[1],
+    label: a.node.shortName ?? undefined, isNode: true,
+    sourceId: a.node.sourceId, nodeNum: a.node.nodeNum, isMeshCore: a.node.isMeshCore ?? false,
+  })),
+  [analysisNodes],
+);
+```
+Pass the verdict to the controller (read from context — see 2.11):
+```tsx
+<LinkProfileController active={linkProfileMode} points={linkEndpointCandidates}
+  endpoints={linkEndpoints} onPick={setLinkEndpoints} onExit={() => setLinkProfileMode(false)}
+  verdict={linkVerdict} />
+```
+
+#### 2.9 `src/hooks/useAutoRadioDefaults.ts` (NEW)
+```ts
+/**
+ * Derives auto-seed frequency + RX sensitivity + provenance for a picked endpoint
+ * pair from the public per-source `radio` summary (GET /api/sources). Prefers a
+ * node endpoint (A first, then B). Returns nulls when neither endpoint is a node
+ * with a resolvable radio — the drawer then keeps the 915 MHz / -129 dBm defaults.
+ */
+export interface AutoRadioDefaults {
+  freqMhz: number | null;
+  rxSensitivityDbm: number | null;
+  provenance: string | null; // e.g. "from Home Base (US)"
+}
+export function useAutoRadioDefaults(a?: LinkEndpoint, b?: LinkEndpoint): AutoRadioDefaults;
+```
+Implementation: `const { data: sources } = useDashboardSources();` find the source whose `id` matches the
+chosen node endpoint's `sourceId`; read `source.radio`. `freqMhz = radio.frequencyMhz`;
+`rxSensitivityDbm = radio.modemPreset != null ? rxSensitivityForModemPreset(radio.modemPreset) : null`;
+`provenance = radio.frequencyMhz != null ? \`from ${source.name}${radio.regionName ? ` (${radio.regionName})` : ''}\` : null`.
+No new fetch — reuses the cached sources query. Memoize on `[sources, a?.sourceId, a?.isNode, b?.sourceId, b?.isNode]`.
+
+#### 2.10 `src/components/MapAnalysis/LinkProfileDrawer.tsx` (EDIT)
+- Import shared `VERDICT_LABEL`/`VERDICT_COLOR` from `../../utils/linkProfile` (drop local copies).
+- Auto-seed with manual-override-wins:
+```ts
+const auto = useAutoRadioDefaults(endpointA, endpointB);
+const [freqEdited, setFreqEdited] = useState(false);
+const [rxEdited, setRxEdited] = useState(false);
+const pairKey = `${endpointA?.id ?? ''}|${endpointB?.id ?? ''}`;
+// Reset "edited" flags when a NEW pair is picked.
+useEffect(() => { setFreqEdited(false); setRxEdited(false); }, [pairKey]);
+// Seed when not manually edited for this pair.
+useEffect(() => { if (!freqEdited && auto.freqMhz != null) setFreqMhz(auto.freqMhz); }, [pairKey, auto.freqMhz, freqEdited]);
+useEffect(() => { if (!rxEdited && auto.rxSensitivityDbm != null) setRxSensitivityDbm(auto.rxSensitivityDbm); }, [pairKey, auto.rxSensitivityDbm, rxEdited]);
+```
+  In the frequency input `onChange`, also `setFreqEdited(true)`; same for RX sensitivity → `setRxEdited(true)`.
+  (Keep the existing `if (!Number.isNaN(v)) setFreqMhz(v)` guard.) Exhaustive-deps: list `pairKey`,
+  `auto.freqMhz`/`auto.rxSensitivityDbm`, and the edited flags exactly as above — no suppressions.
+- Provenance hint: under the Frequency input, render when `auto.provenance && !freqEdited`:
+  `<span className="link-profile-provenance">{auto.provenance}</span>`.
+- Write verdict to context (see 2.11): `useEffect(() => { setLinkVerdict(analysis?.verdict ?? null); }, [analysis?.verdict, setLinkVerdict]);`
+  and clear on unmount: `useEffect(() => () => setLinkVerdict(null), [setLinkVerdict]);`
+- Refine the generic `error` branch (L181-185) into friendly messages by `error.code`:
+  `IDENTICAL_POINTS` → "Pick two different points."; `PATH_TOO_LONG` → "That link is too long to profile
+  (max 500 km)."; `INVALID_COORDINATES` → "One of the points has invalid coordinates."; else the existing
+  generic text. `ELEVATION_DISABLED` and `allTerrainNull` branches already exist — leave the all-null copy
+  (e.g. "No terrain data along this path (open water or a DEM gap).").
+
+#### 2.11 `src/components/MapAnalysis/MapAnalysisContext.tsx` (EDIT)
+Add transient verdict slice:
+```ts
+linkVerdict: LinkVerdict | null;
+setLinkVerdict: (v: LinkVerdict | null) => void;
+```
+`const [linkVerdict, setLinkVerdict] = useState<LinkVerdict | null>(null);` — provide in the context value.
+(Import `LinkVerdict` type from `../../utils/linkProfile`.)
+
+#### 2.12 `src/components/MapAnalysis/LinkProfileController.tsx` (EDIT — verdict color + antimeridian)
+- Add `verdict?: LinkVerdict | null` to `LinkProfileControllerProps`; color the Polyline:
+```tsx
+pathOptions={{ color: verdict ? VERDICT_COLOR[verdict] : '#f59e0b', weight: 3 }}
+```
+  (Import `VERDICT_COLOR` from `../../utils/linkProfile`.)
+- Antimeridian: when both endpoints exist, normalize endpoint B's longitude to the same 360° window as A
+  before building the Polyline `positions`, so a link crossing ±180 draws the short way:
+```ts
+const bLngUnwrapped = endpointB ? endpointB.lng + 360 * Math.round((endpointA.lng - endpointB.lng) / 360) : undefined;
+```
+  Use `[endpointB.lat, bLngUnwrapped]` for the Polyline position only (leave the endpoint CircleMarker and
+  the API call at the true lng). Small, self-contained; backend distance/interpolation already correct.
+
+### Frontend — elevation-source settings UI
+
+#### 2.13 `src/components/SettingsTab.tsx` (EDIT — Elevation / Terrain section, admin-gated)
+Mirror the Apprise API Server pattern exactly (plain-text input + Test button + result span):
+- Local state near the other `local*` fields:
+  `const [localElevationEnabled, setLocalElevationEnabled] = useState(false);`
+  `const [localElevationSourceUrl, setLocalElevationSourceUrl] = useState('');`
+  `const [elevationTestResult, setElevationTestResult] = useState<{ ok: boolean; message: string } | null>(null);`
+  `const [elevationTesting, setElevationTesting] = useState(false);`
+- Load on mount inside the existing settings-fetch effect (alongside `setLocalAppriseApiServerUrl`), reading
+  `settings.elevationEnabled` (string `'true'`/`'false'`) and `settings.elevationSourceUrl` (admins receive
+  the unmasked value — `stripSecretSettings` returns the full map to admins).
+- **`handleSave` (L607):** add `elevationEnabled: localElevationEnabled ? 'true' : 'false'` and
+  `elevationSourceUrl: localElevationSourceUrl.trim()` to the POST body (near L660), and add
+  `localElevationEnabled`, `localElevationSourceUrl` to the **dependency array at L729** (the documented
+  gotcha — without this the save uses stale values).
+- Test handler (uses ApiService, not raw fetch — new component code must not use raw `fetch`):
+```ts
+const handleTestElevation = useCallback(async () => {
+  setElevationTesting(true); setElevationTestResult(null);
+  try {
+    const r = await api.testElevationSource(localElevationSourceUrl.trim());
+    setElevationTestResult(r.success
+      ? { ok: true, message: t('settings.elevation_test_success', 'OK — {{type}}, {{elev}} m in {{ms}} ms', { type: r.detectedType, elev: r.sampleElevation ?? 'n/a', ms: r.latencyMs }) }
+      : { ok: false, message: r.error ?? 'Test failed' });
+  } catch (e) {
+    setElevationTestResult({ ok: false, message: e instanceof Error ? e.message : String(e) });
+  } finally { setElevationTesting(false); }
+}, [localElevationSourceUrl, t]);
+```
+- Section JSX (place within the Maps/tileset area, `isAdmin`-gated like Apprise): an enable checkbox bound
+  to `localElevationEnabled`; a text input `id="elevationSourceUrl"` (`autoComplete="off"`, placeholder
+  showing the default terrarium template, helper text "Leave empty to use the default public AWS Terrarium
+  source"); a "Test" button (`onClick={handleTestElevation}`, disabled while `elevationTesting`) and the
+  colored `elevationTestResult` span. Register the section id in the settings-section list/nav array (mirror
+  how `'settings-apprise-server'` is registered at L99/L1140) if the tab uses a section index.
+
+---
+
+## 3. Test plan (Vitest; route changes via `createRouteTestApp`)
+
+| File | Assertions |
+|---|---|
+| `src/utils/loraFrequency.test.ts` (extend) | `loRaCenterFrequencyMhz`: US LongFast default → ~906.875; `overrideFrequency` set → that value; region 0/unknown → `null`; `REGION_SHORT_NAME[1]==='US'`. |
+| `src/utils/linkBudget.test.ts` (extend) | `loRaSensitivityDbm(11,250)` ≈ −126.5 (±0.5); monotonic: higher SF ⇒ lower (more negative) sensitivity; narrower BW ⇒ lower; unknown SF/BW≤0 → `null`. `rxSensitivityForModemPreset(0)` finite; unknown preset → `null`. |
+| `src/server/services/elevationProvider.test.ts` (extend) | Synthesized Terrarium pixel decoding to −12000 m ⇒ sample `null`; a >9000 m pixel ⇒ `null`; a valid 0 m ocean pixel and a +100 m pixel pass through unchanged. JSON provider: a `-9999`-style value ⇒ `null`. |
+| `src/server/routes/sourceRoutes.*.test.ts` (new or extend, harness) | `GET /api/sources` (anonymous) includes `radio` per source: meshtastic mock manager → `{ frequencyMhz, regionName, modemPreset }`; meshcore mock → `{ frequencyMhz }` from `radioFreq`; MQTT/no-manager → `radio: null`; a manager whose `getCurrentConfig` throws ⇒ list still returns 200 with `radio: null`. |
+| `src/services/api.test.ts` (extend, if present) | `testElevationSource` posts `{ url }` (or `{ url, lat, lng }`) and returns the unwrapped `.data`. |
+| `src/hooks/useAutoRadioDefaults.test.tsx` (new) | Node endpoint with matching source radio → `{ freqMhz, rxSensitivityDbm, provenance }`; arbitrary (non-node) endpoints → all null; A preferred over B; missing `radio` → nulls; `modemPreset` absent → `rxSensitivityDbm: null` but `freqMhz` still set. |
+| `src/components/MapAnalysis/LinkProfileDrawer.test.tsx` (extend) | Auto-seed sets freq + RX from mocked `useAutoRadioDefaults`; editing the freq input sets `freqEdited` so a re-render does **not** overwrite the user value; picking a new pair (changed `pairKey`) re-seeds; provenance hint renders when not edited and hides after edit; error branch renders the friendly `IDENTICAL_POINTS`/`PATH_TOO_LONG` copy by `error.code`. |
+| `src/components/MapAnalysis/LinkProfileController.test.tsx` (extend) | Polyline `pathOptions.color` follows `verdict` (clear→green, marginal→amber, obstructed→red); `verdict` null → amber default; antimeridian pair (179 → −179) yields an unwrapped B-lng within 180° of A (no long-way line). |
+| `src/components/SettingsTab.*.test.tsx` (extend/new) | Elevation enable + URL persist into the save POST body; Test button calls `api.testElevationSource` and renders the success/failure span; `handleSave` dep-array regression guard (edited value is included in the payload). |
+
+Run the **full** suite (`npx vitest run`) + `npm run lint:ci` + `npm run build` before PR (per CLAUDE.md). No standalone scripts.
+
+---
+
+## 4. Work packages (Sonnet-sized, dependency-ordered)
+
+### WP-1 — Backend field + shared math (no UI) *(start immediately)*
+Files: 2.1 loraFrequency numeric + region names; 2.2 linkBudget RX-sensitivity; 2.3 linkProfile
+(LinkEndpoint fields + promote VERDICT_* consts); 2.4 elevationProvider void clamp; 2.5 sourceRoutes
+`radio` summary; 2.6 types; 2.7 ApiService `testElevationSource`. Tests: loraFrequency, linkBudget,
+elevationProvider, sourceRoutes (harness), api client.
+**Acceptance:** `GET /api/sources` returns per-source `radio` (meshtastic/meshcore/null) anonymously and
+never 500s on a throwing manager; DEM void samples become `null`; new pure-math functions covered; drawer
+still compiles against the moved VERDICT_* exports; full suite + `lint:ci` green.
+
+### WP-2 — Auto-frequency + RX + drawer edge UX *(depends WP-1)*
+Files: 2.8 Canvas candidates carry radio identity; 2.9 `useAutoRadioDefaults`; 2.10 drawer auto-seed +
+override-wins + provenance + refined error messages. Tests: `useAutoRadioDefaults`, drawer.
+**Acceptance:** picking a node endpoint auto-populates frequency (+ RX where a modem preset is known) with a
+"from <source> (<region>)" hint; manual edits stick and win; a fresh pair re-seeds; anonymous/no-radio and
+arbitrary-point endpoints gracefully keep 915 MHz / −129 dBm; `IDENTICAL_POINTS`/`PATH_TOO_LONG`/
+`INVALID_COORDINATES`/all-null render friendly copy; exhaustive-deps clean, no suppressions.
+
+### WP-3 — Map path verdict coloring + antimeridian + settings UI *(depends WP-1; parallel with WP-2)*
+Files: 2.11 context verdict slice; 2.8 Canvas passes `verdict` (coordinate with WP-2 on the Canvas edit —
+land WP-2's Canvas change first or merge carefully); 2.12 controller color + lng unwrap; 2.13 SettingsTab
+elevation section. Tests: controller color/antimeridian, SettingsTab.
+**Acceptance:** after analysis the picked path line turns green/amber/red by verdict and reverts to amber
+when cleared; an antimeridian link draws the short way; admins can enable elevation, set/clear a custom
+source URL (unmasked, saved via the settings POST with the dep-array fix), and the Test button reports
+detected type + sample elevation + latency; `useElevationEnabled` continues to gate the toolbar button.
+
+### WP-4 — Documentation *(use the `meshmonitor-docs-writer` agent; depends WP-1..3 for accurate copy)*
+- `docs/features/map-analysis.md`: new "Link Profile / Terrain planning" section — how to open the tool,
+  pick two nodes or arbitrary points, read the terrain/LOS/Fresnel chart + budget verdict, per-source
+  frequency auto-detection with manual override, and graceful degradation (open water / no config).
+- `docs/features/settings.md` (and/or `maps.md`): document the admin Elevation source setting (enable
+  toggle, custom source URL as a server-side secret, Test button) and that the default is the public AWS
+  Terrarium DEM with all fetches server-proxied via `safeFetch`.
+- `docs/.vitepress/config.mts`: ensure `map-analysis` is in the Features sidebar (add if missing).
+- `README.md` "Key Features" (L243): one bullet for terrain link profiling.
+- `CHANGELOG.md`: add an entry under the next version (Keep-a-Changelog "Added" — per-source auto-frequency,
+  terrain link profile polish, elevation-source settings + Test; "Fixed" — DEM void/bathymetry artifacts).
+- `CLAUDE.md` / a dev-note: record the two Phase-3 invariants — (a) the public `GET /api/sources` `radio`
+  summary is intentionally non-secret (RF center freq/region is public); (b) DEM values `< -500 m` are
+  nulled at the provider boundary.
+**Acceptance:** docs build (VitePress) clean; feature reachable from the sidebar; CHANGELOG + README updated.
+
+---
+
+## 5. Invariants honored / non-goals
+
+- **Minimal, additive backend.** One new non-secret field on an existing public payload + a provider clamp
+  + a client-method wrapper for the already-existing `/test` route. No new routes, no migration, no schema,
+  no secret exposure. `elevationEnabled`/`elevationSourceUrl` keys already exist (Phase 1).
+- **No raw `fetch()` in components/pages** — the settings Test button uses `ApiService.testElevationSource`.
+  (`api.getCurrentConfig`'s raw `fetch` is pre-existing service-layer code, out of scope.)
+- **No `any`, TS strict, exhaustive-deps** — auto-seed effects list exact deps; no suppressions. ESLint
+  ratchet must not grow (`npm run lint:ci` exit 0).
+- **Manual override always wins**; auto-seed is per-pair and one-shot.
+- **Elevation is source-agnostic geometry** — no `sourceId` scoping on elevation data (Phase-1 rationale
+  unchanged); the new `radio` summary is *read from* per-source managers but is not stored.
+- **Node GPS altitude still unused** (Phase-2 datum-mismatch decision unchanged).
+- **Out of scope:** RX-sensitivity preset dropdown; MeshCore RX-sensitivity derivation from sf/bw; the
+  no-backend gated-fetch alternative (documented in §0.1 as rejected); GPS-altitude AGL datum work.

--- a/docs/internal/dev-notes/TERRAIN_LINK_PROFILE_EPIC.md
+++ b/docs/internal/dev-notes/TERRAIN_LINK_PROFILE_EPIC.md
@@ -77,7 +77,7 @@ Branch: `feature/link-profile-tool` (worktree ../meshmonitor-link-profile)
 - **Exit criteria:** end-to-end in browser: pick two nodes → drawer shows profile + Fresnel +
   budget verdict; matches site.meshtastic.org for a reference link; suite green; merged.
 
-### Phase 3 — Polish, auto-frequency, docs ⬜
+### Phase 3 — Polish, auto-frequency, docs ✅
 Branch: `feature/link-profile-polish`
 
 - Per-source frequency auto-detection: Meshtastic region enum → center MHz map (honor
@@ -112,3 +112,15 @@ Branch: `feature/link-profile-polish`
   altitude ignored — datum mismatch); snap-within-24px else raw point (no modifier key); drawer =
   absolute overlay in canvas; useElevationEnabled gates the toolbar button. Known issue punted to
   Phase 3: Terrarium void/bathymetry extreme negatives distort the chart Y-domain.
+- 2026-07-16: Phase 2 merged: PR #4147 (squash d9aafbd9; user-approved merge).
+- 2026-07-16: Phase 3 implemented (WP-1 radio math + public `radio` on GET /api/sources + DEM
+  clamp 58f25c76..3bd0e1ee; WP-2 auto-freq/RX seeding + drawer edge UX 01fc25e4; WP-3 verdict
+  coloring + antimeridian + settings UI 36804aec; WP-4 docs 368ebf50). Two browser-validation
+  fixes: 6d414d51 (auto-freq must walk node.sources[] — merged nodes' primary sourceId is often
+  a radio-less MQTT bridge) and 5f249c0d (empty-URL Test probes the default Terrarium source,
+  "(default source)" suffix); 558855c1 rounds seeded RX to 0.1 dB. Live-validated: seed 913.125
+  "from Sandbox (US)", RX −126.5 from preset; verdict-red path; DEM clamp fixed the −12000 m
+  Y-axis blowout; Test button "OK — terrarium, 8732 m in 297 ms (default source)". Decisions:
+  rejected gated per-endpoint config fetches in favor of one public `radio` summary field
+  (frequency/region are public RF info); RX sensitivity computed (−174+10log10(BW)+NF+SNRmin),
+  not a magic table; DEM clamp bounds −500..9000 m at the provider boundary.

--- a/src/components/MapAnalysis/LinkProfileController.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileController.test.tsx
@@ -23,16 +23,33 @@ vi.mock('react-leaflet', () => ({
     mouseEventToLatLng: (e: MouseEvent) => ({ lat: e.clientY, lng: e.clientX }),
     latLngToContainerPoint: ([lat, lng]: [number, number]) => ({ x: lng, y: lat }),
   }),
-  CircleMarker: ({ center, pathOptions }: { center: [number, number]; pathOptions: { fillOpacity: number } }) => (
+  CircleMarker: ({
+    center,
+    pathOptions,
+  }: {
+    center: [number, number];
+    pathOptions: { fillOpacity: number; color: string };
+  }) => (
     <div
       data-testid="link-ring"
       data-lat={center[0]}
       data-lng={center[1]}
       data-filled={pathOptions.fillOpacity > 0}
+      data-color={pathOptions.color}
     />
   ),
-  Polyline: ({ positions, children }: { positions: [number, number][]; children?: React.ReactNode }) => (
-    <div data-testid="link-line" data-positions={JSON.stringify(positions)}>{children}</div>
+  Polyline: ({
+    positions,
+    pathOptions,
+    children,
+  }: {
+    positions: [number, number][];
+    pathOptions: { color: string };
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="link-line" data-positions={JSON.stringify(positions)} data-color={pathOptions.color}>
+      {children}
+    </div>
   ),
   Tooltip: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="link-label">{children}</div>
@@ -68,6 +85,7 @@ function Harness(props: Partial<LinkProfileControllerProps> & { points?: LinkEnd
         props.onPick?.(next);
       }}
       onExit={props.onExit}
+      verdict={props.verdict}
     />
   );
 }
@@ -124,9 +142,14 @@ describe('LinkProfileController', () => {
     clickAt(105, 100); // near A
     clickAt(895, 100); // near C
     const line = screen.getByTestId('link-line');
+    // The drawn line's B longitude is unwrapped into A's 360-degree window
+    // (#4111 Phase 3 WP-3 antimeridian fix) — A=100, C=900 differ by 800, so
+    // the rendered position is 900 - 2*360 = 180 (the "line" test fixture
+    // isn't real geography, but the unwrap math is deterministic for any
+    // input). The tooltip label still uses the true (non-unwrapped) endpoints.
     expect(JSON.parse(line.getAttribute('data-positions')!)).toEqual([
       [100, 100],
-      [100, 900],
+      [100, 180],
     ]);
     expect(screen.getByTestId('link-label').textContent).toMatch(/km$/);
   });
@@ -196,5 +219,58 @@ describe('LinkProfileController', () => {
     expect(onPick).toHaveBeenCalledWith([
       expect.objectContaining({ id: 'a', lat: 100, lng: 100, isNode: true }),
     ]);
+  });
+
+  describe('verdict coloring (#4111 Phase 3 WP-3)', () => {
+    it('defaults to amber (pending) when no verdict is supplied', () => {
+      render(<Harness />);
+      clickAt(105, 100);
+      clickAt(895, 100);
+      expect(screen.getByTestId('link-line').getAttribute('data-color')).toBe('#f59e0b');
+      for (const ring of screen.getAllByTestId('link-ring')) {
+        expect(ring.getAttribute('data-color')).toBe('#f59e0b');
+      }
+    });
+
+    it('defaults to amber (pending) when verdict is explicitly null', () => {
+      render(<Harness verdict={null} />);
+      clickAt(105, 100);
+      clickAt(895, 100);
+      expect(screen.getByTestId('link-line').getAttribute('data-color')).toBe('#f59e0b');
+    });
+
+    it.each([
+      ['clear', '#22c55e'],
+      ['marginal', '#f59e0b'],
+      ['obstructed', '#ef4444'],
+    ] as const)('colors the line and rings %s -> %s', (verdict, color) => {
+      render(<Harness verdict={verdict} />);
+      clickAt(105, 100);
+      clickAt(895, 100);
+      expect(screen.getByTestId('link-line').getAttribute('data-color')).toBe(color);
+      for (const ring of screen.getAllByTestId('link-ring')) {
+        expect(ring.getAttribute('data-color')).toBe(color);
+      }
+    });
+  });
+
+  describe('antimeridian unwrap (#4111 Phase 3 WP-3)', () => {
+    it('draws the short way across +/-180 instead of the long way around', () => {
+      const antimeridianPoints: LinkEndpoint[] = [
+        { id: 'east', lat: 100, lng: 179, label: 'East', isNode: true },
+        { id: 'west', lat: 100, lng: -179, label: 'West', isNode: true },
+      ];
+      render(<Harness points={antimeridianPoints} />);
+      // East point sits at container (179,100); West at (-179,100) — click
+      // directly on each so the snap logic resolves them unambiguously.
+      clickAt(179, 100);
+      clickAt(-179, 100);
+      const line = screen.getByTestId('link-line');
+      const positions = JSON.parse(line.getAttribute('data-positions')!);
+      expect(positions[0]).toEqual([100, 179]);
+      // -179 unwrapped into A's (179) 360-degree window is 181, not -179 —
+      // a short 2-degree hop instead of the 358-degree long way around.
+      expect(positions[1][1]).toBeCloseTo(181, 5);
+    });
   });
 });

--- a/src/components/MapAnalysis/LinkProfileController.tsx
+++ b/src/components/MapAnalysis/LinkProfileController.tsx
@@ -2,11 +2,15 @@ import React, { useEffect, useRef } from 'react';
 import { CircleMarker, Polyline, Tooltip, useMap } from 'react-leaflet';
 import { useSettings } from '../../contexts/SettingsContext';
 import { nearestPoint, measureLabel } from '../../utils/measureDistance';
-import type { LinkEndpoint } from '../../utils/linkProfile';
+import type { LinkEndpoint, LinkVerdict } from '../../utils/linkProfile';
+import { VERDICT_COLOR } from '../../utils/linkProfile';
 import './LinkProfileController.css';
 
 /** Screen-space snap threshold (px) for treating a click as "on" a node. */
 const SNAP_PX = 24;
+
+/** Amber shown while the drawer hasn't resolved a verdict yet (or none applies). */
+const PENDING_COLOR = '#f59e0b';
 
 export interface LinkProfileControllerProps {
   /** When false the tool is inert (no cursor change, no listeners fire visibly). */
@@ -19,6 +23,13 @@ export interface LinkProfileControllerProps {
   onPick: (next: LinkEndpoint[]) => void;
   /** Called when the user presses Escape so the parent can flip `active` off. */
   onExit?: () => void;
+  /**
+   * Computed Link Profile verdict for the current endpoint pair (#4111 Phase
+   * 3 WP-3), owned by the drawer via `MapAnalysisContext`. Colors the
+   * connecting Polyline + endpoint rings via the shared `VERDICT_COLOR`;
+   * falls back to amber while `null` (pending/no analysis yet).
+   */
+  verdict?: LinkVerdict | null;
 }
 
 /**
@@ -47,6 +58,7 @@ const LinkProfileController: React.FC<LinkProfileControllerProps> = ({
   endpoints,
   onPick,
   onExit,
+  verdict,
 }) => {
   const { distanceUnit } = useSettings();
   const map = useMap();
@@ -137,14 +149,26 @@ const LinkProfileController: React.FC<LinkProfileControllerProps> = ({
   if (!enabled) return null;
 
   const [endpointA, endpointB] = endpoints;
+  // Verdict-driven color (#4111 Phase 3 WP-3): amber while pending (no
+  // resolved analysis yet), otherwise the shared clear/marginal/obstructed
+  // color also used by the drawer's chart and stat pill.
+  const verdictColor = verdict ? VERDICT_COLOR[verdict] : PENDING_COLOR;
   const ringStyle = (endpoint: LinkEndpoint) => ({
-    color: '#f59e0b',
+    color: verdictColor,
     weight: 3,
-    fillColor: '#f59e0b',
+    fillColor: verdictColor,
     // Filled for a snapped node, hollow for an arbitrary map point — visually
     // distinguishes the two endpoint kinds (spec §2.7).
     fillOpacity: endpoint.isNode ? 0.6 : 0,
   });
+
+  // Antimeridian fix (#4111 Phase 3 WP-3): unwrap endpoint B's longitude into
+  // the same 360° window as endpoint A before building the Polyline so a
+  // link crossing +/-180 draws the short way across the map instead of
+  // wrapping the long way around. Only affects the drawn line's coordinates —
+  // the endpoint CircleMarker and any API calls keep the true lng.
+  const bLngUnwrapped =
+    endpointA && endpointB ? endpointB.lng + 360 * Math.round((endpointA.lng - endpointB.lng) / 360) : undefined;
 
   return (
     <>
@@ -154,13 +178,13 @@ const LinkProfileController: React.FC<LinkProfileControllerProps> = ({
       {endpointB && (
         <CircleMarker center={[endpointB.lat, endpointB.lng]} radius={12} pathOptions={ringStyle(endpointB)} />
       )}
-      {endpointA && endpointB && (
+      {endpointA && endpointB && bLngUnwrapped !== undefined && (
         <Polyline
           positions={[
             [endpointA.lat, endpointA.lng],
-            [endpointB.lat, endpointB.lng],
+            [endpointB.lat, bLngUnwrapped],
           ]}
-          pathOptions={{ color: '#f59e0b', weight: 3 }}
+          pathOptions={{ color: verdictColor, weight: 3 }}
         >
           <Tooltip permanent direction="center" className="link-profile-label">
             {measureLabel(endpointA, endpointB, distanceUnit)}

--- a/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
@@ -46,12 +46,14 @@ let mockLinkProfileMode = true;
 let mockLinkEndpoints: LinkEndpoint[] = [];
 let setLinkProfileModeSpy: ReturnType<typeof vi.fn>;
 let setLinkEndpointsSpy: ReturnType<typeof vi.fn>;
+let setLinkVerdictSpy: ReturnType<typeof vi.fn>;
 vi.mock('./MapAnalysisContext', () => ({
   useMapAnalysisCtx: () => ({
     linkProfileMode: mockLinkProfileMode,
     linkEndpoints: mockLinkEndpoints,
     setLinkProfileMode: setLinkProfileModeSpy,
     setLinkEndpoints: setLinkEndpointsSpy,
+    setLinkVerdict: setLinkVerdictSpy,
   }),
 }));
 
@@ -134,6 +136,7 @@ describe('LinkProfileDrawer', () => {
     mockLinkEndpoints = [];
     setLinkProfileModeSpy = vi.fn();
     setLinkEndpointsSpy = vi.fn();
+    setLinkVerdictSpy = vi.fn();
     getElevationProfileMock.mockReset();
     mockAutoRadioDefaults = { freqMhz: null, rxSensitivityDbm: null, provenance: null };
   });
@@ -219,7 +222,7 @@ describe('LinkProfileDrawer', () => {
     expect(marginDd.className).toContain('link-margin-negative');
   });
 
-  it('calls setLinkProfileMode(false) and clears endpoints when closed', async () => {
+  it('calls setLinkProfileMode(false), clears endpoints and verdict when closed', async () => {
     mockLinkEndpoints = [endpointA, endpointB];
     getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
     renderDrawer();
@@ -228,6 +231,37 @@ describe('LinkProfileDrawer', () => {
     fireEvent.click(screen.getByRole('button', { name: /close link profile/i }));
     expect(setLinkProfileModeSpy).toHaveBeenCalledWith(false);
     expect(setLinkEndpointsSpy).toHaveBeenCalledWith([]);
+    expect(setLinkVerdictSpy).toHaveBeenCalledWith(null);
+  });
+
+  // #4111 Phase 3 WP-3: the drawer mirrors its computed verdict into
+  // MapAnalysisContext so the map-path Polyline can color itself to match.
+  describe('verdict -> context mirroring (#4111 P3 WP-3)', () => {
+    it('writes the resolved verdict to context once analysis is available', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      await screen.findByText('+31.2 dB');
+      expect(setLinkVerdictSpy).toHaveBeenCalledWith('obstructed');
+    });
+
+    it('clears the context verdict on unmount', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      const { unmount } = renderDrawer();
+      await screen.findByText('+31.2 dB');
+      setLinkVerdictSpy.mockClear();
+
+      unmount();
+      expect(setLinkVerdictSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('writes a null verdict while there is no resolved analysis yet (e.g. only one endpoint picked)', () => {
+      mockLinkEndpoints = [endpointA];
+      renderDrawer();
+      expect(setLinkVerdictSpy).toHaveBeenCalledWith(null);
+    });
   });
 
   // #4111 Phase 3 WP-2: per-source auto-frequency/RX-sensitivity seeding,

--- a/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
@@ -17,6 +17,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LinkProfileDrawer from './LinkProfileDrawer';
+import { ApiError } from '../../services/api';
+import type { AutoRadioDefaults } from '../../hooks/useAutoRadioDefaults';
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import type { ElevationProfile } from '../../types/elevation';
 
@@ -65,6 +67,15 @@ vi.mock('../../services/api', async importOriginal => {
   };
 });
 
+// Auto-frequency/RX-sensitivity suggestion (#4111 P3 WP-2). Defaults to
+// all-null so the existing locked-value tests (which assume the documented
+// 915 MHz / -129 dBm defaults) are unaffected; individual seeding tests
+// override this per-test.
+let mockAutoRadioDefaults: AutoRadioDefaults = { freqMhz: null, rxSensitivityDbm: null, provenance: null };
+vi.mock('../../hooks/useAutoRadioDefaults', () => ({
+  useAutoRadioDefaults: () => mockAutoRadioDefaults,
+}));
+
 const endpointA: LinkEndpoint = { id: 'node-a', lat: 0, lng: 0, isNode: true };
 const endpointB: LinkEndpoint = { id: 'node-b', lat: 0.3, lng: 0, isNode: true };
 
@@ -99,11 +110,21 @@ function renderDrawer() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
   });
-  return render(
+  const utils = render(
     <QueryClientProvider client={queryClient}>
       <LinkProfileDrawer />
     </QueryClientProvider>
   );
+  // Re-renders the same tree (same QueryClient) so tests can flip module-level
+  // mock state (e.g. `mockLinkEndpoints`, `mockAutoRadioDefaults`) and observe
+  // the drawer react to a picker change without unmounting.
+  const rerenderDrawer = () =>
+    utils.rerender(
+      <QueryClientProvider client={queryClient}>
+        <LinkProfileDrawer />
+      </QueryClientProvider>
+    );
+  return { ...utils, rerenderDrawer };
 }
 
 describe('LinkProfileDrawer', () => {
@@ -114,6 +135,7 @@ describe('LinkProfileDrawer', () => {
     setLinkProfileModeSpy = vi.fn();
     setLinkEndpointsSpy = vi.fn();
     getElevationProfileMock.mockReset();
+    mockAutoRadioDefaults = { freqMhz: null, rxSensitivityDbm: null, provenance: null };
   });
 
   it('renders nothing when the tool is off and no endpoints were picked', () => {
@@ -206,5 +228,128 @@ describe('LinkProfileDrawer', () => {
     fireEvent.click(screen.getByRole('button', { name: /close link profile/i }));
     expect(setLinkProfileModeSpy).toHaveBeenCalledWith(false);
     expect(setLinkEndpointsSpy).toHaveBeenCalledWith([]);
+  });
+
+  // #4111 Phase 3 WP-2: per-source auto-frequency/RX-sensitivity seeding,
+  // manual-override-wins, re-seed on a new pair, and the provenance hint.
+  describe('auto radio defaults (#4111 P3 WP-2)', () => {
+    it('auto-seeds frequency and RX sensitivity with a provenance hint', async () => {
+      mockAutoRadioDefaults = { freqMhz: 906.875, rxSensitivityDbm: -126.5, provenance: 'from Home Base (US)' };
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      const freqInput = (await screen.findByLabelText(/Frequency \(MHz\)/i)) as HTMLInputElement;
+      await waitFor(() => expect(freqInput.value).toBe('906.875'));
+      const rxInput = screen.getByLabelText(/RX sensitivity/i) as HTMLInputElement;
+      expect(rxInput.value).toBe('-126.5');
+      expect(screen.getByText('from Home Base (US)')).toBeInTheDocument();
+    });
+
+    it('keeps 915 MHz / -129 dBm defaults when no auto suggestion is available', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      const freqInput = (await screen.findByLabelText(/Frequency \(MHz\)/i)) as HTMLInputElement;
+      expect(freqInput.value).toBe('915');
+      const rxInput = screen.getByLabelText(/RX sensitivity/i) as HTMLInputElement;
+      expect(rxInput.value).toBe('-129');
+      expect(screen.queryByText(/^from /)).not.toBeInTheDocument();
+    });
+
+    it('keeps a manually edited frequency and hides the provenance hint once edited', async () => {
+      mockAutoRadioDefaults = { freqMhz: 906.875, rxSensitivityDbm: -126.5, provenance: 'from Home Base (US)' };
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      const freqInput = (await screen.findByLabelText(/Frequency \(MHz\)/i)) as HTMLInputElement;
+      await waitFor(() => expect(freqInput.value).toBe('906.875'));
+
+      fireEvent.change(freqInput, { target: { value: '433' } });
+      expect(freqInput.value).toBe('433');
+      expect(screen.queryByText('from Home Base (US)')).not.toBeInTheDocument();
+
+      // An unrelated budget-input edit re-renders the drawer — the manually
+      // edited frequency must not be clobbered by the still-active auto value.
+      fireEvent.change(screen.getByLabelText(/Antenna A height AGL/i), { target: { value: '3' } });
+      expect(freqInput.value).toBe('433');
+    });
+
+    it('re-seeds frequency and provenance for a newly picked endpoint pair', async () => {
+      mockAutoRadioDefaults = { freqMhz: 906.875, rxSensitivityDbm: -126.5, provenance: 'from Home Base (US)' };
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      const { rerenderDrawer } = renderDrawer();
+
+      const freqInput = (await screen.findByLabelText(/Frequency \(MHz\)/i)) as HTMLInputElement;
+      await waitFor(() => expect(freqInput.value).toBe('906.875'));
+      fireEvent.change(freqInput, { target: { value: '433' } });
+      expect(freqInput.value).toBe('433');
+
+      // Pick a new pair (different endpoint B) with a different source's suggestion.
+      const endpointC: LinkEndpoint = { id: 'node-c', lat: 0.6, lng: 0, isNode: true };
+      mockLinkEndpoints = [endpointA, endpointC];
+      mockAutoRadioDefaults = { freqMhz: 869.525, rxSensitivityDbm: -120, provenance: 'from Repeater Hill' };
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      rerenderDrawer();
+
+      await waitFor(() => expect(freqInput.value).toBe('869.525'));
+      expect(screen.getByText('from Repeater Hill')).toBeInTheDocument();
+    });
+  });
+
+  // #4111 Phase 3 WP-2: friendly per-code copy for the elevation-profile
+  // error branch (server codes from elevationService.ts's validation order).
+  describe('friendly error messages (#4111 P3 WP-2)', () => {
+    it('shows a friendly message for IDENTICAL_POINTS', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockRejectedValue(
+        new ApiError('Identical points', 400, { code: 'IDENTICAL_POINTS' })
+      );
+      renderDrawer();
+      expect(await screen.findByText('Pick two different points.')).toBeInTheDocument();
+    });
+
+    it('shows a friendly message for PATH_TOO_LONG', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockRejectedValue(
+        new ApiError('Path too long', 400, { code: 'PATH_TOO_LONG' })
+      );
+      renderDrawer();
+      expect(
+        await screen.findByText('That link is too long to profile (max 500 km).')
+      ).toBeInTheDocument();
+    });
+
+    it('shows a friendly message for INVALID_COORDINATES', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockRejectedValue(
+        new ApiError('Bad coordinates', 400, { code: 'INVALID_COORDINATES' })
+      );
+      renderDrawer();
+      expect(
+        await screen.findByText('One of the points has invalid coordinates.')
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the generic message for an unmapped error code', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockRejectedValue(new ApiError('Server exploded', 500, { code: 'SOME_OTHER_CODE' }));
+      renderDrawer();
+      expect(
+        await screen.findByText('Failed to load the elevation profile. Please try again.')
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the generic message for a non-ApiError (network) failure', async () => {
+      mockLinkEndpoints = [endpointA, endpointB];
+      getElevationProfileMock.mockRejectedValue(new Error('network down'));
+      renderDrawer();
+      expect(
+        await screen.findByText('Failed to load the elevation profile. Please try again.')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/MapAnalysis/LinkProfileDrawer.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.tsx
@@ -99,13 +99,15 @@ const ChartTooltip: React.FC<{
 
 const LinkProfileDrawer: React.FC = () => {
   const { distanceUnit } = useSettings();
-  const { linkProfileMode, linkEndpoints, setLinkProfileMode, setLinkEndpoints } = useMapAnalysisCtx();
+  const { linkProfileMode, linkEndpoints, setLinkProfileMode, setLinkEndpoints, setLinkVerdict } =
+    useMapAnalysisCtx();
   const [endpointA, endpointB] = linkEndpoints;
 
   const onClose = useCallback(() => {
     setLinkProfileMode(false);
     setLinkEndpoints([]);
-  }, [setLinkProfileMode, setLinkEndpoints]);
+    setLinkVerdict(null);
+  }, [setLinkProfileMode, setLinkEndpoints, setLinkVerdict]);
 
   // Local budget-input state, seeded from documented defaults. Edits
   // recompute the analysis client-side — they never trigger a refetch.
@@ -169,6 +171,19 @@ const LinkProfileDrawer: React.FC = () => {
         : null,
     [analysis, freqMhz, txPowerDbm, txGainDbi, rxGainDbi, cableLossDb, rxSensitivityDbm]
   );
+
+  // Mirror the computed verdict into context so the map-path Polyline
+  // (`LinkProfileController`, rendered outside the drawer) can color itself
+  // to match (#4111 Phase 3 WP-3). Cleared whenever there's no resolved
+  // analysis (no pair picked yet, loading, error, all-null terrain) and on
+  // unmount, so a closed/reset drawer never leaves a stale color behind.
+  useEffect(() => {
+    setLinkVerdict(analysis?.verdict ?? null);
+  }, [analysis?.verdict, setLinkVerdict]);
+
+  useEffect(() => {
+    return () => setLinkVerdict(null);
+  }, [setLinkVerdict]);
 
   const allTerrainNull = profile ? profile.samples.every(s => s.elevation === null) : false;
 

--- a/src/components/MapAnalysis/LinkProfileDrawer.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.tsx
@@ -14,7 +14,7 @@
  * RX sensitivity, k-factor) recomputes `analyzeLinkProfile`/
  * `computeLinkBudget` client-side via `useMemo` — no refetch.
  */
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import {
   ComposedChart,
   Area,
@@ -30,8 +30,9 @@ import {
 import { useSettings } from '../../contexts/SettingsContext';
 import { ApiError } from '../../services/api';
 import { useElevationProfile } from '../../hooks/useElevationProfile';
+import { useAutoRadioDefaults } from '../../hooks/useAutoRadioDefaults';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
-import { analyzeLinkProfile, type LinkVerdict } from '../../utils/linkProfile';
+import { analyzeLinkProfile, VERDICT_LABEL, VERDICT_COLOR } from '../../utils/linkProfile';
 import { computeLinkBudget, DEFAULT_K_FACTOR } from '../../utils/linkBudget';
 import { formatDistance } from '../../utils/distance';
 
@@ -43,17 +44,15 @@ const DEFAULT_GAIN_DBI = 2.15;
 const DEFAULT_CABLE_LOSS_DB = 0;
 const DEFAULT_RX_SENSITIVITY_DBM = -129;
 
-const VERDICT_LABEL: Record<LinkVerdict, string> = {
-  clear: 'Clear',
-  marginal: 'Marginal',
-  obstructed: 'Obstructed',
+// Friendly copy for the elevation-profile error codes the server can return
+// (#4111 P3 WP-2 — elevationService.ts §"Validation order"). Falls back to a
+// generic message for anything else (network failure, unmapped code, etc).
+const FRIENDLY_ERROR_BY_CODE: Record<string, string> = {
+  IDENTICAL_POINTS: 'Pick two different points.',
+  PATH_TOO_LONG: 'That link is too long to profile (max 500 km).',
+  INVALID_COORDINATES: 'One of the points has invalid coordinates.',
 };
-
-const VERDICT_COLOR: Record<LinkVerdict, string> = {
-  clear: '#22c55e',
-  marginal: '#f59e0b',
-  obstructed: '#ef4444',
-};
+const GENERIC_ERROR_MESSAGE = 'Failed to load the elevation profile. Please try again.';
 
 interface ChartTooltipPayloadItem {
   dataKey?: string;
@@ -120,6 +119,28 @@ const LinkProfileDrawer: React.FC = () => {
   const [rxSensitivityDbm, setRxSensitivityDbm] = useState(DEFAULT_RX_SENSITIVITY_DBM);
   const [kFactor, setKFactor] = useState(DEFAULT_K_FACTOR);
 
+  // Per-source auto-frequency/RX-sensitivity suggestion for the picked pair
+  // (#4111 P3 WP-2). Manual edits always win: an auto value only overwrites
+  // the field while the user hasn't touched it *for this endpoint pair* —
+  // picking a new pair resets both "edited" flags so the new pair re-seeds.
+  const auto = useAutoRadioDefaults(endpointA, endpointB);
+  const [freqEdited, setFreqEdited] = useState(false);
+  const [rxEdited, setRxEdited] = useState(false);
+  const pairKey = `${endpointA?.id ?? ''}|${endpointB?.id ?? ''}`;
+
+  useEffect(() => {
+    setFreqEdited(false);
+    setRxEdited(false);
+  }, [pairKey]);
+
+  useEffect(() => {
+    if (!freqEdited && auto.freqMhz != null) setFreqMhz(auto.freqMhz);
+  }, [pairKey, auto.freqMhz, freqEdited]);
+
+  useEffect(() => {
+    if (!rxEdited && auto.rxSensitivityDbm != null) setRxSensitivityDbm(auto.rxSensitivityDbm);
+  }, [pairKey, auto.rxSensitivityDbm, rxEdited]);
+
   const { data: profile, isLoading, error } = useElevationProfile(endpointA, endpointB);
 
   const analysis = useMemo(
@@ -158,6 +179,14 @@ const LinkProfileDrawer: React.FC = () => {
 
   const isElevationDisabled = error instanceof ApiError && error.code === 'ELEVATION_DISABLED';
 
+  // Friendly per-code copy for the elevation-profile error branch (#4111 P3
+  // WP-2). Falls back to the generic message for unmapped codes / non-ApiError
+  // failures (e.g. a network error).
+  const errorMessage =
+    error instanceof ApiError && error.code && FRIENDLY_ERROR_BY_CODE[error.code]
+      ? FRIENDLY_ERROR_BY_CODE[error.code]
+      : GENERIC_ERROR_MESSAGE;
+
   // Nothing to show: tool is off and no endpoints were ever picked. Hooks
   // above are still called unconditionally (react-hooks rule) — this guard
   // runs after them.
@@ -179,9 +208,7 @@ const LinkProfileDrawer: React.FC = () => {
             Terrain elevation is disabled on this server.
           </div>
         ) : error ? (
-          <div className="map-analysis-link-drawer-error">
-            Failed to load the elevation profile. Please try again.
-          </div>
+          <div className="map-analysis-link-drawer-error">{errorMessage}</div>
         ) : allTerrainNull ? (
           <div className="map-analysis-link-drawer-empty">No terrain data for this path.</div>
         ) : analysis ? (
@@ -307,9 +334,13 @@ const LinkProfileDrawer: React.FC = () => {
               onChange={e => {
                 const v = Number(e.target.value);
                 if (!Number.isNaN(v)) setFreqMhz(v);
+                setFreqEdited(true);
               }}
             />
           </label>
+          {auto.provenance && !freqEdited && (
+            <span className="link-profile-provenance">{auto.provenance}</span>
+          )}
           <label>
             Antenna A height AGL (m)
             <input
@@ -391,6 +422,7 @@ const LinkProfileDrawer: React.FC = () => {
               onChange={e => {
                 const v = Number(e.target.value);
                 if (!Number.isNaN(v)) setRxSensitivityDbm(v);
+                setRxEdited(true);
               }}
             />
           </label>

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -60,11 +60,24 @@ export default function MapAnalysisCanvas() {
     [analysisNodes],
   );
 
-  // #4111 Phase 2 (WP-D): Link Profile picker candidates — same underlying
-  // node list as `measurePoints`, tagged `isNode:true` per `LinkEndpoint`.
+  // #4111 Phase 2 (WP-D) / Phase 3 (WP-2): Link Profile picker candidates —
+  // built directly from `analysisNodes` (not `measurePoints`) so each
+  // candidate carries the radio identity (`sourceId`/`nodeNum`/`isMeshCore`)
+  // that `useAutoRadioDefaults` needs to resolve a per-source frequency/RX
+  // suggestion once picked.
   const linkEndpointCandidates: LinkEndpoint[] = useMemo(
-    () => measurePoints.map((p) => ({ ...p, isNode: true })),
-    [measurePoints],
+    () =>
+      analysisNodes.map((a) => ({
+        id: a.key,
+        lat: a.latLng[0],
+        lng: a.latLng[1],
+        label: a.node.shortName ?? undefined,
+        isNode: true,
+        sourceId: a.node.sourceId,
+        nodeNum: a.node.nodeNum,
+        isMeshCore: a.node.isMeshCore ?? false,
+      })),
+    [analysisNodes],
   );
 
   const center: [number, number] = [

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -63,9 +63,13 @@ export default function MapAnalysisCanvas() {
 
   // #4111 Phase 2 (WP-D) / Phase 3 (WP-2): Link Profile picker candidates —
   // built directly from `analysisNodes` (not `measurePoints`) so each
-  // candidate carries the radio identity (`sourceId`/`nodeNum`/`isMeshCore`)
-  // that `useAutoRadioDefaults` needs to resolve a per-source frequency/RX
-  // suggestion once picked.
+  // candidate carries the radio identity (`sourceId`/`sourceIds`/`nodeNum`/
+  // `isMeshCore`) that `useAutoRadioDefaults` needs to resolve a per-source
+  // frequency/RX suggestion once picked. `sourceIds` carries the FULL
+  // membership list (`node.sources`) — a unified-merged node's bare
+  // `sourceId` is just whichever source most recently reported it, which is
+  // frequently a radio-less MQTT bridge for a multi-source node (#4111 P3
+  // WP-2 follow-up).
   const linkEndpointCandidates: LinkEndpoint[] = useMemo(
     () =>
       analysisNodes.map((a) => ({
@@ -75,6 +79,7 @@ export default function MapAnalysisCanvas() {
         label: a.node.shortName ?? undefined,
         isNode: true,
         sourceId: a.node.sourceId,
+        sourceIds: a.node.sources?.map((s) => s.sourceId) ?? (a.node.sourceId ? [a.node.sourceId] : []),
         nodeNum: a.node.nodeNum,
         isMeshCore: a.node.isMeshCore ?? false,
       })),

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -45,6 +45,7 @@ export default function MapAnalysisCanvas() {
     setLinkProfileMode,
     linkEndpoints,
     setLinkEndpoints,
+    linkVerdict,
   } = useMapAnalysisCtx();
 
   // #3636: measurement endpoints, from the same visible+positioned node list
@@ -111,6 +112,7 @@ export default function MapAnalysisCanvas() {
             endpoints={linkEndpoints}
             onPick={setLinkEndpoints}
             onExit={() => setLinkProfileMode(false)}
+            verdict={linkVerdict}
           />
         )}
         <Pane name="waypoints" style={{ zIndex: 650 }}>

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
 import { useMapAnalysisConfig } from '../../hooks/useMapAnalysisConfig';
-import type { LinkEndpoint } from '../../utils/linkProfile';
+import type { LinkEndpoint, LinkVerdict } from '../../utils/linkProfile';
 
 export interface SelectedTarget {
   type: 'node' | 'segment' | 'neighbor' | 'trail';
@@ -49,6 +49,14 @@ type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
   /** Picked endpoints (0..2) for the Link Profile tool; transient, not persisted. */
   linkEndpoints: LinkEndpoint[];
   setLinkEndpoints: (e: LinkEndpoint[]) => void;
+  /**
+   * Computed verdict for the current Link Profile analysis (#4111 Phase 3
+   * WP-3); written by `LinkProfileDrawer` once `analyzeLinkProfile` resolves
+   * and cleared when the drawer unmounts/endpoints reset. Read by the Canvas
+   * to color the map-path Polyline drawn by `LinkProfileController`.
+   */
+  linkVerdict: LinkVerdict | null;
+  setLinkVerdict: (v: LinkVerdict | null) => void;
 };
 
 const Ctx = createContext<CtxShape | null>(null);
@@ -61,6 +69,7 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const [measureMode, setMeasureMode] = useState(false);
   const [linkProfileMode, setLinkProfileMode] = useState(false);
   const [linkEndpoints, setLinkEndpoints] = useState<LinkEndpoint[]>([]);
+  const [linkVerdict, setLinkVerdict] = useState<LinkVerdict | null>(null);
   return (
     <Ctx.Provider
       value={{
@@ -77,6 +86,8 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
         setLinkProfileMode,
         linkEndpoints,
         setLinkEndpoints,
+        linkVerdict,
+        setLinkVerdict,
       }}
     >
       {children}

--- a/src/components/SettingsTab.elevation.test.tsx
+++ b/src/components/SettingsTab.elevation.test.tsx
@@ -1,0 +1,378 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Elevation / Terrain settings section (#4111 Phase 3 WP-3). SettingsTab.tsx
+ * is a very large component wired into many contexts and child sections; this
+ * suite mocks every dependency that isn't the elevation section under test so
+ * it can render in isolation. `mode="global"` narrows the rendered sections to
+ * `GLOBAL_SECTIONS` (elevation is global, not per-source) which keeps the
+ * mocked-child surface as small as possible; `hasPermission` is stubbed to
+ * return false so the (also-global, canWriteSettings-gated) Position
+ * Estimation section doesn't need its own mock.
+ *
+ * Covers:
+ *  - the enable toggle + source URL load from server settings and persist
+ *    into the `POST /api/settings` body on save;
+ *  - the Test button calling `ApiService.testElevationSource` and rendering
+ *    success/failure copy;
+ *  - the `handleSave` dependency-array regression guard (CLAUDE.md gotcha) —
+ *    an edited elevation field must appear in the very next save payload.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SettingsTab from './SettingsTab';
+
+// ---------------------------------------------------------------------------
+// react-i18next: the global setup.ts mock only handles the 2-arg (key,
+// options) form and interpolates into `key`, not into a `defaultValue`. This
+// component calls `t(key, defaultValueString, optionsObject)` (3-arg) for
+// interpolated copy, so override locally to produce the real English text —
+// mirrors MapAnalysisCanvas.test.tsx's override for the same reason.
+// ---------------------------------------------------------------------------
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      arg2?: string | Record<string, unknown>,
+      arg3?: Record<string, unknown>,
+    ) => {
+      let options: Record<string, unknown> | undefined;
+      let defaultValue: string | undefined;
+      if (typeof arg2 === 'string') {
+        defaultValue = arg2;
+        options = arg3;
+      } else {
+        options = arg2;
+        defaultValue = typeof options?.defaultValue === 'string' ? options.defaultValue : undefined;
+      }
+      let out = defaultValue ?? key;
+      if (options) {
+        for (const [k, v] of Object.entries(options)) {
+          out = out.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+        }
+      }
+      return out;
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Contexts / hooks
+// ---------------------------------------------------------------------------
+vi.mock('../hooks/useSaveBar', () => ({
+  useSaveBar: (options: unknown) => {
+    saveBarCapture.current = options as {
+      hasChanges: boolean;
+      onSave: () => Promise<void>;
+      onDismiss: () => void;
+    };
+  },
+}));
+
+const { saveBarCapture } = vi.hoisted(() => ({
+  saveBarCapture: {
+    current: null as null | { hasChanges: boolean; onSave: () => Promise<void>; onDismiss: () => void },
+  },
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authStatus: { user: { isAdmin: true } },
+    // canWriteSettings gates the (unrelated, also-global) Position Estimation
+    // section — keep it out of the render so this suite doesn't also need to
+    // mock PositionEstimationSection.
+    hasPermission: () => false,
+  }),
+}));
+
+vi.mock('../contexts/UIContext', () => ({
+  useUI: () => ({ showIncompleteNodes: true, setShowIncompleteNodes: vi.fn() }),
+}));
+
+vi.mock('./ToastContainer', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+const { csrfFetchMock } = vi.hoisted(() => ({
+  csrfFetchMock: vi.fn(async () => ({ ok: true, json: async () => ({}) })),
+}));
+vi.mock('../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+vi.mock('../hooks/useDashboardData', () => ({
+  useDashboardSources: () => ({ data: [] }),
+}));
+
+vi.mock('../config/tilesets', () => ({
+  getAllTilesets: () => [],
+}));
+
+vi.mock('../contexts/SettingsContext', () => ({
+  getEffectiveTileset: () => 'osm',
+  useSettings: () => ({
+    customThemes: [],
+    customTilesets: [],
+    enableAudioNotifications: false,
+    setEnableAudioNotifications: vi.fn(),
+    linkPreviewsEnabled: true,
+    setLinkPreviewsEnabled: vi.fn(),
+    meshcoreChannelRetryEnabled: false,
+    setMeshcoreChannelRetryEnabled: vi.fn(),
+    nodeDimmingEnabled: false,
+    setNodeDimmingEnabled: vi.fn(),
+    nodeDimmingStartHours: 24,
+    setNodeDimmingStartHours: vi.fn(),
+    nodeDimmingMinOpacity: 0.3,
+    setNodeDimmingMinOpacity: vi.fn(),
+    nodeHopsCalculation: 'auto',
+    setNodeHopsCalculation: vi.fn(),
+    preferredDashboardSortOption: 'custom',
+    setPreferredDashboardSortOption: vi.fn(),
+    neighborInfoMinZoom: 10,
+    setNeighborInfoMinZoom: vi.fn(),
+    defaultMapCenterLat: null,
+    defaultMapCenterLon: null,
+    defaultMapCenterZoom: null,
+    setDefaultMapCenterLat: vi.fn(),
+    setDefaultMapCenterLon: vi.fn(),
+    setDefaultMapCenterZoom: vi.fn(),
+    mapCenterTargetZoom: 10,
+    setMapCenterTargetZoom: vi.fn(),
+    defaultLandingPage: 'dashboard',
+    setDefaultLandingPage: vi.fn(),
+    appearanceMode: 'system',
+    setAppearanceMode: vi.fn(),
+    darkTheme: 'catppuccin',
+    setDarkTheme: vi.fn(),
+    lightTheme: 'catppuccin-latte',
+    setLightTheme: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Child sections unrelated to the elevation UI under test. `mode="global"`
+// plus `isAdmin=true` (needed so the admin-gated elevation section itself
+// renders) still pulls in these global sections' subcomponents — stub them
+// all to `null` so this suite only exercises the elevation JSX.
+// ---------------------------------------------------------------------------
+vi.mock('./PacketMonitorSettings', () => ({ default: () => null }));
+vi.mock('./ChannelSoundPicker', () => ({ default: () => null }));
+vi.mock('./PkiDmGlobalToggle', () => ({ default: () => null }));
+vi.mock('./configuration/SystemBackupSection', () => ({ default: () => null }));
+vi.mock('./configuration/DatabaseMaintenanceSection', () => ({ default: () => null }));
+vi.mock('./configuration/FirmwareUpdateSection', () => ({ default: () => null }));
+vi.mock('./configuration/ChannelDatabaseSection', () => ({ default: () => null }));
+vi.mock('./CustomThemeManagement', () => ({ CustomThemeManagement: () => null }));
+vi.mock('./CustomTilesetManager', () => ({ CustomTilesetManager: () => null }));
+vi.mock('./LanguageSelector', () => ({ LanguageSelector: () => null }));
+vi.mock('./PositionEstimationSection', () => ({ default: () => null }));
+vi.mock('./TapbackEmojiSettings', () => ({ default: () => null }));
+vi.mock('./settings/EmbedSettings', () => ({ default: () => null }));
+vi.mock('./configuration/DefaultMapCenterPicker', () => ({ DefaultMapCenterPicker: () => null }));
+vi.mock('./GeoJsonLayerManager', () => ({ default: () => null }));
+vi.mock('./MapStyleManager', () => ({ default: () => null }));
+
+// ---------------------------------------------------------------------------
+// ApiService — spread the real module so unrelated methods stay callable,
+// override just testElevationSource (mirrors LinkProfileDrawer.test.tsx's
+// getElevationProfile mock pattern).
+// ---------------------------------------------------------------------------
+const { testElevationSourceMock } = vi.hoisted(() => ({ testElevationSourceMock: vi.fn() }));
+vi.mock('../services/api', async importOriginal => {
+  const actual = await importOriginal<typeof import('../services/api')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      testElevationSource: (...args: unknown[]) => testElevationSourceMock(...args),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mount-time raw `fetch` calls (system status / db health / server settings —
+// none of these go through ApiService or csrfFetch).
+// ---------------------------------------------------------------------------
+let serverSettings: Record<string, string>;
+
+function installFetchMock() {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/system/status')) {
+      return { ok: true, json: async () => ({ isDocker: false }) } as Response;
+    }
+    if (url.includes('/api/health')) {
+      return { ok: true, json: async () => ({ databaseType: 'sqlite', firmwareOtaEnabled: false }) } as Response;
+    }
+    if (url.includes('/api/settings')) {
+      return { ok: true, json: async () => serverSettings } as Response;
+    }
+    return { ok: true, json: async () => ({}) } as Response;
+  }) as typeof fetch;
+}
+
+const noop = vi.fn();
+
+const baseProps = {
+  maxNodeAgeHours: 24,
+  inactiveNodeThresholdHours: 4,
+  inactiveNodeCheckIntervalMinutes: 15,
+  inactiveNodeCooldownHours: 1,
+  temperatureUnit: 'C' as const,
+  distanceUnit: 'km' as const,
+  positionHistoryLineStyle: 'linear' as const,
+  telemetryVisualizationHours: 24,
+  favoriteTelemetryStorageDays: 30,
+  preferredSortField: 'longName' as const,
+  preferredSortDirection: 'asc' as const,
+  timeFormat: '24' as const,
+  dateFormat: 'MM/DD/YYYY' as const,
+  mapTilesetLight: 'osm' as const,
+  mapTilesetDark: 'osm' as const,
+  mapPinStyle: 'meshmonitor' as const,
+  iconStyle: 'lucide' as const,
+  theme: 'catppuccin' as const,
+  language: 'en',
+  solarMonitoringEnabled: false,
+  solarMonitoringLatitude: 0,
+  solarMonitoringLongitude: 0,
+  solarMonitoringAzimuth: 180,
+  solarMonitoringDeclination: 30,
+  currentNodeId: '',
+  nodes: [],
+  baseUrl: '',
+  onMaxNodeAgeChange: noop,
+  onInactiveNodeThresholdHoursChange: noop,
+  onInactiveNodeCheckIntervalMinutesChange: noop,
+  onInactiveNodeCooldownHoursChange: noop,
+  onTemperatureUnitChange: noop,
+  onDistanceUnitChange: noop,
+  onPositionHistoryLineStyleChange: noop,
+  onTelemetryVisualizationChange: noop,
+  onFavoriteTelemetryStorageDaysChange: noop,
+  onPreferredSortFieldChange: noop,
+  onPreferredSortDirectionChange: noop,
+  onTimeFormatChange: noop,
+  onDateFormatChange: noop,
+  onMapTilesetsChange: noop,
+  onMapPinStyleChange: noop,
+  onIconStyleChange: noop,
+  onLanguageChange: noop,
+  onSolarMonitoringEnabledChange: noop,
+  onSolarMonitoringLatitudeChange: noop,
+  onSolarMonitoringLongitudeChange: noop,
+  onSolarMonitoringAzimuthChange: noop,
+  onSolarMonitoringDeclinationChange: noop,
+  mode: 'global' as const,
+};
+
+function renderSettings() {
+  return render(<SettingsTab {...baseProps} />);
+}
+
+describe('SettingsTab — Elevation / Terrain section (#4111 Phase 3 WP-3)', () => {
+  beforeEach(() => {
+    serverSettings = { elevationEnabled: 'true', elevationSourceUrl: '' };
+    csrfFetchMock.mockClear();
+    csrfFetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    testElevationSourceMock.mockReset();
+    saveBarCapture.current = null;
+    installFetchMock();
+  });
+
+  it('loads the enabled state and source URL from server settings', async () => {
+    serverSettings = { elevationEnabled: 'false', elevationSourceUrl: 'https://example.com/{z}/{x}/{y}.png' };
+    renderSettings();
+
+    const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+    await waitFor(() => expect(urlInput.value).toBe('https://example.com/{z}/{x}/{y}.png'));
+    const checkbox = document.getElementById('elevationEnabled') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('defaults the enable toggle on when the server key is absent (matches useElevationEnabled semantics)', async () => {
+    serverSettings = {};
+    renderSettings();
+    await screen.findByLabelText(/Elevation Source URL/i);
+    const checkbox = document.getElementById('elevationEnabled') as HTMLInputElement;
+    await waitFor(() => expect(checkbox.checked).toBe(true));
+  });
+
+  it('persists an edited enable toggle and source URL into the save POST body', async () => {
+    renderSettings();
+    const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+    const checkbox = document.getElementById('elevationEnabled') as HTMLInputElement;
+
+    fireEvent.click(checkbox);
+    fireEvent.change(urlInput, { target: { value: 'https://custom.example/{z}/{x}/{y}.png' } });
+
+    expect(saveBarCapture.current).not.toBeNull();
+    await saveBarCapture.current!.onSave();
+
+    expect(csrfFetchMock).toHaveBeenCalledWith(
+      '/api/settings',
+      expect.objectContaining({ method: 'POST' })
+    );
+    const [, options] = csrfFetchMock.mock.calls[csrfFetchMock.mock.calls.length - 1];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.elevationEnabled).toBe('false'); // toggled off from the loaded 'true'
+    expect(body.elevationSourceUrl).toBe('https://custom.example/{z}/{x}/{y}.png');
+  });
+
+  it('handleSave dependency-array regression guard: an edit to ONLY the source URL is reflected in the very next save', async () => {
+    renderSettings();
+    const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+
+    // Edit nothing else — isolates the elevationSourceUrl dependency. If it
+    // were missing from handleSave's useCallback deps (the CLAUDE.md
+    // dep-array gotcha), this change alone would not recreate the callback
+    // and the stale (empty) URL would be POSTed instead.
+    fireEvent.change(urlInput, { target: { value: 'https://regression-guard.example/tiles' } });
+
+    await saveBarCapture.current!.onSave();
+    const [, options] = csrfFetchMock.mock.calls[csrfFetchMock.mock.calls.length - 1];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.elevationSourceUrl).toBe('https://regression-guard.example/tiles');
+  });
+
+  it('Test button calls ApiService.testElevationSource and renders a success message', async () => {
+    testElevationSourceMock.mockResolvedValue({
+      success: true,
+      detectedType: 'terrarium',
+      sampleElevation: 123.4,
+      latencyMs: 42,
+    });
+    renderSettings();
+    const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+    fireEvent.change(urlInput, { target: { value: 'https://probe.example/tiles' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+    expect(testElevationSourceMock).toHaveBeenCalledWith('https://probe.example/tiles');
+    expect(await screen.findByText(/OK — terrarium, 123.4 m in 42 ms/)).toBeInTheDocument();
+  });
+
+  it('Test button renders the server-reported error on a failed probe', async () => {
+    testElevationSourceMock.mockResolvedValue({
+      success: false,
+      detectedType: 'unknown',
+      sampleElevation: null,
+      latencyMs: 10,
+      error: 'Connection refused',
+    });
+    renderSettings();
+    fireEvent.click(await screen.findByRole('button', { name: 'Test' }));
+
+    expect(await screen.findByText('Connection refused')).toBeInTheDocument();
+  });
+
+  it('Test button renders a generic failure message when the probe throws', async () => {
+    testElevationSourceMock.mockRejectedValue(new Error('network down'));
+    renderSettings();
+    fireEvent.click(await screen.findByRole('button', { name: 'Test' }));
+
+    expect(await screen.findByText('network down')).toBeInTheDocument();
+  });
+});

--- a/src/components/SettingsTab.elevation.test.tsx
+++ b/src/components/SettingsTab.elevation.test.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import SettingsTab from './SettingsTab';
+import { DEFAULT_TERRARIUM_URL } from '../types/elevation';
 
 // ---------------------------------------------------------------------------
 // react-i18next: the global setup.ts mock only handles the 2-arg (key,
@@ -352,6 +353,77 @@ describe('SettingsTab — Elevation / Terrain section (#4111 Phase 3 WP-3)', () 
 
     expect(testElevationSourceMock).toHaveBeenCalledWith('https://probe.example/tiles');
     expect(await screen.findByText(/OK — terrarium, 123.4 m in 42 ms/)).toBeInTheDocument();
+  });
+
+  // Browser-validation follow-up to WP-3: clicking Test with an empty URL
+  // field was sending an empty `url` and surfacing the route's raw 400
+  // "Request body must include a url" message, even though the field's own
+  // helper text says an empty value falls back to the default public
+  // Terrarium source. Test must probe what will actually be used.
+  describe('Test button with an empty source URL (default-fallback follow-up)', () => {
+    it('sends the default Terrarium URL instead of an empty string', async () => {
+      testElevationSourceMock.mockResolvedValue({
+        success: true,
+        detectedType: 'terrarium',
+        sampleElevation: 8732,
+        latencyMs: 294,
+      });
+      renderSettings();
+      // serverSettings.elevationSourceUrl is '' in beforeEach — field starts empty.
+      const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+      expect(urlInput.value).toBe('');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+      expect(testElevationSourceMock).toHaveBeenCalledWith(DEFAULT_TERRARIUM_URL);
+    });
+
+    it('trims a whitespace-only field before falling back to the default URL', async () => {
+      testElevationSourceMock.mockResolvedValue({
+        success: true,
+        detectedType: 'terrarium',
+        sampleElevation: 100,
+        latencyMs: 50,
+      });
+      renderSettings();
+      const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+      fireEvent.change(urlInput, { target: { value: '   ' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+      expect(testElevationSourceMock).toHaveBeenCalledWith(DEFAULT_TERRARIUM_URL);
+    });
+
+    it('labels a successful default-source probe result as "(default source)"', async () => {
+      testElevationSourceMock.mockResolvedValue({
+        success: true,
+        detectedType: 'terrarium',
+        sampleElevation: 8732,
+        latencyMs: 294,
+      });
+      renderSettings();
+      fireEvent.click(await screen.findByRole('button', { name: 'Test' }));
+
+      expect(
+        await screen.findByText(/OK — terrarium, 8732 m in 294 ms \(default source\)/)
+      ).toBeInTheDocument();
+    });
+
+    it('does not append the "(default source)" label when an explicit URL was tested', async () => {
+      testElevationSourceMock.mockResolvedValue({
+        success: true,
+        detectedType: 'terrarium',
+        sampleElevation: 123.4,
+        latencyMs: 42,
+      });
+      renderSettings();
+      const urlInput = (await screen.findByLabelText(/Elevation Source URL/i)) as HTMLInputElement;
+      fireEvent.change(urlInput, { target: { value: 'https://probe.example/tiles' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+      const message = await screen.findByText(/OK — terrarium, 123.4 m in 42 ms/);
+      expect(message.textContent).not.toMatch(/default source/);
+    });
   });
 
   it('Test button renders the server-reported error on a failed probe', async () => {

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -96,7 +96,7 @@ interface SettingsTabProps {
 const GLOBAL_SECTIONS = new Set([
   'settings-language', 'settings-units', 'settings-appearance', 'settings-link-previews', 'settings-meshcore-messaging', 'settings-map',
   'settings-security',
-  'settings-apprise-server', 'settings-backup', 'settings-channel-database',
+  'settings-apprise-server', 'settings-elevation', 'settings-backup', 'settings-channel-database',
   'settings-maintenance', 'settings-analytics',
   // Position estimation is a single global, cross-source batch job (issue
   // #3271) — it belongs in global Settings, not the per-source Automation tab.
@@ -278,6 +278,16 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [initialAppriseApiServerUrl, setInitialAppriseApiServerUrl] = useState<string>('');
   const [isTestingApprise, setIsTestingApprise] = useState<boolean>(false);
   const [appriseTestResult, setAppriseTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  // Elevation / Terrain source settings (#4111 Phase 3 WP-3). Mirrors the
+  // Apprise API Server pattern above: local+initial pair for dirty-tracking,
+  // admins receive the unmasked `elevationSourceUrl` (stripSecretSettings
+  // returns the full map to admins).
+  const [localElevationEnabled, setLocalElevationEnabled] = useState(false);
+  const [initialElevationEnabled, setInitialElevationEnabled] = useState(false);
+  const [localElevationSourceUrl, setLocalElevationSourceUrl] = useState('');
+  const [initialElevationSourceUrl, setInitialElevationSourceUrl] = useState('');
+  const [elevationTestResult, setElevationTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const [elevationTesting, setElevationTesting] = useState(false);
   const { showToast } = useToast();
 
   // Fetch system status to determine if running in Docker
@@ -392,6 +402,19 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             : '';
           setLocalAppriseApiServerUrl(appriseApiServerUrl);
           setInitialAppriseApiServerUrl(appriseApiServerUrl);
+
+          // Load Elevation/Terrain source settings (#4111 P3). Defaults to
+          // enabled unless the server explicitly stored 'false' — mirrors
+          // useElevationEnabled()'s semantics. Admins receive the unmasked
+          // elevationSourceUrl value.
+          const elevationEnabledOn = settings.elevationEnabled !== 'false';
+          setLocalElevationEnabled(elevationEnabledOn);
+          setInitialElevationEnabled(elevationEnabledOn);
+          const elevationSourceUrl = typeof settings.elevationSourceUrl === 'string'
+            ? settings.elevationSourceUrl
+            : '';
+          setLocalElevationSourceUrl(elevationSourceUrl);
+          setInitialElevationSourceUrl(elevationSourceUrl);
         }
       } catch (error) {
         logger.error('Failed to fetch server settings:', error);
@@ -512,7 +535,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       nodeDimmingMinOpacity !== initialNodeDimmingSettings.minOpacity ||
       localAnalyticsProvider !== initialAnalyticsProvider ||
       JSON.stringify(localAnalyticsConfig) !== initialAnalyticsConfig ||
-      localAppriseApiServerUrl !== initialAppriseApiServerUrl;
+      localAppriseApiServerUrl !== initialAppriseApiServerUrl ||
+      localElevationEnabled !== initialElevationEnabled ||
+      localElevationSourceUrl !== initialElevationSourceUrl;
     setHasChanges(changed);
   }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTilesetLight, localMapTilesetDark, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localMapCenterTargetZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, localNodeHopsCalculation, localDashboardSortOption,
       maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTilesetLight, mapTilesetDark, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
@@ -526,7 +551,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localMeshcoreCliTimeoutSeconds, initialMeshcoreCliTimeoutSeconds,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity, initialNodeDimmingSettings,
       localAnalyticsProvider, localAnalyticsConfig, initialAnalyticsProvider, initialAnalyticsConfig,
-      localAppriseApiServerUrl, initialAppriseApiServerUrl]);
+      localAppriseApiServerUrl, initialAppriseApiServerUrl,
+      localElevationEnabled, initialElevationEnabled, localElevationSourceUrl, initialElevationSourceUrl]);
 
   // Reset local state to current saved values (for SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -577,6 +603,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalAnalyticsProvider(initialAnalyticsProvider);
     try { setLocalAnalyticsConfig(JSON.parse(initialAnalyticsConfig)); } catch { setLocalAnalyticsConfig({}); }
     setLocalAppriseApiServerUrl(initialAppriseApiServerUrl);
+    setLocalElevationEnabled(initialElevationEnabled);
+    setLocalElevationSourceUrl(initialElevationSourceUrl);
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
@@ -586,7 +614,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       linkPreviewsEnabled, meshcoreChannelRetryEnabled,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialMeshcoreCliTimeoutSeconds, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
-      initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl]);
+      initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl,
+      initialElevationEnabled, initialElevationSourceUrl]);
 
   const getLocalEffectiveTheme = useCallback((): Theme => {
     if (localAppearanceMode === 'dark') return localDarkTheme;
@@ -658,6 +687,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         analyticsProvider: localAnalyticsProvider,
         analyticsConfig: JSON.stringify(localAnalyticsConfig),
         appriseApiServerUrl: localAppriseApiServerUrl.trim(),
+        elevationEnabled: localElevationEnabled ? 'true' : 'false',
+        elevationSourceUrl: localElevationSourceUrl.trim(),
       };
 
       // Save to server
@@ -717,6 +748,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       setInitialAnalyticsProvider(localAnalyticsProvider);
       setInitialAnalyticsConfig(JSON.stringify(localAnalyticsConfig));
       setInitialAppriseApiServerUrl(localAppriseApiServerUrl.trim());
+      setInitialElevationEnabled(localElevationEnabled);
+      setInitialElevationSourceUrl(localElevationSourceUrl.trim());
 
       showToast(t('settings.saved_success'), 'success');
       setHasChanges(false);
@@ -742,7 +775,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringLatitudeChange, onSolarMonitoringLongitudeChange, onSolarMonitoringAzimuthChange,
       onSolarMonitoringDeclinationChange, setShowIncompleteNodes, showToast, t,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity,
-      localAnalyticsProvider, localAnalyticsConfig, localAppriseApiServerUrl]);
+      localAnalyticsProvider, localAnalyticsConfig, localAppriseApiServerUrl,
+      localElevationEnabled, localElevationSourceUrl]);
 
   // Register with SaveBar
   useSaveBar({
@@ -796,6 +830,38 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       setIsTestingApprise(false);
     }
   }, [csrfFetch, baseUrl, localAppriseApiServerUrl, t]);
+
+  // Probes the (unsaved) elevation source URL via ApiService.testElevationSource
+  // (#4111 P3 WP-3) — a raw fetch is banned in components per CLAUDE.md, and
+  // this exercises the POST /api/elevation/test route added in Phase 1.
+  const handleTestElevation = useCallback(async () => {
+    setElevationTesting(true);
+    setElevationTestResult(null);
+    try {
+      const result = await apiService.testElevationSource(localElevationSourceUrl.trim());
+      setElevationTestResult(
+        result.success
+          ? {
+              ok: true,
+              message: t(
+                'settings.elevation_test_success',
+                'OK — {{type}}, {{elev}} m in {{ms}} ms',
+                {
+                  type: result.detectedType,
+                  elev: result.sampleElevation ?? 'n/a',
+                  ms: result.latencyMs,
+                }
+              ),
+            }
+          : { ok: false, message: result.error ?? t('settings.elevation_test_failure_generic', 'Test failed') }
+      );
+    } catch (error) {
+      logger.error('Failed to test elevation source:', error);
+      setElevationTestResult({ ok: false, message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setElevationTesting(false);
+    }
+  }, [localElevationSourceUrl, t]);
 
   const handleFetchSolarEstimates = async () => {
     setIsFetchingSolarEstimates(true);
@@ -1138,6 +1204,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         { id: 'settings-packet-monitor', label: t('settings.packet_monitor') },
         { id: 'settings-solar', label: t('settings.solar_monitoring') },
         ...(isAdmin ? [{ id: 'settings-apprise-server', label: t('settings.apprise_server_section', 'Apprise API Server') }] : []),
+        ...(isAdmin ? [{ id: 'settings-elevation', label: t('settings.elevation_section', 'Elevation / Terrain') }] : []),
         { id: 'settings-backup', label: t('settings.system_backup', 'System Backup') },
         ...(isAdmin ? [{ id: 'settings-channel-database', label: t('channel_database.title', 'Channel Database') }] : []),
         // Only show Database Maintenance for SQLite - it uses SQLite-specific features like VACUUM
@@ -2013,6 +2080,73 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                   }}
                 >
                   {appriseTestResult.message}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>}
+
+        {show('settings-elevation') && isAdmin && <div id="settings-elevation" className="settings-section">
+          <h3>{t('settings.elevation_section', 'Elevation / Terrain')}</h3>
+          <p className="setting-description">
+            {t(
+              'settings.elevation_section_description',
+              'Powers the Map Analysis Link Profile tool\'s terrain chart. Elevation samples are fetched server-side from a public AWS Terrarium DEM tile source by default; you can point it at a different source below.'
+            )}
+          </p>
+          <div className="setting-item">
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <input
+                id="elevationEnabled"
+                type="checkbox"
+                checked={localElevationEnabled}
+                onChange={(e) => setLocalElevationEnabled(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>{t('settings.elevation_enabled_label', 'Enable terrain elevation')}</span>
+            </label>
+            <span className="setting-description">
+              {t('settings.elevation_enabled_description', 'Turns off the Link Profile tool\'s terrain chart when disabled.')}
+            </span>
+          </div>
+          <div className="setting-item">
+            <label htmlFor="elevationSourceUrl">
+              {t('settings.elevation_source_url_label', 'Elevation Source URL')}
+              <span className="setting-description">
+                {t('settings.elevation_source_url_description', 'Leave empty to use the default public AWS Terrarium source.')}
+              </span>
+            </label>
+            <input
+              id="elevationSourceUrl"
+              type="text"
+              value={localElevationSourceUrl}
+              onChange={(e) => setLocalElevationSourceUrl(e.target.value)}
+              placeholder="https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png"
+              className="setting-input"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <div style={{ marginTop: '0.75rem' }}>
+              <button
+                type="button"
+                onClick={handleTestElevation}
+                disabled={elevationTesting}
+                className="save-button"
+                style={{ width: 'auto', padding: '0.5rem 1rem' }}
+              >
+                {elevationTesting
+                  ? t('settings.elevation_testing', 'Testing…')
+                  : t('settings.elevation_test', 'Test')}
+              </button>
+              {elevationTestResult && (
+                <p
+                  className="setting-description"
+                  style={{
+                    marginTop: '0.5rem',
+                    color: elevationTestResult.ok ? 'var(--color-success, #10b981)' : 'var(--color-error, #ef4444)',
+                  }}
+                >
+                  {elevationTestResult.message}
                 </p>
               )}
             </div>

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '../contexts/AuthContext';
 import GeoJsonLayerManager from './GeoJsonLayerManager';
 import MapStyleManager from './MapStyleManager';
 import { useDashboardSources } from '../hooks/useDashboardData';
+import { DEFAULT_TERRARIUM_URL } from '../types/elevation';
 
 type DistanceUnit = 'km' | 'mi';
 type PositionHistoryLineStyle = 'linear' | 'spline';
@@ -834,24 +835,34 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // Probes the (unsaved) elevation source URL via ApiService.testElevationSource
   // (#4111 P3 WP-3) — a raw fetch is banned in components per CLAUDE.md, and
   // this exercises the POST /api/elevation/test route added in Phase 1.
+  //
+  // An empty/whitespace field means "use the default public Terrarium
+  // source" (per the field's own helper text), so Test must probe that
+  // default rather than send an empty `url` — the route 400s on that with a
+  // raw "Request body must include a url" message that leaked into the UI
+  // (browser-validation follow-up to #4111 P3 WP-3).
   const handleTestElevation = useCallback(async () => {
     setElevationTesting(true);
     setElevationTestResult(null);
+    const trimmedUrl = localElevationSourceUrl.trim();
+    const usedDefault = trimmedUrl.length === 0;
+    const effectiveUrl = usedDefault ? DEFAULT_TERRARIUM_URL : trimmedUrl;
     try {
-      const result = await apiService.testElevationSource(localElevationSourceUrl.trim());
+      const result = await apiService.testElevationSource(effectiveUrl);
       setElevationTestResult(
         result.success
           ? {
               ok: true,
-              message: t(
-                'settings.elevation_test_success',
-                'OK — {{type}}, {{elev}} m in {{ms}} ms',
-                {
-                  type: result.detectedType,
-                  elev: result.sampleElevation ?? 'n/a',
-                  ms: result.latencyMs,
-                }
-              ),
+              message:
+                t(
+                  'settings.elevation_test_success',
+                  'OK — {{type}}, {{elev}} m in {{ms}} ms',
+                  {
+                    type: result.detectedType,
+                    elev: result.sampleElevation ?? 'n/a',
+                    ms: result.latencyMs,
+                  }
+                ) + (usedDefault ? ` ${t('settings.elevation_test_default_source_suffix', '(default source)')}` : ''),
             }
           : { ok: false, message: result.error ?? t('settings.elevation_test_failure_generic', 'Test failed') }
       );
@@ -2121,7 +2132,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               type="text"
               value={localElevationSourceUrl}
               onChange={(e) => setLocalElevationSourceUrl(e.target.value)}
-              placeholder="https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png"
+              placeholder={DEFAULT_TERRARIUM_URL}
               className="setting-input"
               autoComplete="off"
               spellCheck={false}

--- a/src/hooks/useAutoRadioDefaults.test.ts
+++ b/src/hooks/useAutoRadioDefaults.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for useAutoRadioDefaults (Terrain Link Profile epic #4111, Phase 3,
+ * WP-2). Mocks `useDashboardSources` directly (rather than fetch) so this
+ * stays a pure unit test of the resolution logic: candidate selection
+ * (A-preferred), radio -> freq/RX/provenance mapping, and graceful nulls.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAutoRadioDefaults } from './useAutoRadioDefaults';
+import type { LinkEndpoint } from '../utils/linkProfile';
+import type { DashboardSource } from './useDashboardData';
+
+const useDashboardSourcesMock = vi.fn();
+vi.mock('./useDashboardData', () => ({
+  useDashboardSources: (...args: unknown[]) => useDashboardSourcesMock(...args),
+}));
+
+function mockSources(sources: DashboardSource[]) {
+  useDashboardSourcesMock.mockReturnValue({ data: sources });
+}
+
+const nodeA: LinkEndpoint = { id: 'node-a', lat: 1, lng: 2, isNode: true, sourceId: 'src-a' };
+const nodeB: LinkEndpoint = { id: 'node-b', lat: 3, lng: 4, isNode: true, sourceId: 'src-b' };
+const arbitraryPoint: LinkEndpoint = { id: 'pt-1', lat: 5, lng: 6, isNode: false };
+
+const SRC_A: DashboardSource = {
+  id: 'src-a',
+  name: 'Home Base',
+  type: 'meshtastic_tcp',
+  enabled: true,
+  radio: { frequencyMhz: 906.875, regionName: 'US', modemPreset: 0 },
+};
+
+const SRC_B: DashboardSource = {
+  id: 'src-b',
+  name: 'Repeater Hill',
+  type: 'meshcore',
+  enabled: true,
+  radio: { frequencyMhz: 869.525 },
+};
+
+describe('useAutoRadioDefaults', () => {
+  it('returns freq/RX/provenance for a node endpoint with a matching radio source', () => {
+    mockSources([SRC_A, SRC_B]);
+    const { result } = renderHook(() => useAutoRadioDefaults(nodeA, undefined));
+    expect(result.current.freqMhz).toBe(906.875);
+    expect(result.current.rxSensitivityDbm).not.toBeNull();
+    expect(result.current.provenance).toBe('from Home Base (US)');
+  });
+
+  it('prefers endpoint A over B when both resolve to a radio-reporting source', () => {
+    mockSources([SRC_A, SRC_B]);
+    const { result } = renderHook(() => useAutoRadioDefaults(nodeA, nodeB));
+    expect(result.current.freqMhz).toBe(906.875);
+    expect(result.current.provenance).toBe('from Home Base (US)');
+  });
+
+  it('falls back to endpoint B when A has no sourceId', () => {
+    mockSources([SRC_A, SRC_B]);
+    const { result } = renderHook(() => useAutoRadioDefaults(arbitraryPoint, nodeB));
+    expect(result.current.freqMhz).toBe(869.525);
+    expect(result.current.provenance).toBe('from Repeater Hill');
+  });
+
+  it('returns all null for two arbitrary (non-node) endpoints', () => {
+    mockSources([SRC_A, SRC_B]);
+    const { result } = renderHook(() =>
+      useAutoRadioDefaults(arbitraryPoint, { ...arbitraryPoint, id: 'pt-2' })
+    );
+    expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+  });
+
+  it('returns all null when the source list has no matching source (deleted/unknown source)', () => {
+    mockSources([SRC_B]);
+    const { result } = renderHook(() => useAutoRadioDefaults(nodeA, undefined));
+    expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+  });
+
+  it('returns all null when the matched source has no radio summary', () => {
+    mockSources([{ ...SRC_A, radio: null }]);
+    const { result } = renderHook(() => useAutoRadioDefaults(nodeA, undefined));
+    expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+  });
+
+  it('sets rxSensitivityDbm null but still returns freqMhz when modemPreset is absent (e.g. MeshCore)', () => {
+    mockSources([SRC_B]);
+    const { result } = renderHook(() => useAutoRadioDefaults(nodeB, undefined));
+    expect(result.current.freqMhz).toBe(869.525);
+    expect(result.current.rxSensitivityDbm).toBeNull();
+    expect(result.current.provenance).toBe('from Repeater Hill');
+  });
+
+  it('returns all null while sources are still loading (data undefined)', () => {
+    useDashboardSourcesMock.mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useAutoRadioDefaults(nodeA, undefined));
+    expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+  });
+
+  it('returns all null when no endpoints are picked', () => {
+    mockSources([SRC_A]);
+    const { result } = renderHook(() => useAutoRadioDefaults(undefined, undefined));
+    expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+  });
+});

--- a/src/hooks/useAutoRadioDefaults.test.ts
+++ b/src/hooks/useAutoRadioDefaults.test.ts
@@ -41,6 +41,34 @@ const SRC_B: DashboardSource = {
   radio: { frequencyMhz: 869.525 },
 };
 
+// #4111 P3 WP-2 follow-up fixtures: a unified-merged node whose primary
+// `sourceId` (newest reporter) is a radio-less MQTT bridge, but whose full
+// `sourceIds` membership also includes a real meshtastic source with a radio.
+const SRC_MQTT: DashboardSource = {
+  id: 'src-mqtt',
+  name: 'Florida MQTT',
+  type: 'mqtt',
+  enabled: true,
+  radio: null,
+};
+
+const SRC_SANDBOX: DashboardSource = {
+  id: 'src-sandbox',
+  name: 'Sandbox',
+  type: 'meshtastic_tcp',
+  enabled: true,
+  radio: { frequencyMhz: 913.125, regionName: 'US', modemPreset: 0 },
+};
+
+const multiSourceNode: LinkEndpoint = {
+  id: 'node-multi',
+  lat: 7,
+  lng: 8,
+  isNode: true,
+  sourceId: 'src-mqtt', // newest reporter — radio-less MQTT bridge
+  sourceIds: ['src-mqtt', 'src-sandbox'],
+};
+
 describe('useAutoRadioDefaults', () => {
   it('returns freq/RX/provenance for a node endpoint with a matching radio source', () => {
     mockSources([SRC_A, SRC_B]);
@@ -102,5 +130,37 @@ describe('useAutoRadioDefaults', () => {
     mockSources([SRC_A]);
     const { result } = renderHook(() => useAutoRadioDefaults(undefined, undefined));
     expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+  });
+
+  describe('multi-source nodes (#4111 P3 WP-2 follow-up)', () => {
+    it('skips a radio-less primary sourceId and seeds from a secondary source in sourceIds', () => {
+      mockSources([SRC_MQTT, SRC_SANDBOX]);
+      const { result } = renderHook(() => useAutoRadioDefaults(multiSourceNode, undefined));
+      expect(result.current.freqMhz).toBe(913.125);
+      expect(result.current.rxSensitivityDbm).not.toBeNull();
+      expect(result.current.provenance).toBe('from Sandbox (US)');
+    });
+
+    it('returns all null when every source in sourceIds is radio-less', () => {
+      mockSources([SRC_MQTT, { ...SRC_SANDBOX, id: 'src-mqtt-2', radio: null }]);
+      const radioLessNode: LinkEndpoint = {
+        id: 'node-radioless',
+        lat: 9,
+        lng: 10,
+        isNode: true,
+        sourceId: 'src-mqtt',
+        sourceIds: ['src-mqtt', 'src-mqtt-2'],
+      };
+      const { result } = renderHook(() => useAutoRadioDefaults(radioLessNode, undefined));
+      expect(result.current).toEqual({ freqMhz: null, rxSensitivityDbm: null, provenance: null });
+    });
+
+    it('exhausts endpoint A\'s full sourceIds list before falling back to endpoint B', () => {
+      mockSources([SRC_MQTT, SRC_SANDBOX, SRC_B]);
+      const { result } = renderHook(() => useAutoRadioDefaults(multiSourceNode, nodeB));
+      // A's list (src-mqtt radio-less, src-sandbox has radio) resolves before B is consulted.
+      expect(result.current.freqMhz).toBe(913.125);
+      expect(result.current.provenance).toBe('from Sandbox (US)');
+    });
   });
 });

--- a/src/hooks/useAutoRadioDefaults.ts
+++ b/src/hooks/useAutoRadioDefaults.ts
@@ -12,6 +12,14 @@
  * is a node with a matching, radio-reporting source — the drawer then keeps
  * its documented 915 MHz / −129 dBm defaults. No network fetch of its own;
  * reuses the already-polled `useDashboardSources()` query.
+ *
+ * WP-2 follow-up (browser-validation fix): a unified-merged node's bare
+ * `sourceId` is whichever source most recently reported it (see
+ * `mergeNodeRecords` in `useDashboardData.ts`), which for a multi-source node
+ * is frequently a radio-less MQTT bridge. `LinkEndpoint.sourceIds` carries
+ * the node's FULL source membership (newest-first, primary `sourceId`
+ * first) — we walk endpoint A's full list, then endpoint B's, and seed from
+ * the first source in that order that actually reports a `radio.frequencyMhz`.
  */
 import { useMemo } from 'react';
 import { useDashboardSources } from './useDashboardData';
@@ -27,22 +35,38 @@ export interface AutoRadioDefaults {
 
 const EMPTY_DEFAULTS: AutoRadioDefaults = { freqMhz: null, rxSensitivityDbm: null, provenance: null };
 
+/** Every source id that reported this endpoint's node, primary first, truthy-filtered. Empty for non-node endpoints. */
+function candidateSourceIds(endpoint?: LinkEndpoint): string[] {
+  if (!endpoint?.isNode) return [];
+  const ids = endpoint.sourceIds ?? [endpoint.sourceId];
+  return ids.filter((id): id is string => !!id);
+}
+
 export function useAutoRadioDefaults(a?: LinkEndpoint, b?: LinkEndpoint): AutoRadioDefaults {
   const { data: sources } = useDashboardSources();
 
+  // Computed outside the memo (plain, cheap array ops) and reduced to stable
+  // string keys so the memo's dependency array doesn't churn on `a`/`b`
+  // object identity or need to read `a`/`b` directly (exhaustive-deps stays
+  // satisfied with primitive deps — no suppression).
+  const aIdsKey = candidateSourceIds(a).join(',');
+  const bIdsKey = candidateSourceIds(b).join(',');
+
   return useMemo((): AutoRadioDefaults => {
-    const candidateSourceId =
-      a?.isNode && a.sourceId ? a.sourceId : b?.isNode && b.sourceId ? b.sourceId : undefined;
-    if (!candidateSourceId || !sources) return EMPTY_DEFAULTS;
+    if (!sources) return EMPTY_DEFAULTS;
 
-    const source = sources.find(s => s.id === candidateSourceId);
-    const radio = source?.radio;
-    if (!source || !radio || radio.frequencyMhz == null) return EMPTY_DEFAULTS;
+    const orderedIds = [...(aIdsKey ? aIdsKey.split(',') : []), ...(bIdsKey ? bIdsKey.split(',') : [])];
+    for (const id of orderedIds) {
+      const source = sources.find(s => s.id === id);
+      const radio = source?.radio;
+      if (!source || !radio || radio.frequencyMhz == null) continue;
 
-    const rxSensitivityDbm =
-      radio.modemPreset != null ? rxSensitivityForModemPreset(radio.modemPreset) : null;
-    const provenance = `from ${source.name}${radio.regionName ? ` (${radio.regionName})` : ''}`;
+      const rxSensitivityDbm =
+        radio.modemPreset != null ? rxSensitivityForModemPreset(radio.modemPreset) : null;
+      const provenance = `from ${source.name}${radio.regionName ? ` (${radio.regionName})` : ''}`;
+      return { freqMhz: radio.frequencyMhz, rxSensitivityDbm, provenance };
+    }
 
-    return { freqMhz: radio.frequencyMhz, rxSensitivityDbm, provenance };
-  }, [sources, a?.sourceId, a?.isNode, b?.sourceId, b?.isNode]);
+    return EMPTY_DEFAULTS;
+  }, [sources, aIdsKey, bIdsKey]);
 }

--- a/src/hooks/useAutoRadioDefaults.ts
+++ b/src/hooks/useAutoRadioDefaults.ts
@@ -1,0 +1,48 @@
+/**
+ * Auto-frequency / RX-sensitivity defaults for the Terrain Link Profile tool
+ * (epic #4111, Phase 3, WP-2). Derives a suggested center frequency + RX
+ * sensitivity + a human-readable provenance string from the picked endpoint
+ * pair's per-source `radio` summary (the public, non-secret field added to
+ * `GET /api/sources` in WP-1 — see `src/types/elevation.ts`
+ * `SourceRadioSummary` and `src/hooks/useDashboardData.ts`
+ * `DashboardSource.radio`).
+ *
+ * Prefers endpoint A when both are resolvable node endpoints (spec
+ * LINK_PROFILE_POLISH_SPEC.md §2.9). Returns all-null when neither endpoint
+ * is a node with a matching, radio-reporting source — the drawer then keeps
+ * its documented 915 MHz / −129 dBm defaults. No network fetch of its own;
+ * reuses the already-polled `useDashboardSources()` query.
+ */
+import { useMemo } from 'react';
+import { useDashboardSources } from './useDashboardData';
+import { rxSensitivityForModemPreset } from '../utils/linkBudget';
+import type { LinkEndpoint } from '../utils/linkProfile';
+
+export interface AutoRadioDefaults {
+  freqMhz: number | null;
+  rxSensitivityDbm: number | null;
+  /** e.g. "from Home Base (US)"; null whenever freqMhz is null. */
+  provenance: string | null;
+}
+
+const EMPTY_DEFAULTS: AutoRadioDefaults = { freqMhz: null, rxSensitivityDbm: null, provenance: null };
+
+export function useAutoRadioDefaults(a?: LinkEndpoint, b?: LinkEndpoint): AutoRadioDefaults {
+  const { data: sources } = useDashboardSources();
+
+  return useMemo((): AutoRadioDefaults => {
+    const candidateSourceId =
+      a?.isNode && a.sourceId ? a.sourceId : b?.isNode && b.sourceId ? b.sourceId : undefined;
+    if (!candidateSourceId || !sources) return EMPTY_DEFAULTS;
+
+    const source = sources.find(s => s.id === candidateSourceId);
+    const radio = source?.radio;
+    if (!source || !radio || radio.frequencyMhz == null) return EMPTY_DEFAULTS;
+
+    const rxSensitivityDbm =
+      radio.modemPreset != null ? rxSensitivityForModemPreset(radio.modemPreset) : null;
+    const provenance = `from ${source.name}${radio.regionName ? ` (${radio.regionName})` : ''}`;
+
+    return { freqMhz: radio.frequencyMhz, rxSensitivityDbm, provenance };
+  }, [sources, a?.sourceId, a?.isNode, b?.sourceId, b?.isNode]);
+}

--- a/src/hooks/useAutoRadioDefaults.ts
+++ b/src/hooks/useAutoRadioDefaults.ts
@@ -61,8 +61,11 @@ export function useAutoRadioDefaults(a?: LinkEndpoint, b?: LinkEndpoint): AutoRa
       const radio = source?.radio;
       if (!source || !radio || radio.frequencyMhz == null) continue;
 
-      const rxSensitivityDbm =
+      // Rounded to 0.1 dB — this seeds a visible <input>, and the raw formula
+      // output (e.g. -126.52059991327963) is noise past the first decimal.
+      const rawSensitivity =
         radio.modemPreset != null ? rxSensitivityForModemPreset(radio.modemPreset) : null;
+      const rxSensitivityDbm = rawSensitivity != null ? Math.round(rawSensitivity * 10) / 10 : null;
       const provenance = `from ${source.name}${radio.regionName ? ` (${radio.regionName})` : ''}`;
       return { freqMhz: radio.frequencyMhz, rxSensitivityDbm, provenance };
     }

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -11,6 +11,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { isBogusPosition } from '../utils/nullIsland';
 import { classifyNodeTransport, type NodeTransportClass } from '../utils/nodeTransport';
 import { unifiedNodeKey } from '../utils/nodeIdentity';
+import type { SourceRadioSummary } from '../types/elevation';
 
 /**
  * A data source configured in MeshMonitor
@@ -23,6 +24,13 @@ export interface DashboardSource {
   config?: Record<string, unknown>;
   createdAt?: number;
   updatedAt?: number;
+  /**
+   * Public, non-secret per-source radio summary (#4111 P3 WP-1) — center
+   * frequency / region, used by the Link Profile tool's per-source
+   * auto-frequency detection. `null` for sources with no local radio (MQTT)
+   * or when the manager isn't reachable; absent on older cached responses.
+   */
+  radio?: SourceRadioSummary | null;
 }
 
 /**

--- a/src/server/routes/sourceRoutes.radio.test.ts
+++ b/src/server/routes/sourceRoutes.radio.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Source Routes — public `radio` summary on GET /api/sources
+ * (Terrain Link Profile epic #4111, Phase 3 WP-1).
+ *
+ * `radio` is an additive, non-secret field derived per-source from the live
+ * manager (Meshtastic LoRa config / MeshCore local node radio freq). It must
+ * be visible to anonymous callers (no permission gate — same posture as the
+ * rest of the GET /api/sources list) and must never turn a healthy sources
+ * list into a 500 when a manager throws.
+ *
+ * Uses createRouteTestApp() per CLAUDE.md: real DB-backed sources (seeded by
+ * the harness as sourceA/sourceB, both meshtastic_tcp), real optionalAuth.
+ * Only sourceManagerRegistry is mocked — its manager lookups are pure
+ * in-memory objects the router calls at request time, not DB state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+  },
+}));
+
+const mockGetManager = sourceManagerRegistry.getManager as unknown as ReturnType<typeof vi.fn>;
+
+describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+    mockGetManager.mockReset();
+    mockGetManager.mockReturnValue(null);
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  it('includes a meshtastic radio summary (frequencyMhz/regionName/modemPreset) — visible anonymously', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        getCurrentConfig: () => ({
+          deviceConfig: {
+            lora: {
+              region: 1, // US
+              channelNum: 21,
+              overrideFrequency: 0,
+              frequencyOffset: 0,
+              bandwidth: 250,
+              modemPreset: 0, // LONG_FAST
+            },
+          },
+        }),
+      };
+    });
+
+    const agent = await harness.loginAs(null); // anonymous
+    const res = await agent.get('/');
+
+    expect(res.status).toBe(200);
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a).toBeDefined();
+    expect(a.radio).toEqual({
+      frequencyMhz: expect.closeTo(907.125, 2),
+      regionName: 'US',
+      modemPreset: 0,
+    });
+  });
+
+  it('honors overrideFrequency on the meshtastic summary', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        getCurrentConfig: () => ({
+          deviceConfig: {
+            lora: {
+              region: 1,
+              channelNum: 21,
+              overrideFrequency: 915.5,
+              frequencyOffset: 0,
+              bandwidth: 250,
+              modemPreset: 0,
+            },
+          },
+        }),
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio.frequencyMhz).toBeCloseTo(915.5, 3);
+  });
+
+  it('includes a meshcore radio summary ({ frequencyMhz }) derived from getLocalNode().radioFreq', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceB) return null;
+      return {
+        sourceType: 'meshcore',
+        getLocalNode: () => ({ publicKey: 'abc', name: 'MC', advType: 1, radioFreq: 869.525 }),
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const b = res.body.find((s: { id: string }) => s.id === harness.sourceB);
+    expect(b.radio).toEqual({ frequencyMhz: 869.525 });
+  });
+
+  it('returns radio: null when no manager is registered for the source', async () => {
+    mockGetManager.mockReturnValue(null);
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio).toBeNull();
+  });
+
+  it('returns radio: null (not a 500) for an MQTT-type manager with no local radio', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return { sourceType: 'mqtt_broker' };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(res.status).toBe(200);
+    expect(a.radio).toBeNull();
+  });
+
+  it('never 500s when a manager throws from getCurrentConfig() — the whole list still returns 200', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        getCurrentConfig: () => {
+          throw new Error('boom');
+        },
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    expect(res.status).toBe(200);
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio).toBeNull();
+    // sourceB (no manager throw) still resolves normally alongside it.
+    const b = res.body.find((s: { id: string }) => s.id === harness.sourceB);
+    expect(b).toBeDefined();
+  });
+
+  it('admin sees the same radio summary as anonymous (additive, not permission-gated)', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        getCurrentConfig: () => ({
+          deviceConfig: {
+            lora: { region: 3, channelNum: 1, overrideFrequency: 0, frequencyOffset: 0, bandwidth: 250, modemPreset: 0 },
+          },
+        }),
+      };
+    });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio.regionName).toBe('EU_868');
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -7,7 +7,8 @@ import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { MeshtasticManager } from '../meshtasticManager.js';
 import { meshcoreConfigFromSource, ensureMeshCoreManagerStarted } from '../meshcoreConfig.js';
 import { MeshCoreManager } from '../meshcoreManager.js';
-import { isMeshCoreManager } from '../sourceManagerTypes.js';
+import { isMeshCoreManager, isMeshtasticManager } from '../sourceManagerTypes.js';
+import { loRaCenterFrequencyMhz, REGION_SHORT_NAME } from '../../utils/loraFrequency.js';
 import { MqttBrokerManager, type MqttBrokerSourceConfig } from '../mqttBrokerManager.js';
 import { MqttBridgeManager, type MqttBridgeSourceConfig } from '../mqttBridgeManager.js';
 import waypointRoutes from './waypoints.js';
@@ -236,6 +237,60 @@ function stripSourceSecrets<T extends { config?: unknown } | null | undefined>(
   return { ...source, config: rest };
 }
 
+// Public, non-secret per-source radio summary attached to GET /api/sources
+// below (#4111 P3 WP-1). Center frequency / region is inherently public RF
+// information — it is broadcast over the air and printed on every node's
+// config screen — so exposing it on the already-public sources list carries
+// no secret. This is the ONE additive backend field for the Terrain Link
+// Profile tool's per-source frequency auto-detection; see
+// docs/internal/dev-notes/LINK_PROFILE_POLISH_SPEC.md §0.1 for the full
+// rationale (rejected alternative: gated per-endpoint fetches).
+interface SourceRadioSummary {
+  frequencyMhz: number | null;
+  /** Meshtastic only. */
+  regionName?: string;
+  /** Meshtastic only — drives RX-sensitivity auto-seed. */
+  modemPreset?: number;
+}
+
+// Wrapped in try/catch so a manager that throws from getCurrentConfig()/
+// localNode access can never break the sources list (returns null instead).
+function computeSourceRadioSummary(sourceId: string): SourceRadioSummary | null {
+  try {
+    const mgr = sourceManagerRegistry.getManager(sourceId);
+    if (!mgr) return null;
+    if (isMeshtasticManager(mgr)) {
+      const lora = mgr.getCurrentConfig()?.deviceConfig?.lora;
+      if (!lora) return null;
+      const region = Number(lora.region ?? 0);
+      const frequencyMhz = loRaCenterFrequencyMhz(
+        region,
+        Number(lora.channelNum ?? 0),
+        Number(lora.overrideFrequency ?? 0),
+        Number(lora.frequencyOffset ?? 0),
+        Number(lora.bandwidth ?? 250),
+        undefined,
+        Number(lora.modemPreset ?? 0),
+      );
+      return {
+        frequencyMhz,
+        regionName: REGION_SHORT_NAME[region],
+        modemPreset: Number(lora.modemPreset ?? 0),
+      };
+    }
+    if (isMeshCoreManager(mgr)) {
+      // localNode is a private field on MeshCoreManager — use the public
+      // accessor rather than reaching into it directly.
+      const freq = mgr.getLocalNode()?.radioFreq;
+      return { frequencyMhz: typeof freq === 'number' && Number.isFinite(freq) ? freq : null };
+    }
+    return null; // MQTT / bridge sources have no local radio.
+  } catch (error) {
+    logger.debug(`Error computing radio summary for source ${sourceId}:`, error);
+    return null;
+  }
+}
+
 // List all sources — public so the landing page can redirect unauthenticated users
 // to the single-source view (or show the login button on the source list page).
 // Sensitive config fields are not exposed.
@@ -255,6 +310,7 @@ router.get('/', optionalAuth(), async (req: Request, res: Response) => {
       createdAt: s.createdAt,
       updatedAt: s.updatedAt,
       config: s.config,
+      radio: computeSourceRadioSummary(s.id),
     }, isAdmin));
     res.json(projected);
   } catch (error) {

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -419,6 +419,12 @@ describe('Settings Persistence', () => {
         // Apprise API server URL (#3012) — loaded directly by SettingsTab,
         // not surfaced via SettingsContext (admin-only field, no global hook).
         'appriseApiServerUrl',
+        // Elevation/Terrain source settings (#4111 Phase 3 WP-3) — loaded
+        // directly by SettingsTab (admin-only field, no global hook), same
+        // as appriseApiServerUrl above. `elevationEnabled` is also read
+        // publicly via GET /api/settings by useElevationEnabled(), but that's
+        // a direct fetch, not SettingsContext.
+        'elevationEnabled', 'elevationSourceUrl',
       ];
 
       const keysNotLoaded = SETTINGS_TAB_SENDS.filter(

--- a/src/server/services/elevationProvider.test.ts
+++ b/src/server/services/elevationProvider.test.ts
@@ -22,6 +22,7 @@ import {
   detectProviderType,
   decodeTerrariumTile,
   resolveProvider,
+  sanitizeElevation,
   TerrariumTileProvider,
   JsonPointProvider,
   DEFAULT_TERRARIUM_URL,
@@ -126,6 +127,48 @@ describe('decodeTerrariumTile', () => {
   });
 });
 
+describe('sanitizeElevation (#4111 P3 WP-1 DEM void clamp)', () => {
+  it('nulls a Terrarium bathymetry void (e.g. Lake Pontchartrain ~-12000m)', () => {
+    expect(sanitizeElevation(-12000)).toBeNull();
+  });
+
+  it('nulls a value at/below the -500m floor', () => {
+    expect(sanitizeElevation(-500.01)).toBeNull();
+    expect(sanitizeElevation(-501)).toBeNull();
+  });
+
+  it('nulls a defensive out-of-range high value (>9000m)', () => {
+    expect(sanitizeElevation(9000.01)).toBeNull();
+    expect(sanitizeElevation(20000)).toBeNull();
+  });
+
+  it('passes through a valid ocean (0m) sample unchanged', () => {
+    expect(sanitizeElevation(0)).toBe(0);
+  });
+
+  it('passes through a valid +100m sample unchanged', () => {
+    expect(sanitizeElevation(100)).toBe(100);
+  });
+
+  it('passes through a valid below-sea-level-but-real sample (e.g. Death Valley -86m)', () => {
+    expect(sanitizeElevation(-86)).toBe(-86);
+  });
+
+  it('passes through the boundary values (-500m and 9000m) unchanged', () => {
+    expect(sanitizeElevation(-500)).toBe(-500);
+    expect(sanitizeElevation(9000)).toBe(9000);
+  });
+
+  it('nulls a null input', () => {
+    expect(sanitizeElevation(null)).toBeNull();
+  });
+
+  it('nulls a non-finite input', () => {
+    expect(sanitizeElevation(NaN)).toBeNull();
+    expect(sanitizeElevation(Infinity)).toBeNull();
+  });
+});
+
 describe('TerrariumTileProvider.sample', () => {
   const point = { lat: 40.0, lng: -105.0 }; // arbitrary land coordinate
 
@@ -195,6 +238,28 @@ describe('TerrariumTileProvider.sample', () => {
     expect(results).toEqual([500, 500]);
     expect(mockSafeFetch).toHaveBeenCalledTimes(1);
   });
+
+  it('nulls a Terrarium bathymetry-void pixel (#4111 P3 WP-1)', async () => {
+    const tile = makeUniformTerrariumTile(-12000, TILE_SIZE);
+    mockSafeFetch.mockResolvedValue(fakeResponse({ ok: true, buffer: tile }));
+
+    const voidPoint = { lat: 30.0, lng: -90.1 }; // roughly Lake Pontchartrain
+    const provider = new TerrariumTileProvider(DEFAULT_TERRARIUM_URL);
+    const [elevation] = await provider.sample([voidPoint]);
+
+    expect(elevation).toBeNull();
+  });
+
+  it('nulls a defensive out-of-range high pixel (>9000m, #4111 P3 WP-1)', async () => {
+    const tile = makeUniformTerrariumTile(12000, TILE_SIZE);
+    mockSafeFetch.mockResolvedValue(fakeResponse({ ok: true, buffer: tile }));
+
+    const highPoint = { lat: 27.98, lng: 86.92 }; // arbitrary — value is what's under test
+    const provider = new TerrariumTileProvider(DEFAULT_TERRARIUM_URL);
+    const [elevation] = await provider.sample([highPoint]);
+
+    expect(elevation).toBeNull();
+  });
 });
 
 describe('JsonPointProvider.sample', () => {
@@ -260,6 +325,20 @@ describe('JsonPointProvider.sample', () => {
 
     expect(results).toHaveLength(150);
     expect(mockSafeFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('nulls a -9999-style no-data sentinel elevation (#4111 P3 WP-1)', async () => {
+    mockSafeFetch.mockResolvedValue(
+      fakeJsonResponse({
+        ok: true,
+        body: { results: [{ elevation: -9999, location: { lat: 8, lng: 8 } }] },
+      })
+    );
+
+    const provider = new JsonPointProvider(template);
+    const results = await provider.sample([{ lat: 8, lng: 8 }]);
+
+    expect(results).toEqual([null]);
   });
 
   it('substitutes a {locations} placeholder when present in the template', async () => {

--- a/src/server/services/elevationProvider.ts
+++ b/src/server/services/elevationProvider.ts
@@ -51,6 +51,29 @@ const JSON_CACHE_MAX = 10_000;
 const JSON_BATCH_SIZE = 100;
 
 /**
+ * Below this metres a Terrarium/DEM sample is a void/bathymetry artifact, not
+ * real terrain (#4111 P3 WP-1) — e.g. Terrarium encodes Lake Pontchartrain as
+ * roughly -12000 m. Real terrain (including below-sea-level basins like Death
+ * Valley at -86 m) never approaches this.
+ */
+const MIN_VALID_ELEVATION_M = -500;
+
+/** Defensive upper clamp — no terrestrial point exceeds Everest (~8849 m). */
+const MAX_VALID_ELEVATION_M = 9000;
+
+/**
+ * Clamps a raw provider elevation to `null` when it falls outside the
+ * physically-plausible range, so DEM voids/bathymetry artifacts surface as
+ * "no data" (excluded from verdict/worst by `analyzeLinkProfile`) rather than
+ * as wildly wrong terrain (#4111 P3 WP-1, spec §0.3).
+ */
+export function sanitizeElevation(v: number | null): number | null {
+  if (v === null || !Number.isFinite(v)) return null;
+  if (v < MIN_VALID_ELEVATION_M || v > MAX_VALID_ELEVATION_M) return null;
+  return v;
+}
+
+/**
  * URL-shape detection: a `{z}`/`{x}`/`{y}` slippy-tile template is a
  * terrarium PNG source; anything else is treated as an Open-Topo-Data
  * compatible JSON point API.
@@ -147,7 +170,11 @@ export class TerrariumTileProvider implements ElevationProvider {
         const tile = await this.getTile(key, group.x, group.y);
         if (!tile) return; // Fetch/decode failure — leave this tile's points as null.
         for (const { index, px, py } of group.members) {
-          results[index] = tile[py * TILE_SIZE + px];
+          // Clamp DEM voids/bathymetry artifacts (e.g. Terrarium's ~-12000 m
+          // over Lake Pontchartrain) to null (#4111 P3 WP-1). Applied at read
+          // time (not cache-write time) so it covers both fresh-fetch and
+          // cache-hit paths without changing the cached Float32Array's dtype.
+          results[index] = sanitizeElevation(tile[py * TILE_SIZE + px]);
         }
       })
     );
@@ -274,7 +301,9 @@ export class JsonPointProvider implements ElevationProvider {
       const items = body.results ?? [];
       for (let j = 0; j < indices.length; j++) {
         const index = indices[j];
-        const elevation = items[j]?.elevation ?? null;
+        // Clamp DEM voids/out-of-range values (e.g. a `-9999` no-data sentinel)
+        // to null before caching so a bad sample is never re-served (#4111 P3 WP-1).
+        const elevation = sanitizeElevation(items[j]?.elevation ?? null);
         results[index] = elevation;
         jsonCache.set(jsonCacheKey(points[index].lat, points[index].lng), elevation);
       }

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -822,6 +822,63 @@ describe('ApiService BASE_URL Support', () => {
     });
   });
 
+  describe('Elevation API Methods (#4111 P3 WP-1)', () => {
+    beforeEach(() => {
+      (apiService as any).configFetched = true;
+      (apiService as any).baseUrl = '';
+    });
+
+    it('testElevationSource POSTs { url } and returns the unwrapped .data envelope', async () => {
+      const testResult = {
+        success: true,
+        detectedType: 'terrarium',
+        sampleElevation: 1608.5,
+        latencyMs: 123,
+      };
+      mockFetch.mockResolvedValue(createMockResponse({ success: true, data: testResult }));
+
+      const result = await apiService.testElevationSource('https://example.com/{z}/{x}/{y}.png');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/elevation/test', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ url: 'https://example.com/{z}/{x}/{y}.png' }),
+      }));
+      // Unwrapped: the caller receives the inner TestResult, not the envelope.
+      expect(result).toEqual(testResult);
+    });
+
+    it('testElevationSource includes lat/lng when a probe point is given', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({
+        success: true,
+        data: { success: true, detectedType: 'json', sampleElevation: 10, latencyMs: 50 },
+      }));
+
+      await apiService.testElevationSource('https://api.example.com/v1/dem', { lat: 40, lng: -105 });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/elevation/test', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ url: 'https://api.example.com/v1/dem', lat: 40, lng: -105 }),
+      }));
+    });
+
+    it('testElevationSource returns a success:false probe outcome without throwing', async () => {
+      const failedProbe = {
+        success: false,
+        detectedType: 'json',
+        sampleElevation: null,
+        latencyMs: 45,
+        httpStatus: 503,
+        error: 'Upstream unavailable',
+      };
+      mockFetch.mockResolvedValue(createMockResponse({ success: true, data: failedProbe }));
+
+      const result = await apiService.testElevationSource('https://down.example.com/dem');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Upstream unavailable');
+    });
+  });
+
   describe('ApiError handling', () => {
     const createErrorResponse = (status: number, body: any, headers: Record<string, string> = {}) => ({
       ok: false,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,6 @@
 import { DeviceInfo, Channel } from '../types/device';
 import { MeshMessage } from '../types/message';
-import type { ElevationProfile } from '../types/elevation';
+import type { ElevationProfile, ElevationTestResult } from '../types/elevation';
 import {
   sanitizeTextInput,
   validateChannel,
@@ -1555,6 +1555,25 @@ class ApiService {
     const res = await this.post<{ success: boolean; data: ElevationProfile }>(
       '/api/elevation/profile',
       samples != null ? { pointA, pointB, samples } : { pointA, pointB },
+    );
+    return res.data;
+  }
+
+  /**
+   * Probes an elevation source URL via `POST /api/elevation/test` (admin
+   * only, `settings:write`) — powers the Settings tab's Test button (#4111
+   * P3). Unwraps the `{ success, data }` envelope like `getElevationProfile`
+   * above. A `success:false` result is a valid probe outcome (bad URL,
+   * unreachable host, etc.), not a thrown error — callers branch on
+   * `result.success`.
+   */
+  async testElevationSource(
+    url: string,
+    probe?: { lat: number; lng: number },
+  ): Promise<ElevationTestResult> {
+    const res = await this.post<{ success: boolean; data: ElevationTestResult }>(
+      '/api/elevation/test',
+      probe ? { url, lat: probe.lat, lng: probe.lng } : { url },
     );
     return res.data;
   }

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -717,3 +717,12 @@
 .map-analysis-link-drawer-form input.map-analysis-tr-num {
   width: 90px;
 }
+
+/* Auto-frequency provenance hint (#4111 P3 WP-2) — sits under the Frequency
+   input, only while the auto-seeded value hasn't been manually overridden. */
+.link-profile-provenance {
+  font-size: 10px;
+  color: #64748b;
+  text-align: right;
+  margin-top: -4px;
+}

--- a/src/types/elevation.ts
+++ b/src/types/elevation.ts
@@ -44,3 +44,17 @@ export interface SourceRadioSummary {
   /** Meshtastic only — drives RX-sensitivity auto-seed. */
   modemPreset?: number;
 }
+
+/**
+ * Frontend mirror of `src/server/services/elevationProvider.ts`'s
+ * `DEFAULT_TERRARIUM_URL` (#4111 P3 WP-3 follow-up). The server module can't
+ * be imported client-side, so this is duplicated by hand — keep both values
+ * in sync if the default source ever changes. Used by the Settings tab's
+ * elevation Test button so testing an empty source-URL field probes the same
+ * URL the backend actually falls back to (`elevationProvider.ts`'s
+ * `sourceUrl && sourceUrl.trim().length > 0 ? sourceUrl.trim() : DEFAULT_TERRARIUM_URL`),
+ * instead of sending an empty `url` and surfacing the route's 400 validation
+ * error.
+ */
+export const DEFAULT_TERRARIUM_URL =
+  'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png';

--- a/src/types/elevation.ts
+++ b/src/types/elevation.ts
@@ -19,3 +19,28 @@ export interface ElevationProfile {
   provider: string;
   samples: ElevationSample[];
 }
+
+/** Mirror of elevationService `TestResult` for the settings Test button (#4111 P3). */
+export interface ElevationTestResult {
+  success: boolean;
+  detectedType: string;
+  sampleElevation: number | null;
+  latencyMs: number;
+  httpStatus?: number;
+  error?: string;
+}
+
+/**
+ * Client mirror of `sourceRoutes.ts`'s server-side `SourceRadioSummary`
+ * (#4111 P3 WP-1) — the public, non-secret per-source radio field on
+ * `GET /api/sources`. Center frequency / region is inherently public RF
+ * information (broadcast over the air), so this is safe on the anonymous
+ * sources list.
+ */
+export interface SourceRadioSummary {
+  frequencyMhz: number | null;
+  /** Meshtastic only. */
+  regionName?: string;
+  /** Meshtastic only — drives RX-sensitivity auto-seed. */
+  modemPreset?: number;
+}

--- a/src/utils/linkBudget.test.ts
+++ b/src/utils/linkBudget.test.ts
@@ -5,6 +5,10 @@ import {
   fsplDb,
   earthBulgeMeters,
   computeLinkBudget,
+  loRaSensitivityDbm,
+  rxSensitivityForModemPreset,
+  LORA_SNR_LIMIT_DB,
+  MODEM_PRESET_PARAMS,
 } from './linkBudget';
 
 describe('wavelengthMeters', () => {
@@ -94,6 +98,84 @@ describe('earthBulgeMeters', () => {
   it('does not throw for negative distances', () => {
     expect(Number.isNaN(earthBulgeMeters(-100, 5000))).toBe(false);
     expect(earthBulgeMeters(-100, 5000)).toBe(0);
+  });
+});
+
+describe('loRaSensitivityDbm (#4111 P3 WP-1)', () => {
+  // S = -174 + 10*log10(BW_Hz) + NF + SNR_min(SF), NF defaults to 6 dB.
+  // Deviation from LINK_PROFILE_POLISH_SPEC.md §3: the spec's test-plan table
+  // lists "loRaSensitivityDbm(11,250) ≈ -126.5 (±0.5)", but plugging SF=11
+  // into the spec's own formula + LORA_SNR_LIMIT_DB table gives -131.52, not
+  // -126.5 (-174 + 53.9794 + 6 - 17.5 = -131.5206). -126.52 is what SF=9
+  // produces instead (-174 + 53.9794 + 6 - 12.5). Asserting the value the
+  // locked formula actually computes, since the formula (not the example
+  // number) is the source of truth (spec §0.2: "computed, not a magic table").
+  it('SF11/BW250kHz: matches the formula (-174 + 10log10(250000) + 6 - 17.5)', () => {
+    expect(loRaSensitivityDbm(11, 250)).toBeCloseTo(-131.521, 2);
+  });
+
+  it('SF9/BW250kHz: -126.52 (the value the spec\'s example number actually matches)', () => {
+    expect(loRaSensitivityDbm(9, 250)).toBeCloseTo(-126.521, 2);
+  });
+
+  it('higher SF yields a lower (more negative / better) sensitivity at fixed BW', () => {
+    const sf7 = loRaSensitivityDbm(7, 250)!;
+    const sf9 = loRaSensitivityDbm(9, 250)!;
+    const sf11 = loRaSensitivityDbm(11, 250)!;
+    expect(sf9).toBeLessThan(sf7);
+    expect(sf11).toBeLessThan(sf9);
+  });
+
+  it('narrower BW yields a lower (more negative / better) sensitivity at fixed SF', () => {
+    const bw250 = loRaSensitivityDbm(11, 250)!;
+    const bw125 = loRaSensitivityDbm(11, 125)!;
+    expect(bw125).toBeLessThan(bw250);
+  });
+
+  it('returns null for an unknown spreading factor', () => {
+    expect(loRaSensitivityDbm(6, 250)).toBeNull();
+    expect(loRaSensitivityDbm(13, 250)).toBeNull();
+  });
+
+  it('returns null for non-positive bandwidth', () => {
+    expect(loRaSensitivityDbm(11, 0)).toBeNull();
+    expect(loRaSensitivityDbm(11, -10)).toBeNull();
+  });
+
+  it('a higher noise figure raises (worsens) sensitivity', () => {
+    const nf6 = loRaSensitivityDbm(11, 250, 6)!;
+    const nf10 = loRaSensitivityDbm(11, 250, 10)!;
+    expect(nf10).toBeGreaterThan(nf6);
+  });
+
+  it('LORA_SNR_LIMIT_DB covers every SF used by MODEM_PRESET_PARAMS', () => {
+    for (const { sf } of Object.values(MODEM_PRESET_PARAMS)) {
+      expect(LORA_SNR_LIMIT_DB[sf]).toBeDefined();
+    }
+  });
+});
+
+describe('rxSensitivityForModemPreset (#4111 P3 WP-1)', () => {
+  it('preset 0 (LONG_FAST, SF11/BW250) is finite', () => {
+    const result = rxSensitivityForModemPreset(0);
+    expect(result).not.toBeNull();
+    expect(Number.isFinite(result)).toBe(true);
+    expect(result).toBeCloseTo(-131.521, 2);
+  });
+
+  it('returns null for preset 2 (VERY_LONG_SLOW — deprecated, not in MODEM_PRESET_PARAMS)', () => {
+    expect(rxSensitivityForModemPreset(2)).toBeNull();
+  });
+
+  it('returns null for an out-of-range preset value', () => {
+    expect(rxSensitivityForModemPreset(999)).toBeNull();
+  });
+
+  it('every preset 0-13 except 2 resolves to a finite sensitivity', () => {
+    for (let preset = 0; preset <= 13; preset++) {
+      if (preset === 2) continue;
+      expect(Number.isFinite(rxSensitivityForModemPreset(preset))).toBe(true);
+    }
   });
 });
 

--- a/src/utils/linkBudget.ts
+++ b/src/utils/linkBudget.ts
@@ -86,6 +86,74 @@ export function earthBulgeMeters(
   return (d1M * d2M) / (2 * kFactor * earthRadiusM);
 }
 
+/**
+ * Demodulator SNR floor (dB) per LoRa spreading factor, from the Semtech
+ * SX1262 datasheet's sensitivity table (#4111 P3 WP-1).
+ */
+export const LORA_SNR_LIMIT_DB: Record<number, number> = {
+  7: -7.5,
+  8: -10,
+  9: -12.5,
+  10: -15,
+  11: -17.5,
+  12: -20,
+};
+
+/** SX1262 receiver noise figure (dB), used as the default in `loRaSensitivityDbm`. */
+export const DEFAULT_NOISE_FIGURE_DB = 6;
+
+/**
+ * LoRa receiver sensitivity (dBm): `S = -174 + 10*log10(BW_Hz) + NF + SNR_min(SF)`.
+ * The standard thermal-noise link-budget formula (-174 dBm/Hz is the thermal
+ * noise floor at room temperature) — computed rather than a transcribed
+ * magic table, so it's derived and unit-testable (#4111 P3 WP-1, spec §0.2).
+ *
+ * Returns `null` for an unknown spreading factor or non-positive bandwidth.
+ */
+export function loRaSensitivityDbm(
+  spreadingFactor: number,
+  bandwidthKhz: number,
+  noiseFigureDb: number = DEFAULT_NOISE_FIGURE_DB,
+): number | null {
+  const snrMinDb = LORA_SNR_LIMIT_DB[spreadingFactor];
+  if (snrMinDb === undefined || bandwidthKhz <= 0) return null;
+  return -174 + 10 * Math.log10(bandwidthKhz * 1000) + noiseFigureDb + snrMinDb;
+}
+
+/**
+ * Meshtastic modem-preset enum → (SF, BW kHz). Mirrors the `params` strings in
+ * `src/components/configuration/constants.ts` `MODEM_PRESET_OPTIONS` (BW) plus
+ * the firmware's `modemPresetToParams` switch (SF) — see that file for the
+ * per-preset descriptions. Preset `2` (`VERY_LONG_SLOW`) is intentionally
+ * omitted: it is deprecated/removed from `MODEM_PRESET_OPTIONS` and is not a
+ * selectable preset in the UI, so `rxSensitivityForModemPreset(2)` returns
+ * `null` like any other unknown value.
+ */
+export const MODEM_PRESET_PARAMS: Record<number, { sf: number; bwKhz: number }> = {
+  0: { sf: 11, bwKhz: 250 },  // LONG_FAST
+  1: { sf: 12, bwKhz: 125 },  // LONG_SLOW
+  3: { sf: 10, bwKhz: 250 },  // MEDIUM_SLOW
+  4: { sf: 9, bwKhz: 250 },   // MEDIUM_FAST
+  5: { sf: 8, bwKhz: 250 },   // SHORT_SLOW
+  6: { sf: 7, bwKhz: 250 },   // SHORT_FAST
+  7: { sf: 11, bwKhz: 125 },  // LONG_MODERATE
+  8: { sf: 7, bwKhz: 500 },   // SHORT_TURBO
+  9: { sf: 11, bwKhz: 500 },  // LONG_TURBO
+  10: { sf: 9, bwKhz: 125 },  // LITE_FAST
+  11: { sf: 10, bwKhz: 125 }, // LITE_SLOW
+  12: { sf: 7, bwKhz: 62.5 }, // NARROW_FAST
+  13: { sf: 8, bwKhz: 62.5 }, // NARROW_SLOW
+};
+
+/** RX sensitivity (dBm) for a Meshtastic modem preset, or `null` if unknown. */
+export function rxSensitivityForModemPreset(
+  modemPreset: number,
+  noiseFigureDb: number = DEFAULT_NOISE_FIGURE_DB,
+): number | null {
+  const params = MODEM_PRESET_PARAMS[modemPreset];
+  return params ? loRaSensitivityDbm(params.sf, params.bwKhz, noiseFigureDb) : null;
+}
+
 /** Inputs to a full link-budget calculation, independent of path geometry. */
 export interface LinkBudgetInputs {
   txPowerDbm: number;

--- a/src/utils/linkProfile.ts
+++ b/src/utils/linkProfile.ts
@@ -23,6 +23,15 @@ export interface LinkEndpoint extends MeasurePoint {
   isNode: boolean;
   /** Source that reported the node endpoint, for per-source auto-frequency (#4111 P3). */
   sourceId?: string;
+  /**
+   * Every source that reported this node — newest-first, primary (`sourceId`)
+   * first (#4111 P3 WP-2 follow-up). A unified-merged node's bare `sourceId`
+   * is whichever source last reported it, which for a multi-source node is
+   * frequently an MQTT bridge with no local radio (`radio: null`). Auto-
+   * frequency detection must walk this full list to find a radio-reporting
+   * source instead of giving up on the (possibly radio-less) primary.
+   */
+  sourceIds?: string[];
   /** Node number of the picked node endpoint (#4111 P3). */
   nodeNum?: number;
   /** True when the node endpoint is a MeshCore node (#4111 P3). */

--- a/src/utils/linkProfile.ts
+++ b/src/utils/linkProfile.ts
@@ -21,6 +21,12 @@ import {
 /** A picked endpoint for the Link Profile tool. `isNode=false` = arbitrary map point. */
 export interface LinkEndpoint extends MeasurePoint {
   isNode: boolean;
+  /** Source that reported the node endpoint, for per-source auto-frequency (#4111 P3). */
+  sourceId?: string;
+  /** Node number of the picked node endpoint (#4111 P3). */
+  nodeNum?: number;
+  /** True when the node endpoint is a MeshCore node (#4111 P3). */
+  isMeshCore?: boolean;
 }
 
 // Client mirror of the backend `ProfileSample` (kept in `types/elevation.ts`
@@ -29,6 +35,24 @@ export interface LinkEndpoint extends MeasurePoint {
 export type { ElevationSample };
 
 export type LinkVerdict = 'clear' | 'marginal' | 'obstructed';
+
+/**
+ * Shared verdict copy/coloring, promoted from `LinkProfileDrawer.tsx`'s local
+ * consts (#4111 P3 WP-1) so the map-path Polyline (a later work package) can
+ * reuse the same values the drawer displays. The drawer keeps its own local
+ * copies for now — a later package switches it to import these.
+ */
+export const VERDICT_LABEL: Record<LinkVerdict, string> = {
+  clear: 'Clear',
+  marginal: 'Marginal',
+  obstructed: 'Obstructed',
+};
+
+export const VERDICT_COLOR: Record<LinkVerdict, string> = {
+  clear: '#22c55e',
+  marginal: '#f59e0b',
+  obstructed: '#ef4444',
+};
 
 /** Fraction of the first Fresnel zone that must remain clear to call a link "clear" (not just "marginal"). */
 export const DEFAULT_FRESNEL_CLEAR_THRESHOLD = 0.6;

--- a/src/utils/loraFrequency.test.ts
+++ b/src/utils/loraFrequency.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { calculateLoRaFrequency, djb2Hash, getModemPresetChannelName } from './loraFrequency';
+import {
+  calculateLoRaFrequency,
+  djb2Hash,
+  getModemPresetChannelName,
+  loRaCenterFrequencyMhz,
+  REGION_SHORT_NAME,
+} from './loraFrequency';
 
 describe('calculateLoRaFrequency', () => {
   // Default bandwidth is 250 kHz (LongFast preset)
@@ -278,6 +284,52 @@ describe('calculateLoRaFrequency', () => {
       const slot = djb2Hash('MediumFast') % numChannels;
       expect(slot).toBeGreaterThanOrEqual(0);
       expect(slot).toBeLessThan(numChannels);
+    });
+  });
+
+  describe('loRaCenterFrequencyMhz (#4111 P3 WP-1 numeric sibling)', () => {
+    it('US LongFast default (channelNum 0, modemPreset 0) → ~906.875 MHz', () => {
+      // Mirrors the DJB2-hash test above but through the numeric API: hashName
+      // resolves via MODEM_PRESET_CHANNEL_NAMES[0] === 'LongFast', slot 19.
+      const result = loRaCenterFrequencyMhz(1, 0, 0, 0, 250, undefined, 0);
+      expect(result).toBeCloseTo(906.875, 3);
+    });
+
+    it('honors overrideFrequency when set', () => {
+      const result = loRaCenterFrequencyMhz(1, 21, 915.0, 0.5, 250);
+      expect(result).toBeCloseTo(915.5, 3);
+    });
+
+    it('returns null for region 0 (unset/unknown)', () => {
+      expect(loRaCenterFrequencyMhz(0, 1, 0, 0)).toBeNull();
+    });
+
+    it('returns null for an unknown region code', () => {
+      expect(loRaCenterFrequencyMhz(999, 1, 0, 0)).toBeNull();
+    });
+
+    it('returns null for an invalid (out-of-range) channel', () => {
+      expect(loRaCenterFrequencyMhz(1, 105, 0, 0)).toBeNull();
+    });
+
+    it('matches the string API for a plain in-range channel', () => {
+      const asString = calculateLoRaFrequency(1, 21, 0, 0);
+      const asNumber = loRaCenterFrequencyMhz(1, 21, 0, 0);
+      expect(asNumber).toBeCloseTo(parseFloat(asString), 3);
+    });
+  });
+
+  describe('REGION_SHORT_NAME', () => {
+    it('maps region 1 to "US"', () => {
+      expect(REGION_SHORT_NAME[1]).toBe('US');
+    });
+
+    it('maps region 3 to "EU_868"', () => {
+      expect(REGION_SHORT_NAME[3]).toBe('EU_868');
+    });
+
+    it('has no entry for region 0 (UNSET)', () => {
+      expect(REGION_SHORT_NAME[0]).toBeUndefined();
     });
   });
 

--- a/src/utils/loraFrequency.ts
+++ b/src/utils/loraFrequency.ts
@@ -170,6 +170,81 @@ export function getModemPresetChannelName(modemPreset?: number): string | undefi
 }
 
 /**
+ * Numeric center frequency (MHz) for a Meshtastic LoRa config, or `null` when
+ * it can't be computed (region unset/unknown, invalid channel). Honors
+ * `overrideFrequency` (delegates to `calculateLoRaFrequency`, which already
+ * does) so the region-bounds table / DJB2 slot math is not duplicated here —
+ * this is a thin numeric sibling of the existing string formatter
+ * (#4111 P3 WP-1).
+ */
+export function loRaCenterFrequencyMhz(
+  region: number,
+  channelNum: number,
+  overrideFrequency: number,
+  frequencyOffset: number,
+  bandwidth: number = 250,
+  channelName?: string,
+  modemPreset?: number
+): number | null {
+  const formatted = calculateLoRaFrequency(
+    region,
+    channelNum,
+    overrideFrequency,
+    frequencyOffset,
+    bandwidth,
+    channelName,
+    modemPreset
+  );
+  const freq = parseFloat(formatted);
+  return Number.isFinite(freq) ? freq : null;
+}
+
+/**
+ * RegionCode → short name (e.g. 1 → "US"), for provenance hints (#4111 P3
+ * WP-1). Values mirror the region comments in `regionFrequencyBounds` above,
+ * which mirror `meshtastic/protobufs` `config.proto`'s `Config.LoRaConfig.RegionCode`.
+ */
+export const REGION_SHORT_NAME: Record<number, string> = {
+  1: 'US',
+  2: 'EU_433',
+  3: 'EU_868',
+  4: 'CN',
+  5: 'JP',
+  6: 'ANZ',
+  7: 'KR',
+  8: 'TW',
+  9: 'RU',
+  10: 'IN',
+  11: 'NZ_865',
+  12: 'TH',
+  13: 'LORA_24',
+  14: 'UA_433',
+  15: 'UA_868',
+  16: 'MY_433',
+  17: 'MY_919',
+  18: 'SG_923',
+  19: 'PH_433',
+  20: 'PH_868',
+  21: 'PH_915',
+  22: 'ANZ_433',
+  23: 'KZ_433',
+  24: 'KZ_863',
+  25: 'NP_865',
+  26: 'BR_902',
+  27: 'ITU1_2M',
+  28: 'ITU2_2M',
+  29: 'EU_866',
+  30: 'EU_874',
+  31: 'EU_917',
+  32: 'EU_N_868',
+  33: 'ITU3_2M',
+  34: 'ITU1_70CM',
+  35: 'ITU2_70CM',
+  36: 'ITU3_70CM',
+  37: 'ITU2_125CM',
+};
+
+/**
  * DJB2 hash algorithm — matches the Meshtastic firmware's hash() function
  * in RadioInterface.cpp. Used to compute the default frequency slot when
  * channelNum is 0 (not explicitly set by the user).


### PR DESCRIPTION
## Summary
Phase 3 (final) of the Terrain Link Profile epic (#4111), polishing the tool shipped in #4143/#4147. The Link Profile drawer now auto-detects frequency and RX sensitivity from the picked node's source configuration (with a provenance hint and manual-override-wins), the picked map path is colored by the analysis verdict, DEM void/bathymetry artifacts no longer corrupt profiles, the elevation source becomes admin-configurable in Settings with a live Test button, and the feature gets user-facing documentation. This closes out issue #4111.

## Changes
- **Per-source auto-frequency/RX** — new public, non-secret `radio` summary on `GET /api/sources` (Meshtastic: region → center MHz via the existing `loraFrequency` math, honoring `overrideFrequency`; MeshCore: local node's `radioFreq`; MQTT sources: `null`). `useAutoRadioDefaults` walks the picked node's **full source membership** (`node.sources[]`, not just the newest-record `sourceId`, which is frequently a radio-less MQTT bridge — found in live validation) and seeds frequency + RX sensitivity with a "from <source> (region)" hint; user edits always win. RX sensitivity is **computed** (−174 + 10·log10(BW) + NF + SNRmin(SF), per-modem-preset SF/BW table sourced from firmware), not a hardcoded table.
- **Verdict path coloring** — the map polyline + endpoint rings recolor green/amber/red from the shared `VERDICT_COLOR` once the analysis resolves (context slice written by the drawer); antimeridian-crossing links now draw the short way.
- **DEM void clamp** — `sanitizeElevation` (−500..9000 m plausible range) at the provider boundary nulls Terrarium void/bathymetry artifacts (the −12000 m Lake Pontchartrain spike from Phase 2 validation); JSON `-9999` sentinels handled the same way.
- **Settings UI** — admin "Elevation / Terrain" section (global settings): enable toggle, custom source URL (secret, follows the Apprise-URL pattern), Test button reporting detected type + probe elevation + latency; an empty URL field tests the default Terrarium source and labels the result "(default source)".
- **Docs** — `docs/features/map-analysis.md` Terrain Link Profile section, `docs/features/settings.md` elevation section, README feature bullet, CHANGELOG entries; VitePress build verified.
- **Friendly drawer errors** — IDENTICAL_POINTS / PATH_TOO_LONG / INVALID_COORDINATES map to human copy.

## Issues Resolved
Closes #4111 (Phase 3 of 3 — Phases 1 and 2 merged as #4143 and #4147)

## Documentation Updates
User-facing docs added (map-analysis, settings, README, CHANGELOG); epic plan + implementation spec committed to dev-notes.

## Testing
- [x] Full suite: 9,485 passed / 0 failed / 0 suite failures (`success: true` via JSON output file); ~85 new/extended tests incl. `sourceRoutes.radio.test.ts` (real-middleware harness), multi-source auto-freq cases, DEM clamp cases, `SettingsTab.elevation.test.tsx`
- [x] TypeScript clean; `npm run lint:ci` ratchet OK; VitePress docs build passes
- [x] Browser-validated on the dev container: frequency seeds **913.125 "from Sandbox (US)"** with RX −126.5 from the modem preset on a node whose newest report came via an MQTT bridge (the fixed case); verdict-red path; the Phase 2 −12000 m chart blowout is gone; settings Test → "OK — terrarium, 8732 m in 297 ms (default source)"; no console errors
- [ ] Reviewer: pick two nodes of a Meshtastic source in Map Analysis → frequency/RX auto-fill with a provenance hint; edit either → the hint yields to your value; Settings → Elevation/Terrain → Test with an empty URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhiLoNwFoDgxY8fdmF4Yuk