### PR TITLE
feat(map): add "Discard invalid positions" Map setting

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -181,6 +181,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setEnableAudioNotifications,
     linkPreviewsEnabled,
     setLinkPreviewsEnabled,
+    discardInvalidPositions,
+    setDiscardInvalidPositions,
     meshcoreChannelRetryEnabled,
     setMeshcoreChannelRetryEnabled,
     nodeDimmingEnabled,
@@ -248,6 +250,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localPacketLogMaxCount, setLocalPacketLogMaxCount] = useState(1000);
   const [localPacketLogMaxAgeHours, setLocalPacketLogMaxAgeHours] = useState(24);
   const [localLinkPreviewsEnabled, setLocalLinkPreviewsEnabled] = useState(linkPreviewsEnabled);
+  const [localDiscardInvalidPositions, setLocalDiscardInvalidPositions] = useState(discardInvalidPositions);
   const [localMeshcoreChannelRetryEnabled, setLocalMeshcoreChannelRetryEnabled] = useState(meshcoreChannelRetryEnabled);
   const [localSolarMonitoringEnabled, setLocalSolarMonitoringEnabled] = useState(solarMonitoringEnabled);
   const [localSolarMonitoringLatitude, setLocalSolarMonitoringLatitude] = useState(solarMonitoringLatitude);
@@ -360,6 +363,10 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           const linkPreviewsOn = !(settings.linkPreviewsEnabled === '0' || settings.linkPreviewsEnabled === 'false');
           setLocalLinkPreviewsEnabled(linkPreviewsOn);
 
+          // Load discard-invalid-positions (default enabled). Absent key => enabled.
+          const discardInvalidOn = !(settings.discardInvalidPositions === '0' || settings.discardInvalidPositions === 'false');
+          setLocalDiscardInvalidPositions(discardInvalidOn);
+
           // Load MeshCore channel-send auto-retry (#3979). Absent key => disabled.
           const meshcoreChannelRetryOn = settings.meshcoreChannelRetryEnabled === '1' || settings.meshcoreChannelRetryEnabled === 'true';
           setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryOn);
@@ -455,6 +462,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalNodeHopsCalculation(nodeHopsCalculation);
     setLocalDashboardSortOption(preferredDashboardSortOption);
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
+    setLocalDiscardInvalidPositions(discardInvalidPositions);
     setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryEnabled);
     setLocalSolarMonitoringEnabled(solarMonitoringEnabled);
     setLocalSolarMonitoringLatitude(solarMonitoringLatitude);
@@ -462,7 +470,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringAzimuth(solarMonitoringAzimuth);
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
-  }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTilesetLight, mapTilesetDark, mapPinStyle, nodeHopsCalculation, preferredDashboardSortOption, linkPreviewsEnabled, meshcoreChannelRetryEnabled, solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme]);
+  }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTilesetLight, mapTilesetDark, mapPinStyle, nodeHopsCalculation, preferredDashboardSortOption, linkPreviewsEnabled, discardInvalidPositions, meshcoreChannelRetryEnabled, solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme]);
 
   // Default solar monitoring lat/long to device position if still at 0
   useEffect(() => {
@@ -526,6 +534,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringAzimuth !== solarMonitoringAzimuth ||
       localSolarMonitoringDeclination !== solarMonitoringDeclination ||
       localLinkPreviewsEnabled !== linkPreviewsEnabled ||
+      localDiscardInvalidPositions !== discardInvalidPositions ||
       localMeshcoreChannelRetryEnabled !== meshcoreChannelRetryEnabled ||
       localHideIncompleteNodes !== !showIncompleteNodes ||
       localHomoglyphEnabled !== initialHomoglyphEnabled ||
@@ -546,6 +555,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
       localLinkPreviewsEnabled, linkPreviewsEnabled,
+      localDiscardInvalidPositions, discardInvalidPositions,
       localMeshcoreChannelRetryEnabled, meshcoreChannelRetryEnabled,
       localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
       localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes,
@@ -593,6 +603,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringAzimuth(solarMonitoringAzimuth);
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
+    setLocalDiscardInvalidPositions(discardInvalidPositions);
     setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryEnabled);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
     setLocalHomoglyphEnabled(initialHomoglyphEnabled);
@@ -612,7 +623,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       dateFormat, mapTilesetLight, mapTilesetDark, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
-      linkPreviewsEnabled, meshcoreChannelRetryEnabled,
+      linkPreviewsEnabled, discardInvalidPositions, meshcoreChannelRetryEnabled,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialMeshcoreCliTimeoutSeconds, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl,
@@ -676,6 +687,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringAzimuth: localSolarMonitoringAzimuth.toString(),
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
         linkPreviewsEnabled: localLinkPreviewsEnabled ? '1' : '0',
+        discardInvalidPositions: localDiscardInvalidPositions ? '1' : '0',
         meshcoreChannelRetryEnabled: localMeshcoreChannelRetryEnabled ? '1' : '0',
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
         homoglyphEnabled: String(localHomoglyphEnabled),
@@ -733,6 +745,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringAzimuthChange(localSolarMonitoringAzimuth);
       onSolarMonitoringDeclinationChange(localSolarMonitoringDeclination);
       setLinkPreviewsEnabled(localLinkPreviewsEnabled);
+      setDiscardInvalidPositions(localDiscardInvalidPositions);
       setMeshcoreChannelRetryEnabled(localMeshcoreChannelRetryEnabled);
       setShowIncompleteNodes(!localHideIncompleteNodes);
 
@@ -767,7 +780,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localTimeFormat, localDateFormat, localMapTilesetLight, localMapTilesetDark, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localMapCenterTargetZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, getLocalEffectiveTheme, getLocalEffectiveTileset,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
-      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localMeshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes, localMeshcoreCliTimeoutSeconds,
+      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localDiscardInvalidPositions, setDiscardInvalidPositions, localMeshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes, localMeshcoreCliTimeoutSeconds,
       onMaxNodeAgeChange, onInactiveNodeThresholdHoursChange, onInactiveNodeCheckIntervalMinutesChange,
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
@@ -952,6 +965,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       setLocalSolarMonitoringAzimuth(0);
       setLocalSolarMonitoringDeclination(30);
       setLocalLinkPreviewsEnabled(true);
+      setLocalDiscardInvalidPositions(true);
       setLocalMeshcoreChannelRetryEnabled(false);
 
       // Update parent component with defaults
@@ -978,6 +992,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringAzimuthChange(0);
       onSolarMonitoringDeclinationChange(30);
       setLinkPreviewsEnabled(true);
+      setDiscardInvalidPositions(true);
       setMeshcoreChannelRetryEnabled(false);
 
       // Update initial packet monitor settings
@@ -1548,6 +1563,20 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
 
         {show('settings-map') && <div id="settings-map" className="settings-section">
           <h3>{t('settings.map')}</h3>
+          <div className="setting-item">
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={localDiscardInvalidPositions}
+                onChange={(e) => setLocalDiscardInvalidPositions(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>{t('settings.discard_invalid_positions', 'Discard invalid positions')}</span>
+            </label>
+            <span className="setting-description">
+              {t('settings.discard_invalid_positions_description', 'When enabled (default), GPS fixes at Null Island (0,0) — including precision-obscured ones — are discarded on ingest across all sources. Disable to store (0,0) reports as received so you can see which nodes transmit them. Out-of-range / garbage coordinates are always discarded.')}
+            </span>
+          </div>
           <div className="setting-item">
             <label htmlFor="mapTilesetLight">
               {t('settings.map_tileset_light_label', 'Light Mode Tileset')}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -123,6 +123,8 @@ interface SettingsContextType {
   enableAudioNotifications: boolean;
   /** Global toggle: fetch & render OpenGraph link preview cards for URLs in messages. */
   linkPreviewsEnabled: boolean;
+  /** Global Map toggle (default true): discard Null Island (0,0) fixes on ingest. */
+  discardInvalidPositions: boolean;
   /**
    * Global opt-in (issue #3979, default false): auto-retry an AUTOMATED MeshCore
    * channel send once, 30s later, when zero repeaters were heard. Automated
@@ -179,6 +181,7 @@ interface SettingsContextType {
   setSolarMonitoringDeclination: (declination: number) => void;
   setEnableAudioNotifications: (enabled: boolean) => void;
   setLinkPreviewsEnabled: (enabled: boolean) => void;
+  setDiscardInvalidPositions: (enabled: boolean) => void;
   setMeshcoreChannelRetryEnabled: (enabled: boolean) => void;
   mutedChannels: MutedChannel[];
   mutedDMs: MutedDM[];
@@ -486,6 +489,10 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   // Link preview setting - server-backed (global). Defaults to true to preserve
   // the previous always-on behavior; loaded from the server in loadServerSettings.
   const [linkPreviewsEnabled, setLinkPreviewsEnabledState] = useState<boolean>(true);
+
+  // Discard invalid GPS positions on ingest — default true (discard = historical
+  // behavior); loaded from the server in loadServerSettings.
+  const [discardInvalidPositions, setDiscardInvalidPositionsState] = useState<boolean>(true);
 
   // MeshCore automated-channel-send auto-retry (issue #3979) - server-backed
   // (global). Defaults to false (opt-in); loaded from the server in
@@ -909,6 +916,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   // Link preview setter updates state only - value is persisted server-side
   const setLinkPreviewsEnabled = (enabled: boolean) => {
     setLinkPreviewsEnabledState(enabled);
+  };
+
+  // Discard-invalid-positions setter updates state only - persisted server-side
+  const setDiscardInvalidPositions = (enabled: boolean) => {
+    setDiscardInvalidPositionsState(enabled);
   };
 
   // MeshCore channel-retry setter updates state only - persisted server-side
@@ -1434,6 +1446,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             setLinkPreviewsEnabledState(enabled);
           }
 
+          // Discard invalid positions - database-only. Absent key means default
+          // (enabled = discard); only an explicit '0'/'false' turns it off.
+          if (settings.discardInvalidPositions !== undefined) {
+            const enabled = !(settings.discardInvalidPositions === '0' || settings.discardInvalidPositions === 'false');
+            setDiscardInvalidPositionsState(enabled);
+          }
+
           // MeshCore channel-send auto-retry (#3979) - database-only. Absent key
           // means default (disabled); only an explicit '1'/'true' turns it on.
           if (settings.meshcoreChannelRetryEnabled !== undefined) {
@@ -1660,6 +1679,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     customTilesets,
     isLoadingThemes,
     linkPreviewsEnabled,
+    discardInvalidPositions,
     meshcoreChannelRetryEnabled,
     solarMonitoringEnabled,
     solarMonitoringLatitude,
@@ -1711,6 +1731,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     updateCustomTileset,
     deleteCustomTileset,
     setLinkPreviewsEnabled,
+    setDiscardInvalidPositions,
     setMeshcoreChannelRetryEnabled,
     setSolarMonitoringEnabled,
     setSolarMonitoringLatitude,

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -7,7 +7,8 @@
 import { eq, desc, sql, isNull, isNotNull, and, or, lt, gte, inArray, type SQL } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
-import { isBogusPosition } from '../../utils/nullIsland.js';
+import { shouldDiscardPosition } from '../../utils/nullIsland.js';
+import { getDiscardInvalidPositions } from '../../utils/positionIngestConfig.js';
 
 /**
  * meshcore_nodes columns where an incoming `null` in upsertNode means "clear
@@ -320,7 +321,9 @@ export class MeshCoreRepository extends BaseRepository {
     // out of the DB regardless of caller. Undefined (not null) means "not
     // observed" so the merge PRESERVES any valid stored fix rather than
     // clobbering it on a transient bad report (#3763 follow-up).
-    if (isBogusPosition(node.latitude ?? null, node.longitude ?? null)) {
+    // The (0,0) discard honors the global `discardInvalidPositions` setting;
+    // out-of-range junk (e.g. lat 1853 from advert corruption) is always dropped.
+    if (shouldDiscardPosition(node.latitude ?? null, node.longitude ?? null, undefined, getDiscardInvalidPositions())) {
       const { latitude: _blat, longitude: _blon, ...rest } = node;
       node = rest as typeof node;
     }

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -162,6 +162,12 @@ export const VALID_SETTINGS_KEYS = [
   // Global privacy toggle (issue #3416): when '0'/'false', the /api/link-preview
   // endpoint refuses to fetch external URLs and the UI renders no preview cards.
   'linkPreviewsEnabled',
+  // Global Map toggle (default ON = '1'). When enabled (historical behavior),
+  // Null Island (0,0) fixes — including precision-obscured ones — are discarded
+  // on ingest across every source. When '0'/'false', those (0,0) reports are
+  // stored as received so operators can see nodes transmitting them. Non-finite /
+  // out-of-range junk is always discarded regardless. See positionIngestConfig.ts.
+  'discardInvalidPositions',
   // Global opt-in (issue #3979, default OFF): when enabled, an AUTOMATED MeshCore
   // channel/broadcast send that hears ZERO repeaters within 30s is resent exactly
   // once. Applies only to automated senders (Automation Engine action.sendMessage,

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -10,7 +10,8 @@ import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import { getPrimaryMeshtasticManager } from './sourceManagerTypes.js';
 import { calculateDistance } from '../utils/distance.js';
-import { isBogusPosition } from '../utils/nullIsland.js';
+import { shouldDiscardPosition } from '../utils/nullIsland.js';
+import { getDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
 import { isPointInGeofence, distanceToGeofenceCenter } from '../utils/geometry.js';
 import { formatTime, formatDate } from '../utils/datetime.js';
 import { logger } from '../utils/logger.js';
@@ -6023,7 +6024,9 @@ class MeshtasticManager implements ISourceManager {
     // When precisionBits is supplied the check backs out the firmware's
     // position-precision re-centering offset first, so an obscured (0,0) fix
     // (which arrives as e.g. (0.0131, 0.0131) at 14 bits) is still caught.
-    if (isBogusPosition(latitude, longitude, precisionBits)) {
+    // The (0,0) discard is gated on the global `discardInvalidPositions` setting;
+    // out-of-range junk is already rejected by the range checks above regardless.
+    if (shouldDiscardPosition(latitude, longitude, precisionBits, getDiscardInvalidPositions())) {
       return false;
     }
 

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -7,7 +7,7 @@
  * database when the bbox is enabled.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../services/database.js', () => ({
   default: {
@@ -95,6 +95,7 @@ vi.mock('./meshtasticProtobufService.js', () => ({
 }));
 
 import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
+import { setDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
 import { MqttPacketFilter, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
 import databaseService from '../services/database.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
@@ -452,6 +453,44 @@ describe('ingestServiceEnvelope — POSITION Null Island guard (#3763)', () => {
     const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
     expect(arg.latitude).toBeCloseTo(43.7, 5);
     expect(arg.longitude).toBeCloseTo(-79.3, 5);
+  });
+});
+
+describe('ingestServiceEnvelope — discardInvalidPositions=false stores (0,0)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    setDiscardInvalidPositions(false); // operator opted to keep bad positions
+  });
+  afterEach(() => {
+    setDiscardInvalidPositions(true); // restore the default for other suites
+  });
+
+  it('stores a Null Island (0,0) fix when the discard setting is disabled', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({ latitudeI: 0, longitudeI: 0 }));
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.latitude).toBe(0);
+    expect(arg.longitude).toBe(0);
+  });
+
+  it('still discards out-of-range junk even when the discard setting is disabled', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    // latitudeI 1_853_000_000 / 1e7 → 185.3° (out of WGS-84 range)
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({ latitudeI: 1_853_000_000, longitudeI: 100_000_000 }));
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const arg = (databaseService.upsertNodeAsync as any).mock.calls[0][0];
+    expect(arg.latitude).toBeUndefined();
+    expect(arg.longitude).toBeUndefined();
   });
 });
 

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -95,7 +95,7 @@ vi.mock('./meshtasticProtobufService.js', () => ({
 }));
 
 import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
-import { setDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
+import { setDiscardInvalidPositions, __resetDiscardInvalidPositionsForTest } from '../utils/positionIngestConfig.js';
 import { MqttPacketFilter, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
 import databaseService from '../services/database.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
@@ -463,7 +463,7 @@ describe('ingestServiceEnvelope — discardInvalidPositions=false stores (0,0)',
     setDiscardInvalidPositions(false); // operator opted to keep bad positions
   });
   afterEach(() => {
-    setDiscardInvalidPositions(true); // restore the default for other suites
+    __resetDiscardInvalidPositionsForTest(); // restore the default for other suites
   });
 
   it('stores a Null Island (0,0) fix when the discard setting is disabled', async () => {

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -92,7 +92,8 @@ import { calculateDistance } from '../utils/distance.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
-import { isBogusPosition } from '../utils/nullIsland.js';
+import { shouldDiscardPosition } from '../utils/nullIsland.js';
+import { getDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
 import { logger } from '../utils/logger.js';
 import {
   nodeNumToId,
@@ -356,11 +357,12 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
       // classifier above does NOT catch these: with no bbox configured ('no-geo')
       // or a bbox spanning the equator/prime meridian, (0,0) sails through. MQTT
       // relays Meshtastic packets, so pass the sender's precision_bits to enable
-      // the de-offset in isBogusPosition. A bogus fix still refreshes lastHeard;
-      // undefined lat/lon is preserved by upsertNode's `?? existing` merge, so it
-      // never overwrites a previously stored good position with garbage.
+      // the de-offset. A bogus fix still refreshes lastHeard; undefined lat/lon is
+      // preserved by upsertNode's `?? existing` merge, so it never overwrites a
+      // previously stored good position with garbage. The (0,0) discard honors the
+      // global `discardInvalidPositions` setting; out-of-range junk is always dropped.
       const precisionBits = position.precisionBits ?? position.precision_bits ?? undefined;
-      const positionIsBogus = isBogusPosition(lat, lng, precisionBits);
+      const positionIsBogus = shouldDiscardPosition(lat, lng, precisionBits, getDiscardInvalidPositions());
       if (positionIsBogus) {
         logger.debug(`MQTT: dropping bogus position (${lat}, ${lng}) precisionBits=${precisionBits} from ${fromNodeId}`);
       }

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -131,6 +131,9 @@ export interface SettingsCallbacks {
   setAutomationAirtimeCutoffSource?: (source: string, sourceId?: string | null) => void;
   handleAutoWelcomeEnabled?: () => number;
   invalidateHtmlCache?: () => void;
+  // Global (default ON): push the new discard-invalid-positions value into the
+  // cached ingest gate so it takes effect immediately, no restart.
+  setDiscardInvalidPositions?: (enabled: boolean) => void;
   // Per-source (#3901): the scheduler reads the source's own interval, so no
   // intervalHours arg. A null sourceId is a no-op (no global scheduler).
   restartAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
@@ -714,6 +717,13 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
     if ('analyticsProvider' in filteredSettings || 'analyticsConfig' in filteredSettings) {
       callbacks.invalidateHtmlCache?.();
       logger.debug('📊 Analytics settings updated - HTML cache invalidated');
+    }
+
+    if ('discardInvalidPositions' in filteredSettings) {
+      const raw = filteredSettings.discardInvalidPositions;
+      const enabled = !(raw === '0' || raw === 'false');
+      callbacks.setDiscardInvalidPositions?.(enabled);
+      logger.debug(`🗺️ discardInvalidPositions set to ${enabled} — ingest gate updated`);
     }
 
     if ('autoWelcomeEnabled' in filteredSettings) {

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -14,6 +14,7 @@ import { optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { compileUserRegex } from '../../utils/safeRegex.js';
+import { parseDiscardInvalidPositions } from '../../utils/positionIngestConfig.js';
 import { securityDigestService } from '../services/securityDigestService.js';
 import { invalidatePkiDmGlobalCache } from '../services/sourcePkiKeyStore.js';
 import { VALID_SETTINGS_KEYS, stripSecretSettings } from '../constants/settings.js';
@@ -720,8 +721,7 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
     }
 
     if ('discardInvalidPositions' in filteredSettings) {
-      const raw = filteredSettings.discardInvalidPositions;
-      const enabled = !(raw === '0' || raw === 'false');
+      const enabled = parseDiscardInvalidPositions(filteredSettings.discardInvalidPositions);
       callbacks.setDiscardInvalidPositions?.(enabled);
       logger.debug(`🗺️ discardInvalidPositions set to ${enabled} — ingest gate updated`);
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,6 +21,7 @@ import protobufService from './protobufService.js';
 (global as any).meshtasticManager = meshtasticManager;
 import { createRequire } from 'module';
 import { logger } from '../utils/logger.js';
+import { setDiscardInvalidPositions, parseDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
 import { getSessionMiddleware } from './auth/sessionConfig.js';
 import { initializeWebSocket } from './services/webSocketService.js';
 import { initializeOIDC } from './auth/oidcAuth.js';
@@ -423,6 +424,13 @@ setTimeout(async () => {
     // Start the Automation Engine (#3653) — loads enabled automations and
     // subscribes to the event bus so they fire on live mesh traffic.
     await startAutomationEngine();
+
+    // Seed the global "discard invalid GPS positions" ingest gate from settings
+    // (default ON = discard, the historical behavior). Refreshed live on save via
+    // the setDiscardInvalidPositions callback registered below.
+    setDiscardInvalidPositions(
+      parseDiscardInvalidPositions(await databaseService.settings.getSetting('discardInvalidPositions')),
+    );
 
     // Start inactive node notification service with validation
     const inactiveThresholdHoursRaw = parseInt(await databaseService.settings.getSetting('inactiveNodeThresholdHours') || '24', 10);
@@ -917,6 +925,7 @@ setSettingsCallbacks({
   },
   handleAutoWelcomeEnabled: () => { databaseService.handleAutoWelcomeEnabledAsync().catch(() => {}); return 0; },
   invalidateHtmlCache,
+  setDiscardInvalidPositions: (enabled) => setDiscardInvalidPositions(enabled),
   // Auto-delete-by-distance is per-source (#3901): route the restart/stop to
   // the owning source manager so each source schedules against its own settings.
   // There is no global singleton — a null sourceId is a no-op.

--- a/src/utils/nullIsland.test.ts
+++ b/src/utils/nullIsland.test.ts
@@ -5,6 +5,7 @@ import {
   isBogusPosition,
   isNullIslandWithPrecision,
   precisionOffsetDegrees,
+  shouldDiscardPosition,
   NULL_ISLAND_EPSILON,
 } from './nullIsland.js';
 
@@ -165,5 +166,39 @@ describe('isNullIslandWithPrecision', () => {
     expect(isNullIslandWithPrecision(null, 0, 14)).toBe(false);
     expect(isNullIslandWithPrecision(0, undefined, 14)).toBe(false);
     expect(isNullIslandWithPrecision(NaN, 0, 14)).toBe(false);
+  });
+});
+
+describe('shouldDiscardPosition', () => {
+  it('equals isBogusPosition when discardNullIsland is true (default behavior)', () => {
+    expect(shouldDiscardPosition(0, 0, undefined, true)).toBe(true);              // null island
+    expect(shouldDiscardPosition(0.0005, -0.0009, undefined, true)).toBe(true);   // near null island
+    expect(shouldDiscardPosition(precisionOffsetDegrees(14), precisionOffsetDegrees(14), 14, true)).toBe(true); // obscured (0,0)
+    expect(shouldDiscardPosition(1853.45, 1819.63, undefined, true)).toBe(true);  // out of range
+    expect(shouldDiscardPosition(26.33, -80.27, undefined, true)).toBe(false);    // real position
+  });
+
+  it('lets Null Island (incl. precision-obscured) through when discardNullIsland is false', () => {
+    expect(shouldDiscardPosition(0, 0, undefined, false)).toBe(false);
+    expect(shouldDiscardPosition(0.0005, -0.0009, undefined, false)).toBe(false);
+    expect(shouldDiscardPosition(precisionOffsetDegrees(14), precisionOffsetDegrees(14), 14, false)).toBe(false);
+  });
+
+  it('ALWAYS discards out-of-range / non-finite junk, even when discardNullIsland is false', () => {
+    expect(shouldDiscardPosition(1853.45, 1819.63, undefined, false)).toBe(true); // out of range
+    expect(shouldDiscardPosition(90.0001, 0, undefined, false)).toBe(true);        // lat just over 90
+    expect(shouldDiscardPosition(NaN, 0, undefined, false)).toBe(true);
+    expect(shouldDiscardPosition(0, Infinity, undefined, false)).toBe(true);
+  });
+
+  it('never discards a real position regardless of the flag', () => {
+    expect(shouldDiscardPosition(26.33, -80.27, undefined, false)).toBe(false);
+    expect(shouldDiscardPosition(51.4778, 0.0001, undefined, false)).toBe(false); // Greenwich, real lat
+  });
+
+  it('returns false for missing coordinates (no position to discard)', () => {
+    expect(shouldDiscardPosition(null, null, undefined, true)).toBe(false);
+    expect(shouldDiscardPosition(26.33, null, undefined, true)).toBe(false);
+    expect(shouldDiscardPosition(undefined, -80.27, undefined, false)).toBe(false);
   });
 });

--- a/src/utils/nullIsland.ts
+++ b/src/utils/nullIsland.ts
@@ -125,3 +125,29 @@ export function isBogusPosition(
   if (latitude == null || longitude == null) return false;
   return !isValidLatLng(latitude, longitude) || isNullIslandWithPrecision(latitude, longitude, precisionBits);
 }
+
+/**
+ * Ingest-time "should this fix be discarded" predicate, honoring the global
+ * `discardInvalidPositions` setting (see `src/utils/positionIngestConfig.ts`).
+ *
+ * A non-finite or out-of-WGS-84-range coordinate is **always** discarded — it is
+ * unstorable and would blow out the map's auto-fit bounds, and no operator wants
+ * it regardless of the setting. Null Island (0, 0) — including a
+ * position-precision-obscured (0, 0) that arrives re-centered as
+ * `(offset, offset)` — is discarded only when `discardNullIsland` is true (the
+ * default / current behavior). Turning the setting off lets a genuine (0, 0)
+ * report through so operators can see which nodes are transmitting it.
+ *
+ * When `discardNullIsland` is true this is exactly {@link isBogusPosition}.
+ * Null/undefined inputs return `false` (no position to reject).
+ */
+export function shouldDiscardPosition(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+  precisionBits: number | null | undefined,
+  discardNullIsland: boolean,
+): boolean {
+  if (latitude == null || longitude == null) return false;
+  if (!isValidLatLng(latitude, longitude)) return true; // always drop unstorable / out-of-range junk
+  return discardNullIsland && isNullIslandWithPrecision(latitude, longitude, precisionBits);
+}

--- a/src/utils/positionIngestConfig.ts
+++ b/src/utils/positionIngestConfig.ts
@@ -1,0 +1,39 @@
+/**
+ * Global "discard invalid GPS positions" ingest gate.
+ *
+ * Backs the `discardInvalidPositions` Map setting. When enabled (the default and
+ * historical behavior) a Null Island (0, 0) fix — including a precision-obscured
+ * one — is discarded on ingest across every source (Meshtastic TCP, MQTT,
+ * MeshCore). Disabling it lets those (0, 0) reports through so operators can see
+ * which nodes are transmitting them. Non-finite / out-of-range junk is always
+ * discarded regardless (see {@link shouldDiscardPosition}).
+ *
+ * The value is cached in this module rather than read from the DB per packet:
+ * the setting is GLOBAL (not per-source) and changes rarely, but the gate runs
+ * on every position packet across three ingest sites — one of which
+ * (`src/db/repositories/meshcore.ts`) is a low-level repository with no settings
+ * access. A single module-level flag, seeded at startup and refreshed by the
+ * settings-save callback, gives all three sites a zero-DB read.
+ */
+
+// Default ON = discard invalid positions = the behavior before this setting existed.
+let discardInvalidPositions = true;
+
+/** Current value of the global discard-invalid-positions gate. */
+export function getDiscardInvalidPositions(): boolean {
+  return discardInvalidPositions;
+}
+
+/** Update the cached gate (called at startup and from the settings-save callback). */
+export function setDiscardInvalidPositions(enabled: boolean): void {
+  discardInvalidPositions = enabled;
+}
+
+/**
+ * Parse the stored setting value into a boolean with a default-ON policy:
+ * an absent value, `'1'`, or `'true'` → `true`; only an explicit `'0'` / `'false'`
+ * → `false`. Mirrors the frontend parse in SettingsContext.
+ */
+export function parseDiscardInvalidPositions(raw: string | null | undefined): boolean {
+  return !(raw === '0' || raw === 'false');
+}

--- a/src/utils/positionIngestConfig.ts
+++ b/src/utils/positionIngestConfig.ts
@@ -37,3 +37,12 @@ export function setDiscardInvalidPositions(enabled: boolean): void {
 export function parseDiscardInvalidPositions(raw: string | null | undefined): boolean {
   return !(raw === '0' || raw === 'false');
 }
+
+/**
+ * Reset the cached flag to its factory default (`true`). Exported for test
+ * isolation only — a suite that flips the flag must restore it in teardown so it
+ * cannot bleed into other tests (the flag is a process-global module singleton).
+ */
+export function __resetDiscardInvalidPositionsForTest(): void {
+  discardInvalidPositions = true;
+}


### PR DESCRIPTION
## Summary

Adds a global **Map setting**, *Discard invalid positions*, that controls whether Null Island (0,0) GPS fixes are discarded on ingest.

- **Default ON = discard** — the historical behavior (Null Island fixes are dropped across all sources).
- **OFF** — (0,0) reports are stored as received, so operators can see which nodes are transmitting them.

This is the follow-on to #4149/#4150 (which made ingest *always* strip Null Island): it makes that behavior configurable while keeping the safe default.

## Scope decision

The toggle gates the **Null Island discard specifically**. Non-finite and out-of-WGS-84-range junk (e.g. `lat 1853` from MeshCore advert corruption) is **always discarded regardless** — storing it would blow out the map's auto-fit bounds and it isn't a position anyone wants. This mirrors what the Meshtastic gate already does (it rejects out-of-range *before* the Null Island check), so behavior stays consistent across all three sources.

## Implementation

| Area | Change |
|---|---|
| `src/utils/nullIsland.ts` | New `shouldDiscardPosition(lat, lon, precisionBits, discardNullIsland)` — equals `isBogusPosition` when the flag is true; when false, only out-of-range/non-finite is dropped. |
| `src/utils/positionIngestConfig.ts` (new) | Module-level cached global flag (`get`/`set`/`parse`). The setting is global and changes rarely, but the gate runs per position packet across three sites — one of which (the meshcore repo) has no DB access — so a cached flag gives all three a **zero-DB read**. |
| Ingest gates | `meshtasticManager.isValidPosition`, `mqttIngestion` POSITION_APP, `meshcore.upsertNode` now gate on `getDiscardInvalidPositions()`. |
| Wiring | Key added to `VALID_SETTINGS_KEYS`; startup hydration + a `setDiscardInvalidPositions` `SettingsCallbacks` entry so a save takes effect **live, no restart**. |
| Frontend | `discardInvalidPositions` in `SettingsContext` (default `true`, all touchpoints) + a checkbox in the **Map Settings** section of `SettingsTab`. |

## Tests
- `shouldDiscardPosition` unit tests: equals `isBogusPosition` when on; lets (0,0)/precision-obscured (0,0) through when off; always drops out-of-range/non-finite; never drops a real position.
- `mqttIngestion` test: (0,0) is **stored** when the setting is disabled, while out-of-range is **still dropped**.

Verified: affected suites 103 pass + settings suites 163 pass (`success=true`), `tsc` clean (server + touched frontend), `lint:ci` ratchet OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1