### PR TITLE
fix(mqtt): route directed messages to the DM view, not their channel (#4152)

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -137,6 +137,7 @@ import { migration as themeTilesetsMigration, runMigration119Postgres as runThem
 import { migration as addReasonToIgnoredNodesMigration, runMigration120Postgres as runAddReasonToIgnoredNodesPostgres, runMigration120Mysql as runAddReasonToIgnoredNodesMysql } from '../server/migrations/120_add_reason_to_ignored_nodes.js';
 import { migration as mqttPacketLogMigration, runMigration121Postgres, runMigration121Mysql } from '../server/migrations/121_mqtt_packet_log.js';
 import { migration as cleanupOrphanedSourceNodesMigration, runMigration122Postgres, runMigration122Mysql } from '../server/migrations/122_cleanup_orphaned_source_nodes.js';
+import { migration as fixMqttDirectedMessageChannelMigration, runMigration123Postgres, runMigration123Mysql } from '../server/migrations/123_fix_mqtt_directed_message_channel.js';
 
 // ============================================================================
 // Registry
@@ -1943,4 +1944,20 @@ registry.register({
   sqlite: (db) => cleanupOrphanedSourceNodesMigration.up(db),
   postgres: (client) => runMigration122Postgres(client),
   mysql: (pool) => runMigration122Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 123: One-shot re-filing of pre-existing MQTT-sourced directed
+// messages (TEXT_MESSAGE_APP addressed to a specific node) from their LoRa
+// channel to channel -1, so they render in the DM view instead of as
+// broadcasts — matching the TCP path and the #4152 ingestion fix.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 123,
+  name: 'fix_mqtt_directed_message_channel',
+  settingsKey: 'migration_123_fix_mqtt_directed_message_channel',
+  sqlite: (db) => fixMqttDirectedMessageChannelMigration.up(db),
+  postgres: (client) => runMigration123Postgres(client),
+  mysql: (pool) => runMigration123Mysql(pool),
 });

--- a/src/server/migrations/123_fix_mqtt_directed_message_channel.test.ts
+++ b/src/server/migrations/123_fix_mqtt_directed_message_channel.test.ts
@@ -48,11 +48,15 @@ describe('Migration 123: re-file MQTT directed messages (SQLite)', () => {
     insert(db, { id: 'mqtt-dm-nontext',toNodeNum: 0x11223344, channel: 8,  portnum: 3, viaMqtt: 1 }); // untouched (not TEXT)
     insert(db, { id: 'tcp-dm',         toNodeNum: 0x11223344, channel: 8,  portnum: 1, viaMqtt: 0 }); // untouched (not MQTT)
     insert(db, { id: 'mqtt-dm-already',toNodeNum: 0x11223344, channel: -1, portnum: 1, viaMqtt: 1 }); // already correct
+    insert(db, { id: 'mqtt-dm-zero',   toNodeNum: 0,          channel: 8,  portnum: 1, viaMqtt: 1 }); // unset `to` (0) → directed, per TCP path
   });
 
   it('sets channel -1 only for MQTT-sourced directed TEXT messages', () => {
     migration.up(db);
     expect(channelOf(db, 'mqtt-dm')).toBe(-1);
+    // toNodeNum = 0 (unset proto `to`) is a directed address (0 != broadcast),
+    // matching the ingestion gate and the TCP path — it migrates to -1 too.
+    expect(channelOf(db, 'mqtt-dm-zero')).toBe(-1);
   });
 
   it('leaves broadcasts, non-text, and TCP rows untouched', () => {

--- a/src/server/migrations/123_fix_mqtt_directed_message_channel.test.ts
+++ b/src/server/migrations/123_fix_mqtt_directed_message_channel.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration 123 — Re-file MQTT directed messages into the DM view (SQLite path).
+ *
+ * Verifies the one-shot cleanup sets `channel = -1` for MQTT-sourced directed
+ * TEXT_MESSAGE_APP rows only, leaves broadcasts / non-text / TCP rows untouched,
+ * and is idempotent.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './123_fix_mqtt_directed_message_channel.js';
+
+const BROADCAST = 4294967295;
+
+function createMessagesTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      channel INTEGER NOT NULL DEFAULT 0,
+      portnum INTEGER,
+      viaMqtt INTEGER,
+      text TEXT
+    );
+  `);
+}
+
+interface Row { id: string; toNodeNum: number; channel: number; portnum: number | null; viaMqtt: number | null; }
+
+function insert(db: Database.Database, r: Row) {
+  db.prepare(
+    'INSERT INTO messages (id, fromNodeNum, toNodeNum, channel, portnum, viaMqtt, text) VALUES (?, 1, ?, ?, ?, ?, ?)',
+  ).run(r.id, r.toNodeNum, r.channel, r.portnum, r.viaMqtt, 'hi');
+}
+
+function channelOf(db: Database.Database, id: string): number {
+  return (db.prepare('SELECT channel FROM messages WHERE id = ?').get(id) as { channel: number }).channel;
+}
+
+describe('Migration 123: re-file MQTT directed messages (SQLite)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createMessagesTable(db);
+    insert(db, { id: 'mqtt-dm',        toNodeNum: 0x11223344, channel: 8,  portnum: 1, viaMqtt: 1 }); // → -1
+    insert(db, { id: 'mqtt-broadcast', toNodeNum: BROADCAST,  channel: 8,  portnum: 1, viaMqtt: 1 }); // untouched
+    insert(db, { id: 'mqtt-dm-nontext',toNodeNum: 0x11223344, channel: 8,  portnum: 3, viaMqtt: 1 }); // untouched (not TEXT)
+    insert(db, { id: 'tcp-dm',         toNodeNum: 0x11223344, channel: 8,  portnum: 1, viaMqtt: 0 }); // untouched (not MQTT)
+    insert(db, { id: 'mqtt-dm-already',toNodeNum: 0x11223344, channel: -1, portnum: 1, viaMqtt: 1 }); // already correct
+  });
+
+  it('sets channel -1 only for MQTT-sourced directed TEXT messages', () => {
+    migration.up(db);
+    expect(channelOf(db, 'mqtt-dm')).toBe(-1);
+  });
+
+  it('leaves broadcasts, non-text, and TCP rows untouched', () => {
+    migration.up(db);
+    expect(channelOf(db, 'mqtt-broadcast')).toBe(8);
+    expect(channelOf(db, 'mqtt-dm-nontext')).toBe(8);
+    expect(channelOf(db, 'tcp-dm')).toBe(8);
+  });
+
+  it('is idempotent (re-run changes nothing, already-(-1) rows stay)', () => {
+    migration.up(db);
+    expect(channelOf(db, 'mqtt-dm-already')).toBe(-1);
+    // Second run must be a no-op — the `channel <> -1` predicate matches nothing.
+    migration.up(db);
+    expect(channelOf(db, 'mqtt-dm')).toBe(-1);
+    expect(channelOf(db, 'mqtt-broadcast')).toBe(8);
+  });
+});

--- a/src/server/migrations/123_fix_mqtt_directed_message_channel.ts
+++ b/src/server/migrations/123_fix_mqtt_directed_message_channel.ts
@@ -1,0 +1,69 @@
+/**
+ * Migration 123: Re-file MQTT-sourced directed messages into the DM view.
+ *
+ * Before the #4152 ingestion fix, `mqttIngestion.ts` stored every TEXT_MESSAGE_APP
+ * packet with `channel = effectiveChannel`, never checking `toNodeNum`. A message
+ * addressed to a specific node (not broadcast) was therefore bucketed into its
+ * LoRa channel and rendered as an ordinary broadcast in both per-source chat and
+ * Unified Messages. The TCP/radio path has always forced `channel = -1` for
+ * directed messages; this one-shot cleanup brings pre-existing MQTT rows in line.
+ *
+ * Scope is deliberately narrow: only MQTT-sourced (`viaMqtt` true) TEXT_MESSAGE_APP
+ * (`portnum = 1`) rows addressed to a specific node (`toNodeNum` != the broadcast
+ * address 4294967295) that are not already `-1`. Broadcasts, non-text rows, and
+ * TCP/radio rows (which were already correct) are untouched.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL: the `channel <> -1` predicate
+ * means a re-run matches nothing.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 123';
+const BROADCAST_ADDR = 4294967295; // 0xFFFFFFFF
+
+// SQLite / MySQL: camelCase columns, unquoted; boolean stored as 0/1.
+const UPDATE_SQL = `UPDATE messages SET channel = -1
+  WHERE viaMqtt = 1 AND portnum = 1 AND toNodeNum <> ${BROADCAST_ADDR} AND channel <> -1`;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): re-filing MQTT directed messages into the DM view...`);
+    const info = db.prepare(UPDATE_SQL).run();
+    if (info.changes > 0) {
+      logger.info(`${LABEL} (SQLite): re-filed ${info.changes} MQTT directed message(s) to channel -1`);
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (the original per-message channel is not recoverable)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pg client is untyped in the migration runner (matches all sibling migrations)
+export async function runMigration123Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): re-filing MQTT directed messages into the DM view...`);
+  const res = await client.query(
+    `UPDATE messages SET "channel" = -1
+     WHERE "viaMqtt" = true AND "portnum" = 1 AND "toNodeNum" <> ${BROADCAST_ADDR} AND "channel" <> -1`,
+  );
+  if (res?.rowCount) {
+    logger.info(`${LABEL} (PostgreSQL): re-filed ${res.rowCount} MQTT directed message(s) to channel -1`);
+  }
+}
+
+// ============ MySQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mysql pool is untyped in the migration runner (matches all sibling migrations)
+export async function runMigration123Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): re-filing MQTT directed messages into the DM view...`);
+  const [res] = await pool.query(UPDATE_SQL);
+  const affected = (res as { affectedRows?: number } | undefined)?.affectedRows ?? 0;
+  if (affected > 0) {
+    logger.info(`${LABEL} (MySQL): re-filed ${affected} MQTT directed message(s) to channel -1`);
+  }
+}

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -494,6 +494,44 @@ describe('ingestServiceEnvelope — discardInvalidPositions=false stores (0,0)',
   });
 });
 
+describe('ingestServiceEnvelope — TEXT_MESSAGE_APP directed vs broadcast channel (#4152)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+  });
+
+  const textEnvelopeTo = (to: number): ServiceEnvelopeShape => ({
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: 0xabcd1234,
+      from: NODE_IN,
+      to,
+      channel: 0,
+      decoded: { portnum: 1 /* TEXT_MESSAGE_APP */, payload: new Uint8Array([0]) } as any,
+    },
+  });
+
+  it('routes a directed (non-broadcast) message to the DM view via channel -1', async () => {
+    // Regression #4152: a non-PKI text message addressed to a specific node
+    // must land in the direct-message view (channel -1), matching the TCP path,
+    // instead of being bucketed into its LoRa channel and rendered as a broadcast.
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: textEnvelopeTo(0x11223344) });
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.channel).toBe(-1);
+    expect(inserted.toNodeNum).toBe(0x11223344);
+  });
+
+  it('leaves a broadcast message on its channel (not -1)', async () => {
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: textEnvelopeTo(0xffffffff) });
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.channel).not.toBe(-1);
+    expect(inserted.toNodeNum).toBe(0xffffffff);
+  });
+});
+
 describe('ingestServiceEnvelope — TEXT_MESSAGE_APP tapbacks', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -417,6 +417,14 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
         (decodedAny.reply_id as number | undefined);
       const replyId =
         typeof rawReplyId === 'number' && rawReplyId > 0 ? rawReplyId >>> 0 : undefined;
+      // A message directed at a specific node (not broadcast / ^all) belongs in
+      // the direct-message view, not a channel. Mirror the TCP/radio path
+      // (meshtasticManager.processTextMessageProtobuf forces channelIndex = -1 for
+      // toNum !== 4294967295, independent of PKI status). Without this, an
+      // MQTT-sourced directed message is bucketed into its channel and renders as
+      // an ordinary broadcast in both per-source chat and Unified Messages (#4152).
+      const isDirectMessage = toNum !== null && toNum !== 0xffffffff;
+      const messageChannel = isDirectMessage ? -1 : effectiveChannel;
       const msg: DbMessage = {
         // Row ID uses the TCP convention `${sourceId}_${fromNum}_${packetId}`
         // — underscores, fromNum middle, packetId last — so the unified
@@ -431,7 +439,7 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
         fromNodeId,
         toNodeId,
         text,
-        channel: effectiveChannel,
+        channel: messageChannel,
         portnum,
         timestamp: nowMs,
         // Guard against rxTime === 0: MQTT gateway packets frequently arrive


### PR DESCRIPTION
Fixes #4152.

## Problem

MQTT-sourced **directed** (non-broadcast, non-PKI) text messages rendered as ordinary channel/broadcast messages. A message sent *to* a specific node arrived via MQTT and showed up under its LoRa channel (e.g. "LongFast #101") with no indication it was directed.

**Root cause:** `mqttIngestion.ts` TEXT_MESSAGE_APP handling set `channel = effectiveChannel` and never inspected `toNodeNum`. The TCP/radio path (`meshtasticManager.processTextMessageProtobuf`) has always forced `channel = -1` for `toNum !== 4294967295`, independent of PKI — the MQTT path just never did.

## Fix

1. **Ingestion** (`mqttIngestion.ts`): compute `isDirectMessage = toNum !== null && toNum !== 0xffffffff` and store `channel = -1` for directed messages, mirroring the TCP path. New MQTT DMs now land in the direct-message view in both per-source chat (`MessagesTab` branches on `channel === -1`) and Unified Messages.

2. **Migration 123** (SQLite / PostgreSQL / MySQL): a one-shot re-filing of **already-stored** misfiled rows, so the reporter's existing DMs stop rendering as broadcasts:
   ```sql
   UPDATE messages SET channel = -1
   WHERE viaMqtt = <true> AND portnum = 1 AND toNodeNum <> 4294967295 AND channel <> -1
   ```
   Narrow WHERE clause (MQTT-only, TEXT-only, directed-only); idempotent (`channel <> -1` → re-run matches nothing). Broadcasts, non-text, and TCP/radio rows are untouched.

## Tests
- `mqttIngestion.test.ts`: a directed message is stored with `channel === -1`; a broadcast keeps its channel.
- `123_*.test.ts`: sets -1 only for MQTT directed TEXT rows; leaves broadcast / non-text / TCP rows alone; idempotent. `migrations.test.ts` (registry-derived) confirms registration.

Verified: 73 pass (`success=true`), server `tsc` clean, `lint:ci` ratchet OK.

## Deferred (not in scope)
The issue also notes an optional "to: <node>" indicator in Unified Messages (a pre-existing gap affecting *all* directed messages, not the bug). Not included per scope; easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1