### PR TITLE
feat(map-analysis): only offset obscured nodes that share a cell (#4155)

### DIFF
--- a/src/components/MapAnalysis/useAnalysisNodes.test.tsx
+++ b/src/components/MapAnalysis/useAnalysisNodes.test.tsx
@@ -136,6 +136,21 @@ describe('useAnalysisNodes', () => {
     expect(Math.abs(b[0] - 30)).toBeLessThan(0.01);
   });
 
+  it('does NOT merge same-position nodes of different precision into one cell (#4155)', () => {
+    mockUseDashboardUnifiedData.mockReturnValue({
+      nodes: [
+        // Same reported (30,-90) but different precision -> different cell sizes ->
+        // different cells. Each is alone in its own cell, so both stay centered.
+        { ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
+        { ...MOCK_NODES[0], nodeNum: 15, nodeId: '!0000000f', latitude: 30, longitude: -90, positionPrecisionBits: 14 },
+      ],
+    });
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    const byNum = (num: number) => result.current.find((n) => n.node.nodeNum === num)!;
+    expect(byNum(10).latLng).toEqual([30, -90]);
+    expect(byNum(15).latLng).toEqual([30, -90]);
+  });
+
   it('offset is deterministic across renders for shared-cell nodes (#4016)', () => {
     const shared = [
       { ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 },

--- a/src/components/MapAnalysis/useAnalysisNodes.test.tsx
+++ b/src/components/MapAnalysis/useAnalysisNodes.test.tsx
@@ -92,10 +92,11 @@ describe('useAnalysisNodes', () => {
     expect(result.current.some((n) => n.node.nodeNum === 3)).toBe(false);
   });
 
-  it('offsets a low-precision node within its cell but leaves others centered (#4016)', () => {
+  it('leaves a LONE low-precision node at its reported center (#4155)', () => {
     mockUseDashboardUnifiedData.mockReturnValue({
       nodes: [
-        // Low precision (16 bits) -> marker offset from the reported center.
+        // Low precision (16 bits) but ALONE in its cell -> now stays centered
+        // (was offset pre-#4155; a lone marker has nothing to declutter).
         { ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
         // Full precision -> unchanged.
         { ...MOCK_NODES[0], nodeNum: 11, nodeId: '!0000000b', latitude: 40, longitude: -100, positionPrecisionBits: 32 },
@@ -108,24 +109,42 @@ describe('useAnalysisNodes', () => {
     const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
     const byNum = (num: number) => result.current.find((n) => n.node.nodeNum === num)!;
 
-    // Offset node: moved off the exact center, but still within the ~728m cell (~0.0065deg).
-    const offset = byNum(10).latLng;
-    expect(offset[0]).not.toBe(30);
-    expect(offset[1]).not.toBe(-90);
-    expect(Math.abs(offset[0] - 30)).toBeLessThan(0.01);
-
-    // Full-precision, missing-precision, and overridden nodes stay dead-center.
+    expect(byNum(10).latLng).toEqual([30, -90]); // lone obscured node -> dead-center
     expect(byNum(11).latLng).toEqual([40, -100]);
     expect(byNum(12).latLng).toEqual([41, -101]);
     expect(byNum(13).latLng).toEqual([42, -102]);
   });
 
-  it('offset is deterministic across renders (#4016)', () => {
+  it('spreads 2+ low-precision nodes that share an accuracy cell (#4155/#4016)', () => {
     mockUseDashboardUnifiedData.mockReturnValue({
-      nodes: [{ ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 }],
+      nodes: [
+        // Two obscured nodes reporting the SAME snapped cell (same lat/lng + bits).
+        { ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
+        { ...MOCK_NODES[0], nodeNum: 14, nodeId: '!0000000e', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
+      ],
     });
-    const first = renderHook(() => useAnalysisNodes(), { wrapper }).result.current[0].latLng;
-    const second = renderHook(() => useAnalysisNodes(), { wrapper }).result.current[0].latLng;
+    const { result } = renderHook(() => useAnalysisNodes(), { wrapper });
+    const byNum = (num: number) => result.current.find((n) => n.node.nodeNum === num)!;
+
+    const a = byNum(10).latLng;
+    const b = byNum(14).latLng;
+    // Both pushed off the shared center, to distinct spots, still within the cell.
+    expect(a).not.toEqual([30, -90]);
+    expect(b).not.toEqual([30, -90]);
+    expect(a).not.toEqual(b);
+    expect(Math.abs(a[0] - 30)).toBeLessThan(0.01);
+    expect(Math.abs(b[0] - 30)).toBeLessThan(0.01);
+  });
+
+  it('offset is deterministic across renders for shared-cell nodes (#4016)', () => {
+    const shared = [
+      { ...MOCK_NODES[0], nodeNum: 10, nodeId: '!0000000a', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
+      { ...MOCK_NODES[0], nodeNum: 14, nodeId: '!0000000e', latitude: 30, longitude: -90, positionPrecisionBits: 16 },
+    ];
+    mockUseDashboardUnifiedData.mockReturnValue({ nodes: shared });
+    const first = renderHook(() => useAnalysisNodes(), { wrapper }).result.current.find((n) => n.node.nodeNum === 10)!.latLng;
+    mockUseDashboardUnifiedData.mockReturnValue({ nodes: shared });
+    const second = renderHook(() => useAnalysisNodes(), { wrapper }).result.current.find((n) => n.node.nodeNum === 10)!.latLng;
     expect(first).toEqual(second);
   });
 

--- a/src/components/MapAnalysis/useAnalysisNodes.ts
+++ b/src/components/MapAnalysis/useAnalysisNodes.ts
@@ -121,7 +121,7 @@ export function useAnalysisNodes(): AnalysisNode[] {
     for (const { node, latLng } of visible) {
       const bits = node.positionPrecisionBits;
       if (shouldOffsetForPrecision(bits, node.positionIsOverride)) {
-        const cell = precisionCellKey(latLng[0], latLng[1], bits as number);
+        const cell = precisionCellKey(latLng[0], latLng[1], bits);
         cellOccupancy.set(cell, (cellOccupancy.get(cell) ?? 0) + 1);
       }
     }
@@ -135,9 +135,9 @@ export function useAnalysisNodes(): AnalysisNode[] {
         const bits = node.positionPrecisionBits;
         let finalLatLng = latLng;
         if (shouldOffsetForPrecision(bits, node.positionIsOverride)) {
-          const cell = precisionCellKey(latLng[0], latLng[1], bits as number);
+          const cell = precisionCellKey(latLng[0], latLng[1], bits);
           if ((cellOccupancy.get(cell) ?? 0) >= 2) {
-            finalLatLng = offsetWithinPrecisionCell(latLng[0], latLng[1], bits as number, key ?? String(node.nodeNum));
+            finalLatLng = offsetWithinPrecisionCell(latLng[0], latLng[1], bits, key ?? String(node.nodeNum));
           }
         }
         return { node, latLng: finalLatLng, key };

--- a/src/components/MapAnalysis/useAnalysisNodes.ts
+++ b/src/components/MapAnalysis/useAnalysisNodes.ts
@@ -9,7 +9,7 @@ import { nodeMatchesSearch } from './nodeSearch';
 import { getNodeTypeCategory } from '../../utils/nodeTypeCategory';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 import { unifiedNodeKey } from '../../utils/nodeIdentity';
-import { shouldOffsetForPrecision, offsetWithinPrecisionCell } from '../../utils/precisionOffset';
+import { shouldOffsetForPrecision, offsetWithinPrecisionCell, precisionCellKey } from '../../utils/precisionOffset';
 import type { NodeSourceRef } from '../Dashboard/DashboardNodePopup';
 
 /**
@@ -74,7 +74,7 @@ export function useAnalysisNodes(): AnalysisNode[] {
   const { nodes } = useDashboardUnifiedData(sources, sourceIds.length > 0);
 
   return useMemo(() => {
-    return ((nodes ?? []) as NodeRecord[])
+    const visible = ((nodes ?? []) as NodeRecord[])
       .map((n) => ({ node: n, latLng: resolveNodeLatLng(n) }))
       .filter(
         (
@@ -110,17 +110,36 @@ export function useAnalysisNodes(): AnalysisNode[] {
             : (node.sourceId ? [node.sourceId] : []);
           return nodeSourceIds.some((id) => config.sources.includes(id));
         },
-      )
+      );
+
+    // #4155: count how many *visible* offsettable nodes share each accuracy cell.
+    // The #4016 within-cell offset only declutters same-cell stacks; a node alone
+    // in its cell has nothing to declutter, and offsetting it just pushes a marker
+    // off the reported center (potentially to a cell edge) for no reason. So we
+    // spread only cells with 2+ occupants and leave lone nodes at their center.
+    const cellOccupancy = new Map<string, number>();
+    for (const { node, latLng } of visible) {
+      const bits = node.positionPrecisionBits;
+      if (shouldOffsetForPrecision(bits, node.positionIsOverride)) {
+        const cell = precisionCellKey(latLng[0], latLng[1], bits as number);
+        cellOccupancy.set(cell, (cellOccupancy.get(cell) ?? 0) + 1);
+      }
+    }
+
+    return visible
       .map(({ node, latLng }) => {
         const key = unifiedNodeKey(node);
-        // #4016: obscured low-precision nodes are deterministically offset within
-        // their accuracy cell so they don't imply false precision or stack on one
-        // point. Applied here (the single latLng source) so markers, Follow,
-        // bounds, the measurement tool, and the popup all use the same position.
+        // #4016 within-cell offset, gated on cell occupancy (#4155). Applied here
+        // (the single latLng source) so markers, Follow, bounds, the measurement
+        // tool, and the popup all use the same position.
         const bits = node.positionPrecisionBits;
-        const finalLatLng = shouldOffsetForPrecision(bits, node.positionIsOverride)
-          ? offsetWithinPrecisionCell(latLng[0], latLng[1], bits as number, key ?? String(node.nodeNum))
-          : latLng;
+        let finalLatLng = latLng;
+        if (shouldOffsetForPrecision(bits, node.positionIsOverride)) {
+          const cell = precisionCellKey(latLng[0], latLng[1], bits as number);
+          if ((cellOccupancy.get(cell) ?? 0) >= 2) {
+            finalLatLng = offsetWithinPrecisionCell(latLng[0], latLng[1], bits as number, key ?? String(node.nodeNum));
+          }
+        }
         return { node, latLng: finalLatLng, key };
       })
       .filter((entry): entry is AnalysisNode => entry.key !== null);

--- a/src/utils/precisionOffset.test.ts
+++ b/src/utils/precisionOffset.test.ts
@@ -5,6 +5,7 @@ import {
   shouldOffsetForPrecision,
   hasAccuracyCell,
   offsetWithinPrecisionCell,
+  precisionCellKey,
   OBSCURED_PRECISION_MAX_BITS,
 } from './precisionOffset';
 
@@ -96,5 +97,30 @@ describe('offsetWithinPrecisionCell', () => {
     const dNear = Math.abs(near[0] - lat);
     const dFar = Math.abs(far[0] - lat);
     expect(dFar).toBeGreaterThan(dNear);
+  });
+});
+
+describe('precisionCellKey', () => {
+  it('is identical for the same reported position and precision (same cell)', () => {
+    expect(precisionCellKey(30, -90, 16)).toBe(precisionCellKey(30, -90, 16));
+  });
+
+  it('differs when the precision differs (different cell size = different cell)', () => {
+    expect(precisionCellKey(30, -90, 16)).not.toBe(precisionCellKey(30, -90, 14));
+  });
+
+  it('differs for positions in different cells', () => {
+    const size = precisionCellSizeDegrees(16);
+    // Two points more than a full cell apart fall in different cells.
+    expect(precisionCellKey(30, -90, 16)).not.toBe(precisionCellKey(30 + size * 2, -90, 16));
+  });
+
+  it('groups two near-center points of the same snapped cell together', () => {
+    const size = precisionCellSizeDegrees(16);
+    // Points within the same cell (both < one cell apart, same grid index).
+    const baseLatIdx = Math.floor(30 / size);
+    const a = (baseLatIdx + 0.25) * size;
+    const b = (baseLatIdx + 0.75) * size;
+    expect(precisionCellKey(a, -90, 16)).toBe(precisionCellKey(b, -90, 16));
   });
 });

--- a/src/utils/precisionOffset.ts
+++ b/src/utils/precisionOffset.ts
@@ -59,7 +59,7 @@ export function hasAccuracyCell(
 export function shouldOffsetForPrecision(
   bits: number | null | undefined,
   isOverride: boolean | null | undefined,
-): boolean {
+): bits is number {
   if (isOverride) return false;
   if (bits == null) return false;
   return bits >= 1 && bits <= OBSCURED_PRECISION_MAX_BITS;

--- a/src/utils/precisionOffset.ts
+++ b/src/utils/precisionOffset.ts
@@ -109,3 +109,19 @@ export function offsetWithinPrecisionCell(
   const lngOffset = (fy - 0.5) * lngSizeDeg;
   return [lat + latOffset, lng + lngOffset];
 }
+
+/**
+ * Stable key identifying the accuracy cell a reported position falls in, used to
+ * count how many nodes share a cell before deciding whether to offset (issue
+ * #4155). Firmware snaps an obscured position to its cell, so same-cell nodes of
+ * the same precision report identical coordinates and floor to identical grid
+ * indices. `bits` is part of the key because a different precision means a
+ * different cell size — i.e. a different cell — so two nodes only "share a cell"
+ * when both their snapped position AND their precision match.
+ */
+export function precisionCellKey(lat: number, lng: number, bits: number): string {
+  const size = precisionCellSizeDegrees(bits);
+  const latIdx = Math.floor(lat / size);
+  const lngIdx = Math.floor(lng / size);
+  return `${bits}:${latIdx}:${lngIdx}`;
+}


### PR DESCRIPTION
Closes #4155.

## Problem

The #4016 within-cell offset (`offsetWithinPrecisionCell`) jitters every obscured (low `precision_bits`) node marker by a uniform hash of its ID — regardless of whether any *other* node shares its accuracy cell. So a node **alone** in its cell can hash to an edge/corner of its accuracy square for no reason; there's nothing to declutter, and the marker just implies a position offset from what was reported.

## Fix (suggested by Hunter/huntchak in Discord)

Gate the offset on **cell occupancy**:
- **1 node** in a cell → stays at its reported center (no misleading edge placement).
- **2+ nodes** sharing a cell → keep the existing #4016 spread so they separate.

### Changes
- **`precisionOffset.ts`** — new `precisionCellKey(lat, lng, bits)`, a stable grid key. Firmware snaps obscured positions to their cell, so same-cell same-precision nodes floor to identical indices. `bits` is part of the key because a different precision means a different cell size (a different cell), so two nodes only "share a cell" when both snapped position **and** precision match.
- **`useAnalysisNodes.ts`** — materialize the filtered list, count visible offsettable nodes per cell, and only call `offsetWithinPrecisionCell` when the cell has 2+ occupants. Still the single `latLng` source, so markers / Follow / bounds / measurement / popup all agree.

### Tests
- `precisionCellKey`: same pos+bits group together; different precision or different cell don't.
- `useAnalysisNodes`: a lone obscured node now stays dead-center (updated from the old #4016 assertion); 2+ same-cell nodes spread to distinct in-cell spots, deterministically across renders; full/missing/override nodes unaffected.

Verified: 24 pass (`success=true`), `tsc` clean, `lint:ci` ratchet OK.

## Scope
Map Analysis only, as filed. The Dashboard map computes its own independent offset (`DashboardMap.tsx`) and is intentionally left unchanged here — a possible follow-up if cross-map consistency is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1