### PR TITLE
fix(map): stop rendering route segments & heatmap density for marker-less nodes (#4162, #4163)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4442,6 +4442,10 @@ const location = useLocation();
   const visibleNodeNums = useMemo(() => {
     const visibleNodes = processedNodes.filter(node => {
       if (!node.position?.latitude || !node.position?.longitude) return false;
+      // #4162/#3549: "Hide from Map" suppresses the marker (NodesTab drops it
+      // at nodesWithPosition), so it must also drop from this visible set —
+      // otherwise route-segment / neighbor lines dangle to a marker-less node.
+      if (node.hideFromMap) return false;
       if (!nodePassesTransportFilter(node, { showRfNodes, showUdpNodes, showMqttNodes })) return false;
       if (!showIncompleteNodes && !isNodeComplete(node)) return false;
       if (!showEstimatedPositions && node.user?.id && nodesWithEstimatedPosition.has(node.user.id)) return false;

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -437,8 +437,11 @@ export default function DashboardMap({
       const toNum = Number(tr?.toNodeNum);
       if (!Number.isFinite(fromNum) || !Number.isFinite(toNum)) continue;
       const snapshot = parseSnapshotRoutePositions(tr?.routePositions);
+      // #4162: gate on the rendered-marker map (`positionByNodeNum` is built
+      // from `nodesWithPosition`, which excludes hidden/aged nodes) so route
+      // segments never dangle to a node that has no marker.
       const resolvePosition = (nodeNum: number): [number, number] | null =>
-        resolveSegmentPosition(nodeNum, snapshot, positionByNodeNum);
+        resolveSegmentPosition(nodeNum, snapshot, positionByNodeNum, true);
       const keyPrefix = `tr-${tr.sourceId ?? 'x'}-${tr.id}`;
       const decomposed = decomposeTraceroute(
         {

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -36,6 +36,7 @@ interface NodeRecord extends MaybePositionedNode {
     airUtilTx?: number | null;
     uptimeSeconds?: number | null;
   } | null;
+  hideFromMap?: boolean | null;
 }
 
 interface HopEntry {
@@ -99,6 +100,10 @@ export default function AnalysisInspectorPanel() {
   const positionByKey = useMemo(() => {
     const map = new Map<string, [number, number]>();
     for (const n of (nodes ?? []) as NodeRecord[]) {
+      // #4162/#3549: exclude "Hide from Map" nodes so the traceroute summary
+      // (distinct links / observations) counts only marker-visible neighbours,
+      // matching the rendered map.
+      if (n.hideFromMap) continue;
       const ll = resolveNodeLatLng(n);
       if (ll) map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, ll);
     }

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
@@ -31,6 +31,7 @@ interface NodeRecord extends MaybePositionedNode {
   longName?: string | null;
   shortName?: string | null;
   nodeId?: string | null;
+  hideFromMap?: boolean | null;
 }
 
 /**
@@ -94,6 +95,11 @@ export default function TraceroutePathsLayer() {
   const positionByKey = useMemo(() => {
     const map = new Map<string, [number, number]>();
     for (const n of (nodes ?? []) as NodeRecord[]) {
+      // #4162/#3549: "Hide from Map" nodes have no marker (useAnalysisNodes
+      // drops them), so exclude them from the endpoint-position map —
+      // analyzeTraceroutes drops any segment whose endpoint is missing here,
+      // which stops route segments dangling to a marker-less node.
+      if (n.hideFromMap) continue;
       const ll = resolveNodeLatLng(n);
       if (ll) map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, ll);
     }

--- a/src/server/routes/analysisRoutes.test.ts
+++ b/src/server/routes/analysisRoutes.test.ts
@@ -339,6 +339,23 @@ describe('GET /coverage-grid', () => {
     const firstCall = mockDb.analysis.getCoverageGrid.mock.calls[0][0];
     expect(typeof firstCall.postFilter).toBe('function');
   });
+
+  // #4162/#4163 — the coverage grid must exclude hidden-node density too. The
+  // grid is server-binned, so we assert the postFilter handed to
+  // getCoverageGrid drops a hideFromMap node (admin path: display gate only).
+  it('admin: coverage-grid postFilter drops hideFromMap nodes', async () => {
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+      { nodeNum: 2, channel: 0, hideFromMap: true },
+    ]);
+    const app = createApp(adminUser);
+    // Unique cache key so this isn't served from a prior test's cache.
+    await request(app).get('/coverage-grid?since=7777&zoom=8');
+    const call = mockDb.analysis.getCoverageGrid.mock.calls[0][0];
+    expect(typeof call.postFilter).toBe('function');
+    expect(call.postFilter({ sourceId: 'src-a', nodeNum: 1 })).toBe(true);
+    expect(call.postFilter({ sourceId: 'src-a', nodeNum: 2 })).toBe(false);
+  });
 });
 
 describe('GET /hop-counts', () => {

--- a/src/server/routes/analysisRoutes.test.ts
+++ b/src/server/routes/analysisRoutes.test.ts
@@ -173,7 +173,7 @@ describe('GET /positions', () => {
     mockDb.nodes.getAllNodes.mockResolvedValue([
       { nodeNum: 99, channel: 1, positionOverrideIsPrivate: true },
     ]);
-    // Admin bypasses all node-level filters; these mocks should not be consulted
+    // Admin bypasses the permission gates; these mocks should not affect the result
     mockDb.getUserPermissionSetAsync.mockResolvedValue({});
     mockDb.checkPermissionAsync.mockResolvedValue(false);
 
@@ -181,8 +181,51 @@ describe('GET /positions', () => {
     const res = await request(app).get('/positions?since=0');
     expect(res.status).toBe(200);
     expect(res.body.items).toHaveLength(1);
-    // Admin path: getAllNodes should not be called (filter is skipped)
-    expect(mockDb.nodes.getAllNodes).not.toHaveBeenCalled();
+  });
+
+  // #4162/#4163 — "Hide from Map" is a display gate that applies to every user,
+  // admins included, so hidden nodes contribute no heatmap/coverage density.
+  it('admin: hides positions for nodes with hideFromMap set', async () => {
+    const visible = { nodeNum: 1, sourceId: 'src-a', latitude: 1, longitude: 1, altitude: null, timestamp: 1000 };
+    const hidden = { nodeNum: 2, sourceId: 'src-a', latitude: 2, longitude: 2, altitude: null, timestamp: 1000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [visible, hidden], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+      { nodeNum: 2, channel: 0, hideFromMap: true },
+    ]);
+
+    const app = createApp(adminUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].nodeNum).toBe(1);
+  });
+
+  it('regular user: hides positions for nodes with hideFromMap set', async () => {
+    const visible = { nodeNum: 1, sourceId: 'src-a', latitude: 1, longitude: 1, altitude: null, timestamp: 1000 };
+    const hidden = { nodeNum: 2, sourceId: 'src-a', latitude: 2, longitude: 2, altitude: null, timestamp: 1000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [visible, hidden], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    // Both nodes are on channel 0 with viewOnMap granted; only hideFromMap differs.
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+      { nodeNum: 2, channel: 0, hideFromMap: true },
+    ]);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({
+      channel_0: { viewOnMap: true, read: true, write: false },
+    });
+    mockDb.checkPermissionAsync.mockImplementation((_uid: number, resource: string) =>
+      Promise.resolve(resource !== 'nodes_private'),
+    );
+
+    const app = createApp(regularUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].nodeNum).toBe(1);
   });
 });
 

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -68,8 +68,18 @@ function parseSinceMs(raw: unknown): number {
 }
 
 /**
- * Build a synchronous position-row filter that enforces per-channel viewOnMap
- * and positionOverrideIsPrivate gating. Returns null for admins (allow all).
+ * Build a synchronous position-row filter enforcing two kinds of gate:
+ *
+ *  - `hideFromMap` (#4162/#4163): a DISPLAY gate applied to EVERYONE, admins
+ *    included. A node with "Hide from Map" set has no marker on any map
+ *    surface (`useAnalysisNodes`/`embedPublicRoutes` drop it), so its
+ *    historical position telemetry must not contribute heatmap or
+ *    coverage-grid density either.
+ *  - per-channel `viewOnMap` + `positionOverrideIsPrivate`: PERMISSION gates
+ *    applied only to non-admins.
+ *
+ * Returns null only when there is nothing to enforce (admin AND no node is
+ * hidden), so the caller can skip filtering entirely.
  *
  * Pre-fetches all permissions and node metadata once so the returned predicate
  * is pure and cheap to call per item — avoids N async DB round-trips inside
@@ -79,9 +89,38 @@ async function buildPositionFilter(
   user: any,
   sourceIds: string[],
 ): Promise<((pos: PositionRow) => boolean) | null> {
-  if (user?.isAdmin) return null;
-
+  const isAdmin = !!user?.isAdmin;
   const userId: number | null = user?.id ?? null;
+
+  // Batch-load node metadata for all nodes across permitted sources so the
+  // filter predicate runs synchronously. `hideFromMap` is read for every user
+  // (display gate); channel/positionOverrideIsPrivate only feed the non-admin
+  // permission gates below.
+  const nodeInfoByKey = new Map<
+    string,
+    { channel: number; positionOverrideIsPrivate: boolean; hideFromMap: boolean }
+  >();
+  let anyHidden = false;
+  for (const srcId of sourceIds) {
+    const nodes = await databaseService.nodes.getAllNodes(srcId);
+    for (const n of nodes) {
+      const hidden = !!n.hideFromMap;
+      if (hidden) anyHidden = true;
+      nodeInfoByKey.set(`${srcId}:${n.nodeNum}`, {
+        channel: n.channel ?? 0,
+        positionOverrideIsPrivate: !!n.positionOverrideIsPrivate,
+        hideFromMap: hidden,
+      });
+    }
+  }
+
+  // Admins bypass the permission gates. When no node is hidden there is
+  // nothing left to enforce, so skip filtering entirely.
+  if (isAdmin) {
+    if (!anyHidden) return null;
+    return (pos: PositionRow): boolean =>
+      !nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`)?.hideFromMap;
+  }
 
   // Fetch channel permission sets once per source
   const permsBySource = new Map<string, Record<string, { viewOnMap?: boolean } | undefined>>();
@@ -100,22 +139,12 @@ async function buildPositionFilter(
     ? await databaseService.checkPermissionAsync(userId, 'nodes_private', 'read')
     : false;
 
-  // Batch-load node metadata (channel, positionOverrideIsPrivate) for all nodes
-  // across permitted sources so the filter predicate runs synchronously.
-  const nodeInfoByKey = new Map<string, { channel: number; positionOverrideIsPrivate: boolean }>();
-  for (const srcId of sourceIds) {
-    const nodes = await databaseService.nodes.getAllNodes(srcId);
-    for (const n of nodes) {
-      nodeInfoByKey.set(`${srcId}:${n.nodeNum}`, {
-        channel: n.channel ?? 0,
-        positionOverrideIsPrivate: !!n.positionOverrideIsPrivate,
-      });
-    }
-  }
-
   return (pos: PositionRow): boolean => {
     const info = nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`)
-      ?? { channel: 0, positionOverrideIsPrivate: false };
+      ?? { channel: 0, positionOverrideIsPrivate: false, hideFromMap: false };
+
+    // #4162/#4163: hidden nodes have no marker, so contribute no density.
+    if (info.hideFromMap) return false;
 
     // Block private-position nodes unless the user has nodes_private:read
     if (info.positionOverrideIsPrivate && !canViewPrivate) return false;

--- a/src/utils/tracerouteSegments.test.ts
+++ b/src/utils/tracerouteSegments.test.ts
@@ -106,6 +106,35 @@ describe('resolveSegmentPosition', () => {
     const live = new Map<number, [number, number]>();
     expect(resolveSegmentPosition(1, snapshot, live)).toBeNull();
   });
+
+  // #4162 — requireLive gate: a node absent from the rendered-marker map
+  // (aged out / purged / hidden) must not anchor a dangling route segment,
+  // even if the historical snapshot still holds a position for it.
+  describe('requireLive (#4162)', () => {
+    it('drops a node that has a snapshot but is absent from liveNodes', () => {
+      const snapshot = new Map<number, [number, number]>([[1, [1, 1]]]);
+      const live = new Map<number, [number, number]>();
+      expect(resolveSegmentPosition(1, snapshot, live, true)).toBeNull();
+    });
+
+    it('still prefers the snapshot position when the node IS live', () => {
+      const snapshot = new Map<number, [number, number]>([[1, [1, 1]]]);
+      const live = new Map<number, [number, number]>([[1, [9, 9]]]);
+      expect(resolveSegmentPosition(1, snapshot, live, true)).toEqual([1, 1]);
+    });
+
+    it('falls back to the live position for a live node with no snapshot', () => {
+      const snapshot = new Map<number, [number, number]>();
+      const live = new Map<number, [number, number]>([[1, [9, 9]]]);
+      expect(resolveSegmentPosition(1, snapshot, live, true)).toEqual([9, 9]);
+    });
+
+    it('defaults (requireLive=false) to the legacy snapshot-then-live behavior', () => {
+      const snapshot = new Map<number, [number, number]>([[1, [1, 1]]]);
+      const live = new Map<number, [number, number]>();
+      expect(resolveSegmentPosition(1, snapshot, live)).toEqual([1, 1]);
+    });
+  });
 });
 
 describe('hasReturnPath (#2051)', () => {

--- a/src/utils/tracerouteSegments.ts
+++ b/src/utils/tracerouteSegments.ts
@@ -126,12 +126,24 @@ export function parseSnapshotRoutePositions(
  * normalized to `[lat, lng]` tuples — normalizing a consumer's own live-node
  * shape (digest array, raw node map with `latitudeI/longitudeI` vs
  * `latitude/longitude`, etc.) is the caller's job, not this function's.
+ *
+ * `requireLive` (issue #4162): when true, a node absent from `liveNodes`
+ * resolves to `null` (drop the hop) even if the snapshot still holds a
+ * historical position for it. `liveNodes` is the caller's *rendered-marker*
+ * position map, so this keeps route segments attached to actual markers —
+ * a node that has aged out, been purged, or is hidden ("Hide from Map") has
+ * no marker and must not anchor a dangling line. When the node IS live, the
+ * #1862 snapshot-then-live preference is preserved. Route-segment overlays
+ * pass `true`; the single-traceroute display leaves it `false` so it can show
+ * every hop (including hidden/aged relays) of one specific traceroute.
  */
 export function resolveSegmentPosition(
   nodeNum: number,
   snapshot: Map<number, [number, number]>,
   liveNodes: Map<number, [number, number]>,
+  requireLive = false,
 ): [number, number] | null {
+  if (requireLive && !liveNodes.has(nodeNum)) return null;
   return snapshot.get(nodeNum) ?? liveNodes.get(nodeNum) ?? null;
 }
 


### PR DESCRIPTION
## Summary

Fixes #4162 and #4163 — the two are the **same class of bug**: secondary map layers render geometry for nodes that have **no marker**, because the visibility gate the marker layers apply (`hideFromMap`, plus aged-out/purged) was missing on those paths.

## #4162 — dangling route segments

Traceroute-derived RF hop lines rendered without connecting to any visible node marker (even with the age slider on "All"). Root cause: the segment endpoint resolver preferred the historical traceroute snapshot and never checked whether the node still has a marker.

- **`src/utils/tracerouteSegments.ts`** — `resolveSegmentPosition()` gains an opt-in `requireLive` flag. It preserves #1862's snapshot-then-live preference for live nodes but returns `null` (drops the hop) when the node is absent from the caller's *rendered-marker* position map. Route-segment overlays pass `true`; the **single-traceroute display leaves it `false`** so it still shows every hop (including hidden/aged relays) of one specific traceroute.
- **`src/App.tsx`** — the main map's `visibleNodeNums` set (which gates route-segment and neighbor lines at `useTraceroutePaths.tsx:449`) omitted `hideFromMap`, despite a comment stating it mirrors the NodesTab marker filter (which *does* exclude it). Added the check — fixes both line types.
- **`src/components/Dashboard/DashboardMap.tsx`** — route-segment resolver now passes `requireLive: true` (its `positionByNodeNum` is already built from the hidden/aged-excluding marker list).
- **`src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx`** (+ `AnalysisInspectorPanel.tsx`) — the Map Analysis engine resolves positions purely from `positionByKey` and drops any segment whose endpoint is missing there; excluding `hideFromMap` nodes from that map cleanly drops their segments.

## #4163 — heatmap/coverage included hidden nodes

A node with "Hide from Map" set produced no marker but its historical position telemetry still contributed density to the coverage grid and heatmap dots.

- **`src/server/routes/analysisRoutes.ts`** — `buildPositionFilter()` now reads `hideFromMap` and drops hidden nodes. Because it is a **display gate, not a permission**, it applies to **everyone including admins** (the admin early-return was restructured so the `hideFromMap` drop still runs; it returns `null` only when there is genuinely nothing to filter). Covers both `/positions` and `/coverage-grid`.

## Scope note

Scoped to the `hideFromMap`/marker-visibility gate that both issues call out. The #4163 "open question" about *fully deleted/purged* nodes with orphaned telemetry rows is a separate node-deletion-cascade investigation and is **not** included here. The #4162 secondary cleanup gap (`deleteTraceroutesForNode` not purging intermediate-hop rows) is made moot for rendering by the endpoint gate; the stale rows themselves are left for a follow-up.

## Testing

- New `requireLive` unit cases for `resolveSegmentPosition` (drop-when-absent, still-prefer-snapshot-when-live, default legacy behavior).
- New admin + regular-user `hideFromMap` drop cases for `GET /positions`; updated the admin test that assumed `getAllNodes` is never called for admins.
- Full Vitest suite green (0 failures), `tsc --noEmit` clean, `npm run lint:ci` ratchet OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)