### PR TITLE
refactor(map): one shared occupancy-gated precision offset for all maps

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -29,7 +29,8 @@ import PolarGridOverlay from '../PolarGridOverlay';
 import MapLegend from '../MapLegend';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
-import { precisionCellBounds, hasAccuracyCell, shouldOffsetForPrecision, offsetWithinPrecisionCell } from '../../utils/precisionOffset';
+import { precisionCellBounds, hasAccuracyCell, applyPrecisionCellOffsets } from '../../utils/precisionOffset';
+import { unifiedNodeKey } from '../../utils/nodeIdentity';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { useMapContext } from '../../contexts/MapContext';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -285,26 +286,28 @@ export default function DashboardMap({
   // reference instead of drifting per-node inside the marker map loop below.
   const nowMs = Date.now();
   const cutoffTime = nowMs / 1000 - effectiveMaxAge * 60 * 60;
-  const nodesWithPosition = nodes
+  const nodesWithTruePos = nodes
     .filter((n) => !n.isIgnored)
     .filter((n) => !n.hideFromMap) // #3549: per-node "Hide from Map" suppresses the marker only
     .filter((n) => n.isFavorite || (n.lastHeard != null && n.lastHeard >= cutoffTime))
     .filter((n) => nodePassesTransportFilter(n, { showRfNodes, showUdpNodes, showMqttNodes }))
-    .map((n) => {
-      const truePos = getNodeLatLng(n);
-      if (!truePos) return { node: n, pos: null };
-      // #4016: offset obscured low-precision markers within their accuracy cell,
-      // so `pos` (used by the marker, neighbor/traceroute endpoints, and the
-      // measurement tool) declutters same-cell nodes. The accuracy rectangle
-      // below recomputes the TRUE center from the node, so it stays put.
-      if (shouldOffsetForPrecision(n.positionPrecisionBits, n.positionIsOverride)) {
-        const id = String(n.nodeId ?? n.user?.id ?? n.nodeNum);
-        const [lat, lng] = offsetWithinPrecisionCell(truePos.lat, truePos.lng, n.positionPrecisionBits as number, id);
-        return { node: n, pos: { lat, lng } };
-      }
-      return { node: n, pos: truePos };
-    })
-    .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
+    .map((n) => ({ node: n, truePos: getNodeLatLng(n) }))
+    .filter((e): e is { node: any; truePos: { lat: number; lng: number } } => e.truePos !== null);
+
+  // #4016/#4155: offset obscured low-precision markers within their accuracy cell
+  // via the shared occupancy-gated helper — lone nodes stay centered, 2+ same-cell
+  // nodes spread — identical to every other map surface. `pos` (used by the marker,
+  // neighbor/traceroute endpoints, and the measurement tool) thus declutters. The
+  // accuracy rectangle below recomputes the TRUE center from the node, so it stays put.
+  const nodesWithPosition = applyPrecisionCellOffsets(
+    nodesWithTruePos.map(({ node, truePos }) => ({
+      item: node,
+      id: unifiedNodeKey(node) ?? String(node.nodeNum),
+      latLng: [truePos.lat, truePos.lng] as [number, number],
+      bits: node.positionPrecisionBits,
+      isOverride: node.positionIsOverride,
+    })),
+  ).map(({ item: node, latLng }) => ({ node, pos: { lat: latLng[0], lng: latLng[1] } }));
 
   // Array form of node positions for MapBoundsUpdater (fit bounds).
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);

--- a/src/components/MapAnalysis/useAnalysisNodes.ts
+++ b/src/components/MapAnalysis/useAnalysisNodes.ts
@@ -9,7 +9,7 @@ import { nodeMatchesSearch } from './nodeSearch';
 import { getNodeTypeCategory } from '../../utils/nodeTypeCategory';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 import { unifiedNodeKey } from '../../utils/nodeIdentity';
-import { shouldOffsetForPrecision, offsetWithinPrecisionCell, precisionCellKey } from '../../utils/precisionOffset';
+import { applyPrecisionCellOffsets } from '../../utils/precisionOffset';
 import type { NodeSourceRef } from '../Dashboard/DashboardNodePopup';
 
 /**
@@ -112,36 +112,21 @@ export function useAnalysisNodes(): AnalysisNode[] {
         },
       );
 
-    // #4155: count how many *visible* offsettable nodes share each accuracy cell.
-    // The #4016 within-cell offset only declutters same-cell stacks; a node alone
-    // in its cell has nothing to declutter, and offsetting it just pushes a marker
-    // off the reported center (potentially to a cell edge) for no reason. So we
-    // spread only cells with 2+ occupants and leave lone nodes at their center.
-    const cellOccupancy = new Map<string, number>();
-    for (const { node, latLng } of visible) {
-      const bits = node.positionPrecisionBits;
-      if (shouldOffsetForPrecision(bits, node.positionIsOverride)) {
-        const cell = precisionCellKey(latLng[0], latLng[1], bits);
-        cellOccupancy.set(cell, (cellOccupancy.get(cell) ?? 0) + 1);
-      }
-    }
-
-    return visible
-      .map(({ node, latLng }) => {
-        const key = unifiedNodeKey(node);
-        // #4016 within-cell offset, gated on cell occupancy (#4155). Applied here
-        // (the single latLng source) so markers, Follow, bounds, the measurement
-        // tool, and the popup all use the same position.
-        const bits = node.positionPrecisionBits;
-        let finalLatLng = latLng;
-        if (shouldOffsetForPrecision(bits, node.positionIsOverride)) {
-          const cell = precisionCellKey(latLng[0], latLng[1], bits);
-          if ((cellOccupancy.get(cell) ?? 0) >= 2) {
-            finalLatLng = offsetWithinPrecisionCell(latLng[0], latLng[1], bits, key ?? String(node.nodeNum));
-          }
-        }
-        return { node, latLng: finalLatLng, key };
-      })
+    // #4016/#4155 obscured-GPS marker offset, via the shared occupancy-gated
+    // helper so every map surface declutters identically (lone nodes stay
+    // centered; 2+ same-cell nodes spread). Applied here — the single latLng
+    // source — so markers, Follow, bounds, the measurement tool, and the popup
+    // all use the same position.
+    return applyPrecisionCellOffsets(
+      visible.map(({ node, latLng }) => ({
+        item: node,
+        id: unifiedNodeKey(node) ?? String(node.nodeNum),
+        latLng,
+        bits: node.positionPrecisionBits,
+        isOverride: node.positionIsOverride,
+      })),
+    )
+      .map(({ item: node, latLng }) => ({ node, latLng, key: unifiedNodeKey(node) }))
       .filter((entry): entry is AnalysisNode => entry.key !== null);
   }, [nodes, nodeFilter, config.nodeTypes, config.transports, config.sources]);
 }

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -13,7 +13,8 @@ import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, snrToColor } from '../utils/mapHelpers.tsx';
 import { convertSpeed } from '../utils/speedConversion';
 import { getEffectivePosition, getRoleName, hasValidEffectivePosition, isNodeComplete, parseNodeId, resolveMapEndpoint, resolveMarkerCenterTarget, TRACEROUTE_DISPLAY_HOURS } from '../utils/nodeHelpers';
-import { shouldOffsetForPrecision, offsetWithinPrecisionCell, hasAccuracyCell, precisionCellBounds } from '../utils/precisionOffset';
+import { applyPrecisionCellOffsets, hasAccuracyCell, precisionCellBounds } from '../utils/precisionOffset';
+import { unifiedNodeKey } from '../utils/nodeIdentity';
 import MapLegend from './MapLegend';
 import { formatTime, formatDateTime } from '../utils/datetime';
 import { getDistanceToNode, calculateDistance, formatDistance } from '../utils/distance';
@@ -1362,22 +1363,25 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // Creating new [lat, lng] arrays causes React-Leaflet to move markers, destroying spiderfier state
   // Uses getEffectivePosition to respect position overrides (Issue #1526)
   const nodePositions = React.useMemo(() => {
+    // #4016/#4155: offset obscured low-precision markers within their accuracy
+    // cell via the shared occupancy-gated helper — lone nodes stay centered, 2+
+    // same-cell nodes spread — identical to every other map surface. Overridden
+    // positions are never moved; the accuracy Rectangle below keeps using
+    // node.position (the true center).
+    const offset = applyPrecisionCellOffsets(
+      nodesWithPosition
+        .map(node => ({ node, eff: getEffectivePosition(node) }))
+        .filter(e => e.eff.latitude != null && e.eff.longitude != null)
+        .map(({ node, eff }) => ({
+          item: node,
+          id: unifiedNodeKey(node) ?? String(node.nodeNum),
+          latLng: [eff.latitude as number, eff.longitude as number] as [number, number],
+          bits: node.positionPrecisionBits,
+          isOverride: node.positionIsOverride,
+        })),
+    );
     const posMap = new Map<number, [number, number]>();
-    nodesWithPosition.forEach(node => {
-      const effectivePos = getEffectivePosition(node);
-      if (effectivePos.latitude != null && effectivePos.longitude != null) {
-        let lat = effectivePos.latitude;
-        let lng = effectivePos.longitude;
-        // #4016: offset obscured low-precision markers within their accuracy cell
-        // so same-cell nodes declutter. Overridden positions return false from
-        // shouldOffsetForPrecision, so they stay exact; the accuracy Rectangle
-        // below keeps using node.position (the true center).
-        if (shouldOffsetForPrecision(node.positionPrecisionBits, node.positionIsOverride)) {
-          [lat, lng] = offsetWithinPrecisionCell(lat, lng, node.positionPrecisionBits as number, String(node.user?.id ?? node.nodeNum));
-        }
-        posMap.set(node.nodeNum, [lat, lng]);
-      }
-    });
+    for (const { item: node, latLng } of offset) posMap.set(node.nodeNum, latLng);
     return posMap;
   }, [nodesWithPosition.map(n => {
     const pos = getEffectivePosition(n);

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1397,24 +1397,24 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // node" effect and this component's `onOmsClick`.
 
   // #3636: measurement endpoints — nearest-node snapping picks from these.
+  // Use the OFFSET marker position (nodePositions), not the raw center, so the
+  // measure tool snaps to the pin the user sees — matching DashboardMap and the
+  // #4016/#4155 single-position rule (measure/bounds/markers all agree).
   const measurePoints: MeasurePoint[] = React.useMemo(
     () => nodesWithPosition
       .map(node => {
-        const pos = getEffectivePosition(node);
-        if (pos.latitude == null || pos.longitude == null) return null;
+        const pos = nodePositions.get(node.nodeNum);
+        if (!pos) return null;
         return {
           id: String(node.user?.id ?? node.nodeNum),
-          lat: pos.latitude,
-          lng: pos.longitude,
+          lat: pos[0],
+          lng: pos[1],
           label: node.user?.shortName,
         } as MeasurePoint;
       })
       .filter((p): p is MeasurePoint => p !== null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on a position+label signature; label included so tooltip names refresh
-    [nodesWithPosition.map(n => {
-      const pos = getEffectivePosition(n);
-      return `${n.nodeNum}-${pos.latitude}-${pos.longitude}-${n.user?.shortName ?? ''}`;
-    }).join(',')],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on nodePositions (offset) + a label signature so tooltip names refresh
+    [nodePositions, nodesWithPosition.map(n => `${n.nodeNum}-${n.user?.shortName ?? ''}`).join(',')],
   );
 
   const showLabel = mapZoom >= 13;

--- a/src/utils/precisionOffset.test.ts
+++ b/src/utils/precisionOffset.test.ts
@@ -6,6 +6,7 @@ import {
   hasAccuracyCell,
   offsetWithinPrecisionCell,
   precisionCellKey,
+  applyPrecisionCellOffsets,
   OBSCURED_PRECISION_MAX_BITS,
 } from './precisionOffset';
 
@@ -122,5 +123,57 @@ describe('precisionCellKey', () => {
     const a = (baseLatIdx + 0.25) * size;
     const b = (baseLatIdx + 0.75) * size;
     expect(precisionCellKey(a, -90, 16)).toBe(precisionCellKey(b, -90, 16));
+  });
+});
+
+describe('applyPrecisionCellOffsets', () => {
+  const inp = (item: string, latLng: [number, number], bits: number | null | undefined, isOverride = false) =>
+    ({ item, id: item, latLng, bits, isOverride });
+
+  it('leaves a lone offsettable node at its true center', () => {
+    const out = applyPrecisionCellOffsets([inp('a', [30, -90], 16)]);
+    expect(out).toEqual([{ item: 'a', latLng: [30, -90] }]);
+  });
+
+  it('spreads 2+ nodes sharing a cell to distinct in-cell spots', () => {
+    const out = applyPrecisionCellOffsets([inp('a', [30, -90], 16), inp('b', [30, -90], 16)]);
+    const a = out.find((o) => o.item === 'a')!.latLng;
+    const b = out.find((o) => o.item === 'b')!.latLng;
+    expect(a).not.toEqual([30, -90]);
+    expect(b).not.toEqual([30, -90]);
+    expect(a).not.toEqual(b);
+    const half = precisionCellSizeDegrees(16) / 2;
+    expect(Math.abs(a[0] - 30)).toBeLessThanOrEqual(half);
+    expect(Math.abs(b[0] - 30)).toBeLessThanOrEqual(half);
+  });
+
+  it('does NOT merge same-position nodes of different precision (different cells)', () => {
+    const out = applyPrecisionCellOffsets([inp('a', [30, -90], 16), inp('b', [30, -90], 14)]);
+    // Each is alone in its own (differently-sized) cell -> both stay centered.
+    expect(out.find((o) => o.item === 'a')!.latLng).toEqual([30, -90]);
+    expect(out.find((o) => o.item === 'b')!.latLng).toEqual([30, -90]);
+  });
+
+  it('never offsets full-precision, missing-precision, or overridden nodes even when co-located', () => {
+    const out = applyPrecisionCellOffsets([
+      inp('full', [30, -90], 32),
+      inp('missing', [30, -90], null),
+      inp('override', [30, -90], 16, true),
+    ]);
+    expect(out).toEqual([
+      { item: 'full', latLng: [30, -90] },
+      { item: 'missing', latLng: [30, -90] },
+      { item: 'override', latLng: [30, -90] },
+    ]);
+  });
+
+  it('preserves input order and item identity', () => {
+    const out = applyPrecisionCellOffsets([inp('x', [10, 10], 32), inp('y', [20, 20], 32)]);
+    expect(out.map((o) => o.item)).toEqual(['x', 'y']);
+  });
+
+  it('is deterministic across calls', () => {
+    const args = [inp('a', [30, -90], 16), inp('b', [30, -90], 16)];
+    expect(applyPrecisionCellOffsets(args)).toEqual(applyPrecisionCellOffsets(args));
   });
 });

--- a/src/utils/precisionOffset.ts
+++ b/src/utils/precisionOffset.ts
@@ -157,21 +157,21 @@ export interface PrecisionOffsetInput<T> {
 export function applyPrecisionCellOffsets<T>(
   nodes: ReadonlyArray<PrecisionOffsetInput<T>>,
 ): Array<{ item: T; latLng: [number, number] }> {
-  // Pass 1: count offsettable nodes per accuracy cell.
+  // Pass 1: for each node resolve its accuracy cell (null when not offsettable)
+  // and count occupancy. `shouldOffsetForPrecision` is evaluated once per node
+  // here; it also narrows `bits` to a number, which we capture for pass 2.
   const occupancy = new Map<string, number>();
-  for (const n of nodes) {
-    if (shouldOffsetForPrecision(n.bits, n.isOverride)) {
-      const cell = precisionCellKey(n.latLng[0], n.latLng[1], n.bits);
-      occupancy.set(cell, (occupancy.get(cell) ?? 0) + 1);
-    }
-  }
+  const cellOf = nodes.map((n) => {
+    if (!shouldOffsetForPrecision(n.bits, n.isOverride)) return null;
+    const cell = precisionCellKey(n.latLng[0], n.latLng[1], n.bits);
+    occupancy.set(cell, (occupancy.get(cell) ?? 0) + 1);
+    return { cell, bits: n.bits };
+  });
   // Pass 2: offset only nodes whose cell has 2+ occupants.
-  return nodes.map((n) => {
-    if (shouldOffsetForPrecision(n.bits, n.isOverride)) {
-      const cell = precisionCellKey(n.latLng[0], n.latLng[1], n.bits);
-      if ((occupancy.get(cell) ?? 0) >= 2) {
-        return { item: n.item, latLng: offsetWithinPrecisionCell(n.latLng[0], n.latLng[1], n.bits, n.id) };
-      }
+  return nodes.map((n, i) => {
+    const c = cellOf[i];
+    if (c && (occupancy.get(c.cell) ?? 0) >= 2) {
+      return { item: n.item, latLng: offsetWithinPrecisionCell(n.latLng[0], n.latLng[1], c.bits, n.id) };
     }
     return { item: n.item, latLng: n.latLng };
   });

--- a/src/utils/precisionOffset.ts
+++ b/src/utils/precisionOffset.ts
@@ -125,3 +125,54 @@ export function precisionCellKey(lat: number, lng: number, bits: number): string
   const lngIdx = Math.floor(lng / size);
   return `${bits}:${latIdx}:${lngIdx}`;
 }
+
+/**
+ * One node fed to {@link applyPrecisionCellOffsets}: an opaque `item` carried
+ * through untouched, a stable hash `id` (use `unifiedNodeKey` semantics so the
+ * SAME node lands on the SAME in-cell spot on every map), the node's TRUE reported
+ * center `latLng`, and its precision/override flags.
+ */
+export interface PrecisionOffsetInput<T> {
+  item: T;
+  id: string;
+  latLng: [number, number];
+  bits: number | null | undefined;
+  isOverride: boolean | null | undefined;
+}
+
+/**
+ * Occupancy-gated within-cell offset for a set of positioned nodes — the single
+ * shared implementation used by every map surface (Dashboard, NodesTab, Map
+ * Analysis) so obscured-GPS markers declutter identically everywhere.
+ *
+ * A node is offset to a deterministic spot inside its accuracy cell (#4016) ONLY
+ * when 2+ offsettable nodes share that cell (#4155); a node alone in its cell
+ * stays at its true reported center (offsetting a lone marker just implies a
+ * position it never reported). Nodes with fine/absent precision or a user
+ * override are never moved. Pure and deterministic given the same input.
+ *
+ * Returns each input's `item` paired with its resolved `latLng` (offset where the
+ * cell has 2+ occupants, true center otherwise), in the input order.
+ */
+export function applyPrecisionCellOffsets<T>(
+  nodes: ReadonlyArray<PrecisionOffsetInput<T>>,
+): Array<{ item: T; latLng: [number, number] }> {
+  // Pass 1: count offsettable nodes per accuracy cell.
+  const occupancy = new Map<string, number>();
+  for (const n of nodes) {
+    if (shouldOffsetForPrecision(n.bits, n.isOverride)) {
+      const cell = precisionCellKey(n.latLng[0], n.latLng[1], n.bits);
+      occupancy.set(cell, (occupancy.get(cell) ?? 0) + 1);
+    }
+  }
+  // Pass 2: offset only nodes whose cell has 2+ occupants.
+  return nodes.map((n) => {
+    if (shouldOffsetForPrecision(n.bits, n.isOverride)) {
+      const cell = precisionCellKey(n.latLng[0], n.latLng[1], n.bits);
+      if ((occupancy.get(cell) ?? 0) >= 2) {
+        return { item: n.item, latLng: offsetWithinPrecisionCell(n.latLng[0], n.latLng[1], n.bits, n.id) };
+      }
+    }
+    return { item: n.item, latLng: n.latLng };
+  });
+}


### PR DESCRIPTION
Follow-up to #4155 / #4164 — the deferred "align the obscured-GPS offset globally" item, as part of the single-map initiative (epic #4047).

## Problem

The obscured-GPS within-cell marker offset (#4016) was implemented **three separate times**:

| Surface | Occupancy-gated (#4155)? | Hash id |
|---|---|---|
| Map Analysis (`useAnalysisNodes`) | ✅ yes | `unifiedNodeKey ?? nodeNum` |
| Dashboard (`DashboardMap`) | ❌ no — offsets lone nodes | `nodeId ?? user.id ?? nodeNum` |
| NodesTab | ❌ no — offsets lone nodes | `user.id ?? nodeNum` |

So a **lone** obscured node still hashed to a cell edge on the Dashboard and NodesTab maps (the exact thing #4155 fixed, but only in Map Analysis), and the **same node** could land on a **different in-cell spot per map** because each surface seeded the hash differently.

## Fix

Consolidate the algorithm into one shared primitive and route all three surfaces through it:

- **`precisionOffset.ts`** — new `applyPrecisionCellOffsets(nodes)`: the occupancy count + `>= 2` gate + offset, generalized over an opaque `item`. Lone offsettable nodes stay at their true center; 2+ same-cell nodes spread. Pure/deterministic.
- **`useAnalysisNodes` / `DashboardMap` / `NodesTab`** — each keeps its own lat/lng resolver (they legitimately differ: `resolveNodeLatLng` / `getNodeLatLng` / `getEffectivePosition`-with-overrides) and hands `{item, id, latLng, bits, isOverride}` to the shared helper. The hash **id is standardized** to `unifiedNodeKey(node) ?? String(nodeNum)` on all three, so a node lands on the **same** in-cell spot everywhere.

The two accuracy-region *layers* were already descriptor-driven off the true center and are untouched.

## Behavior change
On the **Dashboard and NodesTab** maps, lone obscured nodes now render at their reported **center** instead of a hashed in-cell spot (bringing them in line with #4155). Clustered obscured nodes may shift to a slightly different (still deterministic, in-cell) spot due to the standardized id. Accuracy rectangles are unaffected — they still draw from the true center.

## Tests
- Direct unit tests for `applyPrecisionCellOffsets` (lone→centered, 2+→spread, different-precision same-pos not merged, full/missing/override never moved, order/identity preserved, deterministic).
- Existing Map Analysis / NodesTab / Dashboard suites pass unchanged (65 across the four files).

Verified: 21 precisionOffset + 65 map-suite tests pass (`success=true`), `tsc` clean, `lint:ci` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1