### PR TITLE
fix(map): pin SNR overlay dots to the merged marker position for multi-source nodes (#4166)

### DIFF
--- a/src/components/MapAnalysis/layers/SnrOverlayLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/SnrOverlayLayer.test.tsx
@@ -34,9 +34,18 @@ vi.mock('../../../hooks/useMapAnalysisData', () => ({
       // into the single newest fix across all sources.
       { nodeNum: 1, sourceId: 'b', latitude: 33, longitude: -93, timestamp: 150 },
       { nodeNum: 2, sourceId: 'a', latitude: 31, longitude: -91, timestamp: 50 },
+      // #4166 — node 3 heard over two sources with DIVERGING positions. The
+      // newest raw fix is source b at (99, 99), ts=300 — but the merged node
+      // record (below) resolves to source a's (50, -110). The dot must follow
+      // the MERGED/marker position, not the newest raw fix.
+      { nodeNum: 3, sourceId: 'b', latitude: 99, longitude: 99, timestamp: 300 },
+      { nodeNum: 3, sourceId: 'a', latitude: 50, longitude: -110, timestamp: 250 },
+      // Node 20 is "Hide from Map" (merged record below) — it has an in-window
+      // fix but must produce NO dot.
+      { nodeNum: 20, sourceId: 'a', latitude: 45, longitude: -105, timestamp: 300 },
     ],
     isLoading: false,
-    progress: { percent: 100, loaded: 4, estimatedTotal: 4 },
+    progress: { percent: 100, loaded: 7, estimatedTotal: 7 },
   }),
 }));
 vi.mock('../../../hooks/useDashboardData', () => ({
@@ -52,6 +61,10 @@ vi.mock('../../../hooks/useDashboardData', () => ({
       { nodeNum: 12, sourceId: 'a', snr: -3 },
       { nodeNum: 1, sourceId: 'a', latitude: 35, longitude: -95, snr: -10 },
       { nodeNum: 2, sourceId: 'a', latitude: 31, longitude: -91 /* no snr */ },
+      // #4166 — node 3's merged/marker position is source a's (50, -110).
+      { nodeNum: 3, sourceId: 'a', latitude: 50, longitude: -110, snr: 1 },
+      // #4163-class — hidden node with a position; must produce no dot.
+      { nodeNum: 20, sourceId: 'a', latitude: 45, longitude: -105, snr: 5, hideFromMap: true },
     ],
     traceroutes: [],
     neighborInfo: [],
@@ -100,9 +113,20 @@ describe('SnrOverlayLayer', () => {
     setConfig({ enabled: true, lookbackHours: null });
     renderWith(<SnrOverlayLayer />);
     const dots = screen.getAllByTestId('snr-dot');
-    // Unified positioned nodes: 10, 11 (twice across sources collapses), 1, 2.
-    // Node 12 has no position. Total = 4.
-    expect(dots).toHaveLength(4);
+    // Unified positioned, non-hidden nodes: 10, 11 (twice across sources
+    // collapses), 1, 2, 3. Node 12 has no position; node 20 is hideFromMap.
+    // Total = 5.
+    expect(dots).toHaveLength(5);
+  });
+
+  it('"Last" mode omits hideFromMap nodes (#4163-class — no marker, no dot)', () => {
+    setConfig({ enabled: true, lookbackHours: null });
+    renderWith(<SnrOverlayLayer />);
+    // Node 20 (hideFromMap) sits at lat=45 — it must not render.
+    const hidden = screen.getAllByTestId('snr-dot').find(
+      (d) => d.getAttribute('data-lat') === '45',
+    );
+    expect(hidden).toBeUndefined();
   });
 
   it('colors each dot by the node\'s most recent SNR (matches MapLegend thresholds)', () => {
@@ -121,17 +145,40 @@ describe('SnrOverlayLayer', () => {
     expect(byNum('31')!.getAttribute('data-color')).toBe('#888');
   });
 
-  it('windowed mode dedupes to the latest position per nodeNum across all sources', () => {
+  it('windowed mode renders one dot per nodeNum pinned to the merged marker position', () => {
     setConfig({ enabled: true, lookbackHours: 24 });
     renderWith(<SnrOverlayLayer />);
     const dots = screen.getAllByTestId('snr-dot');
-    // node 1 (3 fixes across sources) collapses to 1 dot, node 2 to 1 dot.
-    expect(dots).toHaveLength(2);
-    // Node 1's newest fix is timestamp=200 (lat=35, lng=-95). Multi-source
-    // older fixes must not win.
+    // Nodes with in-window fixes: 1, 2, 3, 20. Node 20 is hidden → dropped.
+    // node 1 (3 fixes across sources) and node 2 each collapse to one dot.
+    expect(dots).toHaveLength(3);
+    // Node 1 renders at its merged position (lat=35, lng=-95).
     const node1 = dots.find((d) => d.getAttribute('data-lat') === '35');
     expect(node1).toBeDefined();
     expect(node1!.getAttribute('data-lng')).toBe('-95');
+  });
+
+  it('windowed mode follows the merged/marker position, not the newest raw fix (#4166)', () => {
+    setConfig({ enabled: true, lookbackHours: 24 });
+    renderWith(<SnrOverlayLayer />);
+    const dots = screen.getAllByTestId('snr-dot');
+    // Node 3's newest raw fix is source b at (99, 99), ts=300 — but its merged
+    // record resolves to source a's (50, -110). The dot must be at (50, -110).
+    const wrong = dots.find((d) => d.getAttribute('data-lat') === '99');
+    expect(wrong).toBeUndefined();
+    const node3 = dots.find((d) => d.getAttribute('data-lat') === '50');
+    expect(node3).toBeDefined();
+    expect(node3!.getAttribute('data-lng')).toBe('-110');
+  });
+
+  it('windowed mode omits hideFromMap nodes even when they have an in-window fix (#4163-class)', () => {
+    setConfig({ enabled: true, lookbackHours: 24 });
+    renderWith(<SnrOverlayLayer />);
+    // Node 20 (hideFromMap) has an in-window fix at lat=45 but must not render.
+    const hidden = screen.getAllByTestId('snr-dot').find(
+      (d) => d.getAttribute('data-lat') === '45',
+    );
+    expect(hidden).toBeUndefined();
   });
 
   it('windowed mode excludes positions outside the time slider window', () => {

--- a/src/components/MapAnalysis/layers/SnrOverlayLayer.tsx
+++ b/src/components/MapAnalysis/layers/SnrOverlayLayer.tsx
@@ -20,6 +20,7 @@ interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
   sourceId?: string;
   snr?: number | null;
+  hideFromMap?: boolean | null;
 }
 
 interface SnrDot {
@@ -98,6 +99,22 @@ export default function SnrOverlayLayer() {
     return m;
   }, [unified.nodes]);
 
+  // nodeNum -> merged node record. The SNR dot ALWAYS renders at the merged
+  // node's position (`resolveNodeLatLng`), the same coordinate NodeMarkersLayer
+  // and the trail endpoints use — so the dot can never detach from the marker.
+  // (#4166: the old windowed path picked a raw per-fix position by highest
+  // packet timestamp with no source priority, which for a node heard over both
+  // LoRa and MQTT with diverging positions could land on the other source's
+  // fix instead of the merged/marker position.)
+  const nodeByNum = useMemo(() => {
+    const m = new Map<number, NodeRecord>();
+    for (const n of (unified.nodes ?? []) as NodeRecord[]) {
+      const num = Number(n.nodeNum);
+      if (!m.has(num)) m.set(num, n);
+    }
+    return m;
+  }, [unified.nodes]);
+
   const ts = config.timeSlider;
   const dots: SnrDot[] = useMemo(() => {
     if (isLastMode) {
@@ -106,6 +123,8 @@ export default function SnrOverlayLayer() {
       for (const n of (unified.nodes ?? []) as NodeRecord[]) {
         const num = Number(n.nodeNum);
         if (seen.has(num)) continue;
+        // #4163-class: a "Hide from Map" node has no marker, so no SNR dot.
+        if (n.hideFromMap) continue;
         const ll = resolveNodeLatLng(n);
         if (!ll) continue;
         seen.add(num);
@@ -113,38 +132,40 @@ export default function SnrOverlayLayer() {
       }
       return out;
     }
-    // Windowed: dedupe to one dot per nodeNum (across sources) keeping the
-    // newest fix's coordinates. The same node can appear under multiple
-    // sources; per issue #2884 the overlay shows one marker per node.
-    // Time-slider filter is applied against the kept timestamp.
-    const latest = new Map<number, SnrDot>();
+    // Windowed: `positionItems` decides only WHICH nodes had a fix in the
+    // window (and the newest such fix's timestamp, for the time-slider filter);
+    // the dot POSITION comes from the merged node record so it stays pinned to
+    // the marker. A node with in-window fixes but no merged record / no
+    // resolvable position / hidden has no marker, so it gets no dot either.
+    const latestTs = new Map<number, number>();
     for (const p of positionItems as PositionRecord[]) {
       const num = Number(p.nodeNum);
-      const prev = latest.get(num);
-      if (!prev || p.timestamp > prev.timestamp) {
-        latest.set(num, {
-          nodeNum: num,
-          latitude: p.latitude,
-          longitude: p.longitude,
-          timestamp: p.timestamp,
-        });
-      }
+      const prev = latestTs.get(num);
+      if (prev === undefined || p.timestamp > prev) latestTs.set(num, p.timestamp);
     }
-    const all = Array.from(latest.values());
+    const out: SnrDot[] = [];
+    for (const [num, timestamp] of latestTs) {
+      const node = nodeByNum.get(num);
+      if (!node || node.hideFromMap) continue;
+      const ll = resolveNodeLatLng(node);
+      if (!ll) continue;
+      out.push({ nodeNum: num, latitude: ll[0], longitude: ll[1], timestamp });
+    }
     if (
       !ts.enabled ||
       ts.windowStartMs === undefined ||
       ts.windowEndMs === undefined
     ) {
-      return all;
+      return out;
     }
-    return all.filter(
+    return out.filter(
       (d) => d.timestamp >= ts.windowStartMs! && d.timestamp <= ts.windowEndMs!,
     );
   }, [
     isLastMode,
     positionItems,
     unified.nodes,
+    nodeByNum,
     ts.enabled,
     ts.windowStartMs,
     ts.windowEndMs,


### PR DESCRIPTION
## Summary

Fixes #4166 — the Map Analysis **SNR overlay** could render a node's dot detached from its marker/trail, at a stale or wrong-source position, for nodes heard over **both LoRa and MQTT** with diverging positions.

This is the **same *theme*** as #4162/#4163 (an overlay disagreeing with the node markers) but a **different mechanism**: it's the #3642/#4042 family — an overlay resolving its *own* position instead of the canonical merged-node position — not the `hideFromMap` visibility gate fixed in #4167.

## Root cause

`src/components/MapAnalysis/layers/SnrOverlayLayer.tsx`:
- **"Last" mode** already resolved position via `resolveNodeLatLng()` on the merged unified record — matches the marker. ✅
- **Windowed mode** deduped raw per-fix records (`usePositions`) by `nodeNum`, keeping the single highest `timestamp` **across all sources, with no source priority**. That's a different dataset and a different winner than `mergeNodeRecords()` (`useDashboardData.ts`), which picks the "current" marker position by `lastHeard`. When a node's two sources disagree on position, the newest *position packet* need not belong to the source the marker uses → the dot detached and landed near the other source's trail endpoint (which `PositionTrailsLayer` groups per `sourceId:nodeNum`).

## Fix

The SNR dot now **always renders at the merged node's position** (`resolveNodeLatLng()` on the unified record — the exact coordinate `NodeMarkersLayer` and the trail endpoints use) in **both** modes. Windowed mode uses `positionItems` only to decide **which** nodes had an in-window fix (and the newest such timestamp, for the time-slider filter); the coordinate comes from the merged record. The dot can no longer detach from the marker.

### Adjacent gap closed
The SNR overlay never checked `hideFromMap` (the #4163 class, in a layer #4167 didn't touch). Hidden nodes have no marker, so they now produce **no SNR dot** in either mode.

## Behavior note
In windowed mode, dots are now pinned to each node's current merged position rather than its historical in-window fix. This is intentional and consistent with the overlay's existing design — the SNR *color* is already sourced from the current unified record (not per-fix), so the overlay was never a faithful historical replay; the time-slider still gates *which* nodes appear by their in-window fix timestamps.

## Testing
- New windowed **divergence** test: a node whose newest raw fix is at a different position than its merged record must render at the **merged** position, not the raw fix.
- New `hideFromMap` exclusion tests for both "Last" and windowed modes.
- Updated dot-count assertions.
- Full Vitest suite green (0 failures), `tsc --noEmit` clean, `npm run lint:ci` ratchet OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)