### PR TITLE
feat(map-analysis): mirror the Link Profile graph cursor onto the map

### DIFF
--- a/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
@@ -23,8 +23,24 @@ import type { LinkEndpoint } from '../../utils/linkProfile';
 import type { ElevationProfile } from '../../types/elevation';
 
 vi.mock('recharts', () => ({
-  ComposedChart: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="composed-chart">{children}</div>
+  ComposedChart: ({
+    children,
+    onMouseMove,
+    onMouseLeave,
+  }: {
+    children?: React.ReactNode;
+    onMouseMove?: (s: { activeTooltipIndex?: number; isTooltipActive?: boolean }) => void;
+    onMouseLeave?: () => void;
+  }) => (
+    <div data-testid="composed-chart">
+      {/* Test hooks to drive Recharts' hover callbacks with a synthetic state. */}
+      <button
+        data-testid="chart-hover-1"
+        onClick={() => onMouseMove?.({ activeTooltipIndex: 1, isTooltipActive: true })}
+      />
+      <button data-testid="chart-leave" onClick={() => onMouseLeave?.()} />
+      {children}
+    </div>
   ),
   Area: () => null,
   Line: () => null,
@@ -47,6 +63,7 @@ let mockLinkEndpoints: LinkEndpoint[] = [];
 let setLinkProfileModeSpy: ReturnType<typeof vi.fn>;
 let setLinkEndpointsSpy: ReturnType<typeof vi.fn>;
 let setLinkVerdictSpy: ReturnType<typeof vi.fn>;
+let setHoverPointSpy: ReturnType<typeof vi.fn>;
 vi.mock('./MapAnalysisContext', () => ({
   useMapAnalysisCtx: () => ({
     linkProfileMode: mockLinkProfileMode,
@@ -54,6 +71,8 @@ vi.mock('./MapAnalysisContext', () => ({
     setLinkProfileMode: setLinkProfileModeSpy,
     setLinkEndpoints: setLinkEndpointsSpy,
     setLinkVerdict: setLinkVerdictSpy,
+    hoverPoint: null,
+    setHoverPoint: setHoverPointSpy,
   }),
 }));
 
@@ -137,6 +156,7 @@ describe('LinkProfileDrawer', () => {
     setLinkProfileModeSpy = vi.fn();
     setLinkEndpointsSpy = vi.fn();
     setLinkVerdictSpy = vi.fn();
+    setHoverPointSpy = vi.fn();
     getElevationProfileMock.mockReset();
     mockAutoRadioDefaults = { freqMhz: null, rxSensitivityDbm: null, provenance: null };
   });
@@ -181,6 +201,20 @@ describe('LinkProfileDrawer', () => {
 
     const marginDd = screen.getByText('+31.2 dB');
     expect(marginDd.className).toContain('link-margin-positive');
+  });
+
+  it('sets the hover point from the sample under the graph cursor and clears on leave (#4111)', async () => {
+    mockLinkEndpoints = [endpointA, endpointB];
+    getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+    renderDrawer();
+    await screen.findByTestId('composed-chart'); // profile resolved, chart mounted
+
+    fireEvent.click(screen.getByTestId('chart-hover-1'));
+    // OBSTRUCTED_PROFILE.samples[1] = { lat: 0.15, lng: 0 }
+    expect(setHoverPointSpy).toHaveBeenCalledWith({ lat: 0.15, lng: 0 });
+
+    fireEvent.click(screen.getByTestId('chart-leave'));
+    expect(setHoverPointSpy).toHaveBeenCalledWith(null);
   });
 
   it('renders distance in miles when the user prefers miles', async () => {

--- a/src/components/MapAnalysis/LinkProfileDrawer.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.tsx
@@ -97,9 +97,13 @@ const ChartTooltip: React.FC<{
   );
 };
 
+/** The state object Recharts hands to `<ComposedChart onMouseMove>` — derived
+ *  from its own prop type so it can't drift from the installed Recharts version. */
+type ChartMouseState = Parameters<NonNullable<React.ComponentProps<typeof ComposedChart>['onMouseMove']>>[0];
+
 const LinkProfileDrawer: React.FC = () => {
   const { distanceUnit } = useSettings();
-  const { linkProfileMode, linkEndpoints, setLinkProfileMode, setLinkEndpoints, setLinkVerdict } =
+  const { linkProfileMode, linkEndpoints, setLinkProfileMode, setLinkEndpoints, setLinkVerdict, setHoverPoint } =
     useMapAnalysisCtx();
   const [endpointA, endpointB] = linkEndpoints;
 
@@ -107,7 +111,8 @@ const LinkProfileDrawer: React.FC = () => {
     setLinkProfileMode(false);
     setLinkEndpoints([]);
     setLinkVerdict(null);
-  }, [setLinkProfileMode, setLinkEndpoints, setLinkVerdict]);
+    setHoverPoint(null);
+  }, [setLinkProfileMode, setLinkEndpoints, setLinkVerdict, setHoverPoint]);
 
   // Local budget-input state, seeded from documented defaults. Edits
   // recompute the analysis client-side — they never trigger a refetch.
@@ -144,6 +149,26 @@ const LinkProfileDrawer: React.FC = () => {
   }, [pairKey, auto.rxSensitivityDbm, rxEdited]);
 
   const { data: profile, isLoading, error } = useElevationProfile(endpointA, endpointB);
+
+  // Sync the elevation-graph cursor to a marker on the map: each chart row is
+  // index-parallel with the fetched sample, which carries the exact lat/lng of
+  // that point along the link. On mousemove set the hovered sample's coordinate;
+  // clear it when the cursor leaves the plot. The mousemove state type is derived
+  // from Recharts' own onMouseMove prop so it always matches the chart's contract.
+  const handleChartMouseMove = useCallback(
+    (state: ChartMouseState) => {
+      // Recharts types activeTooltipIndex as string | number — coerce to an int.
+      const idx = Number(state?.activeTooltipIndex);
+      if (!profile || !state?.isTooltipActive || !Number.isInteger(idx) || idx < 0) {
+        setHoverPoint(null);
+        return;
+      }
+      const sample = profile.samples[idx];
+      setHoverPoint(sample ? { lat: sample.lat, lng: sample.lng } : null);
+    },
+    [profile, setHoverPoint]
+  );
+  const handleChartMouseLeave = useCallback(() => setHoverPoint(null), [setHoverPoint]);
 
   const analysis = useMemo(
     () =>
@@ -182,8 +207,11 @@ const LinkProfileDrawer: React.FC = () => {
   }, [analysis?.verdict, setLinkVerdict]);
 
   useEffect(() => {
-    return () => setLinkVerdict(null);
-  }, [setLinkVerdict]);
+    return () => {
+      setLinkVerdict(null);
+      setHoverPoint(null);
+    };
+  }, [setLinkVerdict, setHoverPoint]);
 
   const allTerrainNull = profile ? profile.samples.every(s => s.elevation === null) : false;
 
@@ -228,7 +256,12 @@ const LinkProfileDrawer: React.FC = () => {
           <div className="map-analysis-link-drawer-empty">No terrain data for this path.</div>
         ) : analysis ? (
           <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart data={analysis.points} margin={{ top: 10, right: 20, bottom: 5, left: 0 }}>
+            <ComposedChart
+              data={analysis.points}
+              margin={{ top: 10, right: 20, bottom: 5, left: 0 }}
+              onMouseMove={handleChartMouseMove}
+              onMouseLeave={handleChartMouseLeave}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#333" />
               <XAxis
                 dataKey="distanceKm"

--- a/src/components/MapAnalysis/LinkProfileHoverLayer.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileHoverLayer.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import LinkProfileHoverLayer from './LinkProfileHoverLayer';
+
+vi.mock('react-leaflet', () => ({
+  CircleMarker: ({ center }: { center: [number, number] }) => (
+    <div data-testid="hover-marker" data-lat={center[0]} data-lng={center[1]} />
+  ),
+}));
+
+let mockHoverPoint: { lat: number; lng: number } | null = null;
+vi.mock('./MapAnalysisContext', () => ({
+  useMapAnalysisCtx: () => ({ hoverPoint: mockHoverPoint }),
+}));
+
+describe('LinkProfileHoverLayer', () => {
+  it('renders nothing when there is no hover point', () => {
+    mockHoverPoint = null;
+    const { queryByTestId } = render(<LinkProfileHoverLayer />);
+    expect(queryByTestId('hover-marker')).toBeNull();
+  });
+
+  it('renders a marker at the current hover point', () => {
+    mockHoverPoint = { lat: 0.15, lng: -1.2 };
+    const { getByTestId } = render(<LinkProfileHoverLayer />);
+    const marker = getByTestId('hover-marker');
+    expect(marker.getAttribute('data-lat')).toBe('0.15');
+    expect(marker.getAttribute('data-lng')).toBe('-1.2');
+  });
+});

--- a/src/components/MapAnalysis/LinkProfileHoverLayer.tsx
+++ b/src/components/MapAnalysis/LinkProfileHoverLayer.tsx
@@ -1,0 +1,25 @@
+import { CircleMarker } from 'react-leaflet';
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+
+/**
+ * Ephemeral marker showing where the Link Profile elevation-graph cursor maps to
+ * on the terrain (#4111 follow-up). `hoverPoint` is set by {@link LinkProfileDrawer}
+ * on chart mousemove (from the hovered sample's lat/lng) and cleared on
+ * mouseleave / reset, so this renders only while the user is scrubbing the graph.
+ *
+ * Non-interactive so it never intercepts map clicks (e.g. endpoint picking), and
+ * mounted unconditionally by the Canvas — it simply renders nothing when there is
+ * no hover point, which keeps it working whether or not pick-mode is still active.
+ */
+export default function LinkProfileHoverLayer() {
+  const { hoverPoint } = useMapAnalysisCtx();
+  if (!hoverPoint) return null;
+  return (
+    <CircleMarker
+      center={[hoverPoint.lat, hoverPoint.lng]}
+      radius={7}
+      interactive={false}
+      pathOptions={{ color: '#ffffff', weight: 3, fillColor: '#2563eb', fillOpacity: 1 }}
+    />
+  );
+}

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -8,6 +8,7 @@ import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
 import LinkProfileController from './LinkProfileController';
 import LinkProfileDrawer from './LinkProfileDrawer';
+import LinkProfileHoverLayer from './LinkProfileHoverLayer';
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import { BaseMap } from '../map/BaseMap';
 import NodeMarkersLayer from './layers/NodeMarkersLayer';
@@ -151,6 +152,11 @@ export default function MapAnalysisCanvas() {
             paint over them, but above the data layers so the range rings read. */}
         <Pane name="polarGrid" style={{ zIndex: 550 }}>
           {config.layers.polarGrid.enabled && <PolarGridLayer />}
+        </Pane>
+        {/* Link Profile graph-hover marker — highest z so the cursor point reads
+            above every data layer. Renders only while hovering the graph. */}
+        <Pane name="linkProfileHover" style={{ zIndex: 700 }}>
+          <LinkProfileHoverLayer />
         </Pane>
       </BaseMap>
       <TimeSliderControl />

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -57,6 +57,15 @@ type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
    */
   linkVerdict: LinkVerdict | null;
   setLinkVerdict: (v: LinkVerdict | null) => void;
+  /**
+   * Geographic point under the cursor on the Link Profile elevation graph
+   * (#4111 follow-up). `LinkProfileDrawer` sets it on chart mousemove (from the
+   * hovered sample's lat/lng) and clears it on mouseleave / reset; the Canvas
+   * renders a marker there via `LinkProfileHoverLayer` so the graph cursor maps
+   * to a spot on the terrain.
+   */
+  hoverPoint: { lat: number; lng: number } | null;
+  setHoverPoint: (p: { lat: number; lng: number } | null) => void;
 };
 
 const Ctx = createContext<CtxShape | null>(null);
@@ -70,6 +79,7 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const [linkProfileMode, setLinkProfileMode] = useState(false);
   const [linkEndpoints, setLinkEndpoints] = useState<LinkEndpoint[]>([]);
   const [linkVerdict, setLinkVerdict] = useState<LinkVerdict | null>(null);
+  const [hoverPoint, setHoverPoint] = useState<{ lat: number; lng: number } | null>(null);
   return (
     <Ctx.Provider
       value={{
@@ -88,6 +98,8 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
         setLinkEndpoints,
         linkVerdict,
         setLinkVerdict,
+        hoverPoint,
+        setHoverPoint,
       }}
     >
       {children}


### PR DESCRIPTION
Follow-up to the Link Profile / terrain feature (epic #4111).

## What

Moving the mouse across the terrain/elevation **profile graph** now drops a marker on the **map** at the matching geographic point along the link — so it's immediately obvious where a given spot on the profile actually sits on the terrain.

## How

- **`MapAnalysisContext`** — new `hoverPoint: {lat,lng} | null`, added exactly like the existing `linkVerdict` cross-component field (the chart and map are siblings that already communicate only through this context).
- **`LinkProfileDrawer`** — wire `onMouseMove` / `onMouseLeave` on the Recharts `ComposedChart`. Each chart row is index-parallel with the fetched elevation sample, and `ElevationSample` **already carries `lat`/`lng`**, so we just read `profile.samples[activeTooltipIndex]` — **no interpolation**. Cleared on mouseleave, on close, and on unmount so no stale marker lingers. The mousemove state type is derived from Recharts' own `onMouseMove` prop (no `any`, no internal imports).
- **`LinkProfileHoverLayer`** (new) — a small, **non-interactive** `CircleMarker` mounted unconditionally in the canvas at the highest z-pane; renders only while `hoverPoint` is set, so it works whether or not endpoint pick-mode is still active and never intercepts map clicks.

## Tests
- Chart hover sets `hoverPoint` from the hovered sample's coordinate and clears it on leave.
- Hover layer renders a marker only when a point is set.
- Existing `LinkProfileDrawer` / `LinkProfileController` suites updated for the new context field.

Verified: 42 tests pass (`success=true`), `tsc` clean, `lint:ci` OK. Frontend-only, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1