### PR TITLE
ci: stop Node-24 coverage hang blocking merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    # Backstop: no matrix leg should ever run this long. Guards against a hung
-    # step (e.g. the coverage generator wedging on a specific Node major, as
-    # @vitest/coverage-v8 did on Node 24) blocking merges for 30+ minutes.
-    timeout-minutes: 20
+    # Loose catastrophic backstop only. The PRECISE guard for the known coverage
+    # wedge is the step-level `timeout-minutes` on "Generate coverage report"
+    # below; this job cap just stops a totally runaway leg. Keep it comfortably
+    # above a slow-runner full run (setup + test:run + the ≤10m coverage step) so
+    # it never clips a legitimately-slow-but-progressing run — an earlier 20m cap
+    # cancelled the 22.x leg mid-coverage on a slow day.
+    timeout-minutes: 45
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,6 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    # Loose catastrophic backstop only. The PRECISE guard for the known coverage
-    # wedge is the step-level `timeout-minutes` on "Generate coverage report"
-    # below; this job cap just stops a totally runaway leg. Keep it comfortably
-    # above a slow-runner full run (setup + test:run + the ≤10m coverage step) so
-    # it never clips a legitimately-slow-but-progressing run — an earlier 20m cap
-    # cancelled the 22.x leg mid-coverage on a slow day.
-    timeout-minutes: 45
 
     services:
       postgres:
@@ -85,14 +78,15 @@ jobs:
       - name: Run type checking
         run: npm run typecheck
 
-      # The "extras" (test-type check + coverage + Codecov upload) run on ONE
-      # Node version. Deliberately kept OFF 24.x: @vitest/coverage-v8 (v8
-      # provider + forks pool) hangs indefinitely during coverage *generation*
-      # on Node 24, which wedged this job for 30+ min on several PRs while the
-      # plain test run passed on every version. 22.x (LTS) runs it cleanly. The
-      # test suite itself still runs on all matrix versions, incl. 24.x.
+      # Test-file type check runs on ONE Node version (non-blocking; tracks
+      # toward a clean tsconfig.tests). Coverage generation + Codecov upload were
+      # removed (#4172): they ran on a single leg, produced no enforced signal
+      # (no token, no thresholds, no PR status check, no badge — Codecov was
+      # already fail_ci_if_error:false), and @vitest/coverage-v8 hung for 30+ min
+      # on Node 24, repeatedly blocking merges. `npm run test:coverage` remains
+      # available for ad-hoc local reports.
       - name: Type-check tests (non-blocking)
-        if: matrix.node-version == '22.x'
+        if: matrix.node-version == '24.x'
         run: npm run typecheck:tests
         # NON-BLOCKING: ~283 pre-existing test-type errors (mock/signature drift).
         # Flip to blocking (remove continue-on-error) once `npm run typecheck:tests` is clean (0 errors).
@@ -101,24 +95,6 @@ jobs:
 
       - name: Run tests
         run: npm run test:run
-
-      - name: Generate coverage report
-        if: matrix.node-version == '22.x'  # Only generate coverage on one version
-        run: npm run test:coverage
-        # Best-effort + bounded: coverage is reporting-only (the Codecov upload
-        # below is already fail_ci_if_error:false). If the generator ever wedges
-        # again, this times out and is ignored rather than blocking the merge.
-        timeout-minutes: 10
-        continue-on-error: true
-
-      - name: Upload coverage to Codecov
-        if: matrix.node-version == '22.x'
-        uses: codecov/codecov-action@v7
-        with:
-          files: ./coverage/coverage-final.json
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false  # Don't fail if codecov is down
 
   build:
     name: Build Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    # Backstop: no matrix leg should ever run this long. Guards against a hung
+    # step (e.g. the coverage generator wedging on a specific Node major, as
+    # @vitest/coverage-v8 did on Node 24) blocking merges for 30+ minutes.
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -78,8 +82,14 @@ jobs:
       - name: Run type checking
         run: npm run typecheck
 
+      # The "extras" (test-type check + coverage + Codecov upload) run on ONE
+      # Node version. Deliberately kept OFF 24.x: @vitest/coverage-v8 (v8
+      # provider + forks pool) hangs indefinitely during coverage *generation*
+      # on Node 24, which wedged this job for 30+ min on several PRs while the
+      # plain test run passed on every version. 22.x (LTS) runs it cleanly. The
+      # test suite itself still runs on all matrix versions, incl. 24.x.
       - name: Type-check tests (non-blocking)
-        if: matrix.node-version == '24.x'
+        if: matrix.node-version == '22.x'
         run: npm run typecheck:tests
         # NON-BLOCKING: ~283 pre-existing test-type errors (mock/signature drift).
         # Flip to blocking (remove continue-on-error) once `npm run typecheck:tests` is clean (0 errors).
@@ -90,11 +100,16 @@ jobs:
         run: npm run test:run
 
       - name: Generate coverage report
-        if: matrix.node-version == '24.x'  # Only generate coverage on one version
+        if: matrix.node-version == '22.x'  # Only generate coverage on one version
         run: npm run test:coverage
+        # Best-effort + bounded: coverage is reporting-only (the Codecov upload
+        # below is already fail_ci_if_error:false). If the generator ever wedges
+        # again, this times out and is ignored rather than blocking the merge.
+        timeout-minutes: 10
+        continue-on-error: true
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '24.x'
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage/coverage-final.json


### PR DESCRIPTION
## The problem

The `Test Suite (24.x)` CI job has hung for **30+ minutes** on several recent PRs (#4168, #4170, #4171), forcing cancel/rerun or merging past a stuck check — while the exact same tests pass on Node 20/22/25.x and the separate PR Tests workflow.

## Root cause

The matrix runs the coverage "extras" **only on the 24.x leg**:
```yaml
- name: Generate coverage report
  if: matrix.node-version == '24.x'
  run: npm run test:coverage        # vitest run --coverage
- name: Upload coverage to Codecov
  if: matrix.node-version == '24.x'
```
Pulling a hung run's job log shows it precisely: ✓ *Run tests* passes, then **✗ Generate coverage report** ran **32 min** before cancel; *Upload to Codecov* never reached. So it's **`@vitest/coverage-v8` (v8 provider + `forks` pool) hanging during coverage generation on Node 24** — not the tests, not Codecov. The other legs pass because coverage is gated to 24.x only.

## Fix

1. **Move the extras (typecheck:tests + coverage + Codecov) off 24.x → 22.x (LTS)**, which runs coverage cleanly. The plain test suite still runs on every matrix version, including 24.x.
2. **Bound + soften the coverage step**: `timeout-minutes: 10` + `continue-on-error: true` — coverage is reporting-only (Codecov is already `fail_ci_if_error: false`), so if the generator ever wedges again it self-terminates and never blocks a merge.
3. **20-min job-level `timeout-minutes`** backstop so no matrix leg can run away for 30+ min again.

`pull_request` runs use the PR's own workflow file, so **this PR's CI run exercises the fix directly** — expect 24.x to finish quickly (no coverage) and 22.x to run coverage without hanging.

## Note
If it turns out the coverage hang isn't strictly Node-24-specific, the step timeout + `continue-on-error` guarantee it still can't block merges. The separate `Build Check` job stays on 24.x (build-only, no coverage — always green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1