### PR TITLE
fix(map): drop heatmap/coverage density for deleted nodes (#4163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Elevation source settings** — a new admin-only **Elevation / Terrain** settings section enables/disables the Link Profile tool's terrain data and lets you point it at a custom DEM source (tile-template or Open-Topo-Data-compatible JSON API), with a Test button reporting the detected source type, sample elevation, and latency. Defaults to the public AWS Terrarium (SRTM-derived) tile set; all fetches happen server-side through the existing SSRF-guarded outbound path. (#4111)
 
 ### Fixed
+- **Map Analysis: heatmap/coverage overlay no longer shows density for deleted nodes** — position telemetry is not cascade-deleted when a node is removed, so bulk deletes that skip telemetry ("Clean up inactive nodes", "Prune Outside ROI") left orphaned lat/lon rows behind. The #4163 fix gated hidden-but-live nodes; it could not gate *deleted* nodes because their node record is gone. The heatmap and position-trail queries now drop any position whose owning node no longer exists (for every user, admins included) — a markerless position contributes no density — covering both existing orphaned rows and any future ones. (#4163)
 - **Map Analysis: implausible DEM elevation values no longer distort the Link Profile chart** — open-water/void artifacts in some elevation tile sources (observed as extreme negative spikes, e.g. −12000 m over Lake Pontchartrain) are now discarded server-side instead of blowing out the chart's vertical scale. (#4111)
 
 ## [4.13.0] - 2026-07-15

--- a/src/server/routes/analysisRoutes.test.ts
+++ b/src/server/routes/analysisRoutes.test.ts
@@ -227,6 +227,53 @@ describe('GET /positions', () => {
     expect(res.body.items).toHaveLength(1);
     expect(res.body.items[0].nodeNum).toBe(1);
   });
+
+  // #4163 follow-up — telemetry is not cascade-deleted with its node, so bulk
+  // deletes that skip telemetry ("Clean up inactive nodes", "Prune Outside
+  // ROI") leave orphaned position rows. They have no node record, hence no
+  // marker, so they must not appear as heatmap/trail density for any user.
+  it('admin: hides positions for nodes that no longer exist (orphaned telemetry)', async () => {
+    const live = { nodeNum: 1, sourceId: 'src-a', latitude: 1, longitude: 1, altitude: null, timestamp: 1000 };
+    const orphan = { nodeNum: 2, sourceId: 'src-a', latitude: 2, longitude: 2, altitude: null, timestamp: 1000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [live, orphan], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    // Only node 1 still exists; node 2 was deleted but its telemetry remains.
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+    ]);
+
+    const app = createApp(adminUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].nodeNum).toBe(1);
+  });
+
+  it('regular user: hides positions for nodes that no longer exist (orphaned telemetry)', async () => {
+    const live = { nodeNum: 1, sourceId: 'src-a', latitude: 1, longitude: 1, altitude: null, timestamp: 1000 };
+    const orphan = { nodeNum: 2, sourceId: 'src-a', latitude: 2, longitude: 2, altitude: null, timestamp: 1000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [live, orphan], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    // Only node 1 still exists. Channel 0 has viewOnMap granted, so if the
+    // orphan were defaulted onto channel 0 it would leak — assert it doesn't.
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+    ]);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({
+      channel_0: { viewOnMap: true, read: true, write: false },
+    });
+    mockDb.checkPermissionAsync.mockImplementation((_uid: number, resource: string) =>
+      Promise.resolve(resource !== 'nodes_private'),
+    );
+
+    const app = createApp(regularUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].nodeNum).toBe(1);
+  });
 });
 
 describe('GET /traceroutes', () => {
@@ -353,6 +400,22 @@ describe('GET /coverage-grid', () => {
     await request(app).get('/coverage-grid?since=7777&zoom=8');
     const call = mockDb.analysis.getCoverageGrid.mock.calls[0][0];
     expect(typeof call.postFilter).toBe('function');
+    expect(call.postFilter({ sourceId: 'src-a', nodeNum: 1 })).toBe(true);
+    expect(call.postFilter({ sourceId: 'src-a', nodeNum: 2 })).toBe(false);
+  });
+
+  // #4163 follow-up — the coverage grid must also exclude density from
+  // orphaned telemetry whose owning node was deleted/pruned.
+  it('admin: coverage-grid postFilter drops orphaned (deleted-node) positions', async () => {
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+    ]);
+    const app = createApp(adminUser);
+    // Unique cache key so this isn't served from a prior test's cache.
+    await request(app).get('/coverage-grid?since=6666&zoom=8');
+    const call = mockDb.analysis.getCoverageGrid.mock.calls[0][0];
+    expect(typeof call.postFilter).toBe('function');
+    // Node 1 still exists → kept; node 2 was deleted (not in getAllNodes) → dropped.
     expect(call.postFilter({ sourceId: 'src-a', nodeNum: 1 })).toBe(true);
     expect(call.postFilter({ sourceId: 'src-a', nodeNum: 2 })).toBe(false);
   });

--- a/src/server/routes/analysisRoutes.test.ts
+++ b/src/server/routes/analysisRoutes.test.ts
@@ -419,6 +419,30 @@ describe('GET /coverage-grid', () => {
     expect(call.postFilter({ sourceId: 'src-a', nodeNum: 1 })).toBe(true);
     expect(call.postFilter({ sourceId: 'src-a', nodeNum: 2 })).toBe(false);
   });
+
+  // #4163 follow-up — symmetry with the admin case: the non-admin coverage-grid
+  // postFilter must also drop orphaned density, even when the (would-be) channel
+  // is one the user can view on the map. Guards against the deleted node being
+  // defaulted onto channel 0 and slipping past the permission gate.
+  it('non-admin: coverage-grid postFilter drops orphaned (deleted-node) positions', async () => {
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0, hideFromMap: false },
+    ]);
+    // Channel 0 is viewable, so an orphan defaulted onto it would otherwise pass.
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({
+      channel_0: { viewOnMap: true, read: true, write: false },
+    });
+    mockDb.checkPermissionAsync.mockImplementation((_uid: number, resource: string) =>
+      Promise.resolve(resource !== 'nodes_private'),
+    );
+    const app = createApp(regularUser);
+    await request(app).get('/coverage-grid?since=5555&zoom=8');
+    const call = mockDb.analysis.getCoverageGrid.mock.calls[0][0];
+    expect(typeof call.postFilter).toBe('function');
+    // Node 1 exists on a viewable channel → kept; node 2 was deleted → dropped.
+    expect(call.postFilter({ sourceId: 'src-a', nodeNum: 1 })).toBe(true);
+    expect(call.postFilter({ sourceId: 'src-a', nodeNum: 2 })).toBe(false);
+  });
 });
 
 describe('GET /hop-counts', () => {

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -68,8 +68,15 @@ function parseSinceMs(raw: unknown): number {
 }
 
 /**
- * Build a synchronous position-row filter enforcing two kinds of gate:
+ * Build a synchronous position-row filter enforcing three kinds of gate:
  *
+ *  - live-node presence (#4163 follow-up): a DISPLAY gate applied to EVERYONE.
+ *    Position telemetry lives in the `telemetry` table and is NOT cascade-
+ *    deleted when a node is removed, so bulk deletes that don't purge telemetry
+ *    ("Clean up inactive nodes", "Prune Outside ROI") leave orphaned lat/lon
+ *    rows behind. Those rows have no node record — hence no marker on any map —
+ *    so they must not contribute heatmap/coverage density. A position whose
+ *    `(sourceId, nodeNum)` has no current node is dropped.
  *  - `hideFromMap` (#4162/#4163): a DISPLAY gate applied to EVERYONE, admins
  *    included. A node with "Hide from Map" set has no marker on any map
  *    surface (`useAnalysisNodes`/`embedPublicRoutes` drop it), so its
@@ -78,8 +85,9 @@ function parseSinceMs(raw: unknown): number {
  *  - per-channel `viewOnMap` + `positionOverrideIsPrivate`: PERMISSION gates
  *    applied only to non-admins.
  *
- * Returns null only when there is nothing to enforce (admin AND no node is
- * hidden), so the caller can skip filtering entirely.
+ * Always returns a predicate (never null): whether orphaned rows exist can't be
+ * known without inspecting each position, so filtering can't be skipped up
+ * front. The predicate is pure and cheap (one Map lookup per row).
  *
  * Pre-fetches all permissions and node metadata once so the returned predicate
  * is pure and cheap to call per item — avoids N async DB round-trips inside
@@ -88,7 +96,7 @@ function parseSinceMs(raw: unknown): number {
 async function buildPositionFilter(
   user: any,
   sourceIds: string[],
-): Promise<((pos: PositionRow) => boolean) | null> {
+): Promise<(pos: PositionRow) => boolean> {
   const isAdmin = !!user?.isAdmin;
   const userId: number | null = user?.id ?? null;
 
@@ -100,26 +108,26 @@ async function buildPositionFilter(
     string,
     { channel: number; positionOverrideIsPrivate: boolean; hideFromMap: boolean }
   >();
-  let anyHidden = false;
   for (const srcId of sourceIds) {
     const nodes = await databaseService.nodes.getAllNodes(srcId);
     for (const n of nodes) {
-      const hidden = !!n.hideFromMap;
-      if (hidden) anyHidden = true;
       nodeInfoByKey.set(`${srcId}:${n.nodeNum}`, {
         channel: n.channel ?? 0,
         positionOverrideIsPrivate: !!n.positionOverrideIsPrivate,
-        hideFromMap: hidden,
+        hideFromMap: !!n.hideFromMap,
       });
     }
   }
 
-  // Admins bypass the permission gates. When no node is hidden there is
-  // nothing left to enforce, so skip filtering entirely.
+  // Admins bypass the permission gates, but the display gates still apply: a
+  // position whose owning node is hidden (`hideFromMap`) or no longer exists
+  // (orphaned telemetry from a deleted/pruned node — #4163) has no marker, so
+  // it contributes no density.
   if (isAdmin) {
-    if (!anyHidden) return null;
-    return (pos: PositionRow): boolean =>
-      !nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`)?.hideFromMap;
+    return (pos: PositionRow): boolean => {
+      const info = nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`);
+      return !!info && !info.hideFromMap;
+    };
   }
 
   // Fetch channel permission sets once per source
@@ -140,8 +148,12 @@ async function buildPositionFilter(
     : false;
 
   return (pos: PositionRow): boolean => {
-    const info = nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`)
-      ?? { channel: 0, positionOverrideIsPrivate: false, hideFromMap: false };
+    const info = nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`);
+
+    // #4163: orphaned telemetry (owning node deleted/pruned) has no node record
+    // and therefore no marker, so it contributes no density. Drop it before the
+    // permission gates rather than defaulting it onto channel 0.
+    if (!info) return false;
 
     // #4162/#4163: hidden nodes have no marker, so contribute no density.
     if (info.hideFromMap) return false;
@@ -178,9 +190,7 @@ router.get('/positions', async (req: Request, res: Response) => {
     // Enforce per-channel viewOnMap and positionOverrideIsPrivate gates,
     // matching the checks the main map and v1/position-history already apply.
     const posFilter = await buildPositionFilter(user, sourceIds);
-    if (posFilter) {
-      result.items = result.items.filter(posFilter);
-    }
+    result.items = result.items.filter(posFilter);
 
     res.json(result);
   } catch (error) {
@@ -263,7 +273,7 @@ router.get('/coverage-grid', async (req: Request, res: Response) => {
       sourceIds,
       sinceMs,
       zoom,
-      postFilter: posFilter ?? undefined,
+      postFilter: posFilter,
     });
 
     if (isAdmin) {


### PR DESCRIPTION
## Summary

Follow-up to #4163. The original fix stopped the Map Analysis heatmap/coverage overlay from counting **hidden** nodes' historical positions, but explicitly left open the case of **deleted/purged** nodes whose telemetry was orphaned. This PR closes that gap.

## Root cause

Position telemetry lives in the `telemetry` table and is **not** cascade-deleted when a node is removed — migration 041 dropped the legacy `telemetry → nodes` FK, and it was never `ON DELETE CASCADE` anyway. The node-delete paths that go through `deleteNodeAsync` / `purgeAllNodesAsync` (manual delete, purge-all, auto-delete-by-distance, MQTT geo-sweep) purge telemetry explicitly, but the **bulk** paths do not:

- **"Clean up inactive nodes"** (`cleanupInactiveNodes`, `cleanupInactiveNodesForSourceAsync`, `deleteInactiveNodesForSourceSqlite`)
- **"Prune Outside ROI"** (`pruneNodesOutsideBbox`)

These delete only the `nodes` row, leaving orphaned lat/lon telemetry behind.

The #4163 fix gated positions in `buildPositionFilter` using node metadata from `getAllNodes()`. A **deleted** node has no entry there, so the gate couldn't catch it:
- Admin path: `!undefined?.hideFromMap` → `true` → row kept.
- Non-admin path: the row was defaulted onto channel 0 and kept if channel 0 was viewable.

Either way the orphaned position still contributed heatmap/coverage-grid density with **no corresponding marker** — matching the "some hotspots remain unexplained" observation in the issue.

## Fix

`buildPositionFilter` (`src/server/routes/analysisRoutes.ts`) now drops any position whose `(sourceId, nodeNum)` has no current node record, for **every user (admins included)**, across both `/positions` and `/coverage-grid`. A markerless position contributes no density — consistent with the #4162/#4163 display-gate principle. It therefore always returns a predicate instead of short-circuiting to `null`, since orphaned rows can't be detected without inspecting each position.

This is a **non-destructive read-time gate**, chosen over purging telemetry in each delete path because it:
- covers rows **already orphaned** in existing databases as well as any created in future,
- works across all three backends with **no migration**,
- lives in one well-tested location alongside the existing display gates.

Purging orphaned telemetry at delete time (storage hygiene) remains a reasonable separate follow-up.

## Tests

New regression cases in `src/server/routes/analysisRoutes.test.ts`:
- `admin: hides positions for nodes that no longer exist (orphaned telemetry)`
- `regular user: hides positions for nodes that no longer exist (orphaned telemetry)` — asserts the orphan isn't leaked via channel-0 default
- `admin: coverage-grid postFilter drops orphaned (deleted-node) positions`

Targeted suite green (25/25); `tsc --noEmit` clean; `lint:ci` ratchet OK. Full suite deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWT7xu4GM2qJuGHwUm7RKf)_