### PR TITLE
Add Meshview Link Responder to User Scripts Gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -686,5 +686,27 @@
       "Color-coded status (🟢 Good / 🟡 Fair / 🔴 Poor)",
       "No API key or external Python packages required"
     ]
+  },
+  {
+    "name": "Meshview Link Responder",
+    "filename": "meshview-link-responder.sh",
+    "icon": "🔗",
+    "description": "Listens for the !meshview trigger word anywhere in a message and replies via DM with a direct link to that message's packet detail page on your Meshview instance.",
+    "language": "Shell",
+    "tags": ["Meshview", "Example", "MQTT", "DM"],
+    "githubPath": "Yeraze/meshmonitor/examples/auto-responder-scripts/meshview-link-responder.sh",
+    "exampleTrigger": "{before:.+|^}!meshview{after:.+|$}",
+    "requirements": [
+      "POSIX shell (included in MeshMonitor)",
+      "A Meshview instance fed by your mesh's MQTT bridge (e.g. https://meshview.bayme.sh or self-hosted)",
+      "Edit MESHVIEW_BASE_URL in the script to point at your Meshview instance"
+    ],
+    "author": "madeofstown",
+    "features": [
+      "Matches the !meshview trigger anywhere in the message text",
+      "Always replies via DM (private: true), regardless of the triggering channel",
+      "Links straight to the triggering packet's detail page on Meshview",
+      "No external dependencies — POSIX shell only"
+    ]
   }
 ]

--- a/examples/auto-responder-scripts/meshview-link-responder.sh
+++ b/examples/auto-responder-scripts/meshview-link-responder.sh
@@ -13,16 +13,13 @@
 # Trigger: {before:.+|^}!meshview{after:.+|$}
 #
 # Environment variables available:
-# - MESSAGE: Full message text
-# - FROM_NODE: Sender node number
-# - NODE_ID: Destination node ID (e.g., !abcd1234) - for Geofence/AutoResponder3
 # - PACKET_ID: Message packet ID
 ####
 
 # =============================================================================
 # CONFIGURATION - Edit these variables for your Meshview instance
 # =============================================================================
-MESHVIEW_BASE_URL=https://meshview.bayme.sh # Base URL of your Meshview instance
+MESHVIEW_BASE_URL="https://meshview.bayme.sh" # Base URL of your Meshview instance
 # =============================================================================
 
 # Construct the MeshView link for the specific packet

--- a/examples/auto-responder-scripts/meshview-link-responder.sh
+++ b/examples/auto-responder-scripts/meshview-link-responder.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# mm_meta:
+#   name: Meshview Link Responder
+#   emoji: 🔗
+#   language: Shell
+####
+# Meshview Link Responder
+#
+# Looks for the trigger word - !meshview - and responds via DM with a
+# Meshview packet info link for the triggering message.
+# "Can somebody !meshview me?"
+#
+# Trigger: {before:.+|^}!meshview{after:.+|$}
+#
+# Environment variables available:
+# - MESSAGE: Full message text
+# - FROM_NODE: Sender node number
+# - NODE_ID: Destination node ID (e.g., !abcd1234) - for Geofence/AutoResponder3
+# - PACKET_ID: Message packet ID
+####
+
+# =============================================================================
+# CONFIGURATION - Edit these variables for your Meshview instance
+# =============================================================================
+MESHVIEW_BASE_URL=https://meshview.bayme.sh # Base URL of your Meshview instance
+# =============================================================================
+
+# Construct the MeshView link for the specific packet
+MESHVIEW_LINK="${MESHVIEW_BASE_URL}/packet/${PACKET_ID}"
+
+# Create JSON response
+cat <<EOF
+{
+  "response": "Here's your Meshview link: ${MESHVIEW_LINK}",
+  "private": true
+}
+EOF


### PR DESCRIPTION
## Summary
- Adds `examples/auto-responder-scripts/meshview-link-responder.sh`, a POSIX-shell Auto Responder script submitted by @madeofstown that replies via DM with a link to the triggering message's packet detail page on a Meshview instance whenever `!meshview` appears anywhere in the message.
- Adds a matching entry for it in `docs/.vitepress/data/user-scripts.json` (the User Scripts Gallery data source).
- Dropped the `Arguments: --dest {NODE_ID}` comment line from the original submission — it was carried over from the `remote-admin.sh` template and doesn't apply, since this script only reacts to trigger matches and doesn't consume CLI args.

## Review notes
- Trigger pattern `{before:.+|^}!meshview{after:.+|$}` was traced through `src/server/utils/autoResponderMatcher.ts`: it compiles to the anchored regex `^(.+|^)!meshview(.+|$)$`, which correctly matches `!meshview` anywhere in a message (start, middle, or end).
- `"private": true` DM forcing is implemented and honored in `src/server/meshtasticManager.ts` — this is the same mechanism a prior support issue (#2730, same author) asked about; it's confirmed working in the current codebase.
- No user-controlled message text is interpolated into the script's output — only `PACKET_ID`, a MeshMonitor-generated identifier — so there's no injection surface.
- `githubPath` follows the existing `Yeraze/meshmonitor/examples/auto-responder-scripts/<file>` convention used by other in-repo gallery scripts (e.g. `ham.py`, `PirateWeatherADV.py`).

## Test plan
- [x] `npx vitest run tests/unit/UserScriptsGallery.security.test.ts` — 52/52 passing (covers `githubPath` SSRF/path-traversal validation)
- [x] `sh -n examples/auto-responder-scripts/meshview-link-responder.sh` — syntax OK
- [x] `python3 -c "import json; json.load(open('docs/.vitepress/data/user-scripts.json'))"` — valid JSON
- [x] `npx vitepress build docs` — docs site builds cleanly with the new gallery entry

Closes #4178

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01V12b4QkhZpts35xQehgYFV)_