### PR TITLE
fix(traceroute): don't send on a DISABLED channel slot → NO_CHANNEL (#4173)

### DIFF
--- a/src/server/utils/resolveDestinationChannel.test.ts
+++ b/src/server/utils/resolveDestinationChannel.test.ts
@@ -156,4 +156,33 @@ describe('resolveBroadcastChannel', () => {
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(4);
   });
+
+  it('does NOT select a DISABLED slot even though its NULL psk looks mesh-readable (#4173)', async () => {
+    // Reporter's config: PRIMARY(0) uses a private key; slots 1–7 are DISABLED
+    // (role 0) with a NULL psk. A disabled slot has no key on the node, so
+    // encoding a traceroute on it NAKs NO_CHANNEL (6). The disabled NULL-psk
+    // slots must be skipped and we fall back to the enabled PRIMARY slot 0.
+    getAllChannels.mockResolvedValue([
+      { id: 0, psk: 'cHJpdmF0ZWtleQ==', role: 1 }, // PRIMARY, private key
+      { id: 1, psk: null, role: 0 },               // DISABLED
+      { id: 2, psk: null, role: 0 },               // DISABLED
+    ]);
+    expect(await resolveBroadcastChannel(manager, db)).toBe(0);
+  });
+
+  it('skips a DISABLED (null-psk) slot in favor of a lower-priority enabled default-keyed one', async () => {
+    getAllChannels.mockResolvedValue([
+      { id: 1, psk: null, role: 0 },   // DISABLED (null psk) — must be skipped
+      { id: 2, psk: 'AQ==', role: 2 }, // enabled SECONDARY on the default key
+    ]);
+    expect(await resolveBroadcastChannel(manager, db)).toBe(2);
+  });
+
+  it('selects an enabled default-keyed SECONDARY over a private PRIMARY', async () => {
+    getAllChannels.mockResolvedValue([
+      { id: 0, psk: 'cHJpdmF0ZQ==', role: 1 }, // PRIMARY, private
+      { id: 3, psk: 'AQ==', role: 2 },         // enabled default-key SECONDARY
+    ]);
+    expect(await resolveBroadcastChannel(manager, db)).toBe(3);
+  });
 });

--- a/src/server/utils/resolveDestinationChannel.ts
+++ b/src/server/utils/resolveDestinationChannel.ts
@@ -115,8 +115,16 @@ export async function resolveBroadcastChannel(
   db: typeof databaseService,
 ): Promise<number> {
   const channels = await db.channels.getAllChannels(manager.sourceId);
+  // A candidate must be an ENABLED slot. A DISABLED channel (role 0) has no key
+  // configured on the node, so the firmware refuses to encode a packet on that
+  // index and NAKs the sender NO_CHANNEL (6) — traceroute never leaves the node
+  // (issue #4173). Disabled slots are stored with a NULL psk, which would
+  // otherwise pass isMeshReadablePsk() below and, if lower-numbered than the
+  // primary, get selected (e.g. private-key PRIMARY at 0 + disabled slots 1–7).
+  // Among enabled slots we still prefer a mesh-readable (default-key/unencrypted)
+  // one so every intermediate node can decrypt & append the hop (issue #3696).
   const readable = channels
-    .filter((ch) => isValidChannelIndex(ch.id) && isMeshReadablePsk(ch.psk))
+    .filter((ch) => isValidChannelIndex(ch.id) && ch.role !== 0 && isMeshReadablePsk(ch.psk))
     .sort((a, b) => a.id - b.id);
 
   if (readable.length > 0) {
@@ -124,9 +132,9 @@ export async function resolveBroadcastChannel(
   }
 
   logger.warn(
-    `resolveBroadcastChannel: source ${manager.sourceId} has no default-keyed (mesh-readable) channel ` +
-      `among its ${channels.length} channel(s); falling back to channel 0. Traceroutes may show ` +
-      '"Unknown" hops because intermediate nodes cannot decrypt an encrypted-channel payload (issue #3696).',
+    `resolveBroadcastChannel: source ${manager.sourceId} has no ENABLED default-keyed (mesh-readable) ` +
+      `channel among its ${channels.length} channel(s); falling back to channel 0 (the PRIMARY slot, which ` +
+      'is always enabled). Traceroutes may show "Unknown" hops if the primary uses a private key (issue #3696).',
   );
   return 0;
 }


### PR DESCRIPTION
Fixes #4173.

## Symptom
Traceroute does nothing; the server logs a firmware NAK:
```
[WARN] 📮 Routing error from !75e9a15c: NO_CHANNEL (6), requestId: 2901994067
```

## Root cause
`NO_CHANNEL (6)` is **not** a "destination couldn't decrypt" error (that just times out silently). It's a **local, send-side encode failure**: the connected node refuses to encode a packet on a channel *index* whose slot is **DISABLED/unconfigured**, and NAKs the originator — which is why the warning carries our own traceroute's `requestId` and the local node's id.

`resolveBroadcastChannel` (`src/server/utils/resolveDestinationChannel.ts`) picks the lowest-indexed slot whose PSK is "mesh-readable" (default key `AQ==` or unencrypted) so intermediate hops can decrypt & append (issue #3696) — but it **never checked the slot's `role`**. A **DISABLED** slot (role 0) is stored with a **NULL psk**, and `isMeshReadablePsk(null)` returns true. So for a very common config — **PRIMARY(0) with a private key + disabled slots 1–7 (NULL psk)** — it returned **disabled slot 1**, and the node NAK'd `NO_CHANNEL`. The traceroute never left the node.

## Fix
Exclude DISABLED slots (`role !== 0`) from the candidate set. Channel 0 is always forced to PRIMARY (enabled), so the existing fall-back to `0` is guaranteed to be a valid enabled slot. For the reporter's config we now fall back to the **enabled private primary** (which encodes cleanly) instead of a disabled slot.

One-line change to the filter; the rest of the #3696 mesh-readable preference is unchanged.

## Tests
Added to `resolveDestinationChannel.test.ts`:
- The reporter's exact config (private PRIMARY + disabled null-psk slots) → returns `0`, not the disabled slot.
- A disabled null-psk slot is skipped in favor of an enabled default-keyed one.
- An enabled default-keyed SECONDARY is chosen over a private PRIMARY.

Verified: `resolveDestinationChannel` suite 20 pass; traceroute route/scheduler suites 44 pass; server `tsc` clean; `lint:ci` OK.

## Note (related, out of scope)
The auto-traceroute scheduler and auto-responder paths send on `targetNode.channel ?? 0` directly (not through `resolveBroadcastChannel`), so a bogus/disabled index from an MQTT-sourced node row could also NAK `NO_CHANNEL`. That's a separate latent path from the reported manual-traceroute bug — worth a follow-up to route those through a validated selection too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1