### PR TITLE
feat(map): honor "Discard invalid positions" on the render side (closes #4157)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -43,7 +43,8 @@ import {
 import { getSourceColor, resolveSourceColor } from '../../utils/sourceColors';
 import { getOwnNodePositions } from '../../utils/ownNodePositions';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
-import { isBogusPosition } from '../../utils/nullIsland';
+import { shouldDiscardPosition } from '../../utils/nullIsland';
+import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
 import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
@@ -100,7 +101,7 @@ function getNodeLatLng(node: any): { lat: number; lng: number } | null {
   const lat = node?.latitude ?? node?.position?.latitude;
   const lng = node?.longitude ?? node?.position?.longitude;
   // Skip "Null Island" (0,0) — uninitialized/stale GPS default (issue #3763).
-  if (lat != null && lng != null && !isBogusPosition(lat, lng)) {
+  if (lat != null && lng != null && !shouldDiscardPosition(lat, lng, undefined, getDiscardInvalidPositions())) {
     return { lat, lng };
   }
   return null;

--- a/src/components/MapAnalysis/nodePositionUtil.test.ts
+++ b/src/components/MapAnalysis/nodePositionUtil.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveNodeLatLng } from './nodePositionUtil';
+import { setDiscardInvalidPositionsDisplay } from '../../utils/positionDisplayConfig';
+
+describe('resolveNodeLatLng — Null Island display toggle (#4157)', () => {
+  // The module flag is process-global; restore the default (discard) after each.
+  afterEach(() => setDiscardInvalidPositionsDisplay(true));
+
+  it('drops Null Island (0,0) by default (discard setting on)', () => {
+    setDiscardInvalidPositionsDisplay(true);
+    expect(resolveNodeLatLng({ latitude: 0, longitude: 0 })).toBeNull();
+  });
+
+  it('RENDERS Null Island (0,0) when the discard setting is off', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    expect(resolveNodeLatLng({ latitude: 0, longitude: 0 })).toEqual([0, 0]);
+  });
+
+  it('always drops out-of-range junk, even with the setting off', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    expect(resolveNodeLatLng({ latitude: 1853.4, longitude: -1598.7 })).toBeNull();
+  });
+
+  it('always returns a real position regardless of the toggle', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    expect(resolveNodeLatLng({ latitude: 26.33, longitude: -80.27 })).toEqual([26.33, -80.27]);
+    setDiscardInvalidPositionsDisplay(true);
+    expect(resolveNodeLatLng({ latitude: 26.33, longitude: -80.27 })).toEqual([26.33, -80.27]);
+  });
+
+  it('still returns null for missing coordinates', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    expect(resolveNodeLatLng({ latitude: null, longitude: 0 })).toBeNull();
+    expect(resolveNodeLatLng({ position: { latitude: 0 } })).toBeNull();
+  });
+});

--- a/src/components/MapAnalysis/nodePositionUtil.ts
+++ b/src/components/MapAnalysis/nodePositionUtil.ts
@@ -1,4 +1,5 @@
-import { isBogusPosition } from '../../utils/nullIsland';
+import { shouldDiscardPosition } from '../../utils/nullIsland';
+import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 
 /**
  * Resolve a node's lat/lng from either the flat API shape (`{latitude, longitude}`)
@@ -22,6 +23,10 @@ export function resolveNodeLatLng(
   const lat = node.latitude ?? node.position?.latitude;
   const lng = node.longitude ?? node.position?.longitude;
   if (lat == null || lng == null) return null;
-  if (isBogusPosition(lat, lng)) return null;
+  // Null Island (0,0) is normally dropped (uninitialized/stale GPS default,
+  // #3763), but the global "Discard invalid positions" toggle can allow it so
+  // operators can spot misconfigured nodes (#4157). Out-of-range junk is always
+  // dropped regardless.
+  if (shouldDiscardPosition(lat, lng, undefined, getDiscardInvalidPositions())) return null;
   return [lat, lng];
 }

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -18,7 +18,8 @@ import { NeighborLinksLayer, type NeighborLinkDescriptor } from '../map/layers/N
 import PolarGridOverlay from '../PolarGridOverlay';
 import { useSource } from '../../contexts/SourceContext';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
-import { isBogusPosition } from '../../utils/nullIsland';
+import { shouldDiscardPosition } from '../../utils/nullIsland';
+import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 import { getPositionHistoryColor } from '../../utils/mapHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
@@ -240,7 +241,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
       // that would blow the map's fit-bounds out to nothing. The DB store
       // filters these too, but live in-memory contacts reaching the map via
       // getAllNodes() can still carry them.
-      && !isBogusPosition(c.latitude, c.longitude)),
+      && !shouldDiscardPosition(c.latitude, c.longitude, undefined, getDiscardInvalidPositions())),
     [contacts],
   );
 
@@ -386,7 +387,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             // real points to draw a segment (a 2-point response that's all
             // Null Island would otherwise store a degenerate 1-point trail).
             const pts = resp.data
-              .filter(p => !isBogusPosition(p.latitude, p.longitude))
+              .filter(p => !shouldDiscardPosition(p.latitude, p.longitude, undefined, getDiscardInvalidPositions()))
               .map(p => [p.latitude, p.longitude] as [number, number]);
             if (pts.length >= 2) next.set(publicKey, pts);
           }

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -11,6 +11,7 @@ import { type OverlayScheme, getSchemeForTileset, getOverlayColors, type Overlay
 import i18n from '../config/i18n';
 import { type TapbackEmoji, DEFAULT_TAPBACK_EMOJIS } from '../components/EmojiPickerModal/EmojiPickerModal';
 import { DEFAULT_TARGET_ZOOM } from '../utils/mapZoomAnimation';
+import { setDiscardInvalidPositionsDisplay } from '../utils/positionDisplayConfig';
 
 /** A per-channel mute rule. muteUntil = null means indefinite. */
 export interface MutedChannel {
@@ -918,8 +919,12 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     setLinkPreviewsEnabledState(enabled);
   };
 
-  // Discard-invalid-positions setter updates state only - persisted server-side
+  // Discard-invalid-positions setter updates state only - persisted server-side.
+  // Also sync the module mirror SYNCHRONOUSLY (#4157) so the map display filters
+  // (pure utils that can't read context) honor the toggle on the very next render
+  // — an effect would lag a frame, leaving (0,0) hidden until the next data poll.
   const setDiscardInvalidPositions = (enabled: boolean) => {
+    setDiscardInvalidPositionsDisplay(enabled);
     setDiscardInvalidPositionsState(enabled);
   };
 
@@ -1450,6 +1455,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
           // (enabled = discard); only an explicit '0'/'false' turns it off.
           if (settings.discardInvalidPositions !== undefined) {
             const enabled = !(settings.discardInvalidPositions === '0' || settings.discardInvalidPositions === 'false');
+            setDiscardInvalidPositionsDisplay(enabled); // keep the display-filter mirror in sync (#4157)
             setDiscardInvalidPositionsState(enabled);
           }
 

--- a/src/hooks/useDashboardData.test.ts
+++ b/src/hooks/useDashboardData.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement } from 'react';
+import { setDiscardInvalidPositionsDisplay } from '../utils/positionDisplayConfig';
 import {
   useDashboardSources,
   useDashboardSourceData,
@@ -278,6 +279,46 @@ describe('mergeUnifiedSourceData', () => {
     expect(n.longitude).toBe(-80.1374208);
     expect(n.positionPrecisionBits).toBe(13); // precision from the same real record, not the garbage one
     expect(n.lastHeard).toBe(5000);
+  });
+
+  it('leaves a Null-Island-only node positionless when the discard toggle is ON (#4157)', () => {
+    setDiscardInvalidPositionsDisplay(true); // default
+    const merged = mergeUnifiedSourceData([
+      { nodes: [{ nodeNum: 500, lastHeard: 2000, latitude: 0, longitude: 0 }], traceroutes: [], neighborInfo: [], channels: [] },
+      { nodes: [{ nodeNum: 500, lastHeard: 1000, latitude: 0, longitude: 0 }], traceroutes: [], neighborInfo: [], channels: [] },
+    ]);
+    const n = merged.nodes[0] as any;
+    expect(n.latitude).toBeUndefined();
+    expect(n.longitude).toBeUndefined();
+  });
+
+  it('surfaces a Null-Island-only node at (0,0) when the discard toggle is OFF (#4157)', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    try {
+      const merged = mergeUnifiedSourceData([
+        { nodes: [{ nodeNum: 501, lastHeard: 2000, latitude: 0, longitude: 0 }], traceroutes: [], neighborInfo: [], channels: [] },
+      ]);
+      const n = merged.nodes[0] as any;
+      expect(n.latitude).toBe(0);
+      expect(n.longitude).toBe(0);
+    } finally {
+      setDiscardInvalidPositionsDisplay(true);
+    }
+  });
+
+  it('still prefers a real fix over a Null-Island fix even with the toggle OFF (#4157)', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    try {
+      const merged = mergeUnifiedSourceData([
+        { nodes: [{ nodeNum: 502, lastHeard: 2000, latitude: 0, longitude: 0 }], traceroutes: [], neighborInfo: [], channels: [] },       // newest, Null Island
+        { nodes: [{ nodeNum: 502, lastHeard: 1000, latitude: 35.0, longitude: -80.0 }], traceroutes: [], neighborInfo: [], channels: [] }, // older, real fix
+      ]);
+      const n = merged.nodes[0] as any;
+      expect(n.latitude).toBe(35.0); // real fix wins despite the (0,0) record being newer
+      expect(n.longitude).toBe(-80.0);
+    } finally {
+      setDiscardInvalidPositionsDisplay(true);
+    }
   });
 
   it('only marks merged node as ignored when EVERY source has it ignored', () => {

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -8,7 +8,8 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { appBasename } from '../init';
 import { useAuth } from '../contexts/AuthContext';
-import { isBogusPosition } from '../utils/nullIsland';
+import { isBogusPosition, shouldDiscardPosition } from '../utils/nullIsland';
+import { getDiscardInvalidPositions } from '../utils/positionDisplayConfig';
 import { classifyNodeTransport, type NodeTransportClass } from '../utils/nodeTransport';
 import { unifiedNodeKey } from '../utils/nodeIdentity';
 import type { SourceRadioSummary } from '../types/elevation';
@@ -298,11 +299,23 @@ function mergeNodeRecords(records: any[]): any {
   // sources have the true position). Flat (API) and nested position shapes are
   // both supported; lat/lng/nested-position/precision are carried from the SAME
   // record so the marker and its accuracy cell stay consistent.
-  const withPosition = sortedNewestFirst.find((r) => {
-    const lat = r?.latitude ?? r?.position?.latitude;
-    const lng = r?.longitude ?? r?.position?.longitude;
-    return lat != null && lng != null && !isBogusPosition(lat, lng);
-  });
+  const withPosition =
+    sortedNewestFirst.find((r) => {
+      const lat = r?.latitude ?? r?.position?.latitude;
+      const lng = r?.longitude ?? r?.position?.longitude;
+      return lat != null && lng != null && !isBogusPosition(lat, lng);
+    }) ??
+    // #4157: with the "Discard invalid positions" toggle OFF, a real fix above
+    // still wins, but fall back to a Null-Island (0,0) fix when that's ALL any
+    // source reported — so a node that only ever reports (0,0) is visible on the
+    // map instead of positionless. Out-of-range / NaN junk is still rejected.
+    (getDiscardInvalidPositions()
+      ? undefined
+      : sortedNewestFirst.find((r) => {
+          const lat = r?.latitude ?? r?.position?.latitude;
+          const lng = r?.longitude ?? r?.position?.longitude;
+          return lat != null && lng != null && !shouldDiscardPosition(lat, lng, undefined, false);
+        }));
   if (withPosition) {
     if (withPosition.latitude != null) merged.latitude = withPosition.latitude;
     if (withPosition.longitude != null) merged.longitude = withPosition.longitude;

--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, hasValidEffectivePosition, isNodeComplete, resolveMapEndpoint } from './nodeHelpers';
+import { setDiscardInvalidPositionsDisplay } from './positionDisplayConfig';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
 import type { DeviceInfo } from '../types/device';
 
@@ -31,6 +32,16 @@ describe('resolveMapEndpoint (#3642)', () => {
     // But the rendered marker still wins even if the record embeds garbage.
     const onMap = new Map<number, [number, number]>([[0x02ecd5e0, [26.9221888, -80.1374208]]]);
     expect(resolveMapEndpoint(onMap, 0x02ecd5e0, 0.0032768, 0.0032768)).toEqual([26.9221888, -80.1374208]);
+  });
+
+  it('DOES fall back to a Null-Island embedded position when the discard setting is off (#4157)', () => {
+    setDiscardInvalidPositionsDisplay(false);
+    try {
+      const markers = new Map<number, [number, number]>();
+      expect(resolveMapEndpoint(markers, 0x02ecd5e0, 0.0032768, 0.0032768)).toEqual([0.0032768, 0.0032768]);
+    } finally {
+      setDiscardInvalidPositionsDisplay(true); // restore default
+    }
   });
 });
 

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -1,6 +1,7 @@
 import { DeviceInfo } from '../types/device';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
-import { isBogusPosition } from './nullIsland.js';
+import { shouldDiscardPosition } from './nullIsland.js';
+import { getDiscardInvalidPositions } from './positionDisplayConfig.js';
 
 /**
  * Infrastructure node roles (Router, Router Client, Repeater, Router Late)
@@ -132,7 +133,7 @@ export const resolveMapEndpoint = (
   // garbage default (e.g. the 2^15 value 0.0032768) — that would draw a
   // neighbor/route line out to (0, 0) for a node not currently on the map
   // (#02ecd5e0 "Jupiter Dad"). Skip it so the caller omits the line instead.
-  if (embeddedLat != null && embeddedLng != null && !isBogusPosition(embeddedLat, embeddedLng)) {
+  if (embeddedLat != null && embeddedLng != null && !shouldDiscardPosition(embeddedLat, embeddedLng, undefined, getDiscardInvalidPositions())) {
     return [embeddedLat, embeddedLng];
   }
   return null;

--- a/src/utils/positionDisplayConfig.ts
+++ b/src/utils/positionDisplayConfig.ts
@@ -1,0 +1,28 @@
+/**
+ * Browser-side mirror of the global `discardInvalidPositions` Map setting, used
+ * by the map DISPLAY filters (issue #4157 — the render half of the #4158 toggle).
+ *
+ * The setting is global and changes rarely, but the Null Island filter runs in
+ * many render paths and in pure position utils (`resolveNodeLatLng` has 7
+ * callers; `mergeNodeRecords`/`getNodeLatLng` are plain functions) that can't
+ * read React context. Threading the flag through every signature would be very
+ * invasive, so — mirroring the server's `positionIngestConfig` — SettingsContext
+ * keeps this module in sync (synchronously in its setter + on server load) and
+ * each display site reads it via {@link getDiscardInvalidPositions}.
+ *
+ * Default `true` = discard (the historical behavior). When the user turns the
+ * setting off, Null Island (0,0) markers RENDER instead of being hidden, so
+ * RF-only operators can spot misconfigured/spoofed nodes. Out-of-range / NaN
+ * junk is still hidden regardless (see `shouldDiscardPosition`).
+ */
+let discardInvalidPositions = true;
+
+/** Current value of the display-side Null Island discard toggle. */
+export function getDiscardInvalidPositions(): boolean {
+  return discardInvalidPositions;
+}
+
+/** Sync the cached toggle (called by SettingsContext on set + server load). */
+export function setDiscardInvalidPositionsDisplay(enabled: boolean): void {
+  discardInvalidPositions = enabled;
+}


### PR DESCRIPTION
Closes #4157.

## Background
#4158 added the **"Discard invalid positions"** Map setting and wired it into the **ingest** side (when off, `(0,0)` fixes are stored). But the map **display filters still called `isBogusPosition()` unconditionally** — so with the setting off, `(0,0)` positions were *persisted yet still hidden on every map*. That defeats the exact use case #4157 is about: RF-only operators who want to **see** stray `(0,0)` markers to catch misconfigured/spoofed nodes. So the issue couldn't be closed on #4158 alone.

## Change — wire the render side to the toggle
- **`src/utils/positionDisplayConfig.ts`** (new): a browser-side mirror of the setting (mirrors the server's `positionIngestConfig`). `SettingsContext` syncs it **synchronously** in its setter and on server-load, so the pure position utils — which can't read React context — honor the toggle on the very next render with no frame lag.
- Every display filter now uses `shouldDiscardPosition(lat, lng, undefined, getDiscardInvalidPositions())` instead of `isBogusPosition()`:
  - `resolveNodeLatLng` (Map Analysis — 7 callers)
  - `DashboardMap.getNodeLatLng`
  - `nodeHelpers.resolveMapEndpoint`
  - `MeshCoreMap` (marker + trail filters)
  - the unified `mergeNodeRecords`
- **Default behavior is identical**: with the toggle on, `shouldDiscardPosition(…true) ≡ isBogusPosition`. Out-of-range / NaN junk is **always** hidden regardless of the toggle.
- **Merge precedence preserved**: `mergeNodeRecords` still prefers a real fix and only falls back to a `(0,0)` fix (when the toggle is off) if that's *all* any source reported — so a node that only ever reports `(0,0)` becomes visible without letting `(0,0)` override a genuine position.

## Tests
- `resolveNodeLatLng` and `resolveMapEndpoint`: `(0,0)` hidden by default, rendered when the toggle is off, out-of-range always hidden, real positions unaffected.
- All existing map/data suites pass unchanged (187 across the affected files) — default behavior preserved. `tsc` clean, `lint:ci` OK.

Frontend-only, no migration. Together with #4158 this fully delivers #4157: one global toggle that controls both whether Null-Island fixes are **stored** and whether they're **rendered**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1