### PR TITLE
fix(map): keep router short-name visible in Official pin style (closes #4154)

### DIFF
--- a/src/components/map/markerIcons.test.ts
+++ b/src/components/map/markerIcons.test.ts
@@ -327,3 +327,95 @@ describe('createNodeIcon — Meshtastic ROUTER_LATE renders as repeater tower (#
     expect(iconHtml('mtRouter', true)).toBe(iconHtml('mtRouterLate', false));
   });
 });
+
+describe('createNodeIcon — official pinStyle keeps the short-name visible for infra roles (#4154)', () => {
+  it('ROUTER short name is NOT suppressed by the role glyph in official style', () => {
+    const icon = createNodeIcon({
+      hops: 1,
+      shortName: 'RTR1',
+      roleCategory: 'mtRouter',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+
+    // The pre-#4154 bug: roleInner truthy meant the <text> short-name node
+    // never rendered at all for ROUTER/ROUTER_LATE in official style.
+    expect(icon.html).toContain('RTR1');
+    expect(icon.html).toContain('<text');
+  });
+
+  it('ROUTER_LATE short name is NOT suppressed by the role glyph in official style', () => {
+    const icon = createNodeIcon({
+      hops: 1,
+      shortName: 'RTL2',
+      roleCategory: 'mtRouterLate',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+
+    expect(icon.html).toContain('RTL2');
+    expect(icon.html).toContain('<text');
+  });
+
+  it('infra roles still get a distinguishing corner badge carrying the role glyph', () => {
+    const icon = createNodeIcon({
+      hops: 1,
+      shortName: 'RTR1',
+      roleCategory: 'mtRouter',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+    const plain = createNodeIcon({
+      hops: 1,
+      shortName: 'RTR1',
+      roleCategory: 'standard',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+
+    // Badge is present for the infra role and absent for a standard node —
+    // the badge is how official style now differentiates infra without
+    // hiding the short name.
+    expect(icon.html).not.toEqual(plain.html);
+    // The badge wrapper is absolutely positioned in the bottom-right corner.
+    expect(icon.html).toContain('bottom: -2px');
+    expect(icon.html).toContain('right: -2px');
+    expect(plain.html).not.toContain('bottom: -2px');
+  });
+
+  it('MeshCore role glyphs (issue #3546) also keep the short name visible in official style', () => {
+    const icon = createNodeIcon({
+      hops: 1,
+      shortName: 'SNS1',
+      roleCategory: 'sensor',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+
+    expect(icon.html).toContain('SNS1');
+    expect(icon.html).toContain('<text');
+    // Still gets the differentiating corner badge.
+    expect(icon.html).toContain('bottom: -2px');
+  });
+
+  it('emoji short names still render via the emoji overlay (no <text>), unaffected by role', () => {
+    const icon = createNodeIcon({
+      hops: 1,
+      shortName: '🛰️',
+      roleCategory: 'mtRouter',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+
+    expect(icon.html).toContain('🛰️');
+    // Emoji path never used <text>; it overlays a plain div instead.
+    expect(icon.html).not.toContain('<text');
+    // Badge still shows for the infra role.
+    expect(icon.html).toContain('bottom: -2px');
+  });
+
+  it('standard-role nodes are unaffected: no badge markup at all', () => {
+    const icon = createNodeIcon({
+      hops: 1,
+      shortName: 'PLAIN',
+      pinStyle: 'official',
+    }) as unknown as FixtureDivIconOptions;
+
+    expect(icon.html).toContain('PLAIN');
+    expect(icon.html).not.toContain('bottom: -2px');
+  });
+});

--- a/src/components/map/markerIcons.ts
+++ b/src/components/map/markerIcons.ts
@@ -229,14 +229,14 @@ export function createNodeIcon(options: CreateNodeIconOptions): L.DivIcon {
     const circleSize = size;
     const emojiName = shortName && isEmoji(shortName);
 
-    // A role glyph replaces the short-name text so MeshCore node types stay
-    // distinguishable in the official circle style too (issue #3546).
-    const markerSvg = roleInner ? `
-      <svg width="${circleSize}" height="${circleSize}" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="24" cy="24" r="20" fill="white" fill-opacity="0.95" stroke="${color}" stroke-width="${strokeWidth}" />
-        ${roleInner}
-      </svg>
-    ` : emojiName ? `
+    // Issue #4154: the always-visible short-name text is the entire point of
+    // this pin style, so it must render for every role — a role glyph must
+    // NOT swap it out (that was the pre-#4154 behavior, and it hid
+    // ROUTER/ROUTER_LATE short names behind the repeater-tower glyph).
+    // Infrastructure roles are instead differentiated with a small corner
+    // badge (below), layered on top the same way emojiOverlay layers over
+    // the base circle.
+    const markerSvg = emojiName ? `
       <svg width="${circleSize}" height="${circleSize}" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
         <circle cx="24" cy="24" r="20" fill="white" fill-opacity="0.95" stroke="${color}" stroke-width="${strokeWidth}" />
       </svg>
@@ -247,7 +247,7 @@ export function createNodeIcon(options: CreateNodeIconOptions): L.DivIcon {
       </svg>
     `;
 
-    const emojiOverlay = emojiName && !roleInner ? `
+    const emojiOverlay = emojiName ? `
       <div style="
         position: absolute;
         top: 0;
@@ -263,6 +263,25 @@ export function createNodeIcon(options: CreateNodeIconOptions): L.DivIcon {
       ">${shortName}</div>
     ` : '';
 
+    // Small corner badge carrying the role glyph (router tower, sensor,
+    // room-server, companion) so infrastructure nodes stay visually
+    // distinguishable without ever hiding the short-name text (issue #4154,
+    // follow-up to #3546). Reuses roleGlyphMarkerSvg — the same
+    // glyph-over-white-circle drawing already used for MeshCore markers and
+    // legend swatches — scaled down and pinned to the bottom-right corner.
+    const roleBadgeSize = Math.round(circleSize * 0.42);
+    const roleBadge = roleInner && roleCategory ? `
+      <div style="
+        position: absolute;
+        bottom: -2px;
+        right: -2px;
+        width: ${roleBadgeSize}px;
+        height: ${roleBadgeSize}px;
+        filter: drop-shadow(0 1px 2px rgba(0,0,0,0.4));
+        pointer-events: none;
+      ">${roleGlyphMarkerSvg(roleCategory, color, roleBadgeSize)}</div>
+    ` : '';
+
     const classes = [
       animate ? 'node-icon-pulse' : '',
       highlightSelected ? 'node-icon-highlight' : ''
@@ -272,6 +291,7 @@ export function createNodeIcon(options: CreateNodeIconOptions): L.DivIcon {
       <div class="${classes}" style="position: relative; width: ${circleSize}px; height: ${circleSize}px;">
         ${markerSvg}
         ${emojiOverlay}
+        ${roleBadge}
       </div>
     `;
 


### PR DESCRIPTION
## Summary

In `pinStyle: 'official'` — the "Official Meshtastic" circle style whose entire point is an always-visible short-name label — ROUTER / ROUTER_LATE nodes rendered the repeater-tower role glyph **instead of** their short name, so a router's short name was never visible in that mode. The same suppression applied to MeshCore role-glyph nodes (repeater / room server / sensor / companion).

Root cause: the `official` branch of `createNodeIcon()` (`src/components/map/markerIcons.ts`) swapped the `<text>` short-name element out whenever `roleInner` was truthy. ROUTER/ROUTER_LATE always map to the non-standard `'repeater'` category (`nodeTypeCategory.ts`), so the glyph unconditionally won. This predates #4076 (originally added for MeshCore glyphs in #3546); #4076 made `roleCategory` compute unconditionally, exposing the side effect for Meshtastic routers.

## How infrastructure is now differentiated

The official-style circle **always** renders the short-name text (or the emoji overlay for emoji names). Infrastructure roles get a small **bottom-right corner badge** instead of a replacement glyph: a ~42%-scale `roleGlyphMarkerSvg` — the exact same glyph-over-white-circle drawing already used by MeshCore map markers and legend swatches — absolutely positioned over the base circle, following the existing `emojiOverlay` layering pattern. So a router in official style now shows its hop-colored circle with the short name in the middle and a small tower-glyph badge at the bottom-right corner.

- Standard-role nodes: unchanged rendering (no badge markup).
- MeshCore role glyphs (#3546): still present in every style they appeared in — the `meshmonitor` pin style and the `meshcore` variant are untouched; in official style the glyph moves to the corner badge so the short name shows for those roles too.
- Emoji short names: still rendered via the overlay div (never `<text>`), with the badge layered on top for infra roles.
- Only the `official` branch of `createNodeIcon()` changed; the default `meshmonitor` pin style and the `meshcore` variant are byte-identical.

## Tests

New `describe` block in `src/components/map/markerIcons.test.ts` (6 cases):
- official + `mtRouter` / `mtRouterLate` ⇒ icon HTML contains the short-name `<text>` (the regression case)
- infra roles carry the corner-badge markup; standard roles carry none
- MeshCore `sensor` role keeps its short name and gets the badge
- emoji short names keep the overlay path (no `<text>`) with the badge present

## Verification

- Full Vitest suite: `success=true`, 9570 passed, 0 failed, 0 suites failed (JSON reporter)
- `npx tsc --noEmit`: no errors
- `npm run lint:ci`: Lint ratchet OK (exit 0)

Closes #4154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1