### PR TITLE
feat(automation): remote-admin reboot target for device-reboot action (closes #4126)

### DIFF
--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -392,6 +392,7 @@ export const ACTIONS: BlockDef[] = [
     description: 'Reboot the physical device — e.g. reinitialize a flaky BLE bridge or MQTT proxy on a daily schedule.',
     fields: [
       { name: 'sourceIds', label: 'Reboot which node(s)', kind: 'sendSourceMulti', help: 'The connected node(s) to reboot. Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like Schedules and System events. (MQTT sources have no physical device and are excluded.)' },
+      { name: 'targetNodeNum', label: 'Remote target node #', kind: 'number', advanced: true, placeholder: 'blank = locally-connected node', help: 'Meshtastic remote-admin reboot: leave blank to reboot the locally-connected node; set a node number to reboot a remote node over the mesh (uses the session-passkey admin mechanism — the target must have granted admin access). Ignored by MeshCore.' },
       { name: 'seconds', label: 'Reboot delay (seconds)', kind: 'number', advanced: true, placeholder: '10', help: 'Meshtastic: how long the device waits before rebooting (default 10s). Ignored by MeshCore.' },
     ],
   },

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -408,6 +408,35 @@ describe('executeAction', () => {
     expect(calls[1].args).toEqual({ sourceId: 'default', seconds: undefined });
   });
 
+  it('deviceReboot: forwards a remote targetNodeNum to rebootDevice (#4126)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.deviceReboot', { seconds: 15, targetNodeNum: 123456789 }),
+      ctx({ from: 1 }, 'default'),
+      deps,
+    );
+    expect(calls).toEqual([
+      { fn: 'rebootDevice', args: { sourceId: 'default', seconds: 15, targetNodeNum: 123456789 } },
+    ]);
+  });
+
+  it('deviceReboot: no targetNodeNum ⇒ local-only reboot (targetNodeNum undefined)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(node('action.deviceReboot', { seconds: 20 }), ctx({ from: 1 }, 'default'), deps);
+    expect(calls[0].args.targetNodeNum).toBeUndefined();
+    expect(calls[0].args).toMatchObject({ sourceId: 'default', seconds: 20 });
+  });
+
+  it('deviceReboot: ignores a blank/invalid targetNodeNum (falls back to local)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(node('action.deviceReboot', { targetNodeNum: '' }), ctx({ from: 1 }, 'default'), deps);
+    await executeAction(node('action.deviceReboot', { targetNodeNum: 0 }), ctx({ from: 1 }, 'default'), deps);
+    await executeAction(node('action.deviceReboot', { targetNodeNum: 'nope' }), ctx({ from: 1 }, 'default'), deps);
+    expect(calls[0].args.targetNodeNum).toBeUndefined();
+    expect(calls[1].args.targetNodeNum).toBeUndefined();
+    expect(calls[2].args.targetNodeNum).toBeUndefined();
+  });
+
   // ── requestData (#3835) ────────────────────────────────────────────────────
   it('requestData: telemetry passes op/target/channel/telemetryType (the #3835 case)', async () => {
     const { calls, deps } = recorder();

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -437,6 +437,38 @@ describe('executeAction', () => {
     expect(calls[2].args.targetNodeNum).toBeUndefined();
   });
 
+  it('deviceReboot: mixed-source select + targetNodeNum skips MeshCore sources instead of failing the action', async () => {
+    const { calls, deps } = recorder();
+    // A remote-admin target rides Meshtastic's session-passkey mechanism, which
+    // MeshCore lacks. In a mixed multi-select the MeshCore source must be a
+    // recorded no-op (like tapback/nodeManage) — NOT a hard failure that starves
+    // the remaining Meshtastic sources of their reboot.
+    const mixedCtx: EngineEvalContext = {
+      trigger: { triggerType: 'trigger.schedule', sourceId: null, timestamp: 1000, fields: {} },
+      vars: { getValue: async () => null } as unknown as VariableResolver,
+      data: {
+        getNode: async () => null,
+        getTelemetry: async () => null,
+        getSourceProtocol: async (sid: string) => (sid === 'mc' ? 'meshcore' : 'meshtastic'),
+      },
+      varCtx: { sourceId: null, nodeNum: undefined },
+      now: 1000,
+    };
+    const result = await executeAction(
+      node('action.deviceReboot', { sourceIds: ['radioA', 'mc'], targetNodeNum: 42 }),
+      mixedCtx,
+      deps,
+    );
+    // Only the Meshtastic source reached the deps; the MeshCore entry is a skip record.
+    expect(calls).toEqual([
+      { fn: 'rebootDevice', args: { sourceId: 'radioA', seconds: undefined, targetNodeNum: 42 } },
+    ]);
+    expect(result).toEqual([
+      6, // recorder's rebootDevice return for the Meshtastic source
+      { skipped: true, reason: 'remote-admin reboot is not supported on MeshCore' },
+    ]);
+  });
+
   // ── requestData (#3835) ────────────────────────────────────────────────────
   it('requestData: telemetry passes op/target/channel/telemetryType (the #3835 case)', async () => {
     const { calls, deps } = recorder();

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -401,6 +401,14 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
         : [sourceId];
       const results: unknown[] = [];
       for (const sid of sourceIds) {
+        // A remote-admin target rides the Meshtastic session-passkey mechanism,
+        // which MeshCore sources don't have. In a mixed multi-source select,
+        // skip those as a recorded no-op (matching tapback/nodeManage) instead
+        // of hard-failing the whole action and starving later sources.
+        if (targetNodeNum != null && await isMeshCoreSource(ctx, sid)) {
+          results.push({ skipped: true, reason: 'remote-admin reboot is not supported on MeshCore' });
+          continue;
+        }
         results.push(await deps.rebootDevice({ sourceId: sid, seconds, targetNodeNum }));
       }
       return results.length === 1 ? results[0] : results;

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -45,9 +45,11 @@ export interface ActionDeps {
     telemetryType?: TelemetryKind;
   }): Promise<unknown>;
   /** Reboot the physical device behind a source (#3995). `seconds` is the
-   *  Meshtastic reboot delay; MeshCore ignores it. Throws on an unreachable/
-   *  unsupported source so the run-log records a failed step. */
-  rebootDevice(a: { sourceId: string | null; seconds?: number }): Promise<unknown>;
+   *  Meshtastic reboot delay; MeshCore ignores it. `targetNodeNum` (#4126) is an
+   *  optional remote node to reboot over the mesh via the Meshtastic session-passkey
+   *  admin mechanism — omitted = reboot the source's locally-connected node.
+   *  Throws on an unreachable/unsupported source so the run-log records a failed step. */
+  rebootDevice(a: { sourceId: string | null; seconds?: number; targetNodeNum?: number }): Promise<unknown>;
   notify(a: { sourceId: string | null; title: string; body: string; type?: string; urls?: string[] }): Promise<unknown>;
   /** Run a user script file (in $DATA_DIR/scripts) with the given env. Never throws — returns the outcome. */
   runScript(a: { scriptPath: string; env: Record<string, string>; timeoutMs?: number }):
@@ -378,20 +380,28 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
     }
 
     case 'action.deviceReboot': {
-      // Reboot the physical device (#3995). Targets a SOURCE's local node, not a
-      // subject node — so there's no nodeNum. `seconds` is the Meshtastic reboot
-      // delay (default handled by the manager); MeshCore ignores it. Supports the
-      // same multi-source select as sendMessage/requestData so a source-less
-      // schedule trigger can pick which radio(s) to reboot.
+      // Reboot the physical device (#3995). By default targets a SOURCE's local
+      // node — so there's no nodeNum. `seconds` is the Meshtastic reboot delay
+      // (default handled by the manager); MeshCore ignores it. Supports the same
+      // multi-source select as sendMessage/requestData so a source-less schedule
+      // trigger can pick which radio(s) to reboot.
+      //
+      // #4126: an optional `targetNodeNum` reboots a REMOTE node over the mesh via
+      // the source's Meshtastic session-passkey admin mechanism. When set, it is
+      // forwarded to the manager's remote-admin reboot; when blank/absent the
+      // local-only path is unchanged.
       const secondsRaw = p.seconds != null ? Number(p.seconds) : undefined;
       const seconds = secondsRaw != null && Number.isFinite(secondsRaw) && secondsRaw >= 0
         ? Math.floor(secondsRaw) : undefined;
+      const targetRaw = p.targetNodeNum != null && p.targetNodeNum !== '' ? Number(p.targetNodeNum) : undefined;
+      const targetNodeNum = targetRaw != null && Number.isFinite(targetRaw) && targetRaw > 0
+        ? Math.floor(targetRaw) : undefined;
       const sourceIds = Array.isArray(p.sourceIds) && p.sourceIds.length > 0
         ? (p.sourceIds as unknown[]).map(String)
         : [sourceId];
       const results: unknown[] = [];
       for (const sid of sourceIds) {
-        results.push(await deps.rebootDevice({ sourceId: sid, seconds }));
+        results.push(await deps.rebootDevice({ sourceId: sid, seconds, targetNodeNum }));
       }
       return results.length === 1 ? results[0] : results;
     }

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -261,4 +261,38 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
     const deps = createMeshActionDeps();
     await expect(deps.rebootDevice({ sourceId: null })).rejects.toThrow(/requires a target source/);
   });
+
+  // ── remote-admin reboot (#4126) ────────────────────────────────────────────
+  it('with a targetNodeNum, calls sendRebootCommand(target, seconds) not the local rebootDevice', async () => {
+    const sendRebootCommand = vi.fn().mockResolvedValue(undefined);
+    const rebootDevice = vi.fn().mockResolvedValue(undefined);
+    getManager.mockReturnValue({ sendTextMessage: vi.fn(), sendRebootCommand, rebootDevice });
+    const deps = createMeshActionDeps();
+
+    const result = await deps.rebootDevice({ sourceId: 'mt', seconds: 15, targetNodeNum: 123456789 });
+
+    expect(sendRebootCommand).toHaveBeenCalledWith(123456789, 15);
+    expect(rebootDevice).not.toHaveBeenCalled();
+    expect(result).toEqual({ rebooted: true, targetNodeNum: 123456789 });
+  });
+
+  it('with a targetNodeNum and no seconds, lets the manager apply its own default', async () => {
+    const sendRebootCommand = vi.fn().mockResolvedValue(undefined);
+    getManager.mockReturnValue({ sendTextMessage: vi.fn(), sendRebootCommand, rebootDevice: vi.fn() });
+    const deps = createMeshActionDeps();
+
+    await deps.rebootDevice({ sourceId: 'mt', targetNodeNum: 42 });
+
+    expect(sendRebootCommand).toHaveBeenCalledWith(42);
+  });
+
+  it('throws when a targetNodeNum is set on a source without sendRebootCommand (e.g. MeshCore)', async () => {
+    // MeshCore managers expose rebootDevice() but no sendRebootCommand — a remote
+    // target is Meshtastic-only.
+    getManager.mockReturnValue({ sendMessage: vi.fn(), rebootDevice: vi.fn() });
+    const deps = createMeshActionDeps();
+
+    await expect(deps.rebootDevice({ sourceId: 'mc', targetNodeNum: 42 }))
+      .rejects.toThrow(/remote-admin reboot \(Meshtastic sources only\)/);
+  });
 });

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -166,14 +166,31 @@ export function createMeshActionDeps(): ActionDeps {
       throw new Error(`source "${sourceId}" cannot perform node requests`);
     },
 
-    async rebootDevice({ sourceId, seconds }) {
+    async rebootDevice({ sourceId, seconds, targetNodeNum }) {
       // Reboot the physical device (#3995). Both protocol managers expose a
       // `rebootDevice` method: Meshtastic `rebootDevice(seconds)` (void), MeshCore
       // `rebootDevice()` (Companion-only; resolves `false` on failure / repeater
       // firmware, ignores the seconds arg). Calling with `seconds` is safe for
       // both — MeshCore drops the extra argument.
       if (!sourceId) throw new Error('automation reboot action requires a target source');
-      const raw = resolveManager(sourceId) as { rebootDevice?: (seconds?: number) => Promise<unknown> } | undefined;
+      const raw = resolveManager(sourceId) as {
+        rebootDevice?: (seconds?: number) => Promise<unknown>;
+        sendRebootCommand?: (destinationNodeNum: number, seconds?: number) => Promise<unknown>;
+      } | undefined;
+
+      // #4126: remote-admin reboot. When a target node is specified, reboot that
+      // node over the mesh via the Meshtastic session-passkey admin mechanism
+      // (`sendRebootCommand`). This is Meshtastic-only — MeshCore managers have no
+      // such method, so a target on a MeshCore source is a clear error.
+      if (targetNodeNum != null) {
+        if (!raw || typeof raw.sendRebootCommand !== 'function') {
+          throw new Error(`source "${sourceId}" cannot send a remote-admin reboot (Meshtastic sources only)`);
+        }
+        // sendRebootCommand defaults `seconds` to 10 when undefined.
+        await (seconds != null ? raw.sendRebootCommand(targetNodeNum, seconds) : raw.sendRebootCommand(targetNodeNum));
+        return { rebooted: true, targetNodeNum };
+      }
+
       if (!raw || typeof raw.rebootDevice !== 'function') {
         throw new Error(`source "${sourceId}" cannot reboot (no connected device)`);
       }

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -76,6 +76,29 @@ describe('validateAutomationGraph', () => {
     expect(validateAutomationGraph(withCond({ mode: 'bogus' })).valid).toBe(false);
   });
 
+  it('action.deviceReboot: optional targetNodeNum validates present/absent (#4126)', () => {
+    const withReboot = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.schedule', params: { cron: '0 3 * * *' } },
+        { id: 'a', type: 'action.deviceReboot', params },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    // absent → valid (local-only reboot, unchanged behavior)
+    expect(validateAutomationGraph(withReboot({})).valid).toBe(true);
+    // blank string → valid (treated as absent)
+    expect(validateAutomationGraph(withReboot({ targetNodeNum: '' })).valid).toBe(true);
+    // positive node number → valid (remote-admin reboot)
+    expect(validateAutomationGraph(withReboot({ targetNodeNum: 123456789 })).valid).toBe(true);
+    // zero / negative / non-integer → error
+    expect(validateAutomationGraph(withReboot({ targetNodeNum: 0 })).valid).toBe(false);
+    const neg = validateAutomationGraph(withReboot({ targetNodeNum: -1 }));
+    expect(neg.valid).toBe(false);
+    expect(neg.errors.join(' ')).toMatch(/positive node number/);
+    expect(validateAutomationGraph(withReboot({ targetNodeNum: 1.5 })).valid).toBe(false);
+  });
+
   it('rejects non-object config', () => {
     expect(validateAutomationGraph(null).valid).toBe(false);
     expect(validateAutomationGraph(42).errors[0]).toMatch(/must be an object/);

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -377,6 +377,14 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
               errors.push(`action.deviceReboot "${n.id}" requires params.seconds ≥ 0`);
             }
           }
+          // `targetNodeNum` is optional (#4126). Blank/absent = local-only reboot;
+          // a positive integer = remote-admin reboot over the mesh (Meshtastic).
+          if (p.targetNodeNum != null && p.targetNodeNum !== '') {
+            const target = Number(p.targetNodeNum);
+            if (!Number.isInteger(target) || target <= 0) {
+              errors.push(`action.deviceReboot "${n.id}" requires params.targetNodeNum to be a positive node number`);
+            }
+          }
           break;
         case 'action.delay': {
           const secs = Number(p.seconds);


### PR DESCRIPTION
## Summary

Adds an **optional** `targetNodeNum` to the Automation Engine's `action.deviceReboot` action so a workflow can reboot a **remote node over the mesh** via Meshtastic's session-passkey admin mechanism — not just the locally-connected node.

- **Local-only default preserved**: when `targetNodeNum` is blank/absent/invalid, the action calls `rebootDevice(seconds)` exactly as before.
- **Remote path**: when a positive node number is set, the executor forwards it and `meshActionDeps` calls the manager's existing `sendRebootCommand(targetNodeNum, seconds)` — the same proven remote-admin path used by the manual Admin Commands tab (`POST /api/admin/reboot`). `sendRebootCommand` requests/attaches a session passkey for non-local destinations.
- **Per-source correctness**: the target manager is resolved per selected source via `sourceManagerRegistry.getManager(sourceId)` (the existing `resolveManager` helper in `meshActionDeps`), not the global alias. `sendRebootCommand` is Meshtastic-only; a MeshCore source (no such method) throws a clear "Meshtastic sources only" error.
- **No DB migration**: automation action config is stored inside the automation's JSON config graph, so a new optional field needs no schema change. The graph validator (`validateAutomationGraph`) was updated to accept/validate the new optional field.
- **UI**: the builder is catalog-driven, so the new field auto-renders as an advanced number input with helper text ("Leave blank to reboot the locally-connected node; set a node number to reboot a remote node over the mesh…").

## Field
`targetNodeNum` (optional, positive integer) on `action.deviceReboot`.

## Tests
- `actionExecutor.test.ts`: target set ⇒ forwarded to `rebootDevice({..., targetNodeNum})`; absent/blank/zero/non-numeric ⇒ `targetNodeNum` undefined (local path).
- `meshActionDeps.test.ts`: target set ⇒ `sendRebootCommand(target, seconds)` called (not local `rebootDevice`); no-seconds ⇒ manager default; MeshCore source (no `sendRebootCommand`) ⇒ throws.
- `automation.test.ts`: graph validation accepts present/absent, rejects zero/negative/non-integer.

## Verification
- Full Vitest suite: 9571 passed, 0 failed (after `git submodule update --init` for the protobuf-dependent MQTT suites).
- `tsc -p tsconfig.server.json --noEmit`: clean. No new frontend `tsc` errors.
- `npm run lint:ci`: OK.

## Note
Session-passkey behavior for an **unreachable** remote target is inherited from `sendRebootCommand`: it will throw if it cannot obtain a passkey (`Failed to obtain session passkey…`), which the run-log records as a failed step. This was not live-hardware validated here.

Closes #4126

🤖 Generated with [Claude Code](https://claude.com/claude-code)