### PR TITLE
feat(messages): add "Message anyway" override for unmessageable nodes (closes #4153)

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -318,6 +318,14 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   // State for "Jump to Bottom" button
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
 
+  // "Message anyway" override (#4153) for the unmessageable-node DM banner.
+  // `is_unmessagable` is only a NodeInfo self-report, not an enforced
+  // protocol restriction, so it can be stale/wrong. Keyed per-nodeId (not a
+  // single boolean) so overriding one conversation never unlocks another —
+  // switching selectedDMNode naturally looks up a different key, so nothing
+  // leaks between conversations. Cleared on reload (not persisted).
+  const [unmessageableOverrides, setUnmessageableOverrides] = useState<Set<string>>(new Set());
+
   // Handle scroll to detect if user has scrolled up
   const handleScroll = useCallback(() => {
     const container = dmMessagesContainerRef.current;
@@ -781,6 +789,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   const { dmReadOnly, dmReadOnlyReason, actionsReadOnly } = computeMessagesReadOnlyState({
     mqttReadOnly,
     isUnmessagable: selectedNode?.isUnmessagable,
+    // Only ever suppresses the unmessageable gate — never bypasses MQTT
+    // (enforced inside computeMessagesReadOnlyState itself).
+    overrideUnmessageable: selectedDMNode ? unmessageableOverrides.has(selectedDMNode) : false,
   });
 
   return (
@@ -1393,6 +1404,14 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               Only shown for the unmessageable reason — the MQTT-bridge mirror case
               already hides the action buttons too, which is self-explanatory from
               the source picker, so it doesn't get a banner here.
+
+              #4153: `is_unmessagable` is only a NodeInfo self-report, not an
+              enforced protocol restriction — it can be stale or wrong — so the
+              banner offers a "Message anyway" override. The override is keyed
+              per-nodeId (unmessageableOverrides), so it never leaks between
+              conversations, and it is NEVER offered for the MQTT reason (a
+              hard transport limitation, not a self-report — enforced inside
+              computeMessagesReadOnlyState, not just in this banner).
             */}
             {dmReadOnlyReason === 'unmessageable' && (
               <div
@@ -1408,6 +1427,37 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 {t(
                   'messages.unmessageable_banner',
                   'This node reports itself as unmessageable (router/repeater/sensor) — it cannot receive direct messages.'
+                )}
+                {selectedDMNode && (
+                  <>
+                    {' '}
+                    <button
+                      onClick={() => {
+                        const nodeId = selectedDMNode;
+                        setUnmessageableOverrides(prev => {
+                          const next = new Set(prev);
+                          next.add(nodeId);
+                          return next;
+                        });
+                      }}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        color: 'var(--ctp-blue, #1e66f5)',
+                        textDecoration: 'underline',
+                        cursor: 'pointer',
+                        fontWeight: 'bold',
+                        fontSize: 'inherit',
+                      }}
+                      title={t(
+                        'messages.unmessageable_override_title',
+                        'This flag is self-reported and may be stale or wrong. Try messaging this node anyway.'
+                      )}
+                    >
+                      {t('messages.unmessageable_override_button', 'Message anyway')}
+                    </button>
+                  </>
                 )}
               </div>
             )}

--- a/src/components/messagesReadOnlyState.test.ts
+++ b/src/components/messagesReadOnlyState.test.ts
@@ -44,4 +44,54 @@ describe('computeMessagesReadOnlyState (#3831)', () => {
       actionsReadOnly: false,
     });
   });
+
+  describe('overrideUnmessageable ("message anyway", #4153)', () => {
+    it('isUnmessagable=true, override=false: DMs stay hidden (banner shows)', () => {
+      expect(
+        computeMessagesReadOnlyState({ mqttReadOnly: false, isUnmessagable: true, overrideUnmessageable: false })
+      ).toEqual({
+        dmReadOnly: true,
+        dmReadOnlyReason: 'unmessageable',
+        actionsReadOnly: false,
+      });
+    });
+
+    it('isUnmessagable=true, override=true: DMs revealed (composer shows)', () => {
+      expect(
+        computeMessagesReadOnlyState({ mqttReadOnly: false, isUnmessagable: true, overrideUnmessageable: true })
+      ).toEqual({
+        dmReadOnly: false,
+        dmReadOnlyReason: null,
+        actionsReadOnly: false,
+      });
+    });
+
+    it('mqttReadOnly=true, override=true: STILL read-only — override never bypasses MQTT', () => {
+      expect(
+        computeMessagesReadOnlyState({ mqttReadOnly: true, isUnmessagable: false, overrideUnmessageable: true })
+      ).toEqual({
+        dmReadOnly: true,
+        dmReadOnlyReason: 'mqtt',
+        actionsReadOnly: true,
+      });
+    });
+
+    it('mqttReadOnly=true AND isUnmessagable=true, override=true: still read-only via MQTT', () => {
+      expect(
+        computeMessagesReadOnlyState({ mqttReadOnly: true, isUnmessagable: true, overrideUnmessageable: true })
+      ).toEqual({
+        dmReadOnly: true,
+        dmReadOnlyReason: 'mqtt',
+        actionsReadOnly: true,
+      });
+    });
+
+    it('defaults overrideUnmessageable to false when omitted', () => {
+      expect(computeMessagesReadOnlyState({ mqttReadOnly: false, isUnmessagable: true })).toEqual({
+        dmReadOnly: true,
+        dmReadOnlyReason: 'unmessageable',
+        actionsReadOnly: false,
+      });
+    });
+  });
 });

--- a/src/components/messagesReadOnlyState.ts
+++ b/src/components/messagesReadOnlyState.ts
@@ -18,6 +18,13 @@
  *
  * Conflating the two (the pre-#3831 `effectiveReadOnly` flag) wrongly hid the
  * action buttons for unmessageable nodes. Keep them separate.
+ *
+ * `is_unmessagable` is only a NodeInfo *self-report*, not an enforced protocol
+ * restriction, so it can be stale or simply wrong. `overrideUnmessageable`
+ * (#4153) lets the user say "message anyway" and bypass the DM gate for that
+ * node. It must NEVER bypass the MQTT case — MQTT is a hard transport
+ * limitation (no send capability at all), not a self-report, so overriding it
+ * wouldn't work and isn't offered in the UI.
  */
 export interface MessagesReadOnlyState {
   /** Hide the DM message log and the compose field. */
@@ -36,15 +43,22 @@ export interface MessagesReadOnlyState {
 export function computeMessagesReadOnlyState(opts: {
   mqttReadOnly: boolean;
   isUnmessagable: boolean | undefined;
+  /**
+   * User opted to "message anyway" for the currently-selected node (#4153).
+   * Only ever suppresses the `isUnmessagable` gate — MQTT's `mqttReadOnly`
+   * always forces `dmReadOnly` regardless of this flag. Defaults to `false`.
+   */
+  overrideUnmessageable?: boolean;
 }): MessagesReadOnlyState {
-  const { mqttReadOnly, isUnmessagable } = opts;
-  const dmReadOnly = mqttReadOnly || isUnmessagable === true;
+  const { mqttReadOnly, isUnmessagable, overrideUnmessageable = false } = opts;
+  const unmessageableGate = isUnmessagable === true && !overrideUnmessageable;
+  const dmReadOnly = mqttReadOnly || unmessageableGate;
   return {
     // DMs are suppressed by either condition.
     dmReadOnly,
     // Unmessageable is the more specific/actionable reason, so it wins when
     // both apply.
-    dmReadOnlyReason: !dmReadOnly ? null : isUnmessagable === true ? 'unmessageable' : 'mqtt',
+    dmReadOnlyReason: !dmReadOnly ? null : unmessageableGate ? 'unmessageable' : 'mqtt',
     // Action buttons are suppressed ONLY by the MQTT-bridge mirror — an
     // unmessageable node still responds to these channel-routed requests.
     actionsReadOnly: mqttReadOnly,


### PR DESCRIPTION
## Summary

`is_unmessagable` is only a NodeInfo self-report — not an enforced protocol restriction — so it can be stale or plain wrong. This adds a **"Message anyway"** link to the unmessageable-node DM banner (#4139) that reveals the normal DM log + composer for that node.

## Design

- **Per-node session override:** `Set<nodeId>` state in `MessagesTab` — overriding Node A never unlocks Node B; switching nodes naturally looks up a different key; cleared on reload (not persisted).
- **Pure-function enforcement:** `computeMessagesReadOnlyState()` gains an optional `overrideUnmessageable` param that suppresses ONLY the `isUnmessagable` gate. **MQTT is never bypassed** — `mqttReadOnly` still forces read-only regardless of the override, enforced inside the function itself (not just by hiding the button). The banner/button is only rendered for `dmReadOnlyReason === 'unmessageable'`.
- i18n'd button + tooltip explaining the flag is self-reported.

## Tests

5 new cases in `messagesReadOnlyState.test.ts`:
- unmessageable + no override ⇒ banner (read-only)
- unmessageable + override ⇒ composer revealed
- **MQTT + override ⇒ STILL read-only, reason `mqtt`**
- **MQTT + unmessageable + override ⇒ still read-only via MQTT**
- override defaults to false when omitted

Closes #4153

🤖 Generated with [Claude Code](https://claude.com/claude-code)