### PR TITLE
fix(api): v1 'default' source alias deep-scopes by the resolved id, not the literal

### DIFF
--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -17,7 +17,7 @@ import databaseService from '../../../services/database.js';
 import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
 import { logger } from '../../../utils/logger.js';
 import { PortNum } from '../../constants/meshtastic.js';
-import { attachSource } from './sourceParam.js';
+import { attachSource, resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
@@ -78,7 +78,7 @@ function pruneNeighborRateLimit(): void {
 
 router.post('/traceroute', attachSource('traceroute', 'write'), async (req: Request, res: Response) => {
   try {
-    const sourceId = req.params.sourceId as string;
+    const sourceId = resolvedSourceIdFromPath(req) as string;
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
@@ -110,7 +110,7 @@ router.post('/traceroute', attachSource('traceroute', 'write'), async (req: Requ
 
 router.post('/request-position', attachSource('messages', 'write'), async (req: Request, res: Response) => {
   try {
-    const sourceId = req.params.sourceId as string;
+    const sourceId = resolvedSourceIdFromPath(req) as string;
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
@@ -167,7 +167,7 @@ router.post('/request-position', attachSource('messages', 'write'), async (req: 
 
 router.post('/request-nodeinfo', attachSource('messages', 'write'), async (req: Request, res: Response) => {
   try {
-    const sourceId = req.params.sourceId as string;
+    const sourceId = resolvedSourceIdFromPath(req) as string;
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
@@ -223,7 +223,7 @@ router.post('/request-nodeinfo', attachSource('messages', 'write'), async (req: 
 
 router.post('/request-neighbors', attachSource('traceroute', 'write'), async (req: Request, res: Response) => {
   try {
-    const sourceId = req.params.sourceId as string;
+    const sourceId = resolvedSourceIdFromPath(req) as string;
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });

--- a/src/server/routes/v1/channels.ts
+++ b/src/server/routes/v1/channels.ts
@@ -11,12 +11,13 @@ import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { ResourceType } from '../../../types/permission.js';
 import { transformChannel } from '../../utils/channelView.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
 /** Resolve sourceId from path (new /sources/:sourceId mount) or query (legacy). */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -17,6 +17,7 @@ import { ResourceType } from '../../../types/permission.js';
 import { messageLimiter } from '../../middleware/rateLimiters.js';
 import { logger } from '../../../utils/logger.js';
 import { MAX_MESSAGE_BYTES, PortNum } from '../../constants/meshtastic.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 /** Maximum number of message parts allowed when splitting long messages */
 const MAX_MESSAGE_PARTS = 3;
@@ -72,7 +73,7 @@ const router = express.Router({ mergeParams: true });
 
 /** Resolve sourceId from path (new /sources/:sourceId mount) or query/body (legacy). */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   if (fromQuery) return fromQuery;

--- a/src/server/routes/v1/network.ts
+++ b/src/server/routes/v1/network.ts
@@ -9,12 +9,13 @@ import databaseService from '../../../services/database.js';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { getEffectiveDbNodePosition } from '../../utils/nodeEnhancer.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
 /** Resolve sourceId from path or query. */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;

--- a/src/server/routes/v1/nodes.ts
+++ b/src/server/routes/v1/nodes.ts
@@ -11,6 +11,7 @@ import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { filterNodesByChannelPermission, maskNodeLocationByChannel } from '../../utils/nodeEnhancer.js';
 import { findCopyCandidates, copyNodeInfo } from '../../services/nodeInfoCopyService.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 // mergeParams so this router picks up :sourceId when mounted under
 // /sources/:sourceId (new shape). At the root /nodes mount it's undefined
@@ -22,7 +23,7 @@ const router = express.Router({ mergeParams: true });
  * query param; both undefined means "no scope" (legacy cross-source view).
  */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;

--- a/src/server/routes/v1/packets.ts
+++ b/src/server/routes/v1/packets.ts
@@ -7,6 +7,7 @@
 import express, { Request } from 'express';
 import packetLogService from '../../services/packetLogService.js';
 import { logger } from '../../../utils/logger.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 /** Normalize a `since` timestamp to milliseconds (auto-detect seconds vs ms) */
 function normalizeSinceToMs(value: string): number {
@@ -16,7 +17,7 @@ function normalizeSinceToMs(value: string): number {
 
 /** Resolve sourceId from path or query. */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;

--- a/src/server/routes/v1/positionHistory.ts
+++ b/src/server/routes/v1/positionHistory.ts
@@ -11,12 +11,13 @@ import databaseService from '../../../services/database.js';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { checkNodeChannelAccess } from '../../utils/nodeEnhancer.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
 /** Resolve sourceId from path or query. */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;

--- a/src/server/routes/v1/sourceParam.defaultAlias.test.ts
+++ b/src/server/routes/v1/sourceParam.defaultAlias.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression: the v1 `default` source alias must DEEP-SCOPE by the RESOLVED
+ * concrete source id, not the literal string "default".
+ *
+ * `attachSource` normalises `req.params.sourceId` to the resolved id, but
+ * Express RE-DERIVES `req.params` for the nested `mergeParams` sub-router
+ * (`nodesRouter`) from the matched URL — so a handler reading
+ * `req.params.sourceId` sees the raw literal "default". `req.source` is a
+ * request-level property that survives, so it carries the concrete Source.
+ * `getScopedSourceId` now routes through `req.source.id` first
+ * (`resolvedSourceIdFromPath`).
+ *
+ * This test reproduces the exact production wiring from `index.ts`
+ * (`attachSource` + a nested mergeParams sub-router). On the pre-fix code the
+ * nodes query is scoped by "default", which matches no source and returns an
+ * empty list — so the seeded-rows assertion fails (red). With the fix the
+ * query is scoped by the resolved id and the rows come back (green).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const {
+  CONCRETE_ID,
+  SEEDED_NODES,
+  getAllNodes,
+  getActiveNodes,
+} = vi.hoisted(() => {
+  const CONCRETE_ID = 'src-primary-0001';
+  const SEEDED_NODES = [
+    { nodeId: '111', nodeNum: 111, longName: 'Alpha', shortName: 'ALFA', channel: 0 },
+    { nodeId: '222', nodeNum: 222, longName: 'Bravo', shortName: 'BRVO', channel: 0 },
+  ];
+  // Only the concrete id yields rows — "default" (the raw URL literal) yields none.
+  const getAllNodes = vi.fn(async (sourceId?: string) =>
+    sourceId === CONCRETE_ID ? SEEDED_NODES.slice() : []
+  );
+  const getActiveNodes = vi.fn(async (_days: number, sourceId?: string) =>
+    sourceId === CONCRETE_ID ? SEEDED_NODES.slice() : []
+  );
+  return { CONCRETE_ID, SEEDED_NODES, getAllNodes, getActiveNodes };
+});
+
+vi.mock('../../../services/database.js', () => ({
+  default: {
+    sources: {
+      getAllSources: vi.fn(async () => [{ id: CONCRETE_ID, enabled: true, createdAt: 1 }]),
+      getSource: vi.fn(async (id: string) =>
+        id === CONCRETE_ID ? { id: CONCRETE_ID, enabled: true, createdAt: 1 } : null
+      ),
+    },
+    checkPermissionAsync: vi.fn(async () => true),
+    nodes: { getAllNodes, getActiveNodes },
+    telemetry: {
+      getLatestTelemetryValueForAllNodes: vi.fn(async () => new Map()),
+    },
+  },
+}));
+
+// Pass-through channel enrichment so the seeded rows survive to the response.
+vi.mock('../../utils/nodeEnhancer.js', () => ({
+  filterNodesByChannelPermission: vi.fn(async (nodes: unknown[]) => nodes),
+  maskNodeLocationByChannel: vi.fn(async (nodes: unknown[]) => nodes),
+  checkNodeChannelAccess: vi.fn(async () => true),
+  getEffectiveDbNodePosition: vi.fn(() => null),
+}));
+
+// Import after mocks
+import { attachSource } from './sourceParam.js';
+import nodesRouter from './nodes.js';
+import positionHistoryRouter from './positionHistory.js';
+
+function buildApp(user: unknown) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { user: unknown }).user = user;
+    next();
+  });
+  // Exact production wiring from index.ts — attachSource then nested routers.
+  app.use(
+    '/api/v1/sources/:sourceId/nodes',
+    attachSource('nodes', 'read'),
+    positionHistoryRouter,
+    nodesRouter
+  );
+  return app;
+}
+
+const ADMIN = { id: 1, isAdmin: true, isActive: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('v1 `default` source alias deep-scoping (regression)', () => {
+  it('scopes the nodes query by the resolved concrete id, not the literal "default"', async () => {
+    const res = await request(buildApp(ADMIN)).get('/api/v1/sources/default/nodes');
+
+    expect(res.status).toBe(200);
+    // The handler must return the seeded rows for the RESOLVED source. On the
+    // pre-fix code this is [] because the query was scoped by "default".
+    expect(res.body.data).toHaveLength(SEEDED_NODES.length);
+    expect(res.body.data.map((n: { nodeId: string }) => n.nodeId).sort()).toEqual(['111', '222']);
+    // And it must have deep-scoped by the concrete id, never the literal alias.
+    expect(getAllNodes).toHaveBeenCalledWith(CONCRETE_ID);
+    expect(getAllNodes).not.toHaveBeenCalledWith('default');
+  });
+
+  it('still deep-scopes correctly when the concrete id is used directly', async () => {
+    const res = await request(buildApp(ADMIN)).get(`/api/v1/sources/${CONCRETE_ID}/nodes`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(SEEDED_NODES.length);
+    expect(getAllNodes).toHaveBeenCalledWith(CONCRETE_ID);
+  });
+});

--- a/src/server/routes/v1/sourceParam.ts
+++ b/src/server/routes/v1/sourceParam.ts
@@ -147,3 +147,30 @@ export function attachSource(
 export interface RequestWithSource extends Request {
   source: Source;
 }
+
+/**
+ * Request that MAY have passed through `attachSource`. `source` is present only
+ * on the canonical per-source mounts; it is undefined on the legacy root mounts
+ * (`/api/v1/nodes?sourceId=`), where `attachSource` never runs.
+ */
+interface MaybeRequestWithSource extends Request {
+  source?: Source;
+}
+
+/**
+ * Resolve the concrete source id for a path-scoped request.
+ *
+ * Prefers `req.source.id` (attached by `attachSource`) over the raw `:sourceId`
+ * path param. This is load-bearing for the `default` alias: `attachSource`
+ * normalises `req.params.sourceId` to the resolved id, but Express RE-DERIVES
+ * `req.params` for each `mergeParams` sub-router from the matched URL — so a
+ * handler inside a sub-router reads the raw URL literal (e.g. `"default"`), NOT
+ * the normalised value. `req.source` is a request-level property that survives
+ * the re-derivation, so it carries the concrete resolved Source. Returns
+ * `undefined` on the legacy root mounts, where callers fall back to `?sourceId=`.
+ */
+export function resolvedSourceIdFromPath(req: Request): string | undefined {
+  const fromSource = (req as MaybeRequestWithSource).source?.id;
+  if (typeof fromSource === 'string' && fromSource) return fromSource;
+  return typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+}

--- a/src/server/routes/v1/status.ts
+++ b/src/server/routes/v1/status.ts
@@ -9,13 +9,14 @@ import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
 import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
 import { logger } from '../../../utils/logger.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
 router.get('/', async (req: Request, res: Response) => {
   try {
     // Scope priority: path (:sourceId via mergeParams) → query (legacy).
-    const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+    const fromPath = resolvedSourceIdFromPath(req);
     const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
     const statusSourceId = fromPath ?? fromQuery;
     const statusManager = resolveSourceManager(statusSourceId);

--- a/src/server/routes/v1/telemetry.ts
+++ b/src/server/routes/v1/telemetry.ts
@@ -9,12 +9,13 @@ import databaseService from '../../../services/database.js';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { checkNodeChannelAccess, maskTelemetryByChannel } from '../../utils/nodeEnhancer.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
 /** Resolve sourceId from path or query. */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;

--- a/src/server/routes/v1/traceroutes.ts
+++ b/src/server/routes/v1/traceroutes.ts
@@ -9,12 +9,13 @@ import databaseService from '../../../services/database.js';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { maskTraceroutesByChannel } from '../../utils/nodeEnhancer.js';
+import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
 /** Resolve sourceId from path or query. */
 function getScopedSourceId(req: Request): string | undefined {
-  const fromPath = typeof req.params.sourceId === 'string' ? req.params.sourceId : undefined;
+  const fromPath = resolvedSourceIdFromPath(req);
   if (fromPath) return fromPath;
   const fromQuery = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
   return fromQuery;


### PR DESCRIPTION
## Root cause

The v1 API mounts canonical per-source routes at `/api/v1/sources/:sourceId/...` and supports a `default` alias that resolves to the primary/default source. The `attachSource` middleware (`src/server/routes/v1/sourceParam.ts`) resolves the alias, attaches the resolved `Source` to `req.source`, and normalises `req.params.sourceId` to the concrete resolved id.

The bug: **Express re-derives `req.params` for each `mergeParams` sub-router from the matched URL.** So handlers *inside* the sub-routers (`nodesRouter`, `messagesRouter`, etc. — all mounted as nested `Router({ mergeParams: true })`) that read `req.params.sourceId` saw the raw URL literal `"default"`, NOT the id `attachSource` wrote. `req.source` (a request-level property) survives the re-derivation and carries the resolved source.

**Consequence:** requesting `/api/v1/sources/default/nodes` returned `200`, but the handler deep-scoped its DB query by the literal string `"default"`, which matches no rows when the actual default source id differs — silently returning empty results.

Verified empirically with a minimal Express repro: inside a nested `mergeParams` sub-router, `req.params.sourceId === "default"` while `req.source.id === "<concrete>"`.

## Fix

Added `resolvedSourceIdFromPath(req)` to `sourceParam.ts`. It prefers `req.source?.id` (survives re-derivation), falls back to the raw path param, and returns `undefined` on the legacy root mounts. Routed every per-router `getScopedSourceId` helper plus the `status` and `actions` handlers through it.

The existing `?sourceId=` query fallback branches (which serve the legacy root mounts) are left **fully intact** — only the path-derivation line changed. No new `any` (a narrow typed `MaybeRequestWithSource` accessor is used).

Files touched:
- `sourceParam.ts` — new `resolvedSourceIdFromPath` helper + `MaybeRequestWithSource` type
- `nodes.ts`, `channels.ts`, `messages.ts`, `network.ts`, `packets.ts`, `telemetry.ts`, `traceroutes.ts`, `positionHistory.ts` — `getScopedSourceId` now derives the path id via the helper
- `status.ts` — inline path-scope now via the helper
- `actions.ts` — 4 handlers now read the resolved id via the helper (was `req.params.sourceId as string`)
- `sourceParam.defaultAlias.test.ts` — new regression test

## Red → green proof

New test `sourceParam.defaultAlias.test.ts` reproduces the exact production wiring (`attachSource` + nested `mergeParams` sub-router) and seeds a source whose concrete id (`src-primary-0001`) differs from the literal `"default"`, with `nodes.getAllNodes` returning rows only for the concrete id.

- **Red** (helpers reverted): `scopes the nodes query by the resolved concrete id` → **failed** (response `data` empty; query scoped by `"default"`).
- **Green** (fix applied): both assertions pass — seeded rows returned, `getAllNodes` called with the concrete id and never with `"default"`.

## Verification

- Full Vitest suite: **9611 passed, 0 failed, 0 suite failures** (JSON reporter, `success: true`).
- `tsc -p tsconfig.server.json --noEmit`: clean.
- `npm run lint:ci`: exit 0 (no baseline change).

## Note for reviewers

The held **PR #4189** removes the `?sourceId=` query fallbacks (legacy root mounts) from these same `getScopedSourceId` helpers. This PR only changes the path-derivation line and adds an import, so #4189 should need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)