### PR TITLE
feat(messages): show short name alongside long name on message senders (closes #4193)

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -29,7 +29,7 @@ import { applyHomoglyphOptimization } from '../utils/homoglyph';
 import { calculateDistance, formatDistance, getDistanceToNode } from '../utils/distance';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
 import { getMessageContentMatchNodeIds } from '../utils/messageContentFilter';
-import { isNodeComplete, isInfrastructureNode, hasValidPosition, parseNodeId } from '../utils/nodeHelpers';
+import { isNodeComplete, isInfrastructureNode, hasValidPosition, parseNodeId, formatSenderLabel } from '../utils/nodeHelpers';
 import { getEffectiveHops } from '../utils/nodeHops';
 import { scrollInputIntoView } from '../utils/scrollInputIntoView';
 import { useMapContext } from '../contexts/MapContext';
@@ -506,6 +506,18 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
     (nodeId: string): string => {
       const node = nodes.find(n => n.user?.id === nodeId);
       return (node?.user?.shortName && node.user.shortName.trim()) || nodeId.slice(-4);
+    },
+    [nodes]
+  );
+
+  // Per-message sender label: "Long Name (SHRT)" (issue #4193). Kept as a
+  // separate helper rather than folded into getNodeName so the fallback
+  // chain there is untouched; see formatSenderLabel in nodeHelpers.ts for
+  // the pure formatting rules (no duplicate/empty parenthetical).
+  const getSenderLabel = useCallback(
+    (nodeId: string): string => {
+      const node = nodes.find(n => n.user?.id === nodeId);
+      return formatSenderLabel(node?.user?.longName, node?.user?.shortName, nodeId);
     },
     [nodes]
   );
@@ -1534,7 +1546,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         )}
                         <div className="message-item traceroute">
                           <div className="message-header">
-                            <span className="message-from">{getNodeName(msg.from)}</span>
+                            <span className="message-from">{getSenderLabel(msg.from)}</span>
                             <span className="message-time">
                               {formatMessageTime(currentDate, timeFormat, dateFormat)}
                               <HopCountDisplay

--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, hasValidEffectivePosition, isNodeComplete, resolveMapEndpoint, formatLocationSource } from './nodeHelpers';
+import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, formatSenderLabel, hasValidEffectivePosition, isNodeComplete, resolveMapEndpoint, formatLocationSource } from './nodeHelpers';
 import { setDiscardInvalidPositionsDisplay } from './positionDisplayConfig';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
 import type { DeviceInfo } from '../types/device';
@@ -252,6 +252,45 @@ describe('Node Helpers', () => {
         }
       ];
       expect(getNodeShortName(nodesWithWhitespace, '!test1234')).toBe('ABC');
+    });
+  });
+
+  describe('formatSenderLabel (#4193)', () => {
+    it('appends the short name when it adds information', () => {
+      expect(formatSenderLabel('Test Node Alpha', 'TNA', '!abc12345')).toBe('Test Node Alpha (TNA)');
+    });
+
+    it('shows just the long name when there is no short name', () => {
+      expect(formatSenderLabel('Test Node Alpha', undefined, '!abc12345')).toBe('Test Node Alpha');
+      expect(formatSenderLabel('Test Node Alpha', null, '!abc12345')).toBe('Test Node Alpha');
+      expect(formatSenderLabel('Test Node Alpha', '', '!abc12345')).toBe('Test Node Alpha');
+      expect(formatSenderLabel('Test Node Alpha', '   ', '!abc12345')).toBe('Test Node Alpha');
+    });
+
+    it('shows just the long name when the short name is identical', () => {
+      expect(formatSenderLabel('Alice', 'Alice', '!abc12345')).toBe('Alice');
+    });
+
+    it('does not duplicate the short name when there is no long name', () => {
+      // getNodeName-style resolution would already have fallen back to the
+      // short name as the primary display value here — must not render
+      // "TNA (TNA)".
+      expect(formatSenderLabel(undefined, 'TNA', '!abc12345')).toBe('TNA');
+      expect(formatSenderLabel('', 'TNA', '!abc12345')).toBe('TNA');
+    });
+
+    it('falls back to the provided fallback (e.g. node ID) when both names are missing', () => {
+      expect(formatSenderLabel(undefined, undefined, '!abc12345')).toBe('!abc12345');
+      expect(formatSenderLabel('', '', '!abc12345')).toBe('!abc12345');
+    });
+
+    it('renders emoji short names as-is', () => {
+      expect(formatSenderLabel('Test Node Alpha', '😀', '!abc12345')).toBe('Test Node Alpha (😀)');
+    });
+
+    it('trims whitespace from both names before comparing/rendering', () => {
+      expect(formatSenderLabel('  Alice  ', '  ALC  ', '!abc12345')).toBe('Alice (ALC)');
+      expect(formatSenderLabel('  Alice  ', '  Alice  ', '!abc12345')).toBe('Alice');
     });
   });
 

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -322,6 +322,33 @@ export const getNodeName = (nodes: DeviceInfo[], nodeId: string): string => {
   return node?.user?.longName || nodeId;
 };
 
+/**
+ * Format a per-message sender label as "Long Name (SHRT)" — the same
+ * "Name (SHORT)" pattern already used by node pickers/recipient lists.
+ *
+ * Takes the RAW long/short name fields (not fallback-chained display
+ * strings like `getNodeName`/`getNodeShortName`) so it can tell whether
+ * appending the parenthetical short name actually adds information:
+ *   - No short name, or shortName === longName → just the primary name.
+ *   - No long name (primary falls back to shortName, then to `fallback`,
+ *     typically the node ID) → don't render `SHRT (SHRT)`.
+ *   - Otherwise → `Long Name (SHRT)`.
+ * (Issue #4193.)
+ */
+export const formatSenderLabel = (
+  longName: string | null | undefined,
+  shortName: string | null | undefined,
+  fallback: string
+): string => {
+  const trimmedLong = longName?.trim() || '';
+  const trimmedShort = shortName?.trim() || '';
+  const primary = trimmedLong || trimmedShort || fallback;
+  if (trimmedShort && primary !== trimmedShort) {
+    return `${primary} (${trimmedShort})`;
+  }
+  return primary;
+};
+
 export const getNodeShortName = (nodes: DeviceInfo[], nodeId: string): string => {
   if (!nodeId) return '';
   const node = nodes.find(n => n.user?.id === nodeId);


### PR DESCRIPTION
## Summary

In the Messages view's DM message list, the traceroute message header sender label (`MessagesTab.tsx` `.message-from` span) rendered only the sender's long name — inconsistent with the node picker/recipient list in the same file, which already shows the `Long Name (SHRT)` pattern.

This adds the short name alongside the long name for that per-message sender label, reusing the same `Name (SHORT)` convention.

## Changes

- **`src/utils/nodeHelpers.ts`**: new pure helper `formatSenderLabel(longName, shortName, fallback)`. It takes the *raw* long/short name fields (not the fallback-chained display strings from `getNodeName`/`getNodeShortName`) so it can tell whether the parenthetical actually adds information.
- **`src/components/MessagesTab.tsx`**: new `getSenderLabel` callback (co-located with `getNodeName`/`getNodeShortName`, but implemented separately from `getNodeName` — deliberately, to avoid touching its fallback chain since issue #4194 is concurrently working on `getNodeName`'s resolution logic in the same file). Wired into the traceroute message header's `.message-from` span, which was the only per-message (non-picker) sender-label render site in this file.
- **`src/utils/nodeHelpers.test.ts`**: unit tests for `formatSenderLabel`.

## Edge cases handled

- No short name → just the long name.
- `shortName === longName` → just the name once (no `Name (Name)`).
- No long name (would otherwise fall back to showing the short name as primary) → don't render `SHRT (SHRT)`.
- Emoji short names render as-is.
- Both names missing → falls back to the provided fallback (node ID).
- Whitespace-only names are trimmed before comparison/rendering.

## Test coverage

- `src/utils/nodeHelpers.test.ts` — new `describe('formatSenderLabel (#4193)')` block covering all edge cases above.
- Full Vitest suite: 9618 passed, 0 failed.
- `npx tsc --noEmit`: clean.
- `npm run lint:ci`: passes (ratchet OK).

Closes #4193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)