### PR TITLE
chore: bump version to 4.13.1-rc3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.1-rc2",
+  "version": "4.13.1-rc3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.1-rc2",
+  "version": "4.13.1-rc3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.1-rc2
-appVersion: "4.13.1-rc2"
+version: 4.13.1-rc3
+appVersion: "4.13.1-rc3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1-rc2",
+  "version": "4.13.1-rc3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.1-rc2",
+      "version": "4.13.1-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1-rc2",
+  "version": "4.13.1-rc3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.13.1-rc3** across all five files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` version + appVersion, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`).

## Rolled up since rc2 (13 PRs)

**Features**
- #4188 position accuracy + location source in node popups (migration 124)
- #4187 "Message anyway" override for unmessageable nodes
- #4186 automation remote-admin reboot target
- #4196 short name alongside long name on message senders
- #4182 render side honors "Discard invalid positions" toggle
- #4181 occupancy-log-scaled, distance-capped precision offset

**Fixes**
- #4197 MeshCore own node's messages show name, not public key
- #4191 v1 `default` source alias deep-scopes by resolved id
- #4185 compose draft scoped per-conversation (wrong-recipient bug)
- #4184 router short-name visible in Official pin style
- #4180 traceroute doesn't send on a DISABLED channel slot (NO_CHANNEL)
- #4175 heatmap/coverage density drops deleted nodes

**Docs**
- #4179 Meshview Link Responder in User Scripts Gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)