### PR TITLE
feat(nodes): show Noise Floor on the Node Detail quick-stats card

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -624,6 +624,7 @@
     "system_backup.toast_creating": "",
     "settings.solar_latitude_description": "",
     "node_details.air_utilization_tx": "",
+    "node_details.noise_floor": "",
     "hardware.tbeam_v0p7": "",
     "admin_commands.selected": "",
     "settings.settings_management": "",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2852,6 +2852,7 @@
   "node_details.signal_rssi": "Signal (RSSI)",
   "node_details.channel_utilization": "Channel Utilization",
   "node_details.air_utilization_tx": "Air Utilization TX",
+  "node_details.noise_floor": "Noise Floor",
   "node_details.uptime": "Uptime",
   "node_details.node_id": "Node ID",
   "node_details.role": "Role",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -635,6 +635,7 @@
     "system_backup.toast_creating": "",
     "settings.solar_latitude_description": "",
     "node_details.air_utilization_tx": "",
+    "node_details.noise_floor": "",
     "hardware.tbeam_v0p7": "",
     "admin_commands.selected": "",
     "settings.settings_management": "",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -624,6 +624,7 @@
     "system_backup.toast_creating": "Création de la sauvegarde système...",
     "settings.solar_latitude_description": "Position nord‑sud sur la Terre (-90 sud à +90 nord)",
     "node_details.air_utilization_tx": "Utilisation de l'air TX",
+    "node_details.noise_floor": "Plancher de bruit",
     "hardware.tbeam_v0p7": "T‑Beam V0.7",
     "admin_commands.selected": "Sélectionné",
     "settings.settings_management": "Gestion des paramètres",

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -386,6 +386,7 @@
     "system_backup.toast_creating": "",
     "settings.solar_latitude_description": "",
     "node_details.air_utilization_tx": "",
+    "node_details.noise_floor": "",
     "hardware.tbeam_v0p7": "",
     "common.show_more": "",
     "admin_commands.selected": "",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -2720,6 +2720,7 @@
     "node_details.signal_rssi": "Sygnał (RSSI)",
     "node_details.channel_utilization": "Wykorzystanie kanału",
     "node_details.air_utilization_tx": "Wykorzystanie pasma TX",
+    "node_details.noise_floor": "Poziom szumów",
     "node_details.uptime": "Czas działania",
     "node_details.node_id": "Identyfikator węzła",
     "node_details.role": "Rola",

--- a/public/locales/pt_BR.json
+++ b/public/locales/pt_BR.json
@@ -520,6 +520,7 @@
     "settings.analytics": "",
     "settings.solar_latitude_description": "",
     "node_details.air_utilization_tx": "",
+    "node_details.noise_floor": "",
     "hardware.tbeam_v0p7": "",
     "messages.scan_for_admin": "",
     "common.show_more": "",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -1594,6 +1594,7 @@
     "theme_gallery.persistence_desc": "Выбранная вами тема сохраняется автоматически и не меняется между сессиями. Все темы работают на всех страницах и компонентах.",
     "automation.auto_traceroute.limit_to_nodes_description": "При включении этой функции трассировка будет выполняться только для выбранных узлов. При отключении этой функции трассировка будет выполняться для всех узлов.",
     "node_details.air_utilization_tx": "Использование эфира TX",
+    "node_details.noise_floor": "Уровень шума",
     "admin_commands.selected": "Выбранный",
     "detectionsensor_config.save_button": "Сохранить датчик обнаружения",
     "storeforward_config.title": "Хранение и пересылка",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -495,6 +495,7 @@
     "settings.analytics": "",
     "settings.solar_latitude_description": "",
     "node_details.air_utilization_tx": "",
+    "node_details.noise_floor": "",
     "hardware.tbeam_v0p7": "",
     "messages.scan_for_admin": "",
     "common.show_more": "",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -1842,6 +1842,7 @@
     "node_details.signal_rssi": "信号（RSSI）",
     "node_details.channel_utilization": "频道占用",
     "node_details.air_utilization_tx": "空中占用（发送）",
+    "node_details.noise_floor": "噪声基底",
     "node_details.uptime": "运行时长",
     "node_details.node_id": "节点 ID",
     "node_details.role": "角色",

--- a/src/components/NodeDetailsBlock.noiseFloor.test.tsx
+++ b/src/components/NodeDetailsBlock.noiseFloor.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for issue #4109 — the Node Details quick-stats grid shows
+ * a Noise Floor card (dBm) alongside Channel Utilization / Air Utilization TX
+ * whenever `deviceMetrics.noiseFloor` is populated, and omits it otherwise.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import NodeDetailsBlock from './NodeDetailsBlock';
+import type { DeviceInfo } from '../types/device';
+
+// See NodeDetailsBlock.position.test.tsx for rationale on these stubs.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, def?: string) => def ?? key }),
+}));
+vi.mock('../hooks/useServerData', () => ({
+  useChannels: () => ({ channels: [] }),
+  useDeviceConfig: () => ({ currentNodeId: null }),
+}));
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => ({ nodeHopsCalculation: 'client' }),
+}));
+vi.mock('../contexts/MapContext', () => ({
+  useMapContext: () => ({ traceroutes: [] }),
+}));
+vi.mock('./NodeDetailsBlock.css', () => ({}));
+
+const baseNode: DeviceInfo = {
+  nodeNum: 123,
+  user: { id: '!0000007b', longName: 'Node', shortName: 'N', role: 'CLIENT' },
+};
+
+describe('NodeDetailsBlock noise floor card (#4109)', () => {
+  it('renders the Noise Floor card with a formatted dBm value', () => {
+    render(
+      <NodeDetailsBlock
+        node={{ ...baseNode, deviceMetrics: { noiseFloor: -97 } }}
+      />,
+    );
+    expect(screen.getByText('node_details.noise_floor')).toBeInTheDocument();
+    expect(screen.getByText('-97 dBm')).toBeInTheDocument();
+  });
+
+  it('omits the Noise Floor card when noiseFloor is undefined', () => {
+    render(
+      <NodeDetailsBlock
+        node={{ ...baseNode, deviceMetrics: { batteryLevel: 80 } }}
+      />,
+    );
+    expect(screen.queryByText('node_details.noise_floor')).not.toBeInTheDocument();
+  });
+
+  it('omits the Noise Floor card when deviceMetrics is absent entirely', () => {
+    render(<NodeDetailsBlock node={baseNode} />);
+    expect(screen.queryByText('node_details.noise_floor')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -285,6 +285,16 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
             </div>
           )}
 
+          {/* Noise Floor */}
+          {deviceMetrics?.noiseFloor !== undefined && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">{t('node_details.noise_floor')}</div>
+              <div className="node-detail-value">
+                {formatRSSI(deviceMetrics.noiseFloor)}
+              </div>
+            </div>
+          )}
+
           {/* Uptime */}
           {deviceMetrics?.uptimeSeconds !== undefined && (
             <div className="node-detail-card">

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -13957,21 +13957,23 @@ class MeshtasticManager implements ISourceManager {
 
   // Async version that fetches uptimes in a single bulk query - works with all DB backends
   async getAllNodesAsync(sourceId?: string): Promise<DeviceInfo[]> {
-    const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes(
-      'uptimeSeconds',
-      sourceId,
-    );
+    const [uptimeMap, noiseFloorMap] = await Promise.all([
+      databaseService.telemetry.getLatestTelemetryValueForAllNodes('uptimeSeconds', sourceId),
+      databaseService.telemetry.getLatestTelemetryValueForAllNodes('noiseFloor', sourceId),
+    ]);
     // intentional cross-source when sourceId omitted: caller wants unified view across all sources
     const dbNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
     // Without a sourceId the caller wants the unified view, so collapse the
     // per-source rows into one entry per nodeNum. Issue #3135.
     const effective = sourceId ? dbNodes : mergeNodesAcrossSources(dbNodes);
-    return effective.map(node => this.mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId)));
+    return effective.map(node =>
+      this.mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId), noiseFloorMap.get(node.nodeId)),
+    );
   }
 
 
   // Shared mapping logic for converting a DB node to DeviceInfo
-  private mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number): DeviceInfo {
+  private mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number, noiseFloor?: number): DeviceInfo {
       const deviceInfo: any = {
         nodeNum: node.nodeNum,
         user: {
@@ -13986,7 +13988,8 @@ class MeshtasticManager implements ISourceManager {
           voltage: node.voltage,
           channelUtilization: node.channelUtilization,
           airUtilTx: node.airUtilTx,
-          uptimeSeconds
+          uptimeSeconds,
+          noiseFloor
         },
         lastHeard: node.lastHeard,
         snr: node.snr,

--- a/src/server/utils/dbNodeMapper.ts
+++ b/src/server/utils/dbNodeMapper.ts
@@ -18,7 +18,7 @@ import { mergeNodesAcrossSources } from './mergeNodesAcrossSources.js';
 import type { DeviceInfo } from '../meshtasticManager.js';
 import { logger } from '../../utils/logger.js';
 
-export function mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number): DeviceInfo {
+export function mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number, noiseFloor?: number): DeviceInfo {
   const deviceInfo: any = {
     nodeNum: node.nodeNum,
     user: {
@@ -34,6 +34,7 @@ export function mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number): Device
       channelUtilization: node.channelUtilization,
       airUtilTx: node.airUtilTx,
       uptimeSeconds,
+      noiseFloor,
     },
     lastHeard: node.lastHeard,
     snr: node.snr,
@@ -138,12 +139,14 @@ export function mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number): Device
  * `mergeNodesAcrossSources` (issue #3135).
  */
 export async function loadAllNodesAsDeviceInfo(sourceId?: string): Promise<DeviceInfo[]> {
-  const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes(
-    'uptimeSeconds',
-    sourceId,
-  );
+  const [uptimeMap, noiseFloorMap] = await Promise.all([
+    databaseService.telemetry.getLatestTelemetryValueForAllNodes('uptimeSeconds', sourceId),
+    databaseService.telemetry.getLatestTelemetryValueForAllNodes('noiseFloor', sourceId),
+  ]);
   // intentional cross-source when sourceId omitted: caller wants unified view across all sources
   const dbNodes = await databaseService.nodes.getAllNodes(sourceId ?? ALL_SOURCES);
   const effective = sourceId ? dbNodes : mergeNodesAcrossSources(dbNodes);
-  return effective.map(node => mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId)));
+  return effective.map(node =>
+    mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId), noiseFloorMap.get(node.nodeId)),
+  );
 }

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -19,6 +19,8 @@ export interface DeviceInfo {
     channelUtilization?: number;
     airUtilTx?: number;
     uptimeSeconds?: number;
+    /** Radio noise floor in dBm, from LocalStats telemetry (#3396). */
+    noiseFloor?: number;
   };
   hopsAway?: number;
   lastMessageHops?: number; // Hops from most recent packet (hopStart - hopLimit)


### PR DESCRIPTION
Closes #4109

## Summary

Adds a **Noise Floor** card (dBm) to the Node Details quick-stats grid, alongside the existing Channel Utilization / Air Utilization TX cards, using the same conditional-render pattern and reusing `formatRSSI`.

## Plumbing

`noiseFloor` is not a `nodes`-table column — it lives in the `telemetry` table as LocalStats `noiseFloor` rows (wired in #3396). The node-list assembly now bulk-fetches the latest `noiseFloor` per node (same `getLatestTelemetryValueForAllNodes` pattern already used for `uptimeSeconds`, run in parallel via `Promise.all`) and threads it into `deviceMetrics`:

- `src/server/meshtasticManager.ts` — `getAllNodesAsync` + private `mapDbNodeToDeviceInfo`
- `src/server/utils/dbNodeMapper.ts` — shared `loadAllNodesAsDeviceInfo` / `mapDbNodeToDeviceInfo` (MQTT broker/bridge managers)
- `src/types/device.ts` — `DeviceInfo.deviceMetrics.noiseFloor?: number`

## UI

- `src/components/NodeDetailsBlock.tsx` — Noise Floor card rendered only when `deviceMetrics.noiseFloor !== undefined`, formatted with `formatRSSI` (dBm).

## i18n

`node_details.noise_floor` added to all 10 locale files, placed after `node_details.air_utilization_tx`. Translated for en ("Noise Floor"), fr, ru, pl, zh_Hans; empty string for de/es/nb_NO/pt_BR/sv, matching those files where every `node_details.*` key is untranslated.

## Tests

- New `src/components/NodeDetailsBlock.noiseFloor.test.tsx`: card renders with formatted dBm value; absent when `noiseFloor` undefined; absent when `deviceMetrics` missing.
- Full vitest suite: 10298 tests, 0 failures (`success: true` via JSON reporter).
- `npm run lint:ci` exit 0; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1