### PR TITLE
fix(map): spiderfy no longer selects a nearby unrelated node instead of fanning the cluster (#4199)

### DIFF
--- a/src/hooks/useMarkerSpiderfier.grouping.test.tsx
+++ b/src/hooks/useMarkerSpiderfier.grouping.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+/**
+ * Real-OMS grouping regression tests for issue #4199 (Map Analysis spiderfy
+ * click opening the popup of / selecting a nearby unrelated node instead of
+ * fanning out the intended cluster).
+ *
+ * The other spiderfier test (`useMarkerSpiderfier.test.tsx`) mocks
+ * `OverlappingMarkerSpiderfier` to test the hook's OWN bookkeeping, and its
+ * header explicitly notes it "can't prove real fan geometry" — so it cannot
+ * catch a regression in OMS's grouping decision itself. These tests exercise
+ * the REAL vendored library against `SHARED_SPIDERFIER_OPTIONS` with a fake
+ * Leaflet map whose `latLngToLayerPoint` is a fixed linear projection, so
+ * `nearbyDistance` translates to a known pixel geometry.
+ *
+ * OMS decides a marker's group by comparing each registered marker's current
+ * `getLatLng()` (projected to layer pixels) against the CLICKED marker's, and:
+ *   - if the clicked marker is alone within `nearbyDistance` px -> fires 'click'
+ *     (which the consumer turns into openPopup + select);
+ *   - otherwise -> spiderfies the whole within-radius group.
+ * The #4199 bug was that `nearbyDistance` was 50px — wide enough to sweep in a
+ * genuinely-separate node ~40px away. These tests pin the corrected geometry.
+ */
+import { describe, it, expect } from 'vitest';
+import L from 'leaflet';
+import { OverlappingMarkerSpiderfier } from 'ts-overlapping-marker-spiderfier-leaflet';
+import { SHARED_SPIDERFIER_OPTIONS } from './useMarkerSpiderfier';
+
+// 0.001 degrees of lng == 1 layer pixel. Latitude flips sign so the projection
+// is a plain, invertible linear map (enough for OMS's distance math).
+const SCALE = 1000;
+
+/** Fake Leaflet map: only the surface OMS touches, with a linear projection. */
+function makeFakeMap(): L.Map {
+  const map = {
+    // OMS registers 'click'/'zoomend' -> unspiderfy in its constructor.
+    addEventListener() {
+      return map;
+    },
+    removeEventListener() {
+      return map;
+    },
+    latLngToLayerPoint(ll: L.LatLng) {
+      return L.point(ll.lng * SCALE, -ll.lat * SCALE);
+    },
+    layerPointToLatLng(pt: L.Point) {
+      return L.latLng(-pt.y / SCALE, pt.x / SCALE);
+    },
+    hasLayer() {
+      return true;
+    },
+    addLayer() {
+      return map;
+    },
+    removeLayer() {
+      return map;
+    },
+  };
+  return map as unknown as L.Map;
+}
+
+/** A marker `px` pixels east of lng origin at the given lat-derived y (0 by default). */
+function markerAtPx(xPx: number, yPx = 0): L.Marker {
+  return L.marker([-yPx / SCALE, xPx / SCALE]);
+}
+
+interface ClickOutcome {
+  /** The group OMS fanned out, or null if it fired a standalone 'click'. */
+  spiderfied: L.Marker[] | null;
+  /** The marker OMS treated as a standalone click, or null if it fanned. */
+  clicked: L.Marker | null;
+}
+
+function buildOms(markers: L.Marker[], nearbyDistance?: number) {
+  const oms = new OverlappingMarkerSpiderfier(
+    makeFakeMap(),
+    nearbyDistance == null
+      ? SHARED_SPIDERFIER_OPTIONS
+      : { ...SHARED_SPIDERFIER_OPTIONS, nearbyDistance },
+  );
+  for (const m of markers) oms.addMarker(m);
+  return oms;
+}
+
+/** Simulate a real marker click (what OMS's own per-marker listener receives). */
+function click(oms: OverlappingMarkerSpiderfier, marker: L.Marker): ClickOutcome {
+  const outcome: ClickOutcome = { spiderfied: null, clicked: null };
+  oms.addListener('spiderfy', (spiderfied: L.Marker[]) => {
+    outcome.spiderfied = spiderfied;
+  });
+  oms.addListener('click', (m: L.Marker) => {
+    outcome.clicked = m;
+  });
+  marker.fire('click', { target: marker });
+  return outcome;
+}
+
+describe('OMS grouping geometry with SHARED_SPIDERFIER_OPTIONS (#4199)', () => {
+  it('does not sweep an unrelated node ~40px away into a tight cluster', () => {
+    const a = markerAtPx(0); // cluster
+    const b = markerAtPx(5); // cluster (5px from a)
+    const unrelated = markerAtPx(40); // separate node, 40px from the cluster
+    const oms = buildOms([a, b, unrelated]);
+
+    const { spiderfied } = click(oms, a);
+
+    expect(spiderfied).not.toBeNull();
+    expect(spiderfied).toContain(a);
+    expect(spiderfied).toContain(b);
+    // The regression: at the old 50px radius `unrelated` (40px away) was pulled
+    // into the fan; at 20px it is correctly excluded.
+    expect(spiderfied).not.toContain(unrelated);
+    expect(spiderfied).toHaveLength(2);
+  });
+
+  it('clicking the unrelated node fans nothing and selects only itself', () => {
+    const a = markerAtPx(0);
+    const b = markerAtPx(5);
+    const unrelated = markerAtPx(40);
+    const oms = buildOms([a, b, unrelated]);
+
+    const { spiderfied, clicked } = click(oms, unrelated);
+
+    // Nothing within 20px of `unrelated` -> standalone 'click' on it only, never
+    // a fan that drags in the far-away cluster.
+    expect(spiderfied).toBeNull();
+    expect(clicked).toBe(unrelated);
+  });
+
+  it('still fans exact-coincident markers (estimated-position / multi-source piles)', () => {
+    const a = markerAtPx(0);
+    const b = markerAtPx(0); // identical coordinates
+    const oms = buildOms([a, b]);
+
+    const { spiderfied } = click(oms, a);
+
+    expect(spiderfied).not.toBeNull();
+    expect(spiderfied).toHaveLength(2);
+    expect(spiderfied).toContain(a);
+    expect(spiderfied).toContain(b);
+  });
+
+  it('still fans a tight same-cell pile that overlaps within a marker width', () => {
+    // Three obscured nodes whose within-cell offsets sit within ~15px at a low
+    // zoom where their icons overlap.
+    const a = markerAtPx(0);
+    const b = markerAtPx(8, 6);
+    const c = markerAtPx(14, -4);
+    const oms = buildOms([a, b, c]);
+
+    const { spiderfied } = click(oms, a);
+
+    expect(spiderfied).not.toBeNull();
+    expect(spiderfied).toHaveLength(3);
+  });
+
+  it('documents that the old 50px radius WOULD have grouped the unrelated node (why #4199 lowered it)', () => {
+    const a = markerAtPx(0);
+    const b = markerAtPx(5);
+    const unrelated = markerAtPx(40);
+    const oms = buildOms([a, b, unrelated], 50);
+
+    const { spiderfied } = click(oms, a);
+
+    expect(spiderfied).not.toBeNull();
+    // At 50px the 40px-away node is (incorrectly) part of the fan — the bug.
+    expect(spiderfied).toContain(unrelated);
+    expect(spiderfied).toHaveLength(3);
+  });
+});
+
+describe('SHARED_SPIDERFIER_OPTIONS.nearbyDistance (#4199 guard)', () => {
+  it('is small enough to match genuine icon overlap, not a wide screen radius', () => {
+    // Locks the fix: a value back up near the old 50px would re-open #4199.
+    expect(SHARED_SPIDERFIER_OPTIONS.nearbyDistance).toBeLessThanOrEqual(25);
+    // Still large enough to catch (near-)coincident markers reliably.
+    expect(SHARED_SPIDERFIER_OPTIONS.nearbyDistance).toBeGreaterThanOrEqual(15);
+  });
+});

--- a/src/hooks/useMarkerSpiderfier.ts
+++ b/src/hooks/useMarkerSpiderfier.ts
@@ -37,16 +37,40 @@ interface SpiderfierInternals {
  * identically everywhere (issue #3612).
  *
  * These values come from the per-source NodesTab map (`SpiderfierController`),
- * which is the working reference. A 50px `nearbyDistance` is deliberately
- * larger than the library default (20px) so that co-located nodes — including
- * estimated-position nodes that collapse onto the same anchor point — are
- * reliably grouped and separable.
+ * which is the working reference.
+ *
+ * `nearbyDistance` (issue #4199): the pixel radius OMS uses to decide, at click
+ * time, which registered markers belong to the clicked marker's group — it
+ * compares each marker's CURRENT `getLatLng()` (in layer pixels) against the
+ * clicked marker's, purely by screen proximity. This was 50px, which is 2.5x
+ * the library default (20px) and far wider than a marker's icon-overlap zone.
+ * At that radius OMS pulled in — and, on a standalone hit, selected/opened the
+ * popup of — a genuinely-separate, unrelated node that merely happened to sit
+ * within 50px on screen, instead of fanning out the pile the user aimed at.
+ * #4155 made this reachable in more places: a node alone in its precision cell
+ * now renders at its true reported center (it used to always be jittered within
+ * the cell), so an unrelated node can land at a fixed point close to an
+ * intended cluster.
+ *
+ * 20px still reliably groups every pile that genuinely needs fanning, because
+ * those are always within ~a marker's width of each other on screen:
+ *  - exact-coincident anchors (estimated-position nodes, multi-source nodes at
+ *    identical coords) are 0px apart — caught by any radius >= 1;
+ *  - same-precision-cell piles overlap visually only at the low zooms where the
+ *    accuracy cell (and thus the #4016 within-cell offset spread) collapses to a
+ *    few pixels — also well within 20px. At higher zoom the within-cell offset
+ *    already declutters them, so they no longer need a click to separate.
+ * Markers 20-50px apart are visually distinct and individually clickable, so
+ * excluding them from the group is the correct behavior, not a regression.
  */
 export const SHARED_SPIDERFIER_OPTIONS: SpiderfierOptions = {
   /** Keep markers fanned out after clicking so each is individually selectable. */
   keepSpiderfied: true,
-  /** Pixel radius for detecting overlapping markers — 50px catches markers at (near-)identical coords. */
-  nearbyDistance: 50,
+  /** Pixel radius for detecting overlapping markers — matches genuine icon
+   *  overlap so a separate node up to 50px away isn't grouped/selected in place
+   *  of the intended pile (issue #4199). (Near-)identical coords are 0px apart
+   *  and always caught. */
+  nearbyDistance: 20,
   /** Number of markers before switching from circle to spiral layout. */
   circleSpiralSwitchover: 9,
   /** Distance between markers in circle layout (pixels). */


### PR DESCRIPTION
## Summary

Fixes #4199 — on Map Analysis (and every shared-layer map), clicking a cluster of nodes sometimes snapped to / opened the popup of a nearby **unrelated** node instead of fanning out the intended pile.

Closes #4199.

## Root cause (confirmed)

`OverlappingMarkerSpiderfier` decides a marker's group at click time **purely by screen proximity** — it projects every registered marker's current `getLatLng()` to layer pixels and compares against the clicked marker's, within `nearbyDistance`:

```
if (nearbyMarkerData.length === 1) trigger('click', marker); // -> select + openPopup
else                               spiderfy(group);           // -> fan out
```

`SHARED_SPIDERFIER_OPTIONS.nearbyDistance` was **50px** — 2.5× the library default (20px) and far wider than a marker's icon-overlap zone. At that radius OMS pulled a genuinely-separate node (up to 50px away on screen) into the clicked marker's group, or — when that separate node itself received the Leaflet click — selected it and opened its popup instead of fanning the cluster.

**#4155 link (verified):** a node alone in its precision cell now renders at its true reported center (it used to always be jittered within the cell), so an unrelated node can sit at a fixed point close to an intended cluster — making the 50px over-reach hit more often.

## Fix

Lower `nearbyDistance` to **20px**. This still reliably groups every pile that genuinely needs fanning:
- **exact-coincident anchors** (estimated-position nodes, multi-source nodes at identical coords) are 0px apart — caught by any radius ≥ 1;
- **same-precision-cell piles** overlap visually only at the low zooms where the #4016 within-cell offset collapses to a few pixels — well within 20px. At higher zoom the within-cell offset already declutters them.

Markers 20–50px apart are visually distinct and individually clickable, so excluding them from the group is correct behavior, not a regression. Change is in the shared options, so all map surfaces get the consistent fix (#3612 "identical everywhere").

## Tests

Adds `src/hooks/useMarkerSpiderfier.grouping.test.tsx` — a **real-OMS** grouping test (the existing `useMarkerSpiderfier.test.tsx` mocks OMS and, per its own header, "can't prove real fan geometry", so it can't catch grouping regressions). It drives the actual vendored library through a fake Leaflet map with a fixed linear projection and asserts:
- a 40px-away unrelated node is **not** swept into a tight cluster;
- clicking that unrelated node fans nothing and selects only itself;
- exact-coincident and tight same-cell piles **still** fan;
- a control case proving the old 50px radius *would* have grouped the 40px node (why #4199 lowered it);
- a guard pinning `nearbyDistance` in the 15–25px range.

Full vitest suite green (3125 suites, 0 failures), `tsc --noEmit` clean, `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1