### PR TITLE
fix(messages): stop unsynced-RTC nodes rendering chat at ~1970

### DIFF
--- a/src/server/meshtasticManager.duplicate-message.test.ts
+++ b/src/server/meshtasticManager.duplicate-message.test.ts
@@ -279,6 +279,27 @@ describe('MeshtasticManager - Duplicate message suppression', () => {
       );
     });
 
+    it('drops a small nonzero boot-uptime rxTime instead of storing it (unsynced RTC, #4206)', async () => {
+      // Regression: a node without a valid RTC reports rxTime as seconds-since-boot
+      // (e.g. 114571s), which is nonzero and would previously be stored verbatim.
+      // Must be filtered the same way mqttIngestion.ts filters it at ingestion,
+      // so the DB doesn't accumulate implausible rxTime values.
+      mockInsertMessage.mockReturnValue(true);
+
+      const packet = { ...makeMeshPacket(0x11223344, 0xffffffff), rxTime: 114_571 };
+      await (manager as any).processTextMessageProtobuf(packet, 'Boot-uptime clock');
+
+      expect(mockInsertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rxTime: undefined,
+          timestamp: expect.any(Number),
+        }),
+        expect.anything()
+      );
+      const inserted = mockInsertMessage.mock.calls[0][0];
+      expect(inserted.timestamp).toBeGreaterThan(1_600_000_000_000);
+    });
+
     it('should emit correct message data to WebSocket when new', async () => {
       mockInsertMessage.mockReturnValue(true);
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -50,7 +50,7 @@ import { resolveLastHopName } from './utils/lastHop.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
 import { autoAckIsZeroHop, autoAckCellKey, resolveAutoAckReplyRouting } from './utils/autoAckDecision.js';
 import { scriptDependencyEnv } from './utils/scriptRunner.js';
-import { canonicalMessageTime } from './utils/messageTime.js';
+import { canonicalMessageTime, plausibleRxTime } from './utils/messageTime.js';
 import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
 import { isNodeComplete } from '../utils/nodeHelpers.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
@@ -5813,7 +5813,11 @@ class MeshtasticManager implements ISourceManager {
           // undefined (not Date.now()) when the device didn't report a time —
           // matches the MQTT ingestion convention so `rxTime` never conflates
           // "no device time" with "server time" (review follow-up on #4206).
-          rxTime: meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : undefined,
+          // Also filtered through plausibleRxTime so an unsynced-RTC node's
+          // boot-uptime value never lands in the DB, matching the MQTT path
+          // (mqttIngestion.ts) rather than relying solely on the display-time
+          // fallback in canonicalMessageTime().
+          rxTime: plausibleRxTime(meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : undefined) ?? undefined,
           hopStart: hopStart,
           hopLimit: hopLimit,
           relayNode: meshPacket.relayNode ?? undefined, // Last byte of the node that relayed this message

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -365,7 +365,7 @@ type TextMessage = {
   portnum: 1; // TEXT_MESSAGE_APP
   requestId?: number; // For Virtual Node messages, preserve packet ID for ACK matching
   timestamp: number;
-  rxTime: number;
+  rxTime?: number;
   hopStart?: number;
   hopLimit?: number;
   relayNode?: number; // Last byte of the node that relayed this message
@@ -5810,7 +5810,10 @@ class MeshtasticManager implements ISourceManager {
           // implausible ~1970 value as `timestamp` too, defeating the display
           // fallback in canonicalMessageTime() (#4206).
           timestamp: Date.now(),
-          rxTime: meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : Date.now(),
+          // undefined (not Date.now()) when the device didn't report a time —
+          // matches the MQTT ingestion convention so `rxTime` never conflates
+          // "no device time" with "server time" (review follow-up on #4206).
+          rxTime: meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : undefined,
           hopStart: hopStart,
           hopLimit: hopLimit,
           relayNode: meshPacket.relayNode ?? undefined, // Last byte of the node that relayed this message

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5802,7 +5802,14 @@ class MeshtasticManager implements ISourceManager {
           text: messageText,
           channel: channelIndex,
           portnum: PortNum.TEXT_MESSAGE_APP,
-          timestamp: meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : Date.now(),
+          // Server receipt time, always — matches the MQTT ingestion path
+          // (mqttIngestion.ts) and the telemetry convention (raw device time
+          // preserved separately, never used as the canonical `timestamp`).
+          // Previously this mirrored `rxTime`, so a node with an unsynced RTC
+          // (reporting seconds-since-boot instead of epoch seconds) stored an
+          // implausible ~1970 value as `timestamp` too, defeating the display
+          // fallback in canonicalMessageTime() (#4206).
+          timestamp: Date.now(),
           rxTime: meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : Date.now(),
           hopStart: hopStart,
           hopLimit: hopLimit,

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -648,6 +648,17 @@ describe('ingestServiceEnvelope — TEXT_MESSAGE_APP rxTime', () => {
     expect(inserted.timestamp).toBeGreaterThan(0);
   });
 
+  it('drops a small nonzero boot-uptime rxTime (unsynced RTC, #4206)', async () => {
+    // Regression: a node without a valid RTC reports rxTime as seconds-since-boot
+    // (e.g. 114571s), which passes the old `rxTime > 0` guard and would resolve
+    // to ~1970-01-02 in the unified view. Must be dropped the same as rxTime === 0.
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: textEnvelope(114_571) });
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.rxTime).toBeUndefined();
+    expect(inserted.timestamp).toBeGreaterThan(0);
+  });
+
   it('preserves a real rxTime, converting seconds to milliseconds', async () => {
     const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: textEnvelope(1_700_000_000) });
     expect(result.ingested).toBe(true);

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -92,6 +92,7 @@ import { calculateDistance } from '../utils/distance.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
+import { plausibleRxTime } from './utils/messageTime.js';
 import { shouldDiscardPosition } from '../utils/nullIsland.js';
 import { getDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
 import { logger } from '../utils/logger.js';
@@ -442,11 +443,13 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
         channel: messageChannel,
         portnum,
         timestamp: nowMs,
-        // Guard against rxTime === 0: MQTT gateway packets frequently arrive
-        // with an unset (0) receive time. Storing 0 makes the unified view's
-        // `rxTime ?? timestamp` canonical resolve to Unix epoch (Dec 31 1969).
-        // Treat anything <= 0 as "no rxTime" so display falls back to timestamp.
-        rxTime: typeof packet.rxTime === 'number' && packet.rxTime > 0 ? packet.rxTime * 1000 : undefined,
+        // Guard against an implausible rxTime: MQTT gateway packets frequently
+        // arrive with an unset (0) receive time, and unsynced-RTC nodes report
+        // a small nonzero boot-uptime value instead. Either would make the
+        // unified view's canonical resolve land on an early-1970 date, so
+        // plausibleRxTime (shared with canonicalMessageTime, #4206) filters
+        // both out at ingestion rather than only at display time.
+        rxTime: plausibleRxTime(typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined) ?? undefined,
         rxSnr: typeof packet.rxSnr === 'number' ? packet.rxSnr : undefined,
         rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
         viaMqtt: true,
@@ -992,9 +995,10 @@ async function ingestStoreForward(
       channel: effectiveChannel,
       portnum: PortNum.TEXT_MESSAGE_APP,
       timestamp: nowMs,
-      // See TEXT_MESSAGE_APP case: drop rxTime === 0 (unset gateway time) so it
-      // doesn't render as Unix epoch in the unified view's canonical timestamp.
-      rxTime: typeof packet.rxTime === 'number' && packet.rxTime > 0 ? packet.rxTime * 1000 : undefined,
+      // See TEXT_MESSAGE_APP case: drop an implausible rxTime (unset gateway
+      // time, or an unsynced-RTC node's boot-uptime value) so it doesn't
+      // render as an early-1970 date via the unified view's canonical timestamp.
+      rxTime: plausibleRxTime(typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined) ?? undefined,
       rxSnr: typeof packet.rxSnr === 'number' ? packet.rxSnr : undefined,
       rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
       viaMqtt: true,

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -19,6 +19,7 @@ import {
   canReadVirtualChannel,
 } from '../utils/virtualChannelPermissions.js';
 import { buildSourceDashboard, getMaxNodeAgeHours } from '../services/sourceDashboardData.js';
+import { canonicalMessageTime, plausibleRxTime } from '../utils/messageTime.js';
 import type { DbChannelDatabase, DbPacketLog } from '../../db/types.js';
 import type { DbMeshCorePacket } from '../../db/repositories/meshcore.js';
 
@@ -702,12 +703,13 @@ router.get('/messages', async (req: Request, res: Response) => {
         }
 
         for (const m of msgs) {
-          // Treat rxTime <= 0 as missing, not as a real device time. MQTT
-          // gateway packets can carry rxTime === 0 (unset receive time); a
-          // plain `rxTime ?? timestamp` would pick 0 (nullish coalescing only
-          // falls through on null/undefined) and render Unix epoch (Dec 1969).
-          const rxTime = typeof m.rxTime === 'number' && m.rxTime > 0 ? m.rxTime : null;
-          const canonical = (rxTime ?? m.timestamp) as number;
+          // Resolve through the shared helpers so this view's dedup timestamp
+          // and per-reception rxTime use the same implausible-rxTime guard as
+          // message display (#4206, building on #3263) — an MQTT unset rxTime
+          // of 0, or an unsynced-RTC node's small boot-uptime value, must not
+          // win over the real timestamp.
+          const canonical = canonicalMessageTime(m);
+          const rxTime = plausibleRxTime(m.rxTime);
           const reqId = (m.requestId ?? null) as number | null;
           const fromNum = Number(m.fromNodeNum);
           // Dedup key priority:

--- a/src/server/utils/messageTime.test.ts
+++ b/src/server/utils/messageTime.test.ts
@@ -20,6 +20,18 @@ describe('canonicalMessageTime', () => {
   it('treats a negative rxTime as missing', () => {
     expect(canonicalMessageTime({ rxTime: -5, timestamp: 99 })).toBe(99);
   });
+
+  it('falls back to timestamp when rxTime is a small nonzero boot-uptime value (unsynced RTC, #4206)', () => {
+    // Regression: a node without a valid RTC reports rxTime as seconds-since-boot
+    // (e.g. 114571s -> 114571000ms, ~1970-01-02), which is nonzero and would pass
+    // a naive `rxTime > 0` check. Must fall back to the server timestamp instead
+    // of rendering an early-1970 date.
+    expect(canonicalMessageTime({ rxTime: 114_571_000, timestamp: 1_700_000_000_000 })).toBe(1_700_000_000_000);
+  });
+
+  it('accepts a plausible rxTime just above the floor', () => {
+    expect(canonicalMessageTime({ rxTime: 1_577_836_800_001, timestamp: 1 })).toBe(1_577_836_800_001);
+  });
 });
 
 describe('messageReceivedAt', () => {

--- a/src/server/utils/messageTime.test.ts
+++ b/src/server/utils/messageTime.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { canonicalMessageTime, messageReceivedAt } from './messageTime.js';
+import { canonicalMessageTime, messageReceivedAt, plausibleRxTime } from './messageTime.js';
+
+describe('plausibleRxTime', () => {
+  it('returns a plausible rxTime unchanged', () => {
+    expect(plausibleRxTime(1_700_000_000_000)).toBe(1_700_000_000_000);
+  });
+
+  it('returns null for 0, a boot-uptime value, negative, null, or undefined', () => {
+    expect(plausibleRxTime(0)).toBeNull();
+    expect(plausibleRxTime(114_571_000)).toBeNull();
+    expect(plausibleRxTime(-5)).toBeNull();
+    expect(plausibleRxTime(null)).toBeNull();
+    expect(plausibleRxTime(undefined)).toBeNull();
+  });
+});
 
 describe('canonicalMessageTime', () => {
   it('prefers a positive rxTime over timestamp', () => {
@@ -43,5 +57,11 @@ describe('messageReceivedAt', () => {
     // createdAt missing AND rxTime 0 → must land on timestamp, not epoch.
     expect(messageReceivedAt({ createdAt: null, rxTime: 0, timestamp: 1000 })).toBe(1000);
     expect(messageReceivedAt({ rxTime: 0, timestamp: 1000 })).toBe(1000);
+  });
+
+  it('falls back through the chain without leaking a boot-uptime rxTime (#4206)', () => {
+    expect(
+      messageReceivedAt({ createdAt: null, rxTime: 114_571_000, timestamp: 1_700_000_000_000 })
+    ).toBe(1_700_000_000_000);
   });
 });

--- a/src/server/utils/messageTime.ts
+++ b/src/server/utils/messageTime.ts
@@ -1,12 +1,33 @@
 /**
+ * Floor below which a device-reported `rxTime` cannot be a real wall-clock
+ * receive time (2020-01-01T00:00:00Z, in ms). A node with an unsynced RTC
+ * reports seconds-since-boot instead of epoch seconds — a small nonzero value
+ * (e.g. 114571) that multiplies out to a date in early January 1970. That
+ * passes a plain `rxTime > 0` check, so the floor catches it the same way the
+ * exact-zero guard catches an unset gateway time (#4206, building on #3263).
+ */
+const MIN_PLAUSIBLE_RXTIME_MS = 1_577_836_800_000; // 2020-01-01T00:00:00Z
+
+/**
+ * A message's `rxTime` if it is plausible (above the floor), else `null`.
+ * Used where the raw device receive time is surfaced per-reception (e.g. the
+ * unified view) rather than resolved against `timestamp`.
+ */
+export function plausibleRxTime(rxTime: number | null | undefined): number | null {
+  return typeof rxTime === 'number' && rxTime > MIN_PLAUSIBLE_RXTIME_MS ? rxTime : null;
+}
+
+/**
  * Canonical display time for a message row.
  *
  * Prefers the device receive time (`rxTime`) and falls back to the server
- * `timestamp`. The guard against `rxTime <= 0` is load-bearing: MQTT gateway
- * packets frequently arrive with an unset receive time of `0`, and a plain
- * `rxTime ?? timestamp` would pick that `0` (nullish coalescing only falls
- * through on null/undefined) and render the Unix epoch — "December 31, 1969".
- * Treating `<= 0` as missing makes such rows fall back to the server time.
+ * `timestamp`. The guard against an implausible `rxTime` is load-bearing:
+ * MQTT gateway packets and unsynced-RTC nodes frequently report a receive
+ * time that is `0` or a small boot-uptime value, and a plain
+ * `rxTime ?? timestamp` would pick that value (nullish coalescing only falls
+ * through on null/undefined) and render a date in early 1970. Treating
+ * anything below the floor as missing makes such rows fall back to the
+ * server time.
  *
  * Mirrors the same guard applied at the unified-view canonical computation in
  * `routes/unifiedRoutes.ts` and at MQTT ingestion in `mqttIngestion.ts`.
@@ -15,13 +36,14 @@ export function canonicalMessageTime(msg: {
   rxTime?: number | null;
   timestamp: number;
 }): number {
-  return typeof msg.rxTime === 'number' && msg.rxTime > 0 ? msg.rxTime : msg.timestamp;
+  return plausibleRxTime(msg.rxTime) ?? msg.timestamp;
 }
 
 /**
  * Server-side ingest time used by clients for sort order (issue #3187), with
- * the same `rxTime <= 0` guard so a zero receive time can never leak through
- * the `createdAt ?? rxTime ?? timestamp` fallback chain as a 1969 epoch.
+ * the same implausible-rxTime guard so a bogus receive time can never leak
+ * through the `createdAt ?? rxTime ?? timestamp` fallback chain as an early
+ * 1970 date.
  */
 export function messageReceivedAt(msg: {
   createdAt?: number | null;


### PR DESCRIPTION
Closes #4206.

## Problem

Chat/text messages from nodes with an unsynced real-time clock render at ~1970-01-02 in the UI (Channels and DMs), even though MeshMonitor's own receipt time (`createdAt`) is correct.

## Root cause

A node without a valid RTC reports `rxTime` as seconds-since-boot (a small nonzero value, e.g. `114571`) instead of epoch seconds. That value:

1. Passed the exact-zero guard added in #3263 (`rxTime > 0`), because it's nonzero.
2. On the `meshtastic_tcp` ingestion path (`meshtasticManager.ts`), the same device value was stored as **both** `timestamp` and `rxTime` — so the canonical display resolve (`rxTime ?? timestamp`) had no correct value left to fall back to.

## Fix

- **`src/server/utils/messageTime.ts`** — widened the `canonicalMessageTime` / `messageReceivedAt` guard from "`rxTime` truthy" to "`rxTime` above a 2020-01-01 floor." This is the single point `server.ts` and `webSocketService.ts` already route outgoing display timestamps through, so the fix covers the TCP path, the MQTT path, and any future ingestion path that shares the same guard. Added `plausibleRxTime()` as the shared building block.
- **`src/server/meshtasticManager.ts`** (`TEXT_MESSAGE_APP` handler) — `timestamp` is now always `Date.now()` (server receipt time) rather than mirroring the device `rxTime`, matching the existing MQTT ingestion convention (`mqttIngestion.ts`) and the telemetry convention (raw device time kept separately, never used as the canonical `timestamp`). The raw device time is still preserved in `rxTime`.
- **`src/server/routes/unifiedRoutes.ts`** — replaced an inline duplicate of the old exact-zero guard with the shared `canonicalMessageTime` / `plausibleRxTime` helpers, so the unified cross-source view can't drift from the fix.

## Tests

- Added a regression test in `messageTime.test.ts` reproducing the exact repro value from the issue (`rxTime: 114_571_000` → falls back to `timestamp`).
- Added a companion "accepts a plausible rxTime just above the floor" test.
- Full existing suites for the touched files (`messageTime`, `unifiedRoutes`, `meshtasticManager.*`, `mqttIngestion`, `messages.*` repositories) pass — 0 failures.
- `tsc --noEmit` clean.
- `npm run lint:ci` (ratchet gate) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F5WunNkk4oJgw8oBLssKU

---
_Generated by [Claude Code](https://claude.ai/code/session_011F5WunNkk4oJgw8oBLssKU)_