### PR TITLE
chore: bump version to 4.13.1-rc4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.1-rc3",
+  "version": "4.13.1-rc4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.1-rc3",
+  "version": "4.13.1-rc4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.1-rc3
-appVersion: "4.13.1-rc3"
+version: 4.13.1-rc4
+appVersion: "4.13.1-rc4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1-rc3",
+  "version": "4.13.1-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.1-rc3",
+      "version": "4.13.1-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -3513,9 +3513,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3533,9 +3530,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3553,9 +3547,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3573,9 +3564,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3593,9 +3581,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3613,9 +3598,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3919,9 +3901,6 @@
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1-rc3",
+  "version": "4.13.1-rc4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps the version to **4.13.1-rc4** across all five version-of-record files, cutting the next release candidate ahead of the 4.13.1 final. This is the mechanical precursor to publishing the `v4.13.1-rc4` GitHub prerelease (matching the #4198 / #4142 pattern) — once merged, the release will be created targeting `main`.

## Version files updated

- `package.json` → `4.13.1-rc4`
- `package-lock.json` (regenerated via `npm install --package-lock-only`)
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json`

## What's rolled up since rc3

The 8 PRs merged to `main` since the rc3 bump (#4198) that this RC will ship:

**Features**
- #4200 — Meshtastic 2.8: `MEDIUM_TURBO` preset, `MESH_BEACON_APP` portnum, traffic-management & 2.8 opt-in docs
- #4205 — Pin 2.8-preview protobufs (`develop@ba16bfc`) with a 2.7 TrafficManagement compat shim
- #4207 — Decode `MESH_BEACON_APP` + firmware-verified preset channel names (#3854)
- #4209 — Packet Monitor: XEdDSA signature shield for firmware 2.8 packets (#3923)
- #4204 — Derived signal-trend / link-attenuation badge per node (#4110)
- #4201 — Show Noise Floor on the Node Detail quick-stats card (#4109)

**Bug Fixes**
- #4208 — Stop unsynced-RTC nodes rendering chat at ~1970
- #4203 — Spiderfy no longer selects a nearby unrelated node instead of fanning the cluster (#4199)

## Notes

- No functional code changes — version metadata only.
- The branch was restarted from the latest `main` (its prior PR content was already squash-merged via #4200), so this PR contains only the single bump commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWT7xu4GM2qJuGHwUm7RKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWT7xu4GM2qJuGHwUm7RKf)_