### PR TITLE
feat(settings): noIndexEnabled toggle for X-Robots-Tag + /robots.txt (#4202)

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -95,7 +95,7 @@ interface SettingsTabProps {
 }
 
 const GLOBAL_SECTIONS = new Set([
-  'settings-language', 'settings-units', 'settings-appearance', 'settings-link-previews', 'settings-meshcore-messaging', 'settings-map',
+  'settings-language', 'settings-units', 'settings-appearance', 'settings-link-previews', 'settings-privacy', 'settings-meshcore-messaging', 'settings-map',
   'settings-security',
   'settings-apprise-server', 'settings-elevation', 'settings-backup', 'settings-channel-database',
   'settings-maintenance', 'settings-analytics',
@@ -183,6 +183,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLinkPreviewsEnabled,
     discardInvalidPositions,
     setDiscardInvalidPositions,
+    noIndexEnabled,
+    setNoIndexEnabled,
     meshcoreChannelRetryEnabled,
     setMeshcoreChannelRetryEnabled,
     nodeDimmingEnabled,
@@ -251,6 +253,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localPacketLogMaxAgeHours, setLocalPacketLogMaxAgeHours] = useState(24);
   const [localLinkPreviewsEnabled, setLocalLinkPreviewsEnabled] = useState(linkPreviewsEnabled);
   const [localDiscardInvalidPositions, setLocalDiscardInvalidPositions] = useState(discardInvalidPositions);
+  const [localNoIndexEnabled, setLocalNoIndexEnabled] = useState(noIndexEnabled);
   const [localMeshcoreChannelRetryEnabled, setLocalMeshcoreChannelRetryEnabled] = useState(meshcoreChannelRetryEnabled);
   const [localSolarMonitoringEnabled, setLocalSolarMonitoringEnabled] = useState(solarMonitoringEnabled);
   const [localSolarMonitoringLatitude, setLocalSolarMonitoringLatitude] = useState(solarMonitoringLatitude);
@@ -367,6 +370,10 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           const discardInvalidOn = !(settings.discardInvalidPositions === '0' || settings.discardInvalidPositions === 'false');
           setLocalDiscardInvalidPositions(discardInvalidOn);
 
+          // Load no-index (#4202). Absent key => disabled.
+          const noIndexOn = settings.noIndexEnabled === '1' || settings.noIndexEnabled === 'true';
+          setLocalNoIndexEnabled(noIndexOn);
+
           // Load MeshCore channel-send auto-retry (#3979). Absent key => disabled.
           const meshcoreChannelRetryOn = settings.meshcoreChannelRetryEnabled === '1' || settings.meshcoreChannelRetryEnabled === 'true';
           setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryOn);
@@ -463,6 +470,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalDashboardSortOption(preferredDashboardSortOption);
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
     setLocalDiscardInvalidPositions(discardInvalidPositions);
+    setLocalNoIndexEnabled(noIndexEnabled);
     setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryEnabled);
     setLocalSolarMonitoringEnabled(solarMonitoringEnabled);
     setLocalSolarMonitoringLatitude(solarMonitoringLatitude);
@@ -535,6 +543,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringDeclination !== solarMonitoringDeclination ||
       localLinkPreviewsEnabled !== linkPreviewsEnabled ||
       localDiscardInvalidPositions !== discardInvalidPositions ||
+      localNoIndexEnabled !== noIndexEnabled ||
       localMeshcoreChannelRetryEnabled !== meshcoreChannelRetryEnabled ||
       localHideIncompleteNodes !== !showIncompleteNodes ||
       localHomoglyphEnabled !== initialHomoglyphEnabled ||
@@ -556,6 +565,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
       localLinkPreviewsEnabled, linkPreviewsEnabled,
       localDiscardInvalidPositions, discardInvalidPositions,
+      localNoIndexEnabled, noIndexEnabled,
       localMeshcoreChannelRetryEnabled, meshcoreChannelRetryEnabled,
       localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
       localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes,
@@ -604,6 +614,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
     setLocalDiscardInvalidPositions(discardInvalidPositions);
+    setLocalNoIndexEnabled(noIndexEnabled);
     setLocalMeshcoreChannelRetryEnabled(meshcoreChannelRetryEnabled);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
     setLocalHomoglyphEnabled(initialHomoglyphEnabled);
@@ -623,7 +634,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       dateFormat, mapTilesetLight, mapTilesetDark, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, mapCenterTargetZoom, defaultLandingPage, appearanceMode, darkTheme, lightTheme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
-      linkPreviewsEnabled, discardInvalidPositions, meshcoreChannelRetryEnabled,
+      linkPreviewsEnabled, discardInvalidPositions, noIndexEnabled, meshcoreChannelRetryEnabled,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialMeshcoreCliTimeoutSeconds, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl,
@@ -688,6 +699,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
         linkPreviewsEnabled: localLinkPreviewsEnabled ? '1' : '0',
         discardInvalidPositions: localDiscardInvalidPositions ? '1' : '0',
+        noIndexEnabled: localNoIndexEnabled ? '1' : '0',
         meshcoreChannelRetryEnabled: localMeshcoreChannelRetryEnabled ? '1' : '0',
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
         homoglyphEnabled: String(localHomoglyphEnabled),
@@ -746,6 +758,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringDeclinationChange(localSolarMonitoringDeclination);
       setLinkPreviewsEnabled(localLinkPreviewsEnabled);
       setDiscardInvalidPositions(localDiscardInvalidPositions);
+      setNoIndexEnabled(localNoIndexEnabled);
       setMeshcoreChannelRetryEnabled(localMeshcoreChannelRetryEnabled);
       setShowIncompleteNodes(!localHideIncompleteNodes);
 
@@ -780,7 +793,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localTimeFormat, localDateFormat, localMapTilesetLight, localMapTilesetDark, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localMapCenterTargetZoom, localDefaultLandingPage, localAppearanceMode, localDarkTheme, localLightTheme, getLocalEffectiveTheme, getLocalEffectiveTileset,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
-      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localDiscardInvalidPositions, setDiscardInvalidPositions, localMeshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes, localMeshcoreCliTimeoutSeconds,
+      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localLinkPreviewsEnabled, setLinkPreviewsEnabled, localDiscardInvalidPositions, setDiscardInvalidPositions, localNoIndexEnabled, setNoIndexEnabled, localMeshcoreChannelRetryEnabled, setMeshcoreChannelRetryEnabled, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes, localMeshcoreCliTimeoutSeconds,
       onMaxNodeAgeChange, onInactiveNodeThresholdHoursChange, onInactiveNodeCheckIntervalMinutesChange,
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
@@ -1221,6 +1234,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         { id: 'settings-sorting', label: t('settings.sorting') },
         { id: 'settings-appearance', label: t('settings.appearance') },
         { id: 'settings-link-previews', label: t('settings.link_previews', 'Link Previews') },
+        { id: 'settings-privacy', label: t('settings.privacy', 'Privacy') },
         { id: 'settings-meshcore-messaging', label: t('settings.meshcore_messaging', 'MeshCore Messaging') },
         { id: 'settings-map', label: t('settings.map') },
         { id: 'settings-node-display', label: t('settings.node_display') },
@@ -1521,6 +1535,23 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           </h3>
           <p className="setting-description">
             {t('settings.link_previews_description', 'When enabled, MeshMonitor fetches and displays a preview card (title, description, image) for the first URL in a message. The fetch is performed server-side. Disable this to stop all outbound requests to link targets — URLs still render as clickable text.')}
+          </p>
+        </div>}
+
+        {show('settings-privacy') && <div id="settings-privacy" className="settings-section">
+          <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={localNoIndexEnabled}
+                onChange={(e) => setLocalNoIndexEnabled(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>{t('settings.no_index_enabled', 'Discourage search engine & LLM indexing')}</span>
+            </label>
+          </h3>
+          <p className="setting-description">
+            {t('settings.no_index_description', 'When enabled, MeshMonitor adds an "X-Robots-Tag: noindex, nofollow" header to every response and serves a disallow-all /robots.txt, asking search engines and LLM crawlers not to index this dashboard. Both are advisory — a crawler must choose to honor them. The robots.txt body is served in addition to the header because some reverse proxies (e.g. Cloudflare tunnels) strip custom headers at the edge.')}
           </p>
         </div>}
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -126,6 +126,8 @@ interface SettingsContextType {
   linkPreviewsEnabled: boolean;
   /** Global Map toggle (default true): discard Null Island (0,0) fixes on ingest. */
   discardInvalidPositions: boolean;
+  /** Global privacy toggle (issue #4202, default false): emit X-Robots-Tag: noindex, nofollow + disallow-all /robots.txt. */
+  noIndexEnabled: boolean;
   /**
    * Global opt-in (issue #3979, default false): auto-retry an AUTOMATED MeshCore
    * channel send once, 30s later, when zero repeaters were heard. Automated
@@ -183,6 +185,7 @@ interface SettingsContextType {
   setEnableAudioNotifications: (enabled: boolean) => void;
   setLinkPreviewsEnabled: (enabled: boolean) => void;
   setDiscardInvalidPositions: (enabled: boolean) => void;
+  setNoIndexEnabled: (enabled: boolean) => void;
   setMeshcoreChannelRetryEnabled: (enabled: boolean) => void;
   mutedChannels: MutedChannel[];
   mutedDMs: MutedDM[];
@@ -494,6 +497,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   // Discard invalid GPS positions on ingest — default true (discard = historical
   // behavior); loaded from the server in loadServerSettings.
   const [discardInvalidPositions, setDiscardInvalidPositionsState] = useState<boolean>(true);
+
+  // Discourage search-engine / LLM indexing (issue #4202) — server-backed
+  // (global). Defaults to false (opt-in); loaded from the server in
+  // loadServerSettings.
+  const [noIndexEnabled, setNoIndexEnabledState] = useState<boolean>(false);
 
   // MeshCore automated-channel-send auto-retry (issue #3979) - server-backed
   // (global). Defaults to false (opt-in); loaded from the server in
@@ -926,6 +934,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const setDiscardInvalidPositions = (enabled: boolean) => {
     setDiscardInvalidPositionsDisplay(enabled);
     setDiscardInvalidPositionsState(enabled);
+  };
+
+  // No-index setter updates state only - value is persisted server-side
+  const setNoIndexEnabled = (enabled: boolean) => {
+    setNoIndexEnabledState(enabled);
   };
 
   // MeshCore channel-retry setter updates state only - persisted server-side
@@ -1459,6 +1472,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             setDiscardInvalidPositionsState(enabled);
           }
 
+          // No-index (issue #4202) - database-only. Absent key means default
+          // (disabled); only an explicit '1'/'true' turns it on.
+          if (settings.noIndexEnabled !== undefined) {
+            const enabled = settings.noIndexEnabled === '1' || settings.noIndexEnabled === 'true';
+            setNoIndexEnabledState(enabled);
+          }
+
           // MeshCore channel-send auto-retry (#3979) - database-only. Absent key
           // means default (disabled); only an explicit '1'/'true' turns it on.
           if (settings.meshcoreChannelRetryEnabled !== undefined) {
@@ -1686,6 +1706,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     isLoadingThemes,
     linkPreviewsEnabled,
     discardInvalidPositions,
+    noIndexEnabled,
     meshcoreChannelRetryEnabled,
     solarMonitoringEnabled,
     solarMonitoringLatitude,
@@ -1738,6 +1759,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     deleteCustomTileset,
     setLinkPreviewsEnabled,
     setDiscardInvalidPositions,
+    setNoIndexEnabled,
     setMeshcoreChannelRetryEnabled,
     setSolarMonitoringEnabled,
     setSolarMonitoringLatitude,

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -168,6 +168,11 @@ export const VALID_SETTINGS_KEYS = [
   // stored as received so operators can see nodes transmitting them. Non-finite /
   // out-of-range junk is always discarded regardless. See positionIngestConfig.ts.
   'discardInvalidPositions',
+  // Global privacy toggle (issue #4202, default OFF): when enabled, the server
+  // emits an `X-Robots-Tag: noindex, nofollow` header on every response AND
+  // serves a disallow-all `/robots.txt`, discouraging search engines and LLM
+  // crawlers from indexing a publicly-exposed dashboard. See robotsConfig.ts.
+  'noIndexEnabled',
   // Global opt-in (issue #3979, default OFF): when enabled, an AUTOMATED MeshCore
   // channel/broadcast send that hears ZERO repeaters within 30s is resent exactly
   // once. Applies only to automated senders (Automation Engine action.sendMessage,

--- a/src/server/middleware/robotsTag.test.ts
+++ b/src/server/middleware/robotsTag.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the robots / search-indexing middleware (issue #4202).
+ *
+ * Covers both surfaces gated on the global `noIndexEnabled` flag:
+ *   - robotsTagMiddleware: X-Robots-Tag header present/absent by flag.
+ *   - robotsTxtHandler: disallow-all vs permissive body by flag.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { robotsTagMiddleware, robotsTxtHandler } from './robotsTag.js';
+import { setNoIndexEnabled, __resetNoIndexEnabledForTest } from '../../utils/robotsConfig.js';
+
+afterEach(() => {
+  __resetNoIndexEnabledForTest();
+});
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  let body: string | undefined;
+  let contentType: string | undefined;
+  const res = {
+    setHeader: vi.fn((k: string, v: string) => {
+      headers[k] = v;
+    }),
+    type: vi.fn((t: string) => {
+      contentType = t;
+      return res;
+    }),
+    send: vi.fn((b: string) => {
+      body = b;
+      return res;
+    }),
+  } as unknown as Response;
+  return {
+    res,
+    getHeader: (k: string) => headers[k],
+    getBody: () => body,
+    getContentType: () => contentType,
+  };
+}
+
+describe('robotsTagMiddleware', () => {
+  it('sets X-Robots-Tag: noindex, nofollow when enabled', () => {
+    setNoIndexEnabled(true);
+    const { res, getHeader } = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    robotsTagMiddleware({} as Request, res, next);
+
+    expect(getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT set X-Robots-Tag when disabled (default)', () => {
+    const { res, getHeader } = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    robotsTagMiddleware({} as Request, res, next);
+
+    expect(getHeader('X-Robots-Tag')).toBeUndefined();
+    expect(next).toHaveBeenCalledOnce();
+  });
+});
+
+describe('robotsTxtHandler', () => {
+  it('serves a disallow-all body when enabled', () => {
+    setNoIndexEnabled(true);
+    const { res, getBody, getContentType } = makeRes();
+
+    robotsTxtHandler({} as Request, res);
+
+    expect(getContentType()).toBe('text/plain');
+    expect(getBody()).toBe('User-agent: *\nDisallow: /\n');
+  });
+
+  it('serves a permissive body when disabled (default)', () => {
+    const { res, getBody, getContentType } = makeRes();
+
+    robotsTxtHandler({} as Request, res);
+
+    expect(getContentType()).toBe('text/plain');
+    expect(getBody()).toBe('User-agent: *\nDisallow:\n');
+  });
+});

--- a/src/server/middleware/robotsTag.ts
+++ b/src/server/middleware/robotsTag.ts
@@ -1,0 +1,42 @@
+/**
+ * Robots / search-indexing middleware (issue #4202).
+ *
+ * When the global `noIndexEnabled` setting is on, discourage search engines and
+ * LLM crawlers from indexing the dashboard via two independent mechanisms:
+ *
+ *   - {@link robotsTagMiddleware}: adds an `X-Robots-Tag: noindex, nofollow`
+ *     response header to every request.
+ *   - {@link robotsTxtHandler}: serves a disallow-all `/robots.txt` body.
+ *
+ * Both read the cached flag from `robotsConfig` (zero DB reads on the hot path).
+ * The `/robots.txt` body is offered in addition to the header because some
+ * reverse proxies (e.g. Cloudflare tunnels) strip custom response headers at
+ * the edge but never rewrite response bodies.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { getNoIndexEnabled } from '../../utils/robotsConfig.js';
+
+/**
+ * Set `X-Robots-Tag: noindex, nofollow` on every response when the global
+ * no-index gate is enabled. A no-op (just calls `next()`) when disabled.
+ */
+export function robotsTagMiddleware(_req: Request, res: Response, next: NextFunction): void {
+  if (getNoIndexEnabled()) {
+    res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+  }
+  next();
+}
+
+/**
+ * Serve `/robots.txt`. When the gate is enabled, disallow all crawlers;
+ * otherwise return a permissive file that allows everything.
+ */
+export function robotsTxtHandler(_req: Request, res: Response): void {
+  res.type('text/plain');
+  if (getNoIndexEnabled()) {
+    res.send('User-agent: *\nDisallow: /\n');
+  } else {
+    res.send('User-agent: *\nDisallow:\n');
+  }
+}

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -503,6 +503,52 @@ describe('settingsRoutes', () => {
   // panel (e.g. the MQTT broker) must restart THAT source's per-source scheduler
   // — not fall through to a global singleton. Regression: previously the
   // per-source save branch never restarted any distance scheduler at all.
+  describe('POST /api/settings — noIndexEnabled robots gate (#4202)', () => {
+    const setNoIndexSpy = vi.fn();
+
+    beforeEach(() => {
+      setSettingsCallbacks({ setNoIndexEnabled: setNoIndexSpy });
+      setNoIndexSpy.mockClear();
+    });
+
+    afterAll(() => {
+      setSettingsCallbacks({});
+    });
+
+    it('pushes true into the gate when enabled', async () => {
+      const app = createApp(adminUser);
+
+      const res = await request(app)
+        .post('/api/settings')
+        .send({ noIndexEnabled: '1' });
+
+      expect(res.status).toBe(200);
+      expect(setNoIndexSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('pushes false into the gate when disabled', async () => {
+      const app = createApp(adminUser);
+
+      const res = await request(app)
+        .post('/api/settings')
+        .send({ noIndexEnabled: '0' });
+
+      expect(res.status).toBe(200);
+      expect(setNoIndexSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('leaves the gate untouched when the payload has no noIndexEnabled key', async () => {
+      const app = createApp(adminUser);
+
+      const res = await request(app)
+        .post('/api/settings')
+        .send({ meshName: 'Somewhere' });
+
+      expect(res.status).toBe(200);
+      expect(setNoIndexSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('POST /api/settings — per-source auto-delete-by-distance (#3901)', () => {
     const restartSpy = vi.fn();
     const stopSpy = vi.fn();

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -15,6 +15,7 @@ import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { compileUserRegex } from '../../utils/safeRegex.js';
 import { parseDiscardInvalidPositions } from '../../utils/positionIngestConfig.js';
+import { parseNoIndexEnabled } from '../../utils/robotsConfig.js';
 import { securityDigestService } from '../services/securityDigestService.js';
 import { invalidatePkiDmGlobalCache } from '../services/sourcePkiKeyStore.js';
 import { VALID_SETTINGS_KEYS, stripSecretSettings } from '../constants/settings.js';
@@ -135,6 +136,9 @@ export interface SettingsCallbacks {
   // Global (default ON): push the new discard-invalid-positions value into the
   // cached ingest gate so it takes effect immediately, no restart.
   setDiscardInvalidPositions?: (enabled: boolean) => void;
+  // Global (default OFF): push the new no-index value into the cached gate so
+  // the X-Robots-Tag header + /robots.txt body take effect immediately (#4202).
+  setNoIndexEnabled?: (enabled: boolean) => void;
   // Per-source (#3901): the scheduler reads the source's own interval, so no
   // intervalHours arg. A null sourceId is a no-op (no global scheduler).
   restartAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
@@ -724,6 +728,12 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       const enabled = parseDiscardInvalidPositions(filteredSettings.discardInvalidPositions);
       callbacks.setDiscardInvalidPositions?.(enabled);
       logger.debug(`🗺️ discardInvalidPositions set to ${enabled} — ingest gate updated`);
+    }
+
+    if ('noIndexEnabled' in filteredSettings) {
+      const enabled = parseNoIndexEnabled(filteredSettings.noIndexEnabled);
+      callbacks.setNoIndexEnabled?.(enabled);
+      logger.debug(`🤖 noIndexEnabled set to ${enabled} — robots gate updated`);
     }
 
     if ('autoWelcomeEnabled' in filteredSettings) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -22,6 +22,8 @@ import protobufService from './protobufService.js';
 import { createRequire } from 'module';
 import { logger } from '../utils/logger.js';
 import { setDiscardInvalidPositions, parseDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
+import { setNoIndexEnabled, parseNoIndexEnabled } from '../utils/robotsConfig.js';
+import { robotsTagMiddleware, robotsTxtHandler } from './middleware/robotsTag.js';
 import { getSessionMiddleware } from './auth/sessionConfig.js';
 import { initializeWebSocket } from './services/webSocketService.js';
 import { initializeOIDC } from './auth/oidcAuth.js';
@@ -171,6 +173,11 @@ app.use(helmet(helmetConfig));
 // Dynamic CSP middleware - adds custom tile server hostnames from database,
 // and sets frame-ancestors from IFRAME_ALLOWED_ORIGINS when configured.
 app.use(dynamicCspMiddleware(env.isProduction, env.cookieSecure, env.iframeAllowedOrigins));
+
+// Optional "discourage indexing" header (issue #4202). When the global
+// `noIndexEnabled` setting is on, tag every response with
+// `X-Robots-Tag: noindex, nofollow`. No-op otherwise.
+app.use(robotsTagMiddleware);
 
 // Security: CORS configuration with allowed origins
 const getAllowedOrigins = () => {
@@ -430,6 +437,12 @@ setTimeout(async () => {
     // the setDiscardInvalidPositions callback registered below.
     setDiscardInvalidPositions(
       parseDiscardInvalidPositions(await databaseService.settings.getSetting('discardInvalidPositions')),
+    );
+
+    // Seed the global "discourage indexing" gate from settings (default OFF).
+    // Refreshed live on save via the setNoIndexEnabled callback registered below.
+    setNoIndexEnabled(
+      parseNoIndexEnabled(await databaseService.settings.getSetting('noIndexEnabled')),
     );
 
     // Start inactive node notification service with validation
@@ -926,6 +939,7 @@ setSettingsCallbacks({
   handleAutoWelcomeEnabled: () => { databaseService.handleAutoWelcomeEnabledAsync().catch(() => {}); return 0; },
   invalidateHtmlCache,
   setDiscardInvalidPositions: (enabled) => setDiscardInvalidPositions(enabled),
+  setNoIndexEnabled: (enabled) => setNoIndexEnabled(enabled),
   // Auto-delete-by-distance is per-source (#3901): route the restart/stop to
   // the owning source manager so each source schedules against its own settings.
   // There is no global singleton — a null sourceId is a no-op.
@@ -5923,6 +5937,9 @@ if (BASE_URL) {
     staticMiddleware(req, res, next);
   });
 
+  // Serve robots.txt (before SPA fallback) — dynamic body gated on noIndexEnabled (#4202)
+  app.get(`${BASE_URL}/robots.txt`, robotsTxtHandler);
+
   // Serve embed page (before SPA fallback)
   app.get(`${BASE_URL}/embed/:profileId`, createEmbedCspMiddleware(), async (_req: express.Request, res: express.Response) => {
     if (!cachedRewrittenEmbedHtml) {
@@ -5982,6 +5999,9 @@ if (BASE_URL) {
   // bypassing analytics injection entirely — which is the bug that caused
   // GA4 tags to silently not appear on root deployments.
   app.use(express.static(buildPath, { index: false }));
+
+  // Serve robots.txt (before SPA fallback) — dynamic body gated on noIndexEnabled (#4202)
+  app.get('/robots.txt', robotsTxtHandler);
 
   // Serve embed page (before SPA fallback)
   app.get('/embed/:profileId', createEmbedCspMiddleware(), async (_req: express.Request, res: express.Response) => {

--- a/src/utils/robotsConfig.test.ts
+++ b/src/utils/robotsConfig.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the no-index config gate parsing/caching (issue #4202).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  getNoIndexEnabled,
+  setNoIndexEnabled,
+  parseNoIndexEnabled,
+  __resetNoIndexEnabledForTest,
+} from './robotsConfig.js';
+
+afterEach(() => {
+  __resetNoIndexEnabledForTest();
+});
+
+describe('parseNoIndexEnabled', () => {
+  it('defaults OFF for absent/empty values', () => {
+    expect(parseNoIndexEnabled(null)).toBe(false);
+    expect(parseNoIndexEnabled(undefined)).toBe(false);
+    expect(parseNoIndexEnabled('')).toBe(false);
+  });
+
+  it('only enables on explicit truthy string', () => {
+    expect(parseNoIndexEnabled('1')).toBe(true);
+    expect(parseNoIndexEnabled('true')).toBe(true);
+    expect(parseNoIndexEnabled('0')).toBe(false);
+    expect(parseNoIndexEnabled('false')).toBe(false);
+    expect(parseNoIndexEnabled('yes')).toBe(false);
+  });
+});
+
+describe('get/setNoIndexEnabled', () => {
+  it('defaults to false', () => {
+    expect(getNoIndexEnabled()).toBe(false);
+  });
+
+  it('round-trips the cached flag', () => {
+    setNoIndexEnabled(true);
+    expect(getNoIndexEnabled()).toBe(true);
+    setNoIndexEnabled(false);
+    expect(getNoIndexEnabled()).toBe(false);
+  });
+});

--- a/src/utils/robotsConfig.ts
+++ b/src/utils/robotsConfig.ts
@@ -1,0 +1,50 @@
+/**
+ * Global "discourage search-engine / LLM indexing" gate (issue #4202).
+ *
+ * Backs the `noIndexEnabled` setting. When enabled (opt-in, default OFF), the
+ * server:
+ *   1. Emits an `X-Robots-Tag: noindex, nofollow` response header on every
+ *      request via {@link robotsTagMiddleware}, and
+ *   2. Serves a disallow-all `/robots.txt` body.
+ *
+ * The header path is the primary mechanism, but some reverse-proxy setups
+ * (notably Cloudflare tunnels) strip custom response headers at the edge — the
+ * dynamic `/robots.txt` body survives that because proxies don't rewrite
+ * response bodies, so both are offered together.
+ *
+ * The value is cached in this module rather than read from the DB per request:
+ * the setting is GLOBAL (not per-source) and changes rarely, but the gate runs
+ * on the HTTP hot path. A single module-level flag, seeded at startup and
+ * refreshed by the settings-save callback, gives the middleware a zero-DB read.
+ */
+
+// Default OFF = do not add noindex directives = the behavior before this setting existed.
+let noIndexEnabled = false;
+
+/** Current value of the global no-index gate. */
+export function getNoIndexEnabled(): boolean {
+  return noIndexEnabled;
+}
+
+/** Update the cached gate (called at startup and from the settings-save callback). */
+export function setNoIndexEnabled(enabled: boolean): void {
+  noIndexEnabled = enabled;
+}
+
+/**
+ * Parse the stored setting value into a boolean with a default-OFF policy:
+ * only an explicit `'1'` / `'true'` → `true`; an absent value or anything else
+ * → `false`. Mirrors the frontend parse in SettingsContext.
+ */
+export function parseNoIndexEnabled(raw: string | null | undefined): boolean {
+  return raw === '1' || raw === 'true';
+}
+
+/**
+ * Reset the cached flag to its factory default (`false`). Exported for test
+ * isolation only — a suite that flips the flag must restore it in teardown so it
+ * cannot bleed into other tests (the flag is a process-global module singleton).
+ */
+export function __resetNoIndexEnabledForTest(): void {
+  noIndexEnabled = false;
+}


### PR DESCRIPTION
## Summary

Implements the owner-approved plan from #4202: an opt-in global privacy setting (`noIndexEnabled`, default OFF) that discourages search engines and LLM crawlers from indexing a publicly-exposed MeshMonitor dashboard.

When enabled, the server:
1. Emits `X-Robots-Tag: noindex, nofollow` on **every** response (new `robotsTagMiddleware`, registered right after the dynamic CSP middleware so it covers the SPA and `/api/*` too).
2. Serves a **disallow-all `/robots.txt`** (server-rendered, registered before the SPA catch-all in both the `BASE_URL` and root-deployment branches).

The `/robots.txt` body is offered **in addition** to the header specifically to solve the reported case — a Cloudflare tunnel that strips custom response headers at the edge never rewrites response *bodies*, so the dynamic robots.txt survives that setup even when the header does not.

## Implementation

- **`src/utils/robotsConfig.ts`** (new) — cached module-level flag (`get`/`set`/`parse`/test-reset), mirroring `positionIngestConfig.ts`. Zero DB reads on the HTTP hot path.
- **`src/server/middleware/robotsTag.ts`** (new) — `robotsTagMiddleware` + `robotsTxtHandler`.
- **`src/server/constants/settings.ts`** — `noIndexEnabled` added to `VALID_SETTINGS_KEYS`.
- **`src/server/server.ts`** — import, middleware registration, startup seed, `/robots.txt` routes (both branches), and `setNoIndexEnabled` callback.
- **`src/server/routes/settingsRoutes.ts`** — callback type + live refresh on save.
- **`src/contexts/SettingsContext.tsx`** / **`src/components/SettingsTab.tsx`** — full state/setter/load/save plumbing (mirroring `meshcoreChannelRetryEnabled`) plus a new **Privacy** section in General Settings.

## Tests

- `robotsTag.test.ts` — header present/absent by flag; robots.txt body toggles disallow-all vs permissive.
- `robotsConfig.test.ts` — parse (default-OFF policy) + cache round-trip.
- `settingsRoutes.test.ts` — save callback fires with correct boolean; untouched when key absent.
- The existing `server.settings-persistence.test.ts` auto-covers the new key (frontend↔server round-trip).

Full Vitest suite: 9698 passed. The only 2 failures are the pre-existing `meshcoreCompanionCodec.test.ts` (#4094) cases, which fail identically on untouched `main` — they depend on the unmerged meshcore.js fork, not on this change. `tsc --noEmit` clean; `lint:ci` green.

Fixes #4202

🤖 Generated with [Claude Code](https://claude.com/claude-code)