### PR TITLE
fix(telemetry): auto-retry firmware NeighborInfo-hijacked telemetry requests (#4210)

### DIFF
--- a/src/server/meshtasticManager.telemetryNeighborHijack.test.ts
+++ b/src/server/meshtasticManager.telemetryNeighborHijack.test.ts
@@ -6,10 +6,11 @@
  * enabled, the firmware's promiscuous NeighborInfoModule can answer with a
  * NeighborInfo (port 71) reply whose request_id == our telemetry request's
  * packet id, hijacking the reply. The hijack arms the node's 3-minute cooldown,
- * so a retry returns real telemetry — but because LoRa is half-duplex the retry
- * must be DELAYED (an instant retry reaches the node while it is still
- * transmitting and is dropped; verified twice on hardware). These tests cover
- * the manager bookkeeping + the delayed, one-shot auto-retry.
+ * so a retry returns real telemetry — but the hijacking NeighborInfo is
+ * want_ack'd and the node keeps retransmitting it for ~10-30s, so an
+ * instant/5s retry is dropped (hardware delay-sweep: 5s recovered 0/4, ~38s
+ * recovered cleanly). We therefore schedule TWO spaced retries at 30s and 70s
+ * inside the 3-min cooldown. These tests cover the bookkeeping + the schedule.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -42,7 +43,9 @@ vi.mock('../utils/logger.js', () => ({
 const DEST = 0x0a0b0c0d;
 const CHANNEL = 2;
 const REQ_ID = 0x12345678;
-const RETRY_DELAY_MS = 5000;
+const RETRY_1_MS = 30000; // retry #1 at 30s from hijack
+const RETRY_2_MS = 70000; // retry #2 at 70s from hijack
+const DELTA_1_TO_2_MS = RETRY_2_MS - RETRY_1_MS; // 40s between retry #1 and #2
 
 /** A minimal inbound NeighborInfo MeshPacket carrying decoded.requestId. */
 function neighborInfoPacket(requestId: number) {
@@ -71,7 +74,7 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     for (const t of manager.telemetryRetryTimers) clearTimeout(t);
     manager.telemetryRetryTimers.clear();
     manager.sourceId = 'default';
-    // The delayed retry only fires while the manager is connected.
+    // The delayed retries only fire while the manager is connected.
     manager.isConnected = true;
     manager.transport = { disconnect: vi.fn() };
   });
@@ -87,126 +90,170 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
       telemetryType: 'environment',
       sentAt: Date.now(),
       retried: false,
+      resolved: false,
+      packetIds: new Set([REQ_ID]),
+      retryTimers: [],
       ...overrides,
     });
   }
 
-  it('does not retry immediately, then auto-retries exactly once after the delay', async () => {
+  it('does not retry before 30s, then fires retry #1 exactly at 30s', async () => {
     seedPending();
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
 
-    // Retry is scheduled, NOT fired inline.
+    // Scheduled, not fired inline; sequence marked retried immediately (loop-guard).
     expect(sendSpy).not.toHaveBeenCalled();
-    // Pending entry is marked retried immediately so a duplicate NeighborInfo won't re-fire.
     expect(manager.pendingTelemetryRequests.get(REQ_ID)?.retried).toBe(true);
 
-    // Not yet at the delay boundary.
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS - 1);
+    await vi.advanceTimersByTimeAsync(RETRY_1_MS - 1);
     expect(sendSpy).not.toHaveBeenCalled();
 
-    // Delay elapses → the retry fires exactly once with the same args.
     await vi.advanceTimersByTimeAsync(1);
     expect(sendSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy).toHaveBeenCalledWith(DEST, CHANNEL, 'environment', { isAutoRetry: true });
     sendSpy.mockRestore();
   });
 
+  it('fires retry #2 at 70s when the request is still unresolved', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+
+    await vi.advanceTimersByTimeAsync(RETRY_1_MS); // retry #1
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(DELTA_1_TO_2_MS - 1); // just before 70s
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1); // retry #2 at 70s
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    sendSpy.mockRestore();
+  });
+
+  it('a telemetry reply before 30s cancels BOTH retries', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    // Telemetry reply arrives at ~15s.
+    await vi.advanceTimersByTimeAsync(15000);
+    manager.resolvePendingTelemetryRequest(REQ_ID);
+
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(manager.telemetryRetryTimers.size).toBe(0);
+    sendSpy.mockRestore();
+  });
+
+  it('a telemetry reply between 30s and 70s cancels retry #2 (only retry #1 sent)', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    await vi.advanceTimersByTimeAsync(RETRY_1_MS); // retry #1 fires + schedules retry #2
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    // Telemetry reply to retry #1 arrives at ~45s → resolve by the retry's packet id.
+    await vi.advanceTimersByTimeAsync(15000);
+    manager.resolvePendingTelemetryRequest(111);
+
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
+    expect(sendSpy).toHaveBeenCalledTimes(1); // retry #2 cancelled
+    sendSpy.mockRestore();
+  });
+
   it('still processes/stores the NeighborInfo neighbor data (does not drop it)', async () => {
     seedPending();
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(
       neighborInfoPacket(REQ_ID),
       { neighbors: [{ nodeId: 0x55555555, snr: 5, lastRxTime: 100 }] }
     );
 
-    // Neighbor rows persisted regardless of the (delayed) retry.
     expect(mockDeleteNeighbor).toHaveBeenCalledWith(0x0a0b0c0d, 'default');
     expect(mockInsertNeighborBatch).toHaveBeenCalledTimes(1);
     const [records] = mockInsertNeighborBatch.mock.calls[0];
     expect(records).toHaveLength(1);
     expect(records[0].neighborNodeNum).toBe(0x55555555);
 
-    // And the retry still fires after the delay.
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_1_MS);
     expect(sendSpy).toHaveBeenCalledTimes(1);
     sendSpy.mockRestore();
   });
 
   it('does not retry when a matching telemetry reply already cleared the pending entry', async () => {
     seedPending();
-    // Simulate the telemetry reply resolving the pending request.
     manager.resolvePendingTelemetryRequest(REQ_ID);
     expect(manager.pendingTelemetryRequests.has(REQ_ID)).toBe(false);
 
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
     expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
 
   it('does not retry for a NeighborInfo whose request_id does not match any pending request', async () => {
     seedPending();
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(0xdeadbeef), { neighbors: [] });
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
 
     expect(sendSpy).not.toHaveBeenCalled();
-    // Unrelated pending entry is untouched.
     expect(manager.pendingTelemetryRequests.get(REQ_ID)?.retried).toBe(false);
     sendSpy.mockRestore();
   });
 
   it('does not retry for an unsolicited NeighborInfo (no request_id, no pending request)', async () => {
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(
       { from: 0x0a0b0c0d, id: 1, decoded: { portnum: 71 } },
       { neighbors: [] }
     );
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
 
     expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
 
-  it('retries at most once — a second matching NeighborInfo during the delay window does not schedule a second retry', async () => {
+  it('starts the recovery sequence at most once — a second matching NeighborInfo mid-window does not add retries', async () => {
     seedPending();
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
-    // First hijack schedules the retry.
+    // First hijack starts the sequence.
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
-    // Second hijack arrives mid-delay — must NOT schedule another retry.
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS / 2);
+    // Second hijack arrives before retry #1 — must be ignored.
+    await vi.advanceTimersByTimeAsync(RETRY_1_MS / 2);
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
 
-    // Let all timers drain.
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
-    expect(sendSpy).toHaveBeenCalledTimes(1);
+    // Full timeline: exactly retry #1 + retry #2 = 2 sends, not 4.
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
     sendSpy.mockRestore();
   });
 
-  it('does not fire the retry if the manager disconnected before the timer elapses', async () => {
+  it('does not fire retries if the manager disconnected before the timer elapses', async () => {
     seedPending();
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
-    // In-flight timer guard: manager loses connection before the delay elapses.
     manager.isConnected = false;
     manager.transport = null;
 
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
     expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
 
-  it('disconnect() cancels scheduled retry timers and clears pending requests', async () => {
+  it('disconnect() cancels ALL scheduled retry timers and clears pending requests', async () => {
     seedPending();
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
     expect(manager.telemetryRetryTimers.size).toBe(1);
@@ -215,38 +262,49 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     expect(manager.telemetryRetryTimers.size).toBe(0);
     expect(manager.pendingTelemetryRequests.size).toBe(0);
 
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
     expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
 
-  it('does not retry a pending request that has expired past its TTL', async () => {
-    // sentAt well beyond the 3-minute TTL.
-    seedPending({ sentAt: Date.now() - (4 * 60 * 1000) });
-    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+  it('TTL (3 min) comfortably covers the full 70s two-retry schedule', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    // Advance across the whole schedule; the entry must not expire before retry #2.
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    sendSpy.mockRestore();
+  });
+
+  it('does not retry a pending request that has expired past its TTL', async () => {
+    seedPending({ sentAt: Date.now() - (4 * 60 * 1000) });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 111, requestId: 111 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    await vi.advanceTimersByTimeAsync(RETRY_2_MS);
 
     expect(sendSpy).not.toHaveBeenCalled();
-    // Expired entry is pruned.
     expect(manager.pendingTelemetryRequests.has(REQ_ID)).toBe(false);
     sendSpy.mockRestore();
   });
 
   it('records an outgoing telemetry request as pending, keyed by packet id', () => {
-    manager.recordPendingTelemetryRequest(REQ_ID, DEST, CHANNEL, 'device', false);
+    manager.recordPendingTelemetryRequest(REQ_ID, DEST, CHANNEL, 'device');
     const entry = manager.pendingTelemetryRequests.get(REQ_ID);
-    expect(entry).toMatchObject({ destination: DEST, channel: CHANNEL, telemetryType: 'device', retried: false });
+    expect(entry).toMatchObject({ destination: DEST, channel: CHANNEL, telemetryType: 'device', retried: false, resolved: false });
+    expect([...entry.packetIds]).toEqual([REQ_ID]);
   });
 
   it('bounds the pending map size and prunes expired entries', () => {
-    // Insert one already-expired entry, then many fresh ones over the cap.
-    manager.pendingTelemetryRequests.set(1, { destination: DEST, channel: 0, sentAt: Date.now() - (5 * 60 * 1000), retried: false });
+    manager.pendingTelemetryRequests.set(1, {
+      destination: DEST, channel: 0, sentAt: Date.now() - (5 * 60 * 1000),
+      retried: false, resolved: false, packetIds: new Set([1]), retryTimers: [],
+    });
     for (let i = 2; i < 400; i++) {
-      manager.recordPendingTelemetryRequest(i, DEST, 0, 'device', false);
+      manager.recordPendingTelemetryRequest(i, DEST, 0, 'device');
     }
-    // Expired entry gone; size capped at the configured max.
     expect(manager.pendingTelemetryRequests.has(1)).toBe(false);
     expect(manager.pendingTelemetryRequests.size).toBeLessThanOrEqual(256);
   });

--- a/src/server/meshtasticManager.telemetryNeighborHijack.test.ts
+++ b/src/server/meshtasticManager.telemetryNeighborHijack.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the TELEMETRY_APP → NeighborInfo hijack detect-and-auto-retry
+ * (issue #4210 / meshtastic/firmware#11071).
+ *
+ * When we send a telemetry want_response to a remote node that has neighbor_info
+ * enabled, the firmware's promiscuous NeighborInfoModule can answer with a
+ * NeighborInfo (port 71) reply whose request_id == our telemetry request's
+ * packet id, hijacking the reply. The hijack arms the node's 3-minute cooldown,
+ * so an immediate retry returns real telemetry. These tests cover the manager
+ * bookkeeping + one-shot auto-retry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetNode = vi.fn();
+const mockUpsertNode = vi.fn();
+const mockGetNodesByNums = vi.fn();
+const mockDeleteNeighbor = vi.fn();
+const mockInsertNeighborBatch = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: vi.fn(),
+    nodes: {
+      getNode: mockGetNode,
+      getNodesByNums: mockGetNodesByNums,
+    },
+    neighbors: {
+      deleteNeighborInfoForNode: mockDeleteNeighbor,
+      insertNeighborInfoBatch: mockInsertNeighborBatch,
+    },
+    upsertNodeAsync: mockUpsertNode,
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const DEST = 0x0a0b0c0d;
+const CHANNEL = 2;
+const REQ_ID = 0x12345678;
+
+/** A minimal inbound NeighborInfo MeshPacket carrying decoded.requestId. */
+function neighborInfoPacket(requestId: number) {
+  return {
+    from: 0x0a0b0c0d,
+    id: 0x99990000,
+    decoded: { portnum: 71, requestId },
+  };
+}
+
+describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetNode.mockResolvedValue({ nodeNum: DEST, hopsAway: 1 });
+    mockGetNodesByNums.mockResolvedValue(new Map());
+    mockUpsertNode.mockResolvedValue(undefined);
+    mockDeleteNeighbor.mockResolvedValue(undefined);
+    mockInsertNeighborBatch.mockResolvedValue(undefined);
+
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    manager.pendingTelemetryRequests.clear();
+    manager.sourceId = 'default';
+  });
+
+  function seedPending(overrides: Partial<any> = {}) {
+    manager.pendingTelemetryRequests.set(REQ_ID, {
+      destination: DEST,
+      channel: CHANNEL,
+      telemetryType: 'environment',
+      sentAt: Date.now(),
+      retried: false,
+      ...overrides,
+    });
+  }
+
+  it('auto-retries exactly once when an inbound NeighborInfo matches a pending telemetry request', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy).toHaveBeenCalledWith(DEST, CHANNEL, 'environment', { isAutoRetry: true });
+    // Pending entry is marked retried so a duplicate NeighborInfo won't re-fire.
+    expect(manager.pendingTelemetryRequests.get(REQ_ID)?.retried).toBe(true);
+    sendSpy.mockRestore();
+  });
+
+  it('still processes/stores the NeighborInfo neighbor data (does not drop it)', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(
+      neighborInfoPacket(REQ_ID),
+      { neighbors: [{ nodeId: 0x55555555, snr: 5, lastRxTime: 100 }] }
+    );
+
+    // Retry fired AND neighbor rows were persisted.
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(mockDeleteNeighbor).toHaveBeenCalledWith(0x0a0b0c0d, 'default');
+    expect(mockInsertNeighborBatch).toHaveBeenCalledTimes(1);
+    const [records] = mockInsertNeighborBatch.mock.calls[0];
+    expect(records).toHaveLength(1);
+    expect(records[0].neighborNodeNum).toBe(0x55555555);
+    sendSpy.mockRestore();
+  });
+
+  it('does not retry when a matching telemetry reply already cleared the pending entry', async () => {
+    seedPending();
+    // Simulate the telemetry reply resolving the pending request.
+    manager.resolvePendingTelemetryRequest(REQ_ID);
+    expect(manager.pendingTelemetryRequests.has(REQ_ID)).toBe(false);
+
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    expect(sendSpy).not.toHaveBeenCalled();
+    sendSpy.mockRestore();
+  });
+
+  it('does not retry for a NeighborInfo whose request_id does not match any pending request', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(0xdeadbeef), { neighbors: [] });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    // Unrelated pending entry is untouched.
+    expect(manager.pendingTelemetryRequests.get(REQ_ID)?.retried).toBe(false);
+    sendSpy.mockRestore();
+  });
+
+  it('does not retry for an unsolicited NeighborInfo (no request_id, no pending request)', async () => {
+    // No pending entries seeded.
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(
+      { from: 0x0a0b0c0d, id: 1, decoded: { portnum: 71 } },
+      { neighbors: [] }
+    );
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    sendSpy.mockRestore();
+  });
+
+  it('retries at most once — a second matching NeighborInfo does not re-fire', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    sendSpy.mockRestore();
+  });
+
+  it('does not retry a pending request that has expired past its TTL', async () => {
+    // sentAt well beyond the 3-minute TTL.
+    seedPending({ sentAt: Date.now() - (4 * 60 * 1000) });
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    // Expired entry is pruned.
+    expect(manager.pendingTelemetryRequests.has(REQ_ID)).toBe(false);
+    sendSpy.mockRestore();
+  });
+
+  it('records an outgoing telemetry request as pending, keyed by packet id', async () => {
+    // Drive the record helper directly (avoids the transport/protobuf machinery).
+    manager.recordPendingTelemetryRequest(REQ_ID, DEST, CHANNEL, 'device', false);
+    const entry = manager.pendingTelemetryRequests.get(REQ_ID);
+    expect(entry).toMatchObject({ destination: DEST, channel: CHANNEL, telemetryType: 'device', retried: false });
+  });
+
+  it('bounds the pending map size and prunes expired entries', () => {
+    // Insert one already-expired entry, then many fresh ones over the cap.
+    manager.pendingTelemetryRequests.set(1, { destination: DEST, channel: 0, sentAt: Date.now() - (5 * 60 * 1000), retried: false });
+    for (let i = 2; i < 400; i++) {
+      manager.recordPendingTelemetryRequest(i, DEST, 0, 'device', false);
+    }
+    // Expired entry gone; size capped at the configured max.
+    expect(manager.pendingTelemetryRequests.has(1)).toBe(false);
+    expect(manager.pendingTelemetryRequests.size).toBeLessThanOrEqual(256);
+  });
+});

--- a/src/server/meshtasticManager.telemetryNeighborHijack.test.ts
+++ b/src/server/meshtasticManager.telemetryNeighborHijack.test.ts
@@ -6,11 +6,13 @@
  * enabled, the firmware's promiscuous NeighborInfoModule can answer with a
  * NeighborInfo (port 71) reply whose request_id == our telemetry request's
  * packet id, hijacking the reply. The hijack arms the node's 3-minute cooldown,
- * so an immediate retry returns real telemetry. These tests cover the manager
- * bookkeeping + one-shot auto-retry.
+ * so a retry returns real telemetry — but because LoRa is half-duplex the retry
+ * must be DELAYED (an instant retry reaches the node while it is still
+ * transmitting and is dropped; verified twice on hardware). These tests cover
+ * the manager bookkeeping + the delayed, one-shot auto-retry.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockGetNode = vi.fn();
 const mockUpsertNode = vi.fn();
@@ -40,6 +42,7 @@ vi.mock('../utils/logger.js', () => ({
 const DEST = 0x0a0b0c0d;
 const CHANNEL = 2;
 const REQ_ID = 0x12345678;
+const RETRY_DELAY_MS = 5000;
 
 /** A minimal inbound NeighborInfo MeshPacket carrying decoded.requestId. */
 function neighborInfoPacket(requestId: number) {
@@ -55,6 +58,7 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     mockGetNode.mockResolvedValue({ nodeNum: DEST, hopsAway: 1 });
     mockGetNodesByNums.mockResolvedValue(new Map());
     mockUpsertNode.mockResolvedValue(undefined);
@@ -64,7 +68,16 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     const module = await import('./meshtasticManager.js');
     manager = module.default;
     manager.pendingTelemetryRequests.clear();
+    for (const t of manager.telemetryRetryTimers) clearTimeout(t);
+    manager.telemetryRetryTimers.clear();
     manager.sourceId = 'default';
+    // The delayed retry only fires while the manager is connected.
+    manager.isConnected = true;
+    manager.transport = { disconnect: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function seedPending(overrides: Partial<any> = {}) {
@@ -78,16 +91,25 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     });
   }
 
-  it('auto-retries exactly once when an inbound NeighborInfo matches a pending telemetry request', async () => {
+  it('does not retry immediately, then auto-retries exactly once after the delay', async () => {
     seedPending();
     const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
 
+    // Retry is scheduled, NOT fired inline.
+    expect(sendSpy).not.toHaveBeenCalled();
+    // Pending entry is marked retried immediately so a duplicate NeighborInfo won't re-fire.
+    expect(manager.pendingTelemetryRequests.get(REQ_ID)?.retried).toBe(true);
+
+    // Not yet at the delay boundary.
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS - 1);
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    // Delay elapses → the retry fires exactly once with the same args.
+    await vi.advanceTimersByTimeAsync(1);
     expect(sendSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy).toHaveBeenCalledWith(DEST, CHANNEL, 'environment', { isAutoRetry: true });
-    // Pending entry is marked retried so a duplicate NeighborInfo won't re-fire.
-    expect(manager.pendingTelemetryRequests.get(REQ_ID)?.retried).toBe(true);
     sendSpy.mockRestore();
   });
 
@@ -100,13 +122,16 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
       { neighbors: [{ nodeId: 0x55555555, snr: 5, lastRxTime: 100 }] }
     );
 
-    // Retry fired AND neighbor rows were persisted.
-    expect(sendSpy).toHaveBeenCalledTimes(1);
+    // Neighbor rows persisted regardless of the (delayed) retry.
     expect(mockDeleteNeighbor).toHaveBeenCalledWith(0x0a0b0c0d, 'default');
     expect(mockInsertNeighborBatch).toHaveBeenCalledTimes(1);
     const [records] = mockInsertNeighborBatch.mock.calls[0];
     expect(records).toHaveLength(1);
     expect(records[0].neighborNodeNum).toBe(0x55555555);
+
+    // And the retry still fires after the delay.
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
     sendSpy.mockRestore();
   });
 
@@ -118,6 +143,7 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
 
     const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
@@ -127,6 +153,7 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(0xdeadbeef), { neighbors: [] });
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
 
     expect(sendSpy).not.toHaveBeenCalled();
     // Unrelated pending entry is untouched.
@@ -135,26 +162,61 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
   });
 
   it('does not retry for an unsolicited NeighborInfo (no request_id, no pending request)', async () => {
-    // No pending entries seeded.
     const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
 
     await manager.processNeighborInfoProtobuf(
       { from: 0x0a0b0c0d, id: 1, decoded: { portnum: 71 } },
       { neighbors: [] }
     );
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
 
     expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
 
-  it('retries at most once — a second matching NeighborInfo does not re-fire', async () => {
+  it('retries at most once — a second matching NeighborInfo during the delay window does not schedule a second retry', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    // First hijack schedules the retry.
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    // Second hijack arrives mid-delay — must NOT schedule another retry.
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS / 2);
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+
+    // Let all timers drain.
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    sendSpy.mockRestore();
+  });
+
+  it('does not fire the retry if the manager disconnected before the timer elapses', async () => {
     seedPending();
     const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
-    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    // In-flight timer guard: manager loses connection before the delay elapses.
+    manager.isConnected = false;
+    manager.transport = null;
 
-    expect(sendSpy).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    expect(sendSpy).not.toHaveBeenCalled();
+    sendSpy.mockRestore();
+  });
+
+  it('disconnect() cancels scheduled retry timers and clears pending requests', async () => {
+    seedPending();
+    const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
+
+    await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    expect(manager.telemetryRetryTimers.size).toBe(1);
+
+    manager.disconnect();
+    expect(manager.telemetryRetryTimers.size).toBe(0);
+    expect(manager.pendingTelemetryRequests.size).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    expect(sendSpy).not.toHaveBeenCalled();
     sendSpy.mockRestore();
   });
 
@@ -164,6 +226,7 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     const sendSpy = vi.spyOn(manager, 'sendTelemetryRequest').mockResolvedValue({ packetId: 1, requestId: 1 });
 
     await manager.processNeighborInfoProtobuf(neighborInfoPacket(REQ_ID), { neighbors: [] });
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
 
     expect(sendSpy).not.toHaveBeenCalled();
     // Expired entry is pruned.
@@ -171,8 +234,7 @@ describe('MeshtasticManager - telemetry NeighborInfo hijack auto-retry (#4210)',
     sendSpy.mockRestore();
   });
 
-  it('records an outgoing telemetry request as pending, keyed by packet id', async () => {
-    // Drive the record helper directly (avoids the transport/protobuf machinery).
+  it('records an outgoing telemetry request as pending, keyed by packet id', () => {
     manager.recordPendingTelemetryRequest(REQ_ID, DEST, CHANNEL, 'device', false);
     const entry = manager.pendingTelemetryRequests.get(REQ_ID);
     expect(entry).toMatchObject({ destination: DEST, channel: CHANNEL, telemetryType: 'device', retried: false });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -456,17 +456,22 @@ export interface MeshtasticMqttLink {
 }
 
 /**
- * A telemetry want_response request we sent and are still awaiting a reply for.
- * Tracked so we can detect + auto-retry the firmware NeighborInfo-hijack
- * (issue #4210 / meshtastic/firmware#11071). Keyed by the request's packet id,
- * which the firmware echoes back as a reply's `request_id`.
+ * A telemetry want_response "sequence" we sent and are still awaiting a reply
+ * for. Tracked so we can detect + auto-retry the firmware NeighborInfo-hijack
+ * (issue #4210 / meshtastic/firmware#11071). The original request AND each
+ * auto-retry share one object; `packetIds` holds every packet id (original +
+ * retries) so a telemetry reply matching ANY of them resolves the whole
+ * sequence. The pending map keys every one of those packet ids to this object.
  */
 interface PendingTelemetryRequest {
   destination: number;
   channel: number;
   telemetryType?: 'device' | 'environment' | 'airQuality' | 'power';
-  sentAt: number;
-  retried: boolean;
+  sentAt: number;         // when the ORIGINAL request was sent (drives TTL)
+  retried: boolean;       // the hijack auto-retry sequence has already started (loop-guard)
+  resolved: boolean;      // a telemetry reply arrived for some request in this sequence
+  packetIds: Set<number>; // every packet id belonging to this logical request
+  retryTimers: Array<ReturnType<typeof setTimeout>>;
 }
 
 class MeshtasticManager implements ISourceManager {
@@ -573,16 +578,20 @@ class MeshtasticManager implements ISourceManager {
   // requests here (keyed by packet id) so the inbound-NeighborInfo path can
   // auto-retry once. Per-manager (never global) so replies stay on the same source.
   private pendingTelemetryRequests = new Map<number, PendingTelemetryRequest>();
+  // TTL comfortably covers the full ~70s two-retry schedule plus margin.
   private static readonly TELEMETRY_REQUEST_TTL_MS = 3 * 60 * 1000;
   private static readonly TELEMETRY_REQUEST_MAX_PENDING = 256;
-  // Delay before firing the auto-retry (issue #4210). LoRa is half-duplex: the
-  // remote node JUST transmitted the hijacking NeighborInfo, so an instant retry
-  // (~5ms later, hardware-verified twice) reaches it while it is still
-  // transmitting / before RX re-enables and is silently dropped. 5s safely
-  // clears the node's TX + airtime while staying far inside the firmware's
-  // 3-min NeighborInfo cooldown (and the request's 3-min pending TTL); the
-  // frontend telemetry loading state is 30s, so the delay is invisible to users.
-  private static readonly TELEMETRY_HIJACK_RETRY_DELAY_MS = 5000;
+  // Auto-retry schedule after a NeighborInfo hijack (issue #4210), two spaced
+  // retries inside the firmware's 3-min NeighborInfo cooldown. LoRa is
+  // half-duplex AND the hijacking NeighborInfo is want_ack'd, so the node keeps
+  // RETRANSMITTING it for ~10-30s; a retry that lands during that window is
+  // dropped. Hardware delay-sweep: a 5s retry recovered 0/4, a ~38s retry cleanly
+  // recovered real telemetry. Retry #1 at 30s (safely past the want_ack
+  // retransmission window); retry #2 at 70s from the hijack (RF-loss backstop,
+  // still well inside the 3-min cooldown). The frontend telemetry loading state
+  // is 30s, so a recovery on retry #1 is essentially invisible to users.
+  private static readonly TELEMETRY_HIJACK_RETRY_DELAY_MS = 30000;
+  private static readonly TELEMETRY_HIJACK_RETRY_2_DELAY_MS = 70000;
   // Outstanding auto-retry timers, so they can be cancelled on disconnect/teardown.
   private telemetryRetryTimers = new Set<ReturnType<typeof setTimeout>>();
   // Where the cutoff reads ChUtil from: the local node, or the averaged
@@ -8977,102 +8986,173 @@ class MeshtasticManager implements ISourceManager {
   }
 
   /**
-   * Prune expired pending telemetry requests and bound the map size.
-   * Map iteration order is insertion order, so the first keys are the oldest.
+   * Forget a telemetry sequence entirely: cancel its outstanding retry timers
+   * and remove every packet-id key that points to it from the pending map.
+   */
+  private forgetTelemetrySequence(entry: PendingTelemetryRequest): void {
+    for (const timer of entry.retryTimers) {
+      clearTimeout(timer);
+      this.telemetryRetryTimers.delete(timer);
+    }
+    entry.retryTimers = [];
+    for (const pid of entry.packetIds) {
+      this.pendingTelemetryRequests.delete(pid);
+    }
+  }
+
+  /**
+   * Prune expired pending telemetry sequences (by original sentAt) and bound
+   * the map size. Map iteration order is insertion order, so the first keys are
+   * the oldest.
    */
   private pruneExpiredTelemetryRequests(now: number): void {
-    for (const [key, entry] of this.pendingTelemetryRequests) {
+    for (const [, entry] of this.pendingTelemetryRequests) {
       if (now - entry.sentAt > MeshtasticManager.TELEMETRY_REQUEST_TTL_MS) {
-        this.pendingTelemetryRequests.delete(key);
+        this.forgetTelemetrySequence(entry);
       }
     }
     while (this.pendingTelemetryRequests.size > MeshtasticManager.TELEMETRY_REQUEST_MAX_PENDING) {
       const oldestKey = this.pendingTelemetryRequests.keys().next().value;
       if (oldestKey === undefined) break;
-      this.pendingTelemetryRequests.delete(oldestKey);
+      const oldest = this.pendingTelemetryRequests.get(oldestKey);
+      if (oldest) this.forgetTelemetrySequence(oldest);
+      else this.pendingTelemetryRequests.delete(oldestKey);
     }
   }
 
   /**
-   * Record an outgoing telemetry want_response so a firmware NeighborInfo hijack
-   * of its reply can be detected and auto-retried (issue #4210).
-   * @param retried true for the auto-retry send itself, so it is never retried again.
+   * Record a NEW outgoing telemetry want_response so a firmware NeighborInfo
+   * hijack of its reply can be detected and auto-retried (issue #4210). Only
+   * original (non-retry) sends start a sequence; auto-retries are linked onto
+   * the existing sequence by {@link maybeRetryHijackedTelemetry}.
    */
   private recordPendingTelemetryRequest(
     packetId: number,
     destination: number,
     channel: number,
-    telemetryType: 'device' | 'environment' | 'airQuality' | 'power' | undefined,
-    retried: boolean
+    telemetryType: 'device' | 'environment' | 'airQuality' | 'power' | undefined
   ): void {
     if (!packetId) return;
     const now = Date.now();
-    this.pendingTelemetryRequests.set(packetId, { destination, channel, telemetryType, sentAt: now, retried });
+    this.pendingTelemetryRequests.set(packetId, {
+      destination,
+      channel,
+      telemetryType,
+      sentAt: now,
+      retried: false,
+      resolved: false,
+      packetIds: new Set([packetId]),
+      retryTimers: [],
+    });
     this.pruneExpiredTelemetryRequests(now);
   }
 
   /**
-   * A telemetry reply arrived — clear the matching pending request so no
-   * (unnecessary) auto-retry fires. Matched by the reply's request_id.
+   * A telemetry reply arrived — resolve the matching sequence (matched by the
+   * reply's request_id against any of its packet ids), cancel any outstanding
+   * retry timers, and drop it so no further (unnecessary) retries fire.
    */
   private resolvePendingTelemetryRequest(requestId: number): void {
-    if (requestId && this.pendingTelemetryRequests.delete(requestId)) {
-      logger.debug(`📊 Telemetry reply resolved pending request ${requestId} (no retry needed)`);
-    }
+    if (!requestId) return;
+    const entry = this.pendingTelemetryRequests.get(requestId);
+    if (!entry) return;
+    entry.resolved = true;
+    this.forgetTelemetrySequence(entry);
+    logger.debug(`📊 Telemetry reply resolved pending request ${requestId} (cancelled any pending retries)`);
   }
 
   /**
    * Detect the firmware NeighborInfo-hijack of a telemetry want_response
-   * (issue #4210 / meshtastic/firmware#11071) and auto-retry the telemetry
-   * request exactly once. The inbound NeighborInfo is still valid neighbor data
-   * and is processed/stored normally by the caller — this only handles the retry.
+   * (issue #4210 / meshtastic/firmware#11071) and kick off the two-retry
+   * recovery sequence (30s + 70s) at most once. The inbound NeighborInfo is
+   * still valid neighbor data and is processed/stored normally by the caller —
+   * this only handles the retry scheduling.
    */
   private async maybeRetryHijackedTelemetry(meshPacket: { decoded?: { requestId?: number | null } }): Promise<void> {
     const requestId = meshPacket?.decoded?.requestId ? Number(meshPacket.decoded.requestId) : 0;
     if (!requestId) return;
 
     const now = Date.now();
-    this.pruneExpiredTelemetryRequests(now);
-    const pending = this.pendingTelemetryRequests.get(requestId);
-    if (!pending) return;
+    this.pruneExpiredTelemetryRequests(now); // drops the entry if it has expired
+    const entry = this.pendingTelemetryRequests.get(requestId);
+    if (!entry) return;
 
-    if (now - pending.sentAt > MeshtasticManager.TELEMETRY_REQUEST_TTL_MS) {
-      this.pendingTelemetryRequests.delete(requestId);
-      return;
-    }
-
-    const destLabel = `!${pending.destination.toString(16).padStart(8, '0')}`;
-    if (pending.retried) {
-      // Already auto-retried once; the retry was hijacked too (or this is a
-      // duplicate NeighborInfo). Do not retry again — just let it be (no loop).
-      this.pendingTelemetryRequests.delete(requestId);
-      logger.info(`📊 Telemetry request ${requestId} to ${destLabel} was hijacked by a NeighborInfo reply again after auto-retry — giving up (firmware #11071)`);
+    if (entry.retried) {
+      // The recovery sequence is already running (or this is a duplicate
+      // hijack NeighborInfo). Loop-guard: do not start a second sequence.
       return;
     }
 
     // Mark retried FIRST (before scheduling) so a second hijack arriving during
-    // the delay window hits the `pending.retried` branch above and does not
-    // schedule a second retry — the one-shot loop-guard holds across the delay.
-    pending.retried = true;
-    const delaySeconds = Math.round(MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS / 1000);
-    logger.info(`📊 Telemetry request ${requestId} (${pending.telemetryType ?? 'device'}) to ${destLabel} was hijacked by a promiscuous NeighborInfo reply (firmware #11071); the hijack armed the node's 3-min cooldown, so auto-retrying the telemetry request once in ${delaySeconds}s (LoRa is half-duplex — an instant retry is dropped while the node is still transmitting)`);
+    // the retry window is ignored by the guard above — the sequence runs once.
+    entry.retried = true;
+    const destLabel = `!${entry.destination.toString(16).padStart(8, '0')}`;
+    const s1 = Math.round(MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS / 1000);
+    const s2 = Math.round(MeshtasticManager.TELEMETRY_HIJACK_RETRY_2_DELAY_MS / 1000);
+    logger.info(`📊 Telemetry request ${requestId} (${entry.telemetryType ?? 'device'}) to ${destLabel} was hijacked by a promiscuous NeighborInfo reply (firmware #11071); scheduling auto-retries at ${s1}s and ${s2}s (the node keeps retransmitting the want_ack'd NeighborInfo for ~10-30s, so an instant/5s retry is dropped — hardware-verified that ~30s+ recovers telemetry)`);
 
-    // Schedule the actual re-send after a short delay so the node has finished
-    // its TX and re-enabled RX (see TELEMETRY_HIJACK_RETRY_DELAY_MS comment).
+    this.scheduleTelemetryRetry(entry, 1);
+  }
+
+  /**
+   * Schedule one attempt of the hijack-recovery sequence. Attempt 1 fires at
+   * TELEMETRY_HIJACK_RETRY_DELAY_MS (30s) from the hijack; attempt 2 fires at
+   * TELEMETRY_HIJACK_RETRY_2_DELAY_MS (70s) from the hijack, i.e. the delta
+   * after attempt 1.
+   */
+  private scheduleTelemetryRetry(entry: PendingTelemetryRequest, attempt: 1 | 2): void {
+    const delay = attempt === 1
+      ? MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS
+      : MeshtasticManager.TELEMETRY_HIJACK_RETRY_2_DELAY_MS - MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS;
+
     const timer = setTimeout(() => {
+      entry.retryTimers = entry.retryTimers.filter((t) => t !== timer);
       this.telemetryRetryTimers.delete(timer);
-      if (!this.isConnected || !this.transport) {
-        logger.debug(`📊 Skipping auto-retry of telemetry request ${requestId} to ${destLabel} — manager no longer connected`);
-        return;
-      }
-      this.sendTelemetryRequest(pending.destination, pending.channel, pending.telemetryType, { isAutoRetry: true })
-        .catch((error) => {
-          logger.warn(`Failed to auto-retry hijacked telemetry request to ${destLabel}:`, error);
-        });
-    }, MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS);
+      this.fireTelemetryRetry(entry, attempt);
+    }, delay);
     // Do not keep the event loop alive solely for this timer.
     if (typeof timer.unref === 'function') timer.unref();
+    entry.retryTimers.push(timer);
     this.telemetryRetryTimers.add(timer);
+  }
+
+  /**
+   * Fire one auto-retry attempt: only send if the sequence is still unresolved
+   * (no telemetry reply has cleared it) and the manager is still connected.
+   * After a successful attempt-1 send, schedule attempt 2.
+   */
+  private fireTelemetryRetry(entry: PendingTelemetryRequest, attempt: 1 | 2): void {
+    const destLabel = `!${entry.destination.toString(16).padStart(8, '0')}`;
+    if (entry.resolved) {
+      logger.debug(`📊 Skipping telemetry auto-retry #${attempt} to ${destLabel} — telemetry already received`);
+      return;
+    }
+    if (!this.isConnected || !this.transport) {
+      logger.debug(`📊 Skipping telemetry auto-retry #${attempt} to ${destLabel} — manager no longer connected`);
+      return;
+    }
+
+    const atSeconds = attempt === 1
+      ? Math.round(MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS / 1000)
+      : Math.round(MeshtasticManager.TELEMETRY_HIJACK_RETRY_2_DELAY_MS / 1000);
+    logger.info(`📊 Auto-retry #${attempt} (${atSeconds}s after hijack) of telemetry request to ${destLabel} (firmware #11071 NeighborInfo hijack recovery)`);
+
+    this.sendTelemetryRequest(entry.destination, entry.channel, entry.telemetryType, { isAutoRetry: true })
+      .then(({ packetId }) => {
+        // Link this retry's packet id so its telemetry reply resolves the
+        // sequence (and cancels a later retry). Skip if resolved meanwhile.
+        if (!entry.resolved && packetId) {
+          entry.packetIds.add(packetId);
+          this.pendingTelemetryRequests.set(packetId, entry);
+        }
+      })
+      .catch((error) => {
+        logger.warn(`Failed to auto-retry hijacked telemetry request to ${destLabel}:`, error);
+      });
+
+    if (attempt === 1) {
+      this.scheduleTelemetryRetry(entry, 2);
+    }
   }
 
   /**
@@ -9130,8 +9210,12 @@ class MeshtasticManager implements ISourceManager {
       // Track this outstanding request so the firmware NeighborInfo-hijack
       // (issue #4210) can be detected + auto-retried. Firmware echoes the
       // request's MeshPacket id back as the reply's request_id, so key by packetId.
-      // The auto-retry send is recorded as already-retried to prevent a loop.
-      this.recordPendingTelemetryRequest(packetId, destination, channel, telemetryType, options?.isAutoRetry ?? false);
+      // Auto-retry sends are NOT recorded as new sequences — they are linked onto
+      // the existing sequence by maybeRetryHijackedTelemetry so a reply to a
+      // retry resolves (and stops) the whole sequence.
+      if (!options?.isAutoRetry) {
+        this.recordPendingTelemetryRequest(packetId, destination, channel, telemetryType);
+      }
 
       return { packetId, requestId };
     } catch (error) {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -575,6 +575,16 @@ class MeshtasticManager implements ISourceManager {
   private pendingTelemetryRequests = new Map<number, PendingTelemetryRequest>();
   private static readonly TELEMETRY_REQUEST_TTL_MS = 3 * 60 * 1000;
   private static readonly TELEMETRY_REQUEST_MAX_PENDING = 256;
+  // Delay before firing the auto-retry (issue #4210). LoRa is half-duplex: the
+  // remote node JUST transmitted the hijacking NeighborInfo, so an instant retry
+  // (~5ms later, hardware-verified twice) reaches it while it is still
+  // transmitting / before RX re-enables and is silently dropped. 5s safely
+  // clears the node's TX + airtime while staying far inside the firmware's
+  // 3-min NeighborInfo cooldown (and the request's 3-min pending TTL); the
+  // frontend telemetry loading state is 30s, so the delay is invisible to users.
+  private static readonly TELEMETRY_HIJACK_RETRY_DELAY_MS = 5000;
+  // Outstanding auto-retry timers, so they can be cancelled on disconnect/teardown.
+  private telemetryRetryTimers = new Set<ReturnType<typeof setTimeout>>();
   // Where the cutoff reads ChUtil from: the local node, or the averaged
   // strongest-RSSI 0-hop infrastructure neighbours.
   private automationAirtimeCutoffSource: AirtimeCutoffSource = DEFAULT_AIRTIME_CUTOFF_SOURCE;
@@ -1915,6 +1925,14 @@ class MeshtasticManager implements ISourceManager {
     // Clear per-packet dedup sets (no longer relevant after disconnect)
     this.autoAckProcessedPackets.clear();
     this.autoResponderProcessedPackets.clear();
+
+    // Cancel any scheduled telemetry hijack auto-retries (issue #4210) — a retry
+    // fired after disconnect would throw; drop the pending map too.
+    for (const timer of this.telemetryRetryTimers) {
+      clearTimeout(timer);
+    }
+    this.telemetryRetryTimers.clear();
+    this.pendingTelemetryRequests.clear();
 
     logger.debug('Disconnected from Meshtastic node');
   }
@@ -9032,13 +9050,29 @@ class MeshtasticManager implements ISourceManager {
       return;
     }
 
+    // Mark retried FIRST (before scheduling) so a second hijack arriving during
+    // the delay window hits the `pending.retried` branch above and does not
+    // schedule a second retry — the one-shot loop-guard holds across the delay.
     pending.retried = true;
-    logger.info(`📊 Telemetry request ${requestId} (${pending.telemetryType ?? 'device'}) to ${destLabel} was hijacked by a promiscuous NeighborInfo reply (firmware #11071); the hijack armed the node's 3-min cooldown, so auto-retrying the telemetry request once`);
-    try {
-      await this.sendTelemetryRequest(pending.destination, pending.channel, pending.telemetryType, { isAutoRetry: true });
-    } catch (error) {
-      logger.warn(`Failed to auto-retry hijacked telemetry request to ${destLabel}:`, error);
-    }
+    const delaySeconds = Math.round(MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS / 1000);
+    logger.info(`📊 Telemetry request ${requestId} (${pending.telemetryType ?? 'device'}) to ${destLabel} was hijacked by a promiscuous NeighborInfo reply (firmware #11071); the hijack armed the node's 3-min cooldown, so auto-retrying the telemetry request once in ${delaySeconds}s (LoRa is half-duplex — an instant retry is dropped while the node is still transmitting)`);
+
+    // Schedule the actual re-send after a short delay so the node has finished
+    // its TX and re-enabled RX (see TELEMETRY_HIJACK_RETRY_DELAY_MS comment).
+    const timer = setTimeout(() => {
+      this.telemetryRetryTimers.delete(timer);
+      if (!this.isConnected || !this.transport) {
+        logger.debug(`📊 Skipping auto-retry of telemetry request ${requestId} to ${destLabel} — manager no longer connected`);
+        return;
+      }
+      this.sendTelemetryRequest(pending.destination, pending.channel, pending.telemetryType, { isAutoRetry: true })
+        .catch((error) => {
+          logger.warn(`Failed to auto-retry hijacked telemetry request to ${destLabel}:`, error);
+        });
+    }, MeshtasticManager.TELEMETRY_HIJACK_RETRY_DELAY_MS);
+    // Do not keep the event loop alive solely for this timer.
+    if (typeof timer.unref === 'function') timer.unref();
+    this.telemetryRetryTimers.add(timer);
   }
 
   /**

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -455,6 +455,20 @@ export interface MeshtasticMqttLink {
   mqttBrokerSourceId?: string;
 }
 
+/**
+ * A telemetry want_response request we sent and are still awaiting a reply for.
+ * Tracked so we can detect + auto-retry the firmware NeighborInfo-hijack
+ * (issue #4210 / meshtastic/firmware#11071). Keyed by the request's packet id,
+ * which the firmware echoes back as a reply's `request_id`.
+ */
+interface PendingTelemetryRequest {
+  destination: number;
+  channel: number;
+  telemetryType?: 'device' | 'environment' | 'airQuality' | 'power';
+  sentAt: number;
+  retried: boolean;
+}
+
 class MeshtasticManager implements ISourceManager {
   public sourceId: string;
   private sourceConfigOverride: { host?: string; port?: number; heartbeatIntervalSeconds?: number; mqttLink?: MeshtasticMqttLink; passiveMode?: boolean; passiveResyncStaleMs?: number } | null = null;
@@ -551,6 +565,16 @@ class MeshtasticManager implements ISourceManager {
   // Most recent Channel Utilization (%) self-reported by the local node, or null
   // if no device telemetry has been seen yet.
   private localChannelUtilization: number | null = null;
+  // issue #4210 / meshtastic/firmware#11071: a remote node with neighbor_info
+  // enabled hijacks our TELEMETRY_APP want_response with a promiscuous NeighborInfo
+  // reply (its request_id == our request's packet id). The hijack arms the node's
+  // 3-minute NeighborInfo cooldown, so an immediate retry of the same request
+  // returns real telemetry (hardware-verified A/B). We track outstanding telemetry
+  // requests here (keyed by packet id) so the inbound-NeighborInfo path can
+  // auto-retry once. Per-manager (never global) so replies stay on the same source.
+  private pendingTelemetryRequests = new Map<number, PendingTelemetryRequest>();
+  private static readonly TELEMETRY_REQUEST_TTL_MS = 3 * 60 * 1000;
+  private static readonly TELEMETRY_REQUEST_MAX_PENDING = 256;
   // Where the cutoff reads ChUtil from: the local node, or the averaged
   // strongest-RSSI 0-hop infrastructure neighbours.
   private automationAirtimeCutoffSource: AirtimeCutoffSource = DEFAULT_AIRTIME_CUTOFF_SOURCE;
@@ -6634,6 +6658,14 @@ class MeshtasticManager implements ISourceManager {
       const packetTimestamp = telemetry.time ? Number(telemetry.time) * 1000 : undefined;
       const packetId = meshPacket.id ? Number(meshPacket.id) : undefined;
 
+      // A real telemetry reply means our want_response was NOT hijacked — clear
+      // any matching pending request so no auto-retry fires (issue #4210). The
+      // reply's request_id echoes the original telemetry request's packet id.
+      const replyRequestId = meshPacket.decoded?.requestId ? Number(meshPacket.decoded.requestId) : 0;
+      if (replyRequestId) {
+        this.resolvePendingTelemetryRequest(replyRequestId);
+      }
+
       // Track PKI encryption
       await this.trackPKIEncryption(meshPacket, fromNum);
 
@@ -7769,6 +7801,12 @@ class MeshtasticManager implements ISourceManager {
       const fromNodeId = `!${fromNum.toString(16).padStart(8, '0')}`;
 
       logger.debug(`🏠 Neighbor info received from ${fromNodeId}:`, neighborInfo);
+
+      // issue #4210 / meshtastic/firmware#11071: if this NeighborInfo is actually
+      // the firmware's promiscuous hijack of a telemetry want_response we sent
+      // (matched by request_id), auto-retry the telemetry request once. The
+      // NeighborInfo is still valid neighbor data, so processing continues below.
+      await this.maybeRetryHijackedTelemetry(meshPacket);
 
       // MQTT-sourced neighbor info IS persisted (issue #3271): the global, batch
       // position estimator pools the MQTT neighbor graph for extra resolution.
@@ -8921,13 +8959,97 @@ class MeshtasticManager implements ISourceManager {
   }
 
   /**
+   * Prune expired pending telemetry requests and bound the map size.
+   * Map iteration order is insertion order, so the first keys are the oldest.
+   */
+  private pruneExpiredTelemetryRequests(now: number): void {
+    for (const [key, entry] of this.pendingTelemetryRequests) {
+      if (now - entry.sentAt > MeshtasticManager.TELEMETRY_REQUEST_TTL_MS) {
+        this.pendingTelemetryRequests.delete(key);
+      }
+    }
+    while (this.pendingTelemetryRequests.size > MeshtasticManager.TELEMETRY_REQUEST_MAX_PENDING) {
+      const oldestKey = this.pendingTelemetryRequests.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.pendingTelemetryRequests.delete(oldestKey);
+    }
+  }
+
+  /**
+   * Record an outgoing telemetry want_response so a firmware NeighborInfo hijack
+   * of its reply can be detected and auto-retried (issue #4210).
+   * @param retried true for the auto-retry send itself, so it is never retried again.
+   */
+  private recordPendingTelemetryRequest(
+    packetId: number,
+    destination: number,
+    channel: number,
+    telemetryType: 'device' | 'environment' | 'airQuality' | 'power' | undefined,
+    retried: boolean
+  ): void {
+    if (!packetId) return;
+    const now = Date.now();
+    this.pendingTelemetryRequests.set(packetId, { destination, channel, telemetryType, sentAt: now, retried });
+    this.pruneExpiredTelemetryRequests(now);
+  }
+
+  /**
+   * A telemetry reply arrived — clear the matching pending request so no
+   * (unnecessary) auto-retry fires. Matched by the reply's request_id.
+   */
+  private resolvePendingTelemetryRequest(requestId: number): void {
+    if (requestId && this.pendingTelemetryRequests.delete(requestId)) {
+      logger.debug(`📊 Telemetry reply resolved pending request ${requestId} (no retry needed)`);
+    }
+  }
+
+  /**
+   * Detect the firmware NeighborInfo-hijack of a telemetry want_response
+   * (issue #4210 / meshtastic/firmware#11071) and auto-retry the telemetry
+   * request exactly once. The inbound NeighborInfo is still valid neighbor data
+   * and is processed/stored normally by the caller — this only handles the retry.
+   */
+  private async maybeRetryHijackedTelemetry(meshPacket: { decoded?: { requestId?: number | null } }): Promise<void> {
+    const requestId = meshPacket?.decoded?.requestId ? Number(meshPacket.decoded.requestId) : 0;
+    if (!requestId) return;
+
+    const now = Date.now();
+    this.pruneExpiredTelemetryRequests(now);
+    const pending = this.pendingTelemetryRequests.get(requestId);
+    if (!pending) return;
+
+    if (now - pending.sentAt > MeshtasticManager.TELEMETRY_REQUEST_TTL_MS) {
+      this.pendingTelemetryRequests.delete(requestId);
+      return;
+    }
+
+    const destLabel = `!${pending.destination.toString(16).padStart(8, '0')}`;
+    if (pending.retried) {
+      // Already auto-retried once; the retry was hijacked too (or this is a
+      // duplicate NeighborInfo). Do not retry again — just let it be (no loop).
+      this.pendingTelemetryRequests.delete(requestId);
+      logger.info(`📊 Telemetry request ${requestId} to ${destLabel} was hijacked by a NeighborInfo reply again after auto-retry — giving up (firmware #11071)`);
+      return;
+    }
+
+    pending.retried = true;
+    logger.info(`📊 Telemetry request ${requestId} (${pending.telemetryType ?? 'device'}) to ${destLabel} was hijacked by a promiscuous NeighborInfo reply (firmware #11071); the hijack armed the node's 3-min cooldown, so auto-retrying the telemetry request once`);
+    try {
+      await this.sendTelemetryRequest(pending.destination, pending.channel, pending.telemetryType, { isAutoRetry: true });
+    } catch (error) {
+      logger.warn(`Failed to auto-retry hijacked telemetry request to ${destLabel}:`, error);
+    }
+  }
+
+  /**
    * Send a telemetry request to a remote node
    * This sends an empty telemetry packet with wantResponse=true to request telemetry data
    */
   async sendTelemetryRequest(
     destination: number,
     channel: number = 0,
-    telemetryType?: 'device' | 'environment' | 'airQuality' | 'power'
+    telemetryType?: 'device' | 'environment' | 'airQuality' | 'power',
+    options?: { isAutoRetry?: boolean }
   ): Promise<{ packetId: number; requestId: number }> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
@@ -8970,6 +9092,12 @@ class MeshtasticManager implements ISourceManager {
         `Telemetry request (${typeLabel}) to !${destination.toString(16).padStart(8, '0')}`,
         { destination, telemetryType: typeLabel, packetId, requestId }
       );
+
+      // Track this outstanding request so the firmware NeighborInfo-hijack
+      // (issue #4210) can be detected + auto-retried. Firmware echoes the
+      // request's MeshPacket id back as the reply's request_id, so key by packetId.
+      // The auto-retry send is recorded as already-retried to prevent a loop.
+      this.recordPendingTelemetryRequest(packetId, destination, channel, telemetryType, options?.isAutoRetry ?? false);
 
       return { packetId, requestId };
     } catch (error) {


### PR DESCRIPTION
Fixes #4210

## Problem

When MeshMonitor sends a telemetry request (`TELEMETRY_APP`, port 67, `want_response=true`) to a remote Meshtastic node that has `neighbor_info` enabled, the **firmware hijacks the reply**: the promiscuous `NeighborInfoModule` unconditionally answers (when outside its 3-minute cooldown) with a `NeighborInfo` (port 71) packet, winning the reply race over `DeviceTelemetryModule`. The NeighborInfo reply is directed back to us with `request_id` == our telemetry request's packet id.

This is upstream firmware issue [meshtastic/firmware#11071](https://github.com/meshtastic/firmware/issues/11071) — **not a MeshMonitor send bug**; our outgoing request is correct. The user just sees a telemetry request that never returns data.

## Key empirical facts (hardware-verified)

1. The hijacked NeighborInfo reply **arms the node's 3-minute NeighborInfo cooldown**, so a retry of the same telemetry request returns real telemetry.
2. **The retry must be delayed AND land after the node's want_ack retransmission window.** The hijacking NeighborInfo is want_ack'd, so the node keeps *retransmitting* it for ~10-30s; a retry landing in that window is dropped (LoRa is half-duplex). A **hardware delay-sweep** settled the timing:
   - **5s retry → 0/4 recoveries** (node still retransmitting the hijack).
   - **~38s retry → cleanly recovered real telemetry.**

## The fix: detect + two spaced auto-retries (30s / 70s)

`MeshtasticManager` tracks outstanding telemetry `want_response` requests in a **per-manager**, TTL-bounded (~3 min), size-capped map keyed by packet id (the value firmware echoes back as a reply's `request_id`). The original request and each auto-retry share one **sequence** object, so a telemetry reply matching *any* of their packet ids resolves the whole sequence.

1. `sendTelemetryRequest` records each **original** request as a pending sequence (auto-retries are linked onto the existing sequence, not recorded as new ones).
2. A real `TELEMETRY_APP` reply **resolves the sequence and cancels any outstanding retry timers** (matched by `request_id` against the original or any retry packet id).
3. On a `NeighborInfo` whose `request_id` matches a pending sequence, we start a **two-retry recovery schedule inside the 3-min cooldown**:
   - `TELEMETRY_HIJACK_RETRY_DELAY_MS = 30000` — **retry #1 at 30s**, safely past the want_ack retransmission window (empirically ~38s worked, 5s failed).
   - `TELEMETRY_HIJACK_RETRY_2_DELAY_MS = 70000` — **retry #2 at 70s from the hijack**, an RF-loss backstop, still well inside the cooldown.
   - Retry #1 fires only if the request is **still unresolved and connected**; after sending it schedules retry #2. Retry #2 fires only if still unresolved and connected. No further retries.
   - The `NeighborInfo` is **still processed/stored normally** (valid neighbor data — never dropped). The frontend telemetry loading state is 30s, so a recovery on retry #1 is essentially invisible to users.
4. **Loop-guarded:** the sequence is marked retried *before* scheduling, so a second hijack during the window is ignored — the sequence starts at most once.
5. **Teardown-safe:** every outstanding retry timer is tracked and cancelled on `disconnect()` (which also clears the pending map); a timer that fires after disconnect is a no-op. The 3-min pending TTL comfortably covers the ~70s schedule.
6. **Per-source correct:** the map + timers live on each source's manager instance, so replies naturally stay on the same source; nothing is global.

## Tests

`meshtasticManager.telemetryNeighborHijack.test.ts` (15 tests, fake timers): no send before 30s; **retry #1 fires exactly at 30s**; **retry #2 at 70s only if still unresolved**; a telemetry reply **before 30s cancels both**; a reply **between 30s and 70s cancels retry #2** (only retry #1 sent); NeighborInfo data still persisted; matching reply pre-clears the sequence (no retry); non-matching / unsolicited NeighborInfo → no retry; sequence starts **at most once** under a second in-window hijack; **no fire if disconnected before the timer**; `disconnect()` cancels **all** timers + clears pending; **TTL (3 min) covers the full 70s schedule**; expired entries pruned; map size bounded.

Full Vitest suite: **9715 passed, 0 failed**. `tsc --noEmit` clean, `npm run lint:ci` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
