### PR TITLE
Fix case-sensitive TRUST_PROXY parsing (#4216)

### DIFF
--- a/src/server/config/environment.trustproxy.test.ts
+++ b/src/server/config/environment.trustproxy.test.ts
@@ -64,5 +64,47 @@ describe('Trust Proxy Environment Configuration', () => {
       expect(config.trustProxyProvided).toBe(true);
       expect(config.trustProxy).toBe(false);
     });
+
+    it('should treat an IP/CIDR string as a string value', () => {
+      process.env.TRUST_PROXY = '10.0.0.0/8';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxyProvided).toBe(true);
+      expect(config.trustProxy).toBe('10.0.0.0/8');
+    });
+  });
+
+  describe('Case-insensitive booleans (issue #4216)', () => {
+    it.each(['TRUE', 'True', 'tRuE'])('should parse TRUST_PROXY=%s as boolean true', (value) => {
+      process.env.TRUST_PROXY = value;
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxyProvided).toBe(true);
+      expect(config.trustProxy).toBe(true);
+    });
+
+    it.each(['FALSE', 'False', 'fAlSe'])('should parse TRUST_PROXY=%s as boolean false', (value) => {
+      process.env.TRUST_PROXY = value;
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxyProvided).toBe(true);
+      expect(config.trustProxy).toBe(false);
+    });
+
+    it('should tolerate surrounding whitespace', () => {
+      process.env.TRUST_PROXY = '  true  ';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.trustProxyProvided).toBe(true);
+      expect(config.trustProxy).toBe(true);
+    });
   });
 });

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -122,7 +122,7 @@ function parseRateLimit(
 
 /**
  * Parse trust proxy setting
- * Supports: 'true', 'false', numbers (1, 2, etc.), or IP/CIDR strings
+ * Supports: 'true', 'false' (case-insensitive), numbers (1, 2, etc.), or IP/CIDR strings
  * See: https://expressjs.com/en/guide/behind-proxies.html
  */
 function parseTrustProxy(
@@ -134,22 +134,24 @@ function parseTrustProxy(
     return { value: defaultValue, wasProvided: false };
   }
 
-  // Handle boolean values
-  if (envValue === 'true') {
+  const trimmed = envValue.trim();
+
+  // Handle boolean values (case-insensitive: TRUE, False, etc.)
+  if (trimmed.toLowerCase() === 'true') {
     return { value: true, wasProvided: true };
   }
-  if (envValue === 'false') {
+  if (trimmed.toLowerCase() === 'false') {
     return { value: false, wasProvided: true };
   }
 
-  // Handle numeric values (1, 2, etc.)
-  const parsed = parseInt(envValue, 10);
-  if (!isNaN(parsed)) {
-    return { value: parsed, wasProvided: true };
+  // Handle numeric values (1, 2, etc.) — whole-string match only, so IP
+  // addresses like "10.0.0.0/8" aren't truncated to their leading digits
+  if (/^\d+$/.test(trimmed)) {
+    return { value: parseInt(trimmed, 10), wasProvided: true };
   }
 
   // Otherwise treat as string (IP address or CIDR notation)
-  return { value: envValue, wasProvided: true };
+  return { value: trimmed, wasProvided: true };
 }
 
 /**


### PR DESCRIPTION
parseTrustProxy() only matched lowercase 'true'/'false', so values like
TRUST_PROXY=TRUE fell through to the IP/CIDR branch and Express rejected
them with a confusing "invalid IP address: TRUE" error.

- Trim and case-fold the value before the boolean comparisons
- Only treat the value as a numeric hop count when the whole string is
  an integer; previously parseInt() truncated IP strings like
  "10.0.0.0/8" to their leading digits (10), silently misconfiguring
  trust proxy as a hop count
- Add regression tests for mixed-case booleans, whitespace, and CIDR
  strings

Fixes #4216

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D3BmjMACTyCccZsY15e7f3