### PR TITLE
Make parseBoolean() env var parsing case-insensitive

### DIFF
--- a/src/server/config/environment.parseBoolean.test.ts
+++ b/src/server/config/environment.parseBoolean.test.ts
@@ -50,10 +50,55 @@ describe('parseBoolean via COOKIE_SECURE', () => {
     expect(getEnvironmentConfig().cookieSecure).toBe(true);
   });
 
+  it('should report wasProvided=true for valid values', () => {
+    process.env.COOKIE_SECURE = 'TRUE';
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().cookieSecureProvided).toBe(true);
+  });
+
   it('should fall back to the default for invalid values', () => {
     process.env.COOKIE_SECURE = 'yes';
     resetEnvironmentConfig();
 
-    expect(getEnvironmentConfig().cookieSecure).toBe(false);
+    const config = getEnvironmentConfig();
+
+    expect(config.cookieSecure).toBe(false);
+    expect(config.cookieSecureProvided).toBe(false);
+  });
+});
+
+describe('VERSION_CHECK_DISABLED parsing', () => {
+  const originalValue = process.env.VERSION_CHECK_DISABLED;
+
+  afterEach(() => {
+    if (originalValue !== undefined) {
+      process.env.VERSION_CHECK_DISABLED = originalValue;
+    } else {
+      delete process.env.VERSION_CHECK_DISABLED;
+    }
+    resetEnvironmentConfig();
+  });
+
+  it('should default to false when not set', () => {
+    delete process.env.VERSION_CHECK_DISABLED;
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().versionCheckDisabled).toBe(false);
+  });
+
+  // Previously a raw `== "true"` comparison, so TRUE silently became false
+  it.each(['true', 'TRUE', 'True'])('should parse VERSION_CHECK_DISABLED=%s as true', (value) => {
+    process.env.VERSION_CHECK_DISABLED = value;
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().versionCheckDisabled).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', 'False'])('should parse VERSION_CHECK_DISABLED=%s as false', (value) => {
+    process.env.VERSION_CHECK_DISABLED = value;
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().versionCheckDisabled).toBe(false);
   });
 });

--- a/src/server/config/environment.parseBoolean.test.ts
+++ b/src/server/config/environment.parseBoolean.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Boolean Environment Variable Parsing Tests
+ *
+ * Guards parseBoolean() case-insensitivity via getEnvironmentConfig():
+ * values like COOKIE_SECURE=TRUE must parse as booleans instead of
+ * falling through to the default-with-warning path (follow-up to the
+ * TRUST_PROXY casing fix in #4216 / PR #4218).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resetEnvironmentConfig, getEnvironmentConfig } from './environment.js';
+
+describe('parseBoolean via COOKIE_SECURE', () => {
+  const originalCookieSecure = process.env.COOKIE_SECURE;
+
+  afterEach(() => {
+    if (originalCookieSecure !== undefined) {
+      process.env.COOKIE_SECURE = originalCookieSecure;
+    } else {
+      delete process.env.COOKIE_SECURE;
+    }
+    resetEnvironmentConfig();
+  });
+
+  it('should default to false when COOKIE_SECURE is not set', () => {
+    delete process.env.COOKIE_SECURE;
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().cookieSecure).toBe(false);
+  });
+
+  it.each(['true', 'TRUE', 'True', 'tRuE'])('should parse COOKIE_SECURE=%s as true', (value) => {
+    process.env.COOKIE_SECURE = value;
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().cookieSecure).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', 'False', 'fAlSe'])('should parse COOKIE_SECURE=%s as false', (value) => {
+    process.env.COOKIE_SECURE = value;
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().cookieSecure).toBe(false);
+  });
+
+  it('should tolerate surrounding whitespace', () => {
+    process.env.COOKIE_SECURE = '  true  ';
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().cookieSecure).toBe(true);
+  });
+
+  it('should fall back to the default for invalid values', () => {
+    process.env.COOKIE_SECURE = 'yes';
+    resetEnvironmentConfig();
+
+    expect(getEnvironmentConfig().cookieSecure).toBe(false);
+  });
+});

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -19,8 +19,8 @@ import { logger } from '../../utils/logger.js';
 /**
  * Parse boolean environment variable
  * - undefined → defaultValue
- * - 'true' → true
- * - 'false' → false
+ * - 'true' (case-insensitive) → true
+ * - 'false' (case-insensitive) → false
  * - anything else → defaultValue with warning
  */
 function parseBoolean(
@@ -32,11 +32,13 @@ function parseBoolean(
     return { value: defaultValue, wasProvided: false };
   }
 
-  if (envValue === 'true') {
+  const normalized = envValue.trim().toLowerCase();
+
+  if (normalized === 'true') {
     return { value: true, wasProvided: true };
   }
 
-  if (envValue === 'false') {
+  if (normalized === 'false') {
     return { value: false, wasProvided: true };
   }
 

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -497,7 +497,11 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     50
   );
 
-  const versionCheckDisabled = process.env.VERSION_CHECK_DISABLED == "true";
+  const versionCheckDisabled = parseBoolean(
+    'VERSION_CHECK_DISABLED',
+    process.env.VERSION_CHECK_DISABLED,
+    false
+  );
 
   // Meshtastic
   const meshtasticNodeIp = {
@@ -743,7 +747,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   logger.debug(`   ALLOWED_ORIGINS: ${allowedOrigins.value || '*'} (${src(allowedOrigins.wasProvided)})`);
   logger.debug(`   IFRAME_ALLOWED_ORIGINS: ${iframeAllowedOrigins.value.length > 0 ? iframeAllowedOrigins.value.join(',') : '(not set - iframe embedding blocked)'} (${src(iframeAllowedOrigins.wasProvided)})`);
   logger.debug(`   TRUST_PROXY: ${trustProxy.value} (${src(trustProxy.wasProvided)})`);
-  logger.info(`   VERSION_CHECK_DISABLED: ${versionCheckDisabled}`);
+  logger.info(`   VERSION_CHECK_DISABLED: ${versionCheckDisabled.value} (${src(versionCheckDisabled.wasProvided)})`);
   logger.debug('   --- Session/Security ---');
   logger.debug(`   SESSION_SECRET: ${sessionSecretProvided ? '***provided***' : '(auto-generated)'}`);
   logger.debug(`   SESSION_COOKIE_NAME: ${sessionCookieName.value} (${src(sessionCookieName.wasProvided)})`);
@@ -833,7 +837,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     iframeAllowedOriginsProvided: iframeAllowedOrigins.wasProvided,
     trustProxy: trustProxy.value,
     trustProxyProvided: trustProxy.wasProvided,
-    versionCheckDisabled: versionCheckDisabled,
+    versionCheckDisabled: versionCheckDisabled.value,
 
     // Session/Security
     sessionSecret,


### PR DESCRIPTION
Follow-up to #4216 / #4218, addressing the reviewer note from that PR: `parseBoolean()` had the same case-sensitivity footgun as `parseTrustProxy()` — values like `COOKIE_SECURE=TRUE` or `SESSION_ROLLING=False` fell through to the default-with-warning path instead of parsing as booleans.

- Trim and case-fold the value before the `'true'`/`'false'` comparisons, matching the fixed `parseTrustProxy()` behavior
- Add regression tests (mixed-case, whitespace, invalid-value fallback) exercising the parser via `COOKIE_SECURE`

Affects all `parseBoolean`-backed env vars: `SESSION_ROLLING`, `COOKIE_SECURE`, `OIDC_AUTO_CREATE_USERS`, `OIDC_ALLOW_HTTP`, `DISABLE_LOCAL_AUTH`, `DISABLE_ANONYMOUS`, `PROXY_AUTH_ENABLED`, `PROXY_AUTH_AUTO_PROVISION`, `PROXY_AUTH_AUDIT_LOGGING`, `ACCESS_LOG_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3BmjMACTyCccZsY15e7f3

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3BmjMACTyCccZsY15e7f3)_