### PR TITLE
release: v4.13.1 (version bump + docs/blog for Link Quality & 2.8 preview)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.1-rc4",
+  "version": "4.13.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.1-rc4",
+  "version": "4.13.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/blog/2026-07-20-v4.13.1-release.md
+++ b/docs/blog/2026-07-20-v4.13.1-release.md
@@ -1,0 +1,49 @@
+---
+id: news-2026-07-20-v4-13-1-release
+title: MeshMonitor v4.13.1 - Link Quality Tools & a Meshtastic 2.8 Early Preview
+date: '2026-07-20T16:00:00Z'
+category: release
+priority: important
+minVersion: 4.13.1
+tags: [release, link-quality, map, meshtastic-2.8, preview]
+---
+
+MeshMonitor **v4.13.1** builds on the "one map core" foundation from 4.13 with a set of **link-quality tools** for the RF-minded, and an **early preview** of several Meshtastic 2.8 features so you can start seeing them the moment you flash a 2.8 build. There's also a firmware-quirk fix worth calling out for anyone requesting telemetry from neighbour-info nodes.
+
+## Link Quality: see how your links are really doing
+
+If you care about *why* a node is hard to reach — not just that it is — this release is for you.
+
+- **Terrain Link Profile.** On Map Analysis, pick two nodes and get a full terrain cross-section between them: the ground profile from real elevation data, the **Fresnel zone**, and a **link budget** verdict (clear / marginal / obstructed) colored right on the graph. It auto-picks the frequency for your region, handles elevation-data voids gracefully, and the graph cursor mirrors onto the map so you can see exactly where along the path that ridge is. This is the tool for answering "would a repeater on that hill actually help?"
+- **Signal-trend / link-attenuation badge.** Each node now carries a derived badge summarizing whether its link is holding steady, improving, or degrading over time — an at-a-glance read on link health without digging into graphs.
+- **Noise Floor** is now on the Node Detail quick-stats card, alongside SNR and RSSI, so you can tell a weak-signal problem from a noisy-environment problem.
+- **Position accuracy & source in popups.** Node popups (map and chat) now show how precise a position is and where it came from — GPS, a fixed position, or an estimate — so you know how much to trust that dot.
+
+## Map Analysis: the toolbar grew up
+
+- The Map Analysis toolbar is now **icon-based**, with labels moved to tooltips — more map, less chrome.
+- New **Show RF / UDP / MQTT** transport toggles let you filter the map by how packets actually arrived.
+- **Obscured-node handling** got smarter: overlapping markers are offset only when they genuinely share a map cell, scaled by how crowded that cell is, so lone nodes stay put and dense clusters fan out cleanly.
+- A **"Discard invalid positions"** map setting (honored on both ingest and render), plus a pile of fixes: spiderfy no longer opens the wrong node's popup, SNR overlay dots pin to the merged marker for multi-source nodes, and route/heatmap density no longer renders for marker-less or deleted nodes.
+
+## Meshtastic 2.8 — Early Preview
+
+> ⚠️ **This is an early preview.** Meshtastic 2.8 has **not been officially released** — there's no 2.8 tag yet, so MeshMonitor builds this support against the firmware's development branch. Expect these features to **change as 2.8 evolves**, and treat anything here as subject to revision until the firmware ships stable.
+
+With that caveat firmly in place, 4.13.1 gets a head start on 2.8 so the data shows up automatically when you run a preview build:
+
+- **XEdDSA signature shield.** 2.8 can cryptographically sign packets. The Packet Monitor now decodes `MeshPacket.xeddsa_signed` and shows a 🛡️ shield next to signed packets, with the signing status persisted per packet (tri-state: unknown / unsigned / device-verified). The first signed packet from a 2.8 node will light it up.
+- **MeshBeacon decoding.** The new `MESH_BEACON_APP` beacons are decoded and surfaced in the Packet Monitor — beacon text plus the channel/preset it's advertising.
+- **MEDIUM_TURBO preset.** The new modem preset is in the preset tables, with firmware-verified channel-name derivation (which also fixed a long-standing naming bug in the older presets along the way).
+
+**A firmware heads-up while you're here:** 2.8 makes **position and telemetry broadcast opt-in**, and a freshly flashed node defaults **position precision to off**. If a node goes quiet on the map or stops reporting telemetry after upgrading, that's expected 2.8 behavior — not a MeshMonitor bug. The [FAQ](/faq) has the details.
+
+## Also in this release
+
+- **Telemetry that survives a firmware quirk.** Some 2.x nodes with neighbour-info enabled hijack the reply to a telemetry request and send NeighborInfo instead (an upstream firmware behavior — [firmware#11071](https://github.com/meshtastic/firmware/issues/11071)). MeshMonitor now detects this and automatically retries the telemetry request, so you get the metrics you asked for instead of silence.
+- **Privacy toggle:** a new setting serves `X-Robots-Tag: noindex` headers and a disallow-all `robots.txt`, so a publicly-exposed dashboard can ask search engines and crawlers to stay out.
+- **`TRUST_PROXY` and boolean env vars** are now parsed case-insensitively — `True`, `TRUE`, and `true` all work.
+- **Chat timestamps** from unsynced-clock nodes no longer render back in 1970.
+- Plus MQTT, message, and MeshCore fixes, dependency updates, and the usual round of polish. The [full changelog](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md) has every entry.
+
+As always, a lot of the best fixes here started as detailed bug reports — thank you. Flash a 2.8 preview build and let us know what the shield and beacons look like in the wild.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -281,6 +281,22 @@ MeshMonitor **keeps all previously collected history** — nothing you already g
 
 ---
 
+### What is MeshMonitor's "firmware 2.8 early preview" decode support? {#firmware-2-8-early-preview}
+
+::: info Not released yet
+As above, firmware 2.8 is **not officially released** (latest stable is v2.7.26). MeshMonitor has started decoding a few 2.8-only wire formats ahead of release so nothing breaks the day it ships, but these are necessarily built against pre-release protobuf definitions and may still change.
+:::
+
+A few things you may notice if you're running a 2.8 development build:
+
+- **Signed-packet shield in the Packet Monitor.** Firmware 2.8 introduces an **XEdDSA** packet-signing scheme. When the connected node reports a packet as signature-verified, MeshMonitor shows a small shield icon next to it in the [Packet Monitor](/features/packet-monitor). MeshMonitor doesn't verify the signature itself — it only surfaces what the node already checked.
+- **MeshBeacon decoding.** 2.8 adds a periodic `MESH_BEACON_APP` broadcast that a node can use to advertise a joinable channel (name and modem preset). The Packet Monitor decodes and previews these as `[MeshBeacon: "..."]`.
+- **MEDIUM_TURBO modem preset.** A new 500 kHz "medium range, turbo" preset appears alongside the existing presets in configuration screens that list modem presets. See [Modem Preset](/features/device#modem-preset).
+
+None of this requires any action on your part — it's read-only decode support so MeshMonitor stays useful against nodes running early 2.8 builds. Expect this section to be replaced with normal release documentation once 2.8 ships.
+
+---
+
 ## 🔐 User Management
 
 ### How do I reset a user's password as an admin?

--- a/docs/features/device.md
+++ b/docs/features/device.md
@@ -447,6 +447,19 @@ Predefined radio settings that balance range, speed, and reliability. All nodes 
 - **Coding Rate**: 4/7
 - **Best For**: Urban deployments with moderate coverage needs
 
+#### MEDIUM_TURBO
+
+::: tip Firmware 2.8 early preview
+See [What is MeshMonitor's "firmware 2.8 early preview" decode support?](/faq#firmware-2-8-early-preview) — 2.8 is not yet officially released.
+:::
+
+- **Range**: Medium
+- **Speed**: Faster than MEDIUM_FAST
+- **Bandwidth**: 500kHz (widest)
+- **Spreading Factor**: 9
+- **Coding Rate**: 4/5
+- **Best For**: Medium-range deployments that want more throughput than the 250kHz medium presets
+
 #### SHORT_SLOW
 
 - **Range**: Short

--- a/docs/features/global-settings.md
+++ b/docs/features/global-settings.md
@@ -40,6 +40,13 @@ Individual Apprise URLs (per user, per source) are not here — users configure 
 - MFA enforcement defaults
 - Rate-limiter thresholds
 
+### Privacy
+
+::: tip New in 4.13
+:::
+
+- **Discourage search engine & LLM indexing** — opt-in, off by default. When enabled, MeshMonitor adds an `X-Robots-Tag: noindex, nofollow` header to every response and serves a disallow-all `/robots.txt`, asking crawlers not to index the dashboard. Both are advisory (a crawler must choose to honor them); the `/robots.txt` body is offered alongside the header because some reverse proxies (e.g. Cloudflare tunnels) strip custom response headers at the edge.
+
 ### System Backup / Restore
 
 - Create / download / restore system backups (includes the new `sources` table)

--- a/docs/features/link-quality.md
+++ b/docs/features/link-quality.md
@@ -112,3 +112,10 @@ Smart Hops always uses actual message hop counts regardless of this setting. The
 Both features use the `messageHops` telemetry type, which is calculated from each incoming mesh message as `hopStart - hopLimit`. This represents the actual number of relay hops the message traversed to reach your node.
 
 Link Quality additionally factors in traceroute results and encryption error events to provide a more complete reliability picture.
+
+## Signal Trend badge
+
+::: tip New in 4.13
+:::
+
+Don't confuse the Link Quality score above with the **Signal Trend** badge (▲ Improving / → Stable / ▼ Degrading) shown in the [Node Details block](/features/settings#node-details-block) on the Messages page. Signal Trend answers a narrower, RF-focused question: *is this specific node's received signal getting weaker or stronger, day-over-week?* It compares the last 24 hours of RSSI (falling back to SNR when RSSI history is sparse) against the preceding 7-day baseline, and calls out separately when a drop is attributable to a rising local noise floor rather than the link itself. Link Quality, by contrast, is a broader 0-10 reliability score driven by routing (hop-count changes, traceroute failures, encryption errors) rather than raw signal strength. Use Link Quality to judge overall reliability; use Signal Trend to judge whether the RF path itself is changing.

--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -26,6 +26,10 @@ Configuration is per-browser (stored in `localStorage`) and survives reloads.
 
 The page is publicly accessible — but data is silently filtered by your existing per-source permissions. Sources you can't read contribute zero points; nothing renders for them and no error is shown.
 
+::: tip Icon toolbar (New in 4.13)
+The toolbar is now icon-based rather than text-labeled — every button carries a hover tooltip (and `aria-label`) instead of a visible caption, so the same set of controls fits in a much narrower space. Behavior is unchanged; if you're looking for a control by its old label, hover the icons to find it.
+:::
+
 ## Toolbar
 
 The toolbar runs across the top of the canvas. From left to right:
@@ -33,10 +37,14 @@ The toolbar runs across the top of the canvas. From left to right:
 | Control | Purpose |
 | --- | --- |
 | **Source multi-select** | Pick which sources contribute to every layer. "All sources" is the default. |
+| **Node type filter** | Show/hide markers by role category (client, router, sensor, etc. — adapts to whichever source types are connected). |
+| **Transport filter (Show RF / UDP / MQTT)** | Show/hide markers by how the node's most recent packet reached MeshMonitor — over the air (**RF**), the Meshtastic multicast-UDP local transport (**UDP**), or an **MQTT** broker/bridge. Mirrors the same toggle on the Dashboard/Nodes map. A node heard through more than one transport (across sources) stays visible as long as any of its transports is enabled. |
 | **Search box** | Filter visible markers (and traceroute link endpoints) by name or node number. See [Node search](#node-search). |
 | **Node multi-select** | Pick specific nodes to emphasize. Selected nodes render at full opacity; everything else dims. "All nodes" (empty selection) is the default. See [Node selection & emphasis](#node-selection-emphasis). |
 | **Follow / Auto-zoom** | Keep the selected nodes framed as they move — recenter (Follow) and/or fit-to-bounds (Auto-zoom) on each update. See [Follow & Auto-zoom](#follow-auto-zoom). |
 | **Time slider toggle** | Show/hide the floating time-window slider. |
+| **Measure** | Straight-line distance between two positioned nodes. Disabled until at least two positioned nodes exist; mutually exclusive with Link Profile. |
+| **Link Profile** | Terrain, Fresnel clearance, and link-budget verdict between two points. See [Terrain Link Profile](#terrain-link-profile). Only shown when the server has elevation enabled. |
 | **Layer buttons (×8)** | Toggle each visualization layer on/off. The right-edge chevron opens a popover for layer-specific options (lookback window, sub-options). |
 | **Progress bar** | Shows aggregate loading state while any layer is fetching. |
 | **Inspector toggle** | Show/hide the right-side detail panel. |
@@ -114,8 +122,16 @@ Renders every known node from the selected sources using the same icon set as th
 For a node reported by more than one source, the popup includes a **"Seen by N sources"** list with a row per source that links to that source's view — matching the Unified/Dashboard map. The page is also fully multi-source-aware: a node stays visible when **any** of its reporting sources is enabled in the source filter, not only its primary source.
 :::
 
+::: tip Discard invalid positions
+Whether a "Null Island" (0,0) GPS fix renders here follows the global **Discard invalid positions** setting (**Settings → Map**) — the same setting that controls whether it's stored on ingest in the first place. Out-of-range/garbage coordinates are always dropped regardless of this setting. See [Settings → Map Settings](/features/settings#map-settings).
+:::
+
 ::: tip Overlapping markers fan out (New in 4.10)
 When several nodes report the **same coordinates** — a shared site with multiple radios, or a cluster of nodes that inherited one position — they no longer stack into a single un-clickable marker. They **spiderfy** (fan out around the shared point) so each node is individually selectable.
+:::
+
+::: tip Obscured-position offset (New in 4.13)
+A node broadcasting a reduced-precision GPS fix (Meshtastic's `precision_bits`) reports a position snapped to the center of a grid cell that can be well over 100 m across — the true position could be anywhere inside it. When **two or more** such nodes snap to the *same* cell, their markers no longer stack exactly on that center point: each is nudged to a deterministic, stable spot inside its own cell so they're individually clickable without implying a precision the node never reported. A node alone in its cell is left at the true center — nothing to declutter. The nudge distance scales with how many nodes share the cell (more crowding, more spread) and is capped so a very coarse (low-precision) fix never scatters its marker kilometers away. This is separate from the exact-coordinate spiderfy above, and from the dashed **accuracy-region** rectangle (`Show Accuracy`), which always still shows the node's true full cell.
 :::
 
 ### Traceroute paths
@@ -191,6 +207,8 @@ The **verdict** is computed from Fresnel-zone clearance along the path:
 | **Obstructed** | Terrain (plus Earth-curvature bulge) crosses the direct line-of-sight line somewhere along the path. |
 
 Once a verdict is available, the connecting line on the map itself recolors to match (green/amber/red) — so you can see the result without having the drawer's chart in view. It reverts to a neutral amber while no verdict is available yet (still loading, or the pair was just cleared).
+
+Hovering over the chart drops a matching marker on the map at the terrain point under your cursor, so you can correlate a dip or spike in the profile with the actual location along the path. Move off the chart (or clear the pick) to remove it.
 
 ### Link budget inputs
 

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -51,6 +51,8 @@ Click any node marker to view detailed information:
 - Device role
 - Firmware version
 - Network position (hops away)
+- **Position accuracy** (🎯) — a human-readable estimate derived from the node's reported GPS precision (e.g. "~91 m"), shown whenever the node broadcasts a non-full precision fix
+- **Location source** (🛰️) — how the position was obtained: Manual, Internal GPS, or External GPS. Hidden when the node hasn't reported a source.
 
 ### Map Controls
 
@@ -65,6 +67,10 @@ Click any node marker to view detailed information:
 - **Tileset Selector**: Bottom-center visual picker to switch between map styles
 - **Default Tilesets**: OpenStreetMap, Satellite, Topographic, Dark/Light modes
 - **Custom Tilesets**: Any configured custom tile servers appear in the selector
+
+::: tip Per-theme tileset preferences (New in 4.13)
+MeshMonitor remembers a **separate tileset preference for light and dark appearance**, so switching your color theme (e.g. Catppuccin Latte → Mocha) can also switch your map style automatically — a light OSM style while your UI is light, a dark CartoDB style once you flip to a dark theme, without picking the tileset again each time. Configure both in **Settings → Map Settings** (see below); the visual picker on the map always changes the tileset for whichever appearance is currently active.
+:::
 
 #### Map Navigation
 
@@ -251,7 +257,7 @@ See the [Custom Tile Servers](/configuration/custom-tile-servers) guide for comp
 **Method 1: Settings Tab**
 
 1. Navigate to **Settings** → **Map Settings**
-2. In the **Map Tileset Selection** dropdown, choose your desired tileset
+2. Choose your desired tileset from the **Light Mode Tileset** and/or **Dark Mode Tileset** dropdowns — each applies only while the matching UI appearance is active
 3. Click **Save Settings**
 4. The map will reload with the new tileset
 

--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -310,6 +310,14 @@ If you're seeing your private broker flood the mesh after attaching a bridge to 
 - Confirm the device's MQTT credentials match the broker source's `auth.username` / `auth.password`.
 - The broker enforces default-deny auth: connections without configured credentials are rejected. Check the device's MQTT log for "Connection refused: Bad username or password" — if firmware logs aren't visible, watch the broker's `lastError` field on `/api/sources/:id/status`.
 
+### A known node is missing from the map / messages, but its packets show up as "geo-ignored"
+
+MeshMonitor supports a per-source **geo-ignore** membership model for MQTT: nodes reporting a position outside your configured coverage area can be automatically ignored so noisy public/community brokers don't flood your map with distant traffic. If a node you expect to see is missing:
+
+- Check the [MQTT Packet Monitor](/features/packet-monitor#mqtt-sources) — copies dropped by this filter are still captured and flagged with a `geo-ignored` outcome badge, so you can confirm this is what happened to a specific packet.
+- Review and manage the resulting entries in this source's **Edit Source → Automation → Ignored Nodes** list — geo-ignored nodes show a **Geo filter** badge (as opposed to a manually-ignored node), and can be un-ignored from there like any other ignored node.
+- A node that moves back inside the coverage area is automatically un-ignored on a later packet — you don't need to intervene unless you want to.
+
 ### `packetsIn` climbing, `packetsIngested` stays low
 
 Most upstream traffic and most device-publish traffic is encrypted at the channel-payload level (e.g. `LongFast` PSK). MeshMonitor doesn't have those PSKs at the broker level, so the packets get **republished** (they reach other devices and bridges) but **not ingested into the DB**. `packetsDropped` counts these. This is normal — only decodable packets (NodeInfo, unencrypted Position/Telemetry, etc.) end up in `nodes` / `messages` tables under the broker's sourceId.

--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -40,6 +40,11 @@ The Packet Monitor displays **only incoming packets** received from the mesh net
 | TELEMETRY (67) | Device/environment telemetry |
 | TRACEROUTE (70) | Traceroute responses |
 | NEIGHBORINFO (71) | Neighbor information |
+| MESH_BEACON (37) | Firmware 2.8+ periodic beacon advertising a joinable channel (name/preset) — [early preview](/faq#firmware-2-8-early-preview), decoded as `[MeshBeacon: "..."]` |
+
+::: tip Signed-packet shield (firmware 2.8 early preview)
+Packets carrying a firmware-verified **XEdDSA signature** (Meshtastic's new packet-signing scheme, not yet in an official release) show a small shield icon next to the entry. This only reflects what the connected node itself reported as verified — MeshMonitor doesn't re-verify the signature.
+:::
 
 ### Packets That Do NOT Appear
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -222,6 +222,10 @@ The Node Details block provides comprehensive information about the currently se
   - Shows absolute signal strength
   - Lower (more negative) values indicate weaker signal
 
+- **Signal Trend** ▲/→/▼ *(New in 4.13)*: A derived "is this link getting worse?" indicator, distinct from the [Link Quality](/features/link-quality) score. It compares the last 24 hours of RSSI (or SNR, when RSSI history is too sparse) against the preceding 7-day baseline: **Improving** (▲), **Stable** (→), or **Degrading** (▼). Hover the badge for the underlying dB deltas. When the drop is attributable to a rising noise floor rather than the link itself, the tooltip calls that out explicitly. Only shown once enough history exists to say something meaningful.
+
+- **Noise Floor** *(New in 4.13)*: The node's self-reported RF noise floor in dBm, shown alongside RSSI/SNR when the device provides it.
+
 #### Network Performance
 - **Channel Utilization**: Percentage of airtime used by all nodes
   - Helps identify network congestion
@@ -258,6 +262,10 @@ The Node Details block provides comprehensive information about the currently se
 
 - **Via MQTT**: Indicates if node connected via MQTT bridge
   - Shows when node is reachable through MQTT instead of radio
+
+#### Location *(New in 4.13)*
+- **Position**: The node's latitude/longitude as plain text (5 decimal places) — shown so a bad fix (e.g. `0.00000, 0.00000`) is visible at a glance without opening the map
+- **Elevation**: The node's reported GPS altitude in meters
 
 #### Activity
 - **Last Heard**: When the node was last active
@@ -342,9 +350,26 @@ When information is unavailable, the block displays "N/A" for that metric. This 
 
 ## Map Settings
 
+### Discard Invalid Positions
+
+::: tip New in 4.13
+:::
+
+**Description**: Controls whether GPS fixes reported at **Null Island** (0, 0) — including precision-obscured positions that snap to that grid cell — are discarded or kept.
+
+**Default**: Enabled (discard)
+
+**Effect**: When enabled (default), a (0,0) position is dropped **on ingest**, across every source, and never stored. Disable it to store and display these positions as received — useful if you want to identify which nodes are transmitting bad/unset GPS fixes. Out-of-range or otherwise garbage coordinates (NaN, outside ±90/±180°) are always discarded regardless of this setting.
+
+**Location**: Settings → Map Settings
+
 ### Map Tileset Selection
 
 **Description**: Choose which map tile server to use for displaying your mesh network on the interactive map.
+
+::: tip Per-theme selection (New in 4.13)
+The tileset is now chosen **separately for light and dark appearance** — a **Light Mode Tileset** and a **Dark Mode Tileset**, each applied automatically when the matching color theme is active. Existing single-tileset selections were preserved for both slots on upgrade.
+:::
 
 **Default Tilesets**:
 - **OpenStreetMap** (default) - Standard OSM map style
@@ -355,8 +380,8 @@ When information is unavailable, the block displays "N/A" for that metric. This 
 - **ESRI Satellite** - Satellite imagery
 
 **Location**:
-- **Settings Tab**: Map Settings section
-- **Nodes Tab**: Bottom-center tileset selector (visual picker)
+- **Settings Tab**: Map Settings section (Light Mode Tileset / Dark Mode Tileset)
+- **Nodes Tab**: Bottom-center tileset selector (visual picker) — updates whichever slot matches your current appearance
 
 **Effect**: Changes the base map layer displayed on the interactive map. Different tilesets offer different visual styles, levels of detail, and use cases.
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.1-rc4
-appVersion: "4.13.1-rc4"
+version: 4.13.1
+appVersion: "4.13.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1-rc4",
+  "version": "4.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.1-rc4",
+      "version": "4.13.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1-rc4",
+  "version": "4.13.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Promotes **4.13.1-rc4 → 4.13.1** (official release) and brings docs + news current with everything since 4.13.0.

## Version bump (5 files)
`package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml` → **4.13.1**.

## Release blog / news
New `docs/blog/2026-07-20-v4.13.1-release.md` — **Link Quality tools** (Terrain Link Profile, signal-trend/attenuation badge, Noise Floor, position accuracy) and a **Meshtastic 2.8 Early Preview** section (XEdDSA shield, MeshBeacon, MEDIUM_TURBO) explicitly framed as preview/subject-to-change since no official 2.8 release exists yet. `news.json` regenerates from it during the docs build (vitepress `buildStart` plugin).

## Docs refresh (user-facing)
Updated 9 pages under `docs/features/` + `docs/faq.md` for: icon-based Map Analysis toolbar, RF/UDP/MQTT transport toggles, obscured-node precision offset, Discard-invalid-positions, per-theme tilesets, Terrain Link Profile, signal-trend badge, Noise Floor, position accuracy/source, MQTT geo-ignore observability, noindex/robots privacy setting, and a curated 2.8 early-preview FAQ entry.

## Verification
- Version consistent across all 5 files; lockfile regenerated.
- `npm run docs:build` passes (no dead links).
- CI gates below.

Holding merge + the actual release cut for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
