### PR TITLE
feat(map-analysis): neighbor-link terrain integration (#3826 Phase 1)

### DIFF
--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -153,6 +153,8 @@ The inspector also shows a per-node summary: distinct links, in/out counts, obse
 
 Polylines connecting each node to the neighbors reported in its NeighborInfo packets. Edges use opacity to indicate signal quality and are rendered dashed to distinguish them from active traceroute paths.
 
+Clicking a neighbor link opens it in the inspector, which shows the link's great-circle **distance** alongside the reported SNR. When the server has elevation enabled, the inspector also shows the **ground elevation** at each endpoint and a **View terrain profile** button that opens the [Terrain Link Profile](#terrain-link-profile) drawer pre-loaded with the link's two endpoints — the same terrain/Fresnel/link-budget analysis as picking the points by hand, one click from any neighbor link. This works for both Meshtastic and MeshCore neighbor links, as long as both endpoints have known positions.
+
 ### Coverage heatmap
 
 A heat layer built from accumulated position fixes. At low zoom the server returns a **pre-binned coverage grid** for performance; at high zoom (≳12) the client falls back to raw position points. If the result set exceeds 50,000 points, the newest 50k are shown with a banner suggesting a narrower lookback.
@@ -253,6 +255,7 @@ The right-side dock mirrors your current map selection.
 - **Empty:** "Click a node or route segment".
 - **Node selected:** short/long name, node num, hop count, neighbor count, last position timestamp, last SNR/RSSI, list of sources currently reporting it, and a link out to that source's Nodes tab.
 - **Segment selected:** from/to nodes, the last ten traceroutes for the segment with their forward/back SNR, and an **Open full history** button that opens the existing `RouteSegmentTraceroutesModal`.
+- **Neighbor link selected:** both endpoint nodes, reporting source, SNR, and the link's great-circle distance. With elevation enabled, also the ground elevation at each endpoint and a **View terrain profile** shortcut into the Link Profile drawer.
 
 The inspector is collapsible — toggle it from the far-right toolbar button.
 

--- a/docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md
@@ -1,0 +1,81 @@
+# 3D Map & Elevation Epic (#3826)
+
+**Issue:** #3826 — Feature consideration: 3D map mode for elevation display and indoor venue support
+**Started:** 2026-07-20
+**Orchestrator:** /epic harness (Fable)
+
+## Goal
+
+Deliver the two viable tracks from issue #3826:
+
+1. **Interim elevation track:** integrate the existing terrain/link-profile machinery (epic #4111, fully merged) with neighbor links in Map Analysis — per-link distance, endpoint ground elevation, and one-click terrain profile.
+2. **3D map mode:** a real 3D terrain view (MapLibre GL standalone, not the Leaflet adapter) surfaced as a 2D/3D toggle on the Map Analysis page, with DEM terrain, node markers, neighbor links, and traceroute paths.
+
+## Interview decisions (2026-07-20)
+
+- **Scope:** both tracks (interim + 3D).
+- **3D surface:** Map Analysis page gets a 2D/3D toggle. Other maps (Nodes, Dashboard, Embed) stay 2D — future follow-ups.
+- **DEM tiles for the browser:** served via a **server proxy** endpoint (`/api/elevation/tiles/...`) honoring the admin-configured `elevationSourceUrl` (hides keys, reuses server tile cache). Direct client fetch of public terrarium rejected.
+- **Indoor venue / custom 3D tilesets: OUT OF SCOPE.** Closing comment on #3826 should note it as a possible future follow-up (3D buildings via fill-extrusion would be the cheap first step).
+- **Phase structure:** user chose to merge the originally separate "tile proxy" and "3D foundation" phases into one PR → 3 phases total.
+
+## Prior art this epic builds on (do not duplicate)
+
+- **Elevation backend (#4111 Ph1, PR #4143):** `src/server/services/elevationProvider.ts` (TerrariumTileProvider w/ LRU tile cache, JsonPointProvider, SSRF guard, `-500..9000m` clamp), `elevationService.ts` (`computeProfile`), `elevationRoutes.ts` (`POST /api/elevation/profile`, `POST /api/elevation/test`), settings keys `elevationEnabled` / `elevationSourceUrl`.
+- **Link Profile UI (#4111 Ph2/Ph3, PRs #4147/#4151, follow-ups #4156/#4170):** `src/hooks/useElevationProfile.ts`, `useElevationEnabled.ts`, `src/utils/linkProfile.ts` + `linkBudget.ts` + `greatCircle.ts`, `src/components/MapAnalysis/LinkProfileController.tsx` / `LinkProfileDrawer.tsx` / `LinkProfileHoverLayer.tsx`, `MapAnalysisContext.tsx` (`linkProfileMode`, `linkEndpoints`, `linkVerdict`).
+- **Map shell (#4047):** `src/components/map/BaseMap.tsx` (Leaflet; raster/vector branch), `src/components/map/layers/NeighborLinksLayer.tsx`, `src/utils/neighborLinks.ts`.
+- **Map Analysis workspace:** `src/pages/MapAnalysisPage.tsx`, `MapAnalysisCanvas.tsx`, `AnalysisInspectorPanel.tsx` (neighbor branch shows only SNR today), `useMapAnalysisData.ts`, `analysisApi.ts`.
+- **Key datum decision (KEEP):** link-profile math uses DEM ground elevation + antenna AGL, deliberately ignoring node GPS altitude (GPS-vs-DEM datum mismatch; see `LINK_PROFILE_TOOL_SPEC.md` §0/§2.2).
+- `maplibre-gl` ^5.24.0 is already a dependency (currently only used through the Leaflet adapter for flat vector tiles).
+
+## Phases
+
+### Phase 1 — Neighbor-link terrain integration ✅
+
+Branch: `feature/3826-neighbor-link-terrain`
+
+Scope:
+- Map Analysis inspector (`AnalysisInspectorPanel` neighbor branch): show link distance and, when elevation is enabled, endpoint ground elevations.
+- "View terrain profile" action on a selected neighbor link → feeds both endpoints into the existing LinkProfile drawer flow (reuse `MapAnalysisContext` link-profile state; do NOT build a parallel drawer).
+- Works for both Meshtastic and MeshCore neighbor links when both endpoints have positions; graceful absence otherwise.
+- Gated on `elevationEnabled` (`useElevationEnabled`).
+
+Exit criteria:
+- Selecting a neighbor link shows distance (+ elevations when enabled) and a working profile action that opens the existing drawer with correct endpoints.
+- Vitest coverage for the inspector changes + any new pure helpers; full suite green.
+- Browser-validated on the dev container.
+
+### Phase 2 — DEM tile proxy + 3D map foundation ⬜
+
+Branch: `feature/3826-3d-map-foundation`
+
+Scope:
+- **Backend:** `GET /api/elevation/tiles/:z/:x/:y` proxying terrarium raster-dem tiles from the configured `elevationSourceUrl` (reuse `TerrariumTileProvider` URL/fetch/SSRF logic and caching; define behavior when the configured source is a JSON point provider — expected: fall back to default terrarium URL or 404 with a machine code, architect decides). Rate-limited, `optionalAuth`, gated on `elevationEnabled`. Response envelope rules apply to JSON errors (binary tile body on success).
+- **Frontend:** standalone MapLibre GL map component (new, sibling to Leaflet `BaseMap` — e.g. `src/components/map/Base3DMap.tsx`), with: current raster tileset as basemap source, `raster-dem` terrain from the proxy, hillshade layer, pitch/bearing navigation + terrain exaggeration control.
+- 2D/3D toggle on Map Analysis; 3D mode renders node markers (minimum viable layer set). Toggle state persists (localStorage or context, consistent with existing Map Analysis prefs).
+- 3D unavailable states handled: elevation disabled, vector-only custom tileset (raster fallback), JSON point source.
+
+Exit criteria:
+- Tile proxy endpoint tested (route tests via harness) incl. gating + fallback behavior.
+- 3D toggle renders pitched terrain with hillshade + node markers on the dev container; 2D mode unchanged/regression-free.
+- Full suite green; browser-validated with screenshots.
+
+### Phase 3 — 3D layers + polish ⬜
+
+Branch: `feature/3826-3d-layers-polish`
+
+Scope:
+- Neighbor links and traceroute paths rendered in 3D mode.
+- Selection/inspector wiring in 3D (click node/link → `AnalysisInspectorPanel`, incl. the Phase 1 terrain-profile action).
+- Settings surface as needed (e.g. default exaggeration) — remember `VALID_SETTINGS_KEYS` + `SettingsTab` handleSave dep array.
+- Docs: README/docs updates for the 3D mode + elevation proxy; update this epic doc; closing comment plan for #3826 noting indoor support as future work.
+
+Exit criteria:
+- Feature parity in 3D for nodes/neighbor-links/traceroutes incl. selection.
+- Docs merged; full suite green; browser-validated.
+- Issue #3826 closable with a summary + follow-up notes.
+
+## Status log
+
+- 2026-07-20: Epic started. Interview complete, phases agreed (3 phases; user merged tile-proxy + 3D-foundation into Phase 2).
+- 2026-07-20: Phase 1 implemented (spec: `NEIGHBOR_LINK_TERRAIN_SPEC.md`). Frontend-only; new `neighborLinkEndpoints.ts` resolver + inspector wiring. Key decisions during the phase: endpoint elevations reuse `useElevationProfile` with the drawer's exact query key (one fetch per link, drawer open is a cache hit — verified live, request count stayed at 1); `LinkEndpoint.id` uses `unifiedNodeKey` for byte-for-byte parity with `linkEndpointCandidates`. Browser-validated on the dev container: MeshCore link (distance/elevations/profile action + drawer w/ auto-seeded frequency), Meshtastic link (distance via nodeNum resolution), and elevation-disabled gating (distance only, zero elevation requests). Full suite 10,427/0. Note: dev DB had no `/api/analysis/neighbors` rows initially — Meshtastic live check came from an MQTT-broker-source neighbor link.

--- a/docs/internal/dev-notes/NEIGHBOR_LINK_TERRAIN_SPEC.md
+++ b/docs/internal/dev-notes/NEIGHBOR_LINK_TERRAIN_SPEC.md
@@ -1,0 +1,443 @@
+# Neighbor-Link Terrain Integration — Phase 1 Implementation Spec
+
+**Epic:** 3D Map & Elevation (#3826)
+**Phase:** 1 — Neighbor-link terrain integration
+**Branch:** `feature/3826-neighbor-link-terrain`
+**Author:** Phase Architect (Opus)
+**Status:** Ready for implementation
+
+---
+
+## 0. Goal (restated)
+
+When a neighbor link is selected in the Map Analysis workspace, the inspector
+panel (`AnalysisInspectorPanel`) surfaces terrain-aware information:
+
+1. **Link distance** (great-circle) — always, when both endpoints have positions.
+2. **Endpoint ground elevations** (DEM) — only when `elevationEnabled`.
+3. **"View terrain profile"** action — opens the **existing** Link Profile
+   drawer pre-populated with the link's two endpoints, reusing the existing
+   `MapAnalysisContext` link-profile state machine. **No parallel drawer.**
+
+Works for Meshtastic **and** MeshCore neighbor links when both endpoints have
+positions; degrades gracefully otherwise. Gated on `useElevationEnabled` for
+elevations + the profile action, consistent with the toolbar's Link Profile
+button (which is *hidden* when elevation is disabled).
+
+This phase is **frontend-only**. No backend changes (justification in §3.5).
+
+---
+
+## 1. Reuse inventory (build on these — do not duplicate)
+
+| Concern | Existing asset | Path | How Phase 1 uses it |
+|---|---|---|---|
+| Link-profile state machine | `linkProfileMode` / `setLinkProfileMode`, `linkEndpoints` / `setLinkEndpoints`, `measureMode` / `setMeasureMode` | `src/components/MapAnalysis/MapAnalysisContext.tsx` | Inspector's "View terrain profile" writes these to open the drawer. **No new context state.** |
+| Endpoint type | `LinkEndpoint` (`{ id, lat, lng, isNode, sourceId?, sourceIds?, nodeNum?, isMeshCore?, label? }`) | `src/utils/linkProfile.ts` | Neighbor endpoints are built as `LinkEndpoint[]` in the exact shape `MapAnalysisCanvas` already produces for the picker, so `useAutoRadioDefaults` resolves per-source freq/RX. |
+| Elevation profile fetch | `useElevationProfile(a, b)` — TanStack query keyed on rounded coords, `staleTime` 30 min | `src/hooks/useElevationProfile.ts` | Inspector reuses it to read `samples[0]`/`samples[last]` elevation. **Identical query key to the drawer ⇒ shared cache, zero double-fetch** (§2.1). |
+| Elevation gating | `useElevationEnabled()` → boolean | `src/hooks/useElevationEnabled.ts` | Gates endpoint elevations + the profile action (mirrors the toolbar). |
+| Great-circle distance | `calculateDistance(lat1,lon1,lat2,lon2)` → km | `src/utils/distance.ts` | Link distance. **Do not add a new haversine.** |
+| Distance formatting | `formatDistance(km, unit)` | `src/utils/distance.ts` | Formats distance with the user's unit. |
+| Distance unit preference | `useSettings().distanceUnit` | `src/contexts/SettingsContext.tsx` | Feeds `formatDistance` (same as `LinkProfileDrawer`). |
+| Position resolution | `resolveNodeLatLng(node)` → `[lat,lng] \| null` (handles flat + nested shape, Null-Island discard) | `src/components/MapAnalysis/nodePositionUtil.ts` | Resolves both endpoint coordinates from the unified node list. |
+| Unified node list | `useDashboardUnifiedData(sourceIds)` → `{ nodes }` (already consumed in the inspector) | `src/hooks/useDashboardData.ts` | The node array the endpoint resolver walks. Already present in the inspector — no new fetch. |
+| Node shape | `NodeRecord` (`nodeNum`, `sourceId`, `isMeshCore`, `publicKey`, `sources: NodeSourceRef[]`, position fields) | `src/components/MapAnalysis/useAnalysisNodes.ts` | Reference shape for the endpoint resolver's node param. |
+| The drawer itself | `LinkProfileDrawer` (mounted unconditionally in the canvas; renders when `linkProfileMode` on **or** endpoints exist; fetches profile; owns AGL/budget defaults) | `src/components/MapAnalysis/LinkProfileDrawer.tsx` | Opened by the inspector action. **Not modified.** |
+| Map path renderer | `LinkProfileController` (renders verdict-colored polyline + endpoint rings when `linkProfileMode` is on) | `src/components/MapAnalysis/LinkProfileController.tsx` | Renders automatically once the action sets `linkProfileMode=true`. **Not modified.** |
+| Neighbor selection shape | `SelectedTarget` (`type:'neighbor'`, meshtastic: `nodeNum`/`neighborNum`/`sourceId`; meshcore: `publicKey`/`neighborPublicKey`/`nodeName`/`neighborName`; both: `snr`/`timestamp`) | `src/components/MapAnalysis/MapAnalysisContext.tsx` | Input to the endpoint resolver. **No shape change needed** (§2.4). |
+
+### Justification for the one new file
+
+`SelectedTarget` (neighbor variant) carries only identifiers (nodeNum/neighborNum
+or publicKey/neighborPublicKey) — **not coordinates**. Turning a neighbor
+selection into a `LinkEndpoint` pair requires a lookup against the unified node
+list plus the cross-source position fallback the layers use (#3792). That
+mapping is pure, testable, and used from a React component, so it belongs in a
+small dedicated module (`neighborLinkEndpoints.ts`) rather than inlined in the
+already-large `AnalysisInspectorPanel`. No existing helper does this
+(the layers resolve positions into a `Map` for rendering, not into
+`LinkEndpoint` objects).
+
+---
+
+## 2. Design decisions
+
+### 2.1 Endpoint-elevation sourcing — reuse `useElevationProfile`, no new endpoint
+
+**Decision:** The inspector calls `useElevationProfile(endpointA, endpointB)`
+(the same hook the drawer uses) and reads the **first** and **last** sample
+elevations for the two endpoints. It does **not** add a point-elevation
+endpoint and does **not** call the profile endpoint with a custom sample count.
+
+**Why this is the cheapest correct option:**
+- The only elevation routes that exist are `POST /api/elevation/profile` and
+  `POST /api/elevation/test` (verified — no point endpoint). A profile with the
+  default sample count already contains the endpoint elevations as `samples[0]`
+  and `samples[samples.length-1]`.
+- `useElevationProfile`'s query key is `['elevation-profile', [roundA], [roundB]]`
+  — **it does not include the sample count**. Calling it from the inspector with
+  the same endpoints the drawer will use produces the **identical cache entry**.
+  So when the user then clicks "View terrain profile", the drawer's own
+  `useElevationProfile` call is a **cache hit** — the profile is fetched **once**
+  per distinct link and shared. This is strictly better than a separate
+  small-`samples` call, which would create a *different* logical need but the
+  *same* cache key (latent aliasing) — so we deliberately keep the default
+  sample count to guarantee cache-sharing with the drawer.
+- Result: **one** elevation request per distinct neighbor link, cached 30 min,
+  reused by the drawer. No new route, no new hook.
+
+**Rate-limit reasoning (`elevationLimiter` = 20/min, `optionalAuth`):**
+- Cost is one request per *distinct* link selection (TanStack Query dedups +
+  30-min `staleTime`). Re-selecting the same link, or opening its drawer, costs
+  nothing.
+- Worst case: a user rapidly clicks ~20+ *different* neighbor links within a
+  minute → a 429 on the surplus. This degrades gracefully: distance still
+  renders (it's pure math), elevations show `—`, and the action still opens the
+  drawer (which surfaces the elevation error UI it already has). Acceptable and
+  self-healing (the drawer would have fired the same request anyway).
+- **Rejected alternative:** show distance + action only in the inspector and let
+  elevations appear *inside* the drawer. Rejected because the epic exit criteria
+  explicitly require *"distance (+ elevations when enabled)"* in the inspector.
+  The reuse approach delivers inspector elevations at zero marginal fetch cost
+  vs. opening the drawer.
+
+**Gating of the fetch:** the hook is passed `undefined` endpoints (→ query
+disabled) whenever elevation is disabled **or** either endpoint lacks a
+position. So a browse with elevation off, or over unpositioned links, issues
+**no** elevation requests at all.
+
+### 2.2 Gating behavior (consistent with the toolbar)
+
+| Condition | Distance | Endpoint elevations | "View terrain profile" action |
+|---|---|---|---|
+| Both endpoints positioned, `elevationEnabled` | ✅ shown | ✅ shown (loading `…` / value / `—` if DEM null) | ✅ shown |
+| Both endpoints positioned, elevation disabled | ✅ shown | ❌ hidden (no fetch) | ❌ hidden |
+| One/both endpoints have no position | ❌ (can't compute) | ❌ | ❌ |
+
+The action + elevations are gated by `useElevationEnabled()`, mirroring
+`MapAnalysisToolbar` which **hides** the Link Profile button entirely when
+elevation is disabled. Distance is unconditional on positions (pure geometry, no
+elevation dependency) — this is *additive* to the existing neighbor panel
+(names, source, SNR, reported), which continues to render unchanged.
+
+### 2.3 Opening the drawer — reuse the state machine exactly
+
+The "View terrain profile" handler performs, in order:
+
+```ts
+setMeasureMode(false);            // mutual exclusivity, matches toolbar handler
+setLinkEndpoints([endpointA, endpointB]);
+setLinkProfileMode(true);
+```
+
+- `LinkProfileDrawer` (mounted unconditionally in `MapAnalysisCanvas`) renders
+  because `linkProfileMode` is now true and endpoints are set; it fetches the
+  profile (cache hit, §2.1) and computes verdict/budget.
+- `LinkProfileController` mounts (gated on `linkProfileMode`) and draws the
+  verdict-colored polyline + endpoint rings on the map — identical to using the
+  toolbar tool and picking both endpoints.
+- Setting `linkProfileMode=true` also arms the capture-phase picker, so a
+  subsequent map click restarts endpoint A. This is **the existing, expected**
+  tool behavior — no divergence, no special-casing.
+
+This is the minimal correct way to open the drawer with the two endpoints and is
+100% reuse of the existing flow. **No new "open drawer" API is added to context.**
+
+### 2.4 MeshCore handling
+
+- `SelectedTarget` already distinguishes MeshCore neighbor links by the presence
+  of `publicKey` (the inspector's existing `isMeshCore = !!selected.publicKey`
+  branch). No `SelectedTarget` change needed.
+- Endpoint resolution for MeshCore keys on `publicKey`/`neighborPublicKey`
+  against unified nodes where `isMeshCore && publicKey` match — mirroring
+  `MeshCoreNeighborLinksLayer`'s `positionByKey`. MeshCore unified nodes carry a
+  `nodeNum` (populated by the merge), so the built `LinkEndpoint` sets
+  `nodeNum` from the resolved record and `isMeshCore: true` — exactly the shape
+  `MapAnalysisCanvas.linkEndpointCandidates` produces for MeshCore, so
+  `useAutoRadioDefaults` behaves identically.
+- Meshtastic keys on `nodeNum`/`neighborNum` with the #3792 cross-source
+  fallback (prefer the reporting `sourceId`'s record; fall back to any source
+  that has the node positioned). `isMeshCore: false`.
+
+### 2.5 Antenna-height / frequency defaults when opening from a link
+
+Nothing to override. The inspector hands the drawer only the two `LinkEndpoint`
+objects. The drawer owns all budget defaults (`DEFAULT_AGL_M = 2` for both
+antennas, `DEFAULT_FREQ_MHZ = 915`, etc.) and its `useAutoRadioDefaults`
+auto-seeds per-source frequency/RX-sensitivity from the endpoints' `sourceId`/
+`sourceIds`/`nodeNum`/`isMeshCore`. Because we build endpoints in the same shape
+`MapAnalysisCanvas` already produces, defaults and auto-seeding match the
+toolbar-driven flow byte-for-byte. **Match by construction, not by copying
+constants.**
+
+---
+
+## 3. File-by-file changes
+
+### 3.1 NEW — `src/components/MapAnalysis/neighborLinkEndpoints.ts`
+
+Pure, react-free. Resolves a neighbor `SelectedTarget` into a `LinkEndpoint`
+pair using the unified node list.
+
+```ts
+import type { LinkEndpoint } from '../../utils/linkProfile';
+import type { SelectedTarget } from './MapAnalysisContext';
+import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+
+/** Minimal node shape the resolver needs (subset of useAnalysisNodes NodeRecord). */
+export interface EndpointNodeRecord extends MaybePositionedNode {
+  nodeNum?: number;
+  sourceId?: string;
+  isMeshCore?: boolean;
+  publicKey?: string | null;
+  longName?: string | null;
+  shortName?: string | null;
+  sources?: Array<{ sourceId: string }>;
+}
+
+export interface NeighborEndpoints {
+  a: LinkEndpoint;
+  b: LinkEndpoint;
+}
+
+/**
+ * Build a LinkEndpoint pair for a selected neighbor link, or null when either
+ * endpoint cannot be resolved to a rendered position. Meshtastic links key on
+ * nodeNum with the #3792 cross-source fallback; MeshCore links key on publicKey.
+ */
+export function resolveNeighborEndpoints(
+  selected: SelectedTarget,
+  nodes: EndpointNodeRecord[],
+): NeighborEndpoints | null;
+```
+
+Behavior:
+- Guard: `selected.type !== 'neighbor'` → `null`.
+- `isMeshCore = !!selected.publicKey`.
+- **Meshtastic:** find node A by `nodeNum === selected.nodeNum` preferring
+  `sourceId === selected.sourceId`, else any positioned match; node B likewise
+  for `selected.neighborNum`. (Mirror `NeighborLinksLayer`'s
+  `positionByKey`→`positionByNode` fallback.)
+- **MeshCore:** find node A by `isMeshCore && publicKey === selected.publicKey`
+  preferring `sourceId === selected.sourceId`, else any positioned match; node B
+  by `neighborPublicKey`.
+- For each, `resolveNodeLatLng(node)`; if either is `null` → return `null`.
+- Build each `LinkEndpoint`:
+  ```ts
+  {
+    id: isMeshCore ? `${node.sourceId ?? ''}:${node.publicKey ?? ''}`
+                   : `${node.sourceId ?? ''}:${node.nodeNum}`,
+    lat, lng,
+    isNode: true,
+    sourceId: node.sourceId,
+    sourceIds: node.sources?.map(s => s.sourceId) ?? (node.sourceId ? [node.sourceId] : []),
+    nodeNum: node.nodeNum,
+    isMeshCore,
+    label: node.shortName ?? undefined,
+  }
+  ```
+  (`id` shape/semantics match `MapAnalysisCanvas.linkEndpointCandidates`; the
+  key format is only used for React-Query/`useAutoRadioDefaults` identity, so
+  MeshCore's publicKey-based id is fine.)
+
+> Import note: `SelectedTarget` is exported from `MapAnalysisContext.tsx`; import
+> it as a type to avoid a runtime cycle (`import type`).
+
+### 3.2 MODIFY — `src/components/MapAnalysis/AnalysisInspectorPanel.tsx`
+
+New imports:
+```ts
+import { useSettings } from '../../contexts/SettingsContext';
+import { useElevationEnabled } from '../../hooks/useElevationEnabled';
+import { useElevationProfile } from '../../hooks/useElevationProfile';
+import { calculateDistance, formatDistance } from '../../utils/distance';
+import { resolveNeighborEndpoints } from './neighborLinkEndpoints';
+```
+
+Destructure additional context setters:
+```ts
+const {
+  config, selected, setInspectorOpen,
+  setLinkEndpoints, setLinkProfileMode, setMeasureMode,
+} = useMapAnalysisCtx();
+const { distanceUnit } = useSettings();
+const elevationEnabled = useElevationEnabled();
+```
+
+Add top-level hooks (unconditional — React rules; `selected`/`nodes` may be
+anything, the memo just returns `null` when not a neighbor):
+```ts
+const neighborEndpoints = useMemo(
+  () =>
+    selected?.type === 'neighbor'
+      ? resolveNeighborEndpoints(selected, (nodes ?? []) as EndpointNodeRecord[])
+      : null,
+  [selected, nodes],
+);
+
+// Same query key as LinkProfileDrawer ⇒ shared cache. Disabled unless elevation
+// is on AND both endpoints resolved.
+const elevA = elevationEnabled ? neighborEndpoints?.a : undefined;
+const elevB = elevationEnabled ? neighborEndpoints?.b : undefined;
+const { data: neighborProfile, isLoading: neighborElevLoading } =
+  useElevationProfile(elevA, elevB);
+```
+
+Neighbor branch (`selected.type === 'neighbor'`) additions — keep the existing
+`<h3>`, subtitle, Node/Neighbor/Source/SNR/Reported `<dl>`, then append:
+
+- **Distance** row when `neighborEndpoints` is non-null:
+  ```ts
+  const distKm = neighborEndpoints
+    ? calculateDistance(a.lat, a.lng, b.lat, b.lng)   // a=neighborEndpoints.a, b=.b
+    : null;
+  // <dt>Distance</dt><dd>{distKm != null ? formatDistance(distKm, distanceUnit) : '—'}</dd>
+  ```
+- **Endpoint elevations** rows, only when `elevationEnabled && neighborEndpoints`:
+  read `neighborProfile.samples[0].elevation` and
+  `neighborProfile.samples[samples.length-1].elevation`.
+  - loading → `…`; value present → `formatElevation(m)` (e.g. `${Math.round(m)} m`);
+    `null`/no data → `—`.
+  - Render a small helper `formatElevation(m: number | null | undefined): string`
+    (local const, like the existing `formatNumber` family).
+- **"View terrain profile" button**, only when `elevationEnabled && neighborEndpoints`:
+  ```tsx
+  <button
+    type="button"
+    className="map-analysis-link-profile-action"
+    onClick={() => {
+      setMeasureMode(false);
+      setLinkEndpoints([neighborEndpoints.a, neighborEndpoints.b]);
+      setLinkProfileMode(true);
+    }}
+  >
+    View terrain profile
+  </button>
+  ```
+  (Reuse an existing button style class where one fits; a new class is a CSS-only
+  add if needed — no baseline impact.)
+
+Notes / constraints:
+- No raw `fetch()` — all data via hooks/`ApiService` (satisfied).
+- No `any` — type the local node cast as `EndpointNodeRecord[]` (or reuse the
+  panel's existing `NodeRecord`, widened to include `publicKey`/`isMeshCore`/
+  `sources`). Prefer importing `EndpointNodeRecord` from the new helper.
+- `react-hooks/exhaustive-deps`: the new `useMemo` deps are `[selected, nodes]`
+  — complete, no disable needed.
+- All added hooks are at the top level, before the existing early returns
+  (`!config.inspectorOpen`, `!selected`), so hook order is stable.
+
+### 3.3 MODIFY — `src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx` (or new sibling)
+
+See §4.
+
+### 3.4 (Optional) `nodes.css` / MapAnalysis stylesheet
+
+If a new `.map-analysis-link-profile-action` button class is introduced, add its
+rule to the existing MapAnalysis CSS. CSS-only; not lint/baseline relevant.
+Beware the documented `nodes.css` cascade-order gotcha if editing that file.
+
+### 3.5 Backend — NO changes (justification)
+
+The endpoint elevations come from the already-shipped `POST /api/elevation/profile`
+(reused via `useElevationProfile`). No point-elevation endpoint is needed
+(§2.1) and adding one would duplicate the profile-endpoint's SSRF/clamp/rate-limit
+surface for a strictly-worse cache story. All other data (positions, neighbor
+identity, distance) is already client-side. **Frontend-only phase confirmed.**
+
+---
+
+## 4. Test plan (Vitest — standard suite, no standalone scripts)
+
+### 4.1 NEW — `src/components/MapAnalysis/neighborLinkEndpoints.test.ts` (pure helper)
+
+- **Meshtastic, both positioned** → returns endpoints with correct
+  `lat/lng/id/sourceId/nodeNum/isMeshCore:false`; `sourceIds` derived from
+  `sources`.
+- **Meshtastic, cross-source fallback (#3792)** → endpoint B positioned only
+  under a different source than `selected.sourceId` still resolves.
+- **Meshtastic, one endpoint unpositioned** → `null`.
+- **MeshCore, both positioned** (matched by `publicKey`/`neighborPublicKey`,
+  `isMeshCore:true`, `nodeNum` from record) → endpoints returned.
+- **MeshCore, publicKey not found** → `null`.
+- **Null-Island endpoint** (0,0 discarded by `resolveNodeLatLng`) → `null`.
+- **Non-neighbor selection** → `null`.
+
+### 4.2 EXTEND — `AnalysisInspectorPanel.test.tsx`
+
+Add mocks: `../../hooks/useElevationEnabled` and `../../hooks/useElevationProfile`
+(both `vi.mock`), plus `../../contexts/SettingsContext` `useSettings` returning
+`{ distanceUnit: 'km' }`. Extend the `useDashboardUnifiedData` node fixture with a
+second positioned node (nodeNum 2) and a MeshCore pair (publicKeys) so neighbor
+resolution has data. (Non-DB component mocks are still correct per CLAUDE.md —
+this is not a route test, so the route harness does not apply.)
+
+Cases:
+- **Neighbor, both positioned, elevation ENABLED** → renders `Neighbor Link`,
+  `Distance` with a formatted value, both endpoint elevation rows, and a
+  `View terrain profile` button. (`useElevationProfile` mock returns samples
+  with known first/last elevations; assert the rounded metres render.)
+- **Neighbor, both positioned, elevation DISABLED**
+  (`useElevationEnabled → false`) → `Distance` shown; **no** elevation rows;
+  **no** `View terrain profile` button. Assert `useElevationProfile` mock was
+  called with `undefined` endpoints (fetch gated off) — or simply assert the
+  button/elevation rows are absent.
+- **Neighbor, an endpoint unpositioned** → no Distance, no elevations, no action
+  (panel still shows names/source/SNR).
+- **Profile action dispatch** → click `View terrain profile`; assert context
+  state via a probe component reading `useMapAnalysisCtx()`:
+  `linkProfileMode === true`, `linkEndpoints.length === 2` with the expected
+  `nodeNum`s / `isMeshCore` flags, and `measureMode === false`.
+- **MeshCore variant** → select a MeshCore neighbor (set `publicKey`/
+  `neighborPublicKey`/names); assert Distance + action render and the dispatched
+  `linkEndpoints` carry `isMeshCore: true`.
+- **Elevation loading state** → `useElevationProfile` mock `{ isLoading: true }`
+  → elevation rows show the loading placeholder (`…`), Distance still shown.
+
+Existing inspector tests (node/segment/empty/collapse) must remain green
+unchanged.
+
+---
+
+## 5. Work packages
+
+Small phase — **2 packages**, WP-2 depends on WP-1.
+
+### WP-1 — Pure endpoint resolver + tests  *(Sonnet)*
+**Scope:** Create `src/components/MapAnalysis/neighborLinkEndpoints.ts`
+(`resolveNeighborEndpoints` + `EndpointNodeRecord`/`NeighborEndpoints` types) and
+`neighborLinkEndpoints.test.ts`.
+**Depends on:** nothing.
+**Acceptance:**
+- All §4.1 cases pass.
+- Pure/react-free; no `any`; `tsc` clean; imports `LinkEndpoint`/`SelectedTarget`
+  as types only.
+- Endpoint `id`/`sourceIds`/`nodeNum`/`isMeshCore` shape matches
+  `MapAnalysisCanvas.linkEndpointCandidates` for both protocols.
+
+### WP-2 — Inspector integration + component tests  *(Sonnet)*
+**Scope:** Wire `AnalysisInspectorPanel` neighbor branch: distance row (always,
+when positioned), endpoint elevation rows + "View terrain profile" action (gated
+on `useElevationEnabled`), via `resolveNeighborEndpoints` + `useElevationProfile`
+(shared-cache) + `useSettings`. Optional CSS for the action button. Extend
+`AnalysisInspectorPanel.test.tsx` per §4.2.
+**Depends on:** WP-1.
+**Acceptance:**
+- All §4.2 cases pass; existing inspector tests still green.
+- Elevation fetch gated off (undefined endpoints) when elevation disabled or an
+  endpoint is unpositioned.
+- Profile action sets `linkProfileMode`/`linkEndpoints`/`measureMode` correctly
+  (asserted via context probe); opening the drawer in the live app is a
+  cache-hit (browser-validated on the dev container).
+- No raw `fetch()` in the component; no `any`; no new
+  `react-hooks/exhaustive-deps` violations; `npm run lint:ci` exits 0; full
+  Vitest suite green.
+
+---
+
+## 6. Out of scope (Phase 1)
+
+- No 3D map, no MapLibre component, no tile proxy (Phases 2–3).
+- No changes to `LinkProfileDrawer` / `LinkProfileController` / the elevation
+  backend.
+- No new context state, no new API route, no migration.

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
@@ -6,9 +6,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AnalysisInspectorPanel from './AnalysisInspectorPanel';
 import { MapAnalysisProvider, useMapAnalysisCtx } from './MapAnalysisContext';
+import { calculateDistance, formatDistance } from '../../utils/distance';
+import type { ElevationProfile } from '../../types/elevation';
 
 // Real /api/sources/:id/nodes returns FLAT telemetry fields (no nested deviceMetrics).
 // Mock matches that shape so the test catches regressions if we ever revert to nested-only reads.
+// Extended (epic #3826, Phase 1, WP-2) with a second positioned Meshtastic
+// node, an unpositioned Meshtastic node, and a MeshCore pair so neighbor-link
+// endpoint resolution (`resolveNeighborEndpoints`) has data to resolve.
 vi.mock('../../hooks/useDashboardData', () => ({
   useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }] }),
   useDashboardUnifiedData: () => ({
@@ -28,6 +33,41 @@ vi.mock('../../hooks/useDashboardData', () => ({
         channelUtilization: 12.3,
         airUtilTx: 1.45,
         uptimeSeconds: 7200,
+      },
+      {
+        nodeNum: 2,
+        nodeId: '!00000002',
+        sourceId: 'a',
+        longName: 'Bravo',
+        shortName: 'B',
+        position: { latitude: 31, longitude: -90 },
+      },
+      {
+        nodeNum: 3,
+        nodeId: '!00000003',
+        sourceId: 'a',
+        longName: 'Unpositioned',
+        shortName: 'U',
+        // No position — resolveNeighborEndpoints must return null when a
+        // selected neighbor link references this node.
+      },
+      {
+        nodeNum: 101,
+        sourceId: 'a',
+        isMeshCore: true,
+        publicKey: 'pubkeyA1234567890abcdef',
+        longName: 'MeshCore A',
+        shortName: 'MCA',
+        position: { latitude: 40, longitude: -100 },
+      },
+      {
+        nodeNum: 102,
+        sourceId: 'a',
+        isMeshCore: true,
+        publicKey: 'pubkeyB1234567890abcdef',
+        longName: 'MeshCore B',
+        shortName: 'MCB',
+        position: { latitude: 41, longitude: -100 },
       },
     ],
   }),
@@ -51,6 +91,27 @@ vi.mock('../../hooks/useLinkQuality', () => ({
       { timestamp: 1700001000000, quality: 8 },
     ],
   }),
+}));
+
+// Terrain integration mocks (epic #3826, Phase 1, WP-2). Mutable per-test so
+// a single factory serves the enabled/disabled/loading cases.
+let mockElevationEnabled = true;
+vi.mock('../../hooks/useElevationEnabled', () => ({
+  useElevationEnabled: () => mockElevationEnabled,
+}));
+
+let mockElevationProfileResult: { data: ElevationProfile | undefined; isLoading: boolean } = {
+  data: undefined,
+  isLoading: false,
+};
+const useElevationProfileMock = vi.fn((..._args: unknown[]) => mockElevationProfileResult);
+vi.mock('../../hooks/useElevationProfile', () => ({
+  useElevationProfile: (...args: unknown[]) => useElevationProfileMock(...args),
+}));
+
+const mockDistanceUnit: 'km' | 'mi' = 'km';
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ distanceUnit: mockDistanceUnit }),
 }));
 
 function Wrapper({ children }: { children: React.ReactNode }) {
@@ -92,8 +153,100 @@ function SelectSegment() {
   );
 }
 
+/** Meshtastic neighbor link between two positioned nodes (1 <-> 2). */
+function SelectNeighbor() {
+  const ctx = useMapAnalysisCtx();
+  return (
+    <button
+      onClick={() =>
+        ctx.setSelected({
+          type: 'neighbor',
+          nodeNum: 1,
+          neighborNum: 2,
+          sourceId: 'a',
+          snr: 5.5,
+          timestamp: 1700000000000,
+        })
+      }
+    >
+      select-neighbor
+    </button>
+  );
+}
+
+/** Meshtastic neighbor link where the neighbor endpoint has no position. */
+function SelectNeighborUnpositioned() {
+  const ctx = useMapAnalysisCtx();
+  return (
+    <button
+      onClick={() =>
+        ctx.setSelected({
+          type: 'neighbor',
+          nodeNum: 1,
+          neighborNum: 3,
+          sourceId: 'a',
+          snr: 2,
+          timestamp: 1700000000000,
+        })
+      }
+    >
+      select-neighbor-unpositioned
+    </button>
+  );
+}
+
+/** MeshCore neighbor link between two positioned MeshCore nodes. */
+function SelectNeighborMeshCore() {
+  const ctx = useMapAnalysisCtx();
+  return (
+    <button
+      onClick={() =>
+        ctx.setSelected({
+          type: 'neighbor',
+          sourceId: 'a',
+          publicKey: 'pubkeyA1234567890abcdef',
+          neighborPublicKey: 'pubkeyB1234567890abcdef',
+          nodeName: 'MeshCore A',
+          neighborName: 'MeshCore B',
+          snr: 3.1,
+          timestamp: 1700000000000,
+        })
+      }
+    >
+      select-neighbor-meshcore
+    </button>
+  );
+}
+
+/** Reads live context state so tests can assert the profile-action dispatch. */
+function CtxProbe() {
+  const ctx = useMapAnalysisCtx();
+  return (
+    <div data-testid="ctx-probe">
+      {JSON.stringify({
+        linkProfileMode: ctx.linkProfileMode,
+        measureMode: ctx.measureMode,
+        linkEndpoints: ctx.linkEndpoints.map((e) => ({
+          nodeNum: e.nodeNum,
+          isMeshCore: e.isMeshCore,
+        })),
+      })}
+    </div>
+  );
+}
+
+function SetMeasureModeOn() {
+  const ctx = useMapAnalysisCtx();
+  return <button onClick={() => ctx.setMeasureMode(true)}>set-measure-mode</button>;
+}
+
 describe('AnalysisInspectorPanel', () => {
-  beforeEach(() => localStorage.clear());
+  beforeEach(() => {
+    localStorage.clear();
+    mockElevationEnabled = true;
+    mockElevationProfileResult = { data: undefined, isLoading: false };
+    useElevationProfileMock.mockClear();
+  });
 
   it('shows empty state when nothing selected', () => {
     render(
@@ -175,5 +328,154 @@ describe('AnalysisInspectorPanel', () => {
       </Wrapper>,
     );
     expect(screen.getByLabelText(/collapse detail pane/i)).toBeInTheDocument();
+  });
+
+  // ===== Neighbor-link terrain integration (epic #3826, Phase 1, WP-2) =====
+
+  describe('neighbor link terrain integration', () => {
+    const expectedDistance = formatDistance(
+      calculateDistance(30, -90, 31, -90),
+      'km',
+    );
+
+    it('shows distance, endpoint elevations, and the profile action when both endpoints are positioned and elevation is enabled', () => {
+      mockElevationEnabled = true;
+      mockElevationProfileResult = {
+        data: {
+          distanceMeters: 111195,
+          provider: 'test',
+          samples: [
+            { distance: 0, lat: 30, lng: -90, elevation: 123.4 },
+            { distance: 55597, lat: 30.5, lng: -90, elevation: 200 },
+            { distance: 111195, lat: 31, lng: -90, elevation: 87.6 },
+          ],
+        },
+        isLoading: false,
+      };
+      render(
+        <Wrapper>
+          <SelectNeighbor />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-neighbor'));
+
+      expect(screen.getByText('Neighbor Link')).toBeInTheDocument();
+      expect(screen.getByText('Distance')).toBeInTheDocument();
+      expect(screen.getByText(expectedDistance)).toBeInTheDocument();
+      expect(screen.getByText('Node Elevation')).toBeInTheDocument();
+      expect(screen.getByText('Neighbor Elevation')).toBeInTheDocument();
+      expect(screen.getByText('123 m')).toBeInTheDocument();
+      expect(screen.getByText('88 m')).toBeInTheDocument();
+      expect(screen.getByText('View terrain profile')).toBeInTheDocument();
+
+      // Cache-sharing contract (§2.1): the fetch must be issued with the
+      // resolved endpoints, not left disabled, once elevation is enabled.
+      const lastCall = useElevationProfileMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({ nodeNum: 1 });
+      expect(lastCall?.[1]).toMatchObject({ nodeNum: 2 });
+    });
+
+    it('hides elevations and the profile action (but still shows distance) when elevation is disabled', () => {
+      mockElevationEnabled = false;
+      render(
+        <Wrapper>
+          <SelectNeighbor />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-neighbor'));
+
+      expect(screen.getByText('Distance')).toBeInTheDocument();
+      expect(screen.getByText(expectedDistance)).toBeInTheDocument();
+      expect(screen.queryByText('Node Elevation')).not.toBeInTheDocument();
+      expect(screen.queryByText('Neighbor Elevation')).not.toBeInTheDocument();
+      expect(screen.queryByText('View terrain profile')).not.toBeInTheDocument();
+
+      // Fetch gated off entirely: both endpoints passed as undefined.
+      const lastCall = useElevationProfileMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBeUndefined();
+      expect(lastCall?.[1]).toBeUndefined();
+    });
+
+    it('hides distance, elevations, and the profile action when an endpoint is unpositioned', () => {
+      render(
+        <Wrapper>
+          <SelectNeighborUnpositioned />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-neighbor-unpositioned'));
+
+      // Panel still shows names/source/SNR.
+      expect(screen.getByText('Neighbor Link')).toBeInTheDocument();
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(screen.getByText('Unpositioned')).toBeInTheDocument();
+
+      expect(screen.queryByText('Distance')).not.toBeInTheDocument();
+      expect(screen.queryByText('Node Elevation')).not.toBeInTheDocument();
+      expect(screen.queryByText('View terrain profile')).not.toBeInTheDocument();
+    });
+
+    it('shows the loading placeholder for elevations while the profile is loading (distance still shown)', () => {
+      mockElevationProfileResult = { data: undefined, isLoading: true };
+      render(
+        <Wrapper>
+          <SelectNeighbor />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-neighbor'));
+
+      expect(screen.getByText('Distance')).toBeInTheDocument();
+      expect(screen.getByText(expectedDistance)).toBeInTheDocument();
+      const dds = screen.getAllByText('…');
+      expect(dds.length).toBe(2);
+    });
+
+    it('resolves a MeshCore neighbor link (isMeshCore: true) and renders distance + action', () => {
+      render(
+        <Wrapper>
+          <SelectNeighborMeshCore />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-neighbor-meshcore'));
+
+      expect(screen.getByText('MeshCore A')).toBeInTheDocument();
+      expect(screen.getByText('MeshCore B')).toBeInTheDocument();
+      expect(screen.getByText('Distance')).toBeInTheDocument();
+      expect(screen.getByText('View terrain profile')).toBeInTheDocument();
+
+      const lastCall = useElevationProfileMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({ isMeshCore: true, nodeNum: 101 });
+      expect(lastCall?.[1]).toMatchObject({ isMeshCore: true, nodeNum: 102 });
+    });
+
+    it('dispatches linkProfileMode/linkEndpoints/measureMode via the existing MapAnalysisContext state machine when the action is clicked', () => {
+      render(
+        <Wrapper>
+          <SetMeasureModeOn />
+          <CtxProbe />
+          <SelectNeighbor />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      // Arm measureMode first so we can prove the handler flips it off
+      // (mutual exclusivity, matching the toolbar handler).
+      fireEvent.click(screen.getByText('set-measure-mode'));
+      expect(screen.getByTestId('ctx-probe').textContent).toContain('"measureMode":true');
+
+      fireEvent.click(screen.getByText('select-neighbor'));
+      fireEvent.click(screen.getByText('View terrain profile'));
+
+      const probe = JSON.parse(screen.getByTestId('ctx-probe').textContent ?? '{}');
+      expect(probe.linkProfileMode).toBe(true);
+      expect(probe.measureMode).toBe(false);
+      expect(probe.linkEndpoints).toEqual([
+        { nodeNum: 1, isMeshCore: false },
+        { nodeNum: 2, isMeshCore: false },
+      ]);
+    });
   });
 });

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -12,6 +12,11 @@ import {
 import { getTracerouteOptions } from '../../hooks/useMapAnalysisConfig';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+import { useSettings } from '../../contexts/SettingsContext';
+import { useElevationEnabled } from '../../hooks/useElevationEnabled';
+import { useElevationProfile } from '../../hooks/useElevationProfile';
+import { calculateDistance, formatDistance } from '../../utils/distance';
+import { resolveNeighborEndpoints, type EndpointNodeRecord } from './neighborLinkEndpoints';
 
 interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
@@ -51,7 +56,16 @@ interface HopEntry {
  * placeholder otherwise. Hidden entirely when `inspectorOpen` is false.
  */
 export default function AnalysisInspectorPanel() {
-  const { config, selected, setInspectorOpen } = useMapAnalysisCtx();
+  const {
+    config,
+    selected,
+    setInspectorOpen,
+    setLinkEndpoints,
+    setLinkProfileMode,
+    setMeasureMode,
+  } = useMapAnalysisCtx();
+  const { distanceUnit } = useSettings();
+  const elevationEnabled = useElevationEnabled();
   const { data: sources = [] } = useDashboardSources();
   const sourceList = sources as Array<{ id: string; name: string }>;
   const sourceIds =
@@ -118,6 +132,25 @@ export default function AnalysisInspectorPanel() {
     visibleNodeNums: null,
     timeWindow: null,
   });
+
+  // Neighbor-link terrain integration (epic #3826, Phase 1, WP-2). Resolved
+  // unconditionally (top-level hook, before the early returns) — the memo
+  // itself returns null for non-neighbor selections.
+  const neighborEndpoints = useMemo(
+    () =>
+      selected?.type === 'neighbor'
+        ? resolveNeighborEndpoints(selected, (nodes ?? []) as EndpointNodeRecord[])
+        : null,
+    [selected, nodes],
+  );
+  // Same query key as LinkProfileDrawer's useElevationProfile call ⇒ shared
+  // cache (§2.1 of the spec). Disabled (undefined endpoints) unless elevation
+  // is enabled AND both endpoints resolved, so browsing with elevation off or
+  // over unpositioned links issues no elevation requests at all.
+  const elevA = elevationEnabled ? neighborEndpoints?.a : undefined;
+  const elevB = elevationEnabled ? neighborEndpoints?.b : undefined;
+  const { data: neighborProfile, isLoading: neighborElevLoading } =
+    useElevationProfile(elevA, elevB);
 
   if (!config.inspectorOpen) {
     return (
@@ -190,6 +223,11 @@ export default function AnalysisInspectorPanel() {
   const formatLinkQuality = (v: number | null | undefined): string => {
     if (v === null || v === undefined || !Number.isFinite(v)) return '—';
     return `${v.toFixed(1)}/10`;
+  };
+
+  const formatElevation = (v: number | null | undefined): string => {
+    if (v === null || v === undefined || !Number.isFinite(v)) return '—';
+    return `${Math.round(v)} m`;
   };
 
   if (selected.type === 'node') {
@@ -285,6 +323,22 @@ export default function AnalysisInspectorPanel() {
       ? `${selected.publicKey?.substring(0, 8) ?? ''} ↔ ${selected.neighborPublicKey?.substring(0, 8) ?? ''}`
       : `!${(selected.nodeNum ?? 0).toString(16)} ↔ !${(selected.neighborNum ?? 0).toString(16)}`;
     const snr = selected.snr;
+    // Terrain integration (epic #3826, Phase 1, WP-2): distance is shown
+    // whenever both endpoints resolve to a position; endpoint elevations +
+    // the "View terrain profile" action are additionally gated on
+    // `elevationEnabled`, mirroring the toolbar's Link Profile button.
+    const distKm = neighborEndpoints
+      ? calculateDistance(
+          neighborEndpoints.a.lat,
+          neighborEndpoints.a.lng,
+          neighborEndpoints.b.lat,
+          neighborEndpoints.b.lng,
+        )
+      : null;
+    const showElevations = elevationEnabled && !!neighborEndpoints;
+    const samples = neighborProfile?.samples;
+    const elevA = samples && samples.length > 0 ? samples[0].elevation : undefined;
+    const elevB = samples && samples.length > 0 ? samples[samples.length - 1].elevation : undefined;
     return wrap(
       <>
         <h3>Neighbor Link</h3>
@@ -301,7 +355,34 @@ export default function AnalysisInspectorPanel() {
           <dd>{snr === null || snr === undefined ? '—' : `${snr.toFixed(2)} dB`}</dd>
           <dt>Reported</dt>
           <dd>{formatTime(selected.timestamp)}</dd>
+          {neighborEndpoints && (
+            <>
+              <dt>Distance</dt>
+              <dd>{distKm !== null ? formatDistance(distKm, distanceUnit) : '—'}</dd>
+            </>
+          )}
+          {showElevations && (
+            <>
+              <dt>Node Elevation</dt>
+              <dd>{neighborElevLoading ? '…' : formatElevation(elevA)}</dd>
+              <dt>Neighbor Elevation</dt>
+              <dd>{neighborElevLoading ? '…' : formatElevation(elevB)}</dd>
+            </>
+          )}
         </dl>
+        {elevationEnabled && neighborEndpoints && (
+          <button
+            type="button"
+            className="map-analysis-link-profile-action"
+            onClick={() => {
+              setMeasureMode(false);
+              setLinkEndpoints([neighborEndpoints.a, neighborEndpoints.b]);
+              setLinkProfileMode(true);
+            }}
+          >
+            View terrain profile
+          </button>
+        )}
       </>,
     );
   }

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -147,10 +147,10 @@ export default function AnalysisInspectorPanel() {
   // cache (§2.1 of the spec). Disabled (undefined endpoints) unless elevation
   // is enabled AND both endpoints resolved, so browsing with elevation off or
   // over unpositioned links issues no elevation requests at all.
-  const elevA = elevationEnabled ? neighborEndpoints?.a : undefined;
-  const elevB = elevationEnabled ? neighborEndpoints?.b : undefined;
+  const profileEndpointA = elevationEnabled ? neighborEndpoints?.a : undefined;
+  const profileEndpointB = elevationEnabled ? neighborEndpoints?.b : undefined;
   const { data: neighborProfile, isLoading: neighborElevLoading } =
-    useElevationProfile(elevA, elevB);
+    useElevationProfile(profileEndpointA, profileEndpointB);
 
   if (!config.inspectorOpen) {
     return (
@@ -337,8 +337,8 @@ export default function AnalysisInspectorPanel() {
       : null;
     const showElevations = elevationEnabled && !!neighborEndpoints;
     const samples = neighborProfile?.samples;
-    const elevA = samples && samples.length > 0 ? samples[0].elevation : undefined;
-    const elevB = samples && samples.length > 0 ? samples[samples.length - 1].elevation : undefined;
+    const endpointElevA = samples && samples.length > 0 ? samples[0].elevation : undefined;
+    const endpointElevB = samples && samples.length > 0 ? samples[samples.length - 1].elevation : undefined;
     return wrap(
       <>
         <h3>Neighbor Link</h3>
@@ -364,9 +364,9 @@ export default function AnalysisInspectorPanel() {
           {showElevations && (
             <>
               <dt>Node Elevation</dt>
-              <dd>{neighborElevLoading ? '…' : formatElevation(elevA)}</dd>
+              <dd>{neighborElevLoading ? '…' : formatElevation(endpointElevA)}</dd>
               <dt>Neighbor Elevation</dt>
-              <dd>{neighborElevLoading ? '…' : formatElevation(elevB)}</dd>
+              <dd>{neighborElevLoading ? '…' : formatElevation(endpointElevB)}</dd>
             </>
           )}
         </dl>

--- a/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
@@ -35,7 +35,7 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
 
     expect(result).not.toBeNull();
     expect(result?.a).toEqual({
-      id: 'src-a:1',
+      id: 'mt:1',
       lat: 10,
       lng: 20,
       isNode: true,
@@ -46,7 +46,7 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
       label: 'A1',
     });
     expect(result?.b).toEqual({
-      id: 'src-a:2',
+      id: 'mt:2',
       lat: 11,
       lng: 21,
       isNode: true,
@@ -135,7 +135,7 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
 
     expect(result).not.toBeNull();
     expect(result?.a).toEqual({
-      id: 'mc-src:pubA',
+      id: 'mc:pubA',
       lat: 30,
       lng: 40,
       isNode: true,
@@ -146,7 +146,7 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
       label: 'MCA',
     });
     expect(result?.b).toEqual({
-      id: 'mc-src:pubB',
+      id: 'mc:pubB',
       lat: 31,
       lng: 41,
       isNode: true,

--- a/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import { resolveNeighborEndpoints, type EndpointNodeRecord } from './neighborLinkEndpoints';
+import type { SelectedTarget } from './MapAnalysisContext';
+
+describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
+  it('Meshtastic, both positioned: returns endpoints with correct lat/lng/id/sourceId/nodeNum/isMeshCore, sourceIds from sources', () => {
+    const selected: SelectedTarget = {
+      type: 'neighbor',
+      sourceId: 'src-a',
+      nodeNum: 1,
+      neighborNum: 2,
+      snr: 5,
+      timestamp: 1000,
+    };
+    const nodes: EndpointNodeRecord[] = [
+      {
+        nodeNum: 1,
+        sourceId: 'src-a',
+        latitude: 10,
+        longitude: 20,
+        shortName: 'A1',
+        sources: [{ sourceId: 'src-a' }],
+      },
+      {
+        nodeNum: 2,
+        sourceId: 'src-a',
+        latitude: 11,
+        longitude: 21,
+        shortName: 'B1',
+        sources: [{ sourceId: 'src-a' }],
+      },
+    ];
+
+    const result = resolveNeighborEndpoints(selected, nodes);
+
+    expect(result).not.toBeNull();
+    expect(result?.a).toEqual({
+      id: 'src-a:1',
+      lat: 10,
+      lng: 20,
+      isNode: true,
+      sourceId: 'src-a',
+      sourceIds: ['src-a'],
+      nodeNum: 1,
+      isMeshCore: false,
+      label: 'A1',
+    });
+    expect(result?.b).toEqual({
+      id: 'src-a:2',
+      lat: 11,
+      lng: 21,
+      isNode: true,
+      sourceId: 'src-a',
+      sourceIds: ['src-a'],
+      nodeNum: 2,
+      isMeshCore: false,
+      label: 'B1',
+    });
+  });
+
+  it('Meshtastic, cross-source fallback (#3792): endpoint B positioned only under a different source than selected.sourceId still resolves', () => {
+    const selected: SelectedTarget = {
+      type: 'neighbor',
+      sourceId: 'src-a',
+      nodeNum: 1,
+      neighborNum: 2,
+    };
+    const nodes: EndpointNodeRecord[] = [
+      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20 },
+      // Only reported (positioned) under src-b, not the edge's own src-a.
+      { nodeNum: 2, sourceId: 'src-b', latitude: 11, longitude: 21 },
+    ];
+
+    const result = resolveNeighborEndpoints(selected, nodes);
+
+    expect(result).not.toBeNull();
+    expect(result?.b.sourceId).toBe('src-b');
+    expect(result?.b.lat).toBe(11);
+    expect(result?.b.lng).toBe(21);
+  });
+
+  it('Meshtastic, one endpoint unpositioned: returns null', () => {
+    const selected: SelectedTarget = {
+      type: 'neighbor',
+      sourceId: 'src-a',
+      nodeNum: 1,
+      neighborNum: 2,
+    };
+    const nodes: EndpointNodeRecord[] = [
+      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20 },
+      // No latitude/longitude at all for node 2.
+      { nodeNum: 2, sourceId: 'src-a' },
+    ];
+
+    expect(resolveNeighborEndpoints(selected, nodes)).toBeNull();
+  });
+
+  it('MeshCore, both positioned: matched by publicKey/neighborPublicKey, isMeshCore:true, nodeNum from record', () => {
+    const selected: SelectedTarget = {
+      type: 'neighbor',
+      sourceId: 'mc-src',
+      publicKey: 'pubA',
+      neighborPublicKey: 'pubB',
+      nodeName: 'Node A',
+      neighborName: 'Node B',
+      snr: 3,
+      timestamp: 2000,
+      nodeNum: 0,
+      neighborNum: 0,
+    };
+    const nodes: EndpointNodeRecord[] = [
+      {
+        isMeshCore: true,
+        publicKey: 'pubA',
+        sourceId: 'mc-src',
+        nodeNum: 100,
+        latitude: 30,
+        longitude: 40,
+        shortName: 'MCA',
+        sources: [{ sourceId: 'mc-src' }],
+      },
+      {
+        isMeshCore: true,
+        publicKey: 'pubB',
+        sourceId: 'mc-src',
+        nodeNum: 101,
+        latitude: 31,
+        longitude: 41,
+        shortName: 'MCB',
+        sources: [{ sourceId: 'mc-src' }],
+      },
+    ];
+
+    const result = resolveNeighborEndpoints(selected, nodes);
+
+    expect(result).not.toBeNull();
+    expect(result?.a).toEqual({
+      id: 'mc-src:pubA',
+      lat: 30,
+      lng: 40,
+      isNode: true,
+      sourceId: 'mc-src',
+      sourceIds: ['mc-src'],
+      nodeNum: 100,
+      isMeshCore: true,
+      label: 'MCA',
+    });
+    expect(result?.b).toEqual({
+      id: 'mc-src:pubB',
+      lat: 31,
+      lng: 41,
+      isNode: true,
+      sourceId: 'mc-src',
+      sourceIds: ['mc-src'],
+      nodeNum: 101,
+      isMeshCore: true,
+      label: 'MCB',
+    });
+  });
+
+  it('MeshCore, publicKey not found: returns null', () => {
+    const selected: SelectedTarget = {
+      type: 'neighbor',
+      sourceId: 'mc-src',
+      publicKey: 'pubA',
+      neighborPublicKey: 'pub-missing',
+      nodeNum: 0,
+      neighborNum: 0,
+    };
+    const nodes: EndpointNodeRecord[] = [
+      { isMeshCore: true, publicKey: 'pubA', sourceId: 'mc-src', nodeNum: 100, latitude: 30, longitude: 40 },
+    ];
+
+    expect(resolveNeighborEndpoints(selected, nodes)).toBeNull();
+  });
+
+  it('Null-Island endpoint (0,0) is discarded by resolveNodeLatLng, returns null', () => {
+    const selected: SelectedTarget = {
+      type: 'neighbor',
+      sourceId: 'src-a',
+      nodeNum: 1,
+      neighborNum: 2,
+    };
+    const nodes: EndpointNodeRecord[] = [
+      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20 },
+      { nodeNum: 2, sourceId: 'src-a', latitude: 0, longitude: 0 },
+    ];
+
+    expect(resolveNeighborEndpoints(selected, nodes)).toBeNull();
+  });
+
+  it('Non-neighbor selection: returns null', () => {
+    const selected: SelectedTarget = {
+      type: 'node',
+      nodeNum: 1,
+      sourceId: 'src-a',
+    };
+    const nodes: EndpointNodeRecord[] = [
+      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20 },
+    ];
+
+    expect(resolveNeighborEndpoints(selected, nodes)).toBeNull();
+  });
+});

--- a/src/components/MapAnalysis/neighborLinkEndpoints.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.ts
@@ -1,0 +1,122 @@
+/**
+ * Resolves a neighbor-link `SelectedTarget` into a `LinkEndpoint` pair, for
+ * the Map Analysis inspector's terrain integration (epic #3826, Phase 1,
+ * WP-1). Pure and react-free — consumes the unified node list already held
+ * by `AnalysisInspectorPanel` (no new fetch).
+ *
+ * `SelectedTarget` (neighbor variant) carries only identifiers (nodeNum/
+ * neighborNum or publicKey/neighborPublicKey) — not coordinates. This module
+ * does the lookup against the unified node list plus the cross-source
+ * position fallback the neighbor-link layers use (#3792), and shapes the
+ * result into the exact `LinkEndpoint` fields `MapAnalysisCanvas`'s
+ * `linkEndpointCandidates` produces, so `useAutoRadioDefaults` and the Link
+ * Profile drawer treat it identically to a toolbar-picked endpoint.
+ *
+ * See docs/internal/dev-notes/NEIGHBOR_LINK_TERRAIN_SPEC.md §3.1.
+ */
+import type { LinkEndpoint } from '../../utils/linkProfile';
+import type { SelectedTarget } from './MapAnalysisContext';
+import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+
+/** Minimal node shape the resolver needs (subset of useAnalysisNodes' NodeRecord). */
+export interface EndpointNodeRecord extends MaybePositionedNode {
+  nodeNum?: number;
+  sourceId?: string;
+  isMeshCore?: boolean;
+  publicKey?: string | null;
+  longName?: string | null;
+  shortName?: string | null;
+  sources?: Array<{ sourceId: string }>;
+}
+
+export interface NeighborEndpoints {
+  a: LinkEndpoint;
+  b: LinkEndpoint;
+}
+
+interface ResolvedNode {
+  node: EndpointNodeRecord;
+  latLng: [number, number];
+}
+
+/**
+ * Finds the first positioned node matching `matches`, preferring one whose
+ * `sourceId` equals `preferredSourceId` (the edge's reporting source) but
+ * falling back to any other positioned match (#3792 cross-source fallback —
+ * mirrors `NeighborLinksLayer`'s `positionByKey` → `positionByNode` pattern).
+ * Unpositioned matches (no resolvable lat/lng) are skipped entirely.
+ */
+function findPositionedNode(
+  nodes: EndpointNodeRecord[],
+  matches: (n: EndpointNodeRecord) => boolean,
+  preferredSourceId: string | undefined,
+): ResolvedNode | null {
+  let preferred: ResolvedNode | null = null;
+  let fallback: ResolvedNode | null = null;
+  for (const node of nodes) {
+    if (!matches(node)) continue;
+    const latLng = resolveNodeLatLng(node);
+    if (!latLng) continue;
+    if (preferredSourceId !== undefined && node.sourceId === preferredSourceId) {
+      if (!preferred) preferred = { node, latLng };
+    } else if (!fallback) {
+      fallback = { node, latLng };
+    }
+  }
+  return preferred ?? fallback;
+}
+
+function buildEndpoint(resolved: ResolvedNode, isMeshCore: boolean): LinkEndpoint {
+  const { node, latLng } = resolved;
+  return {
+    id: isMeshCore
+      ? `${node.sourceId ?? ''}:${node.publicKey ?? ''}`
+      : `${node.sourceId ?? ''}:${node.nodeNum}`,
+    lat: latLng[0],
+    lng: latLng[1],
+    isNode: true,
+    sourceId: node.sourceId,
+    sourceIds: node.sources?.map((s) => s.sourceId) ?? (node.sourceId ? [node.sourceId] : []),
+    nodeNum: node.nodeNum,
+    isMeshCore,
+    label: node.shortName ?? undefined,
+  };
+}
+
+/**
+ * Build a LinkEndpoint pair for a selected neighbor link, or null when either
+ * endpoint cannot be resolved to a rendered position. Meshtastic links key on
+ * nodeNum with the #3792 cross-source fallback; MeshCore links key on
+ * publicKey.
+ */
+export function resolveNeighborEndpoints(
+  selected: SelectedTarget,
+  nodes: EndpointNodeRecord[],
+): NeighborEndpoints | null {
+  if (selected.type !== 'neighbor') return null;
+
+  const isMeshCore = !!selected.publicKey;
+
+  const resolvedA = isMeshCore
+    ? findPositionedNode(
+        nodes,
+        (n) => !!n.isMeshCore && n.publicKey === selected.publicKey,
+        selected.sourceId,
+      )
+    : findPositionedNode(nodes, (n) => n.nodeNum === selected.nodeNum, selected.sourceId);
+
+  const resolvedB = isMeshCore
+    ? findPositionedNode(
+        nodes,
+        (n) => !!n.isMeshCore && n.publicKey === selected.neighborPublicKey,
+        selected.sourceId,
+      )
+    : findPositionedNode(nodes, (n) => n.nodeNum === selected.neighborNum, selected.sourceId);
+
+  if (!resolvedA || !resolvedB) return null;
+
+  return {
+    a: buildEndpoint(resolvedA, isMeshCore),
+    b: buildEndpoint(resolvedB, isMeshCore),
+  };
+}

--- a/src/components/MapAnalysis/neighborLinkEndpoints.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.ts
@@ -17,6 +17,7 @@
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import type { SelectedTarget } from './MapAnalysisContext';
 import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+import { unifiedNodeKey } from '../../utils/nodeIdentity';
 
 /** Minimal node shape the resolver needs (subset of useAnalysisNodes' NodeRecord). */
 export interface EndpointNodeRecord extends MaybePositionedNode {
@@ -69,9 +70,12 @@ function findPositionedNode(
 function buildEndpoint(resolved: ResolvedNode, isMeshCore: boolean): LinkEndpoint {
   const { node, latLng } = resolved;
   return {
-    id: isMeshCore
-      ? `${node.sourceId ?? ''}:${node.publicKey ?? ''}`
-      : `${node.sourceId ?? ''}:${node.nodeNum}`,
+    // Byte-for-byte parity with MapAnalysisCanvas.linkEndpointCandidates,
+    // whose `id` is `AnalysisNode.key` = `unifiedNodeKey(node)` (`mt:${nodeNum}`
+    // / `mc:${publicKey}`). The matched node always carries the identifier the
+    // matcher keyed on, so the null branch is unreachable in practice; '' is a
+    // defensive fallback only.
+    id: unifiedNodeKey(node) ?? '',
     lat: latLng[0],
     lng: latLng[1],
     isNode: true,

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -382,6 +382,30 @@
   word-break: break-word;
 }
 
+/* Inspector: "View terrain profile" neighbor-link action (epic #3826, Phase
+   1, WP-2). Opens the existing Link Profile drawer pre-populated with the
+   link's two endpoints. */
+.map-analysis-link-profile-action {
+  display: block;
+  width: 100%;
+  margin-top: 14px;
+  background: #1e3a8a;
+  color: #fff;
+  border: 1px solid #2563eb;
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.map-analysis-link-profile-action:hover,
+.map-analysis-link-profile-action:focus-visible {
+  background: #2563eb;
+  border-color: #3b82f6;
+  outline: none;
+}
+
 /* ===== Follow resume overlay (issue #3788 P2 WP-D) ===== */
 .map-analysis-follow-resume {
   position: absolute;


### PR DESCRIPTION
## Summary
Phase 1 of the 3D Map & Elevation epic (#3826). The Map Analysis inspector previously showed only SNR for a selected neighbor link; understanding whether that link *should* work meant manually re-picking both endpoints with the Link Profile tool. This PR surfaces terrain-aware context directly on neighbor-link selection — great-circle distance, DEM ground elevation at each endpoint, and a one-click **View terrain profile** action that opens the existing Link Profile drawer pre-loaded with the link's endpoints. Works for both Meshtastic and MeshCore neighbor links.

## Changes
- New `src/components/MapAnalysis/neighborLinkEndpoints.ts`: pure resolver turning a neighbor `SelectedTarget` into a `LinkEndpoint` pair (nodeNum-keyed for Meshtastic with the #3792 cross-source position fallback, publicKey-keyed for MeshCore; `id` via `unifiedNodeKey` for exact parity with `linkEndpointCandidates`).
- `AnalysisInspectorPanel`: Distance row whenever both endpoints resolve; endpoint elevation rows + **View terrain profile** button gated on `useElevationEnabled()` (mirrors the toolbar's Link Profile button). The action reuses the existing `MapAnalysisContext` state machine (`setLinkEndpoints` + `setLinkProfileMode`) — no parallel drawer, no new context state, no backend changes.
- Endpoint elevations reuse `useElevationProfile` with the drawer's exact query key: one elevation request per distinct link, and opening the drawer afterwards is a cache hit (verified live — request count stayed at 1).
- CSS: `.map-analysis-link-profile-action` inspector CTA.
- Docs: `docs/features/map-analysis.md` (neighbor-links layer + inspector sections); adds the epic plan (`MAP_3D_ELEVATION_EPIC.md`) and Phase 1 spec to dev-notes.

## Issues Resolved
Relates to #3826 (Phase 1 of 3; interim elevation track from the issue's "lighter-weight interim step").

## Documentation Updates
- `docs/features/map-analysis.md`: documented neighbor-link distance/elevation inspector rows and the terrain-profile shortcut.
- `docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md` + `NEIGHBOR_LINK_TERRAIN_SPEC.md` added.

## Testing
- [x] Unit tests pass — full suite 10,427 passed / 0 failed, `success: true` via JSON reporter (includes 7 new resolver tests + 6 new inspector cases)
- [x] TypeScript compiles cleanly (`tsc --noEmit` + `tsconfig.server.json`)
- [x] `npm run lint:ci` exits 0 (no baseline growth)
- [x] Browser-validated on dev container: MeshCore link → distance/elevations/action + drawer opens with auto-seeded frequency ("from MC-Sandbox"); Meshtastic link (MQTT broker source) → distance resolves; elevation disabled → distance only, no elevation requests fired
- [ ] Reviewer: select a neighbor link in Map Analysis (Neighbors layer on) → inspector shows Distance/elevations; click **View terrain profile** → drawer opens with that link's endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1