### PR TITLE
fix(db): give PostgreSQL/MySQL a migration ledger; stop migration 030 rebuilding route_segments on every boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,9 @@ The remainder of this file is reference detail used less often than the rules ab
    - `export async function runMigrationNNNMysql(pool)` for MySQL
 2. Register it in `src/db/migrations.ts` with `registry.register({ number, name, settingsKey, sqlite, postgres, mysql })`.
    `src/db/migrations.test.ts` does **not** need editing — its assertions are registry-derived and automatically cover the new entry.
-3. Make migrations **idempotent** using the shared helpers in `src/server/migrations/helpers.ts`:
+   **`settingsKey` is required** (every migration but the 001 baseline has one) — all three backends use it for idempotency tracking. SQLite checks it inline in its loop; PostgreSQL/MySQL go through the ledger in `src/db/migrationLedger.ts` (#4233).
+3. Make migrations **idempotent** using the shared helpers in `src/server/migrations/helpers.ts`.
+   The ledger means a migration normally runs once per database, but a crash between the migration and its ledger write re-runs it, so **idempotency is still mandatory on every backend**. In particular, never write a migration that unconditionally deletes and rebuilds a table — that is what made 030 wipe and rebuild 865k `route_segments` rows on every single boot (#4233). Guard destructive work behind a "has this already been applied?" check, and batch bulk inserts rather than issuing one round-trip per row.
    - SQLite: `addColumnIfMissing(db, table, column, ddl)` — catches "duplicate column"; re-throws others.
    - PostgreSQL: `addColumnIfMissingPostgres(client, table, column, ddl)` — uses native `ADD COLUMN IF NOT EXISTS`.
    - MySQL columns: `addColumnIfMissingMysql(pool, table, column, ddl)` — `information_schema.COLUMNS` pre-check.

--- a/src/db/migrationLedger.test.ts
+++ b/src/db/migrationLedger.test.ts
@@ -19,6 +19,8 @@ import {
   MIGRATION_COMPLETED,
 } from './migrationLedger.js';
 import type { MigrationEntry } from './migrationRegistry.js';
+import type { PoolClient } from 'pg';
+import type { Pool as MySQLPool } from 'mysql2/promise';
 
 /** Minimal fake `pg` client: canned responses matched on SQL substrings. */
 function fakePgClient(opts: { settingsTableExists: boolean; appliedKeys?: string[] }) {
@@ -36,7 +38,7 @@ function fakePgClient(opts: { settingsTableExists: boolean; appliedKeys?: string
       return { rows: [], rowCount: 0 };
     }),
   };
-  return client;
+  return client as typeof client & PoolClient;
 }
 
 /** Minimal fake mysql2 pool. */
@@ -55,7 +57,7 @@ function fakeMysqlPool(opts: { settingsTableExists: boolean; appliedKeys?: strin
       return [{}];
     }),
   };
-  return pool;
+  return pool as typeof pool & MySQLPool;
 }
 
 function entry(number: number, overrides: Partial<MigrationEntry> = {}): MigrationEntry {

--- a/src/db/migrationLedger.test.ts
+++ b/src/db/migrationLedger.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Migration ledger (PostgreSQL / MySQL) — #4233
+ *
+ * Before the ledger, `createPostgresSchema` / `createMySQLSchema` re-ran every
+ * registered migration on every boot, relying entirely on each migration being
+ * internally idempotent. Migration 030 was not, so every restart cleared and
+ * rebuilt the whole `route_segments` table.
+ *
+ * These tests pin the guard: a migration recorded in the ledger must not run
+ * again, one that is not recorded must run and then be recorded.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  readAppliedMigrationsPostgres,
+  markMigrationAppliedPostgres,
+  readAppliedMigrationsMysql,
+  markMigrationAppliedMysql,
+  runLedgeredMigrations,
+  MIGRATION_COMPLETED,
+} from './migrationLedger.js';
+import type { MigrationEntry } from './migrationRegistry.js';
+
+/** Minimal fake `pg` client: canned responses matched on SQL substrings. */
+function fakePgClient(opts: { settingsTableExists: boolean; appliedKeys?: string[] }) {
+  const queries: { sql: string; params?: any[] }[] = [];
+  const client = {
+    queries,
+    query: vi.fn(async (sql: string, params?: any[]) => {
+      queries.push({ sql, params });
+      if (sql.includes('information_schema.tables')) {
+        return { rows: [{ exists: opts.settingsTableExists }] };
+      }
+      if (sql.includes('SELECT key FROM settings')) {
+        return { rows: (opts.appliedKeys ?? []).map(key => ({ key })) };
+      }
+      return { rows: [], rowCount: 0 };
+    }),
+  };
+  return client;
+}
+
+/** Minimal fake mysql2 pool. */
+function fakeMysqlPool(opts: { settingsTableExists: boolean; appliedKeys?: string[] }) {
+  const queries: { sql: string; params?: any[] }[] = [];
+  const pool = {
+    queries,
+    query: vi.fn(async (sql: string, params?: any[]) => {
+      queries.push({ sql, params });
+      if (sql.includes('information_schema.TABLES')) {
+        return [[{ count: opts.settingsTableExists ? 1 : 0 }]];
+      }
+      if (sql.includes('FROM settings')) {
+        return [(opts.appliedKeys ?? []).map(key => ({ key }))];
+      }
+      return [{}];
+    }),
+  };
+  return pool;
+}
+
+function entry(number: number, overrides: Partial<MigrationEntry> = {}): MigrationEntry {
+  return {
+    number,
+    name: `migration-${number}`,
+    settingsKey: `migration_${String(number).padStart(3, '0')}_test`,
+    ...overrides,
+  };
+}
+
+describe('migration ledger — PostgreSQL', () => {
+  it('returns an empty set when the settings table does not exist yet', async () => {
+    const client = fakePgClient({ settingsTableExists: false });
+    await expect(readAppliedMigrationsPostgres(client)).resolves.toEqual(new Set());
+  });
+
+  it('reads recorded migration keys', async () => {
+    const client = fakePgClient({
+      settingsTableExists: true,
+      appliedKeys: ['migration_030_route_segments', 'migration_031_other'],
+    });
+    const applied = await readAppliedMigrationsPostgres(client);
+    expect(applied.has('migration_030_route_segments')).toBe(true);
+    expect(applied.size).toBe(2);
+  });
+
+  it('only reads keys marked completed', async () => {
+    const client = fakePgClient({ settingsTableExists: true });
+    await readAppliedMigrationsPostgres(client);
+    const read = client.queries.find(q => q.sql.includes('SELECT key FROM settings'));
+    expect(read?.params).toEqual([MIGRATION_COMPLETED]);
+  });
+
+  it('records a migration as an idempotent upsert', async () => {
+    const client = fakePgClient({ settingsTableExists: true });
+    await markMigrationAppliedPostgres(client, 'migration_030_route_segments');
+    const insert = client.queries.at(-1)!;
+    expect(insert.sql).toContain('ON CONFLICT (key) DO UPDATE');
+    expect(insert.params?.[0]).toBe('migration_030_route_segments');
+    expect(insert.params?.[1]).toBe(MIGRATION_COMPLETED);
+  });
+});
+
+describe('migration ledger — MySQL', () => {
+  it('returns an empty set when the settings table does not exist yet', async () => {
+    const pool = fakeMysqlPool({ settingsTableExists: false });
+    await expect(readAppliedMigrationsMysql(pool)).resolves.toEqual(new Set());
+  });
+
+  it('reads recorded migration keys', async () => {
+    const pool = fakeMysqlPool({
+      settingsTableExists: true,
+      appliedKeys: ['migration_030_route_segments'],
+    });
+    const applied = await readAppliedMigrationsMysql(pool);
+    expect(applied.has('migration_030_route_segments')).toBe(true);
+  });
+
+  it('records a migration as an idempotent upsert', async () => {
+    const pool = fakeMysqlPool({ settingsTableExists: true });
+    await markMigrationAppliedMysql(pool, 'migration_030_route_segments');
+    const insert = pool.queries.at(-1)!;
+    expect(insert.sql).toContain('ON DUPLICATE KEY UPDATE');
+    expect(insert.params?.[0]).toBe('migration_030_route_segments');
+  });
+});
+
+describe('runLedgeredMigrations', () => {
+  const harness = (applied: string[]) => ({
+    readApplied: async () => new Set(applied),
+    markApplied: vi.fn(async () => {}),
+  });
+
+  it('skips migrations already recorded in the ledger', async () => {
+    const ran: number[] = [];
+    const migrations = [entry(2), entry(3), entry(4)];
+    const { readApplied, markApplied } = harness([
+      'migration_002_test',
+      'migration_004_test',
+    ]);
+
+    const result = await runLedgeredMigrations({
+      backend: 'Test',
+      handle: {},
+      migrations,
+      pick: m => async () => { ran.push(m.number); },
+      readApplied,
+      markApplied,
+    });
+
+    expect(ran).toEqual([3]);
+    expect(result).toEqual({ ran: 1, skipped: 2 });
+  });
+
+  it('records each migration it runs', async () => {
+    const migrations = [entry(2), entry(3)];
+    const { readApplied, markApplied } = harness([]);
+
+    await runLedgeredMigrations({
+      backend: 'Test',
+      handle: {},
+      migrations,
+      pick: () => async () => {},
+      readApplied,
+      markApplied,
+    });
+
+    expect(markApplied).toHaveBeenCalledTimes(2);
+    expect(markApplied).toHaveBeenCalledWith({}, 'migration_002_test');
+    expect(markApplied).toHaveBeenCalledWith({}, 'migration_003_test');
+  });
+
+  it('always runs the baseline migration, which has no settingsKey', async () => {
+    const ran: number[] = [];
+    const migrations = [entry(1, { settingsKey: undefined }), entry(2)];
+    const { readApplied, markApplied } = harness(['migration_002_test']);
+
+    await runLedgeredMigrations({
+      backend: 'Test',
+      handle: {},
+      migrations,
+      pick: m => async () => { ran.push(m.number); },
+      readApplied,
+      markApplied,
+    });
+
+    // 001 runs (it creates the settings table the ledger lives in) but is not
+    // recorded; 002 is skipped because the ledger already has it.
+    expect(ran).toEqual([1]);
+    expect(markApplied).not.toHaveBeenCalled();
+  });
+
+  it('skips migrations with no implementation for this backend', async () => {
+    const migrations = [entry(2), entry(3)];
+    const { readApplied, markApplied } = harness([]);
+
+    const result = await runLedgeredMigrations({
+      backend: 'Test',
+      handle: {},
+      migrations,
+      pick: m => (m.number === 3 ? async () => {} : undefined),
+      readApplied,
+      markApplied,
+    });
+
+    expect(result).toEqual({ ran: 1, skipped: 0 });
+  });
+
+  it('does not record a migration that threw, so it retries next boot', async () => {
+    const migrations = [entry(2)];
+    const { readApplied, markApplied } = harness([]);
+
+    await expect(runLedgeredMigrations({
+      backend: 'Test',
+      handle: {},
+      migrations,
+      pick: () => async () => { throw new Error('boom'); },
+      readApplied,
+      markApplied,
+    })).rejects.toThrow('boom');
+
+    expect(markApplied).not.toHaveBeenCalled();
+  });
+
+  it('runs everything on a pre-existing database with an empty ledger', async () => {
+    // The one-time post-ledger replay: nothing is recorded yet, so all
+    // migrations run once and are then recorded.
+    const migrations = [entry(2), entry(3), entry(4)];
+    const { readApplied, markApplied } = harness([]);
+
+    const result = await runLedgeredMigrations({
+      backend: 'Test',
+      handle: {},
+      migrations,
+      pick: () => async () => {},
+      readApplied,
+      markApplied,
+    });
+
+    expect(result).toEqual({ ran: 3, skipped: 0 });
+    expect(markApplied).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/db/migrationLedger.ts
+++ b/src/db/migrationLedger.ts
@@ -1,0 +1,154 @@
+/**
+ * Migration Ledger (PostgreSQL / MySQL)
+ *
+ * SQLite has always tracked applied migrations by writing each migration's
+ * `settingsKey` into the `settings` table (see the SQLite loop in
+ * `DatabaseService.runMigrations`). PostgreSQL and MySQL had no equivalent —
+ * their loops re-ran *every* registered migration on *every* boot and relied
+ * entirely on each migration being internally idempotent.
+ *
+ * That assumption broke down (see #4233): migration 030 unconditionally
+ * cleared and rebuilt `route_segments`, so every restart wiped and re-inserted
+ * the whole table — hundreds of thousands of rows on a mature install.
+ *
+ * This module gives PG/MySQL the same ledger SQLite uses, keyed off the same
+ * `settingsKey` values and stored in the same `settings` table. Keeping the
+ * mechanism identical across all three backends means a SQLite → PostgreSQL
+ * restore carries its migration history with it.
+ *
+ * Migration 001 is the baseline that *creates* the `settings` table, so it
+ * carries no `settingsKey` and always runs unguarded (it is pure
+ * `CREATE TABLE IF NOT EXISTS`). Migrations 002+ are guarded. This mirrors
+ * SQLite, where `migrations.test.ts` already asserts 001 has no `settingsKey`
+ * and 002+ all do.
+ */
+
+import { logger } from '../utils/logger.js';
+import type { MigrationEntry } from './migrationRegistry.js';
+import type { PoolClient } from 'pg';
+import type { Pool as MySQLPool } from 'mysql2/promise';
+
+/** Value written for a migration that has been applied. Matches SQLite. */
+export const MIGRATION_COMPLETED = 'completed';
+
+/**
+ * Read the set of already-applied migration keys.
+ *
+ * Returns an empty set when the `settings` table does not exist yet — that is
+ * the fresh-install case, where migration 001 is about to create it.
+ */
+export async function readAppliedMigrationsPostgres(client: PoolClient): Promise<Set<string>> {
+  const exists = await client.query(`
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'settings'
+    ) as exists
+  `);
+  if (!exists.rows[0]?.exists) return new Set();
+
+  const { rows } = await client.query(
+    `SELECT key FROM settings WHERE key LIKE 'migration_%' AND value = $1`,
+    [MIGRATION_COMPLETED],
+  );
+  return new Set(rows.map((r: { key: string }) => r.key));
+}
+
+/** Record a migration as applied. Idempotent. */
+export async function markMigrationAppliedPostgres(client: PoolClient, key: string): Promise<void> {
+  const now = Date.now();
+  await client.query(
+    `INSERT INTO settings (key, value, "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $3)
+     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, "updatedAt" = EXCLUDED."updatedAt"`,
+    [key, MIGRATION_COMPLETED, now],
+  );
+}
+
+/**
+ * Read the set of already-applied migration keys.
+ *
+ * Returns an empty set when the `settings` table does not exist yet.
+ */
+export async function readAppliedMigrationsMysql(pool: MySQLPool): Promise<Set<string>> {
+  const [tableRows] = await pool.query(
+    `SELECT COUNT(*) as count FROM information_schema.TABLES
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'settings'`,
+  );
+  if (!Number((tableRows as Array<{ count: number }>)[0]?.count)) return new Set();
+
+  const [rows] = await pool.query(
+    'SELECT `key` FROM settings WHERE `key` LIKE \'migration_%\' AND value = ?',
+    [MIGRATION_COMPLETED],
+  );
+  return new Set((rows as Array<{ key: string }>).map(r => r.key));
+}
+
+/** Record a migration as applied. Idempotent. */
+export async function markMigrationAppliedMysql(pool: MySQLPool, key: string): Promise<void> {
+  const now = Date.now();
+  await pool.query(
+    'INSERT INTO settings (`key`, value, createdAt, updatedAt) VALUES (?, ?, ?, ?) ' +
+      'ON DUPLICATE KEY UPDATE value = VALUES(value), updatedAt = VALUES(updatedAt)',
+    [key, MIGRATION_COMPLETED, now, now],
+  );
+}
+
+/**
+ * Run a registry's migrations against one backend, skipping any already
+ * recorded in the ledger and recording each one that runs.
+ *
+ * Shared by the PostgreSQL and MySQL paths so the guard logic exists once.
+ * A migration with no `settingsKey` (only 001, the baseline) always runs —
+ * it is what creates the `settings` table the ledger lives in.
+ *
+ * On the first boot after the ledger is introduced the applied-set is empty,
+ * so every migration replays once and is then recorded. There is deliberately
+ * no backfill: there is no way to know which migrations actually ran against
+ * a given pre-existing database, so they are re-run (they are expected to be
+ * idempotent) rather than assumed done.
+ */
+export async function runLedgeredMigrations<H>(opts: {
+  backend: string;
+  handle: H;
+  migrations: ReadonlyArray<MigrationEntry>;
+  /** Extract this backend's migration function, or undefined if it has none. */
+  pick: (m: MigrationEntry) => ((handle: H) => Promise<void>) | undefined;
+  readApplied: (handle: H) => Promise<Set<string>>;
+  markApplied: (handle: H, key: string) => Promise<void>;
+}): Promise<{ ran: number; skipped: number }> {
+  const { backend, handle, migrations, pick, readApplied, markApplied } = opts;
+
+  const applied = await readApplied(handle);
+  let ran = 0;
+  let skipped = 0;
+
+  for (const migration of migrations) {
+    const fn = pick(migration);
+    if (!fn) continue;
+
+    if (migration.settingsKey && applied.has(migration.settingsKey)) {
+      skipped++;
+      continue;
+    }
+
+    const label = `${String(migration.number).padStart(3, '0')} (${migration.name})`;
+    logger.debug(`[${backend}] Running migration ${label}...`);
+    await fn(handle);
+    ran++;
+
+    // Recorded only after the migration resolves. If the process dies between
+    // the two, the migration re-runs on the next boot — which is why every
+    // PG/MySQL migration must remain internally idempotent.
+    if (migration.settingsKey) {
+      await markApplied(handle, migration.settingsKey);
+    }
+  }
+
+  if (skipped > 0) {
+    logger.info(`[${backend}] Skipped ${skipped} already-applied migration(s), ran ${ran}`);
+  } else if (ran > 0) {
+    logger.info(`[${backend}] Ran ${ran} migration(s) (no ledger entries found — recording them now)`);
+  }
+
+  return { ran, skipped };
+}

--- a/src/db/migrationLedger.ts
+++ b/src/db/migrationLedger.ts
@@ -36,6 +36,14 @@ export const MIGRATION_COMPLETED = 'completed';
  *
  * Returns an empty set when the `settings` table does not exist yet — that is
  * the fresh-install case, where migration 001 is about to create it.
+ *
+ * Scoped to the `public` schema, matching every other `information_schema`
+ * lookup in the PostgreSQL path (the pre-v3.7 detection in
+ * `createPostgresSchema`, migration 030's column check, and others). A
+ * deployment using a non-`public` search_path would not be found here — but it
+ * would equally not be found by any of those, so the assumption is consistent
+ * repo-wide rather than introduced by the ledger. Changing it means changing
+ * all of them together.
  */
 export async function readAppliedMigrationsPostgres(client: PoolClient): Promise<Set<string>> {
   const exists = await client.query(`
@@ -74,7 +82,7 @@ export async function readAppliedMigrationsMysql(pool: MySQLPool): Promise<Set<s
     `SELECT COUNT(*) as count FROM information_schema.TABLES
      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'settings'`,
   );
-  if (!Number((tableRows as Array<{ count: number }>)[0]?.count)) return new Set();
+  if (Number((tableRows as Array<{ count: number }>)[0]?.count) === 0) return new Set();
 
   const [rows] = await pool.query(
     'SELECT `key` FROM settings WHERE `key` LIKE \'migration_%\' AND value = ?',
@@ -147,7 +155,10 @@ export async function runLedgeredMigrations<H>(opts: {
   if (skipped > 0) {
     logger.info(`[${backend}] Skipped ${skipped} already-applied migration(s), ran ${ran}`);
   } else if (ran > 0) {
-    logger.info(`[${backend}] Ran ${ran} migration(s) (no ledger entries found — recording them now)`);
+    // No ledger entries: either a fresh install, or an existing database on
+    // its first boot since the ledger was introduced. Both run everything
+    // once and record it; neither repeats.
+    logger.info(`[${backend}] Ran ${ran} migration(s), now recorded in the ledger`);
   }
 
   return { ran, skipped };

--- a/src/db/migrationRegistry.ts
+++ b/src/db/migrationRegistry.ts
@@ -17,12 +17,21 @@ export interface MigrationEntry {
   postgres?: (client: any) => Promise<void>;
   /** MySQL migration function */
   mysql?: (pool: any) => Promise<void>;
-  /** Settings key for SQLite idempotency tracking */
+  /**
+   * Settings key for idempotency tracking, used by all three backends.
+   *
+   * SQLite checks and sets it inline in its migration loop; PostgreSQL and
+   * MySQL read the whole applied-set up front and record each migration after
+   * it runs (see `migrationLedger.ts`, #4233). Only migration 001 — the
+   * baseline that creates the `settings` table the ledger lives in — omits it.
+   */
   settingsKey?: string;
   /**
    * If true, the SQLite migration handles its own idempotency internally
    * (old-style migrations that check sqlite_master or use CREATE TABLE IF NOT EXISTS).
    * The registry loop calls the function without checking/setting the settingsKey.
+   *
+   * SQLite-only — the PG/MySQL ledger guards on `settingsKey` regardless.
    */
   selfIdempotent?: boolean;
 }

--- a/src/server/migrations/030_add_source_id_to_route_segments.ts
+++ b/src/server/migrations/030_add_source_id_to_route_segments.ts
@@ -264,7 +264,11 @@ export const migration = {
  */
 const REBUILD_BATCH_SIZE = 500;
 
-const SEGMENT_COLUMNS = 13;
+/**
+ * Bind parameters per row on the PostgreSQL path. The MySQL path uses 12 —
+ * it hardcodes `isRecordHolder` as `0` in the tuple instead of binding it.
+ */
+const PG_SEGMENT_COLUMNS = 13;
 
 /** Split an array into fixed-size chunks. */
 function chunk<T>(items: T[], size: number): T[][] {
@@ -344,7 +348,7 @@ export async function runMigration030Postgres(client: any): Promise<void> {
     for (const batch of chunk(segments, REBUILD_BATCH_SIZE)) {
       const values: unknown[] = [];
       const tuples = batch.map((s, i) => {
-        const b = i * SEGMENT_COLUMNS;
+        const b = i * PG_SEGMENT_COLUMNS;
         values.push(
           s.fromNodeNum, s.toNodeNum, s.fromNodeId, s.toNodeId, s.distanceKm,
           false, s.fromLatitude, s.fromLongitude, s.toLatitude, s.toLongitude,
@@ -355,7 +359,9 @@ export async function runMigration030Postgres(client: any): Promise<void> {
 
       // PostgreSQL aborts the whole transaction on any statement error, so
       // each batch runs under a savepoint we can roll back to without losing
-      // the work already committed to the transaction.
+      // the work already committed to the transaction. Savepoint names are
+      // connection-local and this loop is sequential on one connection, so the
+      // fixed names cannot collide.
       await client.query('SAVEPOINT batch_sp');
       try {
         await client.query(

--- a/src/server/migrations/030_add_source_id_to_route_segments.ts
+++ b/src/server/migrations/030_add_source_id_to_route_segments.ts
@@ -254,7 +254,47 @@ export const migration = {
 
 // ============ PostgreSQL ============
 
+/**
+ * Rows per multi-row INSERT when rebuilding route_segments.
+ *
+ * The original implementation issued one round-trip per segment, which on a
+ * mature install meant ~865k sequential round-trips inside a single
+ * transaction (#4233). 500 rows × 13 columns = 6,500 bind parameters, well
+ * under PostgreSQL's 65,535 limit and MySQL's default max_allowed_packet.
+ */
+const REBUILD_BATCH_SIZE = 500;
+
+const SEGMENT_COLUMNS = 13;
+
+/** Split an array into fixed-size chunks. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
 export async function runMigration030Postgres(client: any): Promise<void> {
+  // Idempotency guard (#4233). Before the PG/MySQL migration ledger existed,
+  // this migration re-ran on every boot and unconditionally cleared and
+  // rebuilt the whole table. The ledger is now the primary guard; this check
+  // is what makes the one-time post-ledger replay cheap on installs where 030
+  // already ran. The ALTER + DELETE + rebuild below are all inside one
+  // transaction, so on PostgreSQL "column exists" implies "rebuild committed".
+  const columnExists = await client.query(`
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'route_segments'
+        AND column_name = 'sourceId'
+    ) as exists
+  `);
+  if (columnExists.rows[0]?.exists) {
+    logger.info('Migration 030 (PostgreSQL): sourceId already present, skipping rebuild');
+    return;
+  }
+
   logger.info('Running migration 030 (PostgreSQL): Adding sourceId to route_segments and rebuilding from traceroutes...');
 
   await client.query('BEGIN');
@@ -272,9 +312,9 @@ export async function runMigration030Postgres(client: any): Promise<void> {
     `);
 
     const now = Date.now();
-    let inserted = 0;
+    const segments: RebuildSegment[] = [];
     for (const tr of traceroutes as any[]) {
-      const segs = segmentsFromTraceroute(
+      segments.push(...segmentsFromTraceroute(
         Number(tr.fromNodeNum),
         Number(tr.toNodeNum),
         tr.route ?? null,
@@ -282,24 +322,69 @@ export async function runMigration030Postgres(client: any): Promise<void> {
         Number(tr.timestamp),
         tr.sourceId ?? null,
         now,
+      ));
+    }
+
+    const insertOne = async (s: RebuildSegment) => {
+      await client.query(
+        `INSERT INTO route_segments (
+           "fromNodeNum", "toNodeNum", "fromNodeId", "toNodeId", "distanceKm",
+           "isRecordHolder", "fromLatitude", "fromLongitude", "toLatitude", "toLongitude",
+           "timestamp", "createdAt", "sourceId"
+         ) VALUES ($1, $2, $3, $4, $5, false, $6, $7, $8, $9, $10, $11, $12)`,
+        [
+          s.fromNodeNum, s.toNodeNum, s.fromNodeId, s.toNodeId, s.distanceKm,
+          s.fromLatitude, s.fromLongitude, s.toLatitude, s.toLongitude,
+          s.timestamp, s.createdAt, s.sourceId,
+        ],
       );
-      for (const s of segs) {
-        try {
-          await client.query(
-            `INSERT INTO route_segments (
-               "fromNodeNum", "toNodeNum", "fromNodeId", "toNodeId", "distanceKm",
-               "isRecordHolder", "fromLatitude", "fromLongitude", "toLatitude", "toLongitude",
-               "timestamp", "createdAt", "sourceId"
-             ) VALUES ($1, $2, $3, $4, $5, false, $6, $7, $8, $9, $10, $11, $12)`,
-            [
-              s.fromNodeNum, s.toNodeNum, s.fromNodeId, s.toNodeId, s.distanceKm,
-              s.fromLatitude, s.fromLongitude, s.toLatitude, s.toLongitude,
-              s.timestamp, s.createdAt, s.sourceId,
-            ],
-          );
-          inserted++;
-        } catch (err: any) {
-          logger.debug(`Skipped rebuilt segment (FK?): ${err?.message ?? err}`);
+    };
+
+    let inserted = 0;
+    for (const batch of chunk(segments, REBUILD_BATCH_SIZE)) {
+      const values: unknown[] = [];
+      const tuples = batch.map((s, i) => {
+        const b = i * SEGMENT_COLUMNS;
+        values.push(
+          s.fromNodeNum, s.toNodeNum, s.fromNodeId, s.toNodeId, s.distanceKm,
+          false, s.fromLatitude, s.fromLongitude, s.toLatitude, s.toLongitude,
+          s.timestamp, s.createdAt, s.sourceId,
+        );
+        return `($${b + 1}, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5}, $${b + 6}, $${b + 7}, $${b + 8}, $${b + 9}, $${b + 10}, $${b + 11}, $${b + 12}, $${b + 13})`;
+      });
+
+      // PostgreSQL aborts the whole transaction on any statement error, so
+      // each batch runs under a savepoint we can roll back to without losing
+      // the work already committed to the transaction.
+      await client.query('SAVEPOINT batch_sp');
+      try {
+        await client.query(
+          `INSERT INTO route_segments (
+             "fromNodeNum", "toNodeNum", "fromNodeId", "toNodeId", "distanceKm",
+             "isRecordHolder", "fromLatitude", "fromLongitude", "toLatitude", "toLongitude",
+             "timestamp", "createdAt", "sourceId"
+           ) VALUES ${tuples.join(', ')}`,
+          values,
+        );
+        await client.query('RELEASE SAVEPOINT batch_sp');
+        inserted += batch.length;
+      } catch {
+        // A multi-row INSERT fails as a unit, so fall back to per-row inserts
+        // to preserve the original behaviour of skipping individual bad rows
+        // (e.g. FK misses) rather than losing the whole batch.
+        await client.query('ROLLBACK TO SAVEPOINT batch_sp');
+        await client.query('RELEASE SAVEPOINT batch_sp');
+        for (const s of batch) {
+          await client.query('SAVEPOINT row_sp');
+          try {
+            await insertOne(s);
+            await client.query('RELEASE SAVEPOINT row_sp');
+            inserted++;
+          } catch (err: any) {
+            await client.query('ROLLBACK TO SAVEPOINT row_sp');
+            await client.query('RELEASE SAVEPOINT row_sp');
+            logger.debug(`Skipped rebuilt segment (FK?): ${err?.message ?? err}`);
+          }
         }
       }
     }
@@ -317,8 +402,6 @@ export async function runMigration030Postgres(client: any): Promise<void> {
 // ============ MySQL ============
 
 export async function runMigration030Mysql(pool: any): Promise<void> {
-  logger.info('Running migration 030 (MySQL): Adding sourceId to route_segments and rebuilding from traceroutes...');
-
   const conn = await pool.getConnection();
   try {
     // Idempotently add sourceId column.
@@ -326,12 +409,14 @@ export async function runMigration030Mysql(pool: any): Promise<void> {
       `SELECT COLUMN_NAME FROM information_schema.COLUMNS
        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'route_segments' AND COLUMN_NAME = 'sourceId'`
     );
-    if (!Array.isArray(colRows) || colRows.length === 0) {
+    const hadColumn = Array.isArray(colRows) && colRows.length > 0;
+    if (!hadColumn) {
       await conn.query(`ALTER TABLE route_segments ADD COLUMN sourceId VARCHAR(36)`);
       logger.debug('Added sourceId column to route_segments');
     }
 
-    // Index on sourceId.
+    // Index on sourceId. Ensured on both paths — the rebuild may be skipped
+    // below, but the index must exist either way.
     const [idxRows] = await conn.query(
       `SELECT COUNT(*) AS cnt FROM information_schema.STATISTICS
        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'route_segments' AND INDEX_NAME = 'idx_route_segments_source_id'`
@@ -339,6 +424,19 @@ export async function runMigration030Mysql(pool: any): Promise<void> {
     if (!(idxRows as any)[0]?.cnt) {
       await conn.query(`CREATE INDEX idx_route_segments_source_id ON route_segments(sourceId)`);
     }
+
+    // Idempotency guard (#4233) — see the PostgreSQL path. Unlike PostgreSQL,
+    // MySQL implicitly commits DDL, so the ALTER above is not covered by the
+    // rebuild transaction: a crash between the two would leave the column
+    // present with the rebuild not done. The migration ledger is the primary
+    // guard against re-running at all; this check keeps the one-time
+    // post-ledger replay from re-clearing an already-rebuilt table.
+    if (hadColumn) {
+      logger.info('Migration 030 (MySQL): sourceId already present, skipping rebuild');
+      return;
+    }
+
+    logger.info('Running migration 030 (MySQL): Adding sourceId to route_segments and rebuilding from traceroutes...');
 
     await conn.beginTransaction();
     try {
@@ -352,9 +450,9 @@ export async function runMigration030Mysql(pool: any): Promise<void> {
       );
 
       const now = Date.now();
-      let inserted = 0;
+      const segments: RebuildSegment[] = [];
       for (const tr of traceroutes as any[]) {
-        const segs = segmentsFromTraceroute(
+        segments.push(...segmentsFromTraceroute(
           Number(tr.fromNodeNum),
           Number(tr.toNodeNum),
           tr.route ?? null,
@@ -362,24 +460,40 @@ export async function runMigration030Mysql(pool: any): Promise<void> {
           Number(tr.timestamp),
           tr.sourceId ?? null,
           now,
-        );
-        for (const s of segs) {
-          try {
-            await conn.query(
-              `INSERT INTO route_segments (
-                 fromNodeNum, toNodeNum, fromNodeId, toNodeId, distanceKm,
-                 isRecordHolder, fromLatitude, fromLongitude, toLatitude, toLongitude,
-                 timestamp, createdAt, sourceId
-               ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)`,
-              [
-                s.fromNodeNum, s.toNodeNum, s.fromNodeId, s.toNodeId, s.distanceKm,
-                s.fromLatitude, s.fromLongitude, s.toLatitude, s.toLongitude,
-                s.timestamp, s.createdAt, s.sourceId,
-              ],
-            );
-            inserted++;
-          } catch (err: any) {
-            logger.debug(`Skipped rebuilt segment (FK?): ${err?.message ?? err}`);
+        ));
+      }
+
+      const INSERT_PREFIX = `INSERT INTO route_segments (
+        fromNodeNum, toNodeNum, fromNodeId, toNodeId, distanceKm,
+        isRecordHolder, fromLatitude, fromLongitude, toLatitude, toLongitude,
+        timestamp, createdAt, sourceId
+      ) VALUES `;
+      const ROW_TUPLE = '(?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)';
+      const rowValues = (s: RebuildSegment) => [
+        s.fromNodeNum, s.toNodeNum, s.fromNodeId, s.toNodeId, s.distanceKm,
+        s.fromLatitude, s.fromLongitude, s.toLatitude, s.toLongitude,
+        s.timestamp, s.createdAt, s.sourceId,
+      ];
+
+      let inserted = 0;
+      for (const batch of chunk(segments, REBUILD_BATCH_SIZE)) {
+        try {
+          await conn.query(
+            INSERT_PREFIX + batch.map(() => ROW_TUPLE).join(', '),
+            batch.flatMap(rowValues),
+          );
+          inserted += batch.length;
+        } catch {
+          // A multi-row INSERT fails as a unit, so fall back to per-row
+          // inserts to preserve the original behaviour of skipping individual
+          // bad rows (e.g. FK misses) rather than losing the whole batch.
+          for (const s of batch) {
+            try {
+              await conn.query(INSERT_PREFIX + ROW_TUPLE, rowValues(s));
+              inserted++;
+            } catch (err: any) {
+              logger.debug(`Skipped rebuilt segment (FK?): ${err?.message ?? err}`);
+            }
           }
         }
       }

--- a/src/server/migrations/030_route_segments_rebuild.pgmysql.test.ts
+++ b/src/server/migrations/030_route_segments_rebuild.pgmysql.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Migration 030 — PostgreSQL / MySQL rebuild behaviour (#4233)
+ *
+ * The PG/MySQL paths of this migration used to unconditionally
+ * `DELETE FROM route_segments` and then re-INSERT every rebuilt segment one
+ * round-trip at a time. Because PG/MySQL had no migration ledger, that ran on
+ * *every* boot — on a production instance it cleared 865,865 rows and rebuilt
+ * them one INSERT at a time on each restart, blocking startup for minutes and
+ * locking autovacuum out of the table.
+ *
+ * These tests pin both halves of the fix:
+ *   1. the migration skips the destructive rebuild when sourceId already exists
+ *   2. the rebuild batches its inserts instead of one round-trip per row
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runMigration030Postgres,
+  runMigration030Mysql,
+} from './030_add_source_id_to_route_segments.js';
+
+/**
+ * Traceroutes that each rebuild into exactly 2 segments.
+ *
+ * `routePositions` is a map keyed by nodeNum with `lat`/`lng`, and the rebuilt
+ * path is `[toNodeNum, ...route, fromNodeNum]` — so one intermediate hop with
+ * positions for all three nodes yields 2 segments.
+ */
+function tracerouteRows(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    fromNodeNum: 100 + i,
+    toNodeNum: 200 + i,
+    route: JSON.stringify([150 + i]),
+    routePositions: JSON.stringify({
+      [100 + i]: { lat: 30.0, lng: -95.0 },
+      [150 + i]: { lat: 30.5, lng: -95.5 },
+      [200 + i]: { lat: 31.0, lng: -96.0 },
+    }),
+    timestamp: 1_700_000_000_000 + i,
+    sourceId: 'src-1',
+  }));
+}
+
+function fakePgClient(opts: { columnExists: boolean; traceroutes?: any[] }) {
+  const queries: { sql: string; params?: any[] }[] = [];
+  return {
+    queries,
+    query: vi.fn(async (sql: string, params?: any[]) => {
+      queries.push({ sql, params });
+      if (sql.includes('information_schema.columns')) {
+        return { rows: [{ exists: opts.columnExists }] };
+      }
+      if (sql.includes('FROM traceroutes')) {
+        return { rows: opts.traceroutes ?? [] };
+      }
+      if (sql.trimStart().startsWith('DELETE')) {
+        return { rows: [], rowCount: 865 };
+      }
+      return { rows: [], rowCount: 0 };
+    }),
+  };
+}
+
+function fakeMysqlPool(opts: { columnExists: boolean; traceroutes?: any[] }) {
+  const queries: { sql: string; params?: any[] }[] = [];
+  const conn = {
+    query: vi.fn(async (sql: string, params?: any[]) => {
+      queries.push({ sql, params });
+      if (sql.includes('information_schema.COLUMNS')) {
+        return [opts.columnExists ? [{ COLUMN_NAME: 'sourceId' }] : []];
+      }
+      if (sql.includes('information_schema.STATISTICS')) {
+        return [[{ cnt: 1 }]];
+      }
+      if (sql.includes('FROM traceroutes')) {
+        return [opts.traceroutes ?? []];
+      }
+      if (sql.trimStart().startsWith('DELETE')) {
+        return [{ affectedRows: 865 }];
+      }
+      return [{}];
+    }),
+    beginTransaction: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+    release: vi.fn(),
+  };
+  return { queries, conn, getConnection: async () => conn };
+}
+
+const isDelete = (q: { sql: string }) => q.sql.trimStart().startsWith('DELETE');
+const isInsert = (q: { sql: string }) => q.sql.trimStart().startsWith('INSERT');
+
+// PostgreSQL binds isRecordHolder as a parameter; MySQL hardcodes it as `0`
+// in the tuple, so its rows carry one fewer bind parameter.
+const PG_PARAMS_PER_ROW = 13;
+const MYSQL_PARAMS_PER_ROW = 12;
+
+describe('migration 030 — PostgreSQL', () => {
+  it('skips the destructive rebuild when sourceId already exists', async () => {
+    const client = fakePgClient({ columnExists: true, traceroutes: tracerouteRows(5) });
+
+    await runMigration030Postgres(client);
+
+    // The whole point: no DELETE, no rebuild, no transaction.
+    expect(client.queries.filter(isDelete)).toHaveLength(0);
+    expect(client.queries.filter(isInsert)).toHaveLength(0);
+    expect(client.queries.some(q => q.sql.includes('BEGIN'))).toBe(false);
+  });
+
+  it('rebuilds when sourceId is missing', async () => {
+    const client = fakePgClient({ columnExists: false, traceroutes: tracerouteRows(2) });
+
+    await runMigration030Postgres(client);
+
+    expect(client.queries.filter(isDelete)).toHaveLength(1);
+    expect(client.queries.filter(isInsert).length).toBeGreaterThan(0);
+    expect(client.queries.some(q => q.sql.includes('COMMIT'))).toBe(true);
+  });
+
+  it('batches inserts instead of one round-trip per segment', async () => {
+    // 200 traceroutes × 2 segments each = 400 segments, one batch of 500.
+    const client = fakePgClient({ columnExists: false, traceroutes: tracerouteRows(200) });
+
+    await runMigration030Postgres(client);
+
+    const inserts = client.queries.filter(isInsert);
+    expect(inserts).toHaveLength(1);
+    // A single multi-row INSERT carrying every segment's parameters.
+    expect(inserts[0].params!.length).toBe(400 * PG_PARAMS_PER_ROW);
+    expect(inserts[0].sql).toContain('$5200');
+  });
+
+  it('splits into multiple batches beyond the batch size', async () => {
+    // 400 traceroutes × 2 segments = 800 segments → 2 batches (500 + 300).
+    const client = fakePgClient({ columnExists: false, traceroutes: tracerouteRows(400) });
+
+    await runMigration030Postgres(client);
+
+    const inserts = client.queries.filter(isInsert);
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0].params!.length).toBe(500 * PG_PARAMS_PER_ROW);
+    expect(inserts[1].params!.length).toBe(300 * PG_PARAMS_PER_ROW);
+  });
+
+  it('falls back to per-row inserts when a batch fails, skipping only bad rows', async () => {
+    const client = fakePgClient({ columnExists: false, traceroutes: tracerouteRows(3) });
+    const realQuery = client.query;
+    let seenBatch = false;
+
+    client.query = vi.fn(async (sql: string, params?: any[]) => {
+      if (sql.trimStart().startsWith('INSERT') && !seenBatch) {
+        seenBatch = true;
+        client.queries.push({ sql, params });
+        throw new Error('duplicate key');
+      }
+      // One individual row also fails — it must be skipped, not fatal.
+      if (sql.trimStart().startsWith('INSERT') && params?.[0] === 200) {
+        client.queries.push({ sql, params });
+        throw new Error('foreign key violation');
+      }
+      return realQuery(sql, params);
+    }) as any;
+
+    await expect(runMigration030Postgres(client)).resolves.toBeUndefined();
+
+    // Recovered via savepoint and retried row-by-row.
+    expect(client.queries.some(q => q.sql.includes('ROLLBACK TO SAVEPOINT batch_sp'))).toBe(true);
+    expect(client.queries.some(q => q.sql.includes('SAVEPOINT row_sp'))).toBe(true);
+    expect(client.queries.some(q => q.sql.includes('COMMIT'))).toBe(true);
+  });
+});
+
+describe('migration 030 — MySQL', () => {
+  it('skips the destructive rebuild when sourceId already exists', async () => {
+    const pool = fakeMysqlPool({ columnExists: true, traceroutes: tracerouteRows(5) });
+
+    await runMigration030Mysql(pool);
+
+    expect(pool.queries.filter(isDelete)).toHaveLength(0);
+    expect(pool.queries.filter(isInsert)).toHaveLength(0);
+    expect(pool.conn.beginTransaction).not.toHaveBeenCalled();
+    expect(pool.conn.release).toHaveBeenCalled();
+  });
+
+  it('still ensures the sourceId index on the skip path', async () => {
+    const pool = fakeMysqlPool({ columnExists: true });
+
+    await runMigration030Mysql(pool);
+
+    expect(pool.queries.some(q => q.sql.includes('information_schema.STATISTICS'))).toBe(true);
+  });
+
+  it('rebuilds with batched inserts when sourceId is missing', async () => {
+    const pool = fakeMysqlPool({ columnExists: false, traceroutes: tracerouteRows(200) });
+
+    await runMigration030Mysql(pool);
+
+    expect(pool.queries.filter(isDelete)).toHaveLength(1);
+    const inserts = pool.queries.filter(isInsert);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].params!.length).toBe(400 * MYSQL_PARAMS_PER_ROW);
+    expect(pool.conn.commit).toHaveBeenCalled();
+  });
+
+  it('falls back to per-row inserts when a batch fails', async () => {
+    const pool = fakeMysqlPool({ columnExists: false, traceroutes: tracerouteRows(3) });
+    const realQuery = pool.conn.query;
+    let seenBatch = false;
+
+    pool.conn.query = vi.fn(async (sql: string, params?: any[]) => {
+      if (sql.trimStart().startsWith('INSERT') && !seenBatch) {
+        seenBatch = true;
+        pool.queries.push({ sql, params });
+        throw new Error('duplicate key');
+      }
+      return realQuery(sql, params);
+    }) as any;
+
+    await expect(runMigration030Mysql(pool)).resolves.toBeUndefined();
+
+    // 6 segments retried individually after the batch failed.
+    const rowInserts = pool.queries.filter(
+      q => isInsert(q) && q.params?.length === MYSQL_PARAMS_PER_ROW,
+    );
+    expect(rowInserts).toHaveLength(6);
+    expect(pool.conn.commit).toHaveBeenCalled();
+  });
+});

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8,6 +8,13 @@ import { logger } from '../utils/logger.js';
 import { getEnvironmentConfig } from '../server/config/environment.js';
 
 import { registry } from '../db/migrations.js';
+import {
+  readAppliedMigrationsPostgres,
+  markMigrationAppliedPostgres,
+  readAppliedMigrationsMysql,
+  markMigrationAppliedMysql,
+  runLedgeredMigrations,
+} from '../db/migrationLedger.js';
 import { validateThemeDefinition as validateTheme } from '../utils/themeValidation.js';
 import { isSourceyResource } from '../types/permission.js';
 import { computeAveragingIntervalMinutes } from '../utils/telemetryAveraging.js';
@@ -4121,12 +4128,18 @@ class DatabaseService {
         throw new Error('Database is pre-v3.7. Please upgrade to v3.7 first.');
       }
 
-      // Run ALL migrations from the registry — 001 baseline creates all tables
-      for (const migration of registry.getAll()) {
-        if (migration.postgres) {
-          await migration.postgres(client);
-        }
-      }
+      // Run migrations from the registry — 001 baseline creates all tables.
+      // Migrations 002+ are guarded by the ledger so they run exactly once
+      // (#4233); 001 has no settingsKey and always runs (it is the
+      // CREATE TABLE IF NOT EXISTS baseline that creates `settings` itself).
+      await runLedgeredMigrations({
+        backend: 'PostgreSQL',
+        handle: client,
+        migrations: registry.getAll(),
+        pick: m => m.postgres,
+        readApplied: readAppliedMigrationsPostgres,
+        markApplied: markMigrationAppliedPostgres,
+      });
 
       logger.info('[PostgreSQL] Schema initialization complete');
     } finally {
@@ -4161,12 +4174,17 @@ class DatabaseService {
       connection.release();
     }
 
-    // Run ALL migrations from the registry — 001 baseline creates all tables
-    for (const migration of registry.getAll()) {
-      if (migration.mysql) {
-        await migration.mysql(pool);
-      }
-    }
+    // Run migrations from the registry — 001 baseline creates all tables.
+    // Migrations 002+ are guarded by the ledger so they run exactly once
+    // (#4233); 001 has no settingsKey and always runs.
+    await runLedgeredMigrations({
+      backend: 'MySQL',
+      handle: pool,
+      migrations: registry.getAll(),
+      pick: m => m.mysql,
+      readApplied: readAppliedMigrationsMysql,
+      markApplied: markMigrationAppliedMysql,
+    });
 
     logger.info('[MySQL] Schema initialization complete');
   }


### PR DESCRIPTION
Fixes #4233

## Problem

PostgreSQL and MySQL re-ran **every registered migration on every boot**. The `settingsKey` idempotency guard was SQLite-only — `MigrationEntry.settingsKey` was documented as *"Settings key for SQLite idempotency tracking"*, and the PG/MySQL loops iterated the whole registry unconditionally:

```js
for (const migration of registry.getAll()) {
  if (migration.postgres) {
    await migration.postgres(client);   // no guard, ever
  }
}
```

That worked only as long as every PG/MySQL migration was internally idempotent. Migration 030 was not — it unconditionally cleared `route_segments` and rebuilt it from traceroutes with one INSERT round-trip per segment.

On a production instance that meant clearing **865,865 rows and re-inserting them one at a time on every restart**: startup blocked for minutes, the long transaction locked autovacuum out of the table (`LOG: skipping vacuum of "route_segments" --- lock not available`), and boot-timer schedulers logged spurious `Database not initialized` errors while they waited. It scaled steadily worse as traceroute history grew, eventually looking like a failed startup.

## Changes

**1. A real migration ledger for PG/MySQL** — new `src/db/migrationLedger.ts`.

Keyed off the same `settingsKey` values SQLite already uses and stored in the same `settings` table (identical shape on all three backends), so the mechanism is now uniform and a SQLite → PostgreSQL restore carries its migration history with it. `runLedgeredMigrations` holds the guard logic once and both call sites delegate to it, replacing the two duplicated loops.

- Migration 001 — the baseline that *creates* the `settings` table the ledger lives in — has no `settingsKey` and always runs. This mirrors SQLite, where `migrations.test.ts` already asserts 001 has no key and 002+ all do.
- A migration is recorded only *after* it resolves, so a crash in between retries on the next boot.

**2. Migration 030 no longer rebuilds unconditionally.**

- Skips the destructive rebuild when `sourceId` already exists.
- Batches inserts at 500 rows/statement instead of one round-trip per row, with a per-row fallback on batch failure so individual bad rows (FK misses) are still skipped rather than losing the whole batch. On PostgreSQL the fallback recovers through savepoints, since PG aborts the transaction on any statement error.

## Upgrade behaviour

Existing PG/MySQL installs have an empty ledger, so **every migration replays once more on the first boot after this lands**, and is then recorded and never replays again. There is deliberately no backfill — there is no way to know which migrations actually ran against a given pre-existing database, so they are re-run (they are expected to be idempotent) rather than assumed done. Change (2) is what makes that final replay cheap: 030 now sees `sourceId` already present and skips.

## Testing

- `src/db/migrationLedger.test.ts` — 13 tests: ledger read/upsert on both backends, missing-`settings`-table case, skip-when-recorded, record-after-run, baseline-always-runs, no-record-on-throw, and the one-time empty-ledger replay.
- `src/server/migrations/030_route_segments_rebuild.pgmysql.test.ts` — 9 tests: skip guard issues no DELETE/INSERT/transaction, rebuild path batches into single/multiple statements, per-row fallback on batch failure, and the MySQL skip path still ensures the index.
- Full suite green: 3,164 suites, 0 failed; 9,764 passed, 0 failed.
- `npm run lint:ci` passes (no baseline growth); `tsc --noEmit` clean.

Also updated the now-stale `settingsKey` doc comment on `MigrationEntry` and the migration recipe in `CLAUDE.md`, which no longer reflected that PG/MySQL track idempotency at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW