### PR TITLE
fix(ui): repair text spacing left behind by the icon migration (#4217 follow-up)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1800,7 +1800,7 @@
   "dashboard.telemetry_help.step1": "Click a node on the map",
   "dashboard.telemetry_help.step2": "Click More Info at the bottom",
   "dashboard.telemetry_help.step3": "Scroll down to Telemetry Data",
-  "dashboard.telemetry_help.step4": "Click the  star icon next to the metric you want to pin to the dashboard",
+  "dashboard.telemetry_help.step4": "Click the star icon next to the metric you want to pin to the dashboard",
   "dashboard.telemetry_help.back": "Back",
   "dashboard.show_solar": "Show solar overlay",
   "dashboard.hide_solar": "Hide solar overlay",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -4240,7 +4240,7 @@
     "dashboard.telemetry_help.step1": "Cliquez sur un nœud sur la carte",
     "dashboard.telemetry_help.step2": "Cliquez sur Plus d’infos en bas",
     "dashboard.telemetry_help.step3": "Faites défiler jusqu’aux données de télémétrie",
-    "dashboard.telemetry_help.step4": "Cliquez sur l’icône  à côté de la métrique que vous voulez épingler au tableau de bord",
+    "dashboard.telemetry_help.step4": "Cliquez sur l’icône à côté de la métrique que vous voulez épingler au tableau de bord",
     "dashboard.telemetry_help.back": "Retour",
     "info.total_packets": "Total : {{count}} paquets",
     "info.hw_model_distribution": "Modèles matériels",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -1727,7 +1727,7 @@
     "dashboard.telemetry_help.step1": "Kliknij węzeł na mapie",
     "dashboard.telemetry_help.step2": "Kliknij Więcej informacji u dołu",
     "dashboard.telemetry_help.step3": "Przewiń do sekcji Dane telemetryczne",
-    "dashboard.telemetry_help.step4": "Kliknij ikonę gwiazdki  obok metryki, którą chcesz przypiąć do panelu głównego",
+    "dashboard.telemetry_help.step4": "Kliknij ikonę gwiazdki obok metryki, którą chcesz przypiąć do panelu głównego",
     "dashboard.telemetry_help.back": "Wstecz",
     "dashboard.show_solar": "Pokaż nakładkę solarną",
     "dashboard.hide_solar": "Ukryj nakładkę solarną",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -4225,7 +4225,7 @@
     "dashboard.telemetry_help.step1": "Нажмите на узел на карте",
     "dashboard.telemetry_help.step2": "Нажмите «Подробнее» внизу",
     "dashboard.telemetry_help.step3": "Прокрутите вниз до раздела «Данные телеметрии»",
-    "dashboard.telemetry_help.step4": "Нажмите на значок звезды  рядом с метрикой, которую вы хотите закрепить на дашборде",
+    "dashboard.telemetry_help.step4": "Нажмите на значок звезды рядом с метрикой, которую вы хотите закрепить на дашборде",
     "users.connection_view_status": "Посмотреть статус",
     "users.connection_control_device": "Управлять устройством",
     "admin_commands.router_mode_warning_title": "Режим роутера",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -4232,7 +4232,7 @@
     "dashboard.telemetry_help.step1": "点击地图上的一个节点",
     "dashboard.telemetry_help.step2": "点击底部的“更多信息”",
     "dashboard.telemetry_help.step3": "向下滚动到“遥测数据”部分",
-    "dashboard.telemetry_help.step4": "点击您想要固定到仪表盘的指标旁边的  星标图标",
+    "dashboard.telemetry_help.step4": "点击您想要固定到仪表盘的指标旁边的星标图标",
     "dashboard.telemetry_help.back": "返回",
     "info.hw_model_distribution": "硬件型号分布",
     "info.hw_model_breakdown": "各硬件型号的节点数",

--- a/src/components/map/popups/sections.tsx
+++ b/src/components/map/popups/sections.tsx
@@ -265,7 +265,7 @@ export const SourcesList: React.FC<SourcesListProps> = ({ sources, nodeId, onSou
             className="node-popup-source-row node-popup-source-row-button"
             disabled={!clickable}
             onClick={clickable ? () => onSourceSelect!(s, nodeId) : undefined}
-            title={clickable ? `Open ${s.sourceName} Node Details` : undefined}
+            title={clickable ? `Open Node Details for ${s.sourceName}` : undefined}
           >
             <span className={`node-popup-protocol-badge protocol-${s.protocol.toLowerCase()}`}>
               {s.protocol}


### PR DESCRIPTION
Follow-up to #4217, which stripped decorative glyphs from translated strings and from one tooltip but did not collapse the whitespace or restore the separators around them.

## Changes

**Locale double-spaces** — `dashboard.telemetry_help.step4` read `"Click the  star icon…"` in `en`, `fr`, `pl`, `ru`, `zh_Hans` after the ⭐ was removed. Collapsed to a single space. `zh_Hans` collapses to *no* space, since Chinese does not space between words.

**Tooltip separator** — `src/components/map/popups/sections.tsx` lost its `→`, leaving the run-on `Open <source> Node Details`. Rephrased to `Open Node Details for <source>`.

I chose rephrasing over restoring the arrow deliberately: `no-hardcoded-ui-glyph` evaluates each template-literal quasi separately, so in `` `Open ${s.sourceName} → Node Details` `` the second quasi is `" → Node Details"` and matches `LEADING_UI_SYMBOL_PATTERN` (`/^\s*[…→…]/`). The arrow is mid-sentence in the rendered string, so this trips the rule contrary to its own comment ("Mid-sentence arrows describe direction/relationships; a leading arrow is an icon"). Rephrasing avoids both the awkward string and an `eslint-disable` for a cosmetic tooltip. **The quasi-boundary false positive itself is left unfixed** — see below.

## Not addressed here

Two items from the #4217 review remain open, both worth a separate issue:

1. `no-hardcoded-ui-glyph`'s character class omits `●○◐⊘`, so four functional status indicators were missed by the migration and can be reintroduced with green CI: `MeshCoreRoomsView.tsx:239` (three-state login dot), `LiveTracePanel.tsx:135`, `RadioConfigurationSection.tsx:503-504`, `ChannelsConfigSection.tsx:548`.
2. The quasi-boundary false positive described above.

## Validation

- `npx eslint src/components/map/popups/sections.tsx` — clean
- `node scripts/check-ui-locale-glyphs.mjs` — passed
- All 5 edited locale files parse as valid JSON; key sets unchanged
- `vitest run src/components/map/popups` — 115 passed, `success: true`

`npm run lint:ci` fails locally, but every failing path is under `.claude/worktrees/` (stale local agent worktrees, git-excluded). Zero non-worktree ratchet violations.

No behavior change; no locale keys added, renamed, or dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW