### PR TITLE
feat(map-analysis): 3D terrain view + DEM tile proxy (#3826 Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ MeshMonitor supports multiple deployment methods:
 - **Modern UI** - Catppuccin theme with message reactions and threading
 - **Interactive Maps** - Unified node positions and network topology visualization across all sources
 - **Terrain Link Profile** - Two-point terrain elevation, line-of-sight, and Fresnel-zone link-budget planning tool in Map Analysis, with per-source frequency/RX-sensitivity auto-detection and a configurable DEM source
+- **3D Terrain View** - Pitched-terrain MapLibre GL view in Map Analysis with DEM/hillshade rendering, adjustable exaggeration, and clickable node markers, available when a tile-based elevation source is configured
 - **Multi-Database Support** - SQLite (default), PostgreSQL, and MySQL via Drizzle ORM
 - **Notifications** - Web Push and Apprise integration for 100+ services, with inactive-node and low-battery alerts
 - **Automation** - Autoresponders, scheduled announcements, timers, and geofence triggers with rich message templates, plus an airtime-utilization cutoff that automatically pauses bot traffic when the mesh is busy

--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -607,6 +607,53 @@ Probes a candidate DEM source URL and reports what it found. Requires `settings:
 
 A failing probe still returns HTTP 200 — the probe outcome (`data.success: false` plus `data.error`) is the payload, not a request error.
 
+### Get 3D Terrain Capabilities
+
+#### GET /api/elevation/capabilities
+
+Reports whether the [Map Analysis 3D terrain view](../features/map-analysis.md#3d-terrain-view) can be offered, without exposing the configured `elevationSourceUrl` (a secret setting). Public (no authentication), no outbound network calls — derived from settings already loaded server-side.
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "enabled": true,
+    "terrainTiles": true,
+    "provider": "terrarium"
+  }
+}
+```
+
+- `enabled` — mirrors the admin's **Enable terrain elevation** setting.
+- `provider` — `"terrarium"` or `"json"`, auto-detected from the configured (or default) elevation source URL, same detection used by `POST /test`.
+- `terrainTiles` — `true` only when `enabled` **and** `provider === "terrarium"`. A JSON point-API source can power the 2D Link Profile but has no tiles to build a 3D surface from, so `terrainTiles` is `false` in that case even though `enabled` is `true`.
+
+### Get Terrain Tile
+
+#### GET /api/elevation/tiles/{z}/{x}/{y}
+
+Proxies a single Terrarium-encoded DEM tile from the configured (or default) elevation source, for MapLibre GL's `raster-dem` terrain source in the 3D view. Public (no authentication), rate-limited to **600 requests/minute per IP** in production (private/internal IPs exempt) — a single 3D view load legitimately fetches dozens of tiles.
+
+Returns raw `image/png` bytes on success (**not** the `{success, data}` envelope) with:
+```
+Content-Type: image/png
+Cache-Control: public, max-age=604800, immutable
+```
+
+**Example:**
+```bash
+curl http://localhost:8080/api/elevation/tiles/10/163/395 --output tile.png
+```
+
+**Errors** (JSON envelope, `Cache-Control: no-store`):
+- `403 ELEVATION_DISABLED` — the admin has disabled elevation.
+- `409 TERRAIN_TILES_UNAVAILABLE` — the configured elevation source is a JSON point API, which has no tiles to serve. There is no fallback to the public Terrarium source in this case.
+- `400 INVALID_TILE_COORDS` — `z`, `x`, or `y` isn't a valid integer, or `x`/`y` falls outside `[0, 2^z − 1]` for the given zoom (zoom is capped at 15, the source's native maximum).
+- `502 TILE_FETCH_FAILED` — the upstream tile fetch failed (network error, non-OK response, or the SSRF guard blocked the request).
+
+The resolved source URL (and any embedded API key) is never included in a response or error message.
+
 ---
 
 ## Statistics

--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -45,6 +45,7 @@ The toolbar runs across the top of the canvas. From left to right:
 | **Time slider toggle** | Show/hide the floating time-window slider. |
 | **Measure** | Straight-line distance between two positioned nodes. Disabled until at least two positioned nodes exist; mutually exclusive with Link Profile. |
 | **Link Profile** | Terrain, Fresnel clearance, and link-budget verdict between two points. See [Terrain Link Profile](#terrain-link-profile). Only shown when the server has elevation enabled. |
+| **3D** (box icon) | Toggle between the flat 2D map and a pitched-terrain 3D view. See [3D terrain view](#3d-terrain-view). Disabled with a tooltip when elevation is off or the configured elevation source can't serve DEM tiles. |
 | **Layer buttons (×8)** | Toggle each visualization layer on/off. The right-edge chevron opens a popover for layer-specific options (lookback window, sub-options). |
 | **Progress bar** | Shows aggregate loading state while any layer is fetching. |
 | **Inspector toggle** | Show/hide the right-side detail panel. |
@@ -243,6 +244,41 @@ For a node seen by several sources (say, a Meshtastic radio *and* an MQTT bridge
 ### Limitations
 
 The terrain data (SRTM-derived, roughly 90 m per pixel) is a bare-earth elevation model — it does **not** account for buildings, trees, or other vegetation, so a "Clear" verdict is a first-pass estimate of geometric line-of-sight, not a guarantee of a working RF link. Node GPS altitude is not factored into antenna height; only the DEM terrain height plus your entered AGL value is used.
+
+## 3D terrain view
+
+::: tip New in 4.14
+:::
+
+The toolbar's **3D** button (box icon) switches the canvas from the flat Leaflet map to a pitched-terrain [MapLibre GL](https://maplibre.org/) view — the current basemap draped over a real elevation surface with hillshading, so you can tilt and rotate to see how terrain actually sits between nodes.
+
+### Requirements
+
+The button is disabled with an explanatory tooltip unless all of the following hold:
+
+- **Elevation is enabled** on the server (**Settings → Elevation / Terrain**). If it isn't, the tooltip reads *"Elevation is disabled."*
+- **The configured elevation source serves DEM tiles.** 3D terrain needs a Terrarium-encoded tile source (the default public AWS/Mapzen source, or a custom tile-template URL). If the admin has instead configured an Open-Topo-Data-style **JSON point API** — which the 2D [Terrain Link Profile](#terrain-link-profile) tool can still use — there's no tile source to build a 3D surface from, and the tooltip reads *"3D terrain is unavailable with the configured elevation source."* There is deliberately no fallback to the public terrarium tiles in this case: an admin who configured a JSON source did so on purpose (often for an air-gapped or cost-controlled deployment), and silently routing 3D traffic elsewhere would leak requests to a provider they explicitly opted away from.
+- **Your browser supports WebGL.** If it doesn't, the 3D map degrades to a plain-language message and the view automatically switches back to 2D rather than showing a blank canvas.
+
+### Using the 3D view
+
+- **Navigate** with the built-in MapLibre control: drag to pan, scroll/pinch to zoom, right-drag (or two-finger drag) to pitch and rotate. A compass resets bearing to north.
+- **Terrain exaggeration** — a slider (0–2×, default **1.3×**) vertically stretches the DEM so subtle elevation changes read more clearly. It's a per-session view setting, not persisted between visits.
+- **Node markers** render with short-name labels at their real position, draped onto the terrain surface. Click a marker to select it — the same inspector panel used in 2D opens with that node's details.
+- **Basemap** — the 3D view reuses whichever raster tileset you have selected for the 2D map. If your selected tileset is **vector-only**, 3D can't drape a vector style over terrain yet, so it substitutes the default OpenStreetMap raster basemap and shows a small note; your 2D tileset selection is unaffected.
+
+The **2D/3D toggle state persists per-browser** alongside the rest of your Map Analysis toolbar configuration.
+
+### What's not in 3D yet
+
+The 3D view is a foundation, not full layer parity. Not yet available while in 3D mode (all still work normally after switching back to 2D):
+
+- Neighbor links and traceroute paths
+- Coverage heatmap, position trails, range rings, hop shading, and the SNR overlay
+- The time slider
+- Launching the Terrain Link Profile tool directly from the 3D canvas
+
+These are planned for a follow-up phase of the 3D map work.
 
 ## Time slider
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -470,6 +470,10 @@ Description: Offline OpenStreetMap tiles via TileServer GL
 - Implausible DEM samples (below −500 m or above 9000 m — an artifact of open-water/void pixels in some tile sets, not real terrain) are discarded server-side and shown as gaps in the Link Profile chart rather than distorting it.
 - The `POST /api/elevation/profile` endpoint used by the tool is public (unauthenticated) but rate-limited to 20 requests/minute per IP in production (requests from private/internal IPs are exempt); the Test button's endpoint requires `settings:write`.
 
+::: tip Also powers the 3D terrain view (New in 4.14)
+This same elevation source drives Map Analysis's [3D terrain view](/features/map-analysis#3d-terrain-view). A **tile-template** URL (the default Terrarium source, or a custom one) works for both the 2D Link Profile chart and the 3D pitched-terrain map. A **JSON point API** source only supports the 2D Link Profile — there are no tiles to build a 3D surface from, so the 3D toggle stays disabled with an explanatory tooltip for that configuration (no fallback to the default tile source is attempted).
+:::
+
 ## Display Preferences
 
 ### Default Landing Page {#default-landing-page}

--- a/docs/internal/dev-notes/3D_MAP_FOUNDATION_SPEC.md
+++ b/docs/internal/dev-notes/3D_MAP_FOUNDATION_SPEC.md
@@ -1,0 +1,611 @@
+# 3D Map Foundation — Implementation Spec (3D Map & Elevation Epic #3826, Phase 2)
+
+Branch: `feature/3826-3d-map-foundation` (worktree `meshmonitor-3826-p2`, based on
+`origin/main` which already contains Phase 1).
+
+This spec covers Phase 2 only: the **DEM tile proxy** (backend) and the **3D map
+foundation** (frontend MapLibre GL component + a 2D/3D toggle on Map Analysis
+rendering node markers). It binds to the epic interview decisions (2026-07-20):
+server proxy for DEM tiles, 3D only on Map Analysis, indoor/venue tilesets out of
+scope. Phase 3 (neighbor links / traceroutes in 3D, full inspector parity,
+settings surface, docs) is explicitly out of scope here and is noted where the
+seam falls.
+
+**Do not** implement from memory — every reused symbol is cited with a path
+below. Read the cited file before extending it.
+
+---
+
+## 0. Binding constraints (from CLAUDE.md — re-read before coding)
+
+- **Response envelope.** JSON handlers use `ok(res, data)` → `{success:true,data}`
+  and `fail(res, status, code, message, extra?)` → `{success:false,error,code,...}`
+  (`src/server/utils/apiResponse.ts`). The **binary tile handler returns raw
+  `image/png` bytes** (no envelope); only its error paths use `fail()`.
+- **The ApiService unwrap gotcha.** `ApiService.request()` returns the raw JSON
+  body and does **not** unwrap `data`. So any *new* frontend consumer of an
+  `ok(res, x)` handler must read `body.data`. (Contrast: `useElevationEnabled`
+  reads `GET /api/settings`, which returns a **bare** map, not an envelope — do
+  not copy that shape for the new capabilities endpoint, which *is* enveloped.)
+- **No raw SQL outside repositories.** No DB schema work in this phase (settings
+  are key/value rows; both elevation keys already exist — see §1).
+- **Route tests MUST use `createRouteTestApp()`** (`src/server/test-helpers/routeTestApp.ts`);
+  mock only `safeFetch`, never the DB.
+- **Lint ratchet.** `npm run lint:ci` must exit 0. TS strict, no `any`, no raw
+  `fetch()` in `src/components/**` or `src/pages/**` (MapLibre fetching tile URLs
+  internally is fine and expected — the ban is on *app* code), `react-hooks/exhaustive-deps`
+  clean for all new code.
+- **No new settings keys.** `elevationEnabled` and `elevationSourceUrl` already
+  exist in `VALID_SETTINGS_KEYS` (settings.ts L297–298) and
+  `SECRET_SETTINGS_KEYS` (L526). Terrain exaggeration is client-local state; the
+  2D/3D toggle persists in the existing `mapAnalysis.config.v1` localStorage blob
+  (a client config, not a server settings key).
+
+---
+
+## 1. Reuse inventory (use / extend these — do not reinvent)
+
+### Backend
+
+| Concern | Reuse | Path |
+|---|---|---|
+| Terrarium URL template + SSRF-guarded fetch | `TerrariumTileProvider` (URL `{z}/{x}/{y}` substitution, `safeFetch`, `SsrfBlockedError` catch, degrade-to-null resilience) | `src/server/services/elevationProvider.ts` |
+| Provider-type detection | `detectProviderType(url)` → `'terrarium' \| 'json'`; `resolveProvider(sourceUrl)`; `DEFAULT_TERRARIUM_URL` | `src/server/services/elevationProvider.ts` |
+| SSRF guard | `safeFetch`, `SsrfBlockedError` (reuse verbatim — do **not** pass `strict:true`; custom sources may be a LAN tileserver) | `src/server/utils/ssrfGuard.ts` |
+| Generic LRU | `LruCache<K,V>` | `src/server/utils/lruCache.ts` |
+| Route orchestration seam | `computeProfile`, `testSource` live in a service, routes stay thin | `src/server/services/elevationService.ts` |
+| Gating pattern (elevationEnabled → 403, optionalAuth, limiter, settings read) | `POST /profile` in the existing router | `src/server/routes/elevationRoutes.ts` |
+| Rate-limiter factory | `rateLimit(...)` + shared `rateLimitConfig` + `env.isProduction` split (model on `meshcoreDeviceLimiter`; `elevationLimiter` already exists but is 20/min — wrong for tiles) | `src/server/middleware/rateLimiters.ts` |
+| Envelope helpers | `ok`, `fail` | `src/server/utils/apiResponse.ts` |
+| Settings read | `databaseService.settings.getAllSettings()` / `getSetting(key)` | `src/services/database.js` |
+| Route mount point | `apiRouter.use('/elevation', elevationRoutes)` already mounted in server.ts | `src/server/server.ts` |
+| CSP (already permits what MapLibre needs) | `worker-src 'self' blob:`, built-in raster tile hosts in `connect-src`, custom tile hosts added dynamically | `src/server/middleware/dynamicCsp.ts` |
+
+**Why the tile route belongs in `elevationRoutes.ts`, not a new router:** it shares
+the *exact* gating primitives (`elevationEnabled` flag, `optionalAuth`, a
+per-domain limiter, the `elevationSourceUrl` settings read) and the same
+`elevationService`/`elevationProvider` stack. A new router would duplicate the
+mount, the gating, and the settings plumbing for one more path under the same
+`/api/elevation` prefix. Add the two new routes to the existing router.
+
+### Frontend
+
+| Concern | Reuse | Path |
+|---|---|---|
+| Availability flag | `useElevationEnabled()` (TanStack, reads bare `/api/settings`) | `src/hooks/useElevationEnabled.ts` |
+| Shared positioned+visible node list (the data the 3D markers consume) | `useAnalysisNodes()` → `AnalysisNode[] { node: NodeRecord; latLng:[lat,lng]; key:string }` | `src/components/MapAnalysis/useAnalysisNodes.ts` |
+| Map Analysis client config + persistence | `useMapAnalysisConfig()` (localStorage `mapAnalysis.config.v1`, version-guarded `load()` that merges defaults) | `src/hooks/useMapAnalysisConfig.ts` |
+| Context exposure of config fields | `MapAnalysisProvider` / `useMapAnalysisCtx()` (pattern: `followMode`/`setFollowMode` etc.); selection via `selected`/`setSelected` (`SelectedTarget { type:'node'\|'segment'\|'neighbor'\|'trail'; ... }`) | `src/components/MapAnalysis/MapAnalysisContext.tsx` |
+| Toolbar toggle-button + gating pattern | `MapAnalysisToolbar` (measure/link-profile buttons: `className={active?'active':''}`, `disabled`, hidden-when-unavailable, title-hint tooltips) | `src/components/MapAnalysis/MapAnalysisToolbar.tsx` |
+| 2D canvas host (unchanged in 2D) | `MapAnalysisCanvas` composes `BaseMap` + panes | `src/components/MapAnalysis/MapAnalysisCanvas.tsx` |
+| Current basemap tileset id/URL + custom list | `useSettings()` → `mapTileset`, `customTilesets`, `setMapTileset`; `getTilesetById(id, custom)`, `TILESETS`, `DEFAULT_TILESET_ID='osm'`, `isVectorTileUrl` | `src/contexts/SettingsContext.tsx`, `src/config/tilesets.ts` |
+| MapLibre CSS + dep | `maplibre-gl ^5.24.0`; CSS import precedent `'maplibre-gl/dist/maplibre-gl.css'` | `package.json`, `src/components/VectorTileLayer.tsx` |
+
+**Why `Base3DMap` cannot reuse `BaseMap`:** `BaseMap` is hard-wired to
+react-leaflet (`MapContainer`, `TileLayer`, a Leaflet `Map` instance, Leaflet
+panes). MapLibre GL is a different renderer with its own `maplibregl.Map`, its own
+sources/layers, and a WebGL context — there is no shared surface to parameterize.
+`Base3DMap` is a genuinely new sibling that wraps `maplibregl.Map` **directly**
+(`import maplibregl from 'maplibre-gl'`), **not** via `@maplibre/maplibre-gl-leaflet`
+(that adapter embeds MapLibre *inside* Leaflet for vector tiles — the opposite of
+what we need). It sits beside `BaseMap` in `src/components/map/`.
+
+**Why not reuse the Leaflet `NodeMarkersLayer`:** it renders react-leaflet
+`<Marker>` children with Leaflet `DivIcon`s — Leaflet-only, unusable in a WebGL
+map. The 3D marker layer consumes the **same `useAnalysisNodes()` data** but
+renders it as a MapLibre GeoJSON source + `circle`/`symbol` layer (see §2/§D).
+Full icon parity with 2D DivIcons is Phase 3.
+
+---
+
+## 2. Design decisions
+
+### 2.1 JSON-source behavior → machine-coded error (NOT silent terrarium fallback)
+
+When `elevationSourceUrl` resolves to a **JSON point provider**
+(`detectProviderType(url) === 'json'`), the tile endpoint returns
+`fail(res, 409, 'TERRAIN_TILES_UNAVAILABLE', ...)` and the capabilities endpoint
+reports `terrainTiles:false`. It does **not** silently fall back to the public
+AWS terrarium URL.
+
+Rationale:
+1. **Admin intent / privacy.** Configuring a JSON source (self-hosted / API-keyed
+   Open-Topo-Data) is a deliberate choice, often for air-gapped or
+   cost-controlled deployments. Silently routing 3D tile traffic to
+   `s3.amazonaws.com` would leak requests to a third party the admin explicitly
+   opted away from.
+2. **Consistency.** The 2D profile feature (`/profile`) samples the JSON source;
+   if 3D terrain used AWS terrarium instead, the two features would disagree on
+   elevation for the same coordinates.
+3. **Clean UX.** A precise "3D terrain not available with the configured
+   elevation source" state lets the frontend **disable the toggle with a
+   tooltip** (a Phase-2 requirement) rather than render broken/blank terrain.
+
+The default/unset and explicit-terrarium cases still use the public terrarium
+provider exactly as `/profile` does — no regression for the common install.
+
+### 2.2 Capabilities signal → new lightweight `GET /api/elevation/capabilities`
+
+The frontend must know **before** rendering whether to enable the toggle, but it
+**cannot** see `elevationSourceUrl` (secret, stripped from `/api/settings` for
+non-admins). So provider type must be derived **server-side** and exposed as a
+non-secret boolean. Add:
+
+`GET /api/elevation/capabilities` → `ok(res, { enabled, terrainTiles, provider })`
+- `enabled`  = `elevationEnabled !== 'false'`
+- `provider` = `detectProviderType(sourceUrl || DEFAULT_TERRARIUM_URL)` (`'terrarium'|'json'`)
+- `terrainTiles` = `enabled && provider === 'terrarium'`
+
+Public (`optionalAuth`), no network I/O (reads two settings), no URL leak. This is
+not a settings key — it is a derived capability, so it does not touch
+`VALID_SETTINGS_KEYS`.
+
+### 2.3 Raw-tile caching → small module-scope raw-PNG LRU, separate from the decoded cache
+
+The existing `tileCache` in `elevationProvider.ts` stores **decoded `Float32Array`**
+keyed `"z/x/y"` at the fixed sampling zoom 12 — useless to the proxy, which needs
+**raw PNG bytes at arbitrary client zoom**. Add a **second, independent**
+module-scope LRU holding raw tile buffers:
+
+```ts
+const rawTileCache = new LruCache<string, Buffer>(RAW_TILE_CACHE_MAX); // key `"z/x/y"`
+export const RAW_TILE_CACHE_MAX = 256;
+```
+
+Memory bound: terrarium PNGs are ~10–120 KB (typ. ~50 KB); 256 × ~120 KB worst
+case ≈ **~30 MB** ceiling, typically ~13 MB. Justification for caching at all
+(vs. relying solely on the browser HTTP cache): the browser cache already absorbs
+per-client repeats (we set `immutable`, §2.4); the server LRU dampens **cold /
+cross-user / cross-session** refetches and shields the upstream tile host from
+duplicate fan-out during multi-user bursts. Keep it separate from the decoded
+cache — different key space (variable z), different value type, and mixing them
+would evict warm profile tiles under 3D browsing pressure.
+
+### 2.4 Cache-Control → long immutable
+
+DEM terrain is static. On success respond:
+`Cache-Control: public, max-age=604800, immutable` (7 days). This makes the
+browser (and any intermediary) serve repeats from cache without revalidation,
+which is the dominant traffic-reduction lever. Error responses set
+`Cache-Control: no-store`.
+
+### 2.5 Rate limiting → new `elevationTileLimiter` (generous), not `elevationLimiter`
+
+`elevationLimiter` (20/min prod) is correct for `/profile` (one heavy fan-out per
+call) but a 3D interaction legitimately fetches dozens of DEM tiles. Add a
+dedicated limiter modeled on the same factory:
+
+```ts
+export const elevationTileLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: env.isProduction ? 600 : 3000,   // 10/s prod; DEM tiles only — basemap tiles go direct to OSM/etc.
+  message: 'Too many elevation tile requests, please slow down',
+  handler: (req, res) => { logger.warn(`🚫 Rate limit exceeded for ELEVATION_TILES - IP: ${req.ip||'unknown'}`); res.status(429).json({ error: 'Too many elevation tile requests, please slow down', retryAfter: '1 minute' }); },
+  ...rateLimitConfig,   // private IPs exempt, shared keygen
+});
+```
+
+600/min comfortably covers first-load + pan/zoom bursts (a fresh 3D view is
+~20–40 DEM tiles; only these hit the proxy). Abuse (outbound amplification) stays
+bounded by the raw-tile LRU + SSRF guard + `immutable` browser caching + the
+z/x/y validation cap (§2.6). Admin can hard-disable via `elevationEnabled=false`.
+
+### 2.6 Tile coordinate validation + zoom cap
+
+Parse `:z/:x/:y` as integers. Reject (→ `fail(res, 400, 'INVALID_TILE_COORDS')`)
+when: non-integer; `z < 0 || z > MAX_TERRARIUM_TILE_ZOOM` (=15, AWS terrarium's
+max native zoom); `x`/`y` outside `[0, 2^z − 1]`. This also caps the SSRF
+guard's attack surface (only well-formed tile URLs are ever substituted). The
+raster-dem source sets `maxzoom: 15`; MapLibre overzooms terrain past that
+client-side.
+
+### 2.7 Basemap resolution + the `{s}` subdomain gotcha (vector fallback)
+
+3D basemap comes from the user's **current** raster tileset
+(`getTilesetById(mapTileset, customTilesets)`). Two transforms are required
+because MapLibre raster sources differ from Leaflet `TileLayer`:
+
+- **Vector-only tileset → fall back to `TILESETS.osm`.** MapLibre raster sources
+  can't consume a `.pbf`/`.mvt` vector tileset without a full style JSON (out of
+  scope this phase). If `tileset.isVector`, use the default `osm` raster for the
+  3D basemap and surface a subtle note. (The 2D view is unaffected — only the 3D
+  basemap substitutes.)
+- **`{s}` subdomain token → expand to a `tiles[]` array.** MapLibre does **not**
+  support Leaflet's `{s}` placeholder. `osm`/`osmHot`/`carto*`/`openTopo` all use
+  `https://{s}...`. A pure helper `expandSubdomains(url)` returns
+  `['a','b','c'].map(s => url.replace('{s}', s))` when `{s}` is present, else
+  `[url]`. `esriSatellite` has no `{s}` and uses `{z}/{y}/{x}` order — MapLibre
+  substitutes `{x}/{y}/{z}` tokens regardless of order, so it works unmodified.
+
+These two transforms live in a pure, unit-tested util (`§2/D basemap3d.ts`).
+
+### 2.8 Toggle persistence → `viewMode` in the existing Map Analysis config
+
+Add `viewMode: '2d' | '3d'` (default `'2d'`) to `MapAnalysisConfig` and a
+`setViewMode` setter, persisted through the existing `mapAnalysis.config.v1`
+localStorage mechanism. `load()` spreads `DEFAULT_CONFIG` first, so pre-existing
+stored configs (no `viewMode`) default to `'2d'` with **no version bump**. This
+is the same persistence path as `followMode`/`autoZoom`, satisfying "consistent
+with existing Map Analysis prefs." (Not a server settings key — no
+`VALID_SETTINGS_KEYS` involvement.)
+
+### 2.9 Terrain exaggeration → client-local transient state
+
+`useState<number>` in `Base3DMap` (default `1.0`, slider range `0`–`2`), applied
+via `map.setTerrain({ source, exaggeration })`. Not persisted — per the phase
+constraint, and it avoids a settings key. Phase 3 may promote a *default* value to
+a real setting (with the `VALID_SETTINGS_KEYS` + `SettingsTab.handleSave` recipe).
+
+### 2.10 3D interactivity: in-scope vs Phase 3
+
+**In this phase:** raster basemap, `raster-dem` terrain from the proxy, hillshade
+layer, `NavigationControl` (pitch/bearing/zoom/compass), exaggeration slider,
+node markers (GeoJSON `circle` + short-name `symbol` label) built from
+`useAnalysisNodes()`, and **click-a-marker → `setSelected({type:'node', ...})`**
+(minimum viable: opens the existing inspector on the clicked node). Attribution.
+WebGL teardown on unmount.
+
+**Deferred to Phase 3:** neighbor links & traceroute paths in 3D; full node-icon
+parity (DivIcon-equivalent styling, spiderfy, age-fade); popups/tooltips;
+follow/auto-zoom; time-slider integration; the terrain-profile action; vector
+basemap styling. `Base3DMap` is built generic (data in via props) so Phase 3 adds
+layers without reshaping it.
+
+### 2.11 Attribution
+
+Enable MapLibre's built-in `AttributionControl` (compact). Attach the basemap
+`tileset.attribution` (HTML) to the raster source's `attribution`, and an
+elevation credit (`Elevation: Mapzen / AWS Terrain Tiles` for terrarium) to the
+`raster-dem` source's `attribution`. MapLibre aggregates and renders them.
+
+### 2.12 WebGL lifecycle / teardown
+
+`Base3DMap` creates the `maplibregl.Map` in a `useEffect` and calls `map.remove()`
+in cleanup to release the WebGL context (prevents "too many active WebGL contexts"
+leaks on repeated 2D⇄3D toggles). The `Map` instance is held in a `ref`; the
+create/remove pair is symmetric so React 19 StrictMode's dev double-mount
+(mount→unmount→mount) is safe. Basemap/terrain/exaggeration/node-data updates go
+through separate effects that mutate the existing map (`setStyle`/`getSource().setData()`/
+`setTerrain()`), **not** by remounting the map.
+
+### 2.13 CSP — no change expected (verify in browser)
+
+`dynamicCsp.ts` already ships everything MapLibre needs: `worker-src 'self' blob:`
+(MapLibre's blob-URL web workers), the four built-in raster hosts + dynamically
+added custom hosts in `connect-src` (MapLibre fetches raster/DEM tiles via
+`fetch`), and the DEM proxy is same-origin (`connect-src 'self'`). `img-src`
+includes `data: http: https:`. **Verify during browser validation** that
+hillshade/terrain render; the *only* plausible gap is if a browser lacks
+`createImageBitmap` and MapLibre falls back to `Image()` from a blob URL — if (and
+only if) tiles fail with a `blob:` `img-src` violation, add `'blob:'` to the
+`img-src` array in `dynamicCsp.ts` (one-line, low-risk). Do not add it
+preemptively.
+
+### 2.14 Tile-proxy URL construction (base-path)
+
+MapLibre fetches the DEM source URL directly, so the app must build an absolute
+path that honors the deployment base (`BASE_URL`, e.g. `/meshmonitor`). Reuse the
+same base prefix `ApiService` prepends (`ApiService` holds a `baseUrl` field;
+Vite exposes `import.meta.env.BASE_URL`). The DEM source `tiles` entry is
+`` `${base}/api/elevation/tiles/{z}/{x}/{y}` `` where `base` is that prefix
+(trailing-slash-normalized). Keep this in the `basemap3d.ts` util
+(`buildTerrainTileUrl(base)`), unit-tested, so it is not hand-rolled per call
+site and does not use raw `fetch`.
+
+---
+
+## 3. File-by-file changes
+
+### Backend
+
+#### 3.1 `src/server/services/elevationProvider.ts` (EDIT)
+Add raw-tile fetch + cache + a small validation/type helper. No change to
+existing point-sampling code.
+```ts
+export const RAW_TILE_CACHE_MAX = 256;
+export const MAX_TERRARIUM_TILE_ZOOM = 15;
+// module-scope, separate from the decoded `tileCache`:
+const rawTileCache = new LruCache<string, Buffer>(RAW_TILE_CACHE_MAX);
+
+/** Integer + range validation for slippy-tile coords. */
+export function isValidTileCoord(z: number, x: number, y: number): boolean;
+
+/**
+ * Fetch a raw terrarium PNG tile (bytes) for the given z/x/y from a terrarium
+ * URL template, via safeFetch, with a shared raw-PNG LRU. Returns null on
+ * invalid coords, non-terrarium template, non-OK response, SSRF block, or
+ * network error (never throws). Substitutes {z}/{x}/{y} (client-supplied z,
+ * unlike the fixed-zoom point sampler).
+ */
+export async function fetchTerrariumTilePng(
+  urlTemplate: string, z: number, x: number, y: number,
+): Promise<Buffer | null>;
+```
+- `fetchTerrariumTilePng` reuses the exact `safeFetch` + `SsrfBlockedError` catch
+  + `{z}/{x}/{y}` `.replace(...)` pattern already in `TerrariumTileProvider`.
+  Cache hit → return buffer; miss → fetch, `Buffer.from(await res.arrayBuffer())`,
+  `set`, return. Non-OK / thrown → `logger.debug/warn` + return `null` (do not
+  cache failures).
+
+#### 3.2 `src/server/services/elevationService.ts` (EDIT — orchestration, keep routes thin)
+```ts
+export interface ElevationCapabilities { enabled: boolean; terrainTiles: boolean; provider: ProviderType; }
+
+/** Pure-ish: derives capabilities from settings values (no network). */
+export function getElevationCapabilities(
+  elevationEnabled: string | undefined, sourceUrl: string | undefined,
+): ElevationCapabilities;
+
+/**
+ * Resolve the terrain tile bytes for z/x/y honoring elevationSourceUrl.
+ * - elevationEnabled === 'false'      → { code:'ELEVATION_DISABLED', status:403 }
+ * - provider is JSON (no tiles)       → { code:'TERRAIN_TILES_UNAVAILABLE', status:409 }
+ * - invalid coords                    → { code:'INVALID_TILE_COORDS', status:400 }
+ * - upstream miss/failure             → { code:'TILE_FETCH_FAILED', status:502 }
+ * - success                           → { png: Buffer }
+ */
+export async function fetchTerrainTile(
+  z: number, x: number, y: number, elevationEnabled: string | undefined, sourceUrl: string | undefined,
+): Promise<{ png: Buffer } | { code: string; status: number; message: string }>;
+```
+`fetchTerrainTile` resolves the terrarium template (`sourceUrl` if terrarium else
+`DEFAULT_TERRARIUM_URL` is **not** used for JSON — JSON short-circuits to
+`TERRAIN_TILES_UNAVAILABLE`), validates coords, calls `fetchTerrariumTilePng`.
+
+#### 3.3 `src/server/middleware/rateLimiters.ts` (EDIT)
+Append `elevationTileLimiter` (§2.5).
+
+#### 3.4 `src/server/routes/elevationRoutes.ts` (EDIT — add two routes)
+```ts
+// GET /api/elevation/capabilities — PUBLIC (optionalAuth), no network.
+router.get('/capabilities', optionalAuth(), async (_req, res) => {
+  const s = await databaseService.settings.getAllSettings();
+  ok(res, getElevationCapabilities(s.elevationEnabled, s.elevationSourceUrl));
+});
+
+// GET /api/elevation/tiles/:z/:x/:y — PUBLIC (optionalAuth) + tile limiter.
+router.get('/tiles/:z/:x/:y', optionalAuth(), elevationTileLimiter, async (req, res) => {
+  const z = Number(req.params.z), x = Number(req.params.x), y = Number(req.params.y);
+  const s = await databaseService.settings.getAllSettings();
+  const r = await fetchTerrainTile(z, x, y, s.elevationEnabled, s.elevationSourceUrl);
+  if ('code' in r) {
+    res.set('Cache-Control', 'no-store');
+    return fail(res, r.status, r.code, r.message);
+  }
+  res.set('Content-Type', 'image/png');
+  res.set('Cache-Control', 'public, max-age=604800, immutable');
+  return res.send(r.png);           // raw bytes — NOT ok()
+});
+```
+- `:y` may arrive as `123.png`? No — MapLibre requests the template we give it
+  (`.../{z}/{x}/{y}`, no extension), so `:y` is a bare integer. `Number('123')`
+  is fine; a stray extension → `NaN` → `INVALID_TILE_COORDS`.
+- Never include the resolved source URL (or key) in any `fail()` message.
+
+*No `server.ts` change* — `/elevation` is already mounted.
+
+### Frontend
+
+#### 3.5 `src/config/basemap3d.ts` (NEW — pure, react-free, unit-tested)
+```ts
+import { getTilesetById, TILESETS, type TilesetId, type CustomTileset, type TilesetConfig } from './tilesets';
+
+export interface Basemap3DSource { tiles: string[]; attribution: string; maxZoom: number; usedFallback: boolean; }
+
+/** Expand Leaflet {s} into MapLibre tiles[]; single-element when absent. */
+export function expandSubdomains(url: string): string[];
+
+/** Raster basemap for the GL map; vector-only tileset → osm fallback (usedFallback=true). */
+export function resolve3DBasemap(tilesetId: TilesetId, custom: CustomTileset[]): Basemap3DSource;
+
+/** DEM proxy tile URL honoring the deployment base path. */
+export function buildTerrainTileUrl(basePath: string): string; // `${base}/api/elevation/tiles/{z}/{x}/{y}`
+```
+
+#### 3.6 `src/hooks/useTerrainCapabilities.ts` (NEW)
+TanStack query on `/api/elevation/capabilities`. **Reads `body.data`** (enveloped
+— the ApiService gotcha). Returns `{ enabled, terrainTiles, provider }` with safe
+defaults while loading (treat as loading, not available). Sibling test file
+mirrors `useElevationEnabled.test.tsx`.
+```ts
+export function useTerrainCapabilities(): { enabled: boolean; terrainTiles: boolean; isLoading: boolean };
+```
+
+#### 3.7 `src/hooks/useMapAnalysisConfig.ts` (EDIT)
+- Add `viewMode: '2d' | '3d'` to `MapAnalysisConfig`; `DEFAULT_CONFIG.viewMode='2d'`.
+- `load()` already merges `DEFAULT_CONFIG` first → old blobs default to `'2d'`.
+- Add `setViewMode` callback (mirrors `setFollowMode`), export it.
+
+#### 3.8 `src/components/MapAnalysis/MapAnalysisContext.tsx` (EDIT)
+Expose `viewMode` / `setViewMode` from the config hook through `CtxShape` (mirror
+`followMode`/`setFollowMode`).
+
+#### 3.9 `src/components/map/Base3DMap.tsx` (NEW)
+Generic MapLibre GL surface (no Map-Analysis coupling — data via props).
+```ts
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+export interface Node3DFeature { key: string; lat: number; lng: number; label?: string; color?: string; }
+export interface Base3DMapProps {
+  center: [number, number];        // [lat, lng]
+  zoom: number;
+  basemap: Basemap3DSource;        // from resolve3DBasemap
+  terrainTileUrl: string;          // from buildTerrainTileUrl
+  nodes: Node3DFeature[];
+  onNodeClick?: (key: string) => void;
+  className?: string;
+}
+```
+Responsibilities: construct `maplibregl.Map` with a minimal style (raster basemap
+source/layer); on `load` add `raster-dem` source (`encoding:'terrarium'`,
+`tileSize:256`, `maxzoom:15`, `tiles:[terrainTileUrl]`), `map.setTerrain({source,
+exaggeration})`, a `hillshade` layer, a GeoJSON `nodes` source + `circle` +
+`symbol` label layer; `addControl(NavigationControl {visualizePitch:true})` and a
+compact `AttributionControl`; register a `click` handler on the node circle layer
+→ `onNodeClick(feature.properties.key)`; render an exaggeration `<input
+type=range>` overlay (local state → `setTerrain`). Effects: basemap change →
+update raster source; `nodes` change → `getSource('nodes').setData(...)`; unmount
+→ `map.remove()`. All effect deps exhaustive.
+
+#### 3.10 `src/components/MapAnalysis/MapAnalysisCanvas.tsx` (EDIT — add 3D branch)
+- Read `viewMode` from `useMapAnalysisCtx()`; keep `mapTileset`/`customTilesets`
+  from `useSettings()`.
+- When `viewMode === '3d'`: render `Base3DMap` with
+  `basemap = resolve3DBasemap(mapTileset, customTilesets)`,
+  `terrainTileUrl = buildTerrainTileUrl(base)`, `nodes` mapped from
+  `useAnalysisNodes()` (`{key, lat:latLng[0], lng:latLng[1], label:node.shortName}`),
+  `onNodeClick = key => setSelected({type:'node', ... resolve from analysisNodes})`.
+  Center/zoom from the existing `defaultMapCenter*`/`FALLBACK_*` values.
+- When `viewMode === '2d'` (default): render the **existing** `BaseMap` tree
+  **verbatim** — no behavioral change. The 3D branch is additive; 2D is untouched.
+- If `usedFallback` (vector tileset), render a small non-blocking note over the 3D
+  map ("Showing default basemap in 3D — the selected map style is vector-only").
+
+#### 3.11 `src/components/MapAnalysis/MapAnalysisToolbar.tsx` (EDIT — 2D/3D toggle)
+- `const caps = useTerrainCapabilities();`  `const { viewMode, setViewMode } = useMapAnalysisCtx();`
+- Add a 2D/3D toggle button beside existing tools:
+  - **Disabled** (with tooltip) when `!caps.enabled` → "Elevation is disabled"
+    or `caps.enabled && !caps.terrainTiles` → "3D terrain is unavailable with the
+    configured elevation source". While `caps.isLoading`, render disabled/neutral.
+  - Enabled otherwise: `className={viewMode==='3d'?'active':''}`, onClick toggles
+    `setViewMode(viewMode==='3d'?'2d':'3d')`.
+- Follow the existing measure/link-profile title-hint + `active` class pattern.
+- Consider forcing `viewMode` back to `'2d'` if it is `'3d'` but caps become
+  unavailable (guard in the canvas or an effect) so a persisted `'3d'` never
+  strands a user on a disabled feature.
+
+#### 3.12 `src/services/api.ts` (EDIT — optional typed helper)
+Optionally add `getTerrainCapabilities()` for symmetry with `getElevationProfile`;
+acceptable for `useTerrainCapabilities` to call `apiService.get('/api/elevation/capabilities')`
+directly (still reading `body.data`). Either is fine; keep app code off raw `fetch`.
+
+---
+
+## 4. Test plan (Vitest only; route tests via `createRouteTestApp`)
+
+### Backend — `src/server/routes/elevationRoutes.test.ts` (EXTEND, harness)
+Mock **only** `safeFetch` (return a tiny fake PNG `Buffer` for terrarium; a JSON
+body for the JSON case). Use `createRouteTestApp({ mount })`.
+- `GET /tiles/:z/:x/:y` **default provider** → 200, `Content-Type: image/png`,
+  `Cache-Control` has `immutable`, body is the mocked bytes; anonymous succeeds
+  (optionalAuth).
+- **`elevationEnabled='false'`** → 403 `ELEVATION_DISABLED`, `no-store`.
+- **JSON `elevationSourceUrl`** (e.g. `https://x/v1/test?locations={locations}`) →
+  409 `TERRAIN_TILES_UNAVAILABLE`; body must **not** contain the URL/key.
+- **Invalid coords** (`z=99`, `x=-1`, `y=NaN`/`abc`) → 400 `INVALID_TILE_COORDS`.
+- **SSRF still applies**: `safeFetch` mock throws `SsrfBlockedError` → 502
+  `TILE_FETCH_FAILED`, no key leak; assert `safeFetch` was the fetch path (no raw
+  fetch).
+- **Upstream non-OK** (mock `{ok:false,status:404}`) → 502 `TILE_FETCH_FAILED`.
+- `GET /capabilities`: default → `{enabled:true,terrainTiles:true,provider:'terrarium'}`;
+  `elevationEnabled='false'` → `enabled:false,terrainTiles:false`; JSON url →
+  `terrainTiles:false,provider:'json'`. Assert envelope shape (`success:true,data`).
+- Rate limiter smoke: not exhaustively (limiter internals are shared/tested), but
+  assert the route is wired with `elevationTileLimiter` (a 200 path suffices;
+  avoid flakiness).
+
+### Backend — `src/server/services/elevationProvider.test.ts` (EXTEND)
+- `isValidTileCoord` truth table (bounds, negative, non-integer, z>15).
+- `fetchTerrariumTilePng`: mocked `safeFetch` → returns buffer + caches (second
+  call does not re-fetch); non-OK → null; `SsrfBlockedError` → null (no throw);
+  non-terrarium template guarded.
+
+### Backend — `src/server/services/elevationService.test.ts` (EXTEND)
+- `getElevationCapabilities` matrix (enabled/disabled × terrarium/json/default).
+- `fetchTerrainTile` returns the right `{code,status}` per branch and `{png}` on
+  success.
+
+### Frontend (jsdom; **mock `maplibre-gl`** — no WebGL in jsdom)
+`vi.mock('maplibre-gl')` exporting a fake `Map` class capturing constructor
+options and recording `on/addSource/addLayer/setTerrain/addControl/getSource/
+remove` calls; `NavigationControl`/`AttributionControl` as no-op classes;
+`getSource` returns `{ setData: vi.fn() }`.
+- `basemap3d.test.ts` (pure): `expandSubdomains` ({s}→3 urls, none→1);
+  `resolve3DBasemap` (raster passthrough; vector → osm fallback + `usedFallback`;
+  custom raster); `buildTerrainTileUrl` (base-path join, trailing slash).
+- `useTerrainCapabilities.test.tsx`: reads `body.data`; loading defaults;
+  disabled/json cases (mirror `useElevationEnabled.test.tsx`).
+- `Base3DMap.test.tsx`: constructs `Map` with expected center/zoom/basemap tiles;
+  on fake `load` adds `raster-dem` + hillshade + nodes source; node `click` →
+  `onNodeClick`; **unmount calls `map.remove()`** (lifecycle). Exaggeration slider
+  change → `setTerrain` called with new value.
+- `MapAnalysisToolbar.test.tsx` (EXTEND): toggle hidden/disabled + tooltip when
+  `!enabled` and when `enabled && !terrainTiles`; enabled path toggles
+  `setViewMode`; reflects persisted `viewMode`.
+- `MapAnalysisCanvas.test.tsx` (EXTEND): `viewMode='2d'` renders `BaseMap` (2D
+  unchanged — assert no `Base3DMap`); `viewMode='3d'` renders `Base3DMap`
+  (mocked) fed the mapped node data; vector tileset → fallback note.
+- `useMapAnalysisConfig.test.ts` (EXTEND): `viewMode` default `'2d'`; old stored
+  blob without `viewMode` loads as `'2d'`; `setViewMode` persists.
+
+**Final gate (last package):** full Vitest suite (not targeted) + `npm run lint:ci`
+exit 0 before PR (CLAUDE.md).
+
+---
+
+## 5. Work packages
+
+Dependency graph: **WP-A** (backend) and **WP-B** (frontend pure/config) are
+independent and may run in parallel. **WP-C** (Base3DMap) depends on WP-B.
+**WP-D** (integration) depends on WP-A + WP-B + WP-C.
+
+### WP-A — Backend DEM tile proxy + capabilities *(independent; start immediately)*
+Files: `elevationProvider.ts` (raw fetch/cache/validation), `elevationService.ts`
+(`getElevationCapabilities`, `fetchTerrainTile`), `rateLimiters.ts`
+(`elevationTileLimiter`), `elevationRoutes.ts` (2 routes), and the three backend
+test files (§4).
+Acceptance: `GET /tiles/:z/:x/:y` returns `image/png` + `immutable` for the
+default provider (anonymous 200); `ELEVATION_DISABLED` (403), `TERRAIN_TILES_UNAVAILABLE`
+(409, no URL leak), `INVALID_TILE_COORDS` (400), `TILE_FETCH_FAILED` (502 incl.
+SSRF-block) all correct; `GET /capabilities` matrix correct and enveloped; raw-tile
+LRU is separate from the decoded cache; route tests use `createRouteTestApp` +
+mocked `safeFetch` only; `npm run lint:ci` clean. **No frontend dependency.**
+
+### WP-B — Frontend pure utils + capabilities hook + config field *(independent of WP-A)*
+Files: `src/config/basemap3d.ts` (+ test), `src/hooks/useTerrainCapabilities.ts`
+(+ test), `useMapAnalysisConfig.ts` (`viewMode` + setter, + test),
+`MapAnalysisContext.tsx` (expose `viewMode`/`setViewMode`).
+Acceptance: `expandSubdomains`/`resolve3DBasemap`/`buildTerrainTileUrl` unit-tested
+incl. vector fallback and `{s}` expansion; `useTerrainCapabilities` reads
+`body.data` with safe loading defaults; `viewMode` persists and old blobs default
+to `'2d'`; suite green for touched files; lint clean.
+
+### WP-C — `Base3DMap` MapLibre component *(depends WP-B for basemap3d types)*
+Files: `src/components/map/Base3DMap.tsx` (+ `Base3DMap.test.tsx` with mocked
+`maplibre-gl`).
+Acceptance: constructs the GL map from `basemap`/`terrainTileUrl`/`nodes`; adds
+`raster-dem` + terrain + hillshade + node circle/label layers; NavigationControl +
+compact attribution; node click → `onNodeClick`; exaggeration slider → `setTerrain`;
+`map.remove()` on unmount; effect deps exhaustive; lint clean. Renders generic
+(no Map-Analysis imports).
+
+### WP-D — Map Analysis integration (toggle + canvas branch) *(depends A+B+C)*
+Files: `MapAnalysisToolbar.tsx` (2D/3D toggle + gating/tooltips), `MapAnalysisCanvas.tsx`
+(3D branch feeding `useAnalysisNodes` → `Base3DMap`, `setSelected` on click, vector
+fallback note, force-2D guard when caps unavailable), `src/services/api.ts`
+(optional typed helper), extend `MapAnalysisToolbar.test.tsx` + `MapAnalysisCanvas.test.tsx`.
+Acceptance: toggle disabled+tooltip when elevation disabled / JSON source; 3D
+renders pitched terrain + hillshade + node markers on the dev container; 2D mode
+byte-for-byte unchanged (regression-free); persisted `viewMode` respected and
+never strands the user on a disabled feature; browser-validated with screenshots
+(pitched terrain visible, markers clickable, 2D unchanged). **Final gate:** full
+Vitest suite + `npm run lint:ci` exit 0; CSP verified (§2.13) — add `'blob:'` to
+`img-src` *only if* browser validation shows a violation.
+
+---
+
+## 6. Invariants honored / explicit non-goals
+
+- **Honored:** response envelope on all JSON (`ok`/`fail`), raw bytes only for the
+  tile body; no raw SQL / no migration (settings keys pre-exist); route tests via
+  harness with `safeFetch`-only mocking; SSRF guard on every outbound fetch; no
+  secret (`elevationSourceUrl`) ever reaches the client or an error message; no
+  new `VALID_SETTINGS_KEYS`; TS strict / no `any` / no raw `fetch` in components/pages;
+  exhaustive-deps clean; 2D path untouched.
+- **Non-goals (Phase 3):** neighbor links / traceroutes in 3D; full node-icon +
+  spiderfy + popup parity; follow/auto-zoom; time slider in 3D; terrain-profile
+  action from 3D; default-exaggeration setting; vector-basemap styling in 3D;
+  README/docs updates; indoor/venue 3D tilesets (out of scope for the whole epic —
+  fill-extrusion buildings noted as the cheap future first step in the #3826
+  closing comment).

--- a/docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md
@@ -45,7 +45,7 @@ Exit criteria:
 - Vitest coverage for the inspector changes + any new pure helpers; full suite green.
 - Browser-validated on the dev container.
 
-### Phase 2 — DEM tile proxy + 3D map foundation ⬜
+### Phase 2 — DEM tile proxy + 3D map foundation ✅
 
 Branch: `feature/3826-3d-map-foundation`
 
@@ -78,4 +78,5 @@ Exit criteria:
 ## Status log
 
 - 2026-07-20: Epic started. Interview complete, phases agreed (3 phases; user merged tile-proxy + 3D-foundation into Phase 2).
+- 2026-07-20: Phase 2 implemented (spec: `3D_MAP_FOUNDATION_SPEC.md`; 4 work packages A–D). Backend: `GET /api/elevation/tiles/:z/:x/:y` PNG proxy (raw-PNG LRU separate from the decoded cache, `elevationTileLimiter` 600/min, immutable 7-day Cache-Control) + `GET /api/elevation/capabilities` (server-derived because `elevationSourceUrl` is secret); JSON point sources return 409 TERRAIN_TILES_UNAVAILABLE by design — no silent AWS fallback. Frontend: `Base3DMap` (standalone MapLibre GL: terrarium raster-dem terrain, hillshade, pitch 60°, exaggeration slider, GeoJSON node markers), `basemap3d.ts` ({s}-expansion + vector→osm fallback), `useTerrainCapabilities`, `viewMode` persisted in `mapAnalysis.config.v1`. Browser validation found + fixed a real defect: no-WebGL browsers crashed to a blank page when '3d' was persisted (probe + try/catch + `onUnsupported`→ auto-revert to 2D, commit 5340484d). 3D rendering validated via puppeteer + SwiftShader (MCP browser has no WebGL); gating/tooltip/persistence/force-2D all validated live. Phase 3 note: 3D node click selects via `{nodeNum, sourceId}` — verify MeshCore selection parity when wiring the inspector.
 - 2026-07-20: Phase 1 implemented (spec: `NEIGHBOR_LINK_TERRAIN_SPEC.md`). Frontend-only; new `neighborLinkEndpoints.ts` resolver + inspector wiring. Key decisions during the phase: endpoint elevations reuse `useElevationProfile` with the drawer's exact query key (one fetch per link, drawer open is a cache hit — verified live, request count stayed at 1); `LinkEndpoint.id` uses `unifiedNodeKey` for byte-for-byte parity with `linkEndpointCandidates`. Browser-validated on the dev container: MeshCore link (distance/elevations/profile action + drawer w/ auto-seeded frequency), Meshtastic link (distance via nodeNum resolution), and elevation-disabled gating (distance only, zero elevation requests). Full suite 10,427/0. Note: dev DB had no `/api/analysis/neighbors` rows initially — Meshtastic live check came from an MQTT-broker-source neighbor link.

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import MapAnalysisCanvas from './MapAnalysisCanvas';
@@ -99,17 +99,66 @@ vi.mock('../../hooks/useDashboardData', () => ({
   UNIFIED_SOURCE_ID: '__unified__',
 }));
 
+// Mutable so the vector-fallback test (#3826 Phase 2 WP-D) can swap in a
+// vector-only custom tileset without a second describe-level mock factory.
+let mapTilesetMock = 'osm';
+let customTilesetsMock: Array<{
+  id: string;
+  name: string;
+  url: string;
+  attribution: string;
+  maxZoom: number;
+  description: string;
+  createdAt: number;
+  updatedAt: number;
+  isVector?: boolean;
+}> = [];
+
 vi.mock('../../contexts/SettingsContext', () => ({
   useSettings: () => ({
     defaultMapCenterLat: 30,
     defaultMapCenterLon: -90,
     defaultMapCenterZoom: 10,
-    mapTileset: 'osm',
-    customTilesets: [],
+    mapTileset: mapTilesetMock,
+    customTilesets: customTilesetsMock,
     setMapTileset: vi.fn(),
   }),
   // Used by DashboardNodePopup, which now renders inside the node marker popups.
   useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
+// #3826 Phase 2 WP-D: capabilities gate for the force-2D guard. Mutable per
+// test (mirrors the toolbar suite's `terrainCapabilities` mock).
+let terrainCapabilitiesMock = { enabled: true, terrainTiles: true, isLoading: false };
+vi.mock('../../hooks/useTerrainCapabilities', () => ({
+  useTerrainCapabilities: () => terrainCapabilitiesMock,
+}));
+
+// Base3DMap wraps maplibre-gl directly (WebGL) — unusable under jsdom (see
+// spec §4 test plan / Base3DMap.test.tsx, which mocks `maplibre-gl` itself).
+// Here it's mocked at the component level: a stub that renders the mapped
+// props so this suite can assert the 3D branch feeds it the right data,
+// without needing a WebGL context.
+vi.mock('../map/Base3DMap', () => ({
+  Base3DMap: (props: {
+    nodes: Array<{ key: string; lat: number; lng: number; label?: string }>;
+    basemap: { tiles: string[]; usedFallback: boolean };
+    terrainTileUrl: string;
+    onNodeClick?: (key: string) => void;
+  }) => (
+    <div data-testid="base-3d-map" data-terrain-url={props.terrainTileUrl}>
+      {props.nodes.map((n) => (
+        <button
+          key={n.key}
+          type="button"
+          data-testid={`base-3d-node-${n.key}`}
+          onClick={() => props.onNodeClick?.(n.key)}
+        >
+          {n.label}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 // The global setup.ts mock for react-i18next ignores `options.defaultValue`
@@ -158,12 +207,18 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
 };
 
 describe('MapAnalysisCanvas', () => {
-  beforeEach(() => localStorage.clear());
+  beforeEach(() => {
+    localStorage.clear();
+    mapTilesetMock = 'osm';
+    customTilesetsMock = [];
+    terrainCapabilitiesMock = { enabled: true, terrainTiles: true, isLoading: false };
+  });
 
-  it('renders the map container and tile layer', () => {
+  it('renders the map container and tile layer, and NOT Base3DMap, in 2d (default)', () => {
     render(<MapAnalysisCanvas />, { wrapper });
     expect(screen.getByTestId('map-container')).toBeInTheDocument();
     expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-3d-map')).toBeNull();
   });
 
   it('renders a marker per node when markers layer is enabled (default)', () => {
@@ -178,5 +233,83 @@ describe('MapAnalysisCanvas', () => {
     expect(screen.getByText(/Seen by 2 sources/i)).toBeInTheDocument();
     expect(screen.getByText('Alpha Src')).toBeInTheDocument();
     expect(screen.getByText('Beta Src')).toBeInTheDocument();
+  });
+
+  // #3826 Phase 2 WP-D: 3D branch.
+  describe('3D view (viewMode=3d)', () => {
+    const persist3d = () =>
+      localStorage.setItem('mapAnalysis.config.v1', JSON.stringify({ version: 1, viewMode: '3d' }));
+
+    it('renders Base3DMap (not BaseMap) fed the same node data, mapped to Node3DFeature', () => {
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.getByTestId('base-3d-map')).toBeInTheDocument();
+      expect(screen.queryByTestId('map-container')).toBeNull();
+      // node nodeNum:1 (Meshtastic, no isMeshCore) -> unifiedNodeKey 'mt:1';
+      // label mapped from node.shortName ('A').
+      const nodeBtn = screen.getByTestId('base-3d-node-mt:1');
+      expect(nodeBtn).toHaveTextContent('A');
+    });
+
+    it('clicking a 3D node marker resolves the node and does not throw for an unknown key', () => {
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      // onNodeClick is wired through to setSelected internally; the mock just
+      // proves the callback fires without needing to inspect context state.
+      expect(() => fireEvent.click(screen.getByTestId('base-3d-node-mt:1'))).not.toThrow();
+    });
+
+    it('builds the terrain tile URL from the same-origin elevation tile proxy path', () => {
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.getByTestId('base-3d-map')).toHaveAttribute(
+        'data-terrain-url',
+        expect.stringContaining('/api/elevation/tiles/{z}/{x}/{y}'),
+      );
+    });
+
+    it('shows the non-blocking vector-fallback note when the current tileset is vector-only', () => {
+      mapTilesetMock = 'custom-vector';
+      customTilesetsMock = [
+        {
+          id: 'custom-vector',
+          name: 'Custom Vector',
+          url: 'https://example.com/{z}/{x}/{y}.pbf',
+          attribution: '',
+          maxZoom: 14,
+          description: '',
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ];
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.getByText(/Showing default basemap in 3D/i)).toBeInTheDocument();
+    });
+
+    it('does NOT show the vector-fallback note for a raster tileset', () => {
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.queryByText(/Showing default basemap in 3D/i)).toBeNull();
+    });
+
+    it('force-2D guard: a persisted 3d viewMode falls back to BaseMap once capabilities resolve unavailable', () => {
+      terrainCapabilitiesMock = { enabled: false, terrainTiles: false, isLoading: false };
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.queryByTestId('base-3d-map')).toBeNull();
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      // The guard also corrects the persisted config so a later render (e.g.
+      // navigating away and back) doesn't re-attempt 3D.
+      const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+      expect(stored.viewMode).toBe('2d');
+    });
+
+    it('does NOT force back to 2D while capabilities are still loading (avoids a flash to 2D)', () => {
+      terrainCapabilitiesMock = { enabled: false, terrainTiles: false, isLoading: true };
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.getByTestId('base-3d-map')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -145,6 +145,7 @@ vi.mock('../map/Base3DMap', () => ({
     basemap: { tiles: string[]; usedFallback: boolean };
     terrainTileUrl: string;
     onNodeClick?: (key: string) => void;
+    onUnsupported?: () => void;
   }) => (
     <div data-testid="base-3d-map" data-terrain-url={props.terrainTileUrl}>
       {props.nodes.map((n) => (
@@ -157,6 +158,14 @@ vi.mock('../map/Base3DMap', () => ({
           {n.label}
         </button>
       ))}
+      {/* Lets tests simulate the real component's WebGL-unavailable signal. */}
+      <button
+        type="button"
+        data-testid="base-3d-trigger-unsupported"
+        onClick={() => props.onUnsupported?.()}
+      >
+        trigger-unsupported
+      </button>
     </div>
   ),
 }));
@@ -310,6 +319,20 @@ describe('MapAnalysisCanvas', () => {
       persist3d();
       render(<MapAnalysisCanvas />, { wrapper });
       expect(screen.getByTestId('base-3d-map')).toBeInTheDocument();
+    });
+
+    it('flips back to the 2D map when Base3DMap reports WebGL is unsupported', () => {
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      expect(screen.getByTestId('base-3d-map')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('base-3d-trigger-unsupported'));
+
+      expect(screen.queryByTestId('base-3d-map')).toBeNull();
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      // The corrected viewMode also persists so the next visit doesn't retry 3D.
+      const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+      expect(stored.viewMode).toBe('2d');
     });
   });
 });

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { Pane } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -11,6 +11,10 @@ import LinkProfileDrawer from './LinkProfileDrawer';
 import LinkProfileHoverLayer from './LinkProfileHoverLayer';
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import { BaseMap } from '../map/BaseMap';
+import { Base3DMap, type Node3DFeature } from '../map/Base3DMap';
+import { resolve3DBasemap, buildTerrainTileUrl } from '../../config/basemap3d';
+import { useTerrainCapabilities } from '../../hooks/useTerrainCapabilities';
+import { appBasename } from '../../init';
 import NodeMarkersLayer from './layers/NodeMarkersLayer';
 import TraceroutePathsLayer from './layers/TraceroutePathsLayer';
 import NeighborLinksLayer from './layers/NeighborLinksLayer';
@@ -40,6 +44,8 @@ export default function MapAnalysisCanvas() {
   } = useSettings();
   const {
     config,
+    setViewMode,
+    setSelected,
     measureMode,
     setMeasureMode,
     linkProfileMode,
@@ -92,6 +98,69 @@ export default function MapAnalysisCanvas() {
     defaultMapCenterLon ?? FALLBACK_CENTER[1],
   ];
   const zoom = defaultMapCenterZoom ?? FALLBACK_ZOOM;
+
+  // #3826 Phase 2 WP-D: 3D branch (spec §3.10) + force-2D guard (spec §3.11).
+  // A persisted `viewMode:'3d'` must never strand the user once capabilities
+  // resolve unavailable (elevation disabled, or a JSON elevation source with
+  // no DEM tiles): once the capabilities fetch settles unavailable, correct
+  // the *persisted* config back to `'2d'` (effect) and use a
+  // still-loading-safe `effectiveViewMode` for *this* render so a
+  // legitimately-available 3D view doesn't flash to 2D while the
+  // capabilities fetch is still in flight.
+  const terrainCaps = useTerrainCapabilities();
+  const capsUnavailable = !terrainCaps.isLoading && !(terrainCaps.enabled && terrainCaps.terrainTiles);
+  const forced2d = config.viewMode === '3d' && capsUnavailable;
+  useEffect(() => {
+    if (forced2d) setViewMode('2d');
+  }, [forced2d, setViewMode]);
+  const effectiveViewMode = forced2d ? '2d' : config.viewMode;
+
+  // Same shared `useAnalysisNodes()` data the 2D markers layer/picker use
+  // (see `analysisNodes` above), mapped to the shape `Base3DMap` expects.
+  const node3DFeatures: Node3DFeature[] = useMemo(
+    () => analysisNodes.map((a) => ({
+      key: a.key,
+      lat: a.latLng[0],
+      lng: a.latLng[1],
+      label: a.node.shortName ?? undefined,
+    })),
+    [analysisNodes],
+  );
+  const basemap3D = useMemo(
+    () => resolve3DBasemap(mapTileset, customTilesets),
+    [mapTileset, customTilesets],
+  );
+  // `appBasename` is the same base-path prefix `ApiService` was seeded with
+  // at startup (`src/init.ts`) — module-scope constant, never changes.
+  const terrainTileUrl = useMemo(() => buildTerrainTileUrl(appBasename), []);
+  const handleNode3DClick = useCallback(
+    (key: string) => {
+      const match = analysisNodes.find((a) => a.key === key);
+      if (!match) return;
+      setSelected({ type: 'node', nodeNum: Number(match.node.nodeNum), sourceId: match.node.sourceId });
+    },
+    [analysisNodes, setSelected],
+  );
+
+  if (effectiveViewMode === '3d') {
+    return (
+      <div className="map-analysis-canvas" style={{ position: 'relative' }}>
+        <Base3DMap
+          center={center}
+          zoom={zoom}
+          basemap={basemap3D}
+          terrainTileUrl={terrainTileUrl}
+          nodes={node3DFeatures}
+          onNodeClick={handleNode3DClick}
+        />
+        {basemap3D.usedFallback && (
+          <div className="map-analysis-3d-fallback-note">
+            Showing default basemap in 3D — the selected map style is vector-only
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="map-analysis-canvas" style={{ position: 'relative' }}>

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -141,6 +141,10 @@ export default function MapAnalysisCanvas() {
     },
     [analysisNodes, setSelected],
   );
+  // WebGL unavailable on this machine (probe failed or map construction
+  // threw): Base3DMap renders its own fallback message, but we also route
+  // the user back to the working 2D map so they aren't stranded in 3D mode.
+  const handle3DUnsupported = useCallback(() => setViewMode('2d'), [setViewMode]);
 
   if (effectiveViewMode === '3d') {
     return (
@@ -152,6 +156,7 @@ export default function MapAnalysisCanvas() {
           terrainTileUrl={terrainTileUrl}
           nodes={node3DFeatures}
           onNodeClick={handleNode3DClick}
+          onUnsupported={handle3DUnsupported}
         />
         {basemap3D.usedFallback && (
           <div className="map-analysis-3d-fallback-note">

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -27,6 +27,13 @@ export interface SelectedTarget {
   avgSnr?: number | null;
 }
 
+/**
+ * `CtxShape` inherits `config.viewMode` / `setViewMode` (2D vs 3D map
+ * rendering on Map Analysis, #3826 Phase 2) automatically via
+ * `ReturnType<typeof useMapAnalysisConfig>` below, the same way
+ * `config.followMode` / `setFollowMode` already do — no extra field needed
+ * here; the `...config` spread in `MapAnalysisProvider` carries it through.
+ */
 type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
   selected: SelectedTarget | null;
   setSelected: (s: SelectedTarget | null) => void;

--- a/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
@@ -22,6 +22,14 @@ vi.mock('../../hooks/useElevationEnabled', () => ({
   useElevationEnabled: () => elevationEnabled,
 }));
 
+// #3826 Phase 2 WP-D: 2D/3D toggle gate. Mutable per-test (mirrors the
+// `elevationEnabled` mock above) so the same factory serves every
+// enabled/disabled/loading combination.
+let terrainCapabilities = { enabled: true, terrainTiles: true, isLoading: false };
+vi.mock('../../hooks/useTerrainCapabilities', () => ({
+  useTerrainCapabilities: () => terrainCapabilities,
+}));
+
 // Two positioned nodes so `analysisNodes.length >= 2` (both Measure and Link
 // Profile buttons require this to enable). Empty by default so the existing
 // "0 nodes" tests above keep exercising the disabled state.
@@ -43,6 +51,7 @@ describe('MapAnalysisToolbar', () => {
     localStorage.clear();
     elevationEnabled = true;
     unifiedNodes = [];
+    terrainCapabilities = { enabled: true, terrainTiles: true, isLoading: false };
   });
 
   it('renders all 7 layer toggles', () => {
@@ -136,6 +145,66 @@ describe('MapAnalysisToolbar', () => {
       fireEvent.click(measureBtn);
       expect(measureBtn).toHaveClass('active');
       expect(linkBtn).not.toHaveClass('active');
+    });
+  });
+
+  // #3826 Phase 2 WP-D: 2D/3D toggle button.
+  describe('3D View toggle', () => {
+    it('is disabled with an "Elevation is disabled" tooltip when elevation is off', () => {
+      terrainCapabilities = { enabled: false, terrainTiles: false, isLoading: false };
+      render(<MapAnalysisToolbar />, { wrapper });
+      const btn = screen.getByRole('button', { name: '3D View' });
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', 'Elevation is disabled');
+    });
+
+    it('is disabled with a configured-elevation-source tooltip when enabled but tiles are unavailable', () => {
+      terrainCapabilities = { enabled: true, terrainTiles: false, isLoading: false };
+      render(<MapAnalysisToolbar />, { wrapper });
+      const btn = screen.getByRole('button', { name: '3D View' });
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute(
+        'title',
+        '3D terrain is unavailable with the configured elevation source',
+      );
+    });
+
+    it('is neutrally disabled (no unavailability tooltip) while capabilities are loading', () => {
+      terrainCapabilities = { enabled: false, terrainTiles: false, isLoading: true };
+      render(<MapAnalysisToolbar />, { wrapper });
+      const btn = screen.getByRole('button', { name: '3D View' });
+      expect(btn).toBeDisabled();
+      expect(btn).not.toHaveAttribute('title', 'Elevation is disabled');
+      expect(btn).not.toHaveAttribute(
+        'title',
+        '3D terrain is unavailable with the configured elevation source',
+      );
+    });
+
+    it('is enabled and toggles viewMode, persisting to localStorage, when capabilities allow it', () => {
+      render(<MapAnalysisToolbar />, { wrapper });
+      const btn = screen.getByRole('button', { name: '3D View' });
+      expect(btn).not.toBeDisabled();
+      expect(btn).not.toHaveClass('active');
+
+      fireEvent.click(btn);
+      expect(btn).toHaveClass('active');
+      const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+      expect(stored.viewMode).toBe('3d');
+
+      fireEvent.click(btn);
+      expect(btn).not.toHaveClass('active');
+      const storedAfter = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+      expect(storedAfter.viewMode).toBe('2d');
+    });
+
+    it('reflects a persisted viewMode of 3d as active on mount', () => {
+      localStorage.setItem(
+        'mapAnalysis.config.v1',
+        JSON.stringify({ version: 1, viewMode: '3d' }),
+      );
+      render(<MapAnalysisToolbar />, { wrapper });
+      expect(screen.getByRole('button', { name: '3D View' })).toHaveClass('active');
     });
   });
 });

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -2,7 +2,7 @@ import { useMemo, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ArrowLeft, LocateFixed, Maximize, Clock, Ruler, Mountain, RotateCcw,
-  MapPin, Palette, Flag, CircleDashed, Radar, Route, Share2, Flame, Spline, Signal,
+  MapPin, Palette, Flag, CircleDashed, Radar, Route, Share2, Flame, Spline, Signal, Box,
 } from 'lucide-react';
 import { useDashboardSources } from '../../hooks/useDashboardData';
 import LayerToggleButton from './LayerToggleButton';
@@ -16,6 +16,7 @@ import { useAnalysisNodes } from './useAnalysisNodes';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { useOwnNodePositions } from '../../hooks/useOwnNodePositions';
 import { useElevationEnabled } from '../../hooks/useElevationEnabled';
+import { useTerrainCapabilities } from '../../hooks/useTerrainCapabilities';
 import { LayerKey } from '../../hooks/useMapAnalysisConfig';
 import {
   usePositions,
@@ -53,6 +54,7 @@ export default function MapAnalysisToolbar() {
     setTimeSlider,
     setFollowMode,
     setAutoZoom,
+    setViewMode,
     measureMode,
     setMeasureMode,
     linkProfileMode,
@@ -61,6 +63,23 @@ export default function MapAnalysisToolbar() {
   } = useMapAnalysisCtx();
   const { data: sources = [] } = useDashboardSources();
   const elevationEnabled = useElevationEnabled();
+  // #3826 Phase 2 WP-D: 2D/3D toggle gating. `useTerrainCapabilities` (not
+  // `useElevationEnabled`) because the toggle must also distinguish a
+  // configured JSON elevation source (no DEM tiles available) from the
+  // simple enabled/disabled flag the Link Profile button above uses.
+  const terrainCaps = useTerrainCapabilities();
+  const threeDUnavailableReason = terrainCaps.isLoading
+    ? null
+    : !terrainCaps.enabled
+      ? 'Elevation is disabled'
+      : !terrainCaps.terrainTiles
+        ? '3D terrain is unavailable with the configured elevation source'
+        : null;
+  const threeDDisabled = terrainCaps.isLoading || threeDUnavailableReason !== null;
+  const threeDTitle = threeDUnavailableReason
+    ?? (terrainCaps.isLoading
+      ? 'Checking 3D availability…'
+      : config.viewMode === '3d' ? 'Switch to 2D map' : 'Switch to 3D map (pitched terrain)');
 
   // Node picker (issue #3788): deduped/sorted options built from the same
   // shared node hook the markers layer uses, so the picker never lists a node
@@ -180,6 +199,20 @@ export default function MapAnalysisToolbar() {
         aria-label="Time Slider"
       >
         <Clock size={ICON} />
+      </button>
+      {/* #3826 Phase 2 WP-D: 2D/3D toggle. Disabled with a tooltip when the
+          server can't serve DEM terrain tiles (elevation disabled, or a
+          configured JSON elevation source — spec §3.11); neutral-disabled
+          while the capabilities check is in flight. */}
+      <button
+        type="button"
+        className={`map-analysis-layer-btn icon-only ${config.viewMode === '3d' ? 'active' : ''}`}
+        onClick={() => setViewMode(config.viewMode === '3d' ? '2d' : '3d')}
+        disabled={threeDDisabled}
+        title={threeDTitle}
+        aria-label="3D View"
+      >
+        <Box size={ICON} />
       </button>
       {/* #3636: node-to-node LOS distance measurement tool. Disabled until at
           least two positioned nodes exist, matching the "Features"-panel maps. */}

--- a/src/components/map/Base3DMap.css
+++ b/src/components/map/Base3DMap.css
@@ -40,3 +40,19 @@
   min-width: 2.5em;
   text-align: right;
 }
+
+/* Centered fallback shown when WebGL is unavailable (probe failed or the
+   maplibre Map constructor threw) — the caller is expected to route back to
+   2D via onUnsupported, but this keeps the pane meaningful either way. */
+.base-3d-map-unsupported {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  font-size: 0.9rem;
+}

--- a/src/components/map/Base3DMap.css
+++ b/src/components/map/Base3DMap.css
@@ -1,0 +1,42 @@
+/* #3826 Phase 2 WP-C: Base3DMap overlay controls (exaggeration slider). The
+   MapLibre canvas itself is unstyled here — MapLibre ships its own CSS via
+   'maplibre-gl/dist/maplibre-gl.css' (imported in Base3DMap.tsx). */
+.base-3d-map {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.base-3d-map-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.base-3d-map-exaggeration {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.base-3d-map-exaggeration label {
+  white-space: nowrap;
+}
+
+.base-3d-map-exaggeration input[type='range'] {
+  width: 100px;
+}
+
+.base-3d-map-exaggeration span {
+  min-width: 2.5em;
+  text-align: right;
+}

--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act } from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { act, StrictMode } from 'react';
+import { render, fireEvent, cleanup, screen } from '@testing-library/react';
 import { Base3DMap, type Node3DFeature } from './Base3DMap';
 import type { Basemap3DSource } from '../../config/basemap3d';
 
@@ -22,6 +22,8 @@ type Listener = (...args: unknown[]) => void;
 const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(() => {
   class FakeMap {
     static instances: FakeMap[] = [];
+    /** When true, the constructor throws like a real WebGL-init failure. */
+    static throwOnConstruct = false;
     options: any;
     handlers: Record<string, Listener> = {};
     layerHandlers: Record<string, Listener> = {};
@@ -51,6 +53,9 @@ const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(()
     });
 
     constructor(options: any) {
+      if (FakeMap.throwOnConstruct) {
+        throw new Error('Failed to initialize WebGL');
+      }
       this.options = options;
       FakeMap.instances.push(this);
     }
@@ -116,12 +121,22 @@ function currentFakeMap(): InstanceType<typeof FakeMap> {
   return m;
 }
 
+// jsdom has no WebGL: HTMLCanvasElement#getContext('webgl'/'webgl2') returns
+// null, which would trip the component's availability probe in every test.
+// Default the probe to "available"; the WebGL-unavailable suite overrides it.
+let getContextSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   FakeMap.instances = [];
+  FakeMap.throwOnConstruct = false;
+  getContextSpy = vi
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockReturnValue({} as unknown as RenderingContext);
 });
 
 afterEach(() => {
   cleanup();
+  getContextSpy.mockRestore();
 });
 
 describe('Base3DMap', () => {
@@ -260,5 +275,80 @@ describe('Base3DMap', () => {
     const call = nodesSource.setData.mock.calls[0][0];
     expect(call.features).toHaveLength(3);
     expect(call.features[2].properties.key).toBe('node-3');
+  });
+
+  describe('WebGL unavailable', () => {
+    it('probe failure: no crash, no map constructed, fallback message, onUnsupported once', () => {
+      getContextSpy.mockReturnValue(null);
+      const onUnsupported = vi.fn();
+      expect(() =>
+        render(
+          <Base3DMap
+            center={[40.0, -105.0]}
+            zoom={12}
+            basemap={basemap}
+            terrainTileUrl={terrainTileUrl}
+            nodes={nodes}
+            onUnsupported={onUnsupported}
+          />,
+        ),
+      ).not.toThrow();
+
+      expect(FakeMap.instances).toHaveLength(0);
+      expect(screen.getByTestId('base-3d-map-unsupported')).toHaveTextContent(/requires WebGL/i);
+      expect(onUnsupported).toHaveBeenCalledTimes(1);
+    });
+
+    it('constructor throw (probe passed): no crash, fallback message, onUnsupported once', () => {
+      // Probe stays truthy (belt), but the real context creation fails (braces).
+      FakeMap.throwOnConstruct = true;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const onUnsupported = vi.fn();
+      expect(() =>
+        render(
+          <Base3DMap
+            center={[40.0, -105.0]}
+            zoom={12}
+            basemap={basemap}
+            terrainTileUrl={terrainTileUrl}
+            nodes={nodes}
+            onUnsupported={onUnsupported}
+          />,
+        ),
+      ).not.toThrow();
+
+      expect(FakeMap.instances).toHaveLength(0);
+      expect(screen.getByTestId('base-3d-map-unsupported')).toBeInTheDocument();
+      expect(onUnsupported).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    it('StrictMode double-mount fires onUnsupported exactly once', () => {
+      getContextSpy.mockReturnValue(null);
+      const onUnsupported = vi.fn();
+      render(
+        <StrictMode>
+          <Base3DMap
+            center={[40.0, -105.0]}
+            zoom={12}
+            basemap={basemap}
+            terrainTileUrl={terrainTileUrl}
+            nodes={nodes}
+            onUnsupported={onUnsupported}
+          />
+        </StrictMode>,
+      );
+
+      expect(screen.getByTestId('base-3d-map-unsupported')).toBeInTheDocument();
+      expect(onUnsupported).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no exaggeration slider in the unsupported state', () => {
+      getContextSpy.mockReturnValue(null);
+      render(
+        <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+      );
+      expect(screen.queryByTestId('base-3d-map-exaggeration')).toBeNull();
+    });
   });
 });

--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { Base3DMap, type Node3DFeature } from './Base3DMap';
+import type { Basemap3DSource } from '../../config/basemap3d';
+
+// ---------------------------------------------------------------------------
+// Fake maplibre-gl (spec §4: no real WebGL in jsdom). Records constructor
+// options and on/addSource/addLayer/setTerrain/addControl/getSource/remove
+// calls; `load` is fired manually via `triggerLoad()`.
+// ---------------------------------------------------------------------------
+
+type Listener = (...args: unknown[]) => void;
+
+// `vi.mock` factories are hoisted above the rest of the module, so the
+// classes they reference must be created via `vi.hoisted` rather than plain
+// top-level `class` declarations (which are hoisted but stay in the
+// temporal dead zone until their declaration point).
+const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(() => {
+  class FakeMap {
+    static instances: FakeMap[] = [];
+    options: any;
+    handlers: Record<string, Listener> = {};
+    layerHandlers: Record<string, Listener> = {};
+    sources: Record<string, any> = {};
+    layerIds = new Set<string>();
+    removeCalled = false;
+
+    addControl = vi.fn();
+    addSource = vi.fn((id: string, source: any) => {
+      this.sources[id] = source.type === 'geojson' ? { ...source, setData: vi.fn() } : source;
+    });
+    addLayer = vi.fn((layer: any) => {
+      this.layerIds.add(layer.id);
+    });
+    setTerrain = vi.fn();
+    getSource = vi.fn((id: string) => this.sources[id]);
+    getLayer = vi.fn((id: string) => (this.layerIds.has(id) ? {} : undefined));
+    removeLayer = vi.fn((id: string) => {
+      this.layerIds.delete(id);
+    });
+    removeSource = vi.fn((id: string) => {
+      delete this.sources[id];
+    });
+    getCanvas = vi.fn(() => ({ style: {} as CSSStyleDeclaration }));
+    remove = vi.fn(() => {
+      this.removeCalled = true;
+    });
+
+    constructor(options: any) {
+      this.options = options;
+      FakeMap.instances.push(this);
+    }
+
+    on(type: string, arg2: unknown, arg3?: Listener) {
+      if (typeof arg2 === 'function') {
+        this.handlers[type] = arg2 as Listener;
+      } else if (typeof arg3 === 'function') {
+        this.layerHandlers[`${type}:${String(arg2)}`] = arg3;
+      }
+      return this;
+    }
+
+    triggerLoad() {
+      this.handlers.load?.();
+    }
+  }
+
+  class FakeNavigationControl {
+    options: unknown;
+    constructor(options: unknown) {
+      this.options = options;
+    }
+  }
+
+  class FakeAttributionControl {
+    options: unknown;
+    constructor(options: unknown) {
+      this.options = options;
+    }
+  }
+
+  return { FakeMap, FakeNavigationControl, FakeAttributionControl };
+});
+
+vi.mock('maplibre-gl', () => ({
+  default: {
+    Map: FakeMap,
+    NavigationControl: FakeNavigationControl,
+    AttributionControl: FakeAttributionControl,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+
+const basemap: Basemap3DSource = {
+  tiles: ['https://a.tile.osm.example/{z}/{x}/{y}.png'],
+  attribution: 'OSM contributors',
+  maxZoom: 19,
+  usedFallback: false,
+};
+
+const terrainTileUrl = '/api/elevation/tiles/{z}/{x}/{y}';
+
+const nodes: Node3DFeature[] = [
+  { key: 'node-1', lat: 40.0, lng: -105.0, label: 'N1' },
+  { key: 'node-2', lat: 40.1, lng: -105.1, label: 'N2' },
+];
+
+function currentFakeMap(): InstanceType<typeof FakeMap> {
+  const m = FakeMap.instances[FakeMap.instances.length - 1];
+  if (!m) throw new Error('no FakeMap instance constructed');
+  return m;
+}
+
+beforeEach(() => {
+  FakeMap.instances = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Base3DMap', () => {
+  it('constructs the map with lng/lat-converted center, zoom, and basemap tiles', () => {
+    render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    // MapLibre takes [lng, lat]; the prop is [lat, lng].
+    expect(map.options.center).toEqual([-105.0, 40.0]);
+    expect(map.options.zoom).toBe(12);
+    expect(map.options.style.sources['basemap-raster'].tiles).toEqual(basemap.tiles);
+  });
+
+  it('adds raster-dem terrain, hillshade, and node layers on load', () => {
+    render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+
+    expect(map.addSource).toHaveBeenCalledWith(
+      'terrain-dem',
+      expect.objectContaining({ type: 'raster-dem', tiles: [terrainTileUrl], encoding: 'terrarium' }),
+    );
+    expect(map.setTerrain).toHaveBeenCalledWith({ source: 'terrain-dem', exaggeration: 1.3 });
+    expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'terrain-hillshade', type: 'hillshade' }));
+    expect(map.addSource).toHaveBeenCalledWith('nodes', expect.objectContaining({ type: 'geojson' }));
+    expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-circle', type: 'circle' }));
+    expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-label', type: 'symbol' }));
+  });
+
+  it('calls onNodeClick with the clicked feature key', () => {
+    const onNodeClick = vi.fn();
+    render(
+      <Base3DMap
+        center={[40.0, -105.0]}
+        zoom={12}
+        basemap={basemap}
+        terrainTileUrl={terrainTileUrl}
+        nodes={nodes}
+        onNodeClick={onNodeClick}
+      />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+
+    const clickHandler = map.layerHandlers['click:nodes-circle'];
+    expect(clickHandler).toBeDefined();
+    clickHandler({ features: [{ properties: { key: 'node-1' } }] });
+
+    expect(onNodeClick).toHaveBeenCalledWith('node-1');
+  });
+
+  it('updates terrain exaggeration via setTerrain when the slider changes', () => {
+    const { getByLabelText } = render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+    map.setTerrain.mockClear();
+
+    const slider = getByLabelText('Terrain exaggeration') as HTMLInputElement;
+    fireEvent.change(slider, { target: { value: '1.8' } });
+
+    expect(map.setTerrain).toHaveBeenCalledWith({ source: 'terrain-dem', exaggeration: 1.8 });
+  });
+
+  it('calls map.remove() on unmount', () => {
+    const { unmount } = render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+
+    unmount();
+
+    expect(map.remove).toHaveBeenCalled();
+  });
+
+  it('is StrictMode-safe: double-mount/unmount leaves no dangling map', () => {
+    const { unmount } = render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    // Simulate React 19 StrictMode's dev double-invoke of the mount effect
+    // by unmounting and remounting: each mount must get a fresh map and
+    // each unmount must tear its own down cleanly (no shared/leaked state).
+    const firstMap = currentFakeMap();
+    unmount();
+    expect(firstMap.remove).toHaveBeenCalledTimes(1);
+
+    const second = render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const secondMap = currentFakeMap();
+    expect(secondMap).not.toBe(firstMap);
+    second.unmount();
+    expect(secondMap.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('patches the nodes source data when the nodes prop changes', () => {
+    const { rerender } = render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+
+    // The nodes-sync effect also runs once `loaded` flips true (source was
+    // just created with the initial data) — clear that call so the
+    // assertion below isolates the prop-change-triggered update.
+    const nodesSource = map.getSource('nodes');
+    nodesSource.setData.mockClear();
+
+    const updatedNodes: Node3DFeature[] = [...nodes, { key: 'node-3', lat: 40.2, lng: -105.2, label: 'N3' }];
+    rerender(
+      <Base3DMap
+        center={[40.0, -105.0]}
+        zoom={12}
+        basemap={basemap}
+        terrainTileUrl={terrainTileUrl}
+        nodes={updatedNodes}
+      />,
+    );
+
+    expect(nodesSource.setData).toHaveBeenCalledTimes(1);
+    const call = nodesSource.setData.mock.calls[0][0];
+    expect(call.features).toHaveLength(3);
+    expect(call.features[2].properties.key).toBe('node-3');
+  });
+});

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -1,0 +1,280 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import type { Basemap3DSource } from '../../config/basemap3d';
+import './Base3DMap.css';
+
+/** A single node marker fed into the MapLibre `nodes` GeoJSON source. */
+export interface Node3DFeature {
+  key: string;
+  lat: number;
+  lng: number;
+  label?: string;
+  color?: string;
+}
+
+export interface Base3DMapProps {
+  /** Initial center, [lat, lng] (converted to MapLibre's [lng, lat] internally). */
+  center: [number, number];
+  /** Initial zoom. */
+  zoom: number;
+  /** Raster basemap source, from `resolve3DBasemap`. */
+  basemap: Basemap3DSource;
+  /** Same-origin DEM tile URL template, from `buildTerrainTileUrl`. */
+  terrainTileUrl: string;
+  /** Node markers to render as a GeoJSON `circle` + `symbol` label layer. */
+  nodes: Node3DFeature[];
+  /** Fired when a node's circle marker is clicked, with its `key`. */
+  onNodeClick?: (key: string) => void;
+  className?: string;
+}
+
+const BASEMAP_SOURCE_ID = 'basemap-raster';
+const BASEMAP_LAYER_ID = 'basemap-raster-layer';
+const TERRAIN_SOURCE_ID = 'terrain-dem';
+const HILLSHADE_LAYER_ID = 'terrain-hillshade';
+const NODES_SOURCE_ID = 'nodes';
+const NODES_CIRCLE_LAYER_ID = 'nodes-circle';
+const NODES_LABEL_LAYER_ID = 'nodes-label';
+
+const ELEVATION_ATTRIBUTION = 'Elevation: Mapzen / AWS Terrain Tiles';
+const INITIAL_PITCH = 60;
+const DEFAULT_EXAGGERATION = 1.3;
+const EXAGGERATION_MIN = 0;
+const EXAGGERATION_MAX = 2;
+const EXAGGERATION_STEP = 0.1;
+
+/** Build a GeoJSON FeatureCollection from the `nodes` prop for the `nodes` source. */
+function toNodesFeatureCollection(nodes: Node3DFeature[]): GeoJSON.FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: nodes.map((n) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [n.lng, n.lat] },
+      properties: { key: n.key, label: n.label ?? '', color: n.color ?? '#3fb1ce' },
+    })),
+  };
+}
+
+/**
+ * Generic MapLibre GL 3D map surface (#3826 Phase 2 WP-C, spec §3.9).
+ *
+ * Map-Analysis-agnostic: all data comes in via props (`nodes`, `basemap`,
+ * `terrainTileUrl`) and the only outbound signal is `onNodeClick`. Wraps
+ * `maplibregl.Map` directly (not the Leaflet MapLibre adapter used by
+ * `VectorTileLayer` — that embeds MapLibre *inside* Leaflet for 2D vector
+ * tiles, the opposite of what a genuinely 3D/pitched surface needs).
+ *
+ * Lifecycle (spec §2.12): the `maplibregl.Map` is created once in a
+ * mount-effect and destroyed via `map.remove()` in its cleanup, held in a
+ * ref so the create/remove pair is symmetric — safe under React 19
+ * StrictMode's dev double-mount (mount→unmount→mount leaves no dangling
+ * WebGL context). `basemap`/`nodes`/exaggeration changes mutate the
+ * existing map in separate effects rather than remounting it.
+ *
+ * Basemap-identity changes: this implementation removes and re-adds the
+ * raster source/layer in place (simplest correct approach — MapLibre has
+ * no "swap a raster source's tiles" primitive short of `removeSource`
+ * followed by `addSource`, and raster sources are cheap to recreate,
+ * unlike the terrain/hillshade/node layers which persist). The map itself
+ * is never recreated.
+ */
+export function Base3DMap({
+  center,
+  zoom,
+  basemap,
+  terrainTileUrl,
+  nodes,
+  onNodeClick,
+  className,
+}: Base3DMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [exaggeration, setExaggeration] = useState(DEFAULT_EXAGGERATION);
+
+  // Latest props, readable from stable callbacks (click handler, basemap sync)
+  // without adding them as effect deps that would force a map/layer rebuild.
+  const onNodeClickRef = useRef(onNodeClick);
+  onNodeClickRef.current = onNodeClick;
+
+  // ---- Mount / unmount: create the map exactly once ------------------------
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const map = new maplibregl.Map({
+      container,
+      style: {
+        version: 8,
+        sources: {
+          [BASEMAP_SOURCE_ID]: {
+            type: 'raster',
+            tiles: basemap.tiles,
+            tileSize: 256,
+            maxzoom: basemap.maxZoom,
+            attribution: basemap.attribution,
+          },
+        },
+        layers: [
+          {
+            id: BASEMAP_LAYER_ID,
+            type: 'raster',
+            source: BASEMAP_SOURCE_ID,
+          },
+        ],
+      },
+      center: [center[1], center[0]],
+      zoom,
+      pitch: INITIAL_PITCH,
+      attributionControl: false,
+    });
+    mapRef.current = map;
+
+    map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), 'top-right');
+    map.addControl(
+      new maplibregl.AttributionControl({
+        compact: true,
+        customAttribution: [basemap.attribution, ELEVATION_ATTRIBUTION],
+      }),
+      'bottom-right',
+    );
+
+    map.on('load', () => {
+      map.addSource(TERRAIN_SOURCE_ID, {
+        type: 'raster-dem',
+        tiles: [terrainTileUrl],
+        tileSize: 256,
+        maxzoom: 15,
+        encoding: 'terrarium',
+        attribution: ELEVATION_ATTRIBUTION,
+      });
+      map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration: DEFAULT_EXAGGERATION });
+      map.addLayer({
+        id: HILLSHADE_LAYER_ID,
+        type: 'hillshade',
+        source: TERRAIN_SOURCE_ID,
+      });
+
+      map.addSource(NODES_SOURCE_ID, {
+        type: 'geojson',
+        data: toNodesFeatureCollection(nodes),
+      });
+      map.addLayer({
+        id: NODES_CIRCLE_LAYER_ID,
+        type: 'circle',
+        source: NODES_SOURCE_ID,
+        paint: {
+          'circle-radius': 6,
+          'circle-color': ['get', 'color'],
+          'circle-stroke-width': 1.5,
+          'circle-stroke-color': '#ffffff',
+        },
+      });
+      map.addLayer({
+        id: NODES_LABEL_LAYER_ID,
+        type: 'symbol',
+        source: NODES_SOURCE_ID,
+        layout: {
+          'text-field': ['get', 'label'],
+          'text-size': 11,
+          'text-offset': [0, 1.2],
+          'text-anchor': 'top',
+        },
+        paint: {
+          'text-color': '#f8fafc',
+          'text-halo-color': '#0f172a',
+          'text-halo-width': 1,
+        },
+      });
+
+      map.on('click', NODES_CIRCLE_LAYER_ID, (e) => {
+        const feature = e.features?.[0];
+        const key = feature?.properties?.key;
+        if (typeof key === 'string') {
+          onNodeClickRef.current?.(key);
+        }
+      });
+      map.on('mouseenter', NODES_CIRCLE_LAYER_ID, () => {
+        map.getCanvas().style.cursor = 'pointer';
+      });
+      map.on('mouseleave', NODES_CIRCLE_LAYER_ID, () => {
+        map.getCanvas().style.cursor = '';
+      });
+
+      setLoaded(true);
+    });
+
+    return () => {
+      setLoaded(false);
+      map.remove();
+      mapRef.current = null;
+    };
+    // Mount-once: center/zoom are applied only at construction (BaseMap
+    // convention, see BaseMap.tsx), basemap/terrainTileUrl identity changes
+    // are handled by the dedicated effects below rather than remounting.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- Basemap identity change: recreate the raster source in place --------
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loaded) return;
+    if (map.getLayer(BASEMAP_LAYER_ID)) map.removeLayer(BASEMAP_LAYER_ID);
+    if (map.getSource(BASEMAP_SOURCE_ID)) map.removeSource(BASEMAP_SOURCE_ID);
+    map.addSource(BASEMAP_SOURCE_ID, {
+      type: 'raster',
+      tiles: basemap.tiles,
+      tileSize: 256,
+      maxzoom: basemap.maxZoom,
+      attribution: basemap.attribution,
+    });
+    // Re-insert below the hillshade layer so terrain shading stays on top.
+    map.addLayer(
+      { id: BASEMAP_LAYER_ID, type: 'raster', source: BASEMAP_SOURCE_ID },
+      map.getLayer(HILLSHADE_LAYER_ID) ? HILLSHADE_LAYER_ID : undefined,
+    );
+  }, [basemap, loaded]);
+
+  // ---- Node data change: patch the GeoJSON source's data -------------------
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loaded) return;
+    const source = map.getSource(NODES_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
+    source?.setData(toNodesFeatureCollection(nodes));
+  }, [nodes, loaded]);
+
+  // ---- Exaggeration slider ---------------------------------------------------
+  const handleExaggerationChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = Number(e.target.value);
+      setExaggeration(value);
+      const map = mapRef.current;
+      if (map && loaded) {
+        map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration: value });
+      }
+    },
+    [loaded],
+  );
+
+  return (
+    <div className={`base-3d-map ${className ?? ''}`.trim()}>
+      <div ref={containerRef} className="base-3d-map-canvas" data-testid="base-3d-map-canvas" />
+      <div className="base-3d-map-exaggeration" data-testid="base-3d-map-exaggeration">
+        <label htmlFor="base-3d-map-exaggeration-input">Terrain exaggeration</label>
+        <input
+          id="base-3d-map-exaggeration-input"
+          type="range"
+          min={EXAGGERATION_MIN}
+          max={EXAGGERATION_MAX}
+          step={EXAGGERATION_STEP}
+          value={exaggeration}
+          onChange={handleExaggerationChange}
+        />
+        <span>{exaggeration.toFixed(1)}x</span>
+      </div>
+    </div>
+  );
+}
+
+export default Base3DMap;

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -26,6 +26,14 @@ export interface Base3DMapProps {
   nodes: Node3DFeature[];
   /** Fired when a node's circle marker is clicked, with its `key`. */
   onNodeClick?: (key: string) => void;
+  /**
+   * Fired at most once per component instance when WebGL is unavailable and
+   * the 3D map cannot be constructed (probe failed or the maplibre Map
+   * constructor threw). Callers should switch the user back to a working 2D
+   * view; the component itself renders a non-crashing fallback message
+   * either way.
+   */
+  onUnsupported?: () => void;
   className?: string;
 }
 
@@ -43,6 +51,20 @@ const DEFAULT_EXAGGERATION = 1.3;
 const EXAGGERATION_MIN = 0;
 const EXAGGERATION_MAX = 2;
 const EXAGGERATION_STEP = 0.1;
+
+/**
+ * Cheap WebGL availability probe. A passing probe does NOT guarantee the
+ * real map context succeeds (driver blocklists, exhausted contexts), so the
+ * `new maplibregl.Map` call is additionally try/caught — belt and braces.
+ */
+function isWebGlAvailable(): boolean {
+  try {
+    const canvas = document.createElement('canvas');
+    return Boolean(canvas.getContext('webgl2') || canvas.getContext('webgl'));
+  } catch {
+    return false;
+  }
+}
 
 /** Build a GeoJSON FeatureCollection from the `nodes` prop for the `nodes` source. */
 function toNodesFeatureCollection(nodes: Node3DFeature[]): GeoJSON.FeatureCollection {
@@ -86,49 +108,79 @@ export function Base3DMap({
   terrainTileUrl,
   nodes,
   onNodeClick,
+  onUnsupported,
   className,
 }: Base3DMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [webglUnavailable, setWebglUnavailable] = useState(false);
   const [exaggeration, setExaggeration] = useState(DEFAULT_EXAGGERATION);
 
   // Latest props, readable from stable callbacks (click handler, basemap sync)
   // without adding them as effect deps that would force a map/layer rebuild.
   const onNodeClickRef = useRef(onNodeClick);
   onNodeClickRef.current = onNodeClick;
+  const onUnsupportedRef = useRef(onUnsupported);
+  onUnsupportedRef.current = onUnsupported;
+  // Notify-once guard: refs survive StrictMode's dev double-mount (the same
+  // component instance is remounted with state/refs preserved), so
+  // `onUnsupported` fires exactly once even when the mount effect runs twice.
+  const unsupportedNotifiedRef = useRef(false);
 
   // ---- Mount / unmount: create the map exactly once ------------------------
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    const map = new maplibregl.Map({
-      container,
-      style: {
-        version: 8,
-        sources: {
-          [BASEMAP_SOURCE_ID]: {
-            type: 'raster',
-            tiles: basemap.tiles,
-            tileSize: 256,
-            maxzoom: basemap.maxZoom,
-            attribution: basemap.attribution,
+    const markUnsupported = () => {
+      setWebglUnavailable(true);
+      if (!unsupportedNotifiedRef.current) {
+        unsupportedNotifiedRef.current = true;
+        onUnsupportedRef.current?.();
+      }
+    };
+
+    if (!isWebGlAvailable()) {
+      markUnsupported();
+      return;
+    }
+
+    let map: maplibregl.Map;
+    try {
+      map = new maplibregl.Map({
+        container,
+        style: {
+          version: 8,
+          sources: {
+            [BASEMAP_SOURCE_ID]: {
+              type: 'raster',
+              tiles: basemap.tiles,
+              tileSize: 256,
+              maxzoom: basemap.maxZoom,
+              attribution: basemap.attribution,
+            },
           },
+          layers: [
+            {
+              id: BASEMAP_LAYER_ID,
+              type: 'raster',
+              source: BASEMAP_SOURCE_ID,
+            },
+          ],
         },
-        layers: [
-          {
-            id: BASEMAP_LAYER_ID,
-            type: 'raster',
-            source: BASEMAP_SOURCE_ID,
-          },
-        ],
-      },
-      center: [center[1], center[0]],
-      zoom,
-      pitch: INITIAL_PITCH,
-      attributionControl: false,
-    });
+        center: [center[1], center[0]],
+        zoom,
+        pitch: INITIAL_PITCH,
+        attributionControl: false,
+      });
+    } catch (err) {
+      // Real case: the probe can pass while the actual context creation still
+      // fails ("Failed to initialize WebGL") — degrade instead of crashing.
+      console.warn('Base3DMap: WebGL map construction failed', err);
+      markUnsupported();
+      return;
+    }
     mapRef.current = map;
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), 'top-right');
@@ -260,19 +312,25 @@ export function Base3DMap({
   return (
     <div className={`base-3d-map ${className ?? ''}`.trim()}>
       <div ref={containerRef} className="base-3d-map-canvas" data-testid="base-3d-map-canvas" />
-      <div className="base-3d-map-exaggeration" data-testid="base-3d-map-exaggeration">
-        <label htmlFor="base-3d-map-exaggeration-input">Terrain exaggeration</label>
-        <input
-          id="base-3d-map-exaggeration-input"
-          type="range"
-          min={EXAGGERATION_MIN}
-          max={EXAGGERATION_MAX}
-          step={EXAGGERATION_STEP}
-          value={exaggeration}
-          onChange={handleExaggerationChange}
-        />
-        <span>{exaggeration.toFixed(1)}x</span>
-      </div>
+      {webglUnavailable ? (
+        <div className="base-3d-map-unsupported" data-testid="base-3d-map-unsupported" role="alert">
+          3D view requires WebGL, which is not available in this browser
+        </div>
+      ) : (
+        <div className="base-3d-map-exaggeration" data-testid="base-3d-map-exaggeration">
+          <label htmlFor="base-3d-map-exaggeration-input">Terrain exaggeration</label>
+          <input
+            id="base-3d-map-exaggeration-input"
+            type="range"
+            min={EXAGGERATION_MIN}
+            max={EXAGGERATION_MAX}
+            step={EXAGGERATION_STEP}
+            value={exaggeration}
+            onChange={handleExaggerationChange}
+          />
+          <span>{exaggeration.toFixed(1)}x</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/config/basemap3d.test.ts
+++ b/src/config/basemap3d.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { expandSubdomains, resolve3DBasemap, buildTerrainTileUrl } from './basemap3d';
+import { TILESETS, type CustomTileset } from './tilesets';
+
+describe('expandSubdomains', () => {
+  it('expands {s} into a,b,c subdomain URLs', () => {
+    const result = expandSubdomains('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+    expect(result).toEqual([
+      'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    ]);
+  });
+
+  it('returns a single-element array when {s} is absent', () => {
+    const url = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+    expect(expandSubdomains(url)).toEqual([url]);
+  });
+});
+
+describe('resolve3DBasemap', () => {
+  it('passes a predefined raster tileset through unchanged (osm)', () => {
+    const result = resolve3DBasemap('osm', []);
+    expect(result.usedFallback).toBe(false);
+    expect(result.attribution).toBe(TILESETS.osm.attribution);
+    expect(result.maxZoom).toBe(TILESETS.osm.maxZoom);
+    expect(result.tiles).toEqual([
+      'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    ]);
+  });
+
+  it('passes a predefined raster tileset without {s} through unchanged (esriSatellite)', () => {
+    const result = resolve3DBasemap('esriSatellite', []);
+    expect(result.usedFallback).toBe(false);
+    expect(result.tiles).toEqual([TILESETS.esriSatellite.url]);
+  });
+
+  it('falls back to osm for a custom vector-only tileset', () => {
+    const custom: CustomTileset[] = [
+      {
+        id: 'custom-vector',
+        name: 'Vector Style',
+        url: 'https://example.com/tiles/{z}/{x}/{y}.pbf',
+        attribution: 'Example',
+        maxZoom: 18,
+        description: 'A vector tileset',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const result = resolve3DBasemap('custom-vector', custom);
+    expect(result.usedFallback).toBe(true);
+    expect(result.attribution).toBe(TILESETS.osm.attribution);
+    expect(result.maxZoom).toBe(TILESETS.osm.maxZoom);
+    expect(result.tiles[0]).toContain('tile.openstreetmap.org');
+  });
+
+  it('falls back to osm for a custom tileset explicitly flagged isVector', () => {
+    const custom: CustomTileset[] = [
+      {
+        id: 'custom-flagged',
+        name: 'Flagged',
+        url: 'https://example.com/tiles/{z}/{x}/{y}',
+        attribution: 'Example',
+        maxZoom: 18,
+        description: 'Flagged vector without a matching extension',
+        createdAt: 1,
+        updatedAt: 1,
+        isVector: true,
+      },
+    ];
+    const result = resolve3DBasemap('custom-flagged', custom);
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it('passes a custom raster tileset through unchanged', () => {
+    const custom: CustomTileset[] = [
+      {
+        id: 'custom-raster',
+        name: 'Raster Style',
+        url: 'https://example.com/tiles/{z}/{x}/{y}.png',
+        attribution: 'Example Attribution',
+        maxZoom: 16,
+        description: 'A raster tileset',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const result = resolve3DBasemap('custom-raster', custom);
+    expect(result.usedFallback).toBe(false);
+    expect(result.attribution).toBe('Example Attribution');
+    expect(result.maxZoom).toBe(16);
+    expect(result.tiles).toEqual(['https://example.com/tiles/{z}/{x}/{y}.png']);
+  });
+
+  it('falls back to the default tileset (osm) for an unknown tileset id', () => {
+    const result = resolve3DBasemap('does-not-exist', []);
+    expect(result.usedFallback).toBe(false);
+    expect(result.attribution).toBe(TILESETS.osm.attribution);
+  });
+});
+
+describe('buildTerrainTileUrl', () => {
+  it('builds the tile URL template with an empty base path (root deployment)', () => {
+    expect(buildTerrainTileUrl('')).toBe('/api/elevation/tiles/{z}/{x}/{y}');
+  });
+
+  it('joins a base path without a trailing slash', () => {
+    expect(buildTerrainTileUrl('/meshmonitor')).toBe('/meshmonitor/api/elevation/tiles/{z}/{x}/{y}');
+  });
+
+  it('normalizes a base path with a trailing slash', () => {
+    expect(buildTerrainTileUrl('/meshmonitor/')).toBe('/meshmonitor/api/elevation/tiles/{z}/{x}/{y}');
+  });
+});

--- a/src/config/basemap3d.ts
+++ b/src/config/basemap3d.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure, react-free helpers for resolving the 3D (MapLibre GL) basemap from
+ * the app's existing 2D (Leaflet) tileset config (#3826 Phase 2 WP-B, spec
+ * §2.7 / §2.14).
+ *
+ * MapLibre raster sources differ from Leaflet `TileLayer` in two ways that
+ * matter here:
+ *  - MapLibre has no `{s}` subdomain placeholder — Leaflet-style URLs using
+ *    it (`osm`/`osmHot`/`carto*`/`openTopo`) must be expanded into an
+ *    explicit `tiles[]` array, one entry per subdomain.
+ *  - MapLibre raster sources cannot render a vector (`.pbf`/`.mvt`) tileset
+ *    without a full style JSON (out of scope this phase) — vector-only
+ *    tilesets fall back to the default `osm` raster basemap for 3D only;
+ *    the 2D view is unaffected.
+ */
+import { getTilesetById, TILESETS, type TilesetId, type CustomTileset } from './tilesets';
+
+export interface Basemap3DSource {
+  tiles: string[];
+  attribution: string;
+  maxZoom: number;
+  /** True when the requested tileset was vector-only and we substituted `osm`. */
+  usedFallback: boolean;
+}
+
+/** Leaflet subdomains conventionally used by `{s}`-templated tile hosts. */
+const SUBDOMAINS = ['a', 'b', 'c'];
+
+/**
+ * Expand a Leaflet `{s}` subdomain placeholder into an explicit list of
+ * URLs (one per subdomain) for MapLibre's `tiles[]` array. URLs without
+ * `{s}` are returned unchanged as a single-element array.
+ */
+export function expandSubdomains(url: string): string[] {
+  if (!url.includes('{s}')) return [url];
+  return SUBDOMAINS.map((s) => url.replace('{s}', s));
+}
+
+/**
+ * Resolve the raster basemap source to feed a MapLibre GL map from the
+ * user's current 2D tileset selection. Vector-only tilesets (predefined or
+ * custom) fall back to `TILESETS.osm` with `usedFallback: true` so callers
+ * can surface a non-blocking note.
+ */
+export function resolve3DBasemap(tilesetId: TilesetId, custom: CustomTileset[] = []): Basemap3DSource {
+  const tileset = getTilesetById(tilesetId, custom);
+
+  if (tileset.isVector) {
+    const fallback = TILESETS.osm;
+    return {
+      tiles: expandSubdomains(fallback.url),
+      attribution: fallback.attribution,
+      maxZoom: fallback.maxZoom,
+      usedFallback: true,
+    };
+  }
+
+  return {
+    tiles: expandSubdomains(tileset.url),
+    attribution: tileset.attribution,
+    maxZoom: tileset.maxZoom,
+    usedFallback: false,
+  };
+}
+
+/**
+ * Build the same-origin DEM terrain tile URL template honoring the
+ * deployment base path (e.g. `/meshmonitor`, matching `ApiService`'s
+ * `baseUrl` / `import.meta.env.BASE_URL`). `basePath` may be empty (root
+ * deployment), with or without a trailing slash.
+ */
+export function buildTerrainTileUrl(basePath: string): string {
+  const base = basePath.replace(/\/$/, '');
+  return `${base}/api/elevation/tiles/{z}/{x}/{y}`;
+}

--- a/src/hooks/useMapAnalysisConfig.test.ts
+++ b/src/hooks/useMapAnalysisConfig.test.ts
@@ -123,4 +123,38 @@ describe('useMapAnalysisConfig', () => {
     expect(result.current.config.followMode).toBe(false);
     expect(result.current.config.autoZoom).toBe(false);
   });
+
+  it('defaults viewMode to "2d"', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.viewMode).toBe('2d');
+    expect(DEFAULT_CONFIG.viewMode).toBe('2d');
+  });
+
+  it('updates viewMode and persists to localStorage', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setViewMode('3d'));
+    expect(result.current.config.viewMode).toBe('3d');
+    expect(JSON.parse(localStorage.getItem(KEY)!).viewMode).toBe('3d');
+  });
+
+  it('loads an old config missing viewMode as "2d" without throwing (#3826)', () => {
+    const { viewMode: _vm, ...oldConfig } = DEFAULT_CONFIG;
+    localStorage.setItem(KEY, JSON.stringify(oldConfig));
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.viewMode).toBe('2d');
+  });
+
+  it('coerces a garbage viewMode value to "2d"', () => {
+    localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_CONFIG, viewMode: 'not-a-mode' }));
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.viewMode).toBe('2d');
+  });
+
+  it('reset() clears viewMode back to "2d"', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setViewMode('3d'));
+    expect(result.current.config.viewMode).toBe('3d');
+    act(() => result.current.reset());
+    expect(result.current.config.viewMode).toBe('2d');
+  });
 });

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -64,6 +64,8 @@ export interface MapAnalysisConfig {
   followMode: boolean;
   /** Auto-zoom: fit the selected nodes' bounds (+15% margin) each update (issue #3788 P2). */
   autoZoom: boolean;
+  /** 2D (Leaflet) vs 3D (MapLibre GL) map rendering on Map Analysis (#3826 Phase 2). */
+  viewMode: '2d' | '3d';
 }
 
 const ALL_NODE_TYPES_VISIBLE = Object.fromEntries(
@@ -92,6 +94,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
   selectedNodeIds: [],
   followMode: false,
   autoZoom: false,
+  viewMode: '2d',
 };
 
 /** Read the traceroute options off a config, layering stored values over defaults. */
@@ -120,6 +123,7 @@ function load(): MapAnalysisConfig {
       selectedNodeIds: Array.isArray(parsed.selectedNodeIds) ? parsed.selectedNodeIds : [],
       followMode: typeof parsed.followMode === 'boolean' ? parsed.followMode : false,
       autoZoom: typeof parsed.autoZoom === 'boolean' ? parsed.autoZoom : false,
+      viewMode: parsed.viewMode === '3d' ? '3d' : DEFAULT_CONFIG.viewMode,
     };
   } catch {
     return DEFAULT_CONFIG;
@@ -198,6 +202,10 @@ export function useMapAnalysisConfig() {
     setConfig((prev) => ({ ...prev, autoZoom: v }));
   }, []);
 
+  const setViewMode = useCallback((v: MapAnalysisConfig['viewMode']) => {
+    setConfig((prev) => ({ ...prev, viewMode: v }));
+  }, []);
+
   const setTimeSlider = useCallback((ts: Partial<MapAnalysisConfig['timeSlider']>) => {
     setConfig((prev) => ({ ...prev, timeSlider: { ...prev.timeSlider, ...ts } }));
   }, []);
@@ -219,6 +227,7 @@ export function useMapAnalysisConfig() {
     setSelectedNodeIds,
     setFollowMode,
     setAutoZoom,
+    setViewMode,
     setTimeSlider,
     setInspectorOpen,
     reset,

--- a/src/hooks/useTerrainCapabilities.test.tsx
+++ b/src/hooks/useTerrainCapabilities.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useTerrainCapabilities } from './useTerrainCapabilities';
+import apiService from '../services/api';
+
+vi.mock('../services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+describe('useTerrainCapabilities', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the enveloped body.data shape (not the raw body)', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({
+      success: true,
+      data: { enabled: true, terrainTiles: true, provider: 'terrarium' },
+    });
+    const { result } = renderHook(() => useTerrainCapabilities(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.terrainTiles).toBe(true);
+  });
+
+  it('defaults to unavailable (not available) while loading', () => {
+    vi.mocked(apiService.get).mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useTerrainCapabilities(), { wrapper });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.terrainTiles).toBe(false);
+  });
+
+  it('reflects elevation disabled server-side', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({
+      success: true,
+      data: { enabled: false, terrainTiles: false, provider: 'terrarium' },
+    });
+    const { result } = renderHook(() => useTerrainCapabilities(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.terrainTiles).toBe(false);
+  });
+
+  it('reflects a JSON elevation source: enabled but no terrain tiles', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({
+      success: true,
+      data: { enabled: true, terrainTiles: false, provider: 'json' },
+    });
+    const { result } = renderHook(() => useTerrainCapabilities(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.terrainTiles).toBe(false);
+  });
+
+  it('requests /api/elevation/capabilities', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({
+      success: true,
+      data: { enabled: true, terrainTiles: true, provider: 'terrarium' },
+    });
+    renderHook(() => useTerrainCapabilities(), { wrapper });
+    await waitFor(() =>
+      expect(apiService.get).toHaveBeenCalledWith('/api/elevation/capabilities'),
+    );
+  });
+});

--- a/src/hooks/useTerrainCapabilities.ts
+++ b/src/hooks/useTerrainCapabilities.ts
@@ -1,0 +1,54 @@
+/**
+ * Availability + tile-support signal for the 3D map (#3826 Phase 2 WP-B).
+ *
+ * `GET /api/elevation/capabilities` is **enveloped**
+ * (`{success,data}` — `src/server/utils/apiResponse.ts`), unlike
+ * `useElevationEnabled`'s bare `/api/settings` read — this hook must read
+ * `body.data` (the `ApiService.request()` unwrap gotcha).
+ *
+ * Provider type (`terrarium` | `json`) is derived server-side because
+ * `elevationSourceUrl` is a secret setting stripped from `/api/settings`
+ * for non-admins; the capabilities endpoint exposes only the derived
+ * booleans, never the URL.
+ */
+import { useQuery } from '@tanstack/react-query';
+import apiService from '../services/api';
+
+interface ElevationCapabilitiesData {
+  enabled: boolean;
+  terrainTiles: boolean;
+  provider: 'terrarium' | 'json';
+}
+
+export interface TerrainCapabilities {
+  enabled: boolean;
+  terrainTiles: boolean;
+  isLoading: boolean;
+}
+
+/** Safe defaults while loading: treat the toggle as unavailable, not available. */
+const LOADING_DEFAULTS: Omit<TerrainCapabilities, 'isLoading'> = {
+  enabled: false,
+  terrainTiles: false,
+};
+
+export function useTerrainCapabilities(): TerrainCapabilities {
+  const { data, isLoading } = useQuery({
+    queryKey: ['elevation', 'capabilities'],
+    queryFn: () =>
+      apiService.get<{ success: boolean; data: ElevationCapabilitiesData }>(
+        '/api/elevation/capabilities',
+      ),
+    staleTime: 5 * 60_000,
+  });
+
+  if (!data) {
+    return { ...LOADING_DEFAULTS, isLoading };
+  }
+
+  return {
+    enabled: data.data.enabled,
+    terrainTiles: data.data.terrainTiles,
+    isLoading,
+  };
+}

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -182,3 +182,25 @@ export const elevationLimiter = rateLimit({
   },
   ...rateLimitConfig,
 });
+
+// DEM terrain tile proxy (#3826 Phase 2 WP-A) — one call per tile, and a
+// fresh 3D view legitimately fetches dozens on load/pan/zoom, so this is far
+// more generous than `elevationLimiter` (one heavy fan-out per call). Abuse
+// is bounded by the raw-tile LRU + SSRF guard + immutable browser caching +
+// the z/x/y validation cap, not this limiter alone.
+// Default: 600/min (10/s) production, 3000/min development.
+export const elevationTileLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: env.isProduction ? 600 : 3000,
+  message: 'Too many elevation tile requests, please slow down',
+  skip: (req) => isPrivateNetworkIp(req.ip ?? ''),
+  handler: (req, res) => {
+    const ip = req.ip || 'unknown';
+    logger.warn(`🚫 Rate limit exceeded for ELEVATION_TILES - IP: ${ip}, Path: ${req.path}`);
+    res.status(429).json({
+      error: 'Too many elevation tile requests, please slow down',
+      retryAfter: '1 minute'
+    });
+  },
+  ...rateLimitConfig,
+});

--- a/src/server/routes/elevationRoutes.test.ts
+++ b/src/server/routes/elevationRoutes.test.ts
@@ -195,4 +195,125 @@ describe('elevationRoutes', () => {
       expect(res.body.code).toBe('MISSING_URL');
     });
   });
+
+  describe('GET /elevation/capabilities (#3826 Phase 2 WP-A)', () => {
+    it('default settings -> enabled:true, terrainTiles:true, provider:terrarium, enveloped', async () => {
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/capabilities');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual({ enabled: true, terrainTiles: true, provider: 'terrarium' });
+    });
+
+    it('elevationEnabled=false -> enabled:false, terrainTiles:false', async () => {
+      await harness.db.settings.setSetting('elevationEnabled', 'false');
+
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/capabilities');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ enabled: false, terrainTiles: false, provider: 'terrarium' });
+    });
+
+    it('JSON elevationSourceUrl -> terrainTiles:false, provider:json (no URL leak)', async () => {
+      await harness.db.settings.setSetting(
+        'elevationSourceUrl',
+        'https://api.example.com/v1/dem?key=supersecret'
+      );
+
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/capabilities');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ enabled: true, terrainTiles: false, provider: 'json' });
+      expect(JSON.stringify(res.body)).not.toContain('supersecret');
+    });
+
+    it('anonymous request succeeds (public/optionalAuth)', async () => {
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/capabilities');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('GET /elevation/tiles/:z/:x/:y (#3826 Phase 2 WP-A, DEM tile proxy)', () => {
+    it('default provider -> 200, image/png, immutable Cache-Control, anonymous succeeds', async () => {
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/tiles/8/40/96');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/^image\/png/);
+      expect(res.headers['cache-control']).toContain('immutable');
+      expect(res.headers['cache-control']).toContain('public');
+      expect(res.headers['cache-control']).toContain('max-age=604800');
+      expect(res.body.length).toBeGreaterThan(0);
+      expect(mockSafeFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('elevationEnabled=false -> 403 ELEVATION_DISABLED, no-store', async () => {
+      await harness.db.settings.setSetting('elevationEnabled', 'false');
+
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/tiles/8/40/96');
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.code).toBe('ELEVATION_DISABLED');
+      expect(res.headers['cache-control']).toBe('no-store');
+      expect(mockSafeFetch).not.toHaveBeenCalled();
+    });
+
+    it('JSON elevationSourceUrl -> 409 TERRAIN_TILES_UNAVAILABLE, body has no URL/key leak', async () => {
+      const secretUrl = 'https://api.example.com/v1/dem?key=supersecret';
+      await harness.db.settings.setSetting('elevationSourceUrl', secretUrl);
+
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/tiles/8/40/96');
+
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe('TERRAIN_TILES_UNAVAILABLE');
+      expect(JSON.stringify(res.body)).not.toContain('supersecret');
+      expect(JSON.stringify(res.body)).not.toContain(secretUrl);
+      expect(mockSafeFetch).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['/elevation/tiles/99/1/1', 'zoom beyond MAX_TERRARIUM_TILE_ZOOM'],
+      ['/elevation/tiles/8/-1/1', 'negative x'],
+      ['/elevation/tiles/8/1/abc', 'non-numeric y'],
+    ])('invalid coords (%s: %s) -> 400 INVALID_TILE_COORDS', async (path) => {
+      const agent = await harness.loginAs(null);
+      const res = await agent.get(path);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_TILE_COORDS');
+      expect(mockSafeFetch).not.toHaveBeenCalled();
+    });
+
+    it('SSRF-blocked upstream -> 502 TILE_FETCH_FAILED, no key leak, no-store', async () => {
+      // Distinct tile coord — the raw-PNG LRU is module-scoped/shared across
+      // tests in this file, so reusing 8/40/96 would hit the cache warmed by
+      // an earlier test and never reach safeFetch.
+      mockSafeFetch.mockRejectedValueOnce(new MockSsrfBlockedError('blocked: private IP target'));
+
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/tiles/8/41/97');
+
+      expect(res.status).toBe(502);
+      expect(res.body.code).toBe('TILE_FETCH_FAILED');
+      expect(res.headers['cache-control']).toBe('no-store');
+      expect(JSON.stringify(res.body)).not.toContain('private IP target');
+    });
+
+    it('upstream non-OK response -> 502 TILE_FETCH_FAILED', async () => {
+      mockSafeFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/elevation/tiles/8/42/98');
+
+      expect(res.status).toBe(502);
+      expect(res.body.code).toBe('TILE_FETCH_FAILED');
+    });
+  });
 });

--- a/src/server/routes/elevationRoutes.test.ts
+++ b/src/server/routes/elevationRoutes.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PNG } from 'pngjs';
 import elevationRoutes from './elevationRoutes.js';
+import { clearRawTileCacheForTesting } from '../services/elevationProvider.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 
 const mockSafeFetch = vi.hoisted(() => vi.fn());
@@ -73,6 +74,10 @@ describe('elevationRoutes', () => {
     });
     mockSafeFetch.mockReset();
     mockSafeFetch.mockResolvedValue(fakeTileResponse());
+    // The raw-PNG LRU in elevationProvider is module-scoped (shared across
+    // this whole file) — clear it so tile-route tests are isolated regardless
+    // of which z/x/y coordinates they use.
+    clearRawTileCacheForTesting();
   });
 
   afterEach(async () => {
@@ -292,9 +297,6 @@ describe('elevationRoutes', () => {
     });
 
     it('SSRF-blocked upstream -> 502 TILE_FETCH_FAILED, no key leak, no-store', async () => {
-      // Distinct tile coord — the raw-PNG LRU is module-scoped/shared across
-      // tests in this file, so reusing 8/40/96 would hit the cache warmed by
-      // an earlier test and never reach safeFetch.
       mockSafeFetch.mockRejectedValueOnce(new MockSsrfBlockedError('blocked: private IP target'));
 
       const agent = await harness.loginAs(null);

--- a/src/server/routes/elevationRoutes.ts
+++ b/src/server/routes/elevationRoutes.ts
@@ -1,5 +1,6 @@
 /**
  * Elevation Routes — Terrain Link Profile epic #4111 (Phase 1, backend only)
+ * + DEM tile proxy / capabilities (#3826 Phase 2 WP-A).
  *
  * `POST /profile` — public (optionalAuth), rate-limited. Computes an
  * elevation profile between two coordinates against the configured (or
@@ -12,6 +13,18 @@
  * arbitrary admin-supplied URL, identical trust level to mapStyleRoutes'
  * `POST /from-url`.
  *
+ * `GET /capabilities` — public (optionalAuth), no network I/O. Derived,
+ * non-secret capability summary (`elevationSourceUrl` is a secret setting
+ * stripped from `/api/settings` for non-admins) so the frontend can decide
+ * whether to offer the 3D terrain toggle before rendering it.
+ *
+ * `GET /tiles/:z/:x/:y` — public (optionalAuth) + `elevationTileLimiter`
+ * (far more generous than `elevationLimiter` — a single 3D view legitimately
+ * fetches dozens of DEM tiles). Returns raw `image/png` bytes (NOT the
+ * `ok()`/`fail()` envelope on success) with a long `immutable` Cache-Control;
+ * error paths use `fail()` + `no-store`. The resolved source URL/key is never
+ * echoed in a response or log message.
+ *
  * No per-route express.json(): server.ts applies a global
  * `app.use(express.json({ limit: '10mb' }))` ahead of apiRouter, matching
  * neighboring routes (analysisRoutes, tileServerTest).
@@ -20,10 +33,15 @@
 import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
 import { optionalAuth, requirePermission } from '../auth/authMiddleware.js';
-import { elevationLimiter } from '../middleware/rateLimiters.js';
+import { elevationLimiter, elevationTileLimiter } from '../middleware/rateLimiters.js';
 import { ok, fail } from '../utils/apiResponse.js';
 import { logger } from '../../utils/logger.js';
-import { computeProfile, testSource } from '../services/elevationService.js';
+import {
+  computeProfile,
+  testSource,
+  getElevationCapabilities,
+  fetchTerrainTile,
+} from '../services/elevationService.js';
 import type { LatLng } from '../../utils/greatCircle.js';
 
 const router = Router();
@@ -99,5 +117,65 @@ router.post('/test', requirePermission('settings', 'write'), elevationLimiter, a
     fail(res, 500, 'ELEVATION_TEST_FAILED', 'Failed to test elevation source.');
   }
 });
+
+/**
+ * GET /api/elevation/capabilities
+ * Public (optionalAuth), no network I/O — reads two settings and derives a
+ * non-secret capability summary (#3826 Phase 2 WP-A).
+ */
+router.get('/capabilities', optionalAuth(), async (_req: Request, res: Response) => {
+  try {
+    const settings = await databaseService.settings.getAllSettings();
+    const capabilities = getElevationCapabilities(settings.elevationEnabled, settings.elevationSourceUrl);
+    ok(res, capabilities);
+  } catch (error) {
+    logger.error('Error in GET /api/elevation/capabilities:', error);
+    fail(res, 500, 'ELEVATION_CAPABILITIES_FAILED', 'Failed to determine elevation capabilities.');
+  }
+});
+
+function parseTileParam(value: string): number {
+  // `Number('')`/whitespace would otherwise coerce to 0 — require a
+  // non-empty, fully-numeric string so a stray extension (e.g. "123.png")
+  // or empty segment reliably yields NaN -> INVALID_TILE_COORDS.
+  if (!/^-?\d+$/.test(value)) return NaN;
+  return Number(value);
+}
+
+/**
+ * GET /api/elevation/tiles/:z/:x/:y
+ * Public (optionalAuth) + elevationTileLimiter. Returns raw `image/png`
+ * bytes on success (no envelope) — error paths use `fail()`. Never includes
+ * the resolved source URL or key in a response or log message.
+ */
+router.get(
+  '/tiles/:z/:x/:y',
+  optionalAuth(),
+  elevationTileLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const z = parseTileParam(req.params.z);
+      const x = parseTileParam(req.params.x);
+      const y = parseTileParam(req.params.y);
+
+      const settings = await databaseService.settings.getAllSettings();
+      const result = await fetchTerrainTile(z, x, y, settings.elevationEnabled, settings.elevationSourceUrl);
+
+      if ('code' in result) {
+        res.set('Cache-Control', 'no-store');
+        fail(res, result.status, result.code, result.message);
+        return;
+      }
+
+      res.set('Content-Type', 'image/png');
+      res.set('Cache-Control', 'public, max-age=604800, immutable');
+      res.send(result.png);
+    } catch (error) {
+      logger.error('Error in GET /api/elevation/tiles/:z/:x/:y:', error);
+      res.set('Cache-Control', 'no-store');
+      fail(res, 500, 'ELEVATION_TILE_FAILED', 'Failed to fetch terrain tile.');
+    }
+  }
+);
 
 export default router;

--- a/src/server/routes/elevationRoutes.ts
+++ b/src/server/routes/elevationRoutes.ts
@@ -123,10 +123,29 @@ router.post('/test', requirePermission('settings', 'write'), elevationLimiter, a
  * Public (optionalAuth), no network I/O — reads two settings and derives a
  * non-secret capability summary (#3826 Phase 2 WP-A).
  */
+/**
+ * Reads just the two elevation settings keys — deliberately NOT
+ * `getAllSettings()` (full settings-map load), since the tile route can be
+ * hit up to 600/min (PR #4239 review).
+ */
+async function readElevationSettings(): Promise<{
+  elevationEnabled: string | undefined;
+  elevationSourceUrl: string | undefined;
+}> {
+  const [elevationEnabled, elevationSourceUrl] = await Promise.all([
+    databaseService.settings.getSetting('elevationEnabled'),
+    databaseService.settings.getSetting('elevationSourceUrl'),
+  ]);
+  return {
+    elevationEnabled: elevationEnabled ?? undefined,
+    elevationSourceUrl: elevationSourceUrl ?? undefined,
+  };
+}
+
 router.get('/capabilities', optionalAuth(), async (_req: Request, res: Response) => {
   try {
-    const settings = await databaseService.settings.getAllSettings();
-    const capabilities = getElevationCapabilities(settings.elevationEnabled, settings.elevationSourceUrl);
+    const { elevationEnabled, elevationSourceUrl } = await readElevationSettings();
+    const capabilities = getElevationCapabilities(elevationEnabled, elevationSourceUrl);
     ok(res, capabilities);
   } catch (error) {
     logger.error('Error in GET /api/elevation/capabilities:', error);
@@ -158,8 +177,8 @@ router.get(
       const x = parseTileParam(req.params.x);
       const y = parseTileParam(req.params.y);
 
-      const settings = await databaseService.settings.getAllSettings();
-      const result = await fetchTerrainTile(z, x, y, settings.elevationEnabled, settings.elevationSourceUrl);
+      const { elevationEnabled, elevationSourceUrl } = await readElevationSettings();
+      const result = await fetchTerrainTile(z, x, y, elevationEnabled, elevationSourceUrl);
 
       if ('code' in result) {
         res.set('Cache-Control', 'no-store');

--- a/src/server/services/elevationProvider.test.ts
+++ b/src/server/services/elevationProvider.test.ts
@@ -28,6 +28,9 @@ import {
   DEFAULT_TERRARIUM_URL,
   TERRARIUM_ZOOM,
   TILE_SIZE,
+  isValidTileCoord,
+  fetchTerrariumTilePng,
+  MAX_TERRARIUM_TILE_ZOOM,
 } from './elevationProvider.js';
 import { lngLatToTilePixel } from '../../utils/greatCircle.js';
 
@@ -352,6 +355,111 @@ describe('JsonPointProvider.sample', () => {
     const calledUrl = mockSafeFetch.mock.calls[0][0] as string;
     expect(calledUrl).not.toContain('{locations}');
     expect(calledUrl).toContain('1.1111');
+  });
+});
+
+describe('isValidTileCoord (#3826 Phase 2 WP-A)', () => {
+  it('accepts valid coordinates at z=0 (the single 1x1 tile)', () => {
+    expect(isValidTileCoord(0, 0, 0)).toBe(true);
+  });
+
+  it('accepts valid coordinates at a mid zoom', () => {
+    expect(isValidTileCoord(10, 500, 300)).toBe(true);
+  });
+
+  it('accepts the boundary coordinate at MAX_TERRARIUM_TILE_ZOOM', () => {
+    const maxIndex = 2 ** MAX_TERRARIUM_TILE_ZOOM - 1;
+    expect(isValidTileCoord(MAX_TERRARIUM_TILE_ZOOM, maxIndex, maxIndex)).toBe(true);
+    expect(isValidTileCoord(MAX_TERRARIUM_TILE_ZOOM, 0, 0)).toBe(true);
+  });
+
+  it('rejects z beyond MAX_TERRARIUM_TILE_ZOOM', () => {
+    expect(isValidTileCoord(MAX_TERRARIUM_TILE_ZOOM + 1, 0, 0)).toBe(false);
+    expect(isValidTileCoord(99, 0, 0)).toBe(false);
+  });
+
+  it('rejects negative z/x/y', () => {
+    expect(isValidTileCoord(-1, 0, 0)).toBe(false);
+    expect(isValidTileCoord(5, -1, 0)).toBe(false);
+    expect(isValidTileCoord(5, 0, -1)).toBe(false);
+  });
+
+  it('rejects non-integer coordinates', () => {
+    expect(isValidTileCoord(1.5, 0, 0)).toBe(false);
+    expect(isValidTileCoord(1, 0.5, 0)).toBe(false);
+    expect(isValidTileCoord(1, 0, 0.5)).toBe(false);
+    expect(isValidTileCoord(Number.NaN, 0, 0)).toBe(false);
+  });
+
+  it('rejects x/y outside the 2^z tile grid for a given zoom', () => {
+    // At z=2 the grid is 4x4 (indices 0..3).
+    expect(isValidTileCoord(2, 4, 0)).toBe(false);
+    expect(isValidTileCoord(2, 0, 4)).toBe(false);
+    expect(isValidTileCoord(2, 3, 3)).toBe(true);
+  });
+});
+
+describe('fetchTerrariumTilePng (#3826 Phase 2 WP-A, DEM tile proxy raw-fetch)', () => {
+  it('fetches and returns the raw PNG buffer for valid coords', async () => {
+    const tile = makeUniformTerrariumTile(1000, TILE_SIZE);
+    mockSafeFetch.mockResolvedValue(fakeResponse({ ok: true, buffer: tile }));
+
+    const result = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 8, 40, 96);
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result?.equals(tile)).toBe(true);
+    expect(mockSafeFetch).toHaveBeenCalledTimes(1);
+    const calledUrl = mockSafeFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/8/40/96');
+  });
+
+  it('caches raw bytes — a second fetch for the same z/x/y does not refetch', async () => {
+    const tile = makeUniformTerrariumTile(1500, TILE_SIZE);
+    mockSafeFetch.mockResolvedValue(fakeResponse({ ok: true, buffer: tile }));
+
+    const first = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 9, 1, 1);
+    const second = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 9, 1, 1);
+
+    expect(first?.equals(tile)).toBe(true);
+    expect(second?.equals(tile)).toBe(true);
+    expect(mockSafeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null (never throws) on invalid coords, without calling safeFetch', async () => {
+    const result = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 99, 0, 0);
+    expect(result).toBeNull();
+    expect(mockSafeFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a non-terrarium (JSON) template, without calling safeFetch', async () => {
+    const result = await fetchTerrariumTilePng('https://api.opentopodata.org/v1/mapzen', 5, 1, 1);
+    expect(result).toBeNull();
+    expect(mockSafeFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns null (never throws) on a non-OK upstream response', async () => {
+    mockSafeFetch.mockResolvedValue(fakeResponse({ ok: false, status: 404 }));
+    const result = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 5, 2, 2);
+    expect(result).toBeNull();
+  });
+
+  it('returns null (never throws) when safeFetch rejects with SsrfBlockedError', async () => {
+    mockSafeFetch.mockRejectedValue(new MockSsrfBlockedError('blocked target'));
+    const result = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 5, 3, 3);
+    expect(result).toBeNull();
+  });
+
+  it('does not cache a fetch failure — a later call can retry', async () => {
+    mockSafeFetch.mockResolvedValueOnce(fakeResponse({ ok: false, status: 500 }));
+    const tile = makeUniformTerrariumTile(2000, TILE_SIZE);
+    mockSafeFetch.mockResolvedValueOnce(fakeResponse({ ok: true, buffer: tile }));
+
+    const first = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 6, 4, 4);
+    const second = await fetchTerrariumTilePng(DEFAULT_TERRARIUM_URL, 6, 4, 4);
+
+    expect(first).toBeNull();
+    expect(second?.equals(tile)).toBe(true);
+    expect(mockSafeFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/server/services/elevationProvider.test.ts
+++ b/src/server/services/elevationProvider.test.ts
@@ -30,6 +30,7 @@ import {
   TILE_SIZE,
   isValidTileCoord,
   fetchTerrariumTilePng,
+  clearRawTileCacheForTesting,
   MAX_TERRARIUM_TILE_ZOOM,
 } from './elevationProvider.js';
 import { lngLatToTilePixel } from '../../utils/greatCircle.js';
@@ -76,6 +77,9 @@ function fakeJsonResponse(opts: { ok: boolean; status?: number; body?: unknown }
 
 beforeEach(() => {
   mockSafeFetch.mockReset();
+  // The raw-PNG LRU is module-scoped (shared across the whole file) — clear
+  // it so tile-proxy tests never depend on coordinate uniqueness for isolation.
+  clearRawTileCacheForTesting();
 });
 
 describe('detectProviderType', () => {

--- a/src/server/services/elevationProvider.ts
+++ b/src/server/services/elevationProvider.ts
@@ -157,6 +157,16 @@ const tileCache = new LruCache<string, Float32Array>(TILE_CACHE_MAX);
 const rawTileCache = new LruCache<string, Buffer>(RAW_TILE_CACHE_MAX);
 
 /**
+ * Test-only: empties the module-scope raw-PNG tile cache so tests exercising
+ * the tile-proxy fetch path are isolated from each other (the cache is shared
+ * for the lifetime of the module, i.e. an entire test file). Not for
+ * production use.
+ */
+export function clearRawTileCacheForTesting(): void {
+  rawTileCache.clear();
+}
+
+/**
  * Integer + range validation for slippy-tile coordinates. `z` must be within
  * `[0, MAX_TERRARIUM_TILE_ZOOM]`; `x`/`y` must fall within the `2^z` tile
  * grid for that zoom.

--- a/src/server/services/elevationProvider.ts
+++ b/src/server/services/elevationProvider.ts
@@ -44,6 +44,22 @@ export const TILE_SIZE = 256;
 /** Max decoded tiles held in the module-scope LRU cache (see cache below for the memory budget). */
 export const TILE_CACHE_MAX = 64;
 
+/**
+ * Max cached raw (undecoded) terrarium PNG tiles held in the DEM tile-proxy's
+ * module-scope LRU cache (#3826 Phase 2 WP-A). Separate from `TILE_CACHE_MAX`
+ * (decoded `Float32Array`s at the fixed `TERRARIUM_ZOOM`) — the proxy serves
+ * raw bytes at arbitrary client-requested zoom.
+ */
+export const RAW_TILE_CACHE_MAX = 256;
+
+/**
+ * AWS/Mapzen terrarium's max native zoom level. The `raster-dem` source's
+ * `maxzoom` is set to this value; MapLibre overzooms terrain past it
+ * client-side. Also caps the DEM tile-proxy's SSRF attack surface — only
+ * well-formed z/x/y triples are ever substituted into an outbound fetch.
+ */
+export const MAX_TERRARIUM_TILE_ZOOM = 15;
+
 /** Max cached JSON point samples (keyed by rounded lat,lng). */
 const JSON_CACHE_MAX = 10_000;
 
@@ -128,6 +144,31 @@ export function decodeTerrariumTile(
 const tileCache = new LruCache<string, Float32Array>(TILE_CACHE_MAX);
 
 /**
+ * Module-scope raw (undecoded) terrarium PNG tile cache for the DEM tile
+ * proxy (#3826 Phase 2 WP-A). Keyed `"z/x/y"` at whatever zoom the client
+ * requested (unlike `tileCache`, which is fixed at `TERRARIUM_ZOOM`).
+ *
+ * Memory bound: terrarium PNGs are ~10-120 KB (typ. ~50 KB); 256 entries *
+ * ~120 KB worst case ~= 30 MB ceiling, typically ~13 MB. Kept separate from
+ * `tileCache` — different key space (variable z) and value type (raw bytes
+ * vs. decoded Float32Array) — so 3D tile-browsing pressure never evicts warm
+ * link-profile tiles (or vice versa).
+ */
+const rawTileCache = new LruCache<string, Buffer>(RAW_TILE_CACHE_MAX);
+
+/**
+ * Integer + range validation for slippy-tile coordinates. `z` must be within
+ * `[0, MAX_TERRARIUM_TILE_ZOOM]`; `x`/`y` must fall within the `2^z` tile
+ * grid for that zoom.
+ */
+export function isValidTileCoord(z: number, x: number, y: number): boolean {
+  if (!Number.isInteger(z) || !Number.isInteger(x) || !Number.isInteger(y)) return false;
+  if (z < 0 || z > MAX_TERRARIUM_TILE_ZOOM) return false;
+  const maxIndex = 2 ** z - 1;
+  return x >= 0 && x <= maxIndex && y >= 0 && y <= maxIndex;
+}
+
+/**
  * Samples a terrarium-encoded slippy-tile DEM source (e.g. the default
  * Mapzen/AWS `elevation-tiles-prod` dataset). Points are grouped by the tile
  * they fall in so each unique tile is fetched/decoded at most once per
@@ -210,6 +251,56 @@ export class TerrariumTileProvider implements ElevationProvider {
       }
       return null;
     }
+  }
+}
+
+/**
+ * Fetches a raw terrarium PNG tile (bytes, undecoded) for the given `z/x/y`
+ * from a terrarium URL template, via `safeFetch`, backed by the shared
+ * `rawTileCache` LRU (#3826 Phase 2 WP-A, DEM tile proxy).
+ *
+ * Returns `null` — never throws — on: invalid coords, a non-terrarium
+ * template, a non-OK upstream response, an SSRF block, or a network/decode
+ * error. Failures are not cached, so a later request can retry.
+ *
+ * Unlike `TerrariumTileProvider.getTile` (fixed `TERRARIUM_ZOOM`), this
+ * substitutes a client-supplied `z`, which is why coordinate validation
+ * happens here rather than being assumed.
+ */
+export async function fetchTerrariumTilePng(
+  urlTemplate: string,
+  z: number,
+  x: number,
+  y: number,
+): Promise<Buffer | null> {
+  if (!isValidTileCoord(z, x, y)) return null;
+  if (detectProviderType(urlTemplate) !== 'terrarium') return null;
+
+  const key = `${z}/${x}/${y}`;
+  const cached = rawTileCache.get(key);
+  if (cached) return cached;
+
+  const url = urlTemplate
+    .replace('{z}', String(z))
+    .replace('{x}', String(x))
+    .replace('{y}', String(y));
+
+  try {
+    const response = await safeFetch(url);
+    if (!response.ok) {
+      logger.debug(`Elevation: raw terrarium tile fetch returned ${response.status} for ${key}`);
+      return null;
+    }
+    const buffer = Buffer.from(await response.arrayBuffer());
+    rawTileCache.set(key, buffer);
+    return buffer;
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      logger.warn(`Elevation: raw terrarium tile fetch blocked by SSRF guard for ${key}: ${err.message}`);
+    } else {
+      logger.debug(`Elevation: raw terrarium tile fetch failed for ${key}:`, err);
+    }
+    return null;
   }
 }
 

--- a/src/server/services/elevationService.test.ts
+++ b/src/server/services/elevationService.test.ts
@@ -2,18 +2,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockResolveProvider = vi.hoisted(() => vi.fn());
 const mockDetectProviderType = vi.hoisted(() => vi.fn());
+const mockFetchTerrariumTilePng = vi.hoisted(() => vi.fn());
 
-vi.mock('./elevationProvider.js', () => ({
-  resolveProvider: mockResolveProvider,
-  detectProviderType: mockDetectProviderType,
-}));
+// Keep the real (pure) exports — DEFAULT_TERRARIUM_URL, isValidTileCoord —
+// intact via importOriginal; only override the network/detection-touching
+// exports the tests need to control. This lets getElevationCapabilities/
+// fetchTerrainTile tests exercise real coordinate validation while still
+// mocking the outbound fetch path.
+vi.mock('./elevationProvider.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./elevationProvider.js')>();
+  return {
+    ...actual,
+    resolveProvider: mockResolveProvider,
+    detectProviderType: mockDetectProviderType,
+    fetchTerrariumTilePng: mockFetchTerrariumTilePng,
+  };
+});
 
 import { calculateDistance } from '../../utils/distance.js';
 import { SsrfBlockedError } from '../utils/ssrfGuard.js';
 import { stripSecretSettings } from '../constants/settings.js';
+import { DEFAULT_TERRARIUM_URL } from './elevationProvider.js';
 import {
   computeProfile,
   testSource,
+  getElevationCapabilities,
+  fetchTerrainTile,
   MIN_SAMPLES,
   MAX_SAMPLES,
   DEFAULT_SAMPLES,
@@ -35,6 +49,7 @@ beforeEach(() => {
   mockResolveProvider.mockReset();
   mockDetectProviderType.mockReset();
   mockDetectProviderType.mockReturnValue('terrarium');
+  mockFetchTerrariumTilePng.mockReset();
 });
 
 describe('computeProfile', () => {
@@ -201,6 +216,108 @@ describe('testSource', () => {
     await testSource('https://example.com/{z}/{x}/{y}.png', probe);
 
     expect(provider.sample).toHaveBeenCalledWith([probe]);
+  });
+});
+
+describe('getElevationCapabilities (#3826 Phase 2 WP-A)', () => {
+  it('enabled + terrarium (default/unset source) -> terrainTiles:true', () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const caps = getElevationCapabilities(undefined, undefined);
+    expect(caps).toEqual({ enabled: true, terrainTiles: true, provider: 'terrarium' });
+  });
+
+  it('enabled + explicit terrarium source -> terrainTiles:true', () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const caps = getElevationCapabilities('true', 'https://example.com/{z}/{x}/{y}.png');
+    expect(caps).toEqual({ enabled: true, terrainTiles: true, provider: 'terrarium' });
+  });
+
+  it('enabled + JSON source -> terrainTiles:false (no silent terrarium fallback)', () => {
+    mockDetectProviderType.mockReturnValue('json');
+    const caps = getElevationCapabilities('true', 'https://api.opentopodata.org/v1/mapzen');
+    expect(caps).toEqual({ enabled: true, terrainTiles: false, provider: 'json' });
+  });
+
+  it('disabled (elevationEnabled=false) -> enabled:false, terrainTiles:false regardless of provider', () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const caps = getElevationCapabilities('false', undefined);
+    expect(caps).toEqual({ enabled: false, terrainTiles: false, provider: 'terrarium' });
+  });
+
+  it('disabled + JSON source -> enabled:false, terrainTiles:false, provider:json', () => {
+    mockDetectProviderType.mockReturnValue('json');
+    const caps = getElevationCapabilities('false', 'https://api.opentopodata.org/v1/mapzen');
+    expect(caps).toEqual({ enabled: false, terrainTiles: false, provider: 'json' });
+  });
+
+  it('falls back to the default terrarium URL when sourceUrl is empty/whitespace', () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    getElevationCapabilities('true', '   ');
+    expect(mockDetectProviderType).toHaveBeenCalledWith(DEFAULT_TERRARIUM_URL);
+  });
+});
+
+describe('fetchTerrainTile (#3826 Phase 2 WP-A)', () => {
+  it('returns ELEVATION_DISABLED (403) when elevationEnabled=false', async () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const result = await fetchTerrainTile(5, 1, 1, 'false', undefined);
+    expect(result).toMatchObject({ code: 'ELEVATION_DISABLED', status: 403 });
+    expect(mockFetchTerrariumTilePng).not.toHaveBeenCalled();
+  });
+
+  it('returns TERRAIN_TILES_UNAVAILABLE (409) for a configured JSON source, without leaking the URL', async () => {
+    mockDetectProviderType.mockReturnValue('json');
+    const secretUrl = 'https://api.example.com/v1/dem?key=supersecret';
+    const result = await fetchTerrainTile(5, 1, 1, 'true', secretUrl);
+    expect(result).toMatchObject({ code: 'TERRAIN_TILES_UNAVAILABLE', status: 409 });
+    expect(mockFetchTerrariumTilePng).not.toHaveBeenCalled();
+    if ('message' in result) {
+      expect(result.message).not.toContain(secretUrl);
+      expect(result.message).not.toContain('supersecret');
+    }
+  });
+
+  it('returns INVALID_TILE_COORDS (400) for an out-of-range zoom', async () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const result = await fetchTerrainTile(99, 1, 1, 'true', undefined);
+    expect(result).toMatchObject({ code: 'INVALID_TILE_COORDS', status: 400 });
+    expect(mockFetchTerrariumTilePng).not.toHaveBeenCalled();
+  });
+
+  it('returns INVALID_TILE_COORDS (400) for non-integer/NaN coords', async () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const result = await fetchTerrainTile(Number.NaN, 1, 1, 'true', undefined);
+    expect(result).toMatchObject({ code: 'INVALID_TILE_COORDS', status: 400 });
+  });
+
+  it('returns TILE_FETCH_FAILED (502) when the upstream fetch fails', async () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    mockFetchTerrariumTilePng.mockResolvedValue(null);
+    const result = await fetchTerrainTile(5, 1, 1, 'true', undefined);
+    expect(result).toMatchObject({ code: 'TILE_FETCH_FAILED', status: 502 });
+  });
+
+  it('returns { png } on success, resolving the default terrarium URL when unset', async () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const png = Buffer.from([1, 2, 3]);
+    mockFetchTerrariumTilePng.mockResolvedValue(png);
+
+    const result = await fetchTerrainTile(5, 1, 1, undefined, undefined);
+
+    expect('png' in result).toBe(true);
+    if ('png' in result) expect(result.png).toBe(png);
+    expect(mockFetchTerrariumTilePng).toHaveBeenCalledWith(DEFAULT_TERRARIUM_URL, 5, 1, 1);
+  });
+
+  it('passes the configured terrarium sourceUrl through to fetchTerrariumTilePng', async () => {
+    mockDetectProviderType.mockReturnValue('terrarium');
+    const png = Buffer.from([9, 9, 9]);
+    mockFetchTerrariumTilePng.mockResolvedValue(png);
+    const customUrl = 'https://example.com/{z}/{x}/{y}.png';
+
+    await fetchTerrainTile(6, 2, 2, 'true', customUrl);
+
+    expect(mockFetchTerrariumTilePng).toHaveBeenCalledWith(customUrl, 6, 2, 2);
   });
 });
 

--- a/src/server/services/elevationService.ts
+++ b/src/server/services/elevationService.ts
@@ -9,7 +9,14 @@
 
 import { calculateDistance } from '../../utils/distance.js';
 import { interpolateGreatCircle, type LatLng } from '../../utils/greatCircle.js';
-import { detectProviderType, resolveProvider, type ProviderType } from './elevationProvider.js';
+import {
+  detectProviderType,
+  resolveProvider,
+  fetchTerrariumTilePng,
+  isValidTileCoord,
+  DEFAULT_TERRARIUM_URL,
+  type ProviderType,
+} from './elevationProvider.js';
 import { SsrfBlockedError } from '../utils/ssrfGuard.js';
 
 export interface ProfileSample {
@@ -184,4 +191,107 @@ export async function testSource(url: string, probe?: LatLng): Promise<TestResul
           : String(err);
     return { success: false, detectedType, sampleElevation: null, latencyMs, error: message };
   }
+}
+
+/**
+ * Non-secret capability summary derived from settings (#3826 Phase 2 WP-A).
+ * The frontend needs to know whether to offer the 3D toggle before rendering
+ * it, but `elevationSourceUrl` is a secret setting stripped for non-admins —
+ * so provider type must be resolved server-side and exposed as a boolean.
+ */
+export interface ElevationCapabilities {
+  enabled: boolean;
+  terrainTiles: boolean;
+  provider: ProviderType;
+}
+
+/**
+ * Derives elevation/terrain-tile capabilities from raw settings values. Pure
+ * (no network I/O) — provider type detection is a string-shape check, not a
+ * probe.
+ *
+ * - `enabled` mirrors the same `elevationEnabled !== 'false'` gate used by
+ *   `POST /profile`.
+ * - `provider` is `detectProviderType` on the configured `sourceUrl`, or the
+ *   default terrarium URL when unset/empty.
+ * - `terrainTiles` is true only when both enabled AND the provider is
+ *   terrarium — a configured JSON point source never serves DEM tiles (no
+ *   silent fallback to the public AWS terrarium source; see spec §2.1).
+ */
+export function getElevationCapabilities(
+  elevationEnabled: string | undefined,
+  sourceUrl: string | undefined,
+): ElevationCapabilities {
+  const enabled = elevationEnabled !== 'false';
+  const url = sourceUrl && sourceUrl.trim().length > 0 ? sourceUrl.trim() : DEFAULT_TERRARIUM_URL;
+  const provider = detectProviderType(url);
+  const terrainTiles = enabled && provider === 'terrarium';
+  return { enabled, terrainTiles, provider };
+}
+
+/** Shape returned by `fetchTerrainTile` on any failure branch. */
+export interface TileError {
+  code: string;
+  status: number;
+  message: string;
+}
+
+/**
+ * Resolves the terrain tile bytes for `z/x/y`, honoring `elevationSourceUrl`
+ * (#3826 Phase 2 WP-A, DEM tile proxy). Validation order (first failure
+ * wins), matching spec §3.2:
+ *  1. `elevationEnabled === 'false'`         -> `ELEVATION_DISABLED` (403).
+ *  2. Configured provider is JSON (no tiles) -> `TERRAIN_TILES_UNAVAILABLE` (409).
+ *     (JSON never falls back to the public terrarium source — see §2.1.)
+ *  3. Invalid `z/x/y`                        -> `INVALID_TILE_COORDS` (400).
+ *  4. Upstream miss/failure                  -> `TILE_FETCH_FAILED` (502).
+ *  5. Success                                -> `{ png }`.
+ *
+ * Never throws — `fetchTerrariumTilePng` degrades all fetch/SSRF/decode
+ * failures to `null`, which this maps onto `TILE_FETCH_FAILED`.
+ */
+export async function fetchTerrainTile(
+  z: number,
+  x: number,
+  y: number,
+  elevationEnabled: string | undefined,
+  sourceUrl: string | undefined,
+): Promise<{ png: Buffer } | TileError> {
+  const caps = getElevationCapabilities(elevationEnabled, sourceUrl);
+
+  if (!caps.enabled) {
+    return {
+      code: 'ELEVATION_DISABLED',
+      status: 403,
+      message: 'Elevation is disabled on this server.',
+    };
+  }
+
+  if (caps.provider !== 'terrarium') {
+    return {
+      code: 'TERRAIN_TILES_UNAVAILABLE',
+      status: 409,
+      message: 'Terrain tiles are not available with the configured elevation source.',
+    };
+  }
+
+  if (!isValidTileCoord(z, x, y)) {
+    return {
+      code: 'INVALID_TILE_COORDS',
+      status: 400,
+      message: 'Invalid tile coordinates.',
+    };
+  }
+
+  const url = sourceUrl && sourceUrl.trim().length > 0 ? sourceUrl.trim() : DEFAULT_TERRARIUM_URL;
+  const png = await fetchTerrariumTilePng(url, z, x, y);
+  if (!png) {
+    return {
+      code: 'TILE_FETCH_FAILED',
+      status: 502,
+      message: 'Failed to fetch terrain tile from the upstream source.',
+    };
+  }
+
+  return { png };
 }

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -767,3 +767,21 @@
   text-align: right;
   margin-top: -4px;
 }
+
+/* ===== 3D vector-basemap fallback note (#3826 Phase 2 WP-D) ===== */
+/* Non-blocking: sits above the 3D canvas but never intercepts pointer
+   events, so pan/rotate/zoom under it are unaffected. */
+.map-analysis-3d-fallback-note {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  pointer-events: none;
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
## Summary
Phase 2 of the 3D Map & Elevation epic (#3826): MeshMonitor gets its first real 3D map. The Map Analysis page gains a 2D/3D toggle — 3D renders a standalone MapLibre GL view with DEM terrain, hillshade, pitch/bearing navigation, a terrain-exaggeration slider, and node markers. The browser gets DEM tiles through a new server proxy that honors the admin-configured elevation source and never exposes its URL or API key. Leaflet remains untouched for 2D; the two stacks coexist behind the toggle.

## Changes
**Backend**
- `GET /api/elevation/tiles/:z/:x/:y` — terrarium raster-dem PNG proxy (optionalAuth, new `elevationTileLimiter` 600/min prod, `Cache-Control: public, max-age=604800, immutable`; errors are enveloped `fail()` + `no-store`: 403 `ELEVATION_DISABLED`, 409 `TERRAIN_TILES_UNAVAILABLE`, 400 `INVALID_TILE_COORDS`, 502 `TILE_FETCH_FAILED`). Raw-PNG LRU (256 entries, ~30 MB ceiling) separate from the existing decoded-Float32 profile cache; reuses `safeFetch`/SSRF guard.
- `GET /api/elevation/capabilities` — derived `{enabled, terrainTiles, provider}` (server-side because `elevationSourceUrl` is secret). A configured JSON point source reports `terrainTiles:false` — deliberately **no silent fallback** to public AWS tiles.

**Frontend**
- `src/components/map/Base3DMap.tsx` — standalone MapLibre GL component (not the Leaflet adapter): terrarium `raster-dem` terrain + hillshade, initial pitch 60°, NavigationControl with pitch, exaggeration slider (0–2×, default 1.3×), GeoJSON node circle+label layers, click→select, `map.remove()` teardown (StrictMode-safe). Graceful WebGL-unavailable fallback: probe + try/catch → message + `onUnsupported` → Map Analysis auto-reverts to 2D (found via browser validation — previously a no-WebGL browser with persisted 3D crashed to a blank page).
- `src/config/basemap3d.ts` — Leaflet `{s}` subdomain expansion for MapLibre `tiles[]`, vector-tileset → OSM raster fallback (with on-map note), base-path-aware proxy URL.
- `useTerrainCapabilities` hook; `viewMode: '2d'|'3d'` persisted in the existing `mapAnalysis.config.v1`; toolbar toggle disabled with specific tooltips per unavailability reason; force-2D guard so a stale persisted `'3d'` never strands the user.
- 2D path untouched — the existing Leaflet tree renders verbatim when `viewMode==='2d'`.

**Docs:** Map Analysis 3D section, settings elevation note, REST API entries for both endpoints, README feature bullet, epic plan + implementation spec in dev-notes.

## Issues Resolved
Relates to #3826 (Phase 2 of 3). Phase 1 was #4235.

## Documentation Updates
- `docs/features/map-analysis.md` (3D terrain view section + toolbar table row)
- `docs/features/settings.md` (elevation source ↔ 3D availability)
- `docs/api/REST_API.md` (capabilities + tiles endpoints)
- `README.md` (Key Features bullet)
- Dev-notes: `3D_MAP_FOUNDATION_SPEC.md`, `MAP_3D_ELEVATION_EPIC.md` status

## Testing
- [x] Full suite green: 10,511 tests / 0 failures, `success: true` via JSON reporter (route tests use `createRouteTestApp` harness; maplibre-gl fully mocked in jsdom)
- [x] TypeScript + `npm run lint:ci` clean (no baseline growth)
- [x] Live-validated on dev container: tile proxy serves real PNGs with immutable caching; 403/400 machine codes verified; capabilities envelope verified
- [x] 3D rendering validated in Chrome+SwiftShader (pitched terrain, markers, exaggeration slider, user's tileset as basemap, 18 DEM tiles via proxy — screenshot in epic notes)
- [x] Gating validated live: elevation disabled → toggle disabled w/ tooltip; persisted-3D + no WebGL → graceful auto-revert to 2D (no crash); viewMode persistence round-trips reload
- [ ] Reviewer: on Map Analysis, click the cube (Box) toolbar icon → pitched 3D terrain with node markers; toggle back → 2D unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1