### PR TITLE
feat(map-analysis): 3D neighbor/traceroute layers + selection parity (#3826 Phase 3)

### DIFF
--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -263,22 +263,31 @@ The button is disabled with an explanatory tooltip unless all of the following h
 ### Using the 3D view
 
 - **Navigate** with the built-in MapLibre control: drag to pan, scroll/pinch to zoom, right-drag (or two-finger drag) to pitch and rotate. A compass resets bearing to north.
-- **Terrain exaggeration** — a slider (0–2×, default **1.3×**) vertically stretches the DEM so subtle elevation changes read more clearly. It's a per-session view setting, not persisted between visits.
+- **Terrain exaggeration** — a slider (0–2×, default **1.3×**) vertically stretches the DEM so subtle elevation changes read more clearly. Your chosen value **persists per-browser** (New in 4.14, alongside the rest of the Map Analysis toolbar config), so it survives reloads instead of resetting each session.
 - **Node markers** render with short-name labels at their real position, draped onto the terrain surface. Click a marker to select it — the same inspector panel used in 2D opens with that node's details.
+- **Neighbor links and traceroute paths** (New in 4.14) render in 3D too, honoring the same layer toggles, filters, lookback window, and time-slider window as 2D — turning a layer off or narrowing its lookback in the toolbar affects both views identically. They use the same SNR-based color, opacity, and line-weight encoding as 2D, and MQTT/MeshCore links keep their dashed pattern. Unlike 2D, 3D draws links as straight segments rather than curved with direction arrows — the 3D camera's pitch and rotation already separate overlapping links, so curvature isn't needed; direction is instead shown by line color when a node is selected, matching 2D's color semantics.
+- **Selecting a link or traceroute segment** (New in 4.14) works the same as clicking a node: click a neighbor link or traceroute segment in 3D and the inspector opens with that link's details, exactly as in 2D — including Meshtastic and MeshCore neighbor links.
+- **"View terrain profile" from 3D** (New in 4.14) — selecting a neighbor link in 3D and clicking **View terrain profile** in the inspector automatically switches the canvas back to 2D with the [Link Profile](#terrain-link-profile) drawer open and the link drawn on the map. The verdict polyline and endpoint rings are Leaflet-only, so this action always lands you in 2D to see them; the elevation data is already cached from the 3D selection, so the drawer opens instantly.
 - **Basemap** — the 3D view reuses whichever raster tileset you have selected for the 2D map. If your selected tileset is **vector-only**, 3D can't drape a vector style over terrain yet, so it substitutes the default OpenStreetMap raster basemap and shows a small note; your 2D tileset selection is unaffected.
 
 The **2D/3D toggle state persists per-browser** alongside the rest of your Map Analysis toolbar configuration.
 
+::: tip Terrain draping caveat
+Neighbor links and traceroute paths are **not** elevation-sampled onto the terrain surface — MapLibre's line layers render near the base plane and can be partially hidden behind a ridge at high pitch, even though their endpoints (the node markers) sit correctly on the terrain. Treat an occluded link as a rough line-of-sight cue, not a precise indicator; this may be revisited once MapLibre's elevation-sampled line rendering (`line-z-offset`) stabilizes.
+:::
+
 ### What's not in 3D yet
 
-The 3D view is a foundation, not full layer parity. Not yet available while in 3D mode (all still work normally after switching back to 2D):
+The 3D view still doesn't have full layer parity with 2D. Not yet available while in 3D mode (all still work normally after switching back to 2D):
 
-- Neighbor links and traceroute paths
 - Coverage heatmap, position trails, range rings, hop shading, and the SNR overlay
-- The time slider
-- Launching the Terrain Link Profile tool directly from the 3D canvas
+- The time slider **UI** (the persisted time-slider window is still honored by 3D's neighbor/traceroute data — switching between 2D and 3D never changes which links are shown, only whether you can drag the slider handles from the 3D canvas)
+- Follow / Auto-zoom
+- Marker popups and spiderfying of overlapping markers
+- Launching the Terrain Link Profile tool by picking two points directly on the 3D canvas (use the inspector's **View terrain profile** action on a selected neighbor link instead, which auto-switches to 2D)
+- Waypoints
 
-These are planned for a follow-up phase of the 3D map work.
+These are candidates for a follow-up phase of the 3D map work.
 
 ## Time slider
 

--- a/docs/internal/dev-notes/3D_LAYERS_POLISH_SPEC.md
+++ b/docs/internal/dev-notes/3D_LAYERS_POLISH_SPEC.md
@@ -1,0 +1,499 @@
+# 3D Layers + Polish — Implementation Spec (3D Map & Elevation Epic #3826, Phase 3)
+
+Branch: `feature/3826-3d-layers-polish` (worktree, based on origin/main incl. Phases 1+2).
+
+Phase 3 is the final phase. Goal: **neighbor links + traceroute paths rendered
+in 3D**, **selection/inspector wiring in 3D** (nodes, neighbor links, traceroute
+segments) at full parity with 2D — including the Phase-1 terrain-profile action —
+plus exaggeration persistence and the epic close-out.
+
+## 0. Binding constraints (re-read before coding)
+
+- **TS strict, no `any`, exhaustive-deps clean, no raw `fetch()` in `src/components/**`.**
+- **`Base3DMap` stays Map-Analysis-agnostic.** All data in via props (`nodes`,
+  `lines`, `basemap`, `terrainTileUrl`, exaggeration); the only outbound signals
+  are `onNodeClick(key)`, `onLineClick(key)`, `onExaggerationChange(v)`,
+  `onUnsupported()`. It MUST NOT import `SelectedTarget`, `useMapAnalysisCtx`,
+  or any MapAnalysis type. The canvas owns every key→`SelectedTarget` mapping,
+  exactly as it already does for nodes (`analysisNodes.find(a => a.key === key)`).
+- **2D is untouched.** No edits to any existing 2D render path
+  (`layers/NeighborLinksLayer.tsx`, `layers/MeshCoreNeighborLinksLayer.tsx`,
+  `layers/TraceroutePathsLayer.tsx`, `NodeMarkersLayer.tsx`, the shared
+  `map/layers/*`, `LinkProfileController`, `LinkProfileDrawer`). 3D reuses the
+  **same data-fetch hooks and the same shared pure primitives** the 2D adapters
+  use; where the 2D adapters do a thin inline resolution, 3D replicates it in
+  new 3D-only code and a **parity test** locks the two to identical
+  `SelectedTarget` shapes. (Rationale for not extracting shared hooks: the
+  phase constraint forbids touching 2D; the drift risk is bounded by the parity
+  tests plus the already-shared primitives in `utils/neighborLinks.ts` /
+  `utils/mapHelpers.ts`.)
+- **No migration, no new server settings key** (see §2.4 — exaggeration is
+  client-local, same path as `viewMode`).
+
+## 1. Reuse inventory (use / extend these — do NOT reinvent)
+
+| Concern | Reuse | Path |
+|---|---|---|
+| Generic 3D surface | `Base3DMap` (mount-once map, terrain, hillshade, GeoJSON `nodes` source + circle/label layers, click-on-layer pattern, WebGL probe + `onUnsupported` auto-revert, StrictMode-safe teardown) | `src/components/map/Base3DMap.tsx` |
+| Node feature shape | `Node3DFeature { key, lat, lng, label?, color? }` | `src/components/map/Base3DMap.tsx` |
+| Meshtastic neighbor fetch | `useNeighbors({ enabled, sources, lookbackHours })` | `src/hooks/useMapAnalysisData.ts` |
+| MeshCore neighbor fetch | `useMeshCoreNeighbors({ enabled, sources, lookbackHours })` | `src/hooks/useMapAnalysisData.ts` |
+| Traceroute fetch + analysis | `useTraceroutes(...)` + `useTracerouteAnalysis({ traceroutes, positionByKey, selectedNodeNum, selectedSourceId, options, visibleNodeNums, timeWindow })` | `src/hooks/useMapAnalysisData.ts`, `useTracerouteAnalysis` |
+| Unified node list (endpoint positions) | `useDashboardUnifiedData(sources, enabled)` → `{ nodes }`; `useDashboardSources()` | `src/hooks/useDashboardData.ts` |
+| Endpoint position resolve | `resolveNodeLatLng(node)` | `src/components/MapAnalysis/nodePositionUtil.ts` |
+| SNR → line opacity | `snrToNeighborOpacity(snr)` (`null→0.4`, else `clamp((snr+10)/20,0.2,1)`) | `src/utils/neighborLinks.ts` |
+| Traceroute SNR color / weight / opacity / dash | `snrToColor`, `weightByOccurrence`, `getSegmentSnrOpacity`, `MQTT_DASH`, `SnrColorScale` | `src/utils/mapHelpers.ts` |
+| Transport-class color | `transportColor(transportClass)` (already used by 2D neighbor adapter) | `src/utils/mapHelpers.ts` (as imported by `layers/NeighborLinksLayer.tsx`) |
+| Theme palette | `useSettings().overlayColors` (`snrColors`, `mqttSegment`) | `src/contexts/SettingsContext.tsx` |
+| Shared positioned+visible nodes (3D markers already consume) | `useAnalysisNodes()` → `AnalysisNode { node, latLng, key=unifiedNodeKey }` | `src/components/MapAnalysis/useAnalysisNodes.ts` |
+| Selection state | `selected` / `setSelected(SelectedTarget)`; `SelectedTarget` variants (`node` `{nodeNum,sourceId}`; meshtastic `neighbor` `{sourceId,nodeNum,neighborNum,snr,timestamp}`; meshcore `neighbor` `{sourceId,publicKey,neighborPublicKey,nodeName,neighborName,snr,timestamp,nodeNum:0,neighborNum:0}`; `segment` `{fromNodeNum,toNodeNum,direction,occurrences,avgSnr}`) | `src/components/MapAnalysis/MapAnalysisContext.tsx` |
+| Config + persistence | `useMapAnalysisConfig()` (`mapAnalysis.config.v1`, version-guarded `load()` that spreads `DEFAULT_CONFIG`) + `setViewMode` | `src/hooks/useMapAnalysisConfig.ts` |
+| Terrain-profile action (Phase 1) | inspector neighbor branch already sets `linkProfileMode`/`linkEndpoints` via `resolveNeighborEndpoints` + `useElevationProfile` (shared cache) | `src/components/MapAnalysis/AnalysisInspectorPanel.tsx`, `neighborLinkEndpoints.ts` |
+| Page-level inspector mount | `AnalysisInspectorPanel` is mounted in `MapAnalysisPage`, **outside** the canvas → it already renders for selections made in either view | `src/pages/MapAnalysisPage.tsx` |
+
+### New files (justified)
+1. `src/components/MapAnalysis/use3DNeighborLines.ts` — resolves meshtastic +
+   meshcore neighbor edges → `Line3DFeature[]` + `Map<key, SelectedTarget>`,
+   gated by `config.layers.neighbors.enabled` and the time-slider window. Cannot
+   live in the 2D adapters (they're Leaflet components and are off-limits).
+2. `src/components/MapAnalysis/use3DTracerouteLines.ts` — resolves traceroute
+   segments → `Line3DFeature[]` + `Map<key, SelectedTarget>`, gated by
+   `config.layers.traceroutes.enabled`.
+3. Tests for both, incl. the parity tests (see §4).
+
+No new shared util, no new server file, no migration.
+
+## 2. Design decisions
+
+### 2.1 `Line3DFeature` — the generic line contract (keeps Base3DMap agnostic)
+
+```ts
+// in Base3DMap.tsx, exported alongside Node3DFeature
+export interface Line3DFeature {
+  key: string;                    // stable; the ONLY thing echoed back via onLineClick
+  from: [number, number];         // [lat, lng]  (converted to [lng, lat] internally)
+  to: [number, number];           // [lat, lng]
+  color: string;                  // → data-driven line-color  (['get','color'])
+  opacity: number;                // → data-driven line-opacity (['get','opacity'])
+  width: number;                  // → data-driven line-width   (['get','width'])
+  /** Dash pattern in line-widths; omit/empty = solid. */
+  dash?: number[];
+}
+```
+
+`color`/`opacity`/`width` carry the **exact same numbers** the 2D layer computes
+(shared primitives), so the two views are pixel-equivalent on those axes.
+`dash` is the one axis that differs: MapLibre `line-dasharray` **cannot be read
+from feature properties** (confirmed against the style spec — "arrays cannot be
+read from or derived from feature properties"). So Base3DMap **groups
+`lines` by their `dash` signature and creates one `line` layer per distinct
+pattern** (`JSON.stringify(dash ?? [])` as the group key), each with its own
+static `line-dasharray` (omitted for solid), while `line-color`/`-opacity`/
+`-width` stay data-driven within the layer. All line layers share one
+`lines` GeoJSON source. (A single-layer `match`-expression on a `dashKey`
+property is technically available on the pinned `maplibre-gl` ^5.24 — dasharray
+data-driven landed in GL JS 5.8 — but per-pattern layers are simpler to test
+against the fake map and version-agnostic; use them.)
+
+### 2.2 Line encoding parity (color / opacity / width / dash per protocol)
+
+Values below are lifted from the verified 2D adapters so 3D agrees by construction:
+
+| Line kind | color | opacity | width | dash | Source of truth |
+|---|---|---|---|---|---|
+| Meshtastic neighbor | `transportColor(transportClass)` | `snrToNeighborOpacity(snr)` | `2` | `[2,2]` | `layers/NeighborLinksLayer.tsx` (`weight:1`, dash `'4 4'`) |
+| MeshCore neighbor | `#06b6d4` (`MC_NEIGHBOR_COLOR`) | `snrToNeighborOpacity(snr)` | `3` | `[3,2]` | `layers/MeshCoreNeighborLinksLayer.tsx` (`weight:1.5`, dash `'6 4'`) |
+| Traceroute (RF, has SNR) | `snrToColor(avgSnr, snrColors)` (or `directionColors` when a node is selected — see below) | `getSegmentSnrOpacity([{snr}], isMqtt)` | `weightByOccurrence(occurrences)` | none (solid) | `layers/TraceroutePathsLayer.tsx` |
+| Traceroute (MQTT / unknown-SNR) | `overlayColors.mqttSegment` (mqtt) or `snrColors` gray | same | same | `[2,2]` (MQTT dash) | same |
+
+- `color`/`opacity`/`width` reuse the **identical primitives** (`snrToNeighborOpacity`,
+  `snrToColor`, `getSegmentSnrOpacity`, `weightByOccurrence`, `transportColor`)
+  — no new math. `width` maps the 2D leaflet `weight` value 1:1 to
+  maplibre `line-width` (both px); exact dash pixel-lengths are a visual detail,
+  not load-bearing — the **intent** (dashed = MQTT/unknown / meshcore) is what
+  matters and is preserved.
+- Traceroute `colorMode` in 2D is dynamic: **directional** (in/outbound colors +
+  arrows) when a node is selected, **SNR** otherwise. 3D replicates this: when
+  `selected?.type==='node'`, color focused segments by `directionColors`
+  (`OUTBOUND_COLOR #3b82f6` / `INBOUND_COLOR` — read the constants from the 2D
+  adapter's exported values; if not exported, redeclare the two hex constants in
+  the 3D adapter with a `// mirror of layers/TraceroutePathsLayer.tsx` comment and
+  cover them in the parity test), else SNR color. **Arrows/curvature are NOT
+  ported** (see §2.6).
+
+### 2.3 Selection shapes for both protocols (the flagged parity item)
+
+**Node clicks are already at parity — no change needed.** Verified: 2D
+`NodeMarkersLayer` sets `setSelected({ type:'node', nodeNum:Number(n.nodeNum),
+sourceId })` — **no `publicKey`** — and the Phase-2 3D `handleNode3DClick`
+sets the byte-identical `{ type:'node', nodeNum:Number(match.node.nodeNum),
+sourceId }`. The inspector resolves both via the same
+`findNode(nodeNum, sourceId)`. MeshCore nodes carry a merge-populated `nodeNum`,
+so this works for MeshCore too. (Known **pre-existing** 2D limitation, shared
+identically by 3D and therefore not a regression: two MeshCore nodes in one
+source that share a `nodeNum` would both resolve to the first match. The 3D
+click first identifies the exact node by `unifiedNodeKey` before downgrading to
+the `{nodeNum,sourceId}` contract, so it is never *worse* than 2D. Fixing the
+shared contract is out of scope.)
+
+**Neighbor-link clicks — the real work.** The 3D neighbor lines must reproduce
+the 2D `setSelected` payloads exactly:
+
+- Meshtastic: `{ type:'neighbor', sourceId, nodeNum, neighborNum, snr, timestamp }`
+- MeshCore:   `{ type:'neighbor', sourceId, publicKey, neighborPublicKey, nodeName, neighborName, snr, timestamp, nodeNum:0, neighborNum:0 }`
+
+The inspector's neighbor branch keys MeshCore off `isMeshCore = !!selected.publicKey`,
+so the meshcore payload MUST include `publicKey`/`neighborPublicKey`/names and the
+`nodeNum:0, neighborNum:0` sentinels — carry them verbatim. These payloads live in
+the `Map<key, SelectedTarget>` the 3D hooks return; the canvas `onLineClick(key)`
+looks the payload up and calls `setSelected`. A parity test asserts the 3D hook's
+payload for a fixture edge deep-equals the 2D adapter's literal object.
+
+**Traceroute-segment clicks — IN scope.** `{ type:'segment', fromNodeNum,
+toNodeNum, direction, occurrences, avgSnr }`. Line-layer click hit-testing works
+identically to circle layers (`map.on('click', <layerId>, …)` → `e.features[0]`),
+so segment selection is tractable at near-zero marginal cost and completes parity.
+Justification for including it: same click mechanism as neighbor lines, and the
+inspector already has a `segment` branch — leaving it out would be an arbitrary
+gap.
+
+### 2.4 Exaggeration persistence → client-local in `mapAnalysis.config.v1`
+
+**Decision: persist the user's chosen exaggeration client-locally, NOT a server
+setting.** Add `exaggeration: number` (default `1.3`) to `MapAnalysisConfig` +
+`setExaggeration`, same path as `viewMode`/`followMode`/`autoZoom`.
+
+Justification:
+- Exaggeration is a per-user, per-browser **view preference**, exactly like
+  `viewMode` (which Phase 2 already put here) — not a deployment policy. A server
+  setting benefits no other user and would add a `VALID_SETTINGS_KEYS` entry + the
+  `SettingsTab.handleSave` dep-array dance for zero cross-user value. The brief
+  says "do not add server settings casually" — this fails that bar.
+- Client-local reuses the existing versioned-localStorage mechanism with no
+  version bump (`load()` spreads `DEFAULT_CONFIG`, so old blobs default to `1.3`).
+
+`Base3DMap` stays generic: keep its internal slider state but seed it from a new
+optional `initialExaggeration?: number` (default `1.3`) prop and emit
+`onExaggerationChange?(v)` on change. Canvas passes
+`initialExaggeration={config.exaggeration}` + `onExaggerationChange={setExaggeration}`.
+Both props optional → existing Base3DMap tests unaffected. (Seed-once, not fully
+controlled: exaggeration only ever changes via this slider, so external re-sync
+after mount is unnecessary and avoids a prop-driven `setTerrain` effect.)
+
+### 2.5 "View terrain profile" from 3D → auto-switch to 2D with the drawer open
+
+Investigation result:
+- `LinkProfileDrawer` is **map-agnostic** (recharts; reads `linkProfileMode`/
+  `linkEndpoints` from context; no leaflet import) **but is mounted only inside
+  the canvas's 2D branch** (after `</BaseMap>`).
+- `LinkProfileController` (the on-map verdict polyline + endpoint rings) is
+  **Leaflet-coupled** (`useMap`, react-leaflet `Polyline`/`CircleMarker`) and
+  mounted inside `BaseMap`.
+- The inspector (page-level) fires the action purely by setting context state.
+
+**Decision: the Phase-1 "View terrain profile" action, when triggered while
+`config.viewMode === '3d'`, additionally calls `setViewMode('2d')`.** The user
+lands in 2D with the drawer open and the link drawn/colored on the Leaflet map.
+
+Rationale: the verdict polyline + endpoint rings are a core part of the profile
+UX and are genuinely Leaflet-only; rendering just the recharts drawer over 3D
+would be a half-experience (chart but no on-map link) and would require relocating
+the drawer mount out of the 2D branch (touching 2D — forbidden). Auto-switch
+reuses everything already built with a **one-line** addition, and the elevation
+fetch is cache-shared (Phase 1), so the drawer opens instantly. Implementation:
+in `AnalysisInspectorPanel`, read `viewMode` + `setViewMode` from
+`useMapAnalysisCtx()`; in the existing profile-action click handler, prepend
+`if (viewMode === '3d') setViewMode('2d');` before the existing
+`setLinkProfileMode`/`setLinkEndpoints` calls.
+
+### 2.6 Traceroute curvature / arrows NOT ported to 3D
+
+2D draws bezier-**curved** segments (`generateCurvedPath`) and direction arrows to
+declutter overlapping links on a flat map. In a pitched 3D scene the pitch itself
+separates overlapping links, and screen-space bezier curves read as artifacts.
+**3D renders straight `LineString`s (2 vertices) and no arrow markers.** This also
+keeps click hit-testing trivial and the GeoJSON small. Direction is still conveyed
+by **color** (directionColors when a node is selected), matching 2D's color
+semantics. Documented as an intentional 3D simplification, not a gap to close.
+
+### 2.7 Terrain draping caveat (document, do not fix)
+
+MapLibre `line` layers are **not sampled onto the DEM** — there is no
+`line-z-offset` in the stable line-layer style spec. Lines render near the base
+plane and are depth-occluded by terrain; under high pitch a link may be partly
+hidden behind a ridge and its endpoints may not visually touch the
+terrain-elevated circle markers. This is acceptable for topological analysis
+(and the occlusion is a rough LOS cue). Note it in the feature doc and the #3826
+closing comment as a follow-up (elevation-sampled lines via `line-z-offset` when
+it stabilizes). Node markers already sit on the terrain surface (circle/symbol
+layers are elevated) — unchanged.
+
+### 2.8 Time-slider window + layer toggles + lookback
+
+3D honors the **same config state** as 2D: the 3D hooks read
+`config.layers.{neighbors,traceroutes}.enabled` (gate output to `[]` when off and
+pass `enabled` to the fetch hook so no request fires), `layer.lookbackHours`, and
+`config.timeSlider.{enabled,windowStartMs,windowEndMs}` (same `inWindow` filter as
+the 2D adapters). The **time-slider UI stays 2D-only** (it's mounted after
+`</BaseMap>`; Phase 2 deferred it and this phase keeps that) — but the persisted
+window is still honored by the 3D data, so switching 2D↔3D never changes which
+links show. Documented.
+
+### 2.9 3D labels / collision
+
+No change. Node labels (symbol layer) already exist with default collision
+(`text-allow-overlap:false`). **No link labels in 3D** — 2D MapAnalysis lines are
+select-only (no popups; details live in the inspector), so 3D matches by design.
+
+## 3. File-by-file changes
+
+### 3.1 `src/components/map/Base3DMap.tsx` (EDIT) — generic line + exaggeration props
+- Export `interface Line3DFeature` (§2.1).
+- Props add: `lines?: Line3DFeature[]`, `onLineClick?: (key: string) => void`,
+  `initialExaggeration?: number`, `onExaggerationChange?: (v: number) => void`.
+- Constants: `LINES_SOURCE_ID='lines'`, `LINES_LAYER_PREFIX='lines-'`.
+- `toLinesFeatureCollection(lines)`: one `Feature<LineString>` per line;
+  `properties: { key, color, opacity, width, dashKey: JSON.stringify(dash ?? []) }`;
+  `geometry.coordinates = [[fromLng,fromLat],[toLng,toLat]]`.
+- On `load` (after node layers): add `lines` GeoJSON source; then for each
+  distinct `dashKey` present, `addLayer({ id:`${LINES_LAYER_PREFIX}${i}`, type:'line',
+  source:'lines', filter:['==',['get','dashKey'], key], paint:{ 'line-color':['get','color'],
+  'line-opacity':['get','opacity'], 'line-width':['get','width'], ...(dash.length?{'line-dasharray':dash}:{}) } })`.
+  Insert line layers **below** the node circle/label layers (pass the beforeId) so
+  markers stay clickable on top. Register `map.on('click', <lineLayerId>, e => { const k=e.features?.[0]?.properties?.key; if(typeof k==='string') onLineClickRef.current?.(k); })`
+  + `mouseenter`/`mouseleave` cursor, per line layer.
+- **Dynamic dash-group set:** the set of distinct `dashKey`s can change when
+  `lines` changes. On the `lines`-change effect (below), if a new `dashKey`
+  appears create its layer; if a `dashKey` disappears remove its layer; always
+  `getSource('lines').setData(...)`. Keep a `useRef<Set<string>>` of live line
+  layer ids to diff. (Simplest correct approach — the alternative, one static set
+  of layers, can't know patterns ahead of time.)
+- `lines`-change effect mirrors the existing nodes-change effect (guard on
+  `loaded`, `setData`, reconcile dash layers).
+- Exaggeration: `useState(initialExaggeration ?? DEFAULT_EXAGGERATION)`; slider
+  `onChange` sets state, calls `map.setTerrain({source, exaggeration})` (existing),
+  **and** `onExaggerationChange?.(v)`. Keep `onExaggerationChangeRef` like the
+  other callback refs.
+- Teardown unchanged (`map.remove()`); line layers/source die with the map.
+
+### 3.2 `src/components/MapAnalysis/use3DNeighborLines.ts` (NEW)
+```ts
+export interface NeighborLines3D { lines: Line3DFeature[]; selectionByKey: Map<string, SelectedTarget>; }
+export function use3DNeighborLines(): NeighborLines3D
+```
+- Reads `config`, `useDashboardSources`, resolves `sourceIds` exactly as the 2D
+  adapters do (empty `config.sources` ⇒ all source ids).
+- `useNeighbors` + `useMeshCoreNeighbors` with `enabled: config.layers.neighbors.enabled`,
+  `sources: sourceIds`, `lookbackHours: layer.lookbackHours ?? 24`.
+- `useDashboardUnifiedData(sourceIds, sourceIds.length>0)` → `positionByKey`
+  (meshtastic: `${sourceId}:${nodeNum}` + `positionByNode` fallback per #3792;
+  meshcore: `${sourceId}:${publicKey}`) — replicate the two 2D adapters'
+  position maps and the transport-class maps (or reuse whatever the meshtastic
+  adapter imports for `transportColor`).
+- Apply the same `inWindow(timestamp)` filter; build meshtastic + meshcore edges;
+  produce `Line3DFeature` per §2.2 and a `SelectedTarget` per §2.3 keyed by the
+  edge `key` (`String(e.id)` — same key the 2D descriptor uses; namespace with a
+  `mt:`/`mc:` prefix to guarantee no meshtastic/meshcore key collision in the
+  merged map and in Base3DMap's source).
+- When `!config.layers.neighbors.enabled` return `{ lines:[], selectionByKey:new Map() }`.
+- `useMemo` all derivations; exhaustive-deps clean (mirror the 2D adapters' dep
+  arrays incl. the existing `eslint-disable` justification if the same shape is
+  needed).
+
+### 3.3 `src/components/MapAnalysis/use3DTracerouteLines.ts` (NEW)
+```ts
+export interface TracerouteLines3D { lines: Line3DFeature[]; selectionByKey: Map<string, SelectedTarget>; }
+export function use3DTracerouteLines(): TracerouteLines3D
+```
+- Mirror the 2D `layers/TraceroutePathsLayer.tsx` data wiring: `useTraceroutes`,
+  build `positionByKey` (skipping `hideFromMap`), `visibleNodeNums`, `options`,
+  `timeWindow`, `selectedNodeNum`/`selectedSourceId` from `selected`, then
+  `useTracerouteAnalysis(...)` → `segments`.
+- `overlayColors` from `useSettings()`; `colorMode = selectedNodeNum!==null ? 'direction' : 'snr'`.
+- Per segment produce a straight `Line3DFeature` (§2.2/§2.6): `color` via
+  `snrToColor`/directionColors, `opacity` via `getSegmentSnrOpacity`, `width` via
+  `weightByOccurrence`, `dash = (isMqtt || avgSnr==null) ? [2,2] : undefined`;
+  `key = 'tr:'+seg.key`; `selectionByKey.set(key, { type:'segment', fromNodeNum,
+  toNodeNum, direction, occurrences, avgSnr })`.
+- Gate on `config.layers.traceroutes.enabled` (return empties when off; pass
+  `enabled` to `useTraceroutes`).
+
+### 3.4 `src/components/MapAnalysis/MapAnalysisCanvas.tsx` (EDIT — 3D branch only)
+- Call `use3DNeighborLines()` and `use3DTracerouteLines()` at the top level
+  (unconditionally — Rules of Hooks; they self-gate on config).
+- `const lines3D = useMemo(() => [...neighbor.lines, ...traceroute.lines], [...])`.
+- `const selectionByKey = useMemo(() => new Map([...neighbor.selectionByKey, ...traceroute.selectionByKey]), [...])`.
+- `handleLine3DClick = useCallback((key) => { const t = selectionByKey.get(key); if (t) setSelected(t); }, [selectionByKey, setSelected])`.
+- In the `effectiveViewMode==='3d'` return, pass to `Base3DMap`:
+  `lines={lines3D}`, `onLineClick={handleLine3DClick}`,
+  `initialExaggeration={config.exaggeration}`, `onExaggerationChange={setExaggeration}`.
+- Pull `setExaggeration` + `config.exaggeration` from `useMapAnalysisCtx()`
+  (they arrive via the `...config` spread).
+- **2D branch unchanged.**
+
+### 3.5 `src/hooks/useMapAnalysisConfig.ts` (EDIT)
+- `MapAnalysisConfig`: add `/** 3D terrain exaggeration (0–2), client-local (#3826 P3). */ exaggeration: number;`.
+- `DEFAULT_CONFIG.exaggeration = 1.3`.
+- `load()`: add `exaggeration: typeof parsed.exaggeration === 'number' ? Math.max(0, Math.min(2, parsed.exaggeration)) : DEFAULT_CONFIG.exaggeration,`.
+- Add `setExaggeration = useCallback((v:number)=>setConfig(p=>({...p, exaggeration:v})),[])`; export it.
+- `MapAnalysisContext` inherits it via `ReturnType<typeof useMapAnalysisConfig>` (no context edit needed).
+
+### 3.6 `src/components/MapAnalysis/AnalysisInspectorPanel.tsx` (EDIT — profile-from-3D)
+- Destructure `viewMode` + `setViewMode` from `useMapAnalysisCtx()`.
+- In the existing neighbor "View terrain profile" click handler (Phase 1),
+  prepend `if (viewMode === '3d') setViewMode('2d');`. No other change; distance/
+  elevation rows already render regardless of view because the panel is page-level.
+
+### 3.7 Docs (WP-4) — see §5.
+
+No backend, route, schema, migration, or settings-key changes.
+
+## 4. Test plan (Vitest only; jsdom + mocked `maplibre-gl`; no browser automation)
+
+### 4.1 `src/components/map/Base3DMap.test.tsx` (EXTEND the existing fake-maplibre suite)
+- Adds a `lines` source + one line layer per distinct `dash` group on load
+  (assert `addSource('lines', {type:'geojson'})`, `addLayer` with
+  `id` prefixed `lines-`, `type:'line'`, data-driven paint `['get','color']` etc.,
+  and `line-dasharray` present only on dashed groups).
+- Two lines with **different** dash arrays create **two** line layers; two with the
+  same dash create **one**.
+- `onLineClick` fires with the feature `key` (drive `map.layerHandlers['click:lines-0']({features:[{properties:{key:'mt:5'}}]})`).
+- `lines` prop change calls `getSource('lines').setData(...)` with the new
+  FeatureCollection; a newly-appearing dash group adds a layer; a vanished group
+  removes it (extend the fake map with `removeLayer` tracking — already present).
+- `initialExaggeration` seeds the slider and the initial `setTerrain`; changing the
+  slider calls `onExaggerationChange` with the new value AND `setTerrain`.
+- Existing tests (nodes, terrain, WebGL-unavailable, StrictMode) stay green with
+  `lines` omitted.
+
+### 4.2 `src/components/MapAnalysis/use3DNeighborLines.test.ts` (NEW)
+- Mock `useNeighbors`/`useMeshCoreNeighbors`/`useDashboardUnifiedData`/`useDashboardSources`
+  and a `MapAnalysisProvider` (or a light ctx wrapper). Render the hook via
+  `renderHook`.
+- Meshtastic edge with two positioned endpoints → one `Line3DFeature`
+  (`color=transportColor`, `opacity=snrToNeighborOpacity(snr)`, `width=2`,
+  `dash=[2,2]`) and `selectionByKey.get('mt:'+id)` **deep-equals**
+  `{ type:'neighbor', sourceId, nodeNum, neighborNum, snr, timestamp }`
+  — the **parity assertion** vs the literal 2D shape.
+- MeshCore edge → `color=#06b6d4`, `width=3`, `dash=[3,2]`, and payload deep-equals
+  `{ type:'neighbor', sourceId, publicKey, neighborPublicKey, nodeName, neighborName, snr, timestamp, nodeNum:0, neighborNum:0 }`.
+- Unpositioned endpoint → edge dropped. Time-slider window excludes out-of-window
+  edges. `config.layers.neighbors.enabled=false` → empty result AND the fetch
+  hooks called with `enabled:false`.
+
+### 4.3 `src/components/MapAnalysis/use3DTracerouteLines.test.ts` (NEW)
+- Mock `useTraceroutes`/`useDashboardUnifiedData` + `useTracerouteAnalysis` (or feed
+  a fixture segment list). Assert straight 2-vertex lines (no curvature), MQTT/
+  unknown-SNR segment gets `dash=[2,2]`, RF segment solid; `selectionByKey`
+  payload deep-equals `{ type:'segment', fromNodeNum, toNodeNum, direction,
+  occurrences, avgSnr }`. `colorMode` flips to direction colors when a node is
+  selected. Disabled layer → empty.
+
+### 4.4 `src/components/MapAnalysis/MapAnalysisCanvas.test.tsx` (EXTEND or NEW)
+- With `viewMode:'3d'` + caps available: `Base3DMap` receives merged `lines`
+  (neighbors + traceroutes) honoring toggles — neighbors off ⇒ no `mt:`/`mc:`
+  lines; traceroutes off ⇒ no `tr:` lines. (Mock `Base3DMap` to capture props.)
+- `onLineClick('mc:7')` → `setSelected` called with the meshcore neighbor payload.
+- `initialExaggeration`/`onExaggerationChange` wired to `config.exaggeration`/
+  `setExaggeration`.
+
+### 4.5 `AnalysisInspectorPanel.test.tsx` (EXTEND)
+- Neighbor selected while `viewMode:'3d'`: clicking "View terrain profile" calls
+  `setViewMode('2d')` **and** the existing `setLinkProfileMode(true)`/
+  `setLinkEndpoints(...)`; while `viewMode:'2d'` it does **not** call `setViewMode`.
+
+### 4.6 `useMapAnalysisConfig.test.ts` (EXTEND)
+- `DEFAULT_CONFIG.exaggeration===1.3`; `load()` restores a stored value, clamps
+  out-of-range to `[0,2]`, defaults missing to `1.3`; `setExaggeration` persists.
+
+**Gate:** full Vitest suite green; `npm run lint:ci` exits 0; `tsc` clean.
+Browser-validate on the dev container (SwiftShader/puppeteer, per Phase 2) — real
+WebGL: neighbor + traceroute lines render, click a line → inspector opens, profile
+action drops to 2D with the drawer, exaggeration persists across reload.
+
+## 5. Work packages (Sonnet-sized, dependency-ordered)
+
+### WP-1 — `Base3DMap` generic line support + exaggeration props *(no MapAnalysis, no 2D)*
+**Scope:** §3.1 + §4.1. Add `Line3DFeature`, `lines`/`onLineClick`/
+`initialExaggeration`/`onExaggerationChange`; per-dash-group line layers on one
+GeoJSON source; dynamic dash-layer reconciliation; click/cursor handlers below
+node layers; slider seeded + emitting. Extend the fake-maplibre test.
+**Depends on:** none.
+**Acceptance:** new + existing Base3DMap tests green; component imports nothing
+from MapAnalysis (no `SelectedTarget`); `lint:ci`/`tsc` clean; `lines` omitted ⇒
+byte-identical to today's behavior.
+
+### WP-2 — 3D line data hooks + parity tests *(reuse shared fetch hooks + primitives)*
+**Scope:** §3.2, §3.3 + §4.2, §4.3. `use3DNeighborLines` (meshtastic+meshcore) and
+`use3DTracerouteLines`, each returning `{ lines, selectionByKey }`, self-gating on
+config + time window, reusing `useNeighbors`/`useMeshCoreNeighbors`/`useTraceroutes`/
+`useTracerouteAnalysis`/`useDashboardUnifiedData` and the shared color/opacity/
+weight primitives. Parity tests deep-equal the `SelectedTarget` payloads to the
+literal 2D shapes.
+**Depends on:** WP-1 (imports `Line3DFeature`).
+**Acceptance:** hooks return correct lines + payloads for both protocols +
+segments; disabled layers ⇒ empty + `enabled:false` fetch; parity tests pass; no
+2D file touched; `lint:ci`/`tsc` clean.
+
+### WP-3 — Canvas 3D wiring + inspector profile auto-switch + exaggeration config
+**Scope:** §3.4, §3.5, §3.6 + §4.4, §4.5, §4.6. Wire the two hooks into the canvas
+3D branch (merged `lines`, `onLineClick`→`setSelected`, exaggeration props); add
+`exaggeration`/`setExaggeration` to the config hook; inspector profile action
+drops to 2D when in 3D.
+**Depends on:** WP-1, WP-2.
+**Acceptance:** 3D branch feeds toggle-honoring lines; line click selects (incl.
+meshcore); profile-from-3D switches to 2D; exaggeration persists; 2D branch and
+its tests unchanged; full suite + `lint:ci` green; **browser-validated** on the
+dev container.
+
+### WP-4 — Docs + epic close-out
+**Scope:**
+- `docs/features/map-analysis.md`: shrink **"What's not in 3D yet"** (remove
+  neighbor links, traceroute paths, and node/link selection; keep heatmap /
+  trails / range rings / hop-shading / SNR overlay + time-slider UI). Update
+  **"Using the 3D view"**: exaggeration now **persists** per-browser; clicking a
+  node/link/segment opens the inspector; "View terrain profile" from 3D switches
+  to 2D with the drawer. Add the §2.7 draping caveat under a short limitations note.
+- `docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md`: tick Phase 3, add a status-log
+  entry; paste the closing-comment draft (below) into the doc.
+- **Draft the #3826 closing comment as text in this spec + the epic doc — do NOT
+  post it.**
+**Depends on:** WP-3 (docs describe shipped behavior).
+**Acceptance:** docs merged with the phase; epic doc checked off; closing-comment
+draft present.
+
+### Draft closing comment for issue #3826 (text only — do not post)
+> **3D Map & Elevation — shipped (3 phases).**
+> **Phase 1 (#4235):** Map Analysis inspector shows per-neighbor-link distance +
+> endpoint ground elevations and a one-click "View terrain profile" reusing the
+> #4111 Link Profile drawer, for both Meshtastic and MeshCore links.
+> **Phase 2 (#4239):** DEM tile proxy (`GET /api/elevation/tiles/:z/:x/:y` +
+> `/api/elevation/capabilities`, server-derived because the source URL is secret;
+> JSON point-sources return `TERRAIN_TILES_UNAVAILABLE` — no silent AWS fallback)
+> and a standalone MapLibre GL 3D terrain view behind a persisted 2D/3D toggle,
+> with terrarium raster-dem terrain, hillshade, node markers, an exaggeration
+> slider, and graceful no-WebGL fallback.
+> **Phase 3 (`<PR#>`):** neighbor links + traceroute paths in 3D honoring the same
+> toggles/filters/lookback/time-window as 2D; full selection parity (node,
+> neighbor — Meshtastic & MeshCore, and traceroute-segment) into the shared
+> inspector; "View terrain profile" from 3D auto-switches to 2D with the drawer;
+> exaggeration now persists per-browser.
+> **Out of scope (follow-ups):** indoor/venue and custom 3D tilesets — the cheap
+> first step is `fill-extrusion` building footprints from vector tiles. 3D link
+> lines are not yet terrain-draped (MapLibre renders `line` layers in-plane;
+> revisit with `line-z-offset` elevation sampling when it stabilizes). Time-slider
+> UI and coverage-heatmap/trails/range-rings/hop-shading/SNR overlays remain 2D-only.
+
+## 6. Invariants honored / non-goals
+
+- **Honored:** Base3DMap stays Map-Analysis-agnostic (data via props, keys out);
+  2D render paths and their tests untouched; 3D reuses the same data hooks +
+  shared primitives; TS strict / no `any` / no raw `fetch` in components /
+  exhaustive-deps clean; no migration; no new server settings key (exaggeration is
+  client-local like `viewMode`); selection payloads locked to the 2D shapes by
+  parity tests.
+- **Non-goals (this phase / epic):** traceroute curvature + arrows in 3D
+  (color-only direction); on-map link labels/popups in 3D (inspector-only, matches
+  2D); time-slider UI in 3D (window state still honored); terrain-draped lines
+  (documented follow-up); coverage heatmap / trails / range rings / hop shading /
+  SNR overlay in 3D; indoor / custom 3D tilesets (epic-level follow-up, fill-extrusion first).

--- a/docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md
+++ b/docs/internal/dev-notes/MAP_3D_ELEVATION_EPIC.md
@@ -60,7 +60,7 @@ Exit criteria:
 - 3D toggle renders pitched terrain with hillshade + node markers on the dev container; 2D mode unchanged/regression-free.
 - Full suite green; browser-validated with screenshots.
 
-### Phase 3 — 3D layers + polish ⬜
+### Phase 3 — 3D layers + polish ✅
 
 Branch: `feature/3826-3d-layers-polish`
 
@@ -80,3 +80,25 @@ Exit criteria:
 - 2026-07-20: Epic started. Interview complete, phases agreed (3 phases; user merged tile-proxy + 3D-foundation into Phase 2).
 - 2026-07-20: Phase 2 implemented (spec: `3D_MAP_FOUNDATION_SPEC.md`; 4 work packages A–D). Backend: `GET /api/elevation/tiles/:z/:x/:y` PNG proxy (raw-PNG LRU separate from the decoded cache, `elevationTileLimiter` 600/min, immutable 7-day Cache-Control) + `GET /api/elevation/capabilities` (server-derived because `elevationSourceUrl` is secret); JSON point sources return 409 TERRAIN_TILES_UNAVAILABLE by design — no silent AWS fallback. Frontend: `Base3DMap` (standalone MapLibre GL: terrarium raster-dem terrain, hillshade, pitch 60°, exaggeration slider, GeoJSON node markers), `basemap3d.ts` ({s}-expansion + vector→osm fallback), `useTerrainCapabilities`, `viewMode` persisted in `mapAnalysis.config.v1`. Browser validation found + fixed a real defect: no-WebGL browsers crashed to a blank page when '3d' was persisted (probe + try/catch + `onUnsupported`→ auto-revert to 2D, commit 5340484d). 3D rendering validated via puppeteer + SwiftShader (MCP browser has no WebGL); gating/tooltip/persistence/force-2D all validated live. Phase 3 note: 3D node click selects via `{nodeNum, sourceId}` — verify MeshCore selection parity when wiring the inspector.
 - 2026-07-20: Phase 1 implemented (spec: `NEIGHBOR_LINK_TERRAIN_SPEC.md`). Frontend-only; new `neighborLinkEndpoints.ts` resolver + inspector wiring. Key decisions during the phase: endpoint elevations reuse `useElevationProfile` with the drawer's exact query key (one fetch per link, drawer open is a cache hit — verified live, request count stayed at 1); `LinkEndpoint.id` uses `unifiedNodeKey` for byte-for-byte parity with `linkEndpointCandidates`. Browser-validated on the dev container: MeshCore link (distance/elevations/profile action + drawer w/ auto-seeded frequency), Meshtastic link (distance via nodeNum resolution), and elevation-disabled gating (distance only, zero elevation requests). Full suite 10,427/0. Note: dev DB had no `/api/analysis/neighbors` rows initially — Meshtastic live check came from an MQTT-broker-source neighbor link.
+- 2026-07-20: Phase 3 implemented (spec: `3D_LAYERS_POLISH_SPEC.md`; 4 work packages). WP-1 (`cf6ca6f8`): generic `Line3DFeature` + `lines`/`onLineClick`/`initialExaggeration`/`onExaggerationChange` props added to `Base3DMap`, keeping it Map-Analysis-agnostic — per-distinct-dash-pattern line layers on one shared GeoJSON source (MapLibre can't data-drive `line-dasharray` from feature properties), inserted below the node marker layers so markers stay clickable on top. WP-2 (`7c445eb3`): new `use3DNeighborLines`/`use3DTracerouteLines` hooks reuse the same fetch hooks and shared color/opacity/weight primitives as the 2D adapters (`snrToNeighborOpacity`, `snrToColor`, `getSegmentSnrOpacity`, `weightByOccurrence`, `transportColor`), each locked to the 2D `SelectedTarget` shape by a parity test (byte-identical payload for Meshtastic neighbor, MeshCore neighbor, and traceroute segment). WP-3 (`c6662f19`): wired both hooks into the 3D canvas branch (merged lines + click→`setSelected`), added `exaggeration`/`setExaggeration` to `useMapAnalysisConfig` (client-local, `mapAnalysis.config.v1`, clamped 0–2, default 1.3 — no migration, no server settings key), and made the inspector's "View terrain profile" action call `setViewMode('2d')` before opening the drawer when triggered from 3D (the verdict polyline + endpoint rings are Leaflet-only, so profile-from-3D always lands in 2D). Traceroute curvature/arrows and on-map link labels/popups are intentionally not ported to 3D (§2.6/§2.9 of the spec); 3D lines are not terrain-draped (§2.7, documented follow-up). Full suite 10,578/0. **Epic status: all three phases complete, pending PR merge and #3826 issue closeout** (draft closing comment in `3D_LAYERS_POLISH_SPEC.md` §5, reproduced below).
+
+> **3D Map & Elevation — shipped (3 phases).**
+> **Phase 1 (#4235):** Map Analysis inspector shows per-neighbor-link distance +
+> endpoint ground elevations and a one-click "View terrain profile" reusing the
+> #4111 Link Profile drawer, for both Meshtastic and MeshCore links.
+> **Phase 2 (#4239):** DEM tile proxy (`GET /api/elevation/tiles/:z/:x/:y` +
+> `/api/elevation/capabilities`, server-derived because the source URL is secret;
+> JSON point-sources return `TERRAIN_TILES_UNAVAILABLE` — no silent AWS fallback)
+> and a standalone MapLibre GL 3D terrain view behind a persisted 2D/3D toggle,
+> with terrarium raster-dem terrain, hillshade, node markers, an exaggeration
+> slider, and graceful no-WebGL fallback.
+> **Phase 3 (`<PR#>`):** neighbor links + traceroute paths in 3D honoring the same
+> toggles/filters/lookback/time-window as 2D; full selection parity (node,
+> neighbor — Meshtastic & MeshCore, and traceroute-segment) into the shared
+> inspector; "View terrain profile" from 3D auto-switches to 2D with the drawer;
+> exaggeration now persists per-browser.
+> **Out of scope (follow-ups):** indoor/venue and custom 3D tilesets — the cheap
+> first step is `fill-extrusion` building footprints from vector tiles. 3D link
+> lines are not yet terrain-draped (MapLibre renders `line` layers in-plane;
+> revisit with `line-z-offset` elevation sampling when it stabilizes). Time-slider
+> UI and coverage-heatmap/trails/range-rings/hop-shading/SNR overlays remain 2D-only.

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
@@ -226,6 +226,7 @@ function CtxProbe() {
       {JSON.stringify({
         linkProfileMode: ctx.linkProfileMode,
         measureMode: ctx.measureMode,
+        viewMode: ctx.config.viewMode,
         linkEndpoints: ctx.linkEndpoints.map((e) => ({
           nodeNum: e.nodeNum,
           isMeshCore: e.isMeshCore,
@@ -238,6 +239,11 @@ function CtxProbe() {
 function SetMeasureModeOn() {
   const ctx = useMapAnalysisCtx();
   return <button onClick={() => ctx.setMeasureMode(true)}>set-measure-mode</button>;
+}
+
+function SetViewMode3D() {
+  const ctx = useMapAnalysisCtx();
+  return <button onClick={() => ctx.setViewMode('3d')}>set-view-mode-3d</button>;
 }
 
 describe('AnalysisInspectorPanel', () => {
@@ -476,6 +482,49 @@ describe('AnalysisInspectorPanel', () => {
         { nodeNum: 1, isMeshCore: false },
         { nodeNum: 2, isMeshCore: false },
       ]);
+    });
+
+    // #3826 Phase 3 §2.5: profile-from-3D auto-switch.
+    it('switches viewMode to 2d AND dispatches the profile state when triggered while in 3D', () => {
+      render(
+        <Wrapper>
+          <SetViewMode3D />
+          <CtxProbe />
+          <SelectNeighbor />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('set-view-mode-3d'));
+      expect(screen.getByTestId('ctx-probe').textContent).toContain('"viewMode":"3d"');
+
+      fireEvent.click(screen.getByText('select-neighbor'));
+      fireEvent.click(screen.getByText('View terrain profile'));
+
+      const probe = JSON.parse(screen.getByTestId('ctx-probe').textContent ?? '{}');
+      expect(probe.viewMode).toBe('2d');
+      expect(probe.linkProfileMode).toBe(true);
+      expect(probe.linkEndpoints).toEqual([
+        { nodeNum: 1, isMeshCore: false },
+        { nodeNum: 2, isMeshCore: false },
+      ]);
+    });
+
+    it('does NOT call setViewMode when triggered while already in 2d', () => {
+      render(
+        <Wrapper>
+          <CtxProbe />
+          <SelectNeighbor />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      expect(screen.getByTestId('ctx-probe').textContent).toContain('"viewMode":"2d"');
+
+      fireEvent.click(screen.getByText('select-neighbor'));
+      fireEvent.click(screen.getByText('View terrain profile'));
+
+      const probe = JSON.parse(screen.getByTestId('ctx-probe').textContent ?? '{}');
+      expect(probe.viewMode).toBe('2d');
+      expect(probe.linkProfileMode).toBe(true);
     });
   });
 });

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -64,6 +64,7 @@ export default function AnalysisInspectorPanel() {
     setLinkEndpoints,
     setLinkProfileMode,
     setMeasureMode,
+    setViewMode,
   } = useMapAnalysisCtx();
   const { distanceUnit } = useSettings();
   const elevationEnabled = useElevationEnabled();
@@ -376,6 +377,10 @@ export default function AnalysisInspectorPanel() {
             type="button"
             className="map-analysis-link-profile-action"
             onClick={() => {
+              // #3826 Phase 3 §2.5: triggering the profile action while in 3D
+              // auto-switches to 2D, where the drawer + on-map verdict
+              // polyline/endpoint rings actually render.
+              if (config.viewMode === '3d') setViewMode('2d');
               setMeasureMode(false);
               setLinkEndpoints([neighborEndpoints.a, neighborEndpoints.b]);
               setLinkProfileMode(true);

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import MapAnalysisCanvas from './MapAnalysisCanvas';
-import { MapAnalysisProvider } from './MapAnalysisContext';
+import { MapAnalysisProvider, useMapAnalysisCtx } from './MapAnalysisContext';
 
 // Stub react-leaflet — Vitest's jsdom doesn't provide all the DOM bits Leaflet needs.
 vi.mock('react-leaflet', () => ({
@@ -134,6 +134,25 @@ vi.mock('../../hooks/useTerrainCapabilities', () => ({
   useTerrainCapabilities: () => terrainCapabilitiesMock,
 }));
 
+// #3826 Phase 3 WP-3: the two WP-2 3D line-data hooks are mocked directly so
+// this suite can assert the canvas's merge/click/exaggeration wiring without
+// exercising their internal data-fetch stack (that's use3DNeighborLines.test.ts
+// / use3DTracerouteLines.test.ts's job). Mutable per test.
+let neighborLines3DMock: {
+  lines: Array<{ key: string; from: [number, number]; to: [number, number]; color: string; opacity: number; width: number; dash?: number[] }>;
+  selectionByKey: Map<string, Record<string, unknown>>;
+} = { lines: [], selectionByKey: new Map() };
+let tracerouteLines3DMock: {
+  lines: Array<{ key: string; from: [number, number]; to: [number, number]; color: string; opacity: number; width: number; dash?: number[] }>;
+  selectionByKey: Map<string, Record<string, unknown>>;
+} = { lines: [], selectionByKey: new Map() };
+vi.mock('./use3DNeighborLines', () => ({
+  use3DNeighborLines: () => neighborLines3DMock,
+}));
+vi.mock('./use3DTracerouteLines', () => ({
+  use3DTracerouteLines: () => tracerouteLines3DMock,
+}));
+
 // Base3DMap wraps maplibre-gl directly (WebGL) — unusable under jsdom (see
 // spec §4 test plan / Base3DMap.test.tsx, which mocks `maplibre-gl` itself).
 // Here it's mocked at the component level: a stub that renders the mapped
@@ -146,8 +165,17 @@ vi.mock('../map/Base3DMap', () => ({
     terrainTileUrl: string;
     onNodeClick?: (key: string) => void;
     onUnsupported?: () => void;
+    lines?: Array<{ key: string }>;
+    onLineClick?: (key: string) => void;
+    initialExaggeration?: number;
+    onExaggerationChange?: (v: number) => void;
   }) => (
-    <div data-testid="base-3d-map" data-terrain-url={props.terrainTileUrl}>
+    <div
+      data-testid="base-3d-map"
+      data-terrain-url={props.terrainTileUrl}
+      data-line-keys={(props.lines ?? []).map((l) => l.key).join(',')}
+      data-initial-exaggeration={props.initialExaggeration}
+    >
       {props.nodes.map((n) => (
         <button
           key={n.key}
@@ -158,6 +186,16 @@ vi.mock('../map/Base3DMap', () => ({
           {n.label}
         </button>
       ))}
+      {(props.lines ?? []).map((l) => (
+        <button
+          key={l.key}
+          type="button"
+          data-testid={`base-3d-line-${l.key}`}
+          onClick={() => props.onLineClick?.(l.key)}
+        >
+          {l.key}
+        </button>
+      ))}
       {/* Lets tests simulate the real component's WebGL-unavailable signal. */}
       <button
         type="button"
@@ -165,6 +203,14 @@ vi.mock('../map/Base3DMap', () => ({
         onClick={() => props.onUnsupported?.()}
       >
         trigger-unsupported
+      </button>
+      {/* Lets tests simulate the exaggeration slider changing. */}
+      <button
+        type="button"
+        data-testid="base-3d-change-exaggeration"
+        onClick={() => props.onExaggerationChange?.(1.9)}
+      >
+        change-exaggeration
       </button>
     </div>
   ),
@@ -215,12 +261,20 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
+/** Reads live context state (selected target) so tests can assert onLineClick's dispatch. */
+function SelectedProbe() {
+  const ctx = useMapAnalysisCtx();
+  return <div data-testid="selected-probe">{JSON.stringify(ctx.selected)}</div>;
+}
+
 describe('MapAnalysisCanvas', () => {
   beforeEach(() => {
     localStorage.clear();
     mapTilesetMock = 'osm';
     customTilesetsMock = [];
     terrainCapabilitiesMock = { enabled: true, terrainTiles: true, isLoading: false };
+    neighborLines3DMock = { lines: [], selectionByKey: new Map() };
+    tracerouteLines3DMock = { lines: [], selectionByKey: new Map() };
   });
 
   it('renders the map container and tile layer, and NOT Base3DMap, in 2d (default)', () => {
@@ -333,6 +387,133 @@ describe('MapAnalysisCanvas', () => {
       // The corrected viewMode also persists so the next visit doesn't retry 3D.
       const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
       expect(stored.viewMode).toBe('2d');
+    });
+
+    // #3826 Phase 3 WP-3: neighbor/traceroute line wiring + exaggeration.
+    describe('3D line + exaggeration wiring (#3826 Phase 3 WP-3)', () => {
+      it('feeds Base3DMap the merged neighbor + traceroute lines from the WP-2 hooks', () => {
+        neighborLines3DMock = {
+          lines: [
+            { key: 'mt:1', from: [30, -90], to: [31, -91], color: '#06b6d4', opacity: 0.75, width: 2, dash: [2, 2] },
+            { key: 'mc:7', from: [30, -90], to: [31, -91], color: '#06b6d4', opacity: 0.75, width: 3, dash: [3, 2] },
+          ],
+          selectionByKey: new Map(),
+        };
+        tracerouteLines3DMock = {
+          lines: [{ key: 'tr:1-2', from: [30, -90], to: [31, -91], color: '#22c55e', opacity: 1, width: 2 }],
+          selectionByKey: new Map(),
+        };
+        persist3d();
+        render(<MapAnalysisCanvas />, { wrapper });
+        expect(screen.getByTestId('base-3d-map')).toHaveAttribute('data-line-keys', 'mt:1,mc:7,tr:1-2');
+      });
+
+      it('passes through empty lines when both WP-2 hooks report their layers off', () => {
+        // beforeEach seeds both mocks empty — asserts empty state flows through untouched.
+        persist3d();
+        render(<MapAnalysisCanvas />, { wrapper });
+        expect(screen.getByTestId('base-3d-map')).toHaveAttribute('data-line-keys', '');
+      });
+
+      it('honors the neighbor-only toggle: neighbor lines present, no traceroute lines when that hook is empty', () => {
+        neighborLines3DMock = {
+          lines: [{ key: 'mt:1', from: [30, -90], to: [31, -91], color: '#06b6d4', opacity: 0.75, width: 2, dash: [2, 2] }],
+          selectionByKey: new Map(),
+        };
+        persist3d();
+        render(<MapAnalysisCanvas />, { wrapper });
+        const keys = screen.getByTestId('base-3d-map').getAttribute('data-line-keys');
+        expect(keys).toContain('mt:1');
+        expect(keys).not.toContain('tr:');
+      });
+
+      it('honors the traceroute-only toggle: traceroute lines present, no neighbor lines when that hook is empty', () => {
+        tracerouteLines3DMock = {
+          lines: [{ key: 'tr:1-2', from: [30, -90], to: [31, -91], color: '#22c55e', opacity: 1, width: 2 }],
+          selectionByKey: new Map(),
+        };
+        persist3d();
+        render(<MapAnalysisCanvas />, { wrapper });
+        const keys = screen.getByTestId('base-3d-map').getAttribute('data-line-keys');
+        expect(keys).toContain('tr:1-2');
+        expect(keys).not.toContain('mt:');
+        expect(keys).not.toContain('mc:');
+      });
+
+      it('onLineClick dispatches setSelected with the meshcore neighbor payload for an "mc:" key', () => {
+        const mcTarget = {
+          type: 'neighbor',
+          sourceId: 'a',
+          publicKey: 'aa',
+          neighborPublicKey: 'bb',
+          nodeName: 'Alpha',
+          neighborName: 'Beta',
+          snr: 5,
+          timestamp: 0,
+          nodeNum: 0,
+          neighborNum: 0,
+        };
+        neighborLines3DMock = {
+          lines: [{ key: 'mc:7', from: [30, -90], to: [31, -91], color: '#06b6d4', opacity: 0.75, width: 3, dash: [3, 2] }],
+          selectionByKey: new Map([['mc:7', mcTarget]]),
+        };
+        persist3d();
+        render(
+          <>
+            <SelectedProbe />
+            <MapAnalysisCanvas />
+          </>,
+          { wrapper },
+        );
+        fireEvent.click(screen.getByTestId('base-3d-line-mc:7'));
+        expect(JSON.parse(screen.getByTestId('selected-probe').textContent ?? 'null')).toEqual(mcTarget);
+      });
+
+      it('onLineClick dispatches setSelected with the meshtastic neighbor payload for an "mt:" key', () => {
+        const mtTarget = { type: 'neighbor', sourceId: 'a', nodeNum: 1, neighborNum: 2, snr: 5, timestamp: 0 };
+        neighborLines3DMock = {
+          lines: [{ key: 'mt:1', from: [30, -90], to: [31, -91], color: '#06b6d4', opacity: 0.75, width: 2, dash: [2, 2] }],
+          selectionByKey: new Map([['mt:1', mtTarget]]),
+        };
+        persist3d();
+        render(
+          <>
+            <SelectedProbe />
+            <MapAnalysisCanvas />
+          </>,
+          { wrapper },
+        );
+        fireEvent.click(screen.getByTestId('base-3d-line-mt:1'));
+        expect(JSON.parse(screen.getByTestId('selected-probe').textContent ?? 'null')).toEqual(mtTarget);
+      });
+
+      it('clicking a line with no matching selectionByKey entry does not throw or change the selection', () => {
+        neighborLines3DMock = {
+          lines: [{ key: 'mt:1', from: [30, -90], to: [31, -91], color: '#06b6d4', opacity: 0.75, width: 2, dash: [2, 2] }],
+          selectionByKey: new Map(),
+        };
+        persist3d();
+        render(
+          <>
+            <SelectedProbe />
+            <MapAnalysisCanvas />
+          </>,
+          { wrapper },
+        );
+        expect(() => fireEvent.click(screen.getByTestId('base-3d-line-mt:1'))).not.toThrow();
+        expect(screen.getByTestId('selected-probe').textContent).toBe('null');
+      });
+
+      it('passes config.exaggeration as initialExaggeration and persists onExaggerationChange via setExaggeration', () => {
+        persist3d();
+        render(<MapAnalysisCanvas />, { wrapper });
+        expect(screen.getByTestId('base-3d-map')).toHaveAttribute('data-initial-exaggeration', '1.3');
+
+        fireEvent.click(screen.getByTestId('base-3d-change-exaggeration'));
+
+        const stored = JSON.parse(localStorage.getItem('mapAnalysis.config.v1')!);
+        expect(stored.exaggeration).toBe(1.9);
+      });
     });
   });
 });

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -11,10 +11,13 @@ import LinkProfileDrawer from './LinkProfileDrawer';
 import LinkProfileHoverLayer from './LinkProfileHoverLayer';
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import { BaseMap } from '../map/BaseMap';
-import { Base3DMap, type Node3DFeature } from '../map/Base3DMap';
+import { Base3DMap, type Node3DFeature, type Line3DFeature } from '../map/Base3DMap';
 import { resolve3DBasemap, buildTerrainTileUrl } from '../../config/basemap3d';
 import { useTerrainCapabilities } from '../../hooks/useTerrainCapabilities';
 import { appBasename } from '../../init';
+import { use3DNeighborLines } from './use3DNeighborLines';
+import { use3DTracerouteLines } from './use3DTracerouteLines';
+import type { SelectedTarget } from './MapAnalysisContext';
 import NodeMarkersLayer from './layers/NodeMarkersLayer';
 import TraceroutePathsLayer from './layers/TraceroutePathsLayer';
 import NeighborLinksLayer from './layers/NeighborLinksLayer';
@@ -53,6 +56,7 @@ export default function MapAnalysisCanvas() {
     linkEndpoints,
     setLinkEndpoints,
     linkVerdict,
+    setExaggeration,
   } = useMapAnalysisCtx();
 
   // #3636: measurement endpoints, from the same visible+positioned node list
@@ -141,6 +145,32 @@ export default function MapAnalysisCanvas() {
     },
     [analysisNodes, setSelected],
   );
+
+  // #3826 Phase 3 WP-3 (spec §3.4): neighbor + traceroute lines in 3D. Called
+  // unconditionally (Rules of Hooks) — both hooks self-gate on their layer
+  // toggle/time-window and return empties when off, matching the 2D panes'
+  // `config.layers.*.enabled` guards above.
+  const neighborLines3D = use3DNeighborLines();
+  const tracerouteLines3D = use3DTracerouteLines();
+  const lines3D: Line3DFeature[] = useMemo(
+    () => [...neighborLines3D.lines, ...tracerouteLines3D.lines],
+    [neighborLines3D.lines, tracerouteLines3D.lines],
+  );
+  const line3DSelectionByKey = useMemo(
+    () => new Map<string, SelectedTarget>([
+      ...neighborLines3D.selectionByKey,
+      ...tracerouteLines3D.selectionByKey,
+    ]),
+    [neighborLines3D.selectionByKey, tracerouteLines3D.selectionByKey],
+  );
+  const handleLine3DClick = useCallback(
+    (key: string) => {
+      const target = line3DSelectionByKey.get(key);
+      if (target) setSelected(target);
+    },
+    [line3DSelectionByKey, setSelected],
+  );
+
   // WebGL unavailable on this machine (probe failed or map construction
   // threw): Base3DMap renders its own fallback message, but we also route
   // the user back to the working 2D map so they aren't stranded in 3D mode.
@@ -156,7 +186,11 @@ export default function MapAnalysisCanvas() {
           terrainTileUrl={terrainTileUrl}
           nodes={node3DFeatures}
           onNodeClick={handleNode3DClick}
+          lines={lines3D}
+          onLineClick={handleLine3DClick}
           onUnsupported={handle3DUnsupported}
+          initialExaggeration={config.exaggeration}
+          onExaggerationChange={setExaggeration}
         />
         {basemap3D.usedFallback && (
           <div className="map-analysis-3d-fallback-note">

--- a/src/components/MapAnalysis/use3DNeighborLines.test.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MapAnalysisProvider } from './MapAnalysisContext';
+import { use3DNeighborLines } from './use3DNeighborLines';
+
+// Mutable mock state so individual tests can vary the edges/nodes, same
+// convention as layers/NeighborLinksLayer.test.tsx /
+// layers/MeshCoreNeighborLinksLayer.test.tsx.
+const mockState: {
+  mtEdges: Array<Record<string, unknown>>;
+  mcEdges: Array<Record<string, unknown>>;
+  nodes: Array<Record<string, unknown>>;
+} = { mtEdges: [], mcEdges: [], nodes: [] };
+
+const mockUseNeighbors = vi.fn((args: unknown) => ({ data: { items: mockState.mtEdges }, isLoading: false, args }));
+const mockUseMeshCoreNeighbors = vi.fn((args: unknown) => ({ data: { items: mockState.mcEdges }, isLoading: false, args }));
+
+vi.mock('../../hooks/useMapAnalysisData', () => ({
+  useNeighbors: (args: unknown) => mockUseNeighbors(args),
+  useMeshCoreNeighbors: (args: unknown) => mockUseMeshCoreNeighbors(args),
+}));
+vi.mock('../../hooks/useDashboardData', () => ({
+  useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }] }),
+  useDashboardUnifiedData: () => ({ nodes: mockState.nodes }),
+  UNIFIED_SOURCE_ID: '__unified__',
+}));
+
+const NEIGHBORS_ENABLED_CONFIG = {
+  version: 1,
+  layers: {
+    markers: { enabled: true, lookbackHours: null },
+    traceroutes: { enabled: false, lookbackHours: 24 },
+    neighbors: { enabled: true, lookbackHours: 24 },
+    heatmap: { enabled: false, lookbackHours: 24 },
+    trails: { enabled: false, lookbackHours: 24 },
+    hopShading: { enabled: false, lookbackHours: null },
+    snrOverlay: { enabled: false, lookbackHours: null },
+    waypoints: { enabled: true, lookbackHours: null },
+    polarGrid: { enabled: false, lookbackHours: null },
+  },
+  sources: [],
+  timeSlider: { enabled: false },
+  inspectorOpen: true,
+  selectedNodeIds: [],
+};
+
+function setConfig(overrides: Record<string, unknown> = {}) {
+  localStorage.setItem(
+    'mapAnalysis.config.v1',
+    JSON.stringify({ ...NEIGHBORS_ENABLED_CONFIG, ...overrides }),
+  );
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient();
+  return createElement(QueryClientProvider, { client: qc }, createElement(MapAnalysisProvider, null, children));
+}
+
+describe('use3DNeighborLines', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUseNeighbors.mockClear();
+    mockUseMeshCoreNeighbors.mockClear();
+    mockState.mtEdges = [{ id: 1, nodeNum: 1, neighborNum: 2, sourceId: 'a', snr: 5, timestamp: 0 }];
+    mockState.mcEdges = [
+      {
+        id: 7,
+        publicKey: 'aa',
+        neighborPublicKey: 'bb',
+        sourceId: 'a',
+        snr: 5,
+        timestamp: 0,
+        nodeName: 'Alpha',
+        neighborName: 'Beta',
+      },
+    ];
+    mockState.nodes = [
+      { nodeNum: 1, sourceId: 'a', position: { latitude: 30, longitude: -90 } },
+      { nodeNum: 2, sourceId: 'a', position: { latitude: 31, longitude: -91 } },
+      { sourceId: 'a', isMeshCore: true, publicKey: 'aa', position: { latitude: 30, longitude: -90 } },
+      { sourceId: 'a', isMeshCore: true, publicKey: 'bb', position: { latitude: 31, longitude: -91 } },
+    ];
+    setConfig();
+  });
+
+  it('produces a Line3DFeature for a positioned meshtastic edge with §2.2 encoding', () => {
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const line = result.current.lines.find((l) => l.key === 'mt:1');
+    expect(line).toBeDefined();
+    expect(line).toEqual({
+      key: 'mt:1',
+      from: [30, -90],
+      to: [31, -91],
+      color: '#06b6d4', // transportColor('rf')
+      opacity: 0.75, // snrToNeighborOpacity(5) = clamp((5+10)/20, 0.2, 1)
+      width: 2,
+      dash: [2, 2],
+    });
+  });
+
+  it('PARITY: meshtastic selectionByKey deep-equals the 2D setSelected payload (layers/NeighborLinksLayer.tsx L164-171)', () => {
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    expect(result.current.selectionByKey.get('mt:1')).toEqual({
+      type: 'neighbor',
+      sourceId: 'a',
+      nodeNum: 1,
+      neighborNum: 2,
+      snr: 5,
+      timestamp: 0,
+    });
+  });
+
+  it('produces a Line3DFeature for a positioned meshcore edge with §2.2 encoding', () => {
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const line = result.current.lines.find((l) => l.key === 'mc:7');
+    expect(line).toBeDefined();
+    expect(line).toEqual({
+      key: 'mc:7',
+      from: [30, -90],
+      to: [31, -91],
+      color: '#06b6d4', // MC_NEIGHBOR_COLOR
+      opacity: 0.75,
+      width: 3,
+      dash: [3, 2],
+    });
+  });
+
+  it('PARITY: meshcore selectionByKey deep-equals the 2D setSelected payload (layers/MeshCoreNeighborLinksLayer.tsx L125-136)', () => {
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    expect(result.current.selectionByKey.get('mc:7')).toEqual({
+      type: 'neighbor',
+      sourceId: 'a',
+      publicKey: 'aa',
+      neighborPublicKey: 'bb',
+      nodeName: 'Alpha',
+      neighborName: 'Beta',
+      snr: 5,
+      timestamp: 0,
+      nodeNum: 0,
+      neighborNum: 0,
+    });
+  });
+
+  it('drops a meshtastic edge when an endpoint has no position anywhere', () => {
+    mockState.nodes = [{ nodeNum: 1, sourceId: 'a', position: { latitude: 30, longitude: -90 } }];
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(false);
+  });
+
+  it('drops a meshcore edge when an endpoint has no position anywhere', () => {
+    mockState.nodes = [
+      { sourceId: 'a', isMeshCore: true, publicKey: 'aa', position: { latitude: 30, longitude: -90 } },
+    ];
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    expect(result.current.lines.some((l) => l.key === 'mc:7')).toBe(false);
+  });
+
+  it('excludes edges outside the time slider window when the slider is enabled', () => {
+    setConfig({ timeSlider: { enabled: true, windowStartMs: 10, windowEndMs: 20 } });
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    expect(result.current.lines).toHaveLength(0);
+  });
+
+  it('returns empty lines/selectionByKey AND calls the fetch hooks with enabled:false when the layer is disabled', () => {
+    setConfig({
+      layers: { ...NEIGHBORS_ENABLED_CONFIG.layers, neighbors: { enabled: false, lookbackHours: 24 } },
+    });
+    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    expect(result.current.lines).toEqual([]);
+    expect(result.current.selectionByKey.size).toBe(0);
+    expect(mockUseNeighbors).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+    expect(mockUseMeshCoreNeighbors).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+});

--- a/src/components/MapAnalysis/use3DNeighborLines.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.ts
@@ -1,0 +1,250 @@
+import { useMemo } from 'react';
+import {
+  useDashboardSources,
+  useDashboardUnifiedData,
+} from '../../hooks/useDashboardData';
+import { useNeighbors, useMeshCoreNeighbors } from '../../hooks/useMapAnalysisData';
+import { useMapAnalysisCtx, type SelectedTarget } from './MapAnalysisContext';
+import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+import { classifyNodeTransport, type NodeTransportClass } from '../../utils/nodeTransport';
+import { snrToNeighborOpacity } from '../../utils/neighborLinks';
+import type { Line3DFeature } from '../map/Base3DMap';
+
+/**
+ * 3D neighbor-link data hook (#3826 Phase 3 WP-2, spec §3.2).
+ *
+ * Reuses the SAME fetch hooks (`useNeighbors`/`useMeshCoreNeighbors`), the
+ * same shared pure primitives (`snrToNeighborOpacity`, `classifyNodeTransport`),
+ * and the same filters/lookback/time-window the 2D adapters
+ * (`layers/NeighborLinksLayer.tsx`, `layers/MeshCoreNeighborLinksLayer.tsx`)
+ * use, so 2D and 3D always show the same edges. Those files are off-limits to
+ * edit (spec §0); this hook duplicates their thin data-wiring in new 3D-only
+ * code, and the `selectionByKey` payloads are locked to the 2D adapters'
+ * literal `setSelected(...)` shapes by a parity test
+ * (`use3DNeighborLines.test.ts`).
+ */
+
+// mirror of layers/NeighborLinksLayer.tsx L16-20 (transportColor)
+function transportColor(tc: NodeTransportClass): string {
+  if (tc === 'mqtt') return '#22c55e';
+  if (tc === 'udp') return '#f97316';
+  return '#06b6d4';
+}
+
+// mirror of layers/MeshCoreNeighborLinksLayer.tsx L15 (MC_NEIGHBOR_COLOR)
+const MC_NEIGHBOR_COLOR = '#06b6d4';
+
+// Per spec §2.2's line-encoding-parity table.
+const MT_LINE_WIDTH = 2;
+const MT_LINE_DASH = [2, 2];
+const MC_LINE_WIDTH = 3;
+const MC_LINE_DASH = [3, 2];
+
+interface NeighborEdge {
+  id: number | string;
+  nodeNum: number;
+  neighborNum: number;
+  sourceId: string;
+  snr: number | null;
+  timestamp?: number;
+}
+
+interface MeshCoreNeighborEdge {
+  id: number;
+  publicKey: string;
+  neighborPublicKey: string;
+  sourceId: string;
+  snr: number | null;
+  timestamp: number;
+  nodeName: string | null;
+  neighborName: string | null;
+}
+
+interface NodeRecord extends MaybePositionedNode {
+  nodeNum: number;
+  sourceId?: string;
+  isMeshCore?: boolean;
+  publicKey?: string;
+  transportMechanism?: number | null;
+  viaMqtt?: boolean | null;
+}
+
+export interface NeighborLines3D {
+  lines: Line3DFeature[];
+  selectionByKey: Map<string, SelectedTarget>;
+}
+
+export function use3DNeighborLines(): NeighborLines3D {
+  const { config } = useMapAnalysisCtx();
+  const layer = config.layers.neighbors;
+  const { data: sources = [] } = useDashboardSources();
+  const sourceIds =
+    config.sources.length === 0
+      ? (sources as { id: string }[]).map((s) => s.id)
+      : config.sources;
+
+  const { data: mtData } = useNeighbors({
+    enabled: layer.enabled,
+    sources: sourceIds,
+    lookbackHours: layer.lookbackHours ?? 24,
+  });
+  const { data: mcData } = useMeshCoreNeighbors({
+    enabled: layer.enabled,
+    sources: sourceIds,
+    lookbackHours: layer.lookbackHours ?? 24,
+  });
+  const { nodes } = useDashboardUnifiedData(sourceIds, sourceIds.length > 0);
+
+  // Meshtastic endpoint resolution — mirrors layers/NeighborLinksLayer.tsx
+  // L67-106 (positionByKey/transportByKey + the #3792 cross-source fallback
+  // maps keyed by nodeNum alone).
+  const positionByKey = useMemo(() => {
+    const map = new Map<string, [number, number]>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      const ll = resolveNodeLatLng(n);
+      if (ll) map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, ll);
+    }
+    return map;
+  }, [nodes]);
+
+  const transportByKey = useMemo(() => {
+    const map = new Map<string, NodeTransportClass>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, classifyNodeTransport(n));
+    }
+    return map;
+  }, [nodes]);
+
+  const positionByNode = useMemo(() => {
+    const map = new Map<number, [number, number]>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      const ll = resolveNodeLatLng(n);
+      if (ll && !map.has(Number(n.nodeNum))) map.set(Number(n.nodeNum), ll);
+    }
+    return map;
+  }, [nodes]);
+
+  const transportByNode = useMemo(() => {
+    const map = new Map<number, NodeTransportClass>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      if (!map.has(Number(n.nodeNum))) map.set(Number(n.nodeNum), classifyNodeTransport(n));
+    }
+    return map;
+  }, [nodes]);
+
+  // MeshCore endpoint resolution — mirrors layers/MeshCoreNeighborLinksLayer.tsx
+  // L62-70 (positionByKey keyed by publicKey).
+  const mcPositionByKey = useMemo(() => {
+    const map = new Map<string, [number, number]>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      if (!n.isMeshCore || !n.publicKey) continue;
+      const ll = resolveNodeLatLng(n);
+      if (ll) map.set(`${n.sourceId ?? ''}:${n.publicKey}`, ll);
+    }
+    return map;
+  }, [nodes]);
+
+  const ts = config.timeSlider;
+
+  return useMemo(() => {
+    if (!layer.enabled) return { lines: [], selectionByKey: new Map<string, SelectedTarget>() };
+
+    const inWindow = (t: number): boolean =>
+      !ts.enabled ||
+      ts.windowStartMs === undefined ||
+      ts.windowEndMs === undefined ||
+      (t >= ts.windowStartMs && t <= ts.windowEndMs);
+
+    const lines: Line3DFeature[] = [];
+    const selectionByKey = new Map<string, SelectedTarget>();
+
+    // --- Meshtastic edges — mirrors layers/NeighborLinksLayer.tsx L115-175.
+    const mtItems = (mtData as { items?: NeighborEdge[] } | undefined)?.items ?? [];
+    for (const e of mtItems.filter((edge) => inWindow(edge.timestamp ?? 0))) {
+      const aKey = `${e.sourceId}:${Number(e.nodeNum)}`;
+      const bKey = `${e.sourceId}:${Number(e.neighborNum)}`;
+      const a = positionByKey.get(aKey) ?? positionByNode.get(Number(e.nodeNum));
+      const b = positionByKey.get(bKey) ?? positionByNode.get(Number(e.neighborNum));
+      if (!a || !b) continue;
+      const aTx = transportByKey.get(aKey) ?? transportByNode.get(Number(e.nodeNum)) ?? 'rf';
+      const bTx = transportByKey.get(bKey) ?? transportByNode.get(Number(e.neighborNum)) ?? 'rf';
+      const tc: NodeTransportClass =
+        aTx === 'mqtt' || bTx === 'mqtt' ? 'mqtt' : aTx === 'udp' || bTx === 'udp' ? 'udp' : 'rf';
+
+      const key = `mt:${String(e.id)}`;
+      lines.push({
+        key,
+        from: a,
+        to: b,
+        color: transportColor(tc),
+        opacity: snrToNeighborOpacity(e.snr),
+        width: MT_LINE_WIDTH,
+        dash: MT_LINE_DASH,
+      });
+      // PARITY: literal shape of the `setSelected(...)` call in
+      // layers/NeighborLinksLayer.tsx L164-171.
+      selectionByKey.set(key, {
+        type: 'neighbor',
+        sourceId: e.sourceId,
+        nodeNum: Number(e.nodeNum),
+        neighborNum: Number(e.neighborNum),
+        snr: e.snr,
+        timestamp: e.timestamp,
+      });
+    }
+
+    // --- MeshCore edges — mirrors layers/MeshCoreNeighborLinksLayer.tsx L79-140.
+    const mcItems = (mcData as { items?: MeshCoreNeighborEdge[] } | undefined)?.items ?? [];
+    for (const e of mcItems.filter((edge) => inWindow(edge.timestamp))) {
+      const aKey = `${e.sourceId}:${e.publicKey}`;
+      const bKey = `${e.sourceId}:${e.neighborPublicKey}`;
+      const a = mcPositionByKey.get(aKey);
+      const b = mcPositionByKey.get(bKey);
+      if (!a || !b) continue;
+
+      const key = `mc:${String(e.id)}`;
+      lines.push({
+        key,
+        from: a,
+        to: b,
+        color: MC_NEIGHBOR_COLOR,
+        opacity: snrToNeighborOpacity(e.snr),
+        width: MC_LINE_WIDTH,
+        dash: MC_LINE_DASH,
+      });
+      // PARITY: literal shape of the `setSelected(...)` call in
+      // layers/MeshCoreNeighborLinksLayer.tsx L125-136 (incl. the
+      // `nodeNum:0, neighborNum:0` sentinels — carried verbatim).
+      selectionByKey.set(key, {
+        type: 'neighbor',
+        sourceId: e.sourceId,
+        publicKey: e.publicKey,
+        neighborPublicKey: e.neighborPublicKey,
+        nodeName: e.nodeName,
+        neighborName: e.neighborName,
+        snr: e.snr,
+        timestamp: e.timestamp,
+        nodeNum: 0,
+        neighborNum: 0,
+      });
+    }
+
+    return { lines, selectionByKey };
+    // Unlike the 2D adapters (which need an eslint-disable here because their
+    // dep array omits raw `data`/`ts.enabled` etc.), this dep list is fully
+    // exhaustive — `inWindow` is declared inline above and captured by
+    // closure, not as a separate dep.
+  }, [
+    mtData,
+    mcData,
+    positionByKey,
+    positionByNode,
+    transportByKey,
+    transportByNode,
+    mcPositionByKey,
+    layer.enabled,
+    ts.enabled,
+    ts.windowStartMs,
+    ts.windowEndMs,
+  ]);
+}

--- a/src/components/MapAnalysis/use3DTracerouteLines.test.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MapAnalysisProvider, useMapAnalysisCtx } from './MapAnalysisContext';
+import { use3DTracerouteLines } from './use3DTracerouteLines';
+import type { AnalyzedSegment } from '../../hooks/useTracerouteAnalysis';
+import { getSegmentSnrOpacity, weightByOccurrence } from '../../utils/mapHelpers';
+
+// Mutable mock state, same convention as layers/TraceroutePathsLayer.test.tsx.
+const mockState: { segments: AnalyzedSegment[] } = { segments: [] };
+
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    overlayColors: {
+      mqttSegment: '#b4befe',
+      snrColors: {
+        excellent: '#22c55e',
+        good: '#eab308',
+        fair: '#f97316',
+        poor: '#ef4444',
+        noData: '#6c7086',
+      },
+    },
+  }),
+}));
+vi.mock('../../hooks/useMapAnalysisData', () => ({
+  useTraceroutes: () => ({
+    items: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    progress: { loaded: 0, estimatedTotal: 0, percent: 100 },
+  }),
+}));
+vi.mock('../../hooks/useDashboardData', () => ({
+  useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }] }),
+  useDashboardUnifiedData: () => ({ nodes: [] }),
+  UNIFIED_SOURCE_ID: '__unified__',
+}));
+vi.mock('../../hooks/useTracerouteAnalysis', async () => {
+  const actual = await vi.importActual<typeof import('../../hooks/useTracerouteAnalysis')>(
+    '../../hooks/useTracerouteAnalysis',
+  );
+  return {
+    ...actual,
+    useTracerouteAnalysis: () => ({ segments: mockState.segments, summary: null }),
+  };
+});
+
+const TRACEROUTES_ENABLED_CONFIG = {
+  version: 1,
+  layers: {
+    markers: { enabled: true, lookbackHours: null },
+    traceroutes: { enabled: true, lookbackHours: 24 },
+    neighbors: { enabled: false, lookbackHours: 24 },
+    heatmap: { enabled: false, lookbackHours: 24 },
+    trails: { enabled: false, lookbackHours: 24 },
+    hopShading: { enabled: false, lookbackHours: null },
+    snrOverlay: { enabled: false, lookbackHours: null },
+    waypoints: { enabled: true, lookbackHours: null },
+    polarGrid: { enabled: false, lookbackHours: null },
+  },
+  sources: [],
+  timeSlider: { enabled: false },
+  inspectorOpen: true,
+  selectedNodeIds: [],
+};
+
+function setConfig(overrides: Record<string, unknown> = {}) {
+  localStorage.setItem(
+    'mapAnalysis.config.v1',
+    JSON.stringify({ ...TRACEROUTES_ENABLED_CONFIG, ...overrides }),
+  );
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient();
+  return createElement(QueryClientProvider, { client: qc }, createElement(MapAnalysisProvider, null, children));
+}
+
+/** Renders `use3DTracerouteLines()` after selecting a node (via the shared
+ * context), so `colorMode` flips to 'direction' the same way it does when a
+ * user clicks a node marker in the real app. */
+function useTracerouteLinesWithNodeSelected(nodeNum: number, sourceId: string) {
+  const { selected, setSelected } = useMapAnalysisCtx();
+  useEffect(() => {
+    if (!selected) setSelected({ type: 'node', nodeNum, sourceId });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected]);
+  return use3DTracerouteLines();
+}
+
+const RF_SEGMENT: AnalyzedSegment = {
+  key: 'a:0x1111->0x2222',
+  sourceId: 'a',
+  from: 0x1111,
+  to: 0x2222,
+  fromPos: [30, -90],
+  toPos: [31, -91],
+  direction: 'neutral',
+  neighborNum: 0x1111,
+  avgSnr: 8,
+  occurrences: 3,
+  isMqtt: false,
+};
+
+const MQTT_SEGMENT: AnalyzedSegment = {
+  key: 'a:0x3333->0x4444',
+  sourceId: 'a',
+  from: 0x3333,
+  to: 0x4444,
+  fromPos: [32, -92],
+  toPos: [33, -93],
+  direction: 'neutral',
+  neighborNum: 0x3333,
+  avgSnr: null,
+  occurrences: 1,
+  isMqtt: true,
+};
+
+describe('use3DTracerouteLines', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockState.segments = [RF_SEGMENT];
+    setConfig();
+  });
+
+  it('produces a straight 2-vertex Line3DFeature for an RF segment (solid, §2.6 no curvature)', () => {
+    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    const line = result.current.lines.find((l) => l.key === `tr:${RF_SEGMENT.key}`);
+    expect(line).toBeDefined();
+    expect(line).toEqual({
+      key: `tr:${RF_SEGMENT.key}`,
+      from: [30, -90],
+      to: [31, -91],
+      color: '#22c55e', // snrToColor(8, snrColors) -> excellent (>=5)
+      opacity: getSegmentSnrOpacity([{ snr: 8 }], false),
+      width: weightByOccurrence(3),
+      // no `dash` key: solid line.
+    });
+  });
+
+  it('PARITY: segment selectionByKey deep-equals the 2D setSelected payload (layers/TraceroutePathsLayer.tsx L165-174)', () => {
+    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    expect(result.current.selectionByKey.get(`tr:${RF_SEGMENT.key}`)).toEqual({
+      type: 'segment',
+      fromNodeNum: RF_SEGMENT.from,
+      toNodeNum: RF_SEGMENT.to,
+      direction: RF_SEGMENT.direction,
+      occurrences: RF_SEGMENT.occurrences,
+      avgSnr: RF_SEGMENT.avgSnr,
+    });
+  });
+
+  it('dashes an MQTT/unknown-SNR segment (dash=[2,2]) and colors it via overlayColors.mqttSegment', () => {
+    mockState.segments = [MQTT_SEGMENT];
+    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    const line = result.current.lines.find((l) => l.key === `tr:${MQTT_SEGMENT.key}`);
+    expect(line?.dash).toEqual([2, 2]);
+    expect(line?.color).toBe('#b4befe');
+    expect(line?.opacity).toBe(getSegmentSnrOpacity(undefined, true));
+  });
+
+  it('flips colorMode to direction colors when a node is selected', () => {
+    mockState.segments = [
+      { ...RF_SEGMENT, direction: 'outbound' },
+      { ...RF_SEGMENT, key: 'a:0x2222->0x1111', from: 0x2222, to: 0x1111, direction: 'inbound' },
+    ];
+    const { result } = renderHook(() => useTracerouteLinesWithNodeSelected(0x1111, 'a'), { wrapper });
+    const outbound = result.current.lines.find((l) => l.key === 'tr:a:0x1111->0x2222');
+    const inbound = result.current.lines.find((l) => l.key === 'tr:a:0x2222->0x1111');
+    expect(outbound?.color).toBe('#3b82f6'); // OUTBOUND_COLOR (mirror of TraceroutePathsLayer.tsx L25)
+    expect(inbound?.color).toBe('#f43f5e'); // INBOUND_COLOR (mirror of TraceroutePathsLayer.tsx L26)
+  });
+
+  it('falls back to snrColors.noData for a neutral segment while colorMode is direction', () => {
+    mockState.segments = [{ ...RF_SEGMENT, direction: 'neutral' }];
+    const { result } = renderHook(() => useTracerouteLinesWithNodeSelected(0x1111, 'a'), { wrapper });
+    const line = result.current.lines.find((l) => l.key === `tr:${RF_SEGMENT.key}`);
+    expect(line?.color).toBe('#6c7086'); // snrColors.noData
+  });
+
+  it('returns empty lines/selectionByKey when the traceroutes layer is disabled', () => {
+    setConfig({
+      layers: { ...TRACEROUTES_ENABLED_CONFIG.layers, traceroutes: { enabled: false, lookbackHours: 24 } },
+    });
+    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    expect(result.current.lines).toEqual([]);
+    expect(result.current.selectionByKey.size).toBe(0);
+  });
+});

--- a/src/components/MapAnalysis/use3DTracerouteLines.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.ts
@@ -1,0 +1,184 @@
+import { useMemo } from 'react';
+import {
+  useDashboardSources,
+  useDashboardUnifiedData,
+} from '../../hooks/useDashboardData';
+import { useTraceroutes } from '../../hooks/useMapAnalysisData';
+import { useMapAnalysisCtx, type SelectedTarget } from './MapAnalysisContext';
+import { getTracerouteOptions } from '../../hooks/useMapAnalysisConfig';
+import {
+  useTracerouteAnalysis,
+  type AnalyzedSegment,
+  type TracerouteAnalysisInput,
+} from '../../hooks/useTracerouteAnalysis';
+import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+import { visibleNodeNumSet, type SearchableNode } from './nodeSearch';
+import { weightByOccurrence, getSegmentSnrOpacity, snrToColor } from '../../utils/mapHelpers';
+import { useSettings } from '../../contexts/SettingsContext';
+import type { Line3DFeature } from '../map/Base3DMap';
+
+/**
+ * 3D traceroute-segment data hook (#3826 Phase 3 WP-2, spec §3.3).
+ *
+ * Mirrors `layers/TraceroutePathsLayer.tsx`'s data wiring (`useTraceroutes`,
+ * `positionByKey`/`visibleNodeNums`/`options`/`timeWindow`, then
+ * `useTracerouteAnalysis`) and the shared `map/layers/TraceroutePathsLayer.tsx`
+ * `resolveColor`/`resolveOpacity`/`resolveWeight`/`resolveDash` formulas
+ * (both off-limits to edit, spec §0) so 2D and 3D render pixel-equivalent
+ * color/opacity/width and agree on which segments exist. Per spec §2.6, 3D
+ * renders straight 2-vertex lines — no bezier curvature, no direction arrows.
+ * `selectionByKey` is locked to the 2D adapter's literal `onSegmentClick`
+ * payload shape by a parity test (`use3DTracerouteLines.test.ts`).
+ */
+
+// mirror of layers/TraceroutePathsLayer.tsx L25-26 (OUTBOUND_COLOR/INBOUND_COLOR)
+const OUTBOUND_COLOR = '#3b82f6';
+const INBOUND_COLOR = '#f43f5e';
+
+// Per spec §2.6: dashed = MQTT/unknown-SNR segment; solid otherwise.
+const MQTT_UNKNOWN_DASH = [2, 2];
+
+interface NodeRecord extends MaybePositionedNode {
+  nodeNum: number;
+  sourceId?: string;
+  hideFromMap?: boolean | null;
+}
+
+export interface TracerouteLines3D {
+  lines: Line3DFeature[];
+  selectionByKey: Map<string, SelectedTarget>;
+}
+
+/**
+ * Resolve a segment's line color, replicating
+ * `map/layers/TraceroutePathsLayer.tsx`'s `resolveColor` for the two prop
+ * shapes the MapAnalysis 2D adapter actually passes: `colorMode: 'snr'` with
+ * `mqttColor: overlayColors.mqttSegment`, or `colorMode: 'direction'` with
+ * `directionColors: { outbound: OUTBOUND_COLOR, inbound: INBOUND_COLOR }`
+ * (no `neutral` override, so a 'neutral' segment in direction mode falls back
+ * to `snrColors.noData` — same as 2D).
+ */
+function resolveSegmentColor(
+  seg: AnalyzedSegment,
+  colorMode: 'snr' | 'direction',
+  snrColors: Parameters<typeof snrToColor>[1],
+  mqttColor: string,
+): string {
+  if (colorMode === 'direction') {
+    if (seg.direction === 'outbound') return OUTBOUND_COLOR;
+    if (seg.direction === 'inbound') return INBOUND_COLOR;
+    return snrColors.noData;
+  }
+  if (seg.isMqtt) return mqttColor;
+  return snrToColor(seg.avgSnr, snrColors);
+}
+
+export function use3DTracerouteLines(): TracerouteLines3D {
+  const { config, selected, nodeFilter } = useMapAnalysisCtx();
+  const { overlayColors } = useSettings();
+  const layer = config.layers.traceroutes;
+  const options = useMemo(
+    () => getTracerouteOptions(config),
+    // Only the traceroute options object affects the result — mirrors
+    // layers/TraceroutePathsLayer.tsx L76-82.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [config.layers.traceroutes.options],
+  );
+
+  const { data: sources = [] } = useDashboardSources();
+  const sourceIds =
+    config.sources.length === 0
+      ? (sources as { id: string }[]).map((s) => s.id)
+      : config.sources;
+  const { items } = useTraceroutes({
+    enabled: layer.enabled,
+    sources: sourceIds,
+    lookbackHours: layer.lookbackHours ?? 24,
+  });
+  const { nodes } = useDashboardUnifiedData(sourceIds, sourceIds.length > 0);
+
+  const positionByKey = useMemo(() => {
+    const map = new Map<string, [number, number]>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      if (n.hideFromMap) continue;
+      const ll = resolveNodeLatLng(n);
+      if (ll) map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, ll);
+    }
+    return map;
+  }, [nodes]);
+
+  const visibleNodeNums = useMemo(
+    () => visibleNodeNumSet((nodes ?? []) as SearchableNode[], nodeFilter),
+    [nodes, nodeFilter],
+  );
+
+  const ts = config.timeSlider;
+  const timeWindow = useMemo(
+    () =>
+      ts.enabled && ts.windowStartMs !== undefined && ts.windowEndMs !== undefined
+        ? { startMs: ts.windowStartMs, endMs: ts.windowEndMs }
+        : null,
+    [ts.enabled, ts.windowStartMs, ts.windowEndMs],
+  );
+
+  const selectedNodeNum =
+    selected?.type === 'node' && selected.nodeNum !== undefined ? selected.nodeNum : null;
+  const selectedSourceId = selected?.type === 'node' ? selected.sourceId ?? null : null;
+
+  const { segments } = useTracerouteAnalysis({
+    traceroutes: items as TracerouteAnalysisInput[],
+    positionByKey,
+    selectedNodeNum,
+    selectedSourceId,
+    options,
+    visibleNodeNums,
+    timeWindow,
+  });
+
+  // colorMode is dynamic, same as 2D: direction when a node is selected, SNR
+  // otherwise (layers/TraceroutePathsLayer.tsx L140-144).
+  const colorMode: 'snr' | 'direction' = selectedNodeNum !== null ? 'direction' : 'snr';
+
+  return useMemo(() => {
+    if (!layer.enabled) return { lines: [], selectionByKey: new Map<string, SelectedTarget>() };
+
+    const lines: Line3DFeature[] = [];
+    const selectionByKey = new Map<string, SelectedTarget>();
+
+    for (const seg of segments) {
+      const color = resolveSegmentColor(seg, colorMode, overlayColors.snrColors, overlayColors.mqttSegment);
+      const opacity = getSegmentSnrOpacity(
+        seg.avgSnr === null ? undefined : [{ snr: seg.avgSnr }],
+        seg.isMqtt,
+      );
+      const width = weightByOccurrence(seg.occurrences ?? 1);
+      const isDashed = seg.isMqtt || seg.avgSnr == null;
+
+      const key = `tr:${seg.key}`;
+      lines.push({
+        key,
+        // §2.6: straight 2-vertex LineString — no generateCurvedPath, no arrows.
+        from: seg.fromPos,
+        to: seg.toPos,
+        color,
+        opacity,
+        width,
+        ...(isDashed ? { dash: MQTT_UNKNOWN_DASH } : {}),
+      });
+      // PARITY: literal shape of the `onSegmentClick` -> `setSelected(...)`
+      // call in layers/TraceroutePathsLayer.tsx L165-174 (via the
+      // `toRenderSegment` mapping: `seg.fromNodeNum`/`toNodeNum` == this
+      // AnalyzedSegment's `from`/`to`).
+      selectionByKey.set(key, {
+        type: 'segment',
+        fromNodeNum: seg.from,
+        toNodeNum: seg.to,
+        direction: seg.direction,
+        occurrences: seg.occurrences,
+        avgSnr: seg.avgSnr,
+      });
+    }
+
+    return { lines, selectionByKey };
+  }, [segments, colorMode, overlayColors.snrColors, overlayColors.mqttSegment, layer.enabled]);
+}

--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, StrictMode } from 'react';
 import { render, fireEvent, cleanup, screen } from '@testing-library/react';
-import { Base3DMap, type Node3DFeature } from './Base3DMap';
+import { Base3DMap, type Node3DFeature, type Line3DFeature } from './Base3DMap';
 import type { Basemap3DSource } from '../../config/basemap3d';
 
 // ---------------------------------------------------------------------------
@@ -114,6 +114,13 @@ const nodes: Node3DFeature[] = [
   { key: 'node-1', lat: 40.0, lng: -105.0, label: 'N1' },
   { key: 'node-2', lat: 40.1, lng: -105.1, label: 'N2' },
 ];
+
+/** Filters `addLayer` mock calls down to line layers (id prefixed `lines-`). */
+function lineLayerCalls(map: InstanceType<typeof FakeMap>) {
+  return map.addLayer.mock.calls.filter(
+    ([layer]) => typeof layer?.id === 'string' && layer.id.startsWith('lines-'),
+  );
+}
 
 function currentFakeMap(): InstanceType<typeof FakeMap> {
   const m = FakeMap.instances[FakeMap.instances.length - 1];
@@ -275,6 +282,223 @@ describe('Base3DMap', () => {
     const call = nodesSource.setData.mock.calls[0][0];
     expect(call.features).toHaveLength(3);
     expect(call.features[2].properties.key).toBe('node-3');
+  });
+
+  describe('lines (#3826 Phase 3 WP-1)', () => {
+    it('adds no line layers when the lines prop is omitted (back-compat)', () => {
+      render(
+        <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+
+      expect(lineLayerCalls(map)).toHaveLength(0);
+    });
+
+    it('adds a lines source and one line layer per distinct dash group on load', () => {
+      const lines: Line3DFeature[] = [
+        { key: 'mt:1', from: [40.0, -105.0], to: [40.1, -105.1], color: '#3fb1ce', opacity: 0.8, width: 2, dash: [2, 2] },
+        { key: 'mc:1', from: [40.0, -105.0], to: [40.2, -105.2], color: '#06b6d4', opacity: 0.9, width: 3, dash: [3, 2] },
+        { key: 'tr:1', from: [40.0, -105.0], to: [40.3, -105.3], color: '#22c55e', opacity: 1, width: 4 },
+      ];
+      render(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          lines={lines}
+        />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+
+      expect(map.addSource).toHaveBeenCalledWith('lines', expect.objectContaining({ type: 'geojson' }));
+      const calls = lineLayerCalls(map);
+      // Three distinct dash signatures: [2,2], [3,2], and solid (no dash).
+      expect(calls).toHaveLength(3);
+      for (const [layer] of calls) {
+        expect(layer.type).toBe('line');
+        expect(layer.source).toBe('lines');
+        expect(layer.paint['line-color']).toEqual(['get', 'color']);
+        expect(layer.paint['line-opacity']).toEqual(['get', 'opacity']);
+        expect(layer.paint['line-width']).toEqual(['get', 'width']);
+      }
+      const dashed = calls.filter(([layer]) => layer.paint['line-dasharray'] !== undefined);
+      const solid = calls.filter(([layer]) => layer.paint['line-dasharray'] === undefined);
+      expect(dashed).toHaveLength(2);
+      expect(solid).toHaveLength(1);
+      expect(dashed.map(([layer]) => layer.paint['line-dasharray'])).toEqual(
+        expect.arrayContaining([[2, 2], [3, 2]]),
+      );
+      // Line layers must be inserted below the node circle layer.
+      for (const [, beforeId] of calls) {
+        expect(beforeId).toBe('nodes-circle');
+      }
+    });
+
+    it('groups lines with an identical dash pattern into a single layer', () => {
+      const lines: Line3DFeature[] = [
+        { key: 'a', from: [40.0, -105.0], to: [40.1, -105.1], color: '#fff', opacity: 1, width: 2, dash: [2, 2] },
+        { key: 'b', from: [40.0, -105.0], to: [40.2, -105.2], color: '#000', opacity: 1, width: 2, dash: [2, 2] },
+      ];
+      render(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          lines={lines}
+        />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+
+      expect(lineLayerCalls(map)).toHaveLength(1);
+    });
+
+    it('calls onLineClick with the clicked feature key', () => {
+      const onLineClick = vi.fn();
+      const lines: Line3DFeature[] = [
+        { key: 'mt:5', from: [40.0, -105.0], to: [40.1, -105.1], color: '#3fb1ce', opacity: 0.8, width: 2, dash: [2, 2] },
+      ];
+      render(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          lines={lines}
+          onLineClick={onLineClick}
+        />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+
+      const [layer] = lineLayerCalls(map)[0];
+      const clickHandler = map.layerHandlers[`click:${layer.id}`];
+      expect(clickHandler).toBeDefined();
+      clickHandler({ features: [{ properties: { key: 'mt:5' } }] });
+
+      expect(onLineClick).toHaveBeenCalledWith('mt:5');
+    });
+
+    it('patches the lines source and reconciles dash-group layers when lines change', () => {
+      const initialLines: Line3DFeature[] = [
+        { key: 'a', from: [40.0, -105.0], to: [40.1, -105.1], color: '#fff', opacity: 1, width: 2, dash: [2, 2] },
+      ];
+      const { rerender } = render(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          lines={initialLines}
+        />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+      const [initialLayer] = lineLayerCalls(map)[0];
+      const initialLayerId = initialLayer.id as string;
+
+      // The lines-sync effect also runs once `loaded` flips true (source was
+      // just created with the initial data) — clear those calls so the
+      // assertions below isolate the prop-change-triggered update, mirroring
+      // the equivalent `nodes` test above.
+      const linesSource = map.getSource('lines');
+      linesSource.setData.mockClear();
+      map.addLayer.mockClear();
+      map.removeLayer.mockClear();
+
+      // New dash pattern ([3,2]) replaces the old one ([2,2]).
+      const updatedLines: Line3DFeature[] = [
+        { key: 'b', from: [40.0, -105.0], to: [40.2, -105.2], color: '#000', opacity: 1, width: 3, dash: [3, 2] },
+      ];
+      rerender(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          lines={updatedLines}
+        />,
+      );
+
+      expect(linesSource.setData).toHaveBeenCalledTimes(1);
+      const call = linesSource.setData.mock.calls[0][0];
+      expect(call.features).toHaveLength(1);
+      expect(call.features[0].properties.key).toBe('b');
+
+      // A new layer is added for the newly-appearing [3,2] dash group.
+      const newCalls = lineLayerCalls(map);
+      expect(newCalls).toHaveLength(1);
+      expect(newCalls[0][0].paint['line-dasharray']).toEqual([3, 2]);
+      // The vanished [2,2] dash group's layer is removed.
+      expect(map.removeLayer).toHaveBeenCalledWith(initialLayerId);
+    });
+  });
+
+  describe('exaggeration seeding (#3826 Phase 3 WP-1)', () => {
+    it('seeds the slider and the initial setTerrain call from initialExaggeration', () => {
+      render(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          initialExaggeration={0.5}
+        />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+
+      expect(map.setTerrain).toHaveBeenCalledWith({ source: 'terrain-dem', exaggeration: 0.5 });
+      const slider = screen.getByLabelText('Terrain exaggeration') as HTMLInputElement;
+      expect(slider.value).toBe('0.5');
+    });
+
+    it('emits onExaggerationChange (in addition to setTerrain) when the slider changes', () => {
+      const onExaggerationChange = vi.fn();
+      const { getByLabelText } = render(
+        <Base3DMap
+          center={[40.0, -105.0]}
+          zoom={12}
+          basemap={basemap}
+          terrainTileUrl={terrainTileUrl}
+          nodes={nodes}
+          onExaggerationChange={onExaggerationChange}
+        />,
+      );
+      const map = currentFakeMap();
+      act(() => {
+        map.triggerLoad();
+      });
+      map.setTerrain.mockClear();
+
+      const slider = getByLabelText('Terrain exaggeration') as HTMLInputElement;
+      fireEvent.change(slider, { target: { value: '1.8' } });
+
+      expect(map.setTerrain).toHaveBeenCalledWith({ source: 'terrain-dem', exaggeration: 1.8 });
+      expect(onExaggerationChange).toHaveBeenCalledWith(1.8);
+    });
   });
 
   describe('WebGL unavailable', () => {

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -13,6 +13,25 @@ export interface Node3DFeature {
   color?: string;
 }
 
+/**
+ * A single line feature fed into the MapLibre `lines` GeoJSON source
+ * (#3826 Phase 3 WP-1, spec §2.1). Kept generic (no MapAnalysis types) so
+ * `Base3DMap` stays Map-Analysis-agnostic; callers resolve `key` back to a
+ * domain object via `onLineClick`.
+ */
+export interface Line3DFeature {
+  key: string;
+  /** [lat, lng] (converted to MapLibre's [lng, lat] internally). */
+  from: [number, number];
+  /** [lat, lng] (converted to MapLibre's [lng, lat] internally). */
+  to: [number, number];
+  color: string;
+  opacity: number;
+  width: number;
+  /** Dash pattern in line-widths; omit/empty = solid. */
+  dash?: number[];
+}
+
 export interface Base3DMapProps {
   /** Initial center, [lat, lng] (converted to MapLibre's [lng, lat] internally). */
   center: [number, number];
@@ -26,6 +45,10 @@ export interface Base3DMapProps {
   nodes: Node3DFeature[];
   /** Fired when a node's circle marker is clicked, with its `key`. */
   onNodeClick?: (key: string) => void;
+  /** Line segments (neighbor links, traceroute paths, …) to render below the node layers. */
+  lines?: Line3DFeature[];
+  /** Fired when a line is clicked, with its `key`. */
+  onLineClick?: (key: string) => void;
   /**
    * Fired at most once per component instance when WebGL is unavailable and
    * the 3D map cannot be constructed (probe failed or the maplibre Map
@@ -34,6 +57,15 @@ export interface Base3DMapProps {
    * either way.
    */
   onUnsupported?: () => void;
+  /**
+   * Seed value for the terrain-exaggeration slider (default `1.3`, same as
+   * `DEFAULT_EXAGGERATION`). Seed-once: the slider is the only way
+   * exaggeration changes after mount, so this is not re-applied on prop
+   * changes after the initial mount.
+   */
+  initialExaggeration?: number;
+  /** Fired with the new exaggeration value whenever the slider changes. */
+  onExaggerationChange?: (value: number) => void;
   className?: string;
 }
 
@@ -44,6 +76,8 @@ const HILLSHADE_LAYER_ID = 'terrain-hillshade';
 const NODES_SOURCE_ID = 'nodes';
 const NODES_CIRCLE_LAYER_ID = 'nodes-circle';
 const NODES_LABEL_LAYER_ID = 'nodes-label';
+const LINES_SOURCE_ID = 'lines';
+const LINES_LAYER_PREFIX = 'lines-';
 
 const ELEVATION_ATTRIBUTION = 'Elevation: Mapzen / AWS Terrain Tiles';
 const INITIAL_PITCH = 60;
@@ -78,6 +112,45 @@ function toNodesFeatureCollection(nodes: Node3DFeature[]): GeoJSON.FeatureCollec
   };
 }
 
+/** Build a GeoJSON FeatureCollection from the `lines` prop for the `lines` source. */
+function toLinesFeatureCollection(lines: Line3DFeature[]): GeoJSON.FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: lines.map((l) => ({
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [l.from[1], l.from[0]],
+          [l.to[1], l.to[0]],
+        ],
+      },
+      properties: {
+        key: l.key,
+        color: l.color,
+        opacity: l.opacity,
+        width: l.width,
+        dashKey: JSON.stringify(l.dash ?? []),
+      },
+    })),
+  };
+}
+
+/**
+ * Distinct dash patterns present in `lines`, keyed by `JSON.stringify(dash ?? [])`
+ * (spec §2.1 — `line-dasharray` is not data-drivable, so each distinct pattern
+ * gets its own MapLibre line layer sharing the one `lines` GeoJSON source).
+ */
+function dashGroupsOf(lines: Line3DFeature[]): Map<string, number[]> {
+  const groups = new Map<string, number[]>();
+  for (const line of lines) {
+    const dash = line.dash ?? [];
+    const dashKey = JSON.stringify(dash);
+    if (!groups.has(dashKey)) groups.set(dashKey, dash);
+  }
+  return groups;
+}
+
 /**
  * Generic MapLibre GL 3D map surface (#3826 Phase 2 WP-C, spec §3.9).
  *
@@ -108,25 +181,74 @@ export function Base3DMap({
   terrainTileUrl,
   nodes,
   onNodeClick,
+  lines = [],
+  onLineClick,
   onUnsupported,
+  initialExaggeration,
+  onExaggerationChange,
   className,
 }: Base3DMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [webglUnavailable, setWebglUnavailable] = useState(false);
-  const [exaggeration, setExaggeration] = useState(DEFAULT_EXAGGERATION);
+  // Seed-once from initialExaggeration (spec §2.4): exaggeration only ever
+  // changes via the slider below, so no prop-driven re-sync after mount.
+  const [exaggeration, setExaggeration] = useState(() => initialExaggeration ?? DEFAULT_EXAGGERATION);
 
   // Latest props, readable from stable callbacks (click handler, basemap sync)
   // without adding them as effect deps that would force a map/layer rebuild.
   const onNodeClickRef = useRef(onNodeClick);
   onNodeClickRef.current = onNodeClick;
+  const onLineClickRef = useRef(onLineClick);
+  onLineClickRef.current = onLineClick;
+  const onExaggerationChangeRef = useRef(onExaggerationChange);
+  onExaggerationChangeRef.current = onExaggerationChange;
   const onUnsupportedRef = useRef(onUnsupported);
   onUnsupportedRef.current = onUnsupported;
   // Notify-once guard: refs survive StrictMode's dev double-mount (the same
   // component instance is remounted with state/refs preserved), so
   // `onUnsupported` fires exactly once even when the mount effect runs twice.
   const unsupportedNotifiedRef = useRef(false);
+  // Live dash-group -> line-layer-id map, reconciled as `lines` changes
+  // (spec §3.1 — the set of distinct dash patterns isn't known ahead of time).
+  const lineLayerIdsRef = useRef<Map<string, string>>(new Map());
+  const nextLineLayerIndexRef = useRef(0);
+
+  // Adds one MapLibre `line` layer for a dash group, filtered to its
+  // features via `dashKey`, inserted below the node circle/label layers so
+  // markers stay clickable on top. Stable identity (empty deps, refs only)
+  // so it can be an effect dep without forcing extra reconciliation runs.
+  const addLineLayer = useCallback((map: maplibregl.Map, dashKey: string, dash: number[], layerId: string) => {
+    map.addLayer(
+      {
+        id: layerId,
+        type: 'line',
+        source: LINES_SOURCE_ID,
+        filter: ['==', ['get', 'dashKey'], dashKey],
+        paint: {
+          'line-color': ['get', 'color'],
+          'line-opacity': ['get', 'opacity'],
+          'line-width': ['get', 'width'],
+          ...(dash.length ? { 'line-dasharray': dash } : {}),
+        },
+      },
+      NODES_CIRCLE_LAYER_ID,
+    );
+    map.on('click', layerId, (e) => {
+      const feature = e.features?.[0];
+      const key = feature?.properties?.key;
+      if (typeof key === 'string') {
+        onLineClickRef.current?.(key);
+      }
+    });
+    map.on('mouseenter', layerId, () => {
+      map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', layerId, () => {
+      map.getCanvas().style.cursor = '';
+    });
+  }, []);
 
   // ---- Mount / unmount: create the map exactly once ------------------------
   useEffect(() => {
@@ -201,7 +323,7 @@ export function Base3DMap({
         encoding: 'terrarium',
         attribution: ELEVATION_ATTRIBUTION,
       });
-      map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration: DEFAULT_EXAGGERATION });
+      map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration });
       map.addLayer({
         id: HILLSHADE_LAYER_ID,
         type: 'hillshade',
@@ -254,6 +376,20 @@ export function Base3DMap({
         map.getCanvas().style.cursor = '';
       });
 
+      // Lines source + one line layer per distinct dash pattern (spec §2.1/§3.1),
+      // inserted below the node circle/label layers so markers stay clickable
+      // on top. Zero dash groups when `lines` is omitted/empty ⇒ no line
+      // layers added, matching pre-Phase-3 behavior.
+      map.addSource(LINES_SOURCE_ID, {
+        type: 'geojson',
+        data: toLinesFeatureCollection(lines),
+      });
+      for (const [dashKey, dash] of dashGroupsOf(lines)) {
+        const layerId = `${LINES_LAYER_PREFIX}${nextLineLayerIndexRef.current++}`;
+        lineLayerIdsRef.current.set(dashKey, layerId);
+        addLineLayer(map, dashKey, dash, layerId);
+      }
+
       setLoaded(true);
     });
 
@@ -265,6 +401,8 @@ export function Base3DMap({
     // Mount-once: center/zoom are applied only at construction (BaseMap
     // convention, see BaseMap.tsx), basemap/terrainTileUrl identity changes
     // are handled by the dedicated effects below rather than remounting.
+    // `nodes`/`lines` here only seed the initial sources — subsequent
+    // updates are patched by the dedicated sync effects below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -296,6 +434,35 @@ export function Base3DMap({
     source?.setData(toNodesFeatureCollection(nodes));
   }, [nodes, loaded]);
 
+  // ---- Line data change: patch the source + reconcile dash-group layers ----
+  // The set of distinct dash patterns can grow/shrink as `lines` changes, so
+  // this diffs against `lineLayerIdsRef` rather than assuming a fixed layer
+  // set (spec §3.1).
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loaded) return;
+    const source = map.getSource(LINES_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
+    source?.setData(toLinesFeatureCollection(lines));
+
+    const currentGroups = dashGroupsOf(lines);
+    const liveLayerIds = lineLayerIdsRef.current;
+
+    for (const [dashKey, dash] of currentGroups) {
+      if (!liveLayerIds.has(dashKey)) {
+        const layerId = `${LINES_LAYER_PREFIX}${nextLineLayerIndexRef.current++}`;
+        liveLayerIds.set(dashKey, layerId);
+        addLineLayer(map, dashKey, dash, layerId);
+      }
+    }
+
+    for (const [dashKey, layerId] of Array.from(liveLayerIds)) {
+      if (!currentGroups.has(dashKey)) {
+        if (map.getLayer(layerId)) map.removeLayer(layerId);
+        liveLayerIds.delete(dashKey);
+      }
+    }
+  }, [lines, loaded, addLineLayer]);
+
   // ---- Exaggeration slider ---------------------------------------------------
   const handleExaggerationChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -305,6 +472,7 @@ export function Base3DMap({
       if (map && loaded) {
         map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration: value });
       }
+      onExaggerationChangeRef.current?.(value);
     },
     [loaded],
   );

--- a/src/hooks/useMapAnalysisConfig.test.ts
+++ b/src/hooks/useMapAnalysisConfig.test.ts
@@ -157,4 +157,52 @@ describe('useMapAnalysisConfig', () => {
     act(() => result.current.reset());
     expect(result.current.config.viewMode).toBe('2d');
   });
+
+  it('defaults exaggeration to 1.3', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.exaggeration).toBe(1.3);
+    expect(DEFAULT_CONFIG.exaggeration).toBe(1.3);
+  });
+
+  it('updates exaggeration and persists to localStorage', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setExaggeration(1.8));
+    expect(result.current.config.exaggeration).toBe(1.8);
+    expect(JSON.parse(localStorage.getItem(KEY)!).exaggeration).toBe(1.8);
+  });
+
+  it('loads an old config missing exaggeration as 1.3 without throwing (#3826 P3)', () => {
+    const { exaggeration: _ex, ...oldConfig } = DEFAULT_CONFIG;
+    localStorage.setItem(KEY, JSON.stringify(oldConfig));
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    expect(result.current.config.exaggeration).toBe(1.3);
+  });
+
+  it('clamps an out-of-range stored exaggeration into [0,2]', () => {
+    localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_CONFIG, exaggeration: 5 }));
+    const { result: resultHigh } = renderHook(() => useMapAnalysisConfig());
+    expect(resultHigh.current.config.exaggeration).toBe(2);
+
+    localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_CONFIG, exaggeration: -3 }));
+    const { result: resultLow } = renderHook(() => useMapAnalysisConfig());
+    expect(resultLow.current.config.exaggeration).toBe(0);
+  });
+
+  it('coerces a garbage exaggeration value (non-finite or non-number) to the default', () => {
+    localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_CONFIG, exaggeration: 'lots' }));
+    const { result: resultStr } = renderHook(() => useMapAnalysisConfig());
+    expect(resultStr.current.config.exaggeration).toBe(1.3);
+
+    localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_CONFIG, exaggeration: NaN }));
+    const { result: resultNaN } = renderHook(() => useMapAnalysisConfig());
+    expect(resultNaN.current.config.exaggeration).toBe(1.3);
+  });
+
+  it('reset() clears exaggeration back to 1.3', () => {
+    const { result } = renderHook(() => useMapAnalysisConfig());
+    act(() => result.current.setExaggeration(0.5));
+    expect(result.current.config.exaggeration).toBe(0.5);
+    act(() => result.current.reset());
+    expect(result.current.config.exaggeration).toBe(1.3);
+  });
 });

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -66,6 +66,8 @@ export interface MapAnalysisConfig {
   autoZoom: boolean;
   /** 2D (Leaflet) vs 3D (MapLibre GL) map rendering on Map Analysis (#3826 Phase 2). */
   viewMode: '2d' | '3d';
+  /** 3D terrain exaggeration (0–2), client-local (#3826 P3). */
+  exaggeration: number;
 }
 
 const ALL_NODE_TYPES_VISIBLE = Object.fromEntries(
@@ -95,6 +97,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
   followMode: false,
   autoZoom: false,
   viewMode: '2d',
+  exaggeration: 1.3,
 };
 
 /** Read the traceroute options off a config, layering stored values over defaults. */
@@ -124,6 +127,10 @@ function load(): MapAnalysisConfig {
       followMode: typeof parsed.followMode === 'boolean' ? parsed.followMode : false,
       autoZoom: typeof parsed.autoZoom === 'boolean' ? parsed.autoZoom : false,
       viewMode: parsed.viewMode === '3d' ? '3d' : DEFAULT_CONFIG.viewMode,
+      exaggeration:
+        typeof parsed.exaggeration === 'number' && Number.isFinite(parsed.exaggeration)
+          ? Math.max(0, Math.min(2, parsed.exaggeration))
+          : DEFAULT_CONFIG.exaggeration,
     };
   } catch {
     return DEFAULT_CONFIG;
@@ -206,6 +213,10 @@ export function useMapAnalysisConfig() {
     setConfig((prev) => ({ ...prev, viewMode: v }));
   }, []);
 
+  const setExaggeration = useCallback((v: number) => {
+    setConfig((prev) => ({ ...prev, exaggeration: v }));
+  }, []);
+
   const setTimeSlider = useCallback((ts: Partial<MapAnalysisConfig['timeSlider']>) => {
     setConfig((prev) => ({ ...prev, timeSlider: { ...prev.timeSlider, ...ts } }));
   }, []);
@@ -228,6 +239,7 @@ export function useMapAnalysisConfig() {
     setFollowMode,
     setAutoZoom,
     setViewMode,
+    setExaggeration,
     setTimeSlider,
     setInspectorOpen,
     reset,


### PR DESCRIPTION
## Summary
Final phase of the 3D Map & Elevation epic (#3826). The 3D view gains the layers that make it useful for RF analysis: neighbor links and traceroute paths render in 3D with the same toggles, filters, lookback, time-window, and SNR encodings as 2D, and clicking a node, neighbor link, or traceroute segment in 3D drives the same inspector — including Phase 1's distance/elevation/terrain-profile action, with full MeshCore parity. Terrain exaggeration now persists per-browser. With this merged, issue #3826's viable scope is complete.

## Changes
- `Base3DMap`: generic `Line3DFeature[]` + `onLineClick` props — single GeoJSON source, one MapLibre line layer per distinct dash pattern (dasharray isn't data-drivable; color/opacity/width are), rendered beneath node markers, with dynamic dash-layer reconciliation; `initialExaggeration`/`onExaggerationChange` props. Component stays Map-Analysis-agnostic.
- New `use3DNeighborLines` / `use3DTracerouteLines` hooks: consume the same fetch hooks and shared encoding primitives (`snrToNeighborOpacity`, `snrToColor`, `weightByOccurrence`, MQTT dash) the 2D layers use; **parity tests deep-equal the 3D click payloads against the literal `setSelected` shapes in the 2D layers** (file+line cited in the tests), including MeshCore's publicKey-based neighbor variant. No bezier curves/arrows in 3D (flat-map declutter tricks read as artifacts under pitch — direction stays color-encoded).
- Canvas 3D branch wires lines + selection lookup; 2D untouched.
- "View terrain profile" triggered while in 3D auto-switches to 2D with the drawer open (the profile controller's verdict polyline is Leaflet-rendered; the elevation fetch is cache-shared so the drawer opens instantly).
- `exaggeration` persisted in `mapAnalysis.config.v1` (clamped 0–2, default 1.3) — deliberately client-local, no server setting.
- Docs: Map Analysis 3D section updated ("not in 3D yet" list shrunk), spec + epic plan committed; #3826 closing comment drafted in the spec for post-merge.

## Issues Resolved
Relates to #3826 (Phase 3 of 3 — closes out the epic's viable scope; issue closable after merge). Phase 1 = #4235, Phase 2 = #4239.

## Documentation Updates
- `docs/features/map-analysis.md` (3D section: layers, selection, exaggeration persistence, profile auto-switch, terrain-draping caveat)
- Dev-notes: `3D_LAYERS_POLISH_SPEC.md`, `MAP_3D_ELEVATION_EPIC.md` (epic complete)
- No API/settings doc changes (Phase 3 added no endpoints or server settings)

## Testing
- [x] Full suite green: 10,578 tests / 0 failures (`success: true` via JSON reporter); includes deep-equal 2D-parity tests for all three selection shapes
- [x] TypeScript + `npm run lint:ci` clean (no baseline growth)
- [x] Live-validated (Chrome + SwiftShader on the dev container): dashed neighbor lines render in pitched 3D; selection persists across 2D↔3D; profile action from 3D lands on 2D with the drawer open and correct budget; exaggeration 1.8× round-trips a reload; no page errors
- [ ] Reviewer: enable Neighbors, select a link, switch to 3D (cube icon) → lines + inspector; click "View terrain profile" → auto-returns to 2D with the drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1