### PR TITLE
feat(channels): show reactor's short name next to emoji reactions (#4243)

### DIFF
--- a/src/components/ChannelsTab.reactions.test.tsx
+++ b/src/components/ChannelsTab.reactions.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #4243 — the reacting node's short name must be visible next to the emoji in
+ * Channel Messages, not hidden behind a hover-only `title` tooltip (which is
+ * unreachable on touch devices and invisible at a glance).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChannelsTab from './ChannelsTab';
+import type { MeshMessage } from '../types/message';
+
+// ChannelsTab calls useNodes() directly (line 211), which reaches usePoll ->
+// useCsrfFetch -> useCsrf and requires a CsrfProvider. The node list is
+// irrelevant to reaction rendering (short names arrive via the
+// getNodeShortName prop), so stub it rather than standing up the provider tree.
+vi.mock('../hooks/useServerData', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNodes: () => ({ nodes: [], isLoading: false, error: null }),
+}));
+
+// ChannelsTab also pulls distanceUnit and channel-mute state from
+// SettingsContext. Neither affects reaction rendering.
+vi.mock('../contexts/SettingsContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSettings: () => ({ distanceUnit: 'km' }),
+  useNotificationMuteSettings: () => ({
+    isChannelMuted: () => false,
+    muteChannel: async () => {},
+    unmuteChannel: async () => {},
+  }),
+}));
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      (opts?.defaultValue as string) ?? key,
+  }),
+}));
+
+// jsdom has no ResizeObserver; ChannelsTab constructs one on mount (line 384).
+// Stubbed locally rather than in the shared setup file so this PR doesn't
+// change the environment for every other test.
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+const PARENT_PACKET_ID = 5000;
+
+// Message ids are `${sourceId}_${fromNum}_${packetId}` — ChannelsTab matches a
+// reaction to its parent via `msg.id.split('_').pop()`, so the trailing segment
+// must be the parent's packet id.
+const parentMsg: MeshMessage = {
+  id: `src1_111_${PARENT_PACKET_ID}`,
+  from: '!aaaaaaaa',
+  to: '^all',
+  fromNodeId: '!aaaaaaaa',
+  toNodeId: '^all',
+  text: 'anyone around?',
+  channel: 0,
+  timestamp: new Date('2026-07-21T12:00:00Z'),
+};
+
+const reactionMsg: MeshMessage = {
+  id: 'src1_222_5001',
+  from: '!bbbbbbbb',
+  to: '^all',
+  fromNodeId: '!bbbbbbbb',
+  toNodeId: '^all',
+  text: '👍',
+  channel: 0,
+  timestamp: new Date('2026-07-21T12:00:05Z'),
+  replyId: PARENT_PACKET_ID,
+  emoji: 1,
+};
+
+type ChannelsTabProps = React.ComponentProps<typeof ChannelsTab>;
+
+function makeProps(overrides: Partial<ChannelsTabProps> = {}): ChannelsTabProps {
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  return {
+    channels: [{ id: 0, name: 'Primary', psk: '', uplinkEnabled: true, downlinkEnabled: true }],
+    channelDatabaseEntries: [],
+    channelMessages: { 0: [parentMsg, reactionMsg] },
+    messages: [parentMsg, reactionMsg],
+    currentNodeId: '!cccccccc',
+    sourceId: 'src1',
+    connectionStatus: 'connected',
+    selectedChannel: 0,
+    setSelectedChannel: noop,
+    selectedChannelRef: { current: 0 },
+    showMqttMessages: true,
+    setShowMqttMessages: noop,
+    newMessage: '',
+    setNewMessage: noop,
+    replyingTo: null,
+    setReplyingTo: noop,
+    unreadCounts: {},
+    setUnreadCounts: noop,
+    markMessagesAsRead: noop,
+    channelInfoModal: null,
+    setChannelInfoModal: noop,
+    showPsk: false,
+    setShowPsk: noop,
+    timeFormat: '24' as const,
+    dateFormat: 'MM/DD/YYYY' as const,
+    hasPermission: () => true,
+    handleSendMessage: asyncNoop,
+    handleResendMessage: asyncNoop,
+    handleDeleteMessage: asyncNoop,
+    handleSendTapback: noop,
+    handlePurgeChannelMessages: asyncNoop,
+    handleSenderClick: noop,
+    shouldShowData: () => true,
+    getNodeName: (id: string) => (id === '!bbbbbbbb' ? 'Bob Node' : 'Alice Node'),
+    getNodeShortName: (id: string) => (id === '!bbbbbbbb' ? 'BOB' : 'ALC'),
+    isMqttBridgeMessage: () => false,
+    setEmojiPickerMessage: noop,
+    channelMessagesContainerRef: { current: null },
+    ...overrides,
+  } as unknown as ChannelsTabProps;
+}
+
+describe('ChannelsTab reactions (#4243)', () => {
+  it("renders the reactor's short name inline beside the emoji", () => {
+    render(<ChannelsTab {...makeProps()} />);
+
+    const author = document.querySelector('.reaction__author');
+    expect(author).not.toBeNull();
+    expect(author?.textContent).toBe('BOB');
+  });
+
+  it('keeps the emoji itself rendered alongside the name', () => {
+    render(<ChannelsTab {...makeProps()} />);
+
+    const bubble = document.querySelector('.reaction');
+    expect(bubble).not.toBeNull();
+    // The bubble carries both the emoji and the author label.
+    expect(bubble?.textContent).toContain('👍');
+    expect(bubble?.textContent).toContain('BOB');
+  });
+
+  it('still exposes the name via the title tooltip for hover users', () => {
+    render(<ChannelsTab {...makeProps()} />);
+
+    const bubble = document.querySelector('.reaction');
+    // The tooltip is preserved; the inline label is additive, not a replacement.
+    expect(bubble?.getAttribute('title')).toBeTruthy();
+  });
+
+  it('does not render the parent message itself as a reaction bubble', () => {
+    render(<ChannelsTab {...makeProps()} />);
+
+    // Exactly one reaction bubble — the tapback. The parent is a normal message.
+    expect(document.querySelectorAll('.reaction').length).toBe(1);
+    expect(screen.getByText('anyone around?')).toBeTruthy();
+  });
+});

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -1133,16 +1133,26 @@ export default function ChannelsTab({
                                     <LinkPreview text={msg.text} />
                                     {reactions.length > 0 && (
                                       <div className="message-reactions">
-                                        {reactions.map(reaction => (
-                                          <span
-                                            key={reaction.id}
-                                            className={`reaction ${isMyMessage(reaction) ? 'mine' : 'theirs'}`}
-                                            title={t('channels.reaction_tooltip', { name: getNodeShortName(reaction.from) })}
-                                            onClick={() => handleSendTapback(reaction.text, msg)}
-                                          >
-                                            {reaction.text}
-                                          </span>
-                                        ))}
+                                        {reactions.map(reaction => {
+                                          // #4243: show WHO reacted inline. The short
+                                          // name was already resolved here for the
+                                          // tooltip, but a hover-only affordance is
+                                          // unusable on touch and invisible at a glance.
+                                          const reactorName = getNodeShortName(reaction.from);
+                                          return (
+                                            <span
+                                              key={reaction.id}
+                                              className={`reaction ${isMyMessage(reaction) ? 'mine' : 'theirs'}`}
+                                              title={t('channels.reaction_tooltip', { name: reactorName })}
+                                              onClick={() => handleSendTapback(reaction.text, msg)}
+                                            >
+                                              {reaction.text}
+                                              {reactorName && (
+                                                <span className="reaction__author">{reactorName}</span>
+                                              )}
+                                            </span>
+                                          );
+                                        })}
                                       </div>
                                     )}
                                   </div>

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1662,6 +1662,25 @@
   transform: scale(1.1);
 }
 
+/* #4243: the reactor's short name, rendered inline beside the emoji so it is
+   visible without hovering (it was previously only in the title tooltip).
+   Smaller and lighter than the emoji so the emoji stays the primary mark. */
+.reaction__author {
+  margin-left: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.reaction.mine .reaction__author {
+  color: var(--ctp-base);
+}
+
+.reaction.theirs .reaction__author {
+  color: var(--ctp-subtext0);
+}
+
 /* Unread Message Indicators */
 .unread-badge {
   display: inline-flex;


### PR DESCRIPTION
Closes #4243

## Problem

In Channel Messages, the reacting node's short name was only available through the reaction bubble's `title` attribute — a browser hover tooltip. That's unreachable on touch devices and invisible at a glance, so reactions read as anonymous.

`getNodeShortName(reaction.from)` was already being called at that exact call site purely to feed the tooltip.

## Change

Render the short name inline beside the emoji (`.reaction__author`), keeping the tooltip. The label is smaller and lighter than the emoji so the emoji stays the primary mark, and it picks up a contrasting color in `.mine` vs `.theirs` bubbles.

`getNodeShortName` never returns empty — it falls back to the last 4 chars of the node id — so the label always renders; the truthiness guard is defensive only.

## Tests

This adds the **first test file for ChannelsTab**. The component takes all 37 required values as props and uses no `useContext` directly, but it does call three hooks internally (`useNodes`, `useSettings`, `useNotificationMuteSettings`), so those are mocked rather than standing up the full provider tree. `ResizeObserver` is stubbed locally rather than in `src/test/setup.ts`, to avoid changing the environment for every other test in this PR.

**I verified the test catches the regression** rather than assuming it: with the source change stashed, the two behavior assertions fail and the two unchanged-behavior guards (tooltip preserved, parent not rendered as a bubble) still pass.

```
WITHOUT FIX -> success: false  passed: 2  failed: 2
  now failing: renders the reactor's short name inline beside the emoji
  now failing: keeps the emoji itself rendered alongside the name
```

## Validation

- `ChannelsTab.reactions.test.tsx` — 4 tests, `success: true`
- `npx tsc --noEmit` — no errors
- `npx eslint` on both changed source files — clean

## Note

Multiple reactors with the same emoji already render as separate bubbles, so each gets its own name label — there's no grouping/count behavior to reconcile. If you'd prefer grouped bubbles (`👍 3` with names in the tooltip), that's a different design and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW