### PR TITLE
feat(nodes): per-field Copy NodeInfo with overwrite, and fix the MAC address display (#4244)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -349,6 +349,7 @@
   "nodes.copy_nodeinfo_source": "Copy from source",
   "nodes.copy_nodeinfo_current": "Current",
   "nodes.copy_nodeinfo_incoming": "Incoming",
+  "nodes.copy_nodeinfo_select_all": "Select all fields",
   "nodes.copy_nodeinfo_field": "Field",
   "nodes.copy_nodeinfo_no_changes": "No new fields to copy — the target already has all available data.",
   "nodes.copy_nodeinfo_push_to_device": "Push to NodeDB",

--- a/src/components/CopyNodeInfoModal/CopyNodeInfoModal.css
+++ b/src/components/CopyNodeInfoModal/CopyNodeInfoModal.css
@@ -80,6 +80,42 @@
   background: rgba(76, 175, 80, 0.08);
 }
 
+/* #4244: per-field selection column. */
+.copy-nodeinfo-diff .field-select {
+  width: 1%;
+  white-space: nowrap;
+  text-align: center;
+  padding-right: 4px;
+}
+
+.copy-nodeinfo-diff .field-select input {
+  cursor: pointer;
+  margin: 0;
+}
+
+.copy-nodeinfo-diff .field-select input:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+/* A row that REPLACES existing data reads differently from one that fills a
+   blank — amber rather than green, so an overwrite is never mistaken for a
+   purely additive change. */
+.copy-nodeinfo-diff tr.diff-overwrite {
+  background: rgba(255, 167, 38, 0.08);
+}
+
+.copy-nodeinfo-diff tr.diff-overwrite .field-incoming {
+  color: var(--warning-color, #ffa726);
+  font-weight: 600;
+}
+
+/* Unchecked rows recede so the pending selection is obvious at a glance. */
+.copy-nodeinfo-diff tbody tr:not(.is-selected) .field-incoming,
+.copy-nodeinfo-diff tbody tr:not(.is-selected) .field-current {
+  opacity: 0.5;
+}
+
 .copy-nodeinfo-no-changes {
   text-align: center;
   color: var(--text-secondary, #aaa);

--- a/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
+++ b/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
@@ -154,10 +154,13 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
   // Default the selection to every row that would actually change something,
   // which reproduces the old fill-empty behavior plus the stale-value refreshes
   // the old code silently refused to do. Re-runs when the donor changes.
+  //
+  // Deliberately keyed on the donor rather than on diffRows: diffRows is a new
+  // array every render, so depending on it would re-run this effect forever and
+  // stomp the user's checkbox edits on each pass.
   useEffect(() => {
     setSelectedFields(new Set(diffRows.filter(r => r.differs).map(r => r.key as string)));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- #4244 keyed on the
-    // donor, not on diffRows (recomputed every render, would loop).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- #4244 see comment above
   }, [selectedSourceId, currentNode]);
 
   const toggleField = useCallback((key: string) => {

--- a/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
+++ b/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Modal from '../common/Modal';
 import { useSource } from '../../contexts/SourceContext';
@@ -134,10 +134,53 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
     const incomingVal = selectedCandidate ? (selectedCandidate.node as any)[key] : null;
     const isNew = (currentVal == null || currentVal === '') &&
                   incomingVal != null && incomingVal !== '';
-    return { key, label, currentVal, incomingVal, isNew };
+    // #4244: a field can now be copied even when the target already holds a
+    // value, so "would this change anything?" is the real gate, not "is the
+    // target empty?".
+    const hasIncoming = incomingVal != null && incomingVal !== '';
+    const differs = hasIncoming && String(currentVal ?? '') !== String(incomingVal);
+    return { key, label, currentVal, incomingVal, isNew, hasIncoming, differs };
   });
 
-  const hasChanges = diffRows.some(r => r.isNew);
+  // Only rows with an incoming value are selectable — there is nothing to copy
+  // from an empty donor field.
+  const selectableKeys = useMemo(
+    () => diffRows.filter(r => r.hasIncoming).map(r => r.key as string),
+    [diffRows],
+  );
+
+  const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set());
+
+  // Default the selection to every row that would actually change something,
+  // which reproduces the old fill-empty behavior plus the stale-value refreshes
+  // the old code silently refused to do. Re-runs when the donor changes.
+  useEffect(() => {
+    setSelectedFields(new Set(diffRows.filter(r => r.differs).map(r => r.key as string)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- #4244 keyed on the
+    // donor, not on diffRows (recomputed every render, would loop).
+  }, [selectedSourceId, currentNode]);
+
+  const toggleField = useCallback((key: string) => {
+    setSelectedFields(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const allSelected = selectableKeys.length > 0 &&
+    selectableKeys.every(k => selectedFields.has(k));
+
+  const toggleAll = useCallback(() => {
+    setSelectedFields(prev => {
+      const everySelected = selectableKeys.length > 0 &&
+        selectableKeys.every(k => prev.has(k));
+      return everySelected ? new Set<string>() : new Set(selectableKeys);
+    });
+  }, [selectableKeys]);
+
+  const hasChanges = selectedFields.size > 0;
 
   const handleConfirm = useCallback(async () => {
     if (!nodeNum || !selectedSourceId || !sourceId) return;
@@ -157,6 +200,9 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
             fromSourceId: selectedSourceId,
             toSourceId: sourceId,
             pushToNodeDb,
+            // #4244: explicit selection — these overwrite the target even when
+            // it already holds a (possibly derived/stale) value.
+            fields: Array.from(selectedFields),
           }),
         },
       );
@@ -179,7 +225,7 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
     } finally {
       setSaving(false);
     }
-  }, [nodeNum, selectedSourceId, sourceId, pushToNodeDb, csrfFetch, t, onCopied]);
+  }, [nodeNum, selectedSourceId, sourceId, pushToNodeDb, selectedFields, csrfFetch, t, onCopied]);
 
   return (
     <Modal
@@ -235,23 +281,54 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
             <table>
               <thead>
                 <tr>
+                  <th className="field-select">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleAll}
+                      disabled={selectableKeys.length === 0}
+                      aria-label={t('nodes.copy_nodeinfo_select_all', 'Select all fields')}
+                      title={t('nodes.copy_nodeinfo_select_all', 'Select all fields')}
+                    />
+                  </th>
                   <th>{t('nodes.copy_nodeinfo_field')}</th>
                   <th>{t('nodes.copy_nodeinfo_current')}</th>
                   <th>{t('nodes.copy_nodeinfo_incoming')}</th>
                 </tr>
               </thead>
               <tbody>
-                {diffRows.map(row => (
-                  <tr key={row.key} className={row.isNew ? 'diff-new' : ''}>
-                    <td className="field-name">{row.label}</td>
-                    <td className="field-current">
-                      {formatFieldValue(row.key, row.currentVal)}
-                    </td>
-                    <td className={`field-incoming${row.isNew ? ' new-value' : ''}`}>
-                      {formatFieldValue(row.key, row.incomingVal)}
-                    </td>
-                  </tr>
-                ))}
+                {diffRows.map(row => {
+                  const checked = selectedFields.has(row.key as string);
+                  return (
+                    <tr
+                      key={row.key}
+                      className={[
+                        row.isNew ? 'diff-new' : '',
+                        // A row that overwrites existing data is visually
+                        // distinct from one that merely fills a blank (#4244).
+                        row.differs && !row.isNew ? 'diff-overwrite' : '',
+                        checked ? 'is-selected' : '',
+                      ].filter(Boolean).join(' ')}
+                    >
+                      <td className="field-select">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={!row.hasIncoming}
+                          onChange={() => toggleField(row.key as string)}
+                          aria-label={row.label}
+                        />
+                      </td>
+                      <td className="field-name">{row.label}</td>
+                      <td className="field-current">
+                        {formatFieldValue(row.key, row.currentVal)}
+                      </td>
+                      <td className={`field-incoming${row.isNew ? ' new-value' : ''}`}>
+                        {formatFieldValue(row.key, row.incomingVal)}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1240,7 +1240,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
                         {/* Copy NodeInfo from Another Source — local DB
                             operation, no packet transmitted. */}
-                        {selectedNode && !isNodeComplete(selectedNode) && hasPermission('nodes', 'write') && (
+                        {/* #4244: not gated on isNodeComplete — another source may
+                            have heard fresher NodeInfo, and "complete" can mean
+                            nothing more than derived placeholder names. */}
+                        {selectedNode && hasPermission('nodes', 'write') && (
                           <button
                             className="actions-menu-item"
                             onClick={() => {
@@ -2426,6 +2429,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
           hwModel: selectedNode.user?.hwModel,
           role: selectedNode.user?.role != null ? Number(selectedNode.user.role) : null,
           publicKey: selectedNode.user?.publicKey,
+          // #4244: see NodesTab — all eight diffed fields must be passed.
+          macaddr: selectedNode.user?.macaddr,
+          hasPKC: selectedNode.user?.hasPKC,
+          firmwareVersion: selectedNode.user?.firmwareVersion,
         } : null}
         onClose={() => setShowCopyNodeInfoModal(false)}
         onCopied={() => setShowCopyNodeInfoModal(false)}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1614,7 +1614,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   if (node.user?.id && hasPermission('messages', 'read')) {
                     actions.push({ kind: 'more-details', onClick: handlePopupDMClick(node) });
                   }
-                  if (!isNodeComplete(node) && hasPermission('nodes', 'write')) {
+                  // #4244: no longer gated on isNodeComplete -- another source
+                  // may have heard fresher NodeInfo than this one, and
+                  // "complete" can mean nothing more than derived placeholders.
+                  if (hasPermission('nodes', 'write')) {
                     actions.push({ kind: 'copy-nodeinfo', onClick: () => setCopyNodeInfoTarget(node) });
                   }
                   if (hasPermission('messages', 'write') && node.nodeNum !== currentNodeNum) {
@@ -2767,6 +2770,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
           hwModel: copyNodeInfoTarget.user?.hwModel,
           role: copyNodeInfoTarget.user?.role != null ? Number(copyNodeInfoTarget.user.role) : null,
           publicKey: copyNodeInfoTarget.user?.publicKey,
+          // #4244: without these three the modal's "Current" column showed "—"
+          // regardless of what was stored.
+          macaddr: copyNodeInfoTarget.user?.macaddr,
+          hasPKC: copyNodeInfoTarget.user?.hasPKC,
+          firmwareVersion: copyNodeInfoTarget.user?.firmwareVersion,
         } : null}
         onClose={() => setCopyNodeInfoTarget(null)}
         onCopied={() => setCopyNodeInfoTarget(null)}

--- a/src/server/routes/v1/nodes.ts
+++ b/src/server/routes/v1/nodes.ts
@@ -10,7 +10,10 @@ import databaseService, { DbNode } from '../../../services/database.js';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import { logger } from '../../../utils/logger.js';
 import { filterNodesByChannelPermission, maskNodeLocationByChannel } from '../../utils/nodeEnhancer.js';
-import { findCopyCandidates, copyNodeInfo } from '../../services/nodeInfoCopyService.js';
+import {
+  findCopyCandidates, copyNodeInfo, isNodeInfoField, NODE_INFO_FIELDS,
+  type NodeInfoField,
+} from '../../services/nodeInfoCopyService.js';
 import { resolvedSourceIdFromPath } from './sourceParam.js';
 
 // mergeParams so this router picks up :sourceId when mounted under
@@ -260,13 +263,26 @@ router.post('/:nodeNum/copy-nodeinfo', async (req: Request, res: Response) => {
       });
     }
 
-    const { fromSourceId, toSourceId, pushToNodeDb } = req.body ?? {};
+    const { fromSourceId, toSourceId, pushToNodeDb, fields } = req.body ?? {};
     if (!fromSourceId || !toSourceId) {
       return res.status(400).json({
         success: false,
         error: 'Bad Request',
         message: 'fromSourceId and toSourceId are required',
       });
+    }
+
+    // #4244: optional per-field selection; reject unknown names loudly.
+    let selectedFields: NodeInfoField[] | undefined;
+    if (fields !== undefined) {
+      if (!Array.isArray(fields) || !fields.every(isNodeInfoField)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Bad Request',
+          message: `fields must be an array of: ${NODE_INFO_FIELDS.join(', ')}`,
+        });
+      }
+      selectedFields = fields;
     }
 
     if (!await hasNodesReadPermission(userId, isAdmin, fromSourceId)) {
@@ -287,7 +303,9 @@ router.post('/:nodeNum/copy-nodeinfo', async (req: Request, res: Response) => {
       });
     }
 
-    const result = await copyNodeInfo(nodeNum, fromSourceId, toSourceId, !!pushToNodeDb);
+    const result = await copyNodeInfo(
+      nodeNum, fromSourceId, toSourceId, !!pushToNodeDb, selectedFields,
+    );
     res.json({ success: true, data: result });
   } catch (error: any) {
     logger.error('Error copying node info:', error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1075,7 +1075,10 @@ apiRouter.get('/nodes/active', optionalAuth(), async (req, res) => {
 });
 
 // Copy NodeInfo from another source
-import { findCopyCandidates, copyNodeInfo } from './services/nodeInfoCopyService.js';
+import {
+  findCopyCandidates, copyNodeInfo, isNodeInfoField, NODE_INFO_FIELDS,
+  type NodeInfoField,
+} from './services/nodeInfoCopyService.js';
 
 apiRouter.get('/nodes/:nodeNum/copy-candidates', requirePermission('nodes', 'read'), async (req, res) => {
   try {
@@ -1101,11 +1104,25 @@ apiRouter.post('/nodes/:nodeNum/copy-nodeinfo', requirePermission('nodes', 'writ
     if (isNaN(nodeNum)) {
       return res.status(400).json({ error: 'nodeNum must be a number' });
     }
-    const { fromSourceId, toSourceId, pushToNodeDb } = req.body ?? {};
+    const { fromSourceId, toSourceId, pushToNodeDb, fields } = req.body ?? {};
     if (!fromSourceId || !toSourceId) {
       return res.status(400).json({ error: 'fromSourceId and toSourceId are required' });
     }
-    const result = await copyNodeInfo(nodeNum, fromSourceId, toSourceId, !!pushToNodeDb);
+    // #4244: optional per-field selection. Reject unknown names rather than
+    // silently ignoring them, so a client typo surfaces instead of quietly
+    // copying nothing.
+    let selectedFields: NodeInfoField[] | undefined;
+    if (fields !== undefined) {
+      if (!Array.isArray(fields) || !fields.every(isNodeInfoField)) {
+        return res.status(400).json({
+          error: `fields must be an array of: ${NODE_INFO_FIELDS.join(', ')}`,
+        });
+      }
+      selectedFields = fields;
+    }
+    const result = await copyNodeInfo(
+      nodeNum, fromSourceId, toSourceId, !!pushToNodeDb, selectedFields,
+    );
     res.json({ success: true, data: result });
   } catch (error: any) {
     logger.error('Error copying node info:', error);

--- a/src/server/services/nodeInfoCopyService.fields.test.ts
+++ b/src/server/services/nodeInfoCopyService.fields.test.ts
@@ -1,0 +1,164 @@
+/**
+ * #4244 — Copy NodeInfo per-field selection.
+ *
+ * The original loop copied a field only when the TARGET was null/empty:
+ *
+ *   if (donorVal != null && donorVal !== '' && (targetVal == null || targetVal === ''))
+ *
+ * which made the feature useless in its most common case. MeshMonitor
+ * auto-populates longName/shortName with a derived placeholder ("Node
+ * !383c3519"), and a placeholder is a non-empty string — so real incoming
+ * NodeInfo was blocked forever. Same for any field an earlier copy had already
+ * filled (e.g. a role that has since changed upstream: 11 -> 12).
+ *
+ * An explicit `fields` selection now overwrites regardless. Omitting `fields`
+ * must keep the legacy fill-empty-only behavior so other callers are unchanged.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getNode = vi.fn();
+const upsertNode = vi.fn();
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    nodes: {
+      getNode: (...args: unknown[]) => getNode(...args),
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+    },
+    sources: { getAllSources: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: () => null },
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { copyNodeInfo, isNodeInfoField, NODE_INFO_FIELDS } =
+  await import('./nodeInfoCopyService.js');
+
+const DONOR = {
+  nodeNum: 943881497,
+  nodeId: '!383c3519',
+  longName: 'Real Name',
+  shortName: 'REAL',
+  hwModel: 43,
+  role: 12,
+  macaddr: 'aabbccddeeff',
+  publicKey: 'donorkey',
+  hasPKC: true,
+  firmwareVersion: '2.7.4',
+};
+
+/** Target already fully populated — every field would be blocked pre-fix. */
+const POPULATED_TARGET = {
+  nodeNum: 943881497,
+  nodeId: '!383c3519',
+  longName: 'Node !383c3519', // derived placeholder, not real NodeInfo
+  shortName: '3519',
+  hwModel: 1,
+  role: 11, // stale: upstream has since moved to 12
+  macaddr: '112233445566',
+  publicKey: 'oldkey',
+  hasPKC: false,
+  firmwareVersion: '2.7.0',
+};
+
+function wire(donor: unknown, target: unknown) {
+  getNode.mockReset();
+  upsertNode.mockReset().mockResolvedValue(undefined);
+  // copyNodeInfo reads donor first, then target.
+  getNode.mockImplementationOnce(async () => donor)
+         .mockImplementationOnce(async () => target);
+}
+
+beforeEach(() => {
+  getNode.mockReset();
+  upsertNode.mockReset();
+});
+
+describe('copyNodeInfo field selection (#4244)', () => {
+  it('overwrites a populated field when explicitly selected', () => {
+    wire(DONOR, POPULATED_TARGET);
+    return copyNodeInfo(943881497, 'src-a', 'src-b', false, ['longName']).then(res => {
+      expect(res.copiedFields).toEqual(['longName']);
+      const [payload] = upsertNode.mock.calls[0];
+      expect(payload.longName).toBe('Real Name');
+    });
+  });
+
+  it('refreshes a stale role that the old rule refused to touch (11 -> 12)', async () => {
+    wire(DONOR, POPULATED_TARGET);
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false, ['role']);
+    expect(res.copiedFields).toEqual(['role']);
+    expect(upsertNode.mock.calls[0][0].role).toBe(12);
+  });
+
+  it('copies ONLY the selected fields, leaving unchecked ones untouched', async () => {
+    wire(DONOR, POPULATED_TARGET);
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false, ['longName', 'shortName']);
+    expect(res.copiedFields.sort()).toEqual(['longName', 'shortName']);
+    const payload = upsertNode.mock.calls[0][0];
+    expect(payload.role).toBeUndefined();
+    expect(payload.macaddr).toBeUndefined();
+  });
+
+  it('copies macaddr when selected even though the target already has one', async () => {
+    // The reported case: target's real MAC was hidden by the modal, so the user
+    // saw "—" and expected a copy that the server then silently skipped.
+    wire(DONOR, POPULATED_TARGET);
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false, ['macaddr']);
+    expect(res.copiedFields).toEqual(['macaddr']);
+    expect(upsertNode.mock.calls[0][0].macaddr).toBe('aabbccddeeff');
+  });
+
+  it('still skips a selected field when the DONOR has nothing to give', async () => {
+    wire({ ...DONOR, longName: null }, POPULATED_TARGET);
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false, ['longName']);
+    expect(res.copiedFields).toEqual([]);
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty-string donor value as nothing to give', async () => {
+    wire({ ...DONOR, shortName: '' }, POPULATED_TARGET);
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false, ['shortName']);
+    expect(res.copiedFields).toEqual([]);
+  });
+
+  it('preserves legacy fill-empty-only behavior when fields is omitted', async () => {
+    wire(DONOR, POPULATED_TARGET);
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false);
+    // Every target field is populated, so the legacy rule copies nothing.
+    expect(res.copiedFields).toEqual([]);
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('legacy path still fills genuinely empty target fields', async () => {
+    wire(DONOR, { ...POPULATED_TARGET, macaddr: null, firmwareVersion: '' });
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false);
+    expect(res.copiedFields.sort()).toEqual(['firmwareVersion', 'macaddr']);
+  });
+
+  it('an empty fields array falls back to legacy rather than copying nothing', async () => {
+    // Guards the `fields.length > 0` check: [] must not be read as "select all"
+    // nor silently produce a no-op that looks like success.
+    wire(DONOR, { ...POPULATED_TARGET, macaddr: null });
+    const res = await copyNodeInfo(943881497, 'src-a', 'src-b', false, []);
+    expect(res.copiedFields).toEqual(['macaddr']);
+  });
+});
+
+describe('isNodeInfoField (#4244 request validation)', () => {
+  it('accepts every known field name', () => {
+    for (const f of NODE_INFO_FIELDS) expect(isNodeInfoField(f)).toBe(true);
+  });
+
+  it('rejects unknown names and non-strings so client typos surface as 400s', () => {
+    for (const bad of ['nodeNum', 'nodeId', '__proto__', '', 1, null, undefined, {}]) {
+      expect(isNodeInfoField(bad)).toBe(false);
+    }
+  });
+});

--- a/src/server/services/nodeInfoCopyService.ts
+++ b/src/server/services/nodeInfoCopyService.ts
@@ -73,11 +73,35 @@ export async function findCopyCandidates(
   return candidates;
 }
 
+/** Runtime guard for field names arriving from the request body. */
+export function isNodeInfoField(value: unknown): value is NodeInfoField {
+  return typeof value === 'string' && (NODE_INFO_FIELDS as readonly string[]).includes(value);
+}
+
+export { NODE_INFO_FIELDS };
+export type { NodeInfoField };
+
+/**
+ * Copy NodeInfo fields from one source's row to another's.
+ *
+ * `fields` (#4244) selects exactly which fields to copy, and those fields
+ * OVERWRITE the target even when it already holds a value. This exists because
+ * the previous all-or-nothing rule — copy only when the target is null/empty —
+ * made the feature useless in its most common case: MeshMonitor auto-populates
+ * longName/shortName with a derived placeholder ("Node !383c3519"), which is a
+ * non-empty string, so real incoming NodeInfo was blocked forever. The same
+ * applied to any field a prior copy had already filled (e.g. a role that has
+ * since changed upstream).
+ *
+ * Omitting `fields` preserves the legacy fill-empty-only behavior, so existing
+ * callers are unaffected.
+ */
 export async function copyNodeInfo(
   nodeNum: number,
   fromSourceId: string,
   toSourceId: string,
   pushToNodeDb: boolean = false,
+  fields?: readonly NodeInfoField[],
 ): Promise<CopyNodeInfoResult> {
   const donorNode = await databaseService.nodes.getNode(nodeNum, fromSourceId);
   if (!donorNode) {
@@ -92,13 +116,24 @@ export async function copyNodeInfo(
   const updates: Partial<DbNode> = {};
   const copiedFields: string[] = [];
 
+  // An explicit selection means the user has seen both values and chosen to
+  // take the donor's, so a populated target is no longer a reason to skip.
+  const selected = fields && fields.length > 0 ? new Set<string>(fields) : null;
+
   for (const field of NODE_INFO_FIELDS) {
+    if (selected && !selected.has(field)) continue;
+
     const donorVal = (donorNode as any)[field];
-    const targetVal = (targetNode as any)[field];
-    if (donorVal != null && donorVal !== '' && (targetVal == null || targetVal === '')) {
-      (updates as any)[field] = donorVal;
-      copiedFields.push(field);
+    if (donorVal == null || donorVal === '') continue;
+
+    if (!selected) {
+      // Legacy path: fill only what the target is missing.
+      const targetVal = (targetNode as any)[field];
+      if (targetVal != null && targetVal !== '') continue;
     }
+
+    (updates as any)[field] = donorVal;
+    copiedFields.push(field);
   }
 
   if (copiedFields.length === 0) {

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -7,6 +7,13 @@ export interface DeviceInfo {
     hwModel?: number;
     role?: string;
     publicKey?: string;
+    // #4244: the Copy NodeInfo modal diffs all eight NODE_INFO_FIELDS. These
+    // three were absent from this type, so its "Current" column rendered them
+    // as "—" no matter what was stored — making macaddr look copyable when the
+    // server would then refuse to overwrite the real value.
+    macaddr?: string | null;
+    hasPKC?: boolean | null;
+    firmwareVersion?: string | null;
   };
   position?: {
     latitude: number;


### PR DESCRIPTION
Closes #4244

Three related defects. Two were as filed; the third turned out to be a different bug than reported.

## 1. A populated field could never be refreshed

`nodeInfoCopyService.ts` required the **target** to be null/empty, so any non-empty value blocked the copy forever. That's the common case, not an edge case: MeshMonitor auto-populates `longName`/`shortName` with a derived placeholder (`"Node !383c3519"`), and a placeholder is a non-empty string. Same for any field an earlier copy had filled — e.g. the stale `role` in the report (current 11, incoming 12).

`copyNodeInfo` now takes an optional `fields` list. Listed fields **overwrite** regardless of what the target holds. Omitting `fields` preserves the legacy fill-empty-only behavior, so existing callers are unchanged. Both route handlers (`server.ts` and the v1 router) accept and validate `fields`, rejecting unknown names with a 400 rather than silently copying nothing.

## 2. MAC address — a display bug, not a copy bug

This is the part the issue couldn't root-cause, and it isn't where it was being looked for. The service, routes, schema, and write path all handle `macaddr` correctly.

The modal renders its "Current" column from a `currentNode` prop that **both** call sites built with only five keys — `macaddr`, `hasPKC`, and `firmwareVersion` were absent. And `DeviceInfo['user']` had no `macaddr` member at all, so the callers *couldn't* have passed it without a type change.

The chain:
1. `currentVal` is `undefined` → the column renders `—`
2. `isNew` therefore computes `true` → row styled as new, Confirm goes live
3. The server compares the **real** stored value and skips the field → "Copied 0 fields"

`macaddr` is the only one of those three that an MQTT donor ever populates (`mqttIngestion.ts:284`; `firmwareVersion`/`hasPKC` are never set there), which is exactly why it was the only field anyone reported. It also corroborates the reported "6/8 fields" — an MQTT donor can fill at most 6, and only if `macaddr` is among them.

Fixed by adding the three fields to the type and passing them from both call sites.

## 3. The action vanished once a node looked "complete"

Both Actions menus gated on `!isNodeComplete`, but a different source may have heard fresher NodeInfo, and "complete" can mean nothing more than derived placeholders. Ungated on the Node List and DM Actions menus.

**Judgment call:** the inline per-row icon button (`NodesTab.tsx:2111`) stays gated. It's a needs-attention shortcut, and showing it unconditionally would put a copy icon on every row in the list. The issue asks specifically about the dropdown. Easy to change if you'd rather it were unconditional.

## UI

Checkbox column plus a select-all header. Rows that would **overwrite** existing data are styled amber and distinctly from rows that merely fill a blank, so an overwrite is never mistaken for an additive change. Unchecked rows recede. Default selection is every row that would actually change something — which reproduces the old fill-empty behavior *plus* the stale-value refreshes the old code silently refused.

## Validation

- New `nodeInfoCopyService.fields.test.ts` — 11 tests, `success: true`. Covers overwrite-when-selected, the 11→12 role refresh, selection isolation, empty-donor skips, legacy-path preservation, and that `fields: []` falls back to legacy rather than reading as "select all".
- Full Vitest suite on this branch: **27,686 passed**.
- `npx tsc --noEmit` — no errors.

The suite reports 2 failures in `src/server/meshcoreCompanionCodec.test.ts`. **These are pre-existing** — I ran that file against clean `main` (`df4098a8`, none of these changes present) and it fails identically. Unrelated to this PR; looks like the unmerged meshcore.js fork dependency from #4094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW