### PR TITLE
fix(map): clickable neighbor links + terrain analysis on route segments

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -419,8 +419,11 @@ describe('DashboardMap', () => {
       />,
     );
     const polylines = screen.getAllByTestId('map-polyline');
-    // Only the link with valid positions should be rendered
-    expect(polylines.length).toBe(1);
+    // Only the link with valid positions should be rendered. Interactive
+    // links render two polylines since the thin-line click-target fix
+    // (visible line + invisible wide hit companion sharing its positions).
+    expect(polylines.length).toBe(2);
+    expect(new Set(polylines.map((p) => p.getAttribute('data-positions'))).size).toBe(1);
   });
 
   it('resolves a neighbor-link endpoint to the rendered marker position when present, falling back to the embedded coordinate otherwise (#4042)', () => {
@@ -431,7 +434,9 @@ describe('DashboardMap', () => {
         neighborInfo={[neighborLinkStaleEmbeddedCoords]}
       />,
     );
-    const polyline = screen.getByTestId('map-polyline');
+    // Interactive links render visible + hit-companion polylines with the
+    // same positions since the thin-line click-target fix — check the first.
+    const polyline = screen.getAllByTestId('map-polyline')[0];
     const positions = JSON.parse(polyline.getAttribute('data-positions') ?? 'null');
     // nodeNum 100 has a rendered marker at [40.0, -90.0] — the resolved
     // endpoint uses that marker position, NOT the link's stale embedded

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
@@ -527,4 +527,84 @@ describe('AnalysisInspectorPanel', () => {
       expect(probe.linkProfileMode).toBe(true);
     });
   });
+  describe('route segment terrain integration', () => {
+    const expectedDistance = formatDistance(
+      calculateDistance(30, -90, 31, -90),
+      'km',
+    );
+
+    it('shows distance, endpoint elevations, and the profile action for a positioned segment when elevation is enabled', () => {
+      mockElevationEnabled = true;
+      mockElevationProfileResult = {
+        data: {
+          distanceMeters: 111195,
+          provider: 'test',
+          samples: [
+            { distance: 0, lat: 30, lng: -90, elevation: 55.2 },
+            { distance: 111195, lat: 31, lng: -90, elevation: 140.9 },
+          ],
+        },
+        isLoading: false,
+      };
+      render(
+        <Wrapper>
+          <SelectSegment />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-seg'));
+
+      expect(screen.getByText('Route Segment')).toBeInTheDocument();
+      expect(screen.getByText('Distance')).toBeInTheDocument();
+      expect(screen.getByText(expectedDistance)).toBeInTheDocument();
+      expect(screen.getByText('From Elevation')).toBeInTheDocument();
+      expect(screen.getByText('To Elevation')).toBeInTheDocument();
+      expect(screen.getByText('55 m')).toBeInTheDocument();
+      expect(screen.getByText('141 m')).toBeInTheDocument();
+      expect(screen.getByText('View terrain profile')).toBeInTheDocument();
+
+      const lastCall = useElevationProfileMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({ nodeNum: 1, isMeshCore: false });
+      expect(lastCall?.[1]).toMatchObject({ nodeNum: 2, isMeshCore: false });
+    });
+
+    it('shows distance only (no elevations, no action) when elevation is disabled', () => {
+      mockElevationEnabled = false;
+      render(
+        <Wrapper>
+          <SelectSegment />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-seg'));
+
+      expect(screen.getByText('Distance')).toBeInTheDocument();
+      expect(screen.queryByText('From Elevation')).not.toBeInTheDocument();
+      expect(screen.queryByText('View terrain profile')).not.toBeInTheDocument();
+      const lastCall = useElevationProfileMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBeUndefined();
+      expect(lastCall?.[1]).toBeUndefined();
+    });
+
+    it('dispatches the link-profile state machine from a segment selection', () => {
+      render(
+        <Wrapper>
+          <CtxProbe />
+          <SelectSegment />
+          <AnalysisInspectorPanel />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('select-seg'));
+      fireEvent.click(screen.getByText('View terrain profile'));
+
+      const probe = JSON.parse(screen.getByTestId('ctx-probe').textContent ?? '{}');
+      expect(probe.linkProfileMode).toBe(true);
+      expect(probe.measureMode).toBe(false);
+      expect(probe.linkEndpoints).toEqual([
+        { nodeNum: 1, isMeshCore: false },
+        { nodeNum: 2, isMeshCore: false },
+      ]);
+    });
+  });
 });
+

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -16,7 +16,11 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { useElevationEnabled } from '../../hooks/useElevationEnabled';
 import { useElevationProfile } from '../../hooks/useElevationProfile';
 import { calculateDistance, formatDistance } from '../../utils/distance';
-import { resolveNeighborEndpoints, type EndpointNodeRecord } from './neighborLinkEndpoints';
+import {
+  resolveNeighborEndpoints,
+  resolveSegmentEndpoints,
+  type EndpointNodeRecord,
+} from './neighborLinkEndpoints';
 import { UiIcon } from '../icons';
 
 interface NodeRecord extends MaybePositionedNode {
@@ -135,16 +139,19 @@ export default function AnalysisInspectorPanel() {
     timeWindow: null,
   });
 
-  // Neighbor-link terrain integration (epic #3826, Phase 1, WP-2). Resolved
-  // unconditionally (top-level hook, before the early returns) — the memo
-  // itself returns null for non-neighbor selections.
-  const neighborEndpoints = useMemo(
-    () =>
-      selected?.type === 'neighbor'
-        ? resolveNeighborEndpoints(selected, (nodes ?? []) as EndpointNodeRecord[])
-        : null,
-    [selected, nodes],
-  );
+  // Link terrain integration (epic #3826 Phase 1 for neighbor links; extended
+  // to traceroute route segments). Resolved unconditionally (top-level hook,
+  // before the early returns) — the memo itself returns null for other
+  // selection types.
+  const neighborEndpoints = useMemo(() => {
+    if (selected?.type === 'neighbor') {
+      return resolveNeighborEndpoints(selected, (nodes ?? []) as EndpointNodeRecord[]);
+    }
+    if (selected?.type === 'segment') {
+      return resolveSegmentEndpoints(selected, (nodes ?? []) as EndpointNodeRecord[]);
+    }
+    return null;
+  }, [selected, nodes]);
   // Same query key as LinkProfileDrawer's useElevationProfile call ⇒ shared
   // cache (§2.1 of the spec). Disabled (undefined endpoints) unless elevation
   // is enabled AND both endpoints resolved, so browsing with elevation off or
@@ -231,6 +238,63 @@ export default function AnalysisInspectorPanel() {
     if (v === null || v === undefined || !Number.isFinite(v)) return '—';
     return `${Math.round(v)} m`;
   };
+
+  // Shared terrain block for link-shaped selections (neighbor links and
+  // traceroute route segments — epic #3826 Phase 1, extended to segments):
+  // distance is shown whenever both endpoints resolve to a position; endpoint
+  // elevations + the "View terrain profile" action are additionally gated on
+  // `elevationEnabled`, mirroring the toolbar's Link Profile button.
+  const terrainDistKm = neighborEndpoints
+    ? calculateDistance(
+        neighborEndpoints.a.lat,
+        neighborEndpoints.a.lng,
+        neighborEndpoints.b.lat,
+        neighborEndpoints.b.lng,
+      )
+    : null;
+  const terrainSamples = neighborProfile?.samples;
+  const terrainElevA =
+    terrainSamples && terrainSamples.length > 0 ? terrainSamples[0].elevation : undefined;
+  const terrainElevB =
+    terrainSamples && terrainSamples.length > 0
+      ? terrainSamples[terrainSamples.length - 1].elevation
+      : undefined;
+  const terrainRows = (labelA: string, labelB: string) => (
+    <>
+      {neighborEndpoints && (
+        <>
+          <dt>Distance</dt>
+          <dd>{terrainDistKm !== null ? formatDistance(terrainDistKm, distanceUnit) : '—'}</dd>
+        </>
+      )}
+      {elevationEnabled && neighborEndpoints && (
+        <>
+          <dt>{labelA}</dt>
+          <dd>{neighborElevLoading ? '…' : formatElevation(terrainElevA)}</dd>
+          <dt>{labelB}</dt>
+          <dd>{neighborElevLoading ? '…' : formatElevation(terrainElevB)}</dd>
+        </>
+      )}
+    </>
+  );
+  const terrainAction =
+    elevationEnabled && neighborEndpoints ? (
+      <button
+        type="button"
+        className="map-analysis-link-profile-action"
+        onClick={() => {
+          // #3826 Phase 3 §2.5: triggering the profile action while in 3D
+          // auto-switches to 2D, where the drawer + on-map verdict
+          // polyline/endpoint rings actually render.
+          if (config.viewMode === '3d') setViewMode('2d');
+          setMeasureMode(false);
+          setLinkEndpoints([neighborEndpoints.a, neighborEndpoints.b]);
+          setLinkProfileMode(true);
+        }}
+      >
+        View terrain profile
+      </button>
+    ) : null;
 
   if (selected.type === 'node') {
     const node = selectedNode;
@@ -325,22 +389,6 @@ export default function AnalysisInspectorPanel() {
       ? `${selected.publicKey?.substring(0, 8) ?? ''} ↔ ${selected.neighborPublicKey?.substring(0, 8) ?? ''}`
       : `!${(selected.nodeNum ?? 0).toString(16)} ↔ !${(selected.neighborNum ?? 0).toString(16)}`;
     const snr = selected.snr;
-    // Terrain integration (epic #3826, Phase 1, WP-2): distance is shown
-    // whenever both endpoints resolve to a position; endpoint elevations +
-    // the "View terrain profile" action are additionally gated on
-    // `elevationEnabled`, mirroring the toolbar's Link Profile button.
-    const distKm = neighborEndpoints
-      ? calculateDistance(
-          neighborEndpoints.a.lat,
-          neighborEndpoints.a.lng,
-          neighborEndpoints.b.lat,
-          neighborEndpoints.b.lng,
-        )
-      : null;
-    const showElevations = elevationEnabled && !!neighborEndpoints;
-    const samples = neighborProfile?.samples;
-    const endpointElevA = samples && samples.length > 0 ? samples[0].elevation : undefined;
-    const endpointElevB = samples && samples.length > 0 ? samples[samples.length - 1].elevation : undefined;
     return wrap(
       <>
         <h3>Neighbor Link</h3>
@@ -357,38 +405,9 @@ export default function AnalysisInspectorPanel() {
           <dd>{snr === null || snr === undefined ? '—' : `${snr.toFixed(2)} dB`}</dd>
           <dt>Reported</dt>
           <dd>{formatTime(selected.timestamp)}</dd>
-          {neighborEndpoints && (
-            <>
-              <dt>Distance</dt>
-              <dd>{distKm !== null ? formatDistance(distKm, distanceUnit) : '—'}</dd>
-            </>
-          )}
-          {showElevations && (
-            <>
-              <dt>Node Elevation</dt>
-              <dd>{neighborElevLoading ? '…' : formatElevation(endpointElevA)}</dd>
-              <dt>Neighbor Elevation</dt>
-              <dd>{neighborElevLoading ? '…' : formatElevation(endpointElevB)}</dd>
-            </>
-          )}
+          {terrainRows('Node Elevation', 'Neighbor Elevation')}
         </dl>
-        {elevationEnabled && neighborEndpoints && (
-          <button
-            type="button"
-            className="map-analysis-link-profile-action"
-            onClick={() => {
-              // #3826 Phase 3 §2.5: triggering the profile action while in 3D
-              // auto-switches to 2D, where the drawer + on-map verdict
-              // polyline/endpoint rings actually render.
-              if (config.viewMode === '3d') setViewMode('2d');
-              setMeasureMode(false);
-              setLinkEndpoints([neighborEndpoints.a, neighborEndpoints.b]);
-              setLinkProfileMode(true);
-            }}
-          >
-            View terrain profile
-          </button>
-        )}
+        {terrainAction}
       </>,
     );
   }
@@ -468,7 +487,9 @@ export default function AnalysisInspectorPanel() {
             <dd>{selected.avgSnr === null ? '— (unknown)' : `${selected.avgSnr.toFixed(1)} dB`}</dd>
           </>
         )}
+        {terrainRows('From Elevation', 'To Elevation')}
       </dl>
+      {terrainAction}
     </>,
   );
 }

--- a/src/components/MapAnalysis/layers/MeshCoreNeighborLinksLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/MeshCoreNeighborLinksLayer.test.tsx
@@ -45,6 +45,16 @@ vi.mock('../../../hooks/useDashboardData', () => ({
   UNIFIED_SOURCE_ID: '__unified__',
 }));
 
+
+/** Visible line divs only — interactive links also render an invisible
+ *  12px hit companion (opacity 0) since the thin-line click-target fix. */
+function visiblePolys() {
+  return screen.getAllByTestId('poly').filter((el) => {
+    const po = JSON.parse(el.getAttribute('data-path-options') ?? '{}');
+    return po.opacity !== 0;
+  });
+}
+
 describe('MeshCoreNeighborLinksLayer', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -75,7 +85,7 @@ describe('MeshCoreNeighborLinksLayer', () => {
         </MapAnalysisProvider>
       </QueryClientProvider>,
     );
-    const polys = screen.getAllByTestId('poly');
+    const polys = visiblePolys();
     expect(polys).toHaveLength(1);
     // Pins the pre-promotion look (fixed cyan, weight 1.5, dash '6 4') so the
     // shared-layer adapter is byte-for-byte identical. opacity = snrToNeighborOpacity(5)

--- a/src/components/MapAnalysis/layers/NeighborLinksLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/NeighborLinksLayer.test.tsx
@@ -34,6 +34,16 @@ vi.mock('../../../hooks/useDashboardData', () => ({
   UNIFIED_SOURCE_ID: '__unified__',
 }));
 
+
+/** Visible line divs only — interactive links also render an invisible
+ *  12px hit companion (opacity 0) since the thin-line click-target fix. */
+function visiblePolys() {
+  return screen.getAllByTestId('poly').filter((el) => {
+    const po = JSON.parse(el.getAttribute('data-path-options') ?? '{}');
+    return po.opacity !== 0;
+  });
+}
+
 describe('NeighborLinksLayer', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -54,7 +64,7 @@ describe('NeighborLinksLayer', () => {
         </MapAnalysisProvider>
       </QueryClientProvider>,
     );
-    const polys = screen.getAllByTestId('poly');
+    const polys = visiblePolys();
     expect(polys).toHaveLength(1);
     // Pins the pre-promotion look (RF transport color, weight 1, dash '4 4')
     // so the shared-layer adapter is byte-for-byte identical. opacity =
@@ -115,7 +125,7 @@ describe('NeighborLinksLayer', () => {
         </MapAnalysisProvider>
       </QueryClientProvider>,
     );
-    expect(screen.getAllByTestId('poly')).toHaveLength(1);
+    expect(visiblePolys()).toHaveLength(1);
   });
 
   it('still drops an edge when an endpoint has no position on any source', () => {

--- a/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { resolveNeighborEndpoints, type EndpointNodeRecord } from './neighborLinkEndpoints';
+import {
+  resolveNeighborEndpoints,
+  resolveSegmentEndpoints,
+  type EndpointNodeRecord,
+} from './neighborLinkEndpoints';
 import type { SelectedTarget } from './MapAnalysisContext';
 
 describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
@@ -201,4 +205,42 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
 
     expect(resolveNeighborEndpoints(selected, nodes)).toBeNull();
   });
+  describe('resolveSegmentEndpoints', () => {
+    const nodes: EndpointNodeRecord[] = [
+      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20, shortName: 'A1', sources: [{ sourceId: 'src-a' }] },
+      { nodeNum: 2, sourceId: 'src-b', latitude: 11, longitude: 21, shortName: 'B1', sources: [{ sourceId: 'src-b' }] },
+      { nodeNum: 3, sourceId: 'src-a', shortName: 'NOPOS', sources: [{ sourceId: 'src-a' }] },
+    ];
+
+    it('resolves both endpoints by nodeNum for a positioned segment', () => {
+      const result = resolveSegmentEndpoints(
+        { type: 'segment', fromNodeNum: 1, toNodeNum: 2 },
+        nodes,
+      );
+      expect(result).not.toBeNull();
+      expect(result?.a).toMatchObject({ nodeNum: 1, isMeshCore: false, isNode: true });
+      expect(result?.b).toMatchObject({ nodeNum: 2, isMeshCore: false, isNode: true });
+      expect(result?.a.id).toBe('mt:1');
+      expect(result?.b.id).toBe('mt:2');
+    });
+
+    it('returns null when an endpoint is unpositioned', () => {
+      const result = resolveSegmentEndpoints(
+        { type: 'segment', fromNodeNum: 1, toNodeNum: 3 },
+        nodes,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when nodeNums are missing', () => {
+      expect(resolveSegmentEndpoints({ type: 'segment' }, nodes)).toBeNull();
+    });
+
+    it('returns null for a non-segment selection', () => {
+      expect(
+        resolveSegmentEndpoints({ type: 'node', nodeNum: 1, sourceId: 'a' }, nodes),
+      ).toBeNull();
+    });
+  });
 });
+

--- a/src/components/MapAnalysis/neighborLinkEndpoints.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.ts
@@ -124,3 +124,29 @@ export function resolveNeighborEndpoints(
     b: buildEndpoint(resolvedB, isMeshCore),
   };
 }
+
+/**
+ * Build a LinkEndpoint pair for a selected traceroute route segment, or null
+ * when either endpoint cannot be resolved to a rendered position. Segments
+ * carry only `fromNodeNum`/`toNodeNum` (no reporting `sourceId` — the segment
+ * is aggregated across traceroutes), so resolution keys on nodeNum alone with
+ * the same positioned-node fallback the neighbor resolver uses. Segments are
+ * Meshtastic-only (traceroutes are a Meshtastic protocol feature).
+ */
+export function resolveSegmentEndpoints(
+  selected: SelectedTarget,
+  nodes: EndpointNodeRecord[],
+): NeighborEndpoints | null {
+  if (selected.type !== 'segment') return null;
+  if (selected.fromNodeNum === undefined || selected.toNodeNum === undefined) return null;
+
+  const resolvedA = findPositionedNode(nodes, (n) => n.nodeNum === selected.fromNodeNum, undefined);
+  const resolvedB = findPositionedNode(nodes, (n) => n.nodeNum === selected.toNodeNum, undefined);
+
+  if (!resolvedA || !resolvedB) return null;
+
+  return {
+    a: buildEndpoint(resolvedA, false),
+    b: buildEndpoint(resolvedB, false),
+  };
+}

--- a/src/components/map/layers/NeighborLinksLayer.test.tsx
+++ b/src/components/map/layers/NeighborLinksLayer.test.tsx
@@ -22,6 +22,7 @@ interface MockPolylineProps {
   positions: [number, number][];
   pathOptions?: { color?: string; weight?: number; opacity?: number; dashArray?: string };
   className?: string;
+  interactive?: boolean;
   eventHandlers?: { click?: () => void };
   children?: ReactNode;
 }
@@ -42,6 +43,7 @@ vi.mock('react-leaflet', () => ({
       data-opacity={props.pathOptions?.opacity}
       data-dash={props.pathOptions?.dashArray ?? ''}
       data-classname={props.className ?? ''}
+      data-interactive={String(props.interactive ?? true)}
       data-positions={JSON.stringify(props.positions)}
       onClick={props.eventHandlers?.click}
     >
@@ -127,11 +129,39 @@ describe('NeighborLinksLayer', () => {
   });
 
   describe('eventHandlers passthrough', () => {
-    it('fires the descriptor click handler on Polyline click', () => {
+    it('fires the descriptor click handler on the hit-line click', () => {
       const onClick = vi.fn();
       renderLayer([link({ key: 'a', eventHandlers: { click: onClick } })]);
-      fireEvent.click(screen.getByTestId('polyline'));
+      const [visible, hit] = screen.getAllByTestId('polyline');
+      fireEvent.click(hit);
       expect(onClick).toHaveBeenCalledTimes(1);
+      fireEvent.click(visible); // visible line carries no handler
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invisible hit-line for interactive links (thin-line click target fix)', () => {
+    it('renders a wide transparent companion polyline when eventHandlers is set', () => {
+      renderLayer([link({ key: 'a', eventHandlers: { click: vi.fn() } })]);
+      const polys = screen.getAllByTestId('polyline');
+      expect(polys).toHaveLength(2);
+      const [visible, hit] = polys;
+      expect(visible).toHaveAttribute('data-interactive', 'false');
+      expect(hit).toHaveAttribute('data-weight', '12');
+      expect(hit).toHaveAttribute('data-opacity', '0');
+      expect(hit).toHaveAttribute('data-positions', visible.getAttribute('data-positions'));
+    });
+
+    it('renders a hit-line when only children (popup) is set', () => {
+      renderLayer([link({ key: 'a', children: <div data-testid="popup-content">x</div> })]);
+      expect(screen.getAllByTestId('polyline')).toHaveLength(2);
+    });
+
+    it('renders a single interactive-by-default polyline for select-only-less links', () => {
+      renderLayer([link({ key: 'a' })]);
+      const polys = screen.getAllByTestId('polyline');
+      expect(polys).toHaveLength(1);
+      expect(polys[0]).toHaveAttribute('data-interactive', 'true');
     });
   });
 
@@ -179,11 +209,13 @@ describe('NeighborLinksLayer', () => {
   });
 
   describe('popup / tooltip render-prop', () => {
-    it('mounts descriptor children inside the Polyline', () => {
+    it('mounts descriptor children inside the hit-line Polyline', () => {
       renderLayer([
         link({ key: 'a', children: <div data-testid="popup-content">Neighbor info</div> }),
       ]);
       expect(screen.getByTestId('popup-content')).toHaveTextContent('Neighbor info');
+      const [, hit] = screen.getAllByTestId('polyline');
+      expect(hit.querySelector('[data-testid="popup-content"]')).not.toBeNull();
     });
 
     it('renders no popup content when children is omitted', () => {

--- a/src/components/map/layers/NeighborLinksLayer.tsx
+++ b/src/components/map/layers/NeighborLinksLayer.tsx
@@ -45,6 +45,16 @@ export interface NeighborLinksLayerProps {
 }
 
 /**
+ * Interactive links render an invisible companion polyline this wide so a
+ * real pointer can actually hit them. Neighbor links are drawn at weight
+ * 1–1.5 with a dash pattern, and SVG hit-testing covers only the painted
+ * stroke — a 1px dashed line is an effectively unclickable target (and
+ * Leaflet's `clickTolerance` applies only to the Canvas renderer, which the
+ * maps don't use because it drops `className` support).
+ */
+export const NEIGHBOR_LINK_HIT_WEIGHT = 12;
+
+/**
  * Shared neighbor-link render layer (Map Consolidation epic #4047, Phase 7,
  * WP2). Promoted from the 7 near-identical inline/layer renderings across
  * NodesTab, DashboardMap (meshtastic + MeshCore), MapAnalysis
@@ -72,16 +82,29 @@ export function NeighborLinksLayer({ links }: NeighborLinksLayerProps) {
         const fractions = arrows?.fractions ?? neighborArrowFractions;
         const bearing = arrows ? bearingBetween(neighborPos, nodePos) : 0;
 
+        // Interactive links get an invisible wide "hit" companion carrying
+        // the handlers/popup, and the thin visible line opts out of pointer
+        // events so the pair never double-fires. Non-interactive links render
+        // exactly as before.
+        const hasHitLine = Boolean(link.eventHandlers || link.children);
+
         return (
           <Fragment key={link.key}>
             <Polyline
               positions={link.positions}
               pathOptions={link.pathOptions}
               className={link.className}
-              eventHandlers={link.eventHandlers}
-            >
-              {link.children}
-            </Polyline>
+              interactive={!hasHitLine}
+            />
+            {hasHitLine && (
+              <Polyline
+                positions={link.positions}
+                pathOptions={{ weight: NEIGHBOR_LINK_HIT_WEIGHT, opacity: 0 }}
+                eventHandlers={link.eventHandlers}
+              >
+                {link.children}
+              </Polyline>
+            )}
             {arrows &&
               fractions.map((fraction) => (
                 <Marker


### PR DESCRIPTION
## Summary
Two user-reported gaps from exercising the #3826 terrain features. First, neighbor links were effectively unclickable with a real mouse: they render at weight 1–1.5 with a dash pattern, SVG hit-testing covers only the painted stroke, and Leaflet's `clickTolerance` applies only to the Canvas renderer — so clicks required pixel-perfect landing on a lit dash of a 1px line. Second, selecting a traceroute route segment showed no terrain analysis (the #3826 Phase 1 integration covered only neighbor links).

## Changes
- **Shared `NeighborLinksLayer`** (`src/components/map/layers/`): interactive links (those with `eventHandlers` or popup `children`) now render an invisible 12px-wide companion polyline carrying the handlers/popup; the thin visible line opts out of pointer events so the pair never double-fires. Non-interactive links render exactly as before. Benefits every consumer map (NodesTab, Dashboard, MeshCore, Embed, Map Analysis ×2).
- **Route segment terrain** (`AnalysisInspectorPanel`): segment selection now shows great-circle Distance and, when elevation is enabled, From/To ground elevations and the "View terrain profile" action into the existing Link Profile drawer (shared elevation cache; 3D auto-switch preserved). New `resolveSegmentEndpoints` in `neighborLinkEndpoints.ts` (nodeNum-keyed; segments carry no reporting sourceId). The neighbor branch's terrain block is extracted into shared helpers rather than duplicated.
- Consumer tests (DashboardMap + both MapAnalysis adapters) updated for the two-polyline contract; new tests for the hit-line behavior and segment terrain (resolver + inspector + action dispatch).

## Issues Resolved
None filed — user-reported during #3826 epic follow-up testing.

## Documentation Updates
No documentation changes needed (behavioral fix + parity extension of documented features).

## Testing
- [x] Full Vitest suite: only failures are 13 tests in `src/db/repositories/ignoredNodes.test.ts`, an unrelated DB suite that passes 73/73 in isolation and passed in the prior full run (parallel-execution flake; this diff touches no DB code)
- [x] All touched-area suites green: layer 18/18, adapters 26/26, DashboardMap 27/27, inspector+resolver 28/28; typecheck + `lint:ci` clean
- [x] **Real-mouse validation** on the dev container (puppeteer `page.mouse.click`, not synthetic dispatch): neighbor-link click selects the link (4/4 reachable lines at working zoom; ~0 before), segment click shows Distance/elevations/profile action, drawer opens with verdict
- [ ] Reviewer: Map Analysis → enable Neighbors → click a dashed line (should select on first try); click a traceroute segment → inspector shows Distance/elevations + View terrain profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1