### PR TITLE
feat(map-analysis): seed Link Profile antenna AGL from node-reported altitude

### DIFF
--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -220,7 +220,7 @@ Nine inputs drive the analysis; editing any of them recomputes instantly with no
 | Input | Default | Notes |
 | --- | --- | --- |
 | Frequency | 915 MHz | Auto-fills from the picked node's radio config when available (see below) |
-| Antenna height AGL (A and B) | 2 m | Above-ground-level height at each endpoint; node GPS altitude is intentionally **not** used (see [Limitations](#limitations)) |
+| Antenna height AGL (A and B) | 2 m | Above-ground-level height at each endpoint. When a picked node reports an altitude, the field is seeded with `altitude − DEM ground` (shown as \"from node altitude\", editable — your edits always win); otherwise 2 m. The profile math itself always runs on DEM terrain + this AGL value, never raw GPS altitude (see [Limitations](#limitations)) |
 | TX power | 20 dBm | |
 | TX / RX antenna gain | 2.15 dBi each | Standard dipole reference gain |
 | Cable loss | 0 dB | |

--- a/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.test.tsx
@@ -420,4 +420,55 @@ describe('LinkProfileDrawer', () => {
       ).toBeInTheDocument();
     });
   });
+  describe('antenna-AGL seeding from node altitude', () => {
+    it('seeds both AGL inputs from endpoint altitudeM minus DEM ground, with provenance hints', async () => {
+      // OBSTRUCTED_PROFILE ground is 100 m at both ends.
+      mockLinkEndpoints = [
+        { ...endpointA, altitudeM: 130 },
+        { ...endpointB, altitudeM: 112 },
+      ];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Antenna A height AGL (m)')).toHaveValue(30);
+        expect(screen.getByLabelText('Antenna B height AGL (m)')).toHaveValue(12);
+      });
+      expect(screen.getAllByText('from node altitude')).toHaveLength(2);
+    });
+
+    it('keeps the 2 m default when altitudeM is absent or below the DEM ground', async () => {
+      mockLinkEndpoints = [
+        { ...endpointA }, // no altitude
+        { ...endpointB, altitudeM: 95 }, // below the 100 m ground -> datum error
+      ];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('composed-chart')).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText('Antenna A height AGL (m)')).toHaveValue(2);
+      expect(screen.getByLabelText('Antenna B height AGL (m)')).toHaveValue(2);
+      expect(screen.queryByText('from node altitude')).not.toBeInTheDocument();
+    });
+
+    it('manual edits win: typing a value clears the hint and is not overwritten', async () => {
+      mockLinkEndpoints = [
+        { ...endpointA, altitudeM: 130 },
+        { ...endpointB, altitudeM: 112 },
+      ];
+      getElevationProfileMock.mockResolvedValue(OBSTRUCTED_PROFILE);
+      renderDrawer();
+
+      const inputA = screen.getByLabelText('Antenna A height AGL (m)');
+      await waitFor(() => expect(inputA).toHaveValue(30));
+
+      fireEvent.change(inputA, { target: { value: '45' } });
+      expect(inputA).toHaveValue(45);
+      // Only endpoint B's hint remains.
+      expect(screen.getAllByText('from node altitude')).toHaveLength(1);
+    });
+  });
 });
+

--- a/src/components/MapAnalysis/LinkProfileDrawer.tsx
+++ b/src/components/MapAnalysis/LinkProfileDrawer.tsx
@@ -32,7 +32,7 @@ import { ApiError } from '../../services/api';
 import { useElevationProfile } from '../../hooks/useElevationProfile';
 import { useAutoRadioDefaults } from '../../hooks/useAutoRadioDefaults';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
-import { analyzeLinkProfile, VERDICT_LABEL, VERDICT_COLOR } from '../../utils/linkProfile';
+import { aglFromNodeAltitude, analyzeLinkProfile, VERDICT_LABEL, VERDICT_COLOR } from '../../utils/linkProfile';
 import { computeLinkBudget, DEFAULT_K_FACTOR } from '../../utils/linkBudget';
 import { formatDistance } from '../../utils/distance';
 import { UiIcon } from '../icons';
@@ -150,6 +150,43 @@ const LinkProfileDrawer: React.FC = () => {
   }, [pairKey, auto.rxSensitivityDbm, rxEdited]);
 
   const { data: profile, isLoading, error } = useElevationProfile(endpointA, endpointB);
+
+  // Antenna-AGL seeding from node-reported altitude (same manual-edits-win
+  // contract as auto-frequency above): when an endpoint is a node with a
+  // known altitude, suggest `altitude - DEM ground` as the starting height
+  // once the profile arrives. The datum decision stands — node altitude only
+  // seeds the editable input, the model still runs on DEM + AGL.
+  const [aglAEdited, setAglAEdited] = useState(false);
+  const [aglBEdited, setAglBEdited] = useState(false);
+  const [aglASeeded, setAglASeeded] = useState(false);
+  const [aglBSeeded, setAglBSeeded] = useState(false);
+  useEffect(() => {
+    setAglAEdited(false);
+    setAglBEdited(false);
+    setAglASeeded(false);
+    setAglBSeeded(false);
+    setAglA(DEFAULT_AGL_M);
+    setAglB(DEFAULT_AGL_M);
+  }, [pairKey]);
+  useEffect(() => {
+    if (aglAEdited || !profile?.samples.length) return;
+    const seeded = aglFromNodeAltitude(endpointA?.altitudeM, profile.samples[0]?.elevation);
+    if (seeded != null) {
+      setAglA(seeded);
+      setAglASeeded(true);
+    }
+  }, [pairKey, profile, endpointA?.altitudeM, aglAEdited]);
+  useEffect(() => {
+    if (aglBEdited || !profile?.samples.length) return;
+    const seeded = aglFromNodeAltitude(
+      endpointB?.altitudeM,
+      profile.samples[profile.samples.length - 1]?.elevation,
+    );
+    if (seeded != null) {
+      setAglB(seeded);
+      setAglBSeeded(true);
+    }
+  }, [pairKey, profile, endpointB?.altitudeM, aglBEdited]);
 
   // Sync the elevation-graph cursor to a marker on the map: each chart row is
   // index-parallel with the fetched sample, which carries the exact lat/lng of
@@ -398,10 +435,16 @@ const LinkProfileDrawer: React.FC = () => {
               value={aglA}
               onChange={e => {
                 const v = Number(e.target.value);
-                if (!Number.isNaN(v)) setAglA(v);
+                if (!Number.isNaN(v)) {
+                  setAglA(v);
+                  setAglAEdited(true);
+                }
               }}
             />
           </label>
+          {aglASeeded && !aglAEdited && (
+            <span className="link-profile-provenance">from node altitude</span>
+          )}
           <label>
             Antenna B height AGL (m)
             <input
@@ -410,10 +453,16 @@ const LinkProfileDrawer: React.FC = () => {
               value={aglB}
               onChange={e => {
                 const v = Number(e.target.value);
-                if (!Number.isNaN(v)) setAglB(v);
+                if (!Number.isNaN(v)) {
+                  setAglB(v);
+                  setAglBEdited(true);
+                }
               }}
             />
           </label>
+          {aglBSeeded && !aglBEdited && (
+            <span className="link-profile-provenance">from node altitude</span>
+          )}
           <label>
             TX power (dBm)
             <input

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -15,6 +15,7 @@ import { Base3DMap, type Node3DFeature, type Line3DFeature } from '../map/Base3D
 import { resolve3DBasemap, buildTerrainTileUrl } from '../../config/basemap3d';
 import { useTerrainCapabilities } from '../../hooks/useTerrainCapabilities';
 import { appBasename } from '../../init';
+import { resolveNodeAltitude } from './nodePositionUtil';
 import { use3DNeighborLines } from './use3DNeighborLines';
 import { use3DTracerouteLines } from './use3DTracerouteLines';
 import type { SelectedTarget } from './MapAnalysisContext';
@@ -93,6 +94,7 @@ export default function MapAnalysisCanvas() {
         sourceIds: a.node.sources?.map((s) => s.sourceId) ?? (a.node.sourceId ? [a.node.sourceId] : []),
         nodeNum: a.node.nodeNum,
         isMeshCore: a.node.isMeshCore ?? false,
+        altitudeM: resolveNodeAltitude(a.node) ?? undefined,
       })),
     [analysisNodes],
   );

--- a/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.test.ts
@@ -207,8 +207,8 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
   });
   describe('resolveSegmentEndpoints', () => {
     const nodes: EndpointNodeRecord[] = [
-      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20, shortName: 'A1', sources: [{ sourceId: 'src-a' }] },
-      { nodeNum: 2, sourceId: 'src-b', latitude: 11, longitude: 21, shortName: 'B1', sources: [{ sourceId: 'src-b' }] },
+      { nodeNum: 1, sourceId: 'src-a', latitude: 10, longitude: 20, altitude: 35, shortName: 'A1', sources: [{ sourceId: 'src-a' }] },
+      { nodeNum: 2, sourceId: 'src-b', latitude: 11, longitude: 21, position: { altitude: 12 }, shortName: 'B1', sources: [{ sourceId: 'src-b' }] },
       { nodeNum: 3, sourceId: 'src-a', shortName: 'NOPOS', sources: [{ sourceId: 'src-a' }] },
     ];
 
@@ -222,6 +222,9 @@ describe('resolveNeighborEndpoints (#3826 Phase 1 WP-1)', () => {
       expect(result?.b).toMatchObject({ nodeNum: 2, isMeshCore: false, isNode: true });
       expect(result?.a.id).toBe('mt:1');
       expect(result?.b.id).toBe('mt:2');
+      // altitudeM carried from flat + nested shapes to seed the AGL inputs
+      expect(result?.a.altitudeM).toBe(35);
+      expect(result?.b.altitudeM).toBe(12);
     });
 
     it('returns null when an endpoint is unpositioned', () => {

--- a/src/components/MapAnalysis/neighborLinkEndpoints.ts
+++ b/src/components/MapAnalysis/neighborLinkEndpoints.ts
@@ -16,7 +16,7 @@
  */
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import type { SelectedTarget } from './MapAnalysisContext';
-import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
+import { resolveNodeAltitude, resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
 import { unifiedNodeKey } from '../../utils/nodeIdentity';
 
 /** Minimal node shape the resolver needs (subset of useAnalysisNodes' NodeRecord). */
@@ -84,6 +84,7 @@ function buildEndpoint(resolved: ResolvedNode, isMeshCore: boolean): LinkEndpoin
     nodeNum: node.nodeNum,
     isMeshCore,
     label: node.shortName ?? undefined,
+    altitudeM: resolveNodeAltitude(node) ?? undefined,
   };
 }
 

--- a/src/components/MapAnalysis/nodePositionUtil.test.ts
+++ b/src/components/MapAnalysis/nodePositionUtil.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { resolveNodeLatLng } from './nodePositionUtil';
+import { resolveNodeAltitude, resolveNodeLatLng } from './nodePositionUtil';
 import { setDiscardInvalidPositionsDisplay } from '../../utils/positionDisplayConfig';
 
 describe('resolveNodeLatLng — Null Island display toggle (#4157)', () => {
@@ -33,4 +33,19 @@ describe('resolveNodeLatLng — Null Island display toggle (#4157)', () => {
     expect(resolveNodeLatLng({ latitude: null, longitude: 0 })).toBeNull();
     expect(resolveNodeLatLng({ position: { latitude: 0 } })).toBeNull();
   });
+  describe('resolveNodeAltitude', () => {
+    it('reads the flat shape, then the nested position shape', () => {
+      expect(resolveNodeAltitude({ altitude: 42 })).toBe(42);
+      expect(resolveNodeAltitude({ position: { altitude: 7 } })).toBe(7);
+      expect(resolveNodeAltitude({ altitude: 42, position: { altitude: 7 } })).toBe(42);
+    });
+
+    it('returns null for missing or non-finite values', () => {
+      expect(resolveNodeAltitude(null)).toBeNull();
+      expect(resolveNodeAltitude({})).toBeNull();
+      expect(resolveNodeAltitude({ altitude: null })).toBeNull();
+      expect(resolveNodeAltitude({ altitude: NaN })).toBeNull();
+    });
+  });
 });
+

--- a/src/components/MapAnalysis/nodePositionUtil.ts
+++ b/src/components/MapAnalysis/nodePositionUtil.ts
@@ -13,7 +13,12 @@ import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 export interface MaybePositionedNode {
   latitude?: number | null;
   longitude?: number | null;
-  position?: { latitude?: number | null; longitude?: number | null } | null;
+  altitude?: number | null;
+  position?: {
+    latitude?: number | null;
+    longitude?: number | null;
+    altitude?: number | null;
+  } | null;
 }
 
 export function resolveNodeLatLng(
@@ -29,4 +34,16 @@ export function resolveNodeLatLng(
   // dropped regardless.
   if (shouldDiscardPosition(lat, lng, undefined, getDiscardInvalidPositions())) return null;
   return [lat, lng];
+}
+
+/**
+ * Resolve a node's reported altitude (metres) from either the flat or nested
+ * shape, mirroring `resolveNodeLatLng`. When a position override is enabled
+ * the API folds the override into `position`, so this is the effective value.
+ * Returns null when absent or non-finite.
+ */
+export function resolveNodeAltitude(node: MaybePositionedNode | null | undefined): number | null {
+  if (!node) return null;
+  const alt = node.altitude ?? node.position?.altitude;
+  return typeof alt === 'number' && Number.isFinite(alt) ? alt : null;
 }

--- a/src/utils/linkProfile.test.ts
+++ b/src/utils/linkProfile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { analyzeLinkProfile } from './linkProfile';
+import { aglFromNodeAltitude, analyzeLinkProfile } from './linkProfile';
 import { earthBulgeMeters } from './linkBudget';
 import type { ElevationSample } from '../types/elevation';
 
@@ -209,4 +209,25 @@ describe('analyzeLinkProfile', () => {
     expect(analysis.antennaTopAM).toBeCloseTo(105, 6);
     expect(analysis.antennaTopBM).toBeCloseTo(215, 6);
   });
+  describe('aglFromNodeAltitude', () => {
+    it('returns rounded altitude-minus-ground when both are finite and the difference is sane', () => {
+      expect(aglFromNodeAltitude(130, 100)).toBe(30);
+      expect(aglFromNodeAltitude(102.6, 100)).toBe(3);
+    });
+
+    it('returns null below the 0.5 m floor (datum error must not shrink the default)', () => {
+      expect(aglFromNodeAltitude(100.2, 100)).toBeNull();
+      expect(aglFromNodeAltitude(95, 100)).toBeNull();
+    });
+
+    it('returns null when either value is missing or non-finite', () => {
+      expect(aglFromNodeAltitude(undefined, 100)).toBeNull();
+      expect(aglFromNodeAltitude(null, 100)).toBeNull();
+      expect(aglFromNodeAltitude(130, null)).toBeNull();
+      expect(aglFromNodeAltitude(130, undefined)).toBeNull();
+      expect(aglFromNodeAltitude(NaN, 100)).toBeNull();
+      expect(aglFromNodeAltitude(130, NaN)).toBeNull();
+    });
+  });
 });
+

--- a/src/utils/linkProfile.ts
+++ b/src/utils/linkProfile.ts
@@ -36,6 +36,33 @@ export interface LinkEndpoint extends MeasurePoint {
   nodeNum?: number;
   /** True when the node endpoint is a MeshCore node (#4111 P3). */
   isMeshCore?: boolean;
+  /**
+   * The node's reported altitude in metres (effective value — position
+   * overrides are folded in by the API). Used only to SEED the editable
+   * antenna-AGL inputs via `aglFromNodeAltitude`; the profile math itself
+   * stays DEM + AGL (see LINK_PROFILE_TOOL_SPEC.md §0/§2.2 — node altitude
+   * never feeds the model directly because of the GPS-vs-DEM datum mismatch).
+   */
+  altitudeM?: number;
+}
+
+/**
+ * Suggested antenna height AGL from a node's reported altitude and the DEM
+ * ground elevation at its endpoint: `altitude - ground`, rounded. Returns
+ * null (caller keeps the default) when either value is missing/non-finite or
+ * the difference is below 0.5 m — a negative or near-zero difference is
+ * indistinguishable from GPS/datum error and must not shrink the antenna
+ * below the documented 2 m default.
+ */
+export function aglFromNodeAltitude(
+  altitudeM: number | null | undefined,
+  groundM: number | null | undefined,
+): number | null {
+  if (typeof altitudeM !== 'number' || !Number.isFinite(altitudeM)) return null;
+  if (typeof groundM !== 'number' || !Number.isFinite(groundM)) return null;
+  const agl = altitudeM - groundM;
+  if (agl < 0.5) return null;
+  return Math.round(agl);
 }
 
 // Client mirror of the backend `ProfileSample` (kept in `types/elevation.ts`


### PR DESCRIPTION
## Summary
User request: when opening the Link Profile (from a traceroute segment, neighbor link, or the toolbar picker), start from the elevation data we already have instead of a flat 2 m guess. Node-picked endpoints now seed the antenna-AGL inputs with `node altitude − DEM ground at that endpoint` once the profile loads, labeled "from node altitude" and fully editable. The #4111 datum decision stands: node altitude only seeds the editable input — the profile math itself still runs exclusively on DEM terrain + AGL.

## Changes
- `LinkEndpoint.altitudeM` (new optional field) populated by all three endpoint producers — `MapAnalysisCanvas.linkEndpointCandidates` (toolbar picker), `resolveNeighborEndpoints`, and `resolveSegmentEndpoints` — via a new shared `resolveNodeAltitude` in `nodePositionUtil.ts` (flat + nested shape, mirrors `resolveNodeLatLng`; API folds position overrides into the effective value).
- New pure `aglFromNodeAltitude(altitudeM, groundM)` in `linkProfile.ts`: rounded difference, or null when either value is missing/non-finite or the difference is under 0.5 m — a negative/near-zero difference is indistinguishable from GPS/datum error and must not shrink the antenna below the documented 2 m default.
- `LinkProfileDrawer`: seeds each AGL field when the profile arrives using the endpoint's `altitudeM` and the first/last DEM samples, with the same manual-edits-win / reset-per-endpoint-pair contract as the existing auto-frequency seeding; "from node altitude" provenance hint clears on edit. AGL now resets to the default when the endpoint pair changes (previously stale values persisted across pairs).
- Docs: `map-analysis.md` budget-inputs table row updated.

## Issues Resolved
None filed — user-requested follow-up to #3826/#4253.

## Documentation Updates
- `docs/features/map-analysis.md` (Antenna height AGL row: seeding behavior + datum note)

## Testing
- [x] Full suite: 10,616 tests / 0 failures (`success: true` via JSON reporter)
- [x] New tests: `aglFromNodeAltitude` truth table, `resolveNodeAltitude` flat/nested, resolver `altitudeM` carriage, drawer seeding (values + hints, absent/below-ground fallback, manual-edit wins); all existing locked-default drawer tests unchanged and green
- [x] TypeScript + `npm run lint:ci` clean
- [x] Live-validated on the dev container: real segment click → drawer seeded AGL 5 m for a node reporting 8 m over 3 m DEM ground (with hint), while the altitude-less far endpoint correctly stayed at the 2 m default with no hint
- [ ] Reviewer: pick a link whose node reports altitude → AGL fields pre-fill with "from node altitude"; edit one → hint clears and your value sticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1