### PR TITLE
fix(ui): close the status-glyph gap in no-hardcoded-ui-glyph (#4217 follow-up)

### DIFF
--- a/scripts/eslint-rules/no-hardcoded-ui-glyph.mjs
+++ b/scripts/eslint-rules/no-hardcoded-ui-glyph.mjs
@@ -1,5 +1,8 @@
 const EMOJI_PATTERN = /\p{Extended_Pictographic}/u;
-const LEADING_UI_SYMBOL_PATTERN = /^\s*[★☆✓✔✕✖✗⚠ℹ▶◀▲▼→←↑↓]/u;
+// Circle/slash status glyphs (●○◐◯⊘) were missing from this list, so the #4217
+// icon migration silently skipped four functional status indicators and future
+// PRs could reintroduce that class with green CI.
+const LEADING_UI_SYMBOL_PATTERN = /^\s*[★☆✓✔✕✖✗⚠ℹ▶◀▲▼→←↑↓●○◐◯⊘]/u;
 
 export function containsHardcodedUiGlyph(value) {
   if (typeof value !== 'string') return false;
@@ -41,8 +44,15 @@ export const noHardcodedUiGlyph = {
       JSXText(node) {
         report(node, node.value);
       },
-      TemplateElement(node) {
-        report(node, node.value.raw);
+      // Evaluate the template as ONE string rather than per-quasi. Visiting
+      // TemplateElement individually made the leading-symbol test fire on every
+      // chunk boundary: in `Open ${name} → Node Details` the second quasi is
+      // " → Node Details", so a genuinely mid-sentence arrow read as leading and
+      // was reported — contradicting the mid-sentence-arrow exemption above.
+      // Quasis are joined with a space to stand in for the interpolation, which
+      // is enough for both the leading test and the emoji scan.
+      TemplateLiteral(node) {
+        report(node, node.quasis.map((q) => q.value.raw).join(' '));
       },
     };
   },

--- a/scripts/eslint-rules/no-hardcoded-ui-glyph.node-test.mjs
+++ b/scripts/eslint-rules/no-hardcoded-ui-glyph.node-test.mjs
@@ -13,3 +13,17 @@ test('allows ordinary UI copy and protocol identifiers', () => {
     assert.equal(containsHardcodedUiGlyph(value), false, value);
   }
 });
+
+test('detects circle/slash status glyphs (#4240 follow-up)', () => {
+  // These were missing from the leading-symbol list, so the #4217 migration
+  // skipped four functional status indicators without CI noticing.
+  for (const value of ['● live', '○ offline', '◐ partial', '⊘ Disabled', '●', '◯']) {
+    assert.equal(containsHardcodedUiGlyph(value), true, value);
+  }
+});
+
+test('still allows those characters mid-sentence', () => {
+  for (const value of ['Signal ● strength', 'radius ⊘ limit']) {
+    assert.equal(containsHardcodedUiGlyph(value), false, value);
+  }
+});

--- a/src/components/MeshCore/MeshCoreRoomsView.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.tsx
@@ -236,7 +236,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
               >
                 <div className="mc-channel-row-name">
                   <span className={`mc-room-row-status ${loggedIn ? 'logged-in' : hasSaved ? 'has-saved' : 'not-logged-in'}`}>
-                    {loggedIn ? '●' : hasSaved ? '◐' : '○'}
+                    <UiIcon name={loggedIn ? 'statusOn' : hasSaved ? 'statusPartial' : 'statusOff'} size={12} />
                   </span>
                   {' '}
                   {room.advName || room.name || room.publicKey.substring(0, 12) + '…'}

--- a/src/components/admin-commands/RadioConfigurationSection.tsx
+++ b/src/components/admin-commands/RadioConfigurationSection.tsx
@@ -500,8 +500,8 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                         <>
                           {channel.name && channel.name.trim().length > 0 ? channel.name : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('admin_commands.unnamed')}</span>}
                           {channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('admin_commands.primary')}</span>}
-                          {channel.role === 2 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-green)', fontSize: '0.8rem' }}>● {t('admin_commands.secondary')}</span>}
-                          {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}>⊘ {t('admin_commands.disabled')}</span>}
+                          {channel.role === 2 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-green)', fontSize: '0.8rem' }}><UiIcon name="statusOn" size={13} /> {t('admin_commands.secondary')}</span>}
+                          {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}><UiIcon name="blocked" size={13} /> {t('admin_commands.disabled')}</span>}
                         </>
                       ) : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('admin_commands.empty')}</span>}
                     </h4>

--- a/src/components/automations/LiveTracePanel.tsx
+++ b/src/components/automations/LiveTracePanel.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useWebSocketContext } from '../../contexts/WebSocketContext';
 import { StepList, type TraceStep } from './outcomeMeta';
+import { UiIcon } from '../icons';
 
 const TRACE_DURATION_MS = 5 * 60_000;
 const MAX_ENTRIES = 200;
@@ -132,7 +133,7 @@ export default function LiveTracePanel({ automationId, automationName, enabled, 
       <div className="ae-trace-panel-head">
         <div>
           <strong>Live trace</strong> · {automationName}
-          {status === 'live' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}>● live · {mmss(remaining)} left</span>}
+          {status === 'live' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}><UiIcon name="statusOn" size={11} /> live · {mmss(remaining)} left</span>}
           {status === 'connecting' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}>connecting…</span>}
           {status === 'stopped' && <span className="ae-chip" style={{ marginLeft: '0.5rem' }}>stopped (auto)</span>}
           {status === 'error' && <span className="ae-test-badge ae-test-badge--err" style={{ marginLeft: '0.5rem' }}>error: {errorMsg}</span>}

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -545,7 +545,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                               {channel.name || <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('channels_config.unnamed')}</span>}
                               {!hasReorderChanges && channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
                               {hasReorderChanges && displaySlot === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
-                              {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}>⊘ {t('channels_config.disabled')}</span>}
+                              {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}><UiIcon name="blocked" size={13} /> {t('channels_config.disabled')}</span>}
                             </>
                           ) : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('channels_config.empty')}</span>}
                         </h4>

--- a/src/components/icons/UiIcon.tsx
+++ b/src/components/icons/UiIcon.tsx
@@ -25,6 +25,9 @@ import {
   CheckCheck,
   ChevronDown,
   ChevronUp,
+  Circle,
+  CircleDashed,
+  CircleDot,
   CircleHelp,
   CircleX,
   ClipboardList,
@@ -193,6 +196,11 @@ export const UI_ICON_DEFINITIONS = {
   plus: { lucide: Plus, emoji: '➕', usage: 'add and create controls' },
   power: { lucide: Power, emoji: '⚡', usage: 'power controls' },
   radio: { lucide: Radio, emoji: '📻', usage: 'MeshCore and radio state' },
+  // Three-state status dots (#4217 follow-up). Emoji counterparts are the
+  // glyphs these replaced, so emoji-mode users see exactly what they saw before.
+  statusOn: { lucide: CircleDot, emoji: '●', usage: 'active / connected / live status' },
+  statusPartial: { lucide: CircleDashed, emoji: '◐', usage: 'partial or pending status' },
+  statusOff: { lucide: Circle, emoji: '○', usage: 'inactive / disconnected status' },
   radioSignal: { lucide: RadioTower, emoji: '📡', usage: 'RSSI, reception, and traceroutes' },
   reaction: { lucide: Smile, emoji: '😄', usage: 'reactions and tapbacks' },
   refresh: { lucide: RefreshCw, emoji: '🔄', usage: 'refresh, reload, and reboot' },


### PR DESCRIPTION
Follow-up to #4217 / #4238. Two defects in the icon-migration lint rule, in opposite directions.

## 1. The rule couldn't see circle/slash status glyphs

`LEADING_UI_SYMBOL_PATTERN` omitted `●○◐◯⊘`, so the #4217 migration silently skipped four **functional** status indicators — and, worse, future PRs could reintroduce that whole class with green CI. The rule read as enforcing app-wide coverage while quietly permitting it.

Added those characters, then migrated the five sites the widened rule now catches:

| Site | Was | Now |
|---|---|---|
| `ChannelsConfigSection.tsx` | `⊘ Disabled` | `blocked` (existing entry) |
| `RadioConfigurationSection.tsx` | `⊘ Disabled` | `blocked` |
| `RadioConfigurationSection.tsx` | `● Secondary` | `statusOn` |
| `MeshCoreRoomsView.tsx` | `● / ◐ / ○` login state | `statusOn` / `statusPartial` / `statusOff` |
| `LiveTracePanel.tsx` | `● live` | `statusOn` |

Three new registry entries (`statusOn`, `statusPartial`, `statusOff`). Their **emoji counterparts are the exact glyphs they replace**, so emoji-mode users see precisely what they saw before; only Lucide mode changes.

## 2. The rule fired on a *correctly* mid-sentence arrow

The opposite failure, from the same list. The rule visited `TemplateElement`, so each quasi was tested independently. In:

```js
`Open ${s.sourceName} → Node Details`
```

the second quasi is `" → Node Details"` — the arrow is genuinely mid-sentence in the rendered string, but sits at the *start of its chunk*, so `/^\s*[…→…]/` matched. That directly contradicts the rule's own comment ("Mid-sentence arrows describe direction/relationships; a leading arrow is an icon").

It now evaluates the template as one string, joining quasis with a space to stand in for the interpolation.

This is why #4238 rephrased that tooltip rather than restoring its separator — the rule wouldn't accept the correct form. With this fix, `Open X → Node Details` would pass. I've left the rephrased wording alone; reverting it is a separate cosmetic call.

## Validation

- `node --test scripts/eslint-rules/no-hardcoded-ui-glyph.node-test.mjs` — 4 tests pass, including new cases for the status glyphs and for those same characters *mid-sentence* (which must still be allowed)
- 525 component tests across icons / MeshCore / automations / admin-commands / configuration — all pass
- `npm run lint:ci` — **0 in-repo violations**, confirming the widened pattern doesn't catch anything else in the tree
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW