### PR TITLE
fix(dashboard): stop discarding MeshCore favorites in the node projection (#4240 follow-up)

### DIFF
--- a/src/server/services/sourceDashboardData.meshcoreFavorite.test.ts
+++ b/src/server/services/sourceDashboardData.meshcoreFavorite.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #4240 follow-up — MeshCore favorites must survive the dashboard projection.
+ *
+ * `buildSourceNodes` hardcoded `isFavorite: false` for MeshCore nodes, throwing
+ * away the flag `meshcoreManager.getAllNodes()` already returns from
+ * `meshcore_nodes.isFavorite` (migration 094).
+ *
+ * That matters because every map surface gates on
+ * `isFavorite || (lastHeard >= cutoff)` — favorites deliberately bypass the
+ * staleness cutoff. With the flag forced false, a favorited MeshCore node fell
+ * back to the age gate and disappeared from the map once it aged past the
+ * window: the same "favorited node missing from map" symptom as #4240, from a
+ * different cause.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getAllNodes = vi.fn();
+const getManager = vi.fn();
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: (...a: unknown[]) => getManager(...a) },
+}));
+
+vi.mock('../sourceManagerTypes.js', () => ({
+  isMeshCoreManager: (m: unknown) => Boolean(m),
+  isMeshtasticManager: () => false,
+}));
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    nodes: { getAllNodes: vi.fn().mockResolvedValue([]) },
+    getSettingAsync: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { buildSourceNodes } = await import('./sourceDashboardData.js');
+
+const SOURCE = { id: 'mc-1', name: 'MeshCore', type: 'meshcore' } as never;
+const ADMIN = { id: 1, isAdmin: true } as never;
+
+/** A positioned MeshCore contact; `favorite` toggles the flag under test. */
+function mcNode(favorite: boolean, overrides: Record<string, unknown> = {}) {
+  return {
+    publicKey: 'aabbccddeeff00112233',
+    name: 'Repeater One',
+    advType: 2,
+    latitude: 30.1,
+    longitude: -90.2,
+    lastHeard: 1_700_000_000_000,
+    isFavorite: favorite,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getAllNodes.mockReset();
+  getManager.mockReset().mockReturnValue({ sourceId: 'mc-1', getAllNodes });
+});
+
+describe('buildSourceNodes — MeshCore favorites (#4240 follow-up)', () => {
+  it('propagates isFavorite=true from the manager', async () => {
+    getAllNodes.mockResolvedValue([mcNode(true)]);
+    const nodes = await buildSourceNodes(SOURCE, ADMIN);
+    expect(nodes).toHaveLength(1);
+    expect((nodes[0] as { isFavorite: boolean }).isFavorite).toBe(true);
+  });
+
+  it('propagates isFavorite=false for a non-favorited node', async () => {
+    getAllNodes.mockResolvedValue([mcNode(false)]);
+    const nodes = await buildSourceNodes(SOURCE, ADMIN);
+    expect((nodes[0] as { isFavorite: boolean }).isFavorite).toBe(false);
+  });
+
+  it('defaults to false when the manager omits the flag entirely', async () => {
+    const { isFavorite: _omitted, ...withoutFlag } = mcNode(true);
+    getAllNodes.mockResolvedValue([withoutFlag]);
+    const nodes = await buildSourceNodes(SOURCE, ADMIN);
+    expect((nodes[0] as { isFavorite: boolean }).isFavorite).toBe(false);
+  });
+
+  it('keeps isIgnored false — MeshCore has no ignore concept', async () => {
+    // Not a placeholder: meshcoreManager has no isIgnored anywhere, so false is
+    // the accurate value. Pinned so it is not "fixed" into something invented.
+    getAllNodes.mockResolvedValue([mcNode(true)]);
+    const nodes = await buildSourceNodes(SOURCE, ADMIN);
+    expect((nodes[0] as { isIgnored: boolean }).isIgnored).toBe(false);
+  });
+
+  it('preserves the favorite flag across several nodes independently', async () => {
+    getAllNodes.mockResolvedValue([
+      mcNode(true, { publicKey: 'aaaa1111', name: 'Fav' }),
+      mcNode(false, { publicKey: 'bbbb2222', name: 'Plain' }),
+    ]);
+    const nodes = await buildSourceNodes(SOURCE, ADMIN) as Array<{ isFavorite: boolean; longName: string }>;
+    const byName = Object.fromEntries(nodes.map((n) => [n.longName, n.isFavorite]));
+    expect(byName).toEqual({ Fav: true, Plain: false });
+  });
+});

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -70,8 +70,16 @@ export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promis
           sourceId: mcManager.sourceId,
           isMeshCore: true,
           publicKey: pubKey,
+          // MeshCore has no ignore concept (no isIgnored anywhere in
+          // meshcoreManager), so false is accurate rather than a placeholder.
           isIgnored: false,
-          isFavorite: false,
+          // #4240 follow-up: this was hardcoded false, which silently dropped
+          // the favorite flag `getAllNodes()` already returns from
+          // meshcore_nodes.isFavorite (migration 094). Map filters gate on
+          // `isFavorite || lastHeard >= cutoff`, so a favorited MeshCore node
+          // lost its staleness-cutoff bypass and vanished from the map once it
+          // aged past the window — the same symptom as #4240, different cause.
+          isFavorite: n.isFavorite ?? false,
           user: { id: nodeId, longName: n.name, shortName: (n.name || '').substring(0, 4) },
           longName: n.name,
           shortName: (n.name || '').substring(0, 4),


### PR DESCRIPTION
Follow-up to #4240 / #4250. Found while root-causing that issue; different cause, same user-visible symptom.

## Problem

`buildSourceNodes` hardcoded `isFavorite: false` for MeshCore nodes (`sourceDashboardData.ts:73-74`), discarding the flag `meshcoreManager.getAllNodes()` already returns from `meshcore_nodes.isFavorite` (migration 094, settable via `setNodeFavorite`).

Every map surface gates on:

```js
.filter((n) => n.isFavorite || (n.lastHeard != null && n.lastHeard >= cutoffTime))
```

Favorites deliberately bypass the staleness cutoff. With the flag forced `false`, a favorited MeshCore node fell back to the age gate and disappeared from the map once it aged past the window — **"favorited node missing from the map"**, exactly the #4240 report, from an unrelated cause. Anyone hitting this on a MeshCore source would not have been fixed by #4250.

The data was always there; only the projection dropped it. `getAllNodes()` spreads `...base` (the persisted row) before overlaying live contacts, so `isFavorite` survives the in-memory merge — it died one layer later.

## Fix

Pass the flag through: `isFavorite: n.isFavorite ?? false`.

**`isIgnored: false` is deliberately left alone**, and now documented. `meshcoreManager` has no `isIgnored` anywhere — MeshCore has no ignore concept — so `false` is accurate rather than a placeholder. There's a test pinning that, so it isn't later "fixed" into something invented.

## Tests

New `sourceDashboardData.meshcoreFavorite.test.ts` — 5 cases: propagation of `true` and `false`, defaulting to `false` when the manager omits the key, per-node independence across a mixed list, and the `isIgnored` pin.

**Verified the tests catch the regression** rather than assuming: with the fix stashed, the two favorite-propagation cases fail and the three unchanged-behavior cases still pass.

```
WITHOUT FIX -> success: false  passed: 3  failed: 2
  now failing: propagates isFavorite=true from the manager
  now failing: preserves the favorite flag across several nodes independently
```

## Validation

- 2,312 tests across `src/server/services/`, `DashboardMap.test.tsx`, and `sourceRoutes.permissions.test.ts` — all pass
- `npm run lint:ci` — 0 in-repo violations
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW