### PR TITLE
fix(channels): restore compact glyphs in the channel dropdown options

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -586,8 +586,16 @@ export default function ChannelsTab({
                   const displayName = channelConfig?.name || getChannelName(channelId);
                   const unread = unreadCounts[channelId] || 0;
                   const encryptionStatus = channelEncryptionStatus(channelConfig);
-                  const uplink = channelConfig?.uplinkEnabled ? t('channels.mqtt_uplink', 'Uplink') : '';
-                  const downlink = channelConfig?.downlinkEnabled ? t('channels.mqtt_downlink', 'Downlink') : '';
+                  // Compact glyphs, NOT UiIcon: a native <option> cannot render
+                  // SVG children, and the #4217 migration's verbose-text
+                  // substitute made every entry a full sentence. The translated
+                  // labels stay as the option's `title` for hover/AT context.
+                  // eslint-disable-next-line meshmonitor-ui/no-hardcoded-ui-glyph -- #4217: native <option> cannot host UiIcon
+                  const uplink = channelConfig?.uplinkEnabled ? '↑' : '';
+                  // eslint-disable-next-line meshmonitor-ui/no-hardcoded-ui-glyph -- #4217: native <option> cannot host UiIcon
+                  const downlink = channelConfig?.downlinkEnabled ? '↓' : '';
+                  // eslint-disable-next-line meshmonitor-ui/no-hardcoded-ui-glyph -- #4217: native <option> cannot host UiIcon
+                  const encryptionIcon = encryptionStatus === 'secure' ? '🔒' : encryptionStatus === 'default' ? '🔐' : '🔓';
                   const encryptionLabel = encryptionStatus === 'secure'
                     ? t('channels.encrypted_secure')
                     : encryptionStatus === 'default'
@@ -595,15 +603,20 @@ export default function ChannelsTab({
                       : t('channels.unencrypted');
                   const channelConfig2 = channels.find(c => c.id === channelId);
                   const hasLocation = (channelConfig2?.positionPrecision ?? 0) > 0;
+                  // eslint-disable-next-line meshmonitor-ui/no-hardcoded-ui-glyph -- #4217: native <option> cannot host UiIcon
+                  const locationIcon = channelId === autoPositionChannelId ? '📍' : hasLocation ? '📌' : '';
                   const locationLabel = channelId === autoPositionChannelId
                     ? t('channels.location_auto_position')
                     : hasLocation
                       ? t('channels.location_enabled')
                       : '';
+                  const optionTitle = `${encryptionLabel}${locationLabel ? ` · ${locationLabel}` : ''}${
+                    channelConfig?.uplinkEnabled ? ` · ${t('channels.mqtt_uplink', 'Uplink')}` : ''
+                  }${channelConfig?.downlinkEnabled ? ` · ${t('channels.mqtt_downlink', 'Downlink')}` : ''}`;
 
                   return (
-                    <option key={channelId} value={channelId}>
-                      [{encryptionLabel}]{locationLabel ? ` [${locationLabel}]` : ''} {displayName} #{channelId} {uplink}
+                    <option key={channelId} value={channelId} title={optionTitle}>
+                      {encryptionIcon}{locationIcon ? ` ${locationIcon}` : ''} {displayName} #{channelId} {uplink}
                       {downlink} {unread > 0 ? `(${unread})` : ''}
                     </option>
                   );


### PR DESCRIPTION
## Summary
User-reported regression from the #4217 icon migration: the channel selector on the per-source Channels tab turned every option into a full sentence — `[Encrypted with default key (not secure)] [Active (auto-position updates)] Primary #0 MQTT Uplink` — because native `<option>` elements cannot render the SVG `UiIcon` components the migration standardized on, and the migration substituted the icons' full translated labels instead. This restores the compact pre-migration rendering (`🔐 📍 Primary #0 ↑ (3)`).

## Changes
- `ChannelsTab.tsx` channel `<option>`s: back to compact glyphs — 🔒/🔐/🔓 encryption state, 📍/📌 location state, ↑/↓ MQTT uplink/downlink — each with a targeted `meshmonitor-ui/no-hardcoded-ui-glyph` disable referencing #4217, since a native `<option>` genuinely cannot host `UiIcon` (the exception case the rule's guidance anticipates).
- The verbose translated labels are kept as the option's `title` attribute, so hover still explains the state and the translations stay in use.

## Issues Resolved
None filed — user-reported regression from #4217 (screenshot in session). Relates to #4217.

## Documentation Updates
No documentation changes needed.

## Testing
- [x] Full suite: 10,658 tests, 1 failure in `EmbedMap.test.tsx` that passes 14/14 in isolation (parallel-run flake, unrelated file — same class as the known `ignoredNodes.test.ts` flake)
- [x] ChannelsTab tests 4/4; TypeScript, glyph scan, and lint ratchet all clean (disables are issue-referenced)
- [ ] Reviewer: open a Meshtastic source → Channels tab → the dropdown reads `🔐 📍 Primary #0 ↑` style; hover an option for the full text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1