### PR TITLE
chore: bump version to 4.13.2-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.1",
+  "version": "4.13.2-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.1",
+  "version": "4.13.2-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.1
-appVersion: "4.13.1"
+version: 4.13.2-rc1
+appVersion: "4.13.2-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1",
+  "version": "4.13.2-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.1",
+      "version": "4.13.2-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.1",
+  "version": "4.13.2-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Release candidate 1 for **4.13.2**. Version bump only — all five version files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` version + appVersion, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`) moved from `4.13.1` to `4.13.2-rc1`.

## Changes rolled up since 4.13.1
- Clickable neighbor links + terrain analysis on traceroute route segments (#4253)
- Link Profile antenna AGL seeded from node-reported altitude (#4254)
- Unified Messages sender short-names alongside long names (#4257, closes #4193)
- Channel-dropdown compact-glyph restore after the #4217 icon migration (#4258)
- Map-visibility / transport-classification follow-ups (#4240 series) and the #4217 glyph-lint follow-ups (#4255)

## Issues Resolved
None directly — release-prep chore.

## Documentation Updates
No documentation changes (version bump only; release blog lands with the final tag).

## Testing
- [x] All five version files verified at `4.13.2-rc1`; `package-lock.json` regenerated via `npm install --package-lock-only`
- [x] `system-test` label applied (release-prep convention — real-hardware system tests run on version-bump PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1