### PR TITLE
fix(auth): accept Bearer API tokens on legacy /api endpoints (#4259)

### DIFF
--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -15,6 +15,8 @@ Most endpoints require authentication. MeshMonitor supports:
 - **Session cookies** — from a browser login (`POST /api/auth/login`)
 - **Bearer tokens** — long-lived API tokens issued from the Settings UI; send as `Authorization: Bearer <token>`
 
+Both mechanisms work on the legacy `/api/*` endpoints **and** the versioned `/api/v1/*` endpoints (as of 4.13.2). A Bearer token acts as its owning user: it carries exactly that user's per-source permissions, so a request only succeeds where the user would be allowed. On endpoints that permit anonymous access, an **absent or invalid** Bearer token falls through to the anonymous user rather than being rejected; a **valid** token always takes precedence over the anonymous fallback. (The `/api/v1/*` routes are Bearer-only — they never fall through to a session cookie or anonymous.)
+
 Public endpoints are limited to health checks and the optional anonymous read-only mode (`DISABLE_ANONYMOUS=false`).
 
 ## API Versioning & Per-Source Scoping

--- a/src/server/auth/authMiddleware.ts
+++ b/src/server/auth/authMiddleware.ts
@@ -224,10 +224,71 @@ export function optionalAuth() {
 /**
  * Require authentication
  */
+/**
+ * Resolve a user from an `Authorization: Bearer <token>` API token, if one is
+ * present and valid (#4259). Returns the token's owning user (a full
+ * impersonation carrying that user's per-source permission grants — API tokens
+ * are not independently scoped), or null when no Bearer header is present or
+ * the token is missing/expired/invalid.
+ *
+ * This is the shared seam that lets the legacy `/api/*` middlewares
+ * (`requireAuth`, `requirePermission`) honor Bearer tokens the same way the v1
+ * `requireAPIToken()` gate does — previously only session cookies worked
+ * outside `/api/v1/*`, so a fully-permissioned token silently fell through to
+ * the `anonymous` user and got a confusing 403. A valid token upgrades the
+ * request; an absent or bad token leaves resolution to the caller's existing
+ * session/anonymous logic (so anonymous-readable endpoints are unaffected).
+ */
+async function resolveBearerUser(req: Request): Promise<User | null> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.substring(7); // Remove 'Bearer ' prefix
+  let user: User | null;
+  try {
+    user = await databaseService.validateApiTokenAsync(token);
+  } catch (error) {
+    logger.error('Error validating API token in legacy auth middleware:', error);
+    return null;
+  }
+
+  if (!user || !user.isActive) {
+    // Fire-and-forget audit trail for a failed token attempt, matching
+    // requireAPIToken()'s logging.
+    databaseService.auditLogAsync(
+      null,
+      'api_token_invalid',
+      null,
+      JSON.stringify({ path: req.path }),
+      req.ip || req.socket.remoteAddress || 'unknown'
+    ).catch(err => logger.error('Failed to write audit log:', err));
+    return null;
+  }
+
+  databaseService.auditLogAsync(
+    user.id,
+    'api_token_used',
+    req.path,
+    JSON.stringify({ method: req.method }),
+    req.ip || req.socket.remoteAddress || 'unknown'
+  ).catch(err => logger.error('Failed to write audit log:', err));
+
+  return user;
+}
+
 export function requireAuth() {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.session.userId) {
+        // No session — accept a Bearer API token before rejecting (#4259).
+        const tokenUser = await resolveBearerUser(req);
+        if (tokenUser) {
+          req.user = tokenUser;
+          return next();
+        }
+
         // Check if the session cookie exists at all
         const hasCookie = req.headers.cookie?.includes('meshmonitor.sid');
         if (!hasCookie) {
@@ -339,7 +400,15 @@ export function requirePermission(
         }
       }
 
-      // If no authenticated user, try anonymous
+      // No session user — accept a Bearer API token before the anonymous
+      // fallback (#4259). A token resolves to its owning user and is then
+      // subject to the same per-source checkPermissionAsync below, so it can
+      // only do what that user is permitted to do.
+      if (!user) {
+        user = await resolveBearerUser(req);
+      }
+
+      // If still no authenticated user, try anonymous
       if (!user) {
         const anonymousUser = await databaseService.findUserByUsernameAsync('anonymous');
         if (anonymousUser && anonymousUser.isActive) {

--- a/src/server/auth/bearerLegacyAuth.test.ts
+++ b/src/server/auth/bearerLegacyAuth.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Bearer API tokens on legacy /api endpoints (#4259).
+ *
+ * Legacy `/api/*` routes are gated by `requireAuth` / `requirePermission`,
+ * which historically read only the session cookie (then fell through to the
+ * `anonymous` user) — so a valid `Authorization: Bearer` token was silently
+ * ignored outside `/api/v1/*` and permission-gated writes returned a confusing
+ * 403. These tests drive real tokens (minted via the harness's `tokenFor`,
+ * validated through real bcrypt) against routes mounted with each middleware.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { requireAuth, requirePermission } from './authMiddleware.js';
+
+let harness: RouteTestHarness;
+
+beforeEach(async () => {
+  harness = await createRouteTestApp({
+    mount: (app) => {
+      // requirePermission-gated write, scoped to the :id source param.
+      app.post(
+        '/rt/sources/:id/ignore',
+        requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+        (req, res) => res.json({ ok: true, userId: req.user?.id }),
+      );
+      // requireAuth-gated route (session-or-token, no anonymous fallback).
+      app.get('/rt/whoami', requireAuth(), (req, res) =>
+        res.json({ userId: req.user?.id, username: req.user?.username }),
+      );
+    },
+  });
+});
+
+afterEach(() => harness.cleanup());
+
+describe('Bearer tokens on requirePermission-gated legacy routes (#4259)', () => {
+  it('allows a token whose user has the required per-source permission', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceA);
+    const token = await harness.tokenFor(harness.limited);
+
+    const res = await request(harness.app)
+      .post(`/rt/sources/${harness.sourceA}/ignore`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isIgnored: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, userId: harness.limited.id });
+  });
+
+  it('rejects a token whose user lacks the permission on that source (403, not silent-anon)', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceB); // wrong source
+    const token = await harness.tokenFor(harness.limited);
+
+    const res = await request(harness.app)
+      .post(`/rt/sources/${harness.sourceA}/ignore`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isIgnored: true });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN');
+  });
+
+  it('honors an admin token (bypasses the permission check)', async () => {
+    const token = await harness.tokenFor(harness.admin);
+    const res = await request(harness.app)
+      .post(`/rt/sources/${harness.sourceA}/ignore`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isIgnored: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBe(harness.admin.id);
+  });
+
+  it('an invalid/garbage Bearer token falls through to anonymous (unchanged behavior)', async () => {
+    // anonymous has no nodes:write grant → 403 via the anonymous path, NOT a
+    // token-rejection 401. Proves a bad token does not harden anon-readable
+    // endpoints into hard failures.
+    const res = await request(harness.app)
+      .post(`/rt/sources/${harness.sourceA}/ignore`)
+      .set('Authorization', 'Bearer mm_v1_deadbeefdeadbeef')
+      .send({ isIgnored: true });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN');
+  });
+
+  it('still works with a session cookie (no regression)', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent
+      .post(`/rt/sources/${harness.sourceA}/ignore`)
+      .send({ isIgnored: true });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('Bearer tokens on requireAuth-gated legacy routes (#4259)', () => {
+  it('accepts a valid token in place of a session', async () => {
+    const token = await harness.tokenFor(harness.limited);
+    const res = await request(harness.app)
+      .get('/rt/whoami')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ userId: harness.limited.id, username: harness.limited.username });
+  });
+
+  it('rejects with 401 when neither session nor token is present', async () => {
+    const res = await request(harness.app).get('/rt/whoami');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('rejects an invalid token with 401 (no anonymous fallback on requireAuth)', async () => {
+    const res = await request(harness.app)
+      .get('/rt/whoami')
+      .set('Authorization', 'Bearer mm_v1_notarealtoken00');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+});

--- a/src/server/test-helpers/routeTestApp.ts
+++ b/src/server/test-helpers/routeTestApp.ts
@@ -102,6 +102,15 @@ export interface RouteTestHarness {
   /** Delete all permission rows for a user (useful between sub-scenarios in one test). */
   revokeAll(userId: number): Promise<void>;
   /**
+   * Mint a real API token for `user` and return the plaintext `mm_v1_…` string,
+   * for exercising `Authorization: Bearer` on legacy routes end-to-end (#4259).
+   * Backed by `auth.generateAndCreateApiToken` (real bcrypt hash → real
+   * `validateApiTokenAsync`), so the middleware validates it exactly as in
+   * production. Note: generating a token revokes the user's prior active token
+   * (one active token per user), matching the app.
+   */
+  tokenFor(user: SeededUser | number): Promise<string>;
+  /**
    * Delete seeded permissions + sources. Call in `afterEach`.
    * Users are left in place (inactive-safe, unique names).
    */
@@ -274,6 +283,12 @@ export async function createRouteTestApp(
     return agent;
   };
 
+  const tokenFor = async (user: SeededUser | number): Promise<string> => {
+    const userId = typeof user === 'number' ? user : user.id;
+    const { token } = await databaseService.auth.generateAndCreateApiToken(userId, userId);
+    return token;
+  };
+
   return {
     app,
     db: databaseService,
@@ -285,6 +300,7 @@ export async function createRouteTestApp(
     loginAs,
     grant,
     revokeAll,
+    tokenFor,
     cleanup,
   };
 }


### PR DESCRIPTION
## Summary
Bearer API tokens were silently ignored on every legacy `/api/*` endpoint (node-ignore, Automation Engine CRUD, and all other write routes), producing a confusing `403 FORBIDDEN` even for a fully-permissioned token. Root cause: Bearer tokens are only read by `requireAPIToken()`, which is mounted exclusively on `/api/v1/*`; the legacy `requireAuth()` / `requirePermission()` middlewares resolved a user solely from the session cookie (then fell through to the `anonymous` user), so a token request became the anonymous user and was denied.

Per the issue's endorsed option 1 (and confirmed with the maintainer), this fixes the whole class at the middleware layer rather than adding piecemeal v1 routes.

## Changes
- **`src/server/auth/authMiddleware.ts`**: new shared `resolveBearerUser(req)` seam that validates an `Authorization: Bearer` token via the existing `validateApiTokenAsync` and returns the owning user (or null on absent/invalid). Wired into `requirePermission()` **before** the anonymous fallback and into `requireAuth()` **before** the 401. A token resolves to its user and is then subject to the same `checkPermissionAsync(user.id, resource, action, sourceId)` check — **no permission-model change**: a token can only do what its user is allowed to do. Absent/invalid tokens preserve prior behavior (anonymous fallback / 401). Token use is audit-logged (`api_token_used` / `api_token_invalid`), matching `requireAPIToken`.
- **`src/server/test-helpers/routeTestApp.ts`**: new `tokenFor(user)` harness helper that mints a real bcrypt-hashed `api_tokens` row and returns the plaintext `mm_v1_…`, so legacy routes can be tested with a genuine Bearer header end-to-end (the harness previously had no token support).
- **`docs/api/REST_API.md`**: corrected the Authentication section, which claimed broad Bearer support that only `/api/v1/*` actually honored — now accurately describes token behavior across legacy + v1 (token = its user's permissions; absent/invalid falls through to anonymous on anon-readable endpoints; v1 stays Bearer-only).

## Issues Resolved
Fixes #4259

## Documentation Updates
- `docs/api/REST_API.md` Authentication section rewritten for accuracy.

## Testing
- [x] New `src/server/auth/bearerLegacyAuth.test.ts` (8 cases, real tokens through real bcrypt via the harness): permitted token → 200, wrong-source token → 403 FORBIDDEN (not silent-anon), admin token bypass, invalid token → anonymous fallthrough on requirePermission, session-cookie no-regression; requireAuth accepts valid token / 401 on none / 401 on invalid.
- [x] Full suite green apart from one `EmbedMap.test.tsx` parallel-run flake (passes 14/14 in isolation; unrelated to this backend change — same known flake class as `ignoredNodes.test.ts`).
- [x] TypeScript + `npm run lint:ci` clean.
- [x] **Live-validated on the dev container** with the issue's exact repro: `curl -X POST -H "Authorization: Bearer <token>" -d '{"isIgnored":true}' .../api/nodes/!8a2c5e5e/ignored` → **200** (`deviceSync: success`), previously 403; `GET /api/automations` with Bearer → 200; unauthenticated write still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1