### PR TITLE
docs: add MeshEC to Site Gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -98,6 +98,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### MeshEC
+- **URL**: [meshmonitor.mesh.ec](https://meshmonitor.mesh.ec/)
+- **Network**: [mesh.ec](https://mesh.ec/)
+- **Location**: Ecuador, South America
+- **Description**: Monitoring and supporting the Meshtastic and MeshCore networks throughout Ecuador, South America.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary
- Adds MeshEC (https://meshmonitor.mesh.ec/) to the Site Gallery per the submission in #4278
- Follows the existing entry format in `docs/site-gallery.md`

## Test plan
- [x] Docs-only change; no build/test impact
- [x] Verified entry format matches existing gallery entries

Closes #4278

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_015KLJVLS32hxDH9u84NuiwA)_