### PR TITLE
feat(server): cross-source NodeInfo enrichment analysis + apply API (#3837 Phase 1)

### DIFF
--- a/docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md
+++ b/docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md
@@ -43,15 +43,15 @@ apply the enrichment ("Fix") per node or in bulk.
 ### Phase 1 — Backend: enrichment analysis + apply API
 **Branch:** `feature/nodeinfo-enrichment-backend`
 
-- [ ] `src/server/services/nodeInfoEnrichmentService.ts` reusing `nodeInfoCopyService`
+- [x] `src/server/services/nodeInfoEnrichmentService.ts` reusing `nodeInfoCopyService`
       primitives: `analyzeEnrichment()` (per distinct nodeNum: target rows with blank
       fields, best donor row, fillable fields per target) and
       `applyEnrichment(items, pushToNodeDb)` (fill-blanks-only writes via nodes
       repository; optional device push per enriched node).
-- [ ] Routes (unversioned + v1): `GET .../enrichment/analysis` (nodes:read,
+- [x] Routes (unversioned + v1): `GET .../enrichment/analysis` (nodes:read,
       permission-filtered per source) and `POST .../enrichment/apply` (nodes:write on
       every target source; donor source needs nodes:read). Envelope helpers.
-- [ ] Tests: service unit tests, route-harness permission tests, `*.perSource.test.ts`
+- [x] Tests: service unit tests, route-harness permission tests, `*.perSource.test.ts`
       isolation coverage.
 - **Exit criteria:** typecheck + full Vitest suite green; PR merged to main.
 
@@ -71,4 +71,18 @@ apply the enrichment ("Fix") per node or in bulk.
 
 ## Deviations / notes
 
-(Recorded per phase as they occur.)
+- Phase 1: apply endpoint takes an explicit `items` list
+  (`{nodeNum, targetSourceId, donorSourceId}[]`) so Phase 2's per-row Fix and
+  Fix All share one endpoint; fill-blanks-only is enforced by delegating to
+  `copyNodeInfo` WITHOUT the `fields` arg (its legacy path never overwrites
+  non-blank fields and is TOCTOU-safe against stale analyses).
+- Phase 1: `hasPKC` is excluded from analysis/reporting (derived from
+  `publicKey`), but the unchanged write primitive still fills it when blank —
+  documented asymmetry in code comments.
+- Phase 1: handlers live in a new `src/server/routes/shared/` module mounted by
+  BOTH `nodesRoutes.ts` and `v1/nodes.ts` (deliberately better than the
+  duplicated copy-nodeinfo handler pattern).
+- Phase 1: v1 registrations intentionally omit `optionalAuth()` — the v1 router
+  is globally behind `requireAPIToken()`; layering optionalAuth could clobber
+  `req.user` for token clients. Anonymous callers on the unversioned route get
+  200 with an empty analysis (permission-narrowed), never 403.

--- a/docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md
+++ b/docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md
@@ -1,0 +1,74 @@
+# NodeInfo Enrichment Report — Epic Plan (#3837)
+
+**Issue:** #3837 — Auto-push NodeInfo to nodes with missing fields from best available source
+**Status:** In progress (started 2026-07-22)
+**Surface:** New option under "Analysis & Reports" (`/reports` card grid, `AnalysisTab.tsx`)
+
+## Goal
+
+Automate the manual Copy NodeInfo workflow across all nodes: an interactive analysis
+report that scans every physical node (distinct `nodeNum`) across all sources, finds
+rows with blank NodeInfo fields that another source row can fill, and lets the user
+apply the enrichment ("Fix") per node or in bulk.
+
+## Interview decisions (2026-07-22)
+
+- **No scheduler.** The issue's "configurable schedule" is explicitly deferred. This is
+  an interactive Analysis report with a **Fix button** that performs the updates.
+- **Fill blanks only.** Automation never overwrites a non-empty differing field; the
+  report may surface conflicts informationally but the apply path writes only empty
+  target fields.
+- **Device push is an optional toggle, default OFF.** When enabled, each enriched node
+  also gets the existing `pushNodeInfoToDevice` nudge (`sendNodeInfoRequest` on the
+  node's channel — NOT an admin write; same semantics as the manual dialog).
+- **Targets = all incomplete sources.** For each nodeNum, the richest source row donates
+  to every other source row with blank fields (full cross-source convergence).
+- Two phases, each its own merged PR (confirmed by user).
+
+## Reuse anchors (from code survey)
+
+- `src/server/services/nodeInfoCopyService.ts` — `NODE_INFO_FIELDS` (8 fields:
+  longName, shortName, hwModel, role, macaddr, publicKey, hasPKC, firmwareVersion),
+  candidate ranking (fieldsFilled desc, updatedAt desc), copy + `pushNodeInfoToDevice`.
+- `src/db/repositories/nodes.ts` — per-source rows keyed `(nodeNum, sourceId)`.
+- Routes pattern: `src/server/routes/nodesRoutes.ts` + `src/server/routes/v1/nodes.ts`
+  (copy-candidates / copy-nodeinfo), `ok`/`fail` envelope, `requirePermission`.
+- UI: `src/components/Analysis/AnalysisTab.tsx` card grid (`AnalysisType` union +
+  `reports[]` + selected-branch), `SolarMonitoringReport.tsx` as structural template
+  (TanStack useQuery). No `VALID_TABS` change needed (router route, not app tab).
+- Route tests: `createRouteTestApp()` harness (`src/server/test-helpers/routeTestApp.ts`).
+
+## Phases
+
+### Phase 1 — Backend: enrichment analysis + apply API
+**Branch:** `feature/nodeinfo-enrichment-backend`
+
+- [ ] `src/server/services/nodeInfoEnrichmentService.ts` reusing `nodeInfoCopyService`
+      primitives: `analyzeEnrichment()` (per distinct nodeNum: target rows with blank
+      fields, best donor row, fillable fields per target) and
+      `applyEnrichment(items, pushToNodeDb)` (fill-blanks-only writes via nodes
+      repository; optional device push per enriched node).
+- [ ] Routes (unversioned + v1): `GET .../enrichment/analysis` (nodes:read,
+      permission-filtered per source) and `POST .../enrichment/apply` (nodes:write on
+      every target source; donor source needs nodes:read). Envelope helpers.
+- [ ] Tests: service unit tests, route-harness permission tests, `*.perSource.test.ts`
+      isolation coverage.
+- **Exit criteria:** typecheck + full Vitest suite green; PR merged to main.
+
+### Phase 2 — Frontend: Analysis & Reports card
+**Branch:** `feature/nodeinfo-enrichment-report`
+
+- [ ] Extend `AnalysisType` + `reports[]` with a "NodeInfo Enrichment" card; new
+      `src/components/Analysis/NodeInfoEnrichmentReport.tsx` (TanStack useQuery +
+      `ApiService` — raw fetch is banned in new components; `UiIcon` for icons).
+- [ ] Table of enrichable nodes (node, target source(s), missing fields, donor source),
+      per-row **Fix** + **Fix All**, push-to-NodeDB toggle default off, empty/loading/
+      unauthorized states.
+- [ ] Component tests; browser validation in the dev container (screenshots, console
+      clean, gauntlet-channel only for any test traffic).
+- **Exit criteria:** report usable end-to-end against the dev container; suite green;
+  PR merged to main; issue #3837 closed.
+
+## Deviations / notes
+
+(Recorded per phase as they occur.)

--- a/docs/internal/dev-notes/NODEINFO_ENRICHMENT_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/NODEINFO_ENRICHMENT_PHASE1_SPEC.md
@@ -1,0 +1,337 @@
+# NodeInfo Enrichment — Phase 1 (Backend) Implementation Spec
+
+**Epic:** #3837 (NodeInfo Enrichment)
+**Branch:** `feature/nodeinfo-enrichment-backend`
+**Scope:** Backend only — cross-source enrichment service + API routes + tests. No scheduler, no settings keys, no frontend. Never overwrite non-blank fields.
+
+> **Note on the epic doc:** `docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md` does **not** exist on this branch (it was branched from `origin/main` before the epic plan was committed). This spec encodes the approved interview decisions directly: **fill-blanks-only**, **optional `pushToNodeDb` toggle default off**, **all-incomplete-sources are targets**, **no scheduler**. If the epic doc lands later, reconcile against it.
+
+---
+
+## 1. Reuse Inventory
+
+Everything below already exists and MUST be reused. New code is justified against the closest existing mechanism.
+
+### Must reuse as-is
+
+| Mechanism | Location | Use |
+|-----------|----------|-----|
+| `copyNodeInfo(nodeNum, fromSourceId, toSourceId, pushToNodeDb?, fields?)` | `src/server/services/nodeInfoCopyService.ts:99` | **The single write primitive.** Call it **without** the `fields` argument. The legacy no-`fields` path (`nodeInfoCopyService.ts:130-133`) is exactly fill-blanks-only: it skips any field where the target value is `!= null && !== ''`. This makes "never overwrite non-blank" an invariant enforced by the primitive itself — and it is TOCTOU-safe because it re-reads current DB state on every call. **Do NOT pass `fields`** — that flips to #4244 overwrite mode. |
+| `pushNodeInfoToDevice(...)` | `src/server/services/nodeInfoCopyService.ts` (private) | Not called directly. `copyNodeInfo` already invokes it internally when `pushToNodeDb === true` (`nodeInfoCopyService.ts:145`). The enrichment `pushToNodeDb` flag is a straight passthrough into `copyNodeInfo`. No new export needed. |
+| `NODE_INFO_FIELDS` / `NodeInfoField` | `src/server/services/nodeInfoCopyService.ts:6`, exported at `:81` and `export type` | The field allowlist. `['longName','shortName','hwModel','role','macaddr','publicKey','hasPKC','firmwareVersion']`. |
+| `databaseService.nodes.getAllNodes(sourceId: SourceScope)` | `src/db/repositories/nodes.ts:233` | Cross-source node fetch. Pass `ALL_SOURCES` to get every row (each carries `sourceId`). `normalizeBigInts` runs inside, but still coerce `Number(node.nodeNum)` for grouping/compare (BIGINT on PG/MySQL — CLAUDE.md hard rule). |
+| `ALL_SOURCES` | `src/db/repositories/index.js` (re-exported from `base.ts`) | Cross-source scope sentinel for `getAllNodes`. |
+| `databaseService.sources.getAllSources()` | `src/db/repositories/sources.ts:35` | Returns `Source[]` (`{ id, name, type, ... }`) — used for `sourceName` lookup and the source universe. |
+| `databaseService.checkPermissionAsync(userId, resource, action, sourceId)` | `src/services/database.ts` | Per-source permission check. `isAdmin` bypasses. Same call the existing copy routes use (`v1/nodes.ts:108`). |
+| `ok()` / `fail()` envelope | `src/server/utils/apiResponse.ts` | **Mandatory for all new handlers.** `ok(res, data)` → `{ success:true, data }`. `fail(res, status, code, msg, extra?)`. |
+| `createRouteTestApp()` harness | `src/server/test-helpers/routeTestApp.ts` | **Mandatory** for the new route permission test. Provides `sourceA`, `sourceB`, `admin`, `limited`, `grant()`, `loginAs()`, real session + real auth + real SQL permission enforcement. |
+| `optionalAuth()` | `src/server/auth/authMiddleware.js` | Populates `req.user` without hard-gating. Used on the new routes because per-source permission is checked manually in-handler (the batch spans multiple sources, so a single `requirePermission(...)` middleware cannot express it — same reason `v1/nodes.ts` copy-nodeinfo does manual checks). |
+
+### Must extend (small, additive exports on the copy service)
+
+To avoid re-implementing the blank/filled predicate and the donor ranking (both currently **private** in `nodeInfoCopyService.ts`), export them so the enrichment service reuses identical logic instead of duplicating it (CLAUDE.md: reuse over duplication):
+
+- **Export `isNodeInfoFieldBlank(value: unknown): boolean`** — the canonical predicate `value == null || value === ''`. Refactor the existing `countFilledFields` (`nodeInfoCopyService.ts:27`) to call it, so there is one definition.
+- **Export `countFilledNodeInfoFields(node): number`** — rename/expose the existing private `countFilledFields`. Used for donor ranking (most-fields-filled).
+- **Export `ANALYZE_NODE_INFO_FIELDS`** = `NODE_INFO_FIELDS.filter(f => f !== 'hasPKC')` (see hasPKC handling below).
+
+No behavioral change to `copyNodeInfo` / `findCopyCandidates`; these are pure additive exports + one internal refactor.
+
+### New code (justified)
+
+- **`src/server/services/nodeInfoEnrichmentService.ts`** — no existing service does cross-source, all-node analysis; `findCopyCandidates` (`nodeInfoCopyService.ts:41`) is single-node/single-target and gates donors on `longName||shortName`. The enrichment service is the batch, cross-source generalization. It **reuses** `copyNodeInfo` for every write and the exported predicates for analysis.
+- **`src/server/routes/shared/enrichmentHandlers.ts`** — one shared handler pair mounted in both routers, rather than duplicating handler bodies across `nodesRoutes.ts` and `v1/nodes.ts` (the copy routes are duplicated today; this is the deliberately better pattern). Justified by the DRY hard rule.
+
+### hasPKC handling (decision)
+
+`hasPKC` is a derived boolean (`src/db/schema/nodes.ts:54`, `mode:'boolean'`) that means "a public key is present" — it carries no information beyond `publicKey`. Decisions:
+
+1. **Excluded from analysis.** `analyzeEnrichment` computes blanks/fillables over `ANALYZE_NODE_INFO_FIELDS` (NODE_INFO_FIELDS **minus** `hasPKC`). It is never reported as a fillable field and never counted in `fieldCount`. Surfacing "fill hasPKC" would be confusing UI and redundant with `publicKey`.
+2. **Still copied by the write primitive.** `applyEnrichment` delegates to `copyNodeInfo` with **no `fields`**, whose legacy path will copy `hasPKC` iff the target's `hasPKC` is `null` and the donor's is set (`nodeInfoCopyService.ts:130-136`; a `false`/`0` target is treated as filled and skipped, so it is never overwritten). We deliberately do **not** strip `hasPKC` from the write — doing so would require passing `fields`, which flips `copyNodeInfo` into overwrite mode and breaks the fill-blanks-only invariant. So: **report without hasPKC, write via the unchanged primitive.** Document this asymmetry in code comments.
+
+---
+
+## 2. File-by-File Changes
+
+### 2a. `src/server/services/nodeInfoCopyService.ts` (modify — additive)
+
+Add exports (refactor `countFilledFields` to use the new predicate):
+
+```ts
+/** Canonical "this NodeInfo field is empty" predicate. */
+export function isNodeInfoFieldBlank(value: unknown): boolean {
+  return value == null || value === '';
+}
+
+/** Count of NODE_INFO_FIELDS that are non-blank on a node. Used for donor ranking. */
+export function countFilledNodeInfoFields(node: Partial<DbNode>): number {
+  return NODE_INFO_FIELDS.filter(f => !isNodeInfoFieldBlank((node as any)[f])).length;
+}
+
+/** Analysis field set — NODE_INFO_FIELDS minus the derived hasPKC flag. */
+export const ANALYZE_NODE_INFO_FIELDS =
+  NODE_INFO_FIELDS.filter(f => f !== 'hasPKC') as readonly NodeInfoField[];
+```
+
+Refactor existing private `countFilledFields` to delegate to `countFilledNodeInfoFields` (or just export the existing one under the new name). No other changes.
+
+### 2b. `src/server/services/nodeInfoEnrichmentService.ts` (new)
+
+```ts
+import databaseService from '../../services/database.js';
+import { DbNode } from '../../db/types.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
+import { logger } from '../../utils/logger.js';
+import {
+  copyNodeInfo,
+  isNodeInfoFieldBlank,
+  countFilledNodeInfoFields,
+  ANALYZE_NODE_INFO_FIELDS,
+  type NodeInfoField,
+} from './nodeInfoCopyService.js';
+
+export interface EnrichmentTarget {
+  targetSourceId: string;
+  targetSourceName: string;
+  fillableFields: NodeInfoField[];   // excludes hasPKC
+  donorSourceId: string;
+  donorSourceName: string;
+}
+export interface EnrichmentNode {
+  nodeNum: number;
+  nodeId: string;
+  displayName: string;               // longName || shortName || nodeId
+  targets: EnrichmentTarget[];
+}
+export interface EnrichmentAnalysis {
+  nodes: EnrichmentNode[];
+  summary: { nodeCount: number; targetCount: number; fieldCount: number };
+}
+
+export interface EnrichmentApplyItem {
+  nodeNum: number;
+  targetSourceId: string;
+  donorSourceId: string;
+}
+export interface EnrichmentApplyItemResult extends EnrichmentApplyItem {
+  copiedFields: string[];
+  pushedToDevice: boolean;
+  error?: string;                    // per-item failure; does NOT abort the batch
+}
+export interface EnrichmentApplyResult {
+  applied: EnrichmentApplyItemResult[];
+  totalFieldsCopied: number;
+}
+
+/**
+ * @param allowedSourceIds  restrict the source universe (used for permission
+ *   filtering by the route). `undefined` = all sources (admin path).
+ */
+export async function analyzeEnrichment(
+  allowedSourceIds?: readonly string[],
+): Promise<EnrichmentAnalysis> { ... }
+
+export async function applyEnrichment(
+  items: readonly EnrichmentApplyItem[],
+  options: { pushToNodeDb: boolean },
+): Promise<EnrichmentApplyResult> { ... }
+```
+
+**`analyzeEnrichment` algorithm:**
+1. `sources = await databaseService.sources.getAllSources()`. Build `sourceName` map. If `allowedSourceIds` given, drop sources not in it. If the allowed set is empty → return `{ nodes: [], summary: { nodeCount:0, targetCount:0, fieldCount:0 } }`.
+2. `allNodes = await databaseService.nodes.getAllNodes(ALL_SOURCES)`. Group rows by `Number(row.nodeNum)` into `Map<number, DbNode[]>`, keeping only rows whose `sourceId` is in the allowed set.
+3. For each `nodeNum` group with ≥2 source rows:
+   - For each **target** row: `blanks = ANALYZE_NODE_INFO_FIELDS.filter(f => isNodeInfoFieldBlank(target[f]))`. If none, skip this target.
+   - **Donor selection:** among the *other* source rows for this nodeNum (`donorSourceId !== targetSourceId`), keep those that can fill ≥1 of the target's blanks (`donor[f]` non-blank for some `f in blanks`). Rank by `countFilledNodeInfoFields(donor)` desc, tie-break `Number(donor.updatedAt)` desc (identical comparator to `findCopyCandidates` at `nodeInfoCopyService.ts:72`). Pick the top donor.
+   - `fillableFields = blanks.filter(f => !isNodeInfoFieldBlank(donor[f]))`. If empty, skip.
+   - Emit an `EnrichmentTarget`.
+   - Wrap targets into an `EnrichmentNode` (`nodeId` and `displayName` from the highest-`countFilledNodeInfoFields` row in the group: `longName || shortName || nodeId`). Only include nodes with ≥1 target.
+4. `summary`: `nodeCount = nodes.length`; `targetCount = Σ targets`; `fieldCount = Σ fillableFields.length`.
+
+Divergence from `findCopyCandidates` (document in comments): donor validity here is "can fill ≥1 target blank", **not** the `longName||shortName` gate — the enrichment definition is field-driven.
+
+**`applyEnrichment` algorithm:**
+For each item, in a per-item `try/catch` (partial success — one bad item never aborts the batch):
+```ts
+const { copiedFields, pushedToDevice } =
+  await copyNodeInfo(Number(item.nodeNum), item.donorSourceId, item.targetSourceId, options.pushToNodeDb);
+// NOTE: no `fields` arg → legacy fill-blanks-only path (never overwrites non-blank).
+```
+Collect `EnrichmentApplyItemResult` (on throw, set `error: String(err)`, `copiedFields: []`, `pushedToDevice: false`). `totalFieldsCopied = Σ copiedFields.length`. **Permission is enforced in the route, not here** (the service is permission-agnostic and unit-testable).
+
+### 2c. `src/server/routes/shared/enrichmentHandlers.ts` (new)
+
+Two exported handlers, imported by both routers. Both use `ok()`/`fail()`.
+
+```ts
+export async function handleEnrichmentAnalysis(req, res) { ... }
+export async function handleEnrichmentApply(req, res) { ... }
+```
+
+**`handleEnrichmentAnalysis`** (read-only):
+- `user = req.user; userId = user?.id ?? null; isAdmin = user?.isAdmin ?? false`.
+- Compute readable source set: if `isAdmin` → `undefined` (all). Else for each `source` in `getAllSources()`, keep `source.id` where `await checkPermissionAsync(userId, 'nodes', 'read', source.id)` is true (userId null → none). This is the **permission-filtering approach**: analysis only ever computes over sources the caller can read (both as donor and target), so no cross-source leak.
+- `analysis = await analyzeEnrichment(readableSet)`.
+- `return ok(res, analysis)` → `{ success:true, data:{ nodes:[...], summary:{...} } }`.
+- On unexpected error → `fail(res, 500, 'ENRICHMENT_ANALYSIS_FAILED', 'Failed to analyze enrichment')`.
+
+**`handleEnrichmentApply`** (write, fail-closed batch):
+- Parse `{ items, pushToNodeDb }` from `req.body`. Validate:
+  - `items` non-empty array → else `fail(res, 400, 'INVALID_REQUEST', 'items must be a non-empty array')`.
+  - Each item has numeric `nodeNum` and string `targetSourceId`/`donorSourceId`, and `donorSourceId !== targetSourceId` → else `fail(res, 400, 'INVALID_ITEM', '...')`.
+- Permission (fail-closed over the whole batch):
+  - `donorSources = distinct donorSourceId`; `targetSources = distinct targetSourceId`.
+  - Non-admin: require `checkPermissionAsync(userId, 'nodes','read', s)` for every donor source AND `checkPermissionAsync(userId, 'nodes','write', s)` for every target source. If any fails → `fail(res, 403, 'FORBIDDEN', 'Insufficient permission', { missing: [...] })`. (Reject the entire batch — matches copy-nodeinfo's single-op 403 semantics, extended to a set.)
+- `result = await applyEnrichment(items, { pushToNodeDb: pushToNodeDb === true })`.
+- `return ok(res, result)`.
+- On unexpected error → `fail(res, 500, 'ENRICHMENT_APPLY_FAILED', 'Failed to apply enrichment')`.
+
+> **ApiService gotcha (CLAUDE.md):** `ApiService.request()` returns the raw body and does **not** unwrap `data`. These are brand-new endpoints with no existing consumer, so `ok(res, x)` is correct — the Phase 2 frontend must read `body.data` (same lesson as MQTT packet monitor #4138). Do not "flatten" the envelope.
+
+### 2d. `src/server/routes/nodesRoutes.ts` (modify)
+
+Register **before** the parametric `/nodes/:nodeNum/...` routes as defense-in-depth (the literal 2-segment paths below do not collide with `/nodes/:nodeNum/copy-candidates` etc., but placing them first removes all doubt). Both use `optionalAuth()`:
+
+```ts
+import { handleEnrichmentAnalysis, handleEnrichmentApply } from './shared/enrichmentHandlers.js';
+
+router.get('/nodes/enrichment/analysis', optionalAuth(), handleEnrichmentAnalysis);
+router.post('/nodes/enrichment/apply', optionalAuth(), handleEnrichmentApply);
+```
+
+Mounted at `apiRouter.use('/', nodesRoutes)` (`server.ts:833`) →
+`GET /api/nodes/enrichment/analysis`, `POST /api/nodes/enrichment/apply`.
+
+**Route-ordering note:** `nodesRoutes` has no bare `GET /nodes/:nodeNum`; its param routes are all `/nodes/:nodeNum/<literal>` or `/nodes/:nodeId/<literal>`. `/nodes/enrichment/analysis` (segment `analysis` ≠ `copy-candidates`/`positions`/…) cannot be shadowed. Still register first.
+
+### 2e. `src/server/routes/v1/nodes.ts` (modify)
+
+**Ordering is load-bearing here:** this file has a bare `router.get('/:nodeId', ...)` at `v1/nodes.ts:127`. A single-segment `/enrichment` would be captured by it. The enrichment paths are 2-segment (`/enrichment/analysis`), so `/:nodeId` (one segment) will not match — **but** register them **above** `/:nodeId` (line 127) anyway to be safe:
+
+```ts
+import { handleEnrichmentAnalysis, handleEnrichmentApply } from '../shared/enrichmentHandlers.js';
+
+router.get('/enrichment/analysis', handleEnrichmentAnalysis);
+router.post('/enrichment/apply', handleEnrichmentApply);
+```
+
+The v1 router already sits behind the v1 auth chain that populates `req.user`; if it does not apply `optionalAuth` globally, wrap these two with `optionalAuth()` to match `nodesRoutes`. Mounted at `/api/v1/nodes` (root) and `/api/v1/sources/:sourceId/nodes` (mergeParams) → canonical path `GET /api/v1/nodes/enrichment/analysis`, `POST /api/v1/nodes/enrichment/apply`. (The `:sourceId` path param is ignored by these cross-source handlers — they compute their own source universe from permissions.)
+
+### Response shapes (exact JSON)
+
+`GET .../enrichment/analysis` → 200:
+```json
+{ "success": true, "data": {
+  "nodes": [
+    { "nodeNum": 123456, "nodeId": "!0001e240", "displayName": "Base Station",
+      "targets": [
+        { "targetSourceId": "src-b", "targetSourceName": "MQTT",
+          "fillableFields": ["longName","hwModel","role"],
+          "donorSourceId": "src-a", "donorSourceName": "Primary TCP" }
+      ] }
+  ],
+  "summary": { "nodeCount": 1, "targetCount": 1, "fieldCount": 3 }
+} }
+```
+
+`POST .../enrichment/apply` body:
+```json
+{ "items": [ { "nodeNum": 123456, "targetSourceId": "src-b", "donorSourceId": "src-a" } ],
+  "pushToNodeDb": false }
+```
+→ 200:
+```json
+{ "success": true, "data": {
+  "applied": [
+    { "nodeNum": 123456, "targetSourceId": "src-b", "donorSourceId": "src-a",
+      "copiedFields": ["longName","hwModel","role"], "pushedToDevice": false }
+  ],
+  "totalFieldsCopied": 3
+} }
+```
+
+Error codes: `ENRICHMENT_ANALYSIS_FAILED` (500), `INVALID_REQUEST` (400), `INVALID_ITEM` (400), `FORBIDDEN` (403, `{ missing }`), `ENRICHMENT_APPLY_FAILED` (500).
+
+### Apply input shape (decision)
+
+**Explicit item list from the client** — `{ items: [{nodeNum, targetSourceId, donorSourceId}], pushToNodeDb? }` — chosen over server-side re-scan because it directly serves both Phase 2 UI needs: per-row **Fix** posts one item; **Fix All** posts every item from the analysis response. Each item names its own donor+target, so permission checks and the `copyNodeInfo` call are unambiguous. Fill-blanks-only is still enforced by the primitive (no `fields`), so a stale item can never overwrite a field filled since analysis.
+
+---
+
+## 3. Test Plan
+
+All in the standard Vitest suite (SQLite default; PG/MySQL covered by CI service containers).
+
+### 3a. `src/server/services/nodeInfoEnrichmentService.test.ts` (new — service unit)
+
+Mock `databaseService.sources.getAllSources`, `databaseService.nodes.getAllNodes`, and either `databaseService.nodes.getNode`/`upsertNode` **or** `vi.mock('./nodeInfoCopyService.js')` to spy on `copyNodeInfo`. Prefer spying on `copyNodeInfo` for apply tests and mocking the repo for analyze tests. Cases:
+- **analyze — fillable detection:** node in src-A (full) + src-B (blank longName/hwModel) → target src-B lists exactly those fillable fields, donor src-A.
+- **analyze — best donor ranking:** two donors; higher `countFilledNodeInfoFields` wins; on tie, newer `updatedAt` wins.
+- **analyze — hasPKC excluded:** donor has `publicKey`+`hasPKC`, target blank both → `fillableFields` contains `publicKey` but **never** `hasPKC`; `fieldCount` excludes it.
+- **analyze — no blanks:** node identical across sources → not in results.
+- **analyze — single-source node:** appears in only one source → not in results.
+- **analyze — allowedSourceIds filter:** restricting to `['src-A']` drops src-B as both donor and target; empty allowed set → empty result.
+- **analyze — BIGINT nodeNum:** `getAllNodes` returns `nodeNum` as string/bigint-like → grouping via `Number()` still matches rows across sources.
+- **apply — delegates fill-blanks-only:** asserts `copyNodeInfo` called with `(nodeNum, donorSourceId, targetSourceId, false)` and **no 5th `fields` arg**.
+- **apply — pushToNodeDb passthrough:** `{ pushToNodeDb: true }` → 4th arg `true`.
+- **apply — per-item error isolation:** first item's `copyNodeInfo` throws → its result has `error`, second item still applied; batch does not reject.
+- **apply — totalFieldsCopied** sums `copiedFields`.
+
+### 3b. `src/server/services/nodeInfoEnrichmentService.perSource.test.ts` (new — source isolation)
+
+Real singleton `:memory:` SQLite (no repo mock). Seed source rows `src-A`/`src-B` (via `databaseService.sources.createSource`) and a node present in both (donor full in src-A, blank in src-B) plus an unrelated node in a third source. Then:
+- `applyEnrichment([{nodeNum, targetSourceId:'src-B', donorSourceId:'src-A'}], {pushToNodeDb:false})`.
+- Assert: src-B row now has the donor's values; **src-A donor row is unchanged**; the unrelated third-source row is untouched. Proves writes are scoped to `targetSourceId` only.
+- `analyzeEnrichment(['src-A'])` excludes src-B entirely (isolation of the read path).
+
+### 3c. `src/server/routes/nodeInfoEnrichment.permissions.test.ts` (new — route harness)
+
+**Mandatory `createRouteTestApp()`** (CLAUDE.md). Mount a minimal router that registers the two shared handlers behind `optionalAuth()`. Ensure `sourceA`/`sourceB` exist as rows in the `sources` table (seed in `beforeEach` if the harness does not) and seed a node in both. Cases:
+- **analysis filters to readable sources:** grant `limited` `nodes:read` on `sourceA` only → analysis results reference only `sourceA` (never `sourceB` as donor or target). `admin` sees both.
+- **analysis anonymous:** no login → `nodes: []` (200, empty — no readable sources).
+- **apply requires write on target:** `limited` has `nodes:read` on both but `nodes:write` only on `sourceB`; apply with `targetSourceId:sourceA` → 403 `FORBIDDEN`; with `targetSourceId:sourceB` (read on donor `sourceA` granted) → 200.
+- **apply requires read on donor:** write on target but no read on donor source → 403.
+- **admin bypass:** admin applies across both → 200.
+- **validation:** empty `items` → 400 `INVALID_REQUEST`; `donorSourceId === targetSourceId` → 400 `INVALID_ITEM`.
+
+Use `harness.grant(harness.limited.id, 'nodes', 'read'|'write', harness.sourceX)` and `harness.loginAs(...)`. No `checkPermissionAsync` mocking — real SQL enforces (harness template: `sourceRoutes.permissions.test.ts`).
+
+---
+
+## 4. Work Packages
+
+Two packages. **WP-B depends on WP-A** (imports the service + exports). Within WP-A the three test files and the service can be written together; the copy-service export edit is the only shared prerequisite and lives at the top of WP-A.
+
+### WP-A — Enrichment service + copy-service exports (foundation)
+
+**Scope:** additive exports on `nodeInfoCopyService.ts`; new `nodeInfoEnrichmentService.ts`; service unit test; perSource isolation test.
+**Files:**
+- `src/server/services/nodeInfoCopyService.ts` (modify — export `isNodeInfoFieldBlank`, `countFilledNodeInfoFields`, `ANALYZE_NODE_INFO_FIELDS`; refactor `countFilledFields`).
+- `src/server/services/nodeInfoEnrichmentService.ts` (new).
+- `src/server/services/nodeInfoEnrichmentService.test.ts` (new).
+- `src/server/services/nodeInfoEnrichmentService.perSource.test.ts` (new).
+**Parallelism:** none external; can run first. The two test files can be authored in parallel once the service signatures are fixed.
+**Acceptance:**
+- `copyNodeInfo`/`findCopyCandidates` behavior unchanged; new exports typecheck.
+- `analyzeEnrichment`/`applyEnrichment` implemented per §2b; apply calls `copyNodeInfo` with **no `fields`** arg (assert in test).
+- hasPKC never in `fillableFields`/`fieldCount`.
+- `Number(nodeNum)` used for all grouping/compare.
+- Both new test files green; perSource test proves target-only writes and read-path isolation.
+
+### WP-B — API routes + permission harness test
+
+**Scope:** shared handler module; register in both routers; route permission test.
+**Files:**
+- `src/server/routes/shared/enrichmentHandlers.ts` (new).
+- `src/server/routes/nodesRoutes.ts` (modify — two routes, registered before param routes).
+- `src/server/routes/v1/nodes.ts` (modify — two routes, registered **above** `/:nodeId` at line 127).
+- `src/server/routes/nodeInfoEnrichment.permissions.test.ts` (new).
+**Depends on:** WP-A (imports `analyzeEnrichment`/`applyEnrichment` and their types).
+**Acceptance:**
+- Both endpoints reachable at `/api/nodes/enrichment/*` and `/api/v1/nodes/enrichment/*`; no shadowing by `/:nodeNum`/`/:nodeId` (verified by the harness test hitting them).
+- Handlers use `ok()`/`fail()` exclusively with the documented codes.
+- Analysis filters to readable sources; apply is fail-closed on missing read(donor)/write(target); admin bypass works — all asserted via `createRouteTestApp` with real permission rows.
+- Full `npm test` green; `npm run lint:ci` clean (ignoring `.claude/worktrees`).
+
+### Out of scope (all packages)
+Scheduler, settings keys, frontend, overwriting non-blank fields, exporting `pushNodeInfoToDevice`.

--- a/src/server/routes/nodeInfoEnrichment.permissions.test.ts
+++ b/src/server/routes/nodeInfoEnrichment.permissions.test.ts
@@ -1,0 +1,264 @@
+/**
+ * NodeInfo Enrichment routes — permission isolation (Phase 1 WP-B).
+ *
+ * Mounts the REAL `nodesRoutes.ts` router (not a minimal stand-in) via
+ * `createRouteTestApp`, the same pattern as `sourceRoutes.permissions.test.ts`
+ * (the canonical harness template). Mounting the actual router file proves
+ * the new `/nodes/enrichment/analysis` and `/nodes/enrichment/apply`
+ * registrations are reachable and are not shadowed by any of the router's
+ * existing `/nodes/:nodeNum/...` / `/nodes/:nodeId/...` parametric routes.
+ *
+ * `sourceManagerRegistry.js` and `meshtasticManager.js` are mocked for the
+ * same reason `sourceRoutes.permissions.test.ts` mocks them: `nodesRoutes.ts`
+ * imports the source-manager machinery at module load for its *other*
+ * routes (node refresh, favorites, etc.), and those must not attempt real
+ * TCP connections under test. The enrichment routes under test never call
+ * into `sourceManagerRegistry` or `fallbackManager` — they only touch
+ * `databaseService` (real, via the harness singleton) — so the mocks are
+ * inert as far as this file's assertions are concerned.
+ *
+ * Permission enforcement is real: no `checkPermissionAsync` monkey-patching.
+ * `harness.grant(...)` inserts real permission rows and the handlers call
+ * the real `databaseService.checkPermissionAsync`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import nodesRoutes from './nodesRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    getAllManagers: vi.fn().mockReturnValue([]),
+    startManager: vi.fn(),
+    stopManager: vi.fn(),
+  },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  MeshtasticManager: vi.fn().mockImplementation(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  fallbackManager: {
+    getAllNodesAsync: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// Monotonic nodeNum generator. upsertNode's update-path preserves a prior
+// non-blank value when the incoming value is null (#3456/#3505 semantics —
+// blank means "not reported", not "clear"). Since the harness's sourceA/
+// sourceB ids are fixed strings reused across every test in this file (and
+// deleteSource does not cascade to the nodes table), reusing one nodeNum
+// across tests would let a copy from an earlier test "leak" into a later
+// test's supposedly-blank target row. A fresh nodeNum per test sidesteps
+// this entirely (no existingNode row, no preserve-on-null).
+let nodeCounter = 0x50000000;
+function freshNodeNum(): number {
+  nodeCounter += 1;
+  return nodeCounter;
+}
+function toNodeId(nodeNum: number): string {
+  return `!${nodeNum.toString(16).padStart(8, '0')}`;
+}
+
+/**
+ * The `permissions` table has a UNIQUE(user_id, resource, sourceId)
+ * constraint — one row per (user, resource, source), carrying canRead and
+ * canWrite as two columns on that same row. `harness.grant()` only ever
+ * sets one of them true per call, so granting read AND write on the same
+ * (resource, sourceId) requires a single combined insert instead of two
+ * `grant()` calls (the second would violate the unique constraint).
+ */
+async function grantReadAndWrite(harness: RouteTestHarness, userId: number, resource: string, sourceId: string): Promise<void> {
+  await harness.db.auth.createPermission({
+    userId,
+    resource,
+    canRead: true,
+    canWrite: true,
+    sourceId,
+    grantedAt: Date.now(),
+    grantedBy: null,
+  });
+}
+
+describe('NodeInfo enrichment routes — permission isolation (real nodesRoutes router)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: app => app.use('/', nodesRoutes) });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  /**
+   * Seed a fresh nodeNum present in both sourceA (full donor) and sourceB
+   * (blank target: longName/shortName/hwModel unset).
+   */
+  async function seedDonorTargetPair(): Promise<number> {
+    const nodeNum = freshNodeNum();
+    const nodeId = toNodeId(nodeNum);
+    await harness.db.upsertNodeAsync({
+      nodeNum,
+      nodeId,
+      longName: 'Full Name',
+      shortName: 'FN',
+      hwModel: 42,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any, harness.sourceA);
+    await harness.db.upsertNodeAsync({
+      nodeNum,
+      nodeId,
+      longName: null,
+      shortName: null,
+      hwModel: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any, harness.sourceB);
+    return nodeNum;
+  }
+
+  describe('GET /nodes/enrichment/analysis', () => {
+    it('anonymous caller (no login) sees an empty result — 200, not 403', async () => {
+      await seedDonorTargetPair();
+      const agent = await harness.loginAs(null);
+      const res = await agent.get('/nodes/enrichment/analysis');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.nodes).toEqual([]);
+      expect(res.body.data.summary).toEqual({ nodeCount: 0, targetCount: 0, fieldCount: 0 });
+    });
+
+    it('limited caller with nodes:read on sourceA only never sees the sourceB target (filtered out)', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+      // Deliberately no grant on sourceB.
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get('/nodes/enrichment/analysis');
+      expect(res.status).toBe(200);
+      expect(res.body.data.nodes.find((n: any) => n.nodeNum === nodeNum)).toBeUndefined();
+      // Never references sourceB anywhere in the (empty) result.
+      const raw = JSON.stringify(res.body.data);
+      expect(raw).not.toContain(harness.sourceB);
+    });
+
+    it('limited caller with nodes:read on both sources sees the fillable target', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+      await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceB);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get('/nodes/enrichment/analysis');
+      expect(res.status).toBe(200);
+      const node = res.body.data.nodes.find((n: any) => n.nodeNum === nodeNum);
+      expect(node).toBeDefined();
+      const target = node.targets.find((t: any) => t.targetSourceId === harness.sourceB);
+      expect(target).toBeDefined();
+      expect(target.donorSourceId).toBe(harness.sourceA);
+      expect(target.fillableFields.sort()).toEqual(['hwModel', 'longName', 'shortName'].sort());
+    });
+
+    it('admin sees the target across both sources with no explicit grants (admin bypass)', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/nodes/enrichment/analysis');
+      expect(res.status).toBe(200);
+      const node = res.body.data.nodes.find((n: any) => n.nodeNum === nodeNum);
+      expect(node).toBeDefined();
+      expect(
+        node.targets.some((t: any) => t.targetSourceId === harness.sourceB && t.donorSourceId === harness.sourceA),
+      ).toBe(true);
+    });
+  });
+
+  describe('POST /nodes/enrichment/apply', () => {
+    it('400 INVALID_REQUEST when items is missing/empty', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/nodes/enrichment/apply').send({ items: [] });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.code).toBe('INVALID_REQUEST');
+    });
+
+    it('400 INVALID_ITEM when donorSourceId === targetSourceId', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/nodes/enrichment/apply').send({
+        items: [{ nodeNum, targetSourceId: harness.sourceA, donorSourceId: harness.sourceA }],
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_ITEM');
+    });
+
+    it('400 INVALID_ITEM when nodeNum is not numeric', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/nodes/enrichment/apply').send({
+        items: [{ nodeNum: 'not-a-number', targetSourceId: harness.sourceB, donorSourceId: harness.sourceA }],
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_ITEM');
+    });
+
+    it('403 FORBIDDEN when the caller lacks nodes:write on the target source (fail-closed)', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      // read on both, write only on sourceB — apply targets sourceA, which
+      // requires write on sourceA (missing).
+      await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+      await grantReadAndWrite(harness, harness.limited.id, 'nodes', harness.sourceB);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/nodes/enrichment/apply').send({
+        items: [{ nodeNum, targetSourceId: harness.sourceA, donorSourceId: harness.sourceB }],
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('FORBIDDEN');
+      expect(res.body.missing).toEqual(
+        expect.arrayContaining([{ sourceId: harness.sourceA, action: 'write' }]),
+      );
+    });
+
+    it('403 FORBIDDEN when the caller lacks nodes:read on the donor source (fail-closed)', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      // write on target (sourceB) only; no read grant anywhere (donor sourceA unreadable).
+      await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceB);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/nodes/enrichment/apply').send({
+        items: [{ nodeNum, targetSourceId: harness.sourceB, donorSourceId: harness.sourceA }],
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('FORBIDDEN');
+      expect(res.body.missing).toEqual(
+        expect.arrayContaining([{ sourceId: harness.sourceA, action: 'read' }]),
+      );
+    });
+
+    it('200 when the caller holds nodes:read on the donor and nodes:write on the target', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+      await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceB);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/nodes/enrichment/apply').send({
+        items: [{ nodeNum, targetSourceId: harness.sourceB, donorSourceId: harness.sourceA }],
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.applied[0].error).toBeUndefined();
+      expect(res.body.data.applied[0].copiedFields.sort()).toEqual(['hwModel', 'longName', 'shortName'].sort());
+
+      const targetRow = await harness.db.nodes.getNode(nodeNum, harness.sourceB);
+      expect(targetRow?.longName).toBe('Full Name');
+    });
+
+    it('admin bypasses the permission checks and applies across both sources', async () => {
+      const nodeNum = await seedDonorTargetPair();
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/nodes/enrichment/apply').send({
+        items: [{ nodeNum, targetSourceId: harness.sourceB, donorSourceId: harness.sourceA }],
+        pushToNodeDb: false,
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.data.applied[0].error).toBeUndefined();
+      expect(res.body.data.totalFieldsCopied).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/server/routes/nodesRoutes.ts
+++ b/src/server/routes/nodesRoutes.ts
@@ -147,6 +147,15 @@ router.get('/nodes/active', optionalAuth(), async (req, res) => {
   }
 });
 
+// NodeInfo enrichment (cross-source fill-blanks-only). Registered before the
+// parametric /nodes/:nodeNum/... and /nodes/:nodeId/... routes as
+// defense-in-depth — these are literal 2-segment paths that don't collide
+// with any of them, but registering first removes all doubt.
+import { handleEnrichmentAnalysis, handleEnrichmentApply } from './shared/enrichmentHandlers.js';
+
+router.get('/nodes/enrichment/analysis', optionalAuth(), handleEnrichmentAnalysis);
+router.post('/nodes/enrichment/apply', optionalAuth(), handleEnrichmentApply);
+
 // Copy NodeInfo from another source
 import {
   findCopyCandidates, copyNodeInfo, isNodeInfoField, NODE_INFO_FIELDS,

--- a/src/server/routes/shared/enrichmentHandlers.ts
+++ b/src/server/routes/shared/enrichmentHandlers.ts
@@ -1,0 +1,144 @@
+/**
+ * NodeInfo Enrichment — shared route handlers.
+ *
+ * One handler pair, mounted identically by `nodesRoutes.ts` (legacy /api
+ * surface) and `v1/nodes.ts` (`/api/v1/nodes` + `/api/v1/sources/:sourceId/nodes`),
+ * rather than duplicating the handler body across both routers the way the
+ * older `copy-candidates`/`copy-nodeinfo` routes do. See
+ * docs/internal/dev-notes/NODEINFO_ENRICHMENT_PHASE1_SPEC.md §2c.
+ *
+ * No existing cross-router (top-level `routes/` + `routes/v1/`) shared-handler
+ * location was found — `meshcoreRouteShared.ts` is the closest precedent, but
+ * it's used only within the flat `routes/meshcore*.ts` family. A new `shared/`
+ * subdirectory is used here per the spec.
+ */
+import { Request, Response } from 'express';
+import databaseService from '../../../services/database.js';
+import { logger } from '../../../utils/logger.js';
+import { ok, fail } from '../../utils/apiResponse.js';
+import {
+  analyzeEnrichment,
+  applyEnrichment,
+  type EnrichmentApplyItem,
+} from '../../services/nodeInfoEnrichmentService.js';
+
+/** Shape of one raw (unvalidated) item from the request body. */
+interface RawApplyItem {
+  nodeNum?: unknown;
+  targetSourceId?: unknown;
+  donorSourceId?: unknown;
+}
+
+/**
+ * GET .../enrichment/analysis
+ *
+ * Read-only. Computes the source universe the caller may read from — admins
+ * see every source; everyone else is restricted to sources they hold
+ * `nodes:read` on (an anonymous/unauthenticated caller has none, so the
+ * response is `{ nodes: [], summary: { nodeCount:0, targetCount:0, fieldCount:0 } }`,
+ * never a 403 — analysis is always safe to call, it just narrows scope).
+ */
+export async function handleEnrichmentAnalysis(req: Request, res: Response): Promise<Response> {
+  try {
+    const user = (req as any).user;
+    const userId: number | null = user?.id ?? null;
+    const isAdmin: boolean = user?.isAdmin ?? false;
+
+    // undefined = no restriction (admin path); analyzeEnrichment treats
+    // undefined as "all sources".
+    let readableSourceIds: string[] | undefined;
+    if (!isAdmin) {
+      const allSources = await databaseService.sources.getAllSources();
+      const readable: string[] = [];
+      for (const source of allSources) {
+        const canRead = userId !== null
+          && await databaseService.checkPermissionAsync(userId, 'nodes', 'read', source.id);
+        if (canRead) readable.push(source.id);
+      }
+      readableSourceIds = readable;
+    }
+
+    const analysis = await analyzeEnrichment(readableSourceIds);
+    return ok(res, analysis);
+  } catch (error) {
+    logger.error('Error analyzing NodeInfo enrichment:', error);
+    return fail(res, 500, 'ENRICHMENT_ANALYSIS_FAILED', 'Failed to analyze enrichment');
+  }
+}
+
+/**
+ * POST .../enrichment/apply
+ *
+ * Write, fail-closed over the whole batch:
+ *  - `items` must be a non-empty array (else 400 INVALID_REQUEST).
+ *  - Each item must have a numeric `nodeNum`, string `targetSourceId` /
+ *    `donorSourceId`, and the two source ids must differ (else 400
+ *    INVALID_ITEM).
+ *  - Non-admin callers must hold `nodes:read` on every distinct donor source
+ *    AND `nodes:write` on every distinct target source referenced anywhere in
+ *    the batch — a single missing grant rejects the entire batch with 403
+ *    FORBIDDEN and a `missing` list (extends copy-nodeinfo's single-op 403
+ *    semantics to a set).
+ *  - `applyEnrichment` itself is fill-blanks-only (via `copyNodeInfo` with no
+ *    `fields` arg) — never overwrites a non-blank target field.
+ */
+export async function handleEnrichmentApply(req: Request, res: Response): Promise<Response> {
+  try {
+    const user = (req as any).user;
+    const userId: number | null = user?.id ?? null;
+    const isAdmin: boolean = user?.isAdmin ?? false;
+
+    const body = req.body ?? {};
+    const rawItems = body.items;
+
+    if (!Array.isArray(rawItems) || rawItems.length === 0) {
+      return fail(res, 400, 'INVALID_REQUEST', 'items must be a non-empty array');
+    }
+
+    const items: EnrichmentApplyItem[] = [];
+    for (const raw of rawItems as RawApplyItem[]) {
+      const { nodeNum, targetSourceId, donorSourceId } = raw ?? {};
+      const valid = typeof nodeNum === 'number' && Number.isFinite(nodeNum)
+        && typeof targetSourceId === 'string' && targetSourceId.length > 0
+        && typeof donorSourceId === 'string' && donorSourceId.length > 0
+        && donorSourceId !== targetSourceId;
+      if (!valid) {
+        return fail(
+          res,
+          400,
+          'INVALID_ITEM',
+          'Each item requires a numeric nodeNum, string targetSourceId and donorSourceId, and donorSourceId must differ from targetSourceId',
+        );
+      }
+      items.push({ nodeNum: nodeNum as number, targetSourceId: targetSourceId as string, donorSourceId: donorSourceId as string });
+    }
+
+    if (!isAdmin) {
+      const donorSourceIds = new Set(items.map(i => i.donorSourceId));
+      const targetSourceIds = new Set(items.map(i => i.targetSourceId));
+      const missing: Array<{ sourceId: string; action: 'read' | 'write' }> = [];
+
+      for (const sourceId of donorSourceIds) {
+        const canRead = userId !== null
+          && await databaseService.checkPermissionAsync(userId, 'nodes', 'read', sourceId);
+        if (!canRead) missing.push({ sourceId, action: 'read' });
+      }
+      for (const sourceId of targetSourceIds) {
+        const canWrite = userId !== null
+          && await databaseService.checkPermissionAsync(userId, 'nodes', 'write', sourceId);
+        if (!canWrite) missing.push({ sourceId, action: 'write' });
+      }
+
+      if (missing.length > 0) {
+        return fail(res, 403, 'FORBIDDEN', 'Insufficient permission', { missing });
+      }
+    }
+
+    const pushToNodeDb = body.pushToNodeDb === true;
+    const result = await applyEnrichment(items, { pushToNodeDb });
+    return ok(res, result);
+  } catch (error) {
+    logger.error('Error applying NodeInfo enrichment:', error);
+    return fail(res, 500, 'ENRICHMENT_APPLY_FAILED', 'Failed to apply enrichment');
+  }
+}

--- a/src/server/routes/shared/enrichmentHandlers.ts
+++ b/src/server/routes/shared/enrichmentHandlers.ts
@@ -40,7 +40,7 @@ interface RawApplyItem {
  */
 export async function handleEnrichmentAnalysis(req: Request, res: Response): Promise<Response> {
   try {
-    const user = (req as any).user;
+    const user = req.user;
     const userId: number | null = user?.id ?? null;
     const isAdmin: boolean = user?.isAdmin ?? false;
 
@@ -84,7 +84,7 @@ export async function handleEnrichmentAnalysis(req: Request, res: Response): Pro
  */
 export async function handleEnrichmentApply(req: Request, res: Response): Promise<Response> {
   try {
-    const user = (req as any).user;
+    const user = req.user;
     const userId: number | null = user?.id ?? null;
     const isAdmin: boolean = user?.isAdmin ?? false;
 

--- a/src/server/routes/v1/nodes.ts
+++ b/src/server/routes/v1/nodes.ts
@@ -15,6 +15,7 @@ import {
   type NodeInfoField,
 } from '../../services/nodeInfoCopyService.js';
 import { resolvedSourceIdFromPath } from './sourceParam.js';
+import { handleEnrichmentAnalysis, handleEnrichmentApply } from '../shared/enrichmentHandlers.js';
 
 // mergeParams so this router picks up :sourceId when mounted under
 // /sources/:sourceId (new shape). At the root /nodes mount it's undefined
@@ -118,6 +119,33 @@ router.get('/', async (req: Request, res: Response) => {
     });
   }
 });
+
+/**
+ * GET /api/v1/nodes/enrichment/analysis
+ * POST /api/v1/nodes/enrichment/apply
+ *
+ * NodeInfo enrichment (cross-source fill-blanks-only). Registered above the
+ * bare `/:nodeId` route below — `/:nodeId` is single-segment and would
+ * otherwise capture `/enrichment` as a node id. The `/enrichment/analysis`
+ * and `/enrichment/apply` paths are 2-segment, so they would not actually be
+ * shadowed either way, but registering first removes all doubt.
+ *
+ * No `optionalAuth()` wrapper: this router sits behind the v1 router's
+ * global `requireAPIToken()` (routes/v1/index.ts), which hard-401s without a
+ * valid bearer token and always populates `req.user` with a real, active
+ * user — there is no anonymous fallthrough under v1 the way there is under
+ * `nodesRoutes.ts`'s `optionalAuth()`. Layering `optionalAuth()` on top would
+ * re-run the session/cookie lookup and could clobber `req.user` with the
+ * anonymous user for token-only clients, so it is intentionally omitted here
+ * (same reasoning as every other handler in this file).
+ *
+ * The `:sourceId` path param present when mounted under
+ * `/sources/:sourceId/nodes` is ignored — these are cross-source handlers
+ * that compute their own source universe from permissions, not from the
+ * mount's sourceId.
+ */
+router.get('/enrichment/analysis', handleEnrichmentAnalysis);
+router.post('/enrichment/apply', handleEnrichmentApply);
 
 /**
  * GET /api/v1/nodes/:nodeId

--- a/src/server/services/nodeInfoCopyService.ts
+++ b/src/server/services/nodeInfoCopyService.ts
@@ -24,11 +24,22 @@ export interface CopyNodeInfoResult {
   pushedToDevice: boolean;
 }
 
+/** Canonical "this NodeInfo field is empty" predicate. */
+export function isNodeInfoFieldBlank(value: unknown): boolean {
+  return value == null || value === '';
+}
+
+/** Count of NODE_INFO_FIELDS that are non-blank on a node. Used for donor ranking. */
+export function countFilledNodeInfoFields(node: Partial<DbNode>): number {
+  return NODE_INFO_FIELDS.filter(f => !isNodeInfoFieldBlank(node[f as keyof DbNode])).length;
+}
+
+/** Analysis field set — NODE_INFO_FIELDS minus the derived hasPKC flag. */
+export const ANALYZE_NODE_INFO_FIELDS =
+  NODE_INFO_FIELDS.filter(f => f !== 'hasPKC') as readonly NodeInfoField[];
+
 function countFilledFields(node: DbNode): number {
-  return NODE_INFO_FIELDS.filter(f => {
-    const val = node[f as keyof DbNode];
-    return val !== null && val !== undefined && val !== '';
-  }).length;
+  return countFilledNodeInfoFields(node);
 }
 
 function pickNodeInfoFields(node: DbNode): Pick<DbNode, NodeInfoField> {

--- a/src/server/services/nodeInfoEnrichmentService.perSource.test.ts
+++ b/src/server/services/nodeInfoEnrichmentService.perSource.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Per-source isolation tests for nodeInfoEnrichmentService (NodeInfo
+ * Enrichment epic #3837, Phase 1 WP-A).
+ *
+ * Unlike `nodeInfoEnrichmentService.test.ts` (which mocks
+ * `../../services/database.js` and `./nodeInfoCopyService.js` wholesale to
+ * pin the analyze/apply branching logic), this file exercises the REAL
+ * singleton `databaseService` against its `:memory:` SQLite backend — the
+ * same rationale as `mqttGeoSweepService.perSource.test.ts`. It proves that
+ * `applyEnrichment`'s writes land only on the named `targetSourceId` (never
+ * the donor, never an unrelated third source) and that `analyzeEnrichment`'s
+ * read path respects `allowedSourceIds`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import databaseService from '../../services/database.js';
+import { analyzeEnrichment, applyEnrichment } from './nodeInfoEnrichmentService.js';
+
+function seedNode(nodeNum: number, sourceId: string, overrides: Record<string, unknown> = {}) {
+  const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
+  return databaseService.upsertNodeAsync({
+    nodeNum,
+    nodeId,
+    longName: null,
+    shortName: null,
+    hwModel: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  } as any, sourceId);
+}
+
+describe('nodeInfoEnrichmentService — per-source isolation', () => {
+  // Fresh source triple per test so rows from a prior test can't leak into
+  // this one's grouping (the analyze pass groups by nodeNum across ALL
+  // sources it can see).
+  let SRC_A: string;
+  let SRC_B: string;
+  let SRC_OTHER: string;
+  let testCounter = 0;
+
+  beforeEach(async () => {
+    await databaseService.waitForReady();
+    const suffix = ++testCounter;
+    SRC_A = `enrich-ps-a-${suffix}`;
+    SRC_B = `enrich-ps-b-${suffix}`;
+    SRC_OTHER = `enrich-ps-other-${suffix}`;
+    await databaseService.sources.createSource({ id: SRC_A, name: 'Source A', type: 'meshtastic_tcp', config: {}, enabled: true });
+    await databaseService.sources.createSource({ id: SRC_B, name: 'Source B', type: 'meshtastic_tcp', config: {}, enabled: true });
+    await databaseService.sources.createSource({ id: SRC_OTHER, name: 'Source Other', type: 'meshtastic_tcp', config: {}, enabled: true });
+  });
+
+  afterEach(async () => {
+    await databaseService.sources.deleteSource(SRC_A).catch(() => {});
+    await databaseService.sources.deleteSource(SRC_B).catch(() => {});
+    await databaseService.sources.deleteSource(SRC_OTHER).catch(() => {});
+  });
+
+  it('applyEnrichment writes only to targetSourceId; donor row and an unrelated third-source row are untouched', async () => {
+    const NODE = 0x30000001;
+    const NODE2 = 0x30000002;
+
+    // Node present in both A (full donor) and B (blank target).
+    await seedNode(NODE, SRC_A, { longName: 'Full Name', shortName: 'FN', hwModel: 42 });
+    await seedNode(NODE, SRC_B, { longName: null, shortName: null, hwModel: null });
+
+    // Unrelated node living only in a third source — must never be touched.
+    await seedNode(NODE2, SRC_OTHER, { longName: 'Untouched', shortName: 'UT' });
+
+    const result = await applyEnrichment(
+      [{ nodeNum: NODE, targetSourceId: SRC_B, donorSourceId: SRC_A }],
+      { pushToNodeDb: false },
+    );
+
+    expect(result.applied).toHaveLength(1);
+    expect(result.applied[0].error).toBeUndefined();
+    expect(result.applied[0].copiedFields.sort()).toEqual(['hwModel', 'longName', 'shortName'].sort());
+
+    // Target (B) now has the donor's values.
+    const targetRow = await databaseService.nodes.getNode(NODE, SRC_B);
+    expect(targetRow?.longName).toBe('Full Name');
+    expect(targetRow?.shortName).toBe('FN');
+    expect(targetRow?.hwModel).toBe(42);
+
+    // Donor (A) is completely unchanged.
+    const donorRow = await databaseService.nodes.getNode(NODE, SRC_A);
+    expect(donorRow?.longName).toBe('Full Name');
+    expect(donorRow?.shortName).toBe('FN');
+    expect(donorRow?.hwModel).toBe(42);
+
+    // Unrelated third-source row for a different nodeNum is untouched.
+    const otherRow = await databaseService.nodes.getNode(NODE2, SRC_OTHER);
+    expect(otherRow?.longName).toBe('Untouched');
+    expect(otherRow?.shortName).toBe('UT');
+  });
+
+  it('applyEnrichment never overwrites a non-blank field on the target (fill-blanks-only)', async () => {
+    const NODE = 0x30000003;
+
+    await seedNode(NODE, SRC_A, { longName: 'Donor Name', shortName: 'DN', hwModel: 7 });
+    await seedNode(NODE, SRC_B, { longName: 'Existing Target Name', shortName: null, hwModel: null });
+
+    const result = await applyEnrichment(
+      [{ nodeNum: NODE, targetSourceId: SRC_B, donorSourceId: SRC_A }],
+      { pushToNodeDb: false },
+    );
+
+    expect(result.applied[0].copiedFields).not.toContain('longName');
+    expect(result.applied[0].copiedFields.sort()).toEqual(['hwModel', 'shortName'].sort());
+
+    const targetRow = await databaseService.nodes.getNode(NODE, SRC_B);
+    expect(targetRow?.longName).toBe('Existing Target Name'); // untouched
+    expect(targetRow?.shortName).toBe('DN');
+    expect(targetRow?.hwModel).toBe(7);
+  });
+
+  it('analyzeEnrichment(allowedSourceIds) excludes a disallowed source entirely from the read path', async () => {
+    const NODE = 0x30000004;
+
+    await seedNode(NODE, SRC_A, { longName: 'Full Name', shortName: 'FN', hwModel: 42 });
+    await seedNode(NODE, SRC_B, { longName: null, shortName: null, hwModel: null });
+
+    // Unrestricted: both sources visible, B is a valid enrichment target.
+    const full = await analyzeEnrichment([SRC_A, SRC_B]);
+    const fullNode = full.nodes.find(n => n.nodeNum === NODE);
+    expect(fullNode).toBeDefined();
+    expect(fullNode?.targets.some(t => t.targetSourceId === SRC_B)).toBe(true);
+
+    // Restricted to SRC_A only: SRC_B is dropped as both donor and target,
+    // so node NODE (which now only has one visible source row) drops out
+    // entirely.
+    const restricted = await analyzeEnrichment([SRC_A]);
+    expect(restricted.nodes.find(n => n.nodeNum === NODE)).toBeUndefined();
+  });
+});

--- a/src/server/services/nodeInfoEnrichmentService.test.ts
+++ b/src/server/services/nodeInfoEnrichmentService.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getAllSourcesMock: vi.fn(),
+  getAllNodesMock: vi.fn(),
+  copyNodeInfoMock: vi.fn(),
+}));
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: {
+      getAllSources: h.getAllSourcesMock,
+    },
+    nodes: {
+      getAllNodes: h.getAllNodesMock,
+    },
+  },
+}));
+
+vi.mock('./nodeInfoCopyService.js', async () => {
+  const actual = await vi.importActual<any>('./nodeInfoCopyService.js');
+  return {
+    ...actual,
+    copyNodeInfo: h.copyNodeInfoMock,
+  };
+});
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { analyzeEnrichment, applyEnrichment } from './nodeInfoEnrichmentService.js';
+
+const sources = [
+  { id: 'src-A', name: 'Source A', type: 'meshtastic_tcp', enabled: true, createdAt: 0, updatedAt: 0, createdBy: null, config: {}, displayOrder: 0 },
+  { id: 'src-B', name: 'Source B', type: 'mqtt_bridge', enabled: true, createdAt: 0, updatedAt: 0, createdBy: null, config: {}, displayOrder: 1 },
+  { id: 'src-C', name: 'Source C', type: 'meshcore', enabled: true, createdAt: 0, updatedAt: 0, createdBy: null, config: {}, displayOrder: 2 },
+];
+
+const makeRow = (nodeNum: number, sourceId: string, overrides: Record<string, unknown> = {}) => ({
+  nodeNum,
+  nodeId: `!${nodeNum.toString(16).padStart(8, '0')}`,
+  sourceId,
+  longName: null,
+  shortName: null,
+  hwModel: null,
+  role: null,
+  macaddr: null,
+  publicKey: null,
+  hasPKC: null,
+  firmwareVersion: null,
+  updatedAt: 1000,
+  lastHeard: 900,
+  createdAt: 500,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  h.getAllSourcesMock.mockResolvedValue(sources);
+});
+
+describe('analyzeEnrichment', () => {
+  it('lists fillable fields on a target from a fully-populated donor', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { longName: 'Full Node', shortName: 'FN', hwModel: 42, role: 1, updatedAt: 2000 }),
+      makeRow(100, 'src-B', { longName: null, hwModel: null, shortName: 'SB', role: 1, updatedAt: 1000 }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    expect(result.nodes).toHaveLength(1);
+    const node = result.nodes[0];
+    expect(node.nodeNum).toBe(100);
+    expect(node.targets).toHaveLength(1);
+    const target = node.targets[0];
+    expect(target.targetSourceId).toBe('src-B');
+    expect(target.donorSourceId).toBe('src-A');
+    expect(target.fillableFields.sort()).toEqual(['hwModel', 'longName'].sort());
+    expect(result.summary).toEqual({ nodeCount: 1, targetCount: 1, fieldCount: 2 });
+  });
+
+  it('best donor ranking: more filled fields wins', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      // Weaker donor: only longName, but newer updatedAt
+      makeRow(100, 'src-A', { longName: 'Weak Donor', updatedAt: 5000 }),
+      // Stronger donor: longName + hwModel + role, older updatedAt
+      makeRow(100, 'src-B', { longName: 'Strong Donor', hwModel: 7, role: 2, updatedAt: 1000 }),
+      makeRow(100, 'src-C', { longName: null, shortName: null, hwModel: null, role: null }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    const target = result.nodes[0].targets.find(t => t.targetSourceId === 'src-C');
+    expect(target?.donorSourceId).toBe('src-B'); // more fields filled wins
+  });
+
+  it('best donor ranking: tie-break by newer updatedAt', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { longName: 'Older', shortName: 'A', updatedAt: 1000 }),
+      makeRow(100, 'src-B', { longName: 'Newer', shortName: 'B', updatedAt: 9000 }),
+      makeRow(100, 'src-C', { longName: null, shortName: null }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    const target = result.nodes[0].targets.find(t => t.targetSourceId === 'src-C');
+    expect(target?.donorSourceId).toBe('src-B'); // same field count (2 each), newer wins
+  });
+
+  it('excludes hasPKC from fillableFields and fieldCount even when donor has publicKey+hasPKC', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { publicKey: 'abc123', hasPKC: true, updatedAt: 2000 }),
+      makeRow(100, 'src-B', { publicKey: null, hasPKC: null, updatedAt: 1000 }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    const target = result.nodes[0].targets[0];
+    expect(target.fillableFields).toContain('publicKey');
+    expect(target.fillableFields).not.toContain('hasPKC');
+    expect(result.summary.fieldCount).toBe(1);
+  });
+
+  it('excludes nodes with no blank fields across sources', async () => {
+    const full = { longName: 'Same', shortName: 'S', hwModel: 1, role: 1, macaddr: 'AA:BB', publicKey: 'key', hasPKC: true, firmwareVersion: '2.5' };
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { ...full }),
+      makeRow(100, 'src-B', { ...full }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    expect(result.nodes).toHaveLength(0);
+    expect(result.summary).toEqual({ nodeCount: 0, targetCount: 0, fieldCount: 0 });
+  });
+
+  it('excludes nodes present in only a single source', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { longName: null }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    expect(result.nodes).toHaveLength(0);
+  });
+
+  it('allowedSourceIds filters the source universe (as donor and target)', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { longName: 'Full Node', shortName: 'FN', updatedAt: 2000 }),
+      makeRow(100, 'src-B', { longName: null, shortName: null }),
+    ]);
+
+    const restricted = await analyzeEnrichment(['src-A']);
+    // src-B dropped entirely, so no cross-source pair remains for node 100
+    expect(restricted.nodes).toHaveLength(0);
+
+    const empty = await analyzeEnrichment([]);
+    expect(empty).toEqual({ nodes: [], summary: { nodeCount: 0, targetCount: 0, fieldCount: 0 } });
+  });
+
+  it('groups rows by Number(nodeNum) even when repo returns bigint-like values', async () => {
+    h.getAllNodesMock.mockResolvedValue([
+      makeRow(100, 'src-A', { longName: 'Full Node', shortName: 'FN', updatedAt: 2000, nodeNum: 100n as unknown as number }),
+      makeRow(100, 'src-B', { longName: null }),
+    ]);
+
+    const result = await analyzeEnrichment();
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].nodeNum).toBe(100);
+  });
+});
+
+describe('applyEnrichment', () => {
+  it('delegates to copyNodeInfo fill-blanks-only (no fields arg), pushToNodeDb=false', async () => {
+    h.copyNodeInfoMock.mockResolvedValue({ copiedFields: ['longName'], pushedToDevice: false });
+
+    const result = await applyEnrichment(
+      [{ nodeNum: 100, targetSourceId: 'src-B', donorSourceId: 'src-A' }],
+      { pushToNodeDb: false },
+    );
+
+    expect(h.copyNodeInfoMock).toHaveBeenCalledWith(100, 'src-A', 'src-B', false);
+    expect(h.copyNodeInfoMock.mock.calls[0]).toHaveLength(4); // no 5th `fields` arg
+    expect(result.applied[0].copiedFields).toEqual(['longName']);
+    expect(result.applied[0].error).toBeUndefined();
+  });
+
+  it('passes pushToNodeDb=true through as the 4th arg', async () => {
+    h.copyNodeInfoMock.mockResolvedValue({ copiedFields: ['hwModel'], pushedToDevice: true });
+
+    await applyEnrichment(
+      [{ nodeNum: 100, targetSourceId: 'src-B', donorSourceId: 'src-A' }],
+      { pushToNodeDb: true },
+    );
+
+    expect(h.copyNodeInfoMock).toHaveBeenCalledWith(100, 'src-A', 'src-B', true);
+  });
+
+  it('isolates per-item errors: one throwing item does not abort the batch', async () => {
+    h.copyNodeInfoMock
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ copiedFields: ['longName'], pushedToDevice: false });
+
+    const result = await applyEnrichment(
+      [
+        { nodeNum: 100, targetSourceId: 'src-B', donorSourceId: 'src-A' },
+        { nodeNum: 200, targetSourceId: 'src-C', donorSourceId: 'src-A' },
+      ],
+      { pushToNodeDb: false },
+    );
+
+    expect(result.applied).toHaveLength(2);
+    expect(result.applied[0].error).toContain('boom');
+    expect(result.applied[0].copiedFields).toEqual([]);
+    expect(result.applied[1].error).toBeUndefined();
+    expect(result.applied[1].copiedFields).toEqual(['longName']);
+  });
+
+  it('totalFieldsCopied sums copiedFields across all items', async () => {
+    h.copyNodeInfoMock
+      .mockResolvedValueOnce({ copiedFields: ['longName', 'hwModel'], pushedToDevice: false })
+      .mockResolvedValueOnce({ copiedFields: ['role'], pushedToDevice: false });
+
+    const result = await applyEnrichment(
+      [
+        { nodeNum: 100, targetSourceId: 'src-B', donorSourceId: 'src-A' },
+        { nodeNum: 200, targetSourceId: 'src-C', donorSourceId: 'src-A' },
+      ],
+      { pushToNodeDb: false },
+    );
+
+    expect(result.totalFieldsCopied).toBe(3);
+  });
+});

--- a/src/server/services/nodeInfoEnrichmentService.ts
+++ b/src/server/services/nodeInfoEnrichmentService.ts
@@ -1,0 +1,206 @@
+import databaseService from '../../services/database.js';
+import { DbNode } from '../../db/types.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
+import { logger } from '../../utils/logger.js';
+import {
+  copyNodeInfo,
+  isNodeInfoFieldBlank,
+  countFilledNodeInfoFields,
+  ANALYZE_NODE_INFO_FIELDS,
+  type NodeInfoField,
+} from './nodeInfoCopyService.js';
+
+export interface EnrichmentTarget {
+  targetSourceId: string;
+  targetSourceName: string;
+  fillableFields: NodeInfoField[]; // excludes hasPKC
+  donorSourceId: string;
+  donorSourceName: string;
+}
+
+export interface EnrichmentNode {
+  nodeNum: number;
+  nodeId: string;
+  displayName: string; // longName || shortName || nodeId
+  targets: EnrichmentTarget[];
+}
+
+export interface EnrichmentAnalysis {
+  nodes: EnrichmentNode[];
+  summary: { nodeCount: number; targetCount: number; fieldCount: number };
+}
+
+export interface EnrichmentApplyItem {
+  nodeNum: number;
+  targetSourceId: string;
+  donorSourceId: string;
+}
+
+export interface EnrichmentApplyItemResult extends EnrichmentApplyItem {
+  copiedFields: string[];
+  pushedToDevice: boolean;
+  error?: string; // per-item failure; does NOT abort the batch
+}
+
+export interface EnrichmentApplyResult {
+  applied: EnrichmentApplyItemResult[];
+  totalFieldsCopied: number;
+}
+
+/**
+ * `getAllNodes()` rows carry a `sourceId` column at runtime (the repo does
+ * `select()` over the full `nodes` table), but `DbNode` (src/db/types.ts)
+ * does not declare it — same pattern as `RepoNodeInput` in
+ * nodeCacheService.ts. Type it locally rather than widening DbNode itself.
+ */
+type NodeRow = DbNode & { sourceId: string };
+
+/**
+ * Analyze all nodes present in more than one source and compute, for each
+ * source row that is missing NodeInfo fields (a "target"), the best donor
+ * row (from another source) that could fill some of those blanks.
+ *
+ * Divergence from `findCopyCandidates` (nodeInfoCopyService.ts): donor
+ * validity here is "can fill >= 1 of the target's blank fields", not the
+ * `longName || shortName` gate used by `findCopyCandidates` — the
+ * enrichment definition is field-driven rather than name-driven, since the
+ * point of enrichment is filling arbitrary blank fields (not just names).
+ *
+ * @param allowedSourceIds  restrict the source universe (used for permission
+ *   filtering by the route). `undefined` = all sources (admin path).
+ */
+export async function analyzeEnrichment(
+  allowedSourceIds?: readonly string[],
+): Promise<EnrichmentAnalysis> {
+  const empty: EnrichmentAnalysis = { nodes: [], summary: { nodeCount: 0, targetCount: 0, fieldCount: 0 } };
+
+  const allSources = await databaseService.sources.getAllSources();
+  const sourceNameById = new Map<string, string>(allSources.map(s => [s.id, s.name]));
+
+  let allowedSet: Set<string> | null = null;
+  if (allowedSourceIds !== undefined) {
+    allowedSet = new Set(allowedSourceIds);
+    if (allowedSet.size === 0) return empty;
+  }
+
+  const allNodes = (await databaseService.nodes.getAllNodes(ALL_SOURCES)) as NodeRow[];
+
+  // Group rows by physical nodeNum (coerced to Number — BIGINT on PG/MySQL),
+  // keeping only rows whose sourceId is in the allowed set (if restricted).
+  const byNodeNum = new Map<number, NodeRow[]>();
+  for (const row of allNodes) {
+    if (allowedSet && !allowedSet.has(row.sourceId)) continue;
+    const nodeNum = Number(row.nodeNum);
+    const group = byNodeNum.get(nodeNum);
+    if (group) {
+      group.push(row);
+    } else {
+      byNodeNum.set(nodeNum, [row]);
+    }
+  }
+
+  const nodes: EnrichmentNode[] = [];
+  let targetCount = 0;
+  let fieldCount = 0;
+
+  for (const [nodeNum, rows] of byNodeNum) {
+    if (rows.length < 2) continue;
+
+    const targets: EnrichmentTarget[] = [];
+
+    for (const targetRow of rows) {
+      const targetSourceId = targetRow.sourceId;
+      const blanks = ANALYZE_NODE_INFO_FIELDS.filter(f => isNodeInfoFieldBlank(targetRow[f as keyof DbNode]));
+      if (blanks.length === 0) continue;
+
+      // Donor candidates: other source rows for this nodeNum that can fill
+      // at least one of the target's blank fields.
+      const donorCandidates = rows.filter(r => {
+        if (r.sourceId === targetSourceId) return false;
+        return blanks.some(f => !isNodeInfoFieldBlank(r[f as keyof DbNode]));
+      });
+      if (donorCandidates.length === 0) continue;
+
+      // Rank identically to findCopyCandidates: most fields filled first,
+      // tie-break by newer updatedAt.
+      donorCandidates.sort(
+        (a, b) => countFilledNodeInfoFields(b) - countFilledNodeInfoFields(a)
+          || Number(b.updatedAt) - Number(a.updatedAt),
+      );
+      const donor = donorCandidates[0];
+      const donorSourceId = donor.sourceId;
+
+      const fillableFields = blanks.filter(f => !isNodeInfoFieldBlank(donor[f as keyof DbNode]));
+      if (fillableFields.length === 0) continue;
+
+      targets.push({
+        targetSourceId,
+        targetSourceName: sourceNameById.get(targetSourceId) ?? targetSourceId,
+        fillableFields,
+        donorSourceId,
+        donorSourceName: sourceNameById.get(donorSourceId) ?? donorSourceId,
+      });
+    }
+
+    if (targets.length === 0) continue;
+
+    // nodeId/displayName sourced from the row with the most fields filled.
+    const bestRow = [...rows].sort(
+      (a, b) => countFilledNodeInfoFields(b) - countFilledNodeInfoFields(a),
+    )[0];
+    const displayName = bestRow.longName || bestRow.shortName || bestRow.nodeId;
+
+    nodes.push({
+      nodeNum,
+      nodeId: bestRow.nodeId,
+      displayName,
+      targets,
+    });
+
+    targetCount += targets.length;
+    fieldCount += targets.reduce((sum, t) => sum + t.fillableFields.length, 0);
+  }
+
+  return { nodes, summary: { nodeCount: nodes.length, targetCount, fieldCount } };
+}
+
+/**
+ * Apply a batch of enrichment copies. Permission is enforced by the caller
+ * (the route), not here — this service is permission-agnostic and
+ * unit-testable in isolation.
+ *
+ * Each item is applied in its own try/catch so one bad item never aborts
+ * the rest of the batch (partial success).
+ */
+export async function applyEnrichment(
+  items: readonly EnrichmentApplyItem[],
+  options: { pushToNodeDb: boolean },
+): Promise<EnrichmentApplyResult> {
+  const applied: EnrichmentApplyItemResult[] = [];
+
+  for (const item of items) {
+    try {
+      // NOTE: no `fields` arg here — this delegates to copyNodeInfo's legacy
+      // fill-blanks-only path, which never overwrites a non-blank target
+      // field. This is the fill-blanks-only invariant for enrichment; do not
+      // add a `fields` argument, which would flip copyNodeInfo into its
+      // overwrite mode (#4244).
+      const { copiedFields, pushedToDevice } = await copyNodeInfo(
+        Number(item.nodeNum),
+        item.donorSourceId,
+        item.targetSourceId,
+        options.pushToNodeDb,
+      );
+      applied.push({ ...item, copiedFields, pushedToDevice });
+    } catch (error) {
+      logger.error(
+        `Enrichment apply failed for node ${item.nodeNum} (${item.donorSourceId} -> ${item.targetSourceId}):`,
+        error,
+      );
+      applied.push({ ...item, copiedFields: [], pushedToDevice: false, error: String(error) });
+    }
+  }
+
+  const totalFieldsCopied = applied.reduce((sum, a) => sum + a.copiedFields.length, 0);
+  return { applied, totalFieldsCopied };
+}


### PR DESCRIPTION
## Summary
Phase 1 (backend) of the NodeInfo Enrichment epic (#3837). The manual Copy NodeInfo dialog already lets a user fill one node's blank fields from a richer source; this PR generalizes that into a batch mechanism: analyze every physical node (distinct `nodeNum`) across all sources for blank NodeInfo fields another source can fill, and apply the enrichment fill-blanks-only in bulk. Phase 2 adds the "NodeInfo Enrichment" card under Analysis & Reports that consumes these endpoints.

## Changes
- New `src/server/services/nodeInfoEnrichmentService.ts`: `analyzeEnrichment(allowedSourceIds?)` (per-node targets with fillable fields + best donor, ranked by fields-filled then updatedAt — same comparator as `findCopyCandidates`) and `applyEnrichment(items, {pushToNodeDb})` with per-item error isolation.
- All writes delegate to the existing `copyNodeInfo` **without** the `fields` arg — its legacy path is natively fill-blanks-only and re-reads DB state per call, so non-blank fields are never overwritten even from a stale analysis.
- Additive exports on `nodeInfoCopyService.ts` (`isNodeInfoFieldBlank`, `countFilledNodeInfoFields`, `ANALYZE_NODE_INFO_FIELDS`); zero behavior change to the existing copy path. `hasPKC` is excluded from analysis (derived from `publicKey`) but still filled by the unchanged primitive when blank.
- New shared handlers `src/server/routes/shared/enrichmentHandlers.ts` mounted by BOTH `nodesRoutes.ts` (`/api/nodes/enrichment/{analysis,apply}`, `optionalAuth`) and `v1/nodes.ts` (`/api/v1/nodes/enrichment/*`, behind the router-global `requireAPIToken`). Registered above param routes; `ok()`/`fail()` envelope throughout.
- Permissions: analysis is computed only over sources the caller holds `nodes:read` on (admin sees all; anonymous gets an empty 200). Apply is fail-closed over the batch: `nodes:read` on every donor source AND `nodes:write` on every target source, else 403 with a `missing` list.
- Epic plan + Phase 1 spec committed under `docs/internal/dev-notes/`.

## Issues Resolved
Relates to #3837 (Phase 1 of 2 — Phase 2 delivers the Analysis & Reports UI and closes the issue)

## Documentation Updates
`docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md` (epic plan + decisions) and `NODEINFO_ENRICHMENT_PHASE1_SPEC.md`. No public API docs updated — the existing copy-nodeinfo endpoints are likewise dev-notes-only.

## Testing
- [x] Full Vitest suite green: 10,935 tests, 0 failures, `success: true` via JSON reporter (651 pending = PG/MySQL container suites, not required — no schema/migration changes)
- [x] TypeScript compiles cleanly; `lint:ci` clean (no baseline growth)
- [x] 26 new tests: service unit (12), perSource isolation on real SQLite (3), route permission harness (11) mounting the REAL `nodesRoutes` router via `createRouteTestApp` (real session + real SQL permission rows)
- [ ] Reviewer: verify apply never passes a `fields` arg to `copyNodeInfo` (fill-blanks-only invariant, asserted in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1