### PR TITLE
refactor(frontend): migrate six leaf tabs to routes (#3962 5.4 PR3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4706,6 +4706,42 @@ function App() {
             path="security"
             element={<ErrorBoundary fallbackTitle="Security failed to load"><SecurityTab onTabChange={setActiveTab} onSelectDMNode={setSelectedDMNode} openDmWithDraft={openDmWithDraft} /></ErrorBoundary>}
           />
+          <Route
+            path="admin"
+            element={authStatus?.user?.isAdmin ? (
+              <ErrorBoundary fallbackTitle="Admin Commands failed to load">
+                <AdminCommandsTab
+                  key={sourceId || 'default'}
+                  nodes={nodes}
+                  currentNodeId={currentNodeId}
+                  channels={channels}
+                  onChannelsUpdated={fetchChannels}
+                />
+              </ErrorBoundary>
+            ) : null}
+          />
+          <Route
+            path="mqtt-config"
+            element={isMqttBridge && sourceId ? (
+              <ErrorBoundary fallbackTitle="Configuration failed to load">
+                <MqttBridgeConfigurationView key={sourceId} sourceId={sourceId} />
+              </ErrorBoundary>
+            ) : null}
+          />
+          <Route
+            path="packetmonitor"
+            element={
+              <ErrorBoundary fallbackTitle="Packet Monitor failed to load">
+                <div style={{ height: 'calc(100dvh - var(--header-height, 60px) - 4rem)', overflow: 'hidden' }}>
+                  {isMqtt && sourceId ? (
+                    <MqttPacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />
+                  ) : (
+                    <PacketMonitorPanel onClose={() => setActiveTab('nodes')} />
+                  )}
+                </div>
+              </ErrorBoundary>
+            }
+          />
           <Route path="*" element={<>
         {activeTab === 'nodes' && (
           <ErrorBoundary fallbackTitle="Nodes failed to load">
@@ -5202,35 +5238,9 @@ function App() {
           />
           </ErrorBoundary>
         )}
-        {activeTab === 'mqtt-config' && isMqttBridge && sourceId && (
-          <ErrorBoundary fallbackTitle="Configuration failed to load">
-            <MqttBridgeConfigurationView key={sourceId} sourceId={sourceId} />
-          </ErrorBoundary>
-        )}
         {/* 'audit' migrated to <Route path="audit"> above (#3962 5.4 PR1 proof leaf) */}
-        {/* 'notifications', 'users', 'security' migrated to <Route> elements above (#3962 5.4 PR3 leaf tab group) */}
-        {activeTab === 'admin' && authStatus?.user?.isAdmin && (
-          <ErrorBoundary fallbackTitle="Admin Commands failed to load">
-          <AdminCommandsTab
-            key={sourceId || 'default'}
-            nodes={nodes}
-            currentNodeId={currentNodeId}
-            channels={channels}
-            onChannelsUpdated={fetchChannels}
-          />
-          </ErrorBoundary>
-        )}
-        {activeTab === 'packetmonitor' && (
-          <ErrorBoundary fallbackTitle="Packet Monitor failed to load">
-            <div style={{ height: 'calc(100dvh - var(--header-height, 60px) - 4rem)', overflow: 'hidden' }}>
-              {isMqtt && sourceId ? (
-                <MqttPacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />
-              ) : (
-                <PacketMonitorPanel onClose={() => setActiveTab('nodes')} />
-              )}
-            </div>
-          </ErrorBoundary>
-        )}
+        {/* 'notifications', 'users', 'admin', 'security', 'mqtt-config', 'packetmonitor'
+            migrated to <Route> elements above (#3962 5.4 PR3 leaf tab group) */}
           </>} />
         </Routes>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4694,6 +4694,18 @@ function App() {
             path="audit"
             element={<ErrorBoundary fallbackTitle="Audit Log failed to load"><AuditLogTab /></ErrorBoundary>}
           />
+          <Route
+            path="notifications"
+            element={<ErrorBoundary fallbackTitle="Notifications failed to load"><NotificationsTab isAdmin={authStatus?.user?.isAdmin || false} /></ErrorBoundary>}
+          />
+          <Route
+            path="users"
+            element={<ErrorBoundary fallbackTitle="Users failed to load"><UsersTab /></ErrorBoundary>}
+          />
+          <Route
+            path="security"
+            element={<ErrorBoundary fallbackTitle="Security failed to load"><SecurityTab onTabChange={setActiveTab} onSelectDMNode={setSelectedDMNode} openDmWithDraft={openDmWithDraft} /></ErrorBoundary>}
+          />
           <Route path="*" element={<>
         {activeTab === 'nodes' && (
           <ErrorBoundary fallbackTitle="Nodes failed to load">
@@ -5195,9 +5207,8 @@ function App() {
             <MqttBridgeConfigurationView key={sourceId} sourceId={sourceId} />
           </ErrorBoundary>
         )}
-        {activeTab === 'notifications' && <ErrorBoundary fallbackTitle="Notifications failed to load"><NotificationsTab isAdmin={authStatus?.user?.isAdmin || false} /></ErrorBoundary>}
-        {activeTab === 'users' && <ErrorBoundary fallbackTitle="Users failed to load"><UsersTab /></ErrorBoundary>}
         {/* 'audit' migrated to <Route path="audit"> above (#3962 5.4 PR1 proof leaf) */}
+        {/* 'notifications', 'users', 'security' migrated to <Route> elements above (#3962 5.4 PR3 leaf tab group) */}
         {activeTab === 'admin' && authStatus?.user?.isAdmin && (
           <ErrorBoundary fallbackTitle="Admin Commands failed to load">
           <AdminCommandsTab
@@ -5207,11 +5218,6 @@ function App() {
             channels={channels}
             onChannelsUpdated={fetchChannels}
           />
-          </ErrorBoundary>
-        )}
-        {activeTab === 'security' && (
-          <ErrorBoundary fallbackTitle="Security failed to load">
-          <SecurityTab onTabChange={setActiveTab} onSelectDMNode={setSelectedDMNode} openDmWithDraft={openDmWithDraft} />
           </ErrorBoundary>
         )}
         {activeTab === 'packetmonitor' && (


### PR DESCRIPTION
## Summary
PR3 of the Task 5.4 stack (remediation epic #3962): migrate the six self-contained leaf tabs — notifications, users, security, admin, mqtt-config, packetmonitor — from `activeTab === 'x'` render blocks to `<Route>` elements, following the audit-tab template from PR1. Permission/enablement gating moves verbatim (e.g. the packetmonitor guard still bounces to nodes when packet logging is disabled on the source — verified live). App.tsx-only diff, +50/−34.

## Browser validation (dev container, deployed 2f40c24b)
- `/security` route renders the Security Scanner ✓; `/users` renders user management ✓
- `/packetmonitor` correctly redirected by the pre-existing enablement guard (packet logging disabled on the test source) — preserved behavior, traced to App L717–741
- Console clean (known locales-fallback 404 only)

## Issues Resolved
Relates to #3962 (Phase 5.4, PR 3 of ~8).

## Testing
- [x] Full Vitest suite: success=true, 10,281 passed, 0 failed, 0 failed suites
- [x] `tsc --noEmit` 0; `typecheck:tests` 304 = main parity; `lint:ci` green
- [ ] Reviewer: confirm each route element carries the same permission wrapper its render block had

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158hFzsVbodeJK246qAE1dY