### PR TITLE
feat(analysis): NodeInfo Enrichment report under Analysis & Reports (#3837 Phase 2)

### DIFF
--- a/docs/features/analysis-reports.md
+++ b/docs/features/analysis-reports.md
@@ -2,7 +2,7 @@
 
 The **Analysis & Reports** workspace is a global, cross-source analytics page that runs analytical reports against the telemetry, position, and routing data MeshMonitor has collected from every source you can read. It lives at `/reports` and is linked from the bottom of the dashboard sidebar (right under *Map Analysis*).
 
-The first report bundled with the workspace is **Solar Monitoring Analysis** — see below. The card-grid landing page is designed to host additional reports over time without changing the routing or navigation surface.
+Two reports are currently bundled with the workspace: **Solar Monitoring Analysis** and **NodeInfo Enrichment** — see below. The card-grid landing page is designed to host additional reports over time without changing the routing or navigation surface.
 
 ## Solar Monitoring Analysis
 
@@ -60,24 +60,71 @@ Nodes whose simulated minimum drops below `50%` (battery) or `3.5 V` (voltage) a
 
 Solar production must already be configured under **Settings → Solar Monitoring** for the forecast to produce useful output. See the [Solar Monitoring guide](./solar-monitoring) for set-up details.
 
+## NodeInfo Enrichment
+
+Scans every node visible on more than one source for blank NodeInfo fields — Long Name, Short Name, Hardware Model, Role, MAC Address, Public Key, Firmware — that another source's record for the same physical node can fill, and lets you copy the missing data across sources. It generalizes the per-node "Copy NodeInfo" dialog (available from the node detail panel) into a batch view spanning every source you can read.
+
+### What gets analyzed
+
+For every node seen on two or more of your permitted sources, the report checks the fields above for blanks. Each row in the report table is one **(node, target source)** pair — a specific source's record for a specific node that is missing at least one field — and lists:
+
+- The **fillable fields** for that row (only the ones actually blank on the target and present on the donor)
+- The **donor source**: whichever other source holds the most complete record for that node. Completeness is ranked by number of non-blank fields, with the most recently updated record winning ties.
+
+### Running the report
+
+1. Open the dashboard, click **Analysis & Reports** in the sidebar.
+2. Click the **NodeInfo Enrichment** card.
+3. Review the summary tiles — **Nodes**, **Targets**, **Fillable fields** — above the table.
+4. Click **Fix** on a row to apply just that (node, target source) pair, or **Fix All** to apply every row currently listed.
+5. Click **Refresh** to re-run the analysis, e.g. after applying fixes or after new NodeInfo has arrived over the mesh.
+
+### Applying fixes
+
+Applying a row is **fill-blanks-only**: it writes only the fields that are currently empty on the target source's record and never overwrites a field that already has a value — even if the analysis backing the row has gone stale since the page loaded. This makes Fix and Fix All safe to click at any time.
+
+An **Also push to device NodeDB** toggle (default off) sits above the table. When enabled, each node that gets enriched also receives the same NodeInfo-exchange nudge as the manual Copy NodeInfo dialog's push option (`sendNodeInfoRequest` on the node's channel). This generates mesh traffic, so leave it off if you only want to update MeshMonitor's own database.
+
+Because a row reflects only its single best donor, fixing it can uncover further blanks: if that donor didn't have every missing field, the row disappears but the node may resurface with a different (partial) donor on the next analysis. Click **Refresh** (or re-run the report) until the table drains to fully converge a node across all sources.
+
+> **On-demand only.** This report has no background scheduler — it runs interactively whenever you open the card or click Refresh/Fix.
+
 ## Permissions
 
-Both endpoints behind the workspace are scoped to the requesting user's permitted source IDs:
+### Solar Monitoring
+
+Both solar endpoints are scoped to the requesting user's permitted source IDs:
 
 - Admins see all enabled sources
 - Non-admin users see sources where they hold `nodes:read`
 - An optional `?sources=id1,id2` query param restricts the analysis further (intersected with permitted IDs)
 
-The page itself is publicly routable; only the data is gated.
+### NodeInfo Enrichment
+
+- **Analysis** (`GET /api/nodes/enrichment/analysis`) only ever computes over sources the caller holds `nodes:read` on — admins see every source, anonymous/unauthenticated callers see none (an empty, but never a `403`, response).
+- **Applying** (`POST /api/nodes/enrichment/apply`) requires `nodes:read` on the donor source and `nodes:write` on every target source referenced by the request. A single missing grant rejects the whole batch with `403 FORBIDDEN` — partial application of an under-permissioned batch never happens.
+
+The page itself is publicly routable for both reports; only the underlying data is gated.
 
 ## API
 
-The Reports workspace surfaces two endpoints under the existing `/api/analysis/*` namespace:
+### Solar Monitoring
+
+Two endpoints under the existing `/api/analysis/*` namespace:
 
 - `GET /api/analysis/solar-nodes?lookback_days=N&sources=…`
 - `GET /api/analysis/solar-forecast?lookback_days=N&sources=…`
 
 See the [REST API reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/REST_API.md) for the full request/response shapes.
+
+### NodeInfo Enrichment
+
+Two endpoints under `/api/nodes/enrichment/*` (also mirrored at `/api/v1/nodes/enrichment/*`), using the standard `{ success, data }` response envelope:
+
+- `GET /api/nodes/enrichment/analysis` — returns `{ nodes: [...], summary: { nodeCount, targetCount, fieldCount } }`.
+- `POST /api/nodes/enrichment/apply` — body `{ items: [{ nodeNum, targetSourceId, donorSourceId }], pushToNodeDb? }`, returns `{ applied: [...], totalFieldsCopied }`.
+
+Error codes: `INVALID_REQUEST` / `INVALID_ITEM` (400, malformed request body), `FORBIDDEN` (403, missing `nodes:read`/`nodes:write` — includes a `missing` list), `ENRICHMENT_ANALYSIS_FAILED` / `ENRICHMENT_APPLY_FAILED` (500).
 
 ## Related
 

--- a/docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md
+++ b/docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md
@@ -58,18 +58,30 @@ apply the enrichment ("Fix") per node or in bulk.
 ### Phase 2 — Frontend: Analysis & Reports card
 **Branch:** `feature/nodeinfo-enrichment-report`
 
-- [ ] Extend `AnalysisType` + `reports[]` with a "NodeInfo Enrichment" card; new
+- [x] Extend `AnalysisType` + `reports[]` with a "NodeInfo Enrichment" card; new
       `src/components/Analysis/NodeInfoEnrichmentReport.tsx` (TanStack useQuery +
       `ApiService` — raw fetch is banned in new components; `UiIcon` for icons).
-- [ ] Table of enrichable nodes (node, target source(s), missing fields, donor source),
+- [x] Table of enrichable nodes (node, target source(s), missing fields, donor source),
       per-row **Fix** + **Fix All**, push-to-NodeDB toggle default off, empty/loading/
       unauthorized states.
-- [ ] Component tests; browser validation in the dev container (screenshots, console
+- [x] Component tests; browser validation in the dev container (screenshots, console
       clean, gauntlet-channel only for any test traffic).
 - **Exit criteria:** report usable end-to-end against the dev container; suite green;
   PR merged to main; issue #3837 closed.
 
 ## Deviations / notes
+
+- Phase 2: a row's `fillableFields` reflect its single best donor, so fixing a row can
+  surface remaining blanks under a different donor on the next analysis (observed live:
+  fill Firmware from Sandbox → MAC Address appears with donor Florida MQTT). By design;
+  documented in the feature doc ("run again until the list drains").
+- Phase 2: shared field-label map extracted to `src/utils/nodeInfoFields.ts`;
+  `CopyNodeInfoModal` refactored to consume it (zero behavior change).
+- Phase 2: anonymous users see a non-empty analysis when the anonymous account holds
+  `nodes:read` grants (validated live: read-narrowed analysis + apply 403 fail-closed
+  with `missing` list). The empty-state hint covers the no-grants case.
+- Phase 2: component test uses a file-local `react-i18next` mock (the global test setup
+  mocks the 2-arg `t()` form; the component uses the 3-arg default-value form).
 
 - Phase 1: apply endpoint takes an explicit `items` list
   (`{nodeNum, targetSourceId, donorSourceId}[]`) so Phase 2's per-row Fix and

--- a/docs/internal/dev-notes/NODEINFO_ENRICHMENT_PHASE2_SPEC.md
+++ b/docs/internal/dev-notes/NODEINFO_ENRICHMENT_PHASE2_SPEC.md
@@ -1,0 +1,409 @@
+# NodeInfo Enrichment — Phase 2 (Frontend) Implementation Spec
+
+Epic: #3837. Branch: `feature/nodeinfo-enrichment-report`. Phase 1 backend is merged
+to `origin/main` (analysis + apply endpoints live). This phase adds the
+**"NodeInfo Enrichment"** card to the Analysis & Reports grid and its report
+component. No backend changes are in scope.
+
+Authoritative Phase 1 contract (verified against the merged code, not just the P1 spec):
+
+- **Legacy surface used by the frontend** (`src/server/routes/nodesRoutes.ts:156-157`,
+  `optionalAuth()`):
+  - `GET  /api/nodes/enrichment/analysis`
+  - `POST /api/nodes/enrichment/apply`
+- Both return the envelope `{ success: true, data: {...} }`. **`ApiService.request()`
+  returns the raw body and does NOT unwrap `data`** (CLAUDE.md gotcha) → the report
+  must read `body.data`.
+- Analysis is permission-narrowed and **never 403s**: an anonymous/limited caller gets
+  `200 { success:true, data:{ nodes:[], summary:{ nodeCount:0, targetCount:0, fieldCount:0 } } }`
+  (`enrichmentHandlers.ts` `handleEnrichmentAnalysis`).
+- Apply is fail-closed: `400 INVALID_REQUEST` (empty items), `400 INVALID_ITEM`
+  (malformed item / donor==target), `403 FORBIDDEN { missing:[{sourceId,action}] }`
+  (missing read on a donor or write on a target), `500 ENRICHMENT_APPLY_FAILED`.
+
+### Response shapes (exact)
+
+```jsonc
+// GET /api/nodes/enrichment/analysis  → 200
+{ "success": true, "data": {
+  "nodes": [
+    { "nodeNum": 123456, "nodeId": "!0001e240", "displayName": "Base Station",
+      "targets": [
+        { "targetSourceId": "src-b", "targetSourceName": "MQTT",
+          "fillableFields": ["longName","hwModel","role"],   // hasPKC never appears (P1 decision)
+          "donorSourceId": "src-a", "donorSourceName": "Primary TCP" }
+      ] }
+  ],
+  "summary": { "nodeCount": 1, "targetCount": 1, "fieldCount": 3 }
+} }
+
+// POST /api/nodes/enrichment/apply  body
+{ "items": [ { "nodeNum": 123456, "targetSourceId": "src-b", "donorSourceId": "src-a" } ],
+  "pushToNodeDb": false }
+// → 200
+{ "success": true, "data": {
+  "applied": [
+    { "nodeNum": 123456, "targetSourceId": "src-b", "donorSourceId": "src-a",
+      "copiedFields": ["longName","hwModel","role"], "pushedToDevice": false }
+  ],
+  "totalFieldsCopied": 3
+} }
+```
+
+The report's **row unit is one `(node, target)` pair**: flatten every
+`node.targets[]` into table rows. Each row already carries its own
+`nodeNum`/`targetSourceId`/`donorSourceId`, which is exactly the apply item shape —
+per-row **Fix** posts `{ items:[thatRow], pushToNodeDb }`; **Fix All** posts every
+row's item in one call.
+
+---
+
+## 1. Reuse Inventory
+
+| Mechanism | Location (file:line) | Use in Phase 2 |
+|-----------|----------------------|----------------|
+| Card-grid pattern: `AnalysisType` union + `AnalysisCard` + `reports[]` + selected-branch | `src/components/Analysis/AnalysisTab.tsx:16,29,58` | Extend, don't rewrite. Add `'nodeinfo-enrichment'` to the union, one `reports[]` entry, one selected-branch. No `VALID_TABS` change (this is a router route, not an app tab). |
+| Structural template (report layout, `useQuery`, `UiIcon`, i18n, states) | `src/components/Analysis/SolarMonitoringReport.tsx` | Copy the **shape** (`reports-section__title`, banners, `useQuery`), NOT its data layer. **Do NOT reuse its local `fetchJson` raw-`fetch` helper (`SolarMonitoringReport.tsx:107`)** — raw `fetch()` is ESLint-banned in `src/components/**`; that file is a pre-existing baselined exception. New code uses `ApiService`. |
+| `ApiService` singleton (default export `api`) with `.get<T>(endpoint)` / `.post<T>(endpoint, body)` | `src/services/api.ts` (`get` / `post` methods; `request()` auto-injects CSRF for POST, `credentials:'include'`, throws `ApiError{status,code,body}`) | **The blessed data + mutation layer.** `api.get('/api/nodes/enrichment/analysis')` and `api.post('/api/nodes/enrichment/apply', body)`. baseUrl is resolved internally (set from `appBasename` in `main.tsx`); the component does **not** need a `baseUrl` prop for calls. CSRF handled by `request()` — do **not** hand-roll `useCsrfFetch`/`csrfFetch` (that's the legacy path CopyNodeInfoModal uses). |
+| `ApiError` (typed error with `.status` / `.code` / `.message`) | `src/services/api.ts` (`export class ApiError`) | Discriminate apply failures (e.g. 403 `FORBIDDEN`) for the error toast. `useQuery`/`useMutation` surface the thrown `ApiError` as `error`. |
+| TanStack Query provider | mounted app-wide in `src/main.tsx:129` (`<QueryClientProvider client={queryClient}>` wraps the whole router) | `ReportsPage` is a route inside it → `useQuery`/`useMutation`/`useQueryClient` work in production with no extra provider. Tests must supply their own (see §3). |
+| `useToast()` → `{ showToast(message, type, duration?) }`, `type` = `ToastProps['type']` | `src/components/ToastContainer.tsx:11,22`; `ToastProvider` wraps `ReportsPage` (`src/pages/ReportsPage.tsx`) | Success/error feedback after apply. Confirm the exact `type` union in `src/components/Toast.tsx` (`'success' \| 'error' \| ...`). |
+| `UiIcon` + `UiIconName` | `src/components/icons/index.ts`; registry in `src/components/icons/UiIcon.tsx:142-242` | All icons. Valid names available include `identity` (IdCard — "node identifiers"), `copy`, `database`, `sparkles`, `refresh`, `check`, `wrench`, `link`, `info`. **No hardcoded emoji/Unicode** (CLAUDE.md hard rule). |
+| Shared analysis CSS | `src/styles/analysis-reports.css` (imported by `ReportsPage.tsx`) — classes incl. `.reports-section__title/__subtitle`, `.reports-panel`, `.reports-stats/.reports-stat/__label/__value`, `.reports-table/.reports-table-wrap`, `.reports-btn/--ghost`, `.reports-banner/--error/--empty`, `.reports-pill/--ok/--warn` | Reuse for the whole layout. Add only the few enrichment-specific classes named in §2d to this same file. |
+| Field display-name labels: local `DISPLAY_FIELDS` (`longName→"Long Name"`, etc.) | `src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx` (`const DISPLAY_FIELDS = [...] as const`) — **not exported** | **Reuse-over-duplication:** extract to a shared module (§2a) and have BOTH CopyNodeInfoModal and the new report import it, rather than the report redefining a second label map. The 8 keys match `NODE_INFO_FIELDS` in `nodeInfoCopyService.ts`. |
+| Backend-provided display name / id | analysis response fields `node.displayName`, `node.nodeId` | Render directly. **No** `nodeHelpers`/`formatNodeId` call is needed on the frontend — Phase 1 already computed these. |
+
+### New code (justified)
+- `src/components/Analysis/NodeInfoEnrichmentReport.tsx` — the report itself. No
+  existing component renders a cross-source enrichment table; SolarMonitoringReport is
+  chart-shaped and not adaptable.
+- `src/utils/nodeInfoFields.ts` — shared field-label map extracted from
+  CopyNodeInfoModal (see §2a). Justified by the reuse rule: two consumers now need it.
+- `src/components/Analysis/NodeInfoEnrichmentReport.test.tsx` — component tests.
+
+---
+
+## 2. File-by-File Changes
+
+### 2a. `src/utils/nodeInfoFields.ts` (NEW — extract shared labels)
+
+Move the label list out of CopyNodeInfoModal so both components share one source of truth.
+
+```ts
+// One label per NodeInfo field. Keys match NODE_INFO_FIELDS in nodeInfoCopyService.
+// Plain strings (matching the existing modal, which does not i18n these) — keep parity;
+// i18n of field labels is out of scope for this phase.
+export const NODE_INFO_DISPLAY_FIELDS = [
+  { key: 'longName',        label: 'Long Name' },
+  { key: 'shortName',       label: 'Short Name' },
+  { key: 'hwModel',         label: 'Hardware Model' },
+  { key: 'role',            label: 'Role' },
+  { key: 'macaddr',         label: 'MAC Address' },
+  { key: 'publicKey',       label: 'Public Key' },
+  { key: 'hasPKC',          label: 'Has PKC' },
+  { key: 'firmwareVersion', label: 'Firmware' },
+] as const;
+
+export type NodeInfoFieldKey = typeof NODE_INFO_DISPLAY_FIELDS[number]['key'];
+
+export const NODE_INFO_FIELD_LABELS: Record<NodeInfoFieldKey, string> =
+  Object.fromEntries(NODE_INFO_DISPLAY_FIELDS.map(f => [f.key, f.label])) as Record<NodeInfoFieldKey, string>;
+
+/** Map a fillableFields key to its human label, falling back to the raw key. */
+export function nodeInfoFieldLabel(key: string): string {
+  return (NODE_INFO_FIELD_LABELS as Record<string, string>)[key] ?? key;
+}
+```
+
+Then refactor **`CopyNodeInfoModal.tsx`**: delete its local `const DISPLAY_FIELDS`
+and `import { NODE_INFO_DISPLAY_FIELDS as DISPLAY_FIELDS } from '../../utils/nodeInfoFields'`
+(alias to minimize the diff). Leave `formatFieldValue`/`formatTimestamp` in the modal
+(report doesn't need them; the analysis endpoint reports field *names*, not values).
+
+> `hasPKC` never appears in `fillableFields` (Phase 1 excludes it from analysis), so the
+> report will only ever render 7 of these labels — but the map stays complete for the modal.
+
+### 2b. `src/components/Analysis/NodeInfoEnrichmentReport.tsx` (NEW)
+
+**Imports:** `useMemo, useState` (react); `useQuery, useMutation, useQueryClient` (@tanstack/react-query);
+`useTranslation` (react-i18next); `api, { ApiError }` (`../../services/api`); `useToast`
+(`../ToastContainer`); `UiIcon` (`../icons`); `nodeInfoFieldLabel` (`../../utils/nodeInfoFields`).
+
+**Types (local):**
+```ts
+interface EnrichmentTarget { targetSourceId: string; targetSourceName: string;
+  fillableFields: string[]; donorSourceId: string; donorSourceName: string; }
+interface EnrichmentNode { nodeNum: number; nodeId: string; displayName: string;
+  targets: EnrichmentTarget[]; }
+interface EnrichmentSummary { nodeCount: number; targetCount: number; fieldCount: number; }
+interface EnrichmentAnalysis { nodes: EnrichmentNode[]; summary: EnrichmentSummary; }
+interface ApplyItem { nodeNum: number; targetSourceId: string; donorSourceId: string; }
+interface ApplyResult {
+  applied: Array<ApplyItem & { copiedFields: string[]; pushedToDevice: boolean }>;
+  totalFieldsCopied: number; }
+```
+
+**Query key constant:** `const ANALYSIS_KEY = ['nodeinfo-enrichment-analysis'] as const;`
+
+**Data fetch (envelope-aware):**
+```ts
+const { data, isLoading, error, isFetching } = useQuery<EnrichmentAnalysis>({
+  queryKey: ANALYSIS_KEY,
+  queryFn: async () => {
+    const body = await api.get<{ success: boolean; data: EnrichmentAnalysis }>(
+      '/api/nodes/enrichment/analysis');
+    return body.data;              // <-- unwrap the envelope (ApiService does NOT)
+  },
+});
+```
+Fetch on mount (no `enabled` gate — unlike Solar, this report has no input params and
+is safe/cheap for any caller). A `.reports-btn--ghost` "Refresh" button calls
+`queryClient.invalidateQueries({ queryKey: ANALYSIS_KEY })`.
+
+**State:** `const [pushToNodeDb, setPushToNodeDb] = useState(false);` (toggle DEFAULT OFF).
+
+**Mutation (shared by Fix and Fix All):**
+```ts
+const qc = useQueryClient();
+const { showToast } = useToast();
+const applyMutation = useMutation<ApplyResult, ApiError, ApplyItem[]>({
+  mutationFn: async (items) => {
+    const body = await api.post<{ success: boolean; data: ApplyResult }>(
+      '/api/nodes/enrichment/apply', { items, pushToNodeDb });
+    return body.data;
+  },
+  onSuccess: (result) => {
+    const errored = result.applied.filter(a => a.copiedFields.length === 0);
+    showToast(
+      t('analysis.enrichment.apply_success',
+        'Copied {{fields}} field(s) across {{targets}} target(s)',
+        { fields: result.totalFieldsCopied, targets: result.applied.length }),
+      'success');
+    void qc.invalidateQueries({ queryKey: ANALYSIS_KEY }); // refresh → fixed rows drop out
+  },
+  onError: (err) => {
+    showToast(err?.message
+      ?? t('analysis.enrichment.apply_error', 'Failed to apply enrichment'), 'error');
+  },
+});
+```
+- **Fix (per row):** `applyMutation.mutate([row])`. Disable that row's button while
+  `applyMutation.isPending` (and track which row is in flight via a `useState<string|null>`
+  keyed by `${nodeNum}:${targetSourceId}` so only the clicked row shows a spinner label).
+- **Fix All:** `applyMutation.mutate(allRows.map(toItem))`. Disable while pending or when
+  `rows.length === 0`.
+
+> Per-item results: after success the analysis is invalidated and re-fetched, so
+> successfully-filled `(node,target)` rows disappear (their fields are no longer blank).
+> The toast reports `totalFieldsCopied` + count. A row that copied 0 fields (raced/already
+> filled) simply remains — no destructive UI needed. This satisfies "show per-item
+> results + refresh + toast" without a bespoke results panel.
+
+**Derived rows:**
+```ts
+const rows = useMemo(() =>
+  (data?.nodes ?? []).flatMap(n =>
+    n.targets.map(tg => ({ ...tg, nodeNum: n.nodeNum, nodeId: n.nodeId,
+      displayName: n.displayName,
+      rowKey: `${n.nodeNum}:${tg.targetSourceId}` }))), [data]);
+```
+
+**Render branches (in order):**
+1. **Loading** (`isLoading`): `.reports-banner` "Analyzing NodeInfo across sources…".
+2. **Error** (`error`): `.reports-banner reports-banner--error` with `(error as Error).message`.
+3. **Empty** (`rows.length === 0`): `.reports-banner reports-banner--empty` —
+   primary line `t('analysis.enrichment.empty','No nodes need enrichment.')`, plus a muted
+   secondary line covering the anonymous/limited case (see §Anonymous below).
+4. **Populated:** summary stats + push toggle + Fix All + table.
+
+**Header/summary** (reuse `reports-section__title/__subtitle`, `reports-stats`):
+```
+<h2 className="reports-section__title"><UiIcon name="identity" size={22}/> NodeInfo Enrichment</h2>
+<p className="reports-section__subtitle">Fill blank NodeInfo fields for nodes seen on
+   multiple sources, copying from the source that already has the data.</p>
+<div className="reports-stats">
+  reports-stat: summary.nodeCount  "Nodes"
+  reports-stat: summary.targetCount "Targets"
+  reports-stat: summary.fieldCount  "Fillable fields"
+</div>
+```
+
+**Controls row** (`.reports-panel` / `.reports-controls`):
+- Push toggle: `<label><input type="checkbox" checked={pushToNodeDb}
+  onChange={e=>setPushToNodeDb(e.target.checked)} disabled={applyMutation.isPending}/>
+  Also push to device NodeDB</label>` + muted help text. (Mirrors CopyNodeInfoModal's
+  `copy-nodeinfo-push-option`.)
+- Fix All button (`.reports-btn`), `<UiIcon name="sparkles"/>`, disabled when
+  `applyMutation.isPending || rows.length===0`.
+- Refresh button (`.reports-btn--ghost`), `<UiIcon name="refresh"/>`, disabled while
+  `isFetching`.
+
+**Table** (`.reports-table-wrap` > `<table className="reports-table">`): columns
+| Node | Target source | Fillable fields | Donor source | Action |. Per row:
+- Node cell: `{displayName}` bold + `{nodeId}` in a muted `<span>` (reuse
+  `.reports-node__name` / a muted class or inline `.reports-node__meta`).
+- Fillable fields: map `fillableFields` to `<span className="reports-pill">` per
+  `nodeInfoFieldLabel(f)`.
+- Action: Fix button (`.reports-btn`), `<UiIcon name="copy"/>`, label switches to
+  "Fixing…" when that row is the in-flight one; `disabled={applyMutation.isPending}`.
+
+**Props:** none. AnalysisTab renders `<NodeInfoEnrichmentReport />` (no `baseUrl` prop —
+ApiService owns the base path). This avoids an unused-var lint hit.
+
+**exhaustive-deps:** the only `useMemo` dep is `data`; `mutationFn`/callbacks close over
+`pushToNodeDb`/`t`/`qc`/`showToast` which are stable or intentionally captured — keep
+deps honest, do NOT add an `eslint-disable`. (react-hooks/exhaustive-deps is a frozen
+ratchet rule; new violations fail CI.)
+
+### 2c. `src/components/Analysis/AnalysisTab.tsx` (MODIFY — register the card)
+
+- `import NodeInfoEnrichmentReport from './NodeInfoEnrichmentReport';`
+- Union: `type AnalysisType = 'solar-monitoring' | 'nodeinfo-enrichment' | null;`
+- Add to `reports[]`:
+  ```ts
+  { id: 'nodeinfo-enrichment',
+    title: t('analysis.enrichment.title', 'NodeInfo Enrichment'),
+    description: t('analysis.enrichment.description',
+      'Fill blank NodeInfo fields (name, hardware, role, …) for nodes seen on multiple sources by copying from a source that already has the data.'),
+    icon: 'identity' },
+  ```
+- Add selected-branch (mirror the solar branch, `.reports-section` + back button):
+  ```tsx
+  if (selected === 'nodeinfo-enrichment') {
+    return (
+      <div className="reports-section">
+        <button type="button" className="reports-section__back" onClick={() => setSelected(null)}>
+          <UiIcon name="back" size={16} /> {t('analysis.back_to_reports', 'Back to reports')}
+        </button>
+        <NodeInfoEnrichmentReport />
+      </div>
+    );
+  }
+  ```
+  (`baseUrl` prop stays on `AnalysisTab` for Solar; the new report ignores it.)
+
+### 2d. `src/styles/analysis-reports.css` (MODIFY — additive only)
+
+Most styling reuses existing classes. Add only what's missing (append near the other
+`.reports-*` rules):
+- `.reports-enrichment__push` — inline-flex label + help text for the push toggle (or
+  reuse the layout of `.reports-controls__field`; prefer reuse and skip this if it fits).
+- Ensure `.reports-pill` is legible as a field chip (it already exists for solar); if a
+  tighter chip is wanted, add `.reports-field-pill` (small, muted background). Keep new
+  classes to a minimum — reuse `.reports-pill` if acceptable.
+No new CSS file; everything lands in `analysis-reports.css` (the file ReportsPage imports).
+
+### Anonymous / no-permission presentation (decision)
+
+`ReportsPage` is a **public route** and analysis **never 403s** — anonymous and
+permission-limited callers both get an empty `nodes:[]`. There is no reliable signal on
+this endpoint to distinguish "nothing to enrich" from "you can't see enough sources".
+**Decision:** a single empty state (branch 3 above) with two lines:
+- Primary: `No nodes need enrichment.`
+- Muted secondary (`analysis.enrichment.empty_hint`): `Enrichment compares NodeInfo
+  across the sources you can read. If you're signed out or only have access to one
+  source, sign in to see more.`
+
+This is honest without over-engineering (no extra auth probe, no new endpoint). Do NOT
+special-case a "403/unauthorized" branch — the endpoint contract makes it unreachable
+for analysis; apply-time 403s surface via the error toast.
+
+---
+
+## 3. Test Plan
+
+**File:** `src/components/Analysis/NodeInfoEnrichmentReport.test.tsx` (NEW). Vitest +
+`@testing-library/react`. No existing Analysis component test exists; follow the
+QueryClient-wrapper pattern from `src/hooks/useElevationEnabled.test.tsx:18-19` and the
+`vi.mock('../../services/api')` pattern from
+`src/components/configuration/BackupManagementSection.test.tsx`.
+
+**Mocking the API layer** — mock the default export `api` (and `ApiError`):
+```ts
+vi.mock('../../services/api', async (orig) => {
+  const actual = await orig<typeof import('../../services/api')>();
+  return { __esModule: true, default: { get: vi.fn(), post: vi.fn() }, ApiError: actual.ApiError };
+});
+import api from '../../services/api';
+```
+Return the **enveloped** shape from the mock (`{ success:true, data:{...} }`) so the test
+also guards the `body.data` unwrap.
+
+**Render harness** — wrap in a fresh `QueryClient` (retry:false) + `ToastProvider`
+(component calls `useToast`), because the app-level providers from `main.tsx` aren't
+present in a unit test:
+```tsx
+function renderReport() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider><NodeInfoEnrichmentReport /></ToastProvider>
+    </QueryClientProvider>);
+}
+```
+
+**Cases:**
+1. **Loading** → mock `get` to a pending promise; assert the loading banner renders.
+2. **Empty** → `get` resolves `{success:true,data:{nodes:[],summary:{0,0,0}}}`; assert
+   the empty banner + the muted hint line render; no table.
+3. **Populated + summary** → resolve one node / one target with
+   `fillableFields:['longName','hwModel','role']`; assert `displayName`, `nodeId`, the
+   readable field labels ("Long Name","Hardware Model","Role") via `nodeInfoFieldLabel`,
+   donor + target source names, and summary counts (1/1/3) render.
+4. **Fix (single row)** → `post` resolves the applied result; click the row's Fix button;
+   assert `api.post` called once with
+   `{ items:[{nodeNum,targetSourceId,donorSourceId}], pushToNodeDb:false }`; assert a
+   success toast text appears; assert `api.get` re-invoked (invalidation → refetch).
+5. **Push toggle wiring** → toggle the checkbox on, click Fix; assert `post` body has
+   `pushToNodeDb:true`. Assert default is `false` (case 4 already covers off).
+6. **Fix All** → two rows across ≥1 node; click Fix All; assert `post` called once with
+   an `items` array of length 2 (order-independent) containing both rows' items.
+7. **Apply error** → `post` rejects with `new ApiError('Insufficient permission',403,{code:'FORBIDDEN'})`;
+   click Fix; assert an error toast surfaces the message and the table stays intact.
+8. **Error state** → `get` rejects; assert the error banner renders the message.
+
+Use `await screen.findBy…` / `waitFor` for the async query/mutation settles; use
+`userEvent` for clicks/toggles. Keep to gauntlet-safe, no-network unit tests (all IO
+mocked).
+
+**Regression guard for the extraction (2a):** the existing CopyNodeInfoModal test suite
+(if present) must still pass after the `DISPLAY_FIELDS` import swap; run it. No new modal
+test is required — the labels are identical, only their definition site moved.
+
+---
+
+## 4. Work Packages (Sonnet implementers)
+
+### WP-1 — Shared field labels + CSS foundation
+**Scope:** `src/utils/nodeInfoFields.ts` (new, §2a); refactor
+`src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx` to import it (delete local
+`DISPLAY_FIELDS`); additive CSS in `src/styles/analysis-reports.css` (§2d).
+**Depends on:** nothing.
+**Acceptance:**
+- `nodeInfoFields.ts` exports `NODE_INFO_DISPLAY_FIELDS`, `NODE_INFO_FIELD_LABELS`,
+  `nodeInfoFieldLabel`, `NodeInfoFieldKey`.
+- CopyNodeInfoModal renders identically (same labels, same order); its existing tests
+  (and `tsc`) pass.
+- No raw-`fetch`/raw-SQL/lint-ratchet regressions (`npm run lint:ci` clean for touched
+  files; see CLAUDE.md worktree caveat).
+
+### WP-2 — NodeInfoEnrichmentReport + registration + tests
+**Scope:** `src/components/Analysis/NodeInfoEnrichmentReport.tsx` (§2b),
+`AnalysisTab.tsx` registration (§2c), `NodeInfoEnrichmentReport.test.tsx` (§3).
+**Depends on:** WP-1 (imports `nodeInfoFieldLabel`).
+**Acceptance:**
+- Card appears in the Analysis & Reports grid with the `identity` icon; selecting it
+  renders the report with a working Back button.
+- Report fetches via `api.get`, unwraps `body.data`, and mutates via `api.post` (no raw
+  `fetch`, no `csrfFetch`); CSRF is handled by ApiService.
+- Loading / error / empty (with anonymous hint) / populated states all render per §2b.
+- Per-row **Fix** posts a single-item batch; **Fix All** posts all items; push toggle
+  defaults OFF and controls `pushToNodeDb`; success invalidates the analysis query and
+  toasts; apply errors toast the message.
+- All 8 test cases (§3) pass; full Vitest suite green (0 failures); `tsc` clean;
+  `npm run lint:ci` clean for touched files (exhaustive-deps honest, no new
+  `no-explicit-any`/raw-`fetch` baseline growth).
+
+**Out of scope (all packages):** scheduler, settings keys, any backend/route/service
+change, i18n of the field-label strings, browser/dev-container validation (done later by
+the epic runner).

--- a/src/components/Analysis/AnalysisTab.tsx
+++ b/src/components/Analysis/AnalysisTab.tsx
@@ -7,9 +7,10 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import SolarMonitoringReport from './SolarMonitoringReport';
+import NodeInfoEnrichmentReport from './NodeInfoEnrichmentReport';
 import { UiIcon, type UiIconName } from '../icons';
 
-type AnalysisType = 'solar-monitoring' | null;
+type AnalysisType = 'solar-monitoring' | 'nodeinfo-enrichment' | null;
 
 interface AnalysisCard {
   id: Exclude<AnalysisType, null>;
@@ -36,6 +37,15 @@ const AnalysisTab: React.FC<AnalysisTabProps> = ({ baseUrl }) => {
       ),
       icon: 'sun',
     },
+    {
+      id: 'nodeinfo-enrichment',
+      title: t('analysis.enrichment.title', 'NodeInfo Enrichment'),
+      description: t(
+        'analysis.enrichment.description',
+        'Fill blank NodeInfo fields (name, hardware, role, …) for nodes seen on multiple sources by copying from a source that already has the data.',
+      ),
+      icon: 'identity',
+    },
   ];
 
   if (selected === 'solar-monitoring') {
@@ -49,6 +59,21 @@ const AnalysisTab: React.FC<AnalysisTabProps> = ({ baseUrl }) => {
           <UiIcon name="back" size={16} /> {t('analysis.back_to_reports', 'Back to reports')}
         </button>
         <SolarMonitoringReport baseUrl={baseUrl} />
+      </div>
+    );
+  }
+
+  if (selected === 'nodeinfo-enrichment') {
+    return (
+      <div className="reports-section">
+        <button
+          type="button"
+          className="reports-section__back"
+          onClick={() => setSelected(null)}
+        >
+          <UiIcon name="back" size={16} /> {t('analysis.back_to_reports', 'Back to reports')}
+        </button>
+        <NodeInfoEnrichmentReport />
       </div>
     );
   }

--- a/src/components/Analysis/NodeInfoEnrichmentReport.test.tsx
+++ b/src/components/Analysis/NodeInfoEnrichmentReport.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * NodeInfoEnrichmentReport — cross-source NodeInfo enrichment analysis + apply
+ * (#3837 Phase 2 WP-2). Covers loading/error/empty/populated states, per-row
+ * Fix, Fix All, the push-to-NodeDB toggle, and apply-error surfacing.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Override the global i18n mock (src/test/setup.ts) — that mock's `t(key, options)`
+// signature doesn't understand this component's real i18next-style
+// `t(key, defaultValue, options)` calls, so string assertions here need a
+// local mock that returns the default value (with {{var}} interpolation from
+// the options arg), matching the AutoPingSection.test.tsx precedent.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string, options?: Record<string, unknown>) => {
+      let result = typeof defaultValue === 'string' ? defaultValue : key;
+      if (options) {
+        Object.entries(options).forEach(([k, v]) => {
+          result = result.replace(`{{${k}}}`, String(v));
+        });
+      }
+      return result;
+    },
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+vi.mock('../../services/api', async (orig) => {
+  const actual = await orig<typeof import('../../services/api')>();
+  return {
+    __esModule: true,
+    default: { get: vi.fn(), post: vi.fn() },
+    ApiError: actual.ApiError,
+  };
+});
+
+import api, { ApiError } from '../../services/api';
+import { ToastProvider } from '../ToastContainer';
+import NodeInfoEnrichmentReport from './NodeInfoEnrichmentReport';
+
+function renderReport() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <NodeInfoEnrichmentReport />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const emptyAnalysis = {
+  success: true,
+  data: { nodes: [], summary: { nodeCount: 0, targetCount: 0, fieldCount: 0 } },
+};
+
+function oneNodeAnalysis() {
+  return {
+    success: true,
+    data: {
+      nodes: [
+        {
+          nodeNum: 123456,
+          nodeId: '!0001e240',
+          displayName: 'Base Station',
+          targets: [
+            {
+              targetSourceId: 'src-b',
+              targetSourceName: 'MQTT',
+              fillableFields: ['longName', 'hwModel', 'role'],
+              donorSourceId: 'src-a',
+              donorSourceName: 'Primary TCP',
+            },
+          ],
+        },
+      ],
+      summary: { nodeCount: 1, targetCount: 1, fieldCount: 3 },
+    },
+  };
+}
+
+function twoRowAnalysis() {
+  return {
+    success: true,
+    data: {
+      nodes: [
+        {
+          nodeNum: 111,
+          nodeId: '!0000006f',
+          displayName: 'Node A',
+          targets: [
+            {
+              targetSourceId: 'src-b',
+              targetSourceName: 'MQTT',
+              fillableFields: ['longName'],
+              donorSourceId: 'src-a',
+              donorSourceName: 'Primary TCP',
+            },
+          ],
+        },
+        {
+          nodeNum: 222,
+          nodeId: '!000000de',
+          displayName: 'Node B',
+          targets: [
+            {
+              targetSourceId: 'src-c',
+              targetSourceName: 'MeshCore',
+              fillableFields: ['hwModel'],
+              donorSourceId: 'src-a',
+              donorSourceName: 'Primary TCP',
+            },
+          ],
+        },
+      ],
+      summary: { nodeCount: 2, targetCount: 2, fieldCount: 2 },
+    },
+  };
+}
+
+describe('NodeInfoEnrichmentReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the loading banner while the analysis query is pending', async () => {
+    vi.mocked(api.get).mockReturnValue(new Promise(() => {}));
+    renderReport();
+    expect(await screen.findByText(/Analyzing NodeInfo across sources/i)).toBeInTheDocument();
+  });
+
+  it('renders the empty state with the muted sign-in hint when there are no rows', async () => {
+    vi.mocked(api.get).mockResolvedValue(emptyAnalysis);
+    renderReport();
+    expect(await screen.findByText(/No nodes need enrichment\./i)).toBeInTheDocument();
+    expect(screen.getByText(/sign in to see more/i)).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders populated rows, field labels, source names, and summary counts', async () => {
+    vi.mocked(api.get).mockResolvedValue(oneNodeAnalysis());
+    const { container } = renderReport();
+
+    expect(await screen.findByText('Base Station')).toBeInTheDocument();
+    expect(screen.getByText('!0001e240')).toBeInTheDocument();
+    expect(screen.getByText('Long Name')).toBeInTheDocument();
+    expect(screen.getByText('Hardware Model')).toBeInTheDocument();
+    expect(screen.getByText('Role')).toBeInTheDocument();
+    expect(screen.getByText('MQTT')).toBeInTheDocument();
+    expect(screen.getByText('Primary TCP')).toBeInTheDocument();
+
+    // summary stats: 1 node / 1 target / 3 fillable fields
+    const statValues = Array.from(container.querySelectorAll('.reports-stat__value')).map(
+      (el) => el.textContent,
+    );
+    expect(statValues).toEqual(['1', '1', '3']);
+  });
+
+  it('Fix posts a single-item batch with pushToNodeDb:false by default and refetches on success', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue(oneNodeAnalysis());
+    vi.mocked(api.post).mockResolvedValue({
+      success: true,
+      data: {
+        applied: [
+          {
+            nodeNum: 123456,
+            targetSourceId: 'src-b',
+            donorSourceId: 'src-a',
+            copiedFields: ['longName', 'hwModel', 'role'],
+            pushedToDevice: false,
+          },
+        ],
+        totalFieldsCopied: 3,
+      },
+    });
+
+    renderReport();
+    await screen.findByText('Base Station');
+
+    await user.click(screen.getByRole('button', { name: /^Fix$/i }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    expect(api.post).toHaveBeenCalledWith('/api/nodes/enrichment/apply', {
+      items: [{ nodeNum: 123456, targetSourceId: 'src-b', donorSourceId: 'src-a' }],
+      pushToNodeDb: false,
+    });
+
+    expect(await screen.findByText(/Copied 3 field\(s\) across 1 target\(s\)/i)).toBeInTheDocument();
+    // invalidation causes a refetch of the analysis query
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('toggling the push option sends pushToNodeDb:true in the apply body', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue(oneNodeAnalysis());
+    vi.mocked(api.post).mockResolvedValue({
+      success: true,
+      data: {
+        applied: [
+          {
+            nodeNum: 123456,
+            targetSourceId: 'src-b',
+            donorSourceId: 'src-a',
+            copiedFields: ['longName'],
+            pushedToDevice: true,
+          },
+        ],
+        totalFieldsCopied: 1,
+      },
+    });
+
+    renderReport();
+    await screen.findByText('Base Station');
+
+    const toggle = screen.getByRole('checkbox', { name: /Also push to device NodeDB/i });
+    expect(toggle).not.toBeChecked();
+    await user.click(toggle);
+    expect(toggle).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /^Fix$/i }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    expect(api.post).toHaveBeenCalledWith('/api/nodes/enrichment/apply', {
+      items: [{ nodeNum: 123456, targetSourceId: 'src-b', donorSourceId: 'src-a' }],
+      pushToNodeDb: true,
+    });
+  });
+
+  it('Fix All posts every row item in one batch call', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue(twoRowAnalysis());
+    vi.mocked(api.post).mockResolvedValue({
+      success: true,
+      data: {
+        applied: [
+          { nodeNum: 111, targetSourceId: 'src-b', donorSourceId: 'src-a', copiedFields: ['longName'], pushedToDevice: false },
+          { nodeNum: 222, targetSourceId: 'src-c', donorSourceId: 'src-a', copiedFields: ['hwModel'], pushedToDevice: false },
+        ],
+        totalFieldsCopied: 2,
+      },
+    });
+
+    renderReport();
+    await screen.findByText('Node A');
+    await screen.findByText('Node B');
+
+    await user.click(screen.getByRole('button', { name: /Fix All/i }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    const [, body] = vi.mocked(api.post).mock.calls[0];
+    expect(body.items).toHaveLength(2);
+    expect(body.items).toEqual(
+      expect.arrayContaining([
+        { nodeNum: 111, targetSourceId: 'src-b', donorSourceId: 'src-a' },
+        { nodeNum: 222, targetSourceId: 'src-c', donorSourceId: 'src-a' },
+      ]),
+    );
+  });
+
+  it('surfaces an apply error via toast and keeps the table intact', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue(oneNodeAnalysis());
+    vi.mocked(api.post).mockRejectedValue(
+      new ApiError('Insufficient permission', 403, { code: 'FORBIDDEN' }),
+    );
+
+    renderReport();
+    await screen.findByText('Base Station');
+
+    await user.click(screen.getByRole('button', { name: /^Fix$/i }));
+
+    expect(await screen.findByText('Insufficient permission')).toBeInTheDocument();
+    expect(screen.getByText('Base Station')).toBeInTheDocument();
+  });
+
+  it('renders the error banner when the analysis query rejects', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network exploded'));
+    renderReport();
+    expect(await screen.findByText(/network exploded/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Analysis/NodeInfoEnrichmentReport.tsx
+++ b/src/components/Analysis/NodeInfoEnrichmentReport.tsx
@@ -1,0 +1,294 @@
+/**
+ * NodeInfoEnrichmentReport — cross-source NodeInfo enrichment analysis + apply.
+ *
+ * Finds nodes seen on multiple sources where one source is missing NodeInfo
+ * fields (longName, hwModel, role, ...) that another source already has, and
+ * lets the user copy the missing fields over — per-row or in bulk.
+ *
+ * Backend contract (Phase 1, #3837):
+ *  - GET  /api/nodes/enrichment/analysis  -> { success, data: EnrichmentAnalysis }
+ *  - POST /api/nodes/enrichment/apply     -> { success, data: ApplyResult }
+ * `ApiService.request()` returns the raw envelope and does NOT unwrap `data`
+ * (CLAUDE.md gotcha) — every call here reads `body.data` explicitly.
+ */
+import { useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import api, { ApiError } from '../../services/api';
+import { useToast } from '../ToastContainer';
+import { UiIcon } from '../icons';
+import { nodeInfoFieldLabel } from '../../utils/nodeInfoFields';
+
+interface EnrichmentTarget {
+  targetSourceId: string;
+  targetSourceName: string;
+  fillableFields: string[];
+  donorSourceId: string;
+  donorSourceName: string;
+}
+
+interface EnrichmentNode {
+  nodeNum: number;
+  nodeId: string;
+  displayName: string;
+  targets: EnrichmentTarget[];
+}
+
+interface EnrichmentSummary {
+  nodeCount: number;
+  targetCount: number;
+  fieldCount: number;
+}
+
+interface EnrichmentAnalysis {
+  nodes: EnrichmentNode[];
+  summary: EnrichmentSummary;
+}
+
+interface ApplyItem {
+  nodeNum: number;
+  targetSourceId: string;
+  donorSourceId: string;
+}
+
+interface ApplyResult {
+  applied: Array<ApplyItem & { copiedFields: string[]; pushedToDevice: boolean }>;
+  totalFieldsCopied: number;
+}
+
+const ANALYSIS_KEY = ['nodeinfo-enrichment-analysis'] as const;
+
+interface EnrichmentRow extends EnrichmentTarget {
+  nodeNum: number;
+  nodeId: string;
+  displayName: string;
+  rowKey: string;
+}
+
+const NodeInfoEnrichmentReport: React.FC = () => {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const { showToast } = useToast();
+  const [pushToNodeDb, setPushToNodeDb] = useState(false);
+  const [inFlightRowKey, setInFlightRowKey] = useState<string | null>(null);
+
+  const { data, isLoading, error, isFetching } = useQuery<EnrichmentAnalysis>({
+    queryKey: ANALYSIS_KEY,
+    queryFn: async () => {
+      const body = await api.get<{ success: boolean; data: EnrichmentAnalysis }>(
+        '/api/nodes/enrichment/analysis',
+      );
+      return body.data; // envelope not unwrapped by ApiService
+    },
+  });
+
+  const applyMutation = useMutation<ApplyResult, ApiError, ApplyItem[]>({
+    mutationFn: async (items) => {
+      const body = await api.post<{ success: boolean; data: ApplyResult }>(
+        '/api/nodes/enrichment/apply',
+        { items, pushToNodeDb },
+      );
+      return body.data;
+    },
+    onSuccess: (result) => {
+      showToast(
+        t(
+          'analysis.enrichment.apply_success',
+          'Copied {{fields}} field(s) across {{targets}} target(s)',
+          { fields: result.totalFieldsCopied, targets: result.applied.length },
+        ),
+        'success',
+      );
+      void qc.invalidateQueries({ queryKey: ANALYSIS_KEY });
+    },
+    onError: (err) => {
+      showToast(
+        err?.message ?? t('analysis.enrichment.apply_error', 'Failed to apply enrichment'),
+        'error',
+      );
+    },
+    onSettled: () => {
+      setInFlightRowKey(null);
+    },
+  });
+
+  const rows = useMemo<EnrichmentRow[]>(
+    () =>
+      (data?.nodes ?? []).flatMap((n) =>
+        n.targets.map((tg) => ({
+          ...tg,
+          nodeNum: n.nodeNum,
+          nodeId: n.nodeId,
+          displayName: n.displayName,
+          rowKey: `${n.nodeNum}:${tg.targetSourceId}`,
+        })),
+      ),
+    [data],
+  );
+
+  const toApplyItem = (row: EnrichmentRow): ApplyItem => ({
+    nodeNum: row.nodeNum,
+    targetSourceId: row.targetSourceId,
+    donorSourceId: row.donorSourceId,
+  });
+
+  const handleFixRow = (row: EnrichmentRow) => {
+    setInFlightRowKey(row.rowKey);
+    applyMutation.mutate([toApplyItem(row)]);
+  };
+
+  const handleFixAll = () => {
+    setInFlightRowKey(null);
+    applyMutation.mutate(rows.map(toApplyItem));
+  };
+
+  const summary = data?.summary;
+
+  return (
+    <>
+      <div>
+        <h2 className="reports-section__title">
+          <UiIcon name="identity" size={22} />
+          {t('analysis.enrichment.title', 'NodeInfo Enrichment')}
+        </h2>
+        <p className="reports-section__subtitle">
+          {t(
+            'analysis.enrichment.description',
+            'Fill blank NodeInfo fields (name, hardware, role, …) for nodes seen on multiple sources by copying from a source that already has the data.',
+          )}
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="reports-banner">
+          {t('analysis.enrichment.loading', 'Analyzing NodeInfo across sources…')}
+        </div>
+      )}
+
+      {error && (
+        <div className="reports-banner reports-banner--error">
+          {(error as Error).message}
+        </div>
+      )}
+
+      {!isLoading && !error && rows.length === 0 && (
+        <div className="reports-banner reports-banner--empty">
+          <div>{t('analysis.enrichment.empty', 'No nodes need enrichment.')}</div>
+          <div className="reports-banner__hint">
+            {t(
+              'analysis.enrichment.empty_hint',
+              "Enrichment compares NodeInfo across the sources you can read. If you're signed out or only have access to one source, sign in to see more.",
+            )}
+          </div>
+        </div>
+      )}
+
+      {!isLoading && !error && rows.length > 0 && (
+        <>
+          <div className="reports-stats">
+            <Stat label={t('analysis.enrichment.stat_nodes', 'Nodes')} value={String(summary?.nodeCount ?? 0)} />
+            <Stat label={t('analysis.enrichment.stat_targets', 'Targets')} value={String(summary?.targetCount ?? 0)} />
+            <Stat label={t('analysis.enrichment.stat_fields', 'Fillable fields')} value={String(summary?.fieldCount ?? 0)} />
+          </div>
+
+          <div className="reports-panel">
+            <div className="reports-controls">
+              <div className="reports-enrichment__push">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={pushToNodeDb}
+                    onChange={(e) => setPushToNodeDb(e.target.checked)}
+                    disabled={applyMutation.isPending}
+                  />
+                  {t('analysis.enrichment.push_to_device', 'Also push to device NodeDB')}
+                </label>
+                <span className="reports-enrichment__push-help">
+                  {t(
+                    'analysis.enrichment.push_to_device_help',
+                    'Sends the copied fields to the target device over the mesh, in addition to updating the local database.',
+                  )}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="reports-btn"
+                onClick={handleFixAll}
+                disabled={applyMutation.isPending || rows.length === 0}
+              >
+                <UiIcon name="sparkles" size={16} />
+                {applyMutation.isPending && inFlightRowKey === null
+                  ? t('analysis.enrichment.fixing_all', 'Fixing…')
+                  : t('analysis.enrichment.fix_all', 'Fix All')}
+              </button>
+              <button
+                type="button"
+                className="reports-btn reports-btn--ghost"
+                onClick={() => void qc.invalidateQueries({ queryKey: ANALYSIS_KEY })}
+                disabled={isFetching}
+              >
+                <UiIcon name="refresh" size={16} />
+                {t('analysis.enrichment.refresh', 'Refresh')}
+              </button>
+            </div>
+          </div>
+
+          <div className="reports-table-wrap">
+            <table className="reports-table">
+              <thead>
+                <tr>
+                  <th>{t('analysis.enrichment.col_node', 'Node')}</th>
+                  <th>{t('analysis.enrichment.col_target', 'Target source')}</th>
+                  <th>{t('analysis.enrichment.col_fields', 'Fillable fields')}</th>
+                  <th>{t('analysis.enrichment.col_donor', 'Donor source')}</th>
+                  <th>{t('analysis.enrichment.col_action', 'Action')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.rowKey}>
+                    <td>
+                      <div className="reports-node__name">{row.displayName}</div>
+                      <div className="reports-node__meta">{row.nodeId}</div>
+                    </td>
+                    <td>{row.targetSourceName}</td>
+                    <td>
+                      {row.fillableFields.map((f) => (
+                        <span key={f} className="reports-field-pill">
+                          {nodeInfoFieldLabel(f)}
+                        </span>
+                      ))}
+                    </td>
+                    <td>{row.donorSourceName}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="reports-btn"
+                        onClick={() => handleFixRow(row)}
+                        disabled={applyMutation.isPending}
+                      >
+                        <UiIcon name="copy" size={14} />
+                        {applyMutation.isPending && inFlightRowKey === row.rowKey
+                          ? t('analysis.enrichment.fixing', 'Fixing…')
+                          : t('analysis.enrichment.fix', 'Fix')}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+
+const Stat: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="reports-stat">
+    <div className="reports-stat__label">{label}</div>
+    <div className="reports-stat__value">{value}</div>
+  </div>
+);
+
+export default NodeInfoEnrichmentReport;

--- a/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
+++ b/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
@@ -4,6 +4,7 @@ import Modal from '../common/Modal';
 import { useSource } from '../../contexts/SourceContext';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import api from '../../services/api';
+import { NODE_INFO_DISPLAY_FIELDS as DISPLAY_FIELDS } from '../../utils/nodeInfoFields';
 import './CopyNodeInfoModal.css';
 
 interface CopyCandidate {
@@ -44,17 +45,6 @@ interface CopyNodeInfoModalProps {
   onClose: () => void;
   onCopied: () => void;
 }
-
-const DISPLAY_FIELDS = [
-  { key: 'longName', label: 'Long Name' },
-  { key: 'shortName', label: 'Short Name' },
-  { key: 'hwModel', label: 'Hardware Model' },
-  { key: 'role', label: 'Role' },
-  { key: 'macaddr', label: 'MAC Address' },
-  { key: 'publicKey', label: 'Public Key' },
-  { key: 'hasPKC', label: 'Has PKC' },
-  { key: 'firmwareVersion', label: 'Firmware' },
-] as const;
 
 function formatFieldValue(key: string, value: unknown): string {
   if (value === null || value === undefined || value === '') return '—';

--- a/src/styles/analysis-reports.css
+++ b/src/styles/analysis-reports.css
@@ -260,6 +260,13 @@
   padding: 36px 16px;
 }
 
+.reports-banner__hint {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--ctp-subtext0);
+  opacity: 0.85;
+}
+
 /* ── Stat tiles (summary row) ───────────────────────────────────────────── */
 
 .reports-stats {

--- a/src/styles/analysis-reports.css
+++ b/src/styles/analysis-reports.css
@@ -523,3 +523,37 @@
   gap: 12px;
   flex-wrap: wrap;
 }
+
+/* ── NodeInfo Enrichment report (#3837 Phase 2) ─────────────────────────── */
+
+.reports-enrichment__push {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reports-enrichment__push label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ctp-text);
+  cursor: pointer;
+}
+
+.reports-enrichment__push .reports-enrichment__push-help {
+  font-size: 11px;
+  color: var(--ctp-subtext0);
+  margin-left: 24px;
+}
+
+.reports-field-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  margin: 2px 4px 2px 0;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--ctp-surface0);
+  color: var(--ctp-subtext1);
+}

--- a/src/utils/nodeInfoFields.ts
+++ b/src/utils/nodeInfoFields.ts
@@ -1,0 +1,23 @@
+// One label per NodeInfo field. Keys match NODE_INFO_FIELDS in nodeInfoCopyService.
+// Plain strings (matching the existing modal, which does not i18n these) — keep parity;
+// i18n of field labels is out of scope for this phase.
+export const NODE_INFO_DISPLAY_FIELDS = [
+  { key: 'longName',        label: 'Long Name' },
+  { key: 'shortName',       label: 'Short Name' },
+  { key: 'hwModel',         label: 'Hardware Model' },
+  { key: 'role',            label: 'Role' },
+  { key: 'macaddr',         label: 'MAC Address' },
+  { key: 'publicKey',       label: 'Public Key' },
+  { key: 'hasPKC',          label: 'Has PKC' },
+  { key: 'firmwareVersion', label: 'Firmware' },
+] as const;
+
+export type NodeInfoFieldKey = typeof NODE_INFO_DISPLAY_FIELDS[number]['key'];
+
+export const NODE_INFO_FIELD_LABELS: Record<NodeInfoFieldKey, string> =
+  Object.fromEntries(NODE_INFO_DISPLAY_FIELDS.map(f => [f.key, f.label])) as Record<NodeInfoFieldKey, string>;
+
+/** Map a fillableFields key to its human label, falling back to the raw key. */
+export function nodeInfoFieldLabel(key: string): string {
+  return (NODE_INFO_FIELD_LABELS as Record<string, string>)[key] ?? key;
+}


### PR DESCRIPTION
## Summary
Phase 2 (final) of the NodeInfo Enrichment epic. Adds the "NodeInfo Enrichment" card to the Analysis & Reports page: an interactive report that scans every node seen on multiple sources for blank NodeInfo fields another source can fill, and applies the enrichment per-row ("Fix") or in bulk ("Fix All") via the Phase 1 API (#4287). This delivers the interactive scope agreed for #3837 (the issue's scheduled automation was explicitly deferred).

## Changes
- New `src/components/Analysis/NodeInfoEnrichmentReport.tsx`: TanStack `useQuery`/`useMutation` over `ApiService` (`api.get`/`api.post`, envelope `data` unwrapped — no raw `fetch`), summary tiles, table of (node, target source) rows with field-label pills and best-donor source, per-row Fix + Fix All sharing one mutation, "Also push to device NodeDB" toggle default OFF, loading/error/empty states with a sign-in hint, query invalidation + toasts on apply.
- Card registered in `AnalysisTab.tsx` (`AnalysisType` union + `reports[]` + selected branch, `UiIcon name="identity"`).
- Shared field-label map extracted to `src/utils/nodeInfoFields.ts`; `CopyNodeInfoModal` refactored to consume it (zero behavior change).
- Additive CSS in `analysis-reports.css` (`.reports-field-pill`, `.reports-enrichment__push`, `.reports-banner__hint`).
- Feature docs: new NodeInfo Enrichment section in `docs/features/analysis-reports.md` incl. permissions and API subsections; epic plan updated.

## Issues Resolved
Fixes #3837 (Phase 2 of 2; Phase 1 backend merged in #4287)

## Documentation Updates
`docs/features/analysis-reports.md` (new report section), `docs/internal/dev-notes/NODEINFO_ENRICHMENT_EPIC.md` (Phase 2 checked off + deviations). VitePress sidebar unchanged (single-page entry).

## Testing
- [x] Full Vitest suite green: 10,987 tests, 0 failures, `success: true` via JSON reporter (651 pending = PG/MySQL container suites; no schema changes in this PR)
- [x] TypeScript clean; `lint:ci` clean (no baseline growth; no new raw-fetch/exhaustive-deps violations)
- [x] 8 new component tests (`NodeInfoEnrichmentReport.test.tsx`): loading/empty/populated states, Fix body + refetch, push-toggle body, Fix All batch, 403 toast, query-error banner
- [x] Browser-validated in the dev container against live data (1,056 nodes / 1,895 targets / 4,023 fillable fields): card renders, single-row Fix applied with success toast + correct re-analysis, console clean (only pre-existing locale-probe 404), anonymous context shows read-narrowed analysis and gets a fail-closed 403 `{missing}` on apply
- [ ] Reviewer note: a row's fillable list reflects its single best donor — after a Fix, remaining blanks can resurface with a different donor until the list drains (documented behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1