### PR TITLE
refactor(frontend): nodes route + useSourceView orchestration hook (#3962 5.4 PR4)

### DIFF
--- a/eslint-baseline.json
+++ b/eslint-baseline.json
@@ -18,9 +18,9 @@
     "no-restricted-syntax": 2
   },
   "src/App.tsx": {
-    "@typescript-eslint/no-explicit-any": 5,
+    "@typescript-eslint/no-explicit-any": 3,
     "preserve-caught-error": 1,
-    "react-hooks/exhaustive-deps": 20
+    "react-hooks/exhaustive-deps": 16
   },
   "src/cli/migrate-db.ts": {
     "@typescript-eslint/no-explicit-any": 3,
@@ -550,6 +550,9 @@
   },
   "src/hooks/useServerData.ts": {
     "@typescript-eslint/no-explicit-any": 2
+  },
+  "src/hooks/useSourceView.ts": {
+    "react-hooks/exhaustive-deps": 4
   },
   "src/hooks/useTracerouteAnalysis.emptyBack.test.ts": {
     "@typescript-eslint/no-unused-vars": 1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { flushSync } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 // Popup and Polyline moved to useTraceroutePaths hook
 // Recharts imports moved to useTraceroutePaths hook
-import L from 'leaflet';
+// L (leaflet default export) moved with markerRefs to useSourceView (#3962 5.4 PR4)
 import 'leaflet/dist/leaflet.css';
 import './App.css';
 import './components/map/leafletDefaultIcon';
@@ -61,16 +61,16 @@ import { type TemperatureUnit } from './utils/temperature';
 // calculateDistance and formatDistance moved to useTraceroutePaths hook
 import { DeviceInfo, Channel } from './types/device';
 import { MeshMessage } from './types/message';
-import { SortField, SortDirection, NodeFilters } from './types/ui';
+import { NodeFilters } from './types/ui';
 import { getHashTabRedirectTarget } from './utils/tabHashRedirect';
 import { ResourceType } from './types/permission';
 import api, { type ChannelDatabaseEntry } from './services/api';
 import { getPacketStats } from './services/packetApi';
 import { logger } from './utils/logger';
 // generateArrowMarkers moved to useTraceroutePaths hook
-import { isNodeComplete, getEffectivePosition } from './utils/nodeHelpers';
-import { effectiveMapMaxAgeHours } from './utils/mapAge';
-import { nodePassesTransportFilter, transportCutoffSec } from './utils/nodeTransport';
+// isNodeComplete/getEffectivePosition/effectiveMapMaxAgeHours/
+// nodePassesTransportFilter/transportCutoffSec moved with processedNodes/
+// visibleNodeNums/centerMapOnNode to useSourceView (#3962 5.4 PR4)
 import { settingsToMatrix } from './utils/autoAckMatrix';
 import { applyHomoglyphOptimization } from './utils/homoglyph';
 import { playSound, playChannelSound, DEFAULT_SOUND_ID } from './utils/notificationSounds';
@@ -92,8 +92,7 @@ import { useHealth } from './hooks/useHealth';
 import { useTxStatus } from './hooks/useTxStatus';
 import { useVersionCheck } from './hooks/useVersionCheck';
 import { usePoll, type PollData } from './hooks/usePoll';
-import { useTelemetryNodes } from './hooks/useServerData';
-import { useTraceroutePaths } from './hooks/useTraceroutePaths';
+import { useSourceView } from './hooks/useSourceView';
 import { useNotificationNavigationHandler } from './hooks/useNotificationNavigationHandler';
 import LoginModal from './components/LoginModal';
 import LoginPage from './components/LoginPage';
@@ -101,27 +100,19 @@ import { SaveBarProvider, SaveBarGroup } from './contexts/SaveBarContext';
 import { SaveBar } from './components/SaveBar';
 import ErrorBoundary from './components/common/ErrorBoundary';
 
-// Track pending favorite/ignored requests outside component to persist across
-// remounts (App is re-keyed on source switch). Keys are composite strings
-// `${sourceId}:${nodeNum}` so that an optimistic toggle on Source A does not
-// bleed into Source B's view of the same node (bug: single nodeNum key meant
-// clicking favorite on Source 1 forced the same optimistic state onto Source
-// 2's poll response because both sources share nodeNums on overlapping meshes).
-const favoritePendingKey = (sourceId: string | null | undefined, nodeNum: number) =>
-  `${sourceId ?? ''}:${nodeNum}`;
-
-// Entries expire (#4240) — see src/utils/pendingToggles.ts for why a plain Map
-// deadlocked the toggles permanently.
-const pendingFavoriteRequests = new PendingToggleMap();
-const pendingIgnoredRequests = new PendingToggleMap();
-const pendingHideFromMapRequests = new PendingToggleMap();
-
-const ALL_PENDING_TOGGLE_MAPS = [
+// Pending favorite/ignored/hide-from-map toggle tracking now lives in
+// src/utils/pendingToggles.ts as module-level singletons — shared between
+// this file's poll reconciliation (processPollData, below) and the
+// toggleFavorite/toggleFavoriteLock handlers extracted into
+// src/hooks/useSourceView.ts (#3962 5.4 PR4).
+import {
+  sweepAll,
+  favoritePendingKey,
   pendingFavoriteRequests,
   pendingIgnoredRequests,
   pendingHideFromMapRequests,
-];
-import { PendingToggleMap, sweepAll } from './utils/pendingToggles';
+  ALL_PENDING_TOGGLE_MAPS,
+} from './utils/pendingToggles';
 import TracerouteHistoryModal from './components/TracerouteHistoryModal';
 import RouteSegmentTraceroutesModal from './components/RouteSegmentTraceroutesModal';
 
@@ -364,13 +355,12 @@ function App() {
   const { isChannelMuted, isDMMuted } = useNotificationMuteSettings();
 
   // Map context
+  // showPaths/showRoute/showMqttNodes/showUdpNodes/showRfNodes/
+  // showEstimatedPositions/mapZoom/mapMaxAgeHours moved out of this
+  // destructure — their only consumers (processedNodes/visibleNodeNums/
+  // useTraceroutePaths) now live in useSourceView, which calls
+  // useMapContext() itself (#3962 5.4 PR4).
   const {
-    showPaths,
-    showRoute,
-    showMqttNodes,
-    showUdpNodes,
-    showRfNodes,
-    showEstimatedPositions,
     setMapCenterTarget,
     traceroutes,
     setTraceroutes,
@@ -378,14 +368,11 @@ function App() {
     setPositionHistory,
     selectedNodeId,
     setSelectedNodeId,
-    mapZoom,
-    mapMaxAgeHours,
   } = useMapContext();
 
-  // Effective map age cap for traceroute/route-segment visibility (#3322):
-  // the Map Features age slider, clamped to [1, maxNodeAgeHours]. null = follow
-  // the global setting, so default behavior is unchanged.
-  const effectiveMapMaxAge = effectiveMapMaxAgeHours(mapMaxAgeHours, maxNodeAgeHours);
+  // effectiveMapMaxAge (#3322) moved into useSourceView (#3962 5.4 PR4) —
+  // its only consumers (visibleNodeNums, useTraceroutePaths) live there now,
+  // and the hook recomputes it itself from useMapContext()/useSettings().
 
   // Data context
   const {
@@ -417,15 +404,11 @@ function App() {
     setDmLoadingMore,
   } = useData();
 
-  // Telemetry availability Sets (nodes with telemetry/weather/estimated
-  // position/PKC) — sourced directly from the poll cache (#3962 5.4 PR2),
-  // replacing the DataContext Sets that were populated by processPollData.
-  const {
-    nodesWithTelemetry,
-    nodesWithWeather: nodesWithWeatherTelemetry,
-    nodesWithEstimatedPosition,
-    nodesWithPKC,
-  } = useTelemetryNodes();
+  // Telemetry availability Sets (nodesWithTelemetry/nodesWithWeatherTelemetry/
+  // nodesWithEstimatedPosition/nodesWithPKC) were sourced here directly from
+  // the poll cache (#3962 5.4 PR2) but were consumed ONLY by processedNodes/
+  // visibleNodeNums, both now owned by useSourceView (#3962 5.4 PR4), which
+  // calls useTelemetryNodes() itself.
 
   // Consolidated polling for nodes, messages, channels, config
   // Enabled only when connected and not in reboot/user-disconnected state
@@ -576,11 +559,14 @@ function App() {
     setShowMqttMessages,
     error,
     setError,
+    // tracerouteLoading still consumed below (messages block, NodePopup);
+    // setTracerouteLoading's only consumer (handleTraceroute) moved into
+    // useSourceView, which calls useUI() itself (#3962 5.4 PR4).
     tracerouteLoading,
-    setTracerouteLoading,
     nodeFilter: _nodeFilter, // Deprecated - kept for backward compatibility
     setNodeFilter: _setNodeFilter, // Deprecated
-    nodesNodeFilter,
+    // nodesNodeFilter/sortField/sortDirection's only consumer (processedNodes)
+    // moved into useSourceView, which reads them itself via useUI().
     messagesNodeFilter,
     setMessagesNodeFilter,
     securityFilter,
@@ -588,9 +574,7 @@ function App() {
     channelFilter,
     dmFilter,
     setDmFilter,
-    sortField,
     setSortField: _setSortField,
-    sortDirection,
     setSortDirection: _setSortDirection,
     showStatusModal,
     setShowStatusModal,
@@ -930,6 +914,36 @@ function App() {
     [getCsrfToken, refreshCsrfToken]
   );
 
+  // Shared node/traceroute/map orchestration — processedNodes, marker refs,
+  // traceroute path rendering, favorite/delete/purge handlers (#3962 5.4
+  // PR4, task54_spec.md §7). This is the block that makes the nodes route
+  // (and the not-yet-migrated messages/dashboard blocks that still consume
+  // these same handlers) work; see src/hooks/useSourceView.ts.
+  const {
+    processedNodes,
+    shouldShowData,
+    centerMapOnNode,
+    toggleFavorite,
+    toggleFavoriteLock,
+    markerRefs,
+    traceroutePathsElements,
+    selectedNodeTraceroute,
+    visibleNodeNums,
+    tracerouteNodeNums,
+    tracerouteBounds,
+    handleTraceroute,
+    handleDeleteNode,
+    handlePurgeNodeFromDevice,
+  } = useSourceView({
+    baseUrl,
+    authFetch,
+    refetchPoll,
+    nodeFilters,
+    mergedThemeColors,
+    setSelectedRouteSegment,
+    setShowPurgeDataModal,
+  });
+
   // Function to detect MQTT/bridge messages that should be filtered
   const isMqttBridgeMessage = (msg: MeshMessage): boolean => {
     // Primary check: use the viaMqtt field from the packet if available
@@ -959,7 +973,6 @@ function App() {
       }
     });
   };
-  const markerRefs = useRef<Map<string, L.Marker>>(new Map());
 
   // Load configuration and check connection status on startup
   useEffect(() => {
@@ -2587,10 +2600,7 @@ function App() {
     return recentTraceroutes.length > 0 ? recentTraceroutes[0] : null;
   };
 
-  // Helper to check if we should show cached data
-  const shouldShowData = () => {
-    return connectionStatus === 'connected' || connectionStatus === 'user-disconnected';
-  };
+  // shouldShowData moved to useSourceView (#3962 5.4 PR4)
 
   const handleDisconnect = async () => {
     try {
@@ -2653,47 +2663,7 @@ function App() {
     }
   };
 
-  const handleTraceroute = async (nodeId: string, channel?: number) => {
-    if (connectionStatus !== 'connected') {
-      return;
-    }
-
-    try {
-      // Set loading state
-      setTracerouteLoading(nodeId);
-
-      // Convert nodeId to node number
-      const nodeNumStr = nodeId.replace('!', '');
-      const nodeNum = parseInt(nodeNumStr, 16);
-
-      await authFetch(`${baseUrl}/api/traceroute`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ destination: nodeNum, sourceId, ...(channel !== undefined && { channel }) }),
-      });
-
-      logger.debug(`🗺️ Traceroute request sent to ${nodeId}`);
-
-      // Poll for traceroute results with increasing delays
-      // This provides faster UI feedback instead of waiting for the 5s poll interval
-      const pollDelays = [2000, 5000, 10000, 15000]; // 2s, 5s, 10s, 15s
-      pollDelays.forEach(delay => {
-        setTimeout(() => {
-          void refetchPoll();
-        }, delay);
-      });
-
-      // Clear loading state after 30 seconds
-      setTimeout(() => {
-        setTracerouteLoading(null);
-      }, 30000);
-    } catch (error) {
-      logger.error('Failed to send traceroute:', error);
-      setTracerouteLoading(null);
-    }
-  };
+  // handleTraceroute moved to useSourceView (#3962 5.4 PR4)
 
   const handleExchangePosition = async (nodeId: string, channel?: number) => {
     if (connectionStatus !== 'connected') {
@@ -3273,111 +3243,8 @@ function App() {
     }
   };
 
-  const handleDeleteNode = async (nodeNum: number) => {
-    const node = nodes.find(n => n.nodeNum === nodeNum);
-    const nodeName = node?.user?.shortName || node?.user?.longName || `Node ${nodeNum}`;
-
-    if (
-      !window.confirm(
-        `Are you sure you want to DELETE ${nodeName} from the local database?\n\nThis will remove:\n- The node from the map and node list\n- All messages with this node\n- All traceroutes for this node\n- All telemetry data for this node\n\nThis action cannot be undone.`
-      )
-    ) {
-      return;
-    }
-
-    try {
-      const response = await authFetch(`${baseUrl}/api/messages/nodes/${nodeNum}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ sourceId }),
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        showToast(
-          t('toast.deleted_node', {
-            node: nodeName,
-            messages: data.messagesDeleted,
-            traceroutes: data.traceroutesDeleted,
-            telemetry: data.telemetryDeleted,
-          }),
-          'success'
-        );
-        // Close the purge data modal if open
-        setShowPurgeDataModal(false);
-        // Clear the selected DM node if it's the one being deleted
-        const deletedNode = nodes.find(n => n.nodeNum === nodeNum);
-        if (deletedNode && selectedDMNode === deletedNode.user?.id) {
-          setSelectedDMNode('');
-        }
-        // Refresh data from backend to ensure consistency
-        void refetchPoll();
-      } else {
-        const errorData = await response.json();
-        showToast(t('toast.failed_delete_node', { error: errorData.message || t('errors.unknown') }), 'error');
-      }
-    } catch (err) {
-      showToast(
-        t('toast.failed_delete_node', { error: err instanceof Error ? err.message : t('errors.network') }),
-        'error'
-      );
-    }
-  };
-
-  const handlePurgeNodeFromDevice = async (nodeNum: number) => {
-    const node = nodes.find(n => n.nodeNum === nodeNum);
-    const nodeName = node?.user?.shortName || node?.user?.longName || `Node ${nodeNum}`;
-
-    if (
-      !window.confirm(
-        `Are you sure you want to PURGE ${nodeName} from BOTH the connected device AND the local database?\n\nThis will:\n- Send an admin command to remove the node from the device NodeDB\n- Remove the node from the map and node list\n- Delete all messages with this node\n- Delete all traceroutes for this node\n- Delete all telemetry data for this node\n\nThis action cannot be undone and affects both the device and local database.`
-      )
-    ) {
-      return;
-    }
-
-    try {
-      const response = await authFetch(`${baseUrl}/api/messages/nodes/${nodeNum}/purge-from-device`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ sourceId }),
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        showToast(
-          t('toast.purged_node_device', {
-            node: nodeName,
-            messages: data.messagesDeleted,
-            traceroutes: data.traceroutesDeleted,
-            telemetry: data.telemetryDeleted,
-          }),
-          'success'
-        );
-        // Close the purge data modal if open
-        setShowPurgeDataModal(false);
-        // Clear the selected DM node if it's the one being deleted
-        const purgedNode = nodes.find(n => n.nodeNum === nodeNum);
-        if (purgedNode && selectedDMNode === purgedNode.user?.id) {
-          setSelectedDMNode('');
-        }
-        // Refresh data from backend to ensure consistency
-        void refetchPoll();
-      } else {
-        const errorData = await response.json();
-        showToast(t('toast.failed_purge_node_device', { error: errorData.message || t('errors.unknown') }), 'error');
-      }
-    } catch (err) {
-      showToast(
-        t('toast.failed_purge_node_device', { error: err instanceof Error ? err.message : t('errors.network') }),
-        'error'
-      );
-    }
-  };
+  // handleDeleteNode + handlePurgeNodeFromDevice moved to useSourceView
+  // (#3962 5.4 PR4)
 
   const handlePositionOverrideSave = async (
     nodeNum: number,
@@ -3766,369 +3633,12 @@ function App() {
       .sort((a, b) => a - b);
   };
 
-  // Helper function to sort nodes
-  const sortNodes = (nodes: DeviceInfo[], field: SortField, direction: SortDirection): DeviceInfo[] => {
-    return [...nodes].sort((a, b) => {
-      let aVal: any, bVal: any;
+  // sortNodes, filterNodes, processedNodes, and centerMapOnNode moved to
+  // useSourceView (#3962 5.4 PR4)
 
-      switch (field) {
-        case 'longName':
-          aVal = a.user?.longName || `Node ${a.nodeNum}`;
-          bVal = b.user?.longName || `Node ${b.nodeNum}`;
-          break;
-        case 'shortName':
-          aVal = a.user?.shortName || '';
-          bVal = b.user?.shortName || '';
-          break;
-        case 'id':
-          aVal = a.user?.id || a.nodeNum;
-          bVal = b.user?.id || b.nodeNum;
-          break;
-        case 'lastHeard':
-          aVal = a.lastHeard || 0;
-          bVal = b.lastHeard || 0;
-          break;
-        case 'snr':
-          aVal = a.snr || -999;
-          bVal = b.snr || -999;
-          break;
-        case 'battery':
-          aVal = a.deviceMetrics?.batteryLevel || -1;
-          bVal = b.deviceMetrics?.batteryLevel || -1;
-          break;
-        case 'hwModel':
-          aVal = a.user?.hwModel || 0;
-          bVal = b.user?.hwModel || 0;
-          break;
-        case 'hops': {
-          // For nodes without hop data, use fallback values that push them to bottom
-          // Ascending: use 999 (high value = bottom), Descending: use -1 (low value = bottom)
-          const noHopFallback = direction === 'asc' ? 999 : -1;
-          aVal = a.hopsAway !== undefined && a.hopsAway !== null ? a.hopsAway : noHopFallback;
-          bVal = b.hopsAway !== undefined && b.hopsAway !== null ? b.hopsAway : noHopFallback;
-          break;
-        }
-        default:
-          return 0;
-      }
-
-      if (typeof aVal === 'string' && typeof bVal === 'string') {
-        const comparison = aVal.toLowerCase().localeCompare(bVal.toLowerCase());
-        return direction === 'asc' ? comparison : -comparison;
-      } else {
-        const comparison = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
-        return direction === 'asc' ? comparison : -comparison;
-      }
-    });
-  };
-
-  // Helper function to filter nodes
-  const filterNodes = (nodes: DeviceInfo[], filter: string): DeviceInfo[] => {
-    if (!filter.trim()) return nodes;
-
-    const lowerFilter = filter.toLowerCase();
-    return nodes.filter(node => {
-      const longName = (node.user?.longName || '').toLowerCase();
-      const shortName = (node.user?.shortName || '').toLowerCase();
-      const id = (node.user?.id || '').toLowerCase();
-
-      return longName.includes(lowerFilter) || shortName.includes(lowerFilter) || id.includes(lowerFilter);
-    });
-  };
-
-  // Get processed (filtered and sorted) nodes
-  const processedNodes = useMemo((): DeviceInfo[] => {
-    const cutoffTime = Date.now() / 1000 - maxNodeAgeHours * 60 * 60;
-
-    // Age filter (favorites are always visible)
-    const ageFiltered = nodes.filter(node => {
-      if (node.isFavorite) return true;
-      if (!node.lastHeard) return false;
-      return node.lastHeard >= cutoffTime;
-    });
-
-    // Only apply nodesNodeFilter when Nodes tab is active
-    // Messages tab will apply its own messagesNodeFilter
-    const textFiltered = activeTab === 'nodes' ? filterNodes(ageFiltered, nodesNodeFilter) : ageFiltered;
-
-    // Apply advanced filters
-    const advancedFiltered = textFiltered.filter(node => {
-      const nodeId = node.user?.id;
-      const isShowMode = nodeFilters.filterMode === 'show';
-
-      // MQTT filter
-      if (nodeFilters.showMqtt) {
-        const matches = node.viaMqtt;
-        if (isShowMode && !matches) return false; // Show mode: exclude non-matches
-        if (!isShowMode && matches) return false; // Hide mode: exclude matches
-      }
-
-      // Telemetry filter
-      if (nodeFilters.showTelemetry) {
-        const matches = nodeId && nodesWithTelemetry.has(nodeId);
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Environment metrics filter
-      if (nodeFilters.showEnvironment) {
-        const matches = nodeId && nodesWithWeatherTelemetry.has(nodeId);
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Power source filter
-      const batteryLevel = node.deviceMetrics?.batteryLevel;
-      if (nodeFilters.powerSource !== 'both' && batteryLevel !== undefined) {
-        const isPowered = batteryLevel === 101;
-        if (nodeFilters.powerSource === 'powered' && !isPowered) {
-          return false;
-        }
-        if (nodeFilters.powerSource === 'battery' && isPowered) {
-          return false;
-        }
-      }
-
-      // Position filter
-      if (nodeFilters.showPosition) {
-        const hasPosition = node.position && node.position.latitude != null && node.position.longitude != null;
-        const matches = hasPosition;
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Hops filter (always applies regardless of mode)
-      if (node.hopsAway != null) {
-        if (node.hopsAway < nodeFilters.minHops || node.hopsAway > nodeFilters.maxHops) {
-          return false;
-        }
-      }
-
-      // PKI filter
-      if (nodeFilters.showPKI) {
-        const matches = nodeId && nodesWithPKC.has(nodeId);
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Remote Admin filter
-      if (nodeFilters.showRemoteAdmin) {
-        const matches = !!node.hasRemoteAdmin;
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      /**
-       * Unknown nodes filter
-       * Identifies nodes that lack both longName and shortName, which are typically
-       * displayed as "Node 12345678" in the UI. These nodes have only been detected
-       * but haven't provided identifying information yet.
-       */
-      if (nodeFilters.showUnknown) {
-        const hasLongName = node.user?.longName && node.user.longName.trim() !== '';
-        const hasShortName = node.user?.shortName && node.user.shortName.trim() !== '';
-        const isUnknown = !hasLongName && !hasShortName;
-        const matches = isUnknown;
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Ignored nodes filter - hide ignored nodes by default
-      // When showIgnored is false (default): hide ignored nodes
-      // When showIgnored is true: show ignored nodes
-      if (!nodeFilters.showIgnored && node.isIgnored) {
-        return false;
-      }
-
-      // Favorite locked filter
-      if (nodeFilters.showFavoriteLocked) {
-        const matches = !!node.favoriteLocked;
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Device role filter
-      if (nodeFilters.deviceRoles.length > 0) {
-        const role = typeof node.user?.role === 'number' ? node.user.role : parseInt(node.user?.role || '0');
-        const matches = nodeFilters.deviceRoles.includes(role);
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      // Channel filter
-      if (nodeFilters.channels.length > 0) {
-        const nodeChannel = node.channel ?? -1;
-        const matches = nodeFilters.channels.includes(nodeChannel);
-        if (isShowMode && !matches) return false;
-        if (!isShowMode && matches) return false;
-      }
-
-      return true;
-    });
-
-    // Separate favorites from non-favorites
-    const favorites = advancedFiltered.filter(node => node.isFavorite);
-    const nonFavorites = advancedFiltered.filter(node => !node.isFavorite);
-
-    // Sort each group independently
-    const sortedFavorites = sortNodes(favorites, sortField, sortDirection);
-    const sortedNonFavorites = sortNodes(nonFavorites, sortField, sortDirection);
-
-    // Concatenate: favorites first, then non-favorites
-    return [...sortedFavorites, ...sortedNonFavorites];
-  }, [
-    nodes,
-    maxNodeAgeHours,
-    activeTab,
-    nodesNodeFilter,
-    sortField,
-    sortDirection,
-    nodeFilters,
-    nodesWithTelemetry,
-    nodesWithWeatherTelemetry,
-    nodesWithPKC,
-  ]);
-
-  // Function to center map on a specific node
-  const centerMapOnNode = useCallback((node: DeviceInfo) => {
-    const effectivePos = getEffectivePosition(node);
-    if (effectivePos.latitude != null && effectivePos.longitude != null) {
-      setMapCenterTarget([effectivePos.latitude, effectivePos.longitude]);
-    }
-  }, []);
-
-  // pendingFavoriteRequests is defined as a module-level variable to persist across remounts
-
-  // Function to toggle node favorite status
-  const toggleFavorite = async (node: DeviceInfo, event: React.MouseEvent) => {
-    event.stopPropagation(); // Prevent node selection when clicking star
-
-    if (!node.user?.id) {
-      logger.error('Cannot toggle favorite: node has no user ID');
-      return;
-    }
-
-    // Prevent multiple rapid clicks on the same node (scoped to current source)
-    const favKey = favoritePendingKey(sourceId, node.nodeNum);
-    if (pendingFavoriteRequests.get(favKey) !== undefined) {
-      return;
-    }
-
-    // Store the original state before any updates
-    const originalFavoriteStatus = node.isFavorite;
-    const newFavoriteStatus = !originalFavoriteStatus;
-
-    try {
-      // Mark this request as pending with the expected new state
-      pendingFavoriteRequests.set(favKey, newFavoriteStatus);
-
-      // Optimistically update the UI - use flushSync to force immediate render
-      // This prevents the polling from overwriting the optimistic update before it renders
-      flushSync(() => {
-        setNodes(prevNodes => {
-          const updated = prevNodes.map(n =>
-            n.nodeNum === node.nodeNum ? { ...n, isFavorite: newFavoriteStatus } : n
-          );
-          return updated;
-        });
-      });
-
-      // Send update to backend (with device sync enabled by default)
-      const response = await authFetch(`${baseUrl}/api/nodes/${node.user.id}/favorite`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          isFavorite: newFavoriteStatus,
-          syncToDevice: true, // Enable two-way sync to Meshtastic device
-          sourceId,
-        }),
-      });
-
-      if (!response.ok) {
-        if (response.status === 403) {
-          showToast(t('toast.insufficient_permissions_favorites'), 'error');
-          // Revert to original state using the saved original value
-          setNodes(prevNodes =>
-            prevNodes.map(n => (n.nodeNum === node.nodeNum ? { ...n, isFavorite: originalFavoriteStatus } : n))
-          );
-          return;
-        }
-        throw new Error('Failed to update favorite status');
-      }
-
-      const result = await response.json();
-
-      // Log the result including device sync status
-      let statusMessage = `${newFavoriteStatus ? '⭐' : '☆'} Node ${node.user.id} favorite status updated`;
-      if (result.deviceSync) {
-        if (result.deviceSync.status === 'success') {
-          statusMessage += ' (synced to device ✓)';
-        } else if (result.deviceSync.status === 'failed') {
-          // Only show error for actual failures (not firmware compatibility)
-          statusMessage += ` (device sync failed: ${result.deviceSync.error || 'unknown error'})`;
-        }
-        // 'skipped' status (e.g., pre-2.7 firmware) is not shown to user - logged on server only
-      }
-      logger.debug(statusMessage);
-    } catch (error) {
-      logger.error('Error toggling favorite:', error);
-      // Revert to original state using the saved original value
-      setNodes(prevNodes =>
-        prevNodes.map(n => (n.nodeNum === node.nodeNum ? { ...n, isFavorite: originalFavoriteStatus } : n))
-      );
-      // Remove from pending on error since we reverted
-      pendingFavoriteRequests.delete(favKey);
-      showToast(t('toast.failed_update_favorite'), 'error');
-    }
-    // Note: On success, the polling logic will remove from pendingFavoriteRequests
-    // when it detects the server has caught up
-  };
-
-  // Function to toggle node favorite lock status
-  const toggleFavoriteLock = async (node: DeviceInfo, event: React.MouseEvent) => {
-    event.stopPropagation();
-
-    if (!node.user?.id) {
-      logger.error('Cannot toggle favorite lock: node has no user ID');
-      return;
-    }
-
-    const newLocked = !node.favoriteLocked;
-
-    try {
-      // Optimistically update the UI
-      flushSync(() => {
-        setNodes(prevNodes =>
-          prevNodes.map(n =>
-            n.nodeNum === node.nodeNum ? { ...n, favoriteLocked: newLocked } : n
-          )
-        );
-      });
-
-      const response = await authFetch(`${baseUrl}/api/nodes/${node.user.id}/favorite-lock`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ locked: newLocked, sourceId }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Server returned ${response.status}`);
-      }
-
-      logger.debug(`${newLocked ? '🔒' : '🔓'} Node ${node.user.id} favorite lock set to: ${newLocked}`);
-    } catch (error) {
-      logger.error('Error toggling favorite lock:', error);
-      // Revert
-      setNodes(prevNodes =>
-        prevNodes.map(n =>
-          n.nodeNum === node.nodeNum ? { ...n, favoriteLocked: !newLocked } : n
-        )
-      );
-      showToast(t('toast.failed_update_favorite_lock', 'Failed to update favorite lock'), 'error');
-    }
-  };
+  // toggleFavorite + toggleFavoriteLock moved to useSourceView (#3962 5.4
+  // PR4) — toggleIgnored/toggleHideFromMap below are messages-tab-only
+  // (not in the NodesTab census) and stay here until PR7.
 
   // Function to toggle node ignored status
   const toggleIgnored = async (node: DeviceInfo, event: React.MouseEvent) => {
@@ -4355,104 +3865,9 @@ function App() {
 
   // Removed renderSettingsTab - using SettingsTab component instead
 
-  // Create stable digests of nodes and traceroutes that only change when relevant data changes
-  // This prevents unnecessary recalculation of traceroutePathsElements
-  // Uses getEffectivePosition to respect position overrides (Issue #1526)
-  const nodesPositionDigest = useMemo(() => {
-    return nodes.map(n => {
-      const effectivePos = getEffectivePosition(n);
-      return {
-        nodeNum: n.nodeNum,
-        position: effectivePos.latitude != null && effectivePos.longitude != null
-          ? {
-              latitude: effectivePos.latitude,
-              longitude: effectivePos.longitude,
-            }
-          : undefined,
-        user: n.user
-          ? {
-              longName: n.user.longName,
-              shortName: n.user.shortName,
-              id: n.user.id,
-            }
-          : undefined,
-        viaMqtt: n.viaMqtt ?? false,
-      };
-    });
-  }, [nodes.map(n => {
-    const pos = getEffectivePosition(n);
-    return `${n.nodeNum}-${pos.latitude}-${pos.longitude}-${n.viaMqtt ? '1' : '0'}`;
-  }).join(',')]);
-
-  const traceroutesDigest = useMemo(() => {
-    return traceroutes.map(tr => ({
-      fromNodeNum: tr.fromNodeNum,
-      toNodeNum: tr.toNodeNum,
-      fromNodeId: tr.fromNodeId,
-      toNodeId: tr.toNodeId,
-      route: tr.route,
-      routeBack: tr.routeBack,
-      snrTowards: tr.snrTowards,
-      snrBack: tr.snrBack,
-      timestamp: tr.timestamp,
-      createdAt: tr.createdAt,
-    }));
-  }, [
-    traceroutes
-      .map(tr => `${tr.fromNodeNum}-${tr.toNodeNum}-${tr.route}-${tr.routeBack}-${tr.timestamp || tr.createdAt}`)
-      .join(','),
-  ]);
-
-  // Traceroute paths rendering - extracted to useTraceroutePaths hook
-  const tracerouteCallbacks = useMemo(
-    () => ({
-      onSelectNode: (nodeId: string, position: [number, number]) => {
-        setSelectedNodeId(nodeId);
-        setMapCenterTarget(position);
-      },
-      onSelectRouteSegment: (nodeNum1: number, nodeNum2: number) => {
-        setSelectedRouteSegment({ nodeNum1, nodeNum2 });
-      },
-    }),
-    [setSelectedNodeId, setMapCenterTarget]
-  );
-
-  // Compute visible node numbers for neighbor-info line and traceroute path filtering.
-  // Must mirror the per-marker filter in NodesTab so that lines are hidden whenever
-  // their endpoint nodes are hidden (Issues #1102, #3147).
-  const visibleNodeNums = useMemo(() => {
-    // #4240: one clock read per recompute. Deliberately computed INSIDE the memo
-    // rather than listed as a dependency — a fresh timestamp every render would
-    // invalidate this memo on every render.
-    const transportCutoff = transportCutoffSec(effectiveMapMaxAge);
-    const visibleNodes = processedNodes.filter(node => {
-      if (!node.position?.latitude || !node.position?.longitude) return false;
-      // #4162/#3549: "Hide from Map" suppresses the marker (NodesTab drops it
-      // at nodesWithPosition), so it must also drop from this visible set —
-      // otherwise route-segment / neighbor lines dangle to a marker-less node.
-      if (node.hideFromMap) return false;
-      if (!nodePassesTransportFilter(node, { showRfNodes, showUdpNodes, showMqttNodes }, transportCutoff)) return false;
-      if (!showIncompleteNodes && !isNodeComplete(node)) return false;
-      if (!showEstimatedPositions && node.user?.id && nodesWithEstimatedPosition.has(node.user.id)) return false;
-      return true;
-    });
-    return new Set(visibleNodes.map(n => n.nodeNum));
-  }, [processedNodes, showRfNodes, showUdpNodes, showMqttNodes, showIncompleteNodes, showEstimatedPositions, nodesWithEstimatedPosition, effectiveMapMaxAge]);
-
-  const { traceroutePathsElements, selectedNodeTraceroute, tracerouteNodeNums, tracerouteBounds } = useTraceroutePaths({
-    showPaths,
-    showRoute,
-    selectedNodeId,
-    currentNodeId,
-    nodesPositionDigest,
-    traceroutesDigest,
-    distanceUnit,
-    maxNodeAgeHours: effectiveMapMaxAge,
-    themeColors: mergedThemeColors,
-    callbacks: tracerouteCallbacks,
-    visibleNodeNums,
-    mapZoom,
-  });
+  // nodesPositionDigest, traceroutesDigest, tracerouteCallbacks,
+  // visibleNodeNums, and the useTraceroutePaths() call all moved to
+  // useSourceView (#3962 5.4 PR4)
 
   // Navigate to message from search result
   const handleNavigateToMessage = useCallback((result: { id: string; source: string; channel?: number; fromNodeId?: string; fromNodeNum?: number }) => {
@@ -4686,7 +4101,10 @@ function App() {
           an `activeTab === 'x' && …` render gate to its own <Route> one PR at
           a time (task54_spec.md §3). Un-migrated tabs keep rendering via the
           `path="*"` fallback below, unchanged, driven by the activeTab<->route
-          adapter in UIContext. `audit` is the PR1 proof leaf.
+          adapter in UIContext. `audit` was the PR1 proof leaf; PR3 migrated
+          the other leaf tabs; PR4 migrated `nodes` (the default/index tab)
+          alongside extracting its shared node/traceroute/map orchestration
+          into `useSourceView` (src/hooks/useSourceView.ts).
         */}
         <Routes>
           <Route index element={<Navigate to="nodes" replace />} />
@@ -4742,31 +4160,34 @@ function App() {
               </ErrorBoundary>
             }
           />
-          <Route path="*" element={<>
-        {activeTab === 'nodes' && (
-          <ErrorBoundary fallbackTitle="Nodes failed to load">
-          <NodesTab
-            processedNodes={processedNodes}
-            shouldShowData={shouldShowData}
-            centerMapOnNode={centerMapOnNode}
-            toggleFavorite={toggleFavorite}
-            toggleFavoriteLock={toggleFavoriteLock}
-            setActiveTab={setActiveTab}
-            setSelectedDMNode={setSelectedDMNode}
-            markerRefs={markerRefs}
-            traceroutePathsElements={traceroutePathsElements}
-            selectedNodeTraceroute={selectedNodeTraceroute}
-            visibleNodeNums={visibleNodeNums}
-            tracerouteNodeNums={tracerouteNodeNums}
-            tracerouteBounds={tracerouteBounds}
-            onTraceroute={handleTraceroute}
-            connectionStatus={connectionStatus}
-            tracerouteLoading={tracerouteLoading}
-            onDeleteNode={handleDeleteNode}
-            onPurgeNodeFromDevice={handlePurgeNodeFromDevice}
+          <Route
+            path="nodes"
+            element={
+              <ErrorBoundary fallbackTitle="Nodes failed to load">
+                <NodesTab
+                  processedNodes={processedNodes}
+                  shouldShowData={shouldShowData}
+                  centerMapOnNode={centerMapOnNode}
+                  toggleFavorite={toggleFavorite}
+                  toggleFavoriteLock={toggleFavoriteLock}
+                  setActiveTab={setActiveTab}
+                  setSelectedDMNode={setSelectedDMNode}
+                  markerRefs={markerRefs}
+                  traceroutePathsElements={traceroutePathsElements}
+                  selectedNodeTraceroute={selectedNodeTraceroute}
+                  visibleNodeNums={visibleNodeNums}
+                  tracerouteNodeNums={tracerouteNodeNums}
+                  tracerouteBounds={tracerouteBounds}
+                  onTraceroute={handleTraceroute}
+                  connectionStatus={connectionStatus}
+                  tracerouteLoading={tracerouteLoading}
+                  onDeleteNode={handleDeleteNode}
+                  onPurgeNodeFromDevice={handlePurgeNodeFromDevice}
+                />
+              </ErrorBoundary>
+            }
           />
-          </ErrorBoundary>
-        )}
+          <Route path="*" element={<>
         {activeTab === 'channels' && (
           <ErrorBoundary fallbackTitle="Channels failed to load">
           <ChannelsTab

--- a/src/hooks/useSourceView.test.ts
+++ b/src/hooks/useSourceView.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for useSourceView — the shared node/traceroute/map orchestration
+ * hook extracted from App.tsx (#3962 5.4 PR4).
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type React from 'react';
+import type { DeviceInfo } from '../types/device';
+import type { NodeFilters } from '../types/ui';
+import { pendingFavoriteRequests } from '../utils/pendingToggles';
+
+const mockUseSource = vi.fn();
+const mockUseData = vi.fn();
+const mockUseMessaging = vi.fn();
+const mockUseSettings = vi.fn();
+const mockUseUI = vi.fn();
+const mockUseMapContext = vi.fn();
+const mockUseTelemetryNodes = vi.fn();
+const mockUseToast = vi.fn();
+const mockUseTraceroutePaths = vi.fn();
+
+vi.mock('../contexts/SourceContext', () => ({ useSource: () => mockUseSource() }));
+vi.mock('../contexts/DataContext', () => ({ useData: () => mockUseData() }));
+vi.mock('../contexts/MessagingContext', () => ({ useMessaging: () => mockUseMessaging() }));
+vi.mock('../contexts/SettingsContext', () => ({ useSettings: () => mockUseSettings() }));
+vi.mock('../contexts/UIContext', () => ({ useUI: () => mockUseUI() }));
+vi.mock('../contexts/MapContext', () => ({ useMapContext: () => mockUseMapContext() }));
+vi.mock('./useServerData', () => ({ useTelemetryNodes: () => mockUseTelemetryNodes() }));
+vi.mock('../components/ToastContainer', () => ({ useToast: () => mockUseToast() }));
+vi.mock('./useTraceroutePaths', () => ({
+  useTraceroutePaths: (params: unknown) => mockUseTraceroutePaths(params),
+}));
+
+import { useSourceView, type UseSourceViewParams } from './useSourceView';
+
+function makeNode(overrides: Partial<DeviceInfo> = {}): DeviceInfo {
+  return {
+    nodeNum: 100,
+    user: { id: '!64', longName: 'Node A', shortName: 'NDA' },
+    lastHeard: Math.floor(Date.now() / 1000),
+    isFavorite: false,
+    viaMqtt: false,
+    ...overrides,
+  } as DeviceInfo;
+}
+
+const defaultNodeFilters: NodeFilters = {
+  filterMode: 'show',
+  showMqtt: false,
+  showTelemetry: false,
+  showEnvironment: false,
+  powerSource: 'both',
+  showPosition: false,
+  minHops: 0,
+  maxHops: 99,
+  showPKI: false,
+  showRemoteAdmin: false,
+  showUnknown: false,
+  showIgnored: false,
+  showFavoriteLocked: false,
+  deviceRoles: [],
+  channels: [],
+};
+
+function baseParams(overrides: Partial<UseSourceViewParams> = {}): UseSourceViewParams {
+  return {
+    baseUrl: 'http://localhost:3001',
+    authFetch: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    refetchPoll: vi.fn(),
+    nodeFilters: defaultNodeFilters,
+    mergedThemeColors: {
+      mauve: '#cba6f7',
+      red: '#f38ba8',
+      blue: '#89b4fa',
+      overlay0: '#6c7086',
+    },
+    setSelectedRouteSegment: vi.fn(),
+    setShowPurgeDataModal: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useSourceView', () => {
+  let nodes: DeviceInfo[];
+  let setNodes: ReturnType<typeof vi.fn>;
+  let setMapCenterTarget: ReturnType<typeof vi.fn>;
+  let setSelectedNodeId: ReturnType<typeof vi.fn>;
+  let setTracerouteLoading: ReturnType<typeof vi.fn>;
+  let showToast: ReturnType<typeof vi.fn>;
+  let setSelectedDMNode: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // pendingFavoriteRequests is a module-level singleton (persists across
+    // remounts by design, #4240) — clear the key this suite exercises so
+    // tests don't leak state into each other.
+    pendingFavoriteRequests.delete('src-1:100');
+
+    nodes = [makeNode()];
+    setNodes = vi.fn();
+    setMapCenterTarget = vi.fn();
+    setSelectedNodeId = vi.fn();
+    setTracerouteLoading = vi.fn();
+    showToast = vi.fn();
+    setSelectedDMNode = vi.fn();
+
+    mockUseSource.mockReturnValue({ sourceId: 'src-1', sourceName: 'Test', sourceType: 'meshtastic_tcp' });
+    mockUseData.mockReturnValue({ nodes, setNodes, currentNodeId: '!64', connectionStatus: 'connected' });
+    mockUseMessaging.mockReturnValue({ selectedDMNode: null, setSelectedDMNode });
+    mockUseSettings.mockReturnValue({ maxNodeAgeHours: 24, distanceUnit: 'metric' });
+    mockUseUI.mockReturnValue({
+      activeTab: 'nodes',
+      nodesNodeFilter: '',
+      sortField: 'longName',
+      sortDirection: 'asc',
+      setTracerouteLoading,
+      showIncompleteNodes: true,
+    });
+    mockUseMapContext.mockReturnValue({
+      showPaths: false,
+      showRoute: false,
+      showMqttNodes: true,
+      showUdpNodes: true,
+      showRfNodes: true,
+      showEstimatedPositions: true,
+      setMapCenterTarget,
+      traceroutes: [],
+      selectedNodeId: null,
+      setSelectedNodeId,
+      mapZoom: 10,
+      mapMaxAgeHours: null,
+    });
+    mockUseTelemetryNodes.mockReturnValue({
+      nodesWithTelemetry: new Set<string>(),
+      nodesWithWeather: new Set<string>(),
+      nodesWithEstimatedPosition: new Set<string>(),
+      nodesWithPKC: new Set<string>(),
+    });
+    mockUseToast.mockReturnValue({ showToast });
+    mockUseTraceroutePaths.mockReturnValue({
+      traceroutePathsElements: null,
+      selectedNodeTraceroute: null,
+      tracerouteNodeNums: null,
+      tracerouteBounds: null,
+    });
+  });
+
+  describe('processedNodes', () => {
+    it('filters out stale non-favorite nodes but always keeps favorites', () => {
+      const stale = makeNode({ nodeNum: 200, isFavorite: false, lastHeard: 0 });
+      const staleFavorite = makeNode({ nodeNum: 300, isFavorite: true, lastHeard: 0 });
+      mockUseData.mockReturnValue({
+        nodes: [makeNode(), stale, staleFavorite],
+        setNodes,
+        currentNodeId: '!64',
+        connectionStatus: 'connected',
+      });
+
+      const { result } = renderHook(() => useSourceView(baseParams()));
+
+      const nodeNums = result.current.processedNodes.map(n => n.nodeNum);
+      expect(nodeNums).toContain(100);
+      expect(nodeNums).toContain(300); // stale favorite stays
+      expect(nodeNums).not.toContain(200); // stale non-favorite is dropped
+    });
+
+    it('applies nodesNodeFilter text search only when activeTab is "nodes"', () => {
+      const nodeA = makeNode({ nodeNum: 100, user: { id: '!64', longName: 'Alpha', shortName: 'A' } });
+      const nodeB = makeNode({ nodeNum: 200, user: { id: '!c8', longName: 'Bravo', shortName: 'B' } });
+      mockUseData.mockReturnValue({ nodes: [nodeA, nodeB], setNodes, currentNodeId: '!64', connectionStatus: 'connected' });
+      mockUseUI.mockReturnValue({
+        activeTab: 'nodes',
+        nodesNodeFilter: 'Alpha',
+        sortField: 'longName',
+        sortDirection: 'asc',
+        setTracerouteLoading,
+        showIncompleteNodes: true,
+      });
+
+      const { result: onNodesTab } = renderHook(() => useSourceView(baseParams()));
+      expect(onNodesTab.current.processedNodes.map(n => n.nodeNum)).toEqual([100]);
+
+      mockUseUI.mockReturnValue({
+        activeTab: 'messages',
+        nodesNodeFilter: 'Alpha',
+        sortField: 'longName',
+        sortDirection: 'asc',
+        setTracerouteLoading,
+        showIncompleteNodes: true,
+      });
+      const { result: onMessagesTab } = renderHook(() => useSourceView(baseParams()));
+      // messagesNodeFilter is separate — nodesNodeFilter text search is skipped off the nodes tab
+      expect(onMessagesTab.current.processedNodes.map(n => n.nodeNum).sort()).toEqual([100, 200]);
+    });
+
+    it('sorts favorites before non-favorites', () => {
+      const favorite = makeNode({ nodeNum: 200, isFavorite: true, user: { id: '!c8', longName: 'Zeta', shortName: 'Z' } });
+      const nonFavorite = makeNode({ nodeNum: 100, isFavorite: false, user: { id: '!64', longName: 'Alpha', shortName: 'A' } });
+      mockUseData.mockReturnValue({ nodes: [nonFavorite, favorite], setNodes, currentNodeId: '!64', connectionStatus: 'connected' });
+
+      const { result } = renderHook(() => useSourceView(baseParams()));
+      expect(result.current.processedNodes.map(n => n.nodeNum)).toEqual([200, 100]);
+    });
+  });
+
+  describe('traceroute selection state transitions', () => {
+    it('onSelectRouteSegment (wired into useTraceroutePaths callbacks) calls setSelectedRouteSegment', () => {
+      const setSelectedRouteSegment = vi.fn();
+      renderHook(() => useSourceView(baseParams({ setSelectedRouteSegment })));
+
+      expect(mockUseTraceroutePaths).toHaveBeenCalledTimes(1);
+      const passedParams = mockUseTraceroutePaths.mock.calls[0][0];
+      passedParams.callbacks.onSelectRouteSegment(111, 222);
+
+      expect(setSelectedRouteSegment).toHaveBeenCalledWith({ nodeNum1: 111, nodeNum2: 222 });
+    });
+
+    it('onSelectNode (wired into useTraceroutePaths callbacks) selects the node and centers the map', () => {
+      renderHook(() => useSourceView(baseParams()));
+
+      const passedParams = mockUseTraceroutePaths.mock.calls[0][0];
+      passedParams.callbacks.onSelectNode('!abc', [40.1, -75.2]);
+
+      expect(setSelectedNodeId).toHaveBeenCalledWith('!abc');
+      expect(setMapCenterTarget).toHaveBeenCalledWith([40.1, -75.2]);
+    });
+
+    it('passes visibleNodeNums through to useTraceroutePaths, excluding hidden/incomplete/off-transport nodes', () => {
+      const visible = makeNode({ nodeNum: 100, position: { latitude: 40, longitude: -75 } as any });
+      const hidden = makeNode({ nodeNum: 200, position: { latitude: 41, longitude: -76 } as any, hideFromMap: true } as any);
+      mockUseData.mockReturnValue({ nodes: [visible, hidden], setNodes, currentNodeId: '!64', connectionStatus: 'connected' });
+
+      renderHook(() => useSourceView(baseParams()));
+
+      const passedParams = mockUseTraceroutePaths.mock.calls[0][0];
+      expect(passedParams.visibleNodeNums.has(100)).toBe(true);
+      expect(passedParams.visibleNodeNums.has(200)).toBe(false);
+    });
+  });
+
+  describe('centerMapOnNode', () => {
+    it('centers the map on the node effective position', () => {
+      const { result } = renderHook(() => useSourceView(baseParams()));
+
+      act(() => {
+        result.current.centerMapOnNode(makeNode({ position: { latitude: 12.5, longitude: -34.5 } as any } as any));
+      });
+
+      expect(setMapCenterTarget).toHaveBeenCalledWith([12.5, -34.5]);
+    });
+  });
+
+  describe('handleTraceroute', () => {
+    it('sets loading state and POSTs to /api/traceroute for the target node', async () => {
+      const authFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+      const { result } = renderHook(() => useSourceView(baseParams({ authFetch })));
+
+      await act(async () => {
+        await result.current.handleTraceroute('!64');
+      });
+
+      expect(setTracerouteLoading).toHaveBeenCalledWith('!64');
+      expect(authFetch).toHaveBeenCalledWith(
+        'http://localhost:3001/api/traceroute',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ destination: 100, sourceId: 'src-1' }),
+        })
+      );
+    });
+
+    it('is a no-op when not connected', async () => {
+      mockUseData.mockReturnValue({ nodes, setNodes, currentNodeId: '!64', connectionStatus: 'disconnected' });
+      const authFetch = vi.fn();
+      const { result } = renderHook(() => useSourceView(baseParams({ authFetch })));
+
+      await act(async () => {
+        await result.current.handleTraceroute('!64');
+      });
+
+      expect(authFetch).not.toHaveBeenCalled();
+      expect(setTracerouteLoading).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleFavorite pending-request dedup (#4240)', () => {
+    it('skips a second toggle while one is already in flight for the same source+node', async () => {
+      const authFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+      const { result } = renderHook(() => useSourceView(baseParams({ authFetch })));
+      const node = makeNode({ nodeNum: 100, isFavorite: false });
+      const event = { stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+      // Prime the pending map as if a request is already in flight for this source+node.
+      pendingFavoriteRequests.set('src-1:100', true);
+
+      await act(async () => {
+        await result.current.toggleFavorite(node, event);
+      });
+
+      expect(authFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends the favorite toggle when no request is pending', async () => {
+      const authFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ deviceSync: undefined }) });
+      const { result } = renderHook(() => useSourceView(baseParams({ authFetch })));
+      const node = makeNode({ nodeNum: 100, isFavorite: false });
+      const event = { stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+      await act(async () => {
+        await result.current.toggleFavorite(node, event);
+      });
+
+      expect(authFetch).toHaveBeenCalledWith(
+        'http://localhost:3001/api/nodes/!64/favorite',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+});

--- a/src/hooks/useSourceView.ts
+++ b/src/hooks/useSourceView.ts
@@ -1,0 +1,754 @@
+/**
+ * Shared node/traceroute/map orchestration for the (Meshtastic) source view.
+ *
+ * Extracted from App.tsx (#3962 Phase 5.4 PR4, task54_spec.md §3/§7) as part
+ * of migrating the `nodes` tab to a route. `nodes` is the default/index tab
+ * and is entangled with the map + traceroute machinery — this hook is the
+ * "shared-orchestration core" the census in task54_spec.md §1.3 describes:
+ * `processedNodes` (filter/sort), marker refs, traceroute path rendering,
+ * and the favorite/delete/purge handlers.
+ *
+ * These values are consumed by the `nodes` route (NodesTab) AND by several
+ * not-yet-migrated surfaces still living in App.tsx (the inline `messages`
+ * tab block, the global PurgeDataModal, and NodePopup) — App destructures
+ * this hook's return value into the same local names those consumers
+ * already close over, so nothing downstream needs to change.
+ *
+ * Most inputs come from the same React Contexts App.tsx already reads
+ * (useSource/useData/useMapContext/useSettings/useUI/useMessaging) — calling
+ * them again here is a plain second `useContext` subscriber, not a
+ * duplicate side effect, so behavior is unchanged. The handful of genuinely
+ * App-local values (baseUrl, authFetch, refetchPoll, nodeFilters,
+ * mergedThemeColors, and two modal/route-segment setters) are passed in
+ * explicitly.
+ */
+
+import React, { useCallback, useMemo, useRef } from 'react';
+import { flushSync } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import type L from 'leaflet';
+
+import { DeviceInfo } from '../types/device';
+import { SortField, SortDirection, NodeFilters } from '../types/ui';
+import { useSettings } from '../contexts/SettingsContext';
+import { useMapContext } from '../contexts/MapContext';
+import { useData } from '../contexts/DataContext';
+import { useMessaging } from '../contexts/MessagingContext';
+import { useUI } from '../contexts/UIContext';
+import { useSource } from '../contexts/SourceContext';
+import { useToast } from '../components/ToastContainer';
+import { useTelemetryNodes } from './useServerData';
+import { useTraceroutePaths, type ThemeColors } from './useTraceroutePaths';
+import { isNodeComplete, getEffectivePosition } from '../utils/nodeHelpers';
+import { effectiveMapMaxAgeHours } from '../utils/mapAge';
+import { nodePassesTransportFilter, transportCutoffSec } from '../utils/nodeTransport';
+import { logger } from '../utils/logger';
+import { favoritePendingKey, pendingFavoriteRequests } from '../utils/pendingToggles';
+
+export interface UseSourceViewParams {
+  /** App-local, computed via detectBaseUrl at mount. */
+  baseUrl: string;
+  /** App-local useCallback — CSRF-aware fetch wrapper. */
+  authFetch: (url: string, options?: RequestInit, retryCount?: number, timeoutMs?: number) => Promise<Response>;
+  /** App-local — refetch fn from the already-instantiated usePoll() call. */
+  refetchPoll: () => unknown;
+  /** App-local useState — advanced node filters (persisted to localStorage). */
+  nodeFilters: NodeFilters;
+  /** App-local useMemo — theme colors merged with overlay scheme colors. */
+  mergedThemeColors: ThemeColors;
+  /** App-local useState setter — opens RouteSegmentTraceroutesModal. */
+  setSelectedRouteSegment: (segment: { nodeNum1: number; nodeNum2: number } | null) => void;
+  /** App-local useState setter — closes PurgeDataModal on delete/purge success. */
+  setShowPurgeDataModal: (show: boolean) => void;
+}
+
+// Helper function to sort nodes
+const sortNodes = (nodes: DeviceInfo[], field: SortField, direction: SortDirection): DeviceInfo[] => {
+  return [...nodes].sort((a, b) => {
+    let aVal: string | number, bVal: string | number;
+
+    switch (field) {
+      case 'longName':
+        aVal = a.user?.longName || `Node ${a.nodeNum}`;
+        bVal = b.user?.longName || `Node ${b.nodeNum}`;
+        break;
+      case 'shortName':
+        aVal = a.user?.shortName || '';
+        bVal = b.user?.shortName || '';
+        break;
+      case 'id':
+        aVal = a.user?.id || a.nodeNum;
+        bVal = b.user?.id || b.nodeNum;
+        break;
+      case 'lastHeard':
+        aVal = a.lastHeard || 0;
+        bVal = b.lastHeard || 0;
+        break;
+      case 'snr':
+        aVal = a.snr || -999;
+        bVal = b.snr || -999;
+        break;
+      case 'battery':
+        aVal = a.deviceMetrics?.batteryLevel || -1;
+        bVal = b.deviceMetrics?.batteryLevel || -1;
+        break;
+      case 'hwModel':
+        aVal = a.user?.hwModel || 0;
+        bVal = b.user?.hwModel || 0;
+        break;
+      case 'hops': {
+        // For nodes without hop data, use fallback values that push them to bottom
+        // Ascending: use 999 (high value = bottom), Descending: use -1 (low value = bottom)
+        const noHopFallback = direction === 'asc' ? 999 : -1;
+        aVal = a.hopsAway !== undefined && a.hopsAway !== null ? a.hopsAway : noHopFallback;
+        bVal = b.hopsAway !== undefined && b.hopsAway !== null ? b.hopsAway : noHopFallback;
+        break;
+      }
+      default:
+        return 0;
+    }
+
+    if (typeof aVal === 'string' && typeof bVal === 'string') {
+      const comparison = aVal.toLowerCase().localeCompare(bVal.toLowerCase());
+      return direction === 'asc' ? comparison : -comparison;
+    } else {
+      const comparison = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+      return direction === 'asc' ? comparison : -comparison;
+    }
+  });
+};
+
+// Helper function to filter nodes
+const filterNodes = (nodes: DeviceInfo[], filter: string): DeviceInfo[] => {
+  if (!filter.trim()) return nodes;
+
+  const lowerFilter = filter.toLowerCase();
+  return nodes.filter(node => {
+    const longName = (node.user?.longName || '').toLowerCase();
+    const shortName = (node.user?.shortName || '').toLowerCase();
+    const id = (node.user?.id || '').toLowerCase();
+
+    return longName.includes(lowerFilter) || shortName.includes(lowerFilter) || id.includes(lowerFilter);
+  });
+};
+
+export function useSourceView(params: UseSourceViewParams) {
+  const { baseUrl, authFetch, refetchPoll, nodeFilters, mergedThemeColors, setSelectedRouteSegment, setShowPurgeDataModal } = params;
+
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  const { sourceId } = useSource();
+  const { nodes, setNodes, currentNodeId, connectionStatus } = useData();
+  const { selectedDMNode, setSelectedDMNode } = useMessaging();
+  const { maxNodeAgeHours, distanceUnit } = useSettings();
+  const {
+    activeTab,
+    nodesNodeFilter,
+    sortField,
+    sortDirection,
+    setTracerouteLoading,
+    showIncompleteNodes,
+  } = useUI();
+  const {
+    showPaths,
+    showRoute,
+    showMqttNodes,
+    showUdpNodes,
+    showRfNodes,
+    showEstimatedPositions,
+    setMapCenterTarget,
+    traceroutes,
+    selectedNodeId,
+    setSelectedNodeId,
+    mapZoom,
+    mapMaxAgeHours,
+  } = useMapContext();
+  const { nodesWithTelemetry, nodesWithWeather: nodesWithWeatherTelemetry, nodesWithEstimatedPosition, nodesWithPKC } =
+    useTelemetryNodes();
+
+  const markerRefs = useRef<Map<string, L.Marker>>(new Map());
+
+  // Helper to check if we should show cached data
+  const shouldShowData = useCallback(() => {
+    return connectionStatus === 'connected' || connectionStatus === 'user-disconnected';
+  }, [connectionStatus]);
+
+  const handleTraceroute = useCallback(
+    async (nodeId: string, channel?: number) => {
+      if (connectionStatus !== 'connected') {
+        return;
+      }
+
+      try {
+        // Set loading state
+        setTracerouteLoading(nodeId);
+
+        // Convert nodeId to node number
+        const nodeNumStr = nodeId.replace('!', '');
+        const nodeNum = parseInt(nodeNumStr, 16);
+
+        await authFetch(`${baseUrl}/api/traceroute`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ destination: nodeNum, sourceId, ...(channel !== undefined && { channel }) }),
+        });
+
+        logger.debug(`🗺️ Traceroute request sent to ${nodeId}`);
+
+        // Poll for traceroute results with increasing delays
+        // This provides faster UI feedback instead of waiting for the 5s poll interval
+        const pollDelays = [2000, 5000, 10000, 15000]; // 2s, 5s, 10s, 15s
+        pollDelays.forEach(delay => {
+          setTimeout(() => {
+            void refetchPoll();
+          }, delay);
+        });
+
+        // Clear loading state after 30 seconds
+        setTimeout(() => {
+          setTracerouteLoading(null);
+        }, 30000);
+      } catch (error) {
+        logger.error('Failed to send traceroute:', error);
+        setTracerouteLoading(null);
+      }
+    },
+    [connectionStatus, setTracerouteLoading, authFetch, baseUrl, sourceId, refetchPoll]
+  );
+
+  const handleDeleteNode = useCallback(
+    async (nodeNum: number) => {
+      const node = nodes.find(n => n.nodeNum === nodeNum);
+      const nodeName = node?.user?.shortName || node?.user?.longName || `Node ${nodeNum}`;
+
+      if (
+        !window.confirm(
+          `Are you sure you want to DELETE ${nodeName} from the local database?\n\nThis will remove:\n- The node from the map and node list\n- All messages with this node\n- All traceroutes for this node\n- All telemetry data for this node\n\nThis action cannot be undone.`
+        )
+      ) {
+        return;
+      }
+
+      try {
+        const response = await authFetch(`${baseUrl}/api/messages/nodes/${nodeNum}`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ sourceId }),
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          showToast(
+            t('toast.deleted_node', {
+              node: nodeName,
+              messages: data.messagesDeleted,
+              traceroutes: data.traceroutesDeleted,
+              telemetry: data.telemetryDeleted,
+            }),
+            'success'
+          );
+          // Close the purge data modal if open
+          setShowPurgeDataModal(false);
+          // Clear the selected DM node if it's the one being deleted
+          const deletedNode = nodes.find(n => n.nodeNum === nodeNum);
+          if (deletedNode && selectedDMNode === deletedNode.user?.id) {
+            setSelectedDMNode('');
+          }
+          // Refresh data from backend to ensure consistency
+          void refetchPoll();
+        } else {
+          const errorData = await response.json();
+          showToast(t('toast.failed_delete_node', { error: errorData.message || t('errors.unknown') }), 'error');
+        }
+      } catch (err) {
+        showToast(
+          t('toast.failed_delete_node', { error: err instanceof Error ? err.message : t('errors.network') }),
+          'error'
+        );
+      }
+    },
+    [nodes, authFetch, baseUrl, sourceId, showToast, t, setShowPurgeDataModal, selectedDMNode, setSelectedDMNode, refetchPoll]
+  );
+
+  const handlePurgeNodeFromDevice = useCallback(
+    async (nodeNum: number) => {
+      const node = nodes.find(n => n.nodeNum === nodeNum);
+      const nodeName = node?.user?.shortName || node?.user?.longName || `Node ${nodeNum}`;
+
+      if (
+        !window.confirm(
+          `Are you sure you want to PURGE ${nodeName} from BOTH the connected device AND the local database?\n\nThis will:\n- Send an admin command to remove the node from the device NodeDB\n- Remove the node from the map and node list\n- Delete all messages with this node\n- Delete all traceroutes for this node\n- Delete all telemetry data for this node\n\nThis action cannot be undone and affects both the device and local database.`
+        )
+      ) {
+        return;
+      }
+
+      try {
+        const response = await authFetch(`${baseUrl}/api/messages/nodes/${nodeNum}/purge-from-device`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ sourceId }),
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          showToast(
+            t('toast.purged_node_device', {
+              node: nodeName,
+              messages: data.messagesDeleted,
+              traceroutes: data.traceroutesDeleted,
+              telemetry: data.telemetryDeleted,
+            }),
+            'success'
+          );
+          // Close the purge data modal if open
+          setShowPurgeDataModal(false);
+          // Clear the selected DM node if it's the one being deleted
+          const purgedNode = nodes.find(n => n.nodeNum === nodeNum);
+          if (purgedNode && selectedDMNode === purgedNode.user?.id) {
+            setSelectedDMNode('');
+          }
+          // Refresh data from backend to ensure consistency
+          void refetchPoll();
+        } else {
+          const errorData = await response.json();
+          showToast(t('toast.failed_purge_node_device', { error: errorData.message || t('errors.unknown') }), 'error');
+        }
+      } catch (err) {
+        showToast(
+          t('toast.failed_purge_node_device', { error: err instanceof Error ? err.message : t('errors.network') }),
+          'error'
+        );
+      }
+    },
+    [nodes, authFetch, baseUrl, sourceId, showToast, t, setShowPurgeDataModal, selectedDMNode, setSelectedDMNode, refetchPoll]
+  );
+
+  // Get processed (filtered and sorted) nodes
+  const processedNodes = useMemo((): DeviceInfo[] => {
+    const cutoffTime = Date.now() / 1000 - maxNodeAgeHours * 60 * 60;
+
+    // Age filter (favorites are always visible)
+    const ageFiltered = nodes.filter(node => {
+      if (node.isFavorite) return true;
+      if (!node.lastHeard) return false;
+      return node.lastHeard >= cutoffTime;
+    });
+
+    // Only apply nodesNodeFilter when Nodes tab is active
+    // Messages tab will apply its own messagesNodeFilter
+    const textFiltered = activeTab === 'nodes' ? filterNodes(ageFiltered, nodesNodeFilter) : ageFiltered;
+
+    // Apply advanced filters
+    const advancedFiltered = textFiltered.filter(node => {
+      const nodeId = node.user?.id;
+      const isShowMode = nodeFilters.filterMode === 'show';
+
+      // MQTT filter
+      if (nodeFilters.showMqtt) {
+        const matches = node.viaMqtt;
+        if (isShowMode && !matches) return false; // Show mode: exclude non-matches
+        if (!isShowMode && matches) return false; // Hide mode: exclude matches
+      }
+
+      // Telemetry filter
+      if (nodeFilters.showTelemetry) {
+        const matches = nodeId && nodesWithTelemetry.has(nodeId);
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Environment metrics filter
+      if (nodeFilters.showEnvironment) {
+        const matches = nodeId && nodesWithWeatherTelemetry.has(nodeId);
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Power source filter
+      const batteryLevel = node.deviceMetrics?.batteryLevel;
+      if (nodeFilters.powerSource !== 'both' && batteryLevel !== undefined) {
+        const isPowered = batteryLevel === 101;
+        if (nodeFilters.powerSource === 'powered' && !isPowered) {
+          return false;
+        }
+        if (nodeFilters.powerSource === 'battery' && isPowered) {
+          return false;
+        }
+      }
+
+      // Position filter
+      if (nodeFilters.showPosition) {
+        const hasPosition = node.position && node.position.latitude != null && node.position.longitude != null;
+        const matches = hasPosition;
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Hops filter (always applies regardless of mode)
+      if (node.hopsAway != null) {
+        if (node.hopsAway < nodeFilters.minHops || node.hopsAway > nodeFilters.maxHops) {
+          return false;
+        }
+      }
+
+      // PKI filter
+      if (nodeFilters.showPKI) {
+        const matches = nodeId && nodesWithPKC.has(nodeId);
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Remote Admin filter
+      if (nodeFilters.showRemoteAdmin) {
+        const matches = !!node.hasRemoteAdmin;
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      /**
+       * Unknown nodes filter
+       * Identifies nodes that lack both longName and shortName, which are typically
+       * displayed as "Node 12345678" in the UI. These nodes have only been detected
+       * but haven't provided identifying information yet.
+       */
+      if (nodeFilters.showUnknown) {
+        const hasLongName = node.user?.longName && node.user.longName.trim() !== '';
+        const hasShortName = node.user?.shortName && node.user.shortName.trim() !== '';
+        const isUnknown = !hasLongName && !hasShortName;
+        const matches = isUnknown;
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Ignored nodes filter - hide ignored nodes by default
+      // When showIgnored is false (default): hide ignored nodes
+      // When showIgnored is true: show ignored nodes
+      if (!nodeFilters.showIgnored && node.isIgnored) {
+        return false;
+      }
+
+      // Favorite locked filter
+      if (nodeFilters.showFavoriteLocked) {
+        const matches = !!node.favoriteLocked;
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Device role filter
+      if (nodeFilters.deviceRoles.length > 0) {
+        const role = typeof node.user?.role === 'number' ? node.user.role : parseInt(node.user?.role || '0');
+        const matches = nodeFilters.deviceRoles.includes(role);
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Channel filter
+      if (nodeFilters.channels.length > 0) {
+        const nodeChannel = node.channel ?? -1;
+        const matches = nodeFilters.channels.includes(nodeChannel);
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      return true;
+    });
+
+    // Separate favorites from non-favorites
+    const favorites = advancedFiltered.filter(node => node.isFavorite);
+    const nonFavorites = advancedFiltered.filter(node => !node.isFavorite);
+
+    // Sort each group independently
+    const sortedFavorites = sortNodes(favorites, sortField, sortDirection);
+    const sortedNonFavorites = sortNodes(nonFavorites, sortField, sortDirection);
+
+    // Concatenate: favorites first, then non-favorites
+    return [...sortedFavorites, ...sortedNonFavorites];
+  }, [
+    nodes,
+    maxNodeAgeHours,
+    activeTab,
+    nodesNodeFilter,
+    sortField,
+    sortDirection,
+    nodeFilters,
+    nodesWithTelemetry,
+    nodesWithWeatherTelemetry,
+    nodesWithPKC,
+  ]);
+
+  // Function to center map on a specific node
+  const centerMapOnNode = useCallback(
+    (node: DeviceInfo) => {
+      const effectivePos = getEffectivePosition(node);
+      if (effectivePos.latitude != null && effectivePos.longitude != null) {
+        setMapCenterTarget([effectivePos.latitude, effectivePos.longitude]);
+      }
+    },
+    [setMapCenterTarget]
+  );
+
+  // Function to toggle node favorite status
+  const toggleFavorite = useCallback(
+    async (node: DeviceInfo, event: React.MouseEvent) => {
+      event.stopPropagation(); // Prevent node selection when clicking star
+
+      if (!node.user?.id) {
+        logger.error('Cannot toggle favorite: node has no user ID');
+        return;
+      }
+
+      // Prevent multiple rapid clicks on the same node (scoped to current source)
+      const favKey = favoritePendingKey(sourceId, node.nodeNum);
+      if (pendingFavoriteRequests.get(favKey) !== undefined) {
+        return;
+      }
+
+      // Store the original state before any updates
+      const originalFavoriteStatus = node.isFavorite;
+      const newFavoriteStatus = !originalFavoriteStatus;
+
+      try {
+        // Mark this request as pending with the expected new state
+        pendingFavoriteRequests.set(favKey, newFavoriteStatus);
+
+        // Optimistically update the UI - use flushSync to force immediate render
+        // This prevents the polling from overwriting the optimistic update before it renders
+        flushSync(() => {
+          setNodes(prevNodes => {
+            const updated = prevNodes.map(n =>
+              n.nodeNum === node.nodeNum ? { ...n, isFavorite: newFavoriteStatus } : n
+            );
+            return updated;
+          });
+        });
+
+        // Send update to backend (with device sync enabled by default)
+        const response = await authFetch(`${baseUrl}/api/nodes/${node.user.id}/favorite`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            isFavorite: newFavoriteStatus,
+            syncToDevice: true, // Enable two-way sync to Meshtastic device
+            sourceId,
+          }),
+        });
+
+        if (!response.ok) {
+          if (response.status === 403) {
+            showToast(t('toast.insufficient_permissions_favorites'), 'error');
+            // Revert to original state using the saved original value
+            setNodes(prevNodes =>
+              prevNodes.map(n => (n.nodeNum === node.nodeNum ? { ...n, isFavorite: originalFavoriteStatus } : n))
+            );
+            return;
+          }
+          throw new Error('Failed to update favorite status');
+        }
+
+        const result = await response.json();
+
+        // Log the result including device sync status
+        let statusMessage = `${newFavoriteStatus ? '⭐' : '☆'} Node ${node.user.id} favorite status updated`;
+        if (result.deviceSync) {
+          if (result.deviceSync.status === 'success') {
+            statusMessage += ' (synced to device ✓)';
+          } else if (result.deviceSync.status === 'failed') {
+            // Only show error for actual failures (not firmware compatibility)
+            statusMessage += ` (device sync failed: ${result.deviceSync.error || 'unknown error'})`;
+          }
+          // 'skipped' status (e.g., pre-2.7 firmware) is not shown to user - logged on server only
+        }
+        logger.debug(statusMessage);
+      } catch (error) {
+        logger.error('Error toggling favorite:', error);
+        // Revert to original state using the saved original value
+        setNodes(prevNodes =>
+          prevNodes.map(n => (n.nodeNum === node.nodeNum ? { ...n, isFavorite: originalFavoriteStatus } : n))
+        );
+        // Remove from pending on error since we reverted
+        pendingFavoriteRequests.delete(favKey);
+        showToast(t('toast.failed_update_favorite'), 'error');
+      }
+      // Note: On success, the polling logic will remove from pendingFavoriteRequests
+      // when it detects the server has caught up
+    },
+    [sourceId, setNodes, authFetch, baseUrl, showToast, t]
+  );
+
+  // Function to toggle node favorite lock status
+  const toggleFavoriteLock = useCallback(
+    async (node: DeviceInfo, event: React.MouseEvent) => {
+      event.stopPropagation();
+
+      if (!node.user?.id) {
+        logger.error('Cannot toggle favorite lock: node has no user ID');
+        return;
+      }
+
+      const newLocked = !node.favoriteLocked;
+
+      try {
+        // Optimistically update the UI
+        flushSync(() => {
+          setNodes(prevNodes =>
+            prevNodes.map(n =>
+              n.nodeNum === node.nodeNum ? { ...n, favoriteLocked: newLocked } : n
+            )
+          );
+        });
+
+        const response = await authFetch(`${baseUrl}/api/nodes/${node.user.id}/favorite-lock`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ locked: newLocked, sourceId }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Server returned ${response.status}`);
+        }
+
+        logger.debug(`${newLocked ? '🔒' : '🔓'} Node ${node.user.id} favorite lock set to: ${newLocked}`);
+      } catch (error) {
+        logger.error('Error toggling favorite lock:', error);
+        // Revert
+        setNodes(prevNodes =>
+          prevNodes.map(n =>
+            n.nodeNum === node.nodeNum ? { ...n, favoriteLocked: !newLocked } : n
+          )
+        );
+        showToast(t('toast.failed_update_favorite_lock', 'Failed to update favorite lock'), 'error');
+      }
+    },
+    [setNodes, authFetch, baseUrl, sourceId, showToast, t]
+  );
+
+  // Effective map age cap for traceroute/route-segment visibility (#3322):
+  // the Map Features age slider, clamped to [1, maxNodeAgeHours]. null =
+  // follow the global setting, so default behavior is unchanged.
+  const effectiveMapMaxAge = effectiveMapMaxAgeHours(mapMaxAgeHours, maxNodeAgeHours);
+
+  // Create stable digests of nodes and traceroutes that only change when relevant data changes
+  // This prevents unnecessary recalculation of traceroutePathsElements
+  // Uses getEffectivePosition to respect position overrides (Issue #1526)
+  const nodesPositionDigest = useMemo(() => {
+    return nodes.map(n => {
+      const effectivePos = getEffectivePosition(n);
+      return {
+        nodeNum: n.nodeNum,
+        position: effectivePos.latitude != null && effectivePos.longitude != null
+          ? {
+              latitude: effectivePos.latitude,
+              longitude: effectivePos.longitude,
+            }
+          : undefined,
+        user: n.user
+          ? {
+              longName: n.user.longName,
+              shortName: n.user.shortName,
+              id: n.user.id,
+            }
+          : undefined,
+        viaMqtt: n.viaMqtt ?? false,
+      };
+    });
+  }, [nodes.map(n => {
+    const pos = getEffectivePosition(n);
+    return `${n.nodeNum}-${pos.latitude}-${pos.longitude}-${n.viaMqtt ? '1' : '0'}`;
+  }).join(',')]);
+
+  const traceroutesDigest = useMemo(() => {
+    return traceroutes.map(tr => ({
+      fromNodeNum: tr.fromNodeNum,
+      toNodeNum: tr.toNodeNum,
+      fromNodeId: tr.fromNodeId,
+      toNodeId: tr.toNodeId,
+      route: tr.route,
+      routeBack: tr.routeBack,
+      snrTowards: tr.snrTowards,
+      snrBack: tr.snrBack,
+      timestamp: tr.timestamp,
+      createdAt: tr.createdAt,
+    }));
+  }, [
+    traceroutes
+      .map(tr => `${tr.fromNodeNum}-${tr.toNodeNum}-${tr.route}-${tr.routeBack}-${tr.timestamp || tr.createdAt}`)
+      .join(','),
+  ]);
+
+  // Traceroute paths rendering - extracted to useTraceroutePaths hook
+  const tracerouteCallbacks = useMemo(
+    () => ({
+      onSelectNode: (nodeId: string, position: [number, number]) => {
+        setSelectedNodeId(nodeId);
+        setMapCenterTarget(position);
+      },
+      onSelectRouteSegment: (nodeNum1: number, nodeNum2: number) => {
+        setSelectedRouteSegment({ nodeNum1, nodeNum2 });
+      },
+    }),
+    [setSelectedNodeId, setMapCenterTarget, setSelectedRouteSegment]
+  );
+
+  // Compute visible node numbers for neighbor-info line and traceroute path filtering.
+  // Must mirror the per-marker filter in NodesTab so that lines are hidden whenever
+  // their endpoint nodes are hidden (Issues #1102, #3147).
+  const visibleNodeNums = useMemo(() => {
+    // #4240: one clock read per recompute. Deliberately computed INSIDE the memo
+    // rather than listed as a dependency — a fresh timestamp every render would
+    // invalidate this memo on every render.
+    const transportCutoff = transportCutoffSec(effectiveMapMaxAge);
+    const visibleNodes = processedNodes.filter(node => {
+      if (!node.position?.latitude || !node.position?.longitude) return false;
+      // #4162/#3549: "Hide from Map" suppresses the marker (NodesTab drops it
+      // at nodesWithPosition), so it must also drop from this visible set —
+      // otherwise route-segment / neighbor lines dangle to a marker-less node.
+      if (node.hideFromMap) return false;
+      if (!nodePassesTransportFilter(node, { showRfNodes, showUdpNodes, showMqttNodes }, transportCutoff)) return false;
+      if (!showIncompleteNodes && !isNodeComplete(node)) return false;
+      if (!showEstimatedPositions && node.user?.id && nodesWithEstimatedPosition.has(node.user.id)) return false;
+      return true;
+    });
+    return new Set(visibleNodes.map(n => n.nodeNum));
+  }, [processedNodes, showRfNodes, showUdpNodes, showMqttNodes, showIncompleteNodes, showEstimatedPositions, nodesWithEstimatedPosition, effectiveMapMaxAge]);
+
+  const { traceroutePathsElements, selectedNodeTraceroute, tracerouteNodeNums, tracerouteBounds } = useTraceroutePaths({
+    showPaths,
+    showRoute,
+    selectedNodeId,
+    currentNodeId,
+    nodesPositionDigest,
+    traceroutesDigest,
+    distanceUnit,
+    maxNodeAgeHours: effectiveMapMaxAge,
+    themeColors: mergedThemeColors,
+    callbacks: tracerouteCallbacks,
+    visibleNodeNums,
+    mapZoom,
+  });
+
+  return {
+    processedNodes,
+    shouldShowData,
+    centerMapOnNode,
+    toggleFavorite,
+    toggleFavoriteLock,
+    markerRefs,
+    traceroutePathsElements,
+    selectedNodeTraceroute,
+    visibleNodeNums,
+    tracerouteNodeNums,
+    tracerouteBounds,
+    handleTraceroute,
+    handleDeleteNode,
+    handlePurgeNodeFromDevice,
+  };
+}

--- a/src/utils/pendingToggles.ts
+++ b/src/utils/pendingToggles.ts
@@ -79,3 +79,26 @@ export class PendingToggleMap {
 export function sweepAll(maps: PendingToggleMap[], now: number = Date.now()): void {
   for (const map of maps) map.sweep(now);
 }
+
+// Track pending favorite/ignored/hide-from-map requests as module-level
+// singletons so they persist across remounts (App is re-keyed on source
+// switch) and are shared between App.tsx's poll reconciliation
+// (processPollData) and the toggle handlers now living in
+// `src/hooks/useSourceView.ts` (#3962 5.4 PR4). Keys are composite strings
+// `${sourceId}:${nodeNum}` so that an optimistic toggle on Source A does not
+// bleed into Source B's view of the same node (bug: single nodeNum key meant
+// clicking favorite on Source 1 forced the same optimistic state onto Source
+// 2's poll response because both sources share nodeNums on overlapping
+// meshes).
+export const favoritePendingKey = (sourceId: string | null | undefined, nodeNum: number) =>
+  `${sourceId ?? ''}:${nodeNum}`;
+
+export const pendingFavoriteRequests = new PendingToggleMap();
+export const pendingIgnoredRequests = new PendingToggleMap();
+export const pendingHideFromMapRequests = new PendingToggleMap();
+
+export const ALL_PENDING_TOGGLE_MAPS = [
+  pendingFavoriteRequests,
+  pendingIgnoredRequests,
+  pendingHideFromMapRequests,
+];


### PR DESCRIPTION
## Summary
PR4 of the Task 5.4 stack (remediation epic #3962) — the high-risk one: the `nodes` tab (default/index view) becomes a route, and the node/traceroute/map orchestration core (~580 lines of state, memos incl. the ~150-line `processedNodes`, and handlers) extracts from App.tsx into a new `useSourceView` hook. App.tsx: 5,368 → 4,789 (−579). `NodesTab.tsx` itself is **byte-identical** — the hook reproduces its exact prop surface.

The optimistic pending-toggle singletons moved from App to `utils/pendingToggles.ts` (breaking a would-be circular import with the hook). Marker/spiderfy wiring unchanged: `markerRefs` now originates in the hook but App destructures the same binding, so the popup effect and NodesTab's registration logic needed zero edits (both spiderfy test files pass unchanged).

## Browser validation (dev container, deployed 69af0b93)
- Bare source URL → index redirect lands on `/nodes` (default-tab behavior) ✓
- Full render via the hook: 221 node entries, 182 map markers ✓
- Favorite toggle round-trip: Add → auto-favorite set → reverted (optimistic path through the relocated singletons) ✓
- Console: zero errors

## Issues Resolved
Relates to #3962 (Phase 5.4, PR 4 of ~8).

## Testing
- [x] Full Vitest suite: success=true, 10,318 passed, 0 failed, 0 failed suites (incl. all 67 NodesTab/spiderfy/App pin tests unchanged)
- [x] New `useSourceView.test.ts` (11 tests: orchestration surface + traceroute selection transitions)
- [x] `tsc --noEmit` 0; `typecheck:tests` 304 = main parity; `lint:ci` green (App exhaustive-deps 20→16, any 5→3; hook adds only the 2 relocated digest-memo entries — net zero)
- [ ] Reviewer: hook params vs context re-subscription split (4 census items deliberately NOT routed through the hook — they're plain context pass-throughs App still needs for un-migrated tabs; documented in the epic log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158hFzsVbodeJK246qAE1dY