### PR TITLE
refactor(frontend): migrate info/dashboard/configuration tabs to routes (#3962 5.4 PR5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4206,6 +4206,23 @@ function App() {
             }
           />
           <Route
+            path="configuration"
+            element={
+              <ErrorBoundary fallbackTitle="Configuration failed to load">
+                <ConfigurationTab
+                  key={sourceId || 'default'}
+                  baseUrl={baseUrl}
+                  nodes={nodes}
+                  channels={channels}
+                  onRebootDevice={handleRebootDevice}
+                  onConfigChangeTriggeringReboot={handleConfigChangeTriggeringReboot}
+                  onChannelsUpdated={() => fetchChannels()}
+                  refreshTrigger={configRefreshTrigger}
+                />
+              </ErrorBoundary>
+            }
+          />
+          <Route
             path="nodes"
             element={
               <ErrorBoundary fallbackTitle="Nodes failed to load">
@@ -4651,23 +4668,11 @@ function App() {
           </SaveBarGroup>
           </ErrorBoundary>
         )}
-        {activeTab === 'configuration' && (
-          <ErrorBoundary fallbackTitle="Configuration failed to load">
-          <ConfigurationTab
-            key={sourceId || 'default'}
-            baseUrl={baseUrl}
-            nodes={nodes}
-            channels={channels}
-            onRebootDevice={handleRebootDevice}
-            onConfigChangeTriggeringReboot={handleConfigChangeTriggeringReboot}
-            onChannelsUpdated={() => fetchChannels()}
-            refreshTrigger={configRefreshTrigger}
-          />
-          </ErrorBoundary>
-        )}
         {/* 'audit' migrated to <Route path="audit"> above (#3962 5.4 PR1 proof leaf) */}
         {/* 'notifications', 'users', 'admin', 'security', 'mqtt-config', 'packetmonitor'
             migrated to <Route> elements above (#3962 5.4 PR3 leaf tab group) */}
+        {/* 'info', 'dashboard', 'configuration' migrated to <Route> elements above
+            (#3962 5.4 PR5) */}
           </>} />
         </Routes>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4187,6 +4187,25 @@ function App() {
             }
           />
           <Route
+            path="dashboard"
+            element={
+              <ErrorBoundary fallbackTitle="Dashboard failed to load">
+                <Dashboard
+                  temperatureUnit={temperatureUnit}
+                  telemetryHours={telemetryVisualizationHours}
+                  favoriteTelemetryStorageDays={favoriteTelemetryStorageDays}
+                  baseUrl={baseUrl}
+                  currentNodeId={currentNodeId}
+                  canEdit={hasPermission('dashboard', 'write')}
+                  onOpenNodeDetails={(nodeId: string) => {
+                    setSelectedDMNode(nodeId);
+                    setActiveTab('messages');
+                  }}
+                />
+              </ErrorBoundary>
+            }
+          />
+          <Route
             path="nodes"
             element={
               <ErrorBoundary fallbackTitle="Nodes failed to load">
@@ -4337,22 +4356,6 @@ function App() {
                 setMapCenterTarget([node.position.latitude, node.position.longitude]);
                 setActiveTab('nodes');
               }
-            }}
-          />
-          </ErrorBoundary>
-        )}
-        {activeTab === 'dashboard' && (
-          <ErrorBoundary fallbackTitle="Dashboard failed to load">
-          <Dashboard
-            temperatureUnit={temperatureUnit}
-            telemetryHours={telemetryVisualizationHours}
-            favoriteTelemetryStorageDays={favoriteTelemetryStorageDays}
-            baseUrl={baseUrl}
-            currentNodeId={currentNodeId}
-            canEdit={hasPermission('dashboard', 'write')}
-            onOpenNodeDetails={(nodeId: string) => {
-              setSelectedDMNode(nodeId);
-              setActiveTab('messages');
             }}
           />
           </ErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4161,6 +4161,32 @@ function App() {
             }
           />
           <Route
+            path="info"
+            element={
+              <ErrorBoundary fallbackTitle="Info failed to load">
+                <InfoTab
+                  connectionStatus={connectionStatus}
+                  nodeAddress={nodeAddress}
+                  deviceInfo={deviceInfo}
+                  deviceConfig={deviceConfig}
+                  nodes={nodes}
+                  channels={channels}
+                  messages={messages}
+                  channelMessages={channelMessages}
+                  currentNodeId={currentNodeId}
+                  temperatureUnit={temperatureUnit}
+                  telemetryHours={telemetryVisualizationHours}
+                  baseUrl={baseUrl}
+                  getAvailableChannels={getAvailableChannels}
+                  distanceUnit={distanceUnit}
+                  timeFormat={timeFormat}
+                  dateFormat={dateFormat}
+                  isAuthenticated={authStatus?.authenticated || false}
+                />
+              </ErrorBoundary>
+            }
+          />
+          <Route
             path="nodes"
             element={
               <ErrorBoundary fallbackTitle="Nodes failed to load">
@@ -4312,29 +4338,6 @@ function App() {
                 setActiveTab('nodes');
               }
             }}
-          />
-          </ErrorBoundary>
-        )}
-        {activeTab === 'info' && (
-          <ErrorBoundary fallbackTitle="Info failed to load">
-          <InfoTab
-            connectionStatus={connectionStatus}
-            nodeAddress={nodeAddress}
-            deviceInfo={deviceInfo}
-            deviceConfig={deviceConfig}
-            nodes={nodes}
-            channels={channels}
-            messages={messages}
-            channelMessages={channelMessages}
-            currentNodeId={currentNodeId}
-            temperatureUnit={temperatureUnit}
-            telemetryHours={telemetryVisualizationHours}
-            baseUrl={baseUrl}
-            getAvailableChannels={getAvailableChannels}
-            distanceUnit={distanceUnit}
-            timeFormat={timeFormat}
-            dateFormat={dateFormat}
-            isAuthenticated={authStatus?.authenticated || false}
           />
           </ErrorBoundary>
         )}


### PR DESCRIPTION
## Summary
PR5 of the Task 5.4 stack (remediation epic #3962): `info`, `dashboard` (the in-App per-source dashboard, distinct from the root DashboardPage), and `configuration` move from `activeTab` render blocks to routes. Props threaded verbatim; ConfigurationTab internals untouched (live device-config surface — only the mounting moved); the shared effect-based permission redirects apply unchanged through the adapter. App.tsx 4,789 → 4,800 (+11 route-wrapper boilerplate; condensing is PR8's job).

## Browser validation (dev container, deployed 05a746f3)
- `/info`, `/dashboard`, `/configuration` all render fully (configuration shows every section: Node Identity, Device, LoRa, Position, Power, Display…) ✓
- Console clean (known locales-fallback 404 only)

## Issues Resolved
Relates to #3962 (Phase 5.4, PR 5 of ~8).

## Testing
- [x] Full Vitest suite: success=true, 10,326 passed, 0 failed, 0 failed suites
- [x] `tsc --noEmit` 0; `typecheck:tests` 304 = main parity; `lint:ci` green; build OK
- [ ] Reviewer: confirm ConfigurationTab's key/refreshTrigger/handler props are byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158hFzsVbodeJK246qAE1dY