### PR TITLE
refactor(frontend): messages/channels routes + useMessagingView hook (#3962 5.4 PR7)

### DIFF
--- a/eslint-baseline.json
+++ b/eslint-baseline.json
@@ -18,9 +18,8 @@
     "no-restricted-syntax": 2
   },
   "src/App.tsx": {
-    "@typescript-eslint/no-explicit-any": 1,
     "preserve-caught-error": 1,
-    "react-hooks/exhaustive-deps": 16
+    "react-hooks/exhaustive-deps": 10
   },
   "src/cli/migrate-db.ts": {
     "@typescript-eslint/no-explicit-any": 3,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,10 +54,9 @@ import { logger } from './utils/logger';
 // visibleNodeNums/centerMapOnNode to useSourceView (#3962 5.4 PR4)
 import { settingsToMatrix } from './utils/autoAckMatrix';
 import { applyHomoglyphOptimization } from './utils/homoglyph';
-import { playSound, playChannelSound, DEFAULT_SOUND_ID } from './utils/notificationSounds';
 import Sidebar from './components/Sidebar';
 import { SearchModal } from './components/SearchModal/SearchModal.js';
-import { SettingsProvider, useSettings, useNotificationMuteSettings } from './contexts/SettingsContext';
+import { SettingsProvider, useSettings } from './contexts/SettingsContext';
 import { MapProvider, useMapContext } from './contexts/MapContext';
 import type { PositionHistoryItem } from './contexts/MapContext';
 import { DataProvider, useData } from './contexts/DataContext';
@@ -74,6 +73,7 @@ import { useTxStatus } from './hooks/useTxStatus';
 import { useVersionCheck } from './hooks/useVersionCheck';
 import { usePoll, type PollData } from './hooks/usePoll';
 import { useSourceView } from './hooks/useSourceView';
+import { useMessagingView } from './hooks/useMessagingView';
 import { useNotificationNavigationHandler } from './hooks/useNotificationNavigationHandler';
 import LoginModal from './components/LoginModal';
 import LoginPage from './components/LoginPage';
@@ -217,21 +217,14 @@ function App() {
   const showRebootModalRef = useRef<boolean>(false); // Track reboot modal state for interval closure
   const connectionStatusRef = useRef<string>('disconnected'); // Track connection status for interval closure
   const localNodeIdRef = useRef<string>(''); // Track local node ID for immediate access (bypasses React state delay)
-  const pendingMessagesRef = useRef<Map<string, MeshMessage>>(new Map()); // Track pending messages for interval access (bypasses closure stale state)
+  // pendingMessagesRef, the container refs, and channelMessagesRef/messagesRef
+  // moved into useMessagingView (#3962 5.4 PR7) — that hook now owns them and
+  // returns pendingMessagesRef/channelMessagesContainerRef/dmMessagesContainerRef
+  // for the send/resend/tapback handlers below to keep using.
   const homoglyphEnabledRef = useRef<boolean>(false); // Track homoglyph setting for send handlers
 
   // Constants for emoji tapbacks
   const EMOJI_FLAG = 1; // Protobuf flag indicating this is a tapback/reaction
-
-  const channelMessagesContainerRef = useRef<HTMLDivElement>(null);
-  const dmMessagesContainerRef = useRef<HTMLDivElement>(null);
-  const lastScrollLoadTimeRef = useRef<number>(0); // Throttle scroll-triggered loads (200ms)
-  // Track latest channelMessages/messages via refs so the infinite-scroll loaders
-  // see current state without rebuilding their closure on every poll. Without
-  // this the first scroll-up uses a stale offset (0) captured at mount and the
-  // resulting fetch is filtered out by dedup, so the user sees nothing load.
-  const channelMessagesRef = useRef<{ [key: number]: MeshMessage[] }>({});
-  const messagesRef = useRef<MeshMessage[]>([]);
 
   // Detect base URL from pathname
   const detectBaseUrl = () => {
@@ -301,7 +294,6 @@ function App() {
     solarMonitoringLongitude,
     solarMonitoringAzimuth,
     solarMonitoringDeclination,
-    enableAudioNotifications,
     tapbackEmojis,
     setMaxNodeAgeHours,
     setInactiveNodeThresholdHours,
@@ -329,7 +321,9 @@ function App() {
     overlayColors: schemeColors,
   } = useSettings();
 
-  const { isChannelMuted, isDMMuted } = useNotificationMuteSettings();
+  // isChannelMuted/isDMMuted moved into useMessagingView (#3962 5.4 PR7) —
+  // its only consumer (applyPollMessages' notification-sound logic) lives
+  // there now, which calls useNotificationMuteSettings() itself.
 
   // Map context
   // showPaths/showRoute/showMqttNodes/showUdpNodes/showRfNodes/
@@ -359,10 +353,6 @@ function App() {
     setChannels,
     connectionStatus,
     setConnectionStatus,
-    messages,
-    setMessages,
-    channelMessages,
-    setChannelMessages,
     deviceInfo,
     setDeviceInfo,
     deviceConfig,
@@ -371,14 +361,6 @@ function App() {
     setCurrentNodeId,
     nodeAddress,
     setNodeAddress,
-    channelHasMore,
-    setChannelHasMore,
-    channelLoadingMore,
-    setChannelLoadingMore,
-    dmHasMore,
-    setDmHasMore,
-    dmLoadingMore,
-    setDmLoadingMore,
   } = useData();
 
   // Telemetry availability Sets (nodesWithTelemetry/nodesWithWeatherTelemetry/
@@ -386,6 +368,12 @@ function App() {
   // the poll cache (#3962 5.4 PR2) but were consumed ONLY by processedNodes/
   // visibleNodeNums, both now owned by useSourceView (#3962 5.4 PR4), which
   // calls useTelemetryNodes() itself.
+
+  // messages/channelMessages (+ their channelHasMore/channelLoadingMore/
+  // dmHasMore/dmLoadingMore pagination state) were sourced here directly from
+  // DataContext but are not pure poll-cache mirrors — the optimistic-send
+  // merge and infinite-scroll pagination logic they need now live in
+  // useMessagingView (#3962 5.4 PR7), which owns this state itself.
 
   // Consolidated polling for nodes, messages, channels, config
   // Enabled only when connected and not in reboot/user-disconnected state
@@ -518,15 +506,10 @@ function App() {
     unreadCountsData,
   } = useMessaging();
 
-  // The poll callback (processPollData) is memoized without unreadCountsData in
-  // its deps, so bridge the latest filtered counts through a ref. This lets the
-  // per-channel unread badges honor the "Show MQTT/Bridge Messages" toggle the
-  // same way the sidebar dot does (#3787) — the dedicated unread query already
-  // applies excludeMqtt, but the /poll aggregate does not.
-  const unreadCountsDataRef = useRef(unreadCountsData);
-  useEffect(() => {
-    unreadCountsDataRef.current = unreadCountsData;
-  }, [unreadCountsData]);
+  // The unreadCountsData ref-bridge for the poll callback (App's
+  // processPollData is memoized without unreadCountsData in its deps) moved
+  // into useMessagingView (#3962 5.4 PR7) — applyPollMessages needs it, the
+  // favicon effect below reads unreadCountsData directly from context.
 
   // UI context
   const {
@@ -726,8 +709,8 @@ function App() {
   // Track previous total unread count to detect when new messages arrive
   const previousUnreadTotal = useRef<number>(0);
 
-  // Track the newest message ID to detect NEW messages (count-based tracking fails at the 100 message limit)
-  const newestMessageId = useRef<string>('');
+  // newestMessageId moved into useMessagingView (#3962 5.4 PR7) — its only
+  // consumer (applyPollMessages' new-message-sound detection) lives there now.
 
   // Position exchange loading state (separate from traceroute loading)
   const [positionLoading, setPositionLoading] = useState<string | null>(null);
@@ -741,27 +724,8 @@ function App() {
   // Telemetry request loading state
   const [telemetryRequestLoading, setTelemetryRequestLoading] = useState<string | null>(null);
 
-  // Play the notification sound configured for a given channel using the
-  // synthesized Web Audio sound library. Channel `-1` is the DM pseudo-channel;
-  // when no channel is supplied (or it is undefined) the default sound plays,
-  // preserving the previous single-tone behavior. Honors the master audio
-  // toggle exactly as before.
-  const playNotificationSound = useCallback((channelId?: number) => {
-    // Check if audio notifications are enabled
-    if (!enableAudioNotifications) {
-      logger.debug('🔇 Audio notifications disabled, skipping sound');
-      return;
-    }
-
-    logger.debug('🔊 playNotificationSound called for channel:', channelId);
-    if (channelId === undefined) {
-      playSound(DEFAULT_SOUND_ID);
-    } else {
-      // Scope the lookup to the active source so per-source selections (and the
-      // DM pseudo-channel) don't leak across sources that share channel numbers.
-      playChannelSound(channelId, sourceId);
-    }
-  }, [enableAudioNotifications, sourceId]);
+  // playNotificationSound moved into useMessagingView (#3962 5.4 PR7) — its
+  // only consumer (applyPollMessages) lives there now.
 
   // Update favicon with red dot when there are unread messages
   const updateFavicon = useCallback(
@@ -924,6 +888,25 @@ function App() {
     setSelectedRouteSegment,
     setShowPurgeDataModal,
   });
+
+  // Messaging state machinery — messages/channelMessages state (moved off
+  // DataContext), optimistic pendingMessages merge, channel/direct
+  // pagination, and the 8 activeTab-gated scroll/auto-load/mark-as-read
+  // effects (#3962 5.4 PR7, task54_spec.md §3 row 7). The send/resend/
+  // tapback handlers below still consume messages/setMessages/
+  // channelMessages/setChannelMessages/pendingMessagesRef/the two container
+  // refs exactly as they consumed the old DataContext fields — see
+  // src/hooks/useMessagingView.ts.
+  const {
+    messages,
+    setMessages,
+    channelMessages,
+    setChannelMessages,
+    pendingMessagesRef,
+    channelMessagesContainerRef,
+    dmMessagesContainerRef,
+    applyPollMessages,
+  } = useMessagingView();
 
   // Function to detect MQTT/bridge messages that should be filtered
   const isMqttBridgeMessage = (msg: MeshMessage): boolean => {
@@ -1405,392 +1388,10 @@ function App() {
     localStorage.setItem('nodeFilters', JSON.stringify(nodeFilters));
   }, [nodeFilters]);
 
-  // Check if container is scrolled near bottom (within 100px)
-  const isScrolledNearBottom = useCallback((container: HTMLDivElement | null): boolean => {
-    if (!container) return true;
-    const threshold = 100;
-    const { scrollTop, scrollHeight, clientHeight } = container;
-    return scrollHeight - scrollTop - clientHeight < threshold;
-  }, []);
-
-  // Check if container is scrolled near top (within 100px)
-  const isScrolledNearTop = useCallback((container: HTMLDivElement | null): boolean => {
-    if (!container) return false;
-    return container.scrollTop < 100;
-  }, []);
-
-  // Keep refs in sync with the latest state so infinite-scroll loaders read
-  // current values instead of a stale closure. See comment at the ref decls.
-  useEffect(() => {
-    channelMessagesRef.current = channelMessages;
-  }, [channelMessages]);
-
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
-
-  // Load more channel messages (for infinite scroll)
-  const loadMoreChannelMessages = useCallback(async () => {
-    if (channelLoadingMore[selectedChannel] || channelHasMore[selectedChannel] === false) {
-      return;
-    }
-
-    const currentMessages = channelMessagesRef.current[selectedChannel] || [];
-    const offset = currentMessages.length;
-    const container = channelMessagesContainerRef.current;
-
-    // Store scroll position before loading
-    const scrollHeightBefore = container?.scrollHeight || 0;
-
-    setChannelLoadingMore(prev => ({ ...prev, [selectedChannel]: true }));
-
-    try {
-      const result = await api.getChannelMessages(selectedChannel, 100, offset, sourceId);
-
-      if (result.messages.length > 0) {
-        // Process timestamps for new messages
-        const processedMessages = result.messages.map(msg => ({
-          ...msg,
-          timestamp: new Date(msg.timestamp),
-          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
-        }));
-
-        // Prepend older messages to the existing list, deduplicating by id
-        setChannelMessages(prev => {
-          const existingMessages = prev[selectedChannel] || [];
-          const existingIds = new Set(existingMessages.map(m => m.id));
-          const newMessages = processedMessages.filter(m => !existingIds.has(m.id));
-          return {
-            ...prev,
-            [selectedChannel]: [...newMessages, ...existingMessages],
-          };
-        });
-
-        // Restore scroll position after messages are prepended
-        requestAnimationFrame(() => {
-          if (container) {
-            const scrollHeightAfter = container.scrollHeight;
-            container.scrollTop = scrollHeightAfter - scrollHeightBefore;
-          }
-        });
-      }
-
-      setChannelHasMore(prev => ({ ...prev, [selectedChannel]: result.hasMore }));
-    } catch (error) {
-      logger.error('Failed to load more channel messages:', error);
-      showToast(t('toast.failed_load_older_messages'), 'error');
-    } finally {
-      setChannelLoadingMore(prev => ({ ...prev, [selectedChannel]: false }));
-    }
-  }, [
-    selectedChannel,
-    channelLoadingMore,
-    channelHasMore,
-    setChannelMessages,
-    setChannelHasMore,
-    setChannelLoadingMore,
-    showToast,
-  ]);
-
-  // Load more direct messages (for infinite scroll)
-  const loadMoreDirectMessages = useCallback(async () => {
-    if (!selectedDMNode || !currentNodeId) return;
-
-    const dmKey = [currentNodeId, selectedDMNode].sort().join('_');
-    if (dmLoadingMore[dmKey] || dmHasMore[dmKey] === false) {
-      return;
-    }
-
-    // Get current DM messages from the messages array (channel -1 or direct messages)
-    const currentDMs = messagesRef.current.filter(
-      msg =>
-        (msg.fromNodeId === currentNodeId && msg.toNodeId === selectedDMNode) ||
-        (msg.fromNodeId === selectedDMNode && msg.toNodeId === currentNodeId)
-    );
-    const offset = currentDMs.length;
-    const container = dmMessagesContainerRef.current;
-
-    // Store scroll position before loading
-    const scrollHeightBefore = container?.scrollHeight || 0;
-
-    setDmLoadingMore(prev => ({ ...prev, [dmKey]: true }));
-
-    try {
-      const result = await api.getDirectMessages(currentNodeId, selectedDMNode, 100, offset, sourceId);
-
-      if (result.messages.length > 0) {
-        // Process timestamps for new messages
-        const processedMessages = result.messages.map(msg => ({
-          ...msg,
-          timestamp: new Date(msg.timestamp),
-          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
-        }));
-
-        // Prepend older messages to the existing list
-        setMessages(prev => {
-          // Remove duplicates by id
-          const existingIds = new Set(prev.map(m => m.id));
-          const newMessages = processedMessages.filter(m => !existingIds.has(m.id));
-          return [...newMessages, ...prev];
-        });
-
-        // Restore scroll position after messages are prepended
-        requestAnimationFrame(() => {
-          if (container) {
-            const scrollHeightAfter = container.scrollHeight;
-            container.scrollTop = scrollHeightAfter - scrollHeightBefore;
-          }
-        });
-      }
-
-      setDmHasMore(prev => ({ ...prev, [dmKey]: result.hasMore }));
-    } catch (error) {
-      logger.error('Failed to load more direct messages:', error);
-      showToast(t('toast.failed_load_older_messages'), 'error');
-    } finally {
-      setDmLoadingMore(prev => ({ ...prev, [dmKey]: false }));
-    }
-  }, [
-    selectedDMNode,
-    currentNodeId,
-    dmLoadingMore,
-    dmHasMore,
-    setMessages,
-    setDmHasMore,
-    setDmLoadingMore,
-    showToast,
-  ]);
-
-  // Handle scroll events to track scroll position (throttled for load-more)
-  const handleChannelScroll = useCallback(() => {
-    if (channelMessagesContainerRef.current) {
-      const atBottom = isScrolledNearBottom(channelMessagesContainerRef.current);
-      setIsChannelScrolledToBottom(atBottom);
-
-      // Check if scrolled near top and trigger load more (throttled to 200ms)
-      const now = Date.now();
-      if (isScrolledNearTop(channelMessagesContainerRef.current) && now - lastScrollLoadTimeRef.current > 200) {
-        lastScrollLoadTimeRef.current = now;
-        void loadMoreChannelMessages();
-      }
-    }
-  }, [isScrolledNearBottom, isScrolledNearTop, loadMoreChannelMessages]);
-
-  const handleDMScroll = useCallback(() => {
-    if (dmMessagesContainerRef.current) {
-      const atBottom = isScrolledNearBottom(dmMessagesContainerRef.current);
-      setIsDMScrolledToBottom(atBottom);
-
-      // Check if scrolled near top and trigger load more (throttled to 200ms)
-      const now = Date.now();
-      if (isScrolledNearTop(dmMessagesContainerRef.current) && now - lastScrollLoadTimeRef.current > 200) {
-        lastScrollLoadTimeRef.current = now;
-        void loadMoreDirectMessages();
-      }
-    }
-  }, [isScrolledNearBottom, isScrolledNearTop, loadMoreDirectMessages]);
-
-  // Attach scroll event listeners. The handler closures are stable now (they
-  // read state via refs), so we re-run this effect when navigation could have
-  // swapped the underlying DOM node — channel switch, DM switch, or tab
-  // switch — to be sure we attach to the freshly mounted container. Without
-  // this the very first scroll on the initial channel never fires the
-  // load-more handler.
-  useEffect(() => {
-    const channelContainer = channelMessagesContainerRef.current;
-    const dmContainer = dmMessagesContainerRef.current;
-
-    if (channelContainer) {
-      channelContainer.addEventListener('scroll', handleChannelScroll);
-    }
-    if (dmContainer) {
-      dmContainer.addEventListener('scroll', handleDMScroll);
-    }
-
-    return () => {
-      if (channelContainer) {
-        channelContainer.removeEventListener('scroll', handleChannelScroll);
-      }
-      if (dmContainer) {
-        dmContainer.removeEventListener('scroll', handleDMScroll);
-      }
-    };
-  }, [handleChannelScroll, handleDMScroll, activeTab, selectedChannel, selectedDMNode]);
-
-  // Force scroll to bottom when channel changes OR when switching to channels tab
-  // Note: We track initial scroll per channel to avoid re-scrolling when user manually scrolls
-  useEffect(() => {
-    if (activeTab === 'channels' && selectedChannel >= 0) {
-      const currentChannelMessages = channelMessages[selectedChannel] || [];
-      const hasMessages = currentChannelMessages.length > 0;
-
-      // Always scroll to bottom when entering the channels tab or changing channels
-      if (hasMessages) {
-        // Use setTimeout to ensure messages are rendered before scrolling
-        setTimeout(() => {
-          if (channelMessagesContainerRef.current) {
-            channelMessagesContainerRef.current.scrollTop = channelMessagesContainerRef.current.scrollHeight;
-            setIsChannelScrolledToBottom(true);
-          }
-        }, 100);
-      }
-    }
-  }, [selectedChannel, activeTab]);
-
-  // Auto-scroll to bottom when new messages arrive and user is already at the bottom
-  const prevChannelMsgCountRef = useRef<Record<number, number>>({});
-  useEffect(() => {
-    const currentMessages = channelMessages[selectedChannel] || [];
-    const prevCount = prevChannelMsgCountRef.current[selectedChannel] || 0;
-    const currentCount = currentMessages.length;
-
-    if (currentCount > prevCount && prevCount > 0) {
-      // New messages arrived — auto-scroll if user was near the bottom
-      const container = channelMessagesContainerRef.current;
-      if (container) {
-        const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 150;
-        if (isNearBottom) {
-          setTimeout(() => {
-            if (channelMessagesContainerRef.current) {
-              channelMessagesContainerRef.current.scrollTo({
-                top: channelMessagesContainerRef.current.scrollHeight,
-                behavior: 'smooth'
-              });
-            }
-          }, 50);
-        }
-      }
-    }
-
-    prevChannelMsgCountRef.current = {
-      ...prevChannelMsgCountRef.current,
-      [selectedChannel]: currentCount
-    };
-  }, [channelMessages, selectedChannel]);
-
-  // Auto-scroll DMs to bottom when new messages arrive and user is at the bottom
-  const prevDMMsgCountRef = useRef(0);
-  useEffect(() => {
-    const currentCount = messages.length;
-    const prevCount = prevDMMsgCountRef.current;
-
-    if (currentCount > prevCount && prevCount > 0 && activeTab === 'messages') {
-      const container = dmMessagesContainerRef.current;
-      if (container) {
-        const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 150;
-        if (isNearBottom) {
-          setTimeout(() => {
-            if (dmMessagesContainerRef.current) {
-              dmMessagesContainerRef.current.scrollTo({
-                top: dmMessagesContainerRef.current.scrollHeight,
-                behavior: 'smooth'
-              });
-            }
-          }, 50);
-        }
-      }
-    }
-
-    prevDMMsgCountRef.current = currentCount;
-  }, [messages, activeTab]);
-
-  // Auto-load more channel messages if container doesn't have a scrollbar
-  // This fixes the case where a channel has no recent messages and infinite scroll never triggers
-  useEffect(() => {
-    if (activeTab === 'channels' && selectedChannel >= 0) {
-      // Skip if we're already loading or know there are no more messages
-      if (channelLoadingMore[selectedChannel] || channelHasMore[selectedChannel] === false) {
-        return;
-      }
-
-      // Check after a delay to allow the DOM to render
-      const checkTimer = setTimeout(() => {
-        const container = channelMessagesContainerRef.current;
-        if (container) {
-          // If container doesn't have a scrollbar, load more messages
-          const hasScrollbar = container.scrollHeight > container.clientHeight;
-          if (!hasScrollbar) {
-            void loadMoreChannelMessages();
-          }
-        }
-      }, 200);
-
-      return () => clearTimeout(checkTimer);
-    }
-  }, [selectedChannel, activeTab, channelLoadingMore, channelHasMore, loadMoreChannelMessages]);
-
-  // Force scroll to bottom when DM node changes OR when switching to messages tab
-  useEffect(() => {
-    if (activeTab === 'messages' && selectedDMNode && currentNodeId) {
-      const currentDMMessages = messages.filter(
-        msg =>
-          (msg.fromNodeId === currentNodeId && msg.toNodeId === selectedDMNode) ||
-          (msg.fromNodeId === selectedDMNode && msg.toNodeId === currentNodeId)
-      );
-      const hasMessages = currentDMMessages.length > 0;
-
-      // Always scroll to bottom when entering the messages tab or changing conversations
-      if (hasMessages) {
-        setTimeout(() => {
-          if (dmMessagesContainerRef.current) {
-            dmMessagesContainerRef.current.scrollTop = dmMessagesContainerRef.current.scrollHeight;
-            setIsDMScrolledToBottom(true);
-          }
-        }, 150);
-      }
-    }
-  }, [selectedDMNode, activeTab, currentNodeId]);
-
-  // Auto-load more DM messages if container doesn't have a scrollbar
-  // This fixes the case where a conversation has no recent messages and infinite scroll never triggers
-  useEffect(() => {
-    if (activeTab === 'messages' && selectedDMNode && currentNodeId) {
-      const dmKey = [currentNodeId, selectedDMNode].sort().join('_');
-
-      // Skip if we're already loading or know there are no more messages
-      if (dmLoadingMore[dmKey] || dmHasMore[dmKey] === false) {
-        return;
-      }
-
-      // Check after a delay to allow the DOM to render
-      const checkTimer = setTimeout(() => {
-        const container = dmMessagesContainerRef.current;
-        if (container) {
-          // If container doesn't have a scrollbar, load more messages
-          const hasScrollbar = container.scrollHeight > container.clientHeight;
-          if (!hasScrollbar) {
-            void loadMoreDirectMessages();
-          }
-        }
-      }, 200);
-
-      return () => clearTimeout(checkTimer);
-    }
-  }, [selectedDMNode, activeTab, currentNodeId, dmLoadingMore, dmHasMore, loadMoreDirectMessages]);
-
-  // Unread counts polling is now handled by useUnreadCounts hook in MessagingContext
-
-  // Mark messages as read when viewing a channel — also re-fires when new messages arrive
-  // so that incoming messages are immediately marked as read while the user is viewing the channel.
-  // Without the message count dependency, new messages would show as "unread" until the user
-  // clicks away and back (#2316).
-  const currentChannelMsgCount = (channelMessages[selectedChannel] || []).length;
-  useEffect(() => {
-    if (activeTab === 'channels' && selectedChannel >= 0) {
-      void markMessagesAsRead(undefined, selectedChannel);
-    }
-  }, [selectedChannel, activeTab, markMessagesAsRead, currentChannelMsgCount]);
-
-  // Mark messages as read when viewing a DM conversation — also re-fires on new messages
-  // Filter to only the selected conversation so we don't fire on messages from other DMs
-  const currentDMMsgCount = selectedDMNode
-    ? messages.filter(msg => msg.fromNodeId === selectedDMNode || msg.toNodeId === selectedDMNode).length
-    : 0;
-  useEffect(() => {
-    if (activeTab === 'messages' && selectedDMNode) {
-      void markMessagesAsRead(undefined, undefined, selectedDMNode);
-    }
-  }, [selectedDMNode, activeTab, markMessagesAsRead, currentDMMsgCount]);
+  // Message scroll-position tracking / infinite-scroll pagination / auto-load
+  // / mark-as-read effects (isScrolledNearBottom/isScrolledNearTop through
+  // the DM mark-as-read effect) moved into useMessagingView (#3962 5.4 PR7)
+  // — see src/hooks/useMessagingView.ts.
 
   // Handle push notification navigation (click on notification -> navigate to channel/DM and scroll to message)
   useNotificationNavigationHandler(
@@ -1897,22 +1498,8 @@ function App() {
     };
   }, [connectionStatus]);
 
-  // Timer to update message status indicators (timeout detection after 30s)
-  // Only runs when on channels/messages tabs to reduce CPU usage on mobile (#1769)
-  const [, setStatusTick] = useState(0);
-  useEffect(() => {
-    // Only run timer when viewing messaging tabs where status indicators are visible
-    if (activeTab !== 'channels' && activeTab !== 'messages') {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      // Force re-render to update message status indicators
-      setStatusTick(prev => prev + 1);
-    }, 5000); // Update every 5 seconds (reduced from 1s for mobile performance)
-
-    return () => clearInterval(interval);
-  }, [activeTab]);
+  // The message-status-indicator re-render timer (5s tick, gated to
+  // channels/messages tabs) moved into useMessagingView (#3962 5.4 PR7).
 
   const requestFullNodeDatabase = async () => {
     try {
@@ -2307,203 +1894,13 @@ function App() {
         }
       }
 
-      // Process messages data
+      // Process messages data — optimistic-merge + pagination-preserving
+      // logic lives in useMessagingView (#3962 5.4 PR7); this just feeds it
+      // the poll payload + the two App-local values it needs (localNodeId
+      // computed above, and the currently-selected channel so the unread
+      // count for an open channel zeroes instead of incrementing).
       if (data.messages) {
-        const messagesData = data.messages;
-        const processedMessages = messagesData.map((msg: any) => ({
-          ...msg,
-          timestamp: new Date(msg.timestamp),
-          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
-        }));
-
-        // Play notification sound if new messages arrived from OTHER users
-        if (processedMessages.length > 0) {
-          const currentNewestMessage = processedMessages[0];
-          const currentNewestId = currentNewestMessage.id;
-
-          if (newestMessageId.current && currentNewestId !== newestMessageId.current) {
-            const isFromOther = currentNewestMessage.fromNodeId !== localNodeId;
-            const isTextMessage = currentNewestMessage.portnum === 1;
-
-            if (isFromOther && isTextMessage) {
-              logger.debug('New message arrived from other user:', currentNewestMessage.fromNodeId);
-              const isDM = currentNewestMessage.channel === -1;
-              const muted = isDM
-                ? isDMMuted(currentNewestMessage.fromNodeId)
-                : isChannelMuted(currentNewestMessage.channel);
-              if (!muted) {
-                // Play the sound configured for this channel (channel -1 is the
-                // DM pseudo-channel, which has its own selectable sound too).
-                playNotificationSound(currentNewestMessage.channel);
-              } else {
-                logger.debug('🔇 Notification sound suppressed (muted):', isDM ? `DM from ${currentNewestMessage.fromNodeId}` : `channel ${currentNewestMessage.channel}`);
-              }
-            }
-          }
-
-          newestMessageId.current = currentNewestId;
-        }
-
-        // Check for matching messages to remove from pending
-        const currentPending = pendingMessagesRef.current;
-        const updatedPending = new Map(currentPending);
-        let pendingChanged = false;
-
-        if (currentPending.size > 0) {
-          currentPending.forEach((pendingMsg, tempId) => {
-            const isDM = pendingMsg.channel === -1;
-
-            const matchingMessage = processedMessages.find((msg: MeshMessage) => {
-              if (msg.text !== pendingMsg.text) return false;
-
-              const senderMatches =
-                (localNodeId && msg.from === localNodeId) ||
-                msg.from === pendingMsg.from ||
-                msg.fromNodeId === pendingMsg.fromNodeId;
-
-              if (!senderMatches) return false;
-              if (Math.abs(msg.timestamp.getTime() - pendingMsg.timestamp.getTime()) >= 30000) return false;
-
-              if (isDM) {
-                const matches =
-                  msg.toNodeId === pendingMsg.toNodeId ||
-                  (msg.to === pendingMsg.to && (msg.channel === 0 || msg.channel === -1));
-                return matches;
-              } else {
-                return msg.channel === pendingMsg.channel;
-              }
-            });
-
-            if (matchingMessage) {
-              updatedPending.delete(tempId);
-              pendingChanged = true;
-            }
-          });
-
-          if (pendingChanged) {
-            pendingMessagesRef.current = updatedPending;
-            setPendingMessages(updatedPending);
-          }
-        }
-
-        // Compute merged messages using setMessages callback to access current state
-        // Preserve older DM messages loaded via infinite scroll (similar to channel messages)
-        const pendingIds = new Set(Array.from(pendingMessagesRef.current.keys()));
-        const pollMsgIds = new Set(processedMessages.map((m: MeshMessage) => m.id));
-
-        setMessages(currentMessages => {
-          // Keep older messages that aren't in the poll (they were loaded via infinite scroll)
-          // Poll returns newest messages, so any messages not in poll are older
-          const olderMsgs = (currentMessages || []).filter(m => {
-            // If message is in poll results, don't keep it (poll version is authoritative)
-            if (pollMsgIds.has(m.id)) return false;
-
-            // For pending messages (temp IDs), only keep if still pending
-            if (m.id.toString().startsWith('temp_')) {
-              if (!pendingIds.has(m.id)) return false;
-              // Safety net: filter out if a matching server message already exists
-              // This catches edge cases where the ref timing or text/sender matching fails
-              // Must use localNodeId fallback (same as primary dedup) because temp messages
-              // created before first poll may have fromNodeId='me' instead of the real node ID
-              const hasServerMatch = processedMessages.some((pm: MeshMessage) =>
-                pm.text === m.text &&
-                ((localNodeId && pm.from === localNodeId) || pm.fromNodeId === m.fromNodeId || pm.from === m.from) &&
-                Math.abs(pm.timestamp.getTime() - m.timestamp.getTime()) < 30000
-              );
-              if (hasServerMatch) return false;
-              return true;
-            }
-
-            // Keep all other older messages (loaded via infinite scroll)
-            return true;
-          });
-
-          // Combine: older messages + poll messages (poll messages are newer/updated)
-          // Sort by timestamp to maintain order
-          const merged = [...olderMsgs, ...processedMessages];
-          merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-          return merged;
-        });
-
-        // Group messages by channel (use processedMessages since we don't need pending for channel groups)
-        const channelGroups: { [key: number]: MeshMessage[] } = {};
-        processedMessages.forEach((msg: MeshMessage) => {
-          if (msg.channel === -1) return;
-          if (!channelGroups[msg.channel]) {
-            channelGroups[msg.channel] = [];
-          }
-          channelGroups[msg.channel].push(msg);
-        });
-
-        // Update unread counts from the dedicated (filtered) unread query rather
-        // than the raw /poll aggregate, so the per-channel badges respect the
-        // "Show MQTT/Bridge Messages" toggle just like the sidebar dot (#3787).
-        // Fall back to the poll payload only until the first dedicated fetch lands.
-        const currentSelected = selectedChannelRef.current;
-        const newUnreadCounts: { [key: number]: number } = {};
-
-        const filteredChannelUnreads = unreadCountsDataRef.current?.channels ?? data.unreadCounts?.channels;
-        if (filteredChannelUnreads) {
-          Object.entries(filteredChannelUnreads).forEach(([channelId, count]) => {
-            const chId = parseInt(channelId, 10);
-            if (chId === currentSelected) {
-              newUnreadCounts[chId] = 0;
-            } else {
-              newUnreadCounts[chId] = count as number;
-            }
-          });
-        }
-
-        setUnreadCounts(newUnreadCounts);
-
-        // Merge poll messages with existing messages (preserve older messages loaded via infinite scroll)
-        setChannelMessages(prev => {
-          const merged: { [key: number]: MeshMessage[] } = {};
-
-          // Get all channel IDs from both existing and new messages
-          const allChannelIds = new Set([...Object.keys(prev).map(Number), ...Object.keys(channelGroups).map(Number)]);
-
-          allChannelIds.forEach(channelId => {
-            const existingMsgs = prev[channelId] || [];
-            const pollMsgs = channelGroups[channelId] || [];
-
-            // Create a map of poll message IDs for quick lookup
-            const pollMsgIds = new Set(pollMsgs.map(m => m.id));
-
-            // Keep older messages that aren't in the poll (they were loaded via infinite scroll)
-            // Poll returns newest 100, so any messages not in poll are older
-            // Also filter out pending messages that are no longer pending (they've been matched to real messages)
-            const olderMsgs = existingMsgs.filter(m => {
-              // If message is in poll results, don't keep it (poll version is authoritative)
-              if (pollMsgIds.has(m.id)) return false;
-
-              // For pending messages (temp IDs), only keep if still pending
-              // Once matched/acknowledged, pendingIds won't contain it anymore
-              // Channel messages use 'temp_' prefix, DMs use 'temp_dm_' prefix
-              if (m.id.toString().startsWith('temp_')) {
-                if (!pendingIds.has(m.id)) return false;
-                // Safety net: filter out if a matching server message already exists
-                // Must use localNodeId fallback (same as primary dedup) because temp messages
-                // created before first poll may have fromNodeId='me' instead of the real node ID
-                const hasServerMatch = pollMsgs.some(pm =>
-                  pm.text === m.text &&
-                  ((localNodeId && pm.from === localNodeId) || pm.fromNodeId === m.fromNodeId || pm.from === m.from) &&
-                  Math.abs(pm.timestamp.getTime() - m.timestamp.getTime()) < 30000
-                );
-                if (hasServerMatch) return false;
-                return true;
-              }
-
-              // Keep all other older messages (loaded via infinite scroll)
-              return true;
-            });
-
-            // Combine: older messages + poll messages (poll messages are newer/updated)
-            merged[channelId] = [...olderMsgs, ...pollMsgs];
-          });
-
-          return merged;
-        });
+        applyPollMessages(data, localNodeId, selectedChannelRef.current);
       }
 
       // Process config data
@@ -2538,7 +1935,7 @@ function App() {
         setTraceroutes(data.traceroutes);
       }
     },
-    [currentNodeId, playNotificationSound, setTraceroutes, isChannelMuted, isDMMuted]
+    [currentNodeId, setTraceroutes, applyPollMessages]
   );
 
   // Process poll data when it changes (from usePoll hook)
@@ -4078,14 +3475,17 @@ function App() {
         )}
 
         {/*
-          Tab region nested Routes (#3962 5.4 PR1). Each tab is migrating from
-          an `activeTab === 'x' && …` render gate to its own <Route> one PR at
-          a time (task54_spec.md §3). Un-migrated tabs keep rendering via the
-          `path="*"` fallback below, unchanged, driven by the activeTab<->route
-          adapter in UIContext. `audit` was the PR1 proof leaf; PR3 migrated
-          the other leaf tabs; PR4 migrated `nodes` (the default/index tab)
-          alongside extracting its shared node/traceroute/map orchestration
-          into `useSourceView` (src/hooks/useSourceView.ts).
+          Tab region nested Routes (#3962 5.4 PR1). All 15 tabs are now
+          `<Route>` elements (task54_spec.md §3) — the `path="*"` fallback
+          below renders nothing, preserving prior blank-fallback behavior for
+          an unrecognized sub-path. `audit` was the PR1 proof leaf; PR3
+          migrated the other leaf tabs; PR4 migrated `nodes` (the default/
+          index tab) alongside extracting its shared node/traceroute/map
+          orchestration into `useSourceView` (src/hooks/useSourceView.ts);
+          PR5 migrated info/dashboard/configuration; PR6 migrated settings/
+          automation; PR7 migrated channels/messages alongside extracting
+          their messaging state machinery into `useMessagingView`
+          (src/hooks/useMessagingView.ts) — see that file's doc comment.
         */}
         <Routes>
           <Route index element={<Navigate to="nodes" replace />} />
@@ -4299,9 +3699,10 @@ function App() {
               </ErrorBoundary>
             }
           />
-          <Route path="*" element={<>
-        {activeTab === 'channels' && (
-          <ErrorBoundary fallbackTitle="Channels failed to load">
+          <Route
+            path="channels"
+            element={
+              <ErrorBoundary fallbackTitle="Channels failed to load">
           <ChannelsTab
             channels={channels}
             channelDatabaseEntries={channelDatabaseEntries}
@@ -4347,10 +3748,13 @@ function App() {
             onFocusMessageHandled={() => setFocusMessageId(null)}
             mqttReadOnly={isMqttBridge}
           />
-          </ErrorBoundary>
-        )}
-        {activeTab === 'messages' && (
-          <ErrorBoundary fallbackTitle="Messages failed to load">
+              </ErrorBoundary>
+            }
+          />
+          <Route
+            path="messages"
+            element={
+              <ErrorBoundary fallbackTitle="Messages failed to load">
           <MessagesTab
             processedNodes={processedNodes}
             nodes={nodes}
@@ -4425,15 +3829,19 @@ function App() {
               }
             }}
           />
-          </ErrorBoundary>
-        )}
-        {/* 'audit' migrated to <Route path="audit"> above (#3962 5.4 PR1 proof leaf) */}
-        {/* 'notifications', 'users', 'admin', 'security', 'mqtt-config', 'packetmonitor'
-            migrated to <Route> elements above (#3962 5.4 PR3 leaf tab group) */}
-        {/* 'automation', 'settings' migrated to <Route> elements above (#3962 5.4 PR6) */}
-        {/* 'info', 'dashboard', 'configuration' migrated to <Route> elements above
-            (#3962 5.4 PR5) */}
-          </>} />
+              </ErrorBoundary>
+            }
+          />
+          {/* 'audit' migrated to <Route path="audit"> above (#3962 5.4 PR1 proof leaf) */}
+          {/* 'notifications', 'users', 'admin', 'security', 'mqtt-config', 'packetmonitor'
+              migrated to <Route> elements above (#3962 5.4 PR3 leaf tab group) */}
+          {/* 'automation', 'settings' migrated to <Route> elements above (#3962 5.4 PR6) */}
+          {/* 'info', 'dashboard', 'configuration' migrated to <Route> elements above
+              (#3962 5.4 PR5) */}
+          {/* 'channels', 'messages' migrated to <Route> elements above (#3962 5.4 PR7) —
+              every tab is now a route; this catch-all preserves the prior blank-fallback
+              behavior for an unrecognized sub-path. */}
+          <Route path="*" element={null} />
         </Routes>
       </main>
 

--- a/src/contexts/DataContext.test.tsx
+++ b/src/contexts/DataContext.test.tsx
@@ -141,6 +141,13 @@ describe('DataContext Types', () => {
   // now sourced directly from the poll cache via useTelemetryNodes()
   // (see src/hooks/useServerData.test.ts).
 
+  // messages/channelMessages (+ their pagination state) were removed from
+  // DataContext (#3962 5.4 PR7) — they were never pure poll-cache mirrors,
+  // so they moved to useMessagingView rather than a selector (see
+  // src/hooks/useMessagingView.test.ts). The MeshMessage/channelMessages
+  // "type structure" tests above build local mock objects and never touch
+  // useData(), so they remain valid unchanged.
+
   it('should support deviceInfo any type', () => {
     const mockDeviceInfo: any = {
       myNodeNum: 305419896,

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,8 +1,13 @@
 import React, { createContext, useContext, useState, useMemo, ReactNode } from 'react';
 import { DeviceInfo, Channel } from '../types/device';
-import { MeshMessage } from '../types/message';
 import { ConnectionStatus } from '../types/ui';
 
+// messages/channelMessages (+ their channelHasMore/channelLoadingMore/
+// dmHasMore/dmLoadingMore pagination state) were removed (#3962 5.4 PR7).
+// They were never pure poll-cache mirrors — the optimistic-send merge and
+// infinite-scroll pagination logic they need moved to `useMessagingView`
+// (src/hooks/useMessagingView.ts), which now owns this state itself instead
+// of prop-drilling it through DataContext.
 interface DataContextType {
   nodes: DeviceInfo[];
   setNodes: React.Dispatch<React.SetStateAction<DeviceInfo[]>>;
@@ -10,10 +15,6 @@ interface DataContextType {
   setChannels: React.Dispatch<React.SetStateAction<Channel[]>>;
   connectionStatus: ConnectionStatus;
   setConnectionStatus: React.Dispatch<React.SetStateAction<ConnectionStatus>>;
-  messages: MeshMessage[];
-  setMessages: React.Dispatch<React.SetStateAction<MeshMessage[]>>;
-  channelMessages: {[key: number]: MeshMessage[]};
-  setChannelMessages: React.Dispatch<React.SetStateAction<{[key: number]: MeshMessage[]}>>;
   deviceInfo: any;
   setDeviceInfo: React.Dispatch<React.SetStateAction<any>>;
   deviceConfig: any;
@@ -22,15 +23,6 @@ interface DataContextType {
   setCurrentNodeId: React.Dispatch<React.SetStateAction<string>>;
   nodeAddress: string;
   setNodeAddress: React.Dispatch<React.SetStateAction<string>>;
-  // Pagination state for infinite scroll
-  channelHasMore: {[key: number]: boolean};
-  setChannelHasMore: React.Dispatch<React.SetStateAction<{[key: number]: boolean}>>;
-  channelLoadingMore: {[key: number]: boolean};
-  setChannelLoadingMore: React.Dispatch<React.SetStateAction<{[key: number]: boolean}>>;
-  dmHasMore: {[key: string]: boolean};
-  setDmHasMore: React.Dispatch<React.SetStateAction<{[key: string]: boolean}>>;
-  dmLoadingMore: {[key: string]: boolean};
-  setDmLoadingMore: React.Dispatch<React.SetStateAction<{[key: string]: boolean}>>;
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
@@ -43,8 +35,6 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
   const [nodes, setNodes] = useState<DeviceInfo[]>([]);
   const [channels, setChannels] = useState<Channel[]>([]);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
-  const [messages, setMessages] = useState<MeshMessage[]>([]);
-  const [channelMessages, setChannelMessages] = useState<{[key: number]: MeshMessage[]}>({});
   const [deviceInfo, setDeviceInfo] = useState<any>(null);
   const [deviceConfig, setDeviceConfig] = useState<any>(null);
   const [currentNodeId, setCurrentNodeId] = useState<string>('');
@@ -52,11 +42,6 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
   // interpolates nodeAddress, and the literal 'Loading...' must never leak into
   // "Connecting to …" before the real per-source address is resolved (#3611).
   const [nodeAddress, setNodeAddress] = useState<string>('');
-  // Pagination state for infinite scroll
-  const [channelHasMore, setChannelHasMore] = useState<{[key: number]: boolean}>({});
-  const [channelLoadingMore, setChannelLoadingMore] = useState<{[key: number]: boolean}>({});
-  const [dmHasMore, setDmHasMore] = useState<{[key: string]: boolean}>({});
-  const [dmLoadingMore, setDmLoadingMore] = useState<{[key: string]: boolean}>({});
 
   const value = useMemo<DataContextType>(() => ({
     nodes,
@@ -65,10 +50,6 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
     setChannels,
     connectionStatus,
     setConnectionStatus,
-    messages,
-    setMessages,
-    channelMessages,
-    setChannelMessages,
     deviceInfo,
     setDeviceInfo,
     deviceConfig,
@@ -77,28 +58,14 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
     setCurrentNodeId,
     nodeAddress,
     setNodeAddress,
-    channelHasMore,
-    setChannelHasMore,
-    channelLoadingMore,
-    setChannelLoadingMore,
-    dmHasMore,
-    setDmHasMore,
-    dmLoadingMore,
-    setDmLoadingMore,
   }), [
     nodes, setNodes,
     channels, setChannels,
     connectionStatus, setConnectionStatus,
-    messages, setMessages,
-    channelMessages, setChannelMessages,
     deviceInfo, setDeviceInfo,
     deviceConfig, setDeviceConfig,
     currentNodeId, setCurrentNodeId,
     nodeAddress, setNodeAddress,
-    channelHasMore, setChannelHasMore,
-    channelLoadingMore, setChannelLoadingMore,
-    dmHasMore, setDmHasMore,
-    dmLoadingMore, setDmLoadingMore,
   ]);
 
   return (

--- a/src/hooks/useMessagingView.test.ts
+++ b/src/hooks/useMessagingView.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for useMessagingView — the messaging state machinery hook extracted
+ * from App.tsx (#3962 5.4 PR7): optimistic pendingMessages merge, channel/
+ * direct pagination, and the poll-payload merge (applyPollMessages).
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MeshMessage } from '../types/message';
+import type { PollData } from './usePoll';
+
+const mockUseSource = vi.fn();
+const mockUseData = vi.fn();
+const mockUseMessaging = vi.fn();
+const mockUseUI = vi.fn();
+const mockUseSettings = vi.fn();
+const mockUseNotificationMuteSettings = vi.fn();
+const mockUseToast = vi.fn();
+
+vi.mock('../contexts/SourceContext', () => ({ useSource: () => mockUseSource() }));
+vi.mock('../contexts/DataContext', () => ({ useData: () => mockUseData() }));
+vi.mock('../contexts/MessagingContext', () => ({ useMessaging: () => mockUseMessaging() }));
+vi.mock('../contexts/UIContext', () => ({ useUI: () => mockUseUI() }));
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => mockUseSettings(),
+  useNotificationMuteSettings: () => mockUseNotificationMuteSettings(),
+}));
+vi.mock('../components/ToastContainer', () => ({ useToast: () => mockUseToast() }));
+vi.mock('../utils/notificationSounds', () => ({
+  playSound: vi.fn(),
+  playChannelSound: vi.fn(),
+  DEFAULT_SOUND_ID: 'default',
+}));
+
+const mockGetChannelMessages = vi.fn();
+const mockGetDirectMessages = vi.fn();
+vi.mock('../services/api', () => ({
+  default: {
+    getChannelMessages: (...args: unknown[]) => mockGetChannelMessages(...args),
+    getDirectMessages: (...args: unknown[]) => mockGetDirectMessages(...args),
+  },
+}));
+
+import { useMessagingView } from './useMessagingView';
+
+function makeMessage(overrides: Partial<MeshMessage> = {}): MeshMessage {
+  return {
+    id: '1',
+    from: '!aaaaaaaa',
+    to: '^all',
+    fromNodeId: '!aaaaaaaa',
+    toNodeId: '^all',
+    channel: 0,
+    text: 'hello',
+    timestamp: new Date(),
+    portnum: 1,
+    ...overrides,
+  } as MeshMessage;
+}
+
+describe('useMessagingView', () => {
+  let setSelectedChannel: ReturnType<typeof vi.fn>;
+  let setIsChannelScrolledToBottom: ReturnType<typeof vi.fn>;
+  let setIsDMScrolledToBottom: ReturnType<typeof vi.fn>;
+  let markMessagesAsRead: ReturnType<typeof vi.fn>;
+  let setPendingMessages: ReturnType<typeof vi.fn>;
+  let setUnreadCounts: ReturnType<typeof vi.fn>;
+  let showToast: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    setSelectedChannel = vi.fn();
+    setIsChannelScrolledToBottom = vi.fn();
+    setIsDMScrolledToBottom = vi.fn();
+    markMessagesAsRead = vi.fn().mockResolvedValue(undefined);
+    setPendingMessages = vi.fn();
+    setUnreadCounts = vi.fn();
+    showToast = vi.fn();
+
+    mockUseSource.mockReturnValue({ sourceId: 'src-1', sourceName: 'Test', sourceType: 'meshtastic_tcp' });
+    mockUseData.mockReturnValue({ currentNodeId: '!aaaaaaaa' });
+    mockUseMessaging.mockReturnValue({
+      selectedChannel: 0,
+      selectedDMNode: '',
+      setSelectedChannel,
+      setIsChannelScrolledToBottom,
+      setIsDMScrolledToBottom,
+      markMessagesAsRead,
+      setPendingMessages,
+      setUnreadCounts,
+      unreadCountsData: { channels: {}, directMessages: {} },
+    });
+    mockUseUI.mockReturnValue({ activeTab: 'channels' });
+    mockUseSettings.mockReturnValue({ enableAudioNotifications: false });
+    mockUseNotificationMuteSettings.mockReturnValue({
+      isChannelMuted: () => false,
+      isDMMuted: () => false,
+    });
+    mockUseToast.mockReturnValue({ showToast });
+  });
+
+  describe('initial state', () => {
+    it('starts with empty messages/channelMessages', () => {
+      const { result } = renderHook(() => useMessagingView());
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.channelMessages).toEqual({});
+    });
+
+    it('exposes stable container refs and a pendingMessagesRef', () => {
+      const { result } = renderHook(() => useMessagingView());
+      expect(result.current.channelMessagesContainerRef.current).toBeNull();
+      expect(result.current.dmMessagesContainerRef.current).toBeNull();
+      expect(result.current.pendingMessagesRef.current).toBeInstanceOf(Map);
+      expect(result.current.pendingMessagesRef.current.size).toBe(0);
+    });
+  });
+
+  describe('applyPollMessages — optimistic-send reconcile', () => {
+    it('drops a matched pending (temp_) message and keeps only the server row — no duplicate', () => {
+      const { result } = renderHook(() => useMessagingView());
+
+      const now = new Date();
+      const pending: MeshMessage = makeMessage({
+        id: 'temp_1',
+        text: 'hi there',
+        from: '!aaaaaaaa',
+        fromNodeId: '!aaaaaaaa',
+        channel: 0,
+        timestamp: now,
+      });
+
+      // Seed the pending optimistic message the way handleSendMessage does.
+      act(() => {
+        result.current.pendingMessagesRef.current = new Map([[pending.id, pending]]);
+        result.current.setMessages([pending]);
+      });
+
+      const serverRow = makeMessage({
+        id: 'server-1',
+        text: 'hi there',
+        from: '!aaaaaaaa',
+        fromNodeId: '!aaaaaaaa',
+        channel: 0,
+        timestamp: now,
+      });
+
+      const pollData: PollData = {
+        messages: [serverRow as unknown as Record<string, unknown>],
+      } as unknown as PollData;
+
+      act(() => {
+        result.current.applyPollMessages(pollData, '!aaaaaaaa', 0);
+      });
+
+      // The temp row is gone, the server row is present exactly once.
+      const ids = result.current.messages.map(m => m.id);
+      expect(ids).toContain('server-1');
+      expect(ids).not.toContain('temp_1');
+      expect(ids.filter(id => id === 'server-1')).toHaveLength(1);
+
+      // The pending map was reconciled too.
+      expect(setPendingMessages).toHaveBeenCalled();
+    });
+
+    it('preserves an older message not present in the poll response (pagination survives a poll)', () => {
+      const { result } = renderHook(() => useMessagingView());
+
+      const older = makeMessage({ id: 'older-1', text: 'old message' });
+      act(() => {
+        result.current.setMessages([older]);
+      });
+
+      const pollData: PollData = {
+        messages: [makeMessage({ id: 'new-1', text: 'new message' }) as unknown as Record<string, unknown>],
+      } as unknown as PollData;
+
+      act(() => {
+        result.current.applyPollMessages(pollData, '!aaaaaaaa', 0);
+      });
+
+      const ids = result.current.messages.map(m => m.id);
+      expect(ids).toContain('older-1');
+      expect(ids).toContain('new-1');
+    });
+
+    it('never reconstructs a message id — ids pass through unchanged', () => {
+      const { result } = renderHook(() => useMessagingView());
+
+      const rowId = 'src-1_2882400001_123456789';
+      const pollData: PollData = {
+        messages: [makeMessage({ id: rowId }) as unknown as Record<string, unknown>],
+      } as unknown as PollData;
+
+      act(() => {
+        result.current.applyPollMessages(pollData, '!aaaaaaaa', 0);
+      });
+
+      expect(result.current.messages.map(m => m.id)).toEqual([rowId]);
+    });
+
+    it('zeroes the unread count for the currently-open channel', () => {
+      mockUseMessaging.mockReturnValue({
+        selectedChannel: 5,
+        selectedDMNode: '',
+        setSelectedChannel,
+        setIsChannelScrolledToBottom,
+        setIsDMScrolledToBottom,
+        markMessagesAsRead,
+        setPendingMessages,
+        setUnreadCounts,
+        unreadCountsData: { channels: { 5: 3, 6: 2 }, directMessages: {} },
+      });
+
+      const { result } = renderHook(() => useMessagingView());
+
+      const pollData: PollData = {
+        messages: [makeMessage({ id: 'm1', channel: 5 }) as unknown as Record<string, unknown>],
+      } as unknown as PollData;
+
+      act(() => {
+        result.current.applyPollMessages(pollData, '!aaaaaaaa', 5);
+      });
+
+      expect(setUnreadCounts).toHaveBeenCalledWith({ 5: 0, 6: 2 });
+    });
+
+    it('groups channel messages by channel and excludes DM (channel -1) rows', () => {
+      const { result } = renderHook(() => useMessagingView());
+
+      const pollData: PollData = {
+        messages: [
+          makeMessage({ id: 'c1', channel: 1 }) as unknown as Record<string, unknown>,
+          makeMessage({ id: 'dm1', channel: -1 }) as unknown as Record<string, unknown>,
+        ],
+      } as unknown as PollData;
+
+      act(() => {
+        result.current.applyPollMessages(pollData, '!aaaaaaaa', -1);
+      });
+
+      expect(result.current.channelMessages[1]?.map(m => m.id)).toEqual(['c1']);
+      expect(result.current.channelMessages[-1]).toBeUndefined();
+    });
+  });
+
+  describe('pagination — auto-load-if-no-scrollbar path', () => {
+    // loadMoreChannelMessages/loadMoreDirectMessages are hook-internal (App
+    // never called them directly either — only the scroll handler and this
+    // "no scrollbar" effect did), so exercise them the same way: populate a
+    // fake (scrollbar-less) container and let the gated effect fire.
+    function fakeContainer(overrides: Partial<HTMLDivElement> = {}) {
+      return {
+        scrollHeight: 100,
+        clientHeight: 500, // no scrollbar: scrollHeight <= clientHeight
+        scrollTop: 0,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        ...overrides,
+      } as unknown as HTMLDivElement;
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('loadMoreChannelMessages prepends older messages and records hasMore', async () => {
+      mockGetChannelMessages.mockResolvedValue({
+        messages: [makeMessage({ id: 'old-1', text: 'older', timestamp: new Date(0) })],
+        hasMore: true,
+      });
+
+      const { result, rerender } = renderHook(() => useMessagingView());
+
+      act(() => {
+        result.current.setChannelMessages({ 0: [makeMessage({ id: 'newer-1' })] });
+        result.current.channelMessagesContainerRef.current = fakeContainer();
+      });
+
+      // Force the "auto-load if no scrollbar" effect (deps include
+      // selectedChannel) to re-run now that the container ref is populated.
+      mockUseMessaging.mockReturnValue({
+        selectedChannel: 0,
+        selectedDMNode: '',
+        setSelectedChannel,
+        setIsChannelScrolledToBottom,
+        setIsDMScrolledToBottom,
+        markMessagesAsRead,
+        setPendingMessages,
+        setUnreadCounts,
+        unreadCountsData: { channels: {}, directMessages: {} },
+      });
+      rerender();
+
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockGetChannelMessages).toHaveBeenCalledWith(0, 100, 1, 'src-1');
+      const ids = result.current.channelMessages[0]?.map(m => m.id) ?? [];
+      expect(ids).toEqual(['old-1', 'newer-1']);
+    });
+  });
+});

--- a/src/hooks/useMessagingView.ts
+++ b/src/hooks/useMessagingView.ts
@@ -1,0 +1,785 @@
+/**
+ * Messaging state machinery for the `channels`/`messages` tabs of the
+ * (Meshtastic) source view.
+ *
+ * Extracted from App.tsx (#3962 Phase 5.4 PR7, task54_spec.md §3 row 7) as
+ * part of migrating `channels`/`messages` to routes. Unlike the poll-cache
+ * mirrors that PR2/PR8 fold into `useServerData` selectors, `messages` and
+ * `channelMessages` are NOT pure cache mirrors: they merge the poll's
+ * latest ~100 rows with (a) older rows loaded via infinite-scroll pagination
+ * and (b) optimistic "pending" rows created by a just-sent message, so no
+ * selector can replace them — the merge logic has to live somewhere, and
+ * this hook is that somewhere (task54_spec.md §4 PR7 invariants).
+ *
+ * Owns:
+ *  - `messages`/`channelMessages` state (moved off DataContext — the two
+ *    poll-effect writes for them move here too, exposed as
+ *    `applyPollMessages`).
+ *  - The 2 refs the pagination loaders read to avoid a stale-offset bug
+ *    (`messagesRef`, `channelMessagesRef` — see the comment on their
+ *    declarations below), plus the DOM container refs and the "pending
+ *    optimistic send" ref.
+ *  - `loadMoreChannelMessages`/`loadMoreDirectMessages` pagination.
+ *  - The 8 `activeTab`-gated scroll/pagination/read-marking effects
+ *    (task54_spec.md §1.3 census) plus their two non-gated companions
+ *    (the ref-sync effects and the channel auto-scroll-on-new-message
+ *    effect, which historically has no `activeTab` guard — preserved
+ *    as-is for behavior parity).
+ *
+ * Message row-id format is load-bearing (`${sourceId}_${fromNum}_${packetId}`,
+ * cross-source dedup for /api/unified/messages) — everything in this hook
+ * only reads/renders/compares ids, it never reconstructs one.
+ *
+ * The optimistic-send handlers themselves (handleSendMessage,
+ * handleSendDirectMessage, handleSendTapback, handleResendMessage, …) stay
+ * in App.tsx — they're deeply entangled with node lookups, sound/toast/
+ * homoglyph settings, and the shared traceroute/map orchestration already
+ * living there (useSourceView). They consume this hook's `messages`/
+ * `setMessages`/`channelMessages`/`setChannelMessages`/`pendingMessagesRef`/
+ * the two container refs exactly as they consumed the old DataContext
+ * fields — same names, same shapes, so those ~700 lines of handler bodies
+ * did not need to change, only their state source.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { MeshMessage } from '../types/message';
+import { useSource } from '../contexts/SourceContext';
+import { useData } from '../contexts/DataContext';
+import { useMessaging } from '../contexts/MessagingContext';
+import { useUI } from '../contexts/UIContext';
+import { useSettings, useNotificationMuteSettings } from '../contexts/SettingsContext';
+import { useToast } from '../components/ToastContainer';
+import api from '../services/api';
+import { logger } from '../utils/logger';
+import { playSound, playChannelSound, DEFAULT_SOUND_ID } from '../utils/notificationSounds';
+import type { PollData, RawMessage } from './usePoll';
+
+export function useMessagingView() {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  const { sourceId } = useSource();
+  const { currentNodeId } = useData();
+  const {
+    activeTab,
+  } = useUI();
+  const {
+    selectedChannel,
+    selectedDMNode,
+    setIsChannelScrolledToBottom,
+    setIsDMScrolledToBottom,
+    markMessagesAsRead,
+    setPendingMessages,
+    setUnreadCounts,
+    unreadCountsData,
+  } = useMessaging();
+  const { enableAudioNotifications } = useSettings();
+  const { isChannelMuted, isDMMuted } = useNotificationMuteSettings();
+
+  const [messages, setMessages] = useState<MeshMessage[]>([]);
+  const [channelMessages, setChannelMessages] = useState<{ [key: number]: MeshMessage[] }>({});
+
+  // Pagination state for infinite scroll. Local to this hook (#3962 5.4 PR7)
+  // — only the pagination machinery here ever read or wrote these on
+  // DataContext, so they moved rather than being left behind as an orphaned
+  // prop-drill.
+  const [channelHasMore, setChannelHasMore] = useState<{ [key: number]: boolean }>({});
+  const [channelLoadingMore, setChannelLoadingMore] = useState<{ [key: number]: boolean }>({});
+  const [dmHasMore, setDmHasMore] = useState<{ [key: string]: boolean }>({});
+  const [dmLoadingMore, setDmLoadingMore] = useState<{ [key: string]: boolean }>({});
+
+  // Track pending (optimistic, not-yet-server-confirmed) messages for
+  // interval/poll access without a stale closure — the source of truth the
+  // send handlers write to synchronously, ahead of the setPendingMessages
+  // React state update (see handleSendMessage et al. in App.tsx).
+  const pendingMessagesRef = useRef<Map<string, MeshMessage>>(new Map());
+
+  const channelMessagesContainerRef = useRef<HTMLDivElement>(null);
+  const dmMessagesContainerRef = useRef<HTMLDivElement>(null);
+  const lastScrollLoadTimeRef = useRef<number>(0); // Throttle scroll-triggered loads (200ms)
+
+  // Track latest channelMessages/messages via refs so the infinite-scroll loaders
+  // see current state without rebuilding their closure on every poll. Without
+  // this the first scroll-up uses a stale offset (0) captured at mount and the
+  // resulting fetch is filtered out by dedup, so the user sees nothing load.
+  const channelMessagesRef = useRef<{ [key: number]: MeshMessage[] }>({});
+  const messagesRef = useRef<MeshMessage[]>([]);
+
+  // Track the newest message ID to detect NEW messages (count-based tracking
+  // fails at the 100 message limit) — used only by applyPollMessages below.
+  const newestMessageId = useRef<string>('');
+
+  // applyPollMessages (below) is memoized without unreadCountsData in its
+  // deps (the caller — App's processPollData — has the same constraint), so
+  // bridge the latest filtered counts through a ref. This lets the
+  // per-channel unread badges honor the "Show MQTT/Bridge Messages" toggle
+  // the same way the sidebar dot does (#3787) — the dedicated unread query
+  // already applies excludeMqtt, but the /poll aggregate does not.
+  const unreadCountsDataRef = useRef(unreadCountsData);
+  useEffect(() => {
+    unreadCountsDataRef.current = unreadCountsData;
+  }, [unreadCountsData]);
+
+  // Play the notification sound configured for a given channel using the
+  // synthesized Web Audio sound library. Channel `-1` is the DM pseudo-channel;
+  // when no channel is supplied (or it is undefined) the default sound plays,
+  // preserving the previous single-tone behavior. Honors the master audio
+  // toggle exactly as before.
+  const playNotificationSound = useCallback((channelId?: number) => {
+    if (!enableAudioNotifications) {
+      logger.debug('🔇 Audio notifications disabled, skipping sound');
+      return;
+    }
+
+    logger.debug('🔊 playNotificationSound called for channel:', channelId);
+    if (channelId === undefined) {
+      playSound(DEFAULT_SOUND_ID);
+    } else {
+      // Scope the lookup to the active source so per-source selections (and the
+      // DM pseudo-channel) don't leak across sources that share channel numbers.
+      playChannelSound(channelId, sourceId);
+    }
+  }, [enableAudioNotifications, sourceId]);
+
+  // Keep refs in sync with the latest state so infinite-scroll loaders read
+  // current values instead of a stale closure. See comment at the ref decls.
+  useEffect(() => {
+    channelMessagesRef.current = channelMessages;
+  }, [channelMessages]);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  // Load more channel messages (for infinite scroll)
+  const loadMoreChannelMessages = useCallback(async () => {
+    if (channelLoadingMore[selectedChannel] || channelHasMore[selectedChannel] === false) {
+      return;
+    }
+
+    const currentMessages = channelMessagesRef.current[selectedChannel] || [];
+    const offset = currentMessages.length;
+    const container = channelMessagesContainerRef.current;
+
+    // Store scroll position before loading
+    const scrollHeightBefore = container?.scrollHeight || 0;
+
+    setChannelLoadingMore(prev => ({ ...prev, [selectedChannel]: true }));
+
+    try {
+      const result = await api.getChannelMessages(selectedChannel, 100, offset, sourceId);
+
+      if (result.messages.length > 0) {
+        // Process timestamps for new messages
+        const processedMessages = result.messages.map(msg => ({
+          ...msg,
+          timestamp: new Date(msg.timestamp),
+          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
+        }));
+
+        // Prepend older messages to the existing list, deduplicating by id
+        setChannelMessages(prev => {
+          const existingMessages = prev[selectedChannel] || [];
+          const existingIds = new Set(existingMessages.map(m => m.id));
+          const newMessages = processedMessages.filter(m => !existingIds.has(m.id));
+          return {
+            ...prev,
+            [selectedChannel]: [...newMessages, ...existingMessages],
+          };
+        });
+
+        // Restore scroll position after messages are prepended
+        requestAnimationFrame(() => {
+          if (container) {
+            const scrollHeightAfter = container.scrollHeight;
+            container.scrollTop = scrollHeightAfter - scrollHeightBefore;
+          }
+        });
+      }
+
+      setChannelHasMore(prev => ({ ...prev, [selectedChannel]: result.hasMore }));
+    } catch (error) {
+      logger.error('Failed to load more channel messages:', error);
+      showToast(t('toast.failed_load_older_messages'), 'error');
+    } finally {
+      setChannelLoadingMore(prev => ({ ...prev, [selectedChannel]: false }));
+    }
+  }, [
+    selectedChannel,
+    channelLoadingMore,
+    channelHasMore,
+    setChannelMessages,
+    setChannelHasMore,
+    setChannelLoadingMore,
+    showToast,
+    sourceId,
+    t,
+  ]);
+
+  // Load more direct messages (for infinite scroll)
+  const loadMoreDirectMessages = useCallback(async () => {
+    if (!selectedDMNode || !currentNodeId) return;
+
+    const dmKey = [currentNodeId, selectedDMNode].sort().join('_');
+    if (dmLoadingMore[dmKey] || dmHasMore[dmKey] === false) {
+      return;
+    }
+
+    // Get current DM messages from the messages array (channel -1 or direct messages)
+    const currentDMs = messagesRef.current.filter(
+      msg =>
+        (msg.fromNodeId === currentNodeId && msg.toNodeId === selectedDMNode) ||
+        (msg.fromNodeId === selectedDMNode && msg.toNodeId === currentNodeId)
+    );
+    const offset = currentDMs.length;
+    const container = dmMessagesContainerRef.current;
+
+    // Store scroll position before loading
+    const scrollHeightBefore = container?.scrollHeight || 0;
+
+    setDmLoadingMore(prev => ({ ...prev, [dmKey]: true }));
+
+    try {
+      const result = await api.getDirectMessages(currentNodeId, selectedDMNode, 100, offset, sourceId);
+
+      if (result.messages.length > 0) {
+        // Process timestamps for new messages
+        const processedMessages = result.messages.map(msg => ({
+          ...msg,
+          timestamp: new Date(msg.timestamp),
+          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
+        }));
+
+        // Prepend older messages to the existing list
+        setMessages(prev => {
+          // Remove duplicates by id
+          const existingIds = new Set(prev.map(m => m.id));
+          const newMessages = processedMessages.filter(m => !existingIds.has(m.id));
+          return [...newMessages, ...prev];
+        });
+
+        // Restore scroll position after messages are prepended
+        requestAnimationFrame(() => {
+          if (container) {
+            const scrollHeightAfter = container.scrollHeight;
+            container.scrollTop = scrollHeightAfter - scrollHeightBefore;
+          }
+        });
+      }
+
+      setDmHasMore(prev => ({ ...prev, [dmKey]: result.hasMore }));
+    } catch (error) {
+      logger.error('Failed to load more direct messages:', error);
+      showToast(t('toast.failed_load_older_messages'), 'error');
+    } finally {
+      setDmLoadingMore(prev => ({ ...prev, [dmKey]: false }));
+    }
+  }, [
+    selectedDMNode,
+    currentNodeId,
+    dmLoadingMore,
+    dmHasMore,
+    setMessages,
+    setDmHasMore,
+    setDmLoadingMore,
+    showToast,
+    sourceId,
+    t,
+  ]);
+
+  // Check if container is scrolled near bottom (within 100px)
+  const isScrolledNearBottom = useCallback((container: HTMLDivElement | null): boolean => {
+    if (!container) return true;
+    const threshold = 100;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    return scrollHeight - scrollTop - clientHeight < threshold;
+  }, []);
+
+  // Check if container is scrolled near top (within 100px)
+  const isScrolledNearTop = useCallback((container: HTMLDivElement | null): boolean => {
+    if (!container) return false;
+    return container.scrollTop < 100;
+  }, []);
+
+  // Handle scroll events to track scroll position (throttled for load-more)
+  const handleChannelScroll = useCallback(() => {
+    if (channelMessagesContainerRef.current) {
+      const atBottom = isScrolledNearBottom(channelMessagesContainerRef.current);
+      setIsChannelScrolledToBottom(atBottom);
+
+      // Check if scrolled near top and trigger load more (throttled to 200ms)
+      const now = Date.now();
+      if (isScrolledNearTop(channelMessagesContainerRef.current) && now - lastScrollLoadTimeRef.current > 200) {
+        lastScrollLoadTimeRef.current = now;
+        void loadMoreChannelMessages();
+      }
+    }
+  }, [isScrolledNearBottom, isScrolledNearTop, loadMoreChannelMessages, setIsChannelScrolledToBottom]);
+
+  const handleDMScroll = useCallback(() => {
+    if (dmMessagesContainerRef.current) {
+      const atBottom = isScrolledNearBottom(dmMessagesContainerRef.current);
+      setIsDMScrolledToBottom(atBottom);
+
+      // Check if scrolled near top and trigger load more (throttled to 200ms)
+      const now = Date.now();
+      if (isScrolledNearTop(dmMessagesContainerRef.current) && now - lastScrollLoadTimeRef.current > 200) {
+        lastScrollLoadTimeRef.current = now;
+        void loadMoreDirectMessages();
+      }
+    }
+  }, [isScrolledNearBottom, isScrolledNearTop, loadMoreDirectMessages, setIsDMScrolledToBottom]);
+
+  // Attach scroll event listeners. Re-run when navigation could have swapped
+  // the underlying DOM node — channel switch, DM switch, or tab switch, or
+  // when the handler closures themselves change (pagination state changed)
+  // — to be sure we attach to the freshly mounted container / current
+  // closure. Without this the very first scroll on the initial channel never
+  // fires the load-more handler.
+  useEffect(() => {
+    const channelContainer = channelMessagesContainerRef.current;
+    const dmContainer = dmMessagesContainerRef.current;
+
+    if (channelContainer) {
+      channelContainer.addEventListener('scroll', handleChannelScroll);
+    }
+    if (dmContainer) {
+      dmContainer.addEventListener('scroll', handleDMScroll);
+    }
+
+    return () => {
+      if (channelContainer) {
+        channelContainer.removeEventListener('scroll', handleChannelScroll);
+      }
+      if (dmContainer) {
+        dmContainer.removeEventListener('scroll', handleDMScroll);
+      }
+    };
+  }, [handleChannelScroll, handleDMScroll, activeTab, selectedChannel, selectedDMNode]);
+
+  // Force scroll to bottom when channel changes OR when switching to channels tab
+  // Note: We track initial scroll per channel to avoid re-scrolling when user manually scrolls
+  // [GATED EFFECT #1 — task54_spec.md §1.3]
+  useEffect(() => {
+    if (activeTab === 'channels' && selectedChannel >= 0) {
+      const currentChannelMessages = channelMessages[selectedChannel] || [];
+      const hasMessages = currentChannelMessages.length > 0;
+
+      // Always scroll to bottom when entering the channels tab or changing channels
+      if (hasMessages) {
+        // Use setTimeout to ensure messages are rendered before scrolling
+        setTimeout(() => {
+          if (channelMessagesContainerRef.current) {
+            channelMessagesContainerRef.current.scrollTop = channelMessagesContainerRef.current.scrollHeight;
+            setIsChannelScrolledToBottom(true);
+          }
+        }, 100);
+      }
+    }
+  }, [selectedChannel, activeTab, channelMessages, setIsChannelScrolledToBottom]);
+
+  // Auto-scroll to bottom when new messages arrive and user is already at the bottom.
+  // Non-gated companion to GATED EFFECT #2 below (channels vs DMs) — preserved
+  // as-is (no activeTab guard existed here pre-migration).
+  const prevChannelMsgCountRef = useRef<Record<number, number>>({});
+  useEffect(() => {
+    const currentMessages = channelMessages[selectedChannel] || [];
+    const prevCount = prevChannelMsgCountRef.current[selectedChannel] || 0;
+    const currentCount = currentMessages.length;
+
+    if (currentCount > prevCount && prevCount > 0) {
+      // New messages arrived — auto-scroll if user was near the bottom
+      const container = channelMessagesContainerRef.current;
+      if (container) {
+        const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 150;
+        if (isNearBottom) {
+          setTimeout(() => {
+            if (channelMessagesContainerRef.current) {
+              channelMessagesContainerRef.current.scrollTo({
+                top: channelMessagesContainerRef.current.scrollHeight,
+                behavior: 'smooth'
+              });
+            }
+          }, 50);
+        }
+      }
+    }
+
+    prevChannelMsgCountRef.current = {
+      ...prevChannelMsgCountRef.current,
+      [selectedChannel]: currentCount
+    };
+  }, [channelMessages, selectedChannel]);
+
+  // Auto-scroll DMs to bottom when new messages arrive and user is at the bottom
+  // [GATED EFFECT #2 — task54_spec.md §1.3]
+  const prevDMMsgCountRef = useRef(0);
+  useEffect(() => {
+    const currentCount = messages.length;
+    const prevCount = prevDMMsgCountRef.current;
+
+    if (currentCount > prevCount && prevCount > 0 && activeTab === 'messages') {
+      const container = dmMessagesContainerRef.current;
+      if (container) {
+        const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 150;
+        if (isNearBottom) {
+          setTimeout(() => {
+            if (dmMessagesContainerRef.current) {
+              dmMessagesContainerRef.current.scrollTo({
+                top: dmMessagesContainerRef.current.scrollHeight,
+                behavior: 'smooth'
+              });
+            }
+          }, 50);
+        }
+      }
+    }
+
+    prevDMMsgCountRef.current = currentCount;
+  }, [messages, activeTab]);
+
+  // Auto-load more channel messages if container doesn't have a scrollbar
+  // This fixes the case where a channel has no recent messages and infinite scroll never triggers
+  // [GATED EFFECT #3 — task54_spec.md §1.3]
+  useEffect(() => {
+    if (activeTab === 'channels' && selectedChannel >= 0) {
+      // Skip if we're already loading or know there are no more messages
+      if (channelLoadingMore[selectedChannel] || channelHasMore[selectedChannel] === false) {
+        return;
+      }
+
+      // Check after a delay to allow the DOM to render
+      const checkTimer = setTimeout(() => {
+        const container = channelMessagesContainerRef.current;
+        if (container) {
+          // If container doesn't have a scrollbar, load more messages
+          const hasScrollbar = container.scrollHeight > container.clientHeight;
+          if (!hasScrollbar) {
+            void loadMoreChannelMessages();
+          }
+        }
+      }, 200);
+
+      return () => clearTimeout(checkTimer);
+    }
+  }, [selectedChannel, activeTab, channelLoadingMore, channelHasMore, loadMoreChannelMessages]);
+
+  // Force scroll to bottom when DM node changes OR when switching to messages tab
+  // [GATED EFFECT #4 — task54_spec.md §1.3]
+  useEffect(() => {
+    if (activeTab === 'messages' && selectedDMNode && currentNodeId) {
+      const currentDMMessages = messages.filter(
+        msg =>
+          (msg.fromNodeId === currentNodeId && msg.toNodeId === selectedDMNode) ||
+          (msg.fromNodeId === selectedDMNode && msg.toNodeId === currentNodeId)
+      );
+      const hasMessages = currentDMMessages.length > 0;
+
+      // Always scroll to bottom when entering the messages tab or changing conversations
+      if (hasMessages) {
+        setTimeout(() => {
+          if (dmMessagesContainerRef.current) {
+            dmMessagesContainerRef.current.scrollTop = dmMessagesContainerRef.current.scrollHeight;
+            setIsDMScrolledToBottom(true);
+          }
+        }, 150);
+      }
+    }
+  }, [selectedDMNode, activeTab, currentNodeId, messages, setIsDMScrolledToBottom]);
+
+  // Auto-load more DM messages if container doesn't have a scrollbar
+  // This fixes the case where a conversation has no recent messages and infinite scroll never triggers
+  // [GATED EFFECT #5 — task54_spec.md §1.3]
+  useEffect(() => {
+    if (activeTab === 'messages' && selectedDMNode && currentNodeId) {
+      const dmKey = [currentNodeId, selectedDMNode].sort().join('_');
+
+      // Skip if we're already loading or know there are no more messages
+      if (dmLoadingMore[dmKey] || dmHasMore[dmKey] === false) {
+        return;
+      }
+
+      // Check after a delay to allow the DOM to render
+      const checkTimer = setTimeout(() => {
+        const container = dmMessagesContainerRef.current;
+        if (container) {
+          // If container doesn't have a scrollbar, load more messages
+          const hasScrollbar = container.scrollHeight > container.clientHeight;
+          if (!hasScrollbar) {
+            void loadMoreDirectMessages();
+          }
+        }
+      }, 200);
+
+      return () => clearTimeout(checkTimer);
+    }
+  }, [selectedDMNode, activeTab, currentNodeId, dmLoadingMore, dmHasMore, loadMoreDirectMessages]);
+
+  // Mark messages as read when viewing a channel — also re-fires when new messages arrive
+  // so that incoming messages are immediately marked as read while the user is viewing the channel.
+  // Without the message count dependency, new messages would show as "unread" until the user
+  // clicks away and back (#2316).
+  // [GATED EFFECT #6 — task54_spec.md §1.3]
+  const currentChannelMsgCount = (channelMessages[selectedChannel] || []).length;
+  useEffect(() => {
+    if (activeTab === 'channels' && selectedChannel >= 0) {
+      void markMessagesAsRead(undefined, selectedChannel);
+    }
+  }, [selectedChannel, activeTab, markMessagesAsRead, currentChannelMsgCount]);
+
+  // Mark messages as read when viewing a DM conversation — also re-fires on new messages
+  // Filter to only the selected conversation so we don't fire on messages from other DMs
+  // [GATED EFFECT #7 — task54_spec.md §1.3]
+  const currentDMMsgCount = selectedDMNode
+    ? messages.filter(msg => msg.fromNodeId === selectedDMNode || msg.toNodeId === selectedDMNode).length
+    : 0;
+  useEffect(() => {
+    if (activeTab === 'messages' && selectedDMNode) {
+      void markMessagesAsRead(undefined, undefined, selectedDMNode);
+    }
+  }, [selectedDMNode, activeTab, markMessagesAsRead, currentDMMsgCount]);
+
+  // Timer to update message status indicators (timeout detection after 30s)
+  // Only runs when on channels/messages tabs to reduce CPU usage on mobile (#1769)
+  // [GATED EFFECT #8 — task54_spec.md §1.3]
+  const [, setStatusTick] = useState(0);
+  useEffect(() => {
+    // Only run timer when viewing messaging tabs where status indicators are visible
+    if (activeTab !== 'channels' && activeTab !== 'messages') {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      // Force re-render to update message status indicators
+      setStatusTick(prev => prev + 1);
+    }, 5000); // Update every 5 seconds (reduced from 1s for mobile performance)
+
+    return () => clearInterval(interval);
+  }, [activeTab]);
+
+  // Apply a /api/poll payload's messages data — merges the poll's latest rows
+  // with (a) older rows preserved from infinite-scroll pagination and (b)
+  // still-pending optimistic rows, updates unread counts, and plays the
+  // notification sound for a genuinely new incoming message. Moved verbatim
+  // out of App's processPollData (#3962 5.4 PR7) — `currentSelectedChannel`
+  // is `selectedChannelRef.current`, passed in because that ref stays in App
+  // (it's also used by channel-fetch/Sidebar-navigation logic outside this
+  // hook's scope).
+  const applyPollMessages = useCallback(
+    (data: PollData, localNodeId: string, currentSelectedChannel: number) => {
+      if (!data.messages) return;
+
+      const messagesData = data.messages;
+      // RawMessage.deliveryState is a bare `string` (server-side wire shape);
+      // MeshMessage narrows it to MessageDeliveryState. The cast mirrors what
+      // the untyped (`any`) version of this code relied on implicitly — the
+      // server only ever sends valid values.
+      const processedMessages: MeshMessage[] = messagesData.map((msg: RawMessage) => ({
+        ...msg,
+        timestamp: new Date(msg.timestamp),
+        receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
+      } as MeshMessage));
+
+      // Play notification sound if new messages arrived from OTHER users
+      if (processedMessages.length > 0) {
+        const currentNewestMessage = processedMessages[0];
+        const currentNewestId = currentNewestMessage.id;
+
+        if (newestMessageId.current && currentNewestId !== newestMessageId.current) {
+          const isFromOther = currentNewestMessage.fromNodeId !== localNodeId;
+          const isTextMessage = currentNewestMessage.portnum === 1;
+
+          if (isFromOther && isTextMessage) {
+            logger.debug('New message arrived from other user:', currentNewestMessage.fromNodeId);
+            const isDM = currentNewestMessage.channel === -1;
+            const muted = isDM
+              ? isDMMuted(currentNewestMessage.fromNodeId)
+              : isChannelMuted(currentNewestMessage.channel);
+            if (!muted) {
+              // Play the sound configured for this channel (channel -1 is the
+              // DM pseudo-channel, which has its own selectable sound too).
+              playNotificationSound(currentNewestMessage.channel);
+            } else {
+              logger.debug('🔇 Notification sound suppressed (muted):', isDM ? `DM from ${currentNewestMessage.fromNodeId}` : `channel ${currentNewestMessage.channel}`);
+            }
+          }
+        }
+
+        newestMessageId.current = currentNewestId;
+      }
+
+      // Check for matching messages to remove from pending
+      const currentPending = pendingMessagesRef.current;
+      const updatedPending = new Map(currentPending);
+      let pendingChanged = false;
+
+      if (currentPending.size > 0) {
+        currentPending.forEach((pendingMsg, tempId) => {
+          const isDM = pendingMsg.channel === -1;
+
+          const matchingMessage = processedMessages.find((msg: MeshMessage) => {
+            if (msg.text !== pendingMsg.text) return false;
+
+            const senderMatches =
+              (localNodeId && msg.from === localNodeId) ||
+              msg.from === pendingMsg.from ||
+              msg.fromNodeId === pendingMsg.fromNodeId;
+
+            if (!senderMatches) return false;
+            if (Math.abs(msg.timestamp.getTime() - pendingMsg.timestamp.getTime()) >= 30000) return false;
+
+            if (isDM) {
+              const matches =
+                msg.toNodeId === pendingMsg.toNodeId ||
+                (msg.to === pendingMsg.to && (msg.channel === 0 || msg.channel === -1));
+              return matches;
+            } else {
+              return msg.channel === pendingMsg.channel;
+            }
+          });
+
+          if (matchingMessage) {
+            updatedPending.delete(tempId);
+            pendingChanged = true;
+          }
+        });
+
+        if (pendingChanged) {
+          pendingMessagesRef.current = updatedPending;
+          setPendingMessages(updatedPending);
+        }
+      }
+
+      // Compute merged messages using setMessages callback to access current state
+      // Preserve older DM messages loaded via infinite scroll (similar to channel messages)
+      const pendingIds = new Set(Array.from(pendingMessagesRef.current.keys()));
+      const pollMsgIds = new Set(processedMessages.map((m: MeshMessage) => m.id));
+
+      setMessages(currentMessages => {
+        // Keep older messages that aren't in the poll (they were loaded via infinite scroll)
+        // Poll returns newest messages, so any messages not in poll are older
+        const olderMsgs = (currentMessages || []).filter(m => {
+          // If message is in poll results, don't keep it (poll version is authoritative)
+          if (pollMsgIds.has(m.id)) return false;
+
+          // For pending messages (temp IDs), only keep if still pending
+          if (m.id.toString().startsWith('temp_')) {
+            if (!pendingIds.has(m.id)) return false;
+            // Safety net: filter out if a matching server message already exists
+            // This catches edge cases where the ref timing or text/sender matching fails
+            // Must use localNodeId fallback (same as primary dedup) because temp messages
+            // created before first poll may have fromNodeId='me' instead of the real node ID
+            const hasServerMatch = processedMessages.some((pm: MeshMessage) =>
+              pm.text === m.text &&
+              ((localNodeId && pm.from === localNodeId) || pm.fromNodeId === m.fromNodeId || pm.from === m.from) &&
+              Math.abs(pm.timestamp.getTime() - m.timestamp.getTime()) < 30000
+            );
+            if (hasServerMatch) return false;
+            return true;
+          }
+
+          // Keep all other older messages (loaded via infinite scroll)
+          return true;
+        });
+
+        // Combine: older messages + poll messages (poll messages are newer/updated)
+        // Sort by timestamp to maintain order
+        const merged = [...olderMsgs, ...processedMessages];
+        merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        return merged;
+      });
+
+      // Group messages by channel (use processedMessages since we don't need pending for channel groups)
+      const channelGroups: { [key: number]: MeshMessage[] } = {};
+      processedMessages.forEach((msg: MeshMessage) => {
+        if (msg.channel === -1) return;
+        if (!channelGroups[msg.channel]) {
+          channelGroups[msg.channel] = [];
+        }
+        channelGroups[msg.channel].push(msg);
+      });
+
+      // Update unread counts from the dedicated (filtered) unread query rather
+      // than the raw /poll aggregate, so the per-channel badges respect the
+      // "Show MQTT/Bridge Messages" toggle just like the sidebar dot (#3787).
+      // Fall back to the poll payload only until the first dedicated fetch lands.
+      const newUnreadCounts: { [key: number]: number } = {};
+
+      const filteredChannelUnreads = unreadCountsDataRef.current?.channels ?? data.unreadCounts?.channels;
+      if (filteredChannelUnreads) {
+        Object.entries(filteredChannelUnreads).forEach(([channelId, count]) => {
+          const chId = parseInt(channelId, 10);
+          if (chId === currentSelectedChannel) {
+            newUnreadCounts[chId] = 0;
+          } else {
+            newUnreadCounts[chId] = count as number;
+          }
+        });
+      }
+
+      setUnreadCounts(newUnreadCounts);
+
+      // Merge poll messages with existing messages (preserve older messages loaded via infinite scroll)
+      setChannelMessages(prev => {
+        const merged: { [key: number]: MeshMessage[] } = {};
+
+        // Get all channel IDs from both existing and new messages
+        const allChannelIds = new Set([...Object.keys(prev).map(Number), ...Object.keys(channelGroups).map(Number)]);
+
+        allChannelIds.forEach(channelId => {
+          const existingMsgs = prev[channelId] || [];
+          const pollMsgs = channelGroups[channelId] || [];
+
+          // Create a map of poll message IDs for quick lookup
+          const pollMsgIdsForChannel = new Set(pollMsgs.map(m => m.id));
+
+          // Keep older messages that aren't in the poll (they were loaded via infinite scroll)
+          // Poll returns newest 100, so any messages not in poll are older
+          // Also filter out pending messages that are no longer pending (they've been matched to real messages)
+          const olderMsgs = existingMsgs.filter(m => {
+            // If message is in poll results, don't keep it (poll version is authoritative)
+            if (pollMsgIdsForChannel.has(m.id)) return false;
+
+            // For pending messages (temp IDs), only keep if still pending
+            // Once matched/acknowledged, pendingIds won't contain it anymore
+            // Channel messages use 'temp_' prefix, DMs use 'temp_dm_' prefix
+            if (m.id.toString().startsWith('temp_')) {
+              if (!pendingIds.has(m.id)) return false;
+              // Safety net: filter out if a matching server message already exists
+              // Must use localNodeId fallback (same as primary dedup) because temp messages
+              // created before first poll may have fromNodeId='me' instead of the real node ID
+              const hasServerMatch = pollMsgs.some(pm =>
+                pm.text === m.text &&
+                ((localNodeId && pm.from === localNodeId) || pm.fromNodeId === m.fromNodeId || pm.from === m.from) &&
+                Math.abs(pm.timestamp.getTime() - m.timestamp.getTime()) < 30000
+              );
+              if (hasServerMatch) return false;
+              return true;
+            }
+
+            // Keep all other older messages (loaded via infinite scroll)
+            return true;
+          });
+
+          // Combine: older messages + poll messages (poll messages are newer/updated)
+          merged[channelId] = [...olderMsgs, ...pollMsgs];
+        });
+
+        return merged;
+      });
+    },
+    [isChannelMuted, isDMMuted, playNotificationSound, setPendingMessages, setUnreadCounts]
+  );
+
+  return {
+    messages,
+    setMessages,
+    channelMessages,
+    setChannelMessages,
+    pendingMessagesRef,
+    channelMessagesContainerRef,
+    dmMessagesContainerRef,
+    applyPollMessages,
+  };
+}


### PR DESCRIPTION
## Summary
PR7 of the Task 5.4 stack (remediation epic #3962) — the riskiest PR: `messages` and `channels` become routes, and the messaging state machinery (optimistic-send merge, channel/DM pagination, unread marking, the 8 activeTab-gated scroll/read effects, notification-sound support state) extracts into a new `useMessagingView` hook (785 lines). DataContext sheds `messages`/`channelMessages` and the pagination fields (−39 lines) — App's poll processing now calls the hook's `applyPollMessages` with verbatim-relocated merge logic. Send/tapback/resend handlers deliberately stay in App (entangled with node lookups + shared orchestration; they consume the hook's state under unchanged identifiers — bodies untouched). App.tsx 4,560 → 3,968 (−592).

The load-bearing message row-id format (`${sourceId}_${fromNum}_${packetId}`) is consumed, never constructed — guarded by comment per the epic's invariant list.

## Browser validation (dev container, deployed d470ed11, live BLE sandbox node)
- Channels route renders per-source channel list + history ✓
- Test message sent on the **gauntlet** channel: rendered optimistically, composer reset ✓
- **Exactly 1 occurrence after multiple poll cycles** — optimistic entry merged with the polled copy, no dupe/drop (row-id dedup path through the hook) ✓
- Console clean (known locales-fallback 404 only)

## Issues Resolved
Relates to #3962 (Phase 5.4, PR 7 of 8).

## Testing
- [x] Full Vitest suite: success=true, 10,334 passed, 0 failed, 0 failed suites
- [x] New `useMessagingView.test.ts` (8 tests: optimistic merge + pagination surface)
- [x] `tsc --noEmit` 0; `typecheck:tests` 304 = main parity; `lint:ci` green (App exhaustive-deps 16→10, any 1→0)
- [x] ChannelsTab.reactions.test.tsx unchanged and green
- [ ] Reviewer: the deviation note — messaging state was more entangled than the spec census (sound/mute/newest-id support state folded into the hook; send handlers left in App by design) — documented in the epic log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158hFzsVbodeJK246qAE1dY