### PR TITLE
refactor(frontend): migrate high-count raw fetch() sites to ApiService (#3962 5.5 PR1)

### DIFF
--- a/eslint-baseline.json
+++ b/eslint-baseline.json
@@ -317,7 +317,6 @@
     "react-refresh/only-export-components": 1
   },
   "src/components/configuration/BackupManagementSection.tsx": {
-    "no-restricted-syntax": 6,
     "react-hooks/exhaustive-deps": 1
   },
   "src/components/configuration/ChannelDatabaseSection.tsx": {
@@ -328,7 +327,6 @@
     "@typescript-eslint/no-explicit-any": 1
   },
   "src/components/configuration/DatabaseMaintenanceSection.tsx": {
-    "no-restricted-syntax": 5,
     "react-hooks/exhaustive-deps": 1
   },
   "src/components/configuration/DeviceConfigSection.tsx": {
@@ -350,7 +348,6 @@
     "no-restricted-syntax": 1
   },
   "src/components/configuration/SystemBackupSection.tsx": {
-    "no-restricted-syntax": 6,
     "react-hooks/exhaustive-deps": 1
   },
   "src/components/configuration/TelemetryConfigSection.tsx": {
@@ -566,8 +563,7 @@
     "react-refresh/only-export-components": 1
   },
   "src/pages/DashboardPage.tsx": {
-    "@typescript-eslint/no-explicit-any": 10,
-    "no-restricted-syntax": 9
+    "@typescript-eslint/no-explicit-any": 10
   },
   "src/pages/UnifiedMessagesPage.tsx": {
     "no-restricted-syntax": 3

--- a/src/components/configuration/BackupManagementSection.test.tsx
+++ b/src/components/configuration/BackupManagementSection.test.tsx
@@ -5,9 +5,16 @@
  * multi-source setups back up the active source instead of always defaulting
  * to the primary one. Single-source (sourceId === null) views must keep the
  * old un-parameterized URL so the backend's primary-manager fallback applies.
+ *
+ * #3962 Task 5.5: the component's manual-backup call was migrated from raw
+ * fetch() to apiService.download(). These tests now assert directly on the
+ * apiService.download mock's call arguments (the endpoint string) instead of
+ * spying on global.fetch, since ApiService itself — not fetch — is the
+ * component's request boundary post-migration. The sourceId
+ * inclusion/omission semantics being pinned are unchanged.
  */
 import React from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // --- mocks ---------------------------------------------------------------
@@ -30,11 +37,30 @@ vi.mock('../../utils/logger', () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
-vi.mock('../../services/api', () => ({
-  default: {
-    getBaseUrl: vi.fn().mockResolvedValue('http://test'),
-  },
-}));
+// The mock ApiError class is declared inside the factory (not hoisted from
+// module scope) since vi.mock factories only get hoisting exemptions for
+// `mock`-prefixed bindings.
+vi.mock('../../services/api', () => {
+  class MockApiError extends Error {
+    status: number;
+    body?: unknown;
+    constructor(message: string, status: number, options?: { body?: unknown }) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.body = options?.body;
+    }
+  }
+
+  return {
+    ApiError: MockApiError,
+    default: {
+      getBaseUrl: vi.fn().mockResolvedValue('http://test'),
+      get: vi.fn().mockResolvedValue({ enabled: false, maxBackups: 7, backupTime: '02:00' }),
+      download: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
 
 // sourceId is configurable per-test via this mutable holder.
 const sourceState: { sourceId: string | null; sourceName: string | null } = {
@@ -45,69 +71,52 @@ vi.mock('../../contexts/SourceContext', () => ({
   useSource: () => sourceState,
 }));
 
+import apiService from '../../services/api';
 import BackupManagementSection from './BackupManagementSection';
-
-function makeFetchMock() {
-  return vi.fn().mockImplementation((url: string) => {
-    if (typeof url === 'string' && url.includes('/api/backup/settings')) {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ enabled: false, maxBackups: 7, backupTime: '02:00' }),
-      });
-    }
-    // device/backup
-    return Promise.resolve({
-      ok: true,
-      headers: { get: () => 'attachment; filename="abc.yaml"' },
-      text: () => Promise.resolve('yaml: content'),
-    });
-  });
-}
 
 describe('BackupManagementSection — issue #3711 source scoping', () => {
   beforeEach(() => {
     sourceState.sourceId = null;
     sourceState.sourceName = null;
-    // Avoid real download side-effects.
-    global.URL.createObjectURL = vi.fn(() => 'blob:x');
-    global.URL.revokeObjectURL = vi.fn();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    // clearAllMocks() wipes call history; re-arm the resolved values it
+    // also clears the underlying implementation reference for.
+    (apiService.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      enabled: false,
+      maxBackups: 7,
+      backupTime: '02:00',
+    });
+    (apiService.download as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
   });
 
   it('includes sourceId in the manual backup request when a source is selected', async () => {
     sourceState.sourceId = 'src-b';
     sourceState.sourceName = 'B';
-    const fetchMock = makeFetchMock();
-    global.fetch = fetchMock as unknown as typeof fetch;
 
     render(<BackupManagementSection />);
     fireEvent.click(screen.getByText('backup_management.create_button'));
 
     await waitFor(() => {
-      const calledBackup = fetchMock.mock.calls.some(
-        ([u]) => typeof u === 'string' && u.includes('/api/device/backup') && u.includes('sourceId=src-b')
-      );
-      expect(calledBackup).toBe(true);
+      expect(apiService.download).toHaveBeenCalled();
     });
+
+    const [endpoint] = (apiService.download as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(endpoint).toContain('/api/device/backup');
+    expect(endpoint).toContain('sourceId=src-b');
   });
 
   it('omits sourceId when no source is selected (single-source fallback)', async () => {
     sourceState.sourceId = null;
-    const fetchMock = makeFetchMock();
-    global.fetch = fetchMock as unknown as typeof fetch;
 
     render(<BackupManagementSection />);
     fireEvent.click(screen.getByText('backup_management.create_button'));
 
     await waitFor(() => {
-      const backupCall = fetchMock.mock.calls.find(
-        ([u]) => typeof u === 'string' && u.includes('/api/device/backup')
-      );
-      expect(backupCall).toBeTruthy();
-      expect(backupCall![0]).not.toContain('sourceId=');
+      expect(apiService.download).toHaveBeenCalled();
     });
+
+    const [endpoint] = (apiService.download as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(endpoint).toContain('/api/device/backup');
+    expect(endpoint).not.toContain('sourceId=');
   });
 });

--- a/src/components/configuration/BackupManagementSection.tsx
+++ b/src/components/configuration/BackupManagementSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import apiService from '../../services/api';
+import apiService, { ApiError } from '../../services/api';
 import { useToast } from '../ToastContainer';
 import { logger } from '../../utils/logger';
 import { useSaveBar } from '../../hooks/useSaveBar';
@@ -66,27 +66,24 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
 
   const loadBackupSettings = async () => {
     try {
-      const baseUrl = await apiService.getBaseUrl();
-      const response = await fetch(`${baseUrl}/api/backup/settings`, {
-        credentials: 'same-origin'
-      });
-
-      if (response.ok) {
-        const settings = await response.json();
-        const enabled = settings.enabled || false;
-        const max = settings.maxBackups || 7;
-        const time = settings.backupTime || '02:00';
-        setAutoBackupEnabled(enabled);
-        setMaxBackups(max);
-        setBackupTime(time);
-        // Update initial values to match loaded settings
-        initialValuesRef.current = {
-          autoBackupEnabled: enabled,
-          maxBackups: max,
-          backupTime: time
-        };
-      }
+      const settings = await apiService.get<{ enabled?: boolean; maxBackups?: number; backupTime?: string }>('/api/backup/settings');
+      const enabled = settings.enabled || false;
+      const max = settings.maxBackups || 7;
+      const time = settings.backupTime || '02:00';
+      setAutoBackupEnabled(enabled);
+      setMaxBackups(max);
+      setBackupTime(time);
+      // Update initial values to match loaded settings
+      initialValuesRef.current = {
+        autoBackupEnabled: enabled,
+        maxBackups: max,
+        backupTime: time
+      };
     } catch (error) {
+      // Preserve the prior silent-ignore on a non-ok HTTP response; only a
+      // genuine network/transport failure gets logged (same split as the
+      // old `if (response.ok) {...}` with no else branch).
+      if (error instanceof ApiError) return;
       logger.error('Error loading backup settings:', error);
     }
   };
@@ -94,29 +91,11 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
   const handleSaveBackupSettings = async () => {
     try {
       setIsSavingSettings(true);
-      const baseUrl = await apiService.getBaseUrl();
-
-      // Get CSRF token
-      const csrfToken = sessionStorage.getItem('csrfToken');
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (csrfToken) {
-        headers['X-CSRF-Token'] = csrfToken;
-      }
-
-      const response = await fetch(`${baseUrl}/api/backup/settings`, {
-        method: 'POST',
-        headers,
-        credentials: 'same-origin',
-        body: JSON.stringify({
-          enabled: autoBackupEnabled,
-          maxBackups,
-          backupTime
-        })
+      await apiService.post('/api/backup/settings', {
+        enabled: autoBackupEnabled,
+        maxBackups,
+        backupTime
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to save backup settings');
-      }
 
       // Update initial values to match saved settings
       initialValuesRef.current = {
@@ -150,43 +129,14 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
     try {
       showToast(t('backup_management.toast_creating_backup'), 'info');
 
-      const baseUrl = await apiService.getBaseUrl();
       // Scope the backup to the currently-selected source so multi-source
       // setups back up the active source rather than always the primary one.
       // When sourceId is null (legacy/single-source view) the backend falls
       // back to the primary manager, preserving existing behavior.
-      const backupUrl = sourceId
-        ? `${baseUrl}/api/device/backup?save=true&sourceId=${encodeURIComponent(sourceId)}`
-        : `${baseUrl}/api/device/backup?save=true`;
-      const response = await fetch(backupUrl, {
-        method: 'GET',
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to create backup: ${response.statusText}`);
-      }
-
-      const contentDisposition = response.headers.get('Content-Disposition');
-      let filename = 'meshtastic-backup.yaml';
-      if (contentDisposition) {
-        const matches = /filename="?([^"]+)"?/.exec(contentDisposition);
-        if (matches && matches[1]) {
-          filename = matches[1];
-        }
-      }
-
-      const yamlContent = await response.text();
-
-      const blob = new Blob([yamlContent], { type: 'application/x-yaml' });
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
+      const endpoint = sourceId
+        ? `/api/device/backup?save=true&sourceId=${encodeURIComponent(sourceId)}`
+        : '/api/device/backup?save=true';
+      await apiService.download(endpoint, { defaultName: 'meshtastic-backup.yaml' });
 
       showToast(t('backup_management.toast_backup_created'), 'success');
       if (onBackupCreated) onBackupCreated();
@@ -199,17 +149,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
   const handleShowBackups = async () => {
     try {
       setIsLoadingBackups(true);
-      const baseUrl = await apiService.getBaseUrl();
-
-      const response = await fetch(`${baseUrl}/api/backup/list`, {
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to load backup list');
-      }
-
-      const backups = await response.json();
+      const backups = await apiService.get<BackupFile[]>('/api/backup/list');
       setBackupList(backups);
       setIsBackupModalOpen(true);
     } catch (error) {
@@ -222,17 +162,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
 
   const handleDownloadBackup = async (filename: string) => {
     try {
-      const baseUrl = await apiService.getBaseUrl();
-
-      const response = await fetch(`${baseUrl}/api/backup/download/${encodeURIComponent(filename)}`, {
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to download backup');
-      }
-
-      const yamlContent = await response.text();
+      const yamlContent = await apiService.getText(`/api/backup/download/${encodeURIComponent(filename)}`);
 
       const blob = new Blob([yamlContent], { type: 'application/x-yaml' });
       const url = window.URL.createObjectURL(blob);
@@ -257,16 +187,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
     }
 
     try {
-      const baseUrl = await apiService.getBaseUrl();
-
-      const response = await fetch(`${baseUrl}/api/backup/delete/${encodeURIComponent(filename)}`, {
-        method: 'DELETE',
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to delete backup');
-      }
+      await apiService.delete(`/api/backup/delete/${encodeURIComponent(filename)}`);
 
       showToast(t('backup_management.toast_deleted'), 'success');
       // Refresh the backup list

--- a/src/components/configuration/DatabaseMaintenanceSection.tsx
+++ b/src/components/configuration/DatabaseMaintenanceSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import apiService from '../../services/api';
+import apiService, { ApiError } from '../../services/api';
 import { useToast } from '../ToastContainer';
 import { logger } from '../../utils/logger';
 import { useSaveBar } from '../../hooks/useSaveBar';
@@ -100,15 +100,15 @@ const DatabaseMaintenanceSection: React.FC = () => {
   useEffect(() => {
     const fetchDatabaseType = async () => {
       try {
-        const baseUrl = await apiService.getBaseUrl();
-        const response = await fetch(`${baseUrl}/api/health`);
-        if (response.ok) {
-          const data = await response.json();
-          if (data.databaseType) {
-            setDatabaseType(data.databaseType);
-          }
+        const data = await apiService.get<{ databaseType?: 'sqlite' | 'postgres' | 'mysql' }>('/api/health');
+        if (data.databaseType) {
+          setDatabaseType(data.databaseType);
         }
       } catch (error) {
+        // Preserve the prior silent-ignore on a non-ok HTTP response; only a
+        // genuine network/transport failure gets logged (same split as the
+        // old `if (response.ok) {...}` with no else branch).
+        if (error instanceof ApiError) return;
         logger.error('Error fetching database type:', error);
       }
     };
@@ -125,47 +125,39 @@ const DatabaseMaintenanceSection: React.FC = () => {
 
   const loadStatus = async () => {
     try {
-      const baseUrl = await apiService.getBaseUrl();
-      const response = await fetch(`${baseUrl}/api/maintenance/status`, {
-        credentials: 'same-origin'
-      });
-
-      if (response.ok) {
-        const data: MaintenanceStatus = await response.json();
-        setStatus(data);
-        setEnabled(data.enabled);
-        setMaintenanceTime(data.maintenanceTime);
-        setMessageRetentionDays(data.settings.messageRetentionDays);
-        setTracerouteRetentionDays(data.settings.tracerouteRetentionDays);
-        setRouteSegmentRetentionDays(data.settings.routeSegmentRetentionDays);
-        setNeighborInfoRetentionDays(data.settings.neighborInfoRetentionDays);
-        // Update initial values to match loaded settings
-        initialValuesRef.current = {
-          enabled: data.enabled,
-          maintenanceTime: data.maintenanceTime,
-          messageRetentionDays: data.settings.messageRetentionDays,
-          tracerouteRetentionDays: data.settings.tracerouteRetentionDays,
-          routeSegmentRetentionDays: data.settings.routeSegmentRetentionDays,
-          neighborInfoRetentionDays: data.settings.neighborInfoRetentionDays
-        };
-      }
+      const data = await apiService.get<MaintenanceStatus>('/api/maintenance/status');
+      setStatus(data);
+      setEnabled(data.enabled);
+      setMaintenanceTime(data.maintenanceTime);
+      setMessageRetentionDays(data.settings.messageRetentionDays);
+      setTracerouteRetentionDays(data.settings.tracerouteRetentionDays);
+      setRouteSegmentRetentionDays(data.settings.routeSegmentRetentionDays);
+      setNeighborInfoRetentionDays(data.settings.neighborInfoRetentionDays);
+      // Update initial values to match loaded settings
+      initialValuesRef.current = {
+        enabled: data.enabled,
+        maintenanceTime: data.maintenanceTime,
+        messageRetentionDays: data.settings.messageRetentionDays,
+        tracerouteRetentionDays: data.settings.tracerouteRetentionDays,
+        routeSegmentRetentionDays: data.settings.routeSegmentRetentionDays,
+        neighborInfoRetentionDays: data.settings.neighborInfoRetentionDays
+      };
     } catch (error) {
+      // Preserve the prior silent-ignore on a non-ok HTTP response; only a
+      // genuine network/transport failure gets logged.
+      if (error instanceof ApiError) return;
       logger.error('Error loading maintenance status:', error);
     }
   };
 
   const loadDatabaseSize = async () => {
     try {
-      const baseUrl = await apiService.getBaseUrl();
-      const response = await fetch(`${baseUrl}/api/maintenance/size`, {
-        credentials: 'same-origin'
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setDatabaseSize(data.size);
-      }
+      const data = await apiService.get<{ size: number }>('/api/maintenance/size');
+      setDatabaseSize(data.size);
     } catch (error) {
+      // Preserve the prior silent-ignore on a non-ok HTTP response; only a
+      // genuine network/transport failure gets logged.
+      if (error instanceof ApiError) return;
       logger.error('Error loading database size:', error);
     }
   };
@@ -173,32 +165,14 @@ const DatabaseMaintenanceSection: React.FC = () => {
   const handleSaveSettings = async () => {
     try {
       setIsSaving(true);
-      const baseUrl = await apiService.getBaseUrl();
-
-      // Get CSRF token
-      const csrfToken = sessionStorage.getItem('csrfToken');
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (csrfToken) {
-        headers['X-CSRF-Token'] = csrfToken;
-      }
-
-      const response = await fetch(`${baseUrl}/api/settings`, {
-        method: 'POST',
-        headers,
-        credentials: 'same-origin',
-        body: JSON.stringify({
-          maintenanceEnabled: enabled ? 'true' : 'false',
-          maintenanceTime,
-          messageRetentionDays: String(messageRetentionDays),
-          tracerouteRetentionDays: String(tracerouteRetentionDays),
-          routeSegmentRetentionDays: String(routeSegmentRetentionDays),
-          neighborInfoRetentionDays: String(neighborInfoRetentionDays)
-        })
+      await apiService.post('/api/settings', {
+        maintenanceEnabled: enabled ? 'true' : 'false',
+        maintenanceTime,
+        messageRetentionDays: String(messageRetentionDays),
+        tracerouteRetentionDays: String(tracerouteRetentionDays),
+        routeSegmentRetentionDays: String(routeSegmentRetentionDays),
+        neighborInfoRetentionDays: String(neighborInfoRetentionDays)
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to save maintenance settings');
-      }
 
       // Update initial values to match saved settings
       initialValuesRef.current = {
@@ -237,27 +211,7 @@ const DatabaseMaintenanceSection: React.FC = () => {
       setIsRunning(true);
       showToast(t('maintenance.toast_running'), 'info');
 
-      const baseUrl = await apiService.getBaseUrl();
-
-      // Get CSRF token
-      const csrfToken = sessionStorage.getItem('csrfToken');
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (csrfToken) {
-        headers['X-CSRF-Token'] = csrfToken;
-      }
-
-      const response = await fetch(`${baseUrl}/api/maintenance/run`, {
-        method: 'POST',
-        headers,
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to run maintenance');
-      }
-
-      const result = await response.json();
+      const result = await apiService.post<{ stats: MaintenanceStats }>('/api/maintenance/run');
       const stats = result.stats;
       const totalDeleted = stats.messagesDeleted + stats.traceroutesDeleted +
                           stats.routeSegmentsDeleted + stats.neighborInfoDeleted;

--- a/src/components/configuration/SystemBackupSection.tsx
+++ b/src/components/configuration/SystemBackupSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { UiIcon } from '../icons';
-import apiService from '../../services/api';
+import apiService, { ApiError } from '../../services/api';
 import { useToast } from '../ToastContainer';
 import { logger } from '../../utils/logger';
 import { useSaveBar } from '../../hooks/useSaveBar';
@@ -66,27 +66,24 @@ const SystemBackupSection: React.FC = () => {
 
   const loadBackupSettings = async () => {
     try {
-      const baseUrl = await apiService.getBaseUrl();
-      const response = await fetch(`${baseUrl}/api/system/backup/settings`, {
-        credentials: 'same-origin'
-      });
-
-      if (response.ok) {
-        const settings = await response.json();
-        const enabled = settings.enabled || false;
-        const max = settings.maxBackups || 7;
-        const time = settings.backupTime || '03:00';
-        setAutoBackupEnabled(enabled);
-        setMaxBackups(max);
-        setBackupTime(time);
-        // Update initial values to match loaded settings
-        initialValuesRef.current = {
-          autoBackupEnabled: enabled,
-          maxBackups: max,
-          backupTime: time
-        };
-      }
+      const settings = await apiService.get<{ enabled?: boolean; maxBackups?: number; backupTime?: string }>('/api/system/backup/settings');
+      const enabled = settings.enabled || false;
+      const max = settings.maxBackups || 7;
+      const time = settings.backupTime || '03:00';
+      setAutoBackupEnabled(enabled);
+      setMaxBackups(max);
+      setBackupTime(time);
+      // Update initial values to match loaded settings
+      initialValuesRef.current = {
+        autoBackupEnabled: enabled,
+        maxBackups: max,
+        backupTime: time
+      };
     } catch (error) {
+      // Preserve the prior silent-ignore on a non-ok HTTP response; only a
+      // genuine network/transport failure gets logged (same split as the
+      // old `if (response.ok) {...}` with no else branch).
+      if (error instanceof ApiError) return;
       logger.error('Error loading system backup settings:', error);
     }
   };
@@ -94,29 +91,11 @@ const SystemBackupSection: React.FC = () => {
   const handleSaveBackupSettings = async () => {
     try {
       setIsSavingSettings(true);
-      const baseUrl = await apiService.getBaseUrl();
-
-      // Get CSRF token
-      const csrfToken = sessionStorage.getItem('csrfToken');
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (csrfToken) {
-        headers['X-CSRF-Token'] = csrfToken;
-      }
-
-      const response = await fetch(`${baseUrl}/api/system/backup/settings`, {
-        method: 'POST',
-        headers,
-        credentials: 'same-origin',
-        body: JSON.stringify({
-          enabled: autoBackupEnabled,
-          maxBackups,
-          backupTime
-        })
+      await apiService.post('/api/system/backup/settings', {
+        enabled: autoBackupEnabled,
+        maxBackups,
+        backupTime
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to save system backup settings');
-      }
 
       // Update initial values to match saved settings
       initialValuesRef.current = {
@@ -151,27 +130,7 @@ const SystemBackupSection: React.FC = () => {
       setIsCreatingBackup(true);
       showToast(t('system_backup.toast_creating'), 'info');
 
-      const baseUrl = await apiService.getBaseUrl();
-
-      // Get CSRF token
-      const csrfToken = sessionStorage.getItem('csrfToken');
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (csrfToken) {
-        headers['X-CSRF-Token'] = csrfToken;
-      }
-
-      const response = await fetch(`${baseUrl}/api/system/backup`, {
-        method: 'POST',
-        headers,
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.details || 'Failed to create system backup');
-      }
-
-      const result = await response.json();
+      const result = await apiService.post<{ dirname: string }>('/api/system/backup');
       showToast(t('system_backup.toast_backup_created', { dirname: result.dirname }), 'success');
 
       // Refresh backup list if modal is open
@@ -180,7 +139,14 @@ const SystemBackupSection: React.FC = () => {
       }
     } catch (error) {
       logger.error('Error creating system backup:', error);
-      showToast(t('system_backup.toast_backup_failed', { error: error instanceof Error ? error.message : 'Unknown error' }), 'error');
+      // The backend surfaces this failure's detail on `.details`, not the
+      // `.error` field ApiError.message already reads — preserve that
+      // preference exactly.
+      const errorBody = error instanceof ApiError ? error.body as { details?: unknown } | undefined : undefined;
+      const message = typeof errorBody?.details === 'string'
+        ? errorBody.details
+        : error instanceof Error ? error.message : 'Unknown error';
+      showToast(t('system_backup.toast_backup_failed', { error: message }), 'error');
     } finally {
       setIsCreatingBackup(false);
     }
@@ -189,17 +155,7 @@ const SystemBackupSection: React.FC = () => {
   const handleShowBackups = async () => {
     try {
       setIsLoadingBackups(true);
-      const baseUrl = await apiService.getBaseUrl();
-
-      const response = await fetch(`${baseUrl}/api/system/backup/list`, {
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to load system backup list');
-      }
-
-      const backups = await response.json();
+      const backups = await apiService.get<SystemBackupFile[]>('/api/system/backup/list');
       setBackupList(backups);
       setIsBackupModalOpen(true);
     } catch (error) {
@@ -213,25 +169,9 @@ const SystemBackupSection: React.FC = () => {
   const handleDownloadBackup = async (dirname: string) => {
     try {
       showToast(t('system_backup.toast_downloading'), 'info');
-      const baseUrl = await apiService.getBaseUrl();
-
-      const response = await fetch(`${baseUrl}/api/system/backup/download/${encodeURIComponent(dirname)}`, {
-        credentials: 'same-origin'
+      await apiService.download(`/api/system/backup/download/${encodeURIComponent(dirname)}`, {
+        filename: `${dirname}.tar.gz`,
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to download system backup');
-      }
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `${dirname}.tar.gz`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
 
       showToast(t('system_backup.toast_downloaded'), 'success');
     } catch (error) {
@@ -246,24 +186,7 @@ const SystemBackupSection: React.FC = () => {
     }
 
     try {
-      const baseUrl = await apiService.getBaseUrl();
-
-      // Get CSRF token
-      const csrfToken = sessionStorage.getItem('csrfToken');
-      const headers: Record<string, string> = {};
-      if (csrfToken) {
-        headers['X-CSRF-Token'] = csrfToken;
-      }
-
-      const response = await fetch(`${baseUrl}/api/system/backup/delete/${encodeURIComponent(dirname)}`, {
-        method: 'DELETE',
-        headers,
-        credentials: 'same-origin'
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to delete system backup');
-      }
+      await apiService.delete(`/api/system/backup/delete/${encodeURIComponent(dirname)}`);
 
       showToast(t('system_backup.toast_deleted'), 'success');
       // Refresh the backup list

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -12,7 +12,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { SettingsProvider, useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
-import { useCsrf } from '../contexts/CsrfContext';
 import { MapProvider, useMapContext } from '../contexts/MapContext';
 import {
   useDashboardSources,
@@ -32,7 +31,7 @@ import LoginModal from '../components/LoginModal';
 import UserMenu from '../components/UserMenu';
 import { NewsPopup } from '../components/NewsPopup';
 import { ToastProvider } from '../components/ToastContainer';
-import api from '../services/api';
+import api, { ApiError } from '../services/api';
 import { logger } from '../utils/logger';
 import { appBasename } from '../init';
 import { getReservedLandingPath, isReservedLandingValue } from '../utils/defaultLandingPage';
@@ -47,7 +46,6 @@ import { UiIcon } from '../components/icons';
 function DashboardInner() {
   const { t } = useTranslation();
   const { authStatus } = useAuth();
-  const { getToken } = useCsrf();
   const queryClient = useQueryClient();
   const { mapTileset, customTilesets, defaultMapCenterLat, defaultMapCenterLon, maxNodeAgeHours, defaultLandingPage } = useSettings();
   const navigate = useNavigate();
@@ -614,31 +612,25 @@ function DashboardInner() {
     setFormSaving(true);
     setFormError('');
     try {
-      const csrfToken = getToken();
       const body = {
         name: formName.trim(),
         type: formType,
         config: cfg,
         enabled: true,
       };
-      const url = editingSourceId
-        ? `${appBasename}/api/sources/${editingSourceId}`
-        : `${appBasename}/api/sources`;
-      const method = editingSourceId ? 'PUT' : 'POST';
 
-      const res = await fetch(url, {
-        method,
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-csrf-token': csrfToken || '',
-        },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        setFormError((err as any).error ?? t('source.form.error_save_failed'));
-        return;
+      try {
+        if (editingSourceId) {
+          await api.put(`/api/sources/${editingSourceId}`, body);
+        } else {
+          await api.post('/api/sources', body);
+        }
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setFormError((err.body as any)?.error ?? t('source.form.error_save_failed'));
+          return;
+        }
+        throw err;
       }
 
       // Broker save succeeded — now push per-bridge topic-rewrite
@@ -703,26 +695,18 @@ function DashboardInner() {
             delete bridgeConfig.upstream.password;
           }
           try {
-            const bres = await fetch(`${appBasename}/api/sources/${bridgeId}`, {
-              method: 'PUT',
-              credentials: 'include',
-              headers: {
-                'Content-Type': 'application/json',
-                'x-csrf-token': csrfToken || '',
-              },
-              body: JSON.stringify({
-                name: bridge.name,
-                type: 'mqtt_bridge',
-                config: bridgeConfig,
-                enabled: bridge.enabled,
-              }),
+            await api.put(`/api/sources/${bridgeId}`, {
+              name: bridge.name,
+              type: 'mqtt_bridge',
+              config: bridgeConfig,
+              enabled: bridge.enabled,
             });
-            if (!bres.ok) {
-              const err = await bres.json().catch(() => ({}));
-              bridgeErrors.push(`${bridge.name}: ${(err as any).error ?? 'save failed'}`);
-            }
           } catch (e) {
-            bridgeErrors.push(`${bridge.name}: ${(e as Error).message}`);
+            if (e instanceof ApiError) {
+              bridgeErrors.push(`${bridge.name}: ${(e.body as any)?.error ?? 'save failed'}`);
+            } else {
+              bridgeErrors.push(`${bridge.name}: ${(e as Error).message}`);
+            }
           }
         }
         if (bridgeErrors.length > 0) {
@@ -763,16 +747,12 @@ function DashboardInner() {
       return next;
     });
     try {
-      const csrfToken = getToken();
-      const res = await fetch(`${appBasename}/api/sources/${id}/connect`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-csrf-token': csrfToken || '',
-        },
-      });
-      if (!res.ok) return;
+      try {
+        await api.post(`/api/sources/${id}/connect`);
+      } catch (err) {
+        if (err instanceof ApiError) return;
+        throw err;
+      }
 
       refreshSources();
 
@@ -801,35 +781,26 @@ function DashboardInner() {
   // source. Exposed in the kebab menu when the source has autoConnect=false
   // and is currently connected.
   const onDisconnectSource = async (id: string) => {
-    const csrfToken = getToken();
-    const res = await fetch(`${appBasename}/api/sources/${id}/disconnect`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-csrf-token': csrfToken || '',
-      },
-    });
-    if (res.ok) {
-      refreshSources();
-      // Force an immediate status refetch so the "Connected" dot flips to
-      // "Idle" without waiting for the next 15s poll tick.
-      void queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
+    try {
+      await api.post(`/api/sources/${id}/disconnect`);
+    } catch (err) {
+      if (err instanceof ApiError) return;
+      throw err;
     }
+    refreshSources();
+    // Force an immediate status refetch so the "Connected" dot flips to
+    // "Idle" without waiting for the next 15s poll tick.
+    void queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
   };
 
   const onToggleSource = async (id: string, enabled: boolean) => {
-    const csrfToken = getToken();
-    const res = await fetch(`${appBasename}/api/sources/${id}`, {
-      method: 'PUT',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-csrf-token': csrfToken || '',
-      },
-      body: JSON.stringify({ enabled }),
-    });
-    if (res.ok) refreshSourcesDebounced();
+    try {
+      await api.put(`/api/sources/${id}`, { enabled });
+    } catch (err) {
+      if (err instanceof ApiError) return;
+      throw err;
+    }
+    refreshSourcesDebounced();
   };
 
   const onDeleteSource = (id: string) => {
@@ -850,38 +821,30 @@ function DashboardInner() {
       return [...reordered, ...trailing];
     });
 
-    const csrfToken = getToken();
-    const res = await fetch(`${appBasename}/api/sources/reorder`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-csrf-token': csrfToken || '',
-      },
-      body: JSON.stringify({ order: orderedIds }),
-    });
-    refreshSources();
-    if (!res.ok) {
-      logger.warn('Failed to reorder sources:', res.status);
+    try {
+      await api.post('/api/sources/reorder', { order: orderedIds });
+      refreshSources();
+    } catch (err) {
+      if (!(err instanceof ApiError)) throw err;
+      refreshSources();
+      logger.warn('Failed to reorder sources:', err.status);
     }
   };
 
   const confirmDelete = async () => {
     if (!deleteConfirm) return;
-    const csrfToken = getToken();
-    const res = await fetch(`${appBasename}/api/sources/${deleteConfirm}`, {
-      method: 'DELETE',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-csrf-token': csrfToken || '',
-      },
-    });
+    let ok = true;
+    try {
+      await api.delete(`/api/sources/${deleteConfirm}`);
+    } catch (err) {
+      if (!(err instanceof ApiError)) throw err;
+      ok = false;
+    }
     if (selectedSourceId === deleteConfirm) {
       setSelectedSourceId(null);
     }
     setDeleteConfirm(null);
-    if (res.ok) refreshSources();
+    if (ok) refreshSources();
   };
 
   const onPruneOutsideRoi = (id: string) => {
@@ -896,24 +859,20 @@ function DashboardInner() {
   // Cooldown / single-flight / watchdog all live on the server; the click
   // either succeeds (200) or is rejected (409) with state describing why.
   const onResyncSource = async (id: string) => {
-    const csrfToken = getToken();
     try {
-      const res = await fetch(`${appBasename}/api/sources/${id}/resync`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-csrf-token': csrfToken || '',
-        },
-      });
+      await api.post(`/api/sources/${id}/resync`);
       // Refresh source status either way — a successful resync changes the
       // connection state once configComplete arrives, and a rejected click
       // doesn't hurt to re-poll.
       void queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
-      if (!res.ok && res.status !== 409) {
-        logger.warn('Manual resync request failed', { status: res.status });
-      }
     } catch (err) {
+      if (err instanceof ApiError) {
+        void queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
+        if (err.status !== 409) {
+          logger.warn('Manual resync request failed', { status: err.status });
+        }
+        return;
+      }
       logger.error('Manual resync request errored', err);
     }
   };
@@ -923,23 +882,7 @@ function DashboardInner() {
     setPrunePending(true);
     setPruneError(null);
     try {
-      const csrfToken = getToken();
-      const res = await fetch(
-        `${appBasename}/api/sources/${pruneConfirm}/prune-outside-roi`,
-        {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-csrf-token': csrfToken || '',
-          },
-        },
-      );
-      const body = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        setPruneError(body.error || `HTTP ${res.status}`);
-        return;
-      }
+      const body = await api.post<{ count?: number }>(`/api/sources/${pruneConfirm}/prune-outside-roi`);
       setPruneResult({ sourceId: pruneConfirm, count: body.count ?? 0 });
       setPruneConfirm(null);
       refreshSources();

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -971,4 +971,176 @@ describe('ApiService BASE_URL Support', () => {
       expect((err as any).code).toBe('CSRF_TOKEN_INVALID');
     });
   });
+
+  describe('download() (#3962 Task 5.5 PR1)', () => {
+    let clickSpy: ReturnType<typeof vi.fn>;
+    let appendedAnchor: any;
+    let createObjectURLSpy: ReturnType<typeof vi.fn>;
+    let revokeObjectURLSpy: ReturnType<typeof vi.fn>;
+
+    const mockBlobResponse = (
+      ok: boolean,
+      opts: { status?: number; contentDisposition?: string | null; jsonBody?: any } = {}
+    ) => ({
+      ok,
+      status: opts.status ?? (ok ? 200 : 500),
+      headers: {
+        get: (name: string) => (name === 'Content-Disposition' ? opts.contentDisposition ?? null : null),
+      },
+      blob: async () => new Blob(['data']),
+      json: async () => opts.jsonBody ?? { error: 'Request failed' },
+    });
+
+    beforeEach(() => {
+      (apiService as any).baseUrl = '';
+      (apiService as any).configFetched = true;
+      (apiService as any).configPromise = null;
+      mockFetch.mockClear();
+      sessionStorage.clear();
+
+      clickSpy = vi.fn();
+      appendedAnchor = null;
+      createObjectURLSpy = vi.fn(() => 'blob:mock-url');
+      revokeObjectURLSpy = vi.fn();
+
+      (global as any).window.URL = {
+        createObjectURL: createObjectURLSpy,
+        revokeObjectURL: revokeObjectURLSpy,
+      };
+
+      (global as any).document = {
+        createElement: vi.fn(() => {
+          const anchor: any = { click: clickSpy };
+          appendedAnchor = anchor;
+          return anchor;
+        }),
+        body: {
+          appendChild: vi.fn(),
+          removeChild: vi.fn(),
+        },
+      };
+    });
+
+    afterEach(() => {
+      delete (global as any).document;
+      delete (global as any).window.URL;
+    });
+
+    it('downloads a blob and clicks a synthesized anchor using opts.filename', async () => {
+      mockFetch.mockResolvedValue(mockBlobResponse(true));
+
+      await apiService.download('/api/system/backup/download/foo', { filename: 'foo.tar.gz' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/system/backup/download/foo',
+        expect.objectContaining({ method: 'GET', credentials: 'include' })
+      );
+      expect(appendedAnchor.download).toBe('foo.tar.gz');
+      expect(appendedAnchor.href).toBe('blob:mock-url');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+    });
+
+    it('falls back to the Content-Disposition filename when opts.filename is absent', async () => {
+      mockFetch.mockResolvedValue(
+        mockBlobResponse(true, { contentDisposition: 'attachment; filename="server-name.json"' })
+      );
+
+      await apiService.download('/api/channels/1/export');
+
+      expect(appendedAnchor.download).toBe('server-name.json');
+    });
+
+    it('falls back to opts.defaultName when neither filename nor Content-Disposition is present', async () => {
+      mockFetch.mockResolvedValue(mockBlobResponse(true));
+
+      await apiService.download('/api/channels/1/export', { defaultName: 'default.json' });
+
+      expect(appendedAnchor.download).toBe('default.json');
+    });
+
+    it('throws ApiError on non-ok and never touches the DOM', async () => {
+      const { ApiError } = await import('./api');
+      mockFetch.mockResolvedValue(mockBlobResponse(false, { status: 404, jsonBody: { error: 'nope' } }));
+
+      const err = await apiService.download('/api/system/backup/download/foo').catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as Error).message).toBe('nope');
+      expect(clickSpy).not.toHaveBeenCalled();
+      expect(createObjectURLSpy).not.toHaveBeenCalled();
+    });
+
+    it('sends a CSRF header and JSON body for a mutating (POST) download', async () => {
+      sessionStorage.setItem('csrfToken', 'tok123');
+      mockFetch.mockResolvedValue(mockBlobResponse(true));
+
+      await apiService.download('/api/export', { method: 'POST', body: { foo: 'bar' }, filename: 'x.json' });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/export', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ foo: 'bar' }),
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'tok123' }),
+      }));
+    });
+
+    it('exportChannel delegates to download() with a channel-derived default filename', async () => {
+      mockFetch.mockResolvedValue(mockBlobResponse(true));
+
+      await apiService.exportChannel(42);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/channels/42/export',
+        expect.objectContaining({ method: 'GET', credentials: 'include' })
+      );
+      expect(appendedAnchor.download).toMatch(/^channel-42-\d+\.json$/);
+    });
+  });
+
+  describe('getText() (#3962 Task 5.5 PR1)', () => {
+    beforeEach(() => {
+      (apiService as any).baseUrl = '';
+      (apiService as any).configFetched = true;
+      (apiService as any).configPromise = null;
+      mockFetch.mockClear();
+    });
+
+    it('returns response text on success without calling json()', async () => {
+      const jsonSpy = vi.fn();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: { get: () => null },
+        text: async () => 'yaml: content',
+        json: jsonSpy,
+      });
+
+      const result = await apiService.getText('/api/backup/download/foo.yaml');
+
+      expect(result).toBe('yaml: content');
+      expect(jsonSpy).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/backup/download/foo.yaml',
+        expect.objectContaining({ credentials: 'include' })
+      );
+    });
+
+    it('throws ApiError on non-ok instead of calling text()', async () => {
+      const { ApiError } = await import('./api');
+      const textSpy = vi.fn();
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+        json: async () => ({ error: 'missing' }),
+        text: textSpy,
+      });
+
+      const err = await apiService.getText('/api/backup/download/missing.yaml').catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as Error).message).toBe('missing');
+      expect(textSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -458,28 +458,62 @@ class ApiService {
     return response.json();
   }
 
-  async exportChannel(channelId: number): Promise<void> {
+  /**
+   * Streams a response body to a browser download (blob + anchor click).
+   * Filename resolves from opts.filename, else the response's
+   * Content-Disposition header, else opts.defaultName, else a generic
+   * fallback. Throws ApiError on non-ok (same as request()) before ever
+   * touching the DOM. Mirrors request()'s CSRF/credentials handling for
+   * mutating downloads (opts.method other than GET).
+   */
+  async download(endpoint: string, opts?: {
+    method?: string; body?: unknown; filename?: string; defaultName?: string;
+  }): Promise<void> {
     await this.ensureBaseUrl();
-    const response = await fetch(`${this.baseUrl}/api/channels/${channelId}/export`, {
+
+    const method = opts?.method ?? 'GET';
+    const headers: Record<string, string> = {};
+
+    if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method.toUpperCase())) {
+      Object.assign(headers, this.getHeadersWithCsrf());
+    }
+
+    const options: RequestInit = {
+      method,
+      headers,
       credentials: 'include',
-    });
+    };
+
+    if (opts?.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      options.body = JSON.stringify(opts.body);
+    }
+
+    const response = await fetch(`${this.baseUrl}${endpoint}`, options);
 
     if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error || 'Failed to export channel');
+      const body = await response.json().catch(() => ({ error: 'Request failed' })) as {
+        error?: string;
+        code?: string;
+      };
+      const message = body.error || `Request failed with status ${response.status}`;
+      throw new ApiError(message, response.status, { code: body.code, body });
     }
 
-    // Get filename from Content-Disposition header or create default
-    const contentDisposition = response.headers.get('Content-Disposition');
-    let filename = `channel-${channelId}-${Date.now()}.json`;
-    if (contentDisposition) {
-      const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/);
-      if (filenameMatch) {
-        filename = filenameMatch[1];
+    let filename = opts?.filename;
+    if (!filename) {
+      const contentDisposition = response.headers.get('Content-Disposition');
+      if (contentDisposition) {
+        const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/);
+        if (filenameMatch) {
+          filename = filenameMatch[1];
+        }
       }
     }
+    if (!filename) {
+      filename = opts?.defaultName ?? `download-${Date.now()}`;
+    }
 
-    // Download the file
     const blob = await response.blob();
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -489,6 +523,37 @@ class ApiService {
     a.click();
     window.URL.revokeObjectURL(url);
     document.body.removeChild(a);
+  }
+
+  /**
+   * GET an endpoint that returns text/* (not JSON) — e.g. a YAML backup
+   * download whose caller already knows the filename. `request()` always
+   * calls response.json(), which would throw on a text body; this bypasses
+   * that. Throws ApiError on non-ok, same as request().
+   */
+  async getText(endpoint: string): Promise<string> {
+    await this.ensureBaseUrl();
+
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({ error: 'Request failed' })) as {
+        error?: string;
+        code?: string;
+      };
+      const message = body.error || `Request failed with status ${response.status}`;
+      throw new ApiError(message, response.status, { code: body.code, body });
+    }
+
+    return response.text();
+  }
+
+  async exportChannel(channelId: number): Promise<void> {
+    return this.download(`/api/channels/${channelId}/export`, {
+      defaultName: `channel-${channelId}-${Date.now()}.json`,
+    });
   }
 
   async importChannel(slotId: number, channelData: any, sourceId?: string | null): Promise<Channel> {


### PR DESCRIPTION
## Summary
PR1 of Task 5.5 (remediation epic #3962, Phase 5): ApiService gains typed `download()` (blob + Content-Disposition filename; the existing inline `exportChannel` blob logic refactored onto it) and `getText()` (non-JSON responses), then the four highest-count raw-`fetch()` files migrate — DashboardPage (9 sites), SystemBackupSection (6, incl. the tar.gz download), BackupManagementSection (6, incl. the YAML flows), DatabaseMaintenanceSection (5). 26 of 63 sites done; each site's error-handling behavior preserved exactly through the `res.ok` → `ApiError` conversion (silent-ignores stay silent, i18n fallbacks read `err.body.error`, network errors still propagate). Spec-authorized deltas: a few static error strings now show the server's error body instead.

The #3711 source-scoping tests were re-targeted from `global.fetch` spies to the ApiService boundary — same sourceId semantics, pinned at the real post-migration seam.

## Browser validation (dev container, deployed 965b4b6f)
- Dashboard renders all 4 sources with live status (migrated loaders) ✓
- Settings page: backup list modal loads via the migrated GET; maintenance status/size load ✓ — all through ApiService per the network log
- Console clean (known locales-fallback 404 only)

## Issues Resolved
Relates to #3962 (Phase 5.5, PR 1 of 2).

## Testing
- [x] Full Vitest suite: success=true, 10,344 passed, 0 failed, 0 failed suites
- [x] New api.test.ts coverage for download()/getText()
- [x] `tsc --noEmit` 0; `typecheck:tests` 304 = main parity; `lint:ci` green (baseline: 4 files' raw-fetch entries deleted, nothing grew)
- [ ] Reviewer: the error-mapping table in the PR's commit messages — confirm each site's catch semantics vs the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158hFzsVbodeJK246qAE1dY