### PR TITLE
feat(mqtt): apply auto-delete-by-distance inline at ingest (#3900)

### DIFF
--- a/src/components/MQTT/MqttPacketDetailModal.tsx
+++ b/src/components/MQTT/MqttPacketDetailModal.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 const BROADCAST_NODE_NUM = 0xffffffff;
 
-const ENCRYPTED_OUTCOME_BADGES = new Set(['encrypted', 'ignored', 'geo-ignored', 'unsupported-portnum', 'decode-error']);
+const ENCRYPTED_OUTCOME_BADGES = new Set(['encrypted', 'ignored', 'geo-ignored', 'distance', 'unsupported-portnum', 'decode-error']);
 
 function outcomeBadgeClass(outcome: string): string {
   switch (outcome) {
@@ -33,6 +33,8 @@ function outcomeBadgeClass(outcome: string): string {
       return 'mqpm-badge mqpm-badge-ignored';
     case 'geo-ignored':
       return 'mqpm-badge mqpm-badge-geo-ignored';
+    case 'distance':
+      return 'mqpm-badge mqpm-badge-distance';
     case 'unsupported-portnum':
     case 'decode-error':
       return 'mqpm-badge mqpm-badge-error';

--- a/src/components/MQTT/MqttPacketMonitor.css
+++ b/src/components/MQTT/MqttPacketMonitor.css
@@ -226,6 +226,11 @@
   background: color-mix(in srgb, var(--ctp-peach) 15%, transparent);
 }
 
+.mqpm-badge-distance {
+  color: var(--ctp-maroon);
+  background: color-mix(in srgb, var(--ctp-maroon) 15%, transparent);
+}
+
 .mqpm-badge-error {
   color: var(--ctp-red);
   background: color-mix(in srgb, var(--ctp-red) 15%, transparent);

--- a/src/components/MQTT/MqttPacketMonitorView.tsx
+++ b/src/components/MQTT/MqttPacketMonitorView.tsx
@@ -54,7 +54,7 @@ function formatTime(ts: number): string {
   return d.toLocaleTimeString([], { hour12: false }) + '.' + String(d.getMilliseconds()).padStart(3, '0');
 }
 
-const ENCRYPTED_OUTCOME_BADGES = new Set(['encrypted', 'ignored', 'geo-ignored', 'unsupported-portnum', 'decode-error']);
+const ENCRYPTED_OUTCOME_BADGES = new Set(['encrypted', 'ignored', 'geo-ignored', 'distance', 'unsupported-portnum', 'decode-error']);
 
 function outcomeBadgeClass(outcome: string): string {
   switch (outcome) {
@@ -64,6 +64,8 @@ function outcomeBadgeClass(outcome: string): string {
       return 'mqpm-badge mqpm-badge-ignored';
     case 'geo-ignored':
       return 'mqpm-badge mqpm-badge-geo-ignored';
+    case 'distance':
+      return 'mqpm-badge mqpm-badge-distance';
     case 'unsupported-portnum':
     case 'decode-error':
       return 'mqpm-badge mqpm-badge-error';

--- a/src/components/MQTT/mqttPacketTypes.ts
+++ b/src/components/MQTT/mqttPacketTypes.ts
@@ -15,6 +15,7 @@ export type MqttIngestOutcome =
   | 'encrypted'
   | 'ignored'
   | 'geo-ignored'
+  | 'distance'
   | 'unsupported-portnum'
   | 'decode-error';
 

--- a/src/db/repositories/mqttPacketLog.ts
+++ b/src/db/repositories/mqttPacketLog.ts
@@ -17,6 +17,7 @@ export type MqttIngestOutcome =
   | 'encrypted'
   | 'ignored'
   | 'geo-ignored'
+  | 'distance'
   | 'unsupported-portnum'
   | 'decode-error';
 

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -78,6 +78,13 @@ vi.mock('../services/database.js', () => ({
       isNodeIgnoredAsync: async (...a: unknown[]) => isNodeIgnoredAsync(...(a as [number, string])),
       getIgnoredNodesAsync: async (...a: unknown[]) => getIgnoredNodesAsync(...(a as [string | undefined])),
     },
+    // Inline auto-delete-by-distance (#3900) reads per-source settings on each
+    // POSITION packet. Return null so the feature reads as disabled and the
+    // inline check is a no-op for this suite.
+    settings: {
+      getSettingForSource: async () => null,
+    },
+    setNodeIgnoredAsync: vi.fn(async () => undefined),
   },
 }));
 

--- a/src/server/mqttBrokerManager.test.ts
+++ b/src/server/mqttBrokerManager.test.ts
@@ -32,6 +32,17 @@ vi.mock('../services/database.js', () => ({
       addIgnoredNodeAsync: async (...a: unknown[]) => addIgnoredNodeAsync(...(a as [number, string])),
       isIgnoredCached: (...a: unknown[]) => isIgnoredCached(...(a as [number, string])),
     },
+    // Inline auto-delete-by-distance (#3900) reads per-source settings on each
+    // POSITION packet. Return null so the feature reads as disabled and the
+    // inline check is a no-op for this suite.
+    settings: {
+      getSettingForSource: async () => null,
+    },
+    nodes: {
+      getNode: async () => null,
+    },
+    deleteNodeAsync: vi.fn(async () => undefined),
+    setNodeIgnoredAsync: vi.fn(async () => undefined),
   },
 }));
 

--- a/src/server/mqttIngestion.distanceInline.test.ts
+++ b/src/server/mqttIngestion.distanceInline.test.ts
@@ -130,6 +130,36 @@ describe('ingestServiceEnvelope — inline auto-delete-by-distance (#3900)', () 
     });
   });
 
+  it('ignores an out-of-range node end-to-end (action=ignore): populates ignored_nodes and gates later traffic', async () => {
+    await databaseService.settings.setSourceSetting(SRC, 'autoDeleteByDistanceAction', 'ignore');
+    autoDeleteByDistanceService.clearInlineConfigCache(SRC);
+
+    const NODE = 0x20000005;
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => FAR_POSITION);
+    const result = await ingestServiceEnvelope({ sourceId: SRC, envelope: posEnv(NODE) });
+
+    expect(result.reason).toBe('distance');
+    // The node is now recorded in ignored_nodes for this source...
+    await vi.waitFor(async () => {
+      expect(await databaseService.ignoredNodes.isNodeIgnoredAsync(NODE, SRC)).toBe(true);
+    });
+    // ...so a subsequent non-POSITION packet (e.g. TEXT) is dropped by the ignore gate.
+    (protobuf.processPayload as any).mockImplementationOnce(() => 'hi there');
+    const textEnv: ServiceEnvelopeShape = {
+      channelId: 'LongFast',
+      gatewayId: '!00000001',
+      packet: { id: 0x22222222, from: NODE, to: 0xffffffff, channel: 0, decoded: { portnum: 1 /* TEXT */, payload: new Uint8Array([0]) } },
+    };
+    const textResult = await ingestServiceEnvelope({ sourceId: SRC, envelope: textEnv });
+    expect(textResult.ingested).toBe(false);
+    expect(textResult.reason).toBe('ignored');
+
+    // Restore for any later cases / re-runs.
+    await databaseService.settings.setSourceSetting(SRC, 'autoDeleteByDistanceAction', 'delete');
+    autoDeleteByDistanceService.clearInlineConfigCache(SRC);
+  });
+
   it('does not drop when the feature is disabled for the source', async () => {
     await databaseService.settings.setSourceSetting(SRC, 'autoDeleteByDistanceEnabled', 'false');
     autoDeleteByDistanceService.clearInlineConfigCache(SRC);

--- a/src/server/mqttIngestion.distanceInline.test.ts
+++ b/src/server/mqttIngestion.distanceInline.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration tests for inline auto-delete-by-distance at MQTT ingest
+ * (issue #3900).
+ *
+ * When an MQTT source has auto-delete-by-distance enabled, a POSITION packet
+ * whose fix lands beyond the source's configured radius must be dropped as it
+ * arrives — the node never touches the nodeDB — rather than being cleaned up
+ * on the next periodic sweep. Follows the real-singleton-DB pattern of
+ * `mqttIngestion.perSource.test.ts` (only the protobuf decode is mocked) so
+ * the source-scoped settings + node writes are exercised for real.
+ *
+ * No geo `filter` is passed: the inline distance check is a separate, radial
+ * mechanism from the geo-bbox classifier, and a bbox filter would short-circuit
+ * an out-of-box POSITION before the distance check ever runs.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    processPayload: vi.fn((portnum: number, _payload: Uint8Array) => {
+      if (portnum === 3 /* POSITION_APP */) {
+        // Default fix: far from home (0,0). Individual tests override.
+        return { latitudeI: 437_000_000, longitudeI: -793_000_000 };
+      }
+      return null;
+    }),
+  },
+}));
+
+import { ingestServiceEnvelope } from './mqttIngestion.js';
+import { nodeNumToId, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
+import databaseService from '../services/database.js';
+import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceService.js';
+
+const SRC = 'dist-inline-src';
+
+// Home at (0,0), 100km radius. Far ≈ 43.7,-79.3 (~9000km); near ≈ 0.1,0.1 (~16km).
+const FAR_POSITION = { latitudeI: 437_000_000, longitudeI: -793_000_000 };
+const NEAR_POSITION = { latitudeI: 1_000_000, longitudeI: 1_000_000 };
+
+function posEnv(from: number, packetId = 0x12345678): ServiceEnvelopeShape {
+  return {
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: packetId,
+      from,
+      to: 0xffffffff,
+      channel: 0,
+      decoded: { portnum: 3 /* POSITION_APP */, payload: new Uint8Array([0]) },
+    },
+  };
+}
+
+describe('ingestServiceEnvelope — inline auto-delete-by-distance (#3900)', () => {
+  beforeAll(async () => {
+    await databaseService.waitForReady();
+    await databaseService.sources.deleteSource(SRC).catch(() => {});
+    await databaseService.sources.createSource({ id: SRC, name: 'Dist Src', type: 'mqtt_broker', config: {}, enabled: true });
+    await databaseService.settings.setSourceSettings(SRC, {
+      autoDeleteByDistanceEnabled: 'true',
+      autoDeleteByDistanceLat: '0',
+      autoDeleteByDistanceLon: '0',
+      autoDeleteByDistanceThresholdKm: '100',
+      autoDeleteByDistanceAction: 'delete',
+    });
+  });
+
+  afterAll(async () => {
+    await databaseService.sources.deleteSource(SRC).catch(() => {});
+  });
+
+  beforeEach(() => {
+    // Config is cached per-source for 60s; clear so each test's settings win.
+    autoDeleteByDistanceService.clearInlineConfigCache(SRC);
+  });
+
+  it('drops an out-of-range POSITION at ingest (reason=distance) and never creates the node', async () => {
+    const NODE = 0x20000001;
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => FAR_POSITION);
+
+    const result = await ingestServiceEnvelope({ sourceId: SRC, envelope: posEnv(NODE) });
+
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('distance');
+    // No node row should ever have been written.
+    expect(await databaseService.nodes.getNode(NODE, SRC)).toBeNull();
+  });
+
+  it('deletes an already-present node when its out-of-range POSITION arrives', async () => {
+    const NODE = 0x20000002;
+    const NODE_ID = nodeNumToId(NODE);
+    // Seed the node (as if a NodeInfo landed before the position).
+    await databaseService.upsertNodeAsync({
+      nodeNum: NODE,
+      nodeId: NODE_ID,
+      longName: 'Faraway',
+      shortName: 'FAR',
+      hwModel: 1,
+      lastHeard: Math.floor(Date.now() / 1000),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }, SRC);
+    expect(await databaseService.nodes.getNode(NODE, SRC)).not.toBeNull();
+
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => FAR_POSITION);
+    const result = await ingestServiceEnvelope({ sourceId: SRC, envelope: posEnv(NODE) });
+
+    expect(result.reason).toBe('distance');
+    await vi.waitFor(async () => {
+      expect(await databaseService.nodes.getNode(NODE, SRC)).toBeNull();
+    });
+  });
+
+  it('ingests an in-range POSITION normally', async () => {
+    const NODE = 0x20000003;
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => NEAR_POSITION);
+
+    const result = await ingestServiceEnvelope({ sourceId: SRC, envelope: posEnv(NODE) });
+
+    expect(result.ingested).toBe(true);
+    // upsert is fire-and-forget — poll for the row.
+    await vi.waitFor(async () => {
+      const node = await databaseService.nodes.getNode(NODE, SRC);
+      expect(node).not.toBeNull();
+      expect(node?.latitude).toBeCloseTo(0.1, 2);
+    });
+  });
+
+  it('does not drop when the feature is disabled for the source', async () => {
+    await databaseService.settings.setSourceSetting(SRC, 'autoDeleteByDistanceEnabled', 'false');
+    autoDeleteByDistanceService.clearInlineConfigCache(SRC);
+
+    const NODE = 0x20000004;
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => FAR_POSITION);
+    const result = await ingestServiceEnvelope({ sourceId: SRC, envelope: posEnv(NODE) });
+
+    expect(result.ingested).toBe(true);
+    await vi.waitFor(async () => {
+      expect(await databaseService.nodes.getNode(NODE, SRC)).not.toBeNull();
+    });
+
+    // Restore for any later cases / re-runs.
+    await databaseService.settings.setSourceSetting(SRC, 'autoDeleteByDistanceEnabled', 'true');
+  });
+});

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -58,6 +58,13 @@ vi.mock('../services/database.js', () => ({
       addGeoIgnoreAsync: vi.fn(async () => true),
       liftGeoIgnoreAsync: vi.fn(async () => true),
     },
+    // Inline auto-delete-by-distance (#3900) reads per-source settings on each
+    // POSITION packet. Return null so the feature reads as disabled and the
+    // inline check is a no-op for this suite's wiring/branching assertions.
+    settings: {
+      getSettingForSource: vi.fn(async () => null),
+    },
+    setNodeIgnoredAsync: vi.fn(async () => undefined),
   },
 }));
 

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -14,6 +14,7 @@
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import { channelDecryptionService } from './services/channelDecryptionService.js';
 import mqttPacketLogService from './services/mqttPacketLogService.js';
+import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceService.js';
 import databaseService from '../services/database.js';
 
 /**
@@ -146,7 +147,7 @@ export interface MqttIngestionInput {
 
 export interface MqttIngestionResult {
   ingested: boolean;
-  reason?: 'no-packet' | 'no-decoded' | 'encrypted' | 'unsupported-portnum' | 'ignored' | 'geo-ignored' | 'decode-error';
+  reason?: 'no-packet' | 'no-decoded' | 'encrypted' | 'unsupported-portnum' | 'ignored' | 'geo-ignored' | 'distance' | 'decode-error';
   portnum?: number;
 }
 
@@ -370,6 +371,19 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
       if (positionIsBogus) {
         logger.debug(`MQTT: dropping bogus position (${lat}, ${lng}) precisionBits=${precisionBits} from ${fromNodeId}`);
       }
+
+      // Inline auto-delete-by-distance (#3900): when this MQTT source has the
+      // feature enabled, evaluate the fix as it arrives so a node beyond the
+      // configured radius never touches the nodeDB / map — rather than waiting
+      // for the next periodic sweep. Only on a trustworthy (non-bogus) fix; a
+      // bogus position is not a reliable basis for a distance decision.
+      if (!positionIsBogus && lat != null && lng != null) {
+        const outcome = await autoDeleteByDistanceService.applyInlineDistanceCheck(sourceId, fromNum, lat, lng);
+        if (outcome !== 'kept') {
+          return { ingested: false, reason: 'distance', portnum };
+        }
+      }
+
       const node: Partial<DbNode> = {
         nodeNum: fromNum,
         nodeId: fromNodeId,
@@ -574,7 +588,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
   const result = await ingestServiceEnvelopeInner(input);
   void mqttPacketLogService.logEnvelope(input.sourceId, input.envelope, result);
   if (
-    (result.reason === 'ignored' || result.reason === 'geo-ignored') &&
+    (result.reason === 'ignored' || result.reason === 'geo-ignored' || result.reason === 'distance') &&
     typeof input.envelope.packet?.from === 'number'
   ) {
     const fromNum = input.envelope.packet.from >>> 0;

--- a/src/server/services/autoDeleteByDistanceService.inline.test.ts
+++ b/src/server/services/autoDeleteByDistanceService.inline.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the inline (per-packet) distance check on
+ * autoDeleteByDistanceService (issue #3900).
+ *
+ * `applyInlineDistanceCheck` is called synchronously from MQTT ingestion as
+ * each POSITION packet arrives, so a node beyond the source's configured radius
+ * never touches the nodeDB — instead of being cleaned up on the next periodic
+ * cycle. It mirrors runDeleteCycle's protections (local node, favorites) and
+ * caches per-source config to avoid a settings query per packet.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getSettingForSource = vi.fn();
+const getNode = vi.fn();
+const deleteNodeAsync = vi.fn();
+const setNodeIgnoredAsync = vi.fn();
+const isIgnoredCached = vi.fn();
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    settings: { getSettingForSource: (...a: unknown[]) => getSettingForSource(...a) },
+    nodes: { getNode: (...a: unknown[]) => getNode(...a) },
+    ignoredNodes: { isIgnoredCached: (...a: unknown[]) => isIgnoredCached(...a) },
+    deleteNodeAsync: (...a: unknown[]) => deleteNodeAsync(...a),
+    setNodeIgnoredAsync: (...a: unknown[]) => setNodeIgnoredAsync(...a),
+  },
+}));
+
+vi.mock('../utils/resolveSourceManager.js', () => ({
+  resolveSourceManager: () => ({ sendIgnoredNode: vi.fn() }),
+}));
+
+vi.mock('../utils/nodeEnhancer.js', () => ({
+  getEffectiveDbNodePosition: (n: { latitude?: number | null; longitude?: number | null }) => ({
+    latitude: n.latitude ?? null,
+    longitude: n.longitude ?? null,
+  }),
+}));
+
+import { autoDeleteByDistanceService } from './autoDeleteByDistanceService.js';
+
+// A source configured with home (0,0), 100km threshold. Far coordinates
+// (~10,10 ≈ 1560km) are well beyond; near coordinates (~0.1,0.1 ≈ 15km) are in.
+const FAR_LAT = 10;
+const FAR_LON = 10;
+const NEAR_LAT = 0.1;
+const NEAR_LON = 0.1;
+
+function mockSettings(overrides: Record<string, string | null> = {}): void {
+  const base: Record<string, string | null> = {
+    autoDeleteByDistanceEnabled: 'true',
+    autoDeleteByDistanceLat: '0',
+    autoDeleteByDistanceLon: '0',
+    autoDeleteByDistanceThresholdKm: '100',
+    autoDeleteByDistanceAction: 'delete',
+    localNodeNum: null,
+    ...overrides,
+  };
+  getSettingForSource.mockImplementation((_sourceId: string, key: string) =>
+    Promise.resolve(key in base ? base[key] : null),
+  );
+}
+
+describe('autoDeleteByDistanceService.applyInlineDistanceCheck (#3900)', () => {
+  beforeEach(() => {
+    getSettingForSource.mockReset();
+    getNode.mockReset().mockResolvedValue(null);
+    deleteNodeAsync.mockReset().mockResolvedValue(undefined);
+    setNodeIgnoredAsync.mockReset().mockResolvedValue(undefined);
+    isIgnoredCached.mockReset().mockReturnValue(false);
+    // Config is cached per-source; clear between cases so each mockSettings takes.
+    autoDeleteByDistanceService.clearInlineConfigCache();
+  });
+
+  it("returns 'kept' when the feature is disabled for the source", async () => {
+    mockSettings({ autoDeleteByDistanceEnabled: 'false' });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 1, FAR_LAT, FAR_LON);
+    expect(out).toBe('kept');
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns 'kept' when no home coordinates are configured", async () => {
+    mockSettings({ autoDeleteByDistanceLat: null, autoDeleteByDistanceLon: null });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 1, FAR_LAT, FAR_LON);
+    expect(out).toBe('kept');
+  });
+
+  it("returns 'kept' for a node within the threshold", async () => {
+    mockSettings();
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 1, NEAR_LAT, NEAR_LON);
+    expect(out).toBe('kept');
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+    // A within-range node must not incur a getNode lookup.
+    expect(getNode).not.toHaveBeenCalled();
+  });
+
+  it("deletes an existing node beyond the threshold (action=delete)", async () => {
+    mockSettings();
+    getNode.mockResolvedValue({ nodeNum: 1, isFavorite: false });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 1, FAR_LAT, FAR_LON);
+    expect(out).toBe('deleted');
+    expect(deleteNodeAsync).toHaveBeenCalledWith(1, 'A');
+  });
+
+  it("returns 'deleted' without a delete call when the node isn't in the DB yet", async () => {
+    mockSettings();
+    getNode.mockResolvedValue(null);
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 2, FAR_LAT, FAR_LON);
+    expect(out).toBe('deleted');
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it("ignores a node beyond the threshold (action=ignore)", async () => {
+    mockSettings({ autoDeleteByDistanceAction: 'ignore' });
+    getNode.mockResolvedValue({ nodeNum: 3, isFavorite: false, isIgnored: false });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 3, FAR_LAT, FAR_LON);
+    expect(out).toBe('ignored');
+    expect(setNodeIgnoredAsync).toHaveBeenCalledWith(3, true, 'A');
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it("skips the ignore write when the node is already ignored", async () => {
+    mockSettings({ autoDeleteByDistanceAction: 'ignore' });
+    getNode.mockResolvedValue({ nodeNum: 3, isFavorite: false, isIgnored: true });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 3, FAR_LAT, FAR_LON);
+    expect(out).toBe('ignored');
+    expect(setNodeIgnoredAsync).not.toHaveBeenCalled();
+  });
+
+  it("never touches a favorited node beyond the threshold", async () => {
+    mockSettings();
+    getNode.mockResolvedValue({ nodeNum: 4, isFavorite: true });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 4, FAR_LAT, FAR_LON);
+    expect(out).toBe('kept');
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it("protects the local node even when it is beyond the threshold", async () => {
+    mockSettings({ localNodeNum: '5' });
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 5, FAR_LAT, FAR_LON);
+    expect(out).toBe('kept');
+    expect(getNode).not.toHaveBeenCalled();
+    expect(deleteNodeAsync).not.toHaveBeenCalled();
+  });
+
+  it("caches config per source — a second call does not re-read settings", async () => {
+    mockSettings();
+    getNode.mockResolvedValue(null);
+    await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 1, FAR_LAT, FAR_LON);
+    const callsAfterFirst = getSettingForSource.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+    await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 2, FAR_LAT, FAR_LON);
+    // No additional settings reads on the cached second call.
+    expect(getSettingForSource.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("re-reads settings after clearInlineConfigCache", async () => {
+    mockSettings();
+    getNode.mockResolvedValue(null);
+    await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 1, FAR_LAT, FAR_LON);
+    const callsAfterFirst = getSettingForSource.mock.calls.length;
+    autoDeleteByDistanceService.clearInlineConfigCache('A');
+    await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 2, FAR_LAT, FAR_LON);
+    expect(getSettingForSource.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it("skips ingest ('deleted') even when the delete throws", async () => {
+    mockSettings();
+    getNode.mockResolvedValue({ nodeNum: 6, isFavorite: false });
+    deleteNodeAsync.mockRejectedValue(new Error('db down'));
+    const out = await autoDeleteByDistanceService.applyInlineDistanceCheck('A', 6, FAR_LAT, FAR_LON);
+    expect(out).toBe('deleted');
+  });
+});

--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -15,6 +15,23 @@ interface ProcessedNodeInfo {
 }
 
 /**
+ * Resolved per-source config for the inline (per-packet) distance check
+ * (issue #3900). Cached briefly so a busy MQTT broker doesn't issue a handful
+ * of settings queries for every position packet — see {@link AutoDeleteByDistanceService.getInlineConfig}.
+ */
+interface InlineDistanceConfig {
+  enabled: boolean;
+  homeLat: number;
+  homeLon: number;
+  thresholdKm: number;
+  action: DistanceAction;
+  localNodeNum: number | null;
+}
+
+/** Outcome of {@link AutoDeleteByDistanceService.applyInlineDistanceCheck}. */
+export type InlineDistanceOutcome = 'kept' | 'deleted' | 'ignored';
+
+/**
  * Core auto-delete-by-distance logic (issue #3901).
  *
  * This service holds NO scheduling state — the periodic timers live on the
@@ -29,6 +46,119 @@ class AutoDeleteByDistanceService {
   // source already has one in flight, so concurrent per-source schedulers
   // don't spuriously block each other (a global boolean used to).
   private readonly runningSources = new Set<string>();
+
+  // Short-TTL per-source cache of the resolved inline-check config (#3900).
+  // Keyed by sourceId. Invalidated on TTL expiry and eagerly whenever a
+  // source's DistanceDeleteScheduler (re)starts on a settings change.
+  private readonly inlineConfigCache = new Map<string, { cfg: InlineDistanceConfig; expiresAt: number }>();
+  private readonly INLINE_CONFIG_TTL_MS = 60_000;
+
+  /**
+   * Drop the cached inline config for a source (or all sources when omitted),
+   * so the next {@link applyInlineDistanceCheck} re-reads settings. Called by
+   * {@link DistanceDeleteScheduler} on start/stop — i.e. whenever the source's
+   * auto-delete-by-distance settings change.
+   */
+  public clearInlineConfigCache(sourceId?: string): void {
+    if (sourceId) {
+      this.inlineConfigCache.delete(sourceId);
+    } else {
+      this.inlineConfigCache.clear();
+    }
+  }
+
+  /**
+   * Read (and briefly cache) the per-source inline-check config. The feature is
+   * only considered `enabled` when the source has it toggled on AND has valid
+   * home coordinates — mirroring the guard in {@link runDeleteCycle}.
+   */
+  private async getInlineConfig(sourceId: string): Promise<InlineDistanceConfig> {
+    const now = Date.now();
+    const cached = this.inlineConfigCache.get(sourceId);
+    if (cached && cached.expiresAt > now) {
+      return cached.cfg;
+    }
+
+    const s = databaseService.settings;
+    const enabledStr = await s.getSettingForSource(sourceId, 'autoDeleteByDistanceEnabled');
+    const homeLat = parseFloat((await s.getSettingForSource(sourceId, 'autoDeleteByDistanceLat')) || '');
+    const homeLon = parseFloat((await s.getSettingForSource(sourceId, 'autoDeleteByDistanceLon')) || '');
+    const thresholdRaw = parseFloat((await s.getSettingForSource(sourceId, 'autoDeleteByDistanceThresholdKm')) || '100');
+    const actionRaw = (await s.getSettingForSource(sourceId, 'autoDeleteByDistanceAction')) || 'delete';
+    const localNodeNumStr = await s.getSettingForSource(sourceId, 'localNodeNum');
+
+    const cfg: InlineDistanceConfig = {
+      enabled: enabledStr === 'true' && !isNaN(homeLat) && !isNaN(homeLon),
+      homeLat,
+      homeLon,
+      thresholdKm: isNaN(thresholdRaw) ? 100 : thresholdRaw,
+      action: actionRaw === 'ignore' ? 'ignore' : 'delete',
+      localNodeNum: localNodeNumStr ? Number(localNodeNumStr) : null,
+    };
+    this.inlineConfigCache.set(sourceId, { cfg, expiresAt: now + this.INLINE_CONFIG_TTL_MS });
+    return cfg;
+  }
+
+  /**
+   * Inline (per-packet) distance check for a single node position (issue #3900).
+   *
+   * Called synchronously from MQTT ingestion as each POSITION packet arrives so
+   * a node beyond the source's configured radius never touches the nodeDB / map
+   * even momentarily — instead of being cleaned up on the next periodic
+   * {@link runDeleteCycle}. Returns:
+   *   - `'kept'`    → feature off, within range, or protected → caller ingests
+   *   - `'deleted'` → beyond range, action=delete → any existing row is removed;
+   *                   caller must NOT upsert
+   *   - `'ignored'` → beyond range, action=ignore → node marked ignored (so the
+   *                   MQTT ignore gate drops its later traffic); caller skips upsert
+   *
+   * Protections mirror {@link runDeleteCycle}: the local node and favorited nodes
+   * are never touched. `lat`/`lon` must be a trustworthy fix (callers gate on
+   * their bogus-position check first).
+   */
+  public async applyInlineDistanceCheck(
+    sourceId: string,
+    nodeNum: number,
+    lat: number,
+    lon: number,
+  ): Promise<InlineDistanceOutcome> {
+    const cfg = await this.getInlineConfig(sourceId);
+    if (!cfg.enabled) return 'kept';
+
+    // Protect the local node.
+    if (cfg.localNodeNum != null && Number(nodeNum) === cfg.localNodeNum) return 'kept';
+
+    const distance = calculateDistance(cfg.homeLat, cfg.homeLon, lat, lon);
+    if (distance <= cfg.thresholdKm) return 'kept';
+
+    // Beyond threshold — but never touch a favorite (parity with runDeleteCycle).
+    const existing = await databaseService.nodes.getNode(nodeNum, sourceId);
+    if (existing?.isFavorite) return 'kept';
+
+    try {
+      if (cfg.action === 'ignore') {
+        // Skip the write if it's already ignored (either mechanism) — the
+        // ignore gate will keep dropping its traffic regardless.
+        if (!existing?.isIgnored && !databaseService.ignoredNodes.isIgnoredCached(nodeNum, sourceId)) {
+          await databaseService.setNodeIgnoredAsync(nodeNum, true, sourceId);
+        }
+        return 'ignored';
+      }
+      // action === 'delete'
+      if (existing) {
+        await databaseService.deleteNodeAsync(nodeNum, sourceId);
+      }
+      return 'deleted';
+    } catch (error) {
+      logger.error(
+        `❌ Auto-delete-by-distance (inline): failed to ${cfg.action} node ${nodeNum}@${sourceId}:`,
+        error,
+      );
+      // The node is beyond range either way — tell the caller to skip ingest so
+      // a transient DB error can't let an out-of-range node persist.
+      return cfg.action === 'ignore' ? 'ignored' : 'deleted';
+    }
+  }
 
   /**
    * Run now (manual trigger from API)

--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -80,12 +80,21 @@ class AutoDeleteByDistanceService {
     }
 
     const s = databaseService.settings;
-    const enabledStr = await s.getSettingForSource(sourceId, 'autoDeleteByDistanceEnabled');
-    const homeLat = parseFloat((await s.getSettingForSource(sourceId, 'autoDeleteByDistanceLat')) || '');
-    const homeLon = parseFloat((await s.getSettingForSource(sourceId, 'autoDeleteByDistanceLon')) || '');
-    const thresholdRaw = parseFloat((await s.getSettingForSource(sourceId, 'autoDeleteByDistanceThresholdKm')) || '100');
-    const actionRaw = (await s.getSettingForSource(sourceId, 'autoDeleteByDistanceAction')) || 'delete';
-    const localNodeNumStr = await s.getSettingForSource(sourceId, 'localNodeNum');
+    // These six reads are independent — fetch them in parallel so a cache miss
+    // (once per 60s per busy source) doesn't add six serial round-trips to the
+    // ingest hot path (matters most on PostgreSQL/MySQL).
+    const [enabledStr, latStr, lonStr, thresholdStr, actionStr, localNodeNumStr] = await Promise.all([
+      s.getSettingForSource(sourceId, 'autoDeleteByDistanceEnabled'),
+      s.getSettingForSource(sourceId, 'autoDeleteByDistanceLat'),
+      s.getSettingForSource(sourceId, 'autoDeleteByDistanceLon'),
+      s.getSettingForSource(sourceId, 'autoDeleteByDistanceThresholdKm'),
+      s.getSettingForSource(sourceId, 'autoDeleteByDistanceAction'),
+      s.getSettingForSource(sourceId, 'localNodeNum'),
+    ]);
+    const homeLat = parseFloat(latStr || '');
+    const homeLon = parseFloat(lonStr || '');
+    const thresholdRaw = parseFloat(thresholdStr || '100');
+    const actionRaw = actionStr || 'delete';
 
     const cfg: InlineDistanceConfig = {
       enabled: enabledStr === 'true' && !isNaN(homeLat) && !isNaN(homeLon),
@@ -126,7 +135,7 @@ class AutoDeleteByDistanceService {
     if (!cfg.enabled) return 'kept';
 
     // Protect the local node.
-    if (cfg.localNodeNum != null && Number(nodeNum) === cfg.localNodeNum) return 'kept';
+    if (cfg.localNodeNum != null && nodeNum === cfg.localNodeNum) return 'kept';
 
     const distance = calculateDistance(cfg.homeLat, cfg.homeLon, lat, lon);
     if (distance <= cfg.thresholdKm) return 'kept';

--- a/src/server/services/distanceDeleteScheduler.ts
+++ b/src/server/services/distanceDeleteScheduler.ts
@@ -27,6 +27,11 @@ export class DistanceDeleteScheduler {
   async start(): Promise<void> {
     this.stop();
 
+    // Settings just changed (this is called on save) — drop the inline check's
+    // cached config for this source so per-packet decisions pick up the new
+    // home/threshold/action immediately rather than after the TTL (#3900).
+    autoDeleteByDistanceService.clearInlineConfigCache(this.sourceId);
+
     const enabled = await databaseService.settings.getSettingForSource(
       this.sourceId,
       'autoDeleteByDistanceEnabled',

--- a/src/server/services/distanceDeleteScheduler.ts
+++ b/src/server/services/distanceDeleteScheduler.ts
@@ -66,6 +66,13 @@ export class DistanceDeleteScheduler {
 
   /** Stop the scheduler (does not abort an in-progress delete cycle). */
   stop(): void {
+    // Drop the inline check's cached config too (#3900). start() clears it, and
+    // a settings save always goes through start(), but stop() can be called on
+    // its own (e.g. source shutdown, or disabling the feature). Without this the
+    // 60s-TTL cache could keep dropping out-of-range POSITIONs as "enabled" for
+    // up to a minute after the feature was turned off.
+    autoDeleteByDistanceService.clearInlineConfigCache(this.sourceId);
+
     if (this.initialTimeout) {
       clearTimeout(this.initialTimeout);
       this.initialTimeout = null;

--- a/src/server/services/mqttPacketLogService.ts
+++ b/src/server/services/mqttPacketLogService.ts
@@ -164,6 +164,8 @@ function mapOutcome(result: MqttIngestionResult): MqttIngestOutcome {
       return 'ignored';
     case 'geo-ignored':
       return 'geo-ignored';
+    case 'distance':
+      return 'distance';
     case 'unsupported-portnum':
       return 'unsupported-portnum';
     case 'decode-error':


### PR DESCRIPTION
## Summary

Closes #3900.

Auto-delete-by-distance previously ran only on a periodic timer, so a node beyond a source's configured radius could land in the nodeDB and appear on the map until the next sweep. For **MQTT broker/bridge sources**, this now evaluates the fix **inline as each `POSITION_APP` packet arrives**, so an out-of-range node never touches the nodeDB even momentarily — exactly the behavior NullVoid requested in the origin report.

## What changed

- **`autoDeleteByDistanceService.applyInlineDistanceCheck(sourceId, nodeNum, lat, lon)`** → `'kept' | 'deleted' | 'ignored'`. Reuses the same enabled / home-coord / threshold / action settings and the same **local-node + favorite protections** as the periodic `runDeleteCycle`.
  - `action=delete`: removes any existing row and tells the caller to skip the upsert.
  - `action=ignore`: marks the node ignored via `setNodeIgnoredAsync` (writes the `ignored_nodes` table the MQTT ingest gate reads), so subsequent traffic is dropped too.
  - Config is read through a **60s per-source cache** so a busy broker doesn't issue a handful of settings queries per position packet. The cache is invalidated whenever `DistanceDeleteScheduler.start()` runs — which already fires on every settings save — so config changes take effect immediately.
- **`mqttIngestion.ts`**: the check runs in the `POSITION_APP` case only on a trustworthy (non-bogus) fix, before the node upsert. New `'distance'` ingest reason, surfaced in the existing noise-suppressed per-node drop logging.
- **MQTT Packet Monitor observability**: added `'distance'` to `MqttIngestOutcome` (server + frontend type decls), `mapOutcome`, both badge renderers, and a CSS badge (maroon), so distance drops are visible and distinct from geo-ignored. No migration needed — `ingestOutcome` is an unconstrained text column.

Only the MQTT ingest path is affected; the periodic scheduler continues to cover all source types. TCP/MeshCore paths are untouched.

## Testing

- `autoDeleteByDistanceService.inline.test.ts` — 12 unit tests (delete/ignore/kept, favorite + local-node protection, disabled, threshold boundary, per-source cache hit + invalidation, delete-throws fail-closed).
- `mqttIngestion.distanceInline.test.ts` — 4 real-singleton-DB integration tests (out-of-range drop with no node row created, delete of an already-present node, in-range ingest, disabled = ingest).
- Updated the wholesale DB mock in `mqttIngestion.test.ts` to stub the new per-source settings read.
- `tsc --noEmit` clean; `lint:ci` clean; all touched suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158hFzsVbodeJK246qAE1dY