### PR TITLE
feat(server): honor lora.txEnabled with central TX-disabled guard (#4294)

### DIFF
--- a/docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md
@@ -1,0 +1,392 @@
+# TX-Disabled Support — Phase 1 Implementation Spec (Backend)
+
+**Epic:** #4294 — TX-disabled (receive-only) support
+**Phase:** 1 of 3 — Backend: honor `lora.txEnabled` + central transmit guard
+**Branch:** `feature/tx-disabled-backend` (off `origin/main`)
+**Companion doc:** `docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md` (inventory + decisions)
+**Scope:** backend only. All UI/i18n gating is Phase 2 — see "Out of scope" at the end.
+
+All line numbers below were validated against this worktree on 2026-07-23. They will drift as
+edits land; treat them as anchors, re-grep the named symbol before editing.
+
+---
+
+## 1. Problem & goal
+
+Today the backend force-overwrites `lora.txEnabled` to `true` on every LoRa-config write and on
+every import/export path, so a user can never legitimately run a Meshtastic source in receive-only
+mode. Saving an unrelated LoRa field (e.g. hop limit) silently flips TX back on — the reported bug
+(#4294: a ROUTER_LATE listen-only MQTT relay whose TX-off config MeshMonitor reverts).
+
+Phase 1:
+1. Stop forcing `txEnabled: true`; pass through / preserve the device's value.
+2. Add one typed `TxDisabledError` guard at the transmit primitives so every OTA send path — routes,
+   schedulers, automation, v1 API — fails cleanly and consistently when TX is disabled.
+3. Local-node admin over TCP stays fully functional (it's how the user re-enables TX).
+
+### Firmware semantics (already verified in the epic doc)
+`tx_enabled=false` is a hard radio kill switch: every outbound LoRa packet is dropped at the radio.
+RX, decode, TCP API (config read/write, **local** node admin, channel reads) keep working.
+Remote-node sends (messages, traceroute, requests, remote admin) and the node's own
+NodeInfo/Position/Telemetry broadcasts silently die.
+
+---
+
+## 2. How the manager knows TX state (state model)
+
+`MeshtasticManager` already holds the device config in memory:
+
+- `private actualDeviceConfig: any = null;` — `meshtasticManager.ts:783`. Merged from TCP config
+  frames at `meshtasticManager.ts:4266` (`this.actualDeviceConfig = { ...this.actualDeviceConfig, ...parsed.data }`).
+  Config updates arrive over TCP on change, so this field is fresh without any DB hit.
+- The existing `GET /api/device/tx-status` route (`deviceStatusRoutes.ts:9`) already derives TX
+  state as `deviceConfig?.lora?.txEnabled !== false` (default-true when unknown).
+
+**Add a cheap synchronous accessor** — the single source of truth for the guard and the pre-checks:
+
+```ts
+// meshtasticManager.ts — public method, place near getDeviceConfig() (~8756)
+/**
+ * Current transmit state for THIS source, read from the in-memory device config.
+ * Defaults to true when config hasn't arrived yet (fail-open: don't block sends
+ * before we know the radio's state). No DB access — safe to call per packet.
+ */
+isTxEnabled(): boolean {
+  return this.actualDeviceConfig?.lora?.txEnabled !== false;
+}
+```
+
+Rationale for default-true: matches the existing `tx-status` route semantics exactly, and avoids
+blocking legitimate sends during the brief window before the first config frame is decoded.
+
+### Once-per-state-change logging (no per-tick spam)
+Do the state-transition log at the **config-merge point**, not in each tick. In the handler around
+`meshtasticManager.ts:4266`, capture `txEnabled` before and after the merge; when it flips, log once
+at `info`:
+
+```ts
+const prevTx = this.actualDeviceConfig?.lora?.txEnabled !== false;
+this.actualDeviceConfig = { ...this.actualDeviceConfig, ...parsed.data };
+const nextTx = this.actualDeviceConfig?.lora?.txEnabled !== false;
+if (prevTx !== nextTx) {
+  logger.info(nextTx
+    ? `📡 [${this.sourceId}] TX re-enabled — autonomous senders resume`
+    : `🚫 [${this.sourceId}] TX disabled — pausing autonomous senders (node is now receive-only)`);
+}
+```
+
+Individual scheduler/event pre-checks then just return early at `debug` level, so re-enable needs no
+restart and the log stays quiet.
+
+---
+
+## 3. Typed error
+
+There is **no** central server error module today; the only precedent is `SsrfBlockedError`
+(`src/server/utils/ssrfGuard.ts:124`). Its tests re-declare the class via `vi.hoisted` because
+`instanceof` across mocked module boundaries is unreliable. Avoid that trap by making the guard
+identity **property-branded**, not `instanceof`-based.
+
+**New file: `src/server/errors/txDisabledError.ts`**
+
+```ts
+export const TX_DISABLED_CODE = 'TX_DISABLED' as const;
+
+export class TxDisabledError extends Error {
+  /** Brand for cross-module-safe detection (see isTxDisabledError). */
+  readonly isTxDisabledError = true as const;
+  readonly code = TX_DISABLED_CODE;
+  constructor(message = 'Transmit is disabled on this source’s radio') {
+    super(message);
+    this.name = 'TxDisabledError';
+  }
+}
+
+/** Structural check — survives module duplication / mocking (does not rely on instanceof). */
+export function isTxDisabledError(e: unknown): e is TxDisabledError {
+  return !!e && typeof e === 'object' && (e as { isTxDisabledError?: boolean }).isTxDisabledError === true;
+}
+```
+
+Route/scheduler/automation code branches on `isTxDisabledError(error)`, never `instanceof`.
+
+---
+
+## 4. Transmit-primitive guard (the choke point)
+
+Each primitive already opens with `if (!this.isConnected || !this.transport) throw new Error('Not connected...')`.
+Add the TX guard immediately after that connection check:
+
+```ts
+if (!this.isTxEnabled()) {
+  throw new TxDisabledError();
+}
+```
+
+**Primitives to guard** (all in `meshtasticManager.ts`):
+
+| Method | Line | Notes |
+|---|---|---|
+| `sendTextMessage` | 8772 | covers user sends, auto-ack/responder/ping, auto-announce, cron/timer messages, automation, warning sends |
+| `sendTraceroute` | 8939 | covers traceroute route, traceroute scheduler, auto-responder traceroutes |
+| `sendPositionRequest` | 8987 | |
+| `sendNodeInfoRequest` | 9062 | covers key-repair scheduler NodeInfo exchanges + `sendNodeInfoBroadcast` (9426 delegates here) |
+| `sendNeighborInfoRequest` | 9131 | |
+| `sendTelemetryRequest` | 9353 | covers remote LocalStats scheduler |
+
+Guarding these six covers **every** meshtastic OTA send transitively, including the auto-* senders
+and services that call `this.sendTextMessage` (auto-ack ~9949, auto-ping replies ~10058, tapbacks,
+`autoAnnounceService`, timer/cron messages, `nodesRoutes.ts:1243` warning send, automation via
+`meshActionDeps.ts:82`).
+
+### Remote-admin guard (remote target only)
+Local-node admin MUST keep working. Admin sends live in `src/server/services/remoteAdminService.ts`;
+each method computes `isLocalNode` the same way (e.g. `sendRebootCommand` at line 563):
+
+```ts
+const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
+const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+```
+
+Add a private helper and call it in every method that transmits to a potentially-remote target,
+right after `isLocalNode` is computed:
+
+```ts
+// remoteAdminService.ts
+private assertTxForRemoteTarget(isLocalNode: boolean): void {
+  if (!isLocalNode && !this.mgr.isTxEnabled()) {
+    throw new TxDisabledError('Remote admin requires transmit; TX is disabled on this source');
+  }
+}
+```
+
+Apply to the remote-capable senders in `remoteAdminService.ts`: `sendRebootCommand`,
+`sendSetTimeCommand`, remote config/owner setters, `requestRemoteConfig`, and
+`requestRemoteSessionPasskey`. (Grep the file for `isLocalNode` to enumerate — every site that
+computes it and then calls `this.mgr.sendLocalAdminPacket(...)` for a remote target needs the
+assert.) `deviceAdminService.ts` is local-only (local position write, config-from-actual builder) —
+**do not** guard it. **Never** guard `sendLocalAdminPacket` itself (shared with local admin).
+
+Do NOT gate: the time-sync scheduler (local admin), MQTT bridge downlink, MeshCore managers,
+DB-only services.
+
+---
+
+## 5. Route error mapping
+
+`ok()`/`fail()` live in `src/server/utils/apiResponse.ts`. `fail(res, status, code, message, extra?)`
+is always safe for the frontend (`ApiService` reads `error`/`code` only). Map every guarded route:
+
+### 5a. messageRoutes.ts
+- Send at `1310`; catch at `1316` currently `res.status(500).json({ error: 'Failed to send message' })`.
+- Add `import { fail } from '../utils/apiResponse.js';` (not currently imported) and:
+  ```ts
+  } catch (error) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
+    logger.error('Error sending message:', error);
+    res.status(500).json({ error: 'Failed to send message' });
+  }
+  ```
+  (Leave the existing 500 shape as-is — bare-`{error}` handlers convert opportunistically, only the
+  new TX branch uses `fail`.)
+
+### 5b. meshRequestRoutes.ts
+- Five handlers: traceroute (send 34 / catch 39), position (69 / 118), nodeinfo (150 / 196),
+  neighborinfo (264 / 275), telemetry (314 / 329).
+- These use `res.json({ success, error, message })` and already special-case `'Not connected'` → 503.
+  Add a TX branch **before** the not-connected check in each catch:
+  ```ts
+  } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
+    logger.error('Error sending traceroute:', error);
+    if (error?.message?.includes('Not connected')) { /* existing 503 */ }
+    ...
+  }
+  ```
+
+### 5c. adminRoutes.ts (remote target) + configRoutes.ts (remote module-config-request)
+- `configRoutes.ts:282` `requestModuleConfig(configType)` for a remote target → wrap its catch (284)
+  with the TX branch → `fail(res, 409, 'TX_DISABLED', ...)`.
+- adminRoutes remote admin command handlers (remote reboot/set-config/etc.) → same TX branch in their
+  catches. Local-target admin never throws `TxDisabledError`, so local admin is unaffected.
+
+### 5d. v1 API — follow v1's own convention (NOT the fail() envelope)
+v1 formats errors as `res.status(N).json({ success: false, error: '...' })` (e.g.
+`v1/actions.ts:105`). Add a code field for the TX case:
+```ts
+} catch (error) {
+  if (isTxDisabledError(error)) {
+    return res.status(409).json({ success: false, error: 'Transmit is disabled on this source', code: 'TX_DISABLED' });
+  }
+  logger.error('[v1/actions] Error sending traceroute:', error);
+  res.status(500).json({ success: false, error: 'Failed to send traceroute' });
+}
+```
+- `v1/actions.ts`: traceroute, position, nodeinfo, neighborinfo handlers.
+- `v1/messages.ts`: send at `536` (single-packet path). The multi-part path queues via
+  `messageQueueService` (202 accepted) — the queue drains through `sendTextMessage` later, so a
+  queued send that hits TX-disabled is handled by the queue's own error path, not the request. Gate
+  the synchronous `536` send; note the queued path as a known async-skip (acceptable for Phase 1).
+
+---
+
+## 6. Import / export preservation
+
+Decision (epic §5): imports/restores **preserve the device's current `txEnabled`** — strip the field
+before applying. Exports emit the **actual** value. Only the LoRa config UI changes it (§7).
+
+| Site | File:line | Change |
+|---|---|---|
+| LoRa config write | `configRoutes.ts:132-138` | Remove `txEnabled: true`. Pass through the submitted `req.body.txEnabled` (this is the one UI that legitimately sets it — exit criterion 1). |
+| Channel-URL export | `channelRoutes.ts:1064` | Replace `txEnabled: true` with `txEnabled: deviceConfig.lora.txEnabled`. |
+| Channel-URL import | `channelRoutes.ts:1180-1189` | Strip `txEnabled` from `decoded.loraConfig` before `setLoRaConfig`: `const { txEnabled: _drop, ...rest } = decoded.loraConfig; await configImportManager.setLoRaConfig(rest);` |
+| Remote/local config export | `adminRoutes.ts:1066` (local), `adminRoutes.ts:1086` (remote) | Replace `txEnabled: true` with the real source value (`deviceConfig.lora.txEnabled` / `loraConfigData.txEnabled`). |
+| Config import (`/import-config`) | `adminRoutes.ts:1109`, applies via the shared local import logic (~1140) | The channel-import fix (above) covers this path since it reuses that logic. Verify no separate `txEnabled: true` remains in the apply branch. |
+| Backup restore | `systemRestoreService.ts` / `systemBackupService.ts` | **No change** — grep confirms neither writes `lora`/`txEnabled`. Add a one-line comment or a test asserting restore never calls `setLoRaConfig`, to lock in exit criterion 2. |
+
+---
+
+## 7. Autonomous senders — skip at tick, no spam
+
+**Design decision:** the primitive guard is the correctness backstop. To avoid a thrown
+`TxDisabledError` on every tick (and per-tick error logs), add a **cheap `isTxEnabled()` pre-check
+that returns early** at the top of each autonomous tick. The once-per-state-change info log already
+lives at the config-merge point (§2), so ticks stay silent (debug-level early return).
+
+| Sender | Location | Action |
+|---|---|---|
+| Traceroute scheduler | tick in `startTracerouteScheduler` (`meshtasticManager.ts:2197`, sends at 2267) | early-return if `!isTxEnabled()` |
+| Key-repair scheduler | `startKeyRepairScheduler` (2852, sends 2944/2964) | early-return |
+| Remote LocalStats scheduler | `startRemoteLocalStatsScheduler` (2358) | early-return |
+| Remote-admin scanner | `startRemoteAdminScanner` (2624) | early-return (all its sends are remote admin) |
+| Auto-announce | `autoAnnounceService.ts` tick (~78, guarded today by `isDeviceConnected()`) | add `&& this.mgr.isTxEnabled()` to the same guard |
+| Waypoint rebroadcast | `waypointRebroadcastSchedulerService.ts` tick (~50) | early-return if the source's `isTxEnabled()` is false |
+| Timer/cron messages | `startTimerScheduler` (3216) / cron job (3274) | early-return in the job body |
+| Auto-ack | send site `meshtasticManager.ts:~9949` | pre-check in the auto-ack decision path before building the reply |
+| Auto-responder | auto-responder decision path (near auto-ack) | pre-check |
+| Auto-ping | reply sites (~10058) | pre-check before replying |
+| Position-estimation traceroutes | verified: `positionEstimationService`/`Scheduler` do **not** call `sendTraceroute` (they consume observed traceroute/neighbor data). No change; covered by primitive guard if a future path sends. |
+
+For the schedulers that poll one target per tick, the early-return leaves the interval running so TX
+re-enable resumes automatically — matching the existing passive-mode skip philosophy
+(`meshtasticManager.ts:1786-1826`).
+
+**Note on passive mode:** passive mode skips *starting* certain schedulers at connect
+(`meshtasticManager.ts:1785`). TX-disabled is orthogonal — the schedulers still start, they just
+skip *sending* at tick time. Do not conflate the two flags.
+
+---
+
+## 8. Automation engine — skip-and-record
+
+The automation engine records per-action outcomes as `{ skipped: true, reason: '...' }` objects
+(existing pattern in `src/server/services/automation/actionExecutor.ts:317,338,363,409` for
+MeshCore-unsupported actions). Run status is `'completed' | 'failed'`
+(`automationEngineService.ts:66`); a skipped action does **not** fail the run.
+
+The mesh send flows through `meshActionDeps.ts` → `sendTextVia` (line ~79) → `raw.sendTextMessage(...)`
+which will now throw `TxDisabledError` when TX is off. **Catch it in the action executor and convert
+to a skip**, mirroring the existing MeshCore-unsupported skips:
+
+- In `actionExecutor.ts`, wrap the mesh-send action invocation (`deps.sendMessage`/`sendTapback`/the
+  meshRequest/remote-admin actions) so `isTxDisabledError(e)` returns
+  `{ skipped: true, reason: 'TX_DISABLED' }` (or pushes it to `results`) instead of rethrowing.
+- Because the guard is Meshtastic-only, the MeshCore branch of `sendTextVia` never throws
+  `TxDisabledError` — no MeshCore behavior changes.
+
+Acceptance: a send action against a TX-disabled source yields an `automation_runs` entry with the run
+`status: 'completed'` and the action step marked skipped/`TX_DISABLED` — not `status: 'failed'`.
+
+---
+
+## 9. Work packages
+
+Sized for one Sonnet implementer each. **Tests are folded into their owning WP** (each WP lands
+green). Dependency order is strict: WP1 → {WP2, WP3} → WP4-doc.
+
+### WP1 — Error type, manager state accessor, primitive + remote-admin guards
+**Depends on:** nothing.
+**Files:**
+- New `src/server/errors/txDisabledError.ts` (§3).
+- `meshtasticManager.ts`: add `isTxEnabled()` (§2); add state-change info log at the config-merge
+  point (~4266); add the guard to the six primitives (§4).
+- `remoteAdminService.ts`: add `assertTxForRemoteTarget()` + call it in every remote-capable sender (§4).
+**Tests:**
+- `meshtasticManager` guard unit tests: each primitive throws `TxDisabledError` when
+  `actualDeviceConfig.lora.txEnabled === false`; succeeds (no throw for TX reason) when true/undefined.
+- `isTxEnabled()` default-true when config absent.
+- `remoteAdminService`: remote target + TX off → throws; local target (dest 0 / local nodeNum) + TX
+  off → does NOT throw (mock `sendLocalAdminPacket`).
+**Acceptance:** guard unit tests green; local admin path proven unaffected; no route/scheduler changes yet.
+
+### WP2 — Route error mapping + import/export/config passthrough
+**Depends on:** WP1 (imports `isTxDisabledError`, `TxDisabledError`).
+**Files:**
+- `configRoutes.ts` (POST /lora passthrough §6; module-config-request 409 §5c).
+- `channelRoutes.ts` (export actual value; import strip §6).
+- `adminRoutes.ts` (export actual value; remote-admin 409; verify import apply §6).
+- `messageRoutes.ts`, `meshRequestRoutes.ts`, `v1/actions.ts`, `v1/messages.ts` (409 mapping §5).
+**Tests (route harness — `createRouteTestApp`, per CLAUDE.md; `src/server/test-helpers/routeTestApp.ts`):**
+- `POST /api/config/lora` with `txEnabled:false` passes it through to `setLoRaConfig` (no force-true).
+- Channel import does **NOT** call `setLoRaConfig` with a `txEnabled` key (strip assertion).
+- Channel/admin export emits the source's actual `txEnabled`.
+- Each guarded route returns **409 + code `TX_DISABLED`** when the (mocked) manager primitive throws
+  `TxDisabledError`: messages send, meshRequest ×5, config module-request (remote), v1 actions ×N,
+  v1 messages single-send.
+- Backup-restore test: restore path never writes lora `txEnabled` (exit criterion 2).
+Mock the `sourceManagerRegistry`/resolved manager so the primitive throws `TxDisabledError`
+(non-DB mocks stay per CLAUDE.md); use the harness only for the auth/session/permission wiring.
+
+### WP3 — Autonomous sender skips + automation skip-and-record
+**Depends on:** WP1 (`isTxEnabled`, `isTxDisabledError`).
+**Files:**
+- `meshtasticManager.ts` scheduler ticks + auto-ack/responder/ping pre-checks (§7).
+- `autoAnnounceService.ts`, `waypointRebroadcastSchedulerService.ts` (§7).
+- `services/automation/actionExecutor.ts` (catch → skip §8).
+**Tests:**
+- Scheduler-skip unit tests: with TX off, the traceroute/key-repair/remote-LocalStats ticks do not
+  call their primitive; with TX on they do.
+- Auto-ack/responder/ping: no reply attempted when TX off.
+- Automation: send action against TX-disabled source produces a run with `status:'completed'` and a
+  skipped/`TX_DISABLED` action result (extend `actionExecutor.test.ts` / `automationEngineService.test.ts`).
+- Verify no per-tick error log (assert logger not called at error level on repeated ticks).
+**Acceptance:** no unhandled promise rejections from ticks; state-change logged once.
+
+### WP4 — v1 API doc note + full-suite green (fold into WP2/WP3 if preferred)
+**Depends on:** WP2, WP3.
+- Confirm full Vitest suite green (§Testing). No new doc pages (user docs are Phase 3) — only a
+  short code comment where `TX_DISABLED` is emitted so the Phase 3 docs pass can find them.
+This WP is optional bookkeeping; the reviewer may merge it into WP2/WP3.
+
+---
+
+## 10. Testing notes
+
+- Run the **full** Vitest suite before PR (not just targeted files) — the guard touches
+  `meshtasticManager`, which many suites import.
+- New/changed route tests **must** use `createRouteTestApp` (harness at
+  `src/server/test-helpers/routeTestApp.ts`: `harness.grant(userId, resource, action, sourceId)`,
+  `harness.loginAs`, `harness.limited`, `harness.sourceA`, `harness.cleanup`). Non-DB mocks
+  (`sourceManagerRegistry`, resolved manager) remain hand-mocked.
+- Lint gate: `npm run lint:ci` must exit 0 (ignore `.claude/worktrees/` FAIL lines per CLAUDE.md).
+  The new error file + guard code must not add `no-explicit-any` sites (type the error as `unknown`
+  and narrow via `isTxDisabledError`).
+- No migration, no schema change, no new setting key — nothing to add to `VALID_SETTINGS_KEYS` or
+  the migration registry. `txEnabled` already flows through the existing device-config plumbing.
+
+---
+
+## 11. Out of scope (Phase 2 / Phase 3)
+
+- **All frontend gating and i18n** (Phase 2): disabling send buttons, the "Transmit Disabled"
+  banner styling, tooltips, the LoRa-config danger-confirm dialog, `useTxStatus` consumers beyond
+  the existing banner, removing the frontend defensive `txEnabled:true` defaults
+  (`useAdminCommandsState.ts:223`, `AdminCommandsTab.tsx:503,1059`). Phase 1 only makes the backend
+  correct; the UI continues to work (sends now surface a 409 instead of silently succeeding).
+- **Automations builder warning badge, v1 API docs, user-facing receive-only docs, locale string
+  verification** (Phase 3).
+- **MeshCore / MQTT-bridge** TX gating — intentionally never gated (different transport, no such flag).

--- a/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
@@ -1,0 +1,169 @@
+# TX-Disabled Support — Epic Plan
+
+**Epic issue:** #4294 (original bug report, reopened as tracker; #4308 closed as duplicate)
+**Status:**
+- [ ] Phase 1 — Backend: honor the flag + central guard
+- [ ] Phase 2 — Frontend: gating UX
+- [ ] Phase 3 — Polish + docs
+
+**Interview decisions (2026-07-23):**
+- 3 phases as scoped, one PR each.
+- Imports/restores (channel-URL import, remote config import, backup restore) **preserve
+  the device's current txEnabled** — they never write the field. Only the LoRa config UI
+  (with danger-confirm dialog) changes it.
+- Global "Transmit Disabled" banner is the single paused indicator — no per-feature
+  paused badges in settings sections.
+- Epic tracked in #4294 (the original NullVoid bug report — a ROUTER_LATE listen-only
+  MQTT relay whose TX-off config MeshMonitor silently reverts); each phase PR references it.
+
+**Goal:** Stop force-overriding `lora.txEnabled` to `true`, let users legitimately run a
+Meshtastic source in receive-only mode, and degrade the UI/backend gracefully so every
+surface that cannot function with TX disabled is visibly disabled (not broken or silently
+failing).
+
+**Firmware semantics (verified against meshtastic/firmware master):** `tx_enabled=false`
+is a hard kill switch in `RadioLibInterface.cpp` — every outbound LoRa packet is dropped
+at the radio with `ERRNO_DISABLED`. RX, decode, TCP API (config reads/writes, **local**
+node admin, channel reads) all keep working. Remote-node anything (messages, traceroute,
+requests, remote admin) silently dies. The node also stops announcing itself (own
+NodeInfo/Position/Telemetry broadcasts are dropped), so it goes invisible to the mesh.
+
+## Current state
+
+- **The hardcode:** `src/server/routes/configRoutes.ts:129-137` — `POST /api/config/lora`
+  spreads the request body then forces `txEnabled: true` before `setLoRaConfig`.
+- **Other force-true sites:**
+  - `channelRoutes.ts:1180-1189` — channel-URL **import** forces `true`.
+  - `channelRoutes.ts:1064-1066` — channel-URL **export** emits `true` regardless of actual value.
+  - `adminRoutes.ts:1052-1090` (`:1066`, `:1086`) — **remote-node** config export/import forces `true`,
+    even when the remote node legitimately has TX off.
+  - Frontend defensive defaults: `useAdminCommandsState.ts:223`, `AdminCommandsTab.tsx:503,1059`.
+- **Existing detection infra (keep, extend):**
+  - `GET /api/device/tx-status?sourceId=…` (`deviceStatusRoutes.ts:9`) — per-source, reads
+    `deviceConfig.lora.txEnabled`, defaults true.
+  - `useTxStatus` hook (`src/hooks/useTxStatus.ts`) — TanStack Query, per-source key,
+    30s poll. Consumed **only** in `App.tsx:245` → `AppBanners` warning banner.
+  - Nothing else in the app knows TX state; no send button checks it; every scheduler fires anyway.
+- **Not affected (must NOT be gated):** local-node admin over TCP (config read/write,
+  reboot, set-time — the time-sync scheduler is local admin), MQTT bridge downlink
+  (`mqttBridgeManager.ts` publishes to a broker, bypasses the radio), MeshCore sources
+  (own manager/protocol, no such flag), all read-only pages (Dashboard, PacketMonitor,
+  UnifiedTelemetry, MapAnalysis, UnifiedMessages — which has no send box).
+
+## Inventory of TX-dependent surfaces
+
+### Frontend (user-initiated OTA)
+
+| Surface | Location | Endpoint |
+|---|---|---|
+| Channel send box + Enter | `ChannelsTab.tsx` / `App.tsx:2591` | `POST /api/messages/send` |
+| DM send box | `MessagesTab.tsx` / `App.tsx:2166` | `POST /api/messages/send` |
+| Tapback/emoji | `App.tsx:2258` | same |
+| Send Bell (channel + DM) | `App.tsx:2719,2744` | same |
+| Resend | `App.tsx:2790` (wired `ChannelsTab.tsx:1076`, `MessagesTab.tsx:1674`) | same |
+| Send Position (broadcast) | `App.tsx:2768` | `POST /api/position/request` |
+| Traceroute (node list + map popup) | `useSourceView` / `NodePopup.tsx:180` / `App.tsx:3546,3792` | `POST /api/traceroute` |
+| Exchange Position | `MessagesTab.tsx:2217,2274` → `App.tsx:1982` | `POST /api/position/request` |
+| Exchange NodeInfo / key repair | `MessagesTab.tsx:2131,2188` → `App.tsx:2028` | `POST /api/nodeinfo/request` |
+| Request Neighbor Info | `App.tsx:2068` | `POST /api/neighborinfo/request` |
+| Request Telemetry (4 kinds) | `MessagesTab.tsx:2466` → `App.tsx:2118` | `POST /api/telemetry/request` |
+| **Remote**-node admin | `AdminCommandsTab.tsx` (remote target: `:659,:933,:1194,:1404`; passkey polling `:321-359`) | `POST /api/admin/commands` |
+| Module config request (remote) | `api.ts:1265` | `POST /api/config/module/request` |
+| Automations builder (sendMessage action) | `automations/catalog.ts:317`, `AutomationTester.tsx:263` | engine (below) |
+| REST v1 (external consumers) | `v1/actions.ts:79,111,168,224`, `v1/messages.ts:536` | send/traceroute/requests |
+
+### Backend autonomous senders (must skip + log when TX disabled)
+
+All per-source (per manager instance), in `src/server/meshtasticManager.ts` unless noted:
+
+| Scheduler / service | Location |
+|---|---|
+| Traceroute scheduler | `:2197` → `sendTraceroute :2267` |
+| Key-repair scheduler (auto NodeInfo exchange) | `:2852` → `:2944` |
+| Remote LocalStats scheduler | `:2358` |
+| Remote-admin scanner | `:1790` (`RemoteAdminService`) |
+| Auto-announce | `:1125,:3210` → `sendTextMessage` |
+| Waypoint rebroadcast | `waypointRebroadcastSchedulerService.ts:58` |
+| Auto-ack | `~:9694-9963` |
+| Auto-responder | (`autoResponderCooldowns :823`) |
+| Auto-ping sessions | `:10058-10360` |
+| Cron-scheduled messages | `:62,:3274` |
+| Automation engine sends | `automation/actionExecutor.ts:172`, `meshActionDeps.ts:82,146,147` |
+| Position-estimation traceroutes | `:1175,:7831` |
+
+**Not gated:** time-sync scheduler (`:2702` — local admin), autoFavorite/distance-delete/DB
+maintenance/backup (local only).
+
+## Design decisions (recommended)
+
+1. **Disable, don't hide.** Gated controls render disabled with a tooltip ("Transmit is
+   disabled on this node's radio") so users understand *why*, and reads remain available
+   (messages still arrive; RX works). Hiding would make the app look broken.
+2. **Backend is the source of truth and the enforcement point.** A single guard at the
+   transmit primitives (`sendTextMessage`, `sendTraceroute`, `sendPositionRequest`,
+   `sendNodeInfoRequest`, remote-path `sendAdminCommand*`) throws a typed
+   `TxDisabledError`; routes map it to `fail(res, 409, 'TX_DISABLED', …)`. UI gating is
+   UX polish; the choke point is what guarantees correctness (incl. v1 API and any
+   surface we miss).
+3. **Local-node admin stays fully functional.** `sendAdminCommand` gates only when the
+   target ≠ local node. This is what lets the user re-enable TX from MeshMonitor.
+4. **Setting the checkbox requires explicit confirmation.** Unchecking TX in the LoRa
+   config UI shows a danger-confirm dialog spelling out consequences (node goes invisible
+   to the mesh, no sending/traceroute/remote admin until re-enabled).
+5. **Import/export paths preserve instead of force.** Channel-URL import, backup restore,
+   and remote config import should leave `txEnabled` at the device's current value
+   (strip it from the applied config) rather than force `true` — importing channels
+   should not covertly flip a radio setting. Export emits the actual value.
+6. **Schedulers check the flag at tick time and skip with a debug log** (once per state
+   change at info level, not per tick — avoid log spam). They keep running so TX
+   re-enable needs no restart.
+7. **Automation runs record a skip.** A send action against a TX-disabled source writes
+   an `automation_runs` entry marked skipped/TX_DISABLED rather than failing the run.
+8. **Per-source throughout.** Gating keys off the active source's tx-status
+   (`useTxStatus` already per-source). MeshCore and MQTT-bridge sources are never gated.
+
+## Phases (≈3 PRs)
+
+### Phase 1 — Backend: honor the flag + central guard
+- Remove force-true from `configRoutes.ts` POST `/lora`; validate + pass through.
+- Add `TxDisabledError` + guard in the transmit primitives (remote-target-only for admin).
+- Map to `fail(res, 409, 'TX_DISABLED', …)` in messageRoutes, meshRequestRoutes,
+  adminRoutes (remote), v1 routes. `ApiService` already surfaces `error`/`code`.
+- Scheduler tick-time skips (all 12 rows above) + state-change logging.
+- Automation engine: skip-and-record behavior.
+- Import/export preservation changes (`channelRoutes.ts`, `adminRoutes.ts`,
+  `deviceBackupService` already records actual value).
+- Tests: route-harness 409 tests, scheduler skip tests, guard unit tests, import
+  preservation tests.
+
+### Phase 2 — Frontend: gating UX
+- Distribute TX state: reuse `useTxStatus` (shared TanStack cache — no new context
+  needed) in ChannelsTab, MessagesTab, NodePopup/node lists, AdminCommandsTab;
+  invalidate `['txStatus']` after LoRa config save and on config push from device.
+- Disabled states + tooltips on every row of the frontend inventory table.
+- AdminCommandsTab: gate only when a remote node is targeted; banner inside the tab
+  ("remote admin unavailable — TX disabled").
+- LoRa config: enable the checkbox for real; danger-confirm dialog on disable; remove
+  frontend force-true defaults (`useAdminCommandsState.ts:223` etc. become
+  preserve-current).
+- Keep/extend the AppBanners warning (link it to the LoRa config section).
+- Handle 409 TX_DISABLED gracefully anywhere a race slips through (toast, not crash).
+- Tests: component disabled-state tests, hook invalidation test.
+
+### Phase 3 — Polish + docs
+- Automations builder: inline warning badge when a selected source has TX disabled.
+- v1 API docs: document 409 TX_DISABLED.
+- User docs page: receive-only mode — what works, what doesn't.
+- Verify banner/i18n strings across locales.
+
+## Open questions
+
+- Should the **traceroute scheduler / position estimation** state be surfaced in the UI
+  ("paused — TX disabled") or is the global banner enough? (Plan assumes banner is enough.)
+- Backup **restore**: preserve-current (recommended) vs restore the recorded value —
+  restoring `false` from an old backup could surprise a user; preserve-current is safer.
+
+## Effort
+
+Medium epic. Phase 1 is the bulk (touches ~15 backend files + tests), Phase 2 is wide but
+mechanical (one hook + disabled props through ~10 components), Phase 3 is small.

--- a/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
@@ -2,9 +2,28 @@
 
 **Epic issue:** #4294 (original bug report, reopened as tracker; #4308 closed as duplicate)
 **Status:**
-- [ ] Phase 1 — Backend: honor the flag + central guard
+- [x] Phase 1 — Backend: honor the flag + central guard (branch `feature/tx-disabled-backend`)
 - [ ] Phase 2 — Frontend: gating UX
 - [ ] Phase 3 — Polish + docs
+
+**Phase 1 deviations & findings (2026-07-23):**
+- **"Preserve" ≠ strip.** `setLoRaConfig` sends the ENTIRE LoRaConfig struct (whole-message
+  replace) and proto3 decodes an omitted bool as `false` — stripping `txEnabled` on import
+  would have silently disabled TX (the #1328 mechanism). Implemented as an explicit
+  backfill from the device's current value (`manager.isTxEnabled()`) instead. POST /lora
+  likewise backfills when the caller omits the field.
+- **Remote import preserve is best-effort:** cached remote config → decoded URL value →
+  fail-open `true`. A fully-accurate remote preserve needs an extra
+  `requestRemoteConfig(LORA_CONFIG)` round-trip — `TODO(#4294 follow-up)` at the call
+  site in `adminRoutes.ts`; consider in Phase 3.
+- `adminRoutes.ts` has its **own duplicated** import-config logic (spec assumed it shared
+  channelRoutes'); both its force-true sites were fixed independently.
+- Pre-existing bug found & fixed: `POST /config/module/request` was registered after the
+  `/module/:moduleType` wildcard and was unreachable (always 400). Reordered.
+- Waypoint rebroadcast gates in `waypointService.rebroadcastTick` (via `broadcastWaypoint`,
+  not one of the six guarded primitives), with a `typeof manager.isTxEnabled === 'function'`
+  check so MeshCore managers are never touched.
+- Position-estimation needed no change — it consumes observed traceroutes, never sends.
 
 **Interview decisions (2026-07-23):**
 - 3 phases as scoped, one PR each.

--- a/src/server/errors/txDisabledError.ts
+++ b/src/server/errors/txDisabledError.ts
@@ -1,0 +1,16 @@
+export const TX_DISABLED_CODE = 'TX_DISABLED' as const;
+
+export class TxDisabledError extends Error {
+  /** Brand for cross-module-safe detection (see isTxDisabledError). */
+  readonly isTxDisabledError = true as const;
+  readonly code = TX_DISABLED_CODE;
+  constructor(message = 'Transmit is disabled on this source’s radio') {
+    super(message);
+    this.name = 'TxDisabledError';
+  }
+}
+
+/** Structural check — survives module duplication / mocking (does not rely on instanceof). */
+export function isTxDisabledError(e: unknown): e is TxDisabledError {
+  return !!e && typeof e === 'object' && (e as { isTxDisabledError?: boolean }).isTxDisabledError === true;
+}

--- a/src/server/meshtasticManager.autoAckResponderPingTxDisabled.test.ts
+++ b/src/server/meshtasticManager.autoAckResponderPingTxDisabled.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Auto-ack / auto-responder / auto-ping TX-disabled skip (#4294 epic, Phase 1 WP3).
+ *
+ * Each of these reply paths eventually queues its outbound text through
+ * `this.messageQueue.enqueue(...)` (auto-ack, auto-responder) or calls
+ * `this.sendTextMessage(...)` directly (auto-ping command handler / session
+ * ticker) — none of that work should even be attempted while
+ * `isTxEnabled()` is false, so the pre-checks added in meshtasticManager.ts
+ * return early before touching the queue/send primitive.
+ *
+ * Mock pattern mirrors meshtasticManager.node-identity-guards.test.ts /
+ * meshtasticManager.tracerouteScheduler.test.ts (fresh `fallbackManager`
+ * import per test file, full databaseService + messageQueueService mocks).
+ * See docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md §7.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+const mockGetSettingForSource = vi.fn();
+const mockGetNode = vi.fn();
+const mockFindUserByIdAsync = vi.fn();
+const mockFindUserByUsernameAsync = vi.fn();
+const mockCheckPermissionAsync = vi.fn();
+const mockGetUserPermissionSetAsync = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+    findUserByIdAsync: mockFindUserByIdAsync,
+    findUserByUsernameAsync: mockFindUserByUsernameAsync,
+    checkPermissionAsync: mockCheckPermissionAsync,
+    getUserPermissionSetAsync: mockGetUserPermissionSetAsync,
+    settings: {
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+      getSettingForSource: mockGetSettingForSource,
+      setSettingForSource: vi.fn().mockResolvedValue(undefined),
+    },
+    nodes: {
+      getNode: mockGetNode,
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      markNodeAsWelcomedIfNotAlready: vi.fn().mockResolvedValue(false),
+      getNodeCount: vi.fn().mockResolvedValue(0),
+      setNodeFavorite: vi.fn().mockResolvedValue(undefined),
+      updateNodeMessageHops: vi.fn().mockResolvedValue(undefined),
+    },
+    channels: {
+      getChannelById: vi.fn().mockResolvedValue(null),
+      getAllChannels: vi.fn().mockResolvedValue([]),
+      upsertChannel: vi.fn().mockResolvedValue(undefined),
+      getChannelCount: vi.fn().mockResolvedValue(0),
+    },
+    telemetry: {
+      insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
+      getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
+    },
+    messages: {
+      insertMessage: vi.fn().mockResolvedValue(true),
+      getMessages: vi.fn().mockResolvedValue([]),
+      updateMessageTimestamps: vi.fn().mockResolvedValue(true),
+      updateMessageDeliveryState: vi.fn().mockResolvedValue(true),
+    },
+    traceroutes: {
+      insertTraceroute: vi.fn().mockResolvedValue(undefined),
+      insertRouteSegment: vi.fn().mockResolvedValue(undefined),
+    },
+    neighbors: {
+      upsertNeighborInfo: vi.fn().mockResolvedValue(undefined),
+      deleteNeighborInfoForNode: vi.fn().mockResolvedValue(0),
+    },
+    logKeyRepairAttemptAsync: vi.fn().mockResolvedValue(0),
+    clearKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    deleteNodeAsync: vi.fn().mockResolvedValue({}),
+    getNodeNeedingTimeSyncAsync: vi.fn().mockResolvedValue(null),
+    getNodeNeedingRemoteAdminCheckAsync: vi.fn().mockResolvedValue(null),
+    updateNodeRemoteAdminStatusAsync: vi.fn().mockResolvedValue(undefined),
+    getNodesNeedingKeyRepairAsync: vi.fn().mockResolvedValue([]),
+    getKeyRepairLogAsync: vi.fn().mockResolvedValue([]),
+    setKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    insertTelemetryAsync: vi.fn().mockResolvedValue(undefined),
+    getLatestTelemetryForTypeAsync: vi.fn().mockResolvedValue(null),
+    getMessageByRequestIdAsync: vi.fn().mockResolvedValue(null),
+    updateNodeMobilityAsync: vi.fn().mockResolvedValue(0),
+    getRecentEstimatedPositionsAsync: vi.fn().mockResolvedValue([]),
+    getAllGeofenceCooldownsAsync: vi.fn().mockResolvedValue([]),
+    setGeofenceCooldownAsync: vi.fn().mockResolvedValue(undefined),
+    markMessageAsReadAsync: vi.fn().mockResolvedValue(true),
+    getNodeNeedingTracerouteAsync: vi.fn().mockResolvedValue(null),
+    logAutoTracerouteAttemptAsync: vi.fn().mockResolvedValue(0),
+    updateAutoTracerouteResultByNodeAsync: vi.fn().mockResolvedValue(undefined),
+    recordTracerouteRequest: vi.fn(),
+    getNodesNeedingRemoteLocalStatsAsync: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    initialize: vi.fn(),
+    createMeshPacket: vi.fn(),
+  },
+}));
+
+vi.mock('./protobufService.js', () => ({
+  default: {
+    encode: vi.fn(),
+    decode: vi.fn(),
+  },
+  convertIpv4ConfigToStrings: vi.fn(),
+}));
+
+vi.mock('./protobufLoader.js', () => ({
+  getProtobufRoot: vi.fn(),
+}));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('./services/notificationService.js', () => ({
+  notificationService: {
+    checkAndSendNotifications: vi.fn(),
+  },
+}));
+
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeConnected: vi.fn(),
+    notifyNodeDisconnected: vi.fn(),
+  },
+}));
+
+vi.mock('./services/packetLogService.js', () => ({
+  default: {
+    logPacket: vi.fn(),
+  },
+}));
+
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: {
+    tryDecrypt: vi.fn(),
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emit: vi.fn(),
+    on: vi.fn(),
+    emitAutoPingUpdate: vi.fn(),
+  },
+}));
+
+const mockEnqueue = vi.fn();
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: mockEnqueue,
+    setSendCallback: vi.fn(),
+    handleAck: vi.fn(),
+    handleFailure: vi.fn(),
+    recordExternalSend: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return {
+    messageQueueService: mockInstance,
+    MessageQueueService,
+  };
+});
+
+vi.mock('./utils/cronScheduler.js', () => ({
+  validateCron: vi.fn(() => true),
+  scheduleCron: vi.fn((_expression: string, _callback: () => void) => ({
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('./config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({
+    NODE_IP: '127.0.0.1',
+    TCP_PORT: 4403,
+    LOG_LEVEL: 'info',
+  })),
+}));
+
+vi.mock('../utils/autoResponderUtils.js', () => ({
+  normalizeTriggerPatterns: vi.fn(),
+  normalizeTriggerChannels: vi.fn(),
+}));
+
+vi.mock('../utils/nodeHelpers.js', () => ({
+  isNodeComplete: vi.fn(),
+}));
+
+const LOCAL_NODE_NUM = 1234567890;
+const REMOTE_NODE_NUM = 987654321;
+
+/** Backing store for getSettingForSource, keyed by settings key (sourceId ignored — single source in these tests). */
+function wireSettings(overrides: Record<string, string | null>) {
+  mockGetSettingForSource.mockImplementation((_sourceId: string, key: string) =>
+    Promise.resolve(Object.prototype.hasOwnProperty.call(overrides, key) ? overrides[key] : null)
+  );
+}
+
+describe('MeshtasticManager - Auto-Ack/Responder/Ping TX-disabled skip (#4294 WP3)', () => {
+  let manager: any;
+  let loggerModule: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+    loggerModule = await import('../utils/logger.js');
+
+    manager.isConnected = true;
+    manager.localNodeInfo = {
+      nodeNum: LOCAL_NODE_NUM,
+      nodeId: '!499602d2',
+      longName: 'Test Local Node',
+      shortName: 'TLN',
+    };
+    manager.autoAckProcessedPackets = new Set();
+    manager.autoResponderProcessedPackets = new Set();
+    manager.autoAckCooldowns = new Map();
+    manager.autoPingSessions = new Map();
+    manager.cachedAutoAckRegex = null;
+    manager.sendTextMessage = vi.fn().mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('checkAutoAcknowledge', () => {
+    const autoAckMessage = {
+      fromNodeId: '!3ade68b1',
+      timestamp: Date.now(),
+      hopStart: undefined,
+      hopLimit: undefined,
+      viaMqtt: false,
+      relayNode: undefined,
+    };
+
+    it('does not enqueue a reply when TX is disabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      wireSettings({
+        autoAckEnabled: 'true',
+        autoAckChannels: '0',
+        autoAckChannelZeroHopReplyEnabled: 'true',
+      });
+
+      await manager.checkAutoAcknowledge(autoAckMessage, 'ping', 0, false, REMOTE_NODE_NUM, 111);
+
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(loggerModule.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('TX disabled')
+      );
+    });
+
+    it('enqueues a reply normally when TX is enabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      wireSettings({
+        autoAckEnabled: 'true',
+        autoAckChannels: '0',
+        autoAckChannelZeroHopReplyEnabled: 'true',
+        autoAckPreSendDelaySeconds: '0',
+      });
+
+      await manager.checkAutoAcknowledge(autoAckMessage, 'ping', 0, false, REMOTE_NODE_NUM, 222);
+
+      expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('checkAutoResponder', () => {
+    const responderMessage = {
+      text: 'hello',
+      fromNodeNum: REMOTE_NODE_NUM,
+      channel: 0,
+      timestamp: Date.now(),
+    };
+
+    it('does not read trigger config or enqueue a reply when TX is disabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      wireSettings({ autoResponderEnabled: 'true' });
+
+      await manager.checkAutoResponder(responderMessage, false, 333);
+
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(loggerModule.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('TX disabled')
+      );
+      // Never got far enough to look for configured triggers.
+      expect(mockGetSettingForSource).not.toHaveBeenCalledWith(expect.anything(), 'autoResponderTriggers');
+    });
+
+    it('proceeds past the TX check when TX is enabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      wireSettings({ autoResponderEnabled: 'true' }); // no autoResponderTriggers configured
+
+      await manager.checkAutoResponder(responderMessage, false, 444);
+
+      // Guard didn't block; execution reached the (unconfigured) triggers check.
+      expect(loggerModule.logger.debug).not.toHaveBeenCalledWith(
+        expect.stringContaining('TX disabled')
+      );
+      expect(loggerModule.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('No auto-responder triggers configured')
+      );
+    });
+  });
+
+  describe('handleAutoPingCommand', () => {
+    const pingMessage = { text: 'ping 3', fromNodeNum: REMOTE_NODE_NUM, channel: 0 };
+
+    it('does not send a reply and does not start a session when TX is disabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      wireSettings({ autoPingEnabled: 'true' });
+
+      const handled = await manager.handleAutoPingCommand(pingMessage, true);
+
+      expect(handled).toBe(false);
+      expect(manager.sendTextMessage).not.toHaveBeenCalled();
+      expect(manager.autoPingSessions.has(REMOTE_NODE_NUM)).toBe(false);
+      expect(loggerModule.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('TX is disabled')
+      );
+    });
+
+    it('starts a session and sends the confirmation when TX is enabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      wireSettings({ autoPingEnabled: 'true', autoPingMaxPings: '20', autoPingIntervalSeconds: '30', autoPingTimeoutSeconds: '60' });
+      manager.emitAutoPingUpdate = vi.fn().mockResolvedValue(undefined);
+      manager.startAutoPingSession = vi.fn();
+
+      const handled = await manager.handleAutoPingCommand(pingMessage, true);
+
+      expect(handled).toBe(true);
+      expect(manager.sendTextMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Starting 3 pings'),
+        0,
+        REMOTE_NODE_NUM
+      );
+      expect(manager.autoPingSessions.has(REMOTE_NODE_NUM)).toBe(true);
+    });
+  });
+
+  describe('sendNextAutoPing', () => {
+    function makeSession(overrides: Record<string, unknown> = {}) {
+      return {
+        requestedBy: REMOTE_NODE_NUM,
+        channel: 0,
+        totalPings: 5,
+        completedPings: 0,
+        successfulPings: 0,
+        failedPings: 0,
+        intervalMs: 30000,
+        timeoutMs: 60000,
+        timer: null,
+        sending: false,
+        pendingRequestId: null,
+        pendingTimeout: null,
+        startTime: Date.now(),
+        lastPingSentAt: 0,
+        results: [],
+        ...overrides,
+      };
+    }
+
+    it('does not send the next ping when TX is disabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      const session = makeSession();
+
+      await manager.sendNextAutoPing(session);
+
+      expect(manager.sendTextMessage).not.toHaveBeenCalled();
+      // Tick was skipped entirely — session state untouched, so it resumes cleanly later.
+      expect(session.sending).toBe(false);
+      expect(session.pendingRequestId).toBeNull();
+    });
+
+    it('sends the next ping normally when TX is enabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      const session = makeSession();
+
+      await manager.sendNextAutoPing(session);
+
+      expect(manager.sendTextMessage).toHaveBeenCalledWith('Ping 1/5', 0, REMOTE_NODE_NUM);
+    });
+  });
+});

--- a/src/server/meshtasticManager.node-identity-guards.test.ts
+++ b/src/server/meshtasticManager.node-identity-guards.test.ts
@@ -388,6 +388,48 @@ describe('MeshtasticManager - Node Identity Guards', () => {
       // Should not even fetch nodes
       expect(mockGetNodesNeedingKeyRepairAsync).not.toHaveBeenCalled();
     });
+
+    it('should skip all repairs when TX is disabled (#4294 WP3)', async () => {
+      manager.rebootMergeInProgress = false; // reset from the prior "reboot merge" test
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      mockGetNodesNeedingKeyRepairAsync.mockResolvedValue([
+        {
+          nodeNum: REMOTE_NODE_NUM,
+          nodeId: '!3ade68b1',
+          longName: 'Remote Node',
+          attemptCount: 0,
+          lastAttemptTime: null,
+        },
+      ]);
+
+      await manager.processKeyRepairs();
+
+      expect(loggerModule.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Key repair: Skipping - TX disabled')
+      );
+      expect(mockGetNodesNeedingKeyRepairAsync).not.toHaveBeenCalled();
+      expect(manager.sendNodeInfoRequest).not.toHaveBeenCalled();
+    });
+
+    it('should process key repair normally when TX is enabled', async () => {
+      manager.rebootMergeInProgress = false;
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      const remoteNode = {
+        nodeNum: REMOTE_NODE_NUM,
+        nodeId: '!3ade68b1',
+        longName: 'Remote Node',
+        attemptCount: 0,
+        lastAttemptTime: null,
+        channel: 0,
+      };
+      mockGetNodesNeedingKeyRepairAsync.mockResolvedValue([remoteNode]);
+      mockIsNodeSuppressed.mockReturnValue(false);
+      mockGetNode.mockReturnValue(remoteNode);
+
+      await manager.processKeyRepairs();
+
+      expect(manager.sendNodeInfoRequest).toHaveBeenCalledWith(REMOTE_NODE_NUM, 0);
+    });
   });
 
   describe('rebootMergeInProgress guard', () => {

--- a/src/server/meshtasticManager.remoteLocalStatsScheduler.txDisabled.test.ts
+++ b/src/server/meshtasticManager.remoteLocalStatsScheduler.txDisabled.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Remote LocalStats scheduler TX-disabled skip (#4294 epic, Phase 1 WP3).
+ *
+ * Mirrors meshtasticManager.tracerouteScheduler.test.ts's setup/mock pattern:
+ * a bare fallbackManager instance with fake timers and Math.random stubbed to
+ * 0 so the scheduler's startup jitter resolves immediately. See
+ * docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md §7.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+const mockGetNodesNeedingRemoteLocalStatsAsync = vi.fn();
+const mockFindUserByIdAsync = vi.fn();
+const mockFindUserByUsernameAsync = vi.fn();
+const mockCheckPermissionAsync = vi.fn();
+const mockGetUserPermissionSetAsync = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+    getNodesNeedingRemoteLocalStatsAsync: mockGetNodesNeedingRemoteLocalStatsAsync,
+    findUserByIdAsync: mockFindUserByIdAsync,
+    findUserByUsernameAsync: mockFindUserByUsernameAsync,
+    checkPermissionAsync: mockCheckPermissionAsync,
+    getUserPermissionSetAsync: mockGetUserPermissionSetAsync,
+    settings: {
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+      getSettingForSource: vi.fn((_sourceId: string, key: string) => mockGetSetting(key)),
+      setSettingForSource: vi.fn((_sourceId: string, key: string, value: string) => mockSetSetting(key, value)),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      markNodeAsWelcomedIfNotAlready: vi.fn().mockResolvedValue(false),
+      getNodeCount: vi.fn().mockResolvedValue(0),
+      setNodeFavorite: vi.fn().mockResolvedValue(undefined),
+      updateNodeMessageHops: vi.fn().mockResolvedValue(undefined),
+    },
+    channels: {
+      getChannelById: vi.fn().mockResolvedValue(null),
+      getAllChannels: vi.fn().mockResolvedValue([]),
+      upsertChannel: vi.fn().mockResolvedValue(undefined),
+      getChannelCount: vi.fn().mockResolvedValue(0),
+    },
+    telemetry: {
+      insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
+      getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
+    },
+    messages: {
+      insertMessage: vi.fn().mockResolvedValue(true),
+      getMessages: vi.fn().mockResolvedValue([]),
+      updateMessageTimestamps: vi.fn().mockResolvedValue(true),
+      updateMessageDeliveryState: vi.fn().mockResolvedValue(true),
+    },
+    traceroutes: {
+      insertTraceroute: vi.fn().mockResolvedValue(undefined),
+      insertRouteSegment: vi.fn().mockResolvedValue(undefined),
+    },
+    neighbors: {
+      upsertNeighborInfo: vi.fn().mockResolvedValue(undefined),
+      deleteNeighborInfoForNode: vi.fn().mockResolvedValue(0),
+    },
+    logKeyRepairAttemptAsync: vi.fn().mockResolvedValue(0),
+    clearKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    deleteNodeAsync: vi.fn().mockResolvedValue({}),
+    getNodeNeedingTimeSyncAsync: vi.fn().mockResolvedValue(null),
+    getNodeNeedingRemoteAdminCheckAsync: vi.fn().mockResolvedValue(null),
+    updateNodeRemoteAdminStatusAsync: vi.fn().mockResolvedValue(undefined),
+    getNodesNeedingKeyRepairAsync: vi.fn().mockResolvedValue([]),
+    getKeyRepairLogAsync: vi.fn().mockResolvedValue([]),
+    setKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    insertTelemetryAsync: vi.fn().mockResolvedValue(undefined),
+    getLatestTelemetryForTypeAsync: vi.fn().mockResolvedValue(null),
+    getMessageByRequestIdAsync: vi.fn().mockResolvedValue(null),
+    updateNodeMobilityAsync: vi.fn().mockResolvedValue(0),
+    getRecentEstimatedPositionsAsync: vi.fn().mockResolvedValue([]),
+    getAllGeofenceCooldownsAsync: vi.fn().mockResolvedValue([]),
+    setGeofenceCooldownAsync: vi.fn().mockResolvedValue(undefined),
+    markMessageAsReadAsync: vi.fn().mockResolvedValue(true),
+    getNodeNeedingTracerouteAsync: vi.fn().mockResolvedValue(null),
+    logAutoTracerouteAttemptAsync: vi.fn().mockResolvedValue(0),
+    updateAutoTracerouteResultByNodeAsync: vi.fn().mockResolvedValue(undefined),
+    recordTracerouteRequest: vi.fn(),
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    initialize: vi.fn(),
+    createMeshPacket: vi.fn(),
+  },
+}));
+
+vi.mock('./protobufService.js', () => ({
+  default: {
+    encode: vi.fn(),
+    decode: vi.fn(),
+  },
+  convertIpv4ConfigToStrings: vi.fn(),
+}));
+
+vi.mock('./protobufLoader.js', () => ({
+  getProtobufRoot: vi.fn(),
+}));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('./services/notificationService.js', () => ({
+  notificationService: {
+    checkAndSendNotifications: vi.fn(),
+  },
+}));
+
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeConnected: vi.fn(),
+    notifyNodeDisconnected: vi.fn(),
+  },
+}));
+
+vi.mock('./services/packetLogService.js', () => ({
+  default: {
+    logPacket: vi.fn(),
+  },
+}));
+
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: {
+    tryDecrypt: vi.fn(),
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emit: vi.fn(),
+    on: vi.fn(),
+  },
+}));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    handleAck: vi.fn(),
+    handleFailure: vi.fn(),
+    recordExternalSend: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return {
+    messageQueueService: mockInstance,
+    MessageQueueService,
+  };
+});
+
+vi.mock('./utils/cronScheduler.js', () => ({
+  validateCron: vi.fn(() => true),
+  scheduleCron: vi.fn((_expression: string, _callback: () => void) => ({
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('./config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({
+    NODE_IP: '127.0.0.1',
+    TCP_PORT: 4403,
+    LOG_LEVEL: 'info',
+  })),
+}));
+
+vi.mock('../utils/autoResponderUtils.js', () => ({
+  normalizeTriggerPatterns: vi.fn(),
+}));
+
+vi.mock('../utils/nodeHelpers.js', () => ({
+  isNodeComplete: vi.fn(),
+}));
+
+const mockTargetNode = {
+  nodeNum: 88888,
+  nodeId: '!00088888',
+  longName: 'Remote Stats Target',
+  channel: 0,
+  hopsAway: 1,
+};
+
+describe('MeshtasticManager - Remote LocalStats Scheduler TX-disabled skip (#4294 WP3)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+
+    manager.isConnected = true;
+    manager.localNodeInfo = {
+      nodeNum: 1234567890,
+      nodeId: '!12345678',
+      longName: 'Test Node',
+      shortName: 'TN',
+    };
+    manager.lastRemoteLocalStatsSentTime = 0;
+    manager.remoteLocalStatsLastSentAt = new Map();
+
+    manager.requestRemoteLocalStats = vi.fn().mockResolvedValue({ packetId: 1, requestId: 1 });
+    mockGetNodesNeedingRemoteLocalStatsAsync.mockResolvedValue([mockTargetNode]);
+  });
+
+  afterEach(() => {
+    manager.remoteLocalStatsIntervalMinutes = 0;
+    if (manager.remoteLocalStatsJitterTimeout) {
+      clearTimeout(manager.remoteLocalStatsJitterTimeout);
+      manager.remoteLocalStatsJitterTimeout = null;
+    }
+    if (manager.remoteLocalStatsInterval) {
+      clearInterval(manager.remoteLocalStatsInterval);
+      manager.remoteLocalStatsInterval = null;
+    }
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function startScheduler(minutes: number) {
+    manager.remoteLocalStatsIntervalMinutes = minutes;
+    const fn = manager['startRemoteLocalStatsScheduler'].bind(manager);
+    fn();
+  }
+
+  it('does not call requestRemoteLocalStats when TX is disabled, but keeps the interval running', async () => {
+    manager.actualDeviceConfig = { lora: { txEnabled: false } };
+
+    startScheduler(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(manager.requestRemoteLocalStats).not.toHaveBeenCalled();
+    expect(manager.remoteLocalStatsInterval).not.toBeNull();
+  });
+
+  it('calls requestRemoteLocalStats once TX is re-enabled on a later tick', async () => {
+    manager.actualDeviceConfig = { lora: { txEnabled: false } };
+
+    startScheduler(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(manager.requestRemoteLocalStats).not.toHaveBeenCalled();
+
+    manager.actualDeviceConfig = { lora: { txEnabled: true } };
+    manager.lastRemoteLocalStatsSentTime = 0;
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+
+    expect(manager.requestRemoteLocalStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls requestRemoteLocalStats normally when TX is enabled', async () => {
+    manager.actualDeviceConfig = { lora: { txEnabled: true } };
+
+    startScheduler(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(manager.requestRemoteLocalStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/meshtasticManager.tracerouteScheduler.test.ts
+++ b/src/server/meshtasticManager.tracerouteScheduler.test.ts
@@ -406,4 +406,58 @@ describe('MeshtasticManager - Traceroute Scheduler', () => {
       expect(manager.tracerouteInterval).not.toBeNull();
     });
   });
+
+  describe('TX-disabled skip (#4294 WP3)', () => {
+    it('does not call sendTraceroute when TX is disabled, but keeps the interval running', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      manager.lastTracerouteSentTime = 0;
+
+      startScheduler(1);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(manager.sendTraceroute).not.toHaveBeenCalled();
+      // The interval itself must still be armed so a later TX re-enable resumes.
+      expect(manager.tracerouteInterval).not.toBeNull();
+    });
+
+    it('calls sendTraceroute once TX is re-enabled on a later tick', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      manager.lastTracerouteSentTime = 0;
+
+      startScheduler(1);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(manager.sendTraceroute).not.toHaveBeenCalled();
+
+      // TX comes back on before the next tick.
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      manager.lastTracerouteSentTime = 0;
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(manager.sendTraceroute).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls sendTraceroute normally when TX is enabled', async () => {
+      manager.actualDeviceConfig = { lora: { txEnabled: true } };
+      manager.lastTracerouteSentTime = 0;
+
+      startScheduler(1);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(manager.sendTraceroute).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not log at error level across repeated ticks while TX is disabled', async () => {
+      const { logger } = await import('../utils/logger.js');
+      manager.actualDeviceConfig = { lora: { txEnabled: false } };
+      manager.lastTracerouteSentTime = 0;
+
+      startScheduler(1);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(manager.sendTraceroute).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -38,6 +38,7 @@ import { waypointService } from './services/waypointService.js';
 import type { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
 import { MessageQueueService } from './messageQueueService.js';
 import { resolveAutoWelcomeDelaySeconds } from './autoWelcomeDelay.js';
+import { TxDisabledError } from './errors/txDisabledError.js';
 import { resolveAutoAckPreSendDelaySeconds } from './autoAckDelay.js';
 import { normalizeTriggerPatterns, normalizeTriggerChannels } from '../utils/autoResponderUtils.js';
 import { matchAutoResponderPattern } from './utils/autoResponderMatcher.js';
@@ -4262,8 +4263,19 @@ class MeshtasticManager implements ISourceManager {
             logger.debug(`📊 Position config after Proto3 defaults: positionBroadcastSecs=${parsed.data.position.positionBroadcastSecs}, positionBroadcastSmartEnabled=${parsed.data.position.positionBroadcastSmartEnabled}, fixedPosition=${parsed.data.position.fixedPosition}`);
           }
 
-          // Merge the actual device configuration (don't overwrite)
-          this.actualDeviceConfig = { ...this.actualDeviceConfig, ...parsed.data };
+          // Merge the actual device configuration (don't overwrite).
+          // Block-scoped (no-case-declarations): this `case` clause has no
+          // braces of its own, so `const` here needs an explicit block.
+          {
+            const prevTxEnabled = this.actualDeviceConfig?.lora?.txEnabled !== false;
+            this.actualDeviceConfig = { ...this.actualDeviceConfig, ...parsed.data };
+            const nextTxEnabled = this.actualDeviceConfig?.lora?.txEnabled !== false;
+            if (prevTxEnabled !== nextTxEnabled) {
+              logger.info(nextTxEnabled
+                ? `📡 [${this.sourceId}] TX re-enabled — autonomous senders resume`
+                : `🚫 [${this.sourceId}] TX disabled — pausing autonomous senders (node is now receive-only)`);
+            }
+          }
           logger.debug('📊 Merged actualDeviceConfig now has keys:', Object.keys(this.actualDeviceConfig));
           logger.debug('📊 actualDeviceConfig.lora present:', !!this.actualDeviceConfig?.lora);
           if (parsed.data.lora) {
@@ -8752,6 +8764,15 @@ class MeshtasticManager implements ISourceManager {
   }
 
 
+  /**
+   * Current transmit state for THIS source, read from the in-memory device config.
+   * Defaults to true when config hasn't arrived yet (fail-open: don't block sends
+   * before we know the radio's state). No DB access — safe to call per packet.
+   */
+  isTxEnabled(): boolean {
+    return this.actualDeviceConfig?.lora?.txEnabled !== false;
+  }
+
   // Configuration retrieval methods
   async getDeviceConfig(): Promise<any> {
     // Return config data from what we've received via TCP stream
@@ -8772,6 +8793,10 @@ class MeshtasticManager implements ISourceManager {
   async sendTextMessage(text: string, channel: number = 0, destination?: number, replyId?: number, emoji?: number, userId?: number, attribution?: { sourceIp?: string | null; sourcePath?: 'http_api' | 'tcp_radio' | 'mqtt_bridge' | 'system' | null }): Promise<number> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
+    }
+
+    if (!this.isTxEnabled()) {
+      throw new TxDisabledError();
     }
 
     try {
@@ -8941,6 +8966,10 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
+    if (!this.isTxEnabled()) {
+      throw new TxDisabledError();
+    }
+
     if (!this.localNodeInfo) {
       throw new Error('Local node information not available');
     }
@@ -8987,6 +9016,10 @@ class MeshtasticManager implements ISourceManager {
   async sendPositionRequest(destination: number, channel: number = 0): Promise<{ packetId: number; requestId: number }> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
+    }
+
+    if (!this.isTxEnabled()) {
+      throw new TxDisabledError();
     }
 
     if (!this.localNodeInfo) {
@@ -9064,6 +9097,10 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
+    if (!this.isTxEnabled()) {
+      throw new TxDisabledError();
+    }
+
     if (!this.localNodeInfo) {
       throw new Error('Local node information not available');
     }
@@ -9131,6 +9168,10 @@ class MeshtasticManager implements ISourceManager {
   async sendNeighborInfoRequest(destination: number, channel: number = 0): Promise<{ packetId: number; requestId: number }> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
+    }
+
+    if (!this.isTxEnabled()) {
+      throw new TxDisabledError();
     }
 
     if (!this.localNodeInfo) {
@@ -9358,6 +9399,10 @@ class MeshtasticManager implements ISourceManager {
   ): Promise<{ packetId: number; requestId: number }> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
+    }
+
+    if (!this.isTxEnabled()) {
+      throw new TxDisabledError();
     }
 
     if (!this.localNodeInfo) {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2226,6 +2226,13 @@ class MeshtasticManager implements ISourceManager {
 
     // The traceroute execution logic
     const executeTraceroute = async () => {
+      // TX-disabled radios cannot send OTA traceroutes; skip quietly and let the
+      // interval keep running so a later TX re-enable resumes automatically (#4294).
+      if (!this.isTxEnabled()) {
+        logger.debug('🗺️ Auto-traceroute: Skipping - TX disabled on this source');
+        return;
+      }
+
       // Check time window schedule (per-source — written by AutoTracerouteSection
       // via /api/settings?sourceId=, so must be read with getSettingForSource).
       const scheduleEnabled = await databaseService.settings.getSettingForSource(this.sourceId, 'tracerouteScheduleEnabled');
@@ -2381,6 +2388,13 @@ class MeshtasticManager implements ISourceManager {
     logger.debug(`📊 Starting remote LocalStats scheduler with ${this.remoteLocalStatsIntervalMinutes} minute interval (initial jitter: ${Math.round(initialJitterMs / 1000)}s)`);
 
     const executeRemoteLocalStats = async () => {
+      // TX-disabled radios cannot send remote telemetry requests; skip quietly and
+      // let the interval keep running so a later TX re-enable resumes automatically (#4294).
+      if (!this.isTxEnabled()) {
+        logger.debug('📊 Remote LocalStats: Skipping - TX disabled on this source');
+        return;
+      }
+
       // Per-source schedule window (written by AutoLocalStatsSection via
       // /api/settings?sourceId=, so read with getSettingForSource).
       const scheduleEnabled = await databaseService.settings.getSettingForSource(this.sourceId, 'remoteLocalStatsScheduleEnabled');
@@ -2646,6 +2660,13 @@ class MeshtasticManager implements ISourceManager {
     logger.debug(`🔑 Starting remote admin scanner with ${this.remoteAdminScannerIntervalMinutes} minute interval`);
 
     this.remoteAdminScannerInterval = setInterval(async () => {
+      // TX-disabled radios cannot send remote admin packets; skip quietly and let
+      // the interval keep running so a later TX re-enable resumes automatically (#4294).
+      if (!this.isTxEnabled()) {
+        logger.debug('🔑 Remote admin scanner: Skipping - TX disabled on this source');
+        return;
+      }
+
       // Check time window schedule
       const scheduleEnabled = await databaseService.settings.getSettingForSource(this.sourceId, 'remoteAdminScheduleEnabled');
       if (scheduleEnabled === 'true') {
@@ -2880,6 +2901,13 @@ class MeshtasticManager implements ISourceManager {
   private async processKeyRepairs(): Promise<void> {
     if (this.rebootMergeInProgress) {
       logger.debug('🔐 Key repair: skipping - reboot merge in progress');
+      return;
+    }
+
+    // TX-disabled radios cannot send NodeInfo exchanges; skip quietly and let the
+    // interval keep running so a later TX re-enable resumes automatically (#4294).
+    if (!this.isTxEnabled()) {
+      logger.debug('🔐 Key repair: Skipping - TX disabled on this source');
       return;
     }
 
@@ -3274,6 +3302,12 @@ class MeshtasticManager implements ISourceManager {
       // Schedule the cron job
       const job = scheduleCron(trigger.cronExpression, async () => {
         logger.debug(`⏱️ Timer "${trigger.name}" triggered (cron: ${trigger.cronExpression})`);
+        // TX-disabled radios cannot send the timer's mesh output; skip quietly and
+        // let the cron job keep running so a later TX re-enable resumes automatically (#4294).
+        if (!this.isTxEnabled()) {
+          logger.debug(`⏱️ Timer "${trigger.name}": Skipping - TX disabled on this source`);
+          return;
+        }
         // Airtime cutoff: skip timer automations while the mesh is congested
         if (await this.isAutomationAirtimeGated()) {
           return;
@@ -9766,6 +9800,12 @@ class MeshtasticManager implements ISourceManager {
         return;
       }
 
+      // TX-disabled radios cannot send the ack reply; skip quietly (#4294).
+      if (!this.isTxEnabled()) {
+        logger.debug('⏭️ Skipping auto-acknowledge - TX disabled on this source');
+        return;
+      }
+
       // Airtime cutoff: skip while the mesh is congested
       if (await this.isAutomationAirtimeGated()) {
         return;
@@ -10085,6 +10125,13 @@ class MeshtasticManager implements ISourceManager {
       return false;
     }
 
+    // TX-disabled radios cannot send ping replies; skip quietly rather than
+    // letting sendTextMessage throw TxDisabledError partway through (#4294).
+    if (!this.isTxEnabled()) {
+      logger.debug('⏭️  Auto-ping command received but TX is disabled on this source');
+      return false;
+    }
+
     // Airtime cutoff: skip auto-ping while the mesh is congested
     if (await this.isAutomationAirtimeGated()) {
       return false;
@@ -10186,6 +10233,12 @@ class MeshtasticManager implements ISourceManager {
    * Send the next ping in the auto-ping session
    */
   private async sendNextAutoPing(session: AutoPingSession): Promise<void> {
+    // TX-disabled radios cannot send pings; skip this tick quietly and leave the
+    // session's interval running so it resumes automatically on TX re-enable (#4294).
+    if (!this.isTxEnabled()) {
+      return;
+    }
+
     // Check if session is complete — send summary as the final message
     if (session.completedPings >= session.totalPings) {
       void this.finalizeAutoPingSession(session.requestedBy);
@@ -10489,6 +10542,12 @@ class MeshtasticManager implements ISourceManager {
 
       // Skip if auto-responder is disabled
       if (autoResponderEnabled !== 'true') {
+        return;
+      }
+
+      // TX-disabled radios cannot send the auto-responder reply; skip quietly (#4294).
+      if (!this.isTxEnabled()) {
+        logger.debug('⏭️ Skipping auto-responder - TX disabled on this source');
         return;
       }
 

--- a/src/server/meshtasticManager.txDisabled.test.ts
+++ b/src/server/meshtasticManager.txDisabled.test.ts
@@ -1,0 +1,259 @@
+/**
+ * TX-disabled transmit guard (#4294 epic, Phase 1 WP1).
+ *
+ * `lora.txEnabled === false` is a hard radio kill switch reported by the
+ * device's own config. `isTxEnabled()` reads it from the in-memory
+ * `actualDeviceConfig` (default true when unknown/absent — fail-open so we
+ * never block sends before the first config frame arrives). Each of the six
+ * OTA send primitives throws `TxDisabledError` immediately after the
+ * existing "not connected" check, before doing any other work — so these
+ * tests only need `isConnected`/`transport` seeded, not a full send-path
+ * mock, to prove the guard fires (and doesn't fire) at the right times.
+ *
+ * See docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md §2-4.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the VirtualNodeServer so tests never bind a real TCP port
+const { VNConstructor } = vi.hoisted(() => ({
+  VNConstructor: vi.fn(function (this: any, _opts: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    messages: {
+      insertMessage: vi.fn().mockResolvedValue(true),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+    markMessageAsReadAsync: vi.fn().mockResolvedValue(true),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array()),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array()),
+    createTextMessage: vi.fn(() => ({ data: new Uint8Array([1, 2, 3]), messageId: 12345 })),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+vi.mock('./services/packetLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+  packetLogService: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { MeshtasticManager } from './meshtasticManager.js';
+import { isTxDisabledError } from './errors/txDisabledError.js';
+
+/** Seeds the minimal private state each primitive's early checks read. */
+function makeReadyManager(): MeshtasticManager {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).transport = { send: vi.fn().mockResolvedValue(undefined) };
+  (mgr as any).isConnected = true;
+  (mgr as any).localNodeInfo = {
+    nodeNum: 0x0badbeef,
+    nodeId: '!0badbeef',
+    longName: 'Local Node',
+    shortName: 'LOCL',
+  };
+  return mgr;
+}
+
+/**
+ * The guard is the only thing under test here — downstream send logic isn't
+ * fully mocked for every primitive, so a non-TxDisabledError failure past
+ * the guard is an acceptable (and expected) outcome for the "TX enabled"
+ * cases. What matters is that the guard itself never fires.
+ */
+async function expectNotBlockedByTxGuard(fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(isTxDisabledError(error)).toBe(false);
+  }
+}
+
+describe('MeshtasticManager — TX-disabled transmit guard (#4294 WP1)', () => {
+  beforeEach(() => {
+    VNConstructor.mockClear();
+  });
+
+  describe('isTxEnabled()', () => {
+    it('defaults to true when no device config has arrived yet', () => {
+      const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+      expect((mgr as any).actualDeviceConfig).toBeNull();
+      expect(mgr.isTxEnabled()).toBe(true);
+    });
+
+    it('returns true when lora.txEnabled is undefined (Proto3 default)', () => {
+      const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+      (mgr as any).actualDeviceConfig = { lora: {} };
+      expect(mgr.isTxEnabled()).toBe(true);
+    });
+
+    it('returns true when lora.txEnabled is explicitly true', () => {
+      const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: true } };
+      expect(mgr.isTxEnabled()).toBe(true);
+    });
+
+    it('returns false when lora.txEnabled is explicitly false', () => {
+      const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      expect(mgr.isTxEnabled()).toBe(false);
+    });
+  });
+
+  describe('primitive guards — throw TxDisabledError when TX is off', () => {
+    it('sendTextMessage', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendTextMessage('hi', 0)).rejects.toMatchObject({ isTxDisabledError: true, code: 'TX_DISABLED' });
+    });
+
+    it('sendTraceroute', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendTraceroute(0x11111111, 0)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('sendPositionRequest', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendPositionRequest(0x11111111, 0)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('sendNodeInfoRequest', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendNodeInfoRequest(0x11111111, 0)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('sendNeighborInfoRequest', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendNeighborInfoRequest(0x11111111, 0)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('sendTelemetryRequest', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendTelemetryRequest(0x11111111, 0)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('guard fires before the "not connected" checks matter — still requires isConnected/transport first', async () => {
+      const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+      // Not connected at all — should get the pre-existing connection error, not TxDisabledError.
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: false } };
+      await expect(mgr.sendTextMessage('hi', 0)).rejects.toThrow('Not connected to Meshtastic node');
+    });
+  });
+
+  describe('primitive guards — do not block when TX is enabled or unknown', () => {
+    it('sendTextMessage — txEnabled true', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: true } };
+      await expectNotBlockedByTxGuard(() => mgr.sendTextMessage('hi', 0));
+    });
+
+    it('sendTextMessage — txEnabled undefined (config not yet known)', async () => {
+      const mgr = makeReadyManager();
+      await expectNotBlockedByTxGuard(() => mgr.sendTextMessage('hi', 0));
+    });
+
+    it('sendTraceroute — txEnabled true', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: true } };
+      await expectNotBlockedByTxGuard(() => mgr.sendTraceroute(0x11111111, 0));
+    });
+
+    it('sendPositionRequest — txEnabled undefined', async () => {
+      const mgr = makeReadyManager();
+      await expectNotBlockedByTxGuard(() => mgr.sendPositionRequest(0x11111111, 0));
+    });
+
+    it('sendNodeInfoRequest — txEnabled true', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: true } };
+      await expectNotBlockedByTxGuard(() => mgr.sendNodeInfoRequest(0x11111111, 0));
+    });
+
+    it('sendNeighborInfoRequest — txEnabled undefined', async () => {
+      const mgr = makeReadyManager();
+      await expectNotBlockedByTxGuard(() => mgr.sendNeighborInfoRequest(0x11111111, 0));
+    });
+
+    it('sendTelemetryRequest — txEnabled true', async () => {
+      const mgr = makeReadyManager();
+      (mgr as any).actualDeviceConfig = { lora: { txEnabled: true } };
+      await expectNotBlockedByTxGuard(() => mgr.sendTelemetryRequest(0x11111111, 0));
+    });
+  });
+
+  describe('config-merge state-change logging (§2)', () => {
+    it('flips isTxEnabled() as actualDeviceConfig.lora.txEnabled changes across merges', () => {
+      const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+      expect(mgr.isTxEnabled()).toBe(true);
+
+      // Simulate the merge point's assignment directly (the FromRadio parsing
+      // path itself is covered elsewhere; this asserts the accessor tracks
+      // the merged field, which is what the state-change log branches on).
+      (mgr as any).actualDeviceConfig = { ...(mgr as any).actualDeviceConfig, lora: { txEnabled: false } };
+      expect(mgr.isTxEnabled()).toBe(false);
+
+      (mgr as any).actualDeviceConfig = { ...(mgr as any).actualDeviceConfig, lora: { txEnabled: true } };
+      expect(mgr.isTxEnabled()).toBe(true);
+    });
+  });
+});

--- a/src/server/routes/adminRoutes.test.ts
+++ b/src/server/routes/adminRoutes.test.ts
@@ -12,6 +12,7 @@ import adminRoutes from './adminRoutes.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 import { sourceManagerRegistry, type ISourceManager } from '../sourceManagerRegistry.js';
 import { TxDisabledError } from '../errors/txDisabledError.js';
+import protobufService from '../protobufService.js';
 
 // channelUrlService is dynamically imported inside export-config/import-config —
 // mock it so those handlers don't need a real base64url-encoded channel blob.
@@ -129,6 +130,11 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
       getLocalNodeInfo: vi.fn().mockReturnValue({ nodeNum: 1, nodeId: '!00000001', longName: 'Local', shortName: 'LOC' }),
       startDistanceDeleteScheduler: vi.fn().mockResolvedValue(undefined),
       stopDistanceDeleteScheduler: vi.fn(),
+      // Fail-open default, matching the real MeshtasticManager.isTxEnabled().
+      isTxEnabled: vi.fn().mockReturnValue(true),
+      // No cached remote-config snapshot by default (matches a manager that
+      // has never run requestRemoteConfig(LORA_CONFIG) for this node).
+      getRemoteNodeConfig: vi.fn().mockReturnValue(null),
       ...overrides,
     } as unknown as ISourceManager;
   }
@@ -196,11 +202,18 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
     );
   });
 
-  it('POST /import-config (local node) strips txEnabled from the decoded LoRa config before setLoRaConfig', async () => {
+  // setLoRaConfig sends the device the ENTIRE LoRaConfig struct (whole-message
+  // replace, not a patch), and proto3 decodes an omitted bool as false — so
+  // the decoded URL's txEnabled must be overridden with the device's actual
+  // current value (backfilled via isTxEnabled()), never stripped/omitted.
+  // Stripping the key here would have silently sent txEnabled=false to a
+  // TX-enabled device (#4294 regression this test locks in).
+  it('POST /import-config (local node) overrides the decoded txEnabled with the device actual value before setLoRaConfig', async () => {
     const setLoRaConfig = vi.fn().mockResolvedValue(undefined);
     const beginEditSettings = vi.fn().mockResolvedValue(undefined);
     const commitEditSettings = vi.fn().mockResolvedValue(undefined);
-    await sourceManagerRegistry.addManager(makeFakeManager({ setLoRaConfig, beginEditSettings, commitEditSettings }));
+    const isTxEnabled = vi.fn().mockReturnValue(false);
+    await sourceManagerRegistry.addManager(makeFakeManager({ setLoRaConfig, beginEditSettings, commitEditSettings, isTxEnabled }));
 
     const channelUrlService = (await import('../services/channelUrlService.js')).default;
     (channelUrlService.decodeUrl as any).mockReturnValue({
@@ -218,7 +231,121 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
     expect(res.status).toBe(200);
     expect(setLoRaConfig).toHaveBeenCalledTimes(1);
     const [calledWith] = setLoRaConfig.mock.calls[0];
-    expect(calledWith).not.toHaveProperty('txEnabled');
-    expect(calledWith).toMatchObject({ hopLimit: 3, txPower: 20 });
+    // Device's actual current txEnabled (false) wins over the decoded URL's
+    // value (true).
+    expect(calledWith).toMatchObject({ hopLimit: 3, txPower: 20, txEnabled: false });
+  });
+
+  it('POST /import-config (local node) backfills txEnabled:true when the device currently has transmit enabled', async () => {
+    const setLoRaConfig = vi.fn().mockResolvedValue(undefined);
+    const beginEditSettings = vi.fn().mockResolvedValue(undefined);
+    const commitEditSettings = vi.fn().mockResolvedValue(undefined);
+    const isTxEnabled = vi.fn().mockReturnValue(true);
+    await sourceManagerRegistry.addManager(makeFakeManager({ setLoRaConfig, beginEditSettings, commitEditSettings, isTxEnabled }));
+
+    const channelUrlService = (await import('../services/channelUrlService.js')).default;
+    (channelUrlService.decodeUrl as any).mockReturnValue({
+      channels: undefined,
+      loraConfig: { hopLimit: 3 },
+    });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/import-config').send({
+      sourceId: harness.sourceA,
+      nodeNum: 1,
+      url: 'meshtastic://mock',
+    });
+
+    expect(res.status).toBe(200);
+    const [calledWith] = setLoRaConfig.mock.calls[0];
+    expect(calledWith).toMatchObject({ hopLimit: 3, txEnabled: true });
+  });
+
+  describe('POST /import-config (remote node) — best-effort txEnabled preserve', () => {
+    // The remote branch has no local isTxEnabled() to consult; it prefers a
+    // cached remote-config snapshot (getRemoteNodeConfig), falling back to
+    // the decoded URL's own txEnabled, and finally to true (fail-open).
+    // createSetLoRaConfigMessage is real (not mocked) — spy on it to inspect
+    // the exact config object it received before protobuf-encoding, since
+    // sendAdminCommand only sees opaque encoded bytes.
+
+    it('uses the cached remote-config snapshot when available, overriding the decoded value', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      const getRemoteNodeConfig = vi.fn().mockReturnValue({
+        deviceConfig: { lora: { txEnabled: false } },
+        moduleConfig: {},
+        lastUpdated: Date.now(),
+      });
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, getRemoteNodeConfig }));
+
+      const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: undefined,
+        loraConfig: { hopLimit: 3, txEnabled: true },
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/import-config').send({
+        sourceId: harness.sourceA,
+        nodeNum: 999, // remote — does not match getLocalNodeInfo().nodeNum (1)
+        url: 'meshtastic://mock',
+      });
+
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
+      spy.mockRestore();
+    });
+
+    it('falls back to the decoded URL txEnabled when no cached remote config exists', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      const getRemoteNodeConfig = vi.fn().mockReturnValue(null);
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, getRemoteNodeConfig }));
+
+      const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: undefined,
+        loraConfig: { hopLimit: 3, txEnabled: false },
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/import-config').send({
+        sourceId: harness.sourceA,
+        nodeNum: 999,
+        url: 'meshtastic://mock',
+      });
+
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
+      spy.mockRestore();
+    });
+
+    it('falls back to true (fail-open) when neither a cached remote config nor a decoded txEnabled exists', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      const getRemoteNodeConfig = vi.fn().mockReturnValue(null);
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, getRemoteNodeConfig }));
+
+      const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: undefined,
+        loraConfig: { hopLimit: 3 },
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/import-config').send({
+        sourceId: harness.sourceA,
+        nodeNum: 999,
+        url: 'meshtastic://mock',
+      });
+
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
+      spy.mockRestore();
+    });
   });
 });

--- a/src/server/routes/adminRoutes.test.ts
+++ b/src/server/routes/adminRoutes.test.ts
@@ -7,9 +7,20 @@
  * requireAdmin() gate plus one representative body-handling endpoint, via the
  * route-test harness (createRouteTestApp).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import adminRoutes from './adminRoutes.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { sourceManagerRegistry, type ISourceManager } from '../sourceManagerRegistry.js';
+import { TxDisabledError } from '../errors/txDisabledError.js';
+
+// channelUrlService is dynamically imported inside export-config/import-config —
+// mock it so those handlers don't need a real base64url-encoded channel blob.
+vi.mock('../services/channelUrlService.js', () => ({
+  default: {
+    decodeUrl: vi.fn(),
+    encodeUrl: vi.fn().mockReturnValue('meshtastic://mock-url'),
+  },
+}));
 
 describe('adminRoutes — requireAdmin() gate', () => {
   let harness: RouteTestHarness;
@@ -100,5 +111,114 @@ describe('adminRoutes — PUT /auto-favorite-targets/:nodeNum (body-handling)', 
       intervalHours: 6,
       eligibleRoles: [2, 11],
     });
+  });
+});
+
+describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)', () => {
+  let harness: RouteTestHarness;
+
+  // Minimal ISourceManager stub registered under harness.sourceA so
+  // resolveSourceManager() finds it instead of the unconfigured fallbackManager.
+  function makeFakeManager(overrides: Record<string, unknown>): ISourceManager {
+    return {
+      sourceId: harness.sourceA,
+      sourceType: 'meshtastic_tcp',
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockReturnValue({ sourceId: harness.sourceA, sourceName: 'Source A', sourceType: 'meshtastic_tcp', connected: true }),
+      getLocalNodeInfo: vi.fn().mockReturnValue({ nodeNum: 1, nodeId: '!00000001', longName: 'Local', shortName: 'LOC' }),
+      startDistanceDeleteScheduler: vi.fn().mockResolvedValue(undefined),
+      stopDistanceDeleteScheduler: vi.fn(),
+      ...overrides,
+    } as unknown as ISourceManager;
+  }
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', adminRoutes),
+    });
+  });
+
+  afterEach(async () => {
+    await sourceManagerRegistry.removeManager(harness.sourceA);
+    await harness.cleanup();
+  });
+
+  it('POST /reboot returns 409 TX_DISABLED when the remote target has transmit disabled', async () => {
+    const sendRebootCommand = vi.fn().mockRejectedValue(new TxDisabledError());
+    await sourceManagerRegistry.addManager(makeFakeManager({ sendRebootCommand }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/reboot').send({ sourceId: harness.sourceA, nodeNum: 999 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
+  });
+
+  it('POST /set-time returns 409 TX_DISABLED when the remote target has transmit disabled', async () => {
+    const sendSetTimeCommand = vi.fn().mockRejectedValue(new TxDisabledError());
+    await sourceManagerRegistry.addManager(makeFakeManager({ sendSetTimeCommand }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/set-time').send({ sourceId: harness.sourceA, nodeNum: 999 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
+  });
+
+  it('POST /export-config emits the device actual txEnabled instead of forcing true', async () => {
+    const getDeviceConfig = vi.fn().mockResolvedValue({
+      lora: { usePreset: true, modemPreset: 0, bandwidth: 0, spreadFactor: 0, codingRate: 0,
+        frequencyOffset: 0, region: 1, hopLimit: 3, txEnabled: false, txPower: 0,
+        channelNum: 0, sx126xRxBoostedGain: false, configOkToMqtt: false },
+    });
+    await sourceManagerRegistry.addManager(makeFakeManager({ getDeviceConfig }));
+    await harness.db.channels.upsertChannel(
+      { id: 0, name: 'Primary', psk: 'AQ==', uplinkEnabled: false, downlinkEnabled: false, positionPrecision: 32 },
+      harness.sourceA,
+    );
+
+    const channelUrlService = (await import('../services/channelUrlService.js')).default;
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/export-config').send({
+      sourceId: harness.sourceA,
+      channelIds: [0],
+      includeLoraConfig: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(channelUrlService.encodeUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ txEnabled: false }),
+    );
+  });
+
+  it('POST /import-config (local node) strips txEnabled from the decoded LoRa config before setLoRaConfig', async () => {
+    const setLoRaConfig = vi.fn().mockResolvedValue(undefined);
+    const beginEditSettings = vi.fn().mockResolvedValue(undefined);
+    const commitEditSettings = vi.fn().mockResolvedValue(undefined);
+    await sourceManagerRegistry.addManager(makeFakeManager({ setLoRaConfig, beginEditSettings, commitEditSettings }));
+
+    const channelUrlService = (await import('../services/channelUrlService.js')).default;
+    (channelUrlService.decodeUrl as any).mockReturnValue({
+      channels: undefined,
+      loraConfig: { hopLimit: 3, txEnabled: true, txPower: 20 },
+    });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/import-config').send({
+      sourceId: harness.sourceA,
+      nodeNum: 1, // local node — matches getLocalNodeInfo().nodeNum above
+      url: 'meshtastic://mock',
+    });
+
+    expect(res.status).toBe(200);
+    expect(setLoRaConfig).toHaveBeenCalledTimes(1);
+    const [calledWith] = setLoRaConfig.mock.calls[0];
+    expect(calledWith).not.toHaveProperty('txEnabled');
+    expect(calledWith).toMatchObject({ hopLimit: 3, txPower: 20 });
   });
 });

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -22,6 +22,8 @@ import { getRoutingErrorName } from '../constants/meshtastic.js';
 import { CONFIG_TYPE_MAP, MODULE_FIELD_BY_ID, DEVICE_FIELD_BY_ID } from '../constants/configTypes.js';
 import { autoFavoriteManagementScheduler } from '../services/autoFavoriteManagementService.js';
 import protobufService from '../protobufService.js';
+import { fail } from '../utils/apiResponse.js';
+import { isTxDisabledError } from '../errors/txDisabledError.js';
 
 const router = express.Router();
 
@@ -611,9 +613,13 @@ router.post('/load-config', requireAdmin(), async (req, res) => {
       }
 
       res.json({ config });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (isTxDisabledError(error)) {
+        return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+      }
+      const message = error instanceof Error ? error.message : String(error);
       logger.error(`Error loading ${configType} config:`, error);
-      res.status(500).json({ error: `Failed to load ${configType} config: ${error.message}` });
+      res.status(500).json({ error: `Failed to load ${configType} config: ${message}` });
     }
   } catch (error: any) {
     logger.error('Error in load-config endpoint:', error);
@@ -653,6 +659,9 @@ router.post('/ensure-session-passkey', requireAdmin(), async (req, res) => {
       ...status
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error ensuring session passkey:', error);
     res.status(500).json({ error: error.message || 'Failed to ensure session passkey' });
   }
@@ -772,6 +781,9 @@ router.post('/get-channel', requireAdmin(), async (req, res) => {
       }
     }
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error getting channel:', error);
     res.status(500).json({ error: error.message || 'Failed to get channel' });
   }
@@ -832,6 +844,9 @@ router.post('/load-owner', requireAdmin(), async (req, res) => {
       }
     }
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error getting owner:', error);
     res.status(500).json({ error: error.message || 'Failed to get owner info' });
   }
@@ -911,6 +926,9 @@ router.post('/get-device-metadata', requireAdmin(), async (req, res) => {
       }
     }
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error getting device metadata:', error);
     res.status(500).json({ error: error.message || 'Failed to get device metadata' });
   }
@@ -928,6 +946,9 @@ router.post('/reboot', requireAdmin(), async (req, res) => {
     logger.debug(`✅ Sent reboot command to node ${destinationNodeNum} (in ${seconds} seconds)`);
     res.json({ success: true, message: `Reboot command sent (node will reboot in ${seconds} seconds)` });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending reboot command:', error);
     res.status(500).json({ error: error.message || 'Failed to send reboot command' });
   }
@@ -969,6 +990,9 @@ router.post('/set-time', requireAdmin(), async (req, res) => {
     logger.debug(`✅ Sent set-time command to node ${destinationNodeNum}`);
     res.json({ success: true, message: 'Time sync command sent successfully' });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending set-time command:', error);
     res.status(500).json({ error: error.message || 'Failed to send set-time command' });
   }
@@ -1063,7 +1087,7 @@ router.post('/export-config', requireAdmin(), async (req, res) => {
             frequencyOffset: deviceConfig.lora.frequencyOffset,
             region: deviceConfig.lora.region,
             hopLimit: deviceConfig.lora.hopLimit,
-            txEnabled: true,
+            txEnabled: deviceConfig.lora.txEnabled,
             txPower: deviceConfig.lora.txPower,
             channelNum: deviceConfig.lora.channelNum,
             sx126xRxBoostedGain: deviceConfig.lora.sx126xRxBoostedGain,
@@ -1083,7 +1107,7 @@ router.post('/export-config', requireAdmin(), async (req, res) => {
             frequencyOffset: loraConfigData.frequencyOffset,
             region: loraConfigData.region,
             hopLimit: loraConfigData.hopLimit,
-            txEnabled: true,
+            txEnabled: loraConfigData.txEnabled,
             txPower: loraConfigData.txPower,
             channelNum: loraConfigData.channelNum,
             sx126xRxBoostedGain: loraConfigData.sx126xRxBoostedGain,
@@ -1101,6 +1125,9 @@ router.post('/export-config', requireAdmin(), async (req, res) => {
 
     res.json({ url });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error exporting configuration:', error);
     res.status(500).json({ error: 'Failed to export configuration' });
   }
@@ -1177,10 +1204,10 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       // Import LoRa config
       if (decoded.loraConfig) {
         try {
-          const loraConfigToImport = {
-            ...decoded.loraConfig,
-            txEnabled: true,
-          };
+          // Preserve the device's current txEnabled rather than forcing it on
+          // (issue #4294) — strip the imported value so the existing radio
+          // TX state survives a config import.
+          const { txEnabled: _importedTxEnabled, ...loraConfigToImport } = decoded.loraConfig;
           await aicManager.setLoRaConfig(loraConfigToImport);
           // Pacing: LoRa config triggers heavier device processing; allow extra time
           // before commit so the device has finished applying it.
@@ -1236,10 +1263,9 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       // Import LoRa config using admin command
       if (decoded.loraConfig) {
         try {
-          const loraConfigToImport = {
-            ...decoded.loraConfig,
-            txEnabled: true,
-          };
+          // Preserve the remote device's current txEnabled rather than forcing
+          // it on (issue #4294) — strip the imported value.
+          const { txEnabled: _importedTxEnabled, ...loraConfigToImport } = decoded.loraConfig;
           const adminMessage = protobufService.createSetLoRaConfigMessage(loraConfigToImport, sessionPasskey);
           await aicManager.sendAdminCommand(adminMessage, destinationNodeNum);
           loraImported = true;
@@ -1260,6 +1286,9 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       requiresReboot,
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error importing configuration:', error);
     res.status(500).json({ error: error.message || 'Failed to import configuration' });
   }
@@ -1569,6 +1598,9 @@ router.post('/commands', requireAdmin(), async (req, res) => {
       } : {})
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error executing admin command:', error);
     res.status(500).json({ error: error.message || 'Failed to execute admin command' });
   }

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -1204,10 +1204,18 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       // Import LoRa config
       if (decoded.loraConfig) {
         try {
-          // Preserve the device's current txEnabled rather than forcing it on
-          // (issue #4294) — strip the imported value so the existing radio
-          // TX state survives a config import.
-          const { txEnabled: _importedTxEnabled, ...loraConfigToImport } = decoded.loraConfig;
+          // Preserve the device's current txEnabled rather than importing the
+          // URL's value (issue #4294) — local-node import via setLoRaConfig,
+          // which sends the device the ENTIRE LoRaConfig struct (whole-message
+          // replace, not a patch). proto3 decodes an omitted bool as false, so
+          // stripping the key would silently reach the radio as
+          // txEnabled=false and kill TX (the #1328 mechanism that motivated
+          // the original, overly-broad force-true). Backfill explicitly with
+          // the device's actual current value instead.
+          const loraConfigToImport = {
+            ...decoded.loraConfig,
+            txEnabled: aicManager.isTxEnabled(),
+          };
           await aicManager.setLoRaConfig(loraConfigToImport);
           // Pacing: LoRa config triggers heavier device processing; allow extra time
           // before commit so the device has finished applying it.
@@ -1263,9 +1271,35 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       // Import LoRa config using admin command
       if (decoded.loraConfig) {
         try {
-          // Preserve the remote device's current txEnabled rather than forcing
-          // it on (issue #4294) — strip the imported value.
-          const { txEnabled: _importedTxEnabled, ...loraConfigToImport } = decoded.loraConfig;
+          // Preserve the remote device's current txEnabled rather than
+          // importing the URL's value (issue #4294) — same whole-struct-
+          // replace / proto3-missing-bool-defaults-to-false hazard as the
+          // local branch above (setLoRaConfig / createSetLoRaConfigMessage
+          // sends the ENTIRE LoRaConfig; an omitted key reaches the radio as
+          // txEnabled=false), so we must supply an explicit value, never
+          // strip the key.
+          //
+          // Best-effort remote preserve: use the manager's cached remote-config
+          // snapshot (populated only if requestRemoteConfig(LORA_CONFIG) was
+          // called for this node earlier — e.g. via /load-config or
+          // /export-config with includeLoraConfig). This import flow does not
+          // itself fetch the remote node's current LoRa config first — that
+          // would need an extra requestRemoteConfig round-trip (session
+          // passkey + mesh RTT) not currently part of this flow. Falls back to
+          // the decoded URL's own txEnabled (real since #4294's export fix;
+          // older exported URLs may still carry the old forced `true`), and
+          // finally to true (fail-open) if that's absent too.
+          // TODO(#4294 follow-up): a fully-accurate remote preserve would
+          // fetch the remote node's live LoRa config via requestRemoteConfig
+          // before importing.
+          const cachedRemoteLora = aicManager.getRemoteNodeConfig(destinationNodeNum)?.deviceConfig?.lora;
+          const remoteTxEnabled = cachedRemoteLora?.txEnabled !== undefined
+            ? cachedRemoteLora.txEnabled
+            : (decoded.loraConfig.txEnabled ?? true);
+          const loraConfigToImport = {
+            ...decoded.loraConfig,
+            txEnabled: remoteTxEnabled,
+          };
           const adminMessage = protobufService.createSetLoRaConfigMessage(loraConfigToImport, sessionPasskey);
           await aicManager.sendAdminCommand(adminMessage, destinationNodeNum);
           loraImported = true;

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -547,6 +547,20 @@ describe('POST /channels/encode-url', () => {
     expect(res.status).toBe(200);
     expect(res.body.url).toContain('meshtastic.org');
   });
+
+  it('emits the device actual txEnabled instead of forcing true (#4294)', async () => {
+    mockDb.channels.getChannelById.mockResolvedValue({ id: 0, name: 'Primary', psk: 'AQ==' });
+    mockManager.getDeviceConfig.mockResolvedValue({ lora: { region: 1, usePreset: true, txEnabled: false } });
+    mockChannelUrlService.encodeUrl.mockReturnValue('https://meshtastic.org/e/#encoded');
+    const res = await request(app)
+      .post('/channels/encode-url')
+      .send({ channelIds: [0], sourceId: 'src-1', includeLoraConfig: true });
+    expect(res.status).toBe(200);
+    expect(mockChannelUrlService.encodeUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ txEnabled: false }),
+    );
+  });
 });
 
 describe('POST /channels/import-config', () => {
@@ -575,6 +589,19 @@ describe('POST /channels/import-config', () => {
     expect(res.body.requiresReboot).toBe(true);
     expect(mockManager.beginEditSettings).toHaveBeenCalled();
     expect(mockManager.commitEditSettings).toHaveBeenCalled();
+  });
+
+  it('strips txEnabled from the decoded LoRa config before calling setLoRaConfig (#4294)', async () => {
+    mockChannelUrlService.decodeUrl.mockReturnValue({
+      channels: undefined,
+      loraConfig: { region: 1, hopLimit: 3, txEnabled: true },
+    });
+    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#ok', sourceId: 'src-1' });
+    expect(res.status).toBe(200);
+    expect(mockManager.setLoRaConfig).toHaveBeenCalledTimes(1);
+    const [calledWith] = mockManager.setLoRaConfig.mock.calls[0];
+    expect(calledWith).not.toHaveProperty('txEnabled');
+    expect(calledWith).toMatchObject({ region: 1, hopLimit: 3 });
   });
 });
 

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -11,6 +11,7 @@ const mockManager = vi.hoisted(() => ({
   commitEditSettings: vi.fn().mockResolvedValue(undefined),
   setLoRaConfig: vi.fn().mockResolvedValue(undefined),
   refreshNodeDatabase: vi.fn().mockResolvedValue(undefined),
+  isTxEnabled: vi.fn().mockReturnValue(true),
 }));
 vi.mock('../utils/resolveSourceManager.js', () => ({
   resolveSourceManager: vi.fn(() => mockManager),
@@ -591,7 +592,12 @@ describe('POST /channels/import-config', () => {
     expect(mockManager.commitEditSettings).toHaveBeenCalled();
   });
 
-  it('strips txEnabled from the decoded LoRa config before calling setLoRaConfig (#4294)', async () => {
+  // setLoRaConfig sends the device the ENTIRE LoRaConfig struct (whole-message
+  // replace, not a patch), and proto3 decodes an omitted bool as false — so the
+  // decoded URL's txEnabled must be overridden with the device's actual current
+  // value (backfilled via isTxEnabled()), never stripped/omitted (#4294).
+  it('overrides the decoded LoRa config txEnabled with the device actual value before calling setLoRaConfig (#4294)', async () => {
+    mockManager.isTxEnabled.mockReturnValue(false);
     mockChannelUrlService.decodeUrl.mockReturnValue({
       channels: undefined,
       loraConfig: { region: 1, hopLimit: 3, txEnabled: true },
@@ -600,8 +606,21 @@ describe('POST /channels/import-config', () => {
     expect(res.status).toBe(200);
     expect(mockManager.setLoRaConfig).toHaveBeenCalledTimes(1);
     const [calledWith] = mockManager.setLoRaConfig.mock.calls[0];
-    expect(calledWith).not.toHaveProperty('txEnabled');
-    expect(calledWith).toMatchObject({ region: 1, hopLimit: 3 });
+    // The device's actual current txEnabled (false) wins over the decoded
+    // URL's value (true) — the whole point of preserving current TX state.
+    expect(calledWith).toMatchObject({ region: 1, hopLimit: 3, txEnabled: false });
+  });
+
+  it('backfills txEnabled:true when the device currently has transmit enabled', async () => {
+    mockManager.isTxEnabled.mockReturnValue(true);
+    mockChannelUrlService.decodeUrl.mockReturnValue({
+      channels: undefined,
+      loraConfig: { region: 1, hopLimit: 3 },
+    });
+    const res = await request(app).post('/channels/import-config').send({ url: 'https://meshtastic.org/e/#ok', sourceId: 'src-1' });
+    expect(res.status).toBe(200);
+    const [calledWith] = mockManager.setLoRaConfig.mock.calls[0];
+    expect(calledWith).toMatchObject({ region: 1, hopLimit: 3, txEnabled: true });
   });
 });
 

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -1061,9 +1061,9 @@ router.post('/encode-url', requirePermission('configuration', 'read'), requireSo
           frequencyOffset: deviceConfig.lora.frequencyOffset,
           region: deviceConfig.lora.region,
           hopLimit: deviceConfig.lora.hopLimit,
-          // IMPORTANT: Always force txEnabled to true for exported configs
-          // This ensures that when someone imports the config, TX is always enabled
-          txEnabled: true,
+          // Emit the device's actual txEnabled (issue #4294) — exports should
+          // reflect the real radio state, not force TX on.
+          txEnabled: deviceConfig.lora.txEnabled,
           txPower: deviceConfig.lora.txPower,
           channelNum: deviceConfig.lora.channelNum,
           sx126xRxBoostedGain: deviceConfig.lora.sx126xRxBoostedGain,
@@ -1177,15 +1177,12 @@ router.post('/import-config', requirePermission('configuration', 'write'), requi
       try {
         logger.debug(`📥 Importing LoRa config:`, JSON.stringify(decoded.loraConfig, null, 2));
 
-        // IMPORTANT: Always force txEnabled to true
-        // MeshMonitor users need TX enabled to send messages
-        // Ignore any incoming configuration that tries to disable TX
-        const loraConfigToImport = {
-          ...decoded.loraConfig,
-          txEnabled: true,
-        };
+        // Preserve the device's current txEnabled rather than forcing it on
+        // (issue #4294) — strip the imported value so the existing radio TX
+        // state survives a config import.
+        const { txEnabled: _importedTxEnabled, ...loraConfigToImport } = decoded.loraConfig;
 
-        logger.debug(`📥 LoRa config with txEnabled defaulted: txEnabled=${loraConfigToImport.txEnabled}`);
+        logger.debug(`📥 LoRa config import (txEnabled preserved from device, not imported)`);
         await configImportManager.setLoRaConfig(loraConfigToImport);
         // LoRa config triggers heavier processing (frequency calculations, radio reconfiguration)
         // so allow extra time before committing

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -1177,12 +1177,21 @@ router.post('/import-config', requirePermission('configuration', 'write'), requi
       try {
         logger.debug(`📥 Importing LoRa config:`, JSON.stringify(decoded.loraConfig, null, 2));
 
-        // Preserve the device's current txEnabled rather than forcing it on
-        // (issue #4294) — strip the imported value so the existing radio TX
-        // state survives a config import.
-        const { txEnabled: _importedTxEnabled, ...loraConfigToImport } = decoded.loraConfig;
+        // Preserve the device's current txEnabled rather than importing the
+        // URL's value (issue #4294) — this is a local-node import.
+        //
+        // setLoRaConfig sends the ENTIRE LoRaConfig struct to the device (whole
+        // message replace, not a patch), and proto3 decodes an omitted bool as
+        // false. So we can't just strip the key — that would silently reach the
+        // radio as txEnabled=false and kill TX (the exact #1328 mechanism that
+        // motivated the original, overly-broad force-true). Explicitly backfill
+        // with the device's actual current value instead.
+        const loraConfigToImport = {
+          ...decoded.loraConfig,
+          txEnabled: configImportManager.isTxEnabled(),
+        };
 
-        logger.debug(`📥 LoRa config import (txEnabled preserved from device, not imported)`);
+        logger.debug(`📥 LoRa config import: txEnabled preserved from device = ${loraConfigToImport.txEnabled}`);
         await configImportManager.setLoRaConfig(loraConfigToImport);
         // LoRa config triggers heavier processing (frequency calculations, radio reconfiguration)
         // so allow extra time before committing

--- a/src/server/routes/configRoutes.test.ts
+++ b/src/server/routes/configRoutes.test.ts
@@ -8,9 +8,11 @@
  * setters moved out of server.ts into configRoutes.ts.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import configRoutes from './configRoutes.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { sourceManagerRegistry, type ISourceManager } from '../sourceManagerRegistry.js';
+import { TxDisabledError } from '../errors/txDisabledError.js';
 
 describe('configRoutes', () => {
   let harness: RouteTestHarness;
@@ -127,6 +129,85 @@ describe('configRoutes', () => {
       const res = await agent.post('/device').send({ nodeAddress: '1.2.3.4' });
       expect(res.status).not.toBe(403);
       expect(res.status).toBe(500);
+    });
+  });
+
+  describe('POST /lora — txEnabled passthrough (#4294)', () => {
+    // configRoutes resolves the manager via resolveSourceManager(), which reads
+    // the real sourceManagerRegistry. Register a minimal fake manager for
+    // harness.sourceA so we can assert on the exact payload forwarded to
+    // setLoRaConfig, instead of hitting the unconfigured fallbackManager (which
+    // always 500s with "Not connected").
+    let setLoRaConfig: ReturnType<typeof vi.fn>;
+    let requestModuleConfig: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      setLoRaConfig = vi.fn().mockResolvedValue(undefined);
+      requestModuleConfig = vi.fn().mockResolvedValue(undefined);
+      const fakeManager: ISourceManager & { setLoRaConfig: typeof setLoRaConfig; requestModuleConfig: typeof requestModuleConfig } = {
+        sourceId: harness.sourceA,
+        sourceType: 'meshtastic_tcp',
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn().mockReturnValue({ sourceId: harness.sourceA, sourceName: 'Source A', sourceType: 'meshtastic_tcp', connected: true }),
+        getLocalNodeInfo: vi.fn().mockReturnValue(null),
+        startDistanceDeleteScheduler: vi.fn().mockResolvedValue(undefined),
+        stopDistanceDeleteScheduler: vi.fn(),
+        setLoRaConfig,
+        requestModuleConfig,
+      } as unknown as ISourceManager & { setLoRaConfig: typeof setLoRaConfig; requestModuleConfig: typeof requestModuleConfig };
+      await sourceManagerRegistry.addManager(fakeManager);
+      await harness.grant(harness.limited.id, 'configuration', 'write', harness.sourceA);
+    });
+
+    afterEach(async () => {
+      await sourceManagerRegistry.removeManager(harness.sourceA);
+    });
+
+    it('passes txEnabled:false through to setLoRaConfig instead of forcing true', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/lora').send({ sourceId: harness.sourceA, txEnabled: false, hopLimit: 3 });
+
+      expect(res.status).toBe(200);
+      expect(setLoRaConfig).toHaveBeenCalledWith(expect.objectContaining({ txEnabled: false, hopLimit: 3 }));
+    });
+
+    it('passes txEnabled:true through unchanged when the caller sets it', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/lora').send({ sourceId: harness.sourceA, txEnabled: true });
+
+      expect(res.status).toBe(200);
+      expect(setLoRaConfig).toHaveBeenCalledWith(expect.objectContaining({ txEnabled: true }));
+    });
+  });
+
+  describe('POST /module/request — TX_DISABLED mapping (#4294)', () => {
+    it('returns 409 TX_DISABLED when the remote target has transmit disabled', async () => {
+      const requestModuleConfig = vi.fn().mockRejectedValue(new TxDisabledError());
+      const fakeManager = {
+        sourceId: harness.sourceA,
+        sourceType: 'meshtastic_tcp',
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn().mockReturnValue({ sourceId: harness.sourceA, sourceName: 'Source A', sourceType: 'meshtastic_tcp', connected: true }),
+        getLocalNodeInfo: vi.fn().mockReturnValue(null),
+        startDistanceDeleteScheduler: vi.fn().mockResolvedValue(undefined),
+        stopDistanceDeleteScheduler: vi.fn(),
+        requestModuleConfig,
+      } as unknown as ISourceManager;
+      await sourceManagerRegistry.addManager(fakeManager);
+      await harness.grant(harness.limited.id, 'configuration', 'write', harness.sourceA);
+
+      try {
+        const agent = await harness.loginAs(harness.limited);
+        const res = await agent.post('/module/request').send({ sourceId: harness.sourceA, configType: 5 });
+
+        expect(res.status).toBe(409);
+        expect(res.body.success).toBe(false);
+        expect(res.body.code).toBe('TX_DISABLED');
+      } finally {
+        await sourceManagerRegistry.removeManager(harness.sourceA);
+      }
     });
   });
 });

--- a/src/server/routes/configRoutes.test.ts
+++ b/src/server/routes/configRoutes.test.ts
@@ -140,11 +140,17 @@ describe('configRoutes', () => {
     // always 500s with "Not connected").
     let setLoRaConfig: ReturnType<typeof vi.fn>;
     let requestModuleConfig: ReturnType<typeof vi.fn>;
+    let isTxEnabled: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
       setLoRaConfig = vi.fn().mockResolvedValue(undefined);
       requestModuleConfig = vi.fn().mockResolvedValue(undefined);
-      const fakeManager: ISourceManager & { setLoRaConfig: typeof setLoRaConfig; requestModuleConfig: typeof requestModuleConfig } = {
+      // Fail-open default, matching the real MeshtasticManager.isTxEnabled()
+      // (true until config has arrived / when the caller's payload already
+      // carries an explicit txEnabled). Individual tests override this to
+      // exercise the omitted-field backfill.
+      isTxEnabled = vi.fn().mockReturnValue(true);
+      const fakeManager: ISourceManager & { setLoRaConfig: typeof setLoRaConfig; requestModuleConfig: typeof requestModuleConfig; isTxEnabled: typeof isTxEnabled } = {
         sourceId: harness.sourceA,
         sourceType: 'meshtastic_tcp',
         start: vi.fn().mockResolvedValue(undefined),
@@ -155,7 +161,8 @@ describe('configRoutes', () => {
         stopDistanceDeleteScheduler: vi.fn(),
         setLoRaConfig,
         requestModuleConfig,
-      } as unknown as ISourceManager & { setLoRaConfig: typeof setLoRaConfig; requestModuleConfig: typeof requestModuleConfig };
+        isTxEnabled,
+      } as unknown as ISourceManager & { setLoRaConfig: typeof setLoRaConfig; requestModuleConfig: typeof requestModuleConfig; isTxEnabled: typeof isTxEnabled };
       await sourceManagerRegistry.addManager(fakeManager);
       await harness.grant(harness.limited.id, 'configuration', 'write', harness.sourceA);
     });
@@ -178,6 +185,30 @@ describe('configRoutes', () => {
 
       expect(res.status).toBe(200);
       expect(setLoRaConfig).toHaveBeenCalledWith(expect.objectContaining({ txEnabled: true }));
+    });
+
+    // Regression for the whole-struct-replace / proto3 missing-bool hazard:
+    // setLoRaConfig sends the device the ENTIRE LoRaConfig, and an omitted
+    // bool decodes as false on the radio. When the caller's body doesn't
+    // include txEnabled at all (e.g. saving hopLimit from a form with no TX
+    // toggle), the route MUST backfill from the device's current state
+    // rather than send the field omitted/undefined.
+    it('backfills txEnabled from the device state when the caller omits it (radio-kill regression)', async () => {
+      isTxEnabled.mockReturnValue(false);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/lora').send({ sourceId: harness.sourceA, hopLimit: 3 });
+
+      expect(res.status).toBe(200);
+      expect(setLoRaConfig).toHaveBeenCalledWith(expect.objectContaining({ txEnabled: false, hopLimit: 3 }));
+    });
+
+    it('backfills txEnabled:true from the device state when the caller omits it and TX is currently on', async () => {
+      isTxEnabled.mockReturnValue(true);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/lora').send({ sourceId: harness.sourceA, hopLimit: 5 });
+
+      expect(res.status).toBe(200);
+      expect(setLoRaConfig).toHaveBeenCalledWith(expect.objectContaining({ txEnabled: true, hopLimit: 5 }));
     });
   });
 

--- a/src/server/routes/configRoutes.ts
+++ b/src/server/routes/configRoutes.ts
@@ -132,8 +132,23 @@ router.post('/lora', requirePermission('configuration', 'write'), async (req, re
     // one legitimate place a user sets TX on/off. Do NOT force it to true here;
     // that used to silently revert receive-only radios back to TX-enabled on
     // every unrelated LoRa config save.
-    logger.debug(`⚙️ Setting LoRa config: txEnabled=${config.txEnabled}`);
-    await cfgLoraManager.setLoRaConfig(config);
+    //
+    // BUT: setLoRaConfig sends the device the ENTIRE LoRaConfig struct (it's a
+    // whole-message replace, not a patch), and proto3 decodes a missing/omitted
+    // bool field as false (createSetLoRaConfigMessage only includes txEnabled
+    // when it's !== undefined). So when the caller's payload doesn't include
+    // txEnabled at all (e.g. saving hopLimit from a form that doesn't carry a
+    // TX toggle), we MUST backfill it explicitly from the device's current
+    // state — leaving it undefined would silently transmit txEnabled=false and
+    // kill the radio. This is the exact #1328 mechanism that motivated the
+    // original (overly broad) force-true.
+    const loraConfigToSet = {
+      ...config,
+      txEnabled: config.txEnabled !== undefined ? config.txEnabled : cfgLoraManager.isTxEnabled(),
+    };
+
+    logger.debug(`⚙️ Setting LoRa config: txEnabled=${loraConfigToSet.txEnabled}`);
+    await cfgLoraManager.setLoRaConfig(loraConfigToSet);
     res.json({ success: true, message: 'LoRa configuration sent' });
   } catch (error) {
     logger.error('Error setting LoRa config:', error);

--- a/src/server/routes/configRoutes.ts
+++ b/src/server/routes/configRoutes.ts
@@ -214,6 +214,31 @@ router.post('/module/telemetry', requirePermission('configuration', 'write'), as
   }
 });
 
+// IMPORTANT: '/module/request' must be registered before the '/module/:moduleType'
+// wildcard below — Express matches routes in registration order, and ':moduleType'
+// would otherwise swallow the literal path "request" (moduleType='request'), making
+// this handler permanently unreachable (found while adding TX-disabled 409 mapping,
+// issue #4294 — the frontend's `/api/config/module/request` call was 400ing with
+// "Invalid module type: request" instead of ever reaching this handler).
+router.post('/module/request', requirePermission('configuration', 'write'), async (req, res) => {
+  try {
+    const { configType, sourceId: cfgModReqSourceId } = req.body;
+    if (configType === undefined) {
+      res.status(400).json({ error: 'configType is required' });
+      return;
+    }
+    const cfgModReqManager = resolveSourceManager(cfgModReqSourceId);
+    await cfgModReqManager.requestModuleConfig(configType);
+    res.json({ success: true, message: 'Module config request sent' });
+  } catch (error) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
+    logger.error('Error requesting module config:', error);
+    res.status(500).json({ error: 'Failed to request module configuration' });
+  }
+});
+
 // Generic module config endpoint - handles extnotif, storeforward, rangetest, cannedmsg, audio,
 // remotehardware, detectionsensor, paxcounter, serial, ambientlighting, statusmessage, trafficmanagement
 router.post('/module/:moduleType', requirePermission('configuration', 'write'), async (req, res) => {
@@ -266,25 +291,6 @@ router.post('/request', requirePermission('configuration', 'write'), async (req,
   } catch (error) {
     logger.error('Error requesting config:', error);
     res.status(500).json({ error: 'Failed to request configuration' });
-  }
-});
-
-router.post('/module/request', requirePermission('configuration', 'write'), async (req, res) => {
-  try {
-    const { configType, sourceId: cfgModReqSourceId } = req.body;
-    if (configType === undefined) {
-      res.status(400).json({ error: 'configType is required' });
-      return;
-    }
-    const cfgModReqManager = resolveSourceManager(cfgModReqSourceId);
-    await cfgModReqManager.requestModuleConfig(configType);
-    res.json({ success: true, message: 'Module config request sent' });
-  } catch (error) {
-    if (isTxDisabledError(error)) {
-      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
-    }
-    logger.error('Error requesting module config:', error);
-    res.status(500).json({ error: 'Failed to request module configuration' });
   }
 });
 

--- a/src/server/routes/configRoutes.ts
+++ b/src/server/routes/configRoutes.ts
@@ -17,6 +17,8 @@ import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { resolveSourceConnectionConfig } from '../utils/resolveSourceConnectionConfig.js';
 import { isValidModuleConfigType } from '../constants/moduleConfig.js';
 import { getEnvironmentConfig } from '../config/environment.js';
+import { fail } from '../utils/apiResponse.js';
+import { isTxDisabledError } from '../errors/txDisabledError.js';
 
 const env = getEnvironmentConfig();
 const BASE_URL = env.baseUrl;
@@ -126,16 +128,12 @@ router.post('/lora', requirePermission('configuration', 'write'), async (req, re
     const { sourceId: cfgLoraSourceId, ...config } = req.body;
     const cfgLoraManager = resolveSourceManager(cfgLoraSourceId);
 
-    // IMPORTANT: Always force txEnabled to true
-    // MeshMonitor users need TX enabled to send messages
-    // Ignore any incoming configuration that tries to disable TX
-    const loraConfigToSet = {
-      ...config,
-      txEnabled: true,
-    };
-
-    logger.debug(`⚙️ Setting LoRa config with txEnabled defaulted: txEnabled=${loraConfigToSet.txEnabled}`);
-    await cfgLoraManager.setLoRaConfig(loraConfigToSet);
+    // Pass through the submitted txEnabled as-is (issue #4294) — this is the
+    // one legitimate place a user sets TX on/off. Do NOT force it to true here;
+    // that used to silently revert receive-only radios back to TX-enabled on
+    // every unrelated LoRa config save.
+    logger.debug(`⚙️ Setting LoRa config: txEnabled=${config.txEnabled}`);
+    await cfgLoraManager.setLoRaConfig(config);
     res.json({ success: true, message: 'LoRa configuration sent' });
   } catch (error) {
     logger.error('Error setting LoRa config:', error);
@@ -282,6 +280,9 @@ router.post('/module/request', requirePermission('configuration', 'write'), asyn
     await cfgModReqManager.requestModuleConfig(configType);
     res.json({ success: true, message: 'Module config request sent' });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error requesting module config:', error);
     res.status(500).json({ error: 'Failed to request module configuration' });
   }

--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -44,6 +44,7 @@ vi.mock('../auth/authMiddleware.js', () => ({
 import databaseService from '../../services/database.js';
 import { parseDestinationNum } from '../utils/parseDestination.js';
 import meshRequestRoutes from './meshRequestRoutes.js';
+import { TxDisabledError } from '../errors/txDisabledError.js';
 
 const app = express();
 app.use(express.json());
@@ -144,6 +145,14 @@ describe('POST /traceroute', () => {
     expect(res.body.error).toBe('Service Unavailable');
     expect(res.body.message).toContain('Not connected');
   });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendTraceroute.mockRejectedValue(new TxDisabledError());
+    const res = await request(app).post('/traceroute').send({ destination: '!12345678' });
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
+  });
 });
 
 describe('POST /position/request', () => {
@@ -167,6 +176,14 @@ describe('POST /position/request', () => {
     expect(res.body.success).toBe(false);
     expect(res.body.error).toBe('Service Unavailable');
     expect(res.body.message).toContain('Not connected');
+  });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendPositionRequest.mockRejectedValue(new TxDisabledError());
+    const res = await request(app).post('/position/request').send({ destination: '!12345678' });
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
   });
 });
 
@@ -193,6 +210,14 @@ describe('POST /nodeinfo/request', () => {
     expect(res.body.success).toBe(false);
     expect(res.body.error).toBe('Service Unavailable');
     expect(res.body.message).toContain('Not connected');
+  });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendNodeInfoRequest.mockRejectedValue(new TxDisabledError());
+    const res = await request(app).post('/nodeinfo/request').send({ destination: '!12345678' });
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
   });
 });
 
@@ -240,6 +265,17 @@ describe('POST /neighborinfo/request', () => {
     expect(res.body.error).toBe('Service Unavailable');
     expect(res.body.message).toContain('Not connected');
   });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source (after eligibility passes)', async () => {
+    (parseDestinationNum as any).mockResolvedValue(0x0000dddd);
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: 1, nodeId: '!00000001' });
+    (databaseService.nodes.getNode as any).mockResolvedValue({ channel: 1, hopsAway: 0 });
+    mockManager.sendNeighborInfoRequest.mockRejectedValue(new TxDisabledError());
+    const res = await request(app).post('/neighborinfo/request').send({ destination: '!0000dddd' });
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
+  });
 });
 
 describe('POST /telemetry/request', () => {
@@ -278,5 +314,13 @@ describe('POST /telemetry/request', () => {
     expect(res.body.success).toBe(false);
     expect(res.body.error).toBe('Service Unavailable');
     expect(res.body.message).toContain('Not connected');
+  });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendTelemetryRequest.mockRejectedValue(new TxDisabledError());
+    const res = await request(app).post('/telemetry/request').send({ destination: '!12345678', telemetryType: 'environment' });
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
   });
 });

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -6,6 +6,8 @@ import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { parseDestinationNum } from '../utils/parseDestination.js';
 import { resolveDestinationChannel, resolveBroadcastChannel, isValidChannelIndex } from '../utils/resolveDestinationChannel.js';
 import { PortNum } from '../constants/meshtastic.js';
+import { fail } from '../utils/apiResponse.js';
+import { isTxDisabledError } from '../errors/txDisabledError.js';
 
 const router = Router();
 
@@ -37,6 +39,9 @@ router.post('/traceroute', requirePermission('traceroute', 'write'), async (req:
       message: `Traceroute request sent to ${destinationNum.toString(16)} on channel ${channel}`,
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending traceroute:', error);
     if (error?.message?.includes('Not connected')) {
       return res.status(503).json({
@@ -116,6 +121,9 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
       message: `Position request sent to ${destinationNum.toString(16)} on channel ${channel}`,
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending position request:', error);
     if (error?.message?.includes('Not connected')) {
       return res.status(503).json({
@@ -194,6 +202,9 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
       message: `NodeInfo request sent to ${destinationNum.toString(16)} on channel ${channel}`,
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending nodeinfo request:', error);
     if (error?.message?.includes('Not connected')) {
       return res.status(503).json({
@@ -273,6 +284,9 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
       requestId
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending neighborinfo request:', error);
     if (error?.message?.includes('Not connected')) {
       return res.status(503).json({
@@ -327,6 +341,9 @@ router.post('/telemetry/request', requirePermission('messages', 'write'), async 
       requestId
     });
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending telemetry request:', error);
     if (error?.message?.includes('Not connected')) {
       return res.status(503).json({

--- a/src/server/routes/messageRoutes.test.ts
+++ b/src/server/routes/messageRoutes.test.ts
@@ -9,6 +9,7 @@ import express from 'express';
 import session from 'express-session';
 import request from 'supertest';
 import databaseService from '../../services/database.js';
+import { TxDisabledError } from '../errors/txDisabledError.js';
 
 // ---------------------------------------------------------------------------
 // sourceManagerRegistry stub — messageRoutes resolves its default-source
@@ -942,6 +943,49 @@ describe('Message Deletion Routes', () => {
 
       expect(response.status).toBe(500);
       expect(response.body.error).toBe('Device communication error');
+    });
+  });
+
+  describe('POST /api/messages/send', () => {
+    beforeEach(() => {
+      registryStub.getManager.mockReset().mockReturnValue(undefined);
+      registryStub.getAllManagers.mockReset().mockReturnValue([]);
+      registryStub.getPrimaryMeshtasticSourceId.mockReset().mockReturnValue(null);
+    });
+
+    it('returns 409 TX_DISABLED when the manager throws TxDisabledError', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      registryStub.getManager.mockReturnValue({
+        sourceId: 'source-a',
+        sourceType: 'meshtastic_tcp',
+        getLocalNodeInfo: () => ({ nodeNum: 1 }),
+        sendTextMessage: vi.fn().mockRejectedValue(new TxDisabledError()),
+      });
+
+      const response = await request(app)
+        .post('/api/messages/send')
+        .send({ text: 'hello', sourceId: 'source-a' });
+
+      expect(response.status).toBe(409);
+      expect(response.body.success).toBe(false);
+      expect(response.body.code).toBe('TX_DISABLED');
+    });
+
+    it('sends successfully when transmit is enabled', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      registryStub.getManager.mockReturnValue({
+        sourceId: 'source-a',
+        sourceType: 'meshtastic_tcp',
+        getLocalNodeInfo: () => ({ nodeNum: 1 }),
+        sendTextMessage: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const response = await request(app)
+        .post('/api/messages/send')
+        .send({ text: 'hello', sourceId: 'source-a' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
     });
   });
 });

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -20,6 +20,8 @@ import {
 import { parseDestinationNum } from '../utils/parseDestination.js';
 import { transformDbMessageToMeshMessage } from '../utils/transformDbMessage.js';
 import { filterNodesByChannelPermission } from '../utils/nodeEnhancer.js';
+import { fail } from '../utils/apiResponse.js';
+import { isTxDisabledError } from '../errors/txDisabledError.js';
 
 const router = express.Router();
 
@@ -1314,6 +1316,9 @@ router.post('/send', optionalAuth(), async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+    }
     logger.error('Error sending message:', error);
     res.status(500).json({ error: 'Failed to send message' });
   }

--- a/src/server/routes/v1/actions.test.ts
+++ b/src/server/routes/v1/actions.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express, { Express } from 'express';
 import request from 'supertest';
 import { neighborInfoRateLimitMap } from './actions.js';
+import { TxDisabledError } from '../../errors/txDisabledError.js';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Shared test constants
@@ -214,6 +215,16 @@ describe('POST /traceroute', () => {
     expect(res.body.required).toEqual({ resource: 'traceroute', action: 'write', sourceId: SOURCE_A });
   });
 
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendTraceroute.mockRejectedValue(new TxDisabledError());
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
+  });
+
   it('passes sourceId to checkPermissionAsync (per-source)', async () => {
     const app = buildApp(normalUser);
     await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
@@ -353,6 +364,16 @@ describe('POST /request-position', () => {
 
     expect(mockDb.checkPermissionAsync.mock.calls[0][3]).toBe(SOURCE_A);
   });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendPositionRequest.mockRejectedValue(new TxDisabledError());
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
+  });
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -408,6 +429,16 @@ describe('POST /request-nodeinfo', () => {
     await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
 
     expect(mockDb.checkPermissionAsync.mock.calls[0][3]).toBe(SOURCE_A);
+  });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.sendNodeInfoRequest.mockRejectedValue(new TxDisabledError());
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
   });
 });
 
@@ -518,6 +549,17 @@ describe('POST /request-neighbors', () => {
 
     expect(neighborInfoRateLimitMap.has(`${SOURCE_A}:${DEST_NUM}`)).toBe(true);
     expect(neighborInfoRateLimitMap.has(`${SOURCE_B}:${DEST_NUM}`)).toBe(false);
+  });
+
+  it('returns 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: DEST_NUM, nodeId: '!a1b2c3d4' });
+    mockManager.sendNeighborInfoRequest.mockRejectedValue(new TxDisabledError());
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('TX_DISABLED');
   });
 });
 

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -18,6 +18,7 @@ import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
 import { logger } from '../../../utils/logger.js';
 import { PortNum } from '../../constants/meshtastic.js';
 import { attachSource, resolvedSourceIdFromPath } from './sourceParam.js';
+import { isTxDisabledError } from '../../errors/txDisabledError.js';
 
 const router = express.Router({ mergeParams: true });
 
@@ -101,6 +102,9 @@ router.post('/traceroute', attachSource('traceroute', 'write'), async (req: Requ
       },
     });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return res.status(409).json({ success: false, error: 'Transmit is disabled on this source', code: 'TX_DISABLED' });
+    }
     logger.error('[v1/actions] Error sending traceroute:', error);
     res.status(500).json({ success: false, error: 'Failed to send traceroute' });
   }
@@ -158,6 +162,9 @@ router.post('/request-position', attachSource('messages', 'write'), async (req: 
       },
     });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return res.status(409).json({ success: false, error: 'Transmit is disabled on this source', code: 'TX_DISABLED' });
+    }
     logger.error('[v1/actions] Error requesting position:', error);
     res.status(500).json({ success: false, error: 'Failed to request position' });
   }
@@ -214,6 +221,9 @@ router.post('/request-nodeinfo', attachSource('messages', 'write'), async (req: 
       },
     });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return res.status(409).json({ success: false, error: 'Transmit is disabled on this source', code: 'TX_DISABLED' });
+    }
     logger.error('[v1/actions] Error requesting nodeinfo:', error);
     res.status(500).json({ success: false, error: 'Failed to request node info' });
   }
@@ -272,6 +282,9 @@ router.post('/request-neighbors', attachSource('traceroute', 'write'), async (re
       },
     });
   } catch (error) {
+    if (isTxDisabledError(error)) {
+      return res.status(409).json({ success: false, error: 'Transmit is disabled on this source', code: 'TX_DISABLED' });
+    }
     logger.error('[v1/actions] Error requesting neighbor info:', error);
     res.status(500).json({ success: false, error: 'Failed to request neighbor info' });
   }

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -18,6 +18,7 @@ import { messageLimiter } from '../../middleware/rateLimiters.js';
 import { logger } from '../../../utils/logger.js';
 import { MAX_MESSAGE_BYTES, PortNum } from '../../constants/meshtastic.js';
 import { resolvedSourceIdFromPath } from './sourceParam.js';
+import { isTxDisabledError } from '../../errors/txDisabledError.js';
 
 /** Maximum number of message parts allowed when splitting long messages */
 const MAX_MESSAGE_PARTS = 3;
@@ -562,6 +563,9 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
       });
     }
   } catch (error: any) {
+    if (isTxDisabledError(error)) {
+      return res.status(409).json({ success: false, error: 'Transmit is disabled on this source', code: 'TX_DISABLED' });
+    }
     logger.error('Error sending message via v1 API:', error);
 
     // Check for specific error types

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
+import { TxDisabledError } from '../../errors/txDisabledError.js';
 
 // Token constants
 const VALID_TEST_TOKEN = 'mm_v1_test_token_12345678901234567890';
@@ -973,6 +974,25 @@ describe('POST /api/v1/messages - Error Handling', () => {
 
     expect(response.body).toHaveProperty('success', false);
     expect(response.body).toHaveProperty('error', 'Internal Server Error');
+  });
+
+  it('should return 409 TX_DISABLED when transmit is disabled on this source', async () => {
+    const meshtasticManager = await import('../../meshtasticManager.js');
+    vi.mocked(meshtasticManager.fallbackManager.sendTextMessage).mockRejectedValueOnce(
+      new TxDisabledError()
+    );
+
+    const response = await request(app)
+      .post('/api/v1/messages')
+      .set('Authorization', `Bearer ${VALID_TEST_TOKEN}`)
+      .send({
+        text: 'Test message',
+        channel: 0
+      })
+      .expect(409);
+
+    expect(response.body).toHaveProperty('success', false);
+    expect(response.body).toHaveProperty('code', 'TX_DISABLED');
   });
 });
 

--- a/src/server/services/autoAnnounceService.test.ts
+++ b/src/server/services/autoAnnounceService.test.ts
@@ -57,12 +57,14 @@ function makeFakeManager(overrides: Partial<{
   deviceConnected: boolean;
   rebootMergeInProgress: boolean;
   automationAirtimeGated: boolean;
+  txEnabled: boolean;
 }> = {}) {
   const state = {
     sourceId: overrides.sourceId ?? 'test-source',
     deviceConnected: overrides.deviceConnected ?? true,
     rebootMergeInProgress: overrides.rebootMergeInProgress ?? false,
     automationAirtimeGated: overrides.automationAirtimeGated ?? false,
+    txEnabled: overrides.txEnabled ?? true,
   };
   return {
     state,
@@ -70,6 +72,7 @@ function makeFakeManager(overrides: Partial<{
     isDeviceConnected: vi.fn(() => state.deviceConnected),
     isRebootMergeInProgress: vi.fn(() => state.rebootMergeInProgress),
     isAutomationAirtimeGated: vi.fn(async () => state.automationAirtimeGated),
+    isTxEnabled: vi.fn(() => state.txEnabled),
     replaceAnnouncementTokens: vi.fn(async (message: string) => message.replace('{VERSION}', '9.9.9')),
     messageQueue: { enqueue: vi.fn() },
     broadcastNodeInfoToChannels: vi.fn().mockResolvedValue(undefined),
@@ -191,6 +194,34 @@ describe('AutoAnnounceService', () => {
       await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
 
       expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    it('onTick skips sendAutoAnnouncement when TX is disabled (#4294 WP3)', async () => {
+      const mgr = makeFakeManager({ deviceConnected: true, txEnabled: false });
+      const svc = new AutoAnnounceService(mgr as any);
+      const sendSpy = vi.spyOn(svc, 'sendAutoAnnouncement').mockResolvedValue(undefined);
+
+      await svc.startAnnounceScheduler();
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+
+      expect(sendSpy).not.toHaveBeenCalled();
+      // The scheduler itself stays armed so a later TX re-enable resumes automatically.
+      expect(svc.running).toBe(true);
+    });
+
+    it('onTick resumes sendAutoAnnouncement once TX is re-enabled on a later tick (#4294 WP3)', async () => {
+      const mgr = makeFakeManager({ deviceConnected: true, txEnabled: false });
+      const svc = new AutoAnnounceService(mgr as any);
+      const sendSpy = vi.spyOn(svc, 'sendAutoAnnouncement').mockResolvedValue(undefined);
+
+      await svc.startAnnounceScheduler();
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+      expect(sendSpy).not.toHaveBeenCalled();
+
+      mgr.state.txEnabled = true;
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
     });
 
     it('announce-on-start: sends after a 30s delay when enabled and no prior announcement exists', async () => {

--- a/src/server/services/autoAnnounceService.ts
+++ b/src/server/services/autoAnnounceService.ts
@@ -75,13 +75,15 @@ export class AutoAnnounceService {
       label: `Meshtastic:${sourceId}`,
       mode,
       onTick: () => {
-        logger.debug(`📢 Announce tick triggered (connected: ${this.mgr.isDeviceConnected()})`);
-        if (this.mgr.isDeviceConnected()) {
+        logger.debug(`📢 Announce tick triggered (connected: ${this.mgr.isDeviceConnected()}, txEnabled: ${this.mgr.isTxEnabled()})`);
+        // TX-disabled radios cannot broadcast announcements; skip quietly and let
+        // the scheduler keep running so a later TX re-enable resumes automatically (#4294).
+        if (this.mgr.isDeviceConnected() && this.mgr.isTxEnabled()) {
           return this.sendAutoAnnouncement(true).catch((error: Error) => {
             logger.error('❌ Error in auto-announce:', error);
           });
         }
-        logger.debug('📢 Skipping announcement - not connected to node');
+        logger.debug('📢 Skipping announcement - not connected to node or TX disabled');
       },
     });
 

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -4,6 +4,7 @@ import type { EngineEvalContext } from './engineContext.js';
 import type { TriggerContext } from './triggerContext.js';
 import type { AutomationNode } from '../../../types/automation.js';
 import type { VariableResolver } from './variableResolver.js';
+import { TxDisabledError } from '../../errors/txDisabledError.js';
 
 function recorder() {
   const calls: Array<{ fn: string; args: any }> = [];
@@ -15,6 +16,35 @@ function recorder() {
     rebootDevice: async (a) => { calls.push({ fn: 'rebootDevice', args: a }); return 6; },
     notify: async (a) => { calls.push({ fn: 'notify', args: a }); return 4; },
     runScript: async (a) => { calls.push({ fn: 'runScript', args: a }); return { success: true, stdout: '', returnValue: { ok: 1 } }; },
+  };
+  return { calls, deps };
+}
+
+/**
+ * Like `recorder()`, but the named dep function throws `TxDisabledError`
+ * instead of recording a call — simulates a mesh-send action hitting a
+ * TX-disabled Meshtastic source's primitive guard (#4294 WP1/WP3). Other dep
+ * functions still record normally, so mixed-source scenarios can be composed.
+ */
+function recorderWithTxDisabled(failFn: keyof ActionDeps) {
+  const { calls, deps } = recorder();
+  (deps as any)[failFn] = async () => {
+    throw new TxDisabledError();
+  };
+  return { calls, deps };
+}
+
+/**
+ * Like `recorderWithTxDisabled`, but only the given source's call throws —
+ * other sources still record normally. Used for mixed-source multi-select
+ * scenarios (mirrors the MeshCore mixed-source tests above).
+ */
+function recorderWithTxDisabledForSource(failFn: 'sendMessage' | 'sendTapback' | 'requestData' | 'rebootDevice', targetSourceId: string) {
+  const { calls, deps } = recorder();
+  const original = deps[failFn] as (a: any) => Promise<unknown>;
+  (deps as any)[failFn] = async (a: any) => {
+    if (a.sourceId === targetSourceId) throw new TxDisabledError();
+    return original(a);
   };
   return { calls, deps };
 }
@@ -740,5 +770,77 @@ describe('executeAction', () => {
     await executeAction(node('action.delay', { seconds: 9999 }), ctx({}), { ...deps, sleep });
     await executeAction(node('action.delay', { seconds: 2.9 }), ctx({}), { ...deps, sleep });
     expect(slept).toEqual([300_000, 2_000]);
+  });
+
+  // ── TX-disabled skip (#4294 epic, Phase 1 WP3, §8) ────────────────────────
+  // A TX-disabled Meshtastic source's primitive guard throws TxDisabledError
+  // (WP1). The action executor must catch it and record a skip — mirroring the
+  // MeshCore-unsupported skips above — so the automation run stays
+  // status:'completed' instead of failing.
+  describe('TX-disabled skip (#4294 WP3)', () => {
+    it('sendMessage: a TX-disabled source is recorded as a TX_DISABLED skip, not a thrown error', async () => {
+      const { calls, deps } = recorderWithTxDisabled('sendMessage');
+      const result = await executeAction(
+        node('action.sendMessage', { text: 'hello' }),
+        ctx({ from: 5, channel: 2, isDM: false }),
+        deps,
+      );
+      expect(result).toEqual({ skipped: true, reason: 'TX_DISABLED' });
+      expect(calls).toHaveLength(0);
+    });
+
+    it('sendTapback: a TX-disabled source is recorded as a TX_DISABLED skip', async () => {
+      const { calls, deps } = recorderWithTxDisabled('sendTapback');
+      const result = await executeAction(
+        node('action.tapback', { emoji: '👍' }),
+        ctx({ from: 5, channel: 3, packetId: 99, isDM: false }),
+        deps,
+      );
+      expect(result).toEqual({ skipped: true, reason: 'TX_DISABLED' });
+      expect(calls).toHaveLength(0);
+    });
+
+    it('requestData: a TX-disabled source is recorded as a TX_DISABLED skip', async () => {
+      const { calls, deps } = recorderWithTxDisabled('requestData');
+      const result = await executeAction(
+        node('action.requestData', { op: 'traceroute', to: '12345', channel: 1 }),
+        ctx({ from: 5, channel: 0 }),
+        deps,
+      );
+      expect(result).toEqual({ skipped: true, reason: 'TX_DISABLED' });
+      expect(calls).toHaveLength(0);
+    });
+
+    it('deviceReboot: a TX-disabled remote-admin target is recorded as a TX_DISABLED skip', async () => {
+      const { calls, deps } = recorderWithTxDisabled('rebootDevice');
+      const result = await executeAction(
+        node('action.deviceReboot', { targetNodeNum: 42 }),
+        ctx({ from: 1 }, 'default'),
+        deps,
+      );
+      expect(result).toEqual({ skipped: true, reason: 'TX_DISABLED' });
+      expect(calls).toHaveLength(0);
+    });
+
+    it('sendMessage: a mixed multi-source select skips the TX-disabled source but still sends on the others', async () => {
+      const { calls, deps } = recorderWithTxDisabledForSource('sendMessage', 'radioOff');
+      const result = await executeAction(
+        node('action.sendMessage', { text: 'hi', sourceIds: ['radioA', 'radioOff'] }),
+        ctx({ from: 5, channel: 2, isDM: false }),
+        deps,
+      );
+      expect(calls.map((c) => c.args.sourceId)).toEqual(['radioA']);
+      expect(result).toEqual([1, { skipped: true, reason: 'TX_DISABLED' }]);
+    });
+
+    it('a non-TX error still rethrows unchanged (only TxDisabledError is converted to a skip)', async () => {
+      const { deps } = recorder();
+      (deps as any).sendMessage = async () => { throw new Error('boom'); };
+      await expect(executeAction(
+        node('action.sendMessage', { text: 'hi' }),
+        ctx({ from: 5, channel: 2, isDM: false }),
+        deps,
+      )).rejects.toThrow('boom');
+    });
   });
 });

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -8,6 +8,7 @@
  */
 import { type AutomationNode, AUTOMATION_DELAY_MAX_SECONDS } from '../../../types/automation.js';
 import { type EngineEvalContext, interpolateAsync, resolveOperand } from './engineContext.js';
+import { isTxDisabledError } from '../../errors/txDisabledError.js';
 
 export type NodeManageOp = 'favorite' | 'unfavorite' | 'ignore' | 'unignore' | 'delete';
 
@@ -123,6 +124,25 @@ async function str(ctx: EngineEvalContext, raw: unknown): Promise<string | undef
 async function isMeshCoreSource(ctx: EngineEvalContext, sourceId: string | null): Promise<boolean> {
   if (!sourceId) return false;
   return (await ctx.data.getSourceProtocol?.(sourceId)) === 'meshcore';
+}
+
+/**
+ * Run a mesh-send action dep call and push its result into `results`. A
+ * `TxDisabledError` from a TX-disabled Meshtastic source (#4294) is caught and
+ * converted into the file's existing skip shape — mirroring the MeshCore-
+ * unsupported skips above — so the run stays `status: 'completed'` instead of
+ * failing. Any other error rethrows, preserving existing failure behavior.
+ */
+async function pushOrSkipTxDisabled<T>(results: unknown[], fn: () => Promise<T>): Promise<void> {
+  try {
+    results.push(await fn());
+  } catch (error) {
+    if (isTxDisabledError(error)) {
+      results.push({ skipped: true, reason: 'TX_DISABLED' });
+      return;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -272,7 +292,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           // channel broadcasts, so dropping the override on a DM is correct, not a leak.
           // A channel-only fallback send (no `to`) still honors the scope override.
           const fallbackScope = destination != null ? {} : scopeArg;
-          results.push(await deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope }));
+          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope }));
           continue;
         }
         const srcChannels = (await ctx.data.getChannels?.(sid)) ?? [];
@@ -280,7 +300,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           if (sel.protocol && proto && sel.protocol !== proto) continue; // wrong-protocol channel
           const match = srcChannels.find((c) => c.name.toLowerCase() === sel.name.toLowerCase() && c.role !== 0);
           if (!match) continue; // channel not present on this source
-          results.push(await deps.sendMessage({ sourceId: sid, text, channel: match.id, destination, replyId, ...scopeArg }));
+          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: match.id, destination, replyId, ...scopeArg }));
         }
       }
 
@@ -317,7 +337,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           results.push({ skipped: true, reason: 'tapback is not supported on MeshCore' });
           continue;
         }
-        results.push(await deps.sendTapback({ sourceId: sid, emoji, channel, destination, replyId }));
+        await pushOrSkipTxDisabled(results, () => deps.sendTapback({ sourceId: sid, emoji, channel, destination, replyId }));
       }
       // Unwrap the single-target case so the result shape (and run-log
       // resolvedParams) matches the original one-target behavior.
@@ -374,7 +394,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           }
           if (!target) throw new Error(`action.requestData: no target node for "${op}"`);
         }
-        results.push(await deps.requestData({ sourceId: sid, op, target, channel, telemetryType: op === 'telemetry' ? telemetryType : undefined }));
+        await pushOrSkipTxDisabled(results, () => deps.requestData({ sourceId: sid, op, target, channel, telemetryType: op === 'telemetry' ? telemetryType : undefined }));
       }
       return results.length === 1 ? results[0] : results;
     }
@@ -409,7 +429,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           results.push({ skipped: true, reason: 'remote-admin reboot is not supported on MeshCore' });
           continue;
         }
-        results.push(await deps.rebootDevice({ sourceId: sid, seconds, targetNodeNum }));
+        await pushOrSkipTxDisabled(results, () => deps.rebootDevice({ sourceId: sid, seconds, targetNodeNum }));
       }
       return results.length === 1 ? results[0] : results;
     }

--- a/src/server/services/remoteAdminService.test.ts
+++ b/src/server/services/remoteAdminService.test.ts
@@ -50,6 +50,7 @@ function makeFakeManager(overrides: Partial<{
   transportReady: boolean;
   localNodeInfo: { nodeNum: number } | null;
   sessionPasskeys: Map<number, Uint8Array>;
+  txEnabled: boolean;
 }> = {}) {
   const state = {
     transportReady: overrides.transportReady ?? true,
@@ -61,6 +62,7 @@ function makeFakeManager(overrides: Partial<{
     remoteNodeDeviceMetadata: new Map<number, any>(),
     pendingModuleConfigRequests: new Map<number, string>(),
     moduleConfigsEverFetched: false,
+    txEnabled: overrides.txEnabled ?? true,
   };
 
   return {
@@ -77,6 +79,7 @@ function makeFakeManager(overrides: Partial<{
     getRemoteNodeDeviceMetadataMap: vi.fn(() => state.remoteNodeDeviceMetadata),
     resetModuleConfigState: vi.fn(() => { state.moduleConfigsEverFetched = false; }),
     setModuleConfigsEverFetched: vi.fn((v: boolean) => { state.moduleConfigsEverFetched = v; }),
+    isTxEnabled: vi.fn(() => state.txEnabled),
   };
 }
 
@@ -303,6 +306,85 @@ describe('RemoteAdminService', () => {
       const firstSendOrder = (mgr.sendLocalAdminPacket as any).mock.invocationCallOrder[0];
       expect(resetOrder).toBeLessThan(firstSendOrder);
       expect(firstSendOrder).toBeLessThan(fetchedOrder);
+    });
+  });
+
+  describe('TX-disabled guard (#4294 WP1) — remote target blocked, local target unaffected', () => {
+    it('requestRemoteSessionPasskey to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.requestRemoteSessionPasskey(222)).rejects.toMatchObject({ isTxDisabledError: true, code: 'TX_DISABLED' });
+      expect(mgr.sendLocalAdminPacket).not.toHaveBeenCalled();
+    });
+
+    it('requestRemoteConfig to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false, sessionPasskeys: new Map([[222, new Uint8Array([1])]]) });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.requestRemoteConfig(222, 5, false)).rejects.toMatchObject({ isTxDisabledError: true });
+      expect(mgr.sendLocalAdminPacket).not.toHaveBeenCalled();
+    });
+
+    it('requestRemoteChannel to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false, sessionPasskeys: new Map([[222, new Uint8Array([1])]]) });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.requestRemoteChannel(222, 3)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('requestRemoteOwner to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false, sessionPasskeys: new Map([[222, new Uint8Array([1])]]) });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.requestRemoteOwner(222)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('requestRemoteDeviceMetadata to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false, sessionPasskeys: new Map([[222, new Uint8Array([1])]]) });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.requestRemoteDeviceMetadata(222)).rejects.toMatchObject({ isTxDisabledError: true });
+    });
+
+    it('sendRebootCommand to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.sendRebootCommand(222, 5)).rejects.toMatchObject({ isTxDisabledError: true });
+      expect(mgr.sendLocalAdminPacket).not.toHaveBeenCalled();
+    });
+
+    it('sendSetTimeCommand to a remote node throws TxDisabledError when TX is off', async () => {
+      const mgr = makeFakeManager({ txEnabled: false });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.sendSetTimeCommand(222)).rejects.toMatchObject({ isTxDisabledError: true });
+      expect(mgr.sendLocalAdminPacket).not.toHaveBeenCalled();
+    });
+
+    it('local-node targets (dest 0 or local nodeNum) are NOT blocked by TX-disabled', async () => {
+      const mgr = makeFakeManager({ txEnabled: false });
+      const svc = new RemoteAdminService(mgr as any);
+
+      await expect(svc.sendRebootCommand(LOCAL_NODE_NUM, 5)).resolves.toBeUndefined();
+      await expect(svc.sendSetTimeCommand(0)).resolves.toBeUndefined();
+      expect(mgr.sendLocalAdminPacket).toHaveBeenCalledTimes(2);
+    });
+
+    it('requestModuleConfig (always local) is unaffected by TX-disabled', async () => {
+      const mgr = makeFakeManager({ txEnabled: false });
+      const svc = new RemoteAdminService(mgr as any);
+      await expect(svc.requestModuleConfig(14)).resolves.toBeUndefined();
+      expect(mgr.sendLocalAdminPacket).toHaveBeenCalledTimes(1);
+    });
+
+    it('remote sends succeed normally when TX is enabled', async () => {
+      vi.useFakeTimers();
+      try {
+        const mgr = makeFakeManager({ txEnabled: true });
+        const svc = new RemoteAdminService(mgr as any);
+        const promise = svc.sendRebootCommand(222, 5);
+        await vi.advanceTimersByTimeAsync(1);
+        mgr.state.sessionPasskeys.set(222, new Uint8Array([7]));
+        await vi.advanceTimersByTimeAsync(500);
+        await expect(promise).resolves.toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/src/server/services/remoteAdminService.ts
+++ b/src/server/services/remoteAdminService.ts
@@ -37,6 +37,7 @@ import protobufService from '../protobufService.js';
 import { getProtobufRoot } from '../protobufLoader.js';
 import { getEnvironmentConfig } from '../config/environment.js';
 import { logger } from '../../utils/logger.js';
+import { TxDisabledError } from '../errors/txDisabledError.js';
 
 // Maps AdminMessage.ModuleConfigType enum values to the ModuleConfig oneof key
 // used in decoded responses. Covers the module types MeshMonitor surfaces a
@@ -54,6 +55,18 @@ export class RemoteAdminService {
   constructor(private readonly mgr: MeshtasticManager) {}
 
   /**
+   * TX-disabled guard for admin sends that target a remote node. Local-node
+   * admin (isLocalNode=true) must keep working even when TX is off — it's
+   * the mechanism the user re-enables TX with. See
+   * docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md §4.
+   */
+  private assertTxForRemoteTarget(isLocalNode: boolean): void {
+    if (!isLocalNode && !this.mgr.isTxEnabled()) {
+      throw new TxDisabledError('Remote admin requires transmit; TX is disabled on this source');
+    }
+  }
+
+  /**
    * Request session passkey from a remote node
    * Uses getDeviceMetadataRequest (per research findings - Android pattern)
    * @param destinationNodeNum The node number to request session passkey from
@@ -67,6 +80,10 @@ export class RemoteAdminService {
     if (!this.mgr.getLocalNodeInfo()?.nodeNum) {
       throw new Error('Local node number not available');
     }
+
+    const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
+    const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
 
     try {
       // Use getDeviceMetadataRequest (per research - Android pattern uses this for SESSIONKEY_CONFIG)
@@ -161,6 +178,10 @@ export class RemoteAdminService {
     if (!this.mgr.getLocalNodeInfo()?.nodeNum) {
       throw new Error('Local node number not available');
     }
+
+    const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
+    const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
 
     try {
       // Get or request session passkey
@@ -322,6 +343,10 @@ export class RemoteAdminService {
       throw new Error('Local node number not available');
     }
 
+    const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
+    const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
+
     try {
       // Get or request session passkey
       let sessionPasskey = this.mgr.getSessionPasskey(destinationNodeNum);
@@ -415,6 +440,10 @@ export class RemoteAdminService {
       throw new Error('Local node number not available');
     }
 
+    const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
+    const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
+
     try {
       // Get or request session passkey
       let sessionPasskey = this.mgr.getSessionPasskey(destinationNodeNum);
@@ -492,6 +521,10 @@ export class RemoteAdminService {
     if (!this.mgr.getLocalNodeInfo()?.nodeNum) {
       throw new Error('Local node number not available');
     }
+
+    const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
+    const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
 
     try {
       // Get or request session passkey
@@ -571,6 +604,7 @@ export class RemoteAdminService {
 
     const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
     const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
 
     try {
       const root = getProtobufRoot();
@@ -629,6 +663,7 @@ export class RemoteAdminService {
 
     const localNodeNum = this.mgr.getLocalNodeInfo()!.nodeNum;
     const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    this.assertTxForRemoteTarget(isLocalNode);
 
     try {
       const root = getProtobufRoot();

--- a/src/server/services/systemRestoreService.test.ts
+++ b/src/server/services/systemRestoreService.test.ts
@@ -76,6 +76,36 @@ vi.mock('mysql2/promise', () => ({
 
 import { systemRestoreService } from './systemRestoreService.js';
 
+// ─── TX-disabled exit criterion 2 (#4294) ─────────────────────────────────────
+// Restore is a pure DB row restore — it never touches a source manager, so it
+// can never call setLoRaConfig / force lora.txEnabled. This is a structural
+// lock rather than a mocked-manager behavioral test: neither restore nor
+// backup service imports a manager or references setLoRaConfig/txEnabled at
+// all, so there is no runtime call site to intercept. Reads the real
+// filesystem (bypassing this file's `fs` mock) to inspect the actual source.
+
+describe('systemRestoreService / systemBackupService — never touch lora.txEnabled (#4294)', () => {
+  it('restore never calls setLoRaConfig or references txEnabled', async () => {
+    const realFs = await vi.importActual<typeof import('fs')>('fs');
+    const restoreSource = realFs.readFileSync(
+      new URL('./systemRestoreService.ts', import.meta.url),
+      'utf-8'
+    );
+    expect(restoreSource).not.toContain('setLoRaConfig');
+    expect(restoreSource).not.toContain('txEnabled');
+  });
+
+  it('backup never calls setLoRaConfig or references txEnabled', async () => {
+    const realFs = await vi.importActual<typeof import('fs')>('fs');
+    const backupSource = realFs.readFileSync(
+      new URL('./systemBackupService.ts', import.meta.url),
+      'utf-8'
+    );
+    expect(backupSource).not.toContain('setLoRaConfig');
+    expect(backupSource).not.toContain('txEnabled');
+  });
+});
+
 // ─── Valid metadata fixture ───────────────────────────────────────────────────
 
 const validMetadata = {

--- a/src/server/services/waypointService.test.ts
+++ b/src/server/services/waypointService.test.ts
@@ -307,6 +307,49 @@ describe('rebroadcastTick', () => {
     expect(result).toEqual(refreshed);
     expect(emit.mock.calls.find((c) => c[0] === 'upserted')).toBeTruthy();
   });
+
+  // #4294 WP3 — TX-disabled Meshtastic sources must not attempt the OTA send.
+  describe('TX-disabled skip (#4294 WP3)', () => {
+    it('does NOT stamp lastBroadcastAt or call broadcastWaypoint when the source manager reports TX disabled', async () => {
+      mockFindOldestEligible.mockResolvedValueOnce(eligibleRow());
+      const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+      mockGetManager.mockReturnValueOnce({ broadcastWaypoint, isTxEnabled: () => false });
+
+      const result = await waypointService.rebroadcastTick();
+
+      expect(result).toBeNull();
+      expect(broadcastWaypoint).not.toHaveBeenCalled();
+      expect(mockMarkRebroadcasted).not.toHaveBeenCalled();
+    });
+
+    it('broadcasts normally when the source manager reports TX enabled', async () => {
+      const row = eligibleRow();
+      mockFindOldestEligible.mockResolvedValueOnce(row);
+      const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+      mockGetManager.mockReturnValueOnce({ broadcastWaypoint, isTxEnabled: () => true });
+      mockMarkRebroadcasted.mockResolvedValueOnce(true);
+      mockGet.mockResolvedValueOnce({ ...row, lastBroadcastAt: 1234 });
+
+      const result = await waypointService.rebroadcastTick();
+
+      expect(broadcastWaypoint).toHaveBeenCalledOnce();
+      expect(result).not.toBeNull();
+    });
+
+    it('broadcasts normally when the manager has no isTxEnabled (e.g. a MeshCore manager, never gated)', async () => {
+      const row = eligibleRow();
+      mockFindOldestEligible.mockResolvedValueOnce(row);
+      const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+      mockGetManager.mockReturnValueOnce({ broadcastWaypoint });
+      mockMarkRebroadcasted.mockResolvedValueOnce(true);
+      mockGet.mockResolvedValueOnce({ ...row, lastBroadcastAt: 1234 });
+
+      const result = await waypointService.rebroadcastTick();
+
+      expect(broadcastWaypoint).toHaveBeenCalledOnce();
+      expect(result).not.toBeNull();
+    });
+  });
 });
 
 describe('expireSweep', () => {

--- a/src/server/services/waypointService.ts
+++ b/src/server/services/waypointService.ts
@@ -331,6 +331,16 @@ class WaypointService {
       return null;
     }
 
+    // TX-disabled Meshtastic radios cannot send the waypoint OTA; skip quietly
+    // and leave lastBroadcastAt untouched so it retries once TX re-enables (#4294).
+    // MeshCore/other manager types don't expose isTxEnabled and are never gated.
+    if (typeof manager.isTxEnabled === 'function' && !manager.isTxEnabled()) {
+      logger.debug(
+        `[waypointService] rebroadcastTick: TX disabled on source ${candidate.sourceId}, skipping`,
+      );
+      return null;
+    }
+
     try {
       const packetId = await manager.broadcastWaypoint({
         id: candidate.waypointId,


### PR DESCRIPTION
## Summary
Phase 1 of the TX-disabled (receive-only mode) epic #4294. MeshMonitor previously force-overwrote `lora.txEnabled` to `true` on every LoRa config save, channel-URL import/export, and remote config import — silently reverting intentional listen-only nodes (the reported bug: a ROUTER_LATE listen-only MQTT relay whose TX-off config got flipped back on by any unrelated config save). This PR makes the backend honor the flag and fail cleanly everywhere a transmit can no longer happen, while keeping everything that still works (RX, local-node admin over TCP — the path used to re-enable TX) fully functional.

## Changes
- **Typed error + choke point:** new property-branded `TxDisabledError` (`src/server/errors/txDisabledError.ts`, `isTxDisabledError()` predicate — no `instanceof`), thrown by all six OTA transmit primitives in `meshtasticManager.ts` via a new cheap in-memory `isTxEnabled()` accessor (fail-open true until config arrives). Covers every send path transitively.
- **Remote admin gated, local admin untouched:** `remoteAdminService.assertTxForRemoteTarget()` in all 7 remote-capable senders; local-node targets never gated.
- **Route mapping:** guarded routes return `409` with code `TX_DISABLED` (messages send, all 5 mesh-request handlers, remote admin handlers, module-config request, v1 API in its own envelope convention).
- **The direct bug fix:** `POST /api/config/lora` passes the submitted `txEnabled` through. When the caller omits the field it is **backfilled from the device's current state** — `setLoRaConfig` sends the ENTIRE LoRaConfig struct and proto3 decodes a missing bool as `false`, so omission would otherwise silently kill the radio (the original #1328 mechanism).
- **Import/export preservation:** channel-URL and admin config **exports emit the device's actual `txEnabled`**; **imports preserve the target device's current value** via explicit backfill (local: `isTxEnabled()`; remote: cached remote config → decoded URL value → fail-open true, with a `TODO(#4294 follow-up)` for a fully-accurate remote fetch). `adminRoutes` had its own duplicated import logic with two additional force-true sites — both fixed.
- **Autonomous senders skip at tick time** (interval keeps running; TX re-enable resumes automatically; one info log per state change, no per-tick spam): traceroute scheduler, key-repair, remote LocalStats, remote-admin scanner, auto-announce, waypoint rebroadcast, auto-ack, auto-responder, auto-ping, timer/cron messages.
- **Automation engine:** a mesh-send action against a TX-disabled source records `{ skipped: true, reason: 'TX_DISABLED' }` (run stays `completed`), mirroring the existing MeshCore-unsupported skip shape.
- **Never gated:** local-node admin, time-sync, MQTT bridge downlink, MeshCore managers, DB-only services.
- **Drive-by fix:** `POST /config/module/request` was registered after the `/module/:moduleType` wildcard and was unreachable (Express matched `moduleType='request'`, 400ing every call). Reordered.

## Issues Resolved
Relates to #4294 (Phase 1 of 3 — frontend gating UX and docs follow in Phases 2/3)

## Documentation Updates
- `docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md` (epic plan + Phase 1 deviations) and `TX_DISABLED_PHASE1_SPEC.md` (implementation spec) added.
- User-facing receive-only-mode docs and v1 API 409 documentation land in Phase 3 per the epic plan.

## Testing
- [x] Full Vitest suite: `success: true` — 3378/3378 suites, 11,001 passed, 0 failed (109 pending = documented PG/MySQL container skips)
- [x] Server TypeScript compiles cleanly (`tsc -p tsconfig.server.json`)
- [x] `npm run lint:ci` — 0 in-repo FAIL lines
- [x] New coverage: guard unit tests (6 primitives + remote-vs-local admin), route-harness 409 tests across messages/mesh-requests/admin/v1, config passthrough + omitted-field backfill regression test, import/export preservation (incl. all 3 remote fallback tiers), scheduler-skip tests, automation skip-and-record, restore-never-touches-lora lock-in
- [ ] Reviewer: with a TX-disabled source, verify send/traceroute/remote-admin return 409 `TX_DISABLED` while local-node config reads/writes still succeed; saving an unrelated LoRa field must no longer re-enable TX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW