### PR TITLE
feat(ui): gate transmit-dependent controls when TX is disabled (#4294)

### DIFF
--- a/docs/internal/dev-notes/TX_DISABLED_PHASE2_SPEC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_PHASE2_SPEC.md
@@ -1,0 +1,372 @@
+# TX-Disabled Support — Phase 2 Implementation Spec (Frontend gating UX)
+
+**Epic:** #4294 (see `TX_DISABLED_SUPPORT_EPIC.md`). Phase 1 (backend) is merged: every
+transmit primitive throws `TxDisabledError`, routes map it to
+`fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source')`, `POST /api/config/lora`
+now passes the caller's `txEnabled` through (backfilling from device state only when omitted),
+and imports/restores preserve the device's current value.
+
+Phase 2 makes the **frontend** honor the state: every send/request control that cannot work
+with TX disabled renders **disabled with an explanatory tooltip** (never hidden — reads still
+work); the LoRa TX checkbox gets a danger-confirm on disable; TX state refreshes promptly after
+a save; and any 409 that slips through a race shows a clear toast instead of a silent failure.
+
+> **All file:line anchors below were re-verified against the `feature/tx-disabled-frontend`
+> worktree (origin/main + Phase 1). The App.tsx anchors in the epic doc had drifted; these are
+> current.** Line numbers may still shift by a few lines as the implementer edits above them —
+> anchor on the quoted code, not the number.
+
+---
+
+## 1. Reuse inventory (verified — do NOT introduce new primitives for these)
+
+| Concern | What exists | Location |
+|---|---|---|
+| **Per-source TX state** | `useTxStatus({ baseUrl, sourceId })` → `{ isTxDisabled, ... }`, TanStack Query key `['txStatus', baseUrl, sourceId]`, 30s poll. Already consumed once. | `src/hooks/useTxStatus.ts`; consumer `src/App.tsx:245` |
+| **Toast** | `useToast()` → `showToast(message, type, duration?)`, `type ∈ 'success'\|'error'\|'warning'\|'info'`. Provider wraps the app. | `src/components/ToastContainer.tsx` |
+| **Confirm dialog** | The app has **no** shared ConfirmDialog component — the established danger-confirm pattern is `window.confirm(t('<key>'))`. Used verbatim for a comparable radio-config danger (router role) at `DeviceConfigSection.tsx:127` and `SecurityConfigSection.tsx:153`. **Reuse `window.confirm`.** | — |
+| **i18n** | `react-i18next` `const { t } = useTranslation()`. Keys are **flat dotted strings** (e.g. `"lora_config.tx_enabled"`) in per-language JSON under `public/locales/{lng}.json`, loaded over HTTP. `fallbackLng: 'en'`. `t('key', 'Default')` fallback form is used in places. | `src/config/i18n.ts`; strings in `public/locales/en.json` |
+| **Disabled + tooltip pattern** | Native `disabled={...}` on the control + `title={...}` for the hover explanation. This is the app-wide idiom (e.g. `MessagesTab.tsx` exchange buttons `disabled={connectionStatus !== 'connected' || ...}`; `node-indicator-icon title={t(...)}`). No tooltip component. | throughout |
+| **`fetch` wrapper** | `useAuthFetch()` → `authFetch(url, opts)` returns the raw `Response` (adds CSRF, retries 403). App send-handlers read `response.ok` / `await response.json()`. **New code must use `authFetch`, never raw `fetch`** (ratchet ban in `src/components/**`, `src/pages/**`). | `src/hooks/useAuthFetch.ts` |
+| **ApiService errors** | `apiService.request()` throws `ApiError` with `.status` and `.code` on non-2xx (reads `body.code`). So `apiService.setLoRaConfig(...)` / AdminCommandsTab `executeCommand(...)` throw `ApiError{ code: 'TX_DISABLED' }` on a 409. | `src/services/api.ts:43-60,148-160` |
+| **QueryClient** | `useQueryClient()` from `@tanstack/react-query`; App already holds one (`src/App.tsx:357`). | — |
+| **Global banner** | `banners.tx_disabled` string already exists and renders via `AppBanners` when `isTxDisabled`. **Keep as the single paused-features indicator — no per-feature badges.** | `src/components/AppBanners/AppBanners.tsx` |
+
+### Existing i18n keys to reuse (already present, do not re-add)
+- `banners.tx_disabled` — the global banner copy.
+- `lora_config.tx_enabled` = "TX Enabled", `lora_config.tx_enabled_description` = "Enable radio transmission. Disable to make the node listen-only." (ConfigurationTab LoRa form label).
+- `admin_commands.tx_enabled` / `admin_commands.tx_enabled_description` (AdminCommandsTab LoRa form label).
+- `config.lora_saved_toast`, `config.lora_failed` (ConfigurationTab save toasts).
+
+---
+
+## 2. New shared code (small, once)
+
+### 2a. TX-disabled detection helper — `src/utils/txDisabled.ts` (new, pure, no React)
+Pure functions so both `authFetch` (Response) call-sites and `apiService`/`ApiError` call-sites
+share one definition and it is unit-testable. **No CSS, no hook, no `any`.**
+
+```ts
+export const TX_DISABLED_CODE = 'TX_DISABLED';
+
+/** True when a parsed error body from a 409 signals TX disabled. */
+export function isTxDisabledBody(status: number, body: unknown): boolean {
+  return (
+    status === 409 &&
+    typeof body === 'object' && body !== null &&
+    (body as { code?: unknown }).code === TX_DISABLED_CODE
+  );
+}
+
+/** True when a thrown ApiError (or any {code}) is a TX-disabled error. */
+export function isTxDisabledError(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null &&
+    (err as { code?: unknown }).code === TX_DISABLED_CODE
+  );
+}
+```
+
+Ships with `src/utils/txDisabled.test.ts` (WP1).
+
+### 2b. New i18n keys — add to `public/locales/en.json` ONLY
+en.json is the source of truth (4627 keys today; es has 4598 — English leads, Weblate propagates
+translations, and `fallbackLng:'en'` covers any locale that hasn't caught up). **Do NOT hand-edit
+`de/es/fr/nb_NO/pl/pt_BR/ru/sv/zh_Hans.json`** — those are Weblate-managed; missing keys fall back
+to English automatically. Add:
+
+| Key | English value |
+|---|---|
+| `tx_disabled.control_tooltip` | `Transmit is disabled on this node's radio. Re-enable TX in the LoRa configuration to use this.` |
+| `tx_disabled.send_blocked_toast` | `Transmit is disabled on this source — nothing was sent.` |
+| `tx_disabled.remote_admin_notice` | `Remote-node admin is unavailable while Transmit is disabled on this source. Local-node admin still works — you can re-enable TX in the LoRa Config below.` |
+| `lora_config.tx_disable_confirm` | `Disable transmit on this node?\n\nThe node becomes invisible to the mesh: it can still receive, but it will not send messages, respond to traceroutes, or accept remote administration until you re-enable TX. Continue?` |
+
+`AdminCommandsTab`'s inline LoRa checkbox reuses `lora_config.tx_disable_confirm` for its confirm
+(same consequences); no separate `admin_commands.*` confirm key needed.
+
+---
+
+## 3. File-by-file changes
+
+Gating keys off a single derived boolean. In `App.tsx`, compute once (near the existing
+`isTxDisabled` at :245) and thread it down. **MQTT-bridge sources are never gated**, so combine
+with the existing `isMqttBridge` flag:
+
+```ts
+// App.tsx, after line 245
+const txGated = isTxDisabled && !isMqttBridge;   // Meshtastic TCP source with TX off
+```
+(These surfaces — ChannelsTab / MessagesTab / NodePopup — are inherently the Meshtastic unified
+views; MeshCore has its own components and is out of scope by construction.)
+
+### 3.1 `src/App.tsx` — send-handler 409 handling + prop threading
+The handlers use `authFetch` and already branch on `response.ok`. In each handler's non-ok /
+catch path, detect TX-disabled and surface the toast. App already has `showToast`, `t`,
+`isTxDisabledBody`. Handlers (verified):
+
+- `handleSendMessage` — `:2591` (channel send + Enter). Currently returns early on `!connected`.
+  Read `errorData` in the failure branch and, if `isTxDisabledBody(response.status, errorData)`,
+  `showToast(t('tx_disabled.send_blocked_toast'), 'warning')` and return before the generic `setError`.
+- `handleSendBell` (channel) `:2719`, `handleSendBellDM` `:2744` — same failure-branch check.
+- `handleSendPosition` `:2768` — same.
+- `handleResendMessage` `:2790` — same.
+- `handleRequestNeighborInfo` `:2068`, `handleRequestTelemetry` `:2118` — these currently
+  `catch` and only `logger.error`. Add a `response.ok`/`errorData.code` inspection (telemetry
+  already parses `detail`; neighborinfo needs a `response.ok` check added) and toast on TX-disabled.
+- Tapback (`handleSendTapback`) and exchange position/nodeinfo (which route through the same
+  `/api/position/request` and `/api/nodeinfo/request` handlers) — apply the same check in their
+  handler bodies.
+
+Thread the gate flag into the two tab renders and the two NodePopup renders:
+- `<ChannelsTab ... />` at `:3628` — add `txDisabled={txGated}`.
+- `<MessagesTab ... />` at `:3680` — add `txDisabled={txGated}`.
+- Map `<NodePopup>` inside the map route `~:3546` region and the standalone `<NodePopup>` `~:3792`
+  — add `txDisabled={txGated}` to both.
+
+> Ratchet note: adding a `showToast`/`isTxDisabledBody` call inside these handlers introduces no
+> new hook deps (they are plain async functions, not `useCallback`). No `react-hooks/exhaustive-deps`
+> impact in App.tsx.
+
+### 3.2 `src/components/ChannelsTab.tsx` — channel send box, bell, position, tapback
+- Add `txDisabled?: boolean;` to `ChannelsTabProps` (near `connectionStatus: string;` at `:91`)
+  and destructure it (near `:172`).
+- The send form renders only when `connectionStatus === 'connected'` (`:1185`) — keep that; we
+  disable within it, not hide. In the input/button block (`~:1210-1258`):
+  - message textarea `~:1212`: add `disabled={txDisabled}` and wrap or set `title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}`; also guard the Enter handler (`~:1225`) so `handleSendMessage` is not called when `txDisabled`.
+  - bell button `~:1246` (`onSendBell`), position button `~` (`onSendPosition`), send button `:1255` (`disabled={!newMessage.trim()}` → `disabled={!newMessage.trim() || txDisabled}`): add `|| txDisabled` and the conditional `title`.
+- Tapback: the reaction/emoji controls — emoji-picker button `:1099` (`setEmojiPickerMessage`) and
+  existing-reaction click `:1160` (`handleSendTapback`). Add `disabled={txDisabled}` /
+  `title` to the emoji-picker button; for the reaction chips, either disable the click when
+  `txDisabled` or rely on the handler-level 409 toast (chips are also used to read reactions, so
+  prefer keeping them clickable and letting the toast fire). Document the choice inline.
+
+**Because the disabled `title` on a `<button disabled>` does not always fire hover events in every
+browser, wrap the send/bell/position button group's tooltip on an enclosing `<span title=...>`**
+(same trick already acceptable in the codebase) if QA finds the native title doesn't show. The
+input `title` fires reliably.
+
+### 3.3 `src/components/MessagesTab.tsx` — DM send box, bell, resend, exchange/request buttons
+- Add `txDisabled?: boolean;` to `MessagesTabProps` (near `connectionStatus: string;` `:118`),
+  destructure near `:224`.
+- DM send box renders under `connectionStatus === 'connected'` (`:1777`); keep shown, disable within:
+  - DM textarea `~:1798` and send button `:1833` (`disabled={!newMessage.trim()}` → `|| txDisabled`), bell button `:1825` (`onSendBell`): add `|| txDisabled` + conditional `title`.
+- The per-node action buttons already read `connectionStatus !== 'connected' || <loading>`. Add
+  `|| txDisabled` to each and set the `title` to `tx_disabled.control_tooltip` when `txDisabled`:
+  - traceroute `:1208` and the second traceroute button `:2046`/`:2067` (node-detail panel).
+  - send-position / exchange-position `:1239`.
+  - nodeinfo / key-repair exchange `:1250` and `:2132`.
+  - request-telemetry `:1261`.
+  - **Leave `admin scan` `:1295` as-is** unless it maps to a transmit primitive — verify; the
+    remote-admin scanner sends over LoRa, so if it fires an OTA request, gate it too (`|| txDisabled`).
+    (It is a request; gate it.)
+
+### 3.4 `src/components/NodePopup/NodePopup.tsx` + `src/components/map/popups/sections.tsx` — map traceroute
+- `NodePopup` already receives `connectionStatus`, `tracerouteLoading`, `onTraceroute`. Add
+  `txDisabled?: boolean;` to `NodePopupProps` (`:32-47`), destructure (`:53-68`).
+- The traceroute run button lives in `TracerouteBody` (`sections.tsx:360`), gated by
+  `runDisabled` (`:356/:367`, applied to the `<button ... disabled={runDisabled}>` at `:432`).
+  - In `NodePopup`, OR `txDisabled` into the value passed as `runDisabled` (`:182`:
+    `runDisabled={connectionStatus !== 'connected' || tracerouteLoading === node.user?.id || txDisabled}`).
+  - Add an optional `runDisabledReason?: string` prop to `TracerouteBodyProps` and set
+    `title={runDisabledReason}` on the button (so the tooltip explains *why*). `NodePopup` passes
+    `runDisabledReason={txDisabled ? t('tx_disabled.control_tooltip') : undefined}`.
+- `sections.tsx` is a shared popup primitive: adding one optional prop + `title` is additive and
+  keeps its existing tests green.
+
+### 3.5 `src/hooks/useSourceView.ts` — node-list/map traceroute 409 race
+`handleTraceroute` (`:183-225`) is fire-and-forget (`authFetch` then poll; no `response.ok`
+check). Add a `response.ok` guard: on non-ok, parse the body and if
+`isTxDisabledBody(response.status, body)` call `showToast(t('tx_disabled.send_blocked_toast'), 'warning')`
+(both `showToast` and `t` are already in scope, `:140`). This covers the race where the button
+wasn't yet disabled. **Add `showToast`/`t` to the `useCallback` dep array only if not already
+present** (they are already effectively closed over — confirm the existing dep list at `:225` and
+extend minimally to avoid a NEW `exhaustive-deps` violation).
+
+### 3.6 `src/components/configuration/LoRaConfigSection.tsx` — danger-confirm on TX disable
+The `txEnabled` checkbox (`onChange={(e) => setTxEnabled(e.target.checked)}`) is already a real,
+settable control. Wrap the change to confirm only on the true→false transition:
+
+```tsx
+const handleTxEnabledChange = (checked: boolean) => {
+  if (!checked && txEnabled) {
+    if (!window.confirm(t('lora_config.tx_disable_confirm'))) return; // keep it checked
+  }
+  setTxEnabled(checked);
+};
+// ...
+<input id="txEnabled" type="checkbox" checked={txEnabled}
+       onChange={(e) => handleTxEnabledChange(e.target.checked)} ... />
+```
+No other change here; the parent already sends the real value.
+
+### 3.7 `src/components/ConfigurationTab.tsx` — remove nothing to add; wire freshness invalidation
+- `handleSaveLoRaConfig` (`:857`) already sends the real `txEnabled` from state (`:888`) — Phase 1
+  backend consumes it directly. **No force-true to remove here** (the `useState(true)` seed at `:89`
+  is only a pre-load default; `:426-427` overwrites it from device config when present — correct
+  preserve-current behavior).
+- After the successful `apiService.setLoRaConfig(...)` (right after `showToast(t('config.lora_saved_toast')...)`
+  at `:893`), invalidate TX status so the banner + gating update promptly:
+  ```ts
+  queryClient.invalidateQueries({ queryKey: ['txStatus'] }); // prefix match → all sources
+  ```
+  Add `import { useQueryClient } from '@tanstack/react-query';` and
+  `const queryClient = useQueryClient();` (not currently in this file).
+
+### 3.8 `src/components/AdminCommandsTab.tsx` — remove force-true, gate remote actions, confirm, invalidate
+- **Remove the two force-true load defaults** (epic exit criterion 3). At `:503` and `:1059`:
+  `txEnabled: config.txEnabled ?? true,` → `txEnabled: config.txEnabled !== false,`
+  (keeps default-true only when genuinely absent, but reflects an explicit device `false` —
+  matches the `tx-status` default-true convention rather than force-coercing). The send path
+  (`:1652 txEnabled: configState.lora.txEnabled`) already forwards the real value — leave it.
+  > Note: the epic referenced `useAdminCommandsState.ts:223`; **that file does not exist in this
+  > tree** — the only frontend force-true sites are these two `?? true` lines in AdminCommandsTab.
+- **Compute a component-level remote flag.** `localNodeNum`/`isLocalNode` are computed inline in
+  several handlers (`:659`, `:933`, `:1193`). Hoist a memo near the top of the component:
+  ```ts
+  const localNodeNum = useMemo(
+    () => nodes.find(n => (n.user?.id || n.nodeId) === currentNodeId)?.nodeNum,
+    [nodes, currentNodeId]
+  );
+  const isManagingRemoteNode =
+    selectedNodeNum !== null && selectedNodeNum !== 0 && selectedNodeNum !== localNodeNum;
+  ```
+- **TX status for the active source.** Add `const { isTxDisabled } = useTxStatus({ baseUrl, sourceId });`
+  (component already has `sourceId`; import the hook). Derive
+  `const remoteAdminBlocked = isManagingRemoteNode && isTxDisabled;`
+- **Gate remote-target actions (not local).** `executeCommand` (`:1407`) is the single choke point
+  for every remote admin send and already shows a toast on error. Add, at the top of
+  `executeCommand`, an early guard:
+  ```ts
+  if (remoteAdminBlocked) { showToast(t('tx_disabled.remote_admin_notice'), 'warning'); return; }
+  ```
+  and, in its `catch`, detect a 409 race — `if (isTxDisabledError(error)) showToast(t('tx_disabled.send_blocked_toast'), 'warning'); else <existing>`.
+  Add `remoteAdminBlocked` to the `executeCommand` `useCallback` deps (it already depends on
+  `showToast`, `t`). Because **local-node admin never sets `isManagingRemoteNode`**, reboot /
+  set-time / local config-read/write / **local `setLoRaConfig`** stay fully usable — this is the
+  path that re-enables TX.
+- **Disable the remote action buttons + tooltip.** For the action buttons that target the remote
+  node (reboot, purge NodeDB, favorite/ignore, the per-config "Set" buttons), add
+  `disabled={... || remoteAdminBlocked}` and `title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}`.
+  (Belt-and-suspenders with the `executeCommand` guard.)
+- **Inline notice.** When `remoteAdminBlocked`, render a notice block at the top of the tab body:
+  `{remoteAdminBlocked && <div className="admin-notice-banner">{t('tx_disabled.remote_admin_notice')}</div>}`
+  (reuse an existing warning/notice class if present in AdminCommandsTab's stylesheet; otherwise a
+  minimal inline style is acceptable here since this is an existing global-styled component, not a
+  new CSS-module component).
+- **Inline LoRa TX checkbox confirm** (`:2811-2812`): wrap like §3.6 —
+  `onChange={(e) => { const checked = e.target.checked; if (!checked && configState.lora.txEnabled && !window.confirm(t('lora_config.tx_disable_confirm'))) return; setLoRaConfig({ txEnabled: checked }); }}`.
+- **Freshness invalidation** after a successful local LoRa save (`:1670` `executeCommand('setLoRaConfig', ...)`):
+  add `queryClient.invalidateQueries({ queryKey: ['txStatus'] })` after it resolves. Add
+  `useQueryClient` import + instance. (Harmless for remote saves; correct for local.)
+
+---
+
+## 4. Work packages
+
+Dependency-ordered. **Tests fold into each WP** (no separate test WP). Full Vitest suite must be
+green at the end of each WP.
+
+### WP1 — Shared helper + i18n keys (foundation, no UI behavior yet)
+**Files:** `src/utils/txDisabled.ts` (+`.test.ts`); `public/locales/en.json`.
+- Implement `isTxDisabledBody` / `isTxDisabledError` / `TX_DISABLED_CODE`.
+- Add the four new `en.json` keys (§2b).
+- **Tests:** `txDisabled.test.ts` — truthy on `(409, {code:'TX_DISABLED'})` / `{code:'TX_DISABLED'}`,
+  falsy on other statuses/codes/non-objects.
+- No other file imports it yet → safe to land first, unblocks all others.
+
+### WP2 — LoRa checkbox usability + freshness invalidation (config surfaces)
+**Depends on:** WP1 (i18n key). **Files:** `LoRaConfigSection.tsx`, `ConfigurationTab.tsx`,
+plus the AdminCommandsTab LoRa-checkbox confirm + local-save invalidation + the two `?? true`
+removals **only if** WP4 isn't taken first — to keep file sets disjoint, **do the AdminCommandsTab
+LoRa-checkbox confirm, `?? true` removal, and local-save invalidation in WP4**, and keep WP2 to
+`LoRaConfigSection.tsx` + `ConfigurationTab.tsx`.
+- §3.6 confirm dialog in `LoRaConfigSection`.
+- §3.7 `queryClient.invalidateQueries(['txStatus'])` after ConfigurationTab LoRa save.
+- **Tests:** `LoRaConfigSection` test — unchecking TX with `window.confirm` mocked → `true` calls
+  `setTxEnabled(false)`; mocked → `false` does NOT; checking TX never prompts. `ConfigurationTab`
+  test (extend existing) — successful LoRa save calls `queryClient.invalidateQueries` with the
+  `['txStatus']` key (mock `useQueryClient`).
+
+### WP3 — Messaging + map gating (ChannelsTab / MessagesTab / NodePopup / useSourceView / App threading)
+**Depends on:** WP1. **Files:** `App.tsx`, `ChannelsTab.tsx`, `MessagesTab.tsx`,
+`NodePopup/NodePopup.tsx`, `map/popups/sections.tsx`, `hooks/useSourceView.ts` (+ their tests).
+- §3.1 App: `txGated` derivation, prop threading, send-handler 409 toasts.
+- §3.2/§3.3/§3.4/§3.5 disabled+tooltip on every messaging/map send control; 409 race toasts.
+- **Tests:** new `ChannelsTab.txDisabled.test.tsx`, `MessagesTab.txDisabled.test.tsx`
+  (render with `txDisabled` and assert send/bell/position/traceroute/exchange/telemetry controls
+  are `disabled` and carry the tooltip `title`); extend `NodePopup.test.tsx` and
+  `sections.test.tsx` for `runDisabled`/`runDisabledReason`. Assert reads remain enabled.
+- Disjoint from WP2/WP4 file sets → parallelizable with WP2.
+
+### WP4 — AdminCommandsTab remote gating + force-true removal + confirm + invalidation
+**Depends on:** WP1. **Files:** `AdminCommandsTab.tsx` (+ `AdminCommandsTab.txDisabled.test.tsx`).
+- §3.8 in full: `?? true` → `!== false`; `useTxStatus`; `isManagingRemoteNode`/`remoteAdminBlocked`;
+  `executeCommand` guard + catch; remote action buttons disabled+title; inline notice; inline LoRa
+  checkbox confirm; local-save `['txStatus']` invalidation.
+- **Tests:** remote node selected + TX off → `executeCommand` guarded (no network call, notice
+  toast), remote buttons disabled, notice rendered. Local node selected + TX off → admin fully
+  enabled (reboot/set-time/local setLoRaConfig NOT disabled). Unchecking inline TX prompts
+  `window.confirm`. Successful local LoRa save invalidates `['txStatus']`.
+- Single-file (plus its test) → parallelizable with WP2 and WP3.
+
+**Ordering:** WP1 first; then WP2 ‖ WP3 ‖ WP4 in parallel (disjoint files). Merge order is flexible.
+
+---
+
+## 5. ESLint ratchet / conventions guardrails
+
+- **No raw `fetch()`** in any touched component/page — reuse `authFetch` / `apiService`. New util
+  `txDisabled.ts` does no I/O.
+- **`react-hooks/exhaustive-deps` is ratcheted.** When adding `txDisabled` / `remoteAdminBlocked` /
+  `isTxDisabledBody` references inside an existing `useCallback` (`useSourceView.handleTraceroute`,
+  `AdminCommandsTab.executeCommand`), **add every newly-referenced value to that callback's dep
+  array** so no NEW violation is introduced. App.tsx send handlers are plain functions — no dep impact.
+- **No `any`** in new code (`no-explicit-any` is an error). The helper uses `unknown` + narrowing.
+- **No new global CSS.** Changes are `disabled`/`title`/existing-class additions. The only new
+  visible chrome is the AdminCommandsTab inline notice — reuse an existing notice class; if none
+  fits, a minimal inline style is acceptable in that already-global-styled component (a new CSS
+  module for one banner line is not warranted). Do not add rules to the frozen `src/styles/*.css`.
+- **UiIcon rule:** if the notice or any new control needs an icon, use `UiIcon`, never a literal emoji.
+- Verify locally with `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` (empty = pass).
+
+---
+
+## 6. Browser-validation flows (live dev container, chrome-devtools)
+
+Prereq: configure a **Meshtastic TCP source with TX disabled** (set `lora.txEnabled=false` on the
+device, or via the LoRa Config UI using the new confirm — then confirm the global
+`banners.tx_disabled` banner is showing). Drive:
+
+1. **Channel send box** (Channels tab): input + send + bell + position buttons render **disabled**;
+   hovering shows the `tx_disabled.control_tooltip`. Reactions/reads still visible. Enter in the box
+   does not send.
+2. **DM send box** (Messages tab): DM input/send/bell disabled + tooltip; resend button on own
+   messages disabled.
+3. **Per-node request buttons** (Messages node detail): traceroute, exchange position, exchange
+   nodeinfo/key-repair, request telemetry, request neighbor-info, admin-scan all disabled + tooltip.
+4. **Map popup** (Nodes/Map): open a node popup → the "Run traceroute" button is disabled with the
+   tooltip; the rest of the popup (identity/signal/position) reads normally.
+5. **AdminCommandsTab — remote node:** select a *remote* node → inline "remote admin unavailable"
+   notice appears; remote action buttons disabled; clicking a still-enabled path yields the
+   `send_blocked_toast` (race), not a crash.
+6. **AdminCommandsTab — local node:** select the *local* node → all admin controls usable
+   (reboot, set-time, config read/write). **Toggle TX back on via the local LoRa checkbox** — the
+   `lora_config.tx_disable_confirm` prompt appears only when *disabling*; re-enabling does not prompt.
+7. **Freshness:** after saving the LoRa config (either ConfigurationTab or local AdminCommandsTab),
+   confirm the global banner and all gated controls update within a couple seconds **without a page
+   reload** (the `['txStatus']` invalidation), and again passively within the 30s poll if you change
+   TX on the device directly.
+8. **Race toast:** with TX disabled, momentarily race a send before the poll updates (e.g. via a
+   direct API call in devtools) and confirm the backend 409 surfaces as the friendly warning toast.
+9. **Negative control:** repeat 1–4 on a normal TX-enabled source and on an MQTT-bridge source —
+   nothing should be gated.
+
+---
+
+## 7. Out of scope (Phase 3)
+
+- Automations builder `sendMessage` warning badge.
+- v1 API docs, user-facing receive-only docs, locale-string translation verification (Weblate).
+- MeshCore / MQTT-bridge TX gating (intentionally never gated — different transport).
+- Any backend change (Phase 1 is the enforcement point; Phase 2 is UX only).

--- a/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
@@ -2,9 +2,29 @@
 
 **Epic issue:** #4294 (original bug report, reopened as tracker; #4308 closed as duplicate)
 **Status:**
-- [x] Phase 1 — Backend: honor the flag + central guard (branch `feature/tx-disabled-backend`)
-- [ ] Phase 2 — Frontend: gating UX
+- [x] Phase 1 — Backend: honor the flag + central guard (PR #4309, merged)
+- [x] Phase 2 — Frontend: gating UX (branch `feature/tx-disabled-frontend`)
 - [ ] Phase 3 — Polish + docs
+
+**Phase 2 deviations & findings (2026-07-23):**
+- No shared ConfirmDialog exists — reused the app's `window.confirm(t(...))` danger idiom
+  (as DeviceConfigSection does). Tooltips use native `disabled` + `title` (app-wide idiom).
+- One gated surface the spec's inventory missed: `NodesTab.tsx` renders `TracerouteBody`
+  directly for the MAIN map popup (a separate path from App's single `<NodePopup>`). Gated
+  via an exported pure `isTracerouteRunDisabled()` helper (WP3 follow-up commit 0e451008).
+  Audit confirmed no other TracerouteBody/NodeActions consumers were missed (MeshCoreMap =
+  NodeActions only + never gated; DashboardNodePopup = read-only).
+- `useAdminCommandsState.ts` (referenced in the original scope) does not exist — the only
+  frontend force-true sites were two `?? true` in AdminCommandsTab, changed to `!== false`.
+- AdminCommandsTab residual: Device/Module config-section "Set" buttons live in separate
+  files and are protected by the `executeCommand` choke-point guard + the inline
+  remote-admin notice, not each visually disabled. Functionally correct (no remote write
+  succeeds); proven by a test clicking a stubbed section save and asserting no network call.
+  Per-button disabling of those sections is a possible Phase 3 nicety, not a gap.
+- Browser-validated live (TX-disabled Sandbox source): channels/DM gating + tooltips, LoRa
+  confirm (accept/cancel), banner-appears-without-reload after save (invalidation), map-popup
+  traceroute gating, clean console. Note: the live sandbox HARDWARE node reverts
+  `tx_enabled` to true on its own config re-read — a device quirk, not app behavior.
 
 **Phase 1 deviations & findings (2026-07-23):**
 - **"Preserve" ≠ strip.** `setLoRaConfig` sends the ENTIRE LoRaConfig struct (whole-message

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -118,6 +118,10 @@
   "banners.update_manual": "See the update guide for instructions specific to your deployment.",
   "banners.update_guide_link": "Update guide",
 
+  "tx_disabled.control_tooltip": "Transmit is disabled on this node's radio. Re-enable TX in the LoRa configuration to use this.",
+  "tx_disabled.send_blocked_toast": "Transmit is disabled on this source — nothing was sent.",
+  "tx_disabled.remote_admin_notice": "Remote-node admin is unavailable while Transmit is disabled on this source. Local-node admin still works — you can re-enable TX in the LoRa Config below.",
+
   "purgeModal.title": "Purge Data for {{nodeName}}",
   "purgeModal.warning": "These actions cannot be undone. All data for this node will be permanently deleted.",
   "purgeModal.purgeMessages": "Purge All Messages",
@@ -3257,6 +3261,7 @@
   "lora_config.ok_to_mqtt_description": "Sets the ok_to_mqtt flag on outgoing packets, allowing them to be forwarded to MQTT by other nodes",
   "lora_config.tx_enabled": "TX Enabled",
   "lora_config.tx_enabled_description": "Enable radio transmission. Disable to make the node listen-only.",
+  "lora_config.tx_disable_confirm": "Disable transmit on this node?\n\nThe node becomes invisible to the mesh: it can still receive, but it will not send messages, respond to traceroutes, or accept remote administration until you re-enable TX. Continue?",
   "lora_config.override_duty_cycle": "Override Duty Cycle",
   "lora_config.override_duty_cycle_description": "WARNING: Exceed regulatory duty cycle limits. Use only where permitted by law.",
   "lora_config.pa_fan_disabled": "PA Fan Disabled",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3608,6 +3608,7 @@ function App() {
                   tracerouteBounds={tracerouteBounds}
                   onTraceroute={handleTraceroute}
                   connectionStatus={connectionStatus}
+                  txDisabled={txGated}
                   tracerouteLoading={tracerouteLoading}
                   onDeleteNode={handleDeleteNode}
                   onPurgeNodeFromDevice={handlePurgeNodeFromDevice}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import { ResourceType } from './types/permission';
 import api, { type ChannelDatabaseEntry } from './services/api';
 import { getPacketStats } from './services/packetApi';
 import { logger } from './utils/logger';
+import { isTxDisabledBody } from './utils/txDisabled';
 // generateArrowMarkers moved to useTraceroutePaths hook
 // isNodeComplete/getEffectivePosition/effectiveMapMaxAgeHours/
 // nodePassesTransportFilter/transportCutoffSec moved with processedNodes/
@@ -243,6 +244,8 @@ function App() {
 
   // Monitor device TX status to show warning banner when TX is disabled
   const { isTxDisabled } = useTxStatus({ baseUrl, sourceId });
+  // MQTT-bridge sources are never gated (different transport, not affected by radio TX state)
+  const txGated = isTxDisabled && !isMqttBridge;
 
   // Check for version updates. TanStack Query's refetchInterval replaces the
   // hand-rolled setInterval (#3962 Phase 5.1); the hook stops polling on a 404
@@ -1999,13 +2002,22 @@ function App() {
       const nodeNum = parseInt(nodeNumStr, 16);
 
       // Use direct fetch with CSRF token (consistent with other message endpoints)
-      await authFetch(`${baseUrl}/api/position/request`, {
+      const response = await authFetch(`${baseUrl}/api/position/request`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined, ...(channel !== undefined && { channel }) }),
       });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        setPositionLoading(null);
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+        }
+        return;
+      }
 
       logger.debug(`📍 Position request sent to ${nodeId}`);
 
@@ -2045,13 +2057,22 @@ function App() {
       const nodeNum = parseInt(nodeNumStr, 16);
 
       // Use direct fetch with CSRF token
-      await authFetch(`${baseUrl}/api/nodeinfo/request`, {
+      const response = await authFetch(`${baseUrl}/api/nodeinfo/request`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined, ...(channel !== undefined && { channel }) }),
       });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        setNodeInfoLoading(null);
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+        }
+        return;
+      }
 
       logger.debug(`🔑 NodeInfo request sent to ${nodeId}`);
 
@@ -2080,6 +2101,7 @@ function App() {
       // Set loading state
       setNeighborInfoLoading(nodeId);
 
+      let response: Response;
       if (sourceType === 'meshcore' && sourceId) {
         const normalized = nodeId.toLowerCase();
         if (!/^[0-9a-f]{64}$/.test(normalized)) {
@@ -2087,7 +2109,7 @@ function App() {
           setNeighborInfoLoading(null);
           return;
         }
-        await authFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/neighbors/request`, {
+        response = await authFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/neighbors/request`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ publicKey: normalized }),
@@ -2097,12 +2119,21 @@ function App() {
         // Meshtastic: convert hex nodeId to numeric destination
         const nodeNumStr = nodeId.replace('!', '');
         const nodeNum = parseInt(nodeNumStr, 16);
-        await authFetch(`${baseUrl}/api/neighborinfo/request`, {
+        response = await authFetch(`${baseUrl}/api/neighborinfo/request`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined }),
         });
         logger.debug(`🏠 NeighborInfo request sent to ${nodeId}`);
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        setNeighborInfoLoading(null);
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+        }
+        return;
       }
 
       // Clear loading state after 30 seconds
@@ -2148,6 +2179,11 @@ function App() {
 
       if (!response.ok) {
         const detail = await response.json().catch(() => ({}));
+        if (isTxDisabledBody(response.status, detail)) {
+          setTelemetryRequestLoading(null);
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
         throw new Error(detail.error || `Telemetry request failed (${response.status})`);
       }
 
@@ -2322,6 +2358,10 @@ function App() {
         setTimeout(() => refetchPoll(), 500);
       } else {
         const errorData = await response.json();
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
         setError(`Failed to send reaction: ${errorData.error || 'Unknown error'}`);
       }
     } catch (err) {
@@ -2682,7 +2722,6 @@ function App() {
         setTimeout(() => refetchPoll(), 1000);
       } else {
         const errorData = await response.json();
-        setError(`Failed to send message: ${errorData.error}`);
 
         // Remove the message from local state if sending failed
         setMessages(prev => prev.filter(msg => msg.id !== tempId));
@@ -2696,6 +2735,12 @@ function App() {
           pendingMessagesRef.current = updated; // Update ref
           return updated;
         });
+
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
+        setError(`Failed to send message: ${errorData.error}`);
       }
     } catch (err) {
       setError(`Failed to send message: ${err instanceof Error ? err.message : 'Unknown error'}`);
@@ -2733,6 +2778,10 @@ function App() {
         setTimeout(() => refetchPoll(), 1000);
       } else {
         const errorData = await response.json();
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
         setError(`Failed to send bell: ${errorData.error}`);
       }
     } catch (err) {
@@ -2757,6 +2806,11 @@ function App() {
       if (response.ok) {
         logger.debug('Bell DM sent successfully');
       } else {
+        const errorData = await response.json().catch(() => ({}));
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
         setError('Failed to send bell DM');
       }
     } catch (err) {
@@ -2779,6 +2833,10 @@ function App() {
         setTimeout(() => refetchPoll(), 1000);
       } else {
         const errorData = await response.json();
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
         setError(`Failed to send position: ${errorData.error}`);
       }
     } catch (err) {
@@ -2864,7 +2922,6 @@ function App() {
         setTimeout(() => refetchPoll(), 1000);
       } else {
         const errorData = await response.json();
-        setError(`Failed to resend message: ${errorData.error}`);
 
         // Remove the message from local state if sending failed
         setMessages(prev => prev.filter(msg => msg.id !== tempId));
@@ -2880,6 +2937,12 @@ function App() {
           pendingMessagesRef.current = updated;
           return updated;
         });
+
+        if (isTxDisabledBody(response.status, errorData)) {
+          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          return;
+        }
+        setError(`Failed to resend message: ${errorData.error}`);
       }
     } catch (err) {
       setError(`Failed to resend message: ${err instanceof Error ? err.message : 'Unknown error'}`);
@@ -3669,6 +3732,7 @@ function App() {
             focusMessageId={focusMessageId}
             onFocusMessageHandled={() => setFocusMessageId(null)}
             mqttReadOnly={isMqttBridge}
+            txDisabled={txGated}
           />
               </ErrorBoundary>
             }
@@ -3738,6 +3802,7 @@ function App() {
             focusMessageId={focusMessageId}
             onFocusMessageHandled={() => setFocusMessageId(null)}
             mqttReadOnly={isMqttBridge}
+            txDisabled={txGated}
             toggleIgnored={toggleIgnored}
             toggleHideFromMap={toggleHideFromMap}
             toggleFavorite={toggleFavorite}
@@ -3795,6 +3860,7 @@ function App() {
         onDeleteNode={handleDeleteNode}
         onPurgeNodeFromDevice={handlePurgeNodeFromDevice}
         currentNodeNum={currentNodeId ? (nodes.find(n => n.user?.id === currentNodeId)?.nodeNum ?? null) : null}
+        txDisabled={txGated}
       />
 
       {/* News Popup */}

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import apiService from '../services/api';
 import { useToast } from './ToastContainer';
 import { useResolvedSourceId } from '../hooks/useResolvedSourceId';
+import { useTxStatus } from '../hooks/useTxStatus';
+import { isTxDisabledError } from '../utils/txDisabled';
+import { appBasename } from '../init';
 import { MODEM_PRESET_OPTIONS, REGION_OPTIONS, FEM_LNA_MODE_OPTIONS } from './configuration/constants';
 import type { Channel } from '../types/device';
 import { ImportConfigModal } from './configuration/ImportConfigModal';
@@ -29,9 +33,15 @@ interface AdminCommandsTabProps {
 const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeId, channels: _channels = [], onChannelsUpdated: _onChannelsUpdated }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
   // Resolve a concrete sourceId (context source, else primary) — channel-write
   // admin actions require one; other admin calls default to primary anyway.
   const sourceId = useResolvedSourceId();
+  // TX status for the active source — remote-node admin is unavailable while
+  // TX is disabled (Phase 1 backend rejects every remote transmit primitive
+  // with a 409 TX_DISABLED). Local-node admin is unaffected (it's how a user
+  // re-enables TX in the first place).
+  const { isTxDisabled } = useTxStatus({ baseUrl: appBasename, sourceId });
 
   // Use consolidated state hook for config-related state
   const {
@@ -265,6 +275,21 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       setSelectedNodeNum(nodeOptionsMemo[0].nodeNum);
     }
   }, [nodeOptionsMemo, selectedNodeNum]);
+
+  // Determine if we're managing a remote node (not the local node). Hoisted
+  // once here (rather than recomputed per-handler) so the TX-disabled gate
+  // (#4294) can derive off it too.
+  const localNodeNum = useMemo(
+    () => nodeOptions.find(n => n.isLocal)?.nodeNum,
+    [nodeOptions]
+  );
+  const isManagingRemoteNode = useMemo(
+    () => selectedNodeNum !== null && selectedNodeNum !== 0 && selectedNodeNum !== localNodeNum,
+    [selectedNodeNum, localNodeNum]
+  );
+  // Remote-node admin is unavailable while TX is disabled on this source.
+  // Local-node admin (incl. the LoRa "Set" that re-enables TX) stays usable.
+  const remoteAdminBlocked = isManagingRemoteNode && isTxDisabled;
 
   // Filter nodes based on search query
   const filteredNodes = useMemo(() => {
@@ -500,7 +525,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           sx126xRxBoostedGain: config.sx126xRxBoostedGain,
           ignoreMqtt: config.ignoreMqtt,
           configOkToMqtt: config.configOkToMqtt,
-          txEnabled: config.txEnabled ?? true,  // Default to true if undefined
+          txEnabled: config.txEnabled !== false,  // Default true only when genuinely absent; reflect an explicit device `false` (#4294)
           overrideDutyCycle: config.overrideDutyCycle ?? false,
           paFanDisabled: config.paFanDisabled ?? false
         });
@@ -1056,7 +1081,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   sx126xRxBoostedGain: config.sx126xRxBoostedGain,
                   ignoreMqtt: config.ignoreMqtt,
                   configOkToMqtt: config.configOkToMqtt,
-                  txEnabled: config.txEnabled ?? true,  // Default to true if undefined
+                  txEnabled: config.txEnabled !== false,  // Default true only when genuinely absent; reflect an explicit device `false` (#4294)
                   overrideDutyCycle: config.overrideDutyCycle ?? false,
                   paFanDisabled: config.paFanDisabled ?? false
                 });
@@ -1399,15 +1424,17 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
     }
   };
 
-  // Determine if we're managing a remote node (not the local node)
-  // Calculate this once per render to avoid recalculating in handlers
-  const localNodeNum = nodeOptions.find(n => n.isLocal)?.nodeNum;
-  const isManagingRemoteNode = selectedNodeNum !== null && selectedNodeNum !== localNodeNum && selectedNodeNum !== 0;
-
   const executeCommand = useCallback(async (command: string, params: any = {}) => {
     if (selectedNodeNum === null) {
       showToast(t('admin_commands.please_select_node'), 'error');
       throw new Error(t('admin_commands.no_node_selected'));
+    }
+
+    // Remote-node admin is unavailable while TX is disabled on this source
+    // (#4294) — block before the network round-trip and explain why.
+    if (remoteAdminBlocked) {
+      showToast(t('tx_disabled.remote_admin_notice'), 'warning');
+      throw new Error('TX_DISABLED_REMOTE_ADMIN_BLOCKED');
     }
 
     setIsExecuting(true);
@@ -1421,13 +1448,19 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       showToast(result.message || t('admin_commands.command_executed', { command }), 'success');
       return result;
     } catch (error: any) {
-      showToast(error.message || t('admin_commands.failed_execute_command'), 'error');
+      // A 409 TX_DISABLED can still slip through as a race (TX flipped off
+      // between render and send) even when remoteAdminBlocked was false.
+      if (isTxDisabledError(error)) {
+        showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+      } else {
+        showToast(error.message || t('admin_commands.failed_execute_command'), 'error');
+      }
       console.error('Admin command error:', error);
       throw error;
     } finally {
       setIsExecuting(false);
     }
-  }, [selectedNodeNum, sourceId, showToast, t]);
+  }, [selectedNodeNum, sourceId, remoteAdminBlocked, showToast, t]);
 
   const handleReboot = useCallback(async () => {
     if (!confirm(t('admin_commands.reboot_confirmation', { seconds: rebootSeconds }))) {
@@ -1668,11 +1701,15 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
 
     try {
       await executeCommand('setLoRaConfig', { config });
+      // Refresh TX status so the global banner + gating update promptly
+      // instead of waiting for the 30s poll (#4294). Harmless for remote
+      // saves; this is the path that re-enables TX for the local node.
+      void queryClient.invalidateQueries({ queryKey: ['txStatus'] });
     } catch (error) {
       // Error already handled by executeCommand (toast shown)
       console.error('Set LoRa config command failed:', error);
     }
-  }, [configState.lora, executeCommand]);
+  }, [configState.lora, executeCommand, queryClient]);
 
   const handleSetPositionConfig = useCallback(async () => {
     // Calculate position flags from checkboxes using utility function
@@ -2359,6 +2396,26 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         { id: 'admin-auto-favorites', label: t('auto_favorite.nav', 'Automatic Favorites') },
       ]} />
 
+      {remoteAdminBlocked && (
+        <div
+          className="admin-notice-banner"
+          role="status"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.75rem 1rem',
+            marginBottom: '1rem',
+            borderRadius: '4px',
+            backgroundColor: 'var(--ctp-yellow)',
+            color: 'var(--ctp-base)',
+            fontWeight: 500
+          }}
+        >
+          <UiIcon name="alert" /> {t('tx_disabled.remote_admin_notice')}
+        </div>
+      )}
+
       {/* Node Selection Section */}
       <div id="admin-target-node" className="settings-section">
         <h3>{t('admin_commands.target_node')}</h3>
@@ -2474,14 +2531,15 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             </button>
             <button
               onClick={handleRequestDeviceMetadata}
-              disabled={isLoadingDeviceMetadata || selectedNodeNum === null}
+              disabled={isLoadingDeviceMetadata || selectedNodeNum === null || remoteAdminBlocked}
+              title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}
               className="save-button"
               style={{
                 width: '100%',
                 maxWidth: '600px',
                 marginTop: '0.5rem',
-                opacity: (isLoadingDeviceMetadata || selectedNodeNum === null) ? 0.5 : 1,
-                cursor: (isLoadingDeviceMetadata || selectedNodeNum === null) ? 'not-allowed' : 'pointer'
+                opacity: (isLoadingDeviceMetadata || selectedNodeNum === null || remoteAdminBlocked) ? 0.5 : 1,
+                cursor: (isLoadingDeviceMetadata || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer'
               }}
             >
               {isLoadingDeviceMetadata ? t('common.loading') : t('admin_commands.retrieve_device_metadata', 'Retrieve Device Metadata')}
@@ -2489,12 +2547,13 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem', maxWidth: '600px', width: '100%' }}>
               <button
                 onClick={handleSendReboot}
-                disabled={isLoadingReboot || selectedNodeNum === null}
+                disabled={isLoadingReboot || selectedNodeNum === null || remoteAdminBlocked}
+                title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}
                 className="save-button"
                 style={{
                   flex: 1,
-                  opacity: (isLoadingReboot || selectedNodeNum === null) ? 0.5 : 1,
-                  cursor: (isLoadingReboot || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
+                  opacity: (isLoadingReboot || selectedNodeNum === null || remoteAdminBlocked) ? 0.5 : 1,
+                  cursor: (isLoadingReboot || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer',
                   backgroundColor: 'var(--ctp-red)'
                 }}
               >
@@ -2502,12 +2561,13 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
               </button>
               <button
                 onClick={handleSetTime}
-                disabled={isLoadingSetTime || selectedNodeNum === null}
+                disabled={isLoadingSetTime || selectedNodeNum === null || remoteAdminBlocked}
+                title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}
                 className="save-button"
                 style={{
                   flex: 1,
-                  opacity: (isLoadingSetTime || selectedNodeNum === null) ? 0.5 : 1,
-                  cursor: (isLoadingSetTime || selectedNodeNum === null) ? 'not-allowed' : 'pointer'
+                  opacity: (isLoadingSetTime || selectedNodeNum === null || remoteAdminBlocked) ? 0.5 : 1,
+                  cursor: (isLoadingSetTime || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer'
                 }}
               >
                 {isLoadingSetTime ? t('common.loading') : t('admin_commands.set_time', 'Set Time')}
@@ -2809,7 +2869,16 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             <input
               type="checkbox"
               checked={configState.lora.txEnabled}
-              onChange={(e) => setLoRaConfig({ txEnabled: e.target.checked })}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                // Disabling TX makes the node invisible to the mesh — confirm
+                // only on the true->false transition (#4294). Cancelling
+                // leaves the checkbox in its prior (checked) state.
+                if (!checked && configState.lora.txEnabled && !window.confirm(t('lora_config.tx_disable_confirm'))) {
+                  return;
+                }
+                setLoRaConfig({ txEnabled: checked });
+              }}
               disabled={isExecuting}
               style={{ width: 'auto', margin: 0, flexShrink: 0 }}
             />
@@ -2852,10 +2921,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         <button
           className="save-button"
           onClick={handleSetLoRaConfig}
-          disabled={isExecuting || selectedNodeNum === null}
+          disabled={isExecuting || selectedNodeNum === null || remoteAdminBlocked}
+          title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}
           style={{
-            opacity: (isExecuting || selectedNodeNum === null) ? 0.5 : 1,
-            cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer'
+            opacity: (isExecuting || selectedNodeNum === null || remoteAdminBlocked) ? 0.5 : 1,
+            cursor: (isExecuting || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer'
           }}
         >
           {isExecuting ? t('common.saving') : t('admin_commands.save_lora_config')}
@@ -3445,13 +3515,15 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           <div style={{ flex: 1, minWidth: '200px' }}>
             <h4 style={{ marginBottom: '0.75rem', color: 'var(--ctp-text)' }}><UiIcon name="favorite" /> {t('admin_commands.favorites')}</h4>
             {(() => {
-              const isDisabled = isExecuting || nodeManagementNodeNum === null;
+              const isDisabled = isExecuting || nodeManagementNodeNum === null || remoteAdminBlocked;
+              const blockedTitle = remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined;
 
               return (
                 <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                   <button
                     onClick={handleSetFavoriteNode}
                     disabled={isDisabled}
+                    title={blockedTitle}
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
@@ -3470,6 +3542,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   <button
                     onClick={handleRemoveFavoriteNode}
                     disabled={isDisabled}
+                    title={blockedTitle}
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
@@ -3492,13 +3565,15 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           <div style={{ flex: 1, minWidth: '200px' }}>
             <h4 style={{ marginBottom: '0.75rem', color: 'var(--ctp-text)' }}><UiIcon name="blocked" /> {t('admin_commands.ignored_nodes')}</h4>
             {(() => {
-              const isDisabled = isExecuting || nodeManagementNodeNum === null;
+              const isDisabled = isExecuting || nodeManagementNodeNum === null || remoteAdminBlocked;
+              const blockedTitle = remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined;
 
               return (
                 <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                   <button
                     onClick={handleSetIgnoredNode}
                     disabled={isDisabled}
+                    title={blockedTitle}
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
@@ -3517,6 +3592,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   <button
                     onClick={handleRemoveIgnoredNode}
                     disabled={isDisabled}
+                    title={blockedTitle}
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
@@ -3857,17 +3933,18 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             </label>
             <button
               onClick={handleReboot}
-              disabled={isExecuting || selectedNodeNum === null}
+              disabled={isExecuting || selectedNodeNum === null || remoteAdminBlocked}
+              title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}
               style={{
                 backgroundColor: '#ff6b6b',
                 color: '#fff',
                 padding: '0.75rem 1.5rem',
                 border: 'none',
                 borderRadius: '4px',
-                cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
+                cursor: (isExecuting || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer',
                 fontSize: '1rem',
                 fontWeight: 'bold',
-                opacity: (isExecuting || selectedNodeNum === null) ? 0.6 : 1
+                opacity: (isExecuting || selectedNodeNum === null || remoteAdminBlocked) ? 0.6 : 1
               }}
             >
               <UiIcon name="refresh" /> {t('admin_commands.reboot_device')}
@@ -3875,17 +3952,18 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           </div>
           <button
             onClick={handlePurgeNodeDb}
-            disabled={isExecuting || selectedNodeNum === null}
+            disabled={isExecuting || selectedNodeNum === null || remoteAdminBlocked}
+            title={remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined}
             style={{
               backgroundColor: '#d32f2f',
               color: '#fff',
               padding: '0.75rem 1.5rem',
               border: 'none',
               borderRadius: '4px',
-              cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
+              cursor: (isExecuting || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer',
               fontSize: '1rem',
               fontWeight: 'bold',
-              opacity: (isExecuting || selectedNodeNum === null) ? 0.6 : 1
+              opacity: (isExecuting || selectedNodeNum === null || remoteAdminBlocked) ? 0.6 : 1
             }}
           >
             <UiIcon name="delete" /> {t('admin_commands.purge_node_database')}

--- a/src/components/AdminCommandsTab.txDisabled.test.tsx
+++ b/src/components/AdminCommandsTab.txDisabled.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TX-disabled Phase 2 WP4 (#4294): AdminCommandsTab must gate remote-node
+ * admin while TX is disabled on the active source, while leaving local-node
+ * admin (incl. the LoRa "Set" that re-enables TX) fully usable.
+ *
+ * Covered here:
+ *  - remote node selected + TX off -> executeCommand's internal guard blocks
+ *    the send (no /api/admin/commands call) and shows the remote-admin-notice
+ *    toast; the notice banner renders; remote-target buttons render disabled
+ *    with the explanatory title.
+ *  - local node selected + TX off -> admin stays fully enabled (this is the
+ *    path a user re-enables TX from).
+ *  - the inline LoRa TX checkbox confirms only on the checked->unchecked
+ *    transition (window.confirm), matching the LoRaConfigSection pattern.
+ *  - a successful local `setLoRaConfig` save invalidates the ['txStatus']
+ *    query so the banner/gating refresh without waiting for the 30s poll.
+ *
+ * DeviceConfigurationSection/ModuleConfigurationSection/AutoFavoriteManagementSection
+ * are stubbed (separate files, out of WP4's scope) — the "remote node" test
+ * exercises the executeCommand choke point through the stubbed device-save
+ * callback specifically *because* that button's own disabled state lives in
+ * a file WP4 doesn't touch, so its only protection is the internal guard.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// --- hoisted mutable mock state -----------------------------------------
+const h = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  showToast: vi.fn(),
+  apiPost: vi.fn(),
+  txStatus: { isTxDisabled: false },
+}));
+
+// --- mocks ---------------------------------------------------------------
+// `t` MUST be a stable reference across renders: AdminCommandsTab's
+// nodeOptionsMemo is a useMemo keyed on `t`, feeding an effect that calls
+// setNodeOptions unconditionally -- a fresh `t` identity every render turns
+// that into an infinite render loop (defined inline-per-call, as other
+// txDisabled test files do, it hung the whole suite with no error).
+vi.mock('react-i18next', () => {
+  const t = (_key: string, fallback?: string | Record<string, unknown>) => (typeof fallback === 'string' ? fallback : _key);
+  return { useTranslation: () => ({ t }) };
+});
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: h.invalidateQueries,
+  }),
+}));
+
+vi.mock('./ToastContainer', () => ({ useToast: () => ({ showToast: h.showToast }) }));
+
+vi.mock('../hooks/useResolvedSourceId', () => ({ useResolvedSourceId: () => 'source-1' }));
+
+vi.mock('../hooks/useTxStatus', () => ({ useTxStatus: () => h.txStatus }));
+
+vi.mock('../services/api', () => ({
+  default: {
+    setBaseUrl: vi.fn(),
+    post: h.apiPost,
+    exportChannel: vi.fn(),
+    importChannel: vi.fn(),
+    getAllChannels: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('./SectionNav', () => ({ default: () => null }));
+vi.mock('./configuration/ImportConfigModal', () => ({ ImportConfigModal: () => null }));
+vi.mock('./configuration/ExportConfigModal', () => ({ ExportConfigModal: () => null }));
+vi.mock('./admin-commands/ModuleConfigurationSection', () => ({ ModuleConfigurationSection: () => null }));
+vi.mock('./admin-commands/AutoFavoriteManagementSection', () => ({ default: () => null }));
+// DeviceConfigurationSection lives in a separate file WP4 doesn't touch, so
+// its own "Save" button has no visual remoteAdminBlocked gate — expose only
+// the device-save callback so we can prove the executeCommand choke point
+// (not a visual disabled attribute) is what actually blocks it.
+vi.mock('./admin-commands/DeviceConfigurationSection', () => ({
+  DeviceConfigurationSection: ({ onSaveDeviceConfig }: { onSaveDeviceConfig: () => void | Promise<void> }) => (
+    <button data-testid="device-save" onClick={() => void onSaveDeviceConfig()}>Save Device Config</button>
+  ),
+}));
+
+import AdminCommandsTab from './AdminCommandsTab';
+
+const LOCAL_NODE_ID = '!00000064';
+const REMOTE_NODE_ID = '!000000c8';
+const localNode = { nodeNum: 100, user: { id: LOCAL_NODE_ID, longName: 'Local Node', shortName: 'LOC1' } };
+const remoteNode = { nodeNum: 200, user: { id: REMOTE_NODE_ID, longName: 'Remote Node', shortName: 'REM1' } };
+
+/** Force the relevant CollapsibleSections open so their buttons are in the DOM. */
+function expandSections(ids: string[]) {
+  const obj: Record<string, boolean> = {};
+  ids.forEach((id) => { obj[id] = true; });
+  localStorage.setItem('adminCommandsExpandedSections', JSON.stringify(obj));
+}
+
+/** Select the remote node via the target-node search dropdown. */
+function selectRemoteNode() {
+  const input = screen.getByPlaceholderText('Local Node');
+  fireEvent.focus(input);
+  fireEvent.click(screen.getByText('Remote Node'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  h.txStatus.isTxDisabled = false;
+  h.apiPost.mockResolvedValue({});
+});
+
+describe('AdminCommandsTab — remote-node admin gating while TX disabled (#4294)', () => {
+  it('renders the remote-admin notice and disables remote-target buttons when a remote node is selected + TX is off', async () => {
+    h.txStatus.isTxDisabled = true;
+    expandSections(['admin-reboot-purge']);
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    selectRemoteNode();
+
+    await waitFor(() => {
+      expect(screen.getByText('tx_disabled.remote_admin_notice')).toBeInTheDocument();
+    });
+
+    const rebootButton = screen.getByText('admin_commands.reboot_device').closest('button');
+    expect(rebootButton).toBeDisabled();
+    expect(rebootButton).toHaveAttribute('title', 'tx_disabled.remote_admin_notice');
+
+    const purgeButton = screen.getByText('admin_commands.purge_node_database').closest('button');
+    expect(purgeButton).toBeDisabled();
+    expect(purgeButton).toHaveAttribute('title', 'tx_disabled.remote_admin_notice');
+  });
+
+  it('executeCommand blocks the send with no network call and shows the notice toast when remote-node admin is blocked', async () => {
+    h.txStatus.isTxDisabled = true;
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    selectRemoteNode();
+
+    await waitFor(() => {
+      expect(screen.getByText('tx_disabled.remote_admin_notice')).toBeInTheDocument();
+    });
+
+    // DeviceConfigurationSection's own save button isn't visually gated (it
+    // lives in a different file) -- clicking it must still be blocked by
+    // executeCommand's internal guard.
+    fireEvent.click(screen.getByTestId('device-save'));
+
+    await waitFor(() => {
+      expect(h.showToast).toHaveBeenCalledWith('tx_disabled.remote_admin_notice', 'warning');
+    });
+
+    const commandCalls = h.apiPost.mock.calls.filter(([endpoint]) => endpoint === '/api/admin/commands');
+    expect(commandCalls).toHaveLength(0);
+  });
+
+  it('leaves local-node admin fully enabled when TX is off (the path that re-enables TX)', () => {
+    h.txStatus.isTxDisabled = true;
+    expandSections(['radio-config', 'admin-lora-config', 'admin-reboot-purge']);
+    render(<AdminCommandsTab nodes={[localNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    // No remote node exists in this render, so the local node stays selected.
+    expect(screen.queryByText('tx_disabled.remote_admin_notice')).not.toBeInTheDocument();
+
+    const saveLoRaButton = screen.getByText('admin_commands.save_lora_config').closest('button');
+    expect(saveLoRaButton).not.toBeDisabled();
+
+    const rebootButton = screen.getByText('admin_commands.reboot_device').closest('button');
+    expect(rebootButton).not.toBeDisabled();
+  });
+
+  it('confirms before disabling TX via the inline checkbox, and commits when accepted', () => {
+    expandSections(['radio-config', 'admin-lora-config']);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<AdminCommandsTab nodes={[localNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /admin_commands\.tx_enabled/i }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true); // useAdminCommandsState defaults txEnabled: true
+
+    fireEvent.click(checkbox);
+
+    expect(confirmSpy).toHaveBeenCalledWith('lora_config.tx_disable_confirm');
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('does not disable TX via the inline checkbox when the confirm is cancelled', () => {
+    expandSections(['radio-config', 'admin-lora-config']);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<AdminCommandsTab nodes={[localNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /admin_commands\.tx_enabled/i }) as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    expect(confirmSpy).toHaveBeenCalledWith('lora_config.tx_disable_confirm');
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('invalidates the txStatus query after a successful local LoRa config save', async () => {
+    expandSections(['radio-config', 'admin-lora-config']);
+    render(<AdminCommandsTab nodes={[localNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    fireEvent.click(screen.getByText('admin_commands.save_lora_config'));
+
+    await waitFor(() => {
+      expect(h.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['txStatus'] });
+    });
+  });
+});

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -90,6 +90,9 @@ export interface ChannelsTabProps {
   // Connection state
   connectionStatus: string;
 
+  /** TX disabled on this source (epic #4294 Phase 2) — disable send/request controls with a tooltip, keep reads working. */
+  txDisabled?: boolean;
+
   // Channel selection
   selectedChannel: number;
   setSelectedChannel: (channel: number) => void;
@@ -170,6 +173,7 @@ export default function ChannelsTab({
   currentNodeId,
   sourceId = null,
   connectionStatus,
+  txDisabled = false,
   selectedChannel,
   setSelectedChannel,
   selectedChannelRef,
@@ -1098,7 +1102,8 @@ export default function ChannelsTab({
                                         <button
                                           className="emoji-picker-button"
                                           onClick={() => setEmojiPickerMessage(msg)}
-                                          title={t('channels.emoji_button_title')}
+                                          disabled={txDisabled}
+                                          title={txDisabled ? t('tx_disabled.control_tooltip') : t('channels.emoji_button_title')}
                                           aria-label={t('channels.emoji_button_title')}
                                         >
                                           <UiIcon name="reaction" size={15} />
@@ -1152,6 +1157,12 @@ export default function ChannelsTab({
                                           // tooltip, but a hover-only affordance is
                                           // unusable on touch and invisible at a glance.
                                           const reactorName = getNodeShortName(reaction.from);
+                                          // Reaction chips stay clickable even when txDisabled: they are
+                                          // also the read affordance for "who reacted" (hover tooltip +
+                                          // inline name), and disabling them would hide that read-only
+                                          // info. A re-tap while TX is off surfaces the 409 via the
+                                          // handleSendTapback failure-branch toast (App.tsx) instead of
+                                          // being pre-emptively blocked here (epic #4294 Phase 2, §3.2).
                                           return (
                                             <span
                                               key={reaction.id}
@@ -1212,18 +1223,24 @@ export default function ChannelsTab({
                               placeholder={t('channels.send_placeholder', { name: getChannelName(selectedChannel) })}
                               className="message-input"
                               rows={1}
+                              disabled={txDisabled}
+                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                               onKeyDown={e => {
                                 if (
-                                  e.key === 'Enter' &&
-                                  !e.shiftKey &&
-                                  !e.ctrlKey &&
-                                  !e.metaKey &&
-                                  !e.altKey &&
-                                  !e.nativeEvent.isComposing
+                                  txDisabled ||
+                                  !(
+                                    e.key === 'Enter' &&
+                                    !e.shiftKey &&
+                                    !e.ctrlKey &&
+                                    !e.metaKey &&
+                                    !e.altKey &&
+                                    !e.nativeEvent.isComposing
+                                  )
                                 ) {
-                                  e.preventDefault();
-                                  void handleSendMessage(selectedChannel);
+                                  return;
                                 }
+                                e.preventDefault();
+                                void handleSendMessage(selectedChannel);
                               }}
                             />
                             <div className={byteCountDisplay.className}>
@@ -1237,24 +1254,27 @@ export default function ChannelsTab({
                           />
                           <button
                             onClick={() => { void onSendBell?.(selectedChannel, newMessage); setNewMessage(''); }}
+                            disabled={txDisabled}
                             className="send-btn channel-action-btn"
-                            title="Send alert bell"
+                            title={txDisabled ? t('tx_disabled.control_tooltip') : 'Send alert bell'}
                             aria-label="Send alert bell"
                           >
                             <UiIcon name="notifications" size={16} />
                           </button>
                           <button
                             onClick={() => onSendPosition?.(selectedChannel)}
+                            disabled={txDisabled}
                             className="send-btn channel-action-btn"
-                            title="Send position"
+                            title={txDisabled ? t('tx_disabled.control_tooltip') : 'Send position'}
                             aria-label="Send position"
                           >
                             <UiIcon name="location" size={16} />
                           </button>
                           <button
                             onClick={() => handleSendMessage(selectedChannel)}
-                            disabled={!newMessage.trim()}
+                            disabled={!newMessage.trim() || txDisabled}
                             className="send-btn"
+                            title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                           >
                             <UiIcon name="send" size={16} />
                           </button>

--- a/src/components/ChannelsTab.txDisabled.test.tsx
+++ b/src/components/ChannelsTab.txDisabled.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TX-disabled gating (epic #4294 Phase 2, §3.2) — when `txDisabled` is true,
+ * every send/request control in the channel send box (message textarea, send
+ * button, bell, position, per-message emoji-picker "react" button) renders
+ * `disabled` with the shared tooltip copy. Reads (existing reaction chips,
+ * message history) stay fully interactive — see the inline comment in
+ * ChannelsTab.tsx for why reaction chips are deliberately NOT disabled.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import ChannelsTab from './ChannelsTab';
+import type { MeshMessage } from '../types/message';
+
+vi.mock('../hooks/useServerData', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNodes: () => ({ nodes: [], isLoading: false, error: null }),
+}));
+
+vi.mock('../contexts/SettingsContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSettings: () => ({ distanceUnit: 'km' }),
+  useNotificationMuteSettings: () => ({
+    isChannelMuted: () => false,
+    muteChannel: async () => {},
+    unmuteChannel: async () => {},
+  }),
+}));
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      (opts && typeof opts === 'object' && 'defaultValue' in opts
+        ? (opts.defaultValue as string)
+        : undefined) ?? key,
+  }),
+}));
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+const PARENT_PACKET_ID = 6000;
+
+const parentMsg: MeshMessage = {
+  id: `src1_111_${PARENT_PACKET_ID}`,
+  from: '!aaaaaaaa',
+  to: '^all',
+  fromNodeId: '!aaaaaaaa',
+  toNodeId: '^all',
+  text: 'anyone around?',
+  channel: 0,
+  timestamp: new Date('2026-07-21T12:00:00Z'),
+};
+
+const reactionMsg: MeshMessage = {
+  id: 'src1_222_6001',
+  from: '!bbbbbbbb',
+  to: '^all',
+  fromNodeId: '!bbbbbbbb',
+  toNodeId: '^all',
+  text: '👍',
+  channel: 0,
+  timestamp: new Date('2026-07-21T12:00:05Z'),
+  replyId: PARENT_PACKET_ID,
+  emoji: 1,
+};
+
+type ChannelsTabProps = React.ComponentProps<typeof ChannelsTab>;
+
+function makeProps(overrides: Partial<ChannelsTabProps> = {}): ChannelsTabProps {
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  return {
+    channels: [{ id: 0, name: 'Primary', psk: '', uplinkEnabled: true, downlinkEnabled: true }],
+    channelDatabaseEntries: [],
+    channelMessages: { 0: [parentMsg, reactionMsg] },
+    messages: [parentMsg, reactionMsg],
+    currentNodeId: '!cccccccc',
+    sourceId: 'src1',
+    connectionStatus: 'connected',
+    selectedChannel: 0,
+    setSelectedChannel: noop,
+    selectedChannelRef: { current: 0 },
+    showMqttMessages: true,
+    setShowMqttMessages: noop,
+    newMessage: '',
+    setNewMessage: noop,
+    replyingTo: null,
+    setReplyingTo: noop,
+    unreadCounts: {},
+    setUnreadCounts: noop,
+    markMessagesAsRead: noop,
+    channelInfoModal: null,
+    setChannelInfoModal: noop,
+    showPsk: false,
+    setShowPsk: noop,
+    timeFormat: '24' as const,
+    dateFormat: 'MM/DD/YYYY' as const,
+    hasPermission: () => true,
+    handleSendMessage: asyncNoop,
+    handleResendMessage: asyncNoop,
+    handleDeleteMessage: asyncNoop,
+    handleSendTapback: noop,
+    handlePurgeChannelMessages: asyncNoop,
+    handleSenderClick: noop,
+    onSendBell: asyncNoop,
+    onSendPosition: asyncNoop,
+    shouldShowData: () => true,
+    getNodeName: (id: string) => (id === '!bbbbbbbb' ? 'Bob Node' : 'Alice Node'),
+    getNodeShortName: (id: string) => (id === '!bbbbbbbb' ? 'BOB' : 'ALC'),
+    isMqttBridgeMessage: () => false,
+    setEmojiPickerMessage: noop,
+    channelMessagesContainerRef: { current: null },
+    ...overrides,
+  } as unknown as ChannelsTabProps;
+}
+
+describe('ChannelsTab txDisabled gating (#4294 Phase 2)', () => {
+  it('disables the message textarea with the shared tooltip when txDisabled', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea).not.toBeNull();
+    expect(textarea).toBeDisabled();
+    expect(textarea?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+
+  it('disables the send button when txDisabled', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true })} />);
+    const sendBtn = document.querySelector('button.send-btn:not(.channel-action-btn)');
+    expect(sendBtn).not.toBeNull();
+    expect(sendBtn).toBeDisabled();
+  });
+
+  it('disables the bell and position buttons when txDisabled', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true })} />);
+    const actionBtns = document.querySelectorAll('button.send-btn.channel-action-btn');
+    expect(actionBtns.length).toBe(2);
+    actionBtns.forEach(btn => {
+      expect(btn).toBeDisabled();
+      expect(btn.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+    });
+  });
+
+  it('disables the per-message emoji-picker (react) button when txDisabled', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true })} />);
+    const emojiBtn = document.querySelector('button.emoji-picker-button');
+    expect(emojiBtn).not.toBeNull();
+    expect(emojiBtn).toBeDisabled();
+    expect(emojiBtn?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+
+  it('keeps existing reaction chips clickable (reads remain enabled) when txDisabled', () => {
+    const handleSendTapback = vi.fn();
+    render(<ChannelsTab {...makeProps({ txDisabled: true, handleSendTapback })} />);
+    const chip = document.querySelector('.reaction');
+    expect(chip).not.toBeNull();
+    // Reaction chips are <span> elements, not buttons — verify no disabled-like
+    // gating was added and the tapback click handler is still wired (a re-tap
+    // while TX is off is caught by the App.tsx failure-branch toast instead).
+    expect(chip?.getAttribute('aria-disabled')).toBeNull();
+    fireEvent.click(chip as HTMLElement);
+    expect(handleSendTapback).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves all controls enabled when txDisabled is false', () => {
+    // newMessage must be non-empty, or the send button's independent
+    // `!newMessage.trim()` guard would also disable it and mask this assertion.
+    render(<ChannelsTab {...makeProps({ txDisabled: false, newMessage: 'hi' })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea).not.toBeDisabled();
+    document.querySelectorAll('button.send-btn').forEach(btn => {
+      expect(btn).not.toBeDisabled();
+    });
+    const emojiBtn = document.querySelector('button.emoji-picker-button');
+    expect(emojiBtn).not.toBeDisabled();
+  });
+});

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { UiIcon } from './icons';
 import { useTranslation } from 'react-i18next';
 import apiService from '../services/api';
@@ -52,6 +53,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { sourceId } = useSource();
+  const queryClient = useQueryClient();
 
   // Device Config State
   const [longName, setLongName] = useState('');
@@ -891,6 +893,9 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
       }, sourceId);
       setStatusMessage(t('config.lora_saved'));
       showToast(t('config.lora_saved_toast'), 'success');
+      // Refresh TX status promptly so the global banner + gated controls reflect
+      // the new txEnabled value without waiting for the 30s poll (#4294).
+      void queryClient.invalidateQueries({ queryKey: ['txStatus'] });
       onConfigChangeTriggeringReboot?.();
     } catch (error) {
       logger.error('Error saving LoRa config:', error);

--- a/src/components/ConfigurationTab.txDisabled.test.tsx
+++ b/src/components/ConfigurationTab.txDisabled.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TX-disabled Phase 2 WP2 (#4294): after a successful LoRa config save,
+ * ConfigurationTab must invalidate the ['txStatus'] query so the global banner
+ * and every gated control refresh promptly instead of waiting for the 30s poll.
+ *
+ * All sibling *ConfigSection components are stubbed — this test exercises only
+ * ConfigurationTab's own wiring (handleSaveLoRaConfig -> apiService.setLoRaConfig
+ * -> queryClient.invalidateQueries), not the child sections' internals (those
+ * have their own test files).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// --- hoisted mutable mock state -----------------------------------------
+const h = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+// --- mocks ---------------------------------------------------------------
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: h.invalidateQueries,
+  }),
+}));
+
+vi.mock('./ToastContainer', () => ({ useToast: () => ({ showToast: h.showToast }) }));
+
+vi.mock('../contexts/SourceContext', () => ({
+  useSource: () => ({ sourceId: 1, sourceName: 'test-source' }),
+}));
+
+vi.mock('../services/api', () => ({
+  default: {
+    getCurrentConfig: vi.fn().mockResolvedValue({}),
+    getSecurityKeys: vi.fn().mockResolvedValue({}),
+    setLoRaConfig: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+// Stub every sibling config section as a no-op — only LoRaConfigSection needs
+// a real interactive save trigger for this test.
+vi.mock('./configuration/NodeIdentitySection', () => ({ default: () => null }));
+vi.mock('./configuration/DeviceConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/LoRaConfigSection', () => ({
+  default: ({ onSave }: { onSave: () => Promise<void> }) => (
+    <button data-testid="lora-save" onClick={() => void onSave()}>Save LoRa</button>
+  ),
+}));
+vi.mock('./configuration/PositionConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/MQTTConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/NeighborInfoSection', () => ({ default: () => null }));
+vi.mock('./configuration/NetworkConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/PowerConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/DisplayConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/TelemetryConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/ExternalNotificationConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/StoreForwardConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/RangeTestConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/CannedMessageConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/AudioConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/RemoteHardwareConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/DetectionSensorConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/PaxcounterConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/StatusMessageConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/TrafficManagementConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/SerialConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/AmbientLightingConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/SecurityConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/PkiDmDecryptionSection', () => ({ default: () => null }));
+vi.mock('./configuration/ChannelsConfigSection', () => ({ default: () => null }));
+vi.mock('./configuration/GpioPinSummary', () => ({ default: () => null }));
+vi.mock('./configuration/BackupManagementSection', () => ({ default: () => null }));
+vi.mock('./configuration/ImportConfigModal', () => ({ ImportConfigModal: () => null }));
+vi.mock('./configuration/ExportConfigModal', () => ({ ExportConfigModal: () => null }));
+vi.mock('./SectionNav', () => ({ default: () => null }));
+
+import ConfigurationTab from './ConfigurationTab';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ConfigurationTab — TX status freshness invalidation', () => {
+  it('invalidates the txStatus query after a successful LoRa config save', async () => {
+    render(<ConfigurationTab nodes={[]} channels={[]} />);
+
+    const saveButton = await screen.findByTestId('lora-save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(h.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['txStatus'] });
+    });
+  });
+});

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -117,6 +117,9 @@ export interface MessagesTabProps {
   // Connection state
   connectionStatus: string;
 
+  /** TX disabled on this source (epic #4294 Phase 2) — disable send/request controls with a tooltip, keep reads working. */
+  txDisabled?: boolean;
+
   // Selected state
   selectedDMNode: string | null;
   setSelectedDMNode: (nodeId: string) => void;
@@ -222,6 +225,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   messages,
   currentNodeId,
   connectionStatus,
+  txDisabled = false,
   selectedDMNode,
   setSelectedDMNode,
   newMessage,
@@ -1205,7 +1209,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                   void handleTraceroute(selectedDMNode);
                                   setShowActionsMenu(false);
                                 }}
-                                disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode}
+                                disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled}
+                                title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                               >
                                 <UiIcon name="route" /> {t('messages.traceroute_button')}
                                 {tracerouteLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1236,7 +1241,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 void handleExchangePosition(selectedDMNode);
                                 setShowActionsMenu(false);
                               }}
-                              disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode}
+                              disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled}
+                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                             >
                               <UiIcon name="location" /> {t('messages.exchange_position')}
                               {positionLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1247,7 +1253,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 void handleExchangeNodeInfo(selectedDMNode);
                                 setShowActionsMenu(false);
                               }}
-                              disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode}
+                              disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled}
+                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                             >
                               <UiIcon name="key" /> {t('messages.exchange_node_info')}
                               {nodeInfoLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1258,7 +1265,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 setShowTelemetryRequestModal(true);
                                 setShowActionsMenu(false);
                               }}
-                              disabled={connectionStatus !== 'connected' || telemetryRequestLoading === selectedDMNode}
+                              disabled={connectionStatus !== 'connected' || telemetryRequestLoading === selectedDMNode || txDisabled}
+                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                             >
                               <UiIcon name="telemetry" /> {t('messages.request_telemetry')}
                               {telemetryRequestLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1292,7 +1300,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               void handleScanForAdmin(selectedDMNode);
                               setShowActionsMenu(false);
                             }}
-                            disabled={connectionStatus !== 'connected' || adminScanLoading === selectedDMNode}
+                            disabled={connectionStatus !== 'connected' || adminScanLoading === selectedDMNode || txDisabled}
+                            title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                           >
                             <UiIcon name="search" /> {t('messages.scan_for_admin')}
                             {adminScanLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1672,7 +1681,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 <button
                                   className="resend-button"
                                   onClick={() => handleResendMessage(msg)}
-                                  title={t('messages.resend_button_title')}
+                                  disabled={txDisabled}
+                                  title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.resend_button_title')}
                                   aria-label={t('messages.resend_button_title')}
                                 >
                                   ↻
@@ -1693,7 +1703,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               <button
                                 className="emoji-picker-button"
                                 onClick={() => setEmojiPickerMessage(msg)}
-                                title={t('messages.emoji_button_title')}
+                                disabled={txDisabled}
+                                title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.emoji_button_title')}
                                 aria-label={t('messages.emoji_button_title')}
                               >
                                 <UiIcon name="reaction" size={15} />
@@ -1732,6 +1743,11 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             <LinkPreview text={msg.text} />
                             {reactions.length > 0 && (
                               <div className="message-reactions">
+                                {/* Reaction chips stay clickable even when txDisabled — see the
+                                    matching comment in ChannelsTab.tsx (epic #4294 Phase 2, §3.2/§3.3):
+                                    they double as the read affordance for "who reacted", and a
+                                    re-tap while TX is off is caught by the handleSendTapback
+                                    failure-branch toast in App.tsx rather than pre-emptively blocked. */}
                                 {reactions.map(reaction => (
                                   <span
                                     key={reaction.id}
@@ -1798,18 +1814,24 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         placeholder={t('messages.dm_placeholder', { name: getNodeName(selectedDMNode) })}
                         className="message-input"
                         rows={1}
+                        disabled={txDisabled}
+                        title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                         onKeyDown={e => {
                           if (
-                            e.key === 'Enter' &&
-                            !e.shiftKey &&
-                            !e.ctrlKey &&
-                            !e.metaKey &&
-                            !e.altKey &&
-                            !e.nativeEvent.isComposing
+                            txDisabled ||
+                            !(
+                              e.key === 'Enter' &&
+                              !e.shiftKey &&
+                              !e.ctrlKey &&
+                              !e.metaKey &&
+                              !e.altKey &&
+                              !e.nativeEvent.isComposing
+                            )
                           ) {
-                            e.preventDefault();
-                            void handleSendDirectMessage(selectedDMNode);
+                            return;
                           }
+                          e.preventDefault();
+                          void handleSendDirectMessage(selectedDMNode);
                         }}
                       />
                       <div className={byteCountDisplay.className}>
@@ -1823,16 +1845,18 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     />
                     <button
                       onClick={() => { void onSendBell?.(selectedDMNode, newMessage); setNewMessage(''); }}
+                      disabled={txDisabled}
                       className="send-btn channel-action-btn"
-                      title="Send alert bell"
+                      title={txDisabled ? t('tx_disabled.control_tooltip') : 'Send alert bell'}
                       aria-label="Send alert bell"
                     >
                       <UiIcon name="notifications" size={16} />
                     </button>
                     <button
                       onClick={() => handleSendDirectMessage(selectedDMNode)}
-                      disabled={!newMessage.trim()}
+                      disabled={!newMessage.trim() || txDisabled}
                       className="send-btn"
+                      title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                       aria-label={t('common.send')}
                     >
                       <UiIcon name="send" size={16} />
@@ -2043,7 +2067,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleTraceroute(selectedDMNode)}
-                    disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode}
+                    disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled}
+                    title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
@@ -2051,8 +2076,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       color: 'var(--ctp-base)',
                       border: 'none',
                       borderRadius: channels.length > 1 ? '4px 0 0 4px' : '4px',
-                      cursor: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                      opacity: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode ? 0.5 : 1,
+                      cursor: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                      opacity: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                       fontSize: '0.9rem'
                     }}
                   >
@@ -2064,8 +2089,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         e.stopPropagation();
                         setShowTracerouteChannelDropdown(prev => !prev);
                       }}
-                      disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode}
-                      title={t('messages.traceroute_channel')}
+                      disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled}
+                      title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.traceroute_channel')}
                       aria-label={t('messages.traceroute_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
@@ -2074,8 +2099,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         border: 'none',
                         borderLeft: '1px solid var(--ctp-base)',
                         borderRadius: '0 4px 4px 0',
-                        cursor: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                        opacity: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode ? 0.5 : 1,
+                        cursor: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                        opacity: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                         fontSize: '0.9rem'
                       }}
                     >
@@ -2129,7 +2154,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangeNodeInfo(selectedDMNode)}
-                    disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode}
+                    disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled}
+                    title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
@@ -2137,8 +2163,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       color: 'var(--ctp-base)',
                       border: 'none',
                       borderRadius: channels.length > 1 ? '4px 0 0 4px' : '4px',
-                      cursor: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                      opacity: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode ? 0.5 : 1,
+                      cursor: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                      opacity: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                       fontSize: '0.9rem'
                     }}
                   >
@@ -2150,8 +2176,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         e.stopPropagation();
                         setShowNodeInfoChannelDropdown(prev => !prev);
                       }}
-                      disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode}
-                      title={t('messages.exchange_node_info_channel')}
+                      disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled}
+                      title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.exchange_node_info_channel')}
                       aria-label={t('messages.exchange_node_info_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
@@ -2160,8 +2186,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         border: 'none',
                         borderLeft: '1px solid var(--ctp-base)',
                         borderRadius: '0 4px 4px 0',
-                        cursor: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                        opacity: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode ? 0.5 : 1,
+                        cursor: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                        opacity: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                         fontSize: '0.9rem'
                       }}
                     >
@@ -2215,7 +2241,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 <div style={{ display: 'flex', flex: '1 1 auto', minWidth: '120px', position: 'relative' }}>
                   <button
                     onClick={() => handleExchangePosition(selectedDMNode)}
-                    disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode}
+                    disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled}
+                    title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
@@ -2223,8 +2250,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       color: 'var(--ctp-base)',
                       border: 'none',
                       borderRadius: channels.length > 1 ? '4px 0 0 4px' : '4px',
-                      cursor: connectionStatus !== 'connected' || positionLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                      opacity: connectionStatus !== 'connected' || positionLoading === selectedDMNode ? 0.5 : 1,
+                      cursor: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                      opacity: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                       fontSize: '0.9rem'
                     }}
                   >
@@ -2236,8 +2263,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         e.stopPropagation();
                         setShowPositionChannelDropdown(prev => !prev);
                       }}
-                      disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode}
-                      title={t('messages.exchange_position_channel')}
+                      disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled}
+                      title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.exchange_position_channel')}
                       aria-label={t('messages.exchange_position_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
@@ -2246,8 +2273,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         border: 'none',
                         borderLeft: '1px solid var(--ctp-base)',
                         borderRadius: '0 4px 4px 0',
-                        cursor: connectionStatus !== 'connected' || positionLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                        opacity: connectionStatus !== 'connected' || positionLoading === selectedDMNode ? 0.5 : 1,
+                        cursor: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                        opacity: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                         fontSize: '0.9rem'
                       }}
                     >
@@ -2300,7 +2327,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               {!actionsReadOnly && hasPermission('traceroute', 'write') && (
                 <button
                   onClick={() => handleRequestNeighborInfo(selectedDMNode)}
-                  disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode}
+                  disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode || txDisabled}
+                  title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                   style={{
                     flex: '1 1 auto',
                     minWidth: '120px',
@@ -2309,8 +2337,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     color: 'var(--ctp-base)',
                     border: 'none',
                     borderRadius: '4px',
-                    cursor: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode ? 'not-allowed' : 'pointer',
-                    opacity: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode ? 0.5 : 1,
+                    cursor: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
+                    opacity: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode || txDisabled ? 0.5 : 1,
                     fontSize: '0.9rem'
                   }}
                 >

--- a/src/components/MessagesTab.txDisabled.test.tsx
+++ b/src/components/MessagesTab.txDisabled.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TX-disabled gating (epic #4294 Phase 2, §3.3) — when `txDisabled` is true,
+ * every DM send/request control (DM textarea, send, bell, resend, and the
+ * per-node action buttons: traceroute, exchange position, exchange
+ * nodeinfo/key-repair, request neighbor-info, admin scan) renders `disabled`
+ * with the shared tooltip copy. Reads stay enabled.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import MessagesTab from './MessagesTab';
+import type { MeshMessage } from '../types/message';
+
+// MessagesTab pulls a lot of context/poll-cache hooks that are irrelevant to
+// txDisabled gating; stub them the same way ChannelsTab.reactions.test.tsx
+// stubs useNodes, so this render doesn't need the full provider tree.
+vi.mock('../hooks/useServerData', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useDeviceNodes: () => new Set<number>(),
+  useTelemetryNodes: () => ({
+    nodesWithTelemetry: new Set(),
+    nodesWithWeather: new Set(),
+    nodesWithEstimatedPosition: new Set(),
+    nodesWithPKC: new Set(),
+    unmappedCount: 0,
+    estimatedUncertainty: {},
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../contexts/SettingsContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSettings: () => ({ nodeHopsCalculation: 'actual', distanceUnit: 'km' }),
+  useNotificationMuteSettings: () => ({
+    isDMMuted: () => false,
+    muteDM: async () => {},
+    unmuteDM: async () => {},
+    isChannelMuted: () => false,
+    muteChannel: async () => {},
+    unmuteChannel: async () => {},
+  }),
+}));
+
+vi.mock('../contexts/MapContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMapContext: () => ({ traceroutes: [], neighborInfo: [], setNeighborInfo: () => {} }),
+}));
+
+vi.mock('./ToastContainer', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useToast: () => ({ showToast: () => {} }),
+}));
+
+vi.mock('../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useQueryClient: () => ({}),
+}));
+
+// The bottom of the DM panel unconditionally renders four chart/graph
+// components (TelemetryGraphs, SmartHopsGraphs, LinkQualityGraph,
+// PacketStatsChart) — irrelevant to txDisabled gating, but they reach into
+// AuthContext/DataContext trees this render doesn't stand up. Stub them.
+vi.mock('./TelemetryGraphs', () => ({ default: () => null }));
+vi.mock('./SmartHopsGraphs', () => ({ default: () => null }));
+vi.mock('./LinkQualityGraph', () => ({ default: () => null }));
+vi.mock('./PacketStatsChart', () => ({ default: () => null }));
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      (opts && typeof opts === 'object' && 'defaultValue' in opts
+        ? (opts.defaultValue as string)
+        : undefined) ?? key,
+  }),
+}));
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+const CURRENT_NODE_ID = '!cccccccc';
+const DM_NODE_ID = '!aaaaaaaa';
+
+const myMsg: MeshMessage = {
+  id: 'src1_3_7001',
+  from: CURRENT_NODE_ID,
+  to: DM_NODE_ID,
+  fromNodeId: CURRENT_NODE_ID,
+  toNodeId: DM_NODE_ID,
+  text: 'hello there',
+  channel: -1,
+  portnum: 1,
+  isLocalMessage: true,
+  timestamp: new Date('2026-07-21T12:00:00Z'),
+};
+
+const theirMsg: MeshMessage = {
+  id: 'src1_1_7002',
+  from: DM_NODE_ID,
+  to: CURRENT_NODE_ID,
+  fromNodeId: DM_NODE_ID,
+  toNodeId: CURRENT_NODE_ID,
+  text: 'hi back',
+  channel: -1,
+  portnum: 1,
+  timestamp: new Date('2026-07-21T12:00:05Z'),
+};
+
+type MessagesTabProps = React.ComponentProps<typeof MessagesTab>;
+
+function makeProps(overrides: Partial<MessagesTabProps> = {}): MessagesTabProps {
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  return {
+    processedNodes: [],
+    nodes: [],
+    messages: [myMsg, theirMsg],
+    currentNodeId: CURRENT_NODE_ID,
+    connectionStatus: 'connected',
+    selectedDMNode: DM_NODE_ID,
+    setSelectedDMNode: noop,
+    newMessage: 'hi',
+    setNewMessage: noop,
+    replyingTo: null,
+    setReplyingTo: noop,
+    unreadCountsData: null,
+    markMessagesAsRead: asyncNoop,
+    nodeFilter: '',
+    setNodeFilter: noop,
+    messagesNodeFilter: '',
+    setMessagesNodeFilter: noop,
+    dmFilter: 'all' as const,
+    setDmFilter: noop,
+    securityFilter: 'all' as const,
+    channels: [
+      { id: 0, name: 'Primary', psk: '', uplinkEnabled: true, downlinkEnabled: true },
+      { id: 1, name: 'Secondary', psk: '', uplinkEnabled: true, downlinkEnabled: true },
+    ],
+    channelFilter: 'all' as const,
+    showIncompleteNodes: false,
+    showNodeFilterPopup: false,
+    setShowNodeFilterPopup: noop,
+    isMessagesNodeListCollapsed: false,
+    setIsMessagesNodeListCollapsed: noop,
+    tracerouteLoading: null,
+    positionLoading: null,
+    nodeInfoLoading: null,
+    neighborInfoLoading: null,
+    telemetryRequestLoading: null,
+    timeFormat: '24' as const,
+    dateFormat: 'MM/DD/YYYY' as const,
+    temperatureUnit: 'C' as const,
+    telemetryVisualizationHours: 24,
+    distanceUnit: 'km' as const,
+    baseUrl: 'http://localhost',
+    hasPermission: () => true,
+    handleSendDirectMessage: asyncNoop,
+    onSendBell: asyncNoop,
+    handleResendMessage: asyncNoop,
+    handleTraceroute: asyncNoop,
+    handleExchangePosition: asyncNoop,
+    handleExchangeNodeInfo: asyncNoop,
+    handleRequestNeighborInfo: asyncNoop,
+    handleRequestTelemetry: asyncNoop,
+    handleDeleteMessage: asyncNoop,
+    handleSenderClick: noop,
+    handleSendTapback: noop,
+    getRecentTraceroute: () => null,
+    toggleIgnored: asyncNoop,
+    toggleHideFromMap: asyncNoop,
+    toggleFavorite: asyncNoop,
+    toggleFavoriteLock: asyncNoop,
+    setShowTracerouteHistoryModal: noop,
+    setShowPurgeDataModal: noop,
+    setShowPositionOverrideModal: noop,
+    setEmojiPickerMessage: noop,
+    shouldShowData: () => true,
+    handleShowOnMap: noop,
+    dmMessagesContainerRef: { current: null },
+    mqttReadOnly: false,
+    ...overrides,
+  } as unknown as MessagesTabProps;
+}
+
+describe('MessagesTab txDisabled gating (#4294 Phase 2)', () => {
+  it('disables the DM textarea with the shared tooltip when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea).not.toBeNull();
+    expect(textarea).toBeDisabled();
+    expect(textarea?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+
+  it('disables the DM send button when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const sendBtn = document.querySelector('button.send-btn:not(.channel-action-btn)');
+    expect(sendBtn).not.toBeNull();
+    expect(sendBtn).toBeDisabled();
+  });
+
+  it('disables the DM bell button when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const bellBtn = document.querySelector('button.send-btn.channel-action-btn');
+    expect(bellBtn).not.toBeNull();
+    expect(bellBtn).toBeDisabled();
+    expect(bellBtn?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+
+  it('disables the resend button on own messages when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const resendBtn = document.querySelector('button.resend-button');
+    expect(resendBtn).not.toBeNull();
+    expect(resendBtn).toBeDisabled();
+    expect(resendBtn?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+
+  it('disables both traceroute split-buttons (main + channel toggle) when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const tracerouteBtn = screen.getByText('messages.traceroute_button').closest('button');
+    expect(tracerouteBtn).toBeDisabled();
+  });
+
+  it('disables the exchange-position button when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const btn = screen.getByText('messages.exchange_position').closest('button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables the exchange-nodeinfo button when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const btn = screen.getByText('messages.exchange_node_info').closest('button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables the request-neighbor-info button when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const btn = screen.getByText('messages.request_neighbor_info').closest('button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables admin-scan in the actions dropdown when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    fireEvent.click(screen.getByTitle('messages.actions_menu_title'));
+    const btn = screen.getByText('messages.scan_for_admin').closest('button');
+    expect(btn).toBeDisabled();
+    expect(btn?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+
+  it('disables request-telemetry in the actions dropdown when txDisabled', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    fireEvent.click(screen.getByTitle('messages.actions_menu_title'));
+    const btn = screen.getByText('messages.request_telemetry').closest('button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('leaves DM controls enabled and reads working when txDisabled is false', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: false })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea).not.toBeDisabled();
+    const sendBtn = document.querySelector('button.send-btn:not(.channel-action-btn)');
+    expect(sendBtn).not.toBeDisabled();
+    const resendBtn = document.querySelector('button.resend-button');
+    expect(resendBtn).not.toBeDisabled();
+    // Reads: the received message text is still rendered regardless of TX state.
+    expect(screen.getByText('hi back')).toBeTruthy();
+  });
+});

--- a/src/components/NodePopup/NodePopup.test.tsx
+++ b/src/components/NodePopup/NodePopup.test.tsx
@@ -298,6 +298,54 @@ describe('NodePopup (chat overlay)', () => {
     expect(screen.queryByText(/Purge from Device/)).not.toBeInTheDocument();
   });
 
+  it('disables the run-traceroute button with the shared tooltip when txDisabled (epic #4294 Phase 2)', () => {
+    const { container } = render(
+      <NodePopup
+        nodePopup={nodePopupState}
+        nodes={[localNode, remoteNode]}
+        timeFormat="24"
+        dateFormat="MM/DD/YYYY"
+        hasPermission={allowAll}
+        onDMNode={vi.fn()}
+        onShowOnMap={vi.fn()}
+        onClose={vi.fn()}
+        onTraceroute={vi.fn()}
+        connectionStatus="connected"
+        txDisabled
+      />,
+    );
+    // Switch to the Traceroute tab (mirrors the existing "shows the tab bar…"
+    // test above) — the run button only renders inside that tab body.
+    fireEvent.click(screen.getByTitle('Traceroute'));
+    const btn = container.querySelector('.node-popup-btn:not(.traceroute-history-btn)');
+    expect(btn).not.toBeNull();
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'tx_disabled.control_tooltip');
+  });
+
+  it('leaves the run-traceroute button enabled when txDisabled is false and connected', () => {
+    const { container } = render(
+      <NodePopup
+        nodePopup={nodePopupState}
+        nodes={[localNode, remoteNode]}
+        timeFormat="24"
+        dateFormat="MM/DD/YYYY"
+        hasPermission={allowAll}
+        onDMNode={vi.fn()}
+        onShowOnMap={vi.fn()}
+        onClose={vi.fn()}
+        onTraceroute={vi.fn()}
+        connectionStatus="connected"
+        txDisabled={false}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('Traceroute'));
+    const btn = container.querySelector('.node-popup-btn:not(.traceroute-history-btn)');
+    expect(btn).not.toBeNull();
+    expect(btn).not.toBeDisabled();
+    expect(btn).not.toHaveAttribute('title');
+  });
+
   it('omits all danger actions without messages:write permission', () => {
     render(
       <NodePopup

--- a/src/components/NodePopup/NodePopup.tsx
+++ b/src/components/NodePopup/NodePopup.tsx
@@ -48,6 +48,8 @@ interface NodePopupProps {
   onDeleteNode?: (nodeNum: number) => void;
   onPurgeNodeFromDevice?: (nodeNum: number) => void;
   currentNodeNum?: number | null;
+  /** TX disabled on this source (epic #4294 Phase 2) — ORed into the traceroute run button's disabled state. */
+  txDisabled?: boolean;
 }
 
 export const NodePopup: React.FC<NodePopupProps> = ({
@@ -69,6 +71,7 @@ export const NodePopup: React.FC<NodePopupProps> = ({
   onDeleteNode,
   onPurgeNodeFromDevice,
   currentNodeNum,
+  txDisabled = false,
 }) => {
   const { t } = useTranslation();
 
@@ -179,7 +182,8 @@ export const NodePopup: React.FC<NodePopupProps> = ({
             } : undefined}
             onRunTraceroute={node.user?.id && onTraceroute ? () => onTraceroute(node.user!.id) : undefined}
             running={tracerouteLoading === node.user?.id}
-            runDisabled={connectionStatus !== 'connected' || tracerouteLoading === node.user?.id}
+            runDisabled={connectionStatus !== 'connected' || tracerouteLoading === node.user?.id || txDisabled}
+            runDisabledReason={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
           />
         ) : undefined}
       />

--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeNeighborLinkStyle } from './NodesTab';
+import { computeNeighborLinkStyle, isTracerouteRunDisabled } from './NodesTab';
 import {
   getEffectivePosition,
   resolveMarkerCenterTarget,
@@ -61,6 +61,32 @@ describe('NodesTab', () => {
     });
   });
 
+
+  // Epic #4294 Phase 2 — the map node popup's "Run Traceroute" button
+  // (rendered via TracerouteBody inside a Leaflet Popup/Marker/MapContainer
+  // tree that isn't practical to fully render in jsdom) must be disabled
+  // whenever the source's TX is disabled, in addition to the pre-existing
+  // not-connected/already-running gates. NodesTab wires this boolean via
+  // isTracerouteRunDisabled(...) and sets the button's title from
+  // tx_disabled.control_tooltip whenever txDisabled is true — see the
+  // <TracerouteBody runDisabled=.../runDisabledReason=.../> call site.
+  describe('isTracerouteRunDisabled (map popup traceroute run-button gating)', () => {
+    it('is disabled when txDisabled is true, even while connected and idle', () => {
+      expect(isTracerouteRunDisabled('connected', null, '!aaaaaaaa', true)).toBe(true);
+    });
+
+    it('is enabled when connected, idle, and txDisabled is false', () => {
+      expect(isTracerouteRunDisabled('connected', null, '!aaaaaaaa', false)).toBe(false);
+    });
+
+    it('stays disabled for the pre-existing not-connected gate regardless of txDisabled', () => {
+      expect(isTracerouteRunDisabled('disconnected', null, '!aaaaaaaa', false)).toBe(true);
+    });
+
+    it('stays disabled for the pre-existing already-running gate regardless of txDisabled', () => {
+      expect(isTracerouteRunDisabled('connected', '!aaaaaaaa', '!aaaaaaaa', false)).toBe(true);
+    });
+  });
 
   // Regression for the "clicking a node pans to a random location, not the
   // node" bug: markers for low-precision/obscured nodes are rendered at an

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -80,6 +80,8 @@ interface NodesTabProps {
   onTraceroute?: (nodeId: string) => void;
   /** Current connection status */
   connectionStatus?: string;
+  /** TX disabled on this source (epic #4294 Phase 2) — ORed into the traceroute run button's disabled state. */
+  txDisabled?: boolean;
   /** Node ID currently being tracerouted (for loading state) */
   tracerouteLoading?: string | null;
   /** Handler for deleting a node from local database */
@@ -198,6 +200,23 @@ export function computeNeighborLinkStyle(
     },
     arrows: isBidirectional ? undefined : { color: lineColor },
   };
+}
+
+/**
+ * Traceroute run-button gating for the map node popup (epic #4294 Phase 2).
+ * Extracted as a pure function (module-scope, exported) — the popup lives
+ * inside a Leaflet Popup/Marker/MapContainer tree that isn't practical to
+ * fully render in jsdom (see NodesTab.test.tsx's helper-only pattern), so
+ * the gating logic is pinned with a unit test independent of the render.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- #4294 pure helper co-located with its only consumer for adapter unit testing; not a component
+export function isTracerouteRunDisabled(
+  connectionStatus: string | undefined,
+  tracerouteLoading: string | null | undefined,
+  nodeUserId: string | undefined,
+  txDisabled: boolean,
+): boolean {
+  return connectionStatus !== 'connected' || tracerouteLoading === nodeUserId || txDisabled;
 }
 
 /**
@@ -333,6 +352,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   tracerouteBounds,
   onTraceroute,
   connectionStatus,
+  txDisabled = false,
   tracerouteLoading,
   onDeleteNode,
   onPurgeNodeFromDevice,
@@ -1674,7 +1694,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                           distanceUnit={distanceUnit}
                           onRunTraceroute={node.user?.id && onTraceroute ? () => onTraceroute(node.user!.id) : undefined}
                           running={tracerouteLoading === node.user?.id}
-                          runDisabled={connectionStatus !== 'connected' || tracerouteLoading === node.user?.id}
+                          runDisabled={isTracerouteRunDisabled(connectionStatus, tracerouteLoading, node.user?.id, txDisabled)}
+                          runDisabledReason={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
                         />
                       ) : undefined}
                     />
@@ -2924,9 +2945,11 @@ const NodesTab = React.memo(NodesTabComponent, (prevProps, nextProps) => {
     return false; // Allow re-render
   }
 
-  // If connection status or traceroute loading state changed, must re-render
-  // (for traceroute button disabled state and loading indicator)
+  // If connection status, TX-disabled state, or traceroute loading state
+  // changed, must re-render (for traceroute button disabled state and
+  // loading indicator; txDisabled added for epic #4294 Phase 2)
   if (prevProps.connectionStatus !== nextProps.connectionStatus ||
+      prevProps.txDisabled !== nextProps.txDisabled ||
       prevProps.tracerouteLoading !== nextProps.tracerouteLoading) {
     return false; // Allow re-render
   }

--- a/src/components/configuration/LoRaConfigSection.tsx
+++ b/src/components/configuration/LoRaConfigSection.tsx
@@ -169,6 +169,17 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
       overrideFrequency, region, hopLimit, txPower, channelNum, femLnaMode, sx126xRxBoostedGain,
       ignoreMqtt, configOkToMqtt, txEnabled, overrideDutyCycle, paFanDisabled]);
 
+  // Danger-confirm on the true->false TX transition (#4294). Enabling never prompts,
+  // and cancelling the confirm leaves the checkbox checked.
+  const handleTxEnabledChange = useCallback((checked: boolean) => {
+    if (!checked && txEnabled) {
+      if (!window.confirm(t('lora_config.tx_disable_confirm'))) {
+        return;
+      }
+    }
+    setTxEnabled(checked);
+  }, [txEnabled, setTxEnabled, t]);
+
   // Register with SaveBar
   useSaveBar({
     id: 'lora-config',
@@ -532,7 +543,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
             id="txEnabled"
             type="checkbox"
             checked={txEnabled}
-            onChange={(e) => setTxEnabled(e.target.checked)}
+            onChange={(e) => handleTxEnabledChange(e.target.checked)}
             style={{ marginTop: '0.2rem', flexShrink: 0 }}
           />
           <div style={{ flex: 1 }}>

--- a/src/components/configuration/LoRaConfigSection.txDisabled.test.tsx
+++ b/src/components/configuration/LoRaConfigSection.txDisabled.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the TX-enabled checkbox danger-confirm (#4294, TX-disabled Phase 2 WP2).
+ *
+ * Disabling TX makes the node invisible to the mesh, so unchecking the box must
+ * confirm via window.confirm before committing the change. Re-enabling TX never
+ * prompts, and cancelling the confirm must leave the checkbox in its prior state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: () => {},
+}));
+
+import LoRaConfigSection from './LoRaConfigSection';
+
+const baseProps = {
+  usePreset: true,
+  modemPreset: 0,
+  bandwidth: 250,
+  spreadFactor: 11,
+  codingRate: 5,
+  frequencyOffset: 0,
+  overrideFrequency: 0,
+  region: 1,
+  hopLimit: 3,
+  txPower: 30,
+  channelNum: 0,
+  femLnaMode: 0,
+  sx126xRxBoostedGain: false,
+  ignoreMqtt: false,
+  configOkToMqtt: false,
+  txEnabled: true,
+  overrideDutyCycle: false,
+  paFanDisabled: false,
+  setUsePreset: vi.fn(),
+  setModemPreset: vi.fn(),
+  setBandwidth: vi.fn(),
+  setSpreadFactor: vi.fn(),
+  setCodingRate: vi.fn(),
+  setFrequencyOffset: vi.fn(),
+  setOverrideFrequency: vi.fn(),
+  setRegion: vi.fn(),
+  setHopLimit: vi.fn(),
+  setTxPower: vi.fn(),
+  setChannelNum: vi.fn(),
+  setFemLnaMode: vi.fn(),
+  setSx126xRxBoostedGain: vi.fn(),
+  setIgnoreMqtt: vi.fn(),
+  setConfigOkToMqtt: vi.fn(),
+  setTxEnabled: vi.fn(),
+  setOverrideDutyCycle: vi.fn(),
+  setPaFanDisabled: vi.fn(),
+  isSaving: false,
+  onSave: vi.fn(async () => {}),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('LoRaConfigSection — TX-enabled danger-confirm', () => {
+  it('confirms before disabling TX, and calls setTxEnabled(false) when accepted', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<LoRaConfigSection {...baseProps} txEnabled={true} />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /tx_enabled/i }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+
+    checkbox.click();
+
+    expect(confirmSpy).toHaveBeenCalledWith('lora_config.tx_disable_confirm');
+    expect(baseProps.setTxEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('does not call setTxEnabled when the disable confirm is cancelled', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<LoRaConfigSection {...baseProps} txEnabled={true} />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /tx_enabled/i }) as HTMLInputElement;
+    checkbox.click();
+
+    expect(confirmSpy).toHaveBeenCalledWith('lora_config.tx_disable_confirm');
+    expect(baseProps.setTxEnabled).not.toHaveBeenCalled();
+  });
+
+  it('never prompts when re-enabling TX (false -> true)', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<LoRaConfigSection {...baseProps} txEnabled={false} />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /tx_enabled/i }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    checkbox.click();
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(baseProps.setTxEnabled).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/map/popups/sections.test.tsx
+++ b/src/components/map/popups/sections.test.tsx
@@ -398,6 +398,34 @@ describe('TracerouteBody', () => {
     );
     expect(container.querySelector('.spinner')).not.toBeNull();
   });
+
+  it('sets the run button title from runDisabledReason (epic #4294 Phase 2 — TX-disabled tooltip)', () => {
+    const onRun = vi.fn();
+    const { rerender } = render(
+      <TracerouteBody
+        recentTraceroute={null}
+        nodes={[]}
+        distanceUnit="km"
+        onRunTraceroute={onRun}
+      />,
+    );
+    // No reason given — no title attribute.
+    expect(screen.getByText(/Traceroute/).closest('button')).not.toHaveAttribute('title');
+
+    rerender(
+      <TracerouteBody
+        recentTraceroute={null}
+        nodes={[]}
+        distanceUnit="km"
+        onRunTraceroute={onRun}
+        runDisabled
+        runDisabledReason="Transmit is disabled on this node's radio."
+      />,
+    );
+    const btn = screen.getByText(/Traceroute/).closest('button')!;
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', "Transmit is disabled on this node's radio.");
+  });
 });
 
 describe('NodeActions', () => {

--- a/src/components/map/popups/sections.tsx
+++ b/src/components/map/popups/sections.tsx
@@ -354,6 +354,8 @@ export interface TracerouteBodyProps {
   onRunTraceroute?: () => void;
   running?: boolean;
   runDisabled?: boolean;
+  /** Explanatory tooltip for the run button when `runDisabled` is true (e.g. TX-disabled, epic #4294). */
+  runDisabledReason?: string;
 }
 
 /** `.node-popup-traceroute` fwd/return summary + optional History/Run buttons. */
@@ -365,6 +367,7 @@ export const TracerouteBody: React.FC<TracerouteBodyProps> = ({
   onRunTraceroute,
   running = false,
   runDisabled = false,
+  runDisabledReason,
 }) => {
   const { t } = useTranslation();
   return (
@@ -429,7 +432,7 @@ export const TracerouteBody: React.FC<TracerouteBodyProps> = ({
       )}
 
       {onRunTraceroute && (
-        <button className="node-popup-btn" onClick={onRunTraceroute} disabled={runDisabled}>
+        <button className="node-popup-btn" onClick={onRunTraceroute} disabled={runDisabled} title={runDisabledReason}>
           {running ? <span className="spinner"></span> : <UiIcon name="radioSignal" />} {t('node_popup.traceroute', 'Traceroute')}
         </button>
       )}

--- a/src/hooks/useSourceView.ts
+++ b/src/hooks/useSourceView.ts
@@ -44,6 +44,7 @@ import { effectiveMapMaxAgeHours } from '../utils/mapAge';
 import { nodePassesTransportFilter, transportCutoffSec } from '../utils/nodeTransport';
 import { logger } from '../utils/logger';
 import { favoritePendingKey, pendingFavoriteRequests } from '../utils/pendingToggles';
+import { isTxDisabledBody } from '../utils/txDisabled';
 
 export interface UseSourceViewParams {
   /** The deployment base path — App passes `appBasename` (#3962 5.4 PR8
@@ -194,13 +195,22 @@ export function useSourceView(params: UseSourceViewParams) {
         const nodeNumStr = nodeId.replace('!', '');
         const nodeNum = parseInt(nodeNumStr, 16);
 
-        await authFetch(`${baseUrl}/api/traceroute`, {
+        const response = await authFetch(`${baseUrl}/api/traceroute`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ destination: nodeNum, sourceId, ...(channel !== undefined && { channel }) }),
         });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          setTracerouteLoading(null);
+          if (isTxDisabledBody(response.status, errorData)) {
+            showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          }
+          return;
+        }
 
         logger.debug(`🗺️ Traceroute request sent to ${nodeId}`);
 
@@ -222,7 +232,7 @@ export function useSourceView(params: UseSourceViewParams) {
         setTracerouteLoading(null);
       }
     },
-    [connectionStatus, setTracerouteLoading, authFetch, baseUrl, sourceId, refetchPoll]
+    [connectionStatus, setTracerouteLoading, authFetch, baseUrl, sourceId, refetchPoll, showToast, t]
   );
 
   const handleDeleteNode = useCallback(

--- a/src/utils/txDisabled.test.ts
+++ b/src/utils/txDisabled.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { TX_DISABLED_CODE, isTxDisabledBody, isTxDisabledError } from './txDisabled';
+
+describe('txDisabled (#4294)', () => {
+  it('exposes the TX_DISABLED code constant', () => {
+    expect(TX_DISABLED_CODE).toBe('TX_DISABLED');
+  });
+
+  describe('isTxDisabledBody', () => {
+    it('is true for a 409 with a matching code', () => {
+      expect(isTxDisabledBody(409, { code: 'TX_DISABLED' })).toBe(true);
+    });
+
+    it('is true even when the body carries extra fields', () => {
+      expect(isTxDisabledBody(409, { code: 'TX_DISABLED', error: 'Transmit is disabled', extra: 1 })).toBe(true);
+    });
+
+    it('is false for a non-409 status with a matching code', () => {
+      expect(isTxDisabledBody(500, { code: 'TX_DISABLED' })).toBe(false);
+      expect(isTxDisabledBody(403, { code: 'TX_DISABLED' })).toBe(false);
+      expect(isTxDisabledBody(200, { code: 'TX_DISABLED' })).toBe(false);
+    });
+
+    it('is false for a 409 with a different code', () => {
+      expect(isTxDisabledBody(409, { code: 'OTHER_ERROR' })).toBe(false);
+      expect(isTxDisabledBody(409, { code: '' })).toBe(false);
+    });
+
+    it('is false when the body has no code field', () => {
+      expect(isTxDisabledBody(409, {})).toBe(false);
+    });
+
+    it('is false for non-object bodies', () => {
+      expect(isTxDisabledBody(409, null)).toBe(false);
+      expect(isTxDisabledBody(409, undefined)).toBe(false);
+      expect(isTxDisabledBody(409, 'TX_DISABLED')).toBe(false);
+      expect(isTxDisabledBody(409, 42)).toBe(false);
+      expect(isTxDisabledBody(409, ['TX_DISABLED'])).toBe(false);
+    });
+  });
+
+  describe('isTxDisabledError', () => {
+    it('is true for a matching {code} shape', () => {
+      expect(isTxDisabledError({ code: 'TX_DISABLED' })).toBe(true);
+    });
+
+    it('is true for an ApiError-shaped object with extra fields', () => {
+      expect(isTxDisabledError({ status: 409, code: 'TX_DISABLED', message: 'Transmit is disabled' })).toBe(true);
+    });
+
+    it('is false for a different code', () => {
+      expect(isTxDisabledError({ code: 'OTHER_ERROR' })).toBe(false);
+    });
+
+    it('is false when there is no code field', () => {
+      expect(isTxDisabledError({})).toBe(false);
+      expect(isTxDisabledError(new Error('boom'))).toBe(false);
+    });
+
+    it('is false for null/undefined/non-objects', () => {
+      expect(isTxDisabledError(null)).toBe(false);
+      expect(isTxDisabledError(undefined)).toBe(false);
+      expect(isTxDisabledError('TX_DISABLED')).toBe(false);
+      expect(isTxDisabledError(42)).toBe(false);
+    });
+  });
+});

--- a/src/utils/txDisabled.ts
+++ b/src/utils/txDisabled.ts
@@ -1,0 +1,32 @@
+/**
+ * TX-disabled detection helpers (epic #4294, Phase 2).
+ *
+ * Phase 1 (backend) maps every transmit-primitive failure caused by a
+ * source's TX being disabled to `fail(res, 409, 'TX_DISABLED', ...)`. These
+ * pure predicates let both `authFetch`-based call sites (which read a raw
+ * `Response` + parsed JSON body) and `apiService`-based call sites (which
+ * catch a thrown `ApiError{ status, code }`) share one definition of "is
+ * this a TX-disabled error" without duplicating the check or introducing a
+ * shared class/hook dependency between them.
+ *
+ * Pure, no React, no I/O — safe to import from anywhere.
+ */
+
+export const TX_DISABLED_CODE = 'TX_DISABLED';
+
+/** True when a parsed error body from a 409 signals TX disabled. */
+export function isTxDisabledBody(status: number, body: unknown): boolean {
+  return (
+    status === 409 &&
+    typeof body === 'object' && body !== null &&
+    (body as { code?: unknown }).code === TX_DISABLED_CODE
+  );
+}
+
+/** True when a thrown ApiError (or any `{ code }`-shaped value) is a TX-disabled error. */
+export function isTxDisabledError(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null &&
+    (err as { code?: unknown }).code === TX_DISABLED_CODE
+  );
+}


### PR DESCRIPTION
## Summary
Phase 2 of the TX-disabled (receive-only) epic #4294. Phase 1 made the backend honor `lora.txEnabled` and return `409 TX_DISABLED` for blocked transmits; this phase makes the **frontend** honor that state. Every send/request control that cannot work with TX disabled now renders **disabled with an explanatory tooltip** (never hidden — reads still work since RX is unaffected), the LoRa TX checkbox gets a danger-confirm on disable, TX state refreshes promptly after a save, and any 409 that slips through a race surfaces as a friendly toast.

## Changes
- **Shared helper:** `src/utils/txDisabled.ts` — `isTxDisabledBody(status, body)` / `isTxDisabledError(err)` / `TX_DISABLED_CODE` (pure, `unknown`-narrowed). Four new `en.json` i18n keys.
- **Gating model:** `App.tsx` derives `txGated = isTxDisabled && !isMqttBridge` (per-source via the existing `useTxStatus` hook; MQTT-bridge/MeshCore never gated) and threads `txDisabled` into ChannelsTab, MessagesTab, NodePopup, and NodesTab.
- **Messaging surfaces:** channel + DM composers (textarea, send, bell, position, resend, emoji), per-node request buttons (traceroute, exchange position, exchange nodeinfo/key-repair, request telemetry, admin-scan) all disabled + tooltip when TX off. Reaction chips stay clickable (they double as the "who reacted" read affordance; a re-tap is caught by the 409 toast).
- **Map traceroute:** the run button in both the chat `NodePopup` and the **main-map popup** (`NodesTab`'s direct `TracerouteBody`) gated via `runDisabled` + `runDisabledReason` tooltip.
- **AdminCommandsTab:** remote-node-targeted admin gated (disabled buttons + inline notice + `executeCommand` choke-point guard) when TX off; **local-node admin stays fully usable** (it's how you re-enable TX). Removed the two frontend `?? true` force-defaults.
- **LoRa checkbox:** genuinely settable; `window.confirm` danger dialog on the true→false transition only (cancel keeps it checked).
- **Freshness:** `queryClient.invalidateQueries(['txStatus'])` after a successful LoRa save (ConfigurationTab + local AdminCommandsTab) so the banner + gating update without waiting for the 30s poll.
- **409 races:** every send/request handler surfaces `tx_disabled.send_blocked_toast` on a 409 `TX_DISABLED` (covers the window before the poll updates).

## Issues Resolved
Relates to #4294 (Phase 2 of 3 — polish/docs follow in Phase 3)

## Documentation Updates
- Epic plan (`TX_DISABLED_SUPPORT_EPIC.md`) updated with Phase 2 completion + deviations; Phase 2 spec doc added.
- User-facing receive-only docs + v1 API 409 docs land in Phase 3.

## Testing
- [x] Full Vitest suite: `success: true` — 3397/3397 suites, 11,064 passed, 0 failed (109 pending = PG/MySQL container skips)
- [x] `npm run typecheck` clean; `npm run lint:ci` 0 in-repo FAIL lines (no new ratchet violations)
- [x] New tests: `txDisabled` helper, ChannelsTab/MessagesTab disabled-state, NodePopup/sections runDisabled(+Reason), NodesTab `isTracerouteRunDisabled`, LoRaConfigSection confirm accept/cancel/enable-never-prompts, ConfigurationTab + AdminCommandsTab `['txStatus']` invalidation, AdminCommandsTab remote-blocked/local-usable
- [x] **Browser-validated** in the dev container against a TX-disabled Meshtastic source: channel/DM gating + tooltips, LoRa confirm dialog (accept & cancel), banner appears without reload after save, main-map popup traceroute gating, clean console
- [ ] Reviewer: confirm on a TX-disabled source that sends/traceroute/remote-admin are visibly disabled while reads + local-node admin still work; toggling TX via the LoRa checkbox prompts only when disabling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW