### PR TITLE
docs+feat: TX-disabled polish — automations badge, API docs, receive-only guide (#4294)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -72,7 +72,8 @@ export default defineConfig({
             { text: 'Settings', link: '/features/settings' },
             { text: 'Global Settings', link: '/features/global-settings' },
             { text: 'Multi-Source', link: '/features/multi-source' },
-            { text: 'Device Configuration', link: '/features/device' }
+            { text: 'Device Configuration', link: '/features/device' },
+            { text: 'Receive-Only Mode', link: '/features/receive-only-mode' }
           ]
         },
         {

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -466,6 +466,10 @@ Send a text message to the mesh network.
 }
 ```
 
+**Error Responses:**
+- `409 TX_DISABLED` — Transmit is disabled on this source (receive-only mode); nothing was sent.
+  See [Receive-Only Mode](/docs/features/receive-only-mode.md).
+
 ---
 
 ## Channel Management
@@ -611,6 +615,10 @@ Initiate a traceroute to a specific node.
   "message": "Traceroute sent to node 987654321"
 }
 ```
+
+**Error Responses:**
+- `409 TX_DISABLED` — Transmit is disabled on this source (receive-only mode); nothing was sent.
+  See [Receive-Only Mode](/docs/features/receive-only-mode.md).
 
 ### GET /api/traceroutes/recent
 Get recent traceroute results.
@@ -838,6 +846,20 @@ Configure LoRa radio settings.
 ```
 
 **Note:** This triggers a device reboot to apply changes.
+
+::: tip Transmit (TX) Enabled honoring (#4294)
+The LoRa configuration write path no longer force-overrides `txEnabled` to `true`. MeshMonitor
+honors whatever value is submitted, and backfills the device's current value when a client omits
+the field (LoRa config is written as a whole-message replace, so an omitted boolean would
+otherwise decode as `false`). This lets a source legitimately run in **receive-only mode** — see
+[Receive-Only Mode](/docs/features/receive-only-mode.md).
+
+Channel-URL import and remote-node config import likewise **preserve** the device's current
+`txEnabled` value instead of forcing it to `true` — importing channels or a remote config no
+longer covertly re-enables TX on a receive-only node. Remote-node import preservation is
+best-effort (falls back to the last cached remote config, then the decoded URL value, then
+`true` if neither is available); export always emits the actual current value.
+:::
 
 ### POST /api/set-position-config
 Configure position and GPS settings, including fixed position.
@@ -1085,10 +1107,26 @@ v1 API endpoints use the envelope format:
 }
 ```
 
+**Transmit-disabled sources (`409 TX_DISABLED`):** any transmit action — message send, traceroute,
+position/nodeinfo/neighbor/telemetry request, or remote-node admin command — returns the envelope
+format above with `code: "TX_DISABLED"` and HTTP `409` when the target source's LoRa radio has
+`lora.txEnabled = false` (receive-only mode; see [Receive-Only Mode](/docs/features/receive-only-mode.md)):
+
+```json
+{
+  "success": false,
+  "error": "Transmit is disabled on this source",
+  "code": "TX_DISABLED"
+}
+```
+
+Nothing is transmitted. Re-enable **TX Enabled** in the source's LoRa configuration to clear it.
+
 **Common Status Codes:**
 - `200` - Success
 - `400` - Bad Request (invalid parameters, or missing `sourceId` on a per-source v1 endpoint)
 - `404` - Not Found
+- `409` - Conflict (e.g. `TX_DISABLED` — target source is in receive-only mode)
 - `500` - Internal Server Error
 - `503` - Service Unavailable (Meshtastic not connected)
 

--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -107,10 +107,29 @@ v1 API errors use the envelope format:
 
 Per-source v1 endpoints return `400 MISSING_SOURCE_ID` when `sourceId` is absent from a request that requires it. There is no silent fallback to the primary source.
 
+**Transmit-disabled sources (`409 TX_DISABLED`):** any transmit action — message send, traceroute,
+position/nodeinfo/neighbor/telemetry request, or remote-node admin command — returns `409` with
+`code: "TX_DISABLED"` when the target source's LoRa radio has `lora.txEnabled = false` (receive-only
+mode; see [Receive-Only Mode](/docs/features/receive-only-mode.md)):
+
+```json
+{
+  "success": false,
+  "error": "Transmit is disabled on this source",
+  "code": "TX_DISABLED"
+}
+```
+
+Nothing is transmitted. Re-enable **TX Enabled** in the source's LoRa configuration to clear it. This
+applies to both the v1 endpoints above and the equivalent main-API routes (`/api/messages/send`,
+`/api/traceroute`, `/api/position/request`, `/api/nodeinfo/request`, `/api/neighborinfo/request`,
+`/api/telemetry/request`, `/api/admin/commands`).
+
 **Common Status Codes:**
 - `200` - Success
 - `400` - Bad Request (invalid parameters, or missing `sourceId` on a per-source endpoint)
 - `404` - Not Found
+- `409` - Conflict (e.g. `TX_DISABLED` — target source is in receive-only mode)
 - `500` - Internal Server Error
 
 ## Endpoints
@@ -826,6 +845,8 @@ Manually trigger a traceroute request to a specific node to discover the network
 
 **Error Responses:**
 - `400`: Missing or invalid destination node ID
+- `409`: Transmit disabled on this source (`TX_DISABLED`) — the source's LoRa radio is in
+  receive-only mode; see [Receive-Only Mode](/docs/features/receive-only-mode.md)
 - `500`: Failed to send traceroute
 
 **Example:**

--- a/docs/features/device.md
+++ b/docs/features/device.md
@@ -293,6 +293,18 @@ MeshMonitor will warn you before setting ROUTER mode. Only use this for powered,
 When "Use Preset" is disabled, you must manually configure bandwidth, spreading factor, and coding rate. Incorrect settings can prevent communication with other nodes or violate regulatory requirements. Only disable presets if you have specific technical requirements and understand LoRa modulation parameters.
 :::
 
+### TX Enabled
+
+**Description**: Enables or disables radio transmission on this source's node.
+
+**Effect**: When enabled (default), the node transmits normally — messages, traceroutes, requests, and its own NodeInfo/Position/Telemetry broadcasts all go out over LoRa. When disabled, the node becomes **receive-only**: it keeps decoding everything it hears, but every outbound LoRa packet is dropped at the radio.
+
+**Side Effects**: Unchecking this shows a confirmation dialog, because disabling TX has broad consequences — see [Receive-Only Mode](/features/receive-only-mode) for the full list of what still works and what doesn't.
+
+::: warning Receive-Only Mode
+Disabling TX makes the node **invisible to the mesh** — it stops announcing itself, so other nodes will eventually age it out. MeshMonitor's own transmit controls (send, traceroute, remote admin, etc.) are disabled with a tooltip while this is off, and a persistent banner reminds you TX is disabled. See [Receive-Only Mode](/features/receive-only-mode) for details.
+:::
+
 ### Manual LoRa Parameters
 
 These parameters are only available when "Use Preset" is disabled. They provide fine-grained control over radio modulation for advanced users.

--- a/docs/features/receive-only-mode.md
+++ b/docs/features/receive-only-mode.md
@@ -1,0 +1,91 @@
+# Receive-Only Mode
+
+::: tip Added in 4.14 (#4294)
+Run a Meshtastic source with its radio's transmitter turned off — a legitimate, supported
+listen-only configuration for gateways, monitoring stations, and MQTT relays that should never
+key the radio.
+:::
+
+## What it is
+
+Receive-only mode is what happens when a Meshtastic source's LoRa configuration has **TX
+Enabled** turned off (`lora.txEnabled = false`). This maps directly to a hard kill switch in the
+Meshtastic firmware itself (`RadioLibInterface.cpp`): every outbound LoRa packet is dropped at
+the radio driver before it reaches the air. It isn't a MeshMonitor-side restriction — the device
+will refuse to transmit no matter which client talks to it.
+
+Common reasons to run a node this way:
+
+- A **listen-only gateway** feeding packets into MQTT or another aggregator, with no business
+  keying the radio
+- Regulatory or spectrum constraints where a node should only observe
+- A **`ROUTER_LATE`-style relay** you want visible on your dashboard without letting it transmit
+
+Prior to #4294, MeshMonitor silently force-set `txEnabled: true` on every LoRa config write and
+on every channel/config import — so a receive-only node would have TX quietly re-enabled the next
+time someone touched its configuration through MeshMonitor. That override is gone: MeshMonitor
+now **honors and persists** whatever value you set.
+
+## What still works
+
+- **All read-only surfaces** — Dashboard, Packet Monitor, Unified Telemetry, the Map, and message
+  history all work normally, because RX and decode are completely unaffected.
+- **Local-node admin** over the TCP API — config reads/writes, reboot, set-time (the time-sync
+  scheduler is local admin and keeps running), and channel reads.
+- Messages **arriving** from other nodes still show up as normal.
+
+## What's disabled
+
+Everything that requires putting a packet on the air from *this* node:
+
+- Sending channel/DM messages, tapbacks, and resends
+- Traceroute requests
+- Position, NodeInfo, neighbor-info, and telemetry requests
+- **Remote**-node admin commands (local-node admin is unaffected — see above)
+- The node's **own** NodeInfo, Position, and Telemetry broadcasts
+
+That last point matters: because the node stops announcing itself, **it goes invisible to the
+rest of the mesh** over time, even though it can still hear everything happening around it.
+
+## How MeshMonitor behaves
+
+- A persistent warning banner appears while TX is disabled, linking back to the LoRa
+  configuration section.
+- Every send/transmit control (channel and DM send boxes, tapback, resend, the send bell,
+  traceroute, position/nodeinfo/neighbor/telemetry request buttons, remote-node admin actions) is
+  rendered disabled with a tooltip explaining why.
+- If a race lets a transmit request through anyway, the backend rejects it with `409 TX_DISABLED`
+  and the UI surfaces a toast rather than failing silently or crashing. See the
+  [REST API reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md)
+  for the exact error shape.
+- **Automations** that target a receive-only source skip the send and record it in the automation
+  run history rather than failing the run; the automation builder also shows an inline warning
+  badge next to any explicitly-selected source that currently has TX disabled.
+- **Not gated:** the embedded MQTT bridge downlink (it publishes to a broker, bypassing the radio
+  entirely) and MeshCore sources (a different protocol with no equivalent flag).
+
+## How to enable / disable it
+
+1. Open the source's **LoRa Configuration** section (see [Device Configuration](/features/device)).
+2. Toggle **TX Enabled**.
+3. Unchecking it shows a confirmation dialog spelling out the consequences (the node goes
+   invisible to the mesh; no sending, traceroute, or remote admin until you re-enable it). Confirm
+   to apply.
+
+As of #4294, this setting **persists** — MeshMonitor no longer force-reverts it to `true` on
+save, and channel-URL / remote-config imports **preserve** the device's current value instead of
+silently forcing TX back on.
+
+::: warning Some hardware re-reads its own config
+A small number of devices have been observed re-reading their own configuration and reverting
+`tx_enabled` back to `true` on their own, independent of MeshMonitor. If TX keeps re-enabling
+itself after you disable it, that's a device-side quirk, not MeshMonitor overriding your setting
+— check the node's own configuration/firmware behavior.
+:::
+
+## Related
+
+- [Device Configuration](/features/device) — LoRa Radio Configuration, including the TX Enabled
+  checkbox
+- [REST API Reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) — `409 TX_DISABLED` error shape
+- [Multi-Source](/features/multi-source) — TX state is tracked per source

--- a/docs/internal/dev-notes/TX_DISABLED_PHASE3_SPEC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_PHASE3_SPEC.md
@@ -1,0 +1,272 @@
+# TX-Disabled Support — Phase 3 Spec (Polish + Docs, closeout)
+
+**Epic:** #4294 — TX-Disabled Support
+**Phase:** 3 of 3 (final). Phases 1 (backend 409 + honor `txEnabled`) and 2 (frontend
+gating, `useTxStatus` consumers, `src/utils/txDisabled.ts`, `tx_disabled.*` i18n) are merged.
+**Author role:** Phase Architect (spec only — no feature code, no doc prose written here).
+**Worktree validated against:** `/home/yeraze/Development/meshmonitor-tx-disabled-docs`
+(branch `feature/tx-disabled-docs`, off origin/main with Phases 1 & 2 merged).
+
+Phase 3 is deliberately small: one thin code change (automations builder warning badge)
+plus documentation. Everything below is validated against the current tree with file:line
+anchors.
+
+---
+
+## 0. Reuse inventory (use these — do not reinvent)
+
+| Need | Reuse | Location (validated) |
+|---|---|---|
+| Warning icon | `UiIcon` name `alert` (AlertTriangle / ⚠️, "warnings and security risks") | `src/components/icons/UiIcon.tsx:136` |
+| TX-disabled detection predicates | `isTxDisabledError` / `isTxDisabledBody` (already used by Phase 2) | `src/utils/txDisabled.ts` |
+| TX status hook | `useTxStatus({ baseUrl, sourceId })` → `{ isTxDisabled, data:{txEnabled} }` — **single-source only**, cannot be looped | `src/hooks/useTxStatus.ts` |
+| Per-source TX flag origin | `lora.txEnabled` read via `mgr.getCurrentConfig()?.deviceConfig?.lora` | `src/server/routes/sourceRoutes.ts:262` (inside `computeSourceRadioSummary`) |
+| Sources-list public summary choke point | `computeSourceRadioSummary()` → attached as `radio:` on each `GET /api/sources` entry | `src/server/routes/sourceRoutes.ts:257`, merged at `:312` |
+| Automations builder (leaf, pure/presentational) | `AutomationBuilder.tsx`; `sendSourceMulti` field render | `src/components/automations/AutomationBuilder.tsx:150` |
+| `sendSourceMulti` filter | `isSendableSource(s)` (enabled and not MQTT) | `AutomationBuilder.tsx:25` |
+| `SourceOption` shape | `{ id; name; type?; enabled? }` | `AutomationBuilder.tsx:17` |
+| Sources data owner | `AutomationsPage.tsx` fetches `/api/sources` via `apiService.get` | `src/components/automations/AutomationsPage.tsx:192` |
+| CSS (existing automations sheet) | `.ae-muted`, `.ae-switch`, `.ae-token-diag--warn` (`var(--ctp-yellow)`) | `src/components/automations/AutomationsPage.css:58,62,111` |
+| i18n | flat dotted keys in `public/locales/en.json`; existing `tx_disabled.*` block | `public/locales/en.json:121-123` |
+| v1 action route 409 shape | `{ success:false, error:'…', code:'TX_DISABLED' }` (hand-written) | `src/server/routes/v1/actions.ts` (`/traceroute`, `/request-position`, `/request-nodeinfo`, `/request-neighbors`) |
+| Main-API 409 shape | `fail(res, 409, 'TX_DISABLED', '…')` → same JSON body | `messageRoutes.ts:1320`, `meshRequestRoutes.ts:43/125/206/288/345`, `adminRoutes.ts:618/663/785/848/930/950` |
+| Docs sidebar | VitePress `/features/` sidebar, "Core" group | `docs/.vitepress/config.mts:69-77` |
+| User-facing LoRa/device doc | `docs/features/device.md` — "LoRa Radio Configuration" (`:280`) | (no `tx_enabled`/Transmit item today) |
+| API reference docs | `docs/api/REST_API.md` (endpoint-by-endpoint) + `docs/api/API_REFERENCE.md` ("Complete REST API Documentation", VitePress-rendered) | `docs/api/` |
+
+Note: `docs/api/API.md` is explicitly marked outdated ("use REST_API.md or API_REFERENCE.md
+instead") — **do not** edit it. `docs/development/api-reference.md` is only a pointer page to
+REST_API.md + the interactive OpenAPI spec — no endpoint tables there.
+
+---
+
+## 1. Design analysis: the automations badge (the honest per-source check)
+
+The task asks: "when an automation's send-message action targets a source whose TX is disabled,
+show an inline warning badge." Two facts constrain the design:
+
+1. **Automations are global and fan out at runtime.** A `sendMessage` (and `tapback`,
+   `requestData`, `deviceReboot`) action carries a `sourceIds: string[]` multi-select
+   (`kind: 'sendSourceMulti'`, `catalog.ts:313,322,384,394`). "Leave none" = use the
+   triggering source (unknown at design time). So there is **no single design-time sourceId**;
+   there is a set of *explicitly selected* sourceIds, each of which has a concrete,
+   knowable design-time TX state.
+
+2. **`useTxStatus` is single-source and cannot be looped** (React hooks rule). Calling it
+   once per selected source is not viable. `AutomationBuilder` is also a pure presentational
+   component that receives all data via props (no `baseUrl`, no query client, no i18n today).
+
+**Chosen approach — augment the already-public sources list with `txEnabled`, then badge
+each selected TX-disabled source.** This is a concrete, honest, per-selected-source check
+(not invented per-source machinery, and not a vague static note). It piggybacks on the exact
+choke point that already exposes `lora` config publicly for the frequency summary.
+
+Rejected alternatives:
+- N× `GET /api/device/tx-status?sourceId=` fetches from `AutomationsPage` — more code, N
+  requests, and would need a non-hook fetch loop; the one-field sources-list augmentation is
+  strictly simpler and reuses an existing endpoint.
+- A static informational note only ("TX-disabled sources are skipped at runtime") — acceptable
+  *fallback* if reviewers reject the backend field, but weaker: it can't point at *which*
+  selected source is offline. Keep the Phase-1 skip-and-record behavior sentence (below) as a
+  complementary help line regardless.
+
+Scope of the badge: render it in the **shared `sendSourceMulti` render case**
+(`AutomationBuilder.tsx:150`), so it automatically covers every TX action that uses that field
+kind (send message, tapback, request-data, device-reboot) — more correct than special-casing
+`sendMessage`, and zero extra code per action.
+
+---
+
+## 2. Work packages
+
+Two work packages. **WP1 (code) and WP2 (docs) touch disjoint files and are fully parallel.**
+
+### WP1 — Automations builder TX-disabled warning badge
+
+**W1.1 Backend: expose `txEnabled` on the sources list (Meshtastic-only, fail-open true).**
+- File: `src/server/routes/sourceRoutes.ts`.
+- Add `txEnabled?: boolean;` to `interface SourceRadioSummary` (`:248`) with a
+  "Meshtastic only" doc comment.
+- In `computeSourceRadioSummary` Meshtastic branch (`:261-280`), set
+  `txEnabled: lora.txEnabled ?? true` in the returned object (default **true** = fail-open,
+  matching firmware default and `GET /api/device/tx-status`). MeshCore / MQTT branches leave
+  it `undefined` (they have no such flag; badge never shows for them).
+- It surfaces automatically via the existing `radio: computeSourceRadioSummary(s.id)` merge
+  (`:312`). No new endpoint.
+- Sensitivity: `txEnabled` is public RF behavior (the node stops transmitting — observable
+  over the air), consistent with the existing frequency/region rationale in the comment at
+  `:240-247`. No secret; `stripSourceSecrets` unaffected. It rides `optionalAuth()`.
+
+**W1.2 Frontend: thread `txEnabled` into `SourceOption` and render the badge.**
+- `AutomationBuilder.tsx`: extend `SourceOption` (`:17`) with `txEnabled?: boolean;`.
+- `AutomationsPage.tsx` (`:192-194`): the `apiService.get` generic and the `.map` currently
+  project `{ id, name, type, enabled }`. Add `radio?: { txEnabled?: boolean }` to the fetched
+  type and map `txEnabled: s.radio?.txEnabled` into each `SourceOption`.
+- `AutomationBuilder.tsx` `sendSourceMulti` case (`:150`): inside the per-source `.map`, when
+  `s.txEnabled === false` (strict — only on positive knowledge; `undefined` shows nothing),
+  render an inline `<UiIcon name="alert" size={14} />` + short warning text next to the
+  source label. Use a small yellow style (see W1.4).
+- Keep it a **hint, not a hard block**: do not disable the checkbox. A user may legitimately
+  pre-select a source they intend to re-enable, and the runtime engine already skips-and-records
+  (Phase 1). The badge is advisory.
+
+**W1.3 i18n wiring.** `AutomationBuilder` and `AutomationsPage` currently use **no**
+`useTranslation` (the whole automations builder is hardcoded English — catalog help strings,
+"No sendable (non-MQTT) sources.", etc.). The epic requires the string live under
+`tx_disabled.*` in `en.json`. Recommended: add the key (W1.4) and introduce a single
+`useTranslation()` call in `AutomationBuilder` for the badge text/tooltip only (react-i18next
+is already the app-wide provider; low risk). Acceptable fallback if a reviewer prefers not to
+introduce i18n into an otherwise un-i18n'd leaf: hardcode the English literal and still add the
+`en.json` key for future adoption. State whichever choice is made in the PR body.
+
+**W1.4 CSS.** Add one small rule to `src/components/automations/AutomationsPage.css` (a CSS
+module for a single inline badge inside a component that already owns a global sheet is
+overkill; a sibling rule is consistent with `.ae-token-diag--warn`). Suggested:
+`.ae-tx-warn { color: var(--ctp-yellow); font-size: 0.75rem; display: inline-flex; align-items: center; gap: 0.25rem; margin-left: 0.4rem; }`.
+Do not hardcode a hex color — reuse the `--ctp-*` theme vars (already used throughout this sheet).
+
+**W1.5 Tests.**
+- Backend: extend the sources-list route/unit coverage to assert `radio.txEnabled` reflects
+  `lora.txEnabled` (false when disabled; true/absent otherwise). Use the route harness pattern
+  (`createRouteTestApp`) if adding a route test; a `computeSourceRadioSummary` unit test is also
+  acceptable and lighter.
+- Frontend: a component test rendering `AutomationBuilder` with a `sourceMessage`/`action.sendMessage`
+  block and a `sources` array where one source has `txEnabled:false` — assert the badge renders
+  for that source and **not** for a `txEnabled:true`/`undefined` source, and that the checkbox is
+  still enabled.
+- ESLint ratchet: no raw `fetch()` (AutomationsPage uses `apiService`), no new `any`, no new
+  `exhaustive-deps`. Confirm with `npm run lint:ci` (filter out `.claude/worktrees` per CLAUDE.md).
+
+### WP2 — Documentation (all doc files; no code)
+
+**W2.1 v1 API + main-API: document `409 TX_DISABLED`.**
+The v1 external action routes (`src/server/routes/v1/actions.ts`) and the main-API
+message/mesh-request/admin routes both return, on a TX-disabled source:
+```json
+{ "success": false, "error": "Transmit is disabled on this source", "code": "TX_DISABLED" }
+```
+with HTTP **409**. (v1 hand-written; main API via `fail(res, 409, 'TX_DISABLED', …)` — identical body.)
+
+Rather than editing every endpoint block, do both of:
+1. **Add a global entry to the Error Handling sections.** In `docs/api/REST_API.md`
+   ("Error Handling", `:87`, before the "Common Status Codes" list at `:110`) and the
+   equivalent section in `docs/api/API_REFERENCE.md`, add a `409 TX_DISABLED` row/paragraph:
+   "`409 TX_DISABLED` — returned by any transmit action (message send, traceroute, position /
+   nodeinfo / neighbor / telemetry request, remote-node admin) when the target source has
+   `lora.txEnabled = false` (receive-only mode). Body: `{ success:false, error, code:'TX_DISABLED' }`.
+   Nothing is transmitted. Re-enable TX in the LoRa config to clear it." Add `409` to the
+   "Common Status Codes" list too.
+2. **Annotate the specific documented action endpoints** that already have per-endpoint status
+   lists, adding a `409: Transmit disabled on this source (TX_DISABLED)` line:
+   - `docs/api/REST_API.md` → `POST /api/traceroutes/send` (`:808`, currently only documents `500` at `:829`).
+   - `docs/api/API_REFERENCE.md` → `POST /api/messages/send` (`:204`) and any documented
+     position/nodeinfo/neighbor/telemetry request + remote-admin endpoints.
+   The v1 per-source action endpoints (`/api/v1/sources/{id}/actions/*`) are **not** currently
+   in `REST_API.md` or `docs/public/openapi.yaml` endpoint-by-endpoint; the global Error
+   Handling note (step 1) covers them. Optionally add a `409` response with a `$ref` to the
+   existing `Error` schema (`openapi.yaml:72`) if/when those action paths are added to the
+   OpenAPI spec — treat as nice-to-have, not required for closeout.
+
+**W2.2 Document the `txEnabled` behavior change (config/lora + import).**
+In the same API docs (near the LoRa/config write endpoint and the import/export sections), add
+a short note: as of #4294, `POST /api/config/lora` **no longer force-sets `txEnabled: true`** —
+it honors the submitted value and backfills the device's current value when the field is omitted
+(whole-message LoRaConfig replace; an omitted bool would otherwise decode as `false`). Channel-URL
+and config **import/export preserve** the actual `txEnabled` value instead of forcing `true`.
+(Remote-node import preserve is best-effort — see §4.)
+
+**W2.3 New user-facing doc page: Receive-Only Mode.**
+- **File:** `docs/features/receive-only-mode.md`.
+- **Sidebar:** add `{ text: 'Receive-Only Mode', link: '/features/receive-only-mode' }` to the
+  **"Core"** group in `docs/.vitepress/config.mts` (after "Device Configuration", `:75`).
+  Rationale: it is a device/LoRa capability, adjacent to Device Configuration.
+- **Cross-link:** add a short pointer from `docs/features/device.md` "LoRa Radio Configuration"
+  section (`:280`) to the new page.
+- **Outline** (firmware semantics per epic doc — cite them, don't re-derive):
+  1. *What it is* — running a Meshtastic source with `lora.txEnabled = false`; the radio's
+     hard TX kill switch (firmware `RadioLibInterface.cpp` drops every outbound LoRa packet
+     with `ERRNO_DISABLED`).
+  2. *What still works* — RX and decode, all read-only pages (Dashboard, Packet Monitor,
+     Telemetry, Map, Messages history), TCP API config reads/writes, and **local**-node admin
+     (reboot, set-time, config read/write; the time-sync scheduler is local admin).
+  3. *What's disabled* — sending messages/tapbacks, traceroute, position/nodeinfo/neighbor/
+     telemetry requests, **remote**-node admin, and the node's own NodeInfo/Position/Telemetry
+     broadcasts. Consequence: **the node goes invisible to the mesh** (stops announcing itself).
+  4. *How MeshMonitor behaves* — a persistent warning banner (`banners.tx_disabled`); every
+     send/transmit control is disabled with a tooltip; a `409 TX_DISABLED` toast if a race slips
+     through; automations that target a receive-only source skip-and-record at runtime (and now
+     show a builder badge). Not gated: MQTT bridge downlink (publishes to a broker, bypasses the
+     radio) and MeshCore sources (different protocol, no such flag).
+  5. *How to enable / disable* — LoRa config "Transmit Enabled" checkbox + the danger-confirm
+     dialog; note MeshMonitor now **persists** the setting instead of reverting it to `true`
+     (the #4294 fix; previously the force-true override silently re-enabled TX). Caveat worth
+     stating: some hardware re-reads its own config and may revert `tx_enabled` on the device
+     side — that is a device quirk, not MeshMonitor behavior (observed in Phase 2 live testing).
+
+**W2.4 i18n for new user-facing strings.** Any new UI strings (only the automations badge in
+this phase) → `public/locales/en.json` **only**. Other locales are Weblate-managed and fall
+back to English. Doc pages (`.md`) are English-only and need no i18n. Keys to add:
+
+| Key | Suggested English | Used by |
+|---|---|---|
+| `tx_disabled.automation_source_warning` | e.g. "Transmit is disabled on this source — messages sent through it will be skipped." | WP1 badge (`AutomationBuilder.tsx` `sendSourceMulti`) |
+
+Place it in the existing `tx_disabled.*` block (`en.json:121-123`). No other new UI strings.
+
+---
+
+## 3. Parallelism, validation, sequencing
+
+- **WP1 ⟂ WP2 fully parallel** — disjoint files (WP1: `sourceRoutes.ts`, `AutomationBuilder.tsx`,
+  `AutomationsPage.tsx`, `AutomationsPage.css`, `en.json`, tests; WP2: `docs/**` + `config.mts`,
+  plus the one shared file `en.json` for the badge key which is WP1's, not WP2's). They can be
+  one PR (small) or two; recommend a **single Phase-3 PR** since the whole phase is small.
+- **Browser validation: light-touch is sufficient.** The badge is trivial and unit-tested. A
+  single manual check against a TX-disabled sandbox source (open Automations builder → add a
+  Send Message action → confirm the badge appears next to the disabled source and the checkbox
+  still toggles) is enough; a full puppeteer pass is not warranted for closeout. Recommend one
+  screenshot in the PR for the reviewer.
+- **Docs build:** run the VitePress build (or `npm run docs:build` if defined) to confirm the
+  new sidebar link resolves and the page renders — a dead sidebar link fails the docs build.
+- **Gate before PR:** full Vitest suite (0 failures), `npm run lint:ci` clean (filter
+  `.claude/worktrees`), tsc clean. CI runs system tests — none needed to be added for this phase.
+
+---
+
+## 4. Deferred / out-of-scope (file as follow-up, do NOT do in Phase 3)
+
+- **Remote-import `txEnabled` accuracy TODO.** Phase 1 left a `TODO(#4294 follow-up)` at the
+  `adminRoutes.ts` remote import call site: a fully-accurate remote `txEnabled` preserve needs an
+  extra `requestRemoteConfig(LORA_CONFIG)` round-trip (today it is best-effort:
+  cached remote config → decoded URL value → fail-open `true`). **Recommendation: file this as a
+  separate GitHub follow-up issue, not part of Phase 3.** It is a backend round-trip enhancement,
+  not docs/polish, and the fail-open behavior is safe (never disables TX on import). Phase 3
+  should only *document* the best-effort behavior (W2.2), not implement the round-trip.
+- **Per-button disabling of Device/Module config-section "Set" buttons** in AdminCommandsTab
+  (Phase 2 noted these are protected by the `executeCommand` choke-point guard + inline notice,
+  functionally correct). A visual-only nicety; leave out unless the user asks.
+- **OpenAPI spec additions for v1 action endpoints** — the `/actions/*` paths aren't in
+  `openapi.yaml` at all; adding them is a larger doc effort beyond "document the 409." Optional.
+
+---
+
+## 5. File:line reference index (validated this tree)
+
+- `src/server/routes/sourceRoutes.ts:248` — `interface SourceRadioSummary` (add `txEnabled`)
+- `src/server/routes/sourceRoutes.ts:257-291` — `computeSourceRadioSummary` (set `txEnabled` in MT branch)
+- `src/server/routes/sourceRoutes.ts:312` — `radio: computeSourceRadioSummary(s.id)` merge onto list entry
+- `src/components/automations/AutomationBuilder.tsx:17` — `SourceOption` interface
+- `src/components/automations/AutomationBuilder.tsx:25` — `isSendableSource`
+- `src/components/automations/AutomationBuilder.tsx:150` — `case 'sendSourceMulti'` render (badge here)
+- `src/components/automations/AutomationsPage.tsx:192-194` — `/api/sources` fetch + map to `SourceOption`
+- `src/components/automations/catalog.ts:313,322,384,394` — `sendSourceMulti` action fields
+- `src/components/automations/AutomationsPage.css:58,62,111` — existing `.ae-muted/.ae-switch/.ae-token-diag--warn`
+- `src/components/icons/UiIcon.tsx:136` — `alert` icon
+- `public/locales/en.json:121-123` — existing `tx_disabled.*` keys (add new key here)
+- `src/server/routes/v1/actions.ts` — v1 409 `{success:false,error,code:'TX_DISABLED'}`
+- `src/server/routes/messageRoutes.ts:1320`, `meshRequestRoutes.ts:43/125/206/288/345`,
+  `adminRoutes.ts:618/663/785/848/930/950` — main-API `fail(res,409,'TX_DISABLED',…)`
+- `docs/api/REST_API.md:87` (Error Handling), `:808` (`POST /api/traceroutes/send`)
+- `docs/api/API_REFERENCE.md:204` (`POST /api/messages/send`)
+- `docs/features/device.md:280` (LoRa Radio Configuration — cross-link target)
+- `docs/.vitepress/config.mts:69-77` — `/features/` sidebar "Core" group (add page here)

--- a/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
+++ b/docs/internal/dev-notes/TX_DISABLED_SUPPORT_EPIC.md
@@ -3,8 +3,22 @@
 **Epic issue:** #4294 (original bug report, reopened as tracker; #4308 closed as duplicate)
 **Status:**
 - [x] Phase 1 — Backend: honor the flag + central guard (PR #4309, merged)
-- [x] Phase 2 — Frontend: gating UX (branch `feature/tx-disabled-frontend`)
-- [ ] Phase 3 — Polish + docs
+- [x] Phase 2 — Frontend: gating UX (PR #4313, merged)
+- [x] Phase 3 — Polish + docs (branch `feature/tx-disabled-docs`)
+
+**Phase 3 deviations & findings (2026-07-24):**
+- Automations badge: `useTxStatus` is single-source and can't be looped, and the builder has
+  no design-time single sourceId (automations fan out at runtime). Instead of inventing
+  per-source machinery, exposed a fail-open `txEnabled` on the existing public `GET /api/sources`
+  radio summary (`computeSourceRadioSummary`, reusing the same choke point as the frequency
+  feature) and rendered an advisory `UiIcon` badge per selected source row in `sendSourceMulti`.
+  Advisory only — the checkbox stays enabled; runtime skip-and-record (Phase 1) is the real guard.
+- Receive-only-mode user doc added at `docs/features/receive-only-mode.md` + VitePress sidebar +
+  cross-link from device.md; `409 TX_DISABLED` + the config/lora-honors-txEnabled note documented
+  in REST_API.md and API_REFERENCE.md. `docs/api/API.md` left alone (marked outdated).
+- **Follow-up filed separately:** the Phase 1 remote-import-preserve TODO (an
+  `requestRemoteConfig(LORA_CONFIG)` round-trip for fully-accurate remote-node txEnabled preserve)
+  is out of docs/polish scope; current fail-open behavior is safe. Filed as its own issue.
 
 **Phase 2 deviations & findings (2026-07-23):**
 - No shared ConfirmDialog exists — reused the app's `window.confirm(t(...))` danger idiom

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -121,6 +121,7 @@
   "tx_disabled.control_tooltip": "Transmit is disabled on this node's radio. Re-enable TX in the LoRa configuration to use this.",
   "tx_disabled.send_blocked_toast": "Transmit is disabled on this source — nothing was sent.",
   "tx_disabled.remote_admin_notice": "Remote-node admin is unavailable while Transmit is disabled on this source. Local-node admin still works — you can re-enable TX in the LoRa Config below.",
+  "tx_disabled.automation_source_warning": "Transmit is disabled on this source — messages sent through it will be skipped.",
 
   "purgeModal.title": "Purge Data for {{nodeName}}",
   "purgeModal.warning": "These actions cannot be undone. All data for this node will be permanently deleted.",

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -6,6 +6,7 @@
  * the graph model in compile.ts.
  */
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, type BlockDef, type FieldDef } from './catalog';
 import type { WorkflowForm, FormBlock, Rule } from './compile';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
@@ -15,7 +16,7 @@ import type { GeofenceShape } from '../auto-responder/types';
 import { UiIcon } from '../icons';
 
 export interface VariableOption { name: string; type: string; }
-export interface SourceOption { id: string; name: string; type?: string; enabled?: boolean; }
+export interface SourceOption { id: string; name: string; type?: string; enabled?: boolean; txEnabled?: boolean; }
 export interface UnifiedChannelOption {
   name: string; protocol?: string; encryption?: string;
   sources?: Array<{ sourceId: string; sourceName?: string; slot: number }>;
@@ -64,6 +65,7 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
 function FieldInput({ field, value, onChange, variables, sources, channels, scripts, regions, triggerType }: {
   field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; triggerType: string;
 }) {
+  const { t } = useTranslation();
   let control;
   const varNames = variables.map((v) => v.name);
   switch (field.kind) {
@@ -155,11 +157,20 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
           {sendable.length === 0 && <div className="ae-muted">No sendable (non-MQTT) sources.</div>}
           {sendable.map((s) => {
             const badge = protoBadge(s.type);
+            const txWarning = t(
+              'tx_disabled.automation_source_warning',
+              'Transmit is disabled on this source — messages sent through it will be skipped.',
+            );
             return (
               <label key={s.id} className="ae-switch" style={{ display: 'block', marginBottom: '0.2rem' }}>
                 <input type="checkbox" checked={sel.includes(s.id)} onChange={(e) =>
                   onChange(e.target.checked ? [...sel, s.id] : sel.filter((x) => x !== s.id))} />
                 {' '}{s.name}{badge ? <span className="ae-chip">{badge}</span> : null}
+                {s.txEnabled === false && (
+                  <span className="ae-tx-warn" title={txWarning}>
+                    <UiIcon name="alert" size={14} /> {txWarning}
+                  </span>
+                )}
               </label>
             );
           })}

--- a/src/components/automations/AutomationBuilder.txWarning.test.tsx
+++ b/src/components/automations/AutomationBuilder.txWarning.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * AutomationBuilder — TX-disabled advisory badge on sendSourceMulti source
+ * rows (#4294 Phase 3 WP1). The `sendSourceMulti` picker always lists every
+ * sendable source as a checkbox row (selected or not); the badge is a
+ * per-row hint keyed off that source's own `txEnabled`, not off whether it
+ * happens to be checked. It must render only for a row with
+ * `txEnabled === false` (strict — undefined means "unknown", not "off"),
+ * and must never disable the checkbox — advisory only.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AutomationBuilder, { type SourceOption } from './AutomationBuilder';
+import type { WorkflowForm } from './compile';
+
+// Override the global i18n mock from src/test/setup.ts so t(key, default) returns
+// the English default — the component calls t() with an inline fallback string.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string | Record<string, unknown>) =>
+      typeof defaultValue === 'string' ? defaultValue : key,
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+const WARNING_TEXT = 'Transmit is disabled on this source — messages sent through it will be skipped.';
+
+function buildForm(sourceIds: string[]): WorkflowForm {
+  return {
+    trigger: { type: 'trigger.message', params: {} },
+    rules: [
+      {
+        conditions: [],
+        actions: [
+          { type: 'action.sendMessage', params: { text: 'hi', sourceIds } },
+        ],
+      },
+    ],
+    combine: null,
+  };
+}
+
+const sources: SourceOption[] = [
+  { id: 'src-tx-off', name: 'Receive Only Node', type: 'meshtastic_tcp', enabled: true, txEnabled: false },
+  { id: 'src-tx-on', name: 'Normal Node', type: 'meshtastic_tcp', enabled: true, txEnabled: true },
+  { id: 'src-tx-unknown', name: 'Unknown TX Node', type: 'meshtastic_tcp', enabled: true },
+];
+
+function renderBuilder(sourceIds: string[] = []) {
+  return render(
+    <AutomationBuilder
+      form={buildForm(sourceIds)}
+      variables={[]}
+      sources={sources}
+      channels={[]}
+      scripts={[]}
+      regions={[]}
+      onChange={() => {}}
+    />,
+  );
+}
+
+/** The <label> row (checkbox + name + optional badge) for a given source name. */
+function rowFor(name: string): HTMLLabelElement {
+  const checkbox = screen.getByRole('checkbox', { name: new RegExp(name) });
+  const label = checkbox.closest('label');
+  if (!label) throw new Error(`No <label> ancestor found for "${name}" checkbox`);
+  return label as HTMLLabelElement;
+}
+
+describe('AutomationBuilder — TX-disabled advisory badge (#4294 P3)', () => {
+  it('shows the warning badge on the row for a source with txEnabled === false', () => {
+    renderBuilder();
+
+    const row = rowFor('Receive Only Node');
+    expect(row.querySelector('.ae-tx-warn')).not.toBeNull();
+    expect(row).toHaveTextContent(WARNING_TEXT);
+  });
+
+  it('does not show the badge on the row for a source with txEnabled === true', () => {
+    renderBuilder();
+
+    const row = rowFor('Normal Node');
+    expect(row.querySelector('.ae-tx-warn')).toBeNull();
+  });
+
+  it('does not show the badge on the row for a source with unknown (undefined) txEnabled', () => {
+    renderBuilder();
+
+    const row = rowFor('Unknown TX Node');
+    expect(row.querySelector('.ae-tx-warn')).toBeNull();
+  });
+
+  it('renders exactly one badge across the picker when only one source is TX-disabled', () => {
+    renderBuilder();
+
+    expect(document.querySelectorAll('.ae-tx-warn')).toHaveLength(1);
+  });
+
+  it('keeps the checkbox enabled and toggleable for a TX-disabled source that is selected — advisory, not a hard block', () => {
+    renderBuilder(['src-tx-off']);
+
+    const row = rowFor('Receive Only Node');
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeDisabled();
+    expect(checkbox).toBeChecked();
+    expect(row.querySelector('.ae-tx-warn')).not.toBeNull();
+  });
+});

--- a/src/components/automations/AutomationsPage.css
+++ b/src/components/automations/AutomationsPage.css
@@ -61,6 +61,9 @@
 /* Switch */
 .ae-switch { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: var(--ctp-subtext1); cursor: pointer; }
 
+/* TX-disabled advisory badge (#4294 P3) — hint only, never disables the checkbox. */
+.ae-tx-warn { color: var(--ctp-yellow); font-size: 0.75rem; display: inline-flex; align-items: center; gap: 0.25rem; margin-left: 0.4rem; }
+
 /* Form fields */
 .ae-field { margin-bottom: 0.85rem; }
 .ae-field-label { display: flex; align-items: center; gap: 0.35rem; font-size: 0.82rem; font-weight: 600; color: var(--ctp-subtext1); margin-bottom: 0.3rem; }

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -189,8 +189,8 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     apiService.get<Variable[]>('/api/automations/variables')
       .then((vs) => setVariables(vs.map((v) => ({ name: v.name, type: v.type }))))
       .catch(() => setVariables([]));
-    apiService.get<Array<{ id: string; name: string; type?: string; enabled?: boolean }>>('/api/sources')
-      .then((ss) => setSources(ss.map((s) => ({ id: s.id, name: s.name, type: s.type, enabled: s.enabled }))))
+    apiService.get<Array<{ id: string; name: string; type?: string; enabled?: boolean; radio?: { txEnabled?: boolean } }>>('/api/sources')
+      .then((ss) => setSources(ss.map((s) => ({ id: s.id, name: s.name, type: s.type, enabled: s.enabled, txEnabled: s.radio?.txEnabled }))))
       .catch(() => setSources([]));
     apiService.get<UnifiedChannelOption[]>('/api/automations/channels')
       .then((cs) => setChannels(cs))

--- a/src/server/routes/sourceRoutes.radio.test.ts
+++ b/src/server/routes/sourceRoutes.radio.test.ts
@@ -42,7 +42,7 @@ describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
     await harness.cleanup();
   });
 
-  it('includes a meshtastic radio summary (frequencyMhz/regionName/modemPreset) — visible anonymously', async () => {
+  it('includes a meshtastic radio summary (frequencyMhz/regionName/modemPreset/txEnabled) — visible anonymously', async () => {
     mockGetManager.mockImplementation((sourceId: string) => {
       if (sourceId !== harness.sourceA) return null;
       return {
@@ -72,7 +72,64 @@ describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
       frequencyMhz: expect.closeTo(907.125, 2),
       regionName: 'US',
       modemPreset: 0,
+      txEnabled: true,
     });
+  });
+
+  it('reflects txEnabled: false on the meshtastic summary when the source is receive-only (#4294 P3)', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        getCurrentConfig: () => ({
+          deviceConfig: {
+            lora: {
+              region: 1,
+              channelNum: 21,
+              overrideFrequency: 0,
+              frequencyOffset: 0,
+              bandwidth: 250,
+              modemPreset: 0,
+              txEnabled: false,
+            },
+          },
+        }),
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio.txEnabled).toBe(false);
+  });
+
+  it('fails open to txEnabled: true when the field is absent from lora config (#4294 P3)', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        getCurrentConfig: () => ({
+          deviceConfig: {
+            lora: {
+              region: 1,
+              channelNum: 21,
+              overrideFrequency: 0,
+              frequencyOffset: 0,
+              bandwidth: 250,
+              modemPreset: 0,
+              // txEnabled intentionally omitted
+            },
+          },
+        }),
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio.txEnabled).toBe(true);
   });
 
   it('honors overrideFrequency on the meshtastic summary', async () => {

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -251,6 +251,8 @@ interface SourceRadioSummary {
   regionName?: string;
   /** Meshtastic only — drives RX-sensitivity auto-seed. */
   modemPreset?: number;
+  /** Meshtastic only. Fail-open true (matches firmware default) when the field is unset. */
+  txEnabled?: boolean;
 }
 
 // Wrapped in try/catch so a manager that throws from getCurrentConfig()/
@@ -276,6 +278,7 @@ function computeSourceRadioSummary(sourceId: string): SourceRadioSummary | null 
         frequencyMhz,
         regionName: REGION_SHORT_NAME[region],
         modemPreset: Number(lora.modemPreset ?? 0),
+        txEnabled: lora.txEnabled ?? true,
       };
     }
     if (isMeshCoreManager(mgr)) {


### PR DESCRIPTION
## Summary
Phase 3 (final) of the TX-disabled epic #4294 — polish + documentation. Phases 1 (backend guard + honor `txEnabled`) and 2 (frontend gating) are merged; this closes the epic with the automations-builder warning badge and the user/API docs.

## Changes
- **Automations builder badge:** `GET /api/sources` radio summary now exposes a fail-open `txEnabled` (Meshtastic-only), reusing the existing `computeSourceRadioSummary` choke point. The automations builder's `sendSourceMulti` picker renders an advisory `UiIcon` alert badge next to any source whose TX is disabled. Advisory only — the checkbox stays enabled; the real guard is Phase 1's runtime skip-and-record.
- **REST API docs:** documented the `409 TX_DISABLED` response (v1 action/message endpoints use `{success:false,error,code}`; main API routes use the `fail()` envelope) in `REST_API.md` + `API_REFERENCE.md`, plus a note that `POST /api/config/lora` now honors the submitted `txEnabled` (no longer force-true) and imports preserve the device's value.
- **New user guide:** `docs/features/receive-only-mode.md` — what receive-only mode is, firmware semantics, what works (RX, reads, local admin) vs. what's disabled (sending, traceroute, remote admin, own broadcasts → invisible to mesh), MeshMonitor behavior (banner, disabled controls, 409 toast, automation skip), how to enable/disable, and the persistence fix. Sidebar entry + cross-link from `device.md` added; VitePress build passes.
- Epic plan doc marked complete with Phase 3 findings.

## Issues Resolved
Closes #4294 (final phase). Filed #4315 as a follow-up for fully-accurate remote-node `txEnabled` preserve on config import (out of polish scope; current fail-open behavior is safe).

## Documentation Updates
`docs/features/receive-only-mode.md` (new), `docs/features/device.md`, `docs/api/REST_API.md`, `docs/api/API_REFERENCE.md`, VitePress sidebar, epic + Phase 3 spec dev-notes.

## Testing
- [x] Full Vitest suite: `success: true` — 3420/3420 suites, 11,145 passed, 0 failed (109 pending = PG/MySQL container skips)
- [x] `npm run typecheck` + server `tsc` clean; `npm run lint:ci` 0 in-repo FAIL lines
- [x] `npm run docs:build` succeeds; new page renders, sidebar link resolves
- [x] New tests: sourceRoutes radio-summary `txEnabled` (fail-open/true/false), AutomationBuilder badge (renders only for TX-disabled source, checkbox stays enabled)
- [ ] Reviewer: in the automations builder, a send action listing a TX-disabled Meshtastic source shows the advisory badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bxVewVnissUKiGZmhf9FW