### PR TITLE
fix(admin): live remote LoRa config fetch for accurate txEnabled preserve on import (#4315)

### DIFF
--- a/src/server/routes/adminRoutes.test.ts
+++ b/src/server/routes/adminRoutes.test.ts
@@ -261,23 +261,29 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
     expect(calledWith).toMatchObject({ hopLimit: 3, txEnabled: true });
   });
 
-  describe('POST /import-config (remote node) — best-effort txEnabled preserve', () => {
-    // The remote branch has no local isTxEnabled() to consult; it prefers a
-    // cached remote-config snapshot (getRemoteNodeConfig), falling back to
+  describe('POST /import-config (remote node) — txEnabled preserve (#4315)', () => {
+    // The remote branch fetches the remote node's LIVE LoRa config first
+    // (requestRemoteConfig, LORA_CONFIG=5) and reuses its actual txEnabled,
+    // interpreted with isTxEnabled()-style semantics (disabled only when
+    // explicitly false). It falls back — when the live fetch throws or returns
+    // nothing — to a cached remote-config snapshot (getRemoteNodeConfig), then
     // the decoded URL's own txEnabled, and finally to true (fail-open).
     // createSetLoRaConfigMessage is real (not mocked) — spy on it to inspect
     // the exact config object it received before protobuf-encoding, since
     // sendAdminCommand only sees opaque encoded bytes.
 
-    it('uses the cached remote-config snapshot when available, overriding the decoded value', async () => {
+    it('uses the live remote LoRa config txEnabled, overriding the decoded value', async () => {
       const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
       const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      // Live fetch reports the remote device currently has TX disabled.
+      const requestRemoteConfig = vi.fn().mockResolvedValue({ txEnabled: false });
+      // Cached snapshot disagrees (true) — the live value must win over it.
       const getRemoteNodeConfig = vi.fn().mockReturnValue({
-        deviceConfig: { lora: { txEnabled: false } },
+        deviceConfig: { lora: { txEnabled: true } },
         moduleConfig: {},
-        lastUpdated: Date.now(),
+        lastUpdated: 0,
       });
-      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, getRemoteNodeConfig }));
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, requestRemoteConfig, getRemoteNodeConfig }));
 
       const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
       const channelUrlService = (await import('../services/channelUrlService.js')).default;
@@ -294,15 +300,74 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
       });
 
       expect(res.status).toBe(200);
+      expect(requestRemoteConfig).toHaveBeenCalledWith(999, 5, false);
       expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
       spy.mockRestore();
     });
 
-    it('falls back to the decoded URL txEnabled when no cached remote config exists', async () => {
+    it('treats a live config with an omitted txEnabled as enabled (fail-open, matches isTxEnabled)', async () => {
       const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
       const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      // proto3 omits a false bool, but a device with TX enabled likewise omits
+      // nothing meaningful here — the live config comes back without txEnabled.
+      const requestRemoteConfig = vi.fn().mockResolvedValue({ hopLimit: 3 });
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, requestRemoteConfig }));
+
+      const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: undefined,
+        loraConfig: { hopLimit: 3, txEnabled: false },
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/import-config').send({
+        sourceId: harness.sourceA,
+        nodeNum: 999,
+        url: 'meshtastic://mock',
+      });
+
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
+      spy.mockRestore();
+    });
+
+    it('falls back to the cached remote-config snapshot when the live fetch throws', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      const requestRemoteConfig = vi.fn().mockRejectedValue(new Error('remote config timeout'));
+      const getRemoteNodeConfig = vi.fn().mockReturnValue({
+        deviceConfig: { lora: { txEnabled: false } },
+        moduleConfig: {},
+        lastUpdated: 0,
+      });
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, requestRemoteConfig, getRemoteNodeConfig }));
+
+      const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: undefined,
+        loraConfig: { hopLimit: 3, txEnabled: true },
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/import-config').send({
+        sourceId: harness.sourceA,
+        nodeNum: 999,
+        url: 'meshtastic://mock',
+      });
+
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
+      spy.mockRestore();
+    });
+
+    it('falls back to the decoded URL txEnabled when the live fetch returns nothing and no cached config exists', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      const requestRemoteConfig = vi.fn().mockResolvedValue(null);
       const getRemoteNodeConfig = vi.fn().mockReturnValue(null);
-      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, getRemoteNodeConfig }));
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, requestRemoteConfig, getRemoteNodeConfig }));
 
       const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
       const channelUrlService = (await import('../services/channelUrlService.js')).default;
@@ -323,11 +388,12 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
       spy.mockRestore();
     });
 
-    it('falls back to true (fail-open) when neither a cached remote config nor a decoded txEnabled exists', async () => {
+    it('falls back to true (fail-open) when the live fetch, cached config, and decoded txEnabled are all absent', async () => {
       const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
       const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      const requestRemoteConfig = vi.fn().mockResolvedValue(null);
       const getRemoteNodeConfig = vi.fn().mockReturnValue(null);
-      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, getRemoteNodeConfig }));
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, requestRemoteConfig, getRemoteNodeConfig }));
 
       const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
       const channelUrlService = (await import('../services/channelUrlService.js')).default;

--- a/src/server/routes/adminRoutes.test.ts
+++ b/src/server/routes/adminRoutes.test.ts
@@ -328,6 +328,40 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
       });
 
       expect(res.status).toBe(200);
+      expect(requestRemoteConfig).toHaveBeenCalledWith(999, 5, false);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
+      spy.mockRestore();
+    });
+
+    it('interprets a cached snapshot with omitted txEnabled as enabled (matches the live-path semantics)', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      const getSessionPasskey = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+      // Live fetch unavailable; cached snapshot has a lora object but no
+      // txEnabled field — same as a proto3-omitted/default read. It must be
+      // treated as enabled (!== false), not deferred to the decoded URL value.
+      const requestRemoteConfig = vi.fn().mockResolvedValue(null);
+      const getRemoteNodeConfig = vi.fn().mockReturnValue({
+        deviceConfig: { lora: { hopLimit: 3 } },
+        moduleConfig: {},
+        lastUpdated: 0,
+      });
+      await sourceManagerRegistry.addManager(makeFakeManager({ sendAdminCommand, getSessionPasskey, requestRemoteConfig, getRemoteNodeConfig }));
+
+      const spy = vi.spyOn(protobufService, 'createSetLoRaConfigMessage');
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: undefined,
+        loraConfig: { hopLimit: 3, txEnabled: false }, // would win if the cache were ignored
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/import-config').send({
+        sourceId: harness.sourceA,
+        nodeNum: 999,
+        url: 'meshtastic://mock',
+      });
+
+      expect(res.status).toBe(200);
       expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
       spy.mockRestore();
     });

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -1304,8 +1304,13 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
           }
           if (remoteTxEnabled === undefined) {
             const cachedRemoteLora = aicManager.getRemoteNodeConfig(destinationNodeNum)?.deviceConfig?.lora;
-            remoteTxEnabled = cachedRemoteLora?.txEnabled !== undefined
-              ? cachedRemoteLora.txEnabled
+            // Cached snapshot comes from the same requestRemoteConfig source as
+            // the live fetch above, so interpret it with the same
+            // isTxEnabled()-style semantics (disabled only when explicitly
+            // false). Only when there is no cached LoRa snapshot at all do we
+            // consult the decoded URL's own txEnabled, then fail-open true.
+            remoteTxEnabled = cachedRemoteLora
+              ? cachedRemoteLora.txEnabled !== false
               : (decoded.loraConfig.txEnabled ?? true);
           }
           const loraConfigToImport = {

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -1279,23 +1279,35 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
           // txEnabled=false), so we must supply an explicit value, never
           // strip the key.
           //
-          // Best-effort remote preserve: use the manager's cached remote-config
-          // snapshot (populated only if requestRemoteConfig(LORA_CONFIG) was
-          // called for this node earlier — e.g. via /load-config or
-          // /export-config with includeLoraConfig). This import flow does not
-          // itself fetch the remote node's current LoRa config first — that
-          // would need an extra requestRemoteConfig round-trip (session
-          // passkey + mesh RTT) not currently part of this flow. Falls back to
-          // the decoded URL's own txEnabled (real since #4294's export fix;
-          // older exported URLs may still carry the old forced `true`), and
-          // finally to true (fail-open) if that's absent too.
-          // TODO(#4294 follow-up): a fully-accurate remote preserve would
-          // fetch the remote node's live LoRa config via requestRemoteConfig
-          // before importing.
-          const cachedRemoteLora = aicManager.getRemoteNodeConfig(destinationNodeNum)?.deviceConfig?.lora;
-          const remoteTxEnabled = cachedRemoteLora?.txEnabled !== undefined
-            ? cachedRemoteLora.txEnabled
-            : (decoded.loraConfig.txEnabled ?? true);
+          // Fully-accurate remote preserve (issue #4315): fetch the remote
+          // node's LIVE LoRa config first and reuse its actual txEnabled. This
+          // import flow is already a slow multi-round-trip path (per-channel
+          // pacing above), so one more requestRemoteConfig round-trip (session
+          // passkey + mesh RTT) is acceptable. Interpret the result with the
+          // same semantics as the local branch's isTxEnabled() — txEnabled is
+          // disabled only when it is explicitly `false`; a present-but-not-false
+          // (incl. proto3-omitted) value means enabled/fail-open.
+          //
+          // Fallbacks, if the live fetch fails/times out: the manager's cached
+          // remote-config snapshot (populated by an earlier /load-config or
+          // /export-config), then the decoded URL's own txEnabled (real since
+          // #4294's export fix; older exported URLs may still carry the old
+          // forced `true`), and finally true (fail-open).
+          let remoteTxEnabled: boolean | undefined;
+          try {
+            const liveRemoteLora = await aicManager.requestRemoteConfig(destinationNodeNum, 5, false); // LORA_CONFIG = 5
+            if (liveRemoteLora) {
+              remoteTxEnabled = liveRemoteLora.txEnabled !== false;
+            }
+          } catch (error) {
+            logger.warn(`⚠️ Could not fetch live remote LoRa config for txEnabled preserve on node ${destinationNodeNum}; falling back to cached/URL value:`, error);
+          }
+          if (remoteTxEnabled === undefined) {
+            const cachedRemoteLora = aicManager.getRemoteNodeConfig(destinationNodeNum)?.deviceConfig?.lora;
+            remoteTxEnabled = cachedRemoteLora?.txEnabled !== undefined
+              ? cachedRemoteLora.txEnabled
+              : (decoded.loraConfig.txEnabled ?? true);
+          }
           const loraConfigToImport = {
             ...decoded.loraConfig,
             txEnabled: remoteTxEnabled,


### PR DESCRIPTION
## Summary

Follow-up from the TX-disabled epic (#4294). Closes #4315.

Remote-node `POST /import-config` previously preserved the target device's `txEnabled` on a **best-effort** basis:

1. Cached remote-config snapshot (`getRemoteNodeConfig`) — populated only if `requestRemoteConfig(LORA_CONFIG)` had run earlier (e.g. via `/load-config` or `/export-config`)
2. Decoded URL's own `txEnabled` (real since #4294's export fix)
3. Fail-open `true`

This was **safe** (it never strips the key, avoiding the whole-struct-replace / proto3-omitted-bool→false hazard that reaches the radio as `txEnabled=false`), but not guaranteed accurate when no cached config existed.

## Change

Before applying a remote LoRa config import, fetch the remote node's **live** LoRa config via `requestRemoteConfig(LORA_CONFIG)` (session passkey + mesh RTT) and reuse its actual `txEnabled`, interpreted with the same `isTxEnabled()`-style semantics as the local branch — disabled only when explicitly `false`; a present-but-not-false (incl. proto3-omitted) value means enabled/fail-open.

The prior best-effort chain (cached → URL → `true`) remains as a **fallback** for when the live round-trip throws or returns nothing. The import flow is already a slow multi-round-trip path (per-channel pacing), so one more request is acceptable — matching the enhancement described in the issue.

Local-node import continues to preserve accurately via `isTxEnabled()` (unchanged).

## Tests

Rewrote the remote `describe` block in `adminRoutes.test.ts` to cover the new primary path plus each fallback tier:
- live fetch overrides the decoded value (and beats a stale cached snapshot)
- live config with omitted `txEnabled` → treated as enabled (matches `isTxEnabled`)
- live fetch throws → falls back to cached snapshot
- live fetch returns nothing + no cache → falls back to decoded URL value
- everything absent → fail-open `true`

Full `adminRoutes.test.ts` suite passes (16/16); lint ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)