### PR TITLE
feat(atak): decode ATAK V2 (portnum 78) rich CoT via shared zstd dictionaries (#4317)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "protobufs"]
 	path = protobufs
 	url = https://github.com/meshtastic/protobufs.git
+[submodule "takpacket-sdk"]
+	path = takpacket-sdk
+	url = https://github.com/meshtastic/TAKPacket-SDK.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,10 @@ COPY --from=builder /app/dist ./dist
 # Copy protobuf definitions needed by the server
 COPY --from=builder /app/protobufs ./protobufs
 
-# Copy ATAK V2 zstd dictionaries needed by the server (#4317)
-COPY --from=builder /app/takpacket-sdk ./takpacket-sdk
+# Copy ATAK V2 zstd dictionaries needed by the server (#4317) — dictionaries
+# only; the rest of the submodule (testdata, docs, language bindings) is not
+# needed at runtime
+COPY --from=builder /app/takpacket-sdk/dictionaries ./takpacket-sdk/dictionaries
 
 # Fix ownership of dist directory for node user
 RUN chown -R node:node ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,15 @@ RUN if [ ! -f "protobufs/meshtastic/mesh.proto" ]; then \
       exit 1; \
     fi
 
+# ATAK V2 zstd dictionaries (#4317) — runtime data files from the
+# takpacket-sdk git submodule; only the dictionaries directory is needed
+COPY takpacket-sdk/dictionaries ./takpacket-sdk/dictionaries
+RUN if [ ! -f "takpacket-sdk/dictionaries/dict_non_aircraft.zstd" ]; then \
+      echo "ERROR: TAKPacket-SDK dictionaries not found! Git submodule may not be initialized."; \
+      echo "Run: git submodule update --init --recursive"; \
+      exit 1; \
+    fi
+
 # Copy config files and source needed for builds
 COPY tsconfig.json tsconfig.server.json tsconfig.node.json vite.config.ts index.html embed.html ./
 COPY src ./src
@@ -81,6 +90,9 @@ COPY --from=builder /app/dist ./dist
 
 # Copy protobuf definitions needed by the server
 COPY --from=builder /app/protobufs ./protobufs
+
+# Copy ATAK V2 zstd dictionaries needed by the server (#4317)
+COPY --from=builder /app/takpacket-sdk ./takpacket-sdk
 
 # Fix ownership of dist directory for node user
 RUN chown -R node:node ./dist

--- a/docs/features/atak.md
+++ b/docs/features/atak.md
@@ -30,7 +30,7 @@ receipts, and arbitrary detail payloads. MeshMonitor decodes this in the
 | Packet Type | What you see |
 |-------------|--------------|
 | `ATAK_PLUGIN` (72) | `[ATAK PLI …]` for position reports, `[ATAK GeoChat …]` for chat (also delivered to Messages), `[ATAK detail …]`, or `[ATAK GeoChat receipt]` — full decoded `TAKPacket` in the detail view |
-| `ATAK_PLUGIN_V2` (78) | Firmware 2.8+ rich CoT, zstd-compressed — shown as `[ATAK V2 (not decoded), N bytes]`. Decoding is a planned follow-up. |
+| `ATAK_PLUGIN_V2` (78) | Firmware 2.8+ rich CoT (`TAKPacketV2`, zstd dictionary compression) — fully decoded: `[ATAK V2 PLI …]`, `[ATAK V2 GeoChat …]`, `[ATAK V2 marker/route/CASEVAC/EMERGENCY/…]` with the full decoded packet in the detail view. See "ATAK V2 decoding" below. |
 | `ATAK_FORWARDER` (257) | Third-party [ATAK Forwarder](https://github.com/paulmandal/atak-forwarder) packets — identified by name only, not decoded (it's not the official plugin format). |
 
 ATAK **GeoChat** messages are also persisted into MeshMonitor's Messages —
@@ -59,6 +59,47 @@ Nodes map, the Dashboard map, and the Map Analysis canvas.
 
 See [Interactive Maps](/features/maps#atak-contacts) for how ATAK contacts
 fit alongside the other map layers.
+
+## ATAK V2 decoding (portnum 78)
+
+The V2 protocol (`TAKPacketV2`, used by the official plugin for rich CoT —
+shapes, routes, markers, CASEVAC, emergency alerts, TAKTALK, aircraft
+tracks) compresses each packet with **zstd against a shared pre-trained
+dictionary**. The wire payload is `[1 flags byte][zstd body]`; flags bits
+0–5 select the dictionary (`0` = non-aircraft, `1` = aircraft), and `0xFF`
+means the body is an uncompressed `TAKPacketV2` protobuf. Firmware forwards
+these payloads untouched, so MeshMonitor decompresses them itself.
+
+What MeshMonitor does with a decoded V2 packet:
+
+- **Implicit PLI** (no payload variant = position report): upserts the same
+  per-source ATAK contact as a V1 PLI (Phase 2 above), including the map
+  marker and the CoT feed. V2 wire units are normalized on ingest (speed
+  cm/s → m/s, course degrees×100 → degrees, altitude `9999999` = "no
+  altitude" dropped).
+- **GeoChat**: persisted to Messages exactly like V1 GeoChat (channel/DM
+  routing from the mesh envelope, `[ATAK <callsign>]` prefix, push
+  notifications). V2 chat text is never unishox2-compressed, so there is no
+  labeled-but-undecoded case.
+- **Rich CoT variants** (shapes, markers, routes, range & bearing, CASEVAC,
+  emergency, task, TAKTALK, aircraft, raw detail): decoded and visible in
+  the Packet Monitor (variant-labeled preview + full JSON in the detail
+  view). Dedicated map/feed surfaces for these are a follow-up.
+
+**Dictionaries.** The two zstd dictionaries ship in the
+[`meshtastic/TAKPacket-SDK`](https://github.com/meshtastic/TAKPacket-SDK)
+repository (GPL-3.0) and are vendored as the `takpacket-sdk/` git submodule
+— consumed as runtime data files, the same posture as the GPL-3.0
+`protobufs/` submodule. No SDK code is compiled into MeshMonitor; the
+decoder is implemented against the published wire spec
+(`takpacket-sdk/WIRE_FORMAT.md`). If the submodule is missing at runtime (or
+the `zstd-napi` native module can't load), V2 packets gracefully degrade to
+the pre-4.14 labeled-but-undecoded behavior — uncompressed (`0xFF`) packets
+still decode.
+
+Baremetal deployments must initialize the submodule
+(`git submodule update --init --recursive`); the Docker image and LXC
+template include the dictionaries automatically.
 
 ## Phase 3 — CoT feed (ATAK/WinTAK network input)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default [
       'docs/**',      // VitePress site is its own project; .vitepress/cache is build output
       'examples/**',
       'protobufs/**', // git submodule — vendored
+      'takpacket-sdk/**', // git submodule — vendored (ATAK V2 zstd dictionaries, #4317)
       'public/**',
     ],
   },

--- a/lxc/sparse-cone.txt
+++ b/lxc/sparse-cone.txt
@@ -15,7 +15,7 @@
 #   If you add a new top-level directory that is required at runtime, add it
 #   here or the LXC template will silently omit those files on the next build.
 #   After updating: rebuild the template and confirm meshmonitor-update works.
-#   Note: do NOT add protobufs — it is a git submodule (gitlink), not a
+#   Note: do NOT add protobufs or takpacket-sdk — each is a git submodule (gitlink), not a
 #   regular directory. It is populated by git submodule update in Step 6
 #   of build-lxc-template.sh, independent of this cone list.
 #

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,8 @@
         "ts-overlapping-marker-spiderfier-leaflet": "^1.0.5",
         "uuid": "^14.0.1",
         "web-push": "^3.6.7",
-        "yamljs": "^0.3.0"
+        "yamljs": "^0.3.0",
+        "zstd-napi": "^0.0.13"
       },
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
@@ -18735,6 +18736,27 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/zstd-napi": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/zstd-napi/-/zstd-napi-0.0.13.tgz",
+      "integrity": "sha512-ErGF+Ko1PsbooU6oC/sc/diiWKwVa0kd/5AkFSs7kg5kwcEuOtSzOy3xUOadXQlAVNab9TxsxaUk3hOq3cj/lA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || ^15.12.0 || >=16"
+      }
+    },
+    "node_modules/zstd-napi/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "ts-overlapping-marker-spiderfier-leaflet": "^1.0.5",
     "uuid": "^14.0.1",
     "web-push": "^3.6.7",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "zstd-napi": "^0.0.13"
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -14,9 +14,11 @@ import { PortNum } from '../../server/constants/meshtastic.js';
  * Chat-like portnums that render in the DM thread view (#3691). Telemetry,
  * traceroute, and other non-chat DM rows stay excluded. ATAK GeoChat DMs
  * (PortNum.ATAK_PLUGIN, 72) are persisted by processTakPacket with
- * channel = -1 and must surface alongside plain text messages.
+ * channel = -1 and must surface alongside plain text messages. ATAK V2
+ * GeoChat DMs (PortNum.ATAK_PLUGIN_V2, 78, #4317) follow the same path via
+ * processTakV2Packet.
  */
-const DM_CHAT_PORTNUMS = [PortNum.TEXT_MESSAGE_APP, PortNum.ATAK_PLUGIN];
+const DM_CHAT_PORTNUMS = [PortNum.TEXT_MESSAGE_APP, PortNum.ATAK_PLUGIN, PortNum.ATAK_PLUGIN_V2];
 
 /**
  * Repository for message operations

--- a/src/server/meshtasticManager.atakV2.test.ts
+++ b/src/server/meshtasticManager.atakV2.test.ts
@@ -1,0 +1,355 @@
+/**
+ * MeshtasticManager - ATAK V2 persistence (processTakV2Packet, #4317)
+ *
+ * Verifies the implicit-PLI branch upserts exactly one `atak_contacts` row
+ * (and no Messages row), the GeoChat variant persists a Messages row on
+ * portnum 78 with the `[ATAK <callsign>]` provenance prefix, receipts and
+ * rich-CoT variants persist nothing, decode-fallback raw payloads are
+ * ignored, and DB failures are swallowed (RX-only, best-effort).
+ *
+ * Mock harness copied from meshtasticManager.atak.pli.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before any imports
+const mockInsertMessage = vi.fn();
+const mockGetNode = vi.fn();
+const mockUpsertNode = vi.fn();
+const mockGetChannelById = vi.fn();
+const mockUpsertContact = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    insertMessage: mockInsertMessage,
+    getNode: mockGetNode,
+    upsertNode: mockUpsertNode,
+    upsertNodeAsync: mockUpsertNode,
+    getChannelById: mockGetChannelById,
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    settings: {
+      getSetting: vi.fn(),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    nodes: {
+      getNode: mockGetNode,
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      upsertNode: mockUpsertNode,
+      markNodeAsWelcomedIfNotAlready: vi.fn().mockResolvedValue(false),
+      getNodeCount: vi.fn().mockResolvedValue(0),
+      setNodeFavorite: vi.fn().mockResolvedValue(undefined),
+      updateNodeMessageHops: vi.fn().mockResolvedValue(undefined),
+    },
+    channels: {
+      getChannelById: mockGetChannelById,
+      getAllChannels: vi.fn().mockResolvedValue([]),
+      upsertChannel: vi.fn().mockResolvedValue(undefined),
+      getChannelCount: vi.fn().mockResolvedValue(0),
+    },
+    telemetry: {
+      insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
+      getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
+    },
+    messages: {
+      insertMessage: mockInsertMessage,
+      getMessages: vi.fn().mockResolvedValue([]),
+      updateMessageTimestamps: vi.fn().mockResolvedValue(true),
+      updateMessageDeliveryState: vi.fn().mockResolvedValue(true),
+    },
+    traceroutes: {
+      insertTraceroute: vi.fn().mockResolvedValue(undefined),
+      insertRouteSegment: vi.fn().mockResolvedValue(undefined),
+    },
+    neighbors: {
+      upsertNeighborInfo: vi.fn().mockResolvedValue(undefined),
+      deleteNeighborInfoForNode: vi.fn().mockResolvedValue(0),
+    },
+    sources: {
+      getSource: vi.fn().mockResolvedValue({ id: 'default', name: 'Default' }),
+    },
+    atakContacts: {
+      upsertContact: mockUpsertContact,
+    },
+    recordTracerouteRequest: vi.fn(),
+    logKeyRepairAttemptAsync: vi.fn().mockResolvedValue(0),
+    clearKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    deleteNodeAsync: vi.fn().mockResolvedValue({}),
+    getNodeNeedingTracerouteAsync: vi.fn().mockResolvedValue(null),
+    logAutoTracerouteAttemptAsync: vi.fn().mockResolvedValue(0),
+    getNodeNeedingTimeSyncAsync: vi.fn().mockResolvedValue(null),
+    getNodeNeedingRemoteAdminCheckAsync: vi.fn().mockResolvedValue(null),
+    updateNodeRemoteAdminStatusAsync: vi.fn().mockResolvedValue(undefined),
+    getNodesNeedingKeyRepairAsync: vi.fn().mockResolvedValue([]),
+    getKeyRepairLogAsync: vi.fn().mockResolvedValue([]),
+    setKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    insertTelemetryAsync: vi.fn().mockResolvedValue(undefined),
+    getLatestTelemetryForTypeAsync: vi.fn().mockResolvedValue(null),
+    getMessageByRequestIdAsync: vi.fn().mockResolvedValue(null),
+    updateNodeMobilityAsync: vi.fn().mockResolvedValue(0),
+    getRecentEstimatedPositionsAsync: vi.fn().mockResolvedValue([]),
+    updateAutoTracerouteResultByNodeAsync: vi.fn().mockResolvedValue(undefined),
+    getAllGeofenceCooldownsAsync: vi.fn().mockResolvedValue([]),
+    setGeofenceCooldownAsync: vi.fn().mockResolvedValue(undefined),
+    markMessageAsReadAsync: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+const mockEmitNewMessage = vi.fn();
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitNewMessage: mockEmitNewMessage,
+    emit: vi.fn(),
+    on: vi.fn(),
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    initialize: vi.fn(),
+    createMeshPacket: vi.fn(),
+    createTextMessage: vi.fn(),
+  },
+  meshtasticProtobufService: {
+    initialize: vi.fn(),
+    createMeshPacket: vi.fn(),
+    createTextMessage: vi.fn(),
+  },
+}));
+
+vi.mock('./protobufService.js', () => ({
+  default: {
+    encode: vi.fn(),
+    decode: vi.fn(),
+  },
+  convertIpv4ConfigToStrings: vi.fn(),
+}));
+
+vi.mock('./protobufLoader.js', () => ({
+  getProtobufRoot: vi.fn(),
+}));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('./services/notificationService.js', () => ({
+  notificationService: {
+    checkAndSendNotifications: vi.fn(),
+    getServiceStatus: vi.fn(() => ({ anyAvailable: false })),
+  },
+}));
+
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeConnected: vi.fn(),
+    notifyNodeDisconnected: vi.fn(),
+  },
+}));
+
+vi.mock('./services/packetLogService.js', () => ({
+  default: {
+    logPacket: vi.fn(),
+  },
+}));
+
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: {
+    tryDecrypt: vi.fn(),
+  },
+}));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    handleAck: vi.fn(),
+    handleFailure: vi.fn(),
+    recordExternalSend: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return {
+    messageQueueService: mockInstance,
+    MessageQueueService,
+  };
+});
+
+vi.mock('./utils/cronScheduler.js', () => ({
+  validateCron: vi.fn(() => true),
+  scheduleCron: vi.fn((_expression: string, _callback: () => void) => ({
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('./config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({
+    NODE_IP: '127.0.0.1',
+    TCP_PORT: 4403,
+    LOG_LEVEL: 'info',
+  })),
+}));
+
+vi.mock('../utils/autoResponderUtils.js', () => ({
+  normalizeTriggerPatterns: vi.fn(),
+  normalizeTriggerChannels: vi.fn(),
+}));
+
+vi.mock('../utils/nodeHelpers.js', () => ({
+  isNodeComplete: vi.fn(),
+}));
+
+describe('MeshtasticManager - ATAK V2 persistence (processTakV2Packet)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockGetNode.mockReturnValue({
+      nodeNum: 0x1111,
+      nodeId: '!00001111',
+      longName: 'Test Node',
+      shortName: 'TEST',
+    });
+    mockGetChannelById.mockReturnValue({ id: 0, name: 'Primary', role: 1 });
+    mockUpsertContact.mockResolvedValue(undefined);
+    mockInsertMessage.mockResolvedValue(true);
+
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeMeshPacket = (from: number, to: number, channel = 0, id = 42) => ({
+    from,
+    to,
+    id,
+    channel,
+    rxTime: Math.floor(Date.now() / 1000),
+    decoded: {
+      portnum: 78,
+    },
+  });
+
+  it('implicit PLI upserts exactly one ATAK contact and writes no Messages row', async () => {
+    const packet = makeMeshPacket(0x1111, 0xffffffff, 0, 50);
+    const tak = {
+      callsign: 'BRAVO-2',
+      deviceCallsign: 'ANDROID-abc',
+      uid: 'ANDROID-uid-9',
+      team: 9,
+      role: 1,
+      battery: 75,
+      latitudeI: 371234500,
+      longitudeI: -1225432100,
+      altitude: 10,
+      speed: 250,
+      course: 4500,
+    };
+
+    await manager.processTakV2Packet(packet, tak);
+
+    expect(mockUpsertContact).toHaveBeenCalledTimes(1);
+    const row = mockUpsertContact.mock.calls[0][0];
+    expect(row).toMatchObject({
+      uid: 'ANDROID-uid-9',
+      callsign: 'BRAVO-2',
+      deviceCallsign: 'ANDROID-abc',
+      nodeNum: 0x1111,
+      team: 9,
+      role: 1,
+      battery: 75,
+      speed: 3,   // 250 cm/s → m/s rounded
+      course: 45, // 4500 deg×100 → deg
+    });
+    expect(mockInsertMessage).not.toHaveBeenCalled();
+  });
+
+  it('GeoChat persists a Messages row on portnum 78 with the ATAK provenance prefix', async () => {
+    const packet = makeMeshPacket(0x1111, 0xffffffff, 2, 51);
+    const tak = {
+      callsign: 'BRAVO-2',
+      chat: { message: 'On station', toCallsign: '' },
+    };
+
+    await manager.processTakV2Packet(packet, tak);
+
+    expect(mockUpsertContact).not.toHaveBeenCalled();
+    expect(mockInsertMessage).toHaveBeenCalledTimes(1);
+    const [message] = mockInsertMessage.mock.calls[0];
+    expect(message.portnum).toBe(78);
+    expect(message.text).toBe('[ATAK BRAVO-2] On station');
+    expect(message.channel).toBe(2);
+    expect(mockEmitNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('GeoChat DM routes with channel -1 and directed tag', async () => {
+    const packet = makeMeshPacket(0x1111, 0x2222, 0, 52);
+    const tak = {
+      callsign: 'BRAVO-2',
+      chat: { message: 'rally at cp2', toCallsign: 'ALPHA-1' },
+    };
+
+    await manager.processTakV2Packet(packet, tak);
+
+    const [message] = mockInsertMessage.mock.calls[0];
+    expect(message.channel).toBe(-1);
+    expect(message.text).toBe('[ATAK BRAVO-2\u2192ALPHA-1] rally at cp2');
+  });
+
+  it('GeoChat receipts persist nothing', async () => {
+    const packet = makeMeshPacket(0x1111, 0x2222, 0, 53);
+    await manager.processTakV2Packet(packet, { callsign: 'B', chat: { message: '', receiptType: 1 } });
+    await manager.processTakV2Packet(packet, { callsign: 'B', chat: { message: '', receiptForUid: 'X' } });
+
+    expect(mockInsertMessage).not.toHaveBeenCalled();
+    expect(mockUpsertContact).not.toHaveBeenCalled();
+  });
+
+  it('rich-CoT variants (marker) persist neither contact nor message this phase', async () => {
+    const packet = makeMeshPacket(0x1111, 0xffffffff, 0, 54);
+    await manager.processTakV2Packet(packet, {
+      callsign: 'BRAVO-2',
+      latitudeI: 371234500,
+      longitudeI: -1225432100,
+      marker: { name: 'OP1' },
+    });
+
+    expect(mockInsertMessage).not.toHaveBeenCalled();
+    expect(mockUpsertContact).not.toHaveBeenCalled();
+  });
+
+  it('ignores decode-fallback raw payloads without throwing', async () => {
+    const packet = makeMeshPacket(0x1111, 0xffffffff, 0, 55);
+    await expect(manager.processTakV2Packet(packet, new Uint8Array([0x00, 0x01]))).resolves.toBeUndefined();
+    expect(mockInsertMessage).not.toHaveBeenCalled();
+    expect(mockUpsertContact).not.toHaveBeenCalled();
+  });
+
+  it('swallows contact-persistence failures (RX-only, best-effort)', async () => {
+    mockUpsertContact.mockRejectedValueOnce(new Error('db down'));
+    const packet = makeMeshPacket(0x1111, 0xffffffff, 0, 56);
+    await expect(manager.processTakV2Packet(packet, {
+      callsign: 'BRAVO-2',
+      latitudeI: 371234500,
+      longitudeI: -1225432100,
+    })).resolves.toBeUndefined();
+  });
+});

--- a/src/server/meshtasticManager.atakV2.test.ts
+++ b/src/server/meshtasticManager.atakV2.test.ts
@@ -343,6 +343,16 @@ describe('MeshtasticManager - ATAK V2 persistence (processTakV2Packet)', () => {
     expect(mockUpsertContact).not.toHaveBeenCalled();
   });
 
+  it('swallows GeoChat message-insertion failures (RX-only, best-effort)', async () => {
+    mockInsertMessage.mockRejectedValueOnce(new Error('db down'));
+    const packet = makeMeshPacket(0x1111, 0xffffffff, 0, 57);
+    await expect(manager.processTakV2Packet(packet, {
+      callsign: 'BRAVO-2',
+      chat: { message: 'On station' },
+    })).resolves.toBeUndefined();
+    expect(mockEmitNewMessage).not.toHaveBeenCalled();
+  });
+
   it('swallows contact-persistence failures (RX-only, best-effort)', async () => {
     mockUpsertContact.mockRejectedValueOnce(new Error('db down'));
     const packet = makeMeshPacket(0x1111, 0xffffffff, 0, 56);

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6441,6 +6441,9 @@ class MeshtasticManager implements ISourceManager {
       // Implicit PLI: no payload_variant set = position report → contact
       // upsert (never a Messages row). Errors are logged, never thrown
       // (RX-only, best-effort — same contract as the V1 PLI path).
+      // Note the dictionary ID and the variant are orthogonal: an
+      // aircraft-dict (dict 1) packet with no variant set is still a
+      // position report and lands here by design.
       if (variant === undefined) {
         try {
           const pliFromNum = Number(meshPacket.from);
@@ -6455,7 +6458,9 @@ class MeshtasticManager implements ISourceManager {
         return;
       }
 
-      // Only the GeoChat variant becomes a message this phase.
+      // Only the GeoChat variant becomes a message this phase. A DB failure
+      // in the insert/emit path below is covered by this method's outer
+      // catch (logged, never thrown) — same RX-only contract as V1.
       if (variant !== 'chat') return;
       const chat = tak.chat;
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1,6 +1,7 @@
 import databaseService, { type DbMessage } from '../services/database.js';
-import { buildContactRow } from './services/atakContactService.js';
-import meshtasticProtobufService, { formatTakPreview } from './meshtasticProtobufService.js';
+import { buildContactRow, buildContactRowV2 } from './services/atakContactService.js';
+import meshtasticProtobufService, { formatTakPreview, formatTakV2Preview } from './meshtasticProtobufService.js';
+import { takV2Variant } from './takV2Decoder.js';
 import protobufService, { convertIpv4ConfigToStrings } from './protobufService.js';
 import { getProtobufRoot, type MeshBeaconPayload } from './protobufLoader.js';
 import { TcpTransport } from './tcpTransport.js';
@@ -5561,8 +5562,14 @@ class MeshtasticManager implements ISourceManager {
                 processedPayload, meshPacket.decoded.payload.length);
               // decodedPayload keeps the decoded TAKPacket object → renders as JSON in the detail view.
             } else if (portnum === PortNum.ATAK_PLUGIN_V2) {
-              payloadPreview = `[ATAK V2 (not decoded), ${meshPacket.decoded.payload.length} bytes]`;
-              decodedPayload = null; // suppress raw-Uint8Array dump into metadata.decoded_payload
+              // #4317: decoded TAKPacketV2 renders as JSON in the detail view;
+              // when decode fell back (missing dictionary, corrupt frame) the
+              // preview names the dictionary and the raw-bytes dump stays
+              // suppressed as before.
+              payloadPreview = formatTakV2Preview(processedPayload, meshPacket.decoded.payload);
+              if (processedPayload instanceof Uint8Array) {
+                decodedPayload = null; // suppress raw-Uint8Array dump into metadata.decoded_payload
+              }
             } else if (portnum === PortNum.ATAK_FORWARDER) {
               payloadPreview = `[ATAK Forwarder (not decoded), ${meshPacket.decoded.payload.length} bytes]`;
               decodedPayload = null;
@@ -5835,6 +5842,18 @@ class MeshtasticManager implements ISourceManager {
             // preview-only (Packet Monitor) this phase — see processTakPacket.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #3691 decoded protobuf oneof shape (TAKPacket | raw Uint8Array); no generated TS type for protobufjs decode() output here
             await this.processTakPacket(meshPacket, processedPayload as any, {
+              ...context,
+              decryptedBy,
+              decryptedChannelId: decryptedChannelId ?? undefined,
+            });
+            break;
+          case PortNum.ATAK_PLUGIN_V2:
+            // ATAK TAKPacketV2 (RX-only, #4317): implicit PLI upserts an
+            // atak_contacts row, GeoChat persists as a Messages row; the
+            // rich-CoT variants (shapes/routes/markers/…) stay
+            // Packet-Monitor-only (decoded JSON) this phase.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 decoded protobuf oneof shape (TAKPacketV2 | raw Uint8Array); no generated TS type for protobufjs decode() output here
+            await this.processTakV2Packet(meshPacket, processedPayload as any, {
               ...context,
               decryptedBy,
               decryptedChannelId: decryptedChannelId ?? undefined,
@@ -6395,6 +6414,133 @@ class MeshtasticManager implements ISourceManager {
       }
     } catch (error) {
       logger.error('❌ Error processing ATAK TAKPacket:', error);
+    }
+  }
+
+  /**
+   * Process a decoded ATAK TAKPacketV2 (PortNum 78 / ATAK_PLUGIN_V2, #4317).
+   *
+   * RX-only, mirroring processTakPacket's phase scoping: the implicit-PLI
+   * case (no payload_variant set) upserts an `atak_contacts` row via
+   * `buildContactRowV2`; the GeoChat variant becomes a Messages row; every
+   * rich-CoT variant (shapes, markers, routes, rab, casevac, emergency,
+   * task, TAKTALK, aircraft, raw_detail) stays Packet-Monitor-only (decoded
+   * JSON in metadata) until there's a dedicated surface for it. Unlike V1
+   * there is no unishox2/is_compressed concern — strings are always clean
+   * after zstd decompression. GeoChat receipts are still skipped.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 meshPacket/tak are untyped protobuf-decoded shapes (no generated TS type for protobufjs decode() output), matching processTakPacket's existing convention
+  private async processTakV2Packet(meshPacket: any, tak: any, context?: ProcessingContext): Promise<void> {
+    try {
+      // Decode failed upstream (processPayload fell back to the raw
+      // Uint8Array — missing dictionary or corrupt frame) — nothing to persist.
+      if (!tak || typeof tak !== 'object' || tak instanceof Uint8Array) return;
+
+      const variant = takV2Variant(tak);
+
+      // Implicit PLI: no payload_variant set = position report → contact
+      // upsert (never a Messages row). Errors are logged, never thrown
+      // (RX-only, best-effort — same contract as the V1 PLI path).
+      if (variant === undefined) {
+        try {
+          const pliFromNum = Number(meshPacket.from);
+          const row = buildContactRowV2(meshPacket, tak, this.sourceId);
+          if (row) {
+            await this.ensureMessageEndpointNodes(pliFromNum, pliFromNum); // carrying node row
+            await databaseService.atakContacts.upsertContact(row);
+          }
+        } catch (error) {
+          logger.error('❌ Error persisting ATAK V2 PLI contact:', error);
+        }
+        return;
+      }
+
+      // Only the GeoChat variant becomes a message this phase.
+      if (variant !== 'chat') return;
+      const chat = tak.chat;
+
+      // Receipts (delivered/read acks) must NOT surface as chat messages.
+      const receiptType = Number(chat.receiptType ?? chat.receipt_type ?? 0);
+      const receiptForUid = chat.receiptForUid ?? chat.receipt_for_uid;
+      if (receiptType !== 0 || receiptForUid) return;
+
+      const rawMsg = typeof chat.message === 'string' ? chat.message.trim() : '';
+      if (!rawMsg) return;
+
+      // Presentation: same `[ATAK …]` provenance prefix as V1 GeoChat —
+      // V2 carries callsign at the top level (no Contact sub-message).
+      const callsign = tak.callsign || tak.deviceCallsign || tak.device_callsign;
+      const toCallsign = chat.toCallsign ?? chat.to_callsign;
+      const tag = callsign
+        ? (toCallsign ? `[ATAK ${callsign}→${toCallsign}]` : `[ATAK ${callsign}]`)
+        : '[ATAK]';
+      const messageText = `${tag} ${rawMsg}`;
+
+      // Routing/channel: use the Meshtastic envelope, NOT the ATAK UID
+      // fields (same reasoning as processTakPacket).
+      const fromNum = Number(meshPacket.from);
+      const toNum = Number(meshPacket.to);
+      const fromNodeId = `!${fromNum.toString(16).padStart(8, '0')}`;
+      const toNodeId = `!${toNum.toString(16).padStart(8, '0')}`;
+      const isDirectMessage = toNum !== 4294967295;
+      const channelIndex = isDirectMessage ? -1 : (meshPacket.channel !== undefined ? meshPacket.channel : 0);
+
+      await this.ensureMessageEndpointNodes(fromNum, toNum);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 camelCase/snake_case dual-access on an untyped protobuf-decoded meshPacket, matching processTakPacket's existing convention
+      const hopStart = (meshPacket as any).hopStart ?? (meshPacket as any).hop_start ?? null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 camelCase/snake_case dual-access on an untyped protobuf-decoded meshPacket, matching processTakPacket's existing convention
+      const hopLimit = (meshPacket as any).hopLimit ?? (meshPacket as any).hop_limit ?? null;
+
+      const message: TextMessage = {
+        // Same format as processTextMessageProtobuf — load-bearing for
+        // cross-source dedup in /api/unified/messages.
+        id: `${this.sourceId}_${fromNum}_${meshPacket.id || Date.now()}`,
+        fromNodeNum: fromNum,
+        toNodeNum: toNum,
+        fromNodeId,
+        toNodeId,
+        text: messageText,
+        channel: channelIndex,
+        portnum: PortNum.ATAK_PLUGIN_V2,
+        timestamp: Date.now(),
+        rxTime: plausibleRxTime(meshPacket.rxTime ? Number(meshPacket.rxTime) * 1000 : undefined) ?? undefined,
+        hopStart,
+        hopLimit,
+        relayNode: meshPacket.relayNode ?? undefined,
+        viaMqtt: meshPacket.viaMqtt === true || isViaMqtt(meshPacket.transportMechanism),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 snake_case fallback on an untyped protobuf-decoded meshPacket, matching processTakPacket's existing convention
+        rxSnr: meshPacket.rxSnr ?? (meshPacket as any).rx_snr,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 snake_case fallback on an untyped protobuf-decoded meshPacket, matching processTakPacket's existing convention
+        rxRssi: meshPacket.rxRssi ?? (meshPacket as any).rx_rssi,
+        createdAt: Date.now(),
+        decryptedBy: context?.decryptedBy ?? null,
+        sourceIp: null,
+        sourcePath: 'tcp_radio',
+        spoofSuspected: this.assessLocalSpoof(meshPacket).spoofSuspected || undefined,
+      };
+
+      const wasInserted = await databaseService.messages.insertMessage(message, this.sourceId);
+
+      if (wasInserted) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 TextMessage/DbMessage shape mismatch on emit, matching processTakPacket's existing convention
+        dataEventEmitter.emitNewMessage(message as any, this.sourceId);
+        if (isDirectMessage) {
+          logger.debug(`💾 Saved ATAK V2 GeoChat DM from ${message.fromNodeId} to ${message.toNodeId}: "${messageText.substring(0, 30)}..."`);
+        } else {
+          logger.debug(`💾 Saved ATAK V2 GeoChat from ${message.fromNodeId} on channel ${channelIndex}: "${messageText.substring(0, 30)}..."`);
+        }
+
+        // GeoChat is a real message — same push notification as text.
+        await this.sendMessagePushNotification(message, messageText, isDirectMessage);
+
+        // Deliberately NO checkAutoAcknowledge / handleAutoPingCommand /
+        // checkAutoResponder — RX-only (see processTakPacket doc comment).
+      } else {
+        logger.debug(`⏭️ Skipped duplicate ATAK V2 GeoChat ${message.id} (echo from device)`);
+      }
+    } catch (error) {
+      logger.error('❌ Error processing ATAK TAKPacketV2:', error);
     }
   }
 
@@ -9711,9 +9857,10 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // Skip non-chat messages (telemetry, traceroutes, etc.). ATAK GeoChat
-      // (PortNum.ATAK_PLUGIN) is a real chat message too — see processTakPacket —
+      // (PortNum.ATAK_PLUGIN, and its V2 form on PortNum.ATAK_PLUGIN_V2) is a
+      // real chat message too — see processTakPacket / processTakV2Packet —
       // and gets a push notification the same as a text message (spec §7.3).
-      if (message.portnum !== PortNum.TEXT_MESSAGE_APP && message.portnum !== PortNum.ATAK_PLUGIN) {
+      if (message.portnum !== PortNum.TEXT_MESSAGE_APP && message.portnum !== PortNum.ATAK_PLUGIN && message.portnum !== PortNum.ATAK_PLUGIN_V2) {
         return;
       }
 

--- a/src/server/meshtasticProtobufService.test.ts
+++ b/src/server/meshtasticProtobufService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { MeshtasticProtobufService, formatTakPreview } from './meshtasticProtobufService';
+import { MeshtasticProtobufService, formatTakPreview, formatTakV2Preview } from './meshtasticProtobufService';
 import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -766,13 +766,48 @@ describe('MeshtasticProtobufService', () => {
       expect(formatTakPreview(result, payload.length)).toBe('[ATAK GeoChat (compressed)]');
     });
 
-    it('does NOT decode ATAK_PLUGIN_V2 (port 78) - returns the raw payload', () => {
+    it('decodes ATAK_PLUGIN_V2 (port 78) uncompressed payloads to TAKPacketV2 (#4317)', () => {
       if (!requireProtobufs()) return;
 
-      const someBytes = Uint8Array.from([0x10, 0x20, 0x30, 0x40]);
+      const root = getProtobufRoot()!;
+      const TAKPacketV2 = root.lookupType('meshtastic.TAKPacketV2');
+      const pb = TAKPacketV2.encode(TAKPacketV2.create({
+        callsign: 'HAWK',
+        latitudeI: 388895000,
+        longitudeI: -770353000,
+      })).finish();
+      // [0xFF][raw protobuf] = skip-compress wire form, no dictionary needed.
+      const wire = new Uint8Array(1 + pb.length);
+      wire[0] = 0xff;
+      wire.set(pb, 1);
+
+      const result = service.processPayload(78, wire as any);
+      expect(result).not.toBeInstanceOf(Uint8Array);
+      expect(result.callsign).toBe('HAWK');
+      expect(formatTakV2Preview(result, wire)).toBe('[ATAK V2 PLI HAWK: 38.88950°, -77.03530°]');
+    });
+
+    it('falls back to the raw payload for an unknown V2 dictionary ID and labels the preview', () => {
+      if (!requireProtobufs()) return;
+
+      const someBytes = Uint8Array.from([0x10, 0x20, 0x30, 0x40]); // dict 16 is reserved
       const result = service.processPayload(78, someBytes as any);
       expect(result).toBeInstanceOf(Uint8Array);
       expect(Array.from(result as Uint8Array)).toEqual([0x10, 0x20, 0x30, 0x40]);
+      expect(formatTakV2Preview(result, someBytes)).toBe('[ATAK V2, unknown dict 16, 4 bytes (not decoded)]');
+    });
+
+    it('previews V2 GeoChat and rich-CoT variants (#4317)', () => {
+      if (!requireProtobufs()) return;
+
+      expect(formatTakV2Preview({ callsign: 'HAWK', chat: { message: 'On station' } }, new Uint8Array(10)))
+        .toBe('[ATAK V2 GeoChat HAWK: "On station"]');
+      expect(formatTakV2Preview({ callsign: 'HAWK', chat: { message: '', receiptType: 1 } }, new Uint8Array(10)))
+        .toBe('[ATAK V2 GeoChat receipt HAWK]');
+      expect(formatTakV2Preview({ callsign: 'HAWK', emergency: {} }, new Uint8Array(10)))
+        .toBe('[ATAK V2 EMERGENCY HAWK]');
+      expect(formatTakV2Preview({ route: { name: 'EXFIL' } }, new Uint8Array(10)))
+        .toBe('[ATAK V2 route]');
     });
 
     it('does not throw on malformed TAKPacket bytes and previews as undecodable', () => {

--- a/src/server/meshtasticProtobufService.test.ts
+++ b/src/server/meshtasticProtobufService.test.ts
@@ -797,6 +797,16 @@ describe('MeshtasticProtobufService', () => {
       expect(formatTakV2Preview(result, someBytes)).toBe('[ATAK V2, unknown dict 16, 4 bytes (not decoded)]');
     });
 
+    it('labels an uncompressed (0xFF) V2 payload that fails protobuf parse as not decoded', () => {
+      if (!requireProtobufs()) return;
+
+      // 0xFF flags + bytes that are not a valid TAKPacketV2 protobuf.
+      const wire = Uint8Array.from([0xff, 0xff, 0xff, 0xff, 0xff]);
+      const result = service.processPayload(78, wire as any);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(formatTakV2Preview(result, wire)).toBe('[ATAK V2 uncompressed, 5 bytes (not decoded)]');
+    });
+
     it('previews V2 GeoChat and rich-CoT variants (#4317)', () => {
       if (!requireProtobufs()) return;
 

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -7,6 +7,7 @@
 import { loadProtobufDefinitions, getProtobufRoot, type FromRadio, type MeshPacket } from './protobufLoader.js';
 import { logger } from '../utils/logger.js';
 import { PortNum } from './constants/meshtastic.js';
+import { decodeTakV2Payload, takV2Variant, takV2DictName, TAK_V2_UNCOMPRESSED } from './takV2Decoder.js';
 
 export class MeshtasticProtobufService {
   private static instance: MeshtasticProtobufService;
@@ -924,6 +925,16 @@ export class MeshtasticProtobufService {
           return TAKPacket.decode(payload); // throws are caught by the outer try/catch → returns raw payload
         }
 
+        case PortNum.ATAK_PLUGIN_V2: {
+          // TAKPacketV2 (portnum 78, #4317): wire is [1 flags byte][zstd body
+          // with magic stripped] against a shared dictionary, or [0xFF][raw
+          // protobuf]. decodeTakV2Payload returns null on any failure
+          // (missing dictionary/native module, corrupt frame, unknown dict
+          // ID) → return the raw payload, the same contract as an
+          // undecodable port.
+          return decodeTakV2Payload(payload, root) ?? payload;
+        }
+
         default:
           logger.debug(`⚠️ Unhandled port number: ${portnum}`);
           return payload;
@@ -1836,6 +1847,79 @@ export function formatTakPreview(tak: any, payloadSize: number): string {
     return `[ATAK detail${who}: ${n} bytes]`;
   }
   return `[ATAK packet${who}]`;
+}
+
+/**
+ * Human-readable one-line preview for an ATAK V2 packet (Packet Monitor,
+ * #4317). `v2` is the processPayload result: a decoded TAKPacketV2, or the
+ * raw Uint8Array wire payload when decode fell back (missing dictionary,
+ * corrupt frame). `rawPayload` is always the wire payload — its first byte
+ * is the flags byte, used to label undecoded packets by dictionary.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 decoded protobuf oneof shape (TAKPacketV2 | raw Uint8Array); no generated TS type for protobufjs decode() output here
+export function formatTakV2Preview(v2: any, rawPayload: Uint8Array): string {
+  const size = rawPayload?.length ?? 0;
+
+  // Decode fell back to the raw payload — label with the dictionary the
+  // sender used so an operator can tell "dictionary missing" from garbage.
+  if (!v2 || typeof v2 !== 'object' || v2 instanceof Uint8Array) {
+    if (size < 1) return `[ATAK V2, ${size} bytes (not decoded)]`;
+    const flags = rawPayload[0];
+    if (flags === TAK_V2_UNCOMPRESSED) {
+      return `[ATAK V2 uncompressed, ${size} bytes (not decoded)]`;
+    }
+    return `[ATAK V2, ${takV2DictName(flags & 0x3f)}, ${size} bytes (not decoded)]`;
+  }
+
+  const callsign = v2.callsign || v2.deviceCallsign || v2.device_callsign;
+  const who = callsign ? ` ${callsign}` : '';
+  const variant = takV2Variant(v2);
+
+  switch (variant) {
+    case undefined: {
+      // No payload_variant = implicit PLI (position report).
+      const lat = Number(v2.latitudeI ?? v2.latitude_i ?? 0) / 1e7;
+      const lon = Number(v2.longitudeI ?? v2.longitude_i ?? 0) / 1e7;
+      return `[ATAK V2 PLI${who}: ${lat.toFixed(5)}°, ${lon.toFixed(5)}°]`;
+    }
+    case 'chat': {
+      const chat = v2.chat;
+      const receiptType = Number(chat.receiptType ?? chat.receipt_type ?? 0);
+      if (receiptType !== 0 || chat.receiptForUid || chat.receipt_for_uid) {
+        return `[ATAK V2 GeoChat receipt${who}]`;
+      }
+      const msg = typeof chat.message === 'string' ? chat.message.substring(0, 80) : '';
+      return `[ATAK V2 GeoChat${who}: "${msg}"]`;
+    }
+    case 'aircraft':
+      return `[ATAK V2 aircraft track${who}]`;
+    case 'shape':
+      return `[ATAK V2 drawn shape${who}]`;
+    case 'marker':
+      return `[ATAK V2 marker${who}]`;
+    case 'rab':
+      return `[ATAK V2 range & bearing${who}]`;
+    case 'route':
+      return `[ATAK V2 route${who}]`;
+    case 'casevac':
+      return `[ATAK V2 CASEVAC${who}]`;
+    case 'emergency':
+      return `[ATAK V2 EMERGENCY${who}]`;
+    case 'task':
+      return `[ATAK V2 task${who}]`;
+    case 'taktalk': {
+      const msg = typeof v2.taktalk?.message === 'string' ? v2.taktalk.message.substring(0, 60) : '';
+      return msg ? `[ATAK V2 TAKTALK${who}: "${msg}"]` : `[ATAK V2 TAKTALK${who}]`;
+    }
+    case 'taktalkRoom':
+      return `[ATAK V2 TAKTALK room${who}]`;
+    case 'rawDetail': {
+      const bytes = v2.rawDetail ?? v2.raw_detail;
+      return `[ATAK V2 detail${who}: ${bytes?.length ?? 0} bytes]`;
+    }
+    default:
+      return `[ATAK V2 ${variant}${who}]`;
+  }
 }
 
 // Export singleton instance

--- a/src/server/services/atakContactService.test.ts
+++ b/src/server/services/atakContactService.test.ts
@@ -8,7 +8,7 @@
  * coords → null lat/lon, no-pli → null.
  */
 import { describe, it, expect } from 'vitest';
-import { buildContactRow, ATAK_CONTACT_STALE_MS, ATAK_CONTACT_RETENTION_MS } from './atakContactService.js';
+import { buildContactRow, buildContactRowV2, ATAK_CONTACT_STALE_MS, ATAK_CONTACT_RETENTION_MS } from './atakContactService.js';
 
 const makeMeshPacket = (from: number) => ({ from, to: 0xffffffff, id: 1, channel: 0 });
 
@@ -171,5 +171,77 @@ describe('atakContactService.buildContactRow', () => {
   it('exposes the fixed stale/retention window constants', () => {
     expect(ATAK_CONTACT_STALE_MS).toBe(15 * 60 * 1000);
     expect(ATAK_CONTACT_RETENTION_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe('atakContactService.buildContactRowV2', () => {
+  const fullV2 = () => ({
+    callsign: 'BRAVO-2',
+    deviceCallsign: 'ANDROID-abc',
+    uid: 'ANDROID-uid-123',
+    team: 9,
+    role: 2,
+    battery: 64,
+    latitudeI: 371234500,
+    longitudeI: -1225432100,
+    altitude: 120,
+    speed: 450,   // cm/s → 5 m/s (rounded)
+    course: 9050, // degrees×100 → 91° (rounded)
+  });
+
+  it('maps a full implicit-PLI TAKPacketV2 to a contact row with unit normalization', () => {
+    const row = buildContactRowV2(makeMeshPacket(0x2222), fullV2(), 'source-a');
+
+    expect(row).not.toBeNull();
+    expect(row).toMatchObject({
+      uid: 'ANDROID-uid-123', // V2's explicit uid wins over callsigns
+      sourceId: 'source-a',
+      nodeNum: 0x2222,
+      callsign: 'BRAVO-2',
+      deviceCallsign: 'ANDROID-abc',
+      team: 9,
+      role: 2,
+      battery: 64,
+      altitude: 120,
+      speed: 5,  // 450 cm/s
+      course: 91, // 9050 deg×100 (rounded)
+    });
+    expect(row!.latitude).toBeCloseTo(37.12345, 5);
+    expect(row!.longitude).toBeCloseTo(-122.54321, 5);
+  });
+
+  it('falls back uid → deviceCallsign → callsign → nodeNum', () => {
+    const base = { latitudeI: 371234500, longitudeI: -1225432100 };
+    expect(buildContactRowV2(makeMeshPacket(0xAA), { ...base, deviceCallsign: 'EUD-9', callsign: 'C' }, 's')!.uid).toBe('EUD-9');
+    expect(buildContactRowV2(makeMeshPacket(0xAA), { ...base, callsign: 'C' }, 's')!.uid).toBe('C');
+    expect(buildContactRowV2(makeMeshPacket(0xAA), base, 's')!.uid).toBe('!000000aa');
+  });
+
+  it('handles snake_case protobuf field fallbacks', () => {
+    const row = buildContactRowV2(makeMeshPacket(0x2222), {
+      device_callsign: 'EUD-2',
+      latitude_i: 371234500,
+      longitude_i: -1225432100,
+    }, 'source-a');
+    expect(row?.uid).toBe('EUD-2');
+    expect(row?.latitude).toBeCloseTo(37.12345, 5);
+  });
+
+  it('drops the 9999999 "no altitude" sentinel', () => {
+    const row = buildContactRowV2(makeMeshPacket(1), { ...fullV2(), altitude: 9999999 }, 's');
+    expect(row?.altitude).toBeNull();
+  });
+
+  it('nulls bogus (Null Island) coordinates but still upserts identity fields', () => {
+    const row = buildContactRowV2(makeMeshPacket(1), { ...fullV2(), latitudeI: 0, longitudeI: 0 }, 's');
+    expect(row).not.toBeNull();
+    expect(row?.latitude).toBeNull();
+    expect(row?.longitude).toBeNull();
+    expect(row?.callsign).toBe('BRAVO-2');
+  });
+
+  it('returns null for unusable shapes', () => {
+    expect(buildContactRowV2(makeMeshPacket(1), null, 's')).toBeNull();
+    expect(buildContactRowV2(makeMeshPacket(1), new Uint8Array([1, 2]), 's')).toBeNull();
   });
 });

--- a/src/server/services/atakContactService.ts
+++ b/src/server/services/atakContactService.ts
@@ -130,6 +130,75 @@ export function buildContactRow(
 }
 
 /**
+ * TAKPacketV2's "no altitude" sentinel (ATAK hae=9999999.0) — see the
+ * altitude field comment in protobufs/meshtastic/atak.proto.
+ */
+const TAK_V2_NO_ALTITUDE = 9999999;
+
+/**
+ * Pure mapper: decoded implicit-PLI TAKPacketV2 (portnum 78, #4317) →
+ * `AtakContactRow`. The V2 envelope carries identity and position at the top
+ * level (no Contact/Group/Status sub-messages like V1), and V2 has an
+ * explicit `uid` field — preferred over the V1-style callsign fallbacks.
+ *
+ * Unit normalization to match the V1-populated columns (INTEGER, V1 wire
+ * units): V2 `speed` is cm/s → stored as m/s; V2 `course` is degrees×100 →
+ * stored as degrees. `altitude` drops the 9999999 "no altitude" sentinel.
+ * There is no unishox2/is_compressed concern in V2 — strings are always
+ * clean after zstd decompression.
+ */
+export function buildContactRowV2(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 untyped protobuf-decoded MeshPacket shape, matching buildContactRow's existing convention
+  meshPacket: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 untyped protobuf-decoded TAKPacketV2 shape, matching buildContactRow's existing convention
+  tak: any,
+  sourceId: string,
+): AtakContactRow | null {
+  if (!tak || typeof tak !== 'object' || tak instanceof Uint8Array) return null;
+
+  const nodeNumRaw = Number(meshPacket?.from);
+  const nodeNum = Number.isFinite(nodeNumRaw) ? nodeNumRaw >>> 0 : null;
+
+  const callsign: string | null = tak.callsign || null;
+  const deviceCallsign: string | null = tak.deviceCallsign ?? tak.device_callsign ?? null;
+  const uid: string = tak.uid || deviceCallsign || callsign || nodeNumFallbackUid(nodeNum);
+
+  const latitudeI = tak.latitudeI ?? tak.latitude_i;
+  const longitudeI = tak.longitudeI ?? tak.longitude_i;
+  let latitude: number | null = typeof latitudeI === 'number' ? latitudeI * 1e-7 : null;
+  let longitude: number | null = typeof longitudeI === 'number' ? longitudeI * 1e-7 : null;
+  if (latitude !== null && longitude !== null && isBogusPosition(latitude, longitude)) {
+    latitude = null;
+    longitude = null;
+  }
+
+  const altitudeRaw = typeof tak.altitude === 'number' ? tak.altitude : null;
+  const altitude = altitudeRaw === TAK_V2_NO_ALTITUDE ? null : altitudeRaw;
+  const speed = typeof tak.speed === 'number' ? Math.round(tak.speed / 100) : null; // cm/s → m/s
+  const course = typeof tak.course === 'number' ? Math.round(tak.course / 100) : null; // deg×100 → deg
+
+  const now = Date.now();
+
+  return {
+    uid,
+    sourceId,
+    nodeNum,
+    callsign,
+    deviceCallsign,
+    team: typeof tak.team === 'number' ? tak.team : null,
+    role: typeof tak.role === 'number' ? tak.role : null,
+    battery: typeof tak.battery === 'number' ? tak.battery : null,
+    latitude,
+    longitude,
+    altitude,
+    speed,
+    course,
+    lastSeen: now,
+    createdAt: now,
+  };
+}
+
+/**
  * Cleanup scheduler for `atak_contacts` retention (fixed 24h window). Modeled
  * on `MqttPacketLogService` — a small singleton that starts a `setInterval`
  * in its constructor and exposes `stop()` for test teardown.

--- a/src/server/takV2Decoder.test.ts
+++ b/src/server/takV2Decoder.test.ts
@@ -89,6 +89,11 @@ describe.skipIf(!hasFixtures || !hasProtobufs)('takV2Decoder', () => {
       expect(decodeTakV2Payload(Buffer.alloc(0), root)).toBeNull();
     });
 
+    it('returns null for a payload above the LoRa MTU bound without decompressing', () => {
+      const oversized = Buffer.concat([Buffer.from([0x00]), Buffer.alloc(300, 0x41)]);
+      expect(decodeTakV2Payload(oversized, root)).toBeNull();
+    });
+
     it('returns null for a corrupt zstd body', () => {
       const wire = Buffer.from([0x00, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02]);
       expect(decodeTakV2Payload(wire, root)).toBeNull();

--- a/src/server/takV2Decoder.test.ts
+++ b/src/server/takV2Decoder.test.ts
@@ -1,0 +1,151 @@
+/**
+ * ATAK V2 wire decoder tests (#4317).
+ *
+ * The primary suite decodes every golden wire fixture shipped in the
+ * takpacket-sdk submodule (takpacket-sdk/testdata/golden/*.bin — real
+ * `[flags][magicless zstd]` payloads produced by the upstream SDK) and
+ * compares the result against the matching reference protobuf bytes
+ * (testdata/protobuf/*.pb). This pins our decoder to the cross-binding wire
+ * contract, not just to our own implementation.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader';
+import { decodeTakV2Payload, takV2Variant, takV2DictName, TAK_V2_UNCOMPRESSED, resetTakV2DecoderForTests } from './takV2Decoder';
+
+const goldenDir = join(process.cwd(), 'takpacket-sdk', 'testdata', 'golden');
+const protobufFixtureDir = join(process.cwd(), 'takpacket-sdk', 'testdata', 'protobuf');
+const hasFixtures = existsSync(goldenDir) && existsSync(protobufFixtureDir);
+const hasProtobufs = existsSync(join(process.cwd(), 'protobufs', 'meshtastic', 'atak.proto'));
+
+describe.skipIf(!hasFixtures || !hasProtobufs)('takV2Decoder', () => {
+  let TAKPacketV2: any;
+  let root: any;
+
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+    root = getProtobufRoot();
+    TAKPacketV2 = root.lookupType('meshtastic.TAKPacketV2');
+    resetTakV2DecoderForTests();
+  });
+
+  describe('golden wire fixtures (upstream TAKPacket-SDK)', () => {
+    const fixtures = hasFixtures
+      ? readdirSync(goldenDir).filter(f => f.endsWith('.bin')).map(f => basename(f, '.bin'))
+      : [];
+
+    it('has the full upstream fixture set', () => {
+      expect(fixtures.length).toBeGreaterThanOrEqual(40);
+    });
+
+    it.each(fixtures)('decodes %s to the reference protobuf', (name) => {
+      const wire = readFileSync(join(goldenDir, `${name}.bin`));
+      const referenceBytes = readFileSync(join(protobufFixtureDir, `${name}.pb`));
+
+      const decoded = decodeTakV2Payload(wire, root);
+      expect(decoded, `fixture ${name} failed to decode`).not.toBeNull();
+      expect(decoded).not.toBeInstanceOf(Uint8Array);
+
+      const reference = TAKPacketV2.decode(referenceBytes);
+      // Compare in toObject space — protobufjs Message instances carry only
+      // wire-present own fields, so deep-equality on the plain objects pins
+      // byte-level fidelity of the decompression.
+      expect(TAKPacketV2.toObject(decoded, { defaults: true }))
+        .toEqual(TAKPacketV2.toObject(reference, { defaults: true }));
+    });
+
+    it('covers both dictionaries in the fixture set', () => {
+      const dictIds = new Set(
+        fixtures.map(name => readFileSync(join(goldenDir, `${name}.bin`))[0])
+          .filter(flags => flags !== TAK_V2_UNCOMPRESSED)
+          .map(flags => flags & 0x3f)
+      );
+      expect(dictIds.has(0)).toBe(true); // non-aircraft
+      expect(dictIds.has(1)).toBe(true); // aircraft
+    });
+  });
+
+  describe('uncompressed (0xFF) path', () => {
+    it('decodes a [0xFF][raw protobuf] payload without any dictionary', () => {
+      const referenceBytes = readFileSync(join(protobufFixtureDir, 'pli_basic.pb'));
+      const wire = Buffer.concat([Buffer.from([TAK_V2_UNCOMPRESSED]), referenceBytes]);
+
+      const decoded = decodeTakV2Payload(wire, root);
+      expect(decoded).not.toBeNull();
+      expect(TAKPacketV2.toObject(decoded, { defaults: true }))
+        .toEqual(TAKPacketV2.toObject(TAKPacketV2.decode(referenceBytes), { defaults: true }));
+    });
+  });
+
+  describe('failure modes (all degrade to null → raw-payload fallback)', () => {
+    it('returns null for an unknown dictionary ID', () => {
+      const wire = Buffer.from([0x10, 0x01, 0x02, 0x03]); // dict 16 is reserved
+      expect(decodeTakV2Payload(wire, root)).toBeNull();
+    });
+
+    it('returns null for a too-short payload', () => {
+      expect(decodeTakV2Payload(Buffer.from([0x00]), root)).toBeNull();
+      expect(decodeTakV2Payload(Buffer.alloc(0), root)).toBeNull();
+    });
+
+    it('returns null for a corrupt zstd body', () => {
+      const wire = Buffer.from([0x00, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02]);
+      expect(decodeTakV2Payload(wire, root)).toBeNull();
+    });
+
+    it('ignores reserved flag bits 6-7 when extracting the dict ID', () => {
+      const golden = readFileSync(join(goldenDir, 'pli_basic.bin'));
+      expect(golden[0] & 0x3f).toBe(0); // precondition: dict 0 fixture
+      const withReservedBits = Buffer.from(golden);
+      withReservedBits[0] = golden[0] | 0xc0; // set both reserved bits
+      expect(decodeTakV2Payload(withReservedBits, root)).not.toBeNull();
+    });
+
+    it('rejects decompressed output larger than the 4096-byte bomb guard', async () => {
+      // Compress an 8 KB buffer with the real dict-0 compressor (mirroring the
+      // SDK's encode parameters) — a valid frame whose plaintext exceeds the cap.
+      const { Compressor } = await import('zstd-napi');
+      const c = new Compressor();
+      c.setParameters({ compressionLevel: 19, contentSizeFlag: false, checksumFlag: false, dictIDFlag: false, windowLog: 21 });
+      c.loadDictionary(readFileSync(join(process.cwd(), 'takpacket-sdk', 'dictionaries', 'dict_non_aircraft.zstd')));
+      const framed = c.compress(Buffer.alloc(8192, 0x41));
+      const wire = Buffer.concat([Buffer.from([0x00]), framed.subarray(4)]); // strip magic, prepend flags
+      expect(decodeTakV2Payload(wire, root)).toBeNull();
+    });
+  });
+
+  describe('takV2Variant', () => {
+    it('returns undefined for the implicit PLI (no payload_variant)', () => {
+      const decoded = decodeTakV2Payload(readFileSync(join(goldenDir, 'pli_basic.bin')), root);
+      expect(takV2Variant(decoded)).toBeUndefined();
+    });
+
+    it('identifies the chat variant', () => {
+      const decoded = decodeTakV2Payload(readFileSync(join(goldenDir, 'geochat_simple.bin')), root);
+      expect(takV2Variant(decoded)).toBe('chat');
+    });
+
+    it('identifies rich-CoT variants', () => {
+      const cases: Array<[string, string]> = [
+        ['drawing_circle', 'shape'],
+        ['marker_spot', 'marker'],
+        ['emergency_911', 'emergency'],
+        ['casevac', 'casevac'],
+        ['aircraft_adsb', 'aircraft'],
+      ];
+      for (const [fixture, expected] of cases) {
+        const decoded = decodeTakV2Payload(readFileSync(join(goldenDir, `${fixture}.bin`)), root);
+        expect(takV2Variant(decoded), fixture).toBe(expected);
+      }
+    });
+  });
+
+  describe('takV2DictName', () => {
+    it('names the known dictionaries', () => {
+      expect(takV2DictName(0)).toBe('non-aircraft');
+      expect(takV2DictName(1)).toBe('aircraft');
+      expect(takV2DictName(16)).toBe('unknown dict 16');
+    });
+  });
+});

--- a/src/server/takV2Decoder.ts
+++ b/src/server/takV2Decoder.ts
@@ -31,8 +31,24 @@ import { logger } from '../utils/logger.js';
 /** Flags value meaning "body is raw TAKPacketV2 protobuf, no zstd". */
 export const TAK_V2_UNCOMPRESSED = 0xff;
 
-/** Decompression-bomb guard, matching the TAKPacket-SDK decoder limit. */
+/**
+ * Decompression-bomb guard, matching the TAKPacket-SDK decoder limit.
+ * Note this is checked AFTER decompression (zstd-napi's one-shot API has no
+ * max-output parameter), so the real pre-decompression bound is
+ * MAX_WIRE_PAYLOAD below: a ≤237-byte zstd frame can expand to at most a few
+ * MB (RLE blocks emit ≤128 KB per ~4-byte block), so the worst-case cost of
+ * a malicious frame is a transient single-digit-MB allocation that this
+ * guard then drops — not an unbounded one.
+ */
 const MAX_DECOMPRESSED_SIZE = 4096;
+
+/**
+ * ATAK V2 wire payloads are LoRa-MTU-bounded (≤237 bytes, WIRE_FORMAT.md §2).
+ * Reject anything larger before decompressing — it cannot be a legitimate
+ * packet, and this caps the decompression-bomb input surface. Slightly
+ * generous to tolerate any envelope slop.
+ */
+const MAX_WIRE_PAYLOAD = 256;
 
 /** 4-byte zstd frame magic, stripped on the wire and re-prepended here. */
 const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd]);
@@ -61,6 +77,10 @@ interface ZstdDecompressor {
   setParameters(params: { windowLogMax?: number }): void;
 }
 
+// Module-level caches, shared across all packets on Node's single-threaded
+// event loop (decompress() is a synchronous one-shot call, so no interleaving
+// is possible). If decoding ever moves onto worker threads, give each thread
+// its own Decompressor instances — zstd contexts are not thread-safe.
 let zstdModuleFailed = false;
 const decompressors = new Map<number, ZstdDecompressor | null>();
 
@@ -125,6 +145,10 @@ function getDecompressor(dictId: number): ZstdDecompressor | null {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 protobufjs decode() output has no generated TS type, matching the port-72 convention
 export function decodeTakV2Payload(payload: Uint8Array, root: protobuf.Root): any | null {
   if (!payload || payload.length < 2) return null;
+  if (payload.length > MAX_WIRE_PAYLOAD) {
+    logger.debug(`⚠️ ATAK V2: wire payload ${payload.length} bytes exceeds the ${MAX_WIRE_PAYLOAD}-byte LoRa MTU bound; dropping`);
+    return null;
+  }
 
   const flags = payload[0];
   const body = payload.subarray(1);
@@ -137,7 +161,7 @@ export function decodeTakV2Payload(payload: Uint8Array, root: protobuf.Root): an
     const dec = getDecompressor(dictId);
     if (!dec) return null;
     try {
-      protobufBytes = dec.decompress(Buffer.concat([ZSTD_MAGIC, Buffer.from(body)]));
+      protobufBytes = dec.decompress(Buffer.concat([ZSTD_MAGIC, body]));
     } catch (error) {
       logger.debug(`⚠️ ATAK V2: zstd decompression failed (dict ${dictId}, ${body.length} bytes):`, (error as Error).message);
       return null;
@@ -173,6 +197,11 @@ export function decodeTakV2Payload(payload: Uint8Array, root: protobuf.Root): an
 export function takV2Variant(tak: any): string | undefined {
   if (!tak || typeof tak !== 'object') return undefined;
   if (typeof tak.payloadVariant === 'string') return tak.payloadVariant;
+  // Multi-word members appear twice (camelCase + snake_case) because the
+  // shape may be a protobufjs Message (camelCase) or a plain/toObject shape
+  // that kept wire naming; the snake_case hits are normalized to camelCase on
+  // return below. A future multi-word variant needs BOTH an entry here and a
+  // normalization case.
   const variants = [
     'chat', 'aircraft', 'rawDetail', 'raw_detail', 'shape', 'marker', 'rab',
     'route', 'casevac', 'emergency', 'task', 'taktalk', 'taktalkRoom', 'taktalk_room',

--- a/src/server/takV2Decoder.ts
+++ b/src/server/takV2Decoder.ts
@@ -1,0 +1,194 @@
+/**
+ * ATAK V2 wire decoder (PortNum 78 / ATAK_PLUGIN_V2) — issue #4317.
+ *
+ * Wire format (see takpacket-sdk/WIRE_FORMAT.md):
+ *   [1 flags byte][body]
+ * Flags bits 0–5 select a shared zstd dictionary (bits 6–7 reserved, ignored).
+ * The body is a zstd frame whose 4-byte magic (28 B5 2F FD) was stripped on
+ * encode — it must be re-prepended before decompression. Flags 0xFF means the
+ * body is a raw, uncompressed TAKPacketV2 protobuf (skip-compress path /
+ * TAK_TRACKER devices that cannot compress).
+ *
+ * The dictionaries are consumed as runtime data files from the
+ * `takpacket-sdk/` git submodule (meshtastic/TAKPacket-SDK, GPL-3.0) — the
+ * same posture as the GPL-3.0 `protobufs/` submodule whose .proto files are
+ * loaded at runtime. No SDK code is compiled into MeshMonitor; this decoder
+ * is written against the public wire spec.
+ *
+ * Firmware never touches V2 (no transcode, no zstd) — the raw wire payload
+ * arrives at TCP clients as-is, so decompression happens here.
+ *
+ * All failure modes (missing/unbuildable zstd-napi native module, missing
+ * dictionary files, corrupt frames, oversized output) degrade to `null`,
+ * which callers surface as the pre-#4317 "not decoded" behavior.
+ */
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import type * as protobuf from 'protobufjs';
+import { logger } from '../utils/logger.js';
+
+/** Flags value meaning "body is raw TAKPacketV2 protobuf, no zstd". */
+export const TAK_V2_UNCOMPRESSED = 0xff;
+
+/** Decompression-bomb guard, matching the TAKPacket-SDK decoder limit. */
+const MAX_DECOMPRESSED_SIZE = 4096;
+
+/** 4-byte zstd frame magic, stripped on the wire and re-prepended here. */
+const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd]);
+
+const DICT_FILES: Record<number, string> = {
+  0: 'dict_non_aircraft.zstd',
+  1: 'dict_aircraft.zstd',
+};
+
+const DICT_NAMES: Record<number, string> = {
+  0: 'non-aircraft',
+  1: 'aircraft',
+};
+
+/** Human label for a dict ID, for Packet Monitor previews. */
+export function takV2DictName(dictId: number): string {
+  return DICT_NAMES[dictId] ?? `unknown dict ${dictId}`;
+}
+
+// Minimal structural type for zstd-napi's Decompressor — the module is
+// loaded lazily via createRequire (native addon; load failure must degrade,
+// not crash the receive path), so its types can't be imported statically.
+interface ZstdDecompressor {
+  decompress(buffer: Uint8Array): Buffer;
+  loadDictionary(data: Uint8Array): void;
+  setParameters(params: { windowLogMax?: number }): void;
+}
+
+let zstdModuleFailed = false;
+const decompressors = new Map<number, ZstdDecompressor | null>();
+
+/** Base directory of the TAKPacket-SDK submodule (dictionaries live below it). */
+function dictionaryDir(): string {
+  // cwd-relative like protobufLoader.ts resolves the protobufs submodule.
+  return path.join(process.cwd(), 'takpacket-sdk', 'dictionaries');
+}
+
+/**
+ * Lazily construct (and cache) the dictionary-loaded decompressor for a dict
+ * ID. Returns null (cached) when the native module or dictionary file is
+ * unavailable — each failure is warned once, not per-packet.
+ */
+function getDecompressor(dictId: number): ZstdDecompressor | null {
+  if (decompressors.has(dictId)) return decompressors.get(dictId) ?? null;
+  if (zstdModuleFailed) return null;
+
+  const dictFile = DICT_FILES[dictId];
+  if (!dictFile) {
+    // Reserved/unknown dictionary ID — cache the miss so we don't re-log.
+    logger.warn(`⚠️ ATAK V2: unknown zstd dictionary ID ${dictId}; packets with this ID will not be decoded`);
+    decompressors.set(dictId, null);
+    return null;
+  }
+
+  let DecompressorCtor: new () => ZstdDecompressor;
+  try {
+    const require = createRequire(import.meta.url);
+    DecompressorCtor = require('zstd-napi').Decompressor;
+  } catch (error) {
+    zstdModuleFailed = true;
+    logger.warn('⚠️ ATAK V2: zstd-napi native module unavailable; V2 packets will not be decoded:', (error as Error).message);
+    return null;
+  }
+
+  try {
+    const dictPath = path.join(dictionaryDir(), dictFile);
+    const dict = fs.readFileSync(dictPath);
+    const dec = new DecompressorCtor();
+    // Parameters MUST be set before loadDictionary — zstd digests the dict
+    // under the current parameters, and setting them afterwards silently
+    // resets the digested dictionary (see TAKPacket-SDK TakCompressor).
+    // windowLogMax 27 covers frames from peer bindings that auto-size their
+    // window to the 512 KB dictionary.
+    dec.setParameters({ windowLogMax: 27 });
+    dec.loadDictionary(dict);
+    decompressors.set(dictId, dec);
+    return dec;
+  } catch (error) {
+    logger.warn(`⚠️ ATAK V2: failed to load zstd dictionary '${dictFile}' (is the takpacket-sdk submodule initialized?):`, (error as Error).message);
+    decompressors.set(dictId, null);
+    return null;
+  }
+}
+
+/**
+ * Decode an ATAK V2 wire payload into a TAKPacketV2 protobuf message.
+ * Returns null on any failure (caller falls back to the raw payload,
+ * matching processPayload's convention for undecodable ports).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 protobufjs decode() output has no generated TS type, matching the port-72 convention
+export function decodeTakV2Payload(payload: Uint8Array, root: protobuf.Root): any | null {
+  if (!payload || payload.length < 2) return null;
+
+  const flags = payload[0];
+  const body = payload.subarray(1);
+
+  let protobufBytes: Uint8Array;
+  if (flags === TAK_V2_UNCOMPRESSED) {
+    protobufBytes = body;
+  } else {
+    const dictId = flags & 0x3f; // bits 6–7 reserved — receivers ignore them
+    const dec = getDecompressor(dictId);
+    if (!dec) return null;
+    try {
+      protobufBytes = dec.decompress(Buffer.concat([ZSTD_MAGIC, Buffer.from(body)]));
+    } catch (error) {
+      logger.debug(`⚠️ ATAK V2: zstd decompression failed (dict ${dictId}, ${body.length} bytes):`, (error as Error).message);
+      return null;
+    }
+  }
+
+  if (protobufBytes.length > MAX_DECOMPRESSED_SIZE) {
+    logger.warn(`⚠️ ATAK V2: decompressed size ${protobufBytes.length} exceeds ${MAX_DECOMPRESSED_SIZE}-byte limit; dropping`);
+    return null;
+  }
+
+  try {
+    const TAKPacketV2 = root.lookupType('meshtastic.TAKPacketV2');
+    return TAKPacketV2.decode(protobufBytes);
+  } catch (error) {
+    logger.debug('⚠️ ATAK V2: TAKPacketV2 protobuf decode failed:', (error as Error).message);
+    return null;
+  }
+}
+
+/**
+ * Names the payload_variant oneof member set on a decoded TAKPacketV2, or
+ * undefined for the implicit-PLI case (no variant set = position report).
+ *
+ * Prefers protobufjs's virtual oneof getter (`payloadVariant`); falls back
+ * to OWN-property checks for plain-object shapes (tests, toObject output).
+ * Own-property semantics matter: protobufjs message prototypes carry field
+ * defaults (empty Buffer for `raw_detail`, etc.), so a plain `tak[v]`
+ * truthiness read through the prototype chain would misreport every packet
+ * as `rawDetail`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4317 untyped protobufjs decode() output, matching the port-72 convention
+export function takV2Variant(tak: any): string | undefined {
+  if (!tak || typeof tak !== 'object') return undefined;
+  if (typeof tak.payloadVariant === 'string') return tak.payloadVariant;
+  const variants = [
+    'chat', 'aircraft', 'rawDetail', 'raw_detail', 'shape', 'marker', 'rab',
+    'route', 'casevac', 'emergency', 'task', 'taktalk', 'taktalkRoom', 'taktalk_room',
+  ];
+  for (const v of variants) {
+    if (Object.prototype.hasOwnProperty.call(tak, v) && tak[v] !== undefined && tak[v] !== null) {
+      if (v === 'raw_detail') return 'rawDetail';
+      if (v === 'taktalk_room') return 'taktalkRoom';
+      return v;
+    }
+  }
+  return undefined;
+}
+
+/** Test seam: clears cached decompressors / module-failure latch. */
+export function resetTakV2DecoderForTests(): void {
+  decompressors.clear();
+  zstdModuleFailed = false;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       '**/.paperclip/**',
+      'takpacket-sdk/**', // git submodule — has its own vitest suite (#4317)
     ],
     env: {
       DATABASE_PATH: ':memory:',


### PR DESCRIPTION
## Summary

Implements the outcome of the #4317 spike: full decode of `ATAK_PLUGIN_V2` (portnum 78) `TAKPacketV2` packets, which firmware forwards raw (`[1 flags byte][zstd body]`) to TCP clients.

### How

- **`takpacket-sdk/` git submodule** (meshtastic/TAKPacket-SDK, pinned `247bc52`) vendors the two shared zstd dictionaries (`dict_non_aircraft.zstd` 512 KB / `dict_aircraft.zstd` 4 KB) as **runtime data files** — the exact posture of our GPL-3.0 `protobufs/` submodule (loaded at runtime, shipped in the image). No SDK code is compiled into MeshMonitor; the decoder is written against the published wire spec (`takpacket-sdk/WIRE_FORMAT.md`).
- **`src/server/takV2Decoder.ts`**: flags parsing (bits 0–5 dict ID, reserved bits masked), `0xFF` uncompressed path, 4-byte zstd magic re-prepend, `windowLogMax: 27` set before dictionary load, 4096-byte decompression-bomb guard. Uses **`zstd-napi`** (Apache-2.0) since Node's built-in zstd has no dictionary support. Every failure mode (missing submodule, unbuildable native module, corrupt frame, unknown/reserved dict ID) degrades to the previous labeled-but-undecoded behavior.
- **Pipeline wiring**, mirroring the V1 (port 72) path:
  - `processPayload` port-78 case → decoded `TAKPacketV2` (raw payload on fallback)
  - `formatTakV2Preview` variant-labeled Packet Monitor previews; decoded JSON in the detail view; undecoded packets now name the dictionary (`[ATAK V2, non-aircraft, 87 bytes (not decoded)]`)
  - `processTakV2Packet`: **implicit PLI** → `atak_contacts` upsert (V2 `uid` preferred for identity; wire units normalized: speed cm/s → m/s, course deg×100 → deg, altitude `9999999` sentinel dropped) → flows to maps + CoT feed automatically; **GeoChat** → Messages row on portnum 78 (receipts skipped; `DM_CHAT_PORTNUMS` + push-notification gate extended); **rich-CoT variants** (shapes/markers/routes/rab/casevac/emergency/task/TAKTALK/aircraft) stay Packet-Monitor-only this phase.
- **Dockerfile** ships `takpacket-sdk/dictionaries` with a fail-fast submodule check; CI checkouts and the LXC build already use recursive submodule init.
- `eslint.config.mjs` / `vitest.config.ts` exclude the submodule (it carries its own toolchain).

### Licensing note

The dictionaries are GPL-3.0 artifacts consumed as runtime data, identical in kind to the GPL-3.0 `.proto` files we already vendor and ship. `zstd-napi` is Apache-2.0. Details in the spike write-up: https://github.com/Yeraze/meshmonitor/issues/4317#issuecomment-5070345215

### Tests

- `takV2Decoder.test.ts` decodes **all 47 upstream golden wire fixtures** and asserts byte-fidelity against the SDK's reference protobufs (both dictionaries covered), plus uncompressed, unknown-dict, corrupt-frame, reserved-bits, truncation, and decompression-bomb cases.
- Preview formatter, `buildContactRowV2` unit normalization, and manager persistence suites (contact upsert, GeoChat row, receipts, decode-fallback, DB-failure swallow).
- Full suite: **10,712 passed / 0 failed** (skips are the PG/MySQL container suites; no schema changes here). `lint:ci` ratchet clean, typecheck clean.

### Follow-ups (not this PR)

- Map/feed surfaces for rich-CoT variants (shapes, routes, markers, emergency)
- Optional: petition upstream to permissively relicense the dictionary artifacts

Closes #4317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e4dtLyWeYJYJ7SbgFvGG1