### PR TITLE
feat(mqtt): configurable downlink hop_limit override on the embedded broker (#4081)

### DIFF
--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -25,7 +25,7 @@ A self-contained MQTT broker, backed by [Aedes](https://github.com/moscajs/aedes
 - Listens on `0.0.0.0:<port>` (configurable; defaults to the IANA-registered MQTT port `1883`).
 - Authenticates every CONNECT with a single shared username/password pair (default-deny: connections without configured credentials are rejected).
 - Decodes [`ServiceEnvelope`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mqtt.proto) packets from any client that publishes under its `rootTopic` (default `msh`), and ingests decodable payloads (NodeInfo, Position, TextMessage, Telemetry) into the database under this source's `sourceId`. Other clients subscribed to the broker still see the raw byte-for-byte publish, so devices can fan out to each other over MQTT just like they would on a public broker.
-- Optionally clamps `hop_limit` to `0` on every Meshtastic packet it delivers to a connected client ("Zero-hop injection" — see below), matching `mqtt.meshtastic.org`'s behavior so MQTT-bridged packets don't trigger RF re-broadcasts.
+- Optionally rewrites `hop_limit` on every Meshtastic packet it delivers to a connected client ("Override hop limit on delivery" — see below). The usual setting is `0`, matching `mqtt.meshtastic.org`'s behavior so MQTT-bridged packets don't trigger RF re-broadcasts.
 - Generates a synthetic gateway identity (`nodeNum`, `!nodeId`, longName, shortName) at create time so its publishes look like they're coming from a real node to upstream brokers.
 
 **When to use a broker**
@@ -93,7 +93,7 @@ The field is stored in the bridge's `config.mode` JSON field; omitting it (or st
 | **Topic rewriting (cross-root bridging)?** | No | **Yes** — `downlinkTopicRewrite` + `uplinkTopicRewrite` ([details](#topic-rewriting)) | No (requires parent broker) |
 | **Server-side ingestion of decoded packets?** | Yes — under broker `sourceId` | Yes — under bridge `sourceId` (downlink) | Yes — under bridge `sourceId` (downlink) |
 | **Echo suppression (no feedback loops)?** | n/a | Yes (60s `topic+packetId` cache) | Yes |
-| **Zero-hop injection toggle?** | Yes ([details](#zero-hop-injection)) | n/a | n/a |
+| **Hop-limit override on delivery?** | Yes, `0`–`7` ([details](#zero-hop-injection)) | n/a | n/a |
 | **Synthetic gateway identity for outbound publishes?** | Yes (auto-generated at create) | Inherited from parent broker | n/a (no outbound until used as proxy target) |
 | **Default-deny authentication on the listener?** | Yes | n/a | n/a |
 | **Can serve as a `mqttLink` client-proxy target?** | Yes | Yes | **Yes** — primary use case |
@@ -135,7 +135,7 @@ In **Dashboard → Sources → Add Source**, pick **Embedded MQTT Broker (device
 | Listener port | Default `1883` ([IANA-registered MQTT port](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=mqtt)) |
 | Username / Password | Shared credential for all clients |
 | Root topic | Default `msh` — must match what your devices publish under |
-| Zero-hop injection | Off by default. When on, the broker clamps `hop_limit` to `0` on every Meshtastic packet it delivers to a connected device — matching the behavior of [Meshtastic's public broker](https://meshtastic.org/docs/software/integrations/mqtt/). See [Zero-hop injection](#zero-hop-injection) below for when to use it. |
+| Override hop limit on delivery | Off by default. When on, pick a value `0`–`7`; the broker rewrites `hop_limit` to it on every Meshtastic packet it delivers to a connected device. `0` (zero-hop injection) matches the behavior of [Meshtastic's public broker](https://meshtastic.org/docs/software/integrations/mqtt/); nonzero values deliberately let bridged packets re-flood over RF. See [Zero-hop injection](#zero-hop-injection) below for when to use it. |
 
 Save. MeshMonitor will start the broker; you'll see `MQTT broker listening on 0.0.0.0:1883` in the container logs and a new source card in the sidebar.
 
@@ -230,7 +230,7 @@ uplinkTopicRewrite:
   to:   msh/US/TX        # foreign root — what Houston subscribers see
 ```
 
-4. Optionally pair with a **geographic bounding box** in the downlink filter to drop TX traffic from outside the area you care about, and **Zero-hop injection** on the broker to keep the bridged packets from triggering extra RF hops.
+4. Optionally pair with a **geographic bounding box** in the downlink filter to drop TX traffic from outside the area you care about, and a **hop-limit override of `0`** on the broker to keep the bridged packets from triggering extra RF hops.
 
 Filters run on the original (pre-rewrite) topic; the rewrite only changes what gets published. Ingestion records and the bridge's `local-packet` event also use the original topic, so dashboards stay accurate.
 
@@ -243,7 +243,7 @@ Echo suppression is keyed on the **post-rewrite** topic — so an inbound TX pac
 ::: warning Read before deploying
 - **PSKs must match.** Topic rewriting moves bytes, not encryption. If the two meshes use different channel PSKs, the relayed packets arrive at devices on the other side as undecodable noise.
 - **Filter the firehose first.** Without a topic block-list, channel allow-list, portnum allow-list, or **geographic bounding box** in the downlink filter, dropping the entire `msh/US/TX/#` into a local mesh can saturate RF.
-- **Pair with Zero-hop injection** on the broker. Without it, inbound foreign-mesh packets arrive carrying their original `hop_limit` and devices on the receiving side will re-broadcast them over RF — re-flooding the foreign mesh's traffic across your local airwaves.
+- **Pair with a hop-limit override of `0`** on the broker. Without it, inbound foreign-mesh packets arrive carrying their original `hop_limit` and devices on the receiving side will re-broadcast them over RF — re-flooding the foreign mesh's traffic across your local airwaves. Setting a *nonzero* override here does that on purpose; don't.
 - **Standalone bridges cannot rewrite.** A bridge without a parent broker has no parent-broker republish path (downlink) and no `local-packet` event source (uplink), so rewriting would silently do nothing. The validator rejects rewrite fields on standalone bridges.
 - **No wildcards.** `from` / `to` are literal prefixes only. `msh/US/+` is rejected by the validator.
 - **Single rule per direction.** v1 supports one `{from, to}` per direction. Folding multiple foreign roots into one local root (`msh/US/TX/* → msh/US/LA/*` AND `msh/CA/QC/* → msh/US/LA/*`) would need separate bridges today.
@@ -251,25 +251,37 @@ Echo suppression is keyed on the **post-rewrite** topic — so an inbound TX pac
 
 ## Zero-hop injection
 
-::: tip Added in 4.6.3
-The **Zero-hop injection** toggle on the broker source ships in 4.6.3 ([issue #3084](https://github.com/Yeraze/meshmonitor/issues/3084)).
+::: tip Added in 4.6.3, extended in 4.14
+The **Zero-hop injection** toggle on the broker source ships in 4.6.3 ([issue #3084](https://github.com/Yeraze/meshmonitor/issues/3084)). In 4.14 it became a full **hop-limit override** with a configurable `0`–`7` value ([issue #4081](https://github.com/Yeraze/meshmonitor/issues/4081)) — `0` is the original zero-hop behavior and remains the recommended setting.
 :::
 
 Meshtastic's public broker at `mqtt.meshtastic.org` overwrites the `hop_limit` field on every packet it re-publishes to its MQTT clients, setting it to `0`. Devices that receive a packet via MQTT therefore see "no hops remaining" and skip the RF re-broadcast — the firmware enforces a max of 7 hops (10 on older firmware), so without this clamp an MQTT-bridged packet can flood several RF rings before dying out.
 
-If you run a private broker and bridge it to public upstreams, you may want the same behavior. **Zero-hop injection** is an opt-in toggle on the `mqtt_broker` source that does exactly this:
+If you run a private broker and bridge it to public upstreams, you may want the same behavior. **Override hop limit on delivery** is an opt-in setting on the `mqtt_broker` source that does exactly this:
 
-- **Disabled (default)** — packets are forwarded byte-for-byte. Use this for fully private setups where you actually want MQTT-bridged packets to take additional RF hops (small isolated mesh, deliberate fan-out).
-- **Enabled** — the broker decodes each Meshtastic `ServiceEnvelope` it delivers to a connected client, clamps `hop_limit` to `0`, and re-encodes. `hop_start` is preserved so receivers can still compute "how far has this travelled". Mirrors Meshtastic's public broker so private deployments behave the same way.
+- **Disabled (default)** — packets are forwarded byte-for-byte. Use this for fully private setups where you actually want MQTT-bridged packets to take whatever RF hops their original `hop_limit` allows (small isolated mesh, deliberate fan-out).
+- **Enabled with a value of `0`** — the broker decodes each Meshtastic `ServiceEnvelope` it delivers to a connected client, clamps `hop_limit` to `0`, and re-encodes. Mirrors Meshtastic's public broker so private deployments behave the same way. This is what the old "Zero-hop injection" checkbox did, and existing broker sources keep this behavior with no change on your part.
+- **Enabled with a value of `1`–`7`** — the same rewrite, but to a chosen nonzero value. See the warning below before using this.
+
+`hop_start` is never modified, whatever the override, so receivers can still compute "how far has this travelled" from `hop_start - hop_limit`.
+
+### Nonzero overrides: read this first
+
+::: warning A nonzero hop limit re-floods your local mesh
+Packets arriving over MQTT may have originated on a physically distant, completely unrelated mesh. With a nonzero override, **every node in RF range rebroadcasts them, up to that many hops**. On a busy mesh or a broker bridged to a public upstream, this is a real airtime and flood risk.
+
+MeshMonitor isn't bound by Meshtastic LLC's public-broker zero-hop philosophy, so the option exists — but treat it as an advanced setting for deliberately fanning MQTT traffic into a small, private, low-traffic mesh, not as a general-purpose knob.
+:::
 
 Implementation notes:
 
-- The clamp only applies to packets the broker **delivers to its MQTT subscribers** (devices, sidecars, anything that connected to your `mqtt_broker` listener). The original `hop_limit` is preserved in:
+- The rewrite only applies to packets the broker **delivers to its MQTT subscribers** (devices, sidecars, anything that connected to your `mqtt_broker` listener). The original `hop_limit` is preserved in:
   - The MeshMonitor database (so hop diagnostics stay accurate)
   - The payload re-published upstream via any attached `mqtt_bridge` (so the next broker in the chain sees the original value)
-- Topics outside the broker's `rootTopic` (e.g. non-Meshtastic publishes), non-decodable payloads, and packets that already have `hop_limit == 0` are passed through unchanged.
+- Topics outside the broker's `rootTopic` (e.g. non-Meshtastic publishes), non-decodable payloads, and packets that already sit at the target value are passed through unchanged.
+- The stored config field is `downlinkHopLimitOverride` (integer, `0`–`7`; `hop_limit` is a 3-bit protocol field, so `7` is the max). Sources saved before 4.14 carry the older boolean `zeroHopInjection` instead; it is still honored and means the same thing as `downlinkHopLimitOverride: 0`. Editing and saving such a source migrates it to the numeric field.
 
-If you're seeing your private broker flood the mesh after attaching a bridge to a public upstream, this toggle is almost certainly what you want.
+If you're seeing your private broker flood the mesh after attaching a bridge to a public upstream, enabling this with a value of `0` is almost certainly what you want.
 
 ## Comparison: embedded broker vs MQTT proxy sidecar vs node's built-in MQTT
 
@@ -285,7 +297,7 @@ If you're seeing your private broker flood the mesh after attaching a bridge to 
 | **Recovery on broker outage** | Manual node restart | Manual sidecar restart | mqtt.js auto-reconnect with backoff |
 | **Default-deny auth** | Per-device | Per-device | Broker refuses connections without configured username/password |
 | **TLS** | Yes (on device) | Yes (on device + proxy) | **Plain TCP only in v1** (TLS / WSS deferred — track in [#3003](https://github.com/Yeraze/meshmonitor/issues/3003)) |
-| **Zero-hop injection** | n/a (no broker) | n/a (passthrough relay) | **Optional per broker** — clamp `hop_limit` to 0 on delivery to match public-broker behavior ([details](#zero-hop-injection)) |
+| **Zero-hop injection** | n/a (no broker) | n/a (passthrough relay) | **Optional per broker** — rewrite `hop_limit` (0–7) on delivery; 0 matches public-broker behavior ([details](#zero-hop-injection)) |
 | **Operational visibility** | Limited firmware logs | Docker logs | Per-source `packetsIn / packetsIngested / packetsDropped / lastError` in `/api/sources/:id/status` |
 
 ### Plain-English summary

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -39,6 +39,12 @@ import '../styles/dashboard.css';
 import { UiIcon } from '../components/icons';
 
 
+// Protocol max for `hop_limit` (3-bit field). IMPORTANT: this value must match
+// MAX_HOP_LIMIT in src/server/mqttBrokerManager.ts, which the source-save
+// endpoint validates against. Duplicated rather than imported — pages must not
+// pull from src/server.
+const MAX_HOP_LIMIT = 7;
+
 // ---------------------------------------------------------------------------
 // DashboardInner — rendered inside SettingsProvider
 // ---------------------------------------------------------------------------
@@ -149,7 +155,12 @@ function DashboardInner() {
   const [formMqttUsername, setFormMqttUsername] = useState('');
   const [formMqttPassword, setFormMqttPassword] = useState('');
   const [formMqttRootTopic, setFormMqttRootTopic] = useState('msh');
-  const [formMqttZeroHopInjection, setFormMqttZeroHopInjection] = useState(false);
+  // Downlink hop-limit override (#4081). The checkbox is the on/off gate and
+  // the select carries the value 0–7; 0 reproduces the legacy "zero-hop
+  // injection" toggle (#3084), which stored configs may still express as the
+  // boolean `zeroHopInjection`.
+  const [formMqttHopOverrideEnabled, setFormMqttHopOverrideEnabled] = useState(false);
+  const [formMqttHopOverrideValue, setFormMqttHopOverrideValue] = useState(0);
   // Per-bridge topic-rewrite form state, surfaced inside the broker's
   // edit modal so an operator can manage all rewrites for the bridges
   // attached to this broker in one place. Keyed by bridge source id.
@@ -332,7 +343,8 @@ function DashboardInner() {
     setFormMqttUsername('');
     setFormMqttPassword('');
     setFormMqttRootTopic('msh');
-    setFormMqttZeroHopInjection(false);
+    setFormMqttHopOverrideEnabled(false);
+    setFormMqttHopOverrideValue(0);
     setFormMqttBridgeBrokerId('');
     setFormMqttBridgeUrl('');
     setFormMqttBridgeUsername('');
@@ -359,7 +371,16 @@ function DashboardInner() {
       // backend round-trips the existing value when the field stays empty.
       setFormMqttPassword('');
       setFormMqttRootTopic(cfg?.rootTopic ?? 'msh');
-      setFormMqttZeroHopInjection(Boolean(cfg?.zeroHopInjection));
+      // Numeric override wins; fall back to the legacy boolean (= 0) so a
+      // source saved before #4081 still loads with the toggle checked.
+      const storedHopOverride = cfg?.downlinkHopLimitOverride;
+      const hasNumericOverride =
+        typeof storedHopOverride === 'number' &&
+        Number.isInteger(storedHopOverride) &&
+        storedHopOverride >= 0 &&
+        storedHopOverride <= MAX_HOP_LIMIT;
+      setFormMqttHopOverrideEnabled(hasNumericOverride || Boolean(cfg?.zeroHopInjection));
+      setFormMqttHopOverrideValue(hasNumericOverride ? storedHopOverride : 0);
       // Build the per-bridge rewrite form data from every mqtt_bridge
       // source that points at this broker. Empty rewrites are fine —
       // the UI just shows blank inputs.
@@ -466,7 +487,11 @@ function DashboardInner() {
         auth: { username: formMqttUsername.trim(), password: formMqttPassword },
         gateway: { nodeNum, nodeId, longName: formName.trim(), shortName },
         rootTopic: formMqttRootTopic.trim() || 'msh',
-        zeroHopInjection: formMqttZeroHopInjection,
+        // Write only the numeric field (#4081). Dropping the legacy
+        // `zeroHopInjection` boolean is intentional: the PUT replaces the
+        // whole config blob, so an edited source stops carrying two
+        // representations of the same setting.
+        ...(formMqttHopOverrideEnabled ? { downlinkHopLimitOverride: formMqttHopOverrideValue } : {}),
       };
       if (editingSourceId && !formMqttPassword) {
         // Empty password on edit → tell server to keep the existing one.
@@ -1125,22 +1150,50 @@ function DashboardInner() {
                 <label className="dashboard-form-field" style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 8 }}>
                   <input
                     type="checkbox"
-                    checked={formMqttZeroHopInjection}
-                    onChange={(e) => setFormMqttZeroHopInjection(e.target.checked)}
+                    checked={formMqttHopOverrideEnabled}
+                    onChange={(e) => setFormMqttHopOverrideEnabled(e.target.checked)}
                     style={{ marginTop: 3 }}
                   />
                   <span>
                     <span className="dashboard-form-label" style={{ display: 'block' }}>
-                      {t('source.form.mqtt_zero_hop_injection', 'Zero-hop injection')}
+                      {t('source.form.mqtt_hop_limit_override', 'Override hop limit on delivery')}
                     </span>
                     <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)' }}>
                       {t(
-                        'source.form.mqtt_zero_hop_injection_help',
-                        'Clamp hop_limit to 0 on packets the broker delivers to connected devices, matching the public Meshtastic broker. Prevents MQTT-bridged packets from being rebroadcast over RF.',
+                        'source.form.mqtt_hop_limit_override_help',
+                        'Rewrite hop_limit on packets the broker delivers to connected devices. 0 is zero-hop injection, matching the public Meshtastic broker — it prevents MQTT-bridged packets from being rebroadcast over RF.',
                       )}
                     </span>
                   </span>
                 </label>
+                {formMqttHopOverrideEnabled && (
+                  <label className="dashboard-form-field">
+                    <span className="dashboard-form-label">
+                      {t('source.form.mqtt_hop_limit_value', 'Delivered hop limit')}
+                    </span>
+                    <select
+                      className="dashboard-form-input"
+                      value={formMqttHopOverrideValue}
+                      onChange={(e) => setFormMqttHopOverrideValue(Number(e.target.value))}
+                    >
+                      {Array.from({ length: MAX_HOP_LIMIT + 1 }, (_, n) => (
+                        <option key={n} value={n}>
+                          {n === 0
+                            ? t('source.form.mqtt_hop_limit_zero', '0 — zero-hop (no RF rebroadcast)')
+                            : String(n)}
+                        </option>
+                      ))}
+                    </select>
+                    {formMqttHopOverrideValue > 0 && (
+                      <span style={{ fontSize: 11, color: 'var(--ctp-peach)', marginTop: 4 }}>
+                        {t(
+                          'source.form.mqtt_hop_limit_warning',
+                          'Warning: packets arriving over MQTT may have originated on a distant, unrelated mesh. With a nonzero hop limit, every node in RF range will rebroadcast them up to this many hops — a real airtime and flood risk on a busy mesh.',
+                        )}
+                      </span>
+                    )}
+                  </label>
+                )}
 
                 {/* Per-bridge topic rewrites. Only meaningful when editing
                     an existing broker — a brand-new broker has no bridges

--- a/src/server/mqttBrokerManager.test.ts
+++ b/src/server/mqttBrokerManager.test.ts
@@ -46,7 +46,7 @@ vi.mock('../services/database.js', () => ({
   },
 }));
 
-import { MqttBrokerManager } from './mqttBrokerManager.js';
+import { MqttBrokerManager, resolveDownlinkHopLimit } from './mqttBrokerManager.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import databaseService from '../services/database.js';
 import { PortNum } from './constants/meshtastic.js';
@@ -338,7 +338,7 @@ describe('MqttBrokerManager zero-hop injection', () => {
     }
   });
 
-  async function startManager(opts: { zeroHop: boolean }): Promise<void> {
+  async function startManager(opts: { zeroHop?: boolean; hopOverride?: number }): Promise<void> {
     port = await ephemeralPort();
     manager = new MqttBrokerManager('zhi-broker', 'Zero Hop Broker', {
       listener: { port, host: '127.0.0.1' },
@@ -346,6 +346,7 @@ describe('MqttBrokerManager zero-hop injection', () => {
       gateway: { nodeNum: 0xdeadbeef, nodeId: '!deadbeef', longName: 'MM', shortName: 'MM' },
       rootTopic: 'msh',
       zeroHopInjection: opts.zeroHop,
+      downlinkHopLimitOverride: opts.hopOverride,
     });
     await manager.start();
   }
@@ -480,5 +481,135 @@ describe('MqttBrokerManager zero-hop injection', () => {
 
     const received = await receivedPromise;
     expect(received.equals(garbage)).toBe(true);
+  });
+
+  // --- Configurable downlink hop_limit override (#4081) -------------------
+  //
+  // Same forward-transform seam as zero-hop, but with an arbitrary 0-7 target
+  // instead of a hardcoded 0.
+
+  /** Publish `payload` and resolve with what a `msh/#` subscriber receives. */
+  async function roundTrip(payload: Buffer): Promise<Buffer> {
+    subscriber = await connectClient('sub');
+    await new Promise<void>((resolve, reject) => {
+      subscriber!.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    publisher = await connectClient('pub');
+    const receivedPromise = new Promise<Buffer>((resolve) => {
+      subscriber!.once('message', (_topic, p) => resolve(p));
+    });
+    await new Promise<void>((resolve, reject) => {
+      publisher!.publish('msh/US/2/e/LongFast/!12345678', payload, { qos: 0 }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+    });
+    return receivedPromise;
+  }
+
+  it('rewrites hop_limit to a nonzero override on delivery', async () => {
+    await startManager({ hopOverride: 7 });
+
+    const received = await roundTrip(buildEnvelopeWithHopLimit(3));
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(received);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.packet.hopLimit).toBe(7);
+    // hop_start still reflects what the originator set — the override must not
+    // corrupt the hops-taken math consumers derive from hop_start - hop_limit.
+    expect(decoded!.packet.hopStart).toBe(3);
+  });
+
+  it('raises a zero hop_limit packet to the override (proto3 omits the field)', async () => {
+    await startManager({ hopOverride: 5 });
+
+    // hopLimit 0 is omitted on the wire, so the transform sees `undefined`.
+    const original = buildEnvelopeWithHopLimit(0);
+    const received = await roundTrip(original);
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(received);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.packet.hopLimit).toBe(5);
+  });
+
+  it('forwards byte-for-byte when the packet already sits at the override', async () => {
+    await startManager({ hopOverride: 3 });
+
+    const original = buildEnvelopeWithHopLimit(3);
+    const received = await roundTrip(original);
+    expect(received.equals(original)).toBe(true);
+  });
+
+  it('honors an explicit override of 0 exactly like the legacy zero-hop toggle', async () => {
+    await startManager({ hopOverride: 0 });
+
+    const received = await roundTrip(buildEnvelopeWithHopLimit(4));
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(received);
+    expect(decoded!.packet.hopLimit ?? 0).toBe(0);
+    expect(decoded!.packet.hopStart).toBe(4);
+  });
+
+  it('lets a numeric override win over a stale legacy zeroHopInjection flag', async () => {
+    await startManager({ zeroHop: true, hopOverride: 6 });
+
+    const received = await roundTrip(buildEnvelopeWithHopLimit(2));
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(received);
+    expect(decoded!.packet.hopLimit).toBe(6);
+  });
+
+  it('leaves the local-packet event on the original payload with a nonzero override', async () => {
+    await startManager({ hopOverride: 7 });
+
+    publisher = await connectClient('pub');
+    const original = buildEnvelopeWithHopLimit(2);
+
+    const localPacketPromise = new Promise<Buffer>((resolve) => {
+      manager!.once('local-packet', (p: { payload: Buffer }) => resolve(p.payload));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      publisher!.publish('msh/US/2/e/LongFast/!12345678', original, { qos: 0 }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+    });
+
+    const captured = await localPacketPromise;
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(captured);
+    expect(decoded!.packet.hopLimit).toBe(2);
+  });
+});
+
+describe('resolveDownlinkHopLimit', () => {
+  const base = {
+    listener: { port: 1883 },
+    auth: { username: 'u', password: 'p' },
+    gateway: { nodeNum: 1, nodeId: '!1', longName: 'l', shortName: 's' },
+  };
+
+  it('returns null when nothing is configured (pass-through)', () => {
+    expect(resolveDownlinkHopLimit({ ...base })).toBeNull();
+    expect(resolveDownlinkHopLimit({ ...base, zeroHopInjection: false })).toBeNull();
+  });
+
+  it('maps the legacy zeroHopInjection boolean to 0', () => {
+    expect(resolveDownlinkHopLimit({ ...base, zeroHopInjection: true })).toBe(0);
+  });
+
+  it('returns the numeric override across the whole 0-7 range', () => {
+    for (let n = 0; n <= 7; n++) {
+      expect(resolveDownlinkHopLimit({ ...base, downlinkHopLimitOverride: n })).toBe(n);
+    }
+  });
+
+  it('prefers the numeric override over the legacy boolean', () => {
+    expect(
+      resolveDownlinkHopLimit({ ...base, zeroHopInjection: true, downlinkHopLimitOverride: 4 }),
+    ).toBe(4);
+  });
+
+  it('ignores out-of-range or non-integer overrides and falls back', () => {
+    for (const bad of [-1, 8, 3.5, NaN]) {
+      expect(resolveDownlinkHopLimit({ ...base, downlinkHopLimitOverride: bad })).toBeNull();
+      expect(
+        resolveDownlinkHopLimit({ ...base, zeroHopInjection: true, downlinkHopLimitOverride: bad }),
+      ).toBe(0);
+    }
   });
 });

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -33,16 +33,49 @@ export interface MqttBrokerSourceConfig {
   };
   rootTopic?: string;
   /**
-   * When true, clamp `hop_limit` to 0 on Meshtastic ServiceEnvelopes the
-   * broker forwards back to its connected MQTT clients (issue #3084).
-   * Mirrors how Meshtastic's public broker behaves — devices receiving an
-   * MQTT-bridged packet won't re-flood it over RF. The transform runs on
-   * delivery to each subscriber; the original payload still drives our
-   * ingestion and uplink-bridge paths, so persisted hop diagnostics and
-   * upstream re-publishes stay accurate. Defaults to false to preserve
-   * the existing pass-through behavior for private-broker setups.
+   * Legacy zero-hop toggle (issue #3084). Superseded by
+   * `downlinkHopLimitOverride` (#4081) but still honored so stored configs
+   * written before 4.14 keep clamping to 0 without a data migration:
+   * `true` with no numeric override is equivalent to
+   * `downlinkHopLimitOverride: 0`. The override always wins when both are
+   * present. New saves from the UI write only the numeric field, so a source
+   * migrates itself the next time it is edited.
    */
   zeroHopInjection?: boolean;
+  /**
+   * When set (0–7), rewrite `hop_limit` to this value on Meshtastic
+   * ServiceEnvelopes the broker forwards back to its connected MQTT clients
+   * (issue #4081). `0` reproduces the public Meshtastic broker's behavior —
+   * devices receiving an MQTT-bridged packet won't re-flood it over RF. A
+   * nonzero value deliberately does the opposite: packets pulled in from
+   * MQTT get re-injected with that many hops left, so every node in RF range
+   * may rebroadcast them. That is an airtime/flood risk on a busy mesh and
+   * is opt-in for a reason.
+   *
+   * The transform runs on delivery to each subscriber; the original payload
+   * still drives our ingestion and uplink-bridge paths, so persisted hop
+   * diagnostics and upstream re-publishes stay accurate. Undefined (with no
+   * legacy `zeroHopInjection`) means pass through unchanged.
+   */
+  downlinkHopLimitOverride?: number;
+}
+
+/** Protocol max for `hop_limit` — it is a 3-bit field (`HOP_MAX` in firmware). */
+export const MAX_HOP_LIMIT = 7;
+
+/**
+ * Resolve the effective downlink hop-limit override for a broker config, or
+ * null for "pass through unchanged". The numeric `downlinkHopLimitOverride`
+ * wins; the legacy `zeroHopInjection` boolean maps to 0. Out-of-range or
+ * non-integer values are ignored (the route layer rejects them on save, so
+ * this only guards hand-edited or pre-validation configs).
+ */
+export function resolveDownlinkHopLimit(config: MqttBrokerSourceConfig): number | null {
+  const override = config.downlinkHopLimitOverride;
+  if (typeof override === 'number' && Number.isInteger(override) && override >= 0 && override <= MAX_HOP_LIMIT) {
+    return override;
+  }
+  return config.zeroHopInjection ? 0 : null;
 }
 
 export interface MqttBrokerStatus extends SourceStatus {
@@ -103,13 +136,14 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
     if (this.broker) return;
     await bootstrapMqttChannelDatabase(this.sourceId);
     const rootTopicPrefix = (this.config.rootTopic ?? 'msh') + '/';
+    const hopLimitOverride = resolveDownlinkHopLimit(this.config);
     this.broker = new MqttBroker({
       port: this.config.listener.port,
       host: this.config.listener.host,
       auth: this.config.auth,
       brokerId: `meshmonitor-${this.sourceId}`,
-      forwardTransform: this.config.zeroHopInjection
-        ? (topic, payload) => this.applyZeroHop(rootTopicPrefix, topic, payload)
+      forwardTransform: hopLimitOverride !== null
+        ? (topic, payload) => this.applyHopLimitOverride(rootTopicPrefix, topic, payload, hopLimitOverride)
         : undefined,
     });
 
@@ -231,19 +265,30 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
   }
 
   /**
-   * Zero-hop forward transform. Returns a rewritten payload with
-   * `hop_limit = 0` for Meshtastic ServiceEnvelopes on this broker's
-   * root topic, or null to pass the original through. Anything that
-   * isn't a decodable ServiceEnvelope (off-topic, MQTT control, malformed
-   * payload, packet already at zero) falls through unchanged.
+   * Hop-limit forward transform (#3084 zero-hop, generalized in #4081).
+   * Returns a rewritten payload with `hop_limit = hopLimit` for Meshtastic
+   * ServiceEnvelopes on this broker's root topic, or null to pass the
+   * original through. Anything that isn't a decodable ServiceEnvelope
+   * (off-topic, MQTT control, malformed payload, packet already at the
+   * target value) falls through unchanged.
+   *
+   * `hop_start` is deliberately left alone: it records what the originator
+   * set, and rewriting it would corrupt the hop diagnostics every consumer
+   * derives from `hop_start - hop_limit`.
    */
-  private applyZeroHop(rootTopicPrefix: string, topic: string, payload: Buffer): Buffer | null {
+  private applyHopLimitOverride(
+    rootTopicPrefix: string,
+    topic: string,
+    payload: Buffer,
+    hopLimit: number,
+  ): Buffer | null {
     if (!topic.startsWith(rootTopicPrefix)) return null;
     const decoded = meshtasticProtobufService.decodeServiceEnvelope(payload, { quiet: true });
     if (!decoded || !decoded.packet) return null;
     const packet = decoded.packet as { hopLimit?: number; hopStart?: number };
-    if (packet.hopLimit === undefined || packet.hopLimit === 0) return null;
-    packet.hopLimit = 0;
+    // proto3 omits zero on the wire, so an absent field means hop_limit 0.
+    if ((packet.hopLimit ?? 0) === hopLimit) return null;
+    packet.hopLimit = hopLimit;
     const reencoded = meshtasticProtobufService.encodeServiceEnvelope({
       packet: decoded.packet,
       channelId: decoded.channelId,

--- a/src/server/routes/sourceRoutes.hopLimitOverride.test.ts
+++ b/src/server/routes/sourceRoutes.hopLimitOverride.test.ts
@@ -1,0 +1,185 @@
+/**
+ * sourceRoutes — mqtt_broker `downlinkHopLimitOverride` validation (#4081).
+ *
+ * Covers the 0–7 integer gate on both the create and update paths, plus the
+ * absent/null cases (which mean "pass hop_limit through unchanged") and the
+ * legacy `zeroHopInjection` boolean, which stays accepted so pre-#4081
+ * configs round-trip through an edit untouched.
+ *
+ * Uses the real route test harness (real session + real permission SQL), and
+ * creates every source with `enabled: false` so the POST/PUT handlers never
+ * build a live MqttBrokerManager and bind a real TCP listener.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import {
+  createRouteTestApp,
+  type RouteTestHarness,
+} from '../test-helpers/routeTestApp.js';
+
+let harness: RouteTestHarness;
+
+const brokerConfig = (extra: Record<string, unknown> = {}) => ({
+  listener: { port: 21883, host: '127.0.0.1' },
+  auth: { username: 'mm', password: 's3cret' },
+  gateway: { nodeNum: 0x80000001, nodeId: '!80000001', longName: 'MM', shortName: 'MM' },
+  rootTopic: 'msh',
+  ...extra,
+});
+
+beforeEach(async () => {
+  harness = await createRouteTestApp({ mount: (app) => app.use('/', sourceRoutes) });
+});
+
+afterEach(async () => {
+  await harness.db.sources.deleteSource('hop-broker').catch(() => {});
+  await harness.cleanup();
+});
+
+describe('sourceRoutes — mqtt_broker downlinkHopLimitOverride validation', () => {
+  it.each([0, 1, 3, 7])('POST accepts an override of %i', async (value) => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.post('/').send({
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      enabled: false,
+      config: brokerConfig({ downlinkHopLimitOverride: value }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.config.downlinkHopLimitOverride).toBe(value);
+    await harness.db.sources.deleteSource(res.body.id).catch(() => {});
+  });
+
+  it('POST accepts a config with no override at all', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.post('/').send({
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      enabled: false,
+      config: brokerConfig(),
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.config.downlinkHopLimitOverride).toBeUndefined();
+    await harness.db.sources.deleteSource(res.body.id).catch(() => {});
+  });
+
+  it('POST still accepts the legacy zeroHopInjection boolean', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.post('/').send({
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      enabled: false,
+      config: brokerConfig({ zeroHopInjection: true }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.config.zeroHopInjection).toBe(true);
+    await harness.db.sources.deleteSource(res.body.id).catch(() => {});
+  });
+
+  it.each([
+    [8, 'above the 3-bit protocol max'],
+    [-1, 'negative'],
+    [3.5, 'non-integer'],
+    ['3', 'a string'],
+    [true, 'a boolean'],
+  ] as [unknown, string][])('POST rejects an override of %j (%s)', async (value) => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.post('/').send({
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      enabled: false,
+      config: brokerConfig({ downlinkHopLimitOverride: value }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/downlinkHopLimitOverride must be an integer between 0 and 7/);
+  });
+
+  it('PUT accepts a valid override on an existing broker', async () => {
+    await harness.db.sources.createSource({
+      id: 'hop-broker',
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      config: brokerConfig(),
+      enabled: false,
+    });
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent
+      .put('/hop-broker')
+      .send({ config: brokerConfig({ downlinkHopLimitOverride: 6 }) });
+
+    expect(res.status).toBe(200);
+    const stored = await harness.db.sources.getSource('hop-broker');
+    expect((stored!.config as Record<string, unknown>).downlinkHopLimitOverride).toBe(6);
+  });
+
+  it('PUT rejects an out-of-range override and leaves the stored config alone', async () => {
+    await harness.db.sources.createSource({
+      id: 'hop-broker',
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      config: brokerConfig({ downlinkHopLimitOverride: 2 }),
+      enabled: false,
+    });
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent
+      .put('/hop-broker')
+      .send({ config: brokerConfig({ downlinkHopLimitOverride: 9 }) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/downlinkHopLimitOverride must be an integer between 0 and 7/);
+    const stored = await harness.db.sources.getSource('hop-broker');
+    expect((stored!.config as Record<string, unknown>).downlinkHopLimitOverride).toBe(2);
+  });
+
+  it('PUT drops the legacy boolean when the numeric field replaces it', async () => {
+    await harness.db.sources.createSource({
+      id: 'hop-broker',
+      name: 'Hop Broker',
+      type: 'mqtt_broker',
+      config: brokerConfig({ zeroHopInjection: true }),
+      enabled: false,
+    });
+    const agent = await harness.loginAs(harness.admin);
+
+    // Mirrors what the edit form posts after #4081: the numeric field only.
+    const res = await agent
+      .put('/hop-broker')
+      .send({ config: brokerConfig({ downlinkHopLimitOverride: 4 }) });
+
+    expect(res.status).toBe(200);
+    const stored = (await harness.db.sources.getSource('hop-broker'))!.config as Record<string, unknown>;
+    expect(stored.downlinkHopLimitOverride).toBe(4);
+    expect(stored.zeroHopInjection).toBeUndefined();
+  });
+
+  it('does not apply the broker validator to other source types', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    // A bogus hop override on a bridge config is simply ignored — the field
+    // is meaningless there, and rejecting it would be a surprise.
+    const res = await agent.post('/').send({
+      name: 'Bridge',
+      type: 'mqtt_bridge',
+      enabled: false,
+      config: {
+        upstream: { url: 'mqtt://example.invalid:1883' },
+        subscriptions: ['msh/#'],
+        downlinkHopLimitOverride: 99,
+      },
+    });
+
+    expect(res.status).toBe(201);
+    await harness.db.sources.deleteSource(res.body.id).catch(() => {});
+  });
+});

--- a/src/server/routes/sourceRoutes.hopLimitOverride.test.ts
+++ b/src/server/routes/sourceRoutes.hopLimitOverride.test.ts
@@ -163,6 +163,30 @@ describe('sourceRoutes — mqtt_broker downlinkHopLimitOverride validation', () 
     expect(stored.zeroHopInjection).toBeUndefined();
   });
 
+  it('does not apply the broker validator when PUTting a bridge', async () => {
+    // The PUT handler gates on `existing.type`, so a bogus hop override on a
+    // bridge must sail through exactly as it does on POST.
+    await harness.db.sources.createSource({
+      id: 'hop-bridge',
+      name: 'Bridge',
+      type: 'mqtt_bridge',
+      config: { upstream: { url: 'mqtt://example.invalid:1883' }, subscriptions: ['msh/#'] },
+      enabled: false,
+    });
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.put('/hop-bridge').send({
+      config: {
+        upstream: { url: 'mqtt://example.invalid:1883' },
+        subscriptions: ['msh/#'],
+        downlinkHopLimitOverride: 99,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await harness.db.sources.deleteSource('hop-bridge').catch(() => {});
+  });
+
   it('does not apply the broker validator to other source types', async () => {
     const agent = await harness.loginAs(harness.admin);
 

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -9,7 +9,7 @@ import { meshcoreConfigFromSource, ensureMeshCoreManagerStarted } from '../meshc
 import { MeshCoreManager } from '../meshcoreManager.js';
 import { isMeshCoreManager, isMeshtasticManager } from '../sourceManagerTypes.js';
 import { loRaCenterFrequencyMhz, REGION_SHORT_NAME } from '../../utils/loraFrequency.js';
-import { MqttBrokerManager, type MqttBrokerSourceConfig } from '../mqttBrokerManager.js';
+import { MqttBrokerManager, MAX_HOP_LIMIT, type MqttBrokerSourceConfig } from '../mqttBrokerManager.js';
 import { MqttBridgeManager, type MqttBridgeSourceConfig } from '../mqttBridgeManager.js';
 import waypointRoutes from './waypoints.js';
 import { PortNum } from '../constants/meshtastic.js';
@@ -135,6 +135,22 @@ function validateMqttBridgeIgnoreOkToMqtt(config: Record<string, any>): string |
   if (value === undefined || value === null) return null;
   if (typeof value !== 'boolean') {
     return 'mqtt_bridge ignoreOkToMqtt must be a boolean';
+  }
+  return null;
+}
+
+/**
+ * Validate the optional `downlinkHopLimitOverride` on an mqtt_broker config
+ * (#4081). Absent (undefined/null) means "pass hop_limit through unchanged",
+ * which is also what the legacy `zeroHopInjection: false` meant. When
+ * present it must be an integer 0–7 — `hop_limit` is a 3-bit protobuf field,
+ * so anything larger cannot be encoded.
+ */
+function validateMqttBrokerHopLimitOverride(config: Record<string, unknown>): string | null {
+  const value = config?.downlinkHopLimitOverride;
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > MAX_HOP_LIMIT) {
+    return `mqtt_broker downlinkHopLimitOverride must be an integer between 0 and ${MAX_HOP_LIMIT}`;
   }
   return null;
 }
@@ -420,6 +436,12 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
         return res.status(400).json({ error: ignoreOkErr });
       }
     }
+    if (type === 'mqtt_broker') {
+      const hopErr = validateMqttBrokerHopLimitOverride(config ?? {});
+      if (hopErr) {
+        return res.status(400).json({ error: hopErr });
+      }
+    }
     if (!config || typeof config !== 'object') {
       return res.status(400).json({ error: 'config is required and must be an object' });
     }
@@ -550,6 +572,14 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
         const ignoreOkErr = validateMqttBridgeIgnoreOkToMqtt(config);
         if (ignoreOkErr) {
           return res.status(400).json({ error: ignoreOkErr });
+        }
+      }
+
+      // Validate the mqtt_broker downlink hop-limit override (#4081).
+      if (existing.type === 'mqtt_broker') {
+        const hopErr = validateMqttBrokerHopLimitOverride(config);
+        if (hopErr) {
+          return res.status(400).json({ error: hopErr });
         }
       }
 

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -436,14 +436,19 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
         return res.status(400).json({ error: ignoreOkErr });
       }
     }
+    if (!config || typeof config !== 'object') {
+      return res.status(400).json({ error: 'config is required and must be an object' });
+    }
+
+    // Deliberately placed AFTER the config-object guard (unlike the
+    // mqtt_bridge validators above, which predate it and take `config ?? {}`):
+    // the validator then never has to reason about a null config, so adding a
+    // field read to it later can't turn into a TypeError.
     if (type === 'mqtt_broker') {
-      const hopErr = validateMqttBrokerHopLimitOverride(config ?? {});
+      const hopErr = validateMqttBrokerHopLimitOverride(config);
       if (hopErr) {
         return res.status(400).json({ error: hopErr });
       }
-    }
-    if (!config || typeof config !== 'object') {
-      return res.status(400).json({ error: 'config is required and must be an object' });
     }
 
     const vnErr = await validateVirtualNodeConfig(type, config);


### PR DESCRIPTION
Closes #4081.

## Summary

The `mqtt_broker` source could only choose between **zero-hop injection** (#3084) and **byte-for-byte passthrough**. This generalizes that binary toggle into a numeric **0–7 hop-limit override**, so packets pulled in from MQTT can be re-injected onto the local mesh with a chosen number of hops left.

Default stays off — existing deployments are unaffected, and existing broker sources keep clamping to 0.

## Changes

**Backend — `src/server/mqttBrokerManager.ts`**
- New `MqttBrokerSourceConfig.downlinkHopLimitOverride?: number` (0–7; `hop_limit` is a 3-bit protobuf field, so 7 is the max).
- `applyZeroHop()` → `applyHopLimitOverride()`, writing the configured value instead of a hardcoded 0.
- New exported `resolveDownlinkHopLimit(config)`: the numeric field wins, and the legacy `zeroHopInjection` boolean still resolves to `0`. **No data migration needed** — pre-existing configs behave exactly as before.
- A packet whose `hop_limit` is absent on the wire is treated as `0` (proto3 omits zero values). This is what lets a nonzero override actually *raise* the limit; the old code bailed out on `undefined`.
- `hop_start` is deliberately never rewritten, so the `hop_start - hop_limit` diagnostics every consumer derives stay accurate.

**Routes — `src/server/routes/sourceRoutes.ts`**
- `validateMqttBrokerHopLimitOverride()` on both POST and PUT: integer, 0–7, or a 400.

**UI — `src/pages/DashboardPage.tsx`**
- The "Zero-hop injection" checkbox becomes "Override hop limit on delivery" + a 0–7 select (0 labelled as zero-hop).
- Load prefers the numeric field, falls back to the legacy boolean. Save writes **only** the numeric field, so a source migrates itself the next time it is edited.
- Per the issue's item (D), an explicit warning renders whenever the value is nonzero:

  > Packets arriving over MQTT may have originated on a distant, unrelated mesh. With a nonzero hop limit, every node in RF range will rebroadcast them up to this many hops — a real airtime and flood risk on a busy mesh.

**Docs — `docs/features/mqtt-broker.md`**
- Section rewritten for the 0–7 range with a `::: warning` block on the flood/airtime tradeoff. The `#zero-hop-injection` anchor is preserved so existing links still resolve.

## Testing

- 6 new end-to-end broker tests: nonzero rewrite, raise-from-zero (proto3 omitted field), no-op when already at target, explicit 0 matches legacy behavior, numeric override beats a stale legacy boolean, and `local-packet` still carries the original payload.
- New `resolveDownlinkHopLimit` unit block covering the whole 0–7 range, legacy fallback, precedence, and out-of-range/non-integer rejection.
- New `sourceRoutes.hopLimitOverride.test.ts` on the `createRouteTestApp` harness (real session + real permission SQL): POST/PUT accept/reject cases, legacy boolean round-trip, and confirmation that other source types aren't affected.
- Full suite: **10,782 passed, 0 failed** (768 in-repo suite files). PostgreSQL/MySQL suites skipped — no schema or migration changes in this PR.
- `npx tsc --noEmit` clean; `npm run lint:ci` clean (no baseline growth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZtasD4tS76xq2PTDHMA5o