### PR TITLE
feat(mqtt): detect gateways that uplink despite ok_to_mqtt opt-out — Phase 1 backend (#4114)

### DIFF
--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -184,6 +184,65 @@ These are flagged with an outcome badge (`encrypted`, `ignored`, `geo-ignored`,
 the monitor stays useful for diagnosing why a packet's contents aren't visible
 elsewhere in MeshMonitor.
 
+### `ok_to_mqtt` violation detection
+
+Every Meshtastic packet carries an `ok_to_mqtt` bit (bit 0 of `Data.bitfield`) by which the
+originating node signals whether it consents to its traffic being relayed to MQTT. Firmware
+only enforces this bit when a gateway relays *someone else's* packet, and it skips the check
+entirely whenever the gateway believes its configured broker address is private — a check that
+is a plain IP-range test with no awareness of NAT or port forwarding. A gateway reaching its
+broker through a LAN-literal address that is *also* port-forwarded to the internet gets
+misclassified as private, and will silently relay opted-out traffic to what is effectively a
+public broker.
+
+MeshMonitor detects this condition: when a received MQTT packet's `ok_to_mqtt` bit is
+**explicitly clear** and the publishing gateway is not the packet's originator, that is a
+provable, confirmed violation, and MeshMonitor records it. A packet whose bit cannot be read at
+all — because the field was never set, or because the packet is encrypted and MeshMonitor has no
+matching channel key — is recorded only as *unknown/suspected*, never as a confirmed violation.
+
+::: info Not necessarily malicious
+The overwhelmingly likely cause of a detected violation is the firmware misconfiguration
+described above — a gateway whose broker address merely looks private but isn't — not a
+deliberate attempt to bypass a node's opt-out. Treat a violation as a configuration issue worth
+flagging to the gateway operator, not as evidence of hostile intent.
+:::
+
+#### Settings
+
+Violation detection is controlled by three settings, all with working defaults out of the box —
+no configuration is required to start collecting violation history:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `mqtt_oktomqtt_violation_log_enabled` | ON | Kill switch for recording violations. **Unlike** `mqtt_packet_log_enabled` (opt-in, default off), this setting is **on by default**: set it to `0` to disable violation logging; any other value — including leaving it unset — keeps it on. |
+| `mqtt_oktomqtt_violation_retention_days` | `90` | How long a confirmed violation record is retained. |
+| `mqtt_oktomqtt_violation_max_count` | `50000` | Maximum number of violation records retained per source before the oldest are trimmed. |
+
+#### Retention is independent of the Packet Monitor
+
+Confirmed violations are stored in their own record set with their own retention policy — 90
+days / 50,000 records per source — deliberately independent of the Packet Monitor's much shorter
+window (24 hours / 5,000 rows, see [Capture opt-in and retention](#capture-opt-in-and-retention)
+above) and of whether MQTT packet capture is enabled at all. Violation history is therefore
+retained even on installs that never turn on the MQTT Packet Monitor, and isn't lost when the
+packet log trims itself daily.
+
+#### Forward-only detection
+
+Violation detection only covers MQTT traffic received **after** upgrading to a MeshMonitor
+version with this feature. There is no backfill: the `ok_to_mqtt` bit was never previously
+stored, so there is nothing to retroactively re-evaluate for packets received before the
+upgrade — an old row can't be distinguished from a genuinely unreadable one, so guessing would
+only produce wrong answers. Expect an empty violation history immediately after upgrading; it
+fills in as new MQTT traffic arrives.
+
+#### Current availability
+
+This is currently a backend-only capability: violations are detected and recorded, but there is
+no user interface for them yet. A violation badge on Packet Monitor rows and a searchable
+gateway violation report under Analysis & Reports are planned for a future release.
+
 ## Use Cases
 
 The Packet Monitor is useful for:

--- a/docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md
@@ -1,0 +1,1497 @@
+# MQTT `ok_to_mqtt` Violation Detection — Phase 1 Implementation Spec
+
+**Epic:** `MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md` (issue #4114)
+**Phase:** 1 — backend only, no user-visible change
+**Branch / worktree:** `feature/mqtt-oktomqtt-violations` @ `../meshmonitor-mqtt-violations`
+**Migration number:** **128** (verified: `src/db/migrations.ts` has exactly 127 `registry.register(...)` calls,
+highest `number: 127` = `add_atak_contacts` at `src/db/migrations.ts:2017-2023`; `number: 128` is not taken.
+`src/server/migrations/` contains nothing numbered ≥ 128.)
+
+Structural template: `MQTT_PACKET_MONITOR_PHASE1_SPEC.md` (the epic that built `mqtt_packet_log`).
+Implementers follow this document literally. Where it says "reuse", do not hand-roll.
+
+---
+
+## 1. Reuse inventory (MANDATORY — use or extend these; do NOT duplicate)
+
+Everything below was located and read in this worktree. File:line references are verified against
+the current tree.
+
+### 1.1 The bit evaluator to EXTRACT (not reimplement)
+
+| Symbol | Location | Notes |
+|---|---|---|
+| `MqttBridgeManager.evaluateOkToMqtt` | `src/server/mqttBridgeManager.ts:482-499` | **private**, `Promise<boolean>`, **fail-closed**. Plaintext: `(decoded.bitfield & 0x1) === 1`. Encrypted / bitfield-absent: falls through to `channelDecryptionService.tryDecrypt(enc, id, from, channelHash)`; `!result.success \|\| typeof result.bitfield !== 'number'` ⇒ `false`. Missing `enc`/`id`/`from` ⇒ `false`. |
+| Its **only** caller | `src/server/mqttBridgeManager.ts:760-767` (inside `handleUplink`, `:752`) | Gated on `!this.config.ignoreOkToMqtt`; on `false` increments `this.uplinkOkToMqttDrops` (`:265`, surfaced at `:462`) and `return`s. |
+| Config flag | `MqttBridgeConfig.ignoreOkToMqtt?: boolean` — `src/server/mqttBridgeManager.ts:141` (doc at `:131`) | |
+| Existing tests that MUST stay green | `src/server/mqttBridgeManager.test.ts:163-167` (test-helper `bitfield?: number`, defaults to `1`), `:184`, `:214`, `:237`, `:1038-1101` (`bitfield: 0` ⇒ dropped, `bitfield: 1` ⇒ uplinked), `:1103-1141` (`ignoreOkToMqtt: true` ⇒ uplinked with `bitfield: 0`) | |
+
+**Fail-closed is correct for uplink and wrong for detection.** Phase 1 extracts a tri-state core and
+re-expresses the uplink gate as `state === 'yes'`, preserving byte-for-byte behavior. See §2(a).
+
+### 1.2 Decrypt services (both already return `bitfield` — no change needed there)
+
+| Symbol | Location |
+|---|---|
+| `DecryptionResult.bitfield?: number` | `src/server/services/channelDecryptionService.ts:18,34-39` |
+| `isValidProtobuf` extracts + `>>> 0`-normalizes it | `src/server/services/channelDecryptionService.ts:275,302-315` |
+| `attemptDecryptSingleChannel` propagates it | `src/server/services/channelDecryptionService.ts:350` |
+| `channelDecryptionService.tryDecrypt(payload, packetId, fromNode, channelHash?)` | `src/server/services/channelDecryptionService.ts:363` |
+| `channelDecryptionService.isEnabled()` | `src/server/services/channelDecryptionService.ts:94` |
+| `PkiDecryptResult.bitfield?: number` | `src/server/services/pkiDecryptionService.ts:34,40`; populated at `:155` in `decodeData` |
+
+**Verified:** `pkiDecryptionService` has exactly one non-test consumer in the whole tree —
+`src/server/meshtasticManager.ts:4952` (the **TCP** path). **The MQTT ingest path never calls it**, so
+there is no second bitfield-drop to fix in `mqttIngestion.ts`. Do not add a PKI branch to MQTT ingest
+in Phase 1.
+
+### 1.3 Packet-log service and its templates
+
+| Symbol | Location | Notes |
+|---|---|---|
+| `buildMqttPacketLogRow(sourceId, envelope, result)` | `src/server/services/mqttPacketLogService.ts:203-244` | **Exported pure function.** Extend, do not fork. |
+| `mapOutcome(result)` | `:158-177` | module-private; emits `'distance'` at `:167-168`. |
+| `parseGatewayNodeNum(id)` | `:183-187` | module-private; `!id \|\| !id.startsWith('!')` ⇒ `null`; `parseInt(id.slice(1), 16)`, `NaN` ⇒ `null`, else `n >>> 0`. **This spec MOVES it to the shared util (§3.1) and imports it back.** |
+| `buildPreview` | `:193-196` | untouched. |
+| `logEnvelope(sourceId, envelope, result)` | `:109-123` | the single write path; never throws. |
+| Settings TTL cache pattern | `:30-31`, `isEnabled()` `:76-84`, `resetEnabledCache()` `:87-89` | `ENABLED_TTL_MS = 5000`. Clone this shape for the new enable flag. |
+| Retention sweep + **the one 15-min interval** | `CLEANUP_INTERVAL_MS = 15 * 60 * 1000` `:26`; `startCleanupScheduler()` `:37-45`; `runCleanup()` `:51-69`; `stop()` `:145-151` | **Do NOT add a second timer.** Extend `runCleanup()`. |
+| Defaults | `DEFAULT_MAX_COUNT = 5000` `:27`, `DEFAULT_MAX_AGE_HOURS = 24` `:28` | |
+| Template service | `src/server/services/meshcorePacketLogService.ts` | same shape; consult if unsure. |
+
+### 1.4 `MqttPacketLogRepository` (`src/db/repositories/mqttPacketLog.ts`)
+
+| Symbol | Location | Notes |
+|---|---|---|
+| `DbMqttPacket` | `:24-50` | extend with 3 fields (§3.2). |
+| `MqttGroupedQuery` | `:53-61` | unchanged in Phase 1. |
+| `MqttGroupedPacket` | `:64-82` | extend with 2 fields. |
+| `MqttGateway` | `:84-89` | unchanged. |
+| `insertPacket` | `:99-105` | requires `sourceId` (throws otherwise). |
+| `buildGroupedConditions` | `:111-127` | shared WHERE builder. |
+| `getGroupedPackets` | `:138-169` | **explicit 18-aggregate projection** + `groupBy(t.sourceId, t.fromNode, groupKey)` where `groupKey = COALESCE(NULLIF(packetId,0), -id)` (`:140`). A new column does **not** reach the list view without an explicit aggregate. |
+| `getGroupedPacketCount` | `:177-189` | subquery-over-grouped; comment at `:174-175` records that MySQL rejects multi-arg `COUNT(DISTINCT a,b)`. |
+| `getReceptions` | `:200-214` | bare `.select()` ⇒ new columns appear automatically. |
+| `getGateways` | `:220-234` | `groupBy(t.gatewayId)` + `MAX()` aggregates — the shape to copy for the violation gateway summary. |
+| `getPacketCount` | `:240-248` | |
+| `deletePacketsOlderThan(timestamp, sourceId?)` | `:253-263` | |
+| `trimPacketsToCount(sourceId, maxCount)` | `:269-289` | newest-`maxCount`-survive by `(timestamp desc, id desc)`, then delete `id < oldestKeptId`. **Copy this algorithm verbatim.** |
+| `getPacketLogSourceIds()` | `:295-301` | |
+| `deleteAllPackets(sourceId?)` | `:307-316` | |
+| `normalizeBigInts` (inherited) | `src/db/repositories/base.ts:267` | applied to every read; **required** on the new repo too (PG/MySQL BIGINT). |
+
+### 1.5 Migration helpers and DDL templates
+
+`src/server/migrations/helpers.ts` — every idempotency helper, per dialect:
+
+| Helper | Dialect | Mechanism |
+|---|---|---|
+| `addColumnIfMissing(db, table, column, ddl)` | SQLite | catches "duplicate column"; re-throws anything else (`:56-`) |
+| `addColumnIfMissingPostgres(client, table, column, ddl)` | PostgreSQL | native `ADD COLUMN IF NOT EXISTS` |
+| `addColumnIfMissingMysql(pool, table, column, ddl)` | MySQL | `information_schema.COLUMNS` pre-check |
+| `createTableIfMissingMysql(pool, table, createDdl)` | MySQL | `information_schema.TABLES` pre-check |
+| `createIndexIfMissingMysql(pool, table, indexName, createDdl)` | MySQL | `information_schema.STATISTICS` pre-check |
+| — | SQLite / PostgreSQL | native `CREATE TABLE IF NOT EXISTS` / `CREATE [UNIQUE] INDEX IF NOT EXISTS`; no helper needed |
+
+DDL templates:
+- **New table**, all three dialects: `src/server/migrations/121_mqtt_packet_log.ts` — SQLite `:21-66`,
+  PG `:70-108` (note: params typed `import('pg').PoolClient`, **no `any`, no eslint-disable**),
+  MySQL `:112-163` (`information_schema.TABLES` pre-check + inline `INDEX` clauses).
+- **Add column**, all three dialects: `src/server/migrations/125_add_xeddsa_signed_to_packet_log.ts`
+  — the shape to copy, **except** type its PG/MySQL params as 121 does rather than reproducing 125's
+  `any` + eslint-disable (the ESLint ratchet must not grow).
+- Registry entry shape: `src/db/migrations.ts:2009-2023`.
+- `src/db/migrations.test.ts` needs **no edit** — its assertions are registry-derived
+  (`:16-19` count==max, `:29-32` contiguity, `:49-54` all three dialects present, `:71-74`
+  `settingsKey` required for 002+).
+
+### 1.6 Cross-source route plumbing (`src/server/routes/analysisRoutes.ts`)
+
+| Symbol | Location | Notes |
+|---|---|---|
+| `router.use(optionalAuth())` | `:30` | already applied to the whole router. |
+| `resolvePermittedSourceIds(req, resource = 'nodes')` | `:32-52` | admin ⇒ all enabled; else `checkPermissionAsync(user?.id ?? 0, resource, 'read', s.id)` per source. **Pass `'packetmonitor'`.** |
+| `parseSourcesParam(raw)` | `:54-57` | CSV ⇒ `string[] \| null`. |
+| `clampPageSize(raw)` | `:59-63` | default 500, max 2000. |
+| `parseSinceMs(raw)` | `:65-68` | ms epoch, `>= 0`, default 0. |
+| Intersection idiom | `:178-181` and repeated | `requested ? permitted.filter(id => requested.includes(id)) : permitted`. |
+| Mount point | `src/server/server.ts:641` (import), `:794` `apiRouter.use('/analysis', analysisRoutes)` | ⇒ new paths live under `/api/analysis/...`. **No server.ts edit required.** |
+| `AnalysisRepository` | `src/db/repositories/analysis.ts:258`; wired at `src/services/database.ts:658` (getter) and `:919` (construction) | Phase 1 adds a **new** repo, not methods here — see §2(d) justification. |
+| `packetmonitor` is source-scoped | `src/server/constants/permissions.ts:7-14` (`SOURCEY_RESOURCES`) | every check needs a `sourceId`. |
+
+### 1.7 Response envelope, source scoping, test harness
+
+| Symbol | Location | Notes |
+|---|---|---|
+| `ok(res, data?)` | `src/server/utils/apiResponse.ts:15-17` | ⇒ `{ success: true, data }`. |
+| `fail(res, status, code, message, extra?)` | `:31-39` | ⇒ `{ success: false, error, code, ...extra }`. |
+| Frontend does **not** unwrap `data` | comment at `apiResponse.ts:6-10` | Phase 3 must read `body.data`. Restated in §2(e). |
+| `withSourceScope(table, sourceId)` | `src/db/repositories/base.ts:244-` | throws unless a concrete `sourceId` or the `ALL_SOURCES` sentinel (`:33`) is passed. |
+| `normalizeBigInts` | `src/db/repositories/base.ts:267` | |
+| `this.tables` / `buildActiveSchema` | `src/db/repositories/base.ts:57,67`; `src/db/activeSchema.ts:168,273,454` | `mqttPacketLog` key registered at `activeSchema.ts:58-59` (imports), `:194` (interface), `:292/:350/:408` (SCHEMA_MAP). Mirror all five spots for the new table. |
+| `createRouteTestApp(...)` | `src/server/test-helpers/routeTestApp.ts:135`; harness type `:63-119`; `sourceA`/`sourceB` `:72,74`; `admin`/`limited` `:76,78`; `grant(...)` `:96`; `loginAs`, `tokenFor`, `cleanup` `:266-301` | **New route tests MUST use this.** |
+| `createTestDb()` | `src/server/test-helpers/testDb.ts` (used by `src/db/repositories/mqttPacketLog.perSource.test.ts:13,52-55`) | builds a `:memory:` SQLite from the migration registry. |
+| Settings allowlist | `src/server/constants/settings.ts` — existing `mqtt_packet_log_*` keys at `:103-105` | |
+| "SERVER_ONLY_SETTINGS" | **not a production constant** — it is a local allowlist inside `src/server/server.settings-persistence.test.ts:405-432` | It only guards keys that **SettingsTab sends**. Phase 1 adds no SettingsTab field, so **no edit is needed**. See §2(g) for the Phase 2/3 trap. |
+
+### 1.8 Existing tests to extend (do not create parallel files)
+
+`src/db/repositories/mqttPacketLog.perSource.test.ts`, `mqttPacketLog.grouping.test.ts`,
+`src/server/services/mqttPacketLogService.buildRow.test.ts`,
+`src/server/mqttPacketLogService.ingestHook.test.ts`, `src/server/mqttIngestion.test.ts`,
+`src/server/mqttBridgeManager.test.ts`, `src/server/migrations/121_mqtt_packet_log.test.ts`.
+
+### 1.9 Justification for the only genuinely new subsystem
+
+**`mqtt_ok_to_mqtt_violations` table + repository.** The closest existing thing is `mqtt_packet_log`
+itself. It cannot be reused because interview decision 4 requires **retention immunity** relative to
+the packet log's 24 h / 5 000-row trim (`mqttPacketLogService.ts:27-28`), and Phase 3 needs a
+weeks-long lookback. Adding a "don't trim me" flag to `mqtt_packet_log` would fork its retention
+algorithm and defeat the count cap. A separate, far lower-volume table with its own sweep is the
+smaller change. `AnalysisRepository` was also considered as a home for the queries and rejected: it
+is not a `BaseRepository` subclass (`analysis.ts:258-260` holds its own `db`/`dbType`) and has no
+`withSourceScope`/`normalizeBigInts`; a `BaseRepository` subclass is the correct base for a new
+source-scoped table.
+
+**`src/server/utils/okToMqtt.ts`.** New, but it is an *extraction* of `evaluateOkToMqtt`, not a new
+mechanism — required because the same logic now has two callers with opposite failure semantics.
+
+---
+
+## 2. Design decisions (settled — implementers do not re-decide)
+
+### 2(a) Shared tri-state evaluator: location and exact signature
+
+**Location:** `src/server/utils/okToMqtt.ts` (NEW). It imports `ServiceEnvelopeShape` from
+`../mqttPacketFilter.js` (which imports only `constants/meshtastic.js` — no cycle) and
+`channelDecryptionService` from `../services/channelDecryptionService.js` (already imported by
+`mqttBridgeManager`, so no new cycle).
+
+```ts
+export type OkToMqttState = 'yes' | 'no' | 'unknown';
+
+/** Pure. `undefined`/`null`/non-number ⇒ 'unknown'; bit 0 set ⇒ 'yes'; clear ⇒ 'no'. */
+export function readBitfieldOkToMqtt(bitfield: number | null | undefined): OkToMqttState;
+
+/**
+ * Envelope-level resolution, mirroring the original evaluateOkToMqtt control flow exactly:
+ *  1. `packet.decoded.bitfield` is a number  → readBitfieldOkToMqtt(it)
+ *  2. else, `packet.encrypted` + numeric `packet.id` + numeric `packet.from` present
+ *     → await channelDecryptionService.tryDecrypt(enc, id, from, channelHashOrUndefined)
+ *       → success && typeof bitfield === 'number' ? readBitfieldOkToMqtt(bitfield) : 'unknown'
+ *  3. else → 'unknown'
+ * NOTE: deliberately does NOT gate on channelDecryptionService.isEnabled() — the original
+ * evaluator did not, and adding the gate would change uplink behavior.
+ */
+export async function resolveOkToMqttForEnvelope(envelope: ServiceEnvelopeShape): Promise<OkToMqttState>;
+
+/** Fail-closed adapter for the uplink gate: only an explicit 'yes' permits republishing. */
+export function allowsUplink(state: OkToMqttState): boolean; // state === 'yes'
+
+/** Moved verbatim from mqttPacketLogService.ts:183-187. */
+export function parseGatewayNodeNum(id: string | null | undefined): number | null;
+
+export interface OkToMqttViolationEval {
+  state: OkToMqttState;
+  bitfield: number | null;          // raw Data.bitfield, null when unreadable
+  fromNode: number | null;          // u32
+  gatewayNodeNum: number | null;    // u32, parsed from envelope.gatewayId
+  selfGateway: boolean;             // gateway is THIS source's own local gateway (§2(f.1))
+  relayed: boolean;                 // both numeric AND different AND !selfGateway
+  isViolation: boolean;             // state === 'no'      && relayed
+  isSuspected: boolean;             // state === 'unknown' && relayed
+}
+
+/**
+ * Synchronous, pure, allocation-light. Reads ONLY `envelope.packet.decoded.bitfield`,
+ * `envelope.packet.from`, `envelope.gatewayId`. Never decrypts — by the time ingest calls
+ * this, `ingestServiceEnvelopeInner` has already synthesized `packet.decoded` (§2(b)).
+ *
+ * `localGatewayNodeNum` is THIS source's own gateway node number. When the publishing
+ * gateway matches it, the reception is neither a violation nor suspected. This is the
+ * self-echo guard of §2(f.1) — it deliberately does NOT rely on the bridge's echo
+ * suppression, which is not airtight. Omit/`null` only when the caller genuinely has no
+ * local identity.
+ */
+export function detectOkToMqttViolation(
+  envelope: ServiceEnvelopeShape,
+  localGatewayNodeNum?: number | null,
+): OkToMqttViolationEval;
+```
+
+**`MqttBridgeManager` refactor.** Replace the body of `evaluateOkToMqtt`
+(`src/server/mqttBridgeManager.ts:482-499`) with a two-liner; keep the method, its name, its
+`private` modifier, its `Promise<boolean>` signature, and its doc comment (amended to point at the
+shared util and note that `unknown ⇒ drop`):
+
+```ts
+private async evaluateOkToMqtt(envelope: ServiceEnvelopeShape): Promise<boolean> {
+  return allowsUplink(await resolveOkToMqttForEnvelope(envelope));
+}
+```
+
+The call site at `:760-767` is **untouched** — `uplinkOkToMqttDrops` still increments on `false`.
+
+**Behavioral equivalence proof (every existing case still holds):**
+
+| Old code path | Old result | New: state → `allowsUplink` |
+|---|---|---|
+| `decoded.bitfield = 1` (`:485`) | `true` | `'yes'` → `true` — covers `mqttBridgeManager.test.ts:1085`, and `:184/:214/:237` default `bitfield: 1` |
+| `decoded.bitfield = 0` (`:485`) | `false` | `'no'` → `false` — covers `:1038-1101` (`bitfield: 0` dropped, drop counter increments) |
+| `decoded` present, `bitfield` absent, `encrypted` present | falls to `:489-498`, decrypt attempted | step 1 skipped (not a number) → step 2 decrypt attempted — **identical** |
+| `decoded` present, `bitfield` absent, no `encrypted` | `:492` `return false` | step 3 → `'unknown'` → `false` |
+| encrypted, decrypt fails or returns non-numeric bitfield (`:497`) | `false` | `'unknown'` → `false` |
+| encrypted, decrypt yields `bitfield` (`:498`) | `(b & 1) === 1` | `readBitfieldOkToMqtt(b)` — identical |
+| `ignoreOkToMqtt: true` (`:760`) | evaluator never called | unchanged — covers `:1103-1141` |
+
+### 2(b) How `bitfield` survives the server-side decrypt path
+
+**Minimal change**, `src/server/mqttIngestion.ts:190-205`: add `bitfield` to the inline cast type and
+to the synthesized object literal. Nothing else.
+
+```ts
+(packet as {
+  decoded?: {
+    portnum?: number;
+    payload?: Uint8Array;
+    emoji?: number;
+    replyId?: number;
+    channelDatabaseId?: number;
+    bitfield?: number;                 // ← ADD (#4114): the ok_to_mqtt bit must survive decrypt
+  };
+}).decoded = {
+  portnum: r.portnum,
+  payload: r.payload,
+  emoji: r.emoji,
+  replyId: r.replyId,
+  channelDatabaseId: r.channelDatabaseId,
+  bitfield: r.bitfield,                // ← ADD
+};
+```
+
+No typing work downstream: `MeshPacketShape.decoded` already declares `bitfield?: number`
+(`src/server/mqttPacketFilter.ts:47`).
+
+**Why this is sufficient:** `ingestServiceEnvelopeInner` mutates `packet.decoded` **in place**, and
+`logEnvelope` runs *after* it in the wrapper (`mqttIngestion.ts:587-589`). `buildMqttPacketLogRow`
+already relies on exactly this (`decryptedBy: wasEncrypted && decoded ? 'server' : null`,
+`mqttPacketLogService.ts:238`), so the synthesized `bitfield` is visible to the row builder and to
+`detectOkToMqttViolation`.
+
+**PKI path:** verified absent from MQTT ingest — `pkiDecryptionService`'s only non-test consumer is
+`src/server/meshtasticManager.ts:4952` (TCP). **No change, and no new PKI branch, in Phase 1.**
+(`PkiDecryptResult.bitfield` at `pkiDecryptionService.ts:40,155` is already correct if a future phase
+wires it into the TCP packet log.)
+
+### 2(c) Storage shape for the tri-state
+
+**Decision: two columns on `mqtt_packet_log`, no text enum.**
+
+| Column | SQLite | PostgreSQL | MySQL | Meaning |
+|---|---|---|---|---|
+| `bitfield` | `INTEGER` (nullable) | `INTEGER` (nullable) | `INT` (nullable) | Raw `Data.bitfield`. `NULL` = absent/unreadable = **unknown**. |
+| `okToMqttViolation` | `INTEGER NOT NULL DEFAULT 0` | `INTEGER NOT NULL DEFAULT 0` | `INT NOT NULL DEFAULT 0` | 0/1 derived flag. |
+
+**Why a nullable raw int and not a nullable boolean or a text enum:**
+
+1. **Nullable boolean is unusable in the grouped projection.** `mqtt_packet_log.encrypted` is
+   deliberately a raw 0/1 int specifically because *PostgreSQL has no `MAX(boolean)` aggregate*
+   (`src/db/schema/mqttPacketLog.ts:46-50`, repeated at `:85` and `:117`). The Phase 2 badge needs
+   `MAX(okToMqttViolation)` to survive `getGroupedPackets`' explicit projection, so the violation
+   flag **must** be the same raw 0/1 int. Same reason MySQL `ONLY_FULL_GROUP_BY` is satisfied: it is
+   an aggregate over a numeric column, not a bare selected column.
+2. **The tri-state is derivable, so a third column would be redundant state that can diverge.**
+   `bitfield IS NULL` ⇒ `unknown`; `bitfield & 1 = 1` ⇒ `yes`; else ⇒ `no`. Reconstructed in JS via
+   `readBitfieldOkToMqtt(row.bitfield)`.
+3. **Store the raw value, not just the derived bit.** `Data.bitfield` is a `uint32` with room for
+   more flags; keeping the raw value costs one nullable int and makes any future bit readable from
+   history with no migration. It is also the diagnostic the issue's reporter wants ("what did the
+   originator actually set?").
+4. `MAX(bitfield)` across a packet's gateway receptions is *semantically exact*, not a fudge: the
+   bitfield is the **originator's** field, identical in every gateway's copy of the same packet. It
+   is `NULL` only when *every* copy was unreadable.
+
+Third column added in the same migration for interview decision 2:
+
+| `topic` | `TEXT` | `TEXT` | `VARCHAR(512)` | Raw MQTT topic. Diagnostic. |
+
+### 2(d) The durable violations table
+
+**Table:** `mqtt_ok_to_mqtt_violations`. **Per-violating-reception rows, not a rolled-up counter.**
+
+**Why rows, against the growth objection:** Phase 3 needs *both* a per-gateway summary *and*
+drill-down to the individual violating packets over a user-chosen lookback of weeks. A counter
+cannot produce the drill-down, and a counter plus a row table is strictly more code than a row table
+with a `GROUP BY`. Unbounded growth is prevented by three independent mechanisms:
+1. **Violations are rare by construction** — a row requires a gateway that (a) relays someone else's
+   packet and (b) misreads its broker as private. On a healthy mesh the rate is zero; on an affected
+   mesh it is one row per relayed packet per offending gateway, which is exactly the signal.
+2. **Its own retention sweep** (below), independent of the packet log's.
+3. **A dedupe unique index** that collapses re-ingest of the same reception.
+
+**Confirmed violations only.** Rows are written **only** when `state === 'no' && relayed`. "Unknown"
+receptions are deliberately **not** persisted here: on a busy public-broker source essentially every
+relayed encrypted packet is `unknown`, which would make the table the same volume as the packet log
+and destroy the retention-immunity argument. Interview decision 6's `includeUnknown` toggle is served
+from `mqtt_packet_log` instead — see §2(e) and the caveat there.
+
+**Columns** (three dialect definitions in `src/db/schema/mqttOkToMqttViolations.ts`):
+
+| Column | SQLite | PostgreSQL | MySQL | Notes |
+|---|---|---|---|---|
+| `id` | `integer('id').primaryKey({autoIncrement:true})` | `pgInteger('id').primaryKey().generatedAlwaysAsIdentity()` | `mySerial('id').primaryKey()` | mirrors `mqttPacketLog` exactly |
+| `sourceId` | `text` NOT NULL | `pgText` NOT NULL | `myVarchar(255)` NOT NULL | **per-source scoping** |
+| `packetId` | `integer` | `pgBigint({mode:'number'})` | `myBigint({mode:'number'})` | u32; nullable |
+| `fromNode` | `integer` | `pgBigint` | `myBigint` | originator, u32 |
+| `fromNodeId` | `text` | `pgText` | `myVarchar(16)` | `!aabbccdd` |
+| `gatewayId` | `text` | `pgText` | `myVarchar(32)` | publishing gateway |
+| `gatewayNodeNum` | `integer` | `pgBigint` | `myBigint` | u32 |
+| `channelId` | `text` | `pgText` | `myVarchar(64)` | envelope channel **name** |
+| `portnum` | `integer` | `pgInteger` | `myInt` | |
+| `portnumName` | `text` | `pgText` | `myVarchar(48)` | |
+| `bitfield` | `integer` | `pgInteger` | `myInt` | always non-null and even on a confirmed row |
+| `topic` | `text` | `pgText` | `myVarchar(512)` | raw MQTT topic |
+| `rxTime` | `integer` | `pgBigint` | `myBigint` | ms |
+| `timestamp` | `integer` NOT NULL | `pgBigint` NOT NULL | `myBigint` NOT NULL | server capture ms — ordering + retention |
+| `createdAt` | `integer` NOT NULL | `pgBigint` NOT NULL | `myBigint` NOT NULL | |
+
+**Indexes:**
+- `idx_mqtt_v_source_ts (sourceId, timestamp)` — retention sweep + lookback range scans
+- `idx_mqtt_v_source_gw_ts (sourceId, gatewayNodeNum, timestamp)` — gateway summary
+- `idx_mqtt_v_dedupe` **UNIQUE** `(sourceId, packetId, fromNode, gatewayNodeNum)` — dedupe
+
+**Primary key:** surrogate `id`. The natural key is the dedupe tuple, but it contains nullables, so
+it is a unique index rather than a PK.
+
+**Duplicate ingest of the same reception** (retained-frame replay, broker redelivery, both a broker
+publish and a bridge downlink of the same envelope): the unique index makes the second insert a
+**silent no-op**, via a dialect branch inside `insertViolation`:
+- `sqlite` / `postgres`: `.onConflictDoNothing()`
+- `mysql`: `.onDuplicateKeyUpdate({ set: { timestamp: sql`timestamp` } })` (Drizzle MySQL has no
+  `onConflictDoNothing`; assigning a column to itself is the idiomatic no-op)
+
+The first write wins, so `timestamp` records first observation. **Documented limitation:** rows with
+`packetId` NULL/0 cannot dedupe (`NULL != NULL` in a unique index on all three dialects) — the same
+accepted edge already documented for `getReceptions` (`mqttPacketLog.ts:191-199`). Real mesh packets
+essentially always carry a nonzero id.
+
+**Retention — own settings, existing timer.** `mqttPacketLogService.runCleanup()`
+(`:51-69`) gains a second phase. **No new `setInterval`.**
+
+```ts
+// phase 2 of runCleanup(), after the packet-log trim:
+const days = await this.getViolationRetentionDays();          // default 90
+const vCutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+let vRemoved = await databaseService.mqttOkToMqttViolations.deleteViolationsOlderThan(vCutoff);
+const vMax = await this.getViolationMaxCount();               // default 50000
+for (const sid of await databaseService.mqttOkToMqttViolations.getViolationSourceIds()) {
+  vRemoved += await databaseService.mqttOkToMqttViolations.trimViolationsToCount(sid, vMax);
+}
+```
+
+Retention immunity is structural: a different table, a different cutoff (90 d vs 24 h), a different
+cap (50 000/source vs 5 000/source). `mqttPacketLog.deleteAllPackets()` / `deletePacketsOlderThan()`
+never touch it.
+
+**Write gate is independent of `mqtt_packet_log_enabled`.** The packet log is opt-in because it
+writes a row for *every* reception; violations are rare, so the volume argument does not apply, and
+gating them behind the packet monitor would leave the Phase 3 report silently empty on most installs.
+The violation write has its own kill switch, **default ON** (§2(g)). Concretely, `logEnvelope`
+becomes:
+
+```ts
+async logEnvelope(sourceId, envelope, result, topic?, localGatewayNodeNum?): Promise<void> {
+  try {
+    if (!envelope.packet) return;
+    const v = detectOkToMqttViolation(envelope, localGatewayNodeNum); // pure, cheap, no await
+    const packetLogEnabled = await this.isEnabled();     // cached, 5 s TTL
+    const wantViolation = v.isViolation && await this.isViolationLogEnabled(); // cached
+    if (!packetLogEnabled && !wantViolation) return;     // fast path: nothing to write
+    const row = buildMqttPacketLogRow(sourceId, envelope, result, topic, v);
+    if (!row) return;
+    if (wantViolation) {
+      await databaseService.mqttOkToMqttViolations.insertViolation(buildViolationRow(row));
+    }
+    if (packetLogEnabled) {
+      await databaseService.mqttPacketLog.insertPacket(row);
+    }
+  } catch (err) {
+    logger.error('❌ Failed to log MQTT packet:', err);   // never throws — unchanged contract
+  }
+}
+```
+
+`buildViolationRow(row: DbMqttPacket): DbMqttOkToMqttViolation` is a new exported pure function in
+`mqttPacketLogService.ts` — a straight field projection, so the two rows can never disagree.
+
+**Forward-only by design — an empty report right after upgrade is EXPECTED, not a bug.**
+Migration 128 performs **no backfill**, and it cannot: `bitfield` was never captured before this
+change, so every pre-existing `mqtt_packet_log` row has `bitfield = NULL` and
+`okToMqttViolation = 0`, and the violations table starts empty. Consequences the operator will see:
+
+- Both `/api/analysis/mqtt-violations/*` endpoints return empty result sets until **new** MQTT
+  traffic arrives after the upgrade.
+- Historical rows are indistinguishable from genuine "unknown" — they are `bitfield IS NULL`, so
+  with `includeUnknown=true` they would surface as *suspected* purely because they predate the
+  feature. This is why suspected entries are labelled `kind: 'suspected'` and scoped to
+  `suspectedWindowMs`; within a day of upgrade the packet log's own 24 h retention has flushed
+  every pre-migration row, and the ambiguity self-resolves.
+- No `UPDATE` pass is added to the migration. Backfilling would require re-deriving a bit that was
+  never stored — impossible — so a backfill could only write a wrong value.
+
+This matches the precedent set by migration 125 (`xeddsa_signed`, "No backfill: … historical rows
+stay NULL (unknown)", `125_add_xeddsa_signed_to_packet_log.ts:17-19`). WP6 records it in the epic
+doc so the user is not surprised.
+
+### 2(e) Cross-source route surface
+
+Two new handlers in **`src/server/routes/analysisRoutes.ts`** (NOT `mqttPacketRoutes.ts`, which is
+per-source `/api/sources/:id/mqtt/packets`). The router is mounted at `/api/analysis`
+(`server.ts:794`) and already has `optionalAuth()` applied (`analysisRoutes.ts:30`), so **no
+`server.ts` edit**.
+
+Both call `resolvePermittedSourceIds(req, 'packetmonitor')` and intersect with `?sources=` using the
+existing idiom. An unpermitted / anonymous user gets a **200 with empty results**, matching every
+other handler in this file — not a 403.
+
+#### `GET /api/analysis/mqtt-violations/gateways`
+
+Per-gateway summary. Query params:
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `sources` | CSV | all permitted | `parseSourcesParam` |
+| `lookbackDays` | int 1..365 | 7 | ignored when `since` is supplied |
+| `since` | ms epoch | derived from `lookbackDays` | `parseSinceMs` |
+| `until` | ms epoch | `Date.now()` | new local `parseUntilMs` |
+| `includeUnknown` | `'true'`/`'1'` | `false` | see caveat below |
+| `sort` | `violationCount` \| `lastSeen` \| `distinctOriginators` \| `gatewayId` | `violationCount` | anything else ⇒ 400 |
+| `dir` | `asc` \| `desc` | `desc` | anything else ⇒ 400 |
+| `limit` | int | `clampPageSize` (500, max 2000) | |
+| `offset` | int ≥ 0 | 0 | |
+
+Success — `ok(res, {...})`, i.e. the wire body is `{ success: true, data: { ... } }`:
+
+```jsonc
+{ "success": true, "data": {
+  "gateways": [{
+    "gatewayId": "!433e0f28", "gatewayNodeNum": 1128729384,
+    "violationCount": 42,          // confirmed (bit explicitly 0)
+    "suspectedCount": 0,           // 0 unless includeUnknown=true
+    "distinctOriginators": 7,
+    "sourceIds": ["mqtt-main"],
+    "firstSeen": 1753300000000, "lastSeen": 1753380000000
+  }],
+  "total": 3, "limit": 500, "offset": 0,
+  "since": 1752780000000, "until": 1753387000000,
+  "includeUnknown": false,
+  "suspectedAvailable": true,      // false when mqtt_packet_log_enabled is off
+  "suspectedWindowMs": 86400000,   // packet-log max age — the suspected horizon
+  "sources": ["mqtt-main", "mqtt-eu"]
+}}
+```
+
+#### `GET /api/analysis/mqtt-violations/packets`
+
+Drill-down. Same params, plus `gateway` (a single `gatewayId`, optional) and
+`sort ∈ { timestamp, fromNode, gatewayId }` (default `timestamp`).
+
+```jsonc
+{ "success": true, "data": {
+  "violations": [{
+    "id": 91, "kind": "confirmed",          // 'confirmed' | 'suspected'
+    "sourceId": "mqtt-main", "packetId": 123456,
+    "fromNode": 2864434397, "fromNodeId": "!aabbccdd",
+    "gatewayId": "!433e0f28", "gatewayNodeNum": 1128729384,
+    "channelId": "LongFast", "portnum": 1, "portnumName": "TEXT_MESSAGE_APP",
+    "bitfield": 0, "topic": "msh/US/2/e/LongFast/!433e0f28",
+    "rxTime": 1753379999000, "timestamp": 1753380000000
+  }],
+  "total": 42, "limit": 500, "offset": 0,
+  "since": …, "until": …, "gateway": null, "includeUnknown": false,
+  "suspectedAvailable": true, "suspectedWindowMs": 86400000,
+  "sources": ["mqtt-main"]
+}}
+```
+
+Errors — `fail(...)`, all introducing SCREAMING_SNAKE codes. **This is the complete list; §3.17
+step 4 emits exactly these three 400s and nothing else:**
+- `fail(res, 400, 'INVALID_SORT_FIELD', 'Unsupported sort field')`
+- `fail(res, 400, 'INVALID_SORT_DIRECTION', 'Sort direction must be asc or desc')`
+- `fail(res, 400, 'INVALID_RANGE', 'since must be <= until')`
+- `fail(res, 500, 'MQTT_VIOLATIONS_FETCH_FAILED', 'Failed to fetch ok_to_mqtt violations')`
+
+**`includeUnknown` caveat (load-bearing, Phase 3 must surface it).** Confirmed violations come from
+`mqtt_ok_to_mqtt_violations` (weeks). Suspected entries (`bitfield IS NULL AND gatewayNodeNum
+IS NOT NULL AND fromNode IS NOT NULL AND gatewayNodeNum <> fromNode`) are read from
+`mqtt_packet_log`, so they are inherently limited to that table's retention window and require
+`mqtt_packet_log_enabled`. The route reports `suspectedAvailable` and `suspectedWindowMs` so Phase 3
+can render "suspected entries limited to the packet-monitor retention window (24 h)". When
+`includeUnknown=false` (the default) the packet-log query is **not executed at all**.
+
+**Frontend contract restated:** `ApiService.request()` returns the raw JSON body and does **not**
+unwrap `data` (`src/server/utils/apiResponse.ts:6-10`). **Phase 3 must read `body.data`.**
+
+### 2(f) The violation predicate, exactly
+
+```
+isViolation  ⇔  state === 'no'       AND  relayed
+isSuspected  ⇔  state === 'unknown'  AND  relayed
+selfGateway  ⇔  localGatewayNodeNum != null
+                 AND  Number(gatewayNodeNum) === Number(localGatewayNodeNum)
+relayed      ⇔  fromNode !== null  AND  gatewayNodeNum !== null
+                 AND  Number(fromNode) !== Number(gatewayNodeNum)
+                 AND  !selfGateway
+```
+
+All comparisons on `>>> 0`-normalized u32 values, coerced with `Number()` (PG/MySQL return BIGINT).
+
+| # | Case | `state` | `relayed` | Outcome |
+|---|---|---|---|---|
+| 1 | bit = 1, gateway ≠ originator | `yes` | true | not a violation |
+| 2 | bit = 1, gateway = originator | `yes` | false | not a violation |
+| 3 | bit = 0, gateway ≠ originator | `no` | true | **CONFIRMED VIOLATION** — the whole feature |
+| 4 | **bit = 0, gateway = originator (originator publishing its own packet)** | `no` | false | **NEVER a violation, regardless of the bit.** Firmware only enforces `ok_to_mqtt` when relaying *other* nodes' packets; a node uplinking its own traffic is expressing its own choice. Has a dedicated test. |
+| 5 | plaintext, `bitfield` field simply unset | `unknown` | any | suspected iff relayed; never confirmed |
+| 6 | encrypted, no `channel_database` PSK matched ⇒ no `decoded` | `unknown` | any | suspected iff relayed; never confirmed |
+| 7 | encrypted, PSK matched, `bitfield` present | per bit | per gw | rows 1–4 apply |
+| 8 | `gatewayId` null / absent | `unknown`-agnostic | **false** | nothing recorded — relaying cannot be proven |
+| 9 | `gatewayId` malformed (no leading `!`, non-hex, `parseInt` ⇒ `NaN`) ⇒ `parseGatewayNodeNum` returns `null` | any | **false** | nothing recorded |
+| 10 | `packet.from` not a number ⇒ `fromNode === null` | any | **false** | nothing recorded |
+| 11 | `fromNode === 0` | any | compared normally (if `gatewayNodeNum` is also 0 ⇒ not relayed) | per comparison |
+| 12 | broadcast (`to = 0xffffffff`) vs DM | irrelevant | — | predicate is `to`-agnostic; the bit is the originator's global preference, not a per-recipient one |
+| 13 | MQTT-bridge **downlink** (`mqttBridgeManager.handleDownlink`, `:643`, ingest at `:698`) | evaluated identically | | **recorded** — a copy arriving from an upstream broker is precisely the evidence sought |
+| 14 | Local-broker **publish** (`mqttBrokerManager.handlePublish`, `:256`, ingest at `:272`) | evaluated identically | | **recorded** |
+| 15 | **MeshMonitor's own uplink echoing back** (esp. with `ignoreOkToMqtt` on, #4104) | per bit | **false** via `selfGateway` | **Never recorded — see §2(f.1). Enforced by an explicit guard, NOT by echo suppression.** |
+| 16 | Pre-ingest-filter drops (topic/node/portnum pre-filter) | — | — | **out of scope** (epic decision 3) — never reach `ingestServiceEnvelope` |
+
+#### 2(f.1) Self-echo: why an explicit guard, not the echo window
+
+This is the one case that could make the feature accuse its own operator, so it is argued in full.
+
+**Two independent facts, both verified in the tree:**
+
+**Fact 1 — the bridge does not rewrite `gatewayId` on uplink, so a returning echo is attributed to
+the *original* gateway, not to MeshMonitor.** `handleUplink` republishes `p.payload` **byte-for-byte**
+(`mqttBridgeManager.ts:795`/`:800` — `publish(publishTopic, p.payload, p.retained)`); only the
+*topic* is rewritten (`applyTopicRewrite`, `:772`). The per-gateway publisher dispatch reads
+`extractGatewayNum(p.envelope.gatewayId)` (`:780`) but never mutates it. The local broker's zero-hop
+re-encode likewise preserves it (`mqttBrokerManager.ts:250`, `gatewayId: decoded.gatewayId`). So even
+on a missed echo, MeshMonitor's own node number is not what lands in `gatewayId` — the *upstream*
+publisher's is.
+
+**Fact 2 — the echo suppression is nevertheless NOT airtight, so it must not be load-bearing.**
+`matchesEcho` (`mqttBridgeManager.ts:817-821`) matches on **exact topic-string equality AND
+packetId**: `store.some(e => e.topic === topic && e.packetId === packetId)`. Entries are recorded
+under the **post-rewrite** `publishTopic` (`:788`) with `ECHO_TTL_MS = 60_000` (`:232`) in a ring
+bounded at `ECHO_MAX = 256` (`:233`) that evicts **oldest-first** when full (`:813`). Three concrete
+miss modes:
+
+1. **Topic rewrite / canonicalisation by the broker.** If the upstream broker republishes on a
+   different topic than the one we published to (canonical `msh/<region>/2/e/<ch>/<gw>` paths,
+   operator-configured `uplinkTopicRewrite`, or simply a downlink subscription on a different
+   branch), `e.topic === topic` is false and the echo is **not** suppressed.
+2. **Redelivery delayed past 60 s.** Retained-frame replay on reconnect and queued QoS-1 delivery
+   after a network blip routinely exceed the TTL. This codebase already treats delayed replay as
+   real (the `resolveLastHeardSec` replay guard, `mqttIngestion.ts:227`).
+3. **Ring eviction under load.** At >256 uplinks inside the TTL window the oldest entries are
+   `shift()`ed out before they expire, so a busy bridge loses echo entries early.
+
+Additionally, **`mqttBrokerManager.handlePublish` has no echo suppression at all** (`:256-296`) —
+there is no `matchesEcho` call on that path.
+
+**Decision: add the explicit guard.** Per the "do not rely on it" rule, `detectOkToMqttViolation`
+takes `localGatewayNodeNum` and sets `selfGateway`; a self-gateway reception is neither a violation
+nor suspected. Fact 1 means the guard should essentially never fire in practice — which is exactly
+what makes it a cheap, safe belt-and-braces check rather than a behavior change. It costs one integer
+comparison per envelope and removes the entire class of "MeshMonitor flags itself" failure.
+
+**Where `localGatewayNodeNum` comes from** — threaded through `MqttIngestionInput` exactly like
+`topic`, because both call sites already know their own identity. No `sourceManagerRegistry` lookup
+inside `mqttPacketLogService` (that would be a new coupling and a cycle risk):
+
+| Call site | Value |
+|---|---|
+| `mqttBrokerManager.handlePublish` (`:272`) | `parseGatewayNodeNum(this.config.gateway.nodeId)` — `MqttBrokerConfig.gateway.nodeId`, `mqttBrokerManager.ts:30`, already used at `:150,163` |
+| `mqttBridgeManager.handleDownlink` (`:698`) | `this.brokerGatewayNum` — `mqttBridgeManager.ts:283`, set from `localInfo.nodeNum >>> 0` at `:355`, reset to `null` at `:431` |
+
+`null` is a legitimate value (broker not yet connected, no local node info). The guard then simply
+does not apply and the predicate falls back to the plain `gatewayNodeNum !== fromNode` test — which
+is still correct, and is where Fact 1 carries the load.
+
+**If a self-echo is somehow still recorded** (guard `null` *and* echo window missed *and* a future
+change starts rewriting `gatewayId`): the row is attributable and reversible — it names a specific
+gateway with a specific `packetId` and `topic`, and the durable table's own retention will age it
+out. It is not silently destructive. Test coverage: §4.5 and §4.2.
+
+**How a violation surfaces on a grouped list row.** `getGroupedPackets`
+(`mqttPacketLog.ts:138-169`) groups by `(sourceId, fromNode, COALESCE(NULLIF(packetId,0), -id))`,
+collapsing every gateway's reception of one packet into one row. The new aggregate
+`MAX(okToMqttViolation)` therefore means **"at least one gateway violated the bit for this packet"**
+— exactly the Phase 2 badge semantic. Per-gateway attribution lives in `getReceptions` (`:200-214`),
+a bare `.select()` that picks up the new columns with no projection change. `MAX(bitfield)` is added
+alongside and is exact (see §2(c) point 4).
+
+### 2(g) New settings keys
+
+Added to `VALID_SETTINGS_KEYS` in `src/server/constants/settings.ts`, immediately after the existing
+`mqtt_packet_log_*` block (`:103-105`):
+
+| Key | Default (when unset/invalid) | Read by | Meaning |
+|---|---|---|---|
+| `mqtt_oktomqtt_violation_log_enabled` | **`'1'` (ON)** | `mqttPacketLogService.isViolationLogEnabled()` | kill switch for the durable violation write. Semantics: `=== '0'` ⇒ off; anything else (**including unset**) ⇒ on. Note this inverts the `mqtt_packet_log_enabled` convention (`=== '1'`) — deliberate, and must be commented at the constant and in the getter, because the feature must work on installs that never touched settings. |
+| `mqtt_oktomqtt_violation_retention_days` | `90` | `getViolationRetentionDays()` | `parseInt`; must be finite and `> 0`, else default |
+| `mqtt_oktomqtt_violation_max_count` | `50000` | `getViolationMaxCount()` | per-source cap; `parseInt`, finite and `> 0`, else default |
+
+Both numeric getters follow `getMaxCount()`/`getMaxAgeHours()` verbatim
+(`mqttPacketLogService.ts:91-101`); the boolean getter follows `isEnabled()` (`:76-84`) including a
+5 s TTL cache and a `resetViolationEnabledCache()` test seam.
+
+**Server-only check.** There is **no production `SERVER_ONLY_SETTINGS` constant** — it is a local
+allowlist inside `src/server/server.settings-persistence.test.ts:405-432`, and it only guards keys
+that **SettingsTab sends**. Phase 1 adds no SettingsTab field, so **no edit is required**, exactly as
+the existing `mqtt_packet_log_*` keys are absent from it. **Trap for Phase 2/3:** if a UI toggle for
+any of these three keys is added to `SettingsTab`, that test fails unless the key is either loaded by
+`SettingsContext` *or* added to that allowlist. Record this in the epic doc.
+
+**Cross-phase availability asymmetry — Phase 2's badge and Phase 3's report are gated differently.**
+This is coherent but non-obvious, and Phase 2 must be told:
+
+| Surface | Reads from | Gated on | Default install |
+|---|---|---|---|
+| Phase 3 Reports view | `mqtt_ok_to_mqtt_violations` | `mqtt_oktomqtt_violation_log_enabled` — **default ON** | **works** |
+| Phase 2 Packet Monitor badge | `mqtt_packet_log` (via `getGroupedPackets`) | `mqtt_packet_log_enabled` — **default OFF** (opt-in, `mqttPacketLogService.ts:81`) | **badge never appears** |
+
+So on an install that has never enabled the MQTT packet monitor, the Reports view can show
+violations while the packet list shows no badge on any row — because there are no `mqtt_packet_log`
+rows *at all*, not because the badge is broken. This follows directly from §2(d)'s decision to make
+the durable write independent of the packet-log opt-in (the report would otherwise be empty on most
+installs), and it is the right trade: the analysis surface works out of the box, the high-volume
+reception log stays opt-in.
+
+**Phase 2 requirement:** the packet-monitor empty state must explain that capture is opt-in and point
+at `mqtt_packet_log_enabled` — otherwise a user who saw violations in Reports will read the missing
+badge as a bug. The same asymmetry governs `includeUnknown` (§2(e)): suspected entries need the
+packet log too, which is why the route returns `suspectedAvailable`. WP6 records this in the epic doc.
+
+---
+
+## 3. File-by-file changes
+
+### 3.1 `src/server/utils/okToMqtt.ts` — **NEW**
+
+Exports exactly the API in §2(a). Implementation notes:
+- `readBitfieldOkToMqtt`: `typeof b !== 'number' || !Number.isFinite(b)` ⇒ `'unknown'`;
+  `((b >>> 0) & 0x1) === 1 ? 'yes' : 'no'`.
+- `resolveOkToMqttForEnvelope`: reproduce the `:482-499` control flow (see §2(a) table). Must **not**
+  call `channelDecryptionService.isEnabled()`.
+- `parseGatewayNodeNum`: moved verbatim from `mqttPacketLogService.ts:183-187`.
+- `detectOkToMqttViolation`: sync; `bitfield = typeof d?.bitfield === 'number' ? d.bitfield >>> 0 : null`;
+  `fromNode = typeof p?.from === 'number' ? p.from >>> 0 : null`;
+  `gatewayNodeNum = parseGatewayNodeNum(envelope.gatewayId)`;
+  `selfGateway = localGatewayNodeNum != null && gatewayNodeNum != null &&
+  Number(gatewayNodeNum) === Number(localGatewayNodeNum)`; then §2(f)/§2(f.1). The JSDoc must state
+  that `selfGateway` is the belt-and-braces guard and must **not** be removed in favour of the
+  bridge's echo suppression (§2(f.1) Fact 2).
+- No `any`. Full JSDoc citing firmware `MQTT::onSend` (MQTT.cpp:767-788) and issue #4114.
+
+### 3.2 `src/db/schema/mqttPacketLog.ts` — **EDIT**
+
+For each of the three table definitions, add three columns immediately after `payloadPreview` and
+before `createdAt`:
+
+```ts
+// SQLite
+/** Raw `Data.bitfield` (protobuf field 9). NULL = absent/undecryptable = ok_to_mqtt unknown (#4114). */
+bitfield: integer('bitfield'),
+/**
+ * 0/1 integer, NOT a boolean column type — same load-bearing reason as `encrypted` above:
+ * the grouped query does `MAX(okToMqttViolation)` and PostgreSQL has no MAX(boolean).
+ * 1 ⇒ bit 0 was explicitly clear AND the publishing gateway is not the originator (#4114).
+ */
+okToMqttViolation: integer('okToMqttViolation').notNull().default(0),
+/** Raw MQTT topic this reception arrived on. Diagnostic (#4114). */
+topic: text('topic'),
+
+// PostgreSQL
+bitfield: pgInteger('bitfield'),
+okToMqttViolation: pgInteger('okToMqttViolation').notNull().default(0),
+topic: pgText('topic'),
+
+// MySQL
+bitfield: myInt('bitfield'),
+okToMqttViolation: myInt('okToMqttViolation').notNull().default(0),
+topic: myVarchar('topic', { length: 512 }),
+```
+
+**Also fix the stale doc comment at `:53`** — it omits `'distance'`, which both
+`MqttIngestOutcome` (`src/db/repositories/mqttPacketLog.ts:20`) and `mapOutcome`
+(`mqttPacketLogService.ts:167-168`) emit:
+
+```ts
+/** 'ingested' | 'encrypted' | 'ignored' | 'geo-ignored' | 'distance' | 'unsupported-portnum' | 'decode-error'. */
+```
+
+### 3.3 `src/db/schema/mqttOkToMqttViolations.ts` — **NEW**
+
+Three exports — `mqttOkToMqttViolationsSqlite`, `…Postgres`, `…Mysql` — with the columns from §2(d).
+Import style copied from `src/db/schema/mqttPacketLog.ts:1-3`. File-header comment: what the table is,
+why it is separate from `mqtt_packet_log` (retention immunity, §1.9), and that it holds **confirmed
+violations only**.
+
+### 3.4 `src/db/schema/index.ts` — **EDIT**
+
+Add `export * from './mqttOkToMqttViolations.js';` next to line 23.
+
+### 3.5 `src/db/activeSchema.ts` — **EDIT (5 spots)**
+
+Mirror the `mqttPacketLog` wiring exactly:
+1. `:58-59` import block → add the three new table exports.
+2. `:194` `ActiveSchema` interface → `mqttOkToMqttViolations: any;` reusing the existing
+   `// eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4114 matches the existing
+   ActiveSchema per-dialect table pattern; typing burn-down is #3962 Phase 6` comment form
+   (the same disable already exists at `:193` for #4124).
+3. `:292` sqlite map, 4. `:350` postgres map, 5. `:408` mysql map.
+
+### 3.6 `src/server/migrations/128_mqtt_oktomqtt_violations.ts` — **NEW**
+
+Two parts, both idempotent, no destructive rebuild, no backfill.
+
+```ts
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing, addColumnIfMissingPostgres, addColumnIfMissingMysql,
+  createTableIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 128';
+const PL = 'mqtt_packet_log';
+const V  = 'mqtt_ok_to_mqtt_violations';
+```
+
+**SQLite** (`export const migration = { up, down }`):
+
+```sql
+-- part A
+ALTER TABLE mqtt_packet_log ADD COLUMN bitfield INTEGER                       -- addColumnIfMissing
+ALTER TABLE mqtt_packet_log ADD COLUMN okToMqttViolation INTEGER NOT NULL DEFAULT 0
+ALTER TABLE mqtt_packet_log ADD COLUMN topic TEXT
+-- part B
+CREATE TABLE IF NOT EXISTS mqtt_ok_to_mqtt_violations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  sourceId TEXT NOT NULL,
+  packetId INTEGER, fromNode INTEGER, fromNodeId TEXT,
+  gatewayId TEXT, gatewayNodeNum INTEGER,
+  channelId TEXT, portnum INTEGER, portnumName TEXT,
+  bitfield INTEGER, topic TEXT, rxTime INTEGER,
+  timestamp INTEGER NOT NULL, createdAt INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_ts ON mqtt_ok_to_mqtt_violations(sourceId, timestamp);
+CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_gw_ts ON mqtt_ok_to_mqtt_violations(sourceId, gatewayNodeNum, timestamp);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mqtt_v_dedupe ON mqtt_ok_to_mqtt_violations(sourceId, packetId, fromNode, gatewayNodeNum);
+```
+
+`down(db)`: log-only, matching `125_…:43-45` ("column drops are destructive").
+
+**PostgreSQL** — `export async function runMigration128Postgres(client: import('pg').PoolClient): Promise<void>`
+(typed as migration 121 does — **no `any`, no eslint-disable**):
+
+```ts
+await addColumnIfMissingPostgres(client, PL, 'bitfield', '"bitfield" INTEGER');
+await addColumnIfMissingPostgres(client, PL, 'okToMqttViolation', '"okToMqttViolation" INTEGER NOT NULL DEFAULT 0');
+await addColumnIfMissingPostgres(client, PL, 'topic', '"topic" TEXT');
+await client.query(`CREATE TABLE IF NOT EXISTS ${V} (
+  id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  "sourceId" TEXT NOT NULL,
+  "packetId" BIGINT, "fromNode" BIGINT, "fromNodeId" TEXT,
+  "gatewayId" TEXT, "gatewayNodeNum" BIGINT,
+  "channelId" TEXT, portnum INTEGER, "portnumName" TEXT,
+  bitfield INTEGER, topic TEXT, "rxTime" BIGINT,
+  "timestamp" BIGINT NOT NULL, "createdAt" BIGINT NOT NULL
+)`);
+await client.query(`CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_ts ON ${V}("sourceId","timestamp")`);
+await client.query(`CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_gw_ts ON ${V}("sourceId","gatewayNodeNum","timestamp")`);
+await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mqtt_v_dedupe ON ${V}("sourceId","packetId","fromNode","gatewayNodeNum")`);
+```
+
+**MySQL** — `export async function runMigration128Mysql(pool: import('mysql2/promise').Pool): Promise<void>`:
+
+```ts
+await addColumnIfMissingMysql(pool, PL, 'bitfield', 'bitfield INT');
+await addColumnIfMissingMysql(pool, PL, 'okToMqttViolation', 'okToMqttViolation INT NOT NULL DEFAULT 0');
+await addColumnIfMissingMysql(pool, PL, 'topic', 'topic VARCHAR(512)');
+await createTableIfMissingMysql(pool, V, `CREATE TABLE ${V} (
+  id SERIAL PRIMARY KEY,
+  sourceId VARCHAR(255) NOT NULL,
+  packetId BIGINT, fromNode BIGINT, fromNodeId VARCHAR(16),
+  gatewayId VARCHAR(32), gatewayNodeNum BIGINT,
+  channelId VARCHAR(64), portnum INT, portnumName VARCHAR(48),
+  bitfield INT, topic VARCHAR(512), rxTime BIGINT,
+  timestamp BIGINT NOT NULL, createdAt BIGINT NOT NULL,
+  INDEX idx_mqtt_v_source_ts (sourceId, timestamp),
+  INDEX idx_mqtt_v_source_gw_ts (sourceId, gatewayNodeNum, timestamp),
+  UNIQUE KEY idx_mqtt_v_dedupe (sourceId, packetId, fromNode, gatewayNodeNum)
+)`);
+```
+
+(Indexes are inline in the `CREATE`, per the helpers doc-block, so `createIndexIfMissingMysql` is
+not needed here.)
+
+### 3.7 `src/db/migrations.ts` — **EDIT**
+
+Append after the 127 block (`:2009-2023`), following the recipe exactly:
+
+```ts
+// Migration 128: `ok_to_mqtt` violation detection (#4114) — adds bitfield /
+// okToMqttViolation / topic to `mqtt_packet_log`, plus the retention-immune
+// `mqtt_ok_to_mqtt_violations` history table.
+import { migration as mqttOkToMqttViolationsMigration, runMigration128Postgres, runMigration128Mysql }
+  from '../server/migrations/128_mqtt_oktomqtt_violations.js';   // (import at top, with the others)
+
+registry.register({
+  number: 128,
+  name: 'mqtt_oktomqtt_violations',
+  settingsKey: 'migration_128_mqtt_oktomqtt_violations',
+  sqlite: (db) => mqttOkToMqttViolationsMigration.up(db),
+  postgres: (client) => runMigration128Postgres(client),
+  mysql: (pool) => runMigration128Mysql(pool),
+});
+```
+
+`src/db/migrations.test.ts` needs **no edit**.
+
+### 3.8 `src/db/repositories/mqttOkToMqttViolations.ts` — **NEW**
+
+`export class MqttOkToMqttViolationsRepository extends BaseRepository`. Every read passes through
+`this.normalizeBigInts(...)`.
+
+```ts
+export interface DbMqttOkToMqttViolation {
+  id?: number;
+  sourceId: string;                 // required on writes
+  packetId?: number | null;
+  fromNode?: number | null;
+  fromNodeId?: string | null;
+  gatewayId?: string | null;
+  gatewayNodeNum?: number | null;
+  channelId?: string | null;
+  portnum?: number | null;
+  portnumName?: string | null;
+  bitfield?: number | null;
+  topic?: string | null;
+  rxTime?: number | null;
+  timestamp: number;
+  createdAt: number;
+}
+
+export type ViolationGatewaySort = 'violationCount' | 'lastSeen' | 'distinctOriginators' | 'gatewayId';
+export type ViolationListSort    = 'timestamp' | 'fromNode' | 'gatewayId';
+
+export interface ViolationRangeQuery {
+  sourceIds: string[];              // explicit cross-source set; [] ⇒ empty result
+  since: number;                    // ms epoch, inclusive
+  until: number;                    // ms epoch, inclusive
+  gatewayId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface MqttViolationGateway {
+  gatewayId: string | null;
+  gatewayNodeNum: number | null;
+  violationCount: number;
+  distinctOriginators: number;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+class MqttOkToMqttViolationsRepository extends BaseRepository {
+  async insertViolation(v: DbMqttOkToMqttViolation): Promise<void>;
+  async getGatewaySummary(q: ViolationRangeQuery & { sort?: ViolationGatewaySort; dir?: 'asc'|'desc' }): Promise<MqttViolationGateway[]>;
+  async getGatewaySummaryCount(q: ViolationRangeQuery): Promise<number>;
+  async getGatewaySourceIds(q: ViolationRangeQuery): Promise<Array<{ gatewayId: string; sourceId: string }>>;
+  async getViolations(q: ViolationRangeQuery & { sort?: ViolationListSort; dir?: 'asc'|'desc' }): Promise<DbMqttOkToMqttViolation[]>;
+  async getViolationCount(q: ViolationRangeQuery): Promise<number>;
+  async getRowCount(query?: { sourceId?: string }): Promise<number>;
+  async deleteViolationsOlderThan(timestamp: number, sourceId?: string): Promise<number>;
+  async trimViolationsToCount(sourceId: string, maxCount: number): Promise<number>;
+  async getViolationSourceIds(): Promise<string[]>;
+  async deleteAllViolations(sourceId?: string): Promise<number>;
+}
+```
+
+Implementation rules:
+- `insertViolation` throws `new Error('MqttOkToMqttViolationsRepository.insertViolation requires a sourceId')`
+  when `!v.sourceId` (mirrors `insertPacket`, `mqttPacketLog.ts:100-102`). Dedupe branch:
+  `this.dbType === 'mysql' ? …onDuplicateKeyUpdate({ set: { timestamp: sql\`timestamp\` } }) : …onConflictDoNothing()`.
+- **Every cross-source method guards `if (q.sourceIds.length === 0) return [] / 0;`** before building
+  an `inArray` (an empty `inArray` is a dialect-dependent hazard). Then
+  `inArray(t.sourceId, q.sourceIds)`, `gte(t.timestamp, q.since)`, `lte(t.timestamp, q.until)`,
+  optional `eq(t.gatewayId, q.gatewayId)`.
+- Single-source methods (`getRowCount`, `trimViolationsToCount`, `deleteAllViolations`,
+  `deleteViolationsOlderThan` with a `sourceId`) use `this.withSourceScope(t, sourceId)` /
+  `eq(t.sourceId, sourceId)` exactly as `MqttPacketLogRepository` does.
+- `getGatewaySummary`: `.groupBy(t.gatewayId)` with
+  `gatewayNodeNum: sql\`MAX(${t.gatewayNodeNum})\``, `violationCount: sql\`COUNT(*)\``,
+  `distinctOriginators: sql\`COUNT(DISTINCT ${t.fromNode})\``, `firstSeen: sql\`MIN(${t.timestamp})\``,
+  `lastSeen: sql\`MAX(${t.timestamp})\``. **Single-argument `COUNT(DISTINCT …)` only** — MySQL rejects
+  the multi-arg form (comment at `mqttPacketLog.ts:174-175`). `sourceId` must **not** be selected
+  ungrouped (MySQL `ONLY_FULL_GROUP_BY`); the per-gateway `sourceIds` array is assembled by the route
+  from `getGatewaySourceIds` (a `selectDistinct({ gatewayId, sourceId })` over the same filters).
+  ORDER BY is built from the whitelisted `sort`/`dir`, never from raw user input.
+- `getGatewaySummaryCount`: subquery-over-grouped, copied from `getGroupedPacketCount`
+  (`mqttPacketLog.ts:177-189`).
+- `trimViolationsToCount`: copy `trimPacketsToCount` (`:269-289`) verbatim, substituting the table.
+
+### 3.9 `src/db/repositories/mqttPacketLog.ts` — **EDIT**
+
+1. `DbMqttPacket` (`:24-50`) — add `bitfield?: number | null;`,
+   `okToMqttViolation: number;  // 0 | 1`, `topic?: string | null;`.
+2. `MqttGroupedPacket` (`:64-82`) — add `bitfield: number | null;  // representative (MAX) — exact:
+   the field is the originator's` and `okToMqttViolation: number;  // MAX — 1 ⇒ at least one gateway violated`.
+3. `getGroupedPackets` projection (`:143-161`) — add, **before** `gatewayCount`:
+   ```ts
+   bitfield: sql<number | null>`MAX(${t.bitfield})`,
+   okToMqttViolation: sql<number>`MAX(${t.okToMqttViolation})`,
+   ```
+   (Both are aggregates ⇒ `ONLY_FULL_GROUP_BY`-safe and PG-safe. `topic` is deliberately **not**
+   projected onto the grouped row — it is per-reception and reachable via `getReceptions`.)
+4. Two new methods powering `includeUnknown` (§2(e)):
+   ```ts
+   /** Suspected ok_to_mqtt violations (#4114): relayed receptions whose bit was unreadable.
+    *  Bounded by this table's retention window — see MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(e). */
+   async getSuspectedViolations(q: {
+     sourceIds: string[]; since: number; until: number; gatewayId?: string;
+     limit?: number; offset?: number;
+   }): Promise<DbMqttPacket[]>;
+   async getSuspectedViolationGateways(q: { sourceIds: string[]; since: number; until: number }):
+     Promise<Array<{ gatewayId: string | null; gatewayNodeNum: number | null;
+                     suspectedCount: number; distinctOriginators: number;
+                     firstSeen: number; lastSeen: number }>>;
+   ```
+   Predicate for both: `inArray(sourceId, sourceIds)` (with the empty-array guard),
+   `isNull(t.bitfield)`, `isNotNull(t.gatewayNodeNum)`, `isNotNull(t.fromNode)`,
+   `sql\`${t.gatewayNodeNum} <> ${t.fromNode}\``, `gte(t.timestamp, since)`, `lte(t.timestamp, until)`.
+
+### 3.10 `src/db/repositories/index.ts` — **EDIT**
+
+Add `export { MqttOkToMqttViolationsRepository } from './mqttOkToMqttViolations.js';` plus its
+types, next to the `MqttPacketLogRepository` export (`:86`).
+
+### 3.11 `src/services/database.ts` — **EDIT (3 spots)**
+
+Mirroring `mqttPacketLogRepo` exactly:
+1. `:485` neighbourhood — `public mqttOkToMqttViolationsRepo: MqttOkToMqttViolationsRepository | null = null;`
+2. `:673-676` neighbourhood — getter:
+   ```ts
+   get mqttOkToMqttViolations(): MqttOkToMqttViolationsRepository {
+     if (!this.mqttOkToMqttViolationsRepo) throw new Error('Database not initialized');
+     return this.mqttOkToMqttViolationsRepo;
+   }
+   ```
+3. `:922` neighbourhood —
+   `this.mqttOkToMqttViolationsRepo = new MqttOkToMqttViolationsRepository(drizzleDb, this.drizzleDbType);`
+
+(No `*Async` façade methods are added — the packet-monitor family is accessed through the repo
+property, e.g. `databaseService.mqttPacketLog.getGroupedPackets(...)`, and this follows that.)
+
+### 3.12 `src/server/mqttIngestion.ts` — **EDIT (3 spots)**
+
+1. `MqttIngestionInput` (`:134-146`) — add two **optional** fields so no existing caller/test breaks:
+   ```ts
+   /** Raw MQTT topic this envelope arrived on. Diagnostic; persisted on the packet log (#4114). */
+   topic?: string;
+   /**
+    * This source's OWN gateway node number, used by the self-echo guard so MeshMonitor can
+    * never flag itself as a violating gateway (#4114, §2(f.1)). `null`/omitted when the
+    * source has no local identity yet — the guard then simply does not apply.
+    */
+   localGatewayNodeNum?: number | null;
+   ```
+2. `:190-205` — the bitfield preservation of §2(b).
+3. `:589` — `void mqttPacketLogService.logEnvelope(input.sourceId, input.envelope, result,
+   input.topic, input.localGatewayNodeNum);`
+
+### 3.13 `src/server/mqttBrokerManager.ts` — **EDIT (1 spot)**
+
+At `:272-276`, add to the `ingestServiceEnvelope({ … })` object:
+```ts
+topic: msg.topic,
+localGatewayNodeNum: parseGatewayNodeNum(this.config.gateway.nodeId),
+```
+`MqttBrokerConfig.gateway.nodeId` is declared at `:30` and already read at `:150,163`. Import
+`parseGatewayNodeNum` from `./utils/okToMqtt.js`. Hoist the parse to a memoised private field if the
+per-publish `parseInt` shows up in profiling — not required for correctness.
+
+### 3.14 `src/server/mqttBridgeManager.ts` — **EDIT (2 spots)**
+
+1. `:482-499` — the evaluator refactor of §2(a); add
+   `import { allowsUplink, resolveOkToMqttForEnvelope } from './utils/okToMqtt.js';`.
+2. `:698-702` — add to the `ingestServiceEnvelope({ … })` object:
+   ```ts
+   topic,                                        // handleDownlink(topic, …) param, in scope at :643
+   localGatewayNodeNum: this.brokerGatewayNum,   // :283, set from localInfo.nodeNum at :355
+   ```
+   `brokerGatewayNum` is `null` before the broker reports local node info and is reset to `null` at
+   `:431` — both are legitimate, see §2(f.1).
+
+### 3.15 `src/server/services/mqttPacketLogService.ts` — **EDIT**
+
+1. Delete the local `parseGatewayNodeNum` (`:183-187`); import it from `../utils/okToMqtt.js`.
+2. `buildMqttPacketLogRow` (`:203-244`) — new signature and three new row fields:
+   ```ts
+   export function buildMqttPacketLogRow(
+     sourceId: string,
+     envelope: ServiceEnvelopeShape,
+     result: MqttIngestionResult,
+     topic?: string,
+     evaluated?: OkToMqttViolationEval,   // pass the already-computed eval to avoid recompute
+   ): DbMqttPacket | null
+   ```
+   ```ts
+   const v = evaluated ?? detectOkToMqttViolation(envelope);   // caller always passes it
+   // …
+   bitfield: v.bitfield,
+   okToMqttViolation: v.isViolation ? 1 : 0,
+   topic: topic ?? null,
+   ```
+   The `evaluated` parameter is how the self-echo guard reaches the row: `logEnvelope` computes the
+   eval **once** with `localGatewayNodeNum` and passes it in, so `buildMqttPacketLogRow`'s own
+   fallback (which has no local identity) is only ever hit by direct unit-test calls.
+3. New exported pure projection:
+   ```ts
+   /** Project a packet-log row onto the durable violation row. Same source of truth ⇒ they
+    *  can never disagree. Caller has already established row.okToMqttViolation === 1. */
+   export function buildViolationRow(row: DbMqttPacket): DbMqttOkToMqttViolation
+   ```
+   Copies `sourceId, packetId, fromNode, fromNodeId, gatewayId, gatewayNodeNum, channelId,
+   portnum, portnumName, bitfield, topic, rxTime, timestamp, createdAt`.
+4. `logEnvelope` (`:109-123`) — the body in §2(d). Signature gains
+   `topic?: string, localGatewayNodeNum?: number | null`.
+5. Settings: `isViolationLogEnabled()` + `resetViolationEnabledCache()` (clone `:76-89`, **but the
+   default-on inversion of §2(g)**), `getViolationRetentionDays()`, `getViolationMaxCount()`
+   (clone `:91-101`), and matching `DEFAULT_VIOLATION_RETENTION_DAYS = 90`,
+   `DEFAULT_VIOLATION_MAX_COUNT = 50000` fields.
+6. `runCleanup()` (`:51-69`) — second phase per §2(d). Same try/catch, same `logger.debug` summary
+   line (extended to mention violations removed).
+7. Thin pass-throughs for the routes:
+   ```ts
+   async getViolationGatewaySummary(q): Promise<MqttViolationGateway[]>
+   async getViolationGatewaySummaryCount(q): Promise<number>
+   async getViolationGatewaySourceIds(q): Promise<Array<{gatewayId: string; sourceId: string}>>
+   async getViolations(q): Promise<DbMqttOkToMqttViolation[]>
+   async getViolationCount(q): Promise<number>
+   async getSuspectedViolations(q): Promise<DbMqttPacket[]>
+   async getSuspectedViolationGateways(q): Promise<…>
+   ```
+   (Each delegates to the corresponding repo method — same style as `:125-143`.)
+
+### 3.16 `src/server/constants/settings.ts` — **EDIT**
+
+Three keys per §2(g), added after `:105`, with a comment referencing #4114 and calling out the
+default-ON inversion.
+
+### 3.17 `src/server/routes/analysisRoutes.ts` — **EDIT**
+
+**Reuse check (verified).** `analysisRoutes.ts` declares exactly three module-level helpers —
+`parseSourcesParam` (`:54`), `clampPageSize` (`:59`), `parseSinceMs` (`:65`). There is **no**
+`parseUntilMs`, `parseLookbackDays`, or `parseBoolParam` under those or any similar name, so the
+three below are genuinely new. Reuse `parseSourcesParam`, `clampPageSize`, and `parseSinceMs` as-is.
+
+**One near-duplicate to be aware of, deliberately NOT refactored:** the solar handlers inline an
+anonymous lookback parser twice (`:298-302` and `:379-383`). It differs from `parseLookbackDays`
+below in both the query-param name (`lookback_days`, snake_case) and the clamp (**1..90**, vs 1..365
+here). Do **not** unify them in this phase — changing the solar endpoints' clamp or param name is an
+unrelated behavior change. To avoid a third convention, `parseLookbackDays` accepts **both**
+`lookbackDays` and `lookback_days` spellings; the handler passes
+`req.query.lookbackDays ?? req.query.lookback_days`.
+
+Add near the existing helpers (`:54-68`):
+
+```ts
+function parseUntilMs(raw: unknown): number {
+  const n = parseInt(String(raw ?? ''), 10);
+  return Number.isFinite(n) && n > 0 ? n : Date.now();
+}
+function parseLookbackDays(raw: unknown): number {
+  const n = parseInt(String(raw ?? '7'), 10);
+  if (!Number.isFinite(n)) return 7;
+  return Math.min(Math.max(n, 1), 365);
+}
+function parseBoolParam(raw: unknown): boolean {
+  return raw === 'true' || raw === '1';
+}
+const VIOLATION_GATEWAY_SORTS = ['violationCount','lastSeen','distinctOriginators','gatewayId'] as const;
+const VIOLATION_LIST_SORTS    = ['timestamp','fromNode','gatewayId'] as const;
+```
+
+Then the two handlers of §2(e). Both:
+1. `const permitted = await resolvePermittedSourceIds(req, 'packetmonitor');`
+2. intersect with `parseSourcesParam(req.query.sources)` using the existing idiom;
+3. resolve `since` (explicit `since`, else `Date.now() - lookbackDays * 86_400_000`) and `until`;
+   `since > until` ⇒ `fail(res, 400, 'INVALID_RANGE', …)`;
+4. validate `sort`/`dir` against the whitelist ⇒ `fail(res, 400, 'INVALID_SORT_FIELD', …)` /
+   `'INVALID_SORT_DIRECTION'`;
+5. short-circuit `sourceIds.length === 0` to an empty payload via `ok(...)` (200);
+6. query the durable repo; when `includeUnknown`, also query the suspected path — but **only when
+   `await mqttPacketLogService.isEnabled()`**, otherwise set `suspectedAvailable: false` and skip it;
+7. for `/gateways`, merge the suspected per-gateway counts into the confirmed rows by `gatewayId`
+   (gateways present only in the suspected set appear with `violationCount: 0`), then sort/paginate
+   the merged list **in the handler** (both inputs are already bounded by `limit`-free aggregate
+   queries over an indexed range; cap the pre-merge fetch at 2000 rows per side);
+8. attach `sourceIds` per gateway from `getViolationGatewaySourceIds`;
+9. `ok(res, payload)`; `catch` ⇒ `logger.error(...)` + `fail(res, 500, 'MQTT_VIOLATIONS_FETCH_FAILED', …)`.
+
+Node display names are **not** resolved in Phase 1 (`gatewayLongName` is out of the response until a
+phase needs it) — keep the handler free of the N-source `getAllNodes` scan.
+
+---
+
+## 4. Test plan
+
+All standard Vitest suites. **No standalone scripts.** Mocks of async DB methods use
+`mockResolvedValue`.
+
+> **Multi-backend warning:** the PG/MySQL suites are `describe.skipIf(!postgresAvailable)` /
+> `!mysqlAvailable` and **skip silently** with nothing on `localhost:5433` / `localhost:3307`.
+> Before claiming migration/schema work verified, start both containers (recipe in `CLAUDE.md`) and
+> confirm coverage via `numPendingTests` in the JSON reporter, not just `success`.
+
+### 4.1 `src/server/migrations/128_mqtt_oktomqtt_violations.test.ts` — **NEW**
+
+Template: `121_mqtt_packet_log.test.ts`.
+- **SQLite:** run `121`'s `migration.up(db)` first (so `mqtt_packet_log` exists), then `128`.
+  - creates `mqtt_ok_to_mqtt_violations`; **second `up()` does not throw** (idempotency);
+  - all three new `mqtt_packet_log` columns present (`PRAGMA table_info`), and re-running does not
+    throw ("duplicate column" swallowed);
+  - full round-trip insert/read of a violation row;
+  - **dedupe:** inserting the same `(sourceId, packetId, fromNode, gatewayNodeNum)` twice raises a
+    UNIQUE constraint at the raw-SQL level (proving the index exists); the repo-level no-op is
+    covered in 4.5.
+- **PostgreSQL / MySQL:** `vi.fn()` mock client/pool; assert the expected statements were issued
+  (`ADD COLUMN IF NOT EXISTS` ×3 for PG; `information_schema.COLUMNS` pre-checks + `information_schema.TABLES`
+  pre-check for MySQL) and that the functions resolve without throwing.
+
+### 4.2 `src/server/utils/okToMqtt.test.ts` — **NEW**
+
+- `readBitfieldOkToMqtt`: `undefined`/`null`/`NaN`/`'1'` ⇒ `'unknown'`; `0` ⇒ `'no'`; `1` ⇒ `'yes'`;
+  `2` ⇒ `'no'` (bit 0 clear, other bits set); `3` ⇒ `'yes'`; `0xffffffff` ⇒ `'yes'`.
+- `resolveOkToMqttForEnvelope`: plaintext yes/no; plaintext-with-absent-bitfield **and no encrypted**
+  ⇒ `'unknown'`; plaintext-with-absent-bitfield **and encrypted present** ⇒ decrypt attempted (assert
+  `tryDecrypt` called with `(enc, id, from, channelHash)`); decrypt success with bitfield ⇒ mapped;
+  decrypt success with non-numeric bitfield ⇒ `'unknown'`; decrypt failure ⇒ `'unknown'`; missing
+  `id`/`from` ⇒ `'unknown'` with **no** `tryDecrypt` call.
+- **`allowsUplink` fail-closed vs tri-state distinction** (the point of the extraction):
+  `'yes'`⇒`true`, `'no'`⇒`false`, **`'unknown'`⇒`false`**, while the detector treats `'unknown'`
+  as *suspected*, not *violation*.
+- `parseGatewayNodeNum`: `'!aabbccdd'`⇒`0xaabbccdd`; `undefined`/`null`/`''`⇒`null`;
+  `'aabbccdd'` (no `!`)⇒`null`; `'!zzzz'`⇒`null`; `'!ffffffff'`⇒`4294967295` (unsigned).
+- `detectOkToMqttViolation` — **one case per row of the §2(f) table**, with two dedicated, explicitly
+  named tests:
+  - row 4: *"originator publishing its own packet must NOT flag, even with bit 0"*;
+  - row 15 / §2(f.1): *"a gateway equal to our own localGatewayNodeNum must NOT flag, even with
+    bit 0"* — assert `selfGateway === true`, `relayed === false`, `isViolation === false`,
+    `isSuspected === false`. Plus the complements: `localGatewayNodeNum = null` ⇒ guard inert
+    (falls back to the plain `gateway !== originator` test); `localGatewayNodeNum` set but not
+    matching ⇒ normal violation still flags.
+
+### 4.3 `src/server/mqttBridgeManager.test.ts` — **EXTEND**
+
+Existing cases at `:1038-1101` and `:1103-1141` must pass **unmodified** (regression guard for the
+refactor). Add:
+- decoded present with `bitfield` absent **and** `encrypted` present ⇒ `tryDecrypt` is still called;
+- `'unknown'` outcome ⇒ packet not uplinked **and** `uplinkOkToMqttDrops` incremented (assert via
+  `getStatus()` / the counter surfaced at `:462`).
+
+### 4.4 `src/server/mqttIngestion.bitfield.test.ts` — **NEW**
+
+**Proves `bitfield` survives server-side decrypt** — the §2(b) regression guard.
+- Mock `channelDecryptionService.isEnabled()` ⇒ `true` and `tryDecrypt` ⇒
+  `{ success: true, portnum: PortNum.TEXT_MESSAGE_APP, payload, bitfield: 0, channelDatabaseId: 1 }`.
+- Feed an envelope with `packet.encrypted` set and no `packet.decoded` through `ingestServiceEnvelope`.
+- Assert `envelope.packet.decoded.bitfield === 0` afterwards, and that the row handed to
+  `mqttPacketLogService.logEnvelope` carries `bitfield: 0`.
+- Same with `bitfield: 1`, and with `bitfield` omitted from the decrypt result ⇒ row `bitfield: null`.
+- Assert the plaintext path (no decrypt) still carries the wire `bitfield` through untouched.
+
+### 4.5 `src/server/mqttPacketLogService.violations.test.ts` — **NEW**
+
+- violation row **written while `mqtt_packet_log_enabled` is off** (the independence requirement);
+- violation row **not** written when `mqtt_oktomqtt_violation_log_enabled === '0'`;
+- violation row **not** written for originator-self-publish (`gatewayNodeNum === fromNode`, bit 0);
+- **REQUIRED (§2(f.1)): an envelope whose `gatewayId` is our own local node must not produce a
+  violation row.** Call `logEnvelope(sourceId, envelope, result, topic, OUR_NODE_NUM)` with
+  `envelope.gatewayId = '!<OUR_NODE_NUM hex>'`, `bitfield: 0`, and a *different* `fromNode` (i.e.
+  the shape of a genuine violation in every respect except that we are the gateway) — assert **zero**
+  rows in `mqtt_ok_to_mqtt_violations`. This is the "MeshMonitor must never flag its own operator"
+  guarantee and must fail loudly if the guard is ever removed.
+  - Complement: the same envelope with `localGatewayNodeNum` omitted/`null` (the "echo window was
+    missed **and** we have no local identity" worst case) **does** write a row — documenting the
+    residual exposure rather than hiding it. Per §2(f.1) Fact 1 this remains unreachable in practice
+    because the bridge republishes `p.payload` byte-for-byte and never rewrites `gatewayId`, so a
+    real echo carries the *original* gateway's id; the assertion exists to pin that reasoning to a
+    test so a future change to the uplink path breaks visibly here.
+  - Complement: `localGatewayNodeNum` set but not matching ⇒ the row **is** written (guard does not
+    over-suppress).
+- violation row **not** written when `gatewayId` is malformed / `fromNode` is missing;
+- unknown-bitfield relayed reception writes **no** violation row (only the packet-log row, when enabled);
+- `buildViolationRow` field-for-field projection matches its `DbMqttPacket` source;
+- duplicate `logEnvelope` of the same envelope results in **one** stored violation row
+  (repo-level dedupe no-op, run against SQLite via `createTestDb()`);
+- `runCleanup()` invokes **both** retention phases and uses the violation-specific cutoff/cap;
+- **retention immunity:** after `mqttPacketLog.deletePacketsOlderThan(now)` +
+  `deleteAllPackets()`, the violation rows are still present.
+
+### 4.6 `src/server/services/mqttPacketLogService.buildRow.test.ts` — **EXTEND**
+
+Row carries `bitfield`, `okToMqttViolation`, `topic`; `topic` omitted ⇒ `null`; `okToMqttViolation`
+defaults to `0` for every pre-existing case (proving no existing assertion regresses).
+
+### 4.7 `src/server/mqttPacketLogService.ingestHook.test.ts` — **EXTEND**
+
+`logEnvelope` receives the `topic` threaded from `MqttIngestionInput`; a call with no `topic` still
+works (optional field).
+
+### 4.8 `src/db/repositories/mqttOkToMqttViolations.test.ts` — **NEW**
+
+`createTestDb()` + `new MqttOkToMqttViolationsRepository(drizzleDb, 'sqlite')`, following
+`mqttPacketLog.perSource.test.ts:8-56` for setup and a `makeViolation()` factory.
+- `insertViolation` throws without `sourceId`;
+- duplicate insert is a no-op (row count stays 1, first `timestamp` preserved);
+- `getGatewaySummary` counts, `distinctOriginators`, `firstSeen`/`lastSeen`;
+- every `sort` × `dir` combination orders correctly;
+- `limit`/`offset` pagination; `getGatewaySummaryCount` ignores pagination;
+- `since`/`until` range boundaries are **inclusive**;
+- `gatewayId` filter on `getViolations`;
+- **empty `sourceIds` ⇒ `[]` / `0` with no query executed**;
+- `getGatewaySourceIds` pivots correctly for a gateway seen on two sources.
+
+### 4.9 `src/db/repositories/mqttOkToMqttViolations.perSource.test.ts` — **NEW**
+
+Source-isolation on **every** method: seed identical rows under `source-a` and `source-b`; assert
+`getGatewaySummary`/`getViolations`/`getViolationCount`/`getRowCount`/`deleteViolationsOlderThan`/
+`trimViolationsToCount`/`deleteAllViolations` never leak or delete across sources; assert
+`getViolationSourceIds()` returns both.
+
+### 4.10 `src/db/repositories/mqttPacketLog.grouping.test.ts` — **EXTEND**
+
+- `MAX(okToMqttViolation)` surfaces on the grouped row: three gateway receptions of one packet, only
+  one flagged ⇒ grouped row has `okToMqttViolation === 1`;
+- none flagged ⇒ `0`;
+- `MAX(bitfield)` surfaces, and is `null` when every reception's bitfield is `null`;
+- `getReceptions` returns the per-reception `okToMqttViolation`/`bitfield`/`topic` (bare-select
+  auto-pickup);
+- `getSuspectedViolations` matches only `bitfield IS NULL AND gatewayNodeNum <> fromNode`, and
+  excludes self-published and confirmed rows;
+- `getSuspectedViolationGateways` aggregate shape.
+
+### 4.11 `src/db/repositories/mqttPacketLog.perSource.test.ts` — **EXTEND**
+
+Add `bitfield`, `okToMqttViolation`, `topic` to the existing `makePacket()` factory (`:15-44`) so the
+new columns are exercised by the existing isolation assertions.
+
+### 4.12 `src/server/routes/analysisRoutes.mqttViolations.test.ts` — **NEW**
+
+**Uses `createRouteTestApp`.** Do **not** use the deprecated
+`vi.mock('../../services/database.js')` monkey-patch, and do **not** modify the existing
+`analysisRoutes.test.ts` (which is a legacy monkey-patch file; it converts opportunistically, not in
+this phase).
+
+```ts
+harness = await createRouteTestApp({ mount: app => app.use('/', analysisRoutes) });
+await harness.grant(harness.limited.id, 'packetmonitor', 'read', harness.sourceA);
+```
+
+Cases:
+- admin sees both sources; `limited` (granted on `sourceA` only) sees **only** `sourceA` rows — real
+  SQL enforcement, seeded rows in both sources;
+- anonymous / ungranted ⇒ 200 with `gateways: []`, `sources: []`;
+- `?sources=` intersects with the permitted set and cannot widen it (request `sourceB` while granted
+  only `sourceA` ⇒ empty);
+- envelope shape is exactly `{ success: true, data: { … } }` (assert `res.body.data` is where the
+  payload lives — the Phase 3 contract);
+- `sort`/`dir` whitelist: valid values order the response; an unknown `sort` ⇒ 400 +
+  `code: 'INVALID_SORT_FIELD'`;
+- `since > until` ⇒ 400 + `code: 'INVALID_RANGE'`;
+- `limit`/`offset` pagination and `total`;
+- `lookbackDays` clamps to 1..365 and is ignored when `since` is explicit;
+- `includeUnknown=false` (default) ⇒ `suspectedCount: 0` on every row and the packet-log path is not
+  queried; `includeUnknown=true` with `mqtt_packet_log_enabled` off ⇒ `suspectedAvailable: false`;
+  with it on ⇒ suspected rows merged and `kind: 'suspected'` on the packets endpoint;
+- `/packets?gateway=!aabbccdd` filters to one gateway.
+
+### 4.13 Files explicitly **not** affected
+
+- `src/db/repositories/nodes.test.ts` — no `nodes` column is added, so the hand-written
+  `POSTGRES_CREATE` / `MYSQL_CREATE` DDL blocks need no edit.
+- `src/db/migrations.test.ts` — registry-derived assertions cover 128 automatically.
+- `src/server/routes/mqttPacketRoutes.ts` and its tests — the cross-source surface lives in
+  `analysisRoutes.ts` (epic decision 8).
+
+---
+
+## 5. Work packages
+
+Six packages. File ownership is non-overlapping except where noted; where two packages touch the
+same file the ordering is stated explicitly.
+
+```
+        ┌──────────────────────────────────────────────┐
+WP1 ────┼──> WP3 ──┬──> WP4 ──┐                        │
+        │          │          ├──> WP6 (verification)  │
+WP2 ────┴──────────┴──> WP5 ──┘                        │
+        └──────────────────────────────────────────────┘
+
+PARALLEL: WP1 ∥ WP2      (no shared files, no shared symbols)
+PARALLEL: WP4 ∥ WP5      (after WP3)
+SEQUENTIAL: WP1 → WP3 → {WP4, WP5} → WP6 ;  WP2 → WP4
+```
+
+### WP1 — Schema, migration 128, registration, settings keys *(first; parallel with WP2)*
+
+**Owns:** `src/db/schema/mqttOkToMqttViolations.ts` (new) · `src/db/schema/mqttPacketLog.ts` ·
+`src/db/schema/index.ts` · `src/db/activeSchema.ts` · `src/server/migrations/128_mqtt_oktomqtt_violations.ts` (new) ·
+`src/server/migrations/128_mqtt_oktomqtt_violations.test.ts` (new) · `src/db/migrations.ts` ·
+`src/server/constants/settings.ts` · `src/db/repositories/mqttPacketLog.perSource.test.ts` (factory only).
+
+**Scope:** §3.2–§3.7, §3.16, §4.1, §4.11. Includes the stale-comment fix at
+`src/db/schema/mqttPacketLog.ts:53`.
+
+**Depends on:** nothing.
+
+**Acceptance:** `npx vitest run src/server/migrations/128_* src/db/migrations.test.ts` green;
+migration 128 registered with `settingsKey: 'migration_128_mqtt_oktomqtt_violations'` and all three
+dialect functions; migrations registry contiguity test green; PG/MySQL migration params typed as
+`import('pg').PoolClient` / `import('mysql2/promise').Pool` with **no** `any` and **no** new
+eslint-disable; `tsc --noEmit` green; `npm run lint:ci` shows no new in-repo `FAIL`.
+
+### WP2 — Shared tri-state evaluator + detector + bridge refactor *(parallel with WP1)*
+
+**Owns:** `src/server/utils/okToMqtt.ts` (new) · `src/server/utils/okToMqtt.test.ts` (new) ·
+`src/server/mqttBridgeManager.ts` **(evaluator body at `:482-499` only — WP4 touches the call site at
+`:698` afterwards)** · `src/server/mqttBridgeManager.test.ts`.
+
+**Scope:** §2(a), §2(f), §2(f.1) detector guard, §3.1, §3.14 spot 1, §4.2, §4.3.
+
+**Depends on:** nothing (no DB, no schema).
+
+**Acceptance:** `npx vitest run src/server/utils/okToMqtt.test.ts src/server/mqttBridgeManager*`
+green with the pre-existing `:1038-1141` cases **unmodified**; `evaluateOkToMqtt` is a two-liner over
+`allowsUplink(await resolveOkToMqttForEnvelope(env))`; the §2(a) equivalence table has a test per row;
+`detectOkToMqttViolation` has a test per row of the §2(f) table including **both** named cases
+(originator-self-publish, and the §2(f.1) self-gateway guard with its two complements);
+`tsc` + `lint:ci` clean.
+
+### WP3 — Violations repository + `mqtt_packet_log` repo changes + DB wiring *(after WP1)*
+
+**Owns:** `src/db/repositories/mqttOkToMqttViolations.ts` (new) ·
+`src/db/repositories/mqttOkToMqttViolations.test.ts` (new) ·
+`src/db/repositories/mqttOkToMqttViolations.perSource.test.ts` (new) ·
+`src/db/repositories/mqttPacketLog.ts` · `src/db/repositories/mqttPacketLog.grouping.test.ts` ·
+`src/db/repositories/index.ts` · `src/services/database.ts`.
+
+**Scope:** §3.8–§3.11, §4.8–§4.10.
+
+**Depends on:** WP1 (tables must exist in `activeSchema` and in the migration registry that
+`createTestDb()` replays).
+
+**Acceptance:** all three repo test files green; per-source isolation proven on every method; empty
+`sourceIds` guarded; MySQL-safe aggregates only (single-arg `COUNT(DISTINCT …)`, no ungrouped
+`sourceId` in the summary projection); `MAX(okToMqttViolation)`/`MAX(bitfield)` present in
+`getGroupedPackets`; `databaseService.mqttOkToMqttViolations` resolves after init and throws
+`'Database not initialized'` before; `tsc` + `lint:ci` clean.
+
+### WP4 — Ingest plumbing, violation write, retention *(after WP1+WP2+WP3; parallel with WP5)*
+
+**Owns:** `src/server/mqttIngestion.ts` · `src/server/mqttBrokerManager.ts` ·
+`src/server/mqttBridgeManager.ts` **(call site at `:698` only — WP2 goes first on this file)** ·
+`src/server/services/mqttPacketLogService.ts` ·
+`src/server/mqttIngestion.bitfield.test.ts` (new) ·
+`src/server/mqttPacketLogService.violations.test.ts` (new) ·
+`src/server/services/mqttPacketLogService.buildRow.test.ts` ·
+`src/server/mqttPacketLogService.ingestHook.test.ts`.
+
+**Scope:** §2(b), §2(d) write path + retention, §2(f.1) `localGatewayNodeNum` threading,
+§2(g) getters, §3.12–§3.15, §4.4–§4.7.
+
+**Depends on:** WP2 (`detectOkToMqttViolation`, `parseGatewayNodeNum`), WP3 (the repo),
+WP1 (the columns).
+
+**Acceptance:** bitfield-survives-decrypt test green; violation written with the packet log disabled;
+not written when the kill switch is `'0'`; not written for self-publish/malformed-gateway/unknown-bit;
+**the §4.5 REQUIRED self-gateway test passes — an envelope gatewayed by our own local node produces
+zero violation rows**; `localGatewayNodeNum` is threaded from **both** call sites
+(`mqttBrokerManager.handlePublish` and `mqttBridgeManager.handleDownlink`) and the eval is computed
+**once** in `logEnvelope`; duplicate ingest ⇒ one row; retention runs on the **existing** 15-minute
+interval with **no new `setInterval`**; retention-immunity test green; `logEnvelope` still never
+throws; `tsc` + `lint:ci` clean.
+
+### WP5 — Cross-source analysis routes *(after WP3; parallel with WP4)*
+
+**Owns:** `src/server/routes/analysisRoutes.ts` ·
+`src/server/routes/analysisRoutes.mqttViolations.test.ts` (new).
+
+**Scope:** §2(e), §3.17, §4.12. Must **not** modify the legacy `analysisRoutes.test.ts`.
+
+**Depends on:** WP3. (It calls `mqttPacketLogService` pass-throughs added in WP4; to keep WP4∥WP5
+truly parallel, WP5 may call `databaseService.mqttOkToMqttViolations.*` and
+`databaseService.mqttPacketLog.*` **directly** from the handler — that is the pattern
+`analysisRoutes.ts` already uses for `databaseService.analysis.*`. Prefer that and treat the WP4
+service pass-throughs as optional convenience.)
+
+**Acceptance:** route test file green using `createRouteTestApp`; the deprecated
+`vi.mock('../../services/database.js')` pattern is absent from the new file; response bodies are
+`{ success: true, data: {…} }` via `ok()` and every error path uses `fail()` with a SCREAMING_SNAKE
+code; cross-source permission isolation proven by real SQL; `?sources=` cannot widen the permitted
+set; `tsc` + `lint:ci` clean.
+
+### WP6 — Full verification + doc close-out *(after all)*
+
+**Owns:** `docs/internal/dev-notes/MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md` (Phase 1 checkbox +
+"Deviations / notes"). No source files.
+
+**Scope:**
+1. Start the PG (`:5433`) and MySQL (`:3307`) containers per `CLAUDE.md`, then run the **full** suite:
+   `npx vitest run --reporter=json` — confirm `success: true` **and** that `numPendingTests` reflects
+   the multi-backend suites actually running (not silently skipped).
+2. `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` ⇒ empty.
+3. `npx tsc --noEmit` ⇒ clean.
+4. Confirm no `eslint-baseline.json` rule count grew.
+5. Record in the epic doc's "Deviations / notes" — these are cross-phase and user-facing, so they
+   must survive outside this spec:
+   a. **Forward-only, empty on upgrade (§2(d)).** No backfill is possible; both endpoints return
+      empty until new MQTT traffic arrives after the upgrade. **Expected, not a bug** — say so in
+      the epic doc so the user is not surprised, and so Phase 3's empty state can word itself
+      accordingly.
+   b. **Phase 2 / Phase 3 availability asymmetry (§2(g)).** The durable violation write is
+      **default ON**, but the Phase 2 packet-list badge reads `mqtt_packet_log`, which is opt-in and
+      **default OFF**. On a default install the Reports view works while the badge never appears.
+      **Phase 2 must gate its badge on — and explain — `mqtt_packet_log_enabled` in its empty state.**
+   c. **`includeUnknown` retention-window caveat (§2(e))** — suspected entries come from
+      `mqtt_packet_log`, so they are bounded by its 24 h window and require the packet monitor to be
+      enabled; Phase 3 must surface `suspectedAvailable` / `suspectedWindowMs` in the UI.
+   d. **Self-echo guard (§2(f.1))** — `localGatewayNodeNum` exists because the bridge's echo
+      suppression is topic-string + 60 s TTL + 256-entry ring and is therefore not airtight; do not
+      remove the guard in a later phase on the belief that echo suppression covers it.
+   e. **`SERVER_ONLY_SETTINGS` trap (§2(g))** for any Phase 2/3 SettingsTab toggle over the three
+      new keys.
+   f. **packetId-0 dedupe limitation (§2(d)).**
+
+**Acceptance:** all four checks pass; epic doc updated; PR opened; `/ci-monitor` green.
+
+---
+
+## 6. Open risks
+
+1. **`MAX(bitfield)` on a mixed group.** Argued exact in §2(c) (the field is the originator's and is
+   identical in every gateway's copy). If a gateway ever rewrites it, `MAX` biases toward "opted in".
+   The per-reception truth remains in `getReceptions`, and the violation flag is computed
+   per-reception, so this can only understate — never fabricate — a violation. Acceptable.
+2. **Suspected-row volume in the `includeUnknown` query.** Bounded by the packet log's own retention
+   and by `limit`, but on a busy source the pre-merge fetch can still be large; the 2000-row cap in
+   §3.17 step 7 is the guard. If Phase 3 finds it insufficient, push the merge into SQL rather than
+   raising the cap.
+3. **Kill-switch default inversion** (`!== '0'` rather than `=== '1'`). Deliberate and documented, but
+   it is the one place in this feature where a reader's convention-based assumption is wrong. It must
+   carry a comment at both the constant and the getter.

--- a/docs/internal/dev-notes/MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md
+++ b/docs/internal/dev-notes/MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md
@@ -1,0 +1,294 @@
+# MQTT `ok_to_mqtt` Violation Detection — Epic Plan
+
+**Tracking issue:** #4114
+**Status:** Phase 1 in progress
+**Branch strategy:** one worktree + PR per phase, branched from `origin/main`.
+**Started:** 2026-07-24
+
+## Goal
+
+Surface, in MeshMonitor, when an MQTT-relayed packet's `ok_to_mqtt` bit was violated by the
+publishing gateway — i.e. the packet was uplinked by a node **other than its originator**,
+despite the originator not having opted in.
+
+Firmware's `MQTT::onSend()` only enforces the bit (`Data.bitfield` bit 0) when relaying other
+nodes' packets, and only when `isMqttServerAddressPrivate` is false. That check is a pure
+IP-byte test with no NAT/port-forward awareness, so a gateway reaching its broker via a
+LAN-literal address that is *also* port-forwarded gets misclassified as "private" and silently
+skips the opt-out check for every packet it relays. Given a packet where the bit is off and the
+publishing gateway isn't the originator, `isMqttServerAddressPrivate == true` on that gateway is
+the only explanation — so this is a **provable, detectable signature**, not a guess.
+
+## Prior art — what issue #4114 already got for free
+
+Design items **1, 2 (partly), and 3** of the issue body were delivered by the **MQTT Packet
+Monitor epic (#4124)** — see `MQTT_PACKET_MONITOR_EPIC.md`:
+
+- MQTT *is* wired into the Packet Monitor (`mqtt_packet_log`, migration **121**,
+  `mqttPacketLogService.logEnvelope`, `mqttPacketRoutes.ts`, `MqttPacketMonitorView.tsx`).
+- Every envelope reaching `ingestServiceEnvelope` is logged **unconditionally, before** the
+  decrypt/geo/portnum early returns, with an `ingestOutcome`
+  (`ingested | encrypted | ignored | geo-ignored | distance | unsupported-portnum | decode-error`)
+  — this satisfies the bulk of @.m.a.t.t.'s 2026-07-14 comment.
+- Rows are grouped by packet in the list view with a per-gateway receptions detail modal —
+  the issue's item 3.
+- Gateway identity is already captured as `gatewayId` / `gatewayNodeNum` from
+  `envelope.gatewayId`, so the issue's "derive the gateway from the topic string" trick is
+  unnecessary — we have the value directly.
+
+**What remains is the issue's item 4 — the violation flag itself** — plus the gaps below,
+found during Stage 0 exploration:
+
+| Gap | Location |
+|---|---|
+| `mqtt_packet_log` has no `bitfield` / `okToMqtt` / violation column | `src/db/schema/mqttPacketLog.ts` (25 columns, none of them this) |
+| Ingest **discards `bitfield`** on server-side decrypt even though `tryDecrypt` returns it | `src/server/mqttIngestion.ts:190-205` vs `channelDecryptionService.ts:350` |
+| Bit-evaluation logic exists but is `private` and **uplink-only** | `MqttBridgeManager.evaluateOkToMqtt`, `src/server/mqttBridgeManager.ts:482-499` |
+| Raw MQTT `topic` is in scope at both ingest call sites but never passed | `MqttIngestionInput` has no `topic` field (`mqttIngestion.ts:134-146`) |
+| Reports area is **cross-source/global** (no `SourceContext`) while `mqtt_packet_log` is per-source | `/reports` route, `src/main.tsx:168-171` |
+
+## Interview decisions (2026-07-24)
+
+1. **Violation rule — tri-state, strict default.** Store `okToMqtt` as **true / false /
+   unknown**. A violation is flagged only when the bit is **explicitly 0** *and* the publishing
+   gateway is not the originator. An **absent** bitfield is stored as `unknown` and is *not*
+   flagged by default — mirroring firmware exactly (absent ⇒ violation) would flag a large
+   fraction of all relayed traffic. `unknown` remains reachable via an opt-in toggle
+   (see decision 6).
+2. **Store the raw `topic`.** Add a `topic` column to `mqtt_packet_log` and thread `topic`
+   through `MqttIngestionInput` (already in scope at both call sites — one-line change each).
+   Purely diagnostic now that `gatewayId` covers gateway identity, but directly useful for the
+   "which nodes is MQTT actually receiving" diagnosis in the issue comment.
+3. **Pre-ingest-filter drops: OUT OF SCOPE.** #4124 deliberately excluded copies rejected by
+   the topic/node/portnum pre-filter before `ingestServiceEnvelope`. That exclusion stands;
+   file a separate issue if the diagnosis gap resurfaces.
+4. **Durable violation history.** The packet log is trimmed to 5000 rows / 24h by default, so a
+   report reading it directly could only ever show ~a day and would empty on every trim.
+   Phase 1 therefore also writes a **retention-immune** violation record with its own, much
+   longer retention policy, and the report reads from that.
+5. **Report shape — gateway summary + drill-down.** Top table = one row per offending gateway
+   (violation count, distinct originators affected, sources, first/last seen), expandable /
+   clickable into the underlying violating packets. Answers "which gateway is misbehaving"
+   directly.
+6. **Report features (all four):** lookback/date-range control, CSV export, column sorting +
+   pagination, include-`unknown`-bitfield toggle (off by default).
+7. **UI surfaces:** violation **badge in the Packet Monitor list**, a minimal **per-gateway
+   marker in the existing detail modal** (so the badge isn't a dead end when a packet has N
+   gateways), and the **Reports view** as the search/analysis surface. Not doing: a
+   "violations only" toolbar filter, or violation counts in the gateway multi-select.
+8. **Report is cross-source.** `/reports` is a global route outside `source/:sourceId/*`, so
+   the report aggregates across **all sources the user may read**, via a new endpoint in
+   `analysisRoutes.ts` using the existing `resolvePermittedSourceIds(req, 'packetmonitor')`
+   (the resource is already a parameter, defaulting to `'nodes'`), with an optional
+   `?sources=` CSV filter.
+
+## Architecture facts (Stage 0 exploration)
+
+- **`Data.bitfield` is protobuf field 9** (`protobufs/meshtastic/mesh.proto:1233-1235`,
+  `optional uint32`); bit 0 = "user approves upload to MQTT". It **is** present on the loaded
+  protobufjs `meshtastic.Data` type (reflected from the .proto by `protobufLoader.ts:20-32`).
+- **It is already typed on the ingest shape:** `MeshPacketShape.decoded.bitfield?: number`
+  (`src/server/mqttPacketFilter.ts:47`). For **plaintext** MQTT copies it is populated and
+  reachable with no changes. For **server-decrypted** copies it is lost at
+  `mqttIngestion.ts:190-205`, which synthesizes `packet.decoded` with only
+  `{ portnum, payload, emoji, replyId, channelDatabaseId }`.
+- **Both decrypt services already return it:** `channelDecryptionService.ts:34-39, 302-315, 350`
+  and `pkiDecryptionService.ts:40, 155`.
+- **Existing evaluator to extract (not reimplement):** `MqttBridgeManager.evaluateOkToMqtt`
+  (`mqttBridgeManager.ts:482-499`) — reads `decoded.bitfield & 0x1`, falls back to
+  `channelDecryptionService.tryDecrypt` for encrypted payloads, and is **fail-closed**
+  (absent/undecryptable ⇒ `false`). Its only caller is the **uplink** path
+  (`:760-767`, gated on `!config.ignoreOkToMqtt`, increments `uplinkOkToMqttDrops`).
+  Fail-closed is correct for uplink but **wrong** for detection — hence the tri-state helper.
+- **Undecryptable channels are unjudgeable.** Where no `channel_database` PSK matches, the bit
+  cannot be read at all; those rows are `unknown` by construction. The default
+  `LongFast`/short-PSK channels use the publicly known `defaultpsk` family, so they need no
+  real secret.
+- **Grouped-list projection is explicit.** `getGroupedPackets`
+  (`src/db/repositories/mqttPacketLog.ts:138-171`) selects 18 named aggregates and groups by
+  `(sourceId, fromNode, COALESCE(NULLIF(packetId,0), -id))`. A new column **will not reach the
+  list view** unless an explicit aggregate is added (e.g. `MAX(okToMqttViolation)`). MySQL
+  `ONLY_FULL_GROUP_BY`-safe aggregates are required; MySQL also can't do multi-arg
+  `COUNT(DISTINCT …)` (see the comment at `:175`).
+- **`getReceptions`** (`:200-214`) is a bare `.select()`, so it returns all columns
+  automatically — but the **frontend** `MqttReception` type
+  (`src/components/MQTT/mqttPacketTypes.ts:50-59`) exposes only 8 of them and must be extended.
+- **Existing badge system to reuse:** `outcomeBadgeClass` +
+  `mqpm-badge mqpm-badge-{encrypted|ignored|geo-ignored|distance|error}`
+  (`MqttPacketDetailModal.tsx:26-44`, `src/components/MQTT/MqttPacketMonitor.css`).
+- **Reports area anatomy:** `/reports` → `ReportsPage.tsx` → `AnalysisTab.tsx`, which is a
+  **card grid with component-local `useState` selection** (no URL param, not deep-linkable).
+  Adding a report = 3 edits in `AnalysisTab.tsx` (the `AnalysisType` union at `:13`, the
+  `reports` registry array at `:26-45`, an early-return render block cloned from `:62-75`) plus
+  the new component. Outer chrome in `ReportsPage.tsx:24-33` needs no change.
+- **Report templates:** shape/fetch from `NodeInfoEnrichmentReport.tsx` (TanStack `useQuery` +
+  `api.get`, **explicitly returning `body.data`** because `ApiService` does not unwrap the
+  envelope); deferred-run pattern from `SolarMonitoringReport.tsx:110-121, 167-184`;
+  filters/pagination/CSV mechanics from `AuditLogTab.tsx:52-62, 130-194`. Prefer the existing
+  CSV helpers `escapeCsvField` / `downloadTextFile` in `src/utils/nodeExport.ts:123, 207-212`
+  over hand-rolling a Blob.
+- **`.reports-*` global classes** in `src/styles/analysis-reports.css` cover the shared chrome
+  (stats row, panel, controls, table, banners, buttons, pills). Reuse those; put genuinely new
+  report-specific styling in a `*.module.css` per CLAUDE.md, not appended to the global sheet.
+- **Permissions:** there is no `analysis`/`reports` resource. `packetmonitor` is in
+  `SOURCEY_RESOURCES` (`src/server/constants/permissions.ts:7-14`), so every check needs a
+  `sourceId`. Cross-source precedent: `unifiedRoutes.ts:988, 1113`.
+- **Raw `fetch()` is lint-banned** in `src/components/**` and `src/pages/**` — use `ApiService`
+  or a TanStack hook. `MqttPacketMonitorView.tsx` uses `useCsrfFetch` (a baselined legacy
+  site); do not copy that part into new code.
+- **Next migration number: 128** (highest registered is 127, `add_atak_contacts`,
+  `src/db/migrations.ts:2015-2023`). `migrations.test.ts` asserts contiguity and all three
+  dialects, but hardcodes no total.
+- **Settings keys** must be added to `VALID_SETTINGS_KEYS`
+  (`src/server/constants/settings.ts`) or they silently fail to save.
+- **Stale comment to fix in passing:** the `ingestOutcome` doc comment at
+  `src/db/schema/mqttPacketLog.ts:53` omits `'distance'`, which both the repo type
+  (`repositories/mqttPacketLog.ts:20`) and `mapOutcome`
+  (`mqttPacketLogService.ts:167-168`) emit.
+
+## Phases
+
+### Phase 1 — Backend: bitfield capture, violation detection, durable history  [x]
+
+Branch: `feature/mqtt-oktomqtt-violations` (worktree `../meshmonitor-mqtt-violations`).
+
+Deliverables:
+- Shared tri-state `ok_to_mqtt` evaluator extracted from
+  `MqttBridgeManager.evaluateOkToMqtt`, returning `true | false | unknown`, with
+  `MqttBridgeManager` refactored to consume it while **preserving its fail-closed uplink
+  semantics** (`unknown ⇒ don't uplink`).
+- `bitfield` preserved through the server-side decrypt path in `mqttIngestion.ts:190-205`.
+- `topic` threaded through `MqttIngestionInput` and passed at both call sites
+  (`mqttBrokerManager.handlePublish`, `mqttBridgeManager.handleDownlink`).
+- Migration **128**, idempotent across SQLite/PG/MySQL: `topic`, `okToMqtt` (tri-state),
+  and a violation flag on `mqtt_packet_log`; plus a **retention-immune violations table**
+  with its own longer-retention settings.
+- Violation computed at row-build time in `mqttPacketLogService` (explicit bit=0 **and**
+  `gatewayNodeNum != fromNode`), written to both the packet log and the durable table.
+- Repository: violation aggregate (per-gateway summary) + drill-down queries, and the
+  violation flag added to the `getGroupedPackets` projection so the Phase 2 badge can reach
+  the list view. MySQL `ONLY_FULL_GROUP_BY`-safe.
+- Cross-source endpoints in `analysisRoutes.ts` via
+  `resolvePermittedSourceIds(req, 'packetmonitor')`, supporting lookback, `includeUnknown`,
+  sort, and limit/offset. `ok`/`fail` envelope.
+- New settings keys registered in `VALID_SETTINGS_KEYS`.
+- Tests: migration idempotency; evaluator unit tests (incl. the tri-state/fail-closed
+  distinction); bitfield-preservation through server decrypt; violation-computation
+  (originator-self-publish must NOT flag); repository aggregates + a
+  `*.perSource.test.ts` isolation test; route tests via `createRouteTestApp`.
+
+Exit criteria: full Vitest suite green (`success: true` via `--reporter=json`), `lint:ci`
+green (in-repo failures only), typecheck green, PR merged. No user-visible change yet.
+
+### Phase 2 — Packet Monitor UI: violation badge + detail modal marker  [ ]
+
+Deliverables:
+- Violation badge on grouped rows in `MqttPacketMonitorView.tsx`, reusing the existing
+  `mqpm-badge` system.
+- Violation row in the packet section of `MqttPacketDetailModal.tsx` **plus** a per-gateway
+  violation column in the receptions table, extending `MqttReception` in
+  `mqttPacketTypes.ts`.
+- `mqtt.packets.*` i18n keys in `public/locales/en.json` (en only — the other locales have
+  none of this namespace and rely on the inline English defaults).
+- Component tests extending the existing `MqttPacketMonitorView.test.tsx` /
+  `MqttPacketDetailModal.test.tsx`.
+- Browser validation against a live MQTT source via dev-container deploy + chrome-devtools.
+
+Exit criteria: UI validated in the browser, suite/lint/typecheck/CI green, PR merged.
+
+### Phase 3 — Reports: `ok_to_mqtt` gateway violation report  [ ]
+
+Deliverables:
+- New report component under `src/components/Analysis/`, registered in `AnalysisTab.tsx`
+  (union member + registry entry + render block).
+- Gateway summary table (violation count, distinct originators affected, sources, first/last
+  seen) with drill-down to the underlying violating packets.
+- Lookback/date-range control using the deferred-run pattern (no expensive scan on mount);
+  CSV export via `escapeCsvField`/`downloadTextFile`; sortable columns + pagination;
+  include-`unknown`-bitfield toggle, off by default.
+- TanStack `useQuery` + `ApiService` (raw `fetch()` is lint-banned here), unwrapping
+  `body.data` explicitly.
+- i18n keys; reuse `.reports-*` chrome, new styling in a CSS module.
+- Tests; browser validation of the report end-to-end.
+
+Exit criteria: report validated in the browser against real data, suite/lint/typecheck/CI
+green, PR merged, issue #4114 closed.
+
+## Deviations / notes
+
+### Phase 1 (2026-07-24)
+
+Spec: `MQTT_OK_TO_MQTT_PHASE1_SPEC.md`. Implemented as six work packages
+(WP1 schema/migration ∥ WP2 evaluator → WP3 repository → WP4 ingest ∥ WP5 routes → WP6
+verification). Migration number is **128**.
+
+**Things later phases must know:**
+
+1. **Forward-only — no backfill is possible.** The `ok_to_mqtt` bit was never stored before this
+   phase, so historical `mqtt_packet_log` rows cannot be classified retroactively (a backfill
+   could only write a guessed value). Both endpoints return empty until new MQTT traffic arrives
+   after the upgrade. Pre-migration rows read as `bitfield IS NULL` = "suspected" until the
+   packet log's own 24 h retention flushes them.
+2. **Cross-phase availability asymmetry — Phase 2 must surface this.** The durable violation
+   write is **default ON**, so the Phase 3 report works out of the box. But the Phase 2 badge
+   reads `mqtt_packet_log`, which is **opt-in and default OFF**. On a default install the report
+   has data while the badge never appears. Phase 2's empty state must explain the packet-monitor
+   opt-in rather than implying "no violations".
+3. **`includeUnknown` has a much shorter horizon — Phase 3 must surface this.** Confirmed
+   violations come from the durable table (90 d). "Suspected" rows (unreadable bit) are read from
+   `mqtt_packet_log`, so they are bounded by its ~24 h retention *and* require
+   `mqtt_packet_log_enabled`. The endpoints return `suspectedAvailable` and `suspectedWindowMs`
+   precisely so the UI can say so. When `includeUnknown` is false (default) the packet-log query
+   is not executed at all.
+4. **`SERVER_ONLY_SETTINGS` trap.** There is no production `SERVER_ONLY_SETTINGS` constant — it
+   is a local allowlist inside `server.settings-persistence.test.ts` that guards only the keys
+   `SettingsTab` sends. Phase 1 added no SettingsTab field, so no edit was needed. **If Phase 2
+   or 3 adds a UI toggle for any of the three new keys, that test fails** unless the key is
+   either loaded by `SettingsContext` or added to that allowlist.
+5. **Kill-switch convention is inverted, deliberately.** `mqtt_oktomqtt_violation_log_enabled` is
+   `'0'` ⇒ off, anything else *including unset* ⇒ on — unlike `mqtt_packet_log_enabled`
+   (`=== '1'`). Required so the feature works on installs that never touched settings. Commented
+   at both the constant and the getter.
+6. **Dedupe cannot cover `packetId` 0/NULL.** The unique index is
+   `(sourceId, packetId, fromNode, gatewayNodeNum)`, and `NULL != NULL` on all three dialects.
+   Real mesh packets essentially always carry a nonzero id; same accepted edge already documented
+   for `getReceptions`.
+
+**Deviations from the spec as approved:**
+
+- **Self-echo guard added during the spec review** (spec §2(f.1)). The original spec asserted
+  MeshMonitor's own republished packets "never reach ingest". Verification showed the mechanism
+  was different than claimed and not airtight: `matchesEcho` matches on *exact topic-string
+  equality plus packetId*, recorded under the post-rewrite topic, with a 60 s TTL in a 256-entry
+  ring that evicts oldest-first — missable on broker topic rewrite, delayed redelivery, or
+  eviction under load — and `mqttBrokerManager.handlePublish` has **no** echo suppression at all.
+  What actually protects us is that `handleUplink` republishes the payload byte-for-byte and
+  rewrites only the topic, so `gatewayId` is never mutated and a missed echo still carries the
+  *original* gateway's id. Because that is an implicit property rather than a guarantee, an
+  explicit `selfGateway` guard was added (`detectOkToMqttViolation(envelope, localGatewayNodeNum)`,
+  threaded via `MqttIngestionInput`), plus a test pinning the byte-for-byte property so a future
+  change to the uplink path fails visibly instead of silently producing false accusations.
+- **`migrate-db` table list updated** (`src/cli/migrationTables.ts`) — not anticipated by the
+  spec, caught by `migrationTables.test.ts` only in the full-suite run. Without it, a user
+  migrating SQLite → PostgreSQL/MySQL would have silently lost all recorded violations. The table
+  is deliberately migrated (not skipped like the transient packet logs) because it is
+  long-retention history.
+- **Suspected-violation queries live on `MqttPacketLogRepository`**, not the violations
+  repository, since they read `mqtt_packet_log`.
+- WP5 calls `databaseService.*` repositories directly from the route handlers (the pattern
+  `analysisRoutes.ts` already uses) rather than depending on `mqttPacketLogService` pass-throughs,
+  which is what allowed WP4 and WP5 to run in parallel.
+
+**Verification performed:**
+
+- Full Vitest suite with PostgreSQL (`:5433`) and MySQL (`:3307`) containers up — confirmed the
+  multi-backend suites actually executed (`nodes.test.ts` ran 52 PG + 56 MySQL tests) rather than
+  skipping silently, and confirmed `success: true` from the JSON reporter, not the summary line.
+- `tsc --noEmit` clean; `lint:ci` clean (no in-repo `FAIL`); no `eslint-baseline.json` rule count
+  grew.
+- **Migration 128 executed against live PostgreSQL 16 and MySQL 8.4**, beyond the spec's
+  mock-client assertions: DDL applies, is idempotent on re-run, creates all 15 columns and all 3
+  indexes on both, the UNIQUE dedupe index rejects duplicates, and the repository's
+  `onConflictDoNothing` / `onDuplicateKeyUpdate` forms are true no-ops. Worth repeating for any
+  future migration — the repo's migration tests otherwise only assert against mocks, so real
+  dialect syntax is not covered by CI.

--- a/src/cli/migrationTables.ts
+++ b/src/cli/migrationTables.ts
@@ -58,6 +58,11 @@ export const TABLE_ORDER = [
   'packet_log',
   // 4124: MQTT packet monitor reception log (per-gateway rows; sourceId, no FKs)
   'mqtt_packet_log',
+  // 4114: durable ok_to_mqtt violation history (sourceId, no FKs). Deliberately
+  // migrated — unlike the transient packet logs above, this table is long-retention
+  // history (90d) that the Analysis report reads, so dropping it on a backend
+  // migration would silently erase the record of every detected violation.
+  'mqtt_ok_to_mqtt_violations',
   // 3691 Phase 2: per-source ATAK contact state (composite PK uid+sourceId, no FKs)
   'atak_contacts',
   'backup_history',
@@ -108,7 +113,8 @@ export const SOURCE_SCOPED_TABLES = new Set([
   // every backend, so the `sourceId` backfill check never applies to it.
   'embed_profiles', 'meshcore_nodes', 'meshcore_messages',
   'meshcore_neighbor_info', 'meshcore_packet_log',
-  'meshcore_heard_repeaters', 'mqtt_packet_log', 'atak_contacts',
+  'meshcore_heard_repeaters', 'mqtt_packet_log', 'mqtt_ok_to_mqtt_violations',
+  'atak_contacts',
   'auto_favorite_targets', 'auto_favorite_assignments',
   'dead_drop_messages',
 ]);

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -57,6 +57,9 @@ import {
 import {
   mqttPacketLogSqlite, mqttPacketLogPostgres, mqttPacketLogMysql,
 } from './schema/mqttPacketLog.js';
+import {
+  mqttOkToMqttViolationsSqlite, mqttOkToMqttViolationsPostgres, mqttOkToMqttViolationsMysql,
+} from './schema/mqttOkToMqttViolations.js';
 
 // Miscellaneous tables
 import {
@@ -192,6 +195,8 @@ export interface ActiveSchema {
   packetLog: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4124 matches the existing ActiveSchema per-dialect table pattern; typing burn-down is #3962 Phase 6
   mqttPacketLog: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4114 matches the existing ActiveSchema per-dialect table pattern; typing burn-down is #3962 Phase 6
+  mqttOkToMqttViolations: any;
 
   // Miscellaneous tables
   backupHistory: any;
@@ -290,6 +295,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     readMessages: readMessagesSqlite,
     packetLog: packetLogSqlite,
     mqttPacketLog: mqttPacketLogSqlite,
+    mqttOkToMqttViolations: mqttOkToMqttViolationsSqlite,
     backupHistory: backupHistorySqlite,
     systemBackupHistory: systemBackupHistorySqlite,
     customThemes: customThemesSqlite,
@@ -348,6 +354,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     readMessages: readMessagesPostgres,
     packetLog: packetLogPostgres,
     mqttPacketLog: mqttPacketLogPostgres,
+    mqttOkToMqttViolations: mqttOkToMqttViolationsPostgres,
     backupHistory: backupHistoryPostgres,
     systemBackupHistory: systemBackupHistoryPostgres,
     customThemes: customThemesPostgres,
@@ -406,6 +413,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     readMessages: readMessagesMysql,
     packetLog: packetLogMysql,
     mqttPacketLog: mqttPacketLogMysql,
+    mqttOkToMqttViolations: mqttOkToMqttViolationsMysql,
     backupHistory: backupHistoryMysql,
     systemBackupHistory: systemBackupHistoryMysql,
     customThemes: customThemesMysql,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -142,6 +142,7 @@ import { migration as addPositionLocationSourceMigration, runMigration124Postgre
 import { migration as addXeddsaSignedMigration, runMigration125Postgres, runMigration125Mysql } from '../server/migrations/125_add_xeddsa_signed_to_packet_log.js';
 import { migration as addTransportFlagsMigration, runMigration126Postgres, runMigration126Mysql } from '../server/migrations/126_add_transport_flags_to_nodes.js';
 import { migration as addAtakContactsMigration, runMigration127Postgres, runMigration127Mysql } from '../server/migrations/127_add_atak_contacts.js';
+import { migration as mqttOkToMqttViolationsMigration, runMigration128Postgres, runMigration128Mysql } from '../server/migrations/128_mqtt_oktomqtt_violations.js';
 
 // ============================================================================
 // Registry
@@ -2020,4 +2021,19 @@ registry.register({
   sqlite: (db) => addAtakContactsMigration.up(db),
   postgres: (client) => runMigration127Postgres(client),
   mysql: (pool) => runMigration127Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 128: `ok_to_mqtt` violation detection (#4114) — adds bitfield /
+// okToMqttViolation / topic to `mqtt_packet_log`, plus the retention-immune
+// `mqtt_ok_to_mqtt_violations` history table.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 128,
+  name: 'mqtt_oktomqtt_violations',
+  settingsKey: 'migration_128_mqtt_oktomqtt_violations',
+  sqlite: (db) => mqttOkToMqttViolationsMigration.up(db),
+  postgres: (client) => runMigration128Postgres(client),
+  mysql: (pool) => runMigration128Mysql(pool),
 });

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -91,5 +91,13 @@ export type {
   MqttGroupedPacket,
   MqttGateway,
 } from './mqttPacketLog.js';
+export { MqttOkToMqttViolationsRepository } from './mqttOkToMqttViolations.js';
+export type {
+  DbMqttOkToMqttViolation,
+  ViolationGatewaySort,
+  ViolationListSort,
+  ViolationRangeQuery,
+  MqttViolationGateway,
+} from './mqttOkToMqttViolations.js';
 export { AtakContactsRepository } from './atakContacts.js';
 export type { AtakContactRow } from './atakContacts.js';

--- a/src/db/repositories/mqttOkToMqttViolations.perSource.test.ts
+++ b/src/db/repositories/mqttOkToMqttViolations.perSource.test.ts
@@ -1,0 +1,176 @@
+/**
+ * MQTT `ok_to_mqtt` Violations Repository — per-source isolation tests.
+ *
+ * The `mqtt_ok_to_mqtt_violations` table (migration 128) carries a `sourceId`
+ * on every row. These tests assert that every method — cross-source and
+ * single-source alike — never leaks or deletes across sources. See
+ * MQTT_OK_TO_MQTT_PHASE1_SPEC.md §3.8/§4.9.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  MqttOkToMqttViolationsRepository,
+  type DbMqttOkToMqttViolation,
+} from './mqttOkToMqttViolations.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+const SOURCE_A = 'source-a';
+const SOURCE_B = 'source-b';
+
+function makeViolation(sourceId: string, overrides: Partial<DbMqttOkToMqttViolation> = {}): DbMqttOkToMqttViolation {
+  const now = 1_700_000_000_000;
+  return {
+    sourceId,
+    packetId: 100,
+    fromNode: 111,
+    fromNodeId: '!0000006f',
+    gatewayId: '!aabbccdd',
+    gatewayNodeNum: 0xaabbccdd,
+    channelId: 'LongFast',
+    portnum: 1,
+    portnumName: 'TEXT_MESSAGE_APP',
+    bitfield: 0,
+    topic: 'msh/US/2/e/LongFast/!aabbccdd',
+    rxTime: now,
+    timestamp: now,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+describe('MqttOkToMqttViolationsRepository — per-source isolation', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MqttOkToMqttViolationsRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MqttOkToMqttViolationsRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  /** Seed one identically-shaped violation under each source, differing only by identity fields to avoid dedupe collisions. */
+  async function seedBothSources() {
+    await repo.insertViolation(makeViolation(SOURCE_A, {
+      packetId: 1, fromNode: 10, gatewayId: '!gwaaaaaa', gatewayNodeNum: 0xaaaaaaaa, timestamp: 1000, createdAt: 1000,
+    }));
+    await repo.insertViolation(makeViolation(SOURCE_A, {
+      packetId: 2, fromNode: 11, gatewayId: '!gwaaaaaa', gatewayNodeNum: 0xaaaaaaaa, timestamp: 2000, createdAt: 2000,
+    }));
+    await repo.insertViolation(makeViolation(SOURCE_B, {
+      packetId: 1, fromNode: 20, gatewayId: '!gwbbbbbb', gatewayNodeNum: 0xbbbbbbbb, timestamp: 1500, createdAt: 1500,
+    }));
+  }
+
+  it('getGatewaySummary never leaks rows across sources', async () => {
+    await seedBothSources();
+
+    const aOnly = await repo.getGatewaySummary({ sourceIds: [SOURCE_A], since: 0, until: Date.now() + 1_000_000 });
+    expect(aOnly).toHaveLength(1);
+    expect(aOnly[0].gatewayId).toBe('!gwaaaaaa');
+    expect(aOnly[0].violationCount).toBe(2);
+
+    const bOnly = await repo.getGatewaySummary({ sourceIds: [SOURCE_B], since: 0, until: Date.now() + 1_000_000 });
+    expect(bOnly).toHaveLength(1);
+    expect(bOnly[0].gatewayId).toBe('!gwbbbbbb');
+    expect(bOnly[0].violationCount).toBe(1);
+
+    const both = await repo.getGatewaySummary({ sourceIds: [SOURCE_A, SOURCE_B], since: 0, until: Date.now() + 1_000_000 });
+    expect(both).toHaveLength(2);
+  });
+
+  it('getGatewaySummaryCount never leaks rows across sources', async () => {
+    await seedBothSources();
+    expect(await repo.getGatewaySummaryCount({ sourceIds: [SOURCE_A], since: 0, until: Date.now() + 1_000_000 })).toBe(1);
+    expect(await repo.getGatewaySummaryCount({ sourceIds: [SOURCE_B], since: 0, until: Date.now() + 1_000_000 })).toBe(1);
+  });
+
+  it('getGatewaySourceIds returns both sources when requested and neither in isolation', async () => {
+    await seedBothSources();
+    const both = await repo.getGatewaySourceIds({ sourceIds: [SOURCE_A, SOURCE_B], since: 0, until: Date.now() + 1_000_000 });
+    expect(both.map(r => r.sourceId).sort()).toEqual([SOURCE_A, SOURCE_B]);
+
+    const aOnly = await repo.getGatewaySourceIds({ sourceIds: [SOURCE_A], since: 0, until: Date.now() + 1_000_000 });
+    expect(aOnly.every(r => r.sourceId === SOURCE_A)).toBe(true);
+  });
+
+  it('getViolations never leaks rows across sources', async () => {
+    await seedBothSources();
+
+    const aOnly = await repo.getViolations({ sourceIds: [SOURCE_A], since: 0, until: Date.now() + 1_000_000 });
+    expect(aOnly).toHaveLength(2);
+    expect(aOnly.every(r => r.sourceId === SOURCE_A)).toBe(true);
+
+    const bOnly = await repo.getViolations({ sourceIds: [SOURCE_B], since: 0, until: Date.now() + 1_000_000 });
+    expect(bOnly).toHaveLength(1);
+    expect(bOnly.every(r => r.sourceId === SOURCE_B)).toBe(true);
+  });
+
+  it('getViolationCount never leaks rows across sources', async () => {
+    await seedBothSources();
+    expect(await repo.getViolationCount({ sourceIds: [SOURCE_A], since: 0, until: Date.now() + 1_000_000 })).toBe(2);
+    expect(await repo.getViolationCount({ sourceIds: [SOURCE_B], since: 0, until: Date.now() + 1_000_000 })).toBe(1);
+  });
+
+  it('getRowCount is source-scoped', async () => {
+    await seedBothSources();
+    expect(await repo.getRowCount({ sourceId: SOURCE_A })).toBe(2);
+    expect(await repo.getRowCount({ sourceId: SOURCE_B })).toBe(1);
+    expect(await repo.getRowCount()).toBe(3);
+  });
+
+  it('deleteViolationsOlderThan is source-scoped when a sourceId is given', async () => {
+    await repo.insertViolation(makeViolation(SOURCE_A, { packetId: 1, timestamp: 100, createdAt: 100 }));
+    await repo.insertViolation(makeViolation(SOURCE_A, { packetId: 2, timestamp: 500, createdAt: 500 }));
+    await repo.insertViolation(makeViolation(SOURCE_B, { packetId: 1, timestamp: 100, createdAt: 100 }));
+
+    const removed = await repo.deleteViolationsOlderThan(300, SOURCE_A);
+    expect(removed).toBe(1);
+    expect(await repo.getRowCount({ sourceId: SOURCE_A })).toBe(1);
+    // src-b untouched despite being older than the cutoff.
+    expect(await repo.getRowCount({ sourceId: SOURCE_B })).toBe(1);
+  });
+
+  it('trimViolationsToCount keeps the newest N rows for a source only', async () => {
+    for (let i = 0; i < 10; i++) {
+      await repo.insertViolation(makeViolation(SOURCE_A, { packetId: i + 1, timestamp: 100 + i, createdAt: 100 + i }));
+    }
+    await repo.insertViolation(makeViolation(SOURCE_B, { packetId: 999, timestamp: 999, createdAt: 999 }));
+
+    const removed = await repo.trimViolationsToCount(SOURCE_A, 3);
+    expect(removed).toBe(7);
+
+    expect(await repo.getRowCount({ sourceId: SOURCE_A })).toBe(3);
+    // src-b untouched.
+    expect(await repo.getRowCount({ sourceId: SOURCE_B })).toBe(1);
+  });
+
+  it('deleteAllViolations is source-scoped', async () => {
+    await seedBothSources();
+
+    const removed = await repo.deleteAllViolations(SOURCE_A);
+    expect(removed).toBe(2);
+    expect(await repo.getRowCount({ sourceId: SOURCE_A })).toBe(0);
+    expect(await repo.getRowCount({ sourceId: SOURCE_B })).toBe(1);
+  });
+
+  it('getViolationSourceIds returns both sources', async () => {
+    await seedBothSources();
+    const ids = (await repo.getViolationSourceIds()).sort();
+    expect(ids).toEqual([SOURCE_A, SOURCE_B]);
+  });
+
+  it('?sources cannot be widened: requesting a source not in sourceIds never returns its rows', async () => {
+    await seedBothSources();
+    // Only SOURCE_A requested — SOURCE_B rows must never appear regardless of range.
+    const rows = await repo.getViolations({ sourceIds: [SOURCE_A], since: 0, until: Date.now() + 10_000_000 });
+    expect(rows.some(r => r.sourceId === SOURCE_B)).toBe(false);
+  });
+});

--- a/src/db/repositories/mqttOkToMqttViolations.test.ts
+++ b/src/db/repositories/mqttOkToMqttViolations.test.ts
@@ -1,0 +1,212 @@
+/**
+ * MQTT `ok_to_mqtt` Violations Repository — correctness tests.
+ *
+ * `mqtt_ok_to_mqtt_violations` (migration 128) is a durable, retention-immune
+ * history of confirmed ok_to_mqtt violations. See
+ * MQTT_OK_TO_MQTT_PHASE1_SPEC.md §3.8/§4.8.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  MqttOkToMqttViolationsRepository,
+  type DbMqttOkToMqttViolation,
+} from './mqttOkToMqttViolations.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+const SOURCE = 'src-a';
+
+function makeViolation(overrides: Partial<DbMqttOkToMqttViolation> = {}): DbMqttOkToMqttViolation {
+  const now = 1_700_000_000_000;
+  return {
+    sourceId: SOURCE,
+    packetId: 100,
+    fromNode: 111,
+    fromNodeId: '!0000006f',
+    gatewayId: '!aabbccdd',
+    gatewayNodeNum: 0xaabbccdd,
+    channelId: 'LongFast',
+    portnum: 1,
+    portnumName: 'TEXT_MESSAGE_APP',
+    bitfield: 0,
+    topic: 'msh/US/2/e/LongFast/!aabbccdd',
+    rxTime: now,
+    timestamp: now,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+describe('MqttOkToMqttViolationsRepository', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MqttOkToMqttViolationsRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MqttOkToMqttViolationsRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('insertViolation throws without a sourceId', async () => {
+    await expect(repo.insertViolation(makeViolation({ sourceId: '' }))).rejects.toThrow(/sourceId/);
+  });
+
+  it('inserts and round-trips a violation row', async () => {
+    await repo.insertViolation(makeViolation());
+    expect(await repo.getRowCount({ sourceId: SOURCE })).toBe(1);
+  });
+
+  it('duplicate insert (same sourceId/packetId/fromNode/gatewayNodeNum) is a no-op; first timestamp wins', async () => {
+    await repo.insertViolation(makeViolation({ timestamp: 1000, createdAt: 1000 }));
+    await repo.insertViolation(makeViolation({ timestamp: 2000, createdAt: 2000 }));
+
+    expect(await repo.getRowCount({ sourceId: SOURCE })).toBe(1);
+    const rows = await repo.getViolations({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].timestamp).toBe(1000);
+  });
+
+  it('a different gatewayNodeNum on an otherwise-identical row is NOT deduped', async () => {
+    await repo.insertViolation(makeViolation({ gatewayNodeNum: 1 }));
+    await repo.insertViolation(makeViolation({ gatewayNodeNum: 2 }));
+    expect(await repo.getRowCount({ sourceId: SOURCE })).toBe(2);
+  });
+
+  describe('getGatewaySummary', () => {
+    beforeEach(async () => {
+      // Gateway 1: two violations, two distinct originators, seen 1000..3000.
+      await repo.insertViolation(makeViolation({
+        gatewayId: '!gw000001', gatewayNodeNum: 1, fromNode: 10, packetId: 1, timestamp: 1000, createdAt: 1000,
+      }));
+      await repo.insertViolation(makeViolation({
+        gatewayId: '!gw000001', gatewayNodeNum: 1, fromNode: 11, packetId: 2, timestamp: 3000, createdAt: 3000,
+      }));
+      // Gateway 2: one violation, seen at 2000.
+      await repo.insertViolation(makeViolation({
+        gatewayId: '!gw000002', gatewayNodeNum: 2, fromNode: 10, packetId: 3, timestamp: 2000, createdAt: 2000,
+      }));
+    });
+
+    it('counts violations, distinctOriginators, and firstSeen/lastSeen per gateway', async () => {
+      const rows = await repo.getGatewaySummary({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
+      expect(rows).toHaveLength(2);
+
+      const gw1 = rows.find(r => r.gatewayId === '!gw000001');
+      expect(gw1?.violationCount).toBe(2);
+      expect(gw1?.distinctOriginators).toBe(2);
+      expect(gw1?.firstSeen).toBe(1000);
+      expect(gw1?.lastSeen).toBe(3000);
+
+      const gw2 = rows.find(r => r.gatewayId === '!gw000002');
+      expect(gw2?.violationCount).toBe(1);
+      expect(gw2?.distinctOriginators).toBe(1);
+    });
+
+    it('sorts by violationCount desc by default', async () => {
+      const rows = await repo.getGatewaySummary({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
+      expect(rows.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
+    });
+
+    it('every sort field orders correctly in both directions', async () => {
+      const byViolationCountAsc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'violationCount', dir: 'asc',
+      });
+      expect(byViolationCountAsc.map(r => r.gatewayId)).toEqual(['!gw000002', '!gw000001']);
+
+      const byLastSeenAsc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'lastSeen', dir: 'asc',
+      });
+      expect(byLastSeenAsc.map(r => r.gatewayId)).toEqual(['!gw000002', '!gw000001']);
+
+      const byLastSeenDesc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'lastSeen', dir: 'desc',
+      });
+      expect(byLastSeenDesc.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
+
+      const byDistinctOriginatorsDesc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'distinctOriginators', dir: 'desc',
+      });
+      expect(byDistinctOriginatorsDesc.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
+
+      const byGatewayIdAsc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'gatewayId', dir: 'asc',
+      });
+      expect(byGatewayIdAsc.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
+
+      const byGatewayIdDesc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'gatewayId', dir: 'desc',
+      });
+      expect(byGatewayIdDesc.map(r => r.gatewayId)).toEqual(['!gw000002', '!gw000001']);
+    });
+
+    it('limit/offset paginate; getGatewaySummaryCount ignores pagination', async () => {
+      const page1 = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, limit: 1, offset: 0,
+      });
+      expect(page1).toHaveLength(1);
+      const page2 = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, limit: 1, offset: 1,
+      });
+      expect(page2).toHaveLength(1);
+      expect(page1[0].gatewayId).not.toBe(page2[0].gatewayId);
+
+      expect(await repo.getGatewaySummaryCount({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 })).toBe(2);
+    });
+
+    it('since/until range boundaries are inclusive', async () => {
+      const exact = await repo.getGatewaySummary({ sourceIds: [SOURCE], since: 1000, until: 1000 });
+      expect(exact).toHaveLength(1);
+      expect(exact[0].gatewayId).toBe('!gw000001');
+      expect(exact[0].violationCount).toBe(1);
+    });
+
+    it('getGatewaySourceIds pivots correctly for a gateway seen on two sources', async () => {
+      await repo.insertViolation(makeViolation({
+        sourceId: 'src-b', gatewayId: '!gw000001', gatewayNodeNum: 1, fromNode: 20, packetId: 4, timestamp: 1500, createdAt: 1500,
+      }));
+
+      const pivot = await repo.getGatewaySourceIds({
+        sourceIds: [SOURCE, 'src-b'], since: 0, until: Date.now() + 1_000_000,
+      });
+      const gw1Sources = pivot.filter(p => p.gatewayId === '!gw000001').map(p => p.sourceId).sort();
+      expect(gw1Sources).toEqual(['src-a', 'src-b']);
+    });
+  });
+
+  describe('getViolations', () => {
+    beforeEach(async () => {
+      await repo.insertViolation(makeViolation({ gatewayId: '!gw000001', fromNode: 10, packetId: 1, timestamp: 1000, createdAt: 1000 }));
+      await repo.insertViolation(makeViolation({ gatewayId: '!gw000002', fromNode: 20, packetId: 2, timestamp: 2000, createdAt: 2000 }));
+    });
+
+    it('filters by gatewayId', async () => {
+      const rows = await repo.getViolations({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, gatewayId: '!gw000001',
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].gatewayId).toBe('!gw000001');
+    });
+
+    it('orders newest-first by default', async () => {
+      const rows = await repo.getViolations({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
+      expect(rows.map(r => r.packetId)).toEqual([2, 1]);
+    });
+  });
+
+  it('empty sourceIds short-circuits every cross-source method to [] / 0 with no query executed', async () => {
+    await repo.insertViolation(makeViolation());
+    const q = { sourceIds: [] as string[], since: 0, until: Date.now() + 1_000_000 };
+    expect(await repo.getGatewaySummary(q)).toEqual([]);
+    expect(await repo.getGatewaySummaryCount(q)).toBe(0);
+    expect(await repo.getGatewaySourceIds(q)).toEqual([]);
+    expect(await repo.getViolations(q)).toEqual([]);
+    expect(await repo.getViolationCount(q)).toBe(0);
+  });
+});

--- a/src/db/repositories/mqttOkToMqttViolations.test.ts
+++ b/src/db/repositories/mqttOkToMqttViolations.test.ts
@@ -135,6 +135,16 @@ describe('MqttOkToMqttViolationsRepository', () => {
       });
       expect(byDistinctOriginatorsDesc.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
 
+      const byDistinctOriginatorsAsc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'distinctOriginators', dir: 'asc',
+      });
+      expect(byDistinctOriginatorsAsc.map(r => r.gatewayId)).toEqual(['!gw000002', '!gw000001']);
+
+      const byViolationCountDesc = await repo.getGatewaySummary({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'violationCount', dir: 'desc',
+      });
+      expect(byViolationCountDesc.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
+
       const byGatewayIdAsc = await repo.getGatewaySummary({
         sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'gatewayId', dir: 'asc',
       });
@@ -197,6 +207,23 @@ describe('MqttOkToMqttViolationsRepository', () => {
     it('orders newest-first by default', async () => {
       const rows = await repo.getViolations({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
       expect(rows.map(r => r.packetId)).toEqual([2, 1]);
+    });
+
+    it('sorts by fromNode and gatewayId, both directions', async () => {
+      const byFromNodeAsc = await repo.getViolations({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'fromNode', dir: 'asc',
+      });
+      expect(byFromNodeAsc.map(r => r.fromNode)).toEqual([10, 20]);
+
+      const byFromNodeDesc = await repo.getViolations({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'fromNode', dir: 'desc',
+      });
+      expect(byFromNodeDesc.map(r => r.fromNode)).toEqual([20, 10]);
+
+      const byGatewayIdAsc = await repo.getViolations({
+        sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000, sort: 'gatewayId', dir: 'asc',
+      });
+      expect(byGatewayIdAsc.map(r => r.gatewayId)).toEqual(['!gw000001', '!gw000002']);
     });
   });
 

--- a/src/db/repositories/mqttOkToMqttViolations.ts
+++ b/src/db/repositories/mqttOkToMqttViolations.ts
@@ -1,0 +1,293 @@
+/**
+ * MQTT `ok_to_mqtt` Violations Repository
+ *
+ * `mqtt_ok_to_mqtt_violations` (migration 128) is a durable, retention-immune
+ * history of *confirmed* `ok_to_mqtt` violations — a gateway relayed another
+ * node's packet to MQTT while that packet's `Data.bitfield` bit 0 was
+ * explicitly clear. It is deliberately a separate table (and repository)
+ * from `mqtt_packet_log`: the packet log trims to 24h / 5,000 rows, while
+ * this table needs a weeks-long lookback for Phase 3's violation report. See
+ * docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md §1.9/§2(d)/§3.8.
+ */
+import { eq, and, gte, lte, lt, asc, desc, inArray, sql, type SQL } from 'drizzle-orm';
+import { BaseRepository } from './base.js';
+
+export interface DbMqttOkToMqttViolation {
+  id?: number;
+  sourceId: string; // required on writes
+  packetId?: number | null;
+  fromNode?: number | null;
+  fromNodeId?: string | null;
+  gatewayId?: string | null;
+  gatewayNodeNum?: number | null;
+  channelId?: string | null;
+  portnum?: number | null;
+  portnumName?: string | null;
+  bitfield?: number | null;
+  topic?: string | null;
+  rxTime?: number | null;
+  timestamp: number; // server capture ms
+  createdAt: number;
+}
+
+export type ViolationGatewaySort = 'violationCount' | 'lastSeen' | 'distinctOriginators' | 'gatewayId';
+export type ViolationListSort = 'timestamp' | 'fromNode' | 'gatewayId';
+
+/** Explicit cross-source filter set. An empty `sourceIds` array is a guaranteed empty result. */
+export interface ViolationRangeQuery {
+  sourceIds: string[];
+  since: number; // ms epoch, inclusive
+  until: number; // ms epoch, inclusive
+  gatewayId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface MqttViolationGateway {
+  gatewayId: string | null;
+  gatewayNodeNum: number | null;
+  violationCount: number;
+  distinctOriginators: number;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+const DEFAULT_LIMIT = 500;
+
+/**
+ * Repository for the durable `ok_to_mqtt` violation history.
+ */
+export class MqttOkToMqttViolationsRepository extends BaseRepository {
+  /**
+   * Insert one confirmed-violation row. `sourceId` is required so every row
+   * is stamped with its owning source.
+   *
+   * Dedupe: the unique index on `(sourceId, packetId, fromNode,
+   * gatewayNodeNum)` makes re-ingest of the same reception a no-op — first
+   * write wins, so `timestamp` records first observation. MySQL has no
+   * `onConflictDoNothing`, so the idiomatic no-op there is assigning a
+   * column to itself.
+   */
+  async insertViolation(v: DbMqttOkToMqttViolation): Promise<void> {
+    if (!v.sourceId) {
+      throw new Error('MqttOkToMqttViolationsRepository.insertViolation requires a sourceId');
+    }
+    const { mqttOkToMqttViolations } = this.tables;
+    if (this.dbType === 'mysql') {
+      await this.db
+        .insert(mqttOkToMqttViolations)
+        .values(v)
+        .onDuplicateKeyUpdate({ set: { timestamp: sql`timestamp` } });
+    } else {
+      await this.db.insert(mqttOkToMqttViolations).values(v).onConflictDoNothing();
+    }
+  }
+
+  /**
+   * Build the WHERE conditions shared by every cross-source range query.
+   * Callers MUST guard `sourceIds.length === 0` themselves before calling
+   * this — an empty `inArray` is a dialect-dependent hazard.
+   */
+  private buildRangeConditions(q: ViolationRangeQuery): SQL[] {
+    const t = this.tables.mqttOkToMqttViolations;
+    const conditions: SQL[] = [
+      inArray(t.sourceId, q.sourceIds),
+      gte(t.timestamp, q.since),
+      lte(t.timestamp, q.until),
+    ];
+    if (q.gatewayId) {
+      conditions.push(eq(t.gatewayId, q.gatewayId));
+    }
+    return conditions;
+  }
+
+  /**
+   * Per-gateway summary over a time range: violation count, distinct
+   * originators, first/last seen. `sourceId` is deliberately NOT selected
+   * ungrouped (MySQL `ONLY_FULL_GROUP_BY`) — callers assemble per-gateway
+   * `sourceIds` separately via {@link getGatewaySourceIds}.
+   */
+  async getGatewaySummary(
+    q: ViolationRangeQuery & { sort?: ViolationGatewaySort; dir?: 'asc' | 'desc' },
+  ): Promise<MqttViolationGateway[]> {
+    if (q.sourceIds.length === 0) return [];
+    const t = this.tables.mqttOkToMqttViolations;
+    const conditions = this.buildRangeConditions(q);
+    // Single-argument COUNT(DISTINCT …) only — MySQL rejects the multi-arg
+    // form (see the same comment in mqttPacketLog.ts near getGroupedPacketCount).
+    const sortExprMap: Record<ViolationGatewaySort, SQL> = {
+      violationCount: sql`COUNT(*)`,
+      lastSeen: sql`MAX(${t.timestamp})`,
+      distinctOriginators: sql`COUNT(DISTINCT ${t.fromNode})`,
+      gatewayId: sql`${t.gatewayId}`,
+    };
+    // ORDER BY is built from this whitelist, never interpolated from raw user input.
+    const orderExpr = sortExprMap[q.sort ?? 'violationCount'];
+    const orderFn = q.dir === 'asc' ? asc : desc;
+    const rows = await this.db
+      .select({
+        gatewayId: t.gatewayId,
+        gatewayNodeNum: sql<number | null>`MAX(${t.gatewayNodeNum})`,
+        violationCount: sql<number>`COUNT(*)`,
+        distinctOriginators: sql<number>`COUNT(DISTINCT ${t.fromNode})`,
+        firstSeen: sql<number>`MIN(${t.timestamp})`,
+        lastSeen: sql<number>`MAX(${t.timestamp})`,
+      })
+      .from(t)
+      .where(and(...conditions))
+      .groupBy(t.gatewayId)
+      .orderBy(orderFn(orderExpr))
+      .limit(q.limit ?? DEFAULT_LIMIT)
+      .offset(q.offset ?? 0);
+    return this.normalizeBigInts(rows) as unknown as MqttViolationGateway[];
+  }
+
+  /**
+   * Count the number of gateway groups matching the same filters as
+   * {@link getGatewaySummary}, without pagination. Subquery-over-grouped —
+   * portable across SQLite/PostgreSQL/MySQL, unlike `COUNT(DISTINCT a,b)`
+   * which MySQL doesn't support.
+   */
+  async getGatewaySummaryCount(q: ViolationRangeQuery): Promise<number> {
+    if (q.sourceIds.length === 0) return 0;
+    const t = this.tables.mqttOkToMqttViolations;
+    const conditions = this.buildRangeConditions(q);
+    const grouped = this.db
+      .select({ k: sql`1` })
+      .from(t)
+      .where(and(...conditions))
+      .groupBy(t.gatewayId)
+      .as('grouped');
+    const res = await this.db.select({ count: sql<number>`COUNT(*)` }).from(grouped);
+    return Number(res[0]?.count ?? 0);
+  }
+
+  /**
+   * Distinct `(gatewayId, sourceId)` pairs over a range — powers the
+   * per-gateway `sourceIds` array on the summary response without putting
+   * an ungrouped `sourceId` into the aggregate projection.
+   */
+  async getGatewaySourceIds(q: ViolationRangeQuery): Promise<Array<{ gatewayId: string; sourceId: string }>> {
+    if (q.sourceIds.length === 0) return [];
+    const t = this.tables.mqttOkToMqttViolations;
+    const conditions = this.buildRangeConditions(q);
+    const rows = await this.db
+      .selectDistinct({ gatewayId: t.gatewayId, sourceId: t.sourceId })
+      .from(t)
+      .where(and(...conditions));
+    return (rows as Array<{ gatewayId: string | null; sourceId: string }>).filter(
+      (r): r is { gatewayId: string; sourceId: string } => r.gatewayId != null,
+    );
+  }
+
+  /**
+   * Drill-down: individual violation rows over a range, optionally filtered
+   * to one gateway, newest-first by default.
+   */
+  async getViolations(
+    q: ViolationRangeQuery & { sort?: ViolationListSort; dir?: 'asc' | 'desc' },
+  ): Promise<DbMqttOkToMqttViolation[]> {
+    if (q.sourceIds.length === 0) return [];
+    const t = this.tables.mqttOkToMqttViolations;
+    const conditions = this.buildRangeConditions(q);
+    const sortColumnMap: Record<ViolationListSort, SQL> = {
+      timestamp: sql`${t.timestamp}`,
+      fromNode: sql`${t.fromNode}`,
+      gatewayId: sql`${t.gatewayId}`,
+    };
+    const orderExpr = sortColumnMap[q.sort ?? 'timestamp'];
+    const orderFn = q.dir === 'asc' ? asc : desc;
+    const rows = await this.db
+      .select()
+      .from(t)
+      .where(and(...conditions))
+      .orderBy(orderFn(orderExpr))
+      .limit(q.limit ?? DEFAULT_LIMIT)
+      .offset(q.offset ?? 0);
+    return this.normalizeBigInts(rows) as unknown as DbMqttOkToMqttViolation[];
+  }
+
+  /** Count of violation rows matching the same filters as {@link getViolations}, without pagination. */
+  async getViolationCount(q: ViolationRangeQuery): Promise<number> {
+    if (q.sourceIds.length === 0) return 0;
+    const t = this.tables.mqttOkToMqttViolations;
+    const conditions = this.buildRangeConditions(q);
+    const res = await this.db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(t)
+      .where(and(...conditions));
+    return Number(res[0]?.count ?? 0);
+  }
+
+  /**
+   * Raw row count, optionally scoped to one source. Used by retention
+   * (count-based trim) and by the other single-source helpers below.
+   */
+  async getRowCount(query: { sourceId?: string } = {}): Promise<number> {
+    const { mqttOkToMqttViolations } = this.tables;
+    const whereClause = query.sourceId ? eq(mqttOkToMqttViolations.sourceId, query.sourceId) : undefined;
+    const result = await this.db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(mqttOkToMqttViolations)
+      .where(whereClause);
+    return Number(result[0]?.count ?? 0);
+  }
+
+  /** Delete violation rows older than a timestamp (ms). Returns rows removed. */
+  async deleteViolationsOlderThan(timestamp: number, sourceId?: string): Promise<number> {
+    const { mqttOkToMqttViolations } = this.tables;
+    const conditions: SQL[] = [lt(mqttOkToMqttViolations.timestamp, timestamp)];
+    if (sourceId) {
+      conditions.push(eq(mqttOkToMqttViolations.sourceId, sourceId));
+    }
+    const before = await this.getRowCount({ sourceId });
+    await this.db.delete(mqttOkToMqttViolations).where(and(...conditions));
+    const after = await this.getRowCount({ sourceId });
+    return Math.max(0, before - after);
+  }
+
+  /**
+   * Trim a source's violation history down to its newest `maxCount` rows.
+   * Returns the number of rows removed.
+   */
+  async trimViolationsToCount(sourceId: string, maxCount: number): Promise<number> {
+    if (!sourceId || maxCount <= 0) return 0;
+    const { mqttOkToMqttViolations } = this.tables;
+    const total = await this.getRowCount({ sourceId });
+    if (total <= maxCount) return 0;
+
+    // Find the cutoff id: keep the newest `maxCount` rows, delete the rest.
+    const survivors = await this.db
+      .select({ id: mqttOkToMqttViolations.id })
+      .from(mqttOkToMqttViolations)
+      .where(eq(mqttOkToMqttViolations.sourceId, sourceId))
+      .orderBy(desc(mqttOkToMqttViolations.timestamp), desc(mqttOkToMqttViolations.id))
+      .limit(maxCount);
+    if (survivors.length === 0) return 0;
+    const oldestKeptId = Number(survivors[survivors.length - 1].id);
+
+    await this.db
+      .delete(mqttOkToMqttViolations)
+      .where(and(eq(mqttOkToMqttViolations.sourceId, sourceId), lt(mqttOkToMqttViolations.id, oldestKeptId)));
+    return total - survivors.length;
+  }
+
+  /** Distinct source ids currently present in the violations table (for per-source retention trimming). */
+  async getViolationSourceIds(): Promise<string[]> {
+    const { mqttOkToMqttViolations } = this.tables;
+    const rows = await this.db.selectDistinct({ sourceId: mqttOkToMqttViolations.sourceId }).from(mqttOkToMqttViolations);
+    return rows.map((r: { sourceId: string }) => r.sourceId).filter(Boolean);
+  }
+
+  /** Delete all violation rows, optionally scoped to one source. Returns the number of rows removed. */
+  async deleteAllViolations(sourceId?: string): Promise<number> {
+    const { mqttOkToMqttViolations } = this.tables;
+    const count = await this.getRowCount({ sourceId });
+    if (sourceId) {
+      await this.db.delete(mqttOkToMqttViolations).where(eq(mqttOkToMqttViolations.sourceId, sourceId));
+    } else {
+      await this.db.delete(mqttOkToMqttViolations);
+    }
+    return count;
+  }
+}

--- a/src/db/repositories/mqttPacketLog.grouping.test.ts
+++ b/src/db/repositories/mqttPacketLog.grouping.test.ts
@@ -42,6 +42,9 @@ function makePacket(overrides: Partial<DbMqttPacket> = {}): DbMqttPacket {
     ingestOutcome: 'ingested',
     payloadSize: 12,
     payloadPreview: 'hello',
+    bitfield: null,
+    okToMqttViolation: 0,
+    topic: null,
     createdAt: now,
     ...overrides,
   };
@@ -231,5 +234,115 @@ describe('MqttPacketLogRepository — grouped query correctness', () => {
     expect(typeof receptions[0].packetId).toBe('number');
     expect(typeof receptions[0].fromNode).toBe('number');
     expect(typeof receptions[0].timestamp).toBe('number');
+  });
+
+  describe('ok_to_mqtt columns (#4114)', () => {
+    it('MAX(okToMqttViolation) surfaces on the grouped row: one flagged reception out of three', async () => {
+      await repo.insertPacket(makePacket({
+        packetId: 100, fromNode: 111, gatewayId: '!gw000001', timestamp: 1000, okToMqttViolation: 0, bitfield: 1,
+      }));
+      await repo.insertPacket(makePacket({
+        packetId: 100, fromNode: 111, gatewayId: '!gw000002', timestamp: 2000, okToMqttViolation: 1, bitfield: 0,
+      }));
+      await repo.insertPacket(makePacket({
+        packetId: 100, fromNode: 111, gatewayId: '!gw000003', timestamp: 3000, okToMqttViolation: 0, bitfield: 1,
+      }));
+
+      const groups = await repo.getGroupedPackets({ sourceId: SOURCE });
+      expect(groups).toHaveLength(1);
+      expect(groups[0].okToMqttViolation).toBe(1);
+    });
+
+    it('MAX(okToMqttViolation) is 0 when no reception was flagged', async () => {
+      await repo.insertPacket(makePacket({ packetId: 101, fromNode: 112, gatewayId: '!gw000001', okToMqttViolation: 0 }));
+      await repo.insertPacket(makePacket({ packetId: 101, fromNode: 112, gatewayId: '!gw000002', okToMqttViolation: 0 }));
+
+      const groups = await repo.getGroupedPackets({ sourceId: SOURCE });
+      const g = groups.find(row => row.packetId === 101);
+      expect(g?.okToMqttViolation).toBe(0);
+    });
+
+    it('MAX(bitfield) surfaces the representative value and is null when every reception is null', async () => {
+      await repo.insertPacket(makePacket({ packetId: 102, fromNode: 113, gatewayId: '!gw000001', bitfield: 3 }));
+      await repo.insertPacket(makePacket({ packetId: 102, fromNode: 113, gatewayId: '!gw000002', bitfield: null }));
+
+      await repo.insertPacket(makePacket({ packetId: 103, fromNode: 114, gatewayId: '!gw000001', bitfield: null }));
+      await repo.insertPacket(makePacket({ packetId: 103, fromNode: 114, gatewayId: '!gw000002', bitfield: null }));
+
+      const groups = await repo.getGroupedPackets({ sourceId: SOURCE });
+      expect(groups.find(g => g.packetId === 102)?.bitfield).toBe(3);
+      expect(groups.find(g => g.packetId === 103)?.bitfield).toBeNull();
+    });
+
+    it('getReceptions returns the per-reception okToMqttViolation/bitfield/topic (bare-select auto-pickup)', async () => {
+      await repo.insertPacket(makePacket({
+        packetId: 104, fromNode: 115, gatewayId: '!gw000001',
+        bitfield: 0, okToMqttViolation: 1, topic: 'msh/US/2/e/LongFast/!gw000001',
+      }));
+
+      const receptions = await repo.getReceptions(SOURCE, 104, 115);
+      expect(receptions).toHaveLength(1);
+      expect(receptions[0].bitfield).toBe(0);
+      expect(receptions[0].okToMqttViolation).toBe(1);
+      expect(receptions[0].topic).toBe('msh/US/2/e/LongFast/!gw000001');
+    });
+
+    it('getSuspectedViolations matches only bitfield IS NULL AND gatewayNodeNum <> fromNode, excluding self-published and confirmed rows', async () => {
+      // Suspected: unreadable bit, relayed by a different gateway.
+      await repo.insertPacket(makePacket({
+        packetId: 200, fromNode: 300, gatewayId: '!00000400', gatewayNodeNum: 0x400,
+        bitfield: null, okToMqttViolation: 0, timestamp: 1000,
+      }));
+      // Confirmed violation (bitfield NOT NULL) — must NOT appear as suspected.
+      await repo.insertPacket(makePacket({
+        packetId: 201, fromNode: 301, gatewayId: '!00000401', gatewayNodeNum: 0x401,
+        bitfield: 0, okToMqttViolation: 1, timestamp: 1100,
+      }));
+      // Self-published (gatewayNodeNum === fromNode) — must NOT appear as suspected.
+      await repo.insertPacket(makePacket({
+        packetId: 202, fromNode: 302, gatewayId: '!00000402', gatewayNodeNum: 302,
+        bitfield: null, okToMqttViolation: 0, timestamp: 1200,
+      }));
+      // gatewayNodeNum unknown — relaying cannot be proven — must NOT appear.
+      await repo.insertPacket(makePacket({
+        packetId: 203, fromNode: 303, gatewayId: null, gatewayNodeNum: null,
+        bitfield: null, okToMqttViolation: 0, timestamp: 1300,
+      }));
+
+      const suspected = await repo.getSuspectedViolations({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
+      expect(suspected.map(r => r.packetId)).toEqual([200]);
+    });
+
+    it('getSuspectedViolations returns [] for an empty sourceIds array', async () => {
+      await repo.insertPacket(makePacket({ packetId: 210, fromNode: 400, gatewayId: '!gw', gatewayNodeNum: 999, bitfield: null }));
+      expect(await repo.getSuspectedViolations({ sourceIds: [], since: 0, until: Date.now() })).toEqual([]);
+    });
+
+    it('getSuspectedViolationGateways aggregates the same predicate per gateway', async () => {
+      await repo.insertPacket(makePacket({
+        packetId: 220, fromNode: 500, gatewayId: '!00000600', gatewayNodeNum: 0x600,
+        bitfield: null, timestamp: 1000,
+      }));
+      await repo.insertPacket(makePacket({
+        packetId: 221, fromNode: 501, gatewayId: '!00000600', gatewayNodeNum: 0x600,
+        bitfield: null, timestamp: 2000,
+      }));
+      // Different gateway.
+      await repo.insertPacket(makePacket({
+        packetId: 222, fromNode: 502, gatewayId: '!00000601', gatewayNodeNum: 0x601,
+        bitfield: null, timestamp: 1500,
+      }));
+
+      const gateways = await repo.getSuspectedViolationGateways({ sourceIds: [SOURCE], since: 0, until: Date.now() + 1_000_000 });
+      const gw600 = gateways.find(g => g.gatewayId === '!00000600');
+      expect(gw600).toBeDefined();
+      expect(gw600?.suspectedCount).toBe(2);
+      expect(gw600?.distinctOriginators).toBe(2);
+      expect(gw600?.firstSeen).toBe(1000);
+      expect(gw600?.lastSeen).toBe(2000);
+
+      const gw601 = gateways.find(g => g.gatewayId === '!00000601');
+      expect(gw601?.suspectedCount).toBe(1);
+    });
   });
 });

--- a/src/db/repositories/mqttPacketLog.perSource.test.ts
+++ b/src/db/repositories/mqttPacketLog.perSource.test.ts
@@ -12,20 +12,7 @@ import { MqttPacketLogRepository, type DbMqttPacket } from './mqttPacketLog.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
-/**
- * `DbMqttPacket` does not yet declare the ok_to_mqtt columns added to the
- * `mqtt_packet_log` table by migration 128 (#4114) — that repository-level
- * typing lands separately (see MQTT_OK_TO_MQTT_PHASE1_SPEC.md WP3, §3.9).
- * Extend locally so this factory can exercise the new columns across the
- * existing per-source isolation assertions ahead of that change landing.
- */
-type DbMqttPacketWithOkToMqtt = DbMqttPacket & {
-  bitfield?: number | null;
-  okToMqttViolation?: number;
-  topic?: string | null;
-};
-
-function makePacket(sourceId: string, overrides: Partial<DbMqttPacketWithOkToMqtt> = {}): DbMqttPacketWithOkToMqtt {
+function makePacket(sourceId: string, overrides: Partial<DbMqttPacket> = {}): DbMqttPacket {
   const now = 1_700_000_000_000;
   return {
     sourceId,

--- a/src/db/repositories/mqttPacketLog.perSource.test.ts
+++ b/src/db/repositories/mqttPacketLog.perSource.test.ts
@@ -12,7 +12,20 @@ import { MqttPacketLogRepository, type DbMqttPacket } from './mqttPacketLog.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
-function makePacket(sourceId: string, overrides: Partial<DbMqttPacket> = {}): DbMqttPacket {
+/**
+ * `DbMqttPacket` does not yet declare the ok_to_mqtt columns added to the
+ * `mqtt_packet_log` table by migration 128 (#4114) — that repository-level
+ * typing lands separately (see MQTT_OK_TO_MQTT_PHASE1_SPEC.md WP3, §3.9).
+ * Extend locally so this factory can exercise the new columns across the
+ * existing per-source isolation assertions ahead of that change landing.
+ */
+type DbMqttPacketWithOkToMqtt = DbMqttPacket & {
+  bitfield?: number | null;
+  okToMqttViolation?: number;
+  topic?: string | null;
+};
+
+function makePacket(sourceId: string, overrides: Partial<DbMqttPacketWithOkToMqtt> = {}): DbMqttPacketWithOkToMqtt {
   const now = 1_700_000_000_000;
   return {
     sourceId,
@@ -38,6 +51,9 @@ function makePacket(sourceId: string, overrides: Partial<DbMqttPacket> = {}): Db
     ingestOutcome: 'ingested',
     payloadSize: 12,
     payloadPreview: 'hello',
+    bitfield: null,
+    okToMqttViolation: 0,
+    topic: null,
     createdAt: now,
     ...overrides,
   };

--- a/src/db/repositories/mqttPacketLog.ts
+++ b/src/db/repositories/mqttPacketLog.ts
@@ -9,7 +9,7 @@
  * (`getGateways`). See docs/internal/dev-notes/MQTT_PACKET_MONITOR_PHASE1_SPEC.md
  * §2.6/§3 for the design this file implements verbatim.
  */
-import { eq, and, gte, lt, asc, desc, isNotNull, inArray, sql, type SQL } from 'drizzle-orm';
+import { eq, and, gte, lte, lt, asc, desc, isNull, isNotNull, inArray, sql, type SQL } from 'drizzle-orm';
 import { BaseRepository } from './base.js';
 
 export type MqttIngestOutcome =
@@ -46,6 +46,12 @@ export interface DbMqttPacket {
   ingestOutcome: MqttIngestOutcome;
   payloadSize?: number | null;
   payloadPreview?: string | null;
+  /** Raw `Data.bitfield` (protobuf field 9). NULL = absent/undecryptable = ok_to_mqtt unknown (#4114). */
+  bitfield?: number | null;
+  /** 0/1, NOT a boolean column — MAX(okToMqttViolation) in the grouped query needs an int (#4114). */
+  okToMqttViolation: number; // 0 | 1
+  /** Raw MQTT topic this reception arrived on. Diagnostic (#4114). */
+  topic?: string | null;
   createdAt: number;
 }
 
@@ -75,6 +81,8 @@ export interface MqttGroupedPacket {
   ingestOutcome: string;
   payloadSize: number | null;
   payloadPreview: string | null;
+  bitfield: number | null; // representative (MAX) — exact: the field is the originator's
+  okToMqttViolation: number; // MAX — 1 => at least one gateway violated
   gatewayCount: number; // COUNT(DISTINCT gatewayId)
   receptionCount: number; // COUNT(*)
   firstHeard: number; // MIN(timestamp)
@@ -154,6 +162,8 @@ export class MqttPacketLogRepository extends BaseRepository {
         ingestOutcome: sql<string>`MAX(${t.ingestOutcome})`,
         payloadSize: sql<number | null>`MAX(${t.payloadSize})`,
         payloadPreview: sql<string | null>`MAX(${t.payloadPreview})`,
+        bitfield: sql<number | null>`MAX(${t.bitfield})`,
+        okToMqttViolation: sql<number>`MAX(${t.okToMqttViolation})`,
         gatewayCount: sql<number>`COUNT(DISTINCT ${t.gatewayId})`,
         receptionCount: sql<number>`COUNT(*)`,
         firstHeard: sql<number>`MIN(${t.timestamp})`,
@@ -231,6 +241,97 @@ export class MqttPacketLogRepository extends BaseRepository {
       .groupBy(t.gatewayId)
       .orderBy(sql`MAX(${t.timestamp}) DESC`);
     return this.normalizeBigInts(rows) as unknown as MqttGateway[];
+  }
+
+  /**
+   * Suspected ok_to_mqtt violations (#4114): relayed receptions whose bit was
+   * unreadable (`bitfield IS NULL`). Bounded by this table's retention
+   * window — see MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(e). Excludes
+   * self-published rows (`gatewayNodeNum === fromNode`) and rows where
+   * either identity is unknown, since relaying cannot be proven for those.
+   */
+  async getSuspectedViolations(q: {
+    sourceIds: string[];
+    since: number;
+    until: number;
+    gatewayId?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<DbMqttPacket[]> {
+    if (q.sourceIds.length === 0) return [];
+    const t = this.tables.mqttPacketLog;
+    const conditions: SQL[] = [
+      inArray(t.sourceId, q.sourceIds),
+      isNull(t.bitfield),
+      isNotNull(t.gatewayNodeNum),
+      isNotNull(t.fromNode),
+      sql`${t.gatewayNodeNum} <> ${t.fromNode}`,
+      gte(t.timestamp, q.since),
+      lte(t.timestamp, q.until),
+    ];
+    if (q.gatewayId) {
+      conditions.push(eq(t.gatewayId, q.gatewayId));
+    }
+    const rows = await this.db
+      .select()
+      .from(t)
+      .where(and(...conditions))
+      .orderBy(desc(t.timestamp))
+      .limit(q.limit ?? 500)
+      .offset(q.offset ?? 0);
+    return this.normalizeBigInts(rows) as unknown as DbMqttPacket[];
+  }
+
+  /**
+   * Per-gateway aggregate over the same "suspected" predicate as
+   * {@link getSuspectedViolations} — powers the `includeUnknown` merge on
+   * the gateway summary route.
+   */
+  async getSuspectedViolationGateways(q: {
+    sourceIds: string[];
+    since: number;
+    until: number;
+  }): Promise<
+    Array<{
+      gatewayId: string | null;
+      gatewayNodeNum: number | null;
+      suspectedCount: number;
+      distinctOriginators: number;
+      firstSeen: number;
+      lastSeen: number;
+    }>
+  > {
+    if (q.sourceIds.length === 0) return [];
+    const t = this.tables.mqttPacketLog;
+    const conditions: SQL[] = [
+      inArray(t.sourceId, q.sourceIds),
+      isNull(t.bitfield),
+      isNotNull(t.gatewayNodeNum),
+      isNotNull(t.fromNode),
+      sql`${t.gatewayNodeNum} <> ${t.fromNode}`,
+      gte(t.timestamp, q.since),
+      lte(t.timestamp, q.until),
+    ];
+    const rows = await this.db
+      .select({
+        gatewayId: t.gatewayId,
+        gatewayNodeNum: sql<number | null>`MAX(${t.gatewayNodeNum})`,
+        suspectedCount: sql<number>`COUNT(*)`,
+        distinctOriginators: sql<number>`COUNT(DISTINCT ${t.fromNode})`,
+        firstSeen: sql<number>`MIN(${t.timestamp})`,
+        lastSeen: sql<number>`MAX(${t.timestamp})`,
+      })
+      .from(t)
+      .where(and(...conditions))
+      .groupBy(t.gatewayId);
+    return this.normalizeBigInts(rows) as unknown as Array<{
+      gatewayId: string | null;
+      gatewayNodeNum: number | null;
+      suspectedCount: number;
+      distinctOriginators: number;
+      firstSeen: number;
+      lastSeen: number;
+    }>;
   }
 
   /**

--- a/src/db/repositories/mqttPacketLog.ts
+++ b/src/db/repositories/mqttPacketLog.ts
@@ -335,6 +335,40 @@ export class MqttPacketLogRepository extends BaseRepository {
   }
 
   /**
+   * Distinct `(gatewayId, sourceId)` pairs over the same "suspected"
+   * predicate as {@link getSuspectedViolationGateways} — powers the
+   * per-gateway `sourceIds` array for suspected-only gateways on the
+   * `/mqtt-violations/gateways` route (#4114). `sourceId` can't be added to
+   * that method's aggregate projection ungrouped (MySQL `ONLY_FULL_GROUP_BY`),
+   * so this mirrors `MqttOkToMqttViolationsRepository.getGatewaySourceIds`,
+   * which exists for the identical reason on the confirmed-violations side.
+   */
+  async getSuspectedGatewaySourceIds(q: {
+    sourceIds: string[];
+    since: number;
+    until: number;
+  }): Promise<Array<{ gatewayId: string; sourceId: string }>> {
+    if (q.sourceIds.length === 0) return [];
+    const t = this.tables.mqttPacketLog;
+    const conditions: SQL[] = [
+      inArray(t.sourceId, q.sourceIds),
+      isNull(t.bitfield),
+      isNotNull(t.gatewayNodeNum),
+      isNotNull(t.fromNode),
+      sql`${t.gatewayNodeNum} <> ${t.fromNode}`,
+      gte(t.timestamp, q.since),
+      lte(t.timestamp, q.until),
+    ];
+    const rows = await this.db
+      .selectDistinct({ gatewayId: t.gatewayId, sourceId: t.sourceId })
+      .from(t)
+      .where(and(...conditions));
+    return (rows as Array<{ gatewayId: string | null; sourceId: string }>).filter(
+      (r): r is { gatewayId: string; sourceId: string } => r.gatewayId != null,
+    );
+  }
+
+  /**
    * Raw row count (receptions, not groups), optionally scoped to one source.
    * Used by retention (count-based trim).
    */

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -21,6 +21,7 @@ export * from './notifications.js';
 // Packet logging
 export * from './packets.js';
 export * from './mqttPacketLog.js';
+export * from './mqttOkToMqttViolations.js';
 
 // Miscellaneous tables
 export * from './misc.js';

--- a/src/db/schema/mqttOkToMqttViolations.ts
+++ b/src/db/schema/mqttOkToMqttViolations.ts
@@ -1,0 +1,100 @@
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, bigint as pgBigint } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, serial as mySerial, bigint as myBigint } from 'drizzle-orm/mysql-core';
+
+// ============ SQLite Schema ============
+//
+// Durable history of *confirmed* `ok_to_mqtt` violations (issue #4114): a
+// gateway relayed another node's packet to MQTT while that packet's
+// `Data.bitfield` bit 0 was explicitly clear. This is deliberately a
+// separate table from `mqtt_packet_log`, not a flag/extra columns there,
+// because it needs retention immunity relative to the packet log's 24h /
+// 5,000-row trim (`mqttPacketLogService.ts`) — Phase 3 needs a weeks-long
+// lookback for its violation report, and the packet log's aggressive
+// retention would silently discard that history. See
+// docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md §1.9/§2(d).
+//
+// Rows are written ONLY for confirmed violations (`state === 'no' &&
+// relayed`) — "unknown" (undecryptable) receptions are never persisted here;
+// on a busy encrypted source that would be the same volume as the packet log
+// and defeat the retention-immunity argument. "Suspected" (unknown-bitfield)
+// entries are instead served from `mqtt_packet_log` at query time, bounded by
+// its own retention window (spec §2(e)).
+//
+// Own retention sweep, own settings, dedupe via a unique index on the
+// natural reception key. Capture is gated by
+// `mqtt_oktomqtt_violation_log_enabled` (default ON, unlike the opt-in
+// packet log) — see `src/server/constants/settings.ts`.
+
+export const mqttOkToMqttViolationsSqlite = sqliteTable('mqtt_ok_to_mqtt_violations', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  sourceId: text('sourceId').notNull(),
+  /** ServiceEnvelope packet.id. Nullable/0 tolerated (cannot dedupe — see file header). */
+  packetId: integer('packetId'),
+  /** Unsigned 32-bit originator node number. */
+  fromNode: integer('fromNode'),
+  /** `!aabbccdd` form of fromNode. */
+  fromNodeId: text('fromNodeId'),
+  /** `!aabbccdd` form of the relaying gateway's node number. */
+  gatewayId: text('gatewayId'),
+  /** Parsed from gatewayId; nullable when gatewayId is malformed/absent. */
+  gatewayNodeNum: integer('gatewayNodeNum'),
+  /** Envelope channel **name** string. */
+  channelId: text('channelId'),
+  /** Meshtastic PortNum. */
+  portnum: integer('portnum'),
+  /** Human-readable PortNum (e.g. TEXT_MESSAGE_APP). */
+  portnumName: text('portnumName'),
+  /** Raw `Data.bitfield` (protobuf field 9). Always non-null and even (bit 0 clear) on a confirmed row. */
+  bitfield: integer('bitfield'),
+  /** Raw MQTT topic this reception arrived on. Diagnostic. */
+  topic: text('topic'),
+  /** Wire rxTime converted to ms; nullable. */
+  rxTime: integer('rxTime'),
+  /** Server capture time (ms). Ordering + retention cutoff. */
+  timestamp: integer('timestamp').notNull(),
+  createdAt: integer('createdAt').notNull(),
+});
+
+// ============ PostgreSQL Schema ============
+
+export const mqttOkToMqttViolationsPostgres = pgTable('mqtt_ok_to_mqtt_violations', {
+  id: pgInteger('id').primaryKey().generatedAlwaysAsIdentity(),
+  sourceId: pgText('sourceId').notNull(),
+  // Node numbers/packet ids are unsigned 32-bit; PG INTEGER is signed 32-bit.
+  packetId: pgBigint('packetId', { mode: 'number' }),
+  fromNode: pgBigint('fromNode', { mode: 'number' }),
+  fromNodeId: pgText('fromNodeId'),
+  gatewayId: pgText('gatewayId'),
+  gatewayNodeNum: pgBigint('gatewayNodeNum', { mode: 'number' }),
+  channelId: pgText('channelId'),
+  portnum: pgInteger('portnum'),
+  portnumName: pgText('portnumName'),
+  bitfield: pgInteger('bitfield'),
+  topic: pgText('topic'),
+  rxTime: pgBigint('rxTime', { mode: 'number' }),
+  // ms-epoch timestamps overflow 32-bit INTEGER (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
+  createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// ============ MySQL Schema ============
+
+export const mqttOkToMqttViolationsMysql = mysqlTable('mqtt_ok_to_mqtt_violations', {
+  id: mySerial('id').primaryKey(),
+  sourceId: myVarchar('sourceId', { length: 255 }).notNull(),
+  packetId: myBigint('packetId', { mode: 'number' }),
+  fromNode: myBigint('fromNode', { mode: 'number' }),
+  fromNodeId: myVarchar('fromNodeId', { length: 16 }),
+  gatewayId: myVarchar('gatewayId', { length: 32 }),
+  gatewayNodeNum: myBigint('gatewayNodeNum', { mode: 'number' }),
+  channelId: myVarchar('channelId', { length: 64 }),
+  portnum: myInt('portnum'),
+  portnumName: myVarchar('portnumName', { length: 48 }),
+  bitfield: myInt('bitfield'),
+  topic: myVarchar('topic', { length: 512 }),
+  rxTime: myBigint('rxTime', { mode: 'number' }),
+  // ms-epoch timestamps overflow 32-bit INT (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
+  createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
+});

--- a/src/db/schema/mqttPacketLog.ts
+++ b/src/db/schema/mqttPacketLog.ts
@@ -50,11 +50,21 @@ export const mqttPacketLogSqlite = sqliteTable('mqtt_packet_log', {
   encrypted: integer('encrypted').notNull().default(0),
   /** 'server' when MeshMonitor decrypted an encrypted copy server-side, else null. */
   decryptedBy: text('decryptedBy'),
-  /** 'ingested' | 'encrypted' | 'ignored' | 'geo-ignored' | 'unsupported-portnum' | 'decode-error'. */
+  /** 'ingested' | 'encrypted' | 'ignored' | 'geo-ignored' | 'distance' | 'unsupported-portnum' | 'decode-error'. */
   ingestOutcome: text('ingestOutcome').notNull(),
   payloadSize: integer('payloadSize'),
   /** Text preview (TEXT_MESSAGE_APP only in Phase 1) or null. */
   payloadPreview: text('payloadPreview'),
+  /** Raw `Data.bitfield` (protobuf field 9). NULL = absent/undecryptable = ok_to_mqtt unknown (#4114). */
+  bitfield: integer('bitfield'),
+  /**
+   * 0/1 integer, NOT a boolean column type - same load-bearing reason as `encrypted` above:
+   * the grouped query does `MAX(okToMqttViolation)` and PostgreSQL has no MAX(boolean).
+   * 1 => bit 0 was explicitly clear AND the publishing gateway is not the originator (#4114).
+   */
+  okToMqttViolation: integer('okToMqttViolation').notNull().default(0),
+  /** Raw MQTT topic this reception arrived on. Diagnostic (#4114). */
+  topic: text('topic'),
   createdAt: integer('createdAt').notNull(),
 });
 
@@ -88,6 +98,9 @@ export const mqttPacketLogPostgres = pgTable('mqtt_packet_log', {
   ingestOutcome: pgText('ingestOutcome').notNull(),
   payloadSize: pgInteger('payloadSize'),
   payloadPreview: pgText('payloadPreview'),
+  bitfield: pgInteger('bitfield'),
+  okToMqttViolation: pgInteger('okToMqttViolation').notNull().default(0),
+  topic: pgText('topic'),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
 
@@ -120,5 +133,8 @@ export const mqttPacketLogMysql = mysqlTable('mqtt_packet_log', {
   ingestOutcome: myVarchar('ingestOutcome', { length: 24 }).notNull(),
   payloadSize: myInt('payloadSize'),
   payloadPreview: myVarchar('payloadPreview', { length: 256 }),
+  bitfield: myInt('bitfield'),
+  okToMqttViolation: myInt('okToMqttViolation').notNull().default(0),
+  topic: myVarchar('topic', { length: 512 }),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -103,6 +103,15 @@ export const VALID_SETTINGS_KEYS = [
   'mqtt_packet_log_enabled',
   'mqtt_packet_log_max_count',
   'mqtt_packet_log_max_age_hours',
+  // `ok_to_mqtt` violation detection (#4114). Durable-write kill switch is
+  // DEFAULT ON — inverted from the `mqtt_packet_log_enabled` convention
+  // (`=== '1'` means on): here `=== '0'` means off, and anything else,
+  // including unset, means on. This is deliberate so the feature works on
+  // installs that never touched settings. See
+  // docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(g).
+  'mqtt_oktomqtt_violation_log_enabled',
+  'mqtt_oktomqtt_violation_retention_days',
+  'mqtt_oktomqtt_violation_max_count',
   // Rolling retention window (days) for the MeshCore position-history trail (#3852).
   'meshcore_position_history_retention_days',
   'solarMonitoringEnabled',

--- a/src/server/migrations/128_mqtt_oktomqtt_violations.test.ts
+++ b/src/server/migrations/128_mqtt_oktomqtt_violations.test.ts
@@ -1,0 +1,182 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration as migration121 } from './121_mqtt_packet_log.js';
+import {
+  migration,
+  runMigration128Postgres,
+  runMigration128Mysql,
+} from './128_mqtt_oktomqtt_violations.js';
+
+describe('Migration 128 — ok_to_mqtt violation detection', () => {
+  describe('SQLite', () => {
+    function setup(): Database.Database {
+      const db = new Database(':memory:');
+      migration121.up(db); // mqtt_packet_log must exist first
+      return db;
+    }
+
+    it('adds the three mqtt_packet_log columns and creates mqtt_ok_to_mqtt_violations', () => {
+      const db = setup();
+
+      migration.up(db);
+
+      const packetLogCols = (db.prepare(`PRAGMA table_info(mqtt_packet_log)`).all() as Array<{ name: string }>)
+        .map((c) => c.name);
+      expect(packetLogCols).toContain('bitfield');
+      expect(packetLogCols).toContain('okToMqttViolation');
+      expect(packetLogCols).toContain('topic');
+
+      const table = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name = 'mqtt_ok_to_mqtt_violations'`
+      ).get();
+      expect(table).toBeTruthy();
+
+      db.close();
+    });
+
+    it('is idempotent (second up() does not throw)', () => {
+      const db = setup();
+
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+
+      const packetLogCols = (db.prepare(`PRAGMA table_info(mqtt_packet_log)`).all() as Array<{ name: string }>)
+        .map((c) => c.name);
+      expect(packetLogCols.filter((c) => c === 'bitfield')).toHaveLength(1);
+      expect(packetLogCols.filter((c) => c === 'okToMqttViolation')).toHaveLength(1);
+      expect(packetLogCols.filter((c) => c === 'topic')).toHaveLength(1);
+
+      db.close();
+    });
+
+    it('round-trips a full violation row insert/read', () => {
+      const db = setup();
+      migration.up(db);
+
+      const now = Date.now();
+      db.prepare(`
+        INSERT INTO mqtt_ok_to_mqtt_violations (
+          sourceId, packetId, fromNode, fromNodeId, gatewayId, gatewayNodeNum,
+          channelId, portnum, portnumName, bitfield, topic, rxTime, timestamp, createdAt
+        ) VALUES (
+          @sourceId, @packetId, @fromNode, @fromNodeId, @gatewayId, @gatewayNodeNum,
+          @channelId, @portnum, @portnumName, @bitfield, @topic, @rxTime, @timestamp, @createdAt
+        )
+      `).run({
+        sourceId: 'source-a',
+        packetId: 123456,
+        fromNode: 0xaabbccdd,
+        fromNodeId: '!aabbccdd',
+        gatewayId: '!433e0f28',
+        gatewayNodeNum: 0x433e0f28,
+        channelId: 'LongFast',
+        portnum: 1,
+        portnumName: 'TEXT_MESSAGE_APP',
+        bitfield: 0,
+        topic: 'msh/US/2/e/LongFast/!433e0f28',
+        rxTime: now - 500,
+        timestamp: now,
+        createdAt: now,
+      });
+
+      const row = db.prepare(`SELECT * FROM mqtt_ok_to_mqtt_violations WHERE sourceId = 'source-a'`).get() as {
+        packetId: number;
+        fromNodeId: string;
+        gatewayId: string;
+        bitfield: number;
+        topic: string;
+      };
+      expect(row).toBeTruthy();
+      expect(row.packetId).toBe(123456);
+      expect(row.fromNodeId).toBe('!aabbccdd');
+      expect(row.gatewayId).toBe('!433e0f28');
+      expect(row.bitfield).toBe(0);
+      expect(row.topic).toBe('msh/US/2/e/LongFast/!433e0f28');
+
+      db.close();
+    });
+
+    it('enforces the dedupe unique index at the raw-SQL level', () => {
+      const db = setup();
+      migration.up(db);
+
+      const now = Date.now();
+      const insert = () =>
+        db.prepare(`
+          INSERT INTO mqtt_ok_to_mqtt_violations (
+            sourceId, packetId, fromNode, gatewayNodeNum, timestamp, createdAt
+          ) VALUES (@sourceId, @packetId, @fromNode, @gatewayNodeNum, @timestamp, @createdAt)
+        `).run({
+          sourceId: 'source-a',
+          packetId: 42,
+          fromNode: 10,
+          gatewayNodeNum: 20,
+          timestamp: now,
+          createdAt: now,
+        });
+
+      insert();
+      expect(() => insert()).toThrow(/UNIQUE constraint failed/);
+
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('issues ADD COLUMN IF NOT EXISTS for the three mqtt_packet_log columns, then creates the table and indexes', async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }) } as unknown as import('pg').PoolClient;
+
+      await runMigration128Postgres(client);
+
+      const calls = (client.query as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+      expect(calls.length).toBe(7);
+      expect(calls[0][0]).toContain('ADD COLUMN IF NOT EXISTS "bitfield"');
+      expect(calls[1][0]).toContain('ADD COLUMN IF NOT EXISTS "okToMqttViolation"');
+      expect(calls[2][0]).toContain('ADD COLUMN IF NOT EXISTS "topic"');
+      expect(calls[3][0]).toContain('CREATE TABLE IF NOT EXISTS mqtt_ok_to_mqtt_violations');
+      expect(calls[4][0]).toContain('CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_ts');
+      expect(calls[5][0]).toContain('CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_gw_ts');
+      expect(calls[6][0]).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_mqtt_v_dedupe');
+    });
+
+    it('resolves without throwing', async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }) } as unknown as import('pg').PoolClient;
+      await expect(runMigration128Postgres(client)).resolves.not.toThrow();
+    });
+  });
+
+  describe('MySQL', () => {
+    function makeConn(existRows: unknown[]) {
+      return {
+        query: vi.fn().mockResolvedValue([existRows, []]),
+        release: vi.fn(),
+      };
+    }
+
+    it('pre-checks information_schema.COLUMNS for each mqtt_packet_log column and information_schema.TABLES for the new table', async () => {
+      const conn = makeConn([]);
+      const pool = { getConnection: vi.fn().mockResolvedValue(conn) } as unknown as import('mysql2/promise').Pool;
+
+      await runMigration128Mysql(pool);
+
+      // 3 columns x (pre-check + ALTER) + 1 table x (pre-check + CREATE) = 8 queries
+      expect(conn.query).toHaveBeenCalledTimes(8);
+      expect(conn.query.mock.calls[0][0]).toContain('information_schema.COLUMNS');
+      expect(conn.query.mock.calls[1][0]).toContain('ALTER TABLE mqtt_packet_log ADD COLUMN bitfield');
+      expect(conn.query.mock.calls[6][0]).toContain('information_schema.TABLES');
+      expect(conn.query.mock.calls[7][0]).toContain('CREATE TABLE mqtt_ok_to_mqtt_violations');
+    });
+
+    it('skips ALTER/CREATE when columns and table already exist', async () => {
+      const conn = makeConn([{ COLUMN_NAME: 'bitfield' }]);
+      // Every information_schema pre-check call returns a non-empty result so
+      // every ALTER/CREATE is skipped.
+      const pool = { getConnection: vi.fn().mockResolvedValue(conn) } as unknown as import('mysql2/promise').Pool;
+
+      await runMigration128Mysql(pool);
+
+      // Only the 3 column pre-checks + 1 table pre-check = 4 queries, no ALTER/CREATE.
+      expect(conn.query).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/server/migrations/128_mqtt_oktomqtt_violations.ts
+++ b/src/server/migrations/128_mqtt_oktomqtt_violations.ts
@@ -1,0 +1,138 @@
+/**
+ * Migration 128: `ok_to_mqtt` violation detection (#4114).
+ *
+ * Part A: adds `bitfield` / `okToMqttViolation` / `topic` to `mqtt_packet_log`
+ * so a reception's originator-set ok_to_mqtt bit (and the derived violation
+ * flag) survive alongside the rest of the packet log row.
+ *
+ * Part B: creates `mqtt_ok_to_mqtt_violations`, a retention-immune history
+ * table of *confirmed* violations (a gateway relayed another node's packet
+ * while its bit was explicitly clear). It is intentionally a separate table
+ * from `mqtt_packet_log` — see `src/db/schema/mqttOkToMqttViolations.ts` and
+ * docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md §1.9/§2(d) for why.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL via the shared helpers.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+  createTableIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 128';
+const PL = 'mqtt_packet_log';
+const V = 'mqtt_ok_to_mqtt_violations';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ok_to_mqtt columns to ${PL} and creating ${V}...`);
+
+    addColumnIfMissing(db, PL, 'bitfield', 'bitfield INTEGER');
+    addColumnIfMissing(db, PL, 'okToMqttViolation', 'okToMqttViolation INTEGER NOT NULL DEFAULT 0');
+    addColumnIfMissing(db, PL, 'topic', 'topic TEXT');
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${V} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sourceId TEXT NOT NULL,
+        packetId INTEGER,
+        fromNode INTEGER,
+        fromNodeId TEXT,
+        gatewayId TEXT,
+        gatewayNodeNum INTEGER,
+        channelId TEXT,
+        portnum INTEGER,
+        portnumName TEXT,
+        bitfield INTEGER,
+        topic TEXT,
+        rxTime INTEGER,
+        timestamp INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL
+      )
+    `);
+
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_ts ON ${V}(sourceId, timestamp)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_gw_ts ON ${V}(sourceId, gatewayNodeNum, timestamp)`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mqtt_v_dedupe ON ${V}(sourceId, packetId, fromNode, gatewayNodeNum)`);
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops / table drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration128Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ok_to_mqtt columns to ${PL} and creating ${V}...`);
+
+  await addColumnIfMissingPostgres(client, PL, 'bitfield', '"bitfield" INTEGER');
+  await addColumnIfMissingPostgres(client, PL, 'okToMqttViolation', '"okToMqttViolation" INTEGER NOT NULL DEFAULT 0');
+  await addColumnIfMissingPostgres(client, PL, 'topic', '"topic" TEXT');
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${V} (
+      id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      "sourceId" TEXT NOT NULL,
+      "packetId" BIGINT,
+      "fromNode" BIGINT,
+      "fromNodeId" TEXT,
+      "gatewayId" TEXT,
+      "gatewayNodeNum" BIGINT,
+      "channelId" TEXT,
+      portnum INTEGER,
+      "portnumName" TEXT,
+      bitfield INTEGER,
+      topic TEXT,
+      "rxTime" BIGINT,
+      "timestamp" BIGINT NOT NULL,
+      "createdAt" BIGINT NOT NULL
+    )
+  `);
+
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_ts ON ${V}("sourceId","timestamp")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_mqtt_v_source_gw_ts ON ${V}("sourceId","gatewayNodeNum","timestamp")`);
+  await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mqtt_v_dedupe ON ${V}("sourceId","packetId","fromNode","gatewayNodeNum")`);
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration128Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ok_to_mqtt columns to ${PL} and creating ${V}...`);
+
+  await addColumnIfMissingMysql(pool, PL, 'bitfield', 'bitfield INT');
+  await addColumnIfMissingMysql(pool, PL, 'okToMqttViolation', 'okToMqttViolation INT NOT NULL DEFAULT 0');
+  await addColumnIfMissingMysql(pool, PL, 'topic', 'topic VARCHAR(512)');
+
+  await createTableIfMissingMysql(pool, V, `CREATE TABLE ${V} (
+    id SERIAL PRIMARY KEY,
+    sourceId VARCHAR(255) NOT NULL,
+    packetId BIGINT,
+    fromNode BIGINT,
+    fromNodeId VARCHAR(16),
+    gatewayId VARCHAR(32),
+    gatewayNodeNum BIGINT,
+    channelId VARCHAR(64),
+    portnum INT,
+    portnumName VARCHAR(48),
+    bitfield INT,
+    topic VARCHAR(512),
+    rxTime BIGINT,
+    timestamp BIGINT NOT NULL,
+    createdAt BIGINT NOT NULL,
+    INDEX idx_mqtt_v_source_ts (sourceId, timestamp),
+    INDEX idx_mqtt_v_source_gw_ts (sourceId, gatewayNodeNum, timestamp),
+    UNIQUE KEY idx_mqtt_v_dedupe (sourceId, packetId, fromNode, gatewayNodeNum)
+  )`);
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -116,6 +116,7 @@ import databaseService from '../services/database.js';
 import { PortNum } from './constants/meshtastic.js';
 import type { GeoSweepStats } from './services/mqttGeoSweepService.js';
 import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+import { channelDecryptionService } from './services/channelDecryptionService.js';
 
 async function ephemeralPort(): Promise<number> {
   const net = await import('net');
@@ -1150,6 +1151,139 @@ describe('MqttBridgeManager', () => {
     expect(bridge.getStatus().uplinkOkToMqttDrops).toBe(0);
 
     await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  it('ok_to_mqtt: encrypted packet with no decoded bitfield attempts server-side decryption via channelDecryptionService', async () => {
+    // `decoded` and `encrypted` are a real protobuf oneof on MeshPacket
+    // (mesh.proto `payload_variant`) — a genuinely encrypted reception never
+    // carries a parallel `decoded` field on the wire, so this constructs the
+    // natural "encrypted-only" shape. It exercises the exact same branch of
+    // resolveOkToMqttForEnvelope as "decoded present but bitfield absent"
+    // (both skip the plaintext-bitfield check and fall through to the
+    // decrypt attempt); the literal "decoded object present, bitfield unset"
+    // shape is covered directly against the pure function in
+    // src/server/utils/okToMqtt.test.ts.
+    const tryDecryptSpy = vi
+      .spyOn(channelDecryptionService, 'tryDecrypt')
+      .mockResolvedValue({ success: false, error: 'no matching key (test)' });
+
+    const publishesByClient: Array<{ clientId: string | null; topic: string }> = [];
+    upstream.aedes.on('publish', (packet, client) => {
+      if (!client) return;
+      publishesByClient.push({ clientId: client.id, topic: packet.topic });
+    });
+
+    bridge = new MqttBridgeManager('encrypted-unknown-bridge', 'EncUnknown', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: [],
+      mode: 'publish_only',
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+      clientId: '!33333333',
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelopeBytes = meshtasticProtobufService.encodeServiceEnvelope({
+      packet: {
+        from: 0x33333333,
+        to: 0xffffffff,
+        channel: 0,
+        id: 0x40000005,
+        encrypted: new Uint8Array([1, 2, 3, 4]),
+      },
+      channelId: 'LongFast',
+      gatewayId: '!33333333',
+    });
+    if (!envelopeBytes) throw new Error('encode failed');
+
+    try {
+      localClient.publish('msh/CA/ON/PTBO', Buffer.from(envelopeBytes));
+
+      await new Promise((r) => setTimeout(r, 500));
+
+      // The encrypted branch was reached and decryption was attempted with
+      // the ok_to_mqtt evaluator's expected args. (The local broker's own
+      // ingestion of this same locally-published packet independently
+      // calls tryDecrypt too, to decode message/telemetry content — so this
+      // asserts "at least once with these args", not an exact call count.)
+      expect(tryDecryptSpy).toHaveBeenCalledWith(expect.any(Uint8Array), 0x40000005, 0x33333333, 0);
+    } finally {
+      await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+      tryDecryptSpy.mockRestore();
+    }
+  });
+
+  it('ok_to_mqtt: an "unknown" resolution (decrypt failure) is fail-closed — packet not uplinked, uplinkOkToMqttDrops incremented', async () => {
+    const tryDecryptSpy = vi
+      .spyOn(channelDecryptionService, 'tryDecrypt')
+      .mockResolvedValue({ success: false, error: 'no matching key (test)' });
+
+    const publishesByClient: Array<{ clientId: string | null; topic: string }> = [];
+    upstream.aedes.on('publish', (packet, client) => {
+      if (!client) return;
+      publishesByClient.push({ clientId: client.id, topic: packet.topic });
+    });
+
+    bridge = new MqttBridgeManager('encrypted-unknown-drop-bridge', 'EncUnknownDrop', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: [],
+      mode: 'publish_only',
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+      clientId: '!44444444',
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelopeBytes = meshtasticProtobufService.encodeServiceEnvelope({
+      packet: {
+        from: 0x44444444,
+        to: 0xffffffff,
+        channel: 0,
+        id: 0x40000006,
+        encrypted: new Uint8Array([5, 6, 7, 8]),
+      },
+      channelId: 'LongFast',
+      gatewayId: '!44444444',
+    });
+    if (!envelopeBytes) throw new Error('encode failed');
+
+    try {
+      localClient.publish('msh/CA/ON/PTBO', Buffer.from(envelopeBytes));
+
+      await new Promise((r) => setTimeout(r, 500));
+
+      // 'unknown' (decrypt failed) must be fail-closed: not republished, drop
+      // counter incremented — the same policy as an explicit bit-0-unset packet.
+      expect(publishesByClient.some((p) => p.topic === 'msh/CA/ON/PTBO')).toBe(false);
+      expect(bridge.getStatus().uplinkOkToMqttDrops).toBeGreaterThanOrEqual(1);
+    } finally {
+      await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+      tryDecryptSpy.mockRestore();
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -687,6 +687,12 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       sourceId: this.sourceId,
       envelope,
       filter: this.downlinkFilter,
+      topic,
+      // Self-echo guard (#4114, §2(f.1)): `null` before the broker reports
+      // local node info / after a disconnect — the guard then simply does
+      // not apply. Belt-and-braces on top of the (non-airtight) echo
+      // suppression above (`matchesEcho`).
+      localGatewayNodeNum: this.brokerGatewayNum,
     })
       .then((result) => {
         if (result.ingested) this.downlinkIngested++;

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -47,7 +47,7 @@ import {
   formatGatewayClientId,
   type PublisherStatus,
 } from './mqttBridgePublisherPool.js';
-import { channelDecryptionService } from './services/channelDecryptionService.js';
+import { allowsUplink, resolveOkToMqttForEnvelope } from './utils/okToMqtt.js';
 import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
 import { mqttGeoSweepService, type GeoSweepStats } from './services/mqttGeoSweepService.js';
 
@@ -469,33 +469,21 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
    * this packet to be republished upstream. Mirrors firmware
    * `MQTT::onSend` (MQTT.cpp:767-788) — checks bit 0 of `Data.bitfield`.
    *
-   * - Decoded packet with bit set → allow.
-   * - Decoded packet with bit unset or `bitfield` absent → drop.
-   * - Encrypted packet → try server-side decryption via the channel DB,
-   *   then re-check. If decryption fails (no matching key), drop. This
-   *   matches firmware's fail-closed behavior on public brokers.
+   * Delegates to the shared tri-state evaluator in `./utils/okToMqtt.js`
+   * (#4114) — `resolveOkToMqttForEnvelope` reproduces this method's
+   * original control flow exactly (decoded bitfield, else server-side
+   * decrypt via the channel DB, else unknown), and `allowsUplink` applies
+   * the fail-closed uplink policy: only an explicit `'yes'` allows
+   * republishing. An `'unknown'` result (bit unreadable, decrypt failed,
+   * or no matching channel key) → drop. This matches firmware's
+   * fail-closed behavior on public brokers.
    *
    * Note: we deliberately do NOT special-case "private" upstream brokers
    * (per design — operator picks the override per-bridge via
    * `ignoreOkToMqtt` instead of relying on hostname heuristics).
    */
   private async evaluateOkToMqtt(envelope: ServiceEnvelopeShape): Promise<boolean> {
-    const decoded = envelope.packet?.decoded;
-    if (decoded && typeof decoded.bitfield === 'number') {
-      return (decoded.bitfield & 0x1) === 1;
-    }
-    // Encrypted path — try decryption against the channel DB so we can
-    // read the originator's bitfield. If we can't decrypt, fail closed.
-    const enc = envelope.packet?.encrypted;
-    const id = envelope.packet?.id;
-    const from = envelope.packet?.from;
-    if (!enc || typeof id !== 'number' || typeof from !== 'number') return false;
-    const channelHash = typeof envelope.packet?.channel === 'number'
-      ? envelope.packet.channel
-      : undefined;
-    const result = await channelDecryptionService.tryDecrypt(enc, id, from, channelHash);
-    if (!result.success || typeof result.bitfield !== 'number') return false;
-    return (result.bitfield & 0x1) === 1;
+    return allowsUplink(await resolveOkToMqttForEnvelope(envelope));
   }
 
   getLocalNodeInfo() {

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -14,6 +14,7 @@ import { EventEmitter } from 'events';
 import { MqttBroker, type MqttBrokerPublish } from './transports/mqttBroker.js';
 import { MqttPacketFilter, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
 import { ingestServiceEnvelope, bootstrapMqttChannelDatabase } from './mqttIngestion.js';
+import { parseGatewayNodeNum } from './utils/okToMqtt.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import type { Source } from '../db/repositories/sources.js';
@@ -318,6 +319,11 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
       sourceId: this.sourceId,
       envelope,
       filter: this.filter,
+      topic: msg.topic,
+      // Self-echo guard (#4114, §2(f.1)): this source's own gateway node
+      // number, so a local publish is never mistaken for a relayed copy of
+      // someone else's packet.
+      localGatewayNodeNum: parseGatewayNodeNum(this.config.gateway.nodeId),
     })
       .then((result) => {
         if (result.ingested) this.packetsIngested++;

--- a/src/server/mqttIngestion.bitfield.test.ts
+++ b/src/server/mqttIngestion.bitfield.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression guard for §2(b) of MQTT_OK_TO_MQTT_PHASE1_SPEC.md (#4114):
+ * `Data.bitfield` must survive `ingestServiceEnvelopeInner`'s server-side
+ * decrypt path (`mqttIngestion.ts` ~:190-205), which synthesizes
+ * `packet.decoded` from `channelDecryptionService.tryDecrypt(...)`.
+ *
+ * Before this change the synthesized `decoded` object dropped `bitfield`
+ * even though `DecryptionResult.bitfield` already carried it — which meant
+ * `detectOkToMqttViolation` (and the uplink evaluator) could never see the
+ * originator's `ok_to_mqtt` bit for any encrypted MQTT reception. This file
+ * proves the bit is (a) mutated onto the input envelope in place and (b)
+ * visible on the row handed to `mqttPacketLogService.logEnvelope`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const settingsStore: Record<string, string> = {};
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNodeAsync: vi.fn(async () => undefined),
+    nodes: {
+      getNode: vi.fn(async () => null),
+      getNodesByNums: vi.fn(async () => new Map()),
+      upsertNode: vi.fn(async () => undefined),
+    },
+    ignoredNodes: {
+      isIgnoredCached: vi.fn(() => false),
+      addGeoIgnoreAsync: vi.fn(async () => true),
+      liftGeoIgnoreAsync: vi.fn(async () => false),
+    },
+    messages: {
+      getMessage: vi.fn(async () => null),
+      insertMessage: vi.fn(async (_msg: any, _sourceId?: string) => true),
+    },
+    channelDatabase: {
+      findOrCreateByNameAndHashAsync: vi.fn(async () => undefined),
+      getEnabledAsync: vi.fn(async () => []),
+    },
+    getSettingAsync: vi.fn(async (key: string) => settingsStore[key] ?? null),
+    mqttPacketLog: {
+      insertPacket: vi.fn(async () => undefined),
+    },
+    mqttOkToMqttViolations: {
+      insertViolation: vi.fn(async () => undefined),
+    },
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    processPayload: vi.fn((portnum: number, payload: Uint8Array) => {
+      if (portnum === 1 /* TEXT_MESSAGE_APP */) {
+        return new TextDecoder('utf-8').decode(payload);
+      }
+      return null;
+    }),
+    getPortNumName: vi.fn((portnum: number) => (portnum === 1 ? 'TEXT_MESSAGE_APP' : `UNKNOWN_${portnum}`)),
+  },
+}));
+
+// Mock the decryption service directly rather than exercising real AES —
+// this file's job is to prove `bitfield` survives the synthesis step in
+// mqttIngestion.ts, not to re-test decryption itself (covered elsewhere).
+const tryDecryptMock = vi.fn();
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: {
+    isEnabled: vi.fn(() => true),
+    tryDecrypt: (...args: any[]) => tryDecryptMock(...args),
+  },
+}));
+
+import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
+import type { ServiceEnvelopeShape } from './mqttPacketFilter.js';
+import databaseService from '../services/database.js';
+import mqttPacketLogService from './services/mqttPacketLogService.js';
+
+const NODE_A = 0x11111111;
+
+function encryptedEnvelope(): ServiceEnvelopeShape {
+  return {
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: 0x12345678,
+      from: NODE_A,
+      to: 0xffffffff,
+      channel: 8,
+      encrypted: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+    },
+  };
+}
+
+/** Flush the microtask + one macrotask boundary so the fire-and-forget logEnvelope() write lands. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe('mqttIngestion — bitfield survives server-side decrypt (#4114 §2(b))', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetMqttIngestCachesForTest();
+    for (const key of Object.keys(settingsStore)) delete settingsStore[key];
+    settingsStore['mqtt_packet_log_enabled'] = '1';
+    mqttPacketLogService.resetEnabledCache();
+    mqttPacketLogService.resetViolationEnabledCache();
+  });
+
+  it('propagates decrypt-result bitfield=0 onto packet.decoded and the logged row', async () => {
+    tryDecryptMock.mockResolvedValue({
+      success: true,
+      portnum: 1,
+      payload: new TextEncoder().encode('hello'),
+      bitfield: 0,
+      channelDatabaseId: 1,
+    });
+    const envelope = encryptedEnvelope();
+
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
+    expect(result.ingested).toBe(true);
+    // Mutated onto the input envelope in place.
+    expect(envelope.packet?.decoded?.bitfield).toBe(0);
+
+    await flush();
+    expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.bitfield).toBe(0);
+  });
+
+  it('propagates decrypt-result bitfield=1 onto packet.decoded and the logged row', async () => {
+    tryDecryptMock.mockResolvedValue({
+      success: true,
+      portnum: 1,
+      payload: new TextEncoder().encode('hello'),
+      bitfield: 1,
+      channelDatabaseId: 1,
+    });
+    const envelope = encryptedEnvelope();
+
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
+    expect(result.ingested).toBe(true);
+    expect(envelope.packet?.decoded?.bitfield).toBe(1);
+
+    await flush();
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.bitfield).toBe(1);
+  });
+
+  it('row.bitfield is null when the decrypt result omits bitfield', async () => {
+    tryDecryptMock.mockResolvedValue({
+      success: true,
+      portnum: 1,
+      payload: new TextEncoder().encode('hello'),
+      channelDatabaseId: 1,
+      // bitfield intentionally omitted
+    });
+    const envelope = encryptedEnvelope();
+
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
+    expect(result.ingested).toBe(true);
+    expect(envelope.packet?.decoded?.bitfield).toBeUndefined();
+
+    await flush();
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.bitfield).toBeNull();
+  });
+
+  it('plaintext path (already-decoded packet, no decrypt) carries the wire bitfield through untouched', async () => {
+    const envelope: ServiceEnvelopeShape = {
+      channelId: 'LongFast',
+      gatewayId: '!00000001',
+      packet: {
+        id: 0x12345678,
+        from: NODE_A,
+        to: 0xffffffff,
+        channel: 8,
+        decoded: {
+          portnum: 1,
+          payload: new TextEncoder().encode('hello'),
+          bitfield: 1,
+        },
+      },
+    };
+
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
+    expect(result.ingested).toBe(true);
+    // tryDecrypt must not even be called on the plaintext path.
+    expect(tryDecryptMock).not.toHaveBeenCalled();
+    expect(envelope.packet?.decoded?.bitfield).toBe(1);
+
+    await flush();
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.bitfield).toBe(1);
+  });
+});

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -202,7 +202,9 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
             emoji?: number;
             replyId?: number;
             channelDatabaseId?: number;
-            bitfield?: number;                 // ← ADD (#4114): the ok_to_mqtt bit must survive decrypt
+            // The originator's ok_to_mqtt bit must survive server-side decrypt —
+            // violation detection reads it off the synthesized shape (#4114).
+            bitfield?: number;
           };
         }).decoded = {
           portnum: r.portnum,
@@ -210,7 +212,7 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
           emoji: r.emoji,
           replyId: r.replyId,
           channelDatabaseId: r.channelDatabaseId,
-          bitfield: r.bitfield,                // ← ADD
+          bitfield: r.bitfield,
         };
       }
     } catch (err) {

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -143,6 +143,14 @@ export interface MqttIngestionInput {
    * `databaseService.ignoredNodes` instead.
    */
   filter?: MqttPacketFilter;
+  /** Raw MQTT topic this envelope arrived on. Diagnostic; persisted on the packet log (#4114). */
+  topic?: string;
+  /**
+   * This source's OWN gateway node number, used by the self-echo guard so MeshMonitor can
+   * never flag itself as a violating gateway (#4114, §2(f.1)). `null`/omitted when the
+   * source has no local identity yet — the guard then simply does not apply.
+   */
+  localGatewayNodeNum?: number | null;
 }
 
 export interface MqttIngestionResult {
@@ -194,6 +202,7 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
             emoji?: number;
             replyId?: number;
             channelDatabaseId?: number;
+            bitfield?: number;                 // ← ADD (#4114): the ok_to_mqtt bit must survive decrypt
           };
         }).decoded = {
           portnum: r.portnum,
@@ -201,6 +210,7 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
           emoji: r.emoji,
           replyId: r.replyId,
           channelDatabaseId: r.channelDatabaseId,
+          bitfield: r.bitfield,                // ← ADD
         };
       }
     } catch (err) {
@@ -586,7 +596,13 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
  */
 export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<MqttIngestionResult> {
   const result = await ingestServiceEnvelopeInner(input);
-  void mqttPacketLogService.logEnvelope(input.sourceId, input.envelope, result);
+  void mqttPacketLogService.logEnvelope(
+    input.sourceId,
+    input.envelope,
+    result,
+    input.topic,
+    input.localGatewayNodeNum,
+  );
   if (
     (result.reason === 'ignored' || result.reason === 'geo-ignored' || result.reason === 'distance') &&
     typeof input.envelope.packet?.from === 'number'

--- a/src/server/mqttPacketLogService.ingestHook.test.ts
+++ b/src/server/mqttPacketLogService.ingestHook.test.ts
@@ -63,6 +63,13 @@ vi.mock('../services/database.js', () => ({
     mqttPacketLog: {
       insertPacket: vi.fn(async () => undefined),
     },
+    // #4114: violation writes are independent of mqtt_packet_log_enabled and
+    // default ON — most fixtures below never set decoded.bitfield, so the
+    // tri-state is 'unknown' and this is never actually invoked, but the
+    // mock must exist so a stray call doesn't throw "not a function".
+    mqttOkToMqttViolations: {
+      insertViolation: vi.fn(async () => undefined),
+    },
   },
 }));
 
@@ -277,6 +284,33 @@ describe('MQTT Packet Monitor — ingestion hook', () => {
       expect(c[0].packetId).toBe(0xabcdef01);
       expect(c[0].fromNode).toBe(NODE_A);
     }
+  });
+
+  it('threads topic from MqttIngestionInput onto the logged row (#4114)', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor({ portnum: 1, gatewayId: '!00000001' }),
+      topic: 'msh/US/2/e/LongFast/!00000001',
+    });
+    expect(result.ingested).toBe(true);
+
+    await flush();
+    expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.topic).toBe('msh/US/2/e/LongFast/!00000001');
+  });
+
+  it('still logs (topic null) when topic is omitted — optional field', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor({ portnum: 1, gatewayId: '!00000001' }),
+    });
+    expect(result.ingested).toBe(true);
+
+    await flush();
+    expect(databaseService.mqttPacketLog.insertPacket).toHaveBeenCalledTimes(1);
+    const row = (databaseService.mqttPacketLog.insertPacket as any).mock.calls[0][0];
+    expect(row.topic).toBeNull();
   });
 
   it('does not log when mqtt_packet_log_enabled is unset (disabled)', async () => {

--- a/src/server/mqttPacketLogService.violations.test.ts
+++ b/src/server/mqttPacketLogService.violations.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the durable `ok_to_mqtt` violation write path — WP4 of
+ * MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(d)/§2(f.1) (#4114). Runs against a real
+ * in-memory SQLite database (via `createTestDb()`) so dedupe and retention
+ * immunity are proven by real SQL, not a mocked repo.
+ *
+ * See spec §4.5.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import * as schema from '../db/schema/index.js';
+import { createTestDb } from './test-helpers/testDb.js';
+import { MqttPacketLogRepository } from '../db/repositories/mqttPacketLog.js';
+import { MqttOkToMqttViolationsRepository } from '../db/repositories/mqttOkToMqttViolations.js';
+
+const settingsStore: Record<string, string> = {};
+
+let mqttPacketLogRepo: MqttPacketLogRepository;
+let violationsRepo: MqttOkToMqttViolationsRepository;
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSettingAsync: vi.fn(async (key: string) => settingsStore[key] ?? null),
+    get mqttPacketLog() {
+      return mqttPacketLogRepo;
+    },
+    get mqttOkToMqttViolations() {
+      return violationsRepo;
+    },
+  },
+}));
+
+import mqttPacketLogService, { buildViolationRow, buildMqttPacketLogRow } from './services/mqttPacketLogService.js';
+import type { ServiceEnvelopeShape } from './mqttPacketFilter.js';
+
+const OUR_NODE_NUM = 0x99999999;
+const ORIGINATOR_NUM = 0x11111111;
+
+function envelope(overrides: Partial<{
+  gatewayId: string | null;
+  fromNode: number;
+  bitfield: number | undefined;
+  packetId: number;
+}> = {}): ServiceEnvelopeShape {
+  const { gatewayId = '!22222222', fromNode = ORIGINATOR_NUM, bitfield, packetId = 0x12345678 } = overrides;
+  return {
+    channelId: 'LongFast',
+    gatewayId: gatewayId ?? undefined,
+    packet: {
+      id: packetId,
+      from: fromNode,
+      to: 0xffffffff,
+      channel: 8,
+      decoded: {
+        portnum: 1,
+        payload: new TextEncoder().encode('hello'),
+        ...(bitfield !== undefined ? { bitfield } : {}),
+      },
+    },
+  };
+}
+
+const okResult = { ingested: true as const, portnum: 1 };
+
+describe('mqttPacketLogService — ok_to_mqtt violation writes (#4114)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    mqttPacketLogRepo = new MqttPacketLogRepository(drizzleDb, 'sqlite');
+    violationsRepo = new MqttOkToMqttViolationsRepository(drizzleDb, 'sqlite');
+    for (const key of Object.keys(settingsStore)) delete settingsStore[key];
+    mqttPacketLogService.resetEnabledCache();
+    mqttPacketLogService.resetViolationEnabledCache();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  async function countViolations(sourceId = 'src-a'): Promise<number> {
+    return violationsRepo.getRowCount({ sourceId });
+  }
+
+  it('writes a violation row even while mqtt_packet_log_enabled is off (independence, §2(d))', async () => {
+    // Packet log explicitly disabled; violation kill switch left unset (default ON).
+    delete settingsStore['mqtt_packet_log_enabled'];
+    const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(1);
+    const packets = await mqttPacketLogRepo.getReceptions('src-a', env.packet!.id!, ORIGINATOR_NUM);
+    expect(packets.length).toBe(0); // packet log itself stayed empty
+  });
+
+  it('does NOT write a violation row when the kill switch is explicitly off (=== "0")', async () => {
+    settingsStore['mqtt_oktomqtt_violation_log_enabled'] = '0';
+    const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(0);
+  });
+
+  it('does NOT write a violation row for originator self-publish (gatewayNodeNum === fromNode, bit 0)', async () => {
+    const env = envelope({ gatewayId: '!11111111', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(0);
+  });
+
+  describe('self-gateway guard (§2(f.1)) — REQUIRED', () => {
+    it('never writes a violation row when gatewayId is our own local node, even with bit 0', async () => {
+      const env = envelope({
+        gatewayId: `!${OUR_NODE_NUM.toString(16).padStart(8, '0')}`,
+        fromNode: ORIGINATOR_NUM, // different from OUR_NODE_NUM — shape of a genuine violation otherwise
+        bitfield: 0,
+      });
+
+      await mqttPacketLogService.logEnvelope('src-a', env, okResult, undefined, OUR_NODE_NUM);
+
+      expect(await countViolations()).toBe(0);
+    });
+
+    it('complement: same envelope with localGatewayNodeNum omitted DOES write a row (residual exposure, documented)', async () => {
+      const env = envelope({
+        gatewayId: `!${OUR_NODE_NUM.toString(16).padStart(8, '0')}`,
+        fromNode: ORIGINATOR_NUM,
+        bitfield: 0,
+      });
+
+      await mqttPacketLogService.logEnvelope('src-a', env, okResult); // no localGatewayNodeNum
+
+      expect(await countViolations()).toBe(1);
+    });
+
+    it('complement: localGatewayNodeNum set but not matching still flags a normal violation', async () => {
+      const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+
+      await mqttPacketLogService.logEnvelope('src-a', env, okResult, undefined, OUR_NODE_NUM);
+
+      expect(await countViolations()).toBe(1);
+    });
+  });
+
+  it('does NOT write a violation row when gatewayId is malformed', async () => {
+    const env = envelope({ gatewayId: 'not-a-gateway-id', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(0);
+  });
+
+  it('does NOT write a violation row when fromNode is missing', async () => {
+    const env: ServiceEnvelopeShape = {
+      channelId: 'LongFast',
+      gatewayId: '!22222222',
+      packet: {
+        id: 1,
+        to: 0xffffffff,
+        channel: 8,
+        decoded: { portnum: 1, payload: new TextEncoder().encode('hi'), bitfield: 0 },
+      } as any,
+    };
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(0);
+  });
+
+  it('an unknown-bitfield relayed reception writes NO violation row (only the packet-log row, when enabled)', async () => {
+    settingsStore['mqtt_packet_log_enabled'] = '1';
+    mqttPacketLogService.resetEnabledCache();
+    const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM }); // no bitfield at all
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(0);
+    const packets = await mqttPacketLogRepo.getReceptions('src-a', env.packet!.id!, ORIGINATOR_NUM);
+    expect(packets.length).toBe(1);
+    expect(packets[0].bitfield).toBeNull();
+    expect(packets[0].okToMqttViolation).toBe(0);
+  });
+
+  it('buildViolationRow projects field-for-field from its DbMqttPacket source', () => {
+    const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+    const row = buildMqttPacketLogRow('src-a', env, okResult, 'msh/US/2/e/LongFast/!22222222');
+    expect(row).not.toBeNull();
+    const v = buildViolationRow(row!);
+    expect(v.sourceId).toBe(row!.sourceId);
+    expect(v.packetId).toBe(row!.packetId);
+    expect(v.fromNode).toBe(row!.fromNode);
+    expect(v.fromNodeId).toBe(row!.fromNodeId);
+    expect(v.gatewayId).toBe(row!.gatewayId);
+    expect(v.gatewayNodeNum).toBe(row!.gatewayNodeNum);
+    expect(v.channelId).toBe(row!.channelId);
+    expect(v.portnum).toBe(row!.portnum);
+    expect(v.portnumName).toBe(row!.portnumName);
+    expect(v.bitfield).toBe(row!.bitfield);
+    expect(v.topic).toBe(row!.topic);
+    expect(v.rxTime).toBe(row!.rxTime);
+    expect(v.timestamp).toBe(row!.timestamp);
+    expect(v.createdAt).toBe(row!.createdAt);
+  });
+
+  it('duplicate ingest of the same reception results in exactly one stored violation row', async () => {
+    const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM, bitfield: 0, packetId: 0xaabbccdd });
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+
+    expect(await countViolations()).toBe(1);
+  });
+
+  it('runCleanup() invokes both retention phases using the violation-specific cutoff/cap', async () => {
+    settingsStore['mqtt_oktomqtt_violation_retention_days'] = '1';
+    settingsStore['mqtt_oktomqtt_violation_max_count'] = '2';
+
+    // Insert 3 violations, one deliberately old (older than the 1-day cutoff).
+    const now = Date.now();
+    await violationsRepo.insertViolation({
+      sourceId: 'src-a', packetId: 1, fromNode: 1, gatewayId: '!aaaaaaaa', gatewayNodeNum: 0xaaaaaaaa,
+      timestamp: now - 5 * 24 * 60 * 60 * 1000, createdAt: now - 5 * 24 * 60 * 60 * 1000,
+    });
+    await violationsRepo.insertViolation({
+      sourceId: 'src-a', packetId: 2, fromNode: 2, gatewayId: '!bbbbbbbb', gatewayNodeNum: 0xbbbbbbbb,
+      timestamp: now, createdAt: now,
+    });
+    await violationsRepo.insertViolation({
+      sourceId: 'src-a', packetId: 3, fromNode: 3, gatewayId: '!cccccccc', gatewayNodeNum: 0xcccccccc,
+      timestamp: now, createdAt: now,
+    });
+
+    expect(await countViolations()).toBe(3);
+    await mqttPacketLogService.runCleanup();
+    // The 5-day-old row is trimmed by the age cutoff; the max-count cap (2)
+    // is already satisfied by the remaining two rows.
+    expect(await countViolations()).toBe(2);
+  });
+
+  it('retention immunity: violation rows survive mqttPacketLog.deletePacketsOlderThan + deleteAllPackets', async () => {
+    const env = envelope({ gatewayId: '!22222222', fromNode: ORIGINATOR_NUM, bitfield: 0 });
+    settingsStore['mqtt_packet_log_enabled'] = '1';
+    mqttPacketLogService.resetEnabledCache();
+
+    await mqttPacketLogService.logEnvelope('src-a', env, okResult);
+    expect(await countViolations()).toBe(1);
+
+    await mqttPacketLogRepo.deletePacketsOlderThan(Date.now() + 1_000_000);
+    await mqttPacketLogRepo.deleteAllPackets();
+
+    expect(await countViolations()).toBe(1);
+  });
+});

--- a/src/server/routes/analysisRoutes.mqttViolations.test.ts
+++ b/src/server/routes/analysisRoutes.mqttViolations.test.ts
@@ -248,7 +248,7 @@ describe('analysisRoutes — GET /mqtt-violations/gateways', () => {
     expect(res.body.data.gateways.some((g: any) => g.gatewayId === '!44444444')).toBe(false);
   });
 
-  it('includeUnknown=true with mqtt_packet_log_enabled on ⇒ suspected gateway merged in', async () => {
+  it('includeUnknown=true with mqtt_packet_log_enabled on ⇒ suspected gateway merged in, with its sourceIds populated', async () => {
     await harness.db.settings.setSetting('mqtt_packet_log_enabled', '1');
     mqttPacketLogService.resetEnabledCache();
     await harness.db.mqttPacketLog.insertPacket(makeSuspectedPacket({ sourceId: harness.sourceA }));
@@ -262,6 +262,60 @@ describe('analysisRoutes — GET /mqtt-violations/gateways', () => {
     expect(suspectedGw).toBeDefined();
     expect(suspectedGw.violationCount).toBe(0);
     expect(suspectedGw.suspectedCount).toBe(1);
+    // Regression (#4114 code review): a gateway seen ONLY in the suspected set
+    // (mqtt_packet_log) must still report which source it was observed on —
+    // it must not silently fall back to an empty sourceIds array.
+    expect(suspectedGw.sourceIds).toEqual([harness.sourceA]);
+  });
+
+  it('a gateway present in BOTH the confirmed and suspected sets merges counts without one overwriting the other, and spans firstSeen/lastSeen', async () => {
+    await harness.db.settings.setSetting('mqtt_packet_log_enabled', '1');
+    mqttPacketLogService.resetEnabledCache();
+
+    // Confirmed violation on !11111111 at T0 (seeded in beforeEach: !11111111
+    // already carries 2 confirmed violations at T0 and T0+1000).
+    // Add a suspected (bitfield-unreadable) reception from the SAME gateway,
+    // outside that confirmed window on both ends, so the merged firstSeen/
+    // lastSeen must span both signals rather than reporting only the
+    // confirmed side's.
+    await harness.db.mqttPacketLog.insertPacket(
+      makeSuspectedPacket({
+        sourceId: harness.sourceA,
+        packetId: 9099,
+        fromNode: 0xffffffff,
+        fromNodeId: '!ffffffff',
+        gatewayId: '!11111111',
+        gatewayNodeNum: 0x11111111,
+        timestamp: T0 - 5000, // earlier than the confirmed rows' T0
+      }),
+    );
+    await harness.db.mqttPacketLog.insertPacket(
+      makeSuspectedPacket({
+        sourceId: harness.sourceA,
+        packetId: 9100,
+        fromNode: 0xffffffff,
+        fromNodeId: '!ffffffff',
+        gatewayId: '!11111111',
+        gatewayNodeNum: 0x11111111,
+        timestamp: T0 + 6000, // later than the confirmed rows' T0+1000
+      }),
+    );
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&includeUnknown=true');
+    expect(res.status).toBe(200);
+    const gw = res.body.data.gateways.find((g: any) => g.gatewayId === '!11111111');
+    expect(gw).toBeDefined();
+    // Confirmed count (2 rows seeded in beforeEach) must survive the merge...
+    expect(gw.violationCount).toBe(2);
+    // ...and the suspected count (2 rows seeded above) must be added, not
+    // overwrite the confirmed count.
+    expect(gw.suspectedCount).toBe(2);
+    // firstSeen/lastSeen must span BOTH the confirmed rows (T0..T0+1000) and
+    // the suspected rows (T0-5000..T0+6000) — not just the confirmed side.
+    expect(gw.firstSeen).toBe(T0 - 5000);
+    expect(gw.lastSeen).toBe(T0 + 6000);
+    expect(gw.sourceIds).toEqual([harness.sourceA]);
   });
 });
 

--- a/src/server/routes/analysisRoutes.mqttViolations.test.ts
+++ b/src/server/routes/analysisRoutes.mqttViolations.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Analysis Routes — ok_to_mqtt violation detection endpoints (#4114)
+ *
+ * Covers GET /mqtt-violations/gateways and GET /mqtt-violations/packets.
+ * Uses the real-middleware `createRouteTestApp` harness (not the deprecated
+ * `vi.mock('../../services/database.js')` monkey-patch pattern) so that
+ * cross-source permission isolation is proven by real `checkPermissionAsync`
+ * SQL rather than a hand-rolled lambda. Do NOT modify the legacy
+ * `analysisRoutes.test.ts` — it is a separate, pre-existing file covering
+ * `/positions` et al. and converts opportunistically, not in this phase.
+ *
+ * See docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(e)/§3.17/§4.12.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import analysisRoutes from './analysisRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import mqttPacketLogService from '../services/mqttPacketLogService.js';
+import type { DbMqttOkToMqttViolation } from '../../db/repositories/mqttOkToMqttViolations.js';
+import type { DbMqttPacket } from '../../db/repositories/mqttPacketLog.js';
+
+const T0 = 1_753_300_000_000;
+
+function makeViolation(overrides: Partial<DbMqttOkToMqttViolation> & { sourceId: string }): DbMqttOkToMqttViolation {
+  return {
+    packetId: 1,
+    fromNode: 0xaaaaaaaa,
+    fromNodeId: '!aaaaaaaa',
+    gatewayId: '!11111111',
+    gatewayNodeNum: 0x11111111,
+    channelId: 'LongFast',
+    portnum: 1,
+    portnumName: 'TEXT_MESSAGE_APP',
+    bitfield: 0,
+    topic: 'msh/US/2/e/LongFast/!11111111',
+    rxTime: T0 - 100,
+    timestamp: T0,
+    createdAt: T0,
+    ...overrides,
+  };
+}
+
+function makeSuspectedPacket(overrides: Partial<DbMqttPacket> & { sourceId: string }): DbMqttPacket {
+  return {
+    packetId: 9001,
+    fromNode: 0xdddddddd,
+    fromNodeId: '!dddddddd',
+    gatewayId: '!44444444',
+    gatewayNodeNum: 0x44444444,
+    channelId: 'LongFast',
+    portnum: 1,
+    portnumName: 'TEXT_MESSAGE_APP',
+    encrypted: 1,
+    ingestOutcome: 'encrypted',
+    okToMqttViolation: 0,
+    bitfield: null, // unreadable ⇒ "suspected", not confirmed
+    topic: 'msh/US/2/e/LongFast/!44444444',
+    rxTime: T0 - 100,
+    timestamp: T0,
+    createdAt: T0,
+    ...overrides,
+  };
+}
+
+describe('analysisRoutes — GET /mqtt-violations/gateways', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', analysisRoutes) });
+    await harness.grant(harness.limited.id, 'packetmonitor', 'read', harness.sourceA);
+
+    // sourceA: gateway !11111111 sees 2 violations from 2 distinct originators;
+    // gateway !33333333 sees 1 violation. sourceB: gateway !22222222 sees 1 violation.
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({ sourceId: harness.sourceA, packetId: 1001, fromNode: 0xaaaaaaaa, fromNodeId: '!aaaaaaaa', timestamp: T0 }),
+    );
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({ sourceId: harness.sourceA, packetId: 1002, fromNode: 0xbbbbbbbb, fromNodeId: '!bbbbbbbb', timestamp: T0 + 1000 }),
+    );
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: harness.sourceA,
+        packetId: 1003,
+        fromNode: 0xeeeeeeee,
+        fromNodeId: '!eeeeeeee',
+        gatewayId: '!33333333',
+        gatewayNodeNum: 0x33333333,
+        timestamp: T0 + 500,
+      }),
+    );
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: harness.sourceB,
+        packetId: 2001,
+        fromNode: 0xcccccccc,
+        fromNodeId: '!cccccccc',
+        gatewayId: '!22222222',
+        gatewayNodeNum: 0x22222222,
+        timestamp: T0 + 500,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceA);
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceB);
+    await harness.db.mqttPacketLog.deleteAllPackets(harness.sourceA);
+    await harness.db.mqttPacketLog.deleteAllPackets(harness.sourceB);
+    await harness.db.settings.setSetting('mqtt_packet_log_enabled', '0');
+    mqttPacketLogService.resetEnabledCache();
+    await harness.cleanup();
+  });
+
+  it('admin sees gateways across both sources', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.status).toBe(200);
+    const gatewayIds = res.body.data.gateways.map((g: any) => g.gatewayId).sort();
+    expect(gatewayIds).toEqual(['!11111111', '!22222222', '!33333333']);
+    expect(res.body.data.sources.sort()).toEqual([harness.sourceA, harness.sourceB].sort());
+  });
+
+  it('limited user (granted sourceA only) sees only sourceA gateways — real SQL enforcement', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.status).toBe(200);
+    const gatewayIds = res.body.data.gateways.map((g: any) => g.gatewayId).sort();
+    expect(gatewayIds).toEqual(['!11111111', '!33333333']);
+    expect(res.body.data.sources).toEqual([harness.sourceA]);
+  });
+
+  it('anonymous / ungranted user gets 200 with empty gateways and sources', async () => {
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.gateways).toEqual([]);
+    expect(res.body.data.sources).toEqual([]);
+  });
+
+  it('?sources= intersects with the permitted set and cannot widen it', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    // limited is granted sourceA only; requesting sourceB must not leak sourceB data.
+    const res = await agent.get(`/mqtt-violations/gateways?since=0&sources=${harness.sourceB}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.gateways).toEqual([]);
+    expect(res.body.data.sources).toEqual([]);
+  });
+
+  it('envelope shape is exactly { success: true, data: {...} }', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toBeDefined();
+    expect(res.body.data.gateways).toBeInstanceOf(Array);
+    expect(typeof res.body.data.total).toBe('number');
+  });
+
+  it('sorts by violationCount desc by default', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    const counts = res.body.data.gateways.map((g: any) => g.violationCount);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+    expect(res.body.data.gateways[0].gatewayId).toBe('!11111111');
+  });
+
+  it('sorts by violationCount asc when dir=asc', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&dir=asc');
+    const counts = res.body.data.gateways.map((g: any) => g.violationCount);
+    expect(counts).toEqual([...counts].sort((a, b) => a - b));
+  });
+
+  it('sorts by gatewayId', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&sort=gatewayId&dir=asc');
+    const ids = res.body.data.gateways.map((g: any) => g.gatewayId);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  it('unknown sort field ⇒ 400 INVALID_SORT_FIELD', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&sort=bogus');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_SORT_FIELD');
+    expect(res.body.success).toBe(false);
+  });
+
+  it('unknown sort direction ⇒ 400 INVALID_SORT_DIRECTION', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&dir=sideways');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_SORT_DIRECTION');
+  });
+
+  it('since > until ⇒ 400 INVALID_RANGE', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/mqtt-violations/gateways?since=${T0 + 10_000}&until=${T0}`);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_RANGE');
+  });
+
+  it('paginates with limit/offset and reports total', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&limit=1&offset=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.gateways.length).toBe(1);
+    expect(res.body.data.total).toBe(3);
+    expect(res.body.data.limit).toBe(1);
+    expect(res.body.data.offset).toBe(0);
+
+    const res2 = await agent.get('/mqtt-violations/gateways?since=0&limit=1&offset=1');
+    expect(res2.body.data.gateways.length).toBe(1);
+    expect(res2.body.data.gateways[0].gatewayId).not.toBe(res.body.data.gateways[0].gatewayId);
+  });
+
+  it('lookbackDays clamps to 1..365 and is ignored when since is explicit', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    // lookbackDays=99999 would clamp to 365; explicit since=0 must win regardless.
+    const res = await agent.get('/mqtt-violations/gateways?since=0&lookbackDays=99999');
+    expect(res.status).toBe(200);
+    expect(res.body.data.since).toBe(0);
+  });
+
+  it('includeUnknown=false (default): suspectedCount is 0 on every row and the packet-log path is not queried', async () => {
+    // Seed a suspected-only gateway in mqtt_packet_log; it must not appear at all
+    // when includeUnknown is false.
+    await harness.db.mqttPacketLog.insertPacket(makeSuspectedPacket({ sourceId: harness.sourceA }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.status).toBe(200);
+    for (const g of res.body.data.gateways) {
+      expect(g.suspectedCount).toBe(0);
+    }
+    expect(res.body.data.gateways.some((g: any) => g.gatewayId === '!44444444')).toBe(false);
+    expect(res.body.data.suspectedAvailable).toBe(false);
+    expect(res.body.data.suspectedWindowMs).toBe(0);
+  });
+
+  it('includeUnknown=true with mqtt_packet_log_enabled off ⇒ suspectedAvailable: false', async () => {
+    await harness.db.mqttPacketLog.insertPacket(makeSuspectedPacket({ sourceId: harness.sourceA }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&includeUnknown=true');
+    expect(res.status).toBe(200);
+    expect(res.body.data.suspectedAvailable).toBe(false);
+    // Suspected-only gateway must not be merged in when the packet monitor is off.
+    expect(res.body.data.gateways.some((g: any) => g.gatewayId === '!44444444')).toBe(false);
+  });
+
+  it('includeUnknown=true with mqtt_packet_log_enabled on ⇒ suspected gateway merged in', async () => {
+    await harness.db.settings.setSetting('mqtt_packet_log_enabled', '1');
+    mqttPacketLogService.resetEnabledCache();
+    await harness.db.mqttPacketLog.insertPacket(makeSuspectedPacket({ sourceId: harness.sourceA }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&includeUnknown=true');
+    expect(res.status).toBe(200);
+    expect(res.body.data.suspectedAvailable).toBe(true);
+    expect(res.body.data.suspectedWindowMs).toBeGreaterThan(0);
+    const suspectedGw = res.body.data.gateways.find((g: any) => g.gatewayId === '!44444444');
+    expect(suspectedGw).toBeDefined();
+    expect(suspectedGw.violationCount).toBe(0);
+    expect(suspectedGw.suspectedCount).toBe(1);
+  });
+});
+
+describe('analysisRoutes — GET /mqtt-violations/packets', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', analysisRoutes) });
+    await harness.grant(harness.limited.id, 'packetmonitor', 'read', harness.sourceA);
+
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({ sourceId: harness.sourceA, packetId: 1001, fromNode: 0xaaaaaaaa, fromNodeId: '!aaaaaaaa', timestamp: T0 }),
+    );
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: harness.sourceA,
+        packetId: 1002,
+        fromNode: 0xbbbbbbbb,
+        fromNodeId: '!bbbbbbbb',
+        gatewayId: '!33333333',
+        gatewayNodeNum: 0x33333333,
+        timestamp: T0 + 1000,
+      }),
+    );
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: harness.sourceB,
+        packetId: 2001,
+        fromNode: 0xcccccccc,
+        fromNodeId: '!cccccccc',
+        gatewayId: '!22222222',
+        gatewayNodeNum: 0x22222222,
+        timestamp: T0 + 500,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceA);
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceB);
+    await harness.db.mqttPacketLog.deleteAllPackets(harness.sourceA);
+    await harness.db.mqttPacketLog.deleteAllPackets(harness.sourceB);
+    await harness.db.settings.setSetting('mqtt_packet_log_enabled', '0');
+    mqttPacketLogService.resetEnabledCache();
+    await harness.cleanup();
+  });
+
+  it('admin sees violations across both sources, kind: confirmed', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.violations.length).toBe(3);
+    for (const v of res.body.data.violations) {
+      expect(v.kind).toBe('confirmed');
+    }
+  });
+
+  it('limited user sees only sourceA violations', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get('/mqtt-violations/packets?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.violations.length).toBe(2);
+    expect(res.body.data.violations.every((v: any) => v.sourceId === harness.sourceA)).toBe(true);
+  });
+
+  it('anonymous ⇒ 200 with empty violations', async () => {
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/mqtt-violations/packets?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.violations).toEqual([]);
+  });
+
+  it('?gateway= filters to one gateway', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&gateway=!33333333');
+    expect(res.status).toBe(200);
+    expect(res.body.data.violations.length).toBe(1);
+    expect(res.body.data.violations[0].gatewayId).toBe('!33333333');
+    expect(res.body.data.gateway).toBe('!33333333');
+  });
+
+  it('unknown sort field ⇒ 400 INVALID_SORT_FIELD', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&sort=bogus');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_SORT_FIELD');
+  });
+
+  it('unknown sort direction ⇒ 400 INVALID_SORT_DIRECTION', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&dir=up');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_SORT_DIRECTION');
+  });
+
+  it('since > until ⇒ 400 INVALID_RANGE', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/mqtt-violations/packets?since=${T0 + 10_000}&until=${T0}`);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_RANGE');
+  });
+
+  it('paginates with limit/offset and reports total', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&limit=1&offset=0');
+    expect(res.body.data.violations.length).toBe(1);
+    expect(res.body.data.total).toBe(3);
+  });
+
+  it('includeUnknown=true with mqtt_packet_log_enabled on merges suspected rows with kind: suspected', async () => {
+    await harness.db.settings.setSetting('mqtt_packet_log_enabled', '1');
+    mqttPacketLogService.resetEnabledCache();
+    await harness.db.mqttPacketLog.insertPacket(makeSuspectedPacket({ sourceId: harness.sourceA, packetId: 9001 }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&includeUnknown=true');
+    expect(res.status).toBe(200);
+    expect(res.body.data.suspectedAvailable).toBe(true);
+    const suspected = res.body.data.violations.filter((v: any) => v.kind === 'suspected');
+    expect(suspected.length).toBe(1);
+    expect(suspected[0].gatewayId).toBe('!44444444');
+  });
+
+  it('includeUnknown=false does not include suspected rows even when packet log is enabled', async () => {
+    await harness.db.settings.setSetting('mqtt_packet_log_enabled', '1');
+    mqttPacketLogService.resetEnabledCache();
+    await harness.db.mqttPacketLog.insertPacket(makeSuspectedPacket({ sourceId: harness.sourceA, packetId: 9002 }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.violations.every((v: any) => v.kind === 'confirmed')).toBe(true);
+  });
+});

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -16,8 +16,17 @@ import databaseService from '../../services/database.js';
 import { ALL_SOURCES } from '../../db/repositories/index.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
+import { ok, fail } from '../utils/apiResponse.js';
 import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
 import type { PositionRow } from '../../db/repositories/analysis.js';
+import mqttPacketLogService from '../services/mqttPacketLogService.js';
+import type {
+  ViolationGatewaySort,
+  ViolationListSort,
+  MqttViolationGateway,
+  DbMqttOkToMqttViolation,
+} from '../../db/repositories/mqttOkToMqttViolations.js';
+import type { DbMqttPacket } from '../../db/repositories/mqttPacketLog.js';
 import {
   identifySolarNodes,
   summarizeSolarProduction,
@@ -65,6 +74,82 @@ function clampPageSize(raw: unknown): number {
 function parseSinceMs(raw: unknown): number {
   const n = parseInt(String(raw ?? '0'), 10);
   return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+// ── ok_to_mqtt violation detection (#4114) ──────────────────────────────────
+//
+// Two new helpers below (`parseUntilMs`, `parseLookbackDays`, `parseBoolParam`)
+// are genuinely new — there is no `parseUntilMs`/`parseLookbackDays`/
+// `parseBoolParam` under any similar name elsewhere in this file. `parseLookbackDays`
+// deliberately accepts BOTH `lookbackDays` and `lookback_days` spellings so it does
+// not become a third convention alongside the solar handlers' inline
+// `lookback_days` parser (clamp 1..90) below, which is intentionally left
+// untouched — see MQTT_OK_TO_MQTT_PHASE1_SPEC.md §3.17.
+
+function parseUntilMs(raw: unknown): number {
+  const n = parseInt(String(raw ?? ''), 10);
+  return Number.isFinite(n) && n > 0 ? n : Date.now();
+}
+
+function parseLookbackDays(raw: unknown): number {
+  const n = parseInt(String(raw ?? '7'), 10);
+  if (!Number.isFinite(n)) return 7;
+  return Math.min(Math.max(n, 1), 365);
+}
+
+function parseBoolParam(raw: unknown): boolean {
+  return raw === 'true' || raw === '1';
+}
+
+const VIOLATION_GATEWAY_SORTS = ['violationCount', 'lastSeen', 'distinctOriginators', 'gatewayId'] as const;
+const VIOLATION_LIST_SORTS = ['timestamp', 'fromNode', 'gatewayId'] as const;
+
+/** Row shape for the merged `/mqtt-violations/gateways` response. */
+interface ViolationGatewayRow extends MqttViolationGateway {
+  suspectedCount: number;
+  sourceIds: string[];
+}
+
+/** Row shape for the merged `/mqtt-violations/packets` response. */
+interface ViolationPacketRow {
+  id: number | undefined;
+  kind: 'confirmed' | 'suspected';
+  sourceId: string;
+  packetId: number | null;
+  fromNode: number | null;
+  fromNodeId: string | null;
+  gatewayId: string | null;
+  gatewayNodeNum: number | null;
+  channelId: string | null;
+  portnum: number | null;
+  portnumName: string | null;
+  bitfield: number | null;
+  topic: string | null;
+  rxTime: number | null;
+  timestamp: number;
+}
+
+function toViolationPacketRow(
+  kind: 'confirmed' | 'suspected',
+  row: DbMqttOkToMqttViolation | DbMqttPacket,
+): ViolationPacketRow {
+  return {
+    id: row.id,
+    kind,
+    sourceId: row.sourceId,
+    packetId: row.packetId ?? null,
+    fromNode: row.fromNode ?? null,
+    fromNodeId: row.fromNodeId ?? null,
+    gatewayId: row.gatewayId ?? null,
+    gatewayNodeNum: row.gatewayNodeNum ?? null,
+    channelId: row.channelId ?? null,
+    portnum: row.portnum ?? null,
+    portnumName: row.portnumName ?? null,
+    bitfield: row.bitfield ?? null,
+    topic: row.topic ?? null,
+    rxTime: row.rxTime ?? null,
+    timestamp: row.timestamp,
+  };
 }
 
 /**
@@ -450,6 +535,296 @@ router.get('/hop-counts', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error in GET /api/analysis/hop-counts:', error);
     res.status(500).json({ error: 'Failed to fetch hop counts' });
+  }
+});
+
+/**
+ * GET /api/analysis/mqtt-violations/gateways
+ *
+ * Per-gateway `ok_to_mqtt` violation summary (#4114). Confirmed violations
+ * come from the durable `mqtt_ok_to_mqtt_violations` table (90-day
+ * retention, independent of the packet monitor). "Suspected" rows
+ * (`includeUnknown=true`) come from `mqtt_packet_log` instead — bounded by
+ * that table's much shorter retention window and gated on
+ * `mqtt_packet_log_enabled` — so the response reports `suspectedAvailable`
+ * / `suspectedWindowMs` alongside them. See
+ * docs/internal/dev-notes/MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(e)/§3.17.
+ */
+router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
+  try {
+    const permitted = await resolvePermittedSourceIds(req, 'packetmonitor');
+    const requested = parseSourcesParam(req.query.sources);
+    const sourceIds = requested ? permitted.filter((id) => requested.includes(id)) : permitted;
+
+    const until = parseUntilMs(req.query.until);
+    const lookbackDays = parseLookbackDays(req.query.lookbackDays ?? req.query.lookback_days);
+    const hasExplicitSince = typeof req.query.since === 'string' && req.query.since.trim() !== '';
+    const since = hasExplicitSince
+      ? parseSinceMs(req.query.since)
+      : until - lookbackDays * 24 * 60 * 60 * 1000;
+
+    if (since > until) {
+      fail(res, 400, 'INVALID_RANGE', 'since must be <= until');
+      return;
+    }
+
+    const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : 'violationCount';
+    if (!(VIOLATION_GATEWAY_SORTS as readonly string[]).includes(sortRaw)) {
+      fail(res, 400, 'INVALID_SORT_FIELD', 'Unsupported sort field');
+      return;
+    }
+    const sort = sortRaw as ViolationGatewaySort;
+
+    const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : 'desc';
+    if (dirRaw !== 'asc' && dirRaw !== 'desc') {
+      fail(res, 400, 'INVALID_SORT_DIRECTION', 'Sort direction must be asc or desc');
+      return;
+    }
+    const dir = dirRaw;
+
+    const includeUnknown = parseBoolParam(req.query.includeUnknown);
+    const limit = clampPageSize(req.query.limit);
+    const offsetRaw = parseInt(String(req.query.offset ?? '0'), 10);
+    const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
+
+    if (sourceIds.length === 0) {
+      ok(res, {
+        gateways: [],
+        total: 0,
+        limit,
+        offset,
+        since,
+        until,
+        includeUnknown,
+        suspectedAvailable: false,
+        suspectedWindowMs: 0,
+        sources: [],
+      });
+      return;
+    }
+
+    const rangeQuery = { sourceIds, since, until };
+
+    // Fetch confirmed rows (capped at 2000 — see §3.17 step 7 / §6 risk 2)
+    // and always sort/paginate the (possibly merged) list in the handler so
+    // the includeUnknown=true and includeUnknown=false paths share one code
+    // path.
+    const confirmedRows = await databaseService.mqttOkToMqttViolations.getGatewaySummary({
+      ...rangeQuery,
+      limit: 2000,
+      offset: 0,
+    });
+    const confirmedTotal = await databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(rangeQuery);
+    const sourceIdPairs = await databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery);
+
+    const sourceIdsByGateway = new Map<string, Set<string>>();
+    for (const pair of sourceIdPairs) {
+      const set = sourceIdsByGateway.get(pair.gatewayId) ?? new Set<string>();
+      set.add(pair.sourceId);
+      sourceIdsByGateway.set(pair.gatewayId, set);
+    }
+
+    let suspectedAvailable = false;
+    let suspectedWindowMs = 0;
+    const suspectedByGateway = new Map<
+      string,
+      { suspectedCount: number; gatewayNodeNum: number | null; distinctOriginators: number; firstSeen: number; lastSeen: number }
+    >();
+
+    if (includeUnknown) {
+      suspectedAvailable = await mqttPacketLogService.isEnabled();
+      if (suspectedAvailable) {
+        suspectedWindowMs = (await mqttPacketLogService.getMaxAgeHours()) * 60 * 60 * 1000;
+        const suspectedRows = await databaseService.mqttPacketLog.getSuspectedViolationGateways(rangeQuery);
+        for (const row of suspectedRows) {
+          if (!row.gatewayId) continue;
+          suspectedByGateway.set(row.gatewayId, {
+            suspectedCount: row.suspectedCount,
+            gatewayNodeNum: row.gatewayNodeNum,
+            distinctOriginators: row.distinctOriginators,
+            firstSeen: row.firstSeen,
+            lastSeen: row.lastSeen,
+          });
+        }
+      }
+    }
+
+    const mergedByGateway = new Map<string, ViolationGatewayRow>();
+    for (const g of confirmedRows) {
+      if (!g.gatewayId) continue;
+      const suspected = suspectedByGateway.get(g.gatewayId);
+      mergedByGateway.set(g.gatewayId, {
+        ...g,
+        suspectedCount: suspected?.suspectedCount ?? 0,
+        sourceIds: Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []),
+      });
+    }
+    // Gateways present only in the suspected set appear with violationCount: 0.
+    for (const [gatewayId, suspected] of suspectedByGateway) {
+      if (mergedByGateway.has(gatewayId)) continue;
+      mergedByGateway.set(gatewayId, {
+        gatewayId,
+        gatewayNodeNum: suspected.gatewayNodeNum,
+        violationCount: 0,
+        distinctOriginators: suspected.distinctOriginators,
+        firstSeen: suspected.firstSeen,
+        lastSeen: suspected.lastSeen,
+        suspectedCount: suspected.suspectedCount,
+        sourceIds: Array.from(sourceIdsByGateway.get(gatewayId) ?? []),
+      });
+    }
+
+    const merged = Array.from(mergedByGateway.values());
+    const dirMultiplier = dir === 'asc' ? 1 : -1;
+    merged.sort((a, b) => {
+      if (sort === 'gatewayId') {
+        return dirMultiplier * String(a.gatewayId ?? '').localeCompare(String(b.gatewayId ?? ''));
+      }
+      return dirMultiplier * ((a[sort] ?? 0) - (b[sort] ?? 0));
+    });
+
+    const total = includeUnknown ? merged.length : confirmedTotal;
+    const gateways = merged.slice(offset, offset + limit);
+
+    ok(res, {
+      gateways,
+      total,
+      limit,
+      offset,
+      since,
+      until,
+      includeUnknown,
+      suspectedAvailable,
+      suspectedWindowMs,
+      sources: sourceIds,
+    });
+  } catch (error) {
+    logger.error('Error in GET /api/analysis/mqtt-violations/gateways:', error);
+    fail(res, 500, 'MQTT_VIOLATIONS_FETCH_FAILED', 'Failed to fetch ok_to_mqtt violations');
+  }
+});
+
+/**
+ * GET /api/analysis/mqtt-violations/packets
+ *
+ * Drill-down list of individual `ok_to_mqtt` violations (#4114), optionally
+ * filtered to one `gateway`. Same confirmed/suspected split as
+ * `/mqtt-violations/gateways` — see that handler's doc comment and
+ * MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(e)/§3.17.
+ */
+router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
+  try {
+    const permitted = await resolvePermittedSourceIds(req, 'packetmonitor');
+    const requested = parseSourcesParam(req.query.sources);
+    const sourceIds = requested ? permitted.filter((id) => requested.includes(id)) : permitted;
+
+    const until = parseUntilMs(req.query.until);
+    const lookbackDays = parseLookbackDays(req.query.lookbackDays ?? req.query.lookback_days);
+    const hasExplicitSince = typeof req.query.since === 'string' && req.query.since.trim() !== '';
+    const since = hasExplicitSince
+      ? parseSinceMs(req.query.since)
+      : until - lookbackDays * 24 * 60 * 60 * 1000;
+
+    if (since > until) {
+      fail(res, 400, 'INVALID_RANGE', 'since must be <= until');
+      return;
+    }
+
+    const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : 'timestamp';
+    if (!(VIOLATION_LIST_SORTS as readonly string[]).includes(sortRaw)) {
+      fail(res, 400, 'INVALID_SORT_FIELD', 'Unsupported sort field');
+      return;
+    }
+    const sort = sortRaw as ViolationListSort;
+
+    const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : 'desc';
+    if (dirRaw !== 'asc' && dirRaw !== 'desc') {
+      fail(res, 400, 'INVALID_SORT_DIRECTION', 'Sort direction must be asc or desc');
+      return;
+    }
+    const dir = dirRaw;
+
+    const includeUnknown = parseBoolParam(req.query.includeUnknown);
+    const gateway = typeof req.query.gateway === 'string' && req.query.gateway.trim() !== ''
+      ? req.query.gateway
+      : undefined;
+    const limit = clampPageSize(req.query.limit);
+    const offsetRaw = parseInt(String(req.query.offset ?? '0'), 10);
+    const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
+
+    if (sourceIds.length === 0) {
+      ok(res, {
+        violations: [],
+        total: 0,
+        limit,
+        offset,
+        since,
+        until,
+        gateway: gateway ?? null,
+        includeUnknown,
+        suspectedAvailable: false,
+        suspectedWindowMs: 0,
+        sources: [],
+      });
+      return;
+    }
+
+    const rangeQuery = { sourceIds, since, until, gatewayId: gateway };
+
+    const confirmedRows = await databaseService.mqttOkToMqttViolations.getViolations({
+      ...rangeQuery,
+      limit: 2000,
+      offset: 0,
+    });
+    const confirmedTotal = await databaseService.mqttOkToMqttViolations.getViolationCount(rangeQuery);
+
+    let suspectedAvailable = false;
+    let suspectedWindowMs = 0;
+    let suspectedRows: DbMqttPacket[] = [];
+
+    if (includeUnknown) {
+      suspectedAvailable = await mqttPacketLogService.isEnabled();
+      if (suspectedAvailable) {
+        suspectedWindowMs = (await mqttPacketLogService.getMaxAgeHours()) * 60 * 60 * 1000;
+        suspectedRows = await databaseService.mqttPacketLog.getSuspectedViolations({
+          ...rangeQuery,
+          limit: 2000,
+          offset: 0,
+        });
+      }
+    }
+
+    const merged = [
+      ...confirmedRows.map((r) => toViolationPacketRow('confirmed', r)),
+      ...suspectedRows.map((r) => toViolationPacketRow('suspected', r)),
+    ];
+    const dirMultiplier = dir === 'asc' ? 1 : -1;
+    merged.sort((a, b) => {
+      if (sort === 'gatewayId') {
+        return dirMultiplier * String(a.gatewayId ?? '').localeCompare(String(b.gatewayId ?? ''));
+      }
+      return dirMultiplier * ((a[sort] ?? 0) - (b[sort] ?? 0));
+    });
+
+    const total = includeUnknown ? merged.length : confirmedTotal;
+    const violations = merged.slice(offset, offset + limit);
+
+    ok(res, {
+      violations,
+      total,
+      limit,
+      offset,
+      since,
+      until,
+      gateway: gateway ?? null,
+      includeUnknown,
+      suspectedAvailable,
+      suspectedWindowMs,
+      sources: sourceIds,
+    });
+  } catch (error) {
+    logger.error('Error in GET /api/analysis/mqtt-violations/packets:', error);
+    fail(res, 500, 'MQTT_VIOLATIONS_FETCH_FAILED', 'Failed to fetch ok_to_mqtt violations');
   }
 });
 

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -608,15 +608,18 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
     // Fetch confirmed rows (capped at 2000 — see §3.17 step 7 / §6 risk 2)
     // and always sort/paginate the (possibly merged) list in the handler so
     // the includeUnknown=true and includeUnknown=false paths share one code
-    // path.
-    const confirmedRows = await databaseService.mqttOkToMqttViolations.getGatewaySummary({
-      ...rangeQuery,
-      limit: 2000,
-      offset: 0,
-    });
-    const confirmedTotal = await databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(rangeQuery);
-    const sourceIdPairs = await databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery);
+    // path. The three queries below have no data dependency on each other,
+    // so run them concurrently rather than round-tripping in sequence.
+    const [confirmedRows, confirmedTotal, sourceIdPairs] = await Promise.all([
+      databaseService.mqttOkToMqttViolations.getGatewaySummary({ ...rangeQuery, limit: 2000, offset: 0 }),
+      databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(rangeQuery),
+      databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery),
+    ]);
 
+    // Seeded from the confirmed side; the suspected side (below) unions its
+    // own (gatewayId, sourceId) pairs in — a gateway can be known to have
+    // touched a source via either signal, and a suspected-only gateway must
+    // still report which source(s) it was seen on (#4114 code review).
     const sourceIdsByGateway = new Map<string, Set<string>>();
     for (const pair of sourceIdPairs) {
       const set = sourceIdsByGateway.get(pair.gatewayId) ?? new Set<string>();
@@ -634,8 +637,13 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
     if (includeUnknown) {
       suspectedAvailable = await mqttPacketLogService.isEnabled();
       if (suspectedAvailable) {
-        suspectedWindowMs = (await mqttPacketLogService.getMaxAgeHours()) * 60 * 60 * 1000;
-        const suspectedRows = await databaseService.mqttPacketLog.getSuspectedViolationGateways(rangeQuery);
+        // No dependency between these three — run concurrently.
+        const [maxAgeHours, suspectedRows, suspectedSourceIdPairs] = await Promise.all([
+          mqttPacketLogService.getMaxAgeHours(),
+          databaseService.mqttPacketLog.getSuspectedViolationGateways(rangeQuery),
+          databaseService.mqttPacketLog.getSuspectedGatewaySourceIds(rangeQuery),
+        ]);
+        suspectedWindowMs = maxAgeHours * 60 * 60 * 1000;
         for (const row of suspectedRows) {
           if (!row.gatewayId) continue;
           suspectedByGateway.set(row.gatewayId, {
@@ -645,6 +653,11 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
             firstSeen: row.firstSeen,
             lastSeen: row.lastSeen,
           });
+        }
+        for (const pair of suspectedSourceIdPairs) {
+          const set = sourceIdsByGateway.get(pair.gatewayId) ?? new Set<string>();
+          set.add(pair.sourceId);
+          sourceIdsByGateway.set(pair.gatewayId, set);
         }
       }
     }
@@ -656,6 +669,11 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       mergedByGateway.set(g.gatewayId, {
         ...g,
         suspectedCount: suspected?.suspectedCount ?? 0,
+        // A gateway confirmed AND suspected in the same window must report
+        // the true first/last-seen span across both signals, not just the
+        // confirmed side's (#4114 code review).
+        firstSeen: suspected ? Math.min(g.firstSeen, suspected.firstSeen) : g.firstSeen,
+        lastSeen: suspected ? Math.max(g.lastSeen, suspected.lastSeen) : g.lastSeen,
         sourceIds: Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []),
       });
     }
@@ -771,12 +789,11 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
 
     const rangeQuery = { sourceIds, since, until, gatewayId: gateway };
 
-    const confirmedRows = await databaseService.mqttOkToMqttViolations.getViolations({
-      ...rangeQuery,
-      limit: 2000,
-      offset: 0,
-    });
-    const confirmedTotal = await databaseService.mqttOkToMqttViolations.getViolationCount(rangeQuery);
+    // No data dependency between these two — run concurrently.
+    const [confirmedRows, confirmedTotal] = await Promise.all([
+      databaseService.mqttOkToMqttViolations.getViolations({ ...rangeQuery, limit: 2000, offset: 0 }),
+      databaseService.mqttOkToMqttViolations.getViolationCount(rangeQuery),
+    ]);
 
     let suspectedAvailable = false;
     let suspectedWindowMs = 0;
@@ -785,12 +802,13 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
     if (includeUnknown) {
       suspectedAvailable = await mqttPacketLogService.isEnabled();
       if (suspectedAvailable) {
-        suspectedWindowMs = (await mqttPacketLogService.getMaxAgeHours()) * 60 * 60 * 1000;
-        suspectedRows = await databaseService.mqttPacketLog.getSuspectedViolations({
-          ...rangeQuery,
-          limit: 2000,
-          offset: 0,
-        });
+        // No dependency between these two — run concurrently.
+        const [maxAgeHours, rows] = await Promise.all([
+          mqttPacketLogService.getMaxAgeHours(),
+          databaseService.mqttPacketLog.getSuspectedViolations({ ...rangeQuery, limit: 2000, offset: 0 }),
+        ]);
+        suspectedWindowMs = maxAgeHours * 60 * 60 * 1000;
+        suspectedRows = rows;
       }
     }
 

--- a/src/server/routes/mqttPacketRoutes.permissions.test.ts
+++ b/src/server/routes/mqttPacketRoutes.permissions.test.ts
@@ -38,6 +38,7 @@ function makePacket(sourceId: string, overrides: Partial<DbMqttPacket> = {}): Db
     ingestOutcome: 'ingested',
     payloadSize: 12,
     payloadPreview: 'hello',
+    okToMqttViolation: 0,
     createdAt: now,
     ...overrides,
   };

--- a/src/server/services/mqttPacketLogService.buildRow.test.ts
+++ b/src/server/services/mqttPacketLogService.buildRow.test.ts
@@ -9,7 +9,7 @@ vi.mock('../../services/database.js', () => ({
   default: {},
 }));
 
-import { buildMqttPacketLogRow } from './mqttPacketLogService.js';
+import { buildMqttPacketLogRow, buildViolationRow } from './mqttPacketLogService.js';
 import type { ServiceEnvelopeShape } from '../mqttPacketFilter.js';
 import type { MqttIngestionResult } from '../mqttIngestion.js';
 import { PortNum } from '../constants/meshtastic.js';
@@ -55,6 +55,10 @@ describe('buildMqttPacketLogRow', () => {
     it.each(cases)('maps %j -> %s', (result, expected) => {
       const row = buildMqttPacketLogRow('src-a', envelope(), result);
       expect(row?.ingestOutcome).toBe(expected);
+      // #4114: okToMqttViolation defaults to 0 — none of these fixtures set
+      // decoded.bitfield, so the tri-state is 'unknown', never a confirmed
+      // violation. Proves no pre-existing assertion regresses.
+      expect(row?.okToMqttViolation).toBe(0);
     });
 
     it('ingested:true always wins even if a reason is also set', () => {
@@ -261,6 +265,81 @@ describe('buildMqttPacketLogRow', () => {
       expect(row?.sourceId).toBe('src-b');
       expect(row?.channel).toBe(8);
       expect(row?.channelId).toBe('LongFast');
+    });
+  });
+
+  describe('ok_to_mqtt fields (bitfield / okToMqttViolation / topic) — #4114', () => {
+    it('topic is null when omitted', () => {
+      const row = buildMqttPacketLogRow('src-a', envelope(), { ingested: true, portnum: 1 });
+      expect(row?.topic).toBeNull();
+    });
+
+    it('topic is carried through when provided', () => {
+      const row = buildMqttPacketLogRow(
+        'src-a',
+        envelope(),
+        { ingested: true, portnum: 1 },
+        'msh/US/2/e/LongFast/!433e0f28',
+      );
+      expect(row?.topic).toBe('msh/US/2/e/LongFast/!433e0f28');
+    });
+
+    it('bitfield is null when decoded.bitfield is absent (unknown)', () => {
+      const row = buildMqttPacketLogRow('src-a', envelope(), { ingested: true, portnum: 1 });
+      expect(row?.bitfield).toBeNull();
+      expect(row?.okToMqttViolation).toBe(0);
+    });
+
+    it('bitfield/okToMqttViolation reflect the caller-supplied `evaluated` eval (self-echo guard passthrough)', () => {
+      const env = envelope({ gatewayId: '!22222222' }); // distinct from packet.from (0x11111111)
+      env.packet!.decoded = { portnum: PortNum.TEXT_MESSAGE_APP, payload: new TextEncoder().encode('hi'), bitfield: 0 };
+      const evaluated = {
+        state: 'no' as const,
+        bitfield: 0,
+        fromNode: 0x11111111,
+        gatewayNodeNum: 0x22222222,
+        selfGateway: false,
+        relayed: true,
+        isViolation: true,
+        isSuspected: false,
+      };
+      const row = buildMqttPacketLogRow('src-a', env, { ingested: true, portnum: 1 }, undefined, evaluated);
+      expect(row?.bitfield).toBe(0);
+      expect(row?.okToMqttViolation).toBe(1);
+    });
+
+    it('falls back to its own no-local-identity eval when `evaluated` is omitted', () => {
+      const env = envelope({ gatewayId: '!22222222' });
+      env.packet!.decoded = { portnum: PortNum.TEXT_MESSAGE_APP, payload: new TextEncoder().encode('hi'), bitfield: 0 };
+      const row = buildMqttPacketLogRow('src-a', env, { ingested: true, portnum: 1 });
+      expect(row?.bitfield).toBe(0);
+      expect(row?.okToMqttViolation).toBe(1); // gateway (0x22222222) !== from (0x11111111), bit clear
+    });
+  });
+
+  describe('buildViolationRow', () => {
+    it('projects the packet-log row field-for-field onto the violation row shape', () => {
+      const env = envelope({ gatewayId: '!22222222' });
+      env.packet!.decoded = { portnum: PortNum.TEXT_MESSAGE_APP, payload: new TextEncoder().encode('hi'), bitfield: 0 };
+      const row = buildMqttPacketLogRow('src-a', env, { ingested: true, portnum: 1 }, 'msh/US/2/e/LongFast/!22222222');
+      expect(row).not.toBeNull();
+      const v = buildViolationRow(row!);
+      expect(v).toEqual({
+        sourceId: row!.sourceId,
+        packetId: row!.packetId,
+        fromNode: row!.fromNode,
+        fromNodeId: row!.fromNodeId,
+        gatewayId: row!.gatewayId,
+        gatewayNodeNum: row!.gatewayNodeNum,
+        channelId: row!.channelId,
+        portnum: row!.portnum,
+        portnumName: row!.portnumName,
+        bitfield: row!.bitfield,
+        topic: row!.topic,
+        rxTime: row!.rxTime,
+        timestamp: row!.timestamp,
+        createdAt: row!.createdAt,
+      });
     });
   });
 });

--- a/src/server/services/mqttPacketLogService.ts
+++ b/src/server/services/mqttPacketLogService.ts
@@ -4,6 +4,7 @@ import { PortNum } from '../constants/meshtastic.js';
 import meshtasticProtobufService from '../meshtasticProtobufService.js';
 import { nodeNumToId, type ServiceEnvelopeShape } from '../mqttPacketFilter.js';
 import type { MqttIngestionResult } from '../mqttIngestion.js';
+import { detectOkToMqttViolation, parseGatewayNodeNum, type OkToMqttViolationEval } from '../utils/okToMqtt.js';
 import type {
   DbMqttPacket,
   MqttGroupedPacket,
@@ -11,6 +12,13 @@ import type {
   MqttGateway,
   MqttIngestOutcome,
 } from '../../db/repositories/mqttPacketLog.js';
+import type {
+  DbMqttOkToMqttViolation,
+  MqttViolationGateway,
+  ViolationGatewaySort,
+  ViolationListSort,
+  ViolationRangeQuery,
+} from '../../db/repositories/mqttOkToMqttViolations.js';
 
 /**
  * Service for the MQTT Packet Monitor — the multi-gateway-reception
@@ -26,9 +34,13 @@ class MqttPacketLogService {
   private readonly CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
   private readonly DEFAULT_MAX_COUNT = 5000;
   private readonly DEFAULT_MAX_AGE_HOURS = 24;
+  private readonly DEFAULT_VIOLATION_RETENTION_DAYS = 90;
+  private readonly DEFAULT_VIOLATION_MAX_COUNT = 50000;
 
   private enabledCache: { value: boolean; expires: number } | null = null;
   private readonly ENABLED_TTL_MS = 5000;
+
+  private violationEnabledCache: { value: boolean; expires: number } | null = null;
 
   constructor() {
     this.startCleanupScheduler();
@@ -66,6 +78,29 @@ class MqttPacketLogService {
     } catch (error) {
       logger.error('❌ Failed to cleanup MQTT packet logs:', error);
     }
+
+    // Phase 2 (#4114): the durable ok_to_mqtt violations table has its own
+    // retention — a different table, a different cutoff (default 90d vs
+    // 24h), and a different per-source cap — deliberately independent of the
+    // packet log's own sweep above so it survives even when the packet log
+    // is disabled/cleared. See MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(d). Reuses
+    // this same 15-minute timer — do NOT add a second `setInterval`.
+    try {
+      const days = await this.getViolationRetentionDays();
+      const vCutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+      let vRemoved = await databaseService.mqttOkToMqttViolations.deleteViolationsOlderThan(vCutoff);
+
+      const vMax = await this.getViolationMaxCount();
+      for (const sid of await databaseService.mqttOkToMqttViolations.getViolationSourceIds()) {
+        vRemoved += await databaseService.mqttOkToMqttViolations.trimViolationsToCount(sid, vMax);
+      }
+
+      if (vRemoved > 0) {
+        logger.debug(`🧹 MQTT ok_to_mqtt violations cleanup: removed ${vRemoved} old violations`);
+      }
+    } catch (error) {
+      logger.error('❌ Failed to cleanup MQTT ok_to_mqtt violations:', error);
+    }
   }
 
   /**
@@ -101,22 +136,76 @@ class MqttPacketLogService {
   }
 
   /**
+   * Kill switch for the durable ok_to_mqtt violation write (#4114). DEFAULT
+   * ON, and — unlike every other enable flag in this file — INVERTED:
+   * `=== '0'` means off; anything else, including unset, means on. This is
+   * deliberate: the violation write must keep working on every existing
+   * install that never touched settings, since the packet log itself
+   * (`isEnabled()` above) is opt-in and default OFF. See
+   * MQTT_OK_TO_MQTT_PHASE1_SPEC.md §2(g). Cached for `ENABLED_TTL_MS`.
+   */
+  async isViolationLogEnabled(): Promise<boolean> {
+    const now = Date.now();
+    if (this.violationEnabledCache && now < this.violationEnabledCache.expires) {
+      return this.violationEnabledCache.value;
+    }
+    const raw = await databaseService.getSettingAsync('mqtt_oktomqtt_violation_log_enabled');
+    const value = raw !== '0';
+    this.violationEnabledCache = { value, expires: now + this.ENABLED_TTL_MS };
+    return value;
+  }
+
+  /** Test seam — clears the TTL cache so a just-written setting is observed immediately. */
+  resetViolationEnabledCache(): void {
+    this.violationEnabledCache = null;
+  }
+
+  async getViolationRetentionDays(): Promise<number> {
+    const raw = await databaseService.getSettingAsync('mqtt_oktomqtt_violation_retention_days');
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : this.DEFAULT_VIOLATION_RETENTION_DAYS;
+  }
+
+  async getViolationMaxCount(): Promise<number> {
+    const raw = await databaseService.getSettingAsync('mqtt_oktomqtt_violation_max_count');
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : this.DEFAULT_VIOLATION_MAX_COUNT;
+  }
+
+  /**
    * Ingestion entry point — the single method the `mqttIngestion.ts` hook
    * calls. Owns the enabled-gate, the row build, and the best-effort insert
    * so the hook itself stays a one-liner. Never throws — a logging failure
    * must not break the MQTT ingest pipeline.
+   *
+   * The durable ok_to_mqtt violation write (#4114) is independent of the
+   * packet-log opt-in: it has its own kill switch (default ON, see
+   * {@link isViolationLogEnabled}) so Phase 3's report works out of the box
+   * even on installs that never enabled the packet monitor. The eval is
+   * computed once, with `localGatewayNodeNum`, and reused for both the
+   * packet-log row and the violation row so they can never disagree.
    */
   async logEnvelope(
     sourceId: string,
     envelope: ServiceEnvelopeShape,
     result: MqttIngestionResult,
+    topic?: string,
+    localGatewayNodeNum?: number | null,
   ): Promise<void> {
     try {
       if (!envelope.packet) return; // nothing to log
-      if (!(await this.isEnabled())) return; // no-op when disabled (cached)
-      const row = buildMqttPacketLogRow(sourceId, envelope, result);
+      const v = detectOkToMqttViolation(envelope, localGatewayNodeNum); // pure, cheap, no await
+      const packetLogEnabled = await this.isEnabled(); // cached, 5s TTL
+      const wantViolation = v.isViolation && (await this.isViolationLogEnabled()); // cached
+      if (!packetLogEnabled && !wantViolation) return; // fast path: nothing to write
+      const row = buildMqttPacketLogRow(sourceId, envelope, result, topic, v);
       if (!row) return;
-      await databaseService.mqttPacketLog.insertPacket(row);
+      if (wantViolation) {
+        await databaseService.mqttOkToMqttViolations.insertViolation(buildViolationRow(row));
+      }
+      if (packetLogEnabled) {
+        await databaseService.mqttPacketLog.insertPacket(row);
+      }
     } catch (err) {
       logger.error('❌ Failed to log MQTT packet:', err);
     }
@@ -140,6 +229,56 @@ class MqttPacketLogService {
 
   async clearPackets(sourceId?: string): Promise<number> {
     return databaseService.mqttPacketLog.deleteAllPackets(sourceId);
+  }
+
+  async getViolationGatewaySummary(
+    q: ViolationRangeQuery & { sort?: ViolationGatewaySort; dir?: 'asc' | 'desc' },
+  ): Promise<MqttViolationGateway[]> {
+    return databaseService.mqttOkToMqttViolations.getGatewaySummary(q);
+  }
+
+  async getViolationGatewaySummaryCount(q: ViolationRangeQuery): Promise<number> {
+    return databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(q);
+  }
+
+  async getViolationGatewaySourceIds(
+    q: ViolationRangeQuery,
+  ): Promise<Array<{ gatewayId: string; sourceId: string }>> {
+    return databaseService.mqttOkToMqttViolations.getGatewaySourceIds(q);
+  }
+
+  async getViolations(
+    q: ViolationRangeQuery & { sort?: ViolationListSort; dir?: 'asc' | 'desc' },
+  ): Promise<DbMqttOkToMqttViolation[]> {
+    return databaseService.mqttOkToMqttViolations.getViolations(q);
+  }
+
+  async getViolationCount(q: ViolationRangeQuery): Promise<number> {
+    return databaseService.mqttOkToMqttViolations.getViolationCount(q);
+  }
+
+  async getSuspectedViolations(q: {
+    sourceIds: string[];
+    since: number;
+    until: number;
+    gatewayId?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<DbMqttPacket[]> {
+    return databaseService.mqttPacketLog.getSuspectedViolations(q);
+  }
+
+  async getSuspectedViolationGateways(q: { sourceIds: string[]; since: number; until: number }): Promise<
+    Array<{
+      gatewayId: string | null;
+      gatewayNodeNum: number | null;
+      suspectedCount: number;
+      distinctOriginators: number;
+      firstSeen: number;
+      lastSeen: number;
+    }>
+  > {
+    return databaseService.mqttPacketLog.getSuspectedViolationGateways(q);
   }
 
   stop(): void {
@@ -177,16 +316,6 @@ function mapOutcome(result: MqttIngestionResult): MqttIngestOutcome {
 }
 
 /**
- * Parse a `!aabbccdd`-formatted gateway id back into its numeric nodeNum.
- * Returns null for a missing/malformed id.
- */
-function parseGatewayNodeNum(id: string | null | undefined): number | null {
-  if (!id || !id.startsWith('!')) return null;
-  const n = parseInt(id.slice(1), 16);
-  return Number.isNaN(n) ? null : n >>> 0;
-}
-
-/**
  * Lightweight payload preview — text only. Position/telemetry summaries are
  * deferred to a later phase (no protobuf re-decode here).
  */
@@ -204,6 +333,8 @@ export function buildMqttPacketLogRow(
   sourceId: string,
   envelope: ServiceEnvelopeShape,
   result: MqttIngestionResult,
+  topic?: string,
+  evaluated?: OkToMqttViolationEval,
 ): DbMqttPacket | null {
   const p = envelope.packet;
   if (!p) return null;
@@ -215,6 +346,12 @@ export function buildMqttPacketLogRow(
   const decoded = p.decoded; // inner may have synthesized this on server-decrypt
   const portnum = typeof decoded?.portnum === 'number' ? decoded.portnum : null;
   const gatewayId = envelope.gatewayId ?? null;
+  // `evaluated` is the already-computed eval from `logEnvelope` (which knows
+  // `localGatewayNodeNum`, the self-echo guard of §2(f.1)). Direct unit-test
+  // callers that omit it fall back to a no-local-identity eval — the guard
+  // then simply doesn't apply, which is the correct default for a caller
+  // with no local identity to compare against (#4114).
+  const v = evaluated ?? detectOkToMqttViolation(envelope);
   return {
     sourceId,
     packetId: num(p.id),
@@ -239,7 +376,36 @@ export function buildMqttPacketLogRow(
     ingestOutcome: mapOutcome(result),
     payloadSize: decoded?.payload?.length ?? (p.encrypted?.length ?? null),
     payloadPreview: buildPreview(portnum, decoded?.payload),
+    bitfield: v.bitfield,
+    okToMqttViolation: v.isViolation ? 1 : 0,
+    topic: topic ?? null,
     createdAt: now,
+  };
+}
+
+/**
+ * Project a packet-log row onto the durable violation row (#4114). Pure
+ * field projection off the already-built `DbMqttPacket` — deliberately NOT
+ * derived independently from the envelope, so the packet-log row and the
+ * durable violation row can never disagree. Caller has already established
+ * `row.okToMqttViolation === 1`.
+ */
+export function buildViolationRow(row: DbMqttPacket): DbMqttOkToMqttViolation {
+  return {
+    sourceId: row.sourceId,
+    packetId: row.packetId ?? null,
+    fromNode: row.fromNode ?? null,
+    fromNodeId: row.fromNodeId ?? null,
+    gatewayId: row.gatewayId ?? null,
+    gatewayNodeNum: row.gatewayNodeNum ?? null,
+    channelId: row.channelId ?? null,
+    portnum: row.portnum ?? null,
+    portnumName: row.portnumName ?? null,
+    bitfield: row.bitfield ?? null,
+    topic: row.topic ?? null,
+    rxTime: row.rxTime ?? null,
+    timestamp: row.timestamp,
+    createdAt: row.createdAt,
   };
 }
 

--- a/src/server/utils/okToMqtt.test.ts
+++ b/src/server/utils/okToMqtt.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServiceEnvelopeShape } from '../mqttPacketFilter.js';
+
+// channelDecryptionService is mocked at the module level so
+// resolveOkToMqttForEnvelope's decrypt branch can be driven deterministically
+// without touching the real channel-database cache refresh path (#4114).
+const tryDecrypt = vi.fn();
+vi.mock('../services/channelDecryptionService.js', () => ({
+  channelDecryptionService: {
+    tryDecrypt: (...args: unknown[]) => tryDecrypt(...args),
+  },
+}));
+
+import {
+  readBitfieldOkToMqtt,
+  resolveOkToMqttForEnvelope,
+  allowsUplink,
+  parseGatewayNodeNum,
+  detectOkToMqttViolation,
+} from './okToMqtt.js';
+
+const ORIGINATOR = 0x11111111;
+const GATEWAY = 0x22222222;
+
+function gwId(nodeNum: number): string {
+  return `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+function envelope(opts: {
+  from?: number;
+  to?: number;
+  bitfield?: number;
+  /** Whether `packet.decoded` is present at all (false ⇒ simulates an
+   *  encrypted packet the ingest layer never managed to decrypt/synthesize). */
+  hasDecoded?: boolean;
+  gatewayId?: string;
+  encrypted?: Uint8Array;
+  id?: number;
+  channel?: number;
+} = {}): ServiceEnvelopeShape {
+  const { from, to, bitfield, hasDecoded = true, gatewayId, encrypted, id, channel } = opts;
+  return {
+    gatewayId,
+    packet: {
+      from,
+      to,
+      id,
+      channel,
+      encrypted,
+      decoded: hasDecoded ? { bitfield } : undefined,
+    },
+  };
+}
+
+beforeEach(() => {
+  tryDecrypt.mockReset();
+});
+
+describe('readBitfieldOkToMqtt', () => {
+  it('undefined/null/NaN/non-number ⇒ unknown', () => {
+    expect(readBitfieldOkToMqtt(undefined)).toBe('unknown');
+    expect(readBitfieldOkToMqtt(null)).toBe('unknown');
+    expect(readBitfieldOkToMqtt(NaN)).toBe('unknown');
+    expect(readBitfieldOkToMqtt('1' as unknown as number)).toBe('unknown');
+  });
+
+  it('bit 0 clear ⇒ no (regardless of other bits)', () => {
+    expect(readBitfieldOkToMqtt(0)).toBe('no');
+    expect(readBitfieldOkToMqtt(2)).toBe('no');
+  });
+
+  it('bit 0 set ⇒ yes (regardless of other bits)', () => {
+    expect(readBitfieldOkToMqtt(1)).toBe('yes');
+    expect(readBitfieldOkToMqtt(3)).toBe('yes');
+    expect(readBitfieldOkToMqtt(0xffffffff)).toBe('yes');
+  });
+});
+
+describe('resolveOkToMqttForEnvelope', () => {
+  it('plaintext bit set ⇒ yes, no decrypt attempted', async () => {
+    await expect(resolveOkToMqttForEnvelope(envelope({ bitfield: 1 }))).resolves.toBe('yes');
+    expect(tryDecrypt).not.toHaveBeenCalled();
+  });
+
+  it('plaintext bit clear ⇒ no, no decrypt attempted', async () => {
+    await expect(resolveOkToMqttForEnvelope(envelope({ bitfield: 0 }))).resolves.toBe('no');
+    expect(tryDecrypt).not.toHaveBeenCalled();
+  });
+
+  it('decoded present, bitfield absent, no encrypted ⇒ unknown, no decrypt attempted', async () => {
+    await expect(resolveOkToMqttForEnvelope(envelope({ hasDecoded: true }))).resolves.toBe('unknown');
+    expect(tryDecrypt).not.toHaveBeenCalled();
+  });
+
+  it('decoded present, bitfield absent, encrypted present ⇒ decrypt attempted with (enc, id, from, channelHash)', async () => {
+    tryDecrypt.mockResolvedValue({ success: false });
+    const enc = new Uint8Array([1, 2, 3]);
+    await resolveOkToMqttForEnvelope(
+      envelope({ hasDecoded: true, encrypted: enc, id: 42, from: ORIGINATOR, channel: 7 }),
+    );
+    expect(tryDecrypt).toHaveBeenCalledTimes(1);
+    expect(tryDecrypt).toHaveBeenCalledWith(enc, 42, ORIGINATOR, 7);
+  });
+
+  it('decrypt success with numeric bitfield ⇒ mapped through readBitfieldOkToMqtt', async () => {
+    tryDecrypt.mockResolvedValue({ success: true, bitfield: 1 });
+    const enc = new Uint8Array([1]);
+    await expect(
+      resolveOkToMqttForEnvelope(envelope({ hasDecoded: false, encrypted: enc, id: 1, from: ORIGINATOR })),
+    ).resolves.toBe('yes');
+  });
+
+  it('decrypt success with non-numeric bitfield ⇒ unknown', async () => {
+    tryDecrypt.mockResolvedValue({ success: true, bitfield: undefined });
+    const enc = new Uint8Array([1]);
+    await expect(
+      resolveOkToMqttForEnvelope(envelope({ hasDecoded: false, encrypted: enc, id: 1, from: ORIGINATOR })),
+    ).resolves.toBe('unknown');
+  });
+
+  it('decrypt failure ⇒ unknown', async () => {
+    tryDecrypt.mockResolvedValue({ success: false, error: 'no matching key' });
+    const enc = new Uint8Array([1]);
+    await expect(
+      resolveOkToMqttForEnvelope(envelope({ hasDecoded: false, encrypted: enc, id: 1, from: ORIGINATOR })),
+    ).resolves.toBe('unknown');
+  });
+
+  it('missing id/from ⇒ unknown, no decrypt attempted', async () => {
+    const enc = new Uint8Array([1]);
+    await expect(
+      resolveOkToMqttForEnvelope(envelope({ hasDecoded: false, encrypted: enc })),
+    ).resolves.toBe('unknown');
+    expect(tryDecrypt).not.toHaveBeenCalled();
+  });
+});
+
+describe('allowsUplink', () => {
+  it('fail-closed: yes⇒true, no⇒false, unknown⇒false', () => {
+    expect(allowsUplink('yes')).toBe(true);
+    expect(allowsUplink('no')).toBe(false);
+    expect(allowsUplink('unknown')).toBe(false);
+  });
+
+  it('the tri-state vs fail-closed split: unknown drops for uplink but is only "suspected" for detection', () => {
+    expect(allowsUplink('unknown')).toBe(false);
+
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, hasDecoded: true, gatewayId: gwId(GATEWAY) }));
+    expect(r.state).toBe('unknown');
+    expect(r.isSuspected).toBe(true);
+    expect(r.isViolation).toBe(false);
+  });
+});
+
+describe('parseGatewayNodeNum', () => {
+  it('parses a well-formed !hex id', () => {
+    expect(parseGatewayNodeNum('!aabbccdd')).toBe(0xaabbccdd);
+  });
+
+  it('unsigned-normalizes the maximum u32', () => {
+    expect(parseGatewayNodeNum('!ffffffff')).toBe(4294967295);
+  });
+
+  it('missing/undefined/null/empty ⇒ null', () => {
+    expect(parseGatewayNodeNum(undefined)).toBeNull();
+    expect(parseGatewayNodeNum(null)).toBeNull();
+    expect(parseGatewayNodeNum('')).toBeNull();
+  });
+
+  it('missing "!" prefix ⇒ null', () => {
+    expect(parseGatewayNodeNum('aabbccdd')).toBeNull();
+  });
+
+  it('non-hex payload ⇒ null', () => {
+    expect(parseGatewayNodeNum('!zzzz')).toBeNull();
+  });
+});
+
+describe('detectOkToMqttViolation — §2(f) predicate table', () => {
+  it('table row 1: bit=1, gateway ≠ originator ⇒ not a violation', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 1, gatewayId: gwId(GATEWAY) }));
+    expect(r.state).toBe('yes');
+    expect(r.relayed).toBe(true);
+    expect(r.isViolation).toBe(false);
+    expect(r.isSuspected).toBe(false);
+  });
+
+  it('table row 2: bit=1, gateway = originator ⇒ not a violation', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 1, gatewayId: gwId(ORIGINATOR) }));
+    expect(r.state).toBe('yes');
+    expect(r.relayed).toBe(false);
+    expect(r.isViolation).toBe(false);
+  });
+
+  it('table row 3: bit=0, gateway ≠ originator ⇒ CONFIRMED VIOLATION', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) }));
+    expect(r.state).toBe('no');
+    expect(r.relayed).toBe(true);
+    expect(r.isViolation).toBe(true);
+    expect(r.isSuspected).toBe(false);
+  });
+
+  it('table row 4 (named): originator publishing its own packet must NOT flag, even with bit 0', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(ORIGINATOR) }));
+    expect(r.relayed).toBe(false);
+    expect(r.isViolation).toBe(false);
+    expect(r.isSuspected).toBe(false);
+  });
+
+  it('table row 5: plaintext with bitfield field simply unset ⇒ suspected iff relayed, never confirmed', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, hasDecoded: true, gatewayId: gwId(GATEWAY) }));
+    expect(r.state).toBe('unknown');
+    expect(r.relayed).toBe(true);
+    expect(r.isSuspected).toBe(true);
+    expect(r.isViolation).toBe(false);
+  });
+
+  it('table row 6: encrypted with no decoded synthesized (unmatched PSK) ⇒ suspected iff relayed, never confirmed', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, hasDecoded: false, gatewayId: gwId(GATEWAY) }));
+    expect(r.state).toBe('unknown');
+    expect(r.bitfield).toBeNull();
+    expect(r.relayed).toBe(true);
+    expect(r.isSuspected).toBe(true);
+    expect(r.isViolation).toBe(false);
+  });
+
+  it('table row 7: encrypted with PSK matched (bitfield synthesized into decoded) ⇒ rows 1-4 apply', () => {
+    // By the time detectOkToMqttViolation is called, ingestServiceEnvelopeInner
+    // has already synthesized packet.decoded.bitfield from the decrypt result
+    // (§2(b)) — so a server-decrypted reception is indistinguishable here from
+    // a plaintext one, and reproduces row 3's confirmed-violation outcome.
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) }));
+    expect(r.isViolation).toBe(true);
+  });
+
+  it('table row 8: gatewayId null/absent ⇒ nothing recorded (relaying cannot be proven)', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 0 }));
+    expect(r.gatewayNodeNum).toBeNull();
+    expect(r.relayed).toBe(false);
+    expect(r.isViolation).toBe(false);
+    expect(r.isSuspected).toBe(false);
+  });
+
+  it('table row 9: malformed gatewayId ⇒ nothing recorded', () => {
+    const r = detectOkToMqttViolation(envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: 'not-a-gateway-id' }));
+    expect(r.gatewayNodeNum).toBeNull();
+    expect(r.relayed).toBe(false);
+    expect(r.isViolation).toBe(false);
+  });
+
+  it('table row 10: packet.from not numeric ⇒ nothing recorded', () => {
+    const r = detectOkToMqttViolation(envelope({ bitfield: 0, gatewayId: gwId(GATEWAY) }));
+    expect(r.fromNode).toBeNull();
+    expect(r.relayed).toBe(false);
+    expect(r.isViolation).toBe(false);
+  });
+
+  it('table row 11: fromNode=0 is compared like any other numeric value', () => {
+    const relayed = detectOkToMqttViolation(envelope({ from: 0, bitfield: 0, gatewayId: gwId(GATEWAY) }));
+    expect(relayed.fromNode).toBe(0);
+    expect(relayed.relayed).toBe(true);
+    expect(relayed.isViolation).toBe(true);
+
+    const selfPublish = detectOkToMqttViolation(envelope({ from: 0, bitfield: 0, gatewayId: gwId(0) }));
+    expect(selfPublish.relayed).toBe(false);
+    expect(selfPublish.isViolation).toBe(false);
+  });
+
+  it('table row 12: predicate is to-agnostic (broadcast vs DM produce the same outcome)', () => {
+    const broadcast = detectOkToMqttViolation(
+      envelope({ from: ORIGINATOR, to: 0xffffffff, bitfield: 0, gatewayId: gwId(GATEWAY) }),
+    );
+    const dm = detectOkToMqttViolation(
+      envelope({ from: ORIGINATOR, to: 0x99999999, bitfield: 0, gatewayId: gwId(GATEWAY) }),
+    );
+    expect(broadcast.isViolation).toBe(true);
+    expect(dm.isViolation).toBe(true);
+  });
+
+  it('table rows 13-14: bridge downlink and local-broker publish are evaluated identically (no direction concept in the predicate)', () => {
+    // Both mqttBridgeManager.handleDownlink and mqttBrokerManager.handlePublish
+    // pass the same ServiceEnvelopeShape into this pure function; there is no
+    // direction-specific branch here to diverge, so an identical envelope
+    // always yields an identical result regardless of which call site built it.
+    const a = envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) });
+    const b = envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) });
+    expect(detectOkToMqttViolation(a)).toEqual(detectOkToMqttViolation(b));
+  });
+
+  it('table row 15 / §2(f.1) (named): a gateway equal to our own localGatewayNodeNum must NOT flag, even with bit 0', () => {
+    const e = envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) });
+    const r = detectOkToMqttViolation(e, GATEWAY);
+    expect(r.selfGateway).toBe(true);
+    expect(r.relayed).toBe(false);
+    expect(r.isViolation).toBe(false);
+    expect(r.isSuspected).toBe(false);
+  });
+
+  it('§2(f.1) complement: localGatewayNodeNum = null ⇒ guard inert, falls back to the plain gateway≠originator test', () => {
+    const e = envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) });
+    const r = detectOkToMqttViolation(e, null);
+    expect(r.selfGateway).toBe(false);
+    expect(r.relayed).toBe(true);
+    expect(r.isViolation).toBe(true);
+  });
+
+  it('§2(f.1) complement: localGatewayNodeNum set but not matching ⇒ guard does not over-suppress, violation still flags', () => {
+    const e = envelope({ from: ORIGINATOR, bitfield: 0, gatewayId: gwId(GATEWAY) });
+    const OTHER_LOCAL_NODE = 0x33333333;
+    const r = detectOkToMqttViolation(e, OTHER_LOCAL_NODE);
+    expect(r.selfGateway).toBe(false);
+    expect(r.relayed).toBe(true);
+    expect(r.isViolation).toBe(true);
+  });
+
+  // Row 16 (pre-ingest-filter drops: topic/node/portnum pre-filtering) is out
+  // of scope for this pure function — those drops happen upstream, before an
+  // envelope ever reaches ingestServiceEnvelope, so detectOkToMqttViolation is
+  // never invoked for them. Nothing to unit test here; noted for table
+  // completeness (epic decision 3, #4114).
+});

--- a/src/server/utils/okToMqtt.ts
+++ b/src/server/utils/okToMqtt.ts
@@ -1,0 +1,217 @@
+/**
+ * `ok_to_mqtt` tri-state evaluator (#4114).
+ *
+ * Extracted from the formerly-private `MqttBridgeManager.evaluateOkToMqtt`
+ * (`src/server/mqttBridgeManager.ts:482-499` prior to this change) so the
+ * same bit-0 logic can serve two callers with opposite failure semantics:
+ *
+ * - **Uplink gate** (`MqttBridgeManager.evaluateOkToMqtt`, via
+ *   {@link allowsUplink}): fail-closed. An `'unknown'` result must NOT be
+ *   republished upstream — this preserves the original evaluator's
+ *   behavior byte-for-byte.
+ * - **Violation detection** ({@link detectOkToMqttViolation}): NOT
+ *   fail-closed. `'unknown'` means "suspected", never a confirmed
+ *   violation — a gateway that couldn't be proven to have violated the bit
+ *   must not be flagged as if it had.
+ *
+ * Mirrors firmware `MQTT::onSend` (MQTT.cpp:767-788), which checks bit 0 of
+ * `Data.bitfield` before relaying a packet to the configured broker.
+ */
+
+import type { ServiceEnvelopeShape } from '../mqttPacketFilter.js';
+import { channelDecryptionService } from '../services/channelDecryptionService.js';
+
+/**
+ * Tri-state result of resolving a packet's `ok_to_mqtt` preference.
+ *
+ * - `'yes'` — bit 0 of `Data.bitfield` is set: originator opted in to MQTT relay.
+ * - `'no'` — bit 0 is explicitly clear: originator opted out.
+ * - `'unknown'` — the bit could not be read (field absent, or the packet is
+ *   encrypted and could not be decrypted).
+ */
+export type OkToMqttState = 'yes' | 'no' | 'unknown';
+
+/**
+ * Read the `ok_to_mqtt` bit (bit 0) out of a raw `Data.bitfield` value.
+ * Pure. Mirrors firmware `MQTT::onSend` (MQTT.cpp:767-788), which treats a
+ * clear or absent bit as "do not uplink" (#4114).
+ *
+ * @param bitfield Raw `Data.bitfield` (protobuf field 9), or
+ *   `undefined`/`null` when the field wasn't present on the wire.
+ * @returns `'unknown'` when `bitfield` is not a finite number; otherwise
+ *   `'yes'` when bit 0 is set, `'no'` when it is clear.
+ */
+export function readBitfieldOkToMqtt(bitfield: number | null | undefined): OkToMqttState {
+  if (typeof bitfield !== 'number' || !Number.isFinite(bitfield)) return 'unknown';
+  return ((bitfield >>> 0) & 0x1) === 1 ? 'yes' : 'no';
+}
+
+/**
+ * Resolve the `ok_to_mqtt` tri-state for one ServiceEnvelope reception.
+ *
+ * Reproduces the control flow of the original
+ * `MqttBridgeManager.evaluateOkToMqtt` exactly (#4114):
+ *
+ *  1. `packet.decoded.bitfield` is a number → {@link readBitfieldOkToMqtt}.
+ *  2. Else, when `packet.encrypted` plus a numeric `packet.id` and
+ *     `packet.from` are all present → attempt
+ *     `channelDecryptionService.tryDecrypt(enc, id, from, channelHash)`;
+ *     success with a numeric `bitfield` → {@link readBitfieldOkToMqtt} on
+ *     it, otherwise → `'unknown'`.
+ *  3. Else → `'unknown'`.
+ *
+ * Deliberately does **not** gate on `channelDecryptionService.isEnabled()`
+ * — the original evaluator never checked it, and adding that gate now
+ * would change uplink behavior for installs running with decryption
+ * disabled. `tryDecrypt` already returns early/cheaply when disabled.
+ *
+ * @param envelope The decoded ServiceEnvelope reception.
+ * @returns The resolved tri-state. Mirrors firmware `MQTT::onSend`
+ *   (MQTT.cpp:767-788).
+ */
+export async function resolveOkToMqttForEnvelope(
+  envelope: ServiceEnvelopeShape,
+): Promise<OkToMqttState> {
+  const decoded = envelope.packet?.decoded;
+  if (decoded && typeof decoded.bitfield === 'number') {
+    return readBitfieldOkToMqtt(decoded.bitfield);
+  }
+
+  // Encrypted path — try decryption against the channel DB so we can read
+  // the originator's bitfield. If we can't decrypt, the bit is unknown.
+  const enc = envelope.packet?.encrypted;
+  const id = envelope.packet?.id;
+  const from = envelope.packet?.from;
+  if (!enc || typeof id !== 'number' || typeof from !== 'number') return 'unknown';
+
+  const channelHash = typeof envelope.packet?.channel === 'number'
+    ? envelope.packet.channel
+    : undefined;
+  const result = await channelDecryptionService.tryDecrypt(enc, id, from, channelHash);
+  if (!result.success || typeof result.bitfield !== 'number') return 'unknown';
+  return readBitfieldOkToMqtt(result.bitfield);
+}
+
+/**
+ * Fail-closed adapter for the uplink gate (#4114): only an explicit
+ * `'yes'` permits republishing a packet upstream. `'unknown'` (bit
+ * unreadable, decrypt failed, or no matching channel key) drops the
+ * packet, matching firmware's fail-closed behavior on public brokers.
+ *
+ * Do not use this for violation detection — see {@link detectOkToMqttViolation},
+ * which treats `'unknown'` as merely "suspected", not confirmed.
+ */
+export function allowsUplink(state: OkToMqttState): boolean {
+  return state === 'yes';
+}
+
+/**
+ * Parse a `!aabbccdd`-formatted gateway id back into its numeric nodeNum.
+ *
+ * Moved verbatim from `src/server/services/mqttPacketLogService.ts:183-187`
+ * (#4114) so both the packet-log row builder and the violation detector
+ * below share one implementation.
+ *
+ * @returns `null` for a missing/malformed id.
+ */
+export function parseGatewayNodeNum(id: string | null | undefined): number | null {
+  if (!id || !id.startsWith('!')) return null;
+  const n = parseInt(id.slice(1), 16);
+  return Number.isNaN(n) ? null : n >>> 0;
+}
+
+/** Result of {@link detectOkToMqttViolation} (#4114). */
+export interface OkToMqttViolationEval {
+  /** Tri-state `ok_to_mqtt` resolution for this reception. */
+  state: OkToMqttState;
+  /** Raw `Data.bitfield`, `>>> 0`-normalized. `null` when unreadable. */
+  bitfield: number | null;
+  /** Originator node number (`packet.from`), `>>> 0`-normalized. `null` when not numeric. */
+  fromNode: number | null;
+  /** Publishing gateway's node number, parsed from `envelope.gatewayId`. `null` when unparseable. */
+  gatewayNodeNum: number | null;
+  /**
+   * `true` when the publishing gateway is THIS source's own local gateway
+   * (`localGatewayNodeNum`). See Phase 1 spec §2(f.1): this is a
+   * belt-and-braces guard against MeshMonitor flagging its own operator,
+   * independent of — and not a replacement for — the bridge's echo
+   * suppression, which is not airtight (exact topic-string match + a
+   * 60s-TTL, 256-entry ring buffer; missable on topic rewrite, delayed
+   * redelivery, or eviction under load).
+   */
+  selfGateway: boolean;
+  /**
+   * `true` when a distinct, non-local gateway is confirmed to have relayed
+   * someone else's packet — i.e. attribution is provable at all.
+   */
+  relayed: boolean;
+  /** `true` when the bit was explicitly clear on a relayed reception. */
+  isViolation: boolean;
+  /** `true` when the bit could not be read on a relayed reception. */
+  isSuspected: boolean;
+}
+
+/**
+ * Detect whether one gateway reception is a confirmed or suspected
+ * `ok_to_mqtt` violation (#4114). Synchronous, pure, allocation-light.
+ *
+ * Reads ONLY `envelope.packet.decoded.bitfield`, `envelope.packet.from`,
+ * and `envelope.gatewayId` — it never decrypts. By the time ingest calls
+ * this, `ingestServiceEnvelopeInner` has already synthesized
+ * `packet.decoded` for the server-decrypt path (Phase 1 spec §2(b)), so
+ * the bit is available in plaintext form for every reception this function
+ * needs to classify.
+ *
+ * `localGatewayNodeNum` is THIS source's own gateway node number. When the
+ * publishing gateway matches it, the reception is neither a violation nor
+ * suspected — the self-echo guard of §2(f.1). This deliberately does NOT
+ * rely on the bridge's echo suppression (`matchesEcho`,
+ * `mqttBridgeManager.ts:817-821`), which is demonstrably missable (topic
+ * rewrite/canonicalisation by the upstream broker, redelivery delayed past
+ * its 60s TTL, or ring eviction under load — and `mqttBrokerManager`'s
+ * local-publish path has no echo suppression at all). Omit/pass `null`
+ * only when the caller genuinely has no local identity to compare against
+ * — do not remove this guard in favor of the echo suppression alone.
+ *
+ * @param envelope The decoded ServiceEnvelope reception.
+ * @param localGatewayNodeNum This source's own gateway node number, or
+ *   `null`/omitted when not yet known.
+ */
+export function detectOkToMqttViolation(
+  envelope: ServiceEnvelopeShape,
+  localGatewayNodeNum?: number | null,
+): OkToMqttViolationEval {
+  const decoded = envelope.packet?.decoded;
+  const bitfield = typeof decoded?.bitfield === 'number' ? decoded.bitfield >>> 0 : null;
+  const state = readBitfieldOkToMqtt(bitfield);
+
+  const from = envelope.packet?.from;
+  const fromNode = typeof from === 'number' ? from >>> 0 : null;
+
+  const gatewayNodeNum = parseGatewayNodeNum(envelope.gatewayId);
+
+  const selfGateway =
+    localGatewayNodeNum != null &&
+    gatewayNodeNum != null &&
+    Number(gatewayNodeNum) === Number(localGatewayNodeNum);
+
+  const relayed =
+    fromNode !== null &&
+    gatewayNodeNum !== null &&
+    Number(fromNode) !== Number(gatewayNodeNum) &&
+    !selfGateway;
+
+  const isViolation = state === 'no' && relayed;
+  const isSuspected = state === 'unknown' && relayed;
+
+  return {
+    state,
+    bitfield,
+    fromNode,
+    gatewayNodeNum,
+    selfGateway,
+    relayed,
+    isViolation,
+    isSuspected,
+  };
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -46,6 +46,7 @@ import {
   WaypointsRepository,
   MeshCoreRepository,
   MqttPacketLogRepository,
+  MqttOkToMqttViolationsRepository,
   AtakContactsRepository,
   EstimatedPositionsRepository,
   AutoFavoriteTargetsRepository,
@@ -483,6 +484,7 @@ class DatabaseService {
   public waypointsRepo: WaypointsRepository | null = null;
   public meshcoreRepo: MeshCoreRepository | null = null;
   public mqttPacketLogRepo: MqttPacketLogRepository | null = null;
+  public mqttOkToMqttViolationsRepo: MqttOkToMqttViolationsRepository | null = null;
   public atakContactsRepo: AtakContactsRepository | null = null;
   public estimatedPositionsRepo: EstimatedPositionsRepository | null = null;
   public autoFavoriteTargetsRepo: AutoFavoriteTargetsRepository | null = null;
@@ -673,6 +675,11 @@ class DatabaseService {
   get mqttPacketLog(): MqttPacketLogRepository {
     if (!this.mqttPacketLogRepo) throw new Error('Database not initialized');
     return this.mqttPacketLogRepo;
+  }
+
+  get mqttOkToMqttViolations(): MqttOkToMqttViolationsRepository {
+    if (!this.mqttOkToMqttViolationsRepo) throw new Error('Database not initialized');
+    return this.mqttOkToMqttViolationsRepo;
   }
 
   get atakContacts(): AtakContactsRepository {
@@ -920,6 +927,7 @@ class DatabaseService {
       this.waypointsRepo = new WaypointsRepository(drizzleDb, this.drizzleDbType);
       this.meshcoreRepo = new MeshCoreRepository(drizzleDb, this.drizzleDbType);
       this.mqttPacketLogRepo = new MqttPacketLogRepository(drizzleDb, this.drizzleDbType);
+      this.mqttOkToMqttViolationsRepo = new MqttOkToMqttViolationsRepository(drizzleDb, this.drizzleDbType);
       this.atakContactsRepo = new AtakContactsRepository(drizzleDb, this.drizzleDbType);
       this.estimatedPositionsRepo = new EstimatedPositionsRepository(drizzleDb, this.drizzleDbType);
       this.autoFavoriteTargetsRepo = new AutoFavoriteTargetsRepository(drizzleDb, this.drizzleDbType);


### PR DESCRIPTION
Phase 1 of the `ok_to_mqtt` violation-detection epic (#4114). **Backend only — no user-visible UI in this PR.**

## What this detects

Meshtastic packets carry an `ok_to_mqtt` bit (bit 0 of `Data.bitfield`) by which the originator signals consent to MQTT uplink. Firmware's `MQTT::onSend()` only enforces it when relaying *other* nodes' packets, and skips the check entirely when `isMqttServerAddressPrivate` is true — a pure IP-range test with no NAT/port-forward awareness. A gateway reaching its broker via a LAN-literal address that is *also* port-forwarded gets misclassified as private and silently relays opted-out traffic to what is effectively a public broker.

So: bit explicitly clear + publishing gateway ≠ originator ⇒ a **provable** violation. That is what this records.

## Scope note

Design items 1–3 of #4114 already shipped in the MQTT Packet Monitor epic (#4124) — MQTT is wired into the Packet Monitor, rows group per packet with a per-gateway receptions modal, and every envelope reaching `ingestServiceEnvelope` is logged with an outcome. This PR implements the remaining item 4, plus the gaps that turned out to block it.

## Changes

- **`src/server/utils/okToMqtt.ts` (new)** — extracts the formerly-private `MqttBridgeManager.evaluateOkToMqtt` into a shared **tri-state** evaluator (`yes`/`no`/`unknown`). `allowsUplink()` preserves the existing **fail-closed** uplink behavior exactly (`unknown` ⇒ don't uplink), while detection treats `unknown` as merely *suspected* — never a confirmed violation. Conflating those would either break uplink privacy or flood the feature with false accusations.
- **`bitfield` now survives server-side decrypt** (`mqttIngestion.ts`). It was being dropped when synthesizing `packet.decoded`, even though `channelDecryptionService.tryDecrypt` already returned it — without this the feature would be blind to all encrypted MQTT traffic.
- **Migration 128** — `bitfield` / `okToMqttViolation` / `topic` on `mqtt_packet_log`, plus a new retention-immune `mqtt_ok_to_mqtt_violations` table (90 d / 50k per source) swept by the *existing* 15-minute timer. The violation flag is a raw 0/1 int, not a boolean, so `MAX()` works under PostgreSQL and MySQL `ONLY_FULL_GROUP_BY`.
- **Self-echo guard** — MeshMonitor can never flag its own node as a violating gateway. See the note below.
- **Two cross-source endpoints** in `analysisRoutes.ts` (`/mqtt-violations/gateways`, `/mqtt-violations/packets`), gated per-source on `packetmonitor` via the existing `resolvePermittedSourceIds`. These are what Phase 3's report will consume.
- **`migrate-db` table list** updated so violation history survives a SQLite → PostgreSQL/MySQL migration.

## Self-echo: why an explicit guard

The spec initially assumed our own republished packets never reach ingest. Verification showed otherwise: `matchesEcho` matches on *exact topic-string equality + packetId* under the post-rewrite topic, with a 60 s TTL in a 256-entry ring evicting oldest-first — missable on broker topic rewrite, delayed redelivery, or eviction under load — and `mqttBrokerManager.handlePublish` has no echo suppression at all.

What actually saves us is that `handleUplink` republishes the payload byte-for-byte and rewrites only the topic, so `gatewayId` is never mutated and a missed echo still carries the *original* gateway's id. Since that's an implicit property rather than a guarantee, there's now an explicit `selfGateway` guard plus a test pinning the byte-for-byte property, so a future change to the uplink path fails visibly instead of silently producing false accusations. This matters especially alongside #4104's `ignoreOkToMqtt`, which deliberately republishes bit=0 packets.

## Behavior on upgrade

- **Forward-only.** No backfill is possible — the bit was never stored, so historical rows can't be classified retroactively. Expect empty results until new MQTT traffic arrives.
- **Violation recording is default ON** (`mqtt_oktomqtt_violation_log_enabled`, `'0'` ⇒ off, anything else including unset ⇒ on). Deliberately inverted from `mqtt_packet_log_enabled` so the feature works on installs that never touched settings; documented at both the constant and the getter.
- Volume is bounded by construction — a row requires a gateway that both relays someone else's packet *and* misreads its broker as private. On a healthy mesh the rate is zero.

## Testing

- Full Vitest suite: **11,418 passed / 0 failed**, `success: true` from the JSON reporter (not the summary line), with PostgreSQL and MySQL containers up — verified the multi-backend suites actually ran (`nodes.test.ts`: 52 PG + 56 MySQL) rather than skipping silently.
- `tsc --noEmit` clean; `lint:ci` clean; no `eslint-baseline.json` rule count grew.
- **Migration 128 executed against live PostgreSQL 16 and MySQL 8.4** — the repo's migration tests only assert against mock clients, so real dialect syntax is otherwise uncovered. Confirmed: DDL applies, idempotent on re-run, all 15 columns + 3 indexes on both, UNIQUE dedupe index rejects duplicates, and the `onConflictDoNothing`/`onDuplicateKeyUpdate` forms are true no-ops.
- New coverage includes the originator-self-publish case (must never flag), the self-gateway guard, malformed/missing gateway ids, unknown-bit non-flagging, dedupe-to-one-row, retention immunity, and per-source isolation on all 11 repository methods.

## Follow-ups (tracked in the epic plan)

Phase 2 adds the Packet Monitor badge — note its empty state must explain that the badge depends on the opt-in packet log, which is default OFF even though violation recording is default ON. Phase 3 adds the searchable gateway report under Analysis & Reports.

Plan: `docs/internal/dev-notes/MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aucxao43DBCoLHmbubvAS5