### PR TITLE
fix(nodes): rename the Nodes tab to Map and make Send DM focus the compose box (#4325)

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "Knoten",
+    "nav.nodes": "Karte",
     "nav.messages": "Nachrichten",
     "nav.channels": "Kanäle",
     "nav.info": "Info",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -50,7 +50,7 @@
   "auto_favorite.saved": "Auto-favorite settings saved",
   "auto_favorite.save_failed": "Failed to save auto-favorite settings",
   "auto_favorite.load_failed": "Failed to load auto-favorite config",
-  "nav.nodes": "Nodes",
+  "nav.nodes": "Map",
   "nav.messages": "Node Details",
   "nav.channels": "Channels",
   "nav.info": "Info",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "Nodos",
+    "nav.nodes": "Mapa",
     "nav.messages": "Mensajes",
     "nav.channels": "Canales",
     "nav.info": "Información",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "Nœuds",
+    "nav.nodes": "Carte",
     "nav.messages": "Messages",
     "nav.channels": "Canaux",
     "nav.info": "Info",

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "Noder",
+    "nav.nodes": "Kart",
     "nav.messages": "Meldinger",
     "nav.channels": "Kanaler",
     "nav.info": "Info",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -50,7 +50,7 @@
     "auto_favorite.saved": "Ustawienia automatycznego dodawania do ulubionych zostały zapisane",
     "auto_favorite.save_failed": "Nie udało się zapisać ustawień automatycznego dodawania do ulubionych",
     "auto_favorite.load_failed": "Nie udało się wczytać konfiguracji automatycznego dodawania do ulubionych",
-    "nav.nodes": "Węzły",
+    "nav.nodes": "Mapa",
     "nav.channels": "Kanały",
     "nav.info": "Info",
     "nav.messages": "Szczegóły węzła",

--- a/public/locales/pt_BR.json
+++ b/public/locales/pt_BR.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "Nós",
+    "nav.nodes": "Mapa",
     "nav.messages": "Mensagens",
     "nav.channels": "Canais",
     "nav.info": "Info",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "Узлы",
+    "nav.nodes": "Карта",
     "nav.messages": "Сообщения",
     "nav.channels": "Каналы",
     "nav.info": "Инфо",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -1,5 +1,5 @@
 {
-    "nav.nodes": "节点",
+    "nav.nodes": "地图",
     "nav.messages": "消息",
     "nav.channels": "频道",
     "nav.info": "信息",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -488,6 +488,9 @@ function App() {
     newMessage,
     setNewMessage,
     openDmWithDraft,
+    openDmForCompose,
+    pendingComposeFocus,
+    clearComposeFocus,
     replyingTo,
     setReplyingTo,
     pendingMessages: _pendingMessages, // Not used directly - we use pendingMessagesRef for interval access
@@ -3600,6 +3603,7 @@ function App() {
                   toggleFavoriteLock={toggleFavoriteLock}
                   setActiveTab={setActiveTab}
                   setSelectedDMNode={setSelectedDMNode}
+                  openDmForCompose={openDmForCompose}
                   markerRefs={markerRefs}
                   traceroutePathsElements={traceroutePathsElements}
                   selectedNodeTraceroute={selectedNodeTraceroute}
@@ -3750,6 +3754,8 @@ function App() {
             connectionStatus={connectionStatus}
             selectedDMNode={selectedDMNode}
             setSelectedDMNode={setSelectedDMNode}
+            pendingComposeFocus={pendingComposeFocus}
+            clearComposeFocus={clearComposeFocus}
             newMessage={newMessage}
             setNewMessage={setNewMessage}
             replyingTo={replyingTo}

--- a/src/components/MessagesTab.composeFocus.test.tsx
+++ b/src/components/MessagesTab.composeFocus.test.tsx
@@ -212,6 +212,20 @@ describe('MessagesTab compose focus (#4325)', () => {
     expect(clearComposeFocus).toHaveBeenCalled();
   });
 
+  it('ignores an empty-nodeId request rather than focusing the empty conversation', () => {
+    // `handleDMClick` falls back to '' when a node somehow has no user.id.
+    // Both guards test truthiness, so '' short-circuits before any focus —
+    // asserted here so that stays true if the guards are ever rewritten.
+    const clearComposeFocus = vi.fn();
+    render(
+      <MessagesTab
+        {...makeProps({ pendingComposeFocus: '', selectedDMNode: '', clearComposeFocus })}
+      />,
+    );
+
+    expect(document.activeElement).not.toBe(textarea());
+  });
+
   it('still focuses when the compose box mounts after the request arrives', () => {
     // The regression: on the first pass there is no textarea (here modelled via
     // messages:write being absent). A request consumed against the null ref

--- a/src/components/MessagesTab.composeFocus.test.tsx
+++ b/src/components/MessagesTab.composeFocus.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * "Send Direct Message" compose focus (#4325).
+ *
+ * The node list's Send DM button already selected the node and opened the
+ * conversation — what it didn't do was leave you able to type, so the button
+ * dropped you on a compose box you still had to click into. MessagesTab now
+ * honors a `pendingComposeFocus` request.
+ *
+ * The load-bearing case is the LAST test: the request arrives before the
+ * textarea exists (navigating in mounts this tab with the conversation pane
+ * rendering afterwards). An effect alone consumed the request against a null
+ * ref and the box never got focused — that was the actual bug, and it is why
+ * the textarea uses a callback ref.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render } from '@testing-library/react';
+import MessagesTab from './MessagesTab';
+import type { MeshMessage } from '../types/message';
+
+vi.mock('../hooks/useServerData', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useDeviceNodes: () => new Set<number>(),
+  useTelemetryNodes: () => ({
+    nodesWithTelemetry: new Set(),
+    nodesWithWeather: new Set(),
+    nodesWithEstimatedPosition: new Set(),
+    nodesWithPKC: new Set(),
+    unmappedCount: 0,
+    estimatedUncertainty: {},
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../contexts/SettingsContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSettings: () => ({ nodeHopsCalculation: 'actual', distanceUnit: 'km' }),
+  useNotificationMuteSettings: () => ({
+    isDMMuted: () => false,
+    muteDM: async () => {},
+    unmuteDM: async () => {},
+    isChannelMuted: () => false,
+    muteChannel: async () => {},
+    unmuteChannel: async () => {},
+  }),
+}));
+
+vi.mock('../contexts/MapContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMapContext: () => ({ traceroutes: [], neighborInfo: [], setNeighborInfo: () => {} }),
+}));
+
+vi.mock('./ToastContainer', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useToast: () => ({ showToast: () => {} }),
+}));
+
+vi.mock('../hooks/useCsrfFetch', () => ({ useCsrfFetch: () => vi.fn() }));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useQueryClient: () => ({}),
+}));
+
+vi.mock('./TelemetryGraphs', () => ({ default: () => null }));
+vi.mock('./SmartHopsGraphs', () => ({ default: () => null }));
+vi.mock('./LinkQualityGraph', () => ({ default: () => null }));
+vi.mock('./PacketStatsChart', () => ({ default: () => null }));
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      (opts && typeof opts === 'object' && 'defaultValue' in opts
+        ? (opts.defaultValue as string)
+        : undefined) ?? key,
+  }),
+}));
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+const CURRENT_NODE_ID = '!cccccccc';
+const DM_NODE_ID = '!aaaaaaaa';
+const OTHER_NODE_ID = '!bbbbbbbb';
+
+const theirMsg: MeshMessage = {
+  id: 'src1_1_7002',
+  from: DM_NODE_ID,
+  to: CURRENT_NODE_ID,
+  fromNodeId: DM_NODE_ID,
+  toNodeId: CURRENT_NODE_ID,
+  text: 'hi back',
+  channel: -1,
+  portnum: 1,
+  timestamp: new Date('2026-07-21T12:00:05Z'),
+};
+
+type MessagesTabProps = React.ComponentProps<typeof MessagesTab>;
+
+function makeProps(overrides: Partial<MessagesTabProps> = {}): MessagesTabProps {
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  return {
+    processedNodes: [],
+    nodes: [],
+    messages: [theirMsg],
+    currentNodeId: CURRENT_NODE_ID,
+    connectionStatus: 'connected',
+    selectedDMNode: DM_NODE_ID,
+    setSelectedDMNode: noop,
+    newMessage: '',
+    setNewMessage: noop,
+    replyingTo: null,
+    setReplyingTo: noop,
+    unreadCountsData: null,
+    markMessagesAsRead: asyncNoop,
+    nodeFilter: '',
+    setNodeFilter: noop,
+    messagesNodeFilter: '',
+    setMessagesNodeFilter: noop,
+    dmFilter: 'all' as const,
+    setDmFilter: noop,
+    securityFilter: 'all' as const,
+    channels: [{ id: 0, name: 'Primary', psk: '', uplinkEnabled: true, downlinkEnabled: true }],
+    channelFilter: 'all' as const,
+    showIncompleteNodes: false,
+    showNodeFilterPopup: false,
+    setShowNodeFilterPopup: noop,
+    isMessagesNodeListCollapsed: false,
+    setIsMessagesNodeListCollapsed: noop,
+    tracerouteLoading: null,
+    positionLoading: null,
+    nodeInfoLoading: null,
+    neighborInfoLoading: null,
+    telemetryRequestLoading: null,
+    timeFormat: '24' as const,
+    dateFormat: 'MM/DD/YYYY' as const,
+    temperatureUnit: 'C' as const,
+    telemetryVisualizationHours: 24,
+    distanceUnit: 'km' as const,
+    baseUrl: 'http://localhost',
+    hasPermission: () => true,
+    handleSendDirectMessage: asyncNoop,
+    onSendBell: asyncNoop,
+    handleResendMessage: asyncNoop,
+    handleTraceroute: asyncNoop,
+    handleExchangePosition: asyncNoop,
+    handleExchangeNodeInfo: asyncNoop,
+    handleRequestNeighborInfo: asyncNoop,
+    handleRequestTelemetry: asyncNoop,
+    handleDeleteMessage: asyncNoop,
+    handleSenderClick: noop,
+    handleSendTapback: noop,
+    getRecentTraceroute: () => null,
+    toggleIgnored: asyncNoop,
+    toggleHideFromMap: asyncNoop,
+    toggleFavorite: asyncNoop,
+    toggleFavoriteLock: asyncNoop,
+    setShowTracerouteHistoryModal: noop,
+    setShowPurgeDataModal: noop,
+    setShowPositionOverrideModal: noop,
+    setEmojiPickerMessage: noop,
+    shouldShowData: () => true,
+    handleShowOnMap: noop,
+    dmMessagesContainerRef: { current: null },
+    mqttReadOnly: false,
+    ...overrides,
+  } as unknown as MessagesTabProps;
+}
+
+const textarea = () => document.querySelector('textarea.message-input');
+
+describe('MessagesTab compose focus (#4325)', () => {
+  it('focuses the compose box when a request targets the selected node', () => {
+    const clearComposeFocus = vi.fn();
+    render(<MessagesTab {...makeProps({ pendingComposeFocus: DM_NODE_ID, clearComposeFocus })} />);
+
+    expect(textarea()).not.toBeNull();
+    expect(document.activeElement).toBe(textarea());
+    expect(clearComposeFocus).toHaveBeenCalled();
+  });
+
+  it('does not steal focus when no request is pending', () => {
+    const clearComposeFocus = vi.fn();
+    render(<MessagesTab {...makeProps({ pendingComposeFocus: null, clearComposeFocus })} />);
+
+    expect(textarea()).not.toBeNull();
+    expect(document.activeElement).not.toBe(textarea());
+    expect(clearComposeFocus).not.toHaveBeenCalled();
+  });
+
+  it('drops a stale request aimed at a different node without focusing', () => {
+    const clearComposeFocus = vi.fn();
+    render(
+      <MessagesTab
+        {...makeProps({ pendingComposeFocus: OTHER_NODE_ID, clearComposeFocus })}
+      />,
+    );
+
+    expect(document.activeElement).not.toBe(textarea());
+    // Consumed anyway, so it can't fire later against the wrong conversation.
+    expect(clearComposeFocus).toHaveBeenCalled();
+  });
+
+  it('still focuses when the compose box mounts after the request arrives', () => {
+    // The regression: on the first pass there is no textarea (here modelled via
+    // messages:write being absent). A request consumed against the null ref
+    // would be lost; it must survive until the box actually mounts.
+    const clearComposeFocus = vi.fn();
+    const { rerender } = render(
+      <MessagesTab
+        {...makeProps({
+          pendingComposeFocus: DM_NODE_ID,
+          clearComposeFocus,
+          hasPermission: () => false,
+        })}
+      />,
+    );
+    expect(textarea()).toBeNull();
+    expect(clearComposeFocus).not.toHaveBeenCalled();
+
+    rerender(
+      <MessagesTab
+        {...makeProps({
+          pendingComposeFocus: DM_NODE_ID,
+          clearComposeFocus,
+          hasPermission: () => true,
+        })}
+      />,
+    );
+
+    expect(textarea()).not.toBeNull();
+    expect(document.activeElement).toBe(textarea());
+    expect(clearComposeFocus).toHaveBeenCalled();
+  });
+});

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -122,6 +122,10 @@ export interface MessagesTabProps {
 
   // Selected state
   selectedDMNode: string | null;
+  /** Node whose compose box the node list asked us to focus (#4325), or null. */
+  pendingComposeFocus?: string | null;
+  /** Consume the focus request above. */
+  clearComposeFocus?: () => void;
   setSelectedDMNode: (nodeId: string) => void;
 
   // Message input
@@ -228,6 +232,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   txDisabled = false,
   selectedDMNode,
   setSelectedDMNode,
+  pendingComposeFocus = null,
+  clearComposeFocus,
   newMessage,
   setNewMessage,
   replyingTo,
@@ -525,6 +531,48 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   const dmMessageInputRef = useRef<HTMLTextAreaElement>(null);
 
   useAutoResizeTextarea(dmMessageInputRef, newMessage);
+
+  // Honor a "Send Direct Message" focus request from the node list (#4325).
+  //
+  // Two paths, because the request usually arrives BEFORE the compose textarea
+  // exists: navigating in from the node list mounts this tab, and on that first
+  // pass the conversation pane (and its textarea) has not rendered yet. An
+  // effect alone therefore fires against a null ref and, if it consumed the
+  // request, the box would never get focused — that was the original bug.
+  //
+  //  - `attachDmInput` (callback ref) fires the moment the textarea mounts and
+  //    focuses it if a request is outstanding. This is the normal path.
+  //  - The effect below covers the case where the textarea is ALREADY mounted
+  //    when the request lands (same conversation re-requested), which the
+  //    callback ref cannot see because it does not re-fire.
+  //
+  // A request is only consumed once actually honored, except for a stale one
+  // aimed at a different node, which is dropped so it can't fire later.
+  const composeFocusTargetRef = useRef<string | null>(null);
+  composeFocusTargetRef.current =
+    pendingComposeFocus && pendingComposeFocus === selectedDMNode ? pendingComposeFocus : null;
+  const clearComposeFocusRef = useRef(clearComposeFocus);
+  clearComposeFocusRef.current = clearComposeFocus;
+
+  const attachDmInput = useCallback((el: HTMLTextAreaElement | null) => {
+    dmMessageInputRef.current = el;
+    if (el && composeFocusTargetRef.current) {
+      el.focus();
+      composeFocusTargetRef.current = null;
+      clearComposeFocusRef.current?.();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!pendingComposeFocus || !clearComposeFocus) return;
+    if (pendingComposeFocus !== selectedDMNode) {
+      clearComposeFocus();
+      return;
+    }
+    if (!dmMessageInputRef.current) return; // textarea not mounted yet — attachDmInput will take it
+    dmMessageInputRef.current.focus();
+    clearComposeFocus();
+  }, [pendingComposeFocus, selectedDMNode, clearComposeFocus]);
 
   // Helper functions
   const getNodeName = useCallback(
@@ -1807,7 +1855,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   <div className="message-input-container">
                     <div className="input-with-counter">
                       <textarea
-                        ref={dmMessageInputRef}
+                        ref={attachDmInput}
                         value={newMessage}
                         onChange={e => setNewMessage(e.target.value)}
                         onFocus={scrollInputIntoView}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -68,6 +68,8 @@ interface NodesTabProps {
   toggleFavoriteLock?: (node: DeviceInfo, event: React.MouseEvent) => Promise<void>;
   setActiveTab: (tab: TabType) => void;
   setSelectedDMNode: (nodeId: string) => void;
+  /** Select a node for a new DM and ask the DM view to focus its compose box (#4325). */
+  openDmForCompose: (nodeId: string) => void;
   markerRefs: React.MutableRefObject<Map<string, LeafletMarker>>;
   traceroutePathsElements: React.ReactNode;
   selectedNodeTraceroute: React.ReactNode;
@@ -345,6 +347,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   toggleFavoriteLock,
   setActiveTab,
   setSelectedDMNode,
+  openDmForCompose,
   markerRefs,
   traceroutePathsElements,
   selectedNodeTraceroute,
@@ -1094,13 +1097,17 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     };
   }, [toggleFavoriteLock]);
 
+  // "Send Direct Message" (#4325). Selecting the node already opened the
+  // conversation; openDmForCompose additionally asks the DM view to focus its
+  // compose box, so the button leaves you able to type instead of on a
+  // conversation you still have to click into.
   const handleDMClick = useCallback((node: DeviceInfo) => {
     return (e: React.MouseEvent) => {
       e.stopPropagation();
-      setSelectedDMNode(node.user?.id || '');
+      openDmForCompose(node.user?.id || '');
       setActiveTab('messages');
     };
-  }, [setSelectedDMNode, setActiveTab]);
+  }, [openDmForCompose, setActiveTab]);
 
   const handleCopyNodeInfoClick = useCallback((node: DeviceInfo) => {
     return (e: React.MouseEvent) => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -174,6 +174,13 @@ const Sidebar: React.FC<SidebarProps> = ({
       <nav className="sidebar-nav">
         <SectionHeader title={t('nav.section_main')} />
         <div className="sidebar-section">
+          {/* Labelled "Map" (#4325) — the tab is the map + node list, and the
+              Map icon never matched the old "Nodes" label. The `nodes` tab id
+              and the `nav.nodes` locale key are deliberately unchanged: the id
+              is part of the route (/source/:id/nodes) so renaming it would
+              break existing bookmarks, and the key is what every locale file
+              is already translated against. Same divergence as `nav.messages`,
+              which reads "Node Details". */}
           <NavItem id="nodes" label={t('nav.nodes')} icon={icon('nodes')} />
           {hasAnyChannelPermission() && (
             <NavItem

--- a/src/contexts/MessagingContext.tsx
+++ b/src/contexts/MessagingContext.tsx
@@ -20,6 +20,18 @@ interface MessagingContextType {
   setNewMessage: React.Dispatch<React.SetStateAction<string>>;
   /** Select a DM node and pre-fill the compose draft atomically (survives the #4183 draft-scoping clear). */
   openDmWithDraft: (nodeId: string, message: string) => void;
+  /**
+   * Select a DM node for composing and ask the DM view to focus its compose box
+   * once it renders (#4325). Used by the node list's "Send Direct Message"
+   * button: without the focus request the button lands you on the conversation
+   * with an empty, unfocused textarea, so "Send DM" didn't actually let you
+   * start typing.
+   */
+  openDmForCompose: (nodeId: string) => void;
+  /** Node whose compose box is waiting to be focused, or null. */
+  pendingComposeFocus: string | null;
+  /** Consume the focus request — call after focusing (or when it can't be honored). */
+  clearComposeFocus: () => void;
   replyingTo: MeshMessage | null;
   setReplyingTo: React.Dispatch<React.SetStateAction<MeshMessage | null>>;
   pendingMessages: Map<string, MeshMessage>;
@@ -88,6 +100,24 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
     setNewMessage(message);
   }, []);
 
+  // "Send Direct Message" from the node list (#4325). Selecting the node was
+  // already enough to open the conversation, but the compose box was left
+  // unfocused, so the button dropped you somewhere you still had to click
+  // before typing. The DM view honors this request once it has rendered a
+  // compose box for the same node, then clears it.
+  const [pendingComposeFocus, setPendingComposeFocus] = useState<string | null>(null);
+
+  const openDmForCompose = useCallback((nodeId: string) => {
+    // Reuse the draft-safe selection path so the empty draft we want isn't
+    // racing the #4183 scoping effect.
+    composeConvKeyRef.current = `dm:${nodeId}`;
+    setSelectedDMNode(nodeId);
+    setNewMessage('');
+    setPendingComposeFocus(nodeId);
+  }, []);
+
+  const clearComposeFocus = useCallback(() => setPendingComposeFocus(null), []);
+
   // Use TanStack Query hooks for unread counts - only enable when authenticated.
   // Exclude MQTT messages from the count when the user has opted to hide them,
   // so the sidebar dot and channel badges don't light up for MQTT-only traffic.
@@ -133,6 +163,9 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
     newMessage,
     setNewMessage,
     openDmWithDraft,
+    openDmForCompose,
+    pendingComposeFocus,
+    clearComposeFocus,
     replyingTo,
     setReplyingTo,
     pendingMessages,
@@ -151,6 +184,7 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
     selectedChannel, setSelectedChannel,
     newMessage, setNewMessage,
     openDmWithDraft,
+    openDmForCompose, pendingComposeFocus, clearComposeFocus,
     replyingTo, setReplyingTo,
     pendingMessages, setPendingMessages,
     unreadCounts, setUnreadCounts,


### PR DESCRIPTION
Addresses #4325.

## 1. "Nodes" tab → "Map"

The tab's Lucide `Map` icon never matched its "Nodes" label. Rather than swap the icon, the label now matches what the tab actually is — a map with a node list beside it. Translated across every locale that carries the key (`sv.json` is an all-placeholder file and stays empty).

**Deliberately not renamed:** the `nodes` tab id and the `nav.nodes` locale key.
- The id is part of the route (`/source/:id/nodes`), so renaming it breaks existing bookmarks and deep links.
- The key is what all nine locale files are already translated against.

This is the same key/label divergence `nav.messages` already carries (it reads "Node Details").

## 2. "Send DM" focuses the compose box

**The issue's diagnosis was not quite right,** and it changed the fix. It reported the button "just navigates to the Node Details tab — it doesn't open a message compose view." Driving the real app shows it already selected the node and opened the conversation, with the correct `Send direct message to <node>...` compose box rendered.

What it did **not** do was focus that box. So pressing "Send DM" left you on a conversation you still had to click into before typing — which is what makes the label feel wrong.

`MessagingContext` gains `openDmForCompose(nodeId)`: selects the node via the draft-safe path (so the empty draft doesn't race the #4183 scoping effect) and records a focus request the DM view consumes.

### The part that took two attempts

Navigating in from the node list mounts `MessagesTab` with the conversation pane rendering on a later pass. A `useEffect` alone therefore fires against a **null** ref — and consuming the request there means the box is never focused. That was the first implementation; it typechecked, looked right, and **failed in the browser**.

The textarea now takes a **callback ref** that focuses the moment it mounts. The effect is retained only for the already-mounted case (same conversation re-requested), which a callback ref cannot see because it does not re-fire. A request aimed at a different node is dropped rather than left to fire later against the wrong conversation.

## Verification

Both changes driven against the running dev container, not just unit-tested:

- Sidebar nav renders `Map` / `Channels` / `Node Details`.
- Clicking "Send Direct Message" on a node row lands on the conversation with `document.activeElement === textarea.message-input` and an empty draft.
- Typing works immediately; switching to a different node's DM clears the draft (no #4183 leak) and focuses the new box.

`MessagesTab.composeFocus.test.tsx` covers four cases: focus on request, no focus without a request, stale cross-node request dropped, and the mount-later path. **The mount-later test fails without the callback ref** — verified by reverting it.

- Full suite: **10,879 passed, 0 failed** across 776 in-repo suite files
- `npx tsc --noEmit` clean; `npm run lint:ci` clean (no baseline growth)

## Not addressed

The issue's other half: the "Node Details" tab still uses the `directMessages` (Mail) icon, which reads as "compose a message" for what is now a details view. Left out because this change was scoped to the rename plus the button — happy to add the icon swap here if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZtasD4tS76xq2PTDHMA5o