### PR TITLE
fix(mqtt): page and sort ok_to_mqtt violations in SQL, fixes #4330

### DIFF
--- a/docs/internal/dev-notes/MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md
+++ b/docs/internal/dev-notes/MQTT_OK_TO_MQTT_VIOLATIONS_EPIC.md
@@ -11,10 +11,27 @@
 | 2 — Packet Monitor badge + per-gateway attribution | #4328 | badge, four-state marker, detail-view column |
 | 3 — Reports view | #4331 | gateway summary + drill-down, window control, CSV, unproven toggle |
 
-**Follow-up filed:** #4330 — the endpoints cap at 2000 rows and never pass `sort`/`dir` to SQL,
-so rows past offset 2000 are unreachable and ascending sorts over a saturated scan are wrong.
-Phase 3 mitigates honestly in the UI (`2,000+`, clamped paging, two distinct warnings); the
-backend fix is tracked separately. **Revisit Phase 3's cap warnings when #4330 lands.**
+**Follow-up #4330 — RESOLVED** (see below). The endpoints capped at 2000 rows and never passed
+`sort`/`dir` to SQL, so rows past offset 2000 were unreachable and ascending sorts over a
+saturated scan were wrong. Phase 3 mitigated honestly in the UI; #4330 then fixed the backend:
+
+- **`includeUnknown=false` (the default) is now fully fixed** — `sort`/`dir`/`limit`/`offset` push
+  into SQL, `total` is an exact `COUNT`, every row at every offset is reachable. No cap.
+- **`includeUnknown=true` keeps the in-handler merge** (two differently-shaped tables must be
+  interleaved before ordering) and therefore keeps a cap, deliberately and narrowly. Saturation is
+  far less likely there: the suspected side is already bounded by `mqtt_packet_log`'s own retention
+  (24 h default) and row cap. A SQL `UNION` was considered and declined — dialect-correct union
+  over two differently-shaped tables plus an aggregate-over-union for the summary was judged too
+  much query-layer risk for the benefit.
+- **New response contract: `capApplied: boolean` + `scanCap: number`** on both endpoints.
+  `capApplied` is **always `false`** on the default path, and `true` on the opt-in path only when a
+  pre-merge fetch actually saturated. **The UI must gate every cap affordance on `capApplied`, never
+  on `total >= cap`** — that inference was the bug's frontend twin: on a mesh with >2000 violations
+  and everything reachable, it rendered `2,000+`, clamped paging to hide reachable rows, and showed
+  false warnings. An existing Phase 3 test had encoded exactly that wrong inference.
+- Trap re-encountered: on the gateways endpoint `sourceIds` is attached from a **separate**
+  `getGatewaySourceIds` query inside the merge loop. Skipping the merge on the fast path silently
+  returns `sourceIds: []` for every row. Guarded with a test.
 
 ## Goal
 

--- a/src/components/Analysis/MqttViolationsReport.test.tsx
+++ b/src/components/Analysis/MqttViolationsReport.test.tsx
@@ -56,11 +56,12 @@ import api, { ApiError } from '../../services/api';
 import { downloadTextFile } from '../../utils/nodeExport';
 import { ToastProvider } from '../ToastContainer';
 import MqttViolationsReport from './MqttViolationsReport';
-import type {
-  ViolationGatewayRow,
-  ViolationGatewaysResponse,
-  ViolationPacketRow,
-  ViolationPacketsResponse,
+import {
+  API_SCAN_CAP,
+  type ViolationGatewayRow,
+  type ViolationGatewaysResponse,
+  type ViolationPacketRow,
+  type ViolationPacketsResponse,
 } from './mqttViolationTypes';
 
 function renderReport() {
@@ -105,6 +106,10 @@ function baseResponse(overrides: Partial<ViolationGatewaysResponse> = {}): {
       suspectedAvailable: false,
       suspectedWindowMs: 0,
       sources: ['mqtt-a'],
+      // Default-path default: the server never applies the cap on this path
+      // (#4330) — tests that want a saturated opt-in scan must override both.
+      capApplied: false,
+      scanCap: API_SCAN_CAP,
       ...overrides,
     },
   };
@@ -158,6 +163,8 @@ function packetsResponse(overrides: Partial<ViolationPacketsResponse> = {}): {
       suspectedWindowMs: 0,
       sources: ['mqtt-a'],
       gateway: '!433e0f28',
+      capApplied: false,
+      scanCap: API_SCAN_CAP,
       ...overrides,
     },
   };
@@ -311,12 +318,25 @@ describe('MqttViolationsReport', () => {
     expect(url).toContain('offset=0');
   });
 
-  it('test 7: cap honesty — 2,000+ label, cap warnings, and clamped pager', async () => {
+  // #4330: capApplied must gate everything cap-related — never `total >= cap`.
+  // Prior to the fix this test asserted the old `total >= API_SCAN_CAP`
+  // inference without ever setting `capApplied`; it now explicitly opts in
+  // (`capApplied: true`), which is the only case (opt-in scan that actually
+  // saturated) where the server ever reports it.
+  it('test 7: opt-in capApplied=true — 2,000+ label, cap warnings, and clamped pager', async () => {
     const user = userEvent.setup();
     vi.mocked(api.get).mockResolvedValue(
-      baseResponse({ gateways: [gatewayRow()], total: 5000, limit: 50, offset: 0 }),
+      baseResponse({
+        gateways: [gatewayRow()],
+        total: 5000,
+        limit: 50,
+        offset: 0,
+        includeUnknown: true,
+        capApplied: true,
+      }),
     );
     renderReport();
+    await user.click(screen.getByRole('checkbox', { name: /Include unproven/i }));
     await user.click(screen.getByRole('button', { name: /Run report/i }));
 
     expect(await screen.findByText(/2,000\+ gateways/)).toBeInTheDocument();
@@ -332,6 +352,8 @@ describe('MqttViolationsReport', () => {
         total: 5000,
         limit: 50,
         offset: 0,
+        includeUnknown: true,
+        capApplied: true,
       }),
     );
     await user.click(screen.getByRole('button', { name: 'Confirmed' }));
@@ -339,6 +361,71 @@ describe('MqttViolationsReport', () => {
     expect(
       await screen.findByText(/Sorting ascending inside a capped scan/i),
     ).toBeInTheDocument();
+  });
+
+  it('test 7b (#4330 regression): default path, total above scanCap but capApplied=false renders the real total, offers real paging, and shows no cap warnings', async () => {
+    const user = userEvent.setup();
+    // 2,268 mirrors the live-system number cited in issue #4330 — every row
+    // is reachable on the default path even though it exceeds the 2,000 cap.
+    vi.mocked(api.get).mockResolvedValue(
+      baseResponse({
+        gateways: [gatewayRow()],
+        total: 2268,
+        limit: 50,
+        offset: 0,
+        capApplied: false,
+      }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+
+    // Real total, not the old "2,000+" clamp.
+    expect(await screen.findByText('2,268 gateways')).toBeInTheDocument();
+    expect(screen.queryByText(/2,000\+ gateways/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Showing the first 2,000 rows/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Sorting ascending inside a capped scan/i)).not.toBeInTheDocument();
+    // Paging reaches past the old 2000-row/40-page clamp: ceil(2268/50) = 46.
+    expect(screen.getByText('Page 1 of 46')).toBeInTheDocument();
+
+    // Ascending sort must not trigger the "capped scan" caveat either — no
+    // rows were dropped before ordering on this path.
+    vi.mocked(api.get).mockResolvedValue(
+      baseResponse({
+        gateways: [gatewayRow()],
+        total: 2268,
+        limit: 50,
+        offset: 0,
+        capApplied: false,
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Confirmed' }));
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('2,268 gateways')).toBeInTheDocument();
+    expect(screen.queryByText(/Sorting ascending inside a capped scan/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 46')).toBeInTheDocument();
+  });
+
+  it('test 7c: opt-in response with capApplied=false renders no cap warnings', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue(
+      baseResponse({
+        gateways: [gatewayRow()],
+        total: 2268,
+        limit: 50,
+        offset: 0,
+        includeUnknown: true,
+        suspectedAvailable: true,
+        capApplied: false,
+      }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('checkbox', { name: /Include unproven/i }));
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+
+    expect(await screen.findByText('2,268 gateways')).toBeInTheDocument();
+    expect(screen.queryByText(/2,000\+ gateways/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Showing the first 2,000 rows/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Sorting ascending inside a capped scan/i)).not.toBeInTheDocument();
   });
 
   it('test 8: includeUnknown toggle changes request and rendering', async () => {
@@ -733,6 +820,125 @@ describe('MqttViolationsReport', () => {
         (call) => String(call[0]).includes('/mqtt-violations/packets') && String(call[0]).includes('limit=2000'),
       );
     expect(exportCall).toBeDefined();
+  });
+
+  it('test 9b (#4330 regression): drill-down default path, total above scanCap but capApplied=false renders the real total/pager and no cap warnings', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () => baseResponse({ gateways: [gatewayRow()], total: 1 }),
+      () =>
+        packetsResponse({
+          violations: [packetRow()],
+          total: 3000,
+          limit: 100,
+          offset: 0,
+          capApplied: false,
+        }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!433e0f28');
+
+    const row = screen.getByText('!433e0f28').closest('tr')!;
+    await user.click(row);
+    await screen.findByText('violation');
+
+    const detailCell = screen.getByText(/Violating packets published by/i).closest('td')!;
+    // ceil(3000/100) = 30 pages, well past the old 20-page (2000/100) clamp.
+    expect(within(detailCell).getByText('Page 1 of 30')).toBeInTheDocument();
+    expect(
+      within(detailCell).queryByText(/Showing the first 2,000 rows/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(detailCell).queryByText(/Sorting ascending inside a capped scan/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('test 9c: drill-down opt-in capApplied=true renders the cap warning, clamped pager, and ascending variant', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () =>
+        baseResponse({
+          gateways: [gatewayRow()],
+          total: 1,
+          includeUnknown: true,
+          suspectedAvailable: true,
+        }),
+      () =>
+        packetsResponse({
+          violations: [packetRow()],
+          total: 5000,
+          limit: 100,
+          offset: 0,
+          includeUnknown: true,
+          suspectedAvailable: true,
+          capApplied: true,
+        }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('checkbox', { name: /Include unproven/i }));
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!433e0f28');
+
+    const row = screen.getByText('!433e0f28').closest('tr')!;
+    await user.click(row);
+    await screen.findByText('violation');
+
+    const detailCell = screen.getByText(/Violating packets published by/i).closest('td')!;
+    expect(
+      within(detailCell).getByText(/Showing the first 2,000 rows/i),
+    ).toBeInTheDocument();
+    // 2000 reachable / 100 per page = 20 pages.
+    expect(within(detailCell).getByText('Page 1 of 20')).toBeInTheDocument();
+    expect(
+      within(detailCell).queryByText(/Sorting ascending inside a capped scan/i),
+    ).not.toBeInTheDocument();
+
+    // Time is the drill-down's default active sort (desc) — one click flips it to asc.
+    await user.click(within(detailCell).getByRole('button', { name: 'Time' }));
+    expect(
+      await within(detailCell).findByText(/Sorting ascending inside a capped scan/i),
+    ).toBeInTheDocument();
+  });
+
+  it('test 9d: drill-down opt-in capApplied=false renders no cap warnings', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () =>
+        baseResponse({
+          gateways: [gatewayRow()],
+          total: 1,
+          includeUnknown: true,
+          suspectedAvailable: true,
+        }),
+      () =>
+        packetsResponse({
+          violations: [packetRow()],
+          total: 3000,
+          limit: 100,
+          offset: 0,
+          includeUnknown: true,
+          suspectedAvailable: true,
+          capApplied: false,
+        }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('checkbox', { name: /Include unproven/i }));
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!433e0f28');
+
+    const row = screen.getByText('!433e0f28').closest('tr')!;
+    await user.click(row);
+    await screen.findByText('violation');
+
+    const detailCell = screen.getByText(/Violating packets published by/i).closest('td')!;
+    expect(
+      within(detailCell).queryByText(/Showing the first 2,000 rows/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(detailCell).queryByText(/Sorting ascending inside a capped scan/i),
+    ).not.toBeInTheDocument();
+    expect(within(detailCell).getByText('Page 1 of 30')).toBeInTheDocument();
   });
 
   it('test 18: aria-expanded lives on the expand button, not the <tr> (role="row" doesn\'t support it)', async () => {

--- a/src/components/Analysis/MqttViolationsReport.test.tsx
+++ b/src/components/Analysis/MqttViolationsReport.test.tsx
@@ -318,6 +318,43 @@ describe('MqttViolationsReport', () => {
     expect(url).toContain('offset=0');
   });
 
+  // #4332 follow-up: changing the summary's page size left drill.offset
+  // untouched, so an expanded gateway could be stranded on a drill-down page
+  // that no longer exists for its own result set (empty for no visible
+  // reason). Changing the page size must reset it back to 0.
+  it('test 6b: changing the summary page size resets the drill-down offset', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () => baseResponse({ gateways: [gatewayRow()], total: 1 }),
+      () => packetsResponse({ violations: [packetRow()], total: 250, limit: 100, offset: 0 }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!433e0f28');
+
+    const row = screen.getByText('!433e0f28').closest('tr')!;
+    await user.click(row);
+    await screen.findByText('violation');
+    expect(api.get).toHaveBeenCalledTimes(2);
+
+    // Advance the drill-down to offset=100 (page 2) before touching the
+    // summary's page size.
+    const detailCell = screen.getByText(/Violating packets published by/i).closest('td')!;
+    await user.click(within(detailCell).getByRole('button', { name: /^Next$/i }));
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(3));
+    expect(urlOf(vi.mocked(api.get), 2)).toContain('offset=100');
+
+    // Changing the summary's page size must reset drill.offset back to 0 —
+    // the next packets request should carry offset=0 again, not the stale 100.
+    await user.selectOptions(screen.getByRole('combobox', { name: /Rows per page/i }), '25');
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(5)); // gateways refetch + packets refetch
+    const packetsCalls = vi
+      .mocked(api.get)
+      .mock.calls.filter((call) => String(call[0]).includes('/mqtt-violations/packets'));
+    const lastPacketsUrl = String(packetsCalls[packetsCalls.length - 1][0]);
+    expect(lastPacketsUrl).toContain('offset=0');
+  });
+
   // #4330: capApplied must gate everything cap-related — never `total >= cap`.
   // Prior to the fix this test asserted the old `total >= API_SCAN_CAP`
   // inference without ever setting `capApplied`; it now explicitly opts in
@@ -820,6 +857,96 @@ describe('MqttViolationsReport', () => {
         (call) => String(call[0]).includes('/mqtt-violations/packets') && String(call[0]).includes('limit=2000'),
       );
     expect(exportCall).toBeDefined();
+  });
+
+  // #4332 follow-up: the export request limit and its honesty message must
+  // come from the most recently loaded response's `scanCap`, not the local
+  // API_SCAN_CAP constant — otherwise the two can silently drift apart.
+  it('test 16c: gateway CSV export uses the loaded response\'s scanCap, not the local constant', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url.includes('limit=500')) {
+        return baseResponse({
+          gateways: manyGatewayRows(500),
+          total: 600,
+          limit: 500,
+          offset: 0,
+          scanCap: 500,
+        });
+      }
+      // Initial summary load — scanCap: 500 is the server's echoed cap for
+      // this (hypothetical) window, deliberately different from the local
+      // API_SCAN_CAP (2000) so a test using the wrong source of truth fails.
+      return baseResponse({ gateways: [gatewayRow()], total: 1, scanCap: 500 });
+    });
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!433e0f28');
+
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }));
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    const exportUrl = urlOf(vi.mocked(api.get), 1);
+    expect(exportUrl).toContain('/api/analysis/mqtt-violations/gateways?');
+    expect(exportUrl).toContain('limit=500');
+    expect(exportUrl).not.toContain('limit=2000');
+
+    // capped because exported(500) >= scanCap(500); the message must quote
+    // 500, not the local 2000 constant.
+    await waitFor(() =>
+      expect(screen.getAllByText(/500 of 600 matching rows/).length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByText(/2,000 rows/)).not.toBeInTheDocument();
+  });
+
+  it('test 16d: drill-down CSV export uses the packets response\'s scanCap, not the summary\'s', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url.includes('/mqtt-violations/packets') && url.includes('limit=300')) {
+        return packetsResponse({
+          violations: [packetRow(), packetRow({ id: 2, packetId: 998 })],
+          total: 400,
+          scanCap: 300,
+        });
+      }
+      if (url.includes('/mqtt-violations/packets')) {
+        // Drill-down's own live query — scanCap: 300, deliberately different
+        // from the summary's scanCap: 500 below, to prove the export reads
+        // packetsQuery.data, not data.
+        return packetsResponse({ violations: [packetRow()], total: 1, scanCap: 300 });
+      }
+      return baseResponse({ gateways: [gatewayRow()], total: 1, scanCap: 500 });
+    });
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!433e0f28');
+
+    const row = screen.getByText('!433e0f28').closest('tr')!;
+    await user.click(row);
+    await screen.findByText('violation');
+
+    const exportButtons = screen.getAllByRole('button', { name: /Export CSV/i });
+    await user.click(exportButtons[exportButtons.length - 1]);
+
+    await waitFor(() => expect(downloadTextFile).toHaveBeenCalledTimes(1));
+    const exportCall = vi
+      .mocked(api.get)
+      .mock.calls.find(
+        (call) => String(call[0]).includes('/mqtt-violations/packets') && String(call[0]).includes('limit=300'),
+      );
+    expect(exportCall).toBeDefined();
+    const noWrongCapCall = vi
+      .mocked(api.get)
+      .mock.calls.find(
+        (call) => String(call[0]).includes('/mqtt-violations/packets') && String(call[0]).includes('limit=500'),
+      );
+    expect(noWrongCapCall).toBeUndefined();
+
+    // capped because exported(2) < scanCap(300) but total(400) > exported(2).
+    await waitFor(() =>
+      expect(screen.getAllByText(/2 of 400 matching rows/).length).toBeGreaterThan(0),
+    );
+    expect(screen.getAllByText(/300 rows/).length).toBeGreaterThan(0);
   });
 
   it('test 9b (#4330 regression): drill-down default path, total above scanCap but capApplied=false renders the real total/pager and no cap warnings', async () => {

--- a/src/components/Analysis/MqttViolationsReport.tsx
+++ b/src/components/Analysis/MqttViolationsReport.tsx
@@ -367,11 +367,16 @@ const MqttViolationsReport: React.FC = () => {
   const hasData = hasSources && gateways.length > 0;
   const infoBannersEligible = hasSources && (isEmpty || hasData);
 
-  const capReached = !!data && data.total >= API_SCAN_CAP;
-  const reachable = data ? Math.min(data.total, API_SCAN_CAP) : 0;
+  // Gate on the server's own `capApplied` echo, never on `total >= scanCap`
+  // (#4330). On the default path capApplied is always false and `total` is
+  // an exact COUNT with every row reachable, so a mesh with more rows than
+  // the cap still pages correctly instead of being clamped/mislabeled.
+  const capApplied = data?.capApplied === true;
+  const scanCap = data?.scanCap ?? API_SCAN_CAP;
+  const reachable = data ? (capApplied ? Math.min(data.total, scanCap) : data.total) : 0;
   const totalPages = data ? Math.max(1, Math.ceil(reachable / data.limit)) : 1;
   const currentPage = data ? Math.floor(data.offset / data.limit) + 1 : 1;
-  const capLabel = API_SCAN_CAP.toLocaleString();
+  const capLabel = scanCap.toLocaleString();
 
   const windowFmt = data ? formatSuspectedWindow(data.suspectedWindowMs) : null;
   const windowText =
@@ -399,11 +404,17 @@ const MqttViolationsReport: React.FC = () => {
     'Receptions where the ok_to_mqtt bit could not be read — usually because MeshMonitor has no key for the channel. Not proven, and not sortable.',
   );
 
-  // Drill-down cap honesty (§2(c) rule 5 — same treatment as the summary table).
+  // Drill-down cap honesty (§2(c) rule 5 — same treatment as the summary
+  // table, gated on the response's own `capApplied`/`scanCap`, not a
+  // `total >= cap` inference (#4330).
   const drillTotal = packetsQuery.data?.total ?? 0;
-  const drillCapReached = !!packetsQuery.data && drillTotal >= API_SCAN_CAP;
+  const drillCapApplied = packetsQuery.data?.capApplied === true;
+  const drillScanCap = packetsQuery.data?.scanCap ?? API_SCAN_CAP;
+  const drillCapLabel = drillScanCap.toLocaleString();
   const drillLimit = packetsQuery.data?.limit ?? drill.limit;
-  const drillReachable = packetsQuery.data ? Math.min(drillTotal, API_SCAN_CAP) : 0;
+  const drillReachable = packetsQuery.data
+    ? (drillCapApplied ? Math.min(drillTotal, drillScanCap) : drillTotal)
+    : 0;
   const drillTotalPages = packetsQuery.data ? Math.max(1, Math.ceil(drillReachable / drillLimit)) : 1;
   const drillCurrentPage = packetsQuery.data
     ? Math.floor(packetsQuery.data.offset / drillLimit) + 1
@@ -630,7 +641,7 @@ const MqttViolationsReport: React.FC = () => {
 
       {run && !isLoading && !error && data && hasData && (
         <>
-          {capReached && (
+          {capApplied && (
             <div className="reports-banner reports-banner--warning">
               {t(
                 'analysis.mqtt_violations.cap_warning',
@@ -639,7 +650,7 @@ const MqttViolationsReport: React.FC = () => {
               )}
             </div>
           )}
-          {capReached && applied.dir === 'asc' && (
+          {capApplied && applied.dir === 'asc' && (
             <div className="reports-banner reports-banner--warning">
               {t(
                 'analysis.mqtt_violations.cap_warning_asc',
@@ -652,7 +663,7 @@ const MqttViolationsReport: React.FC = () => {
           <div className="reports-stats">
             <Stat
               label={t('analysis.mqtt_violations.stat_gateways', 'Gateways')}
-              value={capReached ? `${capLabel}+` : stats.gatewayCount.toLocaleString()}
+              value={capApplied ? `${capLabel}+` : stats.gatewayCount.toLocaleString()}
             />
             <Stat
               label={t('analysis.mqtt_violations.stat_confirmed', 'Confirmed violations')}
@@ -883,21 +894,21 @@ const MqttViolationsReport: React.FC = () => {
                                 packetsQuery.data &&
                                 drillHasData && (
                                   <>
-                                    {drillCapReached && (
+                                    {drillCapApplied && (
                                       <div className="reports-banner reports-banner--warning">
                                         {t(
                                           'analysis.mqtt_violations.cap_warning',
                                           'Showing the first {{cap}} rows. The API caps a single scan at {{cap}} rows, so the total and any later pages are incomplete — narrow the window or select fewer sources.',
-                                          { cap: capLabel },
+                                          { cap: drillCapLabel },
                                         )}
                                       </div>
                                     )}
-                                    {drillCapReached && drill.dir === 'asc' && (
+                                    {drillCapApplied && drill.dir === 'asc' && (
                                       <div className="reports-banner reports-banner--warning">
                                         {t(
                                           'analysis.mqtt_violations.cap_warning_asc',
                                           'Sorting ascending inside a capped scan orders only those {{cap}} rows, not the whole window.',
-                                          { cap: capLabel },
+                                          { cap: drillCapLabel },
                                         )}
                                       </div>
                                     )}
@@ -1034,7 +1045,7 @@ const MqttViolationsReport: React.FC = () => {
           <div className={styles.pager}>
             <span className={styles.pagerInfo}>
               <span>
-                {capReached
+                {capApplied
                   ? t('analysis.mqtt_violations.total_rows_capped', '{{cap}}+ gateways', {
                       cap: capLabel,
                     })

--- a/src/components/Analysis/MqttViolationsReport.tsx
+++ b/src/components/Analysis/MqttViolationsReport.tsx
@@ -29,9 +29,10 @@
  * the summary. It reuses the Phase 2 `okToMqttState()`/`MqttOkToMqttMarker`
  * primitives via the `kind` -> fields adapter (§2(a.3)) and never recomputes
  * `relayed` itself. CSV export (§2(d)) re-fetches the *whole* filtered
- * result set (capped at `API_SCAN_CAP`, the same ceiling the server
- * enforces) rather than exporting only the current page, and always
- * surfaces the cap to the user instead of silently truncating.
+ * result set (capped at the most recently loaded response's `scanCap`,
+ * falling back to the local `API_SCAN_CAP` constant if nothing has loaded
+ * yet — #4332 follow-up) rather than exporting only the current page, and
+ * always surfaces the cap to the user instead of silently truncating.
  */
 import { Fragment, useMemo, useState } from 'react';
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
@@ -145,14 +146,21 @@ function rowKeyOf(row: ViolationGatewayRow): string {
  * (PHASE3 §2(d)). Never a silent truncation: `capped` is true whenever the
  * export hit the API's hard ceiling OR the server reports more rows exist
  * than were actually exported.
+ *
+ * `exportCap` is the request limit the caller actually used (the most
+ * recently loaded response's `scanCap`, falling back to `API_SCAN_CAP` only
+ * when nothing has loaded yet — #4332 follow-up). It must be the same value
+ * used to build the export request, so the message never drifts from what
+ * was actually asked for.
  */
 function buildExportMessage(
   t: TFn,
   exported: number,
   total: number,
+  exportCap: number,
 ): { message: string; capped: boolean } {
-  const capped = exported >= API_SCAN_CAP || total > exported;
-  const cap = API_SCAN_CAP.toLocaleString();
+  const capped = exported >= exportCap || total > exported;
+  const cap = exportCap.toLocaleString();
   const message = capped
     ? t(
         'analysis.mqtt_violations.export_capped',
@@ -266,6 +274,10 @@ const MqttViolationsReport: React.FC = () => {
     const patch = { limit, offset: 0 };
     setDraft((d) => ({ ...d, ...patch }));
     setApplied((a) => ({ ...a, ...patch }));
+    // The summary's own page size doesn't bound the drill-down's result set,
+    // but an expanded gateway can be left pointing at a drill-down page that
+    // no longer exists once the summary reloads — reset it too (#4332).
+    setDrill((d) => ({ ...d, offset: 0 }));
   };
 
   /** Toggle expand/collapse. Always resets the drill-down's own pagination
@@ -293,19 +305,27 @@ const MqttViolationsReport: React.FC = () => {
 
   /**
    * CSV export re-fetches the *whole* filtered result set at the API's hard
-   * ceiling (`limit=API_SCAN_CAP, offset=0`), not just the current page
-   * (§2(d)). A one-shot `fetchQuery` rather than a second live `useQuery` —
-   * this is an imperative action, not a render-driven data need.
+   * ceiling (`limit=scanCap, offset=0`), not just the current page (§2(d)).
+   * A one-shot `fetchQuery` rather than a second live `useQuery` — this is
+   * an imperative action, not a render-driven data need.
+   *
+   * The cap itself is a deliberate client-side choice (avoid pulling
+   * unbounded rows into the browser) — only the *number* comes from the
+   * server: the most recently loaded summary response's `scanCap`, falling
+   * back to the local `API_SCAN_CAP` constant only if nothing has loaded
+   * yet, so the request limit and the honesty message can never drift from
+   * what the server actually enforces (#4332 follow-up).
    */
   const handleExportGateways = async () => {
     setGatewayExportPending(true);
+    const exportCap = data?.scanCap ?? API_SCAN_CAP;
     try {
       const body = await queryClient.fetchQuery({
         queryKey: ['mqtt-violations-gateways-export', applied],
         queryFn: async () => {
           const b = await api.get<{ success: boolean; data: ViolationGatewaysResponse }>(
             `/api/analysis/mqtt-violations/gateways?${buildViolationParams(applied, {
-              limit: API_SCAN_CAP,
+              limit: exportCap,
               offset: 0,
             })}`,
           );
@@ -314,7 +334,7 @@ const MqttViolationsReport: React.FC = () => {
       });
       const csv = buildGatewaysCsv(body.gateways);
       downloadTextFile(gatewaysCsvFilename(), csv, 'text/csv');
-      const { message, capped } = buildExportMessage(t, body.gateways.length, body.total);
+      const { message, capped } = buildExportMessage(t, body.gateways.length, body.total, exportCap);
       setGatewayExportWarning(capped ? message : null);
       showToast(message, capped ? 'error' : 'success');
     } catch {
@@ -327,6 +347,10 @@ const MqttViolationsReport: React.FC = () => {
 
   const handleExportPackets = async (gatewayId: string) => {
     setDrillExportPending(true);
+    // The drill-down's own packets response, not the summary's — the two
+    // endpoints echo the same server constant today, but this stays correct
+    // if that ever changes (#4332 follow-up).
+    const exportCap = packetsQuery.data?.scanCap ?? API_SCAN_CAP;
     try {
       const body = await queryClient.fetchQuery({
         queryKey: ['mqtt-violations-packets-export', gatewayId, applied, drill.sort, drill.dir],
@@ -336,7 +360,7 @@ const MqttViolationsReport: React.FC = () => {
               gateway: gatewayId,
               sort: drill.sort,
               dir: drill.dir,
-              limit: API_SCAN_CAP,
+              limit: exportCap,
               offset: 0,
             })}`,
           );
@@ -345,7 +369,7 @@ const MqttViolationsReport: React.FC = () => {
       });
       const csv = buildPacketsCsv(body.violations);
       downloadTextFile(packetsCsvFilename(gatewayId), csv, 'text/csv');
-      const { message, capped } = buildExportMessage(t, body.violations.length, body.total);
+      const { message, capped } = buildExportMessage(t, body.violations.length, body.total, exportCap);
       setDrillExportWarning(capped ? message : null);
       showToast(message, capped ? 'error' : 'success');
     } catch {

--- a/src/components/Analysis/mqttViolationTypes.ts
+++ b/src/components/Analysis/mqttViolationTypes.ts
@@ -52,6 +52,19 @@ export interface ViolationResponseMeta {
   /** MEANINGLESS unless includeUnknown === true. */
   suspectedWindowMs: number;
   sources: string[];
+  /**
+   * True only when a pre-merge fetch actually saturated the server's scan
+   * cap before sorting (#4330). ALWAYS false on the default
+   * (`includeUnknown=false`) path — that path sorts/pages in SQL with an
+   * exact COUNT, so every row at every offset is reachable and there is no
+   * cap. Never infer "capped" from `total >= scanCap` — a mesh can
+   * legitimately have more rows than the cap with none of them dropped.
+   */
+  capApplied: boolean;
+  /** The server's scan-cap ceiling (currently 2000). Use this, not a local
+   * constant, whenever a cap value is displayed to the user — it can never
+   * drift from what the server actually enforced. */
+  scanCap: number;
 }
 
 export interface ViolationGatewaysResponse extends ViolationResponseMeta {

--- a/src/server/routes/analysisRoutes.mqttViolations.test.ts
+++ b/src/server/routes/analysisRoutes.mqttViolations.test.ts
@@ -213,6 +213,14 @@ describe('analysisRoutes — GET /mqtt-violations/gateways', () => {
     expect(res2.body.data.gateways[0].gatewayId).not.toBe(res.body.data.gateways[0].gatewayId);
   });
 
+  it('a negative offset is clamped to 0 rather than passed through', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&limit=10&offset=-5');
+    expect(res.status).toBe(200);
+    expect(res.body.data.offset).toBe(0);
+    expect(res.body.data.gateways.length).toBe(3);
+  });
+
   it('lookbackDays clamps to 1..365 and is ignored when since is explicit', async () => {
     const agent = await harness.loginAs(harness.admin);
     // lookbackDays=99999 would clamp to 365; explicit since=0 must win regardless.
@@ -527,6 +535,14 @@ describe('analysisRoutes — GET /mqtt-violations/packets', () => {
     const res = await agent.get('/mqtt-violations/packets?since=0&limit=1&offset=0');
     expect(res.body.data.violations.length).toBe(1);
     expect(res.body.data.total).toBe(3);
+  });
+
+  it('a negative offset is clamped to 0 rather than passed through', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&limit=10&offset=-5');
+    expect(res.status).toBe(200);
+    expect(res.body.data.offset).toBe(0);
+    expect(res.body.data.violations.length).toBe(3);
   });
 
   it('includeUnknown=true with mqtt_packet_log_enabled on merges suspected rows with kind: suspected', async () => {

--- a/src/server/routes/analysisRoutes.mqttViolations.test.ts
+++ b/src/server/routes/analysisRoutes.mqttViolations.test.ts
@@ -317,6 +317,110 @@ describe('analysisRoutes — GET /mqtt-violations/gateways', () => {
     expect(gw.lastSeen).toBe(T0 + 6000);
     expect(gw.sourceIds).toEqual([harness.sourceA]);
   });
+
+  // ── #4330: capApplied / scanCap contract + the sourceIds trap ──────────
+
+  it('#4330: capApplied is false and scanCap is 2000 on the default (includeUnknown=false) path', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.capApplied).toBe(false);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
+
+  it('#4330: sourceIds is populated per gateway on the default path (the merge-skip trap)', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.gateways.length).toBeGreaterThan(0);
+    for (const g of res.body.data.gateways) {
+      expect(Array.isArray(g.sourceIds)).toBe(true);
+      expect(g.sourceIds.length).toBeGreaterThan(0);
+    }
+    const gw1 = res.body.data.gateways.find((g: any) => g.gatewayId === '!11111111');
+    expect(gw1.sourceIds).toEqual([harness.sourceA]);
+  });
+
+  it('#4330: includeUnknown=true reports capApplied=false when the pre-merge fetch does not saturate', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&includeUnknown=true');
+    expect(res.status).toBe(200);
+    expect(res.body.data.capApplied).toBe(false);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
+});
+
+describe('analysisRoutes — GET /mqtt-violations/gateways — pagination beyond the 2000-row cap (#4330)', () => {
+  let harness: RouteTestHarness;
+  const TOTAL_GATEWAYS = 2100;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', analysisRoutes) });
+    // Each violation carries a distinct gatewayId/gatewayNodeNum, so the
+    // per-gateway summary groups into TOTAL_GATEWAYS rows — well past the
+    // old hardcoded 2000-row cap.
+    const inserts: Promise<void>[] = [];
+    for (let i = 0; i < TOTAL_GATEWAYS; i++) {
+      const gatewayNodeNum = 0x50000000 + i;
+      const gatewayId = `!${gatewayNodeNum.toString(16).padStart(8, '0')}`;
+      inserts.push(
+        harness.db.mqttOkToMqttViolations.insertViolation(
+          makeViolation({
+            sourceId: harness.sourceA,
+            packetId: 5000 + i,
+            fromNode: 0xaaaaaaaa,
+            fromNodeId: '!aaaaaaaa',
+            gatewayId,
+            gatewayNodeNum,
+            timestamp: T0 + i,
+          }),
+        ),
+      );
+    }
+    await Promise.all(inserts);
+  }, 30_000);
+
+  afterEach(async () => {
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceA);
+    await harness.cleanup();
+  }, 30_000);
+
+  it('#4330: total is exact beyond the cap and capApplied is false on the default path', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&limit=50&offset=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(TOTAL_GATEWAYS);
+    expect(res.body.data.capApplied).toBe(false);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
+
+  it('#4330 regression: offset beyond 2000 returns real, non-empty rows', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&limit=500&offset=2050');
+    expect(res.status).toBe(200);
+    expect(res.body.data.gateways.length).toBe(TOTAL_GATEWAYS - 2050);
+    expect(res.body.data.total).toBe(TOTAL_GATEWAYS);
+  });
+
+  it('#4330 regression: ascending sort by lastSeen returns the earliest groups first, not just the tail of a truncated scan', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&sort=lastSeen&dir=asc&limit=5&offset=0');
+    expect(res.status).toBe(200);
+    const lastSeens = res.body.data.gateways.map((g: any) => g.lastSeen);
+    expect(lastSeens).toEqual([...lastSeens].sort((a, b) => a - b));
+    // i=0 inserted at T0 — the true earliest. The old bug would only ever
+    // sort within whatever subset of rows the hardcoded 2000-row confirmed
+    // fetch happened to retain, which could omit this row entirely.
+    expect(lastSeens[0]).toBe(T0);
+  });
+
+  it('#4330: includeUnknown=true reports capApplied=true once the confirmed pre-merge fetch saturates', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/gateways?since=0&includeUnknown=true&limit=10&offset=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.capApplied).toBe(true);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
 });
 
 describe('analysisRoutes — GET /mqtt-violations/packets', () => {
@@ -448,5 +552,86 @@ describe('analysisRoutes — GET /mqtt-violations/packets', () => {
     const res = await agent.get('/mqtt-violations/packets?since=0');
     expect(res.status).toBe(200);
     expect(res.body.data.violations.every((v: any) => v.kind === 'confirmed')).toBe(true);
+  });
+
+  // ── #4330: capApplied / scanCap contract ────────────────────────────────
+
+  it('#4330: capApplied is false and scanCap is 2000 on the default (includeUnknown=false) path', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.capApplied).toBe(false);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
+
+  it('#4330: includeUnknown=true reports capApplied=false when the pre-merge fetch does not saturate', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&includeUnknown=true');
+    expect(res.status).toBe(200);
+    expect(res.body.data.capApplied).toBe(false);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
+});
+
+describe('analysisRoutes — GET /mqtt-violations/packets — pagination beyond the 2000-row cap (#4330)', () => {
+  let harness: RouteTestHarness;
+  const TOTAL_VIOLATIONS = 2100;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', analysisRoutes) });
+    const inserts: Promise<void>[] = [];
+    for (let i = 0; i < TOTAL_VIOLATIONS; i++) {
+      inserts.push(
+        harness.db.mqttOkToMqttViolations.insertViolation(
+          makeViolation({
+            sourceId: harness.sourceA,
+            packetId: 6000 + i,
+            fromNode: 0xaaaaaaaa,
+            fromNodeId: '!aaaaaaaa',
+            timestamp: T0 + i,
+          }),
+        ),
+      );
+    }
+    await Promise.all(inserts);
+  }, 30_000);
+
+  afterEach(async () => {
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceA);
+    await harness.cleanup();
+  }, 30_000);
+
+  it('#4330: total is exact beyond the cap and capApplied is false on the default path', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&limit=50&offset=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(TOTAL_VIOLATIONS);
+    expect(res.body.data.capApplied).toBe(false);
+    expect(res.body.data.scanCap).toBe(2000);
+  });
+
+  it('#4330 regression: offset beyond 2000 returns real, non-empty rows', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&limit=500&offset=2050');
+    expect(res.status).toBe(200);
+    expect(res.body.data.violations.length).toBe(TOTAL_VIOLATIONS - 2050);
+    expect(res.body.data.total).toBe(TOTAL_VIOLATIONS);
+  });
+
+  it('#4330 regression: ascending sort by timestamp returns the oldest rows first, not just the tail of a truncated scan', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&sort=timestamp&dir=asc&limit=5&offset=0');
+    expect(res.status).toBe(200);
+    const timestamps = res.body.data.violations.map((v: any) => v.timestamp);
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => a - b));
+    expect(timestamps[0]).toBe(T0);
+  });
+
+  it('#4330: includeUnknown=true reports capApplied=true once the confirmed pre-merge fetch saturates', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/mqtt-violations/packets?since=0&includeUnknown=true&limit=10&offset=0');
+    expect(res.status).toBe(200);
+    expect(res.body.data.capApplied).toBe(true);
+    expect(res.body.data.scanCap).toBe(2000);
   });
 });

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -104,6 +104,18 @@ function parseBoolParam(raw: unknown): boolean {
 const VIOLATION_GATEWAY_SORTS = ['violationCount', 'lastSeen', 'distinctOriginators', 'gatewayId'] as const;
 const VIOLATION_LIST_SORTS = ['timestamp', 'fromNode', 'gatewayId'] as const;
 
+/**
+ * Cap on the pre-merge fetch used ONLY by the `includeUnknown=true` path
+ * (#4330). It bounds `getGatewaySummary`/`getViolations`'s "confirmed" fetch
+ * and `getSuspectedViolations`'s "suspected" fetch before they are merged and
+ * re-sorted in JS — a merge that cannot be pushed into SQL because the two
+ * sides come from different tables (see the handler doc comments). It plays
+ * NO role in the default `includeUnknown=false` path, which pages entirely
+ * in SQL and is uncapped. Exposed to the frontend as `scanCap` so it never
+ * hardcodes the number independently.
+ */
+const API_SCAN_CAP = 2000;
+
 /** Row shape for the merged `/mqtt-violations/gateways` response. */
 interface ViolationGatewayRow extends MqttViolationGateway {
   suspectedCount: number;
@@ -599,20 +611,68 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
         suspectedAvailable: false,
         suspectedWindowMs: 0,
         sources: [],
+        capApplied: false,
+        scanCap: API_SCAN_CAP,
       });
       return;
     }
 
     const rangeQuery = { sourceIds, since, until };
 
-    // Fetch confirmed rows (capped at 2000 — see §3.17 step 7 / §6 risk 2)
-    // and always sort/paginate the (possibly merged) list in the handler so
-    // the includeUnknown=true and includeUnknown=false paths share one code
-    // path. The three queries below have no data dependency on each other,
-    // so run them concurrently rather than round-tripping in sequence.
-    const [confirmedRows, confirmedTotal, sourceIdPairs] = await Promise.all([
-      databaseService.mqttOkToMqttViolations.getGatewaySummary({ ...rangeQuery, limit: 2000, offset: 0 }),
-      databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(rangeQuery),
+    if (!includeUnknown) {
+      // ── Default path (#4330 fix) ──────────────────────────────────────
+      // Only the confirmed table is involved, so there is nothing to merge:
+      // push sort/dir/limit/offset straight into SQL. `total` is an exact
+      // COUNT and every row at every offset is reachable — no cap, ever.
+      const [gatewayRows, total, sourceIdPairs] = await Promise.all([
+        databaseService.mqttOkToMqttViolations.getGatewaySummary({ ...rangeQuery, sort, dir, limit, offset }),
+        databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(rangeQuery),
+        databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery),
+      ]);
+
+      const sourceIdsByGateway = new Map<string, Set<string>>();
+      for (const pair of sourceIdPairs) {
+        const set = sourceIdsByGateway.get(pair.gatewayId) ?? new Set<string>();
+        set.add(pair.sourceId);
+        sourceIdsByGateway.set(pair.gatewayId, set);
+      }
+
+      // Trap (#4330): sourceIds is attached here from the separate
+      // getGatewaySourceIds query — skipping this step silently drops it
+      // (every row would come back with sourceIds: []).
+      const gateways: ViolationGatewayRow[] = gatewayRows
+        .filter((g): g is MqttViolationGateway & { gatewayId: string } => g.gatewayId != null)
+        .map((g) => ({
+          ...g,
+          suspectedCount: 0,
+          sourceIds: Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []),
+        }));
+
+      ok(res, {
+        gateways,
+        total,
+        limit,
+        offset,
+        since,
+        until,
+        includeUnknown,
+        suspectedAvailable: false,
+        suspectedWindowMs: 0,
+        sources: sourceIds,
+        capApplied: false,
+        scanCap: API_SCAN_CAP,
+      });
+      return;
+    }
+
+    // ── includeUnknown=true (#4330: opt-in, still merged+sorted in JS) ──
+    // Confirmed rows (durable table) and suspected rows (mqtt_packet_log)
+    // must be merged before ordering because they come from two different
+    // tables — a SQL UNION was considered and declined for this PR. The
+    // confirmed fetch below is capped at API_SCAN_CAP; capApplied reports
+    // whether that cap actually dropped rows before the merge.
+    const [confirmedRows, sourceIdPairs] = await Promise.all([
+      databaseService.mqttOkToMqttViolations.getGatewaySummary({ ...rangeQuery, limit: API_SCAN_CAP, offset: 0 }),
       databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery),
     ]);
 
@@ -627,38 +687,35 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       sourceIdsByGateway.set(pair.gatewayId, set);
     }
 
-    let suspectedAvailable = false;
     let suspectedWindowMs = 0;
     const suspectedByGateway = new Map<
       string,
       { suspectedCount: number; gatewayNodeNum: number | null; distinctOriginators: number; firstSeen: number; lastSeen: number }
     >();
 
-    if (includeUnknown) {
-      suspectedAvailable = await mqttPacketLogService.isEnabled();
-      if (suspectedAvailable) {
-        // No dependency between these three — run concurrently.
-        const [maxAgeHours, suspectedRows, suspectedSourceIdPairs] = await Promise.all([
-          mqttPacketLogService.getMaxAgeHours(),
-          databaseService.mqttPacketLog.getSuspectedViolationGateways(rangeQuery),
-          databaseService.mqttPacketLog.getSuspectedGatewaySourceIds(rangeQuery),
-        ]);
-        suspectedWindowMs = maxAgeHours * 60 * 60 * 1000;
-        for (const row of suspectedRows) {
-          if (!row.gatewayId) continue;
-          suspectedByGateway.set(row.gatewayId, {
-            suspectedCount: row.suspectedCount,
-            gatewayNodeNum: row.gatewayNodeNum,
-            distinctOriginators: row.distinctOriginators,
-            firstSeen: row.firstSeen,
-            lastSeen: row.lastSeen,
-          });
-        }
-        for (const pair of suspectedSourceIdPairs) {
-          const set = sourceIdsByGateway.get(pair.gatewayId) ?? new Set<string>();
-          set.add(pair.sourceId);
-          sourceIdsByGateway.set(pair.gatewayId, set);
-        }
+    const suspectedAvailable = await mqttPacketLogService.isEnabled();
+    if (suspectedAvailable) {
+      // No dependency between these three — run concurrently.
+      const [maxAgeHours, suspectedRows, suspectedSourceIdPairs] = await Promise.all([
+        mqttPacketLogService.getMaxAgeHours(),
+        databaseService.mqttPacketLog.getSuspectedViolationGateways(rangeQuery),
+        databaseService.mqttPacketLog.getSuspectedGatewaySourceIds(rangeQuery),
+      ]);
+      suspectedWindowMs = maxAgeHours * 60 * 60 * 1000;
+      for (const row of suspectedRows) {
+        if (!row.gatewayId) continue;
+        suspectedByGateway.set(row.gatewayId, {
+          suspectedCount: row.suspectedCount,
+          gatewayNodeNum: row.gatewayNodeNum,
+          distinctOriginators: row.distinctOriginators,
+          firstSeen: row.firstSeen,
+          lastSeen: row.lastSeen,
+        });
+      }
+      for (const pair of suspectedSourceIdPairs) {
+        const set = sourceIdsByGateway.get(pair.gatewayId) ?? new Set<string>();
+        set.add(pair.sourceId);
+        sourceIdsByGateway.set(pair.gatewayId, set);
       }
     }
 
@@ -701,8 +758,11 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       return dirMultiplier * ((a[sort] ?? 0) - (b[sort] ?? 0));
     });
 
-    const total = includeUnknown ? merged.length : confirmedTotal;
+    const total = merged.length;
     const gateways = merged.slice(offset, offset + limit);
+    // capApplied: the pre-merge confirmed fetch hit the cap, meaning rows
+    // were dropped before the merge/sort ran (#4330).
+    const capApplied = confirmedRows.length >= API_SCAN_CAP;
 
     ok(res, {
       gateways,
@@ -715,6 +775,8 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       suspectedAvailable,
       suspectedWindowMs,
       sources: sourceIds,
+      capApplied,
+      scanCap: API_SCAN_CAP,
     });
   } catch (error) {
     logger.error('Error in GET /api/analysis/mqtt-violations/gateways:', error);
@@ -783,33 +845,68 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
         suspectedAvailable: false,
         suspectedWindowMs: 0,
         sources: [],
+        capApplied: false,
+        scanCap: API_SCAN_CAP,
       });
       return;
     }
 
     const rangeQuery = { sourceIds, since, until, gatewayId: gateway };
 
-    // No data dependency between these two — run concurrently.
-    const [confirmedRows, confirmedTotal] = await Promise.all([
-      databaseService.mqttOkToMqttViolations.getViolations({ ...rangeQuery, limit: 2000, offset: 0 }),
-      databaseService.mqttOkToMqttViolations.getViolationCount(rangeQuery),
-    ]);
+    if (!includeUnknown) {
+      // ── Default path (#4330 fix) ──────────────────────────────────────
+      // Only the confirmed table is involved, so there is nothing to merge:
+      // push sort/dir/limit/offset straight into SQL. `total` is an exact
+      // COUNT and every row at every offset is reachable — no cap, ever.
+      const [confirmedRows, total] = await Promise.all([
+        databaseService.mqttOkToMqttViolations.getViolations({ ...rangeQuery, sort, dir, limit, offset }),
+        databaseService.mqttOkToMqttViolations.getViolationCount(rangeQuery),
+      ]);
 
-    let suspectedAvailable = false;
+      const violations = confirmedRows.map((r) => toViolationPacketRow('confirmed', r));
+
+      ok(res, {
+        violations,
+        total,
+        limit,
+        offset,
+        since,
+        until,
+        gateway: gateway ?? null,
+        includeUnknown,
+        suspectedAvailable: false,
+        suspectedWindowMs: 0,
+        sources: sourceIds,
+        capApplied: false,
+        scanCap: API_SCAN_CAP,
+      });
+      return;
+    }
+
+    // ── includeUnknown=true (#4330: opt-in, still merged+sorted in JS) ──
+    // Confirmed rows (durable table) and suspected rows (mqtt_packet_log)
+    // must be merged before ordering because they come from two different
+    // tables — a SQL UNION was considered and declined for this PR. Both
+    // pre-merge fetches below are capped at API_SCAN_CAP; capApplied reports
+    // whether either cap actually dropped rows before the merge.
+    const confirmedRows = await databaseService.mqttOkToMqttViolations.getViolations({
+      ...rangeQuery,
+      limit: API_SCAN_CAP,
+      offset: 0,
+    });
+
     let suspectedWindowMs = 0;
     let suspectedRows: DbMqttPacket[] = [];
 
-    if (includeUnknown) {
-      suspectedAvailable = await mqttPacketLogService.isEnabled();
-      if (suspectedAvailable) {
-        // No dependency between these two — run concurrently.
-        const [maxAgeHours, rows] = await Promise.all([
-          mqttPacketLogService.getMaxAgeHours(),
-          databaseService.mqttPacketLog.getSuspectedViolations({ ...rangeQuery, limit: 2000, offset: 0 }),
-        ]);
-        suspectedWindowMs = maxAgeHours * 60 * 60 * 1000;
-        suspectedRows = rows;
-      }
+    const suspectedAvailable = await mqttPacketLogService.isEnabled();
+    if (suspectedAvailable) {
+      // No dependency between these two — run concurrently.
+      const [maxAgeHours, rows] = await Promise.all([
+        mqttPacketLogService.getMaxAgeHours(),
+        databaseService.mqttPacketLog.getSuspectedViolations({ ...rangeQuery, limit: API_SCAN_CAP, offset: 0 }),
+      ]);
+      suspectedWindowMs = maxAgeHours * 60 * 60 * 1000;
+      suspectedRows = rows;
     }
 
     const merged = [
@@ -824,8 +921,11 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
       return dirMultiplier * ((a[sort] ?? 0) - (b[sort] ?? 0));
     });
 
-    const total = includeUnknown ? merged.length : confirmedTotal;
+    const total = merged.length;
     const violations = merged.slice(offset, offset + limit);
+    // capApplied: either pre-merge fetch hit its cap, meaning rows were
+    // dropped before the merge/sort ran (#4330).
+    const capApplied = confirmedRows.length >= API_SCAN_CAP || suspectedRows.length >= API_SCAN_CAP;
 
     ok(res, {
       violations,
@@ -839,6 +939,8 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
       suspectedAvailable,
       suspectedWindowMs,
       sources: sourceIds,
+      capApplied,
+      scanCap: API_SCAN_CAP,
     });
   } catch (error) {
     logger.error('Error in GET /api/analysis/mqtt-violations/packets:', error);

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -721,6 +721,18 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
 
     const mergedByGateway = new Map<string, ViolationGatewayRow>();
     for (const g of confirmedRows) {
+      // Defensive only, not reachable via the write path (#4330 review):
+      // a confirmed row exists in mqtt_ok_to_mqtt_violations only when
+      // detectOkToMqttViolation() set isViolation, which requires
+      // `relayed`, which requires gatewayNodeNum !== null — and
+      // gatewayNodeNum is parseGatewayNodeNum(envelope.gatewayId), which is
+      // non-null only when envelope.gatewayId was itself a valid, non-empty
+      // `!`-prefixed id. buildViolationRow() stores that same
+      // envelope.gatewayId verbatim (mqttPacketLogService.ts:348,399), so a
+      // written violation row can never carry a null gatewayId. This guard
+      // therefore cannot cause `total = merged.length` (below) to diverge
+      // from `capApplied = confirmedRows.length >= API_SCAN_CAP` — every
+      // row fetched here is counted by both.
       if (!g.gatewayId) continue;
       const suspected = suspectedByGateway.get(g.gatewayId);
       mergedByGateway.set(g.gatewayId, {
@@ -889,16 +901,20 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
     // tables — a SQL UNION was considered and declined for this PR. Both
     // pre-merge fetches below are capped at API_SCAN_CAP; capApplied reports
     // whether either cap actually dropped rows before the merge.
-    const confirmedRows = await databaseService.mqttOkToMqttViolations.getViolations({
-      ...rangeQuery,
-      limit: API_SCAN_CAP,
-      offset: 0,
-    });
+    // The confirmed fetch and the suspectedAvailable check have no data
+    // dependency on each other — run them concurrently (#4330 review).
+    const [confirmedRows, suspectedAvailable] = await Promise.all([
+      databaseService.mqttOkToMqttViolations.getViolations({
+        ...rangeQuery,
+        limit: API_SCAN_CAP,
+        offset: 0,
+      }),
+      mqttPacketLogService.isEnabled(),
+    ]);
 
     let suspectedWindowMs = 0;
     let suspectedRows: DbMqttPacket[] = [];
 
-    const suspectedAvailable = await mqttPacketLogService.isEnabled();
     if (suspectedAvailable) {
       // No dependency between these two — run concurrently.
       const [maxAgeHours, rows] = await Promise.all([


### PR DESCRIPTION
Fixes #4330 — the `ok_to_mqtt` violation endpoints capped at 2000 rows, making rows past that offset unreachable and ascending sorts wrong.

## The bug

Both `/api/analysis/mqtt-violations/{gateways,packets}` handlers called the repositories with a hardcoded `limit: 2000, offset: 0` and then sorted and sliced **in JavaScript** — unconditionally, in both `includeUnknown` modes. Two consequences:

1. **Rows past offset 2000 were unreachable** even when `total` was an exact `COUNT`, so a pager built on `total` offered pages that came back empty.
2. **`sort`/`dir` never reached SQL**, so the retained 2000 were always the repository defaults (`COUNT(*) DESC` for gateways, `timestamp DESC` for packets). An **ascending** sort over a saturated scan therefore ordered only the worst/newest 2000 rows — quietly wrong answers.

## The fix

**Default path (`includeUnknown=false`) — fully fixed.** `sort`/`dir`/`limit`/`offset` push straight into SQL, `total` stays an exact `COUNT`, and the in-handler merge is skipped entirely. No cap, every row reachable at any offset, ascending sorts correct.

**Opt-in path (`includeUnknown=true`) — narrowed, not eliminated.** This path genuinely must interleave two differently-shaped tables before ordering, so it keeps the pre-merge fetch and JS sort. Saturation is far less likely here: the suspected side is already bounded by `mqtt_packet_log`'s own retention (24 h default) and row cap. A SQL `UNION` was considered and **declined** — dialect-correct union across SQLite/PostgreSQL/MySQL over two differently-shaped tables, plus an aggregate-over-union for the gateway summary, was judged too much query-layer risk for the benefit.

## New contract: `capApplied` + `scanCap`

This is the part that matters, and it fixes the bug's **frontend twin**.

The report previously inferred "was I capped?" from `total >= API_SCAN_CAP` using a locally hardcoded constant. Once the default path returns exact totals with everything reachable, that inference becomes actively harmful: on a mesh with more than 2000 violations it would render `2,000+`, clamp paging to hide reachable rows, and display warnings that are simply false.

So the server now states it:
- **`capApplied: false` always** on the default path.
- **`capApplied: true`** on the opt-in path only when a pre-merge fetch actually saturated (`confirmedRows.length >= scanCap`, or either side for `/packets`). If it ran without saturating, `false`.
- **`scanCap: number`** so the UI never hardcodes 2000 independently.

The report now gates every cap affordance on `capApplied` — the total display, the `totalPages` clamp, both warning banners (general and ascending-sort), and the drill-down's equivalents.

**An existing Phase 3 test had encoded the wrong inference** (asserting cap behaviour from `total: 5000` without ever setting `capApplied`). It's updated, and called out here rather than quietly changed.

## A trap worth naming

On the gateways endpoint, `sourceIds` per gateway is attached from a **separate** `getGatewaySourceIds` query, inside the merge loop the fast path now skips. Skipping it naively returns `sourceIds: []` for every row — silently undoing a fix from an earlier review round on #4114. Guarded with a test.

## Not changed, deliberately

The **CSV export cap** stays. That's a client-side choice to avoid pulling unbounded rows into the browser, not the API bug, and it keeps its honesty message reporting exported-vs-matched.

## Testing

- Full Vitest suite: **11,531 passed / 0 failed**, `success: true` from the JSON reporter, with PostgreSQL and MySQL containers up and confirmed genuinely exercised (52 PG + 56 MySQL tests in `nodes.test.ts`).
- `tsc --noEmit` clean; `lint:ci` clean; locale glyph scan passed.
- New backend tests: sort/dir reach SQL and reorder (including ascending, the previously-broken case); `offset` beyond 2000 returns real rows with an exact `total`; `capApplied === false` even when `total` exceeds the cap; `sourceIds` populated on the fast path; `capApplied` true/false correctness on the opt-in path.
- New frontend tests: a default-path response with `total` above `scanCap` and `capApplied: false` renders the real total, pages across it, and shows no warnings (including with `dir: 'asc'`); opt-in with `capApplied: true` still warns; same coverage for the drill-down.

**Browser-verified.** Live data here has only 7 offending gateways, so the summary table can't reach 2000 naturally — the regression scenario was exercised in the real built bundle by returning a synthetic `total: 2268, capApplied: false`, paging to **page 21 of 23**, and confirming the row for gateway `!000007d0` (2000 in hex) renders. That row was unreachable under the old clamp. Where this would have bitten real users is the drill-down: the worst gateway logged 476 violations in 7 days, extrapolating to roughly 6,000 over a 90-day window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aucxao43DBCoLHmbubvAS5