### PR TITLE
chore: bump version to 4.13.2-rc4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.2-rc3",
+  "version": "4.13.2-rc4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.2-rc3",
+  "version": "4.13.2-rc4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.2-rc3
-appVersion: "4.13.2-rc3"
+version: 4.13.2-rc4
+appVersion: "4.13.2-rc4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.2-rc3",
+  "version": "4.13.2-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.2-rc3",
+      "version": "4.13.2-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.2-rc3",
+  "version": "4.13.2-rc4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump `4.13.2-rc3` → `4.13.2-rc4`.

## What this RC rolls up

The complete `ok_to_mqtt` violation-detection epic (#4114), plus its pagination follow-up:

| PR | What |
|---|---|
| #4324 | **Phase 1** — backend detection: migration 128, tri-state `ok_to_mqtt` evaluator extracted from the uplink gate, `bitfield` preserved through server-side decrypt, retention-immune 90-day violation history, cross-source analysis endpoints |
| #4328 | **Phase 2** — Packet Monitor: violation badge on grouped rows + per-gateway attribution in the detail view (four-state marker) |
| #4331 | **Phase 3** — `ok_to_mqtt Violations` report under Analysis & Reports: gateway summary, drill-down, window presets, CSV export, include-unproven toggle |
| #4332 | **#4330 fix** — SQL sorting/paging on the default path (no more unreachable rows past offset 2000, no more wrong ascending sorts), plus the `capApplied`/`scanCap` contract |

Net user-visible effect: MeshMonitor now detects when an MQTT gateway relays another node's packet despite the originator not opting in — a provable signature of the firmware's private-broker-address misclassification — and surfaces it both per-packet and as a searchable report.

## Files updated

All five per the project convention: `package.json`, `package-lock.json` (regenerated via `npm install --package-lock-only`), `helm/meshmonitor/Chart.yaml` (both `version` and `appVersion`), `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`. Verified no `4.13.2-rc3` references remain in any of them.

## Note

Labeled for hardware system tests, as release version-bump PRs always are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aucxao43DBCoLHmbubvAS5