### PR TITLE
fix: merge Helm chart repo index instead of overwriting it on every deploy

### DIFF
--- a/scripts/build-helm-repo.sh
+++ b/scripts/build-helm-repo.sh
@@ -28,8 +28,23 @@ helm lint "$CHART_DIR"
 echo "==> Packaging chart into $OUT_DIR"
 helm package "$CHART_DIR" --destination "$OUT_DIR"
 
+# $OUT_DIR (docs/public/charts/) is gitignored and rebuilt from a clean
+# checkout on every run, so it only ever contains the chart version just
+# packaged above. Without merging in the index already live at $REPO_URL,
+# `helm repo index` would overwrite the published index.yaml with a
+# single-entry index, deleting every previously released version from the
+# repo (#4335). Fetch the current published index, if any, and merge it in.
+EXISTING_INDEX="$(mktemp)"
+trap 'rm -f "$EXISTING_INDEX"' EXIT
+
 echo "==> Generating repository index (url: $REPO_URL)"
-helm repo index "$OUT_DIR" --url "$REPO_URL"
+if curl -fsSL "$REPO_URL/index.yaml" -o "$EXISTING_INDEX"; then
+  echo "==> Merging with existing published index ($REPO_URL/index.yaml)"
+  helm repo index "$OUT_DIR" --url "$REPO_URL" --merge "$EXISTING_INDEX"
+else
+  echo "==> No existing published index found at $REPO_URL/index.yaml; generating fresh index"
+  helm repo index "$OUT_DIR" --url "$REPO_URL"
+fi
 
 echo "==> Helm repository contents:"
 ls -la "$OUT_DIR"


### PR DESCRIPTION
## Summary
- `scripts/build-helm-repo.sh` (run by `.github/workflows/deploy-docs.yml` on every push touching `helm/**`, `docs/**`, `package.json`, etc.) packages only the chart version at the current commit into the gitignored, freshly-checked-out `docs/public/charts/` directory, then ran `helm repo index` with no `--merge` — regenerating `index.yaml` from scratch with a single entry and silently deleting every previously published chart version from `https://meshmonitor.org/charts`.
- Fetch the currently-published `index.yaml` (best-effort — it won't exist on the very first publish) and pass it to `helm repo index --merge` so prior version entries are preserved instead of dropped.

Fixes #4335.

## Test plan
- [x] `bash -n scripts/build-helm-repo.sh` — syntax check passes
- [ ] CI: `Deploy Documentation` workflow run on merge to `main` republishes `https://meshmonitor.org/charts/index.yaml` and confirm it now contains all prior chart versions plus the new one (network policy in this sandbox blocks fetching the real `helm` binary / `get.helm.sh`, so this could not be exercised end-to-end locally — `helm repo index --merge`'s documented behavior is to preserve existing entries not present in the packaged directory, which is the only thing this change relies on)

https://claude.ai/code/session_019ebSXKDTLPWws3CBX28WdD

---
_Generated by [Claude Code](https://claude.ai/code/session_019ebSXKDTLPWws3CBX28WdD)_