### PR TITLE
fix(helm): fail loudly when the published chart index can't be fetched

### DIFF
--- a/scripts/build-helm-repo.sh
+++ b/scripts/build-helm-repo.sh
@@ -37,14 +37,36 @@ helm package "$CHART_DIR" --destination "$OUT_DIR"
 EXISTING_INDEX="$(mktemp)"
 trap 'rm -f "$EXISTING_INDEX"' EXIT
 
+#
+# Distinguish "no index published yet" from "could not reach the index": both
+# are non-2xx as far as `curl -f` is concerned, but only the first is safe to
+# proceed from. Regenerating a fresh index after a transient DNS/5xx/TLS
+# failure would silently reintroduce #4335 and drop every released version,
+# while exiting 0. A failed deploy is recoverable by re-running; an
+# overwritten index is visible to everyone running `helm repo update`, so we
+# fail loudly instead.
 echo "==> Generating repository index (url: $REPO_URL)"
-if curl -fsSL "$REPO_URL/index.yaml" -o "$EXISTING_INDEX"; then
-  echo "==> Merging with existing published index ($REPO_URL/index.yaml)"
-  helm repo index "$OUT_DIR" --url "$REPO_URL" --merge "$EXISTING_INDEX"
-else
-  echo "==> No existing published index found at $REPO_URL/index.yaml; generating fresh index"
-  helm repo index "$OUT_DIR" --url "$REPO_URL"
-fi
+# curl still writes %{http_code} (as 000) when it never got a response, so do
+# not append a fallback code here — that would report a doubled "000000".
+HTTP_CODE="$(curl -sSL -w '%{http_code}' -o "$EXISTING_INDEX" "$REPO_URL/index.yaml" || true)"
+HTTP_CODE="${HTTP_CODE:-000}"
+
+case "$HTTP_CODE" in
+  200)
+    echo "==> Merging with existing published index ($REPO_URL/index.yaml)"
+    helm repo index "$OUT_DIR" --url "$REPO_URL" --merge "$EXISTING_INDEX"
+    ;;
+  404)
+    echo "==> No existing published index found at $REPO_URL/index.yaml; generating fresh index"
+    helm repo index "$OUT_DIR" --url "$REPO_URL"
+    ;;
+  *)
+    echo "error: could not fetch $REPO_URL/index.yaml (HTTP $HTTP_CODE)." >&2
+    echo "       Refusing to publish an index that would drop already-released chart versions (#4335)." >&2
+    echo "       Re-run the deploy once the chart repository is reachable again." >&2
+    exit 1
+    ;;
+esac
 
 echo "==> Helm repository contents:"
 ls -la "$OUT_DIR"


### PR DESCRIPTION
Follow-up to #4336, as offered in review.

## The residual failure mode

#4336 correctly stopped `helm repo index` from wiping previously released chart versions (#4335) by merging the published index. But its `else` branch conflated two very different situations, because `curl -f` fails on **any** non-2xx *or* network error:

| Situation | Old behaviour | Correct? |
|---|---|---|
| No index published yet (genuine first run) | generate fresh index | ✅ |
| Couldn't reach the index (DNS blip, 5xx, TLS, Pages deploy mid-flight) | generate fresh index | ❌ **silently reintroduces #4335** |

In the second case the script exits 0 having just published a single-entry index — dropping every released version, with nothing in the log to say so. Since this runs on the docs-deploy path, it's a realistic way to lose the published index again.

## The fix

Branch on HTTP status instead of a bare success/failure:

- **200** → merge with the published index *(unchanged)*
- **404** → no index published yet, generate a fresh one *(unchanged)*
- **anything else**, including `000` when no response arrived → **fail the build** with an explanatory error

Failing is the safer default here: a failed deploy is recoverable by re-running, whereas an overwritten index is immediately visible to everyone running `helm repo update`.

## Verification

There's no test harness for this script, so I exercised it directly — a stub HTTP server returning each status, with a stubbed `helm` on `PATH` recording its invocations:

| Case | Exit | `helm repo index` calls | Passed `--merge`? |
|---|---|---|---|
| HTTP 200 | 0 | 1 | yes |
| HTTP 404 | 0 | 1 | no (correct) |
| HTTP 503 | 1 | **0** | — |
| Connection refused | 1 | **0** | — |

The two failure cases never invoke `helm repo index` at all, which is the whole point — the old code would have run it and published the truncated index.

`bash -n` clean. (`shellcheck` isn't installed in this environment, so it wasn't run.)

One self-inflicted bug caught by that testing and fixed before pushing: `curl -w '%{http_code}'` already emits `000` when it gets no response, so an added `|| echo 000` produced a doubled `HTTP 000000` in the error message. That string lands in a failed-deploy log, so it's worth being right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aucxao43DBCoLHmbubvAS5