### PR TITLE
fix(map): let the mobile node list resize to full width

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../styles/nodes.css';
 import { Popup, Tooltip, Polyline, Circle, useMap } from 'react-leaflet';
@@ -755,25 +755,51 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     mobile: isMobileLayout(window.innerWidth, window.innerHeight),
   }));
 
-  useEffect(() => {
+  // useLayoutEffect + ResizeObserver rather than useEffect + resize/
+  // orientationchange listeners. The initial state above has to fall back to
+  // window.innerWidth because the ref is null until the DOM exists, and that
+  // over-estimates the container by the width of the app rail. Measuring in a
+  // layout effect corrects it before paint, so the resizable's bounds are never
+  // briefly wrong (which could otherwise persist a clamped width the user never
+  // chose). The observer also catches container changes that fire no window
+  // event at all.
+  useLayoutEffect(() => {
+    const el = splitViewRef.current;
     const measure = () => {
-      const measured = splitViewRef.current?.getBoundingClientRect().width;
+      const measured = el?.getBoundingClientRect().width;
       const next = {
         availableWidth: measured && measured > 0 ? measured : window.innerWidth,
         mobile: isMobileLayout(window.innerWidth, window.innerHeight),
       };
-      // Bail on no-op updates: `resize` fires continuously during a window drag,
-      // and this state feeds the resizable's bounds.
+      // Bail on no-op updates: this fires continuously during a window drag and
+      // the value feeds the resizable's bounds.
       setSidebarMetrics(prev =>
         prev.availableWidth === next.availableWidth && prev.mobile === next.mobile ? prev : next
       );
     };
     measure();
-    window.addEventListener('resize', measure);
+
+    if (!el || typeof ResizeObserver === 'undefined') {
+      // jsdom and very old browsers: fall back to the window events.
+      window.addEventListener('resize', measure);
+      window.addEventListener('orientationchange', measure);
+      return () => {
+        window.removeEventListener('resize', measure);
+        window.removeEventListener('orientationchange', measure);
+      };
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    // ResizeObserver sees the container resize, but `mobile` also depends on
+    // viewport HEIGHT, which can cross the landscape threshold without the
+    // container's width changing.
     window.addEventListener('orientationchange', measure);
+    window.addEventListener('resize', measure);
     return () => {
-      window.removeEventListener('resize', measure);
+      observer.disconnect();
       window.removeEventListener('orientationchange', measure);
+      window.removeEventListener('resize', measure);
     };
   }, []);
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -34,6 +34,7 @@ import WaypointEditorModal from './WaypointEditorModal';
 import { useWaypoints } from '../hooks/useWaypoints';
 import type { Waypoint, WaypointInput } from '../types/waypoint';
 import { useResizable } from '../hooks/useResizable';
+import { resolveNodeSidebarMaxWidth, isMobileLayout, NODE_SIDEBAR_MIN_WIDTH_PX } from '../utils/sidebarWidth';
 import ZoomHandler from './ZoomHandler';
 import MapPositionHandler from './MapPositionHandler';
 import PolarGridOverlay from './PolarGridOverlay.js';
@@ -742,7 +743,43 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     return saved === 'true';
   });
 
-  // Node list sidebar resizable width (default 380px, min 200px, max 50% viewport)
+  // Width of the split-view container, which is what the node list may claim —
+  // not the viewport. The container is `position: fixed; left: var(--sidebar-width);
+  // right: 0`, so it already excludes the app rail. Tracked in state (rather than
+  // read inline) so the ceiling follows an orientation change or window resize:
+  // a plain `window.innerWidth` read only re-evaluates when something else
+  // happens to re-render this component.
+  const splitViewRef = useRef<HTMLDivElement>(null);
+  const [sidebarMetrics, setSidebarMetrics] = useState(() => ({
+    availableWidth: window.innerWidth,
+    mobile: isMobileLayout(window.innerWidth, window.innerHeight),
+  }));
+
+  useEffect(() => {
+    const measure = () => {
+      const measured = splitViewRef.current?.getBoundingClientRect().width;
+      const next = {
+        availableWidth: measured && measured > 0 ? measured : window.innerWidth,
+        mobile: isMobileLayout(window.innerWidth, window.innerHeight),
+      };
+      // Bail on no-op updates: `resize` fires continuously during a window drag,
+      // and this state feeds the resizable's bounds.
+      setSidebarMetrics(prev =>
+        prev.availableWidth === next.availableWidth && prev.mobile === next.mobile ? prev : next
+      );
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    window.addEventListener('orientationchange', measure);
+    return () => {
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('orientationchange', measure);
+    };
+  }, []);
+
+  // Node list sidebar resizable width. Mobile viewports may drag it to the full
+  // container width (the map sits behind a toggle there, so half-width was an
+  // arbitrary ceiling); desktop keeps the 50% split. See utils/sidebarWidth.ts.
   const {
     size: sidebarWidth,
     isResizing: isSidebarResizing,
@@ -751,8 +788,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   } = useResizable({
     id: 'nodes-sidebar-width',
     defaultHeight: 380,
-    minHeight: 200,
-    maxHeight: Math.round(window.innerWidth * 0.5),
+    minHeight: NODE_SIDEBAR_MIN_WIDTH_PX,
+    maxHeight: resolveNodeSidebarMaxWidth(sidebarMetrics.availableWidth, sidebarMetrics.mobile),
     direction: 'horizontal'
   });
 
@@ -1927,7 +1964,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   const mapDefaults = getMapCenter();
 
   return (
-    <div className="nodes-split-view nodes-anchored-view">
+    <div ref={splitViewRef} className="nodes-split-view nodes-anchored-view">
       {/* Anchored Node List Sidebar */}
       <div
         ref={sidebarRef}

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useResizable clamped every resizable against `window.innerHeight * 0.8`,
+ * including horizontal ones — capping a *width* against the viewport's
+ * *height*. On a landscape phone that silently overrode whatever maxHeight the
+ * caller asked for, which is the second half of the "node list won't go full
+ * width on mobile" bug (the first half being NodesTab's own 50% ceiling).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
+import { useResizable } from './useResizable';
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', { value: width, writable: true, configurable: true });
+  Object.defineProperty(window, 'innerHeight', { value: height, writable: true, configurable: true });
+}
+
+/** Drag the handle by `delta` px along the resize axis and return the new size. */
+function drag(
+  result: { current: ReturnType<typeof useResizable> },
+  from: number,
+  delta: number,
+  axis: 'x' | 'y',
+) {
+  const pos = axis === 'x' ? { clientX: from, clientY: 0 } : { clientX: 0, clientY: from };
+  act(() => {
+    result.current.handleMouseDown({
+      ...pos,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+    } as unknown as React.MouseEvent);
+  });
+  const to = axis === 'x' ? from + delta : from - delta; // vertical grows upward
+  act(() => {
+    window.dispatchEvent(new MouseEvent('mousemove', {
+      clientX: axis === 'x' ? to : 0,
+      clientY: axis === 'y' ? to : 0,
+    }));
+  });
+  return result.current.size;
+}
+
+const ORIGINAL = { w: window.innerWidth, h: window.innerHeight };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  setViewport(ORIGINAL.w, ORIGINAL.h);
+  vi.restoreAllMocks();
+});
+
+describe('useResizable — horizontal clamping uses viewport WIDTH', () => {
+  it('lets a landscape phone drag a sidebar past 0.8 * viewport height', () => {
+    // 844x390 landscape. The old ceiling was 390*0.8 = 312px, so a caller
+    // asking for 844 could never exceed 312 — full width was unreachable.
+    setViewport(844, 390);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-landscape',
+      defaultHeight: 300,
+      minHeight: 200,
+      maxHeight: 844,
+      direction: 'horizontal',
+    }));
+
+    const size = drag(result, 300, 500, 'x');
+    expect(size).toBeGreaterThan(390 * 0.8);
+    expect(size).toBe(800); // 300 + 500, under the 844 ceiling
+  });
+
+  it('still refuses to exceed the viewport width', () => {
+    setViewport(390, 844);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-portrait-ceiling',
+      defaultHeight: 300,
+      minHeight: 200,
+      maxHeight: 390,
+      direction: 'horizontal',
+    }));
+
+    expect(drag(result, 300, 5000, 'x')).toBe(390);
+  });
+
+  it('honours a caller max below the viewport width (desktop 50% split)', () => {
+    setViewport(1920, 1080);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-desktop',
+      defaultHeight: 380,
+      minHeight: 200,
+      maxHeight: 930,
+      direction: 'horizontal',
+    }));
+
+    expect(drag(result, 380, 5000, 'x')).toBe(930);
+  });
+
+  it('never lets min win past the viewport when max < min on a tiny viewport', () => {
+    setViewport(150, 800);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-tiny',
+      defaultHeight: 200,
+      minHeight: 200,
+      maxHeight: 100,
+      direction: 'horizontal',
+    }));
+
+    expect(drag(result, 200, 500, 'x')).toBeLessThanOrEqual(150);
+  });
+});
+
+describe('useResizable — the initial size is clamped to the current bounds', () => {
+  it('clamps the persisted width that no longer fits, instead of overflowing', () => {
+    // The real phone case: 380px desktop default inside a 342px container put
+    // the drag handle at x=419 on a 390px-wide screen — off-screen, so the user
+    // could not drag it back into range.
+    setViewport(390, 844);
+    localStorage.setItem('resizable_size_nodes-sidebar-width', '380');
+
+    const { result } = renderHook(() => useResizable({
+      id: 'nodes-sidebar-width',
+      defaultHeight: 380,
+      minHeight: 200,
+      maxHeight: 342,
+      direction: 'horizontal',
+    }));
+
+    expect(result.current.size).toBe(342);
+    // The correction is persisted so it survives a reload.
+    expect(localStorage.getItem('resizable_size_nodes-sidebar-width')).toBe('342');
+  });
+
+  it('clamps an unclamped default the same way', () => {
+    setViewport(390, 844);
+    const { result } = renderHook(() => useResizable({
+      id: 'fresh-mobile',
+      defaultHeight: 380,
+      minHeight: 200,
+      maxHeight: 342,
+      direction: 'horizontal',
+    }));
+    expect(result.current.size).toBe(342);
+  });
+
+  it('leaves an in-range size untouched and does not write to storage', () => {
+    setViewport(1920, 1080);
+    localStorage.setItem('resizable_size_in-range', '500');
+    const { result } = renderHook(() => useResizable({
+      id: 'in-range',
+      defaultHeight: 380,
+      minHeight: 200,
+      maxHeight: 930,
+      direction: 'horizontal',
+    }));
+    expect(result.current.size).toBe(500);
+    expect(localStorage.getItem('resizable_size_in-range')).toBe('500');
+  });
+});
+
+describe('useResizable — vertical clamping is unchanged', () => {
+  it('keeps the 0.8 * viewport height ceiling', () => {
+    setViewport(1920, 1000);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-vertical-ceiling',
+      defaultHeight: 300,
+      minHeight: 150,
+      maxHeight: 5000, // deliberately above the guard
+      direction: 'vertical',
+    }));
+
+    expect(drag(result, 500, 5000, 'y')).toBe(800); // 1000 * 0.8
+  });
+
+  it('honours a caller max below the guard', () => {
+    setViewport(1920, 1000);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-vertical-caller-max',
+      defaultHeight: 280,
+      minHeight: 120,
+      maxHeight: 600,
+      direction: 'vertical',
+    }));
+
+    expect(drag(result, 500, 5000, 'y')).toBe(600);
+  });
+
+  it('enforces the minimum', () => {
+    setViewport(1920, 1000);
+    const { result } = renderHook(() => useResizable({
+      id: 'test-vertical-min',
+      defaultHeight: 300,
+      minHeight: 150,
+      maxHeight: 600,
+      direction: 'vertical',
+    }));
+
+    expect(drag(result, 500, -5000, 'y')).toBe(150);
+  });
+});

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -63,13 +63,30 @@ export function useResizable(options: UseResizableOptions): UseResizableReturn {
   const [isResizing, setIsResizing] = useState(false);
   const resizeStartRef = useRef<{ startPos: number; startSize: number } | null>(null);
 
-  // Constrain size to bounds
+  // Constrain size to bounds.
+  //
+  // The safety ceiling has to be measured on the axis being resized. It used to
+  // be `window.innerHeight * 0.8` unconditionally, which is meaningless for a
+  // horizontal resizable: it capped a *width* against the viewport's *height*,
+  // so a landscape phone (e.g. 844x390) could not drag a sidebar past 312px no
+  // matter what maxHeight the caller asked for.
+  //
+  // Vertical callers keep the exact previous behaviour (0.8 of the viewport
+  // height). Horizontal callers get the full viewport width as the ceiling, so
+  // an explicit maxHeight is what actually governs — a full-width panel is a
+  // legitimate layout on a narrow screen, where a 0.8 ceiling would just strand
+  // an unusable sliver of the other pane.
   const constrainSize = useCallback((newSize: number): number => {
-    const effectiveMaxHeight = typeof maxHeight === 'number'
-      ? Math.min(maxHeight, window.innerHeight * 0.8)
+    const ceiling = direction === 'horizontal'
+      ? window.innerWidth
       : window.innerHeight * 0.8;
-    return Math.max(minHeight, Math.min(newSize, effectiveMaxHeight));
-  }, [minHeight, maxHeight]);
+    const effectiveMax = typeof maxHeight === 'number'
+      ? Math.min(maxHeight, ceiling)
+      : ceiling;
+    // A caller whose max is below its own min (very narrow viewport) must not
+    // end up with min winning and overflowing the container.
+    return Math.min(Math.max(minHeight, Math.min(newSize, effectiveMax)), ceiling);
+  }, [minHeight, maxHeight, direction]);
 
   // Handle mouse move during resize
   const handleMouseMove = useCallback((e: MouseEvent) => {
@@ -174,6 +191,24 @@ export function useResizable(options: UseResizableOptions): UseResizableReturn {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [constrainSize]);
+
+  // ...and on mount / whenever the bounds themselves change. The initial value
+  // comes straight from localStorage (or defaultHeight) and used to be applied
+  // unclamped, so a size that no longer fits the current bounds survived until
+  // the user happened to resize the window. On a phone that stranded the node
+  // list at its 380px desktop default inside a 342px container, pushing its
+  // drag handle off-screen — unreachable, so there was no way to correct it.
+  // Depending on constrainSize also re-clamps when a caller's maxHeight changes
+  // (e.g. rotating the device), not just on first render.
+  useEffect(() => {
+    setSize(currentSize => {
+      const clamped = constrainSize(currentSize);
+      // Only persist when we actually had to correct something, so this never
+      // writes a value the user didn't choose.
+      if (clamped !== currentSize) saveSize(id, clamped);
+      return clamped;
+    });
+  }, [constrainSize, id]);
 
   return {
     size,

--- a/src/utils/sidebarWidth.test.ts
+++ b/src/utils/sidebarWidth.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The Map view's node list is drag-resizable, but its ceiling was a flat
+ * `innerWidth * 0.5` on every viewport. On a phone that stops the list — the
+ * pane you are actually reading, with the map behind a toggle — at half the
+ * screen, and on a narrow phone the ceiling fell below the floor.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveNodeSidebarMaxWidth,
+  isMobileLayout,
+  MOBILE_BREAKPOINT_PX,
+  MOBILE_LANDSCAPE_MAX_HEIGHT_PX,
+  NODE_SIDEBAR_MIN_WIDTH_PX,
+} from './sidebarWidth';
+
+describe('isMobileLayout', () => {
+  it.each([
+    ['iPhone SE portrait', 375, 667],
+    ['iPhone 14 portrait', 390, 844],
+    ['Pixel portrait', 412, 915],
+    ['iPad portrait (at the breakpoint)', MOBILE_BREAKPOINT_PX, 1024],
+  ])('%s (%ix%i) is mobile via the width rule', (_l, w, h) => {
+    expect(isMobileLayout(w, h)).toBe(true);
+  });
+
+  it.each([
+    ['iPhone 14 landscape', 844, 390],
+    ['iPhone SE landscape', 667, 375],
+    ['landscape at the height limit', 900, MOBILE_LANDSCAPE_MAX_HEIGHT_PX],
+  ])('%s (%ix%i) is mobile via the landscape rule', (_l, w, h) => {
+    // This is the case a width-only test misclassifies: 844 > 768, yet App.css
+    // still collapses the rail to 48px, so it IS the mobile layout.
+    expect(isMobileLayout(w, h)).toBe(true);
+  });
+
+  it.each([
+    ['1080p desktop', 1920, 1080],
+    ['laptop', 1366, 768],
+    ['small desktop window', 1000, 700],
+    ['tall narrow-ish desktop', 1200, 1000],
+  ])('%s (%ix%i) is NOT mobile', (_l, w, h) => {
+    expect(isMobileLayout(w, h)).toBe(false);
+  });
+
+  it('does not treat a short PORTRAIT window as mobile landscape', () => {
+    // height <= 500 but portrait — the CSS query requires orientation: landscape.
+    expect(isMobileLayout(900, 480)).toBe(true);  // landscape (900 > 480)
+    expect(isMobileLayout(480, 400)).toBe(true);  // width rule catches this one
+    expect(isMobileLayout(1000, 1000)).toBe(false); // square: not landscape
+  });
+});
+
+describe('resolveNodeSidebarMaxWidth', () => {
+  describe('mobile gets the full container width', () => {
+    it.each([
+      ['iPhone SE portrait', 375 - 48],
+      ['iPhone 14 portrait', 390 - 48],
+      ['iPhone 14 landscape', 844 - 48],
+      ['small tablet portrait', 600],
+    ])('%s (%ipx container) → the whole container', (_label, available) => {
+      expect(resolveNodeSidebarMaxWidth(available, true)).toBe(available);
+    });
+
+    it('is the regression: the old half-width rule capped a phone well short', () => {
+      const available = 390 - 48; // 342
+      const oldCap = Math.round(available * 0.5); // 171
+      expect(resolveNodeSidebarMaxWidth(available, true)).toBeGreaterThan(oldCap);
+      expect(resolveNodeSidebarMaxWidth(available, true)).toBe(available);
+    });
+
+    it('never returns a max below the min, even for a container under the floor', () => {
+      // The old rule produced max=195 < min=200 on a 390px viewport, which
+      // pinned the list to exactly one width regardless of drag.
+      expect(resolveNodeSidebarMaxWidth(150, true)).toBe(NODE_SIDEBAR_MIN_WIDTH_PX);
+      expect(resolveNodeSidebarMaxWidth(NODE_SIDEBAR_MIN_WIDTH_PX, true)).toBe(NODE_SIDEBAR_MIN_WIDTH_PX);
+    });
+  });
+
+  describe('desktop keeps the 50% split', () => {
+    it.each([
+      [770, 385],
+      [1280 - 60, 610],
+      [1920 - 60, 930],
+    ])('%ipx container → %ipx', (available, expected) => {
+      expect(resolveNodeSidebarMaxWidth(available, false)).toBe(expected);
+    });
+
+    it('does not regress desktop: the map always keeps at least half the area', () => {
+      const available = 1465;
+      expect(resolveNodeSidebarMaxWidth(available, false)).toBeLessThanOrEqual(available / 2 + 1);
+    });
+  });
+
+  describe('degenerate inputs', () => {
+    it.each([0, -100, NaN, Infinity])('%p falls back to the min rather than junk', (v) => {
+      expect(resolveNodeSidebarMaxWidth(v, true)).toBe(NODE_SIDEBAR_MIN_WIDTH_PX);
+      expect(resolveNodeSidebarMaxWidth(v, false)).toBe(NODE_SIDEBAR_MIN_WIDTH_PX);
+    });
+  });
+});

--- a/src/utils/sidebarWidth.test.ts
+++ b/src/utils/sidebarWidth.test.ts
@@ -42,11 +42,26 @@ describe('isMobileLayout', () => {
     expect(isMobileLayout(w, h)).toBe(false);
   });
 
-  it('does not treat a short PORTRAIT window as mobile landscape', () => {
-    // height <= 500 but portrait — the CSS query requires orientation: landscape.
-    expect(isMobileLayout(900, 480)).toBe(true);  // landscape (900 > 480)
-    expect(isMobileLayout(480, 400)).toBe(true);  // width rule catches this one
-    expect(isMobileLayout(1000, 1000)).toBe(false); // square: not landscape
+  it('treats a wide, short viewport as mobile landscape', () => {
+    expect(isMobileLayout(900, 480)).toBe(true);
+  });
+
+  it('falls back to the width rule for a narrow, short viewport', () => {
+    // Reaches `true` via `width <= 768`, not via the landscape branch.
+    expect(isMobileLayout(480, 400)).toBe(true);
+  });
+
+  it('is not mobile for a large square viewport', () => {
+    // Square counts as landscape per the CSS, but 1000px height is far past
+    // the 500px limit, so the landscape branch does not apply.
+    expect(isMobileLayout(1000, 1000)).toBe(false);
+  });
+
+  it('matches the CSS treatment of a square viewport as landscape', () => {
+    // `orientation: landscape` fires at width === height. Unreachable in
+    // practice (a square under the 500px height limit is also under the 768px
+    // width rule), but pinned so the "mirrors the CSS" claim stays honest.
+    expect(isMobileLayout(400, 400)).toBe(true);
   });
 });
 

--- a/src/utils/sidebarWidth.ts
+++ b/src/utils/sidebarWidth.ts
@@ -1,0 +1,68 @@
+/**
+ * Node-list sidebar sizing rules (issue: mobile node list capped at half width).
+ *
+ * The Map view's node list is drag-resizable. Its ceiling used to be a flat
+ * `window.innerWidth * 0.5` regardless of viewport, which is wrong on a phone:
+ * there the list is the primary surface and the map lives behind a toggle, so
+ * half the screen is an arbitrary limit on the pane you are actually reading.
+ * On a 390px-wide phone it was worse than arbitrary — the 195px ceiling landed
+ * *below* the 200px floor, pinning the list to exactly one width.
+ */
+
+/** Matches the `@media (max-width: 768px)` breakpoint used across the sheets. */
+export const MOBILE_BREAKPOINT_PX = 768;
+
+/**
+ * Matches the `@media (max-height: 500px) and (orientation: landscape)` block.
+ * A landscape phone is wider than MOBILE_BREAKPOINT_PX but is still the mobile
+ * layout — App.css collapses the rail to 48px for both conditions, so the width
+ * test alone would misclassify it as desktop.
+ */
+export const MOBILE_LANDSCAPE_MAX_HEIGHT_PX = 500;
+
+/** Narrowest useful node list. */
+export const NODE_SIDEBAR_MIN_WIDTH_PX = 200;
+
+/** Fraction of the available area the list may claim on a desktop viewport. */
+export const NODE_SIDEBAR_DESKTOP_MAX_FRACTION = 0.5;
+
+/**
+ * Whether the viewport is in the app's mobile layout.
+ *
+ * Deliberately mirrors the two `:root { --sidebar-width: 48px }` media queries
+ * in App.css rather than inventing a third definition of "mobile". Keep the two
+ * in sync: if those queries change, this changes with them.
+ *
+ * Note this does NOT catch a 1366x768 laptop (width > 768, height > 500), so
+ * desktop keeps its 50% split.
+ */
+export function isMobileLayout(viewportWidth: number, viewportHeight: number): boolean {
+  if (viewportWidth <= MOBILE_BREAKPOINT_PX) return true;
+  return viewportHeight <= MOBILE_LANDSCAPE_MAX_HEIGHT_PX && viewportWidth > viewportHeight;
+}
+
+/**
+ * Largest width the node list may be dragged to.
+ *
+ * @param availableWidth Width of the split-view container — NOT the viewport.
+ *   The container is `position: fixed; left: var(--sidebar-width); right: 0`, so
+ *   it already excludes the app rail (48px mobile / 60px desktop). Measuring the
+ *   container rather than subtracting a hardcoded rail width keeps this correct
+ *   if the rail ever changes.
+ * @param mobile Result of isMobileLayout() for the current viewport.
+ *
+ * Mobile: the whole container, so the list can cover the map entirely.
+ * Desktop: half, so the map keeps usable space next to it.
+ *
+ * Never returns less than the floor — a container narrower than the floor would
+ * otherwise produce max < min, which pins the list to a single width.
+ */
+export function resolveNodeSidebarMaxWidth(availableWidth: number, mobile: boolean): number {
+  if (!Number.isFinite(availableWidth) || availableWidth <= 0) {
+    return NODE_SIDEBAR_MIN_WIDTH_PX;
+  }
+  const max = mobile
+    ? availableWidth
+    : Math.round(availableWidth * NODE_SIDEBAR_DESKTOP_MAX_FRACTION);
+  return Math.max(NODE_SIDEBAR_MIN_WIDTH_PX, max);
+}

--- a/src/utils/sidebarWidth.ts
+++ b/src/utils/sidebarWidth.ts
@@ -38,7 +38,12 @@ export const NODE_SIDEBAR_DESKTOP_MAX_FRACTION = 0.5;
  */
 export function isMobileLayout(viewportWidth: number, viewportHeight: number): boolean {
   if (viewportWidth <= MOBILE_BREAKPOINT_PX) return true;
-  return viewportHeight <= MOBILE_LANDSCAPE_MAX_HEIGHT_PX && viewportWidth > viewportHeight;
+  // `>=` not `>`: CSS `orientation: landscape` counts a square viewport as
+  // landscape. The two can only ever disagree at width === height, which also
+  // requires height <= 500 and therefore width <= 500 — already caught by the
+  // width rule above — so this is about making the "mirrors the CSS" claim
+  // exactly true rather than about a reachable case.
+  return viewportHeight <= MOBILE_LANDSCAPE_MAX_HEIGHT_PX && viewportWidth >= viewportHeight;
 }
 
 /**


### PR DESCRIPTION
On a phone, the Map view's node list can't be dragged past roughly half the screen. Reported: *"on mobile, it won't let me set the size larger than half the screen width. It should allow for full width."*

Three separate limits were involved. All three had to go for the drag to actually reach full width.

## 1. `NodesTab` capped the list at a flat 50% of the viewport

`maxHeight: Math.round(window.innerWidth * 0.5)` on every viewport. On a 390px phone that's a **195px ceiling sitting below the 200px floor**, so `constrainSize` returned the floor for any drag — the list was pinned to exactly one width, not merely limited to half.

The ceiling now comes from `resolveNodeSidebarMaxWidth()`, which measures the **split-view container** rather than the viewport. That container is `position: fixed; left: var(--sidebar-width); right: 0`, so it already excludes the 48/60px app rail — measuring it means "full width" is the area actually available, with no hardcoded rail width to drift.

## 2. `useResizable` clamped the wrong axis

`Math.min(maxHeight, window.innerHeight * 0.8)` was applied to horizontal resizables too — capping a **width** against the viewport's **height**. On a landscape phone (844×390) that's a 312px ceiling that silently overrides whatever `maxHeight` the caller passes, so fixing only #1 would not have worked in landscape.

The ceiling is now taken on the axis being resized. Vertical callers (packet monitor, DM send section) keep the exact previous `0.8 * innerHeight` behavior — the node list is the only horizontal consumer, and the new tests pin the vertical cases so this stays true.

## 3. The initial size was never clamped

Found while testing live, not from reading: the 380px desktop default inside a 342px container put the drag handle at **x=419 on a 390px screen — off-screen and unreachable**, so a fresh phone had no way to drag it back into range. The size is now clamped on mount and whenever the bounds change (e.g. rotation), persisting only when a correction was actually needed so it never writes a width the user didn't choose.

## Defining "mobile"

`isMobileLayout()` mirrors the two `:root { --sidebar-width: 48px }` media queries in `App.css` — `max-width: 768px` **or** `max-height: 500px and (orientation: landscape)` — rather than inventing a third definition of mobile.

This matters: my first cut keyed off container width alone, and a landscape phone (844 > 768) fell through to the desktop 50% branch and capped at 398px, *even though the CSS had already collapsed its rail to 48px*. Only driving a real landscape viewport caught it. The rule still excludes a 1366×768 laptop (width > 768, height > 500), so desktop keeps its 50% split.

The container width is tracked in state and re-measured on `resize`/`orientationchange`; the previous inline `window.innerWidth` read only re-evaluated when something unrelated happened to re-render `NodesTab`.

## Verification

Full suite: **11,729 tests, 0 failures, 0 failed suites** (669 skipped are the PostgreSQL/MySQL suites — no schema changes here). `tsc --noEmit` clean, `lint:ci` no in-repo failures. 36 new unit tests.

The horizontal `useResizable` tests were confirmed to **fail against the pre-fix hook** while all vertical ones pass, so they discriminate rather than pass vacuously.

Driven against the dev container at three viewports, dragging with real touch events on mobile and mouse on desktop:

| Viewport | Container | Max reachable | Notes |
|---|---|---|---|
| Phone portrait 390×844 | 342px | **342 (full)** | was pinned at 200; floor still 200; stored 380 corrected to 342, handle back on-screen at x=381 |
| Phone landscape 844×390 | 796px | **796 (full)** | past both the old 312px axis ceiling and the first cut's 398px |
| Desktop 1920×1080 | 1860px | **930 (50%)** | unchanged |

## Open question for the reviewer

On a fresh phone the list now defaults to full width, hiding the map until you collapse it. This is **not** a regression — the old 380px default already overflowed the 342px container and squeezed the map to zero, just with an unreachable handle — but if a narrower mobile default (say 60% of the container, with full width still available by dragging) is preferred, that's a small follow-up. Left alone here because the report was specifically about the maximum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZtasD4tS76xq2PTDHMA5o