### PR TITLE
Fix Map Style activation UI, label collision, and Dashboard styling (#4348)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2791,8 +2791,8 @@
   "theme_gallery.persistence_desc": "Your theme choice is saved automatically and will persist across sessions. All themes work seamlessly across all pages and components.",
 
   "tileset.map_style": "Map Style",
-  "tileset.map_style_light": "Map Style (Light mode)",
-  "tileset.map_style_dark": "Map Style (Dark mode)",
+  "tileset.tileset_light": "Tileset (Light mode)",
+  "tileset.tileset_dark": "Tileset (Dark mode)",
   "tileset.custom": "Custom",
   "tileset.collapse": "Collapse tileset selector",
   "tileset.expand": "Expand tileset selector",

--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -33,7 +33,12 @@ const mocks = vi.hoisted(() => ({
 // `leaflet` mock below doesn't provide) — both are stubbed the same way
 // BaseMap.test.tsx does it, so this bare-component render stays dependency-free.
 vi.mock('../VectorTileLayer', () => ({
-  VectorTileLayer: () => <div data-testid="vector-tile-layer" />,
+  // Surfaces styleJson as a data attribute (issue #4348) so tests can assert
+  // DashboardMap forwards the active MapLibre style through to the vector
+  // tile layer, matching NodesTab's behavior.
+  VectorTileLayer: ({ styleJson }: { styleJson?: Record<string, unknown> }) => (
+    <div data-testid="vector-tile-layer" data-style-json={styleJson ? JSON.stringify(styleJson) : ''} />
+  ),
 }));
 vi.mock('../map/leafletDefaultIcon', () => ({}));
 
@@ -135,11 +140,14 @@ vi.mock('../../utils/mapIcons', () => ({
 }));
 
 vi.mock('../../config/tilesets', () => ({
-  getTilesetById: () => ({
-    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-    attribution: '© OSM',
-    maxZoom: 19,
-  }),
+  // Resolves the fixture vector tileset (below) as a vector tileset so
+  // BaseMap takes its VectorTileLayer branch (issue #4348 problem 4); every
+  // other id keeps the pre-existing raster stub the rest of this file relies on.
+  getTilesetById: (id: string) => (
+    id === 'custom-vector-1'
+      ? { url: 'http://tileserver.local/data/v3/{z}/{x}/{y}.pbf', attribution: '', maxZoom: 19, isVector: true }
+      : { url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png', attribution: '© OSM', maxZoom: 19 }
+  ),
   DEFAULT_TILESET_ID: 'osm',
 }));
 
@@ -309,6 +317,7 @@ describe('DashboardMap', () => {
     mocks.settings.defaultMapCenterLat = null;
     mocks.settings.defaultMapCenterLon = null;
     mocks.settings.defaultMapCenterZoom = null;
+    mocks.settings.activeStyleJson = null;
   });
 
   // --- Default Map Center vs auto-fit (issue #4125) ---------------------------
@@ -648,5 +657,45 @@ describe('DashboardMap', () => {
     const markers = screen.getAllByTestId('map-marker');
     expect(markers).toHaveLength(1);
     expect(markers[0].textContent).not.toContain('MC');
+  });
+
+  // --- Active Map Style passthrough (issue #4348 problem 4) --------------
+  // DashboardMap previously never applied a custom MapLibre style at all —
+  // it didn't consume activeStyleJson from SettingsContext or forward it to
+  // BaseMap. These tests guard the fix: the vector tile layer must receive
+  // whatever style is currently active, and must not blow up when none is.
+
+  const vectorCustomTileset = {
+    id: 'custom-vector-1',
+    name: 'Self-hosted vector',
+    url: 'http://tileserver.local/data/v3/{z}/{x}/{y}.pbf',
+    attribution: '',
+    isVector: true,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  it('forwards the active map style JSON into the vector tile layer', () => {
+    const styleJson = { version: 8, sources: {}, layers: [] };
+    mocks.settings.activeStyleJson = styleJson;
+    render(
+      <DashboardMap
+        {...defaultProps}
+        tilesetId={vectorCustomTileset.id}
+        customTilesets={[vectorCustomTileset]}
+      />,
+    );
+    expect(screen.getByTestId('vector-tile-layer').dataset.styleJson).toBe(JSON.stringify(styleJson));
+  });
+
+  it('renders the vector tile layer without a style when no map style is active', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        tilesetId={vectorCustomTileset.id}
+        customTilesets={[vectorCustomTileset]}
+      />,
+    );
+    expect(screen.getByTestId('vector-tile-layer').dataset.styleJson).toBe('');
   });
 });

--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     defaultMapCenterLat: null as number | null,
     defaultMapCenterLon: null as number | null,
     defaultMapCenterZoom: null as number | null,
+    activeStyleJson: null as Record<string, unknown> | null,
   },
 }));
 

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -168,6 +168,7 @@ export default function DashboardMap({
     defaultMapCenterLat,
     defaultMapCenterLon,
     defaultMapCenterZoom,
+    activeStyleJson,
   } = useSettings();
 
   // A Default Map Center is only "configured" when all three parts are set.
@@ -627,6 +628,7 @@ export default function DashboardMap({
         zoom={hasConfiguredDefaultCenter ? defaultMapCenterZoom : 10}
         tilesetId={tilesetId}
         customTilesets={customTilesets}
+        styleJson={activeStyleJson ?? undefined}
         zoomControl
         showTilesetSelector={showTileSelector}
         onTilesetChange={setMapTileset}

--- a/src/components/MapStyleManager.test.tsx
+++ b/src/components/MapStyleManager.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MapStyleManager from './MapStyleManager';
+
+// issue #4348 — the "Activate" action and active-style badge are new; the
+// delete-while-active guard is the fix for a review finding that a failed
+// DELETE must not clear the active-style selection.
+
+const mockApiGet = vi.fn();
+vi.mock('../services/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    getBaseUrl: vi.fn().mockResolvedValue(''),
+  },
+}));
+
+const mockCsrfFetch = vi.fn();
+vi.mock('../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => mockCsrfFetch,
+}));
+
+const mockSetActiveMapStyleId = vi.fn();
+const mockLoadMapStyles = vi.fn();
+const settingsMock = vi.hoisted(() => ({ activeStyleId: null as string | null }));
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    activeStyleId: settingsMock.activeStyleId,
+    setActiveMapStyleId: mockSetActiveMapStyleId,
+    loadMapStyles: mockLoadMapStyles,
+  }),
+}));
+
+const styleA = { id: 'style-a', name: 'Style A', filename: 'a.json', sourceType: 'upload' as const, sourceUrl: null, createdAt: 0, updatedAt: 0 };
+const styleB = { id: 'style-b', name: 'Style B', filename: 'b.json', sourceType: 'url' as const, sourceUrl: 'https://example.com/b.json', createdAt: 0, updatedAt: 0 };
+
+describe('MapStyleManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    settingsMock.activeStyleId = null;
+    mockApiGet.mockResolvedValue([styleA, styleB]);
+  });
+
+  it('shows an Active badge for the currently active style and an Activate button for the rest', async () => {
+    settingsMock.activeStyleId = 'style-a';
+    render(<MapStyleManager />);
+
+    await screen.findByDisplayValue('Style A');
+    expect(screen.getByText('Active')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Activate' })).toBeDefined();
+  });
+
+  it('activating a style calls the shared setActiveMapStyleId setter', async () => {
+    const user = userEvent.setup();
+    render(<MapStyleManager />);
+
+    await screen.findByDisplayValue('Style A');
+    const activateButtons = screen.getAllByRole('button', { name: 'Activate' });
+    await user.click(activateButtons[0]);
+
+    expect(mockSetActiveMapStyleId).toHaveBeenCalledWith('style-a');
+  });
+
+  it('clears the active style only after a successful delete', async () => {
+    settingsMock.activeStyleId = 'style-a';
+    mockCsrfFetch.mockResolvedValue({ ok: true });
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const user = userEvent.setup();
+    render(<MapStyleManager />);
+
+    await screen.findByDisplayValue('Style A');
+    const [deleteA] = screen.getAllByRole('button', { name: 'Delete' });
+    await user.click(deleteA);
+
+    await waitFor(() => expect(mockSetActiveMapStyleId).toHaveBeenCalledWith(null));
+    expect(mockLoadMapStyles).toHaveBeenCalled();
+  });
+
+  it('does not clear the active style when the delete request fails', async () => {
+    settingsMock.activeStyleId = 'style-a';
+    mockCsrfFetch.mockResolvedValue({ ok: false });
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+    render(<MapStyleManager />);
+
+    await screen.findByDisplayValue('Style A');
+    const [deleteA] = screen.getAllByRole('button', { name: 'Delete' });
+    await user.click(deleteA);
+
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+    expect(mockSetActiveMapStyleId).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/components/MapStyleManager.test.tsx
+++ b/src/components/MapStyleManager.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MapStyleManager from './MapStyleManager';
@@ -42,6 +42,10 @@ describe('MapStyleManager', () => {
     vi.clearAllMocks();
     settingsMock.activeStyleId = null;
     mockApiGet.mockResolvedValue([styleA, styleB]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('shows an Active badge for the currently active style and an Activate button for the rest', async () => {

--- a/src/components/MapStyleManager.test.tsx
+++ b/src/components/MapStyleManager.test.tsx
@@ -81,6 +81,7 @@ describe('MapStyleManager', () => {
 
     await waitFor(() => expect(mockSetActiveMapStyleId).toHaveBeenCalledWith(null));
     expect(mockLoadMapStyles).toHaveBeenCalled();
+    expect(screen.queryByDisplayValue('Style A')).toBeNull();
   });
 
   it('does not clear the active style when the delete request fails', async () => {

--- a/src/components/MapStyleManager.test.tsx
+++ b/src/components/MapStyleManager.test.tsx
@@ -88,6 +88,8 @@ describe('MapStyleManager', () => {
     settingsMock.activeStyleId = 'style-a';
     mockCsrfFetch.mockResolvedValue({ ok: false });
     vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const alertSpy = vi.fn();
+    vi.stubGlobal('alert', alertSpy);
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const user = userEvent.setup();
     render(<MapStyleManager />);
@@ -97,6 +99,7 @@ describe('MapStyleManager', () => {
     await user.click(deleteA);
 
     await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Delete failed'));
     expect(mockSetActiveMapStyleId).not.toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
   });

--- a/src/components/MapStyleManager.tsx
+++ b/src/components/MapStyleManager.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import type { MapStyle } from '../server/services/mapStyleService.js';
 import api from '../services/api';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
+import { useSettings } from '../contexts/SettingsContext';
+import { UiIcon } from './icons';
 
 const MapStyleManager: React.FC = () => {
   const [styles, setStyles] = useState<MapStyle[]>([]);
@@ -15,6 +17,7 @@ const MapStyleManager: React.FC = () => {
   const [generatingStyle, setGeneratingStyle] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const csrfFetch = useCsrfFetch();
+  const { activeStyleId, setActiveMapStyleId, loadMapStyles } = useSettings();
 
   const fetchStyles = useCallback(async () => {
     try {
@@ -30,6 +33,13 @@ const MapStyleManager: React.FC = () => {
   useEffect(() => {
     void fetchStyles();
   }, [fetchStyles]);
+
+  // Activate a style as the app-wide default (issue #4348). This is the same
+  // action as the "Map Style" dropdown on the map's Features panel — exposed
+  // here too so the active style is discoverable from Settings.
+  const activateStyle = useCallback(async (id: string) => {
+    await setActiveMapStyleId(id);
+  }, [setActiveMapStyleId]);
 
   const handleUpload = async (file: File) => {
     setUploading(true);
@@ -49,6 +59,7 @@ const MapStyleManager: React.FC = () => {
         throw new Error(err.error ?? 'Upload failed');
       }
       await fetchStyles();
+      await loadMapStyles();
     } catch (err) {
       console.error('Failed to upload map style:', err);
       alert(`Upload failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
@@ -75,6 +86,7 @@ const MapStyleManager: React.FC = () => {
       setImportUrl('');
       setImportName('');
       await fetchStyles();
+      await loadMapStyles();
     } catch (err) {
       console.error('Failed to import map style from URL:', err);
       alert(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
@@ -110,7 +122,12 @@ const MapStyleManager: React.FC = () => {
       setTileJsonName('');
     } catch (err) {
       console.error('Failed to generate map style from tileserver:', err);
-      alert(`Generation failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      alert(
+        `Generation failed: ${message}\n\n` +
+        'This field expects a raw TileJSON endpoint (e.g. /data/v3.json), not a style.json file. ' +
+        'To import a style.json directly, use the "Style URL" field above instead.'
+      );
     } finally {
       setGeneratingStyle(false);
     }
@@ -141,6 +158,11 @@ const MapStyleManager: React.FC = () => {
       });
       if (!response.ok) throw new Error('Delete failed');
       setStyles(prev => prev.filter(s => s.id !== id));
+      if (activeStyleId === id) {
+        // The active style just got deleted — clear the selection everywhere.
+        await setActiveMapStyleId(null);
+      }
+      await loadMapStyles();
     } catch (err) {
       console.error('Failed to delete map style:', err);
     }
@@ -158,6 +180,13 @@ const MapStyleManager: React.FC = () => {
           <span className="setting-description">Upload and manage MapLibre GL style JSON files for vector tile layers.</span>
         </label>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {/* Import: upload a file directly, or fetch a ready style.json by URL.
+              Both save immediately as a usable map style (issue #4348). */}
+          <div style={{ fontWeight: 600, fontSize: '0.9em' }}>Import an Existing Style</div>
+          <div style={{ fontSize: '0.85em', color: 'var(--text-muted, #888)', marginBottom: '2px' }}>
+            Upload a MapLibre GL style.json file, or fetch one from a URL. Both are saved immediately as a usable map style.
+          </div>
+
           {/* File upload */}
           <div>
             <input
@@ -204,12 +233,17 @@ const MapStyleManager: React.FC = () => {
             </button>
           </div>
 
-          {/* Generate from tileserver */}
-          <div style={{ marginTop: '4px', borderTop: '1px solid var(--border-color, #eee)', paddingTop: '8px' }}>
-            <div style={{ fontSize: '0.85em', color: 'var(--text-muted, #888)', marginBottom: '4px' }}>
-              Generate a default style from your tileserver's TileJSON endpoint (e.g.{' '}
-              <code style={{ fontSize: '0.9em' }}>http://tileserver:8080/data/v3.json</code>).
-              Edit the downloaded file and upload it above.
+          {/* Generate from tileserver: this is a DIFFERENT feature from the
+              import above — it builds a brand-new style from a raw TileJSON
+              endpoint and only downloads it to your browser (issue #4348,
+              problem 3). It does not save a map style server-side; edit the
+              downloaded file and upload it above to actually use it. */}
+          <div style={{ marginTop: '8px', borderTop: '1px solid var(--border-color, #eee)', paddingTop: '8px' }}>
+            <div style={{ fontWeight: 600, fontSize: '0.9em' }}>Generate a New Style from Tileserver</div>
+            <div style={{ fontSize: '0.85em', color: 'var(--text-muted, #888)', margin: '2px 0 4px' }}>
+              Generate a default style from your tileserver's raw TileJSON endpoint (e.g.{' '}
+              <code style={{ fontSize: '0.9em' }}>http://tileserver:8080/data/v3.json</code>) and download it.
+              This does not save a style — edit the downloaded file and upload it above.
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
               <input
@@ -268,6 +302,33 @@ const MapStyleManager: React.FC = () => {
               }}>
                 {style.sourceType === 'upload' ? 'Upload' : 'URL'}
               </span>
+
+              {/* Active indicator / Activate action (issue #4348) — this is
+                  the same "which style is used on the map" state as the
+                  in-map "Map Style" dropdown, surfaced here so it's
+                  discoverable from Settings. */}
+              {activeStyleId === style.id ? (
+                <span style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  fontSize: '0.75em',
+                  padding: '2px 6px',
+                  borderRadius: '3px',
+                  background: 'var(--success-color, #28a745)',
+                  color: '#fff',
+                  whiteSpace: 'nowrap',
+                }}>
+                  <UiIcon name="check" /> Active
+                </span>
+              ) : (
+                <button
+                  onClick={() => void activateStyle(style.id)}
+                  style={{ padding: '2px 8px', background: 'var(--accent-color, #4a9eff)', color: '#fff', border: 'none', borderRadius: '3px', cursor: 'pointer', fontSize: '0.85em', whiteSpace: 'nowrap' }}
+                >
+                  Activate
+                </button>
+              )}
 
               {/* Delete */}
               <button

--- a/src/components/MapStyleManager.tsx
+++ b/src/components/MapStyleManager.tsx
@@ -34,13 +34,6 @@ const MapStyleManager: React.FC = () => {
     void fetchStyles();
   }, [fetchStyles]);
 
-  // Activate a style as the app-wide default (issue #4348). This is the same
-  // action as the "Map Style" dropdown on the map's Features panel — exposed
-  // here too so the active style is discoverable from Settings.
-  const activateStyle = useCallback(async (id: string) => {
-    await setActiveMapStyleId(id);
-  }, [setActiveMapStyleId]);
-
   const handleUpload = async (file: File) => {
     setUploading(true);
     try {
@@ -303,10 +296,9 @@ const MapStyleManager: React.FC = () => {
                 {style.sourceType === 'upload' ? 'Upload' : 'URL'}
               </span>
 
-              {/* Active indicator / Activate action (issue #4348) — this is
-                  the same "which style is used on the map" state as the
-                  in-map "Map Style" dropdown, surfaced here so it's
-                  discoverable from Settings. */}
+              {/* Active indicator / Activate action — same "which style is
+                  used on the map" state as the in-map "Map Style" dropdown,
+                  surfaced here so it's discoverable from Settings (#4348). */}
               {activeStyleId === style.id ? (
                 <span style={{
                   display: 'inline-flex',
@@ -323,7 +315,7 @@ const MapStyleManager: React.FC = () => {
                 </span>
               ) : (
                 <button
-                  onClick={() => void activateStyle(style.id)}
+                  onClick={() => void setActiveMapStyleId(style.id)}
                   style={{ padding: '2px 8px', background: 'var(--accent-color, #4a9eff)', color: '#fff', border: 'none', borderRadius: '3px', cursor: 'pointer', fontSize: '0.85em', whiteSpace: 'nowrap' }}
                 >
                   Activate

--- a/src/components/MapStyleManager.tsx
+++ b/src/components/MapStyleManager.tsx
@@ -158,6 +158,7 @@ const MapStyleManager: React.FC = () => {
       await loadMapStyles();
     } catch (err) {
       console.error('Failed to delete map style:', err);
+      alert(`Delete failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   };
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -58,7 +58,6 @@ import { toNodeCardModel, type NodeCardModel } from './map/popups/nodeCardModel'
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import api from '../services/api';
 import type { GeoJsonLayer } from '../server/services/geojsonService.js';
-import type { MapStyle } from '../server/services/mapStyleService.js';
 import { CopyNodeInfoModal } from './CopyNodeInfoModal';
 import { UiIcon } from './icons';
 import { useToast } from './ToastContainer';
@@ -484,6 +483,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     defaultMapCenterLon,
     defaultMapCenterZoom,
     mapCenterTargetZoom,
+    mapStyles,
+    activeStyleId,
+    activeStyleJson,
+    setActiveMapStyleId,
   } = useSettings();
 
   // Effective map age cap from the Map Features age slider (#3322), clamped to
@@ -835,11 +838,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // Track if packet logging is enabled on the server
   const [packetLogEnabled, setPacketLogEnabled] = useState<boolean>(false);
   const [geoJsonLayers, setGeoJsonLayers] = useState<GeoJsonLayer[]>([]);
-  const [mapStyles, setMapStyles] = useState<MapStyle[]>([]);
-  const [activeStyleId, setActiveStyleId] = useState<string | null>(() => {
-    try { return localStorage.getItem('meshmonitor-activeMapStyleId') || null; } catch { return null; }
-  });
-  const [activeStyleJson, setActiveStyleJson] = useState<Record<string, unknown> | null>(null);
+  // mapStyles/activeStyleId/activeStyleJson now live in SettingsContext
+  // (issue #4348) so DashboardMap can share the same active style.
 
   // Track if map controls are collapsed
   const [isMapControlsCollapsed, setIsMapControlsCollapsed] = useState(() => {
@@ -995,42 +995,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     void fetchGeoJsonLayers();
   }, []);
 
-  useEffect(() => {
-    const fetchMapStyles = async () => {
-      try {
-        const data = await api.get<MapStyle[]>('/api/map-styles/styles');
-        setMapStyles(data);
-
-        // Determine which style to use: localStorage > server default > none
-        let resolvedStyleId = activeStyleId;
-
-        if (!resolvedStyleId) {
-          // No localStorage value — check server default
-          try {
-            const settings = await api.get<{ activeMapStyleId?: string }>('/api/settings');
-            if (settings.activeMapStyleId) {
-              resolvedStyleId = settings.activeMapStyleId;
-              setActiveStyleId(resolvedStyleId);
-            }
-          } catch { /* ignore settings fetch failure */ }
-        }
-
-        // Load style data if we have a resolved ID
-        if (resolvedStyleId && data.some((s: MapStyle) => s.id === resolvedStyleId)) {
-          try {
-            setActiveStyleJson(await api.get<Record<string, unknown>>(`/api/map-styles/styles/${resolvedStyleId}/data`));
-          } catch { /* ignore style data fetch failure */ }
-        } else if (resolvedStyleId) {
-          // Saved style no longer exists, clear it
-          setActiveStyleId(null);
-          try { localStorage.removeItem('meshmonitor-activeMapStyleId'); } catch { /* ignore */ }
-        }
-      } catch (err) {
-        console.error('Failed to fetch map styles:', err);
-      }
-    };
-    void fetchMapStyles();
-  }, []);
+  // mapStyles/activeStyleId/activeStyleJson are fetched and resolved once by
+  // SettingsContext's own mount effect (issue #4348) — no local fetch needed.
 
   // Refs to access latest values without recreating listeners
   const processedNodesRef = useRef(processedNodes);
@@ -2690,28 +2656,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         Map Style
                         <select
                           value={activeStyleId ?? ''}
-                          onChange={async (e) => {
+                          onChange={(e) => {
                             const styleId = e.target.value || null;
-                            setActiveStyleId(styleId);
-                            try { localStorage.setItem('meshmonitor-activeMapStyleId', styleId ?? ''); } catch { /* ignore */ }
-                            // Save as server default so incognito/new browsers get this style
-                            void api.getBaseUrl().then(baseUrl => {
-                              csrfFetch(`${baseUrl}/api/settings`, {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ activeMapStyleId: styleId ?? '' }),
-                              }).catch(err => console.error('Failed to save map style setting:', err));
-                            });
-                            if (styleId) {
-                              try {
-                                const data = await api.get<Record<string, unknown>>(`/api/map-styles/styles/${styleId}/data`);
-                                setActiveStyleJson(data);
-                              } catch (err) {
-                                console.error('Failed to fetch map style data:', err);
-                              }
-                            } else {
-                              setActiveStyleJson(null);
-                            }
+                            void setActiveMapStyleId(styleId);
                           }}
                           style={{ padding: '2px 6px', border: '1px solid var(--border-color, #ccc)', borderRadius: '3px', background: 'var(--input-bg, #fff)', color: 'var(--text-color, #000)' }}
                         >

--- a/src/components/TilesetSelector.test.tsx
+++ b/src/components/TilesetSelector.test.tsx
@@ -32,12 +32,12 @@ describe('TilesetSelector', () => {
 
   it('identifies the light-mode slot edited by the in-map selector', () => {
     render(<TilesetSelector selectedTilesetId="osm" onTilesetChange={vi.fn()} />);
-    expect(screen.getByText('Map Style (Light mode)')).toBeDefined();
+    expect(screen.getByText('Tileset (Light mode)')).toBeDefined();
   });
 
   it('identifies the dark-mode slot edited by the in-map selector', () => {
     settings.activeMapTilesetMode = 'dark';
     render(<TilesetSelector selectedTilesetId="cartoDark" onTilesetChange={vi.fn()} />);
-    expect(screen.getByText('Map Style (Dark mode)')).toBeDefined();
+    expect(screen.getByText('Tileset (Dark mode)')).toBeDefined();
   });
 });

--- a/src/components/TilesetSelector.tsx
+++ b/src/components/TilesetSelector.tsx
@@ -38,8 +38,8 @@ export const TilesetSelector: React.FC<TilesetSelectorProps> = ({
         <div className="tileset-header">
           <div className="tileset-selector-title">
             {activeMapTilesetMode === 'dark'
-              ? t('tileset.map_style_dark', 'Map Style (Dark mode)')
-              : t('tileset.map_style_light', 'Map Style (Light mode)')}
+              ? t('tileset.tileset_dark', 'Tileset (Dark mode)')
+              : t('tileset.tileset_light', 'Tileset (Light mode)')}
           </div>
           <button
             className="tileset-collapse-btn"

--- a/src/components/VectorTileLayer.tsx
+++ b/src/components/VectorTileLayer.tsx
@@ -206,7 +206,7 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14, styleJson }: V
           source: 'vector-tiles',
           'source-layer': 'transportation_name',
           layout: {
-            'text-field': '{name}',
+            'text-field': ['coalesce', ['get', 'name'], ['get', 'name:latin']],
             'text-font': ['Open Sans Regular'],
             'symbol-placement': 'line',
             'text-size': {
@@ -232,7 +232,7 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14, styleJson }: V
           source: 'vector-tiles',
           'source-layer': 'place',
           layout: {
-            'text-field': '{name}',
+            'text-field': ['coalesce', ['get', 'name'], ['get', 'name:latin']],
             'text-font': ['Open Sans Regular'],
             'text-size': {
               base: 1,
@@ -254,7 +254,7 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14, styleJson }: V
           source: 'vector-tiles',
           'source-layer': 'water_name',
           layout: {
-            'text-field': '{name}',
+            'text-field': ['coalesce', ['get', 'name'], ['get', 'name:latin']],
             'text-font': ['Open Sans Regular'],
             'text-size': {
               base: 1,
@@ -277,7 +277,7 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14, styleJson }: V
           'source-layer': 'poi',
           minzoom: 14,
           layout: {
-            'text-field': '{name}',
+            'text-field': ['coalesce', ['get', 'name'], ['get', 'name:latin']],
             'text-font': ['Open Sans Regular'],
             'text-size': 11,
             'text-offset': [0, 0.8],

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_TARGET_ZOOM } from '../utils/mapZoomAnimation';
 import { setDiscardInvalidPositionsDisplay } from '../utils/positionDisplayConfig';
 import { setActiveWindowHours } from '../utils/activeWindowConfig';
 import { IconStyleProvider, type IconStyle } from './IconStyleContext';
+import type { MapStyle } from '../server/services/mapStyleService.js';
 
 export type { IconStyle } from './IconStyleContext';
 
@@ -119,6 +120,13 @@ interface SettingsContextType {
   customThemes: CustomTheme[];
   customTilesets: CustomTileset[];
   isLoadingThemes: boolean;
+  /** MapLibre style JSON manifest (issue #4348) — lifted out of NodesTab-local
+   *  state so both NodesTab and DashboardMap can render the same active style. */
+  mapStyles: MapStyle[];
+  activeStyleId: string | null;
+  activeStyleJson: Record<string, unknown> | null;
+  setActiveMapStyleId: (id: string | null) => Promise<void>;
+  loadMapStyles: () => Promise<void>;
   solarMonitoringEnabled: boolean;
   solarMonitoringLatitude: number;
   solarMonitoringLongitude: number;
@@ -551,6 +559,16 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
 
   // Custom tilesets state (database-only, not persisted in localStorage)
   const [customTilesets, setCustomTilesets] = useState<CustomTileset[]>([]);
+
+  // Map style state (issue #4348): which MapLibre style JSON (if any) is
+  // active, lifted out of NodesTab-local state so DashboardMap can also
+  // render it. activeStyleId is seeded from localStorage; the server-side
+  // `activeMapStyleId` setting acts as the cross-browser default.
+  const [mapStyles, setMapStyles] = useState<MapStyle[]>([]);
+  const [activeStyleId, setActiveStyleIdState] = useState<string | null>(() => {
+    try { return localStorage.getItem('meshmonitor-activeMapStyleId') || null; } catch { return null; }
+  });
+  const [activeStyleJson, setActiveStyleJson] = useState<Record<string, unknown> | null>(null);
 
   const overlayScheme = React.useMemo<OverlayScheme>(() => {
     const customTileset = customTilesets.find(ct => `custom-${ct.id}` === mapTileset);
@@ -1229,6 +1247,95 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     }
   }, [customTilesets, baseUrl, getCsrfToken]);
 
+  /**
+   * Load the map style manifest and resolve which style (if any) is active
+   * (issue #4348). Resolution order: localStorage (per-browser override) >
+   * the server-side `activeMapStyleId` setting (cross-browser default) > none.
+   * Reads localStorage directly (rather than closing over `activeStyleId`
+   * state) so this callback has a stable identity and is safe to re-run
+   * (e.g. after MapStyleManager uploads/deletes a style) without re-firing
+   * its mount effect.
+   */
+  const loadMapStyles = React.useCallback(async () => {
+    try {
+      const data = await api.get<MapStyle[]>('/api/map-styles/styles');
+      if (!Array.isArray(data)) return;
+      setMapStyles(data);
+
+      let resolvedStyleId: string | null = null;
+      try { resolvedStyleId = localStorage.getItem('meshmonitor-activeMapStyleId') || null; } catch { /* ignore */ }
+
+      if (!resolvedStyleId) {
+        // No localStorage value — fall back to the server-side default.
+        try {
+          const settings = await api.get<{ activeMapStyleId?: string }>('/api/settings');
+          if (settings.activeMapStyleId) {
+            resolvedStyleId = settings.activeMapStyleId;
+            setActiveStyleIdState(resolvedStyleId);
+          }
+        } catch { /* ignore settings fetch failure */ }
+      } else {
+        setActiveStyleIdState(resolvedStyleId);
+      }
+
+      if (resolvedStyleId && data.some((s: MapStyle) => s.id === resolvedStyleId)) {
+        try {
+          setActiveStyleJson(await api.get<Record<string, unknown>>(`/api/map-styles/styles/${resolvedStyleId}/data`));
+        } catch (error) {
+          logger.error('Failed to fetch active map style data:', error);
+        }
+      } else if (resolvedStyleId) {
+        // Saved style no longer exists — clear it.
+        setActiveStyleIdState(null);
+        try { localStorage.removeItem('meshmonitor-activeMapStyleId'); } catch { /* ignore */ }
+      }
+    } catch (error) {
+      logger.error('Failed to load map styles:', error);
+    }
+  }, []);
+
+  /**
+   * Mark a map style active (or clear it with `null`), persisting the choice
+   * to localStorage (per-browser) and the server-side `activeMapStyleId`
+   * setting (cross-browser default), then loads its style JSON.
+   */
+  const setActiveMapStyleId = React.useCallback(async (id: string | null) => {
+    setActiveStyleIdState(id);
+    try {
+      if (id) localStorage.setItem('meshmonitor-activeMapStyleId', id);
+      else localStorage.removeItem('meshmonitor-activeMapStyleId');
+    } catch { /* ignore */ }
+
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const csrfToken = getCsrfToken();
+      if (csrfToken) {
+        headers['X-CSRF-Token'] = csrfToken;
+      }
+
+      await fetch(`${baseUrl}/api/settings`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify({ activeMapStyleId: id ?? '' })
+      });
+
+      logger.debug('✅ Active map style setting saved:', id);
+    } catch (error) {
+      logger.error('Failed to save active map style setting:', error);
+    }
+
+    if (id) {
+      try {
+        setActiveStyleJson(await api.get<Record<string, unknown>>(`/api/map-styles/styles/${id}/data`));
+      } catch (error) {
+        logger.error('Failed to fetch map style data:', error);
+      }
+    } else {
+      setActiveStyleJson(null);
+    }
+  }, [baseUrl, getCsrfToken]);
+
   // Load settings from server on mount
   React.useEffect(() => {
     const loadServerSettings = async () => {
@@ -1632,6 +1739,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     void loadCustomThemes();
   }, [loadCustomThemes]);
 
+  // Load map styles on mount (issue #4348)
+  React.useEffect(() => {
+    void loadMapStyles();
+  }, [loadMapStyles]);
+
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.matchMedia) return;
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -1713,6 +1825,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     customThemes,
     customTilesets,
     isLoadingThemes,
+    mapStyles,
+    activeStyleId,
+    activeStyleJson,
+    setActiveMapStyleId,
+    loadMapStyles,
     linkPreviewsEnabled,
     discardInvalidPositions,
     noIndexEnabled,
@@ -1828,6 +1945,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     customThemes,
     customTilesets,
     isLoadingThemes,
+    mapStyles,
+    activeStyleId,
+    activeStyleJson,
+    setActiveMapStyleId,
+    loadMapStyles,
     linkPreviewsEnabled,
     discardInvalidPositions,
     noIndexEnabled,
@@ -1966,6 +2088,8 @@ export const useMapSettings = () => {
     addCustomTileset: s.addCustomTileset, updateCustomTileset: s.updateCustomTileset, deleteCustomTileset: s.deleteCustomTileset,
     positionHistoryLineStyle: s.positionHistoryLineStyle, setPositionHistoryLineStyle: s.setPositionHistoryLineStyle,
     temporaryTileset: s.temporaryTileset, setTemporaryTileset: s.setTemporaryTileset,
+    mapStyles: s.mapStyles, activeStyleId: s.activeStyleId, activeStyleJson: s.activeStyleJson,
+    setActiveMapStyleId: s.setActiveMapStyleId, loadMapStyles: s.loadMapStyles,
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes #4348 — a detailed report of four related problems with the "Map Style" (custom MapLibre vector style) feature, plus an optional labeling note. Root causes verified against `main` before implementing (see the issue comment for full analysis).

- **Problem 1 (no activation UI in Settings):** map-style state (`mapStyles`/`activeStyleId`/`activeStyleJson`) was local to `NodesTab.tsx` only, with no way to activate a style from Settings. Lifted this state into `SettingsContext` (alongside `customTilesets`, which already worked this way) and added an "Activate" action + active-style badge to `MapStyleManager.tsx`'s style list, using the same shared setter the map's dropdown now calls.
- **Problem 2 (label collision):** `TilesetSelector.tsx`'s panel headers ("Map Style (Dark/Light mode)" — picks a `CustomTileset`) collided with the unrelated style-JSON dropdown in `NodesTab.tsx` (also "Map Style" — picks a `MapStyle`). Renamed the tileset-picker headers to "Tileset (Dark/Light mode)" and updated the i18n keys + tests.
- **Problem 3 (confusing MapStyleManager layout):** the "Style URL"/Fetch (saves immediately) and "TileJSON URL"/Download (browser-download only, doesn't save) sections were separated only by a thin border. Added distinct headings ("Import an Existing Style" vs. "Generate a New Style from Tileserver") and clarified the mismatch error message when a style.json URL is pasted into the TileJSON field.
- **Problem 4 (Dashboard map never applies a custom style):** `DashboardMap.tsx` never fetched or passed `styleJson` into `BaseMap`, because that state lived only in `NodesTab.tsx`. Since it's now in shared `SettingsContext`, `DashboardMap.tsx` consumes `activeStyleJson` and passes it through, matching `NodesTab.tsx`.
- **Related note:** `VectorTileLayer.tsx`'s default fallback style hardcoded `'text-field': '{name}'` for label layers with no fallback for the common `name:latin` OpenMapTiles-schema variant. Switched to a `['coalesce', ['get', 'name'], ['get', 'name:latin']]` expression on all four label layers.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Targeted Vitest suites (`SettingsContext`, `NodesTab`, `DashboardMap`, `TilesetSelector`) — 106/106 passing
- [x] `npm run lint:ci` (ESLint ratchet gate) — passes, no new violations
- [ ] CI (system tests, full suite, PG/MySQL matrix)

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ59TjB6jE1oqw9ZLGsihm)_