### PR TITLE
chore(ci): drop Node 20 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x, 25.x]
+        # Node 20 dropped: nothing we ship runs it. The main image is Node 24,
+        # the LXC template is NodeSource 24, and armv7 — the lowest target — is
+        # Node 22 (Dockerfile.armv7 pins 22 because Node 24 has no ARMv7 build).
+        # 20.x was test-only, and the ecosystem has moved past it: node-gyp 13
+        # and its bundled undici require >=22, so a native rebuild of
+        # better-sqlite3 now fails outright on Node 20.
+        node-version: [22.x, 24.x, 25.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        # Keep in step with ci.yml's matrix. Node 20 dropped — see the comment
+        # there; the lowest shipped target is armv7 on Node 22.
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # MeshMonitor — Claude Agent Brief
 
 **Version:** 4.13.x (multi-source architecture)
-**Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
+**Stack:** React 19 + TS + Vite frontend / Node.js 22+ (Docker image ships Node 24; armv7 image ships Node 22 — the lowest supported runtime, since Node 24 has no ARMv7 build; CI matrix covers 22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For a complete feature list and technical details, visit **[meshmonitor.org](htt
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - Docker (recommended) or local Node.js environment
 - At least one mesh source — a Meshtastic device (WiFi/Ethernet, or Serial/BLE via bridge), a MeshCore device, or an MQTT broker
 

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -107,7 +107,7 @@ For environments where Docker isn't available or preferred, you can run MeshMoni
 ### 1. System Requirements
 
 **Required software:**
-- **Node.js 20+** (Node.js 24 LTS recommended)
+- **Node.js 22+** (Node.js 24 LTS recommended)
 - **npm** (included with Node.js)
 - **git** (for cloning the repository and protobuf submodule)
 - **Build tools** for compiling native modules (bcrypt, better-sqlite3)

--- a/docs/development/claude-getting-started.md
+++ b/docs/development/claude-getting-started.md
@@ -45,7 +45,7 @@ MeshMonitor is a full-stack web application for monitoring Meshtastic mesh netwo
 
 Before starting, ensure you have:
 
-- **Node.js 20+** (22+ recommended)
+- **Node.js 22+** (24 recommended)
 - **npm** (comes with Node.js)
 - **Git** with submodule support
 - **Docker** and **Docker Compose** (for containerized development)

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -10,7 +10,7 @@ If you're using Claude Code as your AI assistant, check out our **[Claude Code G
 
 ### Prerequisites
 
-- Node.js 20 or later (22+ recommended)
+- Node.js 22 or later (24 recommended)
 - npm
 - Git
 - A Meshtastic device or `meshtasticd`

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -19,7 +19,7 @@ See [.devcontainer/README.md](https://github.com/yeraze/meshmonitor/blob/main/.d
 
 Before you begin, ensure you have:
 
-- **Node.js 20+** (Node.js 22+ recommended)
+- **Node.js 22+** (Node.js 24 recommended)
 - **npm** (comes with Node.js)
 - **Git** with submodule support
 - A Meshtastic device connected to your network via IP (WiFi or Ethernet)
@@ -341,7 +341,7 @@ npm install
 
 ### Node Version Issues
 
-MeshMonitor requires Node.js 20+. Check your version:
+MeshMonitor requires Node.js 22+. Check your version:
 
 ```bash
 node --version  # Should be v20.x.x or higher

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,7 +95,7 @@ Choose one based on your deployment method:
 - **Proxmox LXC**: Proxmox VE 7.0+
 - **Kubernetes**: Kubernetes cluster with Helm 3+
 - **NixOS**: NixOS system
-- **Bare Metal**: Node.js 20+ and npm
+- **Bare Metal**: Node.js 22+ and npm
 
 ## Quick Start with Docker Compose
 


### PR DESCRIPTION
Node 20 existed **only in the CI matrix** — nothing we ship runs it:

| Target | Node |
|---|---|
| Docker amd64 + arm64 | 24.15.0-alpine |
| Docker **armv7** (RPi 2/3 32-bit) | **22.22.2** — the lowest shipped runtime |
| LXC template | NodeSource 24 |

`Dockerfile.armv7` pins 22 deliberately, per its own header: *"Node.js 24 doesn't support ARMv7, so we use Node.js 22 LTS."* So armv7 is constrained by a **ceiling, not a floor**, and already sits above the Node 20 line. This changes what we test, not what any user runs.

## It had also stopped being testable

On the dependabot production-dependencies PR (#4349), the Node 20 leg fails at **"Install dependencies"**, not at any test:

```
npm error path .../node_modules/better-sqlite3
npm error prebuild-install warn install No prebuilt binaries found (target=20.20.2 ...)
npm error gyp ERR! stack TypeError: webidl.util.markAsUncloneable is not a function
   at new CacheStorage (.../node-gyp/node_modules/undici/lib/web/cache/cachestorage.js:20:17)
```

`better-sqlite3` finds no prebuilt binary for 20.20.2, falls back to `node-gyp@13`, whose bundled `undici@8` requires `>=22.19` and crashes on Node 20. Several other dependabot PRs are red for the same reason — the leg was blocking routine dependency updates while testing a runtime we don't ship.

## Changes

- `ci.yml`: `20.x/22.x/24.x/25.x` → `22.x/24.x/25.x`
- `release.yml`: `20.x/22.x/24.x` → `22.x/24.x` (kept in step with ci.yml)
- User-facing docs `Node.js 20+` → `22+` — these state a support promise we would otherwise no longer be testing: README, getting-started, DEPLOYMENT_GUIDE, development/{setup,index,claude-getting-started}
- CLAUDE.md now records **armv7-on-Node-22 as the lowest supported runtime**, so the reason for the floor is written down rather than rediscovered next time

**Deliberately untouched:** `CHANGELOG.md` (historical release notes) and `docs/internal/dev-notes/*` (decision records describing the matrix as it was).

## Checks

- Both workflow files parse as YAML; matrices verified to resolve to `['22.x','24.x','25.x']` and `['22.x','24.x']`
- Every version-gated step (`if: matrix.node-version == '24.x'`) keys off 24.x, which remains in both matrices — no step becomes unreachable

## Not included

No `engines` field added to `package.json`. That would make the floor machine-enforced and start warning users installing on Node 20, which is a support-policy change affecting users rather than CI. Easy follow-up if you want the requirement enforced rather than documented.

## Expected knock-on

#4349 (12 patch bumps) and #4354 (`@testing-library/jest-dom` v7, which declares `engines.node >= 22`) should both go green once rebased onto this. #4350 / #4353 / #4355 have real type-check and test failures and will still need work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZtasD4tS76xq2PTDHMA5o