### PR TITLE
fix(map): let waypoint placement clicks win over overlay popups (#4342)

### DIFF
--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -9,6 +9,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { computeNeighborLinkStyle, isTracerouteRunDisabled } from './NodesTab';
 import {
   getEffectivePosition,
@@ -135,6 +137,46 @@ describe('NodesTab', () => {
     it('returns null when the node has no rendered marker (caller falls back to raw center)', () => {
       const nodePositions = new Map<number, [number, number]>();
       expect(resolveMarkerCenterTarget(NODE_NUM, nodePositions)).toBeNull();
+    });
+  });
+
+  // Issue #4342 — "GeoJSON overlay tooltip blocks waypoint creation".
+  //
+  // Leaflet's bindPopup handler calls DomEvent.stop() on the layer's click
+  // (leaflet/src/layer/Popup.js `_openPopup`), which sets
+  // originalEvent._stopped, and Map._fireDOMEvent bails out of its target loop
+  // as soon as that flag is set — BEFORE it reaches the map itself. So any
+  // click landing on popup-bound overlay geometry (a GeoJSON feature, a node
+  // or waypoint marker, a traceroute line, a neighbor link, an accuracy
+  // region) opened that layer's popup and never reached the map 'click'
+  // handler in WaypointMapEventBridge, so no waypoint was created.
+  //
+  // The fix makes interactive geometry click-through for the duration of
+  // placement, which is a hit-testing property jsdom cannot exercise — so this
+  // pins the CSS contract instead: as long as `.waypoint-placing` is on the
+  // container (WaypointMapEventBridge's first effect), interactive overlay
+  // geometry must not be a pointer target. Deleting that rule silently
+  // reintroduces the bug.
+  describe('waypoint placement mode suppresses overlay hit-testing (#4342)', () => {
+    const css = readFileSync(resolve('src/components/WaypointEditorModal.css'), 'utf8');
+
+    // Strip comments so the prose above the rule can't satisfy the assertions.
+    const rules = css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+    it('makes .leaflet-interactive click-through while .waypoint-placing is set', () => {
+      const rule = rules.match(
+        /\.leaflet-container\.waypoint-placing\s+\.leaflet-interactive\s*\{[^}]*\}/g,
+      )?.find(r => /pointer-events\s*:\s*none/.test(r));
+
+      expect(rule, 'pointer-events:none rule for .waypoint-placing .leaflet-interactive is missing').toBeDefined();
+      // Leaflet's own `.leaflet-pane > svg path.leaflet-interactive` /
+      // `.leaflet-marker-icon.leaflet-interactive { pointer-events: auto }`
+      // rules are more specific, so the override has to be !important.
+      expect(rule).toMatch(/pointer-events\s*:\s*none\s*!important/);
+    });
+
+    it('keeps the crosshair cursor rule that signals placement mode', () => {
+      expect(rules).toMatch(/\.leaflet-container\.waypoint-placing[^{]*\{[^}]*cursor\s*:\s*crosshair/);
     });
   });
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -302,8 +302,10 @@ const TracerouteBoundsController: React.FC<{
  * - Right-click anywhere (when `canCreate`) opens the editor with that
  *   location seeded as the new waypoint's coordinates.
  *
- * Toggles the `waypoint-placing` class on the leaflet container so CSS can
- * change the cursor to a crosshair during placement.
+ * Toggles the `waypoint-placing` class on the leaflet container. That class
+ * drives the crosshair cursor AND (issue #4342) makes interactive overlay
+ * geometry click-through, so the pick below always wins over a feature popup —
+ * see the rule in WaypointEditorModal.css for why that is load-bearing.
  */
 const WaypointMapEventBridge: React.FC<{
   placing: boolean;
@@ -314,8 +316,14 @@ const WaypointMapEventBridge: React.FC<{
 
   useEffect(() => {
     const container = map.getContainer();
-    if (placing) container.classList.add('waypoint-placing');
-    else container.classList.remove('waypoint-placing');
+    if (placing) {
+      container.classList.add('waypoint-placing');
+      // A popup left open from a previous click floats above the map with its
+      // own pointer-events, so it would eat the placement click (#4342).
+      map.closePopup();
+    } else {
+      container.classList.remove('waypoint-placing');
+    }
     return () => container.classList.remove('waypoint-placing');
   }, [placing, map]);
 

--- a/src/components/WaypointEditorModal.css
+++ b/src/components/WaypointEditorModal.css
@@ -248,3 +248,20 @@
 .leaflet-container.waypoint-placing .leaflet-interactive {
   cursor: crosshair !important;
 }
+
+/* Issue #4342 — placement mode is modal: overlay geometry must not swallow the
+ * click. Leaflet's bindPopup handler calls DomEvent.stop() on the layer's click
+ * (leaflet/src/layer/Popup.js `_openPopup`), which flags originalEvent._stopped
+ * and makes Map._fireDOMEvent bail BEFORE the map's own 'click' fires. So a
+ * click landing on a GeoJSON feature — or any node marker, waypoint marker,
+ * traceroute line, neighbor link, accuracy region — opened that layer's popup
+ * and WaypointMapEventBridge never saw the pick. Making interactive geometry
+ * click-through for the duration of placement routes every click to the map
+ * itself, and stops sticky tooltips from tracking the crosshair as a bonus.
+ *
+ * This covers the SVG-path and DOM-marker renderers, which is everything the
+ * app renders today; a canvas renderer (`preferCanvas`) hit-tests in JS and
+ * would need a JS-side guard instead. */
+.leaflet-container.waypoint-placing .leaflet-interactive {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
Fixes #4342.

## The bug

Clicking the map to place a waypoint did nothing whenever the click landed on a GeoJSON overlay feature — the feature's tooltip/popup came up instead.

## Root cause

Not `GeoJsonOverlay`. Leaflet's `bindPopup` installs a click handler that calls `DomEvent.stop(e)` (`leaflet/src/layer/Popup.js` `_openPopup`), setting `originalEvent._stopped`. `Map._fireDOMEvent` checks that flag after firing each target and bails out of its loop **before** it reaches the map itself, so the `map.on('click')` handler in `WaypointMapEventBridge` never fires.

That makes it a general defect, not a GeoJSON one: every popup-bound overlay swallows the pick identically — node markers, waypoint markers, traceroute lines, neighbor links, accuracy regions. So the fix is scoped to placement mode rather than to one layer.

## The fix

Placement mode is modal now. While `.waypoint-placing` is on the Leaflet container, interactive overlay geometry is click-through, so every click hit-tests to the map itself and the pick always wins. Sticky tooltips stop tracking the crosshair as a side effect. Entering placement mode also closes any already-open popup, which floats above the map with its own pointer-events and would otherwise eat the click.

Covers the SVG-path and DOM-marker renderers — everything the app renders today. A canvas renderer (`preferCanvas`) hit-tests in JS and would need a JS-side guard; noted in the code comment.

## Validation

Driven against the live dev container using the browser's own hit-testing (`elementFromPoint` at the click coordinates, dispatching on the element it returns), with the "Counties" GeoJSON layer enabled:

| | before | after |
|---|---|---|
| hit target at (730, 1168) | `path.leaflet-interactive` | `.leaflet-container` |
| popup | opens `NAME: COLLIER` | none |
| waypoint editor | not opened | opens, seeded 26.162834 / -80.879974 |
| placement mode | stuck on | exits |

Outside placement mode the same click still opens the feature popup — no regression to normal overlay interaction.

## Tests

Hit-testing is not something jsdom exercises, so the regression test pins the CSS contract instead — the rule's presence and its `!important` (needed to beat Leaflet's own more-specific `pointer-events: auto` rules). Deleting the rule silently reintroduces the bug; the behavioral proof is the live run above.

`tsc` clean, `lint:ci` clean (no in-repo FAILs), full Vitest suite green (20,627 passed; the single failure was in a stale `.claude/worktrees/` checkout, which is git-excluded and never seen by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZtasD4tS76xq2PTDHMA5o