### PR TITLE
chore(map): route DefaultCenterController logs through the logger

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -61,6 +61,7 @@ import type { GeoJsonLayer } from '../server/services/geojsonService.js';
 import { CopyNodeInfoModal } from './CopyNodeInfoModal';
 import { UiIcon } from './icons';
 import { useToast } from './ToastContainer';
+import { logger } from '../utils/logger';
 
 interface NodesTabProps {
   processedNodes: DeviceInfo[];
@@ -242,14 +243,14 @@ const DefaultCenterController: React.FC<{
   const hadSavedPosition = useRef(localStorage.getItem('mapCenter') !== null);
 
   useEffect(() => {
-    console.log('[DefaultCenterController] effect fired', {
+    logger.debug('[DefaultCenterController] effect fired', {
       applied: applied.current,
       hadSaved: hadSavedPosition.current,
       lat, lon, zoom,
     });
     if (applied.current || hadSavedPosition.current) return;
     if (lat !== null && lon !== null && zoom !== null) {
-      console.log('[DefaultCenterController] applying configured default', lat, lon, zoom);
+      logger.debug('[DefaultCenterController] applying configured default', lat, lon, zoom);
       applied.current = true;
       map.setView([lat, lon], zoom, { animate: false });
     }


### PR DESCRIPTION
Surfaced by the review on #4364, which flagged two `console.log` calls in `DefaultCenterController` as pre-existing noise. Split out here rather than folded into that bugfix.

## What

`src/components/NodesTab.tsx` had two raw `console.log` calls that shipped to production:

- The first fires on **every run of the effect** — on mount, and again on every change to the configured default lat/lon/zoom — and dumps a state object (`applied`, `hadSaved`, `lat`, `lon`, `zoom`) into every user's browser console.
- The second fires when the configured default center is actually applied.

Both are now `logger.debug` (`src/utils/logger.ts`), which is what the other 53 frontend files already use, and the right tier per that file's own guidance: state inspection around a guard, not an operational event.

## Why this is genuinely silent in production

Worth stating explicitly, since `src/utils/logger.ts` reads `process.env` and `process` does not exist in a browser: Vite folds it away at build time. From the running container's bundle:

```js
function g(){let e={}.LOG_LEVEL?.toLowerCase();return e&&h.includes(e)?e:`info`}
```

`process.env` compiled to `{}`, so `getLogLevel()` resolves to `info` and every `logger.debug` call is dropped — no `process` reference, no throw. Under `npm run dev` the level resolves to `debug`, so the output is still there when you actually want it.

## Scope

Three lines, one file. The `console.error` calls elsewhere in `NodesTab.tsx` are legitimate error reporting and are untouched.

`tsc` clean, `lint:ci` clean, `NodesTab.test.tsx` + `logger.test.ts` green (32 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZtasD4tS76xq2PTDHMA5o