### PR TITLE
fix(meshtastic): only push add_contact when the radio lacks the peer's key (#4368)

### DIFF
--- a/src/server/meshtasticManager.contactPushGuard.test.ts
+++ b/src/server/meshtasticManager.contactPushGuard.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression tests for issue #4368 — `add_contact` re-sent before every PKI DM.
+ *
+ * MeshMonitor pushed a contact to the radio ahead of EVERY PKI-encrypted DM.
+ * That is not a free no-op: the firmware's `NodeDB::addFromContact()` sets
+ * `is_favorite = true` to shield the entry from NodeDB eviction, so every DM —
+ * including every automated Auto-Ack reply — re-favorited its recipient. The
+ * favorite then came back down through the NodeInfo sync, making it look like
+ * foreign state was leaking in when MeshMonitor had caused it.
+ *
+ * The fix pushes only when we lack evidence the radio already holds the node's
+ * public key. These tests drive the REAL `sendTextMessage` and the REAL
+ * NodeInfo-processing methods rather than re-implementing the predicate.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetNode = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: { getSettingForSource: vi.fn().mockResolvedValue(null), getSetting: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: (...args: unknown[]) => mockGetNode(...args),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    messages: { insertMessage: vi.fn().mockResolvedValue(undefined) },
+    telemetry: { insertTelemetry: vi.fn(), insertTelemetryBatch: vi.fn() },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+}));
+
+const LOCAL = 0x0a0a0a0a;
+const PEER = 0x22222222;
+const PEER_KEY = 'HsTA8jkJVxYBxqfm0V8KZ8wOlqL+R5vP3yEXRtY3p9c=';
+
+const PEER_ROW = {
+  nodeNum: PEER,
+  nodeId: '!22222222',
+  longName: 'Peer Node',
+  shortName: 'PEER',
+  publicKey: PEER_KEY,
+  hwModel: 43,
+  keyMismatchDetected: false,
+};
+
+describe('MeshtasticManager — add_contact push guard (#4368)', () => {
+  let manager: any;
+  let pushSpy: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+    manager.localNodeInfo = { nodeNum: LOCAL };
+    manager.isConnected = true;
+    manager.transport = { send: vi.fn().mockResolvedValue(undefined) };
+    (manager as any).deviceNodeNums.clear();
+    (manager as any).deviceContactKeyNums.clear();
+    mockGetNode.mockResolvedValue(PEER_ROW);
+    // Stub the actual admin-frame emission; we assert on the call, not the bytes.
+    pushSpy = vi.spyOn(manager as any, 'pushContactToRadio').mockImplementation(async (n: any) => {
+      (manager as any).deviceNodeNums.add(n.nodeNum);
+      (manager as any).deviceContactKeyNums.add(n.nodeNum);
+    });
+  });
+
+  afterEach(() => {
+    (manager as any).deviceContactKeyNums.clear();
+    (manager as any).deviceNodeNums.clear();
+    vi.restoreAllMocks();
+  });
+
+  async function dm(text: string): Promise<void> {
+    // sendTextMessage(text, channel, destination). Downstream persistence isn't
+    // under test — swallow anything that fails after the guard has run.
+    try {
+      await manager.sendTextMessage(text, 0, PEER);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  it('pushes the contact on the FIRST DM when the radio has never shown us the key', async () => {
+    await dm('first');
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    expect(pushSpy.mock.calls[0][0].nodeNum).toBe(PEER);
+  });
+
+  // The actual bug: Auto-Ack fires a DM per received message, and every one of
+  // them re-pushed the contact, re-favoriting the peer each time.
+  it('does NOT re-push on subsequent DMs to the same node', async () => {
+    await dm('first');
+    await dm('second');
+    await dm('third');
+    await dm('fourth');
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('never pushes when the radio already reported the key from its own NodeDB', async () => {
+    await manager.processNodeInfoProtobuf({
+      num: PEER,
+      user: {
+        id: '!22222222',
+        longName: 'Peer Node',
+        shortName: 'PEER',
+        publicKey: Buffer.from(PEER_KEY, 'base64'),
+      },
+    });
+    expect(manager.hasDeviceContactKey(PEER)).toBe(true);
+
+    await dm('hello');
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('never pushes when a mesh NodeInfo carrying the key reached us through the radio', async () => {
+    await manager.processNodeInfoMessageProtobuf(
+      { from: PEER, id: 1 },
+      {
+        id: '!22222222',
+        longName: 'Peer Node',
+        shortName: 'PEER',
+        publicKey: new Uint8Array(Buffer.from(PEER_KEY, 'base64')),
+      },
+    );
+    expect(manager.hasDeviceContactKey(PEER)).toBe(true);
+
+    await dm('hello');
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  // A key-repair purge (sendRemoveNode) takes the key with the node, so the
+  // next DM must push again or the firmware has nothing to encrypt with.
+  it('pushes again after a key-repair purge drops the node from the radio', async () => {
+    await dm('first');
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+
+    manager.removeDeviceNodeNum(PEER);
+    expect(manager.hasDeviceContactKey(PEER)).toBe(false);
+
+    await dm('after purge');
+    expect(pushSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats key evidence as per-connection state', async () => {
+    await dm('first');
+    expect(manager.hasDeviceContactKey(PEER)).toBe(true);
+
+    // A different radio (or one whose NodeDB was wiped) may not hold the key.
+    (manager as any).deviceContactKeyNums.clear();
+    expect(manager.hasDeviceContactKey(PEER)).toBe(false);
+
+    await dm('after reconnect');
+    expect(pushSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not push for a node with a detected key mismatch (PKI is skipped entirely)', async () => {
+    mockGetNode.mockResolvedValue({ ...PEER_ROW, keyMismatchDetected: true });
+    await dm('mismatched');
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not push for a node with no public key at all', async () => {
+    mockGetNode.mockResolvedValue({ ...PEER_ROW, publicKey: null });
+    await dm('no key');
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('tracks evidence per node — one peer being known says nothing about another', async () => {
+    const OTHER = 0x33333333;
+    await dm('first');
+    expect(manager.hasDeviceContactKey(PEER)).toBe(true);
+    expect(manager.hasDeviceContactKey(OTHER)).toBe(false);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -846,6 +846,18 @@ class MeshtasticManager implements ISourceManager {
   // favoritesService.ts's header comment for the full rationale.
   private autoFavoritingNodes = new Set<number>();  // Track nodes currently being auto-favorited
   private deviceNodeNums: Set<number> = new Set();  // Nodes in the connected radio's local database
+  /**
+   * Nodes we have positive evidence the radio already holds a PUBLIC KEY for
+   * (issue #4368). Deliberately distinct from `deviceNodeNums`, which only says
+   * the radio knows the node exists — it can know a node without holding its
+   * key, and guarding on it alone would break PKI DMs in that case.
+   *
+   * Gates `pushContactToRadio`. Sending `add_contact` is not free: the firmware
+   * favorites the contact in `NodeDB::addFromContact()` to protect it from
+   * NodeDB eviction, so re-pushing before every DM re-favorited every
+   * recipient. Push only when the radio actually needs the key.
+   */
+  private deviceContactKeyNums: Set<number> = new Set();
   // autoFavoriteSweepRunning moved to FavoritesService (#3962 Phase 4.2a PR4 §4c) — no pinned test reaches into it.
   private rebootMergeInProgress = false;  // Guard against broadcasts during node identity merge
   private lastHeapPurgeAt: number | null = null;  // Timestamp of last auto heap purge
@@ -1662,6 +1674,9 @@ class MeshtasticManager implements ISourceManager {
       this.initConfigCache = [];
       this.startConfigCapture();
       this.deviceNodeNums.clear();
+      // Key evidence is per-connection: a different radio (or one whose NodeDB
+      // was wiped while we were away) may not hold the keys the last one did.
+      this.deviceContactKeyNums.clear();
       this.channel0Exists = false;  // Reset channel 0 cache on reconnect
 
       // Snapshot channel state before config sync for migration detection (#2425)
@@ -7035,6 +7050,10 @@ class MeshtasticManager implements ISourceManager {
         // Convert Uint8Array to base64 for storage
         nodeData.publicKey = Buffer.from(user.publicKey).toString('base64');
         nodeData.hasPKC = true;
+        // This NodeInfo reached us THROUGH the radio, so the radio saw the same
+        // key and stored it in its own NodeDB. That is our evidence that a
+        // pre-DM add_contact would be redundant (issue #4368).
+        this.deviceContactKeyNums.add(fromNum);
         logger.debug(`🔐 Received NodeInfo with public key for ${nodeId} (${user.longName}): ${nodeData.publicKey.substring(0, 20)}... (${user.publicKey.length} bytes)`);
 
         // Check for key security issues
@@ -8644,6 +8663,13 @@ class MeshtasticManager implements ISourceManager {
           // Convert Uint8Array to base64 for storage
           const deviceSyncKey = Buffer.from(nodeInfo.user.publicKey).toString('base64');
 
+          // The radio is reporting a key out of its OWN NodeDB — the most direct
+          // evidence there is that a pre-DM add_contact would be redundant
+          // (issue #4368). Recorded regardless of the mismatch handling below:
+          // a mismatched key still means the radio HAS one, and the DM path
+          // skips PKI (and so the push) entirely while keyMismatchDetected is set.
+          this.deviceContactKeyNums.add(Number(nodeInfo.num));
+
           // Device sync keys should NOT overwrite mesh-received keys for remote nodes.
           // The connected device's internal nodeDb may have stale/incorrect cached keys,
           // while mesh-received keys (from processNodeInfoMessageProtobuf) come directly
@@ -9032,7 +9058,18 @@ class MeshtasticManager implements ISourceManager {
             pkiEncrypted = true;
             logger.debug(`🔐 DM to !${destination.toString(16).padStart(8, '0')} — requesting PKI encryption (node has public key)`);
             try {
-              await this.pushContactToRadio(targetNode);
+              // Only push when the radio actually needs the key (issue #4368).
+              // add_contact is not idempotent from the user's perspective: the
+              // firmware favorites the contact in NodeDB::addFromContact() to
+              // shield it from NodeDB eviction, so pushing before EVERY DM
+              // re-favorited every recipient — including automated Auto-Ack
+              // replies. Pushing once (or never, when the radio already showed
+              // us the key) still guarantees PKI works.
+              if (!this.deviceContactKeyNums.has(destination)) {
+                await this.pushContactToRadio(targetNode);
+              } else {
+                logger.debug(`📇 Skipping add_contact for !${destination.toString(16).padStart(8, '0')} — radio already holds its public key`);
+              }
             } catch {
               // Non-fatal — radio may already have the contact, or the send failed
               // transiently. On failure deviceNodeNums is left untouched (the add only
@@ -12908,6 +12945,9 @@ class MeshtasticManager implements ISourceManager {
     // restored. Track it locally so the UI's "not in device DB" warning clears on the
     // next poll without waiting for the radio to independently re-report the node.
     this.deviceNodeNums.add(targetNode.nodeNum);
+    // We just handed the radio this node's key, so further pre-DM pushes are
+    // redundant until the connection resets or a key repair purges it (#4368).
+    this.deviceContactKeyNums.add(targetNode.nodeNum);
     logger.debug(`📇 Pushed contact for !${targetNode.nodeNum.toString(16).padStart(8, '0')} to radio NodeDB before PKI DM`);
   }
 
@@ -13331,6 +13371,14 @@ class MeshtasticManager implements ISourceManager {
     return this.deviceNodeNums.has(nodeNum);
   }
 
+  /**
+   * Whether we have evidence the radio already holds this node's public key,
+   * and so does not need an `add_contact` before a PKI DM (issue #4368).
+   */
+  hasDeviceContactKey(nodeNum: number): boolean {
+    return this.deviceContactKeyNums.has(nodeNum);
+  }
+
   // ── Narrow accessors for NodeDbMaintenanceService (#3962 Phase 4.2a PR2 §4f) ──
   // These exist only to bridge previously-private state to the extracted
   // service without widening the fields themselves or touching the
@@ -13358,6 +13406,9 @@ class MeshtasticManager implements ISourceManager {
   /** Drop a node from the connected radio's local-database tracking set. */
   removeDeviceNodeNum(nodeNum: number): void {
     this.deviceNodeNums.delete(nodeNum);
+    // Key-repair purges (sendRemoveNode) take the key with the node, so the
+    // next DM must push the contact again rather than assume it is there.
+    this.deviceContactKeyNums.delete(nodeNum);
   }
 
   // ── Narrow accessor for AutoAnnounceService (#3962 Phase 4.2a PR3 §4b) ──


### PR DESCRIPTION
Fixes #4368.

## Problem

MeshMonitor sent an `add_contact` admin message before **every** PKI-encrypted DM, with no check for whether the radio already had that contact (`meshtasticManager.ts`, the `pushContactToRadio` call in `sendTextMessage`).

That is not a free no-op. The firmware's [`NodeDB::addFromContact()`](https://github.com/meshtastic/firmware/blob/master/src/mesh/NodeDB.cpp) sets `is_favorite = true` to shield the entry from NodeDB eviction:

> *"Boring old nodes" are the first to be evicted out of the node database when full. This includes a newly-zeroed nodeinfo because it has: `!is_favorite && last_heard==0`. To keep this from happening when we addFromContact, we set the new node as a favorite.*

So every DM — including every automated Auto-Ack reply — re-favorited its recipient. The favorite then came back through the NodeInfo downsync, which made it look like foreign device state was leaking in when MeshMonitor had caused it.

This matches the reported symptom exactly: *every* DM recipient favorited, regardless of hop count or role. The zero-cost-hop auto-favorite feature (0-hop + relay-role gated) could never explain that.

## Fix

New `deviceContactKeyNums` set: nodes we have positive evidence the radio already holds a public key for.

Deliberately **distinct from `deviceNodeNums`**, which only means the radio knows the node exists — it can know a node without holding its key, and guarding on that alone would silently break PKI DMs in exactly that case.

**Evidence recorded when:**
- the device's own NodeDB dump reports `user.publicKey` — most authoritative, the radio stating what it holds
- a mesh NodeInfo carrying a key reaches us *through* the radio, so the radio saw and stored the same key
- we successfully push a contact ourselves

**Evidence invalidated when:**
- the connection resets — a different radio, or one whose NodeDB was wiped while we were away, may not hold the same keys
- a key repair purges the node via `removeDeviceNodeNum` — the purge takes the key with it, so the next DM must push again

Net effect: the radio still gets the key whenever it genuinely lacks one, so PKI DMs keep working — but a node is no longer re-favorited on every message.

## What this deliberately does NOT do

- **No filtering of the `isFavorite` downsync.** An earlier revision of #4368 proposed that. It would have left MeshMonitor favoriting nodes on the device while hiding the fact from the UI, and regressed #213 (offline favorite changes). The downsync is correct and untouched.
- **No CLIENT_BASE special-casing.** Current firmware already implements the [meshtastic/design#39](https://github.com/meshtastic/design/issues/39) exception, in both `addFromContact` and `AdminModule.cpp:110` (admin-key auto-favorite). That alignment belongs at the firmware layer, and duplicating it here would be redundant.

## Testing

9 new tests in `meshtasticManager.contactPushGuard.test.ts`, driving the **real** `sendTextMessage` and the **real** NodeInfo-processing methods rather than re-implementing the predicate (the pattern the existing `pushContactToRadio guard` block in `meshtasticManager.test.ts` uses).

**Verified non-vacuous** — with the guard reverted, 3 of the 9 fail:
- `does NOT re-push on subsequent DMs to the same node`
- `never pushes when the radio already reported the key from its own NodeDB`
- `never pushes when a mesh NodeInfo carrying the key reached us through the radio`

Also covered: first-DM still pushes, re-push after key-repair purge, per-connection reset, per-node isolation, and the two no-push paths (key mismatch, no public key).

`tsc --noEmit` clean; `lint:ci` ratchet clean.

Full local suite: **11,112 passed, 0 failed** (679 skipped = the PostgreSQL/MySQL suites; no schema or migration work in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB
