### PR TITLE
fix(map): wire activeStyleJson into MapAnalysis and MeshCore BaseMap consumers

### DIFF
--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -46,6 +46,7 @@ export default function MapAnalysisCanvas() {
     mapTileset,
     customTilesets,
     setMapTileset,
+    activeStyleJson,
   } = useSettings();
   const {
     config,
@@ -211,6 +212,7 @@ export default function MapAnalysisCanvas() {
         zoom={zoom}
         tilesetId={mapTileset}
         customTilesets={customTilesets}
+        styleJson={activeStyleJson ?? undefined}
         showTilesetSelector
         onTilesetChange={setMapTileset}
       >

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -92,7 +92,7 @@ interface MeshCoreMapProps {
 
 export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm, isLoading = false, resizeTrigger }) => {
   const { t } = useTranslation();
-  const { mapTileset, customTilesets, setMapTileset } = useSettings();
+  const { mapTileset, customTilesets, setMapTileset, activeStyleJson } = useSettings();
   const { timeFormat, dateFormat } = useDisplaySettings();
   const { sourceId } = useSource();
   const csrfFetch = useCsrfFetch();
@@ -480,6 +480,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         zoom={zoom}
         tilesetId={mapTileset}
         customTilesets={customTilesets}
+        styleJson={activeStyleJson ?? undefined}
         showTilesetSelector={showTileSelector}
         onTilesetChange={setMapTileset}
         resizeTrigger={resizeTrigger}


### PR DESCRIPTION
## Summary

Closes #4374.

#4360 lifted `activeStyleJson` into `SettingsContext` and wired it into `DashboardMap.tsx`/`NodesTab.tsx`, but two more `<BaseMap>` consumers were never updated to consume it, so a custom Map Style silently never applied on those two surfaces:

- `src/components/MapAnalysis/MapAnalysisCanvas.tsx` — `activeStyleJson` wasn't destructured from `useSettings()`, and its `<BaseMap>` call had no `styleJson` prop.
- `src/components/MeshCore/MeshCoreMap.tsx` — same gap.

Both get the same two-line fix `DashboardMap.tsx` already received: destructure `activeStyleJson` and pass `styleJson={activeStyleJson ?? undefined}` into the `<BaseMap>` call.

Per the issue, `EmbedMap.tsx` is intentionally excluded — it has no `SettingsProvider` in its bundle (documented in an existing comment at `EmbedMap.tsx:258-261`), so `activeStyleJson` isn't reachable there the same way; that would need a separate mechanism and is out of scope here.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:ci` — no in-repo `FAIL` lines
- [x] Targeted suites: `MapAnalysisCanvas.test.tsx` + `MeshCoreMap.test.tsx` — 24/24 passed
- [x] Full Vitest suite: 10965 passed, 9 failed, 770 skipped. The 9 failures are all in `src/server/mqttBrokerManager.test.ts` ("zero-hop injection" protobuf encode errors), unrelated to this change — confirmed pre-existing by running the same file against `origin/main` (this branch is `main` + this 2-file diff, `git diff origin/main --stat` shows only the two map files touched).
- [ ] Not browser-validated in this session — no dev container was deployed. Please verify visually that a custom Map Style now applies on the Map Analysis and MeshCore map views before merging.

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01MB93JJ3aT85e6C7cvnGYsk)_