### PR TITLE
fix(map): give the tile selector a mobile bottom sheet (#4380)

### DIFF
--- a/src/components/TilesetSelector.css
+++ b/src/components/TilesetSelector.css
@@ -122,10 +122,64 @@
   text-transform: uppercase;
 }
 
-/* Hide on mobile devices */
+/*
+ * Mobile: full-width bottom sheet (#4380).
+ *
+ * This block used to be `.tileset-selector-wrapper { display: none }`, which
+ * hid the panel outright while the Features-panel "Show Tile Selection"
+ * checkbox stayed visible and toggleable — the control looked broken because
+ * it drove something CSS had already removed. TilesetSelector now renders a
+ * non-draggable sheet at this breakpoint instead (see the `isMobile` branch in
+ * TilesetSelector.tsx), so the panel is positioned here rather than hidden.
+ *
+ * `.draggable-overlay` keeps its own mobile `display: none` in
+ * DraggableOverlay.css — untouched, since the mobile sheet no longer renders
+ * through DraggableOverlay and the map legends still rely on that rule.
+ */
 @media (max-width: 768px) {
-  .tileset-selector-wrapper {
-    display: none;
+  .tileset-selector-sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1200;
+    width: 100%;
+    /* Clear of the home indicator / gesture bar on notched devices. */
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    background-color: var(--ctp-base);
+    border-top: 1px solid var(--ctp-surface1);
+    box-shadow: 0 -2px 12px rgb(0 0 0 / 35%);
+  }
+
+  .tileset-selector-sheet .tileset-selector {
+    width: 100%;
+    max-width: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  /* The header is the sheet's handle: tapping the chevron expands/collapses. */
+  .tileset-selector-sheet .tileset-header {
+    padding: 12px 16px;
+    cursor: default;
+  }
+
+  .tileset-selector-sheet .tileset-collapse-btn {
+    /* Comfortable touch target — the desktop button is mouse-sized. */
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Cap the list so the sheet never swallows the whole map on a short screen. */
+  .tileset-selector-sheet .tileset-buttons {
+    max-height: 45vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tileset-selector-sheet .tileset-button {
+    min-height: 44px;
   }
 }
 

--- a/src/components/TilesetSelector.test.tsx
+++ b/src/components/TilesetSelector.test.tsx
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TilesetSelector } from './TilesetSelector';
 
 const settings = {
@@ -39,5 +39,94 @@ describe('TilesetSelector', () => {
     settings.activeMapTilesetMode = 'dark';
     render(<TilesetSelector selectedTilesetId="cartoDark" onTilesetChange={vi.fn()} />);
     expect(screen.getByText('Tileset (Dark mode)')).toBeDefined();
+  });
+});
+
+/**
+ * #4380: on mobile the panel was force-hidden by
+ * `.tileset-selector-wrapper { display: none }`, while the Features-panel
+ * "Show Tile Selection" checkbox stayed visible and toggleable — a control
+ * driving something that could never appear. The mobile branch renders a
+ * bottom sheet instead of the draggable overlay.
+ */
+describe('TilesetSelector — mobile bottom sheet (#4380)', () => {
+  const setViewport = (mobile: boolean) => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: mobile && query.includes('max-width'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+  };
+
+  afterEach(() => {
+    setViewport(false);
+  });
+
+  it('renders the sheet variant on a mobile viewport', () => {
+    setViewport(true);
+    const { container } = render(
+      <TilesetSelector selectedTilesetId="osm" onTilesetChange={vi.fn()} />
+    );
+
+    expect(container.querySelector('.tileset-selector-sheet')).not.toBeNull();
+  });
+
+  it('does not render the sheet variant on a desktop viewport', () => {
+    setViewport(false);
+    const { container } = render(
+      <TilesetSelector selectedTilesetId="osm" onTilesetChange={vi.fn()} />
+    );
+
+    expect(container.querySelector('.tileset-selector-sheet')).toBeNull();
+  });
+
+  it('stays reachable on mobile — expanding reveals the tileset list', () => {
+    setViewport(true);
+    const view = render(<TilesetSelector selectedTilesetId="osm" onTilesetChange={vi.fn()} />);
+
+    // Collapsed by default: the header shows, the list does not.
+    const { container } = view;
+    expect(container.querySelectorAll('.tileset-button').length).toBe(0);
+
+    fireEvent.click(container.querySelector('.tileset-collapse-btn')!);
+    expect(container.querySelectorAll('.tileset-button').length).toBeGreaterThan(0);
+  });
+
+  it('collapses after a tileset is picked, so the choice is visible', () => {
+    setViewport(true);
+    const onTilesetChange = vi.fn();
+    const { container } = render(
+      <TilesetSelector selectedTilesetId="osm" onTilesetChange={onTilesetChange} />
+    );
+
+    fireEvent.click(container.querySelector('.tileset-collapse-btn')!);
+    const tilesetButtons = container.querySelectorAll('.tileset-button');
+    expect(tilesetButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(tilesetButtons[0]);
+
+    expect(onTilesetChange).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('.tileset-selector.collapsed')).not.toBeNull();
+    expect(container.querySelectorAll('.tileset-button').length).toBe(0);
+  });
+
+  it('keeps the panel open after a pick on desktop', () => {
+    setViewport(false);
+    const onTilesetChange = vi.fn();
+    const { container } = render(
+      <TilesetSelector selectedTilesetId="osm" onTilesetChange={onTilesetChange} />
+    );
+
+    fireEvent.click(container.querySelector('.tileset-collapse-btn')!);
+    const tilesetButtons = container.querySelectorAll('.tileset-button');
+    fireEvent.click(tilesetButtons[0]);
+
+    expect(onTilesetChange).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('.tileset-selector.collapsed')).toBeNull();
   });
 });

--- a/src/components/TilesetSelector.tsx
+++ b/src/components/TilesetSelector.tsx
@@ -4,6 +4,7 @@ import { UiIcon } from './icons';
 import { getAllTilesets, type TilesetId } from '../config/tilesets';
 import { useSettings } from '../contexts/SettingsContext';
 import { DraggableOverlay } from './DraggableOverlay';
+import { useIsMobileViewport } from '../hooks/useIsMobileViewport';
 import './TilesetSelector.css';
 
 interface TilesetSelectorProps {
@@ -27,6 +28,71 @@ export const TilesetSelector: React.FC<TilesetSelectorProps> = ({
   const { customTilesets, activeMapTilesetMode } = useSettings();
   const tilesets = getAllTilesets(customTilesets);
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const isMobile = useIsMobileViewport();
+
+  const title =
+    activeMapTilesetMode === 'dark'
+      ? t('tileset.tileset_dark', 'Tileset (Dark mode)')
+      : t('tileset.tileset_light', 'Tileset (Light mode)');
+
+  const handleTilesetChange = (tilesetId: TilesetId) => {
+    onTilesetChange(tilesetId);
+    // Dismiss-on-select, mobile only: the sheet covers the map it is styling,
+    // so leaving it open would hide the result of the choice just made. On
+    // desktop the panel sits beside the map and stays put, as it always has.
+    if (isMobile) setIsCollapsed(true);
+  };
+
+  const panel = (
+    <div className={`tileset-selector ${isCollapsed ? 'collapsed' : ''}`}>
+      <div className="tileset-header">
+        <div className="tileset-selector-title">{title}</div>
+        <button
+          className="tileset-collapse-btn"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          onMouseDown={(e) => e.stopPropagation()}
+          title={isCollapsed ? t('tileset.expand') : t('tileset.collapse')}
+        >
+          <UiIcon name={isCollapsed ? 'chevronDown' : 'chevronUp'} />
+        </button>
+      </div>
+      {!isCollapsed && (
+        <div className="tileset-buttons">
+          {tilesets.map((tileset) => (
+            <button
+              key={tileset.id}
+              className={`tileset-button ${selectedTilesetId === tileset.id ? 'active' : ''}`}
+              onClick={() => handleTilesetChange(tileset.id)}
+              title={tileset.description || tileset.name}
+            >
+              <div
+                className="tileset-preview"
+                style={{
+                  backgroundImage: `url(${getTilePreviewUrl(tileset.url)})`
+                }}
+              />
+              <div className="tileset-name">
+                {tileset.name}
+                {tileset.isCustom && <span className="custom-badge">{t('tileset.custom')}</span>}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  // Mobile: a full-width bottom sheet instead of the draggable overlay (#4380).
+  // Dragging a floating panel around a phone screen is not useful, and the
+  // overlay was force-hidden by CSS on this breakpoint — the Features-panel
+  // checkbox stayed toggleable but controlled something that could never
+  // appear. Collapsed, the sheet is a tappable title bar pinned to the bottom;
+  // expanded, it lists the tilesets full-width.
+  if (isMobile) {
+    return (
+      <div className="tileset-selector-wrapper tileset-selector-sheet">{panel}</div>
+    );
+  }
 
   return (
     <DraggableOverlay
@@ -34,46 +100,7 @@ export const TilesetSelector: React.FC<TilesetSelectorProps> = ({
       defaultPosition={getDefaultPosition()}
       className="tileset-selector-wrapper"
     >
-      <div className={`tileset-selector ${isCollapsed ? 'collapsed' : ''}`}>
-        <div className="tileset-header">
-          <div className="tileset-selector-title">
-            {activeMapTilesetMode === 'dark'
-              ? t('tileset.tileset_dark', 'Tileset (Dark mode)')
-              : t('tileset.tileset_light', 'Tileset (Light mode)')}
-          </div>
-          <button
-            className="tileset-collapse-btn"
-            onClick={() => setIsCollapsed(!isCollapsed)}
-            onMouseDown={(e) => e.stopPropagation()}
-            title={isCollapsed ? t('tileset.expand') : t('tileset.collapse')}
-          >
-            <UiIcon name={isCollapsed ? 'chevronDown' : 'chevronUp'} />
-          </button>
-        </div>
-        {!isCollapsed && (
-          <div className="tileset-buttons">
-            {tilesets.map((tileset) => (
-              <button
-                key={tileset.id}
-                className={`tileset-button ${selectedTilesetId === tileset.id ? 'active' : ''}`}
-                onClick={() => onTilesetChange(tileset.id)}
-                title={tileset.description || tileset.name}
-              >
-                <div
-                  className="tileset-preview"
-                  style={{
-                    backgroundImage: `url(${getTilePreviewUrl(tileset.url)})`
-                  }}
-                />
-                <div className="tileset-name">
-                  {tileset.name}
-                  {tileset.isCustom && <span className="custom-badge">{t('tileset.custom')}</span>}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      {panel}
     </DraggableOverlay>
   );
 };

--- a/src/hooks/useIsMobileViewport.ts
+++ b/src/hooks/useIsMobileViewport.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { MOBILE_BREAKPOINT_PX } from '../utils/sidebarWidth';
+
+const QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX}px)`;
+
+/**
+ * Whether the viewport is at or below the app's mobile breakpoint.
+ *
+ * Distinct from `useIsDesktop`, which asks about pointer precision
+ * (`pointer: fine`) — a touchscreen laptop is "not desktop" by that test but is
+ * emphatically not a phone-width viewport. Components that need to mirror a
+ * `@media (max-width: 768px)` CSS rule in JS want this hook; the two questions
+ * are not interchangeable.
+ *
+ * Shares `MOBILE_BREAKPOINT_PX` with the sheets so there is one definition of
+ * the breakpoint rather than a hardcoded 768 in yet another place.
+ */
+export function useIsMobileViewport(): boolean {
+  const get = () => (typeof window === 'undefined' ? false : window.matchMedia(QUERY).matches);
+  const [isMobile, setIsMobile] = useState<boolean>(get);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia(QUERY);
+    const handler = (e: MediaQueryListEvent | { matches: boolean }) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler as EventListener);
+    setIsMobile(mql.matches);
+    return () => mql.removeEventListener('change', handler as EventListener);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

At ≤768px the tile-selector popover never appeared. `.tileset-selector-wrapper { display: none }` hid it outright, while the Features panel kept rendering a live, toggleable **Show Tile Selection** checkbox — so the control looked broken rather than unavailable, and there was no way to pick a basemap on a phone at all.

This replaces the hide with a real mobile variant rather than just un-hiding a draggable panel, which would be its own bad experience on a touch screen.

Fixes #4380.

## Changes

- **`TilesetSelector.tsx`** — below the breakpoint, render a full-width bottom sheet instead of `DraggableOverlay`. The panel markup is shared between both variants, so there is one source of truth for the tileset list.
- **`TilesetSelector.css`** — the mobile block now positions the sheet (fixed, full-width, `safe-area-inset-bottom` padding, list capped at `45vh` with its own scroll, 44px touch targets) instead of hiding the wrapper.
- **`useIsMobileViewport.ts`** (new) — mirrors the `max-width: 768px` CSS rule in JS, reusing `MOBILE_BREAKPOINT_PX` so the breakpoint has one definition.
- **`TilesetSelector.test.tsx`** — 5 new cases.

## Design notes for the reviewer

Two decisions worth a look:

**No new `onRequestClose` prop.** The reporter's dismiss-on-select behavior needs the sheet to close after a pick. Threading a close callback would mean touching all four `BaseMap` consumers, and `MapAnalysisCanvas` force-shows the selector and owns no toggle state to close — it would have nothing to pass. Instead the sheet reuses the panel's existing collapse state: collapsed it is a tappable title bar pinned to the bottom, expanded it lists the tilesets, and picking one collapses it so the map underneath is visible. All four consumers keep working unchanged.

**`DraggableOverlay.css` is deliberately untouched.** Its own mobile `display: none` still applies — the mobile branch simply doesn't render through `DraggableOverlay`, so the rule is irrelevant here and the map legends that depend on it are unaffected.

`useIsMobileViewport` is separate from the existing `useIsDesktop` on purpose: that hook asks about pointer precision (`pointer: fine`), so a touchscreen laptop reads as "not desktop" while being nothing like a phone-width viewport. Mirroring a width media query needs a width test.

## Issues Resolved

Fixes #4380. Reported by @wilhel1812 in Discord, who also proposed the full-width/dismiss-on-select shape used here.

## Documentation Updates

No documentation changes needed — no documented behavior changes; the feature simply becomes reachable on a viewport where it previously could not render.

## Testing

- [x] Full unit suite: 11,762 passed, 0 failed, `success: true`
- [x] `tsc -p tsconfig.server.json --noEmit` clean; `npm run lint:ci` clean
- [x] New tests cover: sheet renders on mobile, does **not** on desktop, expanding reveals the list, picking collapses it on mobile, picking does **not** collapse it on desktop
- [x] z-index (1200) checked against the sheet-wide range: above the map-overlay band (1000), below modals and app chrome (10000+)
- [ ] **Reviewer check (worth doing — see below):** load the Map tab at a ≤768px viewport, enable **Show Tile Selection**, confirm the sheet appears pinned to the bottom, expands, switches basemap, and collapses on select
- [ ] Reviewer check: confirm desktop is visually unchanged — panel still draggable, still stays open after a pick

**Known verification gap:** jsdom does no layout, so the unit tests pin the branch logic and dismiss-on-select but cannot confirm the sheet's on-screen geometry. The CSS itself has not been exercised in a real mobile browser. That is the one thing worth eyeballing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)