### PR TITLE
fix(map): persist the "Show ATAK Contacts" toggle (#4378)

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -143,6 +143,7 @@ import { migration as addXeddsaSignedMigration, runMigration125Postgres, runMigr
 import { migration as addTransportFlagsMigration, runMigration126Postgres, runMigration126Mysql } from '../server/migrations/126_add_transport_flags_to_nodes.js';
 import { migration as addAtakContactsMigration, runMigration127Postgres, runMigration127Mysql } from '../server/migrations/127_add_atak_contacts.js';
 import { migration as mqttOkToMqttViolationsMigration, runMigration128Postgres, runMigration128Mysql } from '../server/migrations/128_mqtt_oktomqtt_violations.js';
+import { migration as addShowAtakContactsMigration, runMigration129Postgres, runMigration129Mysql } from '../server/migrations/129_add_show_atak_contacts_to_map_prefs.js';
 
 // ============================================================================
 // Registry
@@ -2036,4 +2037,19 @@ registry.register({
   sqlite: (db) => mqttOkToMqttViolationsMigration.up(db),
   postgres: (client) => runMigration128Postgres(client),
   mysql: (pool) => runMigration128Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 129: persist the "Show ATAK Contacts" map toggle (#4378). #3691
+// added the toggle and its MapContext default but never the column behind it,
+// so every save was silently dropped by the route's explicit field list.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 129,
+  name: 'add_show_atak_contacts_to_map_prefs',
+  settingsKey: 'migration_129_add_show_atak_contacts_to_map_prefs',
+  sqlite: (db) => addShowAtakContactsMigration.up(db),
+  postgres: (client) => runMigration129Postgres(client),
+  mysql: (pool) => runMigration129Mysql(pool),
 });

--- a/src/db/repositories/mapPreferences.test.ts
+++ b/src/db/repositories/mapPreferences.test.ts
@@ -57,6 +57,19 @@ describe('userMapPreferences — positionHistoryPointsOnly toggle (#3492)', () =
   });
 });
 
+describe('userMapPreferences — showAtakContacts toggle (#4378)', () => {
+  it('maps JS `showAtakContacts` → SQL column `show_atak_contacts` on all three backends', () => {
+    for (const table of [
+      schema.userMapPreferencesSqlite,
+      schema.userMapPreferencesPostgres,
+      schema.userMapPreferencesMysql,
+    ]) {
+      const col = (table as unknown as { showAtakContacts: { name: string } }).showAtakContacts;
+      expect(col.name).toBe('show_atak_contacts');
+    }
+  });
+});
+
 describe('userMapPreferences — per-theme tilesets (#4096)', () => {
   it('maps both themed fields to snake_case columns on all three backends', () => {
     for (const table of [

--- a/src/db/repositories/mapPreferences.ts
+++ b/src/db/repositories/mapPreferences.ts
@@ -47,6 +47,7 @@ export class MapPreferencesRepository extends BaseRepository {
         showAnimations: row.showAnimations ?? false,
         showAccuracyRegions: row.showAccuracyRegions ?? false,
         showEstimatedPositions: row.showEstimatedPositions ?? false,
+        showAtakContacts: row.showAtakContacts ?? false,
         positionHistoryHours: row.positionHistoryHours ?? null,
         mapMaxAgeHours: row.mapMaxAgeHours ?? null,
         positionHistoryPointsOnly: row.positionHistoryPointsOnly ?? false,
@@ -76,6 +77,7 @@ export class MapPreferencesRepository extends BaseRepository {
     showAnimations?: boolean;
     showAccuracyRegions?: boolean;
     showEstimatedPositions?: boolean;
+    showAtakContacts?: boolean;
     positionHistoryHours?: number | null;
     mapMaxAgeHours?: number | null;
     positionHistoryPointsOnly?: boolean;
@@ -105,6 +107,7 @@ export class MapPreferencesRepository extends BaseRepository {
         if (preferences.showAnimations !== undefined) set.showAnimations = preferences.showAnimations;
         if (preferences.showAccuracyRegions !== undefined) set.showAccuracyRegions = preferences.showAccuracyRegions;
         if (preferences.showEstimatedPositions !== undefined) set.showEstimatedPositions = preferences.showEstimatedPositions;
+        if (preferences.showAtakContacts !== undefined) set.showAtakContacts = preferences.showAtakContacts;
         if (preferences.positionHistoryHours !== undefined) set.positionHistoryHours = preferences.positionHistoryHours;
         if (preferences.mapMaxAgeHours !== undefined) set.mapMaxAgeHours = preferences.mapMaxAgeHours;
         if (preferences.positionHistoryPointsOnly !== undefined) set.positionHistoryPointsOnly = preferences.positionHistoryPointsOnly;
@@ -131,6 +134,7 @@ export class MapPreferencesRepository extends BaseRepository {
           showAnimations: preferences.showAnimations ?? false,
           showAccuracyRegions: preferences.showAccuracyRegions ?? false,
           showEstimatedPositions: preferences.showEstimatedPositions ?? true,
+          showAtakContacts: preferences.showAtakContacts ?? false,
           positionHistoryHours: preferences.positionHistoryHours ?? null,
           mapMaxAgeHours: preferences.mapMaxAgeHours ?? null,
           positionHistoryPointsOnly: preferences.positionHistoryPointsOnly ?? false,

--- a/src/db/schema/misc.ts
+++ b/src/db/schema/misc.ts
@@ -114,6 +114,9 @@ export const userMapPreferencesSqlite = sqliteTable('user_map_preferences', {
   showAnimations: integer('show_animations', { mode: 'boolean' }).default(false),
   showAccuracyRegions: integer('show_accuracy_regions', { mode: 'boolean' }).default(false),
   showEstimatedPositions: integer('show_estimated_positions', { mode: 'boolean' }).default(false),
+  // ATAK contact marker visibility (#3691, persisted in #4378). Default false —
+  // opt-in, unlike showWaypoints.
+  showAtakContacts: integer('show_atak_contacts', { mode: 'boolean' }).default(false),
   positionHistoryHours: integer('position_history_hours'),
   // Map age slider: hide nodes/traceroutes older than this on the map (hours).
   // NULL = follow the global maxNodeAgeHours setting. See #3322.
@@ -146,6 +149,7 @@ export const userMapPreferencesPostgres = pgTable('user_map_preferences', {
   showAnimations: pgBoolean('show_animations').default(false),
   showAccuracyRegions: pgBoolean('show_accuracy_regions').default(false),
   showEstimatedPositions: pgBoolean('show_estimated_positions').default(false),
+  showAtakContacts: pgBoolean('show_atak_contacts').default(false),
   positionHistoryHours: pgInteger('position_history_hours'),
   mapMaxAgeHours: pgInteger('map_max_age_hours'),
   positionHistoryPointsOnly: pgBoolean('position_history_points_only').default(false),
@@ -398,6 +402,7 @@ export const userMapPreferencesMysql = mysqlTable('user_map_preferences', {
   showAnimations: myBoolean('show_animations').default(false),
   showAccuracyRegions: myBoolean('show_accuracy_regions').default(false),
   showEstimatedPositions: myBoolean('show_estimated_positions').default(false),
+  showAtakContacts: myBoolean('show_atak_contacts').default(false),
   positionHistoryHours: myInt('position_history_hours'),
   mapMaxAgeHours: myInt('map_max_age_hours'),
   positionHistoryPointsOnly: myBoolean('position_history_points_only').default(false),

--- a/src/server/migrations/129_add_show_atak_contacts_to_map_prefs.ts
+++ b/src/server/migrations/129_add_show_atak_contacts_to_map_prefs.ts
@@ -1,0 +1,59 @@
+/**
+ * Migration 129: Add `show_atak_contacts` column to `user_map_preferences`.
+ *
+ * The ATAK/CoT Phase 2 work (#3691) added a "Show ATAK Contacts" toggle to the
+ * Map Features panel and wired it through `MapContext`, but never extended the
+ * persistence chain behind it — no column, no repository field, no route field.
+ * The client POSTed `showAtakContacts` to `/api/user/map-preferences`, the
+ * route's explicit destructure silently dropped it, and the save returned
+ * `{ success: true }`. Every reload reset the toggle to its in-memory default
+ * of `false` (#4378).
+ *
+ * Default FALSE, matching `MapContext`'s `useState(false)` and the #3691
+ * "ATAK contacts are opt-in" decision, so a fresh row read agrees with what an
+ * unconfigured user already sees. Contrast migration 074 (`show_waypoints`),
+ * which defaults TRUE because that toggle is opt-out.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL via the shared helpers.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 129';
+const TABLE = 'user_map_preferences';
+const COLUMN = 'show_atak_contacts';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+    addColumnIfMissing(db, TABLE, COLUMN, `${COLUMN} INTEGER DEFAULT 0`);
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration129Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+  await addColumnIfMissingPostgres(client, TABLE, COLUMN, `"${COLUMN}" BOOLEAN DEFAULT FALSE`);
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration129Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+  await addColumnIfMissingMysql(pool, TABLE, COLUMN, `${COLUMN} BOOLEAN DEFAULT FALSE`);
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/userPreferencesRoutes.test.ts
+++ b/src/server/routes/userPreferencesRoutes.test.ts
@@ -69,4 +69,59 @@ describe('userPreferencesRoutes', () => {
       expect(res.status).toBe(400);
     });
   });
+
+  /**
+   * #4378: the route destructures an explicit field list, so a preference the
+   * client sends but the list omits is dropped with a `{ success: true }` reply
+   * — no error surfaces, and the next GET returns the old value. That is
+   * exactly how "Show ATAK Contacts" behaved from #3691 until this fix, so the
+   * regression has to assert the round-trip, not just the 200.
+   */
+  describe('showAtakContacts round-trip (#4378)', () => {
+    it('persists showAtakContacts=true across a save/load cycle', async () => {
+      const agent = await harness.loginAs(harness.limited);
+
+      const post = await agent.post('/map-preferences').send({ showAtakContacts: true });
+      expect(post.status).toBe(200);
+
+      const get = await agent.get('/map-preferences');
+      expect(get.status).toBe(200);
+      expect(get.body.preferences).toMatchObject({ showAtakContacts: true });
+    });
+
+    it('persists showAtakContacts=false without falling back to the default', async () => {
+      const agent = await harness.loginAs(harness.limited);
+
+      await agent.post('/map-preferences').send({ showAtakContacts: true });
+      await agent.post('/map-preferences').send({ showAtakContacts: false });
+
+      const get = await agent.get('/map-preferences');
+      expect(get.body.preferences).toMatchObject({ showAtakContacts: false });
+    });
+
+    it('leaves showAtakContacts untouched when a save omits it', async () => {
+      const agent = await harness.loginAs(harness.limited);
+
+      await agent.post('/map-preferences').send({ showAtakContacts: true });
+      await agent.post('/map-preferences').send({ showPaths: true });
+
+      const get = await agent.get('/map-preferences');
+      expect(get.body.preferences).toMatchObject({ showAtakContacts: true, showPaths: true });
+    });
+
+    it('400s on a non-boolean showAtakContacts', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/map-preferences').send({ showAtakContacts: 'yes' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('defaults to false for a user who never saved it', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      await agent.post('/map-preferences').send({ showPaths: true });
+
+      const get = await agent.get('/map-preferences');
+      expect(get.body.preferences.showAtakContacts).toBe(false);
+    });
+  });
 });

--- a/src/server/routes/userPreferencesRoutes.ts
+++ b/src/server/routes/userPreferencesRoutes.ts
@@ -40,10 +40,10 @@ router.post('/map-preferences', requireAuth(), async (req, res) => {
       return res.status(403).json({ error: 'Cannot save preferences for anonymous user' });
     }
 
-    const { mapTileset, mapTilesetLight, mapTilesetDark, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryPointsOnly, positionHistoryHours, mapMaxAgeHours } = req.body;
+    const { mapTileset, mapTilesetLight, mapTilesetDark, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions, showAtakContacts, positionHistoryPointsOnly, positionHistoryHours, mapMaxAgeHours } = req.body;
 
     // Validate boolean values
-    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryPointsOnly };
+    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions, showAtakContacts, positionHistoryPointsOnly };
     for (const [key, value] of Object.entries(booleanFields)) {
       if (value !== undefined && typeof value !== 'boolean') {
         return res.status(400).json({ error: `${key} must be a boolean` });
@@ -82,6 +82,7 @@ router.post('/map-preferences', requireAuth(), async (req, res) => {
       showAnimations,
       showAccuracyRegions,
       showEstimatedPositions,
+      showAtakContacts,
       positionHistoryPointsOnly,
       positionHistoryHours,
       mapMaxAgeHours,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4882,6 +4882,7 @@ class DatabaseService {
     showAnimations?: boolean;
     showAccuracyRegions?: boolean;
     showEstimatedPositions?: boolean;
+    showAtakContacts?: boolean;
     positionHistoryHours?: number | null;
     mapMaxAgeHours?: number | null;
     positionHistoryPointsOnly?: boolean;


### PR DESCRIPTION
## Summary

"Show ATAK Contacts" never stayed checked — for every user, regardless of ATAK usage. The client was doing its part: `MapContext.setShowAtakContacts()` updates local state and POSTs `showAtakContacts` to `/api/user/map-preferences`. But the persistence chain behind that field was never built.

`POST /map-preferences` destructures an explicit field list from `req.body`, and `showAtakContacts` was not in it — so the value was dropped on the floor and the route still answered `{ success: true }`. Nothing surfaced to the user. The next preferences load returned a row that never contained the field, and the client fell back to `useState(false)`: exactly "never stays checked".

This looks like an oversight from ATAK/CoT Phase 2 (#3691) — the toggle and its default shipped, but the route → service → repository → schema chain didn't, unlike every sibling toggle (`showWaypoints`, `showMqttNodes`, …).

Fixes #4378.

## Changes

Wires the field end to end:

- **Migration 129** — adds `user_map_preferences.show_atak_contacts` on SQLite / PostgreSQL / MySQL, idempotent via the shared helpers.
- **Schema** (`src/db/schema/misc.ts`) — the column on all three table definitions.
- **Repository** (`mapPreferences.ts`) — read, the update path, and the insert path.
- **`DatabaseService.saveMapPreferencesAsync`** — parameter type.
- **Route** (`userPreferencesRoutes.ts`) — destructure, boolean validation, and the save call.

**No frontend change** — the client already sent and read the field correctly.

### Default is FALSE

Deliberate, and the opposite of migration 074 (`show_waypoints`). ATAK contacts are opt-in per #3691, and `MapContext` defaults to `useState(false)`, so a fresh row read has to agree with what an unconfigured user already sees on screen. `show_waypoints` defaults TRUE because that toggle is opt-out.

## Issues Resolved

Fixes #4378. Reported by NullVoid (Discord).

## Documentation Updates

No documentation changes needed — this restores the documented behavior of an existing toggle rather than changing or adding any.

## Testing

- [x] Full unit suite: **11,763 passed, 0 failed**, `success: true`
- [x] **Verified against live PostgreSQL and MySQL containers** — repository suites ran 1,408 passed with **0 skipped**, so migration 129 is genuinely exercised on all three backends rather than silently skipping (per the CLAUDE.md multi-backend caveat)
- [x] `tsc -p tsconfig.server.json --noEmit` clean; `npm run lint:ci` clean
- [x] **Regression test verified to actually catch the bug** — reverting just the route destructure fails 3 of the 5 new cases
- [ ] Reviewer check: toggle **Show ATAK Contacts** on the map, hard-refresh, confirm it stays checked; toggle it off, refresh, confirm it stays off

### Note on the test shape

The new cases assert the full save→load round-trip, not a 200. That is the point: the failure mode here was a *successful-looking* save, so any test that stopped at the status code would have passed against the broken code. They also cover the un-obvious cases — that a save omitting the field leaves the stored value alone, and that an explicit `false` persists rather than reading as "absent, use the default".

Route tests use the existing `createRouteTestApp()` harness (real session + real auth middleware + real SQL), per the CLAUDE.md route-test rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)