### PR TITLE
test(packet-log): de-flake the since-timestamp filter test

### DIFF
--- a/src/server/services/packetLogService.test.ts
+++ b/src/server/services/packetLogService.test.ts
@@ -132,11 +132,22 @@ describe('PacketLogService', () => {
   });
 
   describe('Packet Filtering', () => {
+    /**
+     * Captured once per test and shared with the `since` case below, which
+     * needs to place a cutoff *between* these fixtures. Re-reading the clock
+     * inside that test instead made it flaky: the fixtures sit 100ms/50ms/0ms
+     * behind this value, so a cutoff of `Date.now() - 60` only lands between
+     * the first two packets while under 10ms has elapsed since seeding. On a
+     * loaded CI runner it routinely did not, and the middle packet dropped out
+     * of the window — "expected 1 to be 2", with nothing actually broken.
+     */
+    let baseTime: number;
+
     beforeEach(async () => {
       databaseService.setSetting('packet_log_enabled', '1');
 
       // Add test data
-      const baseTime = Date.now();
+      baseTime = Date.now();
 
       await packetLogService.logPacket({
         packet_id: 1,
@@ -208,9 +219,12 @@ describe('PacketLogService', () => {
     });
 
     it('should filter by since timestamp', async () => {
-      const baseTime = Date.now();
+      // Cutoff sits between the -100ms fixture and the -50ms one, anchored to
+      // the same clock read that seeded them. `since` is an absolute epoch-ms
+      // bound compared as `timestamp >= since` — not a relative window, so the
+      // 60 here is 60 milliseconds, not the "60s" an earlier comment claimed.
       const packets = await packetLogService.getPackets({ since: baseTime - 60 });
-      expect(packets.length).toBe(2); // Should only get packets from last 60s
+      expect(packets.length).toBe(2); // the -50ms and -0ms packets; -100ms excluded
     });
 
     it('should support multiple filters combined', async () => {


### PR DESCRIPTION
## Summary

`PacketLogService > Packet Filtering > should filter by since timestamp` fails intermittently in CI with `expected 1 to be 2` while nothing is actually broken. It hit #4384 most recently — failing on the Node 22 leg and passing on Node 25 **for the same commit**, which is the tell that this is timing and not behavior.

This is a pre-existing flake, unrelated to whatever PR happens to be unlucky. It costs a rerun each time it fires, and worse, it trains everyone to rerun a red Test Suite leg without reading it.

## Root cause

`beforeEach` seeds three fixtures relative to a local `baseTime`:

| packet | timestamp |
|---|---|
| 1 | `baseTime - 100` |
| 2 | `baseTime - 50` |
| 3 | `baseTime` |

The test then **re-read the clock** and filtered `since: Date.now() - 60`.

`since` is an absolute epoch-ms bound, compared in the repository as `pl.timestamp >= ${since}`. So getting the expected 2 rows requires:

```
baseTime - 50 >= testTime - 60     →     testTime - baseTime <= 10ms
```

A 10ms budget covering three awaited `logPacket()` calls and whatever else the runner is doing. On a loaded CI box that is regularly exceeded, packet 2 falls outside the window, and one row comes back instead of two.

## The fix

Hoist `baseTime` to the `describe` scope so the cutoff is anchored to the same clock read that produced the fixtures. The window is then correct by construction rather than by how fast the runner is.

I deliberately did **not** just widen the window (e.g. `- 60` → `- 1000`). That lowers the failure rate without removing the race, which is the worst of both outcomes: still flaky, but rarely enough that the next failure looks like a real regression.

The assertion is unchanged — it still pins that `since` excludes the older packet, which is the behavior the test exists to cover.

### Also: the comment was wrong

It read `// Should only get packets from last 60s`. The 60 is 60 **milliseconds** — the fixtures are ms offsets and `since` is not a relative window. That wording would mislead anyone adjusting these fixtures, and plausibly explains why the tight margin went unnoticed. Replaced with a description of what the bound actually does.

## Issues Resolved

None filed — surfaced as CI noise on #4384. No behavior change; test-only.

## Documentation Updates

No documentation changes needed.

## Testing

- [x] Full unit suite: **11,198 passed, 0 failed**, `success: true`; confirmed the target test *ran* rather than skipped
- [x] `tsc -p tsconfig.server.json --noEmit` clean; `npm run lint:ci` clean
- [x] **Fix verified in both directions, not just asserted.** Injecting a 200ms delay before the assertion to simulate a slow runner:
  - old form → **fails**, `expected +0 to be 2` (same shape as the CI failure, larger gap)
  - hoisted form → **passes**

  Temporary scaffolding removed; the committed file contains only the hoist and the comment.
- [ ] Reviewer check: nothing else in the file depends on the old block-scoped `baseTime` — the `Packet Count` describe has its own, deliberately left alone since its tests never re-read the clock

**Coverage note:** this run reports 679 skips rather than the usual ~109 because the PostgreSQL/MySQL containers were down. That does not affect this change — `packetLogService.test.ts` is not in `SHARED_DB_TESTS` and runs against the SQLite singleton — but flagging it so the number is not mistaken for full multi-backend coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)