### PR TITLE
chore: bump version to 4.13.3-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.2",
+  "version": "4.13.3-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.2",
+  "version": "4.13.3-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.2
-appVersion: "4.13.2"
+version: 4.13.3-rc1
+appVersion: "4.13.3-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.2",
+  "version": "4.13.3-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.2",
+      "version": "4.13.3-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.2",
+  "version": "4.13.3-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps the version to **4.13.3-rc1** across all five version files. Patch bump — everything merged since `v4.13.2` is a fix, test, perf, or CI change; no new features.

| File | 4.13.2 → 4.13.3-rc1 |
|------|---------------------|
| `package.json` | ✅ |
| `package-lock.json` | ✅ (regenerated) |
| `helm/meshmonitor/Chart.yaml` | ✅ (`version` + `appVersion`) |
| `desktop/package.json` | ✅ |
| `desktop/src-tauri/tauri.conf.json` | ✅ |

## What's in this candidate

Nine commits since `v4.13.2`:

- **Map / MapAnalysis** — 3D view gets the view-state, follow, and layer plumbing 2D already had, keyed on the effective view mode; CSP `connect-src` widened so every built-in tileset host loads 3D basemaps (#4371). `activeStyleJson` wired into MapAnalysis and the MeshCore BaseMap.
- **Map UI** — tile selector gets a mobile bottom sheet (#4380); the "Show ATAK Contacts" toggle now persists (#4378).
- **Nodes** — every node row gets a distinct Node Details button (#4379).
- **News** — meshmonitor.org links in the news feed are absolutized (#4377).
- **CI** — stable releases publish to the `:dev` tag as well as `:latest` (#4382); unit suite parallelized and duplicate workflows retired; de-flaked the packet-log since-timestamp filter test (#4386).

## Test plan

- [ ] CI unit + integration suites green
- [ ] System tests green (label applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyRkje9qCerXExJMxjeBRT