### PR TITLE
feat(automations): hop-count tapback + {{ trigger.hopEmoji }} (#4340 phase 1)

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -155,6 +155,19 @@ or more actions.
 Reacts to the triggering message with an emoji. Minimal by design — it carries no routing logic
 (the conditions do the routing).
 
+- **Emoji source** — *A fixed emoji* (default; what every existing automation does before this
+  field existed) or *The message's hop count*.
+- Hop-count mode reacts with `*️⃣` for a direct (0-hop) message and `1️⃣`–`7️⃣` above, clamping at
+  `7️⃣` — the same table Auto-Acknowledge uses, so the two features never drift apart.
+- Triggers with no hop information (a Schedule or System trigger wired to a tapback, or a message
+  whose hop data is missing) record a **skipped no-op**, not a run failure.
+- The **Emoji** field is hidden while hop-count mode is selected; your fixed emoji is remembered if
+  you switch back to it later.
+- MeshCore sources are still skipped — MeshCore has no tapback concept on the protocol.
+- **Send via sources** — which radios send the reaction. Leave none to use the source that
+  triggered the automation — but a source **is required** for source-less triggers (System events
+  and Schedules).
+
 ### Send a message
 
 Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the body.
@@ -262,6 +275,107 @@ to let a repeater finish transmitting before replying. The pause only lasts for 
 durable across a restart; the dry-run [simulator](#testing-dry-run) resolves it instantly instead of
 actually waiting.
 
+## Recipe — per-channel range-test acks (issue #4340)
+
+A common base-station setup runs a busy **primary** community channel plus a quieter secondary
+channel (call it **RangeTest**) set aside for range testers. The operator wants an ack on the
+primary channel to redirect testers to RangeTest, while the ack on RangeTest itself says something
+appropriate for people who are already there. One global Auto-Acknowledge body can't be true in
+both places at once — this recipe answers it with two small automations.
+
+**The key insight:** a hop-count tapback is a **separate packet** whose entire payload is the
+reaction emoji. Moving the "how many hops did that take" signal into the tapback frees the whole
+text body for channel-specific wording — exactly the byte pressure the issue describes.
+
+### Automation A — "Range-test ack — Primary"
+
+**WHEN** *A message is received*
+- **Text contains:** `test` — or use **Text matches regex** `\b(test|ping)\b` for word-boundary
+  matching so it doesn't fire on "latest" or "pingpong".
+- **On channels:** `Primary`.
+- **Cooldown (seconds):** leave at `0`. See [Cooldown caveat](#cooldown-caveat-per-automation-not-per-node)
+  below before raising it.
+
+**THEN**
+1. `Send a tapback (reaction)` → **Emoji source:** *The message's hop count*.
+2. `Send a message` → leave **On channels** empty (it replies on the triggering channel), body:
+
+   ```
+   {{ trigger.hopEmoji }} {{ trigger.senderLabel }} {{ trigger.hops }}h {{ trigger.snr }}dB · range tests → #RangeTest
+   ```
+
+### Automation B — "Range-test ack — RangeTest"
+
+Identical trigger, except **On channels:** `RangeTest`.
+
+**THEN** the same hop-count tapback, plus a body that doesn't repeat the channel redirect (they're
+already there):
+
+```
+{{ trigger.hopEmoji }} {{ trigger.senderLabel }} {{ trigger.hops }}h SNR {{ trigger.snr }} RSSI {{ trigger.rssi }}
+```
+
+### Tapback-only variant
+
+Delete the `Send a message` action from both automations. The hop-count reaction alone answers a
+range test — direct-or-how-many-hops — at 7 bytes and zero channel noise. Add the text action back
+only where you actually want channel-specific wording.
+
+### Why two automations, not one with two rules
+
+The obvious alternative — one automation, trigger on `Primary, RangeTest`, then two rules gated by
+a text condition on the channel — isn't available today: the **Text comparison** condition's field
+picker (`Field` on `condition.string`) offers *Message text*, *Sender node id*, *Recipient node id*,
+and *MeshCore scope/region* for a message trigger, but not the channel name. Use the two-automation
+form above; it costs one extra automation, not any extra typing per rule.
+
+### Cooldown caveat (per-automation, not per-node)
+
+Be aware before you set a non-zero **Cooldown (seconds)**: the engine's cooldown currently applies
+to the whole automation, not to each sending node individually. On a busy channel, a cooldown after
+acking one range-tester suppresses acks to the *next* tester who pings before the window elapses.
+Leave it at `0` for this recipe, or accept that trade-off deliberately. Per-node cooldown scope is
+planned for Phase 2 of the epic this recipe belongs to (see
+[`AUTOACK_AUTOMATION_EPIC.md`](https://github.com/Yeraze/meshmonitor/blob/main/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md)
+internally).
+
+### Byte budget
+
+Keycap emoji (`*️⃣`, `1️⃣`…`7️⃣`) are **7 bytes each** in UTF-8 (base character + `U+FE0F` +
+`U+20E3`, 1 + 3 + 3 bytes). `{{ trigger.hopEmoji }}` therefore costs 7 bytes wherever it appears in
+a text body — one more reason the tapback (whose entire payload *is* the emoji) is the cheaper way
+to carry that signal than embedding it in text.
+
+With representative values (`senderLabel` = `N0CALL-1`, 3 hops, SNR `-6.5`, RSSI `-110`), the two
+example bodies above come out to:
+
+| Body | Bytes (`getUtf8ByteLength`) |
+| --- | --- |
+| Automation A ("… range tests → #RangeTest") | 56 |
+| Automation B ("… SNR … RSSI …") | 38 |
+
+Both are far under any applicable limit, leaving plenty of headroom to make the wording friendlier.
+On the limit itself: the issue's **237 bytes** is the Meshtastic LoRa on-air MTU — the *total*
+packet size, including its 16-byte header, not the usable text payload. The protobuf definitions
+(`protobufs/meshtastic/mesh.proto`, `Constants.DATA_PAYLOAD_LEN`) put the actual `Data` payload
+budget behind that header at **233 bytes**, a few bytes tighter than 237 once the header is
+accounted for. Separately, **MeshMonitor's own `MAX_MESSAGE_BYTES = 200`** constant
+(`src/server/constants/meshtastic.ts`) is a self-imposed, more conservative cap — but it is enforced
+only by the HTTP compose route (`routes/v1/messages.ts`, used by the message-composer UI and the
+public API). The Automation Engine's **Send a message** action does not go through that route: it
+calls the source manager's `sendTextMessage()` directly, so it is **not** subject to the 200-byte
+check or to any MeshMonitor-side truncation. In practice this means an automation body can use the
+full ~233-byte protocol budget if it needs to — but for this recipe there's no need to get anywhere
+near it.
+
+### Closing the loop
+
+Auto-Acknowledge stays a single global body by design; this recipe answers issue #4340 without
+adding a second configuration axis to it, by moving the per-channel branching into the Automation
+Engine feature built for exactly that. Two short automations — one per channel — replace the
+would-be per-channel Auto-Acknowledge field, and the hop-count tapback carries the "how many hops
+did that take" signal for free, in its own packet, regardless of which text (if any) accompanies it.
+
 ## Variables
 
 Variables are a separate, first-class management area under the Automations tab. A variable is
@@ -311,6 +425,7 @@ values, the set-variable value) accept **double-brace tokens**:
 | Token | Resolves to |
 | --- | --- |
 | `{{ trigger.* }}` | A field from the current trigger (e.g. `{{ trigger.text }}`, `{{ trigger.fromId }}`, `{{ trigger.hops }}`, `{{ trigger.value }}`, `{{ trigger.latestVersion }}`). The available fields depend on the trigger type |
+| `{{ trigger.hopEmoji }}` | The message trigger's hop count as an emoji — `*️⃣` direct, `1️⃣`–`7️⃣` (`7️⃣` = 7 or more). Same mapping as the tapback's hop-count mode above. Blank when the hop count is unknown |
 | `{{ trigger.sourceId }}` / `{{ trigger.timestamp }}` | Available for every trigger; `timestamp` renders as a local date/time |
 | `{{ var.name }}` | A user-defined variable; `{{ var.name.field }}` for nested `json` access |
 | `{{ NOW }}` | The current time, rendered as a local `YYYY-MM-DD HH:mm:ss` |

--- a/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md
+++ b/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md
@@ -1,0 +1,176 @@
+# Epic — Auto-Acknowledge on the Automation Engine
+
+**Issue:** #4340 (per-channel Auto-Acknowledge message body)
+**Status:** Phase 1 in progress
+**Owner:** orchestrated via `/epic`
+
+## Goal
+
+Issue #4340 asks for a per-channel Auto-Acknowledge body so a base station can
+tell range-testers on the primary channel to move to a secondary channel,
+without telling users *already on* the secondary channel to go somewhere else.
+
+Rather than growing Auto-Acknowledge a second configuration axis, we answer it
+in the **Automation Engine**, which was built for exactly this kind of
+branching. A user writes one rule per channel: filter on channel + trigger
+word, then respond with a hop-count tapback and/or a channel-appropriate text
+body.
+
+The epic then goes one step further and makes the Automation Engine a genuine
+superset of Auto-Acknowledge, ending in a converter that turns an existing
+Auto-Ack config into an editable automation.
+
+## What already existed (survey, 2026-07-28)
+
+Most of the #4340 scenario is expressible today:
+
+| Piece | Status |
+|---|---|
+| Trigger on message, filter by channel | `trigger.message` `channels` filter — `triggerContext.ts:322` |
+| Filter by trigger word | `textContains` / `regex` — `triggerContext.ts:335-338` |
+| Branch on hop count | `condition.numeric` on field `hops` — `catalog.ts:138` |
+| Respond with text | `action.sendMessage`, `{{ trigger.hops }}` available |
+| Send a tapback | `action.tapback` — **fixed emoji only**, `actionExecutor.ts:319` |
+
+The one real gap: a tapback cannot derive its emoji from hop count. AutoAck's
+table is an un-exported inline constant at `meshtasticManager.ts:10183`:
+
+```ts
+const HOP_COUNT_EMOJIS = ['*️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣'];
+```
+
+Reproducing it in an automation today needs eight near-identical rules.
+
+Fidelity gaps for a converter, found in the same survey:
+
+- **Cooldown granularity.** AutoAck cools down **per node**
+  (`meshtasticManager.ts:10090`); the engine cools down **per automation**
+  (`automationEngineService.ts:119`, `lastFired: Map<automationId, ms>`). On a
+  busy channel the engine's version would swallow acks to every other sender.
+- **No engine equivalent** for `autoAckSkipIncompleteNodes`,
+  `autoAckIgnoredNodes`, or `autoAckMaxAttempts`.
+- `autoAckPreSendDelaySeconds` **does** map — onto `action.delay`.
+
+## Decisions (interview, 2026-07-28)
+
+1. **Scope:** hop-count tapback *and* an AutoAck → Automation converter.
+2. **Design:** extend the existing `action.tapback` with an
+   `emojiMode: 'fixed' | 'hopCount'` select rather than adding a separate
+   action type — reuses its source loop, MeshCore skip, and TX-disabled
+   handling. Absent `emojiMode` means `fixed`, so existing automations are
+   untouched.
+3. **Token:** also expose `{{ trigger.hopEmoji }}` so message bodies can embed
+   the emoji, which is what makes the mixed text+emoji replies in #4340 work.
+4. **Issue #4340:** close it in Phase 1 with the concrete recipe.
+5. **Cooldown:** add a `cooldownScope` trigger param (`automation | node |
+   sourceNode`) rather than a variable-based workaround or accepting the
+   behaviour change.
+6. **Fidelity gaps:** add real engine conditions rather than warning about
+   them, so a converted automation behaves identically.
+7. **Converter output:** one automation per source, emitting **only the rules
+   whose 2×2 cells are actually enabled** (readable graph over literal 1:1
+   mapping).
+8. **Handover:** the conversion dialog ends with a checked-by-default "turn off
+   Auto-Acknowledge for this source" option — user confirms.
+
+**Out of scope:** MeshCore tapbacks (no such concept on the protocol — the
+existing `action.tapback` already records a skip for MeshCore sources). The
+`{{ trigger.hopEmoji }}` token is still populated for MeshCore messages, since
+`hopCount` exists there and the token is usable in text bodies.
+
+## Phases
+
+### Phase 1 — Hop-count tapback + `{{ trigger.hopEmoji }}` — [x] complete
+
+Extract the hop→emoji table into a shared helper used by both AutoAck and the
+engine; add `emojiMode` to `action.tapback`; expose `hopEmoji` as a derived
+trigger field and registered token; write the #4340 recipe and close the issue.
+
+**Exit criteria**
+- An automation with `emojiMode: hopCount` sends `*️⃣` at 0 hops and `1️⃣`–`7️⃣`
+  above, clamping at 7.
+- `{{ trigger.hopEmoji }}` resolves in `action.sendMessage` text.
+- AutoAck's own tapback behaviour is provably unchanged (existing tests green,
+  no new table).
+- Recipe documented; #4340 closed with a link to it.
+
+### Phase 2 — Per-node cooldown scope — [ ] not started
+
+Add `cooldownScope: 'automation' | 'node' | 'sourceNode'` to trigger params;
+key `lastFired` by the composite; make the trace message name the node.
+
+**Exit criteria**
+- Two senders on one channel cool down independently under `node` scope.
+- Absent `cooldownScope` behaves exactly as today (`automation`).
+- Trace output distinguishes which key was cooling down.
+
+### Phase 3 — Fidelity conditions — [ ] not started
+
+`condition.nodeComplete`, a node-in-list condition covering ignore lists, and a
+`maxAttempts` param on the send/tapback actions.
+
+**Exit criteria**
+- Every Auto-Acknowledge setting has an expressible engine equivalent, listed
+  explicitly in this doc at phase close.
+
+### Phase 4 — AutoAck → Automation converter — [ ] not started
+
+Backend graph builder (minimal rules), a preview + create route, and a button
+in `AutoAcknowledgeSection` showing a conversion report plus the
+checked-by-default disable option.
+
+**Exit criteria**
+- Converting a real config produces an automation that reproduces its
+  behaviour.
+- Preview shows the graph before anything is written.
+- Browser-validated end to end.
+
+## Notes / deviations
+
+_(updated at each phase close)_
+
+### Phase 1 close (2026-07-28)
+
+- **`showIf` is new, general infrastructure, not a reuse of anything.** The original brief assumed
+  `FieldDef.advanced` already gated conditional visibility; it turned out to be declared on six
+  fields but never read by `AutomationBuilder.tsx` — inert metadata. Phase 1 added the real
+  mechanism: a declarative `FieldDef.showIf: { field, equals?, notEquals? }`, a pure exported
+  `fieldVisible()` predicate (unit-tested via a full truth table, including the legacy-graph case
+  where an absent `emojiMode` must still show the `emoji` field), and one `.filter()` in
+  `BlockFields`. `action.tapback`'s `emoji` field is the first (and, as of Phase 1, only) consumer.
+  Hidden fields are never cleared — switching `emojiMode` back to `fixed` restores whatever fixed
+  emoji was previously configured.
+- **"No hop information" is a recorded skip, not a thrown error.** A hop-count tapback whose trigger
+  carries no hop data (a Schedule/System trigger wired to it, or a message missing
+  `hopStart`/`hopLimit`) returns `{ skipped: true, reason: 'tapback emojiMode=hopCount: the trigger
+  carries no hop count' }` and never calls `sendTapback`. Throwing would have marked the whole
+  automation run failed and spammed the run log for what is really a benign "nothing to react
+  with" case — the same shape already used for the MeshCore-tapback and TX-disabled skips.
+- **`deriveHops()` can go negative; the hop-emoji clamp papers over it, deliberately.** AutoAck's own
+  `hopsTraveled` calculation guards `hopStart >= hopLimit` before subtracting; the engine's
+  `deriveHops()` (used for `{{ trigger.hops }}` and `condition.numeric` on `hops`) has no such guard
+  and can render a negative number on a malformed packet. `hopCountEmoji()` clamps negative input to
+  `0` (`*️⃣`), so `{{ trigger.hopEmoji }}` and the hop-count tapback are always well-formed even when
+  `{{ trigger.hops }}` isn't. `deriveHops()` was deliberately **not** changed to add the guard —
+  doing so would silently alter every existing `condition.numeric` comparison on `hops` for anyone
+  who already has one. This divergence is intentional and pinned by a unit test.
+- **Docs/behaviour mismatch found and *not* fixed in Phase 1:** `docs/features/automation-engine.md`
+  claimed the `action.sendMessage` MeshCore **scope** select "reveals a Region picker" when
+  `scopeMode` is set to *A specific region…*. In the shipped builder, `scopeName` actually renders
+  unconditionally (no `showIf`) — the doc described the intended UX, not the real one. `showIf` now
+  makes fixing this trivial; it's a small follow-up (either add `showIf: { field: 'scopeMode',
+  equals: 'named' }` to `scopeName`, or correct the doc to say it's always visible), tracked as a
+  follow-up rather than folded into this hop-tapback change to keep the diff scoped.
+- **Payload-limit finding for the #4340 recipe:** the reporter's 237 bytes is the Meshtastic LoRa
+  on-air MTU (total packet, including a 16-byte header), not the usable text payload. The protobuf
+  `Constants.DATA_PAYLOAD_LEN = 233` (`protobufs/meshtastic/mesh.proto`) is the actual `Data`
+  payload budget. Separately, MeshMonitor's own `MAX_MESSAGE_BYTES = 200`
+  (`src/server/constants/meshtastic.ts`) is enforced only by the HTTP compose route
+  (`routes/v1/messages.ts`) — the Automation Engine's `action.sendMessage` calls
+  `mgr.sendTextMessage()` directly and is subject to **neither** check. Documented in the new
+  recipe section rather than left as an assumption.
+- **The one-automation/two-rules alternative form is not available today.** Verified against the
+  live `condition.string` field picker (`EVENT_STRING['trigger.message']` in
+  `src/components/automations/catalog.ts`): it exposes *Message text*, *Sender node id*, *Recipient
+  node id*, and *MeshCore scope/region* — no channel name. The recipe ships only the
+  two-automation form and documents the gap instead of a workaround that doesn't exist yet.

--- a/docs/internal/dev-notes/HOP_TAPBACK_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/HOP_TAPBACK_PHASE1_SPEC.md
@@ -1,0 +1,605 @@
+# Hop-Count Tapback — Phase 1 Implementation Spec
+
+**Epic:** `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md` · **Issue:** #4340
+**Branch:** `feature/hop-count-tapback` · **Worktree:** `/home/yeraze/Development/meshmonitor-hop-tapback`
+
+## 1. Reuse inventory (read this before writing any code)
+
+Everything below already exists and **must be used or extended, not
+re-implemented**. Verified by symbolic search on 2026-07-28.
+
+| Existing thing | Location | How Phase 1 uses it |
+|---|---|---|
+| `HOP_COUNT_EMOJIS` inline table | `src/server/meshtasticManager.ts:10184` | **Deleted**; becomes the body of the new shared helper. AutoAck imports it back. |
+| Hop-emoji glyphs (2nd copy!) | `src/components/EmojiPickerModal/EmojiPickerModal.tsx:32-40` | **De-duplicated** against the same helper. This is the "no second copy anywhere" requirement — it is not hypothetical, it exists today. |
+| `deriveHops(msg)` | `src/server/services/automation/triggerContext.ts:28` | Sole source of `hops` for Meshtastic; `hopEmoji` derives from its result. **Do not change it.** |
+| `msg.hopCount` (MeshCore) | `triggerContext.ts:162` | Sole source of `hops` for MeshCore; `hopEmoji` derives from it identically. |
+| `targetSource(node, ctx)` | `actionExecutor.ts` (private) | Unchanged — still resolves the tapback's source. |
+| `isMeshCoreSource(ctx, sid)` | `actionExecutor.ts` (private) | Unchanged — MeshCore skip stays exactly where it is, inside the per-source loop. |
+| `pushOrSkipTxDisabled(results, fn)` | `actionExecutor.ts` (private) | Unchanged — the `deps.sendTapback` call still goes through it. |
+| `interpolateAsync(text, ctx)` | `engineContext.ts` | Used only by `action.sendMessage`. **Do NOT start interpolating `p.emoji`** — that is a behaviour change out of scope. |
+| Recorded-skip shape `{ skipped: true, reason }` | `actionExecutor.ts` (tapback/MeshCore, nodeManage, requestData) | The **exact** shape the new "no hop information" outcome must use. |
+| `REQUEST_OPS` + its optional-param validation | `src/types/automation.ts` validation switch (`switch (n.type)` at :330) | The template for `emojiMode` validation: validate only when present. |
+| `BLOCK_BY_TYPE`, `fieldsFor`, `FieldDef`, `BlockDef` | `src/components/automations/catalog.ts:1-40` | `emojiMode` is a plain `kind: 'select'` `FieldDef` — no new `FieldKind` needed. |
+| `FieldInput` switch + `BlockFields` | `AutomationBuilder.tsx:65` / `:225-235` | `BlockFields` gains one `.filter()`; the `FieldInput` switch is **not** touched. |
+| `defaultParams(type, triggerType)` | `AutomationBuilder.tsx:48` | Already seeds a `select`'s first option — this gives new tapback blocks `emojiMode: 'fixed'` for free. |
+| `TRIGGER_TOKENS` / `UNIVERSAL_TOKENS` | `SubstitutionsHelp.tsx:12-40` | Source of truth that `tokenHints.ts` validates against. `hopEmoji` **must** be registered here or the builder flags it red. |
+| `ActionView` | `AutomationTester.tsx:~265` | Already renders `resolvedParams.emoji`; needs only a headline hint + skip handling. |
+| `recorder()` / `ctx()` / `node()` | `actionExecutor.test.ts:9-80` | All new executor tests use these. Do not invent new harnesses. |
+| `recordingDeps()` | `automationSimulator.ts:~106` | **Unchanged.** No new dep ⇒ no drift risk. |
+| `meshActionDeps.sendTapback` | `meshActionDeps.ts:~105` | **Unchanged.** The emoji is fully resolved before the dep is called. |
+| `getUtf8ByteLength` | `src/utils/text.ts:8` | Used by the docs author to compute the recipe's byte counts. |
+| `MAX_MESSAGE_BYTES = 200` | `src/server/constants/meshtastic.ts:336` | The real MeshMonitor cap. See §7 note on the reporter's "237". |
+
+### Justification for the one new module
+
+`src/utils/hopEmoji.ts` (~25 lines) is the only new file. Closest existing
+candidates and why they lose:
+
+- **`src/server/constants/meshtastic.ts`** — CLAUDE.md reserves it for
+  *protocol values* (PortNum, RoutingError). A hop→emoji table is presentation,
+  not protocol; and it is server-only, so `EmojiPickerModal.tsx` would keep its
+  duplicate. **Rejected.**
+- **`src/server/utils/autoAckDecision.ts`** — genuinely the closest (pure,
+  testable AutoAck decision helpers). But the Automation Engine importing an
+  `autoAck*` module makes the name a lie, and it is server-only ⇒ the frontend
+  duplicate survives. **Rejected.**
+- **`src/utils/autoAckMatrix.ts`** — shared, but models the 2×2 toggle matrix,
+  an unrelated concern, and is again AutoAck-named. **Rejected.**
+- **`src/utils/hopEmoji.ts`** — `src/utils/**` is the established shared tier
+  (`meshtasticManager.ts` already imports `../utils/distance.js`,
+  `../utils/nullIsland.js`, `../utils/positionIngestConfig.js`). Reachable by
+  all four consumers. **Chosen.**
+
+## 2. Deliverable 1 — shared hop→emoji helper
+
+### 2.1 New file `src/utils/hopEmoji.ts`
+
+```ts
+/**
+ * Hop-count → emoji mapping, shared by Auto-Acknowledge (meshtasticManager) and
+ * the Automation Engine (action.tapback emojiMode=hopCount, {{ trigger.hopEmoji }}).
+ *
+ * Presentation, not protocol — hence src/utils/ rather than
+ * src/server/constants/meshtastic.ts, and shared rather than server-only so the
+ * tapback emoji picker uses the same glyphs. There must be exactly ONE copy of
+ * this table in the repo.
+ *
+ * 0 hops is *️⃣ (asterisk keycap = "direct"), NOT 0️⃣. 7 and above clamp to 7️⃣
+ * (Meshtastic's hop_limit maxes at 7).
+ */
+export const HOP_COUNT_EMOJIS = ['*️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣'] as const;
+
+/** Highest hop count with a distinct glyph; anything above clamps to it. */
+export const HOP_EMOJI_MAX = 7;
+
+/**
+ * Emoji for a hop count, or `undefined` when the hop count is unknown.
+ *
+ * - null / undefined / non-finite → `undefined` (caller decides)
+ * - negative (a malformed hopStart < hopLimit packet) → clamped to 0 → `*️⃣`
+ * - fractional → truncated toward zero
+ * - >= HOP_EMOJI_MAX → `7️⃣`
+ *
+ * Returning `undefined` rather than `*️⃣` for "unknown" is deliberate: telling a
+ * range-tester they were direct when we do not know the hop count is a lie, and
+ * both engine call sites have a meaningful "unknown" branch.
+ */
+export function hopCountEmoji(hops: number | null | undefined): string | undefined {
+  if (hops == null || !Number.isFinite(hops)) return undefined;
+  return HOP_COUNT_EMOJIS[Math.min(Math.max(Math.trunc(hops), 0), HOP_EMOJI_MAX)];
+}
+```
+
+The signature is deliberately `number | null | undefined` rather than `unknown`:
+it removes the `Number('') === 0` / `Number(null) === 0` foot-gun entirely and
+matches both call sites' real types (`deriveHops` returns `number | undefined`,
+`msg.hopCount ?? undefined`).
+
+### 2.2 AutoAck consumes it — `src/server/meshtasticManager.ts:10183-10185`
+
+Replace the three lines with:
+
+```ts
+// Hop count emojis: *️⃣ for 0 (direct), 1️⃣-7️⃣ for 1-7+ hops. Shared with the
+// Automation Engine's action.tapback emojiMode=hopCount (src/utils/hopEmoji.ts).
+// `hopsTraveled` is already floored at 0 above, so the fallback is unreachable.
+const hopEmoji = hopCountEmoji(hopsTraveled) ?? HOP_COUNT_EMOJIS[0];
+```
+
+Import: `import { hopCountEmoji, HOP_COUNT_EMOJIS } from '../utils/hopEmoji.js';`
+(note the `.js` extension — matches the file's existing `../utils/*.js` imports).
+
+**Behaviour is provably identical:** `hopsTraveled` at `:10126-10133` is
+`hopStart - hopLimit` only when both are non-null *and* `hopStart >= hopLimit`,
+else `0` — i.e. always a finite integer ≥ 0. `hopCountEmoji` on such a value
+reduces to `HOP_COUNT_EMOJIS[Math.min(hopsTraveled, 7)]`, byte-for-byte the old
+expression. Everything downstream (`tapbackTarget`, `logger.debug`,
+`messageQueue.enqueue(hopEmoji, …, 1)`) is untouched.
+
+### 2.3 De-duplicate the frontend copy — `EmojiPickerModal.tsx:32-40`
+
+Replace the eight literal hop entries with a mapped block over
+`HOP_COUNT_EMOJIS`:
+
+```ts
+// Hop count emojis (for ping/test responses) — glyphs come from the single
+// shared table so they can never drift from Auto-Acknowledge / automations.
+...HOP_COUNT_EMOJIS.map((emoji, hops) => ({
+  emoji,
+  title: hops === 0 ? 'Direct (0 hops)' : hops === HOP_EMOJI_MAX ? '7+ hops' : `${hops} hop${hops === 1 ? '' : 's'}`,
+})),
+```
+
+The resulting `DEFAULT_TAPBACK_EMOJIS` array must be **element-for-element
+identical** to today (same order, same glyphs, same titles) — pinned by test.
+
+## 3. Deliverable 2 — `emojiMode` on `action.tapback`
+
+### 3.1 Checklist walk-through (all ten items, confirmed against the tree)
+
+| # | Item | Phase 1 action |
+|---|---|---|
+| 1 | `src/types/automation.ts:36` `ActionType` union | **No change** — extending `action.tapback`, not adding a type. |
+| 2 | `src/types/automation.ts:82` `ACTION_TYPES` | **No change.** |
+| 3 | Param-validation switch (`switch (n.type)` at `:330`) | **Add a `case 'action.tapback'`** — see §3.2. |
+| 4 | `ActionDeps` | **No change.** The emoji is computed *before* `deps.sendTapback`. |
+| 5 | `actionExecutor.ts` dispatch switch (`case 'action.tapback'` at `:318`) | **Change** — see §3.3. |
+| 6 | `meshActionDeps.ts:~105` | **No change** (deps did not grow). |
+| 7 | `automationSimulator.ts:~106 recordingDeps()` | **No change** (deps did not grow) — this is why the design resolves the emoji before the dep boundary. |
+| 8 | `catalog.ts:307` ACTIONS BlockDef | **Change** — see §3.4. |
+| 9 | `FieldKind` + `AutomationBuilder.tsx` switch | **No new kind.** `emojiMode` is `kind: 'select'`, already rendered. |
+| 10 | `AutomationTester.tsx ActionView` | **Change (small)** — see §3.6. |
+
+### 3.2 Type + validation — `src/types/automation.ts`
+
+Add next to the other operand unions (near `REQUEST_OPS`):
+
+```ts
+/** Where action.tapback's emoji comes from. Absent = 'fixed' (pre-4.14 behaviour). */
+export type TapbackEmojiMode = 'fixed' | 'hopCount';
+export const TAPBACK_EMOJI_MODES: readonly TapbackEmojiMode[] = ['fixed', 'hopCount'];
+```
+
+In the `switch (n.type)` param-check block, mirroring `action.requestData`:
+
+```ts
+case 'action.tapback':
+  // Optional. Absent/unset = 'fixed' — every pre-existing stored automation
+  // must keep validating and behaving exactly as before.
+  if (p.emojiMode != null && !TAPBACK_EMOJI_MODES.includes(p.emojiMode as TapbackEmojiMode)) {
+    errors.push(`action.tapback "${n.id}" requires params.emojiMode ∈ {fixed,hopCount}`);
+  }
+  break;
+```
+
+**Do not** add a required-`emoji` check — `p.emoji` has always been optional
+(defaults `'👍'`), and requiring it would reject stored graphs.
+
+### 3.3 Executor — `src/server/services/automation/actionExecutor.ts:318`
+
+```ts
+case 'action.tapback': {
+  // emojiMode (#4340): 'fixed' (default, and what an absent param means) uses the
+  // configured emoji; 'hopCount' derives it from the triggering message's hop
+  // count via the table AutoAcknowledge uses (src/utils/hopEmoji.ts).
+  const hopMode = p.emojiMode === 'hopCount';
+  let emoji: string;
+  if (hopMode) {
+    const derived = hopCountEmoji(ctx.trigger.fields.hops as number | null | undefined);
+    if (derived === undefined) {
+      // No hop information: a schedule/system trigger wired to a tapback, or a
+      // message whose hopStart/hopLimit were absent. Record a no-op skip in the
+      // same shape as the MeshCore/TX-disabled skips rather than throwing — a
+      // throw would mark the whole run failed and spam the run log.
+      return { skipped: true, reason: 'tapback emojiMode=hopCount: the trigger carries no hop count' };
+    }
+    emoji = derived;
+  } else {
+    emoji = String(p.emoji ?? '👍');
+  }
+  // …everything below is UNCHANGED: replyId / destination / channel resolution,
+  //   the sourceIds loop, isMeshCoreSource skip, pushOrSkipTxDisabled, unwrap.
+}
+```
+
+Explicit ordering decision (test-visible, so pin it): the hop-count resolution
+happens **before** the per-source loop. Consequences —
+
+- MeshCore trigger **with** `hopCount` + a Meshtastic target source → hop emoji
+  sent normally.
+- MeshCore trigger **with** `hopCount` + a MeshCore target source → existing
+  `'tapback is not supported on MeshCore'` skip (unchanged).
+- Any trigger **without** hop info → the single `'…carries no hop count'` skip,
+  returned before any source is examined.
+- `emojiMode: 'fixed'`, absent, or any unrecognised value → the existing
+  `String(p.emoji ?? '👍')` path, bit-identical to today. (Server-side
+  validation rejects unrecognised values at save time; the executor is
+  deliberately lenient for graphs written before validation.)
+
+Import: `import { hopCountEmoji } from '../../../utils/hopEmoji.js';`
+
+### 3.4 Catalog — `src/components/automations/catalog.ts:307-315`
+
+```ts
+{
+  type: 'action.tapback',
+  label: 'Send a tapback (reaction)',
+  description: 'React to the triggering message.',
+  fields: [
+    {
+      name: 'emojiMode', label: 'Emoji source', kind: 'select',
+      options: [
+        { value: 'fixed', label: 'A fixed emoji' },
+        { value: 'hopCount', label: `The message's hop count (${HOP_COUNT_EMOJIS[0]} direct, ${HOP_COUNT_EMOJIS[1]}–${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]})` },
+      ],
+      help: `Hop count reacts with ${HOP_COUNT_EMOJIS[0]} for a direct (0-hop) message and ${HOP_COUNT_EMOJIS[1]}–${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} above, clamping at ${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} — the same table Auto-Acknowledge uses. Triggers with no hop information (Schedule, System) record a skipped no-op.`,
+    },
+    { name: 'emoji', label: 'Emoji', kind: 'emoji', placeholder: '👍', showIf: { field: 'emojiMode', notEquals: 'hopCount' } },
+    { name: 'sourceIds', /* …unchanged… */ },
+  ],
+},
+```
+
+Import `HOP_COUNT_EMOJIS`/`HOP_EMOJI_MAX` from `../../utils/hopEmoji` (no `.js`
+— this is a Vite frontend module; match the file's neighbours' style).
+
+**ORCHESTRATOR CORRECTION (C1):** every emoji glyph in this file's labels and
+`help` copy MUST be interpolated from `HOP_COUNT_EMOJIS`, never typed as a
+literal. CLAUDE.md bans hardcoded emoji in JSX and locale UI copy; interpolating
+the shared constant satisfies it and keeps the single-source-of-truth property.
+Add above the block:
+`// #4340: protocol/content emoji (the glyphs actually sent over the mesh), not UI iconography — UiIcon does not apply. Glyphs are interpolated from the shared table so they cannot drift.`
+
+**Ordering matters twice:**
+1. `emojiMode` is listed *first* so the mode drives the field below it visually.
+2. `defaultParams()` (`AutomationBuilder.tsx:48`) seeds a `select`'s first
+   option when it is non-empty, so a **newly added** tapback block gets
+   `params.emojiMode = 'fixed'`. This equals today's behaviour and is safe.
+   **Existing stored graphs have no `emojiMode` at all and are never rewritten**
+   — the executor's default carries them.
+
+**Do NOT** put `emojiMode` behind `advanced: true` (see §3.5 — `advanced` is
+currently inert).
+
+### 3.5 Conditional field visibility — the general mechanism
+
+**Finding: no such mechanism exists today.** `FieldDef.advanced` is declared at
+`catalog.ts:23` and set on six fields, but `AutomationBuilder.tsx` never reads
+it — `BlockFields` maps over `def.fields` unconditionally. So there is nothing
+to reuse and a real (small) gap to close.
+
+Smallest general mechanism — **one optional declarative field on `FieldDef` +
+one pure predicate + one `.filter()`**:
+
+`catalog.ts`:
+```ts
+export interface FieldDef {
+  // …existing…
+  /**
+   * Render this field only when a sibling param matches. Omitted = always shown.
+   * Declarative (not a predicate function) so the catalog stays serialisable data.
+   */
+  showIf?: { field: string; equals?: unknown; notEquals?: unknown };
+}
+
+/** Should this field render, given the block's current params? Pure — unit-tested without React. */
+export function fieldVisible(field: FieldDef, params: Record<string, unknown>): boolean {
+  const c = field.showIf;
+  if (!c) return true;
+  const v = params[c.field];
+  if ('equals' in c && v !== c.equals) return false;
+  if ('notEquals' in c && v === c.notEquals) return false;
+  return true;
+}
+```
+
+`AutomationBuilder.tsx` `BlockFields` (~:227) — one-line change:
+```ts
+{def.fields.filter((f) => fieldVisible(f, block.params)).map((f) => { /* unchanged */ })}
+```
+
+Semantics to honour:
+- Hidden ≠ cleared. **Never delete `params.emoji` when the field is hidden** —
+  the user's fixed emoji is preserved across a `hopCount` → `fixed` round-trip,
+  and the executor already ignores it in `hopCount` mode.
+- A legacy graph with no `emojiMode` yields `params.emojiMode === undefined`,
+  which `!== 'hopCount'` ⇒ the Emoji field is shown. Correct.
+
+**Explicit non-goal:** do not retrofit `showIf` onto `scopeMode`/`scopeName` in
+this phase. File a follow-up issue instead ("docs claim `scopeName` is
+conditionally revealed; it is not — now fixable with `showIf`").
+
+### 3.6 Dry-run headline — `AutomationTester.tsx ActionView`
+
+```ts
+} else if (a.type === 'action.tapback') {
+  if (p.skipped) { headline = `Tapback → skipped (${String(p.reason ?? '')})`; }
+  else {
+    headline = `Tapback → ${p.destination != null ? `DM to node ${p.destination}` : `channel ${p.channel ?? 0}`}`;
+    sent = <div className="ae-test-sent">{String(p.emoji ?? '')}</div>;
+  }
+}
+```
+
+No simulator change is needed: `SimEventInput` already carries
+`hopStart`/`hopLimit` (`automationSimulator.ts:65-66, 208-209`) and the Test
+panel already renders **Hop start** / **Hop limit** inputs
+(`AutomationTester.tsx:235`), so the dry-run exercises `emojiMode: hopCount`
+end-to-end today.
+
+## 4. Deliverable 3 — `{{ trigger.hopEmoji }}`
+
+### 4.1 Meshtastic — `triggerContext.ts:68-96`
+
+`deriveHops(msg)` is currently called inline at `:80`. Hoist it so it is
+computed once:
+
+```ts
+const hops = deriveHops(msg);
+// …
+hops,
+hopEmoji: hopCountEmoji(hops),
+```
+
+### 4.2 MeshCore — `triggerContext.ts:~162`
+
+```ts
+const hops = msg.hopCount ?? undefined;
+// …
+hops,
+hopEmoji: hopCountEmoji(hops),
+```
+
+MeshCore has no tapback, but the token is usable in `action.sendMessage` bodies
+— that is the point (per the epic's out-of-scope note).
+
+### 4.3 Documented divergence (do not "fix" it)
+
+`deriveHops` has **no `hopStart >= hopLimit` guard** — unlike AutoAck's
+`hopsTraveled` at `meshtasticManager.ts:10126`. So on a malformed packet
+`{{ trigger.hops }}` can render a negative number while
+`{{ trigger.hopEmoji }}` renders `*️⃣` (clamped). **Leave `deriveHops` alone** —
+changing it would silently alter every existing `condition.numeric` on field
+`hops`. Add a comment at the `hopEmoji` line recording the divergence, and a
+unit test pinning it.
+
+Unknown hops ⇒ the field is `undefined` ⇒ `interpolate` renders blank, matching
+the documented "An unknown or empty value renders blank" contract. Confirm
+against `interpolate.test.ts` rather than assuming.
+
+### 4.4 UI token registry — `SubstitutionsHelp.tsx:24`
+
+Add to `TRIGGER_TOKENS['trigger.message']`, immediately after the existing
+`['hops', …]` entry:
+
+```ts
+// #4340: these are protocol/content emoji (the actual glyphs sent over the mesh),
+// not UI iconography — UiIcon does not apply. See CLAUDE.md "App-owned interface icons".
+['hopEmoji', `Hop count as an emoji — ${HOP_COUNT_EMOJIS[0]} direct, ${HOP_COUNT_EMOJIS[1]}–${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} (${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} = 7 or more); blank when the hop count is unknown`],
+```
+
+**The comment and the interpolation are both mandatory** (orchestrator
+correction C1 applies here too).
+
+Registering here automatically makes `tokenHints.ts`
+(`validTokenSet` / `anyTriggerTokenSet`) accept the token — no change to
+`tokenHints.ts` itself.
+
+**Do not** add `hopEmoji` to `fieldsFor`'s condition field lists. It is a
+string; comparing hop *emoji* is strictly worse than the existing
+`condition.numeric` on `hops`, and it would clutter the picker.
+
+## 5. Deliverable 4 — docs + the #4340 recipe
+
+### 5.1 `docs/features/automation-engine.md`
+
+**§ Actions → "Send a tapback (reaction)"** (`:153`) — replace the two-line stub:
+
+- **Emoji source** — *A fixed emoji* (default; what every existing automation
+  does) or *The message's hop count*.
+- Hop-count mode: `*️⃣` for a direct 0-hop message, `1️⃣`–`7️⃣` above, clamping at
+  `7️⃣`. Same table Auto-Acknowledge uses.
+- Triggers with no hop information (Schedule, System, or a message with no
+  `hopStart`/`hopLimit`) record a **skipped no-op**, not a failure.
+- MeshCore sources are still skipped — MeshCore has no tapback concept.
+- The **Emoji** field is hidden while hop-count mode is selected; your fixed
+  emoji is remembered if you switch back.
+
+**§ Tokens** (`:306`) — add a `{{ trigger.hopEmoji }}` row to the
+message-trigger token list, noting it renders blank when hop count is unknown.
+
+### 5.2 New section: `## Recipe — per-channel range-test acks (issue #4340)`
+
+Place it after `## Actions`. It must be followable verbatim.
+
+**The scenario (from the issue):** a base station on a busy primary community
+channel plus a secondary community channel. Range-testers ping on the primary;
+the operator wants the primary-channel ack to redirect them to the secondary
+channel, while the secondary-channel ack says something appropriate for people
+already there. One global Auto-Acknowledge body cannot be true in both places.
+
+**The key insight to state up front:** the hop-count reaction is a **separate
+packet** whose entire payload is the emoji. Moving the signal report into a
+hop-count tapback frees the whole text body for channel-specific wording —
+exactly the byte pressure the reporter describes.
+
+**Primary form — two automations (uses only blocks that provably exist today):**
+
+*Automation A — "Range-test ack — Primary"*
+- **WHEN** `A message is received`
+  - *Text contains:* `test`. Use *Text matches regex* `\b(test|ping)\b` for word
+    boundaries.
+  - *On channels:* `Primary`.
+  - *Cooldown (seconds):* leave `0`. **Call this out honestly:** the engine's
+    cooldown is currently per-automation, so a non-zero cooldown on a busy
+    channel swallows acks to *other* senders. Per-node cooldown scope lands in
+    Phase 2 of this epic.
+- **THEN**
+  1. `Send a tapback (reaction)` → **Emoji source: The message's hop count**
+  2. `Send a message` → leave *On channels* empty (replies on the triggering
+     channel), body:
+     `{{ trigger.hopEmoji }} {{ trigger.senderLabel }} {{ trigger.hops }}h {{ trigger.snr }}dB · range tests → #RangeTest`
+
+*Automation B — "Range-test ack — RangeTest"*
+- Identical trigger, but *On channels:* `RangeTest`.
+- **THEN** the same hop-count tapback, plus:
+  `{{ trigger.hopEmoji }} {{ trigger.senderLabel }} {{ trigger.hops }}h SNR {{ trigger.snr }} RSSI {{ trigger.rssi }}`
+
+*Tapback-only variant:* delete the `Send a message` action from A and B. The
+hop-count reaction alone carries the full range-test answer at ~7 bytes and zero
+channel noise.
+
+**Alternative form — one automation, two rules.** Same trigger with *On
+channels:* `Primary, RangeTest`, then two rules each gated by a `Text/String
+check` condition on the `channelName` field. **The docs author must verify in
+the builder that `channelName` is selectable in the condition field picker
+before publishing this variant** — if not, ship only the two-automation form and
+note the limitation.
+
+**Byte budget — must be numerically correct in the published doc.** Compute each
+example body with `getUtf8ByteLength` (`src/utils/text.ts:8`) and state the
+numbers. Non-obvious facts to include:
+- Keycap sequences are **7 bytes each** in UTF-8 (base char + U+FE0F +
+  U+20E3 = 1 + 3 + 3). `{{ trigger.hopEmoji }}` therefore costs 7 bytes in a
+  text body — which is precisely why putting it in the *tapback* is the win.
+- The reporter's **237 bytes** is the Meshtastic `TEXT_MESSAGE_APP` on-wire
+  payload maximum. **MeshMonitor's own constant is `MAX_MESSAGE_BYTES = 200`**
+  (`src/server/constants/meshtastic.ts:336`). The docs author **must trace**
+  whether an automation `sendMessage` is subject to that path (it routes through
+  `mgr.sendTextMessage`, while the 200-byte check lives in
+  `routes/v1/messages.ts:482`) and document the number that actually applies.
+  Do not publish "237" unverified.
+
+**Closing paragraph** — why this answers #4340 without per-channel
+Auto-Acknowledge fields, plus a drafted issue comment linking to the new doc
+section.
+
+**ORCHESTRATOR CORRECTION (C3):** WP4 drafts the closing comment into the PR
+description only. **Do not post to or close issue #4340** — the orchestrator
+does that after the PR merges.
+
+### 5.3 `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`
+
+Flip Phase 1 to `[x] complete`, and record under **Notes / deviations**: the
+`showIf` mechanism, the "no hop info → recorded skip" decision, the
+`deriveHops`-can-go-negative divergence, and the `scopeName` docs/behaviour
+mismatch follow-up.
+
+## 6. Test plan (mandatory — standard Vitest suite, no standalone scripts)
+
+| File | New / extend | Cases |
+|---|---|---|
+| `src/utils/hopEmoji.test.ts` | **new** | All 8 glyphs by index, pinned as exact string literals (catches a copy-paste of `0️⃣` for `*️⃣`); `0 → *️⃣`; `7 → 7️⃣`; `8`, `99` → `7️⃣`; `-1`, `-99` → `*️⃣`; `2.9 → 2️⃣`; `undefined`/`null`/`NaN`/`Infinity` → `undefined`; `HOP_COUNT_EMOJIS.length === 8`; `HOP_EMOJI_MAX === 7`. |
+| `src/server/meshtasticManager.autoAckTapbackEmoji.test.ts` | **new** — the "provably unchanged" regression | Drive `checkAutoAcknowledge` with `hopStart/hopLimit` pairs; assert the **first argument to `messageQueue.enqueue`** is `*️⃣` (0 hops), `3️⃣` (3), `7️⃣` (9, clamped), `*️⃣` when `hopStart < hopLimit` or either is absent. Model on `meshtasticManager.autoAckTokens.perSource.test.ts`. Also assert the tapback enqueue still passes `maxAttempts = 1` and `emoji flag = 1`. |
+| `src/components/EmojiPickerModal/EmojiPickerModal.hopEmojis.test.ts` | **new** | `DEFAULT_TAPBACK_EMOJIS` still contains exactly the 8 hop entries, in order, with the original titles (`'Direct (0 hops)'`, `'1 hop'`, `'2 hops'` … `'7+ hops'`); array length/order otherwise unchanged. |
+| `src/types/automation.test.ts` | extend | `emojiMode: 'fixed'`/`'hopCount'` validate; `'random'` produces the `∈ {fixed,hopCount}` error; a tapback node with **no** `emojiMode` still validates. |
+| `src/server/services/automation/actionExecutor.test.ts` | extend | `emojiMode` absent → `👍`; `'fixed'` → configured emoji; `'hopCount'` + `hops: 0` → `*️⃣`; `3` → `3️⃣`; `9` → `7️⃣`; `-2` → `*️⃣`; `undefined` → `{ skipped: true, reason: /no hop count/ }` **and `sendTapback` never called**; `'hopCount'` on a MeshCore source with hops present → existing MeshCore skip; multi-source → same emoji on every source; `'hopCount'` ignores a stale `p.emoji`. |
+| `src/server/services/automation/triggerContext.test.ts` | extend | `buildMessageContext` sets `hopEmoji` from `hopStart/hopLimit` (`3/1 → 2️⃣`); `undefined` when either absent; negative derived hops → `*️⃣` while `hops` stays negative (the documented divergence); MeshCore context sets `hopEmoji` from `msg.hopCount`, `undefined` when absent. |
+| `src/server/services/automation/automationSimulator.test.ts` | extend | Dry-run a `hopCount` tapback with `hopStart/hopLimit` → `resolvedParams.emoji === '3️⃣'`; no hop fields → recorded skip surfaces in `actions[0]`; `recordingDeps()` still satisfies `ActionDeps`. |
+| `src/server/services/automation/interpolate.test.ts` *(or `engineContext`)* | extend | `{{ trigger.hopEmoji }}` interpolates the glyph; blank when the field is `undefined`. |
+| `src/components/automations/catalog.showIf.test.ts` | **new** | `fieldVisible` truth table: no `showIf` → true; `equals` match/mismatch; `notEquals` match/mismatch; both together; `undefined` param vs `notEquals: 'hopCount'` → **true** (legacy-graph case). Plus: `action.tapback` has `emojiMode` before `emoji`, and `emoji` carries `showIf`. |
+| `src/components/automations/AutomationBuilder.emojiMode.test.tsx` | **new** (model on `AutomationBuilder.txWarning.test.tsx`) | `emojiMode: 'hopCount'` does **not** render the Emoji input; `'fixed'`/absent does; switching to `hopCount` **preserves** `params.emoji`. |
+| `src/components/automations/tokenHints.test.ts` | extend | `{{ trigger.hopEmoji }}` classifies as `'ok'` for `trigger.message`. |
+
+Also required per CLAUDE.md: full `npx vitest run` green (0 failures, confirmed
+via `--reporter=json` `success: true`) and
+`npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` empty. No
+new route ⇒ no envelope work; no schema change ⇒ no migration, no PG/MySQL
+containers required.
+
+## 7. Work packages
+
+All agents share **one worktree**. File ownership is exclusive — two packages
+never edit the same file, and the parallel pair (WP2/WP3) share no file.
+
+### WP1 — Shared helper + AutoAck extraction *(must land first; blocks everything)*
+
+**Owns:** `src/utils/hopEmoji.ts` (new) · `src/utils/hopEmoji.test.ts` (new) ·
+`src/server/meshtasticManager.ts` ·
+`src/server/meshtasticManager.autoAckTapbackEmoji.test.ts` (new) ·
+`src/components/EmojiPickerModal/EmojiPickerModal.tsx` ·
+`src/components/EmojiPickerModal/EmojiPickerModal.hopEmojis.test.ts` (new)
+
+**Acceptance:** `grep -rn "'\*️⃣'" src` returns exactly one non-test hit —
+`src/utils/hopEmoji.ts`. `hopCountEmoji` matches the §2.1 contract. AutoAck's
+emitted emoji is byte-identical for every hop value. `DEFAULT_TAPBACK_EMOJIS`
+unchanged element-for-element. Full suite green.
+
+### WP2 — Engine: `emojiMode` + `hopEmoji` field *(after WP1; parallel with WP3)*
+
+**Owns:** `src/types/automation.ts` · `src/types/automation.test.ts` ·
+`src/server/services/automation/actionExecutor.ts` · `.../actionExecutor.test.ts` ·
+`.../triggerContext.ts` · `.../triggerContext.test.ts` ·
+`.../automationSimulator.test.ts` · `.../interpolate.test.ts`
+
+**Acceptance:** §3.2/§3.3/§4 implemented exactly. `ActionDeps`,
+`meshActionDeps.ts`, `recordingDeps()` **not modified** (verify with
+`git diff --stat`). Every pre-existing tapback test passes **unmodified**. The
+no-hop path returns the recorded-skip shape and never calls `sendTapback`. Full
+suite green.
+
+### WP3 — Builder: `showIf`, catalog entry, token registry, tester *(after WP1; parallel with WP2)*
+
+**Owns:** `src/components/automations/catalog.ts` · `.../AutomationBuilder.tsx` ·
+`.../SubstitutionsHelp.tsx` · `.../AutomationTester.tsx` ·
+`.../catalog.showIf.test.ts` (new) ·
+`.../AutomationBuilder.emojiMode.test.tsx` (new) · `.../tokenHints.test.ts`
+
+**Hard constraint:** WP3 must **not** edit `src/types/automation.ts` (WP2 owns
+it). Use the string literals `'fixed'`/`'hopCount'` directly in the catalog
+`options`, with a comment pointing at `TapbackEmojiMode`. The token name is
+exactly `hopEmoji`; WP2 populates it.
+
+**ORCHESTRATOR CORRECTION (C2):** WP3 does **not** deploy or drive the dev
+container. Only one dev container may run at a time and the orchestrator manages
+it — WP3 delivers unit/component tests only; browser validation is the
+orchestrator's Stage 5.
+
+**Acceptance:** `fieldVisible` is a pure exported function with a full
+truth-table test; `BlockFields` filters through it; the Emoji field is hidden in
+`hopCount` mode and its stored value is preserved across a mode round-trip;
+`{{ trigger.hopEmoji }}` classifies as `'ok'`; `ActionView` shows the mode/skip.
+
+### WP4 — Docs + #4340 recipe *(after WP2 and WP3 both land)*
+
+**Owns:** `docs/features/automation-engine.md` ·
+`docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`
+
+**Acceptance:** §5 delivered. Byte counts computed with `getUtf8ByteLength`, not
+estimated. The applicable payload limit is **traced in code** before publishing
+(200 vs 237). Every field name, block label, and token in the recipe matches the
+shipped builder verbatim. A draft #4340 closing comment goes in the PR
+description — the issue itself is **not** touched (C3).
+
+**Dependency graph:** `WP1 → (WP2 ∥ WP3) → WP4`
+
+## 8. Contradictions found against the original brief
+
+1. **`catalog.ts`/`AutomationBuilder.tsx` have no conditional-visibility support
+   at all.** `FieldDef.advanced` is declared and set on six fields but **never
+   read** by the builder — inert metadata, not a precedent. `showIf` (§3.5) is
+   the new minimal general mechanism.
+2. **`docs/features/automation-engine.md` already documents behaviour that does
+   not exist:** it says the `action.sendMessage` MeshCore scope select "reveals a
+   Region picker", but `scopeName` renders unconditionally. Flagged as a
+   follow-up that `showIf` now makes trivial.
+3. **The hop-emoji table already has a second copy** at
+   `EmojiPickerModal.tsx:32-40`. The brief framed this as extracting one inline
+   constant; it is a two-site de-duplication — which is why the helper lands in
+   shared `src/utils/` rather than `src/server/**`.
+4. **The `emoji` `FieldKind` has no renderer.** `'emoji'` is in the `FieldKind`
+   union but `FieldInput` has no `case 'emoji'` — it falls through to `default`
+   and renders a plain text input.
+5. **`deriveHops()` can return a negative number** — it lacks the
+   `hopStart >= hopLimit` guard AutoAck has. The helper clamps; `deriveHops` is
+   deliberately left alone.
+6. **The 237-byte figure is the reporter's, not MeshMonitor's.** The codebase
+   constant is `MAX_MESSAGE_BYTES = 200`, referenced only from
+   `routes/v1/messages.ts`; the automation path goes to `mgr.sendTextMessage`
+   directly. WP4 must trace which limit applies.
+7. **Checklist items 4, 6 and 7 are confirmed no-ops** — the design resolves the
+   emoji before the `ActionDeps` boundary, so `meshActionDeps.ts` and
+   `recordingDeps()` cannot drift.
+8. **`AutomationTester` already supports hop input**, so the dry-run needs no new
+   UI to exercise `hopCount`.

--- a/src/components/EmojiPickerModal/EmojiPickerModal.hopEmojis.test.ts
+++ b/src/components/EmojiPickerModal/EmojiPickerModal.hopEmojis.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_TAPBACK_EMOJIS } from './EmojiPickerModal';
+
+// Regression test for #4340 WP1 §2.3: the 8 hop-count entries in
+// DEFAULT_TAPBACK_EMOJIS used to be hand-typed literals — a second copy of the
+// same table AutoAck carries. They're now generated from the shared
+// src/utils/hopEmoji.ts table. This pins the resulting array so the generated
+// entries stay element-for-element identical to the original literals (same
+// order, same glyphs, same titles).
+
+describe('EmojiPickerModal - DEFAULT_TAPBACK_EMOJIS hop-count entries (#4340)', () => {
+  const HOP_TITLES = [
+    'Direct (0 hops)',
+    '1 hop',
+    '2 hops',
+    '3 hops',
+    '4 hops',
+    '5 hops',
+    '6 hops',
+    '7+ hops',
+  ];
+  const HOP_GLYPHS = ['*️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣'];
+
+  it('contains exactly the 8 hop entries, in order, with the original titles', () => {
+    const hopEntries = DEFAULT_TAPBACK_EMOJIS.filter((e) => HOP_GLYPHS.includes(e.emoji));
+    expect(hopEntries).toHaveLength(8);
+    expect(hopEntries.map((e) => e.emoji)).toEqual(HOP_GLYPHS);
+    expect(hopEntries.map((e) => e.title)).toEqual(HOP_TITLES);
+  });
+
+  it('places the hop entries as a contiguous block right after "Double exclamation"', () => {
+    const idx = DEFAULT_TAPBACK_EMOJIS.findIndex((e) => e.title === 'Double exclamation');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const following = DEFAULT_TAPBACK_EMOJIS.slice(idx + 1, idx + 9);
+    expect(following.map((e) => e.emoji)).toEqual(HOP_GLYPHS);
+  });
+
+  it('array length and non-hop entries are otherwise unchanged (32 total)', () => {
+    expect(DEFAULT_TAPBACK_EMOJIS).toHaveLength(32);
+    expect(DEFAULT_TAPBACK_EMOJIS[0]).toEqual({ emoji: '👍', title: 'Thumbs up' });
+    expect(DEFAULT_TAPBACK_EMOJIS[DEFAULT_TAPBACK_EMOJIS.length - 1]).toEqual({ emoji: '💯', title: '100' });
+  });
+});

--- a/src/components/EmojiPickerModal/EmojiPickerModal.tsx
+++ b/src/components/EmojiPickerModal/EmojiPickerModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { MeshMessage } from '../../types/message';
 import './EmojiPickerModal.css';
 import { UiIcon } from '../icons';
+import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX } from '../../utils/hopEmoji';
 
 /**
  * Tapback emoji type
@@ -29,15 +30,12 @@ export const DEFAULT_TAPBACK_EMOJIS: TapbackEmoji[] = [
   { emoji: '❓', title: 'Question' },
   { emoji: '❗', title: 'Exclamation' },
   { emoji: '‼️', title: 'Double exclamation' },
-  // Hop count emojis (for ping/test responses)
-  { emoji: '*️⃣', title: 'Direct (0 hops)' },
-  { emoji: '1️⃣', title: '1 hop' },
-  { emoji: '2️⃣', title: '2 hops' },
-  { emoji: '3️⃣', title: '3 hops' },
-  { emoji: '4️⃣', title: '4 hops' },
-  { emoji: '5️⃣', title: '5 hops' },
-  { emoji: '6️⃣', title: '6 hops' },
-  { emoji: '7️⃣', title: '7+ hops' },
+  // Hop count emojis (for ping/test responses) — glyphs come from the single
+  // shared table so they can never drift from Auto-Acknowledge / automations.
+  ...HOP_COUNT_EMOJIS.map((emoji, hops) => ({
+    emoji,
+    title: hops === 0 ? 'Direct (0 hops)' : hops === HOP_EMOJI_MAX ? '7+ hops' : `${hops} hop${hops === 1 ? '' : 's'}`,
+  })),
   // Fun emojis (OLED compatible)
   { emoji: '💩', title: 'Poop' },
   { emoji: '👋', title: 'Wave' },

--- a/src/components/automations/AutomationBuilder.emojiMode.test.tsx
+++ b/src/components/automations/AutomationBuilder.emojiMode.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * AutomationBuilder — `action.tapback` emojiMode field visibility (#4340 WP3
+ * §3.5/§3.4). The Emoji field is hidden while Emoji source = "The message's
+ * hop count", and its stored value must survive a hopCount → fixed round
+ * trip (hidden ≠ cleared — the builder never deletes params.emoji).
+ *
+ * Test values for the fixed "emoji" param are plain placeholder strings, not
+ * real emoji glyphs — the `emoji` FieldKind has no dedicated renderer (falls
+ * through to a plain text input, per the spec's finding #4), and keeping
+ * glyph literals out of this file avoids any tension with the "no hardcoded
+ * emoji glyph outside a HOP_COUNT_EMOJIS interpolation" rule (#4340 C1),
+ * which governs the shipped catalog/token copy this suite is testing.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AutomationBuilder from './AutomationBuilder';
+import type { WorkflowForm } from './compile';
+
+// Override the global i18n mock so t(key, default) returns the English default.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string | Record<string, unknown>) =>
+      typeof defaultValue === 'string' ? defaultValue : key,
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+const FIXED_EMOJI = 'fixed-emoji-placeholder';
+
+function buildForm(params: Record<string, unknown>): WorkflowForm {
+  return {
+    trigger: { type: 'trigger.message', params: {} },
+    rules: [
+      {
+        conditions: [],
+        actions: [{ type: 'action.tapback', params }],
+      },
+    ],
+    combine: null,
+  };
+}
+
+function renderBuilder(params: Record<string, unknown>, onChange: (f: WorkflowForm) => void = () => {}) {
+  return render(
+    <AutomationBuilder
+      form={buildForm(params)}
+      variables={[]}
+      sources={[]}
+      channels={[]}
+      scripts={[]}
+      regions={[]}
+      onChange={onChange}
+    />,
+  );
+}
+
+/** The <select>/<input> control for a FieldDef, found via its `.ae-field` label. */
+function controlFor(labelText: string): HTMLElement {
+  const label = screen.getByText(labelText);
+  const container = label.closest('.ae-field');
+  if (!container) throw new Error(`No .ae-field ancestor found for label "${labelText}"`);
+  const control = container.querySelector('select, input, textarea');
+  if (!control) throw new Error(`No control found in field "${labelText}"`);
+  return control as HTMLElement;
+}
+
+describe('AutomationBuilder — action.tapback emojiMode (#4340)', () => {
+  it('shows the Emoji field when emojiMode is "fixed"', () => {
+    renderBuilder({ emojiMode: 'fixed', emoji: FIXED_EMOJI });
+    expect(screen.getByText('Emoji')).toBeInTheDocument();
+  });
+
+  it('shows the Emoji field when emojiMode is absent (legacy graph)', () => {
+    renderBuilder({ emoji: FIXED_EMOJI });
+    expect(screen.getByText('Emoji')).toBeInTheDocument();
+  });
+
+  it('hides the Emoji field when emojiMode is "hopCount"', () => {
+    renderBuilder({ emojiMode: 'hopCount', emoji: FIXED_EMOJI });
+    expect(screen.queryByText('Emoji')).not.toBeInTheDocument();
+  });
+
+  it('still shows the Emoji source select in hopCount mode', () => {
+    renderBuilder({ emojiMode: 'hopCount', emoji: FIXED_EMOJI });
+    expect(screen.getByText('Emoji source')).toBeInTheDocument();
+  });
+
+  it('preserves params.emoji across a hopCount → fixed round trip (hidden ≠ cleared)', async () => {
+    const user = userEvent.setup();
+    let latest: WorkflowForm = buildForm({ emojiMode: 'hopCount', emoji: FIXED_EMOJI });
+    const onChange = (f: WorkflowForm) => { latest = f; };
+    const { rerender } = renderBuilder({ emojiMode: 'hopCount', emoji: FIXED_EMOJI }, onChange);
+
+    // The Emoji field is hidden in hopCount mode — only Emoji source + Send via sources render.
+    expect(screen.queryByText('Emoji')).not.toBeInTheDocument();
+
+    // Switch the "Emoji source" select back to "A fixed emoji".
+    const select = controlFor('Emoji source') as HTMLSelectElement;
+    await user.selectOptions(select, 'fixed');
+
+    expect(latest.rules[0].actions[0].params.emojiMode).toBe('fixed');
+    // The stored fixed emoji was never deleted while the field was hidden.
+    expect(latest.rules[0].actions[0].params.emoji).toBe(FIXED_EMOJI);
+
+    // Re-render with the updated form and confirm the Emoji field is visible again,
+    // pre-populated with the preserved value.
+    rerender(
+      <AutomationBuilder
+        form={latest}
+        variables={[]}
+        sources={[]}
+        channels={[]}
+        scripts={[]}
+        regions={[]}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('Emoji')).toBeInTheDocument();
+    expect((controlFor('Emoji') as HTMLInputElement).value).toBe(FIXED_EMOJI);
+  });
+});

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -7,7 +7,7 @@
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, type BlockDef, type FieldDef } from './catalog';
+import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, fieldVisible, type BlockDef, type FieldDef } from './catalog';
 import type { WorkflowForm, FormBlock, Rule } from './compile';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
 import GeofenceFieldInput from './GeofenceFieldInput';
@@ -224,7 +224,7 @@ function BlockFields({ block, triggerType, variables, sources, channels, scripts
   if (!def) return null;
   return (
     <>
-      {def.fields.map((f) => {
+      {def.fields.filter((f) => fieldVisible(f, block.params)).map((f) => {
         const field = f.kind === 'fieldselect' ? { ...f, groups: fieldsFor(block.type, triggerType) } : f;
         return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} triggerType={triggerType}
           onChange={(v) => onParams({ ...block.params, [f.name]: v })} />;

--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -264,8 +264,14 @@ function ActionView({ a }: { a: SimResult['actions'][number] }) {
     headline = `Send message → ${p.destination != null ? `DM to node ${p.destination}` : `channel ${p.channel ?? 0}`}`;
     sent = <div className="ae-test-sent">{String(p.text ?? '')}</div>;
   } else if (a.type === 'action.tapback') {
-    headline = `Tapback → ${p.destination != null ? `DM to node ${p.destination}` : `channel ${p.channel ?? 0}`}`;
-    sent = <div className="ae-test-sent">{String(p.emoji ?? '')}</div>;
+    // emojiMode=hopCount with no hop info on the trigger records a skip (#4340)
+    // instead of sending — see actionExecutor.ts action.tapback.
+    if (p.skipped) {
+      headline = `Tapback → skipped (${String(p.reason ?? '')})`;
+    } else {
+      headline = `Tapback → ${p.destination != null ? `DM to node ${p.destination}` : `channel ${p.channel ?? 0}`}`;
+      sent = <div className="ae-test-sent">{String(p.emoji ?? '')}</div>;
+    }
   } else if (a.type === 'action.notify') {
     headline = 'Notify (Apprise)';
     sent = (

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -6,6 +6,7 @@
  * Used by both the builder (next to the message fields) and the Test panel.
  */
 import { UiIcon } from '../icons';
+import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX } from '../../utils/hopEmoji';
 
 // All `{{ trigger.* }}` tokens, by trigger type. `sourceId`/`timestamp` are added to every group.
 export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
@@ -22,6 +23,9 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
     ['to', 'Recipient node number'], ['toId', 'Recipient node id'], ['channel', 'Channel index'],
     ['portnum', 'Port number'], ['packetId', 'Packet id (used as tapback replyId) — Meshtastic only; unset for MeshCore, where replyToTrigger instead auto-prepends the @[senderLabel] mention'],
     ['hops', 'Hop count (hopStart − hopLimit)'], ['hopStart', 'Hop start'], ['hopLimit', 'Hop limit'],
+    // #4340: these are protocol/content emoji (the actual glyphs sent over the mesh),
+    // not UI iconography — UiIcon does not apply. See CLAUDE.md "App-owned interface icons".
+    ['hopEmoji', `Hop count as an emoji — ${HOP_COUNT_EMOJIS[0]} direct, ${HOP_COUNT_EMOJIS[1]}–${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} (${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} = 7 or more); blank when the hop count is unknown`],
     ['snr', 'Receive SNR — RF-received messages only'], ['rssi', 'Receive RSSI dBm — RF only'],
     ['isBroadcast', 'true if broadcast (alias of isChannel)'],
     ['wantAck', 'Sender requested an ack'], ['replyId', 'Replied-to packet id'],

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `showIf` conditional field visibility (#4340 WP3 §3.5) — the general
+ * mechanism a `FieldDef` uses to hide itself based on a sibling param, plus
+ * the `action.tapback` catalog entry that is its first consumer.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { fieldVisible, ACTIONS, type FieldDef } from './catalog';
+import { HOP_COUNT_EMOJIS } from '../../utils/hopEmoji';
+
+describe('fieldVisible', () => {
+  it('is visible when the field has no showIf', () => {
+    const field: FieldDef = { name: 'x', label: 'X', kind: 'text' };
+    expect(fieldVisible(field, {})).toBe(true);
+    expect(fieldVisible(field, { x: 'anything' })).toBe(true);
+  });
+
+  it('equals: visible only when the sibling param matches', () => {
+    const field: FieldDef = { name: 'x', label: 'X', kind: 'text', showIf: { field: 'mode', equals: 'a' } };
+    expect(fieldVisible(field, { mode: 'a' })).toBe(true);
+    expect(fieldVisible(field, { mode: 'b' })).toBe(false);
+    expect(fieldVisible(field, {})).toBe(false); // undefined !== 'a'
+  });
+
+  it('notEquals: visible except when the sibling param matches', () => {
+    const field: FieldDef = { name: 'x', label: 'X', kind: 'text', showIf: { field: 'mode', notEquals: 'hopCount' } };
+    expect(fieldVisible(field, { mode: 'fixed' })).toBe(true);
+    expect(fieldVisible(field, { mode: 'hopCount' })).toBe(false);
+  });
+
+  it('notEquals: an undefined sibling param (legacy graph, field never written) is visible', () => {
+    // A stored automation created before emojiMode existed has no key at all —
+    // params.emojiMode is undefined, which !== 'hopCount', so the field shows.
+    const field: FieldDef = { name: 'emoji', label: 'Emoji', kind: 'emoji', showIf: { field: 'emojiMode', notEquals: 'hopCount' } };
+    expect(fieldVisible(field, {})).toBe(true);
+  });
+
+  it('both equals and notEquals set: both conditions must pass', () => {
+    const field: FieldDef = { name: 'x', label: 'X', kind: 'text', showIf: { field: 'mode', equals: 'a', notEquals: 'b' } };
+    expect(fieldVisible(field, { mode: 'a' })).toBe(true);
+    // 'b' fails both equals (b !== a -> hidden) — equals check alone already hides it.
+    expect(fieldVisible(field, { mode: 'b' })).toBe(false);
+    expect(fieldVisible(field, { mode: 'c' })).toBe(false); // fails equals
+  });
+});
+
+describe('action.tapback catalog entry', () => {
+  const tapback = ACTIONS.find((a) => a.type === 'action.tapback');
+
+  it('exists and lists emojiMode before emoji', () => {
+    expect(tapback).toBeDefined();
+    const names = (tapback?.fields ?? []).map((f) => f.name);
+    const modeIdx = names.indexOf('emojiMode');
+    const emojiIdx = names.indexOf('emoji');
+    expect(modeIdx).toBeGreaterThanOrEqual(0);
+    expect(emojiIdx).toBeGreaterThan(modeIdx);
+  });
+
+  it('emojiMode is a select with fixed/hopCount options, fixed first', () => {
+    const field = tapback?.fields.find((f) => f.name === 'emojiMode');
+    expect(field?.kind).toBe('select');
+    expect(field?.options?.map((o) => o.value)).toEqual(['fixed', 'hopCount']);
+  });
+
+  it('emoji carries showIf hiding it when emojiMode is hopCount', () => {
+    const field = tapback?.fields.find((f) => f.name === 'emoji');
+    expect(field?.showIf).toEqual({ field: 'emojiMode', notEquals: 'hopCount' });
+  });
+
+  it('emojiMode option label and help resolve to the real hop-emoji glyphs (interpolation ran)', () => {
+    const field = tapback?.fields.find((f) => f.name === 'emojiMode');
+    const hopOption = field?.options?.find((o) => o.value === 'hopCount');
+    expect(hopOption?.label).toContain(HOP_COUNT_EMOJIS[0]);
+    expect(field?.help).toContain(HOP_COUNT_EMOJIS[0]);
+  });
+
+  it('no emoji glyph is hardcoded as a literal in catalog.ts source (C1) — every glyph is interpolated from HOP_COUNT_EMOJIS', () => {
+    // Read the actual source file (not the evaluated module) so a literal
+    // keycap glyph typed into a label/help string is caught even though the
+    // *interpolated* HOP_COUNT_EMOJIS[...] result would look identical at runtime.
+    const here = fileURLToPath(import.meta.url);
+    const catalogPath = here.replace(/catalog\.showIf\.test\.ts$/, 'catalog.ts');
+    const source = readFileSync(catalogPath, 'utf8');
+    for (const glyph of HOP_COUNT_EMOJIS) {
+      expect(source.includes(glyph)).toBe(false);
+    }
+  });
+});

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -5,6 +5,7 @@
  * metadata only; the engine validates the resulting graph server-side. Field
  * `kind` maps to an input renderer in AutomationBuilder.
  */
+import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX } from '../../utils/hopEmoji';
 
 export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect' | 'regionSelect';
 
@@ -23,6 +24,21 @@ export interface FieldDef {
   advanced?: boolean;
   /** This `text`/`textarea` field accepts `{{ }}` tokens → highlight + typo-check. */
   tokens?: boolean;
+  /**
+   * Render this field only when a sibling param matches. Omitted = always shown.
+   * Declarative (not a predicate function) so the catalog stays serialisable data.
+   */
+  showIf?: { field: string; equals?: unknown; notEquals?: unknown };
+}
+
+/** Should this field render, given the block's current params? Pure — unit-tested without React. */
+export function fieldVisible(field: FieldDef, params: Record<string, unknown>): boolean {
+  const c = field.showIf;
+  if (!c) return true;
+  const v = params[c.field];
+  if ('equals' in c && v !== c.equals) return false;
+  if ('notEquals' in c && v === c.notEquals) return false;
+  return true;
 }
 
 export interface BlockDef {
@@ -308,8 +324,20 @@ export const ACTIONS: BlockDef[] = [
     type: 'action.tapback',
     label: 'Send a tapback (reaction)',
     description: 'React to the triggering message.',
+    // #4340: protocol/content emoji (the glyphs actually sent over the mesh), not UI
+    // iconography — UiIcon does not apply. Glyphs are interpolated from the shared
+    // table so they cannot drift.
     fields: [
-      { name: 'emoji', label: 'Emoji', kind: 'emoji', placeholder: '👍' },
+      {
+        // 'fixed' | 'hopCount' — see TapbackEmojiMode in src/types/automation.ts.
+        name: 'emojiMode', label: 'Emoji source', kind: 'select',
+        options: [
+          { value: 'fixed', label: 'A fixed emoji' },
+          { value: 'hopCount', label: `The message's hop count (${HOP_COUNT_EMOJIS[0]} direct, ${HOP_COUNT_EMOJIS[1]}–${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]})` },
+        ],
+        help: `Hop count reacts with ${HOP_COUNT_EMOJIS[0]} for a direct (0-hop) message and ${HOP_COUNT_EMOJIS[1]}–${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} above, clamping at ${HOP_COUNT_EMOJIS[HOP_EMOJI_MAX]} — the same table Auto-Acknowledge uses. Triggers with no hop information (Schedule, System) record a skipped no-op.`,
+      },
+      { name: 'emoji', label: 'Emoji', kind: 'emoji', placeholder: '👍', showIf: { field: 'emojiMode', notEquals: 'hopCount' } },
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios send the reaction (MeshCore sources are skipped — tapbacks are Meshtastic-only). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
     ],
   },

--- a/src/components/automations/tokenHints.test.ts
+++ b/src/components/automations/tokenHints.test.ts
@@ -19,6 +19,10 @@ describe('classifyToken', () => {
     expect(classifyToken('var.flag', valid)).toBe('ok');
     expect(classifyToken('NOW', valid)).toBe('ok');
   });
+  it('ok for {{ trigger.hopEmoji }} on trigger.message (#4340)', () => {
+    const valid = validTokenSet('trigger.message', []);
+    expect(classifyToken('trigger.hopEmoji', valid)).toBe('ok');
+  });
   it('foreign for a real token that belongs to a DIFFERENT trigger', () => {
     const sys = validTokenSet('trigger.system', []);
     // trigger.from is a message token — valid somewhere, but not for system

--- a/src/server/meshtasticManager.autoAckTapbackEmoji.test.ts
+++ b/src/server/meshtasticManager.autoAckTapbackEmoji.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MeshtasticManager } from './meshtasticManager.js';
+import databaseService from '../services/database.js';
+
+// Regression test for #4340 WP1: the AutoAck tapback emoji used to be produced
+// by an inline `HOP_COUNT_EMOJIS` table + `Math.min(hopsTraveled, 7)` right at
+// the call site. Both were extracted into the shared `src/utils/hopEmoji.ts`
+// helper (also used by the Automation Engine's action.tapback emojiMode=hopCount
+// and {{ trigger.hopEmoji }}). This test proves the emitted emoji, and the
+// enqueue() call shape around it, are byte-identical to before the extraction.
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      getSettingForSource: vi.fn(),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+    },
+    channels: {
+      getChannelById: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return { messageQueueService: mockInstance, MessageQueueService };
+});
+
+describe('MeshtasticManager - Auto-Ack tapback emoji provably unchanged (#4340 WP1)', () => {
+  const FROM_NUM = 0x11223344;
+  const SOURCE_ID = 'source-tapback';
+
+  // Every test enables the tapback cell and disables the reply cell for BOTH
+  // possible cells (zero-hop / multi-hop), so the test doesn't need to predict
+  // which cell a given hopStart/hopLimit pair lands in. Cooldown is forced to 0
+  // so repeated calls to the same fromNum within one test file never collide.
+  const settingsFor = (overrides: Record<string, string | null> = {}) => {
+    const table: Record<string, string | null> = {
+      autoAckEnabled: 'true',
+      autoAckRegex: null, // default '^(test|ping)'
+      autoAckChannels: null,
+      autoAckIgnoredNodes: null,
+      autoAckSkipIncompleteNodes: null,
+      autoAckCooldownSeconds: '0',
+      autoAckPreSendDelaySeconds: null,
+      autoAckChannelZeroHopTapbackEnabled: 'true',
+      autoAckChannelMultiHopTapbackEnabled: 'true',
+      autoAckDirectZeroHopTapbackEnabled: 'true',
+      autoAckDirectMultiHopTapbackEnabled: 'true',
+      autoAckChannelZeroHopReplyEnabled: 'false',
+      autoAckChannelMultiHopReplyEnabled: 'false',
+      autoAckDirectZeroHopReplyEnabled: 'false',
+      autoAckDirectMultiHopReplyEnabled: 'false',
+      ...overrides,
+    };
+    return async (_sourceId: string, key: string) => (key in table ? table[key] : null);
+  };
+
+  let packetId = 1;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(databaseService.nodes.getNode).mockResolvedValue(null);
+    vi.mocked(databaseService.nodes.getActiveNodes).mockResolvedValue([]);
+    vi.mocked(databaseService.settings.getSetting).mockResolvedValue(null);
+  });
+
+  const runAndGetEnqueueArgs = async (message: {
+    hopStart?: number | null;
+    hopLimit?: number | null;
+    viaMqtt?: boolean;
+  }) => {
+    const manager = new MeshtasticManager(SOURCE_ID);
+    vi.mocked(databaseService.settings.getSettingForSource).mockImplementation(settingsFor());
+
+    // Channel message (isDirectMessage=false) on channel 0. autoAckChannels is
+    // null so the channel allowlist would normally reject it — but that gate
+    // only runs `if (!isDirectMessage)`, so use a DM instead to skip it and
+    // exercise the tapback path directly, matching the spec's "hopStart/hopLimit
+    // pairs" cases without needing to also stub a channel allowlist.
+    await (manager as any).checkAutoAcknowledge(
+      { hopStart: message.hopStart, hopLimit: message.hopLimit, viaMqtt: message.viaMqtt, timestamp: Date.now() },
+      'test', // matches default autoAckRegex '^(test|ping)'
+      0, // channelIndex
+      true, // isDirectMessage
+      FROM_NUM,
+      packetId++,
+      undefined,
+      undefined,
+    );
+
+    const enqueueMock = (manager as any).messageQueue.enqueue as ReturnType<typeof vi.fn>;
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    return enqueueMock.mock.calls[0];
+  };
+
+  it('0 hops (hopStart===hopLimit) → *️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: 0, hopLimit: 0 });
+    expect(args[0]).toBe('*️⃣');
+  });
+
+  it('3 hops (hopStart=3, hopLimit=0) → 3️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: 3, hopLimit: 0 });
+    expect(args[0]).toBe('3️⃣');
+  });
+
+  it('9 hops (hopStart=9, hopLimit=0), clamped → 7️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: 9, hopLimit: 0 });
+    expect(args[0]).toBe('7️⃣');
+  });
+
+  it('hopStart < hopLimit (malformed) → *️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: 1, hopLimit: 3 });
+    expect(args[0]).toBe('*️⃣');
+  });
+
+  it('hopStart absent → *️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: undefined, hopLimit: 0 });
+    expect(args[0]).toBe('*️⃣');
+  });
+
+  it('hopLimit absent → *️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: 3, hopLimit: undefined });
+    expect(args[0]).toBe('*️⃣');
+  });
+
+  it('both hopStart/hopLimit absent → *️⃣', async () => {
+    const args = await runAndGetEnqueueArgs({});
+    expect(args[0]).toBe('*️⃣');
+  });
+
+  it('the tapback enqueue call shape (destination/replyId/channel/maxAttempts/emoji-flag) is unchanged', async () => {
+    const args = await runAndGetEnqueueArgs({ hopStart: 2, hopLimit: 0 });
+    // [0] emoji, [1] destination (fromNum for DM), [2] replyId (packetId),
+    // [3] onSuccess, [4] onFailure, [5] channel (undefined for DM),
+    // [6] maxAttempts, [7] emoji flag.
+    expect(args[0]).toBe('2️⃣');
+    expect(args[1]).toBe(FROM_NUM);
+    expect(typeof args[2]).toBe('number'); // replyId = the triggering packetId
+    expect(typeof args[3]).toBe('function'); // onSuccess
+    expect(typeof args[4]).toBe('function'); // onFailure
+    expect(args[5]).toBeUndefined(); // channel: undefined for a DM
+    expect(args[6]).toBe(1); // maxAttempts — tapbacks are best-effort, don't retry
+    expect(args[7]).toBe(1); // emoji flag = 1 for tapback/reaction
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -50,6 +50,7 @@ import { shouldGateAutomations, averageStrongestNeighborUtilization, DEFAULT_AIR
 import { resolveLastHopName } from './utils/lastHop.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
 import { autoAckIsZeroHop, autoAckCellKey, resolveAutoAckReplyRouting } from './utils/autoAckDecision.js';
+import { hopCountEmoji, HOP_COUNT_EMOJIS } from '../utils/hopEmoji.js';
 import { scriptDependencyEnv } from './utils/scriptRunner.js';
 import { canonicalMessageTime, plausibleRxTime } from './utils/messageTime.js';
 import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
@@ -10180,9 +10181,10 @@ class MeshtasticManager implements ISourceManager {
       // Delivered the same way the trigger arrived: DM→DM, channel→channel.
       // Note: packetId can be 0 (valid unsigned integer), so check explicitly.
       if (cellTapbackEnabled && packetId != null) {
-        // Hop count emojis: *️⃣ for 0 (direct), 1️⃣-7️⃣ for 1-7+ hops
-        const HOP_COUNT_EMOJIS = ['*️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣'];
-        const hopEmoji = HOP_COUNT_EMOJIS[Math.min(hopsTraveled, 7)];
+        // Hop count emojis: *️⃣ for 0 (direct), 1️⃣-7️⃣ for 1-7+ hops. Shared with the
+        // Automation Engine's action.tapback emojiMode=hopCount (src/utils/hopEmoji.ts).
+        // `hopsTraveled` is already floored at 0 above, so the fallback is unreachable.
+        const hopEmoji = hopCountEmoji(hopsTraveled) ?? HOP_COUNT_EMOJIS[0];
         const tapbackTarget = isDirectMessage
           ? `!${fromNum.toString(16).padStart(8, '0')}`
           : `channel ${channelIndex}`;

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -375,6 +375,83 @@ describe('executeAction', () => {
     expect(Array.isArray(result)).toBe(false);
   });
 
+  // ── emojiMode (#4340) ───────────────────────────────────────────────────
+  it('tapback: emojiMode absent defaults to the configured emoji (👍)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.tapback', {}),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false }),
+      deps,
+    );
+    expect(calls[0].args).toMatchObject({ emoji: '👍' });
+  });
+
+  it("tapback: emojiMode 'fixed' uses the configured emoji", async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.tapback', { emojiMode: 'fixed', emoji: '✅' }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false }),
+      deps,
+    );
+    expect(calls[0].args).toMatchObject({ emoji: '✅' });
+  });
+
+  it("tapback: emojiMode 'hopCount' derives the emoji from trigger.hops (0/3/9/-2)", async () => {
+    const cases: Array<[number, string]> = [[0, '*️⃣'], [3, '3️⃣'], [9, '7️⃣'], [-2, '*️⃣']];
+    for (const [hops, expected] of cases) {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.tapback', { emojiMode: 'hopCount' }),
+        ctx({ from: 5, channel: 3, packetId: 99, isDM: false, hops }),
+        deps,
+      );
+      expect(calls[0].args).toMatchObject({ emoji: expected });
+    }
+  });
+
+  it("tapback: emojiMode 'hopCount' ignores a stale params.emoji", async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.tapback', { emojiMode: 'hopCount', emoji: '💯' }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false, hops: 3 }),
+      deps,
+    );
+    expect(calls[0].args).toMatchObject({ emoji: '3️⃣' });
+  });
+
+  it("tapback: emojiMode 'hopCount' with no hop info records a skip and never calls sendTapback", async () => {
+    const { calls, deps } = recorder();
+    const result = await executeAction(
+      node('action.tapback', { emojiMode: 'hopCount' }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false }), // no `hops` field
+      deps,
+    );
+    expect(result).toEqual({ skipped: true, reason: expect.stringMatching(/no hop count/) });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("tapback: emojiMode 'hopCount' on a MeshCore source with hops present still hits the existing MeshCore skip", async () => {
+    const { calls, deps } = recorder();
+    const result = await executeAction(
+      node('action.tapback', { emojiMode: 'hopCount' }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false, hops: 2 }, 'mc', 'meshcore'),
+      deps,
+    );
+    expect(result).toMatchObject({ skipped: true, reason: 'tapback is not supported on MeshCore' });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("tapback: emojiMode 'hopCount' sends the same derived emoji to every selected source", async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.tapback', { emojiMode: 'hopCount', sourceIds: ['radioA', 'radioB'] }),
+      ctx({ from: 5, channel: 3, packetId: 99, isDM: false, hops: 1 }),
+      deps,
+    );
+    expect(calls.map((c) => c.args.sourceId)).toEqual(['radioA', 'radioB']);
+    expect(calls.every((c) => c.args.emoji === '1️⃣')).toBe(true);
+  });
+
   it('nodeManage: defaults to the subject node and validates op', async () => {
     const { calls, deps } = recorder();
     await executeAction(node('action.nodeManage', { op: 'favorite' }), ctx({ from: 222 }), deps);

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -9,6 +9,7 @@
 import { type AutomationNode, AUTOMATION_DELAY_MAX_SECONDS } from '../../../types/automation.js';
 import { type EngineEvalContext, interpolateAsync, resolveOperand } from './engineContext.js';
 import { isTxDisabledError } from '../../errors/txDisabledError.js';
+import { hopCountEmoji } from '../../../utils/hopEmoji.js';
 
 export type NodeManageOp = 'favorite' | 'unfavorite' | 'ignore' | 'unignore' | 'delete';
 
@@ -316,7 +317,24 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
     }
 
     case 'action.tapback': {
-      const emoji = String(p.emoji ?? '👍');
+      // emojiMode (#4340): 'fixed' (default, and what an absent param means) uses the
+      // configured emoji; 'hopCount' derives it from the triggering message's hop
+      // count via the table AutoAcknowledge uses (src/utils/hopEmoji.ts).
+      const hopMode = p.emojiMode === 'hopCount';
+      let emoji: string;
+      if (hopMode) {
+        const derived = hopCountEmoji(ctx.trigger.fields.hops as number | null | undefined);
+        if (derived === undefined) {
+          // No hop information: a schedule/system trigger wired to a tapback, or a
+          // message whose hopStart/hopLimit were absent. Record a no-op skip in the
+          // same shape as the MeshCore/TX-disabled skips rather than throwing — a
+          // throw would mark the whole run failed and spam the run log.
+          return { skipped: true, reason: 'tapback emojiMode=hopCount: the trigger carries no hop count' };
+        }
+        emoji = derived;
+      } else {
+        emoji = String(p.emoji ?? '👍');
+      }
       // Default replyId is the triggering packet; route the way the trigger arrived.
       const replyId = p.replyId != null ? await num(ctx, p.replyId) : (ctx.trigger.fields.packetId as number | undefined);
       const destination = isDM ? (ctx.trigger.fields.from as number | undefined) : undefined;

--- a/src/server/services/automation/automationSimulator.test.ts
+++ b/src/server/services/automation/automationSimulator.test.ts
@@ -175,6 +175,45 @@ describe('simulateAutomation', () => {
     expect(fail.conditionResults['c']).toBe(false);
   });
 
+  // ── action.tapback emojiMode=hopCount (#4340) ───────────────────────────
+  it("tapback emojiMode 'hopCount': dry-run resolves the derived emoji, no IO", async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'a', type: 'action.tapback', params: { emojiMode: 'hopCount' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const r = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'message', text: 'ping', from: 111, hopStart: 3, hopLimit: 0, packetId: 1 },
+    });
+    expect(r.status).toBe('completed');
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0].type).toBe('action.tapback');
+    expect((r.actions[0].resolvedParams as any).emoji).toBe('3️⃣');
+  });
+
+  it("tapback emojiMode 'hopCount' with no hop fields: the recorded skip surfaces as the action's resolved params", async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'a', type: 'action.tapback', params: { emojiMode: 'hopCount' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const r = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'message', text: 'ping', from: 111 }, // no hopStart/hopLimit
+    });
+    expect(r.status).toBe('completed');
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0].ok).toBe(true); // a recorded skip is not an execution failure
+    expect(r.actions[0].resolvedParams).toMatchObject({ skipped: true, reason: expect.stringMatching(/no hop count/) });
+  });
+
   it('runScript: dry-run records the action without spawning a process', async () => {
     const graph: AutomationGraph = {
       version: 1,

--- a/src/server/services/automation/interpolate.test.ts
+++ b/src/server/services/automation/interpolate.test.ts
@@ -50,6 +50,17 @@ describe('interpolate', () => {
     const lk = (p: string) => ({ 'var.lastTimestamp': 1782331391 } as Record<string, number>)[p];
     expect(interpolate('{{ var.lastTimestamp }}', lk)).toBe('1782331391');
   });
+
+  // {{ trigger.hopEmoji }} (#4340) — populated by triggerContext.ts, rendered here
+  // through the same generic token-lookup path every other trigger.* field uses.
+  it('renders {{ trigger.hopEmoji }} when present, and blank when the field is unknown', () => {
+    const withHop = (p: string) => ({ 'trigger.hopEmoji': '3️⃣' } as Record<string, string>)[p];
+    expect(interpolate('hops: {{ trigger.hopEmoji }}', withHop)).toBe('hops: 3️⃣');
+    // Unknown hop count → the field is undefined → renders blank, matching the
+    // documented "unknown/empty value renders blank" contract.
+    const noHop = () => undefined;
+    expect(interpolate('hops: [{{ trigger.hopEmoji }}]', noHop)).toBe('hops: []');
+  });
 });
 
 describe('extractPaths', () => {

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -106,6 +106,27 @@ describe('buildMessageContext', () => {
     expect(buildMessageContext(msg(), 'default', 1).fields.senderLabel).toBe('!0000006f');
     expect(buildMessageContext(msg(), 'default', 1).fields.protocol).toBe('meshtastic');
   });
+
+  // hopEmoji (#4340)
+  it('sets hopEmoji from the derived hop count', () => {
+    const ctx = buildMessageContext(msg({ hopStart: 3, hopLimit: 1 }), 'default', 1);
+    expect(ctx.fields.hops).toBe(2);
+    expect(ctx.fields.hopEmoji).toBe('2️⃣');
+  });
+
+  it('hopEmoji is undefined when hopStart/hopLimit are absent (unknown hops)', () => {
+    const ctx = buildMessageContext(msg({ hopStart: undefined, hopLimit: undefined }), 'default', 1);
+    expect(ctx.fields.hops).toBeUndefined();
+    expect(ctx.fields.hopEmoji).toBeUndefined();
+  });
+
+  it('documented divergence: a negative derived hop count clamps hopEmoji to *️⃣ while `hops` stays negative', () => {
+    // deriveHops has no hopStart >= hopLimit guard (unlike AutoAck's hopsTraveled) —
+    // this is deliberate, see §4.3 of the hop-tapback spec. Do NOT "fix" deriveHops.
+    const ctx = buildMessageContext(msg({ hopStart: 1, hopLimit: 3 }), 'default', 1);
+    expect(ctx.fields.hops).toBe(-2);
+    expect(ctx.fields.hopEmoji).toBe('*️⃣');
+  });
 });
 
 describe('other trigger contexts', () => {
@@ -284,6 +305,13 @@ describe('buildMeshCoreMessageContext (#3833)', () => {
     expect(ctx.fields.scopeName).toBe('paris');
     expect(ctx.fields.scoped).toBe(true);
     expect(ctx.fields.hops).toBe(2);
+    expect(ctx.fields.hopEmoji).toBe('2️⃣'); // #4340
+  });
+
+  it('hopEmoji is undefined when msg.hopCount is absent (#4340)', () => {
+    const ctx = buildMeshCoreMessageContext(mcMsg({ fromPublicKey: 'aabbcc' }), 'default', 1);
+    expect(ctx.fields.hops).toBeUndefined();
+    expect(ctx.fields.hopEmoji).toBeUndefined();
   });
 
   it('maps a DM: recipient pubkey present, no channel, isDM', () => {

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -10,6 +10,7 @@ import type { DbMessage } from '../../../services/database.js';
 import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import type { TriggerType } from '../../../types/automation.js';
 import { compileUserRegex } from '../../../utils/safeRegex.js';
+import { hopCountEmoji } from '../../../utils/hopEmoji.js';
 
 /** Meshtastic broadcast address (0xFFFFFFFF); also defined inline in the manager. */
 export const BROADCAST_ADDR = 0xffffffff;
@@ -65,6 +66,7 @@ export function buildMessageContext(
   const fromName = (labels?.fromName && String(labels.fromName).trim()) || fromId;
   const channelName = isDM ? undefined : (labels?.channelName ?? undefined);
   const senderLabel = fromName || channelName || fromId;
+  const hops = deriveHops(msg);
   const fields: Record<string, unknown> = {
     from: Number(msg.fromNodeNum),
     fromId: msg.fromNodeId,
@@ -77,7 +79,13 @@ export function buildMessageContext(
     senderLabel,
     portnum: msg.portnum,
     packetId: Number.isFinite(parsedPacketId) ? parsedPacketId : undefined,
-    hops: deriveHops(msg),
+    hops,
+    // #4340: hopCountEmoji clamps a negative hop count to 0 (*️⃣), but `hops`
+    // above is deriveHops' raw (possibly negative, on a malformed hopStart <
+    // hopLimit packet) value — deliberately NOT aligned. Changing deriveHops to
+    // guard against this would silently alter every existing condition.numeric
+    // on field `hops`, so the divergence is documented here instead.
+    hopEmoji: hopCountEmoji(hops),
     hopStart: msg.hopStart,
     hopLimit: msg.hopLimit,
     isDM,
@@ -143,6 +151,7 @@ export function buildMeshCoreMessageContext(
   // (channel posts may carry no name prefix), else the channel name, else the raw
   // id (a pubkey for DMs/rooms, or the synthetic `channel-<idx>` key).
   const senderLabel = fromName || channelName || fromId;
+  const hops = msg.hopCount ?? undefined;
   const fields: Record<string, unknown> = {
     // MeshCore senders are pubkey strings; channel messages have no per-sender
     // pubkey, so `from` is the synthetic `channel-<idx>` key. `fromName` carries
@@ -159,7 +168,10 @@ export function buildMeshCoreMessageContext(
     isDM,
     isChannel,
     isBroadcast: isChannel,
-    hops: msg.hopCount ?? undefined,
+    hops,
+    // #4340: same shared table as the Meshtastic context; MeshCore has no
+    // tapback concept, but the token is usable in action.sendMessage bodies.
+    hopEmoji: hopCountEmoji(hops),
     snr: msg.snr,
     rssi: msg.rssi,
     // MeshCore scope/region (#3833). `scopeCode` 0 = explicitly unscoped, null/

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -99,6 +99,28 @@ describe('validateAutomationGraph', () => {
     expect(validateAutomationGraph(withReboot({ targetNodeNum: 1.5 })).valid).toBe(false);
   });
 
+  // ── action.tapback emojiMode (#4340) ────────────────────────────────────
+  it('action.tapback: emojiMode validates when present, and absence still validates', () => {
+    const withTapback = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'a', type: 'action.tapback', params },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    // absent → valid (pre-4.14 stored automations keep validating)
+    expect(validateAutomationGraph(withTapback({})).valid).toBe(true);
+    expect(validateAutomationGraph(withTapback({ emoji: '👍' })).valid).toBe(true);
+    // valid modes
+    expect(validateAutomationGraph(withTapback({ emojiMode: 'fixed' })).valid).toBe(true);
+    expect(validateAutomationGraph(withTapback({ emojiMode: 'hopCount' })).valid).toBe(true);
+    // invalid mode → error
+    const bad = validateAutomationGraph(withTapback({ emojiMode: 'random' }));
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.join(' ')).toMatch(/emojiMode ∈ \{fixed,hopCount\}/);
+  });
+
   it('rejects non-object config', () => {
     expect(validateAutomationGraph(null).valid).toBe(false);
     expect(validateAutomationGraph(42).errors[0]).toMatch(/must be an object/);

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -117,6 +117,10 @@ export type NumericOp = (typeof NUMERIC_OPS)[number];
 export const REQUEST_OPS = ['telemetry', 'position', 'traceroute', 'nodeinfo', 'neighbors', 'advert'] as const;
 export type RequestOp = (typeof REQUEST_OPS)[number];
 
+/** Where action.tapback's emoji comes from. Absent = 'fixed' (pre-4.14 behaviour). */
+export type TapbackEmojiMode = 'fixed' | 'hopCount';
+export const TAPBACK_EMOJI_MODES: readonly TapbackEmojiMode[] = ['fixed', 'hopCount'];
+
 /**
  * Match modes for `condition.meshcoreScope` (#3914). A MeshCore text message
  * carries a region "scope" (`scopeCode` 0 = unscoped, >0 = a region; `scopeName`
@@ -367,6 +371,13 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
         case 'action.requestData':
           if (p.op != null && !REQUEST_OPS.includes(p.op as RequestOp)) {
             errors.push(`action.requestData "${n.id}" requires a valid params.op`);
+          }
+          break;
+        case 'action.tapback':
+          // Optional. Absent/unset = 'fixed' — every pre-existing stored automation
+          // must keep validating and behaving exactly as before.
+          if (p.emojiMode != null && !TAPBACK_EMOJI_MODES.includes(p.emojiMode as TapbackEmojiMode)) {
+            errors.push(`action.tapback "${n.id}" requires params.emojiMode ∈ {fixed,hopCount}`);
           }
           break;
         case 'action.deviceReboot':

--- a/src/utils/hopEmoji.test.ts
+++ b/src/utils/hopEmoji.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX, hopCountEmoji } from './hopEmoji';
+
+describe('hopEmoji', () => {
+  describe('HOP_COUNT_EMOJIS', () => {
+    it('has exactly 8 glyphs, pinned as exact string literals', () => {
+      // Pinned individually (not just .toEqual on the whole array) so a
+      // copy-paste of 0️⃣ for *️⃣ at index 0 fails loudly rather than being
+      // masked by an array-level diff.
+      expect(HOP_COUNT_EMOJIS[0]).toBe('*️⃣');
+      expect(HOP_COUNT_EMOJIS[1]).toBe('1️⃣');
+      expect(HOP_COUNT_EMOJIS[2]).toBe('2️⃣');
+      expect(HOP_COUNT_EMOJIS[3]).toBe('3️⃣');
+      expect(HOP_COUNT_EMOJIS[4]).toBe('4️⃣');
+      expect(HOP_COUNT_EMOJIS[5]).toBe('5️⃣');
+      expect(HOP_COUNT_EMOJIS[6]).toBe('6️⃣');
+      expect(HOP_COUNT_EMOJIS[7]).toBe('7️⃣');
+      expect(HOP_COUNT_EMOJIS.length).toBe(8);
+    });
+
+    it('HOP_EMOJI_MAX is 7', () => {
+      expect(HOP_EMOJI_MAX).toBe(7);
+    });
+  });
+
+  describe('hopCountEmoji', () => {
+    it('maps 0 to the direct asterisk keycap, not 0️⃣', () => {
+      expect(hopCountEmoji(0)).toBe('*️⃣');
+    });
+
+    it('maps 1-7 to their own glyphs', () => {
+      expect(hopCountEmoji(1)).toBe('1️⃣');
+      expect(hopCountEmoji(2)).toBe('2️⃣');
+      expect(hopCountEmoji(3)).toBe('3️⃣');
+      expect(hopCountEmoji(4)).toBe('4️⃣');
+      expect(hopCountEmoji(5)).toBe('5️⃣');
+      expect(hopCountEmoji(6)).toBe('6️⃣');
+      expect(hopCountEmoji(7)).toBe('7️⃣');
+    });
+
+    it('clamps values above 7 to 7️⃣', () => {
+      expect(hopCountEmoji(8)).toBe('7️⃣');
+      expect(hopCountEmoji(99)).toBe('7️⃣');
+    });
+
+    it('clamps negative values to 0 (a malformed hopStart < hopLimit packet)', () => {
+      expect(hopCountEmoji(-1)).toBe('*️⃣');
+      expect(hopCountEmoji(-99)).toBe('*️⃣');
+    });
+
+    it('truncates fractional hop counts toward zero', () => {
+      expect(hopCountEmoji(2.9)).toBe('2️⃣');
+    });
+
+    it('returns undefined for unknown hop counts', () => {
+      expect(hopCountEmoji(undefined)).toBeUndefined();
+      expect(hopCountEmoji(null)).toBeUndefined();
+      expect(hopCountEmoji(NaN)).toBeUndefined();
+      expect(hopCountEmoji(Infinity)).toBeUndefined();
+    });
+  });
+});

--- a/src/utils/hopEmoji.ts
+++ b/src/utils/hopEmoji.ts
@@ -1,0 +1,33 @@
+/**
+ * Hop-count → emoji mapping, shared by Auto-Acknowledge (meshtasticManager) and
+ * the Automation Engine (action.tapback emojiMode=hopCount, {{ trigger.hopEmoji }}).
+ *
+ * Presentation, not protocol — hence src/utils/ rather than
+ * src/server/constants/meshtastic.ts, and shared rather than server-only so the
+ * tapback emoji picker uses the same glyphs. There must be exactly ONE copy of
+ * this table in the repo.
+ *
+ * 0 hops is *️⃣ (asterisk keycap = "direct"), NOT 0️⃣. 7 and above clamp to 7️⃣
+ * (Meshtastic's hop_limit maxes at 7).
+ */
+export const HOP_COUNT_EMOJIS = ['*️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣'] as const;
+
+/** Highest hop count with a distinct glyph; anything above clamps to it. */
+export const HOP_EMOJI_MAX = 7;
+
+/**
+ * Emoji for a hop count, or `undefined` when the hop count is unknown.
+ *
+ * - null / undefined / non-finite → `undefined` (caller decides)
+ * - negative (a malformed hopStart < hopLimit packet) → clamped to 0 → `*️⃣`
+ * - fractional → truncated toward zero
+ * - >= HOP_EMOJI_MAX → `7️⃣`
+ *
+ * Returning `undefined` rather than `*️⃣` for "unknown" is deliberate: telling a
+ * range-tester they were direct when we do not know the hop count is a lie, and
+ * both engine call sites have a meaningful "unknown" branch.
+ */
+export function hopCountEmoji(hops: number | null | undefined): string | undefined {
+  if (hops == null || !Number.isFinite(hops)) return undefined;
+  return HOP_COUNT_EMOJIS[Math.min(Math.max(Math.trunc(hops), 0), HOP_EMOJI_MAX)];
+}


### PR DESCRIPTION
## Summary

Phase 1 of the [Auto-Acknowledge on the Automation Engine epic](docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md), which answers issue #4340 (per-channel Auto-Acknowledge message body).

#4340 asks for a per-channel Auto-Ack body so a base station can redirect range-testers off the primary channel without misdirecting users already on the secondary channel. Rather than adding a second configuration axis to Auto-Acknowledge, we answer it in the Automation Engine — which already supports channel filters, trigger-word matching, hop-count conditions, and per-rule message bodies.

A survey found the scenario was **almost** expressible today. The one real gap: `action.tapback` could only send a fixed emoji, so reproducing Auto-Ack's `*️⃣1️⃣2️⃣…7️⃣` hop reaction needed eight near-identical rules. This PR closes that gap.

## What changed

- **Shared hop→emoji helper** (`src/utils/hopEmoji.ts`). The table was an un-exported inline constant in `checkAutoAcknowledge` **and** a second hand-typed copy in `EmojiPickerModal`. Both now consume one shared table; a test asserts exactly one non-test copy exists.
- **`action.tapback` gained an "Emoji source" select** — *A fixed emoji* (default; an absent setting means this, so every stored automation is untouched) or *The message's hop count*.
- **New `{{ trigger.hopEmoji }}` token**, populated for both Meshtastic and MeshCore messages, usable in `action.sendMessage` bodies. Renders blank when the hop count is unknown.
- **`showIf` — a general conditional-field-visibility mechanism for the builder.** `FieldDef.advanced` was declared but never read, so there was nothing to reuse. The Emoji field now hides in hop-count mode; the stored fixed emoji survives switching back.
- **Docs**: the action and token entries, plus a new step-by-step recipe answering #4340.

## Notable decisions

- A trigger with no hop information records a **skipped no-op**, not a failure — a throw would mark the whole run failed and spam the run log for every Schedule/System trigger wired to a tapback.
- The emoji resolves **before** the per-source loop, so `ActionDeps`, `meshActionDeps.ts` and the dry-run simulator's `recordingDeps()` are all untouched and cannot drift.
- `deriveHops()` can return a negative number (it lacks Auto-Ack's `hopStart >= hopLimit` guard). The helper clamps to `*️⃣`; `deriveHops` is deliberately left alone because changing it would silently alter every existing `condition.numeric` on field `hops`. Documented and pinned by test.

## Findings worth flagging

- The automation `sendMessage` path bypasses `MAX_MESSAGE_BYTES = 200` entirely — that check lives only in `routes/v1/messages.ts`, while automations call `mgr.sendTextMessage()` directly. Documented honestly rather than papered over.
- `channelName` is **not** selectable in the `condition.string` field picker, so the recipe ships only the two-automation form rather than a one-automation/two-rules variant that would not actually work.
- `docs/features/automation-engine.md` claims the MeshCore scope select "reveals a Region picker"; it does not — `scopeName` renders unconditionally. Now trivially fixable with `showIf`. Follow-up, not fixed here.

## Testing

- Full Vitest suite: **11,260 passed, 0 failed, 0 suites failed** (`success: true` via `--reporter=json`).
- Lint ratchet (`npm run lint:ci`) clean; `npm run typecheck` clean.
- New regression test proves Auto-Acknowledge's emitted emoji is byte-identical after the extraction, including that the tapback enqueue still passes `maxAttempts=1` and the emoji flag.
- A source-scan test reads `catalog.ts` from disk to prove no emoji glyph was typed as a literal (all interpolated from the shared table, per the CLAUDE.md hardcoded-emoji rule).

## Browser validation

Driven in the dev container against this build:

| Check | Result |
|---|---|
| "Emoji source" select present, defaults to fixed | pass |
| Selecting hop count hides the Emoji field | pass |
| Switching back to fixed restores it | pass |
| Dry run, hop start 4 / hop limit 1 (= 3 hops) | rendered 3️⃣ |
| Dry run with no hop info | recorded skip, not a failure |
| Console errors/warnings | none |

## Next phases

2. Per-node cooldown scope (the engine's cooldown is currently per-automation, which suppresses acks to other senders on a busy channel — called out honestly in the recipe).
3. Fidelity conditions for Auto-Ack parity.
4. The Auto-Ack → Automation converter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB