### PR TITLE
feat(automations): per-node cooldown scope (#4340 phase 2)

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -39,8 +39,9 @@ Key properties:
   (below) to scope a workflow to a subset of sources when you want.
 - **Permission-gated.** The tab and its API are gated by a dedicated global `automations`
   permission, separate from the legacy per-source `automation` permission.
-- **Cooldown / rate-limit** per automation prevents mesh spam, plus a per-run action cap and a
-  loop guard so an automation can't runaway-recurse.
+- **Cooldown / rate-limit** per automation, or **per node / per source+node** via the trigger's
+  *Cooldown applies to* (below), prevents mesh spam, plus a per-run action cap and a loop guard
+  so an automation can't runaway-recurse.
 - **Variables** — a separate management area for user-defined values (constants and runtime
   flags/counters) referenced anywhere as `{{ var.name }}`.
 - **Run log** — every fire is recorded with its per-step outcome for debugging.
@@ -93,7 +94,9 @@ every hour). It is backed by a live [croner](https://github.com/Hexagon/croner) 
 - A cron job is armed per enabled schedule automation; **create / update / enable / disable /
   delete** all re-arm correctly (the old job is stopped first, so there are never stale or
   duplicate jobs).
-- The per-automation **cooldown** is honored on each fire.
+- The **cooldown** is honored on each fire. A schedule trigger has no triggering message and no
+  subject node, so its cooldown is always **automation-wide** — the *Cooldown applies to* field
+  isn't offered here (see [Cooldown applies to](#cooldown-applies-to)).
 - The cron is **validated at save time** (5-field, no seconds) — an invalid expression is rejected
   in the builder rather than silently never firing.
 
@@ -113,6 +116,48 @@ Defines a geographic region and fires when a node **enters**, **leaves**, or **d
 inside)** it. The region is drawn directly on a Leaflet map — either a **circle** (center + radius)
 or a **polygon** — using the shared geofence map editor. Evaluation is shape-aware (point-in-circle
 or polygon ray-cast). See also the dedicated [Geofence Triggers](/features/geofence-triggers) page.
+
+### Cooldown applies to
+
+The five triggers with a **Cooldown (seconds)** field — **A message is received**, **A new node is
+discovered**, **A node is updated**, **Telemetry is received**, and **A node enters/leaves a
+region** — also get a **Cooldown applies to** select, directly beneath it. It's hidden until you set
+a non-zero cooldown, and setting the cooldown back to `0` hides it again without losing your choice
+— the value is remembered if you raise the cooldown again later. (Schedule and System triggers have
+no cooldown field at all, so they get no scope field either.)
+
+| Value | Meaning |
+| --- | --- |
+| **The whole automation (one shared timer)** | One timer for the whole rule — the default, and what an automation with no scope set (including every automation saved before this feature existed) behaves as. On a busy channel, acking one sender suppresses the ack to the next one until the window elapses. |
+| **Each node separately** | One timer per subject node (the message sender, the telemetry/geofence node, …) — acking one range-tester no longer suppresses the ack to the next. |
+| **Each node, per source** | One timer per (source, node) — the same physical node heard via two sources (e.g. a Meshtastic TCP link and an MQTT bridge) cools down independently. |
+
+**Worked example** — `trigger.message` on channel `Primary`, cooldown `60`, scope **Each node
+separately**:
+
+| t | event | verdict |
+| --- | --- | --- |
+| 0s | node 111 sends "test" | fires |
+| 5s | node 222 sends "test" | **fires** (under *The whole automation* this would be suppressed) |
+| 20s | node 111 sends "test" | suppressed — `cooldown active — 40s remaining (node 111)` |
+| 70s | node 111 sends "test" | fires (window elapsed) |
+
+Under **Each node, per source**, node 111 heard on `tcp-1` and on `mqtt-1` cools down independently
+— a message on one source never suppresses the ack on the other.
+
+**Degraded fallback, honestly stated.** Per-node/per-source scoping needs a subject to key off. When
+an event has none, the cooldown falls back to one shared timer — the same behaviour as *The whole
+automation* — rather than never firing or never cooling down. This applies to:
+
+- **Schedule** and **System** triggers (no triggering message, so no subject node at all).
+- **MeshCore channel messages.** MeshCore **DMs and room posts** get real per-sender cooldown, keyed
+  by the sender's public key — the same identity Auto-Acknowledge's own per-node cooldown uses. A
+  **channel** post cannot, on any design: the protocol carries no per-sender identity on a channel
+  packet, only a synthetic per-channel slot key shared by *every* sender on that channel, so keying
+  off it would look per-node while actually being per-channel.
+
+The live trace names which fallback applied, e.g. `cooldown active — 12s remaining (automation-wide
+(this event has no subject node))`.
 
 ## Conditions
 
@@ -293,8 +338,10 @@ text body for channel-specific wording — exactly the byte pressure the issue d
 - **Text contains:** `test` — or use **Text matches regex** `\b(test|ping)\b` for word-boundary
   matching so it doesn't fire on "latest" or "pingpong".
 - **On channels:** `Primary`.
-- **Cooldown (seconds):** leave at `0`. See [Cooldown caveat](#cooldown-caveat-per-automation-not-per-node)
-  below before raising it.
+- **Cooldown (seconds):** `60`. **Cooldown applies to:** *Each node separately* — see
+  [Cooldown applies to](#cooldown-applies-to). This keys the throttle off the sending node, so
+  acking one range-tester no longer suppresses the ack to the next one who pings inside the same
+  60 seconds.
 
 **THEN**
 1. `Send a tapback (reaction)` → **Emoji source:** *The message's hop count*.
@@ -328,16 +375,6 @@ a text condition on the channel — isn't available today: the **Text comparison
 picker (`Field` on `condition.string`) offers *Message text*, *Sender node id*, *Recipient node id*,
 and *MeshCore scope/region* for a message trigger, but not the channel name. Use the two-automation
 form above; it costs one extra automation, not any extra typing per rule.
-
-### Cooldown caveat (per-automation, not per-node)
-
-Be aware before you set a non-zero **Cooldown (seconds)**: the engine's cooldown currently applies
-to the whole automation, not to each sending node individually. On a busy channel, a cooldown after
-acking one range-tester suppresses acks to the *next* tester who pings before the window elapses.
-Leave it at `0` for this recipe, or accept that trade-off deliberately. Per-node cooldown scope is
-planned for Phase 2 of the epic this recipe belongs to (see
-[`AUTOACK_AUTOMATION_EPIC.md`](https://github.com/Yeraze/meshmonitor/blob/main/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md)
-internally).
 
 ### Byte budget
 
@@ -506,7 +543,10 @@ showing **why it did or didn't run**:
 - **fired** — the trigger matched and the action steps ran; the per-step trace is shown.
 - **prefiltered** — the event was filtered out before the conditions ran (e.g. wrong source/channel),
   with the reason.
-- **cooldown** — the rule matched but was suppressed by its cooldown window.
+- **cooldown** — the rule matched but was suppressed by its cooldown window. The reason names the
+  key that was cooling down, e.g. `cooldown active — 40s remaining (node 111)` or
+  `cooldown active — 12s remaining (automation-wide (this event has no subject node))` (see
+  [Cooldown applies to](#cooldown-applies-to)).
 
 The panel keeps the most recent entries in a rolling buffer and **auto-stops after 5 minutes** (and
 on close or disconnect), so a trace never runs unbounded.

--- a/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md
+++ b/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md
@@ -94,7 +94,7 @@ trigger field and registered token; write the #4340 recipe and close the issue.
   no new table).
 - Recipe documented; #4340 closed with a link to it.
 
-### Phase 2 — Per-node cooldown scope — [ ] not started
+### Phase 2 — Per-node cooldown scope — [x] complete
 
 Add `cooldownScope: 'automation' | 'node' | 'sourceNode'` to trigger params;
 key `lastFired` by the composite; make the trace message name the node.
@@ -174,3 +174,98 @@ _(updated at each phase close)_
   `src/components/automations/catalog.ts`): it exposes *Message text*, *Sender node id*, *Recipient
   node id*, and *MeshCore scope/region* — no channel name. The recipe ships only the
   two-automation form and documents the gap instead of a workaround that doesn't exist yet.
+
+### Phase 2 close (2026-07-28)
+
+- **`TriggerContext.subjectNodeKey` is new, and deliberately cooldown-only.** `subjectNodeNum`
+  already drives node hydration (`getSubjectNode`) and variable scoping, both of which need a real
+  Meshtastic node number — widening it to also carry a MeshCore pubkey string would have broken
+  both. `subjectNodeKey` is an **optional** protocol-agnostic sibling: `undefined` (the default, and
+  what every existing Meshtastic builder and test-literal construction site leaves it as) means
+  "derive it from `subjectNodeNum`"; an explicit `null` means "this event has no stable per-subject
+  identity at all"; a set string is the identity to key cooldown off directly. `subjectKeyOf(ctx)`
+  resolves it. This kept every non-MeshCore builder, `automationSimulator.ts`, and every existing
+  `TriggerContext` test-literal untouched.
+- **MeshCore is only *half* scopable, and the failure mode is subtle enough to spell out.**
+  `buildMeshCoreMessageContext` sets `subjectNodeKey` to the sender's `fromPublicKey` for a **DM or
+  room post** — the same identity `meshcoreManager`'s own per-sender auto-ack cooldown already uses
+  — but to `null` for a **channel** post. The naive fix (key off `ctx.fields.from` unconditionally)
+  would have kept working for DMs while silently keying a channel automation off the synthetic
+  `channel-<idx>` slot string that *every sender on that channel shares* — a per-channel cooldown
+  wearing a per-node label, indistinguishable from correct behaviour until two different senders on
+  the same channel failed to cool down independently. `isChannel` (already computed for
+  `parseMeshCoreChannelIdx`) gates it explicitly.
+- **No subject ⇒ degrade to the automation-wide key, not "never fire" or "never cool down."**
+  `cooldownKeyFor` falls back to the automation-wide key (and marks the verdict `degraded`) for
+  Schedule triggers, System triggers, and MeshCore channel messages — every case with no stable
+  per-subject identity. *Never fire* would be a silent breakage (a Schedule automation with
+  `cooldownScope: 'node'`, reachable via JSON import, would stop firing with no visible cause) —
+  exactly the class of bug this phase exists to prevent. *Never cool down* would turn a throttle
+  into a spam faucet on a MeshCore channel and grow the map unbounded. *Automation-wide fallback* is
+  provably no worse than pre-Phase-2 behaviour, costs exactly one map entry, and the live trace names
+  it out loud (`cooldown active — Ns remaining (automation-wide (this event has no subject node))`).
+- **`showIf` gained a `truthy` operator.** Phase 1's `equals`/`notEquals` can't express "a number
+  field that is set" — `cooldownSeconds` can legitimately be `undefined` (never touched), `''`
+  (cleared — the `number` renderer emits `''`), or `0`, and `notEquals: 0` would show the field in
+  the first two cases. `truthy` covers all three uniformly via `Boolean(v)`. Known, harmless wart:
+  the string `'0'` is truthy, so it would show an extra select — not reachable through the number
+  renderer today. **Phase 1 semantics are preserved verbatim: hidden ≠ cleared.** Setting the
+  cooldown back to `0` hides *Cooldown applies to* but keeps `params.cooldownScope`, and the engine
+  ignores it anyway (`cooldownGate` returns early when `cooldownSeconds <= 0`) — the value survives a
+  hide/show round-trip, browser-validated.
+- **Eviction: an exact expiry pass, with a hard backstop.** `lastFired` is now
+  `Map<automationId, Map<cooldownKey, ms>>` — one inner map per automation, one entry per distinct
+  subject under `node`/`sourceNode` scope. Unlike a packet-dedup set, a cooldown entry has a provable
+  expiry: once `now - ts >= cooldownSeconds * 1000` it can never suppress anything again, so deleting
+  it is behaviour-neutral. `markFired` prunes only past a high watermark
+  (`COOLDOWN_KEYS_MAX = 4096`, mirroring `autoAckProcessedPackets`'s `> 1000` trim), first doing the
+  exact expiry pass, then — only if still over `COOLDOWN_KEYS_TRIM_TO = 2048` (the pathological case
+  of more than 2048 distinct subjects firing inside a single cooldown window) — dropping the oldest
+  entries as a backstop. Deliberately **not** modelled on `meshtasticManager.autoAckCooldowns`
+  (`Map<nodeNum, ms>`), which is never evicted at all — it gets away with that because it's
+  per-manager and bounded in practice by one radio's NodeDB, while the engine's map is per
+  (automation × node) across every source including MQTT firehoses, so the same choice would be a
+  real leak here. Also: `lastFired` is no longer written unconditionally — `markFired` returns
+  immediately when `cooldownSeconds <= 0`, since a timestamp that's never read is memory spent for
+  nothing, keeping the common cooldown-less automation at exactly zero cooldown-map entries.
+- **Validation is a pre-switch guard, not a per-trigger-type `case`.** `cooldownScope` is a
+  trigger-level param shared by all seven trigger types; duplicating it into seven `case` labels
+  inside `validateAutomationGraph`'s `switch (n.type)` would silently miss the eighth trigger type
+  someone adds later. It's checked once via `categoryOf(n.type) === 'trigger'` immediately before the
+  switch. Orchestrator-approved deviation from the brief's per-`case` precedent (`action.tapback`'s
+  `emojiMode`, which is right for a *single-block* param but wrong for a param seven blocks share).
+- **Finding beyond the brief: the validation guard makes `parseCooldownScope`'s runtime leniency
+  unreachable via the normal load path.** `parseCooldownScope` is documented as "deliberately lenient
+  at runtime" (absent/unrecognised → `'automation'`) on the theory that graphs written before
+  validation existed must still run — but `validateAutomationGraph` now rejects an unrecognised
+  `cooldownScope` **at save/import time**, so a stored automation can never reach `load()` with a
+  bogus value in the first place; the automation is rejected wholesale, not silently downgraded to
+  `'automation'` scope. The runtime leniency is real defence-in-depth (it protects against a graph
+  written directly to the DB, bypassing validation), but it is not exercised by any path a normal
+  user can trigger. The engine test for this case (§6, case (e)) asserts the **actual** observed
+  behaviour — the automation is rejected and never loads — rather than the spec's original wording of
+  "`'bogus'` behaves as `'automation'`" at runtime, which describes `parseCooldownScope` in isolation,
+  not the end-to-end load path.
+- **Lint ratchet caught a new `no-explicit-any` (baseline 6 → 7) in `automationEngineService.ts`.**
+  The `cooldownScope` lookup at `load()` originally cast through `(triggerNode.params as any)`,
+  copying the existing `cooldownSeconds` line it sits beside. `params` is already typed
+  `Record<string, unknown>`, so the cast was unnecessary — dropped it (`triggerNode.params?.cooldownScope`)
+  rather than growing the baseline. `npm run lint:ci` confirmed the ratchet holds at 6 with the cast
+  removed.
+- **The disable → re-enable edge case, restated precisely.** `load()` now drops `lastFired` state for
+  any automation id no longer present in `this.index` (deleted or disabled), since a dead id is
+  unreachable from any dispatch site and would otherwise strand up to `COOLDOWN_KEYS_MAX` entries
+  forever for a node-scoped automation on a churny mesh. Observable edge, accepted: disabling and
+  re-enabling a rule **inside its own cooldown window** now lets it fire immediately instead of
+  waiting out the remainder, whereas before this phase the cooldown map was keyed only by
+  `automationId` and survived a disable/enable cycle. Erring toward firing is the safer direction of
+  the two available (the alternative — leaking cooldown state for automations that no longer exist —
+  is strictly worse), and it is pinned by a regression test (§6 case (j)).
+- **Two out-of-scope follow-ups still need issues filed (spec §8).** `geofenceState`
+  (`Map<'${automationId}:${nodeNum}', boolean>`, `automationEngineService.ts:121-122, :514-516`) and
+  `meshtasticManager.autoAckCooldowns` (`Map<nodeNum, ms>`, `meshtasticManager.ts:825`) have the same
+  unbounded-growth shape this phase just fixed for `lastFired`, and neither was touched here.
+  `geofenceState` in particular can't reuse this phase's "delete once expired" eviction verbatim —
+  deleting an entry there is *not* behaviour-neutral, since it resets the enter/exit dwell baseline
+  for that node, so it needs its own design decision rather than a copy-paste of `pruneCooldownKeys`.
+  Both need a follow-up issue; neither has one yet as of this close.

--- a/docs/internal/dev-notes/COOLDOWN_SCOPE_PHASE2_SPEC.md
+++ b/docs/internal/dev-notes/COOLDOWN_SCOPE_PHASE2_SPEC.md
@@ -1,0 +1,683 @@
+# Per-Node Cooldown Scope — Phase 2 Implementation Spec
+
+**Epic:** `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md` · **Issue:** #4340 (follow-on)
+**Branch:** `feature/cooldown-scope` · **Worktree:** `/home/yeraze/Development/meshmonitor-cooldown-scope`
+**Base:** `origin/main` @ `01fbf745` (Phase 1 merged)
+
+> **Orchestrator sign-off (2026-07-28):** the §9.1 deviation — validating
+> `cooldownScope` with a pre-switch `categoryOf(n.type) === 'trigger'` guard
+> rather than a per-type `case` — is **approved**. `cooldownScope` is shared by
+> all seven trigger types; seven duplicated `case` labels would silently miss
+> the eighth trigger type someone adds later.
+
+## 1. Reuse inventory (read this before writing any code)
+
+Everything below already exists and **must be used or extended, not
+re-implemented**. Verified by symbolic search on 2026-07-28 against this worktree.
+
+| Existing thing | Location | How Phase 2 uses it |
+|---|---|---|
+| `lastFired: Map<automationId, ms>` | `automationEngineService.ts:119-120` | **Re-keyed** to `Map<automationId, Map<cooldownKey, ms>>`. Name kept. |
+| `cooledDown(a, now)` | `automationEngineService.ts:249-253` | **Replaced** by `cooldownGate(a, ctx, now)` — one helper that decides *and* names the key, so the three call sites can't drift. |
+| The three cooldown gates | `automationEngineService.ts:205-212` (onSchedule), `:278-285` (runTrigger), `:525-532` (checkGeofences) | All three collapse onto `cooldownGate` + `markFired`. **A fix applied to only one is the bug this phase exists to avoid.** |
+| `geofenceState = new Map<\`${a.id}:${nodeNum}\`, boolean>` | `automationEngineService.ts:121-122, :514-516` | **Precedent, not a target.** Proves the `${automationId}:${nodeNum}` composite-key shape is already house style here. Its own unbounded growth is pre-existing — see §8. |
+| `AutomationVariablesRepository.buildScopeKey(scope, ctx)` | `src/db/repositories/automationVariables.ts:82-99` | **Key-shape source of truth.** `global → ''`, `node → '<node>'`, `sourceNode → '<source>:<node>'`. Cooldown keys use the *identical* shape, pinned by a cross-check test (§6). Not called directly — see §2.4. |
+| `VARIABLE_SCOPES = ['global','source','node','sourceNode']` | `src/types/automation.ts:142-143` | The vocabulary `cooldownScope` deliberately mirrors (`automation` ≙ `global`). |
+| `TAPBACK_EMOJI_MODES` + its validation `case` | `src/types/automation.ts:120-122`, `:375-381` | **The exact backward-compat precedent** for `COOLDOWN_SCOPES`: exported const array, union type, validate *only when present*. |
+| `varContextFromTrigger(trigger)` | `engineContext.ts:87-89` | The existing TriggerContext → scope-context adapter. `cooldownKeyFor()` lands **next to it, same file** — same concern, no new module. |
+| `TriggerContext.subjectNodeNum` | `triggerContext.ts:17, :21` | Sole numeric subject identity. **Not changed** — drives node hydration (`getSubjectNode`) and variable scoping, both of which need a real Meshtastic node number. |
+| `buildMeshCoreMessageContext` | `triggerContext.ts:134-195` | The **only** builder that gains an explicit `subjectNodeKey` (MeshCore pubkey). |
+| `parseMeshCoreChannelIdx(fromPublicKey)` | `triggerContext.ts:120-123` | Reused to detect the synthetic `channel-<idx>` sender key. Already computed as `isChannel` at `:140-141`. |
+| MeshCore per-sender auto-ack cooldown | `meshcoreManager.ts:6905-6918` (`dm:${pk}` / `ch${idx}:${pk}`) | Confirms full `fromPublicKey` is the right MeshCore identity, and that channel messages must be keyed by channel, not sender. |
+| AutoAck per-node cooldown `Map<nodeNum, ms>` | `meshtasticManager.ts:825, :10090-10099, :10263` | The behaviour we are porting. Also the **counter-example** for eviction — it is unbounded (§2.5). |
+| `autoAckProcessedPackets` high-water trim | `meshtasticManager.ts:9992-9996` (`> 1000 → keep last 500`) | **The eviction pattern we copy**, refined with an exact expiry pass (§2.5). |
+| `fieldVisible(field, params)` + `FieldDef.showIf` | `catalog.ts:26-41` (Phase 1) | Extended with **one** operator, `truthy` (§4.1). No new mechanism. |
+| `BlockFields` `.filter(fieldVisible)` | `AutomationBuilder.tsx:227` | **Unchanged.** The new field rides the existing filter. |
+| `defaultParams(type, triggerType)` | `AutomationBuilder.tsx:48-63` | Already seeds a `select`'s first option → new trigger blocks get `cooldownScope: 'automation'` free. Order options accordingly. |
+| `COOLDOWN: FieldDef` shared const | `catalog.ts:51-54` | The new `COOLDOWN_SCOPE` const sits beside it, spliced into the same five blocks. |
+| `SUBJECT_NODE_TRIGGERS` | `catalog.ts:149-150` | **Load-bearing coincidence, verified:** the five triggers carrying `COOLDOWN` are *exactly* these five. |
+| `automationTraceBus.emit` / `emitTrace` | `automationEngineService.ts:293-304` | **Unchanged.** The key name rides the existing `reason` string, rendered verbatim at `LiveTracePanel.tsx:169`. |
+| `createTestDb` / `recorder()` / `engineWith()` | `automationEngineService.test.ts:12, :17-26, :77-79` | All new engine tests use these. Do not invent a new harness. |
+| `FieldDef.advanced` | `catalog.ts:23` | **Declared, never read** (Phase 1 finding, re-verified). Set for consistency; do not rely on it. |
+
+### 1.1 Justification: zero new modules
+
+| Candidate new file | Rejected because |
+|---|---|
+| `src/server/services/automation/cooldownScope.ts` | Splits a 6-line pure function from `varContextFromTrigger()`, the existing trigger→scope-key adapter it is a sibling of. `engineContext.ts` is already imported by both consumers. **Rejected.** |
+| `src/types/cooldown.ts` | `src/types/automation.ts` is the canonical home for every other engine vocabulary constant (`REQUEST_OPS`, `TAPBACK_EMOJI_MODES`, `VARIABLE_SCOPES`, `COLLAPSE_MODES`). **Rejected.** |
+
+**Result:** `COOLDOWN_SCOPES` / `CooldownScope` / `parseCooldownScope()` →
+`src/types/automation.ts`. `cooldownKeyFor()` → `engineContext.ts`.
+`subjectKeyOf()` → `triggerContext.ts`. Nothing else.
+
+## 2. Backend design
+
+### 2.1 The vocabulary — `src/types/automation.ts`
+
+Add next to `TAPBACK_EMOJI_MODES` (`:120-122`):
+
+```ts
+/**
+ * What a trigger's `cooldownSeconds` window is keyed by (#4340 Phase 2).
+ *
+ *  - 'automation'  one timer for the whole rule — the pre-4.14 behaviour and
+ *                  what an ABSENT/unrecognised value means. Never change this.
+ *  - 'node'        one timer per subject node (message sender / telemetry or
+ *                  geofence node), so acking one range-tester does not suppress
+ *                  the ack to the next one.
+ *  - 'sourceNode'  one timer per (source, node), so the same physical node heard
+ *                  via two sources cools down independently.
+ *
+ * Key shapes mirror AutomationVariablesRepository.buildScopeKey exactly
+ * ('' / '<node>' / '<source>:<node>') so cooldown keys and variable scope keys
+ * read identically in logs and traces.
+ */
+export const COOLDOWN_SCOPES = ['automation', 'node', 'sourceNode'] as const;
+export type CooldownScope = (typeof COOLDOWN_SCOPES)[number];
+
+/**
+ * Coerce a stored `params.cooldownScope` to a CooldownScope. Absent, blank, or
+ * unrecognised → 'automation'. Deliberately lenient at RUNTIME (graphs written
+ * before validation existed must still run) while validateAutomationGraph
+ * rejects unrecognised values at SAVE time — the same split Phase 1 used for
+ * action.tapback's emojiMode.
+ */
+export function parseCooldownScope(raw: unknown): CooldownScope {
+  return COOLDOWN_SCOPES.includes(raw as CooldownScope) ? (raw as CooldownScope) : 'automation';
+}
+```
+
+### 2.2 Validation — `src/types/automation.ts` (~:330-334)
+
+`cooldownScope` is a **trigger-level** param shared by all seven trigger types.
+Duplicating it into seven `case` labels would silently miss the eighth trigger
+type someone adds later, so it is a guard immediately **before** the
+`switch (n.type)` inside the same loop, using the existing `categoryOf()` helper
+(`:100-105`):
+
+```ts
+for (const n of rawNodes as AutomationNode[]) {
+  const p = (n.params ?? {}) as Record<string, unknown>;
+  // Cooldown scope (#4340 Phase 2) is a trigger-level param every trigger type
+  // shares, so it is checked once here rather than duplicated into seven cases
+  // (which would silently miss any trigger type added later). Optional:
+  // absent/unset = 'automation', the pre-4.14 behaviour every stored automation
+  // depends on — same contract as action.tapback's emojiMode.
+  if (categoryOf(n.type) === 'trigger'
+      && p.cooldownScope != null
+      && !COOLDOWN_SCOPES.includes(p.cooldownScope as CooldownScope)) {
+    errors.push(`${n.type} "${n.id}" requires params.cooldownScope ∈ {automation,node,sourceNode}`);
+  }
+  switch (n.type) { /* …unchanged… */ }
+}
+```
+
+Do **not** add validation for `cooldownSeconds` — it is unvalidated today
+(`Number(…) ?? 0 || 0` at `automationEngineService.ts:156`) and tightening it
+would reject stored graphs.
+
+### 2.3 Subject identity — `triggerContext.ts`
+
+**The problem.** `subjectNodeNum` is populated for Meshtastic message /
+nodeDiscovered / nodeUpdated / telemetry / geofence; is `null` for
+`trigger.schedule` (always, `:283-289`); is `null` for
+`buildMeshCoreMessageContext` (always, `:190-192`); and is *usually* null for
+`trigger.system` (only `connection:status` passes a `nodeNum`).
+
+Add an **optional** protocol-agnostic subject key. Optional so no existing
+construction site (including `automationSimulator.ts:271` and every test that
+builds a `TriggerContext` literal) needs touching:
+
+```ts
+export interface TriggerContext {
+  triggerType: TriggerType;
+  sourceId: string | null;
+  /** Subject node for node/sourceNode variable scope binding. */
+  subjectNodeNum: number | null;
+  /**
+   * Protocol-agnostic subject identity, for cooldown scoping (#4340 Phase 2).
+   *
+   * `undefined` (the default, and what every Meshtastic builder leaves it as)
+   * means "derive it from subjectNodeNum". Set EXPLICITLY only where the
+   * subject has an identity that is not a Meshtastic node number — today that
+   * is only MeshCore, whose senders are pubkey strings. An explicit `null`
+   * means "this event has no stable per-subject identity at all".
+   *
+   * Deliberately NOT reused for variable scoping or node hydration: both call
+   * getNode(sourceId, nodeNum) / buildScopeKey with a NUMBER and must keep
+   * doing so. This field is cooldown-only.
+   */
+  subjectNodeKey?: string | null;
+  timestamp: number;
+  fields: Record<string, unknown>;
+}
+
+/**
+ * The subject's cooldown identity, or null when the event has none.
+ * Explicit `subjectNodeKey` wins; otherwise derive from `subjectNodeNum`.
+ */
+export function subjectKeyOf(ctx: TriggerContext): string | null {
+  if (ctx.subjectNodeKey !== undefined) return ctx.subjectNodeKey;
+  return ctx.subjectNodeNum == null ? null : String(ctx.subjectNodeNum);
+}
+```
+
+**MeshCore — supported, with one honest limitation.** In
+`buildMeshCoreMessageContext` (`:187-194`), beside the existing
+`subjectNodeNum: null`:
+
+```ts
+// #4340 Phase 2: MeshCore has no node numbers, so per-node cooldown keys off
+// the sender pubkey instead — the same identity meshcoreManager's own auto-ack
+// cooldown uses (meshcoreManager.ts:6909). A DM/room post carries the real
+// sender key. A CHANNEL post does not: `fromPublicKey` is the synthetic
+// `channel-<idx>` slot key SHARED by every sender on that channel (see
+// parseMeshCoreChannelIdx above), so keying by it would look per-node while
+// actually being per-channel. Null there, which degrades to the automation-wide
+// key rather than lying.
+subjectNodeKey: isChannel ? null : (msg.fromPublicKey ?? null),
+```
+
+`isChannel` is already computed at `:141`. No other builder changes.
+
+**Behaviour when there is no subject.** `cooldownKeyFor` **falls back to the
+automation-wide key** and marks the verdict `degraded`. Rationale, stated so
+nobody "fixes" it later:
+
+- *Never fire* would be a silent breakage — a Schedule or System automation with
+  `cooldownScope: 'node'` (reachable via JSON import) would stop working with no
+  visible cause. This is exactly the silently-never-fires bug to avoid.
+- *Never cool down* would turn a throttle into a spam faucet on a MeshCore
+  channel and would grow the map with a fresh key per event.
+- *Automation-wide fallback* is exactly today's behaviour, so the degraded path
+  is provably no worse than the status quo, costs one map entry, and the trace
+  says so out loud.
+
+### 2.4 The key + label — `engineContext.ts`
+
+Beside `varContextFromTrigger` (`:87-89`):
+
+```ts
+/** Truncate a long subject id (a 64-char MeshCore pubkey) for trace/log copy. */
+function shortSubject(id: string): string {
+  return id.length > 16 ? `${id.slice(0, 12)}…` : id;
+}
+
+export interface CooldownKeyResolution {
+  /** Map key. '' is the automation-wide key (also the degraded fallback). */
+  key: string;
+  /** Human phrase naming the key, for the cooldown trace reason. */
+  label: string;
+  /** True when the requested scope could not be honoured and we fell back. */
+  degraded: boolean;
+}
+
+/**
+ * Resolve a trigger context to its cooldown key under `scope` (#4340 Phase 2).
+ *
+ * Key shapes intentionally match AutomationVariablesRepository.buildScopeKey's
+ * global/node/sourceNode shapes ('' / '<node>' / '<source>:<node>') — pinned by
+ * a cross-check test — so cooldown keys and variable scope keys read alike.
+ * It is NOT called directly: buildScopeKey's ctx.nodeNum is typed `number` and
+ * widening it to accept a MeshCore pubkey string would silently let VARIABLE
+ * scoping key off pubkeys too, a behaviour change we explicitly do not want.
+ *
+ * When the requested scope cannot be honoured (no subject node on a schedule /
+ * system / MeshCore-channel event, or no sourceId under 'sourceNode'), this
+ * degrades to the automation-wide key — today's exact behaviour — rather than
+ * never firing or never cooling down. See COOLDOWN_SCOPES for why.
+ */
+export function cooldownKeyFor(scope: CooldownScope, trigger: TriggerContext): CooldownKeyResolution {
+  if (scope === 'automation') return { key: '', label: 'automation-wide', degraded: false };
+  const node = subjectKeyOf(trigger);
+  if (node == null) {
+    return { key: '', label: 'automation-wide (this event has no subject node)', degraded: true };
+  }
+  if (scope === 'node') return { key: node, label: `node ${shortSubject(node)}`, degraded: false };
+  const src = trigger.sourceId;
+  if (!src) {
+    return { key: '', label: 'automation-wide (this event has no source)', degraded: true };
+  }
+  return { key: `${src}:${node}`, label: `source ${src} · node ${shortSubject(node)}`, degraded: false };
+}
+```
+
+### 2.5 The engine — `automationEngineService.ts`
+
+**State (`:117-124`):**
+
+```ts
+/** automationId → cooldown key → last fired ms. Inner key shape: cooldownKeyFor(). */
+private lastFired = new Map<string, Map<string, number>>();
+```
+
+**Bounds (module scope, above the class):**
+
+```ts
+/**
+ * Per-automation cooldown-key bounds (#4340 Phase 2). Under 'automation' scope
+ * an automation holds exactly ONE key, as before. Under 'node'/'sourceNode' it
+ * holds one per distinct subject — on a large mesh with MQTT sources that is
+ * thousands, so it must be bounded.
+ *
+ * Shape copied from meshtasticManager's autoAckProcessedPackets high-water trim
+ * (`> 1000 → keep last 500`, :9992): prune only when a high watermark is passed,
+ * and always bring the size well under it, so pruning is amortised O(1) per fire.
+ *
+ * Refined with an EXACT first pass: unlike a packet-dedup set, a cooldown entry
+ * has a provable expiry — once `now - ts >= cooldownSeconds*1000` it can never
+ * suppress anything, so deleting it is behaviour-neutral. The hard trim below is
+ * only a backstop for the pathological case of >TRIM_TO distinct subjects firing
+ * inside a single cooldown window.
+ *
+ * Deliberately NOT modelled on meshtasticManager's autoAckCooldowns
+ * (Map<nodeNum, ms>, :825) — that map is never evicted at all. It gets away with
+ * it because it is per-manager and bounded in practice by one radio's NodeDB;
+ * the engine's is per (automation × node) across EVERY source including MQTT
+ * firehoses, so the same choice would be a real leak here.
+ */
+const COOLDOWN_KEYS_MAX = 4096;
+const COOLDOWN_KEYS_TRIM_TO = 2048;
+```
+
+**`LoadedAutomation` (`:54-61`)** gains `cooldownScope: CooldownScope`.
+
+**`load()` (`:156`)** gains, beside `cooldownSeconds`:
+
+```ts
+const cooldownScope = parseCooldownScope((triggerNode.params as any)?.cooldownScope);
+```
+
+…and, after `this.index = index;` (`:163`), drops state for automations that are
+no longer loaded:
+
+```ts
+// Drop cooldown state for automations that are no longer loaded (deleted or
+// disabled). They are unreachable — runTrigger/onSchedule/checkGeofences only
+// iterate `this.index` — so this is unobservable while they stay out of the
+// index. One observable edge, accepted: disabling and re-enabling a rule inside
+// its own cooldown window now lets it fire immediately instead of waiting out
+// the remainder. Erring toward firing is the safe direction, and without this a
+// deleted node-scoped automation would strand up to COOLDOWN_KEYS_MAX entries
+// forever.
+const liveIds = new Set<string>();
+for (const list of index.values()) for (const a of list) liveIds.add(a.id);
+for (const id of this.lastFired.keys()) if (!liveIds.has(id)) this.lastFired.delete(id);
+```
+
+**Gate + mark — replaces `cooledDown` (`:249-253`):**
+
+```ts
+/**
+ * Cooldown verdict for one automation against one event. Returns the key to
+ * stamp on success, or the trace reason on suppression.
+ *
+ * This is the ONLY place the cooldown window is evaluated. The three call sites
+ * (message/node/telemetry/system dispatch, schedule dispatch, geofence) must all
+ * route through it — a scope fix applied to only one of them is the exact bug
+ * this phase exists to prevent.
+ */
+private cooldownGate(
+  a: LoadedAutomation,
+  ctx: TriggerContext,
+  now: number,
+): { ok: true; key: string } | { ok: false; reason: string } {
+  if (a.cooldownSeconds <= 0) return { ok: true, key: '' };
+  const { key, label } = cooldownKeyFor(a.cooldownScope, ctx);
+  const last = this.lastFired.get(a.id)?.get(key);
+  const windowMs = a.cooldownSeconds * 1000;
+  if (last == null || now - last >= windowMs) return { ok: true, key };
+  const remainingMs = Math.max(0, windowMs - (now - last));
+  return { ok: false, reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining (${label})` };
+}
+
+/** Stamp a fire against its cooldown key, bounding the per-automation key set. */
+private markFired(a: LoadedAutomation, key: string, now: number): void {
+  // No cooldown ⇒ nothing can ever be suppressed ⇒ never grow the map. (Today
+  // the timestamp is written unconditionally, but it is only ever READ inside
+  // the `cooldownSeconds > 0` branch, so skipping it is unobservable and keeps
+  // memory at zero for the overwhelmingly common cooldown-less automation.)
+  if (a.cooldownSeconds <= 0) return;
+  let inner = this.lastFired.get(a.id);
+  if (!inner) { inner = new Map(); this.lastFired.set(a.id, inner); }
+  inner.set(key, now);
+  if (inner.size > COOLDOWN_KEYS_MAX) this.pruneCooldownKeys(a, inner, now);
+}
+
+private pruneCooldownKeys(a: LoadedAutomation, inner: Map<string, number>, now: number): void {
+  const windowMs = a.cooldownSeconds * 1000;
+  // Exact pass: an entry older than the window can no longer suppress anything.
+  for (const [k, ts] of inner) if (now - ts >= windowMs) inner.delete(k);
+  if (inner.size <= COOLDOWN_KEYS_TRIM_TO) return;
+  // Backstop: more than COOLDOWN_KEYS_TRIM_TO distinct subjects fired inside one
+  // window. Drop the oldest — they expire soonest — accepting that those few
+  // subjects may fire once early rather than growing without bound.
+  const byAge = [...inner.entries()].sort((x, y) => x[1] - y[1]);
+  for (let i = 0; i < byAge.length - COOLDOWN_KEYS_TRIM_TO; i++) inner.delete(byAge[i][0]);
+  logger.debug(`[AutomationEngine] "${a.name}" cooldown keys trimmed to ${inner.size} (scope=${a.cooldownScope})`);
+}
+```
+
+**All three call sites become identical.** `onSchedule` (`:205-212`):
+
+```ts
+const gate = this.cooldownGate(a, ctx, now);
+if (!gate.ok) {
+  if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
+  return 0;
+}
+this.markFired(a, gate.key, now);
+```
+
+`runTrigger` (`:278-285`) and `checkGeofences` (`:525-532`) take the same five
+lines with `continue` instead of `return 0`, and `geoCtx` as the context in the
+geofence case. **After the change, `this.lastFired.get(a.id)` must not appear
+anywhere outside `cooldownGate`/`markFired`/`pruneCooldownKeys`/`load` — that is
+a grep-checkable acceptance criterion.**
+
+Also update the class doc comment (`:6`): "enforces a per-automation cooldown" →
+"enforces the trigger's cooldown at its configured scope (automation / node /
+source+node)".
+
+### 2.6 Worked example — why this closes the #4340 gap
+
+`trigger.message` on channel `Primary`, `cooldownSeconds: 60`,
+`cooldownScope: 'node'`.
+
+| t | event | key | verdict |
+|---|---|---|---|
+| 0s | node 111 sends "test" | `'111'` | fires, `lastFired['a']['111'] = 0` |
+| 5s | node 222 sends "test" | `'222'` | **fires** (today: suppressed) |
+| 20s | node 111 sends "test" | `'111'` | suppressed — `cooldown active — 40s remaining (node 111)` |
+| 70s | node 111 sends "test" | `'111'` | fires |
+
+Under `sourceNode`, node 111 heard on `tcp-1` and `mqtt-1` gets keys
+`'tcp-1:111'` and `'mqtt-1:111'` — independent.
+
+## 3. What does **not** change
+
+- **There is no `resetCooldowns` method anywhere in the tree.**
+  `grep -rn "resetCooldown" src` returns nothing. Nothing to update; do not add one.
+- **The simulator does not model cooldown at all.** `automationSimulator.ts` has
+  no `lastFired`, and `simulateAutomation` runs the graph whenever the pre-filter
+  matches (`:290-320`). A dry-run therefore ignores `cooldownScope` entirely —
+  correct, since a dry-run must always show the operator what *would* happen.
+  Pinned by a regression test (§6) so nobody adds cooldown to the tester later
+  without a decision.
+- **The Test panel (`AutomationTester.tsx`) has no cooldown UI** and gains none.
+- **`recordingDeps()` / `ActionDeps` / `meshActionDeps.ts` are untouched** —
+  cooldown is a pre-dispatch gate, entirely above the deps boundary.
+- **`automationTraceBus` / `LiveTracePanel.tsx` are untouched** — the key name
+  rides the existing `reason` string.
+- **No route, no envelope work, no new setting** (so no `VALID_SETTINGS_KEYS`
+  entry), **no schema change, no migration** — therefore no PostgreSQL/MySQL
+  containers are required to verify this phase.
+- **`graphEvaluator.ts` is untouched.** The evaluator runs strictly *after* the
+  cooldown gate and has no cooldown concept.
+
+## 4. Frontend
+
+### 4.1 `showIf` gains one operator — `catalog.ts:15-41`
+
+The scope select is meaningless while `cooldownSeconds` is unset or `0`, so it
+must be gated. `showIf` currently supports only `equals`/`notEquals`, and
+`cooldownSeconds` can legitimately be `undefined` (never touched), `''` (cleared
+— the `number` renderer emits `''`, `AutomationBuilder.tsx:73-74`), or `0`.
+`notEquals: 0` would show the field in the first two cases. So extend `showIf`
+with a generic truthiness operator rather than inventing a second mechanism:
+
+```ts
+showIf?: {
+  field: string;
+  equals?: unknown;
+  notEquals?: unknown;
+  /** Visible only when the sibling param is truthy (`true`) / falsy (`false`).
+   *  Covers "a number field that is unset, blank, or 0" in one operator. */
+  truthy?: boolean;
+};
+```
+
+```ts
+export function fieldVisible(field: FieldDef, params: Record<string, unknown>): boolean {
+  const c = field.showIf;
+  if (!c) return true;
+  const v = params[c.field];
+  if ('equals' in c && v !== c.equals) return false;
+  if ('notEquals' in c && v === c.notEquals) return false;
+  // Boolean(v) covers undefined / '' / 0 / false uniformly. Known, harmless
+  // wart: the string '0' is truthy — it only shows an extra select.
+  if (c.truthy !== undefined && Boolean(v) !== c.truthy) return false;
+  return true;
+}
+```
+
+**Phase 1 semantics are preserved verbatim: hidden ≠ cleared.** Setting the
+cooldown back to `0` hides the select but keeps `params.cooldownScope`, and the
+engine ignores it anyway (`cooldownGate` returns early when
+`cooldownSeconds <= 0`), so there is no behaviour risk in either direction.
+
+### 4.2 The field — `catalog.ts`, beside `COOLDOWN` (`:51-54`)
+
+```ts
+const COOLDOWN_SCOPE: FieldDef = {
+  name: 'cooldownScope', label: 'Cooldown applies to', kind: 'select', advanced: true,
+  // Values mirror CooldownScope in src/types/automation.ts. Kept as literals so
+  // this frontend catalog keeps its zero dependency on the server-side types
+  // module (the same call Phase 1 made for action.tapback's emojiMode).
+  // 'automation' MUST be first: defaultParams() seeds a select's first option,
+  // so a newly added trigger block gets the pre-4.14 behaviour.
+  options: [
+    { value: 'automation', label: 'The whole automation (one shared timer)' },
+    { value: 'node', label: 'Each node separately' },
+    { value: 'sourceNode', label: 'Each node, per source' },
+  ],
+  // Only meaningful once a cooldown is actually set.
+  showIf: { field: 'cooldownSeconds', truthy: true },
+  help: 'The whole automation: one timer for the rule — on a busy channel, answering one node suppresses the answer to the next. Each node separately: every sending/subject node gets its own timer, which is what you want for a range-test responder. Each node, per source: the same node heard via two sources cools down independently. Triggers with no subject node (Schedule, System, MeshCore channel messages) fall back to one shared timer.',
+};
+```
+
+Add `COOLDOWN_SCOPE` immediately after `COOLDOWN` in the `fields` array of the
+**five** trigger blocks that carry `COOLDOWN`: `trigger.message` (`:70`),
+`trigger.nodeDiscovered` (`:77`), `trigger.nodeUpdated` (`:83`),
+`trigger.telemetry` (`:101`), `trigger.geofence` (`:142`). **Do not** add it to
+`trigger.schedule` or `trigger.system` — they expose no cooldown field today,
+and those two are precisely the trigger types with no subject node.
+
+### 4.3 `AutomationBuilder.tsx` — no change
+
+`BlockFields` already filters through `fieldVisible` (`:227`), and
+`defaultParams` (`:48-63`) already seeds selects. **Verify with
+`git diff --stat` that this file is unmodified** — if it needed a change, the
+design went wrong.
+
+Note for the implementer: legacy stored graphs have `cooldownSeconds: 60` and no
+`cooldownScope`, so the `select` renders `value=''` (`:84`) with no matching
+option — the browser displays the first option ("The whole automation") while
+`params.cooldownScope` stays `undefined`. Display and effective behaviour agree,
+and it is byte-identical to how Phase 1's `emojiMode` behaves on legacy graphs.
+Do **not** "fix" this by writing a default into stored params.
+
+## 5. Docs
+
+### 5.1 `docs/features/automation-engine.md`
+
+- **`:42`** — "Cooldown / rate-limit **per automation**" → "Cooldown / rate-limit
+  per automation, or **per node / per source+node** via the trigger's *Cooldown
+  applies to*".
+- **`:96`** (schedule section) — note a schedule trigger has no subject node, so
+  its cooldown is always automation-wide.
+- **New subsection under the trigger docs** — *Cooldown applies to*: the three
+  values, the per-node worked example from §2.6, the degraded fallback and
+  exactly which triggers hit it (Schedule, System, MeshCore **channel** messages
+  — while MeshCore **DMs and room posts** do get real per-sender cooldown), and
+  the "hidden until you set a cooldown" UI behaviour.
+- **`:296`** (recipe, Automation A) — replace "leave at `0`" with: set `60`, set
+  **Cooldown applies to** = *Each node separately*. **This is the user-visible
+  payoff of the phase; the recipe must be updated or the phase is not done.**
+- **`:332-340`** — **delete** the whole "Cooldown caveat (per-automation, not
+  per-node)" section and replace it with a short pointer to the new subsection.
+  It documents a limitation that no longer exists.
+- **`:509`** (live trace) — note the `cooldown` reason now names the key that was
+  cooling down.
+
+### 5.2 `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`
+
+Flip Phase 2 to `[x] complete`; add a **Phase 2 close** block under *Notes /
+deviations* recording: the `subjectNodeKey` addition and why it is cooldown-only;
+the MeshCore channel-vs-DM asymmetry; the degraded-to-automation-wide fallback
+decision; the `showIf.truthy` extension; the eviction strategy and its two caps;
+the pre-switch validation guard; and the disable→re-enable cooldown reset.
+
+## 6. Test plan (mandatory — standard Vitest suite, no standalone scripts)
+
+| File | New / extend | Cases |
+|---|---|---|
+| `src/types/automation.test.ts` | extend | `cooldownScope` `'automation'`/`'node'`/`'sourceNode'` validate on a `trigger.message`; `'perNode'` produces the `∈ {automation,node,sourceNode}` error; **a trigger node with NO `cooldownScope` still validates**; the guard applies to a non-message trigger too (e.g. `trigger.telemetry`); `parseCooldownScope`: each valid value round-trips, `undefined`/`null`/`''`/`'bogus'`/`0` → `'automation'`. |
+| `src/server/services/automation/triggerContext.test.ts` | extend | `subjectKeyOf`: Meshtastic message ctx → `'111'`; schedule ctx → `null`; system ctx with `nodeNum` → that number as a string, without → `null`; explicit `subjectNodeKey: null` beats a non-null `subjectNodeNum`. `buildMeshCoreMessageContext`: a **DM** → `subjectNodeKey === '<pubkey>'`; a **channel** post (`fromPublicKey: 'channel-0'`) → `subjectNodeKey === null`; a **room post** → the author pubkey. Every Meshtastic builder leaves `subjectNodeKey` `undefined`. |
+| `src/server/services/automation/engineContext.test.ts` *(create if absent — check first)* | new/extend | `cooldownKeyFor` truth table across all three scopes × {Meshtastic node, MeshCore pubkey, no subject, no sourceId}: keys `''`/`'111'`/`'src:111'`; `degraded` true only on the two fallbacks; labels contain `automation-wide` / `node 111` / `source … · node …`; a 64-char pubkey label truncates to 12 chars + `…` while the **key stays full-length**. **Cross-check test:** for a Meshtastic context, `cooldownKeyFor('node'\|'sourceNode', ctx).key` equals `buildScopeKey('node'\|'sourceNode', varContextFromTrigger(ctx))`. |
+| `src/server/services/automation/automationEngineService.test.ts` | extend | **(a) headline:** `cooldownSeconds: 60`, `cooldownScope: 'node'`; node 111 fires, node 222 fires **in the same window**, node 111 suppressed, node 111 fires after the window. **(b) regression:** identical graph with `cooldownScope` **absent** reproduces `:284`'s existing per-automation assertions exactly. **(c)** explicit `'automation'` behaves identically to (b). **(d)** `'sourceNode'`: same node on `'a'` then `'b'` both fire; repeat on `'a'` suppressed. **(e)** `'bogus'` behaves as `'automation'`. **(f) trace, all three sites:** message dispatch under `node` → reason matches `/cooldown active/` **and** `/node 111/`; `onSchedule` under `node` → `/automation-wide/`; `checkGeofences` under `node` → names the moving node. **(g)** MeshCore: two DMs from different pubkeys under `node` both fire; two **channel** messages → second suppressed with `automation-wide`. **(h)** `cooldownSeconds: 0` + `'node'` → every event fires. **(i) eviction:** with `cooldownSeconds: 1` and a fake clock, drive >`COOLDOWN_KEYS_MAX` distinct senders across advancing time; assert *behaviour* (a node inside its window is still suppressed), not map size. **(j) load-prune:** fire, disable, `load()`, re-enable, `load()`, fire same node inside the original window → it fires. |
+| `src/server/services/automation/automationSimulator.test.ts` | extend | A dry-run with `cooldownSeconds: 60, cooldownScope: 'node'` fires; running `simulateAutomation` twice with the same subject at the same `now` fires **both** times — the simulator models no cooldown, by design. |
+| `src/components/automations/catalog.showIf.test.ts` | extend | `truthy` truth table: `truthy: true` with `undefined`/`''`/`0`/`false` → hidden, with `1`/`60`/`'x'` → visible; `truthy: false` inverts; combined with `equals`. Catalog: all five cooldown-bearing blocks list `cooldownScope` **immediately after** `cooldownSeconds`; options exactly `['automation','node','sourceNode']` with `automation` first; `showIf` exactly `{ field: 'cooldownSeconds', truthy: true }`; `trigger.schedule`/`trigger.system` have **neither** field. |
+| `src/components/automations/AutomationBuilder.cooldownScope.test.tsx` | **new** (model on `AutomationBuilder.emojiMode.test.tsx`) | `cooldownSeconds` unset → select **not** rendered; `0` → not rendered; `60` → rendered; changing it writes `params.cooldownScope = 'node'`; clearing the cooldown hides the select but **preserves** `params.cooldownScope`. |
+
+Also required per CLAUDE.md: full `npx vitest run` green (0 failures, confirmed
+via `--reporter=json` `success: true`), and
+`npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` empty.
+**No schema change ⇒ no migration and no PG/MySQL containers needed.**
+
+## 7. Work packages
+
+All agents share **one worktree**. File ownership is exclusive; the parallel pair
+(WP2 ∥ WP3) share no file.
+
+### WP1 — Vocabulary + validation *(must land first; blocks WP2 and WP3)*
+
+**Owns:** `src/types/automation.ts` · `src/types/automation.test.ts`
+
+**Delivers:** §2.1 and §2.2.
+
+**Acceptance:** the three constants/functions exported with documented
+semantics; a trigger node with no `cooldownScope` validates unchanged; an
+unrecognised value errors with the `∈ {automation,node,sourceNode}` message; the
+guard fires for **every** trigger type; `parseCooldownScope` is lenient per §2.1.
+`git diff --stat` shows exactly two files. Full suite green.
+
+### WP2 — Engine: keying, gating, trace, eviction *(after WP1; parallel with WP3)*
+
+**Owns:** `src/server/services/automation/triggerContext.ts` ·
+`.../triggerContext.test.ts` · `.../engineContext.ts` ·
+`.../engineContext.test.ts` (new if absent) · `.../automationEngineService.ts` ·
+`.../automationEngineService.test.ts` · `.../automationSimulator.test.ts`
+
+**Delivers:** §2.3, §2.4, §2.5, and the WP2 rows of §6.
+
+**Hard constraints:**
+- Must **not** edit `src/types/automation.ts` (WP1) or anything under
+  `src/components/` (WP3).
+- Must **not** modify `automationSimulator.ts`, `actionExecutor.ts`,
+  `meshActionDeps.ts`, `graphEvaluator.ts`, `automationTraceBus.ts`, or
+  `LiveTracePanel.tsx`. Verify with `git diff --stat`.
+- `subjectNodeNum` semantics must not change; `subjectNodeKey` must stay
+  **optional**.
+- After the change,
+  `grep -n "lastFired" src/server/services/automation/automationEngineService.ts`
+  must show hits only inside the declaration, `load()`, `cooldownGate`,
+  `markFired`, and `pruneCooldownKeys` — **no `lastFired.get(a.id)` may survive
+  at any of the three dispatch sites.**
+- Every pre-existing test in `automationEngineService.test.ts` must pass
+  **unmodified**, including the two `/cooldown active/` reason assertions at
+  `:614` and `:657` — so the reason string must keep that exact prefix and
+  append the key phrase in parentheses.
+
+**Acceptance:** two senders on one channel cool down independently under `node`
+scope; absent `cooldownScope` is byte-for-byte today's behaviour; all three trace
+sites name the key; the eviction behaviour test passes; the simulator is provably
+cooldown-free. Full suite green.
+
+### WP3 — Builder: `showIf.truthy` + the catalog field *(after WP1; parallel with WP2)*
+
+**Owns:** `src/components/automations/catalog.ts` · `.../catalog.showIf.test.ts` ·
+`.../AutomationBuilder.cooldownScope.test.tsx` (new)
+
+**Hard constraints:**
+- Must **not** edit `src/types/automation.ts` (WP1) or `AutomationBuilder.tsx`.
+  Use the string literals with a comment pointing at `CooldownScope`, exactly as
+  Phase 1 did for `emojiMode`. **`AutomationBuilder.tsx` appearing in
+  `git diff --stat` is a design failure — stop and escalate.**
+- Do **not** rely on `FieldDef.advanced` for visibility — it is still never read.
+- Does **not** deploy or drive the dev container; browser validation is the
+  orchestrator's stage.
+
+**Acceptance:** `fieldVisible` handles `truthy` per the truth table and the
+existing `equals`/`notEquals` tests still pass unmodified; the select is hidden
+until a non-zero cooldown is set and its value survives a hide/show round-trip;
+the five-block/two-block split of §4.2 is asserted. Full suite green.
+
+### WP4 — Docs *(after WP2 and WP3 both land)*
+
+**Owns:** `docs/features/automation-engine.md` ·
+`docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`
+
+**Acceptance:** §5 delivered. The "Cooldown caveat" section is **removed**, not
+merely amended. The #4340 recipe now instructs a non-zero cooldown with *Each
+node separately*. Every field label and option label quoted in the docs matches
+the shipped catalog verbatim. The MeshCore channel-vs-DM asymmetry is
+documented, not glossed.
+
+**Dependency graph:** `WP1 → (WP2 ∥ WP3) → WP4`
+
+## 8. Explicit non-goals
+
+- **`geofenceState` is not bounded by this phase.** It has the same unbounded
+  `${automationId}:${nodeNum}` growth (`automationEngineService.ts:121,
+  :514-516`) and predates this work. Deleting an entry is *not* behaviour-neutral
+  there — it resets the enter/exit baseline. Needs its own decision.
+  **File a follow-up issue.**
+- **`meshtasticManager.autoAckCooldowns` is not bounded** by this phase either —
+  noted in §2.5 only as the counter-example. Same follow-up issue.
+- **No `cooldownScope` for `trigger.schedule` / `trigger.system` in the UI.** The
+  engine honours the param if an imported JSON sets it (degrading to
+  automation-wide); the builder does not offer it because those triggers expose
+  no cooldown field at all today.
+- **No `channel` cooldown scope.** Genuinely useful for MeshCore channel messages,
+  but not in the epic's decision list, and Meshtastic's `channelName` is not
+  resolvable in the trigger context without a DB lookup on the cooldown hot path.
+  Note it in the epic as a candidate.
+- **`cooldownSeconds` validation** is not added (§2.2).
+
+## 9. Contradictions and findings against the original brief
+
+1. **The validation `switch` is keyed on `n.type`, and `cooldownScope` belongs to
+   all seven trigger types.** The brief asked for a `case` following the
+   `action.tapback` precedent; `emojiMode` is a *single-block* param, so its
+   `case` is right for it, but replicating that here means seven duplicated
+   `case` labels that silently miss the eighth trigger type added later. §2.2
+   uses a one-line `categoryOf(n.type) === 'trigger'` guard. **Orchestrator
+   signed off 2026-07-28.**
+2. **`load()` pruning changes one edge case.** Disabling and re-enabling a
+   node-scoped automation inside its own cooldown window will now let it fire
+   immediately. Every alternative was worse. Documented, tested (§6 case (j)).
+3. **`showIf` as shipped in Phase 1 cannot express "a number field that is set".**
+   `equals`/`notEquals` cannot distinguish `undefined` / `''` / `0`. §4.1 adds
+   one generic `truthy` operator — an extension, not a second mechanism.
+4. **`graphEvaluator.test.ts` is not a relevant suite.** The evaluator runs
+   strictly downstream of the cooldown gate.
+5. **`resetCooldowns` does not exist.** `grep -rn "resetCooldown" src` is empty.
+6. **MeshCore is only *half* scopable, and the failure mode is subtle.**
+   `buildMeshCoreMessageContext` sets `subjectNodeNum: null` for **all** MeshCore
+   messages, so the naive fix (key off `ctx.fields.from`) would key a MeshCore
+   **channel** automation off the synthetic `channel-<idx>` slot string that
+   *every sender on that channel shares* — a per-channel cooldown wearing a
+   per-node label. §2.3 keys off `fromPublicKey` only when it is a real sender
+   key and returns `null` for channel posts.
+7. **`trigger.schedule` and `trigger.system` already honour a cooldown in the
+   engine but expose no cooldown field in the builder** (`catalog.ts:104-124`).
+   Pre-existing inconsistency, unchanged here.
+8. **The five `COOLDOWN`-bearing trigger blocks are exactly
+   `SUBJECT_NODE_TRIGGERS` (`catalog.ts:149`).** Verified, not assumed. WP3's
+   catalog test pins the pairing.
+9. **`lastFired` is written unconditionally today, even when
+   `cooldownSeconds === 0`.** §2.5 stops doing that — unobservable, and keeps
+   memory at exactly zero for the common cooldown-less automation.

--- a/src/components/automations/AutomationBuilder.cooldownScope.test.tsx
+++ b/src/components/automations/AutomationBuilder.cooldownScope.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * AutomationBuilder — trigger `cooldownScope` field visibility (#4340 Phase 2
+ * WP3 §4.1/§4.2). The "Cooldown applies to" select is hidden while
+ * cooldownSeconds is unset, blank (cleared via the number renderer), or `0`,
+ * and its stored value must survive a set → clear → set round trip (hidden ≠
+ * cleared — the builder never deletes params.cooldownScope).
+ *
+ * Modeled on AutomationBuilder.emojiMode.test.tsx (Phase 1's showIf consumer),
+ * adapted for a TRIGGER-level field (form.trigger.params) rather than an
+ * action's params.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AutomationBuilder from './AutomationBuilder';
+import type { WorkflowForm } from './compile';
+
+// Override the global i18n mock so t(key, default) returns the English default.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string | Record<string, unknown>) =>
+      typeof defaultValue === 'string' ? defaultValue : key,
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+function buildForm(triggerParams: Record<string, unknown>): WorkflowForm {
+  return {
+    trigger: { type: 'trigger.message', params: triggerParams },
+    rules: [
+      {
+        conditions: [],
+        actions: [{ type: 'action.nothing', params: {} }],
+      },
+    ],
+    combine: null,
+  };
+}
+
+function renderBuilder(triggerParams: Record<string, unknown>, onChange: (f: WorkflowForm) => void = () => {}) {
+  return render(
+    <AutomationBuilder
+      form={buildForm(triggerParams)}
+      variables={[]}
+      sources={[]}
+      channels={[]}
+      scripts={[]}
+      regions={[]}
+      onChange={onChange}
+    />,
+  );
+}
+
+/** The <select>/<input> control for a FieldDef, found via its `.ae-field` label. */
+function controlFor(labelText: string): HTMLElement {
+  const label = screen.getByText(labelText);
+  const container = label.closest('.ae-field');
+  if (!container) throw new Error(`No .ae-field ancestor found for label "${labelText}"`);
+  const control = container.querySelector('select, input, textarea');
+  if (!control) throw new Error(`No control found in field "${labelText}"`);
+  return control as HTMLElement;
+}
+
+describe('AutomationBuilder — trigger cooldownScope (#4340 Phase 2)', () => {
+  it('does not render the select when cooldownSeconds is unset', () => {
+    renderBuilder({});
+    expect(screen.queryByText('Cooldown applies to')).not.toBeInTheDocument();
+  });
+
+  it('does not render the select when cooldownSeconds is 0', () => {
+    renderBuilder({ cooldownSeconds: 0 });
+    expect(screen.queryByText('Cooldown applies to')).not.toBeInTheDocument();
+  });
+
+  it('does not render the select when cooldownSeconds is "" (cleared via the number input)', () => {
+    renderBuilder({ cooldownSeconds: '' });
+    expect(screen.queryByText('Cooldown applies to')).not.toBeInTheDocument();
+  });
+
+  it('renders the select when cooldownSeconds is a positive number', () => {
+    renderBuilder({ cooldownSeconds: 60 });
+    expect(screen.getByText('Cooldown applies to')).toBeInTheDocument();
+  });
+
+  it('changing the select writes params.cooldownScope', async () => {
+    const user = userEvent.setup();
+    let latest: WorkflowForm = buildForm({ cooldownSeconds: 60 });
+    const onChange = (f: WorkflowForm) => { latest = f; };
+    renderBuilder({ cooldownSeconds: 60 }, onChange);
+
+    const select = controlFor('Cooldown applies to') as HTMLSelectElement;
+    await user.selectOptions(select, 'node');
+
+    expect(latest.trigger.params.cooldownScope).toBe('node');
+  });
+
+  it('preserves params.cooldownScope across a set → clear → set round trip (hidden ≠ cleared)', async () => {
+    const user = userEvent.setup();
+    let latest: WorkflowForm = buildForm({ cooldownSeconds: 60, cooldownScope: 'node' });
+    const onChange = (f: WorkflowForm) => { latest = f; };
+    const { rerender } = renderBuilder({ cooldownSeconds: 60, cooldownScope: 'node' }, onChange);
+
+    expect(screen.getByText('Cooldown applies to')).toBeInTheDocument();
+    expect((controlFor('Cooldown applies to') as HTMLSelectElement).value).toBe('node');
+
+    // Clear the cooldown back to '' via the number input.
+    const cooldownInput = controlFor('Cooldown (seconds)') as HTMLInputElement;
+    await user.clear(cooldownInput);
+
+    // params.cooldownScope must survive even though the field is now hidden.
+    expect(latest.trigger.params.cooldownSeconds).toBe('');
+    expect(latest.trigger.params.cooldownScope).toBe('node');
+
+    rerender(
+      <AutomationBuilder
+        form={latest}
+        variables={[]}
+        sources={[]}
+        channels={[]}
+        scripts={[]}
+        regions={[]}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.queryByText('Cooldown applies to')).not.toBeInTheDocument();
+
+    // Re-set a positive cooldown — the select reappears pre-populated with the
+    // preserved value, not reset to the first option.
+    rerender(
+      <AutomationBuilder
+        form={buildForm({ cooldownSeconds: 60, cooldownScope: 'node' })}
+        variables={[]}
+        sources={[]}
+        channels={[]}
+        scripts={[]}
+        regions={[]}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('Cooldown applies to')).toBeInTheDocument();
+    expect((controlFor('Cooldown applies to') as HTMLSelectElement).value).toBe('node');
+  });
+});

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { fieldVisible, ACTIONS, type FieldDef } from './catalog';
+import { fieldVisible, ACTIONS, TRIGGERS, type FieldDef } from './catalog';
 import { HOP_COUNT_EMOJIS } from '../../utils/hopEmoji';
 
 describe('fieldVisible', () => {
@@ -42,6 +42,43 @@ describe('fieldVisible', () => {
     // 'b' fails both equals (b !== a -> hidden) — equals check alone already hides it.
     expect(fieldVisible(field, { mode: 'b' })).toBe(false);
     expect(fieldVisible(field, { mode: 'c' })).toBe(false); // fails equals
+  });
+
+  // #4340 Phase 2: truthy — covers "a number field that is unset, blank, or 0"
+  // in one operator, since equals/notEquals cannot distinguish those three.
+  describe('truthy', () => {
+    const truthyField: FieldDef = { name: 'x', label: 'X', kind: 'select', showIf: { field: 'cooldownSeconds', truthy: true } };
+    const falsyField: FieldDef = { name: 'x', label: 'X', kind: 'select', showIf: { field: 'cooldownSeconds', truthy: false } };
+
+    it('truthy: true hides on undefined / "" / 0 / false', () => {
+      expect(fieldVisible(truthyField, {})).toBe(false); // undefined — never touched
+      expect(fieldVisible(truthyField, { cooldownSeconds: '' })).toBe(false); // cleared via the number renderer
+      expect(fieldVisible(truthyField, { cooldownSeconds: 0 })).toBe(false);
+      expect(fieldVisible(truthyField, { cooldownSeconds: false })).toBe(false);
+    });
+
+    it('truthy: true shows on 1 / 60 / a non-empty string', () => {
+      expect(fieldVisible(truthyField, { cooldownSeconds: 1 })).toBe(true);
+      expect(fieldVisible(truthyField, { cooldownSeconds: 60 })).toBe(true);
+      expect(fieldVisible(truthyField, { cooldownSeconds: 'x' })).toBe(true);
+    });
+
+    it('truthy: false inverts — visible only when the sibling is falsy', () => {
+      expect(fieldVisible(falsyField, {})).toBe(true);
+      expect(fieldVisible(falsyField, { cooldownSeconds: '' })).toBe(true);
+      expect(fieldVisible(falsyField, { cooldownSeconds: 0 })).toBe(true);
+      expect(fieldVisible(falsyField, { cooldownSeconds: 1 })).toBe(false);
+      expect(fieldVisible(falsyField, { cooldownSeconds: 60 })).toBe(false);
+    });
+
+    it('truthy combined with equals: both conditions must pass', () => {
+      const field: FieldDef = { name: 'x', label: 'X', kind: 'select', showIf: { field: 'cooldownSeconds', truthy: true } };
+      // Independently re-verify with a different sibling to confirm the two showIf
+      // operators (equals vs truthy) don't leak state between fields.
+      const other: FieldDef = { name: 'y', label: 'Y', kind: 'text', showIf: { field: 'mode', equals: 'a' } };
+      expect(fieldVisible(field, { cooldownSeconds: 60 })).toBe(true);
+      expect(fieldVisible(other, { mode: 'a', cooldownSeconds: 0 })).toBe(true);
+    });
   });
 });
 
@@ -85,5 +122,51 @@ describe('action.tapback catalog entry', () => {
     for (const glyph of HOP_COUNT_EMOJIS) {
       expect(source.includes(glyph)).toBe(false);
     }
+  });
+});
+
+// #4340 Phase 2 §4.2/§6 — the cooldownScope field, spliced into exactly the
+// five trigger blocks that already carry cooldownSeconds (SUBJECT_NODE_TRIGGERS
+// in catalog.ts, verified as the same five in §1 finding #8).
+describe('trigger.* cooldownScope catalog entries (#4340 Phase 2)', () => {
+  const COOLDOWN_BEARING_TYPES = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence'];
+  const NO_COOLDOWN_TYPES = ['trigger.schedule', 'trigger.system'];
+
+  it.each(COOLDOWN_BEARING_TYPES)('%s lists cooldownScope immediately after cooldownSeconds', (type) => {
+    const block = TRIGGERS.find((t) => t.type === type);
+    expect(block).toBeDefined();
+    const names = (block?.fields ?? []).map((f) => f.name);
+    const cooldownIdx = names.indexOf('cooldownSeconds');
+    const scopeIdx = names.indexOf('cooldownScope');
+    expect(cooldownIdx).toBeGreaterThanOrEqual(0);
+    expect(scopeIdx).toBe(cooldownIdx + 1);
+  });
+
+  it.each(NO_COOLDOWN_TYPES)('%s has neither cooldownSeconds nor cooldownScope', (type) => {
+    const block = TRIGGERS.find((t) => t.type === type);
+    expect(block).toBeDefined();
+    const names = (block?.fields ?? []).map((f) => f.name);
+    expect(names).not.toContain('cooldownSeconds');
+    expect(names).not.toContain('cooldownScope');
+  });
+
+  it('cooldownScope options are exactly automation/node/sourceNode, automation first', () => {
+    const block = TRIGGERS.find((t) => t.type === 'trigger.message');
+    const field = block?.fields.find((f) => f.name === 'cooldownScope');
+    expect(field?.kind).toBe('select');
+    expect(field?.options?.map((o) => o.value)).toEqual(['automation', 'node', 'sourceNode']);
+  });
+
+  it('cooldownScope carries showIf hiding it until cooldownSeconds is truthy', () => {
+    const block = TRIGGERS.find((t) => t.type === 'trigger.message');
+    const field = block?.fields.find((f) => f.name === 'cooldownScope');
+    expect(field?.showIf).toEqual({ field: 'cooldownSeconds', truthy: true });
+  });
+
+  it('every cooldown-bearing block shares the identical cooldownScope FieldDef object', () => {
+    // COOLDOWN_SCOPE is a single shared const spliced into all five blocks —
+    // not five separately-authored copies that could drift apart.
+    const fields = COOLDOWN_BEARING_TYPES.map((type) => TRIGGERS.find((t) => t.type === type)?.fields.find((f) => f.name === 'cooldownScope'));
+    for (const f of fields) expect(f).toBe(fields[0]);
   });
 });

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -28,7 +28,14 @@ export interface FieldDef {
    * Render this field only when a sibling param matches. Omitted = always shown.
    * Declarative (not a predicate function) so the catalog stays serialisable data.
    */
-  showIf?: { field: string; equals?: unknown; notEquals?: unknown };
+  showIf?: {
+    field: string;
+    equals?: unknown;
+    notEquals?: unknown;
+    /** Visible only when the sibling param is truthy (`true`) / falsy (`false`).
+     *  Covers "a number field that is unset, blank, or 0" in one operator (#4340 Phase 2). */
+    truthy?: boolean;
+  };
 }
 
 /** Should this field render, given the block's current params? Pure — unit-tested without React. */
@@ -38,6 +45,9 @@ export function fieldVisible(field: FieldDef, params: Record<string, unknown>): 
   const v = params[c.field];
   if ('equals' in c && v !== c.equals) return false;
   if ('notEquals' in c && v === c.notEquals) return false;
+  // Boolean(v) covers undefined / '' / 0 / false uniformly. Known, harmless
+  // wart: the string '0' is truthy — it only shows an extra select.
+  if (c.truthy !== undefined && Boolean(v) !== c.truthy) return false;
   return true;
 }
 
@@ -51,6 +61,23 @@ export interface BlockDef {
 const COOLDOWN: FieldDef = {
   name: 'cooldownSeconds', label: 'Cooldown (seconds)', kind: 'number', advanced: true,
   placeholder: '0', help: 'Minimum seconds between firings — an anti-spam throttle. 0 = no limit.',
+};
+
+const COOLDOWN_SCOPE: FieldDef = {
+  name: 'cooldownScope', label: 'Cooldown applies to', kind: 'select', advanced: true,
+  // Values mirror CooldownScope in src/types/automation.ts. Kept as literals so
+  // this frontend catalog keeps its zero dependency on the server-side types
+  // module (the same call Phase 1 made for action.tapback's emojiMode).
+  // 'automation' MUST be first: defaultParams() seeds a select's first option,
+  // so a newly added trigger block gets the pre-4.14 behaviour.
+  options: [
+    { value: 'automation', label: 'The whole automation (one shared timer)' },
+    { value: 'node', label: 'Each node separately' },
+    { value: 'sourceNode', label: 'Each node, per source' },
+  ],
+  // Only meaningful once a cooldown is actually set.
+  showIf: { field: 'cooldownSeconds', truthy: true },
+  help: 'The whole automation: one timer for the rule — on a busy channel, answering one node suppresses the answer to the next. Each node separately: every sending/subject node gets its own timer, which is what you want for a range-test responder. Each node, per source: the same node heard via two sources cools down independently. Triggers with no subject node (Schedule, System, MeshCore channel messages) fall back to one shared timer.',
 };
 
 // ─── Triggers (WHEN) ─────────────────────────────────────────────────────────
@@ -68,19 +95,20 @@ export const TRIGGERS: BlockDef[] = [
       { name: 'channel', label: 'On channel #', kind: 'number', placeholder: 'any', advanced: true, help: 'Match by raw channel index. Note: the same channel can be a different index on different sources — use the name above for cross-source automations. Ignored when "On channels" above is set.' },
       { name: 'from', label: 'From node #', kind: 'number', placeholder: 'any', advanced: true, help: 'Only fire for messages from this node number.' },
       COOLDOWN,
+      COOLDOWN_SCOPE,
     ],
   },
   {
     type: 'trigger.nodeDiscovered',
     label: 'A new node is discovered',
     description: 'Fires the first time a node is seen. Note: new-vs-updated detection is coming in a later update — for now this behaves like “A node is updated”. Use that trigger meanwhile.',
-    fields: [COOLDOWN],
+    fields: [COOLDOWN, COOLDOWN_SCOPE],
   },
   {
     type: 'trigger.nodeUpdated',
     label: 'A node is updated',
     description: "Fires when a node's info changes (name, role, position…).",
-    fields: [COOLDOWN],
+    fields: [COOLDOWN, COOLDOWN_SCOPE],
   },
   {
     type: 'trigger.telemetry',
@@ -99,6 +127,7 @@ export const TRIGGERS: BlockDef[] = [
         ],
       },
       COOLDOWN,
+      COOLDOWN_SCOPE,
     ],
   },
   {
@@ -140,6 +169,7 @@ export const TRIGGERS: BlockDef[] = [
       },
       { name: 'shape', label: 'Region', kind: 'geofence', help: 'Draw a circle (center + radius) or a polygon on the map.' },
       COOLDOWN,
+      COOLDOWN_SCOPE,
     ],
   },
 ];

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -302,6 +302,323 @@ describe('AutomationEngineService', () => {
     expect(calls).toHaveLength(2);
   });
 
+  // ── cooldownScope (#4340 Phase 2) ───────────────────────────────────────────
+  describe('cooldownScope (#4340 Phase 2)', () => {
+    it('(a) headline: two senders on one channel cool down independently under node scope', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // node 111 fires (t0)
+      clock += 5_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 222 }), 'default')).toBe(1); // node 222 fires — same window, unaffected
+      clock += 15_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(0); // node 111 still cooling down (t0+20s)
+      clock += 41_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // node 111 past its window (t0+61s)
+      expect(calls).toHaveLength(3);
+    });
+
+    it('(b) regression: cooldownScope absent reproduces per-automation behaviour exactly', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          // No cooldownScope param at all — the pre-Phase-2 shape.
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60 } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // fires (t0)
+      clock += 5_000;
+      // A DIFFERENT node's message is suppressed too — automation-wide, not per-node.
+      expect(await engine.onMessage(message({ fromNodeNum: 222 }), 'default')).toBe(0);
+      clock += 56_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // past cooldown (t0+61s)
+      expect(calls).toHaveLength(2);
+    });
+
+    it('(c) explicit cooldownScope: automation behaves identically to absent', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'automation' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1);
+      clock += 5_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 222 }), 'default')).toBe(0);
+      clock += 56_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1);
+      expect(calls).toHaveLength(2);
+    });
+
+    it('(d) sourceNode: the same node on two different sources cools down independently', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'sourceNode' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'a')).toBe(1); // fires on source 'a'
+      clock += 1_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'b')).toBe(1); // same node, different source — fires
+      clock += 1_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'a')).toBe(0); // repeat on 'a' — still cooling down
+      expect(calls).toHaveLength(2);
+    });
+
+    // (e) Spec §6 describes 'bogus' as degrading to automation-wide at RUNTIME —
+    // that is parseCooldownScope's own contract, exercised directly by WP1's
+    // src/types/automation.test.ts. In this engine, though, `load()`
+    // unconditionally runs every stored graph through validateAutomationGraph
+    // (WP1 §2.2, orchestrator-approved §9.1 guard), and that guard rejects an
+    // unrecognised params.cooldownScope on ANY trigger node — so an automation
+    // with cooldownScope: 'bogus' never reaches parseCooldownScope at all; it is
+    // skipped at load with a warning, same as any other structurally-invalid
+    // graph. That is a stricter (and safer) outcome than "silently degrades" —
+    // documented here rather than asserting the spec's literal wording, which
+    // does not hold given WP1's landed validation.
+    it('(e) an unrecognised cooldownScope fails graph validation and the automation never loads', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'bogus' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(engine.countFor('trigger.message')).toBe(0);
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(0);
+      expect(calls).toHaveLength(0);
+    });
+
+    it('(f1) trace: message dispatch under node scope names the cooling-down node', async () => {
+      const got: any[] = [];
+      automationTraceBus.setSink((_id, payload) => got.push(payload));
+      const a = await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(recorder().deps);
+      await engine.load();
+      automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+      await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default'); // fires
+      clock += 5_000;
+      await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default'); // suppressed
+      const cooldownEvent = got.find((g) => g.outcome === 'cooldown');
+      expect(cooldownEvent.reason).toMatch(/cooldown active/);
+      expect(cooldownEvent.reason).toMatch(/node 111/);
+    });
+
+    it('(f2) trace: onSchedule under node scope names automation-wide (no subject node)', async () => {
+      const got: any[] = [];
+      automationTraceBus.setSink((_id, payload) => got.push(payload));
+      const a = await createEnabled('cron', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.schedule', params: { cron: '* * * * *', cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 'n', type: 'action.notify', params: { body: 'tick' } },
+        ],
+        edges: [{ from: 't', to: 'n' }],
+      });
+      const engine = engineWith(recorder().deps);
+      await engine.load();
+      automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+      await engine.onSchedule(a.id); // fires (t0)
+      clock += 5_000;
+      await engine.onSchedule(a.id); // within cooldown
+      const cooldownEvent = got.find((g) => g.outcome === 'cooldown');
+      expect(cooldownEvent.reason).toMatch(/cooldown active/);
+      expect(cooldownEvent.reason).toMatch(/automation-wide/);
+    });
+
+    it('(f3) trace: checkGeofences under node scope names the moving node', async () => {
+      const got: any[] = [];
+      automationTraceBus.setSink((_id, payload) => got.push(payload));
+      const a = await createEnabled('geo-enter', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.geofence', params: { event: 'enter', lat: 0, lon: 0, radiusKm: 5, cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 'n', type: 'action.notify', params: { body: 'entered' } },
+        ],
+        edges: [{ from: 't', to: 'n' }],
+      });
+      const pos = { lat: 1, lon: 0 }; // outside
+      const geoData = { getNode: async () => ({ nodeNum: 5, latitude: pos.lat, longitude: pos.lon }), getTelemetry: async () => null };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps: recorder().deps, data: geoData, now: () => clock });
+      await engine.load();
+      automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+      await engine.checkGeofences(5, 'default'); // baseline (outside)
+      pos.lat = 0.01; // move inside
+      await engine.checkGeofences(5, 'default'); // enter → fires, marks node 5
+      pos.lat = 1; // move outside (mode is 'enter'; not a fire, just updates state)
+      await engine.checkGeofences(5, 'default');
+      pos.lat = 0.01; // move inside again — same cooldown window
+      await engine.checkGeofences(5, 'default');
+
+      const cooldownEvent = got.find((g) => g.outcome === 'cooldown');
+      expect(cooldownEvent).toBeDefined();
+      expect(cooldownEvent.reason).toMatch(/cooldown active/);
+      expect(cooldownEvent.reason).toMatch(/node 5/);
+    });
+
+    it('(g1) MeshCore: two DMs from different pubkeys under node scope both fire', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('mc-ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 's', type: 'action.sendMessage', params: { text: 'pong' } },
+        ],
+        edges: [{ from: 't', to: 's' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'nodeA', text: 'ping' }), 'default')).toBe(1);
+      clock += 5_000;
+      expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'nodeB', text: 'ping' }), 'default')).toBe(1);
+      clock += 5_000;
+      expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'nodeA', text: 'ping' }), 'default')).toBe(0); // still cooling
+      expect(calls).toHaveLength(2);
+    });
+
+    it('(g2) MeshCore: two channel messages under node scope degrade to automation-wide — second suppressed', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('mc-ping-ch', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 's', type: 'action.sendMessage', params: { text: 'pong' } },
+        ],
+        edges: [{ from: 't', to: 's' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      // Both on channel slot 0 — fromPublicKey is the synthetic 'channel-0' key,
+      // which subjectKeyOf() never uses, so both events share the degraded
+      // automation-wide key even though they'd naively look like two "senders".
+      expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'channel-0', text: 'ping' }), 'default')).toBe(1);
+      clock += 5_000;
+      expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'channel-0', text: 'ping' }), 'default')).toBe(0);
+      expect(calls).toHaveLength(1);
+    });
+
+    it('(h) cooldownSeconds: 0 with cooldownScope: node fires on every event', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 0, cooldownScope: 'node' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1);
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1);
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1);
+      expect(calls).toHaveLength(3);
+    });
+
+    it('(i) eviction: a node inside its window stays suppressed after driving the key set past its bound', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 1, cooldownScope: 'node' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      // node 999999 fires and starts its 1s cooldown window.
+      expect(await engine.onMessage(message({ fromNodeNum: 999_999 }), 'default')).toBe(1);
+      // Drive > COOLDOWN_KEYS_MAX (4096) distinct senders through, one per ms —
+      // well inside node 999999's 1s window for the earliest ones, well past it
+      // for the bulk, exercising both the exact-expiry prune and the hard trim.
+      for (let i = 0; i < 4200; i++) {
+        clock += 1;
+        await engine.onMessage(message({ fromNodeNum: 1_000_000 + i }), 'default');
+      }
+      // node 999999 is now WAY past its 1s window — it must fire again (behaviour,
+      // not map size, is what eviction must preserve).
+      expect(await engine.onMessage(message({ fromNodeNum: 999_999 }), 'default')).toBe(1);
+
+      // Re-verify the suppression half of the contract still holds post-eviction:
+      // a fresh node fires once, then is suppressed inside its own window.
+      const freshCalls = calls.length;
+      expect(await engine.onMessage(message({ fromNodeNum: 2_000_000 }), 'default')).toBe(1);
+      expect(await engine.onMessage(message({ fromNodeNum: 2_000_000 }), 'default')).toBe(0);
+      expect(calls.length).toBe(freshCalls + 1);
+    });
+
+    it('(j) load-prune: disabling and re-enabling inside the cooldown window lets it fire immediately', async () => {
+      const { calls, deps } = recorder();
+      const a = await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node' } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // fires, marks node 111
+      await autos.setEnabled(a.id, false);
+      await engine.load(); // automation drops out of the index → its cooldown state is pruned
+      await autos.setEnabled(a.id, true);
+      await engine.load(); // re-enabled with a clean slate
+
+      clock += 5_000; // still well inside the original 60s window
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // fires immediately
+      expect(calls).toHaveLength(2);
+    });
+  });
+
   it('welcome-once anti-spam via a per-node flag', async () => {
     const { calls, deps } = recorder();
     await varsRepo.createVariable({ name: 'welcomed', type: 'flag', scope: 'node' });

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -2,9 +2,10 @@
  * Automation Engine service (#3653, §4) — the runtime orchestrator.
  *
  * Loads enabled automations, indexes them by trigger type, and on each mesh event
- * builds the trigger context, fast-fails on the trigger pre-filter, enforces a
- * per-automation cooldown, evaluates the graph (condition routing / collapse /
- * fanout / actions / setVar), and writes a run-log row.
+ * builds the trigger context, fast-fails on the trigger pre-filter, enforces the
+ * trigger's cooldown at its configured scope (automation / node / source+node),
+ * evaluates the graph (condition routing / collapse / fanout / actions / setVar),
+ * and writes a run-log row.
  *
  * Phase 1a is synchronous: every run completes to `completed`/`failed`; the
  * `waiting` status and flow.delay arrive in 1b. Mesh IO is injected via ActionDeps
@@ -16,9 +17,11 @@ import type { AutomationsRepository } from '../../../db/repositories/automations
 import {
   validateAutomationGraph,
   categoryOf,
+  parseCooldownScope,
   type AutomationGraph,
   type AutomationNode,
   type TriggerType,
+  type CooldownScope,
 } from '../../../types/automation.js';
 import { VariableResolver } from './variableResolver.js';
 import {
@@ -49,6 +52,7 @@ import {
   type NodeDataProvider,
   varContextFromTrigger,
   resolveOperand,
+  cooldownKeyFor,
 } from './engineContext.js';
 
 interface LoadedAutomation {
@@ -58,7 +62,33 @@ interface LoadedAutomation {
   triggerNode: AutomationNode;
   triggerType: TriggerType;
   cooldownSeconds: number;
+  cooldownScope: CooldownScope;
 }
+
+/**
+ * Per-automation cooldown-key bounds (#4340 Phase 2). Under 'automation' scope
+ * an automation holds exactly ONE key, as before. Under 'node'/'sourceNode' it
+ * holds one per distinct subject — on a large mesh with MQTT sources that is
+ * thousands, so it must be bounded.
+ *
+ * Shape copied from meshtasticManager's autoAckProcessedPackets high-water trim
+ * (`> 1000 → keep last 500`, :9992): prune only when a high watermark is passed,
+ * and always bring the size well under it, so pruning is amortised O(1) per fire.
+ *
+ * Refined with an EXACT first pass: unlike a packet-dedup set, a cooldown entry
+ * has a provable expiry — once `now - ts >= cooldownSeconds*1000` it can never
+ * suppress anything, so deleting it is behaviour-neutral. The hard trim below is
+ * only a backstop for the pathological case of >TRIM_TO distinct subjects firing
+ * inside a single cooldown window.
+ *
+ * Deliberately NOT modelled on meshtasticManager's autoAckCooldowns
+ * (Map<nodeNum, ms>, :825) — that map is never evicted at all. It gets away with
+ * it because it is per-manager and bounded in practice by one radio's NodeDB;
+ * the engine's is per (automation × node) across EVERY source including MQTT
+ * firehoses, so the same choice would be a real leak here.
+ */
+const COOLDOWN_KEYS_MAX = 4096;
+const COOLDOWN_KEYS_TRIM_TO = 2048;
 
 /** Compact result of evaluating one automation — persisted run-log shape is unchanged;
  *  this is the subset the live trace ("view logs") streams to the browser. */
@@ -116,8 +146,8 @@ export class AutomationEngineService {
 
   /** triggerType → loaded automations. */
   private index = new Map<TriggerType, LoadedAutomation[]>();
-  /** automationId → last fired ms (cooldown). */
-  private lastFired = new Map<string, number>();
+  /** automationId → cooldown key → last fired ms. Inner key shape: cooldownKeyFor(). */
+  private lastFired = new Map<string, Map<string, number>>();
   /** `${automationId}:${nodeNum}` → was the node inside the geofence last check. */
   private geofenceState = new Map<string, boolean>();
   /** automationId → live cron job, for `trigger.schedule` automations. */
@@ -154,13 +184,25 @@ export class AutomationEngineService {
       if (!triggerNode) continue;
       const triggerType = triggerNode.type as TriggerType;
       const cooldownSeconds = Number((triggerNode.params as any)?.cooldownSeconds ?? 0) || 0;
+      const cooldownScope = parseCooldownScope((triggerNode.params as any)?.cooldownScope);
       const entry: LoadedAutomation = {
-        id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds,
+        id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds, cooldownScope,
       };
       if (!index.has(triggerType)) index.set(triggerType, []);
       index.get(triggerType)!.push(entry);
     }
     this.index = index;
+    // Drop cooldown state for automations that are no longer loaded (deleted or
+    // disabled). They are unreachable — runTrigger/onSchedule/checkGeofences only
+    // iterate `this.index` — so this is unobservable while they stay out of the
+    // index. One observable edge, accepted: disabling and re-enabling a rule inside
+    // its own cooldown window now lets it fire immediately instead of waiting out
+    // the remainder. Erring toward firing is the safe direction, and without this a
+    // deleted node-scoped automation would strand up to COOLDOWN_KEYS_MAX entries
+    // forever.
+    const liveIds = new Set<string>();
+    for (const list of index.values()) for (const a of list) liveIds.add(a.id);
+    for (const id of this.lastFired.keys()) if (!liveIds.has(id)) this.lastFired.delete(id);
     this.rescheduleCron();
     logger.info(`[AutomationEngine] loaded ${rows.length} enabled automation(s)`);
   }
@@ -202,14 +244,12 @@ export class AutomationEngineService {
     const now = this.now();
     const ctx = buildScheduleContext(null, now);
     const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
-    if (!this.cooledDown(a, now)) {
-      if (traced) {
-        const remainingMs = Math.max(0, a.cooldownSeconds * 1000 - (now - (this.lastFired.get(a.id) ?? 0)));
-        this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining` });
-      }
+    const gate = this.cooldownGate(a, ctx, now);
+    if (!gate.ok) {
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
       return 0;
     }
-    this.lastFired.set(a.id, now);
+    this.markFired(a, gate.key, now);
     const fr = await this.fireAutomation(a, ctx, now);
     if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
     return 1;
@@ -246,10 +286,53 @@ export class AutomationEngineService {
     if (!r.ok) throw new Error(r.error);
   }
 
-  private cooledDown(a: LoadedAutomation, now: number): boolean {
-    if (a.cooldownSeconds <= 0) return true;
-    const last = this.lastFired.get(a.id);
-    return last == null || now - last >= a.cooldownSeconds * 1000;
+  /**
+   * Cooldown verdict for one automation against one event. Returns the key to
+   * stamp on success, or the trace reason on suppression.
+   *
+   * This is the ONLY place the cooldown window is evaluated. The three call sites
+   * (message/node/telemetry/system dispatch, schedule dispatch, geofence) must all
+   * route through it — a scope fix applied to only one of them is the exact bug
+   * this phase exists to prevent.
+   */
+  private cooldownGate(
+    a: LoadedAutomation,
+    ctx: TriggerContext,
+    now: number,
+  ): { ok: true; key: string } | { ok: false; reason: string } {
+    if (a.cooldownSeconds <= 0) return { ok: true, key: '' };
+    const { key, label } = cooldownKeyFor(a.cooldownScope, ctx);
+    const last = this.lastFired.get(a.id)?.get(key);
+    const windowMs = a.cooldownSeconds * 1000;
+    if (last == null || now - last >= windowMs) return { ok: true, key };
+    const remainingMs = Math.max(0, windowMs - (now - last));
+    return { ok: false, reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining (${label})` };
+  }
+
+  /** Stamp a fire against its cooldown key, bounding the per-automation key set. */
+  private markFired(a: LoadedAutomation, key: string, now: number): void {
+    // No cooldown ⇒ nothing can ever be suppressed ⇒ never grow the map. (Today
+    // the timestamp is written unconditionally, but it is only ever READ inside
+    // the `cooldownSeconds > 0` branch, so skipping it is unobservable and keeps
+    // memory at zero for the overwhelmingly common cooldown-less automation.)
+    if (a.cooldownSeconds <= 0) return;
+    let inner = this.lastFired.get(a.id);
+    if (!inner) { inner = new Map(); this.lastFired.set(a.id, inner); }
+    inner.set(key, now);
+    if (inner.size > COOLDOWN_KEYS_MAX) this.pruneCooldownKeys(a, inner, now);
+  }
+
+  private pruneCooldownKeys(a: LoadedAutomation, inner: Map<string, number>, now: number): void {
+    const windowMs = a.cooldownSeconds * 1000;
+    // Exact pass: an entry older than the window can no longer suppress anything.
+    for (const [k, ts] of inner) if (now - ts >= windowMs) inner.delete(k);
+    if (inner.size <= COOLDOWN_KEYS_TRIM_TO) return;
+    // Backstop: more than COOLDOWN_KEYS_TRIM_TO distinct subjects fired inside one
+    // window. Drop the oldest — they expire soonest — accepting that those few
+    // subjects may fire once early rather than growing without bound.
+    const byAge = [...inner.entries()].sort((x, y) => x[1] - y[1]);
+    for (let i = 0; i < byAge.length - COOLDOWN_KEYS_TRIM_TO; i++) inner.delete(byAge[i][0]);
+    logger.debug(`[AutomationEngine] "${a.name}" cooldown keys trimmed to ${inner.size} (scope=${a.cooldownScope})`);
   }
 
   /**
@@ -275,14 +358,12 @@ export class AutomationEngineService {
         if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: describeMiss?.(a) ?? 'did not match the trigger filter' });
         continue;
       }
-      if (!this.cooledDown(a, now)) {
-        if (traced) {
-          const remainingMs = Math.max(0, a.cooldownSeconds * 1000 - (now - (this.lastFired.get(a.id) ?? 0)));
-          this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining` });
-        }
+      const gate = this.cooldownGate(a, ctx, now);
+      if (!gate.ok) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
         continue;
       }
-      this.lastFired.set(a.id, now);
+      this.markFired(a, gate.key, now);
       fired++;
       const fr = await this.fireAutomation(a, ctx, now);
       if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
@@ -522,14 +603,12 @@ export class AutomationEngineService {
         if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'prefiltered', reason: prev === undefined ? 'first sighting — baseline only' : `no ${mode} transition (node ${inside ? 'inside' : 'outside'})` });
         continue;
       }
-      if (!this.cooledDown(a, now)) {
-        if (traced) {
-          const remainingMs = Math.max(0, a.cooldownSeconds * 1000 - (now - (this.lastFired.get(a.id) ?? 0)));
-          this.emitTrace(a, geoCtx, now, { outcome: 'cooldown', reason: `cooldown active — ${Math.ceil(remainingMs / 1000)}s remaining` });
-        }
+      const gate = this.cooldownGate(a, geoCtx, now);
+      if (!gate.ok) {
+        if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'cooldown', reason: gate.reason });
         continue;
       }
-      this.lastFired.set(a.id, now);
+      this.markFired(a, gate.key, now);
       fired++;
       const fr = await this.fireAutomation(a, geoCtx, now);
       if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -184,7 +184,9 @@ export class AutomationEngineService {
       if (!triggerNode) continue;
       const triggerType = triggerNode.type as TriggerType;
       const cooldownSeconds = Number((triggerNode.params as any)?.cooldownSeconds ?? 0) || 0;
-      const cooldownScope = parseCooldownScope((triggerNode.params as any)?.cooldownScope);
+      // No `as any` needed: params is Record<string, unknown> and parseCooldownScope
+      // takes unknown. (The cooldownSeconds line above predates the lint ratchet.)
+      const cooldownScope = parseCooldownScope(triggerNode.params?.cooldownScope);
       const entry: LoadedAutomation = {
         id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds, cooldownScope,
       };

--- a/src/server/services/automation/automationSimulator.test.ts
+++ b/src/server/services/automation/automationSimulator.test.ts
@@ -38,6 +38,28 @@ describe('simulateAutomation', () => {
     expect((r.actions[0].resolvedParams as any).replyId).toBe(42); // reply to triggering packet
   });
 
+  // #4340 Phase 2: the simulator has no lastFired map and never gates on
+  // cooldownScope — a dry-run must always show the operator what WOULD happen,
+  // regardless of the rule's real-world cooldown state. Pinned so nobody adds
+  // cooldown modelling to the tester later without a deliberate decision.
+  it('cooldownScope is a no-op in the simulator: the same subject fires on every dry-run', async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node' } },
+        { id: 'a', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const opts = { graph, varsRepo, event: { kind: 'message' as const, text: 'ping', from: 111 }, now: 1_000_000 };
+    const first = await simulateAutomation(opts);
+    const second = await simulateAutomation(opts); // same subject, same `now` — still fires
+    expect(first.matched).toBe(true);
+    expect(first.actions).toHaveLength(1);
+    expect(second.matched).toBe(true);
+    expect(second.actions).toHaveLength(1);
+  });
+
   it('false branch is not taken (condition routes correctly)', async () => {
     const graph: AutomationGraph = {
       version: 1,

--- a/src/server/services/automation/engineContext.test.ts
+++ b/src/server/services/automation/engineContext.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { cooldownKeyFor, varContextFromTrigger, type CooldownKeyResolution } from './engineContext.js';
+import type { TriggerContext } from './triggerContext.js';
+import { AutomationVariablesRepository } from '../../../db/repositories/automationVariables.js';
+
+/** Minimal TriggerContext builder for cooldownKeyFor truth-table tests. */
+function ctx(over: Partial<TriggerContext> = {}): TriggerContext {
+  return {
+    triggerType: 'trigger.message',
+    sourceId: 'src-1',
+    subjectNodeNum: 111,
+    timestamp: 1000,
+    fields: {},
+    ...over,
+  };
+}
+
+const LONG_PUBKEY = 'a'.repeat(64);
+
+describe('cooldownKeyFor (#4340 Phase 2)', () => {
+  describe('scope: automation', () => {
+    it('is always the automation-wide key, regardless of subject', () => {
+      const r = cooldownKeyFor('automation', ctx());
+      expect(r).toEqual<CooldownKeyResolution>({ key: '', label: 'automation-wide', degraded: false });
+    });
+
+    it('is automation-wide even with no subject at all', () => {
+      const r = cooldownKeyFor('automation', ctx({ subjectNodeNum: null }));
+      expect(r.key).toBe('');
+      expect(r.degraded).toBe(false);
+    });
+  });
+
+  describe('scope: node', () => {
+    it('keys by the Meshtastic subject node number', () => {
+      const r = cooldownKeyFor('node', ctx({ subjectNodeNum: 111 }));
+      expect(r.key).toBe('111');
+      expect(r.label).toContain('node 111');
+      expect(r.degraded).toBe(false);
+    });
+
+    it('keys by an explicit MeshCore subject pubkey', () => {
+      const r = cooldownKeyFor('node', ctx({ subjectNodeNum: null, subjectNodeKey: 'aabbccdd' }));
+      expect(r.key).toBe('aabbccdd');
+      expect(r.label).toContain('node aabbccdd');
+      expect(r.degraded).toBe(false);
+    });
+
+    it('degrades to automation-wide when there is no subject (schedule/system/MeshCore-channel)', () => {
+      const r = cooldownKeyFor('node', ctx({ subjectNodeNum: null }));
+      expect(r.key).toBe('');
+      expect(r.label).toContain('automation-wide');
+      expect(r.degraded).toBe(true);
+    });
+
+    it('a long pubkey label truncates to 12 chars + ellipsis, but the KEY stays full-length', () => {
+      const r = cooldownKeyFor('node', ctx({ subjectNodeNum: null, subjectNodeKey: LONG_PUBKEY }));
+      expect(r.key).toBe(LONG_PUBKEY);
+      expect(r.key.length).toBe(64);
+      expect(r.label).toContain(`${LONG_PUBKEY.slice(0, 12)}…`);
+      expect(r.label).not.toContain(LONG_PUBKEY);
+    });
+  });
+
+  describe('scope: sourceNode', () => {
+    it('keys by source + Meshtastic node number', () => {
+      const r = cooldownKeyFor('sourceNode', ctx({ sourceId: 'src-1', subjectNodeNum: 111 }));
+      expect(r.key).toBe('src-1:111');
+      expect(r.label).toContain('src-1');
+      expect(r.degraded).toBe(false);
+    });
+
+    it('keys by source + MeshCore pubkey', () => {
+      const r = cooldownKeyFor('sourceNode', ctx({ sourceId: 'src-1', subjectNodeNum: null, subjectNodeKey: 'aabbccdd' }));
+      expect(r.key).toBe('src-1:aabbccdd');
+      expect(r.degraded).toBe(false);
+    });
+
+    it('degrades to automation-wide when there is no subject', () => {
+      const r = cooldownKeyFor('sourceNode', ctx({ subjectNodeNum: null }));
+      expect(r.key).toBe('');
+      expect(r.degraded).toBe(true);
+    });
+
+    it('degrades to automation-wide when there is no sourceId', () => {
+      const r = cooldownKeyFor('sourceNode', ctx({ sourceId: null, subjectNodeNum: 111 }));
+      expect(r.key).toBe('');
+      expect(r.label).toContain('automation-wide');
+      expect(r.degraded).toBe(true);
+    });
+  });
+
+  // Key-shape source of truth (spec §1, §2.4): cooldown keys must read identically
+  // to AutomationVariablesRepository.buildScopeKey's node/sourceNode shapes.
+  describe('cross-check against AutomationVariablesRepository.buildScopeKey', () => {
+    it('node scope matches buildScopeKey("node", varContextFromTrigger(ctx))', () => {
+      const c = ctx({ sourceId: 'src-1', subjectNodeNum: 111 });
+      const expected = AutomationVariablesRepository.buildScopeKey('node', varContextFromTrigger(c));
+      expect(cooldownKeyFor('node', c).key).toBe(expected);
+    });
+
+    it('sourceNode scope matches buildScopeKey("sourceNode", varContextFromTrigger(ctx))', () => {
+      const c = ctx({ sourceId: 'src-1', subjectNodeNum: 111 });
+      const expected = AutomationVariablesRepository.buildScopeKey('sourceNode', varContextFromTrigger(c));
+      expect(cooldownKeyFor('sourceNode', c).key).toBe(expected);
+    });
+  });
+});

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -10,9 +10,10 @@
  * `node.*` (hydrated subject node incl. calculated `ageMinutes`/`roleName`), and
  * `telemetry.*` (latest reading per metric for the subject node).
  */
-import { type TriggerContext, resolveTriggerPath } from './triggerContext.js';
+import { type TriggerContext, resolveTriggerPath, subjectKeyOf } from './triggerContext.js';
 import type { VariableResolver, VarContext } from './variableResolver.js';
 import { interpolate, extractPaths, type InterpolationValue } from './interpolate.js';
+import type { CooldownScope } from '../../../types/automation.js';
 
 /** Subset of a node record used for condition fields. */
 export interface NodeFacts {
@@ -86,6 +87,49 @@ export const ROLE_NAMES = [
 
 export function varContextFromTrigger(trigger: TriggerContext): VarContext {
   return { sourceId: trigger.sourceId, nodeNum: trigger.subjectNodeNum };
+}
+
+/** Truncate a long subject id (a 64-char MeshCore pubkey) for trace/log copy. */
+function shortSubject(id: string): string {
+  return id.length > 16 ? `${id.slice(0, 12)}…` : id;
+}
+
+export interface CooldownKeyResolution {
+  /** Map key. '' is the automation-wide key (also the degraded fallback). */
+  key: string;
+  /** Human phrase naming the key, for the cooldown trace reason. */
+  label: string;
+  /** True when the requested scope could not be honoured and we fell back. */
+  degraded: boolean;
+}
+
+/**
+ * Resolve a trigger context to its cooldown key under `scope` (#4340 Phase 2).
+ *
+ * Key shapes intentionally match AutomationVariablesRepository.buildScopeKey's
+ * global/node/sourceNode shapes ('' / '<node>' / '<source>:<node>') — pinned by
+ * a cross-check test — so cooldown keys and variable scope keys read alike.
+ * It is NOT called directly: buildScopeKey's ctx.nodeNum is typed `number` and
+ * widening it to accept a MeshCore pubkey string would silently let VARIABLE
+ * scoping key off pubkeys too, a behaviour change we explicitly do not want.
+ *
+ * When the requested scope cannot be honoured (no subject node on a schedule /
+ * system / MeshCore-channel event, or no sourceId under 'sourceNode'), this
+ * degrades to the automation-wide key — today's exact behaviour — rather than
+ * never firing or never cooling down. See COOLDOWN_SCOPES for why.
+ */
+export function cooldownKeyFor(scope: CooldownScope, trigger: TriggerContext): CooldownKeyResolution {
+  if (scope === 'automation') return { key: '', label: 'automation-wide', degraded: false };
+  const node = subjectKeyOf(trigger);
+  if (node == null) {
+    return { key: '', label: 'automation-wide (this event has no subject node)', degraded: true };
+  }
+  if (scope === 'node') return { key: node, label: `node ${shortSubject(node)}`, degraded: false };
+  const src = trigger.sourceId;
+  if (!src) {
+    return { key: '', label: 'automation-wide (this event has no source)', degraded: true };
+  }
+  return { key: `${src}:${node}`, label: `source ${src} · node ${shortSubject(node)}`, degraded: false };
 }
 
 /** Hydrate (once) the trigger's subject node. Null when there is no subject node. */

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -6,6 +6,7 @@ import {
   buildTelemetryContext,
   buildSystemContext,
   buildScheduleContext,
+  buildGeofenceContext,
   deriveHops,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
@@ -14,7 +15,9 @@ import {
   messageFilterChannelNames,
   messageFilterUsesChannelName,
   resolveTriggerPath,
+  subjectKeyOf,
   BROADCAST_ADDR,
+  type TriggerContext,
 } from './triggerContext.js';
 import type { DbMessage } from '../../../services/database.js';
 import type { MeshCoreMessage } from '../../meshcoreManager.js';
@@ -153,6 +156,48 @@ describe('other trigger contexts', () => {
     expect(ctx.triggerType).toBe('trigger.schedule');
     expect(ctx.subjectNodeNum).toBeNull();
     expect(ctx.fields.timestamp).toBe(1234);
+  });
+
+  // #4340 Phase 2: every Meshtastic-side builder leaves subjectNodeKey undefined
+  // — subjectKeyOf() then derives it from subjectNodeNum.
+  it('every Meshtastic builder leaves subjectNodeKey undefined', () => {
+    expect(buildMessageContext(msg(), 'default', 1).subjectNodeKey).toBeUndefined();
+    expect(buildNodeContext('trigger.nodeUpdated', 999, [], 'default', 5).subjectNodeKey).toBeUndefined();
+    expect(buildTelemetryContext(7, 'batteryLevel', 18, '%', 'default', 5).subjectNodeKey).toBeUndefined();
+    expect(buildSystemContext('bootup', null, null, undefined, 5).subjectNodeKey).toBeUndefined();
+    expect(buildScheduleContext(null, 1234).subjectNodeKey).toBeUndefined();
+    expect(buildGeofenceContext(5, 'enter', 0, 0, 1, 'default', 5).subjectNodeKey).toBeUndefined();
+  });
+});
+
+describe('subjectKeyOf (#4340 Phase 2)', () => {
+  it('derives from subjectNodeNum for a Meshtastic message context', () => {
+    const ctx = buildMessageContext(msg(), 'default', 1234);
+    expect(subjectKeyOf(ctx)).toBe('111');
+  });
+
+  it('is null for a schedule context (no subject node)', () => {
+    const ctx = buildScheduleContext(null, 1234);
+    expect(subjectKeyOf(ctx)).toBeNull();
+  });
+
+  it('is the stringified nodeNum for a system context that carries one, null otherwise', () => {
+    const withNode = buildSystemContext('source-connected', 'default', 42, undefined, 5);
+    expect(subjectKeyOf(withNode)).toBe('42');
+    const withoutNode = buildSystemContext('bootup', null, null, undefined, 5);
+    expect(subjectKeyOf(withoutNode)).toBeNull();
+  });
+
+  it('an explicit subjectNodeKey: null wins over a non-null subjectNodeNum', () => {
+    const ctx: TriggerContext = {
+      triggerType: 'trigger.message',
+      sourceId: 'default',
+      subjectNodeNum: 111,
+      subjectNodeKey: null,
+      timestamp: 1,
+      fields: {},
+    };
+    expect(subjectKeyOf(ctx)).toBeNull();
   });
 });
 
@@ -296,6 +341,9 @@ describe('buildMeshCoreMessageContext (#3833)', () => {
     );
     expect(ctx.triggerType).toBe('trigger.message');
     expect(ctx.subjectNodeNum).toBeNull();
+    // #4340 Phase 2: a channel post's fromPublicKey is the synthetic channel-<idx>
+    // slot key SHARED by every sender — cooldown must degrade, not key off it.
+    expect(ctx.subjectNodeKey).toBeNull();
     expect(ctx.fields.channel).toBe(3);
     expect(ctx.fields.isBroadcast).toBe(true);
     expect(ctx.fields.isDM).toBe(false);
@@ -326,6 +374,8 @@ describe('buildMeshCoreMessageContext (#3833)', () => {
     expect(ctx.fields.from).toBe('aabbcc');
     // scopeCode 0 = explicitly unscoped → not "scoped"
     expect(ctx.fields.scoped).toBe(false);
+    // #4340 Phase 2: a DM carries the real sender pubkey as its cooldown key.
+    expect(ctx.subjectNodeKey).toBe('aabbcc');
   });
 
   it('a room post is neither DM nor broadcast and has no channel', () => {
@@ -337,6 +387,8 @@ describe('buildMeshCoreMessageContext (#3833)', () => {
     expect(ctx.fields.channel).toBeUndefined();
     expect(ctx.fields.isDM).toBe(false);
     expect(ctx.fields.isBroadcast).toBe(false);
+    // #4340 Phase 2: a room post's author pubkey is a real per-sender identity.
+    expect(ctx.subjectNodeKey).toBe('authorkey');
   });
 
   // Universal cross-protocol tokens (#3978)

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -20,9 +20,32 @@ export interface TriggerContext {
   sourceId: string | null;
   /** Subject node for node/sourceNode variable scope binding (sender / telemetry / updated node). */
   subjectNodeNum: number | null;
+  /**
+   * Protocol-agnostic subject identity, for cooldown scoping (#4340 Phase 2).
+   *
+   * `undefined` (the default, and what every Meshtastic builder leaves it as)
+   * means "derive it from subjectNodeNum". Set EXPLICITLY only where the
+   * subject has an identity that is not a Meshtastic node number — today that
+   * is only MeshCore, whose senders are pubkey strings. An explicit `null`
+   * means "this event has no stable per-subject identity at all".
+   *
+   * Deliberately NOT reused for variable scoping or node hydration: both call
+   * getNode(sourceId, nodeNum) / buildScopeKey with a NUMBER and must keep
+   * doing so. This field is cooldown-only.
+   */
+  subjectNodeKey?: string | null;
   timestamp: number;
   /** `trigger.*` values, keyed WITHOUT the `trigger.` prefix. */
   fields: Record<string, unknown>;
+}
+
+/**
+ * The subject's cooldown identity, or null when the event has none.
+ * Explicit `subjectNodeKey` wins; otherwise derive from `subjectNodeNum`.
+ */
+export function subjectKeyOf(ctx: TriggerContext): string | null {
+  if (ctx.subjectNodeKey !== undefined) return ctx.subjectNodeKey;
+  return ctx.subjectNodeNum == null ? null : String(ctx.subjectNodeNum);
 }
 
 /** Derived hop count: hopStart − hopLimit when both present (0 ⇒ direct/zero-hop). */
@@ -189,6 +212,15 @@ export function buildMeshCoreMessageContext(
     sourceId,
     // No Meshtastic-style numeric node → no node.* hydration for MeshCore messages.
     subjectNodeNum: null,
+    // #4340 Phase 2: MeshCore has no node numbers, so per-node cooldown keys off
+    // the sender pubkey instead — the same identity meshcoreManager's own auto-ack
+    // cooldown uses (meshcoreManager.ts:6909). A DM/room post carries the real
+    // sender key. A CHANNEL post does not: `fromPublicKey` is the synthetic
+    // `channel-<idx>` slot key SHARED by every sender on that channel (see
+    // parseMeshCoreChannelIdx above), so keying by it would look per-node while
+    // actually being per-channel. Null there, which degrades to the automation-wide
+    // key rather than lying.
+    subjectNodeKey: isChannel ? null : (msg.fromPublicKey ?? null),
     timestamp,
     fields,
   };

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   validateAutomationGraph,
   categoryOf,
+  parseCooldownScope,
   AUTOMATION_CONFIG_VERSION,
   type AutomationGraph,
 } from './automation.js';
@@ -119,6 +120,44 @@ describe('validateAutomationGraph', () => {
     const bad = validateAutomationGraph(withTapback({ emojiMode: 'random' }));
     expect(bad.valid).toBe(false);
     expect(bad.errors.join(' ')).toMatch(/emojiMode ∈ \{fixed,hopCount\}/);
+  });
+
+  // ── trigger.* cooldownScope (#4340 Phase 2) ─────────────────────────────
+  it('trigger.message: cooldownScope validates when present, and absence still validates', () => {
+    const withTrigger = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params },
+        { id: 'a', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    // absent → valid (pre-Phase-2 stored automations keep validating unchanged)
+    expect(validateAutomationGraph(withTrigger({})).valid).toBe(true);
+    expect(validateAutomationGraph(withTrigger({ textContains: 'ping' })).valid).toBe(true);
+    // valid scopes
+    expect(validateAutomationGraph(withTrigger({ cooldownScope: 'automation' })).valid).toBe(true);
+    expect(validateAutomationGraph(withTrigger({ cooldownScope: 'node' })).valid).toBe(true);
+    expect(validateAutomationGraph(withTrigger({ cooldownScope: 'sourceNode' })).valid).toBe(true);
+    // invalid scope → error
+    const bad = validateAutomationGraph(withTrigger({ cooldownScope: 'perNode' }));
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.join(' ')).toMatch(/cooldownScope ∈ \{automation,node,sourceNode\}/);
+  });
+
+  it('cooldownScope guard applies to every trigger type, not just trigger.message', () => {
+    const withTelemetryTrigger = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.telemetry', params },
+        { id: 'a', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    expect(validateAutomationGraph(withTelemetryTrigger({ cooldownScope: 'node' })).valid).toBe(true);
+    const bad = validateAutomationGraph(withTelemetryTrigger({ cooldownScope: 'bogus' }));
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.join(' ')).toMatch(/trigger\.telemetry .* requires params\.cooldownScope ∈ \{automation,node,sourceNode\}/);
   });
 
   it('rejects non-object config', () => {
@@ -247,5 +286,21 @@ describe('validateAutomationGraph', () => {
       ],
       edges: [{ from: 't', to: 'v' }, { from: 'v', to: 'a' }],
     })).errors.join()).toMatch(/requires params.variable/);
+  });
+});
+
+describe('parseCooldownScope', () => {
+  it('round-trips each valid value', () => {
+    expect(parseCooldownScope('automation')).toBe('automation');
+    expect(parseCooldownScope('node')).toBe('node');
+    expect(parseCooldownScope('sourceNode')).toBe('sourceNode');
+  });
+
+  it('coerces absent/blank/unrecognised values to "automation"', () => {
+    expect(parseCooldownScope(undefined)).toBe('automation');
+    expect(parseCooldownScope(null)).toBe('automation');
+    expect(parseCooldownScope('')).toBe('automation');
+    expect(parseCooldownScope('bogus')).toBe('automation');
+    expect(parseCooldownScope(0)).toBe('automation');
   });
 });

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -122,6 +122,35 @@ export type TapbackEmojiMode = 'fixed' | 'hopCount';
 export const TAPBACK_EMOJI_MODES: readonly TapbackEmojiMode[] = ['fixed', 'hopCount'];
 
 /**
+ * What a trigger's `cooldownSeconds` window is keyed by (#4340 Phase 2).
+ *
+ *  - 'automation'  one timer for the whole rule — the pre-4.14 behaviour and
+ *                  what an ABSENT/unrecognised value means. Never change this.
+ *  - 'node'        one timer per subject node (message sender / telemetry or
+ *                  geofence node), so acking one range-tester does not suppress
+ *                  the ack to the next one.
+ *  - 'sourceNode'  one timer per (source, node), so the same physical node heard
+ *                  via two sources cools down independently.
+ *
+ * Key shapes mirror AutomationVariablesRepository.buildScopeKey exactly
+ * ('' / '<node>' / '<source>:<node>') so cooldown keys and variable scope keys
+ * read identically in logs and traces.
+ */
+export const COOLDOWN_SCOPES = ['automation', 'node', 'sourceNode'] as const;
+export type CooldownScope = (typeof COOLDOWN_SCOPES)[number];
+
+/**
+ * Coerce a stored `params.cooldownScope` to a CooldownScope. Absent, blank, or
+ * unrecognised → 'automation'. Deliberately lenient at RUNTIME (graphs written
+ * before validation existed must still run) while validateAutomationGraph
+ * rejects unrecognised values at SAVE time — the same split Phase 1 used for
+ * action.tapback's emojiMode.
+ */
+export function parseCooldownScope(raw: unknown): CooldownScope {
+  return COOLDOWN_SCOPES.includes(raw as CooldownScope) ? (raw as CooldownScope) : 'automation';
+}
+
+/**
  * Match modes for `condition.meshcoreScope` (#3914). A MeshCore text message
  * carries a region "scope" (`scopeCode` 0 = unscoped, >0 = a region; `scopeName`
  * = the resolved region). This condition matches:
@@ -331,6 +360,16 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
   if (errors.length === 0) {
     for (const n of rawNodes as AutomationNode[]) {
       const p = (n.params ?? {}) as Record<string, unknown>;
+      // Cooldown scope (#4340 Phase 2) is a trigger-level param every trigger type
+      // shares, so it is checked once here rather than duplicated into seven cases
+      // (which would silently miss any trigger type added later). Optional:
+      // absent/unset = 'automation', the pre-4.14 behaviour every stored automation
+      // depends on — same contract as action.tapback's emojiMode.
+      if (categoryOf(n.type) === 'trigger'
+          && p.cooldownScope != null
+          && !COOLDOWN_SCOPES.includes(p.cooldownScope as CooldownScope)) {
+        errors.push(`${n.type} "${n.id}" requires params.cooldownScope ∈ {automation,node,sourceNode}`);
+      }
       switch (n.type) {
         case 'flow.collapse':
           if (!COLLAPSE_MODES.includes(p.mode as CollapseMode)) {


### PR DESCRIPTION
## Summary

Phase 2 of the [Auto-Acknowledge on the Automation Engine epic](docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md), following #4390.

The Automation Engine cooled down **per automation**, while Auto-Acknowledge cools down **per node**. On a busy channel that difference is the whole ballgame: answering one range-tester suppressed the answer to everyone else. Phase 1's shipped #4340 recipe had to instruct operators to leave cooldown at `0` because of it. This PR closes that gap and updates the recipe.

## What changed

Triggers gained a **"Cooldown applies to"** select beneath **Cooldown (seconds)**:

- **The whole automation (one shared timer)** — the default, and what an absent setting means. Existing automations are untouched.
- **Each node separately** — one timer per subject node.
- **Each node, per source** — one timer per (source, node), so the same physical node heard via two sources cools down independently.

The cooldown trace now names the key that was cooling down, e.g. `cooldown active — 40s remaining (node 111)`.

## Notable decisions

- **All three cooldown gate sites collapse onto one `cooldownGate()` + `markFired()` pair.** There were three (`onSchedule`, `runTrigger`, `checkGeofences`), each with its own copy of the window arithmetic. A scope fix applied to only one would have been a silent bug, so the design removes the possibility rather than warning about it — enforced by a grep-checkable criterion that no `lastFired.get(a.id)` survives at any dispatch site.
- **MeshCore is half-scopable, and the naive fix is a trap.** `buildMeshCoreMessageContext` sets `subjectNodeNum: null` for *all* MeshCore messages, so keying off the sender field would key a channel automation off the synthetic `channel-<idx>` slot that **every sender on that channel shares** — a per-channel cooldown wearing a per-node label. Instead a new optional `subjectNodeKey` carries the real sender pubkey for **DMs and room posts**, and is `null` for **channel posts**, which degrades honestly. Documented as exactly that asymmetry, not flattened into "MeshCore supported/unsupported".
- **No-subject events degrade to the automation-wide key** rather than never firing or never cooling down. Never-firing would silently break a Schedule automation with no visible cause; never-cooling-down would turn a throttle into a spam faucet. The degraded path is provably identical to today's behaviour, and the trace says so out loud.
- **Bounded memory.** `lastFired` went from one entry per automation to one per (automation, node) — thousands on a large mesh with MQTT sources. Entries are only created when a cooldown is actually set, pruned exactly (an entry older than the window can never suppress anything, so deleting it is behaviour-neutral), with a high-water backstop modelled on `autoAckProcessedPackets`. `load()` also drops state for automations no longer loaded.
- **`showIf` gained one operator, `truthy`.** The Phase 1 mechanism could not express "a number field that is set", since `cooldownSeconds` can be `undefined`, `''` or `0`. One generic operator, not a second mechanism.

## Findings worth flagging

- An invalid `cooldownScope` causes the automation to be **rejected at load** by `validateAutomationGraph`, so `parseCooldownScope`'s runtime leniency is unreachable via that path. The test asserts actual behaviour rather than the spec's original wording.
- The lint ratchet caught a new `no-explicit-any` (6→7) from the scope lookup; fixed by dropping an unnecessary cast, since `params` is already `Record<string, unknown>`.
- **Two pre-existing unbounded maps found, not fixed here:** `geofenceState` has the identical (automation, node) growth shape, and `meshtasticManager.autoAckCooldowns` is never evicted at all. Neither is safe to change inside this diff — `geofenceState` deletion is *not* behaviour-neutral (it resets the enter/exit baseline). Follow-up issues to file.

## Testing

- Full Vitest suite: **11,315 passed, 0 failed, 0 suites failed** (`success: true` via `--reporter=json`).
- Lint ratchet and typecheck clean.
- Every pre-existing cooldown test passes **unmodified**, including the two `/cooldown active/` reason assertions — the reason string keeps its exact prefix and appends the key phrase.
- New: two senders on one channel cool down independently under node scope; absent scope reproduces today's behaviour exactly; all three trace sites name the key; eviction asserted by behaviour rather than private map size; MeshCore DM-vs-channel asymmetry; the simulator is provably cooldown-free.

## Browser validation

| Check | Result |
|---|---|
| Hidden until a cooldown is set | pass |
| Appears on a non-zero cooldown, 3 options, defaults to the whole automation | pass |
| Selecting "Each node separately" persists | pass |
| Hidden again at `0` | pass |
| Value survives the round-trip (hidden ≠ cleared) | pass |
| Console errors | none related (one pre-existing i18n `en-US.json` 404) |

## Next phases

3. Fidelity conditions for Auto-Ack parity (`nodeComplete`, node-in-list, `maxAttempts`).
4. The Auto-Ack → Automation converter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB