### PR TITLE
fix(traceroute): portal the strip hover popup and show the Map node card

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1964,7 +1964,13 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                           // Always renders at default size (#4381 follow-up):
                           // narrow panels are handled by `.scroller`'s
                           // horizontal scroll, not a width heuristic.
-                          <TracerouteStrip graph={stripGraph} meta={stripMeta} />
+                          <TracerouteStrip
+                            graph={stripGraph}
+                            meta={stripMeta}
+                            timeFormat={timeFormat}
+                            dateFormat={dateFormat}
+                            distanceUnit={distanceUnit}
+                          />
                         ) : (
                           <div className="traceroute-route">
                             {t('messages.traceroute_no_response', 'No response received')}

--- a/src/components/traceroute/TracerouteStrip.module.css
+++ b/src/components/traceroute/TracerouteStrip.module.css
@@ -12,7 +12,9 @@
 
 .scroller {
   overflow-x: auto;
-  overflow-y: hidden; /* tooltips live inside the reserved topBand */
+  /* The strip's own content never needs to overflow vertically, and the hover
+   * popup escapes via a portal rather than by being let out of here. */
+  overflow-y: hidden;
   overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
   max-width: 100%;
@@ -114,52 +116,35 @@
   cursor: help;
 }
 
-.tooltip {
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translate(-50%, -100%);
-  min-width: 120px;
-  max-width: 220px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
-  border-radius: 4px;
-  padding: 0.35rem 0.5rem;
-  font-size: 0.75rem;
-  line-height: 1.3;
-  color: var(--ctp-text);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  white-space: normal;
-  text-align: left;
-  z-index: 20;
-  /* Always in the DOM (never `display: none`) so `aria-describedby`
-   * resolves for assistive tech; visibility is purely visual. */
-  opacity: 0;
+/* The hover popup is portalled to `document.body` and positioned in viewport
+ * coordinates by JS. It MUST NOT be a descendant of `.node`: that element
+ * carries a `transform`, which would make it the containing block for a
+ * `position: fixed` child and re-trap the popup inside `.scroller`'s
+ * `overflow: hidden` — the exact clipping this replaced.
+ *
+ * Rendered only while hovered/focused, so there is no always-in-DOM
+ * requirement here; `aria-describedby` is set on the node only while the
+ * popup exists, so the reference never dangles. */
+.hoverPopup {
+  position: fixed;
+  z-index: 10002; /* matches NodePopup's chat overlay */
+  /* Non-interactive by design: the popup is a preview, not a surface to
+   * click into, so it never steals the pointer from the glyph beneath it. */
   pointer-events: none;
-  transition: opacity 0.15s ease;
+  /* Hidden until measured and placed, so the first paint can't flash at the
+   * provisional 0,0 position. */
+  opacity: 0;
+  transition: opacity 0.12s ease;
 }
 
-.node:hover .tooltip,
-.node:focus-visible .tooltip {
+.hoverPopupReady {
   opacity: 1;
-}
-
-.tipLong {
-  font-weight: 600;
-}
-
-.tipRole,
-.tipId {
-  color: var(--ctp-subtext1);
 }
 
 /* Visually-hidden lane caption ("Forward"/"Return") announced ahead of each
  * SNR label's value, for screen-reader users who can't rely on vertical
  * position to distinguish the two lanes. Standard clip-based sr-only
- * pattern — never `display: none` for the same reason as `.tooltip`. */
+ * pattern — never `display: none`, which would drop it from the a11y tree. */
 .srOnly {
   position: absolute;
   width: 1px;

--- a/src/components/traceroute/TracerouteStrip.test.tsx
+++ b/src/components/traceroute/TracerouteStrip.test.tsx
@@ -607,6 +607,67 @@ describe('TracerouteStrip', () => {
     expect(parseFloat(popup.style.left)).toBeGreaterThanOrEqual(0);
   });
 
+  it('clamps against the RIGHT viewport edge too, not just the left', () => {
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node' })],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    const div = nodeDivFor('FRM');
+
+    // Anchor hard against the right edge — a centred popup would overflow.
+    const vw = window.innerWidth;
+    vi.spyOn(div, 'getBoundingClientRect').mockReturnValue({
+      top: 400, bottom: 436, left: vw - 34, right: vw - 2, width: 32, height: 36,
+      x: vw - 34, y: 400, toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(div);
+    const popup = document.querySelector('[role="tooltip"]') as HTMLElement;
+    Object.defineProperty(popup, 'offsetWidth', { value: 240, configurable: true });
+    Object.defineProperty(popup, 'offsetHeight', { value: 100, configurable: true });
+    fireEvent.scroll(window);
+
+    const left = parseFloat(popup.style.left);
+    expect(left + 240).toBeLessThanOrEqual(vw);
+  });
+
+  it('hides when the anchor scrolls out of view rather than following it off-screen', () => {
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node' })],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    const div = nodeDivFor('FRM');
+
+    fireEvent.mouseEnter(div);
+    expect(document.querySelector('[role="tooltip"]')).not.toBeNull();
+
+    // Simulate the panel scrolling the glyph entirely above the viewport.
+    vi.spyOn(div, 'getBoundingClientRect').mockReturnValue({
+      top: -320, bottom: -273, left: 500, right: 532, width: 32, height: 47,
+      x: 500, y: -320, toJSON: () => ({}),
+    } as DOMRect);
+    fireEvent.scroll(window);
+
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+    expect(div.getAttribute('aria-describedby')).toBeNull();
+  });
+
   it('removes its scroll/resize listeners when the popup hides', () => {
     const graph = buildTracerouteStripGraph({
       fromNodeNum: 100,

--- a/src/components/traceroute/TracerouteStrip.test.tsx
+++ b/src/components/traceroute/TracerouteStrip.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { TracerouteStrip, type TracerouteStripNodeMeta } from './TracerouteStrip';
 import { buildTracerouteStripGraph, type TracerouteStripInput } from '../../utils/tracerouteStrip';
 
@@ -38,6 +38,10 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+/** Display formats the strip forwards to `LastHeardFooter`. Spread into every
+ *  render so the tests don't restate them 12 times. */
+const FMT = { timeFormat: '24' as const, dateFormat: 'YYYY-MM-DD' as const };
+
 function makeMeta(opts: {
   nodeNum: number;
   shortName: string;
@@ -45,16 +49,36 @@ function makeMeta(opts: {
   roleLabel?: string | null;
   hops?: number;
   unmessagable?: boolean;
+  hwModelName?: string;
+  snr?: number;
+  battery?: number;
+  lastHeard?: number;
+  pos?: { lat: number; lng: number };
 }): TracerouteStripNodeMeta {
+  const nodeId = `!${opts.nodeNum.toString(16).padStart(8, '0')}`;
   return {
     nodeNum: opts.nodeNum,
     shortName: opts.shortName,
     longName: opts.longName ?? null,
     roleLabel: opts.roleLabel ?? null,
-    nodeId: `!${opts.nodeNum.toString(16).padStart(8, '0')}`,
+    nodeId,
     category: 'mtClient',
     hops: opts.hops ?? 1,
     unmessagable: opts.unmessagable ?? false,
+    card: {
+      longName: opts.longName ?? opts.shortName,
+      shortName: opts.shortName,
+      nodeId,
+      nodeNum: opts.nodeNum,
+      roleName: opts.roleLabel ?? undefined,
+      hwModelName: opts.hwModelName,
+      hops: opts.hops ?? 1,
+      snr: opts.snr,
+      battery: opts.battery,
+      lastHeard: opts.lastHeard,
+      position: opts.pos,
+    },
+    pos: opts.pos,
   };
 }
 
@@ -80,7 +104,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    const { container } = render(<TracerouteStrip graph={graph} meta={meta} />);
+    const { container } = render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
     expect(graph.nodes).toHaveLength(3);
     expect(container.querySelectorAll('[tabindex="0"]')).toHaveLength(3);
   });
@@ -101,7 +125,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    const { container } = render(<TracerouteStrip graph={graph} meta={meta} />);
+    const { container } = render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
     // Full overlap: exactly 3 nodes total, all on row 0.
     expect(graph.nodes).toHaveLength(3);
     expect(graph.nodes.every((n) => n.row === 0)).toBe(true);
@@ -130,7 +154,7 @@ describe('TracerouteStrip', () => {
       [130, makeMeta({ nodeNum: 130, shortName: 'E', longName: 'Node E' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
 
     const branchNode = graph.nodes.find((n) => n.nodeNum === 130);
     expect(branchNode?.row).toBe(2);
@@ -157,7 +181,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
 
     const forwardLabel = screen.getByText('5.0 dB').closest('span');
     const returnLabel = screen.getByText('-10.0 dB').closest('span');
@@ -183,7 +207,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
 
     const chip = screen.getByText('?');
     expect(chip).toHaveAttribute(
@@ -215,7 +239,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    const { container } = render(<TracerouteStrip graph={graph} meta={meta} />);
+    const { container } = render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
     // Exactly one SNR label rendered (the unknown-sentinel one) — the null
     // edge contributes NO element, not an empty one.
     const labelSpans = container.querySelectorAll('span[style*="left"]');
@@ -237,8 +261,8 @@ describe('TracerouteStrip', () => {
 
     render(
       <>
-        <TracerouteStrip graph={graph} meta={meta} />
-        <TracerouteStrip graph={graph} meta={meta} />
+        <TracerouteStrip graph={graph} meta={meta} {...FMT} />
+        <TracerouteStrip graph={graph} meta={meta} {...FMT} />
       </>,
     );
 
@@ -265,7 +289,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node', roleLabel: 'Router' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
 
     const div = nodeDivFor('FRM');
     expect(div).toHaveAttribute('tabindex', '0');
@@ -290,7 +314,7 @@ describe('TracerouteStrip', () => {
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
 
     const div = nodeDivFor('FRM');
     const label = div.getAttribute('aria-label') ?? '';
@@ -299,30 +323,106 @@ describe('TracerouteStrip', () => {
     expect(label).not.toMatch(/,\s*,/);
   });
 
-  it('keeps the tooltip in the DOM (never display:none) and wires it via aria-describedby', () => {
-    const input: TracerouteStripInput = {
+  it('portals the hover popup to document.body, outside the clipping scroller', () => {
+    // The popup MUST NOT live under `.node` — that element carries a
+    // `transform`, which would make it the containing block for a fixed-
+    // position child and re-trap the popup inside `.scroller`'s
+    // `overflow: hidden`. Escaping that clipping is the whole point.
+    const graph = buildTracerouteStripGraph({
       fromNodeNum: 100,
       toNodeNum: 200,
       route: '[]',
       routeBack: null,
-    };
-    const graph = buildTracerouteStripGraph(input);
+    });
     const meta = new Map<number, TracerouteStripNodeMeta>([
       [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node', roleLabel: 'Client' })],
       [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    const { container } = render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+
+    // Nothing rendered until hovered.
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
 
     const div = nodeDivFor('FRM');
+    fireEvent.mouseEnter(div);
+
+    const popup = document.querySelector('[role="tooltip"]');
+    expect(popup).not.toBeNull();
+    // Portalled: present in the document but NOT inside the strip's own tree.
+    expect(container.contains(popup)).toBe(false);
+    expect(popup!.closest('[role="group"]')).toBeNull();
+
+    fireEvent.mouseLeave(div);
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it('wires aria-describedby to the portalled popup only while it is shown', () => {
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node', roleLabel: 'Client' })],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    const div = nodeDivFor('FRM');
+
+    // No dangling reference to a popup that isn't rendered.
+    expect(div.getAttribute('aria-describedby')).toBeNull();
+
+    // Keyboard focus opens it too, not just the mouse.
+    fireEvent.focus(div);
     const tipId = div.getAttribute('aria-describedby');
     expect(tipId).toBeTruthy();
-    const tooltip = document.getElementById(tipId!);
-    expect(tooltip).not.toBeNull();
-    expect(tooltip).toHaveAttribute('role', 'tooltip');
-    expect(tooltip!.style.display).not.toBe('none');
-    expect(tooltip!.textContent).toContain('From Node');
-    expect(tooltip!.textContent).toContain('Client');
+    const popup = document.getElementById(tipId!);
+    expect(popup).not.toBeNull();
+    expect(popup!.getAttribute('role')).toBe('tooltip');
+
+    fireEvent.blur(div);
+    expect(div.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('shows the Map-style card fields (role, hardware, hops, SNR, battery, position)', () => {
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [
+        100,
+        makeMeta({
+          nodeNum: 100,
+          shortName: 'FRM',
+          longName: 'From Node',
+          roleLabel: 'Client (Base)',
+          hwModelName: 'Station G2',
+          hops: 2,
+          snr: 7.25,
+          battery: 64,
+          pos: { lat: 26.30307, lng: -80.21952 },
+        }),
+      ],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    fireEvent.mouseEnter(nodeDivFor('FRM'));
+
+    const popup = document.querySelector('[role="tooltip"]') as HTMLElement;
+    const text = popup.textContent ?? '';
+    expect(text).toContain('From Node');
+    expect(text).toContain('Client (Base)');
+    expect(text).toContain('Station G2');
+    expect(text).toContain('7.3'); // SNR, one decimal
+    expect(text).toContain('64');
+    expect(text).toContain('26.30307');
   });
 
   it('spine model (WP-C): a forward-exclusive node renders above the spine and a return-exclusive node below it', () => {
@@ -354,7 +454,7 @@ describe('TracerouteStrip', () => {
       [BOCA, makeMeta({ nodeNum: BOCA, shortName: 'Boca', longName: 'Node Boca' })],
     ]);
 
-    const { unmount } = render(<TracerouteStrip graph={forwardGraph} meta={forwardMeta} />);
+    const { unmount } = render(<TracerouteStrip graph={forwardGraph} meta={forwardMeta} {...FMT} />);
 
     const csNode = forwardGraph.nodes.find((n) => n.nodeNum === CS)!;
     const yrzeNode = forwardGraph.nodes.find((n) => n.nodeNum === YRZE)!;
@@ -396,7 +496,7 @@ describe('TracerouteStrip', () => {
       [X, makeMeta({ nodeNum: X, shortName: 'XX', longName: 'Node XX' })],
     ]);
 
-    render(<TracerouteStrip graph={bothGraph} meta={bothMeta} />);
+    render(<TracerouteStrip graph={bothGraph} meta={bothMeta} {...FMT} />);
 
     const bNode = bothGraph.nodes.find((n) => n.nodeNum === B)!;
     const aNode = bothGraph.nodes.find((n) => n.nodeNum === A)!;
@@ -431,11 +531,109 @@ describe('TracerouteStrip', () => {
       [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node' })],
     ]);
 
-    render(<TracerouteStrip graph={graph} meta={meta} />);
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
 
     const div = nodeDivFor('Unknown');
-    const tipId = div.getAttribute('aria-describedby');
-    const tooltip = document.getElementById(tipId!);
-    expect(tooltip!.textContent).toBe('!000000c8'); // 200 in padded hex
+    fireEvent.mouseEnter(div);
+
+    const popup = document.querySelector('[role="tooltip"]') as HTMLElement;
+    expect(popup).not.toBeNull();
+    // A hop nobody identified has no card model — it must still render
+    // without crashing, carrying the one fact we do have.
+    expect(popup.textContent).toContain('!000000c8'); // 200 in padded hex
+  });
+
+  it('repositions below the anchor when there is no room above it', () => {
+    // jsdom has no layout, so drive the geometry explicitly: a glyph near the
+    // top of the viewport cannot fit a popup above it, which is exactly the
+    // clipping case that motivated this change.
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node' })],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    const div = nodeDivFor('FRM');
+
+    // Anchor sits 4px from the top — no room for a 100px popup above it.
+    vi.spyOn(div, 'getBoundingClientRect').mockReturnValue({
+      top: 4, bottom: 40, left: 500, right: 532, width: 32, height: 36, x: 500, y: 4,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(div);
+    const popup = document.querySelector('[role="tooltip"]') as HTMLElement;
+    Object.defineProperty(popup, 'offsetWidth', { value: 240, configurable: true });
+    Object.defineProperty(popup, 'offsetHeight', { value: 100, configurable: true });
+    fireEvent.scroll(window); // force a reposition with the measurements in place
+
+    // Flipped below the anchor's bottom edge, not negative-top above it.
+    expect(parseFloat(popup.style.top)).toBeGreaterThanOrEqual(40);
+  });
+
+  it('clamps horizontally so the popup never overflows the viewport edge', () => {
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node' })],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    const div = nodeDivFor('FRM');
+
+    // Anchor hard against the left edge — a centred popup would go negative.
+    vi.spyOn(div, 'getBoundingClientRect').mockReturnValue({
+      top: 400, bottom: 436, left: 2, right: 34, width: 32, height: 36, x: 2, y: 400,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(div);
+    const popup = document.querySelector('[role="tooltip"]') as HTMLElement;
+    Object.defineProperty(popup, 'offsetWidth', { value: 240, configurable: true });
+    Object.defineProperty(popup, 'offsetHeight', { value: 100, configurable: true });
+    fireEvent.scroll(window);
+
+    expect(parseFloat(popup.style.left)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('removes its scroll/resize listeners when the popup hides', () => {
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: null,
+    });
+    const meta = new Map<number, TracerouteStripNodeMeta>([
+      [100, makeMeta({ nodeNum: 100, shortName: 'FRM', longName: 'From Node' })],
+      [200, makeMeta({ nodeNum: 200, shortName: 'TGT', longName: 'Target Node' })],
+    ]);
+
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    render(<TracerouteStrip graph={graph} meta={meta} {...FMT} />);
+    const div = nodeDivFor('FRM');
+
+    fireEvent.mouseEnter(div);
+    const addedScroll = addSpy.mock.calls.filter((c) => String(c[0]) === 'scroll').length;
+    expect(addedScroll).toBeGreaterThan(0);
+
+    fireEvent.mouseLeave(div);
+    const removedScroll = removeSpy.mock.calls.filter((c) => String(c[0]) === 'scroll').length;
+    expect(removedScroll).toBe(addedScroll);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
   });
 });

--- a/src/components/traceroute/TracerouteStrip.tsx
+++ b/src/components/traceroute/TracerouteStrip.tsx
@@ -78,7 +78,6 @@ interface HoverState {
 interface PopupPosition {
   left: number;
   top: number;
-  placement: 'above' | 'below';
 }
 
 const DEFAULT_GLYPH_SIZE = 32;
@@ -163,13 +162,13 @@ export function TracerouteStrip({
       return;
     }
 
-    let placement: 'above' | 'below' = 'above';
+    // Prefer above the glyph; flip below when it doesn't fit. If neither side
+    // fits (very short viewport, very tall card) the popup is clamped into
+    // view and may overlap the anchor — being readable beats being correctly
+    // placed but off-screen.
     let top = a.top - POPUP_GAP - height;
     if (top < POPUP_GAP) {
-      placement = 'below';
       top = a.bottom + POPUP_GAP;
-      // Neither side fits (very short viewport): clamp into view rather than
-      // letting it run off the bottom.
       if (top + height > vh - POPUP_GAP) {
         top = Math.max(POPUP_GAP, vh - POPUP_GAP - height);
       }
@@ -181,9 +180,7 @@ export function TracerouteStrip({
     );
 
     setPopupPos((prev) =>
-      prev && prev.left === left && prev.top === top && prev.placement === placement
-        ? prev
-        : { left, top, placement },
+      prev && prev.left === left && prev.top === top ? prev : { left, top },
     );
   }, [hover, hide]);
 

--- a/src/components/traceroute/TracerouteStrip.tsx
+++ b/src/components/traceroute/TracerouteStrip.tsx
@@ -13,9 +13,11 @@
  *
  * See docs/internal/dev-notes/TRACEROUTE_VISUAL_STRIP_SPEC.md §4.3/§4.4.
  */
-import { useId, useMemo } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { NodeTypeCategory } from '../../utils/nodeTypeCategory';
+import type { DateFormat, TimeFormat } from '../../contexts/SettingsContext';
 import { getHopColor } from '../../utils/roleGlyphSvg';
 import {
   layoutTracerouteStrip,
@@ -23,6 +25,9 @@ import {
   type StripLane,
   type TracerouteStripGraph,
 } from '../../utils/tracerouteStrip';
+import { NodeCard } from '../map/popups/NodeCard';
+import { IdentityItems, SignalItems, PositionItem, LastHeardFooter } from '../map/popups/sections';
+import type { NodeCardModel } from '../map/popups/nodeCardModel';
 import { NodeGlyph } from './NodeGlyph';
 import styles from './TracerouteStrip.module.css';
 
@@ -39,12 +44,41 @@ export interface TracerouteStripNodeMeta {
   /** Effective hops; 999 = unknown (grey). */
   hops: number;
   unmessagable: boolean;
+  /** View-model for the hover popup — the same card the Map page renders.
+   *  Built by `buildStripNodeMeta`, which is the layer that holds the
+   *  `DeviceInfo`; this component stays a pure function of plain data. */
+  card: NodeCardModel;
+  /** Reported coordinates, when the node has a position fix. */
+  pos?: { lat: number; lng: number };
 }
 
 export interface TracerouteStripProps {
   graph: TracerouteStripGraph;
   /** nodeNum -> metadata. A missing entry renders the unknown placeholder. */
   meta: Map<number, TracerouteStripNodeMeta>;
+  timeFormat: TimeFormat;
+  dateFormat: DateFormat;
+  distanceUnit?: 'km' | 'mi' | 'nm';
+}
+
+/** Gap between the glyph and the popup, and the minimum margin kept between
+ *  the popup and every viewport edge. */
+const POPUP_GAP = 8;
+
+interface HoverState {
+  /** StripNode id — identifies the exact glyph, not just the nodeNum (the
+   *  same node can occupy several lanes). */
+  id: string;
+  nodeNum: number;
+  isPlaceholder: boolean;
+  fallbackId: string;
+  anchor: HTMLElement;
+}
+
+interface PopupPosition {
+  left: number;
+  top: number;
+  placement: 'above' | 'below';
 }
 
 const DEFAULT_GLYPH_SIZE = 32;
@@ -70,14 +104,158 @@ function laneClassFor(lane: StripLane): string {
   }
 }
 
-export function TracerouteStrip({ graph, meta }: TracerouteStripProps) {
+export function TracerouteStrip({
+  graph,
+  meta,
+  timeFormat,
+  dateFormat,
+  distanceUnit = 'km',
+}: TracerouteStripProps) {
   const { t } = useTranslation();
   const uid = useId();
 
   const layout = useMemo(() => layoutTracerouteStrip(graph), [graph]);
 
+  const [hover, setHover] = useState<HoverState | null>(null);
+  const [popupPos, setPopupPos] = useState<PopupPosition | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
+  const hide = useCallback(() => {
+    setHover(null);
+    setPopupPos(null);
+  }, []);
+
+  const show = useCallback(
+    (id: string, nodeNum: number, isPlaceholder: boolean, fallbackId: string, anchor: HTMLElement) => {
+      setPopupPos(null); // re-measure for the new anchor before showing
+      setHover({ id, nodeNum, isPlaceholder, fallbackId, anchor });
+    },
+    [],
+  );
+
+  /**
+   * Place the popup against the anchor glyph, in viewport coordinates.
+   *
+   * Prefer above; flip below when there isn't room. The popup is portalled to
+   * `document.body` because `.node` carries a `transform`, which would
+   * otherwise make it the containing block for a `position: fixed` child and
+   * trap the popup inside `.scroller`'s `overflow: hidden`.
+   *
+   * Measures the rendered popup rather than assuming its size — the card's
+   * height varies with how many fields a node has.
+   */
+  const reposition = useCallback(() => {
+    const anchor = hover?.anchor;
+    const popup = popupRef.current;
+    if (!anchor || !popup) return;
+
+    const a = anchor.getBoundingClientRect();
+    const width = popup.offsetWidth;
+    const height = popup.offsetHeight;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let placement: 'above' | 'below' = 'above';
+    let top = a.top - POPUP_GAP - height;
+    if (top < POPUP_GAP) {
+      placement = 'below';
+      top = a.bottom + POPUP_GAP;
+      // Neither side fits (very short viewport): clamp into view rather than
+      // letting it run off the bottom.
+      if (top + height > vh - POPUP_GAP) {
+        top = Math.max(POPUP_GAP, vh - POPUP_GAP - height);
+      }
+    }
+
+    const left = Math.max(
+      POPUP_GAP,
+      Math.min(a.left + a.width / 2 - width / 2, vw - POPUP_GAP - width),
+    );
+
+    setPopupPos((prev) =>
+      prev && prev.left === left && prev.top === top && prev.placement === placement
+        ? prev
+        : { left, top, placement },
+    );
+  }, [hover]);
+
+  // Position after the popup has rendered (so it can be measured), before paint.
+  useLayoutEffect(() => {
+    if (!hover) return;
+    reposition();
+  }, [hover, reposition]);
+
+  // The strip sits inside `.nodes-main-content`, which scrolls — so the anchor
+  // moves without the window scrolling. `capture: true` catches scroll on any
+  // ancestor, not just the window.
+  useEffect(() => {
+    if (!hover) return;
+    const onMove = () => reposition();
+    window.addEventListener('scroll', onMove, true);
+    window.addEventListener('resize', onMove);
+    return () => {
+      window.removeEventListener('scroll', onMove, true);
+      window.removeEventListener('resize', onMove);
+    };
+  }, [hover, reposition]);
+
   const glyphSize = DEFAULT_GLYPH_SIZE;
   const arrowId = `${uid}-head`;
+
+  /**
+   * The hover popup body — the same card the Map page renders, minus the
+   * action buttons (the popup is non-interactive) and minus the traceroute
+   * tab (redundant inside a traceroute strip). Composed from the shared
+   * popup family rather than re-implemented.
+   *
+   * A hop we never resolved (`BROADCAST_ADDR`, or a node absent from `meta`)
+   * has no card model, so it falls back to a minimal card carrying just the
+   * padded hex id — same information the old inline tooltip showed.
+   */
+  const hoverCard = useMemo(() => {
+    if (!hover) return null;
+    const hovered = hover.isPlaceholder ? undefined : meta.get(hover.nodeNum);
+
+    if (!hovered) {
+      return (
+        <NodeCard
+          model={{ longName: t('messages.traceroute_unknown_node', 'Unknown') }}
+          sections={
+            <div className="node-popup-grid">
+              <IdentityItems model={{ longName: '', nodeId: hover.fallbackId }} />
+            </div>
+          }
+        />
+      );
+    }
+
+    return (
+      <NodeCard
+        model={hovered.card}
+        sections={
+          <>
+            <div className="node-popup-grid">
+              <IdentityItems model={hovered.card} />
+              <SignalItems
+                model={hovered.card}
+                showAltitude
+                showPluggedIn
+                snrDecimals={1}
+                distanceUnit={distanceUnit}
+              />
+              {hovered.pos && <PositionItem position={hovered.pos} />}
+            </div>
+            <LastHeardFooter
+              lastHeard={hovered.card.lastHeard}
+              mode="absolute"
+              timeFormat={timeFormat}
+              dateFormat={dateFormat}
+            />
+          </>
+        }
+      />
+    );
+  }, [hover, meta, distanceUnit, timeFormat, dateFormat, t]);
 
   const stripLabel = t('messages.traceroute_strip_label', 'Traceroute path');
   const forwardLegCaption = t('messages.traceroute_leg_forward', 'Forward');
@@ -194,8 +372,14 @@ export function TracerouteStrip({ graph, meta }: TracerouteStripProps) {
               className={cx(styles.node, laneClassFor(n.lane))}
               style={{ left: center.x, top: center.y }}
               tabIndex={0}
-              aria-describedby={tipId}
+              aria-describedby={hover?.id === n.id ? tipId : undefined}
               aria-label={accessibleName}
+              onMouseEnter={(e) =>
+                show(n.id, n.nodeNum, isPlaceholder, nodeId, e.currentTarget)
+              }
+              onMouseLeave={hide}
+              onFocus={(e) => show(n.id, n.nodeNum, isPlaceholder, nodeId, e.currentTarget)}
+              onBlur={hide}
             >
               <NodeGlyph
                 category={category}
@@ -205,21 +389,24 @@ export function TracerouteStrip({ graph, meta }: TracerouteStripProps) {
                 unknown={isPlaceholder}
               />
               <span className={styles.shortName}>{shortName}</span>
-              {/* Always in the DOM (opacity: 0, not display: none) so
-                  aria-describedby resolves for assistive tech (spec §4.3). */}
-              <span id={tipId} role="tooltip" className={styles.tooltip}>
-                {!isPlaceholder && (
-                  <>
-                    <span className={styles.tipLong}>{longName ?? shortName}</span>
-                    {roleLabel && <span className={styles.tipRole}>{roleLabel}</span>}
-                  </>
-                )}
-                <span className={styles.tipId}>{nodeId}</span>
-              </span>
             </div>
           );
         })}
       </div>
+
+      {hover &&
+        createPortal(
+          <div
+            ref={popupRef}
+            id={`${uid}-tip-${hover.id}`}
+            role="tooltip"
+            className={cx(styles.hoverPopup, popupPos && styles.hoverPopupReady)}
+            style={{ left: popupPos?.left ?? 0, top: popupPos?.top ?? 0 }}
+          >
+            {hoverCard}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/components/traceroute/TracerouteStrip.tsx
+++ b/src/components/traceroute/TracerouteStrip.tsx
@@ -155,6 +155,14 @@ export function TracerouteStrip({
     const vw = window.innerWidth;
     const vh = window.innerHeight;
 
+    // The anchor can be scrolled out of view while the popup is open (hover,
+    // then scroll the panel). Anchoring to something off-screen would drag the
+    // popup off with it, so drop it instead.
+    if (a.bottom < 0 || a.top > vh || a.right < 0 || a.left > vw) {
+      hide();
+      return;
+    }
+
     let placement: 'above' | 'below' = 'above';
     let top = a.top - POPUP_GAP - height;
     if (top < POPUP_GAP) {
@@ -177,7 +185,7 @@ export function TracerouteStrip({
         ? prev
         : { left, top, placement },
     );
-  }, [hover]);
+  }, [hover, hide]);
 
   // Position after the popup has rendered (so it can be measured), before paint.
   useLayoutEffect(() => {

--- a/src/utils/tracerouteStripMeta.ts
+++ b/src/utils/tracerouteStripMeta.ts
@@ -14,6 +14,7 @@ import type { TracerouteStripNodeMeta } from '../components/traceroute/Tracerout
 import { getEffectiveHops } from './nodeHops';
 import { getNodeTypeCategory } from './nodeTypeCategory';
 import { getRoleName } from './nodeHelpers';
+import { toNodeCardModel } from '../components/map/popups/nodeCardModel';
 
 /** Structural subset of a traceroute row — the same shape `getEffectiveHops`
  *  needs for its `'traceroute'` calculation mode. */
@@ -70,6 +71,16 @@ export function buildStripNodeMeta(
     const hops = getEffectiveHops(node, opts.hopsCalculation, opts.traceroutes, opts.currentNodeNum);
     const unmessagable = !!node.isUnmessagable;
 
+    // The hover popup renders the same card the Map page shows, so build its
+    // view-model here rather than in the component: this adapter is the only
+    // layer that holds a `DeviceInfo`, and keeping the conversion here is what
+    // lets `TracerouteStrip` stay a pure function of plain data.
+    const pos =
+      node.position?.latitude != null && node.position?.longitude != null
+        ? { lat: node.position.latitude, lng: node.position.longitude }
+        : undefined;
+    const card = toNodeCardModel(node, 'meshtastic', { effectiveHops: hops, pos });
+
     meta.set(nodeNum, {
       nodeNum,
       shortName,
@@ -79,6 +90,8 @@ export function buildStripNodeMeta(
       category,
       hops,
       unmessagable,
+      card,
+      pos,
     });
   }
 


### PR DESCRIPTION
Follow-up to #4392. Two problems with the traceroute strip's hover popup: it clipped, and it was too sparse.

## The clipping

The popup was a DOM child of `.node`, which carries `transform: translate(-50%, -50%)`. A `transform` makes that element the containing block for any `position: fixed` descendant — so the popup could never escape, and `.scroller`'s `overflow-y: hidden` clipped it. It also *always* rendered above its glyph, with nothing handling the bottom or side edges; the only mitigation was reserved headroom in the layout math, which fails as soon as a node sits near the top.

**Fix:** portal it to `document.body` and position it in viewport coordinates.

- Prefer above, **flip below** when there isn't room — this is the case that actually clipped.
- Clamp horizontally against both viewport edges.
- Recompute on scroll/resize with `capture: true`: the strip lives inside `.nodes-main-content`, which scrolls independently of the window, so the anchor moves without a window scroll event.
- **Measure** the rendered popup instead of assuming its size. The existing `NodePopup` clamps against hardcoded dimensions; the card's height varies per node, so that approach would misplace it.
- Hide when the anchor scrolls out of view, rather than dragging the popup off-screen with it.

Verified in the browser against a live traceroute — hovering a node 40px from the viewport top now flips below and renders fully visible (95→422 in a 950px viewport), and the popup visibly extends outside the traceroute box.

## The content

Now the same card the Map page renders, composed from the shared popup family rather than a hand-rolled subset — `toNodeCardModel` + `NodeCard` / `IdentityItems` / `SignalItems` / `PositionItem` / `LastHeardFooter`. Live example gains: hardware model, hops, SNR, altitude, position accuracy, location source, coordinates, last heard.

Omitted deliberately: `NodeActions` (the popup is non-interactive, so buttons would be unreachable) and the traceroute tab (redundant inside a traceroute strip).

`buildStripNodeMeta` builds the card model, because it is the only layer holding a `DeviceInfo` — that keeps `TracerouteStrip` a pure function of plain data, as its module contract states.

## Accessibility

`aria-describedby` is now set **only while the popup exists**, so it never references a missing element. The popup keeps `role="tooltip"` and opens on keyboard focus as well as hover. Because it's portalled it is no longer a descendant of the node, so the id reference is asserted by test rather than assumed.

## Verification

- Full suite **12,053 tests, 0 failures**, 0 failed suites.
- `npm run typecheck` clean; lint ratchet passes; `typecheck:tests` at 360, **identical per-file counts to `main`**.
- Zero diff to `src/styles/nodes.css` and to the map popup family (`NodeCard.tsx`, `sections.tsx`, `nodeCardModel.ts`) — the card is reused, not modified.
- New tests: portalled outside the strip tree, `aria-describedby` wiring appears/disappears with the popup, flip-below when there's no room above, horizontal clamping, enriched fields render, unknown placeholder still renders, and scroll/resize listeners are removed on hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyRkje9qCerXExJMxjeBRT
