### PR TITLE
fix(dashboard): give every sidebar link an icon (#4395)

### DIFF
--- a/src/components/Dashboard/DashboardSidebar.module.css
+++ b/src/components/Dashboard/DashboardSidebar.module.css
@@ -1,0 +1,20 @@
+/**
+ * DashboardSidebar — scoped styles (issue #4395).
+ *
+ * The six bottom-of-sidebar navigation links each render a `UiIcon` before
+ * their label. The legacy global `.dashboard-sidebar-link` rule in
+ * `src/styles/dashboard.css` is frozen, so the flex layout that keeps the icon
+ * and label aligned lives here and is applied alongside the global class.
+ */
+
+.linkWithIcon {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Keep the glyph from being squeezed when a long label wraps the flex line. */
+.linkWithIcon > svg,
+.linkWithIcon > [data-ui-icon] {
+  flex-shrink: 0;
+}

--- a/src/components/Dashboard/DashboardSidebar.test.tsx
+++ b/src/components/Dashboard/DashboardSidebar.test.tsx
@@ -189,6 +189,23 @@ describe('DashboardSidebar', () => {
     expect(screen.getByRole('button', { name: /source\.sidebar\.unified_telemetry/ })).toBeInTheDocument();
   });
 
+  it('gives every sidebar navigation link an icon (#4395)', () => {
+    renderSidebar();
+    const links = Array.from(
+      document.querySelectorAll('.dashboard-sidebar-links .dashboard-sidebar-link'),
+    );
+    // Unified Messages, Unified Telemetry, Unified Packets, Map Analysis,
+    // Analysis & Reports, Automation Engine.
+    expect(links).toHaveLength(6);
+    for (const link of links) {
+      expect(link.querySelector('[data-ui-icon]')).not.toBeNull();
+    }
+    const iconNames = links.map((l) =>
+      l.querySelector('[data-ui-icon]')?.getAttribute('data-ui-icon'),
+    );
+    expect(iconNames).toEqual(['messages', 'telemetry', 'package', 'map', 'reports', 'bot']);
+  });
+
   it('renders Map Analysis link below the unified links and navigates to /analysis on click', async () => {
     const navigate = vi.fn();
     vi.mocked(useNavigate).mockReturnValue(navigate);

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -27,6 +27,13 @@ import type { DashboardSource, SourceStatus, UnifiedStatus } from '../../hooks/u
 import { UNIFIED_SOURCE_ID } from '../../hooks/useDashboardData';
 import { useAuth } from '../../contexts/AuthContext';
 import { BrandIcon, UiIcon } from '../icons';
+import styles from './DashboardSidebar.module.css';
+
+// Every sidebar navigation link renders an icon before its label (issue #4395).
+// The global `.dashboard-sidebar-link` rule carries the colour and typography;
+// the CSS-module class adds the flex layout that aligns the glyph with the text.
+const SIDEBAR_LINK_CLASS =
+  `dashboard-sidebar-link dashboard-sidebar-link--active ${styles.linkWithIcon}`;
 
 // Persisted, user-resizable sidebar width (issue #3356). The width is stored
 // in localStorage so it survives reloads; min/max bounds keep the layout from
@@ -787,38 +794,43 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
 
       <div className="dashboard-sidebar-links">
         <button
-          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          className={SIDEBAR_LINK_CLASS}
           onClick={() => navigate('/unified/messages')}
         >
+          <UiIcon name="messages" size={18} />
           {t('source.sidebar.unified_messages')}
         </button>
         <button
-          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          className={SIDEBAR_LINK_CLASS}
           onClick={() => navigate('/unified/telemetry')}
         >
+          <UiIcon name="telemetry" size={18} />
           {t('source.sidebar.unified_telemetry')}
         </button>
         <button
-          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          className={SIDEBAR_LINK_CLASS}
           onClick={() => navigate('/unified/packets')}
         >
+          <UiIcon name="package" size={18} />
           {t('source.sidebar.unified_packets', 'Unified Packets')}
         </button>
         <button
-          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          className={SIDEBAR_LINK_CLASS}
           onClick={() => navigate('/analysis')}
         >
+          <UiIcon name="map" size={18} />
           {t('source.sidebar.map_analysis')}
         </button>
         <button
-          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          className={SIDEBAR_LINK_CLASS}
           onClick={() => navigate('/reports')}
         >
+          <UiIcon name="reports" size={18} />
           {t('source.sidebar.reports', 'Analysis & Reports')}
         </button>
         {hasPermission('automations', 'read') && (
           <button
-            className="dashboard-sidebar-link dashboard-sidebar-link--active"
+            className={SIDEBAR_LINK_CLASS}
             onClick={() => navigate('/automations')}
           >
             <UiIcon name="bot" size={18} />


### PR DESCRIPTION
## Summary

The dashboard sidebar's bottom link group has six sibling entries, but only **Automation Engine** rendered an icon. The other five were plain text, so the group read as half-finished.

Per the decision on the issue, this **adds icons to all of them** — the `bot` icon stays.

## What changed

- `src/components/Dashboard/DashboardSidebar.tsx`
  - All six links now render `<UiIcon name="…" size={18} />` before their label, matching the existing Automation Engine markup exactly (same element order, same position in the button).
  - The repeated `className="dashboard-sidebar-link dashboard-sidebar-link--active"` string is now a single `SIDEBAR_LINK_CLASS` constant, so the six links cannot drift apart again.
- `src/components/Dashboard/DashboardSidebar.module.css` (new)
  - `.linkWithIcon` adds `display: flex; align-items: center; gap: 6px` plus `flex-shrink: 0` on the glyph. The global `.dashboard-sidebar-link` rule in `src/styles/dashboard.css` has no flex/gap at all (the bot icon was previously butted straight against its label), and the global sheets are frozen — so the layout lives in a scoped CSS module per CLAUDE.md.
- `src/components/Dashboard/DashboardSidebar.test.tsx`
  - New test asserts all six links carry a `[data-ui-icon]` element, in the expected order.

## Icons chosen

All names already exist in the `UI_ICON_DEFINITIONS` registry (`src/components/icons/UiIcon.tsx`) — nothing new was registered, and no emoji were hardcoded.

| Link | Icon | Why |
|---|---|---|
| Unified Messages | `messages` (MessageCircle) | registry usage: "messages and replies" |
| Unified Telemetry | `telemetry` (BarChart3) | the registry's telemetry entry |
| Unified Packets | `package` (Package) | registry usage: "packets, packages, and store-forward" |
| Map Analysis | `map` (Map) | registry usage: "maps and topology" |
| Analysis & Reports | `reports` (ClipboardList) | the registry's reports entry |
| Automation Engine | `bot` (Bot) | unchanged |

## Scope check

`dashboard-sidebar-link` appears in exactly one block in this file — the six links named in the issue. The sidebar footer buttons (`users`, `settings`, …) already have icons and use a different class; they were not touched.

## Verification

- `npx tsc -p tsconfig.server.json --noEmit` — **No errors found**
- `npx tsc --noEmit` — **0 errors** (no new ones)
- `npx vitest run --reporter=json --maxWorkers=2` — `success: true`, **12049 total / 11349 passed / 0 failed / 679 skipped**, 3576 suites, 0 failed suites
- `npm run lint:ci` — **no `FAIL` lines** for in-repo files

Closes #4395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob