### PR TITLE
fix(map): give the legend a usable mobile presentation (#4389)

### DIFF
--- a/src/components/MapLegend.css
+++ b/src/components/MapLegend.css
@@ -142,9 +142,84 @@
   white-space: nowrap;
 }
 
-/* Hide on mobile devices */
+/*
+ * Mobile: a docked, tap-to-expand legend card (#4389).
+ *
+ * This block used to be `.map-legend-wrapper { display: none }`, which hid the
+ * legend outright while the Features-panel "Show Legend" checkbox stayed
+ * visible and toggleable — the control looked broken because it drove
+ * something CSS had already removed. MapLegend now renders a non-draggable
+ * card at this breakpoint (see the `isMobile` branch in MapLegend.tsx), so the
+ * panel is positioned here rather than hidden.
+ *
+ * Deliberately NOT the #4380 full-width bottom sheet. That fix suits a
+ * "pick one, then dismiss" control; the legend is reference material with
+ * nothing to select, so it is a small corner card that stays where the reader
+ * put it. Sitting above and behind the tile-selector sheet lets both be open.
+ *
+ * `.draggable-overlay` keeps its own mobile `display: none` in
+ * DraggableOverlay.css — untouched, since this card no longer renders through
+ * DraggableOverlay and PositionHistoryLegend still relies on that rule.
+ */
 @media (max-width: 768px) {
-  .map-legend-wrapper {
-    display: none;
+  .map-legend-mobile {
+    position: fixed;
+    left: 12px;
+    /* Clears the collapsed tile-selector bottom sheet (~48px, #4380) and the
+       Leaflet attribution strip, plus the home indicator on notched devices. */
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 60px);
+    /* Under the tile-selector sheet (1200): if the two ever overlap, the panel
+       the user just tapped wins. */
+    z-index: 1150;
+    /* Never wider than the screen — the page must not scroll sideways. */
+    max-width: min(320px, calc(100vw - 24px));
+    background: var(--ctp-surface0);
+    border: 1px solid var(--ctp-surface1);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 2px 12px rgb(0 0 0 / 35%);
+    overflow: hidden;
+  }
+
+  .map-legend-mobile .map-legend {
+    max-width: 100%;
+  }
+
+  /* The whole header is the tap target, so give it a finger-sized row. */
+  .map-legend-mobile .legend-header {
+    cursor: pointer;
+    min-height: 44px;
+  }
+
+  .map-legend-mobile .legend-collapse-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  /* Long legend content scrolls inside the card instead of growing it past
+     the top of the screen. `.legend-body` exists on mobile only (see
+     MapLegend.tsx) so desktop flex spacing is untouched. */
+  .map-legend-mobile .legend-body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    width: 100%;
+    max-height: 50vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+    /* Scrolling the legend must not pan the map underneath it. */
+    overscroll-behavior: contain;
+  }
+
+  /* Labels wrap rather than pushing the card wider than the viewport. */
+  .map-legend-mobile .legend-label,
+  .map-legend-mobile .legend-time-label {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .map-legend-mobile .legend-item {
+    max-width: 100%;
   }
 }

--- a/src/components/MapLegend.test.tsx
+++ b/src/components/MapLegend.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 // Mock Leaflet before importing components
@@ -177,5 +177,116 @@ describe('MapLegend', () => {
       expect(screen.getByText('map.legend.local')).toBeInTheDocument();
       expect(screen.getByText('6+')).toBeInTheDocument();
     });
+  });
+});
+
+/**
+ * #4389: on mobile the legend was force-hidden by
+ * `.map-legend-wrapper { display: none }` while the Features-panel "Show
+ * Legend" checkbox stayed visible and toggleable — a control driving something
+ * that could never appear. The mobile branch renders a docked, tap-to-expand
+ * card instead of the draggable overlay.
+ */
+describe('MapLegend — mobile card (#4389)', () => {
+  const setViewport = (mobile: boolean) => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: mobile && query.includes('max-width'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    setViewport(false);
+  });
+
+  it('renders the card variant, not the draggable overlay, on a mobile viewport', () => {
+    setViewport(true);
+    const { container } = render(<MapLegend />);
+
+    expect(container.querySelector('.map-legend-mobile')).not.toBeNull();
+    expect(container.querySelector('.draggable-overlay')).toBeNull();
+  });
+
+  it('keeps the draggable overlay on a desktop viewport', () => {
+    setViewport(false);
+    const { container } = render(<MapLegend />);
+
+    expect(container.querySelector('.map-legend-mobile')).toBeNull();
+    expect(container.querySelector('.draggable-overlay')).not.toBeNull();
+  });
+
+  it('starts compact on mobile and expands on a header tap', () => {
+    setViewport(true);
+    const { container } = render(<MapLegend />);
+
+    // Compact by default: header only, no legend rows.
+    expect(container.querySelector('.map-legend')).toHaveClass('collapsed');
+    expect(container.querySelectorAll('.legend-item').length).toBe(0);
+
+    fireEvent.click(container.querySelector('.legend-header')!);
+
+    expect(container.querySelector('.map-legend')).not.toHaveClass('collapsed');
+    expect(container.querySelectorAll('.legend-item').length).toBe(4);
+  });
+
+  it('collapses again on a second header tap', () => {
+    setViewport(true);
+    const { container } = render(<MapLegend />);
+    const header = container.querySelector('.legend-header')!;
+
+    fireEvent.click(header);
+    expect(container.querySelector('.map-legend')).not.toHaveClass('collapsed');
+
+    fireEvent.click(header);
+    expect(container.querySelector('.map-legend')).toHaveClass('collapsed');
+    expect(container.querySelectorAll('.legend-item').length).toBe(0);
+  });
+
+  it('counts a chevron tap once — the click must not also reach the header', () => {
+    setViewport(true);
+    const { container } = render(<MapLegend />);
+
+    fireEvent.click(container.querySelector('.legend-header')!); // expand
+    fireEvent.click(container.querySelector('.legend-collapse-btn')!);
+
+    expect(container.querySelector('.map-legend')).toHaveClass('collapsed');
+  });
+
+  it('scrolls its content inside the card rather than growing off-screen', () => {
+    setViewport(true);
+    const { container } = render(<MapLegend />);
+    fireEvent.click(container.querySelector('.legend-header')!);
+
+    // The scroll container is the mobile-only `.legend-body` — `.map-legend-mobile
+    // .legend-body` carries max-height + overflow-y in MapLegend.css.
+    const body = container.querySelector('.legend-body');
+    expect(body).not.toBeNull();
+    expect(body!.querySelectorAll('.legend-item').length).toBe(4);
+  });
+
+  it('does not wrap the body on desktop, so flex spacing is unchanged', () => {
+    setViewport(false);
+    const { container } = render(<MapLegend />);
+
+    expect(container.querySelector('.legend-body')).toBeNull();
+    expect(container.querySelectorAll('.map-legend > .legend-item').length).toBe(4);
+  });
+
+  it('honors a stored collapse preference over the mobile default', () => {
+    localStorage.setItem('mapLegendCollapsed', 'false');
+    setViewport(true);
+    const { container } = render(<MapLegend />);
+
+    expect(container.querySelector('.map-legend')).not.toHaveClass('collapsed');
   });
 });

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettings, TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatDateTime } from '../utils/datetime';
 import { DraggableOverlay } from './DraggableOverlay';
 import { MESHCORE_CATEGORIES, NODE_TYPE_CATEGORY_META } from '../utils/nodeTypeCategory';
 import { roleGlyphMarkerSvg } from '../utils/mapIcons';
+import { useIsMobileViewport } from '../hooks/useIsMobileViewport';
 import './MapLegend.css';
 import { UiIcon } from './icons';
 
@@ -47,9 +48,14 @@ const getDefaultPosition = () => ({
 const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, showNodeTypes }) => {
   const { t } = useTranslation();
   const { overlayColors } = useSettings();
+  const isMobile = useIsMobileViewport();
   const [isCollapsed, setIsCollapsed] = useState(() => {
     const stored = localStorage.getItem('mapLegendCollapsed');
-    return stored !== null ? stored === 'true' : false; // expanded by default
+    if (stored !== null) return stored === 'true';
+    // Desktop: expanded by default — the panel is draggable and sits clear of
+    // the map. Mobile (#4389): the card overlays the map it describes, so it
+    // starts as a compact pill the reader taps open.
+    return isMobile;
   });
 
   const handleToggleCollapse = () => {
@@ -57,6 +63,48 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, s
     setIsCollapsed(newValue);
     localStorage.setItem('mapLegendCollapsed', String(newValue));
   };
+
+  // On mobile the whole header is the tap target — a 24px chevron is a poor
+  // touch target, and the legend has no other action to compete with the tap.
+  // The chevron keeps working; it just stops the click reaching the header so
+  // one tap is not counted twice.
+  const handleCollapseButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    handleToggleCollapse();
+  };
+
+  const handleHeaderKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleToggleCollapse();
+    }
+  };
+
+  // The mobile card renders inside the Leaflet container, so a touch that
+  // starts on it would otherwise pan the map underneath — and a scroll of the
+  // legend body would drag the map with it. DraggableOverlay does the same for
+  // the desktop panel; this branch does not go through it, so it repeats the
+  // guard rather than inheriting it. stopPropagation only hides the event from
+  // Leaflet; it does not preventDefault, so the card still scrolls normally.
+  const cardRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    const stop = (e: Event) => e.stopPropagation();
+    const types = ['wheel', 'dblclick', 'mousedown', 'touchstart', 'pointerdown'];
+    types.forEach((type) => el.addEventListener(type, stop, { capture: true }));
+    return () => types.forEach((type) => el.removeEventListener(type, stop, { capture: true }));
+  }, [isMobile]);
+
+  const mobileHeaderProps: React.HTMLAttributes<HTMLDivElement> = isMobile
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        'aria-expanded': !isCollapsed,
+        onClick: handleToggleCollapse,
+        onKeyDown: handleHeaderKeyDown,
+      }
+    : {};
 
   // Hop gradient: local green → blue → purple → red
   const hopGradientCss = `linear-gradient(to right, ${overlayColors.hopColors.local}, ${overlayColors.hopColors.gradient.join(', ')})`;
@@ -72,124 +120,155 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, s
     return formatDateTime(new Date(timestamp), positionHistory.timeFormat, positionHistory.dateFormat);
   };
 
+  const legendBody = (
+    <>
+      <div className="legend-gradient-container">
+        <div
+          className="legend-gradient-bar"
+          style={{ background: hopGradientCss }}
+        />
+        <div className="legend-gradient-labels">
+          <span className="legend-gradient-label">{t('map.legend.local')}</span>
+          <span className="legend-gradient-label">6+</span>
+        </div>
+      </div>
+      <div className="legend-divider" />
+      <span className="legend-title">{t('map.legend.neighbors', 'Neighbors')}</span>
+      {/* Line style: solid = bidirectional, dashed = one-way */}
+      <div className="legend-item">
+        <svg width="24" height="12" className="legend-line-sample">
+          <line x1="0" y1="6" x2="24" y2="6"
+            stroke={overlayColors.neighborLine} strokeWidth={4} strokeOpacity={0.85} />
+        </svg>
+        <span className="legend-label">{t('map.legend.bidirectional', 'Bidirectional')}</span>
+      </div>
+      <div className="legend-item">
+        <svg width="24" height="12" className="legend-line-sample">
+          <line x1="0" y1="6" x2="18" y2="6"
+            stroke={overlayColors.neighborLine} strokeWidth={2} strokeDasharray="5,5" strokeOpacity={0.5} />
+          <polygon points="18,2 24,6 18,10" fill={overlayColors.neighborLine} opacity={0.7} />
+        </svg>
+        <span className="legend-label">{t('map.legend.unidirectional', 'One-way')}</span>
+      </div>
+      <span className="legend-sublabel" style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '2px' }}>
+        {t('map.legend.thickerBrighter', 'Thicker line = stronger signal')}
+      </span>
+      <div className="legend-divider" />
+      <span className="legend-title">{t('map.legend.otherLines', 'Other Lines')}</span>
+      {otherLineItems.map((item) => (
+        <div key={item.label} className="legend-item">
+          <svg width="24" height="12" className="legend-line-sample">
+            <line x1="0" y1="6" x2="24" y2="6"
+              stroke={item.color} strokeWidth={item.width}
+              strokeDasharray={item.dashArray || 'none'} strokeOpacity={item.opacity} />
+          </svg>
+          <span className="legend-label">{item.label}</span>
+        </div>
+      ))}
+      {showNodeTypes && (
+        <>
+          <div className="legend-divider" />
+          <span className="legend-title">{t('map.nodeType.legendTitle', 'Node Types')}</span>
+          {/* Standard nodes keep the default marker, so only the four
+              glyph categories are listed (matches the analysis legend). */}
+          {MESHCORE_CATEGORIES.filter((c) => c !== 'standard').map((category) => {
+            const meta = NODE_TYPE_CATEGORY_META[category];
+            return (
+              <div key={category} className="legend-item">
+                <span
+                  className="legend-line-sample"
+                  style={{ display: 'inline-flex', width: 20, height: 20 }}
+                  aria-hidden="true"
+                  dangerouslySetInnerHTML={{ __html: roleGlyphMarkerSvg(category, NODE_TYPE_LEGEND_COLOR, 20) }}
+                />
+                <span className="legend-label">{t(meta.labelKey, meta.label)}</span>
+              </div>
+            );
+          })}
+        </>
+      )}
+      {positionHistory && (
+        <>
+          <div className="legend-divider" />
+          <span className="legend-title">{t('map.legend.positionHistory')}</span>
+          <div className="legend-gradient-container">
+            <div
+              className="legend-gradient-bar"
+              style={{
+                background: `linear-gradient(to right, rgb(${overlayColors.positionHistoryOld.r}, ${overlayColors.positionHistoryOld.g}, ${overlayColors.positionHistoryOld.b}), rgb(${overlayColors.positionHistoryNew.r}, ${overlayColors.positionHistoryNew.g}, ${overlayColors.positionHistoryNew.b}))`,
+              }}
+            />
+            <div className="legend-gradient-labels">
+              <span className="legend-gradient-label oldest">{t('map.legend.oldest')}</span>
+              <span className="legend-gradient-label newest">{t('map.legend.newest')}</span>
+            </div>
+          </div>
+          <div className="legend-time-labels">
+            <span className="legend-time-label">{formatTime(positionHistory.oldestTime)}</span>
+            <span className="legend-time-label">{formatTime(positionHistory.newestTime)}</span>
+          </div>
+        </>
+      )}
+      {unmappedCount != null && unmappedCount > 0 && (
+        <>
+          <div className="legend-divider" />
+          <span className="legend-sublabel" style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+            {t('map.legend.unmappedNodes', '{{count}} node(s) without location', { count: unmappedCount })}
+          </span>
+        </>
+      )}
+    </>
+  );
+
+  const panel = (
+    <div className={`map-legend ${isCollapsed ? 'collapsed' : ''}`}>
+      <div className="legend-header" {...mobileHeaderProps}>
+        <span className="legend-title">{t('map.legend.hops')}</span>
+        <button
+          className="legend-collapse-btn"
+          onClick={handleCollapseButtonClick}
+          onMouseDown={(e) => e.stopPropagation()}
+          title={isCollapsed ? 'Expand legend' : 'Collapse legend'}
+        >
+          <UiIcon name={isCollapsed ? 'chevronDown' : 'chevronUp'} size={15} />
+        </button>
+      </div>
+      {/* The scroll container exists on mobile only, where the card is capped
+          at 50vh — wrapping the body unconditionally would turn the legend's
+          direct flex children into grandchildren and change desktop spacing. */}
+      {!isCollapsed && (isMobile ? <div className="legend-body">{legendBody}</div> : legendBody)}
+    </div>
+  );
+
+  // Mobile: a docked, tap-to-expand card instead of the draggable overlay
+  // (#4389). `.map-legend-wrapper` used to be `display: none` here while the
+  // Features-panel "Show Legend" checkbox stayed toggleable, so the control
+  // drove something that could never appear. Dragging a floating panel around a
+  // phone screen is not useful, so this branch skips DraggableOverlay entirely
+  // — which leaves `.draggable-overlay`'s own mobile `display: none` untouched
+  // for its other consumers (TilesetSelector's desktop path,
+  // PositionHistoryLegend).
+  //
+  // Deliberately NOT the #4380 bottom sheet: the tile selector is a "pick one,
+  // then dismiss" control, so a full-width sheet that closes on selection fits.
+  // The legend is purely informational with nothing to select, so it stays a
+  // small corner card the reader opens and closes at will, and it sits clear of
+  // (and under) the tile-selector sheet so the two can be open at once.
+  if (isMobile) {
+    return (
+      <div ref={cardRef} className="map-legend-wrapper map-legend-mobile">
+        {panel}
+      </div>
+    );
+  }
+
   return (
     <DraggableOverlay
       id="map-legend"
       defaultPosition={getDefaultPosition()}
       className="map-legend-wrapper"
     >
-      <div className={`map-legend ${isCollapsed ? 'collapsed' : ''}`}>
-        <div className="legend-header">
-          <span className="legend-title">{t('map.legend.hops')}</span>
-          <button
-            className="legend-collapse-btn"
-            onClick={handleToggleCollapse}
-            onMouseDown={(e) => e.stopPropagation()}
-            title={isCollapsed ? 'Expand legend' : 'Collapse legend'}
-          >
-            <UiIcon name={isCollapsed ? 'chevronDown' : 'chevronUp'} size={15} />
-          </button>
-        </div>
-        {!isCollapsed && (
-          <>
-            <div className="legend-gradient-container">
-              <div
-                className="legend-gradient-bar"
-                style={{ background: hopGradientCss }}
-              />
-              <div className="legend-gradient-labels">
-                <span className="legend-gradient-label">{t('map.legend.local')}</span>
-                <span className="legend-gradient-label">6+</span>
-              </div>
-            </div>
-            <div className="legend-divider" />
-            <span className="legend-title">{t('map.legend.neighbors', 'Neighbors')}</span>
-            {/* Line style: solid = bidirectional, dashed = one-way */}
-            <div className="legend-item">
-              <svg width="24" height="12" className="legend-line-sample">
-                <line x1="0" y1="6" x2="24" y2="6"
-                  stroke={overlayColors.neighborLine} strokeWidth={4} strokeOpacity={0.85} />
-              </svg>
-              <span className="legend-label">{t('map.legend.bidirectional', 'Bidirectional')}</span>
-            </div>
-            <div className="legend-item">
-              <svg width="24" height="12" className="legend-line-sample">
-                <line x1="0" y1="6" x2="18" y2="6"
-                  stroke={overlayColors.neighborLine} strokeWidth={2} strokeDasharray="5,5" strokeOpacity={0.5} />
-                <polygon points="18,2 24,6 18,10" fill={overlayColors.neighborLine} opacity={0.7} />
-              </svg>
-              <span className="legend-label">{t('map.legend.unidirectional', 'One-way')}</span>
-            </div>
-            <span className="legend-sublabel" style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '2px' }}>
-              {t('map.legend.thickerBrighter', 'Thicker line = stronger signal')}
-            </span>
-            <div className="legend-divider" />
-            <span className="legend-title">{t('map.legend.otherLines', 'Other Lines')}</span>
-            {otherLineItems.map((item) => (
-              <div key={item.label} className="legend-item">
-                <svg width="24" height="12" className="legend-line-sample">
-                  <line x1="0" y1="6" x2="24" y2="6"
-                    stroke={item.color} strokeWidth={item.width}
-                    strokeDasharray={item.dashArray || 'none'} strokeOpacity={item.opacity} />
-                </svg>
-                <span className="legend-label">{item.label}</span>
-              </div>
-            ))}
-            {showNodeTypes && (
-              <>
-                <div className="legend-divider" />
-                <span className="legend-title">{t('map.nodeType.legendTitle', 'Node Types')}</span>
-                {/* Standard nodes keep the default marker, so only the four
-                    glyph categories are listed (matches the analysis legend). */}
-                {MESHCORE_CATEGORIES.filter((c) => c !== 'standard').map((category) => {
-                  const meta = NODE_TYPE_CATEGORY_META[category];
-                  return (
-                    <div key={category} className="legend-item">
-                      <span
-                        className="legend-line-sample"
-                        style={{ display: 'inline-flex', width: 20, height: 20 }}
-                        aria-hidden="true"
-                        dangerouslySetInnerHTML={{ __html: roleGlyphMarkerSvg(category, NODE_TYPE_LEGEND_COLOR, 20) }}
-                      />
-                      <span className="legend-label">{t(meta.labelKey, meta.label)}</span>
-                    </div>
-                  );
-                })}
-              </>
-            )}
-            {positionHistory && (
-              <>
-                <div className="legend-divider" />
-                <span className="legend-title">{t('map.legend.positionHistory')}</span>
-                <div className="legend-gradient-container">
-                  <div
-                    className="legend-gradient-bar"
-                    style={{
-                      background: `linear-gradient(to right, rgb(${overlayColors.positionHistoryOld.r}, ${overlayColors.positionHistoryOld.g}, ${overlayColors.positionHistoryOld.b}), rgb(${overlayColors.positionHistoryNew.r}, ${overlayColors.positionHistoryNew.g}, ${overlayColors.positionHistoryNew.b}))`,
-                    }}
-                  />
-                  <div className="legend-gradient-labels">
-                    <span className="legend-gradient-label oldest">{t('map.legend.oldest')}</span>
-                    <span className="legend-gradient-label newest">{t('map.legend.newest')}</span>
-                  </div>
-                </div>
-                <div className="legend-time-labels">
-                  <span className="legend-time-label">{formatTime(positionHistory.oldestTime)}</span>
-                  <span className="legend-time-label">{formatTime(positionHistory.newestTime)}</span>
-                </div>
-              </>
-            )}
-            {unmappedCount != null && unmappedCount > 0 && (
-              <>
-                <div className="legend-divider" />
-                <span className="legend-sublabel" style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
-                  {t('map.legend.unmappedNodes', '{{count}} node(s) without location', { count: unmappedCount })}
-                </span>
-              </>
-            )}
-          </>
-        )}
-      </div>
+      {panel}
     </DraggableOverlay>
   );
 };


### PR DESCRIPTION
## Problem

At `<=768px` the map legend never appeared. `.map-legend-wrapper` was force-hidden
by CSS (`MapLegend.css`), and `.draggable-overlay` hides itself at the same
breakpoint — while the Features panel kept showing a live, toggleable
"Show Legend" checkbox. The control looked broken rather than unavailable, and
there was no way to read the link-style / node-type / position-history key on a
phone.

Reported by @wilhel1812 as a follow-up to #4380.

## The mobile pattern, and why it differs from #4380

The tile selector (#4380) is a "pick one, then dismiss" control, so a full-width
bottom sheet that closes on selection fits it. The legend is reference material
with nothing to select, so copying that shape would give it a dismiss gesture it
has no use for and hand a full-width sheet to content the reader wants to keep
open *while* looking at the map.

This uses a **docked, tap-to-expand card** instead:

- Bottom-left corner, compact pill by default (just the title + chevron).
- Tap the header — the whole row, not just a 24px chevron — to expand; tap it
  again (or the chevron) to collapse. Keyboard: Enter/Space, with
  `role="button"` and `aria-expanded`.
- Expanded content is capped at `50vh` and scrolls inside its own container, so
  a long legend never grows off the top of the screen.
- `max-width: min(320px, calc(100vw - 24px))` plus `overflow-x: hidden` and
  wrapping labels — the page never scrolls sideways.
- `z-index: 1150`, below the tile-selector sheet's 1200, and offset
  `60px` from the bottom so it clears the collapsed tile-selector bar and the
  Leaflet attribution strip. Both panels can be open at once.
- The collapse state still persists in `localStorage`; a stored preference wins
  over the mobile default.

## What changed

**`src/components/MapLegend.tsx`**
- Added `useIsMobileViewport()` (the hook introduced by #4380 — no new
  breakpoint definition).
- Below the breakpoint, returns a plain `.map-legend-wrapper.map-legend-mobile`
  card instead of `DraggableOverlay`. Dragging a floating panel around a phone
  is not useful, and skipping the overlay leaves `.draggable-overlay`'s own
  mobile `display: none` untouched for its other consumers — checked all three:
  `TilesetSelector` (desktop path only since #4380), `PositionHistoryLegend`,
  and this component. **No shared CSS was modified.**
- Default collapse state is now `isMobile` when nothing is stored: expanded on
  desktop as before, compact on a phone.
- Extracted the body into `legendBody` and the panel into `panel`. On mobile the
  body is wrapped in a `.legend-body` scroll container; on desktop it is not —
  wrapping unconditionally would turn the legend's direct flex children into
  grandchildren and change desktop spacing. **Desktop DOM is identical to
  before.**
- The card renders inside the Leaflet container, so it repeats
  `DraggableOverlay`'s event guard: `wheel` / `dblclick` / `mousedown` /
  `touchstart` / `pointerdown` are stopped at the card, so scrolling the legend
  does not pan the map underneath. `stopPropagation` only hides the event from
  Leaflet — it does not `preventDefault`, so the card still scrolls.
- The chevron's click now stops propagating, so a chevron tap is not also
  counted as a header tap (covered by a test).

**`src/components/MapLegend.css`**
- Replaced the `@media (max-width: 768px) { .map-legend-wrapper { display: none } }`
  block with the card styles, all scoped under `.map-legend-mobile`. The comment
  block records why this is not the #4380 sheet shape.
- Component-scoped sheet, matching how #4380 extended `TilesetSelector.css`.
  `src/styles/nodes.css` and the other global sheets are untouched, so the
  #3532 cascade-ordering trap is not in play here.

**`src/components/MapLegend.test.tsx`**
- New `MapLegend — mobile card (#4389)` block, following the
  `TilesetSelector.test.tsx` viewport-mock template: mobile renders the card and
  not the draggable overlay; desktop still renders the overlay; starts compact
  on mobile; expands and re-collapses on header taps; a chevron tap counts once;
  the scroll container holds the legend rows; desktop has no `.legend-body` and
  keeps its rows as direct `.map-legend` children; a stored preference beats the
  mobile default.

## Verification

- `npx tsc -p tsconfig.server.json --noEmit` — no errors.
- `npx tsc --noEmit` — no errors.
- `npx vitest run --maxWorkers=2` (full suite) — `success: true`,
  **12,056 tests, 0 failed, 0 failed suites**, 115 skipped (the
  PostgreSQL/MySQL suites, which skip without their containers).
- `npm run lint:ci` — no `FAIL` lines for in-repo files.

Per the working agreement for parallel agents, the Docker dev container was not
built or run for this change, so **a live mobile-viewport check is still
recommended** — in particular the card's bottom offset against a real Leaflet
attribution strip, and the interaction with the tile-selector sheet when both
are enabled.

Closes #4389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob
