### PR TITLE
feat(meshcore): add per-node ignore list to the auto-responder (#4391)

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -4632,5 +4632,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5022,5 +5022,7 @@
   "meshcore.automation.pathfinding.filter.snr_min_label": "Min SNR (dB)",
   "meshcore.automation.pathfinding.filter.signal_note": "Leave a threshold at its floor value to ignore it.",
   "meshcore.automation.pathfinding.filter.preview_count": "{{count}} contacts will be targeted",
-  "meshcore.automation.pathfinding.filter.no_match": "No contacts match the current filters"
+  "meshcore.automation.pathfinding.filter.no_match": "No contacts match the current filters",
+  "meshcore.automation.autoack.node_ignore_list": "Sender Ignore List",
+  "meshcore.automation.autoack.node_ignore_list_description": "Never auto-acknowledge these senders — use it to break a bot echo loop. One entry per line, or comma-separated. An entry is either a public key (full key or any leading prefix, with or without a leading \"!\") or a contact/sender name. Names are matched ignoring case and extra spaces, and are the only way to exclude a channel sender, because MeshCore channel packets carry no sender key."
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -4632,5 +4632,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -4632,5 +4632,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -4625,5 +4625,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -4623,5 +4623,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/pt_BR.json
+++ b/public/locales/pt_BR.json
@@ -4623,5 +4623,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -4625,5 +4625,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -4623,5 +4623,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -4625,5 +4625,7 @@
     "meshcore.automation.pathfinding.filter.signal_note": "",
     "settings.map_center_target_zoom_label": "",
     "meshcore.automation.pathfinding.filter.title": "",
-    "meshcore.automation.pathfinding.filter.master_toggle": ""
+    "meshcore.automation.pathfinding.filter.master_toggle": "",
+    "meshcore.automation.autoack.node_ignore_list": "",
+    "meshcore.automation.autoack.node_ignore_list_description": ""
 }

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -22,6 +22,8 @@ interface AutoAckSettings {
   /** Pre-send delay (seconds) before the ack reply is sent (#3876). */
   preSendDelaySeconds: number;
   testMessages: string;
+  /** Per-sender ignore list — key prefixes and/or contact names (#4391). */
+  ignoredNodes: string;
   /** MeshCore scope/region for the ack reply (#3833). */
   scopeMode: ScopeMode;
   scopeName: string;
@@ -46,6 +48,7 @@ const DEFAULTS: AutoAckSettings = {
   cooldownSeconds: 0,
   preSendDelaySeconds: 0,
   testMessages: DEFAULT_TEST_MESSAGES,
+  ignoredNodes: '',
   scopeMode: 'inherit',
   scopeName: '',
 };
@@ -113,6 +116,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
           cooldownSeconds: typeof json.data.cooldownSeconds === 'number' ? json.data.cooldownSeconds : 0,
           preSendDelaySeconds: typeof json.data.preSendDelaySeconds === 'number' ? json.data.preSendDelaySeconds : 0,
           testMessages: json.data.testMessages || DEFAULT_TEST_MESSAGES,
+          ignoredNodes: typeof json.data.ignoredNodes === 'string' ? json.data.ignoredNodes : '',
           scopeMode: (json.data.scopeMode as ScopeMode) || 'inherit',
           scopeName: json.data.scopeName || '',
         };
@@ -164,6 +168,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
       settings.cooldownSeconds !== initial.cooldownSeconds ||
       settings.preSendDelaySeconds !== initial.preSendDelaySeconds ||
       settings.testMessages !== initial.testMessages ||
+      settings.ignoredNodes !== initial.ignoredNodes ||
       settings.scopeMode !== initial.scopeMode ||
       settings.scopeName !== initial.scopeName ||
       channelsChanged,
@@ -193,6 +198,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             cooldownSeconds: settings.cooldownSeconds,
             preSendDelaySeconds: settings.preSendDelaySeconds,
             testMessages: settings.testMessages,
+            ignoredNodes: settings.ignoredNodes,
             scopeMode: settings.scopeMode,
             scopeName: settings.scopeName,
           }),
@@ -440,6 +446,29 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
               {t('meshcore.automation.autoack.presend_delay_help', 'seconds (0 = send immediately, max 120)')}
             </span>
           </div>
+        </div>
+
+        {/* Per-sender ignore list (#4391) */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label htmlFor="meshcoreAutoAckIgnoredNodes">
+            {t('meshcore.automation.autoack.node_ignore_list', 'Sender Ignore List')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.node_ignore_list_description',
+                'Never auto-acknowledge these senders — use it to break a bot echo loop. One entry per line, or comma-separated. An entry is either a public key (full key or any leading prefix, with or without a leading "!") or a contact/sender name. Names are matched ignoring case and extra spaces, and are the only way to exclude a channel sender, because MeshCore channel packets carry no sender key.',
+              )}
+            </span>
+          </label>
+          <textarea
+            id="meshcoreAutoAckIgnoredNodes"
+            value={settings.ignoredNodes}
+            onChange={(e) => update('ignoredNodes', e.target.value)}
+            placeholder={'a1b2c3d4e5f6\nEcho Bot'}
+            disabled={disabled || !canWrite}
+            className="setting-input"
+            rows={3}
+            style={{ fontFamily: 'monospace', resize: 'vertical', minHeight: '70px' }}
+          />
         </div>
 
         {/* MeshCore scope/region for the ack reply (#3833) */}

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -280,6 +280,8 @@ export const VALID_SETTINGS_KEYS = [
   'meshcoreAutoAckCooldownSeconds',
   'meshcoreAutoAckPreSendDelaySeconds',
   'meshcoreAutoAckTestMessages',
+  // Per-sender ignore list for the MeshCore auto-responder (#4391)
+  'meshcoreAutoAckIgnoredNodes',
   // MeshCore auto-announce
   'meshcoreAutoAnnounceEnabled',
   'meshcoreAutoAnnounceIntervalHours',
@@ -450,6 +452,8 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'meshcoreAutoAckCooldownSeconds',
   'meshcoreAutoAckPreSendDelaySeconds',
   'meshcoreAutoAckTestMessages',
+  // Per-sender ignore list for the MeshCore auto-responder (#4391)
+  'meshcoreAutoAckIgnoredNodes',
   // MeshCore auto-announce
   'meshcoreAutoAnnounceEnabled',
   'meshcoreAutoAnnounceIntervalHours',

--- a/src/server/meshcoreAutoAckIgnore.test.ts
+++ b/src/server/meshcoreAutoAckIgnore.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Parser + matcher tests for the MeshCore Auto-Acknowledge sender ignore
+ * list (#4391).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseMeshCoreIgnoreList,
+  isMeshCoreIgnoreListEmpty,
+  isMeshCoreSenderIgnored,
+} from './meshcoreAutoAckIgnore.js';
+
+const FULL_KEY = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const DM_PREFIX = 'a1b2c3d4e5f6'; // 6-byte prefix, the shape a DM actually carries
+
+describe('parseMeshCoreIgnoreList', () => {
+  it('returns an empty list for null/undefined/blank input', () => {
+    for (const raw of [null, undefined, '', '   ', '\n\n', ' , ,\n']) {
+      const list = parseMeshCoreIgnoreList(raw);
+      expect(isMeshCoreIgnoreListEmpty(list)).toBe(true);
+    }
+  });
+
+  it('splits on commas and newlines', () => {
+    const list = parseMeshCoreIgnoreList('aabb,ccdd\neeff\r\n0011');
+    expect(list.keys).toEqual(['aabb', 'ccdd', 'eeff', '0011']);
+  });
+
+  it('keeps names with internal spaces intact (unlike the Meshtastic parser)', () => {
+    const list = parseMeshCoreIgnoreList('Echo Bot, Weather Relay\n  Alice  MeshCore  ');
+    expect(list.names).toEqual(['echo bot', 'weather relay', 'alice meshcore']);
+  });
+
+  it('lowercases hex entries and strips an optional leading "!"', () => {
+    const list = parseMeshCoreIgnoreList('!AABBCCDD');
+    expect(list.keys).toEqual(['aabbccdd']);
+  });
+
+  it('ignores hex entries shorter than two characters', () => {
+    const list = parseMeshCoreIgnoreList('a');
+    expect(list.keys).toEqual([]);
+    expect(list.names).toEqual(['a']);
+  });
+
+  it('files a hex-looking entry under BOTH keys and names', () => {
+    const list = parseMeshCoreIgnoreList('beef');
+    expect(list.keys).toEqual(['beef']);
+    expect(list.names).toEqual(['beef']);
+  });
+
+  it('de-duplicates entries', () => {
+    const list = parseMeshCoreIgnoreList('AABB\naabb, aabb');
+    expect(list.keys).toEqual(['aabb']);
+  });
+});
+
+describe('isMeshCoreSenderIgnored', () => {
+  it('never matches when the list is empty', () => {
+    const list = parseMeshCoreIgnoreList('');
+    expect(isMeshCoreSenderIgnored(list, { publicKey: FULL_KEY, names: ['Echo Bot'] })).toBe(false);
+  });
+
+  it('matches a stored full key against the short prefix a DM carries', () => {
+    const list = parseMeshCoreIgnoreList(FULL_KEY);
+    expect(isMeshCoreSenderIgnored(list, { publicKey: DM_PREFIX })).toBe(true);
+  });
+
+  it('matches a stored short prefix against a full sender key', () => {
+    const list = parseMeshCoreIgnoreList('a1b2c3');
+    expect(isMeshCoreSenderIgnored(list, { publicKey: FULL_KEY })).toBe(true);
+  });
+
+  it('does not match an unrelated key', () => {
+    const list = parseMeshCoreIgnoreList(FULL_KEY);
+    expect(isMeshCoreSenderIgnored(list, { publicKey: 'ffeeddccbbaa' })).toBe(false);
+  });
+
+  it('matches a contact name ignoring case and extra whitespace', () => {
+    const list = parseMeshCoreIgnoreList('echo bot');
+    expect(isMeshCoreSenderIgnored(list, { names: ['  ECHO   Bot '] })).toBe(true);
+  });
+
+  it('matches any of the candidate names (message name or resolved contact)', () => {
+    const list = parseMeshCoreIgnoreList('Weather Relay');
+    expect(isMeshCoreSenderIgnored(list, { names: [undefined, null, 'Weather Relay'] })).toBe(true);
+  });
+
+  it('does not partially match a name', () => {
+    const list = parseMeshCoreIgnoreList('Echo');
+    expect(isMeshCoreSenderIgnored(list, { names: ['Echo Bot'] })).toBe(false);
+  });
+
+  it('never key-matches the synthetic channel-<idx> sender key', () => {
+    // Channel packets carry no sender key; the manager synthesises one.
+    const list = parseMeshCoreIgnoreList('ch,cha,channel');
+    expect(isMeshCoreSenderIgnored(list, { publicKey: 'channel-3' })).toBe(false);
+  });
+
+  it('still excludes a channel sender by name', () => {
+    const list = parseMeshCoreIgnoreList('Echo Bot');
+    expect(isMeshCoreSenderIgnored(list, { publicKey: 'channel-3', names: ['Echo Bot'] })).toBe(true);
+  });
+});

--- a/src/server/meshcoreAutoAckIgnore.ts
+++ b/src/server/meshcoreAutoAckIgnore.ts
@@ -1,0 +1,98 @@
+/**
+ * MeshCore Auto-Acknowledge sender ignore list (#4391).
+ *
+ * The Meshtastic Auto-Acknowledge module skips senders listed in
+ * `autoAckIgnoredNodes`, parsed as canonical `!xxxxxxxx` node IDs. MeshCore has
+ * no equivalent identifier, so this list matches on what a MeshCore operator can
+ * actually see and copy in the UI:
+ *
+ *  - **Public key / key prefix** — hex, with or without a leading `!`. A DM
+ *    arrives carrying only a 12-hex-char (6-byte) key prefix while the contact
+ *    panel shows the full 64-char key, so matching is prefix-wise in BOTH
+ *    directions: a stored entry matches when either value is a prefix of the
+ *    other. Minimum 2 hex characters, so a stray single character can't
+ *    black-hole the whole mesh.
+ *  - **Contact / sender name** — matched case-insensitively with surrounding and
+ *    repeated whitespace collapsed. Names are the ONLY sender identity a channel
+ *    message carries: MeshCore channel packets have no sender field on the wire,
+ *    so the manager synthesises `fromPublicKey` as `channel-<idx>` and recovers
+ *    the sender from the `"Name: "` body prefix. Without name entries a channel
+ *    bot could not be excluded at all.
+ *
+ * Entries are separated by commas or newlines — NOT arbitrary whitespace, unlike
+ * the Meshtastic parser, because MeshCore contact names routinely contain
+ * spaces ("Alice MeshCore").
+ */
+
+export interface MeshCoreIgnoreList {
+  /** Lowercase hex public-key prefixes. */
+  keys: string[];
+  /** Lowercase, whitespace-collapsed display names. */
+  names: string[];
+}
+
+/** Hex entry: 2–64 characters, so a 1-char typo can't match every sender. */
+const HEX_ENTRY = /^[0-9a-f]{2,64}$/;
+const HEX_ONLY = /^[0-9a-f]+$/;
+
+const normalizeName = (value: string): string =>
+  value.trim().replace(/\s+/g, ' ').toLowerCase();
+
+/**
+ * Parse the raw `meshcoreAutoAckIgnoredNodes` setting into key-prefix and name
+ * buckets. An entry that looks like hex lands in BOTH buckets, so a contact
+ * literally named "beef" is still excludable.
+ */
+export function parseMeshCoreIgnoreList(raw: string | null | undefined): MeshCoreIgnoreList {
+  const keys = new Set<string>();
+  const names = new Set<string>();
+  if (!raw) return { keys: [], names: [] };
+
+  for (const token of raw.split(/[,\r\n]+/)) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+    names.add(normalizeName(trimmed));
+    const hex = (trimmed.startsWith('!') ? trimmed.slice(1) : trimmed).toLowerCase();
+    if (HEX_ENTRY.test(hex)) keys.add(hex);
+  }
+
+  return { keys: [...keys], names: [...names] };
+}
+
+export function isMeshCoreIgnoreListEmpty(list: MeshCoreIgnoreList): boolean {
+  return list.keys.length === 0 && list.names.length === 0;
+}
+
+export interface MeshCoreSenderIdentity {
+  /** Public key or key prefix from the triggering message. */
+  publicKey?: string | null;
+  /** Candidate display names (message sender name, resolved contact names). */
+  names?: Array<string | null | undefined>;
+}
+
+/**
+ * True when the sender matches any entry in the ignore list.
+ */
+export function isMeshCoreSenderIgnored(
+  list: MeshCoreIgnoreList,
+  sender: MeshCoreSenderIdentity,
+): boolean {
+  if (isMeshCoreIgnoreListEmpty(list)) return false;
+
+  const key = (sender.publicKey ?? '').trim().toLowerCase();
+  // Channel senders carry a synthetic `channel-<idx>` key — non-hex, so it can
+  // never collide with a real key entry.
+  if (key.length >= 2 && HEX_ONLY.test(key)) {
+    for (const entry of list.keys) {
+      if (key.startsWith(entry) || entry.startsWith(key)) return true;
+    }
+  }
+
+  for (const candidate of sender.names ?? []) {
+    if (!candidate) continue;
+    const name = normalizeName(candidate);
+    if (name && list.names.includes(name)) return true;
+  }
+
+  return false;
+}

--- a/src/server/meshcoreManager.autoAckIgnore.test.ts
+++ b/src/server/meshcoreManager.autoAckIgnore.test.ts
@@ -1,0 +1,194 @@
+/**
+ * MeshCore Auto-Acknowledge sender ignore list — skip decision (#4391).
+ *
+ * A sender on `meshcoreAutoAckIgnoredNodes` must get no auto-reply; everyone
+ * else still does. Entries match a public key (or key prefix) and/or a
+ * contact/sender name, and the setting is read per source.
+ *
+ * Stubs the bridge transport and the settings/channels DB the same way
+ * meshcoreManager.autoAckScope.test.ts does — no real backend or DB.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreMessage } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+
+const FULL_KEY = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const DM_PREFIX = 'a1b2c3d4e5f6';
+
+/** Records every (sourceId, key) pair the manager asked the settings store for. */
+type SettingsRead = { sourceId: string; key: string };
+
+function makeManager(opts: {
+  sourceId?: string;
+  /** Per-source ignore-list value; keyed by sourceId. */
+  ignoredBySource?: Record<string, string | null>;
+  contacts?: Array<{ publicKey: string; advName?: string; name?: string }>;
+} = {}) {
+  const sourceId = opts.sourceId ?? 'source-a';
+  const m = new MeshCoreManager(sourceId);
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+
+  for (const c of opts.contacts ?? []) {
+    (m as any).contacts.set(c.publicKey, c);
+  }
+
+  const sends: Array<{ text: string; dest?: string; channel?: number }> = [];
+  (m as any).sendMessage = vi.fn(async (text: string, dest?: string, channel?: number) => {
+    sends.push({ text, dest, channel });
+    return true;
+  });
+
+  vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
+    getChannelById: vi.fn(async (id: number) => ({ id, name: `ch${id}`, scope: null })),
+    updateChannelScope: vi.fn(async () => {}),
+    upsertChannel: vi.fn(async () => {}),
+    getAllChannels: vi.fn(async () => []),
+    deleteChannel: vi.fn(async () => {}),
+  } as any);
+
+  const base: Record<string, string | null> = {
+    meshcoreAutoAckEnabled: 'true',
+    meshcoreAutoAckRegex: '^(test|ping)',
+    meshcoreAutoAckChannels: '1',
+    meshcoreAutoAckDirectMessages: 'true',
+    meshcoreAutoAckCooldownSeconds: '0',
+    meshcoreAutoAckUseDM: 'false',
+    meshcoreAutoAckMessage: 'ack',
+    meshcoreAutoAckPreSendDelaySeconds: '0',
+    meshcoreAutoAckScopeMode: 'inherit',
+  };
+
+  const reads: SettingsRead[] = [];
+  vi.spyOn(databaseService, 'settings', 'get').mockReturnValue({
+    getSettingForSource: vi.fn(async (sid: string, key: string) => {
+      reads.push({ sourceId: sid, key });
+      if (key === 'meshcoreAutoAckIgnoredNodes') return opts.ignoredBySource?.[sid] ?? null;
+      return key in base ? base[key] : null;
+    }),
+    setSourceSetting: vi.fn(async () => {}),
+  } as any);
+
+  return { manager: m, sends, reads };
+}
+
+function dmMessage(overrides: Partial<MeshCoreMessage> = {}): MeshCoreMessage {
+  return {
+    id: 'm1',
+    fromPublicKey: DM_PREFIX,
+    fromName: 'Echo Bot',
+    text: 'ping',
+    timestamp: Date.now(),
+    scopeCode: null,
+    scopeName: null,
+    ...overrides,
+  };
+}
+
+function channelMessage(overrides: Partial<MeshCoreMessage> = {}): MeshCoreMessage {
+  return {
+    id: 'm2',
+    // Channel packets carry no sender key — the manager synthesises this.
+    fromPublicKey: 'channel-1',
+    fromName: 'Echo Bot',
+    text: 'ping',
+    timestamp: Date.now(),
+    scopeCode: null,
+    scopeName: null,
+    ...overrides,
+  };
+}
+
+describe('MeshCoreManager — Auto-Ack sender ignore list (#4391)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('replies when the ignore list is unset', async () => {
+    const { manager, sends } = makeManager();
+    await (manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect(sends).toHaveLength(1);
+  });
+
+  it('replies when the ignore list is whitespace-only', async () => {
+    const { manager, sends } = makeManager({ ignoredBySource: { 'source-a': '  \n , \n ' } });
+    await (manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect(sends).toHaveLength(1);
+  });
+
+  it('skips a DM sender listed by full public key (message carries only the prefix)', async () => {
+    const { manager, sends } = makeManager({
+      ignoredBySource: { 'source-a': FULL_KEY },
+      contacts: [{ publicKey: FULL_KEY, advName: 'Echo Bot' }],
+    });
+    await (manager as any).checkAutoAcknowledge(dmMessage(), true, undefined, null, null);
+    expect(sends).toHaveLength(0);
+  });
+
+  it('skips a DM sender listed by short key prefix with a leading "!"', async () => {
+    const { manager, sends } = makeManager({
+      ignoredBySource: { 'source-a': '!A1B2C3' },
+      contacts: [{ publicKey: FULL_KEY, advName: 'Echo Bot' }],
+    });
+    await (manager as any).checkAutoAcknowledge(dmMessage(), true, undefined, null, null);
+    expect(sends).toHaveLength(0);
+  });
+
+  it('replies to a DM sender whose key is not on the list', async () => {
+    const { manager, sends } = makeManager({
+      ignoredBySource: { 'source-a': 'ffeeddcc' },
+      contacts: [{ publicKey: FULL_KEY, advName: 'Echo Bot' }],
+    });
+    await (manager as any).checkAutoAcknowledge(dmMessage(), true, undefined, null, null);
+    expect(sends).toHaveLength(1);
+  });
+
+  it('skips a channel sender listed by name (case/space-insensitive)', async () => {
+    const { manager, sends } = makeManager({ ignoredBySource: { 'source-a': 'echo   BOT' } });
+    await (manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect(sends).toHaveLength(0);
+  });
+
+  it('skips a sender matched via the resolved contact name, not the message name', async () => {
+    const { manager, sends } = makeManager({
+      ignoredBySource: { 'source-a': 'Weather Relay' },
+      contacts: [{ publicKey: FULL_KEY, advName: 'Weather Relay' }],
+    });
+    await (manager as any).checkAutoAcknowledge(
+      dmMessage({ fromName: undefined }), true, undefined, null, null,
+    );
+    expect(sends).toHaveLength(0);
+  });
+
+  it('replies to a channel sender whose name is not on the list', async () => {
+    const { manager, sends } = makeManager({ ignoredBySource: { 'source-a': 'Someone Else' } });
+    await (manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect(sends).toHaveLength(1);
+  });
+
+  it('reads the ignore list for its own sourceId', async () => {
+    const { manager, reads } = makeManager({ sourceId: 'source-b' });
+    await (manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    const ignoreReads = reads.filter(r => r.key === 'meshcoreAutoAckIgnoredNodes');
+    expect(ignoreReads).toHaveLength(1);
+    expect(ignoreReads[0].sourceId).toBe('source-b');
+  });
+
+  it('isolates the list per source — source-a skips, source-b still replies', async () => {
+    const ignoredBySource = { 'source-a': 'Echo Bot', 'source-b': null };
+
+    const a = makeManager({ sourceId: 'source-a', ignoredBySource });
+    await (a.manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect(a.sends).toHaveLength(0);
+
+    vi.restoreAllMocks();
+    const b = makeManager({ sourceId: 'source-b', ignoredBySource });
+    await (b.manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect(b.sends).toHaveLength(1);
+  });
+
+  it('does not consume a cooldown slot for an ignored sender', async () => {
+    const { manager, sends } = makeManager({ ignoredBySource: { 'source-a': 'Echo Bot' } });
+    await (manager as any).checkAutoAcknowledge(channelMessage(), false, 1, null, null);
+    expect((manager as any).autoAckCooldowns.size).toBe(0);
+    expect(sends).toHaveLength(0);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -24,6 +24,11 @@ import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
 import { resolveMessageScope } from './meshcoreScopeResolve.js';
 import {
+  parseMeshCoreIgnoreList,
+  isMeshCoreIgnoreListEmpty,
+  isMeshCoreSenderIgnored,
+} from './meshcoreAutoAckIgnore.js';
+import {
   MeshCoreVirtualNodeServer,
   type MeshCoreVirtualNodeConfig,
 } from './meshcoreVirtualNodeServer.js';
@@ -6898,6 +6903,24 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         );
         if (channelIdx === undefined || !enabledChannels.has(channelIdx)) {
           logger.debug(`[MeshCore:${sourceId}] Auto-ack: channel ${channelIdx} not in allowlist`);
+          return;
+        }
+      }
+
+      // Per-sender ignore list (#4391): keeps a chatty bot from echo-looping
+      // with the auto-responder. Checked BEFORE the cooldown so an ignored
+      // sender never consumes a cooldown slot. Entries match a public key
+      // (or key prefix) and/or a contact/sender name — see meshcoreAutoAckIgnore.ts.
+      const ignoreList = parseMeshCoreIgnoreList(
+        await settings.getSettingForSource(sourceId, 'meshcoreAutoAckIgnoredNodes'),
+      );
+      if (!isMeshCoreIgnoreListEmpty(ignoreList)) {
+        const senderContact = this.resolveContactByPrefix(message.fromPublicKey);
+        if (isMeshCoreSenderIgnored(ignoreList, {
+          publicKey: message.fromPublicKey,
+          names: [message.fromName, senderContact?.advName, senderContact?.name],
+        })) {
+          logger.debug(`[MeshCore:${sourceId}] Auto-ack: sender ${message.fromName ?? message.fromPublicKey} is on the ignore list`);
           return;
         }
       }

--- a/src/server/routes/meshcoreAutomationRoutes.ts
+++ b/src/server/routes/meshcoreAutomationRoutes.ts
@@ -268,6 +268,7 @@ router.get(
       const cooldownSeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckCooldownSeconds');
       const preSendDelaySeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckPreSendDelaySeconds');
       const testMessages = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckTestMessages');
+      const ignoredNodes = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckIgnoredNodes');
       const scopeMode = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeMode');
       const scopeName = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckScopeName');
 
@@ -290,6 +291,8 @@ router.get(
           // value written directly to the DB can't escape the UI's bounds.
           preSendDelaySeconds: resolveAutoAckPreSendDelaySeconds(preSendDelaySeconds),
           testMessages: testMessages || 'test\nTest message\nping\nPING\nHello world\nTESTING 123',
+          // Per-sender ignore list (#4391): key prefixes and/or contact names.
+          ignoredNodes: ignoredNodes || '',
           // MeshCore scope/region for the ack reply (#3833).
           scopeMode: (scopeMode as 'inherit' | 'trigger' | 'unscoped' | 'named') || 'inherit',
           scopeName: scopeName || '',
@@ -320,6 +323,7 @@ router.post(
         cooldownSeconds,
         preSendDelaySeconds,
         testMessages,
+        ignoredNodes,
         scopeMode,
         scopeName,
       } = req.body as {
@@ -332,6 +336,7 @@ router.post(
         cooldownSeconds?: number;
         preSendDelaySeconds?: number;
         testMessages?: string;
+        ignoredNodes?: string;
         scopeMode?: 'inherit' | 'trigger' | 'unscoped' | 'named';
         scopeName?: string;
       };
@@ -378,6 +383,11 @@ router.post(
       }
       if (testMessages !== undefined) {
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAckTestMessages', testMessages);
+      }
+      if (ignoredNodes !== undefined) {
+        // Stored verbatim (minus edge whitespace) so the operator's own layout
+        // survives a round-trip; parsing happens at match time (#4391).
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckIgnoredNodes', String(ignoredNodes).trim());
       }
       if (scopeMode !== undefined) {
         const mode = ['inherit', 'trigger', 'unscoped', 'named'].includes(String(scopeMode)) ? String(scopeMode) : 'inherit';


### PR DESCRIPTION
## Summary

The Meshtastic Auto-Acknowledge module has a per-node ignore list (`autoAckIgnoredNodes`); the MeshCore auto-responder had none, so a bot could echo-loop with it. This mirrors the feature for MeshCore.

New per-source setting: **`meshcoreAutoAckIgnoredNodes`** (registered in both `VALID_SETTINGS_KEYS` and `PER_SOURCE_SETTINGS_KEYS`).

## What was mirrored

| Meshtastic | MeshCore (this PR) |
|---|---|
| `AutoAcknowledgeSection.tsx` "Node Ignore List" textarea | `MeshCoreAutoAckSection.tsx` "Sender Ignore List" textarea, same visual style (label + `setting-description` + monospace textarea) |
| `autoAckIgnoredNodes` setting | `meshcoreAutoAckIgnoredNodes` setting |
| Inline parse + skip in `meshtasticManager.checkAutoAcknowledge` | `src/server/meshcoreAutoAckIgnore.ts` parser/matcher, applied in `meshcoreManager.checkAutoAcknowledge` |
| `automation.auto_ack.node_ignore_list[_description]` | `meshcore.automation.autoack.node_ignore_list[_description]` |

Read/write plumbed through `GET`/`POST /api/sources/:id/meshcore/automation/autoack` as `ignoredNodes`.

The skip runs **before** the per-sender cooldown, so an ignored sender never consumes a cooldown slot.

## Accepted entry format, and why it differs from Meshtastic node IDs

Meshtastic has one canonical sender identity — a 32-bit node ID rendered `!xxxxxxxx` — so its parser splits on any whitespace/comma and keeps only 8-hex-char tokens. MeshCore has no such identifier, so entries match what an operator can actually see and copy:

- **Public key or key prefix** — hex, with or without a leading `!`. A DM arrives carrying only a 12-hex-char (6-byte) key prefix while the contact panel shows the full 64-char key, so matching is prefix-wise **in both directions**: an entry matches when either value is a prefix of the other. Minimum 2 hex chars, so a stray single character can't black-hole the mesh.
- **Contact / sender name** — matched case-insensitively with surrounding and repeated whitespace collapsed. Names are the **only** sender identity a channel message carries: MeshCore channel packets have no sender field on the wire, so the manager synthesises `fromPublicKey` as `channel-<idx>` and recovers the sender from the `"Name: "` body prefix. Without name entries a channel bot could not be excluded at all. Candidates checked: the message's `fromName`, plus the resolved contact's `advName` / `name`.
- A hex-looking entry is filed under **both** buckets, so a contact literally named "beef" is still excludable. The synthetic `channel-<idx>` key is non-hex and can never collide with a key entry.

**Separators are commas and newlines only** — not arbitrary whitespace as in the Meshtastic parser — because MeshCore contact names routinely contain spaces ("Alice MeshCore"). Comma- and newline-separated entry lists therefore behave the same as the Meshtastic field.

The format is documented in the field's help text (i18n string, English source in `en.json`, empty-string placeholders in the other nine locales per this repo's untranslated-key convention) and in the module header of `src/server/meshcoreAutoAckIgnore.ts`.

## Files changed

- `src/server/meshcoreAutoAckIgnore.ts` (new) — parser + matcher
- `src/server/meshcoreManager.ts` — skip decision in `checkAutoAcknowledge`
- `src/server/constants/settings.ts` — key registration (both lists)
- `src/server/routes/meshcoreAutomationRoutes.ts` — GET/POST `ignoredNodes`
- `src/components/MeshCore/MeshCoreAutoAckSection.tsx` — UI field
- `public/locales/*.json` (10) — two new keys
- `src/server/meshcoreAutoAckIgnore.test.ts` (new) — 16 parser/matcher tests
- `src/server/meshcoreManager.autoAckIgnore.test.ts` (new) — 11 skip-decision tests

## Test evidence

New coverage: sender on the list ⇒ no auto-reply (by full key, by short `!`-prefixed prefix, by channel-sender name, by resolved contact name); sender not on it ⇒ reply; unset and whitespace-only settings ⇒ everyone gets a reply; the setting is read for the manager's own `sourceId` and `source-a` skipping does not affect `source-b`; an ignored sender consumes no cooldown slot; the synthetic `channel-<idx>` key never key-matches.

```
npx tsc -p tsconfig.server.json --noEmit   # No errors found
npx tsc -p tsconfig.json --noEmit          # No errors found
npx vitest run --reporter=json --maxWorkers=2
  success: true | numTotalTests: 12075 | numFailedTests: 0 | numFailedTestSuites: 0 | numPendingTests: 109
npm run lint:ci   # 0 in-repo FAIL lines
```

Closes #4391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob
