### PR TITLE
feat(map): per-overlay toggle to disable the GeoJSON click popup (#4344)

### DIFF
--- a/src/components/GeoJsonLayerManager.tsx
+++ b/src/components/GeoJsonLayerManager.tsx
@@ -147,6 +147,20 @@ const GeoJsonLayerManager: React.FC = () => {
                 <span style={{ fontSize: '0.85em' }}>Public</span>
               </label>
 
+              {/* Click popup opt-out (issue #4344) — off by default, so layers
+                  keep the popup they have today. */}
+              <label
+                style={{ display: 'flex', alignItems: 'center', gap: '4px', cursor: 'pointer' }}
+                title="Suppress the popup that opens when you click this layer's features, so map clicks (such as creating a Waypoint) pass through. The hover tooltip still shows the feature name."
+              >
+                <input
+                  type="checkbox"
+                  checked={layer.disablePopup ?? false}
+                  onChange={(e) => updateLayer(layer.id, { disablePopup: e.target.checked })}
+                />
+                <span style={{ fontSize: '0.85em' }}>Disable click popup</span>
+              </label>
+
               {/* Color */}
               <label style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                 <span style={{ fontSize: '0.85em' }}>Color</span>

--- a/src/components/GeoJsonOverlay.test.tsx
+++ b/src/components/GeoJsonOverlay.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * GeoJsonOverlay — per-overlay click-popup opt-out (issue #4344).
+ *
+ * The point of these tests: when a layer sets `disablePopup`, the feature must
+ * NOT get a click popup bound, while the hover tooltip binding stays exactly as
+ * it was. (The tooltip is deliberately out of scope here — issue #4342 tracks
+ * the separate tooltip/Waypoint interaction bug.)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import type { GeoJsonLayer } from '../server/services/geojsonService.js';
+import GeoJsonOverlay from './GeoJsonOverlay';
+
+/** Stub leaflet layer handed to `onEachFeature`. */
+interface LayerStub {
+  bindPopup: ReturnType<typeof vi.fn>;
+  bindTooltip: ReturnType<typeof vi.fn>;
+}
+type OnEachFeature = (
+  feature: { properties: Record<string, unknown> },
+  leafletLayer: LayerStub
+) => void;
+
+// `vi.mock` factories are hoisted above the imports, so anything they close over
+// must come from `vi.hoisted` — a plain module-level const is still in its
+// temporal dead zone when the factory runs.
+const mocks = vi.hoisted(() => ({
+  // Captures the props react-leaflet's <GeoJSON> would have received, so a test
+  // can drive `onEachFeature` directly with a stub leaflet layer.
+  capturedGeoJsonProps: [] as Array<{ onEachFeature: unknown }>,
+  featureCollection: {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-122.4, 37.8] },
+        properties: { name: 'Sector 7', note: 'restricted' },
+      },
+    ],
+  },
+}));
+
+vi.mock('react-leaflet', () => ({
+  GeoJSON: (props: { onEachFeature: unknown }) => {
+    mocks.capturedGeoJsonProps.push(props);
+    return <div data-testid="geojson-layer" />;
+  },
+}));
+
+vi.mock('leaflet', () => ({
+  default: { circleMarker: vi.fn() },
+}));
+
+vi.mock('../services/api', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue(mocks.featureCollection),
+    getBaseUrl: vi.fn().mockResolvedValue(''),
+  },
+}));
+
+function makeLayer(overrides: Partial<GeoJsonLayer> = {}): GeoJsonLayer {
+  return {
+    id: 'layer-1',
+    name: 'Test Layer',
+    filename: 'layer-1.geojson',
+    visible: true,
+    publiclyVisible: false,
+    disablePopup: false,
+    style: { color: '#e74c3c', opacity: 0.7, weight: 2, fillOpacity: 0.3 },
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+/** Renders the overlay and runs its `onEachFeature` against a stub leaflet layer. */
+async function bindFirstFeature(layer: GeoJsonLayer): Promise<LayerStub> {
+  render(<GeoJsonOverlay layers={[layer]} />);
+  await waitFor(() => expect(mocks.capturedGeoJsonProps.length).toBeGreaterThan(0));
+
+  const stub: LayerStub = { bindPopup: vi.fn(), bindTooltip: vi.fn() };
+  const last = mocks.capturedGeoJsonProps[mocks.capturedGeoJsonProps.length - 1];
+  (last.onEachFeature as OnEachFeature)(
+    { properties: { name: 'Sector 7', note: 'restricted' } },
+    stub
+  );
+  return stub;
+}
+
+describe('GeoJsonOverlay — disablePopup (#4344)', () => {
+  beforeEach(() => {
+    mocks.capturedGeoJsonProps.length = 0;
+  });
+
+  it('binds both popup and tooltip by default', async () => {
+    const stub = await bindFirstFeature(makeLayer());
+
+    expect(stub.bindPopup).toHaveBeenCalledTimes(1);
+    expect(String(stub.bindPopup.mock.calls[0][0])).toContain('Sector 7');
+    expect(stub.bindTooltip).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not bind the click popup when disablePopup is set', async () => {
+    const stub = await bindFirstFeature(makeLayer({ disablePopup: true }));
+
+    expect(stub.bindPopup).not.toHaveBeenCalled();
+  });
+
+  it('still binds the hover tooltip when disablePopup is set', async () => {
+    const stub = await bindFirstFeature(makeLayer({ disablePopup: true }));
+
+    expect(stub.bindTooltip).toHaveBeenCalledTimes(1);
+    expect(stub.bindTooltip).toHaveBeenCalledWith('Sector 7', {
+      permanent: false,
+      sticky: true,
+    });
+  });
+
+  it('treats a legacy layer without the field as popup-enabled', async () => {
+    const legacy = makeLayer();
+    delete (legacy as Partial<GeoJsonLayer>).disablePopup;
+
+    const stub = await bindFirstFeature(legacy);
+
+    expect(stub.bindPopup).toHaveBeenCalledTimes(1);
+    expect(stub.bindTooltip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/GeoJsonOverlay.tsx
+++ b/src/components/GeoJsonOverlay.tsx
@@ -101,12 +101,18 @@ const GeoJsonOverlay: React.FC<GeoJsonOverlayProps> = ({
               const label = labelKey ? props[labelKey] as string : undefined;
 
               if (label) {
-                // Build popup with all non-empty string properties
-                const popupLines = Object.entries(props)
-                  .filter(([, v]) => v && typeof v === 'string' && String(v).length < 200)
-                  .slice(0, 10)
-                  .map(([k, v]) => `<b>${k}:</b> ${v}`);
-                leafletLayer.bindPopup(popupLines.join('<br/>'));
+                // Click popup is per-layer opt-out (issue #4344). Skipping the
+                // bind leaves the feature click-through, so map click handlers
+                // (e.g. create Waypoint) still fire over the overlay. The hover
+                // tooltip below is deliberately unaffected either way.
+                if (!layer.disablePopup) {
+                  // Build popup with all non-empty string properties
+                  const popupLines = Object.entries(props)
+                    .filter(([, v]) => v && typeof v === 'string' && String(v).length < 200)
+                    .slice(0, 10)
+                    .map(([k, v]) => `<b>${k}:</b> ${v}`);
+                  leafletLayer.bindPopup(popupLines.join('<br/>'));
+                }
                 leafletLayer.bindTooltip(label, { permanent: false, sticky: true });
               }
             }}

--- a/src/server/routes/geojsonRoutes.disablePopup.test.ts
+++ b/src/server/routes/geojsonRoutes.disablePopup.test.ts
@@ -1,0 +1,156 @@
+/**
+ * GeoJSON Routes — per-overlay "disable click popup" flag (issue #4344)
+ *
+ * Uses the real-middleware harness (createRouteTestApp) rather than the
+ * monkey-patched DatabaseService pattern in geojsonRoutes.test.ts, so the
+ * `settings:write` gate on PUT /layers/:id is enforced by real SQL.
+ *
+ * The GeoJsonService itself is real, backed by a per-test temp directory —
+ * the flag's persistence is exercised end to end (HTTP → manifest.json → HTTP).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GeoJsonService } from '../services/geojsonService.js';
+import { createGeoJsonRouter } from './geojsonRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+const VALID_GEOJSON = JSON.stringify({
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [-122.4, 37.8] },
+      properties: { name: 'Test Point' },
+    },
+  ],
+});
+
+describe('geojsonRoutes — disablePopup flag (#4344)', () => {
+  let harness: RouteTestHarness;
+  let tmpDir: string;
+  let service: GeoJsonService;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'geojson-popup-route-'));
+    service = new GeoJsonService(tmpDir);
+    harness = await createRouteTestApp({
+      mount: app => app.use('/api/geojson', createGeoJsonRouter(service)),
+    });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('serves disablePopup=false for a freshly uploaded layer', async () => {
+    service.addLayer('fresh.geojson', VALID_GEOJSON);
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/api/geojson/layers');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].disablePopup).toBe(false);
+  });
+
+  it('PUT sets disablePopup and the value survives a re-read', async () => {
+    const layer = service.addLayer('toggle.geojson', VALID_GEOJSON);
+    const agent = await harness.loginAs(harness.admin);
+
+    const put = await agent
+      .put(`/api/geojson/layers/${layer.id}`)
+      .send({ disablePopup: true });
+    expect(put.status).toBe(200);
+    expect(put.body.disablePopup).toBe(true);
+
+    const list = await agent.get('/api/geojson/layers');
+    expect(list.body[0].disablePopup).toBe(true);
+
+    // And it persisted to the manifest on disk, not just in memory.
+    expect(
+      new GeoJsonService(tmpDir).getLayers().find(l => l.id === layer.id)?.disablePopup
+    ).toBe(true);
+  });
+
+  it('PUT can turn disablePopup back off', async () => {
+    const layer = service.addLayer('backoff.geojson', VALID_GEOJSON);
+    const agent = await harness.loginAs(harness.admin);
+
+    await agent.put(`/api/geojson/layers/${layer.id}`).send({ disablePopup: true });
+    const off = await agent
+      .put(`/api/geojson/layers/${layer.id}`)
+      .send({ disablePopup: false });
+
+    expect(off.status).toBe(200);
+    expect(off.body.disablePopup).toBe(false);
+  });
+
+  it('a PUT that omits disablePopup leaves it unchanged', async () => {
+    const layer = service.addLayer('partial.geojson', VALID_GEOJSON);
+    const agent = await harness.loginAs(harness.admin);
+
+    await agent.put(`/api/geojson/layers/${layer.id}`).send({ disablePopup: true });
+    const rename = await agent
+      .put(`/api/geojson/layers/${layer.id}`)
+      .send({ name: 'renamed' });
+
+    expect(rename.status).toBe(200);
+    expect(rename.body.name).toBe('renamed');
+    expect(rename.body.disablePopup).toBe(true);
+  });
+
+  it('rejects the toggle for a user without settings:write', async () => {
+    const layer = service.addLayer('denied.geojson', VALID_GEOJSON);
+    const agent = await harness.loginAs(harness.limited);
+
+    const res = await agent
+      .put(`/api/geojson/layers/${layer.id}`)
+      .send({ disablePopup: true });
+
+    expect(res.status).toBe(403);
+    expect(service.getLayers()[0].disablePopup).toBe(false);
+  });
+
+  it('allows the toggle once settings:write is granted', async () => {
+    const layer = service.addLayer('granted.geojson', VALID_GEOJSON);
+    await harness.grant(harness.limited.id, 'settings', 'write');
+    const agent = await harness.loginAs(harness.limited);
+
+    const res = await agent
+      .put(`/api/geojson/layers/${layer.id}`)
+      .send({ disablePopup: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.disablePopup).toBe(true);
+  });
+
+  it('404s with the shared error envelope for an unknown layer', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .put('/api/geojson/layers/does-not-exist')
+      .send({ disablePopup: true });
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('GEOJSON_LAYER_NOT_FOUND');
+  });
+
+  it('exposes disablePopup to anonymous viewers of a public layer', async () => {
+    const layer = service.addLayer('publicpopup.geojson', VALID_GEOJSON);
+    const admin = await harness.loginAs(harness.admin);
+    await admin
+      .put(`/api/geojson/layers/${layer.id}`)
+      .send({ publiclyVisible: true, disablePopup: true });
+
+    const anon = await harness.loginAs(null);
+    const res = await anon.get('/api/geojson/layers');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].disablePopup).toBe(true);
+  });
+});

--- a/src/server/routes/geojsonRoutes.ts
+++ b/src/server/routes/geojsonRoutes.ts
@@ -9,6 +9,7 @@ import express from 'express';
 import { GeoJsonService, LayerStyle } from '../services/geojsonService.js';
 import { logger } from '../../utils/logger.js';
 import { requirePermission, optionalAuth } from '../auth/authMiddleware.js';
+import { fail } from '../utils/apiResponse.js';
 
 /** True when the request is unauthenticated (the optionalAuth anonymous fallback). */
 function isAnonymousRequest(req: Request): boolean {
@@ -91,21 +92,31 @@ export function createGeoJsonRouter(service: GeoJsonService): Router {
 
   /**
    * PUT /api/geojson/layers/:id
-   * Update layer metadata (name, visible, style)
+   * Update layer metadata (name, visible, publiclyVisible, disablePopup, style).
+   *
+   * Success stays a bare layer object (no `ok()` envelope): the manager UI reads
+   * `await response.json()` as the layer directly, and ApiService does not unwrap
+   * `data`. Error paths use the shared `fail()` helper, which is always safe.
    */
   router.put('/layers/:id', requirePermission('settings', 'write'), express.json(), async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const updates = req.body as { name?: string; visible?: boolean; publiclyVisible?: boolean; style?: LayerStyle };
+      const updates = req.body as {
+        name?: string;
+        visible?: boolean;
+        publiclyVisible?: boolean;
+        disablePopup?: boolean;
+        style?: LayerStyle;
+      };
       const layer = service.updateLayer(id, updates);
       return res.json(layer);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error('[GeoJsonRoutes] Error updating layer:', error);
       if (message.toLowerCase().includes('not found')) {
-        return res.status(404).json({ error: message });
+        return fail(res, 404, 'GEOJSON_LAYER_NOT_FOUND', message);
       }
-      return res.status(500).json({ error: message });
+      return fail(res, 500, 'GEOJSON_LAYER_UPDATE_FAILED', message);
     }
   });
 

--- a/src/server/services/geojsonService.test.ts
+++ b/src/server/services/geojsonService.test.ts
@@ -276,4 +276,63 @@ describe('GeoJsonService', () => {
       expect(() => service.getPublicLayerData(priv.id)).toThrow(/not found/i);
     });
   });
+
+  // --- Click-popup opt-out (issue #4344) ---
+  describe('disablePopup', () => {
+    it('defaults new layers to disablePopup=false (popup stays on)', () => {
+      const layer = service.addLayer('popup.geojson', validFeatureCollection);
+      expect(layer.disablePopup).toBe(false);
+    });
+
+    it('defaults discovered layers to disablePopup=false', () => {
+      fs.writeFileSync(path.join(tmpDir, 'dropped-in.geojson'), validFeatureCollection, 'utf-8');
+      const discovered = service.discoverLayers();
+      expect(discovered).toHaveLength(1);
+      expect(discovered[0].disablePopup).toBe(false);
+    });
+
+    it('backfills disablePopup=false for legacy manifest entries', () => {
+      // Legacy manifest written without the field (pre-#4344)
+      const legacy = { layers: [{ id: 'legacy', name: 'Legacy', filename: 'legacy.geojson', visible: true, publiclyVisible: false, style: { color: '#000', opacity: 0.7, weight: 2, fillOpacity: 0.3 }, createdAt: 1, updatedAt: 1 }] };
+      fs.writeFileSync(path.join(tmpDir, 'manifest.json'), JSON.stringify(legacy));
+      const manifest = service.loadManifest();
+      expect(manifest.layers[0].disablePopup).toBe(false);
+    });
+
+    it('round-trips through the manifest on disk', () => {
+      const layer = service.addLayer('roundtrip.geojson', validFeatureCollection);
+
+      expect(service.updateLayer(layer.id, { disablePopup: true }).disablePopup).toBe(true);
+      // Fresh instance re-reads manifest.json — proves it persisted rather than
+      // only mutating the in-memory object.
+      expect(
+        new GeoJsonService(tmpDir).getLayers().find(l => l.id === layer.id)?.disablePopup
+      ).toBe(true);
+
+      expect(service.updateLayer(layer.id, { disablePopup: false }).disablePopup).toBe(false);
+      expect(
+        new GeoJsonService(tmpDir).getLayers().find(l => l.id === layer.id)?.disablePopup
+      ).toBe(false);
+    });
+
+    it('leaves the other layer fields untouched when toggled', () => {
+      const layer = service.addLayer('isolated.geojson', validFeatureCollection);
+      service.updateLayer(layer.id, { publiclyVisible: true, name: 'keepme' });
+
+      const updated = service.updateLayer(layer.id, { disablePopup: true });
+      expect(updated.name).toBe('keepme');
+      expect(updated.publiclyVisible).toBe(true);
+      expect(updated.visible).toBe(true);
+      expect(updated.style.color).toBe(layer.style.color);
+    });
+
+    it('is preserved on layers served to public viewers', () => {
+      const pub = service.addLayer('pubpopup.geojson', validFeatureCollection);
+      service.updateLayer(pub.id, { publiclyVisible: true, disablePopup: true });
+
+      const publicLayers = service.getPublicLayers();
+      expect(publicLayers).toHaveLength(1);
+      expect(publicLayers[0].disablePopup).toBe(true);
+    });
+  });
 });

--- a/src/server/services/geojsonService.ts
+++ b/src/server/services/geojsonService.ts
@@ -34,6 +34,16 @@ export interface GeoJsonLayer {
    * Default false — public exposure is per-layer opt-in (issue #3407).
    */
   publiclyVisible: boolean;
+  /**
+   * When true, the layer's features do NOT bind a click popup. The hover
+   * tooltip is unaffected. Default false — popups stay on, matching the
+   * behaviour every layer had before issue #4344.
+   *
+   * Why it exists: a popup-bound overlay swallows map clicks, so operators who
+   * want click-to-create-Waypoint over an overlay area can opt that layer out
+   * while others keep the popup.
+   */
+  disablePopup: boolean;
   style: LayerStyle;
   createdAt: number;
   updatedAt: number;
@@ -105,8 +115,11 @@ export class GeoJsonService {
       const manifest = JSON.parse(raw) as GeoJsonManifest;
       // Backfill publiclyVisible for layers created before #3407 — default to
       // false so pre-existing layers stay private until explicitly opted in.
+      // Backfill disablePopup for layers created before #4344 — default false
+      // so existing overlays keep their click popup.
       for (const layer of manifest.layers ?? []) {
         if (layer.publiclyVisible === undefined) layer.publiclyVisible = false;
+        if (layer.disablePopup === undefined) layer.disablePopup = false;
       }
       return manifest;
     } catch (err) {
@@ -194,6 +207,7 @@ export class GeoJsonService {
       filename,
       visible: true,
       publiclyVisible: false,
+      disablePopup: false,
       style: {
         color,
         opacity: 0.7,
@@ -247,7 +261,9 @@ export class GeoJsonService {
 
   updateLayer(
     id: string,
-    updates: Partial<Pick<GeoJsonLayer, 'name' | 'visible' | 'publiclyVisible' | 'style'>>
+    updates: Partial<
+      Pick<GeoJsonLayer, 'name' | 'visible' | 'publiclyVisible' | 'disablePopup' | 'style'>
+    >
   ): GeoJsonLayer {
     const manifest = this.loadManifest();
     const index = manifest.layers.findIndex(l => l.id === id);
@@ -261,6 +277,7 @@ export class GeoJsonService {
     if (updates.name !== undefined) layer.name = updates.name;
     if (updates.visible !== undefined) layer.visible = updates.visible;
     if (updates.publiclyVisible !== undefined) layer.publiclyVisible = updates.publiclyVisible;
+    if (updates.disablePopup !== undefined) layer.disablePopup = updates.disablePopup;
     if (updates.style !== undefined) layer.style = { ...layer.style, ...updates.style };
     layer.updatedAt = Date.now();
 
@@ -322,6 +339,7 @@ export class GeoJsonService {
         filename: newFilename,
         visible: true,
         publiclyVisible: false,
+        disablePopup: false,
         style: {
           color: DEFAULT_COLOR_PALETTE[colorIndex],
           opacity: 0.7,


### PR DESCRIPTION
Adds a third per-overlay checkbox — **Disable click popup** — next to *Visible* and *Public* in Map settings. When set, that overlay's features no longer bind a click popup, so a map click (for example create-Waypoint) passes through the overlay area. The hover tooltip is untouched.

This is a per-overlay preference, not a behaviour change: the default is off, so every existing overlay keeps the popup it has today.

Deliberately separate from #4342 (the tooltip-blocks-Waypoint bug) — no tooltip behaviour is changed here.

## No migration was needed — and why

GeoJSON overlays are **not stored in the database**. There is no overlay table, no `src/db/schema/` entry, and no repository: `GeoJsonService` persists the overlay list as `/data/geojson/manifest.json` on disk (`grep -ril geojson src/db/` returns nothing). So the new flag is a field on the existing manifest JSON blob, exactly where `visible` and `publiclyVisible` already live — adding a DB column would have created a second, disconnected source of truth.

Backward compatibility is handled the same way #3407 handled `publiclyVisible`: `loadManifest()` backfills `disablePopup = false` on any layer written before this change, and the frontend reads `layer.disablePopup ?? false`. A manifest from an older build therefore behaves exactly as it does today (popup enabled). Both paths are covered by tests.

## Changes

| File | Change |
|------|--------|
| `src/server/services/geojsonService.ts` | `disablePopup: boolean` on `GeoJsonLayer`; defaults to `false` in `addLayer` and `discoverLayers`; backfilled in `loadManifest`; accepted by `updateLayer` |
| `src/server/routes/geojsonRoutes.ts` | `PUT /api/geojson/layers/:id` accepts `disablePopup`; error paths converted to the shared `fail()` envelope |
| `src/components/GeoJsonOverlay.tsx` | Skips `bindPopup` when the flag is set; `bindTooltip` binding left exactly as-is |
| `src/components/GeoJsonLayerManager.tsx` | Third checkbox with hover help text, following the *Public* pattern |
| `src/server/services/geojsonService.test.ts` | Round-trip / default / backfill / isolation coverage |
| `src/server/routes/geojsonRoutes.disablePopup.test.ts` | New route tests on the `createRouteTestApp()` harness (real session + real `requirePermission` SQL) |
| `src/components/GeoJsonOverlay.test.tsx` | Popup not bound when the flag is set, tooltip still bound |

The PUT success response stays a bare layer object rather than moving to `ok()`: `GeoJsonLayerManager` reads `await response.json()` as the layer directly and `ApiService.request()` does not unwrap `data`, so enveloping the success payload would break the consumer. `fail()` is used on the error paths, which is always safe.

No i18n keys were added — this project has no locale files; the existing *Visible* / *Public* labels are inline strings with a `title` help attribute, and the new checkbox follows that pattern.

## Verification

Both multi-backend containers were up for the run, so the PostgreSQL and MySQL suites really executed rather than skipping silently:

```
docker run -d --rm --name mm-test-pg-4344    ... -p 5433:5432 postgres:16
docker run -d --rm --name mm-test-mysql-4344 ... -p 3307:3306 mysql:8.4
```

- `npx tsc -p tsconfig.server.json --noEmit` — clean
- `npx tsc --noEmit` (frontend) — clean
- `npm run lint:ci` — `Lint ratchet OK`, no in-repo `FAIL` lines
- Full Vitest suite — `success: true`, 12066 total, **11936 passed, 0 failed, 0 failed suites** (3581 suites), 109 pending

Skip check — the multi-backend suites ran rather than skipping silently: **311 PostgreSQL-named tests passed, 0 skipped; 316 MySQL-named tests passed, 0 skipped.** The 109 pending are unrelated pre-existing `.skip`s, not the ~1,500 that appear when the DB containers are absent.

Touched suites: `geojsonService.test.ts` 35 passed, `geojsonRoutes.test.ts` 15 passed, `geojsonRoutes.disablePopup.test.ts` 8 passed, `GeoJsonOverlay.test.tsx` 4 passed.

Closes #4344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob
