### PR TITLE
feat(meshcore): add zero-hop ping action (#4393)

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -273,4 +273,127 @@ describe('MeshCoreContactDetailPanel', () => {
 
     confirmSpy.mockRestore();
   });
+
+  describe('zero-hop ping (#4393)', () => {
+    const PING_LABEL = 'Ping (0 hop)';
+
+    it('offers Ping even when no route is cached (unlike Trace Path)', () => {
+      // pathLen null == unknown route: Trace Path is hidden, Ping is not,
+      // because a ping builds its own one-hop path from the contact key.
+      const contact: MeshCoreContact = { publicKey: PK, advType: 2, pathLen: null };
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contact}
+          publicKey={PK}
+          onTracePath={vi.fn()}
+          onPingZeroHop={vi.fn().mockResolvedValue({ ok: false, error: 'x' })}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+      expect(screen.getByRole('button', { name: PING_LABEL })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Trace Path' })).toBeNull();
+    });
+
+    it('hides Ping without nodes:write', () => {
+      const contact: MeshCoreContact = { publicKey: PK, advType: 2 };
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contact}
+          publicKey={PK}
+          onPingZeroHop={vi.fn()}
+          canWriteNodes={false}
+          isCompanion
+        />,
+      );
+      expect(screen.queryByRole('button', { name: PING_LABEL })).toBeNull();
+    });
+
+    it('hides Ping on a non-Companion source', () => {
+      const contact: MeshCoreContact = { publicKey: PK, advType: 2 };
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contact}
+          publicKey={PK}
+          onPingZeroHop={vi.fn()}
+          canWriteNodes
+          isCompanion={false}
+        />,
+      );
+      expect(screen.queryByRole('button', { name: PING_LABEL })).toBeNull();
+    });
+
+    it('renders RTT and both SNR readings on a successful ping', async () => {
+      const contact: MeshCoreContact = { publicKey: PK, advType: 2 };
+      const onPingZeroHop = vi.fn().mockResolvedValue({
+        ok: true,
+        hopHash: 'aa',
+        rttMs: 812,
+        snrToTarget: 10,
+        snrFromTarget: -3.5,
+      });
+
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contact}
+          publicKey={PK}
+          onPingZeroHop={onPingZeroHop}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: PING_LABEL }));
+
+      await waitFor(() => {
+        const status = screen.getByRole('status').textContent ?? '';
+        expect(status).toContain('Direct — in range');
+        expect(status).toContain('812 ms');
+        expect(status).toContain('10.00 dB');
+        expect(status).toContain('-3.50 dB');
+      });
+      expect(onPingZeroHop).toHaveBeenCalledWith(PK);
+    });
+
+    it('shows the server reason verbatim when the node does not answer', async () => {
+      const contact: MeshCoreContact = { publicKey: PK, advType: 2 };
+      const error = 'No reply — the node is not in direct radio range (or does not repeat traces).';
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contact}
+          publicKey={PK}
+          onPingZeroHop={vi.fn().mockResolvedValue({ ok: false, error })}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: PING_LABEL }));
+
+      await waitFor(() => expect(screen.getByRole('status').textContent).toBe(error));
+    });
+
+    it('omits the outbound SNR when the node reported none', async () => {
+      const contact: MeshCoreContact = { publicKey: PK, advType: 2 };
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contact}
+          publicKey={PK}
+          onPingZeroHop={vi.fn().mockResolvedValue({
+            ok: true, hopHash: 'aa', rttMs: 90, snrToTarget: null, snrFromTarget: 4,
+          })}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: PING_LABEL }));
+
+      await waitFor(() => {
+        const status = screen.getByRole('status').textContent ?? '';
+        expect(status).toContain('4.00 dB');
+        expect(status).not.toContain('SNR at node');
+      });
+    });
+  });
 });

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -13,7 +13,7 @@ import { formatRelativeTime } from '../../utils/datetime';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSource } from '../../contexts/SourceContext';
 import { MeshCoreRemoteConsole } from './MeshCoreRemoteConsole';
-import type { MeshCoreActions, TracePathResult } from './hooks/useMeshCore';
+import type { MeshCoreActions, TracePathResult, ZeroHopPingResult } from './hooks/useMeshCore';
 import api from '../../services/api';
 import '../NodeDetailsBlock.css';
 import { UiIcon } from '../icons';
@@ -46,6 +46,9 @@ interface MeshCoreContactDetailPanelProps {
   /** Send a trace-path diagnostic along the contact's cached path and
    *  return per-hop SNR data. Unset hides the Trace Path button. */
   onTracePath?: (publicKey: string) => Promise<TracePathResult | null>;
+  /** Zero-hop ping (#4393) — trace along a synthetic one-hop path so a reply
+   *  proves the node is in direct RF range. Unset hides the Ping button. */
+  onPingZeroHop?: (publicKey: string) => Promise<ZeroHopPingResult>;
   /** Flood a path-discovery request to learn the forwarding route. The
    *  path update arrives asynchronously. Unset hides the button. */
   onDiscoverPath?: (publicKey: string) => Promise<boolean>;
@@ -97,6 +100,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   onSetOutPath,
   repeaters,
   onTracePath,
+  onPingZeroHop,
   onDiscoverPath,
   onRemoveContact,
   onExportContact,
@@ -123,6 +127,10 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const [traceResult, setTraceResult] = useState<TracePathResult | null>(null);
   const [traceError, setTraceError] = useState<string | null>(null);
   const [discovering, setDiscovering] = useState(false);
+
+  // Zero-hop ping state (#4393)
+  const [pinging, setPinging] = useState(false);
+  const [pingResult, setPingResult] = useState<ZeroHopPingResult | null>(null);
 
   // Remove contact state
   const [removing, setRemoving] = useState(false);
@@ -233,6 +241,11 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   );
   const canShowTraceButton =
     !!onTracePath && canWriteNodes && isCompanion && pathKnown && pathLen! > 0;
+  // Ping needs no cached path (that is the point — it builds a synthetic
+  // one-hop path from the contact's own key hash), so unlike Trace Path it is
+  // offered whether or not an out_path is known.
+  const canShowPingButton =
+    !!onPingZeroHop && canWriteNodes && isCompanion;
   const canShowDiscoverButton =
     !!onDiscoverPath && canWriteNodes && isCompanion;
   const canShowRemoveButton =
@@ -258,6 +271,17 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
       }
     } finally {
       setTracing(false);
+    }
+  };
+
+  const handlePingZeroHop = async () => {
+    if (!onPingZeroHop || pinging) return;
+    setPinging(true);
+    setPingResult(null);
+    try {
+      setPingResult(await onPingZeroHop(publicKey));
+    } finally {
+      setPinging(false);
     }
   };
 
@@ -545,8 +569,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               available because the device retransmits the stored advert
               regardless of route state. Rendered in one card so the
               actions stay grouped at the bottom of the grid. */}
-          {(canShowResetButton || canShowShareButton || canShowEditButton || canShowTraceButton || canShowDiscoverButton || canShowRemoveButton || canShowExportButton || canShowNeighboursButton) &&
-            (canShowShareButton || canShowEditButton || canShowTraceButton || canShowDiscoverButton || canShowRemoveButton || canShowExportButton || canShowNeighboursButton || pathKnown) && (
+          {(canShowResetButton || canShowShareButton || canShowEditButton || canShowTraceButton || canShowPingButton || canShowDiscoverButton || canShowRemoveButton || canShowExportButton || canShowNeighboursButton) &&
+            (canShowShareButton || canShowEditButton || canShowTraceButton || canShowPingButton || canShowDiscoverButton || canShowRemoveButton || canShowExportButton || canShowNeighboursButton || pathKnown) && (
             <div className="node-detail-card node-detail-card-2col">
               <div className="node-detail-label">
                 {t('meshcore.contact_details.actions_label', 'Actions')}
@@ -599,6 +623,25 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     {tracing
                       ? t('meshcore.contact_details.trace_path_running', 'Tracing…')
                       : t('meshcore.contact_details.trace_path_button', 'Trace Path')}
+                  </button>
+                )}
+                {canShowPingButton && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={handlePingZeroHop}
+                    disabled={pinging}
+                    title={t(
+                      'meshcore.contact_details.ping_zero_hop_hint',
+                      'Send a zero-hop trace. A reply means this node is in direct radio range (repeaters and room servers only — companions do not repeat traces).',
+                    )}
+                    aria-label={t('meshcore.contact_details.ping_zero_hop_button', 'Ping (0 hop)')}
+                  >
+                    <UiIcon name="radioSignal" size={14} />
+                    {' '}
+                    {pinging
+                      ? t('meshcore.contact_details.ping_zero_hop_running', 'Pinging…')
+                      : t('meshcore.contact_details.ping_zero_hop_button', 'Ping (0 hop)')}
                   </button>
                 )}
                 {canShowDiscoverButton && (
@@ -675,6 +718,42 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 )}
                 {traceError && (
                   <span style={{ color: 'var(--ctp-red)' }} role="alert">{traceError}</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Zero-hop ping result (#4393). A reply proves a direct RF link;
+              a failure is reported verbatim from the server so "out of range"
+              reads differently from "not a Companion". */}
+          {pingResult && (
+            <div className="node-detail-card node-detail-card-2col">
+              <div className="node-detail-label">
+                {t('meshcore.contact_details.ping_zero_hop_results', 'Zero-Hop Ping')}
+              </div>
+              <div className="node-detail-value" role="status">
+                {pingResult.ok ? (
+                  <span style={{ color: 'var(--ctp-green)' }}>
+                    {t('meshcore.contact_details.ping_zero_hop_direct', 'Direct — in range')}
+                    {' · '}
+                    {t('meshcore.contact_details.ping_zero_hop_rtt', 'RTT')} {pingResult.rttMs} ms
+                    {pingResult.snrToTarget !== null && (
+                      <>
+                        {' · '}
+                        {t('meshcore.contact_details.ping_zero_hop_snr_out', 'SNR at node')}{' '}
+                        <span className={getSignalClass(pingResult.snrToTarget)}>
+                          {pingResult.snrToTarget.toFixed(2)} dB
+                        </span>
+                      </>
+                    )}
+                    {' · '}
+                    {t('meshcore.contact_details.ping_zero_hop_snr_in', 'SNR here')}{' '}
+                    <span className={getSignalClass(pingResult.snrFromTarget)}>
+                      {pingResult.snrFromTarget.toFixed(2)} dB
+                    </span>
+                  </span>
+                ) : (
+                  <span style={{ color: 'var(--ctp-red)' }}>{pingResult.error}</span>
                 )}
               </div>
             </div>

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -75,6 +75,7 @@ function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions 
     shareContact: vi.fn().mockResolvedValue({ ok: true }),
     setContactOutPath: vi.fn().mockResolvedValue(true),
     traceContactPath: vi.fn().mockResolvedValue(null),
+    pingContactZeroHop: vi.fn().mockResolvedValue({ ok: false, error: 'no reply' }),
     discoverContactPath: vi.fn().mockResolvedValue(true),
     removeContact: vi.fn().mockResolvedValue(true),
     exportContact: vi.fn().mockResolvedValue(null),

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -531,6 +531,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 onShareContact={actions.shareContact}
                 onSetOutPath={actions.setContactOutPath}
                 onTracePath={actions.traceContactPath}
+                onPingZeroHop={actions.pingContactZeroHop}
                 onDiscoverPath={actions.discoverContactPath}
                 onRemoveContact={actions.removeContact}
                 onExportContact={actions.exportContact}

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -35,6 +35,24 @@ export interface TracePathResult {
   lastSnr: number;
 }
 
+/**
+ * Outcome of a zero-hop ping (#4393). On success the SNR pair tells you how
+ * each end heard the other; on failure `error` is the server's actionable
+ * reason (out of range, not a Companion, disconnected, unknown contact).
+ */
+export type ZeroHopPingResult =
+  | {
+      ok: true;
+      /** Path hash byte used — the first byte of the target public key, hex. */
+      hopHash: string;
+      rttMs: number;
+      /** SNR the target measured on our frame; null if the node omitted it. */
+      snrToTarget: number | null;
+      /** SNR our radio measured on the returning frame. */
+      snrFromTarget: number;
+    }
+  | { ok: false; error: string };
+
 export interface MeshCoreNode {
   publicKey: string;
   name: string;
@@ -138,6 +156,10 @@ export interface MeshCoreActions {
   /** Send a trace-path diagnostic along the contact's cached forwarding
    *  route and return per-hop SNR data. Resolves `null` on failure. */
   traceContactPath: (publicKey: string) => Promise<TracePathResult | null>;
+  /** Zero-hop ping (#4393) — trace along a synthetic one-hop path built from
+   *  the target's own key hash, bypassing any cached route. A reply proves the
+   *  node is in direct RF range. Requires nodes:write. */
+  pingContactZeroHop: (publicKey: string) => Promise<ZeroHopPingResult>;
   /** Flood a path-discovery request to the contact. The device sends a
    *  lightweight telemetry request via flood; when the contact replies,
    *  the PATH return mechanism establishes the forwarding route. The path
@@ -1214,6 +1236,28 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const pingContactZeroHop = useCallback(async (publicKey: string): Promise<ZeroHopPingResult> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/ping`,
+        { method: 'POST' },
+      );
+      const data = await response.json();
+      if (!data.success) {
+        return { ok: false, error: data.error || 'Ping failed' };
+      }
+      return {
+        ok: true,
+        hopHash: data.data.hopHash,
+        rttMs: data.data.rttMs,
+        snrToTarget: data.data.snrToTarget ?? null,
+        snrFromTarget: data.data.snrFromTarget,
+      };
+    } catch (_err) {
+      return { ok: false, error: 'Ping failed' };
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const removeContact = useCallback(async (publicKey: string): Promise<boolean> => {
     try {
       const response = await csrfFetch(
@@ -1761,6 +1805,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       shareContact,
       setContactOutPath,
       traceContactPath,
+      pingContactZeroHop,
       removeContact,
       setNodeFavorite,
       exportContact,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -176,6 +176,34 @@ export interface ShareContactResult {
 }
 
 /**
+ * Result of {@link MeshCoreManager.pingContactZeroHop} (issue #4393).
+ *
+ * A zero-hop ping is a TRACE (companion command `SendTracePath`, opcode 36)
+ * whose path is the single 1-byte hash of the target's public key. Only a node
+ * in DIRECT radio range that forwards packets can answer it, so a reply proves
+ * direct reachability and a timeout means "not directly reachable".
+ *
+ * `snrToTarget` is the SNR the *target* measured on our outbound frame;
+ * `snrFromTarget` is the SNR our own radio measured on the returning frame.
+ * `rttMs` is measured host-side around the companion command, so it includes
+ * the USB/TCP link latency as well as airtime — treat it as approximate.
+ */
+export type ZeroHopPingResult =
+  | {
+      ok: true;
+      /** Path hash byte used (first byte of the target public key), hex. */
+      hopHash: string;
+      rttMs: number;
+      snrToTarget: number | null;
+      snrFromTarget: number;
+    }
+  | {
+      ok: false;
+      reason: 'not-companion' | 'disconnected' | 'unknown-contact' | 'no-reply';
+      error: string;
+    };
+
+/**
  * Result of {@link MeshCoreManager.syncDeviceTime}. `reason` distinguishes the
  * pre-flight guard failures (which the route reports as a 409) from an actual
  * device/command failure (`command-failed`, reported as a 502 with `error`).
@@ -3872,6 +3900,102 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     } catch (error) {
       logger.error('[MeshCore] tracePathRaw threw:', error);
       return null;
+    }
+  }
+
+  /**
+   * Zero-hop ping ("Ping [zero hops]" in the MeshCore phone app) — issue #4393.
+   *
+   * Sends a TRACE packet (companion command `SendTracePath`, opcode 36, via the
+   * `trace_path` bridge command) whose path is a single 1-byte hop hash: the
+   * first byte of the target's public key. The firmware's TRACE handler
+   * (`Mesh::onRecvPacket`, MeshCore `src/Mesh.cpp`) only forwards the frame when
+   *   - it arrives route-direct (zero hops so far), AND
+   *   - the node's own identity hash matches the next path byte, AND
+   *   - `allowPacketForward()` is true.
+   * So a reply proves the target heard us with NO intermediate repeater: exactly
+   * the "is this node in direct RF range?" test the requester asked for.
+   *
+   * Caveat (documented, not worked around): `allowPacketForward()` is false on
+   * plain Companion firmware, so only repeaters / room servers (and any node
+   * with transport enabled) can answer a trace. Pinging a companion contact
+   * times out even when it is in range.
+   *
+   * Unlike {@link traceContactPath} this deliberately ignores the contact's
+   * cached `out_path` — the whole point is to bypass the learned multi-hop route
+   * and test the direct link.
+   */
+  async pingContactZeroHop(publicKey: string): Promise<ZeroHopPingResult> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      return {
+        ok: false,
+        reason: 'not-companion',
+        error: 'Zero-hop ping requires MeshCore Companion firmware.',
+      };
+    }
+    if (!this.connected) {
+      return { ok: false, reason: 'disconnected', error: 'Source is disconnected.' };
+    }
+    if (!/^[0-9a-fA-F]{64}$/.test(publicKey)) {
+      return { ok: false, reason: 'unknown-contact', error: 'Invalid public key.' };
+    }
+    const contact = this.contacts.get(publicKey);
+    if (!contact) {
+      return {
+        ok: false,
+        reason: 'unknown-contact',
+        error: 'Contact is not known to this source.',
+      };
+    }
+
+    // MeshCore path hashes are the leading byte(s) of the node's public key
+    // (`Identity::isHashMatch`). meshcore.js sends SendTracePath with flags=0,
+    // i.e. path hash size 1 (firmware reads the hash width from flags & 0x03),
+    // so a zero-hop path is exactly one byte.
+    const hopByte = parseInt(publicKey.slice(0, 2), 16);
+    const path = Uint8Array.from([hopByte]);
+    const hopHash = publicKey.slice(0, 2).toLowerCase();
+
+    const startedAt = Date.now();
+    try {
+      // extra_timeout gives the firmware's estimated direct-path timeout a
+      // little margin; the bridge ceiling is only a backstop for a device that
+      // never answers the command at all.
+      const response = await this.sendBridgeCommand(
+        'trace_path',
+        { path, extra_timeout: 3000 },
+        30_000,
+      );
+      if (!response.success) {
+        logger.debug(
+          `[MeshCore:${this.sourceId}] zero-hop ping to ${hopHash} got no reply: ${response.error}`,
+        );
+        return {
+          ok: false,
+          reason: 'no-reply',
+          error: 'No reply — the node is not in direct radio range (or does not repeat traces).',
+        };
+      }
+      this.recordMeshTx();
+      const rttMs = Date.now() - startedAt;
+      const d = response.data ?? {};
+      const rawSnrs: number[] = Array.isArray(d.pathSnrs) ? (d.pathSnrs as number[]) : [];
+      // Trace SNRs travel the wire as int8 of (SNR*4) but reach us as unsigned
+      // bytes, so sign-extend before scaling or -6 dB reads back as +62.5 dB.
+      const snrToTarget = rawSnrs.length > 0 ? ((rawSnrs[0] << 24) >> 24) / 4 : null;
+      const snrFromTarget = typeof d.lastSnr === 'number' ? d.lastSnr : 0;
+      logger.debug(
+        `[MeshCore:${this.sourceId}] zero-hop ping ${hopHash} ok: rtt=${rttMs}ms ` +
+          `snrToTarget=${snrToTarget ?? 'n/a'} snrFromTarget=${snrFromTarget}`,
+      );
+      return { ok: true, hopHash, rttMs, snrToTarget, snrFromTarget };
+    } catch (error) {
+      logger.error('[MeshCore] pingContactZeroHop threw:', error);
+      return {
+        ok: false,
+        reason: 'no-reply',
+        error: 'No reply — the node is not in direct radio range (or does not repeat traces).',
+      };
     }
   }
 

--- a/src/server/meshcoreManager.zeroHopPing.test.ts
+++ b/src/server/meshcoreManager.zeroHopPing.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for MeshCoreManager.pingContactZeroHop() — issue #4393.
+ *
+ * A zero-hop ping is a TRACE (companion command SendTracePath, opcode 36,
+ * issued here through the `trace_path` bridge command) whose path is the
+ * single 1-byte hop hash of the target's own public key. The firmware only
+ * forwards a route-direct TRACE whose next path byte matches its identity
+ * hash (MeshCore `src/Mesh.cpp`, `Mesh::onRecvPacket`), so a reply proves the
+ * node is in direct RF range.
+ *
+ * These tests pin the command construction (which bridge command, which path
+ * bytes) and the SNR sign handling — trace SNRs arrive as unsigned bytes of an
+ * int8 × 4, so a naive `raw / 4` turns -6 dB into +62.5 dB.
+ *
+ * Uses the private-method-stubbing pattern from meshcoreManager.shareContact.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeCall {
+  cmd: string;
+  params: Record<string, unknown>;
+  timeout?: number;
+}
+
+const PK = 'a3' + 'f'.repeat(62); // first byte 0xa3 → hop hash "a3"
+
+function makeManager(opts: {
+  deviceType?: MeshCoreDeviceType;
+  connected?: boolean;
+  knownContact?: boolean;
+  response?: { success: boolean; data?: unknown; error?: string };
+  throws?: boolean;
+}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = opts.deviceType ?? MeshCoreDeviceType.COMPANION;
+  (m as any).connected = opts.connected ?? true;
+  if (opts.knownContact !== false) {
+    (m as any).contacts = new Map([[PK, { publicKey: PK, name: 'Repeater One' }]]);
+  }
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (
+    cmd: string,
+    params: Record<string, unknown>,
+    timeout?: number,
+  ) => {
+    bridgeCalls.push({ cmd, params, timeout });
+    if (opts.throws) throw new Error('link dropped');
+    return {
+      id: '1',
+      ...(opts.response ?? {
+        success: true,
+        data: { pathLen: 1, flags: 0, pathSnrs: [40], lastSnr: 7.25 },
+      }),
+    };
+  };
+
+  return { manager: m, bridgeCalls };
+}
+
+describe('MeshCoreManager — pingContactZeroHop (#4393)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('issues trace_path with a single-byte synthetic path built from the target key', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(true);
+    expect(bridgeCalls).toHaveLength(1);
+    expect(bridgeCalls[0].cmd).toBe('trace_path');
+
+    const path = bridgeCalls[0].params.path as Uint8Array;
+    expect(path).toBeInstanceOf(Uint8Array);
+    // Zero hop == exactly one hash byte, the target's own leading key byte.
+    expect(Array.from(path)).toEqual([0xa3]);
+    expect(bridgeCalls[0].params.extra_timeout).toBe(3000);
+  });
+
+  it('ignores the contact cached out_path (the point is to bypass the learned route)', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    // A multi-hop cached route must not leak into the ping path.
+    (manager as any).contacts.set(PK, {
+      publicKey: PK,
+      outPath: '11,22,33',
+      pathLen: 3,
+    });
+
+    await manager.pingContactZeroHop(PK);
+    expect(Array.from(bridgeCalls[0].params.path as Uint8Array)).toEqual([0xa3]);
+  });
+
+  it('reports the SNR pair and a measured round-trip time on success', async () => {
+    const { manager } = makeManager({
+      response: { success: true, data: { pathLen: 1, flags: 0, pathSnrs: [40], lastSnr: 7.25 } },
+    });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result).toMatchObject({
+      ok: true,
+      hopHash: 'a3',
+      snrToTarget: 10, // 40 / 4
+      snrFromTarget: 7.25,
+    });
+    if (result.ok) {
+      expect(result.rttMs).toBeGreaterThanOrEqual(0);
+      expect(Number.isFinite(result.rttMs)).toBe(true);
+    }
+  });
+
+  it('sign-extends the trace SNR byte so a negative link SNR is not read as huge and positive', async () => {
+    // -6 dB → int8(-24) → wire byte 0xE8 (232 unsigned). Naive /4 gives +58.
+    const { manager } = makeManager({
+      response: { success: true, data: { pathLen: 1, flags: 0, pathSnrs: [232], lastSnr: -3.5 } },
+    });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.snrToTarget).toBe(-6);
+      expect(result.snrFromTarget).toBe(-3.5);
+    }
+  });
+
+  it('returns snrToTarget=null when the reply carries no path SNRs', async () => {
+    const { manager } = makeManager({
+      response: { success: true, data: { pathLen: 1, flags: 0, pathSnrs: [], lastSnr: 1 } },
+    });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.snrToTarget).toBeNull();
+  });
+
+  it('maps a device/backend failure to reason "no-reply" with an out-of-range message', async () => {
+    const { manager } = makeManager({
+      response: { success: false, error: 'timeout' },
+    });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('no-reply');
+      expect(result.error).toMatch(/direct radio range/i);
+    }
+  });
+
+  it('maps a thrown bridge error to reason "no-reply" rather than propagating', async () => {
+    const { manager } = makeManager({ throws: true });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('no-reply');
+  });
+
+  it('refuses on non-Companion firmware without transmitting', async () => {
+    const { manager, bridgeCalls } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not-companion');
+      expect(result.error).toMatch(/Companion/i);
+    }
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('refuses when disconnected without transmitting', async () => {
+    const { manager, bridgeCalls } = makeManager({ connected: false });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('disconnected');
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('refuses an unknown contact without transmitting', async () => {
+    const { manager, bridgeCalls } = makeManager({ knownContact: false });
+    const result = await manager.pingContactZeroHop(PK);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('unknown-contact');
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('refuses a malformed public key without transmitting', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    const result = await manager.pingContactZeroHop('nothex');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('unknown-contact');
+    expect(bridgeCalls).toHaveLength(0);
+  });
+});

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -22,6 +22,7 @@ import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
 import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
 import { isBogusPosition } from '../../utils/nullIsland.js';
 import { managerFor, isValidPublicKey, auditMeshcoreEvent, parseHexPathChain } from './meshcoreRouteShared.js';
+import { ok, fail } from '../utils/apiResponse.js';
 
 const router = Router({ mergeParams: true });
 
@@ -324,6 +325,56 @@ router.post(
     } catch (error) {
       logger.error('[API] Error tracing contact path:', error);
       res.status(500).json({ success: false, error: 'Failed to trace path' });
+    }
+  },
+);
+
+/**
+ * POST /api/sources/:id/meshcore/contacts/:publicKey/ping
+ *
+ * Zero-hop ping (issue #4393) — the "Ping [zero hops]" action from the MeshCore
+ * phone app. Sends a TRACE along a synthetic one-hop path (the target's own
+ * public-key hash byte), bypassing any cached multi-hop out_path. A reply means
+ * the node answered us with no intermediate repeater, i.e. it is in direct RF
+ * range; a timeout means it is not (or does not repeat traces — see the manager
+ * docstring; plain Companion firmware never forwards a trace).
+ *
+ * Requires nodes:write like the other transmitting actions.
+ *
+ * 200 → { success: true, data: { hopHash, rttMs, snrToTarget, snrFromTarget } }
+ * 409 → guard failure (not a Companion / disconnected / unknown contact)
+ * 504 → no reply (not in direct range)
+ */
+router.post(
+  '/contacts/:publicKey/ping',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return fail(res, 400, 'INVALID_PUBLIC_KEY', 'Invalid public key — must be 64-char hex');
+      }
+      const result = await managerFor(req, res).pingContactZeroHop(publicKey);
+      if (!result.ok) {
+        const status = result.reason === 'no-reply' ? 504 : 409;
+        const code =
+          result.reason === 'no-reply' ? 'MESHCORE_PING_NO_REPLY'
+          : result.reason === 'not-companion' ? 'MESHCORE_PING_NOT_COMPANION'
+          : result.reason === 'disconnected' ? 'MESHCORE_PING_DISCONNECTED'
+          : 'MESHCORE_PING_UNKNOWN_CONTACT';
+        return fail(res, status, code, result.error, { reason: result.reason });
+      }
+      return ok(res, {
+        hopHash: result.hopHash,
+        rttMs: result.rttMs,
+        snrToTarget: result.snrToTarget,
+        snrFromTarget: result.snrFromTarget,
+      });
+    } catch (error) {
+      logger.error('[API] Error pinging contact (zero hop):', error);
+      return fail(res, 500, 'MESHCORE_PING_FAILED', 'Failed to ping contact');
     }
   },
 );

--- a/src/server/routes/meshcoreRoutes.zeroHopPing.test.ts
+++ b/src/server/routes/meshcoreRoutes.zeroHopPing.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Route tests — POST /contacts/:publicKey/ping (zero-hop ping, issue #4393)
+ *
+ * Uses the real-middleware harness (createRouteTestApp) per CLAUDE.md: real
+ * express-session + real auth middleware + real permission SQL against the
+ * singleton's `:memory:` SQLite DB. Only the source-manager registry is mocked
+ * (non-DB) — the router-level guard requires a registered manager whose
+ * `sourceType === 'meshcore'`, and the handler needs a `pingContactZeroHop`.
+ *
+ * Mount prefix mirrors `src/server/server.ts`
+ * (`apiRouter.use('/sources/:id/meshcore', meshcoreRoutes)`); the harness talks
+ * to the Express app directly, so the `/api` segment is not needed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import meshcoreRoutes from './meshcoreRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+const { pingMock } = vi.hoisted(() => ({ pingMock: vi.fn() }));
+
+vi.mock('../sourceManagerRegistry.js', () => {
+  const stubFor = (sourceId: string) => ({
+    sourceId,
+    sourceType: 'meshcore' as const,
+    pingContactZeroHop: pingMock,
+  });
+  const managers = new Map([
+    ['rt-source-a', stubFor('rt-source-a')],
+    ['rt-source-b', stubFor('rt-source-b')],
+  ]);
+  return {
+    sourceManagerRegistry: {
+      getManager: (sourceId: string) => managers.get(sourceId),
+      getAllManagers: () => Array.from(managers.values()),
+    },
+  };
+});
+
+const PK = 'a3' + 'f'.repeat(62);
+
+const OK_RESULT = {
+  ok: true as const,
+  hopHash: 'a3',
+  rttMs: 812,
+  snrToTarget: 10,
+  snrFromTarget: 7.25,
+};
+
+describe('meshcoreRoutes — POST /contacts/:publicKey/ping (#4393)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    pingMock.mockReset();
+    pingMock.mockResolvedValue(OK_RESULT);
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/sources/:id/meshcore', meshcoreRoutes),
+    });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  const urlFor = (sourceId: string, publicKey = PK) =>
+    `/sources/${sourceId}/meshcore/contacts/${publicKey}/ping`;
+
+  it('returns 401 when unauthenticated', async () => {
+    const agent = await harness.loginAs(null);
+    const res = await agent.post(urlFor(harness.sourceA));
+    expect(res.status).toBe(401);
+    expect(pingMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 without nodes:write on the source', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(urlFor(harness.sourceA));
+    expect(res.status).toBe(403);
+    expect(pingMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with the ping envelope when granted nodes:write', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual({
+      hopHash: 'a3',
+      rttMs: 812,
+      snrToTarget: 10,
+      snrFromTarget: 7.25,
+    });
+    expect(pingMock).toHaveBeenCalledWith(PK);
+  });
+
+  it('per-source scoping: nodes:write on sourceA does not authorize sourceB', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+
+    expect((await agent.post(urlFor(harness.sourceA))).status).toBe(200);
+    expect((await agent.post(urlFor(harness.sourceB))).status).toBe(403);
+  });
+
+  it('rejects a malformed public key with 400 INVALID_PUBLIC_KEY before touching the device', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post(urlFor(harness.sourceA, 'not-a-key'));
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('INVALID_PUBLIC_KEY');
+    expect(pingMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a no-reply (out of range) result to 504 MESHCORE_PING_NO_REPLY', async () => {
+    pingMock.mockResolvedValue({
+      ok: false,
+      reason: 'no-reply',
+      error: 'No reply — the node is not in direct radio range (or does not repeat traces).',
+    });
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(504);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('MESHCORE_PING_NO_REPLY');
+    expect(res.body.reason).toBe('no-reply');
+    expect(res.body.error).toMatch(/direct radio range/i);
+  });
+
+  it.each([
+    ['not-companion', 'MESHCORE_PING_NOT_COMPANION'],
+    ['disconnected', 'MESHCORE_PING_DISCONNECTED'],
+    ['unknown-contact', 'MESHCORE_PING_UNKNOWN_CONTACT'],
+  ])('maps guard failure %s to 409 %s', async (reason, code) => {
+    pingMock.mockResolvedValue({ ok: false, reason, error: 'nope' });
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe(code);
+    expect(res.body.reason).toBe(reason);
+  });
+
+  it('returns 500 MESHCORE_PING_FAILED when the manager throws', async () => {
+    pingMock.mockRejectedValue(new Error('boom'));
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('MESHCORE_PING_FAILED');
+  });
+
+  it('returns 404 for a source with no registered MeshCore manager', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post(urlFor('not-registered'));
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Adds the **"Ping (0 hop)"** action Kokoshell asked for to the MeshCore contact **Actions** menu — the direct-RF-range test the MeshCore phone app offers.

## Protocol mechanism (researched, not guessed)

A zero-hop ping is a **TRACE** packet: companion command **`SendTracePath` (opcode 36)**, answered by the **`TraceData` (0x89)** push. The path carries **exactly one hop hash — the first byte of the target's own public key**, so the packet is addressed "route via you, and nobody else".

Where each piece was verified:

| Claim | Verified in |
|---|---|
| `SendTracePath = 36`, `TraceData = 0x89`, frame layout `[code][tag:u32LE][auth:u32LE][flags:u8][path…]` | `node_modules/@liamcottle/meshcore.js/src/constants.js`, `src/connection/connection.js:325` (`sendCommandSendTracePath`), and this repo's own `src/server/meshcoreCompanionCodec.ts:336` |
| meshcore.js sends `flags = 0` ⇒ path hash size 1 byte | `connection.js:331`; firmware reads the width from `flags & 0x03` |
| Path hash = leading byte(s) of the public key | firmware `Identity::isHashMatch`; corroborated by meshcore.js's own (deprecated) `pingRepeaterZeroHop`, which uses `contactPublicKey.subarray(0, 1)` as the path |
| A trace is only forwarded when it arrives **route-direct**, its next path byte matches the node's identity hash, **and** `allowPacketForward()` is true | MeshCore firmware `src/Mesh.cpp`, `Mesh::onRecvPacket` (fetched from `ripplebiz/MeshCore@main`) |

Because forwarding requires all three conditions, a reply can only have come from a node that heard us **directly**. That is exactly the "which nodes are in direct RF range" signal requested.

I deliberately did **not** use meshcore.js's `pingRepeaterZeroHop`: the library marks it `@deprecated ... will be removed in a future update` and tells callers to migrate to `tracePath`. It also works by sniffing the raw `LogRxData` echo feed, which is opt-in in MeshMonitor. `tracePath` is the supported path, already plumbed through this repo (`trace_path` bridge command → `meshcoreNativeBackend.ts` → `c.tracePath()`), and returns richer data (both directions' SNR).

### Known, documented limitation (not worked around)

`Mesh::allowPacketForward()` returns **false** on plain Companion firmware. So only **repeaters / room servers** (and anything with transport enabled) can answer a trace — pinging a companion contact times out even when it is in range. This is a firmware property, not something the client can fix; the button's tooltip and the manager docstring both say so. This matches why meshcore.js named the old helper `pingRepeaterZeroHop`.

## What the action does

**Backend**
- `MeshCoreManager.pingContactZeroHop(publicKey)` — Companion-only, requires a known contact, ignores the contact's cached `out_path` (the whole point is to bypass the learned multi-hop route). Returns a discriminated result: `{ ok: true, hopHash, rttMs, snrToTarget, snrFromTarget }` or `{ ok: false, reason, error }` with `reason ∈ not-companion | disconnected | unknown-contact | no-reply`.
- `POST /api/sources/:id/meshcore/contacts/:publicKey/ping` in the contacts sub-router (mounted via the `meshcoreRoutes.ts` barrel). `requireAuth()` + `requirePermission('nodes','write', { sourceIdFrom: 'params.id' })` + `meshcoreDeviceLimiter`, same as its neighbours. Uses the `ok()` / `fail()` envelope. 400 `INVALID_PUBLIC_KEY`, 409 for guard failures, **504 `MESHCORE_PING_NO_REPLY`** for out-of-range, 500 on throw.

**Frontend**
- `pingContactZeroHop` action in `useMeshCore`, wired into `MeshCoreContactDetailPanel` next to Trace Path / Discover Path. Button uses `UiIcon name="radioSignal"` — no hardcoded emoji.
- Unlike **Trace Path**, **Ping** is offered even with **no cached route**, since it builds its own path.
- Result line reports `Direct — in range · RTT <n> ms · SNR at node <x> dB · SNR here <y> dB`, SNRs colour-coded through the existing `getSignalClass`. A failure prints the server's reason verbatim, so "out of range" reads differently from "not a Companion".

**Bug fixed along the way:** trace path-SNRs reach the host as *unsigned* bytes of an `int8 × 4`. The new code sign-extends before scaling; without it a −6 dB link reads back as **+58 dB**. (Pre-existing `traceContactPath` still has this; left alone as out of scope for this issue.)

## Secondary "mark direct nodes" — DEFERRED

Not included. Colouring by *ping outcome* needs a new persisted per-contact field (nothing on `meshcore_nodes` records ping results) and therefore a migration, which the scope for this change excludes. Worth noting the closest existing signal is **already shipped**: the MeshCore map colours links green via `hopCountColor(pathLen === 0)` and the contact detail already labels a zero-hop cached route **"Direct"** — both derived from the device's learned `out_path`, not from an active probe.

## ⚠️ UNVALIDATED ON HARDWARE

No MeshCore device was available in this environment. The frame construction is verified against the vendored `meshcore.js` and the MeshCore firmware source, and the whole path is unit-tested, but **nobody has fired this at a real repeater**. Please run a live check against an in-range repeater (expect a reply with sensible SNRs) and an out-of-range/companion contact (expect the 504 "not in direct radio range") before this ships in a release.

## Test evidence

- New: `src/server/meshcoreManager.zeroHopPing.test.ts` (11 tests) — pins the bridge command, the single-byte synthetic path `[0xa3]`, that a cached 3-hop `out_path` does **not** leak into it, SNR sign-extension (`232 → −6 dB`), and all four refusal paths short-circuiting before any transmit.
- New: `src/server/routes/meshcoreRoutes.zeroHopPing.test.ts` (11 tests) — uses the mandatory `createRouteTestApp()` harness (real session + real auth + real permission SQL): 401 unauthenticated, 403 without `nodes:write`, 200 envelope, **per-source isolation** (grant on sourceA ⇒ 403 on sourceB), 400 bad key, 504 no-reply, 409 per guard reason, 500 on throw, 404 unregistered source.
- Extended: `MeshCoreContactDetailPanel.test.tsx` (+6) — button visibility gates, success rendering, verbatim error, omitted outbound SNR.

Verification run:

```
npx tsc -p tsconfig.server.json --noEmit   → No errors found
npx tsc -p tsconfig.json --noEmit          → No errors found
npx vitest run --reporter=json --maxWorkers=2
   success: true · 12076 tests · 0 failed · 0 failed suites · 3581 suites
npm run lint:ci                            → no in-repo FAIL lines
```

(`tsconfig.tests.json` still reports its pre-existing baseline errors; confirmed byte-identical before and after this change by stashing and re-running.)

Closes #4393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob
