### PR TITLE
feat(tx-guard): allow sends when UDP Broadcast can relay for a TX-disabled node (#4394)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -105,6 +105,7 @@
 
   "banners.default_password_warning": "Security Warning: The admin account is using the default password. Please change it immediately in the Users tab.",
   "banners.tx_disabled": "Transmit Disabled: Your device cannot send messages. TX is currently disabled in the LoRa configuration. Enable it via the Meshtastic app or re-import your configuration.",
+  "banners.tx_disabled_udp_relay": "Radio Transmit Disabled: This device does not transmit over LoRa itself. UDP Broadcast is on, so sends go out over the local network and another node there relays them to the mesh.",
   "banners.config_error": "Configuration Error",
   "banners.learn_more": "Learn more",
   "banners.update_available": "Update available: v{{version}}",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,8 +242,11 @@ function App() {
   // Monitor server health and auto-reload on version change (e.g., after auto-upgrade)
   useHealth({ baseUrl, reloadOnVersionChange: true });
 
-  // Monitor device TX status to show warning banner when TX is disabled
-  const { isTxDisabled } = useTxStatus({ baseUrl, sourceId });
+  // Monitor device TX status to show warning banner when TX is disabled.
+  // `isTxDisabled` already accounts for the UDP-broadcast relay path: a radio
+  // with TX off but UDP Broadcast on can still send, and reports isUdpRelay
+  // instead so the banner stays honest about how packets leave (#4394).
+  const { isTxDisabled, isUdpRelay } = useTxStatus({ baseUrl, sourceId });
   // MQTT-bridge sources are never gated (different transport, not affected by radio TX state)
   const txGated = isTxDisabled && !isMqttBridge;
 
@@ -3318,6 +3321,7 @@ function App() {
 
       <AppBanners
         isTxDisabled={isTxDisabled}
+        isUdpRelay={isUdpRelay}
         configIssues={configIssues}
         updateAvailable={updateAvailable}
         latestVersion={latestVersion}

--- a/src/components/AppBanners/AppBanners.test.tsx
+++ b/src/components/AppBanners/AppBanners.test.tsx
@@ -114,6 +114,21 @@ describe('AppBanners — warning banners', () => {
     expect(screen.getByText(/banners\.tx_disabled/)).toBeInTheDocument();
   });
 
+  // #4394: radio TX off + UDP Broadcast on — sends still reach the mesh through a
+  // LAN peer, so the banner must explain the relay instead of claiming the device
+  // cannot send.
+  it('renders the UDP-relay banner instead of the "cannot send" one', () => {
+    render(
+      <AppBanners {...baseProps} updateAvailable={false} isTxDisabled={false} isUdpRelay deploymentMethod="docker" />
+    );
+    expect(screen.getByText(/banners\.tx_disabled_udp_relay/)).toBeInTheDocument();
+  });
+
+  it('shows no TX banner when TX is fine and there is no relay', () => {
+    render(<AppBanners {...baseProps} updateAvailable={false} isTxDisabled={false} deploymentMethod="docker" />);
+    expect(screen.queryByText(/banners\.tx_disabled/)).not.toBeInTheDocument();
+  });
+
   it('renders a config issue banner with a docs link', () => {
     render(
       <AppBanners

--- a/src/components/AppBanners/AppBanners.tsx
+++ b/src/components/AppBanners/AppBanners.tsx
@@ -14,6 +14,12 @@ export const DISMISSED_UPDATE_VERSION_KEY = 'meshmonitor_dismissed_update_versio
 
 interface AppBannersProps {
   isTxDisabled: boolean;
+  /**
+   * Radio TX is off but UDP Broadcast relays sends through a LAN peer (#4394).
+   * Mutually exclusive with `isTxDisabled` — sends work, so the banner says so
+   * rather than claiming the device cannot send.
+   */
+  isUdpRelay?: boolean;
   configIssues: ConfigIssue[];
   updateAvailable: boolean;
   latestVersion: string;
@@ -31,6 +37,7 @@ function readDismissedVersion(): string | null {
 
 export const AppBanners: React.FC<AppBannersProps> = ({
   isTxDisabled,
+  isUdpRelay = false,
   configIssues,
   updateAvailable,
   latestVersion,
@@ -91,22 +98,28 @@ export const AppBanners: React.FC<AppBannersProps> = ({
     }
   };
 
+  // At most one TX banner shows: either sends are blocked, or the radio is off
+  // but UDP Broadcast relays them (#4394). Both occupy the same slot, so the
+  // offsets below count them as one.
+  const showTxBanner = isTxDisabled || isUdpRelay;
+
   return (
     <>
-      {/* TX Disabled Warning Banner */}
-      {isTxDisabled && (
+      {/* TX Disabled / UDP-relay Warning Banner */}
+      {showTxBanner && (
         <div
           className="warning-banner"
           style={{ top: 'var(--header-height)' }}
         >
-          <UiIcon name="alert" /> {t('banners.tx_disabled')}
+          <UiIcon name="alert" />{' '}
+          {isTxDisabled ? t('banners.tx_disabled') : t('banners.tx_disabled_udp_relay')}
         </div>
       )}
 
       {/* Configuration Issue Warning Banners */}
       {configIssues.map((issue, index) => {
         // Calculate how many banners are above this one
-        const bannersAbove = [isTxDisabled].filter(Boolean).length + index;
+        const bannersAbove = [showTxBanner].filter(Boolean).length + index;
         const topOffset =
           bannersAbove === 0
             ? 'var(--header-height)'
@@ -131,7 +144,7 @@ export const AppBanners: React.FC<AppBannersProps> = ({
       {showUpdateBanner &&
         (() => {
           // Calculate total warning banners above the update banner
-          const warningBannersCount = [isTxDisabled].filter(Boolean).length + configIssues.length;
+          const warningBannersCount = [showTxBanner].filter(Boolean).length + configIssues.length;
           const topOffset =
             warningBannersCount === 0
               ? 'var(--header-height)'

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -16,7 +16,16 @@ import type { GeofenceShape } from '../auto-responder/types';
 import { UiIcon } from '../icons';
 
 export interface VariableOption { name: string; type: string; }
-export interface SourceOption { id: string; name: string; type?: string; enabled?: boolean; txEnabled?: boolean; }
+export interface SourceOption {
+  id: string;
+  name: string;
+  type?: string;
+  enabled?: boolean;
+  /** Raw radio TX flag. */
+  txEnabled?: boolean;
+  /** `txEnabled || udpRelayEnabled` — the real "can this source send?" answer (#4394). */
+  canTransmit?: boolean;
+}
 export interface UnifiedChannelOption {
   name: string; protocol?: string; encryption?: string;
   sources?: Array<{ sourceId: string; sourceName?: string; slot: number }>;
@@ -166,7 +175,10 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
                 <input type="checkbox" checked={sel.includes(s.id)} onChange={(e) =>
                   onChange(e.target.checked ? [...sel, s.id] : sel.filter((x) => x !== s.id))} />
                 {' '}{s.name}{badge ? <span className="ae-chip">{badge}</span> : null}
-                {s.txEnabled === false && (
+                {/* Prefer canTransmit: a TX-disabled radio with UDP Broadcast on
+                    still delivers, so it must not be flagged (#4394). Older
+                    servers omit the field — fall back to the raw radio flag. */}
+                {(s.canTransmit ?? s.txEnabled) === false && (
                   <span className="ae-tx-warn" title={txWarning}>
                     <UiIcon name="alert" size={14} /> {txWarning}
                   </span>

--- a/src/components/automations/AutomationBuilder.txWarning.test.tsx
+++ b/src/components/automations/AutomationBuilder.txWarning.test.tsx
@@ -47,6 +47,8 @@ const sources: SourceOption[] = [
   { id: 'src-tx-off', name: 'Receive Only Node', type: 'meshtastic_tcp', enabled: true, txEnabled: false },
   { id: 'src-tx-on', name: 'Normal Node', type: 'meshtastic_tcp', enabled: true, txEnabled: true },
   { id: 'src-tx-unknown', name: 'Unknown TX Node', type: 'meshtastic_tcp', enabled: true },
+  // #4394: radio TX off, but UDP Broadcast relays through a LAN peer — sends work.
+  { id: 'src-udp-relay', name: 'Udp Relay Node', type: 'meshtastic_tcp', enabled: true, txEnabled: false, canTransmit: true },
 ];
 
 function renderBuilder(sourceIds: string[] = []) {
@@ -98,6 +100,13 @@ describe('AutomationBuilder — TX-disabled advisory badge (#4294 P3)', () => {
     renderBuilder();
 
     expect(document.querySelectorAll('.ae-tx-warn')).toHaveLength(1);
+  });
+
+  it('does not show the badge when the radio is TX-disabled but canTransmit is true (UDP relay, #4394)', () => {
+    renderBuilder();
+
+    const row = rowFor('Udp Relay Node');
+    expect(row.querySelector('.ae-tx-warn')).toBeNull();
   });
 
   it('keeps the checkbox enabled and toggleable for a TX-disabled source that is selected — advisory, not a hard block', () => {

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -189,8 +189,18 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     apiService.get<Variable[]>('/api/automations/variables')
       .then((vs) => setVariables(vs.map((v) => ({ name: v.name, type: v.type }))))
       .catch(() => setVariables([]));
-    apiService.get<Array<{ id: string; name: string; type?: string; enabled?: boolean; radio?: { txEnabled?: boolean } }>>('/api/sources')
-      .then((ss) => setSources(ss.map((s) => ({ id: s.id, name: s.name, type: s.type, enabled: s.enabled, txEnabled: s.radio?.txEnabled }))))
+    apiService.get<Array<{ id: string; name: string; type?: string; enabled?: boolean; radio?: { txEnabled?: boolean; canTransmit?: boolean } }>>('/api/sources')
+      // `canTransmit` includes the UDP-broadcast relay path — a TX-disabled radio
+      // with UDP Broadcast on still delivers automation sends (#4394). The
+      // builder prefers it and falls back to `txEnabled` on older servers.
+      .then((ss) => setSources(ss.map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: s.type,
+        enabled: s.enabled,
+        txEnabled: s.radio?.txEnabled,
+        canTransmit: s.radio?.canTransmit,
+      }))))
       .catch(() => setSources([]));
     apiService.get<UnifiedChannelOption[]>('/api/automations/channels')
       .then((cs) => setChannels(cs))

--- a/src/hooks/useTxStatus.test.tsx
+++ b/src/hooks/useTxStatus.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useTxStatus send-gating (#4294 banner, #4394 UDP-broadcast relay).
+ *
+ * `isTxDisabled` must mean "sends are futile", not "the radio's TX flag is
+ * off": a node with `lora.txEnabled=false` but `network.enabledProtocols &
+ * UDP_BROADCAST` still reaches the mesh through a LAN peer that relays its
+ * UDP broadcasts. That case reports `isUdpRelay` instead, so the UI can stay
+ * honest about how packets leave without disabling the compose box.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useTxStatus } from './useTxStatus';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+function mockTxStatus(body: Record<string, unknown>) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  }));
+}
+
+describe('useTxStatus', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it('is not TX-disabled when the radio can transmit', async () => {
+    mockTxStatus({ txEnabled: true, udpRelayEnabled: false, canTransmit: true });
+    const { result } = renderHook(() => useTxStatus({ refetchInterval: 60000 }), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.isTxDisabled).toBe(false);
+    expect(result.current.isUdpRelay).toBe(false);
+  });
+
+  it('is TX-disabled when neither the radio nor UDP broadcast can carry a send', async () => {
+    mockTxStatus({ txEnabled: false, udpRelayEnabled: false, canTransmit: false });
+    const { result } = renderHook(() => useTxStatus({ refetchInterval: 60000 }), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.isTxDisabled).toBe(true);
+    expect(result.current.isUdpRelay).toBe(false);
+  });
+
+  it('is NOT TX-disabled when the radio is off but UDP broadcast relays (#4394)', async () => {
+    mockTxStatus({ txEnabled: false, udpRelayEnabled: true, canTransmit: true });
+    const { result } = renderHook(() => useTxStatus({ refetchInterval: 60000 }), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.isTxDisabled).toBe(false);
+    expect(result.current.isUdpRelay).toBe(true);
+  });
+
+  it('falls back to txEnabled when an older server omits canTransmit', async () => {
+    mockTxStatus({ txEnabled: false });
+    const { result } = renderHook(() => useTxStatus({ refetchInterval: 60000 }), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.isTxDisabled).toBe(true);
+    expect(result.current.isUdpRelay).toBe(false);
+  });
+
+  it('reports nothing disabled before the query resolves', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    const { result } = renderHook(() => useTxStatus({ refetchInterval: 60000 }), { wrapper });
+    expect(result.current.isTxDisabled).toBe(false);
+    expect(result.current.isUdpRelay).toBe(false);
+  });
+});

--- a/src/hooks/useTxStatus.ts
+++ b/src/hooks/useTxStatus.ts
@@ -12,8 +12,20 @@ import { useQuery } from '@tanstack/react-query';
  * TX Status response from the backend
  */
 export interface TxStatusData {
-  /** Whether TX is enabled on the device */
+  /** Whether the radio itself is TX-enabled (`lora.txEnabled`) */
   txEnabled: boolean;
+  /**
+   * Whether the device broadcasts its outgoing packets over local-LAN UDP
+   * (`network.enabledProtocols & UDP_BROADCAST`). A TX-disabled node with this
+   * on still reaches the mesh, because a LAN peer relays for it (#4394).
+   * Absent on older servers.
+   */
+  udpRelayEnabled?: boolean;
+  /**
+   * Whether sends have any path onto the mesh (`txEnabled || udpRelayEnabled`).
+   * Absent on older servers — callers fall back to `txEnabled`.
+   */
+  canTransmit?: boolean;
 }
 
 /**
@@ -85,9 +97,21 @@ export function useTxStatus({
     retry: 1,
   });
 
+  const data = query.data;
+  // A source with the radio TX-disabled but UDP Broadcast on can still put
+  // packets on the mesh through a LAN peer, so it must NOT be send-gated (#4394).
+  // `canTransmit` is absent on older servers — fall back to the radio flag.
+  const canTransmit = data ? (data.canTransmit ?? data.txEnabled) : true;
+
   return {
     ...query,
-    /** Whether TX is disabled (inverse of txEnabled for convenience) */
-    isTxDisabled: query.data ? !query.data.txEnabled : false,
+    /** Whether sends are blocked entirely (no radio TX and no UDP relay path) */
+    isTxDisabled: data ? !canTransmit : false,
+    /**
+     * Whether the radio is TX-disabled but UDP Broadcast relays sends anyway.
+     * Sends are allowed; the UI should say "relayed via UDP broadcast", not
+     * "cannot send".
+     */
+    isUdpRelay: data ? data.txEnabled === false && data.udpRelayEnabled === true : false,
   };
 }

--- a/src/server/constants/meshtastic.ts
+++ b/src/server/constants/meshtastic.ts
@@ -108,6 +108,36 @@ export const TransportMechanism = {
 export type TransportMechanismType = typeof TransportMechanism[keyof typeof TransportMechanism];
 
 /**
+ * Flags for `Config.NetworkConfig.enabled_protocols` (a bit field).
+ * From meshtastic.Config.NetworkConfig.ProtocolFlags in config.proto.
+ */
+export const NetworkProtocolFlags = {
+  /** Do not broadcast packets over any auxiliary network protocol */
+  NO_BROADCAST: 0x0000,
+  /** Broadcast packets via UDP over the local network */
+  UDP_BROADCAST: 0x0001,
+} as const;
+
+export type NetworkProtocolFlagsType = typeof NetworkProtocolFlags[keyof typeof NetworkProtocolFlags];
+
+/**
+ * True when a device's `network.enabledProtocols` bit field has UDP_BROADCAST set.
+ *
+ * Firmware `Router::send()` calls `udpHandler->onSend(p)` gated ONLY on this
+ * flag — there is no `tx_enabled` check on that path — so a TX-disabled node
+ * still emits every outgoing packet onto the local LAN, where a peer with a
+ * working radio (e.g. a CLIENT_BASE) relays it onto the mesh (#4394).
+ *
+ * Tolerant of the proto3 shapes we see on the wire: absent/null/undefined
+ * (field omitted, meaning 0) and non-numeric junk both read as "off".
+ */
+export function isUdpBroadcastEnabled(enabledProtocols: unknown): boolean {
+  const flags = Number(enabledProtocols ?? 0);
+  if (!Number.isFinite(flags)) return false;
+  return (flags & NetworkProtocolFlags.UDP_BROADCAST) !== 0;
+}
+
+/**
  * Get the name of a transport mechanism
  */
 export function getTransportMechanismName(mechanism: number): string {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -60,7 +60,7 @@ import { migrateAutomationChannels } from './utils/automationChannelMigration.js
 import { detectChannelMoves } from './utils/channelMoveDetection.js';
 import { detectLocalNodeSpoof, SentPacketIdCache, type SpoofDetectionResult } from './utils/spoofDetection.js';
 import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
-import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, resolveRadioPacketTransport, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName } from './constants/meshtastic.js';
+import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, resolveRadioPacketTransport, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isUdpBroadcastEnabled } from './constants/meshtastic.js';
 import { normalizeChannelRole } from './constants/channelRole.js';
 import { createRequire } from 'module';
 import { validateCron, scheduleCron, type CronJob } from './utils/cronScheduler.js';
@@ -2246,7 +2246,7 @@ class MeshtasticManager implements ISourceManager {
     const executeTraceroute = async () => {
       // TX-disabled radios cannot send OTA traceroutes; skip quietly and let the
       // interval keep running so a later TX re-enable resumes automatically (#4294).
-      if (!this.isTxEnabled()) {
+      if (!this.canTransmit()) {
         logger.debug('🗺️ Auto-traceroute: Skipping - TX disabled on this source');
         return;
       }
@@ -2408,7 +2408,7 @@ class MeshtasticManager implements ISourceManager {
     const executeRemoteLocalStats = async () => {
       // TX-disabled radios cannot send remote telemetry requests; skip quietly and
       // let the interval keep running so a later TX re-enable resumes automatically (#4294).
-      if (!this.isTxEnabled()) {
+      if (!this.canTransmit()) {
         logger.debug('📊 Remote LocalStats: Skipping - TX disabled on this source');
         return;
       }
@@ -2680,7 +2680,7 @@ class MeshtasticManager implements ISourceManager {
     this.remoteAdminScannerInterval = setInterval(async () => {
       // TX-disabled radios cannot send remote admin packets; skip quietly and let
       // the interval keep running so a later TX re-enable resumes automatically (#4294).
-      if (!this.isTxEnabled()) {
+      if (!this.canTransmit()) {
         logger.debug('🔑 Remote admin scanner: Skipping - TX disabled on this source');
         return;
       }
@@ -2924,7 +2924,7 @@ class MeshtasticManager implements ISourceManager {
 
     // TX-disabled radios cannot send NodeInfo exchanges; skip quietly and let the
     // interval keep running so a later TX re-enable resumes automatically (#4294).
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       logger.debug('🔐 Key repair: Skipping - TX disabled on this source');
       return;
     }
@@ -3322,7 +3322,7 @@ class MeshtasticManager implements ISourceManager {
         logger.debug(`⏱️ Timer "${trigger.name}" triggered (cron: ${trigger.cronExpression})`);
         // TX-disabled radios cannot send the timer's mesh output; skip quietly and
         // let the cron job keep running so a later TX re-enable resumes automatically (#4294).
-        if (!this.isTxEnabled()) {
+        if (!this.canTransmit()) {
           logger.debug(`⏱️ Timer "${trigger.name}": Skipping - TX disabled on this source`);
           return;
         }
@@ -4319,13 +4319,18 @@ class MeshtasticManager implements ISourceManager {
           // Block-scoped (no-case-declarations): this `case` clause has no
           // braces of its own, so `const` here needs an explicit block.
           {
-            const prevTxEnabled = this.actualDeviceConfig?.lora?.txEnabled !== false;
+            // Log against canTransmit(), not the raw radio flag: a TX-disabled
+            // node with UDP Broadcast on still reaches the mesh via a LAN peer,
+            // so the autonomous senders keep running (#4394).
+            const prevCanTransmit = this.canTransmit();
             this.actualDeviceConfig = { ...this.actualDeviceConfig, ...parsed.data };
-            const nextTxEnabled = this.actualDeviceConfig?.lora?.txEnabled !== false;
-            if (prevTxEnabled !== nextTxEnabled) {
-              logger.info(nextTxEnabled
+            const nextCanTransmit = this.canTransmit();
+            if (prevCanTransmit !== nextCanTransmit) {
+              logger.info(nextCanTransmit
                 ? `📡 [${this.sourceId}] TX re-enabled — autonomous senders resume`
                 : `🚫 [${this.sourceId}] TX disabled — pausing autonomous senders (node is now receive-only)`);
+            } else if (nextCanTransmit && !this.isTxEnabled()) {
+              logger.debug(`📡 [${this.sourceId}] Radio TX is disabled but UDP Broadcast is on — sends relay via the local network`);
             }
           }
           logger.debug('📊 Merged actualDeviceConfig now has keys:', Object.keys(this.actualDeviceConfig));
@@ -9001,12 +9006,46 @@ class MeshtasticManager implements ISourceManager {
 
 
   /**
-   * Current transmit state for THIS source, read from the in-memory device config.
-   * Defaults to true when config hasn't arrived yet (fail-open: don't block sends
-   * before we know the radio's state). No DB access — safe to call per packet.
+   * Current RADIO transmit state for THIS source, read from the in-memory device
+   * config. Defaults to true when config hasn't arrived yet (fail-open: don't
+   * block sends before we know the radio's state). No DB access — safe to call
+   * per packet.
+   *
+   * This is the raw `lora.txEnabled` truth and nothing else — config
+   * import/export and backup paths depend on it to preserve the device's own
+   * setting (#4294). Use `canTransmit()` to decide whether a send is futile.
    */
   isTxEnabled(): boolean {
     return this.actualDeviceConfig?.lora?.txEnabled !== false;
+  }
+
+  /**
+   * True when this node relays its outgoing packets over local-LAN UDP broadcast
+   * (`network.enabledProtocols & UDP_BROADCAST`), read from the in-memory device
+   * config. Defaults to false when the config hasn't arrived (proto3 omits a 0
+   * bit field, so "unknown" and "off" are indistinguishable — treat as off).
+   *
+   * Firmware `Router::send()` calls `udpHandler->onSend(p)` gated only on this
+   * flag, with no `tx_enabled` check, so a TX-disabled node's packets still hit
+   * the LAN and a peer with a working radio can relay them onto the mesh (#4394).
+   */
+  isUdpBroadcastRelayEnabled(): boolean {
+    return isUdpBroadcastEnabled(this.actualDeviceConfig?.network?.enabledProtocols);
+  }
+
+  /**
+   * Whether a send from THIS source has any path onto the mesh (#4394).
+   *
+   * Truth table:
+   *   tx on,  udp off → true   (normal radio TX)
+   *   tx on,  udp on  → true
+   *   tx off, udp on  → true   (RF is dead, but a LAN peer relays for us)
+   *   tx off, udp off → false  (receive-only; sends are futile → TX_DISABLED)
+   *
+   * This — not `isTxEnabled()` — is the guard every transmit primitive uses.
+   */
+  canTransmit(): boolean {
+    return this.isTxEnabled() || this.isUdpBroadcastRelayEnabled();
   }
 
   // Configuration retrieval methods
@@ -9031,7 +9070,7 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       throw new TxDisabledError();
     }
 
@@ -9213,7 +9252,7 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       throw new TxDisabledError();
     }
 
@@ -9265,7 +9304,7 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       throw new TxDisabledError();
     }
 
@@ -9344,7 +9383,7 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       throw new TxDisabledError();
     }
 
@@ -9417,7 +9456,7 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       throw new TxDisabledError();
     }
 
@@ -9648,7 +9687,7 @@ class MeshtasticManager implements ISourceManager {
       throw new Error('Not connected to Meshtastic node');
     }
 
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       throw new TxDisabledError();
     }
 
@@ -10015,7 +10054,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // TX-disabled radios cannot send the ack reply; skip quietly (#4294).
-      if (!this.isTxEnabled()) {
+      if (!this.canTransmit()) {
         logger.debug('⏭️ Skipping auto-acknowledge - TX disabled on this source');
         return;
       }
@@ -10342,7 +10381,7 @@ class MeshtasticManager implements ISourceManager {
 
     // TX-disabled radios cannot send ping replies; skip quietly rather than
     // letting sendTextMessage throw TxDisabledError partway through (#4294).
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       logger.debug('⏭️  Auto-ping command received but TX is disabled on this source');
       return false;
     }
@@ -10450,7 +10489,7 @@ class MeshtasticManager implements ISourceManager {
   private async sendNextAutoPing(session: AutoPingSession): Promise<void> {
     // TX-disabled radios cannot send pings; skip this tick quietly and leave the
     // session's interval running so it resumes automatically on TX re-enable (#4294).
-    if (!this.isTxEnabled()) {
+    if (!this.canTransmit()) {
       return;
     }
 
@@ -10761,7 +10800,7 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // TX-disabled radios cannot send the auto-responder reply; skip quietly (#4294).
-      if (!this.isTxEnabled()) {
+      if (!this.canTransmit()) {
         logger.debug('⏭️ Skipping auto-responder - TX disabled on this source');
         return;
       }

--- a/src/server/meshtasticManager.udpBroadcastTxGuard.test.ts
+++ b/src/server/meshtasticManager.udpBroadcastTxGuard.test.ts
@@ -1,0 +1,258 @@
+/**
+ * UDP-broadcast relay and the transmit guard (#4394).
+ *
+ * Firmware `Router::send()` calls `udpHandler->onSend(p)` gated ONLY on
+ * `config.network.enabled_protocols & UDP_BROADCAST` — there is no
+ * `tx_enabled` check on that path. So a node with the radio TX-disabled but
+ * UDP Broadcast enabled still puts every outgoing packet on the local LAN,
+ * where a peer with a working radio (e.g. a CLIENT_BASE) relays it onto the
+ * mesh. Blocking those sends was wrong.
+ *
+ * The guard therefore keys off `canTransmit()`:
+ *
+ *   tx on,  udp off → allow
+ *   tx on,  udp on  → allow
+ *   tx off, udp on  → allow  (relayed by a LAN peer)
+ *   tx off, udp off → block  (TX_DISABLED, the #4294 receive-only case)
+ *
+ * `isTxEnabled()` keeps its old, narrower meaning (raw `lora.txEnabled`)
+ * because the config import/export/backup paths depend on it to preserve the
+ * device's own setting — see #4294.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the VirtualNodeServer so tests never bind a real TCP port
+const { VNConstructor } = vi.hoisted(() => ({
+  VNConstructor: vi.fn(function (this: any, _opts: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    messages: {
+      insertMessage: vi.fn().mockResolvedValue(true),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+    markMessageAsReadAsync: vi.fn().mockResolvedValue(true),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array()),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array()),
+    createTextMessage: vi.fn(() => ({ data: new Uint8Array([1, 2, 3]), messageId: 12345 })),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+vi.mock('./services/packetLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+  packetLogService: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { MeshtasticManager } from './meshtasticManager.js';
+import { isTxDisabledError } from './errors/txDisabledError.js';
+import { NetworkProtocolFlags, isUdpBroadcastEnabled } from './constants/meshtastic.js';
+
+const UDP = NetworkProtocolFlags.UDP_BROADCAST;
+
+function makeManager(deviceConfig: any): MeshtasticManager {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).transport = { send: vi.fn().mockResolvedValue(undefined) };
+  (mgr as any).isConnected = true;
+  (mgr as any).localNodeInfo = {
+    nodeNum: 0x0badbeef,
+    nodeId: '!0badbeef',
+    longName: 'Local Node',
+    shortName: 'LOCL',
+  };
+  (mgr as any).actualDeviceConfig = deviceConfig;
+  return mgr;
+}
+
+/**
+ * Downstream send logic isn't fully mocked, so any non-TxDisabledError failure
+ * past the guard is fine — what matters is that the guard itself never fires.
+ */
+async function expectNotBlockedByTxGuard(fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(isTxDisabledError(error)).toBe(false);
+  }
+}
+
+describe('isUdpBroadcastEnabled() — ProtocolFlags bit test (#4394)', () => {
+  it('matches the config.proto flag value', () => {
+    expect(NetworkProtocolFlags.NO_BROADCAST).toBe(0x0000);
+    expect(NetworkProtocolFlags.UDP_BROADCAST).toBe(0x0001);
+  });
+
+  it('is false for the proto3 "field omitted" shapes', () => {
+    expect(isUdpBroadcastEnabled(undefined)).toBe(false);
+    expect(isUdpBroadcastEnabled(null)).toBe(false);
+    expect(isUdpBroadcastEnabled(0)).toBe(false);
+  });
+
+  it('is true when the UDP_BROADCAST bit is set, alone or alongside others', () => {
+    expect(isUdpBroadcastEnabled(1)).toBe(true);
+    expect(isUdpBroadcastEnabled(3)).toBe(true);
+    expect(isUdpBroadcastEnabled(0xffff)).toBe(true);
+  });
+
+  it('is false when other bits are set but UDP_BROADCAST is not', () => {
+    expect(isUdpBroadcastEnabled(2)).toBe(false);
+    expect(isUdpBroadcastEnabled(0xfffe)).toBe(false);
+  });
+
+  it('is false for non-numeric junk rather than throwing', () => {
+    expect(isUdpBroadcastEnabled('nonsense')).toBe(false);
+    expect(isUdpBroadcastEnabled({})).toBe(false);
+  });
+});
+
+describe('MeshtasticManager — canTransmit() truth table (#4394)', () => {
+  beforeEach(() => {
+    VNConstructor.mockClear();
+  });
+
+  it('tx on, udp off → can transmit', () => {
+    const mgr = makeManager({ lora: { txEnabled: true }, network: { enabledProtocols: 0 } });
+    expect(mgr.isTxEnabled()).toBe(true);
+    expect(mgr.isUdpBroadcastRelayEnabled()).toBe(false);
+    expect(mgr.canTransmit()).toBe(true);
+  });
+
+  it('tx on, udp on → can transmit', () => {
+    const mgr = makeManager({ lora: { txEnabled: true }, network: { enabledProtocols: UDP } });
+    expect(mgr.isUdpBroadcastRelayEnabled()).toBe(true);
+    expect(mgr.canTransmit()).toBe(true);
+  });
+
+  it('tx off, udp on → can transmit (a LAN peer relays for us)', () => {
+    const mgr = makeManager({ lora: { txEnabled: false }, network: { enabledProtocols: UDP } });
+    expect(mgr.isTxEnabled()).toBe(false);
+    expect(mgr.isUdpBroadcastRelayEnabled()).toBe(true);
+    expect(mgr.canTransmit()).toBe(true);
+  });
+
+  it('tx off, udp off → cannot transmit', () => {
+    const mgr = makeManager({ lora: { txEnabled: false }, network: { enabledProtocols: 0 } });
+    expect(mgr.canTransmit()).toBe(false);
+  });
+
+  it('tx off with NO network config at all → treated as udp off, cannot transmit', () => {
+    const mgr = makeManager({ lora: { txEnabled: false } });
+    expect(mgr.isUdpBroadcastRelayEnabled()).toBe(false);
+    expect(mgr.canTransmit()).toBe(false);
+  });
+
+  it('tx off with network config present but enabledProtocols omitted → cannot transmit', () => {
+    const mgr = makeManager({ lora: { txEnabled: false }, network: {} });
+    expect(mgr.canTransmit()).toBe(false);
+  });
+
+  it('no device config at all → fail-open, can transmit', () => {
+    const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+    expect((mgr as any).actualDeviceConfig).toBeNull();
+    expect(mgr.canTransmit()).toBe(true);
+  });
+
+  it('keeps isTxEnabled() reporting the RAW radio flag so config import/export still preserves it (#4294)', () => {
+    const mgr = makeManager({ lora: { txEnabled: false }, network: { enabledProtocols: UDP } });
+    // The radio truly cannot transmit — only canTransmit() may say otherwise.
+    expect(mgr.isTxEnabled()).toBe(false);
+  });
+});
+
+describe('MeshtasticManager — transmit primitives honor the UDP relay path (#4394)', () => {
+  beforeEach(() => {
+    VNConstructor.mockClear();
+  });
+
+  const blocked = { lora: { txEnabled: false }, network: { enabledProtocols: 0 } };
+  const relayed = { lora: { txEnabled: false }, network: { enabledProtocols: UDP } };
+
+  it('sendTextMessage throws TX_DISABLED when tx off and udp off', async () => {
+    const mgr = makeManager(blocked);
+    await expect(mgr.sendTextMessage('hi', 0)).rejects.toMatchObject({
+      isTxDisabledError: true,
+      code: 'TX_DISABLED',
+    });
+  });
+
+  it('sendTextMessage is NOT blocked when tx off but udp broadcast is on', async () => {
+    const mgr = makeManager(relayed);
+    await expectNotBlockedByTxGuard(() => mgr.sendTextMessage('hi', 0));
+  });
+
+  it('sendTraceroute is NOT blocked when tx off but udp broadcast is on', async () => {
+    const mgr = makeManager(relayed);
+    await expectNotBlockedByTxGuard(() => mgr.sendTraceroute(0x11111111, 0));
+  });
+
+  it('sendTraceroute is still blocked when tx off and udp off', async () => {
+    const mgr = makeManager(blocked);
+    await expect(mgr.sendTraceroute(0x11111111, 0)).rejects.toMatchObject({ isTxDisabledError: true });
+  });
+
+  it('sendPositionRequest is NOT blocked when tx off but udp broadcast is on', async () => {
+    const mgr = makeManager(relayed);
+    await expectNotBlockedByTxGuard(() => mgr.sendPositionRequest(0x11111111, 0));
+  });
+
+  it('sendNodeInfoRequest is NOT blocked when tx off but udp broadcast is on', async () => {
+    const mgr = makeManager(relayed);
+    await expectNotBlockedByTxGuard(() => mgr.sendNodeInfoRequest(0x11111111, 0));
+  });
+});

--- a/src/server/routes/deviceStatusRoutes.test.ts
+++ b/src/server/routes/deviceStatusRoutes.test.ts
@@ -5,6 +5,7 @@ import express from 'express';
 const mockManager = vi.hoisted(() => ({
   getDeviceConfig: vi.fn(),
   getSecurityKeys: vi.fn(),
+  isUdpBroadcastRelayEnabled: vi.fn(() => false),
 }));
 
 vi.mock('../utils/resolveSourceManager.js', () => ({
@@ -25,17 +26,33 @@ app.use('/', deviceStatusRoutes);
 beforeEach(() => vi.clearAllMocks());
 
 describe('GET /device/tx-status', () => {
+  beforeEach(() => mockManager.isUdpBroadcastRelayEnabled.mockReturnValue(false));
+
   it('reports txEnabled true by default', async () => {
     mockManager.getDeviceConfig.mockResolvedValue({ lora: {} });
     const res = await request(app).get('/device/tx-status');
     expect(res.status).toBe(200);
     expect(res.body.txEnabled).toBe(true);
+    expect(res.body.canTransmit).toBe(true);
   });
 
   it('reports txEnabled false when explicitly disabled', async () => {
     mockManager.getDeviceConfig.mockResolvedValue({ lora: { txEnabled: false } });
     const res = await request(app).get('/device/tx-status');
     expect(res.body.txEnabled).toBe(false);
+    expect(res.body.udpRelayEnabled).toBe(false);
+    expect(res.body.canTransmit).toBe(false);
+  });
+
+  // #4394: firmware still UDP-broadcasts a TX-disabled node's outgoing packets,
+  // and a LAN peer relays them onto the mesh — so sends are NOT futile.
+  it('reports canTransmit true when TX is off but UDP Broadcast relays', async () => {
+    mockManager.getDeviceConfig.mockResolvedValue({ lora: { txEnabled: false } });
+    mockManager.isUdpBroadcastRelayEnabled.mockReturnValue(true);
+    const res = await request(app).get('/device/tx-status');
+    expect(res.body.txEnabled).toBe(false);
+    expect(res.body.udpRelayEnabled).toBe(true);
+    expect(res.body.canTransmit).toBe(true);
   });
 });
 

--- a/src/server/routes/deviceStatusRoutes.ts
+++ b/src/server/routes/deviceStatusRoutes.ts
@@ -12,7 +12,15 @@ router.get('/device/tx-status', optionalAuth(), async (req: Request, res: Respon
     const txManager = resolveSourceManager(txSourceId);
     const deviceConfig = await txManager.getDeviceConfig();
     const txEnabled = deviceConfig?.lora?.txEnabled !== false; // Default to true if undefined
-    res.json({ txEnabled });
+    // UDP-broadcast relay (#4394): with `network.enabledProtocols & UDP_BROADCAST`
+    // set, firmware still emits outgoing packets onto the LAN even when the radio
+    // is TX-disabled, and a peer there relays them onto the mesh. Such a source can
+    // send, so the UI gates on `canTransmit`, not on `txEnabled` alone. Managers
+    // without the method (non-Meshtastic) report no relay.
+    const udpRelayEnabled = typeof txManager.isUdpBroadcastRelayEnabled === 'function'
+      ? txManager.isUdpBroadcastRelayEnabled()
+      : false;
+    res.json({ txEnabled, udpRelayEnabled, canTransmit: txEnabled || udpRelayEnabled });
   } catch (error) {
     logger.error('Error getting TX status:', error);
     res.status(500).json({ error: 'Failed to get TX status' });

--- a/src/server/routes/sourceRoutes.radio.test.ts
+++ b/src/server/routes/sourceRoutes.radio.test.ts
@@ -73,7 +73,43 @@ describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
       regionName: 'US',
       modemPreset: 0,
       txEnabled: true,
+      udpRelayEnabled: false,
+      canTransmit: true,
     });
+  });
+
+  // #4394: firmware UDP-broadcasts outgoing packets whenever
+  // `network.enabledProtocols & UDP_BROADCAST` is set, with no tx_enabled check,
+  // so a LAN peer relays them. Such a source can send even with the radio off.
+  it('reports canTransmit: true when TX is off but UDP Broadcast relays (#4394)', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceA) return null;
+      return {
+        sourceType: 'meshtastic_tcp',
+        isUdpBroadcastRelayEnabled: () => true,
+        getCurrentConfig: () => ({
+          deviceConfig: {
+            lora: {
+              region: 1,
+              channelNum: 21,
+              overrideFrequency: 0,
+              frequencyOffset: 0,
+              bandwidth: 250,
+              modemPreset: 0,
+              txEnabled: false,
+            },
+          },
+        }),
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
+    expect(a.radio.txEnabled).toBe(false);
+    expect(a.radio.udpRelayEnabled).toBe(true);
+    expect(a.radio.canTransmit).toBe(true);
   });
 
   it('reflects txEnabled: false on the meshtastic summary when the source is receive-only (#4294 P3)', async () => {
@@ -102,6 +138,7 @@ describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
 
     const a = res.body.find((s: { id: string }) => s.id === harness.sourceA);
     expect(a.radio.txEnabled).toBe(false);
+    expect(a.radio.canTransmit).toBe(false);
   });
 
   it('fails open to txEnabled: true when the field is absent from lora config (#4294 P3)', async () => {

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -269,6 +269,14 @@ interface SourceRadioSummary {
   modemPreset?: number;
   /** Meshtastic only. Fail-open true (matches firmware default) when the field is unset. */
   txEnabled?: boolean;
+  /** Meshtastic only. `network.enabledProtocols & UDP_BROADCAST` — a LAN peer relays our sends (#4394). */
+  udpRelayEnabled?: boolean;
+  /**
+   * Meshtastic only. Whether sends from this source have any path onto the mesh:
+   * `txEnabled || udpRelayEnabled`. Consumers gating "can this source send?" must
+   * read THIS, not `txEnabled` (#4394).
+   */
+  canTransmit?: boolean;
 }
 
 // Wrapped in try/catch so a manager that throws from getCurrentConfig()/
@@ -290,11 +298,17 @@ function computeSourceRadioSummary(sourceId: string): SourceRadioSummary | null 
         undefined,
         Number(lora.modemPreset ?? 0),
       );
+      const txEnabled = lora.txEnabled ?? true;
+      const udpRelayEnabled = typeof mgr.isUdpBroadcastRelayEnabled === 'function'
+        ? mgr.isUdpBroadcastRelayEnabled()
+        : false;
       return {
         frequencyMhz,
         regionName: REGION_SHORT_NAME[region],
         modemPreset: Number(lora.modemPreset ?? 0),
-        txEnabled: lora.txEnabled ?? true,
+        txEnabled,
+        udpRelayEnabled,
+        canTransmit: txEnabled || udpRelayEnabled,
       };
     }
     if (isMeshCoreManager(mgr)) {

--- a/src/server/services/autoAnnounceService.test.ts
+++ b/src/server/services/autoAnnounceService.test.ts
@@ -58,6 +58,8 @@ function makeFakeManager(overrides: Partial<{
   rebootMergeInProgress: boolean;
   automationAirtimeGated: boolean;
   txEnabled: boolean;
+  /** #4394: `network.enabledProtocols & UDP_BROADCAST` — a LAN peer relays our sends. */
+  udpRelayEnabled: boolean;
 }> = {}) {
   const state = {
     sourceId: overrides.sourceId ?? 'test-source',
@@ -65,6 +67,7 @@ function makeFakeManager(overrides: Partial<{
     rebootMergeInProgress: overrides.rebootMergeInProgress ?? false,
     automationAirtimeGated: overrides.automationAirtimeGated ?? false,
     txEnabled: overrides.txEnabled ?? true,
+    udpRelayEnabled: overrides.udpRelayEnabled ?? false,
   };
   return {
     state,
@@ -73,6 +76,8 @@ function makeFakeManager(overrides: Partial<{
     isRebootMergeInProgress: vi.fn(() => state.rebootMergeInProgress),
     isAutomationAirtimeGated: vi.fn(async () => state.automationAirtimeGated),
     isTxEnabled: vi.fn(() => state.txEnabled),
+    isUdpBroadcastRelayEnabled: vi.fn(() => state.udpRelayEnabled),
+    canTransmit: vi.fn(() => state.txEnabled || state.udpRelayEnabled),
     replaceAnnouncementTokens: vi.fn(async (message: string) => message.replace('{VERSION}', '9.9.9')),
     messageQueue: { enqueue: vi.fn() },
     broadcastNodeInfoToChannels: vi.fn().mockResolvedValue(undefined),
@@ -219,6 +224,19 @@ describe('AutoAnnounceService', () => {
       expect(sendSpy).not.toHaveBeenCalled();
 
       mgr.state.txEnabled = true;
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // #4394: the radio is off, but UDP Broadcast puts the announcement on the LAN
+    // where a peer relays it onto the mesh — the tick must not be skipped.
+    it('onTick still announces when TX is off but UDP Broadcast relays (#4394)', async () => {
+      const mgr = makeFakeManager({ deviceConnected: true, txEnabled: false, udpRelayEnabled: true });
+      const svc = new AutoAnnounceService(mgr as any);
+      const sendSpy = vi.spyOn(svc, 'sendAutoAnnouncement').mockResolvedValue(undefined);
+
+      await svc.startAnnounceScheduler();
       await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
 
       expect(sendSpy).toHaveBeenCalledTimes(1);

--- a/src/server/services/autoAnnounceService.ts
+++ b/src/server/services/autoAnnounceService.ts
@@ -75,10 +75,11 @@ export class AutoAnnounceService {
       label: `Meshtastic:${sourceId}`,
       mode,
       onTick: () => {
-        logger.debug(`📢 Announce tick triggered (connected: ${this.mgr.isDeviceConnected()}, txEnabled: ${this.mgr.isTxEnabled()})`);
+        logger.debug(`📢 Announce tick triggered (connected: ${this.mgr.isDeviceConnected()}, canTransmit: ${this.mgr.canTransmit()})`);
         // TX-disabled radios cannot broadcast announcements; skip quietly and let
         // the scheduler keep running so a later TX re-enable resumes automatically (#4294).
-        if (this.mgr.isDeviceConnected() && this.mgr.isTxEnabled()) {
+        // UDP Broadcast counts as a transmit path — a LAN peer relays for us (#4394).
+        if (this.mgr.isDeviceConnected() && this.mgr.canTransmit()) {
           return this.sendAutoAnnouncement(true).catch((error: Error) => {
             logger.error('❌ Error in auto-announce:', error);
           });

--- a/src/server/services/remoteAdminService.test.ts
+++ b/src/server/services/remoteAdminService.test.ts
@@ -51,6 +51,8 @@ function makeFakeManager(overrides: Partial<{
   localNodeInfo: { nodeNum: number } | null;
   sessionPasskeys: Map<number, Uint8Array>;
   txEnabled: boolean;
+  /** #4394: `network.enabledProtocols & UDP_BROADCAST` — a LAN peer relays our sends. */
+  udpRelayEnabled: boolean;
 }> = {}) {
   const state = {
     transportReady: overrides.transportReady ?? true,
@@ -63,6 +65,7 @@ function makeFakeManager(overrides: Partial<{
     pendingModuleConfigRequests: new Map<number, string>(),
     moduleConfigsEverFetched: false,
     txEnabled: overrides.txEnabled ?? true,
+    udpRelayEnabled: overrides.udpRelayEnabled ?? false,
   };
 
   return {
@@ -80,6 +83,8 @@ function makeFakeManager(overrides: Partial<{
     resetModuleConfigState: vi.fn(() => { state.moduleConfigsEverFetched = false; }),
     setModuleConfigsEverFetched: vi.fn((v: boolean) => { state.moduleConfigsEverFetched = v; }),
     isTxEnabled: vi.fn(() => state.txEnabled),
+    isUdpBroadcastRelayEnabled: vi.fn(() => state.udpRelayEnabled),
+    canTransmit: vi.fn(() => state.txEnabled || state.udpRelayEnabled),
   };
 }
 
@@ -370,6 +375,23 @@ describe('RemoteAdminService', () => {
       const svc = new RemoteAdminService(mgr as any);
       await expect(svc.requestModuleConfig(14)).resolves.toBeUndefined();
       expect(mgr.sendLocalAdminPacket).toHaveBeenCalledTimes(1);
+    });
+
+    // #4394: the radio is TX-disabled, but UDP Broadcast puts the admin packet on
+    // the LAN where a peer relays it — remote admin is genuinely usable.
+    it('remote sends are NOT blocked when TX is off but UDP Broadcast relays', async () => {
+      vi.useFakeTimers();
+      try {
+        const mgr = makeFakeManager({ txEnabled: false, udpRelayEnabled: true });
+        const svc = new RemoteAdminService(mgr as any);
+        const promise = svc.sendRebootCommand(222, 5);
+        await vi.advanceTimersByTimeAsync(1);
+        mgr.state.sessionPasskeys.set(222, new Uint8Array([7]));
+        await vi.advanceTimersByTimeAsync(500);
+        await expect(promise).resolves.toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('remote sends succeed normally when TX is enabled', async () => {

--- a/src/server/services/remoteAdminService.ts
+++ b/src/server/services/remoteAdminService.ts
@@ -61,7 +61,9 @@ export class RemoteAdminService {
    * docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md §4.
    */
   private assertTxForRemoteTarget(isLocalNode: boolean): void {
-    if (!isLocalNode && !this.mgr.isTxEnabled()) {
+    // canTransmit(), not isTxEnabled(): with UDP Broadcast on, a LAN peer relays
+    // our admin packets onto the mesh even with the radio TX-disabled (#4394).
+    if (!isLocalNode && !this.mgr.canTransmit()) {
       throw new TxDisabledError('Remote admin requires transmit; TX is disabled on this source');
     }
   }

--- a/src/server/services/waypointService.test.ts
+++ b/src/server/services/waypointService.test.ts
@@ -313,7 +313,7 @@ describe('rebroadcastTick', () => {
     it('does NOT stamp lastBroadcastAt or call broadcastWaypoint when the source manager reports TX disabled', async () => {
       mockFindOldestEligible.mockResolvedValueOnce(eligibleRow());
       const broadcastWaypoint = vi.fn().mockResolvedValue(42);
-      mockGetManager.mockReturnValueOnce({ broadcastWaypoint, isTxEnabled: () => false });
+      mockGetManager.mockReturnValueOnce({ broadcastWaypoint, canTransmit: () => false });
 
       const result = await waypointService.rebroadcastTick();
 
@@ -326,7 +326,7 @@ describe('rebroadcastTick', () => {
       const row = eligibleRow();
       mockFindOldestEligible.mockResolvedValueOnce(row);
       const broadcastWaypoint = vi.fn().mockResolvedValue(42);
-      mockGetManager.mockReturnValueOnce({ broadcastWaypoint, isTxEnabled: () => true });
+      mockGetManager.mockReturnValueOnce({ broadcastWaypoint, canTransmit: () => true });
       mockMarkRebroadcasted.mockResolvedValueOnce(true);
       mockGet.mockResolvedValueOnce({ ...row, lastBroadcastAt: 1234 });
 
@@ -336,7 +336,27 @@ describe('rebroadcastTick', () => {
       expect(result).not.toBeNull();
     });
 
-    it('broadcasts normally when the manager has no isTxEnabled (e.g. a MeshCore manager, never gated)', async () => {
+    // #4394: radio TX off but UDP Broadcast on — canTransmit() is true, so the
+    // waypoint still goes out (relayed by a LAN peer).
+    it('broadcasts when the radio is TX-disabled but canTransmit() is true (UDP relay)', async () => {
+      const row = eligibleRow();
+      mockFindOldestEligible.mockResolvedValueOnce(row);
+      const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+      mockGetManager.mockReturnValueOnce({
+        broadcastWaypoint,
+        isTxEnabled: () => false,
+        canTransmit: () => true,
+      });
+      mockMarkRebroadcasted.mockResolvedValueOnce(true);
+      mockGet.mockResolvedValueOnce({ ...row, lastBroadcastAt: 1234 });
+
+      const result = await waypointService.rebroadcastTick();
+
+      expect(broadcastWaypoint).toHaveBeenCalledOnce();
+      expect(result).not.toBeNull();
+    });
+
+    it('broadcasts normally when the manager has no canTransmit (e.g. a MeshCore manager, never gated)', async () => {
       const row = eligibleRow();
       mockFindOldestEligible.mockResolvedValueOnce(row);
       const broadcastWaypoint = vi.fn().mockResolvedValue(42);

--- a/src/server/services/waypointService.ts
+++ b/src/server/services/waypointService.ts
@@ -333,8 +333,10 @@ class WaypointService {
 
     // TX-disabled Meshtastic radios cannot send the waypoint OTA; skip quietly
     // and leave lastBroadcastAt untouched so it retries once TX re-enables (#4294).
-    // MeshCore/other manager types don't expose isTxEnabled and are never gated.
-    if (typeof manager.isTxEnabled === 'function' && !manager.isTxEnabled()) {
+    // `canTransmit()` also clears the send when UDP Broadcast is on, since a LAN
+    // peer relays the packet onto the mesh for us (#4394).
+    // MeshCore/other manager types don't expose canTransmit and are never gated.
+    if (typeof manager.canTransmit === 'function' && !manager.canTransmit()) {
       logger.debug(
         `[waypointService] rebroadcastTick: TX disabled on source ${candidate.sourceId}, skipping`,
       );


### PR DESCRIPTION
## Why

MeshMonitor blocked **all** sends whenever a source's LoRa `tx_enabled=false` (receive-only mode, epic #4294). That is too strict for a real topology: a TX-disabled node with **UDP Broadcast** enabled still gets its packets onto the mesh, because a peer on the same LAN (e.g. a `CLIENT_BASE`) relays them over its own radio.

Firmware `Router::send()` (`src/mesh/Router.cpp`):

```cpp
#if HAS_UDP_MULTICAST
    if (udpHandler && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
        udpHandler->onSend(const_cast<meshtastic_MeshPacket *>(p));
    }
#endif
    assert(iface);
    return iface->send(p);
```

The UDP hand-off is gated **only** on `enabled_protocols & UDP_BROADCAST` — there is no `tx_enabled` check on that path (RF suppression happens further down, at the radio interface). So the packet genuinely leaves the node and reaches the mesh.

This implements option 2 from the issue: make the guard smarter. No new user-facing "force send" setting — the behavior is derived automatically from device config.

## Truth table (the guard that landed)

`MeshtasticManager.canTransmit() = isTxEnabled() || isUdpBroadcastRelayEnabled()`

| radio `lora.txEnabled` | `network.enabledProtocols & UDP_BROADCAST` | result |
|---|---|---|
| on | off | allow |
| on | on | allow |
| **off** | **on** | **allow** (relayed by a LAN peer) |
| off | off | block — `TX_DISABLED` (409) |
| off | network config missing / `enabledProtocols` omitted | block (proto3 omits a 0 bit field, so unknown == off) |
| no device config at all | — | allow (unchanged fail-open) |

`isTxEnabled()` deliberately keeps its old, narrow meaning (raw `lora.txEnabled`). The #4294 backfill paths — config import (`configRoutes`, `channelRoutes`, `adminRoutes`), export, and device backup — still read it, so a UDP-relay source's radio flag is never silently flipped back on by an import. `setLoRaConfig` remains a whole-struct replace and still receives an explicit `txEnabled`.

## Surfaces changed

**Protocol constants**
- `src/server/constants/meshtastic.ts`: new `NetworkProtocolFlags` (`NO_BROADCAST: 0x0000`, `UDP_BROADCAST: 0x0001`, from `config.proto`) + `isUdpBroadcastEnabled(enabledProtocols)` — no magic numbers.

**Backend guard**
- `src/server/meshtasticManager.ts`: new `isUdpBroadcastRelayEnabled()` and `canTransmit()`; all **15** transmit-primitive guards switched from `!this.isTxEnabled()` to `!this.canTransmit()` (sendTextMessage, traceroute, position/nodeinfo requests, telemetry, waypoint, auto-ack responder, auto-traceroute, remote LocalStats, remote-admin scanner, key repair, timer triggers, …). The config-merge state log now flips on `canTransmit()`, so the "pausing autonomous senders" line no longer fires for a relay-capable node.
- `src/server/services/remoteAdminService.ts`: remote-target admin guard now uses `canTransmit()`.
- `src/server/services/autoAnnounceService.ts`: announce tick gated on `canTransmit()`.
- `src/server/services/waypointService.ts`: rebroadcast tick gated on `canTransmit()` (still no-ops for managers that don't expose it, e.g. MeshCore).

**API**
- `GET /api/device/tx-status` now returns `{ txEnabled, udpRelayEnabled, canTransmit }` (was `{ txEnabled }` — additive).
- `GET /api/sources` `radio` summary gains `udpRelayEnabled` and `canTransmit`.

**Frontend (kept honest — the node still cannot transmit over RF itself)**
- `useTxStatus`: `isTxDisabled` now means "no send path at all" (`!canTransmit`, falling back to `txEnabled` on older servers) and a new `isUdpRelay` flag marks the distinct "radio off, relayed via UDP broadcast" state. This automatically un-gates the compose box, traceroute buttons and remote-admin UI that consume `txGated` in `App.tsx`.
- `AppBanners`: a UDP-relay source no longer gets the "your device cannot send messages" banner. It gets a distinct one: *"Radio Transmit Disabled: This device does not transmit over LoRa itself. UDP Broadcast is on, so sends go out over the local network and another node there relays them to the mesh."* (`banners.tx_disabled_udp_relay`, en.json; other locales fall back to English).
- Automations source picker: the "Transmit is disabled on this source" advisory badge now keys off `canTransmit`, so a relay-capable source isn't flagged.

## Test evidence

New: `src/server/meshtasticManager.udpBroadcastTxGuard.test.ts` (flag helper + the full truth table + primitive guards), `src/hooks/useTxStatus.test.tsx` (gating, relay state, old-server fallback, pre-resolve state).
Extended: `deviceStatusRoutes.test.ts`, `sourceRoutes.radio.test.ts`, `AppBanners.test.tsx`, `AutomationBuilder.txWarning.test.tsx`, `remoteAdminService.test.ts`, `autoAnnounceService.test.ts`, `waypointService.test.ts`.

```
npx tsc -p tsconfig.server.json --noEmit   → clean
npx tsc -p tsconfig.json --noEmit          → clean
npx vitest run (full suite)                → success: true
                                             12080 tests, 11950 passed, 0 failed, 109 skipped
                                             3582 suites, 0 failed
npm run lint:ci                            → no in-repo FAIL lines
```

(PostgreSQL/MySQL containers were not up locally; this change touches no schema or migrations, so the multi-backend suites are unaffected — CI covers them anyway.)

## Out of scope

- No user-facing override setting (explicitly rejected in favor of option 2).
- MeshCore sources are untouched — they have no `tx_enabled`/UDP-broadcast concept.
- No live-hardware validation of the relay itself; the rationale is read straight from firmware source and the reporter's field report.

Closes #4394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob
