### PR TITLE
feat(waypoints): let the user pick the broadcast channel (#4341)

### DIFF
--- a/docs/features/waypoints.md
+++ b/docs/features/waypoints.md
@@ -58,6 +58,7 @@ Authoring is available on the per-source dashboard map for users with `waypoints
    - **Icon** — pick an emoji from the picker (rendered with VS-16 forcing so it shows as an emoji on every platform)
    - **Lock to me** — only your node can edit this waypoint after broadcast
    - **Expires** — toggle on to set an expiry timestamp; off means "never expires"
+   - **Channel** — which of the source's channels the waypoint is broadcast on. The list comes from the waypoint's own source, so you only ever see channels that source can transmit on. Leave it alone and the waypoint goes out on Primary (slot 0), the channel every waypoint used before this option existed. The picker is disabled for virtual waypoints, which are never transmitted.
 5. Click **Save**. MeshMonitor allocates a waypoint id (Python-style id allocation), persists the row, and broadcasts a WAYPOINT_APP packet to the mesh.
 
 ### Edit
@@ -76,16 +77,20 @@ Waypoints are exposed on the v1 source-scoped routes, gated by `waypoints:read|w
 | --- | --- | --- |
 | `GET`    | `/api/sources/:id/waypoints` | List waypoints (supports `?bbox=` and `?include_expired=`) |
 | `POST`   | `/api/sources/:id/waypoints` | Create a local waypoint and broadcast it |
-| `PATCH`  | `/api/sources/:id/waypoints/:waypointId` | Update name/description/icon/expiry/lock |
+| `PATCH`  | `/api/sources/:id/waypoints/:waypointId` | Update name/description/icon/expiry/lock/channel |
 | `DELETE` | `/api/sources/:id/waypoints/:waypointId` | Delete locally and broadcast a tombstone |
 
 All mutations require the standard `X-CSRF-Token` header. Mutations on a waypoint with `locked_to` set to another node return `403`.
+
+`POST` and `PATCH` accept an optional `channel` field — an integer device channel slot `0`-`7`. Anything else returns `400`. Omit it and the waypoint stays on slot 0.
 
 ## Database
 
 Waypoints live in a per-source `waypoints` table introduced in migration **053**, with composite primary key `(sourceId, waypointId)`, a foreign key to `sources` with `ON DELETE CASCADE`, and indexes on `(sourceId, expireAt)` and `(sourceId, ownerNodeNum)`.
 
 Migrations **054** / **055** seed the new `waypoints:read` / `waypoints:write` permissions for existing users by cloning their `messages` grants per source.
+
+Migration **130** adds the `channel` column that records which slot a waypoint is broadcast on. Rows created before it read back as `NULL`, which every send site treats as slot 0 — the same channel they always used.
 
 The daily database maintenance tick sweeps expired waypoints (with a grace window) and emits `waypoint:expired` events for each removed row.
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -22,7 +22,7 @@ import { getTilesetById } from '../config/tilesets';
 import { getEffectiveHops, getMapHoverTooltipMeta } from '../utils/nodeHops';
 import { buildNodeExportRows, nodesToCsv, nodesToHtml, downloadTextFile } from '../utils/nodeExport';
 import { useMapContext } from '../contexts/MapContext';
-import { useTelemetryNodes, useDeviceConfig, useNodes, setNodeFieldInCache } from '../hooks/useServerData';
+import { useTelemetryNodes, useDeviceConfig, useNodes, useChannels, setNodeFieldInCache } from '../hooks/useServerData';
 import { useQueryClient } from '@tanstack/react-query';
 import { useUI } from '../contexts/UIContext';
 import { useSettings } from '../contexts/SettingsContext';
@@ -541,6 +541,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   // ----- Waypoint authoring state -----
   const canWriteWaypoints = hasPermission('waypoints', 'write');
+  // Channels come from the poll cache, which is already keyed on the active
+  // source — so the picker only ever offers the waypoint's own source (#4341).
+  const { channels: sourceChannels } = useChannels();
   const waypointMutations = useWaypoints(currentSourceId);
   const [waypointEditorOpen, setWaypointEditorOpen] = useState(false);
   const [waypointEditorInitial, setWaypointEditorInitial] = useState<Waypoint | null>(null);
@@ -2914,6 +2917,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       <WaypointEditorModal
         isOpen={waypointEditorOpen}
         initial={waypointEditorInitial}
+        channels={sourceChannels}
         defaultCoords={waypointDefaultCoords}
         selfNodeNum={localNodeNum ?? null}
         onClose={() => setWaypointEditorOpen(false)}

--- a/src/components/WaypointEditorModal.test.tsx
+++ b/src/components/WaypointEditorModal.test.tsx
@@ -44,6 +44,8 @@ describe('WaypointEditorModal — create mode', () => {
       expire: null,
       locked_to: null,
       virtual: false,
+      // #4341: no explicit pick => slot 0, the channel waypoints always used.
+      channel: 0,
       rebroadcast_interval_s: null,
     });
   });
@@ -77,6 +79,76 @@ describe('WaypointEditorModal — create mode', () => {
   });
 });
 
+describe('WaypointEditorModal — broadcast channel (#4341)', () => {
+  const CHANNELS = [
+    { id: 0, name: '' },
+    { id: 1, name: 'gauntlet' },
+    { id: 2, name: 'admin' },
+    // Channel-Database virtual channel — must never be offered.
+    { id: 101, name: 'mqtt-virtual' },
+  ];
+
+  it('renders one option per device channel slot and hides virtual channels', () => {
+    const { getByLabelText } = renderModal({ channels: CHANNELS });
+    const select = getByLabelText('Broadcast channel') as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(['0', '1', '2']);
+    expect(select.options[0]!.textContent).toMatch(/Primary/);
+    expect(select.options[1]!.textContent).toMatch(/gauntlet/);
+  });
+
+  it('puts the selected channel into the saved payload', async () => {
+    const { onSave, getByText, getByLabelText } = renderModal({
+      channels: CHANNELS,
+      defaultCoords: { lat: 1, lon: 2 },
+    });
+
+    fireEvent.change(getByLabelText('Broadcast channel'), { target: { value: '2' } });
+    fireEvent.click(getByText(/Create/));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].channel).toBe(2);
+  });
+
+  it('falls back to a Primary-only picker when the source reports no channels', () => {
+    const { getByLabelText } = renderModal();
+    const select = getByLabelText('Broadcast channel') as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+    expect(select.value).toBe('0');
+  });
+
+  it('disables the picker for a virtual (never transmitted) waypoint', () => {
+    const { getByText, getByLabelText } = renderModal({ channels: CHANNELS });
+    fireEvent.click(getByText(/Virtual \(do not broadcast\)/));
+    expect((getByLabelText('Broadcast channel') as HTMLSelectElement).disabled).toBe(true);
+  });
+
+  it('pre-selects the stored channel in edit mode', () => {
+    const { getByLabelText } = renderModal({
+      channels: CHANNELS,
+      initial: {
+        sourceId: 's1', waypointId: 7, ownerNodeNum: 1, latitude: 10, longitude: 20,
+        expireAt: null, lockedTo: null, name: 'Existing', description: '',
+        iconCodepoint: null, iconEmoji: '📍', isVirtual: false, channel: 2,
+        rebroadcastIntervalS: null, lastBroadcastAt: null, firstSeenAt: 0, lastUpdatedAt: 0,
+      },
+    });
+    expect((getByLabelText('Broadcast channel') as HTMLSelectElement).value).toBe('2');
+  });
+
+  it('shows slot 0 for a waypoint stored before the column existed', () => {
+    const { getByLabelText } = renderModal({
+      channels: CHANNELS,
+      initial: {
+        sourceId: 's1', waypointId: 7, ownerNodeNum: 1, latitude: 10, longitude: 20,
+        expireAt: null, lockedTo: null, name: 'Legacy', description: '',
+        iconCodepoint: null, iconEmoji: '📍', isVirtual: false, channel: null,
+        rebroadcastIntervalS: null, lastBroadcastAt: null, firstSeenAt: 0, lastUpdatedAt: 0,
+      },
+    });
+    expect((getByLabelText('Broadcast channel') as HTMLSelectElement).value).toBe('0');
+  });
+});
+
 describe('WaypointEditorModal — edit mode', () => {
   it('pre-fills fields from `initial` and shows Save (not Create)', async () => {
     const { getByText, container } = renderModal({
@@ -93,6 +165,7 @@ describe('WaypointEditorModal — edit mode', () => {
         iconCodepoint: 0x1f3d5,
         iconEmoji: '🏕️',
         isVirtual: false,
+        channel: null,
         rebroadcastIntervalS: null,
         lastBroadcastAt: null,
         firstSeenAt: 0,

--- a/src/components/WaypointEditorModal.tsx
+++ b/src/components/WaypointEditorModal.tsx
@@ -5,7 +5,7 @@
  * behavior. In create mode pass `initial={null}` (or omit it); in edit mode
  * pass the existing waypoint and the dialog pre-fills.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Modal from './common/Modal';
 import type { Waypoint, WaypointInput } from '../types/waypoint';
 import './WaypointEditorModal.css';
@@ -13,9 +13,27 @@ import { UiIcon } from './icons';
 
 const DEFAULT_EMOJIS = ['📍', '🏠', '🏕️', '⛺', '🚗', '🛟', '⚠️', '⭐', '🚩', '🛠️'];
 
+/**
+ * Highest device channel slot a Meshtastic radio exposes. Virtual channels
+ * from the Channel Database use ids at/above `CHANNEL_DB_OFFSET` (100) and
+ * cannot carry an outgoing waypoint, so they are filtered out of the picker.
+ */
+const MAX_CHANNEL_INDEX = 7;
+
+/** Minimal shape the picker needs — matches `Channel` from `types/device`. */
+export interface WaypointChannelOption {
+  id: number;
+  name?: string;
+}
+
 export interface WaypointEditorModalProps {
   isOpen: boolean;
   initial?: Waypoint | null;
+  /**
+   * Channels of the waypoint's own source. Slots above 7 (Channel Database
+   * virtual channels) are ignored — the radio cannot transmit on them.
+   */
+  channels?: WaypointChannelOption[];
   /** Optional callback to enter map-pick mode for coordinates. */
   onPickLocation?: () => void;
   onClose: () => void;
@@ -41,7 +59,13 @@ function localToExpireSeconds(local: string): number | null {
 }
 
 export default function WaypointEditorModal(props: WaypointEditorModalProps) {
-  const { isOpen, initial, onPickLocation, onClose, onSave, selfNodeNum, defaultCoords } = props;
+  const { isOpen, initial, channels, onPickLocation, onClose, onSave, selfNodeNum, defaultCoords } =
+    props;
+
+  const deviceChannels = useMemo(
+    () => (channels ?? []).filter((c) => Number.isInteger(c.id) && c.id >= 0 && c.id <= MAX_CHANNEL_INDEX),
+    [channels],
+  );
 
   const [lat, setLat] = useState('');
   const [lon, setLon] = useState('');
@@ -52,9 +76,20 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
   const [hasExpiry, setHasExpiry] = useState(false);
   const [lockToSelf, setLockToSelf] = useState(false);
   const [virtual, setVirtual] = useState(false);
+  const [channel, setChannel] = useState(0);
   const [rebroadcast, setRebroadcast] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // A waypoint can name a slot the source no longer reports (renamed, or the
+  // channel list has not loaded). Keep it in the list so the picker shows the
+  // real stored value instead of silently rendering blank.
+  const channelOptions = useMemo(() => {
+    if (deviceChannels.some((c) => c.id === channel)) return deviceChannels;
+    return [...deviceChannels, { id: channel, name: `Channel ${channel}` }].sort(
+      (a, b) => a.id - b.id,
+    );
+  }, [deviceChannels, channel]);
 
   // Reset form when opened or `initial` changes
   useEffect(() => {
@@ -71,6 +106,8 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
         initial.lockedTo != null && selfNodeNum != null && initial.lockedTo === selfNodeNum,
       );
       setVirtual(Boolean(initial.isVirtual));
+      // `null` on rows created before #4341 — those went out on slot 0.
+      setChannel(initial.channel ?? 0);
       setRebroadcast(
         initial.rebroadcastIntervalS
           ? String(Math.max(10, Math.round(initial.rebroadcastIntervalS / 60)))
@@ -86,6 +123,7 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
       setExpireLocal('');
       setLockToSelf(false);
       setVirtual(false);
+      setChannel(0);
       setRebroadcast('');
     }
     setError(null);
@@ -137,6 +175,7 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
       expire,
       locked_to: lockToSelf && selfNodeNum != null ? selfNodeNum : null,
       virtual,
+      channel,
       rebroadcast_interval_s: rebroadcastIntervalS,
     };
   }
@@ -285,6 +324,29 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
             onChange={(e) => setVirtual(e.target.checked)}
           />
           <span>Virtual (do not broadcast)</span>
+        </label>
+
+        <label className="form-label">
+          Channel
+          <select
+            className="form-input"
+            value={channel}
+            onChange={(e) => setChannel(Number(e.target.value))}
+            disabled={virtual || deviceChannels.length === 0}
+            aria-label="Broadcast channel"
+          >
+            {channelOptions.map((ch) => (
+              <option key={ch.id} value={ch.id}>
+                {ch.name || `Channel ${ch.id}`}
+                {ch.id === 0 ? ' (Primary)' : ''}
+              </option>
+            ))}
+          </select>
+          <span className="form-hint">
+            {virtual
+              ? 'Virtual waypoints are never transmitted, so the channel is unused.'
+              : 'The waypoint and any rebroadcasts go out on this channel.'}
+          </span>
         </label>
 
         <label className="form-label">

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -144,6 +144,7 @@ import { migration as addTransportFlagsMigration, runMigration126Postgres, runMi
 import { migration as addAtakContactsMigration, runMigration127Postgres, runMigration127Mysql } from '../server/migrations/127_add_atak_contacts.js';
 import { migration as mqttOkToMqttViolationsMigration, runMigration128Postgres, runMigration128Mysql } from '../server/migrations/128_mqtt_oktomqtt_violations.js';
 import { migration as addShowAtakContactsMigration, runMigration129Postgres, runMigration129Mysql } from '../server/migrations/129_add_show_atak_contacts_to_map_prefs.js';
+import { migration as addWaypointChannelMigration, runMigration130Postgres, runMigration130Mysql } from '../server/migrations/130_add_waypoint_channel.js';
 
 // ============================================================================
 // Registry
@@ -2052,4 +2053,20 @@ registry.register({
   sqlite: (db) => addShowAtakContactsMigration.up(db),
   postgres: (client) => runMigration129Postgres(client),
   mysql: (pool) => runMigration129Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 130: per-waypoint broadcast channel (#4341). Waypoints used to go
+// out on the implicit slot 0; the editor now lets the user choose, and the
+// choice has to survive reloads and drive the rebroadcast scheduler.
+// NULL = not chosen, and every read site falls back to 0.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 130,
+  name: 'add_waypoint_channel',
+  settingsKey: 'migration_130_add_waypoint_channel',
+  sqlite: (db) => addWaypointChannelMigration.up(db),
+  postgres: (client) => runMigration130Postgres(client),
+  mysql: (pool) => runMigration130Mysql(pool),
 });

--- a/src/db/repositories/waypoints.ts
+++ b/src/db/repositories/waypoints.ts
@@ -21,6 +21,8 @@ export interface Waypoint {
   iconCodepoint: number | null;
   iconEmoji: string | null;
   isVirtual: boolean;
+  /** Device channel slot the waypoint is broadcast on. `null` = slot 0 (#4341). */
+  channel: number | null;
   rebroadcastIntervalS: number | null;
   lastBroadcastAt: number | null;
   firstSeenAt: number;
@@ -40,6 +42,7 @@ export interface WaypointUpsertInput {
   iconCodepoint?: number | null;
   iconEmoji?: string | null;
   isVirtual?: boolean;
+  channel?: number | null;
   rebroadcastIntervalS?: number | null;
   lastBroadcastAt?: number | null;
 }
@@ -63,6 +66,7 @@ function deserializeRow(row: any): Waypoint {
     iconCodepoint: row.iconCodepoint == null ? null : Number(row.iconCodepoint),
     iconEmoji: row.iconEmoji ?? null,
     isVirtual: Boolean(row.isVirtual),
+    channel: row.channel == null ? null : Number(row.channel),
     rebroadcastIntervalS: row.rebroadcastIntervalS == null ? null : Number(row.rebroadcastIntervalS),
     lastBroadcastAt: row.lastBroadcastAt == null ? null : Number(row.lastBroadcastAt),
     firstSeenAt: Number(row.firstSeenAt),
@@ -101,6 +105,7 @@ export class WaypointsRepository extends BaseRepository {
         input.iconCodepoint === undefined ? existing?.iconCodepoint ?? null : input.iconCodepoint,
       iconEmoji: input.iconEmoji === undefined ? existing?.iconEmoji ?? null : input.iconEmoji,
       isVirtual: (input.isVirtual ?? existing?.isVirtual ?? false) ? 1 : 0,
+      channel: input.channel === undefined ? existing?.channel ?? null : input.channel,
       rebroadcastIntervalS:
         input.rebroadcastIntervalS === undefined
           ? existing?.rebroadcastIntervalS ?? null

--- a/src/db/schema/waypoints.ts
+++ b/src/db/schema/waypoints.ts
@@ -48,6 +48,8 @@ export const waypointsSqlite = sqliteTable('waypoints', {
   iconCodepoint: integer('icon_codepoint'),
   iconEmoji: text('icon_emoji'),
   isVirtual: integer('is_virtual').notNull().default(0),
+  /** Device channel slot the waypoint is broadcast on. NULL = slot 0 (#4341). */
+  channel: integer('channel'),
   rebroadcastIntervalS: integer('rebroadcast_interval_s'),
   lastBroadcastAt: integer('last_broadcast_at'),
   firstSeenAt: integer('first_seen_at').notNull(),
@@ -73,6 +75,8 @@ export const waypointsPostgres = pgTable('waypoints', {
   iconCodepoint: pgInteger('icon_codepoint'),
   iconEmoji: pgText('icon_emoji'),
   isVirtual: pgInteger('is_virtual').notNull().default(0),
+  /** Device channel slot the waypoint is broadcast on. NULL = slot 0 (#4341). */
+  channel: pgInteger('channel'),
   rebroadcastIntervalS: pgInteger('rebroadcast_interval_s'),
   lastBroadcastAt: pgBigint('last_broadcast_at', { mode: 'number' }),
   firstSeenAt: pgBigint('first_seen_at', { mode: 'number' }).notNull(),
@@ -98,6 +102,8 @@ export const waypointsMysql = mysqlTable('waypoints', {
   iconCodepoint: myInt('icon_codepoint'),
   iconEmoji: myVarchar('icon_emoji', { length: 16 }),
   isVirtual: myInt('is_virtual').notNull().default(0),
+  /** Device channel slot the waypoint is broadcast on. NULL = slot 0 (#4341). */
+  channel: myInt('channel'),
   rebroadcastIntervalS: myInt('rebroadcast_interval_s'),
   lastBroadcastAt: myBigint('last_broadcast_at', { mode: 'number' }),
   firstSeenAt: myBigint('first_seen_at', { mode: 'number' }).notNull(),

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8316,7 +8316,11 @@ class MeshtasticManager implements ISourceManager {
   private async processWaypointMessage(meshPacket: any, decoded: any): Promise<void> {
     try {
       const fromNum = Number(meshPacket.from ?? 0);
-      await waypointService.upsertFromMesh(this.sourceId, fromNum, decoded);
+      // Record the slot the waypoint arrived on so an edit or a scheduled
+      // rebroadcast goes back out on the same channel (#4341).
+      const rawChannel = meshPacket.channel;
+      const channel = rawChannel === undefined || rawChannel === null ? undefined : Number(rawChannel);
+      await waypointService.upsertFromMesh(this.sourceId, fromNum, decoded, channel);
     } catch (error) {
       logger.error('Error processing waypoint message:', error);
     }

--- a/src/server/meshtasticManager.waypoint.test.ts
+++ b/src/server/meshtasticManager.waypoint.test.ts
@@ -132,7 +132,19 @@ describe('MeshtasticManager — Waypoint wiring', () => {
     await (mgr as any).processWaypointMessage(meshPacket, decoded);
 
     expect(upsertFromMeshMock).toHaveBeenCalledTimes(1);
-    expect(upsertFromMeshMock).toHaveBeenCalledWith('src-1', 555, decoded);
+    // #4341: the packet carried no `channel`, so the service is told "unknown"
+    // and leaves any stored channel alone.
+    expect(upsertFromMeshMock).toHaveBeenCalledWith('src-1', 555, decoded, undefined);
+  });
+
+  // #4341 — an inbound waypoint remembers the slot it arrived on so an edit or
+  // a scheduled rebroadcast goes back out on the same channel.
+  it('processWaypointMessage forwards the packet channel to waypointService', async () => {
+    const mgr = makeManager();
+    const decoded = { id: 99, latitude_i: 1, longitude_i: 2, expire: 0 };
+    await (mgr as any).processWaypointMessage({ from: BigInt(555), channel: 3 }, decoded);
+
+    expect(upsertFromMeshMock).toHaveBeenCalledWith('src-1', 555, decoded, 3);
   });
 
   it('broadcastWaypoint encodes and sends a WAYPOINT_APP packet via the transport', async () => {

--- a/src/server/migrations/130_add_waypoint_channel.test.ts
+++ b/src/server/migrations/130_add_waypoint_channel.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Migration 130 — add `waypoints.channel` (#4341).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration as createWaypoints } from './053_create_waypoints.js';
+import { migration } from './130_add_waypoint_channel.js';
+
+function createSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
+  `);
+  createWaypoints.up(db);
+  const ts = Date.now();
+  db.prepare(`
+    INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+    VALUES ('src-1', 'Source 1', 'meshtastic_tcp', '{}', 1, ?, ?)
+  `).run(ts, ts);
+}
+
+function columns(db: Database.Database): string[] {
+  return (db.prepare(`PRAGMA table_info(waypoints)`).all() as any[]).map((c) => c.name);
+}
+
+describe('Migration 130 — add waypoints.channel', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    createSchema(db);
+  });
+
+  it('adds the channel column', () => {
+    expect(columns(db)).not.toContain('channel');
+    migration.up(db);
+    expect(columns(db)).toContain('channel');
+  });
+
+  it('leaves pre-existing rows on NULL, which readers treat as slot 0', () => {
+    const now = Date.now();
+    db.prepare(`
+      INSERT INTO waypoints (source_id, waypoint_id, latitude, longitude, first_seen_at, last_updated_at)
+      VALUES ('src-1', 1, 30, -90, ?, ?)
+    `).run(now, now);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT channel FROM waypoints WHERE waypoint_id = 1`).get() as any;
+    expect(row.channel).toBeNull();
+  });
+
+  it('stores a chosen slot', () => {
+    migration.up(db);
+    const now = Date.now();
+    db.prepare(`
+      INSERT INTO waypoints (source_id, waypoint_id, latitude, longitude, channel, first_seen_at, last_updated_at)
+      VALUES ('src-1', 2, 30, -90, 3, ?, ?)
+    `).run(now, now);
+
+    const row = db.prepare(`SELECT channel FROM waypoints WHERE waypoint_id = 2`).get() as any;
+    expect(row.channel).toBe(3);
+  });
+
+  it('is idempotent', () => {
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+    expect(columns(db).filter((c) => c === 'channel')).toHaveLength(1);
+  });
+});

--- a/src/server/migrations/130_add_waypoint_channel.ts
+++ b/src/server/migrations/130_add_waypoint_channel.ts
@@ -1,0 +1,55 @@
+/**
+ * Migration 130: Add `channel` column to `waypoints` (#4341).
+ *
+ * Waypoints used to go out on the implicit default channel slot 0 — the
+ * `options.channel ?? 0` fallback in `meshtasticManager.broadcastWaypoint`.
+ * The editor now lets the user pick the broadcast channel, and that choice has
+ * to survive a reload and be reused by the rebroadcast scheduler, so it needs
+ * a column.
+ *
+ * NULL means "not chosen" and every read site falls back to 0, so existing
+ * rows keep today's behaviour exactly.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL via the shared helpers.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 130';
+const TABLE = 'waypoints';
+const COLUMN = 'channel';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+    addColumnIfMissing(db, TABLE, COLUMN, `${COLUMN} INTEGER`);
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration130Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+  await addColumnIfMissingPostgres(client, TABLE, COLUMN, `"${COLUMN}" INTEGER`);
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration130Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+  await addColumnIfMissingMysql(pool, TABLE, COLUMN, `${COLUMN} INT`);
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/waypoints.test.ts
+++ b/src/server/routes/waypoints.test.ts
@@ -56,6 +56,7 @@ vi.mock('../services/waypointService.js', () => ({
 import databaseService from '../../services/database.js';
 import waypointRoutes from './waypoints.js';
 import { waypointService } from '../services/waypointService.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 
 const mockWaypointService = waypointService as unknown as {
@@ -233,6 +234,145 @@ describe('Waypoint routes', () => {
         .post(`/api/sources/${harness.sourceA}/waypoints`)
         .send({ lat: 30, lon: -90, rebroadcast_interval_s: 600 });
       expect(res.status).toBe(201);
+    });
+  });
+
+  // ── Broadcast channel selection (#4341) ─────────────────────────────────────
+
+  describe('broadcast channel (#4341)', () => {
+    /** Register a fake connected manager and hand back its broadcast spies. */
+    function mockManager() {
+      const broadcastWaypoint = vi.fn().mockResolvedValue(1234);
+      const broadcastWaypointDelete = vi.fn().mockResolvedValue(1234);
+      (sourceManagerRegistry.getManager as ReturnType<typeof vi.fn>).mockReturnValue({
+        getLocalNodeInfo: () => ({ nodeNum: 42 }),
+        broadcastWaypoint,
+        broadcastWaypointDelete,
+      });
+      return { broadcastWaypoint, broadcastWaypointDelete };
+    }
+
+    it('threads the chosen channel into createLocal and the outgoing packet', async () => {
+      const { broadcastWaypoint } = mockManager();
+      mockWaypointService.createLocal.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 7, latitude: 30, longitude: -90,
+        name: '', description: '', iconCodepoint: null, expireAt: null, lockedTo: null,
+        isVirtual: false, channel: 3,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
+        .send({ lat: 30, lon: -90, channel: 3 });
+
+      expect(res.status).toBe(201);
+      expect(mockWaypointService.createLocal).toHaveBeenCalledWith(
+        harness.sourceA,
+        42,
+        expect.objectContaining({ channel: 3 }),
+        expect.any(Object),
+      );
+      expect(broadcastWaypoint).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 7 }),
+        { channel: 3 },
+      );
+    });
+
+    it('defaults to slot 0 when the caller omits the channel (pre-#4341 behaviour)', async () => {
+      const { broadcastWaypoint } = mockManager();
+      mockWaypointService.createLocal.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 8, latitude: 30, longitude: -90,
+        name: '', description: '', iconCodepoint: null, expireAt: null, lockedTo: null,
+        isVirtual: false, channel: 0,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
+        .send({ lat: 30, lon: -90 });
+
+      expect(res.status).toBe(201);
+      expect(mockWaypointService.createLocal).toHaveBeenCalledWith(
+        harness.sourceA,
+        42,
+        expect.objectContaining({ channel: 0 }),
+        expect.any(Object),
+      );
+      expect(broadcastWaypoint).toHaveBeenCalledWith(expect.anything(), { channel: 0 });
+    });
+
+    it('falls back to slot 0 for a stored row that predates the column (channel null)', async () => {
+      const { broadcastWaypoint } = mockManager();
+      mockWaypointService.createLocal.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 9, latitude: 30, longitude: -90,
+        name: '', description: '', iconCodepoint: null, expireAt: null, lockedTo: null,
+        isVirtual: false, channel: null,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      await agent.post(`/api/sources/${harness.sourceA}/waypoints`).send({ lat: 30, lon: -90 });
+
+      expect(broadcastWaypoint).toHaveBeenCalledWith(expect.anything(), { channel: 0 });
+    });
+
+    it.each([8, -1, 1.5, 'abc'])('rejects an out-of-range channel (%s) with 400', async (bad) => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/sources/${harness.sourceA}/waypoints`)
+        .send({ lat: 30, lon: -90, channel: bad });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/channel must be an integer between 0 and 7/);
+    });
+
+    it('PATCH threads a new channel through update and the rebroadcast packet', async () => {
+      const { broadcastWaypoint } = mockManager();
+      mockWaypointService.update.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 5, latitude: 30, longitude: -90,
+        name: '', description: '', iconCodepoint: null, expireAt: null, lockedTo: null,
+        isVirtual: false, channel: 2,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .patch(`/api/sources/${harness.sourceA}/waypoints/5`)
+        .send({ channel: 2 });
+
+      expect(res.status).toBe(200);
+      expect(mockWaypointService.update).toHaveBeenCalledWith(
+        harness.sourceA,
+        5,
+        42,
+        expect.objectContaining({ channel: 2 }),
+      );
+      expect(broadcastWaypoint).toHaveBeenCalledWith(expect.anything(), { channel: 2 });
+    });
+
+    it('PATCH leaves the stored channel alone when the field is omitted', async () => {
+      mockManager();
+      mockWaypointService.update.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 5, latitude: 30, longitude: -90,
+        name: '', description: '', isVirtual: false, channel: 4,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      await agent.patch(`/api/sources/${harness.sourceA}/waypoints/5`).send({ name: 'edit' });
+
+      const fields = mockWaypointService.update.mock.calls[0][3];
+      expect(fields).not.toHaveProperty('channel');
+    });
+
+    it('sends the delete tombstone on the waypoint\'s own channel', async () => {
+      const { broadcastWaypointDelete } = mockManager();
+      vi.spyOn(databaseService.waypoints, 'getAsync').mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 1, isVirtual: false, channel: 5,
+      } as any);
+      mockWaypointService.deleteLocal.mockResolvedValue(true);
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.delete(`/api/sources/${harness.sourceA}/waypoints/1`);
+
+      expect(res.status).toBe(200);
+      expect(broadcastWaypointDelete).toHaveBeenCalledWith(1, { channel: 5 });
     });
   });
 

--- a/src/server/routes/waypoints.ts
+++ b/src/server/routes/waypoints.ts
@@ -63,6 +63,32 @@ function parseRebroadcastIntervalS(raw: unknown): number | null | undefined | { 
   return n;
 }
 
+/**
+ * Highest device channel slot a Meshtastic radio exposes. The protobuf layer
+ * already clamps out-of-range values to 0, but rejecting them here means a
+ * typo surfaces as a 400 instead of silently landing on Primary.
+ */
+export const MAX_CHANNEL_INDEX = 7;
+
+/**
+ * Parse the `channel` body field (#4341). Returns:
+ *   - `undefined` when the caller omitted it (no change on PATCH; slot 0 on POST)
+ *   - a slot index 0..7 when valid
+ *   - a string error message when the value is out of range / not an integer
+ *
+ * `null` is treated as "unset" and collapses to `undefined` so clearing the
+ * field falls back to today's default rather than writing a NULL the reader
+ * would have to interpret anyway.
+ */
+function parseChannel(raw: unknown): number | undefined | { error: string } {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n > MAX_CHANNEL_INDEX) {
+    return { error: `channel must be an integer between 0 and ${MAX_CHANNEL_INDEX}` };
+  }
+  return n;
+}
+
 // GET /api/sources/:id/waypoints?includeExpired=&bbox=minLat,minLon,maxLat,maxLon
 router.get(
   '/',
@@ -125,6 +151,12 @@ router.post(
         ? null
         : Number(body.locked_to);
       const virtual = Boolean(body.virtual);
+      const parsedChannel = parseChannel(body.channel);
+      if (parsedChannel && typeof parsedChannel === 'object' && 'error' in parsedChannel) {
+        return badRequest(res, parsedChannel.error);
+      }
+      // Omitted / cleared => slot 0, exactly where waypoints went before #4341.
+      const channel = (parsedChannel as number | undefined) ?? 0;
       const parsedRebroadcast = parseRebroadcastIntervalS(body.rebroadcast_interval_s);
       if (parsedRebroadcast && typeof parsedRebroadcast === 'object' && 'error' in parsedRebroadcast) {
         return badRequest(res, parsedRebroadcast.error);
@@ -150,6 +182,7 @@ router.post(
           icon,
           expireAt,
           lockedTo,
+          channel,
           rebroadcastIntervalS,
         },
         { virtual },
@@ -160,16 +193,20 @@ router.post(
       // the rebroadcast scheduler (follow-up PR) will retry.
       if (!virtual && manager && typeof (manager as any).broadcastWaypoint === 'function') {
         try {
-          await (manager as any).broadcastWaypoint({
-            id: persisted.waypointId,
-            latitude: persisted.latitude,
-            longitude: persisted.longitude,
-            expire: persisted.expireAt ?? 0,
-            lockedTo: persisted.lockedTo ?? 0,
-            name: persisted.name,
-            description: persisted.description,
-            icon: persisted.iconCodepoint ?? 0,
-          });
+          await (manager as any).broadcastWaypoint(
+            {
+              id: persisted.waypointId,
+              latitude: persisted.latitude,
+              longitude: persisted.longitude,
+              expire: persisted.expireAt ?? 0,
+              lockedTo: persisted.lockedTo ?? 0,
+              name: persisted.name,
+              description: persisted.description,
+              icon: persisted.iconCodepoint ?? 0,
+            },
+            // Stored value is already validated on write; NULL rows predate #4341.
+            { channel: persisted.channel ?? 0 },
+          );
         } catch (err) {
           logger.warn(`Failed to broadcast new waypoint ${persisted.waypointId}:`, err);
         }
@@ -218,6 +255,14 @@ router.patch(
       if (body.locked_to !== undefined) {
         fields.lockedTo = body.locked_to === null ? null : Number(body.locked_to);
       }
+      if (body.channel !== undefined) {
+        const parsed = parseChannel(body.channel);
+        if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+          return badRequest(res, parsed.error);
+        }
+        // An explicit null/'' clears the choice back to the slot-0 default.
+        fields.channel = (parsed as number | undefined) ?? 0;
+      }
       if (body.rebroadcast_interval_s !== undefined) {
         const parsed = parseRebroadcastIntervalS(body.rebroadcast_interval_s);
         if (parsed && typeof parsed === 'object' && 'error' in parsed) {
@@ -241,16 +286,20 @@ router.patch(
 
       if (!persisted.isVirtual && manager && typeof (manager as any).broadcastWaypoint === 'function') {
         try {
-          await (manager as any).broadcastWaypoint({
-            id: persisted.waypointId,
-            latitude: persisted.latitude,
-            longitude: persisted.longitude,
-            expire: persisted.expireAt ?? 0,
-            lockedTo: persisted.lockedTo ?? 0,
-            name: persisted.name,
-            description: persisted.description,
-            icon: persisted.iconCodepoint ?? 0,
-          });
+          await (manager as any).broadcastWaypoint(
+            {
+              id: persisted.waypointId,
+              latitude: persisted.latitude,
+              longitude: persisted.longitude,
+              expire: persisted.expireAt ?? 0,
+              lockedTo: persisted.lockedTo ?? 0,
+              name: persisted.name,
+              description: persisted.description,
+              icon: persisted.iconCodepoint ?? 0,
+            },
+            // Stored value is already validated on write; NULL rows predate #4341.
+            { channel: persisted.channel ?? 0 },
+          );
         } catch (err) {
           logger.warn(`Failed to broadcast updated waypoint ${persisted.waypointId}:`, err);
         }
@@ -297,7 +346,11 @@ router.delete(
 
       if (removed && !existing.isVirtual && manager && typeof (manager as any).broadcastWaypointDelete === 'function') {
         try {
-          await (manager as any).broadcastWaypointDelete(waypointId);
+          // The tombstone has to go out on the same channel the waypoint lives
+          // on, otherwise listeners on that channel never see the delete.
+          await (manager as any).broadcastWaypointDelete(waypointId, {
+            channel: existing.channel ?? 0,
+          });
         } catch (err) {
           logger.warn(`Failed to broadcast waypoint delete ${waypointId}:`, err);
         }

--- a/src/server/services/waypointService.test.ts
+++ b/src/server/services/waypointService.test.ts
@@ -60,7 +60,12 @@ vi.mock('./dataEventEmitter.js', () => ({
   },
 }));
 
-import { waypointService, codepointToEmoji, emojiToCodepoint } from './waypointService.js';
+import {
+  waypointService,
+  codepointToEmoji,
+  emojiToCodepoint,
+  normalizeWaypointChannel,
+} from './waypointService.js';
 
 beforeEach(() => {
   mockUpsert.mockReset();
@@ -349,6 +354,108 @@ describe('rebroadcastTick', () => {
       expect(broadcastWaypoint).toHaveBeenCalledOnce();
       expect(result).not.toBeNull();
     });
+  });
+});
+
+// #4341 — the user-chosen broadcast channel has to survive persistence and be
+// reused by the rebroadcast scheduler; unspecified must stay on slot 0.
+describe('broadcast channel (#4341)', () => {
+  describe('normalizeWaypointChannel', () => {
+    it('passes through valid device slots', () => {
+      for (const slot of [0, 1, 5, 7]) {
+        expect(normalizeWaypointChannel(slot)).toBe(slot);
+      }
+    });
+
+    it('collapses null/undefined/out-of-range values to slot 0', () => {
+      expect(normalizeWaypointChannel(null)).toBe(0);
+      expect(normalizeWaypointChannel(undefined)).toBe(0);
+      expect(normalizeWaypointChannel(8)).toBe(0);
+      expect(normalizeWaypointChannel(-1)).toBe(0);
+      expect(normalizeWaypointChannel(2.5)).toBe(0);
+      // Channel-Database virtual channels can never carry a waypoint.
+      expect(normalizeWaypointChannel(101)).toBe(0);
+    });
+  });
+
+  it('createLocal persists the chosen channel', async () => {
+    mockGetExistingIds.mockResolvedValueOnce(new Set());
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.createLocal('s1', 1, { latitude: 1, longitude: 2, channel: 4 });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ channel: 4 }));
+  });
+
+  it('createLocal defaults to slot 0 when no channel is given', async () => {
+    mockGetExistingIds.mockResolvedValueOnce(new Set());
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.createLocal('s1', 1, { latitude: 1, longitude: 2 });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ channel: 0 }));
+  });
+
+  it('update keeps the stored channel when the field is omitted', async () => {
+    mockGet.mockResolvedValueOnce(eligibleRow({ channel: 6 }));
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.update('s1', 7, 0, { name: 'renamed' });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ channel: 6 }));
+  });
+
+  it('update writes a new channel when one is supplied', async () => {
+    mockGet.mockResolvedValueOnce(eligibleRow({ channel: 6 }));
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.update('s1', 7, 0, { channel: 2 });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ channel: 2 }));
+  });
+
+  it('upsertFromMesh records the channel the packet arrived on', async () => {
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.upsertFromMesh('s1', 99, { id: 3, latitudeI: 1e7, longitudeI: 2e7 }, 5);
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ channel: 5 }));
+  });
+
+  it('upsertFromMesh leaves the stored channel untouched when the packet channel is unknown', async () => {
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.upsertFromMesh('s1', 99, { id: 3, latitudeI: 1e7, longitudeI: 2e7 });
+
+    expect(mockUpsert.mock.calls[0][0].channel).toBeUndefined();
+  });
+
+  it("rebroadcastTick sends on the waypoint's stored channel", async () => {
+    const row = eligibleRow({ channel: 3 });
+    mockFindOldestEligible.mockResolvedValueOnce(row);
+    const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+    mockGetManager.mockReturnValueOnce({ broadcastWaypoint });
+    mockMarkRebroadcasted.mockResolvedValueOnce(true);
+    mockGet.mockResolvedValueOnce({ ...row, lastBroadcastAt: 1234 });
+
+    await waypointService.rebroadcastTick();
+
+    expect(broadcastWaypoint).toHaveBeenCalledWith(expect.objectContaining({ id: 7 }), {
+      channel: 3,
+    });
+  });
+
+  it('rebroadcastTick falls back to slot 0 for rows predating the column', async () => {
+    const row = eligibleRow({ channel: null });
+    mockFindOldestEligible.mockResolvedValueOnce(row);
+    const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+    mockGetManager.mockReturnValueOnce({ broadcastWaypoint });
+    mockMarkRebroadcasted.mockResolvedValueOnce(true);
+    mockGet.mockResolvedValueOnce({ ...row, lastBroadcastAt: 1234 });
+
+    await waypointService.rebroadcastTick();
+
+    expect(broadcastWaypoint).toHaveBeenCalledWith(expect.anything(), { channel: 0 });
   });
 });
 

--- a/src/server/services/waypointService.ts
+++ b/src/server/services/waypointService.ts
@@ -93,6 +93,8 @@ export interface CreateLocalInput {
   expireAt?: number | null;
   /** nodeNum that's allowed to edit, or 0/null for open. */
   lockedTo?: number | null;
+  /** Device channel slot to broadcast on. null/undefined = slot 0 (#4341). */
+  channel?: number | null;
   rebroadcastIntervalS?: number | null;
 }
 
@@ -104,7 +106,22 @@ export interface UpdateInput {
   icon?: number | string | null;
   expireAt?: number | null;
   lockedTo?: number | null;
+  channel?: number | null;
   rebroadcastIntervalS?: number | null;
+}
+
+/**
+ * Normalise a channel slot to something the radio will accept. Meshtastic
+ * devices expose 8 channel slots (0-7); anything else — including `null` /
+ * `undefined` — collapses to 0, which is the channel waypoints were broadcast
+ * on before #4341. Keeping this in one place means the default is identical in
+ * the route, the scheduler, and the manager.
+ */
+export function normalizeWaypointChannel(channel: number | null | undefined): number {
+  if (channel === null || channel === undefined) return 0;
+  const n = Number(channel);
+  if (!Number.isInteger(n) || n < 0 || n > 7) return 0;
+  return n;
 }
 
 class WaypointService {
@@ -117,6 +134,8 @@ class WaypointService {
     sourceId: string,
     fromNum: number | bigint,
     decoded: DecodedWaypointMessage,
+    /** Channel slot the packet arrived on, so an edit/rebroadcast stays on it. */
+    channel?: number | null,
   ): Promise<Waypoint | null> {
     const waypointId = pickNumber(decoded.id);
     if (waypointId === undefined) {
@@ -169,6 +188,10 @@ class WaypointService {
       iconCodepoint: iconCodepoint ?? null,
       iconEmoji,
       isVirtual: false,
+      // Only record a channel when the caller actually knew one — passing
+      // `undefined` leaves an existing row's stored channel untouched.
+      channel:
+        channel === undefined || channel === null ? undefined : normalizeWaypointChannel(channel),
     });
 
     dataEventEmitter.emitWaypointUpserted(persisted, sourceId);
@@ -231,6 +254,7 @@ class WaypointService {
       iconCodepoint: iconCodepoint ?? null,
       iconEmoji,
       isVirtual: Boolean(options.virtual),
+      channel: normalizeWaypointChannel(fields.channel),
       rebroadcastIntervalS: fields.rebroadcastIntervalS ?? null,
     });
 
@@ -274,6 +298,10 @@ class WaypointService {
       iconCodepoint,
       iconEmoji,
       isVirtual: existing.isVirtual,
+      channel:
+        fields.channel === undefined
+          ? existing.channel
+          : normalizeWaypointChannel(fields.channel),
       rebroadcastIntervalS:
         fields.rebroadcastIntervalS === undefined
           ? existing.rebroadcastIntervalS
@@ -342,16 +370,21 @@ class WaypointService {
     }
 
     try {
-      const packetId = await manager.broadcastWaypoint({
-        id: candidate.waypointId,
-        latitude: candidate.latitude,
-        longitude: candidate.longitude,
-        expire: candidate.expireAt ?? 0,
-        lockedTo: candidate.lockedTo ?? 0,
-        name: candidate.name,
-        description: candidate.description,
-        icon: candidate.iconCodepoint ?? 0,
-      });
+      const packetId = await manager.broadcastWaypoint(
+        {
+          id: candidate.waypointId,
+          latitude: candidate.latitude,
+          longitude: candidate.longitude,
+          expire: candidate.expireAt ?? 0,
+          lockedTo: candidate.lockedTo ?? 0,
+          name: candidate.name,
+          description: candidate.description,
+          icon: candidate.iconCodepoint ?? 0,
+        },
+        // Rebroadcast on the channel the waypoint was created with (#4341);
+        // rows predating the column have `channel === null` and stay on 0.
+        { channel: normalizeWaypointChannel(candidate.channel) },
+      );
 
       if (!packetId) {
         // Manager refused (e.g. not connected). Same rationale as above —

--- a/src/types/waypoint.ts
+++ b/src/types/waypoint.ts
@@ -18,6 +18,11 @@ export interface Waypoint {
   iconCodepoint: number | null;
   iconEmoji: string | null;
   isVirtual: boolean;
+  /**
+   * Device channel slot (0-7) the waypoint is broadcast on. `null` on rows
+   * created before #4341 — readers fall back to slot 0, the old behaviour.
+   */
+  channel: number | null;
   rebroadcastIntervalS: number | null;
   lastBroadcastAt: number | null;
   firstSeenAt: number;
@@ -35,5 +40,7 @@ export interface WaypointInput {
   expire?: number | null;
   locked_to?: number | null;
   virtual?: boolean;
+  /** Device channel slot (0-7) to broadcast on. Omitted = slot 0. */
+  channel?: number | null;
   rebroadcast_interval_s?: number | null;
 }


### PR DESCRIPTION
Waypoints always went out on device channel slot 0 — the implicit `options.channel ?? 0` fallback in `meshtasticManager.broadcastWaypoint`. There was no way to say "put this pin on the gauntlet channel." The waypoint editor now has a **Channel** picker, and the choice is threaded through every layer of the send path.

Closes #4341

## Send path threaded

Create / edit (the layer that was missing the field is marked):

```
WaypointEditorModal            channel state + <select>, into WaypointInput.channel   ← new
  → useWaypoints create/update mutation      POST/PATCH body (already generic JSON)
    → routes/waypoints.ts                    parseChannel() → 400 outside 0-7          ← new
      → waypointService.createLocal/update   normalizeWaypointChannel → persisted      ← new
        → databaseService.waypoints.upsert   waypoints.channel column                  ← new
      → manager.broadcastWaypoint(wp, { channel })                                     ← new arg
        → meshtasticProtobufService.createWaypointMessage   already accepted options.channel
```

Two more send sites that would otherwise have drifted back to slot 0:

- **Delete tombstone** — `broadcastWaypointDelete(id, { channel: existing.channel ?? 0 })`. Peers listening on channel 3 never saw a delete broadcast on channel 0.
- **Rebroadcast scheduler** — `waypointService.rebroadcastTick` now sends on `candidate.channel`, so a waypoint with a rebroadcast interval keeps its channel every hour instead of only on the first send.

**Inbound** waypoints also record the slot they arrived on (`processWaypointMessage` passes `meshPacket.channel` to `upsertFromMesh`), so editing a mesh-received waypoint does not silently move it to Primary.

## Default preserved

Omitted, `null`, or empty `channel` resolves to **slot 0** at every layer — the exact channel waypoints used before this change. `normalizeWaypointChannel()` is the single definition of that fallback and also collapses out-of-range values (including Channel-Database virtual channels at id ≥ 100, which a radio cannot transmit on). Stored rows predating the column read back `NULL` and take the same path.

## Per-source scoping

The picker's options come from `useChannels()`, which reads the poll cache keyed on the active source, so it only ever offers channels belonging to the waypoint's own source. Server-side, managers are resolved through `sourceManagerRegistry.getManager(sourceId)` as before — no global singleton.

## Migration: yes, 130

Persistence is required, not optional: without a column the rebroadcast scheduler and the edit dialog both fall back to slot 0 and the user's choice is lost on the first reload. `waypoints` had no channel column, so migration **130** adds a nullable `channel` across all three backends (`addColumnIfMissing` / `addColumnIfMissingPostgres` / `addColumnIfMissingMysql`, registered with `settingsKey: migration_130_add_waypoint_channel`, idempotent). NULL is the "not chosen" sentinel and every reader falls back to 0, so no backfill is needed and existing rows behave identically.

## Test evidence

Full suite against live PostgreSQL (`localhost:5433`) and MySQL (`localhost:3307`) containers:

```
success: true
numTotalTests:        12079
numPassedTests:       11949
numFailedTests:           0
numFailedTestSuites:      0
numPendingTests:        109   (not ~1500 — the multi-backend suites really ran)
PostgreSQL-named passing tests: 311
MySQL-named passing tests:      316
waypoint-named passing tests:    70
```

New coverage:

- `routes/waypoints.test.ts` (`createRouteTestApp` harness): chosen channel reaches `createLocal` **and** the outgoing packet; omitted channel defaults to 0; `NULL` stored row sends on 0; `8` / `-1` / `1.5` / `"abc"` all 400; PATCH threads a new channel and leaves the stored one alone when omitted; delete tombstone goes out on the waypoint's own channel.
- `services/waypointService.test.ts`: `normalizeWaypointChannel` table; createLocal persists / defaults; update preserves vs. overwrites; `upsertFromMesh` records the arrival channel and leaves it untouched when unknown; `rebroadcastTick` sends on the stored channel and falls back to 0.
- `migrations/130_add_waypoint_channel.test.ts`: column added, pre-existing rows stay NULL, chosen slot round-trips, idempotent re-run.
- `WaypointEditorModal.test.tsx`: picker renders one option per device slot and hides virtual channels; selection lands in the saved payload; Primary-only fallback when the source reports no channels; disabled for virtual waypoints; pre-selects the stored channel and shows 0 for legacy rows.
- `meshtasticManager.waypoint.test.ts`: inbound packet channel forwarded.

Also verified: `tsc -p tsconfig.server.json --noEmit` and `tsc --noEmit` both clean, `lint:ci` produces no in-repo FAIL lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob
