### PR TITLE
feat(automations): Auto-Ack parity conditions (#4340 phase 3)

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -168,8 +168,8 @@ different set — this is how If / ElseIf / Else is built.
 | Condition | What it checks |
 | --- | --- |
 | **Always (no filtering)** | A pass-through that always matches — use it when a rule should act unconditionally |
-| **Number comparison** | A numeric field (`==`, `!=`, `>`, `<`, `>=`, `<=`). Fields come from the event (e.g. hop count, SNR/RSSI), the hydrated **node** record (battery, hops away, role, position, age, …), or the node's **latest telemetry**. The value can be a literal or `{{ var.name }}` |
-| **Text comparison** | A string field (`contains`, `equals`, `starts with`, `ends with`, `matches regex`, `doesn't contain`) over message text, node name/role, etc. |
+| **Number comparison** | A numeric field (`==`, `!=`, `>`, `<`, `>=`, `<=`). Fields come from the event (e.g. hop count, SNR/RSSI, **is a direct message**, **arrived via MQTT**), the hydrated **node** record (battery, hops away, role, position, age, …), or the node's **latest telemetry**. The value can be a literal or `{{ var.name }}` |
+| **Text comparison** | A string field (`contains`, `equals`, `starts with`, `ends with`, `matches regex`, `doesn't contain`, `is one of`, `isn't one of`) over message text, node name/role, node info completeness, etc. |
 | **Source is one of…** | The **Source filter** — restricts the workflow to a chosen subset of sources (the "global but scopeable" knob). Leave empty to allow any source |
 | **Distance from a point** | The subject node is within / farther than *N* km of a reference lat/lon |
 | **Variable check** | Compares a [user-defined variable](#variables) against a literal or another value; with no operator it tests "is set / flag raised?" |
@@ -177,6 +177,59 @@ different set — this is how If / ElseIf / Else is built.
 
 A missing or undefined field never throws — numeric/string comparisons against it simply evaluate
 **false**.
+
+### `isDM` / `viaMqtt` — booleans as `1`/`0`
+
+The message trigger's **Number comparison** field picker offers **Is a direct message** (`isDM`) and
+**Arrived via MQTT** (`viaMqtt`) alongside hop count, SNR, and RSSI. Both resolve as a number —
+`1` for true, `0` for false — because a boolean value compared with `condition.numeric` is coerced
+the same way (`true → 1`, `false → 0`). Compare with `== 1` / `== 0` rather than a boolean literal:
+
+- `isDM == 1` — the message is a direct message; `isDM == 0` — it's a channel/broadcast post.
+- `viaMqtt == 1` — it arrived over an MQTT bridge; `viaMqtt == 0` — it arrived over RF.
+
+Together, `hops == 0` **and** `viaMqtt == 0` is "zero-hop, heard directly" — the same "ZeroHop"
+definition Auto-Acknowledge uses for its own {Channel,Direct} × {ZeroHop,MultiHop} matrix. A packet
+with no hop information at all resolves `hops` to `undefined`, so a *branch* on `hops > 0` (true/false
+ports) is the reliable way to route ZeroHop vs. MultiHop — two independent `== 0` / `> 0` conditions
+would both evaluate false for a hopless packet and match neither branch.
+
+### `node.completeness` — three states, not a boolean
+
+**Node** field **Node info completeness** (`node.completeness`) resolves to one of three strings:
+
+| Value | Meaning |
+| --- | --- |
+| `complete` | The subject node's row exists and has a real long/short name and a hardware model from NODEINFO. |
+| `incomplete` | The row exists, but NODEINFO hasn't arrived yet (e.g. a default `Node !xxxxxxxx` name). |
+| `unknown` | There is **no** row for the subject at all — or the trigger has no subject node in the first place (Schedule / System triggers). |
+
+The third state is the point: a boolean `isComplete` field can't distinguish "the node is known but
+incomplete" from "nothing is known about this node yet" — both would read as falsy. Auto-Acknowledge's
+own skip-incomplete-nodes behavior only skips a sender when its node row **exists and is incomplete**;
+an unrecognized/unknown sender is never skipped. Reproduce that with a **Text comparison** on
+`node.completeness`, operator **is one of**, value `complete, unknown` — matching everything except
+a confirmed-incomplete node.
+
+### `is one of` / `isn't one of`
+
+The **Text comparison** condition's operator list includes **is one of** (`in`) and **isn't one of**
+(`notIn`) alongside `contains`/`equals`/etc. — membership in a literal, comma- or whitespace-separated
+list, typed directly into the **Value** field (e.g. `complete, unknown` or `!aabbccdd, !11223344`).
+
+- **Separators** — split on any run of commas and/or whitespace (`a,b`, `a, b`, `a  b`, and
+  `a,\nb` all produce the same two-item list).
+- **Case-insensitive** — both the list and the field value are lowercased before comparing, so
+  `ROUTER` matches a list entry of `router`.
+- **Exact-token matching, not substring** — `!aabbccdd` is **not** considered "one of"
+  `!aabbccddee`; each list entry must match the whole field value, the same way a node-id ignore
+  list is meant to work.
+- **Empty value** — an empty/blank list makes `is one of` always **false** and `isn't one of` always
+  **true** — the correct reading of "an unset ignore list ignores nobody."
+
+A common use is a per-source-ignore-list condition — **Text comparison** on **Sender node id**
+(`fromId`), operator **isn't one of**, value the node ids to ignore (`!xxxxxxxx`, comma- or
+whitespace-separated) — which continues the rule only for senders **not** on that list.
 
 ### FINALLY combine modes
 
@@ -243,6 +296,23 @@ Sends text to a channel or as a DM, with full `{{ }}` token interpolation in the
   message's scope** (reply on the same region it arrived on), **Unscoped (flood, no region)**, or
   **A specific region…** — the latter reveals a **Region** picker (token-aware). See
   [Regions / Scopes](/features/meshcore#regions-scopes).
+- **DM resend attempts** *(advanced; hidden until **DM to node #** is set)* — resend this DM up to
+  **1–3** times until the recipient ACKs it, the same retry Auto-Acknowledge's own reply uses. Leave
+  blank for a single, direct send — today's behavior for every automation created before this field
+  existed.
+  - **Meshtastic DMs only.** It is ignored for a channel/broadcast send (the queue hardcodes a single
+    attempt there) and for a MeshCore send (MeshCore has no equivalent queue).
+  - **Setting it opts the send into the source's outgoing message queue**, which also **spaces
+    consecutive sends 30 seconds apart** — the same throttle every other queued DM on that source
+    (auto-responder, welcome, mailbox) already runs under. A busy automation that sets this on every
+    fire will send noticeably slower than one that doesn't.
+  - **The run-log shape changes too.** An unset (single-send) DM records the outcome immediately —
+    including a `TX_DISABLED` skip when the source has transmit disabled. A **queued** DM (this field
+    set) is fire-and-forget: the action returns a queue id right away, and if the source has TX
+    disabled, that surfaces later as a logged warning from the queue's own failure handler — **not**
+    as a `TX_DISABLED` skip entry on the run. This mirrors Auto-Acknowledge's own queued-reply
+    behavior exactly; it just means a TX-disabled source shows the action as *queued*, not
+    *skipped*, so don't be surprised if the run log looks like it sent when transmit was actually off.
 
 The overall send is a **source × channel matrix**: each selected source posts to the matching local
 slot of each selected channel.

--- a/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md
+++ b/docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md
@@ -104,7 +104,7 @@ key `lastFired` by the composite; make the trace message name the node.
 - Absent `cooldownScope` behaves exactly as today (`automation`).
 - Trace output distinguishes which key was cooling down.
 
-### Phase 3 — Fidelity conditions — [ ] not started
+### Phase 3 — Fidelity conditions — [x] complete
 
 `condition.nodeComplete`, a node-in-list condition covering ignore lists, and a
 `maxAttempts` param on the send/tapback actions.
@@ -269,3 +269,130 @@ _(updated at each phase close)_
   deleting an entry there is *not* behaviour-neutral, since it resets the enter/exit dwell baseline
   for that node, so it needs its own design decision rather than a copy-paste of `pruneCooldownKeys`.
   Both need a follow-up issue; neither has one yet as of this close.
+
+### Phase 3 close (2026-07-28)
+
+**The parity mapping table** (pasted verbatim from
+`docs/internal/dev-notes/AUTOACK_PARITY_PHASE3_SPEC.md` §2 — the phase's exit criterion. It is
+mechanically enforced by `src/server/services/automation/autoAckParity.test.ts`, which fails if a
+row here is removed while its key is still in `VALID_SETTINGS_KEYS`, or if a new `autoAck*` key is
+added without a corresponding row):
+
+Every key in `VALID_SETTINGS_KEYS` beginning `autoAck` — 33 of them (`src/server/constants/settings.ts:20-60`). "Per-source?" is membership in `PER_SOURCE_SETTINGS_KEYS` (`:338-370`).
+
+| # | Setting | Per-source? | Engine equivalent | Status |
+|---|---|---|---|---|
+| 1 | `autoAckEnabled` | yes | The automation's own `enabled` column + `condition.sourceFilter` bound to that source | **exists** |
+| 2 | `autoAckRegex` | yes | `trigger.message` param `regex` | **exists** ¹ |
+| 3 | `autoAckMessage` | yes | `action.sendMessage` param `text` | **exists** ² |
+| 4 | `autoAckMessageDirect` | yes | A second `action.sendMessage` on the ZeroHop branch | **exists** ² |
+| 5 | `autoAckChannels` | yes | `trigger.message` param `channels` (unified, by name) | **exists** ³ |
+| 6 | `autoAckDirectMessages` | yes | — *(deprecated; migration 093 folds it into the Direct\* cells)* | **n/a — deprecated** |
+| 7 | `autoAckUseDM` | yes | — *(deprecated; folded into the `*ReplyDmEnabled` cells)* | **n/a — deprecated** |
+| 8 | `autoAckSkipIncompleteNodes` | yes | `condition.string` · field `node.completeness` · op `in` · value `complete, unknown` | **Phase 3 adds** (field + operators) ⁴ |
+| 9 | `autoAckIgnoredNodes` | yes | `condition.string` · field `fromId` · op `notIn` · value = the list verbatim | **Phase 3 adds** (operators) ⁵ |
+| 10 | `autoAckTapbackEnabled` | **no** (global-only) | — *(deprecated)* | **n/a — deprecated** |
+| 11 | `autoAckReplyEnabled` | **no** (global-only) | — *(deprecated)* | **n/a — deprecated** |
+| 12 | `autoAckDirectEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 13 | `autoAckDirectTapbackEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 14 | `autoAckDirectReplyEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 15 | `autoAckMultihopEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 16 | `autoAckMultihopTapbackEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 17 | `autoAckMultihopReplyEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 18 | `autoAckTestMessages` | **no** (global) | **Not convertible, and does not need to be.** No server code reads it — it is a UI scratchpad on `AutoAcknowledgeSection.tsx` for pasting sample text. Its engine analogue is the Test panel (`AutomationTester.tsx`), a mechanism, not a setting. | **not convertible (by design)** |
+| 19 | `autoAckCooldownSeconds` | yes | `trigger.message` `cooldownSeconds` + `cooldownScope: 'node'` | **exists** (Phase 2) ⁶ |
+| 20 | `autoAckPreSendDelaySeconds` | yes | `action.delay` before the first send in the chain | **exists** ⁷ |
+| 21 | `autoAckMaxAttempts` | yes | `action.sendMessage` param `maxAttempts` | **Phase 3 adds** ⁸ |
+| 22 | `autoAckChannelZeroHopReplyEnabled` | yes | Cell rule emits `action.sendMessage`; cell = `isDM == 0` ∧ `hops == 0` ∧ `viaMqtt == 0` | **exists + Phase 3 adds `isDM`/`viaMqtt` to the picker** ⁹ |
+| 23 | `autoAckChannelZeroHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** (Phase 1) |
+| 24 | `autoAckChannelZeroHopReplyDmEnabled` | yes | That cell's `action.sendMessage` gets `to: {{ trigger.from }}` | **exists** |
+| 25 | `autoAckChannelMultiHopReplyEnabled` | yes | Cell = `isDM == 0` ∧ ¬(`hops == 0` ∧ `viaMqtt == 0`) → `action.sendMessage` | **exists + picker** ⁹ |
+| 26 | `autoAckChannelMultiHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** |
+| 27 | `autoAckChannelMultiHopReplyDmEnabled` | yes | `to: {{ trigger.from }}` on that cell's send | **exists** |
+| 28 | `autoAckDirectZeroHopReplyEnabled` | yes | Cell = `isDM == 1` ∧ `hops == 0` ∧ `viaMqtt == 0` → `action.sendMessage` | **exists + picker** ⁹ |
+| 29 | `autoAckDirectZeroHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** |
+| 30 | `autoAckDirectZeroHopReplyDmEnabled` | yes | No-op for Direct cells (a DM reply is inherently a DM); converter emits `to: {{ trigger.from }}` regardless | **exists** |
+| 31 | `autoAckDirectMultiHopReplyEnabled` | yes | Cell = `isDM == 1` ∧ ¬ZeroHop → `action.sendMessage` | **exists + picker** ⁹ |
+| 32 | `autoAckDirectMultiHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** |
+| 33 | `autoAckDirectMultiHopReplyDmEnabled` | yes | No-op for Direct cells | **exists** |
+
+**Notes (each is a Phase 4 converter obligation, not a Phase 3 gap):**
+
+1. AutoAck defaults to `^(test|ping)` when the setting is blank (`meshtasticManager.ts:10102`); the engine's blank `regex` means **match anything**. The converter must emit the literal default.
+2. Token dialects differ: AutoAck uses `{NUMBER_HOPS}`/`{TIME}`/`{NODE_NAME}`; the engine uses `{{ trigger.hops }}`/`{{ NOW }}`/`{{ trigger.fromName }}`. Translation is Phase 4 work. `{{ trigger.hopEmoji }}` (Phase 1) has no AutoAck equivalent — a superset, not a gap.
+3. AutoAck stores channel **indices**; `trigger.message.channels` is unified **by name**. The converter resolves index→name per source. A source with two same-named channels is a converter edge case, not an engine one.
+4. Tri-state is required for fidelity: AutoAck skips only when the node row **exists and is incomplete** (`if (fromNode && !isNodeComplete(fromNode))`, `:10084`). `complete, unknown` reproduces that exactly. See spec §9.1.
+5. `in`/`notIn` split on `/[\s,]+/` and compare case-insensitively — the same separators and casing as AutoAck's own parser (`:10040-10043`). The converter normalises each entry to canonical `!xxxxxxxx` (AutoAck accepts a bare 8-hex token; `trigger.fromId` always carries the `!`). An **empty** value makes `notIn` always true, matching an unset ignore list — but the converter should simply omit the condition.
+6. AutoAck's default is **60s** when unset (`:10092`); the engine's is **0**. The converter must emit `60` explicitly. `cooldownScope: 'node'` is mandatory — AutoAck's map is keyed by `fromNum` (`:10094`).
+7. Two semantic differences: AutoAck's delay is a non-blocking `setTimeout` (`:10172-10178`) while `action.delay` blocks its own run and caps at `AUTOMATION_DELAY_MAX_SECONDS = 300`; and AutoAck applies the same delay independently to the tapback and the reply, so a converted linear chain needs the `action.delay` once, before the first send.
+8. **Read this row carefully.** `checkAutoAcknowledge` never reads `autoAckMaxAttempts`. `MessageQueueService.resolveDmMaxAttempts()` reads it per-source and applies it to **every queued DM** on that source (auto-responder, welcome, mailbox, auto-ack reply). It therefore affects the AutoAck **reply, and only when that reply is a DM**: the AutoAck **tapback** hardcodes `1` ("tapbacks are best-effort, don't retry", `:10207`) and **channel** sends hardcode `1` (`messageQueueService.ts:112`). Consequently `maxAttempts` goes on `action.sendMessage` **only** — see spec §9.2. The setting also keeps governing the source's other queued DMs after conversion, so disabling AutoAck does not retire it.
+9. `isDM` and `viaMqtt` already resolve at runtime (`triggerContext.ts:113,120` + `asNumber()` boolean coercion) but were **not** offered by the builder's field picker, and `fieldselect` is a plain `<select>` (`AutomationBuilder.tsx:89-99`) — a converter-written value would render blank and be overwritten on the first edit. Phase 3 adds both options so a converted automation is **editable**, not merely runnable. `viaMqtt` is load-bearing: `isZeroHop = hopsTraveled === 0 && !viaMqtt` (`AUTOACK_2X2_PLAN.md`, `:10141`).
+
+**Adjacent behaviour not in the table** (not `autoAck*` keys, recorded so Phase 4 does not rediscover them): the per-packet dedup guard (`:9967-9978`) has no engine analogue and needs none; the TX-disabled skip (`:10001`) is already mirrored by `pushOrSkipTxDisabled`; the airtime cutoff (`isAutomationAirtimeGated`, `automationAirtimeCutoff*`) is shared infrastructure both paths already honour; the local-node skip (`:10065-10070`) is already covered by the engine's self-drop (`getLocalNodeNum`, #3914). **MeshCore auto-ack is a separate `meshcoreAutoAck*` namespace** (`meshcoreManager.ts:6873-6925`) and is out of scope for this table.
+
+**Decisions and findings recorded at close (spec §7 WP5 / §9):**
+
+- **No new `ConditionType`, no new node-in-list block.** The two "new conditions" the epic
+  originally named (`condition.nodeComplete`, a node-in-list condition) shipped instead as a
+  computed `node.completeness` field on the existing `node.*` mechanism, plus generic `in`/`notIn`
+  operators on `condition.string`. The tri-state argument is decisive, not just a reuse call: AutoAck
+  skips a sender only when its node row **exists and is incomplete**
+  (`if (fromNode && !isNodeComplete(fromNode))`, `meshtasticManager.ts:10084`), so a faithful
+  conversion needs three states — a boolean field collapses "row missing" and "row incomplete" into
+  the same falsy value, and `condition.numeric`'s `NaN` handling would make *both* `== 1` and `== 0`
+  read false for an unknown sender, so neither "complete" nor "not complete" could be expressed for
+  it. `node.completeness in (complete, unknown)` is the correct, and only, faithful expression.
+- **`in`/`notIn` is deliberately generic, not a node-list-only block.** A single-purpose
+  `condition.nodeInList` would cover only the ignore-list case; the generic string operator covers it
+  *and* every other string field (node names, `roleName`, `channelName`, `telemetryType`, system
+  `event`) for the same implementation cost — a `default:` branch inside the existing `stringCompare`
+  switch, no new `ConditionType`.
+- **`autoAckMaxAttempts` is a queue setting, not an Auto-Ack setting — the load-bearing discovery of
+  this phase.** `checkAutoAcknowledge` never reads it. It is
+  `MessageQueueService.resolveDmMaxAttempts()`, applied to **every** queued DM on the source
+  (auto-responder, welcome, mailbox, and the AutoAck reply — but only when that reply is a DM;
+  AutoAck's own tapback and channel sends both hardcode `1` attempt). This means `maxAttempts` on
+  `action.sendMessage` was **not required for converter fidelity** — Phase 3 could have shipped
+  without it and row 21 would simply read *not convertible — it is a per-source queue setting that
+  survives conversion and keeps governing the source's other automated DMs*. The user was shown that
+  trade-off explicitly and chose to ship `maxAttempts` anyway, as a capability in its own right, not
+  a parity gap-filler.
+- **`ActionDeps.sendMessage` grew an optional field, and `automationSimulator.ts` needed no edit.**
+  Wiring `maxAttempts` through to `MessageQueueService.enqueue()` required
+  `ActionDeps.sendMessage`'s argument object to gain an optional `maxAttempts` key
+  (`actionExecutor.ts`) and a new duck-typed `messageQueue` capability check in `meshActionDeps.ts`.
+  The dry-run simulator did **not** need a matching code change: `recordingDeps().sendMessage`
+  already spreads its whole argument object (`{ action: 'sendMessage', ...a }`), so the new field
+  reaches the Test panel automatically — pinned by a drift-guard test in
+  `automationSimulator.test.ts` so a future refactor of `recordingDeps` can't silently drop it.
+- **The `isDM`/`viaMqtt` picker gap was real, not hypothetical.** Both fields already resolved at
+  runtime (`triggerContext.ts`, `asNumber()`'s boolean coercion), but were absent from the builder's
+  field picker. Because `fieldselect` renders a plain `<select>`
+  (`AutomationBuilder.tsx:89-99`), a converter-written `condition.numeric` on `isDM` would have shown
+  **blank** in the builder and been **silently overwritten the moment a user opened it to look** —
+  breaking a converted automation on first touch, not on save. Phase 3 adds both options purely as
+  catalog entries (zero engine change) so a converted automation is editable, not just runnable.
+- **The queued-send path is a documented behavioral divergence, not a bug.** When `maxAttempts` is
+  set, the send becomes fire-and-forget through the source's outgoing queue: it returns a queue id
+  rather than a packet id, and a TX-disabled source doesn't produce `pushOrSkipTxDisabled`'s
+  `{skipped, reason:'TX_DISABLED'}` run-log entry — instead the queue's own `onFailure` handler logs
+  a warning some time later. This exactly mirrors how Auto-Acknowledge's own reply already behaves,
+  which is the parity being bought, but it means a TX-disabled source now records the action as
+  *queued* rather than *skipped*. Documented in `docs/features/automation-engine.md` under
+  **Send a message** so an operator isn't surprised by the run log.
+- **Four Phase 4 converter obligations, carried forward from spec §2's footnotes:**
+  1. **Regex default** — AutoAck's blank `autoAckRegex` means `^(test|ping)`
+     (`meshtasticManager.ts:10102`); the engine's blank `regex` means match-anything. The converter
+     must emit the literal default rather than an empty string.
+  2. **Cooldown default** — AutoAck's unset cooldown is **60s** (`:10092`); the engine's unset
+     cooldown is **0** (no throttle). The converter must emit `60` explicitly, with
+     `cooldownScope: 'node'` (AutoAck's map is keyed by `fromNum`).
+  3. **Channel index → name** — AutoAck stores channel **indices**; `trigger.message.channels` is
+     unified **by name** across sources. The converter must resolve index→name per source at
+     conversion time; two same-named channels on one source is a converter edge case to handle
+     explicitly.
+  4. **`hops > 0` as a branch, not two independent conditions** — a packet with no
+     `hopStart`/`hopLimit` yields `hops === undefined` → `NaN`, so `== 0` and `> 0` are **both**
+     false; AutoAck instead floors it to `0` and treats it as ZeroHop. The converter must route
+     ZeroHop/MultiHop off a single `condition.numeric hops > 0` node's true/false ports, not two
+     separate `== 0` / `> 0` conditions, or a hopless packet matches neither branch.

--- a/docs/internal/dev-notes/AUTOACK_PARITY_PHASE3_SPEC.md
+++ b/docs/internal/dev-notes/AUTOACK_PARITY_PHASE3_SPEC.md
@@ -1,0 +1,530 @@
+# Auto-Acknowledge Parity Conditions — Phase 3 Implementation Spec
+
+**Epic:** `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md` · **Issue:** #4340 (follow-on)
+**Branch:** `feature/autoack-parity-conditions` · **Worktree:** `/home/yeraze/Development/meshmonitor-autoack-parity`
+**Base:** `origin/main` @ `1e61ee07` (Phases 1 and 2 merged)
+
+> **Orchestrator sign-off (2026-07-28):**
+> **(a) APPROVED** — Phase 3 adds no new `ConditionType`. The two conditions the epic
+> named become a computed `node.completeness` field plus `in`/`notIn` operators on
+> `condition.string`. The tri-state argument is decisive: AutoAck skips on
+> `fromNode && !isNodeComplete(fromNode)`, so a MISSING node row must not skip, and a
+> boolean field cannot distinguish that from an incomplete node.
+> **(b) APPROVED by the user (2026-07-28)** — WP3 proceeds and ships in Phase 3.
+> The finding stands and must be documented honestly: `autoAckMaxAttempts` is NOT an
+> Auto-Ack setting (it is `MessageQueueService.resolveDmMaxAttempts`, applied to every
+> queued DM on the source), so `maxAttempts` on `action.sendMessage` is **not** required
+> for converter fidelity — it is delivered as a capability in its own right. The user
+> was shown that trade-off explicitly and chose to keep it in this phase.
+>
+> WP3's hard constraints in §7 are therefore load-bearing, not advisory: the unset call
+> shape must stay byte-identical so every existing automation keeps today's fire-once
+> behaviour, `automationSimulator.ts` (source) must not be edited, and the queue must be
+> reached via the existing `resolveManager` duck-typing — no `instanceof`, no `as any`.
+
+## 1. Reuse inventory (read this before writing any code)
+
+Everything below already exists and **must be used or extended, not re-implemented**. Verified by symbolic search on 2026-07-28 against this worktree.
+
+| Existing thing | Location | How Phase 3 uses it |
+|---|---|---|
+| `resolveFieldValue(ctx, field)`'s `node.` branch | `engineContext.ts:204-224` | **Extended** with one computed prop, `node.completeness`, joining the existing `ageMinutes` (`:215`) and `roleName` (`:220`). This is the entire "nodeComplete condition". |
+| `ROLE_NAMES` | `engineContext.ts:83-86` | **Precedent** for a server-side value vocabulary living in `engineContext.ts` rather than `types/automation.ts`. `NODE_COMPLETENESS` lands beside it. |
+| `isNodeComplete(node)` + `DbNodeLike` | `src/utils/nodeHelpers.ts:375-426` | **Called verbatim.** `NodeFacts` (`engineContext.ts:19-38`) already carries `longName`/`shortName`/`hwModel` — structurally a `DbNodeLike`. **Do not re-implement the "Node !xxxxxxxx" default-name check.** |
+| `getSubjectNode(ctx)` | `engineContext.ts:136-142` | Unchanged. Its `null` return is what makes `unknown` a distinguishable third state. |
+| `createMeshNodeDataProvider().getNode` | `meshNodeData.ts:19-26` → `NodesRepository.getNode` (`src/db/repositories/nodes.ts:130-150`) | Returns the **full row** (`.select()`), so `hwModel` is populated for real traffic without any repository change. |
+| `stringCompare(op, a, b)` | `conditionEvaluator.ts:32-46` | **Extended** with two cases, `in` / `notIn`. `condition.string` has **no** `op` validation in `validateAutomationGraph` today, so no types change is needed for them. |
+| `STRING_OP_OPTIONS` | `catalog.ts:251-255` | **Extended** with the two operators, and **exported** (one word) so the §6 parity test can cross-check it against the evaluator. |
+| `EVENT_NUMERIC['trigger.message']` | `catalog.ts:183-186` | **Extended** with `isDM` and `viaMqtt`. Both are already in `ctx.trigger.fields` (`triggerContext.ts:113,120`) and `asNumber()` (`conditionEvaluator.ts:49-54`) already coerces `boolean → 1/0`. **Catalog-only change; zero engine change.** |
+| `NODE_STRING` | `catalog.ts:214-217` | **Extended** with `node.completeness`. Label carries the legal values, exactly as `node.roleName` carries `(e.g. ROUTER)`. |
+| `autoAckIgnoredNodes` parser | `meshtasticManager.ts:10037-10051` (`split(/[\s,]+/)`, lowercase, optional `!`) | **Separator/casing source of truth** for the `in`/`notIn` operator, so a converted list pastes across verbatim. Not called — the operator stays a generic string op. |
+| `condition.meshcoreScope`'s `mode` + `includeUnscoped` | `types/automation.ts` `MESHCORE_SCOPE_MODES`, validation at the `case`, `conditionEvaluator.ts:96-115` | **Precedent considered and rejected** for node-completeness (§9.1) — it is the house shape for a *narrow* block whose data is unreachable generically. `node.completeness` **is** reachable generically. |
+| `parseCooldownScope` / `COOLDOWN_SCOPES` (Phase 2) | `types/automation.ts` | **Exact template** for `parseSendMaxAttempts` / `SEND_MAX_ATTEMPTS_MIN|MAX`: exported const, lenient runtime parser, validate *only when present*. |
+| `case 'action.delay'` param validation | `types/automation.ts` (`AUTOMATION_DELAY_MAX_SECONDS` bound check) | **Exact template** for the new `case 'action.sendMessage'` range check on `maxAttempts`. |
+| `MessageQueueService.enqueue(..., maxAttemptsOverride, emoji)` | `src/server/messageQueueService.ts:101-114` | **The only DM retry/ACK mechanism in the app.** WP3 calls it; it is not modified. |
+| `MessageQueueService.resolveDmMaxAttempts()` | `src/server/messageQueueService.ts:75-85` (clamp `[1,3]`, `MAX_ATTEMPTS = 3`) | **Bound source of truth** for `SEND_MAX_ATTEMPTS_MIN|MAX`. Not modified (§8). |
+| `MeshtasticManager.messageQueue` | `meshtasticManager.ts:1107` — `public readonly` | Already public and per-source. WP3 reaches it through the existing `resolveManager(sourceId)` duck-typing in `meshActionDeps.ts:49-52`, **never** `instanceof` (CLAUDE.md). |
+| `scopeArg` "only forward the key when set" trick | `actionExecutor.ts:305-306`, used at `:296`/`:304` | **Copied verbatim** for `maxAttempts`, so the default call shape — and every existing `actionExecutor.test.ts` assertion — is byte-identical. |
+| `pushOrSkipTxDisabled(results, fn)` | `actionExecutor.ts:127-140` | Unchanged; both send call sites keep it. Its TX-disabled catch does **not** cover the queued path (§2.4 caveat, deliberate). |
+| `recordingDeps()` | `automationSimulator.ts:110-124` | **No edit needed.** `async sendMessage(a) { return { action:'sendMessage', ...a } }` spreads the new optional field into the dry-run automatically. Pinned by a test so it cannot drift (§6). |
+| `fieldVisible()` + `FieldDef.showIf.truthy` | `catalog.ts:31-52` (Phase 1 + Phase 2) | **Reused unchanged** to gate the new `maxAttempts` field on `to` being set. No new operator this phase. |
+| `defaultParams(type, triggerType)` | `AutomationBuilder.tsx:48-63` | Seeds only `select`/`fieldselect`. `maxAttempts` is `kind: 'number'` ⇒ **absent by default** ⇒ today's behaviour. No change. |
+| `clean(params)` in the compiler | `src/components/automations/compile.ts:34-41` | Drops `''`/`null`/`undefined`, so clearing the number field removes the param. `compile`/`decompile` are generic over block types ⇒ **`compile.ts` needs no change** for any of this phase. |
+| `AutomationTester.tsx` fact builder + headline | `AutomationTester.tsx:96-99`, `:261-293` | `numFact('hwModel')` + one `<Field>`; one clause on the `sendMessage` headline. Both one-liners. |
+| `createTestDb` / `recorder()` / `engineWith()` | `automationEngineService.test.ts:12,17-26,77-79` | Any engine-level test uses these. Do not invent a harness. |
+| `VALID_SETTINGS_KEYS` / `PER_SOURCE_SETTINGS_KEYS` | `src/server/constants/settings.ts:9`, `:338` | **Read-only inputs** to the §6 parity test. **Phase 3 adds no setting**, so neither list is edited. |
+
+### 1.1 Justification: zero new modules, zero new block types
+
+| Candidate | Rejected because |
+|---|---|
+| `condition.nodeComplete` (a new `ConditionType`) | The predicate is a pure function of the already-hydrated subject node, reachable through the existing `node.*` field mechanism. A new type costs a union member, a `CONDITION_TYPES` entry, a validation `case`, an evaluator `case`, a catalog block, and a `fieldsFor` exemption — to express what `condition.string` on `node.completeness` expresses with **one computed prop**. See §9.1 for the tri-state argument that also makes it *more* correct. **Rejected.** |
+| `condition.nodeInList` / `condition.nodeIgnored` | The list is a literal baked into the graph by the converter, not a lookup. A `notIn` operator on `condition.string` covers it *and* every other string field (node names, `roleName`, `channelName`, `telemetryType`, system `event`). A single-purpose block would be strictly less capable and strictly more code. **Rejected.** |
+| `condition.boolean` (a generic true/false block) | Would be the third way to compare a field, alongside `numeric` and `string`. `asNumber()` already coerces `boolean → 1/0`, so `condition.numeric` on `isDM` `== 1` works today with **zero** engine change. **Rejected**; revisit only if the `== 1` idiom proves confusing in the wild. |
+| `src/server/services/automation/nodeCompleteness.ts` | Would split a 4-line computed prop from `resolveFieldValue`, its only caller, next to two identical siblings. **Rejected.** |
+| `src/types/sendAttempts.ts` | `types/automation.ts` is the canonical home for every engine vocabulary constant (`REQUEST_OPS`, `TAPBACK_EMOJI_MODES`, `COOLDOWN_SCOPES`, `COLLAPSE_MODES`). **Rejected.** |
+| Adding `in`/`notIn` to `NUMERIC_OPS` | `condition.numeric`'s `op` **is** validated against `NUMERIC_OPS`, so this would widen a validated union for a case `fromId` already covers in its native `!xxxxxxxx` form. **Rejected** (§8). |
+
+**Result:** `SEND_MAX_ATTEMPTS_MIN|MAX` + `parseSendMaxAttempts()` + one validation `case` → `src/types/automation.ts`. `NODE_COMPLETENESS` + the `node.completeness` branch → `engineContext.ts`. Two `case`s → `conditionEvaluator.ts`. One optional field + two forwardings → `actionExecutor.ts`. One queued branch → `meshActionDeps.ts`. Field options → `catalog.ts`. **No new source module.**
+
+## 2. The parity mapping table (phase exit criterion; Phase 4's input)
+
+Every key in `VALID_SETTINGS_KEYS` beginning `autoAck` — 33 of them (`src/server/constants/settings.ts:20-60`). "Per-source?" is membership in `PER_SOURCE_SETTINGS_KEYS` (`:338-370`). This table is mirrored by an in-code constant asserted against `VALID_SETTINGS_KEYS` in **both** directions (§6, `autoAckParity.test.ts`) — a future `autoAck*` key fails the suite until this table is updated.
+
+| # | Setting | Per-source? | Engine equivalent | Status |
+|---|---|---|---|---|
+| 1 | `autoAckEnabled` | yes | The automation's own `enabled` column + `condition.sourceFilter` bound to that source | **exists** |
+| 2 | `autoAckRegex` | yes | `trigger.message` param `regex` | **exists** ¹ |
+| 3 | `autoAckMessage` | yes | `action.sendMessage` param `text` | **exists** ² |
+| 4 | `autoAckMessageDirect` | yes | A second `action.sendMessage` on the ZeroHop branch | **exists** ² |
+| 5 | `autoAckChannels` | yes | `trigger.message` param `channels` (unified, by name) | **exists** ³ |
+| 6 | `autoAckDirectMessages` | yes | — *(deprecated; migration 093 folds it into the Direct\* cells)* | **n/a — deprecated** |
+| 7 | `autoAckUseDM` | yes | — *(deprecated; folded into the `*ReplyDmEnabled` cells)* | **n/a — deprecated** |
+| 8 | `autoAckSkipIncompleteNodes` | yes | `condition.string` · field `node.completeness` · op `in` · value `complete, unknown` | **Phase 3 adds** (field + operators) ⁴ |
+| 9 | `autoAckIgnoredNodes` | yes | `condition.string` · field `fromId` · op `notIn` · value = the list verbatim | **Phase 3 adds** (operators) ⁵ |
+| 10 | `autoAckTapbackEnabled` | **no** (global-only) | — *(deprecated)* | **n/a — deprecated** |
+| 11 | `autoAckReplyEnabled` | **no** (global-only) | — *(deprecated)* | **n/a — deprecated** |
+| 12 | `autoAckDirectEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 13 | `autoAckDirectTapbackEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 14 | `autoAckDirectReplyEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 15 | `autoAckMultihopEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 16 | `autoAckMultihopTapbackEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 17 | `autoAckMultihopReplyEnabled` | yes | — *(deprecated)* | **n/a — deprecated** |
+| 18 | `autoAckTestMessages` | **no** (global) | **Not convertible, and does not need to be.** No server code reads it — it is a UI scratchpad on `AutoAcknowledgeSection.tsx` for pasting sample text. Its engine analogue is the Test panel (`AutomationTester.tsx`), a mechanism, not a setting. | **not convertible (by design)** |
+| 19 | `autoAckCooldownSeconds` | yes | `trigger.message` `cooldownSeconds` + `cooldownScope: 'node'` | **exists** (Phase 2) ⁶ |
+| 20 | `autoAckPreSendDelaySeconds` | yes | `action.delay` before the first send in the chain | **exists** ⁷ |
+| 21 | `autoAckMaxAttempts` | yes | `action.sendMessage` param `maxAttempts` | **Phase 3 adds** ⁸ |
+| 22 | `autoAckChannelZeroHopReplyEnabled` | yes | Cell rule emits `action.sendMessage`; cell = `isDM == 0` ∧ `hops == 0` ∧ `viaMqtt == 0` | **exists + Phase 3 adds `isDM`/`viaMqtt` to the picker** ⁹ |
+| 23 | `autoAckChannelZeroHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** (Phase 1) |
+| 24 | `autoAckChannelZeroHopReplyDmEnabled` | yes | That cell's `action.sendMessage` gets `to: {{ trigger.from }}` | **exists** |
+| 25 | `autoAckChannelMultiHopReplyEnabled` | yes | Cell = `isDM == 0` ∧ ¬(`hops == 0` ∧ `viaMqtt == 0`) → `action.sendMessage` | **exists + picker** ⁹ |
+| 26 | `autoAckChannelMultiHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** |
+| 27 | `autoAckChannelMultiHopReplyDmEnabled` | yes | `to: {{ trigger.from }}` on that cell's send | **exists** |
+| 28 | `autoAckDirectZeroHopReplyEnabled` | yes | Cell = `isDM == 1` ∧ `hops == 0` ∧ `viaMqtt == 0` → `action.sendMessage` | **exists + picker** ⁹ |
+| 29 | `autoAckDirectZeroHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** |
+| 30 | `autoAckDirectZeroHopReplyDmEnabled` | yes | No-op for Direct cells (a DM reply is inherently a DM); converter emits `to: {{ trigger.from }}` regardless | **exists** |
+| 31 | `autoAckDirectMultiHopReplyEnabled` | yes | Cell = `isDM == 1` ∧ ¬ZeroHop → `action.sendMessage` | **exists + picker** ⁹ |
+| 32 | `autoAckDirectMultiHopTapbackEnabled` | yes | Same cell → `action.tapback` `emojiMode: 'hopCount'` | **exists** |
+| 33 | `autoAckDirectMultiHopReplyDmEnabled` | yes | No-op for Direct cells | **exists** |
+
+**Notes (each is a Phase 4 converter obligation, not a Phase 3 gap):**
+
+1. AutoAck defaults to `^(test|ping)` when the setting is blank (`meshtasticManager.ts:10102`); the engine's blank `regex` means **match anything**. The converter must emit the literal default.
+2. Token dialects differ: AutoAck uses `{NUMBER_HOPS}`/`{TIME}`/`{NODE_NAME}`; the engine uses `{{ trigger.hops }}`/`{{ NOW }}`/`{{ trigger.fromName }}`. Translation is Phase 4 work. `{{ trigger.hopEmoji }}` (Phase 1) has no AutoAck equivalent — a superset, not a gap.
+3. AutoAck stores channel **indices**; `trigger.message.channels` is unified **by name**. The converter resolves index→name per source. A source with two same-named channels is a converter edge case, not an engine one.
+4. Tri-state is required for fidelity: AutoAck skips only when the node row **exists and is incomplete** (`if (fromNode && !isNodeComplete(fromNode))`, `:10084`). `complete, unknown` reproduces that exactly. See §9.1.
+5. `in`/`notIn` split on `/[\s,]+/` and compare case-insensitively — the same separators and casing as AutoAck's own parser (`:10040-10043`). The converter normalises each entry to canonical `!xxxxxxxx` (AutoAck accepts a bare 8-hex token; `trigger.fromId` always carries the `!`). An **empty** value makes `notIn` always true, matching an unset ignore list — but the converter should simply omit the condition.
+6. AutoAck's default is **60s** when unset (`:10092`); the engine's is **0**. The converter must emit `60` explicitly. `cooldownScope: 'node'` is mandatory — AutoAck's map is keyed by `fromNum` (`:10094`).
+7. Two semantic differences: AutoAck's delay is a non-blocking `setTimeout` (`:10172-10178`) while `action.delay` blocks its own run and caps at `AUTOMATION_DELAY_MAX_SECONDS = 300`; and AutoAck applies the same delay independently to the tapback and the reply, so a converted linear chain needs the `action.delay` once, before the first send.
+8. **Read this row carefully.** `checkAutoAcknowledge` never reads `autoAckMaxAttempts`. `MessageQueueService.resolveDmMaxAttempts()` reads it per-source and applies it to **every queued DM** on that source (auto-responder, welcome, mailbox, auto-ack reply). It therefore affects the AutoAck **reply, and only when that reply is a DM**: the AutoAck **tapback** hardcodes `1` ("tapbacks are best-effort, don't retry", `:10207`) and **channel** sends hardcode `1` (`messageQueueService.ts:112`). Consequently `maxAttempts` goes on `action.sendMessage` **only** — see §9.2. The setting also keeps governing the source's other queued DMs after conversion, so disabling AutoAck does not retire it.
+9. `isDM` and `viaMqtt` already resolve at runtime (`triggerContext.ts:113,120` + `asNumber()` boolean coercion) but are **not offered by the builder's field picker**, and `fieldselect` is a plain `<select>` (`AutomationBuilder.tsx:89-99`) — a converter-written value renders blank and is overwritten on the first edit. Phase 3 adds both options so a converted automation is **editable**, not merely runnable. `viaMqtt` is load-bearing: `isZeroHop = hopsTraveled === 0 && !viaMqtt` (`AUTOACK_2X2_PLAN.md`, `:10141`).
+
+**Adjacent behaviour not in the table** (not `autoAck*` keys, recorded so Phase 4 does not rediscover them): the per-packet dedup guard (`:9967-9978`) has no engine analogue and needs none; the TX-disabled skip (`:10001`) is already mirrored by `pushOrSkipTxDisabled`; the airtime cutoff (`isAutomationAirtimeGated`, `automationAirtimeCutoff*`) is shared infrastructure both paths already honour; the local-node skip (`:10065-10070`) is already covered by the engine's self-drop (`getLocalNodeNum`, #3914). **MeshCore auto-ack is a separate `meshcoreAutoAck*` namespace** (`meshcoreManager.ts:6873-6925`) and is out of scope for this table.
+
+## 3. Backend design
+
+### 3.1 `node.completeness` — `engineContext.ts`
+
+Beside `ROLE_NAMES` (`:83-86`):
+
+```ts
+/**
+ * The three states of `node.completeness` (#4340 Phase 3).
+ *
+ *  - 'complete'    the subject node's row exists and isNodeComplete() passes
+ *                  (real longName, a shortName, and an hwModel from NODEINFO).
+ *  - 'incomplete'  the row exists but NODEINFO has not arrived.
+ *  - 'unknown'     there is NO row for the subject, or the event has no subject
+ *                  node at all (Schedule / System / MeshCore).
+ *
+ * The third state is the point. Auto-Acknowledge skips a sender only when the
+ * row EXISTS and is incomplete (`if (fromNode && !isNodeComplete(fromNode))`,
+ * meshtasticManager.ts:10084) — an unknown sender is NOT skipped. A boolean
+ * field cannot express that: a missing row and an incomplete row both resolve
+ * to a falsy/undefined value. So the AutoAck rule is
+ * `node.completeness in (complete, unknown)`.
+ */
+export const NODE_COMPLETENESS = ['complete', 'incomplete', 'unknown'] as const;
+export type NodeCompleteness = (typeof NODE_COMPLETENESS)[number];
+```
+
+In `resolveFieldValue`'s `node.` branch (`:206-224`), **before** the existing `if (!node) return undefined;` guard:
+
+```ts
+if (field.startsWith('node.')) {
+  const node = await getSubjectNode(ctx);
+  const prop = field.slice('node.'.length);
+  // #4340 Phase 3: resolved BEFORE the `!node` guard below, because "there is no
+  // node row" is a meaningful VALUE here ('unknown'), not a missing field.
+  if (prop === 'completeness') {
+    return node ? (isNodeComplete(node) ? 'complete' : 'incomplete') : 'unknown';
+  }
+  if (!node) return undefined;
+  // …ageMinutes / roleName / passthrough unchanged…
+}
+```
+
+Import: `import { isNodeComplete } from '../../../utils/nodeHelpers.js';`. `NodeFacts` is structurally a `DbNodeLike` (`longName?`, `shortName?`, `hwModel?`) — no cast, no shim, no new type. `nodeHelpers.ts` is framework-free and already imported by server code.
+
+**`getSubjectNode` is memoised** (`ctx.__nodeP`), so a graph using both `node.completeness` and `node.batteryLevel` still performs one DB read.
+
+### 3.2 `in` / `notIn` — `conditionEvaluator.ts`
+
+In `stringCompare` (`:32-46`), before `default`:
+
+```ts
+    // #4340 Phase 3: membership in a literal list. Separators and casing mirror
+    // Auto-Acknowledge's own autoAckIgnoredNodes parser (meshtasticManager.ts:
+    // 10040-10043) — comma OR whitespace, case-insensitive — so a converted
+    // ignore list pastes across verbatim. Deliberately generic: no node-id
+    // normalisation happens here (the converter emits canonical !xxxxxxxx
+    // tokens, which is exactly the shape trigger.fromId carries).
+    // An EMPTY list makes `in` never match and `notIn` always match — which is
+    // the correct reading of "an unset ignore list ignores nobody".
+    case 'in':
+    case 'notIn': {
+      const hit = b.toLowerCase().split(/[\s,]+/).filter(Boolean).includes(al);
+      return op === 'in' ? hit : !hit;
+    }
+```
+
+`al` is the already-lowercased left operand (`:33`). **No `validateAutomationGraph` change** — `condition.string` has no `op` validation today, and adding one would reject stored graphs (same reasoning as Phase 2's `cooldownSeconds`).
+
+### 3.3 `maxAttempts` vocabulary + validation — `types/automation.ts`
+
+Beside `COOLDOWN_SCOPES`:
+
+```ts
+/**
+ * App-level DM resend cap for `action.sendMessage` (#4340 Phase 3).
+ *
+ * Mirrors MessageQueueService's own bound (src/server/messageQueueService.ts:
+ * 75-85, `Math.min(3, Math.max(1, …))`, #4266) — an unbounded value would let an
+ * automation be abused as a repeat-broadcast mechanism. The duplication is
+ * deliberate: this module must stay dependency-free (the frontend imports it),
+ * and the queue's clamp is load-bearing for #4266 and must not be refactored
+ * from here. autoAckParity.test.ts pins the two to the same numbers.
+ */
+export const SEND_MAX_ATTEMPTS_MIN = 1;
+export const SEND_MAX_ATTEMPTS_MAX = 3;
+
+/**
+ * Coerce a stored `params.maxAttempts` to an integer in [1,3], or `undefined`
+ * for absent / blank / unparseable — `undefined` means "one direct send", the
+ * pre-4.14 behaviour every stored automation depends on. Lenient at RUNTIME
+ * while validateAutomationGraph rejects an out-of-range value at SAVE time —
+ * the same split Phase 1 used for emojiMode and Phase 2 for cooldownScope.
+ */
+export function parseSendMaxAttempts(raw: unknown): number | undefined {
+  if (raw == null || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  return Math.min(SEND_MAX_ATTEMPTS_MAX, Math.max(SEND_MAX_ATTEMPTS_MIN, n));
+}
+```
+
+New `case` in the per-block param switch, modelled on `case 'action.delay'`:
+
+```ts
+        case 'action.sendMessage':
+          // Optional. Absent/blank = one direct send — every pre-existing stored
+          // automation must keep validating and behaving exactly as before.
+          if (p.maxAttempts != null && p.maxAttempts !== '') {
+            const n = Number(p.maxAttempts);
+            if (!Number.isInteger(n) || n < SEND_MAX_ATTEMPTS_MIN || n > SEND_MAX_ATTEMPTS_MAX) {
+              errors.push(`action.sendMessage "${n2.id}" requires params.maxAttempts ∈ [${SEND_MAX_ATTEMPTS_MIN}, ${SEND_MAX_ATTEMPTS_MAX}]`);
+            }
+          }
+          break;
+```
+
+*(The loop variable is `n`; rename the local to avoid shadowing — implementer's choice, e.g. `attempts`.)*
+
+### 3.4 `maxAttempts` through the deps boundary — `actionExecutor.ts`
+
+`ActionDeps.sendMessage`'s argument object (`:21-33`) gains:
+
+```ts
+    /**
+     * App-level DM resend cap (#4340 Phase 3), 1–3. Absent = one direct send —
+     * today's behaviour for every existing automation. Honoured ONLY for a
+     * Meshtastic DM: the retry machinery is MessageQueueService, which hardcodes
+     * maxAttempts=1 for channel sends, and MeshCore has no queue at all. See
+     * meshActionDeps.sendTextVia.
+     */
+    maxAttempts?: number;
+```
+
+In `case 'action.sendMessage'`, beside the `scopeArg` computation:
+
+```ts
+      // Only forward the key when set, so the default (unset) call shape — and
+      // thus the run-log resolvedParams and every existing test — is unchanged.
+      // Same trick as scopeArg above.
+      const attempts = parseSendMaxAttempts(p.maxAttempts);
+      const attemptsArg = attempts !== undefined ? { maxAttempts: attempts } : {};
+```
+
+…spread into **both** `deps.sendMessage(…)` call sites (`:296` and `:304`). The channel-loop site (`:304`) can only be reached with `destination == null`, so the value is inert there; forwarding it anyway keeps one rule ("the deps decide whether it applies") and keeps the dry-run's resolved params honest about what the user configured.
+
+### 3.5 The queued path — `meshActionDeps.ts`
+
+Add a duck-typed capability interface beside `MeshSendManager` (`:19-32`):
+
+```ts
+/**
+ * A Meshtastic manager's per-source outgoing queue (meshtasticManager.ts:1107,
+ * `public readonly`). The ONLY thing in the app that retries a DM until it is
+ * ACKed — the same path Auto-Acknowledge's reply takes (meshtasticManager.ts:
+ * 10248). Duck-typed like every other capability check in this file; never
+ * `instanceof` (CLAUDE.md).
+ */
+interface QueuedSendManager {
+  messageQueue?: {
+    enqueue(
+      text: string, destination: number, replyId?: number,
+      onSuccess?: () => void, onFailure?: (reason: string) => void,
+      channel?: number, maxAttemptsOverride?: number, emoji?: number,
+    ): string;
+  };
+}
+```
+
+`sendTextVia` gains a `maxAttempts?: number` parameter and, inside the existing Meshtastic branch (`:79-84`), **before** the direct `sendTextMessage` call:
+
+```ts
+    const dest = typeof destination === 'number' ? destination : undefined;
+    // #4340 Phase 3. Opt-in ONLY: absent maxAttempts, a channel send, or a
+    // MeshCore source all take the unchanged direct path below.
+    //   * Channel sends are excluded because the queue hardcodes maxAttempts=1
+    //     for them (messageQueueService.ts:112) — the parameter would buy
+    //     nothing while silently imposing the queue's 30s inter-send throttle
+    //     on every channel automation that set it.
+    //   * The queue is fire-and-forget: it returns a queue id synchronously, so
+    //     this returns a descriptive object instead of a packet id, and a
+    //     TX-disabled throw surfaces later in the queue's onFailure rather than
+    //     through actionExecutor's pushOrSkipTxDisabled. Both are exactly how
+    //     Auto-Acknowledge itself behaves — that IS the parity.
+    const q = (raw as QueuedSendManager).messageQueue;
+    if (maxAttempts != null && dest != null && typeof q?.enqueue === 'function') {
+      const id = q.enqueue(
+        text, dest, replyId,
+        () => logger.debug(`[Automation] queued DM to !${dest.toString(16).padStart(8, '0')} delivered`),
+        (reason: string) => logger.warn(`[Automation] queued DM to !${dest.toString(16).padStart(8, '0')} failed: ${reason}`),
+        undefined,             // channel: undefined ⇒ this is a DM
+        maxAttempts,
+        emoji || undefined,
+      );
+      return { queued: true, messageId: id, maxAttempts };
+    }
+    return raw.sendTextMessage(text, channel, dest, replyId, emoji);
+```
+
+`createMeshActionDeps().sendMessage` (`:107-109`) destructures and forwards `maxAttempts`. `sendTapback` (`:111-113`) is **unchanged** — see §9.2. Add `import { logger } from '../../../utils/logger.js';`.
+
+### 3.6 Worked example — the converted AutoAck rule
+
+Source `tcp-1`; AutoAck config: regex `^(test|ping)`, channels `[0]`, cooldown 60s, skip-incomplete on, ignore list `!aabbccdd, 11223344`, max attempts 3, ChannelZeroHop = Reply+Tapback with Respond-via-DM.
+
+```
+trigger.message   { channels:[{protocol:'meshtastic',name:'Primary'}],
+                    regex:'^(test|ping)', cooldownSeconds:60, cooldownScope:'node' }
+  → condition.sourceFilter { sourceIds:['tcp-1'] }
+  → condition.string  { field:'fromId',           op:'notIn', value:'!aabbccdd, !11223344' }
+  → condition.string  { field:'node.completeness', op:'in',    value:'complete, unknown' }
+  → condition.numeric { field:'isDM',    op:'==', value:0 }
+  → condition.numeric { field:'viaMqtt', op:'==', value:0 }
+  → condition.numeric { field:'hops',    op:'>',  value:0 }        // ← MultiHop on `true`,
+                                                                   //   ZeroHop on `false`
+  ─false→ action.tapback     { emojiMode:'hopCount' }
+       →  action.sendMessage { text:'…', to:'{{ trigger.from }}', maxAttempts:3 }
+```
+
+The `hops > 0` **branch**, rather than two independent `== 0` / `> 0` conditions, is deliberate: a packet with no `hopStart`/`hopLimit` yields `hops === undefined` → `NaN` → **both** comparisons false, whereas AutoAck floors it to `0` and treats it as ZeroHop (`:10127-10134`). Routing ZeroHop onto the `false` port reproduces AutoAck exactly at zero code cost. **Record this in the epic; it is a Phase 4 converter obligation.**
+
+## 4. What does **not** change
+
+- **No new `ConditionType`, no new `ActionType`, no new `TriggerType`.** `CONDITION_TYPES` / `ACTION_TYPES` / `TRIGGER_TYPES` and their unions are untouched.
+- **`automationEngineService.ts` is untouched.** No trigger param, no cooldown interaction, no dispatch change. Verify with `git diff --stat`.
+- **`automationSimulator.ts` is untouched.** `recordingDeps().sendMessage` spreads its argument object, so the new optional field reaches the dry-run for free (§6 pins this).
+- **`triggerContext.ts` is untouched.** `isDM` / `viaMqtt` / `fromId` / `hops` are already in `fields`; Phase 3 only makes them *selectable*.
+- **`graphEvaluator.ts`, `automationTraceBus.ts`, `LiveTracePanel.tsx`, `variableResolver.ts`, `meshNodeData.ts` are untouched.**
+- **`compile.ts` / `decompile()` are untouched** — generic over `{type, params}`.
+- **`AutomationBuilder.tsx` is untouched.** New field options ride the existing `fieldselect`/`number` renderers and the existing `fieldVisible` filter (`:227-228`). **Its appearance in `git diff --stat` is a design failure — stop and escalate.**
+- **`MessageQueueService` is untouched** — no signature, clamp, or interval change. WP3 is a caller only.
+- **`meshtasticManager.ts` / `checkAutoAcknowledge` / `AutoAcknowledgeSection.tsx` / `AutomationContext.tsx` are untouched.** AutoAck's own behaviour must be provably unchanged this phase.
+- **`meshcoreManager.ts` is untouched.** MeshCore's `meshcoreAutoAck*` namespace is out of scope.
+- **No new setting** ⇒ no `VALID_SETTINGS_KEYS` / `PER_SOURCE_SETTINGS_KEYS` edit. **No schema change, no migration** ⇒ no PostgreSQL/MySQL containers required to verify this phase.
+- **No route, no response envelope work.** Phase 3 adds no HTTP surface. (Phase 4's preview/create route is where the envelope rules land.)
+- **Per-source scoping:** all three new conditions are evaluated from `TriggerContext.sourceId` + `subjectNodeNum` through the existing `NodeDataProvider.getNode(sourceId, nodeNum)`. **No new query, no new repository method, no raw SQL.** The ignore list is a literal in the graph, and the graph is scoped by the existing `condition.sourceFilter`.
+
+## 5. Frontend
+
+### 5.1 `catalog.ts` — field pickers and operators
+
+```ts
+const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
+  'trigger.message': [
+    { value: 'hops', label: 'Hop count' }, { value: 'from', label: 'Sender node #' },
+    { value: 'channel', label: 'Channel #' }, { value: 'snr', label: 'SNR' }, { value: 'rssi', label: 'RSSI' },
+    // #4340 Phase 3: booleans compared as 1/0 (the engine's asNumber() coerces
+    // them). Needed to express Auto-Acknowledge's {Channel,Direct} ×
+    // {ZeroHop,MultiHop} matrix, where ZeroHop means hops == 0 AND NOT viaMqtt.
+    { value: 'isDM', label: 'Is a direct message (1 = yes, 0 = channel)' },
+    { value: 'viaMqtt', label: 'Arrived via MQTT (1 = yes, 0 = RF)' },
+  ],
+  …
+};
+
+const NODE_STRING: FieldOpt[] = [
+  …,
+  // #4340 Phase 3 — see NODE_COMPLETENESS in engineContext.ts. Three states, so
+  // "complete or not yet known" is expressible with the `is one of` operator.
+  { value: 'node.completeness', label: 'Node info completeness (complete / incomplete / unknown)' },
+];
+
+export const STRING_OP_OPTIONS = [   // ← now exported, for the parity cross-check test
+  …,
+  { value: 'in', label: 'is one of (comma list)' },
+  { value: 'notIn', label: "isn't one of (comma list)" },
+];
+```
+
+### 5.2 `catalog.ts` — the `maxAttempts` field on `action.sendMessage`
+
+Appended to that block's `fields`, after `replyToTrigger`:
+
+```ts
+      {
+        name: 'maxAttempts', label: 'DM resend attempts', kind: 'number', advanced: true,
+        placeholder: '1', // 1–3; mirrors SEND_MAX_ATTEMPTS_* in src/types/automation.ts.
+        // Only meaningful for a DM — the queue hardcodes 1 attempt for channel
+        // sends. Reuses Phase 2's showIf.truthy so an unset/blank/0 `to` hides it.
+        showIf: { field: 'to', truthy: true },
+        help: 'Resend this DM (1–3) until the recipient ACKs it — the same retry Auto-Acknowledge uses. Leave blank for a single send. Setting it routes the DM through the source’s outgoing queue, which also spaces sends 30 seconds apart. Meshtastic DMs only: ignored for channel messages and MeshCore.',
+      },
+```
+
+`showIf: { field: 'to', truthy: true }` is a **direct reuse** of Phase 2's operator; no new `showIf` mechanism this phase.
+
+### 5.3 `AutomationTester.tsx` — two one-liners
+
+- **`hwModel` subject-node fact.** `numFact('hwModel');` at `:96` plus `<Field label="HW model (#)" value={facts.hwModel} onChange={(v) => setFact('hwModel', v)} type="number" />` beside Long/Short name (`:166-167`). Without it a dry-run of `node.completeness` reports `incomplete` for any synthetic node, because `isNodeComplete` requires an `hwModel` — a confusing false negative. (`stubData` merges `{ nodeNum, ...liveNode, ...node }`, so a *real* node's `hwModel` already survives.)
+- **Headline.** At `:264`, append the cap when it is set and the send is a DM:
+  `headline = \`Send message → ${p.destination != null ? \`DM to node ${p.destination}${p.maxAttempts ? \` (up to ${p.maxAttempts} attempts)\` : ''}\` : \`channel ${p.channel ?? 0}\`}\`;`
+  This is the visible proof that the param crossed the deps boundary.
+
+### 5.4 No change
+
+`AutomationBuilder.tsx`, `compile.ts`, `tokenHints.ts`, `SubstitutionsHelp.tsx` (no new `{{ }}` token this phase), `AutomationsPage.tsx`, `LiveTracePanel.tsx`.
+
+## 6. Test plan (mandatory — standard Vitest suite, no standalone scripts)
+
+| File | New / extend | Cases |
+|---|---|---|
+| `src/types/automation.test.ts` | extend | `parseSendMaxAttempts`: `1`/`2`/`3` round-trip; `'2'` → `2`; `undefined`/`null`/`''`/`'x'`/`1.5` → `undefined`; `0` → `1`, `9` → `3` (clamp). Validation: `action.sendMessage` with **no** `maxAttempts` validates unchanged; `''` validates; `2` validates; `0`, `4`, `'x'`, `2.5` each produce the `∈ [1, 3]` error. A graph with only `text` still validates (regression: the new `case` must not require anything). |
+| `src/server/services/automation/engineContext.test.ts` | extend | `resolveFieldValue(ctx, 'node.completeness')` truth table: full node → `'complete'`; `longName: 'Node !aabbccdd'` → `'incomplete'`; missing `hwModel` → `'incomplete'`; missing `shortName` → `'incomplete'`; provider returns `null` → `'unknown'`; `subjectNodeNum: null` (schedule ctx) → `'unknown'`. **Cross-check:** for every case, the value equals `isNodeComplete(row) ? 'complete' : 'incomplete'` where the row exists — i.e. the condition never re-implements the helper. `NODE_COMPLETENESS` contains exactly those three strings. Existing `ageMinutes`/`roleName`/passthrough tests pass **unmodified** (the new branch must not shadow them), and `node.<missing prop>` still returns `undefined`. `getSubjectNode` is called **once** for a ctx that reads both `node.completeness` and `node.batteryLevel` (memoisation regression). |
+| `src/server/services/automation/conditionEvaluator.test.ts` | extend | `in`/`notIn`: comma list, whitespace list, mixed `a, b  c`; case-insensitive both sides; exact-token (not substring) — `'!aabbccdd'` is **not** `in` `'!aabbccddee'`; empty value → `in` false, `notIn` true; left operand missing → `in` false, `notIn` true; every pre-existing `stringCompare` op behaves unchanged. End-to-end `condition.string` nodes: `{field:'fromId', op:'notIn', value:'!aabbccdd'}` false for that sender, true for another; `{field:'node.completeness', op:'in', value:'complete, unknown'}` true for complete **and** for a null node, false for incomplete. `condition.numeric` on `isDM`/`viaMqtt` with `== 1` / `== 0` for both boolean values **and** for `undefined` (→ `NaN` → both false, pinning the documented behaviour). |
+| `src/server/services/automation/actionExecutor.test.ts` | extend | `action.sendMessage` with **no** `maxAttempts` calls `deps.sendMessage` with an argument object that has **no `maxAttempts` key** (`expect(arg).not.toHaveProperty('maxAttempts')` — the "unchanged call shape" contract); with `maxAttempts: 2` forwards `2`; with `'3'` forwards `3`; with `9` forwards `3` (clamped by `parseSendMaxAttempts`); with `''` forwards nothing. Forwarded on the channel-multi path too. `action.tapback` **never** receives `maxAttempts` (`sendTapback` arg has no such key) — pins §9.2. |
+| `src/server/services/automation/meshActionDeps.test.ts` | extend | With a fake manager exposing `sendTextMessage` **and** `messageQueue.enqueue`: no `maxAttempts` → `sendTextMessage` called, `enqueue` **not**; `maxAttempts: 3` + numeric `destination` → `enqueue` called with `(text, dest, replyId, fn, fn, undefined, 3, undefined)` and `sendTextMessage` **not**, return value `{ queued: true, messageId, maxAttempts: 3 }`; `maxAttempts: 3` + **no** destination (channel send) → `sendTextMessage`; a manager with **no** `messageQueue` → `sendTextMessage` (graceful degrade); a MeshCore manager (only `sendMessage`) → MeshCore path, `maxAttempts` ignored, no throw. |
+| `src/server/services/automation/automationSimulator.test.ts` | extend | **Drift guard (no production change in this file):** a dry-run of `action.sendMessage` with `to` + `maxAttempts: 2` returns `resolvedParams.maxAttempts === 2`, proving `recordingDeps()`'s spread carries new deps fields; and the dry-run performs **no** real send (no `messageQueue` reachable from the simulator). |
+| `src/components/automations/catalog.showIf.test.ts` | extend | `EVENT_NUMERIC['trigger.message']` contains `isDM` and `viaMqtt`; `NODE_STRING` contains `node.completeness`; `STRING_OP_OPTIONS` contains `in` and `notIn` and is exported; `action.sendMessage`'s `maxAttempts` field is `kind: 'number'`, `advanced: true`, `showIf` exactly `{ field: 'to', truthy: true }`; `fieldVisible(maxAttemptsField, {})`/`{to: ''}`/`{to: 0}` → false, `{to: '{{ trigger.from }}'}`/`{to: 123}` → true. Existing `truthy`/`equals`/`notEquals` tests pass **unmodified**. |
+| `src/components/automations/AutomationTester.parity.test.tsx` | **new** (model on `AutomationBuilder.emojiMode.test.tsx`) | The Subject-node facts form renders an **HW model** input and writes `facts.hwModel`; a `sendMessage` result with `destination` + `maxAttempts: 3` renders a headline containing `up to 3 attempts`; the same result **without** `maxAttempts`, and a channel result **with** it, do not. |
+| `src/server/services/automation/autoAckParity.test.ts` | **new — the phase's exit criterion** | Holds the §2 table as an in-code `const AUTOACK_PARITY: Record<string, {status: 'exists'\|'phase3'\|'deprecated'\|'notConvertible'; engine: string[]}>`, and asserts: **(a)** its key set equals `VALID_SETTINGS_KEYS.filter(k => k.startsWith('autoAck'))` in **both directions** — a new `autoAck*` key fails this suite until the table is updated; **(b)** every `type:` reference resolves in `TRIGGER_TYPES`/`CONDITION_TYPES`/`ACTION_TYPES`; **(c)** every `param:` reference is a real `FieldDef.name` in that block's `BLOCK_BY_TYPE` entry; **(d)** every `field:` reference appears in `numericFields('trigger.message')`/`stringFields('trigger.message')` flattened; **(e)** every `op:` reference appears in `STRING_OP_OPTIONS` or `NUMERIC_OPS`; **(f)** exactly the rows the table marks `deprecated` are the ten keys migration 093 lists (`src/server/migrations/093_autoack_matrix.ts:29-36` + the two DM-routing keys); **(g)** `SEND_MAX_ATTEMPTS_MIN/MAX === 1/3`, pinning the duplication of `MessageQueueService`'s clamp; **(h)** every key the table marks `phase3` or `exists` names at least one engine reference (no empty promises). |
+
+Also required per CLAUDE.md: full `npx vitest run` green (0 failures, confirmed via `--reporter=json` `success: true`), and `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` empty. **No schema change ⇒ no migration and no PG/MySQL containers needed.** Watch the ratchet: `automationEngineService.ts`'s `no-explicit-any` baseline is 6 — do not add casts; `p.maxAttempts` on a `Record<string, unknown>` needs none.
+
+## 7. Work packages
+
+All agents share **one worktree**. File ownership is exclusive; the parallel trio (WP2 ∥ WP3 ∥ WP4) share no file.
+
+### WP1 — Vocabulary + validation *(must land first; blocks WP2/WP3/WP4)*
+
+**Owns:** `src/types/automation.ts` · `src/types/automation.test.ts`
+**Delivers:** §3.3 and the WP1 row of §6.
+**Hard constraints:** do **not** add a `ConditionType`/`ActionType`; do **not** validate `condition.string`'s `op`. `git diff --stat` shows exactly two files.
+**Acceptance:** an `action.sendMessage` node with no `maxAttempts` validates byte-identically to today; out-of-range errors carry the `∈ [1, 3]` message; `parseSendMaxAttempts` is lenient per §3.3. Full suite green.
+
+### WP2 — Engine conditions: `node.completeness` + `in`/`notIn` *(after WP1; ∥ WP3, WP4)*
+
+**Owns:** `src/server/services/automation/engineContext.ts` · `.../engineContext.test.ts` · `.../conditionEvaluator.ts` · `.../conditionEvaluator.test.ts`
+**Delivers:** §3.1, §3.2, and the WP2 rows of §6.
+**Hard constraints:**
+- Must **not** edit `src/types/automation.ts` (WP1), anything under `src/components/` (WP4), `actionExecutor.ts` / `meshActionDeps.ts` (WP3), `triggerContext.ts`, `automationEngineService.ts`, `meshNodeData.ts`, or any repository.
+- **Must not re-implement `isNodeComplete`** — import it from `src/utils/nodeHelpers.ts`. A local copy of the `'Node !'` prefix check is an automatic reject.
+- The `node.completeness` branch must sit **before** the `if (!node)` guard; every existing `node.*` test must pass unmodified.
+- `in`/`notIn` must be added to `stringCompare` only — no new `case` in `evaluateCondition`, no validation change.
+
+**Acceptance:** the §3.1 tri-state truth table holds including `unknown`; `notIn` on `fromId` reproduces AutoAck's ignore-list semantics for canonical `!xxxxxxxx` tokens with either separator; existing `conditionEvaluator.test.ts` passes unmodified. Full suite green.
+
+### WP3 — `maxAttempts` through the deps boundary *(after WP1; ∥ WP2, WP4)* — **independently droppable, see §9.2**
+
+**Owns:** `src/server/services/automation/actionExecutor.ts` · `.../actionExecutor.test.ts` · `.../meshActionDeps.ts` · `.../meshActionDeps.test.ts` · `.../automationSimulator.test.ts`
+**Delivers:** §3.4, §3.5, and the WP3 rows of §6 (including the simulator drift guard).
+**Hard constraints:**
+- **`automationSimulator.ts` (the source file) must NOT be edited** — only its test. `recordingDeps()`'s spread already carries the field; if the implementer finds themselves editing `recordingDeps`, the design went wrong — stop and escalate.
+- Must **not** edit `src/server/messageQueueService.ts` or `src/server/meshtasticManager.ts`.
+- Must **not** add `maxAttempts` to `ActionDeps.sendTapback` (§9.2).
+- Reach the queue only via the existing `resolveManager(sourceId)` duck-typing. **No `instanceof`, no `as any`** (CLAUDE.md + the `no-explicit-any` ratchet).
+- The unset call shape must be byte-identical: every existing `actionExecutor.test.ts` assertion on `deps.sendMessage`'s argument passes unmodified.
+
+**Acceptance:** a DM with `maxAttempts` enqueues (and only then); everything else takes today's direct path; the dry-run surfaces the param without a simulator source change. Full suite green.
+
+### WP4 — Builder catalog + Test panel *(after WP1; ∥ WP2, WP3)*
+
+**Owns:** `src/components/automations/catalog.ts` · `.../catalog.showIf.test.ts` · `.../AutomationTester.tsx` · `.../AutomationTester.parity.test.tsx` (new)
+**Delivers:** §5 and the WP4 rows of §6.
+**Hard constraints:**
+- Must **not** edit `AutomationBuilder.tsx`, `compile.ts`, `tokenHints.ts`, or anything under `src/server/` or `src/types/`. Use string literals with a comment pointing at the server-side constant, exactly as Phase 1 did for `emojiMode` and Phase 2 for `cooldownScope`. **`AutomationBuilder.tsx` in `git diff --stat` is a design failure — stop and escalate.**
+- Do **not** add a new `showIf` operator; reuse `truthy`.
+- Do **not** rely on `FieldDef.advanced` for visibility — it is still never read.
+- Does **not** deploy or drive the dev container; browser validation is the orchestrator's stage.
+
+**Acceptance:** the four new picker options and two new operators are present and asserted; the `maxAttempts` field hides until `to` is set; the Tester exposes `hwModel` and reports the attempt cap. Full suite green.
+
+### WP5 — Parity table, docs, epic close *(after WP2, WP3, WP4 all land)*
+
+**Owns:** `src/server/services/automation/autoAckParity.test.ts` (new) · `docs/features/automation-engine.md` · `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`
+
+**Delivers:**
+- The §6 `autoAckParity.test.ts` file — the phase's exit criterion. Its in-code table **must** be a faithful copy of §2, with a comment in each file pointing at the other.
+- `docs/features/automation-engine.md`: under **Conditions** (`:162`) document `node.completeness` (the three states, why `unknown` exists, the `in complete, unknown` idiom) and the `is one of` / `isn't one of` operators (separators, case-insensitivity, exact-token matching, empty-list semantics); note the new `isDM` / `viaMqtt` numeric fields and the `1/0` idiom; under **Send a message** (`:216`) document `maxAttempts` including the Meshtastic-DM-only restriction and the 30s queue throttle it opts into.
+- `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`: flip Phase 3 to `[x] complete`; **paste §2's mapping table verbatim** (the exit criterion says it lives in the epic doc); add a **Phase 3 close** block under *Notes / deviations* recording: the no-new-condition-type decision and the tri-state argument; the `in`/`notIn` genericity choice; the `autoAckMaxAttempts` discovery (it is a queue setting, not an AutoAck setting) and the `ActionDeps` growth with the reason `recordingDeps()` needed no edit; the `isDM`/`viaMqtt` picker gap and the `fieldselect` clobbering it prevents; and the four Phase 4 converter obligations (regex default, cooldown default 60, channel index→name, `hops > 0` as a **branch** so no-hop-info lands in ZeroHop).
+
+**Acceptance:** §2's table appears in the epic doc; `autoAckParity.test.ts` fails if a row is removed or an `autoAck*` key is added; every field label, option label, and operator label quoted in the docs matches the shipped catalog verbatim; the `autoAckTestMessages` and `autoAckMaxAttempts` rows are documented honestly, not glossed.
+
+**Dependency graph:** `WP1 → (WP2 ∥ WP3 ∥ WP4) → WP5`
+
+## 8. Explicit non-goals
+
+- **No `maxAttempts` on `action.tapback`.** AutoAck's own tapback hardcodes `1` (`:10207`). Adding it would give the engine a capability AutoAck deliberately lacks — anti-parity — and grow `ActionDeps.sendTapback` for nothing.
+- **No queueing of channel sends.** AutoAck's channel reply *does* go through the queue (rate-limited, `maxAttempts` forced to 1), so a converted channel-reply automation still sends without the 30s throttle. A documented divergence, in the direction of promptness, and not something `autoAckMaxAttempts` expresses. Note it in the epic as a candidate.
+- **`MessageQueueService`'s clamp is not refactored** to import `SEND_MAX_ATTEMPTS_*`. It is load-bearing for #4266 and reads its setting synchronously; the duplication is pinned by a test instead.
+- **No `in`/`notIn` on `condition.numeric`.** `NUMERIC_OPS` is a validated union and `fromId` covers the node case in AutoAck's own notation.
+- **No `condition.string` `op` validation.** Unvalidated today; adding it would reject stored graphs (same call Phase 2 made for `cooldownSeconds`).
+- **The `ignored_nodes` table is not exposed as a condition.** It is the #4115 geo-ignore/manual blocklist, a different feature that AutoAck never consults (§9.3). `node.isIgnored` *does* resolve today through `resolveFieldValue`'s raw-row passthrough (`NodesRepository.getNode` does a full `.select()`), but it is not in the picker and is not pinned by any test — a candidate follow-up, not this phase.
+- **`deriveHops()` is still not guarded.** Phase 1 recorded why; the `hops > 0` **branch** in §3.6 is the conversion answer, not an engine change.
+- **MeshCore auto-ack parity** (`meshcoreAutoAck*`) remains out of scope, per the 2×2 plan.
+- **The engine's missing payload-length check** (`MAX_MESSAGE_BYTES`, Phase 1 close) is unchanged here.
+- **`geofenceState` / `autoAckCooldowns` unbounded growth** — still the Phase 2 follow-up, still without an issue filed as of this spec.
+
+## 9. Contradictions and findings against the original brief
+
+1. **The two "new conditions" the epic named should not be new conditions.** *(Sign-off requested.)* `condition.nodeComplete` becomes a `node.completeness` computed field, and the node-in-list condition becomes `in`/`notIn` operators on `condition.string`. Beyond the reuse argument, the field version is **more correct**: AutoAck skips only when the node row exists *and* is incomplete (`:10084`), so a faithful conversion needs three states. A boolean `node.isComplete` collapses "row missing" and "row incomplete" into the same `undefined`/`NaN`, and `condition.numeric` returns **false for both `== 1` and `== 0`** on `NaN` — meaning neither "is complete" nor "is not complete" could be expressed for an unknown sender. The generic operators additionally serve node names, `roleName`, `channelName`, `telemetryType`, and system `event` at no extra cost. Precedent acknowledged: `condition.meshcoreScope` **is** a narrow block — but its data (`scopeCode`/`scopeName` semantics) is not reachable generically; `node.completeness` is.
+2. **`maxAttempts` forces `ActionDeps` to change, breaking Phases 1 and 2's rule.** *(Sign-off requested.)* `ActionDeps.sendMessage`'s argument object gains an optional `maxAttempts`. **However, `automationSimulator.ts` needs no code change** — `recordingDeps()` returns `{ action: 'sendMessage', ...a }` (`:112`), so the field reaches the dry-run automatically; WP3 adds a test pinning that so it cannot silently drift. The deeper finding is that the brief's premise was wrong twice over: `autoAckMaxAttempts` is a `MessageQueueService` per-source setting that `checkAutoAcknowledge` never reads, and the engine has never used the queue at all (`meshActionDeps` calls `sendTextMessage` directly). Making the param real therefore means opting a Meshtastic **DM** send into the queue — which also opts it into the queue's 30s inter-send interval and turns the run-log entry from a packet id into `{ queued: true, … }`. All three are exactly how AutoAck already behaves, which is the parity being bought, but they are behaviour, not plumbing. **WP3 is therefore scoped so it can be dropped whole:** if the orchestrator declines, drop WP3 + WP1's `sendMessage` validation case + WP4's `maxAttempts` field, and row 21 of §2 flips to *not convertible — it is a per-source queue setting that survives conversion and keeps governing the source's other automated DMs*.
+3. **The two ignore lists are unrelated, confirmed.** `autoAckIgnoredNodes` is a per-source *setting string* parsed inline at `:10037-10051`, used only by auto-ack. The #4115 list is the `ignored_nodes` *table* (`src/db/schema/ignoredNodes.ts`, migration 048, PK `(nodeNum, sourceId)`, `reason ∈ {'manual','geo'}`, `IgnoredNodesRepository`, `ignoredNodeRoutes.ts`), mirrored to `nodes.isIgnored` — the app-wide blocklist. **`checkAutoAcknowledge` never consults it.** Converting the setting therefore means baking a literal list into the graph, which is precisely what `notIn` does.
+4. **The 2×2 matrix is *not* fully expressible today, contradicting "already covered".** `isDM` and `viaMqtt` resolve at runtime but are absent from the builder's field picker (`catalog.ts:183-186`), and `fieldselect` renders a plain `<select>` (`AutomationBuilder.tsx:89-99`) — a converter-written `condition.numeric` on `isDM` would show blank and be **overwritten on the first edit**, which would silently break a converted automation the moment a user opened it. `viaMqtt` is required, not optional: `isZeroHop = hopsTraveled === 0 && !viaMqtt` (`:10141`).
+5. **`autoAckMaxAttempts` never reaches `messageQueue.enqueue` from the auto-ack path.** The reply enqueue (`:10248-10259`) passes six arguments and no override; the tapback enqueue (`:10196-10209`) passes an explicit `1`. The clamp lives in `MessageQueueService.resolveDmMaxAttempts()` (`:75-85`) and fires for any DM enqueued on that source with no override.
+6. **`autoAckTestMessages` has no server reader.** Only `AutoAcknowledgeSection.tsx`, `AutomationTab.tsx`, `AutomationContext.tsx`, and `App.tsx` touch it, and it is **not** in `PER_SOURCE_SETTINGS_KEYS`. It is a UI scratchpad. The only honest table entry is *not convertible, and does not need to be*.
+7. **Two deprecated keys are global-only.** `autoAckTapbackEnabled` and `autoAckReplyEnabled` are in `VALID_SETTINGS_KEYS` but **not** in `PER_SOURCE_SETTINGS_KEYS`, unlike the other eight deprecated keys. Migration 093 reads the per-source ones; these two are pure legacy globals. Recorded so the Phase 4 converter does not go looking for per-source values that were never written.
+8. **A no-hop-info packet converts wrong unless the ZeroHop rule is a `false` branch.** AutoAck floors `hopsTraveled` to `0` when `hopStart`/`hopLimit` are absent or inverted (`:10127-10134`) and treats it as **ZeroHop**; the engine's `hops` is `undefined` there, so `== 0` and `> 0` are **both** false and the message would match no cell at all. §3.6's single `condition.numeric hops > 0` with `true`/`false` ports fixes this with no engine change. Phase 4 obligation.
+9. **`condition.string`'s `eq`/`neq` are case-*sensitive* while every other operator lowercases** (`conditionEvaluator.ts:35-41`). Pre-existing, not changed here. Harmless for `node.completeness` (lowercase constants) and for `fromId` (lowercase hex), but the new `in`/`notIn` deliberately follow the *majority* (case-insensitive) behaviour, and the docs must say so.
+10. **`meshNodeData.getNode` passes `sourceId ?? undefined`**, which becomes an **unscoped** lookup under the composite `(nodeNum, sourceId)` PK when `sourceId` is null — the exact hazard `:10081-10082` warns about in AutoAck. Not reachable for `trigger.message` (its `sourceId` is always set) and pre-existing, so **not changed** here; recorded because `node.completeness` inherits it and a future source-less trigger with a subject node would expose it.
+
+### Critical Files for Implementation
+
+- `/home/yeraze/Development/meshmonitor-autoack-parity/src/server/services/automation/engineContext.ts`
+- `/home/yeraze/Development/meshmonitor-autoack-parity/src/server/services/automation/conditionEvaluator.ts`
+- `/home/yeraze/Development/meshmonitor-autoack-parity/src/server/services/automation/meshActionDeps.ts`
+- `/home/yeraze/Development/meshmonitor-autoack-parity/src/components/automations/catalog.ts`
+- `/home/yeraze/Development/meshmonitor-autoack-parity/src/types/automation.ts`

--- a/src/components/automations/AutomationTester.parity.test.tsx
+++ b/src/components/automations/AutomationTester.parity.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * AutomationTester — Phase 3 parity additions (#4340 WP4 §5.3).
+ *
+ * Two one-liners from the spec:
+ *  - `hwModel` joins the Subject-node facts form (`buildNode()`'s `numFact`
+ *    list) so a dry-run of `node.completeness` doesn't report a false
+ *    'incomplete' for an otherwise-complete synthetic node — isNodeComplete()
+ *    (src/utils/nodeHelpers.ts) requires an hwModel.
+ *  - The `action.sendMessage` result headline reports the DM resend cap
+ *    (`maxAttempts`, added to `action.sendMessage` by WP3/catalog.ts) when
+ *    present, proving the param crossed the deps boundary into the dry-run.
+ *
+ * Modeled on AutomationBuilder.emojiMode.test.tsx's rendering conventions,
+ * but drives AutomationTester directly — this file owns AutomationTester.tsx,
+ * not AutomationBuilder.tsx (#4340 Phase 3 §7 WP4 hard constraint).
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AutomationTester, { type SimResult } from './AutomationTester';
+
+vi.mock('../../services/api', () => ({
+  default: { post: vi.fn() },
+}));
+
+import apiService from '../../services/api';
+
+const mockedPost = apiService.post as unknown as ReturnType<typeof vi.fn>;
+
+function baseConfig() {
+  return { ok: true as const, config: { trigger: { type: 'trigger.message', params: {} }, rules: [] }, triggerType: 'trigger.message' };
+}
+
+function renderTester() {
+  return render(<AutomationTester getConfig={baseConfig} variables={[]} sources={[]} />);
+}
+
+function simResult(actions: SimResult['actions']): SimResult {
+  return {
+    matched: true,
+    status: 'completed',
+    triggerType: 'trigger.message',
+    fields: {},
+    conditionResults: {},
+    actions,
+    variableWrites: [],
+    steps: [],
+  };
+}
+
+describe('AutomationTester — subject-node hwModel fact (#4340 Phase 3)', () => {
+  beforeEach(() => {
+    mockedPost.mockReset();
+    mockedPost.mockResolvedValue(simResult([]));
+  });
+
+  it('renders an "HW model (#)" input under Subject-node facts', async () => {
+    const user = userEvent.setup();
+    renderTester();
+    await user.click(screen.getByText(/Subject-node facts & variable overrides/));
+    expect(screen.getByText('HW model (#)')).toBeInTheDocument();
+  });
+
+  it('forwards the entered hwModel as a numeric node fact on the test POST body', async () => {
+    const user = userEvent.setup();
+    renderTester();
+    await user.click(screen.getByText(/Subject-node facts & variable overrides/));
+
+    const label = screen.getByText('HW model (#)');
+    const input = label.closest('.ae-field')?.querySelector('input');
+    if (!input) throw new Error('HW model input not found');
+    await user.type(input, '43');
+
+    await user.click(screen.getByRole('button', { name: /run test/i }));
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalled());
+    const body = mockedPost.mock.calls[0][1] as { node?: Record<string, unknown> };
+    expect(body.node?.hwModel).toBe(43);
+  });
+});
+
+describe('AutomationTester — action.sendMessage headline reports maxAttempts (#4340 Phase 3)', () => {
+  beforeEach(() => {
+    mockedPost.mockReset();
+  });
+
+  it('shows "up to N attempts" for a DM result carrying maxAttempts', async () => {
+    const user = userEvent.setup();
+    mockedPost.mockResolvedValue(simResult([
+      { nodeId: 'a1', type: 'action.sendMessage', ok: true, resolvedParams: { destination: 123, maxAttempts: 3, text: 'hi' } },
+    ]));
+    renderTester();
+    await user.click(screen.getByRole('button', { name: /run test/i }));
+
+    await waitFor(() => expect(screen.getByText(/DM to node 123/)).toBeInTheDocument());
+    expect(screen.getByText(/up to 3 attempts/)).toBeInTheDocument();
+  });
+
+  it('omits the attempts clause for a DM result with no maxAttempts', async () => {
+    const user = userEvent.setup();
+    mockedPost.mockResolvedValue(simResult([
+      { nodeId: 'a1', type: 'action.sendMessage', ok: true, resolvedParams: { destination: 123, text: 'hi' } },
+    ]));
+    renderTester();
+    await user.click(screen.getByRole('button', { name: /run test/i }));
+
+    await waitFor(() => expect(screen.getByText(/DM to node 123/)).toBeInTheDocument());
+    expect(screen.queryByText(/attempts/)).not.toBeInTheDocument();
+  });
+
+  it('omits the attempts clause for a channel result even when maxAttempts is set', async () => {
+    const user = userEvent.setup();
+    mockedPost.mockResolvedValue(simResult([
+      { nodeId: 'a1', type: 'action.sendMessage', ok: true, resolvedParams: { channel: 0, maxAttempts: 3, text: 'hi' } },
+    ]));
+    renderTester();
+    await user.click(screen.getByRole('button', { name: /run test/i }));
+
+    await waitFor(() => expect(screen.getByText(/channel 0/)).toBeInTheDocument());
+    expect(screen.queryByText(/attempts/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -95,6 +95,10 @@ export default function AutomationTester({ getConfig, variables, sources }: Prop
     const numFact = (k: string) => { if (facts[k] !== undefined && facts[k] !== '') out[k] = Number(facts[k]); };
     numFact('batteryLevel'); numFact('voltage'); numFact('role'); numFact('hopsAway');
     numFact('channelUtilization'); numFact('airUtilTx'); numFact('snr'); numFact('altitude');
+    // #4340 Phase 3: isNodeComplete() (src/utils/nodeHelpers.ts) requires an
+    // hwModel, so a synthetic node.completeness dry-run reads 'incomplete'
+    // without this — a confusing false negative for an otherwise-complete node.
+    numFact('hwModel');
     if (facts.longName) out.longName = facts.longName;
     if (facts.shortName) out.shortName = facts.shortName;
     if (facts.latitude) out.latitude = Number(facts.latitude);
@@ -165,6 +169,7 @@ export default function AutomationTester({ getConfig, variables, sources }: Prop
             <Field label="Altitude" value={facts.altitude} onChange={(v) => setFact('altitude', v)} type="number" />
             <Field label="Long name" value={facts.longName} onChange={(v) => setFact('longName', v)} />
             <Field label="Short name" value={facts.shortName} onChange={(v) => setFact('shortName', v)} />
+            <Field label="HW model (#)" value={facts.hwModel} onChange={(v) => setFact('hwModel', v)} type="number" />
             <Field label="Latitude" value={facts.latitude} onChange={(v) => setFact('latitude', v)} type="number" />
             <Field label="Longitude" value={facts.longitude} onChange={(v) => setFact('longitude', v)} type="number" />
           </div>
@@ -261,7 +266,10 @@ function ActionView({ a }: { a: SimResult['actions'][number] }) {
   let headline: string = a.type.replace('action.', '');
   let sent: ReactNode = null;
   if (a.type === 'action.sendMessage') {
-    headline = `Send message → ${p.destination != null ? `DM to node ${p.destination}` : `channel ${p.channel ?? 0}`}`;
+    // #4340 Phase 3: maxAttempts (action.sendMessage's DM resend cap, see
+    // catalog.ts) only applies to a DM — proof the param crossed the deps
+    // boundary (§5.3 of the phase 3 spec).
+    headline = `Send message → ${p.destination != null ? `DM to node ${p.destination}${p.maxAttempts ? ` (up to ${p.maxAttempts} attempts)` : ''}` : `channel ${p.channel ?? 0}`}`;
     sent = <div className="ae-test-sent">{String(p.text ?? '')}</div>;
   } else if (a.type === 'action.tapback') {
     // emojiMode=hopCount with no hop info on the trigger records a skip (#4340)

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { fieldVisible, ACTIONS, TRIGGERS, type FieldDef } from './catalog';
+import { fieldVisible, ACTIONS, TRIGGERS, numericFields, stringFields, STRING_OP_OPTIONS, type FieldDef } from './catalog';
 import { HOP_COUNT_EMOJIS } from '../../utils/hopEmoji';
 
 describe('fieldVisible', () => {
@@ -168,5 +168,57 @@ describe('trigger.* cooldownScope catalog entries (#4340 Phase 2)', () => {
     // not five separately-authored copies that could drift apart.
     const fields = COOLDOWN_BEARING_TYPES.map((type) => TRIGGERS.find((t) => t.type === type)?.fields.find((f) => f.name === 'cooldownScope'));
     for (const f of fields) expect(f).toBe(fields[0]);
+  });
+});
+
+// #4340 Phase 3 §5/§6 WP4 — Auto-Ack parity catalog additions: the isDM/viaMqtt
+// numeric fields, the node.completeness string field, the in/notIn string
+// operators, and the maxAttempts field on action.sendMessage.
+describe('Auto-Ack parity catalog additions (#4340 Phase 3)', () => {
+  const flatten = (groups: ReturnType<typeof numericFields>) => groups.flatMap((g) => g.options);
+
+  it('EVENT_NUMERIC for trigger.message includes isDM and viaMqtt', () => {
+    const values = flatten(numericFields('trigger.message')).map((o) => o.value);
+    expect(values).toContain('isDM');
+    expect(values).toContain('viaMqtt');
+  });
+
+  it('NODE_STRING includes node.completeness', () => {
+    const values = flatten(stringFields('trigger.message')).map((o) => o.value);
+    expect(values).toContain('node.completeness');
+  });
+
+  it('STRING_OP_OPTIONS is exported and includes in / notIn', () => {
+    const values = STRING_OP_OPTIONS.map((o) => o.value);
+    expect(values).toContain('in');
+    expect(values).toContain('notIn');
+  });
+
+  describe('action.sendMessage maxAttempts field', () => {
+    const sendMessage = ACTIONS.find((a) => a.type === 'action.sendMessage');
+    const maxAttemptsField = sendMessage?.fields.find((f) => f.name === 'maxAttempts');
+
+    it('exists as an advanced number field', () => {
+      expect(maxAttemptsField).toBeDefined();
+      expect(maxAttemptsField?.kind).toBe('number');
+      expect(maxAttemptsField?.advanced).toBe(true);
+    });
+
+    it('carries showIf exactly { field: "to", truthy: true } — reuses Phase 2\'s operator, no new one', () => {
+      expect(maxAttemptsField?.showIf).toEqual({ field: 'to', truthy: true });
+    });
+
+    it('is hidden until "to" is set (unset / blank / 0)', () => {
+      expect(maxAttemptsField).toBeDefined();
+      expect(fieldVisible(maxAttemptsField as FieldDef, {})).toBe(false);
+      expect(fieldVisible(maxAttemptsField as FieldDef, { to: '' })).toBe(false);
+      expect(fieldVisible(maxAttemptsField as FieldDef, { to: 0 })).toBe(false);
+    });
+
+    it('is visible once "to" is set to a token or a node number', () => {
+      expect(maxAttemptsField).toBeDefined();
+      expect(fieldVisible(maxAttemptsField as FieldDef, { to: '{{ trigger.from }}' })).toBe(true);
+      expect(fieldVisible(maxAttemptsField as FieldDef, { to: 123 })).toBe(true);
+    });
   });
 });

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -183,6 +183,11 @@ const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
   'trigger.message': [
     { value: 'hops', label: 'Hop count' }, { value: 'from', label: 'Sender node #' },
     { value: 'channel', label: 'Channel #' }, { value: 'snr', label: 'SNR' }, { value: 'rssi', label: 'RSSI' },
+    // #4340 Phase 3: booleans compared as 1/0 (the engine's asNumber() coerces
+    // them). Needed to express Auto-Acknowledge's {Channel,Direct} ×
+    // {ZeroHop,MultiHop} matrix, where ZeroHop means hops == 0 AND NOT viaMqtt.
+    { value: 'isDM', label: 'Is a direct message (1 = yes, 0 = channel)' },
+    { value: 'viaMqtt', label: 'Arrived via MQTT (1 = yes, 0 = RF)' },
   ],
   'trigger.telemetry': [{ value: 'value', label: 'Reading value' }, { value: 'nodeNum', label: 'Node #' }],
   'trigger.nodeUpdated': [{ value: 'nodeNum', label: 'Node #' }],
@@ -214,6 +219,9 @@ const NODE_NUMERIC: FieldOpt[] = [
 const NODE_STRING: FieldOpt[] = [
   { value: 'node.longName', label: 'Long name' }, { value: 'node.shortName', label: 'Short name' },
   { value: 'node.nodeId', label: 'Node id' }, { value: 'node.roleName', label: 'Role name (e.g. ROUTER)' },
+  // #4340 Phase 3 — see NODE_COMPLETENESS in engineContext.ts. Three states, so
+  // "complete or not yet known" is expressible with the `is one of` operator.
+  { value: 'node.completeness', label: 'Node info completeness (complete / incomplete / unknown)' },
 ];
 // Latest telemetry of a metric for the subject node.
 const TELEMETRY_FIELDS: FieldOpt[] = [
@@ -248,10 +256,17 @@ const NUMERIC_OP_OPTIONS = [
   { value: '>', label: '> greater than' }, { value: '<', label: '< less than' },
   { value: '>=', label: '≥ at least' }, { value: '<=', label: '≤ at most' },
 ];
-const STRING_OP_OPTIONS = [
+// Exported (one word) so autoAckParity.test.ts (#4340 Phase 3, WP5) can
+// cross-check these labels/values against conditionEvaluator.ts's stringCompare.
+export const STRING_OP_OPTIONS = [
   { value: 'contains', label: 'contains' }, { value: 'eq', label: 'equals' },
   { value: 'startsWith', label: 'starts with' }, { value: 'endsWith', label: 'ends with' },
   { value: 'regex', label: 'matches regex' }, { value: 'notContains', label: "doesn't contain" },
+  // #4340 Phase 3: membership in a comma/whitespace-separated list, mirroring
+  // Auto-Acknowledge's own autoAckIgnoredNodes parser (meshtasticManager.ts,
+  // separators + case-insensitivity) — see conditionEvaluator.ts's `in`/`notIn`.
+  { value: 'in', label: 'is one of (comma list)' },
+  { value: 'notIn', label: "isn't one of (comma list)" },
 ];
 
 // ─── Conditions (IF) ─────────────────────────────────────────────────────────
@@ -381,6 +396,14 @@ export const ACTIONS: BlockDef[] = [
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
       { name: 'replyToTrigger', label: 'Reply to the triggering message', kind: 'checkbox', advanced: true, help: 'Meshtastic: threads the reply as a tapback. MeshCore has no tapback, so instead it auto-prepends the @[sender]: mention (using {{ trigger.senderLabel }} — sender name, else channel name, else id) to your text, so you don’t have to write it yourself. An existing @[…] mention in your text = no change.' },
+      {
+        name: 'maxAttempts', label: 'DM resend attempts', kind: 'number', advanced: true,
+        placeholder: '1', // 1–3; mirrors SEND_MAX_ATTEMPTS_* in src/types/automation.ts.
+        // Only meaningful for a DM — the queue hardcodes 1 attempt for channel
+        // sends. Reuses Phase 2's showIf.truthy so an unset/blank/0 `to` hides it.
+        showIf: { field: 'to', truthy: true },
+        help: 'Resend this DM (1–3) until the recipient ACKs it — the same retry Auto-Acknowledge uses. Leave blank for a single send. Setting it routes the DM through the source’s outgoing queue, which also spaces sends 30 seconds apart. Meshtastic DMs only: ignored for channel messages and MeshCore.',
+      },
       {
         name: 'scopeMode', label: 'MeshCore scope', kind: 'select', advanced: true,
         options: [

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -764,6 +764,83 @@ describe('executeAction', () => {
     expect(calls[0].args).toMatchObject({ sourceId: 'srcB', channel: 3 });
   });
 
+  // ── maxAttempts (#4340 Phase 3, WP3 §3.4) ───────────────────────────────
+  describe('sendMessage: maxAttempts forwarding', () => {
+    it('no maxAttempts param ⇒ the call shape has no maxAttempts key at all (unchanged behavior contract)', async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}' }),
+        ctx({ from: 5, channel: 1, isDM: true }),
+        deps,
+      );
+      expect(calls[0].args).not.toHaveProperty('maxAttempts');
+    });
+
+    it('maxAttempts: 2 forwards 2', async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', maxAttempts: 2 }),
+        ctx({ from: 5, channel: 1, isDM: true }),
+        deps,
+      );
+      expect(calls[0].args.maxAttempts).toBe(2);
+    });
+
+    it("maxAttempts: '3' (string) forwards 3", async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', maxAttempts: '3' }),
+        ctx({ from: 5, channel: 1, isDM: true }),
+        deps,
+      );
+      expect(calls[0].args.maxAttempts).toBe(3);
+    });
+
+    it('maxAttempts: 9 is clamped to 3 by parseSendMaxAttempts', async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', maxAttempts: 9 }),
+        ctx({ from: 5, channel: 1, isDM: true }),
+        deps,
+      );
+      expect(calls[0].args.maxAttempts).toBe(3);
+    });
+
+    it("maxAttempts: '' (blank) forwards nothing — no maxAttempts key", async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', maxAttempts: '' }),
+        ctx({ from: 5, channel: 1, isDM: true }),
+        deps,
+      );
+      expect(calls[0].args).not.toHaveProperty('maxAttempts');
+    });
+
+    it('is forwarded on the channel-multi (source×channel matrix) path too', async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.sendMessage', { text: 'hi', sourceIds: ['A', 'B'], channels: [{ name: 'gauntlet', protocol: 'meshtastic' }], maxAttempts: 2 }),
+        ctxWithChannels({
+          A: [{ id: 2, name: 'gauntlet', role: 2 }],
+          B: [{ id: 5, name: 'gauntlet', role: 2 }],
+        }, { A: 'meshtastic', B: 'meshtastic' }),
+        deps,
+      );
+      expect(calls).toHaveLength(2);
+      expect(calls.every((c) => c.args.maxAttempts === 2)).toBe(true);
+    });
+
+    it('action.tapback never receives maxAttempts, even when params carry one (§9.2)', async () => {
+      const { calls, deps } = recorder();
+      await executeAction(
+        node('action.tapback', { emoji: '👍', maxAttempts: 3 }),
+        ctx({ from: 5, channel: 3, packetId: 99, isDM: true }),
+        deps,
+      );
+      expect(calls[0].args).not.toHaveProperty('maxAttempts');
+    });
+  });
+
   it('nothing: is a no-op that calls no deps', async () => {
     const { calls, deps } = recorder();
     await expect(executeAction(node('action.nothing', {}), ctx({ from: 5 }), deps)).resolves.toBeUndefined();

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -6,7 +6,7 @@
  * logic (DM vs channel, target source/node resolution, tapback replyId) is
  * unit-tested without a live node. The real deps wiring lives in meshActionDeps.ts.
  */
-import { type AutomationNode, AUTOMATION_DELAY_MAX_SECONDS } from '../../../types/automation.js';
+import { type AutomationNode, AUTOMATION_DELAY_MAX_SECONDS, parseSendMaxAttempts } from '../../../types/automation.js';
 import { type EngineEvalContext, interpolateAsync, resolveOperand } from './engineContext.js';
 import { isTxDisabledError } from '../../errors/txDisabledError.js';
 import { hopCountEmoji } from '../../../utils/hopEmoji.js';
@@ -28,6 +28,14 @@ export interface ActionDeps {
     /** MeshCore scope/region override (#3833). undefined = inherit channel/default;
      *  '' = explicit unscoped; non-empty = that region. Ignored by Meshtastic. */
     scopeOverride?: string | null;
+    /**
+     * App-level DM resend cap (#4340 Phase 3), 1–3. Absent = one direct send —
+     * today's behaviour for every existing automation. Honoured ONLY for a
+     * Meshtastic DM: the retry machinery is MessageQueueService, which hardcodes
+     * maxAttempts=1 for channel sends, and MeshCore has no queue at all. See
+     * meshActionDeps.sendTextVia.
+     */
+    maxAttempts?: number;
   }): Promise<unknown>;
   sendTapback(a: {
     sourceId: string | null;
@@ -261,6 +269,12 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       // thus the run-log resolvedParams and existing tests — is unchanged.
       const scopeArg = scopeOverride !== undefined ? { scopeOverride } : {};
 
+      // #4340 Phase 3. Only forward the key when set, so the default (unset)
+      // call shape — and thus the run-log resolvedParams and every existing
+      // test — is unchanged. Same trick as scopeArg above.
+      const attempts = parseSendMaxAttempts(p.maxAttempts);
+      const attemptsArg = attempts !== undefined ? { maxAttempts: attempts } : {};
+
       // Target sources: explicit multi-select, else the legacy single source /
       // the triggering source.
       const sourceIds = Array.isArray(p.sourceIds) && p.sourceIds.length > 0
@@ -293,7 +307,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           // channel broadcasts, so dropping the override on a DM is correct, not a leak.
           // A channel-only fallback send (no `to`) still honors the scope override.
           const fallbackScope = destination != null ? {} : scopeArg;
-          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope }));
+          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope, ...attemptsArg }));
           continue;
         }
         const srcChannels = (await ctx.data.getChannels?.(sid)) ?? [];
@@ -301,7 +315,7 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
           if (sel.protocol && proto && sel.protocol !== proto) continue; // wrong-protocol channel
           const match = srcChannels.find((c) => c.name.toLowerCase() === sel.name.toLowerCase() && c.role !== 0);
           if (!match) continue; // channel not present on this source
-          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: match.id, destination, replyId, ...scopeArg }));
+          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: match.id, destination, replyId, ...scopeArg, ...attemptsArg }));
         }
       }
 

--- a/src/server/services/automation/autoAckParity.test.ts
+++ b/src/server/services/automation/autoAckParity.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Auto-Acknowledge ↔ Automation Engine parity (#4340 Phase 3, WP5).
+ *
+ * This is the phase's EXIT CRITERION, not a nicety. `AUTOACK_PARITY` below is
+ * an in-code copy of the mapping table in
+ * `docs/internal/dev-notes/AUTOACK_PARITY_PHASE3_SPEC.md` §2, which is itself
+ * pasted verbatim into `docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md`
+ * under the "Phase 3 close" notes. All three copies must describe the same 33
+ * `autoAck*` settings keys. If you change one, change all three.
+ *
+ * The tests below make the parity claim MECHANICAL:
+ *  - it fails if a row is deleted from this table while its key is still in
+ *    `VALID_SETTINGS_KEYS` (a) below;
+ *  - it fails the moment a new `autoAck*` key is added to
+ *    `VALID_SETTINGS_KEYS` without a corresponding row here (a);
+ *  - every `type:`/`param:`/`field:`/`op:` reference embedded in a row's
+ *    `engine` array is cross-checked against the SHIPPED catalog
+ *    (`src/components/automations/catalog.ts`) and engine vocabulary
+ *    (`src/types/automation.ts`), not against the spec — so a catalog rename
+ *    breaks this file, not just the docs.
+ *
+ * This table is Phase 4's input: the AutoAck → Automation converter reads the
+ * `status` and `engine` columns to know what it must emit.
+ */
+import { describe, it, expect } from 'vitest';
+import { VALID_SETTINGS_KEYS, PER_SOURCE_SETTINGS_KEYS } from '../../constants/settings.js';
+import {
+  TRIGGER_TYPES,
+  CONDITION_TYPES,
+  ACTION_TYPES,
+  SEND_MAX_ATTEMPTS_MIN,
+  SEND_MAX_ATTEMPTS_MAX,
+  type NumericOp,
+} from '../../../types/automation.js';
+import {
+  BLOCK_BY_TYPE,
+  numericFields,
+  stringFields,
+  STRING_OP_OPTIONS,
+} from '../../../components/automations/catalog.js';
+
+/**
+ * Mirrors NUMERIC_OP_OPTIONS in src/components/automations/catalog.ts (not
+ * exported there — only STRING_OP_OPTIONS is, per §5.1 of the Phase 3 spec).
+ * Typed against `NumericOp` so a change to that union fails this file at
+ * compile time rather than silently going stale.
+ */
+const NUMERIC_OPS: readonly NumericOp[] = ['==', '!=', '>', '<', '>=', '<='];
+
+type ParityStatus = 'exists' | 'phase3' | 'deprecated' | 'notConvertible';
+
+interface ParityRow {
+  /** Membership in PER_SOURCE_SETTINGS_KEYS. */
+  perSource: boolean;
+  status: ParityStatus;
+  /**
+   * Free-form description PLUS zero or more machine-checked references:
+   *   'type:<TriggerType|ConditionType|ActionType>'
+   *   'param:<blockType>.<FieldDef.name>'   (FieldDef.name in that block's fields)
+   *   'field:<name>'                        (a numericFields/stringFields('trigger.message') option)
+   *   'op:<value>'                          (a STRING_OP_OPTIONS/NUMERIC_OPS value)
+   * Untagged strings are documentation only and are not validated.
+   */
+  engine: string[];
+}
+
+/**
+ * §2 of AUTOACK_PARITY_PHASE3_SPEC.md, verbatim. 33 keys — every
+ * `VALID_SETTINGS_KEYS` entry beginning `autoAck`.
+ */
+const AUTOACK_PARITY: Record<string, ParityRow> = {
+  // 1
+  autoAckEnabled: {
+    perSource: true, status: 'exists',
+    engine: ["the automation's own enabled column", 'type:condition.sourceFilter'],
+  },
+  // 2 — AutoAck defaults to ^(test|ping) when blank; the engine's blank regex means
+  // "match anything". Converter must emit the literal default.
+  autoAckRegex: {
+    perSource: true, status: 'exists',
+    engine: ['type:trigger.message', 'param:trigger.message.regex'],
+  },
+  // 3 — token dialects differ ({NUMBER_HOPS}/{TIME}/{NODE_NAME} vs {{ trigger.hops }}/
+  // {{ NOW }}/{{ trigger.fromName }}); Phase 4 translation work.
+  autoAckMessage: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.sendMessage', 'param:action.sendMessage.text'],
+  },
+  // 4 — a second action.sendMessage on the ZeroHop+RespondViaDM branch.
+  autoAckMessageDirect: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.sendMessage', 'param:action.sendMessage.text'],
+  },
+  // 5 — AutoAck stores channel indices; trigger.message.channels is unified by name.
+  autoAckChannels: {
+    perSource: true, status: 'exists',
+    engine: ['type:trigger.message', 'param:trigger.message.channels'],
+  },
+  // 6 — deprecated; migration 093 folds it into the Direct* cells.
+  autoAckDirectMessages: { perSource: true, status: 'deprecated', engine: [] },
+  // 7 — deprecated; folded into the *ReplyDmEnabled cells.
+  autoAckUseDM: { perSource: true, status: 'deprecated', engine: [] },
+  // 8 — tri-state required for fidelity: AutoAck skips only when the row EXISTS
+  // and is incomplete. `complete, unknown` reproduces that exactly (§9.1).
+  autoAckSkipIncompleteNodes: {
+    perSource: true, status: 'phase3',
+    engine: ['type:condition.string', 'field:node.completeness', 'op:in'],
+  },
+  // 9 — in/notIn split on the same separators + casing as AutoAck's own parser.
+  // Converter normalises each entry to canonical !xxxxxxxx.
+  autoAckIgnoredNodes: {
+    perSource: true, status: 'phase3',
+    engine: ['type:condition.string', 'field:fromId', 'op:notIn'],
+  },
+  // 10 — global-only (NOT in PER_SOURCE_SETTINGS_KEYS); deprecated.
+  autoAckTapbackEnabled: { perSource: false, status: 'deprecated', engine: [] },
+  // 11 — global-only; deprecated.
+  autoAckReplyEnabled: { perSource: false, status: 'deprecated', engine: [] },
+  // 12-17 — deprecated; migration 093 folds these hop-only keys into the 2x2 matrix.
+  autoAckDirectEnabled: { perSource: true, status: 'deprecated', engine: [] },
+  autoAckDirectTapbackEnabled: { perSource: true, status: 'deprecated', engine: [] },
+  autoAckDirectReplyEnabled: { perSource: true, status: 'deprecated', engine: [] },
+  autoAckMultihopEnabled: { perSource: true, status: 'deprecated', engine: [] },
+  autoAckMultihopTapbackEnabled: { perSource: true, status: 'deprecated', engine: [] },
+  autoAckMultihopReplyEnabled: { perSource: true, status: 'deprecated', engine: [] },
+  // 18 — NOT CONVERTIBLE, AND DOES NOT NEED TO BE. No server code reads this key —
+  // it is a UI scratchpad on AutoAcknowledgeSection.tsx for pasting sample text.
+  // Its "engine analogue" (the Test panel) is a mechanism, not a setting, so there
+  // is deliberately no equivalent recorded here.
+  autoAckTestMessages: { perSource: false, status: 'notConvertible', engine: [] },
+  // 19 — AutoAck's default is 60s when unset; the engine's is 0. Converter must
+  // emit 60 explicitly. cooldownScope:'node' is mandatory (AutoAck keys by fromNum).
+  autoAckCooldownSeconds: {
+    perSource: true, status: 'exists',
+    engine: ['type:trigger.message', 'param:trigger.message.cooldownSeconds', 'param:trigger.message.cooldownScope'],
+  },
+  // 20 — AutoAck's delay is non-blocking and independently applied to tapback+reply;
+  // action.delay blocks its own run and caps at 300s. A converted chain needs it once.
+  autoAckPreSendDelaySeconds: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.delay', 'param:action.delay.seconds'],
+  },
+  // 21 — READ THIS ROW CAREFULLY. checkAutoAcknowledge NEVER reads this setting.
+  // MessageQueueService.resolveDmMaxAttempts() reads it per-source and applies it
+  // to EVERY queued DM on that source (auto-responder, welcome, mailbox, AND the
+  // AutoAck reply when — and only when — that reply is a DM). AutoAck's own
+  // tapback hardcodes 1 ("tapbacks are best-effort, don't retry") and its channel
+  // sends hardcode 1 too (messageQueueService.ts). So maxAttempts on
+  // action.sendMessage was NOT required for converter fidelity — the user was
+  // shown that trade-off explicitly (spec §9.2, orchestrator sign-off) and chose
+  // to ship it anyway, as a capability in its own right, not a parity gap-filler.
+  // Converting AutoAck itself does not need to touch this row: the setting keeps
+  // governing the source's OTHER queued DMs after conversion regardless.
+  autoAckMaxAttempts: {
+    perSource: true, status: 'phase3',
+    engine: ['type:action.sendMessage', 'param:action.sendMessage.maxAttempts'],
+  },
+  // 22 — cell = isDM==0 AND hops==0 AND viaMqtt==0. Phase 3 adds isDM/viaMqtt to
+  // the field picker (they already resolved at runtime, but a converter-written
+  // value rendered blank and was clobbered on first edit — see spec §9 finding 4).
+  autoAckChannelZeroHopReplyEnabled: {
+    perSource: true, status: 'phase3',
+    engine: ['type:action.sendMessage', 'field:isDM', 'field:viaMqtt', 'field:hops', 'op:=='],
+  },
+  // 23 — same cell → action.tapback emojiMode:'hopCount'.
+  autoAckChannelZeroHopTapbackEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.tapback', 'param:action.tapback.emojiMode'],
+  },
+  // 24 — that cell's action.sendMessage gets to: {{ trigger.from }}.
+  autoAckChannelZeroHopReplyDmEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.sendMessage', 'param:action.sendMessage.to'],
+  },
+  // 25 — cell = isDM==0 AND NOT(hops==0 AND viaMqtt==0). See spec §3.6: the
+  // hops>0 BRANCH (not two independent conditions) is required so a packet
+  // with no hop info (undefined → NaN) still lands in ZeroHop, matching AutoAck.
+  autoAckChannelMultiHopReplyEnabled: {
+    perSource: true, status: 'phase3',
+    engine: ['type:action.sendMessage', 'field:isDM', 'field:viaMqtt', 'field:hops', 'op:=='],
+  },
+  autoAckChannelMultiHopTapbackEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.tapback', 'param:action.tapback.emojiMode'],
+  },
+  autoAckChannelMultiHopReplyDmEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.sendMessage', 'param:action.sendMessage.to'],
+  },
+  // 28 — cell = isDM==1 AND hops==0 AND viaMqtt==0.
+  autoAckDirectZeroHopReplyEnabled: {
+    perSource: true, status: 'phase3',
+    engine: ['type:action.sendMessage', 'field:isDM', 'field:viaMqtt', 'field:hops', 'op:=='],
+  },
+  autoAckDirectZeroHopTapbackEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.tapback', 'param:action.tapback.emojiMode'],
+  },
+  // 30 — no-op for Direct cells (a DM reply is inherently a DM); converter emits
+  // to: {{ trigger.from }} regardless.
+  autoAckDirectZeroHopReplyDmEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['param:action.sendMessage.to'],
+  },
+  autoAckDirectMultiHopReplyEnabled: {
+    perSource: true, status: 'phase3',
+    engine: ['type:action.sendMessage', 'field:isDM', 'field:viaMqtt', 'field:hops', 'op:=='],
+  },
+  autoAckDirectMultiHopTapbackEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['type:action.tapback', 'param:action.tapback.emojiMode'],
+  },
+  autoAckDirectMultiHopReplyDmEnabled: {
+    perSource: true, status: 'exists',
+    engine: ['param:action.sendMessage.to'],
+  },
+};
+
+/**
+ * Deprecated by migration 093 (src/server/migrations/093_autoack_matrix.ts).
+ * Mirrors its `LEGACY_SUFFIXES` array (:29-36 there — everything EXCEPT
+ * `autoAckEnabled`, which the migration reads as an input signal but does not
+ * itself deprecate) plus the two global-only DM-routing keys
+ * (`autoAckTapbackEnabled`, `autoAckReplyEnabled`) that predate the matrix and
+ * are NOT in `LEGACY_SUFFIXES` because they are global-only, never per-source,
+ * so the migration's per-source translation never touches them (spec §9
+ * finding 7). Hardcoded rather than imported: this test owns only itself, and
+ * `093_autoack_matrix.ts` does not export `LEGACY_SUFFIXES`.
+ */
+const EXPECTED_DEPRECATED_KEYS = [
+  'autoAckDirectMessages',
+  'autoAckUseDM',
+  'autoAckDirectEnabled',
+  'autoAckDirectTapbackEnabled',
+  'autoAckDirectReplyEnabled',
+  'autoAckMultihopEnabled',
+  'autoAckMultihopTapbackEnabled',
+  'autoAckMultihopReplyEnabled',
+  'autoAckTapbackEnabled',
+  'autoAckReplyEnabled',
+].sort();
+
+describe('autoAckParity (#4340 Phase 3 exit criterion)', () => {
+  const settingsAutoAckKeys = (VALID_SETTINGS_KEYS as readonly string[]).filter((k) => k.startsWith('autoAck'));
+  const tableKeys = Object.keys(AUTOACK_PARITY);
+
+  it('(a) has exactly one row per autoAck* key in VALID_SETTINGS_KEYS, both directions', () => {
+    // A key removed from AUTOACK_PARITY while still in VALID_SETTINGS_KEYS...
+    const missingFromTable = settingsAutoAckKeys.filter((k) => !tableKeys.includes(k));
+    expect(missingFromTable, `keys in VALID_SETTINGS_KEYS but missing from AUTOACK_PARITY: ${missingFromTable.join(', ')}`).toEqual([]);
+    // ...and a new autoAck* key added to VALID_SETTINGS_KEYS without a row here.
+    const extraInTable = tableKeys.filter((k) => !settingsAutoAckKeys.includes(k));
+    expect(extraInTable, `keys in AUTOACK_PARITY but not in VALID_SETTINGS_KEYS: ${extraInTable.join(', ')}`).toEqual([]);
+    expect(tableKeys.length).toBe(33);
+  });
+
+  it('perSource flag matches PER_SOURCE_SETTINGS_KEYS membership for every row', () => {
+    const perSourceSet = new Set(PER_SOURCE_SETTINGS_KEYS as readonly string[]);
+    for (const [key, row] of Object.entries(AUTOACK_PARITY)) {
+      expect(perSourceSet.has(key), `${key}.perSource=${row.perSource} but PER_SOURCE_SETTINGS_KEYS membership is ${perSourceSet.has(key)}`).toBe(row.perSource);
+    }
+  });
+
+  describe('every tagged engine reference resolves against the shipped catalog', () => {
+    const allNodeTypes = new Set<string>([...TRIGGER_TYPES, ...CONDITION_TYPES, ...ACTION_TYPES]);
+    // trigger.message is the trigger every convertible row is expressed under.
+    const flatNumericFields = new Set(numericFields('trigger.message').flatMap((g) => g.options.map((o) => o.value)));
+    const flatStringFields = new Set(stringFields('trigger.message').flatMap((g) => g.options.map((o) => o.value)));
+    const stringOps = new Set(STRING_OP_OPTIONS.map((o) => o.value));
+    const numericOps = new Set<string>(NUMERIC_OPS);
+
+    for (const [key, row] of Object.entries(AUTOACK_PARITY)) {
+      for (const ref of row.engine) {
+        if (ref.startsWith('type:')) {
+          const type = ref.slice('type:'.length);
+          it(`${key}: type "${type}" is a real TriggerType/ConditionType/ActionType`, () => {
+            expect(allNodeTypes.has(type)).toBe(true);
+          });
+        } else if (ref.startsWith('param:')) {
+          const path = ref.slice('param:'.length);
+          // LAST dot: blockType itself is dotted (e.g. "trigger.message", "action.sendMessage").
+          const dot = path.lastIndexOf('.');
+          const blockType = path.slice(0, dot);
+          const fieldName = path.slice(dot + 1);
+          it(`${key}: param "${path}" is a real FieldDef.name on ${blockType}`, () => {
+            const block = BLOCK_BY_TYPE[blockType];
+            expect(block, `no BLOCK_BY_TYPE entry for "${blockType}"`).toBeDefined();
+            expect(block.fields.some((f) => f.name === fieldName), `${blockType} has no field named "${fieldName}"`).toBe(true);
+          });
+        } else if (ref.startsWith('field:')) {
+          const field = ref.slice('field:'.length);
+          it(`${key}: field "${field}" is offered by numericFields/stringFields('trigger.message')`, () => {
+            expect(flatNumericFields.has(field) || flatStringFields.has(field), `"${field}" not found in either field group`).toBe(true);
+          });
+        } else if (ref.startsWith('op:')) {
+          const op = ref.slice('op:'.length);
+          it(`${key}: op "${op}" is a real STRING_OP_OPTIONS or NUMERIC_OPS value`, () => {
+            expect(stringOps.has(op) || numericOps.has(op), `"${op}" not found in either operator set`).toBe(true);
+          });
+        }
+      }
+    }
+  });
+
+  it('(f) deprecated rows are exactly migration 093\'s legacy keys + the two global-only DM-routing keys', () => {
+    const actualDeprecated = Object.entries(AUTOACK_PARITY)
+      .filter(([, row]) => row.status === 'deprecated')
+      .map(([key]) => key)
+      .sort();
+    expect(actualDeprecated).toEqual(EXPECTED_DEPRECATED_KEYS);
+  });
+
+  it('(g) SEND_MAX_ATTEMPTS_MIN/MAX are 1/3, pinning the duplication of MessageQueueService\'s clamp', () => {
+    expect(SEND_MAX_ATTEMPTS_MIN).toBe(1);
+    expect(SEND_MAX_ATTEMPTS_MAX).toBe(3);
+  });
+
+  it('(h) every "exists" or "phase3" row names at least one engine reference (no empty promises)', () => {
+    const emptyPromises = Object.entries(AUTOACK_PARITY)
+      .filter(([, row]) => (row.status === 'exists' || row.status === 'phase3') && row.engine.length === 0)
+      .map(([key]) => key);
+    expect(emptyPromises).toEqual([]);
+  });
+
+  it('notConvertible/deprecated rows carry no engine reference (nothing to fake)', () => {
+    const fakedPromises = Object.entries(AUTOACK_PARITY)
+      .filter(([, row]) => (row.status === 'notConvertible' || row.status === 'deprecated') && row.engine.length > 0)
+      .map(([key]) => key);
+    expect(fakedPromises).toEqual([]);
+  });
+
+  it('autoAckTestMessages is documented honestly: global, not convertible, no engine claim', () => {
+    const row = AUTOACK_PARITY.autoAckTestMessages;
+    expect(row.perSource).toBe(false);
+    expect(row.status).toBe('notConvertible');
+    expect(row.engine).toEqual([]);
+  });
+
+  it('autoAckMaxAttempts is a Phase 3 capability, not a converter-fidelity requirement, and stays per-source', () => {
+    const row = AUTOACK_PARITY.autoAckMaxAttempts;
+    expect(row.perSource).toBe(true);
+    expect(row.status).toBe('phase3');
+    expect(row.engine).toContain('param:action.sendMessage.maxAttempts');
+  });
+});

--- a/src/server/services/automation/automationSimulator.test.ts
+++ b/src/server/services/automation/automationSimulator.test.ts
@@ -236,6 +236,33 @@ describe('simulateAutomation', () => {
     expect(r.actions[0].resolvedParams).toMatchObject({ skipped: true, reason: expect.stringMatching(/no hop count/) });
   });
 
+  // #4340 Phase 3, WP3: drift guard. automationSimulator.ts (the SOURCE file) is
+  // NOT edited for this feature — recordingDeps().sendMessage already spreads
+  // its received argument object (`{ action: 'sendMessage', ...a }`), so a new
+  // ActionDeps.sendMessage field reaches the dry-run for free. This test pins
+  // that so a future refactor of recordingDeps can't silently drop it.
+  it('maxAttempts (#4340 Phase 3): dry-run surfaces it via the recordingDeps spread with no simulator source change', async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'a', type: 'action.sendMessage', params: { text: 'pong', to: '{{ trigger.from }}', maxAttempts: 2 } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const r = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'message', text: 'ping', from: 111, packetId: 1 },
+    });
+    expect(r.status).toBe('completed');
+    expect(r.actions).toHaveLength(1);
+    expect((r.actions[0].resolvedParams as any).maxAttempts).toBe(2);
+    // Dry-run performs no real send: the recorded result carries no queue
+    // artifact (messageId/queued) — proof no messageQueue was reached.
+    expect((r.actions[0].resolvedParams as any).queued).toBeUndefined();
+    expect((r.actions[0].resolvedParams as any).messageId).toBeUndefined();
+  });
+
   it('runScript: dry-run records the action without spawning a process', async () => {
     const graph: AutomationGraph = {
       version: 1,

--- a/src/server/services/automation/conditionEvaluator.test.ts
+++ b/src/server/services/automation/conditionEvaluator.test.ts
@@ -191,6 +191,76 @@ describe('evaluateCondition', () => {
     expect(await evaluateCondition(n, ctx({}))).toBe(false);                                 // Meshtastic
   });
 
+  it('string: in / notIn membership (#4340 Phase 3)', async () => {
+    const inList = (value: string) => node('condition.string', { field: 'fromId', op: 'in', value });
+    const notInList = (value: string) => node('condition.string', { field: 'fromId', op: 'notIn', value });
+
+    // comma list
+    expect(await evaluateCondition(inList('!aabbccdd,!11223344'), ctx({ fromId: '!aabbccdd' }))).toBe(true);
+    expect(await evaluateCondition(inList('!aabbccdd,!11223344'), ctx({ fromId: '!deadbeef' }))).toBe(false);
+    // whitespace list
+    expect(await evaluateCondition(inList('!aabbccdd !11223344'), ctx({ fromId: '!11223344' }))).toBe(true);
+    // mixed separators
+    expect(await evaluateCondition(inList('!aabbccdd, !11223344  !99887766'), ctx({ fromId: '!99887766' }))).toBe(true);
+
+    // case-insensitive on both sides
+    expect(await evaluateCondition(inList('!AABBCCDD'), ctx({ fromId: '!aabbccdd' }))).toBe(true);
+    expect(await evaluateCondition(notInList('!AABBCCDD'), ctx({ fromId: '!aabbccdd' }))).toBe(false);
+
+    // exact-token match, not substring
+    expect(await evaluateCondition(inList('!aabbccddee'), ctx({ fromId: '!aabbccdd' }))).toBe(false);
+    expect(await evaluateCondition(inList('!aabbccdd'), ctx({ fromId: '!aabbccddee' }))).toBe(false);
+
+    // empty value: `in` never matches, `notIn` always matches — unset ignore list ignores nobody
+    expect(await evaluateCondition(inList(''), ctx({ fromId: '!aabbccdd' }))).toBe(false);
+    expect(await evaluateCondition(notInList(''), ctx({ fromId: '!aabbccdd' }))).toBe(true);
+
+    // left operand missing: `in` false, `notIn` true
+    expect(await evaluateCondition(inList('!aabbccdd'), ctx({}))).toBe(false);
+    expect(await evaluateCondition(notInList('!aabbccdd'), ctx({}))).toBe(true);
+
+    // notIn as an AutoAck ignore-list reproduction: excluded sender is filtered, others pass
+    expect(await evaluateCondition(notInList('!aabbccdd, !11223344'), ctx({ fromId: '!aabbccdd' }))).toBe(false);
+    expect(await evaluateCondition(notInList('!aabbccdd, !11223344'), ctx({ fromId: '!deadbeef' }))).toBe(true);
+  });
+
+  it('string: every pre-existing op still behaves unchanged alongside the new in/notIn cases', async () => {
+    expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'eq', value: 'ping' }), ctx({ text: 'ping' }))).toBe(true);
+    expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'neq', value: 'ping' }), ctx({ text: 'pong' }))).toBe(true);
+    expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'startsWith', value: 'PI' }), ctx({ text: 'ping' }))).toBe(true);
+    expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'endsWith', value: 'NG' }), ctx({ text: 'ping' }))).toBe(true);
+    expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'notContains', value: 'xyz' }), ctx({ text: 'ping' }))).toBe(true);
+  });
+
+  it('node.completeness: `in complete, unknown` reproduces AutoAck\'s skip-incomplete gate (#4340 Phase 3)', async () => {
+    const gate = node('condition.string', { field: 'node.completeness', op: 'in', value: 'complete, unknown' });
+    // complete row → passes
+    expect(await evaluateCondition(gate, ctx({}, { node: { nodeNum: 111, longName: 'Base Station', shortName: 'BASE', hwModel: 9 } }))).toBe(true);
+    // no row at all (unknown) → passes — AutoAck does NOT skip an unknown sender
+    expect(await evaluateCondition(gate, ctx({}, { node: null }))).toBe(true);
+    // incomplete row → fails — AutoAck DOES skip an incomplete sender
+    expect(await evaluateCondition(gate, ctx({}, { node: { nodeNum: 111, longName: 'Node !aabbccdd' } }))).toBe(false);
+  });
+
+  it('numeric: isDM / viaMqtt compared as 1/0, including the undefined→NaN→both-false case', async () => {
+    const isDmTrue = node('condition.numeric', { field: 'isDM', op: '==', value: 1 });
+    const isDmFalse = node('condition.numeric', { field: 'isDM', op: '==', value: 0 });
+    expect(await evaluateCondition(isDmTrue, ctx({ isDM: true }))).toBe(true);
+    expect(await evaluateCondition(isDmFalse, ctx({ isDM: true }))).toBe(false);
+    expect(await evaluateCondition(isDmTrue, ctx({ isDM: false }))).toBe(false);
+    expect(await evaluateCondition(isDmFalse, ctx({ isDM: false }))).toBe(true);
+    // undefined (field absent) → NaN → both comparisons false, per §9.9's documented behaviour
+    expect(await evaluateCondition(isDmTrue, ctx({}))).toBe(false);
+    expect(await evaluateCondition(isDmFalse, ctx({}))).toBe(false);
+
+    const viaMqttTrue = node('condition.numeric', { field: 'viaMqtt', op: '==', value: 1 });
+    const viaMqttFalse = node('condition.numeric', { field: 'viaMqtt', op: '==', value: 0 });
+    expect(await evaluateCondition(viaMqttTrue, ctx({ viaMqtt: true }))).toBe(true);
+    expect(await evaluateCondition(viaMqttFalse, ctx({ viaMqtt: false }))).toBe(true);
+    expect(await evaluateCondition(viaMqttTrue, ctx({}))).toBe(false);
+    expect(await evaluateCondition(viaMqttFalse, ctx({}))).toBe(false);
+  });
+
   it('logical: AND / OR / NOT over sub-conditions', async () => {
     const t = { type: 'condition.numeric', params: { field: 'v', op: '==', value: 1 } };
     const f = { type: 'condition.numeric', params: { field: 'v', op: '==', value: 9 } };

--- a/src/server/services/automation/conditionEvaluator.ts
+++ b/src/server/services/automation/conditionEvaluator.ts
@@ -42,6 +42,19 @@ function stringCompare(op: string, a: string, b: string): boolean {
     case 'regex':
       // RE2 (linear-time) — immune to ReDoS from user-supplied patterns.
       try { return compileUserRegex(b).test(a); } catch { return false; }
+    // #4340 Phase 3: membership in a literal list. Separators and casing mirror
+    // Auto-Acknowledge's own autoAckIgnoredNodes parser (meshtasticManager.ts:
+    // 10040-10043) — comma OR whitespace, case-insensitive — so a converted
+    // ignore list pastes across verbatim. Deliberately generic: no node-id
+    // normalisation happens here (the converter emits canonical !xxxxxxxx
+    // tokens, which is exactly the shape trigger.fromId carries).
+    // An EMPTY list makes `in` never match and `notIn` always match — which is
+    // the correct reading of "an unset ignore list ignores nobody".
+    case 'in':
+    case 'notIn': {
+      const hit = bl.split(/[\s,]+/).filter(Boolean).includes(al);
+      return op === 'in' ? hit : !hit;
+    }
     default: return false;
   }
 }

--- a/src/server/services/automation/engineContext.test.ts
+++ b/src/server/services/automation/engineContext.test.ts
@@ -1,7 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { cooldownKeyFor, varContextFromTrigger, type CooldownKeyResolution } from './engineContext.js';
+import {
+  cooldownKeyFor,
+  varContextFromTrigger,
+  resolveFieldValue,
+  getSubjectNode,
+  NODE_COMPLETENESS,
+  type CooldownKeyResolution,
+  type EngineEvalContext,
+  type NodeFacts,
+} from './engineContext.js';
 import type { TriggerContext } from './triggerContext.js';
+import type { VariableResolver } from './variableResolver.js';
 import { AutomationVariablesRepository } from '../../../db/repositories/automationVariables.js';
+import { isNodeComplete } from '../../../utils/nodeHelpers.js';
 
 /** Minimal TriggerContext builder for cooldownKeyFor truth-table tests. */
 function ctx(over: Partial<TriggerContext> = {}): TriggerContext {
@@ -104,5 +115,118 @@ describe('cooldownKeyFor (#4340 Phase 2)', () => {
       const expected = AutomationVariablesRepository.buildScopeKey('sourceNode', varContextFromTrigger(c));
       expect(cooldownKeyFor('sourceNode', c).key).toBe(expected);
     });
+  });
+});
+
+describe('resolveFieldValue: node.* (#4340 Phase 3)', () => {
+  const FAKE_VARS = { getValue: async () => null } as unknown as VariableResolver;
+
+  /** Minimal EngineEvalContext builder. `node: undefined` means "no row for this subject". */
+  function evalCtx(opts: {
+    node?: NodeFacts | null;
+    subjectNodeNum?: number | null;
+    now?: number;
+    getNodeSpy?: { calls: number };
+  } = {}): EngineEvalContext {
+    const trigger: TriggerContext = {
+      triggerType: 'trigger.message',
+      sourceId: 'src-1',
+      subjectNodeNum: opts.subjectNodeNum === undefined ? 111 : opts.subjectNodeNum,
+      timestamp: 1000,
+      fields: {},
+    };
+    return {
+      trigger,
+      vars: FAKE_VARS,
+      data: {
+        getNode: async () => {
+          if (opts.getNodeSpy) opts.getNodeSpy.calls += 1;
+          return opts.node ?? null;
+        },
+        getTelemetry: async () => null,
+      },
+      varCtx: { sourceId: trigger.sourceId, nodeNum: trigger.subjectNodeNum },
+      now: opts.now ?? 1000,
+    };
+  }
+
+  const COMPLETE_NODE: NodeFacts = { nodeNum: 111, longName: 'Base Station', shortName: 'BASE', hwModel: 9 };
+
+  it('NODE_COMPLETENESS contains exactly the three tri-state values', () => {
+    expect(NODE_COMPLETENESS).toEqual(['complete', 'incomplete', 'unknown']);
+  });
+
+  it('truth table: a fully-hydrated node is "complete"', async () => {
+    const c = evalCtx({ node: COMPLETE_NODE });
+    expect(await resolveFieldValue(c, 'node.completeness')).toBe('complete');
+  });
+
+  it('truth table: a default "Node !xxxxxxxx" longName is "incomplete"', async () => {
+    const c = evalCtx({ node: { ...COMPLETE_NODE, longName: 'Node !aabbccdd' } });
+    expect(await resolveFieldValue(c, 'node.completeness')).toBe('incomplete');
+  });
+
+  it('truth table: a missing hwModel is "incomplete"', async () => {
+    const c = evalCtx({ node: { ...COMPLETE_NODE, hwModel: undefined } });
+    expect(await resolveFieldValue(c, 'node.completeness')).toBe('incomplete');
+  });
+
+  it('truth table: a missing shortName is "incomplete"', async () => {
+    const c = evalCtx({ node: { ...COMPLETE_NODE, shortName: undefined } });
+    expect(await resolveFieldValue(c, 'node.completeness')).toBe('incomplete');
+  });
+
+  it('truth table: no row for the subject (provider returns null) is "unknown"', async () => {
+    const c = evalCtx({ node: null });
+    expect(await resolveFieldValue(c, 'node.completeness')).toBe('unknown');
+  });
+
+  it('truth table: no subject node at all (schedule/system context) is "unknown"', async () => {
+    const c = evalCtx({ subjectNodeNum: null });
+    expect(await resolveFieldValue(c, 'node.completeness')).toBe('unknown');
+  });
+
+  it('cross-check: never re-implements isNodeComplete — value tracks the helper directly for every row that exists', async () => {
+    const rows: NodeFacts[] = [
+      COMPLETE_NODE,
+      { ...COMPLETE_NODE, longName: 'Node !aabbccdd' },
+      { ...COMPLETE_NODE, hwModel: undefined },
+      { ...COMPLETE_NODE, shortName: undefined },
+    ];
+    for (const row of rows) {
+      const c = evalCtx({ node: row });
+      const expected = isNodeComplete(row) ? 'complete' : 'incomplete';
+      expect(await resolveFieldValue(c, 'node.completeness')).toBe(expected);
+    }
+  });
+
+  it('does not shadow existing node.* behaviour: ageMinutes, roleName, and passthrough still work', async () => {
+    const now = 10_000_000;
+    const c = evalCtx({
+      node: { nodeNum: 111, lastHeard: now / 1000 - 60 * 60, role: 2, batteryLevel: 42 },
+      now,
+    });
+    expect(await resolveFieldValue(c, 'node.ageMinutes')).toBe(60);
+    expect(await resolveFieldValue(c, 'node.roleName')).toBe('ROUTER');
+    expect(await resolveFieldValue(c, 'node.batteryLevel')).toBe(42);
+  });
+
+  it('node.<missing prop> still returns undefined when the row exists', async () => {
+    const c = evalCtx({ node: COMPLETE_NODE });
+    expect(await resolveFieldValue(c, 'node.notARealProp')).toBeUndefined();
+  });
+
+  it('node.<anything> still returns undefined when there is no row', async () => {
+    const c = evalCtx({ node: null });
+    expect(await resolveFieldValue(c, 'node.batteryLevel')).toBeUndefined();
+  });
+
+  it('getSubjectNode is memoised: reading node.completeness and node.batteryLevel on the same ctx performs one DB read', async () => {
+    const spy = { calls: 0 };
+    const c = evalCtx({ node: COMPLETE_NODE, getNodeSpy: spy });
+    await resolveFieldValue(c, 'node.completeness');
+    await resolveFieldValue(c, 'node.batteryLevel');
+    await getSubjectNode(c);
+    expect(spy.calls).toBe(1);
   });
 });

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -14,6 +14,7 @@ import { type TriggerContext, resolveTriggerPath, subjectKeyOf } from './trigger
 import type { VariableResolver, VarContext } from './variableResolver.js';
 import { interpolate, extractPaths, type InterpolationValue } from './interpolate.js';
 import type { CooldownScope } from '../../../types/automation.js';
+import { isNodeComplete } from '../../../utils/nodeHelpers.js';
 
 /** Subset of a node record used for condition fields. */
 export interface NodeFacts {
@@ -84,6 +85,25 @@ export const ROLE_NAMES = [
   'CLIENT', 'CLIENT_MUTE', 'ROUTER', 'ROUTER_CLIENT', 'REPEATER', 'TRACKER',
   'SENSOR', 'TAK', 'CLIENT_HIDDEN', 'LOST_AND_FOUND', 'TAK_TRACKER', 'ROUTER_LATE',
 ];
+
+/**
+ * The three states of `node.completeness` (#4340 Phase 3).
+ *
+ *  - 'complete'    the subject node's row exists and isNodeComplete() passes
+ *                  (real longName, a shortName, and an hwModel from NODEINFO).
+ *  - 'incomplete'  the row exists but NODEINFO has not arrived.
+ *  - 'unknown'     there is NO row for the subject, or the event has no subject
+ *                  node at all (Schedule / System / MeshCore).
+ *
+ * The third state is the point. Auto-Acknowledge skips a sender only when the
+ * row EXISTS and is incomplete (`if (fromNode && !isNodeComplete(fromNode))`,
+ * meshtasticManager.ts:10084) — an unknown sender is NOT skipped. A boolean
+ * field cannot express that: a missing row and an incomplete row both resolve
+ * to a falsy/undefined value. So the AutoAck rule is
+ * `node.completeness in (complete, unknown)`.
+ */
+export const NODE_COMPLETENESS = ['complete', 'incomplete', 'unknown'] as const;
+export type NodeCompleteness = (typeof NODE_COMPLETENESS)[number];
 
 export function varContextFromTrigger(trigger: TriggerContext): VarContext {
   return { sourceId: trigger.sourceId, nodeNum: trigger.subjectNodeNum };
@@ -210,8 +230,13 @@ export async function resolveFieldValue(ctx: EngineEvalContext, field: string): 
 
   if (field.startsWith('node.')) {
     const node = await getSubjectNode(ctx);
-    if (!node) return undefined;
     const prop = field.slice('node.'.length);
+    // #4340 Phase 3: resolved BEFORE the `!node` guard below, because "there is no
+    // node row" is a meaningful VALUE here ('unknown'), not a missing field.
+    if (prop === 'completeness') {
+      return node ? (isNodeComplete(node) ? 'complete' : 'incomplete') : 'unknown';
+    }
+    if (!node) return undefined;
     if (prop === 'ageMinutes') {
       if (node.lastHeard == null) return undefined;
       const lastMs = node.lastHeard > 1e12 ? node.lastHeard : node.lastHeard * 1000; // tolerate s or ms

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -133,6 +133,78 @@ describe('createMeshActionDeps — MeshCore source resolved from sourceManagerRe
   });
 });
 
+// #4340 Phase 3, WP3 §3.5: maxAttempts routes a Meshtastic DM through the
+// manager's MessageQueueService instead of the direct sendTextMessage call.
+describe('createMeshActionDeps sendMessage — maxAttempts through the queue (#4340 Phase 3)', () => {
+  beforeEach(() => { getManager.mockReset(); });
+
+  it('no maxAttempts ⇒ sendTextMessage is called, enqueue is not', async () => {
+    const sendTextMessage = vi.fn().mockResolvedValue(1);
+    const enqueue = vi.fn().mockReturnValue('q1');
+    getManager.mockReturnValue({ sendTextMessage, messageQueue: { enqueue } });
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mt', text: 'hi', channel: 0, destination: 777 });
+
+    expect(sendTextMessage).toHaveBeenCalledWith('hi', 0, 777, undefined, 0);
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('maxAttempts + numeric destination ⇒ enqueue is called with the documented arg order, sendTextMessage is not', async () => {
+    const sendTextMessage = vi.fn().mockResolvedValue(1);
+    const enqueue = vi.fn().mockReturnValue('q42');
+    getManager.mockReturnValue({ sendTextMessage, messageQueue: { enqueue } });
+    const deps = createMeshActionDeps();
+
+    const result = await deps.sendMessage({ sourceId: 'mt', text: 'pong', channel: 0, destination: 777, replyId: 5, maxAttempts: 3 });
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const args = enqueue.mock.calls[0];
+    expect(args[0]).toBe('pong');       // text
+    expect(args[1]).toBe(777);          // destination
+    expect(args[2]).toBe(5);            // replyId
+    expect(typeof args[3]).toBe('function'); // onSuccess
+    expect(typeof args[4]).toBe('function'); // onFailure
+    expect(args[5]).toBeUndefined();    // channel: undefined ⇒ a DM
+    expect(args[6]).toBe(3);            // maxAttemptsOverride
+    expect(args[7]).toBeUndefined();    // emoji (0 || undefined)
+    expect(sendTextMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ queued: true, messageId: 'q42', maxAttempts: 3 });
+  });
+
+  it('maxAttempts set but no destination (a channel send) ⇒ sendTextMessage, not enqueue', async () => {
+    const sendTextMessage = vi.fn().mockResolvedValue(1);
+    const enqueue = vi.fn().mockReturnValue('q1');
+    getManager.mockReturnValue({ sendTextMessage, messageQueue: { enqueue } });
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mt', text: 'hi', channel: 2, maxAttempts: 3 });
+
+    expect(sendTextMessage).toHaveBeenCalledWith('hi', 2, undefined, undefined, 0);
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('a manager with no messageQueue degrades gracefully to sendTextMessage', async () => {
+    const sendTextMessage = vi.fn().mockResolvedValue(1);
+    getManager.mockReturnValue({ sendTextMessage }); // no messageQueue at all
+    const deps = createMeshActionDeps();
+
+    await deps.sendMessage({ sourceId: 'mt', text: 'hi', channel: 0, destination: 777, maxAttempts: 3 });
+
+    expect(sendTextMessage).toHaveBeenCalledWith('hi', 0, 777, undefined, 0);
+  });
+
+  it('a MeshCore manager (only sendMessage) ignores maxAttempts, no throw', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    getManager.mockReturnValue({ sendMessage }); // MeshCore-shaped, no messageQueue/sendTextMessage
+    const deps = createMeshActionDeps();
+
+    await expect(deps.sendMessage({ sourceId: 'mc', text: 'hi', channel: 0, destination: '3745442c10a1', maxAttempts: 3 }))
+      .resolves.toBe(true);
+    expect(sendMessage).toHaveBeenCalledWith('hi', '3745442c10a1', 0, undefined, true);
+  });
+});
+
 describe('createMeshActionDeps requestData — node operations (#3835)', () => {
   beforeEach(() => { getManager.mockReset(); });
 

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -14,7 +14,25 @@ import databaseService from '../../../services/database.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { appriseNotificationService } from '../appriseNotificationService.js';
 import { runScript as runUserScript } from '../../utils/scriptRunner.js';
+import { logger } from '../../../utils/logger.js';
 import type { ActionDeps } from './actionExecutor.js';
+
+/**
+ * A Meshtastic manager's per-source outgoing queue (meshtasticManager.ts:1107,
+ * `public readonly`). The ONLY thing in the app that retries a DM until it is
+ * ACKed — the same path Auto-Acknowledge's reply takes (meshtasticManager.ts:
+ * 10248). Duck-typed like every other capability check in this file; never
+ * `instanceof` (CLAUDE.md).
+ */
+interface QueuedSendManager {
+  messageQueue?: {
+    enqueue(
+      text: string, destination: number, replyId?: number,
+      onSuccess?: () => void, onFailure?: (reason: string) => void,
+      channel?: number, maxAttemptsOverride?: number, emoji?: number,
+    ): string;
+  };
+}
 
 interface MeshSendManager {
   sendTextMessage(text: string, channel?: number, destination?: number, replyId?: number, emoji?: number): Promise<number>;
@@ -72,6 +90,7 @@ async function sendTextVia(
   replyId?: number,
   emoji = 0,
   scopeOverride?: string | null,
+  maxAttempts?: number,
 ): Promise<unknown> {
   if (!sourceId) throw new Error('automation action requires a target source');
   const raw = resolveManager(sourceId) as
@@ -79,6 +98,29 @@ async function sendTextVia(
   if (raw && typeof raw.sendTextMessage === 'function') {
     // Meshtastic has no scope/region concept — scopeOverride is dropped.
     const dest = typeof destination === 'number' ? destination : undefined;
+    // #4340 Phase 3. Opt-in ONLY: absent maxAttempts, a channel send, or a
+    // MeshCore source all take the unchanged direct path below.
+    //   * Channel sends are excluded because the queue hardcodes maxAttempts=1
+    //     for them (messageQueueService.ts:112) — the parameter would buy
+    //     nothing while silently imposing the queue's 30s inter-send throttle
+    //     on every channel automation that set it.
+    //   * The queue is fire-and-forget: it returns a queue id synchronously, so
+    //     this returns a descriptive object instead of a packet id, and a
+    //     TX-disabled throw surfaces later in the queue's onFailure rather than
+    //     through actionExecutor's pushOrSkipTxDisabled. Both are exactly how
+    //     Auto-Acknowledge itself behaves — that IS the parity.
+    const q = (raw as QueuedSendManager).messageQueue;
+    if (maxAttempts != null && dest != null && typeof q?.enqueue === 'function') {
+      const id = q.enqueue(
+        text, dest, replyId,
+        () => logger.debug(`[Automation] queued DM to !${dest.toString(16).padStart(8, '0')} delivered`),
+        (reason: string) => logger.warn(`[Automation] queued DM to !${dest.toString(16).padStart(8, '0')} failed: ${reason}`),
+        undefined,             // channel: undefined ⇒ this is a DM
+        maxAttempts,
+        emoji || undefined,
+      );
+      return { queued: true, messageId: id, maxAttempts };
+    }
     return raw.sendTextMessage(text, channel, dest, replyId, emoji);
   }
   if (raw && typeof raw.sendMessage === 'function') {
@@ -104,8 +146,8 @@ async function sendTextVia(
 
 export function createMeshActionDeps(): ActionDeps {
   return {
-    async sendMessage({ sourceId, text, channel, destination, replyId, scopeOverride }) {
-      return sendTextVia(sourceId, text, channel ?? 0, destination, replyId, 0, scopeOverride);
+    async sendMessage({ sourceId, text, channel, destination, replyId, scopeOverride, maxAttempts }) {
+      return sendTextVia(sourceId, text, channel ?? 0, destination, replyId, 0, scopeOverride, maxAttempts);
     },
 
     async sendTapback({ sourceId, emoji, channel, destination, replyId }) {

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -3,6 +3,9 @@ import {
   validateAutomationGraph,
   categoryOf,
   parseCooldownScope,
+  parseSendMaxAttempts,
+  SEND_MAX_ATTEMPTS_MIN,
+  SEND_MAX_ATTEMPTS_MAX,
   AUTOMATION_CONFIG_VERSION,
   type AutomationGraph,
 } from './automation.js';
@@ -160,6 +163,36 @@ describe('validateAutomationGraph', () => {
     expect(bad.errors.join(' ')).toMatch(/trigger\.telemetry .* requires params\.cooldownScope ∈ \{automation,node,sourceNode\}/);
   });
 
+  // ── action.sendMessage maxAttempts (#4340 Phase 3) ──────────────────────
+  it('action.sendMessage: maxAttempts validates when present, and absence still validates', () => {
+    const withSendMessage = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: {} },
+        { id: 'a', type: 'action.sendMessage', params },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    // absent → valid (pre-Phase-3 stored automations, and any automation that
+    // never sets maxAttempts, keep validating byte-identically to today)
+    expect(validateAutomationGraph(withSendMessage({ text: 'pong' })).valid).toBe(true);
+    // a graph with only `text` still validates — the new case must not require
+    // anything (regression per §6).
+    expect(validateAutomationGraph(withSendMessage({})).valid).toBe(true);
+    // blank string → valid (treated as absent)
+    expect(validateAutomationGraph(withSendMessage({ text: 'pong', maxAttempts: '' })).valid).toBe(true);
+    // in-range values → valid
+    expect(validateAutomationGraph(withSendMessage({ text: 'pong', maxAttempts: 1 })).valid).toBe(true);
+    expect(validateAutomationGraph(withSendMessage({ text: 'pong', maxAttempts: 2 })).valid).toBe(true);
+    expect(validateAutomationGraph(withSendMessage({ text: 'pong', maxAttempts: 3 })).valid).toBe(true);
+    // out-of-range / non-integer / non-numeric → error, with the ∈ [1, 3] message
+    for (const bad of [0, 4, 'x', 2.5]) {
+      const r = validateAutomationGraph(withSendMessage({ text: 'pong', maxAttempts: bad }));
+      expect(r.valid).toBe(false);
+      expect(r.errors.join(' ')).toMatch(/requires params\.maxAttempts ∈ \[1, 3\]/);
+    }
+  });
+
   it('rejects non-object config', () => {
     expect(validateAutomationGraph(null).valid).toBe(false);
     expect(validateAutomationGraph(42).errors[0]).toMatch(/must be an object/);
@@ -302,5 +335,35 @@ describe('parseCooldownScope', () => {
     expect(parseCooldownScope('')).toBe('automation');
     expect(parseCooldownScope('bogus')).toBe('automation');
     expect(parseCooldownScope(0)).toBe('automation');
+  });
+});
+
+describe('parseSendMaxAttempts', () => {
+  it('bounds are 1 and 3 (#4340 Phase 3)', () => {
+    expect(SEND_MAX_ATTEMPTS_MIN).toBe(1);
+    expect(SEND_MAX_ATTEMPTS_MAX).toBe(3);
+  });
+
+  it('round-trips each in-range integer value', () => {
+    expect(parseSendMaxAttempts(1)).toBe(1);
+    expect(parseSendMaxAttempts(2)).toBe(2);
+    expect(parseSendMaxAttempts(3)).toBe(3);
+  });
+
+  it('coerces a numeric string', () => {
+    expect(parseSendMaxAttempts('2')).toBe(2);
+  });
+
+  it('returns undefined for absent/blank/unparseable values', () => {
+    expect(parseSendMaxAttempts(undefined)).toBeUndefined();
+    expect(parseSendMaxAttempts(null)).toBeUndefined();
+    expect(parseSendMaxAttempts('')).toBeUndefined();
+    expect(parseSendMaxAttempts('x')).toBeUndefined();
+    expect(parseSendMaxAttempts(1.5)).toBeUndefined();
+  });
+
+  it('clamps out-of-range values instead of rejecting them (lenient at runtime)', () => {
+    expect(parseSendMaxAttempts(0)).toBe(1);
+    expect(parseSendMaxAttempts(9)).toBe(3);
   });
 });

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -151,6 +151,33 @@ export function parseCooldownScope(raw: unknown): CooldownScope {
 }
 
 /**
+ * App-level DM resend cap for `action.sendMessage` (#4340 Phase 3).
+ *
+ * Mirrors MessageQueueService's own bound (src/server/messageQueueService.ts:
+ * 75-85, `Math.min(3, Math.max(1, …))`, #4266) — an unbounded value would let an
+ * automation be abused as a repeat-broadcast mechanism. The duplication is
+ * deliberate: this module must stay dependency-free (the frontend imports it),
+ * and the queue's clamp is load-bearing for #4266 and must not be refactored
+ * from here. autoAckParity.test.ts pins the two to the same numbers.
+ */
+export const SEND_MAX_ATTEMPTS_MIN = 1;
+export const SEND_MAX_ATTEMPTS_MAX = 3;
+
+/**
+ * Coerce a stored `params.maxAttempts` to an integer in [1,3], or `undefined`
+ * for absent / blank / unparseable — `undefined` means "one direct send", the
+ * pre-4.14 behaviour every stored automation depends on. Lenient at RUNTIME
+ * while validateAutomationGraph rejects an out-of-range value at SAVE time —
+ * the same split Phase 1 used for emojiMode and Phase 2 for cooldownScope.
+ */
+export function parseSendMaxAttempts(raw: unknown): number | undefined {
+  if (raw == null || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  return Math.min(SEND_MAX_ATTEMPTS_MAX, Math.max(SEND_MAX_ATTEMPTS_MIN, n));
+}
+
+/**
  * Match modes for `condition.meshcoreScope` (#3914). A MeshCore text message
  * carries a region "scope" (`scopeCode` 0 = unscoped, >0 = a region; `scopeName`
  * = the resolved region). This condition matches:
@@ -443,6 +470,16 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
           }
           break;
         }
+        case 'action.sendMessage':
+          // Optional. Absent/blank = one direct send — every pre-existing stored
+          // automation must keep validating and behaving exactly as before.
+          if (p.maxAttempts != null && p.maxAttempts !== '') {
+            const attempts = Number(p.maxAttempts);
+            if (!Number.isInteger(attempts) || attempts < SEND_MAX_ATTEMPTS_MIN || attempts > SEND_MAX_ATTEMPTS_MAX) {
+              errors.push(`action.sendMessage "${n.id}" requires params.maxAttempts ∈ [${SEND_MAX_ATTEMPTS_MIN}, ${SEND_MAX_ATTEMPTS_MAX}]`);
+            }
+          }
+          break;
         default:
           break;
       }


### PR DESCRIPTION
## Summary

Phase 3 of the [Auto-Acknowledge on the Automation Engine epic](docs/internal/dev-notes/AUTOACK_AUTOMATION_EPIC.md), following #4390 and #4396.

Goal: make the Automation Engine able to express everything Auto-Acknowledge can, so Phase 4's AutoAck→Automation converter produces a faithful automation rather than a lossy one.

**The phase's exit criterion is a test, not a promise.** `autoAckParity.test.ts` holds a row per `autoAck*` key in `VALID_SETTINGS_KEYS` and cross-checks each claimed engine equivalent against the *shipped* catalog — so it fails if a row is removed, if a new `autoAck*` key is added without one, or if a catalog field/operator is renamed. Verified by perturbing it in both directions and confirming the failure, then restoring.

## What changed

- **`node.completeness`** — a computed tri-state node field: `complete` / `incomplete` / `unknown`.
- **`is one of` / `isn't one of`** — `in`/`notIn` operators on the string condition, with AutoAck's own separator and casing rules (comma or whitespace, case-insensitive), so an ignore list pastes across verbatim.
- **`isDM` and `viaMqtt`** exposed in the numeric condition picker.
- **`DM resend attempts`** on Send a message — routes a Meshtastic DM through `MessageQueueService` for ACK-verified retry.

## Notable decisions

- **No new condition types.** The two conditions the epic originally named are delivered as a computed `node.*` field plus two generic string operators — both reuse existing mechanisms rather than growing the condition registry.
- **The tri-state is load-bearing, not fussiness.** AutoAck skips a sender only when the row *exists* and is incomplete (`if (fromNode && !isNodeComplete(fromNode))`) — an unknown sender is **not** skipped. A boolean field cannot express that, because a missing row and an incomplete row collapse to the same value. The faithful rule is `node.completeness is one of (complete, unknown)`. `isNodeComplete` is imported, never re-implemented.
- **`isDM`/`viaMqtt` turned out to be required, not nice-to-have.** Both resolve at runtime but were missing from the picker, so the Auto-Ack 2×2 matrix cells were **not expressible in the builder at all**. `viaMqtt` is load-bearing: `isZeroHop = hopsTraveled === 0 && !viaMqtt`.
- **`maxAttempts` is opt-in and narrow.** The queue path engages only for a Meshtastic DM with the param explicitly set; absent param, channel sends, MeshCore, and tapbacks all take today's unchanged direct path, and the unset call shape is byte-identical. Channel sends are excluded deliberately — the queue hardcodes 1 attempt for them, so the param would buy nothing while imposing the queue's 30s throttle.

## Findings worth flagging

- **`autoAckMaxAttempts` is not an Auto-Ack setting at all.** `checkAutoAcknowledge` never reads it; it is `MessageQueueService.resolveDmMaxAttempts`, applied to every queued DM on the source (AutoAck's tapback and channel sends both hardcode 1). So `maxAttempts` was **not required for converter fidelity** — it ships as a capability in its own right, after an explicit decision to keep it in scope rather than defer.
- **Known semantic difference in the queued path:** it is fire-and-forget, returning a queue id rather than a packet id, so a TX-disabled source records the action as *queued* rather than emitting a `TX_DISABLED` run-log skip (the failure surfaces later via the queue's `onFailure` warning). This mirrors Auto-Acknowledge's own behaviour and is documented under the field.
- **`autoAckTestMessages` has no server reader** — a frontend-only scratchpad, recorded as genuinely not convertible rather than given an invented equivalent.
- **The two ignore lists are different things:** `autoAckIgnoredNodes` is a per-source setting string; the #4115 `ignored_nodes` table is a general app-wide blocklist AutoAck never consults. Kept distinct.

## Testing

- Full Vitest suite: **11,456 passed, 0 failed, 0 suites failed** (`success: true` via `--reporter=json`).
- Typecheck and lint ratchet clean.
- Every pre-existing `sendMessage` assertion passes **unmodified** — the unset call shape did not change.
- `automationSimulator.ts` (source) is untouched; the dry-run carries the new param through `recordingDeps()`'s existing spread, pinned by a drift-guard test.

## Browser validation

| Check | Result |
|---|---|
| `node.completeness` in the string field picker | pass |
| `is one of` / `isn't one of` operators present | pass |
| `isDM` + `viaMqtt` in the numeric picker | pass |
| "DM resend attempts" hidden until a DM target is set | pass |
| No new condition types added | pass |
| Console errors | none related (one pre-existing i18n `en-US.json` 404) |

## Next

4. The AutoAck → Automation converter, which consumes the parity table this phase produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB