### PR TITLE
chore: bump version to 4.13.3-rc2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.3-rc1",
+  "version": "4.13.3-rc2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.3-rc1",
+  "version": "4.13.3-rc2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.3-rc1
-appVersion: "4.13.3-rc1"
+version: 4.13.3-rc2
+appVersion: "4.13.3-rc2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc1",
+  "version": "4.13.3-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.3-rc1",
+      "version": "4.13.3-rc2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc1",
+  "version": "4.13.3-rc2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to `4.13.3-rc2`, picking up the completed **Auto-Acknowledge → Automation Engine epic** (#4340).

All five version files updated per the release checklist: `package.json`, `package-lock.json` (regenerated via `npm install --package-lock-only`), `helm/meshmonitor/Chart.yaml` (both `version` and `appVersion`), `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`.

## What landed since rc1

The epic shipped in four merged PRs:

| PR | Phase | What |
|---|---|---|
| #4390 | 1 | Hop-count tapback (`emojiMode`) + `{{ trigger.hopEmoji }}`, and a `showIf` mechanism for the builder |
| #4396 | 2 | Per-node cooldown scope (`cooldownScope: automation \| node \| sourceNode`) |
| #4407 | 3 | Auto-Ack parity conditions — `node.completeness`, `is one of` / `isn't one of`, `isDM`/`viaMqtt` pickers, DM resend attempts |
| #4408 | 4 | The Auto-Acknowledge → Automation converter, plus the derived `zeroHop` field |

Issue #4340 (per-channel Auto-Acknowledge body) was closed in Phase 1 with a documented recipe; phases 2–4 then made the Automation Engine a genuine superset of Auto-Acknowledge and shipped the converter.

Also filed during the epic, not fixed in it: #4399 (two unbounded maps) and #4400 (an `ok_to_mqtt` fail-closed test that flakes open).

## Testing

Version-only change — no source modified. `main` was green at `17f221fd` with the full suite at 11,734 passing.

Labelled `system-test` per the release process for version-bump chores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB