### PR TITLE
fix(virtual-node): fall back to persisted modem preset for slot-0 channel name (#4037)

### DIFF
--- a/src/server/virtualNodeServer.channelPresetFallback.test.ts
+++ b/src/server/virtualNodeServer.channelPresetFallback.test.ts
@@ -136,6 +136,22 @@ describe('VirtualNodeServer.sendChannelsFromDb() — issue #4037 preset-name fal
     );
   });
 
+  it('swallows getSetting errors and leaves the name undefined', async () => {
+    getAllChannelsMock.mockResolvedValue([emptySlot0]);
+    getSettingMock.mockRejectedValue(new Error('DB unavailable'));
+
+    const manager = makeFakeManager('src-1', null);
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    const result = await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(result).toEqual({ sent: 1, disconnected: false });
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: undefined }) })
+    );
+  });
+
   it('does not crash on a non-numeric persisted preset value and leaves the name undefined', async () => {
     getAllChannelsMock.mockResolvedValue([emptySlot0]);
     getSettingMock.mockResolvedValue('garbage');

--- a/src/server/virtualNodeServer.channelPresetFallback.test.ts
+++ b/src/server/virtualNodeServer.channelPresetFallback.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression test for issue #4037 — Virtual Node clients briefly lost the
+ * slot-0 channel display name ("Long Fast" -> generic "Channel 0") whenever
+ * config was requested in the window right after a physical-node disconnect.
+ *
+ * `sendChannelsFromDb()` derives the slot-0 name fallback from
+ * `meshtasticManager.getActualDeviceConfig()?.lora?.modemPreset`, an
+ * in-memory value that `handleDisconnected()` nulls out on every physical
+ * disconnect (non-passive mode) until the device re-sends LoRa config on
+ * reconnect. A Virtual Node client requesting config during that window used
+ * to get slot 0 with no name at all. It must now fall back to the durable
+ * per-source `lora.preset.<sourceId>` setting (the same one channelRoutes.ts,
+ * unifiedRoutes.ts, and sourceDashboardData.ts already use for this exact
+ * fallback) so the name survives the gap.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getAllChannelsMock, getSettingMock } = vi.hoisted(() => ({
+  getAllChannelsMock: vi.fn(),
+  getSettingMock: vi.fn(),
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    channels: {
+      getAllChannels: getAllChannelsMock,
+    },
+    nodes: {
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+    },
+    settings: {
+      getSetting: getSettingMock,
+    },
+    getSettingAsync: vi.fn().mockResolvedValue(null),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    createChannel: vi.fn(async (opts: any) => new Uint8Array([opts.settings?.name ? 1 : 0])),
+  },
+}));
+
+vi.mock('./protobufService.js', () => ({
+  default: {},
+}));
+
+import meshtasticProtobufService from './meshtasticProtobufService.js';
+import { VirtualNodeServer } from './virtualNodeServer.js';
+
+function makeFakeManager(sourceId: string, actualDeviceConfig: any) {
+  return {
+    sourceId,
+    getLocalNodeInfo: () => ({ nodeNum: 0x11223344, nodeId: '!11223344' }),
+    getActualDeviceConfig: () => actualDeviceConfig,
+  } as any;
+}
+
+function attachFakeClient(vn: VirtualNodeServer, clientId: string) {
+  const socket = { destroyed: false, writable: true, write: (_frame: unknown, cb: (err?: Error) => void) => cb() };
+  (vn as any).clients.set(clientId, {
+    socket,
+    id: clientId,
+    buffer: Buffer.alloc(0),
+    connectedAt: new Date(),
+    lastActivity: new Date(),
+  });
+}
+
+const emptySlot0 = { id: 0, name: '', role: 1, psk: null, uplinkEnabled: false, downlinkEnabled: false, positionPrecision: undefined };
+
+describe('VirtualNodeServer.sendChannelsFromDb() — issue #4037 preset-name fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefers the live device config and skips the DB setting when it is available', async () => {
+    const sourceId = 'src-1';
+    getAllChannelsMock.mockResolvedValue([emptySlot0]);
+    getSettingMock.mockImplementation((key: string) =>
+      Promise.resolve(key === `lora.preset.${sourceId}` ? '0' /* LongFast */ : null)
+    );
+
+    // Live config says MediumFast (4) — should win over the persisted LongFast (0).
+    const manager = makeFakeManager(sourceId, { lora: { modemPreset: 4 } });
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: 'MediumFast' }) })
+    );
+    // Live value sufficed — the durable setting must not be read.
+    expect(getSettingMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the persisted lora.preset.<sourceId> setting when live device config is unavailable (post-disconnect)', async () => {
+    const sourceId = 'src-1';
+    getAllChannelsMock.mockResolvedValue([emptySlot0]);
+    // Simulates the persisted setting written by persistModemPreset() —
+    // durable across the actualDeviceConfig=null gap left by handleDisconnected().
+    getSettingMock.mockImplementation((key: string) =>
+      Promise.resolve(key === `lora.preset.${sourceId}` ? '0' /* LONG_FAST */ : null)
+    );
+
+    // actualDeviceConfig is null — mirrors the state right after a physical
+    // disconnect, before the device has re-sent LoRa config.
+    const manager = makeFakeManager(sourceId, null);
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    const result = await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(result).toEqual({ sent: 1, disconnected: false });
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: 'LongFast' }) })
+    );
+  });
+
+  it('leaves the name undefined when neither live config nor a persisted preset is known', async () => {
+    getAllChannelsMock.mockResolvedValue([emptySlot0]);
+    getSettingMock.mockResolvedValue(null);
+
+    const manager = makeFakeManager('src-1', null);
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    const result = await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(result).toEqual({ sent: 1, disconnected: false });
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: undefined }) })
+    );
+  });
+
+  it('does not crash on a non-numeric persisted preset value and leaves the name undefined', async () => {
+    getAllChannelsMock.mockResolvedValue([emptySlot0]);
+    getSettingMock.mockResolvedValue('garbage');
+
+    const manager = makeFakeManager('src-1', null);
+    const vn = new VirtualNodeServer({ port: 0, meshtasticManager: manager });
+    attachFakeClient(vn, 'client-1');
+
+    const result = await (vn as any).sendChannelsFromDb('client-1');
+
+    expect(result).toEqual({ sent: 1, disconnected: false });
+    expect(meshtasticProtobufService.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.objectContaining({ name: undefined }) })
+    );
+  });
+});

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -755,7 +755,25 @@ export class VirtualNodeServer extends EventEmitter {
     // channel entries (otherwise uplink_enabled defaults to false and every
     // packet is dropped).
     const deviceConfig = this.config.meshtasticManager.getActualDeviceConfig?.();
-    const presetFallback = getPrimaryChannelNameFallback(deviceConfig?.lora?.modemPreset);
+    let presetFallback = getPrimaryChannelNameFallback(deviceConfig?.lora?.modemPreset);
+
+    // getActualDeviceConfig() is in-memory only: handleDisconnected() nulls it
+    // on every physical-node disconnect until the device re-sends LoRa config
+    // on reconnect. A client requesting config during that window would
+    // otherwise get slot 0 with no name at all, which the Meshtastic app
+    // renders as the placeholder "Channel 0" (#4037). Fall back to the durable
+    // per-source `lora.preset.<sourceId>` setting written by
+    // persistModemPreset() (same fallback channelRoutes.ts, unifiedRoutes.ts,
+    // and sourceDashboardData.ts already use).
+    if (!presetFallback) {
+      try {
+        const raw = await databaseService.settings.getSetting(`lora.preset.${sourceId}`);
+        const n = raw != null ? Number(raw) : NaN;
+        if (Number.isFinite(n)) presetFallback = getPrimaryChannelNameFallback(n);
+      } catch (err) {
+        logger.debug(`Virtual node: Failed to load persisted modem preset for source ${sourceId}:`, err);
+      }
+    }
 
     let sent = 0;
     for (const ch of dbChannels) {


### PR DESCRIPTION
## Summary

Fixes the channel-name half of #4037: Virtual Node clients that request config right after a physical-node disconnect got channel slot 0 with no name, which the Meshtastic Android app renders as the placeholder "Channel 0" instead of the preset name ("Long Fast").

`sendChannelsFromDb()` derived the slot-0 name fallback from `meshtasticManager.getActualDeviceConfig()?.lora?.modemPreset` — an in-memory cache that `handleDisconnected()` nulls on every physical disconnect until the device re-sends LoRa config. A `ble-bridge` link (the reporter's setup) flaps often, so the window recurs daily.

The fix keeps the live value as first choice and, when it yields no name, reads the durable per-source `lora.preset.<sourceId>` setting that `persistModemPreset()` already writes — the same fallback `channelRoutes.ts`, `unifiedRoutes.ts`, and `sourceDashboardData.ts` already use. The DB read only fires in the gap window, once per config request.

This re-does closed PR #4038 on current `main`: that commit predated #4207, which rewrote the preset-name area (`MODEM_PRESET_CHANNEL_NAMES`), so it no longer applied cleanly.

The MQTT "connection rejected" half of #4037 stays open — that error comes from the Android app's own broker connection, which MeshMonitor is not part of.

## Changes

- `src/server/virtualNodeServer.ts` — durable-setting fallback in `sendChannelsFromDb()` (+19/-1).
- `src/server/virtualNodeServer.channelPresetFallback.test.ts` — new regression tests: live config wins (no DB read), fallback from setting during the disconnect gap, both absent, garbage setting value.

## Testing

- `npx vitest run src/server/virtualNodeServer` — 68/68 pass (`success: true` via JSON reporter).
- `npx tsc --noEmit` — clean.
- `npm run lint:ci` — ratchet gate passes (no in-repo FAIL lines).

Fixes #4037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob