### PR TITLE
fix(virtual-node): stop duplicate MQTT client-proxy publishing (#4037 follow-up)

### DIFF
--- a/src/server/meshtasticManager.mqttProxyDedup.test.ts
+++ b/src/server/meshtasticManager.mqttProxyDedup.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for issue #4037 follow-up — duplicate MQTT client-proxy publishing.
+ *
+ * When a device has mqtt.proxy_to_client_enabled, it emits
+ * FromRadio.mqttClientProxyMessage frames asking its client to publish them
+ * to the MQTT broker. Two consumers can act on the SAME frame:
+ *
+ *   1. handleDeviceMqttProxyMessage() publishes to the linked embedded broker
+ *      when the source has an active mqttLink (mqttLinkBroker non-null).
+ *   2. _processIncomingDataImpl broadcasts every FromRadio frame to ALL
+ *      virtual-node clients, and each connected Meshtastic app then runs its
+ *      own broker connection and publishes the same envelope again.
+ *
+ * The fix: when the mqttLink is active, the proxy frame must NOT reach VN
+ * clients at all (MeshMonitor is the proxy). When it is not active, the frame
+ * goes to exactly ONE delegate client via broadcastToProxyDelegate (a
+ * physical node never double-publishes because BLE is single-client).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the VirtualNodeServer so tests never bind a real TCP port
+const { broadcastMock, proxyDelegateMock, VNConstructor } = vi.hoisted(() => {
+  const startMock = vi.fn().mockResolvedValue(undefined);
+  const stopMock = vi.fn().mockResolvedValue(undefined);
+  const broadcastMock = vi.fn().mockResolvedValue(undefined);
+  const proxyDelegateMock = vi.fn().mockResolvedValue(undefined);
+  const VNConstructor = vi.fn(function (this: any, _opts: any) {
+    this.start = startMock;
+    this.stop = stopMock;
+    this.broadcastToClients = broadcastMock;
+    this.broadcastToProxyDelegate = proxyDelegateMock;
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  });
+  return { broadcastMock, proxyDelegateMock, VNConstructor };
+});
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+// Prevent the constructor's async position-recalc path from touching the DB
+const { getNodeMock } = vi.hoisted(() => ({
+  getNodeMock: vi.fn().mockResolvedValue({
+    nodeNum: 123,
+    nodeId: '!0000007b',
+    longName: 'Test Node',
+    shortName: 'TN',
+    hwModel: 1,
+  }),
+}));
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    upsertNodeAsync: vi.fn().mockResolvedValue(undefined),
+    sources: {
+      getSource: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: getNodeMock,
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+// Mock the protobuf service so we control what parseIncomingData reports
+const { parseIncomingDataMock } = vi.hoisted(() => ({
+  parseIncomingDataMock: vi.fn(),
+}));
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    parseIncomingData: parseIncomingDataMock,
+    // peekServiceEnvelopePacketId (mqttProxyBridge) probes the payload for a
+    // packet id; returning null makes echo suppression a quiet no-op.
+    decodeServiceEnvelope: vi.fn().mockReturnValue(null),
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array([4, 5, 6])),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+
+// Stub packet-log service so processMeshPacket's logging branch stays quiet
+vi.mock('./services/packetLogService.js', () => {
+  const svc = { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() };
+  return { default: svc, packetLogService: svc };
+});
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+const RAW_FRAME = new Uint8Array([0x12, 0x34, 0x56]);
+
+function makeManager(): MeshtasticManager {
+  return new MeshtasticManager('src-1', {
+    host: '127.0.0.1',
+    port: 4403,
+    virtualNode: { enabled: true, port: 4503, allowAdminCommands: false },
+  });
+}
+
+function proxyParsed() {
+  return {
+    type: 'mqttClientProxyMessage',
+    data: {
+      topic: 'msh/US/2/e/LongFast/!abcdef01',
+      data: new Uint8Array([9, 9, 9]),
+      retained: false,
+    },
+  };
+}
+
+describe('MeshtasticManager — mqttClientProxyMessage VN dedup (#4037 follow-up)', () => {
+  beforeEach(() => {
+    broadcastMock.mockClear();
+    proxyDelegateMock.mockClear();
+    parseIncomingDataMock.mockReset();
+  });
+
+  it('with mqttLink active: no VN client receives the frame, and the link handler publishes it', async () => {
+    const mgr = makeManager();
+    const publishMock = vi.fn().mockResolvedValue(undefined);
+    (mgr as any).mqttLinkBroker = { publish: publishMock };
+    parseIncomingDataMock.mockReturnValue(proxyParsed());
+
+    await mgr.processIncomingData(RAW_FRAME);
+
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(proxyDelegateMock).not.toHaveBeenCalled();
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(publishMock).toHaveBeenCalledWith(
+      'msh/US/2/e/LongFast/!abcdef01',
+      expect.any(Buffer),
+      false,
+    );
+  });
+
+  it('with NO mqttLink: exactly one delegate client receives the frame (not broadcast-to-all)', async () => {
+    const mgr = makeManager();
+    parseIncomingDataMock.mockReturnValue(proxyParsed());
+
+    await mgr.processIncomingData(RAW_FRAME);
+
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(proxyDelegateMock).toHaveBeenCalledTimes(1);
+    expect(proxyDelegateMock).toHaveBeenCalledWith(RAW_FRAME);
+  });
+
+  it('regression: a non-proxy frame (nodeInfo) still reaches ALL clients via broadcastToClients', async () => {
+    const mgr = makeManager();
+    // Stub the dispatch target so the test stays off the DB path.
+    (mgr as any).processNodeInfoProtobuf = vi.fn().mockResolvedValue(undefined);
+    parseIncomingDataMock.mockReturnValue({ type: 'nodeInfo', data: { num: 123 } });
+
+    await mgr.processIncomingData(RAW_FRAME);
+
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    expect(broadcastMock).toHaveBeenCalledWith(RAW_FRAME);
+    expect(proxyDelegateMock).not.toHaveBeenCalled();
+  });
+
+  it('regression: channel and configComplete frames stay filtered from every VN path (#1567)', async () => {
+    const mgr = makeManager();
+    parseIncomingDataMock.mockReturnValue({ type: 'channel', data: { index: 0 } });
+
+    await mgr.processIncomingData(RAW_FRAME);
+
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(proxyDelegateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4173,8 +4173,30 @@ class MeshtasticManager implements ISourceManager {
         const virtualNodeServer = this.virtualNodeServer;
         if (virtualNodeServer) {
           try {
-            await virtualNodeServer.broadcastToClients(data);
-            logger.debug(`📡 Broadcasted ${parsed?.type || 'unparsed'} to virtual node clients (${data.length} bytes)`);
+            if (parsed?.type === 'mqttClientProxyMessage') {
+              // - 'mqttClientProxyMessage': the device is asking its client to publish this
+              //   envelope to the MQTT broker (mqtt.proxy_to_client_enabled). Two consumers
+              //   can act on the SAME frame (#4037 follow-up): when an mqttLink is active,
+              //   handleDeviceMqttProxyMessage() below publishes it to the linked broker, so
+              //   relaying the frame to VN clients would make every connected app publish it
+              //   AGAIN — duplicate publishes on the broker. Even without an mqttLink,
+              //   broadcasting to ALL clients makes each app proxy independently (N duplicate
+              //   publishes). A physical node never has this problem because BLE is
+              //   single-client, so mirror that: drop the frame when the link handles it,
+              //   otherwise relay it to a single delegate (the newest connected client).
+              //   Accepted tradeoff: handleDeviceMqttProxyMessage() can still no-op with
+              //   the link attached (empty topic/data, or echo suppression) — the frame is
+              //   then intentionally dropped by both paths (echo = must not republish;
+              //   malformed = firmware bug).
+              if (this.mqttLinkBroker) {
+                logger.debug(`📡 [${this.sourceId}] mqttClientProxyMessage handled by mqttLink — not relayed to virtual node clients (#4037)`);
+              } else {
+                await virtualNodeServer.broadcastToProxyDelegate(data);
+              }
+            } else {
+              await virtualNodeServer.broadcastToClients(data);
+              logger.debug(`📡 Broadcasted ${parsed?.type || 'unparsed'} to virtual node clients (${data.length} bytes)`);
+            }
           } catch (error) {
             logger.error('Virtual node: Failed to broadcast message to clients:', error);
           }

--- a/src/server/virtualNodeServer.proxyDelegate.test.ts
+++ b/src/server/virtualNodeServer.proxyDelegate.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for issue #4037 follow-up — MQTT client-proxy delegate selection.
+ *
+ * When a device has mqtt.proxy_to_client_enabled, it emits
+ * FromRadio.mqttClientProxyMessage frames asking its client to publish them to
+ * the broker. A physical node only ever has one BLE client, so firmware
+ * assumes exactly one proxy. `broadcastToProxyDelegate` must therefore send
+ * the frame to exactly ONE virtual-node client — the most recently connected
+ * client whose socket is still live and writable — instead of all of them,
+ * or every connected app publishes the same envelope (duplicate publishes).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module mocks — set up BEFORE the import of virtualNodeServer.js
+// ────────────────────────────────────────────────────────────────────────────
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    nodes: {
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      setNodeFavorite: vi.fn().mockResolvedValue(undefined),
+    },
+    getSettingAsync: vi.fn().mockResolvedValue(null),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array([10, 20, 30])),
+    createFakeRoutingAck: vi.fn().mockResolvedValue(new Uint8Array([0xa, 0xc, 0xc])),
+    parseToRadio: vi.fn(),
+    normalizePortNum: vi.fn((n: unknown) => (typeof n === 'number' ? n : 0)),
+    getPortNumName: (n: number) => `PORT_${n}`,
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+
+vi.mock('./protobufService.js', () => {
+  const svc = {
+    decodeAdminMessage: vi.fn(),
+  };
+  return { default: svc, protobufService: svc };
+});
+
+import { VirtualNodeServer } from './virtualNodeServer.js';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makeFakeManager(sourceId: string = 'src-1') {
+  return {
+    sourceId,
+    getLocalNodeInfo: () => ({ nodeNum: 0x11223344, nodeId: '!11223344' }),
+    processIncomingData: vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+function makeServer(): VirtualNodeServer {
+  return new VirtualNodeServer({
+    port: 4503,
+    meshtasticManager: makeFakeManager(),
+  });
+}
+
+/**
+ * Stub a connected client into the VN's private clients Map and capture
+ * writes via a Uint8Array recorder.
+ */
+function attachFakeClient(
+  vn: VirtualNodeServer,
+  clientId: string,
+  connectedAt: Date,
+  opts: { destroyed?: boolean; writable?: boolean } = {},
+) {
+  const writes: Uint8Array[] = [];
+  const fakeSocket: any = {
+    destroyed: opts.destroyed ?? false,
+    writable: opts.writable ?? true,
+    remoteAddress: '192.168.1.50',
+    write: (chunk: Uint8Array, cb?: (err?: Error) => void) => {
+      writes.push(chunk);
+      if (cb) cb();
+      return true;
+    },
+    end: vi.fn(),
+    destroy: vi.fn(),
+    on: vi.fn(),
+  };
+
+  const client = {
+    socket: fakeSocket,
+    id: clientId,
+    buffer: Buffer.alloc(0),
+    connectedAt,
+    lastActivity: new Date(),
+  };
+
+  (vn as any).clients.set(clientId, client);
+  return { writes, client };
+}
+
+const PAYLOAD = new Uint8Array([1, 2, 3, 4]);
+
+// ────────────────────────────────────────────────────────────────────────────
+// broadcastToProxyDelegate
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('VirtualNodeServer.broadcastToProxyDelegate — #4037 single-delegate proxy', () => {
+  it('sends to exactly the newest connected writable client when multiple clients are connected', async () => {
+    const vn = makeServer();
+    const older = attachFakeClient(vn, 'client-old', new Date('2026-07-29T10:00:00Z'));
+    const middle = attachFakeClient(vn, 'client-mid', new Date('2026-07-29T10:05:00Z'));
+    const newest = attachFakeClient(vn, 'client-new', new Date('2026-07-29T10:10:00Z'));
+
+    await vn.broadcastToProxyDelegate(PAYLOAD);
+
+    expect(older.writes).toHaveLength(0);
+    expect(middle.writes).toHaveLength(0);
+    expect(newest.writes).toHaveLength(1);
+  });
+
+  it('frames the payload exactly like broadcastToClients (0x94 0xc3 header + length + payload)', async () => {
+    const vn = makeServer();
+    const { writes } = attachFakeClient(vn, 'client-1', new Date());
+
+    await vn.broadcastToProxyDelegate(PAYLOAD);
+
+    expect(writes).toHaveLength(1);
+    const frame = Buffer.from(writes[0]);
+    expect(frame[0]).toBe(0x94);
+    expect(frame[1]).toBe(0xc3);
+    expect((frame[2] << 8) | frame[3]).toBe(PAYLOAD.length);
+    expect(frame.subarray(4).equals(Buffer.from(PAYLOAD))).toBe(true);
+  });
+
+  it('skips a destroyed newest socket and falls back to the next-newest writable client', async () => {
+    const vn = makeServer();
+    const older = attachFakeClient(vn, 'client-old', new Date('2026-07-29T10:00:00Z'));
+    const destroyedNewest = attachFakeClient(vn, 'client-dead', new Date('2026-07-29T10:10:00Z'), {
+      destroyed: true,
+    });
+
+    await vn.broadcastToProxyDelegate(PAYLOAD);
+
+    expect(destroyedNewest.writes).toHaveLength(0);
+    expect(older.writes).toHaveLength(1);
+  });
+
+  it('skips a non-writable newest socket and falls back to the next-newest writable client', async () => {
+    const vn = makeServer();
+    const older = attachFakeClient(vn, 'client-old', new Date('2026-07-29T10:00:00Z'));
+    const unwritableNewest = attachFakeClient(vn, 'client-stuck', new Date('2026-07-29T10:10:00Z'), {
+      writable: false,
+    });
+
+    await vn.broadcastToProxyDelegate(PAYLOAD);
+
+    expect(unwritableNewest.writes).toHaveLength(0);
+    expect(older.writes).toHaveLength(1);
+  });
+
+  it('drops the frame without throwing when no writable client exists', async () => {
+    const vn = makeServer();
+    attachFakeClient(vn, 'client-dead', new Date(), { destroyed: true });
+
+    await expect(vn.broadcastToProxyDelegate(PAYLOAD)).resolves.toBeUndefined();
+  });
+
+  it('drops the frame without throwing when no clients are connected at all', async () => {
+    const vn = makeServer();
+
+    await expect(vn.broadcastToProxyDelegate(PAYLOAD)).resolves.toBeUndefined();
+  });
+
+  it('does not throw when the delegate socket write errors (sendToClient rejection is swallowed)', async () => {
+    const vn = makeServer();
+    const { client } = attachFakeClient(vn, 'client-err', new Date());
+    client.socket.write = (_chunk: Uint8Array, cb?: (err?: Error) => void) => {
+      if (cb) cb(new Error('boom'));
+      return true;
+    };
+
+    await expect(vn.broadcastToProxyDelegate(PAYLOAD)).resolves.toBeUndefined();
+  });
+
+  it('regression: broadcastToClients still reaches ALL writable clients', async () => {
+    const vn = makeServer();
+    const a = attachFakeClient(vn, 'client-a', new Date('2026-07-29T10:00:00Z'));
+    const b = attachFakeClient(vn, 'client-b', new Date('2026-07-29T10:10:00Z'));
+
+    await vn.broadcastToClients(PAYLOAD);
+
+    expect(a.writes).toHaveLength(1);
+    expect(b.writes).toHaveLength(1);
+  });
+});

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -1133,6 +1133,46 @@ export class VirtualNodeServer extends EventEmitter {
   }
 
   /**
+   * Send a message to a single "proxy delegate" client instead of all clients.
+   *
+   * Used for FromRadio.mqttClientProxyMessage frames (#4037 follow-up): the
+   * device asks its client to publish the payload to the MQTT broker. A
+   * physical node only ever has one BLE client, so firmware assumes exactly
+   * one proxy. Broadcasting the frame to every connected app would make each
+   * of them publish the same envelope — duplicate publishes on the broker.
+   * Mirror the physical-node behavior by delegating to the most recently
+   * connected client with a live, writable socket (newest wins).
+   */
+  public async broadcastToProxyDelegate(data: Uint8Array): Promise<void> {
+    let delegateId: string | null = null;
+    let delegateConnectedAt = 0;
+    for (const [clientId, client] of this.clients.entries()) {
+      if (client.socket.destroyed || !client.socket.writable) {
+        continue;
+      }
+      if (!delegateId || client.connectedAt.getTime() > delegateConnectedAt) {
+        delegateId = clientId;
+        delegateConnectedAt = client.connectedAt.getTime();
+      }
+    }
+
+    if (!delegateId) {
+      logger.debug('Virtual node: No writable client available as MQTT proxy delegate, dropping frame');
+      return;
+    }
+
+    logger.debug(`Virtual node: Sending MQTT proxy frame to delegate ${delegateId} (newest of ${this.clients.size} clients)`);
+    try {
+      await this.sendToClient(delegateId, data);
+    } catch (error) {
+      // sendToClient rejects on write error; swallow it so this method stays
+      // self-contained like broadcastToClients — a failed delegate write must
+      // never throw into the packet-processing path.
+      logger.error(`Virtual node: Failed to send proxy frame to ${delegateId}:`, (error as Error).message);
+    }
+  }
+
+  /**
    * Create a framed message (4-byte header + payload)
    */
   private createFrame(data: Uint8Array): Buffer {


### PR DESCRIPTION
## Summary

Follow-up to #4037 / #4415. When a device has `mqtt.proxy_to_client_enabled = true`, its `FromRadio.mqttClientProxyMessage` frames were double-consumed:

1. With an `mqttLink` configured, `handleDeviceMqttProxyMessage()` published them to the linked embedded broker, **and**
2. `_processIncomingDataImpl` broadcast the same frame to **all** Virtual Node clients — each of which, seeing `proxy_to_client_enabled=true` in the replayed moduleConfig, also published it.

Result: duplicate publishes at the broker whenever an mqttLink was active with any VN client connected, or whenever two or more VN clients were connected (each proxied independently). A physical node never hits this — BLE is single-client.

## Changes

- **mqttLink wins:** when `this.mqttLinkBroker` is attached, `mqttClientProxyMessage` frames are no longer relayed to VN clients at all. The gate uses the same field `handleDeviceMqttProxyMessage()` checks, so "enabled but detached" correctly falls through to the delegate path instead of dropping the frame on both sides.
- **Single proxy delegate:** without an mqttLink, the frame goes to exactly one VN client — the most recently connected one with a writable socket (`VirtualNodeServer.broadcastToProxyDelegate()`, which reuses `sendToClient()`), mirroring the physical node's one-BLE-client reality. Reconnect churn hands the role to the new connection naturally since disconnects remove clients from the map.
- All other FromRadio types keep the existing broadcast-to-all behavior; the #1567 channel/configComplete filter is untouched, as is the client→radio `ToRadio` proxy path.
- 12 new tests across `meshtasticManager.mqttProxyDedup.test.ts` and `virtualNodeServer.proxyDelegate.test.ts`: link-active suppression (with the mqttLink publish still asserted), no-link single-delegate relay, newest-wins election, destroyed/non-writable/zero-client fallbacks, write-error containment, and broadcast-to-all + #1567 regression guards.

Note for testers: a VN client that is *not* the delegate will now show the MQTT proxy as inactive — that is the intended single-proxy behavior, not a regression.

## Testing

- `npx vitest run src/server/virtualNodeServer src/server/meshtasticManager` — 852 passed / 0 failed (`success: true` via JSON reporter).
- `npm run typecheck` — clean.
- `npm run lint:ci` — ratchet gate passes.

Refs #4037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob