### PR TITLE
fix(automation): disable Convert-to-Automation button for MeshCore sources

### DIFF
--- a/src/components/AutoAcknowledgeSection.convertButton.test.tsx
+++ b/src/components/AutoAcknowledgeSection.convertButton.test.tsx
@@ -104,6 +104,19 @@ describe('AutoAcknowledgeSection — Convert to an Automation button', () => {
 
     const button = screen.getByRole('button', { name: /Convert to an Automation/ });
     expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Save your changes first — converting now would use the last saved configuration, not your unsaved edits.',
+    );
+  });
+
+  it('leaves the button enabled when sourceType is null (no SourceProvider)', () => {
+    mockUseSource.mockReturnValue({ sourceId: 'source-1', sourceName: 'Test Source', sourceType: null });
+    render(<AutoAcknowledgeSection {...defaultProps} />);
+
+    const button = screen.getByRole('button', { name: /Convert to an Automation/ });
+    expect(button).not.toBeDisabled();
+    expect(button).not.toHaveAttribute('title');
   });
 
   it('disables the button for a MeshCore source, even with no unsaved changes (#4420)', () => {
@@ -113,6 +126,9 @@ describe('AutoAcknowledgeSection — Convert to an Automation button', () => {
     const button = screen.getByRole('button', { name: /Convert to an Automation/ });
     expect(button).toBeInTheDocument();
     expect(button).toBeDisabled();
-    expect(button).toHaveAttribute('title', 'Convert to an Automation is only available for Meshtastic sources.');
+    // The global react-i18next mock (src/test/setup.ts) returns the key verbatim,
+    // ignoring the t()-call's fallback default — so this asserts the i18n key,
+    // not the rendered English copy.
+    expect(button).toHaveAttribute('title', 'automation.auto_ack.convert_meshtastic_only');
   });
 });

--- a/src/components/AutoAcknowledgeSection.convertButton.test.tsx
+++ b/src/components/AutoAcknowledgeSection.convertButton.test.tsx
@@ -32,8 +32,9 @@ vi.mock('../hooks/useSaveBar', () => ({
 vi.mock('../contexts/SettingsContext', () => ({
   useSettings: () => ({ timeFormat: '24h', dateFormat: 'YYYY-MM-DD' }),
 }));
+const mockUseSource = vi.fn(() => ({ sourceId: 'source-1', sourceName: 'Test Source', sourceType: 'meshtastic_tcp' }));
 vi.mock('../contexts/SourceContext', () => ({
-  useSource: () => ({ sourceId: 'source-1', sourceName: 'Test Source' }),
+  useSource: () => mockUseSource(),
 }));
 
 const mockChannels: Channel[] = [
@@ -80,6 +81,7 @@ const defaultProps = {
 describe('AutoAcknowledgeSection — Convert to an Automation button', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseSource.mockReturnValue({ sourceId: 'source-1', sourceName: 'Test Source', sourceType: 'meshtastic_tcp' });
   });
 
   afterEach(() => {
@@ -102,5 +104,15 @@ describe('AutoAcknowledgeSection — Convert to an Automation button', () => {
 
     const button = screen.getByRole('button', { name: /Convert to an Automation/ });
     expect(button).toBeDisabled();
+  });
+
+  it('disables the button for a MeshCore source, even with no unsaved changes (#4420)', () => {
+    mockUseSource.mockReturnValue({ sourceId: 'source-1', sourceName: 'Test Source', sourceType: 'meshcore' });
+    render(<AutoAcknowledgeSection {...defaultProps} />);
+
+    const button = screen.getByRole('button', { name: /Convert to an Automation/ });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'Convert to an Automation is only available for Meshtastic sources.');
   });
 });

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -327,6 +327,19 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     onSave: handleSaveForSaveBar,
     onDismiss: resetChanges
   });
+
+  // Convert-to-Automation button state (#4340 Phase 4 WP4, #4420). `sourceType`
+  // is `null` outside a SourceProvider (legacy/single-source views) — that
+  // intentionally falls through to "not MeshCore" so the button stays enabled
+  // there, matching pre-#4420 behavior for those views.
+  const isMeshCoreSource = sourceType === 'meshcore';
+  const isConvertDisabled = hasChanges || isMeshCoreSource;
+  const convertDisabledReason = isMeshCoreSource
+    ? t('automation.auto_ack.convert_meshtastic_only', 'Convert to an Automation is only available for Meshtastic sources.')
+    : hasChanges
+      ? 'Save your changes first — converting now would use the last saved configuration, not your unsaved edits.'
+      : undefined;
+
   return (
     <>
       <div className="automation-section-header" style={{
@@ -368,40 +381,29 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             Also disabled for MeshCore sources — the converter targets Meshtastic's
             Direct/Multi-hop Auto-Ack split; MeshCore's flat Auto-Ack template is out
             of scope for the epic and the server 400s SOURCE_NOT_MESHTASTIC (#4420). */}
-        {(() => {
-          const isMeshCore = sourceType === 'meshcore';
-          const disabledReason = isMeshCore
-            ? 'Convert to an Automation is only available for Meshtastic sources.'
-            : hasChanges
-              ? 'Save your changes first — converting now would use the last saved configuration, not your unsaved edits.'
-              : undefined;
-          const isDisabled = hasChanges || isMeshCore;
-          return (
-            <button
-              type="button"
-              onClick={() => setIsConvertDialogOpen(true)}
-              disabled={isDisabled}
-              title={disabledReason}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.4rem',
-                padding: '0.4rem 0.85rem',
-                borderRadius: '6px',
-                background: 'var(--ctp-surface2)',
-                color: isDisabled ? 'var(--ctp-subtext0)' : 'var(--ctp-text)',
-                border: '1px solid var(--ctp-surface2)',
-                cursor: isDisabled ? 'not-allowed' : 'pointer',
-                opacity: isDisabled ? 0.6 : 1,
-                fontSize: '0.85rem',
-                whiteSpace: 'nowrap'
-              }}
-            >
-              <UiIcon name="bot" size={16} />
-              Convert to an Automation…
-            </button>
-          );
-        })()}
+        <button
+          type="button"
+          onClick={() => setIsConvertDialogOpen(true)}
+          disabled={isConvertDisabled}
+          title={convertDisabledReason}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.4rem',
+            padding: '0.4rem 0.85rem',
+            borderRadius: '6px',
+            background: 'var(--ctp-surface2)',
+            color: isConvertDisabled ? 'var(--ctp-subtext0)' : 'var(--ctp-text)',
+            border: '1px solid var(--ctp-surface2)',
+            cursor: isConvertDisabled ? 'not-allowed' : 'pointer',
+            opacity: isConvertDisabled ? 0.6 : 1,
+            fontSize: '0.85rem',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          <UiIcon name="bot" size={16} />
+          Convert to an Automation…
+        </button>
       </div>
 
       <AutoAckConvertDialog

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { useSourceQuery } from '../hooks/useSourceQuery';
+import { useSource } from '../contexts/SourceContext';
 import { useSettings } from '../contexts/SettingsContext';
 import { formatTime, formatDate } from '../utils/datetime';
 import { Channel } from '../types/device';
@@ -79,6 +80,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
 }) => {
   const { t } = useTranslation();
   const { timeFormat, dateFormat } = useSettings();
+  const { sourceType } = useSource();
   const csrfFetch = useCsrfFetch();
   const sourceQuery = useSourceQuery();
   const { showToast } = useToast();
@@ -362,30 +364,44 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
         </h2>
         {/* #4340 Phase 4 WP4 — one-way door into the Automation Engine. Disabled while
             there are unsaved edits: converting now would convert the *saved* config,
-            not what's on screen, and silently discard the user's in-progress changes. */}
-        <button
-          type="button"
-          onClick={() => setIsConvertDialogOpen(true)}
-          disabled={hasChanges}
-          title={hasChanges ? 'Save your changes first — converting now would use the last saved configuration, not your unsaved edits.' : undefined}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.4rem',
-            padding: '0.4rem 0.85rem',
-            borderRadius: '6px',
-            background: 'var(--ctp-surface2)',
-            color: hasChanges ? 'var(--ctp-subtext0)' : 'var(--ctp-text)',
-            border: '1px solid var(--ctp-surface2)',
-            cursor: hasChanges ? 'not-allowed' : 'pointer',
-            opacity: hasChanges ? 0.6 : 1,
-            fontSize: '0.85rem',
-            whiteSpace: 'nowrap'
-          }}
-        >
-          <UiIcon name="bot" size={16} />
-          Convert to an Automation…
-        </button>
+            not what's on screen, and silently discard the user's in-progress changes.
+            Also disabled for MeshCore sources — the converter targets Meshtastic's
+            Direct/Multi-hop Auto-Ack split; MeshCore's flat Auto-Ack template is out
+            of scope for the epic and the server 400s SOURCE_NOT_MESHTASTIC (#4420). */}
+        {(() => {
+          const isMeshCore = sourceType === 'meshcore';
+          const disabledReason = isMeshCore
+            ? 'Convert to an Automation is only available for Meshtastic sources.'
+            : hasChanges
+              ? 'Save your changes first — converting now would use the last saved configuration, not your unsaved edits.'
+              : undefined;
+          const isDisabled = hasChanges || isMeshCore;
+          return (
+            <button
+              type="button"
+              onClick={() => setIsConvertDialogOpen(true)}
+              disabled={isDisabled}
+              title={disabledReason}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.4rem',
+                padding: '0.4rem 0.85rem',
+                borderRadius: '6px',
+                background: 'var(--ctp-surface2)',
+                color: isDisabled ? 'var(--ctp-subtext0)' : 'var(--ctp-text)',
+                border: '1px solid var(--ctp-surface2)',
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                opacity: isDisabled ? 0.6 : 1,
+                fontSize: '0.85rem',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              <UiIcon name="bot" size={16} />
+              Convert to an Automation…
+            </button>
+          );
+        })()}
       </div>
 
       <AutoAckConvertDialog


### PR DESCRIPTION
## Summary

Fixes the confusing UX reported in #4420 ("MeshCore: Cannot find 'Convert to automation' button in Auto-Acknowledge Settings").

The Auto-Acknowledge → Automation converter (#4340 / #4408) is **intentionally scoped to Meshtastic sources only** — per `docs/internal/dev-notes/AUTOACK_CONVERTER_PHASE4_SPEC.md` §5.2: *"MeshCore is out of scope by the epic — its Auto-Ack is a flat template with no Direct/Multi-hop split."* The server already enforces this: `POST /api/automations/convert/preview` and `.../create` both 400 with `SOURCE_NOT_MESHTASTIC` for a MeshCore source (`src/server/routes/autoAckConverterRoutes.ts:104-106`).

However, the **"Convert to an Automation…" button itself was rendered unconditionally** in `AutoAcknowledgeSection.tsx`, regardless of the active source's type. A MeshCore user would see (or not immediately notice) an enabled-looking button, click it, wait for the preview fetch, and only then learn the feature doesn't apply to their source.

## What changed

- `AutoAcknowledgeSection.tsx` now reads `sourceType` from `useSource()` and disables the button (with an explanatory `title` tooltip) when `sourceType === 'meshcore'`, using the same disabled/tooltip pattern already used for the `hasChanges` case.
- Added a regression test in `AutoAcknowledgeSection.convertButton.test.tsx` asserting the button is disabled with the correct tooltip for a MeshCore source, and still enabled for a Meshtastic source with no unsaved changes.

## Note on the original report

The reporter said they couldn't find the button at all, which this change doesn't fully explain on its own (the button was previously always rendered, just non-functional for MeshCore) — the most likely explanation is a stale cached frontend bundle after upgrading to v4.13.3-rc2, or the button blending in among the disabled-looking controls. Either way, this change makes the actual, intentional limitation (Meshtastic-only) visible and self-explanatory instead of surfacing as a runtime error after a round trip, which is the right behavior regardless of the exact repro.

## Testing

- `npx vitest run src/components/AutoAcknowledgeSection.convertButton.test.tsx` — 3/3 passing (2 existing + 1 new)
- `npx vitest run src/components/AutoAcknowledgeSection` — 6 passing / 49 skipped (pre-existing skip, unrelated)
- `npx eslint src/components/AutoAcknowledgeSection.tsx src/components/AutoAcknowledgeSection.convertButton.test.tsx` — only the pre-existing baselined `react-hooks/exhaustive-deps` finding (unchanged, unrelated to this diff)
- `npm run lint:ci` — clean (no FAIL lines outside `.claude/worktrees`)
- `npx tsc --noEmit` — no new errors in the touched files


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGpE5qygZeRxvWPJxEBcxp)_