### PR TITLE
fix(meshcore): scope /snapshot messages field to messages:read permission

### DIFF
--- a/src/server/routes/meshcoreDeviceRoutes.snapshot.permissions.test.ts
+++ b/src/server/routes/meshcoreDeviceRoutes.snapshot.permissions.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Route test — GET /sources/:id/meshcore/snapshot message-permission scoping
+ * (issue #4422).
+ *
+ * `/snapshot` is gated only by `connection:read` (a viewer needs that just to
+ * see the source at all), but its `messages` field carries DM content, which
+ * has its own, stricter `messages:read` grant ("Node Details & DM"). Before
+ * the fix, a caller with `connection:read` but not `messages:read` — e.g. an
+ * anonymous user given view-only status access — received full message
+ * content via this bundled payload.
+ *
+ * Uses the real-middleware harness (createRouteTestApp) per CLAUDE.md: real
+ * express-session + real auth middleware + real checkPermissionAsync against
+ * the singleton's `:memory:` SQLite DB. Only the source-manager registry is
+ * mocked (non-DB) with a stub manager carrying one DM and one channel message.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import meshcoreRoutes from './meshcoreRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+const STUB_MESSAGES = [
+  { id: 'm1', fromPublicKey: 'aaaa', toPublicKey: 'bbbb', text: 'secret dm', timestamp: 1000 },
+];
+
+vi.mock('../sourceManagerRegistry.js', () => {
+  const stubFor = (sourceId: string) => ({
+    sourceId,
+    sourceType: 'meshcore' as const,
+    getConnectionStatus: () => ({ connected: true, deviceType: 1, config: null }),
+    getLocalNode: () => null,
+    getContacts: () => [],
+    getAllNodes: async () => [],
+    getRecentMessages: (_limit?: number) => STUB_MESSAGES,
+  });
+  const managers = new Map([['rt-source-a', stubFor('rt-source-a')]]);
+  return {
+    sourceManagerRegistry: {
+      getManager: (sourceId: string) => managers.get(sourceId),
+      getAllManagers: () => Array.from(managers.values()),
+    },
+  };
+});
+
+describe('meshcoreDeviceRoutes — GET /snapshot message-permission scoping (#4422)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/sources/:id/meshcore', meshcoreRoutes),
+    });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  const urlFor = (sourceId: string) => `/sources/${sourceId}/meshcore/snapshot`;
+
+  it('omits messages when the caller has connection:read but not messages:read', async () => {
+    await harness.grant(harness.limited.id, 'connection', 'read', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+
+    const res = await agent.get(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.messages).toEqual([]);
+    expect(res.body.data.seqCursor).toBe(0);
+  });
+
+  it('includes messages once messages:read is also granted', async () => {
+    await harness.grant(harness.limited.id, 'connection', 'read', harness.sourceA);
+    await harness.grant(harness.limited.id, 'messages', 'read', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+
+    const res = await agent.get(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.messages).toHaveLength(1);
+    expect(res.body.data.messages[0].text).toBe('secret dm');
+    expect(res.body.data.seqCursor).toBe(1000);
+  });
+
+  it('admin sees messages regardless of explicit grants', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.get(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.messages).toHaveLength(1);
+  });
+
+  it('anonymous (unauthenticated) caller without messages:read gets no messages', async () => {
+    await harness.grant(harness.anonymous.id, 'connection', 'read', harness.sourceA);
+    const agent = await harness.loginAs(null);
+
+    const res = await agent.get(urlFor(harness.sourceA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.messages).toEqual([]);
+  });
+});

--- a/src/server/routes/meshcoreDeviceRoutes.ts
+++ b/src/server/routes/meshcoreDeviceRoutes.ts
@@ -13,6 +13,7 @@ import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
 import { managerFor, isValidConnectionParams } from './meshcoreRouteShared.js';
+import databaseService from '../../services/database.js';
 
 const router = Router({ mergeParams: true });
 
@@ -146,6 +147,13 @@ router.get(
  * GET /api/sources/:id/meshcore/snapshot
  * Single-call initial load: status, localNode, contacts, nodes, messages, and a seqCursor
  * (the timestamp of the newest message) for reconnect catch-up.
+ *
+ * The route itself is gated only by `connection:read` (a viewer needs that
+ * just to see the source at all), but `messages` carries DM content, which
+ * has its own, stricter `messages:read` grant ("Node Details & DM"). A
+ * caller with `connection:read` but not `messages:read` — e.g. an anonymous
+ * user given view-only status access — must not receive message content via
+ * this bundled payload (issue #4422).
  */
 router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
@@ -154,7 +162,15 @@ router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', 
     const localNode = manager.getLocalNode();
     const contacts = manager.getContacts();
     const nodes = await manager.getAllNodes();
-    const messages = manager.getRecentMessages(50);
+
+    const sourceId = (req.params as { id: string }).id;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4422 req.user is untyped on Express.Request, matches existing pattern (sourceRoutes.ts)
+    const user = (req as any).user;
+    const isAdmin = user?.isAdmin ?? false;
+    const canReadMessages = isAdmin || (user
+      ? await databaseService.checkPermissionAsync(user.id, 'messages', 'read', sourceId)
+      : false);
+    const messages = canReadMessages ? manager.getRecentMessages(50) : [];
     const seqCursor = messages.length > 0 ? Math.max(...messages.map(m => m.timestamp)) : 0;
 
     // Mirror the contacts-with-localNode logic from GET /contacts


### PR DESCRIPTION
## Summary
- `GET /api/sources/:id/meshcore/snapshot` bundled up to 50 recent messages (DMs included) into its response, but was gated only by `connection:read` ("Can Control Connection: View status"), not `messages:read` ("Node Details & DM")
- A caller with `connection:read` but not `messages:read` — e.g. an anonymous user granted only view-only status access — received full message content on initial page load / reconnect, bypassing the permission that's meant to gate DM visibility
- Every other message-bearing route (`/messages`, `/messages/channel/:idx`, the `join-source` websocket room) already checks `messages:read` correctly; `/snapshot` was the one path that skipped it
- `messages` (and `seqCursor`) are now conditioned on a `messages:read` check for the requesting user against the source, mirroring the existing per-field permission-narrowing pattern in `sourceRoutes.ts`'s dashboard status endpoint

## Test plan
- [x] Added `src/server/routes/meshcoreDeviceRoutes.snapshot.permissions.test.ts` using the real-middleware route harness (`createRouteTestApp`), covering:
  - `connection:read` only → `messages: []`, `seqCursor: 0`
  - `connection:read` + `messages:read` → messages included
  - admin → bypasses the check
  - unauthenticated/anonymous caller without `messages:read` → no messages (reproduces the reported scenario)
- [x] `npx vitest run src/server/routes/meshcoreDeviceRoutes.snapshot.permissions.test.ts src/server/routes/meshcoreRoutes.test.ts src/server/routes/meshcoreRoutes.pathfindingFilter.test.ts` — all passing
- [x] `npm run lint:ci` (ratchet) — passing, no new violations (one unavoidable `@typescript-eslint/no-explicit-any` for the untyped `req.user`, justified inline with a targeted disable comment matching existing convention)

Fixes #4422

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5qzcVeQzafCVEExGn2Uk)_