### PR TITLE
fix(traceroute): route strip edges and labels around unrelated node glyphs (#4428)

### DIFF
--- a/docs/internal/dev-notes/TRACEROUTE_VISUAL_STRIP_SPEC.md
+++ b/docs/internal/dev-notes/TRACEROUTE_VISUAL_STRIP_SPEC.md
@@ -766,9 +766,10 @@ export interface StripLayout {
   height: number;
   /** StripNode.id -> glyph CENTER, in the container's coordinate space. */
   centers: Map<string, StripPoint>;
-  /** Per-edge polyline through 2 or 3 points, already offset off the glyph
-   *  edges so the arrowhead lands on the rim, not under the icon, and
-   *  translated into its leg's lane. */
+  /** Per-edge polyline through 2+ points, already offset off the glyph
+   *  edges so the arrowhead lands on the rim, not under the icon,
+   *  translated into its leg's lane, and routed around unrelated glyphs
+   *  (#4428). */
   edgePaths: Map<string, StripPoint[]>;
   /** Where each edge's SNR label anchors (§3.5.1). */
   labelAnchors: Map<string, StripPoint>;
@@ -812,14 +813,26 @@ occupied, `rowCount = 2`, `columns = 5` →
 `width = 320`, `height = 44 + 2*76 + 44 = 240`. Spine sits at
 `y = 44 + 1*76 + 16 = 136`; the raised `CS`/`TRPK` at `y = 60`.
 
-**Edge paths (unchanged).**
+**Edge paths.**
 * Same-row edge → straight segment between the two centers, both ends pulled in
-  by `glyphSize / 2 + 3` along the segment.
+  by `glyphSize / 2 + EDGE_RIM_MARGIN` (= `+3`) along the segment.
 * Row-crossing edge → 3-point polyline: start rim, elbow at
   `{ x: (x0+x1)/2, y: max(y0,y1) }`, end rim. Straight dog-legs, not beziers —
   easier to read at this pitch and trivially assertable.
 * Then the whole path (2 or 3 points) is translated by
   `canonicalPerpendicular(c0, c1) * LANE_OFFSET * (leg === 'forward' ? +1 : -1)`.
+* **Glyph routing (#4428).** The translated path is then bent around every
+  OTHER node's clearance circle, radius
+  `edgeClearance = glyphSize/2 + EDGE_RIM_MARGIN + LANE_OFFSET` — an edge
+  spanning non-adjacent columns, or a dog-leg grazing a glyph, must not render
+  through nodes it doesn't terminate at. Two bounded, deterministic phases in
+  `routeAroundGlyphs`: (1) an elbow inside a circle is pushed radially out
+  past it; (2) any segment still cutting a circle gets a bend inserted just
+  past the rim (`+ BEND_MARGIN`) at its deepest point. Both phases push
+  radially — the side the lane-translated path already favors — falling back
+  to the leg's lane direction when degenerate, so forward detours stay above
+  and return detours below. Result stays a plain `<polyline>`; paths are
+  therefore **2+ points**, not just 2 or 3.
 
 **`LANE_OFFSET = 5` and `canonicalPerpendicular` are preserved exactly as they
 are.** They exist because the forward and return legs routinely traverse the
@@ -833,7 +846,15 @@ column on different rows) is only reachable from hand-built fixtures and has a
 dedicated test; keep it.
 
 **Label anchors:** §3.5.1. Note the anchor `y` is now derived from row centers,
-so it is independent of `LANE_OFFSET`; the anchor `x` still comes from the
+so it is independent of `LANE_OFFSET` — that row-band rule is also what makes
+the C1 invariant hold, so #4428 never moves a label vertically. The anchor `x`
+(#4428) samples the FINAL routed path: the midpoint of the longest segment
+whose midpoint clears every glyph circle by
+`labelClearRadius = glyphSize/2 + LABEL_HALF_HEIGHT + LABEL_CLEARANCE`
+(ties → the earlier segment; deterministic), with a horizontal-only nudge as a
+last resort. For an un-detoured same-row edge this IS the old endpoint
+midpoint, so plain strips are pixel-identical; on a detoured edge it moves the
+label off the bend and off the avoided glyph's column. X still comes from the
 translated path, which is what separates the two legs' labels on a vertical
 chord.
 

--- a/src/utils/tracerouteStrip.test.ts
+++ b/src/utils/tracerouteStrip.test.ts
@@ -15,6 +15,8 @@ import {
   type TracerouteStripGraph,
   type StripLayoutOptions,
   type StripLane,
+  type StripLeg,
+  type StripPoint,
 } from './tracerouteStrip';
 
 // Reusable "real" node numbers — small distinct integers that are never
@@ -1233,5 +1235,209 @@ describe('layoutTracerouteStrip — per-leg edge lanes (#4381 follow-up #2)', ()
     expect(fwdPath[0].x).not.toBeCloseTo(retPath[0].x, 1);
     expect(fwdPath.every((p) => p.x > colCenterX)).toBe(true);
     expect(retPath.every((p) => p.x < colCenterX)).toBe(true);
+  });
+});
+
+describe('layoutTracerouteStrip — edge/label glyph collision avoidance (#4428)', () => {
+  // Constants recomputed from the public StripLayoutOptions rather than
+  // importing the privates, same pattern as the C1 block above.
+  const NODE_NAME_GAP = 2;
+  const LABEL_HALF_HEIGHT = 8;
+  const LABEL_CLEARANCE = 4;
+  const EDGE_RIM_MARGIN = 3; // matches tracerouteStrip.ts's EDGE_RIM_MARGIN (the pullIn `+3`)
+  const LANE_OFFSET = 5; // matches tracerouteStrip.ts's LANE_OFFSET
+
+  /** Mirrors tracerouteStrip.ts's edgeClearance(): the radius around an
+   *  UNRELATED node's center no edge segment may enter. */
+  const edgeClearance = (glyphSize: number) => glyphSize / 2 + EDGE_RIM_MARGIN + LANE_OFFSET;
+  /** Mirrors tracerouteStrip.ts's labelClearRadius(). */
+  const labelClearRadius = (glyphSize: number) => glyphSize / 2 + LABEL_HALF_HEIGHT + LABEL_CLEARANCE;
+
+  /** Distance from point `p` to the segment `a`->`b`. */
+  function distPointToSegment(p: StripPoint, a: StripPoint, b: StripPoint): number {
+    const abx = b.x - a.x;
+    const aby = b.y - a.y;
+    const len2 = abx * abx + aby * aby;
+    const t = len2 === 0 ? 0 : Math.max(0, Math.min(1, ((p.x - a.x) * abx + (p.y - a.y) * aby) / len2));
+    return Math.hypot(p.x - (a.x + t * abx), p.y - (a.y + t * aby));
+  }
+
+  /** Asserts every segment of `path` clears `center` by at least `radius`. */
+  function expectPathClears(path: StripPoint[], center: StripPoint, radius: number): void {
+    for (let i = 0; i < path.length - 1; i++) {
+      expect(distPointToSegment(center, path[i], path[i + 1])).toBeGreaterThanOrEqual(radius - 1e-6);
+    }
+  }
+
+  /** Hand-built (same precedent as the dx===0 test above): a same-row edge
+   *  spanning non-adjacent columns with an UNRELATED node in the intermediate
+   *  column — before #4428 the straight pull-back line ran right through it. */
+  function sameRowSpanGraph(leg: StripLeg): TracerouteStripGraph {
+    return {
+      nodes: [
+        { id: 'n0', nodeNum: A, lane: 'spine', row: 0, col: 0, legs: [leg], shared: false, isUnknown: false },
+        { id: 'mid', nodeNum: B, lane: 'spine', row: 0, col: 1, legs: [leg], shared: false, isUnknown: false },
+        { id: 'n2', nodeNum: C, lane: 'spine', row: 0, col: 2, legs: [leg], shared: false, isUnknown: false },
+      ],
+      edges: [{ id: 'long', leg, fromId: 'n0', toId: 'n2', snr: 5, snrUnknown: false }],
+      columns: 3,
+      hasForward: leg === 'forward',
+      hasReturn: leg === 'return',
+      isEmpty: false,
+    };
+  }
+
+  /** Hand-built: a row-crossing dog-leg whose elbow `{(x0+x1)/2, max(y0,y1)}`
+   *  lands exactly ON an unrelated node's center (row 1, col 1) — before
+   *  #4428 the dog-leg's two segments met inside that glyph. */
+  function dogLegThroughGlyphGraph(): TracerouteStripGraph {
+    return {
+      nodes: [
+        { id: 'n0', nodeNum: A, lane: 'forward', row: 0, col: 0, legs: ['forward'], shared: false, isUnknown: false },
+        { id: 'obs', nodeNum: B, lane: 'spine', row: 1, col: 1, legs: ['forward'], shared: false, isUnknown: false },
+        { id: 'n2', nodeNum: C, lane: 'spine', row: 1, col: 2, legs: ['forward'], shared: false, isUnknown: false },
+      ],
+      edges: [{ id: 'cross', leg: 'forward', fromId: 'n0', toId: 'n2', snr: 5, snrUnknown: false }],
+      columns: 3,
+      hasForward: true,
+      hasReturn: false,
+      isEmpty: false,
+    };
+  }
+
+  const DEFAULTS = { colWidth: 64, rowHeight: 76, glyphSize: 32, nameHeight: 14, topBand: 44, bottomBand: 44 };
+
+  it('(a) routes a same-row edge spanning non-adjacent columns around the intermediate glyph', () => {
+    const graph = sameRowSpanGraph('forward');
+    const layout = layoutTracerouteStrip(graph, DEFAULTS);
+    const path = layout.edgePaths.get('long')!;
+    const obstacle = layout.centers.get('mid')!; // (96, 60)
+    const rowY = layout.centers.get('n0')!.y; // 60
+
+    // Before #4428 this was the 2-point straight line (51,55)->(141,55),
+    // passing 5px from the obstacle's center — now it bends around it.
+    expect(path.length).toBeGreaterThan(2);
+    expectPathClears(path, obstacle, edgeClearance(DEFAULTS.glyphSize));
+
+    // The endpoints are untouched: still the lane-translated rim points.
+    expect(path[0]).toEqual({ x: 32 + DEFAULTS.glyphSize / 2 + EDGE_RIM_MARGIN, y: rowY - LANE_OFFSET });
+    expect(path[path.length - 1]).toEqual({ x: 160 - DEFAULTS.glyphSize / 2 - EDGE_RIM_MARGIN, y: rowY - LANE_OFFSET });
+
+    // The detour stays on the forward leg's side of the row (above) — it
+    // never dips into the return lane.
+    for (const p of path) expect(p.y).toBeLessThanOrEqual(rowY - LANE_OFFSET + 1e-6);
+  });
+
+  it('(a2) routes the same span for the RETURN leg on the opposite side (below), keeping the legs visually separated', () => {
+    const graph = sameRowSpanGraph('return');
+    const layout = layoutTracerouteStrip(graph, DEFAULTS);
+    const path = layout.edgePaths.get('long')!;
+    const obstacle = layout.centers.get('mid')!;
+    const rowY = layout.centers.get('n0')!.y;
+
+    expect(path.length).toBeGreaterThan(2);
+    expectPathClears(path, obstacle, edgeClearance(DEFAULTS.glyphSize));
+    for (const p of path) expect(p.y).toBeGreaterThanOrEqual(rowY + LANE_OFFSET - 1e-6);
+  });
+
+  it('(b) relocates a cross-row dog-leg elbow that lands on an unrelated glyph, clearing it', () => {
+    const graph = dogLegThroughGlyphGraph();
+    const layout = layoutTracerouteStrip(graph, DEFAULTS);
+    const path = layout.edgePaths.get('cross')!;
+    const obstacle = layout.centers.get('obs')!; // (96, 136) == the raw elbow
+
+    // Still a single-elbow dog-leg — the elbow MOVED, it didn't multiply.
+    expect(path).toHaveLength(3);
+    expectPathClears(path, obstacle, edgeClearance(DEFAULTS.glyphSize));
+    // The elbow itself sits outside the clearance circle.
+    expect(Math.hypot(path[1].x - obstacle.x, path[1].y - obstacle.y))
+      .toBeGreaterThanOrEqual(edgeClearance(DEFAULTS.glyphSize) - 1e-6);
+  });
+
+  it('(c) anchors the label off the detour bump and clear of every glyph circle, keeping lane semantics', () => {
+    const graph = sameRowSpanGraph('forward');
+    const layout = layoutTracerouteStrip(graph, DEFAULTS);
+    const anchor = layout.labelAnchors.get('long')!;
+    const rowY = layout.centers.get('n0')!.y;
+
+    // Lane semantics intact: the forward label still anchors labelOffset
+    // above its own row (the C1 row-band rule — Y is unchanged by #4428).
+    const labelOffset = (DEFAULTS.glyphSize + NODE_NAME_GAP + DEFAULTS.nameHeight) / 2 + LABEL_HALF_HEIGHT + LABEL_CLEARANCE;
+    expect(anchor.y).toBeCloseTo(rowY - labelOffset, 5);
+
+    // Before #4428, X was the raw endpoint midpoint = 96 — the obstacle's
+    // exact column, directly on top of the inserted detour bend. Now it
+    // samples the longest clear segment (tie -> the earlier one, so it lands
+    // left of the bump).
+    expect(anchor.x).toBeLessThan(96);
+
+    // And the anchor clears every glyph circle by the label margin.
+    for (const n of graph.nodes) {
+      const c = layout.centers.get(n.id)!;
+      expect(Math.hypot(anchor.x - c.x, anchor.y - c.y))
+        .toBeGreaterThanOrEqual(labelClearRadius(DEFAULTS.glyphSize) - 1e-6);
+    }
+  });
+
+  it('leaves an unobstructed strip pixel-identical: 2-point line, label X at the endpoint midpoint', () => {
+    // Direct 2-node graph — nothing to route around, so #4428 must be a
+    // no-op: no extra bends, and the label X equals the pre-#4428 midpoint.
+    const graph = buildTracerouteStripGraph({
+      fromNodeNum: FROM,
+      toNodeNum: TO,
+      route: '[]',
+      snrTowards: '[20]',
+      routeBack: '[]',
+      snrBack: '[-40]',
+    });
+    const layout = layoutTracerouteStrip(graph);
+    for (const e of graph.edges) {
+      const path = layout.edgePaths.get(e.id)!;
+      expect(path).toHaveLength(2);
+      expect(layout.labelAnchors.get(e.id)!.x).toBeCloseTo((path[0].x + path[1].x) / 2, 5);
+    }
+  });
+
+  it('is deterministic — the same graph yields the identical routed layout on every call', () => {
+    const first = layoutTracerouteStrip(sameRowSpanGraph('forward'), DEFAULTS);
+    const second = layoutTracerouteStrip(sameRowSpanGraph('forward'), DEFAULTS);
+    expect(second).toEqual(first);
+  });
+
+  it('edge-clearance sweep: every edge segment clears every non-endpoint glyph across real §3.7 fixtures and the #4428 repros', () => {
+    const graphs: TracerouteStripGraph[] = [
+      buildTracerouteStripGraph({
+        fromNodeNum: A, toNodeNum: D, route: JSON.stringify([B, C]), routeBack: JSON.stringify([E]),
+        snrTowards: JSON.stringify([10, 20, 30]), snrBack: JSON.stringify([1, 2]),
+      }),
+      buildTracerouteStripGraph({
+        fromNodeNum: 3001, toNodeNum: 3005,
+        route: JSON.stringify([3002, 3003, 3004]),
+        snrTowards: JSON.stringify([42, -45, 29, 15]),
+        routeBack: JSON.stringify([3002]),
+        snrBack: JSON.stringify([37, 44]),
+      }),
+      buildTracerouteStripGraph({
+        fromNodeNum: FROM, toNodeNum: TO,
+        route: JSON.stringify([BROADCAST_ADDR, 3145]),
+        routeBack: JSON.stringify([3145, BROADCAST_ADDR]),
+        snrTowards: JSON.stringify([1, 2, 3]),
+        snrBack: JSON.stringify([4, 5, 6]),
+      }),
+      sameRowSpanGraph('forward'),
+      sameRowSpanGraph('return'),
+      dogLegThroughGlyphGraph(),
+    ];
+    const clearance = edgeClearance(DEFAULTS.glyphSize);
+    for (const graph of graphs) {
+      const layout = layoutTracerouteStrip(graph, DEFAULTS);
+      for (const e of graph.edges) {
+        const path = layout.edgePaths.get(e.id)!;
+        for (const n of graph.nodes) {
+          if (n.id === e.fromId || n.id === e.toId) continue;
+          expectPathClears(path, layout.centers.get(n.id)!, clearance);
+        }
+      }
+    }
   });
 });

--- a/src/utils/tracerouteStrip.ts
+++ b/src/utils/tracerouteStrip.ts
@@ -765,9 +765,23 @@ const EDGE_RIM_MARGIN = 3;
  *  slack here. */
 const BEND_MARGIN = LABEL_CLEARANCE;
 
-/** Bounded pass counts that make the routing loops total. Realistic grid
- *  layouts resolve in one pass; the caps only matter for pathological
- *  custom options. */
+/** Passes of phase 1 (interior-vertex push-out) in `routeAroundGlyphs`.
+ *
+ *  Why ONE pass suffices for geometry the builder + floored options produce:
+ *  a pushed vertex lands exactly `detour` from the offending node's center,
+ *  so it can only fall inside a SECOND node's circle when the two centers
+ *  sit closer than `clearance + detour` (24 + 28 = 52px at defaults). Grid
+ *  centers are at least min(colWidth, rowHeight) apart — 64px columns and
+ *  the 72px `minRowHeight` floor at defaults — so a pushed vertex can never
+ *  enter another circle, and the second pass verifies quiescence and breaks.
+ *  The remaining passes only absorb push chains under custom options that
+ *  pack columns tighter than `clearance + detour`.
+ *
+ *  If the cap is exhausted anyway (unreachable from produced geometry), a
+ *  vertex stays inside some circle; phase 2 deliberately skips segments
+ *  whose endpoint sits in-circle, so that one elbow renders on the glyph —
+ *  the pre-#4428 appearance for that edge — and the loop still terminates.
+ *  Degraded looks, never a hang or crash. */
 const VERTEX_PUSH_PASSES = 4;
 
 /** Numeric slack for "already clear" comparisons. */
@@ -846,6 +860,32 @@ function routeAroundGlyphs(
   }
 
   // Phase 2: insert bends where a segment cuts a clearance circle.
+  //
+  // Why 2N+4 cannot be hit by geometry the strip actually produces. First,
+  // termination never depends on the cap: every loop iteration either
+  // inserts a bend (counted against the cap) or advances `i`, and `pts`
+  // grows only by insertions — so the walk always ends. The cap only bounds
+  // how many bends we are willing to spend. Per obstacle, a bend is inserted
+  // only for a segment whose BOTH endpoints lie outside that obstacle's
+  // clearance circle (in-circle endpoints are skipped above). Such a chord
+  // with both endpoints at distance >= `detour` and central wrap angle θ has
+  // minimum distance >= detour·cos(θ/2), so it still cuts the circle only
+  // when θ > 2·acos(clearance/detour) — about 62° at defaults (24/28).
+  // Inserting the bend at the deepest point splits the wrap roughly in half,
+  // so one bend resolves any wrap up to ~124°, and even the absolute worst
+  // case — a near-diameter crossing, θ -> 180°, which the builder's grid
+  // cannot produce because every path is a lane-offset row line or a
+  // rim-pulled dog-leg — resolves after two splits, i.e. 3 bends. Produced
+  // paths cut shallowly (the lane offset is 5px against a 24px radius) and
+  // take exactly 1 bend per cut obstacle; 2 per obstacle plus 4 spare is
+  // therefore beyond anything reachable (the #4428 tests sweep every §3.7
+  // fixture plus the repro graphs and never exceed 1 per obstacle).
+  //
+  // If the cap were exhausted anyway (conceivable only with extreme custom
+  // StripLayoutOptions, e.g. colWidth far below glyphSize so circles swallow
+  // whole segments), `best` stays null, the walk runs to the end, and the
+  // remaining cuts simply render through the glyph — the pre-#4428 look for
+  // that edge, never an infinite loop or a crash.
   const maxBends = 2 * obstacles.length + 4;
   let inserted = 0;
   let i = 0;

--- a/src/utils/tracerouteStrip.ts
+++ b/src/utils/tracerouteStrip.ts
@@ -626,9 +626,11 @@ export interface StripLayout {
   height: number;
   /** StripNode.id -> glyph CENTER, in the container's coordinate space. */
   centers: Map<string, StripPoint>;
-  /** Per-edge polyline through 2 or 3 points, already offset off the glyph
+  /** Per-edge polyline through 2+ points, already offset off the glyph
    *  edges so the arrowhead lands on the rim, not under the icon, and
-   *  translated into its leg's lane. */
+   *  translated into its leg's lane. Base shape is 2 points (same-row) or 3
+   *  (row-crossing dog-leg); extra bend points appear where the path had to
+   *  route around an unrelated node's glyph (#4428). */
   edgePaths: Map<string, StripPoint[]>;
   /** Where each edge's SNR label anchors (§3.5.1). */
   labelAnchors: Map<string, StripPoint>;
@@ -740,6 +742,199 @@ function canonicalPerpendicular(a: StripPoint, b: StripPoint): StripPoint {
   return { x: uy, y: -ux }; // 90° rotation; canonical dx>=0 => y<=0 ("up")
 }
 
+// ---------------------------------------------------------------------------
+// Edge/label glyph collision avoidance (#4428). The straight/dog-leg paths
+// above only consider an edge's OWN two endpoints, so an edge spanning
+// non-adjacent columns (or a dog-leg whose elbow lands near a glyph) used to
+// render straight through unrelated nodes, and the SNR label — whose X was
+// the raw endpoint midpoint — could sit exactly on the glyph/bend it should
+// avoid. `routeAroundGlyphs` bends the path around every other node's
+// clearance circle; `pickLabelX` then samples the label X from the FINAL
+// routed path. Both are pure, bounded, and deterministic — same graph in,
+// same geometry out.
+// ---------------------------------------------------------------------------
+
+/** Rim margin between a glyph's edge and where an edge line starts/ends —
+ *  the historical inline `+3` in `pullIn`, named because `edgeClearance`
+ *  reuses it (#4428). */
+const EDGE_RIM_MARGIN = 3;
+
+/** How far past a clearance circle a detour bend is placed. A bend exactly
+ *  ON the circle's rim would let its two adjacent segments graze back
+ *  inside; the same breathing room LABEL_CLEARANCE gives labels is enough
+ *  slack here. */
+const BEND_MARGIN = LABEL_CLEARANCE;
+
+/** Bounded pass counts that make the routing loops total. Realistic grid
+ *  layouts resolve in one pass; the caps only matter for pathological
+ *  custom options. */
+const VERTEX_PUSH_PASSES = 4;
+
+/** Numeric slack for "already clear" comparisons. */
+const GEOM_EPS = 1e-6;
+
+/** Radius around an UNRELATED node's center that no edge segment may enter
+ *  (#4428): the same rim the edge's own endpoints respect (`pullIn` =
+ *  glyphSize/2 + EDGE_RIM_MARGIN) plus one LANE_OFFSET, so both legs'
+ *  lane-translated parallels still clear the glyph by the full rim margin. */
+function edgeClearance(o: StripLayoutOptions): number {
+  return o.glyphSize / 2 + EDGE_RIM_MARGIN + LANE_OFFSET;
+}
+
+function dist(a: StripPoint, b: StripPoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/** Closest point to `c` on the segment `a`->`b`, plus its parameter t∈[0,1]. */
+function closestPointOnSegment(
+  a: StripPoint,
+  b: StripPoint,
+  c: StripPoint,
+): { point: StripPoint; t: number } {
+  const abx = b.x - a.x;
+  const aby = b.y - a.y;
+  const len2 = abx * abx + aby * aby;
+  if (len2 < GEOM_EPS) return { point: { x: a.x, y: a.y }, t: 0 };
+  const t = Math.max(0, Math.min(1, ((c.x - a.x) * abx + (c.y - a.y) * aby) / len2));
+  return { point: { x: a.x + t * abx, y: a.y + t * aby }, t };
+}
+
+/**
+ * Bend an (already lane-translated) polyline around every obstacle's
+ * clearance circle. Two phases, both deterministic and bounded:
+ *
+ * 1. Interior vertices (the dog-leg elbow) inside a circle are pushed
+ *    radially out past it — radially, so the vertex leaves on the side the
+ *    path already favors; a vertex exactly ON a center falls back to
+ *    `laneDir` (the leg's own lane-offset direction), which is what keeps
+ *    forward detours above and return detours below.
+ * 2. The segments are walked in order; wherever one cuts a circle, a bend is
+ *    inserted just past the rim at the deepest point (same radial /
+ *    `laneDir` side rule), and the shortened segment is re-checked before
+ *    advancing. A segment whose own endpoint sits inside a circle is left
+ *    alone — bending cannot fix it, and after phase 1 only a rim endpoint of
+ *    a pathologically tight custom layout can hit that.
+ *
+ * The result is still a plain polyline (the strip renders `<polyline>`),
+ * just with 0+ extra bend points.
+ */
+function routeAroundGlyphs(
+  path: StripPoint[],
+  obstacles: StripPoint[],
+  clearance: number,
+  laneDir: StripPoint,
+): StripPoint[] {
+  if (obstacles.length === 0) return path;
+  const detour = clearance + BEND_MARGIN;
+  const pts = path.slice();
+
+  // Phase 1: push interior vertices out of every clearance circle.
+  for (let pass = 0; pass < VERTEX_PUSH_PASSES; pass++) {
+    let moved = false;
+    for (let i = 1; i < pts.length - 1; i++) {
+      for (const c of obstacles) {
+        const d = dist(pts[i], c);
+        if (d >= clearance - GEOM_EPS) continue;
+        const dir = d > GEOM_EPS
+          ? { x: (pts[i].x - c.x) / d, y: (pts[i].y - c.y) / d }
+          : laneDir;
+        pts[i] = { x: c.x + dir.x * detour, y: c.y + dir.y * detour };
+        moved = true;
+      }
+    }
+    if (!moved) break;
+  }
+
+  // Phase 2: insert bends where a segment cuts a clearance circle.
+  const maxBends = 2 * obstacles.length + 4;
+  let inserted = 0;
+  let i = 0;
+  while (i < pts.length - 1) {
+    const p = pts[i];
+    const q = pts[i + 1];
+    let best: { w: StripPoint; t: number } | null = null;
+    if (inserted < maxBends) {
+      for (const c of obstacles) {
+        if (dist(p, c) < clearance - GEOM_EPS || dist(q, c) < clearance - GEOM_EPS) continue;
+        const { point: f, t } = closestPointOnSegment(p, q, c);
+        const d = dist(f, c);
+        if (d >= clearance - GEOM_EPS) continue;
+        const dir = d > GEOM_EPS
+          ? { x: (f.x - c.x) / d, y: (f.y - c.y) / d }
+          : laneDir;
+        const w = { x: c.x + dir.x * detour, y: c.y + dir.y * detour };
+        // A bend coinciding with an endpoint can't make progress — skip it.
+        if (dist(w, p) < GEOM_EPS || dist(w, q) < GEOM_EPS) continue;
+        // Deepest-first would also work; earliest-along-the-segment keeps
+        // the left-to-right walk orderly. Ties keep the first obstacle in
+        // node order — deterministic either way.
+        if (!best || t < best.t) best = { w, t };
+      }
+    }
+    if (best) {
+      pts.splice(i + 1, 0, best.w);
+      inserted++;
+      // Re-check p -> bend before advancing.
+    } else {
+      i++;
+    }
+  }
+  return pts;
+}
+
+/** Approximate a rendered SNR label by a circle around its anchor: half its
+ *  height plus the same breathing room the vertical rule uses. Width is NOT
+ *  modeled — the C1 row-band rule (`labelOffset`) already keeps anchors
+ *  vertically clear of every node footprint; this radius only guards the
+ *  horizontal pick/nudge in `pickLabelX`. */
+function labelClearRadius(o: StripLayoutOptions): number {
+  return o.glyphSize / 2 + LABEL_HALF_HEIGHT + LABEL_CLEARANCE;
+}
+
+/**
+ * #4428: choose the label's X from the FINAL routed path. Candidates are the
+ * path's segment midpoints, longest segment first (ties -> the earlier
+ * segment, so the pick is deterministic); the first whose anchor point
+ * clears every glyph circle wins. If none clears (only reachable with tiny
+ * custom layouts), fall back to the longest segment's midpoint and push it
+ * horizontally clear of each offender in turn — horizontal ONLY, so the
+ * forward-above/return-below lane semantics and the C1 row-band invariant
+ * survive untouched.
+ */
+function pickLabelX(
+  path: StripPoint[],
+  anchorY: number,
+  glyphCenters: StripPoint[],
+  radius: number,
+): number {
+  const candidates: { x: number; len: number; idx: number }[] = [];
+  for (let i = 0; i < path.length - 1; i++) {
+    candidates.push({
+      x: (path[i].x + path[i + 1].x) / 2,
+      len: dist(path[i], path[i + 1]),
+      idx: i,
+    });
+  }
+  candidates.sort((a, b) => b.len - a.len || a.idx - b.idx);
+  const clears = (x: number): boolean =>
+    glyphCenters.every((c) => dist({ x, y: anchorY }, c) >= radius - GEOM_EPS);
+  for (const cand of candidates) {
+    if (clears(cand.x)) return cand.x;
+  }
+  let x = candidates[0].x;
+  for (let pass = 0; pass <= glyphCenters.length; pass++) {
+    const offender = glyphCenters.find(
+      (c) => dist({ x, y: anchorY }, c) < radius - GEOM_EPS,
+    );
+    if (!offender) break;
+    const dy = anchorY - offender.y;
+    const reach = Math.sqrt(Math.max(0, radius * radius - dy * dy));
+    // Push just past the offender's circle, away from it (ties push right).
+    x = offender.x + (x >= offender.x ? 1 : -1) * (reach + LABEL_CLEARANCE);
+  }
+  return x;
+}
+
 export function layoutTracerouteStrip(
   graph: TracerouteStripGraph,
   opts?: Partial<StripLayoutOptions>,
@@ -769,7 +964,10 @@ export function layoutTracerouteStrip(
   const nodeById = new Map(graph.nodes.map((n) => [n.id, n] as const));
   const edgePaths = new Map<string, StripPoint[]>();
   const labelAnchors = new Map<string, StripPoint>();
-  const pullIn = o.glyphSize / 2 + 3;
+  const pullIn = o.glyphSize / 2 + EDGE_RIM_MARGIN;
+  const clearance = edgeClearance(o);
+  const labelRadius = labelClearRadius(o);
+  const allGlyphCenters = graph.nodes.map((n) => centers.get(n.id)!);
 
   for (const e of graph.edges) {
     const c0 = centers.get(e.fromId);
@@ -803,21 +1001,35 @@ export function layoutTracerouteStrip(
     const laneDy = perpUp.y * LANE_OFFSET * laneSign;
     path = path.map((p) => ({ x: p.x + laneDx, y: p.y + laneDy }));
 
+    // #4428: bend the lane-translated path around every OTHER node's
+    // clearance circle — an edge spanning non-adjacent columns (or a dog-leg
+    // grazing a glyph) must not render through nodes it doesn't terminate at.
+    const obstacles: StripPoint[] = [];
+    for (const n of graph.nodes) {
+      if (n.id === e.fromId || n.id === e.toId) continue;
+      obstacles.push(centers.get(n.id)!);
+    }
+    const laneDir = { x: perpUp.x * laneSign, y: perpUp.y * laneSign };
+    path = routeAroundGlyphs(path, obstacles, clearance, laneDir);
+
     edgePaths.set(e.id, path);
 
     // §3.5.1: the label's Y anchors off ROW CENTERS, not the (lane-offset-
     // translated) path — otherwise, with three possible rows, a flat +/-
     // offset from the path can land inside the wrong lane's node footprint.
-    // X still comes from the translated path, which is what keeps a purely
-    // vertical chord's two legs horizontally separated.
-    const first = path[0];
-    const last = path[path.length - 1];
-    const midX = (first.x + last.x) / 2;
+    // That row-band rule is also what guarantees C1 (|anchor.y - center.y|
+    // >= labelOffset for EVERY node), so #4428 never moves a label
+    // vertically. X samples the FINAL routed path via `pickLabelX` — before
+    // #4428 it was the raw endpoint midpoint, which could sit exactly on a
+    // detour bend or on the column of the glyph the path just routed around.
+    // For an un-detoured same-row edge the longest (only) segment's midpoint
+    // IS the endpoint midpoint, so plain strips are pixel-identical.
     const laneYSign = e.leg === 'forward' ? -1 : 1; // forward=up, return=down
     const anchorY = sameRow
       ? c0.y + laneYSign * offset // same-row: offset off this row's center
       : (c0.y + c1.y) / 2; // crossing: middle of the inter-row gap
-    labelAnchors.set(e.id, { x: midX, y: anchorY });
+    const anchorX = pickLabelX(path, anchorY, allGlyphCenters, labelRadius);
+    labelAnchors.set(e.id, { x: anchorX, y: anchorY });
   }
 
   return { width, height, centers, edgePaths, labelAnchors };


### PR DESCRIPTION
## Summary

Fixes #4428: in the traceroute strip, an edge spanning non-adjacent columns (or a dog-leg whose elbow lands near a glyph) rendered straight through unrelated node glyphs, and the dB label — computed independently as the raw endpoint midpoint — could sit exactly on a glyph even with the line fixed.

- **Edge routing:** after the existing per-leg lane translation, `routeAroundGlyphs` bends each polyline around every non-endpoint node's clearance circle (`glyphSize/2 + EDGE_RIM_MARGIN + LANE_OFFSET` — all named constants derived from existing layout values; the historical inline `+3` in `pullIn` is now `EDGE_RIM_MARGIN`). Two bounded phases: interior vertices (dog-leg elbows) inside a circle are pushed radially past it, then segments still cutting a circle get a bend inserted at the deepest point. Push side follows the path's radial preference, falling back to the leg's lane direction — forward detours bend up, return detours bend down. Pure, deterministic, still a plain polyline; no rendering-component changes.
- **Label anchors** (per the issue's follow-up comment): X now samples the FINAL routed path — midpoint of the longest segment clearing every glyph circle by the label margin — with a horizontal-nudge fallback. Y keeps the row-band rule, preserving the C1 invariant and the `.above`/`.below` lane semantics.
- Un-detoured edges compute the exact pre-fix coordinates — plain strips are pixel-identical.

## Testing

- **Zero existing tests changed**: all 129 pre-existing strip layout/render tests pass byte-identical.
- 7 new regression tests asserting real geometric clearance (point-to-segment distance ≥ clearance for every non-endpoint glyph): same-row span over an intermediate glyph (both legs, opposite detour sides), dog-leg elbow on a glyph, label clearance, a no-op guard (unobstructed strip pixel-identical), determinism, and a clearance sweep over the spec's §3.7 fixtures.
- Full Vitest suite: **12,600 passed / 0 failed** (`success: true`, JSON reporter); `tsc` clean; lint ratchet passes.
- Spec doc (`TRACEROUTE_VISUAL_STRIP_SPEC.md`) updated with the routing rule.

Fixes #4428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTfGTsPBskKYJUK8SSvYob