### PR TITLE
fix(meshcore): guard startAutoPathfinding() against overlapping calls

### DIFF
--- a/src/server/meshcoreManager.autoPathfindingOverlap.test.ts
+++ b/src/server/meshcoreManager.autoPathfindingOverlap.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for #4434: MeshCore Auto-Pathfinding's time interval was
+ * not being respected — reports of packets accelerating over time until the
+ * source was disabled and re-enabled.
+ *
+ * Root cause: `startAutoPathfinding()` does `stopAutoPathfinding()` then
+ * several sequential `await`s on settings reads before finally installing a
+ * jitter `setTimeout` → recurring `setInterval`. There was no guard against
+ * two overlapping calls (e.g. a reconnect racing a settings save, or two
+ * reconnects racing each other via `attemptReconnect()`/the fire-and-forget
+ * call in `connect()`). Each overlapping call's `stopAutoPathfinding()` ran
+ * too early to clear a sibling call's not-yet-installed timer, so both calls
+ * independently installed their own timer and only the most recently
+ * assigned handle remained reachable — the other became an orphan that no
+ * future `stopAutoPathfinding()` could ever clear. Every additional race
+ * stacked one more orphaned interval, compounding the effective packet rate
+ * over a session, matching the reported "accelerates over time" symptom and
+ * "disable/re-enable resets it" behavior (a fresh manager has no orphans
+ * yet).
+ *
+ * The fix adds an `autoPathfindingGeneration` counter, bumped by every
+ * `stopAutoPathfinding()` call, that a `startAutoPathfinding()` call checks
+ * before installing its timer — a superseded call aborts instead of
+ * installing an unreachable timer.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+
+function mockPathfindingSettings() {
+  return vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+    async (_sourceId: string | null | undefined, key: string) => {
+      switch (key) {
+        case 'meshcoreAutoPathfindingEnabled':
+          return 'true';
+        case 'meshcoreAutoPathfindingPathDiscoveryEnabled':
+          return 'true';
+        case 'meshcoreAutoPathfindingNeighborsEnabled':
+          return 'false';
+        case 'meshcoreAutoPathfindingIntervalMinutes':
+          return '3';
+        case 'meshcoreAutoPathfindingRepeatHours':
+          return '1';
+        default:
+          return null;
+      }
+    }
+  );
+}
+
+describe('MeshCoreManager.startAutoPathfinding() overlap guard (#4434)', () => {
+  beforeEach(() => {
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    // Deterministic jitter: initialJitterMs = Math.random() * maxJitterMs.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('a second overlapping start supersedes the first — only one timer survives', async () => {
+    const m = new MeshCoreManager('test-source');
+    mockPathfindingSettings();
+
+    const call1 = m.startAutoPathfinding();
+    const call2 = m.startAutoPathfinding();
+    await Promise.all([call1, call2]);
+
+    // Before the fix both calls independently installed a jitter timeout —
+    // the first became an orphan no future stopAutoPathfinding() could
+    // clear. Only the most recent call should end up owning one.
+    expect(vi.getTimerCount()).toBe(1);
+    expect((m as any).autoPathfindingJitterTimeout).not.toBeNull();
+  });
+
+  it('three overlapping (re)starts still leave exactly one live interval firing', async () => {
+    const m = new MeshCoreManager('test-source');
+    mockPathfindingSettings();
+    (m as any).connected = true;
+    (m as any).getContacts = vi.fn().mockReturnValue([]);
+
+    // Simulates a burst of overlapping calls (reconnect flap racing a
+    // settings save, e.g.) — each used to leave the previous timer running
+    // and orphaned, compounding the effective packet rate over time.
+    await Promise.all([
+      m.startAutoPathfinding(),
+      m.startAutoPathfinding(),
+      m.startAutoPathfinding(),
+    ]);
+
+    // Jitter delay is 0ms (Math.random mocked) — let it fire and install the
+    // recurring interval.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('stopAutoPathfinding() invalidates an in-flight start (e.g. a disconnect racing connect())', async () => {
+    const m = new MeshCoreManager('test-source');
+    mockPathfindingSettings();
+
+    const inFlightStart = m.startAutoPathfinding();
+    // Simulate disconnect() running while the settings reads above are still
+    // in flight (connect()'s call to startAutoPathfinding() is
+    // fire-and-forget).
+    m.stopAutoPathfinding();
+    await inFlightStart;
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect((m as any).autoPathfindingJitterTimeout).toBeNull();
+    expect((m as any).autoPathfindingTimer).toBeNull();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -922,6 +922,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   private autoPathfindingTimer: NodeJS.Timeout | null = null;
   private autoPathfindingJitterTimeout: NodeJS.Timeout | null = null;
   private autoPathfindingLastRunAt: number = 0;
+  // Bumped by every stopAutoPathfinding() call (including the one at the top
+  // of startAutoPathfinding()). Lets a concurrent/overlapping start() call
+  // detect it has been superseded before it installs a timer — see #4434.
+  private autoPathfindingGeneration: number = 0;
 
   // Auto-announce scheduler state. announceScheduler holds the recurring
   // trigger (cron or interval) via the shared CronOrIntervalScheduler
@@ -6124,6 +6128,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
 
   async startAutoPathfinding(): Promise<void> {
     this.stopAutoPathfinding();
+    const myGeneration = this.autoPathfindingGeneration;
 
     const enabledRaw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoPathfindingEnabled');
     if (enabledRaw !== 'true') {
@@ -6228,7 +6233,17 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: run complete`);
     };
 
+    if (myGeneration !== this.autoPathfindingGeneration) {
+      // A newer startAutoPathfinding() call (or a stopAutoPathfinding()) ran
+      // while we were awaiting settings above — don't install a timer this
+      // stale call no longer owns (#4434: overlapping starts previously
+      // stacked orphaned setInterval handles no future stop() could reach).
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: start superseded, aborting`);
+      return;
+    }
+
     this.autoPathfindingJitterTimeout = setTimeout(() => {
+      if (myGeneration !== this.autoPathfindingGeneration) return;
       this.autoPathfindingJitterTimeout = null;
       executeRun().catch(err => logger.error('[MeshCore] Auto-pathfinding scheduler error:', err));
       this.autoPathfindingTimer = setInterval(executeRun, repeatMs);
@@ -6236,6 +6251,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   }
 
   stopAutoPathfinding(): void {
+    this.autoPathfindingGeneration++;
     if (this.autoPathfindingJitterTimeout) {
       clearTimeout(this.autoPathfindingJitterTimeout);
       this.autoPathfindingJitterTimeout = null;


### PR DESCRIPTION
## Summary
- Fixes #4434 — MeshCore Auto-Pathfinding (and its interaction with reconnects) was not respecting the configured interval; packet transmission would accelerate over a session until the source was disabled and re-enabled.
- Adds an `autoPathfindingGeneration` counter to `MeshCoreManager`, bumped by every `stopAutoPathfinding()` call, that `startAutoPathfinding()` checks before installing its `setTimeout`/`setInterval` — a superseded call now aborts instead of silently orphaning a timer.

## Root cause
`startAutoPathfinding()` is `async`: it calls `stopAutoPathfinding()` synchronously, then does several sequential `await`s on per-source settings reads before finally installing a jitter `setTimeout` → recurring `setInterval`. There was no guard against two overlapping calls to this method. `startAutoPathfinding()` is invoked:
- fire-and-forget (unawaited) from `connect()` on every successful connect **and every reconnect**,
- awaited from the pathfinding-settings save route.

If a second call started while a first call's settings-read chain was still pending (a reconnect flapping, or a settings save racing a reconnect), each call's own `stopAutoPathfinding()` ran too early to clear the sibling call's not-yet-installed timer. Both calls then independently finished and each **overwrote** the same instance fields holding the timer handles. Whichever assignment happened first became an orphan — no future `stopAutoPathfinding()` could reach it anymore, since only the most-recently-assigned handle is reachable — and it kept firing forever alongside the new one. Every additional race (another reconnect, another settings save) stacked one more orphaned interval, compounding the effective packet rate over the session — matching the reported "interval not respected, accelerates over time" symptom. Disabling and re-enabling the source didn't clear the orphans directly, but reset `connected` so their `executeRun()` no-ops went quiet until the next reconnect re-activated them, which read as "resets it."

## Fix
- New `autoPathfindingGeneration` field, incremented on every `stopAutoPathfinding()` call (including the one `startAutoPathfinding()` itself makes on entry).
- `startAutoPathfinding()` captures the generation right after its own `stopAutoPathfinding()` call and checks it again immediately before scheduling the jitter timeout, and once more inside the jitter timeout's callback (since the jitter delay can be up to 5 minutes, long enough for another start/stop to have happened in the meantime). A stale call aborts without touching timer state.
- This also fixes the disconnect-races-connect() case: `disconnect()`'s `stopAutoPathfinding()` call now reliably invalidates any in-flight `startAutoPathfinding()` promise left over from an unawaited `connect()` call, so it can no longer install a timer on an already-torn-down manager.

## Test plan
- [x] New regression test `src/server/meshcoreManager.autoPathfindingOverlap.test.ts` — verified it **fails without the fix** (3 overlapping starts → 3 live timers) and **passes with it** (→ 1 live timer), plus a disconnect-races-in-flight-start case.
- [x] Full `meshcoreManager` test suite (39 files / 337 tests) passes.
- [x] `npm run lint:ci` passes (no ratchet growth).
- [x] `tsc --noEmit` reports no new errors.

---
-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_017cKUr83pV8N7niBgEyRK3k)_