### PR TITLE
fix(telemetry): humanize Dashboard uptime widget (#3261) + align DM chart padding (#4426)

### DIFF
--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -28,7 +28,7 @@ import { useWidgetMode } from '../hooks/useWidgetMode';
 import { useWidgetRange } from '../hooks/useWidgetRange';
 import { useSource } from '../contexts/SourceContext';
 import { getLatestValue } from '../utils/telemetry';
-import { unitScale } from '../utils/telemetryFormat';
+import { unitScale, formatDuration, isUptimeType } from '../utils/telemetryFormat';
 import TelemetryGauge from './TelemetryGauge';
 import TelemetryNumericLabel from './TelemetryNumericLabel';
 import { UiIcon } from './icons';
@@ -481,6 +481,10 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     const nodeName = formatNodeName(node, favorite.nodeId);
     const isTemperature = isTemperatureType(favorite.telemetryType);
+    // Uptime-in-seconds metrics (uptimeSeconds, hostUptimeSeconds,
+    // paxcounterUptime, mc_*_uptime_secs) display as humanized durations
+    // instead of raw seconds (#3261).
+    const isUptime = isUptimeType(favorite.telemetryType);
     const color = getColor(favorite.telemetryType);
     const label = isPaxcounterCombined ? 'Paxcounter' : getTranslatedLabel(favorite.telemetryType);
 
@@ -569,7 +573,13 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
       0
     );
     const valueScale = isTemperature ? null : unitScale(baseUnit, seriesMaxAbs);
-    const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : (valueScale ? valueScale.unit : baseUnit);
+    // Humanized durations carry their own units ("3d 4h"), so drop the
+    // stored "s" unit for uptime metrics — mirrors UnifiedTelemetryPage.
+    const unit = isTemperature
+      ? getTemperatureUnit(temperatureUnit)
+      : isUptime
+        ? ''
+        : (valueScale ? valueScale.unit : baseUnit);
 
     // For combined paxcounter chart, merge BLE data
     if (isPaxcounterCombined) {
@@ -618,6 +628,10 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
         : v / (valueScale ? valueScale.factor : 1);
     const handleRangeChange = (r: { min: number; max: number }) =>
       setRange({ min: toStored(r.min), max: toStored(r.max) });
+
+    // Display formatter for uptime metrics: humanize seconds in the gauge,
+    // the numeric label, the Y-axis ticks and the tooltip (#3261).
+    const uptimeFormatter = isUptime ? formatDuration : undefined;
 
     return (
       <div ref={setNodeRef} style={style} className="dashboard-chart-container">
@@ -685,6 +699,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
               timestamp={latest.timestamp}
               nodeId={favorite.nodeId}
               onRangeChange={handleRangeChange}
+              formatValue={uptimeFormatter}
             />
           ) : (
             <div className="dashboard-no-data">{t('dashboard.no_chart_data')}</div>
@@ -696,6 +711,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
               unit={unit}
               color={color}
               timestamp={latest.timestamp}
+              formatValue={uptimeFormatter}
             />
           ) : (
             <div className="dashboard-no-data">{t('dashboard.no_chart_data')}</div>
@@ -711,7 +727,12 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
                 tick={{ fontSize: 12 }}
                 tickFormatter={timestamp => formatChartAxisTimestamp(timestamp, globalTimeRange, timeFormat)}
               />
-              <YAxis yAxisId="left" tick={{ fontSize: 12 }} domain={['auto', 'auto']} />
+              <YAxis
+                yAxisId="left"
+                tick={{ fontSize: 12 }}
+                domain={['auto', 'auto']}
+                tickFormatter={uptimeFormatter ? (v: number) => uptimeFormatter(v) : undefined}
+              />
               <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} domain={['auto', 'auto']} hide={true} />
               <Tooltip
                 contentStyle={{
@@ -721,6 +742,15 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
                   color: '#cdd6f4',
                 }}
                 labelStyle={{ color: '#cdd6f4' }}
+                formatter={
+                  uptimeFormatter
+                    ? (value, name) =>
+                        // Leave the solar overlay (watt-hours) untouched.
+                        name === 'solarEstimate' || typeof value !== 'number'
+                          ? value
+                          : uptimeFormatter(value)
+                    : undefined
+                }
                 labelFormatter={value => {
                   const date = new Date(value);
                   return date.toLocaleString([], {

--- a/src/components/TelemetryChart.uptime.test.tsx
+++ b/src/components/TelemetryChart.uptime.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Dashboard telemetry widget uptime humanization (#3261).
+ *
+ * The shared Dashboard chart (TelemetryChart) must render uptime-in-seconds
+ * metrics (uptimeSeconds, hostUptimeSeconds, paxcounterUptime, mc_*_uptime_secs)
+ * as humanized durations in numeric mode, gauge mode, the Y-axis ticks and
+ * the tooltip — and leave non-uptime metrics (e.g. batteryLevel) untouched.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TelemetryChart from './TelemetryChart';
+import { useTelemetry } from '../hooks/useTelemetry';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: vi.fn(),
+}));
+
+let widgetMode = 'numeric';
+vi.mock('../hooks/useWidgetMode', () => ({
+  useWidgetMode: () => [widgetMode, vi.fn()],
+}));
+
+vi.mock('../hooks/useWidgetRange', () => ({
+  useWidgetRange: () => [{ min: 0, max: 100 }, vi.fn()],
+}));
+
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => ({ timeFormat: '24h' }),
+}));
+
+vi.mock('../contexts/SourceContext', () => ({
+  useSource: () => ({ sourceId: 'src-test', sourceName: 'Test Source' }),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+// Capture axis/tooltip props so the formatter wiring is assertable.
+interface CapturedProps {
+  yAxis: Array<Record<string, unknown>>;
+  tooltip: Array<Record<string, unknown>>;
+}
+const captured: CapturedProps = { yAxis: [], tooltip: [] };
+
+vi.mock('recharts', () => ({
+  ComposedChart: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="composed-chart">{children}</div>
+  ),
+  Line: () => null,
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: (props: Record<string, unknown>) => {
+    captured.yAxis.push(props);
+    return null;
+  },
+  CartesianGrid: () => null,
+  Tooltip: (props: Record<string, unknown>) => {
+    captured.tooltip.push(props);
+    return null;
+  },
+  ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NODE_ID = '!a1b2c3d4';
+
+// 1,543,452 s = 17 days 20 hours (and change)
+const UPTIME_SECONDS = 1543452;
+
+const telemetryRow = (telemetryType: string, value: number, unit: string) => ({
+  id: 1,
+  nodeId: NODE_ID,
+  telemetryType,
+  timestamp: Date.now() - 60_000,
+  value,
+  unit,
+});
+
+const setTelemetry = (rows: ReturnType<typeof telemetryRow>[]) => {
+  (useTelemetry as Mock).mockReturnValue({
+    data: rows,
+    isLoading: false,
+    error: null,
+  });
+};
+
+const renderChart = (telemetryType: string) =>
+  render(
+    <TelemetryChart
+      id={`${NODE_ID}-${telemetryType}`}
+      favorite={{ nodeId: NODE_ID, telemetryType }}
+      node={undefined}
+      temperatureUnit="C"
+      hours={24}
+      baseUrl=""
+      globalTimeRange={null}
+      globalMinTime={undefined}
+      solarEstimates={new Map()}
+      onRemove={vi.fn()}
+    />
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  widgetMode = 'numeric';
+  captured.yAxis.length = 0;
+  captured.tooltip.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Numeric mode
+// ---------------------------------------------------------------------------
+
+describe('TelemetryChart uptime humanization (#3261)', () => {
+  it.each([
+    ['uptimeSeconds'],
+    ['hostUptimeSeconds'],
+    ['paxcounterUptime'],
+    ['mc_uptime_secs'],
+  ])('numeric mode humanizes %s instead of raw seconds', telemetryType => {
+    setTelemetry([telemetryRow(telemetryType, UPTIME_SECONDS, 's')]);
+    renderChart(telemetryType);
+
+    expect(screen.getByText('17d 20h')).toBeTruthy();
+    expect(screen.queryByText(String(UPTIME_SECONDS))).toBeNull();
+  });
+
+  it('numeric mode leaves non-uptime metrics untouched', () => {
+    setTelemetry([telemetryRow('batteryLevel', 85, '%')]);
+    renderChart('batteryLevel');
+
+    expect(screen.getByText('85')).toBeTruthy();
+    expect(screen.getByText('%')).toBeTruthy();
+  });
+
+  it('drops the redundant "s" unit for uptime metrics in the header', () => {
+    setTelemetry([telemetryRow('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderChart('uptimeSeconds');
+
+    expect(screen.queryByText('(s)')).toBeNull();
+    // Humanized value carries its own unit, so no separate unit element.
+    expect(screen.queryByText('s', { selector: '.telemetry-numeric-unit' })).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Gauge mode
+  // -------------------------------------------------------------------------
+
+  it('gauge mode humanizes the uptime value', () => {
+    widgetMode = 'gauge';
+    setTelemetry([telemetryRow('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderChart('uptimeSeconds');
+
+    expect(screen.getByText('17d 20h')).toBeTruthy();
+    expect(screen.queryByText(String(UPTIME_SECONDS))).toBeNull();
+  });
+
+  it('gauge mode leaves non-uptime metrics untouched', () => {
+    widgetMode = 'gauge';
+    setTelemetry([telemetryRow('batteryLevel', 85, '%')]);
+    renderChart('batteryLevel');
+
+    expect(screen.getByText('85')).toBeTruthy();
+  });
+
+  // -------------------------------------------------------------------------
+  // Chart mode: Y-axis tickFormatter + Tooltip formatter
+  // -------------------------------------------------------------------------
+
+  it('chart mode wires a duration tickFormatter into the left Y-axis', () => {
+    widgetMode = 'chart';
+    setTelemetry([telemetryRow('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderChart('uptimeSeconds');
+
+    const leftAxis = captured.yAxis.find(p => p.yAxisId === 'left');
+    expect(leftAxis).toBeTruthy();
+    const tickFormatter = leftAxis!.tickFormatter as (v: number) => string;
+    expect(typeof tickFormatter).toBe('function');
+    expect(tickFormatter(90000)).toBe('1d 1h');
+    expect(tickFormatter(UPTIME_SECONDS)).toBe('17d 20h');
+  });
+
+  it('chart mode wires a duration formatter into the tooltip, sparing solar', () => {
+    widgetMode = 'chart';
+    setTelemetry([telemetryRow('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderChart('uptimeSeconds');
+
+    expect(captured.tooltip.length).toBeGreaterThan(0);
+    const formatter = captured.tooltip[0].formatter as (
+      value: number | string,
+      name: string
+    ) => number | string;
+    expect(typeof formatter).toBe('function');
+    expect(formatter(UPTIME_SECONDS, 'value')).toBe('17d 20h');
+    // Solar overlay stays in watt-hours.
+    expect(formatter(5.5, 'solarEstimate')).toBe(5.5);
+  });
+
+  it('chart mode leaves non-uptime metrics without a Y-axis tickFormatter', () => {
+    widgetMode = 'chart';
+    setTelemetry([telemetryRow('batteryLevel', 85, '%')]);
+    renderChart('batteryLevel');
+
+    const leftAxis = captured.yAxis.find(p => p.yAxisId === 'left');
+    expect(leftAxis).toBeTruthy();
+    expect(leftAxis!.tickFormatter).toBeUndefined();
+    expect(captured.tooltip[0]?.formatter).toBeUndefined();
+  });
+});

--- a/src/components/TelemetryGauge.tsx
+++ b/src/components/TelemetryGauge.tsx
@@ -11,6 +11,12 @@ interface TelemetryGaugeProps {
   nodeId: string;
   onRangeChange: (range: WidgetRange) => void;
   canEditRange?: boolean;
+  /**
+   * Optional display formatter for the value and min/max labels (e.g.
+   * formatDuration for uptime-in-seconds metrics, #3261). The range inputs
+   * keep raw numbers so editing still works.
+   */
+  formatValue?: (value: number) => string;
 }
 
 const SWEEP_DEG = 200;
@@ -40,6 +46,7 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
   timestamp,
   onRangeChange,
   canEditRange = false,
+  formatValue,
 }) => {
   const cx = 100;
   const cy = 90;
@@ -58,6 +65,14 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
   const date = new Date(timestamp);
   const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
+  const displayValue = formatValue
+    ? formatValue(value)
+    : Number.isInteger(value)
+      ? String(value)
+      : value.toFixed(1);
+  const displayMin = formatValue ? formatValue(min) : String(min);
+  const displayMax = formatValue ? formatValue(max) : String(max);
+
   const handleMinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = parseFloat(e.target.value);
     if (!isNaN(v)) onRangeChange({ min: v, max });
@@ -70,7 +85,7 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
 
   return (
     <div className="telemetry-gauge">
-      <svg viewBox="0 0 200 160" width="100%" aria-label={`Gauge: ${value} ${unit}`}>
+      <svg viewBox="0 0 200 160" width="100%" aria-label={`Gauge: ${displayValue}${unit ? ` ${unit}` : ''}`}>
         {/* Background arc */}
         <path d={bgPath} fill="none" stroke="var(--ctp-surface0)" strokeWidth={14} strokeLinecap="round" />
         {/* Value arc */}
@@ -85,7 +100,7 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
           fontSize="9"
           fill="var(--ctp-subtext0)"
         >
-          {min}
+          {displayMin}
         </text>
         {/* Max label */}
         <text
@@ -95,11 +110,11 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
           fontSize="9"
           fill="var(--ctp-subtext0)"
         >
-          {max}
+          {displayMax}
         </text>
         {/* Value */}
         <text x={cx} y={cy + 4} textAnchor="middle" fontSize="26" fontWeight="bold" fill="var(--ctp-text)">
-          {Number.isInteger(value) ? value : value.toFixed(1)}
+          {displayValue}
         </text>
         {/* Unit */}
         <text x={cx} y={cy + 18} textAnchor="middle" fontSize="11" fill="var(--ctp-subtext0)">

--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -6,6 +6,20 @@
   border-radius: var(--radius-lg);
 }
 
+/*
+ * DM conversation view (#4426): match the 12px horizontal inset the
+ * unmessageable banner and node-info sections use inside
+ * .dm-conversation-panel. Longhand left/right only, so the vertical
+ * padding still comes from the base rule above (20px) and its mobile
+ * override below (10px). The higher specificity here wins over both
+ * shorthand rules for the horizontal axis regardless of source order,
+ * which sidesteps the mobile-cascade ordering trap (#3532).
+ */
+.dm-conversation-panel .telemetry-graphs {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
 .telemetry-graphs-header {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/TelemetryNumericLabel.tsx
+++ b/src/components/TelemetryNumericLabel.tsx
@@ -5,15 +5,24 @@ interface TelemetryNumericLabelProps {
   unit: string;
   color: string;
   timestamp: number;
+  /**
+   * Optional display formatter for the raw value (e.g. formatDuration for
+   * uptime-in-seconds metrics, #3261). Defaults to the numeric rendering.
+   */
+  formatValue?: (value: number) => string;
 }
 
-const TelemetryNumericLabel: React.FC<TelemetryNumericLabelProps> = ({ value, unit, color, timestamp }) => {
+const TelemetryNumericLabel: React.FC<TelemetryNumericLabelProps> = ({ value, unit, color, timestamp, formatValue }) => {
   const date = new Date(timestamp);
   const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const displayValue = Number.isInteger(value) ? value.toString() : value.toFixed(2);
+  const displayValue = formatValue
+    ? formatValue(value)
+    : Number.isInteger(value)
+      ? value.toString()
+      : value.toFixed(2);
 
   return (
-    <div className="telemetry-numeric" aria-label={`${value} ${unit}`}>
+    <div className="telemetry-numeric" aria-label={`${displayValue}${unit ? ` ${unit}` : ''}`}>
       <span className="telemetry-numeric-value" style={{ color }}>
         {displayValue}
       </span>


### PR DESCRIPTION
## Summary

Two related telemetry-chart fixes in one PR.

### #3261 (reopened) — Dashboard telemetry widget shows raw uptime seconds

PR #3264 humanized uptime on the Unified Telemetry page and detail panels, but the Dashboard's shared per-node chart widget (`TelemetryChart.tsx`) was never wired up: a favorited "Device Uptime" / "Host Uptime" / "Paxcounter Uptime" metric rendered as e.g. `1543452 s`.

This wires the existing `formatDuration()` / `isUptimeType()` helpers from `src/utils/telemetryFormat.ts` into every display mode of the widget:

- **Numeric mode** — `TelemetryNumericLabel` gains an optional `formatValue` prop; uptime renders as `17d 20h`.
- **Gauge mode** — `TelemetryGauge` gains the same prop for the value text and min/max arc labels; the range edit inputs keep raw numbers so editing still works.
- **Chart mode** — the left Y-axis `tickFormatter` and the `Tooltip` `formatter` humanize values; the solar overlay series (watt-hours) is explicitly spared.
- The redundant `(s)` unit drops from the widget header for uptime metrics, matching `UnifiedTelemetryPage`.

Not MeshCore-specific: covers `uptimeSeconds` (Meshtastic LocalStats), `hostUptimeSeconds`, `paxcounterUptime`, and the MeshCore `*_uptime_secs` suffix. `isUptimeType()` already matched all of these, so the helper (and its other consumers) is untouched. Non-uptime metrics render exactly as before.

### #4426 — Telemetry chart padding doesn't line up in DM conversation view

Inside `.dm-conversation-panel` each child supplies its own inset; the unmessageable banner and node-info sections use 12px horizontal padding while the chart card (`.telemetry-graphs`) used 20px (10px mobile).

Added a DM-scoped override in `TelemetryGraphs.css` setting only `padding-left/right: 12px`. Longhand properties keep vertical padding flowing from the base rule (20px desktop) and its mobile override (10px), and the higher specificity wins on the horizontal axis regardless of source order — which sidesteps the mobile `@media` cascade-ordering trap (#3532). The Telemetry tab and all other non-DM uses of `.telemetry-graphs` are unaffected.

## Test plan

- New `src/components/TelemetryChart.uptime.test.tsx` (10 tests): numeric mode humanizes all four uptime type names and leaves `batteryLevel` untouched; gauge mode humanizes value; Y-axis `tickFormatter` and `Tooltip` `formatter` are wired for uptime (and absent for non-uptime); the tooltip formatter spares the `solarEstimate` series; the `(s)` unit is dropped from the header.
- Full Vitest suite: 12,842 tests, 0 failures (`success: true` via `--reporter=json`; 109 skipped = the PG/MySQL container-gated suites, no schema changes here).
- `npm run lint:ci` exits 0 with zero `FAIL` lines.
- `npx tsc --noEmit` clean.

Closes #3261
Closes #4426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9
