### PR TITLE
fix(settings): close the defects the per-source epic uncovered (#4419)

### DIFF
--- a/docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_EPIC.md
+++ b/docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_EPIC.md
@@ -229,7 +229,7 @@ intermediate count on this screen, sample for longer before concluding the filte
 showing the age filter taking effect on both the node list and the map; #4412
 closable.
 
-### [ ] Phase 5 — Close the follow-up defects this epic uncovered
+### [x] Phase 5 — Close the follow-up defects this epic uncovered — **COMPLETE** (PR pending)
 
 Added 2026-07-29 at the user's direction: the issues filed along the way get
 addressed, not left orphaned. All four are pre-existing and independent of
@@ -357,6 +357,62 @@ Option 2 is the smallest change and matches what an admin would predict. Raise a
 Phase 2 boundary.
 
 ## Deviations log
+
+### Phase 5
+- **Migration 050 frozen at today's 170-key snapshot, not the 87-key authoring-time list.**
+  Measured against `aae251a6` (the commit that added 050) and independently re-verified:
+  **87 keys then, 170 now, strict superset, 0 removed, 83 added** — and this epic's nine
+  Node Display keys are all among the added. Today's snapshot is the only *zero-delta*
+  option; freezing at 87 would be subtractive, silently ending promotion of those nine for
+  every future v3.x upgrader. A cleanup phase must not change upgrade semantics. The list is
+  now a frozen literal with a comment explaining why, so nobody re-imports the live array.
+- **050's PG/MySQL round-trip loops (~170 each) were deliberately NOT fixed** — the #4233
+  anti-pattern, but it runs once per database under the ledger. The new tests assert
+  behavior only, never round-trip counts, so a future batching fix won't break them.
+- **`externalUrl` was a live user-facing bug, not just an orphan.** Nothing writes it, so
+  `baseUrl` is always `''` — meaning *every Apprise security digest ever sent contained a
+  dead relative link*, `View details: /security`. Fixed by omitting the line when `baseUrl`
+  is empty; a writer is a product decision (filed as **#4437**), not a cleanup.
+- **The `isLocal` flag was deferred, deliberately** (filed as **#4438**). Measured at 7
+  production files, a `MeshCoreContact` type change, and an API response-shape change. The
+  hard part is proving the flag is set on *every* producer — miss one and the local node
+  silently vanishes from the list, which is worse than the bug it fixes. Phase 5 added the
+  four missing `NOTE:` pointers Phase 4 left unmarked.
+
+**Test-quality findings — the sharpest set in the epic. 19 of 27 existing tests in these
+areas would have stayed green with their defect fully present:**
+- All 8 migration-050 tests use keys present in *both* the 87- and 170-key lists, so the
+  suite is **structurally incapable** of observing that the input set varies. Only a
+  source-text drift guard can catch it.
+- `getSourceSettings` had **zero tests as a subject** — it appeared only as an incidental
+  oracle inside `deleteSourceSettings` tests. It is the function Phase 5 rewrote.
+- Migration 050 had **no PostgreSQL or MySQL coverage at all**, despite shipping
+  hand-written implementations for both. Phase 5 added its first.
+- `securityDigestService.perSource.test.ts` seeded `externalUrl: 'https://a.example'` — **a
+  value no production write path can produce.** That fixture is precisely how the orphan
+  stayed hidden.
+- The four `#3806` regex tests are global-path-only; with `prefix=''` the buggy and fixed
+  code are byte-identical, so they were blind rather than bug-pinning.
+
+**Two spec-level test flaws caught *before* shipping, because every new test had to
+demonstrate its own failure first:**
+- WP2: the spec's proof that `getSourceSettings` is prefix-scoped (count `db.select()`
+  calls, expect 1) **would not have caught the regression** — `getAllSettings()` also issues
+  exactly one `select()`, and its JS-filtered result is functionally correct. Strengthened
+  to spy on `getAllSettings` and assert it is never called.
+- WP1: the spec's seeding for one test would have failed RE2 validation under *both* buggy
+  and fixed code, passing for the wrong reason. Corrected to isolate the actual flip.
+
+This is the first phase where the mutation-check requirement caught bad tests at design
+time rather than review time. Keep it.
+
+**Known gap, not fixed here:** `DatabaseService.auditLogAsync` (`src/services/database.ts:4491-4493`)
+accepts `valueBefore`/`valueAfter` and explicitly `void`s them — the schema has no columns.
+So Phase 1's `auditSettingsWrite` computes a full before/after diff for every settings
+change and discards it. The `details` field still records *which* keys changed, so the audit
+trail is not empty, but the diff computation is dead weight — including the
+`Object.defineProperty` two reviewers questioned, which exists solely to build a discarded
+value. Pre-existing; needs a schema migration to resolve.
 
 ### Phase 4
 - **D1 — settings surface composed as a section, not a `SettingsTab` mount.**

--- a/docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md
+++ b/docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md
@@ -1,0 +1,976 @@
+# Phase 5 Spec — Close the follow-up defects (#4419 + migration 050 drift + `externalUrl`)
+
+**Epic:** #4412 (per-source Node Display). **Phase:** 5 of 6. **Issue:** #4419.
+**Worktree:** `/home/yeraze/Development/meshmonitor-followups`
+**Branch:** `feature/per-source-settings-followups` (base `origin/main`, Phase 4 = `6cc26bcb`).
+**Status:** spec only — nothing implemented.
+
+Phase 5 is a **cleanup** phase. Every item below is a pre-existing defect this epic
+surfaced. Nothing here adds a user-facing feature, and nothing here changes upgrade
+semantics. Two candidate items are explicitly **deferred** with reasoning (§5, §6).
+
+---
+
+## 1. Reuse inventory (read this before writing a line)
+
+Everything Phase 5 needs already exists somewhere in the tree. Nothing new is
+invented except one private helper (1.2) and one frozen constant (1.6).
+
+### 1.1 The prefixed-lookup pattern — `auditSettingsWrite`
+`src/server/routes/settingsRoutes.ts:187-224`
+
+```ts
+const prefix = sourceId ? `source:${sourceId}:` : '';
+const before = currentSettings[`${prefix}${key}`];
+```
+
+This is the **correct** shape and the model for the #4419(a) fix. It works because
+`getAllSettings()` (`src/db/repositories/settings.ts:35`) returns *every* row
+including `source:{id}:{key}` ones — so the scoped before-value needs **no extra
+query**. WP1 extracts this expression into a named helper and calls it from both
+`auditSettingsWrite` and the auto-ack regex guard. **Do not add a second DB read.**
+
+### 1.2 The dialect-branched LIKE/ESCAPE — `deleteSourceSettings`
+`src/db/repositories/settings.ts:292-299`, with the empirically-verified rationale in
+the doc comment at `:274-291`:
+
+```ts
+const pattern = this.sourcePrefix(sourceId).replace(/([\\%_])/g, '\\$1') + '%';
+const query = this.isMySQL()
+  ? sql`${settings.key} LIKE ${pattern} ESCAPE '\\\\'`   // MySQL: TWO literal backslashes
+  : sql`${settings.key} LIKE ${pattern} ESCAPE '\\'`;    // SQLite/PG: exactly ONE
+```
+
+WP2 **extracts this into a private `sourceNamespaceMatch(sourceId): SQL`** and calls it
+from both `getSourceSettings` (new) and `deleteSourceSettings` (unchanged behaviour).
+This is the one new helper in the phase, and it exists to *remove* a duplicate, not add one.
+Do not re-derive the backslash rule; it cost a live-container debugging session in Phase 1.
+
+### 1.3 `sourcePrefix()` / `isMySQL()`
+`src/db/repositories/settings.ts:171` and `src/db/repositories/base.ts:102`.
+Already private/protected and already correct. Use them; do not inline `` `source:${id}:` ``.
+
+### 1.4 `getSettingForSources(ids, key)` — the Phase 2 batched primitive
+`src/db/repositories/settings.ts:222-247`. **Deliberately not used by Phase 5** — see §3.3
+for the analysis of why none of `getSourceSettings`' three callers should convert to it.
+
+### 1.5 The one-query proof harness
+`src/db/repositories/settings.test.ts:369-395` —
+`getSettingForSources - issues exactly one SELECT for the whole batch`. It monkey-patches
+the protected drizzle handle and counts `select` calls:
+
+```ts
+const dbHandle = (repo as any).db;
+const realSelect = dbHandle.select.bind(dbHandle);
+let selectCalls = 0;
+dbHandle.select = (...args: unknown[]) => { selectCalls += 1; return realSelect(...args); };
+try { /* … */ expect(selectCalls).toBe(1); } finally { dbHandle.select = realSelect; }
+```
+
+WP2 copies this verbatim for `getSourceSettings`. It satisfies the epic's exit criterion
+"a test proving `getSourceSettings` issues one scoped query rather than reading the whole table."
+
+### 1.6 The frozen-key-list pattern — migration 131
+`src/server/migrations/131_seed_per_source_node_display.ts:52-80`. `NODE_DISPLAY_SEED` is
+an exported local constant with a doc comment that names the hazard explicitly
+("Deliberately does NOT import `PER_SOURCE_SETTINGS_KEYS` (contrast migration 050)…").
+WP3 gives 050 the identical treatment: exported `PROMOTED_SETTING_KEYS`, same style of
+doc comment, plus the drift guard 131 never got.
+
+### 1.7 The three-backend test body — `runSettingsTests`
+`src/db/repositories/settings.test.ts:49-435`, invoked by three `describe` blocks
+(SQLite always; PG/MySQL under `describe.skipIf`). A test added **inside `runSettingsTests`
+runs on all three backends for free.** WP2 must add its tests there, not in a new file.
+
+### 1.8 The PG/MySQL migration test template
+`src/server/migrations/131_seed_per_source_node_display.pgmysql.test.ts` — two halves
+(fake-client always-runs + live-container `skipIf`), with the "silent skip still reports
+`success: true`" warning in its header. WP3 copies the scaffolding wholesale.
+
+### 1.9 The route test harness
+`src/server/test-helpers/routeTestApp.ts` → `createRouteTestApp()`; already used by
+`settingsRoutes.perSource.test.ts` (`:27`). Provides `app`, `sourceA`, `sourceB`, `admin`,
+`limited`, `loginAs()`, `grant()`, `cleanup()` against a real `:memory:` SQLite DB with all
+migrations applied. **All new route tests go here.**
+
+### 1.10 Prototype-safe property writes
+`setSourceSettings` (`settings.ts:257-272`) and `auditSettingsWrite`
+(`settingsRoutes.ts:207-210`) both use `Object.defineProperty` rather than `obj[key] = v`
+to prove to CodeQL that a non-literal key cannot reach a prototype-pollution sink.
+WP2 reuses this in the rewritten `getSourceSettings` (§3.1) — the current implementation
+writes `result[k.slice(prefix.length)] = v`, and `setSourceSettings`' key filter
+(`/^[A-Za-z0-9_.-]+$/`) *permits* `__proto__`, so the sink is reachable today.
+
+### 1.11 Existing `PER_SOURCE_KEYS_NOT_POSTABLE` orphan entry
+`src/server/constants/settings.ts:625-631` already documents `externalUrl` in place.
+WP4 edits that comment; it does **not** move the key or touch `VALID_SETTINGS_KEYS`.
+
+---
+
+## 2. WP1 — #4419(a): per-source POST must compare against the per-source current value
+
+### 2.1 The defect
+`src/server/routes/settingsRoutes.ts:326-330`:
+
+```ts
+const willBeEnabled =
+  'autoAckEnabled' in filteredSettings
+    ? filteredSettings.autoAckEnabled === 'true'
+    : currentSettings.autoAckEnabled === 'true';       // ← global row
+const regexChanged = pattern !== (currentSettings.autoAckRegex ?? '');   // ← global row
+```
+
+`currentSettings` is `await databaseService.settings.getAllSettings()` (`:284`), which
+returns **bare, un-prefixed** keys alongside the prefixed ones. On
+`POST /api/settings?sourceId=X` the correct "current" value lives at
+`source:X:autoAckEnabled` / `source:X:autoAckRegex`. Both `autoAckEnabled` and
+`autoAckRegex` are in `PER_SOURCE_SETTINGS_KEYS`, so a source that overrides the global
+gets change-detection wrong **in both directions**:
+
+| Scenario | Today | Correct |
+|---|---|---|
+| Source X stores a lookaround regex (persisted before RE2), auto-ack OFF, user re-saves it unchanged to toggle something else. Global row differs. | `regexChanged = true` → RE2 rejects → **400, section permanently stuck** — the exact #3806 failure the guard was written to prevent | `regexChanged = false` → 200 |
+| Source X's regex differs from global; user changes X's regex to a *new* bad pattern that happens to equal the global row. | `regexChanged = false` → bad pattern **saved unvalidated** | `regexChanged = true` → 400 |
+| Auto-ack disabled on source X but enabled globally; user saves a bad regex. | `willBeEnabled = true` → 400 on a source where auto-ack is off | `willBeEnabled = false` → 200 |
+
+### 2.2 Audit of every other `currentSettings.<key>` read
+
+Full enumeration (`grep -n currentSettings src/server/routes/settingsRoutes.ts`):
+
+| Line | Read | Reachable from the per-source branch? |
+|---|---|---|
+| `:284` | assignment (`getAllSettings()`) | n/a |
+| `:329` | `currentSettings.autoAckEnabled` | **YES — defect. Fix.** |
+| `:330` | `currentSettings.autoAckRegex` | **YES — defect. Fix.** |
+| `:198` | `currentSettings[`${prefix}${key}`]` inside `auditSettingsWrite` | yes, and **already correct** |
+| `:886` | `currentSettings['autoWelcomeEnabled']` | **NO.** The per-source branch (`:765`) ends with `return ok(res, { ignoredKeys });` at `:842`. `:886` is unreachable when `sourceId` is non-null. |
+| `:1176`, `:1187` | `DELETE /api/settings` handler | separate route, global-only |
+
+`:886` needs no code change, but WP1 **must add a one-line comment** anchoring the
+invariant, because the safety of that read is positional and a future edit that moves the
+`return` would silently reintroduce the same class of bug:
+
+```ts
+// Global-branch only: the `if (sourceId)` branch above returns at :842, so
+// `currentSettings[...]` here is always the un-prefixed global row by construction (#4419).
+```
+
+### 2.3 Change
+
+Add a module-level helper next to `auditSettingsWrite` (before it, so the doc comment reads
+in order):
+
+```ts
+/**
+ * The `settings` row key that holds the current value of `key` for this write's scope:
+ * `source:{id}:{key}` for a scoped POST, the bare key for a global one.
+ *
+ * `currentSettings` is one `getAllSettings()` snapshot containing BOTH namespaces, so
+ * scoped change-detection costs no extra query — that is the whole point (#4419).
+ * Any pre-write comparison inside `POST /` that can run with a non-null `sourceId` MUST
+ * go through this; reading `currentSettings.<bareKey>` directly compares a per-source
+ * save against the global row.
+ */
+function scopedSettingKey(key: string, sourceId: string | null): string {
+  return sourceId ? `source:${sourceId}:${key}` : key;
+}
+```
+
+Then:
+
+```ts
+// settingsRoutes.ts — inside auditSettingsWrite, replacing the local `prefix` const
+const before = currentSettings[scopedSettingKey(key, sourceId)];
+
+// settingsRoutes.ts:326-330
+const willBeEnabled =
+  'autoAckEnabled' in filteredSettings
+    ? filteredSettings.autoAckEnabled === 'true'
+    : currentSettings[scopedSettingKey('autoAckEnabled', sourceId)] === 'true';
+const regexChanged = pattern !== (currentSettings[scopedSettingKey('autoAckRegex', sourceId)] ?? '');
+```
+
+Notes for the implementer:
+- `auditSettingsWrite`'s `Object.defineProperty` block at `:207-210` and the
+  `validKeySet` check at `:197` are **load-bearing for CodeQL** (see the comment at
+  `:200-206`). Leave them exactly as they are; only the `before =` line changes.
+- Deleting the now-unused `const prefix = …` at `:195` is required (ESLint).
+- Behaviour on the **global** path is byte-identical (`sourceId === null` ⇒
+  `scopedSettingKey` is the identity function). This must be asserted, not assumed — see
+  the regression tests in 2.5.
+- A scoped POST for a source with **no** stored `autoAckRegex` row now compares against
+  `undefined ?? ''`. A first-ever non-empty pattern therefore reads as changed and is
+  validated. That is the intended semantics (there is no stored pattern to unstick).
+
+### 2.4 Files
+| File | Change |
+|---|---|
+| `src/server/routes/settingsRoutes.ts` | add `scopedSettingKey`; rewrite `:198`, `:329`, `:330`; drop `:195`; add the `:886` invariant comment |
+| `src/server/routes/settingsRoutes.perSource.test.ts` | new `describe` block (2.5) |
+
+### 2.5 New tests — `settingsRoutes.perSource.test.ts`
+
+Harness-based (§1.9), `harness.admin` (permission is not the subject). Add:
+
+```
+describe('POST /api/settings — autoAck change-detection is scope-correct (#4419a)')
+```
+
+1. **`a scoped re-save of the source's own bad regex is allowed while auto-ack is off (the #3806 unstick, per source)`**
+   Seed `source:{A}:autoAckRegex = 'foo(?=bar)'` and `source:{A}:autoAckEnabled = 'false'`
+   directly via `databaseService.settings.setSourceSetting`; seed a *different* global
+   `autoAckRegex = 'plain'`. POST `?sourceId=A` with `{autoAckRegex:'foo(?=bar)', autoAckEnabled:'false'}` → **200**.
+   *Fails with the defect present* (global differs ⇒ `regexChanged` true ⇒ RE2 400).
+2. **`a scoped change to a NEW bad regex is rejected even when it equals the global row`**
+   Global `autoAckRegex = 'foo(?=bar)'`; `source:{A}:autoAckRegex = 'plain'`, auto-ack off.
+   POST `?sourceId=A` `{autoAckRegex:'foo(?=bar)', autoAckEnabled:'false'}` → **400**.
+   *Fails with the defect present* (equals global ⇒ `regexChanged` false ⇒ unvalidated 200).
+3. **`willBeEnabled reads this source's own flag, not the global one`**
+   Global `autoAckEnabled = 'true'`; `source:{A}:autoAckEnabled = 'false'`. POST
+   `?sourceId=A` `{autoAckRegex:'foo(?=bar)'}` (no `autoAckEnabled` in body) → **200**.
+   *Fails with the defect present* → 400.
+4. **`sourceA's regex state does not affect a sourceB save`**
+   Seed a bad regex on A only; POST the same pattern on B with auto-ack off → **400**
+   (B has no stored pattern to unstick). Confirms no cross-source leak in the new lookup.
+5. **`the unscoped POST still compares against the global row (no regression)`**
+   Global `autoAckRegex = 'foo(?=bar)'`, `autoAckEnabled='false'`, plus a *different*
+   `source:{A}:autoAckRegex`. POST with **no** `sourceId` and the same pattern → **200**.
+   Pins the identity-function property of `scopedSettingKey`.
+6. **`the audit row records the per-source before-value`**
+   Scoped POST that changes `source:{A}:autoAckMessage`; assert the emitted audit
+   `oldValue` JSON carries the **source's** prior value, not the global one. (Guards the
+   `auditSettingsWrite` refactor — it must stay behaviour-identical.)
+
+### 2.6 Acceptance criteria (WP1)
+- [ ] Tests 1–3 each **fail on `git stash`-ed production code and pass after** — the
+      implementer must run them against the unfixed file once and record the failure
+      output in the commit message. A test that passes both ways is not evidence.
+- [ ] `npx vitest run src/server/routes/settingsRoutes.perSource.test.ts src/server/routes/settingsRoutes.test.ts` — 0 failures.
+- [ ] `grep -n 'currentSettings\.' src/server/routes/settingsRoutes.ts` returns **no** hits
+      inside the `POST /` handler above line 842.
+- [ ] `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` is empty.
+
+---
+
+## 3. WP2 — #4419(b): `getSourceSettings` becomes a prefix-scoped query
+
+### 3.1 The defect and the change
+`src/db/repositories/settings.ts:178-188` reads the **entire** `settings` table and
+filters in JS. Migration 131 made that table grow as (keys × sources), and the function is
+on the `GET /api/settings?sourceId=` path — i.e. every settings page load.
+
+Replace with:
+
+```ts
+/**
+ * Predicate matching every row in one source's `source:{id}:` namespace.
+ *
+ * Extracted so the wildcard escaping and the dialect-dependent ESCAPE literal are
+ * stated exactly once, and so the read (getSourceSettings) and the write
+ * (deleteSourceSettings) can never disagree about what "this source's namespace" means.
+ *
+ * `_` and `%` are LIKE wildcards; source ids are UUIDs today, but escape defensively so
+ * a future non-UUID id cannot over-match a sibling namespace.
+ *
+ * The ESCAPE literal's backslash count is dialect-dependent (verified empirically against
+ * live containers in #4412 Phase 1, not by inspection): MySQL's default backslash-escape
+ * mode means a single-quoted string needs TWO literal backslash characters to represent
+ * ONE escape character, and errors ("syntax error near ''\''") on a single-backslash
+ * literal. SQLite and PostgreSQL (standard_conforming_strings, the default) treat
+ * backslash as an ordinary character in a '...' string, so ONE literal backslash there
+ * already IS the one-character escape sequence — a two-backslash literal fails there
+ * ("ESCAPE expression must be a single character").
+ */
+private sourceNamespaceMatch(sourceId: string): SQL {
+  const { settings } = this.tables;
+  const pattern = this.sourcePrefix(sourceId).replace(/([\\%_])/g, '\\$1') + '%';
+  return this.isMySQL()
+    ? sql`${settings.key} LIKE ${pattern} ESCAPE '\\\\'`
+    : sql`${settings.key} LIKE ${pattern} ESCAPE '\\'`;
+}
+
+/**
+ * Get all settings for one source, keyed by BARE key (prefix stripped).
+ *
+ * One prefix-scoped query. The previous implementation called getAllSettings() and
+ * filtered in JS — O(total settings) per call, and migration 131 grew that table as
+ * (keys x sources) (#4419).
+ *
+ * Rows are written with Object.defineProperty, not `result[k] = v`: setSourceSettings'
+ * key filter (/^[A-Za-z0-9_.-]+$/) permits the literal name `__proto__`, so a stored row
+ * `source:{id}:__proto__` would otherwise reach a prototype-pollution sink on the read
+ * path. defineProperty creates an own data property and never invokes the setter.
+ */
+async getSourceSettings(sourceId: string): Promise<Record<string, string>> {
+  const { settings } = this.tables;
+  const prefix = this.sourcePrefix(sourceId);
+  const rows = await this.db
+    .select({ key: settings.key, value: settings.value })
+    .from(settings)
+    .where(this.sourceNamespaceMatch(sourceId));
+
+  const result: Record<string, string> = {};
+  for (const row of rows as Array<{ key: string; value: string }>) {
+    if (!row.key.startsWith(prefix)) continue;
+    Object.defineProperty(result, row.key.slice(prefix.length), {
+      value: row.value, enumerable: true, writable: true, configurable: true,
+    });
+  }
+  return result;
+}
+
+async deleteSourceSettings(sourceId: string): Promise<void> {
+  await this.db.delete(this.tables.settings).where(this.sourceNamespaceMatch(sourceId));
+}
+```
+
+Implementation notes:
+- Keep the return type a **plain object literal**, not `Object.create(null)` — callers
+  spread it (`settingsRoutes.ts:260`), mutate it (`settingsRoutes.ts:1717-1738`), and tests
+  assert `toEqual({…})`. `defineProperty` on a normal `{}` closes the sink without changing
+  the object's shape.
+- The `startsWith(prefix)` re-check is belt-and-braces against a dialect LIKE surprise;
+  it costs nothing and makes the slice provably safe.
+- `SQL` needs importing from `drizzle-orm` alongside the existing `eq, inArray, sql`.
+- The `deleteSourceSettings` doc comment at `:274-291` moves onto `sourceNamespaceMatch`;
+  leave a short pointer on `deleteSourceSettings` (its #4233 single-statement rationale
+  is still its own and must survive).
+
+**Honest performance note to put in the commit message, not in a claim of an index win:**
+on PostgreSQL with a non-`C` collation, a plain btree PK does **not** serve `LIKE 'x%'`
+(that needs `text_pattern_ops`), so PG may still seq-scan. The win is real regardless —
+filtering happens in the DB, only matching rows cross the wire, and the whole-table JS
+object build disappears. Do **not** add an index; the `settings` table is hundreds of rows.
+
+### 3.2 Callers — blast radius
+`grep -rn getSourceSettings src --include=*.ts --include=*.tsx | grep -v '\.test\.'`:
+
+| Site | Use | Impact |
+|---|---|---|
+| `settingsRoutes.ts:259` | `GET /api/settings?sourceId=` merge | needs the whole namespace — unchanged |
+| `settingsRoutes.ts:1675` | `GET /auto-ping` override prefetch | unchanged |
+| `settingsRoutes.ts:1707` | `POST /auto-ping` override prefetch (mutated in place) | unchanged |
+
+Return shape and semantics are identical, so all three are no-diff.
+
+### 3.3 Should any caller use `getSettingForSources` instead? — **No.**
+The brief asked. Answer with reasoning so it is not re-litigated:
+- `:259` genuinely wants the *whole* namespace to merge over globals. `getSettingForSources`
+  is one-key-many-sources; the wrong axis.
+- `:1675`/`:1707` prefetch 4 keys for **one** source and then fall through to
+  `getSetting()` for the global. Converting them to 4 × `getSettingForSource` swaps one
+  range scan for four point lookups (no win), and `:1707` **mutates `sourceOverrides` in
+  place** after each write (`sourceOverrides['autoPingEnabled'] = …`), so the conversion is
+  a restructure, not a substitution.
+
+Fixing the primitive fixes all three call sites with a zero-line caller diff. That is the
+complete fix; converting callers is neither necessary nor beneficial.
+
+### 3.4 Files
+| File | Change |
+|---|---|
+| `src/db/repositories/settings.ts` | add `sourceNamespaceMatch`; rewrite `getSourceSettings`; re-point `deleteSourceSettings` |
+| `src/db/repositories/settings.test.ts` | 5 new tests inside `runSettingsTests` |
+
+### 3.5 New tests — inside `runSettingsTests` (all three backends, §1.7)
+
+`getSourceSettings` currently has **zero** tests as a subject (§7). Add:
+
+1. **`getSourceSettings - returns this source's rows with the prefix stripped`** — seed
+   two keys on A, one on B, one bare global; assert A's map is exactly the two bare keys.
+2. **`getSourceSettings - excludes the un-namespaced global rows`** — seed
+   `maxNodeAgeHours = '24'` globally and nothing per-source; assert `{}`.
+3. **`getSourceSettings - a sourceId containing a LIKE wildcard does not over-match a lookalike namespace`** —
+   mirror of the existing `deleteSourceSettings` test at `:281`: seed `source_a` and
+   `sourceXa`; assert `getSourceSettings('source_a')` returns only `source_a`'s rows. **This
+   is the test that would catch a wrong ESCAPE literal on MySQL** and is the reason the
+   whole suite must be confirmed to have run on all three backends (§8.2).
+4. **`getSourceSettings - issues exactly one SELECT and does not read the whole table`** —
+   copy the harness at `:369-395`; assert `selectCalls === 1` **and** that the query is
+   scoped, by seeding 3 sibling sources and asserting the returned map has only A's keys.
+   (Count alone is insufficient: `getAllSettings()` is also one `select`.)
+5. **`getSourceSettings - a stored __proto__ key does not pollute the prototype`** —
+   `setSourceSetting(A, '__proto__', 'pwned')`; assert
+   `({} as any).polluted === undefined`, `Object.getPrototypeOf({}) === Object.prototype`,
+   and that the returned map carries `__proto__` as an own enumerable property.
+
+### 3.6 Acceptance criteria (WP2)
+- [ ] `npx vitest run src/db/repositories/settings.test.ts src/server/routes/sourceRoutes.settingsCleanup.test.ts src/server/routes/unifiedRoutes.perSource.test.ts src/server/routes/settingsRoutes.test.ts` — 0 failures.
+- [ ] The PG and MySQL halves of `settings.test.ts` are **proven to have run**, not
+      skipped — see §8.2 for the exact command and what to paste into the commit message.
+- [ ] Test 4 fails if `getSourceSettings` is reverted to the scan-and-filter body.
+- [ ] `npm run lint:ci` clean (worktree-filtered).
+
+---
+
+## 4. WP3 — Migration 050: freeze the promoted key list
+
+### 4.1 The defect
+`src/server/migrations/050_promote_globals_to_default_source.ts:34` imports
+`PER_SOURCE_SETTINGS_KEYS` and iterates it in all three backends (`:68`, `:129`, `:202`).
+Fresh installs replay every migration (#3962 deleted `createTables`), so 050 runs against
+whatever that array holds **today**. The array has grown from 87 keys to 170 since 050 was
+authored; the drift is live, and this epic contributed 9 of those keys.
+
+### 4.2 **Decision: freeze at today's 170-key list (a verbatim snapshot), not the 87-key authoring-time list.**
+
+Measured facts (computed by diffing `src/server/constants/settings.ts` at
+`aae251a64a573965c5bc6fb24b926dd52fb2d78b` — the commit that added 050, 2026-04-28 — against `HEAD`):
+
+- `PER_SOURCE_SETTINGS_KEYS`: **87 keys then, 170 now. 83 added, 0 removed.** Today's list
+  is a strict superset.
+- Of those 83 added keys, exactly **9** were already user-writable global settings at
+  050-authoring time (i.e. present in `VALID_SETTINGS_KEYS` then): `maxNodeAgeHours`,
+  `inactiveNodeThresholdHours`, `inactiveNodeCheckIntervalMinutes`,
+  `inactiveNodeCooldownHours`, `nodeHopsCalculation`, `hideIncompleteNodes`,
+  `nodeDimmingEnabled`, `nodeDimmingStartHours`, `nodeDimmingMinOpacity` — **exactly this
+  epic's Node Display nine.**
+- The other **74** did not exist as valid settings keys at 050-authoring time, so an
+  install old enough to still need 050 cannot have a global row for them written through
+  `POST /api/settings`. 050's `if (!globalRow) continue` makes them inert.
+
+Justification:
+
+1. **A cleanup phase must not change upgrade semantics.** Snapshotting today's array is the
+   only option with a provably zero behaviour delta at the moment of the fix. The migration
+   keeps doing exactly what `main` does today; it just stops being a moving target.
+2. **Freezing at 87 would be an active regression, not a restoration.** It would stop
+   promoting those 9 keys for every future v3.x/early-4.x upgrader. Migration 131 does
+   re-seed the same ten Node Display keys from globals for every row in `sources`, so the
+   user-visible loss is small — but "make the upgrade path do less" is a behaviour change,
+   and this phase is not authorised to make one.
+3. **The remaining 74 keys cost nothing to keep.** Provably inert on the promote path for
+   any install that has not yet run 050.
+4. **The existing-vs-fresh divergence the brief flags is pre-existing and unavoidable, and
+   freezing at today resolves it in the safe direction.** An install that ran 050 in April
+   got the April list; nothing can retroactively change that. Between "an install migrating
+   later gets *more* of its legacy config preserved" and "gets *less*", the former is the
+   only defensible default.
+5. **Fresh installs are unaffected either way.** On a genuinely empty database 050 finds
+   zero global rows and promotes nothing. The list content only matters on the *upgrade*
+   path — which is exactly what point 2 protects.
+6. **Freezing does not create a future gap; it makes an existing implicit one explicit and
+   forces the correct pattern.** After the freeze, key #171 will not be promoted by 050 —
+   but it already isn't, for every install that ran 050 before #171 existed. The correct
+   remedy for a newly-per-source key is its own seed/promote migration, which is precisely
+   the precedent migration 131 set. WP3 writes that rule into 050's doc comment.
+
+### 4.3 Change
+
+In `050_promote_globals_to_default_source.ts`:
+
+- **Delete** `import { PER_SOURCE_SETTINGS_KEYS } from '../constants/settings.js';`
+- **Add** an exported frozen constant immediately after `const LABEL`:
+
+```ts
+/**
+ * The per-source settings keys this migration promotes, FROZEN as of 4.13.3.
+ *
+ * Deliberately NOT an import of PER_SOURCE_SETTINGS_KEYS (contrast the original 050, and
+ * compare migration 131's NODE_DISPLAY_SEED): a migration is a statement about a point in
+ * time, and fresh installs replay every migration (#3962 deleted createTables), so an
+ * imported array runs against whatever it contains *today*, not what it contained when
+ * this migration shipped. That drift was live — the array grew 87 -> 170 keys between 050
+ * shipping and this freeze (#4419).
+ *
+ * This snapshot is the 170-key list as of the freeze, NOT the 87-key list 050 originally
+ * ran with. That choice is deliberate: a snapshot of today changes nothing for anyone at
+ * freeze time, whereas reverting to the 87-key list would stop promoting nine long-standing
+ * globals (maxNodeAgeHours and the node-dimming / inactive-node group) for every future
+ * v3.x upgrader. See PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md §4.2 for the full analysis.
+ *
+ * DO NOT append to this list when a new setting becomes per-source. This list is history.
+ * A key that becomes per-source AFTER this freeze needs its own seed/promote migration —
+ * that is what migration 131 is, and it is the pattern to copy.
+ */
+export const PROMOTED_SETTING_KEYS: readonly string[] = [
+  /* … 170 string literals, verbatim from PER_SOURCE_SETTINGS_KEYS at this commit … */
+];
+```
+
+- Replace the three `for (const key of PER_SOURCE_SETTINGS_KEYS)` loops (`:68`, `:129`,
+  `:202`) with `PROMOTED_SETTING_KEYS`. **No other logic changes.**
+
+**How to produce the 170 literals — do not hand-transcribe.** Run this in the worktree and
+paste the output verbatim:
+
+```bash
+node -e "
+const fs=require('fs');
+const t=fs.readFileSync('src/server/constants/settings.ts','utf8');
+const m=t.match(/export const PER_SOURCE_SETTINGS_KEYS[^=]*=\s*\[([\s\S]*?)\]\s*as const;/);
+const k=[...m[1].matchAll(/'([^']+)'/g)].map(x=>x[1]);
+console.error('count='+k.length);
+console.log(k.map(x=>\"  '\"+x+\"',\").join('\n'));
+"
+```
+Assert `count=170` before pasting. Keep the source array's grouping comments **out** —
+the frozen list is a flat historical record, not a maintained taxonomy.
+
+### 4.4 Explicitly out of scope for WP3
+The PG (`:129-144`) and MySQL (`:202-…`) loops do **one SELECT and one INSERT per key** —
+170 sequential round trips each, the #4233 anti-pattern. Under the migration ledger this
+runs once per database (~170 ms), so it is not worth the risk in a cleanup phase.
+**Do not batch it.** Record it as an observation in the epic deviations log; the
+orchestrator can file it separately if it wants. Consequence for testing: the new
+pgmysql test must assert **behaviour**, never round-trip counts — pinning 170 round trips
+would itself be an implementation-asserting test, the exact thing §7 audits for.
+
+### 4.5 Files
+| File | Change |
+|---|---|
+| `src/server/migrations/050_promote_globals_to_default_source.ts` | drop the import, add `PROMOTED_SETTING_KEYS`, re-point 3 loops |
+| `src/server/migrations/050_promote_globals_to_default_source.test.ts` | add the 2 drift-guard tests (4.6) |
+| `src/server/migrations/050_promote_globals_to_default_source.pgmysql.test.ts` | **NEW** (4.7) |
+
+`src/db/migrations.ts` needs **no** change — the registry entry, `settingsKey`, and
+migration number are all untouched. `src/db/migrations.test.ts` is registry-derived and
+also needs no change.
+
+### 4.6 New tests — `050_…test.ts` (SQLite)
+The existing 8 tests all stay (§7, Area 3). Add:
+
+1. **`the promoted key list is frozen — 050 does not import the live constants array (#4419)`**
+
+```ts
+const src = readFileSync(new URL('./050_promote_globals_to_default_source.ts', import.meta.url), 'utf8');
+expect(src).not.toMatch(/PER_SOURCE_SETTINGS_KEYS/);
+expect(src).not.toMatch(/from ['"]\.\.\/constants\/settings\.js['"]/);
+```
+   This is the **only** test that can catch the defect. Everything else is blind to it.
+
+2. **`PROMOTED_SETTING_KEYS is the 170-key 4.13.3 snapshot`** — assert
+   `toHaveLength(170)`, `new Set(...).size === 170` (no dupes), and three era sentinels:
+   `'autoResponderEnabled'` (original 050 list), `'meshcoreAutoAckEnabled'` (4.9-era),
+   `'maxNodeAgeHours'` (added by this epic's Phase 1).
+   **Do not** assert equality against `PER_SOURCE_SETTINGS_KEYS` — that re-couples them and
+   defeats the entire fix. The magic number 170 is the point; it must never change.
+
+### 4.7 New test — `050_…pgmysql.test.ts` (NEW)
+Copy the two-half structure and header warning from
+`131_seed_per_source_node_display.pgmysql.test.ts` (§1.8).
+
+**Fake-client half** (always runs — this is what makes the WP verifiable even with the
+containers down):
+- PG: promotes a global row for a key in `PROMOTED_SETTING_KEYS` into
+  `source:{default}:{key}`; SQL shape is quoted-camelCase columns + `ON CONFLICT (key) DO NOTHING`.
+- MySQL: same, with backticked `` `key` `` + `INSERT IGNORE`.
+- A global row whose key is **not** in `PROMOTED_SETTING_KEYS` is never inserted —
+  this is the fake-client expression of the freeze.
+- No assertions on query counts (§4.4).
+
+**Container half** (`describe.skipIf(!postgresAvailable)` / `!mysqlAvailable`) — same
+invariants as the SQLite suite, against `localhost:5433` / `localhost:3307`:
+- promotes globals into the default source's namespace;
+- leaves the original global row intact (non-destructive);
+- does not overwrite an existing per-source override;
+- is idempotent across two consecutive runs;
+- backfills `NULL`-`sourceId` rows in `auto_traceroute_nodes` / `auto_time_sync_nodes`.
+
+Required DDL: `settings`, `sources`, `auto_traceroute_nodes`, `auto_time_sync_nodes`.
+Read `src/server/migrations/_legacyDefaultSource.ts` first — `ensureDefaultSourceIdPostgres` /
+`…Mysql` determine the `sources` columns the fixture must provide.
+
+This is 050's **first** PG/MySQL coverage of any kind. Two of the invariants above
+(non-destructive, no-override-clobber) are correctness properties of the `ON CONFLICT` /
+`INSERT IGNORE` clause that nothing currently tests on those backends.
+
+### 4.8 Acceptance criteria (WP3)
+- [ ] `npx vitest run src/server/migrations/050_promote_globals_to_default_source.test.ts src/server/migrations/050_promote_globals_to_default_source.pgmysql.test.ts src/db/migrations.test.ts` — 0 failures.
+- [ ] `count=170` from the generator command is recorded in the commit message.
+- [ ] Test 4.6(1) fails when the import is restored (demonstrate once).
+- [ ] The PG and MySQL container halves are **proven to have run** — §8.2.
+- [ ] `grep -c "'" src/server/migrations/050_*.ts` sanity: `PROMOTED_SETTING_KEYS` has 170
+      entries and the diff touches no logic outside the three loop headers and the import.
+
+---
+
+## 5. WP4 — `externalUrl`: recommendation and minimal safe change
+
+### 5.1 Findings
+- **One reader:** `src/server/services/securityDigestService.ts:332` —
+  `const baseUrl = (await …getSettingForSource(sourceId,'externalUrl')) || '';`
+- **Zero writers.** Repo-wide grep hits only `constants/settings.ts` (the
+  `PER_SOURCE_SETTINGS_KEYS` entry at `:489` and the `PER_SOURCE_KEYS_NOT_POSTABLE`
+  orphan comment at `:625-631`), the service, and its own test.
+- **Downstream:** `baseUrl` flows into `formatDigestSummary` / `formatDigestDetailed`
+  (`:59`, `:125`, `:255`, `:389-390`) which emit `[View details](${baseUrl}/security)` or
+  `View details: ${baseUrl}/security`. With `baseUrl === ''` **every Apprise security
+  digest ever sent contains a dead relative link** — `View details: /security` — in a
+  Discord/email/ntfy message where a relative path resolves to nothing.
+- **No existing source of truth to wire it to.** `env.baseUrl` (`server.ts:75`) is the
+  `BASE_URL` *path prefix* (`/meshmonitor`), not an absolute origin. Producing a working
+  link needs a scheme + host the server does not know.
+
+### 5.2 Recommendation
+
+**This needs a product decision; Phase 5 must not make it.** Wiring a writer means a new
+user-facing "External URL" setting (new `VALID_SETTINGS_KEYS` entry, new UI field,
+validation, per-source vs. global scope, secret-stripping question) — a feature. Deleting
+the read means deleting the "View details" link from digests — a product removal.
+
+**Minimal safe change for this phase: suppress the dangling link when no URL is
+configured.** It is pure output correctness — it removes text that is broken 100% of the
+time today, adds no setting, deletes no working behaviour, and the link returns
+automatically the day a writer is wired.
+
+```ts
+/**
+ * The digest's "View details" line. Omitted entirely when no absolute external URL is
+ * configured, because `${''}/security` renders as a dead relative path in an Apprise
+ * message. `externalUrl` currently has NO writer anywhere in the repo (#4419 / <new issue>);
+ * whether it should become a user-configurable setting is a product decision, not a
+ * cleanup. Until then this keeps the broken line out of every digest.
+ */
+function detailsLink(baseUrl: string, markdown: boolean): string | null {
+  if (!baseUrl) return null;
+  return markdown ? `[View details](${baseUrl}/security)` : `View details: ${baseUrl}/security`;
+}
+```
+Route all six emission sites (`:80`, `:88`, `:105`, `:119`, `:146`, `:154`, `:255`) through
+it, pushing only when non-null. No test currently asserts the string `View details`
+anywhere in the repo, so this is a low-collision edit.
+
+Also update the `PER_SOURCE_KEYS_NOT_POSTABLE` comment (`constants/settings.ts:625-631`) to
+reference the newly filed product issue instead of "§8.7", and **leave the key exactly
+where it is**. Do not touch `VALID_SETTINGS_KEYS`.
+
+**Fallback if the orchestrator judges even this too much:** document-only — update the two
+comments, add the test at 5.4(1) as a `.todo`, file the issue, change no behaviour. Say so
+explicitly rather than half-doing it.
+
+### 5.3 File the product issue
+Title: `[QUESTION] externalUrl is read by the security digest and written nowhere — wire a writer or drop the link?`
+Body: the §5.1 findings, both options with their costs, and the note that adding the key to
+`VALID_SETTINGS_KEYS` is the one thing that must not happen by accident. Link #4419, #4412.
+
+### 5.4 New tests — `securityDigestService.test.ts`
+1. **`a digest with no externalUrl configured contains no dangling "/security" link`** —
+   assert the rendered body does **not** match `/View details/`. Fails on today's code.
+2. **`a digest with externalUrl configured emits an absolute link`** — seed
+   `https://mesh.example`; assert `View details: https://mesh.example/security`. Pins that
+   the suppression is conditional, not a deletion.
+
+Also add a two-line comment to `securityDigestService.perSource.test.ts:42,47`: the fixture
+seeds `externalUrl: 'https://a.example'` into a mocked settings map, a value **no production
+write path can produce** — a fiction that helped this orphan hide. The test's own subject
+(per-source dispatch) is fine; the comment stops the next reader inferring a writer exists.
+
+---
+
+## 6. The `(local)` naming heuristic — **defer to its own issue. Do not implement here.**
+
+### 6.1 Actual surface (larger than the brief's "two server route files and three components")
+**Writers (server):** `src/server/routes/meshcoreContactsRoutes.ts:108`,
+`src/server/routes/meshcoreDeviceRoutes.ts:181` — both synthesize
+`` advName: `${localNode.name} (local)` ``.
+**Readers (client):** `src/utils/meshcoreHelpers.ts:36`,
+`src/components/MeshCore/MeshCoreNodesView.tsx:294` and `:324`,
+`src/components/MeshCore/MeshCoreMap.tsx:329` and `:343`,
+`src/components/MeshCore/MeshCoreMessageRouteModal.tsx:108`.
+**Tests pinning the convention:** `MeshCoreNodesView.test.tsx:314`,
+`MeshCoreMessageRouteModal.test.tsx:176`.
+That is **7 production files** (2 server + 1 shared util + 3 components + a
+`MeshCoreContact` type change), a server response-shape change, and 2+ test files.
+
+### 6.2 Why defer
+1. **Bigger than the other four items combined.** WP1–WP4 touch 6 production files total.
+2. **The hard part is not the flag, it is proving completeness.** An `isLocal` flag is only
+   correct if it is present on **every** path that produces a `MeshCoreContact` — the REST
+   contacts list, the device route, any websocket push, any cached/persisted path. Missing
+   one silently *un*-exempts the local node, which is a worse regression than the bug being
+   fixed (a user's own node vanishing from the list beats a stranger's oddly-named node
+   staying). Establishing that is a survey, not a cleanup.
+3. **The failure mode requires a user to literally include the string `(local)` in their
+   device name.** Zero reports. Low severity, non-zero fix risk — the wrong trade for a
+   cleanup phase.
+4. **It straddles the phase.** WP1–WP4 are backend/DB; folding in a MeshCore UI + API-shape
+   change defeats the file-ownership discipline and makes the PR two reviews.
+
+### 6.3 What WP4 does do (cheap, in scope)
+Phase 4 left `NOTE:` comments only in `MeshCoreNodesView.tsx` (`:285-289`, `:319`). The
+other **four** read sites carry no warning at all. Add a one-line pointer at
+`meshcoreHelpers.ts:36`, `MeshCoreMap.tsx:329`, `MeshCoreMap.tsx:343`, and
+`MeshCoreMessageRouteModal.tsx:108`:
+
+```ts
+// `(local)` is a server-side naming convention (meshcoreContactsRoutes.ts:108,
+// meshcoreDeviceRoutes.ts:181), not a protocol field — a user-chosen name containing
+// "(local)" matches here too. Tracked for an explicit isLocal flag in #<new issue>.
+```
+
+File the issue: `[BUG] MeshCore local-node detection matches on the name string "(local)"`,
+listing all 7 files, the 2 writers, and the completeness constraint from 6.2(2).
+
+---
+
+## 7. Test audit — keep / rewrite / delete
+
+Classification of every existing test touching the four areas. The column that matters is
+the last one.
+
+### Area 1 — `settingsRoutes` POST change-detection (#4419a)
+| Test | Verdict | Green with the defect present? |
+|---|---|---|
+| `settingsRoutes.test.ts:275` rejects lookaround when enabling | **keep** | **YES** — global path (`sourceId=null`), where `prefix=''` makes buggy and fixed code byte-identical |
+| `settingsRoutes.test.ts:287` allows toggling OFF with a persisted bad regex (#3806) | **keep** | **YES** — same |
+| `settingsRoutes.test.ts:307` rejects newly changing to a bad pattern while disabled | **keep** | **YES** — same |
+| `settingsRoutes.test.ts:323` accepts a valid regex when enabling | **keep** | **YES** — same |
+| `settingsRoutes.test.ts:237/248/259` regex too long / complex / invalid syntax | keep | yes — global path, and they enable auto-ack so `regexChanged` is not load-bearing |
+| `settingsRoutes.perSource.test.ts` (all 12) | keep | yes — none touch `autoAckRegex` |
+
+**Finding:** the four `#3806` tests are not bug-pinning — they assert the right thing for
+the global path — but the scoped path has **zero** coverage, so the defect was structurally
+invisible. WP1 §2.5 closes it. `settingsRoutes.test.ts` stays on the deprecated
+`vi.mock('../../services/database.js')` pattern; **WP1 must not touch that file**, or
+CLAUDE.md's opportunistic-conversion rule drags a 1,270-line harness migration into a
+cleanup phase. New tests go in the already-converted `perSource` file.
+
+### Area 2 — `getSourceSettings` (#4419b)
+| Test | Verdict | Green with the defect present? |
+|---|---|---|
+| `settings.test.ts:243` `deleteSourceSettings - removes only the target prefix` | keep | yes — uses `getSourceSettings` as an oracle only |
+| `settings.test.ts:267` `deleteSourceSettings - no-op on unknown sourceId` | keep | yes |
+| `settings.test.ts:281` `deleteSourceSettings - LIKE wildcard lookalike` | **keep — and it becomes load-bearing for the read too** once both share `sourceNamespaceMatch` | yes |
+| `sourceRoutes.settingsCleanup.test.ts` (3 tests) | keep | yes — asserts the requirement through the public surface. Good test. |
+| `unifiedRoutes.perSource.test.ts` | keep | mentions `getSourceSettings` only in a doc comment |
+
+**Finding (new):** **no test anywhere calls `getSourceSettings` as its subject.** Bare-key
+stripping, sibling-namespace exclusion, global-row exclusion, wildcard-lookalike
+over-matching, and query count are all uncovered. The function Phase 5 is rewriting is
+untested. WP2 §3.5 adds 5.
+
+### Area 3 — Migration 050
+| Test | Verdict | Green with the defect present? |
+|---|---|---|
+| `050_…test.ts:72` promotes legacy globals | keep | **YES** |
+| `:89` preserves the original global (non-destructive) | keep | **YES** |
+| `:98` does not overwrite an existing per-source override | keep | **YES** |
+| `:108` skips keys with no global value | keep (verify it still asserts 0 rows) | **YES** |
+| `:121` idempotent | keep | **YES** |
+| `:135` backfills `auto_traceroute_nodes` | keep | **YES** |
+| `:155` backfills `auto_time_sync_nodes` | keep | **YES** |
+| `:166` synthesizes a default source when `sources` is empty | keep | **YES** |
+
+**Finding (new, and the most serious in this audit): all eight tests stay green with the
+drift bug fully present.** They exercise three concrete keys —
+`autoResponderEnabled`, `autoResponderTriggers`, `tracerouteIntervalMinutes` — that are in
+*both* the 87-key authoring list and today's 170, so the suite is structurally incapable of
+observing that the migration's input set changes over time. It is the same failure class as
+the four bug-pinning tests Phases 2–3 deleted, one level up: the tests aren't wrong, they
+are aimed at a property that cannot vary. The only test that can catch it is the
+source-text drift guard at §4.6(1). Second finding: **050 has no PG/MySQL coverage at all**
+despite shipping hand-written PG and MySQL implementations — WP3 §4.7.
+
+### Area 4 — `externalUrl`
+| Test | Verdict | Green with the defect present? |
+|---|---|---|
+| `securityDigestService.perSource.test.ts:42,47` — fixture seeds `externalUrl` per source | **keep, annotate** | **YES** |
+| `securityDigestService.test.ts` (all) | keep | yes — none assert on `View details` |
+
+**Finding (new):** the `perSource` fixture seeds `externalUrl: 'https://a.example'` into a
+mocked settings map — **a value no production write path can produce.** The test's actual
+subject (per-source dispatch) is sound and it is not bug-pinning, but the fixture presents
+a configured-and-working setting, which is how a reader concludes a writer exists. WP4
+adds the annotation; §5.4 adds the two tests that assert the requirement.
+
+### Area 5 — `(local)` heuristic (deferred, §6)
+| Test | Verdict | Green with the defect present? |
+|---|---|---|
+| `MeshCoreNodesView.test.tsx:312` `bypasses the cutoff for the local node` | **asserts the implementation** — hard-codes `advName: 'MyNode (local)'`, i.e. it tests the naming convention rather than "the local node is exempt". It passes today for a *user-named* node containing `(local)` — which is the bug. | yes |
+| `MeshCoreMessageRouteModal.test.tsx:176` `'Base (local)'` fixture | same class | yes |
+| Verdict for Phase 5 | **leave both untouched** — the deferral issue owns them; rewriting them without the `isLocal` flag would just re-pin the convention | |
+
+### Audit summary
+| | count |
+|---|---|
+| keep, unchanged | 24 |
+| keep + annotate | 3 (`settings.test.ts:281`, `securityDigestService.perSource.test.ts` fixture ×2) |
+| rewrite | 0 |
+| delete | 0 |
+| **would stay green with their area's defect fully present** | **19** |
+| new tests added by this phase | 15 (6 WP1 + 5 WP2 + 2 WP3-SQLite + ~11 WP3-pgmysql + 2 WP4) |
+
+Nothing needs deleting this phase — a first for this epic. The problem here is not
+tests pinning bugs; it is **19 tests aimed at properties that cannot vary**, which is why
+four real defects survived four merged phases. Every new test in this spec names the
+mutation it is supposed to catch, and WP1/WP3 must demonstrate the failure once.
+
+---
+
+## 8. Test plan
+
+Standard Vitest suite only. No system tests, no browser validation (this phase has no
+user-visible surface beyond the digest line in §5.2, which has no UI).
+
+### 8.1 Prerequisites
+PostgreSQL on `localhost:5433` and MySQL on `localhost:3307` are already up. Confirm
+before starting:
+```bash
+(exec 3<>/dev/tcp/127.0.0.1/5433) 2>/dev/null && echo "pg up" || echo "PG DOWN"
+(exec 3<>/dev/tcp/127.0.0.1/3307) 2>/dev/null && echo "mysql up" || echo "MYSQL DOWN"
+```
+If either is down, restart with the commands in CLAUDE.md → Multi-Database. A missing
+container makes the suites **skip silently** while still reporting `success: true`.
+
+### 8.2 Proving multi-backend tests actually ran (required for WP2 and WP3)
+`success: true` is not evidence. Use the JSON reporter and check the skip count:
+
+```bash
+npx vitest run <files> --reporter=json --outputFile=/tmp/claude-1000/-home-yeraze-Development-meshmonitor/53db95f3-753a-437d-b735-fb47603d2993/scratchpad/wpN.json
+jq '{success, passed:.numPassedTests, failed:.numFailedTests, pending:.numPendingTests}' \
+   /tmp/claude-1000/-home-yeraze-Development-meshmonitor/53db95f3-753a-437d-b735-fb47603d2993/scratchpad/wpN.json
+```
+- **`pending` must be 0** for these files. Any non-zero value means a `describe.skipIf`
+  block was skipped — the run does not count.
+- Additionally, `settings.test.ts` and the pgmysql suites print
+  `✓ PostgreSQL connection established` / `✓ MySQL connection established` on stdout.
+  Capture both lines.
+- Paste the `jq` output **and** both `✓` lines into the WP's commit message. A WP that
+  claims three-backend verification without them is not accepted.
+
+### 8.3 Targeted commands per WP (parallel-safe)
+**Concurrent full-suite runs corrupt the shared MySQL test schema** (Phase 3 deviations
+log — an agent's parallel `vitest` invocations produced failures in files it never
+touched). While WPs run in parallel each runs **only** its own list:
+
+| WP | Command |
+|---|---|
+| WP1 | `npx vitest run src/server/routes/settingsRoutes.perSource.test.ts src/server/routes/settingsRoutes.test.ts` |
+| WP2 | `npx vitest run src/db/repositories/settings.test.ts src/server/routes/sourceRoutes.settingsCleanup.test.ts src/server/routes/unifiedRoutes.perSource.test.ts src/server/routes/settingsRoutes.test.ts` |
+| WP3 | `npx vitest run src/server/migrations/050_promote_globals_to_default_source.test.ts src/server/migrations/050_promote_globals_to_default_source.pgmysql.test.ts src/db/migrations.test.ts` |
+| WP4 | `npx vitest run src/server/services/securityDigestService.test.ts src/server/services/securityDigestService.perSource.test.ts src/components/MeshCore/` |
+
+**WP2 and WP3 both touch PG/MySQL containers.** If they run concurrently, run WP3's
+container half *after* WP2 finishes, or serialise the two. Note it in the ownership table.
+
+### 8.4 Orchestrator-only: the single authoritative full run
+After all WPs merge into the branch, **one** run, nothing else executing:
+```bash
+npx vitest run --reporter=json --outputFile=<scratchpad>/full.json
+jq '{success, passed:.numPassedTests, failed:.numFailedTests, pending:.numPendingTests}' <scratchpad>/full.json
+```
+`success: true` **and** `failed: 0`. Compare `pending` against a pre-change baseline —
+it should drop (WP3 adds container tests) and must not rise.
+
+Then: `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` → empty.
+And `npx tsc --noEmit`.
+
+### 8.5 Mutation checks (required evidence, not optional)
+| WP | Mutation | Must fail |
+|---|---|---|
+| WP1 | revert `:329`/`:330` to `currentSettings.autoAck*` | §2.5 tests 1, 2, 3 |
+| WP2 | revert `getSourceSettings` to the `getAllSettings()` + JS filter body | §3.5 test 4 |
+| WP3 | restore `import { PER_SOURCE_SETTINGS_KEYS }` and re-point one loop | §4.6 test 1 |
+| WP4 | remove the `if (!baseUrl) return null` guard | §5.4 test 1 |
+Each WP records the failure output in its commit message.
+
+---
+
+## 9. Work packages, ordering, and file ownership
+
+Four packages, each one Sonnet agent. **All four are independent — no dependencies.** They
+may run fully in parallel subject to the container caveat in §8.3.
+
+| WP | Title | Depends on | Size |
+|---|---|---|---|
+| **WP1** | #4419(a) — scope-correct change detection in `POST /api/settings` | — | S |
+| **WP2** | #4419(b) — `getSourceSettings` prefix-scoped query | — | S |
+| **WP3** | Migration 050 — freeze the promoted key list + first PG/MySQL coverage | — | **L** (the pgmysql suite is the bulk) |
+| **WP4** | `externalUrl` minimal fix + `(local)` deferral comments + 2 issues filed | — | S |
+
+### 9.1 File ownership — no file is written by two packages
+
+| File | Owner |
+|---|---|
+| `src/server/routes/settingsRoutes.ts` | **WP1** |
+| `src/server/routes/settingsRoutes.perSource.test.ts` | **WP1** |
+| `src/db/repositories/settings.ts` | **WP2** |
+| `src/db/repositories/settings.test.ts` | **WP2** |
+| `src/server/migrations/050_promote_globals_to_default_source.ts` | **WP3** |
+| `src/server/migrations/050_promote_globals_to_default_source.test.ts` | **WP3** |
+| `src/server/migrations/050_promote_globals_to_default_source.pgmysql.test.ts` (new) | **WP3** |
+| `src/server/services/securityDigestService.ts` | **WP4** |
+| `src/server/services/securityDigestService.test.ts` | **WP4** |
+| `src/server/services/securityDigestService.perSource.test.ts` | **WP4** |
+| `src/server/constants/settings.ts` | **WP4** (comment only, `:625-631`) |
+| `src/utils/meshcoreHelpers.ts` | **WP4** (comment only) |
+| `src/components/MeshCore/MeshCoreMap.tsx` | **WP4** (comment only) |
+| `src/components/MeshCore/MeshCoreMessageRouteModal.tsx` | **WP4** (comment only) |
+| `docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_EPIC.md` | **orchestrator only** |
+| `docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md` | **orchestrator only** |
+
+Read-only for everyone: `src/server/migrations/131_seed_per_source_node_display*.ts`,
+`src/server/test-helpers/routeTestApp.ts`, `src/db/migrations.ts`.
+
+**No WP edits the epic doc.** Each reports its deviations in its commit message; the
+orchestrator writes the Phase 5 deviations-log section once, at the end. This removes the
+only serialisation point between the four packages.
+
+**Read-only file both WP3 and WP4 depend on:** `src/server/constants/settings.ts`. WP3
+*reads* `PER_SOURCE_SETTINGS_KEYS` (via the generator command in §4.3) but never writes the
+file; WP4 owns the write. WP3 must run its generator **before** WP4's comment edit lands,
+or simply re-run it — the array itself is untouched either way, so there is no race.
+
+**Shared-worktree hazard (see auto-memory `feedback_parallel_agents_rtk_commit_hazard`):**
+all four WPs run in the same checkout. Commit with an **explicit pathspec**
+(`git commit -- <files>`), never a bare `git commit -a` / rtk-wrapped auto-stage, or one
+agent sweeps another's in-progress files. Audit the file list on every commit.
+
+### 9.2 Per-package acceptance criteria
+See §2.6 (WP1), §3.6 (WP2), §4.8 (WP3). WP4:
+- [ ] `npx vitest run src/server/services/securityDigestService.test.ts src/server/services/securityDigestService.perSource.test.ts src/components/MeshCore/` — 0 failures.
+- [ ] `grep -c externalUrl src/server/constants/settings.ts` unchanged (2 hits: the
+      `PER_SOURCE_SETTINGS_KEYS` entry and the `PER_SOURCE_KEYS_NOT_POSTABLE` entry) and
+      `grep -n externalUrl src/server/constants/settings.ts` shows it is **still absent**
+      from `VALID_SETTINGS_KEYS`.
+- [ ] Both issues filed; their numbers are in the comments, not `TODO` or `#XXXX`.
+- [ ] `npm run lint:ci` clean (worktree-filtered).
+
+### 9.3 Phase exit criteria (orchestrator)
+- [ ] All four WPs merged into `feature/per-source-settings-followups`.
+- [ ] Single authoritative full suite green — §8.4 — with `pending` not risen.
+- [ ] `npm run lint:ci` clean, `npx tsc --noEmit` clean.
+- [ ] The five mutation checks in §8.5 each demonstrated once.
+- [ ] Two issues filed (`externalUrl` product question; `(local)` → `isLocal` flag).
+- [ ] Epic deviations log updated with the Phase 5 section, **including** the §4.4
+      observation about 050's PG/MySQL per-key round trips.
+- [ ] #4419 closable.
+
+---
+
+## 10. Risks for the orchestrator to weigh
+
+1. **The migration-050 frozen list is the one judgement call in this phase.** §4.2 argues
+   for today's 170-key snapshot over the 87-key authoring-time list, and the argument turns
+   on nine specific keys. If the user's instinct is "a migration should replay exactly what
+   it originally did," the 87-key answer is defensible — but it must be a *deliberate*
+   choice to stop promoting `maxNodeAgeHours` and the node-dimming/inactive-node group on
+   future v3.x upgrades (partly mitigated by migration 131 re-seeding the same ten keys).
+   **Worth a one-line confirmation before WP3 starts** — it is cheap to ask and expensive
+   to redo, since the frozen list becomes history the moment it ships.
+2. **WP3 is materially larger than the other three.** Its pgmysql suite is 050's first
+   PG/MySQL coverage and needs `settings` + `sources` + two `auto_*` tables of fixture DDL.
+   If the phase needs to fit a smaller budget, the container half is the splittable part:
+   the fake-client half alone still proves the freeze. Do not drop the fake-client half —
+   it is the only always-runs evidence.
+3. **`externalUrl` §5.2 changes digest output.** It removes a line that is broken 100% of
+   the time, but it *is* an output change in a notification path with live users. The
+   document-only fallback in §5.2 is available; decide before WP4 starts rather than
+   reverting after review.
+4. **The `(local)` deferral (§6) is a recommendation, not a decision I can make alone.**
+   If the user wants it in this epic, it should be Phase 5b or a Phase 7 — not folded into
+   these four packages. The blocking question is 6.2(2): proving every `MeshCoreContact`
+   producer sets the flag.
+5. **Parallel WPs + shared PG/MySQL containers.** WP2 and WP3 both hit `localhost:5433`
+   and `:3307`. §8.3 says serialise their container-touching runs; if the orchestrator
+   would rather not manage that, run WP3 alone after WP1/WP2/WP4 finish — it is the only
+   WP with no logical dependency on ordering anyway.
+6. **`settingsRoutes.test.ts` (1,270 lines) is still on the deprecated `vi.mock` pattern.**
+   WP1 is explicitly forbidden from touching it (§7 Area 1) to avoid triggering CLAUDE.md's
+   opportunistic-conversion rule mid-cleanup. That leaves a known-deprecated file in the
+   tree; if a reviewer flags it, the answer is "separate PR," not "convert it now."
+7. **19 existing tests would stay green with their area's defect present** (§7). The
+   remedy in this spec is per-test mutation evidence (§8.5). If the orchestrator drops that
+   requirement to save time, Phase 5 will produce tests with the same blind spot as the ones
+   it is auditing.

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -326,6 +326,9 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     if (localNodePosition?.lat != null && localNodePosition?.lng != null) {
       return [localNodePosition.lat, localNodePosition.lng];
     }
+    // NOTE: `(local)` is a server-side naming convention (meshcoreContactsRoutes.ts:108,
+    // meshcoreDeviceRoutes.ts:181), not a protocol field — a user-chosen name containing
+    // "(local)" matches here too. Tracked for an explicit isLocal flag in #4438.
     const local = positioned.find(c => c.advName?.includes('(local)'));
     if (local) return [local.latitude!, local.longitude!];
     return null;
@@ -340,6 +343,9 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const pathSegments = useMemo(() => {
     if (!showPaths || !localPos) return [];
     return positioned
+      // NOTE: `(local)` is a server-side naming convention (meshcoreContactsRoutes.ts:108,
+      // meshcoreDeviceRoutes.ts:181), not a protocol field — a user-chosen name containing
+      // "(local)" matches here too. Tracked for an explicit isLocal flag in #4438.
       .filter(c => !c.advName?.includes('(local)') && typeof c.pathLen === 'number')
       .map(c => ({
         key: c.publicKey,

--- a/src/components/MeshCore/MeshCoreMessageRouteModal.tsx
+++ b/src/components/MeshCore/MeshCoreMessageRouteModal.tsx
@@ -105,6 +105,9 @@ const MeshCoreMessageRouteModal: React.FC<Props> = ({ message, fromLabel, contac
     const senderPos = contactPosition(senderContact);
     if (senderPos) points.push({ label: fromLabel, lat: senderPos.lat, lon: senderPos.lon, kind: 'endpoint' });
     points.push(...hopPoints);
+    // NOTE: `(local)` is a server-side naming convention (meshcoreContactsRoutes.ts:108,
+    // meshcoreDeviceRoutes.ts:181), not a protocol field — a user-chosen name containing
+    // "(local)" matches here too. Tracked for an explicit isLocal flag in #4438.
     const localContact = contacts.find((c) => c.advName?.includes('(local)'));
     const localPos = contactPosition(localContact);
     if (localPos) {

--- a/src/db/repositories/settings.test.ts
+++ b/src/db/repositories/settings.test.ts
@@ -296,6 +296,114 @@ function runSettingsTests(getBackend: () => TestBackend) {
     expect(await repo.getSourceSettings('sourceXa')).toEqual({ maxNodeAgeHours: '12' });
   });
 
+  it('getSourceSettings - returns this source\'s rows with the prefix stripped', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.setSourceSetting('source-a', 'maxNodeAgeHours', '48');
+    await repo.setSourceSetting('source-a', 'hideIncompleteNodes', '1');
+    await repo.setSourceSetting('source-b', 'maxNodeAgeHours', '12');
+    await repo.setSetting('maxNodeAgeHours', '24');
+
+    const result = await repo.getSourceSettings('source-a');
+
+    expect(result).toEqual({ maxNodeAgeHours: '48', hideIncompleteNodes: '1' });
+  });
+
+  it('getSourceSettings - excludes the un-namespaced global rows', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.setSetting('maxNodeAgeHours', '24');
+
+    const result = await repo.getSourceSettings('source-a');
+
+    expect(result).toEqual({});
+  });
+
+  it('getSourceSettings - a sourceId containing a LIKE wildcard does not over-match a lookalike namespace', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // 'source_a' (underscore) is a single-char LIKE wildcard that would match
+    // 'sourceXa' unless escaped. Mirrors the deleteSourceSettings test above —
+    // this is the test that would catch a wrong ESCAPE literal on MySQL.
+    await repo.setSourceSetting('source_a', 'maxNodeAgeHours', '48');
+    await repo.setSourceSetting('sourceXa', 'maxNodeAgeHours', '12');
+
+    expect(await repo.getSourceSettings('source_a')).toEqual({ maxNodeAgeHours: '48' });
+  });
+
+  it('getSourceSettings - issues exactly one SELECT and does not read the whole table', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // Three sibling sources so a correctly-scoped query returns only A's rows,
+    // not the whole table. Counting db.select() calls alone is insufficient:
+    // the old getAllSettings()-then-JS-filter body also issues exactly one
+    // select() (from inside getAllSettings), so that count is 1 either way.
+    // The real distinguishing signal is whether getAllSettings() itself gets
+    // called at all — the scoped implementation never calls it.
+    await repo.setSourceSetting('source-a', 'maxNodeAgeHours', '48');
+    await repo.setSourceSetting('source-b', 'maxNodeAgeHours', '168');
+    await repo.setSourceSetting('source-c', 'maxNodeAgeHours', '24');
+
+    // Monkey-patching the protected drizzle handle to count round trips (no-explicit-any is off in *.test.ts).
+    const dbHandle = (repo as any).db;
+    const realSelect = dbHandle.select.bind(dbHandle);
+    let selectCalls = 0;
+    dbHandle.select = (...args: unknown[]) => {
+      selectCalls += 1;
+      return realSelect(...args);
+    };
+
+    const realGetAllSettings = repo.getAllSettings.bind(repo);
+    let getAllSettingsCalls = 0;
+    (repo as any).getAllSettings = (...args: unknown[]) => {
+      getAllSettingsCalls += 1;
+      return realGetAllSettings(...(args as []));
+    };
+
+    try {
+      const result = await repo.getSourceSettings('source-a');
+      expect(selectCalls).toBe(1);
+      expect(getAllSettingsCalls).toBe(0);
+      expect(result).toEqual({ maxNodeAgeHours: '48' });
+    } finally {
+      dbHandle.select = realSelect;
+      (repo as any).getAllSettings = realGetAllSettings;
+    }
+  });
+
+  it('getSourceSettings - a stored __proto__ key does not pollute the prototype', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.setSourceSetting('source-a', '__proto__', 'pwned');
+
+    const result = await repo.getSourceSettings('source-a');
+
+    expect((({}) as any).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(result, '__proto__')?.value).toBe('pwned');
+  });
+
   it('getSettingForSources - batched multi-source hit/miss for one key', async () => {
     const backend = getBackend();
     if (!backend.available) {

--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -4,7 +4,7 @@
  * Handles all settings-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, inArray, sql } from 'drizzle-orm';
+import { eq, inArray, sql, SQL } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
@@ -173,16 +173,58 @@ export class SettingsRepository extends BaseRepository {
   }
 
   /**
-   * Get all settings for a specific source (returns bare keys without prefix)
+   * Predicate matching every row in one source's `source:{id}:` namespace.
+   *
+   * Extracted so the wildcard escaping and the dialect-dependent ESCAPE literal are
+   * stated exactly once, and so the read (getSourceSettings) and the write
+   * (deleteSourceSettings) can never disagree about what "this source's namespace" means.
+   *
+   * `_` and `%` are LIKE wildcards; source ids are UUIDs today, but escape defensively so
+   * a future non-UUID id cannot over-match a sibling namespace.
+   *
+   * The ESCAPE literal's backslash count is dialect-dependent (verified empirically against
+   * live containers in #4412 Phase 1, not by inspection): MySQL's default backslash-escape
+   * mode means a single-quoted string needs TWO literal backslash characters to represent
+   * ONE escape character, and errors ("syntax error near ''\''") on a single-backslash
+   * literal. SQLite and PostgreSQL (standard_conforming_strings, the default) treat
+   * backslash as an ordinary character in a '...' string, so ONE literal backslash there
+   * already IS the one-character escape sequence — a two-backslash literal fails there
+   * ("ESCAPE expression must be a single character").
+   */
+  private sourceNamespaceMatch(sourceId: string): SQL {
+    const { settings } = this.tables;
+    const pattern = this.sourcePrefix(sourceId).replace(/([\\%_])/g, '\\$1') + '%';
+    return this.isMySQL()
+      ? sql`${settings.key} LIKE ${pattern} ESCAPE '\\\\'`
+      : sql`${settings.key} LIKE ${pattern} ESCAPE '\\'`;
+  }
+
+  /**
+   * Get all settings for one source, keyed by BARE key (prefix stripped).
+   *
+   * One prefix-scoped query. The previous implementation called getAllSettings() and
+   * filtered in JS — O(total settings) per call, and migration 131 grew that table as
+   * (keys x sources) (#4419).
+   *
+   * Rows are written with Object.defineProperty, not `result[k] = v`: setSourceSettings'
+   * key filter (/^[A-Za-z0-9_.-]+$/) permits the literal name `__proto__`, so a stored row
+   * `source:{id}:__proto__` would otherwise reach a prototype-pollution sink on the read
+   * path. defineProperty creates an own data property and never invokes the setter.
    */
   async getSourceSettings(sourceId: string): Promise<Record<string, string>> {
+    const { settings } = this.tables;
     const prefix = this.sourcePrefix(sourceId);
-    const all = await this.getAllSettings();
+    const rows = await this.db
+      .select({ key: settings.key, value: settings.value })
+      .from(settings)
+      .where(this.sourceNamespaceMatch(sourceId));
+
     const result: Record<string, string> = {};
-    for (const [k, v] of Object.entries(all)) {
-      if (k.startsWith(prefix)) {
-        result[k.slice(prefix.length)] = v;
-      }
+    for (const row of rows as Array<{ key: string; value: string }>) {
+      if (!row.key.startsWith(prefix)) continue;
+      Object.defineProperty(result, row.key.slice(prefix.length), {
+        value: row.value, enumerable: true, writable: true, configurable: true,
+      });
     }
     return result;
   }
@@ -277,25 +319,12 @@ export class SettingsRepository extends BaseRepository {
    * match, which is the per-row round-trip pattern that made migration 030 a
    * startup hazard (#4233).
    *
-   * `_` and `%` are LIKE wildcards; source ids are UUIDs today, but escape
-   * defensively so a future non-UUID id cannot over-match a sibling namespace.
-   *
-   * The ESCAPE literal's backslash count is dialect-dependent (verified
-   * empirically, not just by inspection): MySQL's default backslash-escape
-   * mode means a single-quoted string needs TWO literal backslash characters
-   * to represent ONE escape character, and errors ("syntax error near ''\''")
-   * on a single-backslash literal. SQLite and PostgreSQL (standard_conforming_strings,
-   * the default) treat backslash as an ordinary character in a '...' string, so
-   * ONE literal backslash there already IS the one-character escape sequence —
-   * a two-backslash literal fails there ("ESCAPE expression must be a single character").
+   * The namespace match (including the dialect-dependent ESCAPE literal) lives in
+   * `sourceNamespaceMatch` so the read (getSourceSettings) and this delete can never
+   * disagree about what "this source's namespace" means.
    */
   async deleteSourceSettings(sourceId: string): Promise<void> {
-    const { settings } = this.tables;
-    const pattern = this.sourcePrefix(sourceId).replace(/([\\%_])/g, '\\$1') + '%';
-    const query = this.isMySQL()
-      ? sql`${settings.key} LIKE ${pattern} ESCAPE '\\\\'`
-      : sql`${settings.key} LIKE ${pattern} ESCAPE '\\'`;
-    await this.db.delete(settings).where(query);
+    await this.db.delete(this.tables.settings).where(this.sourceNamespaceMatch(sourceId));
   }
 
   // ─── Synchronous SQLite variants ────────────────────────────────────────

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -622,12 +622,15 @@ export const PER_SOURCE_KEYS_NOT_POSTABLE = new Set<string>([
   'lastAnnouncementTime',   // announceRoutes.ts:15,17; autoAnnounceService.ts:242,244
   'localNodeNum',           // meshtasticManager.ts:4688,4748
   // ── KNOWN ORPHAN — not legitimized by being listed here ─────────────────
-  // externalUrl is READ at securityDigestService.ts:332 and written NOWHERE in
-  // the repo. It is in this set because it is in fact absent from
+  // externalUrl is READ at securityDigestService.ts (detailsLink()) and written
+  // NOWHERE in the repo. It is in this set because it is in fact absent from
   // VALID_SETTINGS_KEYS, not because that absence is correct. Either the write
-  // path was never built or the read is dead. Tracked in §8.7; needs its own
-  // issue. Do NOT "fix" it by adding it to VALID_SETTINGS_KEYS — that creates a
-  // new user-writable setting, which is a feature, not a Phase 1 cleanup.
+  // path was never built or the read is dead. Phase 5 WP4 suppressed the dead
+  // "/security" link this produced (securityDigestService.ts) rather than wiring
+  // a writer; the product question of whether to add a writer or drop the
+  // feature is tracked in #4437. Do NOT "fix" it by adding it to
+  // VALID_SETTINGS_KEYS — that creates a new user-writable setting, which is a
+  // feature, not a cleanup.
   'externalUrl',
 ]);
 

--- a/src/server/migrations/050_promote_globals_to_default_source.pgmysql.test.ts
+++ b/src/server/migrations/050_promote_globals_to_default_source.pgmysql.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Migration 050 — PostgreSQL / MySQL behaviour (#4419 / PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC §4.7).
+ *
+ * This is migration 050's FIRST PostgreSQL or MySQL coverage of any kind, despite it
+ * shipping hand-written implementations for both backends since it was authored. Two
+ * halves, per CLAUDE.md guidance for schema/migration work:
+ *
+ *   1. Fake-client half (always runs): pins the exact dialect SQL shape (quoted
+ *      camelCase columns + `ON CONFLICT (key) DO NOTHING` on PostgreSQL, backticked
+ *      `key` + `INSERT IGNORE` on MySQL) and the frozen-list behaviour — a global row
+ *      whose key is not in `PROMOTED_SETTING_KEYS` is never promoted. Modeled on
+ *      131_seed_per_source_node_display.pgmysql.test.ts.
+ *
+ *      Deliberately NO assertions on round-trip counts. 050's PG/MySQL loops issue one
+ *      SELECT + one INSERT per key (~170 round trips) — the #4233 anti-pattern — but
+ *      fixing that is explicitly out of scope for this freeze (spec §4.4): the ledger
+ *      means this migration runs once per database, and pinning the round-trip count
+ *      here would make a future batching fix fail this suite for no behavioural reason.
+ *
+ *   2. Container half (`describe.skipIf(!postgresAvailable/!mysqlAvailable)`): runs the
+ *      real migration functions against the live test containers (localhost:5433 /
+ *      :3307) and asserts the same promote/preserve/override/idempotency/backfill
+ *      invariants as the SQLite suite. A silent skip here still reports `success: true`
+ *      at the suite level — confirm via `numPendingTests` in the JSON reporter, not
+ *      just the pass/fail summary.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import {
+  runMigration050Postgres,
+  runMigration050Mysql,
+  PROMOTED_SETTING_KEYS,
+} from './050_promote_globals_to_default_source.js';
+import { postgresAvailable, mysqlAvailable } from '../../db/repositories/test-utils.js';
+
+const { Pool: PgPool } = pg;
+
+const SAMPLE_KEY = 'autoResponderEnabled'; // present in PROMOTED_SETTING_KEYS
+const NOT_PROMOTED_KEY = 'someFutureSettingNotYetFrozen'; // deliberately NOT in the frozen list
+const DEFAULT_SOURCE = { id: 'src-old', createdAt: 1000 };
+
+// ---------------------------------------------------------------------------
+// Fake-client half
+// ---------------------------------------------------------------------------
+
+function fakePgClient(opts: { globals: Record<string, string> }) {
+  const queries: { sql: string; params?: any[] }[] = [];
+  return {
+    queries,
+    query: vi.fn(async (sql: string, params?: any[]) => {
+      queries.push({ sql, params });
+      const s = sql.trimStart();
+      if (s.startsWith("SELECT to_regclass")) {
+        return { rows: [{ reg: 'sources' }] };
+      }
+      if (s.startsWith('SELECT id FROM sources')) {
+        return { rows: [{ id: DEFAULT_SOURCE.id }] };
+      }
+      if (s.startsWith('SELECT value FROM settings')) {
+        const key = params?.[0];
+        const value = key !== undefined ? opts.globals[key] : undefined;
+        return value === undefined ? { rows: [], rowCount: 0 } : { rows: [{ value }], rowCount: 1 };
+      }
+      if (s.startsWith('INSERT INTO settings')) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (s.startsWith('UPDATE auto_traceroute_nodes') || s.startsWith('UPDATE auto_time_sync_nodes')) {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [], rowCount: 0 };
+    }),
+  };
+}
+
+function fakeMysqlPool(opts: { globals: Record<string, string> }) {
+  const queries: { sql: string; params?: any[] }[] = [];
+  const conn = {
+    query: vi.fn(async (sql: string, params?: any[]) => {
+      queries.push({ sql, params });
+      const s = sql.trimStart();
+      if (s.includes('information_schema.tables')) {
+        return [[{ c: 1 }]];
+      }
+      if (s.startsWith('SELECT id FROM sources')) {
+        return [[{ id: DEFAULT_SOURCE.id }]];
+      }
+      if (s.startsWith('SELECT value FROM settings')) {
+        const key = params?.[0];
+        const value = key !== undefined ? opts.globals[key] : undefined;
+        return [value === undefined ? [] : [{ value }]];
+      }
+      if (s.startsWith('INSERT IGNORE INTO settings')) {
+        return [{ affectedRows: 1 }];
+      }
+      if (s.startsWith('UPDATE auto_traceroute_nodes') || s.startsWith('UPDATE auto_time_sync_nodes')) {
+        return [{ affectedRows: 0 }];
+      }
+      return [{}];
+    }),
+    beginTransaction: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+    release: vi.fn(),
+  };
+  return { queries, conn, getConnection: async () => conn };
+}
+
+const isInsert = (q: { sql: string }) => q.sql.trimStart().startsWith('INSERT');
+const insertedKeyFrom = (params: any[] | undefined) => {
+  const prefixedKey = params?.[0] as string | undefined;
+  return prefixedKey?.replace(/^source:[^:]+:/, '');
+};
+
+describe('migration 050 — PostgreSQL (fake client)', () => {
+  it('promotes a global row for a key in PROMOTED_SETTING_KEYS into source:{default}:{key}', async () => {
+    const client = fakePgClient({ globals: { [SAMPLE_KEY]: 'true' } });
+    await runMigration050Postgres(client as any);
+
+    const inserts = client.queries.filter(isInsert);
+    const match = inserts.find((ins) => insertedKeyFrom(ins.params) === SAMPLE_KEY);
+    expect(match).toBeDefined();
+    expect(match!.params?.[0]).toBe(`source:${DEFAULT_SOURCE.id}:${SAMPLE_KEY}`);
+    expect(match!.params?.[1]).toBe('true');
+  });
+
+  it('quotes camelCase timestamp columns and uses ON CONFLICT (key) DO NOTHING', async () => {
+    const client = fakePgClient({ globals: { [SAMPLE_KEY]: 'true' } });
+    await runMigration050Postgres(client as any);
+
+    const inserts = client.queries.filter(isInsert);
+    expect(inserts.length).toBeGreaterThan(0);
+    for (const ins of inserts) {
+      expect(ins.sql).toContain('"createdAt"');
+      expect(ins.sql).toContain('"updatedAt"');
+      expect(ins.sql).toContain('ON CONFLICT (key) DO NOTHING');
+    }
+  });
+
+  it('never promotes a global row whose key is not in PROMOTED_SETTING_KEYS (the freeze)', async () => {
+    expect(PROMOTED_SETTING_KEYS).not.toContain(NOT_PROMOTED_KEY);
+    const client = fakePgClient({ globals: { [SAMPLE_KEY]: 'true', [NOT_PROMOTED_KEY]: 'sneaky' } });
+    await runMigration050Postgres(client as any);
+
+    const inserts = client.queries.filter(isInsert);
+    expect(inserts.some((ins) => insertedKeyFrom(ins.params) === NOT_PROMOTED_KEY)).toBe(false);
+    // Sanity: the loop never even queries a key outside the frozen list.
+    expect(client.queries.some((q) => q.sql.startsWith('SELECT value FROM settings') && q.params?.[0] === NOT_PROMOTED_KEY)).toBe(false);
+  });
+
+  it('when sources table is missing, logs and returns without throwing', async () => {
+    const client = {
+      queries: [] as any[],
+      query: vi.fn(async (sql: string) => {
+        if (sql.trimStart().startsWith('SELECT to_regclass')) {
+          return { rows: [{ reg: null }] };
+        }
+        throw new Error('relation "sources" does not exist');
+      }),
+    };
+    await expect(runMigration050Postgres(client as any)).resolves.toBeUndefined();
+  });
+});
+
+describe('migration 050 — MySQL (fake pool)', () => {
+  it('promotes a global row for a key in PROMOTED_SETTING_KEYS into source:{default}:{key}', async () => {
+    const pool = fakeMysqlPool({ globals: { [SAMPLE_KEY]: 'true' } });
+    await runMigration050Mysql(pool as any);
+
+    const inserts = pool.queries.filter(isInsert);
+    const match = inserts.find((ins) => insertedKeyFrom(ins.params) === SAMPLE_KEY);
+    expect(match).toBeDefined();
+    expect(match!.params?.[0]).toBe(`source:${DEFAULT_SOURCE.id}:${SAMPLE_KEY}`);
+    expect(match!.params?.[1]).toBe('true');
+    expect(pool.conn.commit).toHaveBeenCalled();
+  });
+
+  it('backticks `key` and uses INSERT IGNORE', async () => {
+    const pool = fakeMysqlPool({ globals: { [SAMPLE_KEY]: 'true' } });
+    await runMigration050Mysql(pool as any);
+
+    const inserts = pool.queries.filter(isInsert);
+    expect(inserts.length).toBeGreaterThan(0);
+    for (const ins of inserts) {
+      expect(ins.sql).toContain('`key`');
+      expect(ins.sql).toContain('INSERT IGNORE');
+    }
+  });
+
+  it('never promotes a global row whose key is not in PROMOTED_SETTING_KEYS (the freeze)', async () => {
+    expect(PROMOTED_SETTING_KEYS).not.toContain(NOT_PROMOTED_KEY);
+    const pool = fakeMysqlPool({ globals: { [SAMPLE_KEY]: 'true', [NOT_PROMOTED_KEY]: 'sneaky' } });
+    await runMigration050Mysql(pool as any);
+
+    const inserts = pool.queries.filter(isInsert);
+    expect(inserts.some((ins) => insertedKeyFrom(ins.params) === NOT_PROMOTED_KEY)).toBe(false);
+    expect(pool.queries.some((q) => q.sql.startsWith('SELECT value FROM settings') && q.params?.[0] === NOT_PROMOTED_KEY)).toBe(false);
+  });
+
+  it('when sources table is missing, logs and returns without throwing', async () => {
+    const conn = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes('information_schema.tables')) {
+          return [[{ c: 0 }]];
+        }
+        throw new Error("Table 'meshmonitor.sources' doesn't exist");
+      }),
+      beginTransaction: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      rollback: vi.fn(async () => {}),
+      release: vi.fn(),
+    };
+    const pool = { getConnection: async () => conn };
+    await expect(runMigration050Mysql(pool as any)).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Container half — real PostgreSQL / MySQL test containers.
+// ---------------------------------------------------------------------------
+
+const PG_CREATE = `
+  DROP TABLE IF EXISTS auto_traceroute_nodes CASCADE;
+  DROP TABLE IF EXISTS auto_time_sync_nodes CASCADE;
+  DROP TABLE IF EXISTS settings CASCADE;
+  DROP TABLE IF EXISTS sources CASCADE;
+  CREATE TABLE sources (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    config TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" BIGINT NOT NULL,
+    "updatedAt" BIGINT NOT NULL,
+    "createdBy" INTEGER
+  );
+  CREATE TABLE settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    "createdAt" BIGINT NOT NULL,
+    "updatedAt" BIGINT NOT NULL
+  );
+  CREATE TABLE auto_traceroute_nodes (
+    id SERIAL PRIMARY KEY,
+    "nodeNum" BIGINT NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    "createdAt" BIGINT NOT NULL,
+    "sourceId" TEXT
+  );
+  CREATE TABLE auto_time_sync_nodes (
+    id SERIAL PRIMARY KEY,
+    "nodeNum" BIGINT NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    "createdAt" BIGINT NOT NULL,
+    "sourceId" TEXT
+  );
+`;
+
+const MYSQL_CREATE = `
+  DROP TABLE IF EXISTS auto_traceroute_nodes;
+  DROP TABLE IF EXISTS auto_time_sync_nodes;
+  DROP TABLE IF EXISTS settings;
+  DROP TABLE IF EXISTS sources;
+  CREATE TABLE sources (
+    id VARCHAR(64) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    config TEXT NOT NULL,
+    enabled TINYINT NOT NULL DEFAULT 1,
+    createdAt BIGINT NOT NULL,
+    updatedAt BIGINT NOT NULL,
+    createdBy INT
+  );
+  CREATE TABLE settings (
+    \`key\` VARCHAR(255) PRIMARY KEY,
+    value TEXT NOT NULL,
+    createdAt BIGINT NOT NULL,
+    updatedAt BIGINT NOT NULL
+  );
+  CREATE TABLE auto_traceroute_nodes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nodeNum BIGINT NOT NULL,
+    enabled TINYINT DEFAULT 1,
+    createdAt BIGINT NOT NULL,
+    sourceId VARCHAR(64)
+  );
+  CREATE TABLE auto_time_sync_nodes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nodeNum BIGINT NOT NULL,
+    enabled TINYINT DEFAULT 1,
+    createdAt BIGINT NOT NULL,
+    sourceId VARCHAR(64)
+  );
+`;
+
+describe.skipIf(!postgresAvailable)('migration 050 — PostgreSQL (container)', () => {
+  let pool: InstanceType<typeof PgPool>;
+
+  beforeAll(async () => {
+    pool = new PgPool({
+      host: 'localhost',
+      port: 5433,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+    });
+    await pool.query(PG_CREATE);
+  });
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  it('promotes globals, preserves the source, does not clobber overrides, backfills orphans, and is idempotent', async () => {
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO sources (id, name, type, config, enabled, "createdAt", "updatedAt")
+       VALUES ('src-old', 'Old', 'meshtastic_tcp', '{}', true, $1, $1),
+              ('src-new', 'New', 'meshtastic_tcp', '{}', true, $2, $2)`,
+      [now, now + 1000],
+    );
+    await pool.query(
+      `INSERT INTO settings (key, value, "createdAt", "updatedAt") VALUES
+        ('autoResponderEnabled', 'true', $1, $1),
+        ('source:src-old:tracerouteIntervalMinutes', 'override-value', $1, $1),
+        ('tracerouteIntervalMinutes', 'global-value', $1, $1)`,
+      [now],
+    );
+    await pool.query(
+      `INSERT INTO auto_traceroute_nodes ("nodeNum", "createdAt", "sourceId") VALUES ($1, $2, NULL)`,
+      [0xdeadbeef, now],
+    );
+    await pool.query(
+      `INSERT INTO auto_time_sync_nodes ("nodeNum", "createdAt", "sourceId") VALUES ($1, $2, NULL)`,
+      [0xcafebabe, now],
+    );
+
+    const client1 = await pool.connect();
+    try {
+      await runMigration050Postgres(client1);
+    } finally {
+      client1.release();
+    }
+
+    const { rows } = await pool.query(`SELECT key, value FROM settings WHERE key LIKE 'source:%'`);
+    const settings = Object.fromEntries(rows.map((r: any) => [r.key, r.value]));
+
+    // The oldest source (src-old, earlier createdAt) is the default and receives the promotion.
+    expect(settings['source:src-old:autoResponderEnabled']).toBe('true');
+    // The newer source must NOT inherit.
+    expect(settings['source:src-new:autoResponderEnabled']).toBeUndefined();
+    // Existing per-source override is untouched.
+    expect(settings['source:src-old:tracerouteIntervalMinutes']).toBe('override-value');
+
+    // Original global row is preserved (non-destructive).
+    const { rows: globalRow } = await pool.query(`SELECT value FROM settings WHERE key = 'autoResponderEnabled'`);
+    expect(globalRow[0].value).toBe('true');
+
+    // Backfills.
+    const { rows: trRows } = await pool.query(`SELECT "sourceId" FROM auto_traceroute_nodes`);
+    expect(trRows[0].sourceId).toBe('src-old');
+    const { rows: tsRows } = await pool.query(`SELECT "sourceId" FROM auto_time_sync_nodes`);
+    expect(tsRows[0].sourceId).toBe('src-old');
+
+    const { rows: countBefore } = await pool.query(`SELECT COUNT(*)::int AS c FROM settings`);
+
+    // Idempotency: run again.
+    const client2 = await pool.connect();
+    try {
+      await runMigration050Postgres(client2);
+    } finally {
+      client2.release();
+    }
+
+    const { rows: countAfter } = await pool.query(`SELECT COUNT(*)::int AS c FROM settings`);
+    expect(countAfter[0].c).toBe(countBefore[0].c);
+
+    const { rows: overrideAfter } = await pool.query(
+      `SELECT value FROM settings WHERE key = 'source:src-old:tracerouteIntervalMinutes'`,
+    );
+    expect(overrideAfter[0].value).toBe('override-value');
+  });
+});
+
+describe.skipIf(!mysqlAvailable)('migration 050 — MySQL (container)', () => {
+  let pool: mysql.Pool;
+
+  beforeAll(async () => {
+    pool = mysql.createPool({
+      host: 'localhost',
+      port: 3307,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+      connectionLimit: 5,
+    });
+    // MySQL2's pool.query doesn't run multi-statement by default; execute
+    // the DDL statements individually.
+    for (const stmt of MYSQL_CREATE.split(';').map((s) => s.trim()).filter(Boolean)) {
+      await pool.query(stmt);
+    }
+  });
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  it('promotes globals, preserves the source, does not clobber overrides, backfills orphans, and is idempotent', async () => {
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+       VALUES ('src-old', 'Old', 'meshtastic_tcp', '{}', 1, ?, ?),
+              ('src-new', 'New', 'meshtastic_tcp', '{}', 1, ?, ?)`,
+      [now, now, now + 1000, now + 1000],
+    );
+    await pool.query(
+      'INSERT INTO settings (`key`, value, createdAt, updatedAt) VALUES (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?)',
+      [
+        'autoResponderEnabled', 'true', now, now,
+        'source:src-old:tracerouteIntervalMinutes', 'override-value', now, now,
+        'tracerouteIntervalMinutes', 'global-value', now, now,
+      ],
+    );
+    await pool.query(
+      `INSERT INTO auto_traceroute_nodes (nodeNum, createdAt, sourceId) VALUES (?, ?, NULL)`,
+      [0xdeadbeef, now],
+    );
+    await pool.query(
+      `INSERT INTO auto_time_sync_nodes (nodeNum, createdAt, sourceId) VALUES (?, ?, NULL)`,
+      [0xcafebabe, now],
+    );
+
+    await runMigration050Mysql(pool);
+
+    const [rows] = await pool.query(`SELECT \`key\`, value FROM settings WHERE \`key\` LIKE 'source:%'`);
+    const settings: Record<string, string> = {};
+    for (const row of rows as any[]) settings[row.key] = row.value;
+
+    expect(settings['source:src-old:autoResponderEnabled']).toBe('true');
+    expect(settings['source:src-new:autoResponderEnabled']).toBeUndefined();
+    expect(settings['source:src-old:tracerouteIntervalMinutes']).toBe('override-value');
+
+    const [globalRow] = await pool.query(`SELECT value FROM settings WHERE \`key\` = 'autoResponderEnabled'`);
+    expect((globalRow as any[])[0].value).toBe('true');
+
+    const [trRows] = await pool.query(`SELECT sourceId FROM auto_traceroute_nodes`);
+    expect((trRows as any[])[0].sourceId).toBe('src-old');
+    const [tsRows] = await pool.query(`SELECT sourceId FROM auto_time_sync_nodes`);
+    expect((tsRows as any[])[0].sourceId).toBe('src-old');
+
+    const [countBeforeRows] = await pool.query(`SELECT COUNT(*) AS c FROM settings`);
+    const countBefore = (countBeforeRows as any[])[0].c;
+
+    await runMigration050Mysql(pool);
+
+    const [countAfterRows] = await pool.query(`SELECT COUNT(*) AS c FROM settings`);
+    const countAfter = (countAfterRows as any[])[0].c;
+    expect(countAfter).toBe(countBefore);
+
+    const [overrideAfter] = await pool.query(
+      "SELECT value FROM settings WHERE `key` = 'source:src-old:tracerouteIntervalMinutes'",
+    );
+    expect((overrideAfter as any[])[0].value).toBe('override-value');
+  });
+});

--- a/src/server/migrations/050_promote_globals_to_default_source.test.ts
+++ b/src/server/migrations/050_promote_globals_to_default_source.test.ts
@@ -6,8 +6,9 @@
  * `getSettingForSource` is removed.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
 import Database from 'better-sqlite3';
-import { migration } from './050_promote_globals_to_default_source.js';
+import { migration, PROMOTED_SETTING_KEYS } from './050_promote_globals_to_default_source.js';
 
 function createSchema(db: Database.Database) {
   db.exec(`
@@ -172,5 +173,29 @@ describe('Migration 050 — promote globals to default source', () => {
     expect(sources).toHaveLength(1);
     const id = sources[0].id;
     expect(getSetting(db, `source:${id}:autoResponderEnabled`)).toBe('true');
+  });
+
+  it('the promoted key list is frozen — 050 does not import the live constants array (#4419)', () => {
+    // This is the ONLY test that can catch the drift bug: every other test in this
+    // file uses keys present in both the 87-key (authoring-time) and 170-key
+    // (current) PER_SOURCE_SETTINGS_KEYS lists, so the suite is structurally blind
+    // to whether 050 iterates a live import or a frozen snapshot. See
+    // PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md §4.6.
+    const src = readFileSync(new URL('./050_promote_globals_to_default_source.ts', import.meta.url), 'utf8');
+    expect(src).not.toMatch(/PER_SOURCE_SETTINGS_KEYS/);
+    expect(src).not.toMatch(/from ['"]\.\.\/constants\/settings\.js['"]/);
+  });
+
+  it('PROMOTED_SETTING_KEYS is the 170-key 4.13.3 snapshot', () => {
+    // Deliberately NOT asserted against PER_SOURCE_SETTINGS_KEYS — that would
+    // re-couple the two and defeat the entire fix. The magic number 170 is the
+    // point: it must never move as the live array grows.
+    expect(PROMOTED_SETTING_KEYS).toHaveLength(170);
+    expect(new Set(PROMOTED_SETTING_KEYS).size).toBe(170);
+
+    // Era sentinels: one from each generation of the live array.
+    expect(PROMOTED_SETTING_KEYS).toContain('autoResponderEnabled'); // original 050 list
+    expect(PROMOTED_SETTING_KEYS).toContain('meshcoreAutoAckEnabled'); // 4.9-era addition
+    expect(PROMOTED_SETTING_KEYS).toContain('maxNodeAgeHours'); // this epic's Phase 1 addition
   });
 });

--- a/src/server/migrations/050_promote_globals_to_default_source.ts
+++ b/src/server/migrations/050_promote_globals_to_default_source.ts
@@ -31,7 +31,6 @@
  */
 import type { Database } from 'better-sqlite3';
 import { logger } from '../../utils/logger.js';
-import { PER_SOURCE_SETTINGS_KEYS } from '../constants/settings.js';
 import {
   ensureDefaultSourceIdSqlite,
   ensureDefaultSourceIdPostgres,
@@ -39,6 +38,200 @@ import {
 } from './_legacyDefaultSource.js';
 
 const LABEL = 'Migration 050';
+
+/**
+ * The per-source settings keys this migration promotes, FROZEN as of 4.13.3.
+ *
+ * Deliberately NOT sourced from the live per-source-settings constants array in
+ * `constants/settings.ts` (contrast the original 050, and compare migration 131's
+ * NODE_DISPLAY_SEED): a migration is a statement about a point in
+ * time, and fresh installs replay every migration (#3962 deleted createTables), so an
+ * imported array runs against whatever it contains *today*, not what it contained when
+ * this migration shipped. That drift was live — the array grew 87 -> 170 keys between 050
+ * shipping and this freeze (#4419).
+ *
+ * This snapshot is the 170-key list as of the freeze, NOT the 87-key list 050 originally
+ * ran with. That choice is deliberate: a snapshot of today changes nothing for anyone at
+ * freeze time, whereas reverting to the 87-key list would stop promoting nine long-standing
+ * globals (maxNodeAgeHours and the node-dimming / inactive-node group) for every future
+ * v3.x upgrader. See PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md §4.2 for the full analysis.
+ *
+ * DO NOT append to this list when a new setting becomes per-source. This list is history.
+ * A key that becomes per-source AFTER this freeze needs its own seed/promote migration —
+ * that is what migration 131 is, and it is the pattern to copy.
+ */
+export const PROMOTED_SETTING_KEYS: readonly string[] = [
+  'autoAckChannels',
+  'autoAckCooldownSeconds',
+  'autoAckPreSendDelaySeconds',
+  'autoAckMaxAttempts',
+  'autoAckDirectEnabled',
+  'autoAckDirectMessages',
+  'autoAckDirectReplyEnabled',
+  'autoAckDirectTapbackEnabled',
+  'autoAckEnabled',
+  'autoAckIgnoredNodes',
+  'autoAckMessage',
+  'autoAckMessageDirect',
+  'autoAckMultihopEnabled',
+  'autoAckMultihopReplyEnabled',
+  'autoAckMultihopTapbackEnabled',
+  'autoAckRegex',
+  'autoAckSkipIncompleteNodes',
+  'autoAckUseDM',
+  'autoAckChannelZeroHopReplyEnabled',
+  'autoAckChannelZeroHopTapbackEnabled',
+  'autoAckChannelZeroHopReplyDmEnabled',
+  'autoAckChannelMultiHopReplyEnabled',
+  'autoAckChannelMultiHopTapbackEnabled',
+  'autoAckChannelMultiHopReplyDmEnabled',
+  'autoAckDirectZeroHopReplyEnabled',
+  'autoAckDirectZeroHopTapbackEnabled',
+  'autoAckDirectZeroHopReplyDmEnabled',
+  'autoAckDirectMultiHopReplyEnabled',
+  'autoAckDirectMultiHopTapbackEnabled',
+  'autoAckDirectMultiHopReplyDmEnabled',
+  'automationAirtimeCutoffThreshold',
+  'automationAirtimeCutoffSource',
+  'autoAnnounceChannelIndexes',
+  'autoAnnounceEnabled',
+  'autoAnnounceIntervalHours',
+  'autoAnnounceMessage',
+  'autoAnnounceNodeInfoChannels',
+  'autoAnnounceNodeInfoDelaySeconds',
+  'autoAnnounceNodeInfoEnabled',
+  'autoAnnounceOnStart',
+  'autoAnnounceSchedule',
+  'autoAnnounceUseSchedule',
+  'autoDeleteByDistanceAction',
+  'autoDeleteByDistanceEnabled',
+  'autoDeleteByDistanceIntervalHours',
+  'autoDeleteByDistanceLat',
+  'autoDeleteByDistanceLon',
+  'autoDeleteByDistanceThresholdKm',
+  'autoFavoriteEnabled',
+  'autoFavoriteNodes',
+  'autoFavoriteStaleHours',
+  'autoHeapManagementEnabled',
+  'autoHeapManagementThresholdBytes',
+  'autoKeyManagementEnabled',
+  'autoPingEnabled',
+  'autoPingIntervalSeconds',
+  'autoPingMaxPings',
+  'autoPingTimeoutSeconds',
+  'autoResponderEnabled',
+  'autoResponderSkipIncompleteNodes',
+  'autoResponderTriggers',
+  'autoTimeSyncEnabled',
+  'autoTimeSyncIntervalMinutes',
+  'autoWelcomeEnabled',
+  'autoWelcomeMaxHops',
+  'autoWelcomeMessage',
+  'autoWelcomeTarget',
+  'autoWelcomeWaitForName',
+  'autoWelcomeDelay',
+  'pkiDmDecryptionEnabled',
+  'meshcoreAutoPathfindingEnabled',
+  'meshcoreAutoPathfindingPathDiscoveryEnabled',
+  'meshcoreAutoPathfindingNeighborsEnabled',
+  'meshcoreAutoPathfindingIntervalMinutes',
+  'meshcoreAutoPathfindingRepeatHours',
+  'meshcorePathfindingFilterEnabled',
+  'meshcorePathfindingFilterContactsEnabled',
+  'meshcorePathfindingFilterRegexEnabled',
+  'meshcorePathfindingFilterNameRegex',
+  'meshcorePathfindingFilterLastHeardEnabled',
+  'meshcorePathfindingFilterLastHeardHours',
+  'meshcorePathfindingFilterHopsEnabled',
+  'meshcorePathfindingFilterHopsMin',
+  'meshcorePathfindingFilterHopsMax',
+  'meshcorePathfindingFilterSignalEnabled',
+  'meshcorePathfindingFilterRssiMin',
+  'meshcorePathfindingFilterSnrMin',
+  'meshcoreRespondToDiscovery',
+  'meshcoreAutoAckEnabled',
+  'meshcoreAutoAckRegex',
+  'meshcoreAutoAckMessage',
+  'meshcoreAutoAckChannels',
+  'meshcoreAutoAckDirectMessages',
+  'meshcoreAutoAckUseDM',
+  'meshcoreAutoAckCooldownSeconds',
+  'meshcoreAutoAckPreSendDelaySeconds',
+  'meshcoreAutoAckTestMessages',
+  'meshcoreAutoAckIgnoredNodes',
+  'meshcoreAutoAnnounceEnabled',
+  'meshcoreAutoAnnounceIntervalHours',
+  'meshcoreAutoAnnounceMessage',
+  'meshcoreAutoAnnounceChannelIndexes',
+  'meshcoreAutoAnnounceOnStart',
+  'meshcoreAutoAnnounceUseSchedule',
+  'meshcoreAutoAnnounceSchedule',
+  'meshcoreAutoAnnounceAdvertEnabled',
+  'meshcoreAutoAnnounceAdvertDelaySeconds',
+  'meshcoreAutoAnnounceLastRunAt',
+  'meshcoreAutoResponderEnabled',
+  'meshcoreAutoResponderTriggers',
+  'meshcoreTimerTriggers',
+  'meshcoreDefaultScope',
+  'maxNodeAgeHours',
+  'inactiveNodeThresholdHours',
+  'inactiveNodeCheckIntervalMinutes',
+  'inactiveNodeCooldownHours',
+  'nodeHopsCalculation',
+  'hideIncompleteNodes',
+  'nodeDimmingEnabled',
+  'nodeDimmingStartHours',
+  'nodeDimmingMinOpacity',
+  'externalUrl',
+  'geofenceTriggers',
+  'lastAnnouncementTime',
+  'localNodeNum',
+  'localStatsIntervalMinutes',
+  'timerTriggers',
+  'remoteAdminScannerIntervalMinutes',
+  'remoteAdminScheduleEnabled',
+  'remoteAdminScheduleEnd',
+  'remoteAdminScheduleStart',
+  'securityDigestAppriseUrl',
+  'securityDigestFormat',
+  'securityDigestReportType',
+  'securityDigestSuppressEmpty',
+  'tracerouteIntervalMinutes',
+  'tracerouteScheduleEnabled',
+  'tracerouteScheduleEnd',
+  'tracerouteScheduleStart',
+  'tracerouteNodeFilterEnabled',
+  'tracerouteFilterChannels',
+  'tracerouteFilterRoles',
+  'tracerouteFilterHwModels',
+  'tracerouteFilterNameRegex',
+  'tracerouteFilterNodesEnabled',
+  'tracerouteFilterChannelsEnabled',
+  'tracerouteFilterRolesEnabled',
+  'tracerouteFilterHwModelsEnabled',
+  'tracerouteFilterRegexEnabled',
+  'tracerouteExpirationHours',
+  'tracerouteSortByHops',
+  'tracerouteFilterLastHeardEnabled',
+  'tracerouteFilterLastHeardHours',
+  'tracerouteFilterHopsEnabled',
+  'tracerouteFilterHopsMin',
+  'tracerouteFilterHopsMax',
+  'remoteLocalStatsIntervalMinutes',
+  'remoteLocalStatsScheduleEnabled',
+  'remoteLocalStatsScheduleStart',
+  'remoteLocalStatsScheduleEnd',
+  'remoteLocalStatsFilterEnabled',
+  'remoteLocalStatsFilterNodes',
+  'remoteLocalStatsFilterNodesEnabled',
+  'remoteLocalStatsFilterRoles',
+  'remoteLocalStatsFilterRolesEnabled',
+  'remoteLocalStatsFilterFavoriteEnabled',
+  'remoteLocalStatsFilterNameRegex',
+  'remoteLocalStatsFilterRegexEnabled',
+  'remoteLocalStatsFilterLastHeardEnabled',
+  'remoteLocalStatsFilterLastHeardHours',
+];
 
 function now(): number {
   return Date.now();
@@ -65,7 +258,7 @@ export const migration = {
       );
       const readGlobal = db.prepare(`SELECT value FROM settings WHERE key = ?`);
 
-      for (const key of PER_SOURCE_SETTINGS_KEYS) {
+      for (const key of PROMOTED_SETTING_KEYS) {
         const globalRow = readGlobal.get(key) as { value: string } | undefined;
         if (!globalRow) continue;
 
@@ -126,7 +319,7 @@ export async function runMigration050Postgres(client: any): Promise<void> {
     let promoted = 0;
     const ts = now();
 
-    for (const key of PER_SOURCE_SETTINGS_KEYS) {
+    for (const key of PROMOTED_SETTING_KEYS) {
       const globalRes = await client.query(
         `SELECT value FROM settings WHERE key = $1`,
         [key],
@@ -199,7 +392,7 @@ export async function runMigration050Mysql(pool: any): Promise<void> {
     let promoted = 0;
     const ts = now();
 
-    for (const key of PER_SOURCE_SETTINGS_KEYS) {
+    for (const key of PROMOTED_SETTING_KEYS) {
       const [globalRows] = await conn.query(
         `SELECT value FROM settings WHERE \`key\` = ?`,
         [key],

--- a/src/server/routes/settingsRoutes.perSource.test.ts
+++ b/src/server/routes/settingsRoutes.perSource.test.ts
@@ -91,6 +91,13 @@ describe('POST /api/settings — per-source permission scoping (#4412 WP2 §6.3)
 
     // Intended (epic) behavior would be 403 here. Actual current behavior is
     // 200 — see the root-cause comment above the test.
+    //
+    // TODO(#4416): when the two SOURCEY_RESOURCES lists are reconciled, BOTH
+    // assertions below flip to 403 and this test should be renamed off
+    // "KNOWN GAP". Do NOT make them pass by weakening the grant setup — a 403
+    // here is the entire point of that fix. #4416 also carries the migration
+    // that re-grants existing sourceId=NULL rows; without it every non-admin
+    // user loses settings access the moment the classification flips.
     const resB = await agent
       .post(`/api/settings?sourceId=${harness.sourceB}`)
       .send({ maxNodeAgeHours: '48' });

--- a/src/server/routes/settingsRoutes.perSource.test.ts
+++ b/src/server/routes/settingsRoutes.perSource.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import settingsRoutes, { setSettingsCallbacks } from './settingsRoutes.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import databaseService from '../../services/database.js';
 
 describe('POST /api/settings — per-source permission scoping (#4412 WP2 §6.3)', () => {
   let harness: RouteTestHarness;
@@ -234,5 +235,155 @@ describe('POST /api/settings — per-source permission scoping (#4412 WP2 §6.3)
       expect(res.status).toBe(200);
       expect(res.body.maxNodeAgeHours).toBe('99');
     });
+  });
+});
+
+// #4419(a): POST /api/settings compared the auto-ack change-detection guard against
+// `currentSettings.<bareKey>` (the GLOBAL row) even on a scoped (?sourceId=) write.
+// getAllSettings() returns both namespaces in one snapshot, so the correct comparison
+// costs no extra query — it just has to read `source:{id}:<key>` instead of `<key>`.
+// See src/server/routes/settingsRoutes.ts's `scopedSettingKey()` helper and
+// PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md §2.
+describe('POST /api/settings — autoAck change-detection is scope-correct (#4419a)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/api/settings', settingsRoutes),
+    });
+  });
+
+  afterEach(async () => {
+    await harness.db.settings.deleteSourceSettings(harness.sourceA).catch(() => {});
+    await harness.db.settings.deleteSourceSettings(harness.sourceB).catch(() => {});
+    await harness.db.settings.deleteSetting('autoAckRegex').catch(() => {});
+    await harness.db.settings.deleteSetting('autoAckEnabled').catch(() => {});
+    await harness.db.settings.deleteSetting('autoAckMessage').catch(() => {});
+    await harness.cleanup();
+  });
+
+  it('a scoped re-save of the source\'s own bad regex is allowed while auto-ack is off (the #3806 unstick, per source)', async () => {
+    // Source A already has a lookaround pattern on file (persisted before RE2
+    // validation existed) and auto-ack disabled. The GLOBAL row holds a
+    // DIFFERENT pattern — this is the case the defect gets wrong: reading the
+    // global row makes an unchanged per-source save look changed.
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckRegex', 'foo(?=bar)');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckEnabled', 'false');
+    await harness.db.settings.setSetting('autoAckRegex', 'plain');
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ autoAckRegex: 'foo(?=bar)', autoAckEnabled: 'false' });
+
+    // Fails with the defect present: currentSettings.autoAckRegex resolves to the
+    // global 'plain', which differs from the posted pattern, so regexChanged is
+    // (wrongly) true and RE2 rejects the lookaround pattern with a 400 — the
+    // exact #3806 failure the guard exists to prevent, reintroduced per-source.
+    expect(res.status).toBe(200);
+  });
+
+  it('a scoped change to a NEW bad regex is rejected even when it equals the global row', async () => {
+    // Global row already holds the lookaround pattern; source A's own stored
+    // pattern is different ('plain'). The defect compares against the GLOBAL
+    // row, sees no change, and skips validation — saving a new bad pattern
+    // unvalidated.
+    await harness.db.settings.setSetting('autoAckRegex', 'foo(?=bar)');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckRegex', 'plain');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckEnabled', 'false');
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ autoAckRegex: 'foo(?=bar)', autoAckEnabled: 'false' });
+
+    // Fails with the defect present: currentSettings.autoAckRegex (global) already
+    // equals the posted pattern, so regexChanged is (wrongly) false and the new
+    // bad pattern is saved unvalidated (200) instead of rejected (400).
+    expect(res.status).toBe(400);
+  });
+
+  it('willBeEnabled reads this source\'s own flag, not the global one', async () => {
+    // Both the global row and source A's row already hold the SAME (invalid)
+    // pattern as the one being posted, so regexChanged is false either way —
+    // this isolates the test to the willBeEnabled half of the guard. Auto-ack
+    // is globally enabled but OFF for source A; only the per-source flag
+    // should be consulted, since the posted body doesn't include
+    // autoAckEnabled at all.
+    await harness.db.settings.setSetting('autoAckEnabled', 'true');
+    await harness.db.settings.setSetting('autoAckRegex', 'foo(?=bar)');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckEnabled', 'false');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckRegex', 'foo(?=bar)');
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ autoAckRegex: 'foo(?=bar)' });
+
+    // Fails with the defect present: currentSettings.autoAckEnabled (global) is
+    // 'true', so willBeEnabled is (wrongly) true, forcing validation of the
+    // (unchanged, but invalid) pattern -> 400.
+    expect(res.status).toBe(200);
+  });
+
+  it("sourceA's regex state does not affect a sourceB save", async () => {
+    // Seed a bad pattern on source A only. Posting the SAME pattern to source B
+    // (which has no stored override at all) must still be rejected — B has no
+    // prior value to "unstick" against, so this pins that the new per-source
+    // lookup does not leak A's state into B's comparison.
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckRegex', 'foo(?=bar)');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckEnabled', 'false');
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceB}`)
+      .send({ autoAckRegex: 'foo(?=bar)', autoAckEnabled: 'false' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('the unscoped POST still compares against the global row (no regression)', async () => {
+    // Pins the identity-function property of scopedSettingKey: with sourceId
+    // null it must behave exactly as before. A DIFFERENT per-source override on
+    // source A must have zero influence on the global comparison.
+    await harness.db.settings.setSetting('autoAckRegex', 'foo(?=bar)');
+    await harness.db.settings.setSetting('autoAckEnabled', 'false');
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckRegex', 'a-totally-different-pattern');
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent
+      .post('/api/settings')
+      .send({ autoAckRegex: 'foo(?=bar)', autoAckEnabled: 'false' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('the audit row records the per-source before-value', async () => {
+    // Guards the auditSettingsWrite refactor (prefix -> scopedSettingKey): the
+    // emitted audit event must still carry the SOURCE's prior value as
+    // `before`, not the global row's. auditLogAsync currently discards
+    // valueBefore/valueAfter before they reach the DB (see the "Note" in
+    // DatabaseService.auditLogAsync), so this asserts on the call arguments
+    // via a spy rather than reading a persisted row back.
+    await harness.db.settings.setSourceSetting(harness.sourceA, 'autoAckMessage', 'old source message');
+    await harness.db.settings.setSetting('autoAckMessage', 'old global message');
+
+    const spy = vi.spyOn(databaseService, 'auditLogAsync');
+    try {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(`/api/settings?sourceId=${harness.sourceA}`)
+        .send({ autoAckMessage: 'new source message' });
+      expect(res.status).toBe(200);
+
+      const call = spy.mock.calls.find((args) => args[2] === 'settings');
+      expect(call).toBeDefined();
+      const [, , , details, , valueBefore, valueAfter] = call!;
+      expect(JSON.parse(details as string).sourceId).toBe(harness.sourceA);
+      expect(JSON.parse(valueBefore as string).autoAckMessage).toBe('old source message');
+      expect(JSON.parse(valueAfter as string).autoAckMessage).toBe('new source message');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -174,6 +174,20 @@ const INACTIVE_NODE_KEYS = [
 ] as const;
 
 /**
+ * The `settings` row key that holds the current value of `key` for this write's scope:
+ * `source:{id}:{key}` for a scoped POST, the bare key for a global one.
+ *
+ * `currentSettings` is one `getAllSettings()` snapshot containing BOTH namespaces, so
+ * scoped change-detection costs no extra query — that is the whole point (#4419).
+ * Any pre-write comparison inside `POST /` that can run with a non-null `sourceId` MUST
+ * go through this; reading `currentSettings.<bareKey>` directly compares a per-source
+ * save against the global row.
+ */
+function scopedSettingKey(key: string, sourceId: string | null): string {
+  return sourceId ? `source:${sourceId}:${key}` : key;
+}
+
+/**
  * Audit-log a settings write. Called from BOTH the per-source branch and the
  * global branch, so per-source changes stop being invisible (epic #4412 bug #6).
  *
@@ -192,10 +206,9 @@ async function auditSettingsWrite(
 ): Promise<void> {
   const validKeySet = new Set<string>(VALID_SETTINGS_KEYS as readonly string[]);
   const changed: Record<string, { before: string | undefined; after: string }> = {};
-  const prefix = sourceId ? `source:${sourceId}:` : '';
   for (const key of Object.keys(filteredSettings)) {
     if (!validKeySet.has(key)) continue;
-    const before = currentSettings[`${prefix}${key}`];
+    const before = currentSettings[scopedSettingKey(key, sourceId)];
     if (before !== filteredSettings[key]) {
       // `Object.defineProperty` (not `changed[key] = ...`) is deliberate, not
       // stylistic: it's how the code proved to static analysis / CodeQL that
@@ -326,8 +339,8 @@ router.post('/', requirePermission('settings', 'write', { sourceIdFrom: 'query' 
       const willBeEnabled =
         'autoAckEnabled' in filteredSettings
           ? filteredSettings.autoAckEnabled === 'true'
-          : currentSettings.autoAckEnabled === 'true';
-      const regexChanged = pattern !== (currentSettings.autoAckRegex ?? '');
+          : currentSettings[scopedSettingKey('autoAckEnabled', sourceId)] === 'true';
+      const regexChanged = pattern !== (currentSettings[scopedSettingKey('autoAckRegex', sourceId)] ?? '');
 
       if (willBeEnabled || regexChanged) {
         if (pattern.length > 100) {
@@ -883,6 +896,8 @@ router.post('/', requirePermission('settings', 'write', { sourceIdFrom: 'query' 
     }
 
     if ('autoWelcomeEnabled' in filteredSettings) {
+      // Global-branch only: the `if (sourceId)` branch above returns at :842, so
+      // `currentSettings[...]` here is always the un-prefixed global row by construction (#4419).
       const wasEnabled = currentSettings['autoWelcomeEnabled'] === 'true';
       const nowEnabled = filteredSettings['autoWelcomeEnabled'] === 'true';
       if (!wasEnabled && nowEnabled) {

--- a/src/server/services/securityDigestService.perSource.test.ts
+++ b/src/server/services/securityDigestService.perSource.test.ts
@@ -35,6 +35,11 @@ describe('securityDigestService — per-source dispatch', () => {
     const fakeDb: any = {
       settings: {
         getSettingForSource: vi.fn(async (sid: string, key: string) => {
+          // NOTE: `externalUrl` below is a mock fixture value only — there is NO
+          // production write path for this key anywhere in the repo (#4437). This
+          // suite's actual subject is per-source dispatch, which is fine and
+          // unaffected either way; don't read this fixture as evidence a writer
+          // exists.
           const overrides: Record<string, Record<string, string>> = {
             'src-A': {
               securityDigestAppriseUrl: 'discord://a',

--- a/src/server/services/securityDigestService.test.ts
+++ b/src/server/services/securityDigestService.test.ts
@@ -57,6 +57,39 @@ describe('securityDigestService', () => {
       const result = formatDigestSummary(issues, baseUrl, false);
       expect(result).toContain('No security issues');
     });
+
+    it('a digest with no externalUrl configured contains no dangling "/security" link', () => {
+      const issues = {
+        total: 5,
+        lowEntropyCount: 1,
+        duplicateKeyCount: 3,
+        excessivePacketsCount: 1,
+        timeOffsetCount: 0,
+        nodes: [],
+        topBroadcasters: [],
+      };
+
+      // baseUrl === '' is what production sends today — `externalUrl` has no writer
+      // (#4437). This must not render a dead relative "/security" link.
+      const result = formatDigestSummary(issues, '');
+      expect(result).not.toMatch(/View details/);
+      expect(result).not.toContain('/security');
+    });
+
+    it('a digest with externalUrl configured emits an absolute link', () => {
+      const issues = {
+        total: 5,
+        lowEntropyCount: 1,
+        duplicateKeyCount: 3,
+        excessivePacketsCount: 1,
+        timeOffsetCount: 0,
+        nodes: [],
+        topBroadcasters: [],
+      };
+
+      const result = formatDigestSummary(issues, 'https://mesh.example');
+      expect(result).toContain('View details: https://mesh.example/security');
+    });
   });
 
   describe('formatDigestDetailed', () => {

--- a/src/server/services/securityDigestService.ts
+++ b/src/server/services/securityDigestService.ts
@@ -54,6 +54,18 @@ function nodeId(nodeNum: number): string {
   return `!${nodeNum.toString(16).padStart(8, '0')}`;
 }
 
+/**
+ * The digest's "View details" line. Omitted entirely when no absolute external URL is
+ * configured, because `${''}/security` renders as a dead relative path in an Apprise
+ * message. `externalUrl` currently has NO writer anywhere in the repo (#4419 / #4437);
+ * whether it should become a user-configurable setting is a product decision, not a
+ * cleanup. Until then this keeps the broken line out of every digest.
+ */
+function detailsLink(baseUrl: string, markdown: boolean): string | null {
+  if (!baseUrl) return null;
+  return markdown ? `[View details](${baseUrl}/security)` : `View details: ${baseUrl}/security`;
+}
+
 export function formatDigestSummary(
   issues: SecurityIssuesData,
   baseUrl: string,
@@ -77,16 +89,16 @@ export function formatDigestSummary(
         '',
         '> No security issues detected.',
         '',
-        `[View details](${baseUrl}/security)`,
-      ].join('\n');
+        detailsLink(baseUrl, true),
+      ].filter((l): l is string => l !== null).join('\n');
     }
     return [
       `MeshMonitor Security Digest — ${date}`,
       '',
       'No security issues detected.',
       '',
-      `View details: ${baseUrl}/security`,
-    ].join('\n');
+      detailsLink(baseUrl, false),
+    ].filter((l): l is string => l !== null).join('\n');
   }
 
   if (md) {
@@ -102,8 +114,8 @@ export function formatDigestSummary(
       `| Excessive Packets | ${issues.excessivePacketsCount} |`,
       `| Time Offset | ${issues.timeOffsetCount} |`,
       '',
-      `[View details](${baseUrl}/security)`,
-    ].join('\n');
+      detailsLink(baseUrl, true),
+    ].filter((l): l is string => l !== null).join('\n');
   }
 
   return [
@@ -116,8 +128,8 @@ export function formatDigestSummary(
     `  Excessive Packets: ${issues.excessivePacketsCount} node${issues.excessivePacketsCount !== 1 ? 's' : ''}`,
     `  Time Offset:      ${issues.timeOffsetCount} node${issues.timeOffsetCount !== 1 ? 's' : ''}`,
     '',
-    `View details: ${baseUrl}/security`,
-  ].join('\n');
+    detailsLink(baseUrl, false),
+  ].filter((l): l is string => l !== null).join('\n');
 }
 
 export function formatDigestDetailed(
@@ -143,16 +155,16 @@ export function formatDigestDetailed(
         '',
         '> No security issues detected.',
         '',
-        `[View details](${baseUrl}/security)`,
-      ].join('\n');
+        detailsLink(baseUrl, true),
+      ].filter((l): l is string => l !== null).join('\n');
     }
     return [
       `MeshMonitor Security Digest — ${date}`,
       '',
       'No security issues detected.',
       '',
-      `View details: ${baseUrl}/security`,
-    ].join('\n');
+      detailsLink(baseUrl, false),
+    ].filter((l): l is string => l !== null).join('\n');
   }
 
   const lines: string[] = [];
@@ -252,7 +264,8 @@ export function formatDigestDetailed(
     }
   }
 
-  lines.push('', md ? `[View details](${baseUrl}/security)` : `View details: ${baseUrl}/security`);
+  const link = detailsLink(baseUrl, md);
+  if (link !== null) lines.push('', link);
   return lines.join('\n');
 }
 

--- a/src/utils/meshcoreHelpers.ts
+++ b/src/utils/meshcoreHelpers.ts
@@ -33,6 +33,9 @@ export function mapContactsToNodes(contacts: MeshCoreContact[]): MeshCoreMapNode
     .filter(c => c.publicKey && typeof c.latitude === 'number' && isFinite(c.latitude)
       && typeof c.longitude === 'number' && isFinite(c.longitude))
     .map(c => {
+      // NOTE: `(local)` is a server-side naming convention (meshcoreContactsRoutes.ts:108,
+      // meshcoreDeviceRoutes.ts:181), not a protocol field — a user-chosen name containing
+      // "(local)" matches here too. Tracked for an explicit isLocal flag in #4438.
       const isLocalNode = c.advName?.includes('(local)');
       return {
         publicKey: String(c.publicKey),


### PR DESCRIPTION
Phase 5 of the per-source Node Display epic. **Closes #4419.** Cleanup phase — every defect here is pre-existing and was found while doing Phases 1-4.

Plan: `docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_EPIC.md`
Spec: `docs/internal/dev-notes/PER_SOURCE_NODE_DISPLAY_PHASE5_SPEC.md`

## 1. Per-source saves compared against the *global* current value (#4419a)

`settingsRoutes.ts` read `currentSettings.autoAckRegex` — but `currentSettings` comes from `getAllSettings()`, which returns **bare, un-prefixed** keys. On a `POST /api/settings?sourceId=X` the correct current value is the `source:X:` row, so change-detection was wrong **in both directions** when a source overrode the global: an unchanged value could look changed, and a changed one could look unchanged and skip regex validation.

Fixed via a shared `scopedSettingKey()` helper, which `auditSettingsWrite` (already correct) now also uses, so there is one implementation.

## 2. `getSourceSettings` was a full-table scan (#4419b)

It called `getAllSettings()` and filtered in JS. Migration 131 made the settings table grow as (keys × sources), so this got materially worse. Now a single prefix-scoped query.

The dialect trap was **not** rediscovered: MySQL needs two literal backslashes in the `ESCAPE` literal where SQLite and PostgreSQL need exactly one. That was found empirically in Phase 1, and the logic is now extracted into a shared `sourceNamespaceMatch()` helper rather than copied.

## 3. Migration 050 replayed against a mutable array

050 imported `PER_SOURCE_SETTINGS_KEYS`. Fresh installs replay every migration, so it ran against whatever that array holds **today** — and the drift is live, since this epic added 9 keys to it in Phase 1.

**Frozen at today's 170-key snapshot**, not the 87-key authoring-time list. Measured against `aae251a6` and independently re-verified: **87 then, 170 now, strict superset, 0 removed, 83 added**, with this epic's nine Node Display keys among the added.

Today's snapshot is the only **zero-delta** option. Freezing at 87 would be *subtractive* — it would silently stop promoting those nine for every future v3.x upgrader. A cleanup phase must not change upgrade semantics.

050's ~170-round-trip PG/MySQL loops are deliberately **not** fixed (the #4233 anti-pattern, but it runs once per DB under the ledger). The new tests assert behavior only, never round-trip counts, so a future batching fix won't break them.

## 4. `externalUrl` — a live user-facing bug, not just an orphan

Read by `securityDigestService.ts:332`, written **nowhere**. So `baseUrl` is always `''`, which means **every Apprise security digest ever sent has contained a dead relative link** — `View details: /security`.

Fixed by omitting the line when `baseUrl` is empty. Deliberately **not** fixed by adding the key to `VALID_SETTINGS_KEYS` — that silently creates a new user-writable setting, which is a product decision. Filed as **#4437**.

Also filed **#4438** for the `isLocal` flag: measured at 7 production files, a type change, and an API response-shape change, where the hard part is proving the flag is set on *every* producer — miss one and the local node silently vanishes, worse than the bug. Phase 5 added the four missing `NOTE:` pointers instead.

## Test quality — 19 of 27 existing tests here would have stayed green with their defect present

- **All 8 migration-050 tests** use keys present in *both* key lists, so the suite is **structurally incapable** of observing the drift. Only a source-text guard catches it.
- **`getSourceSettings` had zero tests as a subject** — only as an incidental oracle inside `deleteSourceSettings` tests. It is the function this PR rewrites.
- **Migration 050 had no PG or MySQL coverage at all**, despite shipping hand-written implementations for both. This PR adds its first.
- **`securityDigestService.perSource.test.ts` seeded `externalUrl: 'https://a.example'`** — a value no production write path can produce. That fixture is exactly how the orphan hid.

**Two spec-level test flaws were caught before shipping**, because every new test had to demonstrate its own failure against unfixed code first:
- The proposed proof that `getSourceSettings` is prefix-scoped (count `select()` calls, expect 1) **would not have caught the regression** — `getAllSettings()` also issues exactly one. Strengthened to assert `getAllSettings` is never called.
- One WP1 test's seeding would have failed validation under *both* buggy and fixed code, passing for the wrong reason.

## Verification

- Full suite **12,733 passing, 0 failing**, `success: true` via JSON reporter, PG + MySQL live, 109 skips unchanged.
- `tsc --noEmit` clean; `lint:ci` clean — and the `getSourceSettings` rewrite *reduced* that file's `no-explicit-any` baseline from 6 to 4.
- Every fix demonstrated failing against the unfixed code before being accepted.

## Known gap, documented not fixed

`DatabaseService.auditLogAsync` accepts `valueBefore`/`valueAfter` and explicitly `void`s them — the schema has no columns. So `auditSettingsWrite` computes a full before/after diff per settings change and discards it. The `details` field still records which keys changed. Pre-existing; needs a schema migration.

Closes #4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB
