### PR TITLE
feat(traceroute): statistical route aggregation + union layout engine (epic phase 1)

### DIFF
--- a/docs/internal/dev-notes/SR_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/SR_PHASE1_SPEC.md
@@ -1,0 +1,848 @@
+# Statistical Route Visualization — Phase 1 Implementation Spec
+
+**Epic:** `docs/internal/dev-notes/STATISTICAL_ROUTE_EPIC.md`
+**Phase goal:** pure utilities only. No React, no API, no DB, no schema change, no
+new dependency, no visible product change.
+**Branch:** `feature/statistical-route-phase1`
+**Predecessor spec:** `docs/internal/dev-notes/TRACEROUTE_VISUAL_STRIP_SPEC.md`
+(§3.4 lane/column algorithm, §3.5 edges/labels, §3.6 layout). Read §3.4.7
+(invariants I1–I6) before touching anything here.
+
+Everything in §2 (Design decisions) is binding. Where this spec deviates from a
+rule the strip spec set, it says so and gives the reason.
+
+---
+
+## 1. Reuse inventory (mandatory)
+
+Everything below already exists. **The implementation MUST use these. It must
+not re-parse, re-filter, or re-derive any of them.** Anything not on this list
+is justified in §1.3.
+
+### 1.1 Must reuse — already exported
+
+| What | Path:line | How Phase 1 uses it |
+|---|---|---|
+| `parseHopArray(json)` | `src/utils/tracerouteSegments.ts:261` | The only JSON array parser. Tolerates `null` / `'null'` / `''`. |
+| `hasRouteData(route)` | `src/utils/tracerouteSegments.ts:273` | Gates the forward leg. |
+| `hasReturnPath(routeBack, snrBack)` | `src/utils/tracerouteSegments.ts:198` | Gates the return leg (#2051/#3622). |
+| `isValidRouteNode(nodeNum)` | `src/utils/tracerouteSegments.ts:73` | Reserved/invalid hop predicate. |
+| `BROADCAST_ADDR` (`4294967295`) | `src/utils/tracerouteSegments.ts:62` | The unknown-hop placeholder. Re-exported by `tracerouteStrip.ts:58`. |
+| `filterHops(hops)` | `src/utils/tracerouteStrip.ts:177` (**private today — WP1 exports it**) | §3.3 hop-filter policy: endpoints never filtered, `BROADCAST_ADDR` kept and flagged `isUnknown`, other invalid hops dropped. |
+| `StripNode` / `StripEdge` / `StripLane` / `StripLeg` / `StripPoint` / `StripLayout` / `StripLayoutOptions` / `TracerouteStripGraph` | `src/utils/tracerouteStrip.ts:80,107,78,71,619,624,586,120` | The union types extend these. The layout returns a plain `StripLayout`. |
+| `DEFAULT_LAYOUT_OPTIONS` | `src/utils/tracerouteStrip.ts:610` (**private today — WP1 exports it**) | Same pitch, glyph size, and bands as the single-route strip. |
+| `pullToward(from, to, dist)` | `src/utils/tracerouteStrip.ts:639` (**private — WP1 exports**) | Rim pull-in for edge endpoints. |
+| `canonicalPerpendicular(a, b)` | `src/utils/tracerouteStrip.ts:732` (**private — WP1 exports**) | Direction-stable perpendicular; supplies `laneDir` to the router. |
+| `routeAroundGlyphs(path, obstacles, clearance, laneDir)` | `src/utils/tracerouteStrip.ts:835` (**private — WP1 exports**) | #4428 glyph-collision routing. Reused verbatim; the union layout adds nothing to it. |
+| `pickLabelX(path, anchorY, glyphCenters, radius)` | `src/utils/tracerouteStrip.ts:944` (**private — WP1 exports**) | Label/tooltip anchor X sampled from the final routed path. |
+| `edgeClearance(o)` / `labelClearRadius(o)` / `labelOffset(o)` / `minBand(o)` / `minRowHeight(o)` | `src/utils/tracerouteStrip.ts:794,930,678,684,694` (**private — WP1 exports**) | The clearance arithmetic. Never re-derive a radius or a floor. |
+| `EDGE_RIM_MARGIN` / `GEOM_EPS` | `src/utils/tracerouteStrip.ts:760,788` (**private — WP1 exports**) | Rim margin for the 2-point/vertical path; epsilon for clearance assertions in tests. |
+| `paddedHexId(nodeNum)` | `src/utils/tracerouteStrip.ts:66` | Not used by Phase 1 code, but the renderer already has it for Phase 2. No copy. |
+
+### 1.2 Consulted, deliberately NOT reused
+
+| What | Why not |
+|---|---|
+| `decomposeTraceroute` (`src/utils/tracerouteSegments.ts`) | Needs a `resolvePosition` callback and **drops every hop without a position**. The union graph must keep every hop. Same reasoning the strip spec gave in its §1.2. |
+| `buildTracerouteStripGraph` (`src/utils/tracerouteStrip.ts:560`) | Builds one row's spine graph with SNR-paired edges. The union graph has no spine, no per-leg lanes, and no SNR. Reusing it would mean discarding most of its output and then merging N graphs — more work than walking the filtered legs directly. Phase 1 reuses its *filter* (`filterHops`) and its *geometry*, which is where the real duplication risk sits. |
+| `formatTracerouteRoute` (`src/utils/traceroute.tsx:143`) | The third parse path the strip spec §1.3 already ruled against. It compacts the SNR array while filtering. Do not touch it, do not import it. |
+| `useTracerouteAnalysis.ts` local `parseNumArray` | Fourth parse path. Same ruling. |
+
+### 1.3 New modules, justified against the closest existing one
+
+| New file | Closest existing | Why new |
+|---|---|---|
+| `src/utils/tracerouteAggregate.ts` | `src/utils/tracerouteStrip.ts` (`buildTracerouteStripGraph`) | `tracerouteStrip.ts` is documented as "the one graph shape the strip renders" for **one** traceroute, with SNR-paired directed edges and a spine. Aggregation is a different question — count occurrences across N rows, undirected, SNR-free — and its output is a counting model, not a render model. Folding it in would double that module's size and give it two unrelated public entry points. It reuses `filterHops` and every parser, so no rule is duplicated. |
+| `src/utils/tracerouteUnionLayout.ts` | `layoutTracerouteStrip` (`src/utils/tracerouteStrip.ts:978`) | `layoutTracerouteStrip` takes a `TracerouteStripGraph` whose `col`/`row` are **already assigned** by the spine builder; it only turns cells into pixels. The union graph arrives with no cells at all — assigning them is the hard part and has no analogue in the strip. The pixel half is pure reuse: this module calls the same exported helpers and returns the same `StripLayout`, so the two layouts cannot drift. |
+
+### 1.4 Files WP1 modifies, and the rule for doing it
+
+`src/utils/tracerouteStrip.ts` gets **export-only** changes plus one widened
+optional property. No logic moves, no behavior changes. The existing
+`src/utils/tracerouteStrip.test.ts` (50 cases) passing unchanged is the
+acceptance gate for WP1.
+
+---
+
+## 2. Design decisions
+
+### D1 — Orientation: every leg runs local → peer
+
+The `/api/traceroutes/history/:from/:to` endpoint is bidirectional, so a row's
+`fromNodeNum`/`toNodeNum` may be `(local, peer)` **or** `(peer, local)`. A
+row's return leg always runs the opposite way from its forward leg. Both
+problems collapse into one rule:
+
+> Build each leg's hop sequence in its own traversal order, then **reverse it
+> if `sequence[0] !== localNodeNum`**.
+
+Every leg starts and ends at the two endpoints (they are never filtered, strip
+spec §3.3), so this always yields a sequence that starts at `localNodeNum` and
+ends at `peerNodeNum`. No other orientation logic exists anywhere in Phase 1.
+
+Rows whose endpoint pair is not `{localNodeNum, peerNodeNum}` are skipped and
+counted in `mismatchedRoutes`. The endpoint is pair-scoped, so this should be
+zero in production; the counter exists so a bug shows up as a number rather
+than as silently missing data.
+
+`localNodeNum === peerNodeNum` returns an empty union (`isEmpty: true`). A
+self-pair has no two-endpoint axis to lay out.
+
+### D2 — Row inclusion, and the denominator
+
+A row is **included** when its endpoints match the pair **and** it yields at
+least one drawable leg:
+
+```
+hasForward = hasRouteData(row.route)
+hasReturn  = hasReturnPath(parseHopArray(row.routeBack), row.snrBack)
+included   = hasForward || hasReturn
+```
+
+This is exactly the map's skip rule (`useTraceroutePaths.tsx:886-898`) and the
+strip's (`tracerouteStrip.ts:560-572`). A row with neither leg is a failed
+traceroute; it is excluded and counted in `excludedRoutes`.
+
+`totalRoutes` = the count of **included** rows. Every `share` divides by it, so
+a failed traceroute never dilutes a share.
+
+Note `hasReturnPath` reads `snrBack`. A row with an empty `routeBack` but a
+non-empty `snrBack` therefore contributes a real zero-hop return leg
+(`[peer, local]` → after orientation `[local, peer]`). That is correct: the
+return really did travel direct.
+
+### D3 — Counting: once per traceroute, for both nodes and edges
+
+* **Node count.** A node counts **once per included row in which it appears in
+  any leg**, not once per occurrence. A node in both legs of one row counts
+  once. A node twice in one leg (a loop) counts once.
+* **Edge count.** An edge between `A` and `B` counts **once per included row in
+  which `A` and `B` were adjacent in any leg**. Adjacent in both legs of one
+  row still counts once. Adjacent twice within one leg still counts once.
+* **Undirected.** `A→B` and `B→A` are the same edge. The canonical key sorts
+  the two node ids, so the direction of traversal never reaches the output.
+
+Consequence, and the reason for the rule: `share = count / totalRoutes` then
+lands in `(0, 1]` and reads as a plain English sentence — "seen in 12 of 15
+routes (80%)", which is exactly the tooltip the epic committed to. Counting
+occurrences instead would let a share exceed 1 and would make a node that a
+single route visits twice look more reliable than one that ten routes visit
+once.
+
+Both counters are implemented with a per-row `Set` of ids seen, flushed into
+the running totals at the end of each row.
+
+**Self-adjacency is dropped.** When `sequence[k]` and `sequence[k+1]` resolve
+to the same id (a node repeated back-to-back), no edge is emitted. A self-loop
+has no renderable geometry in the strip.
+
+### D4 — Anonymous hop identity: keyed by hop depth (a scoped relaxation of I6)
+
+`BROADCAST_ADDR` is not a node identity. The firmware writes it when
+`insertUnknownHops()` backfills a gap — "a hop happened here and nobody
+recorded who" (strip spec §1.4). Two unknown hops in two different traceroutes
+may or may not be the same radio, and nothing in the data can tell you.
+
+Three candidate rules were considered:
+
+1. **Never merge.** Every unknown hop in every leg of every row is its own
+   node. Rejected: a 15-route history with one unknown hop each produces 15
+   distinct unknown nodes, each with `share = 1/15`, each pinned at the opacity
+   floor. The picture gets worse the more data you have, which inverts the
+   whole point of the view.
+2. **Merge by anchoring neighbours** (identity = the pair of real nodes on
+   either side). Rejected: it fragments as soon as a neighbour is itself
+   unknown, it is not defined for an unknown adjacent to another unknown, and
+   its determinism argument is far harder to write than to test.
+3. **Merge by hop depth.** Chosen.
+
+> **Rule.** An unknown hop's identity is `u:${depth}`, where `depth` is its
+> index in the **filtered, oriented (local → peer)** sequence. Real nodes keep
+> the identity `n:${nodeNum}` regardless of depth.
+
+Depth is measured after filtering and after orientation, so it is the same
+quantity in both legs of a row and in every row: hops away from the local node.
+
+**What the merged node claims.** It claims "in P% of routes there was an
+unrecorded hop at position *k* on the path". That statement is true, useful,
+and makes no claim about which device it was. The glyph stays the neutral
+Unknown placeholder and Phase 2's tooltip must say "unrecorded hop" — never a
+node name.
+
+**Why this does not violate strip invariant I6.** I6 exists because the
+single-route strip draws a *shared spine node*, which asserts "the forward and
+return legs both went through this same device". The union strip has no spine
+and asserts no device identity for an unknown node at all. The relaxation is
+scoped to `tracerouteAggregate.ts`; `tracerouteStrip.ts` keeps I6 untouched.
+
+Ids are prefixed (`n:` / `u:`), so a real node and an unknown hop can never
+collide.
+
+### D5 — Column assignment: lower-median depth, grouped, endpoints pinned
+
+A node can sit at depth 1 in one route and depth 3 in another. It gets one
+column.
+
+```
+depthKey(node) = depthSamples[floor((depthSamples.length - 1) / 2)]
+```
+
+with `depthSamples` sorted ascending — the **lower median**. Integer in,
+integer out. The lower median biases left, so one rare long detour cannot drag
+a node rightward; and it is a single array index, so its determinism needs no
+argument beyond "the array is sorted".
+
+`depthSamples` holds one entry per **(row, leg, occurrence)**, not one per row.
+A row contributing both legs weights that node twice, which is the right
+weighting — it is two independent observations of where the node sat. This is
+deliberately a different granularity from `count`, and the type doc says so;
+`depthSamples.length` is not `count`.
+
+**Grouping.** Intermediates are partitioned by `depthKey`. The distinct keys,
+sorted ascending, become dense column indices. Then:
+
+* the local endpoint is pinned to column `0`, alone;
+* the peer endpoint is pinned to column `columns - 1`, alone.
+
+So `columns = 2 + (number of distinct intermediate depthKeys)`, and columns `0`
+and `columns - 1` each hold exactly one node. Endpoints bracket the graph even
+when a stray route makes some intermediate's median larger than the peer's.
+
+Every intermediate has `depthKey >= 1` — depth 0 is the local node by
+construction — so an intermediate can never land in the local column.
+
+### D6 — Row assignment: alternating offsets around a dominant line
+
+Within a column group, order nodes by `(share desc, id asc)`. `id` is unique,
+so this is a total order. Then assign a signed offset by index:
+
+| index | 0 | 1 | 2 | 3 | 4 | … |
+|---|---|---|---|---|---|---|
+| offset | 0 | +1 | −1 | +2 | −2 | … |
+
+(index `i`: `i === 0 ? 0 : (i % 2 === 1 ? (i+1)/2 : -(i/2))`.)
+
+Then shift globally so the smallest offset is row 0:
+
+```
+row(node) = offset(node) - min(all offsets)
+rowCount  = max(all offsets) - min(all offsets) + 1
+```
+
+**The property this buys.** The most frequent node in *every* column sits at
+offset 0, so it always lands on the same row. The dominant path renders as one
+straight horizontal line, and variants fan out above and below it. That is the
+union graph's counterpart to the single-route strip's spine, and it falls out
+of the arithmetic rather than needing its own pass.
+
+Consequences worth knowing:
+
+* A history with one repeated path gives every group exactly one node, every
+  offset 0, one row — visually the plain strip.
+* Alternation starts **downward** (`+1` before `−1`), so a two-way fan puts the
+  dominant node on the top row and the variant below it. This reads better than
+  the reverse for the common "one usual path, one occasional detour" case.
+
+### D7 — Same-column edges use the vertical 2-point form
+
+Two nodes with the same `depthKey` can be adjacent. Example: `route1 = L,A,B,P`
+and `route2 = L,B,A,P` gives both `A` and `B` a lower median of 1, so both land
+in column 1, and they are adjacent. This is real data, not a contrived case.
+
+`layoutTracerouteStrip`'s row-crossing branch would break here: its elbow is
+`{ x: (c0.x + c1.x) / 2, y: max(c0.y, c1.y) }`, which for a vertical chord
+equals the lower endpoint's centre, so `pullToward(c1, mid, pullIn)` divides by
+a zero-length vector and returns `c1` itself — a line ending inside the glyph.
+
+> **Rule.** Branch on **column**, not on row. `col(a) === col(b)` → 2-point
+> path (`pullToward` both ways). `col(a) !== col(b) && row(a) !== row(b)` →
+> 3-point dog-leg, same elbow as the strip. Otherwise → 2-point path.
+
+**Deferred, on purpose.** A nicer fix is to split a column group so adjacent
+nodes never share a column. That is graph colouring; any greedy heuristic needs
+its own determinism proof and its own test matrix, and the vertical edge above
+renders correctly and legibly without one. Recorded as a Phase-3 candidate, not
+a Phase-1 gap.
+
+### D8 — No lane offset, no arrowheads, no SNR
+
+The epic settled on combined-undirected edges rendered in a single neutral
+lane. So:
+
+* The union layout applies **no** `LANE_OFFSET` translation. There is no
+  competing leg to separate from.
+* It still calls `edgeClearance(o)`, which includes one `LANE_OFFSET` of
+  headroom. Keeping the same clearance radius as the strip costs 5px of
+  generosity and keeps one definition of "how close may a line pass a glyph".
+* `UnionStripEdge.snr` is always `null` and `snrUnknown` always `false`. SNR is
+  not aggregated. There is no defensible single SNR for an adjacency observed
+  across a dozen routes at different times, and the epic rules out numeric
+  labels anyway. Do not add a mean.
+* `UnionStripEdge.leg` is fixed to `'forward'`. It is a required field on
+  `StripEdge`, and `'forward'` is the value the renderer's solid-line CSS hook
+  keys on. **Phase 2 must branch on `graph.mode === 'statistical'` to suppress
+  arrowheads and SNR labels — it must not read `leg` as a direction claim.**
+
+### D9 — Opacity floor: `MIN_STAT_OPACITY = 0.28`
+
+```
+statOpacity(share) = round3(MIN_STAT_OPACITY + (1 - MIN_STAT_OPACITY) * clamp01(share))
+```
+
+`round3(x) = Math.round(x * 1000) / 1000`.
+
+* One constant serves both nodes and edges. Two floors would invite them to
+  drift apart for no gain.
+* `0.28`: below roughly `0.2` a 32px glyph stops being discernible against the
+  strip background in either theme, and a rare-but-real relay must stay
+  visible and hoverable — that is the whole reason the epic asked for a floor.
+  `0.28` clears that with margin while still leaving a 0.28 → 1.00 ramp, so the
+  encoding keeps most of its dynamic range.
+* `share === 1` maps to exactly `1`. `share` near 0 maps to `0.28`.
+* Rounding to three decimals keeps float noise out of deep-equality assertions.
+
+The constant and the function live in `tracerouteAggregate.ts`, next to
+`share`. Opacity is a pure function of the count model, not of geometry.
+
+### D10 — Output shape maps onto the strip's, by extension
+
+| Union type | Extends | Added fields |
+|---|---|---|
+| `UnionStripNode` | `StripNode` | `count`, `share`, `opacity`, `isEndpoint` |
+| `UnionStripEdge` | `StripEdge` | `aId`, `bId`, `count`, `share`, `opacity` |
+| `UnionStripGraph` | `TracerouteStripGraph` | `mode: 'statistical'`, `totalRoutes` |
+
+Because they extend, a `UnionStripGraph` is assignable to
+`TracerouteStripGraph` and `layoutTracerouteUnion` returns a plain
+`StripLayout`. Phase 2's renderer changes are: a `mode` branch that reads
+`opacity` and suppresses arrowheads/SNR labels, and a tooltip that reads
+`count`/`share`/`totalRoutes`.
+
+Inherited fields on a union node are pinned:
+
+* `lane: 'spine'` — one neutral band; keeps the renderer's existing lane class
+  hook working.
+* `legs: []`, `shared: false` — the union graph has no leg semantics. Phase 2
+  must not read either field in statistical mode.
+* `id` — reused verbatim from the aggregate (`n:…` / `u:…`), so
+  `layout.centers` keys match `StatNode.id` and Phase 2 can cross-reference the
+  count model without a second map.
+* `hasForward: false`, `hasReturn: false` — no single leg produced this graph.
+
+Edge id is `stat:${aId}|${bId}` with `aId < bId`.
+
+### D11 — Determinism
+
+No `Date.now`, no `Math.random`, no `localeCompare` (locale-dependent ordering
+is not determinism), no object-iteration order dependence.
+
+*Aggregation.* One pass over rows. All state in `Map`s keyed by string. Output
+arrays sorted by `id` with a plain `<` / `>` comparator; ids are unique, so the
+order is total. `depthSamples` is sorted ascending before it leaves the module.
+Counts are integers; `share` is integer ÷ integer.
+
+**Stronger than determinism: the union graph is invariant under permutation of
+the input rows.** Counts are sums, `depthSamples` is sorted, and the output
+arrays are id-sorted. Nothing carries row order. This is a named test.
+
+*Layout.* `depthKey` is an index into a sorted integer array. Group order is
+sorted distinct integers. Within-group order is `(share desc, id asc)` with
+unique `id`. Offsets come from an index. Geometry is arithmetic.
+`routeAroundGlyphs` is documented bounded and deterministic
+(`tracerouteStrip.ts:768-788, 862-889`). Therefore identical input gives
+deep-equal output, and the layout is permutation-invariant too, since its input
+is.
+
+---
+
+## 3. File-by-file changes
+
+### 3.1 `src/utils/tracerouteStrip.ts` — MODIFY (WP1)
+
+Export-only. No logic moves. No behavior changes.
+
+Add `export` to each of these existing declarations, each with a one-line
+`@internal` note naming `tracerouteUnionLayout.ts` / `tracerouteAggregate.ts`
+as the consumer:
+
+```ts
+export interface RawHop { nodeNum: number; snr?: number; }   // widened: snr was `number | undefined`
+export interface InternalLegHop { nodeNum: number; snr: number | undefined; isUnknown: boolean; }
+
+export function filterHops(hops: RawHop[]): InternalLegHop[];
+
+export const DEFAULT_LAYOUT_OPTIONS: StripLayoutOptions;
+export const EDGE_RIM_MARGIN: number;
+export const GEOM_EPS: number;
+
+export function pullToward(from: StripPoint, to: StripPoint, dist: number): StripPoint;
+export function canonicalPerpendicular(a: StripPoint, b: StripPoint): StripPoint;
+export function labelOffset(o: StripLayoutOptions): number;
+export function minBand(o: StripLayoutOptions): number;
+export function minRowHeight(o: StripLayoutOptions): number;
+export function edgeClearance(o: StripLayoutOptions): number;
+export function labelClearRadius(o: StripLayoutOptions): number;
+export function routeAroundGlyphs(
+  path: StripPoint[], obstacles: StripPoint[], clearance: number, laneDir: StripPoint,
+): StripPoint[];
+export function pickLabelX(
+  path: StripPoint[], anchorY: number, glyphCenters: StripPoint[], radius: number,
+): number;
+```
+
+Only one signature changes: `RawHop.snr` becomes optional so the aggregate can
+pass `{ nodeNum }` without a meaningless `snr: undefined`. Every existing caller
+already supplies `snr` explicitly, and `filterHops` reads it as
+`number | undefined` either way.
+
+Add a short banner paragraph under the existing module banner: this module is
+now also the geometry and hop-filter home for the statistical union layout, and
+the `@internal` exports exist so the two layouts cannot drift.
+
+### 3.2 `src/utils/tracerouteAggregate.ts` — CREATE (WP2)
+
+```ts
+/** BROADCAST_ADDR unknown hops are keyed `u:<depth>`; real nodes `n:<nodeNum>`. */
+export const REAL_NODE_ID_PREFIX = 'n';
+export const UNKNOWN_HOP_ID_PREFIX = 'u';
+
+/** Minimum rendered opacity for a node or edge, whatever its share (D9). */
+export const MIN_STAT_OPACITY = 0.28;
+
+/** Structural subset of a `/api/traceroutes/history/:from/:to` row. Matches
+ *  `DbTraceroute` (src/db/types.ts:197) and `TracerouteParticipationEntry`
+ *  (src/services/api.ts:48) in the fields it reads. */
+export interface AggregateTracerouteRow {
+  id?: number;
+  fromNodeNum: number;
+  toNodeNum: number;
+  route?: string | null;
+  routeBack?: string | null;
+  snrBack?: string | null;
+  timestamp?: number;
+}
+
+export interface StatNode {
+  /** `n:<nodeNum>` or `u:<depth>`. Unique within one union graph. */
+  id: string;
+  /** BROADCAST_ADDR for an unknown hop. */
+  nodeNum: number;
+  isUnknown: boolean;
+  /** The hop depth this identity is keyed on; null for real nodes (D4). */
+  unknownDepth: number | null;
+  isEndpoint: boolean;
+  /** Included rows containing this node in any leg. Never per-occurrence (D3). */
+  count: number;
+  /** count / totalRoutes, in (0, 1]. */
+  share: number;
+  /** One entry per (row, leg, occurrence), sorted ascending. NOT `count` —
+   *  this is the observation multiset the column algorithm medians (D5). */
+  depthSamples: number[];
+}
+
+export interface StatEdge {
+  /** `${aId}|${bId}` with aId < bId. */
+  id: string;
+  aId: string;
+  bId: string;
+  /** Included rows in which the two nodes were adjacent in any leg (D3). */
+  count: number;
+  share: number;
+}
+
+export interface TracerouteUnionGraph {
+  localNodeNum: number;
+  peerNodeNum: number;
+  /** Included rows — the denominator of every share. */
+  totalRoutes: number;
+  /** Rows with no parseable leg at all (failed traceroutes). */
+  excludedRoutes: number;
+  /** Rows whose endpoint pair was not {local, peer}. Expected 0. */
+  mismatchedRoutes: number;
+  /** Sorted by `id` ascending. */
+  nodes: StatNode[];
+  /** Sorted by `id` ascending. */
+  edges: StatEdge[];
+  isEmpty: boolean;
+}
+
+export function buildTracerouteUnion(
+  rows: readonly AggregateTracerouteRow[],
+  localNodeNum: number,
+  peerNodeNum: number,
+): TracerouteUnionGraph;
+
+/** Linear ramp from MIN_STAT_OPACITY at share→0 to 1 at share=1, rounded to
+ *  three decimals. Clamps out-of-range input. */
+export function statOpacity(share: number): number;
+```
+
+Internal, not exported:
+
+```ts
+interface OrientedLeg { ids: string[]; nodeNums: number[]; isUnknown: boolean[]; }
+function orientedLegs(row, localNodeNum, peerNodeNum): OrientedLeg[]  // 0, 1, or 2 legs
+```
+
+Algorithm, per row:
+
+1. Endpoint check → `mismatchedRoutes`, skip.
+2. Forward raw hops = `[from, ...parseHopArray(route), to]`; return raw hops =
+   `[to, ...parseHopArray(routeBack), from]`. Gate each with
+   `hasRouteData` / `hasReturnPath`.
+3. `filterHops` each present leg.
+4. Reverse the leg if `hops[0].nodeNum !== localNodeNum` (D1).
+5. Map hop `k` to an id: `isUnknown ? u:${k} : n:${nodeNum}`.
+6. Per-row `Set<string>` of node ids, per-row `Set<string>` of edge ids. Record
+   `depthSamples` per occurrence.
+7. Flush both sets into the running counters; `totalRoutes += 1`.
+
+Then compute shares, sort `depthSamples`, sort `nodes` and `edges` by `id`.
+
+`isEmpty` is `totalRoutes === 0`.
+
+### 3.3 `src/utils/tracerouteUnionLayout.ts` — CREATE (WP3)
+
+```ts
+import type { StripLayout, StripLayoutOptions, StripNode, StripEdge,
+              TracerouteStripGraph } from './tracerouteStrip';
+import type { AggregateTracerouteRow, TracerouteUnionGraph } from './tracerouteAggregate';
+// value imports: statOpacity, buildTracerouteUnion from './tracerouteAggregate';
+// value imports: DEFAULT_LAYOUT_OPTIONS, EDGE_RIM_MARGIN, pullToward,
+//   canonicalPerpendicular, labelOffset, minBand, minRowHeight, edgeClearance,
+//   labelClearRadius, routeAroundGlyphs, pickLabelX from './tracerouteStrip';
+
+export interface UnionStripNode extends StripNode {
+  /** Included routes containing this node. */
+  count: number;
+  share: number;
+  /** statOpacity(share). Precomputed so the renderer maps nothing. */
+  opacity: number;
+  isEndpoint: boolean;
+}
+
+export interface UnionStripEdge extends StripEdge {
+  aId: string;
+  bId: string;
+  count: number;
+  share: number;
+  opacity: number;
+}
+
+export interface UnionStripGraph extends TracerouteStripGraph {
+  /** Discriminant. Phase 2's renderer branches on this, never on `leg`. */
+  mode: 'statistical';
+  totalRoutes: number;
+  nodes: UnionStripNode[];
+  edges: UnionStripEdge[];
+}
+
+/** Assign columns (D5), rows (D6), and ids, and attach counts/opacity. Pure. */
+export function buildUnionStripGraph(union: TracerouteUnionGraph): UnionStripGraph;
+
+/** Cells -> pixels. Same arithmetic, floors, clearance, and glyph routing as
+ *  `layoutTracerouteStrip`, via the helpers that module now exports. */
+export function layoutTracerouteUnion(
+  graph: UnionStripGraph,
+  opts?: Partial<StripLayoutOptions>,
+): StripLayout;
+
+/** One-shot seam for Phase 2. */
+export function buildStatisticalStrip(
+  rows: readonly AggregateTracerouteRow[],
+  localNodeNum: number,
+  peerNodeNum: number,
+  opts?: Partial<StripLayoutOptions>,
+): { union: TracerouteUnionGraph; graph: UnionStripGraph; layout: StripLayout };
+```
+
+`buildUnionStripGraph` steps:
+
+1. Empty union → `{ mode:'statistical', totalRoutes:0, nodes:[], edges:[],
+   columns:0, hasForward:false, hasReturn:false, isEmpty:true }`.
+2. `depthKey` per node (D5). Partition intermediates; sort distinct keys
+   ascending; pin local to column 0 and peer to the last column.
+3. Per column, order by `(share desc, id asc)`; assign offsets (D6); shift to
+   dense rows.
+4. Emit `UnionStripNode`s with `lane:'spine'`, `legs:[]`, `shared:false`,
+   `opacity: statOpacity(share)`; sort by `(row asc, col asc)` to match the
+   strip's node ordering contract.
+5. Emit `UnionStripEdge`s in `union.edges` order (already id-sorted), with
+   `leg:'forward'`, `snr:null`, `snrUnknown:false`,
+   `fromId:aId`, `toId:bId`, `id: 'stat:' + aId + '|' + bId`.
+
+`layoutTracerouteUnion` steps — mirroring `layoutTracerouteStrip:978-1076`:
+
+1. `o = { ...DEFAULT_LAYOUT_OPTIONS, ...opts }`; floor `topBand`/`bottomBand`
+   at `minBand(o)` and `rowHeight` at `minRowHeight(o)`.
+2. `centers[id] = { x: col*colWidth + colWidth/2,
+   y: topBand + row*rowHeight + glyphSize/2 }`.
+   `width = columns * colWidth`;
+   `height = topBand + (maxRow+1)*rowHeight + bottomBand`.
+   An empty graph gives `width 0` and a one-row height, matching the strip.
+3. Per edge: choose the path form by **column** (D7). `pullIn =
+   glyphSize/2 + EDGE_RIM_MARGIN`. **No lane translation.**
+4. Obstacles = every node centre except the edge's own two.
+   `laneDir = canonicalPerpendicular(c0, c1)` (the "up" side; an arbitrary but
+   fixed tie-break, used only when a vertex lands exactly on a glyph centre).
+   `path = routeAroundGlyphs(path, obstacles, edgeClearance(o), laneDir)`.
+5. `labelAnchors` — computed even though statistical mode renders no SNR label,
+   so the return value is a complete `StripLayout` and Phase 2 gets a
+   ready-made tooltip anchor. `anchorY = sameRow ? c0.y - labelOffset(o)
+   : (c0.y + c1.y) / 2`; `anchorX = pickLabelX(path, anchorY, allCenters,
+   labelClearRadius(o))`.
+
+---
+
+## 4. Test plan
+
+Vitest, default node environment (all three modules are pure). New `*.test.ts`
+files next to the modules. No standalone scripts, no snapshot files.
+
+### 4.1 `src/utils/tracerouteStrip.test.ts` — ADD to existing (WP1)
+
+New `describe('exported internals (statistical route Phase 1)')`:
+
+1. `filterHops` keeps both endpoints even when their node numbers are reserved.
+2. `filterHops` keeps `BROADCAST_ADDR` intermediates and flags `isUnknown`.
+3. `filterHops` drops invalid intermediates and does not re-index survivors'
+   SNR samples.
+4. `filterHops` accepts a `RawHop` with `snr` omitted.
+5. `minBand`/`minRowHeight`/`labelOffset`/`edgeClearance`/`labelClearRadius`
+   return the documented values for `DEFAULT_LAYOUT_OPTIONS`.
+6. `routeAroundGlyphs` returns the input path unchanged when `obstacles` is
+   empty.
+7. **All 50 existing cases still pass unchanged** — the WP1 gate.
+
+### 4.2 `src/utils/tracerouteAggregate.test.ts` — CREATE (WP2)
+
+*Counting rules*
+
+1. Node counted once per row when it appears in both legs of that row.
+2. Node counted once per row when it appears twice in one leg (a loop).
+3. Edge counted once per row when the pair is adjacent in both legs.
+4. Edge counted once per row when the pair is adjacent twice in one leg.
+5. `A→B` in one row and `B→A` in another produce **one** edge with `count: 2`.
+6. Endpoints have `count === totalRoutes` and `share === 1`.
+7. `share` equals `count / totalRoutes` for every node and edge.
+8. Self-adjacency (`sequence[k] === sequence[k+1]`) emits no edge.
+
+*Direction and normalization*
+
+9. A row stored `(peer, local)` produces the same union as the same route
+   stored `(local, peer)`.
+10. A mixed history of both orientations merges into one graph, not two.
+11. The return leg is oriented local→peer, so its hop depths count from local.
+12. `localNodeNum === peerNodeNum` returns an empty union.
+13. A row whose endpoints are neither local nor peer increments
+    `mismatchedRoutes` and is excluded from `totalRoutes`.
+
+*Row exclusion*
+
+14. `route: null, routeBack: null` → `excludedRoutes: 1`, `totalRoutes: 0`.
+15. `route: 'null'` and `routeBack: ''` → excluded (the string forms).
+16. Forward-only row is included.
+17. Return-only row (empty `routeBack`, non-empty `snrBack`) is included and
+    yields a direct local–peer edge.
+18. A failed row mixed into a good history does not change any share.
+19. Malformed JSON (`route: '{'`) parses to `[]` via `parseHopArray`; the row
+    still counts as a direct forward leg.
+
+*Unknown hops*
+
+20. Two routes, each with one unknown at depth 1, merge to a single `u:1` node
+    with `count: 2`.
+21. Unknowns at different depths stay distinct (`u:1` and `u:2`).
+22. An unknown never merges with a real node at the same depth.
+23. `unknownDepth` is set exactly when `isUnknown` is true (U7).
+24. An unknown in the forward leg and one at the same depth in the return leg
+    of the **same** row merge and still count once.
+25. `nodeNum === BROADCAST_ADDR` on every unknown node.
+
+*Hop filtering (delegated, asserted once)*
+
+26. A reserved intermediate (`nodeNum: 2`) is dropped from the union.
+27. Reserved values at the endpoints are kept (endpoints are never filtered).
+
+*Degenerate and structural*
+
+28. Empty `rows` → `isEmpty: true`, `totalRoutes: 0`, no nodes, no edges.
+29. Single route → every share is 1, node count is path length.
+30. Two disjoint routes (no shared intermediates) → union contains both paths,
+    each intermediate at `share: 0.5`, endpoints at 1.
+31. Two routes sharing a prefix → the shared prefix nodes carry the higher
+    share, the diverging tails 0.5 each.
+32. A node visited at different depths in two routes yields
+    `depthSamples: [d1, d2]` sorted ascending.
+33. `depthSamples.length` may exceed `count` (documented granularity).
+
+*Invariants and determinism*
+
+34. U1: every `share` is in `(0, 1]`.
+35. U3: node ids unique; edge ids unique.
+36. U4: every edge's `aId`/`bId` resolves to a node in `nodes`.
+37. U5: `aId < bId` for every edge.
+38. U6: permuting `rows` yields a deep-equal union graph.
+39. Two calls with the same input yield deep-equal output.
+40. Node and edge arrays are sorted by `id` ascending.
+
+*Opacity*
+
+41. `statOpacity(1) === 1`.
+42. `statOpacity(0)` and `statOpacity(1/50)` are both `>= MIN_STAT_OPACITY`.
+43. `statOpacity` is monotone non-decreasing across a swept range.
+44. Out-of-range input (`-1`, `2`) clamps to `MIN_STAT_OPACITY` / `1`.
+
+### 4.3 `src/utils/tracerouteUnionLayout.test.ts` — CREATE (WP3)
+
+*Columns*
+
+1. Local at column 0, peer at column `columns - 1`.
+2. Columns 0 and `columns - 1` hold exactly one node each.
+3. A node at depth 1 in one route and depth 3 in another gets the lower median
+   (column derived from key 1).
+4. Even-count `depthSamples` take the **lower** median.
+5. Direct-only history → `columns === 2`, one row.
+6. Two routes of different length → dense column indices, no gaps.
+
+*Rows*
+
+7. Single repeated path → every node on one row.
+8. Two parallel paths → two rows; the more frequent node sits on the dominant
+   row.
+9. The dominant node of every column shares one row index (D6's property).
+10. Offsets alternate `0, +1, -1, +2, -2` for a four-way fan in one column.
+11. No two nodes in one column share a row.
+
+*Edges and geometry*
+
+12. Same-column adjacency renders a 2-point vertical path, both endpoints
+    pulled in, neither point equal to a glyph centre (D7).
+13. Same-row, different-column adjacency renders a 2-point path.
+14. Different-row, different-column adjacency renders a 3-point dog-leg with
+    the elbow at the lower row.
+15. An edge spanning non-adjacent columns bends around the intervening glyph:
+    no path vertex and no sampled point on any segment lies closer than
+    `edgeClearance(o) - GEOM_EPS` to an unrelated node centre.
+16. Every `graph.nodes` id has a `layout.centers` entry (L1).
+17. `width === columns * colWidth`; `height` matches the floored band formula.
+18. Custom `opts` below the floors are raised to `minBand` / `minRowHeight`.
+19. Every `edgePaths` entry has at least 2 points.
+20. Every edge has a `labelAnchors` entry, and its `y` clears every node centre
+    by at least `labelOffset(o)` on a same-row edge.
+
+*Graph shape*
+
+21. Every node has `lane: 'spine'`, `legs: []`, `shared: false`.
+22. Every edge has `leg: 'forward'`, `snr: null`, `snrUnknown: false`.
+23. `mode === 'statistical'`; `hasForward`/`hasReturn` are false.
+24. `opacity === statOpacity(share)` on every node and edge.
+25. Node ids are carried over verbatim from the aggregate.
+26. Empty union → empty graph, `columns: 0`, `width: 0`, and a layout that does
+    not throw.
+
+*Determinism*
+
+27. Two runs of `buildStatisticalStrip` on the same rows deep-equal, including
+    every `Map` (compare via `[...map.entries()]`).
+28. Permuting the input rows yields a deep-equal layout.
+29. No `Date`/`Math.random` reachable: assert stability with a frozen clock is
+    unnecessary — instead assert case 27 twice with `Math.random` stubbed to a
+    throwing spy.
+
+*Integration with fixtures*
+
+30. A realistic 15-row fixture (mixed orientations, one failed row, two
+    unknowns, one loop) produces a graph satisfying L1–L4 and every clearance
+    assertion.
+
+---
+
+## 5. Work packages
+
+Three packages. **WP1 and WP2 are independent and touch disjoint files, so they
+run in parallel.** WP3 needs both.
+
+```
+WP1 ─┐
+     ├─> WP3
+WP2 ─┘
+```
+
+### WP1 — Export the strip's geometry and hop filter
+
+**Files (exclusive):** `src/utils/tracerouteStrip.ts`,
+`src/utils/tracerouteStrip.test.ts`
+
+**Scope:** §3.1 and §4.1. Add `export` to the listed declarations, widen
+`RawHop.snr` to optional, add the banner paragraph and the `@internal` notes,
+add the new test block.
+
+**Acceptance:**
+- `npx tsc --noEmit` clean.
+- All 50 existing `tracerouteStrip.test.ts` cases pass **unchanged** — no test
+  edited, no expectation moved.
+- The six new cases in §4.1 pass.
+- `git diff` contains no change to any function body in `tracerouteStrip.ts`
+  other than the `RawHop` interface line. A reviewer must be able to confirm
+  "export-only" by reading the diff.
+- `npm run lint:ci` shows no in-repo `FAIL`.
+
+### WP2 — Aggregation module
+
+**Files (exclusive):** `src/utils/tracerouteAggregate.ts`,
+`src/utils/tracerouteAggregate.test.ts`
+
+**Scope:** §3.2 and §4.2. Implements D1–D4, D9, and the aggregation half of
+D11.
+
+**Dependency note:** WP2 does **not** import from `tracerouteStrip.ts`. It
+would like `filterHops`, but WP1 may not have landed. Implement against
+`isValidRouteNode` + `BROADCAST_ADDR` from `tracerouteSegments.ts` behind a
+local `filterLegHops` helper with the identical policy, and leave a
+`// TODO(WP3): replace with filterHops from tracerouteStrip once WP1 lands`
+marker. **WP3 performs that swap and deletes the local helper** — this is the
+one duplication the phase tolerates, and it exists only so the two packages can
+run at the same time. If WP1 has already merged when WP2 starts, import
+`filterHops` directly and skip the marker.
+
+**Acceptance:**
+- All 44 cases in §4.2 pass.
+- `npx tsc --noEmit` clean; no `any`; strict mode.
+- No import from React, an API module, a DB module, or `tracerouteStrip.ts`
+  (unless WP1 landed first).
+- Case 38 (row-permutation invariance) passes — this is the package's headline
+  property.
+- `npm run lint:ci` shows no in-repo `FAIL`.
+
+### WP3 — Union layout module
+
+**Files (exclusive):** `src/utils/tracerouteUnionLayout.ts`,
+`src/utils/tracerouteUnionLayout.test.ts`
+**Files touched for the WP2 swap:** `src/utils/tracerouteAggregate.ts` (delete
+the local hop filter, import `filterHops`).
+
+**Depends on:** WP1 (the exports) and WP2 (the aggregate types).
+
+**Scope:** §3.3 and §4.3. Implements D5–D8, D10, and the layout half of D11.
+
+**Acceptance:**
+- All 30 cases in §4.3 pass.
+- `layoutTracerouteUnion` contains **no** copy of a formula that
+  `tracerouteStrip.ts` exports. Reviewer check: the module's only geometry
+  arithmetic is the centre/width/height formulas of §3.3 step 2; every radius,
+  floor, and routing call is an import.
+- Case 12 (same-column vertical edge) passes — it is the case a naive port of
+  `layoutTracerouteStrip` gets wrong.
+- Case 15 (glyph clearance on a column-spanning edge) passes.
+- `tracerouteAggregate.ts` no longer defines a local hop filter.
+- Full Vitest suite green (`success: true` in the JSON reporter, not just a
+  green summary line — see CLAUDE.md).
+- `npx tsc --noEmit` clean; no `any`.
+- `npm run lint:ci` shows no in-repo `FAIL`.
+
+### Phase exit
+
+Typecheck clean, full suite green, `lint:ci` clean, three modules exported and
+tested, **no UI or behavior change shipped**. The orchestrator records D1–D11 in
+`STATISTICAL_ROUTE_EPIC.md` and ticks Phase 1.

--- a/docs/internal/dev-notes/STATISTICAL_ROUTE_EPIC.md
+++ b/docs/internal/dev-notes/STATISTICAL_ROUTE_EPIC.md
@@ -43,7 +43,7 @@ relays are the most frequent and reliable on the path.
 ## Phases
 
 ### Phase 1 — Aggregation core + union-graph layout engine
-- [ ] Complete
+- [x] Complete (2026-07-30)
 
 Pure utilities, no visible product change:
 - Aggregation: given `DbTraceroute[]` pair history + the two endpoint nodeNums,
@@ -59,6 +59,22 @@ Pure utilities, no visible product change:
 
 **Exit criteria:** typecheck + full suite green; pure modules exported and tested;
 no UI/behavior change shipped; spec decisions recorded in this doc.
+
+**Phase 1 record (2026-07-30):**
+- Shipped `src/utils/tracerouteAggregate.ts` (counting model, 44 tests) and
+  `src/utils/tracerouteUnionLayout.ts` (cells+pixels, 30 tests);
+  `tracerouteStrip.ts` got export-only changes (+6 tests) so both layouts share
+  one set of geometry helpers. Full design: `SR_PHASE1_SPEC.md` decisions D1–D11.
+- Key decisions: anon hops merge by hop depth (`u:<depth>`); once-per-traceroute
+  counting so shares stay in (0,1]; lower-median column assignment with endpoints
+  pinned; alternating row offsets make the dominant path a straight line; edges
+  branch on column (not row) to avoid the vertical-chord divide-by-zero; opacity
+  floor `MIN_STAT_OPACITY = 0.28`; `UnionStripGraph` extends the strip types with
+  `mode: 'statistical'`.
+- Phase 2 seam: `buildStatisticalStrip(rows, localNodeNum, peerNodeNum, opts?)`.
+- Deviation from spec §5: work packages ran sequentially (WP1→WP2→WP3) instead of
+  WP1∥WP2, so WP2 imported `filterHops` directly and the tolerated temporary
+  hop-filter duplication never existed.
 
 ### Phase 2 — UI integration
 - [ ] Complete

--- a/docs/internal/dev-notes/STATISTICAL_ROUTE_EPIC.md
+++ b/docs/internal/dev-notes/STATISTICAL_ROUTE_EPIC.md
@@ -1,0 +1,86 @@
+# Statistical Route Visualization — Epic Plan
+
+**Status:** In progress (started 2026-07-30)
+**Orchestrator:** Epic harness session
+**Related:** TRACEROUTE_STRIP_INTERACTIVITY_EPIC.md (PRs #4424/#4427/#4429/#4430), TRACEROUTE_VISUAL_STRIP_SPEC.md (#4381)
+
+## Goal
+
+For a Meshtastic source, many traceroutes accumulate for the same fixed node pair
+(local node ↔ conversation partner). In addition to showing each individual route,
+add a **"Statistical route"** view: a merged union graph of all historical routes
+for the pair, where each node glyph's and edge's opacity maps to how often that
+node/adjacency occurred across the history. The user can then see at a glance which
+relays are the most frequent and reliable on the path.
+
+## Interview decisions
+
+| Question | Decision |
+|----------|----------|
+| Surface | New "Statistical" entry in the existing `TracerouteParticipationPicker` dropdown in the Node Details box (Messages tab). Map overlays unchanged. |
+| Data window | All stored pair history (per-pair retention already caps rows). No time filter, no window UI. |
+| Pair scope | Only traceroutes whose endpoints are the local node and the selected conversation node, either direction — via the existing `GET /api/traceroutes/history/:from/:to` (bidirectional, source-scoped, `requirePermission('traceroute','read')`). Relay-only participation entries stay individually pickable but do NOT feed the aggregate. |
+| Direction counting | **Combined undirected.** An adjacency counts whenever the two nodes were adjacent in any leg (forward or return) of any traceroute. The statistical strip renders a single neutral lane — no forward/return split, no dashed return styling. |
+| Encoding | Opacity by occurrence share, plus hover tooltip percentages ("seen in 12 of 15 routes (80%)"). No permanent numeric labels, no stroke-width scaling. |
+| Phasing | Two phases, each its own merged PR. |
+
+## Standing constraints (from CLAUDE.md / survey)
+
+- Aggregation is a pure frontend/util concern; **no schema change, no new endpoint** —
+  `/history/:from/:to` already returns full pair history with `route`/`routeBack` JSON.
+- Rows with no parseable `route` AND no parseable `routeBack` (failed traceroutes) are
+  excluded from the aggregate, matching the map's skip rule.
+- Reuse `tracerouteSegments.ts` parsers (`parseHopArray`, `isValidRouteNode`,
+  `BROADCAST_ADDR` handling) — do not re-implement route parsing.
+- Layout work extends `src/utils/tracerouteStrip.ts` conventions (pure, deterministic,
+  no Date.now/random); rendering extends `TracerouteStrip.tsx` + CSS module.
+- Unknown hops (`BROADCAST_ADDR`) are position-anonymous; the union graph must not
+  merge distinct unknown hops across traceroutes into one node blindly — architect
+  decides the identity rule and documents it in the Phase 1 spec.
+- Apply an opacity floor (rare nodes/edges must stay visible/hoverable).
+- New UI strings go through i18n; icons via UiIcon; CSS module additions only.
+
+## Phases
+
+### Phase 1 — Aggregation core + union-graph layout engine
+- [ ] Complete
+
+Pure utilities, no visible product change:
+- Aggregation: given `DbTraceroute[]` pair history + the two endpoint nodeNums,
+  produce a union graph: nodes (nodeNum or anonymous-hop identity) and undirected
+  edges, each with occurrence count and share (count / total included traceroutes).
+- Layout: extend the strip layout engine (or a parallel pure module following its
+  conventions) to lay out a multi-path union graph between two fixed endpoints —
+  handling nodes that appear at different hop depths in different routes, and
+  reusing/extending the glyph-collision routing where applicable.
+- Exhaustive Vitest coverage in the standard suite: aggregation counting rules,
+  direction combining, failed-row exclusion, unknown-hop identity, layout
+  determinism/collision cases.
+
+**Exit criteria:** typecheck + full suite green; pure modules exported and tested;
+no UI/behavior change shipped; spec decisions recorded in this doc.
+
+### Phase 2 — UI integration
+- [ ] Complete
+
+- `TracerouteParticipationPicker`: add a "Statistical (N routes)" option, shown only
+  when the pair history has ≥ 2 aggregatable routes.
+- Fetch pair history via existing `ApiService.getTracerouteHistory` behind a TanStack
+  hook (mirroring `useNodeTraceroutes` conventions).
+- `TracerouteStrip`: statistical render mode — neutral single-lane edges, per-node and
+  per-edge opacity from occurrence share, hover tooltips with "seen in X of N routes
+  (P%)", keyboard/aria parity with the existing strip.
+- MessagesTab wiring: statistical pick interacts with the displayed-traceroute rules
+  (a statistical pick suppresses the single-route strip; new poll rows / partner
+  change reset per existing rules).
+- Copy links behavior in statistical mode: hidden (a statistical aggregate has no
+  single forward/return text form).
+- i18n strings, CSS module additions, component + MessagesTab tests.
+- Browser validation on the dev container (chrome-devtools), docs pass.
+
+**Exit criteria:** all Phase-2 UI behaviors verified in the live app; full suite +
+lint:ci green; docs updated; PR merged.
+
+## Deviations log
+
+(none yet)

--- a/src/utils/tracerouteAggregate.test.ts
+++ b/src/utils/tracerouteAggregate.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for `tracerouteAggregate.ts` (Statistical Route epic, Phase 1 WP2).
+ * §4.2 of `docs/internal/dev-notes/SR_PHASE1_SPEC.md`, cases 1-44.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildTracerouteUnion,
+  statOpacity,
+  REAL_NODE_ID_PREFIX,
+  UNKNOWN_HOP_ID_PREFIX,
+  MIN_STAT_OPACITY,
+  type AggregateTracerouteRow,
+} from './tracerouteAggregate';
+import { BROADCAST_ADDR } from './tracerouteSegments';
+
+const LOCAL = 100;
+const PEER = 200;
+
+/** Build a minimal row. `route`/`routeBack`/`snrBack` default to absent. */
+function row(overrides: Partial<AggregateTracerouteRow> = {}): AggregateTracerouteRow {
+  return {
+    fromNodeNum: LOCAL,
+    toNodeNum: PEER,
+    ...overrides,
+  };
+}
+
+const n = (nodeNum: number): string => `${REAL_NODE_ID_PREFIX}:${nodeNum}`;
+const u = (depth: number): string => `${UNKNOWN_HOP_ID_PREFIX}:${depth}`;
+
+describe('tracerouteAggregate — counting rules', () => {
+  it('1. node counted once per row when it appears in both legs of that row', () => {
+    // forward L,A,P ; return P,A,L — A appears in both legs of the same row.
+    const rows = [row({ route: JSON.stringify([300]), routeBack: JSON.stringify([300]), snrBack: '[1]' })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeA = union.nodes.find((x) => x.id === n(300));
+    expect(nodeA?.count).toBe(1);
+  });
+
+  it('2. node counted once per row when it appears twice in one leg (a loop)', () => {
+    // forward L,A,B,A,P — A appears twice in the single forward leg.
+    const rows = [row({ route: JSON.stringify([300, 400, 300]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeA = union.nodes.find((x) => x.id === n(300));
+    expect(nodeA?.count).toBe(1);
+  });
+
+  it('3. edge counted once per row when the pair is adjacent in both legs', () => {
+    // forward L,A,B,P ; return P,B,A,L — A-B adjacent in both legs of one row.
+    const rows = [
+      row({ route: JSON.stringify([300, 400]), routeBack: JSON.stringify([400, 300]), snrBack: '[1,1]' }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const edgeAB = union.edges.find((e) => e.aId === n(300) && e.bId === n(400));
+    expect(edgeAB?.count).toBe(1);
+  });
+
+  it('4. edge counted once per row when the pair is adjacent twice in one leg', () => {
+    // forward L,A,B,A,P — (A,B) and (B,A) both undirected-A-B.
+    const rows = [row({ route: JSON.stringify([300, 400, 300]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const edgeAB = union.edges.find(
+      (e) => (e.aId === n(300) && e.bId === n(400)) || (e.aId === n(400) && e.bId === n(300)),
+    );
+    expect(edgeAB?.count).toBe(1);
+  });
+
+  it('5. A→B in one row and B→A in another produce one edge with count 2', () => {
+    const rows = [
+      row({ route: JSON.stringify([300, 400]) }), // L,A,B,P
+      row({ route: JSON.stringify([400, 300]) }), // L,B,A,P
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const edgesAB = union.edges.filter(
+      (e) => (e.aId === n(300) && e.bId === n(400)) || (e.aId === n(400) && e.bId === n(300)),
+    );
+    expect(edgesAB.length).toBe(1);
+    expect(edgesAB[0].count).toBe(2);
+  });
+
+  it('6. endpoints have count === totalRoutes and share === 1', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }),
+      row({ route: JSON.stringify([400]) }),
+      row({ route: JSON.stringify([]) }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const local = union.nodes.find((x) => x.id === n(LOCAL));
+    const peer = union.nodes.find((x) => x.id === n(PEER));
+    expect(local?.count).toBe(union.totalRoutes);
+    expect(local?.share).toBe(1);
+    expect(peer?.count).toBe(union.totalRoutes);
+    expect(peer?.share).toBe(1);
+  });
+
+  it('7. share equals count / totalRoutes for every node and edge', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }),
+      row({ route: JSON.stringify([]) }),
+      row({ route: JSON.stringify([]) }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    for (const nd of union.nodes) expect(nd.share).toBeCloseTo(nd.count / union.totalRoutes, 10);
+    for (const e of union.edges) expect(e.share).toBeCloseTo(e.count / union.totalRoutes, 10);
+  });
+
+  it('8. self-adjacency (sequence[k] === sequence[k+1]) emits no edge', () => {
+    // A repeated back-to-back can only arise via the reserved-node drop
+    // collapsing two survivors into adjacent identical ids is not directly
+    // constructible from a route array (identical consecutive node numbers
+    // ARE possible in raw route data), so use route [300, 300].
+    const rows = [row({ route: JSON.stringify([300, 300]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const selfEdge = union.edges.find((e) => e.aId === n(300) && e.bId === n(300));
+    expect(selfEdge).toBeUndefined();
+  });
+});
+
+describe('tracerouteAggregate — direction and normalization', () => {
+  it('9. a row stored (peer, local) produces the same union as (local, peer)', () => {
+    const rowsForward = [row({ route: JSON.stringify([300]) })];
+    const rowsReverse = [row({ fromNodeNum: PEER, toNodeNum: LOCAL, route: JSON.stringify([300]) })];
+    const unionForward = buildTracerouteUnion(rowsForward, LOCAL, PEER);
+    const unionReverse = buildTracerouteUnion(rowsReverse, LOCAL, PEER);
+    expect(unionReverse.nodes).toEqual(unionForward.nodes);
+    expect(unionReverse.edges).toEqual(unionForward.edges);
+  });
+
+  it('10. a mixed history of both orientations merges into one graph, not two', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }),
+      row({ fromNodeNum: PEER, toNodeNum: LOCAL, route: JSON.stringify([300]) }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeA = union.nodes.filter((x) => x.id === n(300));
+    expect(nodeA.length).toBe(1);
+    expect(nodeA[0].count).toBe(2);
+    expect(union.totalRoutes).toBe(2);
+  });
+
+  it('11. the return leg is oriented local→peer, so its hop depths count from local', () => {
+    // routeBack [400, 500] means raw return sequence peer,400,500,local; after
+    // orientation (reverse, since it starts at peer not local) it becomes
+    // local,500,400,peer — so 500 is at depth 1 and 400 is at depth 2.
+    const rows = [row({ routeBack: JSON.stringify([400, 500]), snrBack: '[1,1,1]' })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const node500 = union.nodes.find((x) => x.id === n(500));
+    const node400 = union.nodes.find((x) => x.id === n(400));
+    expect(node500?.depthSamples).toEqual([1]);
+    expect(node400?.depthSamples).toEqual([2]);
+  });
+
+  it('12. localNodeNum === peerNodeNum returns an empty union', () => {
+    const union = buildTracerouteUnion([row({ fromNodeNum: LOCAL, toNodeNum: LOCAL })], LOCAL, LOCAL);
+    expect(union.isEmpty).toBe(true);
+    expect(union.totalRoutes).toBe(0);
+    expect(union.nodes).toEqual([]);
+    expect(union.edges).toEqual([]);
+  });
+
+  it('13. a row whose endpoints are neither local nor peer increments mismatchedRoutes', () => {
+    const rows = [row({ fromNodeNum: 900, toNodeNum: 901, route: JSON.stringify([]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    expect(union.mismatchedRoutes).toBe(1);
+    expect(union.totalRoutes).toBe(0);
+  });
+});
+
+describe('tracerouteAggregate — row exclusion', () => {
+  it('14. route: null, routeBack: null → excludedRoutes: 1, totalRoutes: 0', () => {
+    const union = buildTracerouteUnion([row({ route: null, routeBack: null })], LOCAL, PEER);
+    expect(union.excludedRoutes).toBe(1);
+    expect(union.totalRoutes).toBe(0);
+  });
+
+  it("15. route: 'null' and routeBack: '' → excluded (the string forms)", () => {
+    const union = buildTracerouteUnion([row({ route: 'null', routeBack: '' })], LOCAL, PEER);
+    expect(union.excludedRoutes).toBe(1);
+    expect(union.totalRoutes).toBe(0);
+  });
+
+  it('16. forward-only row is included', () => {
+    const union = buildTracerouteUnion([row({ route: JSON.stringify([300]) })], LOCAL, PEER);
+    expect(union.totalRoutes).toBe(1);
+    expect(union.excludedRoutes).toBe(0);
+  });
+
+  it('17. return-only row (empty routeBack, non-empty snrBack) is included and yields a direct local–peer edge', () => {
+    const union = buildTracerouteUnion([row({ routeBack: '[]', snrBack: '[-10]' })], LOCAL, PEER);
+    expect(union.totalRoutes).toBe(1);
+    const directEdge = union.edges.find((e) => e.aId === n(LOCAL) && e.bId === n(PEER));
+    expect(directEdge).toBeDefined();
+    expect(directEdge?.count).toBe(1);
+  });
+
+  it('18. a failed row mixed into a good history does not change any share', () => {
+    const goodOnly = buildTracerouteUnion(
+      [row({ route: JSON.stringify([300]) }), row({ route: JSON.stringify([300]) })],
+      LOCAL,
+      PEER,
+    );
+    const withFailed = buildTracerouteUnion(
+      [
+        row({ route: JSON.stringify([300]) }),
+        row({ route: null, routeBack: null }),
+        row({ route: JSON.stringify([300]) }),
+      ],
+      LOCAL,
+      PEER,
+    );
+    expect(withFailed.totalRoutes).toBe(goodOnly.totalRoutes);
+    expect(withFailed.excludedRoutes).toBe(1);
+    const nodeA = withFailed.nodes.find((x) => x.id === n(300));
+    const nodeAGood = goodOnly.nodes.find((x) => x.id === n(300));
+    expect(nodeA?.share).toBe(nodeAGood?.share);
+  });
+
+  it('19. malformed JSON (route: "{") parses to [] via parseHopArray; the row still counts as a direct forward leg', () => {
+    const union = buildTracerouteUnion([row({ route: '{' })], LOCAL, PEER);
+    expect(union.totalRoutes).toBe(1);
+    const directEdge = union.edges.find((e) => e.aId === n(LOCAL) && e.bId === n(PEER));
+    expect(directEdge).toBeDefined();
+  });
+});
+
+describe('tracerouteAggregate — unknown hops', () => {
+  it('20. two routes, each with one unknown at depth 1, merge to a single u:1 node with count 2', () => {
+    const rows = [
+      row({ route: JSON.stringify([BROADCAST_ADDR]) }),
+      row({ route: JSON.stringify([BROADCAST_ADDR]) }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const unknownNodes = union.nodes.filter((x) => x.isUnknown);
+    expect(unknownNodes.length).toBe(1);
+    expect(unknownNodes[0].id).toBe(u(1));
+    expect(unknownNodes[0].count).toBe(2);
+  });
+
+  it('21. unknowns at different depths stay distinct (u:1 and u:2)', () => {
+    const rows = [
+      row({ route: JSON.stringify([BROADCAST_ADDR]) }), // depth 1
+      row({ route: JSON.stringify([300, BROADCAST_ADDR]) }), // depth 2
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const unknownIds = union.nodes.filter((x) => x.isUnknown).map((x) => x.id);
+    expect(unknownIds).toEqual(expect.arrayContaining([u(1), u(2)]));
+    expect(unknownIds.length).toBe(2);
+  });
+
+  it('22. an unknown never merges with a real node at the same depth', () => {
+    const rows = [
+      row({ route: JSON.stringify([BROADCAST_ADDR]) }), // u:1
+      row({ route: JSON.stringify([300]) }), // n:300, also at depth 1
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const unknownNode = union.nodes.find((x) => x.id === u(1));
+    const realNode = union.nodes.find((x) => x.id === n(300));
+    expect(unknownNode).toBeDefined();
+    expect(realNode).toBeDefined();
+    expect(unknownNode?.count).toBe(1);
+    expect(realNode?.count).toBe(1);
+  });
+
+  it('23. unknownDepth is set exactly when isUnknown is true', () => {
+    const rows = [row({ route: JSON.stringify([300, BROADCAST_ADDR]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    for (const nd of union.nodes) {
+      if (nd.isUnknown) expect(nd.unknownDepth).not.toBeNull();
+      else expect(nd.unknownDepth).toBeNull();
+    }
+  });
+
+  it('24. an unknown in the forward leg and one at the same depth in the return leg of the same row merge and still count once', () => {
+    // forward: L, unknown(depth1), P — return: P, unknown(depth1 after orientation), L
+    const rows = [
+      row({
+        route: JSON.stringify([BROADCAST_ADDR]),
+        routeBack: JSON.stringify([BROADCAST_ADDR]),
+        snrBack: '[1,1]',
+      }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const unknownNodes = union.nodes.filter((x) => x.id === u(1));
+    expect(unknownNodes.length).toBe(1);
+    expect(unknownNodes[0].count).toBe(1);
+  });
+
+  it('25. nodeNum === BROADCAST_ADDR on every unknown node', () => {
+    const rows = [row({ route: JSON.stringify([BROADCAST_ADDR]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    for (const nd of union.nodes.filter((x) => x.isUnknown)) {
+      expect(nd.nodeNum).toBe(BROADCAST_ADDR);
+    }
+  });
+});
+
+describe('tracerouteAggregate — hop filtering (delegated, asserted once)', () => {
+  it('26. a reserved intermediate (nodeNum: 2) is dropped from the union', () => {
+    const rows = [row({ route: JSON.stringify([2, 300]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const reservedNode = union.nodes.find((x) => x.nodeNum === 2);
+    expect(reservedNode).toBeUndefined();
+    const nodeA = union.nodes.find((x) => x.id === n(300));
+    expect(nodeA).toBeDefined();
+  });
+
+  it('27. reserved values at the endpoints are kept (endpoints are never filtered)', () => {
+    // Use a reserved local endpoint value (2) and confirm it survives as a
+    // node — filterHops never filters index 0 / last index.
+    const union = buildTracerouteUnion([row({ fromNodeNum: 2, toNodeNum: PEER, route: '[]' })], 2, PEER);
+    const localNode = union.nodes.find((x) => x.id === n(2));
+    expect(localNode).toBeDefined();
+    expect(localNode?.isEndpoint).toBe(true);
+  });
+});
+
+describe('tracerouteAggregate — degenerate and structural', () => {
+  it('28. empty rows → isEmpty: true, totalRoutes: 0, no nodes, no edges', () => {
+    const union = buildTracerouteUnion([], LOCAL, PEER);
+    expect(union.isEmpty).toBe(true);
+    expect(union.totalRoutes).toBe(0);
+    expect(union.nodes).toEqual([]);
+    expect(union.edges).toEqual([]);
+  });
+
+  it('29. single route → every share is 1, node count is path length', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    expect(union.nodes.length).toBe(4); // local, 300, 400, peer
+    for (const nd of union.nodes) expect(nd.share).toBe(1);
+  });
+
+  it('30. two disjoint routes (no shared intermediates) → union contains both paths, each intermediate at share 0.5, endpoints at 1', () => {
+    const rows = [row({ route: JSON.stringify([300]) }), row({ route: JSON.stringify([400]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeA = union.nodes.find((x) => x.id === n(300));
+    const nodeB = union.nodes.find((x) => x.id === n(400));
+    const local = union.nodes.find((x) => x.id === n(LOCAL));
+    const peer = union.nodes.find((x) => x.id === n(PEER));
+    expect(nodeA?.share).toBe(0.5);
+    expect(nodeB?.share).toBe(0.5);
+    expect(local?.share).toBe(1);
+    expect(peer?.share).toBe(1);
+  });
+
+  it('31. two routes sharing a prefix → the shared prefix nodes carry the higher share, the diverging tails 0.5 each', () => {
+    const rows = [
+      row({ route: JSON.stringify([300, 400]) }),
+      row({ route: JSON.stringify([300, 500]) }),
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeShared = union.nodes.find((x) => x.id === n(300));
+    const nodeTail1 = union.nodes.find((x) => x.id === n(400));
+    const nodeTail2 = union.nodes.find((x) => x.id === n(500));
+    expect(nodeShared?.share).toBe(1);
+    expect(nodeTail1?.share).toBe(0.5);
+    expect(nodeTail2?.share).toBe(0.5);
+  });
+
+  it('32. a node visited at different depths in two routes yields depthSamples [d1, d2] sorted ascending', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }), // depth 1
+      row({ route: JSON.stringify([400, 300]) }), // depth 2
+    ];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeA = union.nodes.find((x) => x.id === n(300));
+    expect(nodeA?.depthSamples).toEqual([1, 2]);
+  });
+
+  it('33. depthSamples.length may exceed count (documented granularity)', () => {
+    // A appears in both legs of the same row: count 1, but two depth samples.
+    const rows = [row({ route: JSON.stringify([300]), routeBack: JSON.stringify([300]), snrBack: '[1]' })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const nodeA = union.nodes.find((x) => x.id === n(300));
+    expect(nodeA?.count).toBe(1);
+    expect(nodeA?.depthSamples.length).toBeGreaterThan(nodeA!.count);
+  });
+});
+
+describe('tracerouteAggregate — invariants and determinism', () => {
+  const fixtureRows: AggregateTracerouteRow[] = [
+    row({ route: JSON.stringify([300, 400]) }),
+    row({ fromNodeNum: PEER, toNodeNum: LOCAL, route: JSON.stringify([400, 500]) }),
+    row({ route: JSON.stringify([BROADCAST_ADDR, 300]) }),
+    row({ route: null, routeBack: null }), // excluded
+    row({ fromNodeNum: 900, toNodeNum: 901, route: '[]' }), // mismatched
+    row({ routeBack: JSON.stringify([500, 300]), snrBack: '[1,1,1]' }),
+  ];
+
+  it('34. U1: every share is in (0, 1]', () => {
+    const union = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    for (const nd of union.nodes) {
+      expect(nd.share).toBeGreaterThan(0);
+      expect(nd.share).toBeLessThanOrEqual(1);
+    }
+    for (const e of union.edges) {
+      expect(e.share).toBeGreaterThan(0);
+      expect(e.share).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('35. U3: node ids unique; edge ids unique', () => {
+    const union = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    expect(new Set(union.nodes.map((x) => x.id)).size).toBe(union.nodes.length);
+    expect(new Set(union.edges.map((x) => x.id)).size).toBe(union.edges.length);
+  });
+
+  it('36. U4: every edges aId/bId resolves to a node in nodes', () => {
+    const union = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    const ids = new Set(union.nodes.map((x) => x.id));
+    for (const e of union.edges) {
+      expect(ids.has(e.aId)).toBe(true);
+      expect(ids.has(e.bId)).toBe(true);
+    }
+  });
+
+  it('37. U5: aId < bId for every edge', () => {
+    const union = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    for (const e of union.edges) {
+      expect(e.aId < e.bId).toBe(true);
+    }
+  });
+
+  it('38. U6: permuting rows yields a deep-equal union graph', () => {
+    const permuted = [...fixtureRows].reverse();
+    const unionA = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    const unionB = buildTracerouteUnion(permuted, LOCAL, PEER);
+    expect(unionB).toEqual(unionA);
+  });
+
+  it('39. two calls with the same input yield deep-equal output', () => {
+    const unionA = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    const unionB = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    expect(unionB).toEqual(unionA);
+  });
+
+  it('40. node and edge arrays are sorted by id ascending', () => {
+    const union = buildTracerouteUnion(fixtureRows, LOCAL, PEER);
+    const nodeIds = union.nodes.map((x) => x.id);
+    const sortedNodeIds = [...nodeIds].sort();
+    expect(nodeIds).toEqual(sortedNodeIds);
+    const edgeIds = union.edges.map((x) => x.id);
+    const sortedEdgeIds = [...edgeIds].sort();
+    expect(edgeIds).toEqual(sortedEdgeIds);
+  });
+});
+
+describe('tracerouteAggregate — statOpacity', () => {
+  it('41. statOpacity(1) === 1', () => {
+    expect(statOpacity(1)).toBe(1);
+  });
+
+  it('42. statOpacity(0) and statOpacity(1/50) are both >= MIN_STAT_OPACITY', () => {
+    expect(statOpacity(0)).toBeGreaterThanOrEqual(MIN_STAT_OPACITY);
+    expect(statOpacity(1 / 50)).toBeGreaterThanOrEqual(MIN_STAT_OPACITY);
+    expect(statOpacity(0)).toBe(MIN_STAT_OPACITY);
+  });
+
+  it('43. statOpacity is monotone non-decreasing across a swept range', () => {
+    let prev = -Infinity;
+    for (let i = 0; i <= 20; i++) {
+      const share = i / 20;
+      const opacity = statOpacity(share);
+      expect(opacity).toBeGreaterThanOrEqual(prev);
+      prev = opacity;
+    }
+  });
+
+  it('44. out-of-range input (-1, 2) clamps to MIN_STAT_OPACITY / 1', () => {
+    expect(statOpacity(-1)).toBe(MIN_STAT_OPACITY);
+    expect(statOpacity(2)).toBe(1);
+  });
+});

--- a/src/utils/tracerouteAggregate.ts
+++ b/src/utils/tracerouteAggregate.ts
@@ -1,0 +1,404 @@
+/**
+ * Traceroute statistical union — pure counting model (Statistical Route epic,
+ * Phase 1 WP2).
+ *
+ * Pure, React-free, API-free, DB-free — safe to import from a node-environment
+ * test or from any presentation layer. This module answers a different
+ * question than `tracerouteStrip.ts`: given N traceroute rows between the
+ * SAME two endpoints, how often did each node and each adjacency appear? The
+ * output is a counting model (`TracerouteUnionGraph`), not a render model —
+ * undirected, SNR-free, with no column/row placement. `tracerouteUnionLayout.ts`
+ * (WP3) turns this into a `UnionStripGraph` for the strip renderer.
+ *
+ * See `docs/internal/dev-notes/SR_PHASE1_SPEC.md` §2 (design decisions
+ * D1–D4, D9, D11) and §3.2 for the full design. This file implements that
+ * section exactly.
+ *
+ * ONE parse path, reused verbatim, never re-derived:
+ *   - `parseHopArray`/`hasRouteData`/`hasReturnPath` from `tracerouteSegments.ts`
+ *     (the single home for traceroute JSON parsing).
+ *   - `filterHops` from `tracerouteStrip.ts` (§3.3 hop-filter policy: endpoints
+ *     never filtered, `BROADCAST_ADDR` kept and flagged `isUnknown`, other
+ *     invalid hops dropped).
+ *
+ * ORIENTATION (D1). The history endpoint is bidirectional, so a row's
+ * `fromNodeNum`/`toNodeNum` may be `(local, peer)` or `(peer, local)`, and a
+ * row's return leg always runs the opposite way from its forward leg. Both
+ * problems collapse into one rule: build each leg's hop sequence in its own
+ * traversal order, then reverse it if `sequence[0] !== localNodeNum`. Every
+ * leg starts and ends at the two endpoints (never filtered), so this always
+ * yields a sequence that starts at `localNodeNum` and ends at `peerNodeNum`.
+ *
+ * IDENTITY (D4). A real node's identity is `n:<nodeNum>` regardless of hop
+ * depth — two occurrences of the same physical node anywhere merge onto one
+ * `StatNode`. An unknown (`BROADCAST_ADDR`) hop's identity is `u:<depth>`,
+ * where `depth` is its index in the filtered, ORIENTED (local -> peer)
+ * sequence — merging unknown hops by depth, not by never merging them or by
+ * anchoring neighbours, is what keeps a large history's unknown-hop count
+ * from fragmenting into one useless node per traceroute (see D4's rejected
+ * alternatives).
+ *
+ * COUNTING (D3). A node counts once per INCLUDED ROW in which it appears in
+ * any leg — not once per occurrence, so a loop or a node shared by both legs
+ * of one row still counts once. An edge between A and B counts once per
+ * included row in which they were adjacent in any leg, undirected (the
+ * canonical key sorts the two node ids, so `A→B` and `B→A` are the same
+ * edge). Self-adjacency (`sequence[k] === sequence[k+1]`) never emits an
+ * edge — a self-loop has no renderable geometry in the strip.
+ *
+ * DETERMINISM (D11). One pass over rows; all running state lives in `Map`s
+ * keyed by string id. Output arrays are sorted by `id` with a plain `<`/`>`
+ * comparator (ids are unique, so the order is total); `depthSamples` is
+ * sorted ascending before it leaves the module. The union graph is invariant
+ * under permutation of the input rows: counts are sums, `depthSamples` is
+ * sorted, and the output arrays are id-sorted — nothing carries row order.
+ */
+
+import { parseHopArray, hasRouteData, hasReturnPath } from './tracerouteSegments';
+import { filterHops, type RawHop, type InternalLegHop } from './tracerouteStrip';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Real-node id prefix. A real node's identity is `n:<nodeNum>`, regardless
+ *  of the hop depth(s) it was observed at (D4). */
+export const REAL_NODE_ID_PREFIX = 'n';
+
+/** Unknown-hop id prefix. `BROADCAST_ADDR` hops are keyed `u:<depth>`, where
+ *  `depth` is the hop's index in the filtered, oriented (local -> peer)
+ *  sequence — a scoped relaxation of the single-route strip's I6 (D4). */
+export const UNKNOWN_HOP_ID_PREFIX = 'u';
+
+/** Minimum rendered opacity for a node or edge, whatever its share (D9). One
+ *  constant serves both nodes and edges so the two floors cannot drift apart. */
+export const MIN_STAT_OPACITY = 0.28;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Structural subset of a `/api/traceroutes/history/:from/:to` row. Matches
+ *  `DbTraceroute` (src/db/types.ts:197) and `TracerouteParticipationEntry`
+ *  (src/services/api.ts:48) in the fields it reads. */
+export interface AggregateTracerouteRow {
+  id?: number;
+  fromNodeNum: number;
+  toNodeNum: number;
+  route?: string | null;
+  routeBack?: string | null;
+  snrBack?: string | null;
+  timestamp?: number;
+}
+
+export interface StatNode {
+  /** `n:<nodeNum>` or `u:<depth>`. Unique within one union graph. */
+  id: string;
+  /** BROADCAST_ADDR for an unknown hop. */
+  nodeNum: number;
+  isUnknown: boolean;
+  /** The hop depth this identity is keyed on; null for real nodes (D4). */
+  unknownDepth: number | null;
+  isEndpoint: boolean;
+  /** Included rows containing this node in any leg. Never per-occurrence (D3). */
+  count: number;
+  /** count / totalRoutes, in (0, 1]. */
+  share: number;
+  /** One entry per (row, leg, occurrence), sorted ascending. NOT `count` —
+   *  this is the observation multiset the column algorithm medians (D5). */
+  depthSamples: number[];
+}
+
+export interface StatEdge {
+  /** `${aId}|${bId}` with aId < bId. */
+  id: string;
+  aId: string;
+  bId: string;
+  /** Included rows in which the two nodes were adjacent in any leg (D3). */
+  count: number;
+  share: number;
+}
+
+export interface TracerouteUnionGraph {
+  localNodeNum: number;
+  peerNodeNum: number;
+  /** Included rows — the denominator of every share. */
+  totalRoutes: number;
+  /** Rows with no parseable leg at all (failed traceroutes). */
+  excludedRoutes: number;
+  /** Rows whose endpoint pair was not {local, peer}. Expected 0. */
+  mismatchedRoutes: number;
+  /** Sorted by `id` ascending. */
+  nodes: StatNode[];
+  /** Sorted by `id` ascending. */
+  edges: StatEdge[];
+  isEmpty: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal shapes
+// ---------------------------------------------------------------------------
+
+/** One leg's hop sequence, already filtered and oriented local -> peer. */
+interface OrientedLeg {
+  ids: string[];
+  nodeNums: number[];
+  isUnknown: boolean[];
+}
+
+/** Mutable per-node running total, keyed by id. Flushed into `StatNode`s
+ *  (with `share` computed and `depthSamples` sorted) once `totalRoutes` is
+ *  final. */
+interface NodeAgg {
+  id: string;
+  nodeNum: number;
+  isUnknown: boolean;
+  unknownDepth: number | null;
+  isEndpoint: boolean;
+  count: number;
+  depthSamples: number[];
+}
+
+/** Mutable per-edge running total, keyed by the canonical `aId|bId`. */
+interface EdgeAgg {
+  id: string;
+  aId: string;
+  bId: string;
+  count: number;
+}
+
+function idFor(hop: InternalLegHop, depth: number): string {
+  return hop.isUnknown ? `${UNKNOWN_HOP_ID_PREFIX}:${depth}` : `${REAL_NODE_ID_PREFIX}:${hop.nodeNum}`;
+}
+
+/**
+ * Build one leg's filtered, oriented hop sequence, or `null` when the leg is
+ * absent for this row.
+ *
+ * `startNum`/`endNum` are the leg's own raw traversal endpoints (forward:
+ * `row.fromNodeNum` -> `row.toNodeNum`; return: `row.toNodeNum` ->
+ * `row.fromNodeNum`) — orientation is applied AFTER filtering, per D1, by
+ * reversing the filtered sequence when it doesn't already start at
+ * `localNodeNum`.
+ */
+function buildOrientedLeg(
+  startNum: number,
+  intermediates: number[],
+  endNum: number,
+  localNodeNum: number,
+): OrientedLeg {
+  const rawHops: RawHop[] = [
+    { nodeNum: startNum },
+    ...intermediates.map((nodeNum): RawHop => ({ nodeNum })),
+    { nodeNum: endNum },
+  ];
+  let filtered = filterHops(rawHops);
+  if (filtered.length > 0 && filtered[0].nodeNum !== localNodeNum) {
+    filtered = [...filtered].reverse();
+  }
+
+  const ids: string[] = [];
+  const nodeNums: number[] = [];
+  const isUnknown: boolean[] = [];
+  filtered.forEach((hop, depth) => {
+    ids.push(idFor(hop, depth));
+    nodeNums.push(hop.nodeNum);
+    isUnknown.push(hop.isUnknown);
+  });
+  return { ids, nodeNums, isUnknown };
+}
+
+/**
+ * Build 0, 1, or 2 oriented legs for one already-endpoint-matched row.
+ * `localNodeNum`/`peerNodeNum` are the union's fixed pair; `row.fromNodeNum`/
+ * `row.toNodeNum` may equal either order (D1).
+ */
+function orientedLegs(
+  row: AggregateTracerouteRow,
+  localNodeNum: number,
+): { legs: OrientedLeg[]; included: boolean } {
+  const hasForward = hasRouteData(row.route);
+  const routeBack = parseHopArray(row.routeBack);
+  const hasReturn = hasReturnPath(routeBack, row.snrBack);
+  const included = hasForward || hasReturn;
+  if (!included) return { legs: [], included: false };
+
+  const legs: OrientedLeg[] = [];
+  if (hasForward) {
+    const route = parseHopArray(row.route);
+    legs.push(buildOrientedLeg(row.fromNodeNum, route, row.toNodeNum, localNodeNum));
+  }
+  if (hasReturn) {
+    legs.push(buildOrientedLeg(row.toNodeNum, routeBack, row.fromNodeNum, localNodeNum));
+  }
+  return { legs, included: true };
+}
+
+/**
+ * Fold one leg's oriented sequence into the row-scoped node/edge id sets
+ * (D3's per-row dedup) and push every occurrence's depth onto the running
+ * `NodeAgg.depthSamples` (D5's observation multiset — NOT deduped per row).
+ */
+function foldLeg(
+  leg: OrientedLeg,
+  localNodeNum: number,
+  peerNodeNum: number,
+  nodeAgg: Map<string, NodeAgg>,
+  rowNodeIds: Set<string>,
+  rowEdgeKeys: Map<string, { aId: string; bId: string }>,
+): void {
+  for (let depth = 0; depth < leg.ids.length; depth++) {
+    const id = leg.ids[depth];
+    const nodeNum = leg.nodeNums[depth];
+    const isUnknown = leg.isUnknown[depth];
+    rowNodeIds.add(id);
+
+    let agg = nodeAgg.get(id);
+    if (!agg) {
+      agg = {
+        id,
+        nodeNum,
+        isUnknown,
+        unknownDepth: isUnknown ? depth : null,
+        isEndpoint: !isUnknown && (nodeNum === localNodeNum || nodeNum === peerNodeNum),
+        count: 0,
+        depthSamples: [],
+      };
+      nodeAgg.set(id, agg);
+    }
+    agg.depthSamples.push(depth);
+  }
+
+  for (let k = 1; k < leg.ids.length; k++) {
+    const a = leg.ids[k - 1];
+    const b = leg.ids[k];
+    if (a === b) continue; // self-adjacency: no renderable geometry (D3).
+    const aId = a < b ? a : b;
+    const bId = a < b ? b : a;
+    rowEdgeKeys.set(`${aId}|${bId}`, { aId, bId });
+  }
+}
+
+function compareById(a: { id: string }, b: { id: string }): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the statistical union graph for every traceroute row between
+ * `localNodeNum` and `peerNodeNum`. See the module banner for the counting,
+ * identity, orientation, and determinism rules; see §3.2 of the spec for the
+ * per-row algorithm this implements verbatim.
+ */
+export function buildTracerouteUnion(
+  rows: readonly AggregateTracerouteRow[],
+  localNodeNum: number,
+  peerNodeNum: number,
+): TracerouteUnionGraph {
+  if (localNodeNum === peerNodeNum) {
+    // A self-pair has no two-endpoint axis to lay out (D1).
+    return {
+      localNodeNum,
+      peerNodeNum,
+      totalRoutes: 0,
+      excludedRoutes: 0,
+      mismatchedRoutes: 0,
+      nodes: [],
+      edges: [],
+      isEmpty: true,
+    };
+  }
+
+  const nodeAgg = new Map<string, NodeAgg>();
+  const edgeAgg = new Map<string, EdgeAgg>();
+  let totalRoutes = 0;
+  let excludedRoutes = 0;
+  let mismatchedRoutes = 0;
+
+  for (const row of rows) {
+    const isForwardOrient = row.fromNodeNum === localNodeNum && row.toNodeNum === peerNodeNum;
+    const isReverseOrient = row.fromNodeNum === peerNodeNum && row.toNodeNum === localNodeNum;
+    if (!isForwardOrient && !isReverseOrient) {
+      mismatchedRoutes++;
+      continue;
+    }
+
+    const { legs, included } = orientedLegs(row, localNodeNum);
+    if (!included) {
+      excludedRoutes++;
+      continue;
+    }
+
+    totalRoutes++;
+    const rowNodeIds = new Set<string>();
+    const rowEdgeKeys = new Map<string, { aId: string; bId: string }>();
+    for (const leg of legs) {
+      foldLeg(leg, localNodeNum, peerNodeNum, nodeAgg, rowNodeIds, rowEdgeKeys);
+    }
+
+    for (const id of rowNodeIds) {
+      nodeAgg.get(id)!.count++;
+    }
+    for (const { aId, bId } of rowEdgeKeys.values()) {
+      const key = `${aId}|${bId}`;
+      let agg = edgeAgg.get(key);
+      if (!agg) {
+        agg = { id: key, aId, bId, count: 0 };
+        edgeAgg.set(key, agg);
+      }
+      agg.count++;
+    }
+  }
+
+  const nodes: StatNode[] = Array.from(nodeAgg.values())
+    .map((agg): StatNode => ({
+      id: agg.id,
+      nodeNum: agg.nodeNum,
+      isUnknown: agg.isUnknown,
+      unknownDepth: agg.unknownDepth,
+      isEndpoint: agg.isEndpoint,
+      count: agg.count,
+      share: totalRoutes > 0 ? agg.count / totalRoutes : 0,
+      depthSamples: [...agg.depthSamples].sort((a, b) => a - b),
+    }))
+    .sort(compareById);
+
+  const edges: StatEdge[] = Array.from(edgeAgg.values())
+    .map((agg): StatEdge => ({
+      id: agg.id,
+      aId: agg.aId,
+      bId: agg.bId,
+      count: agg.count,
+      share: totalRoutes > 0 ? agg.count / totalRoutes : 0,
+    }))
+    .sort(compareById);
+
+  return {
+    localNodeNum,
+    peerNodeNum,
+    totalRoutes,
+    excludedRoutes,
+    mismatchedRoutes,
+    nodes,
+    edges,
+    isEmpty: totalRoutes === 0,
+  };
+}
+
+/** `round3(x) = Math.round(x * 1000) / 1000` — keeps float noise out of
+ *  deep-equality assertions (D9). */
+function round3(x: number): number {
+  return Math.round(x * 1000) / 1000;
+}
+
+/**
+ * Linear ramp from `MIN_STAT_OPACITY` at `share -> 0` to `1` at `share = 1`,
+ * rounded to three decimals. Clamps out-of-range input (D9).
+ */
+export function statOpacity(share: number): number {
+  const clamped = Math.min(1, Math.max(0, share));
+  return round3(MIN_STAT_OPACITY + (1 - MIN_STAT_OPACITY) * clamped);
+}

--- a/src/utils/tracerouteStrip.test.ts
+++ b/src/utils/tracerouteStrip.test.ts
@@ -11,12 +11,21 @@ import {
   buildStripGraphFromLegs,
   layoutTracerouteStrip,
   BROADCAST_ADDR,
+  filterHops,
+  DEFAULT_LAYOUT_OPTIONS,
+  minBand,
+  minRowHeight,
+  labelOffset,
+  edgeClearance,
+  labelClearRadius,
+  routeAroundGlyphs,
   type TracerouteStripInput,
   type TracerouteStripGraph,
   type StripLayoutOptions,
   type StripLane,
   type StripLeg,
   type StripPoint,
+  type RawHop,
 } from './tracerouteStrip';
 
 // Reusable "real" node numbers — small distinct integers that are never
@@ -1439,5 +1448,99 @@ describe('layoutTracerouteStrip — edge/label glyph collision avoidance (#4428)
         }
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Statistical Route epic, Phase 1, WP1 (docs/internal/dev-notes/
+// SR_PHASE1_SPEC.md §3.1/§4.1): tracerouteStrip.ts's private geometry and
+// hop-filter internals are now exported `@internal` for tracerouteUnionLayout
+// .ts / tracerouteAggregate.ts to reuse. This block asserts those exports
+// behave exactly as the (still-private, still-tested-above) implementation
+// always has — export-only, no logic changes. The 50 pre-existing cases above
+// remain the real behavioral coverage for this module.
+// ---------------------------------------------------------------------------
+describe('exported internals (statistical route Phase 1)', () => {
+  it('filterHops keeps both endpoints even when their node numbers are reserved', () => {
+    const hops: RawHop[] = [
+      { nodeNum: 2, snr: undefined }, // reserved endpoint
+      { nodeNum: 100, snr: 5 },
+      { nodeNum: 3, snr: 6 }, // reserved endpoint
+    ];
+    const result = filterHops(hops);
+    expect(result).toEqual([
+      { nodeNum: 2, snr: undefined, isUnknown: false },
+      { nodeNum: 100, snr: 5, isUnknown: false },
+      { nodeNum: 3, snr: 6, isUnknown: false },
+    ]);
+  });
+
+  it('filterHops keeps BROADCAST_ADDR intermediates and flags isUnknown', () => {
+    const hops: RawHop[] = [
+      { nodeNum: 100, snr: undefined },
+      { nodeNum: BROADCAST_ADDR, snr: 7 },
+      { nodeNum: 200, snr: 8 },
+    ];
+    const result = filterHops(hops);
+    expect(result).toEqual([
+      { nodeNum: 100, snr: undefined, isUnknown: false },
+      { nodeNum: BROADCAST_ADDR, snr: 7, isUnknown: true },
+      { nodeNum: 200, snr: 8, isUnknown: false },
+    ]);
+  });
+
+  it("filterHops drops invalid intermediates and does not re-index survivors' SNR samples", () => {
+    const hops: RawHop[] = [
+      { nodeNum: 100, snr: undefined },
+      { nodeNum: 2, snr: 11 }, // reserved, intermediate -> dropped
+      { nodeNum: 150, snr: 22 },
+      { nodeNum: 200, snr: 33 },
+    ];
+    const result = filterHops(hops);
+    // The dropped hop's snr (11) disappears with it; the survivor keeps its
+    // OWN paired snr (22) rather than inheriting/shifting into the gap.
+    expect(result).toEqual([
+      { nodeNum: 100, snr: undefined, isUnknown: false },
+      { nodeNum: 150, snr: 22, isUnknown: false },
+      { nodeNum: 200, snr: 33, isUnknown: false },
+    ]);
+  });
+
+  it('filterHops accepts a RawHop with snr omitted', () => {
+    const hops: RawHop[] = [
+      { nodeNum: 100 },
+      { nodeNum: 150 },
+      { nodeNum: 200 },
+    ];
+    const result = filterHops(hops);
+    expect(result).toEqual([
+      { nodeNum: 100, snr: undefined, isUnknown: false },
+      { nodeNum: 150, snr: undefined, isUnknown: false },
+      { nodeNum: 200, snr: undefined, isUnknown: false },
+    ]);
+  });
+
+  it('minBand/minRowHeight/labelOffset/edgeClearance/labelClearRadius return the documented values for DEFAULT_LAYOUT_OPTIONS', () => {
+    // nodeHalfHeight = (glyphSize + NODE_NAME_GAP + nameHeight) / 2
+    //                = (32 + 2 + 14) / 2 = 24
+    // labelOffset     = nodeHalfHeight + LABEL_HALF_HEIGHT + LABEL_CLEARANCE
+    //                = 24 + 8 + 4 = 36
+    expect(labelOffset(DEFAULT_LAYOUT_OPTIONS)).toBe(36);
+    // minBand = labelOffset + LABEL_HALF_HEIGHT = 36 + 8 = 44
+    expect(minBand(DEFAULT_LAYOUT_OPTIONS)).toBe(44);
+    // minRowHeight = 2 * labelOffset = 72
+    expect(minRowHeight(DEFAULT_LAYOUT_OPTIONS)).toBe(72);
+    // edgeClearance = glyphSize / 2 + EDGE_RIM_MARGIN + LANE_OFFSET
+    //               = 16 + 3 + 5 = 24
+    expect(edgeClearance(DEFAULT_LAYOUT_OPTIONS)).toBe(24);
+    // labelClearRadius = glyphSize / 2 + LABEL_HALF_HEIGHT + LABEL_CLEARANCE
+    //                  = 16 + 8 + 4 = 28
+    expect(labelClearRadius(DEFAULT_LAYOUT_OPTIONS)).toBe(28);
+  });
+
+  it('routeAroundGlyphs returns the input path unchanged when obstacles is empty', () => {
+    const path: StripPoint[] = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
+    const result = routeAroundGlyphs(path, [], edgeClearance(DEFAULT_LAYOUT_OPTIONS), { x: 0, y: -1 });
+    expect(result).toEqual(path);
   });
 });

--- a/src/utils/tracerouteStrip.ts
+++ b/src/utils/tracerouteStrip.ts
@@ -44,6 +44,12 @@
  * keyed on `lane`, not `row`, because `row` is derived/dense and would
  * otherwise make ids unstable as lane occupancy changes; `layout.centers`
  * keys off `id`, so that stability matters.
+ *
+ * This module is also the geometry and hop-filter home for the statistical
+ * union layout (Statistical Route epic, Phase 1): several internals below
+ * are exported `@internal` for `tracerouteUnionLayout.ts` /
+ * `tracerouteAggregate.ts` to reuse verbatim, so the two layouts cannot
+ * drift apart on shared arithmetic.
  */
 
 import {
@@ -149,8 +155,9 @@ export interface TracerouteStripInput {
 
 /** One post-filter hop: a real node number to render, paired with its own
  *  arrival SNR sample (raw, dB x4; undefined = no sample) and whether it is
- *  the BROADCAST_ADDR placeholder. */
-interface InternalLegHop {
+ *  the BROADCAST_ADDR placeholder.
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export interface InternalLegHop {
   nodeNum: number;
   snr: number | undefined;
   isUnknown: boolean;
@@ -162,10 +169,13 @@ interface InternalLegInput {
   hops: InternalLegHop[];
 }
 
-/** One raw hop, paired with its arrival SNR, before validity filtering. */
-interface RawHop {
+/** One raw hop, paired with its arrival SNR, before validity filtering.
+ *  `snr` widened to optional so `tracerouteAggregate.ts` can pass
+ *  `{ nodeNum }` without a meaningless `snr: undefined`.
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export interface RawHop {
   nodeNum: number;
-  snr: number | undefined;
+  snr?: number;
 }
 
 /**
@@ -173,8 +183,9 @@ interface RawHop {
  * Index 0 and the last index are endpoints (`fromNodeNum`/`toNodeNum`) and
  * are never filtered, even if they happen to be invalid/reserved values —
  * they are real device node numbers, not raw route placeholders.
+ * @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts.
  */
-function filterHops(hops: RawHop[]): InternalLegHop[] {
+export function filterHops(hops: RawHop[]): InternalLegHop[] {
   const result: InternalLegHop[] = [];
   const lastIndex = hops.length - 1;
   for (let i = 0; i < hops.length; i++) {
@@ -607,7 +618,8 @@ export interface StripLayoutOptions {
   bottomBand: number;
 }
 
-const DEFAULT_LAYOUT_OPTIONS: StripLayoutOptions = {
+/** @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export const DEFAULT_LAYOUT_OPTIONS: StripLayoutOptions = {
   colWidth: 64,
   rowHeight: 76, // was 56 before the spine model — see §3.5.2 C3.
   glyphSize: 32,
@@ -636,7 +648,8 @@ export interface StripLayout {
   labelAnchors: Map<string, StripPoint>;
 }
 
-function pullToward(from: StripPoint, to: StripPoint, dist: number): StripPoint {
+/** @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export function pullToward(from: StripPoint, to: StripPoint, dist: number): StripPoint {
   const dx = to.x - from.x;
   const dy = to.y - from.y;
   const d = Math.hypot(dx, dy) || 1;
@@ -675,13 +688,15 @@ function nodeHalfHeight(o: StripLayoutOptions): number {
  *  symmetric, since the glyph above and the short name below both sit
  *  `nodeHalfHeight` from center), guaranteeing the label's far edge clears
  *  the node's near edge by at least `LABEL_CLEARANCE`. */
-function labelOffset(o: StripLayoutOptions): number {
+/** @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export function labelOffset(o: StripLayoutOptions): number {
   return nodeHalfHeight(o) + LABEL_HALF_HEIGHT + LABEL_CLEARANCE;
 }
 
 /** Minimum topBand/bottomBand that keeps a label's OWN far edge inside the
- *  canvas once it sits `labelOffset` away from the outermost row's center. */
-function minBand(o: StripLayoutOptions): number {
+ *  canvas once it sits `labelOffset` away from the outermost row's center.
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export function minBand(o: StripLayoutOptions): number {
   return labelOffset(o) + LABEL_HALF_HEIGHT;
 }
 
@@ -690,8 +705,9 @@ function minBand(o: StripLayoutOptions): number {
  *  margin (`rowHeight - labelOffset >= labelOffset`); a crossing edge's
  *  label sits at the gap midpoint, `rowHeight / 2` from each endpoint row,
  *  which needs the same floor. Below this floor a forward label on the
- *  spine row could land inside the raised row above it. */
-function minRowHeight(o: StripLayoutOptions): number {
+ *  spine row could land inside the raised row above it.
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export function minRowHeight(o: StripLayoutOptions): number {
   return 2 * labelOffset(o);
 }
 
@@ -728,8 +744,9 @@ const LANE_OFFSET = 5;
  * `labelOffset`'s sign already follows). "Up" is defined as `y <= 0`: for a
  * same-row (horizontal) chord this is straight up the screen, matching the
  * forward-label-above / return-label-below convention already in place.
+ * @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts.
  */
-function canonicalPerpendicular(a: StripPoint, b: StripPoint): StripPoint {
+export function canonicalPerpendicular(a: StripPoint, b: StripPoint): StripPoint {
   let dx = b.x - a.x;
   let dy = b.y - a.y;
   if (dx < 0 || (dx === 0 && dy < 0)) {
@@ -756,8 +773,9 @@ function canonicalPerpendicular(a: StripPoint, b: StripPoint): StripPoint {
 
 /** Rim margin between a glyph's edge and where an edge line starts/ends —
  *  the historical inline `+3` in `pullIn`, named because `edgeClearance`
- *  reuses it (#4428). */
-const EDGE_RIM_MARGIN = 3;
+ *  reuses it (#4428).
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export const EDGE_RIM_MARGIN = 3;
 
 /** How far past a clearance circle a detour bend is placed. A bend exactly
  *  ON the circle's rim would let its two adjacent segments graze back
@@ -784,14 +802,16 @@ const BEND_MARGIN = LABEL_CLEARANCE;
  *  Degraded looks, never a hang or crash. */
 const VERTEX_PUSH_PASSES = 4;
 
-/** Numeric slack for "already clear" comparisons. */
-const GEOM_EPS = 1e-6;
+/** Numeric slack for "already clear" comparisons.
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export const GEOM_EPS = 1e-6;
 
 /** Radius around an UNRELATED node's center that no edge segment may enter
  *  (#4428): the same rim the edge's own endpoints respect (`pullIn` =
  *  glyphSize/2 + EDGE_RIM_MARGIN) plus one LANE_OFFSET, so both legs'
- *  lane-translated parallels still clear the glyph by the full rim margin. */
-function edgeClearance(o: StripLayoutOptions): number {
+ *  lane-translated parallels still clear the glyph by the full rim margin.
+ *  @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export function edgeClearance(o: StripLayoutOptions): number {
   return o.glyphSize / 2 + EDGE_RIM_MARGIN + LANE_OFFSET;
 }
 
@@ -831,8 +851,9 @@ function closestPointOnSegment(
  *
  * The result is still a plain polyline (the strip renders `<polyline>`),
  * just with 0+ extra bend points.
+ * @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts.
  */
-function routeAroundGlyphs(
+export function routeAroundGlyphs(
   path: StripPoint[],
   obstacles: StripPoint[],
   clearance: number,
@@ -927,7 +948,8 @@ function routeAroundGlyphs(
  *  modeled — the C1 row-band rule (`labelOffset`) already keeps anchors
  *  vertically clear of every node footprint; this radius only guards the
  *  horizontal pick/nudge in `pickLabelX`. */
-function labelClearRadius(o: StripLayoutOptions): number {
+/** @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts. */
+export function labelClearRadius(o: StripLayoutOptions): number {
   return o.glyphSize / 2 + LABEL_HALF_HEIGHT + LABEL_CLEARANCE;
 }
 
@@ -940,8 +962,9 @@ function labelClearRadius(o: StripLayoutOptions): number {
  * horizontally clear of each offender in turn — horizontal ONLY, so the
  * forward-above/return-below lane semantics and the C1 row-band invariant
  * survive untouched.
+ * @internal exported for tracerouteUnionLayout.ts / tracerouteAggregate.ts.
  */
-function pickLabelX(
+export function pickLabelX(
   path: StripPoint[],
   anchorY: number,
   glyphCenters: StripPoint[],

--- a/src/utils/tracerouteUnionLayout.test.ts
+++ b/src/utils/tracerouteUnionLayout.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Tests for `tracerouteUnionLayout.ts` (Statistical Route epic, Phase 1 WP3).
+ * §4.3 of `docs/internal/dev-notes/SR_PHASE1_SPEC.md`, cases 1-30.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildUnionStripGraph,
+  layoutTracerouteUnion,
+  buildStatisticalStrip,
+} from './tracerouteUnionLayout';
+import { buildTracerouteUnion, statOpacity, type AggregateTracerouteRow } from './tracerouteAggregate';
+import {
+  DEFAULT_LAYOUT_OPTIONS,
+  minBand,
+  minRowHeight,
+  labelOffset,
+  edgeClearance,
+  GEOM_EPS,
+  type StripPoint,
+} from './tracerouteStrip';
+import { BROADCAST_ADDR } from './tracerouteSegments';
+
+const LOCAL = 100;
+const PEER = 200;
+
+/** Build a minimal row. `route`/`routeBack`/`snrBack` default to absent. */
+function row(overrides: Partial<AggregateTracerouteRow> = {}): AggregateTracerouteRow {
+  return {
+    fromNodeNum: LOCAL,
+    toNodeNum: PEER,
+    ...overrides,
+  };
+}
+
+const n = (nodeNum: number): string => `n:${nodeNum}`;
+
+/** Shorthand: rows -> a UnionStripGraph, skipping the pixel layout. */
+function buildGraph(rows: AggregateTracerouteRow[]) {
+  return buildUnionStripGraph(buildTracerouteUnion(rows, LOCAL, PEER));
+}
+
+/** Closest distance from point `p` to the segment `a`->`b`. Independent
+ *  reimplementation for test verification — not a copy of anything the
+ *  module under test imports or exports. */
+function pointToSegmentDistance(p: StripPoint, a: StripPoint, b: StripPoint): number {
+  const abx = b.x - a.x;
+  const aby = b.y - a.y;
+  const len2 = abx * abx + aby * aby;
+  if (len2 < 1e-9) return Math.hypot(p.x - a.x, p.y - a.y);
+  const t = Math.max(0, Math.min(1, ((p.x - a.x) * abx + (p.y - a.y) * aby) / len2));
+  const cx = a.x + t * abx;
+  const cy = a.y + t * aby;
+  return Math.hypot(p.x - cx, p.y - cy);
+}
+
+/** Minimum distance from any obstacle centre to any point on any segment of `path`. */
+function minDistanceToObstacles(path: StripPoint[], obstacles: StripPoint[]): number {
+  let min = Infinity;
+  for (let i = 0; i < path.length - 1; i++) {
+    for (const o of obstacles) {
+      min = Math.min(min, pointToSegmentDistance(o, path[i], path[i + 1]));
+    }
+  }
+  return min;
+}
+
+describe('tracerouteUnionLayout — columns', () => {
+  it('1. local at column 0, peer at column columns - 1', () => {
+    const graph = buildGraph([row({ route: JSON.stringify([300]) })]);
+    const local = graph.nodes.find((nd) => nd.id === n(LOCAL));
+    const peer = graph.nodes.find((nd) => nd.id === n(PEER));
+    expect(local?.col).toBe(0);
+    expect(peer?.col).toBe(graph.columns - 1);
+  });
+
+  it('2. columns 0 and columns - 1 hold exactly one node each', () => {
+    const graph = buildGraph([row({ route: JSON.stringify([300]) }), row({ route: JSON.stringify([400]) })]);
+    expect(graph.nodes.filter((nd) => nd.col === 0).length).toBe(1);
+    expect(graph.nodes.filter((nd) => nd.col === graph.columns - 1).length).toBe(1);
+  });
+
+  it('3. a node at depth 1 in one route and depth 3 in another gets the lower median (column derived from key 1)', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }), // 300 at depth 1
+      row({ route: JSON.stringify([400, 500, 300]) }), // 300 at depth 3
+    ];
+    const graph = buildGraph(rows);
+    const node300 = graph.nodes.find((nd) => nd.id === n(300));
+    // depthSamples [1,3] -> lower median index 0 -> key 1 -> column 1.
+    expect(node300?.col).toBe(1);
+  });
+
+  it('4. even-count depthSamples take the LOWER median', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }), // 300 depth 1
+      row({ route: JSON.stringify([400, 300]) }), // 400 depth 1, 300 depth 2
+      row({ route: JSON.stringify([800, 900]) }), // 800 depth 1, 900 depth 2 — makes key 2 a distinct column
+    ];
+    const graph = buildGraph(rows);
+    // 300's depthSamples [1,2] -> lower median index 0 -> key 1. If the
+    // (wrong) upper median were used, 300 would land in the key-2 column.
+    const node300 = graph.nodes.find((nd) => nd.id === n(300));
+    const node400 = graph.nodes.find((nd) => nd.id === n(400));
+    expect(node300?.col).toBe(node400?.col);
+    expect(node300?.col).toBe(1);
+  });
+
+  it('5. direct-only history -> columns === 2, one row', () => {
+    const graph = buildGraph([row({ route: '[]' })]);
+    expect(graph.columns).toBe(2);
+    expect(graph.nodes.every((nd) => nd.row === 0)).toBe(true);
+  });
+
+  it('6. two routes of different length -> dense column indices, no gaps', () => {
+    const rows = [row({ route: JSON.stringify([300]) }), row({ route: JSON.stringify([400, 500, 600]) })];
+    const graph = buildGraph(rows);
+    const usedCols = new Set(graph.nodes.map((nd) => nd.col));
+    expect(usedCols.size).toBe(graph.columns);
+    for (let c = 0; c < graph.columns; c++) expect(usedCols.has(c)).toBe(true);
+  });
+});
+
+describe('tracerouteUnionLayout — rows', () => {
+  it('7. single repeated path -> every node on one row', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) }), row({ route: JSON.stringify([300, 400]) })];
+    const graph = buildGraph(rows);
+    expect(graph.nodes.every((nd) => nd.row === 0)).toBe(true);
+  });
+
+  it('8. two parallel paths -> two rows; the more frequent node sits on the dominant row', () => {
+    const rows = [
+      row({ route: JSON.stringify([300]) }),
+      row({ route: JSON.stringify([300]) }),
+      row({ route: JSON.stringify([300]) }),
+      row({ route: JSON.stringify([400]) }),
+    ];
+    const graph = buildGraph(rows);
+    const node300 = graph.nodes.find((nd) => nd.id === n(300))!; // share 0.75
+    const node400 = graph.nodes.find((nd) => nd.id === n(400))!; // share 0.25
+    const distinctRows = new Set(graph.nodes.map((nd) => nd.row));
+    expect(distinctRows.size).toBe(2);
+    expect(node300.row).not.toBe(node400.row);
+    // The dominant (higher-share) node shares the local/peer row — the
+    // "straight line" property (D6).
+    const local = graph.nodes.find((nd) => nd.id === n(LOCAL))!;
+    expect(node300.row).toBe(local.row);
+  });
+
+  it('9. the dominant node of every column shares one row index (D6 property)', () => {
+    // Two columns, each a 3-way fan with strictly descending shares —
+    // (A1,B1) most frequent, then (A2,B2), then (A3,B3).
+    const rows = [
+      ...Array(3).fill(row({ route: JSON.stringify([301, 302]) })),
+      ...Array(2).fill(row({ route: JSON.stringify([303, 304]) })),
+      ...Array(1).fill(row({ route: JSON.stringify([305, 306]) })),
+    ];
+    const graph = buildGraph(rows);
+    const dominantCol1 = graph.nodes.find((nd) => nd.id === n(301))!; // highest share in its column
+    const dominantCol2 = graph.nodes.find((nd) => nd.id === n(302))!;
+    expect(dominantCol1.col).not.toBe(dominantCol2.col);
+    expect(dominantCol1.row).toBe(dominantCol2.row);
+  });
+
+  it('10. offsets alternate 0, +1, -1, +2, -2 for a five-node fan in one column', () => {
+    // Five distinct-depth-1 intermediates with strictly descending counts,
+    // so (share desc, id asc) order is unambiguous.
+    const rows: AggregateTracerouteRow[] = [];
+    const counts: [number, number][] = [
+      [701, 5],
+      [702, 4],
+      [703, 3],
+      [704, 2],
+      [705, 1],
+    ];
+    for (const [nodeNum, count] of counts) {
+      for (let i = 0; i < count; i++) rows.push(row({ route: JSON.stringify([nodeNum]) }));
+    }
+    const graph = buildGraph(rows);
+    const rowOf = (num: number): number => graph.nodes.find((nd) => nd.id === n(num))!.row;
+    const base = rowOf(701); // offset 0 — differences below match the offset table exactly.
+    expect(rowOf(702) - base).toBe(1);
+    expect(rowOf(703) - base).toBe(-1);
+    expect(rowOf(704) - base).toBe(2);
+    expect(rowOf(705) - base).toBe(-2);
+  });
+
+  it('11. no two nodes in one column share a row', () => {
+    const rows = [
+      ...Array(3).fill(row({ route: JSON.stringify([301, 302]) })),
+      ...Array(2).fill(row({ route: JSON.stringify([303, 304]) })),
+      ...Array(1).fill(row({ route: JSON.stringify([305, 306]) })),
+      row({ route: JSON.stringify([301, 700, 302]) }), // adds an extra depth-2 node sharing 302's column
+    ];
+    const graph = buildGraph(rows);
+    const byCol = new Map<number, number[]>();
+    for (const nd of graph.nodes) {
+      const arr = byCol.get(nd.col) ?? [];
+      arr.push(nd.row);
+      byCol.set(nd.col, arr);
+    }
+    for (const [, rowsInCol] of byCol) {
+      expect(new Set(rowsInCol).size).toBe(rowsInCol.length);
+    }
+  });
+});
+
+describe('tracerouteUnionLayout — edges and geometry', () => {
+  it('12. same-column adjacency renders a 2-point vertical path, both endpoints pulled in, neither point equal to a glyph centre (D7)', () => {
+    // route1 = L,300,400,P ; route2 = L,400,300,P — the spec's D7 example.
+    // Both 300 and 400 get depthSamples [1,2] -> lower median 1 -> same column.
+    const rows = [row({ route: JSON.stringify([300, 400]) }), row({ route: JSON.stringify([400, 300]) })];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const nodeA = graph.nodes.find((nd) => nd.id === n(300))!;
+    const nodeB = graph.nodes.find((nd) => nd.id === n(400))!;
+    expect(nodeA.col).toBe(nodeB.col);
+    expect(nodeA.row).not.toBe(nodeB.row);
+
+    const edge = graph.edges.find(
+      (e) => (e.aId === nodeA.id && e.bId === nodeB.id) || (e.aId === nodeB.id && e.bId === nodeA.id),
+    )!;
+    expect(edge).toBeDefined();
+    const path = layout.edgePaths.get(edge.id)!;
+    expect(path.length).toBe(2);
+
+    const centerA = layout.centers.get(nodeA.id)!;
+    const centerB = layout.centers.get(nodeB.id)!;
+    for (const p of path) {
+      expect(p).not.toEqual(centerA);
+      expect(p).not.toEqual(centerB);
+    }
+  });
+
+  it('13. same-row, different-column adjacency renders a 2-point path', () => {
+    // Single route: both 300 (col 1) and 400 (col 2) are the sole occupant
+    // of their column, so both share offset 0 -> the same row.
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const node300 = graph.nodes.find((nd) => nd.id === n(300))!;
+    const node400 = graph.nodes.find((nd) => nd.id === n(400))!;
+    expect(node300.col).not.toBe(node400.col);
+    expect(node300.row).toBe(node400.row);
+    const edge = graph.edges.find(
+      (e) => (e.aId === node300.id && e.bId === node400.id) || (e.aId === node400.id && e.bId === node300.id),
+    )!;
+    const path = layout.edgePaths.get(edge.id)!;
+    expect(path.length).toBe(2);
+  });
+
+  it('14. different-row, different-column adjacency renders a 3-point dog-leg with the elbow at the lower row', () => {
+    const rows = [
+      ...Array(2).fill(row({ route: JSON.stringify([300, 400]) })), // 400: share 2/3
+      row({ route: JSON.stringify([300, 500]) }), // 500: share 1/3, sits on the +1 row
+    ];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const node300 = graph.nodes.find((nd) => nd.id === n(300))!; // col 1, sole occupant -> row shared w/ local
+    const node500 = graph.nodes.find((nd) => nd.id === n(500))!; // col 2, lower share -> different row
+    expect(node300.col).not.toBe(node500.col);
+    expect(node300.row).not.toBe(node500.row);
+
+    const edge = graph.edges.find(
+      (e) => (e.aId === node300.id && e.bId === node500.id) || (e.aId === node500.id && e.bId === node300.id),
+    )!;
+    const path = layout.edgePaths.get(edge.id)!;
+    expect(path.length).toBe(3);
+    const c0 = layout.centers.get(node300.id)!;
+    const c1 = layout.centers.get(node500.id)!;
+    expect(path[1].y).toBeCloseTo(Math.max(c0.y, c1.y), 6);
+  });
+
+  it('15. an edge spanning non-adjacent columns bends around the intervening glyph (clearance)', () => {
+    // A long single-leg path establishes 3 intervening columns, all on row
+    // 0; a second, return-only row adds a direct local<->peer edge, which
+    // must detour around 300/400/500's glyphs sitting exactly on that line.
+    const rows = [
+      row({ route: JSON.stringify([300, 400, 500]) }),
+      row({ routeBack: '[]', snrBack: '[-10]' }),
+    ];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const local = graph.nodes.find((nd) => nd.id === n(LOCAL))!;
+    const peer = graph.nodes.find((nd) => nd.id === n(PEER))!;
+    expect(local.row).toBe(peer.row); // all-single-occupant columns -> one flat row
+
+    const directEdge = graph.edges.find(
+      (e) => (e.aId === local.id && e.bId === peer.id) || (e.aId === peer.id && e.bId === local.id),
+    )!;
+    expect(directEdge).toBeDefined();
+    const path = layout.edgePaths.get(directEdge.id)!;
+
+    const o = { ...DEFAULT_LAYOUT_OPTIONS };
+    const clearance = edgeClearance(o);
+    const obstacles = graph.nodes
+      .filter((nd) => nd.id !== local.id && nd.id !== peer.id)
+      .map((nd) => layout.centers.get(nd.id)!);
+    const min = minDistanceToObstacles(path, obstacles);
+    expect(min).toBeGreaterThanOrEqual(clearance - GEOM_EPS);
+  });
+
+  it('16. every graph.nodes id has a layout.centers entry (L1)', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    for (const nd of graph.nodes) expect(layout.centers.has(nd.id)).toBe(true);
+  });
+
+  it('17. width === columns * colWidth; height matches the floored band formula', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const o = { ...DEFAULT_LAYOUT_OPTIONS };
+    expect(layout.width).toBe(graph.columns * o.colWidth);
+    const topBand = Math.max(o.topBand, minBand(o));
+    const bottomBand = Math.max(o.bottomBand, minBand(o));
+    const rowHeight = Math.max(o.rowHeight, minRowHeight(o));
+    const maxRow = Math.max(...graph.nodes.map((nd) => nd.row));
+    expect(layout.height).toBe(topBand + (maxRow + 1) * rowHeight + bottomBand);
+  });
+
+  it('18. custom opts below the floors are raised to minBand / minRowHeight', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const { graph } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const tinyOpts = { topBand: 1, bottomBand: 1, rowHeight: 1 };
+    const layout = layoutTracerouteUnion(graph, tinyOpts);
+    const o = { ...DEFAULT_LAYOUT_OPTIONS, ...tinyOpts };
+    const topBand = Math.max(o.topBand, minBand(o));
+    const bottomBand = Math.max(o.bottomBand, minBand(o));
+    const rowHeight = Math.max(o.rowHeight, minRowHeight(o));
+    const maxRow = Math.max(...graph.nodes.map((nd) => nd.row));
+    expect(layout.height).toBe(topBand + (maxRow + 1) * rowHeight + bottomBand);
+    // Floors actually took effect: the raw (too-small) opts alone would give a smaller height.
+    expect(layout.height).toBeGreaterThan(tinyOpts.topBand + (maxRow + 1) * tinyOpts.rowHeight + tinyOpts.bottomBand);
+  });
+
+  it('19. every edgePaths entry has at least 2 points', () => {
+    const rows = [
+      row({ route: JSON.stringify([300, 400, 500]) }),
+      row({ routeBack: '[]', snrBack: '[-10]' }),
+    ];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    for (const e of graph.edges) {
+      const path = layout.edgePaths.get(e.id);
+      expect(path).toBeDefined();
+      expect(path!.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('20. every edge has a labelAnchors entry, and its y clears every node centre by at least labelOffset(o) on a same-row edge', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const { graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    const o = { ...DEFAULT_LAYOUT_OPTIONS };
+    const offset = labelOffset(o);
+    const nodeById = new Map(graph.nodes.map((nd) => [nd.id, nd]));
+    for (const e of graph.edges) {
+      const anchor = layout.labelAnchors.get(e.id);
+      expect(anchor).toBeDefined();
+      const fromNode = nodeById.get(e.fromId)!;
+      const toNode = nodeById.get(e.toId)!;
+      if (fromNode.row === toNode.row) {
+        for (const nd of graph.nodes) {
+          const c = layout.centers.get(nd.id)!;
+          expect(Math.abs(anchor!.y - c.y)).toBeGreaterThanOrEqual(offset - GEOM_EPS);
+        }
+      }
+    }
+  });
+});
+
+describe('tracerouteUnionLayout — graph shape', () => {
+  it('21. every node has lane: "spine", legs: [], shared: false', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const graph = buildGraph(rows);
+    for (const nd of graph.nodes) {
+      expect(nd.lane).toBe('spine');
+      expect(nd.legs).toEqual([]);
+      expect(nd.shared).toBe(false);
+    }
+  });
+
+  it('22. every edge has leg: "forward", snr: null, snrUnknown: false', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const graph = buildGraph(rows);
+    for (const e of graph.edges) {
+      expect(e.leg).toBe('forward');
+      expect(e.snr).toBeNull();
+      expect(e.snrUnknown).toBe(false);
+    }
+  });
+
+  it('23. mode === "statistical"; hasForward/hasReturn are false', () => {
+    const rows = [row({ route: JSON.stringify([300, 400]) })];
+    const graph = buildGraph(rows);
+    expect(graph.mode).toBe('statistical');
+    expect(graph.hasForward).toBe(false);
+    expect(graph.hasReturn).toBe(false);
+  });
+
+  it('24. opacity === statOpacity(share) on every node and edge', () => {
+    const rows = [
+      row({ route: JSON.stringify([300, 400]) }),
+      row({ route: JSON.stringify([300]) }),
+    ];
+    const graph = buildGraph(rows);
+    for (const nd of graph.nodes) expect(nd.opacity).toBe(statOpacity(nd.share));
+    for (const e of graph.edges) expect(e.opacity).toBe(statOpacity(e.share));
+  });
+
+  it('25. node ids are carried over verbatim from the aggregate', () => {
+    const rows = [row({ route: JSON.stringify([300, BROADCAST_ADDR]) })];
+    const union = buildTracerouteUnion(rows, LOCAL, PEER);
+    const graph = buildUnionStripGraph(union);
+    const unionIds = new Set(union.nodes.map((nd) => nd.id));
+    const graphIds = new Set(graph.nodes.map((nd) => nd.id));
+    expect(graphIds).toEqual(unionIds);
+    for (const nd of union.nodes) {
+      const gnd = graph.nodes.find((x) => x.id === nd.id)!;
+      expect(gnd.nodeNum).toBe(nd.nodeNum);
+      expect(gnd.isUnknown).toBe(nd.isUnknown);
+    }
+  });
+
+  it('26. empty union -> empty graph, columns: 0, width: 0, and a layout that does not throw', () => {
+    const graph = buildGraph([]);
+    expect(graph.isEmpty).toBe(true);
+    expect(graph.columns).toBe(0);
+    expect(graph.nodes).toEqual([]);
+    expect(graph.edges).toEqual([]);
+    expect(() => layoutTracerouteUnion(graph)).not.toThrow();
+    const layout = layoutTracerouteUnion(graph);
+    expect(layout.width).toBe(0);
+  });
+});
+
+describe('tracerouteUnionLayout — determinism', () => {
+  const fixtureRows: AggregateTracerouteRow[] = [
+    row({ route: JSON.stringify([300, 400]) }),
+    row({ fromNodeNum: PEER, toNodeNum: LOCAL, route: JSON.stringify([400, 500]) }),
+    row({ route: JSON.stringify([BROADCAST_ADDR, 300]) }),
+    row({ route: null, routeBack: null }), // excluded
+    row({ routeBack: JSON.stringify([500, 300]), snrBack: '[1,1,1]' }),
+  ];
+
+  it('27. two runs of buildStatisticalStrip on the same rows deep-equal, including every Map', () => {
+    const a = buildStatisticalStrip(fixtureRows, LOCAL, PEER);
+    const b = buildStatisticalStrip(fixtureRows, LOCAL, PEER);
+    expect(a.union).toEqual(b.union);
+    expect(a.graph).toEqual(b.graph);
+    expect(a.layout.width).toBe(b.layout.width);
+    expect(a.layout.height).toBe(b.layout.height);
+    expect([...a.layout.centers.entries()]).toEqual([...b.layout.centers.entries()]);
+    expect([...a.layout.edgePaths.entries()]).toEqual([...b.layout.edgePaths.entries()]);
+    expect([...a.layout.labelAnchors.entries()]).toEqual([...b.layout.labelAnchors.entries()]);
+  });
+
+  it('28. permuting the input rows yields a deep-equal layout', () => {
+    const permuted = [...fixtureRows].reverse();
+    const a = buildStatisticalStrip(fixtureRows, LOCAL, PEER);
+    const b = buildStatisticalStrip(permuted, LOCAL, PEER);
+    expect(a.graph).toEqual(b.graph);
+    expect([...a.layout.centers.entries()]).toEqual([...b.layout.centers.entries()]);
+    expect([...a.layout.edgePaths.entries()]).toEqual([...b.layout.edgePaths.entries()]);
+    expect([...a.layout.labelAnchors.entries()]).toEqual([...b.layout.labelAnchors.entries()]);
+  });
+
+  it('29. no Date/Math.random reachable — stubbing Math.random to throw does not break a repeat run', () => {
+    const spy = vi.spyOn(Math, 'random').mockImplementation(() => {
+      throw new Error('Math.random must not be called');
+    });
+    try {
+      const a = buildStatisticalStrip(fixtureRows, LOCAL, PEER);
+      const b = buildStatisticalStrip(fixtureRows, LOCAL, PEER);
+      expect(a.graph).toEqual(b.graph);
+      expect([...a.layout.centers.entries()]).toEqual([...b.layout.centers.entries()]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('tracerouteUnionLayout — integration with fixtures', () => {
+  it('30. a realistic 15-row fixture (mixed orientations, one failed row, two unknowns, one loop) produces a valid graph', () => {
+    const rows: AggregateTracerouteRow[] = [
+      row({ route: JSON.stringify([300]) }),
+      row({ route: JSON.stringify([300, 400]) }),
+      row({ fromNodeNum: PEER, toNodeNum: LOCAL, route: JSON.stringify([400, 300]) }), // reverse orientation
+      row({ route: JSON.stringify([500]) }),
+      row({ route: JSON.stringify([500, 600]) }),
+      row({ routeBack: JSON.stringify([700]), snrBack: '[1,1]' }), // return-only leg
+      row({ route: JSON.stringify([BROADCAST_ADDR]) }), // unknown at depth 1
+      row({ route: JSON.stringify([300, BROADCAST_ADDR]) }), // unknown at depth 2
+      row({ route: JSON.stringify([300, 300]) }), // loop: 300 twice in one leg
+      row({ route: null, routeBack: null }), // failed row -> excluded
+      row({ route: JSON.stringify([400]) }),
+      row({ route: JSON.stringify([600]) }),
+      row({ fromNodeNum: PEER, toNodeNum: LOCAL, route: JSON.stringify([600]) }), // reverse orientation
+      row({ route: JSON.stringify([300, 400, 500]) }),
+      row({ route: '[]' }), // direct only
+    ];
+    expect(rows.length).toBe(15);
+
+    const { union, graph, layout } = buildStatisticalStrip(rows, LOCAL, PEER);
+    expect(union.totalRoutes).toBe(14); // one excluded
+    expect(union.nodes.filter((nd) => nd.isUnknown).length).toBe(2); // u:1 and u:2
+
+    // L1: every node has a centre.
+    for (const nd of graph.nodes) expect(layout.centers.has(nd.id)).toBe(true);
+    // L2: every edge path has >= 2 points.
+    for (const e of graph.edges) expect(layout.edgePaths.get(e.id)!.length).toBeGreaterThanOrEqual(2);
+    // L3: every edge has a label anchor.
+    for (const e of graph.edges) expect(layout.labelAnchors.has(e.id)).toBe(true);
+    // L4: width/height match the documented formula.
+    const o = { ...DEFAULT_LAYOUT_OPTIONS };
+    expect(layout.width).toBe(graph.columns * o.colWidth);
+
+    // Every clearance assertion: no path (of any edge) passes closer than
+    // edgeClearance(o) - GEOM_EPS to any node it doesn't terminate at.
+    const clearance = edgeClearance(o);
+    for (const e of graph.edges) {
+      const path = layout.edgePaths.get(e.id)!;
+      const obstacles = graph.nodes
+        .filter((nd) => nd.id !== e.fromId && nd.id !== e.toId)
+        .map((nd) => layout.centers.get(nd.id)!);
+      expect(minDistanceToObstacles(path, obstacles)).toBeGreaterThanOrEqual(clearance - GEOM_EPS);
+    }
+  });
+});

--- a/src/utils/tracerouteUnionLayout.ts
+++ b/src/utils/tracerouteUnionLayout.ts
@@ -1,0 +1,380 @@
+/**
+ * Statistical union layout — turns a `TracerouteUnionGraph` (the counting
+ * model from `tracerouteAggregate.ts`) into cells (column/row) and then
+ * pixels, for the strip renderer (Statistical Route epic, Phase 1 WP3).
+ *
+ * Pure, React-free, API-free, DB-free — safe to import from a node-
+ * environment test or from any presentation layer.
+ *
+ * See `docs/internal/dev-notes/SR_PHASE1_SPEC.md` §2 (design decisions
+ * D5–D8, D10, D11) and §3.3 for the full design. This file implements that
+ * section exactly.
+ *
+ * TWO HALVES, TWO SOURCES OF TRUTH.
+ *   - `buildUnionStripGraph` (D5/D6) assigns columns and rows. This is the
+ *     hard part, and it has no analogue in `tracerouteStrip.ts` — the union
+ *     graph arrives with no cells at all, unlike a `TracerouteStripGraph`
+ *     whose spine builder already assigned `col`/`row`.
+ *   - `layoutTracerouteUnion` (D7/D8) turns cells into pixels. This is pure
+ *     reuse: every radius, floor, and routing call below is an IMPORT from
+ *     `tracerouteStrip.ts`, not a re-derivation — `pullToward`,
+ *     `canonicalPerpendicular`, `labelOffset`, `minBand`, `minRowHeight`,
+ *     `edgeClearance`, `labelClearRadius`, `routeAroundGlyphs`, `pickLabelX`,
+ *     `DEFAULT_LAYOUT_OPTIONS`, `EDGE_RIM_MARGIN` are all reused verbatim, so
+ *     the two layouts cannot drift apart on shared arithmetic. The only
+ *     local geometry arithmetic left is the centre/width/height formulas
+ *     (§3.3 step 2) and the two path-form shapes each edge picks between
+ *     (§3.3 step 3, D7) — neither is an exported helper of the strip module
+ *     either; `layoutTracerouteStrip` computes them inline too.
+ *
+ * COLUMN ASSIGNMENT (D5). Each intermediate node gets one column, keyed by
+ * the LOWER MEDIAN of its `depthSamples` (already sorted ascending by
+ * `buildTracerouteUnion`) — a single array index, so no separate sort is
+ * needed here. Distinct depth keys, sorted ascending, become dense column
+ * indices `1..distinctKeys.length`. The local endpoint is pinned to column
+ * `0`, alone; the peer endpoint is pinned to column `columns - 1`, alone.
+ *
+ * ROW ASSIGNMENT (D6). Within one column's node group, order by
+ * `(share desc, id asc)` and assign a signed offset by index:
+ * `0, +1, -1, +2, -2, …`. Offsets are then shifted GLOBALLY (across every
+ * column, not per column) so the smallest offset becomes row 0. Because
+ * index 0 in every group gets offset 0, the most frequent node in EVERY
+ * column lands on the same row — the union graph's counterpart to the
+ * single-route strip's spine, and it falls out of the arithmetic rather
+ * than needing its own pass.
+ *
+ * EDGE PATH FORM (D7). `layoutTracerouteStrip`'s row-crossing branch keys
+ * off ROW: same row -> 2-point, different row -> 3-point dog-leg with the
+ * elbow at `{ x: mid, y: max(y0, y1) }`. That elbow formula divides by a
+ * zero-length vector when the chord is perfectly VERTICAL — exactly what a
+ * same-column, different-row union edge is (two nodes sharing a
+ * `depthKey` are real data: `route1 = L,A,B,P` and `route2 = L,B,A,P` gives
+ * both A and B a lower median of 1). So this module branches on COLUMN, not
+ * row: same column -> 2-point (`pullToward` both ways, exactly the strip's
+ * same-row form); different column AND different row -> 3-point dog-leg
+ * (the strip's row-crossing form); otherwise (different column, same row)
+ * -> 2-point.
+ *
+ * NO LANE OFFSET, NO SNR, NO ARROWHEAD DIRECTION CLAIM (D8). The epic
+ * settled on combined-undirected edges in one neutral lane: no
+ * `LANE_OFFSET` translation (there is no competing leg to separate from),
+ * `snr`/`snrUnknown` are always `null`/`false`, and `leg` is pinned
+ * `'forward'` only because it is a required `StripEdge` field the
+ * renderer's solid-line CSS hook keys on — Phase 2 must branch on
+ * `graph.mode === 'statistical'` to suppress arrowheads/SNR labels, never
+ * read `leg` as a direction claim here.
+ *
+ * DETERMINISM (D11). `depthKey` is an index into a sorted array. Group
+ * order is sorted distinct integers, walked column-by-column (not via `Map`
+ * iteration order) so nothing depends on insertion order. Within-group
+ * order is `(share desc, id asc)` with unique `id`. Offsets come from an
+ * index. Geometry is arithmetic; `routeAroundGlyphs` is itself documented
+ * bounded and deterministic. So identical input gives deep-equal output,
+ * and — since `tracerouteAggregate.ts`'s output is permutation-invariant —
+ * so is this module's.
+ */
+
+import type {
+  StripLayout,
+  StripLayoutOptions,
+  StripNode,
+  StripEdge,
+  StripPoint,
+  TracerouteStripGraph,
+} from './tracerouteStrip';
+import {
+  DEFAULT_LAYOUT_OPTIONS,
+  EDGE_RIM_MARGIN,
+  pullToward,
+  canonicalPerpendicular,
+  labelOffset,
+  minBand,
+  minRowHeight,
+  edgeClearance,
+  labelClearRadius,
+  routeAroundGlyphs,
+  pickLabelX,
+} from './tracerouteStrip';
+import type { AggregateTracerouteRow, StatNode, TracerouteUnionGraph } from './tracerouteAggregate';
+import { statOpacity, buildTracerouteUnion } from './tracerouteAggregate';
+
+// ---------------------------------------------------------------------------
+// Public types (D10)
+// ---------------------------------------------------------------------------
+
+export interface UnionStripNode extends StripNode {
+  /** Included routes containing this node (`StatNode.count`, D3). */
+  count: number;
+  /** `count / totalRoutes` (D3). */
+  share: number;
+  /** `statOpacity(share)` — precomputed so the renderer maps nothing (D9). */
+  opacity: number;
+  /** True for the local/peer node this union was built between. */
+  isEndpoint: boolean;
+}
+
+export interface UnionStripEdge extends StripEdge {
+  aId: string;
+  bId: string;
+  /** Included routes in which the two nodes were adjacent (`StatEdge.count`, D3). */
+  count: number;
+  share: number;
+  opacity: number;
+}
+
+export interface UnionStripGraph extends TracerouteStripGraph {
+  /** Discriminant. Phase 2's renderer branches on this, never on `leg`. */
+  mode: 'statistical';
+  totalRoutes: number;
+  nodes: UnionStripNode[];
+  edges: UnionStripEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Column/row assignment (D5/D6)
+// ---------------------------------------------------------------------------
+
+/** Lower median of `node.depthSamples` (D5). `depthSamples` is already
+ *  sorted ascending by `buildTracerouteUnion` — this is a single array
+ *  index, no sort needed here. Only meaningful for an intermediate; an
+ *  endpoint's column is pinned directly and never consults this. */
+function depthKey(node: StatNode): number {
+  return node.depthSamples[Math.floor((node.depthSamples.length - 1) / 2)];
+}
+
+/** `(share desc, id asc)` — `id` is unique, so this is a total order (D6). */
+function compareForRowOrder(a: StatNode, b: StatNode): number {
+  if (a.share !== b.share) return b.share - a.share;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** Signed offset for a node's index within its column group's
+ *  `(share desc, id asc)` order: `0, +1, -1, +2, -2, …` (D6). */
+function offsetForIndex(i: number): number {
+  if (i === 0) return 0;
+  return i % 2 === 1 ? (i + 1) / 2 : -(i / 2);
+}
+
+/**
+ * Assign columns (D5), rows (D6), and ids, and attach counts/opacity. Pure.
+ * See the module banner for the full algorithm; this is §3.3's `buildUnionStripGraph`.
+ */
+export function buildUnionStripGraph(union: TracerouteUnionGraph): UnionStripGraph {
+  if (union.isEmpty) {
+    return {
+      mode: 'statistical',
+      totalRoutes: 0,
+      nodes: [],
+      edges: [],
+      columns: 0,
+      hasForward: false,
+      hasReturn: false,
+      isEmpty: true,
+    };
+  }
+
+  // --- Step 2 (D5): column assignment ---
+  // A row is only included (D2) when its two-endpoint axis is drawable, so
+  // both the local and peer StatNode are guaranteed present whenever
+  // `union.isEmpty` is false — every included row's oriented sequence starts
+  // at `localNodeNum` and ends at `peerNodeNum` (D1).
+  const localNode = union.nodes.find((nd) => nd.isEndpoint && nd.nodeNum === union.localNodeNum)!;
+  const peerNode = union.nodes.find((nd) => nd.isEndpoint && nd.nodeNum === union.peerNodeNum)!;
+  const intermediates = union.nodes.filter((nd) => nd.id !== localNode.id && nd.id !== peerNode.id);
+
+  const distinctKeys = Array.from(new Set(intermediates.map(depthKey))).sort((a, b) => a - b);
+  const colOfDepthKey = new Map<number, number>(distinctKeys.map((key, i) => [key, i + 1]));
+  const columns = 2 + distinctKeys.length;
+
+  const colOf = new Map<string, number>();
+  colOf.set(localNode.id, 0);
+  colOf.set(peerNode.id, columns - 1);
+  for (const nd of intermediates) colOf.set(nd.id, colOfDepthKey.get(depthKey(nd))!);
+
+  // --- Step 3 (D6): row assignment, per column group, then a global shift ---
+  // Walked by explicit column index (0..columns-1), not `Map` iteration
+  // order, so group processing order never depends on insertion order (D11).
+  const groups: StatNode[][] = Array.from({ length: columns }, () => []);
+  groups[0].push(localNode);
+  groups[columns - 1].push(peerNode);
+  for (const nd of intermediates) groups[colOf.get(nd.id)!].push(nd);
+
+  const offsetOf = new Map<string, number>();
+  for (const group of groups) {
+    const ordered = [...group].sort(compareForRowOrder);
+    ordered.forEach((nd, i) => offsetOf.set(nd.id, offsetForIndex(i)));
+  }
+  const minOffset = Math.min(...union.nodes.map((nd) => offsetOf.get(nd.id)!));
+  const rowOf = new Map<string, number>();
+  for (const nd of union.nodes) rowOf.set(nd.id, offsetOf.get(nd.id)! - minOffset);
+
+  // --- Step 4: emit UnionStripNodes, sorted (row asc, col asc) to match the
+  // strip's node-ordering contract ---
+  const nodes: UnionStripNode[] = union.nodes
+    .map(
+      (nd): UnionStripNode => ({
+        // D10: id is reused verbatim from the aggregate (n:… / u:…), not
+        // the strip's `${lane}-${col}-${nodeNum}` scheme — layout.centers
+        // keys off it, so Phase 2 can cross-reference the count model
+        // without a second map.
+        id: nd.id,
+        nodeNum: nd.nodeNum,
+        lane: 'spine',
+        row: rowOf.get(nd.id)!,
+        col: colOf.get(nd.id)!,
+        legs: [],
+        shared: false,
+        isUnknown: nd.isUnknown,
+        count: nd.count,
+        share: nd.share,
+        opacity: statOpacity(nd.share),
+        isEndpoint: nd.isEndpoint,
+      }),
+    )
+    .sort((a, b) => a.row - b.row || a.col - b.col);
+
+  // --- Step 5: emit UnionStripEdges. `union.edges` is already id-sorted
+  // (aId < bId, D11) — no re-sort needed. ---
+  const edges: UnionStripEdge[] = union.edges.map(
+    (e): UnionStripEdge => ({
+      id: `stat:${e.aId}|${e.bId}`,
+      leg: 'forward',
+      fromId: e.aId,
+      toId: e.bId,
+      snr: null,
+      snrUnknown: false,
+      aId: e.aId,
+      bId: e.bId,
+      count: e.count,
+      share: e.share,
+      opacity: statOpacity(e.share),
+    }),
+  );
+
+  return {
+    mode: 'statistical',
+    totalRoutes: union.totalRoutes,
+    nodes,
+    edges,
+    columns,
+    hasForward: false,
+    hasReturn: false,
+    isEmpty: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cells -> pixels (D7/D8), mirroring `layoutTracerouteStrip`
+// ---------------------------------------------------------------------------
+
+/**
+ * Cells -> pixels. Same arithmetic, floors, clearance, and glyph routing as
+ * `layoutTracerouteStrip`, via the helpers that module exports — see the
+ * module banner for why every radius/floor/routing call here is an import
+ * rather than a re-derivation.
+ */
+export function layoutTracerouteUnion(
+  graph: UnionStripGraph,
+  opts?: Partial<StripLayoutOptions>,
+): StripLayout {
+  const o: StripLayoutOptions = { ...DEFAULT_LAYOUT_OPTIONS, ...opts };
+  // Defensive floors, same as the strip: guarantee the label-clearance
+  // invariants even if a caller passes custom bands/rowHeight too small for
+  // its glyphSize/nameHeight.
+  const topBand = Math.max(o.topBand, minBand(o));
+  const bottomBand = Math.max(o.bottomBand, minBand(o));
+  const rowHeight = Math.max(o.rowHeight, minRowHeight(o));
+
+  // §3.3 step 2 — the one piece of geometry arithmetic this module owns:
+  // it has no exported-helper equivalent in tracerouteStrip.ts (that
+  // module inlines the identical formula in `layoutTracerouteStrip`).
+  const centers = new Map<string, StripPoint>();
+  let maxRow = 0;
+  for (const n of graph.nodes) {
+    maxRow = Math.max(maxRow, n.row);
+    centers.set(n.id, {
+      x: n.col * o.colWidth + o.colWidth / 2,
+      y: topBand + n.row * rowHeight + o.glyphSize / 2,
+    });
+  }
+
+  // An empty graph (columns 0, no nodes) gives width 0 and a one-row
+  // height, matching the strip's empty-graph shape.
+  const width = graph.columns * o.colWidth;
+  const height = topBand + (maxRow + 1) * rowHeight + bottomBand;
+
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n] as const));
+  const edgePaths = new Map<string, StripPoint[]>();
+  const labelAnchors = new Map<string, StripPoint>();
+  const pullIn = o.glyphSize / 2 + EDGE_RIM_MARGIN;
+  const clearance = edgeClearance(o);
+  const labelRadius = labelClearRadius(o);
+  const allGlyphCenters = graph.nodes.map((n) => centers.get(n.id)!);
+
+  for (const e of graph.edges) {
+    const c0 = centers.get(e.fromId);
+    const c1 = centers.get(e.toId);
+    const fromNode = nodeById.get(e.fromId);
+    const toNode = nodeById.get(e.toId);
+    if (!c0 || !c1 || !fromNode || !toNode) continue; // defensive; should not happen
+
+    // D7: branch on COLUMN, not row — see the module banner for why the
+    // strip's row-crossing elbow breaks on a same-column (vertical) chord.
+    const sameCol = fromNode.col === toNode.col;
+    const sameRow = fromNode.row === toNode.row;
+    let path: StripPoint[];
+    if (!sameCol && !sameRow) {
+      // Different column, different row: 3-point dog-leg, the strip's own
+      // row-crossing elbow shape (not an exported helper either).
+      const mid: StripPoint = { x: (c0.x + c1.x) / 2, y: Math.max(c0.y, c1.y) };
+      const start = pullToward(c0, mid, pullIn);
+      const end = pullToward(c1, mid, pullIn);
+      path = [start, mid, end];
+    } else {
+      // Same column (D7's vertical case), or same row/different column:
+      // both are the strip's same-row 2-point form.
+      const start = pullToward(c0, c1, pullIn);
+      const end = pullToward(c1, c0, pullIn);
+      path = [start, end];
+    }
+
+    // D8: no lane translation — there is no competing leg to separate from.
+
+    // #4428 glyph-collision routing, reused verbatim (D7/D8 add nothing to
+    // it): obstacles are every OTHER node's centre.
+    const obstacles: StripPoint[] = [];
+    for (const n of graph.nodes) {
+      if (n.id === e.fromId || n.id === e.toId) continue;
+      obstacles.push(centers.get(n.id)!);
+    }
+    // "Up" side; an arbitrary but fixed tie-break, used only when a pushed
+    // vertex lands exactly on a glyph centre.
+    const laneDir = canonicalPerpendicular(c0, c1);
+    path = routeAroundGlyphs(path, obstacles, clearance, laneDir);
+
+    edgePaths.set(e.id, path);
+
+    // §3.3 step 5: computed even though statistical mode renders no SNR
+    // label, so the return value is a complete StripLayout and Phase 2 gets
+    // a ready-made tooltip anchor. No forward/return sign here (D8) — the
+    // union graph has no leg semantics to pick "above" vs "below" from.
+    const anchorY = sameRow ? c0.y - labelOffset(o) : (c0.y + c1.y) / 2;
+    const anchorX = pickLabelX(path, anchorY, allGlyphCenters, labelRadius);
+    labelAnchors.set(e.id, { x: anchorX, y: anchorY });
+  }
+
+  return { width, height, centers, edgePaths, labelAnchors };
+}
+
+/** One-shot seam for Phase 2: rows -> counting model -> cells -> pixels. */
+export function buildStatisticalStrip(
+  rows: readonly AggregateTracerouteRow[],
+  localNodeNum: number,
+  peerNodeNum: number,
+  opts?: Partial<StripLayoutOptions>,
+): { union: TracerouteUnionGraph; graph: UnionStripGraph; layout: StripLayout } {
+  const union = buildTracerouteUnion(rows, localNodeNum, peerNodeNum);
+  const graph = buildUnionStripGraph(union);
+  const layout = layoutTracerouteUnion(graph, opts);
+  return { union, graph, layout };
+}


### PR DESCRIPTION
## Summary
Phase 1 of the Statistical Route Visualization epic (`docs/internal/dev-notes/STATISTICAL_ROUTE_EPIC.md`). Users often hold many traceroutes for the same node pair; the epic adds a "Statistical route" view that overlays all of them and maps opacity to how often each node and adjacency occurred, so the most reliable relays stand out at a glance. This PR ships the pure computation half — the counting model and the union-graph layout engine — with **no UI or behavior change**. Phase 2 wires it into the Node Details strip and its participation picker.

## Changes
- **`src/utils/tracerouteAggregate.ts` (new):** `buildTracerouteUnion(rows, local, peer)` folds bidirectional pair history into an undirected union graph — per-node/per-edge occurrence counts and shares, once-per-traceroute counting, failed-row exclusion matching the map's skip rule, anonymous hops merged by hop depth (`u:<depth>`), plus `statOpacity()` with a 0.28 floor. Reuses `parseHopArray`/`hasRouteData`/`hasReturnPath`/`filterHops` — no new parse path.
- **`src/utils/tracerouteUnionLayout.ts` (new):** `buildUnionStripGraph` assigns columns (lower-median hop depth, endpoints pinned) and rows (alternating offsets — the dominant path renders as one straight line); `layoutTracerouteUnion` turns cells into pixels reusing the strip's exported geometry helpers (incl. #4428 glyph-collision routing), branching edge shape on column to avoid the vertical-chord degenerate case. `buildStatisticalStrip` is the one-shot Phase 2 seam. Output types extend `StripNode`/`StripEdge`/`TracerouteStripGraph` with `mode: 'statistical'`.
- **`src/utils/tracerouteStrip.ts`:** export-only changes (15 internals now exported `@internal` for the union layout, so the two layouts share one set of geometry formulas) plus one type widening (`RawHop.snr` optional). No function body changed.
- **Docs:** epic plan (`STATISTICAL_ROUTE_EPIC.md`) + full Phase 1 spec (`SR_PHASE1_SPEC.md`, design decisions D1–D11).
- **Tests:** 44 aggregation cases (incl. row-permutation invariance), 30 layout cases (incl. same-column vertical edges and glyph-clearance assertions), 6 new strip-export cases; all 50 pre-existing strip tests pass unchanged.

## Issues Resolved
None (epic tracked via `STATISTICAL_ROUTE_EPIC.md`; Phase 2 follows).

## Documentation Updates
Internal dev-notes only (epic plan + phase spec). User-facing docs land with Phase 2's UI.

## Testing
- [x] Unit tests pass — full suite `success: true`, 12,843 passed / 0 failed (PG/MySQL suites skip locally as usual; no schema/DB change in this PR)
- [x] TypeScript compiles cleanly (`tsc --noEmit` and `tsconfig.server.json`)
- [x] `npm run lint:ci` in-repo gate clean
- [ ] Reviewer: confirm the `tracerouteStrip.ts` diff is export-only (every hunk is an `export` keyword or doc comment, except the `RawHop.snr?` line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9