### PR TITLE
fix(nodes): guard lastHeard against replayed position/telemetry packets

### DIFF
--- a/src/server/meshtasticManager.lastHeardReplayGuard.test.ts
+++ b/src/server/meshtasticManager.lastHeardReplayGuard.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for #4192 / #4445 — the replay guard (replayGuard.ts) was
+ * only wired into the generic packet upsert and NodeInfo handling. Position,
+ * telemetry, paxcounter, and Store & Forward heartbeat packets stamped
+ * `lastHeard: Date.now() / 1000` unconditionally, so a firmware-2.8 PhoneAPI
+ * replay of cached position/telemetry (old `rx_time`, per-node) still made an
+ * offline node look freshly heard even though the generic-packet path (and
+ * its per-transport `transportLastRf`/`transportLastUdp` stamps) correctly
+ * froze `lastHeard` at the true last-contact time — exactly the symptom
+ * reported in #4445 (lastHeard newer than both transport timestamps).
+ *
+ * These tests drive each fixed handler directly with a stale (`rxTime` >6h
+ * old) and a fresh packet, asserting `lastHeard` passed to `upsertNodeAsync`
+ * is `undefined` (preserved) for the stale case and a live timestamp for the
+ * fresh case.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUpsertNodeAsync = vi.fn().mockResolvedValue(undefined);
+const mockGetNode = vi.fn().mockResolvedValue(null);
+const mockInsertTelemetry = vi.fn().mockResolvedValue(undefined);
+const mockGetDirectMessages = vi.fn().mockResolvedValue([]);
+const mockGetMessage = vi.fn().mockResolvedValue(null);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNodeAsync: mockUpsertNodeAsync,
+    nodes: { getNode: mockGetNode, upsertNode: vi.fn(), getAllNodes: vi.fn().mockResolvedValue([]) },
+    telemetry: { insertTelemetry: mockInsertTelemetry },
+    messages: { getDirectMessages: mockGetDirectMessages, getMessage: mockGetMessage },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('MeshtasticManager - lastHeard replay guard coverage (#4192/#4445)', () => {
+  let manager: any;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const staleRxTime = nowSec - 24 * 60 * 60; // 24h old — well past the 6h threshold
+  const freshRxTime = nowSec - 30; // 30s old — clearly live
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetNode.mockResolvedValue(null);
+    mockGetDirectMessages.mockResolvedValue([]);
+    mockGetMessage.mockResolvedValue(null);
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+    vi.spyOn(manager, 'trackPKIEncryption').mockResolvedValue(undefined);
+  });
+
+  function lastHeardArg(): number | undefined {
+    expect(mockUpsertNodeAsync).toHaveBeenCalled();
+    const call = mockUpsertNodeAsync.mock.calls[mockUpsertNodeAsync.mock.calls.length - 1];
+    return call[0].lastHeard;
+  }
+
+  describe('processTelemetryMessageProtobuf', () => {
+    it('does not advance lastHeard for a stale/replayed telemetry packet', async () => {
+      const meshPacket = { from: 0x11111111, id: 1, rxTime: staleRxTime };
+      await manager.processTelemetryMessageProtobuf(meshPacket, {
+        deviceMetrics: { batteryLevel: 90 },
+      });
+
+      expect(lastHeardArg()).toBeUndefined();
+    });
+
+    it('advances lastHeard for a live telemetry packet', async () => {
+      const meshPacket = { from: 0x11111111, id: 2, rxTime: freshRxTime };
+      await manager.processTelemetryMessageProtobuf(meshPacket, {
+        deviceMetrics: { batteryLevel: 90 },
+      });
+
+      expect(lastHeardArg()).toBeCloseTo(nowSec, -1);
+    });
+  });
+
+  describe('processPaxcounterMessageProtobuf', () => {
+    it('does not advance lastHeard for a stale/replayed paxcounter packet', async () => {
+      const meshPacket = { from: 0x22222222, id: 3, rxTime: staleRxTime };
+      await manager.processPaxcounterMessageProtobuf(meshPacket, { wifi: 5, ble: 2 });
+
+      expect(lastHeardArg()).toBeUndefined();
+    });
+
+    it('advances lastHeard for a live paxcounter packet', async () => {
+      const meshPacket = { from: 0x22222222, id: 4, rxTime: freshRxTime };
+      await manager.processPaxcounterMessageProtobuf(meshPacket, { wifi: 5, ble: 2 });
+
+      expect(lastHeardArg()).toBeCloseTo(nowSec, -1);
+    });
+  });
+
+  describe('processStoreForwardMessage — ROUTER_HEARTBEAT', () => {
+    const ROUTER_HEARTBEAT = 2;
+
+    it('does not advance lastHeard for a stale/replayed S&F heartbeat', async () => {
+      const meshPacket = { from: 0x33333333, id: 5, rxTime: staleRxTime };
+      await manager.processStoreForwardMessage(meshPacket, {
+        rr: ROUTER_HEARTBEAT,
+        heartbeat: { period: 900, secondary: 0 },
+      });
+
+      expect(lastHeardArg()).toBeUndefined();
+    });
+
+    it('advances lastHeard for a live S&F heartbeat', async () => {
+      const meshPacket = { from: 0x33333333, id: 6, rxTime: freshRxTime };
+      await manager.processStoreForwardMessage(meshPacket, {
+        rr: ROUTER_HEARTBEAT,
+        heartbeat: { period: 900, secondary: 0 },
+      });
+
+      expect(lastHeardArg()).toBeCloseTo(nowSec, -1);
+    });
+  });
+
+  describe('processPositionMessageProtobuf', () => {
+    // latitudeI/longitudeI are degrees * 1e7 on the wire.
+    const position = { latitudeI: 407128000, longitudeI: -740060000, altitude: 10 };
+
+    it('does not advance lastHeard for a stale/replayed position packet', async () => {
+      const meshPacket = { from: 0x44444444, id: 7, rxTime: staleRxTime };
+      await manager.processPositionMessageProtobuf(meshPacket, position);
+
+      expect(lastHeardArg()).toBeUndefined();
+    });
+
+    it('advances lastHeard for a live position packet', async () => {
+      const meshPacket = { from: 0x44444444, id: 8, rxTime: freshRxTime };
+      await manager.processPositionMessageProtobuf(meshPacket, position);
+
+      expect(lastHeardArg()).toBeCloseTo(nowSec, -1);
+    });
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6669,7 +6669,7 @@ class MeshtasticManager implements ISourceManager {
             nodeNum: fromNum,
             nodeId: fromNodeId,
             isStoreForwardServer: true,
-            lastHeard: Date.now() / 1000,
+            lastHeard: this.lastHeardFor(meshPacket),
             updatedAt: Date.now(),
           }, this.sourceId);
           break;
@@ -6698,6 +6698,21 @@ class MeshtasticManager implements ISourceManager {
     } catch (error) {
       logger.error('❌ Error processing Store & Forward message:', error);
     }
+  }
+
+  /**
+   * Resolve `lastHeard` for a packet-derived node upsert, applying the replay
+   * guard (see replayGuard.ts) so a stale/replayed frame — e.g. firmware 2.8's
+   * PhoneAPI replaying cached NodeDB position/telemetry with an old `rx_time`,
+   * or a retained MQTT frame — can't advance a node's `lastHeard` past its
+   * true last-contact time (issue #4192/#4445). Every packet-derived
+   * `lastHeard` stamp outside the generic upsert path should go through this.
+   */
+  private lastHeardFor(meshPacket: { rxTime?: unknown }): number | undefined {
+    return resolveLastHeardSec(
+      meshPacket.rxTime != null ? Number(meshPacket.rxTime) : undefined,
+      Date.now(),
+    );
   }
 
   /**
@@ -6953,7 +6968,7 @@ class MeshtasticManager implements ISourceManager {
           const technicalData: any = {
             nodeNum: fromNum,
             nodeId: nodeId,
-            lastHeard: Date.now() / 1000,
+            lastHeard: this.lastHeardFor(meshPacket),
           };
           // -128 is the firmware "no SNR" sentinel; accept 0 dB (issue #3590).
           if (meshPacket.rxSnr != null && meshPacket.rxSnr !== -128) {
@@ -6970,8 +6985,9 @@ class MeshtasticManager implements ISourceManager {
             latitude: coords.latitude,
             longitude: coords.longitude,
             altitude: position.altitude,
-            // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-            lastHeard: Date.now() / 1000,
+            // Replay guard (see replayGuard.ts): omit lastHeard for replayed/retained
+            // frames so a stale position can't resurrect an offline node (#4192/#4445).
+            lastHeard: this.lastHeardFor(meshPacket),
             positionChannel: channelIndex,
             positionPrecisionBits: precisionBits,
             positionGpsAccuracy: gpsAccuracy,
@@ -7319,8 +7335,9 @@ class MeshtasticManager implements ISourceManager {
       const nodeData: any = {
         nodeNum: fromNum,
         nodeId: nodeId,
-        // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-        lastHeard: Date.now() / 1000
+        // Replay guard (see replayGuard.ts): omit lastHeard for replayed/retained
+        // frames so stale telemetry can't resurrect an offline node (#4192/#4445).
+        lastHeard: this.lastHeardFor(meshPacket)
       };
 
       // Only include SNR/RSSI if they have valid values
@@ -7479,8 +7496,9 @@ class MeshtasticManager implements ISourceManager {
       const nodeData: any = {
         nodeNum: fromNum,
         nodeId: nodeId,
-        // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-        lastHeard: Date.now() / 1000
+        // Replay guard (see replayGuard.ts): omit lastHeard for replayed/retained
+        // frames so stale paxcounter data can't resurrect an offline node (#4192/#4445).
+        lastHeard: this.lastHeardFor(meshPacket)
       };
 
       // Only include SNR/RSSI if they have valid values

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7101,10 +7101,7 @@ class MeshtasticManager implements ISourceManager {
         // Use server time for lastHeard — rxTime from the device clock is unreliable.
         // Replay guard (see replayGuard.ts): omit lastHeard for replayed/retained
         // frames so a stale NodeInfo can't resurrect an offline node.
-        lastHeard: resolveLastHeardSec(
-          meshPacket.rxTime != null ? Number(meshPacket.rxTime) : undefined,
-          Date.now(),
-        ),
+        lastHeard: this.lastHeardFor(meshPacket),
       };
 
       // Capture public key if present


### PR DESCRIPTION
## Summary

Fixes #4192. Closes #4445 as a duplicate reproduction with fresh packet-level evidence.

- The stale-replay guard (`src/server/utils/replayGuard.ts`, #3569) freezes `lastHeard` when a packet's `rx_time` is more than 6h stale, but it was only wired into two call sites in `meshtasticManager.ts`: the generic per-packet node upsert, and `processNodeInfoMessageProtobuf`.
- `processPositionMessageProtobuf`, `processTelemetryMessageProtobuf`, `processPaxcounterMessageProtobuf`, and the Store & Forward `ROUTER_HEARTBEAT` handler all stamped `lastHeard: Date.now() / 1000` **unconditionally**. These run in `processMeshPacket`'s portnum dispatch *after* the guarded generic upsert, so their unguarded write silently clobbered the correctly-frozen value.
- Net effect: a firmware-2.8 PhoneAPI replay of cached position/telemetry (old `rx_time`, synthesized on client reconnect) still resurrected offline nodes in the node list — exactly what #4192 described, and what #4445 reproduced with concrete evidence: `lastHeard` newer than both `transportLastRf` and `transportLastUdp` (which *do* go through the guarded path and were correctly frozen at the node's true last contact).
- Added a small `private lastHeardFor(meshPacket)` helper wrapping `resolveLastHeardSec` and applied it at the four previously-unguarded sites.
- Left `processTracerouteMessage`/`processNeighborInfoProtobuf` and the local-node / brand-new-node-creation `lastHeard` stamps untouched — those are live-event or first-write cases, not replay-resurrection cases.

## Test plan

- [x] New regression suite `src/server/meshtasticManager.lastHeardReplayGuard.test.ts` drives each fixed handler (position, telemetry, paxcounter, S&F heartbeat) with a stale (>6h old `rx_time`) and a fresh packet, asserting `lastHeard` is preserved vs. advanced.
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:ci` clean (no baseline growth)
- [x] Targeted suites pass: the new test file, `replayGuard.test.ts`, `meshtasticManager.test.ts`, `meshtasticManager.telemetryCanonical.test.ts`, `meshtasticManager.positionChannel.test.ts`, `meshtasticManager.airQualityParticles.test.ts`, `meshtasticManager.position-precision.test.ts`
- [ ] Full local Vitest suite was still running at push time; CI will cover it

---
_Generated by [Claude Code](https://claude.ai/code/session_0194ZLphbzLoEKRou9Z4niNm)_