### PR TITLE
Fix: purge position history also clears the global position estimate (#4450)

### DIFF
--- a/src/server/routes/messageRoutes.test.ts
+++ b/src/server/routes/messageRoutes.test.ts
@@ -95,6 +95,9 @@ describe('Message Deletion Routes', () => {
       },
     });
     (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(true);
+    // Global estimated-position purge (#4450) — defaults to "nothing to delete"; individual
+    // tests override to assert the phantom estimate is cleared alongside real telemetry.
+    (databaseService as any).deleteEstimatedPositionsByNodeNumsAsync = vi.fn().mockResolvedValue(0);
     // Set up traceroutes repo mock
     Object.defineProperty(databaseService, 'messages', {
       get: () => mockMessagesRepo,
@@ -583,6 +586,25 @@ describe('Message Deletion Routes', () => {
         expect.stringContaining('5'),
         expect.any(String)
       );
+    });
+
+    it('should also purge the node\'s global position estimate and fold it into deletedCount (#4450)', async () => {
+      // A node with zero real telemetry (purgePositionHistory finds nothing) can still
+      // carry a stale row in the global estimated_positions table (positionEstimationService).
+      // The purge endpoint must clear that too, or the UI reports "Purged 0" while the
+      // phantom map marker persists.
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      mockTelemetryRepo.purgePositionHistory.mockResolvedValue(0);
+      (databaseService as any).deleteEstimatedPositionsByNodeNumsAsync = vi.fn().mockResolvedValue(1);
+      vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
+
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/position-history')
+        .send({ sourceId: 'source-a' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('deletedCount', 1);
+      expect((databaseService as any).deleteEstimatedPositionsByNodeNumsAsync).toHaveBeenCalledWith([123456]);
     });
   });
 

--- a/src/server/routes/messageRoutes.test.ts
+++ b/src/server/routes/messageRoutes.test.ts
@@ -556,6 +556,21 @@ describe('Message Deletion Routes', () => {
       expect(response.body).toHaveProperty('deletedCount', 18);
       expect(response.body).toHaveProperty('message', 'Node position history purged successfully');
       expect(mockTelemetryRepo.purgePositionHistory).toHaveBeenCalledWith(123456, 'source-a');
+      expect((databaseService as any).deleteEstimatedPositionsByNodeNumsAsync).toHaveBeenCalledWith([123456]);
+    });
+
+    it('should sum telemetry and estimate deletions into a single deletedCount (#4450)', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      mockTelemetryRepo.purgePositionHistory.mockResolvedValue(18);
+      (databaseService as any).deleteEstimatedPositionsByNodeNumsAsync = vi.fn().mockResolvedValue(2);
+      vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
+
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/position-history')
+        .send({ sourceId: 'source-a' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('deletedCount', 20);
     });
 
     it('should scope purge to the provided sourceId', async () => {

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -637,7 +637,12 @@ router.delete('/nodes/:nodeNum/position-history', requireMessagesWrite, async (r
       return res.status(400).json({ error: 'Bad request', message: 'sourceId is required' });
     }
 
-    const deletedCount = await databaseService.telemetry.purgePositionHistory(nodeNum, sourceId);
+    const deletedTelemetryCount = await databaseService.telemetry.purgePositionHistory(nodeNum, sourceId);
+    // The global position estimate (issue #3271) lives outside per-source telemetry —
+    // a node with zero real telemetry can still carry a stale estimate, which the
+    // purge above would otherwise silently leave behind (#4450).
+    const deletedEstimateCount = await databaseService.deleteEstimatedPositionsByNodeNumsAsync([nodeNum]);
+    const deletedCount = deletedTelemetryCount + deletedEstimateCount;
 
     logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} position history records for node ${nodeNum} (source=${sourceId})`);
 


### PR DESCRIPTION
## Summary

Fixes the "Purge Location History" half of #4450: a node with zero real GPS telemetry can still carry a phantom entry in the global `estimated_positions` table (`positionEstimationService`), and the purge endpoint was blind to it.

## Root cause

`positionEstimationService.solveNodePosition()` (`src/server/services/positionEstimationService.ts:112-161`) is a weighted-centroid solver. With exactly **one** anchor observation (e.g. a single NeighborInfo entry or traceroute segment directly adjacent to the locally-connected node), the "centroid" is mathematically identical to that one anchor's coordinates — this is documented/intentional ("a single anchor can't triangulate — only tells us 'within radio range'"), and there's no minimum-anchor-count guard, so the estimate is still persisted (with a 5 km uncertainty radius that isn't currently surfaced anywhere in the UI).

Because the locally-connected node is itself a GPS anchor, any node whose only observation names the local node produces an estimate that is **exactly the local node's own coordinates** — matching the reported symptom of a phantom pin sitting on top of the connected node.

Separately, `DELETE /api/nodes/:nodeNum/position-history` (`src/server/routes/messageRoutes.ts`) only purged the per-source `telemetry` table. The phantom node never had raw telemetry rows to begin with, so the purge always reported `Purged 0 position records` and the estimate persisted until the next scheduled recompute reproduced it — exactly as reported.

## Fix

`DELETE /api/nodes/:nodeNum/position-history` now also calls `deleteEstimatedPositionsByNodeNumsAsync([nodeNum])` and folds that count into `deletedCount`, so purging a node's position history actually clears the phantom estimate (immediately — until the next scheduled recompute, since the underlying traceroute/neighbor data is untouched).

## Related

This is closely related to #4432 (estimated positions are indistinguishable from real GPS client-side — no `positionIsEstimated` flag). That issue tracks the deeper UI-disclosure fix (badge/dashed marker/uncertainty radius) so users can tell a trilaterated guess apart from a real GPS fix; this PR only fixes the purge-doesn't-work symptom reported in #4450. Full resolution of "phantom-looking" pins likely wants both.

## Test plan
- [x] Added a regression test asserting the estimate purge is called and folded into `deletedCount` (`src/server/routes/messageRoutes.test.ts`)
- [x] `npx vitest run src/server/routes/messageRoutes.test.ts` — 58/58 pass
- [x] `npx vitest run src/server/services/positionEstimationService` — 21/21 pass (untouched, confirms root-cause understanding)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:ci` — clean (no new violations)
- [x] Full `npx vitest run` — 9 pre-existing failures, all in unrelated protobuf-loading tests (MQTT/PKI/shared-contact), none touching this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01SA1B4HpAzrSc3nkSMXzN9y)_