### PR TITLE
fix(nav): pass showList from every back-to-dashboard button (#4447)

### DIFF
--- a/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.test.tsx
@@ -8,6 +8,13 @@ import { MemoryRouter } from 'react-router-dom';
 import MapAnalysisToolbar from './MapAnalysisToolbar';
 import { MapAnalysisProvider } from './MapAnalysisContext';
 
+// #4447: the Back to Sources button must navigate with `showList` state.
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 vi.mock('../../hooks/useDashboardData', () => ({
   useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }] }),
   // The Polar Grid toggle resolves own-node positions via these hooks (#3971).
@@ -49,6 +56,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
 describe('MapAnalysisToolbar', () => {
   beforeEach(() => {
     localStorage.clear();
+    mockNavigate.mockClear();
     elevationEnabled = true;
     unifiedNodes = [];
     terrainCapabilities = { enabled: true, terrainTiles: true, isLoading: false };
@@ -276,6 +284,16 @@ describe('MapAnalysisToolbar', () => {
       const btn = screen.getByRole('button', { name: /^heatmap$/i });
       expect(btn).toBeDisabled();
       expect(btn).toHaveClass('active');
+    });
+  });
+
+  describe('Back to Sources button (#4447)', () => {
+    it('navigates with showList so the dashboard does not bounce to the default landing page', () => {
+      render(<MapAnalysisToolbar />, { wrapper });
+      fireEvent.click(screen.getByRole('button', { name: /back to sources/i }));
+      // Without the flag, DashboardPage's default-landing-page effect redirects
+      // straight back out of the dashboard the user just asked for.
+      expect(mockNavigate).toHaveBeenCalledWith('/', { state: { showList: true } });
     });
   });
 });

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -179,7 +179,7 @@ export default function MapAnalysisToolbar() {
       <button
         type="button"
         className="map-analysis-back icon-only"
-        onClick={() => navigate('/')}
+        onClick={() => navigate('/', { state: { showList: true } })}
         title="Back to Sources"
         aria-label="Back to Sources"
       >

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -7,8 +7,8 @@
  * explaining types and scopes.
  */
 import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { isValidCron } from 'cron-validator';
-import { appBasename } from '../../init';
 import apiService from '../../services/api';
 import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption, type ScriptOption } from './AutomationBuilder';
 import AutomationTester from './AutomationTester';
@@ -67,11 +67,15 @@ function validateForm(form: WorkflowForm): string[] {
 
 export default function AutomationsPage() {
   const [view, setView] = useState<'automations' | 'variables'>('automations');
+  const navigate = useNavigate();
   return (
     <div className="ae-page">
       <div className="ae-container">
         <div className="ae-topbar">
-          <button className="ae-btn ae-btn--ghost" onClick={() => { window.location.href = `${appBasename}/`; }}><UiIcon name="back" size={15} /> Dashboard</button>
+          {/* Router navigation, not window.location: only a client-side navigate
+              carries `showList`, which is what tells DashboardPage to show the
+              source list instead of bouncing to the default landing page (#4447). */}
+          <button className="ae-btn ae-btn--ghost" onClick={() => navigate('/', { state: { showList: true } })}><UiIcon name="back" size={15} /> Dashboard</button>
         </div>
         <h1 className="ae-title">Automation Engine</h1>
         <p className="ae-subtitle">Advanced Mode (beta) — global “when this happens, do that” workflows across every source.</p>

--- a/src/pages/GlobalSettingsPage.tsx
+++ b/src/pages/GlobalSettingsPage.tsx
@@ -72,7 +72,7 @@ function GlobalSettingsInner() {
   return (
     <div style={{ maxWidth: 1200, margin: '0 auto', padding: '1rem' }}>
       <button
-        onClick={() => navigate('/')}
+        onClick={() => navigate('/', { state: { showList: true } })}
         style={{
           background: 'none',
           border: 'none',

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -25,7 +25,7 @@ export default function ReportsPage() {
             <button
               type="button"
               className="reports-header__back"
-              onClick={() => navigate('/')}
+              onClick={() => navigate('/', { state: { showList: true } })}
             >
               <UiIcon name="back" size={16} /> {t('common.back', 'Dashboard')}
             </button>

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -17,7 +17,7 @@ function UsersPageInner() {
   return (
     <div style={{ maxWidth: 1200, margin: '0 auto', padding: '1rem' }}>
       <button
-        onClick={() => navigate('/')}
+        onClick={() => navigate('/', { state: { showList: true } })}
         style={{
           background: 'none',
           border: 'none',

--- a/src/pages/backToDashboardNavigation.test.ts
+++ b/src/pages/backToDashboardNavigation.test.ts
@@ -43,9 +43,12 @@ const read = (rel: string) => readFileSync(resolve(srcRoot, rel), 'utf8');
  *  no second argument, i.e. no state. */
 const BARE_ROOT_NAVIGATE = /navigate\(\s*['"`]\/['"`]\s*\)/;
 
-/** A hard navigation to the app root. Cannot carry router state, so it always
- *  triggers the redirect. */
-const HARD_ROOT_NAVIGATION = /(?:window\.)?location\.(?:href|assign|replace)\s*[=(]\s*[`'"]?\$\{appBasename\}\//;
+/** Any hard navigation, however it spells the destination. A full page load
+ *  cannot carry router state, so it always triggers the redirect — the exact
+ *  shape of the URL expression is beside the point, which is why this matches
+ *  the assignment rather than the string (`${appBasename}/`, `appBasename +
+ *  '/'`, a hardcoded '/meshmonitor/', …). */
+const HARD_ROOT_NAVIGATION = /(?:window\.)?location\.(?:href\s*=|assign\s*\(|replace\s*\()/;
 
 describe('back-to-dashboard navigation (#4447)', () => {
   it.each(BACK_TO_DASHBOARD_SOURCES)('%s passes showList when navigating to the dashboard', (rel) => {

--- a/src/pages/backToDashboardNavigation.test.ts
+++ b/src/pages/backToDashboardNavigation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Back-to-Dashboard navigation guard (#4447).
+ *
+ * `DashboardPage` skips its default-landing-page redirect only when it is
+ * navigated to with `location.state.showList === true`
+ * (`DashboardPage.tsx`, "default landing page redirect"). Every button that
+ * sends the user back to the dashboard must therefore carry that flag —
+ * otherwise a deployment with a configured default landing page bounces the
+ * user straight back out of the dashboard they just asked for.
+ *
+ * Five buttons shipped without it (#4447, reported by matt via Discord). The
+ * Automation Engine's was worse than a missing flag: it used
+ * `window.location.href`, a full page load, which cannot carry router state at
+ * all and so redirected unconditionally.
+ *
+ * This reads the source rather than rendering, deliberately. The five pages
+ * live behind very different provider stacks, and the property under test is
+ * one line in each — a regex guard covers all five for the cost of one cheap
+ * test, and it fails for a NEW page that gets the same thing wrong. Rendered
+ * behavior for the toolbar button is asserted in
+ * `MapAnalysisToolbar.test.tsx`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = resolve(here, '..');
+
+/** Every source file with a "back to the dashboard" control. */
+const BACK_TO_DASHBOARD_SOURCES = [
+  'components/MapAnalysis/MapAnalysisToolbar.tsx',
+  'pages/ReportsPage.tsx',
+  'pages/UsersPage.tsx',
+  'pages/GlobalSettingsPage.tsx',
+  'components/automations/AutomationsPage.tsx',
+];
+
+const read = (rel: string) => readFileSync(resolve(srcRoot, rel), 'utf8');
+
+/** `navigate('/')` — with any quote style and optional whitespace — carrying
+ *  no second argument, i.e. no state. */
+const BARE_ROOT_NAVIGATE = /navigate\(\s*['"`]\/['"`]\s*\)/;
+
+/** A hard navigation to the app root. Cannot carry router state, so it always
+ *  triggers the redirect. */
+const HARD_ROOT_NAVIGATION = /(?:window\.)?location\.(?:href|assign|replace)\s*[=(]\s*[`'"]?\$\{appBasename\}\//;
+
+describe('back-to-dashboard navigation (#4447)', () => {
+  it.each(BACK_TO_DASHBOARD_SOURCES)('%s passes showList when navigating to the dashboard', (rel) => {
+    const source = read(rel);
+
+    expect(source).toMatch(/navigate\(\s*['"`]\/['"`]\s*,\s*\{\s*state:\s*\{\s*showList:\s*true/);
+  });
+
+  it.each(BACK_TO_DASHBOARD_SOURCES)('%s has no stateless navigate("/")', (rel) => {
+    expect(read(rel)).not.toMatch(BARE_ROOT_NAVIGATE);
+  });
+
+  it.each(BACK_TO_DASHBOARD_SOURCES)('%s does not hard-navigate to the app root', (rel) => {
+    // A full page load drops router state entirely, so the dashboard can never
+    // see showList and redirects every time (#4447 item 5).
+    expect(read(rel)).not.toMatch(HARD_ROOT_NAVIGATION);
+  });
+
+  it('DashboardPage still keys its redirect skip on location.state.showList', () => {
+    // If this contract ever moves, the guards above are testing nothing.
+    expect(read('pages/DashboardPage.tsx')).toMatch(/state\s+as\s+\{\s*showList\?:\s*boolean/);
+  });
+});


### PR DESCRIPTION
## Summary
With a Default Landing Page configured, five "Back"/"Back to Dashboard" buttons sent the user to that landing page instead of the dashboard. `DashboardPage` skips its default-landing redirect only when navigated to with `location.state.showList === true`; these five didn't pass it, so the dashboard immediately bounced the user back out.

Reported by matt (Discord) via Yeraze.

## Changes
- **Map Analysis** (`MapAnalysisToolbar.tsx`), **Analysis & Reports** (`ReportsPage.tsx`), **Users** (`UsersPage.tsx`), **Global Settings** (`GlobalSettingsPage.tsx`): `navigate('/')` → `navigate('/', { state: { showList: true } })`, matching the pattern the unified pages already use.
- **Automation Engine** (`AutomationsPage.tsx`): was `window.location.href = ${appBasename}/` — a full page load, which cannot carry router state at all, so it redirected *unconditionally* rather than merely missing the flag. Now uses `useNavigate` (the page already renders inside the `BrowserRouter` at `main.tsx:176`, so no other wiring was needed) and drops the now-unused `appBasename` import.
- **Tests:** a source-level guard (`src/pages/backToDashboardNavigation.test.ts`) covering all five call sites — each must pass `showList`, none may use a bare `navigate('/')` or a hard root navigation — plus an assertion that `DashboardPage` still keys its skip on `location.state.showList`, so the guard can't silently stop testing anything. A rendered-behavior test was added to the existing `MapAnalysisToolbar` harness.

Source extraction was chosen for the cross-cutting guard because the five pages sit behind very different provider stacks while the property under test is one line in each; it also catches a *new* page making the same mistake. It was mutation-checked — reverting one call site fails exactly that site's two assertions.

## Issues Resolved
Fixes #4447

## Documentation Updates
No documentation changes needed — this restores the documented behavior of the Default Landing Page setting.

## Testing
- [x] Full Vitest suite `success: true` — 12,992 passed / 0 failed (PG/MySQL skip locally; no DB/server change here)
- [x] TypeScript compiles cleanly; `lint:ci` in-repo gate clean
- [x] Guard test mutation-verified (reverting a fix makes it fail)
- [ ] Reviewer: set a source as Default Landing Page, then use Back from Map Analysis, Reports, Users, Global Settings and Automation Engine — each should land on the source list, not the default page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9