### PR TITLE
fix(position-estimation): exclude single-anchor estimates by default (closes #4450)

### DIFF
--- a/src/server/services/positionEstimationScheduler.test.ts
+++ b/src/server/services/positionEstimationScheduler.test.ts
@@ -18,6 +18,7 @@ import {
   positionEstimationScheduler,
   DEFAULT_FREQUENCY_HOURS,
   DEFAULT_LOOKBACK_HOURS,
+  DEFAULT_MAX_UNCERTAINTY_KM,
 } from './positionEstimationScheduler.js';
 
 const HOUR = 60 * 60 * 1000;
@@ -64,7 +65,26 @@ describe('positionEstimationScheduler.runNow', () => {
     });
   });
 
-  it('passes maxUncertaintyKm: 0 (no limit) when the setting is unset', async () => {
+  it('defaults maxUncertaintyKm below the single-anchor radius when unset (#4450)', async () => {
+    // Was 0 (no limit), which stored single-anchor solves. Those land at exactly
+    // DEFAULT_SINGLE_ANCHOR_KM (5 km) on the anchor's own coordinates, which is
+    // the phantom pin on top of the connected node reported in #4450.
+    await positionEstimationScheduler.runNow();
+    expect(mockService.positionEstimationService.recomputeAll).toHaveBeenCalledWith({
+      lookbackMs: DEFAULT_LOOKBACK_HOURS * HOUR,
+      maxUncertaintyKm: DEFAULT_MAX_UNCERTAINTY_KM,
+    });
+    // Pin the relationship rather than the literal: any default >= 5 would let
+    // the single-anchor class straight back in.
+    expect(DEFAULT_MAX_UNCERTAINTY_KM).toBeGreaterThan(0);
+    expect(DEFAULT_MAX_UNCERTAINTY_KM).toBeLessThan(5);
+  });
+
+  it('still treats an explicitly configured 0 as "no limit" (#4450 opt-out)', async () => {
+    mockDb.settings.getSetting.mockImplementation(async (key: string) => {
+      if (key === 'position_estimation_max_uncertainty_km') return '0';
+      return null;
+    });
     await positionEstimationScheduler.runNow();
     expect(mockService.positionEstimationService.recomputeAll).toHaveBeenCalledWith({
       lookbackMs: DEFAULT_LOOKBACK_HOURS * HOUR,

--- a/src/server/services/positionEstimationScheduler.ts
+++ b/src/server/services/positionEstimationScheduler.ts
@@ -10,6 +10,7 @@
  *   - position_estimation_enabled         (default true)
  *   - position_estimation_frequency_hours (default 6)
  *   - position_estimation_lookback_hours  (default 168 = 7 days)
+ *   - position_estimation_max_uncertainty_km (default 2; 0 = no limit)
  *
  * On first boot after migration 082 (no prior run recorded) it runs once
  * immediately to backfill estimates from stored history.
@@ -22,9 +23,35 @@ const LAST_RUN_KEY = 'position_estimation_last_run';
 
 export const DEFAULT_FREQUENCY_HOURS = 6;
 export const DEFAULT_LOOKBACK_HOURS = 168; // 7 days
-// 0 = no limit (store every solvable estimate). Opt-in: the operator sets a
-// km ceiling to drop low-confidence estimates that draw huge map circles.
-export const DEFAULT_MAX_UNCERTAINTY_KM = 0;
+/**
+ * Ceiling on a solved estimate's uncertainty radius, in km. Estimates above it
+ * are not stored, and any existing row for that node is deleted (see
+ * `recomputeAll`'s `rejectedNodeNums`), so changing this self-heals on the next
+ * scheduled run.
+ *
+ * **2 km, chosen to exclude single-anchor solves (#4450).** With one
+ * observation the weighted centroid is *mathematically identical* to that one
+ * anchor's coordinates: `solveNodePosition` returns the anchor's exact lat/lon
+ * with `DEFAULT_SINGLE_ANCHOR_KM` (5 km) uncertainty, which says nothing more
+ * than "somewhere within radio range of that anchor". Because the
+ * locally-connected node is itself an anchor, any node whose only observation
+ * named it produced an estimate at *exactly the local node's coordinates* —
+ * rendered as an ordinary pin, indistinguishable from a real GPS fix. That is
+ * the phantom marker reported in #4450.
+ *
+ * This previously defaulted to 0 (no limit), so those estimates were stored by
+ * default. Any threshold below 5 excludes the single-anchor class exactly,
+ * since that case always lands on 5.0 km; 2 km additionally drops genuinely
+ * loose multi-anchor solves while keeping tight ones.
+ *
+ * **0 still means "no limit"** — an operator who explicitly sets 0 keeps the
+ * previous behavior. Only an unset value picks up this default.
+ *
+ * Surfacing uncertainty in the UI, so a trilaterated guess is visually distinct
+ * from a GPS fix, is tracked separately in #4432; this default is the
+ * conservative floor until that lands.
+ */
+export const DEFAULT_MAX_UNCERTAINTY_KM = 2;
 const MIN_FREQUENCY_HOURS = 0.5;
 const MIN_LOOKBACK_HOURS = 1;
 const CHECK_INTERVAL_MS = 60_000;

--- a/src/server/services/positionEstimationService.test.ts
+++ b/src/server/services/positionEstimationService.test.ts
@@ -25,6 +25,7 @@ import {
   type TracerouteForEstimation,
   type NeighborForEstimation,
 } from './positionEstimationService.js';
+import { DEFAULT_MAX_UNCERTAINTY_KM } from './positionEstimationScheduler.js';
 
 const NOW = 1_700_000_000_000;
 
@@ -336,6 +337,28 @@ describe('positionEstimationService.recomputeAll', () => {
       // Nothing stored for the over-threshold node...
       expect(mockDb.upsertEstimatedPositionsAsync.mock.calls[0][0]).toHaveLength(0);
       // ...and its existing estimate (if any) is cleared.
+      expect(mockDb.deleteEstimatedPositionsByNodeNumsAsync.mock.calls[0][0]).toContain(5);
+    });
+
+    it('rejects the single-anchor estimate at the SHIPPED default (#4450)', async () => {
+      // The regression that mattered: the threshold machinery above always
+      // worked, but DEFAULT_MAX_UNCERTAINTY_KM was 0 ("no limit"), so a stock
+      // install stored single-anchor solves. Those sit at the anchor's exact
+      // coordinates — and since the locally-connected node is itself an anchor,
+      // that is the phantom pin on top of your own node reported in #4450.
+      //
+      // Asserted against the real exported default rather than a literal, so
+      // this fails if it is ever raised back above the 5 km single-anchor radius.
+      singleAnchorSetup();
+      const result = await positionEstimationService.recomputeAll({
+        lookbackMs: 7 * 24 * 60 * 60 * 1000,
+        maxUncertaintyKm: DEFAULT_MAX_UNCERTAINTY_KM,
+      });
+      expect(result.estimatedNodeCount).toBe(0);
+      expect(result.rejectedNodeCount).toBe(1);
+      expect(mockDb.upsertEstimatedPositionsAsync.mock.calls[0][0]).toHaveLength(0);
+      // The stale row is cleared too, so existing installs self-heal on the
+      // next scheduled run rather than needing a manual purge.
       expect(mockDb.deleteEstimatedPositionsByNodeNumsAsync.mock.calls[0][0]).toContain(5);
     });
 


### PR DESCRIPTION
Closes #4450 — the half that #4452 didn't cover.

## The reported symptom

Nodes that have never broadcast a position show on the map at the **exact coordinates of the connected node**, with a pin in the node list implying a real GPS fix.

## Root cause is the solver, not the map

`solveNodePosition` computes a weighted centroid. With a **single** observation, that centroid is mathematically identical to that one anchor's coordinates:

```ts
const latitude  = wLat / wSum;   // one term ⇒ exactly obs.anchorLat
const longitude = wLon / wSum;
```

It returns the anchor's exact lat/lon with `DEFAULT_SINGLE_ANCHOR_KM` (5 km) uncertainty — which conveys nothing beyond *"somewhere within radio range of that anchor"*. Because the locally-connected node is itself an anchor, any node whose only observation named it produced an estimate sitting precisely on top of it.

The solver is behaving as designed and documented (*"a single anchor can't triangulate — only tells us 'within radio range'"*). The problem is that a 5 km guess renders as an ordinary pin.

## The fix was a default, not new machinery

`recomputeAll` already rejects estimates above `maxUncertaintyKm`, and already deletes any stored row for a rejected node. That code was correct and tested.

But `DEFAULT_MAX_UNCERTAINTY_KM = 0`, which it reads as *"no limit — store every solvable estimate"*. So a stock install stored single-anchor solves.

**Now 2 km.** Single-anchor solves always land on exactly 5.0 km, so any threshold below 5 excludes that class precisely; 2 km additionally drops genuinely loose multi-anchor solves while keeping tight ones.

- **Existing installs self-heal** on the next scheduled run — rejected nodes get their stored estimate deleted, no manual purge needed.
- **`0` still means "no limit."** An operator who explicitly sets 0 keeps the previous behavior; only an *unset* value picks up the new default.

## Why not the alternatives

- **Rejecting single-anchor solves outright** in the solver would override an explicit design decision that the single-anchor case is intentional, and would bypass the operator's own precision setting.
- **UI disclosure alone** (#4432 — dashed marker, uncertainty radius, no GPS pin) is the right long-term answer, but the reporter keeps seeing a marker on their own node until it lands. This default is the conservative floor in the meantime, and #4432 remains the real disclosure fix.

## Tests

Both new tests assert against the **exported default**, not a literal, so raising it back above the 5 km single-anchor radius fails the build.

Verified by mutation — restoring `0`:
```
AssertionError: expected 0 to be greater than 0          (scheduler: default must exclude single-anchor)
AssertionError: expected 1 to be +0                      (service: estimate stored instead of rejected)
```
Plus a test pinning that an explicitly configured `0` still means no limit.

## Verification

- Full suite **13,028 passing, 0 failing**, `success: true` via JSON reporter; 109 skips unchanged.
- `tsc --noEmit` clean; `lint:ci` clean.

## Note for release notes

Installs that never set `position_estimation_max_uncertainty_km` will see low-confidence estimates disappear from the map on the next estimation run (default every 6 hours). That is the intended fix. Setting the value to `0` restores the previous behavior.

Closes #4450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB
