### PR TITLE
chore: bump version to 4.13.3-rc3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.3-rc2",
+  "version": "4.13.3-rc3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.3-rc2",
+  "version": "4.13.3-rc3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.3-rc2
-appVersion: "4.13.3-rc2"
+version: 4.13.3-rc3
+appVersion: "4.13.3-rc3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc2",
+  "version": "4.13.3-rc3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.3-rc2",
+      "version": "4.13.3-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc2",
+  "version": "4.13.3-rc3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version-bump chore rolling the next release candidate: **4.13.3-rc2 → 4.13.3-rc3**.

All five version files updated:

- `package.json`
- `package-lock.json` (regenerated via `npm install --package-lock-only`)
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json`

No functional changes.

## What landed since rc2

26 commits, headline items:

**Features**
- Statistical route view — aggregation + union layout engine (#4444) and Node Details strip (#4451)
- Traceroute interactivity — participation picker across all sources (#4427), popup More Details + edge tooltips (#4424), Copy Forward/Return/Both links (#4429)
- Per-source settings foundation and guardrails (#4412 Phases 2/3), plus MeshCore per-source node-age filtering (#4433)

**Fixes**
- Position estimation: exclude single-anchor estimates by default (#4450); purge also clears the global estimate (#4452)
- Guard `lastHeard` against replayed position/telemetry packets (#4446)
- Per-source epic defect sweep — settings (#4441) and five more (#4453)
- `settings` is now a per-source permission resource (#4443)
- MeshCore `startAutoPathfinding()` overlap guard (#4434); virtual-node duplicate MQTT proxy publish (#4038)
- Bound `geofenceState` / `autoAckCooldowns` growth (#4399)

## Test plan

- [ ] CI green (full Vitest suite, lint ratchet, system tests via `system-test` label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB