### PR TITLE
fix(telemetry,sidebar): humanize per-node uptime graphs (#3261), stop sidebar controls overlapping the shared footer (#4436)

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -27,30 +27,11 @@
   width: calc(240px + env(safe-area-inset-left, 0px));
 }
 
-.sidebar-footer {
-  padding: 12px 16px;
-  border-top: 1px solid var(--ctp-surface1);
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  background: var(--ctp-mantle);
-  margin-top: auto;
-}
+/* The old .sidebar-footer / .version-text / .news-link rules are gone: the
+   per-source footer is the shared SidebarFooter component (#4436), which
+   carries its own CSS module. .github-link survives — LoginPage uses it. */
 
-.sidebar.collapsed .sidebar-footer {
-  justify-content: center;
-  padding: 12px 8px;
-}
-
-.version-text {
-  font-size: 12px;
-  color: var(--ctp-subtext0);
-  font-weight: 500;
-  font-family: var(--font-mono);
-}
-
-.github-link,
-.news-link {
+.github-link {
   color: var(--ctp-subtext0);
   display: flex;
   align-items: center;
@@ -59,15 +40,7 @@
   text-decoration: none;
 }
 
-.news-link {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-}
-
-.github-link:hover,
-.news-link:hover {
+.github-link:hover {
   color: var(--ctp-text);
 }
 
@@ -93,14 +66,22 @@
   transform: scale(1.05);
 }
 
+/* In normal flow directly above the footer (#4436). These used to be
+   absolutely positioned at `bottom: 70px`, a strip sized for the previous
+   three-item footer. The shared SidebarFooter is taller — much taller in the
+   60px collapsed rail, where its six icons wrap — so the controls landed on
+   top of it. Laying them out in flow removes the magic number entirely. */
 .sidebar-controls {
-  position: absolute;
-  right: 8px;
-  bottom: 70px; /* Above the footer */
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: flex-end;
   gap: 8px;
-  z-index: 1;
+  padding: 0 8px 8px 8px;
+  flex-shrink: 0;
+}
+
+.sidebar.collapsed .sidebar-controls {
+  justify-content: center;
 }
 
 .sidebar-pin {
@@ -189,7 +170,9 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 8px 8px 120px 8px; /* Bottom padding for toggle button and footer */
+  /* The controls and footer are in-flow siblings now (#4436), so no bottom
+     strip needs reserving here — just a little breathing room. */
+  padding: 8px;
   overflow-y: auto;
   overflow-x: hidden;
   flex: 1;
@@ -324,19 +307,11 @@
     padding-bottom: max(4px, env(safe-area-inset-bottom));
   }
 
-  /* Only change: reduce nav bottom padding from 120px */
-  .sidebar-nav {
-    padding-bottom: 50px;
-  }
-
-  /* Hide footer to free up space */
-  .sidebar-footer {
-    display: none;
-  }
-
-  /* Adjust controls position since footer is hidden */
+  /* The footer hides itself here via SidebarFooter's hideOnCompactLandscape,
+     and the controls are in normal flow (#4436), so neither the old
+     nav bottom-padding reservation nor a `bottom` offset is needed. */
   .sidebar-controls {
-    bottom: 8px;
+    padding-bottom: 4px;
   }
 }
 
@@ -416,15 +391,14 @@
     gap: 1px;
   }
 
-  /* Hide footer in landscape to maximize nav space */
-  .sidebar-footer {
-    display: none !important;
-  }
-
+  /* The footer hides itself in landscape (SidebarFooter's
+     hideOnCompactLandscape) to maximize nav space, so the controls can float
+     in the freed corner rather than sit in flow (#4436). */
   .sidebar-controls {
     position: absolute;
     bottom: 4px;
     right: 4px;
+    padding: 0;
     flex-direction: row;
     gap: 4px;
   }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -283,20 +283,11 @@ const Sidebar: React.FC<SidebarProps> = ({
         )}
       </nav>
 
-      {/* Shared footer (issue #4436) — same link set as the unified
-          dashboard sidebar. Users/Settings clicks switch tabs here, matching
-          the main-nav entries above. */}
-      <SidebarFooter
-        isAdmin={isAdmin}
-        canReadSettings={hasPermission('settings', 'read', { anySource: true })}
-        onUsersClick={() => setActiveTab('users')}
-        onSettingsClick={() => setActiveTab('settings')}
-        onNewsClick={onNewsClick}
-        hideVersion={isCollapsed}
-        pinToBottom
-        hideOnCompactLandscape
-      />
-
+      {/* Pin/collapse controls sit in normal flow directly above the footer.
+          They used to be absolutely positioned at a hardcoded `bottom: 70px`,
+          which assumed the old three-item footer; the shared SidebarFooter
+          (#4436) is taller — and much taller in the 60px collapsed rail, where
+          its six icons wrap — so the controls landed on top of it. */}
       <div className="sidebar-controls">
         {!isCollapsed && (
           <button
@@ -315,6 +306,22 @@ const Sidebar: React.FC<SidebarProps> = ({
           <UiIcon name={isCollapsed ? 'forward' : 'back'} size={18} />
         </button>
       </div>
+
+      {/* Shared footer (issue #4436) — same link set as the unified
+          dashboard sidebar. Users/Settings clicks switch tabs here, matching
+          the main-nav entries above. `narrowIcons` packs the icon row into the
+          collapsed rail instead of letting it wrap one-icon-per-line. */}
+      <SidebarFooter
+        isAdmin={isAdmin}
+        canReadSettings={hasPermission('settings', 'read', { anySource: true })}
+        onUsersClick={() => setActiveTab('users')}
+        onSettingsClick={() => setActiveTab('settings')}
+        onNewsClick={onNewsClick}
+        hideVersion={isCollapsed}
+        narrowIcons={isCollapsed}
+        pinToBottom
+        hideOnCompactLandscape
+      />
     </aside>
   );
 };

--- a/src/components/SidebarFooter.module.css
+++ b/src/components/SidebarFooter.module.css
@@ -32,6 +32,22 @@
   gap: 6px;
 }
 
+/* Narrow rail (the 60px collapsed per-source sidebar): a two-column grid keeps
+   the six icons in three short rows instead of six full-width ones (#4436). */
+.narrow {
+  padding: 8px 4px;
+}
+
+.narrow .icons {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 2px;
+}
+
+.narrow .btn {
+  padding: 3px;
+}
+
 .btn {
   background: none;
   border: none;

--- a/src/components/SidebarFooter.test.tsx
+++ b/src/components/SidebarFooter.test.tsx
@@ -88,6 +88,17 @@ describe('SidebarFooter', () => {
     expect(baseProps.onSettingsClick).toHaveBeenCalledTimes(1);
   });
 
+  it('applies the narrow-rail layout only when narrowIcons is set', () => {
+    // The collapsed per-source rail is 60px wide; without this the six icons
+    // wrap one per line and the footer overruns the sidebar (#4436).
+    const { container, unmount } = render(<SidebarFooter {...baseProps} narrowIcons />);
+    expect(container.firstElementChild?.className).toMatch(/narrow/);
+    unmount();
+
+    const plain = render(<SidebarFooter {...baseProps} />);
+    expect(plain.container.firstElementChild?.className).not.toMatch(/narrow/);
+  });
+
   it('fires the News click handler and disables the button when absent', () => {
     const { unmount } = render(<SidebarFooter {...baseProps} />);
     fireEvent.click(screen.getByTitle('source.sidebar.news'));

--- a/src/components/SidebarFooter.tsx
+++ b/src/components/SidebarFooter.tsx
@@ -31,6 +31,12 @@ export interface SidebarFooterProps {
   onNewsClick?: () => void;
   /** Hides the version line (per-source sidebar collapsed state). */
   hideVersion?: boolean;
+  /**
+   * Packs the icons for a narrow rail (the 60px collapsed per-source sidebar).
+   * Without it the six icons wrap one per line and the footer grows to roughly
+   * a third of the sidebar's height (#4436).
+   */
+  narrowIcons?: boolean;
   /** Pins the footer to the bottom of a flex-column sidebar. */
   pinToBottom?: boolean;
   /** Hides the footer on short landscape screens (per-source sidebar). */
@@ -44,6 +50,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({
   onSettingsClick,
   onNewsClick,
   hideVersion = false,
+  narrowIcons = false,
   pinToBottom = false,
   hideOnCompactLandscape = false,
 }) => {
@@ -51,6 +58,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({
 
   const footerClass = [
     styles.footer,
+    narrowIcons ? styles.narrow : '',
     pinToBottom ? styles.pinToBottom : '',
     hideOnCompactLandscape ? styles.hideOnCompactLandscape : '',
   ]

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -28,7 +28,7 @@ import { useWidgetMode } from '../hooks/useWidgetMode';
 import { useWidgetRange } from '../hooks/useWidgetRange';
 import { useSource } from '../contexts/SourceContext';
 import { getLatestValue } from '../utils/telemetry';
-import { unitScale, formatDuration, isUptimeType } from '../utils/telemetryFormat';
+import { telemetryDisplayScale } from '../utils/telemetryFormat';
 import TelemetryGauge from './TelemetryGauge';
 import TelemetryNumericLabel from './TelemetryNumericLabel';
 import { UiIcon } from './icons';
@@ -481,10 +481,6 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     const nodeName = formatNodeName(node, favorite.nodeId);
     const isTemperature = isTemperatureType(favorite.telemetryType);
-    // Uptime-in-seconds metrics (uptimeSeconds, hostUptimeSeconds,
-    // paxcounterUptime, mc_*_uptime_secs) display as humanized durations
-    // instead of raw seconds (#3261).
-    const isUptime = isUptimeType(favorite.telemetryType);
     const color = getColor(favorite.telemetryType);
     const label = isPaxcounterCombined ? 'Paxcounter' : getTranslatedLabel(favorite.telemetryType);
 
@@ -563,23 +559,15 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     // Prepare chart data
     const chartData = prepareChartData(telemetryData, isTemperature, temperatureUnit, solarEstimates, globalMinTime, timeFormat);
-    // Auto-scale current/power so a sub-1 A/W series reads as mA/mW (#3261).
-    // One factor for the whole series (chosen from its largest magnitude)
-    // keeps every point, the axis, the gauge range and the numeric readout on
-    // the same prefix. Temperature keeps its own C/F handling below.
-    const baseUnit = telemetryData[0]?.unit || '';
-    const seriesMaxAbs = telemetryData.reduce(
-      (m, d) => (typeof d.value === 'number' ? Math.max(m, Math.abs(d.value)) : m),
-      0
+    // Humanize uptime and auto-scale current/power (#3261). Shared with the
+    // per-node graphs (TelemetryGraphs) so the two surfaces cannot drift.
+    // Temperature keeps its own C/F handling below.
+    const display = telemetryDisplayScale(
+      favorite.telemetryType,
+      telemetryData.map(d => d.value),
+      telemetryData[0]?.unit || ''
     );
-    const valueScale = isTemperature ? null : unitScale(baseUnit, seriesMaxAbs);
-    // Humanized durations carry their own units ("3d 4h"), so drop the
-    // stored "s" unit for uptime metrics — mirrors UnifiedTelemetryPage.
-    const unit = isTemperature
-      ? getTemperatureUnit(temperatureUnit)
-      : isUptime
-        ? ''
-        : (valueScale ? valueScale.unit : baseUnit);
+    const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : display.unit;
 
     // For combined paxcounter chart, merge BLE data
     if (isPaxcounterCombined) {
@@ -610,8 +598,8 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     // Apply the chart's display scale to the plotted series. The solar overlay
     // lives on its own axis (watt-hours) and is left untouched.
-    const scaledChartData = valueScale && valueScale.factor !== 1
-      ? chartData.map((d) => ({ ...d, value: d.value == null ? d.value : d.value * valueScale.factor }))
+    const scaledChartData = !isTemperature && display.factor !== 1
+      ? chartData.map((d) => ({ ...d, value: d.value == null ? d.value : d.value * display.factor }))
       : chartData;
 
     // Gauge/numeric modes display a single raw value, so convert it (and the
@@ -619,19 +607,15 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
     // for temperature, the stored A/W for current/power), so edits made in the
     // displayed unit are converted back before saving.
     const toDisplay = (v: number) =>
-      isTemperature
-        ? formatTemperature(v, 'C', temperatureUnit)
-        : v * (valueScale ? valueScale.factor : 1);
+      isTemperature ? formatTemperature(v, 'C', temperatureUnit) : v * display.factor;
     const toStored = (v: number) =>
-      isTemperature
-        ? formatTemperature(v, temperatureUnit, 'C')
-        : v / (valueScale ? valueScale.factor : 1);
+      isTemperature ? formatTemperature(v, temperatureUnit, 'C') : v / display.factor;
     const handleRangeChange = (r: { min: number; max: number }) =>
       setRange({ min: toStored(r.min), max: toStored(r.max) });
 
     // Display formatter for uptime metrics: humanize seconds in the gauge,
     // the numeric label, the Y-axis ticks and the tooltip (#3261).
-    const uptimeFormatter = isUptime ? formatDuration : undefined;
+    const uptimeFormatter = display.formatValue;
 
     return (
       <div ref={setNodeRef} style={style} className="dashboard-chart-container">

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -715,7 +715,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
                 yAxisId="left"
                 tick={{ fontSize: 12 }}
                 domain={['auto', 'auto']}
-                tickFormatter={uptimeFormatter ? (v: number) => uptimeFormatter(v) : undefined}
+                tickFormatter={uptimeFormatter}
               />
               <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} domain={['auto', 'auto']} hide={true} />
               <Tooltip

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -371,11 +371,10 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
               domain={['auto', 'auto']}
               allowDecimals={!INTEGER_TELEMETRY_TYPES.has(type)}
               tickFormatter={
-                display.formatValue
-                  ? (v: number) => display.formatValue!(v)
-                  : INTEGER_TELEMETRY_TYPES.has(type)
-                    ? (v: number) => Math.round(v).toString()
-                    : undefined
+                display.formatValue ??
+                (INTEGER_TELEMETRY_TYPES.has(type)
+                  ? (v: number) => Math.round(v).toString()
+                  : undefined)
               }
             />
             <YAxis

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -16,6 +16,7 @@ import { useWidgetMode } from '../hooks/useWidgetMode';
 import { useWidgetRange } from '../hooks/useWidgetRange';
 import { useSource } from '../contexts/SourceContext';
 import { getLatestValue } from '../utils/telemetry';
+import { telemetryDisplayScale } from '../utils/telemetryFormat';
 import TelemetryGauge from './TelemetryGauge';
 import TelemetryNumericLabel from './TelemetryNumericLabel';
 import { getTelemetryLabel } from './TelemetryChart';
@@ -197,7 +198,10 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
 
   const isTemperature = isTemperatureType(type);
   const chartData = prepareChartData(data, isTemperature, globalMinTime);
-  const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : data[0]?.unit || '';
+  // Humanize uptime and auto-scale current/power the same way the Dashboard
+  // widget does (#3261). Temperature keeps its own C/F handling below.
+  const display = telemetryDisplayScale(type, data.map(d => d.value), data[0]?.unit || '');
+  const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : display.unit;
   const label = isPaxcounterCombined ? 'Paxcounter' : getTelemetryLabel(type);
   const color = getColor(type);
 
@@ -227,13 +231,20 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
 
   const latest = getLatestValue(data);
 
+  // Apply the display scale to the plotted series. The solar overlay lives on
+  // its own axis (watt-hours) and is left untouched.
+  const scaledChartData = !isTemperature && display.factor !== 1
+    ? chartData.map(d => ({ ...d, value: d.value == null ? d.value : d.value * display.factor }))
+    : chartData;
+
   // Gauge/numeric modes display a single raw value, so convert it (and the
-  // gauge range) to the selected unit. Ranges persist in Celsius, so edits
-  // made while displaying Fahrenheit are converted back before saving.
+  // gauge range) to the selected unit. Ranges persist in base units (Celsius
+  // for temperature, the stored A/W for current/power), so edits made in the
+  // displayed unit are converted back before saving.
   const toDisplayTemp = (v: number) =>
-    isTemperature ? formatTemperature(v, 'C', temperatureUnit) : v;
+    isTemperature ? formatTemperature(v, 'C', temperatureUnit) : v * display.factor;
   const toStoredTemp = (v: number) =>
-    isTemperature ? formatTemperature(v, temperatureUnit, 'C') : v;
+    isTemperature ? formatTemperature(v, temperatureUnit, 'C') : v / display.factor;
   const handleRangeChange = (r: { min: number; max: number }) =>
     setRange({ min: toStoredTemp(r.min), max: toStoredTemp(r.max) });
 
@@ -326,6 +337,7 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
             nodeId={nodeId}
             onRangeChange={handleRangeChange}
             canEditRange={canEditSettings}
+            formatValue={display.formatValue}
           />
         ) : (
           <div className="telemetry-no-data">{t('telemetry.no_data')}</div>
@@ -337,13 +349,14 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
             unit={unit}
             color={color}
             timestamp={latest.timestamp}
+            formatValue={display.formatValue}
           />
         ) : (
           <div className="telemetry-no-data">{t('telemetry.no_data')}</div>
         )
       ) : (
         <ResponsiveContainer width="100%" height={200}>
-          <ComposedChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+          <ComposedChart data={scaledChartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
             <XAxis
               dataKey="timestamp"
@@ -357,7 +370,13 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
               tick={{ fontSize: 12 }}
               domain={['auto', 'auto']}
               allowDecimals={!INTEGER_TELEMETRY_TYPES.has(type)}
-              tickFormatter={INTEGER_TELEMETRY_TYPES.has(type) ? (v: number) => Math.round(v).toString() : undefined}
+              tickFormatter={
+                display.formatValue
+                  ? (v: number) => display.formatValue!(v)
+                  : INTEGER_TELEMETRY_TYPES.has(type)
+                    ? (v: number) => Math.round(v).toString()
+                    : undefined
+              }
             />
             <YAxis
               yAxisId="right"
@@ -374,6 +393,15 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
                 color: chartColors.text,
               }}
               labelStyle={{ color: chartColors.text }}
+              formatter={
+                display.formatValue
+                  ? (value, name) =>
+                      // Leave the solar overlay (watt-hours) untouched.
+                      name === 'solarEstimate' || typeof value !== 'number'
+                        ? value
+                        : display.formatValue!(value)
+                  : undefined
+              }
               labelFormatter={value => {
                 const date = new Date(value);
                 return date.toLocaleString([], {

--- a/src/components/TelemetryGraphs.uptime.test.tsx
+++ b/src/components/TelemetryGraphs.uptime.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Per-node telemetry graphs: uptime humanization and current/power
+ * auto-scaling (#3261).
+ *
+ * PR #4439 fixed only the Dashboard widget (TelemetryChart). TelemetryGraphs —
+ * the near-identical component behind the node Info/Messages telemetry
+ * sections — kept rendering "Device Uptime (s)" with raw seconds, and never
+ * got the mA/mW scaling either. Both now share `telemetryDisplayScale`, and
+ * these tests pin the behaviour on this side of the pair.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TelemetryGraphs from './TelemetryGraphs';
+import { ToastProvider } from './ToastContainer';
+import { CsrfProvider } from '../contexts/CsrfContext';
+import { SettingsProvider } from '../contexts/SettingsContext';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: () => true, isAdmin: true, authenticated: true }),
+}));
+
+vi.mock('../hooks/useResolvedSourceId', () => ({ useResolvedSourceId: () => 'src-test' }));
+
+let widgetMode = 'numeric';
+vi.mock('../hooks/useWidgetMode', () => ({
+  useWidgetMode: () => [widgetMode, vi.fn()],
+}));
+
+vi.mock('../hooks/useWidgetRange', () => ({
+  useWidgetRange: () => [{ min: 0, max: 100 }, vi.fn()],
+}));
+
+// Capture axis/tooltip props so the formatter wiring is assertable.
+const captured: {
+  yAxis: Array<Record<string, unknown>>;
+  tooltip: Array<Record<string, unknown>>;
+} = { yAxis: [], tooltip: [] };
+
+vi.mock('recharts', () => ({
+  ComposedChart: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  LineChart: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Line: () => null,
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: (props: Record<string, unknown>) => {
+    captured.yAxis.push(props);
+    return null;
+  },
+  CartesianGrid: () => null,
+  Tooltip: (props: Record<string, unknown>) => {
+    captured.tooltip.push(props);
+    return null;
+  },
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NODE_ID = '!a1b2c3d4';
+
+// 1,543,452 s = 17 days 20 hours (and change) — the value from the report.
+const UPTIME_SECONDS = 1543452;
+
+let testQueryClient: QueryClient;
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={testQueryClient}>
+    <CsrfProvider>
+      <SettingsProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </SettingsProvider>
+    </CsrfProvider>
+  </QueryClientProvider>
+);
+
+const renderGraphs = () => {
+  testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return render(<TelemetryGraphs nodeId={NODE_ID} />, { wrapper: TestWrapper });
+};
+
+const row = (telemetryType: string, value: number, unit: string) => ({
+  id: 1,
+  nodeId: NODE_ID,
+  telemetryType,
+  timestamp: Date.now() - 60_000,
+  value,
+  unit,
+});
+
+const serveTelemetry = (rows: ReturnType<typeof row>[]) => {
+  (global.fetch as Mock).mockImplementation((url: string) => {
+    if (url.includes('/api/settings')) {
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }
+    if (url.includes('/api/solar/estimates')) {
+      return Promise.resolve({ ok: true, json: async () => ({ count: 0, estimates: [] }) });
+    }
+    if (url.includes('/api/csrf-token')) {
+      return Promise.resolve({ ok: true, json: async () => ({ token: 'test-csrf-token' }) });
+    }
+    return Promise.resolve({ ok: true, json: async () => rows });
+  });
+};
+
+/** The `title` attribute of the single rendered graph header. */
+const graphTitle = () => document.querySelector('.graph-title')?.getAttribute('title') ?? '';
+
+/** Text of the numeric-mode readout. */
+const numericValue = () =>
+  document.querySelector('.telemetry-numeric-value')?.textContent ?? '';
+
+global.fetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  widgetMode = 'numeric';
+  captured.yAxis.length = 0;
+  captured.tooltip.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+
+describe('TelemetryGraphs uptime humanization (#3261)', () => {
+  it.each([['uptimeSeconds'], ['hostUptimeSeconds'], ['paxcounterUptime'], ['mc_uptime_secs']])(
+    'numeric mode humanizes %s instead of raw seconds',
+    async telemetryType => {
+      serveTelemetry([row(telemetryType, UPTIME_SECONDS, 's')]);
+      renderGraphs();
+
+      await waitFor(() => expect(screen.getByText('17d 20h')).toBeTruthy());
+      expect(screen.queryByText(String(UPTIME_SECONDS))).toBeNull();
+    }
+  );
+
+  it('drops the redundant "s" unit from the graph header', async () => {
+    serveTelemetry([row('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderGraphs();
+
+    await waitFor(() => expect(document.querySelector('.graph-title')).toBeTruthy());
+    // Regression: this read "Device Uptime (s)" before the fix.
+    expect(graphTitle()).toContain('Device Uptime');
+    expect(graphTitle()).not.toContain('(s)');
+  });
+
+  it('gauge mode humanizes the uptime value', async () => {
+    widgetMode = 'gauge';
+    serveTelemetry([row('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderGraphs();
+
+    await waitFor(() => expect(screen.getByText('17d 20h')).toBeTruthy());
+    expect(screen.queryByText(String(UPTIME_SECONDS))).toBeNull();
+  });
+
+  it('chart mode wires duration formatters into the Y-axis and tooltip', async () => {
+    widgetMode = 'chart';
+    serveTelemetry([row('uptimeSeconds', UPTIME_SECONDS, 's')]);
+    renderGraphs();
+
+    await waitFor(() => expect(captured.yAxis.length).toBeGreaterThan(0));
+
+    const leftAxis = captured.yAxis.find(p => p.yAxisId === 'left');
+    const tickFormatter = leftAxis!.tickFormatter as (v: number) => string;
+    expect(tickFormatter(90000)).toBe('1d 1h');
+
+    const formatter = captured.tooltip[0].formatter as (
+      value: number | string,
+      name: string
+    ) => number | string;
+    expect(formatter(UPTIME_SECONDS, 'value')).toBe('17d 20h');
+    // Solar overlay stays in watt-hours.
+    expect(formatter(5.5, 'solarEstimate')).toBe(5.5);
+  });
+
+  it('leaves non-uptime, non-integer metrics untouched', async () => {
+    widgetMode = 'chart';
+    // channelUtilization is a float, so no integer tick formatter competes here.
+    serveTelemetry([row('channelUtilization', 15.5, '%')]);
+    renderGraphs();
+
+    await waitFor(() => expect(captured.yAxis.length).toBeGreaterThan(0));
+
+    const leftAxis = captured.yAxis.find(p => p.yAxisId === 'left');
+    expect(leftAxis!.tickFormatter).toBeUndefined();
+    expect(captured.tooltip[0]?.formatter).toBeUndefined();
+    expect(graphTitle()).toContain('(%)');
+  });
+
+  it('keeps the integer tick formatter for integer metrics', async () => {
+    widgetMode = 'chart';
+    serveTelemetry([row('numOnlineNodes', 12, '')]);
+    renderGraphs();
+
+    await waitFor(() => expect(captured.yAxis.length).toBeGreaterThan(0));
+
+    const leftAxis = captured.yAxis.find(p => p.yAxisId === 'left');
+    const tickFormatter = leftAxis!.tickFormatter as (v: number) => string;
+    expect(tickFormatter(12.4)).toBe('12');
+  });
+});
+
+describe('TelemetryGraphs current/power auto-scaling (#3261)', () => {
+  it('shows a sub-1 A reading in mA', async () => {
+    serveTelemetry([row('mc_current', 0.05, 'A')]);
+    renderGraphs();
+
+    await waitFor(() => expect(numericValue()).not.toBe(''));
+    expect(Number(numericValue())).toBeCloseTo(50, 2);
+    expect(graphTitle()).toContain('(mA)');
+  });
+
+  it('leaves a >= 1 A reading in A', async () => {
+    serveTelemetry([row('mc_current', 2.5, 'A')]);
+    renderGraphs();
+
+    await waitFor(() => expect(numericValue()).not.toBe(''));
+    expect(Number(numericValue())).toBeCloseTo(2.5, 2);
+    expect(graphTitle()).toContain('(A)');
+  });
+});

--- a/src/utils/telemetryFormat.test.ts
+++ b/src/utils/telemetryFormat.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { unitScale, scaleMeasurement, isUptimeType, formatDuration } from './telemetryFormat';
+import {
+  unitScale,
+  scaleMeasurement,
+  isUptimeType,
+  formatDuration,
+  telemetryDisplayScale,
+} from './telemetryFormat';
 
 describe('unitScale', () => {
   it('keeps amps above 1 A in A', () => {
@@ -110,5 +116,55 @@ describe('formatDuration', () => {
 
   it('clamps negatives to zero', () => {
     expect(formatDuration(-100)).toBe('0m');
+  });
+});
+
+describe('telemetryDisplayScale', () => {
+  it('humanizes uptime and drops the redundant "s" unit', () => {
+    const d = telemetryDisplayScale('uptimeSeconds', [1543452], 's');
+    expect(d.isUptime).toBe(true);
+    expect(d.factor).toBe(1);
+    expect(d.unit).toBe('');
+    expect(d.formatValue!(1543452)).toBe('17d 20h');
+  });
+
+  it.each(['hostUptimeSeconds', 'paxcounterUptime', 'mc_uptime_secs'])(
+    'treats %s as an uptime series',
+    type => {
+      expect(telemetryDisplayScale(type, [90000], 's').isUptime).toBe(true);
+    }
+  );
+
+  it('picks one prefix for the whole series from its largest magnitude', () => {
+    // The 0.9 A peak keeps the series in mA rather than flipping per point.
+    const d = telemetryDisplayScale('mc_current', [0.02, 0.9, 0.05], 'A');
+    expect(d.factor).toBe(1000);
+    expect(d.unit).toBe('mA');
+    expect(d.formatValue).toBeUndefined();
+  });
+
+  it('keeps a series with an amp-scale peak in A', () => {
+    const d = telemetryDisplayScale('mc_current', [0.02, 2.5], 'A');
+    expect(d.factor).toBe(1);
+    expect(d.unit).toBe('A');
+  });
+
+  it('ignores nulls and non-finite entries when sizing the series', () => {
+    const d = telemetryDisplayScale('mc_power', [null, undefined, NaN, 0.012], 'W');
+    expect(d.unit).toBe('mW');
+    expect(d.factor).toBe(1000);
+  });
+
+  it('leaves non-scalable units alone', () => {
+    expect(telemetryDisplayScale('voltage', [3.7], 'V')).toEqual({
+      isUptime: false,
+      factor: 1,
+      unit: 'V',
+    });
+  });
+
+  it('handles an empty series', () => {
+    const d = telemetryDisplayScale('channelUtilization', [], '%');
+    expect(d).toEqual({ isUptime: false, factor: 1, unit: '%' });
   });
 });

--- a/src/utils/telemetryFormat.ts
+++ b/src/utils/telemetryFormat.ts
@@ -104,3 +104,51 @@ export function formatDuration(seconds: number): string {
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
 }
+
+/** How one telemetry series should be scaled and labelled for display. */
+export interface TelemetryDisplay {
+  /** True when the series is an uptime in seconds. */
+  isUptime: boolean;
+  /** Multiply a stored value by this to get the displayed value. */
+  factor: number;
+  /** Unit for titles/gauges. Empty for uptime — "3d 4h" carries its own. */
+  unit: string;
+  /**
+   * Formatter for gauge readouts, numeric labels, axis ticks and tooltips.
+   * Undefined when the raw number is already the right thing to show.
+   */
+  formatValue?: (value: number) => string;
+}
+
+/**
+ * Resolve the display scale for a whole telemetry series (#3261).
+ *
+ * Both chart surfaces — the Dashboard widget (`TelemetryChart`) and the
+ * per-node graphs (`TelemetryGraphs`) — call this so they cannot drift apart:
+ * the Dashboard fix originally shipped alone and left the per-node graphs
+ * rendering "Device Uptime (s)" with raw seconds.
+ *
+ * One factor is chosen for the entire series (from its largest magnitude) so
+ * every point, the axis, the gauge range and the numeric readout share one
+ * prefix. Temperature is *not* handled here — it has its own C/F conversion
+ * in the callers.
+ *
+ * @param type       telemetry type key (e.g. `uptimeSeconds`, `mc_current`)
+ * @param values     the series values; nulls and non-finite entries ignored
+ * @param storedUnit the unit the values are stored in (e.g. `A`, `W`, `s`)
+ */
+export function telemetryDisplayScale(
+  type: string,
+  values: Array<number | null | undefined>,
+  storedUnit: string
+): TelemetryDisplay {
+  if (isUptimeType(type)) {
+    return { isUptime: true, factor: 1, unit: '', formatValue: formatDuration };
+  }
+  const seriesMaxAbs = values.reduce<number>(
+    (max, v) => (typeof v === 'number' && Number.isFinite(v) ? Math.max(max, Math.abs(v)) : max),
+    0
+  );
+  const scale = unitScale(storedUnit, seriesMaxAbs);
+  return { isUptime: false, factor: scale.factor, unit: scale.unit };
+}


### PR DESCRIPTION
Closes #3261
Closes #4436

Both issues were reopened because the earlier fixes didn't reach the surfaces the reporter was actually looking at. Each had a different root cause than the follow-up analysis in the issue threads suggested.

## #3261 — the fix landed on the wrong twin

PR #4439 humanized uptime in `TelemetryChart.tsx` (the Dashboard widget grid). Its near-identical twin, `TelemetryGraphs.tsx` — the per-node graphs rendered by `InfoTab`, `MessagesTab` and `MeshCoreDirectMessagesView` — was never touched. It has the same chart/gauge/numeric mode toggle, so it reads as "the widget" too.

The `(s)` suffix in the reporter's screenshot is the decisive tell: `TelemetryChart` sets `unit = ''` for uptime and so *cannot* render `Device Uptime (s)`. `TelemetryGraphs` could, and did. No stale Docker image involved.

`TelemetryGraphs` also never got the mA/mW auto-scaling that was this issue's original ask.

Both components now derive their display scale from one shared helper, `telemetryDisplayScale()` in `src/utils/telemetryFormat.ts`, which returns `{ isUptime, factor, unit, formatValue }` for a whole series. Callers keep their own temperature C/F handling. `TelemetryChart` is refactored onto it so the pair cannot drift a third time.

## #4436 — the layout difference isn't `pinToBottom`

`.sidebar-controls` (pin + collapse) was absolutely positioned at a hardcoded `bottom: 70px` — a strip sized for the three-item footer that the shared `SidebarFooter` replaced. The new footer carries six icons with `flex-wrap`, and in the 60px collapsed rail they wrapped one per line, making the footer ~190px tall. The controls landed on top of it.

- The controls now sit in normal flow above the footer. No magic number, and the matching `padding-bottom: 120px` reservation on `.sidebar-nav` goes away with it.
- A new `narrowIcons` option lays the collapsed rail's icons out as a two-column grid (3 short rows instead of 6 full-width ones).
- Dead `.sidebar-footer` / `.version-text` / `.news-link` rules left behind by the original #4436 refactor are removed (`.github-link` stays — `LoginPage` uses it).

The other follow-up reported on that issue — Settings using a different mechanism per context — **is not a defect**. `UIContext.setActiveTab` navigates the router to `/source/:id/settings` (`src/contexts/UIContext.tsx:81-84`), so both contexts change the URL and both support the back button. They deliberately land on different Settings surfaces. Likewise the unified dashboard's footer *is* bottom-anchored: `.dashboard-sidebar-links` above it carries `margin-top: auto`.

## Testing

- Full Vitest suite: **13,196 tests, 0 failures** (713 skipped — the PG/MySQL suites; this change is frontend-only, no schema or migration work).
- New `src/components/TelemetryGraphs.uptime.test.tsx` (11 tests): humanization across numeric/gauge/chart modes for all four uptime types, the dropped `(s)` suffix, solar overlay left alone, the integer tick formatter preserved, and A→mA scaling both ways.
- New `telemetryDisplayScale` unit tests, plus a `narrowIcons` test on `SidebarFooter`.
- `npm run lint:ci` clean; `tsc --noEmit` clean.
- **Verified in the dev container**, not just in tests:
  - Device Uptime graph title renders `Device Uptime` (no `(s)`); Y-axis ticks read `0m / 11h 6m / 22h13m / 1d 9h / 1d 20h`; numeric mode `2h 9m`; gauge mode `2h 9m`.
  - Collapsed sidebar: controls at y 1900–1944, footer at 1944–2037 — **0px overlap** (was overlapping before).
  - Expanded sidebar: pin/collapse right-aligned above a single-row footer, version line intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)