### PR TITLE
fix(traceroute): relayed participation in the node picker is MQTT-only

### DIFF
--- a/src/db/repositories/sources.test.ts
+++ b/src/db/repositories/sources.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-import { SourcesRepository } from './sources.js';
+import { SourcesRepository, isMqttSourceType } from './sources.js';
 import * as schema from '../schema/index.js';
 import { createTestDb } from '../../server/test-helpers/testDb.js';
 
@@ -102,5 +102,22 @@ describe('SourcesRepository', () => {
 
     const sources = await repo.getAllSources();
     expect(sources.map((s) => s.id)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('isMqttSourceType', () => {
+  it('is true for both MQTT source types', () => {
+    expect(isMqttSourceType('mqtt_broker')).toBe(true);
+    expect(isMqttSourceType('mqtt_bridge')).toBe(true);
+  });
+
+  it('is false for the node-backed source types', () => {
+    expect(isMqttSourceType('meshtastic_tcp')).toBe(false);
+    expect(isMqttSourceType('meshcore')).toBe(false);
+  });
+
+  it('is false for an unknown/missing type (a failed lookup is not MQTT)', () => {
+    expect(isMqttSourceType(undefined)).toBe(false);
+    expect(isMqttSourceType(null)).toBe(false);
   });
 });

--- a/src/db/repositories/sources.ts
+++ b/src/db/repositories/sources.ts
@@ -21,6 +21,19 @@ export interface Source {
   createdBy: number | null;
 }
 
+/**
+ * True for the two MQTT source types.
+ *
+ * An MQTT source is a firehose with no origin node of its own, which changes
+ * what some per-node views can meaningfully show — see the traceroute
+ * participation picker in `tracerouteRoutes.ts`. Accepts `undefined`/`null` so
+ * a caller can pass a lookup that missed without a separate guard; an unknown
+ * type is not MQTT.
+ */
+export function isMqttSourceType(type: Source['type'] | undefined | null): boolean {
+  return type === 'mqtt_broker' || type === 'mqtt_bridge';
+}
+
 export interface CreateSourceInput {
   id: string;
   name: string;

--- a/src/db/repositories/traceroutes.participation.test.ts
+++ b/src/db/repositories/traceroutes.participation.test.ts
@@ -225,4 +225,124 @@ describe('TraceroutesRepository.getTraceroutesInvolvingNode (phase 2 §4/§8.2)'
     });
     expect(result).toHaveLength(2);
   });
+
+  // Relayed participation is MQTT-only; a Meshtastic/MeshCore source's picker
+  // must list only the routes the node is an endpoint of.
+  describe('endpointOnly', () => {
+    /** One endpoint row + one relayed row, both involving node 111. */
+    async function seedBoth() {
+      await repo.insertTraceroute(
+        makeTraceroute({ fromNodeNum: 111, toNodeNum: 222, timestamp: Date.now(), packetId: 1 }),
+        'src-a',
+      );
+      await repo.insertTraceroute(
+        makeTraceroute({
+          fromNodeNum: 333,
+          toNodeNum: 444,
+          route: '[111]',
+          timestamp: Date.now() + 1,
+          packetId: 2,
+        }),
+        'src-a',
+      );
+    }
+
+    it('drops relayed rows and keeps endpoint rows', async () => {
+      await seedBoth();
+      const result = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        endpointOnly: true,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].packetId).toBe(1);
+      expect(result[0].participation).toBe('endpoint');
+    });
+
+    it('keeps relayed rows when not set (the MQTT path)', async () => {
+      await seedBoth();
+      const result = await repo.getTraceroutesInvolvingNode(111, { sourceId: 'src-a' });
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.participation).sort()).toEqual(['endpoint', 'hop']);
+    });
+
+    it('matches the node on either endpoint column', async () => {
+      await repo.insertTraceroute(
+        makeTraceroute({ fromNodeNum: 111, toNodeNum: 222, packetId: 1 }),
+        'src-a',
+      );
+      await repo.insertTraceroute(
+        makeTraceroute({ fromNodeNum: 222, toNodeNum: 111, packetId: 2, timestamp: Date.now() + 1 }),
+        'src-a',
+      );
+      const result = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        endpointOnly: true,
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('stays source-scoped', async () => {
+      await repo.insertTraceroute(makeTraceroute({ fromNodeNum: 111, toNodeNum: 222 }), 'src-a');
+      await repo.insertTraceroute(makeTraceroute({ fromNodeNum: 111, toNodeNum: 222 }), 'src-b');
+      const result = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        endpointOnly: true,
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('honours sinceTimestamp and limit, newest first', async () => {
+      const now = Date.now();
+      for (let i = 0; i < 5; i++) {
+        await repo.insertTraceroute(
+          makeTraceroute({ fromNodeNum: 111, toNodeNum: 222, timestamp: now + i, packetId: i }),
+          'src-a',
+        );
+      }
+      const limited = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        endpointOnly: true,
+        limit: 2,
+      });
+      expect(limited).toHaveLength(2);
+      expect(limited[0].packetId).toBe(4);
+
+      const windowed = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        endpointOnly: true,
+        sinceTimestamp: now + 3,
+      });
+      expect(windowed).toHaveLength(2);
+    });
+
+    it('is not bounded by scanLimit — an old pair survives a busy source', async () => {
+      const now = Date.now();
+      // The node's only route is the oldest row, behind 30 unrelated ones.
+      await repo.insertTraceroute(
+        makeTraceroute({ fromNodeNum: 111, toNodeNum: 222, timestamp: now, packetId: 999 }),
+        'src-a',
+      );
+      for (let i = 1; i <= 30; i++) {
+        await repo.insertTraceroute(
+          makeTraceroute({ fromNodeNum: 777, toNodeNum: 888, timestamp: now + i, packetId: i }),
+          'src-a',
+        );
+      }
+      // The scan window never reaches it...
+      const scanned = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        scanLimit: 5,
+      });
+      expect(scanned).toHaveLength(0);
+
+      // ...but the pushed-down SQL predicate finds it regardless.
+      const direct = await repo.getTraceroutesInvolvingNode(111, {
+        sourceId: 'src-a',
+        endpointOnly: true,
+        scanLimit: 5,
+      });
+      expect(direct).toHaveLength(1);
+      expect(direct[0].packetId).toBe(999);
+    });
+  });
 });

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -235,6 +235,11 @@ export class TraceroutesRepository extends BaseRepository {
       // Every row matched on an endpoint column, so the kind is known without
       // re-deriving it — but go through the shared classifier anyway so the
       // two modes cannot disagree about what "endpoint" means.
+      //
+      // The `?? 'endpoint'` is unreachable in practice: the classifier returns
+      // null only when the node is neither an endpoint nor a hop, and the SQL
+      // predicate above already proved it is an endpoint. It is a defensive
+      // default for a classifier/predicate divergence, not a real case.
       return (this.normalizeBigInts(rows) as DbTraceroute[]).map(row => ({
         ...row,
         participation: tracerouteParticipationKind(row, nodeNum) ?? 'endpoint',

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -168,21 +168,35 @@ export class TraceroutesRepository extends BaseRepository {
 
   /**
    * Every traceroute on `sourceId` that `nodeNum` took part in — as an endpoint
-   * OR as an intermediate hop in `route`/`routeBack` — newest first.
+   * OR (when `endpointOnly` is false) as an intermediate hop in
+   * `route`/`routeBack` — newest first.
    *
-   * Hop membership lives inside a JSON string column. There is no
-   * database-agnostic SQL for that (LIKE-matching JSON text is wrong across
-   * three backends and would match substrings of other node numbers), and raw
-   * SQL is banned outside migrations. So this does ONE bounded, ordered,
-   * source-scoped scan through the query builder and filters in JS.
+   * `endpointOnly` exists because "traceroutes this node relayed" is only
+   * meaningful for an MQTT source. An MQTT source has no origin node of its
+   * own, so relayed rows are the only way its nodes can render the strip at
+   * all. A Meshtastic/MeshCore source *does* have an origin node, and its
+   * picker should list the routes between that node and the selected one —
+   * showing routes between two other nodes that merely passed through is
+   * confusing there, and made the picker's list (38) disagree with the
+   * statistical aggregate's count (25) for the same node. The caller decides
+   * from the source's type; see `tracerouteRoutes.ts`.
    *
-   * `scanLimit` bounds memory. Because the scan is newest-first, exceeding it
-   * can only drop OLDER participations — never the ones the picker shows.
+   * The two modes take deliberately different paths:
    *
-   * `sinceTimestamp` is optional: when omitted, no time filter is applied and
-   * the bounded newest-first `scanLimit` scan alone limits the work (picker
-   * parity with the Traceroute History dialog — issue-referenced amendment,
-   * see SR_PHASE2_SPEC.md D14/S1).
+   * - `endpointOnly`: endpoint membership is two indexed columns, so it is a
+   *   plain SQL predicate with the real `limit` pushed down. No scan window,
+   *   so an old pair can never fall off the end of a busy source's history.
+   * - Full participation: hop membership lives inside a JSON string column.
+   *   There is no database-agnostic SQL for that (LIKE-matching JSON text is
+   *   wrong across three backends and would match substrings of other node
+   *   numbers), and raw SQL is banned outside migrations. So this does ONE
+   *   bounded, ordered, source-scoped scan through the query builder and
+   *   filters in JS. `scanLimit` bounds memory; because the scan is
+   *   newest-first, exceeding it can only drop OLDER participations.
+   *
+   * `sinceTimestamp` is optional: when omitted, no time filter is applied
+   * (picker parity with the Traceroute History dialog — issue-referenced
+   * amendment, see SR_PHASE2_SPEC.md D14/S1).
    */
   async getTraceroutesInvolvingNode(
     nodeNum: number,
@@ -191,6 +205,9 @@ export class TraceroutesRepository extends BaseRepository {
        *  per-source by definition, so an `ALL_SOURCES` caller is a bug this
        *  signature makes unrepresentable. */
       sourceId: string;
+      /** Restrict to rows where `nodeNum` is `fromNodeNum` or `toNodeNum`,
+       *  excluding relayed (hop) participation. */
+      endpointOnly?: boolean;
       sinceTimestamp?: number;
       limit?: number;
       scanLimit?: number;
@@ -203,6 +220,25 @@ export class TraceroutesRepository extends BaseRepository {
     const conditions = [this.withSourceScope(traceroutes, opts.sourceId)];
     if (opts.sinceTimestamp !== undefined) {
       conditions.push(gte(traceroutes.timestamp, opts.sinceTimestamp));
+    }
+
+    if (opts.endpointOnly) {
+      conditions.push(
+        or(eq(traceroutes.fromNodeNum, nodeNum), eq(traceroutes.toNodeNum, nodeNum))!,
+      );
+      const rows = await this.db
+        .select()
+        .from(traceroutes)
+        .where(and(...conditions))
+        .orderBy(desc(traceroutes.timestamp))
+        .limit(limit);
+      // Every row matched on an endpoint column, so the kind is known without
+      // re-deriving it — but go through the shared classifier anyway so the
+      // two modes cannot disagree about what "endpoint" means.
+      return (this.normalizeBigInts(rows) as DbTraceroute[]).map(row => ({
+        ...row,
+        participation: tracerouteParticipationKind(row, nodeNum) ?? 'endpoint',
+      }));
     }
 
     const rows = await this.db

--- a/src/server/routes/tracerouteRoutes.participation.test.ts
+++ b/src/server/routes/tracerouteRoutes.participation.test.ts
@@ -171,19 +171,87 @@ describe('GET /api/traceroutes/participation/:nodeNum', () => {
     expect(res.body.data.entries).toHaveLength(0);
   });
 
-  it('returns hop-only participation (node inside route but not an endpoint)', async () => {
-    await seedTraceroute(harness, harness.sourceA, {
-      fromNodeNum: 500,
-      toNodeNum: 600,
-      route: '[111,777]',
+  // Relayed (hop) participation is MQTT-only. harness.sourceA/B are
+  // meshtastic_tcp, so they get the endpoint-only list; an MQTT source gets
+  // every route that passed through the node.
+  describe('relayed participation is scoped by source type', () => {
+    /** An MQTT source alongside the harness's meshtastic ones. */
+    async function createMqttSource(id = 'src-mqtt') {
+      await harness.db.sources.createSource({
+        id,
+        name: 'Test MQTT',
+        type: 'mqtt_bridge',
+        config: {},
+      });
+      return id;
+    }
+
+    it('omits a hop-only row on a meshtastic source', async () => {
+      await seedTraceroute(harness, harness.sourceA, {
+        fromNodeNum: 500,
+        toNodeNum: 600,
+        route: '[111,777]',
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/participation/111').query({ sourceId: harness.sourceA });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.entries).toHaveLength(0);
     });
 
-    const agent = await harness.loginAs(harness.admin);
-    const res = await agent.get('/participation/111').query({ sourceId: harness.sourceA });
+    it('returns a hop-only row on an MQTT source', async () => {
+      const mqttSource = await createMqttSource();
+      await seedTraceroute(harness, mqttSource, {
+        fromNodeNum: 500,
+        toNodeNum: 600,
+        route: '[111,777]',
+      });
 
-    expect(res.status).toBe(200);
-    expect(res.body.data.entries).toHaveLength(1);
-    expect(res.body.data.entries[0].participation).toBe('hop');
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/participation/111').query({ sourceId: mqttSource });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.entries).toHaveLength(1);
+      expect(res.body.data.entries[0].participation).toBe('hop');
+    });
+
+    it('keeps endpoint rows on a meshtastic source', async () => {
+      await seedTraceroute(harness, harness.sourceA, {
+        fromNodeNum: 111,
+        toNodeNum: 222,
+        packetId: 1,
+      });
+      await seedTraceroute(harness, harness.sourceA, {
+        fromNodeNum: 500,
+        toNodeNum: 600,
+        route: '[111]',
+        packetId: 2,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/participation/111').query({ sourceId: harness.sourceA });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.entries).toHaveLength(1);
+      expect(res.body.data.entries[0].participation).toBe('endpoint');
+      expect(res.body.data.entries[0].route).toBeNull();
+    });
+
+    it('falls back to endpoint-only for an unknown source id', async () => {
+      // No sources row for this id; the narrower list is the safe default.
+      await seedTraceroute(harness, 'src-ghost', {
+        fromNodeNum: 500,
+        toNodeNum: 600,
+        route: '[111]',
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/participation/111').query({ sourceId: 'src-ghost' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.entries).toHaveLength(0);
+    });
   });
 
   it('routePositions is absent from every entry', async () => {
@@ -201,12 +269,14 @@ describe('GET /api/traceroutes/participation/:nodeNum', () => {
   });
 
   it('hopCount is null for a null/unparseable route, and the hop-array length otherwise', async () => {
+    // Both rows are endpoint participations for 111 — a relayed row would be
+    // filtered out on this meshtastic source and never reach the projection.
     await seedTraceroute(harness, harness.sourceA, { fromNodeNum: 111, toNodeNum: 222, packetId: 1, route: null });
     await seedTraceroute(harness, harness.sourceA, {
-      fromNodeNum: 333,
+      fromNodeNum: 111,
       toNodeNum: 444,
       packetId: 2,
-      route: '[111]',
+      route: '[999]',
     });
 
     const agent = await harness.loginAs(harness.admin);
@@ -214,7 +284,7 @@ describe('GET /api/traceroutes/participation/:nodeNum', () => {
 
     expect(res.status).toBe(200);
     const nullRouteEntry = res.body.data.entries.find((e: any) => e.route === null);
-    const hopRouteEntry = res.body.data.entries.find((e: any) => e.route === '[111]');
+    const hopRouteEntry = res.body.data.entries.find((e: any) => e.route === '[999]');
     expect(nullRouteEntry.hopCount).toBeNull();
     expect(hopRouteEntry.hopCount).toBe(1);
   });

--- a/src/server/routes/tracerouteRoutes.participation.test.ts
+++ b/src/server/routes/tracerouteRoutes.participation.test.ts
@@ -176,13 +176,8 @@ describe('GET /api/traceroutes/participation/:nodeNum', () => {
   // every route that passed through the node.
   describe('relayed participation is scoped by source type', () => {
     /** An MQTT source alongside the harness's meshtastic ones. */
-    async function createMqttSource(id = 'src-mqtt') {
-      await harness.db.sources.createSource({
-        id,
-        name: 'Test MQTT',
-        type: 'mqtt_bridge',
-        config: {},
-      });
+    async function createMqttSource(type: 'mqtt_bridge' | 'mqtt_broker', id = `src-${type}`) {
+      await harness.db.sources.createSource({ id, name: `Test ${type}`, type, config: {} });
       return id;
     }
 
@@ -200,21 +195,26 @@ describe('GET /api/traceroutes/participation/:nodeNum', () => {
       expect(res.body.data.entries).toHaveLength(0);
     });
 
-    it('returns a hop-only row on an MQTT source', async () => {
-      const mqttSource = await createMqttSource();
-      await seedTraceroute(harness, mqttSource, {
-        fromNodeNum: 500,
-        toNodeNum: 600,
-        route: '[111,777]',
-      });
+    // Both MQTT types, not just the bridge — the two are separate strings in
+    // the sources table and only the predicate knows they behave alike.
+    it.each(['mqtt_bridge', 'mqtt_broker'] as const)(
+      'returns a hop-only row on a %s source',
+      async type => {
+        const mqttSource = await createMqttSource(type);
+        await seedTraceroute(harness, mqttSource, {
+          fromNodeNum: 500,
+          toNodeNum: 600,
+          route: '[111,777]',
+        });
 
-      const agent = await harness.loginAs(harness.admin);
-      const res = await agent.get('/participation/111').query({ sourceId: mqttSource });
+        const agent = await harness.loginAs(harness.admin);
+        const res = await agent.get('/participation/111').query({ sourceId: mqttSource });
 
-      expect(res.status).toBe(200);
-      expect(res.body.data.entries).toHaveLength(1);
-      expect(res.body.data.entries[0].participation).toBe('hop');
-    });
+        expect(res.status).toBe(200);
+        expect(res.body.data.entries).toHaveLength(1);
+        expect(res.body.data.entries[0].participation).toBe('hop');
+      },
+    );
 
     it('keeps endpoint rows on a meshtastic source', async () => {
       await seedTraceroute(harness, harness.sourceA, {

--- a/src/server/routes/tracerouteRoutes.ts
+++ b/src/server/routes/tracerouteRoutes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { requirePermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
 import { ALL_SOURCES } from '../../db/repositories/index.js';
+import { isMqttSourceType } from '../../db/repositories/sources.js';
 import { logger } from '../../utils/logger.js';
 import { ok, fail } from '../utils/apiResponse.js';
 import { maskTraceroutesByChannel } from '../utils/nodeEnhancer.js';
@@ -102,10 +103,23 @@ router.get('/history/:fromNodeNum/:toNodeNum', requirePermission('traceroute', '
 
 // GET /api/traceroutes/participation/:nodeNum?sourceId=…&hours=168&limit=100
 //
-// Every stored traceroute on ONE source that this node took part in — as an
-// endpoint or as an intermediate hop. Backs the Node Details traceroute picker
-// (epic phase 2), which is the only way an MQTT source (no origin node, so no
-// own-request traceroute) can render the strip at all.
+// Stored traceroutes on ONE source that this node took part in. What counts as
+// "took part" depends on the source's type:
+//
+//   MQTT (mqtt_bridge / mqtt_broker) — endpoint OR intermediate hop. An MQTT
+//     source has no origin node of its own and therefore no own-request
+//     traceroute, so relayed rows are the only way its nodes can render the
+//     strip at all. This is what the picker was built for (epic phase 2).
+//
+//   Everything else (meshtastic_tcp / meshcore) — endpoint only. These sources
+//     DO have an origin node, and the picker should list the routes between it
+//     and the selected node. Listing routes between two other nodes that merely
+//     passed through the selected one is confusing, and it made the picker's
+//     list disagree with the statistical aggregate's route count for the same
+//     node (the aggregate is pair-scoped).
+//
+// An unknown/missing source falls back to endpoint-only: the narrower, less
+// surprising list is the safe default when the type can't be established.
 //
 // sourceId is REQUIRED: the picker is per-source by definition, and a silent
 // ALL_SOURCES fallback would mix another source's rows for the same nodeNum.
@@ -147,8 +161,13 @@ router.get(
         return fail(res, 400, 'INVALID_LIMIT', 'limit must be between 1 and 200');
       }
 
+      // Relayed (hop) participation is MQTT-only — see the header comment.
+      const source = await databaseService.sources.getSource(sourceId);
+      const endpointOnly = !isMqttSourceType(source?.type);
+
       const rows = await databaseService.traceroutes.getTraceroutesInvolvingNode(nodeNum, {
         sourceId,
+        endpointOnly,
         sinceTimestamp,
         limit,
       });


### PR DESCRIPTION
## Problem

Reported by @Yeraze: selecting **Yeraze StationG2** on the Sandbox (Meshtastic TCP) source shows a traceroute list where most rows neither begin nor end at that node.

Confirmed against the live source. `/api/traceroutes/participation` returned **38 entries — 25 endpoint, 13 relayed**. The relayed rows are routes between two *other* nodes that merely passed through G2, and the picker labels them by their own endpoints (`8558 → TRON`), so the list reads as if it were showing unrelated traceroutes.

A second symptom falls out of the same cause: the picker's first option is the statistical aggregate, which is **pair-scoped**, so it read `Statistical (25 routes)` above a list of 38. The count and the list were describing different sets.

## Rule

Relayed participation exists for **MQTT** sources. An MQTT source has no origin node of its own and therefore no own-request traceroute — relayed rows are the only way its nodes can render the strip at all, which is what the picker was built for (the route's own header comment already said so). The rule was simply never scoped to the source type.

- `mqtt_bridge` / `mqtt_broker` → endpoint **or** relayed hop (unchanged).
- `meshtastic_tcp` / `meshcore` → endpoint only.
- Unknown/missing source → endpoint only; the narrower list is the safe default.

`GET /api/traceroutes/participation/:nodeNum` now resolves the source and passes `endpointOnly` to `getTraceroutesInvolvingNode`. New `isMqttSourceType()` predicate lives beside the `Source` type.

## Bonus: the endpoint-only path drops the scan window

Hop membership lives in a JSON string column, so the existing implementation scans the 2000 newest source-scoped rows and filters in JS. Endpoint membership is two indexed columns, so `endpointOnly` is a pushed-down SQL predicate carrying the real `limit` — no scan window at all. An old pair can no longer fall off the end of a busy source's history. There is a regression test for exactly that (scan path finds 0, endpoint path finds the row).

## Testing

- Full Vitest suite: **13,208 tests, 0 failures** (713 skipped — the PG/MySQL suites; no schema or migration change here). `npm run lint:ci` clean, `tsc --noEmit` clean on both tsconfigs.
- New repository tests: relayed dropped / kept per flag, either endpoint column matched, source scoping held, `sinceTimestamp`+`limit` honoured newest-first, and the scan-window regression.
- Route tests restructured around source type: hop row omitted on meshtastic, returned on an MQTT source, endpoint rows kept, unknown source falls back to endpoint-only. The `hopCount` test now seeds two endpoint rows, since a relayed row no longer reaches the projection on the harness's `meshtastic_tcp` sources.
- New `isMqttSourceType` unit tests.
- **Verified against live data in the dev container:**
  | query | before | after |
  |---|---|---|
  | StationG2 on Sandbox (meshtastic_tcp) | 38 (25 endpoint + 13 hop) | **25, all endpoint**, all paired with the local node |
  | hop-only node `1424488583` on MQTT bridge | 50 hop | **50 hop** (unchanged) |
  | same hop-only node on Sandbox | 50 hop | **0** |
- UI check: the picker now reads `Statistical (25 routes)` above exactly **25** dated entries, **0** marked relayed, every row `8558 ↔ Yrze`.

## One judgment call

This implements "the selected node is an endpoint of the route" rather than strictly "the route pairs the source node with the selected node". They differ only for a stored route with the selected node at one end and a *third* node at the other. On the live Sandbox source that is 1 row in 66 (`3636107843 → 4294967295` — a broadcast address, so likely malformed). The strict pair filter would need the server to resolve the source's own node number, which fails closed to an empty picker whenever the source is disconnected, so the simpler rule won. Easy to tighten if the stricter reading is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)