### PR TITLE
fix(meshcore): infinite-scroll pagination for channel message history

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -394,6 +394,103 @@ describe('MeshCoreChannelsView — per-channel backlog fetch (#3442)', () => {
   });
 });
 
+describe('MeshCoreChannelsView — infinite scroll pagination (#4460)', () => {
+  // Routes the per-channel-messages endpoint to a different page depending on
+  // whether the request carries an offset, so a scroll-to-top can be observed
+  // fetching (and prepending) the older page.
+  function pagedFetch(page0: MeshCoreMessage[], olderPage: MeshCoreMessage[]) {
+    return vi.fn((url: string) => {
+      if (url.includes('/api/channels/all')) {
+        return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+      }
+      if (url.includes('/messages/channel-counts')) {
+        return Promise.resolve(jsonResponse({ success: true, counts: {} }));
+      }
+      if (url.includes('/messages/channel/0')) {
+        const offsetMatch = /[?&]offset=(\d+)/.exec(url);
+        const offset = offsetMatch ? Number(offsetMatch[1]) : 0;
+        return offset > 0
+          ? Promise.resolve(jsonResponse({ success: true, data: olderPage, hasMore: false }))
+          : Promise.resolve(jsonResponse({ success: true, data: page0, hasMore: true }));
+      }
+      return Promise.resolve(jsonResponse({ success: true, data: [] }));
+    });
+  }
+
+  it('fetches and prepends an older page when scrolled to the top of the channel', async () => {
+    csrfFetchMock.mockImplementation(pagedFetch(
+      [{ id: 'p0', fromPublicKey: 'channel-0', text: 'recent message', timestamp: 200 }],
+      [{ id: 'p-old', fromPublicKey: 'channel-0', text: 'much older message', timestamp: 100 }],
+    ));
+
+    const { container } = render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('recent message')).toBeTruthy());
+    expect(screen.queryByText('much older message')).toBeNull();
+
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    fireEvent.scroll(list);
+
+    await waitFor(() => expect(screen.getByText('much older message')).toBeTruthy());
+    // Still there — the older page is prepended, not swapped in.
+    expect(screen.getByText('recent message')).toBeTruthy();
+
+    const hitOlderPage = csrfFetchMock.mock.calls.some(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('/meshcore/messages/channel/0') && (c[0] as string).includes('offset=1'),
+    );
+    expect(hitOlderPage).toBe(true);
+  });
+
+  it('does not request an older page once hasMore is false', async () => {
+    csrfFetchMock.mockImplementation((url: string) => {
+      if (url.includes('/api/channels/all')) {
+        return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+      }
+      if (url.includes('/messages/channel-counts')) {
+        return Promise.resolve(jsonResponse({ success: true, counts: {} }));
+      }
+      if (url.includes('/messages/channel/0')) {
+        return Promise.resolve(jsonResponse({
+          success: true,
+          data: [{ id: 'p0', fromPublicKey: 'channel-0', text: 'only message', timestamp: 200 }],
+          hasMore: false,
+        }));
+      }
+      return Promise.resolve(jsonResponse({ success: true, data: [] }));
+    });
+
+    const { container } = render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('only message')).toBeTruthy());
+    const callCountBeforeScroll = csrfFetchMock.mock.calls.length;
+
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    fireEvent.scroll(list);
+
+    // No new request should follow — hasMore was false, so there's nothing to page into.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(csrfFetchMock.mock.calls.length).toBe(callCountBeforeScroll);
+  });
+});
+
 describe('MeshCoreChannelsView — sending', () => {
   it('passes the active channel idx to actions.sendMessage', async () => {
     csrfFetchMock.mockImplementation((url: string) => {

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -111,6 +111,19 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // of the global recent-tail). Live updates still arrive via `messages` and
   // are merged in below.
   const [history, setHistory] = useState<MeshCoreMessage[]>([]);
+  // Infinite-scroll pagination for the active channel's history (#4460): does
+  // an older page exist beyond `history`, and is one currently being fetched.
+  // Reset alongside `history` on every channel switch/reconnect.
+  const [hasMoreHistory, setHasMoreHistory] = useState(false);
+  const [loadingOlderHistory, setLoadingOlderHistory] = useState(false);
+  // Mirrors `history` so `loadOlderHistory` always reads the current backlog
+  // length (as the fetch offset) without depending on `history` and thereby
+  // getting a fresh callback identity on every page load.
+  const historyRef = useRef<MeshCoreMessage[]>([]);
+  historyRef.current = history;
+  // Guards `loadOlderHistory` against a stale response landing after the
+  // operator has already switched channels.
+  const activeChannelIdxRef = useRef<number>(0);
   // Accurate persisted message count per channel index (for the list badges),
   // so a quiet channel doesn't read as empty next to a busy one just because
   // the shared pool's recent-tail happened to exclude it.
@@ -382,6 +395,11 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     if (!sourceId) return;
     let cancelled = false;
     const idx = active.id;
+    activeChannelIdxRef.current = idx;
+    // A fresh channel/reconnect always starts pagination over from the newest
+    // page — any in-flight load-older for the previous channel is now stale.
+    setHasMoreHistory(false);
+    setLoadingOlderHistory(false);
     void (async () => {
       try {
         const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/messages/channel/${idx}?limit=200`;
@@ -390,16 +408,57 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
         const data = await response.json();
         if (!cancelled) {
           setHistory(data?.success && Array.isArray(data.data) ? (data.data as MeshCoreMessage[]) : []);
+          setHasMoreHistory(Boolean(data?.hasMore));
         }
       } catch (err) {
         if (!cancelled) {
           console.error('Failed to fetch MeshCore channel messages:', err);
           setHistory([]);
+          setHasMoreHistory(false);
         }
       }
     })();
     return () => { cancelled = true; };
   }, [baseUrl, sourceId, active.id, csrfFetch, status?.connected]);
+
+  // Load an older page of the active channel's history (#4460 infinite scroll).
+  // Offset is the current backlog length (oldest-first fetch order means the
+  // next page picks up right where `history`'s oldest entry leaves off).
+  // Idempotent against overlapping calls: bails if a load is already in
+  // flight or the channel has no older page.
+  const loadOlderHistory = useCallback(() => {
+    if (!sourceId || loadingOlderHistory || !hasMoreHistory) return;
+    const idx = active.id;
+    const offset = historyRef.current.length;
+    setLoadingOlderHistory(true);
+    void (async () => {
+      try {
+        const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/messages/channel/${idx}?limit=100&offset=${offset}`;
+        const response = await csrfFetch(url);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        // The operator may have switched channels while this was in flight —
+        // discard a response that no longer matches the active channel.
+        if (activeChannelIdxRef.current !== idx) return;
+        if (data?.success && Array.isArray(data.data)) {
+          const older = data.data as MeshCoreMessage[];
+          setHistory(prev => {
+            const seen = new Set(prev.map(m => m.id));
+            const fresh = older.filter(m => !seen.has(m.id));
+            return [...fresh, ...prev];
+          });
+          setHasMoreHistory(Boolean(data.hasMore));
+        } else {
+          setHasMoreHistory(false);
+        }
+      } catch (err) {
+        console.error('Failed to load older MeshCore channel messages:', err);
+        if (activeChannelIdxRef.current === idx) setHasMoreHistory(false);
+      } finally {
+        if (activeChannelIdxRef.current === idx) setLoadingOlderHistory(false);
+      }
+    })();
+  }, [sourceId, baseUrl, csrfFetch, active.id, hasMoreHistory, loadingOlderHistory]);
 
   // Merge the fetched backlog with any live messages for this channel (socket
   // pushes land in `messages`). Dedupe by id, letting the live copy win so
@@ -662,6 +721,9 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           onNodeNameClick={onNodeNameClick}
           onReply={handleReply}
           conversationKey={`channel-${active.id}`}
+          onLoadOlder={loadOlderHistory}
+          hasMoreOlder={hasMoreHistory}
+          loadingOlder={loadingOlderHistory}
           maxBytes={
             showScopeOverride && overrideScope !== null && overrideScope !== ''
               ? 120

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -402,6 +402,10 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     setLoadingOlderHistory(false);
     void (async () => {
       try {
+        // The initial page is intentionally larger than a load-older page
+        // (200 vs. loadOlderHistory's 100 below) — worth front-loading more
+        // on first open since it's the one fetch every channel visit pays
+        // for, while later pages are opportunistic and don't need to match.
         const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/messages/channel/${idx}?limit=200`;
         const response = await csrfFetch(url);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -363,6 +363,45 @@ describe('MeshCoreMessageStream load older (#4460)', () => {
     // newScrollTop = scrollHeightAfter(380) - scrollHeightBefore(300) + scrollTopBefore(10)
     expect(list.scrollTop).toBe(90);
   });
+
+  it('discards a pending restore when the conversation changes mid-load', () => {
+    const onLoadOlder = vi.fn();
+    const { container, rerender } = render(
+      <MeshCoreMessageStream
+        messages={twoMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+        loadingOlder={false}
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    list.scrollTop = 10;
+    fireEvent.scroll(list);
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+
+    // The operator switches channels before that load settles. The parent
+    // resets its load-older state on a channel switch, so the request never
+    // resolves back into this component — the captured metrics are now stale.
+    scrollHeightValue = 380;
+    rerender(
+      <MeshCoreMessageStream
+        messages={[msg('x', 5000, 'other channel'), msg('y', 6000, 'other channel 2')]}
+        conversationKey="channel-1"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder={false}
+        loadingOlder={false}
+      />,
+    );
+
+    // The new conversation must land at the bottom via the entry scroll (380),
+    // NOT at 380 - 300 + 10 = 90, which is what channel-0's abandoned snapshot
+    // would produce if the restore ref survived the conversation change.
+    expect(list.scrollTop).toBe(380);
+    expect(list.scrollTop).not.toBe(90);
+  });
 });
 
 describe('MeshCoreMessageStream focus restore (#3823)', () => {

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -227,6 +227,144 @@ describe('MeshCoreMessageStream entry scroll (#3810)', () => {
   });
 });
 
+describe('MeshCoreMessageStream load older (#4460)', () => {
+  let scrollHeightValue = 0;
+
+  beforeEach(() => {
+    // Run rAF callbacks synchronously so the scroll-restore effect commits
+    // during the test instead of on a later animation frame.
+    vi.stubGlobal('requestAnimationFrame', (cb: (time: number) => void) => {
+      cb(0);
+      return 0;
+    });
+    scrollHeightValue = 300;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() { return scrollHeightValue; },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() { return 200; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight;
+    delete (HTMLElement.prototype as { clientHeight?: number }).clientHeight;
+  });
+
+  const twoMessages = () => [
+    msg('b', 2000, 'second'),
+    msg('c', 3000, 'third'),
+  ];
+
+  it('calls onLoadOlder when scrolled near the top and an older page exists', () => {
+    const onLoadOlder = vi.fn();
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={twoMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    list.scrollTop = 10;
+    fireEvent.scroll(list);
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onLoadOlder when there is no older page', () => {
+    const onLoadOlder = vi.fn();
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={twoMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder={false}
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    list.scrollTop = 10;
+    fireEvent.scroll(list);
+    expect(onLoadOlder).not.toHaveBeenCalled();
+  });
+
+  it('does not call onLoadOlder while a load is already in flight', () => {
+    const onLoadOlder = vi.fn();
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={twoMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+        loadingOlder
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    list.scrollTop = 10;
+    fireEvent.scroll(list);
+    expect(onLoadOlder).not.toHaveBeenCalled();
+  });
+
+  it('does not call onLoadOlder when not scrolled near the top', () => {
+    const onLoadOlder = vi.fn();
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={twoMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    list.scrollTop = 150;
+    fireEvent.scroll(list);
+    expect(onLoadOlder).not.toHaveBeenCalled();
+  });
+
+  it('restores the viewport to the same content once older messages are prepended', () => {
+    const onLoadOlder = vi.fn();
+    const { container, rerender } = render(
+      <MeshCoreMessageStream
+        messages={twoMessages()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+        loadingOlder={false}
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    list.scrollTop = 10;
+    fireEvent.scroll(list);
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+
+    // Simulate the fetch resolving: the parent prepends an older message
+    // (growing scrollHeight by 80px of new content) and flips loadingOlder
+    // back to false.
+    scrollHeightValue = 380;
+    rerender(
+      <MeshCoreMessageStream
+        messages={[msg('a', 1000, 'first'), ...twoMessages()]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder={false}
+        loadingOlder={false}
+      />,
+    );
+
+    // newScrollTop = scrollHeightAfter(380) - scrollHeightBefore(300) + scrollTopBefore(10)
+    expect(list.scrollTop).toBe(90);
+  });
+});
+
 describe('MeshCoreMessageStream focus restore (#3823)', () => {
   it('returns focus to the input after a send resolves', async () => {
     // Controllable send so we can observe the disabled→enabled transition.

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -199,6 +199,18 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   const pendingOlderRestoreRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
   const lastLoadOlderAtRef = useRef(0);
 
+  // Drop any load-older snapshot when the conversation changes. Without this, a
+  // load-older triggered in one conversation and abandoned by switching away
+  // (the parent resets `loadingOlder`, so the request never settles here) leaves
+  // stale metrics in the ref. The restore effect below would then fire on the
+  // NEW conversation's first message change and scroll it to a position derived
+  // from the old conversation's height — beating the entry scroll, since both
+  // use requestAnimationFrame and the restore is registered later.
+  // Declared before that effect so it clears the ref first on a key change.
+  useEffect(() => {
+    pendingOlderRestoreRef.current = null;
+  }, [conversationKey]);
+
   const handleScroll = useCallback(() => {
     const container = listRef.current;
     if (!container) return;

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -28,7 +28,23 @@ interface MeshCoreMessageStreamProps {
   conversationKey?: string;
   /** Maximum UTF-8 byte length for a message. Send is blocked when exceeded. */
   maxBytes?: number;
+  /** When provided together with `hasMoreOlder`, the stream requests older
+   *  history (#4460) once the user scrolls near the top, throttled to avoid
+   *  spamming the caller. The caller owns fetching/prepending and is expected
+   *  to be idempotent against overlapping calls (guard on `loadingOlder`). */
+  onLoadOlder?: () => void;
+  /** Whether an older page of history exists beyond what's currently loaded. */
+  hasMoreOlder?: boolean;
+  /** True while a load-older request is in flight. Used to gate re-triggering
+   *  and to know when it's safe to restore scroll position after older
+   *  messages are prepended. */
+  loadingOlder?: boolean;
 }
+
+/** Scroll-to-top distance (px) that triggers a load-older request. */
+const LOAD_OLDER_THRESHOLD_PX = 100;
+/** Minimum time between load-older triggers, to avoid spamming scroll events. */
+const LOAD_OLDER_THROTTLE_MS = 200;
 
 function formatTime(ts: number): string {
   return new Date(ts).toLocaleTimeString();
@@ -75,6 +91,9 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   onDeleteMessage,
   conversationKey,
   maxBytes = 130,
+  onLoadOlder,
+  hasMoreOlder,
+  loadingOlder,
 }) => {
   const { t } = useTranslation();
   const [draft, setDraft] = useState('');
@@ -174,13 +193,51 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     }
   }, [messages.length]);
 
+  // Scroll metrics captured right before a load-older request fires, so the
+  // restore effect below can keep the same content under the viewport once
+  // older messages are prepended (rather than jumping the user to the top).
+  const pendingOlderRestoreRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
+  const lastLoadOlderAtRef = useRef(0);
+
   const handleScroll = useCallback(() => {
     const container = listRef.current;
     if (!container) return;
     const isNearBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight < 100;
     setShowJumpToBottom(!isNearBottom);
-  }, []);
+
+    if (
+      onLoadOlder &&
+      hasMoreOlder &&
+      !loadingOlder &&
+      container.scrollTop < LOAD_OLDER_THRESHOLD_PX
+    ) {
+      const now = Date.now();
+      if (now - lastLoadOlderAtRef.current > LOAD_OLDER_THROTTLE_MS) {
+        lastLoadOlderAtRef.current = now;
+        pendingOlderRestoreRef.current = {
+          scrollHeight: container.scrollHeight,
+          scrollTop: container.scrollTop,
+        };
+        onLoadOlder();
+      }
+    }
+  }, [onLoadOlder, hasMoreOlder, loadingOlder]);
+
+  // Once a load-older request settles (loadingOlder flips back to false),
+  // restore the viewport to the same content it was showing before older
+  // messages were prepended — otherwise the prepend would visually yank the
+  // conversation down by the height of the newly-inserted rows.
+  useEffect(() => {
+    if (loadingOlder) return;
+    const container = listRef.current;
+    const pending = pendingOlderRestoreRef.current;
+    if (!container || !pending) return;
+    pendingOlderRestoreRef.current = null;
+    requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight - pending.scrollHeight + pending.scrollTop;
+    });
+  }, [messages, loadingOlder]);
 
   const scrollToBottom = useCallback(() => {
     const container = listRef.current;

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -764,6 +764,27 @@ describe('MeshCoreRepository — sourceId stamping', () => {
       const rows = await repo.getChannelMessages(1, 2, 'src-a');
       expect(rows.map(r => r.id)).toEqual(['c1-4', 'c1-3']);
     });
+
+    // #4460 — infinite-scroll pagination for the MeshCore channel view.
+    it('honors offset to page further back into history', async () => {
+      for (let i = 0; i < 5; i++) {
+        await insert(`c1-${i}`, { fromPublicKey: 'channel-1', timestamp: 500 + i }, 'src-a');
+      }
+      const firstPage = await repo.getChannelMessages(1, 2, 'src-a', 0);
+      expect(firstPage.map(r => r.id)).toEqual(['c1-4', 'c1-3']);
+      const secondPage = await repo.getChannelMessages(1, 2, 'src-a', 2);
+      expect(secondPage.map(r => r.id)).toEqual(['c1-2', 'c1-1']);
+      const thirdPage = await repo.getChannelMessages(1, 2, 'src-a', 4);
+      expect(thirdPage.map(r => r.id)).toEqual(['c1-0']);
+    });
+
+    it('defaults offset to 0 when omitted', async () => {
+      for (let i = 0; i < 3; i++) {
+        await insert(`c1-${i}`, { fromPublicKey: 'channel-1', timestamp: 600 + i }, 'src-a');
+      }
+      const rows = await repo.getChannelMessages(1, 2, 'src-a');
+      expect(rows.map(r => r.id)).toEqual(['c1-2', 'c1-1']);
+    });
   });
 
   describe('getChannelMessageCounts', () => {

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -848,11 +848,15 @@ export class MeshCoreRepository extends BaseRepository {
    * Unlike {@link getRecentMessages} (a single global tail slice shared by every
    * channel and DM), this returns each channel's own backlog independently, so a
    * busy channel can't evict another channel's history from the visible window.
+   *
+   * `offset` paginates further into the channel's history (newest-first, so
+   * offset 0 is the most recent page) for infinite-scroll load-older support.
    */
   async getChannelMessages(
     channelIdx: number,
     limit: number = 100,
     sourceId?: string,
+    offset: number = 0,
   ): Promise<DbMeshCoreMessage[]> {
     const { meshcoreMessages } = this.tables;
     const result = await this.db
@@ -860,7 +864,8 @@ export class MeshCoreRepository extends BaseRepository {
       .from(meshcoreMessages)
       .where(this.channelWhereClause(channelIdx, sourceId))
       .orderBy(desc(meshcoreMessages.timestamp))
-      .limit(limit);
+      .limit(limit)
+      .offset(offset);
     return this.normalizeBigInts(result) as unknown as DbMeshCoreMessage[];
   }
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5744,12 +5744,15 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * gets its own history independent of the shared in-memory pool and the
    * global recent-tail that {@link getRecentMessages} serves. Returns
    * oldest-first to match the ordering the message stream expects.
+   *
+   * `offset` pages further back into history (for infinite-scroll load-older).
    */
-  async getChannelMessages(channelIdx: number, limit: number = 100): Promise<MeshCoreMessage[]> {
+  async getChannelMessages(channelIdx: number, limit: number = 100, offset: number = 0): Promise<MeshCoreMessage[]> {
     const stored = await databaseService.meshcore.getChannelMessages(
       channelIdx,
       limit,
       this.sourceId,
+      offset,
     );
     // Enrich outgoing channel messages with their heard-by repeater set (#3700)
     // in one batched query.

--- a/src/server/routes/meshcoreMessagingRoutes.ts
+++ b/src/server/routes/meshcoreMessagingRoutes.ts
@@ -55,6 +55,10 @@ router.get('/messages', optionalAuth(), requirePermission('messages', 'read', { 
  * Per-channel message backlog. Unlike /messages (a global recent-tail shared by
  * every channel and DM), this returns just channel :idx's history — so a busy
  * channel can't push another channel's messages out of the visible window.
+ *
+ * Supports `offset` for infinite-scroll pagination (load-older-on-scroll-to-top,
+ * #4460), mirroring the Meshtastic `/api/messages/channel/:channel` endpoint.
+ * `hasMore` in the response tells the client whether an older page exists.
  */
 router.get('/messages/channel/:idx', optionalAuth(), requirePermission('messages', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
@@ -68,11 +72,24 @@ router.get('/messages/channel/:idx', optionalAuth(), requirePermission('messages
     } else if (limit > VALIDATION.MAX_MESSAGE_LIMIT) {
       limit = VALIDATION.MAX_MESSAGE_LIMIT;
     }
-    const messages = await managerFor(req, res).getChannelMessages(idx, limit);
+    let offset = parseInt(req.query.offset as string || '0', 10);
+    if (isNaN(offset) || offset < 0) {
+      offset = 0;
+    } else if (offset > VALIDATION.MAX_MESSAGE_OFFSET) {
+      offset = VALIDATION.MAX_MESSAGE_OFFSET;
+    }
+    // Fetch limit+1 (oldest-first) to detect whether an older page exists
+    // without a separate COUNT query.
+    const page = await managerFor(req, res).getChannelMessages(idx, limit + 1, offset);
+    const hasMore = page.length > limit;
+    // The extra lookahead row is the oldest one — drop it so exactly `limit`
+    // messages (oldest-first) go to the client.
+    const messages = hasMore ? page.slice(1) : page;
     res.json({
       success: true,
       data: messages,
       count: messages.length,
+      hasMore,
     });
   } catch (error) {
     logger.error('[API] Error getting channel messages:', error);

--- a/src/server/routes/meshcoreMessagingRoutes.ts
+++ b/src/server/routes/meshcoreMessagingRoutes.ts
@@ -78,12 +78,15 @@ router.get('/messages/channel/:idx', optionalAuth(), requirePermission('messages
     } else if (offset > VALIDATION.MAX_MESSAGE_OFFSET) {
       offset = VALIDATION.MAX_MESSAGE_OFFSET;
     }
-    // Fetch limit+1 (oldest-first) to detect whether an older page exists
-    // without a separate COUNT query.
+    // The manager already reverses the DB's newest-first rows to oldest-first
+    // (see MeshCoreManager.getChannelMessages), so `page` here is ascending.
+    // Fetch limit+1 to detect whether an older page exists without a
+    // separate COUNT query.
     const page = await managerFor(req, res).getChannelMessages(idx, limit + 1, offset);
     const hasMore = page.length > limit;
-    // The extra lookahead row is the oldest one — drop it so exactly `limit`
-    // messages (oldest-first) go to the client.
+    // The extra lookahead row is the oldest one in this ascending array —
+    // i.e. index 0 — so drop it to send exactly `limit` messages, still
+    // oldest-first, to the client.
     const messages = hasMore ? page.slice(1) : page;
     res.json({
       success: true,

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -76,6 +76,9 @@ export const VALIDATION = {
   MAX_NAME_LENGTH: 32,
   /** Maximum message history limit */
   MAX_MESSAGE_LIMIT: 1000,
+  /** Maximum pagination offset for message history (mirrors the Meshtastic
+   *  /api/messages/channel offset cap) */
+  MAX_MESSAGE_OFFSET: 50000,
   /** Radio frequency range (MHz) */
   FREQ_MIN: 137.0,
   FREQ_MAX: 1020.0,

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -45,6 +45,7 @@ const meshcoreManager = {
   getContacts: vi.fn().mockReturnValue([]),
   getContact: vi.fn().mockReturnValue(undefined),
   getRecentMessages: vi.fn().mockReturnValue([]),
+  getChannelMessages: vi.fn().mockResolvedValue([]),
   // Message deletion / purge (#3981)
   deleteStoredMessage: vi.fn().mockResolvedValue(true),
   purgeConversation: vi.fn().mockResolvedValue(3),
@@ -1352,6 +1353,60 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(200);
       // Should clamp to max limit (1000) without error
       expect(meshcoreManager.getRecentMessages).toHaveBeenCalledWith(1000);
+    });
+  });
+
+  // #4460 — infinite-scroll pagination for the MeshCore channel view.
+  describe('GET /api/sources/test-source/meshcore/messages/channel/:idx', () => {
+    afterEach(() => {
+      meshcoreManager.getChannelMessages.mockReset();
+      meshcoreManager.getChannelMessages.mockResolvedValue([]);
+    });
+
+    it('requests limit+1 (oldest-first) and reports hasMore=false when the page is not full', async () => {
+      meshcoreManager.getChannelMessages.mockResolvedValueOnce([
+        { id: 'a', fromPublicKey: 'channel-1', text: 'hi', timestamp: 1 },
+        { id: 'b', fromPublicKey: 'channel-1', text: 'yo', timestamp: 2 },
+      ]);
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/1?limit=100');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(meshcoreManager.getChannelMessages).toHaveBeenCalledWith(1, 101, 0);
+      expect(response.body.hasMore).toBe(false);
+      expect(response.body.data.map((m: any) => m.id)).toEqual(['a', 'b']);
+    });
+
+    it('drops the lookahead row and reports hasMore=true when an older page exists', async () => {
+      // limit=2 → manager is asked for 3 (oldest-first); the extra oldest row
+      // ("extra") is dropped from the response but proves more history exists.
+      meshcoreManager.getChannelMessages.mockResolvedValueOnce([
+        { id: 'extra', fromPublicKey: 'channel-1', text: 'older', timestamp: 1 },
+        { id: 'a', fromPublicKey: 'channel-1', text: 'hi', timestamp: 2 },
+        { id: 'b', fromPublicKey: 'channel-1', text: 'yo', timestamp: 3 },
+      ]);
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/1?limit=2');
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.getChannelMessages).toHaveBeenCalledWith(1, 3, 0);
+      expect(response.body.hasMore).toBe(true);
+      expect(response.body.data.map((m: any) => m.id)).toEqual(['a', 'b']);
+    });
+
+    it('passes offset through to the manager', async () => {
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/1?limit=100&offset=200');
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.getChannelMessages).toHaveBeenCalledWith(1, 101, 200);
+    });
+
+    it('clamps a negative offset to 0', async () => {
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/1?limit=100&offset=-5');
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.getChannelMessages).toHaveBeenCalledWith(1, 101, 0);
+    });
+
+    it('rejects a non-numeric channel index', async () => {
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/abc?limit=100');
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -1406,6 +1406,12 @@ describe('MeshCore Routes', () => {
       expect(meshcoreManager.getChannelMessages).toHaveBeenCalledWith(1, 101, 0);
     });
 
+    it('clamps an offset above MAX_MESSAGE_OFFSET (50000)', async () => {
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/1?limit=100&offset=999999');
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.getChannelMessages).toHaveBeenCalledWith(1, 101, 50000);
+    });
+
     it('rejects a non-numeric channel index', async () => {
       const response = await request(app).get('/api/sources/test-source/meshcore/messages/channel/abc?limit=100');
       expect(response.status).toBe(400);

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -1364,6 +1364,9 @@ describe('MeshCore Routes', () => {
     });
 
     it('requests limit+1 (oldest-first) and reports hasMore=false when the page is not full', async () => {
+      // The manager contract is oldest-first (it reverses the DB's DESC rows
+      // before returning); the mock below mirrors that, and the route must
+      // pass the order through unchanged.
       meshcoreManager.getChannelMessages.mockResolvedValueOnce([
         { id: 'a', fromPublicKey: 'channel-1', text: 'hi', timestamp: 1 },
         { id: 'b', fromPublicKey: 'channel-1', text: 'yo', timestamp: 2 },


### PR DESCRIPTION
## Summary

Fixes #4460 — scrolling up in a MeshCore channel never loaded older messages, even when history existed. Confirmed root cause: unlike the Meshtastic side, the MeshCore channel-message path had no pagination anywhere in the stack — the repository query, the manager method, and the `/messages/channel/:idx` route only ever accepted a flat `limit`, and the frontend fetched a channel's backlog **once** per channel switch (`limit=200`) with no way to page further back. It wasn't a UI bug so much as a feature that was never built for MeshCore, unlike the equivalent Meshtastic `ChannelsTab`/`useMessagingView.ts` infinite-scroll implementation.

- `src/db/repositories/meshcore.ts` — `getChannelMessages()` gains an `offset` param.
- `src/server/meshcoreManager.ts` — `getChannelMessages()` passes `offset` through.
- `src/server/routes/meshcoreMessagingRoutes.ts` — `GET /messages/channel/:idx` accepts `offset`, fetches `limit+1` to detect more history, and returns `hasMore` (mirrors the existing Meshtastic `/api/messages/channel/:channel` pattern).
- `src/server/routes/meshcoreRouteShared.ts` — adds a `MAX_MESSAGE_OFFSET` clamp (mirrors the Meshtastic offset cap).
- `src/components/MeshCore/MeshCoreChannelsView.tsx` — tracks `hasMoreHistory`/`loadingOlderHistory` for the active channel and adds `loadOlderHistory()`, which pages by `offset = history.length`, dedupes, and prepends.
- `src/components/MeshCore/MeshCoreMessageStream.tsx` — new optional `onLoadOlder`/`hasMoreOlder`/`loadingOlder` props; detects scroll-to-top (throttled), and restores the viewport's scroll position once older messages are prepended so the operator isn't visually yanked around.

Scope note: MeshCore direct messages (`MeshCoreDirectMessagesView.tsx`) have a separate, more basic limitation — they render entirely from the shared 100-message live pool with no per-conversation backlog fetch at all. That's a distinct gap from the one reported (channels), so I left DM pagination out of this PR rather than scope-creep it.

## Test plan

- [x] New repository tests: offset pagination + default-offset-0 behavior (`meshcore.test.ts`)
- [x] New route tests: `limit+1`/`hasMore` lookahead trick, offset passthrough, offset clamping, bad-index rejection (`meshcoreRoutes.test.ts`)
- [x] New component tests: scroll-to-top triggers `onLoadOlder`, respects `hasMoreOlder`/`loadingOlder` gating, and restores scroll position after prepend (`MeshCoreMessageStream.test.tsx`)
- [x] New integration tests: `MeshCoreChannelsView` fetches and prepends an older page on scroll-to-top, and doesn't request further pages once `hasMore` is false (`MeshCoreChannelsView.test.tsx`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint:ci` — clean
- [x] All MeshCore-related suites (68 files / 906 tests) pass
- [ ] Full `npm test` suite (running; will confirm via CI)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv7FiAu9GYEMQW23ibXRSX)_