### PR TITLE
chore(scripts): retry transient GitHub API errors in the CI/release watchers

### DIFF
--- a/scripts/watch-ci.sh
+++ b/scripts/watch-ci.sh
@@ -34,6 +34,15 @@
 # Tunables (env vars):
 #   WATCH_CI_INTERVAL   poll interval in seconds (default 60)
 #   WATCH_CI_LIMIT      number of recent runs to inspect (default 20)
+#   WATCH_CI_RETRIES    attempts per GitHub API call before giving up (default 3)
+#   WATCH_CI_BACKOFF    base seconds between retries, multiplied by attempt
+#                       number for linear backoff (default 5)
+#
+# Transient API errors are retried rather than fatal. A single TLS handshake
+# timeout or DNS blip used to kill a 25-minute watch with exit 2; now only
+# WATCH_CI_RETRIES *consecutive* failures do. Retry notices go to stderr, so
+# the stdout contract (exactly one terminal line) is unchanged for -q consumers
+# — but a failing call is never silent.
 
 set -euo pipefail
 
@@ -46,13 +55,39 @@ fi
 TARGET="${1:?Usage: watch-ci.sh [-q] <PR_NUMBER|BRANCH_NAME>}"
 INTERVAL="${WATCH_CI_INTERVAL:-60}"
 LIMIT="${WATCH_CI_LIMIT:-20}"
+RETRIES="${WATCH_CI_RETRIES:-3}"
+BACKOFF="${WATCH_CI_BACKOFF:-5}"
 
 log() { $QUIET || echo "$@"; }
+
+# Run a gh command, retrying transient failures with linear backoff. Prints the
+# command's stdout on success (empty output is a valid success). On the final
+# failure, reports the last error to stderr and returns 1.
+#
+# Progress and error notices go to STDERR deliberately: this runs inside a
+# command substitution, so anything on stdout would be captured as data — and a
+# retry that logged to stdout would silently corrupt the caller's results.
+retry_api() {
+  local attempt=1 out
+  while :; do
+    if out=$("$@" 2>&1); then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -ge "$RETRIES" ]; then
+      echo "✗ API call failed after $RETRIES attempts: $out" >&2
+      return 1
+    fi
+    echo "[$(date '+%H:%M:%S')] transient API error (attempt $attempt/$RETRIES), retrying in $((attempt * BACKOFF))s: $out" >&2
+    sleep "$((attempt * BACKOFF))"
+    attempt=$((attempt + 1))
+  done
+}
 
 PR_NUMBER=""
 if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
   PR_NUMBER="$TARGET"
-  if ! BRANCH=$(gh pr view "$TARGET" --json headRefName -q .headRefName 2>/dev/null); then
+  if ! BRANCH=$(retry_api gh pr view "$TARGET" --json headRefName -q .headRefName); then
     echo "✗ Could not resolve PR #$TARGET" >&2
     exit 2
   fi
@@ -138,10 +173,13 @@ while true; do
 
   # Only consider runs whose headSha matches the current tip. (gh run list has
   # no commit filter, so filter in jq. HEAD_SHA is a hex OID — safe to splice.)
-  if ! RESULTS=$(gh run list --branch "$BRANCH" --limit "$LIMIT" \
+  # Retried rather than fatal-on-first-error: over a 25-minute watch a single
+  # network blip is expected, and losing the whole watch to it is what pushes
+  # callers into hand-rolling their own (worse) pollers.
+  if ! RESULTS=$(retry_api gh run list --branch "$BRANCH" --limit "$LIMIT" \
                    --json name,conclusion,status,headSha \
-                   -q ".[] | select(.headSha == \"$HEAD_SHA\") | \"\(.name)|\(.status)|\(.conclusion)\"" 2>&1); then
-    echo "✗ gh run list failed: $RESULTS" >&2
+                   -q ".[] | select(.headSha == \"$HEAD_SHA\") | \"\(.name)|\(.status)|\(.conclusion)\""); then
+    echo "✗ gh run list failed after $RETRIES attempts — giving up on $BRANCH" >&2
     exit 2
   fi
 

--- a/scripts/watch-release.sh
+++ b/scripts/watch-release.sh
@@ -33,6 +33,16 @@
 #   WATCH_RELEASE_INTERVAL   poll interval in seconds (default 60)
 #   WATCH_RELEASE_LIMIT      number of recent release-event runs to inspect
 #                            (default 10)
+#   WATCH_RELEASE_RETRIES    attempts per GitHub API call before giving up
+#                            (default 3)
+#   WATCH_RELEASE_BACKOFF    base seconds between retries, multiplied by attempt
+#                            number for linear backoff (default 5)
+#
+# Transient API errors are retried rather than fatal. A single TLS handshake
+# timeout killed a v4.13.3-rc3 release watch outright with exit 2; now only
+# WATCH_RELEASE_RETRIES *consecutive* failures do. Retry notices go to stderr,
+# so the stdout contract is unchanged for -q consumers — but a failing call is
+# never silent.
 
 set -euo pipefail
 
@@ -45,8 +55,34 @@ fi
 TAG="${1:-}"
 INTERVAL="${WATCH_RELEASE_INTERVAL:-60}"
 LIMIT="${WATCH_RELEASE_LIMIT:-10}"
+RETRIES="${WATCH_RELEASE_RETRIES:-3}"
+BACKOFF="${WATCH_RELEASE_BACKOFF:-5}"
 
 log() { $QUIET || echo "$@"; }
+
+# Run a gh command, retrying transient failures with linear backoff. Prints the
+# command's stdout on success (empty output is a valid success). On the final
+# failure, reports the last error to stderr and returns 1.
+#
+# Progress and error notices go to STDERR deliberately: this runs inside a
+# command substitution, so anything on stdout would be captured as data — and a
+# retry that logged to stdout would silently corrupt the caller's results.
+retry_api() {
+  local attempt=1 out
+  while :; do
+    if out=$("$@" 2>&1); then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -ge "$RETRIES" ]; then
+      echo "✗ API call failed after $RETRIES attempts: $out" >&2
+      return 1
+    fi
+    echo "[$(date '+%H:%M:%S')] transient API error (attempt $attempt/$RETRIES), retrying in $((attempt * BACKOFF))s: $out" >&2
+    sleep "$((attempt * BACKOFF))"
+    attempt=$((attempt + 1))
+  done
+}
 
 if [ -n "$TAG" ]; then
   log "Watching release workflows for tag: $TAG"
@@ -71,10 +107,13 @@ last_summary=""
 while true; do
   TIMESTAMP=$(date '+%H:%M:%S')
 
-  if ! RESULTS=$(gh run list --limit "$LIMIT" --event release \
+  # Retried rather than fatal-on-first-error: release builds (multi-arch Docker,
+  # Desktop, LXC) run long enough that a single network blip is expected, and
+  # losing the watch to it is what pushes callers into hand-rolling their own.
+  if ! RESULTS=$(retry_api gh run list --limit "$LIMIT" --event release \
                    --json databaseId,name,conclusion,status,createdAt \
-                   -q '.[] | "\(.databaseId)|\(.name)|\(.status)|\(.conclusion)"' 2>&1); then
-    echo "✗ gh run list failed: $RESULTS" >&2
+                   -q '.[] | "\(.databaseId)|\(.name)|\(.status)|\(.conclusion)"'); then
+    echo "✗ gh run list failed after $RETRIES attempts — giving up" >&2
     exit 2
   fi
 


### PR DESCRIPTION
## Summary

Both `scripts/watch-ci.sh` and `scripts/watch-release.sh` exited `2` on the **first** `gh run list` error, so a single TLS handshake timeout or DNS blip killed an otherwise-healthy watch. One did exactly that during the v4.13.3-rc3 release.

That matters beyond the lost watch: it's the failure mode that pushes callers into hand-rolling their own (worse) pollers instead of using these scripts, which is what `/ci-monitor` is built around.

Both scripts already degraded gracefully on transient errors *elsewhere* — `watch-ci.sh`'s `resolve_sha` falls back to the last known tip, and `is_conflicting` treats an empty read as "keep watching". `gh run list` was the lone fatal-on-first-error call. This removes that asymmetry.

## Changes

- New `retry_api` helper in both scripts: linear backoff, N attempts, only the Nth **consecutive** failure is fatal.
- Applied to `gh run list` in both, plus `watch-ci.sh`'s startup PR-branch resolution.
- Tunables: `WATCH_CI_RETRIES` / `WATCH_CI_BACKOFF` and `WATCH_RELEASE_*` equivalents (default 3 attempts, 5s base).

**Retry notices go to stderr, not stdout.** The helper runs inside a command substitution, so anything on stdout would be captured as data and silently corrupt the caller's results. This also preserves the "`-q` prints exactly one terminal line" contract `/ci-monitor` dispatches on, while making a failing call visible rather than silent.

Exit-code semantics are unchanged: `0` green, `1` failure, `2` API error, `3` merge conflict. A persistent outage still exits `2` — just after N attempts instead of one.

## Test plan

Fault-injected with a fake `gh` on `PATH` returning a real TLS-timeout error:

- [x] 2 transient failures then success → recovers, `EXIT=0`, 3 attempts
- [x] persistent failure → `EXIT=2` after **exactly 3** attempts (not 1, not unbounded)
- [x] stdout carries only the single terminal line while retrying (notices on stderr)
- [x] same two cases verified against `watch-release.sh`
- [x] live smoke test against real GitHub API (PR #4461) → `EXIT=0`
- [x] `bash -n` clean on both

No application code touched — scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB