### PR TITLE
fix(pwa): deep-link notification clicks to the source route (#4463)

### DIFF
--- a/src/hooks/useNotificationNavigationHandler.test.tsx
+++ b/src/hooks/useNotificationNavigationHandler.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for useNotificationNavigationHandler's route-awareness (#4463).
+ *
+ * Covers the two behaviours added when the notification deep link moved from
+ * the scope root + hash to a real `/source/:sourceId/<tab>` route:
+ *
+ * 1. Nothing is applied — and nothing is *cleared* — until the source route
+ *    has resolved. `setActiveTab` is a no-op while `useParams().sourceId` is
+ *    undefined, so clearing early would drop the navigation permanently.
+ * 2. A notification for a different source hands off via the router, and the
+ *    navigation is applied only once the route has caught up — never against
+ *    whichever source happened to be open.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import type { NotificationNavigationData } from '../utils/notificationUrl';
+
+const mockClearPendingNavigation = vi.fn();
+let mockPendingNavigation: NotificationNavigationData | null = null;
+
+vi.mock('./usePushNotificationNavigation', () => ({
+  usePushNotificationNavigation: () => ({
+    pendingNavigation: mockPendingNavigation,
+    clearPendingNavigation: mockClearPendingNavigation,
+  }),
+}));
+
+import { useNotificationNavigationHandler } from './useNotificationNavigationHandler';
+
+/** Path the router is currently on, kept current by <LocationRecorder />. */
+let currentPath = '';
+
+function LocationRecorder() {
+  currentPath = useLocation().pathname;
+  return null;
+}
+
+/**
+ * Callbacks that record the route in effect at the moment they were called, so
+ * a navigation applied against the *wrong* source is observable.
+ */
+function makeCallbacks() {
+  const pathsWhenCalled: Record<string, string[]> = {
+    setActiveTab: [],
+    setSelectedChannel: [],
+    setSelectedDMNode: [],
+  };
+  return {
+    pathsWhenCalled,
+    setActiveTab: vi.fn(() => void pathsWhenCalled.setActiveTab.push(currentPath)),
+    setSelectedChannel: vi.fn(() => void pathsWhenCalled.setSelectedChannel.push(currentPath)),
+    setSelectedDMNode: vi.fn(() => void pathsWhenCalled.setSelectedDMNode.push(currentPath)),
+  };
+}
+
+const READY_STATE = {
+  connectionStatus: 'connected',
+  channels: [{ id: 0 }],
+  activeTab: 'nodes',
+  selectedChannel: 0,
+  selectedDMNode: null,
+};
+
+/**
+ * Render the hook underneath a route, so `useParams().sourceId` resolves
+ * exactly as it does in the real app (App.tsx renders under
+ * `source/:sourceId/*`). An `initialPath` of '/' leaves sourceId undefined.
+ */
+function renderAtPath(initialPath: string, callbacks: ReturnType<typeof makeCallbacks>) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <LocationRecorder />
+      <Routes>
+        <Route path="source/:sourceId/*" element={<>{children}</>} />
+        <Route path="*" element={<>{children}</>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  return renderHook(() => useNotificationNavigationHandler(callbacks, READY_STATE), { wrapper });
+}
+
+describe('useNotificationNavigationHandler — route awareness (#4463)', () => {
+  beforeEach(() => {
+    mockPendingNavigation = null;
+    mockClearPendingNavigation.mockClear();
+    currentPath = '';
+  });
+
+  it('applies a channel navigation when the route source matches', () => {
+    mockPendingNavigation = {
+      type: 'channel',
+      sourceId: 'src-a',
+      channelId: 3,
+      messageId: 'm1',
+    };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/source/src-a/nodes', callbacks);
+
+    expect(callbacks.setActiveTab).toHaveBeenCalledWith('channels');
+    expect(callbacks.setSelectedChannel).toHaveBeenCalledWith(3);
+    expect(mockClearPendingNavigation).toHaveBeenCalled();
+  });
+
+  it('applies a DM navigation when the route source matches', () => {
+    mockPendingNavigation = {
+      type: 'dm',
+      sourceId: 'src-a',
+      senderNodeId: '!node123',
+      messageId: 'm2',
+    };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/source/src-a/nodes', callbacks);
+
+    expect(callbacks.setActiveTab).toHaveBeenCalledWith('messages');
+    expect(callbacks.setSelectedDMNode).toHaveBeenCalledWith('!node123');
+    expect(mockClearPendingNavigation).toHaveBeenCalled();
+  });
+
+  it('still applies navigation for payloads with no sourceId (pre-4.13.4)', () => {
+    mockPendingNavigation = { type: 'channel', channelId: 2 };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/source/src-a/nodes', callbacks);
+
+    expect(callbacks.setActiveTab).toHaveBeenCalledWith('channels');
+    expect(callbacks.setSelectedChannel).toHaveBeenCalledWith(2);
+  });
+
+  it('does not clear the navigation while the source route is unresolved', () => {
+    // The regression this guards: setActiveTab is a no-op without a sourceId,
+    // so clearing here would lose the notification with no retry.
+    mockPendingNavigation = { type: 'channel', sourceId: 'src-a', channelId: 3 };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/', callbacks);
+
+    expect(callbacks.setActiveTab).not.toHaveBeenCalled();
+    expect(callbacks.setSelectedChannel).not.toHaveBeenCalled();
+    expect(mockClearPendingNavigation).not.toHaveBeenCalled();
+  });
+
+  it('routes to the target source before applying a cross-source notification', () => {
+    mockPendingNavigation = { type: 'channel', sourceId: 'src-b', channelId: 3 };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/source/src-a/nodes', callbacks);
+
+    // The hand-off completes: the router switches to src-b and only then is
+    // the channel applied. Applying it while still on src-a would select
+    // channel 3 of the wrong source.
+    expect(currentPath).toBe('/source/src-b/channels');
+    expect(callbacks.pathsWhenCalled.setSelectedChannel).toEqual(['/source/src-b/channels']);
+    expect(callbacks.pathsWhenCalled.setActiveTab).toEqual(['/source/src-b/channels']);
+  });
+
+  it('routes to the target source for a cross-source DM', () => {
+    mockPendingNavigation = { type: 'dm', sourceId: 'src-b', senderNodeId: '!x' };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/source/src-a/nodes', callbacks);
+
+    expect(currentPath).toBe('/source/src-b/messages');
+    expect(callbacks.pathsWhenCalled.setSelectedDMNode).toEqual(['/source/src-b/messages']);
+  });
+
+  it('does not lose a cross-source navigation during the hand-off', () => {
+    // react-router's pushState does not remount this hook, so clearing before
+    // the route catches up would leave nothing to re-read the navigation.
+    mockPendingNavigation = { type: 'dm', sourceId: 'src-b', senderNodeId: '!x' };
+    const callbacks = makeCallbacks();
+
+    renderAtPath('/source/src-a/nodes', callbacks);
+
+    expect(callbacks.setSelectedDMNode).toHaveBeenCalledWith('!x');
+  });
+});

--- a/src/hooks/useNotificationNavigationHandler.ts
+++ b/src/hooks/useNotificationNavigationHandler.ts
@@ -10,6 +10,7 @@
  */
 
 import { useState, useEffect, useRef, type MutableRefObject } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { logger } from '../utils/logger';
 import { usePushNotificationNavigation } from './usePushNotificationNavigation';
 
@@ -48,6 +49,8 @@ export function useNotificationNavigationHandler(
   state: NavigationState
 ): void {
   const { pendingNavigation, clearPendingNavigation } = usePushNotificationNavigation();
+  const navigate = useNavigate();
+  const { sourceId: routeSourceId } = useParams<{ sourceId: string }>();
   const [scrollToMessageId, setScrollToMessageId] = useState<string | null>(null);
   
   // Use ref to persist scroll target across re-renders
@@ -69,6 +72,30 @@ export function useNotificationNavigationHandler(
   // We wait until the app is connected to ensure data is loaded
   useEffect(() => {
     if (!pendingNavigation) return;
+
+    // The route must have resolved before any of the callbacks below can do
+    // anything — `setActiveTab` is a no-op while `useParams().sourceId` is
+    // undefined (UIContext.tsx). Returning (rather than falling through to
+    // clearPendingNavigation) lets the effect retry instead of silently
+    // dropping the navigation (#4463).
+    if (!routeSourceId) {
+      logger.debug('📬 Waiting for the source route to resolve before navigating...');
+      return;
+    }
+
+    // A notification for a different source can only be handled by that
+    // source's own view. Switch routes and keep the payload pending — the
+    // effect re-runs once `routeSourceId` catches up and then falls through to
+    // the normal handling below. (Clearing here would lose it: react-router's
+    // pushState does not remount this hook, so nothing would re-read the URL.)
+    if (pendingNavigation.sourceId && pendingNavigation.sourceId !== routeSourceId) {
+      const tab = pendingNavigation.type === 'dm' ? 'messages' : 'channels';
+      logger.info(
+        `📬 Notification targets source ${pendingNavigation.sourceId}, switching from ${routeSourceId}`
+      );
+      void navigate(`/source/${encodeURIComponent(pendingNavigation.sourceId)}/${tab}`);
+      return;
+    }
 
     // Wait until we have a connection (data is loaded)
     // Allow navigation when connected or when we have channels data
@@ -118,6 +145,8 @@ export function useNotificationNavigationHandler(
     selectedChannelRef,
     connectionStatus,
     channels,
+    routeSourceId,
+    navigate,
   ]);
 
   // Scroll to specific message after navigation from push notification

--- a/src/hooks/usePushNotificationNavigation.test.ts
+++ b/src/hooks/usePushNotificationNavigation.test.ts
@@ -257,6 +257,112 @@ describe('usePushNotificationNavigation', () => {
     });
   });
 
+  // #4463: the service worker now cold-launches the app on a real route with
+  // the payload in the query string, because the app is path-routed.
+  describe('URL query-string navigation (#4463)', () => {
+    it('reads notificationNav from the query string', async () => {
+      const navigationData: NotificationNavigationData = {
+        type: 'dm',
+        sourceId: 'src-a',
+        senderNodeId: '!node123',
+        messageId: 'msg_dm_1',
+      };
+
+      const { result } = renderHook(() => usePushNotificationNavigation());
+
+      const params = new URLSearchParams();
+      params.set('notificationNav', JSON.stringify(navigationData));
+
+      act(() => {
+        window.history.replaceState(
+          null,
+          '',
+          `/source/src-a/messages?${params.toString()}`
+        );
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+
+      await waitFor(() => {
+        expect(result.current.pendingNavigation).toEqual(navigationData);
+      });
+    });
+
+    it('strips only notificationNav, preserving the path and other query params', async () => {
+      const navigationData: NotificationNavigationData = {
+        type: 'channel',
+        sourceId: 'src-b',
+        channelId: 2,
+      };
+
+      const { result } = renderHook(() => usePushNotificationNavigation());
+
+      const params = new URLSearchParams();
+      params.set('keepMe', 'yes');
+      params.set('notificationNav', JSON.stringify(navigationData));
+
+      act(() => {
+        window.history.replaceState(
+          null,
+          '',
+          `/source/src-b/channels?${params.toString()}`
+        );
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+
+      await waitFor(() => {
+        expect(result.current.pendingNavigation).toEqual(navigationData);
+      });
+
+      // The path must survive — the router owns it, and dropping it would
+      // bounce the user off the source route we just deep-linked to.
+      expect(window.location.pathname).toBe('/source/src-b/channels');
+      expect(new URLSearchParams(window.location.search).get('keepMe')).toBe('yes');
+      expect(new URLSearchParams(window.location.search).get('notificationNav')).toBeNull();
+    });
+
+    it('preserves the sourceId field through the URL round trip', async () => {
+      const navigationData: NotificationNavigationData = {
+        type: 'channel',
+        sourceId: 'source-with-dashes-123',
+        channelId: 7,
+        messageId: 'src_1234_5678',
+      };
+
+      const { result } = renderHook(() => usePushNotificationNavigation());
+
+      const params = new URLSearchParams();
+      params.set('notificationNav', JSON.stringify(navigationData));
+
+      act(() => {
+        window.history.replaceState(null, '', `/source/x/channels?${params.toString()}`);
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+
+      await waitFor(() => {
+        expect(result.current.pendingNavigation?.sourceId).toBe('source-with-dashes-123');
+      });
+    });
+
+    it('ignores a query string without notificationNav', () => {
+      window.history.replaceState(null, '', '/source/src-a/messages?other=1');
+
+      const { result } = renderHook(() => usePushNotificationNavigation());
+
+      expect(result.current.pendingNavigation).toBeNull();
+    });
+
+    it('handles invalid JSON in the query string without crashing', () => {
+      const { result } = renderHook(() => usePushNotificationNavigation());
+
+      act(() => {
+        window.history.replaceState(null, '', '/source/src-a/messages?notificationNav=nope');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+
+      expect(result.current.pendingNavigation).toBeNull();
+    });
+  });
+
   describe('clearPendingNavigation', () => {
     it('should clear pendingNavigation when called', async () => {
       const { result } = renderHook(() => usePushNotificationNavigation());

--- a/src/hooks/usePushNotificationNavigation.ts
+++ b/src/hooks/usePushNotificationNavigation.ts
@@ -3,20 +3,17 @@
  *
  * This hook listens for:
  * 1. Messages from the service worker when a notification is clicked (app already open)
- * 2. URL hash parameters when the app is opened from a notification click
+ * 2. The `notificationNav` URL parameter when the app is cold-launched from a
+ *    notification click (query string, with the legacy hash form as fallback)
  *
  * It provides the navigation data and a way to clear it after navigating.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import { logger } from '../utils/logger';
+import { NOTIFICATION_NAV_PARAM, type NotificationNavigationData } from '../utils/notificationUrl';
 
-export interface NotificationNavigationData {
-  type: 'channel' | 'dm';
-  channelId?: number;
-  messageId?: string;
-  senderNodeId?: string;
-}
+export type { NotificationNavigationData } from '../utils/notificationUrl';
 
 interface UsePushNotificationNavigationReturn {
   /** Navigation data from a notification click, null if none pending */
@@ -25,46 +22,87 @@ interface UsePushNotificationNavigationReturn {
   clearPendingNavigation: () => void;
 }
 
-// Check for navigation data in URL hash immediately (before React hydration)
-// This ensures we don't lose the data if the hash is modified
-const getInitialNavigationFromHash = (): NotificationNavigationData | null => {
-  if (typeof window === 'undefined') return null;
-  
-  const hash = window.location.hash;
-  if (!hash || hash.length <= 1) return null;
-  
+/**
+ * Parse a `notificationNav` payload out of a `?a=b`/`#a=b` parameter string.
+ * Returns null when the parameter is absent or unparseable.
+ */
+const parseNavParams = (
+  paramString: string,
+  label: string
+): NotificationNavigationData | null => {
+  if (!paramString) return null;
   try {
-    const params = new URLSearchParams(hash.substring(1));
-    const navDataStr = params.get('notificationNav');
-    if (navDataStr) {
-      const navData = JSON.parse(navDataStr) as NotificationNavigationData;
-      logger.info('📬 [Initial] Found notification navigation data in URL:', navData);
-      return navData;
-    }
+    const navDataStr = new URLSearchParams(paramString).get(NOTIFICATION_NAV_PARAM);
+    if (!navDataStr) return null;
+    const navData = JSON.parse(navDataStr) as NotificationNavigationData;
+    logger.info(`📬 [${label}] Found notification navigation data in URL:`, navData);
+    return navData;
   } catch (error) {
-    logger.error('📬 [Initial] Failed to parse notification navigation data:', error);
+    logger.error(`📬 [${label}] Failed to parse notification navigation data:`, error);
+    return null;
   }
-  return null;
+};
+
+// Check for navigation data in the URL immediately (before React hydration) so
+// it survives the router's own history rewrites.
+//
+// The service worker puts the payload in the *query string* and cold-launches
+// the app on `/source/<id>/<tab>` (#4463) — the old hash form is still read as
+// a fallback for notifications that were already delivered by an older build.
+const getInitialNavigationFromUrl = (): NotificationNavigationData | null => {
+  if (typeof window === 'undefined') return null;
+  return (
+    parseNavParams(window.location.search.replace(/^\?/, ''), 'Initial') ??
+    parseNavParams(window.location.hash.replace(/^#/, ''), 'Initial/hash')
+  );
+};
+
+/**
+ * Strip `notificationNav` from the current URL without discarding any other
+ * query parameters, and without touching the path (the router owns that).
+ */
+const stripNavParamFromUrl = (): void => {
+  const search = new URLSearchParams(window.location.search);
+  search.delete(NOTIFICATION_NAV_PARAM);
+  const hash = window.location.hash.replace(/^#/, '');
+  const hashParams = new URLSearchParams(hash);
+  const hadNavInHash = hashParams.has(NOTIFICATION_NAV_PARAM);
+  hashParams.delete(NOTIFICATION_NAV_PARAM);
+
+  const nextSearch = search.toString();
+  const nextHash = hadNavInHash ? hashParams.toString() : hash;
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname +
+      (nextSearch ? `?${nextSearch}` : '') +
+      (nextHash ? `#${nextHash}` : '')
+  );
 };
 
 // Store initial navigation data before React hydration can clear it
 let initialNavData: NotificationNavigationData | null = null;
 if (typeof window !== 'undefined') {
-  initialNavData = getInitialNavigationFromHash();
+  initialNavData = getInitialNavigationFromUrl();
   // Clean up the URL immediately to prevent re-reads
   if (initialNavData) {
-    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    stripNavParamFromUrl();
   }
 }
 
 export function usePushNotificationNavigation(): UsePushNotificationNavigationReturn {
   // Use initial navigation data captured before React mounted
-  const [pendingNavigation, setPendingNavigation] = useState<NotificationNavigationData | null>(() => {
-    // Consume the initial nav data
-    const data = initialNavData;
-    initialNavData = null; // Clear so it's only used once
-    return data;
-  });
+  const [pendingNavigation, setPendingNavigation] = useState<NotificationNavigationData | null>(
+    () => initialNavData
+  );
+
+  // Consume the module-level capture once the hook has actually mounted.
+  // This must NOT happen inside the useState initializer: <React.StrictMode>
+  // double-invokes initializers, so the second call would see null and the
+  // navigation would be dropped in development.
+  useEffect(() => {
+    initialNavData = null;
+  }, []);
 
   // Handle messages from service worker
   useEffect(() => {
@@ -87,35 +125,28 @@ export function usePushNotificationNavigation(): UsePushNotificationNavigationRe
     };
   }, []);
 
-  // Check URL hash for navigation data (backup check - main check happens before React mounts)
-  // This handles edge cases where the hash might be set after initial mount
+  // Backup check for navigation data arriving after mount (the main check
+  // happens at module load, before React mounts). Covers both the query-string
+  // form and the legacy hash form.
   useEffect(() => {
-    const checkHashForNavigation = () => {
-      const hash = window.location.hash;
-      if (!hash || hash.length <= 1) return;
+    const checkUrlForNavigation = () => {
+      const navData =
+        parseNavParams(window.location.search.replace(/^\?/, ''), 'UrlChange') ??
+        parseNavParams(window.location.hash.replace(/^#/, ''), 'HashChange');
 
-      try {
-        const params = new URLSearchParams(hash.substring(1));
-        const navDataStr = params.get('notificationNav');
-
-        if (navDataStr) {
-          const navData = JSON.parse(navDataStr) as NotificationNavigationData;
-          logger.info('📬 [HashChange] Found notification navigation data:', navData);
-          setPendingNavigation(navData);
-
-          // Clean up the URL hash after reading
-          window.history.replaceState(null, '', window.location.pathname + window.location.search);
-        }
-      } catch (error) {
-        logger.error('📬 Failed to parse notification navigation data from URL:', error);
+      if (navData) {
+        setPendingNavigation(navData);
+        stripNavParamFromUrl();
       }
     };
 
     // Listen for hash changes in case a notification is clicked while app is open
-    window.addEventListener('hashchange', checkHashForNavigation);
+    window.addEventListener('hashchange', checkUrlForNavigation);
+    window.addEventListener('popstate', checkUrlForNavigation);
 
     return () => {
-      window.removeEventListener('hashchange', checkHashForNavigation);
+      window.removeEventListener('hashchange', checkUrlForNavigation);
+      window.removeEventListener('popstate', checkUrlForNavigation);
     };
   }, []);
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -10031,15 +10031,20 @@ class MeshtasticManager implements ISourceManager {
         body = messageText.length > 100 ? messageText.substring(0, 97) + '...' : messageText;
       }
 
-      // Build navigation data for push notification click handling
+      // Build navigation data for push notification click handling.
+      // `sourceId` is required for the cold-launch deep link: the service
+      // worker builds a `/source/<sourceId>/<tab>` route from it, because the
+      // app root renders DashboardPage and never reads navigation data (#4463).
       const navigationData = isDirectMessage
         ? {
             type: 'dm' as const,
+            sourceId: this.sourceId,
             messageId: message.id,
             senderNodeId: fromNode?.nodeId || message.fromNodeId,
           }
         : {
             type: 'channel' as const,
+            sourceId: this.sourceId,
             channelId: message.channel,
             messageId: message.id,
           };

--- a/src/sw.navigation.test.ts
+++ b/src/sw.navigation.test.ts
@@ -198,6 +198,25 @@ describe('Push Notification Navigation Data', () => {
       expect(decodeNav(url.href)).toEqual(data);
     });
 
+    it('does not emit a double "?" when the scope already carries a query string', () => {
+      const scopeWithQuery = 'https://mesh.example.com/meshmonitor/?proxy=1';
+
+      // Both branches: with a sourceId (real route) and without (root fallback).
+      const routed = buildNotificationUrl(scopeWithQuery, {
+        type: 'dm',
+        sourceId: 'src-a',
+        senderNodeId: '!x',
+      });
+      const fallback = buildNotificationUrl(scopeWithQuery, { type: 'channel', channelId: 1 });
+
+      expect(routed.match(/\?/g)).toHaveLength(1);
+      expect(fallback.match(/\?/g)).toHaveLength(1);
+      expect(decodeNav(routed).sourceId).toBe('src-a');
+      expect(decodeNav(fallback).channelId).toBe(1);
+      // The fallback keeps the scope's own parameters rather than clobbering them.
+      expect(new URL(fallback).searchParams.get('proxy')).toBe('1');
+    });
+
     it('returns the bare scope when there is no navigation payload', () => {
       expect(buildNotificationUrl(SCOPE)).toBe(SCOPE);
       expect(buildNotificationUrl(SCOPE, null)).toBe(SCOPE);

--- a/src/sw.navigation.test.ts
+++ b/src/sw.navigation.test.ts
@@ -5,14 +5,12 @@
  * these tests validate the data structures and logic patterns used.
  */
 import { describe, it, expect } from 'vitest';
-
-// Type definitions matching sw.ts
-interface NotificationNavigationData {
-  type: 'channel' | 'dm';
-  channelId?: number;
-  messageId?: string;
-  senderNodeId?: string;
-}
+// The real implementation the service worker calls — importing it (rather than
+// re-deriving the URL inline) is what lets these tests catch a regression.
+import {
+  buildNotificationUrl,
+  type NotificationNavigationData,
+} from './utils/notificationUrl';
 
 interface PushNotificationPayload {
   title: string;
@@ -108,6 +106,112 @@ describe('Push Notification Navigation Data', () => {
 
         expect(data.senderNodeId).toBe(nodeId);
       });
+    });
+  });
+
+  // Regression coverage for #4463: the service worker used to cold-launch the
+  // app at `${scope}#notificationNav=...`. The app is path-routed, so the scope
+  // root renders DashboardPage — which never mounts the navigation handler, so
+  // the deep link was silently dropped on every platform.
+  describe('buildNotificationUrl (#4463)', () => {
+    const SCOPE = 'https://mesh.example.com/meshmonitor/';
+
+    const decodeNav = (url: string): NotificationNavigationData => {
+      const parsed = new URL(url);
+      return JSON.parse(parsed.searchParams.get('notificationNav')!);
+    };
+
+    it('targets the source-scoped messages route for a DM', () => {
+      const data: NotificationNavigationData = {
+        type: 'dm',
+        sourceId: 'src-a',
+        messageId: 'dm_msg_1',
+        senderNodeId: '!sender123',
+      };
+
+      const url = new URL(buildNotificationUrl(SCOPE, data));
+
+      expect(url.pathname).toBe('/meshmonitor/source/src-a/messages');
+      expect(decodeNav(url.href)).toEqual(data);
+    });
+
+    it('targets the source-scoped channels route for a channel message', () => {
+      const data: NotificationNavigationData = {
+        type: 'channel',
+        sourceId: 'src-b',
+        channelId: 3,
+        messageId: 'msg_12345',
+      };
+
+      const url = new URL(buildNotificationUrl(SCOPE, data));
+
+      expect(url.pathname).toBe('/meshmonitor/source/src-b/channels');
+      expect(decodeNav(url.href)).toEqual(data);
+    });
+
+    it('never puts the payload in the hash — the app no longer routes on it', () => {
+      const url = new URL(
+        buildNotificationUrl(SCOPE, { type: 'dm', sourceId: 'src-a', senderNodeId: '!x' })
+      );
+
+      expect(url.hash).toBe('');
+      expect(url.searchParams.get('notificationNav')).not.toBeNull();
+    });
+
+    it('does not land on the scope root when a sourceId is present', () => {
+      const url = buildNotificationUrl(SCOPE, {
+        type: 'channel',
+        sourceId: 'src-a',
+        channelId: 0,
+      });
+
+      expect(new URL(url).pathname).not.toBe('/meshmonitor/');
+    });
+
+    it('works for a root-mounted deployment (no BASE_URL)', () => {
+      const url = new URL(
+        buildNotificationUrl('https://mesh.example.com/', {
+          type: 'dm',
+          sourceId: 'src-a',
+          senderNodeId: '!x',
+        })
+      );
+
+      expect(url.pathname).toBe('/source/src-a/messages');
+    });
+
+    it('percent-encodes a sourceId containing URL-significant characters', () => {
+      const url = new URL(
+        buildNotificationUrl(SCOPE, { type: 'dm', sourceId: 'a/b?c', senderNodeId: '!x' })
+      );
+
+      expect(url.pathname).toBe('/meshmonitor/source/a%2Fb%3Fc/messages');
+    });
+
+    it('falls back to the scope root but keeps the payload when sourceId is absent', () => {
+      // Pre-4.13.4 notifications already delivered to a device carry no sourceId.
+      const data: NotificationNavigationData = { type: 'channel', channelId: 1 };
+
+      const url = new URL(buildNotificationUrl(SCOPE, data));
+
+      expect(url.pathname).toBe('/meshmonitor/');
+      expect(decodeNav(url.href)).toEqual(data);
+    });
+
+    it('returns the bare scope when there is no navigation payload', () => {
+      expect(buildNotificationUrl(SCOPE)).toBe(SCOPE);
+      expect(buildNotificationUrl(SCOPE, null)).toBe(SCOPE);
+    });
+
+    it('round-trips special characters in messageId', () => {
+      const data: NotificationNavigationData = {
+        type: 'channel',
+        sourceId: 'src-a',
+        channelId: 1,
+        messageId: 'msg_with_special_chars_!@#$%&=?',
+      };
+
+      expect(decodeNav(buildNotificationUrl(SCOPE, data)).messageId).toBe(data.messageId);
     });
   });
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -103,23 +103,22 @@ registerRoute(
 // PUSH NOTIFICATION HANDLERS
 // ==========================================
 
-// Navigation data interface for notification clicks
-interface NotificationNavigationData {
-  type: 'channel' | 'dm';
-  channelId?: number;
-  messageId?: string;
-  senderNodeId?: string;
-}
+// Navigation data + deep-link URL construction (shared with the app and tests)
+import { buildNotificationUrl, type NotificationNavigationData } from './utils/notificationUrl';
 
 // Handle push events (background notifications)
 self.addEventListener('push', event => {
   console.log('[Service Worker] Push received:', event);
 
+  // Resolve against the registration scope, not the origin root — a
+  // root-absolute '/logo.png' 404s under a BASE_URL sub-path deployment.
+  const defaultIcon = new URL('logo.png', self.registration.scope).href;
+
   let notificationData = {
     title: 'MeshMonitor',
     body: 'You have a new notification',
-    icon: '/logo.png',
-    badge: '/logo.png',
+    icon: defaultIcon,
+    badge: defaultIcon,
     tag: undefined as string | undefined, // Will be set uniquely per notification
     data: undefined as NotificationNavigationData | undefined, // Navigation data for click handling
   };
@@ -195,16 +194,11 @@ self.addEventListener('notificationclick', event => {
         }
       }
 
-      // If app is not open, open it with navigation data in URL hash
+      // If app is not open, cold-launch it directly on the target route
       if (self.clients.openWindow) {
-        let url = self.registration.scope;
-        if (navigationData) {
-          // Encode navigation data in URL hash for the app to read on load
-          const params = new URLSearchParams();
-          params.set('notificationNav', JSON.stringify(navigationData));
-          url = `${self.registration.scope}#${params.toString()}`;
-        }
-        return self.clients.openWindow(url);
+        return self.clients.openWindow(
+          buildNotificationUrl(self.registration.scope, navigationData)
+        );
       }
     })
   );

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -221,8 +221,10 @@ self.addEventListener('pushsubscriptionchange', event => {
           throw new Error('Missing subscription keys');
         }
 
-        // Send new subscription to backend
-        return fetch('/api/push/subscribe', {
+        // Send new subscription to backend. Resolve against the registration
+        // scope — a root-absolute '/api/...' misses the server entirely under
+        // a BASE_URL sub-path deployment, silently losing the re-subscription.
+        return fetch(new URL('api/push/subscribe', self.registration.scope).href, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/src/utils/notificationUrl.ts
+++ b/src/utils/notificationUrl.ts
@@ -44,14 +44,15 @@ export function buildNotificationUrl(
 ): string {
   if (!navigationData) return scope;
 
-  const params = new URLSearchParams();
-  params.set(NOTIFICATION_NAV_PARAM, JSON.stringify(navigationData));
-  const query = params.toString();
-
-  if (!navigationData.sourceId) {
-    return `${scope}?${query}`;
-  }
-
-  const path = `source/${encodeURIComponent(navigationData.sourceId)}/${tabForNavigation(navigationData)}`;
-  return `${scope}${path}?${query}`;
+  // Build through URL/searchParams rather than string concatenation so a scope
+  // that already carries a query string (some reverse-proxy setups) does not
+  // produce a double `?`, and so existing parameters survive.
+  const url = new URL(
+    navigationData.sourceId
+      ? `source/${encodeURIComponent(navigationData.sourceId)}/${tabForNavigation(navigationData)}`
+      : '',
+    scope
+  );
+  url.searchParams.set(NOTIFICATION_NAV_PARAM, JSON.stringify(navigationData));
+  return url.href;
 }

--- a/src/utils/notificationUrl.ts
+++ b/src/utils/notificationUrl.ts
@@ -1,0 +1,57 @@
+/**
+ * Deep-link URL construction for push notification clicks.
+ *
+ * Lives outside `src/sw.ts` so the service worker and the tests share one
+ * implementation — the previous tests re-implemented the URL logic inline and
+ * therefore could not catch a regression in it (#4463).
+ */
+
+export interface NotificationNavigationData {
+  type: 'channel' | 'dm';
+  /** Source the message belongs to. Absent on pre-4.13.4 payloads. */
+  sourceId?: string;
+  channelId?: number;
+  messageId?: string;
+  senderNodeId?: string;
+}
+
+/** Query parameter carrying the serialized navigation payload. */
+export const NOTIFICATION_NAV_PARAM = 'notificationNav';
+
+/** Route tab that handles each notification type. */
+export function tabForNavigation(navigationData: NotificationNavigationData): 'messages' | 'channels' {
+  return navigationData.type === 'dm' ? 'messages' : 'channels';
+}
+
+/**
+ * Build the URL to open for a notification click.
+ *
+ * The app is path-routed (`<base>/source/:sourceId/<tab>`, see src/main.tsx).
+ * The scope root falls through to `path="*"` → DashboardPage, which never
+ * mounts the notification-navigation handler — so opening the root loses the
+ * navigation entirely (#4463). Target the real route instead, and carry the
+ * payload in the query string, since the app no longer routes on the hash.
+ *
+ * Payloads without a `sourceId` (older notifications still in flight, or a
+ * push from a build that predates this change) fall back to the scope root
+ * with the payload attached, so an already-loaded source view can still use it.
+ *
+ * @param scope Registration scope — an absolute URL ending in `/`.
+ */
+export function buildNotificationUrl(
+  scope: string,
+  navigationData?: NotificationNavigationData | null
+): string {
+  if (!navigationData) return scope;
+
+  const params = new URLSearchParams();
+  params.set(NOTIFICATION_NAV_PARAM, JSON.stringify(navigationData));
+  const query = params.toString();
+
+  if (!navigationData.sourceId) {
+    return `${scope}?${query}`;
+  }
+
+  const path = `source/${encodeURIComponent(navigationData.sourceId)}/${tabForNavigation(navigationData)}`;
+  return `${scope}${path}?${query}`;
+}


### PR DESCRIPTION
Fixes #4463.

## Not a WebKit bug

The issue was filed as blocked on [WebKit 259212](https://bugs.webkit.org/show_bug.cgi?id=259212). That bug is **RESOLVED / CONFIGURATION CHANGED** — the reporter's own closing comment says it only failed on `localhost` and works fine once deployed over HTTPS. The real, still-open iOS bug ([writeup](https://intercom.help/progressier/en/articles/9213767-why-ios-push-notifications-sometimes-don-t-redirect-to-the-correct-url-in-a-pwa)) fires under the *opposite* conditions — app already running, launched by its icon — so it does not explain the "app fully closed" repro.

The failure is ours, and it reproduces on **every** platform with the app closed, not just iOS.

## Root cause

`src/sw.ts` cold-launched the app at `${scope}#notificationNav={...}`.

Since #3962 Task 5.4 the app is path-routed (`<BrowserRouter>`, routes at `source/:sourceId/<tab>`). The scope root falls through to `path="*"` → `DashboardPage` (`src/main.tsx:186-189`), which never mounts the notification-navigation handler — that lives in `App.tsx:1371`, under `source/:sourceId/*`. So the deep link landed on a page that could not read it.

Worse: `usePushNotificationNavigation` captures at **module-import** time (`App` is a static import), so on the Dashboard it read the hash and immediately `history.replaceState`'d it away — destroying the payload before any consumer existed.

iOS just hits this far more often because the PWA is usually cold. Desktop users normally have the app open on a source route, taking the working `postMessage` path — which matches the "already open path works" note in the issue.

## Changes

| | |
|---|---|
| `src/server/meshtasticManager.ts` | Add `sourceId` to the navigation payload — without it no correct route can be built. |
| `src/utils/notificationUrl.ts` **(new)** | `buildNotificationUrl()` targets `${scope}source/<id>/<messages\|channels>?notificationNav=…`. Payloads with no `sourceId` (notifications already delivered by an older build) fall back to the scope root *with the payload attached*. |
| `src/sw.ts` | Call the shared builder. Also resolve the default notification `icon`/`badge` against the registration scope — root-absolute `/logo.png` 404s under a `BASE_URL` sub-path deployment. |
| `src/hooks/usePushNotificationNavigation.ts` | Read the payload from the query string, keeping the hash form as a backward-compatible fallback. Strip only the `notificationNav` parameter instead of discarding the whole search string and path. Consume the module-level capture in an effect rather than the `useState` initializer — `<React.StrictMode>` double-invokes initializers, so the second call would return `null` and drop the navigation in dev. |
| `src/hooks/useNotificationNavigationHandler.ts` | Stop calling `clearPendingNavigation()` before the route resolves (`setActiveTab` is a no-op while `useParams().sourceId` is undefined), so it retries instead of silently dropping. Hand off via the router when the notification targets a *different* source than the one currently open — previously it would have applied the navigation to the wrong source. |

## Tests

`sw.navigation.test.ts` previously re-implemented the URL logic inline, which is why it could not catch this. It now imports the real builder.

- 9 new cases for `buildNotificationUrl`: DM → `/messages`, channel → `/channels`, never emits a hash, never lands on the scope root when a `sourceId` is present, root-mounted deployments, `sourceId` percent-encoding, no-`sourceId` fallback, and payload round-trips.
- 5 new cases for query-string reading: payload parsed from `?notificationNav=`, path and unrelated query params preserved on strip, `sourceId` survives the round trip, and malformed input handled.

## Verification

- `tsc --noEmit` clean.
- Full Vitest suite: **13,109 passed, 0 failed** (109 skipped — PG/MySQL containers not running locally; this change touches no schema or migrations).
- `npm run lint:ci` clean.
- `npm run build` succeeds and the emitted `dist/sw.js` contains the `source/` route construction, confirming the new path is bundled and reachable.

Not device-tested on iOS — but the bug is now reproducible and verifiable in any desktop browser with the app closed, which is how the fix was validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB
