### PR TITLE
feat(meshcore): Analyzer Observer publisher service — Phase 2 (#4457)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_ANALYZER_OBSERVER_EPIC.md
+++ b/docs/internal/dev-notes/MESHCORE_ANALYZER_OBSERVER_EPIC.md
@@ -1,6 +1,6 @@
 # MeshCore Analyzer Observer MQTT Output — Epic Plan (#4457)
 
-**Status:** Phase 1 complete (PR pending) — Phase 2 next
+**Status:** Phase 2 complete (PR pending) — Phase 3 (UI + docs) next
 **Issue:** #4457 — publish packets heard by a MeshCore Companion source to a MeshCore Analyzer-compatible MQTT broker, so the node counts as an observer without a second app fighting over the serial port.
 **Scope guard:** observation-only. MeshMonitor publishes; it never subscribes to or injects broker traffic into the mesh. The broker's admin-only `serial/commands` remote-serial feature is out of scope.
 
@@ -47,10 +47,10 @@ Upstream issue michaelhart/meshcore-mqtt-broker#9 has no reply. We built the con
 - **Exit:** config + key round-trip through the API with secrets redacted; full suite green; merged PR.
 
 ### Phase 2 — Observer publisher service
-- [ ] `meshcoreObserverPublisher` per source: `manager.on('ota_packet')`, analyzer-contract packet JSON (decoder lib for hash/decode/advert privacy), publish via `MqttBrokerClient` (wss), retained `/status` + LWT, token renewal, reconnect via coordinator.
-- [ ] Lifecycle: start/stop with manager + restart on config change; observer status in `getStatus()` (connected, publishes, lastPublishAt, lastError).
-- [ ] Tests with mocked broker; per-source isolation.
-- **Exit:** live end-to-end against local `meshcore-mqtt-broker` (Docker, `test` region): token auth accepted, packets + status seen by a subscriber; merged PR.
+- [x] `meshcoreObserverPublisher` per source: `manager.on('ota_packet')`, analyzer-contract packet JSON (hash/decode implemented ourselves, not the decoder lib — see deviations (a)/(b); no advert privacy filter — see deviation (c)), publish via `MqttBrokerClient` (ws/wss), retained `/status` + explicit graceful-offline (LWT alone is broker-filtered — see deviation (e)), token renewal, reconnect via coordinator.
+- [x] Lifecycle: start/stop with manager + restart on config change (plus the hot-swap follow-up, deviation (f)); observer status in `getStatus()` (connected, publishes, lastPublishAt, lastError).
+- [x] Tests with mocked broker; per-source isolation.
+- **Exit:** live end-to-end against local `meshcore-mqtt-broker` (Docker, `test` region): token auth accepted, packets + status seen by a subscriber; merged PR. — **Done 2026-07-31**, run against a real companion (Yeraze MC Sandbox) instead of a synthetic feed; all 10 §8 criteria passed (see deviation (j)).
 
 ### Phase 3 — Frontend UI + docs
 - [ ] Observer fieldset in the MeshCore source modal: enable, broker URL, IATA, audience, fetch-key-from-device button + paste fallback, key-stored indicator.
@@ -71,3 +71,18 @@ Upstream issue michaelhart/meshcore-mqtt-broker#9 has no reply. We built the con
 - **Route-test harness gap.** `harness.grant()` collides with the `permissions` table's `UNIQUE(user_id, resource, sourceId)` index when granting read then write separately. Tests needing both use a local `grantReadWrite()` helper that writes one row with both flags set.
 - **Known gap (accepted).** A `meshcore_observer_keys` row orphans on source delete, same as `source_pki_keys` today. Cascade cleanup is deferred to its own change.
 - **Phase 2 seam.** `mintObserverTokenForSource()` is intentionally unrouted — Phase 2's publisher is its first consumer.
+
+### Phase 2
+
+- **(a)** The decoder library's `messageHash` (`@michaelhart/meshcore-decoder`'s `calculateMessageHash`) is a 32-bit djb2-style rolling hash, **not** `Packet::calculatePacketHash`. The analyzer contract's `hash` field is SHA-256-derived and 16 upper-hex chars, so we implement it ourselves rather than call the decoder lib (spec D-2).
+- **(b)** We decode the path/payload boundary with the **packed** `path_len` byte (`hashSize=(b>>6)+1`, `hopCount=b&0x3f`), not the reference's plain byte-count read. The two are byte-identical for 1-byte hash mode (effectively all real traffic); a named test pins the divergence for multi-byte hash mode, where the reference is simply wrong against firmware `Packet.h` (spec D-3).
+- **(c)** The reference publishes **no decoded advert fields** on the wire — its "advert opt-in privacy filter" (`name.endswith('^')`) has zero observable effect, since `format_packet_data()` never merges the advert decode into the payload. We match the wire: no advert fields, no filter implemented (spec D-4).
+- **(d)** Timestamps are emitted as UTC ISO-8601 with `Z` (`new Date().toISOString()`), a deliberate deviation from the reference's naive local `datetime.now().isoformat()` — naive local time is undisambiguatable and the broker itself parses timestamps with `new Date(...)` (spec D-8).
+- **(e)** The broker's stale-status filter suppresses the LWT on an ungraceful disconnect, so graceful stop publishes an explicit `offline` status before closing the socket (§2.4). This required a fix to `MqttBrokerClient.disconnect()`: the original force-end path discarded the queued offline publish, so a new `disconnect({flush: true})` (2s force-end fallback) is used, exclusively by `publisher.stop()`.
+- **(f)** `reconfigureObserver` hot-swap shipped (closes the Phase 1 follow-up) — toggling `observer.enabled` or its config no longer bounces the MeshCore radio link. Verified live: no reconnect logged for an observer-only config change.
+- **(g)** The reference's nameless-advert bug (`payload_value["name"]` unguarded, raising `KeyError`, swallowed by an outer `except`, degrading the packet to `route="U"`/`packet_type="0"`/`payload_len="0"`) is **not** replicated — our decode is total and never degrades a well-formed advert.
+- **(h)** The token renewal predicate subtracts the check interval as well as the expiry threshold, closing the reference's ~55-minute post-expiry hole (same three constants as the reference, different comparison — spec §3.2/§6).
+- **(i)** E2E against real hardware surfaced two live-only bugs invisible to the unit suite: a bare `require()` broke in the bundled ESM server (fixed via `createRequire`), and `firmware_version` doubled the `v` prefix because the device already reports its version with a leading `v` (fixed by not re-prepending it).
+- **(j)** E2E performed 2026-07-31 against a real companion (Yeraze MC Sandbox) and `meshcore-mqtt-broker` run from source (not a synthetic feed). All 10 §8 criteria passed: auth with correct audience; online status with retain-strip; packets with the full string-typed contract; hash independently verified; `path` present only on route D; no topic normalization; publisher never subscribes; graceful offline delivered after the flush fix; hot-swap with zero device bounce; bad audience produces a clean `lastError` and a single rejection with no reconnect storm.
+
+**Superseded checklist text (Phase 2, above):** the Phase 2 checklist item's parenthetical "(decoder lib for hash/decode/advert privacy)" is superseded by deviations (a)-(c) — hash/decode are hand-rolled, not decoder-lib calls, and no advert privacy filter exists. Its "reconnect via coordinator" wording refers only to the `MqttBrokerClient`'s own reconnect backoff, not to observer-toggle behavior, which is covered separately by the hot-swap in deviation (f); see also Phase 1's now-closed "Restart hook" note above.

--- a/docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md
+++ b/docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md
@@ -1,0 +1,1000 @@
+# MeshCore Analyzer Observer — Phase 2 Implementation Spec
+
+**Epic:** #4457 (`MESHCORE_ANALYZER_OBSERVER_EPIC.md`)
+**Phase:** 2 — Observer publisher service (backend only, no UI)
+**Depends on:** Phase 1 (merged: config block, `meshcore_observer_keys` + migration 133, key store, token minter, key routes)
+**Branch:** `feature/meshcore-observer-mqtt-phase2`
+
+Phase 1 shipped every input the publisher needs and deliberately left
+`mintObserverTokenForSource()` unrouted as its seam. Phase 2 builds the consumer:
+one publisher per MeshCore Companion source that relays every OTA packet the
+radio hears to a MeshCore-Analyzer-compatible MQTT broker, publishes online/offline
+status, and never subscribes to anything.
+
+---
+
+## 0. Decisions made in this spec (read first)
+
+| # | Decision | Rationale |
+|---|---|---|
+| **D-1** | Two new modules: a **pure encoder** (`meshcoreObserverPacket.ts`) and a **stateful publisher** (`meshcoreObserverPublisher.ts`). | The encoder is 100% deterministic → golden-testable with fixed hex, no mocks. Keeping MQTT out of it is what makes §7.2 possible. |
+| **D-2** | **Do not** use `MeshCorePacketDecoder.calculateMessageHash()` from `@michaelhart/meshcore-decoder` for the `hash` field. | Verified in `node_modules/@michaelhart/meshcore-decoder/src/decoder/packet-decoder.ts`: `calculateMessageHash` is a 32-bit djb2-style rolling hash rendered as **8** hex chars. It is **not** `Packet::calculatePacketHash`. The analyzer contract's `hash` is SHA-256-derived, 16 upper-hex chars. We implement it (§2.3). |
+| **D-3** | Path/payload boundary uses the **packed** `path_len` decode (`hashSize=(b>>6)+1`, `hopCount=b&0x3f`), **not** the reference's plain-byte-count read. | For 1-byte hash mode (`b ≤ 0x3f` — effectively all real traffic) the two are **byte-identical**, so hashes still match every other observer. In multi-byte hash mode the reference is simply wrong against firmware `Packet.h`, and would emit a hash nobody can reproduce. A named test pins the divergence. |
+| **D-4** | The published packet payload carries **no decoded advert fields**. | Verified against `packet_capture.py`: `format_packet_data()` copies only `route_type`/`payload_type`/`path` out of the decode result. The advert fields parsed by `parse_advert()` are **never** merged into `packet_data`. The "advert opt-in privacy filter" (`name.endswith('^')`) therefore has **zero** observable effect on the wire. We replicate the wire, so we publish no advert fields at all and implement no filter. This is both byte-faithful and the privacy-safest option. |
+| **D-5** | `MqttBrokerClient` gains two optional constructor options: `will` and `keepalive`. | It has no LWT support today and the contract requires one. ~6 lines, additive, default-preserving. Justified in §1. |
+| **D-6** | Reconnect uses the client's **own** backoff (1 s → 60 s, stability-gated). **No** `MqttReconnectCoordinator`. | The coordinator exists to collapse N sockets to the *same* broker into one shared timer (`mqttBridgePublisherPool`). The observer opens exactly one socket per source; a coordinator would be an empty abstraction. |
+| **D-7** | `reconfigureObserver()` hot-swap **is in scope** for Phase 2 (WP6). | Phase 1 §4.2 deferred it only because there was nothing to swap into. There is now. Without it, toggling the observer runs `removeManager` → `ensureMeshCoreManagerStarted`, bouncing the companion serial/TCP link for seconds. `sourceRoutes.ts` already carries the Phase-1 TODO comment marking the exact insertion point (~L983). |
+| **D-8** | `timestamp` is emitted as **UTC ISO-8601 with `Z`** (`new Date().toISOString()`), not the reference's naive local `datetime.now().isoformat()`. | A naive local timestamp is un-disambiguatable by any consumer; the broker itself parses it with `new Date(...)` in its stale-status filter. `Z` is strictly more correct and universally parsed. Recorded as a deliberate deviation. |
+| **D-9** | Token is minted at connect + on a renewal timer; a renewal **tears down and rebuilds** the `MqttBrokerClient`. | mqtt.js bakes `username`/`password` into the CONNECT packet at `connect()` time; there is no supported credential-refresh API. Mutating the options object does not re-read. Recreating the client is the only correct path (this is also what the reference does — `reconnect_mqtt_broker_with_new_token`). |
+| **D-10** | The observer status sub-object is **stripped for anonymous / non-`nodes:read` callers** in `GET /api/sources/:id/status`. | That route is `optionalAuth()` and returns the bare status early when `!canReadNodes` (`sourceRoutes.ts` L1118-1120). `lastError` can contain the broker hostname. Stripping is one branch and keeps the leak surface at zero. |
+| **D-11** | The observer is **not** gated on `meshcore_packet_log_enabled`. | It consumes `manager.emit('ota_packet')` (`meshcoreManager.ts` L1793), which is emitted unconditionally, *before* the packet-log gate in `handleOtaPacket()`. Same second-consumer posture as the Virtual Node bridge (#3963). |
+| **D-12** | No new global settings, no `VALID_SETTINGS_KEYS` entry, no migration, no schema change. | Everything the publisher needs is already per-source: the `observer` config block (Phase 1) and the `meshcore_observer_keys` row (Phase 1). |
+
+---
+
+## 1. Reuse inventory (MANDATORY — read before writing any code)
+
+Nothing below is to be re-implemented. Anything new is justified in §1.13.
+
+### 1.1 The event source — `manager.on('ota_packet')`
+
+| What | Where | Notes |
+|---|---|---|
+| Emit site | `src/server/meshcoreManager.ts` L1782-1795 | `else if (event_type === 'ota_packet')` → `this.emit('ota_packet', data)`. **Deliberately not gated** on the packet-monitor setting (comment at L1786-1791 says so explicitly). |
+| Producer | `src/server/meshcoreNativeBackend.ts` L492-503 | Emits `{ payload_type, payload_type_string, route_type, route_type_string, path_len_raw, hop_count, path_hops, snr, rssi, payload_size, raw_hex }`. **Native (Companion) backend only** — the serial/CLI repeater backend never emits it. This is the mechanical reason the observer is companion-only, matching Phase 1's `OBSERVER_REQUIRES_COMPANION` validation. |
+| Declared event shape | `src/server/meshcoreVirtualNodeServer.ts` L180-188 (`OtaPacketEvent`) | `{ snr?, rssi?, raw_hex? }`. **Import this type; do not redeclare it.** |
+| Second-consumer precedent | `meshcoreVirtualNodeServer.ts` L336 (`on`), L353 (`off`), L1312-1330 (`handleOtaPacket`) | The exact pattern to copy: bound arrow-property listener registered in `start()`, removed in `stop()`, handler is sync, returns early on empty `raw_hex`, never throws. |
+
+> **Trap (verified):** `payload_size` on the event is `raw.length` — the **whole frame**, not the payload. Do **not** wire it to the contract's `payload_len`. Likewise `path_len_raw` is the raw packed byte and `hop_count` is already decoded. The encoder derives everything from `raw_hex` itself (§3.1) so it has one source of truth and one thing to golden-test.
+
+### 1.2 MQTT client — `MqttBrokerClient`
+
+`src/server/transports/mqttBrokerClient.ts` (476 lines).
+
+| What | Where | Notes |
+|---|---|---|
+| `connect(url, opts)` passthrough | L180 | Uses mqtt.js `connect()`, which supports `ws:`, `wss:`, `mqtt:`, `mqtts:` natively. **No change needed for wss.** |
+| `publish(topic, payload, retained)` | L277-286 | QoS 0, promise-wrapped. Exactly our need. |
+| Self-managed backoff | L128-137, L287-333 | `reconnectPeriod: 0` on mqtt.js; own 1 s→60 s exponential with a 30 s stability gate before reset. Reuse; do **not** add a second retry layer. |
+| Auth-rejection classification | L219-235 | CONNACK code 4/5 → `authFailed = true` + `emit('permission-denied', { kind: 'auth', message })`. This is the hook for §6's auth-cooldown. |
+| `isConnected()` / `getLastError()` | L355-361 | Status plumbing. |
+| `normalizeBrokerUrl()` | L465-476 | Already applied by `observerConfigFromSource` (Phase 1). Do not call it twice. |
+
+**Verified gaps that WP2 fills (D-5):**
+- `MqttBrokerClientOptions` has **no `will`** field, and `connect()` never sets one. The contract requires an LWT.
+- `keepalive` is hardcoded to `15` (L171). The LetsMesh preset is 60. 15 is safe (more frequent pings; the broker also runs WS ping/pong) but make it overridable so the observer can match the preset.
+
+**Verified non-issues, do not "fix":**
+- `lookup: sharedDnsLookup` (L177) is a net/tls socket option. For `ws`/`wss` mqtt.js builds the socket via the `ws` package and passes only `opts.wsOptions`, so `lookup` is silently ignored on websocket transports. Harmless — no DNS caching on wss, that is all.
+- `rejectUnauthorized` is likewise not forwarded on `wss` for the same reason. Public analyzer brokers use valid certs (`ws`'s own default already verifies), so this does not matter. Do not add a `wsOptions` plumbing layer for it.
+
+**Trap:** `publish()` only guards on `!this.client`, not on `connected`. mqtt.js queues QoS-0 publishes while offline (`queueQoSZero` defaults true), so a disconnected observer on a busy mesh would grow an unbounded in-memory queue. The publisher **must** gate on `isConnected()` itself (§3.2).
+
+### 1.3 Status shape precedent
+
+| What | Where |
+|---|---|
+| `MqttBridgeStatus extends SourceStatus` | `src/server/mqttBridgeManager.ts` L186-228 — the "extend the base status with a feature sub-object" precedent. |
+| `PublisherStatus` | `src/server/mqttBridgePublisherPool.ts` L45-52 — `{ clientId, connected, publishes, lastPublishAt, lastError }`. Our observer status is this shape plus `configured` / `keyStored` / `dropped` / `tokenExpiresAt`. |
+| `getStatus()` builder | `mqttBridgePublisherPool.ts` L94-106 — read counters off the entry, `connected` off the live client. |
+| `SourceStatus` base | `src/server/sourceManagerRegistry.ts` L8-15 |
+| MeshCore `getStatus()` | `src/server/meshcoreManager.ts` L5604-5611 — the four-field return we extend. |
+
+### 1.4 Lifecycle mirror sites
+
+The observer binds to exactly the four places the Virtual Node server already binds:
+
+| Site | `meshcoreManager.ts` | Action |
+|---|---|---|
+| `connect()` success | L1173 `await this.startVirtualNodeServer()` | add `await this.startObserver()` immediately after |
+| `disconnect()` | L1314 `await this.stopVirtualNodeServer()` | add `await this.stopObserver()` immediately before |
+| unexpected socket drop | L6037 | same |
+| `teardownTransportOnly()` | L6069 | same |
+
+`startVirtualNodeServer()` (L1236-1255) / `stopVirtualNodeServer()` (L1257-1265) are the exact shape to copy: idempotent (`if (!cfg?.enabled || this.x) return`), try/catch, non-fatal, null the field on failure.
+
+### 1.5 Hot-swap precedent (WP6)
+
+| What | Where |
+|---|---|
+| Registry passthrough | `src/server/sourceManagerRegistry.ts` L114-127 (`reconfigureVirtualNode`) — duck-typed `typeof manager.reconfigureX === 'function'` guard, returns `false` when unsupported. |
+| Route branch | `src/server/routes/sourceRoutes.ts` L895-900 (`vnChanged` branch) |
+| Insertion point | `sourceRoutes.ts` ~L978-998 — the MeshCore config-change branch, which already carries the Phase-1 TODO comment naming `manager.reconfigureObserver(...)`. |
+
+### 1.6 Phase 1 seams
+
+| What | Where | Contract |
+|---|---|---|
+| `observerConfigFromSource(cfg)` | `src/server/meshcoreConfig.ts` | Returns `undefined` unless enabled **and** all of `brokerUrl`/`iataCode`/`tokenAudience` present; normalizes URL, uppercases IATA, trims audience. |
+| `MeshCoreConfig.observer` | `src/server/meshcoreManager.ts` L352 | Already plumbed through both `meshcoreConfigFromSource` branches. Read it as `this.config?.observer`. |
+| `mintObserverTokenForSource(sourceId)` | `src/server/services/meshcoreObserverToken.ts` L118 | `Promise<ObserverToken \| null>`; `{ token, publicKey, issuedAt, expiresAt }`. **Refined in WP3** — see §3.3. |
+| `OBSERVER_TOKEN_TTL_SECONDS` | same, L33 | `86_400`. |
+| Key store | `src/server/services/meshcoreObserverKeyStore.ts` | `getMeshCoreObserverKeyStore()` → `.status(sourceId): Promise<ObserverKeyStatus>` (`{ stored, publicKey, origin, updatedAt, keyRotated, canStore, reason }`), `.load(sourceId)` → `{kind:'none'\|'ok'\|'key_rotated'}`. Use `.status()` for the `keyStored` flag; never call `.load()` from status code. |
+
+### 1.7 Packet decode reference
+
+`src/utils/meshcorePacketDecode.ts` — `decodeMeshCorePacket(rawHex)` (L140) already does the packed `path_len` decode (L179-181) that D-3 requires, plus payload-boundary math.
+
+**Do not call it from the encoder.** It returns a UI-shaped object (`hops` as hex strings, `payloadTypeName`, `errors[]`) and is a browser-targeted module; the encoder needs raw byte offsets to feed SHA-256 and must be dependency-free for the golden tests. **Do** cross-check the encoder's parse against it: WP1 adds a test asserting the encoder's `(payloadType, routeType, hopCount, payloadStart)` agrees with `decodeMeshCorePacket()` on every fixture. If they ever disagree, one of them is wrong.
+
+### 1.8 Existing packet field vocabulary
+
+`src/server/services/meshcorePacketLogService.ts` + `meshcoreManager.handleOtaPacket()` (L1810-1835) already extract `payload_type`, `route_type`, `path_len_raw`, `hop_count`, `path_hops`, `snr`, `rssi`, `payload_size`, `raw_hex`. Use the same *names* when logging; the analyzer contract's names differ and are fixed by §2.
+
+### 1.9 Test fixtures
+
+`src/server/meshcoreNativeBackend.otaPacket.test.ts` (L108-140) has real `rawHex` fixtures for a TXT_MSG flood packet and an ADVERT direct packet. `src/utils/meshcorePacketDecode.test.ts` has more. **Source WP1's golden fixtures from these files** rather than hand-rolling frames.
+
+### 1.10 Test mocking approach
+
+`src/server/transports/mqttBrokerClient.test.ts` L1-26 is the canonical mqtt.js mock: `vi.mock('mqtt', () => ({ connect: vi.fn(() => makeFakeClient()) }))` where `makeFakeClient()` is an `EventEmitter` with `subscribe`/`publish`/`end`/`reconnect` stubs, plus `lastFakeClient()` / `lastConnectOptions()` accessors. **Copy this for WP2 and WP4.**
+
+`src/server/mqttBridgeManager.permission.test.ts` L1-70 runs a **real Aedes** broker on an ephemeral port for auth/ACL behaviour. Use that style only if a mock cannot express the case; it is slower.
+
+### 1.11 Response envelope / route conventions
+
+`src/server/utils/apiResponse.ts` (`ok` / `fail`). **Not applicable to WP5's status change** — `GET /:id/status` returns a bare `res.json(status)` object today and `ApiService.request()` does not unwrap `data`. Converting it would break every consumer. Leave the wire shape alone; only add/strip the `observer` key.
+
+### 1.12 App version
+
+`require('../../../package.json')` — pattern at `src/server/services/newsService.ts` L14, `routes/healthRoutes.ts` L8.
+
+### 1.13 What is genuinely new, and why
+
+| New file/change | Why nothing existing covers it |
+|---|---|
+| `meshcoreObserverPacket.ts` | The analyzer wire format is a third-party contract (string-typed numerics, `SNR`/`RSSI` capitalisation, `route` single letters, `hash` = SHA-256[:16] upper). Nothing in-repo emits it. Pure + golden-tested. |
+| `meshcoreObserverPublisher.ts` | No existing service owns "one authenticated publish-only MQTT socket per MeshCore source with token renewal". `mqttBridgePublisherPool` is Meshtastic-gateway-keyed and bridge-scoped. |
+| `will` / `keepalive` on `MqttBrokerClientOptions` | Verified absent (§1.2). Additive and default-preserving. |
+| `mintObserverTokenForSourceDetailed()` | Phase 1's null-for-all-failures contract cannot distinguish "no key" from "envelope rotated" from "config incomplete" — the publisher needs those for `lastError` (§6). Added **alongside** the existing function, which becomes a wrapper so Phase 1's tests keep passing unchanged. |
+
+---
+
+## 2. The wire contract, verified against source
+
+Recovered by reading `michaelhart/meshcore-packet-capture@main/packet_capture.py` (2286 lines) and `michaelhart/meshcore-mqtt-broker@main/src/server.ts` (1004 lines) on 2026-07-31.
+
+### 2.1 Connection
+
+| Item | Value | Source |
+|---|---|---|
+| Transport | Broker listens **plain WebSocket** on `MQTT_WS_PORT` (default 8883); TLS is terminated externally (Cloudflare tunnel). Public deployments are therefore `wss://host:443`; a local broker is `ws://localhost:8883`. | `server.ts` L817-830, L972 |
+| Username | `v1_{PUBLIC_KEY}` — `PUBLIC_KEY` is 64 hex chars, uppercased by the broker before matching | `server.ts` L184-198 |
+| Password | The Phase-1 JWT-style token. Broker calls `verifyAuthToken(password, publicKey)` from the **same** `@michaelhart/meshcore-decoder` we mint with | `server.ts` L207` |
+| Audience | Rejected unless `tokenPayload.aud === AUTH_EXPECTED_AUDIENCE` (broker's env). Empty audience env ⇒ check skipped | `server.ts` L220-225 |
+| MQTT version | 3.1.1 (aedes) — `MqttBrokerClient` already pins `protocolVersion: 4` | — |
+| QoS | 0 everywhere. The reference explicitly downgrades QoS 1 → 0 "to prevent retry storms" | `packet_capture.py` L1470-1472 |
+
+### 2.2 Topics
+
+```
+meshcore/{REGION}/{PUBLIC_KEY}/packets
+meshcore/{REGION}/{PUBLIC_KEY}/status
+```
+
+Broker rules (`server.ts` `authorizePublish`, L252-410) — **violating any of these closes the connection**, not just rejects the publish:
+
+1. Topic must start with `meshcore/` and split into **≥ 4** parts.
+2. `parts[1]` (region): literal `XXX` → **disconnect**. Case-insensitive `test` → allowed, normalized to lowercase `test`. Otherwise must match `/^[A-Z]{3}$/` **and** resolve via `airport-utils.getAirportInfo()` → else **disconnect**.
+3. `parts[2]` must be 64 hex chars **and** equal the authenticated public key → else **disconnect**.
+4. Broker rewrites the topic to `meshcore/{normalizedRegion}/{UPPER_PUBKEY}/{rest}`.
+5. Any payload published to a `meshcore/...` topic must parse as JSON containing `origin_id` that uppercases to the authenticated key → else publish rejected (`server.ts` L435-455).
+6. `packet.retain` is **stripped** from any topic ending in `/status` (L261-266). Publish it retained anyway — the reference does, and the flag is simply cleared.
+
+**Publisher-side region normalization:** Phase 1's `observerConfigFromSource` uppercases `iataCode`, yielding `TEST` for the test region. Publish `test` lowercase yourself so the topic needs no broker rewrite:
+
+```ts
+const region = cfg.iataCode.toLowerCase() === 'test' ? 'test' : cfg.iataCode.toUpperCase();
+```
+
+**Subscribe: never.** `authorizeSubscribe` (L559-590) closes any publisher client that subscribes to anything other than its own `/serial/commands`. Remote serial is explicitly out of scope (§10), so the observer's subscription set is empty — this is an invariant, not a default.
+
+### 2.3 Packet payload — exact field set
+
+Source: `packet_capture.py` `format_packet_data()` L1717-1833. This dict **is** the published JSON (`output_packet()` L1938-1975 does `json.dumps(packet_data)` straight to the `packets` topic). Key order is irrelevant; presence, name, and **type** are not.
+
+| Key | JSON type | Value | Reference line |
+|---|---|---|---|
+| `origin` | string | Device name | L1810 |
+| `origin_id` | string | 64-hex **UPPERCASE** public key | L1811 |
+| `timestamp` | string | ISO-8601 — see **D-8** | L1812 |
+| `type` | string | Literal `"PACKET"` | L1813 |
+| `direction` | string | Literal `"rx"` | L1814 |
+| `time` | string | `HH:MM:SS`, **local** | L1815 |
+| `date` | string | `DD/MM/YYYY`, **local** | L1816 |
+| `len` | **string** | Total frame bytes, decimal | L1817 |
+| `packet_type` | **string** | Payload type as a decimal string `"0"`…`"15"` | L1818 |
+| `route` | string | `"F"` / `"D"` / `"T"` / `"U"` | L1819 |
+| `payload_len` | **string** | Payload bytes, decimal | L1820 |
+| `raw` | string | Whole OTA frame, **UPPERCASE** hex | L1821 |
+| `SNR` | **string** | `String(snr)` or `"Unknown"` — note capitalisation | L1822 |
+| `RSSI` | **string** | `String(rssi)` or `"Unknown"` | L1823 |
+| `hash` | string | 16 **UPPERCASE** hex chars (§2.3.2) | L1824 |
+| `path` | string | **Present only when `route === "D"`**; comma-joined 2-hex-char hop tokens, e.g. `"a1,b2,c3"` | L1828-1829 |
+
+Every numeric is a **string**. Emitting `len: 42` instead of `len: "42"` is a contract violation.
+
+#### 2.3.1 `route` mapping
+
+Reference `route_map` (L1741-1746) keyed on the route-type **name**:
+
+| `route_type` | name | `route` |
+|---|---|---|
+| `0x00` | `TRANSPORT_FLOOD` | `"F"` |
+| `0x01` | `FLOOD` | `"F"` |
+| `0x02` | `DIRECT` | `"D"` |
+| `0x03` | `TRANSPORT_DIRECT` | `"T"` |
+| decode failed | — | `"U"` (and `packet_type` falls back to `"0"`, `payload_len` to `"0"`) |
+
+Note `TRANSPORT_DIRECT` maps to `"T"`, **not** `"D"` — so a `TRANSPORT_DIRECT` packet gets **no** `path` key.
+
+#### 2.3.2 `hash` — `Packet::calculatePacketHash`
+
+Reference `calculate_packet_hash()` L1668-1716:
+
+```
+payload_type = (header >> 2) & 0x0F
+route_type   = header & 0x03
+offset       = 1 + (route_type in {0x00, 0x03} ? 4 : 0)   # skip transport codes
+path_len_raw = bytes[offset]; offset += 1
+offset      += pathByteLength(path_len_raw)                # ← D-3: packed decode
+payload      = bytes[offset..]
+
+sha = SHA256()
+sha.update([payload_type])                                  # 1 byte
+if payload_type == 9:  sha.update(uint16le(path_len_raw))   # TRACE only, 2 bytes
+sha.update(payload)
+hash = sha.hexdigest()[0:16].upper()                        # 16 upper-hex chars
+```
+
+On any exception the reference returns the literal `"0000000000000000"`. **Replicate that sentinel** — never throw out of the encoder.
+
+`pathByteLength(b)` per **D-3**:
+```ts
+if (b === 0xff) return 0;                    // direct, no relay hashes
+return (b & 0x3f) * (((b >> 6) & 0x03) + 1); // hopCount × hashSize
+```
+For `b ≤ 0x3f` this equals `b` — identical to the reference's plain read.
+
+#### 2.3.3 `payload_len`
+
+Reference prefers the firmware-supplied `payload_length` from the RF-log event, else computes `total − 1 − transportBytes − 1 − pathBytes` (L1774-1786). Our event has no equivalent field (`payload_size` is the whole frame — §1.1 trap), so **always compute**, using the same offsets as §2.3.2. Clamp at `0`.
+
+#### 2.3.4 Advert fields — **not published** (D-4)
+
+`decode_and_publish_message()` (L1579-1667) parses adverts and applies the opt-in rule (merge only when `name` ends with `"^"`, otherwise record the key prefix in `opted_in_ids` and merge nothing). `format_packet_data()` then reads only `route_type`, `payload_type`, `payload_type_value`, and `path` from that result — the advert fields are dead-ended. **Publish no advert fields and implement no filter.**
+
+Also note the reference's advert branch does `payload_value["name"]` unguarded, so a nameless advert raises `KeyError`, is swallowed by the outer `except`, and returns `None` — degrading that packet to `route="U", packet_type="0", payload_len="0"`. **Do not replicate that bug**; our decode is total and never degrades a well-formed advert. Record as a deviation.
+
+### 2.4 Status payload
+
+Source: `publish_status()` L1369-1387 (online) and the LWT literal at L1355-1366 (offline).
+
+| Key | Type | Online | Offline (LWT) |
+|---|---|---|---|
+| `status` | string | `"online"` | `"offline"` |
+| `timestamp` | string | ISO-8601 | ISO-8601 |
+| `origin` | string | device name | device name |
+| `origin_id` | string | 64-hex UPPER | 64-hex UPPER |
+| `model` | string | from DeviceQuery, else `"unknown"` | *(absent in the reference LWT)* |
+| `firmware_version` | string | e.g. `"v1.16.1 (Build: …)"`, else `"unknown"` | *(absent)* |
+| `radio` | string | radio params, else `"unknown"` | *(absent)* |
+| `client_version` | string | `"{name}/{version}"` | *(absent)* |
+
+Emit the online form with `retain: true` immediately after CONNACK, and register the offline form as the LWT.
+
+**Verified upstream quirk — the LWT is (usually) never delivered.** `authorizeForward` (L637-660) blocks any `/status` message whose `timestamp` is older than the last one seen for that `origin_id`. The LWT payload is fixed at CONNECT time, so its timestamp is always *older* than the online status published milliseconds later, and the broker drops it as stale. This affects the reference identically. Do not work around it. Instead: on **graceful** stop, publish an explicit `offline` status (fresh timestamp) before disconnecting — that one is delivered.
+
+### 2.5 Field sources on our side
+
+| Contract field | Source | Fallback |
+|---|---|---|
+| `origin` | `manager.getLocalNode()?.name` | `manager.getStatus().sourceName` → `"MeshMonitor"` |
+| `origin_id` | `token.publicKey` (already UPPER from Phase 1) | — |
+| `model` | `localNode.model` | `"unknown"` |
+| `firmware_version` | `localNode.ver` → `"v{ver}"`, plus `" (Build: {firmwareBuild})"` when present | `"unknown"` |
+| `radio` | `` `${radioFreq},${radioBw},${radioSf},${radioCr}` `` when all four present on `localNode` | `"unknown"` |
+| `client_version` | `` `meshmonitor/${pkg.version}` `` | — |
+
+`MeshCoreNode` fields are at `meshcoreManager.ts` L372-406. `model`/`ver`/`firmwareBuild` are populated in-memory by the telemetry poller and may be undefined — the fallbacks are load-bearing, not decorative.
+
+---
+
+## 3. New modules
+
+### 3.1 `src/server/services/meshcoreObserverPacket.ts` (NEW, pure)
+
+No imports from the manager, the DB, mqtt, or the logger. `node:crypto` only.
+
+```ts
+/** Contract payload published to meshcore/{REGION}/{PUBKEY}/packets. Every numeric is a string. */
+export interface ObserverPacketPayload {
+  origin: string;
+  origin_id: string;
+  timestamp: string;
+  type: 'PACKET';
+  direction: 'rx';
+  time: string;
+  date: string;
+  len: string;
+  packet_type: string;
+  route: 'F' | 'D' | 'T' | 'U';
+  payload_len: string;
+  raw: string;
+  SNR: string;
+  RSSI: string;
+  hash: string;
+  /** Present ONLY when route === 'D'. Comma-joined 2-hex-char hop tokens. */
+  path?: string;
+}
+
+export interface ObserverStatusPayload {
+  status: 'online' | 'offline';
+  timestamp: string;
+  origin: string;
+  origin_id: string;
+  model?: string;
+  firmware_version?: string;
+  radio?: string;
+  client_version?: string;
+}
+
+export interface ObserverPacketIdentity {
+  origin: string;
+  originId: string;   // UPPER 64-hex
+}
+
+/** Structural parse of an OTA frame. Never throws; `ok:false` on any problem. */
+export interface ObserverFrameParse {
+  ok: boolean;
+  payloadType: number;      // 0..15
+  routeType: number;        // 0..3
+  pathLenRaw: number | null;
+  hopCount: number;
+  hashSize: number;
+  /** Per-hop relay hashes, lowercase hex, `hashSize` bytes each. */
+  hops: string[];
+  payloadStart: number;     // byte offset of the payload
+  payloadLen: number;
+  totalBytes: number;
+}
+
+/** Decode a packed path_len byte → total path bytes on the wire. 0xff ⇒ 0. */
+export function pathByteLength(pathLenRaw: number): number;
+
+/** Structural parse from raw hex. Total; never throws. */
+export function parseObserverFrame(rawHex: string): ObserverFrameParse;
+
+/**
+ * MeshCore `Packet::calculatePacketHash` — SHA-256 over
+ * [payload_type] (+ uint16le(path_len_raw) for TRACE) + payload,
+ * first 8 bytes as 16 UPPERCASE hex chars.
+ * Returns '0000000000000000' on any parse failure (reference parity).
+ */
+export function calculateMeshCorePacketHash(rawHex: string): string;
+
+/** Build the analyzer-contract packet payload. Never throws. */
+export function buildObserverPacketPayload(
+  event: OtaPacketEvent,
+  identity: ObserverPacketIdentity,
+  now?: Date,
+): ObserverPacketPayload | null;   // null iff raw_hex is missing/blank
+
+export function buildObserverStatusPayload(
+  status: 'online' | 'offline',
+  identity: ObserverPacketIdentity,
+  device?: { model?: string; firmwareVersion?: string; radio?: string; clientVersion?: string },
+  now?: Date,
+): ObserverStatusPayload;
+
+/** meshcore/{region}/{PUBKEY}/{packets|status}. Applies the `test`-lowercase rule. */
+export function observerTopics(iataCode: string, publicKey: string): {
+  region: string; packets: string; status: string;
+};
+```
+
+Implementation notes:
+- `now` is an injectable `Date` — every golden test passes a fixed one. Default `new Date()`.
+- `time` = `HH:MM:SS` zero-padded from `now.getHours/Minutes/Seconds` (**local**, reference parity).
+  `date` = `DD/MM/YYYY` zero-padded from `now.getDate/getMonth()+1/getFullYear` (**local**).
+  `timestamp` = `now.toISOString()` (**UTC**, D-8).
+  The local/UTC split is deliberate and mixed — read §7.1's timezone-discipline callout
+  before writing a single golden assertion for these three fields.
+- `SNR`/`RSSI`: `typeof event.snr === 'number' ? String(event.snr) : 'Unknown'`. `String(6.25)` → `"6.25"`, matching Python's `str(6.25)`. `String(-9)` → `"-9"`. Do **not** `.toFixed()`.
+- `raw`: `rawHex.replace(/[^0-9a-fA-F]/g, '').toUpperCase()`.
+- `path`: emitted only when `route === 'D'`, as `hops.join(',')`, hops lowercase (reference derives them from a Python `.hex()`). When `hopCount === 0`, the key is present with value `""` — matching `",".join([])`.
+- `parseObserverFrame` must set `ok:false` (→ `route:'U'`, `packet_type:'0'`, `payload_len:'0'`, no `path`) when: fewer than 2 bytes; truncated before/inside transport codes; truncated before `path_len`; `payloadStart > totalBytes`; or `payloadVersion !== 0`. That last one mirrors the reference's `VER_1`-only gate (L1622-1626). `len`, `raw`, `hash`, and the identity/timestamp fields are still emitted.
+- `hashSize === 4` (bits 7:6 = `11`) is reserved — treat as `ok:false`.
+
+### 3.2 `src/server/services/meshcoreObserverPublisher.ts` (NEW)
+
+```ts
+export interface MeshCoreObserverStatus {
+  /** observer.enabled AND all three config fields present. */
+  configured: boolean;
+  /** A signing key row exists AND is decryptable under the current SESSION_SECRET. */
+  keyStored: boolean;
+  connected: boolean;
+  publishes: number;
+  /** Packets dropped because the socket was down (see §1.2 trap). */
+  dropped: number;
+  lastPublishAt: number | null;
+  lastError: string | null;
+  /** Unix SECONDS (matches ObserverToken.expiresAt). */
+  tokenExpiresAt: number | null;
+}
+
+export interface MeshCoreObserverPublisherOptions {
+  sourceId: string;
+  config: NonNullable<MeshCoreConfig['observer']>;
+  /** Live device facts, read lazily at publish/status time. */
+  device: () => {
+    origin: string; model?: string; firmwareVersion?: string; radio?: string;
+  };
+  /** Injection seams for tests. */
+  mintToken?: (sourceId: string) => Promise<ObserverTokenResult>;
+  createClient?: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+}
+
+export class MeshCoreObserverPublisher {
+  constructor(options: MeshCoreObserverPublisherOptions);
+
+  /** Mint → connect → publish online status. Resolves even on failure (state is in getStatus()). */
+  start(): Promise<void>;
+
+  /** Publish an explicit offline status (§2.4), then disconnect. Idempotent. */
+  stop(): Promise<void>;
+
+  /** Sync, never throws. Call from the manager's `ota_packet` listener. */
+  handleOtaPacket(event: OtaPacketEvent): void;
+
+  getStatus(): MeshCoreObserverStatus;
+  isRunning(): boolean;
+}
+```
+
+Behaviour:
+
+**`start()`**
+1. `mintToken(sourceId)` (default `mintObserverTokenForSourceDetailed`). Non-`ok` → set `lastError` from §6's table, `keyStored` from the result kind, **return without connecting**. No retry loop, no crash.
+2. `keyStored = true`, `tokenExpiresAt = token.expiresAt`.
+3. Compute topics via `observerTopics(config.iataCode, token.publicKey)`.
+4. Build the LWT payload now (`buildObserverStatusPayload('offline', identity)`).
+5. `createClient({ url: config.brokerUrl, username: 'v1_' + token.publicKey, password: token.token, clientIdPrefix: 'meshmonitor-observer', keepalive: 60, will: { topic: topics.status, payload: Buffer.from(JSON.stringify(lwt)), qos: 0, retain: true } })`.
+6. Wire listeners **before** `connect()`:
+   - `connect` → `connected = true`, `lastError = null`, reset `authFailures`, publish the retained `online` status.
+   - `close` / `offline` → `connected = false`.
+   - `error` → `lastError = redactToken(err.message)`.
+   - `permission-denied` `{kind:'auth'}` → `authFailures++`; at `MAX_AUTH_FAILURES` (5) call the internal hard-stop (§6).
+7. `await client.connect()` (resolves on CONNACK **or** first error — L246-258).
+8. Arm the renewal timer (`setInterval`, `RENEWAL_CHECK_MS = 3_600_000`, `.unref()`).
+
+**`handleOtaPacket(event)`** — the hot path, called once per received radio packet:
+```
+if (!client || !client.isConnected()) { dropped++; return; }
+const payload = buildObserverPacketPayload(event, identity);
+if (!payload) return;                                   // blank raw_hex
+void client.publish(topics.packets, Buffer.from(JSON.stringify(payload)), false)
+  .then(() => { publishes++; lastPublishAt = Date.now(); })
+  .catch(err => { lastError = redactToken(err.message); });
+```
+No `await`, no throw, **no token minting** (Phase 1 §2.5: minting is a WASM Ed25519 signature — per-packet is unaffordable).
+
+**Renewal** (D-9) — on each timer tick, renew when
+
+```ts
+nowSeconds >= tokenExpiresAt - (RENEWAL_CHECK_MS / 1000 + RENEWAL_THRESHOLD_S)
+//            i.e. expiresAt - (3600 + 300) = expiresAt - 3900s
+```
+
+> **The check interval must be inside the threshold (deliberate deviation from the
+> reference constants).** The reference tests `now >= expires_at - JWT_RENEWAL_THRESHOLD`
+> (300 s) on a 3600 s interval (`packet_capture.py` L594-606, L2212-2240), which leaves
+> an expiry hole: a tick landing at `exp − 301 s` does not renew, and the next tick fires
+> ~55 min **after** expiry. An already-established connection survives that window —
+> aedes verifies the token only at CONNECT (`server.ts` L207) — but any reconnect inside
+> it auth-fails, and the resulting `lastError` ("Broker rejected the observer auth
+> token…") sends the operator hunting through `tokenAudience` and the stored key instead
+> of at a stale password. Folding the check interval into the threshold guarantees at
+> least one tick fires before expiry. Renewing early is free (one Ed25519 signature) and
+> strictly safe, so widen the window rather than shorten the interval. Against the 24 h
+> `OBSERVER_TOKEN_TTL_SECONDS` this renews at ~22 h 55 m.
+
+On a tick that meets the condition:
+1. `mintToken(sourceId)`; non-`ok` → `lastError`, leave the existing connection alone, retry next tick.
+2. Tear down the current client (`await client.disconnect()`), build a **new** one with the fresh password + a fresh LWT, connect, republish `online`.
+3. A renewal that fails to connect leaves `connected = false`; the new client's own backoff drives recovery.
+
+**`stop()`** — clear the timer; if connected, publish `offline` (best-effort, swallow errors); `await client.disconnect()`; null the client; `connected = false`.
+
+**`redactToken(msg)`** — a private helper that strips anything matching the token shape (`/[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[0-9A-Fa-f]{128}/`) from a message before it lands in `lastError`, which is user-visible. Phase 1 §5.5 logging discipline: **never** log the token, the private key, or the password field.
+
+### 3.3 `meshcoreObserverToken.ts` — refinement (WP3)
+
+Add, without changing any existing export's behaviour:
+
+```ts
+export type ObserverTokenResult =
+  | { kind: 'ok'; token: ObserverToken }
+  | { kind: 'not_configured' }      // source missing, not meshcore, or observer block absent/incomplete
+  | { kind: 'no_key' }              // no row in meshcore_observer_keys
+  | { kind: 'key_rotated' }         // envelope encrypted under a different SESSION_SECRET
+  | { kind: 'mint_failed'; message: string };  // derive/sign threw
+
+export async function mintObserverTokenForSourceDetailed(
+  sourceId: string,
+): Promise<ObserverTokenResult>;
+```
+
+`mintObserverTokenForSource()` becomes a two-line wrapper:
+```ts
+const r = await mintObserverTokenForSourceDetailed(sourceId);
+return r.kind === 'ok' ? r.token : null;
+```
+Phase 1's tests for it must pass **unmodified** — that is WP3's acceptance gate.
+
+`mint_failed.message` must be the WASM/library error text, which Phase 1 §5.5 says must not escape to a user surface; the publisher maps it to a fixed string (§6) and logs the detail at `debug`.
+
+### 3.4 `MqttBrokerClientOptions` — additive (WP2)
+
+```ts
+export interface MqttBrokerClientOptions {
+  // …existing…
+  /** MQTT Last Will and Testament. Forwarded verbatim to mqtt.js. */
+  will?: IClientOptions['will'];
+  /** Keepalive seconds. Defaults to 15 (Meshtastic-firmware parity). */
+  keepalive?: number;
+}
+```
+In `connect()` (L163-179): `keepalive: this.options.keepalive ?? 15,` and `...(this.options.will ? { will: this.options.will } : {}),`. Omitting `will` when unset keeps the connect-options object byte-identical for every existing caller.
+
+---
+
+## 4. Manager integration (WP5)
+
+`src/server/meshcoreManager.ts`:
+
+```ts
+private observerPublisher: MeshCoreObserverPublisher | null = null;
+private readonly onObserverOtaPacket = (data: OtaPacketEvent): void => {
+  this.observerPublisher?.handleOtaPacket(data);
+};
+
+/**
+ * Start the Analyzer Observer publisher (opt-in, Companion only). Idempotent
+ * and non-fatal — a broker that is down must never block the device link.
+ */
+private async startObserver(): Promise<void> {
+  const obs = this.config?.observer;
+  if (!obs?.enabled || this.observerPublisher) return;
+  if (!this.nativeBackend) return;            // repeater/serial never emits ota_packet
+  try {
+    this.observerPublisher = new MeshCoreObserverPublisher({
+      sourceId: this.sourceId,
+      config: obs,
+      device: () => ({
+        origin: this.localNode?.name || this.sourceName || 'MeshMonitor',
+        model: this.localNode?.model,
+        firmwareVersion: this.localNode?.ver
+          ? `v${this.localNode.ver}${this.localNode.firmwareBuild ? ` (Build: ${this.localNode.firmwareBuild})` : ''}`
+          : undefined,
+        radio: formatRadioInfo(this.localNode),
+      }),
+    });
+    this.on('ota_packet', this.onObserverOtaPacket);
+    await this.observerPublisher.start();
+  } catch (err) {
+    logger.error(`[MeshCore:${this.sourceId}] Failed to start Analyzer Observer: ${(err as Error).message}`);
+    this.off('ota_packet', this.onObserverOtaPacket);
+    this.observerPublisher = null;
+  }
+}
+
+private async stopObserver(): Promise<void> {
+  if (!this.observerPublisher) return;
+  this.off('ota_packet', this.onObserverOtaPacket);
+  try { await this.observerPublisher.stop(); }
+  catch (err) { logger.debug(`[MeshCore:${this.sourceId}] Observer stop threw: ${(err as Error).message}`); }
+  this.observerPublisher = null;
+}
+
+getObserverStatus(): MeshCoreObserverStatus | undefined {
+  return this.observerPublisher?.getStatus();
+}
+```
+
+Call sites: exactly the four in §1.4.
+
+**`formatRadioInfo(node)`** — module-local helper: returns `` `${radioFreq},${radioBw},${radioSf},${radioCr}` `` when all four are numbers, else `undefined`.
+
+**Listener-leak guard:** `off()` runs in `stopObserver()` **and** in `startObserver()`'s catch. `EventEmitter` default `maxListeners` is 10; a manager that starts/stops the observer repeatedly without removing would warn. WP5's test asserts `manager.listenerCount('ota_packet')` returns to its baseline after a start/stop cycle.
+
+### 4.1 Status surface (D-10)
+
+`meshcoreManager.getStatus()` (L5604):
+```ts
+getStatus(sourceName?: string): MeshCoreSourceStatus {
+  const observer = this.observerPublisher?.getStatus();
+  return {
+    sourceId: this.sourceId,
+    sourceName: sourceName ?? this.sourceName,
+    sourceType: 'meshcore',
+    connected: this.connected,
+    ...(observer ? { observer } : {}),
+  };
+}
+```
+with `export interface MeshCoreSourceStatus extends SourceStatus { observer?: MeshCoreObserverStatus }`.
+
+Spreading conditionally keeps the JSON byte-identical for every source without an observer — no existing consumer sees a new key.
+
+`src/server/routes/sourceRoutes.ts` `GET /:id/status`, at the `!canReadNodes` early return (L1118-1120):
+```ts
+if (!canReadNodes) {
+  const { observer: _observer, ...publicStatus } = status as Record<string, unknown>;
+  return res.json(publicStatus);
+}
+```
+This is the **only** change to that route. The authorized path already spreads `...status`, so `observer` flows through untouched.
+
+---
+
+## 5. Hot-swap (WP6)
+
+**`meshcoreManager.reconfigureObserver(newObserverConfig)`** — mirrors `reconfigureVirtualNode`:
+```ts
+async reconfigureObserver(observer: MeshCoreObserverConfig | undefined): Promise<void> {
+  await this.stopObserver();
+  if (this.config) this.config.observer = observerConfigFromSource({ observer } as MeshCoreSourceConfig);
+  if (this.connected) await this.startObserver();
+}
+```
+Note it re-runs `observerConfigFromSource` so the hot-swap path normalizes identically to the boot path (URL normalization, IATA uppercase, audience trim, and the incomplete-block → `undefined` rule). Passing the raw block through would let an incomplete config start a publisher that the boot path would have refused.
+
+**`sourceManagerRegistry.reconfigureObserver(sourceId, cfg)`** — copy L114-127 verbatim, swapping the method name.
+
+**`sourceRoutes.ts` PUT branch** (~L978-998) — replace the unconditional restart with:
+```ts
+const oldObs = JSON.stringify((existing.config as any)?.observer ?? null);
+const newObs = JSON.stringify((source.config as any)?.observer ?? null);
+const observerChanged = oldObs !== newObs;
+const restOfConfigChanged = !deepEqualIgnoring(existing.config, source.config, ['observer']);
+
+if (observerChanged && !restOfConfigChanged) {
+  await sourceManagerRegistry.reconfigureObserver(source.id, (source.config as any)?.observer);
+} else {
+  /* existing removeManager → ensureMeshCoreManagerStarted restart */
+}
+```
+`deepEqualIgnoring` is a small local helper (compare `JSON.stringify` of both configs with the named keys deleted from shallow clones). **Fail safe:** if it cannot decide, take the restart branch. The restart branch is the status quo and always correct; the hot-swap branch is the optimization.
+
+Delete the Phase-1 TODO comment above that block in the same commit.
+
+---
+
+## 6. Failure modes, error table, backoff
+
+| Condition | Detected where | `lastError` | Behaviour |
+|---|---|---|---|
+| `observer.enabled` false / block incomplete | `startObserver()` | — | Publisher never constructed; `getStatus()` returns `undefined`; no `observer` key on the source status. |
+| Repeater / serial source | `startObserver()` (`!this.nativeBackend`) | — | Never starts. Belt-and-braces behind Phase 1's `OBSERVER_REQUIRES_COMPANION` validation. |
+| No signing key stored | `mintToken` → `no_key` | `"No observer signing key stored for this source."` | `keyStored:false`, `connected:false`. **No connect attempt, no retry loop.** Recovery = import a key (Phase 1 route) + config change / reconnect. |
+| `SESSION_SECRET` rotated | `mintToken` → `key_rotated` | `"Stored observer signing key cannot be decrypted (SESSION_SECRET changed). Re-import the key."` | Same as above. |
+| Mint threw (WASM/derive) | `mintToken` → `mint_failed` | `"Failed to mint observer auth token."` (library text at `debug` only) | Same as above. |
+| Broker unreachable / DNS / TCP refused | `client` `error` + `close` | redacted `err.message` | `MqttBrokerClient`'s own 1 s→60 s backoff (§1.2). Nothing new. |
+| Auth rejected (CONNACK 4/5) | `permission-denied` `{kind:'auth'}` | `"Broker rejected the observer auth token (check tokenAudience and the stored key)."` | `authFailures++`. **Below 5:** let the client's backoff retry with the *same* token — do not re-mint (a fresh token with the same key/audience would be rejected identically; re-minting per attempt is the hot-loop we must avoid). **At 5:** hard-stop — clear the renewal timer, `await client.disconnect()`, null the client, `connected:false`, keep `lastError`. Recovery = config change (WP6 hot-swap) or source reconnect. |
+| Broker closes on a topic-policy violation | `close` (no CONNACK error) | last `err.message`, else `null` | Should be unreachable: the region is validated by Phase 1's `validateObserverConfig`, and the pubkey in the topic is *by construction* the authenticated key. If it happens the client just reconnects. |
+| Publish rejected (`origin_id` mismatch) | — | — | Unreachable by construction: `origin_id` and the topic pubkey come from the same `token.publicKey`. A regression test asserts they are the same string. |
+| Socket down when a packet arrives | `handleOtaPacket` | — | `dropped++`, return. **Never** hand it to mqtt.js's offline queue (§1.2 trap). |
+| Malformed / truncated `raw_hex` | `parseObserverFrame` | — | Publishes with `route:'U'`, `packet_type:'0'`, `payload_len:'0'`, `hash:'0000000000000000'`. Never throws, never drops the packet. |
+| Blank / missing `raw_hex` | `buildObserverPacketPayload` → `null` | — | Silently skipped (mirrors VN `handleOtaPacket` L1325). |
+
+Constants: `MAX_AUTH_FAILURES = 5`, `RENEWAL_CHECK_MS = 3_600_000`, `RENEWAL_THRESHOLD_S = 300` — the same three values as the reference (`packet_capture.py` L184-186, L200-203).
+
+**The renewal *predicate* deliberately differs.** The reference compares against
+`expires_at − RENEWAL_THRESHOLD_S` alone; we compare against
+`expires_at − (RENEWAL_CHECK_MS / 1000 + RENEWAL_THRESHOLD_S)`. Testing only the
+threshold on a coarser interval leaves an expiry hole — see the callout in §3.2 for
+the full reasoning. Any change to `RENEWAL_CHECK_MS` must keep it inside the effective
+window, i.e. the predicate must always subtract the interval as well as the threshold;
+never hardcode `3900`.
+
+---
+
+## 7. Test plan
+
+Standard Vitest. No new test infrastructure. Every new test file lives beside its module.
+
+### 7.1 `meshcoreObserverPacket.test.ts` — golden tests (the core of this phase)
+
+Fixtures: reuse the real `rawHex` strings from `src/server/meshcoreNativeBackend.otaPacket.test.ts` (L112-140) and `src/utils/meshcorePacketDecode.test.ts`. Minimum coverage:
+
+> **Timezone discipline — read before writing the goldens.** `time` and `date` come from
+> **local** getters (`getHours`/`getDate`/…), per the reference (§3.1). Hardcoding
+> `"14:30:05"` against a `new Date('2026-07-31T14:30:05Z')` passes on a UTC CI runner and
+> fails on any developer machine in another zone. Three rules:
+> 1. **Whole-object goldens** build the expected `time`/`date` from the *same* fixed
+>    `Date` via its own local getters, with a comment saying this mirrors the
+>    implementation's TZ handling. Everything else in the object — including
+>    `timestamp` — stays a hardcoded literal.
+> 2. `timestamp` is `toISOString()` (UTC, `Z`) and is **always** hardcoded. It is
+>    TZ-independent by construction and is the field that would silently regress if D-8
+>    were undone, so it must be pinned by a literal, not recomputed.
+> 3. Do **not** set `process.env.TZ` or reach for a TZ-mocking helper. Pinning the zone
+>    would hide a real bug: an implementation that switched to UTC getters must fail
+>    these tests for every non-UTC operator.
+
+- **Full-payload golden**, fixed `now`, for each of: FLOOD TXT_MSG, DIRECT (with hops), TRANSPORT_FLOOD, TRANSPORT_DIRECT, ADVERT. Assert the **entire object** with `toEqual` — this is what pins the contract. `timestamp` is a literal; `time`/`date` are derived from the same fixed `Date`'s local getters per rule 1 above.
+- **`time`/`date` format (named test, TZ-independent):** construct the `Date` from **local components** — `new Date(2026, 6, 5, 9, 4, 3)` (5 Jul 2026, 09:04:03 local, deliberately single-digit in every position) — so the local getters return exactly those values in every zone. Assert the hardcoded strings `time === '09:04:03'` and `date === '05/07/2026'`. This is the zero-padding and `DD/MM` (not `MM/DD`) regression guard.
+- **`time`/`date` shape:** across all goldens, `time` matches `/^\d{2}:\d{2}:\d{2}$/` and `date` matches `/^\d{2}\/\d{2}\/\d{4}$/`.
+- **Type discipline:** every one of `len`, `packet_type`, `payload_len`, `SNR`, `RSSI` is `typeof === 'string'`. A named test, because this is the easiest thing to regress.
+- **`path` presence:** present iff `route === 'D'`; absent for `F`, `T`, `U`; `""` when `route === 'D'` with zero hops.
+- **`route` map:** all four route types plus the decode-failure `'U'`.
+- **`hash`:**
+  - matches a hand-computed SHA-256 for a fixed frame (compute the expected in the test from `node:crypto`, spelling out the `[payload_type] + payload` input — do not just re-call the function);
+  - TRACE (`payload_type === 9`) includes `uint16le(path_len_raw)` — assert it differs from the same frame hashed without it;
+  - returns `'0000000000000000'` for `''`, `'zz'`, and a 1-byte frame;
+  - is 16 chars, `/^[0-9A-F]{16}$/`.
+- **D-3 divergence (named test):** a synthetic frame with `path_len_raw = 0x81` (2-byte hashes × 1 hop). Assert our `payloadStart`/`hash` follow the packed decode, and document in the test body that the Python reference would read 129 path bytes here and produce a different hash. Also assert that for every `path_len_raw ≤ 0x3f` fixture, packed and plain agree.
+- **`ok:false` paths:** empty, 1-byte, truncated-before-transport-codes, truncated-before-path-len, truncated path, `payloadVersion !== 0`, reserved `hashSize === 4`.
+- **`SNR`/`RSSI`:** `6.25 → "6.25"`, `-9 → "-9"`, `0 → "0"` (not `"Unknown"` — a `0` SNR is real data), `undefined/null → "Unknown"`.
+- **Cross-check vs. `decodeMeshCorePacket`:** for every fixture, `parseObserverFrame` agrees with `decodeMeshCorePacket` on payload type, route type, hop count, and payload size.
+- **`observerTopics`:** `'TEST'`/`'test'` → `meshcore/test/...`; `'MCO'` → `meshcore/MCO/...`; pubkey uppercased.
+- **`buildObserverStatusPayload`:** online includes all 8 keys; offline omits the optional four; `origin_id` is uppercase.
+
+### 7.2 `meshcoreObserverPublisher.test.ts`
+
+Mock mqtt.js per §1.10 and inject `mintToken`.
+
+- **Connect wiring:** `lastConnectOptions()` has `username === 'v1_' + PUBKEY`, `password === token`, `keepalive === 60`, `will.topic === 'meshcore/test/PUBKEY/status'`, `will.retain === true`, and the will payload parses to `{status:'offline', origin_id: PUBKEY}`.
+- **Online status on connect:** emit `connect` on the fake client → exactly one publish to `.../status`, `retain === true`, payload `status:'online'`.
+- **Never subscribes:** after start + connect + 10 `handleOtaPacket` calls, `fakeClient.subscribe` was never called. **Assert this explicitly — it is the phase's headline invariant.**
+- **Packet publish:** `handleOtaPacket` → one publish to `.../packets`, `retain === false`, payload deep-equals `buildObserverPacketPayload(...)`.
+- **`origin_id` === topic pubkey** for both packet and status publishes.
+- **Backpressure:** with the client not connected, 5 `handleOtaPacket` calls → `publish` never called, `getStatus().dropped === 5`.
+- **Counters:** `publishes`, `lastPublishAt`, and `lastError` (on a rejected publish) all move correctly.
+- **`no_key` / `key_rotated` / `mint_failed`:** `start()` resolves, `createClient` never called, `getStatus()` has the right `keyStored` + `lastError`, and no timer is left armed (`vi.getTimerCount()`).
+- **Auth cooldown:** emit `permission-denied {kind:'auth'}` ×5 → client disconnected, `isRunning() === false`, `lastError` set, `mintToken` called **exactly once** total (proves no per-attempt minting).
+- **Renewal (fake timers):** `expiresAt` inside the effective window (`expiresAt − 3900s`) → on tick, `mintToken` called a second time, the old client's `end` called, a **new** `connect` with the new password, and a fresh `online` status published.
+- **Renewal window boundary (named test — the §3.2/§6 defect):** a token whose `expiresAt` sits at `now + 3600 + 300 + 60` (i.e. **outside** the 300 s threshold but **inside** one check interval of expiry) **must** renew on the first tick. Under the reference's threshold-only predicate this test fails, and the next tick would land after expiry. Assert `mintToken` was called a second time on tick 1. Also assert the negative: `expiresAt` at `now + 7200` does **not** renew on tick 1.
+- **Renewal mint failure:** old client untouched, `lastError` set, retried on the next tick.
+- **`stop()`:** publishes `offline` **before** `end`, is idempotent, clears the timer.
+- **Token redaction:** force an `error` whose message embeds a token-shaped string; assert `getStatus().lastError` does not contain it.
+
+### 7.3 `meshcoreManager.observer.test.ts`
+
+- Observer not constructed when `observer` is absent / `enabled:false` / incomplete; `getStatus()` has **no** `observer` key.
+- Observer not constructed on a source with no native backend (repeater), even with a complete config.
+- `ota_packet` emitted on the manager reaches `publisher.handleOtaPacket` (spy).
+- **Ungated (D-11):** with `meshcorePacketLogService.isEnabled()` mocked `false`, the observer still receives the packet. Named test.
+- Start → stop → start leaves `manager.listenerCount('ota_packet')` at its baseline.
+- `disconnect()` calls `publisher.stop()`.
+- `getStatus()` embeds the observer sub-object when running.
+
+### 7.4 Per-source isolation (**required**)
+
+`meshcoreObserverPublisher.perSource.test.ts`: two publishers with different `sourceId`, key, and IATA.
+- Distinct topics; neither publishes to the other's.
+- A packet handed to A never appears on B's client.
+- Counters are independent.
+- `mintToken` is called with the correct `sourceId` by each.
+
+### 7.5 Route status test
+
+`sourceRoutes.observerStatus.test.ts` using `createRouteTestApp()` (**required** for new route tests — CLAUDE.md):
+- Anonymous `GET /:id/status` → **no** `observer` key.
+- A user without `nodes:read` on that source → no `observer` key.
+- A user with `nodes:read` → `observer` present with the full shape.
+- Admin → present.
+- A source with no observer configured → no `observer` key for anyone (no `undefined` leak).
+
+### 7.6 `mqttBrokerClient.test.ts` additions
+
+- `will` forwarded verbatim to `mqtt.connect`.
+- `will` **absent** from connect options when not supplied (no `undefined` key) — protects existing callers.
+- `keepalive` defaults to 15; honours an override.
+
+### 7.7 Token module
+
+Extend `meshcoreObserverToken.test.ts`:
+- `mintObserverTokenForSourceDetailed` returns each of the five kinds under the right conditions.
+- `mintObserverTokenForSource` still returns `ObserverToken | null` identically — **Phase 1's existing assertions must pass unmodified.**
+
+### 7.8 Suite hygiene
+
+- Full Vitest run, 0 failures, before the PR. PostgreSQL/MySQL containers are **not** required — Phase 2 touches no schema, no migration, and no repository.
+- `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` → empty. Do **not** run `npm run lint:baseline`.
+- New code must not add `any`. `OtaPacketEvent`'s fields are optional — narrow with `typeof x === 'number'`, never cast.
+
+---
+
+## 8. Appendix — E2E validation recipe (run manually; **not** in CI)
+
+The broker repo ships **no** Dockerfile and no compose file (verified against the repo tree), so this runs it from source inside a `node:24` container. It requires network access to clone and to `npm install`.
+
+### 8.1 Bring up the broker
+
+```bash
+mkdir -p /tmp/mc-broker && cd /tmp/mc-broker
+git clone --depth 1 https://github.com/michaelhart/meshcore-mqtt-broker.git broker
+```
+
+`/tmp/mc-broker/broker/.env` — **every** variable below is mandatory: `loadMqttConfig` / `loadAbuseConfig` / `loadSubscriberConfig` call `validateRequiredEnvVars()` and `process.exit(1)` on any missing key (`src/config.ts`).
+
+```dotenv
+MQTT_WS_PORT=8883
+MQTT_HOST=0.0.0.0
+AUTH_EXPECTED_AUDIENCE=mqtt.local.test
+
+SUBSCRIBER_MAX_CONNECTIONS_DEFAULT=5
+SUBSCRIBER_1=viewer1:viewerpass:2
+
+ABUSE_ENFORCEMENT_ENABLED=false
+ABUSE_DUPLICATE_WINDOW_SIZE=100
+ABUSE_DUPLICATE_WINDOW_MS=300000
+ABUSE_DUPLICATE_THRESHOLD=10
+ABUSE_MAX_DUPLICATES_PER_PACKET=5
+ABUSE_DUPLICATE_RATE_THRESHOLD=0.3
+ABUSE_DUPLICATE_RATE_WINDOW_MS=300000
+ABUSE_BUCKET_CAPACITY=20
+ABUSE_BUCKET_REFILL_RATE=3
+ABUSE_MAX_PACKET_SIZE=255
+ABUSE_MAX_TOPICS_PER_DAY=3
+ABUSE_ANOMALY_THRESHOLD=10
+ABUSE_MAX_IATA_CHANGES_24H=3
+ABUSE_TOPIC_HISTORY_SIZE=50
+ABUSE_TOPIC_HISTORY_WINDOW_MS=86400000
+ABUSE_PERSISTENCE_PATH=/tmp/abuse-detection.db
+ABUSE_PERSISTENCE_INTERVAL_MS=300000
+ABUSE_STATE_RETENTION_MS=604800000
+```
+
+`/tmp/mc-broker/docker-compose.yml`:
+```yaml
+services:
+  meshcore-broker:
+    image: node:24
+    working_dir: /app
+    volumes:
+      - ./broker:/app
+    command: sh -c "npm install --no-audit --no-fund && npm start"
+    ports:
+      - "8883:8883"
+    environment:
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+```
+
+```bash
+cd /tmp/mc-broker && docker compose up   # keep this terminal open
+```
+
+Ready when the banner prints `WebSocket MQTT listening on: ws://0.0.0.0:8883`.
+
+> The broker is **plain WebSocket** — the URL is `ws://`, not `wss://`. TLS is terminated upstream in production. Port 8883 here is a *WebSocket* port, not the MQTTS port, so **do not** let `normalizeBrokerUrl` see a bare `host:8883` (it would prefix `mqtts://`, L473). Always type the full `ws://localhost:8883` into the source config.
+
+### 8.2 Configure the MeshMonitor source
+
+Against the dev container (`./scripts/api-test.sh login`, admin/`changeme`):
+
+1. Ensure a MeshCore **Companion** source is connected.
+2. Import its signing key — Phase 1 route:
+   `./scripts/api-test.sh post /api/sources/<id>/observer/key/import '{}'`
+   Confirm the response has `stored: true` and a 64-hex `publicKey`; **record it** as `$PUBKEY`.
+3. `PUT /api/sources/<id>` with `config.observer`:
+```json
+{ "observer": { "enabled": true,
+                "brokerUrl": "ws://localhost:8883",
+                "iataCode": "test",
+                "tokenAudience": "mqtt.local.test" } }
+```
+`tokenAudience` **must** string-equal `AUTH_EXPECTED_AUDIENCE` or CONNACK is rejected.
+
+### 8.3 Subscribe and assert
+
+```bash
+npx --yes mqtt-cli >/dev/null 2>&1 || true   # or use the snippet below
+node -e '
+const mqtt = require("mqtt");
+const c = mqtt.connect("ws://localhost:8883", {
+  username: "viewer1", password: "viewerpass", protocolVersion: 4, clean: true,
+});
+c.on("connect", () => { console.log("SUB connected"); c.subscribe("meshcore/#"); });
+c.on("message", (t, p) => console.log(t, p.toString()));
+'
+```
+
+**Pass criteria (all must hold):**
+
+1. **Broker log** shows `[AUTH] ✓ Publisher authenticated [aud: mqtt.local.test]` for `[O:<first 8 of $PUBKEY>]`.
+2. **Status:** within seconds of the source connecting, one message on `meshcore/test/$PUBKEY/status` with `status:"online"`, `origin_id` equal to `$PUBKEY` (uppercase), plus `model` / `firmware_version` / `radio` / `client_version`. Broker logs `Stripping retain flag from STATUS message`.
+3. **Packets:** as the radio hears traffic, messages on `meshcore/test/$PUBKEY/packets`, each carrying every §2.3 key, with `type:"PACKET"`, `direction:"rx"`, and `len`/`packet_type`/`payload_len`/`SNR`/`RSSI` all **JSON strings**.
+4. **`hash`** is 16 uppercase hex chars and is stable across two receptions of the same frame (compare against a `meshcore_packet_log` row's `raw_hex` run through `calculateMeshCorePacketHash`).
+5. **`path`** appears only on messages with `route:"D"`.
+6. **No topic normalization:** the broker never logs `Normalized topic:` for our publishes — proof the publisher already emits the canonical form.
+7. **No subscribe:** the broker never logs `Subscribe denied (publisher)` and never closes our client. `authorizeSubscribe` closes any publisher that subscribes, so a clean run **is** the observation-only proof.
+8. **Graceful offline:** `PUT` the source with `observer.enabled:false` → an `offline` status arrives on `.../status` before the client disconnects. (The **LWT** offline, by contrast, is expected *not* to arrive on an ungraceful kill — see §2.4's stale-status quirk. Verify by `docker kill`ing the MeshMonitor container and confirming the broker logs `[FILTER] Blocking stale status message`.)
+9. **Hot-swap (WP6):** toggling `observer.enabled` does **not** log a MeshCore reconnect for the source; the device link stays up. Confirm in the MeshMonitor log.
+10. **Bad audience:** set `tokenAudience` to `wrong.test` → broker logs `[AUTH] ✗ Invalid audience`, and `GET /api/sources/<id>/status` shows `observer.lastError` mentioning the rejected token, with `observer.connected:false` and **no** reconnect storm (≤ 1 attempt/minute after backoff settles).
+
+Teardown: `docker compose down && rm -rf /tmp/mc-broker`.
+
+---
+
+## 9. Work packages
+
+One Sonnet agent each. **Exclusive file ownership within a package.** Never commit a dangling import: a package that adds a *consumer* of a symbol must land after (or with) the package that adds the symbol.
+
+### WP1 — Packet/status encoder (parallel with WP2, WP3)
+**Owns:** `src/server/services/meshcoreObserverPacket.ts` (NEW), `src/server/services/meshcoreObserverPacket.test.ts` (NEW)
+**Depends on:** nothing.
+**Do:** §3.1 in full. Source fixtures per §1.9. Cross-check against `decodeMeshCorePacket` per §1.7.
+**Acceptance:** §7.1 green, including the named D-3 divergence test, the string-typing test, and the TZ-independent `time`/`date` format test. Module imports nothing but `node:crypto` and the `OtaPacketEvent` type. `npx tsc --noEmit` clean. Self-contained — nothing imports it yet, so the tree stays green.
+**Also verify:** the suite passes under a non-UTC zone — `TZ=Asia/Kolkata npx vitest run src/server/services/meshcoreObserverPacket.test.ts` (a half-hour offset catches errors a whole-hour zone would mask). CI runs UTC, so this is the only place the TZ bug can be caught.
+
+### WP2 — `MqttBrokerClient` LWT + keepalive (parallel with WP1, WP3)
+**Owns:** `src/server/transports/mqttBrokerClient.ts`, `src/server/transports/mqttBrokerClient.test.ts`
+**Depends on:** nothing.
+**Do:** §3.4 only. Two optional options, two lines in `connect()`. **No other change to this file** — it is on the hot path for every MQTT bridge.
+**Acceptance:** §7.6 green; the full existing `mqttBrokerClient.test.ts` and `mqttBridgeManager*.test.ts` suites still pass; connect options are byte-identical when `will`/`keepalive` are omitted.
+
+### WP3 — Token result refinement (parallel with WP1, WP2)
+**Owns:** `src/server/services/meshcoreObserverToken.ts`, `src/server/services/meshcoreObserverToken.test.ts`
+**Depends on:** nothing.
+**Do:** §3.3. Add `ObserverTokenResult` + `mintObserverTokenForSourceDetailed`; reduce `mintObserverTokenForSource` to a wrapper.
+**Acceptance:** §7.7 green; **every pre-existing assertion in that test file passes unmodified**; `mintObserverToken` and `deriveObserverPublicKey` are untouched.
+
+### WP4 — Publisher service
+**Owns:** `src/server/services/meshcoreObserverPublisher.ts` (NEW), `…test.ts` (NEW), `…perSource.test.ts` (NEW)
+**Depends on:** WP1, WP2, WP3 (all three merged).
+**Do:** §3.2 in full, plus the §6 failure matrix.
+**Acceptance:** §7.2 + §7.4 green. The **never-subscribes**, **no-per-packet-minting**, and **renewal-window-boundary** tests are non-negotiable — the last one is what pins the §3.2 predicate against a regression back to the reference's threshold-only form. Nothing imports the publisher yet — the tree stays green.
+
+### WP5 — Manager lifecycle + status surface
+**Owns:** `src/server/meshcoreManager.ts`, `src/server/routes/sourceRoutes.ts` (**status route only**), `src/server/meshcoreManager.observer.test.ts` (NEW), `src/server/routes/sourceRoutes.observerStatus.test.ts` (NEW)
+**Depends on:** WP4.
+**Do:** §4 + §4.1. Four lifecycle call sites, `startObserver`/`stopObserver`/`getObserverStatus`, `formatRadioInfo`, the `getStatus()` spread, `MeshCoreSourceStatus`, and the one `!canReadNodes` strip.
+**Do not** touch the `PUT /:id` handler — that is WP6.
+**Acceptance:** §7.3 + §7.5 green. The listener-leak test and the D-11 ungated test are required. `GET /:id/status` JSON is byte-identical for non-MeshCore sources and for MeshCore sources without an observer.
+
+### WP6 — `reconfigureObserver` hot-swap
+**Owns:** `src/server/meshcoreManager.ts`, `src/server/sourceManagerRegistry.ts`, `src/server/routes/sourceRoutes.ts` (**PUT handler only**), `src/server/routes/sourceRoutes.observerReconfigure.test.ts` (NEW)
+**Depends on:** WP5 — **strictly sequential**, it edits two of the same files.
+**Do:** §5. Delete the Phase-1 TODO comment.
+**Acceptance:** an observer-only config change calls `reconfigureObserver` and **not** `removeManager`; a change touching any other config key still takes the full-restart branch; a change touching both takes the restart branch; an unsupported manager type returns `false` without throwing.
+
+### WP7 — E2E validation, epic doc, PR
+**Owns:** `docs/internal/dev-notes/MESHCORE_ANALYZER_OBSERVER_EPIC.md`
+**Depends on:** WP6.
+**Do:**
+- Run §8 end-to-end against a real companion and a locally-run broker. Capture the broker log lines proving criteria 1-10.
+- Full Vitest suite (0 failures) + `lint:ci` gate per §7.8.
+- Tick the Phase 2 boxes; record under "Deviations / notes → Phase 2": **(a)** D-2 — the decoder library's `messageHash` is *not* `calculatePacketHash`; **(b)** D-3 — packed vs. plain `path_len`, identical for 1-byte hash mode; **(c)** D-4 — the reference publishes no advert fields, so the opt-in filter is a no-op on the wire and is not implemented; **(d)** D-8 — UTC `Z` timestamps; **(e)** §2.4 — the broker's stale-status filter suppresses the LWT, so graceful stop publishes an explicit offline; **(f)** D-7 — the Phase-1 hot-swap follow-up is now done; **(g)** the reference's nameless-advert `KeyError` bug, not replicated; **(h)** §3.2/§6 — the renewal predicate subtracts the check interval as well as the threshold, closing the reference's ~55-minute post-expiry hole (same three constants, different comparison); **(i)** §7.1 — `time`/`date` are local-zone by contract, so the goldens derive them from the fixed `Date` rather than hardcoding, and WP1 runs the suite once under a non-UTC `TZ` because CI is UTC-only.
+- PR via `/create-pr`, CI via `/ci-monitor`.
+
+### Dependency graph
+```
+WP1 ─┐
+WP2 ─┼─► WP4 ─► WP5 ─► WP6 ─► WP7
+WP3 ─┘
+```
+
+---
+
+## 10. Explicitly OUT OF SCOPE for Phase 2
+
+A PR containing any of these will be sent back.
+
+- **Any frontend change.** No `DashboardPage` fieldset, no `MeshCoreConfigurationView` panel, no locale strings, no `UiIcon`, no `useSourceStatuses` change. Phase 3.
+- **User-facing documentation.** Phase 3. (The epic-doc deviations note in WP7 is internal and required.)
+- **Any subscribe path.** No `client.subscribe()`, no message handler, no `/serial/commands`, no remote-serial or remote-command feature. This is the phase's headline invariant.
+- **The `raw` topic** (`meshcore/{IATA}/{PUBKEY}/raw`). The reference publishes it only when explicitly configured; it is not part of the analyzer contract.
+- **The `decoded` / `debug` topics** from the reference's default topic map.
+- **Advert privacy-filter machinery** or any decoded-payload field in the packet JSON (D-4).
+- **Multi-broker fan-out.** The reference supports MQTT1–MQTT4; our config block has exactly one `brokerUrl`.
+- **Periodic advert transmission** (`send_advert` / `advert_scheduler` in the reference) — that transmits on the radio; we are observation-only.
+- **New global settings** or `VALID_SETTINGS_KEYS` entries.
+- **Migrations, schema changes, repositories, raw SQL.** Phase 2 touches none.
+- **Changing the `GET /:id/status` wire shape** beyond adding/stripping the `observer` key.
+- **Converting existing handlers to the `ok()`/`fail()` envelope.**
+- **Cascade cleanup of `meshcore_observer_keys` on source delete** — still a separate change (Phase 1 known gap).
+- **`MqttReconnectCoordinator` adoption** (D-6), and any second retry/backoff layer on top of `MqttBrokerClient`'s.

--- a/src/server/meshcoreManager.observer.test.ts
+++ b/src/server/meshcoreManager.observer.test.ts
@@ -1,0 +1,333 @@
+/**
+ * MeshCore Analyzer Observer — manager lifecycle integration (#4457 Phase 2,
+ * WP5). Covers startObserver()/stopObserver()/getObserverStatus(), the four
+ * lifecycle call sites' effect on the bound 'ota_packet' listener, the D-11
+ * "ungated" invariant (the observer receives packets regardless of the
+ * opt-in packet-monitor setting), and the getStatus() conditional spread.
+ *
+ * `MeshCoreObserverPublisher` itself is mocked — its own behaviour (mint,
+ * connect, publish, renewal, ...) is covered by
+ * meshcoreObserverPublisher.test.ts. This file only asserts the manager
+ * constructs/destroys/wires it correctly.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const isEnabled = vi.fn();
+const logPacket = vi.fn().mockResolvedValue(undefined);
+const emitMeshCoreOtaPacket = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: { meshcore: {} },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreOtaPacket: (...args: unknown[]) => emitMeshCoreOtaPacket(...args),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreContactUpdated: vi.fn(),
+    emitMeshCoreStatusUpdated: vi.fn(),
+    emitMeshCoreLocalNodeUpdated: vi.fn(),
+  },
+}));
+
+vi.mock('./services/meshcorePacketLogService.js', () => ({
+  default: {
+    isEnabled: (...args: unknown[]) => isEnabled(...args),
+    logPacket: (...args: unknown[]) => logPacket(...args),
+  },
+}));
+
+// Fake MeshCoreObserverPublisher. Tracks every constructed instance on a
+// static array so tests can inspect start()/stop()/handleOtaPacket() calls.
+// `nextStartError` lets one test force the next-constructed instance's
+// start() to reject, to exercise startObserver()'s catch/cleanup path.
+vi.mock('./services/meshcoreObserverPublisher.js', () => {
+  class MeshCoreObserverPublisher {
+    static instances: MeshCoreObserverPublisher[] = [];
+    static nextStartError: Error | null = null;
+    options: unknown;
+    start: ReturnType<typeof vi.fn>;
+    stop = vi.fn().mockResolvedValue(undefined);
+    handleOtaPacket = vi.fn();
+    getStatus = vi.fn().mockReturnValue({
+      configured: true,
+      keyStored: true,
+      connected: true,
+      publishes: 0,
+      dropped: 0,
+      lastPublishAt: null,
+      lastError: null,
+      tokenExpiresAt: null,
+    });
+    isRunning = vi.fn().mockReturnValue(true);
+    constructor(options: unknown) {
+      this.options = options;
+      const err = MeshCoreObserverPublisher.nextStartError;
+      MeshCoreObserverPublisher.nextStartError = null;
+      this.start = err ? vi.fn().mockRejectedValue(err) : vi.fn().mockResolvedValue(undefined);
+      MeshCoreObserverPublisher.instances.push(this);
+    }
+  }
+  return { MeshCoreObserverPublisher };
+});
+
+import { MeshCoreManager } from './meshcoreManager.js';
+import { MeshCoreObserverPublisher } from './services/meshcoreObserverPublisher.js';
+
+type FakeInstance = {
+  options: unknown;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  handleOtaPacket: ReturnType<typeof vi.fn>;
+  getStatus: ReturnType<typeof vi.fn>;
+  isRunning: ReturnType<typeof vi.fn>;
+};
+type FakePublisherCtor = typeof MeshCoreObserverPublisher & {
+  instances: FakeInstance[];
+  nextStartError: Error | null;
+};
+const FakePublisher = MeshCoreObserverPublisher as unknown as FakePublisherCtor;
+
+const EXPECTED_STATUS = {
+  configured: true,
+  keyStored: true,
+  connected: true,
+  publishes: 0,
+  dropped: 0,
+  lastPublishAt: null,
+  lastError: null,
+  tokenExpiresAt: null,
+};
+
+const COMPLETE_OBSERVER_CONFIG = {
+  enabled: true,
+  brokerUrl: 'ws://localhost:8883',
+  iataCode: 'test',
+  tokenAudience: 'aud',
+};
+
+const SAMPLE_OTA_EVENT = {
+  payload_type: 0x02,
+  payload_type_string: 'TXT_MSG',
+  route_type: 0x01,
+  route_type_string: 'FLOOD',
+  path_len_raw: 0x02,
+  hop_count: 2,
+  path_hops: ['a3', '7f'],
+  snr: 6.25,
+  rssi: -42,
+  payload_size: 24,
+  raw_hex: 'deadbeef',
+};
+
+function dispatchOtaPacket(m: MeshCoreManager, data: Record<string, unknown>): void {
+  // @ts-expect-error - exercising private method, same idiom as
+  // meshcoreManager.otaPacket.test.ts.
+  m.handleBridgeEvent({ event_type: 'ota_packet', data });
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('MeshCoreManager — Analyzer Observer lifecycle (#4457 Phase 2)', () => {
+  beforeEach(() => {
+    FakePublisher.instances.length = 0;
+    FakePublisher.nextStartError = null;
+    isEnabled.mockReset().mockResolvedValue(false);
+    logPacket.mockClear();
+    emitMeshCoreOtaPacket.mockClear();
+  });
+
+  describe('construction gating', () => {
+    it('does not construct a publisher when observer config is absent', async () => {
+      const m = new MeshCoreManager('src-a');
+      (m as any).config = {};
+      (m as any).nativeBackend = {};
+
+      await (m as any).startObserver();
+
+      expect(FakePublisher.instances).toHaveLength(0);
+      expect(m.getStatus()).not.toHaveProperty('observer');
+    });
+
+    it('does not construct a publisher when observer.enabled is false', async () => {
+      const m = new MeshCoreManager('src-b');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG, enabled: false } };
+      (m as any).nativeBackend = {};
+
+      await (m as any).startObserver();
+
+      expect(FakePublisher.instances).toHaveLength(0);
+      expect(m.getStatus()).not.toHaveProperty('observer');
+    });
+
+    it('does not construct a publisher for an incomplete observer block (no `enabled`)', async () => {
+      const m = new MeshCoreManager('src-c');
+      (m as any).config = { observer: {} };
+      (m as any).nativeBackend = {};
+
+      await (m as any).startObserver();
+
+      expect(FakePublisher.instances).toHaveLength(0);
+      expect(m.getStatus()).not.toHaveProperty('observer');
+    });
+
+    it('does not construct a publisher without a native backend (repeater/serial)', async () => {
+      const m = new MeshCoreManager('src-d');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = null; // repeater/serial never emits ota_packet
+
+      await (m as any).startObserver();
+
+      expect(FakePublisher.instances).toHaveLength(0);
+      expect(m.getStatus()).not.toHaveProperty('observer');
+    });
+
+    it('constructs exactly one publisher for a Companion source with a complete, enabled config', async () => {
+      const m = new MeshCoreManager('src-e');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+
+      await (m as any).startObserver();
+
+      expect(FakePublisher.instances).toHaveLength(1);
+      expect(FakePublisher.instances[0].start).toHaveBeenCalledTimes(1);
+    });
+
+    it('is idempotent — calling startObserver() twice constructs only one publisher', async () => {
+      const m = new MeshCoreManager('src-f');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+
+      await (m as any).startObserver();
+      await (m as any).startObserver();
+
+      expect(FakePublisher.instances).toHaveLength(1);
+    });
+  });
+
+  describe('ota_packet wiring', () => {
+    it('reaches publisher.handleOtaPacket via the manager ota_packet event', async () => {
+      const m = new MeshCoreManager('src-g');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      await (m as any).startObserver();
+
+      dispatchOtaPacket(m, { ...SAMPLE_OTA_EVENT });
+      await flush();
+
+      const publisher = FakePublisher.instances[0];
+      expect(publisher.handleOtaPacket).toHaveBeenCalledTimes(1);
+      expect(publisher.handleOtaPacket).toHaveBeenCalledWith(
+        expect.objectContaining({ snr: 6.25, rssi: -42, raw_hex: 'deadbeef' }),
+      );
+    });
+
+    it('D-11: the observer still receives the packet when the packet-monitor capture setting is disabled', async () => {
+      isEnabled.mockResolvedValue(false);
+      const m = new MeshCoreManager('src-h');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      await (m as any).startObserver();
+
+      dispatchOtaPacket(m, { ...SAMPLE_OTA_EVENT });
+      await flush();
+
+      // Capture is off, so the packet-monitor persistence path is a no-op...
+      expect(logPacket).not.toHaveBeenCalled();
+      // ...but the observer — a second, unconditional consumer of the same
+      // 'ota_packet' event (same posture as the Virtual Node bridge, #3963) —
+      // still receives it.
+      const publisher = FakePublisher.instances[0];
+      expect(publisher.handleOtaPacket).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reach the publisher when no observer is running', async () => {
+      const m = new MeshCoreManager('src-i');
+      // No config.observer at all — startObserver() never called/never constructs.
+      dispatchOtaPacket(m, { ...SAMPLE_OTA_EVENT });
+      await flush();
+
+      expect(FakePublisher.instances).toHaveLength(0);
+    });
+  });
+
+  describe('listener-leak guard', () => {
+    it('leaves listenerCount("ota_packet") at its baseline after start -> stop -> start', async () => {
+      const m = new MeshCoreManager('src-j');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      const baseline = m.listenerCount('ota_packet');
+
+      await (m as any).startObserver();
+      expect(m.listenerCount('ota_packet')).toBe(baseline + 1);
+
+      await (m as any).stopObserver();
+      expect(m.listenerCount('ota_packet')).toBe(baseline);
+
+      await (m as any).startObserver();
+      expect(m.listenerCount('ota_packet')).toBe(baseline + 1);
+    });
+
+    it('removes the listener and nulls the field when start() throws', async () => {
+      const m = new MeshCoreManager('src-k');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      const baseline = m.listenerCount('ota_packet');
+      FakePublisher.nextStartError = new Error('boom');
+
+      await (m as any).startObserver();
+
+      expect(m.listenerCount('ota_packet')).toBe(baseline);
+      expect((m as any).observerPublisher).toBeNull();
+      expect(FakePublisher.instances).toHaveLength(1);
+      expect(FakePublisher.instances[0].start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('disconnect() integration', () => {
+    it('calls publisher.stop() during disconnect()', async () => {
+      const m = new MeshCoreManager('src-l');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = { disconnect: vi.fn().mockResolvedValue(undefined) };
+      await (m as any).startObserver();
+      const publisher = FakePublisher.instances[0];
+
+      await m.disconnect();
+
+      expect(publisher.stop).toHaveBeenCalledTimes(1);
+      expect((m as any).observerPublisher).toBeNull();
+    });
+  });
+
+  describe('getStatus()', () => {
+    it('embeds the observer sub-object when the publisher is running', async () => {
+      const m = new MeshCoreManager('src-m');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      await (m as any).startObserver();
+
+      const status = m.getStatus('My Source');
+
+      expect(status.observer).toEqual(EXPECTED_STATUS);
+      expect(status.sourceId).toBe('src-m');
+      expect(status.sourceName).toBe('My Source');
+    });
+
+    it('omits the observer key entirely for a source with no observer (byte-identical JSON)', () => {
+      const m = new MeshCoreManager('src-n');
+      const status = m.getStatus('Plain Source');
+      expect(status).not.toHaveProperty('observer');
+      expect(JSON.stringify(status)).toBe(
+        JSON.stringify({
+          sourceId: 'src-n',
+          sourceName: 'Plain Source',
+          sourceType: 'meshcore',
+          connected: false,
+        }),
+      );
+    });
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -41,7 +41,12 @@ import {
 // file at runtime, so this side of the edge must stay `import type` to avoid a
 // circular runtime dependency. Same pattern already used for
 // MeshCoreVirtualNodeConfig above (that cycle runs the other direction).
-import type { MeshCoreObserverConfig } from './meshcoreConfig.js';
+// reconfigureObserver() (#4457 Phase 2, WP6) needs the `observerConfigFromSource`
+// *function* from that same module for normalization parity with the boot path;
+// a static value import of it here would make the cycle real (meshcoreConfig.ts
+// already imports the MeshCoreManager class by value), so it is resolved with a
+// dynamic import() at call time instead — see reconfigureObserver() below.
+import type { MeshCoreObserverConfig, MeshCoreSourceConfig } from './meshcoreConfig.js';
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import { notificationService } from './services/notificationService.js';
 import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
@@ -1369,6 +1374,31 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   /** Analyzer Observer status, or undefined when the observer isn't running for this source. */
   getObserverStatus(): MeshCoreObserverStatus | undefined {
     return this.observerPublisher?.getStatus();
+  }
+
+  /**
+   * Hot-swap the Analyzer Observer sub-config without bouncing the companion
+   * device connection (#4457 Phase 2, WP6). Mirrors reconfigureVirtualNode on
+   * MeshtasticManager: stop the current publisher, re-derive the normalized
+   * runtime config, and restart only if the source is currently connected.
+   *
+   * Re-runs `observerConfigFromSource` (rather than trusting the caller's raw
+   * block) so the hot-swap path normalizes identically to the boot path — URL
+   * normalization, IATA uppercase, audience trim, and the incomplete-block →
+   * undefined rule all apply here exactly as they do in
+   * `meshcoreConfigFromSource`. Passing the raw block through unnormalized
+   * would let an incomplete config start a publisher the boot path would have
+   * refused.
+   */
+  async reconfigureObserver(observer: MeshCoreObserverConfig | undefined): Promise<void> {
+    await this.stopObserver();
+    if (this.config) {
+      const { observerConfigFromSource } = await import('./meshcoreConfig.js');
+      this.config.observer = observerConfigFromSource({ observer } as MeshCoreSourceConfig);
+    }
+    if (this.connected) {
+      await this.startObserver();
+    }
   }
 
   /**

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -31,7 +31,12 @@ import {
 import {
   MeshCoreVirtualNodeServer,
   type MeshCoreVirtualNodeConfig,
+  type OtaPacketEvent,
 } from './meshcoreVirtualNodeServer.js';
+import {
+  MeshCoreObserverPublisher,
+  type MeshCoreObserverStatus,
+} from './services/meshcoreObserverPublisher.js';
 // Type-only import — meshcoreConfig.ts imports MeshCoreConfig (below) from this
 // file at runtime, so this side of the edge must stay `import type` to avoid a
 // circular runtime dependency. Same pattern already used for
@@ -352,6 +357,17 @@ export interface MeshCoreConfig {
   observer?: MeshCoreObserverConfig;
 }
 
+/**
+ * MeshCoreManager.getStatus() return type. Extends the base SourceStatus with
+ * an optional `observer` sub-object (#4457 Phase 2 WP5) — present only when an
+ * Analyzer Observer publisher is constructed for this source. Conditionally
+ * spread in getStatus() so the JSON is byte-identical for every source
+ * without an observer (no new key appears for existing consumers).
+ */
+export interface MeshCoreSourceStatus extends SourceStatus {
+  observer?: MeshCoreObserverStatus;
+}
+
 export type MeshCoreConnectionState =
   | 'disconnected'
   | 'connecting'
@@ -403,6 +419,23 @@ export interface MeshCoreNode {
   firmwareBuild?: string;
   model?: string;
   ver?: string;
+}
+
+/**
+ * Analyzer Observer (#4457 Phase 2) `radio` status field: `freq,bw,sf,cr` when
+ * every one of the four is a known number, else undefined. Module-local (not
+ * exported) — only startObserver() needs it.
+ */
+function formatRadioInfo(node: MeshCoreNode | null): string | undefined {
+  if (
+    typeof node?.radioFreq !== 'number' ||
+    typeof node?.radioBw !== 'number' ||
+    typeof node?.radioSf !== 'number' ||
+    typeof node?.radioCr !== 'number'
+  ) {
+    return undefined;
+  }
+  return `${node.radioFreq},${node.radioBw},${node.radioSf},${node.radioCr}`;
 }
 
 export interface MeshCoreContact {
@@ -719,6 +752,19 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   // Companion: native JS backend (meshcore.js). sendBridgeCommand delegates here.
   private nativeBackend: MeshCoreNativeBackend | null = null;
   private virtualNodeServer: MeshCoreVirtualNodeServer | null = null;
+
+  // Analyzer Observer publisher (#4457 Phase 2). Companion-only — see
+  // startObserver()'s !nativeBackend guard.
+  private observerPublisher: MeshCoreObserverPublisher | null = null;
+  /**
+   * Bound arrow-property listener registered on 'ota_packet' in startObserver()
+   * and removed in stopObserver() — same shape as the Virtual Node bridge's
+   * onManagerOtaPacket (meshcoreVirtualNodeServer.ts). Kept as a stable
+   * reference so on()/off() target the exact same function.
+   */
+  private readonly onObserverOtaPacket = (data: OtaPacketEvent): void => {
+    this.observerPublisher?.handleOtaPacket(data);
+  };
 
   // Heartbeat / auto-reconnect state (native-backend only).
   private connectionState: MeshCoreConnectionState = 'disconnected';
@@ -1172,6 +1218,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       // is known — the server synthesizes SelfInfo from it. Non-fatal on error.
       await this.startVirtualNodeServer();
 
+      // Start the Analyzer Observer publisher (opt-in, Companion only, #4457
+      // Phase 2). Non-fatal on error — a broker that's down must never block
+      // the device link.
+      await this.startObserver();
+
       // Start auto-pathfinding scheduler if configured for this source.
       this.startAutoPathfinding().catch(err =>
         logger.warn(`[MeshCore:${this.sourceId}] Failed to start auto-pathfinding: ${(err as Error).message}`),
@@ -1270,6 +1321,57 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   }
 
   /**
+   * Start the Analyzer Observer publisher (#4457 Phase 2) if this source has
+   * it enabled. Companion-only — the repeater/serial backend never emits
+   * 'ota_packet', so a publisher on that backend would sit idle forever.
+   * Idempotent and non-fatal: a broker that is down (or misconfigured) must
+   * never block the device link. Mirrors startVirtualNodeServer()'s shape.
+   */
+  private async startObserver(): Promise<void> {
+    const obs = this.config?.observer;
+    if (!obs?.enabled || this.observerPublisher) return;
+    if (!this.nativeBackend) return; // repeater/serial never emits ota_packet
+
+    try {
+      this.observerPublisher = new MeshCoreObserverPublisher({
+        sourceId: this.sourceId,
+        config: obs,
+        device: () => ({
+          origin: this.localNode?.name || this.sourceName || 'MeshMonitor',
+          model: this.localNode?.model,
+          firmwareVersion: this.localNode?.ver
+            ? `v${this.localNode.ver}${this.localNode.firmwareBuild ? ` (Build: ${this.localNode.firmwareBuild})` : ''}`
+            : undefined,
+          radio: formatRadioInfo(this.localNode),
+        }),
+      });
+      this.on('ota_packet', this.onObserverOtaPacket);
+      await this.observerPublisher.start();
+    } catch (err) {
+      logger.error(`[MeshCore:${this.sourceId}] Failed to start Analyzer Observer: ${(err as Error).message}`);
+      this.off('ota_packet', this.onObserverOtaPacket);
+      this.observerPublisher = null;
+    }
+  }
+
+  /** Stop the Analyzer Observer publisher if running. Safe to call when not started. */
+  private async stopObserver(): Promise<void> {
+    if (!this.observerPublisher) return;
+    this.off('ota_packet', this.onObserverOtaPacket);
+    try {
+      await this.observerPublisher.stop();
+    } catch (err) {
+      logger.debug(`[MeshCore:${this.sourceId}] Observer stop threw: ${(err as Error).message}`);
+    }
+    this.observerPublisher = null;
+  }
+
+  /** Analyzer Observer status, or undefined when the observer isn't running for this source. */
+  getObserverStatus(): MeshCoreObserverStatus | undefined {
+    return this.observerPublisher?.getStatus();
+  }
+
+  /**
    * Disconnect from the device
    */
   async disconnect(): Promise<void> {
@@ -1308,6 +1410,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // Stop auto-announce + timer-trigger schedulers.
     this.stopAutoAnnounce();
     this.stopTimerTriggers();
+
+    // Stop the Analyzer Observer publisher before the Virtual Node server /
+    // native backend go away (#4457 Phase 2) — mirrors the VN server's own
+    // teardown-ordering rationale below.
+    await this.stopObserver();
 
     // Stop the Virtual Node server (if running) before tearing down the link
     // and clearing localNode — it reads localNode to answer AppStart.
@@ -5601,12 +5708,14 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * (e.g. the /status route). When omitted, the stored this.sourceName is used so
    * aggregate getAllStatuses() calls return a meaningful name.
    */
-  getStatus(sourceName?: string): SourceStatus {
+  getStatus(sourceName?: string): MeshCoreSourceStatus {
+    const observer = this.observerPublisher?.getStatus();
     return {
       sourceId: this.sourceId,
       sourceName: sourceName ?? this.sourceName,
       sourceType: 'meshcore',
       connected: this.connected,
+      ...(observer ? { observer } : {}),
     };
   }
 
@@ -6034,6 +6143,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     this.connected = false;
     this.connectionState = 'disconnected';
     this.stopHeartbeat();
+    await this.stopObserver();
     await this.stopVirtualNodeServer();
     // Release the dead backend. Without this `nativeBackend` keeps pointing at a
     // closed connection, so sendBridgeCommand()'s `!nativeBackend` guard never
@@ -6061,6 +6171,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // native backend's own 'disconnected' event so it doesn't re-enter the
     // unexpected-drop path. connect() clears the flag when the reconnect lands.
     this.intentionalTeardown = true;
+
+    // Stop the Analyzer Observer publisher first (#4457 Phase 2) — same
+    // rationale as the VN server below: it shouldn't keep publishing (or hold
+    // a socket open) once the underlying transport is going away.
+    await this.stopObserver();
 
     // Stop the Virtual Node server first, same as disconnect() does. Without
     // this, the VN server keeps accepting app connections while isConnected()

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1399,6 +1399,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       this.config.observer = observerConfigFromSource({ observer } as MeshCoreSourceConfig);
     }
     if (this.connected) {
+      // startObserver() is a no-op when the normalized config came back
+      // disabled/incomplete (its !obs?.enabled guard), so calling it
+      // unconditionally here is safe — a disable hot-swap ends with the
+      // publisher stopped and nothing restarted.
       await this.startObserver();
     }
   }

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1344,8 +1344,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         device: () => ({
           origin: this.localNode?.name || this.sourceName || 'MeshMonitor',
           model: this.localNode?.model,
+          // Some firmwares report `ver` with a leading 'v' already (live
+          // device: 'v1.15.0-dee3e26') — don't double it up.
           firmwareVersion: this.localNode?.ver
-            ? `v${this.localNode.ver}${this.localNode.firmwareBuild ? ` (Build: ${this.localNode.firmwareBuild})` : ''}`
+            ? `${this.localNode.ver.startsWith('v') ? '' : 'v'}${this.localNode.ver}${this.localNode.firmwareBuild ? ` (Build: ${this.localNode.firmwareBuild})` : ''}`
             : undefined,
           radio: formatRadioInfo(this.localNode),
         }),

--- a/src/server/routes/sourceRoutes.observerReconfigure.test.ts
+++ b/src/server/routes/sourceRoutes.observerReconfigure.test.ts
@@ -1,0 +1,203 @@
+/**
+ * PUT /:id — Analyzer Observer hot-swap (#4457 Phase 2, WP6, spec §5).
+ *
+ * An edit that touches ONLY the `observer` sub-block hot-swaps the publisher
+ * in place via `sourceManagerRegistry.reconfigureObserver()` — the companion
+ * device connection stays up. Any other config change (or a change that also
+ * touches `observer`) takes the existing full restart
+ * (`removeManager` → `ensureMeshCoreManagerStarted`), which remains the
+ * always-correct baseline behavior; the hot-swap branch is strictly an
+ * optimization layered on top of it.
+ *
+ * Uses the real createRouteTestApp harness (real session + auth middleware +
+ * real permission SQL) per CLAUDE.md's Route Test Harness guidance.
+ * `sourceManagerRegistry`'s singleton export is mocked so the route branch can
+ * be observed directly; the real `SourceManagerRegistry` class is left
+ * un-mocked (via `vi.importActual`) so the fourth acceptance case can unit-test
+ * the actual duck-typed guard in `reconfigureObserver()` end-to-end.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { SourceManagerRegistry } from '../sourceManagerRegistry.js';
+import type { ISourceManager } from '../sourceManagerRegistry.js';
+
+const mockSourceRegistry = vi.hoisted(() => ({
+  getManager: vi.fn(),
+  reconfigureObserver: vi.fn(),
+  removeManager: vi.fn(),
+  addManager: vi.fn(),
+}));
+
+vi.mock('../sourceManagerRegistry.js', async () => {
+  const actual = await vi.importActual<typeof import('../sourceManagerRegistry.js')>('../sourceManagerRegistry.js');
+  return {
+    ...actual,
+    // Only the singleton is replaced — sourceRoutes.ts and meshcoreConfig.ts
+    // both import this named export. The `SourceManagerRegistry` class itself
+    // stays the real implementation so the last test below can exercise it
+    // directly.
+    sourceManagerRegistry: mockSourceRegistry,
+  };
+});
+
+const SOURCE_ID = 'obs-reconfig-source';
+
+const BASE_CONFIG = {
+  transport: 'usb' as const,
+  port: '/dev/ttyACM0',
+  deviceType: 'companion' as const,
+};
+
+const OBSERVER_A = {
+  enabled: true,
+  brokerUrl: 'ws://localhost:8883',
+  iataCode: 'test',
+  tokenAudience: 'mqtt.local.test',
+};
+
+const OBSERVER_B = {
+  enabled: true,
+  brokerUrl: 'ws://otherbroker.example:8883',
+  iataCode: 'mco',
+  tokenAudience: 'mqtt.other.test',
+};
+
+describe('PUT /:id — Analyzer Observer hot-swap (#4457 Phase 2, WP6)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+
+    mockSourceRegistry.getManager.mockReset();
+    mockSourceRegistry.reconfigureObserver.mockReset();
+    mockSourceRegistry.removeManager.mockReset();
+    mockSourceRegistry.addManager.mockReset();
+    mockSourceRegistry.getManager.mockReturnValue(undefined);
+    mockSourceRegistry.reconfigureObserver.mockResolvedValue(true);
+    mockSourceRegistry.removeManager.mockResolvedValue(undefined);
+    mockSourceRegistry.addManager.mockResolvedValue(undefined);
+
+    await harness.db.sources.deleteSource(SOURCE_ID).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await harness.db.sources.deleteSource(SOURCE_ID).catch(() => {});
+    await harness.cleanup();
+  });
+
+  async function seedSource(config: Record<string, unknown>) {
+    await harness.db.sources.createSource({
+      id: SOURCE_ID,
+      name: 'Observer Reconfig Source',
+      type: 'meshcore',
+      config,
+      enabled: true,
+    });
+  }
+
+  it('an observer-only change calls reconfigureObserver and NOT removeManager', async () => {
+    await seedSource({ ...BASE_CONFIG });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.put(`/${SOURCE_ID}`).send({
+      config: { ...BASE_CONFIG, observer: OBSERVER_A },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledTimes(1);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledWith(SOURCE_ID, OBSERVER_A);
+    expect(mockSourceRegistry.removeManager).not.toHaveBeenCalled();
+    expect(mockSourceRegistry.addManager).not.toHaveBeenCalled();
+  });
+
+  it('a change touching any other config key (observer unchanged) takes the restart branch', async () => {
+    await seedSource({ ...BASE_CONFIG, heartbeatIntervalSeconds: 5 });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.put(`/${SOURCE_ID}`).send({
+      config: { ...BASE_CONFIG, heartbeatIntervalSeconds: 30 },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.removeManager).toHaveBeenCalledWith(SOURCE_ID);
+    expect(mockSourceRegistry.addManager).toHaveBeenCalledTimes(1);
+    expect(mockSourceRegistry.reconfigureObserver).not.toHaveBeenCalled();
+  });
+
+  it('a change touching both the observer block and another key takes the restart branch', async () => {
+    await seedSource({ ...BASE_CONFIG, heartbeatIntervalSeconds: 5, observer: OBSERVER_A });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.put(`/${SOURCE_ID}`).send({
+      config: { ...BASE_CONFIG, heartbeatIntervalSeconds: 30, observer: OBSERVER_B },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.removeManager).toHaveBeenCalledWith(SOURCE_ID);
+    expect(mockSourceRegistry.addManager).toHaveBeenCalledTimes(1);
+    expect(mockSourceRegistry.reconfigureObserver).not.toHaveBeenCalled();
+  });
+
+  it('a no-op resubmission (nothing changed) also takes the restart branch, unchanged from pre-WP6 behavior', async () => {
+    await seedSource({ ...BASE_CONFIG, observer: OBSERVER_A });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.put(`/${SOURCE_ID}`).send({
+      config: { ...BASE_CONFIG, observer: OBSERVER_A },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.removeManager).toHaveBeenCalledWith(SOURCE_ID);
+    expect(mockSourceRegistry.reconfigureObserver).not.toHaveBeenCalled();
+  });
+});
+
+describe('SourceManagerRegistry.reconfigureObserver — duck-typed guard (#4457 Phase 2, WP6)', () => {
+  // Exercises the REAL SourceManagerRegistry class (not the mock above) end to
+  // end, per spec §5's "duck-typed typeof check, returns false when
+  // unsupported" requirement. Never `instanceof`.
+  function stubManager(overrides: Partial<ISourceManager> = {}): ISourceManager {
+    return {
+      sourceId: 'stub-source',
+      sourceType: 'meshtastic_tcp',
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      getStatus: () => ({
+        sourceId: 'stub-source',
+        sourceName: 'Stub',
+        sourceType: 'meshtastic_tcp',
+        connected: false,
+      }),
+      getLocalNodeInfo: () => null,
+      startDistanceDeleteScheduler: vi.fn().mockResolvedValue(undefined),
+      stopDistanceDeleteScheduler: vi.fn(),
+      ...overrides,
+    } as ISourceManager;
+  }
+
+  it('returns false without throwing when the registered manager has no reconfigureObserver', async () => {
+    const registry = new SourceManagerRegistry();
+    await registry.addManager(stubManager());
+
+    await expect(registry.reconfigureObserver('stub-source', { enabled: true })).resolves.toBe(false);
+  });
+
+  it('returns false without throwing for a sourceId with no registered manager at all', async () => {
+    const registry = new SourceManagerRegistry();
+
+    await expect(registry.reconfigureObserver('does-not-exist', undefined)).resolves.toBe(false);
+  });
+
+  it('delegates to the manager and returns true when reconfigureObserver is supported', async () => {
+    const registry = new SourceManagerRegistry();
+    const reconfigureObserver = vi.fn().mockResolvedValue(undefined);
+    await registry.addManager(stubManager({ reconfigureObserver } as unknown as Partial<ISourceManager>));
+
+    const cfg = { enabled: true, brokerUrl: 'ws://x', iataCode: 'test', tokenAudience: 'aud' };
+    await expect(registry.reconfigureObserver('stub-source', cfg)).resolves.toBe(true);
+    expect(reconfigureObserver).toHaveBeenCalledWith(cfg);
+  });
+});

--- a/src/server/routes/sourceRoutes.observerStatus.test.ts
+++ b/src/server/routes/sourceRoutes.observerStatus.test.ts
@@ -1,0 +1,159 @@
+/**
+ * GET /:id/status — Analyzer Observer sub-object visibility (#4457 Phase 2,
+ * WP5, spec §4.1 / D-10).
+ *
+ * The observer status can carry `lastError`, which may embed the broker
+ * hostname, so it is stripped for anonymous / non-`nodes:read` callers at
+ * the existing `!canReadNodes` early return. This is the ONE change to that
+ * route — the wire shape is otherwise untouched (spec §1.11: this route
+ * stays a bare `res.json(...)`, never the ok()/fail() envelope).
+ *
+ * Uses the real createRouteTestApp harness (real session + auth middleware +
+ * real permission SQL) per CLAUDE.md's Route Test Harness guidance. Only
+ * `sourceManagerRegistry` is mocked, with a fake MeshCore manager whose
+ * getStatus() includes/omits the `observer` key — exactly what the real
+ * MeshCoreManager.getStatus() conditional spread produces.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+const mockSourceRegistry = vi.hoisted(() => ({
+  getManager: vi.fn(),
+}));
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: mockSourceRegistry,
+}));
+
+const SOURCE_ID = 'obs-status-source';
+const NO_OBSERVER_SOURCE_ID = 'obs-status-source-none';
+
+const FULL_OBSERVER_STATUS = {
+  configured: true,
+  keyStored: true,
+  connected: true,
+  publishes: 42,
+  dropped: 1,
+  lastPublishAt: 1700000000000,
+  lastError: 'Broker rejected the observer auth token (mqtt://internal-broker.example:8883)',
+  tokenExpiresAt: 1700086400,
+};
+
+function fakeMeshCoreManager(observer: typeof FULL_OBSERVER_STATUS | undefined) {
+  return {
+    sourceType: 'meshcore' as const,
+    getStatus: (name?: string) => ({
+      sourceId: SOURCE_ID,
+      sourceName: name ?? 'Observer Status Source',
+      sourceType: 'meshcore' as const,
+      connected: true,
+      ...(observer ? { observer } : {}),
+    }),
+    getLocalNode: () => null,
+    getAllNodes: () => [],
+  };
+}
+
+describe('GET /:id/status — Analyzer Observer visibility (#4457 Phase 2)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+
+    await harness.db.sources.deleteSource(SOURCE_ID).catch(() => {});
+    await harness.db.sources.createSource({
+      id: SOURCE_ID,
+      name: 'Observer Status Source',
+      type: 'meshcore',
+      config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion' },
+      enabled: true,
+    });
+
+    await harness.db.sources.deleteSource(NO_OBSERVER_SOURCE_ID).catch(() => {});
+    await harness.db.sources.createSource({
+      id: NO_OBSERVER_SOURCE_ID,
+      name: 'No Observer Source',
+      type: 'meshcore',
+      config: { transport: 'usb', port: '/dev/ttyACM1', deviceType: 'companion' },
+      enabled: true,
+    });
+
+    mockSourceRegistry.getManager.mockReset();
+    mockSourceRegistry.getManager.mockImplementation((id: string) => {
+      if (id === SOURCE_ID) return fakeMeshCoreManager(FULL_OBSERVER_STATUS);
+      if (id === NO_OBSERVER_SOURCE_ID) return fakeMeshCoreManager(undefined);
+      return undefined;
+    });
+  });
+
+  afterEach(async () => {
+    await harness.db.sources.deleteSource(SOURCE_ID).catch(() => {});
+    await harness.db.sources.deleteSource(NO_OBSERVER_SOURCE_ID).catch(() => {});
+    await harness.cleanup();
+  });
+
+  it('strips the observer key for an anonymous caller', async () => {
+    const agent = await harness.loginAs(null);
+    const res = await agent.get(`/${SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('observer');
+    // Every other field still round-trips.
+    expect(res.body.sourceId).toBe(SOURCE_ID);
+    expect(res.body.connected).toBe(true);
+  });
+
+  it('strips the observer key for a user without nodes:read on this source', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('observer');
+  });
+
+  it('includes the full observer shape for a user granted nodes:read on this source', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'read', SOURCE_ID);
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.observer).toEqual(FULL_OBSERVER_STATUS);
+  });
+
+  it('includes the observer sub-object for the admin', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/${SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.observer).toEqual(FULL_OBSERVER_STATUS);
+  });
+
+  it('never leaks a raw broker hostname to an unauthorized caller via lastError', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body)).not.toContain('internal-broker.example');
+  });
+
+  describe('a source with no observer configured', () => {
+    it('has no observer key for the admin (no `undefined` leak)', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get(`/${NO_OBSERVER_SOURCE_ID}/status`);
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('observer');
+    });
+
+    it('has no observer key for a user granted nodes:read', async () => {
+      await harness.grant(harness.limited.id, 'nodes', 'read', NO_OBSERVER_SOURCE_ID);
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/${NO_OBSERVER_SOURCE_ID}/status`);
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('observer');
+    });
+
+    it('has no observer key for an anonymous caller', async () => {
+      const agent = await harness.loginAs(null);
+      const res = await agent.get(`/${NO_OBSERVER_SOURCE_ID}/status`);
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('observer');
+    });
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -1116,7 +1116,13 @@ router.get('/:id/status', optionalAuth(), async (req: Request, res: Response) =>
       : false);
 
     if (!canReadNodes) {
-      return res.json(status);
+      // Analyzer Observer status (#4457 Phase 2, D-10) can leak the broker
+      // hostname via lastError — strip it for anonymous / non-nodes:read
+      // callers. Every other field on `status` is unaffected. See
+      // MESHCORE_OBSERVER_PHASE2_SPEC.md §4.1 — this route intentionally
+      // stays a bare `res.json(...)`, not the ok()/fail() envelope.
+      const { observer: _observer, ...publicStatus } = status as Record<string, unknown>;
+      return res.json(publicStatus);
     }
 
     // Cheap COUNT(*) queries — never throw on empty source.

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -168,6 +168,31 @@ export function validateObserverConfig(
   return null;
 }
 
+// Shallow-clone-and-strip comparison used by the MeshCore config-change branch
+// (#4457 Phase 2, WP6) to tell an Analyzer-Observer-only edit apart from any
+// other config change. Compares JSON.stringify of both objects with the named
+// keys deleted from shallow clones — cheap and order-stable for the plain JSON
+// config blobs stored on a Source row. FAIL-SAFE: if stringification throws
+// (should not happen for a parsed JSON config, but the caller must never rely
+// on that), this returns false — "not equal" — so the caller takes the always-
+// correct full-restart branch rather than risking a wrong hot-swap.
+function deepEqualIgnoring(
+  a: Record<string, unknown> | null | undefined,
+  b: Record<string, unknown> | null | undefined,
+  ignoreKeys: string[],
+): boolean {
+  const strip = (v: Record<string, unknown> | null | undefined): Record<string, unknown> => {
+    const clone = { ...(v ?? {}) };
+    for (const key of ignoreKeys) delete clone[key];
+    return clone;
+  };
+  try {
+    return JSON.stringify(strip(a)) === JSON.stringify(strip(b));
+  } catch {
+    return false;
+  }
+}
+
 // Build the right ISourceManager for a stored Source row. Used by both the
 // HTTP create path and the startup wiring in server.ts.
 export function buildMqttManagerForSource(
@@ -971,29 +996,46 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
         }
       }
     } else if (wasEnabled && isNowEnabled && source.type === 'meshcore' && newAutoConnect && config !== undefined) {
-      // MeshCore source config changed while enabled and autoConnect on —
-      // the connect config is baked in at connect-time, so any change means
-      // remove the old manager and register a fresh one with the updated config.
+      // MeshCore source config changed while enabled and autoConnect on.
       //
-      // Analyzer Observer (#4457 Phase 1, §4.2): this blanket restart is also
-      // how an `observer` config change (inside the same config blob) takes
-      // effect — deliberately reusing this existing hook rather than adding a
-      // new one, since Phase 1 ships no publisher to hot-swap into yet.
-      // Known cost: toggling the observer bounces the companion link like any
-      // other MeshCore config edit does today. Phase 2 follow-up: add a
-      // targeted `observerChanged` branch calling
-      // `manager.reconfigureObserver(...)`, mirroring the `vnChanged` branch
-      // above, once the publisher exists to reconfigure.
-      try {
-        const mcConfig = meshcoreConfigFromSource(source);
-        if (mcConfig) {
-          await sourceManagerRegistry.removeManager(source.id);
-          await ensureMeshCoreManagerStarted(source, mcConfig);
-        } else {
-          logger.warn(`MeshCore source ${source.id} updated to incomplete config`);
+      // Analyzer Observer (#4457 Phase 2, WP6): an edit that touches ONLY the
+      // `observer` sub-block hot-swaps the publisher in place via
+      // reconfigureObserver, mirroring the `vnChanged` branch above — the
+      // companion device connection stays up. Any other change (or a change
+      // that ALSO touches `observer`, or a comparison deepEqualIgnoring
+      // cannot decide) takes the existing full restart: remove the old
+      // manager and register a fresh one with the updated config. The
+      // restart branch is the always-correct status quo; the hot-swap
+      // branch is strictly an optimization on top of it.
+      const oldCfg = (existing.config as Record<string, unknown>) || {};
+      const newCfg = (source.config as Record<string, unknown>) || {};
+      const oldObs = JSON.stringify(oldCfg.observer ?? null);
+      const newObs = JSON.stringify(newCfg.observer ?? null);
+      const observerChanged = oldObs !== newObs;
+      const restOfConfigChanged = !deepEqualIgnoring(oldCfg, newCfg, ['observer']);
+
+      if (observerChanged && !restOfConfigChanged) {
+        // Hot-swap only the Analyzer Observer sub-feature.
+        try {
+          await sourceManagerRegistry.reconfigureObserver(
+            source.id,
+            newCfg.observer as Record<string, unknown> | undefined,
+          );
+        } catch (err) {
+          logger.warn(`Could not hot-swap Analyzer Observer for source ${source.id}:`, err);
         }
-      } catch (err) {
-        logger.warn(`Could not restart MeshCore manager for source ${source.id}:`, err);
+      } else {
+        try {
+          const mcConfig = meshcoreConfigFromSource(source);
+          if (mcConfig) {
+            await sourceManagerRegistry.removeManager(source.id);
+            await ensureMeshCoreManagerStarted(source, mcConfig);
+          } else {
+            logger.warn(`MeshCore source ${source.id} updated to incomplete config`);
+          }
+        } catch (err) {
+          logger.warn(`Could not restart MeshCore manager for source ${source.id}:`, err);
+        }
       }
     }
 

--- a/src/server/services/meshcoreObserverPacket.test.ts
+++ b/src/server/services/meshcoreObserverPacket.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Golden tests for the MeshCore Analyzer Observer packet/status encoder
+ * (#4457 Phase 2, WP1). See `docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md`
+ * §2 (wire contract) and §7.1 (this test plan).
+ *
+ * Fixture provenance note: `src/server/meshcoreNativeBackend.otaPacket.test.ts`
+ * builds its `raw_hex` fixtures against a *mock* `Packet.fromBytes` that lays
+ * bytes out as `[payload_type, route_type, pathLen, ...path]` — a test-mock
+ * convenience for that file, NOT the real firmware wire encoding (real header
+ * byte = `(version<<6)|(payloadType<<2)|routeType`). Reusing those bytes here
+ * would exercise the wrong header bit-packing. Frame *bytes* below are instead
+ * built with the same real-encoding `Builder`/`header()` helper used by
+ * `src/utils/meshcorePacketDecode.test.ts` (several frames below are the exact
+ * same fixtures, byte for byte, enabling the §1.7 cross-check). Where the
+ * otaPacket fixtures' SNR/RSSI *values* line up with a scenario here, those
+ * numeric values are reused directly.
+ *
+ * Timezone discipline (spec §7.1): `time`/`date` come from LOCAL Date getters;
+ * `timestamp` is UTC (`toISOString()`, D-8) and is always a hardcoded literal.
+ * Whole-object goldens derive the expected `time`/`date` from the SAME fixed
+ * `Date` via its own local getters — never hardcode them, and never set
+ * `process.env.TZ` in this file (a UTC-getter regression must fail on every
+ * non-UTC operator, not be hidden by a pinned zone).
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { decodeMeshCorePacket } from '../../utils/meshcorePacketDecode.js';
+import {
+  pathByteLength,
+  parseObserverFrame,
+  calculateMeshCorePacketHash,
+  buildObserverPacketPayload,
+  buildObserverStatusPayload,
+  observerTopics,
+  type ObserverPacketIdentity,
+} from './meshcoreObserverPacket.js';
+import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
+
+// ── Frame builder (mirrors src/utils/meshcorePacketDecode.test.ts's Builder —
+//    real wire-format header bit-packing, not the native-backend test mock) ──
+class Builder {
+  private parts: number[] = [];
+  u8(v: number) {
+    this.parts.push(v & 0xff);
+    return this;
+  }
+  u16le(v: number) {
+    this.parts.push(v & 0xff, (v >> 8) & 0xff);
+    return this;
+  }
+  bytes(arr: number[]) {
+    this.parts.push(...arr.map((x) => x & 0xff));
+    return this;
+  }
+  fill(n: number, v = 0) {
+    for (let i = 0; i < n; i++) this.parts.push(v & 0xff);
+    return this;
+  }
+  hex(): string {
+    return this.parts.map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  array(): number[] {
+    return this.parts.slice();
+  }
+}
+
+const header = (route: number, payload: number, version = 0) =>
+  ((version & 0x03) << 6) | ((payload & 0x0f) << 2) | (route & 0x03);
+
+/** Independent reference implementation of §2.3.2's hash pseudocode, for cross-checking. */
+function referenceHash(payloadType: number, pathLenRaw: number, payload: number[]): string {
+  const sha = createHash('sha256');
+  sha.update(Buffer.from([payloadType]));
+  if (payloadType === 0x09) {
+    const le = Buffer.alloc(2);
+    le.writeUInt16LE(pathLenRaw & 0xffff, 0);
+    sha.update(le);
+  }
+  sha.update(Buffer.from(payload));
+  return sha.digest('hex').slice(0, 16).toUpperCase();
+}
+
+const IDENTITY: ObserverPacketIdentity = {
+  origin: 'TestNode',
+  // 64 hex chars, uppercase, by construction.
+  originId: 'AB'.repeat(32),
+};
+
+function toEvent(rawHex: string, snr?: number | null, rssi?: number | null): OtaPacketEvent {
+  return { raw_hex: rawHex, snr, rssi };
+}
+
+describe('pathByteLength', () => {
+  it('returns 0 for the direct sentinel 0xff', () => {
+    expect(pathByteLength(0xff)).toBe(0);
+  });
+
+  it('agrees with a plain byte-count read for every path_len_raw <= 0x3f', () => {
+    for (let b = 0; b <= 0x3f; b++) {
+      expect(pathByteLength(b)).toBe(b);
+    }
+  });
+
+  it('decodes packed hash-size/hop-count above 0x3f', () => {
+    // 0x81 = 0b1000_0001 -> hashSize=(2)+1=3, hopCount=1 -> 3*1=3
+    expect(pathByteLength(0x81)).toBe(3);
+    // 0x42 = 0b0100_0010 -> hashSize=(1)+1=2, hopCount=2 -> 2*2=4
+    expect(pathByteLength(0x42)).toBe(4);
+  });
+});
+
+describe('parseObserverFrame — ok:false paths', () => {
+  it('empty input', () => {
+    const p = parseObserverFrame('');
+    expect(p.ok).toBe(false);
+    expect(p.totalBytes).toBe(0);
+  });
+
+  it('1-byte frame (fewer than 2 bytes)', () => {
+    const p = parseObserverFrame('00');
+    expect(p.ok).toBe(false);
+    expect(p.totalBytes).toBe(1);
+  });
+
+  it('truncated before/inside transport codes', () => {
+    // TRANSPORT_FLOOD (route 0x00) needs 4 transport bytes; only 2 supplied.
+    const hex = new Builder().u8(header(0x00, 0x02)).bytes([0x01, 0x02]).hex();
+    const p = parseObserverFrame(hex);
+    expect(p.ok).toBe(false);
+  });
+
+  it('truncated before path_len (transport codes present, nothing after)', () => {
+    const hex = new Builder().u8(header(0x00, 0x02)).u16le(0).u16le(0).hex();
+    const p = parseObserverFrame(hex);
+    expect(p.ok).toBe(false);
+    expect(p.totalBytes).toBe(5);
+  });
+
+  it('truncated path hashes (mirrors decodeMeshCorePacket.test.ts truncation fixture)', () => {
+    // Claims 3 hops of 1-byte hashes but provides none — identical bytes to
+    // decodeMeshCorePacket.test.ts's "does not throw on a truncated packet" fixture.
+    const hex = new Builder().u8(header(0x01, 0x02)).u8(0x03).hex();
+    const p = parseObserverFrame(hex);
+    expect(p.ok).toBe(false);
+  });
+
+  it('payloadVersion !== 0 (VER_1-only gate)', () => {
+    // Identical bytes to decodeMeshCorePacket.test.ts's header-bitfield fixture.
+    const hex = new Builder().u8(header(0x01, 0x02, 1)).u8(0xff).hex();
+    const p = parseObserverFrame(hex);
+    expect(p.ok).toBe(false);
+    // But structural fields are still fully populated.
+    expect(p.payloadType).toBe(0x02);
+    expect(p.routeType).toBe(0x01);
+    expect(p.hopCount).toBe(0);
+    expect(p.payloadStart).toBe(2);
+    expect(p.payloadLen).toBe(0);
+  });
+
+  it('reserved hashSize === 4 (bits 7:6 = 11)', () => {
+    // pathLenRaw 0xC1 -> hashSize=4 (reserved), hopCount=1.
+    const hex = new Builder()
+      .u8(header(0x01, 0x02))
+      .u8(0xc1)
+      .bytes([0x01, 0x02, 0x03, 0x04]) // 1 hop * 4-byte hash
+      .u8(0x99) // 1 payload byte
+      .hex();
+    const p = parseObserverFrame(hex);
+    expect(p.ok).toBe(false);
+    expect(p.hashSize).toBe(4);
+    expect(p.hopCount).toBe(1);
+    expect(p.payloadLen).toBe(1);
+  });
+});
+
+describe('parseObserverFrame — D-3 packed vs. plain divergence (named test)', () => {
+  it('path_len_raw = 0x81 uses the packed decode, not a plain byte count', () => {
+    // header: DIRECT (0x02) + TXT_MSG (0x02); pathLenRaw=0x81 -> hashSize=3, hopCount=1.
+    const hex = new Builder()
+      .u8(header(0x02, 0x02))
+      .u8(0x81)
+      .bytes([0xaa, 0xbb, 0xcc]) // 1 hop * 3-byte hash (packed decode)
+      .bytes([0x11, 0x22, 0x33]) // payload
+      .hex();
+
+    const p = parseObserverFrame(hex);
+    expect(p.ok).toBe(true);
+    expect(p.hashSize).toBe(3);
+    expect(p.hopCount).toBe(1);
+    expect(p.hops).toEqual(['aabbcc']);
+    expect(p.payloadStart).toBe(5); // 1 (header) + 1 (pathlen) + 3 (packed path bytes)
+    expect(p.payloadLen).toBe(3);
+
+    // Our hash: SHA-256([payload_type] + the 3-byte packed-decode payload).
+    const ourHash = calculateMeshCorePacketHash(hex);
+    expect(ourHash).toBe(referenceHash(0x02, 0x81, [0x11, 0x22, 0x33]));
+
+    // The Python reference's plain byte-count read would treat 0x81 (=129
+    // decimal) as a literal path length of 129 bytes. This 8-byte frame has
+    // only 3 bytes left after the path_len byte, so a plain read consumes
+    // everything remaining as "path" and is left with an EMPTY payload —
+    // a different, wrong hash input. This is the named D-3 divergence: the
+    // two decodes agree only for path_len_raw <= 0x3f (see the
+    // `pathByteLength` suite above).
+    const plainReferenceHash = referenceHash(0x02, 0x81, []);
+    expect(ourHash).not.toBe(plainReferenceHash);
+  });
+});
+
+describe('parseObserverFrame — cross-check vs. decodeMeshCorePacket (§1.7)', () => {
+  const fixtures: { name: string; hex: string }[] = [
+    {
+      name: 'FLOOD TXT_MSG',
+      hex: new Builder()
+        .u8(header(0x01, 0x02))
+        .u8(0x02) // hashSize1, hopCount2
+        .bytes([0xa3, 0x7f])
+        .bytes([0x12, 0x34, 0xde, 0xad, 0xbe, 0xef])
+        .hex(),
+    },
+    {
+      name: 'DIRECT with hops',
+      hex: new Builder()
+        .u8(header(0x02, 0x05))
+        .u8(0x42) // hashSize2, hopCount2
+        .bytes([0xaa, 0xbb, 0xcc, 0xdd])
+        .bytes([0xde, 0xad, 0xbe, 0xef, 0x01, 0x02])
+        .hex(),
+    },
+    {
+      name: 'TRANSPORT_FLOOD',
+      hex: new Builder()
+        .u8(header(0x00, 0x02))
+        .u16le(0x1234)
+        .u16le(0xabcd)
+        .u8(0x01) // hashSize1, hopCount1
+        .bytes([0x5a])
+        .bytes([0x12, 0x34, 0xca, 0xfe])
+        .hex(),
+    },
+    {
+      name: 'TRANSPORT_DIRECT',
+      hex: new Builder()
+        .u8(header(0x03, 0x03))
+        .u16le(0x0001)
+        .u16le(0x0002)
+        .u8(0x02) // hashSize1, hopCount2
+        .bytes([0x11, 0x22])
+        .bytes([0x99, 0x88])
+        .hex(),
+    },
+    {
+      name: 'ADVERT (direct, no hops)',
+      hex: new Builder()
+        .u8(header(0x02, 0x04))
+        .u8(0xff)
+        .fill(32, 0x01) // pubkey
+        .fill(4, 0x00) // timestamp
+        .fill(64, 0x02) // signature
+        .u8(0x00) // flags: no lat/lon/name
+        .hex(),
+    },
+    {
+      name: 'payloadVersion !== 0 (still cross-checkable)',
+      hex: new Builder().u8(header(0x01, 0x02, 1)).u8(0xff).hex(),
+    },
+  ];
+
+  it.each(fixtures)('agrees with decodeMeshCorePacket on $name', ({ hex }) => {
+    const ours = parseObserverFrame(hex);
+    const theirs = decodeMeshCorePacket(hex)!;
+    expect(theirs).not.toBeNull();
+    expect(ours.payloadType).toBe(theirs.header.payloadType);
+    expect(ours.routeType).toBe(theirs.header.routeType);
+    expect(ours.hopCount).toBe(theirs.path.hopCount);
+    expect(ours.payloadLen).toBe(theirs.payload.sizeBytes);
+  });
+});
+
+describe('calculateMeshCorePacketHash', () => {
+  it('matches a hand-computed SHA-256 over [payload_type] + payload', () => {
+    // FLOOD + TXT_MSG, direct (no hops), payload = [0xAA, 0xBB, 0xCC].
+    const hex = new Builder().u8(header(0x01, 0x02)).u8(0xff).bytes([0xaa, 0xbb, 0xcc]).hex();
+
+    const expected = createHash('sha256')
+      .update(Buffer.from([0x02, 0xaa, 0xbb, 0xcc])) // [payload_type] + payload, spelled out
+      .digest('hex')
+      .slice(0, 16)
+      .toUpperCase();
+
+    expect(calculateMeshCorePacketHash(hex)).toBe(expected);
+  });
+
+  it('TRACE (payload_type 9) includes uint16le(path_len_raw) as a hash prefix', () => {
+    // FLOOD + TRACE, pathLenRaw=0x03 (hashSize1, hopCount3).
+    const hex = new Builder()
+      .u8(header(0x01, 0x09))
+      .u8(0x03)
+      .bytes([0x01, 0x02, 0x03])
+      .bytes([0x55, 0x66])
+      .hex();
+
+    const withPrefix = calculateMeshCorePacketHash(hex);
+
+    const withoutPrefix = createHash('sha256')
+      .update(Buffer.from([0x09, 0x55, 0x66])) // no path_len_raw prefix
+      .digest('hex')
+      .slice(0, 16)
+      .toUpperCase();
+
+    expect(withPrefix).not.toBe(withoutPrefix);
+  });
+
+  it('returns the sentinel for empty, invalid-hex, and 1-byte input', () => {
+    expect(calculateMeshCorePacketHash('')).toBe('0000000000000000');
+    expect(calculateMeshCorePacketHash('zz')).toBe('0000000000000000');
+    expect(calculateMeshCorePacketHash('00')).toBe('0000000000000000');
+  });
+
+  it('is 16 uppercase hex chars', () => {
+    const hex = new Builder().u8(header(0x01, 0x02)).u8(0xff).bytes([0x01]).hex();
+    expect(calculateMeshCorePacketHash(hex)).toMatch(/^[0-9A-F]{16}$/);
+  });
+});
+
+describe('buildObserverPacketPayload — full-payload goldens', () => {
+  // Fixed `now` shared by every golden. `timestamp` (UTC, D-8) is always a
+  // hardcoded literal; `time`/`date` (local) are derived from this SAME Date
+  // via its own local getters, per the timezone-discipline callout above.
+  const now = new Date('2026-07-31T14:30:05.123Z');
+  const expectedTimestamp = '2026-07-31T14:30:05.123Z';
+  const expectedTime = [now.getHours(), now.getMinutes(), now.getSeconds()]
+    .map((n) => String(n).padStart(2, '0'))
+    .join(':');
+  const expectedDate = [
+    String(now.getDate()).padStart(2, '0'),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getFullYear()),
+  ].join('/');
+
+  it('FLOOD TXT_MSG', () => {
+    const rawBytes = [0x12, 0x34, 0xde, 0xad, 0xbe, 0xef];
+    const hex = new Builder().u8(header(0x01, 0x02)).u8(0x02).bytes([0xa3, 0x7f]).bytes(rawBytes).hex();
+    const payload = buildObserverPacketPayload(toEvent(hex, 6.25, -42), IDENTITY, now);
+
+    expect(payload).toEqual({
+      origin: IDENTITY.origin,
+      origin_id: IDENTITY.originId,
+      timestamp: expectedTimestamp,
+      type: 'PACKET',
+      direction: 'rx',
+      time: expectedTime,
+      date: expectedDate,
+      len: '10',
+      packet_type: '2',
+      route: 'F',
+      payload_len: '6',
+      raw: hex.toUpperCase(),
+      SNR: '6.25',
+      RSSI: '-42',
+      hash: referenceHash(0x02, 0x02, rawBytes),
+    });
+  });
+
+  it('DIRECT (with hops)', () => {
+    const rawBytes = [0xde, 0xad, 0xbe, 0xef, 0x01, 0x02];
+    const hex = new Builder()
+      .u8(header(0x02, 0x05))
+      .u8(0x42)
+      .bytes([0xaa, 0xbb, 0xcc, 0xdd])
+      .bytes(rawBytes)
+      .hex();
+    const payload = buildObserverPacketPayload(toEvent(hex, -3.5, -88), IDENTITY, now);
+
+    expect(payload).toEqual({
+      origin: IDENTITY.origin,
+      origin_id: IDENTITY.originId,
+      timestamp: expectedTimestamp,
+      type: 'PACKET',
+      direction: 'rx',
+      time: expectedTime,
+      date: expectedDate,
+      len: '12',
+      packet_type: '5',
+      route: 'D',
+      payload_len: '6',
+      raw: hex.toUpperCase(),
+      SNR: '-3.5',
+      RSSI: '-88',
+      hash: referenceHash(0x05, 0x42, rawBytes),
+      path: 'aabb,ccdd',
+    });
+  });
+
+  it('TRANSPORT_FLOOD', () => {
+    const rawBytes = [0x12, 0x34, 0xca, 0xfe];
+    const hex = new Builder()
+      .u8(header(0x00, 0x02))
+      .u16le(0x1234)
+      .u16le(0xabcd)
+      .u8(0x01)
+      .bytes([0x5a])
+      .bytes(rawBytes)
+      .hex();
+    const payload = buildObserverPacketPayload(toEvent(hex, undefined, -70), IDENTITY, now);
+
+    expect(payload).toEqual({
+      origin: IDENTITY.origin,
+      origin_id: IDENTITY.originId,
+      timestamp: expectedTimestamp,
+      type: 'PACKET',
+      direction: 'rx',
+      time: expectedTime,
+      date: expectedDate,
+      len: '11',
+      packet_type: '2',
+      route: 'F',
+      payload_len: '4',
+      raw: hex.toUpperCase(),
+      SNR: 'Unknown',
+      RSSI: '-70',
+      hash: referenceHash(0x02, 0x01, rawBytes),
+    });
+    expect(payload).not.toHaveProperty('path');
+  });
+
+  it('TRANSPORT_DIRECT (maps to "T", never gets a path even with hops)', () => {
+    const rawBytes = [0x99, 0x88];
+    const hex = new Builder()
+      .u8(header(0x03, 0x03))
+      .u16le(0x0001)
+      .u16le(0x0002)
+      .u8(0x02)
+      .bytes([0x11, 0x22])
+      .bytes(rawBytes)
+      .hex();
+    const payload = buildObserverPacketPayload(toEvent(hex, 0, -100), IDENTITY, now);
+
+    expect(payload).toEqual({
+      origin: IDENTITY.origin,
+      origin_id: IDENTITY.originId,
+      timestamp: expectedTimestamp,
+      type: 'PACKET',
+      direction: 'rx',
+      time: expectedTime,
+      date: expectedDate,
+      len: '10',
+      packet_type: '3',
+      route: 'T',
+      payload_len: '2',
+      raw: hex.toUpperCase(),
+      SNR: '0',
+      RSSI: '-100',
+      hash: referenceHash(0x03, 0x02, rawBytes),
+    });
+    expect(payload).not.toHaveProperty('path');
+  });
+
+  it('ADVERT (direct, zero hops -> path is present and empty)', () => {
+    const advertPayload = new Builder().fill(32, 0x01).fill(4, 0x00).fill(64, 0x02).u8(0x00).array();
+    const hex = new Builder().u8(header(0x02, 0x04)).u8(0xff).bytes(advertPayload).hex();
+    const payload = buildObserverPacketPayload(toEvent(hex, -1, -90), IDENTITY, now);
+
+    expect(payload).toEqual({
+      origin: IDENTITY.origin,
+      origin_id: IDENTITY.originId,
+      timestamp: expectedTimestamp,
+      type: 'PACKET',
+      direction: 'rx',
+      time: expectedTime,
+      date: expectedDate,
+      len: String(2 + advertPayload.length),
+      packet_type: '4',
+      route: 'D',
+      payload_len: String(advertPayload.length),
+      raw: hex.toUpperCase(),
+      SNR: '-1',
+      RSSI: '-90',
+      hash: referenceHash(0x04, 0xff, advertPayload),
+      path: '',
+    });
+  });
+});
+
+describe('buildObserverPacketPayload — format/shape guards', () => {
+  const fixedHex = new Builder().u8(header(0x01, 0x02)).u8(0xff).bytes([0x01, 0x02]).hex();
+
+  it('time/date shape matches across all goldens', () => {
+    const payload = buildObserverPacketPayload(toEvent(fixedHex), IDENTITY)!;
+    expect(payload.time).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    expect(payload.date).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+  });
+
+  it('time/date format (TZ-independent, zero-padding + DD/MM regression guard)', () => {
+    // Local components: 5 Jul 2026, 09:04:03 local time — every field
+    // deliberately single digit so the local getters return exactly these
+    // values in EVERY timezone (no UTC/local skew possible for this assertion).
+    const localNow = new Date(2026, 6, 5, 9, 4, 3);
+    const payload = buildObserverPacketPayload(toEvent(fixedHex), IDENTITY, localNow)!;
+    expect(payload.time).toBe('09:04:03');
+    expect(payload.date).toBe('05/07/2026');
+  });
+
+  it('every numeric field is a JSON string (type discipline)', () => {
+    const payload = buildObserverPacketPayload(toEvent(fixedHex, 6.25, -42), IDENTITY)!;
+    expect(typeof payload.len).toBe('string');
+    expect(typeof payload.packet_type).toBe('string');
+    expect(typeof payload.payload_len).toBe('string');
+    expect(typeof payload.SNR).toBe('string');
+    expect(typeof payload.RSSI).toBe('string');
+  });
+
+  it('path is present iff route === "D"', () => {
+    const direct = new Builder().u8(header(0x02, 0x02)).u8(0xff).bytes([0x01]).hex();
+    const flood = new Builder().u8(header(0x01, 0x02)).u8(0xff).bytes([0x01]).hex();
+
+    expect(buildObserverPacketPayload(toEvent(direct), IDENTITY)).toHaveProperty('path');
+    expect(buildObserverPacketPayload(toEvent(flood), IDENTITY)).not.toHaveProperty('path');
+  });
+
+  it('route map covers all four route types plus the decode-failure "U"', () => {
+    const flood = new Builder().u8(header(0x01, 0x02)).u8(0xff).bytes([0x01]).hex();
+    const direct = new Builder().u8(header(0x02, 0x02)).u8(0xff).bytes([0x01]).hex();
+    const transportFlood = new Builder()
+      .u8(header(0x00, 0x02))
+      .u16le(0)
+      .u16le(0)
+      .u8(0xff)
+      .bytes([0x01])
+      .hex();
+    const transportDirect = new Builder()
+      .u8(header(0x03, 0x02))
+      .u16le(0)
+      .u16le(0)
+      .u8(0xff)
+      .bytes([0x01])
+      .hex();
+    // Malformed: transport route missing its 4 transport-code bytes entirely.
+    const malformed = new Builder().u8(header(0x00, 0x02)).u8(0x01).hex();
+
+    expect(buildObserverPacketPayload(toEvent(flood), IDENTITY)!.route).toBe('F');
+    expect(buildObserverPacketPayload(toEvent(direct), IDENTITY)!.route).toBe('D');
+    expect(buildObserverPacketPayload(toEvent(transportFlood), IDENTITY)!.route).toBe('F');
+    expect(buildObserverPacketPayload(toEvent(transportDirect), IDENTITY)!.route).toBe('T');
+
+    const u = buildObserverPacketPayload(toEvent(malformed), IDENTITY)!;
+    expect(u.route).toBe('U');
+    expect(u.packet_type).toBe('0');
+    expect(u.payload_len).toBe('0');
+    expect(u).not.toHaveProperty('path');
+    expect(u.hash).toBe('0000000000000000');
+  });
+
+  it('SNR/RSSI formatting: 6.25 -> "6.25", -9 -> "-9", 0 -> "0" (not Unknown), undefined/null -> "Unknown"', () => {
+    expect(buildObserverPacketPayload(toEvent(fixedHex, 6.25, undefined), IDENTITY)!.SNR).toBe('6.25');
+    expect(buildObserverPacketPayload(toEvent(fixedHex, -9, undefined), IDENTITY)!.SNR).toBe('-9');
+    expect(buildObserverPacketPayload(toEvent(fixedHex, 0, undefined), IDENTITY)!.SNR).toBe('0');
+    expect(buildObserverPacketPayload(toEvent(fixedHex, undefined, undefined), IDENTITY)!.SNR).toBe('Unknown');
+    expect(buildObserverPacketPayload(toEvent(fixedHex, null, null), IDENTITY)!.RSSI).toBe('Unknown');
+  });
+
+  it('returns null iff raw_hex is missing/blank', () => {
+    expect(buildObserverPacketPayload(toEvent(''), IDENTITY)).toBeNull();
+    expect(buildObserverPacketPayload(toEvent('   '), IDENTITY)).toBeNull();
+    expect(buildObserverPacketPayload({ snr: 1, rssi: 1 }, IDENTITY)).toBeNull();
+  });
+});
+
+describe('buildObserverStatusPayload', () => {
+  const now = new Date('2026-07-31T14:30:05.123Z');
+
+  it('online includes all 8 keys', () => {
+    const p = buildObserverStatusPayload(
+      'online',
+      IDENTITY,
+      { model: 'M1', firmwareVersion: 'v1.16.1', radio: '910.0,250,10,5', clientVersion: 'meshmonitor/4.13.3' },
+      now,
+    );
+    expect(Object.keys(p).sort()).toEqual(
+      ['client_version', 'firmware_version', 'model', 'origin', 'origin_id', 'radio', 'status', 'timestamp'].sort(),
+    );
+    expect(p.status).toBe('online');
+    expect(p.origin_id).toBe(IDENTITY.originId);
+  });
+
+  it('online falls back to "unknown" for absent device fields', () => {
+    const p = buildObserverStatusPayload('online', IDENTITY, undefined, now);
+    expect(p.model).toBe('unknown');
+    expect(p.firmware_version).toBe('unknown');
+    expect(p.radio).toBe('unknown');
+    expect(p.client_version).toBe('unknown');
+  });
+
+  it('offline omits the optional four device keys', () => {
+    const p = buildObserverStatusPayload('offline', IDENTITY, undefined, now);
+    expect(Object.keys(p).sort()).toEqual(['origin', 'origin_id', 'status', 'timestamp'].sort());
+    expect(p.status).toBe('offline');
+  });
+
+  it('origin_id is always uppercased', () => {
+    const lower: ObserverPacketIdentity = { origin: 'x', originId: IDENTITY.originId.toLowerCase() };
+    const p = buildObserverStatusPayload('offline', lower, undefined, now);
+    expect(p.origin_id).toBe(IDENTITY.originId);
+  });
+});
+
+describe('observerTopics', () => {
+  it('normalizes the "test" region to lowercase regardless of input case', () => {
+    expect(observerTopics('TEST', 'abc').region).toBe('test');
+    expect(observerTopics('test', 'abc').region).toBe('test');
+  });
+
+  it('uppercases a real IATA code and the public key', () => {
+    const t = observerTopics('mco', 'abc123');
+    expect(t.region).toBe('MCO');
+    expect(t.packets).toBe('meshcore/MCO/ABC123/packets');
+    expect(t.status).toBe('meshcore/MCO/ABC123/status');
+  });
+});

--- a/src/server/services/meshcoreObserverPacket.ts
+++ b/src/server/services/meshcoreObserverPacket.ts
@@ -104,7 +104,7 @@ function hexToBytesLocal(hex: string | null | undefined): Uint8Array {
   const len = Math.floor(clean.length / 2);
   const out = new Uint8Array(len);
   for (let i = 0; i < len; i++) {
-    out[i] = parseInt(clean.substr(i * 2, 2), 16);
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
   }
   return out;
 }
@@ -264,6 +264,10 @@ export function calculateMeshCorePacketHash(rawHex: string): string {
 
     const pathLenRaw = bytes[offset];
     offset += 1;
+    // 0xff is the firmware sentinel for "sent direct, no relay hops" —
+    // pathByteLength maps it to 0, so no hop bytes are skipped before the
+    // payload. Same net layout parseObserverFrame produces via its explicit
+    // pathLenRaw !== 0xff branch.
     offset += pathByteLength(pathLenRaw);
 
     const payload = bytes.subarray(Math.min(offset, bytes.length));

--- a/src/server/services/meshcoreObserverPacket.ts
+++ b/src/server/services/meshcoreObserverPacket.ts
@@ -1,0 +1,369 @@
+/**
+ * meshcoreObserverPacket
+ *
+ * Pure, dependency-free encoder for the MeshCore Analyzer Observer MQTT wire
+ * contract (#4457 Phase 2, WP1). Turns a raw OTA packet event (or a
+ * status transition) into the exact JSON shape a
+ * `michaelhart/meshcore-mqtt-broker`-compatible analyzer expects on
+ * `meshcore/{REGION}/{PUBLIC_KEY}/{packets|status}`.
+ *
+ * This module imports nothing but `node:crypto` and the `OtaPacketEvent`
+ * type (type-only, erased at compile time) — no manager, no DB, no mqtt, no
+ * logger. That is what makes every function here golden-testable with fixed
+ * hex strings and a fixed `Date`, and safe to reuse from both the publisher
+ * service and any future consumer.
+ *
+ * Wire contract verified against `michaelhart/meshcore-packet-capture`'s
+ * `packet_capture.py` (`format_packet_data()`, `calculate_packet_hash()`) —
+ * see `docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md` §2 for the
+ * full derivation, including the deliberate deviations:
+ *   - D-2: `hash` is SHA-256-derived (`calculateMeshCorePacketHash` below),
+ *     NOT `@michaelhart/meshcore-decoder`'s 32-bit djb2 `messageHash`.
+ *   - D-3: the path/payload boundary uses the *packed* `path_len` decode
+ *     (`hashSize=(b>>6)+1`, `hopCount=b&0x3f`), not a plain byte count. The
+ *     two agree for `b <= 0x3f` (effectively all real traffic).
+ *   - D-4: no decoded advert fields are ever published; the reference's own
+ *     "opt-in" privacy filter is a no-op on the wire (verified dead code).
+ *   - D-8: `timestamp` is UTC ISO-8601 (`Z`), not the reference's naive
+ *     local `datetime.now().isoformat()`.
+ *
+ * `raw_hex` is the sole source of truth — the `OtaPacketEvent`'s
+ * `payload_size`-equivalent fields (when present elsewhere in the codebase)
+ * describe the WHOLE FRAME, not the payload; nothing here trusts anything
+ * but `raw_hex`, `snr`, and `rssi` off the event.
+ */
+import { createHash } from 'node:crypto';
+import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
+
+/** Contract payload published to meshcore/{REGION}/{PUBKEY}/packets. Every numeric is a string. */
+export interface ObserverPacketPayload {
+  origin: string;
+  origin_id: string;
+  timestamp: string;
+  type: 'PACKET';
+  direction: 'rx';
+  time: string;
+  date: string;
+  len: string;
+  packet_type: string;
+  route: 'F' | 'D' | 'T' | 'U';
+  payload_len: string;
+  raw: string;
+  SNR: string;
+  RSSI: string;
+  hash: string;
+  /** Present ONLY when route === 'D'. Comma-joined 2-hex-char hop tokens. */
+  path?: string;
+}
+
+export interface ObserverStatusPayload {
+  status: 'online' | 'offline';
+  timestamp: string;
+  origin: string;
+  origin_id: string;
+  model?: string;
+  firmware_version?: string;
+  radio?: string;
+  client_version?: string;
+}
+
+export interface ObserverPacketIdentity {
+  origin: string;
+  originId: string; // UPPER 64-hex
+}
+
+/** Structural parse of an OTA frame. Never throws; `ok:false` on any problem. */
+export interface ObserverFrameParse {
+  ok: boolean;
+  payloadType: number; // 0..15
+  routeType: number; // 0..3
+  pathLenRaw: number | null;
+  hopCount: number;
+  hashSize: number;
+  /** Per-hop relay hashes, lowercase hex, `hashSize` bytes each. */
+  hops: string[];
+  payloadStart: number; // byte offset of the payload
+  payloadLen: number;
+  totalBytes: number;
+}
+
+const SENTINEL_HASH = '0000000000000000';
+
+/** `route_type` (0..3) → contract `route` letter. TRANSPORT_DIRECT (0x03) maps to "T", not "D". */
+const ROUTE_LETTER: Record<number, 'F' | 'D' | 'T'> = {
+  0x00: 'F', // TRANSPORT_FLOOD
+  0x01: 'F', // FLOOD
+  0x02: 'D', // DIRECT
+  0x03: 'T', // TRANSPORT_DIRECT
+};
+
+// ── Byte helpers (reimplemented locally — no import, per the pure-module rule) ──
+
+function hexToBytesLocal(hex: string | null | undefined): Uint8Array {
+  const clean = (hex ?? '').replace(/[^0-9a-fA-F]/g, '');
+  const len = Math.floor(clean.length / 2);
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+function bytesToHexLocal(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += bytes[i].toString(16).padStart(2, '0');
+  return s;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** `HH:MM:SS`, from the Date's LOCAL getters (reference parity). */
+function formatLocalTime(d: Date): string {
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+/** `DD/MM/YYYY`, from the Date's LOCAL getters (reference parity). */
+function formatLocalDate(d: Date): string {
+  return `${pad2(d.getDate())}/${pad2(d.getMonth() + 1)}/${d.getFullYear()}`;
+}
+
+/** `String(n)` for a real number (including 0), else the literal `"Unknown"`. */
+function formatNumberOrUnknown(v: number | null | undefined): string {
+  return typeof v === 'number' ? String(v) : 'Unknown';
+}
+
+/**
+ * Decode a packed path_len byte → total path bytes on the wire (D-3).
+ * `0xff` (direct, no relay hashes) ⇒ 0.
+ * For `b <= 0x3f` this equals `b` — identical to a plain byte-count read.
+ */
+export function pathByteLength(pathLenRaw: number): number {
+  if (pathLenRaw === 0xff) return 0;
+  return (pathLenRaw & 0x3f) * (((pathLenRaw >> 6) & 0x03) + 1);
+}
+
+/**
+ * Structural parse from raw hex. Total; never throws.
+ *
+ * `ok` is false when: fewer than 2 bytes; truncated before/inside transport
+ * codes; truncated before `path_len`; truncated path; `payloadStart >
+ * totalBytes`; the reserved `hashSize === 4` (bits 7:6 = `11`); or
+ * `payloadVersion !== 0` (mirrors the reference's VER_1-only gate).
+ *
+ * Even when `ok` is false, `payloadType`/`routeType`/`hopCount`/`hashSize`/
+ * `payloadStart`/`payloadLen` are still populated whenever the parse could
+ * validly reach that point — this is what lets the encoder's parse agree
+ * with `decodeMeshCorePacket()` on a version-1 fixture even though our
+ * `ok` differs.
+ */
+export function parseObserverFrame(rawHex: string): ObserverFrameParse {
+  const bytes = hexToBytesLocal(rawHex);
+  const totalBytes = bytes.length;
+
+  const empty: ObserverFrameParse = {
+    ok: false,
+    payloadType: 0,
+    routeType: 0,
+    pathLenRaw: null,
+    hopCount: 0,
+    hashSize: 0,
+    hops: [],
+    payloadStart: 0,
+    payloadLen: 0,
+    totalBytes,
+  };
+
+  if (totalBytes < 2) {
+    return empty;
+  }
+
+  const header = bytes[0];
+  const payloadType = (header >> 2) & 0x0f;
+  const routeType = header & 0x03;
+  const payloadVersion = (header >> 6) & 0x03;
+
+  let offset = 1;
+  const hasTransportCodes = routeType === 0x00 || routeType === 0x03;
+  if (hasTransportCodes) {
+    if (offset + 4 > totalBytes) {
+      return { ...empty, payloadType, routeType };
+    }
+    offset += 4;
+  }
+
+  if (offset >= totalBytes) {
+    return { ...empty, payloadType, routeType };
+  }
+
+  const pathLenRaw = bytes[offset];
+  offset += 1;
+
+  let hopCount = 0;
+  let hashSize = 0;
+  const hops: string[] = [];
+
+  if (pathLenRaw !== 0xff) {
+    hashSize = (pathLenRaw >> 6) + 1;
+    hopCount = pathLenRaw & 0x3f;
+    const pathBytes = hopCount * hashSize;
+    if (offset + pathBytes > totalBytes) {
+      return { ...empty, payloadType, routeType, pathLenRaw, hopCount, hashSize };
+    }
+    for (let i = 0; i < hopCount; i++) {
+      const start = offset + i * hashSize;
+      hops.push(bytesToHexLocal(bytes.subarray(start, start + hashSize)));
+    }
+    offset += pathBytes;
+  }
+
+  const payloadStart = offset;
+  const truncatedPayload = payloadStart > totalBytes;
+  const reservedHashSize = hashSize === 4;
+  const payloadLen = truncatedPayload ? 0 : totalBytes - payloadStart;
+
+  const ok = !truncatedPayload && !reservedHashSize && payloadVersion === 0;
+
+  return {
+    ok,
+    payloadType,
+    routeType,
+    pathLenRaw,
+    hopCount,
+    hashSize,
+    hops,
+    payloadStart: Math.min(payloadStart, totalBytes),
+    payloadLen,
+    totalBytes,
+  };
+}
+
+/**
+ * MeshCore `Packet::calculatePacketHash` — SHA-256 over
+ * [payload_type] (+ uint16le(path_len_raw) for TRACE) + payload,
+ * first 8 bytes as 16 UPPERCASE hex chars.
+ * Returns '0000000000000000' on any parse failure (reference parity).
+ *
+ * Deliberately independent of `parseObserverFrame`'s `ok` gate — this
+ * replicates the reference's `calculate_packet_hash()` verbatim, which does
+ * not check `payloadVersion` or the reserved hash-size case, only structural
+ * truncation.
+ */
+export function calculateMeshCorePacketHash(rawHex: string): string {
+  try {
+    const bytes = hexToBytesLocal(rawHex);
+    if (bytes.length < 1) return SENTINEL_HASH;
+
+    const header = bytes[0];
+    const payloadType = (header >> 2) & 0x0f;
+    const routeType = header & 0x03;
+
+    let offset = 1 + (routeType === 0x00 || routeType === 0x03 ? 4 : 0);
+    if (offset >= bytes.length) return SENTINEL_HASH; // no path_len byte available
+
+    const pathLenRaw = bytes[offset];
+    offset += 1;
+    offset += pathByteLength(pathLenRaw);
+
+    const payload = bytes.subarray(Math.min(offset, bytes.length));
+
+    const sha = createHash('sha256');
+    sha.update(Uint8Array.from([payloadType]));
+    if (payloadType === 0x09) {
+      // TRACE: prefix with uint16le(path_len_raw).
+      const le = new Uint8Array(2);
+      le[0] = pathLenRaw & 0xff;
+      le[1] = (pathLenRaw >> 8) & 0xff;
+      sha.update(le);
+    }
+    sha.update(payload);
+
+    return sha.digest('hex').slice(0, 16).toUpperCase();
+  } catch {
+    return SENTINEL_HASH;
+  }
+}
+
+/** Build the analyzer-contract packet payload. Never throws. `null` iff `raw_hex` is missing/blank. */
+export function buildObserverPacketPayload(
+  event: OtaPacketEvent,
+  identity: ObserverPacketIdentity,
+  now: Date = new Date(),
+): ObserverPacketPayload | null {
+  const rawHexInput = event.raw_hex;
+  if (!rawHexInput || rawHexInput.trim() === '') return null;
+
+  const raw = rawHexInput.replace(/[^0-9a-fA-F]/g, '').toUpperCase();
+  const parse = parseObserverFrame(rawHexInput);
+  const hash = calculateMeshCorePacketHash(rawHexInput);
+
+  const route: ObserverPacketPayload['route'] = parse.ok ? (ROUTE_LETTER[parse.routeType] ?? 'U') : 'U';
+  const packetType = parse.ok ? String(parse.payloadType) : '0';
+  const payloadLen = parse.ok ? String(Math.max(0, parse.payloadLen)) : '0';
+
+  const payload: ObserverPacketPayload = {
+    origin: identity.origin,
+    origin_id: identity.originId.toUpperCase(),
+    timestamp: now.toISOString(),
+    type: 'PACKET',
+    direction: 'rx',
+    time: formatLocalTime(now),
+    date: formatLocalDate(now),
+    len: String(parse.totalBytes),
+    packet_type: packetType,
+    route,
+    payload_len: payloadLen,
+    raw,
+    SNR: formatNumberOrUnknown(event.snr),
+    RSSI: formatNumberOrUnknown(event.rssi),
+    hash,
+  };
+
+  if (route === 'D') {
+    payload.path = parse.ok ? parse.hops.join(',') : '';
+  }
+
+  return payload;
+}
+
+/** Build the analyzer-contract status payload (online or offline/LWT). */
+export function buildObserverStatusPayload(
+  status: 'online' | 'offline',
+  identity: ObserverPacketIdentity,
+  device?: { model?: string; firmwareVersion?: string; radio?: string; clientVersion?: string },
+  now: Date = new Date(),
+): ObserverStatusPayload {
+  const base: ObserverStatusPayload = {
+    status,
+    timestamp: now.toISOString(),
+    origin: identity.origin,
+    origin_id: identity.originId.toUpperCase(),
+  };
+
+  if (status !== 'online') {
+    return base; // LWT / graceful-offline form: no device sub-fields.
+  }
+
+  return {
+    ...base,
+    model: device?.model ?? 'unknown',
+    firmware_version: device?.firmwareVersion ?? 'unknown',
+    radio: device?.radio ?? 'unknown',
+    client_version: device?.clientVersion ?? 'unknown',
+  };
+}
+
+/** meshcore/{region}/{PUBKEY}/{packets|status}. Applies the `test`-lowercase rule. */
+export function observerTopics(
+  iataCode: string,
+  publicKey: string,
+): { region: string; packets: string; status: string } {
+  const region = iataCode.toLowerCase() === 'test' ? 'test' : iataCode.toUpperCase();
+  const pubkey = publicKey.toUpperCase();
+  return {
+    region,
+    packets: `meshcore/${region}/${pubkey}/packets`,
+    status: `meshcore/${region}/${pubkey}/status`,
+  };
+}

--- a/src/server/services/meshcoreObserverPublisher.perSource.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.perSource.test.ts
@@ -1,0 +1,231 @@
+/**
+ * meshcoreObserverPublisher per-source isolation tests (#4457 Phase 2, WP4 —
+ * spec §7.4). Two publishers, two distinct sources: distinct topics,
+ * distinct clients, independent counters, and `mintToken` invoked with the
+ * correct `sourceId` for each. This is the multi-source architecture's
+ * mandatory isolation guarantee (see CLAUDE.md "Adding a Per-Source
+ * Feature") applied to the observer publisher.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type MockedFunction } from 'vitest';
+import { EventEmitter } from 'events';
+
+type PublishCallback = (err?: Error) => void;
+type PublishOpts = { qos: number; retain: boolean };
+
+interface FakeMqttClient extends EventEmitter {
+  subscribe: MockedFunction<(topics: string[], opts: { qos: number }, cb?: () => void) => void>;
+  publish: MockedFunction<(topic: string, payload: Buffer, opts: PublishOpts, cb?: PublishCallback) => void>;
+  end: MockedFunction<(force: boolean, opts: Record<string, never>, cb?: () => void) => void>;
+  reconnect: MockedFunction<() => void>;
+}
+
+function makeFakeClient(): FakeMqttClient {
+  const c = new EventEmitter() as FakeMqttClient;
+  c.subscribe = vi.fn((_topics: string[], _opts: { qos: number }, cb?: () => void) => {
+    cb?.();
+  }) as FakeMqttClient['subscribe'];
+  c.publish = vi.fn((_topic: string, _payload: Buffer, _opts: PublishOpts, cb?: PublishCallback) => {
+    cb?.();
+  }) as FakeMqttClient['publish'];
+  c.end = vi.fn((_force: boolean, _opts: Record<string, never>, cb?: () => void) => {
+    cb?.();
+  }) as FakeMqttClient['end'];
+  c.reconnect = vi.fn() as FakeMqttClient['reconnect'];
+  return c;
+}
+
+vi.mock('mqtt', () => ({
+  connect: vi.fn(() => makeFakeClient()),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { connect } from 'mqtt';
+import {
+  MeshCoreObserverPublisher,
+  type MeshCoreObserverPublisherOptions,
+} from './meshcoreObserverPublisher.js';
+import type { ObserverToken, ObserverTokenResult } from './meshcoreObserverToken.js';
+
+const mockConnect = connect as MockedFunction<typeof connect>;
+const lastFakeClient = (): FakeMqttClient => mockConnect.mock.results.at(-1)!.value as FakeMqttClient;
+const lastConnectOptions = () => mockConnect.mock.calls.at(-1)![1];
+
+interface SourceFixture {
+  sourceId: string;
+  pubkey: string;
+  tokenString: string;
+  iataCode: string;
+  origin: string;
+}
+
+const SOURCE_A: SourceFixture = {
+  sourceId: 'src-observer-A',
+  pubkey: 'AA'.repeat(32),
+  tokenString: 'headerA.payloadA.' + 'a'.repeat(128),
+  iataCode: 'JFK',
+  origin: 'NodeA',
+};
+
+const SOURCE_B: SourceFixture = {
+  sourceId: 'src-observer-B',
+  pubkey: 'BB'.repeat(32),
+  tokenString: 'headerB.payloadB.' + 'b'.repeat(128),
+  iataCode: 'LHR',
+  origin: 'NodeB',
+};
+
+function makeToken(fixture: SourceFixture): ObserverToken {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return {
+    token: fixture.tokenString,
+    publicKey: fixture.pubkey,
+    issuedAt: nowSeconds,
+    expiresAt: nowSeconds + 86_400,
+  };
+}
+
+function makeMintToken(
+  fixture: SourceFixture,
+): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+  fn.mockResolvedValue({ kind: 'ok', token: makeToken(fixture) });
+  return fn;
+}
+
+function makePublisher(
+  fixture: SourceFixture,
+  mintToken: MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>,
+): MeshCoreObserverPublisher {
+  const config: MeshCoreObserverPublisherOptions['config'] = {
+    enabled: true,
+    brokerUrl: 'mqtt://broker.test:1883',
+    iataCode: fixture.iataCode,
+    tokenAudience: 'aud.test',
+  };
+  return new MeshCoreObserverPublisher({
+    sourceId: fixture.sourceId,
+    config,
+    device: () => ({ origin: fixture.origin }),
+    mintToken,
+  });
+}
+
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function startAndConnect(publisher: MeshCoreObserverPublisher): Promise<FakeMqttClient> {
+  const startPromise = publisher.start();
+  await flushMicrotasks(3);
+  const client = lastFakeClient();
+  client.emit('connect');
+  await startPromise;
+  return client;
+}
+
+describe('MeshCoreObserverPublisher — per-source isolation (#4457 §7.4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('gives each source distinct topics and a distinct client', async () => {
+    const mintA = makeMintToken(SOURCE_A);
+    const mintB = makeMintToken(SOURCE_B);
+    const pubA = makePublisher(SOURCE_A, mintA);
+    await startAndConnect(pubA);
+    const optsA = lastConnectOptions();
+
+    const pubB = makePublisher(SOURCE_B, mintB);
+    await startAndConnect(pubB);
+    const optsB = lastConnectOptions();
+
+    expect(optsA.will!.topic).toBe(`meshcore/JFK/${SOURCE_A.pubkey}/status`);
+    expect(optsB.will!.topic).toBe(`meshcore/LHR/${SOURCE_B.pubkey}/status`);
+    expect(optsA.username).toBe(`v1_${SOURCE_A.pubkey}`);
+    expect(optsB.username).toBe(`v1_${SOURCE_B.pubkey}`);
+    expect(optsA.password).not.toBe(optsB.password);
+  });
+
+  it('calls mintToken with the correct sourceId for each publisher', async () => {
+    const mintA = makeMintToken(SOURCE_A);
+    const mintB = makeMintToken(SOURCE_B);
+    const pubA = makePublisher(SOURCE_A, mintA);
+    const pubB = makePublisher(SOURCE_B, mintB);
+
+    await startAndConnect(pubA);
+    await startAndConnect(pubB);
+
+    expect(mintA).toHaveBeenCalledWith(SOURCE_A.sourceId);
+    expect(mintB).toHaveBeenCalledWith(SOURCE_B.sourceId);
+    expect(mintA).not.toHaveBeenCalledWith(SOURCE_B.sourceId);
+    expect(mintB).not.toHaveBeenCalledWith(SOURCE_A.sourceId);
+  });
+
+  it('never cross-delivers a packet handed to A onto B\'s client, and keeps counters independent', async () => {
+    const mintA = makeMintToken(SOURCE_A);
+    const mintB = makeMintToken(SOURCE_B);
+    const pubA = makePublisher(SOURCE_A, mintA);
+    const clientA = await startAndConnect(pubA);
+    const pubB = makePublisher(SOURCE_B, mintB);
+    const clientB = await startAndConnect(pubB);
+
+    clientA.publish.mockClear();
+    clientB.publish.mockClear();
+
+    // Three packets to A only.
+    pubA.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    pubA.handleOtaPacket({ snr: 2, rssi: -2, raw_hex: '0900bb' });
+    pubA.handleOtaPacket({ snr: 3, rssi: -3, raw_hex: '0900cc' });
+    await flushMicrotasks();
+
+    expect(clientA.publish).toHaveBeenCalledTimes(3);
+    expect(clientB.publish).not.toHaveBeenCalled();
+    for (const call of clientA.publish.mock.calls) {
+      expect(call[0]).toBe(`meshcore/JFK/${SOURCE_A.pubkey}/packets`);
+    }
+
+    // One packet to B only.
+    pubB.handleOtaPacket({ snr: 9, rssi: -9, raw_hex: '0900dd' });
+    await flushMicrotasks();
+
+    expect(clientB.publish).toHaveBeenCalledTimes(1);
+    expect(clientB.publish.mock.calls[0]![0]).toBe(`meshcore/LHR/${SOURCE_B.pubkey}/packets`);
+    // A's count is unaffected by B's activity.
+    expect(clientA.publish).toHaveBeenCalledTimes(3);
+
+    expect(pubA.getStatus().publishes).toBe(3);
+    expect(pubB.getStatus().publishes).toBe(1);
+    expect(pubA.getStatus().dropped).toBe(0);
+    expect(pubB.getStatus().dropped).toBe(0);
+  });
+
+  it('drops for one source independently of the other being connected', async () => {
+    const mintA = makeMintToken(SOURCE_A);
+    const mintB = makeMintToken(SOURCE_B);
+    const pubA = makePublisher(SOURCE_A, mintA);
+    await startAndConnect(pubA);
+
+    // B started but never connected — its socket stays down.
+    const pubB = makePublisher(SOURCE_B, mintB);
+    const startPromiseB = pubB.start();
+    await flushMicrotasks(3);
+    const clientB = lastFakeClient();
+
+    pubB.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    pubB.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900bb' });
+
+    expect(pubB.getStatus().dropped).toBe(2);
+    expect(pubA.getStatus().dropped).toBe(0);
+
+    clientB.emit('error', new Error('unreachable'));
+    await startPromiseB;
+  });
+});

--- a/src/server/services/meshcoreObserverPublisher.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.test.ts
@@ -414,6 +414,13 @@ describe('MeshCoreObserverPublisher', () => {
       expect(client.publish).toHaveBeenCalledTimes(1);
       expect(client.end).toHaveBeenCalledTimes(1);
     });
+
+    it('is safe to call before start() — no client, no publish, no throw', async () => {
+      const { publisher } = makePublisher();
+      await expect(publisher.stop()).resolves.toBeUndefined();
+      expect(publisher.isRunning()).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 
   it('redacts token-shaped substrings from lastError', async () => {

--- a/src/server/services/meshcoreObserverPublisher.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.test.ts
@@ -1,0 +1,427 @@
+/**
+ * meshcoreObserverPublisher tests (#4457 Phase 2, WP4 — spec §7.2).
+ *
+ * Mocks the 'mqtt' module per §1.10 (same pattern as
+ * `transports/mqttBrokerClient.test.ts`) and drives the REAL
+ * `MqttBrokerClient` underneath — only `mintToken` is injected. This lets
+ * these tests exercise the real connect-options wiring (LWT, keepalive,
+ * username/password) exactly as `MqttBrokerClient` builds them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type MockedFunction } from 'vitest';
+import { EventEmitter } from 'events';
+
+type SubscribeCallback = (
+  err: Error | null,
+  granted: Array<{ topic: string; qos: number }>,
+  packet: unknown,
+) => void;
+type PublishCallback = (err?: Error) => void;
+type EndCallback = () => void;
+type PublishOpts = { qos: number; retain: boolean };
+type SubscribeOpts = { qos: number };
+type EndOpts = Record<string, never>;
+
+interface FakeMqttClient extends EventEmitter {
+  subscribe: MockedFunction<(topics: string[], opts: SubscribeOpts, cb?: SubscribeCallback) => void>;
+  publish: MockedFunction<(topic: string, payload: Buffer, opts: PublishOpts, cb?: PublishCallback) => void>;
+  end: MockedFunction<(force: boolean, opts: EndOpts, cb?: EndCallback) => void>;
+  reconnect: MockedFunction<() => void>;
+}
+
+// Fake mqtt.js client: an EventEmitter with the methods MqttBrokerClient uses.
+function makeFakeClient(): FakeMqttClient {
+  const c = new EventEmitter() as FakeMqttClient;
+  c.subscribe = vi.fn((_topics: string[], _opts: SubscribeOpts, cb?: SubscribeCallback) => {
+    cb?.(null, [], {});
+  }) as FakeMqttClient['subscribe'];
+  c.publish = vi.fn((_topic: string, _payload: Buffer, _opts: PublishOpts, cb?: PublishCallback) => {
+    cb?.();
+  }) as FakeMqttClient['publish'];
+  c.end = vi.fn((_force: boolean, _opts: EndOpts, cb?: EndCallback) => {
+    cb?.();
+  }) as FakeMqttClient['end'];
+  c.reconnect = vi.fn() as FakeMqttClient['reconnect'];
+  return c;
+}
+
+vi.mock('mqtt', () => ({
+  connect: vi.fn(() => makeFakeClient()),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { connect } from 'mqtt';
+import {
+  MeshCoreObserverPublisher,
+  RENEWAL_CHECK_MS,
+  RENEWAL_THRESHOLD_S,
+  MAX_AUTH_FAILURES,
+  type MeshCoreObserverPublisherOptions,
+} from './meshcoreObserverPublisher.js';
+import { buildObserverPacketPayload } from './meshcoreObserverPacket.js';
+import type { ObserverToken, ObserverTokenResult } from './meshcoreObserverToken.js';
+import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
+
+const mockConnect = connect as MockedFunction<typeof connect>;
+const lastFakeClient = (): FakeMqttClient => mockConnect.mock.results.at(-1)!.value as FakeMqttClient;
+const lastConnectOptions = () => mockConnect.mock.calls.at(-1)![1];
+
+const SOURCE_ID = 'src-observer-1';
+const PUBKEY = 'AB'.repeat(32); // 64 hex chars
+const TOKEN_STRING = 'headerpart1234567890abcdef.payloadpart1234567890abcdef.' + 'a'.repeat(128);
+
+function makeToken(overrides: Partial<ObserverToken> = {}): ObserverToken {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return {
+    token: TOKEN_STRING,
+    publicKey: PUBKEY,
+    issuedAt: nowSeconds,
+    expiresAt: nowSeconds + 86_400,
+    ...overrides,
+  };
+}
+
+function makeConfig(): MeshCoreObserverPublisherOptions['config'] {
+  return {
+    enabled: true,
+    brokerUrl: 'mqtt://broker.test:1883',
+    iataCode: 'TEST',
+    tokenAudience: 'aud.test',
+  };
+}
+
+function makeDevice(): MeshCoreObserverPublisherOptions['device'] {
+  return () => ({
+    origin: 'MyNode',
+    model: 'ModelX',
+    firmwareVersion: 'v1.16.1',
+    radio: '915,250,7,5',
+  });
+}
+
+function makeMintToken(
+  ...results: ObserverTokenResult[]
+): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+  for (const r of results) fn.mockResolvedValueOnce(r);
+  return fn;
+}
+
+function makeMintTokenAlwaysOk(
+  token: ObserverToken = makeToken(),
+): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+  fn.mockResolvedValue({ kind: 'ok', token });
+  return fn;
+}
+
+function makePublisher(
+  mintToken: MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> = makeMintTokenAlwaysOk(),
+  sourceId: string = SOURCE_ID,
+): { publisher: MeshCoreObserverPublisher; mintToken: typeof mintToken } {
+  const publisher = new MeshCoreObserverPublisher({
+    sourceId,
+    config: makeConfig(),
+    device: makeDevice(),
+    mintToken,
+  });
+  return { publisher, mintToken };
+}
+
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+/** Starts the publisher, flushes to the point the client is created, then fires 'connect'. */
+async function startAndConnect(publisher: MeshCoreObserverPublisher): Promise<FakeMqttClient> {
+  const startPromise = publisher.start();
+  await flushMicrotasks(3);
+  const client = lastFakeClient();
+  client.emit('connect');
+  await startPromise;
+  return client;
+}
+
+describe('MeshCoreObserverPublisher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('connect wiring', () => {
+    it('wires username, password, keepalive, and a retained offline LWT', async () => {
+      const { publisher } = makePublisher();
+      await startAndConnect(publisher);
+
+      const opts = lastConnectOptions();
+      expect(opts.username).toBe(`v1_${PUBKEY}`);
+      expect(opts.password).toBe(TOKEN_STRING);
+      expect(opts.keepalive).toBe(60);
+      expect(opts.will).toBeDefined();
+      expect(opts.will!.topic).toBe(`meshcore/test/${PUBKEY}/status`);
+      expect(opts.will!.retain).toBe(true);
+
+      const lwt = JSON.parse((opts.will!.payload as Buffer).toString());
+      expect(lwt.status).toBe('offline');
+      expect(lwt.origin_id).toBe(PUBKEY);
+    });
+  });
+
+  it('publishes a single retained online status immediately on connect', async () => {
+    const { publisher } = makePublisher();
+    const client = await startAndConnect(publisher);
+
+    expect(client.publish).toHaveBeenCalledTimes(1);
+    const [topic, payload, opts] = client.publish.mock.calls[0]!;
+    expect(topic).toBe(`meshcore/test/${PUBKEY}/status`);
+    expect(opts.retain).toBe(true);
+    const body = JSON.parse(payload.toString());
+    expect(body.status).toBe('online');
+    expect(body.origin_id).toBe(PUBKEY);
+  });
+
+  it('NEVER subscribes to anything, even after packets flow (headline invariant)', async () => {
+    const { publisher } = makePublisher();
+    const client = await startAndConnect(publisher);
+
+    for (let i = 0; i < 10; i++) {
+      publisher.handleOtaPacket({ snr: 5, rssi: -70, raw_hex: '0900aa' });
+    }
+
+    expect(client.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('publishes each OTA packet as the exact contract payload, with origin_id matching the topic pubkey', async () => {
+    const { publisher } = makePublisher();
+    const client = await startAndConnect(publisher);
+    client.publish.mockClear();
+
+    const event: OtaPacketEvent = { snr: 6.25, rssi: -42, raw_hex: '0900aa' };
+    publisher.handleOtaPacket(event);
+    await flushMicrotasks();
+
+    expect(client.publish).toHaveBeenCalledTimes(1);
+    const [topic, payload, opts] = client.publish.mock.calls[0]!;
+    expect(topic).toBe(`meshcore/test/${PUBKEY}/packets`);
+    expect(opts.retain).toBe(false);
+
+    const expected = buildObserverPacketPayload(event, { origin: 'MyNode', originId: PUBKEY });
+    const actual = JSON.parse(payload.toString());
+    expect(actual).toEqual(expected);
+    expect(actual.origin_id).toBe(PUBKEY);
+  });
+
+  it('drops packets and counts them when the socket is down (never queues via mqtt.js)', async () => {
+    const { publisher } = makePublisher();
+    const startPromise = publisher.start();
+    await flushMicrotasks(3);
+    const client = lastFakeClient();
+    // Deliberately do NOT emit 'connect' — the socket stays down.
+
+    for (let i = 0; i < 5; i++) {
+      publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    }
+
+    expect(client.publish).not.toHaveBeenCalled();
+    expect(publisher.getStatus().dropped).toBe(5);
+
+    // Tidy up the pending start() so nothing lingers.
+    client.emit('error', new Error('unreachable'));
+    await startPromise;
+  });
+
+  it('tracks publishes, lastPublishAt, and lastError', async () => {
+    const { publisher } = makePublisher();
+    const client = await startAndConnect(publisher);
+    client.publish.mockClear();
+
+    publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    await flushMicrotasks();
+    expect(publisher.getStatus().publishes).toBe(1);
+    expect(publisher.getStatus().lastPublishAt).not.toBeNull();
+
+    client.publish.mockImplementationOnce((_t, _p, _o, cb) => cb?.(new Error('publish failed')));
+    publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900bb' });
+    await flushMicrotasks();
+    expect(publisher.getStatus().lastError).toContain('publish failed');
+  });
+
+  describe('mint failures at start() — no connect attempt, no retry loop', () => {
+    it.each([
+      ['no_key', { kind: 'no_key' } as const, 'No observer signing key stored for this source.'],
+      [
+        'key_rotated',
+        { kind: 'key_rotated' } as const,
+        'Stored observer signing key cannot be decrypted (SESSION_SECRET changed). Re-import the key.',
+      ],
+      [
+        'mint_failed',
+        { kind: 'mint_failed', message: 'wasm boom' } as const,
+        'Failed to mint observer auth token.',
+      ],
+    ])('resolves without connecting on %s', async (_label, result, expectedError) => {
+      const mintToken = makeMintToken(result as ObserverTokenResult);
+      const { publisher } = makePublisher(mintToken);
+
+      await publisher.start();
+
+      expect(mockConnect).not.toHaveBeenCalled();
+      const status = publisher.getStatus();
+      expect(status.keyStored).toBe(false);
+      expect(status.lastError).toBe(expectedError);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  it('hard-stops after MAX_AUTH_FAILURES consecutive auth rejections, without re-minting', async () => {
+    const mintToken = makeMintTokenAlwaysOk();
+    const { publisher } = makePublisher(mintToken);
+    const client = await startAndConnect(publisher);
+
+    for (let i = 0; i < MAX_AUTH_FAILURES; i++) {
+      const err = Object.assign(new Error('bad creds'), { code: 4 });
+      client.emit('error', err);
+    }
+    await flushMicrotasks();
+
+    expect(publisher.isRunning()).toBe(false);
+    expect(publisher.getStatus().lastError).toContain('Broker rejected the observer auth token');
+    expect(mintToken).toHaveBeenCalledTimes(1); // proves no per-attempt re-minting
+    expect(client.end).toHaveBeenCalled();
+  });
+
+  it('renews on a timer tick: mints again, tears down the old client, connects a new one, republishes online', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const tokenA = makeToken({ expiresAt: nowSeconds + 120 }); // comfortably inside the renewal window at tick 1
+    const tokenBString = TOKEN_STRING.replace(/^header/, 'renewd');
+    const tokenB = makeToken({ token: tokenBString, expiresAt: nowSeconds + 86_400 + 120 });
+    const mintToken = makeMintToken({ kind: 'ok', token: tokenA }, { kind: 'ok', token: tokenB });
+    const { publisher } = makePublisher(mintToken);
+    const oldClient = await startAndConnect(publisher);
+
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+
+    expect(mintToken).toHaveBeenCalledTimes(2);
+    expect(oldClient.end).toHaveBeenCalled();
+
+    const newClient = lastFakeClient();
+    expect(newClient).not.toBe(oldClient);
+    const opts = lastConnectOptions();
+    expect(opts.password).toBe(tokenBString);
+
+    newClient.publish.mockClear();
+    newClient.emit('connect');
+    await flushMicrotasks();
+    expect(newClient.publish).toHaveBeenCalledTimes(1); // fresh online status on the new client
+  });
+
+  describe('renewal window boundary (§3.2/§6 — closes the reference\'s ~55min expiry hole)', () => {
+    it('renews on tick 1 when expiry falls inside the widened window (outside the naive 300s threshold)', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      // Outside the naive 300s threshold measured at mint time...
+      const expiresAt = nowSeconds + RENEWAL_CHECK_MS / 1000 + RENEWAL_THRESHOLD_S + 60;
+      expect(expiresAt - nowSeconds).toBeGreaterThan(RENEWAL_THRESHOLD_S);
+      // ...but inside one check interval of expiry, so the reference's
+      // threshold-only rule would miss it at tick 1 and fire ~55min late at
+      // tick 2 (after the token has already expired).
+
+      const tokenA = makeToken({ expiresAt });
+      const tokenB = makeToken({ expiresAt: expiresAt + 86_400 });
+      const mintToken = makeMintToken({ kind: 'ok', token: tokenA }, { kind: 'ok', token: tokenB });
+      const { publisher } = makePublisher(mintToken);
+      await startAndConnect(publisher);
+
+      vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+      await flushMicrotasks();
+
+      expect(mintToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT renew on tick 1 when expiry is comfortably outside the widened window', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      // Remaining life at tick 1 = (2*interval + threshold + 60) - interval
+      // = interval + threshold + 60 — 60s more than the widened window,
+      // unambiguously outside it.
+      const expiresAt = nowSeconds + 2 * (RENEWAL_CHECK_MS / 1000) + RENEWAL_THRESHOLD_S + 60;
+      const tokenA = makeToken({ expiresAt });
+      const mintToken = makeMintTokenAlwaysOk(tokenA);
+      const { publisher } = makePublisher(mintToken);
+      await startAndConnect(publisher);
+
+      vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+      await flushMicrotasks();
+
+      expect(mintToken).toHaveBeenCalledTimes(1); // only the initial mint — no renewal yet
+    });
+  });
+
+  it('leaves the existing connection untouched on a renewal mint failure, and retries next tick', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const expiresAt = nowSeconds + 120;
+    const tokenA = makeToken({ expiresAt });
+    const mintToken = makeMintToken(
+      { kind: 'ok', token: tokenA },
+      { kind: 'mint_failed', message: 'wasm boom' },
+      { kind: 'ok', token: makeToken({ expiresAt: expiresAt + 86_400 }) },
+    );
+    const { publisher } = makePublisher(mintToken);
+    const client = await startAndConnect(publisher);
+
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+
+    expect(mintToken).toHaveBeenCalledTimes(2);
+    expect(client.end).not.toHaveBeenCalled();
+    expect(publisher.getStatus().lastError).toBe('Failed to mint observer auth token.');
+
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+    expect(mintToken).toHaveBeenCalledTimes(3);
+  });
+
+  describe('stop()', () => {
+    it('publishes an explicit offline status before disconnecting, and is idempotent', async () => {
+      const { publisher } = makePublisher();
+      const client = await startAndConnect(publisher);
+      client.publish.mockClear();
+
+      await publisher.stop();
+
+      expect(client.publish).toHaveBeenCalledTimes(1);
+      const [topic, payload, opts] = client.publish.mock.calls[0]!;
+      expect(topic).toBe(`meshcore/test/${PUBKEY}/status`);
+      expect(JSON.parse(payload.toString()).status).toBe('offline');
+      expect(opts.retain).toBe(true);
+      expect(client.end).toHaveBeenCalledTimes(1);
+
+      const publishOrder = client.publish.mock.invocationCallOrder[0]!;
+      const endOrder = client.end.mock.invocationCallOrder[0]!;
+      expect(publishOrder).toBeLessThan(endOrder);
+      expect(vi.getTimerCount()).toBe(0);
+
+      await publisher.stop();
+      expect(client.publish).toHaveBeenCalledTimes(1);
+      expect(client.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('redacts token-shaped substrings from lastError', async () => {
+    const { publisher } = makePublisher();
+    const client = await startAndConnect(publisher);
+
+    const embeddedToken = 'headerpart1234567890abcdef.payloadpart1234567890abcdef.' + 'b'.repeat(128);
+    client.emit('error', new Error(`token rejected: ${embeddedToken}`));
+
+    const lastError = publisher.getStatus().lastError;
+    expect(lastError).not.toBeNull();
+    expect(lastError).not.toContain(embeddedToken);
+    expect(lastError).toContain('[REDACTED]');
+  });
+});

--- a/src/server/services/meshcoreObserverPublisher.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.test.ts
@@ -387,7 +387,7 @@ describe('MeshCoreObserverPublisher', () => {
   });
 
   describe('stop()', () => {
-    it('publishes an explicit offline status before disconnecting, and is idempotent', async () => {
+    it('publishes an explicit offline status before disconnecting (flushed), and is idempotent', async () => {
       const { publisher } = makePublisher();
       const client = await startAndConnect(publisher);
       client.publish.mockClear();
@@ -400,6 +400,10 @@ describe('MeshCoreObserverPublisher', () => {
       expect(JSON.parse(payload.toString()).status).toBe('offline');
       expect(opts.retain).toBe(true);
       expect(client.end).toHaveBeenCalledTimes(1);
+      // flush:true — disconnect() must end non-forcefully so the offline
+      // publish above actually reaches the wire instead of being discarded
+      // by an immediate forced close (spec §2.4 / E2E criterion 8).
+      expect(client.end.mock.calls[0]![0]).toBe(false);
 
       const publishOrder = client.publish.mock.invocationCallOrder[0]!;
       const endOrder = client.end.mock.invocationCallOrder[0]!;

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -34,6 +34,7 @@
  *   stop: clear the renewal timer and disconnect, and stay stopped until an
  *   operator-driven config change / reconnect.
  */
+import { createRequire } from 'module';
 import { MqttBrokerClient, type MqttBrokerClientOptions } from '../transports/mqttBrokerClient.js';
 import { logger } from '../../utils/logger.js';
 import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
@@ -50,7 +51,8 @@ import {
   type ObserverTokenResult,
 } from './meshcoreObserverToken.js';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- CJS interop for package.json, same pattern as newsService.ts / healthRoutes.ts.
+// createRequire interop for package.json, same pattern as newsService.ts.
+const require = createRequire(import.meta.url);
 const appVersion: string = require('../../../package.json').version;
 
 /** Re-check the token's remaining life once an hour. */

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -161,6 +161,12 @@ export class MeshCoreObserverPublisher {
    * failure reason lands in `getStatus().lastError`, never a thrown error.
    */
   async start(): Promise<void> {
+    // Reset the auth-failure state so a fresh start (e.g. a new instance
+    // reused in tests, or any future restart path) is never poisoned by a
+    // prior hard-stop — the guard is a concurrency latch, not a permanent
+    // fuse (review #4468 obs. 4).
+    this.authStopping = false;
+    this.authFailures = 0;
     const result = await this.mintTokenFn(this.options.sourceId);
     if (result.kind !== 'ok') {
       this.keyStored = false;

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -1,0 +1,432 @@
+/**
+ * meshcoreObserverPublisher
+ *
+ * MeshCore Analyzer Observer publisher (#4457 Phase 2, WP4). One instance
+ * per MeshCore Companion source: mints an auth token (Phase 1 WP3 seam),
+ * opens one authenticated, publish-only MQTT socket to a
+ * `michaelhart/meshcore-mqtt-broker`-compatible broker, relays every OTA
+ * packet the radio hears (WP1's encoder), and publishes online/offline
+ * status. **Never subscribes to anything** — that is this phase's headline
+ * invariant (see `docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md`
+ * §2.2, §9 WP4, §10).
+ *
+ * Design notes (see the spec §3.2/§6 for the full derivation):
+ * - Token minting happens at `start()` and again on a renewal timer — never
+ *   per-packet. Minting is a WASM Ed25519 signature and is unaffordable at
+ *   packet rate (Phase 1 §2.5).
+ * - mqtt.js bakes `username`/`password` into the CONNECT packet, so renewal
+ *   tears down the client and builds a fresh one with a fresh password and a
+ *   fresh LWT (D-9) rather than trying to mutate an established connection.
+ * - The renewal predicate deliberately widens the reference's threshold-only
+ *   window by folding the check interval into it, closing a ~55-minute
+ *   post-expiry hole the reference has. See `checkRenewal()` below and the
+ *   spec §3.2 callout. Never hardcode the resulting 3900s constant — always
+ *   derive it from `RENEWAL_CHECK_MS` / `RENEWAL_THRESHOLD_S`.
+ * - Backpressure: `handleOtaPacket` gates on `client.isConnected()` itself
+ *   and drops when the socket is down. mqtt.js queues QoS-0 publishes while
+ *   offline by default, which would grow an unbounded in-memory queue on a
+ *   busy mesh with a broker that's down — never let a publish reach a
+ *   disconnected client.
+ * - Auth-rejection cooldown: below `MAX_AUTH_FAILURES` we let the client's
+ *   own backoff retry with the *same* token (a fresh token signed with the
+ *   same key/audience would be rejected identically — re-minting per
+ *   attempt is the hot-loop we must avoid). At `MAX_AUTH_FAILURES` we hard
+ *   stop: clear the renewal timer and disconnect, and stay stopped until an
+ *   operator-driven config change / reconnect.
+ */
+import { MqttBrokerClient, type MqttBrokerClientOptions } from '../transports/mqttBrokerClient.js';
+import { logger } from '../../utils/logger.js';
+import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
+import type { MeshCoreConfig } from '../meshcoreManager.js';
+import {
+  buildObserverPacketPayload,
+  buildObserverStatusPayload,
+  observerTopics,
+  type ObserverPacketIdentity,
+} from './meshcoreObserverPacket.js';
+import {
+  mintObserverTokenForSourceDetailed,
+  type ObserverToken,
+  type ObserverTokenResult,
+} from './meshcoreObserverToken.js';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CJS interop for package.json, same pattern as newsService.ts / healthRoutes.ts.
+const appVersion: string = require('../../../package.json').version;
+
+/** Re-check the token's remaining life once an hour. */
+export const RENEWAL_CHECK_MS = 3_600_000;
+/**
+ * Safety margin (seconds) folded on top of `RENEWAL_CHECK_MS` when deciding
+ * whether to renew. See the module header / spec §3.2 for why the check
+ * interval itself must be part of the window, not just this margin.
+ */
+export const RENEWAL_THRESHOLD_S = 300;
+/** Consecutive CONNACK auth rejections before the publisher hard-stops. */
+export const MAX_AUTH_FAILURES = 5;
+
+/** Strips anything shaped like a minted observer token (or a JWT-style secret) from a message. */
+const TOKEN_SHAPE_PATTERN = /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[0-9A-Fa-f]{128}/g;
+
+/** Never let a token/password-shaped substring escape into a user-visible `lastError`. */
+function redactToken(message: string): string {
+  return message.replace(TOKEN_SHAPE_PATTERN, '[REDACTED]');
+}
+
+const LAST_ERROR = {
+  notConfigured: 'Analyzer Observer configuration is incomplete for this source.',
+  noKey: 'No observer signing key stored for this source.',
+  keyRotated:
+    'Stored observer signing key cannot be decrypted (SESSION_SECRET changed). Re-import the key.',
+  mintFailed: 'Failed to mint observer auth token.',
+  authRejected: 'Broker rejected the observer auth token (check tokenAudience and the stored key).',
+} as const;
+
+export interface MeshCoreObserverStatus {
+  /** `observer.enabled` AND all three config fields present. */
+  configured: boolean;
+  /** A signing key row exists AND is decryptable under the current SESSION_SECRET. */
+  keyStored: boolean;
+  connected: boolean;
+  publishes: number;
+  /** Packets dropped because the socket was down when they arrived. */
+  dropped: number;
+  lastPublishAt: number | null;
+  lastError: string | null;
+  /** Unix SECONDS (matches `ObserverToken.expiresAt`). */
+  tokenExpiresAt: number | null;
+}
+
+export interface MeshCoreObserverPublisherOptions {
+  sourceId: string;
+  config: NonNullable<MeshCoreConfig['observer']>;
+  /** Live device facts, read lazily at publish/status time — never cached at construction. */
+  device: () => {
+    origin: string;
+    model?: string;
+    firmwareVersion?: string;
+    radio?: string;
+  };
+  /** Injection seam for tests. Defaults to `mintObserverTokenForSourceDetailed`. */
+  mintToken?: (sourceId: string) => Promise<ObserverTokenResult>;
+  /** Injection seam for tests. Defaults to `(opts) => new MqttBrokerClient(opts)`. */
+  createClient?: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+}
+
+/** Minimal shape of the `permission-denied` event `MqttBrokerClient` emits. */
+interface PermissionDeniedReason {
+  kind: 'subscribe' | 'auth';
+  topics?: string[];
+  message: string;
+}
+
+export class MeshCoreObserverPublisher {
+  private readonly options: MeshCoreObserverPublisherOptions;
+  private readonly mintTokenFn: (sourceId: string) => Promise<ObserverTokenResult>;
+  private readonly createClientFn: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+  private readonly configured: boolean;
+
+  private client: MqttBrokerClient | null = null;
+  private topics: { region: string; packets: string; status: string } | null = null;
+  private tokenPublicKey: string | null = null;
+
+  private keyStored = false;
+  private publishes = 0;
+  private dropped = 0;
+  private lastPublishAt: number | null = null;
+  private lastError: string | null = null;
+  private tokenExpiresAt: number | null = null;
+
+  private running = false;
+  private authFailures = 0;
+  private authStopping = false;
+  private renewing = false;
+  private renewalTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: MeshCoreObserverPublisherOptions) {
+    this.options = options;
+    this.mintTokenFn = options.mintToken ?? mintObserverTokenForSourceDetailed;
+    this.createClientFn = options.createClient ?? ((opts) => new MqttBrokerClient(opts));
+    this.configured = !!(
+      options.config.enabled &&
+      options.config.brokerUrl &&
+      options.config.iataCode &&
+      options.config.tokenAudience
+    );
+  }
+
+  /**
+   * Mint → connect → publish online status. Resolves even on failure — the
+   * failure reason lands in `getStatus().lastError`, never a thrown error.
+   */
+  async start(): Promise<void> {
+    const result = await this.mintTokenFn(this.options.sourceId);
+    if (result.kind !== 'ok') {
+      this.keyStored = false;
+      this.lastError = this.mintFailureMessage(result);
+      return;
+    }
+
+    await this.connectWithToken(result.token);
+    this.armRenewalTimer();
+    this.running = true;
+  }
+
+  /** Publish an explicit offline status, then disconnect. Idempotent. */
+  async stop(): Promise<void> {
+    this.clearRenewalTimer();
+    const client = this.client;
+    if (!client) {
+      this.running = false;
+      return;
+    }
+
+    this.client = null;
+    this.running = false;
+
+    const identity = this.getIdentity();
+    if (identity && this.topics) {
+      try {
+        const offline = buildObserverStatusPayload('offline', identity);
+        await client.publish(this.topics.status, Buffer.from(JSON.stringify(offline)), true);
+      } catch {
+        // Best-effort — a broker that's already unreachable shouldn't block shutdown.
+      }
+    }
+
+    try {
+      await client.disconnect();
+    } catch {
+      // Best-effort.
+    }
+  }
+
+  /**
+   * Sync, never throws. Call from the manager's `ota_packet` listener. No
+   * token minting on this path — see the module header.
+   */
+  handleOtaPacket(event: OtaPacketEvent): void {
+    const client = this.client;
+    if (!client || !client.isConnected() || !this.topics || !this.tokenPublicKey) {
+      this.dropped++;
+      return;
+    }
+
+    const identity: ObserverPacketIdentity = {
+      origin: this.options.device().origin,
+      originId: this.tokenPublicKey,
+    };
+    const payload = buildObserverPacketPayload(event, identity);
+    if (!payload) return; // blank/missing raw_hex — mirrors VN handleOtaPacket.
+
+    void client
+      .publish(this.topics.packets, Buffer.from(JSON.stringify(payload)), false)
+      .then(() => {
+        this.publishes++;
+        this.lastPublishAt = Date.now();
+      })
+      .catch((err: unknown) => {
+        this.lastError = redactToken(err instanceof Error ? err.message : String(err));
+      });
+  }
+
+  getStatus(): MeshCoreObserverStatus {
+    return {
+      configured: this.configured,
+      keyStored: this.keyStored,
+      connected: this.client?.isConnected() ?? false,
+      publishes: this.publishes,
+      dropped: this.dropped,
+      lastPublishAt: this.lastPublishAt,
+      lastError: this.lastError,
+      tokenExpiresAt: this.tokenExpiresAt,
+    };
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  private getIdentity(): ObserverPacketIdentity | null {
+    if (!this.tokenPublicKey) return null;
+    return { origin: this.options.device().origin, originId: this.tokenPublicKey };
+  }
+
+  private mintFailureMessage(result: Exclude<ObserverTokenResult, { kind: 'ok' }>): string {
+    switch (result.kind) {
+      case 'not_configured':
+        return LAST_ERROR.notConfigured;
+      case 'no_key':
+        return LAST_ERROR.noKey;
+      case 'key_rotated':
+        return LAST_ERROR.keyRotated;
+      case 'mint_failed':
+        // The library error text can be verbose; log it at debug only and
+        // never let it surface as `lastError` (Phase 1 §5.5 logging discipline).
+        logger.debug(`[MeshCoreObserver:${this.options.sourceId}] mint failed: ${result.message}`);
+        return LAST_ERROR.mintFailed;
+    }
+  }
+
+  private buildClientOptions(
+    token: ObserverToken,
+    topics: { status: string },
+  ): MqttBrokerClientOptions {
+    const identity: ObserverPacketIdentity = {
+      origin: this.options.device().origin,
+      originId: token.publicKey,
+    };
+    const lwt = buildObserverStatusPayload('offline', identity);
+    return {
+      // Config completeness (brokerUrl/iataCode/tokenAudience all present) is
+      // guaranteed by `observerConfigFromSource` before this publisher is ever
+      // constructed (meshcoreManager only builds one when `observer` is
+      // non-undefined) — non-null assert rather than threading a narrower
+      // type through every read.
+      url: this.options.config.brokerUrl!,
+      username: `v1_${token.publicKey}`,
+      password: token.token,
+      clientIdPrefix: 'meshmonitor-observer',
+      keepalive: 60,
+      will: {
+        topic: topics.status,
+        payload: Buffer.from(JSON.stringify(lwt)),
+        qos: 0,
+        retain: true,
+      },
+    };
+  }
+
+  private wireClientListeners(client: MqttBrokerClient): void {
+    client.on('connect', () => {
+      this.lastError = null;
+      this.authFailures = 0;
+      this.publishOnlineStatus();
+    });
+    client.on('error', (err: Error) => {
+      // `MqttBrokerClient` emits BOTH `permission-denied` and a raw `error`
+      // for the same CONNACK auth rejection (code 4/5), `permission-denied`
+      // first. Skip here so the fixed, more actionable auth message from the
+      // `permission-denied` listener below isn't clobbered by the raw
+      // `err.message` (e.g. "Bad username or password").
+      const code = (err as Error & { code?: number }).code;
+      if (code === 4 || code === 5) return;
+      this.lastError = redactToken(err.message);
+    });
+    client.on('permission-denied', (reason: PermissionDeniedReason) => {
+      if (reason.kind !== 'auth') return;
+      this.authFailures++;
+      this.lastError = LAST_ERROR.authRejected;
+      if (this.authFailures >= MAX_AUTH_FAILURES) {
+        void this.hardStopOnAuthFailure();
+      }
+    });
+  }
+
+  private publishOnlineStatus(): void {
+    const client = this.client;
+    const identity = this.getIdentity();
+    if (!client || !identity || !this.topics) return;
+
+    const dev = this.options.device();
+    const payload = buildObserverStatusPayload('online', identity, {
+      model: dev.model,
+      firmwareVersion: dev.firmwareVersion,
+      radio: dev.radio,
+      clientVersion: `meshmonitor/${appVersion}`,
+    });
+    void client
+      .publish(this.topics.status, Buffer.from(JSON.stringify(payload)), true)
+      .catch((err: unknown) => {
+        this.lastError = redactToken(err instanceof Error ? err.message : String(err));
+      });
+  }
+
+  private async connectWithToken(token: ObserverToken): Promise<void> {
+    this.tokenPublicKey = token.publicKey;
+    this.tokenExpiresAt = token.expiresAt;
+    this.keyStored = true;
+    this.topics = observerTopics(this.options.config.iataCode!, token.publicKey);
+
+    const opts = this.buildClientOptions(token, this.topics);
+    const client = this.createClientFn(opts);
+    this.wireClientListeners(client);
+    this.client = client;
+    await client.connect();
+  }
+
+  /** D-9: mqtt.js bakes credentials in at CONNECT time — renewal tears down and rebuilds. */
+  private async rebuildClientWithToken(token: ObserverToken): Promise<void> {
+    const oldClient = this.client;
+    this.client = null;
+    if (oldClient) {
+      try {
+        await oldClient.disconnect();
+      } catch {
+        // Best-effort — proceed to bring the new client up regardless.
+      }
+    }
+    await this.connectWithToken(token);
+  }
+
+  private armRenewalTimer(): void {
+    this.clearRenewalTimer();
+    this.renewalTimer = setInterval(() => {
+      void this.checkRenewal();
+    }, RENEWAL_CHECK_MS);
+    this.renewalTimer.unref();
+  }
+
+  private clearRenewalTimer(): void {
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer);
+      this.renewalTimer = null;
+    }
+  }
+
+  /**
+   * Renew when `nowSeconds >= tokenExpiresAt - (RENEWAL_CHECK_MS/1000 +
+   * RENEWAL_THRESHOLD_S)`. The reference tests only the threshold on a
+   * coarser interval, which leaves an expiry hole — see the module header
+   * and spec §3.2/§6. Never hardcode the resulting window; always derive it
+   * from the two constants.
+   */
+  private async checkRenewal(): Promise<void> {
+    if (this.renewing || this.tokenExpiresAt === null) return;
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const windowSeconds = RENEWAL_CHECK_MS / 1000 + RENEWAL_THRESHOLD_S;
+    if (nowSeconds < this.tokenExpiresAt - windowSeconds) return;
+
+    this.renewing = true;
+    try {
+      const result = await this.mintTokenFn(this.options.sourceId);
+      if (result.kind !== 'ok') {
+        // Old client untouched — a transient mint failure must not tear down
+        // a working connection. Retried automatically on the next tick.
+        this.lastError = this.mintFailureMessage(result);
+        return;
+      }
+      await this.rebuildClientWithToken(result.token);
+    } finally {
+      this.renewing = false;
+    }
+  }
+
+  private async hardStopOnAuthFailure(): Promise<void> {
+    if (this.authStopping) return;
+    this.authStopping = true;
+    this.clearRenewalTimer();
+    const client = this.client;
+    this.client = null;
+    this.running = false;
+    if (client) {
+      try {
+        await client.disconnect();
+      } catch {
+        // Best-effort.
+      }
+    }
+  }
+}

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -196,7 +196,13 @@ export class MeshCoreObserverPublisher {
     }
 
     try {
-      await client.disconnect();
+      // flush:true — the offline publish above only resolves once mqtt.js
+      // has accepted the packet, not once it's actually on the wire. A
+      // plain forced end() (the default used elsewhere in this class, e.g.
+      // renewal/hard-stop) can close the socket before that QoS-0 packet is
+      // flushed, silently dropping the graceful-stop offline status (spec
+      // §2.4 / E2E criterion 8).
+      await client.disconnect({ flush: true });
     } catch {
       // Best-effort.
     }

--- a/src/server/services/meshcoreObserverToken.test.ts
+++ b/src/server/services/meshcoreObserverToken.test.ts
@@ -22,6 +22,7 @@ import {
   isValidObserverPrivateKey,
   mintObserverToken,
   mintObserverTokenForSource,
+  mintObserverTokenForSourceDetailed,
 } from './meshcoreObserverToken.js';
 import { MeshCoreObserverKeyStore, setMeshCoreObserverKeyStoreForTesting } from './meshcoreObserverKeyStore.js';
 
@@ -271,6 +272,123 @@ describe('meshcoreObserverToken', () => {
       const verified = await verifyAuthToken(result!.token, pub);
       expect(verified).not.toBeNull();
       expect(verified!.aud).toBe('my-aud');
+    });
+  });
+
+  describe('mintObserverTokenForSourceDetailed', () => {
+    beforeEach(() => {
+      sourceRows.clear();
+      observerRows.clear();
+      setMeshCoreObserverKeyStoreForTesting(null);
+    });
+
+    it("kind 'not_configured' when the source does not exist", async () => {
+      expect(await mintObserverTokenForSourceDetailed('missing')).toEqual({ kind: 'not_configured' });
+    });
+
+    it("kind 'not_configured' for a non-meshcore source", async () => {
+      sourceRows.set('src-mt', { id: 'src-mt', type: 'meshtastic_tcp', config: {} });
+      expect(await mintObserverTokenForSourceDetailed('src-mt')).toEqual({ kind: 'not_configured' });
+    });
+
+    it("kind 'not_configured' when the observer config block is absent/incomplete", async () => {
+      sourceRows.set('src-a', { id: 'src-a', type: 'meshcore', config: {} });
+      expect(await mintObserverTokenForSourceDetailed('src-a')).toEqual({ kind: 'not_configured' });
+
+      sourceRows.set('src-b', {
+        id: 'src-b',
+        type: 'meshcore',
+        config: { observer: { enabled: true, brokerUrl: 'mqtts://broker:8883' } }, // missing iataCode/tokenAudience
+      });
+      expect(await mintObserverTokenForSourceDetailed('src-b')).toEqual({ kind: 'not_configured' });
+    });
+
+    it("kind 'no_key' when no key is stored", async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secret'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+      sourceRows.set('src-c', {
+        id: 'src-c',
+        type: 'meshcore',
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'aud' },
+        },
+      });
+      expect(await mintObserverTokenForSourceDetailed('src-c')).toEqual({ kind: 'no_key' });
+    });
+
+    it("kind 'key_rotated' when the stored envelope was encrypted under a different SESSION_SECRET", async () => {
+      const secretA = 'secretA'.repeat(8);
+      const secretB = 'secretB'.repeat(8);
+      const storeA = new MeshCoreObserverKeyStore(secretA, true);
+      setMeshCoreObserverKeyStoreForTesting(storeA);
+
+      const pub = await deriveObserverPublicKey(PRIV);
+      await storeA.store('src-d', PRIV, pub, 'manual');
+
+      const storeB = new MeshCoreObserverKeyStore(secretB, true);
+      setMeshCoreObserverKeyStoreForTesting(storeB);
+
+      sourceRows.set('src-d', {
+        id: 'src-d',
+        type: 'meshcore',
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'aud' },
+        },
+      });
+      expect(await mintObserverTokenForSourceDetailed('src-d')).toEqual({ kind: 'key_rotated' });
+    });
+
+    it("kind 'mint_failed' with the library's message when the stored key is structurally invalid", async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secretF'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+      // Store the deterministic UNCLAMPED fixture directly — `store()` does
+      // not validate the key material, so this round-trips through `load()`
+      // as `{ kind: 'ok' }` and only fails inside `mintObserverToken`'s own
+      // `deriveObserverPublicKey` call, exercising the mint_failed path.
+      await keyStore.store('src-f', UNCLAMPED_PRIV, 'unused-public-key-placeholder', 'manual');
+
+      sourceRows.set('src-f', {
+        id: 'src-f',
+        type: 'meshcore',
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'aud' },
+        },
+      });
+
+      const result = await mintObserverTokenForSourceDetailed('src-f');
+      expect(result.kind).toBe('mint_failed');
+      if (result.kind === 'mint_failed') {
+        expect(result.message).toBe('Invalid Analyzer Observer signing key: key derivation failed');
+      }
+    });
+
+    it("kind 'ok' mints a valid token for a fully configured source with a stored key", async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secretG'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+
+      const pub = await deriveObserverPublicKey(PRIV);
+      await keyStore.store('src-g', PRIV, pub, 'device');
+
+      sourceRows.set('src-g', {
+        id: 'src-g',
+        type: 'meshcore',
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'my-aud' },
+        },
+      });
+
+      const result = await mintObserverTokenForSourceDetailed('src-g');
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.token.publicKey).toBe(pub);
+        const verified = await verifyAuthToken(result.token.token, pub);
+        expect(verified).not.toBeNull();
+        expect(verified!.aud).toBe('my-aud');
+      }
+    });
+
+    it("mintObserverTokenForSource still collapses to null for every non-'ok' kind", async () => {
+      expect(await mintObserverTokenForSource('missing')).toBeNull();
     });
   });
 });

--- a/src/server/services/meshcoreObserverToken.ts
+++ b/src/server/services/meshcoreObserverToken.ts
@@ -102,22 +102,36 @@ export async function mintObserverToken(
 }
 
 /**
+ * Discriminated result for {@link mintObserverTokenForSourceDetailed}. Lets
+ * the Phase 2 publisher distinguish *why* minting didn't produce a token —
+ * `mintObserverTokenForSource`'s flat `null` collapses all of these into one
+ * case, which is fine for Phase 1 but not enough for the publisher's
+ * `lastError` surface (spec §3.3/§6).
+ */
+export type ObserverTokenResult =
+  | { kind: 'ok'; token: ObserverToken }
+  /** Source missing, not `meshcore`, or the `observer` config block absent/incomplete. */
+  | { kind: 'not_configured' }
+  /** No row in `meshcore_observer_keys` for this source. */
+  | { kind: 'no_key' }
+  /** Stored envelope was encrypted under a different `SESSION_SECRET`. */
+  | { kind: 'key_rotated' }
+  /** `mintObserverToken` threw (WASM/derive/sign failure). `message` is the
+   *  sanitized library text — callers must log it at `debug` only and never
+   *  surface it directly to a user (module header logging discipline). */
+  | { kind: 'mint_failed'; message: string };
+
+/**
  * Mint a token for a configured source: loads the stored signing key, reads
  * `observer.tokenAudience` from the source's saved config, derives the
- * public key, and signs.
+ * public key, and signs. Unlike {@link mintObserverTokenForSource}, the
+ * failure reason is distinguishable — see {@link ObserverTokenResult}.
  *
- * Returns null when: no key is stored, the stored envelope is rotated
- * (SESSION_SECRET changed), the source is not `meshcore`, or the `observer`
- * config block is absent/incomplete (mirrors `observerConfigFromSource`'s
- * own definition of "incomplete" — missing `brokerUrl`/`iataCode`/
- * `tokenAudience`, or not enabled).
- *
- * Not exposed via any route in Phase 1 — this exists so Phase 2's publisher
- * has a tested seam.
+ * Not exposed via any route — this is the publisher's (Phase 2) seam.
  */
-export async function mintObserverTokenForSource(sourceId: string): Promise<ObserverToken | null> {
+export async function mintObserverTokenForSourceDetailed(sourceId: string): Promise<ObserverTokenResult> {
   const source = await databaseService.sources.getSource(sourceId);
-  if (!source || source.type !== 'meshcore') return null;
+  if (!source || source.type !== 'meshcore') return { kind: 'not_configured' };
 
   const cfg = (source.config ?? {}) as MeshCoreSourceConfig;
   const observer = observerConfigFromSource(cfg);
@@ -125,16 +139,35 @@ export async function mintObserverTokenForSource(sourceId: string): Promise<Obse
   // iataCode/tokenAudience are all present (see its own definition of
   // "incomplete"), but its declared type still marks tokenAudience optional —
   // narrow explicitly so this stays type-safe if that contract ever loosens.
-  if (!observer || !observer.tokenAudience) return null;
+  if (!observer || !observer.tokenAudience) return { kind: 'not_configured' };
 
   const keyResult = await getMeshCoreObserverKeyStore().load(sourceId);
-  if (keyResult.kind !== 'ok') return null;
+  if (keyResult.kind === 'none') return { kind: 'no_key' };
+  if (keyResult.kind === 'key_rotated') return { kind: 'key_rotated' };
 
   try {
-    return await mintObserverToken(keyResult.privateKeyHex, observer.tokenAudience);
+    const token = await mintObserverToken(keyResult.privateKeyHex, observer.tokenAudience);
+    return { kind: 'ok', token };
   } catch (err) {
-    // Never let a thrown error carry key material into the log.
-    logger.warn(`[ObserverToken:${sourceId}] failed to mint token: ${(err as Error).message}`);
-    return null;
+    // Never let a thrown error carry key material into the log at anything
+    // above debug — the message itself is the sanitized text from
+    // `mintObserverToken`'s own catch, but treat it as sensitive regardless.
+    const message = (err as Error).message;
+    logger.debug(`[ObserverToken:${sourceId}] failed to mint token: ${message}`);
+    return { kind: 'mint_failed', message };
   }
+}
+
+/**
+ * Mint a token for a configured source, collapsed to Phase 1's flat
+ * `ObserverToken | null` contract. Thin wrapper over
+ * {@link mintObserverTokenForSourceDetailed} — kept so Phase 1 callers and
+ * tests are unaffected by the WP3 refinement.
+ *
+ * Not exposed via any route in Phase 1 — this exists so Phase 2's publisher
+ * has a tested seam.
+ */
+export async function mintObserverTokenForSource(sourceId: string): Promise<ObserverToken | null> {
+  const r = await mintObserverTokenForSourceDetailed(sourceId);
+  return r.kind === 'ok' ? r.token : null;
 }

--- a/src/server/sourceManagerRegistry.ts
+++ b/src/server/sourceManagerRegistry.ts
@@ -126,6 +126,31 @@ export class SourceManagerRegistry extends EventEmitter {
     }
   }
 
+  /**
+   * Hot-swap the Analyzer Observer configuration of a MeshCore manager
+   * (#4457 Phase 2, WP6) without restarting its upstream device connection.
+   * Returns true if a swap happened, false if the manager does not exist or
+   * does not support observer reconfiguration. Duck-typed (never
+   * `instanceof`) so this stays manager-type-agnostic — same shape as
+   * reconfigureVirtualNode above.
+   */
+  async reconfigureObserver(sourceId: string, cfg: Record<string, unknown> | undefined): Promise<boolean> {
+    const manager = this.managers.get(sourceId) as unknown as
+      | { reconfigureObserver?: (cfg: Record<string, unknown> | undefined) => Promise<void> }
+      | undefined;
+    if (!manager || typeof manager.reconfigureObserver !== 'function') {
+      return false;
+    }
+    try {
+      await manager.reconfigureObserver(cfg);
+      logger.info(`Hot-swapped Analyzer Observer config for source ${sourceId}`);
+      return true;
+    } catch (error) {
+      logger.error(`Failed to reconfigure Analyzer Observer for source ${sourceId}:`, error);
+      throw error;
+    }
+  }
+
   getAllManagers(): ISourceManager[] {
     return Array.from(this.managers.values());
   }

--- a/src/server/transports/mqttBrokerClient.test.ts
+++ b/src/server/transports/mqttBrokerClient.test.ts
@@ -118,6 +118,62 @@ describe('MqttBrokerClient', () => {
     });
   });
 
+  describe('disconnect() — flush option (graceful-stop offline-status fix)', () => {
+    it('defaults to an immediate forced end (existing behavior pinned)', async () => {
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
+      void client.connect();
+      const fake = lastFakeClient();
+      fake.emit('connect');
+
+      await client.disconnect();
+
+      expect(fake.end).toHaveBeenCalledTimes(1);
+      expect(fake.end.mock.calls[0][0]).toBe(true);
+    });
+
+    it('disconnect({ flush: true }) ends non-forcefully so queued outgoing packets can flush', async () => {
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
+      void client.connect();
+      const fake = lastFakeClient();
+      fake.emit('connect');
+
+      await client.disconnect({ flush: true });
+
+      expect(fake.end).toHaveBeenCalledTimes(1);
+      expect(fake.end.mock.calls[0][0]).toBe(false);
+    });
+
+    it('flush disconnect still resolves via the ~2s fallback if the graceful end callback never fires', async () => {
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
+      void client.connect();
+      const fake = lastFakeClient();
+      fake.emit('connect');
+
+      // Simulate a wedged/unreachable socket: a non-forced end() never
+      // invokes its callback (mqtt.js waiting on an ack that will never
+      // come), but a forced end() (the fallback) does.
+      fake.end.mockImplementation((force: boolean, _opts: unknown, cb?: () => void) => {
+        if (force) cb?.();
+      });
+
+      let resolved = false;
+      const disconnectPromise = client.disconnect({ flush: true }).then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toBe(false); // graceful end() callback never fired — not resolved yet
+
+      vi.advanceTimersByTime(2000);
+      await disconnectPromise;
+
+      expect(resolved).toBe(true);
+      expect(fake.end).toHaveBeenCalledTimes(2); // graceful attempt + forced fallback
+      expect(fake.end.mock.calls[0][0]).toBe(false);
+      expect(fake.end.mock.calls[1][0]).toBe(true);
+    });
+  });
+
   describe('MqttReconnectCoordinator backoff growth', () => {
     it('grows the shared reconnect delay geometrically while flapping (1s → 2s → 4s)', () => {
       const coord = new MqttReconnectCoordinator();

--- a/src/server/transports/mqttBrokerClient.test.ts
+++ b/src/server/transports/mqttBrokerClient.test.ts
@@ -86,6 +86,38 @@ describe('MqttBrokerClient', () => {
     });
   });
 
+  describe('will + keepalive options (§3.4)', () => {
+    it('forwards `will` verbatim to mqtt.connect', () => {
+      const will = {
+        topic: 'meshcore/test/ABCDEF/status',
+        payload: Buffer.from('{"status":"offline"}'),
+        qos: 0 as const,
+        retain: true,
+      };
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883', will });
+      void client.connect();
+      expect(lastConnectOptions().will).toBe(will);
+    });
+
+    it('omits `will` from connect options entirely when not supplied', () => {
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
+      void client.connect();
+      expect('will' in lastConnectOptions()).toBe(false);
+    });
+
+    it('defaults keepalive to 15 when not supplied', () => {
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
+      void client.connect();
+      expect(lastConnectOptions().keepalive).toBe(15);
+    });
+
+    it('honours a keepalive override', () => {
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883', keepalive: 60 });
+      void client.connect();
+      expect(lastConnectOptions().keepalive).toBe(60);
+    });
+  });
+
   describe('MqttReconnectCoordinator backoff growth', () => {
     it('grows the shared reconnect delay geometrically while flapping (1s → 2s → 4s)', () => {
       const coord = new MqttReconnectCoordinator();

--- a/src/server/transports/mqttBrokerClient.ts
+++ b/src/server/transports/mqttBrokerClient.ts
@@ -30,6 +30,10 @@ export interface MqttBrokerClientOptions {
   clientId?: string;
   clientIdPrefix?: string;
   rejectUnauthorized?: boolean;
+  /** MQTT Last Will and Testament. Forwarded verbatim to mqtt.js. */
+  will?: IClientOptions['will'];
+  /** Keepalive seconds. Defaults to 15 (Meshtastic-firmware parity). */
+  keepalive?: number;
 }
 
 export interface MqttBrokerClientMessage {
@@ -168,13 +172,17 @@ export class MqttBrokerClient extends EventEmitter {
       password: this.options.password,
       protocolVersion: 4, // MQTT 3.1.1
       clean: true,
-      keepalive: 15, // match Meshtastic firmware (PubSubClient default)
+      keepalive: this.options.keepalive ?? 15, // match Meshtastic firmware (PubSubClient default)
       reconnectPeriod: 0, // we handle reconnect ourselves
       connectTimeout: 30_000,
       rejectUnauthorized: this.options.rejectUnauthorized ?? true,
       // Cache DNS across connections/reconnects. The hostname stays on the
       // socket, so TLS SNI / cert validation is unaffected. See cachingDnsLookup.ts.
       lookup: sharedDnsLookup,
+      // Omit the `will` key entirely when unset, so the connect-options object
+      // stays byte-identical for every existing caller (D-5 / §3.4 of
+      // MESHCORE_OBSERVER_PHASE2_SPEC.md).
+      ...(this.options.will ? { will: this.options.will } : {}),
     };
     this.client = connect(url, connectOptions);
 

--- a/src/server/transports/mqttBrokerClient.ts
+++ b/src/server/transports/mqttBrokerClient.ts
@@ -339,7 +339,19 @@ export class MqttBrokerClient extends EventEmitter {
     );
   }
 
-  async disconnect(): Promise<void> {
+  /**
+   * @param opts.flush When true, ends the underlying mqtt.js client
+   *   non-forcefully first (`end(false)`) so any not-yet-flushed outgoing
+   *   packet (e.g. a graceful-stop offline status publish) has a chance to
+   *   actually hit the wire before the socket closes, per
+   *   `MESHCORE_OBSERVER_PHASE2_SPEC.md` §2.4/E2E criterion 8 — `publish()`
+   *   resolving only means mqtt.js accepted the packet, not that it was
+   *   sent. Raced against a ~2s fallback that force-ends (`end(true)`) so
+   *   a wedged/unreachable socket can never hang this promise forever.
+   *   Default (omitted/false) is byte-identical to the original behavior:
+   *   an immediate forced `end(true)`.
+   */
+  async disconnect(opts?: { flush?: boolean }): Promise<void> {
     if (this.coordinator) {
       this.coordinator.unregister(this);
       this.coordinator = null;
@@ -350,9 +362,28 @@ export class MqttBrokerClient extends EventEmitter {
     }
     this.clearStableReset();
     if (!this.client) return;
-    await new Promise<void>((resolve) => {
-      this.client!.end(true, {}, () => resolve());
-    });
+    const client = this.client;
+
+    if (opts?.flush) {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(fallback);
+          resolve();
+        };
+        const fallback = setTimeout(() => {
+          client.end(true, {}, finish);
+        }, 2000);
+        client.end(false, {}, finish);
+      });
+    } else {
+      await new Promise<void>((resolve) => {
+        client.end(true, {}, () => resolve());
+      });
+    }
+
     this.client = null;
     this.connected = false;
     this.subscriptions.clear();


### PR DESCRIPTION
## Summary
Phase 2 of 3 for the MeshCore Analyzer Observer epic (#4457): the publisher service. A MeshCore Companion source with the observer enabled now relays every OTA packet it hears to a MeshCore-Analyzer-compatible MQTT broker (FL Mesh / LetsMesh backbone), publishing analyzer-contract JSON on `meshcore/{IATA}/{PUBKEY}/packets` and online/offline on `/status` — authenticated with the Ed25519 token machinery Phase 1 shipped (#4464). **Observation-only: the publisher never subscribes to anything** (asserted by a named test and proven live — the broker closes any publisher that subscribes, and ours never was). No UI yet (Phase 3). Spec: `docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md`.

## Changes
- **Encoder** (`meshcoreObserverPacket.ts`, pure): analyzer wire contract verified field-by-field against the reference client — string-typed numerics, `SNR`/`RSSI` capitalisation, route letter map (`TRANSPORT_DIRECT`→`"T"`), `path` only on `route:"D"`, SHA-256 `Packet::calculatePacketHash` (the decoder lib's `messageHash` is djb2 — not usable), packed `path_len` decode with a named divergence test, `'0000000000000000'` failure sentinel. 39 golden tests, TZ-independent (verified under `TZ=Asia/Kolkata`).
- **Publisher** (`meshcoreObserverPublisher.ts`): one publish-only socket per source; token minted at connect + renewed on a timer whose window covers the check interval (closes the reference's ~55-min post-expiry hole); renewal tears down and rebuilds the client (mqtt.js bakes credentials into CONNECT); backpressure gates on `isConnected()` so mqtt.js's offline queue can never grow unbounded; auth-rejection cooldown hard-stops after 5 CONNACKs without ever re-minting; token-shaped strings redacted from every user-visible error.
- **Client** (`MqttBrokerClient`): additive `will` (LWT) + `keepalive` options; new `disconnect({flush:true})` that flushes outgoing packets with a 2s force-end fallback — default behavior byte-identical for all existing callers.
- **Lifecycle**: observer starts/stops with the manager at the same four sites as the Virtual Node server; companion-only; consumes the ungated `ota_packet` emit (independent of `meshcore_packet_log_enabled`, tested). `getStatus()` gains a conditionally-spread `observer` sub-object (stripped for callers without `nodes:read`).
- **Hot-swap**: `reconfigureObserver` on manager + registry; an observer-only config change no longer bounces the companion radio link (closes Phase 1's follow-up).
- **Token module**: `mintObserverTokenForSourceDetailed` with 5 discriminated result kinds; Phase 1's wrapper contract preserved with its tests unmodified.

## Live E2E (2026-07-31, real hardware)
Ran against a real companion (Yeraze MC Sandbox, `ttyUSB2`) and `meshcore-mqtt-broker` built from source (`test` region, real Ed25519 token auth). **All 10 spec §8 criteria passed**: broker authenticated `v1_{PUBKEY}` with the device-exported key; online status with retain-strip; real RF packets in full contract shape with hashes verified by an independent implementation; no topic normalization; never subscribed; graceful offline delivered; hot-swap with zero device reconnects; bad audience → clean `lastError`, one rejection, no storm. Three live-only bugs found and fixed: bare `require()` in the ESM bundle, doubled `v` in `firmware_version`, and force-end discarding the graceful offline publish.

## Issues Resolved
Relates to #4457 (Phase 2 of 3 — issue stays open until Phase 3 lands).

## Documentation Updates
Internal only: Phase 2 spec + epic-plan deviations (a-j). User-facing docs land in Phase 3 with the UI.

## Testing
- [x] Full Vitest suite green: 13,453 tests, 0 failures, `success:true` via JSON reporter
- [x] TypeScript compiles cleanly; `lint:ci` ratchet gate passes (7 rule counts improved)
- [x] No schema/migration changes — PG/MySQL suites not required for this phase
- [x] Never-subscribes and no-per-packet-minting invariants asserted by named tests
- [x] Live E2E: 10/10 criteria against real companion + real broker (see above)
- [ ] Reviewer: the encoder's golden tests (`meshcoreObserverPacket.test.ts`) pin the third-party wire contract — treat any change there as a contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9