### PR TITLE
fix(positions): stop Null Island estimates being shown as real positions

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -148,6 +148,7 @@ import { migration as addWaypointChannelMigration, runMigration130Postgres, runM
 import { migration as seedPerSourceNodeDisplayMigration, runMigration131Postgres, runMigration131Mysql } from '../server/migrations/131_seed_per_source_node_display.js';
 import { migration as fanOutSettingsPermissionsMigration, runMigration132Postgres, runMigration132Mysql } from '../server/migrations/132_fan_out_settings_permissions.js';
 import { migration as addMeshCoreObserverKeysMigration, runMigration133Postgres, runMigration133Mysql } from '../server/migrations/133_add_meshcore_observer_keys.js';
+import { migration as clearNullIslandEstimatesMigration, runMigration134Postgres, runMigration134Mysql } from '../server/migrations/134_clear_null_island_estimates.js';
 
 // ============================================================================
 // Registry
@@ -2126,4 +2127,13 @@ registry.register({
   sqlite: (db) => addMeshCoreObserverKeysMigration.up(db),
   postgres: (client) => runMigration133Postgres(client),
   mysql: (pool) => runMigration133Mysql(pool),
+});
+
+registry.register({
+  number: 134,
+  name: 'clear_null_island_estimates',
+  settingsKey: 'migration_134_clear_null_island_estimates',
+  sqlite: (db) => clearNullIslandEstimatesMigration.up(db),
+  postgres: (client) => runMigration134Postgres(client),
+  mysql: (pool) => runMigration134Mysql(pool),
 });

--- a/src/server/migrations/134_clear_null_island_estimates.test.ts
+++ b/src/server/migrations/134_clear_null_island_estimates.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import DatabaseConstructor from 'better-sqlite3';
+import type { Database } from 'better-sqlite3';
+import { migration } from './134_clear_null_island_estimates.js';
+import { NULL_ISLAND_EPSILON } from '../../utils/nullIsland.js';
+
+/**
+ * Migration 134 (#4432 follow-up): estimated positions solved onto Null Island
+ * are not positions. Migration 107 swept `nodes` / `meshcore_nodes` / `telemetry`
+ * but never this table, so bogus rows survived and were re-substituted onto the
+ * very nodes whose real (0,0) fix 107 had just cleared.
+ */
+describe('migration 134: clear Null Island estimated positions', () => {
+  let db: Database;
+
+  const insert = (nodeNum: number, lat: number | null, lon: number | null) =>
+    db
+      .prepare(
+        `INSERT INTO estimated_positions (nodeNum, nodeId, latitude, longitude, uncertaintyKm, observationCount, updatedAt)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(nodeNum, `!${nodeNum.toString(16).padStart(8, '0')}`, lat, lon, 0.05, 2, Date.now());
+
+  const remaining = () =>
+    db.prepare('SELECT nodeNum FROM estimated_positions ORDER BY nodeNum').all().map((r: any) => r.nodeNum);
+
+  beforeEach(() => {
+    db = new DatabaseConstructor(':memory:');
+    db.exec(`
+      CREATE TABLE estimated_positions (
+        nodeNum INTEGER PRIMARY KEY,
+        nodeId TEXT NOT NULL,
+        latitude REAL,
+        longitude REAL,
+        uncertaintyKm REAL,
+        observationCount INTEGER,
+        updatedAt INTEGER
+      )
+    `);
+  });
+
+  it('deletes rows at exactly (0,0)', () => {
+    insert(1, 0, 0);
+    insert(2, 35.1, -80.6);
+
+    migration.up(db);
+
+    expect(remaining()).toEqual([2]);
+  });
+
+  it('deletes rows within the shared Null Island epsilon', () => {
+    // The firmware "garbage default" fixes migration 107 documents: 2^15 and
+    // 2^16 in 1e-7 degrees land just inside the 0.01 radius.
+    insert(1, 0.0032768, 0.0032768);
+    insert(2, 0.0065536, 0.0065536);
+
+    migration.up(db);
+
+    expect(remaining()).toEqual([]);
+  });
+
+  // The radius only rejects a coordinate near BOTH axes, so a genuine node on
+  // the equator or the prime meridian must survive — that distinction is the
+  // whole reason Null Island filtering is a two-axis test.
+  it('keeps a real equator or prime-meridian estimate', () => {
+    insert(1, 0, 37.5);           // equator, Kenya
+    insert(2, 51.48, 0);          // prime meridian, Greenwich
+    insert(3, 0, -0.5);           // on the equator, just outside the radius
+
+    migration.up(db);
+
+    expect(remaining()).toEqual([1, 2, 3]);
+  });
+
+  it('keeps a coordinate just outside the epsilon on both axes', () => {
+    const outside = NULL_ISLAND_EPSILON * 1.5;
+    insert(1, outside, outside);
+
+    migration.up(db);
+
+    expect(remaining()).toEqual([1]);
+  });
+
+  it('leaves rows with NULL coordinates alone', () => {
+    insert(1, null, null);
+
+    migration.up(db);
+
+    expect(remaining()).toEqual([1]);
+  });
+
+  it('is idempotent', () => {
+    insert(1, 0, 0);
+    insert(2, 35.1, -80.6);
+
+    migration.up(db);
+    migration.up(db);
+    migration.up(db);
+
+    expect(remaining()).toEqual([2]);
+  });
+});

--- a/src/server/migrations/134_clear_null_island_estimates.ts
+++ b/src/server/migrations/134_clear_null_island_estimates.ts
@@ -1,0 +1,86 @@
+/**
+ * Migration 134: Delete "Null Island" (0,0) rows from `estimated_positions`.
+ *
+ * Follow-up to #4432. Migration 107 cleared bogus (0,0) coordinates from `nodes`,
+ * `meshcore_nodes`, and `telemetry` — but not from the global `estimated_positions`
+ * table, which did not yet exist in that sweep's scope. That left a gap:
+ *
+ *   1. A node reported a bogus (0,0) fix, so it became a (0,0) *anchor*.
+ *   2. The estimator averaged it into a neighbouring node's solve, storing an
+ *      estimate at (0,0) with a confident-looking sub-kilometre radius.
+ *   3. Migration 107 nulled the original (0,0) fix in `nodes`, so those nodes
+ *      then fell through to the estimate — re-substituting the exact coordinates
+ *      107 had just removed, now indistinguishable from a real position.
+ *
+ * The runtime hole is closed separately in positionEstimationService: bogus
+ * anchors are dropped before they can constrain anything, and a solve that lands
+ * on Null Island returns null instead of being stored. This migration removes the
+ * rows already written by the old behaviour.
+ *
+ * Deleting (rather than nulling) is correct here: unlike `nodes`, a row in
+ * `estimated_positions` has no meaning without coordinates — the table is one
+ * derived estimate per node, and the scheduled recompute re-creates any row that
+ * still has a legitimate solve.
+ *
+ * Naturally idempotent: once the rows are gone they no longer match, so re-running
+ * is a no-op. The radius (NULL_ISLAND_EPSILON) is shared with the runtime filter
+ * so the two never drift.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import { NULL_ISLAND_EPSILON as EPS } from '../../utils/nullIsland.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 134 (SQLite): Deleting Null Island estimated positions...');
+    try {
+      db.exec(
+        `DELETE FROM estimated_positions ` +
+          `WHERE latitude IS NOT NULL AND longitude IS NOT NULL ` +
+          `AND ABS(latitude) < ${EPS} AND ABS(longitude) < ${EPS}`,
+      );
+      logger.debug('Deleted Null Island rows from estimated_positions');
+    } catch (e) {
+      logger.warn('Could not delete Null Island estimated positions:', e instanceof Error ? e.message : String(e));
+    }
+    logger.info('Migration 134 complete (SQLite): Null Island estimates cleared');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration134Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 134 (PostgreSQL): Deleting Null Island estimated positions...');
+  try {
+    await client.query(
+      `DELETE FROM estimated_positions ` +
+        `WHERE "latitude" IS NOT NULL AND "longitude" IS NOT NULL ` +
+        `AND ABS("latitude") < $1 AND ABS("longitude") < $1`,
+      [EPS],
+    );
+    logger.debug('Deleted Null Island rows from estimated_positions');
+  } catch (e) {
+    logger.warn('Could not delete Null Island estimated positions:', e instanceof Error ? e.message : String(e));
+  }
+  logger.info('Migration 134 complete (PostgreSQL): Null Island estimates cleared');
+}
+
+// ============ MySQL ============
+
+export async function runMigration134Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 134 (MySQL): Deleting Null Island estimated positions...');
+  try {
+    await pool.query(
+      `DELETE FROM estimated_positions ` +
+        `WHERE latitude IS NOT NULL AND longitude IS NOT NULL ` +
+        `AND ABS(latitude) < ? AND ABS(longitude) < ?`,
+      [EPS, EPS],
+    );
+    logger.debug('Deleted Null Island rows from estimated_positions');
+  } catch (e) {
+    logger.warn('Could not delete Null Island estimated positions:', e instanceof Error ? e.message : String(e));
+  }
+  logger.info('Migration 134 complete (MySQL): Null Island estimates cleared');
+}

--- a/src/server/services/positionEstimationService.test.ts
+++ b/src/server/services/positionEstimationService.test.ts
@@ -159,6 +159,75 @@ describe('solveNodePosition', () => {
   });
 });
 
+// #4432 follow-up: a bogus anchor drags the weighted centroid to (0,0) and the
+// resulting "estimate" gets substituted onto a node as though it were a fix.
+// Two lines of defence: drop bogus anchors, and reject a solve that lands there.
+describe('Null Island rejection (#4432 follow-up)', () => {
+  it('returns null when the weighted centroid lands on Null Island', () => {
+    // Legitimate anchors placed symmetrically about (0,0) average onto it —
+    // the case anchor filtering alone cannot catch.
+    const result = solveNodePosition(
+      [
+        obs({ anchorLat: 1, anchorLon: 1, snrDb: 0 }),
+        obs({ anchorLat: -1, anchorLon: -1, snrDb: 0 }),
+      ],
+      NOW,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('still solves normally when the centroid is a real position', () => {
+    const result = solveNodePosition(
+      [
+        obs({ anchorLat: 35.0, anchorLon: -80.0, snrDb: 0 }),
+        obs({ anchorLat: 35.2, anchorLon: -80.2, snrDb: 0 }),
+      ],
+      NOW,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.latitude).toBeCloseTo(35.1, 5);
+  });
+
+  it('solves for a genuine equator anchor pair (only BOTH axes near 0 is bogus)', () => {
+    const result = solveNodePosition(
+      [
+        obs({ anchorLat: 0, anchorLon: 37.4, snrDb: 0 }),
+        obs({ anchorLat: 0, anchorLon: 37.6, snrDb: 0 }),
+      ],
+      NOW,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.latitude).toBeCloseTo(0, 5);
+    expect(result!.longitude).toBeCloseTo(37.5, 5);
+  });
+
+  it('drops a Null Island anchor before it can constrain a neighbour', () => {
+    const anchors = new Map<number, { lat: number; lon: number }>([
+      [10, { lat: 0, lon: 0 }],        // bogus — must not anchor anything
+      [20, { lat: 35.1, lon: -80.6 }], // real
+    ]);
+    const neighbors: NeighborForEstimation[] = [
+      { nodeNum: 1, neighborNodeNum: 10, snr: 5, timestamp: NOW },
+      { nodeNum: 2, neighborNodeNum: 20, snr: 5, timestamp: NOW },
+    ];
+
+    const out = buildObservations([], neighbors, anchors);
+
+    expect(out.get(1)).toBeUndefined();
+    expect(out.get(2)).toHaveLength(1);
+    expect(out.get(2)![0].anchorLat).toBeCloseTo(35.1, 5);
+  });
+
+  it('does not mutate the caller\'s anchors map', () => {
+    const anchors = new Map<number, { lat: number; lon: number }>([[10, { lat: 0, lon: 0 }]]);
+
+    buildObservations([], [], anchors);
+
+    expect(anchors.size).toBe(1);
+    expect(anchors.get(10)).toEqual({ lat: 0, lon: 0 });
+  });
+});
+
 describe('buildObservations', () => {
   const anchors = new Map<number, { lat: number; lon: number }>([
     [100, { lat: 10, lon: 20 }],

--- a/src/server/services/positionEstimationService.ts
+++ b/src/server/services/positionEstimationService.ts
@@ -20,6 +20,7 @@
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { calculateDistance } from '../../utils/distance.js';
+import { isBogusPosition } from '../../utils/nullIsland.js';
 import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
 import type { EstimatedPositionInput } from '../../db/repositories/index.js';
 
@@ -132,6 +133,14 @@ export function solveNodePosition(observations: PositionObservation[], now: numb
 
   const latitude = wLat / wSum;
   const longitude = wLon / wSum;
+
+  // A solve that lands on Null Island is not a position (#4432 follow-up).
+  // buildObservations already drops bogus anchors, so this is the second line of
+  // defence: legitimate anchors placed symmetrically about (0, 0) can still
+  // average onto it. Returning null means "no usable estimate", which is exactly
+  // what a Gulf-of-Guinea centroid is — better than storing a row that later gets
+  // substituted onto the node as though it were a fix.
+  if (isBogusPosition(latitude, longitude)) return null;
 
   // Kish effective sample size — robust to skewed weights.
   const nEff = (wSum * wSum) / w2Sum;
@@ -248,22 +257,33 @@ export function buildObservations(
 ): Map<number, PositionObservation[]> {
   const out = new Map<number, PositionObservation[]>();
 
+  // Drop anchors that are not real positions before they can constrain anything
+  // (#4432 follow-up). A Null Island or otherwise invalid anchor drags the
+  // weighted centroid toward (0, 0) and produces an estimate in the Gulf of
+  // Guinea — which then gets substituted onto the node as if it were a fix.
+  // Filtered into a new map rather than deleting from the caller's: this
+  // function is otherwise free of side effects and callers reuse the map.
+  const usableAnchors = new Map<number, { lat: number; lon: number }>();
+  for (const [nodeNum, a] of anchors) {
+    if (!isBogusPosition(a.lat, a.lon)) usableAnchors.set(nodeNum, a);
+  }
+
   for (const tr of traceroutes) {
     const route = parseNumberArray(tr.route);
     const forwardPath = [tr.fromNodeNum, ...route, tr.toNodeNum];
-    addPathObservations(forwardPath, parseNumberArray(tr.snrTowards), tr.timestamp, anchors, out);
+    addPathObservations(forwardPath, parseNumberArray(tr.snrTowards), tr.timestamp, usableAnchors, out);
 
     const routeBack = parseNumberArray(tr.routeBack);
     if (routeBack.length > 0) {
       const returnPath = [tr.toNodeNum, ...routeBack, tr.fromNodeNum];
-      addPathObservations(returnPath, parseNumberArray(tr.snrBack), tr.timestamp, anchors, out);
+      addPathObservations(returnPath, parseNumberArray(tr.snrBack), tr.timestamp, usableAnchors, out);
     }
   }
 
   for (const nb of neighbors) {
     // NeighborInfo snr is already in dB. Either side may be the unpositioned target.
-    const nodeAnchor = anchors.get(nb.nodeNum);
-    const neighborAnchor = anchors.get(nb.neighborNodeNum);
+    const nodeAnchor = usableAnchors.get(nb.nodeNum);
+    const neighborAnchor = usableAnchors.get(nb.neighborNodeNum);
     const snrDb = nb.snr != null && Number.isFinite(nb.snr) ? nb.snr : undefined;
 
     if (neighborAnchor && !nodeAnchor) {

--- a/src/server/utils/nodeEnhancer.test.ts
+++ b/src/server/utils/nodeEnhancer.test.ts
@@ -235,6 +235,62 @@ describe('nodeEnhancer: enhanceNodeForClient', () => {
       expect(result.positionIsEstimated).toBe(false);
     });
   });
+
+  // #4432 follow-up. Priority 2 used a truthiness test (`lat && lon`), so a
+  // coordinate of exactly 0 read as "unpositioned" and a genuine fix on the
+  // equator or prime meridian was overwritten by an estimate.
+  describe('Priority 2 accepts a zero coordinate (#4432 follow-up)', () => {
+    const estimateAt = (lat: number, lon: number) => {
+      const m = new Map();
+      m.set('!00000001', { latitude: lat, longitude: lon, uncertaintyKm: 2.5 });
+      return m;
+    };
+
+    it('keeps a real equator fix instead of substituting an estimate', async () => {
+      const equator = { ...mockNode, positionOverrideEnabled: false, position: { latitude: 0, longitude: 37.5 } };
+
+      const result = await enhanceNodeForClient(equator, regularUser, estimateAt(50, 60));
+
+      expect(result.position.latitude).toBe(0);
+      expect(result.position.longitude).toBe(37.5);
+      expect(result.positionIsEstimated).toBe(false);
+    });
+
+    it('keeps a real prime-meridian fix', async () => {
+      const meridian = { ...mockNode, positionOverrideEnabled: false, position: { latitude: 51.48, longitude: 0 } };
+
+      const result = await enhanceNodeForClient(meridian, regularUser, estimateAt(50, 60));
+
+      expect(result.position.longitude).toBe(0);
+      expect(result.positionIsEstimated).toBe(false);
+    });
+
+    // The gate must stay independently correct: a bare presence check would
+    // accept a stray Null Island fix and present it as GPS, which is worse than
+    // the truthiness behaviour it replaced.
+    it('still rejects Null Island and falls through to the estimate', async () => {
+      const nullIsland = { ...mockNode, positionOverrideEnabled: false, position: { latitude: 0, longitude: 0 } };
+
+      const result = await enhanceNodeForClient(nullIsland, regularUser, estimateAt(50, 60));
+
+      expect(result.position.latitude).toBe(50);
+      expect(result.positionIsEstimated).toBe(true);
+    });
+
+    // The combined end state for the two real nodes that prompted this work.
+    // Migration 107 already nulled their bogus (0,0) fix in `nodes`; migration
+    // 134 now removes the Null Island *estimate* that was refilling it. With
+    // both gone the node is simply unpositioned — no coordinates, and nothing
+    // for the UI to mislabel as a GPS fix.
+    it('leaves the node unpositioned once both the bogus fix and estimate are gone', async () => {
+      const cleared = { ...mockNode, positionOverrideEnabled: false, position: null };
+
+      const result = await enhanceNodeForClient(cleared, regularUser, new Map());
+
+      expect(result.positionIsEstimated).toBe(false);
+      expect(result.position).toBeNull();
+    });
+  });
 });
 
 describe('nodeEnhancer: filterNodesByChannelPermission', () => {

--- a/src/server/utils/nodeEnhancer.ts
+++ b/src/server/utils/nodeEnhancer.ts
@@ -3,6 +3,7 @@ import type { DeviceInfo } from '../meshtasticManager.js';
 import type { User } from '../../types/auth.js';
 import type { ResourceType, PermissionSet } from '../../types/permission.js';
 import databaseService from '../../services/database.js';
+import { isBogusPosition } from '../../utils/nullIsland.js';
 import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
 
 /**
@@ -114,7 +115,20 @@ export async function enhanceNodeForClient(
   }
 
   // Priority 2: Use regular GPS position if available (already set in node.position)
-  if (node.position?.latitude && node.position?.longitude) {
+  //
+  // Presence check, not truthiness: a latitude or longitude of exactly 0 is a
+  // real coordinate (the equator / the prime meridian), and the old truthy test
+  // treated such a node as unpositioned, overwriting its genuine fix with an
+  // estimate (#4432 follow-up).
+  //
+  // Null Island — where BOTH are ~0 — is explicitly rejected rather than left to
+  // upstream filtering. It is already filtered at ingest and by migration 107,
+  // but making the gate independently correct matters: a bare presence check
+  // would accept a stray (0, 0) and render it as a GPS fix, which is worse than
+  // the behaviour this change replaces. Falling through lets an estimate take
+  // over, correctly labelled.
+  const pos = node.position;
+  if (pos?.latitude != null && pos?.longitude != null && !isBogusPosition(pos.latitude, pos.longitude)) {
     return enhancedNode;
   }
 


### PR DESCRIPTION
Follow-up to #4432, found by the provenance pill that PR added.

## What was wrong

Two nodes on this install were rendering a confident sub-kilometre position in the Gulf of Guinea. The chain:

1. A node reported a bogus `(0,0)` fix, making it a `(0,0)` **anchor**.
2. The estimator averaged that anchor into a neighbour's solve and stored an estimate at `(0,0)` with a ±0.05 km radius.
3. Migration 107 nulled the original `(0,0)` fix in `nodes` — but never swept `estimated_positions`. Those nodes then fell through to the estimate, **re-substituting the exact coordinates 107 had just removed**.

Before #4432 this was invisible; the new `ESTIMATED` pill made it legible, which is how it surfaced.

Verified against the live database rather than inferred:

```
estimated_positions rows: 481
exactly (0,0): 2
  !0acb55dc  ±0.05 km  observationCount=2
  !9e8bb91e  ±0.05 km  observationCount=2
```

Both solved from 2 observations — confirming bogus *anchors* were the cause, not a solver quirk.

## Three changes

**Migration 134** deletes Null Island rows from `estimated_positions`. Deleting rather than nulling is deliberate: unlike `nodes`, a row there is meaningless without coordinates, and the scheduled recompute recreates any row that still has a legitimate solve. Idempotent, and shares `NULL_ISLAND_EPSILON` with the runtime filter so the two cannot drift.

**`positionEstimationService`** drops bogus anchors before they can constrain anything — into a *copy*, since `buildObservations` is otherwise free of side effects and callers reuse the map. Plus `solveNodePosition` returns `null` when the weighted centroid itself lands on Null Island, catching what filtering cannot: legitimate anchors placed symmetrically about `(0,0)` averaging onto it.

**`nodeEnhancer` Priority 2** used a truthiness test (`lat && lon`), so a latitude or longitude of exactly `0` — the equator, the prime meridian — read as "unpositioned" and had a genuine fix overwritten by an estimate.

## One decision worth review attention

The gate now rejects Null Island **explicitly** rather than relying on upstream filtering. My first pass left it to migration 107 and ingest guards, but that's worse than what it replaces: a bare presence check would accept a stray `(0,0)` and render it as a `GPS` fix, whereas the old truthiness test at least fell through to an estimate. Making the gate independently correct also removes the ordering hazard between these two fixes, which is why they ship together.

`nodeEnhancer.test.ts` pins the combined end state for the two real nodes: with both the bogus fix (107) and the bogus estimate (134) gone, they are simply unpositioned — no coordinates, nothing for the UI to mislabel.

## Testing

- Full Vitest suite: **13,390 passed, 0 failed**, 109 skipped — with PostgreSQL and MySQL containers up so the multi-backend suites actually executed.
- New coverage: 6 migration cases (exact zero, in-epsilon firmware garbage defaults, equator/meridian survival, outside-epsilon, NULL coords, idempotency), 5 estimator cases, 4 enhancer cases.
- `tsc --noEmit` clean; `npm run lint:ci` passes.

A note on that suite figure: an earlier run reported 45 failures in `nodes.test.ts` (PostgreSQL/MySQL backends only). That was stale state in long-lived test containers, not a regression — recreating them gave 171/171 on that file unchanged, and the full run above is against fresh containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB