### PR TITLE
fix(api): GET /stats returns 500 whenever sourceId is omitted

### DIFF
--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -465,7 +465,7 @@ export class MessagesRepository extends BaseRepository {
    *
    * Keeps branching: per-dialect date formatting.
    */
-  async getMessagesByDay(days: number = 7, sourceId?: SourceScope): Promise<Array<{ date: string; count: number }>> {
+  async getMessagesByDay(days: number = 7, sourceId: SourceScope): Promise<Array<{ date: string; count: number }>> {
     const cutoff = this.now() - days * 24 * 60 * 60 * 1000;
     const { messages } = this.tables;
 

--- a/src/server/routes/dataExchangeRoutes.test.ts
+++ b/src/server/routes/dataExchangeRoutes.test.ts
@@ -20,6 +20,7 @@ vi.mock('../auth/authMiddleware.js', () => ({
   requireAdmin: () => (req: any, _res: any, next: any) => { req.user = { id: 1, isAdmin: true }; next(); },
 }));
 
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import dataExchangeRoutes from './dataExchangeRoutes.js';
 
 const app = express();
@@ -47,6 +48,26 @@ describe('GET /stats', () => {
     });
     expect(mockDb.messages.getMessageCount).toHaveBeenCalledWith('src-1');
     expect(mockDb.getMessagesByDayAsync).toHaveBeenCalledWith(7, 'src-1');
+  });
+
+  // Regression: without an explicit sourceId every count must opt in to the
+  // cross-source sentinel. getMessagesByDayAsync used to be handed a bare
+  // undefined, which withSourceScope rejects, so the whole endpoint 500'd for any
+  // caller that did not pass sourceId (the aggregate dashboard, and any health
+  // check hitting /stats bare).
+  it('passes the ALL_SOURCES sentinel to every count when sourceId is omitted', async () => {
+    mockDb.messages.getMessageCount.mockResolvedValue(10);
+    mockDb.nodes.getNodeCount.mockResolvedValue(5);
+    mockDb.channels.getChannelCount.mockResolvedValue(3);
+    mockDb.getMessagesByDayAsync.mockResolvedValue([]);
+
+    const res = await request(app).get('/stats');
+
+    expect(res.status).toBe(200);
+    expect(mockDb.messages.getMessageCount).toHaveBeenCalledWith(ALL_SOURCES);
+    expect(mockDb.nodes.getNodeCount).toHaveBeenCalledWith(ALL_SOURCES);
+    expect(mockDb.channels.getChannelCount).toHaveBeenCalledWith(ALL_SOURCES);
+    expect(mockDb.getMessagesByDayAsync).toHaveBeenCalledWith(7, ALL_SOURCES);
   });
 
   it('returns 500 when a count throws', async () => {

--- a/src/server/routes/dataExchangeRoutes.ts
+++ b/src/server/routes/dataExchangeRoutes.ts
@@ -14,7 +14,7 @@ router.get('/stats', requirePermission('dashboard', 'read'), async (req: Request
     const messageCount = await databaseService.messages.getMessageCount(statsSourceId ?? ALL_SOURCES);
     const nodeCount = await databaseService.nodes.getNodeCount(statsSourceId ?? ALL_SOURCES);
     const channelCount = await databaseService.channels.getChannelCount(statsSourceId ?? ALL_SOURCES);
-    const messagesByDay = await databaseService.getMessagesByDayAsync(7, statsSourceId);
+    const messagesByDay = await databaseService.getMessagesByDayAsync(7, statsSourceId ?? ALL_SOURCES);
 
     res.json({
       messageCount,

--- a/src/server/routes/dataExchangeRoutes.ts
+++ b/src/server/routes/dataExchangeRoutes.ts
@@ -10,11 +10,14 @@ const router: Router = Router();
 router.get('/stats', requirePermission('dashboard', 'read'), async (req: Request, res: Response) => {
   try {
     const statsSourceId = req.query.sourceId as string | undefined;
-    // intentional cross-source: stats totals span all sources when no sourceId is specified
-    const messageCount = await databaseService.messages.getMessageCount(statsSourceId ?? ALL_SOURCES);
-    const nodeCount = await databaseService.nodes.getNodeCount(statsSourceId ?? ALL_SOURCES);
-    const channelCount = await databaseService.channels.getChannelCount(statsSourceId ?? ALL_SOURCES);
-    const messagesByDay = await databaseService.getMessagesByDayAsync(7, statsSourceId ?? ALL_SOURCES);
+    // intentional cross-source: stats totals span all sources when no sourceId is specified.
+    // Resolved once — the bug this replaced was one of four copies of this
+    // expression drifting from the other three.
+    const statsScope = statsSourceId ?? ALL_SOURCES;
+    const messageCount = await databaseService.messages.getMessageCount(statsScope);
+    const nodeCount = await databaseService.nodes.getNodeCount(statsScope);
+    const channelCount = await databaseService.channels.getChannelCount(statsScope);
+    const messagesByDay = await databaseService.getMessagesByDayAsync(7, statsScope);
 
     res.json({
       messageCount,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1699,7 +1699,11 @@ class DatabaseService {
   }
 
 
-  async getMessagesByDayAsync(days: number = 7, sourceId?: SourceScope): Promise<Array<{ date: string; count: number }>> {
+  // sourceId is REQUIRED, matching the sibling count methods (getMessageCount,
+  // getNodeCount, getChannelCount). Leaving it optional kept `undefined`
+  // expressible, which withSourceScope rejects at runtime — so the omission
+  // this fixes would have surfaced as a 500 again rather than a compile error.
+  async getMessagesByDayAsync(days: number = 7, sourceId: SourceScope): Promise<Array<{ date: string; count: number }>> {
     if (this.messagesRepo) {
       return this.messagesRepo.getMessagesByDay(days, sourceId);
     }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1699,7 +1699,7 @@ class DatabaseService {
   }
 
 
-  async getMessagesByDayAsync(days: number = 7, sourceId?: string): Promise<Array<{ date: string; count: number }>> {
+  async getMessagesByDayAsync(days: number = 7, sourceId?: SourceScope): Promise<Array<{ date: string; count: number }>> {
     if (this.messagesRepo) {
       return this.messagesRepo.getMessagesByDay(days, sourceId);
     }


### PR DESCRIPTION
## The bug

`GET /api/stats` returns **HTTP 500 / `STATS_FAILED`** for any caller that does not pass `sourceId`.

`routes/dataExchangeRoutes.ts` scopes three of its four queries with `statsSourceId ?? ALL_SOURCES`, but hands the fourth a bare `statsSourceId`:

```ts
const messageCount  = await databaseService.messages.getMessageCount(statsSourceId ?? ALL_SOURCES);
const nodeCount     = await databaseService.nodes.getNodeCount(statsSourceId ?? ALL_SOURCES);
const channelCount  = await databaseService.channels.getChannelCount(statsSourceId ?? ALL_SOURCES);
const messagesByDay = await databaseService.getMessagesByDayAsync(7, statsSourceId);   // <-- undefined
```

With `sourceId` omitted that argument is `undefined`, which `BaseRepository.withSourceScope` rejects by design:

```
withSourceScope: sourceId is required. Pass a concrete sourceId, or the
ALL_SOURCES sentinel for an intentional cross-source query. Omitting sourceId
used to silently return rows from every source (data leak).
```

The throw is caught by the route's `catch` and surfaced as a generic 500, so the endpoint fails with no hint of the cause. The comment immediately above the block states the intended behaviour — *"intentional cross-source: stats totals span all sources when no sourceId is specified"* — so this is a missed conversion, not a deliberate restriction. Only the `?sourceId=...` path ever worked; the aggregate path was dead.

## Why the type checker did not catch it

`DatabaseService.getMessagesByDayAsync` declared `sourceId?: string`, narrower than the `SourceScope` that its own `messagesRepo.getMessagesByDay` accepts. Passing the `ALL_SOURCES` symbol would not have compiled, so the correct call was not even expressible from the service. Widening the service signature to `SourceScope` fixes the leaky abstraction and keeps the service in step with the repository layer.

## Changes

- `routes/dataExchangeRoutes.ts` — pass `ALL_SOURCES` when no `sourceId` is supplied, matching the three sibling calls.
- `services/database.ts` — widen `getMessagesByDayAsync`'s `sourceId` to `SourceScope`.
- `routes/dataExchangeRoutes.test.ts` — regression test for the bare `/stats` call, asserting all four counts receive the sentinel. The existing test only exercised `/stats?sourceId=...`, which is why this went unnoticed.

## Verification

- Reproduced on a live 4.13.0 deployment: `GET /api/stats` → 500 `STATS_FAILED`, `GET /api/stats?sourceId=<id>` → 200. After the change, the bare call returns 200 with correct cross-source totals (message/node/channel counts, and a non-empty `messagesByDay`).
- The new test **fails without** the route change (`expected "vi.fn()" to be called with arguments: [ 7, Symbol(ALL_SOURCES) ]`) and passes with it.
- `npx vitest run src/server/routes/dataExchangeRoutes.test.ts` → 7 passed.
- `npx tsc --noEmit` → clean.

No behaviour change for callers that already pass `sourceId`.
