### PR TITLE
chore(release): 4.13.3-rc4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.3-rc3",
+  "version": "4.13.3-rc4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.3-rc3",
+  "version": "4.13.3-rc4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.3-rc3
-appVersion: "4.13.3-rc3"
+version: 4.13.3-rc4
+appVersion: "4.13.3-rc4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc3",
+  "version": "4.13.3-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.3-rc3",
+      "version": "4.13.3-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc3",
+  "version": "4.13.3-rc4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.13.3-rc4** across all five files: `package.json`, `package-lock.json` (regenerated via `npm install --package-lock-only`), `helm/meshmonitor/Chart.yaml` (both `version` and `appVersion`), `desktop/src-tauri/tauri.conf.json`, and `desktop/package.json`.

Diff is version lines only.

## Since rc3

**Meshtastic 2.8 / protobufs — #4466**
Submodule refreshed to `develop@6ceceae` (61 commits). Protocol tables brought in line: HardwareModel 141–143, `LORA_OTA_APP = 79`, `UA_868` marked deprecated, `DeviceMetadata.has_xeddsa` surfaced.

`MeshPacket.rx_rssi` gained explicit presence upstream, which turned a latent ambiguity into a live defect: a 2.8 node spoofing the local node at point-blank range reports `rx_rssi = 0`, no other RF marker fires, and the packet was classified as our own outgoing transmission. Fixed with a regression test on that exact case.

**Position provenance — #4467**
Node Details now states where a position came from — a GPS / Estimated / Override pill plus a ± accuracy radius (multilateration uncertainty for an estimate, the precision-bits half-cell for a coarse fix). On this install that covers 481 nodes that were previously showing estimates indistinguishable from real GPS fixes.

**Null Island estimates — #4469**
Found by the pill above. Migration 107 had cleared bogus (0,0) fixes from `nodes` but never swept `estimated_positions`, so those nodes fell through to a Null Island *estimate* — re-substituting the exact coordinates 107 removed. Migration 134 purges the stored rows, the estimator no longer generates them, and the display gate now accepts a genuine equator or prime-meridian coordinate instead of treating a zero as "unpositioned".

**MeshCore Analyzer Observer — #4464 / #4468 / #4471**
Phases 1–3: backend foundation, publisher service, UI and docs.

## Testing

Full Vitest suite on the merge base: **13,390 passed, 0 failed**, 109 skipped, run with PostgreSQL and MySQL containers up so the multi-backend suites actually executed. `tsc --noEmit` clean, `npm run lint:ci` passes.

Labelled `system-test` per release-chore convention — this bump carries a database migration (134) and the 2.8 protobuf pin, both of which the hardware legs exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB