### PR TITLE
fix(meshcore): preserve hop/route/scope info in channel message history

### DIFF
--- a/src/server/meshcoreManager.channelMessagesFields.test.ts
+++ b/src/server/meshcoreManager.channelMessagesFields.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for #4474 — MeshCore hop-count/route-path/scope info
+ * disappearing on older messages.
+ *
+ * `MeshCoreManager.getChannelMessages` serves the per-channel history endpoint
+ * (`/api/sources/:id/meshcore/messages/channel/:idx`), used for both the
+ * initial channel load and infinite-scroll "load older" (#4460). Unlike the
+ * in-memory recent-tail (`getRecentMessages`, populated live and already
+ * carrying these fields), this method re-hydrates from the DB row
+ * (`DbMeshCoreMessage`) and must forward `hopCount` / `routePath` /
+ * `scopeCode` / `scopeName` onto the API-shaped `MeshCoreMessage` it returns —
+ * otherwise messages loaded from history render without the route info that
+ * was visible when they first arrived live.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+
+describe('MeshCoreManager.getChannelMessages field passthrough (#4474)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards hopCount/routePath/scopeCode/scopeName from the DB row', async () => {
+    const m = new MeshCoreManager('test-source');
+    vi.spyOn(databaseService.meshcore, 'getChannelMessages').mockResolvedValue([
+      {
+        id: 'a',
+        fromPublicKey: 'channel-0',
+        toPublicKey: 'channel-0',
+        text: 'hi',
+        timestamp: 1000,
+        createdAt: 1000,
+        hopCount: 2,
+        routePath: 'a3,7f',
+        scopeCode: 5,
+        scopeName: 'TestRegion',
+      },
+    ]);
+    vi.spyOn(databaseService.meshcore, 'getHeardRepeatersForMessages').mockResolvedValue({});
+
+    const [message] = await m.getChannelMessages(0, 100, 0);
+
+    expect(message.hopCount).toBe(2);
+    expect(message.routePath).toBe('a3,7f');
+    expect(message.scopeCode).toBe(5);
+    expect(message.scopeName).toBe('TestRegion');
+  });
+
+  it('defaults route fields to null when the DB row has none (direct/unknown)', async () => {
+    const m = new MeshCoreManager('test-source');
+    vi.spyOn(databaseService.meshcore, 'getChannelMessages').mockResolvedValue([
+      {
+        id: 'b',
+        fromPublicKey: 'channel-0',
+        toPublicKey: 'channel-0',
+        text: 'direct',
+        timestamp: 2000,
+        createdAt: 2000,
+      },
+    ]);
+    vi.spyOn(databaseService.meshcore, 'getHeardRepeatersForMessages').mockResolvedValue({});
+
+    const [message] = await m.getChannelMessages(0, 100, 0);
+
+    expect(message.hopCount).toBeNull();
+    expect(message.routePath).toBeNull();
+    expect(message.scopeCode).toBeNull();
+    expect(message.scopeName).toBeNull();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5926,6 +5926,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         rssi: dbMsg.rssi ?? undefined,
         snr: dbMsg.snr ?? undefined,
         sourceId: dbMsg.sourceId ?? undefined,
+        hopCount: dbMsg.hopCount ?? null,
+        routePath: dbMsg.routePath ?? null,
+        scopeCode: dbMsg.scopeCode ?? null,
+        scopeName: dbMsg.scopeName ?? null,
         heardBy: heard && heard.length > 0
           ? heard.map(r => ({ hash: r.repeaterHash, name: r.repeaterName, snr: r.snr }))
           : undefined,


### PR DESCRIPTION
Fixes #4474

## Summary
- `MeshCoreManager.getChannelMessages` backs the `/api/sources/:id/meshcore/messages/channel/:idx` endpoint, used for both the initial per-channel message load and the infinite-scroll "load older" pagination (#4460/#4461).
- Its DB-row → API mapping dropped `hopCount`, `routePath`, `scopeCode`, and `scopeName`, even though these are persisted columns on `meshcore_messages`.
- Live messages come from a separate in-memory pool (populated on receive, and correctly re-hydrated with these fields on `connect()`), which is why hop/path/scope info showed up on a message right when it arrived, then disappeared once that message was instead paginated in from history — matching the reported "disappears on older messages" behavior.
- Fix: forward `hopCount` / `routePath` / `scopeCode` / `scopeName` from the DB row in `getChannelMessages`, mirroring the mapping already done in `connect()`'s DB rehydration.

## Test plan
- [x] Added `src/server/meshcoreManager.channelMessagesFields.test.ts` — regression test asserting `getChannelMessages` forwards these fields (and defaults to `null` when the DB row has none).
- [x] `npx vitest run src/server/meshcoreManager*.test.ts src/server/routes/meshcoreRoutes.test.ts src/db/repositories/meshcore.test.ts` — 43 files / 607 tests passed.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint:ci` — clean (no new ratchet violations).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wpq1d3ZYDGqgJ4SJ5WrKJG)_