### PR TITLE
fix(messaging): stop older-message loads from force-scrolling to bottom

### DIFF
--- a/src/hooks/useMessagingView.test.ts
+++ b/src/hooks/useMessagingView.test.ts
@@ -308,4 +308,105 @@ describe('useMessagingView', () => {
       expect(ids).toEqual(['old-1', 'newer-1']);
     });
   });
+
+  describe('regression: loading older messages must not force-scroll to bottom (#4476)', () => {
+    // Bug: GATED EFFECT #1 scrolled the channel container to the bottom on
+    // *any* channelMessages change, including loadMoreChannelMessages
+    // prepending older history — so every scroll-up-to-load-more was
+    // immediately yanked back down. The fix gates the forced scroll to fire
+    // once per channel/tab entry, tracked via a ref that only resets on
+    // selectedChannel/activeTab change.
+    function fakeContainer(overrides: Partial<HTMLDivElement> = {}) {
+      return {
+        scrollHeight: 100,
+        clientHeight: 500,
+        scrollTop: 0,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        ...overrides,
+      } as unknown as HTMLDivElement;
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not reset scrollTop when older messages are prepended after the initial entry scroll', async () => {
+      const { result } = renderHook(() => useMessagingView());
+
+      const container = fakeContainer({ scrollHeight: 1000, scrollTop: 500 });
+
+      act(() => {
+        result.current.channelMessagesContainerRef.current = container;
+        result.current.setChannelMessages({ 0: [makeMessage({ id: 'newer-1' })] });
+      });
+
+      // Let the entry-scroll effect run and consume the pending flag.
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+        await Promise.resolve();
+      });
+
+      // Simulate the user having scrolled up to read history.
+      container.scrollTop = 200;
+
+      // Now simulate loadMoreChannelMessages prepending an older page —
+      // this changes channelMessages just like a real infinite-scroll load.
+      act(() => {
+        result.current.setChannelMessages({
+          0: [makeMessage({ id: 'old-1', timestamp: new Date(0) }), makeMessage({ id: 'newer-1' })],
+        });
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+        await Promise.resolve();
+      });
+
+      // The bug forced scrollTop back to scrollHeight (1000) here; the fix
+      // leaves the user's scroll position alone.
+      expect(container.scrollTop).toBe(200);
+    });
+
+    it('still scrolls to bottom once when the channel/tab is (re-)entered', async () => {
+      const { result, rerender } = renderHook(
+        ({ activeTab }: { activeTab: string }) => {
+          mockUseUI.mockReturnValue({ activeTab });
+          return useMessagingView();
+        },
+        { initialProps: { activeTab: 'channels' } }
+      );
+
+      const container = fakeContainer({ scrollHeight: 1000, scrollTop: 0 });
+
+      act(() => {
+        result.current.channelMessagesContainerRef.current = container;
+        result.current.setChannelMessages({ 0: [makeMessage({ id: 'newer-1' })] });
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+        await Promise.resolve();
+      });
+
+      expect(container.scrollTop).toBe(1000);
+
+      // Leave the channels tab and simulate the user having scrolled away,
+      // then re-enter — the one-time scroll should re-arm.
+      container.scrollTop = 0;
+      rerender({ activeTab: 'messages' });
+      rerender({ activeTab: 'channels' });
+
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+        await Promise.resolve();
+      });
+
+      expect(container.scrollTop).toBe(1000);
+    });
+  });
 });

--- a/src/hooks/useMessagingView.ts
+++ b/src/hooks/useMessagingView.ts
@@ -358,16 +358,30 @@ export function useMessagingView() {
     };
   }, [handleChannelScroll, handleDMScroll, activeTab, selectedChannel, selectedDMNode]);
 
-  // Force scroll to bottom when channel changes OR when switching to channels tab
-  // Note: We track initial scroll per channel to avoid re-scrolling when user manually scrolls
+  // Force scroll to bottom when channel changes OR when switching to channels tab.
+  // `channelMessages` has to stay a dependency because messages for a
+  // freshly-selected channel can still be in flight (poll hasn't landed
+  // yet) at the moment selectedChannel/activeTab change — but that means
+  // this effect also re-fires for reasons that AREN'T a channel/tab switch,
+  // e.g. loadMoreChannelMessages prepending older history while scrolled up,
+  // which without the pending-flag below would yank the view back to the
+  // bottom on every older-page load (#4476). pendingChannelScrollRef tracks
+  // whether the one-time scroll for the *current* channel/tab entry has
+  // already happened, and is only reset by the entry effect right below.
   // [GATED EFFECT #1 — task54_spec.md §1.3]
+  const pendingChannelScrollRef = useRef(true);
   useEffect(() => {
-    if (activeTab === 'channels' && selectedChannel >= 0) {
+    pendingChannelScrollRef.current = true;
+  }, [selectedChannel, activeTab]);
+
+  useEffect(() => {
+    if (activeTab === 'channels' && selectedChannel >= 0 && pendingChannelScrollRef.current) {
       const currentChannelMessages = channelMessages[selectedChannel] || [];
       const hasMessages = currentChannelMessages.length > 0;
 
-      // Always scroll to bottom when entering the channels tab or changing channels
+      // Scroll to bottom once when entering the channels tab or changing channels.
       if (hasMessages) {
+        pendingChannelScrollRef.current = false;
         // Use setTimeout to ensure messages are rendered before scrolling
         setTimeout(() => {
           if (channelMessagesContainerRef.current) {
@@ -465,10 +479,20 @@ export function useMessagingView() {
     }
   }, [selectedChannel, activeTab, channelLoadingMore, channelHasMore, loadMoreChannelMessages]);
 
-  // Force scroll to bottom when DM node changes OR when switching to messages tab
+  // Force scroll to bottom when DM node changes OR when switching to messages tab.
+  // Same one-time-per-entry gating as GATED EFFECT #1 above, and for the same
+  // reason (#4476): `messages` must stay a dependency so a still-in-flight
+  // initial fetch can still trigger the scroll, but without the pending flag
+  // loadMoreDirectMessages prepending older history would re-trigger this on
+  // every older-page load and yank the view back to the bottom.
   // [GATED EFFECT #4 — task54_spec.md §1.3]
+  const pendingDMScrollRef = useRef(true);
   useEffect(() => {
-    if (activeTab === 'messages' && selectedDMNode && currentNodeId) {
+    pendingDMScrollRef.current = true;
+  }, [selectedDMNode, activeTab]);
+
+  useEffect(() => {
+    if (activeTab === 'messages' && selectedDMNode && currentNodeId && pendingDMScrollRef.current) {
       const currentDMMessages = messages.filter(
         msg =>
           (msg.fromNodeId === currentNodeId && msg.toNodeId === selectedDMNode) ||
@@ -476,8 +500,9 @@ export function useMessagingView() {
       );
       const hasMessages = currentDMMessages.length > 0;
 
-      // Always scroll to bottom when entering the messages tab or changing conversations
+      // Scroll to bottom once when entering the messages tab or changing conversations
       if (hasMessages) {
+        pendingDMScrollRef.current = false;
         setTimeout(() => {
           if (dmMessagesContainerRef.current) {
             dmMessagesContainerRef.current.scrollTop = dmMessagesContainerRef.current.scrollHeight;


### PR DESCRIPTION
## Summary

Fixes #4476 — scrolling up in a Meshtastic channel (or DM conversation) to load older messages immediately snapped the view back to the bottom, every time, making it impossible to actually read history.

Root cause: in `src/hooks/useMessagingView.ts`, the "scroll to bottom on channel/DM entry" effects (`GATED EFFECT #1` and `GATED EFFECT #4`) depend on `channelMessages`/`messages` so a still-in-flight initial fetch can still trigger the entry scroll after a channel/tab switch. But that dependency also makes the effects re-fire on **every** messages-array change — including `loadMoreChannelMessages`/`loadMoreDirectMessages` prepending an older page during infinite scroll. Those loaders already restore scroll position correctly via `requestAnimationFrame`, but ~100–150ms later the entry-scroll effect fires again and unconditionally sets `scrollTop = scrollHeight`, undoing it.

- `src/hooks/useMessagingView.ts` — gate both entry-scroll effects behind a ref (`pendingChannelScrollRef` / `pendingDMScrollRef`) that's only reset when `selectedChannel`/`selectedDMNode` or `activeTab` actually changes. Later messages-array updates from pagination or new poll messages no longer re-trigger the forced scroll; the existing "auto-scroll on new message only if already near bottom" effects are untouched and still handle the live-update case.

## Test plan

- [x] New regression test: scroll position survives an older-page load after the initial entry scroll has already happened
- [x] New regression test: the entry-scroll still fires once when the channel/tab is (re-)entered
- [x] `npx vitest run src/hooks/useMessagingView.test.ts` — 10/10 pass
- [x] `npx vitest run src/hooks/` — 427/427 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint:ci` — clean (no FAIL lines outside `.claude/worktrees`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzheBuAewE6kNeeEa21v7z)_