### PR TITLE
fix(admin): send admin messages at the node's configured hop limit

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -48,7 +48,7 @@ import { UiIcon } from '../components/icons';
 
 
 // Protocol max for `hop_limit` (3-bit field). IMPORTANT: this value must match
-// MAX_HOP_LIMIT in src/server/mqttBrokerManager.ts, which the source-save
+// MAX_HOP_LIMIT in src/server/constants/meshtastic.ts, which the source-save
 // endpoint validates against. Duplicated rather than imported — pages must not
 // pull from src/server.
 const MAX_HOP_LIMIT = 7;

--- a/src/server/constants/meshtastic.test.ts
+++ b/src/server/constants/meshtastic.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isViaMqtt, TransportMechanism, getTransportMechanismName, RoutingError, isPkiError, getPortNumName, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isValidNodeNum, MAX_NODE_NUM } from './meshtastic.js';
+import { isViaMqtt, TransportMechanism, getTransportMechanismName, RoutingError, isPkiError, getPortNumName, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isValidNodeNum, MAX_NODE_NUM, resolveHopLimit, DEFAULT_HOP_LIMIT, MAX_HOP_LIMIT } from './meshtastic.js';
 
 describe('isViaMqtt', () => {
   it('should return true for MQTT transport mechanism', () => {
@@ -207,5 +207,39 @@ describe('isValidNodeNum', () => {
     expect(isValidNodeNum(null)).toBe(false);
     expect(isValidNodeNum(undefined)).toBe(false);
     expect(isValidNodeNum({})).toBe(false);
+  });
+});
+
+describe('resolveHopLimit', () => {
+  it('passes through valid configured values', () => {
+    for (let hops = 0; hops <= MAX_HOP_LIMIT; hops++) {
+      expect(resolveHopLimit(hops)).toBe(hops);
+    }
+  });
+
+  it('passes an explicit 0 through rather than promoting it to the default', () => {
+    // Firmware honors a configured 0 for its own sends. Note a real device
+    // configured to 0 arrives as null (proto3 omits zero scalars), so this
+    // exact input only comes from an explicit caller — see the null case below.
+    expect(resolveHopLimit(0)).toBe(0);
+  });
+
+  it('falls back to the firmware default when config has not arrived', () => {
+    // Proto3 omits an unset hop_limit, so it decodes as null/undefined here —
+    // which is also how a genuinely-zero device config reaches us.
+    expect(resolveHopLimit(undefined)).toBe(DEFAULT_HOP_LIMIT);
+    expect(resolveHopLimit(null)).toBe(DEFAULT_HOP_LIMIT);
+  });
+
+  it('clamps above-protocol values to the 3-bit max', () => {
+    expect(resolveHopLimit(8)).toBe(MAX_HOP_LIMIT);
+    expect(resolveHopLimit(255)).toBe(MAX_HOP_LIMIT);
+  });
+
+  it('rejects negative, fractional, and non-numeric values', () => {
+    expect(resolveHopLimit(-1)).toBe(DEFAULT_HOP_LIMIT);
+    expect(resolveHopLimit(2.5)).toBe(DEFAULT_HOP_LIMIT);
+    expect(resolveHopLimit(NaN)).toBe(DEFAULT_HOP_LIMIT);
+    expect(resolveHopLimit('5' as unknown as number)).toBe(DEFAULT_HOP_LIMIT);
   });
 });

--- a/src/server/constants/meshtastic.ts
+++ b/src/server/constants/meshtastic.ts
@@ -367,6 +367,44 @@ export const MIN_TRACEROUTE_INTERVAL_MS = 30 * 1000;
 export const MAX_MESSAGE_BYTES = 200;
 
 /**
+ * Protocol max for `hop_limit` — it is a 3-bit field (`HOP_MAX` in firmware).
+ */
+export const MAX_HOP_LIMIT = 7;
+
+/**
+ * Fallback hop limit for packets we build before the device's LoRa config has
+ * arrived. Matches the firmware default (`config.lora.hop_limit` = 3).
+ *
+ * Prefer the node's own configured value when it is known — see
+ * {@link resolveHopLimit} and `MeshtasticManager.getConfiguredHopLimit()`.
+ */
+export const DEFAULT_HOP_LIMIT = 3;
+
+/**
+ * Normalize a hop limit read from device config into a value safe to put on the
+ * wire, falling back to {@link DEFAULT_HOP_LIMIT} when it is unknown or invalid.
+ *
+ * An explicit `0` is passed through — firmware honors a configured 0 for its own
+ * packets (`Router::send` → `Default::getConfiguredOrDefaultHopLimit`, which
+ * returns `config.lora.hop_limit` as-is below `HOP_MAX`).
+ *
+ * Caveat: a device that IS configured to 0 does not reach us as `0`. Proto3
+ * omits zero scalars, so protobuf.js decodes the field to `null` and it is
+ * indistinguishable from "config hasn't arrived" — both take the default of 3
+ * here. That ambiguity is unavoidable on the wire and self-correcting in
+ * practice: firmware rewrites an inbound `hop_limit == 0` on a `want_ack`
+ * packet from the phone API back to the node's own configured value
+ * (`Router.cpp`), so nothing we send at 0 escapes at the wrong depth.
+ */
+export function resolveHopLimit(configured: number | undefined | null): number {
+  if (typeof configured !== 'number' || !Number.isInteger(configured)) {
+    return DEFAULT_HOP_LIMIT;
+  }
+  if (configured < 0) return DEFAULT_HOP_LIMIT;
+  return Math.min(configured, MAX_HOP_LIMIT);
+}
+
+/**
  * Maximum valid Meshtastic node number.
  *
  * `nodeNum` is a 32-bit unsigned integer in the Meshtastic protocol — values

--- a/src/server/meshtasticManager.adminHopLimit.test.ts
+++ b/src/server/meshtasticManager.adminHopLimit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `getConfiguredHopLimit()` — the local node's own `lora.hopLimit`, read from
+ * the in-memory device config.
+ *
+ * Admin packets used to be built with a hardcoded `hopLimit: 3`, so a user who
+ * raised their node's hop limit to reach a deeper mesh still had every remote
+ * admin command expire 3 hops out. This accessor is what the admin send paths
+ * read instead; it mirrors `isTxEnabled()`'s shape (in-memory config, no DB
+ * access, safe per packet).
+ *
+ * The mock set below mirrors `meshtasticManager.txDisabled.test.ts` — enough to
+ * construct a manager without touching a socket, a DB, or a real TCP port.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const { VNConstructor } = vi.hoisted(() => ({
+  VNConstructor: vi.fn(function (this: any, _opts: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    messages: { insertMessage: vi.fn().mockResolvedValue(true) },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+    markMessageAsReadAsync: vi.fn().mockResolvedValue(true),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array()),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array()),
+    createTextMessage: vi.fn(() => ({ data: new Uint8Array([1, 2, 3]), messageId: 12345 })),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+vi.mock('./services/packetLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+  packetLogService: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { MeshtasticManager } from './meshtasticManager.js';
+import { DEFAULT_HOP_LIMIT, MAX_HOP_LIMIT } from './constants/meshtastic.js';
+
+function makeManager(lora?: Record<string, unknown>): MeshtasticManager {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  if (lora !== undefined) {
+    (mgr as any).actualDeviceConfig = { lora };
+  }
+  return mgr;
+}
+
+describe('MeshtasticManager.getConfiguredHopLimit()', () => {
+  it('falls back to the firmware default when no device config has arrived yet', () => {
+    const mgr = makeManager();
+    expect((mgr as any).actualDeviceConfig).toBeNull();
+    expect(mgr.getConfiguredHopLimit()).toBe(DEFAULT_HOP_LIMIT);
+  });
+
+  it('falls back to the firmware default when lora config exists but hopLimit is absent', () => {
+    // Proto3 omits an unset hop_limit, so the field reads back undefined.
+    expect(makeManager({}).getConfiguredHopLimit()).toBe(DEFAULT_HOP_LIMIT);
+  });
+
+  it('returns the configured hop limit when the device reports one', () => {
+    expect(makeManager({ hopLimit: 5 }).getConfiguredHopLimit()).toBe(5);
+    expect(makeManager({ hopLimit: 7 }).getConfiguredHopLimit()).toBe(7);
+  });
+
+  it('passes an explicit 0 through', () => {
+    // Reachable only if a decode ever surfaces a literal 0; a real device
+    // configured to 0 omits the field (proto3) and lands on the default above.
+    expect(makeManager({ hopLimit: 0 }).getConfiguredHopLimit()).toBe(0);
+  });
+
+  it('clamps a nonsense above-protocol value to the 3-bit max', () => {
+    expect(makeManager({ hopLimit: 42 }).getConfiguredHopLimit()).toBe(MAX_HOP_LIMIT);
+  });
+
+  it('reflects a config update without needing a reconnect', () => {
+    const mgr = makeManager({ hopLimit: 3 });
+    expect(mgr.getConfiguredHopLimit()).toBe(3);
+    (mgr as any).actualDeviceConfig = { lora: { hopLimit: 6 } };
+    expect(mgr.getConfiguredHopLimit()).toBe(6);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -61,7 +61,7 @@ import { migrateAutomationChannels } from './utils/automationChannelMigration.js
 import { detectChannelMoves } from './utils/channelMoveDetection.js';
 import { detectLocalNodeSpoof, SentPacketIdCache, type SpoofDetectionResult } from './utils/spoofDetection.js';
 import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
-import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, resolveRadioPacketTransport, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isUdpBroadcastEnabled } from './constants/meshtastic.js';
+import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, resolveRadioPacketTransport, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isUdpBroadcastEnabled, resolveHopLimit } from './constants/meshtastic.js';
 import { normalizeChannelRole } from './constants/channelRole.js';
 import { createRequire } from 'module';
 import { validateCron, scheduleCron, type CronJob } from './utils/cronScheduler.js';
@@ -9094,6 +9094,23 @@ class MeshtasticManager implements ISourceManager {
    */
   isTxEnabled(): boolean {
     return this.actualDeviceConfig?.lora?.txEnabled !== false;
+  }
+
+  /**
+   * The hop limit THIS node is configured to use for its own outgoing packets,
+   * read from the in-memory device config. Falls back to the firmware default
+   * (3) when the LoRa config hasn't arrived yet. No DB access — safe to call
+   * per packet.
+   *
+   * Packets we build and hand to the radio carry whatever `hop_limit` we set;
+   * the firmware does not substitute the user's setting for us. Meshtastic
+   * Python resolves it client-side the same way (`mesh_interface.py`
+   * `_sendPacket` reads `localConfig.lora.hop_limit` when the caller passes
+   * none), which is why admin commands there reach nodes further than 3 hops
+   * out and ours did not.
+   */
+  getConfiguredHopLimit(): number {
+    return resolveHopLimit(this.actualDeviceConfig?.lora?.hopLimit);
   }
 
   /**

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -21,6 +21,7 @@ import type { Source } from '../db/repositories/sources.js';
 import { loadAllNodesAsDeviceInfo } from './utils/dbNodeMapper.js';
 import type { DeviceInfo } from './meshtasticManager.js';
 import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
+import { MAX_HOP_LIMIT } from './constants/meshtastic.js';
 import { logger } from '../utils/logger.js';
 
 export interface MqttBrokerSourceConfig {
@@ -61,8 +62,12 @@ export interface MqttBrokerSourceConfig {
   downlinkHopLimitOverride?: number;
 }
 
-/** Protocol max for `hop_limit` — it is a 3-bit field (`HOP_MAX` in firmware). */
-export const MAX_HOP_LIMIT = 7;
+/**
+ * Protocol max for `hop_limit`. Re-exported from `constants/meshtastic.ts`,
+ * which is the canonical home; kept here so existing importers (sourceRoutes)
+ * keep working.
+ */
+export { MAX_HOP_LIMIT };
 
 /**
  * Resolve the effective downlink hop-limit override for a broker config, or

--- a/src/server/protobufService.adminHopLimit.test.ts
+++ b/src/server/protobufService.adminHopLimit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Admin packets must carry the local node's CONFIGURED hop limit, not a
+ * hardcoded 3.
+ *
+ * The builder used to pin `hopLimit: 3` — the firmware default — so a user who
+ * raised `lora.hop_limit` to reach a deep mesh still had every remote admin
+ * command die 3 hops out with no indication why. Meshtastic Python resolves
+ * this client-side (`mesh_interface.py` `_sendPacket` falls back to
+ * `localConfig.lora.hop_limit` when the caller passes none); these tests pin
+ * the same behavior on our side.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import protobufService from './protobufService.js';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+import { DEFAULT_HOP_LIMIT, MAX_HOP_LIMIT } from './constants/meshtastic.js';
+
+/** Decode a ToRadio admin packet back to its MeshPacket. */
+function decodePacket(encoded: Uint8Array): any {
+  const root = getProtobufRoot()!;
+  const ToRadio = root.lookupType('meshtastic.ToRadio');
+  return (ToRadio.decode(encoded) as any).packet;
+}
+
+describe('createAdminPacket hop limit', () => {
+  const payload = new Uint8Array([1, 2, 3]);
+
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  it('uses the caller-supplied hop limit', () => {
+    const packet = decodePacket(protobufService.createAdminPacket(payload, 0xaabbccdd, 0x11223344, 7));
+    expect(packet.hopLimit).toBe(7);
+  });
+
+  it('falls back to the firmware default when no hop limit is supplied', () => {
+    const packet = decodePacket(protobufService.createAdminPacket(payload, 0xaabbccdd, 0x11223344));
+    expect(packet.hopLimit).toBe(DEFAULT_HOP_LIMIT);
+  });
+
+  it('falls back to the firmware default when config has not arrived (undefined)', () => {
+    const packet = decodePacket(protobufService.createAdminPacket(payload, 0xaabbccdd, 0x11223344, undefined));
+    expect(packet.hopLimit).toBe(DEFAULT_HOP_LIMIT);
+  });
+
+  it('clamps above-protocol values to MAX_HOP_LIMIT', () => {
+    const packet = decodePacket(protobufService.createAdminPacket(payload, 0xaabbccdd, 0x11223344, 99));
+    expect(packet.hopLimit).toBe(MAX_HOP_LIMIT);
+  });
+
+  it('passes an explicit 0 through rather than promoting it to the default', () => {
+    // Proto3 omits a zero hopLimit, so it decodes back as null/undefined — the
+    // assertion is that it was NOT silently rewritten to 3. Firmware itself
+    // rewrites an inbound want_ack packet at hop_limit 0 to the node's own
+    // configured value, so this is safe on the wire either way.
+    const packet = decodePacket(protobufService.createAdminPacket(payload, 0xaabbccdd, 0x11223344, 0));
+    expect(packet.hopLimit ?? 0).toBe(0);
+  });
+
+  it('applies the same resolution to createAdminPacketWithId', () => {
+    const { data, packetId } = protobufService.createAdminPacketWithId(payload, 0xaabbccdd, 0x11223344, 5);
+    expect(packetId).toBeGreaterThan(0);
+    expect(decodePacket(data).hopLimit).toBe(5);
+  });
+
+  it('leaves the rest of the admin packet shape untouched', () => {
+    const packet = decodePacket(protobufService.createAdminPacket(payload, 0xaabbccdd, 0x11223344, 6));
+    expect(packet.to).toBe(0xaabbccdd);
+    expect(packet.from).toBe(0x11223344);
+    expect(packet.wantAck).toBe(true);
+    expect(packet.priority).toBe(70);
+    expect(packet.pkiEncrypted).toBe(true);
+    expect(packet.decoded.portnum).toBe(6); // ADMIN_APP
+    expect(packet.decoded.wantResponse).toBe(true);
+  });
+});

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { getProtobufRoot } from './protobufLoader.js';
 import { buildSharedContactPayload } from './services/sharedContactService.js';
 import { logger } from '../utils/logger.js';
-import { PortNum } from './constants/meshtastic.js';
+import { PortNum, resolveHopLimit } from './constants/meshtastic.js';
 import { MODULE_FIELD_BY_ID } from './constants/configTypes.js';
 
 export interface MeshtasticPosition {
@@ -1883,9 +1883,11 @@ class ProtobufService {
    * @param adminMessagePayload The encoded admin message
    * @param destination Optional destination node number (0 for local node)
    * @param fromNodeNum Optional source node number (required for proper packet routing)
+   * @param hopLimit Optional hop limit; pass the local node's configured
+   *   `lora.hopLimit` for remote admin. Defaults to DEFAULT_HOP_LIMIT.
    */
-  createAdminPacket(adminMessagePayload: Uint8Array, destination: number = 0, fromNodeNum?: number): Uint8Array {
-    return this.createAdminPacketWithId(adminMessagePayload, destination, fromNodeNum).data;
+  createAdminPacket(adminMessagePayload: Uint8Array, destination: number = 0, fromNodeNum?: number, hopLimit?: number): Uint8Array {
+    return this.createAdminPacketWithId(adminMessagePayload, destination, fromNodeNum, hopLimit).data;
   }
 
   /**
@@ -1893,7 +1895,7 @@ class ProtobufService {
    * caller can correlate the inbound routing ACK (Routing.request_id === id).
    * Used by the ACK-aware admin send path (issue #2608 follow-up).
    */
-  createAdminPacketWithId(adminMessagePayload: Uint8Array, destination: number = 0, fromNodeNum?: number): { data: Uint8Array; packetId: number } {
+  createAdminPacketWithId(adminMessagePayload: Uint8Array, destination: number = 0, fromNodeNum?: number, hopLimit?: number): { data: Uint8Array; packetId: number } {
     try {
       const root = getProtobufRoot();
       const ToRadio = root?.lookupType('meshtastic.ToRadio');
@@ -1916,12 +1918,19 @@ class ProtobufService {
       const packetId = Math.floor(Math.random() * 0xFFFFFFFF) + 1;
       logger.debug(`🔍 Generated packet ID: ${packetId} (0x${packetId.toString(16)})`);
 
+      // Honor the local node's configured hop limit when the caller supplies it.
+      // Meshtastic Python does the same (mesh_interface.py `_sendPacket` falls
+      // back to `localConfig.lora.hop_limit`), so a node configured for a deep
+      // mesh can actually reach its remote admin targets. Falls back to the
+      // firmware default when config hasn't arrived yet.
+      const effectiveHopLimit = resolveHopLimit(hopLimit);
+
       const meshPacketData: any = {
         id: packetId,
         to: destination,
         decoded: dataMsg,
         channel: 0,
-        hopLimit: 3,
+        hopLimit: effectiveHopLimit,
         wantAck: true,
         priority: 70,  // RELIABLE priority
         pkiEncrypted: true  // Python CLI sets this flag even with plaintext admin messages
@@ -1943,7 +1952,7 @@ class ProtobufService {
       });
 
       const encoded = ToRadio.encode(toRadio).finish();
-      logger.debug(`📤 Created admin ToRadio packet (destination: ${destination})`);
+      logger.debug(`📤 Created admin ToRadio packet (destination: ${destination}, hopLimit: ${effectiveHopLimit})`);
       logger.debug('🔍 ToRadio bytes:', Array.from(encoded).map(b => b.toString(16).padStart(2, '0')).join(' '));
       return { data: encoded, packetId };
     } catch (error) {

--- a/src/server/services/adminTransactionService.test.ts
+++ b/src/server/services/adminTransactionService.test.ts
@@ -29,15 +29,18 @@ import { AdminTransactionService } from './adminTransactionService.js';
 function makeFakeManager(overrides: Partial<{
   transportReady: boolean;
   localNodeInfo: { nodeNum: number } | null;
+  hopLimit: number;
 }> = {}) {
   const state = {
     transportReady: overrides.transportReady ?? true,
     localNodeInfo: overrides.localNodeInfo === undefined ? { nodeNum: 111 } : overrides.localNodeInfo,
+    hopLimit: overrides.hopLimit ?? 3,
   };
   return {
     state,
     isTransportReady: vi.fn(() => state.transportReady),
     getLocalNodeInfo: vi.fn(() => state.localNodeInfo),
+    getConfiguredHopLimit: vi.fn(() => state.hopLimit),
     sendLocalAdminPacket: vi.fn().mockResolvedValue(undefined),
     logOutgoingPacket: vi.fn().mockResolvedValue(undefined),
   };
@@ -71,7 +74,7 @@ describe('AdminTransactionService', () => {
       const svc = new AdminTransactionService(mgr as any);
 
       await svc.sendAdminCommand(new Uint8Array([9]), 222);
-      expect(createAdminPacket).toHaveBeenCalledWith(expect.any(Uint8Array), 222, 111);
+      expect(createAdminPacket).toHaveBeenCalledWith(expect.any(Uint8Array), 222, 111, 3);
       expect(mgr.sendLocalAdminPacket).toHaveBeenCalledWith(expect.any(Uint8Array));
       expect(mgr.logOutgoingPacket).toHaveBeenCalledWith(
         6, 222, 0, expect.any(String), { destinationNodeNum: 222, isRemoteAdmin: true },
@@ -84,6 +87,16 @@ describe('AdminTransactionService', () => {
 
       await svc.sendAdminCommand(new Uint8Array([9]), 111);
       expect(mgr.logOutgoingPacket).not.toHaveBeenCalled();
+    });
+
+    it('sends admin commands at the node\'s CONFIGURED hop limit, not a hardcoded 3', async () => {
+      // A node configured for a deep mesh must be able to admin nodes further
+      // than the firmware default of 3 hops away.
+      const mgr = makeFakeManager({ hopLimit: 7 });
+      const svc = new AdminTransactionService(mgr as any);
+
+      await svc.sendAdminCommand(new Uint8Array([9]), 222);
+      expect(createAdminPacket).toHaveBeenCalledWith(expect.any(Uint8Array), 222, 111, 7);
     });
   });
 
@@ -136,6 +149,18 @@ describe('AdminTransactionService', () => {
 
       const result = await svc.sendAdminCommandAwaitAck(new Uint8Array([1]), 222, 5000);
       expect(result).toEqual({ packetId: 557, acked: true, errorReason: 0, timedOut: false });
+    });
+
+    it('builds the ack-aware packet at the node\'s configured hop limit', async () => {
+      createAdminPacketWithId.mockReturnValue({ data: new Uint8Array([1]), packetId: 558 });
+      const mgr = makeFakeManager({ hopLimit: 5 });
+      const svc = new AdminTransactionService(mgr as any);
+
+      const pending = svc.sendAdminCommandAwaitAck(new Uint8Array([1]), 222, 5000);
+      expect(createAdminPacketWithId).toHaveBeenCalledWith(expect.any(Uint8Array), 222, 111, 5);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await pending;
     });
   });
 

--- a/src/server/services/adminTransactionService.ts
+++ b/src/server/services/adminTransactionService.ts
@@ -82,7 +82,8 @@ export class AdminTransactionService {
       const adminPacket = protobufService.createAdminPacket(
         adminMessagePayload,
         destinationNodeNum,
-        localNodeNum
+        localNodeNum,
+        this.mgr.getConfiguredHopLimit()
       );
 
       await this.mgr.sendLocalAdminPacket(adminPacket);
@@ -175,7 +176,8 @@ export class AdminTransactionService {
     const { data: adminPacket, packetId } = protobufService.createAdminPacketWithId(
       adminMessagePayload,
       destinationNodeNum,
-      localNodeNum
+      localNodeNum,
+      this.mgr.getConfiguredHopLimit()
     );
 
     // Register the waiter BEFORE sending so a fast ACK can't be missed.

--- a/src/server/services/remoteAdminService.test.ts
+++ b/src/server/services/remoteAdminService.test.ts
@@ -53,6 +53,7 @@ function makeFakeManager(overrides: Partial<{
   txEnabled: boolean;
   /** #4394: `network.enabledProtocols & UDP_BROADCAST` — a LAN peer relays our sends. */
   udpRelayEnabled: boolean;
+  hopLimit: number;
 }> = {}) {
   const state = {
     transportReady: overrides.transportReady ?? true,
@@ -66,6 +67,7 @@ function makeFakeManager(overrides: Partial<{
     moduleConfigsEverFetched: false,
     txEnabled: overrides.txEnabled ?? true,
     udpRelayEnabled: overrides.udpRelayEnabled ?? false,
+    hopLimit: overrides.hopLimit ?? 3,
   };
 
   return {
@@ -83,6 +85,7 @@ function makeFakeManager(overrides: Partial<{
     resetModuleConfigState: vi.fn(() => { state.moduleConfigsEverFetched = false; }),
     setModuleConfigsEverFetched: vi.fn((v: boolean) => { state.moduleConfigsEverFetched = v; }),
     isTxEnabled: vi.fn(() => state.txEnabled),
+    getConfiguredHopLimit: vi.fn(() => state.hopLimit),
     isUdpBroadcastRelayEnabled: vi.fn(() => state.udpRelayEnabled),
     canTransmit: vi.fn(() => state.txEnabled || state.udpRelayEnabled),
   };
@@ -214,6 +217,33 @@ describe('RemoteAdminService', () => {
         await vi.advanceTimersByTimeAsync(250);
         const result = await promise;
         expect(result).toEqual({ longName: 'fresh' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('sends remote-admin requests at the node\'s configured hop limit, not a hardcoded 3', async () => {
+      // Regression: every remote admin packet used to leave at hop_limit 3 (the
+      // firmware default), so a node configured for a deeper mesh could never
+      // administer anything more than 3 hops out.
+      vi.useFakeTimers();
+      try {
+        const mgr = makeFakeManager({
+          sessionPasskeys: new Map([[222, new Uint8Array([1])]]),
+          hopLimit: 7,
+        });
+        const svc = new RemoteAdminService(mgr as any);
+
+        const promise = svc.requestRemoteOwner(222);
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(createAdminPacket).toHaveBeenCalledWith(
+          expect.anything(), 222, LOCAL_NODE_NUM, 7,
+        );
+
+        mgr.state.remoteNodeOwners.set(222, { longName: 'fresh' });
+        await vi.advanceTimersByTimeAsync(250);
+        await promise;
       } finally {
         vi.useRealTimers();
       }

--- a/src/server/services/remoteAdminService.ts
+++ b/src/server/services/remoteAdminService.ts
@@ -104,7 +104,7 @@ export class RemoteAdminService {
       });
       const encoded = AdminMessage.encode(adminMsg).finish();
 
-      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum, this.mgr.getConfiguredHopLimit());
 
       await this.mgr.sendLocalAdminPacket(adminPacket);
       logger.debug(`🔑 Requested session passkey from remote node ${destinationNodeNum} (via getDeviceMetadataRequest)`);
@@ -270,7 +270,7 @@ export class RemoteAdminService {
       }
 
       // Send the request
-      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum, this.mgr.getConfiguredHopLimit());
       await this.mgr.sendLocalAdminPacket(adminPacket);
       logger.debug(`📡 Requested ${isModuleConfig ? 'module' : 'device'} config type ${configType} from remote node ${destinationNodeNum}`);
 
@@ -388,7 +388,7 @@ export class RemoteAdminService {
       }
 
       // Send the request
-      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum, this.mgr.getConfiguredHopLimit());
       await this.mgr.sendLocalAdminPacket(adminPacket);
       logger.debug(`📡 Requested channel ${channelIndex} from remote node ${destinationNodeNum}`);
 
@@ -481,7 +481,7 @@ export class RemoteAdminService {
       this.mgr.getRemoteNodeOwnersMap().delete(destinationNodeNum);
 
       // Send the request
-      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum, this.mgr.getConfiguredHopLimit());
       await this.mgr.sendLocalAdminPacket(adminPacket);
       logger.debug(`📡 Requested owner info from remote node ${destinationNodeNum}`);
 
@@ -561,7 +561,7 @@ export class RemoteAdminService {
       this.mgr.getRemoteNodeDeviceMetadataMap().delete(destinationNodeNum);
 
       // Send the request
-      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, destinationNodeNum, this.mgr.getLocalNodeInfo()!.nodeNum, this.mgr.getConfiguredHopLimit());
       await this.mgr.sendLocalAdminPacket(adminPacket);
       logger.debug(`📡 Requested device metadata from remote node ${destinationNodeNum}`);
 
@@ -639,7 +639,7 @@ export class RemoteAdminService {
       const encoded = AdminMessage.encode(adminMsg).finish();
 
       const targetNodeNum = isLocalNode ? localNodeNum : destinationNodeNum;
-      const adminPacket = protobufService.createAdminPacket(encoded, targetNodeNum, localNodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, targetNodeNum, localNodeNum, this.mgr.getConfiguredHopLimit());
       await this.mgr.sendLocalAdminPacket(adminPacket);
 
       logger.info(`🔄 Sent reboot command to node ${targetNodeNum} (reboot in ${seconds} seconds)`);
@@ -701,7 +701,7 @@ export class RemoteAdminService {
       const encoded = AdminMessage.encode(adminMsg).finish();
 
       const targetNodeNum = isLocalNode ? localNodeNum : destinationNodeNum;
-      const adminPacket = protobufService.createAdminPacket(encoded, targetNodeNum, localNodeNum);
+      const adminPacket = protobufService.createAdminPacket(encoded, targetNodeNum, localNodeNum, this.mgr.getConfiguredHopLimit());
       await this.mgr.sendLocalAdminPacket(adminPacket);
 
       logger.debug(`🕐 Sent set time command to node ${targetNodeNum} (time: ${currentTime} / ${new Date(currentTime * 1000).toISOString()})`);


### PR DESCRIPTION
## Problem

Every admin packet was built with a hardcoded `hopLimit: 3` in `protobufService.createAdminPacketWithId()` — the *firmware default*, not the user's setting. All 31 admin call sites funnel through that one builder, which had no hop-limit parameter.

The result: a user who raised their node's LoRa hop limit to reach a deeper mesh still had every **remote** admin command (get/set config, reboot, set-time, session-key request) expire 3 hops out, with no indication why. Traceroute and telemetry to the same node worked fine — they size their hop limits (`7` and `Math.min(7, hopsAway + 2)` respectively), so a node could be traced and polled but not administered.

## Why the configured value is the right answer

Meshtastic Python resolves this client-side. `mesh_interface.py` `_sendPacket`:

```python
if hopLimit is not None:
    meshPacket.hop_limit = hopLimit
else:
    loraConfig = getattr(self.localNode.localConfig, "lora")
    meshPacket.hop_limit = getattr(loraConfig, "hop_limit")
```

`node.py` calls `_sendAdmin(...)` ~30 times and never passes `hopLimit`, so admin traffic there goes out at the node's configured limit.

Firmware does **not** substitute it for us: `Router.cpp` rewrites an inbound `hop_limit` only when it is already `0` (and `want_ack`, from the phone API). Our nonzero 3 was never getting replaced.

## Changes

- **`constants/meshtastic.ts`** — `MAX_HOP_LIMIT`, `DEFAULT_HOP_LIMIT`, and `resolveHopLimit()`. This is the canonical home for protocol values per CLAUDE.md; `mqttBrokerManager` now re-exports `MAX_HOP_LIMIT` from here so its importers (`sourceRoutes`) are unchanged.
- **`MeshtasticManager.getConfiguredHopLimit()`** — mirrors `isTxEnabled()`: reads in-memory `actualDeviceConfig.lora.hopLimit`, no DB access, safe to call per packet.
- **`createAdminPacket` / `createAdminPacketWithId`** — optional 4th `hopLimit` param, defaulting to the firmware default.
- **`remoteAdminService`** (7 sites) and **`adminTransactionService`** (2 sites) pass the configured value.

Local-node builders (`deviceAdminService`, `nodeDbMaintenanceService`, the four in `meshtasticManager`) are deliberately left alone — those packets are consumed by the attached radio and never transmitted, so hop limit is inert there.

### On a configured hop limit of 0

`resolveHopLimit` passes an explicit `0` through, since firmware honors a configured 0 for its own sends (`Default::getConfiguredOrDefaultHopLimit` returns it as-is below `HOP_MAX`).

But a device *actually* set to 0 does not reach us as `0` — proto3 omits zero scalars, so protobuf.js decodes it to `null`, indistinguishable from "config hasn't arrived yet". Both take the default of 3. That ambiguity is unavoidable on the wire and self-correcting in practice, since firmware rewrites an inbound `want_ack` packet at `hop_limit == 0` back to the node's own configured value. The comments and tests state this rather than implying we can detect it.

## Compatibility

Behavior is unchanged until the device reports a LoRa config, and unchanged for any node left at the default of 3.

## Testing

- Full Vitest suite: `success: true`, **12,889 passed / 0 failed**. (713 skipped — the PostgreSQL/MySQL containers weren't running locally. No schema or migration work here, so that's not a coverage gap for this change; CI runs both as service containers.)
- `tsc --noEmit` clean; `lint:ci` reports no in-repo failures.
- New coverage:
  - `resolveHopLimit` unit tests (pass-through, 0, clamping, invalid input).
  - `protobufService.adminHopLimit.test.ts` — decodes the ToRadio and asserts the actual wire value, clamping, and that the rest of the admin packet shape (`to`/`from`/`wantAck`/`priority`/`pkiEncrypted`/portnum) is untouched.
  - `meshtasticManager.adminHopLimit.test.ts` — the accessor across missing config, absent field, configured values, and hot config updates.
  - Regression tests in both service suites asserting a configured `7` reaches the builder instead of `3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9