### PR TITLE
fix(ui): restore the send-message button icon (#4478)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1271,16 +1271,34 @@ body {
   color: var(--ctp-overlay1);
 }
 
+/*
+ * Single source of truth for the message-compose send button (#4478).
+ *
+ * This rule used to be duplicated: a second `.send-btn` block further down this
+ * file re-declared `padding: 0.75rem 1.5rem` at equal specificity and won the
+ * cascade, while `width: 40px` still came from here. Under the global
+ * `box-sizing: border-box`, 48px of horizontal padding inside a 40px box leaves
+ * zero content width, so the flex child — `<UiIcon name="send" size={16} />` —
+ * was squeezed to nothing and the button rendered as a solid blue rectangle.
+ * The `.channel-action-btn` siblings escaped only because their
+ * `padding: 0.5rem !important` outranked the duplicate.
+ *
+ * The declarations below are the values that block actually produced, so the
+ * button looks unchanged; only the padding conflict is resolved. Keep this as
+ * the ONLY `.send-btn` declaration — and note that the mobile override in the
+ * `@media (max-width: 768px)` block below is declared *after* this one on
+ * purpose, or the cascade silently shadows it (same trap as issue #3532).
+ */
 .send-btn {
   padding: 0.75rem 0.5rem;
   min-width: 40px;
   width: 40px;
-  background: var(--ctp-green);
+  background: var(--ctp-blue);
   color: var(--ctp-accent-text);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   font-weight: 600;
-  font-size: 1.5rem;
+  font-size: 1rem;
   cursor: pointer;
   transition: all 0.2s;
   display: flex;
@@ -1289,8 +1307,13 @@ body {
   flex-shrink: 0;
 }
 
+/* Never let the icon absorb a future padding/width regression. */
+.send-btn > svg {
+  flex-shrink: 0;
+}
+
 .send-btn:hover:not(:disabled) {
-  background: var(--ctp-teal);
+  background: var(--ctp-sapphire);
   transform: translateY(-1px);
   box-shadow: 0 6px 20px -3px rgba(166, 227, 161, 0.4);
 }
@@ -1983,27 +2006,7 @@ body {
   color: var(--ctp-overlay1);
 }
 
-.send-btn {
-  padding: 0.75rem 1.5rem;
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
-  border: none;
-  border-radius: var(--radius-lg);
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.send-btn:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
-  transform: translateY(-1px);
-}
-
-.send-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+/* `.send-btn` is defined once, above — see the note there (#4478). */
 
 /* Mobile: text input full width, action buttons on second row */
 @media (max-width: 768px) {

--- a/src/styles/sendButtonIcon.test.ts
+++ b/src/styles/sendButtonIcon.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test for #4478 — the compose "Send message" button rendered as a
+ * solid colored rectangle with no visible icon.
+ *
+ * `App.css` declared `.send-btn` twice at equal specificity. The later block
+ * re-declared `padding: 0.75rem 1.5rem` and won the cascade, while `width: 40px`
+ * kept coming from the earlier block. With the global `box-sizing: border-box`
+ * (src/index.css), 48px of horizontal padding inside a 40px box leaves zero
+ * content width, so the flex child — `<UiIcon name="send" size={16} />` — was
+ * squeezed to nothing.
+ *
+ * jsdom implements neither the cascade across stylesheets nor layout, so a
+ * rendering test cannot catch this. These assertions read the stylesheet source
+ * instead and check the two properties that actually caused the bug: that there
+ * is a single unconditional `.send-btn` rule, and that its box model leaves
+ * room for the icon.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const APP_CSS = readFileSync(
+  fileURLToPath(new URL('../App.css', import.meta.url)),
+  'utf-8'
+);
+
+/** Size passed to <UiIcon name="send" size={16} /> in ChannelsTab/MessagesTab. */
+const SEND_ICON_PX = 16;
+
+/** Strip comments so commentary mentioning `.send-btn` isn't parsed as a rule. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Extract the bodies of every *unconditional* `.send-btn { ... }` rule — i.e.
+ * ones at column 0, excluding indented copies nested inside `@media` blocks and
+ * excluding compound selectors like `.send-btn:hover` / `.send-btn > svg`.
+ */
+function unconditionalSendBtnRules(css: string): string[] {
+  return [...stripComments(css).matchAll(/^\.send-btn\s*\{([^}]*)\}/gm)].map(m => m[1]);
+}
+
+/**
+ * Resolve a property the way the cascade does: across every matching rule at
+ * equal specificity, the *last* declaration wins. Reading only the first rule
+ * would miss precisely the bug this file guards — the original stylesheet's
+ * first `.send-btn` block had perfectly fine geometry, and the duplicate that
+ * broke it came later.
+ */
+function effectiveDeclaration(bodies: string[], prop: string): string | undefined {
+  let winner: string | undefined;
+  for (const body of bodies) {
+    const match = body.match(new RegExp(`(?:^|;)\\s*${prop}\\s*:\\s*([^;]+)`));
+    if (match) winner = match[1].trim();
+  }
+  return winner;
+}
+
+/** Convert a `rem`/`px` CSS length to px, assuming the 16px root font size. */
+function toPx(value: string): number {
+  const rem = value.match(/^(-?[\d.]+)rem$/);
+  if (rem) return parseFloat(rem[1]) * 16;
+  const px = value.match(/^(-?[\d.]+)px$/);
+  if (px) return parseFloat(px[1]);
+  throw new Error(`Unsupported CSS length: ${value}`);
+}
+
+describe('.send-btn leaves room for its icon (#4478)', () => {
+  it('is declared exactly once, so no later block can silently win the cascade', () => {
+    expect(unconditionalSendBtnRules(APP_CSS)).toHaveLength(1);
+  });
+
+  it('has horizontal padding that fits inside its fixed width under border-box', () => {
+    const bodies = unconditionalSendBtnRules(APP_CSS);
+
+    const width = effectiveDeclaration(bodies, 'width');
+    const padding = effectiveDeclaration(bodies, 'padding');
+    expect(width).toBeDefined();
+    expect(padding).toBeDefined();
+
+    // `padding: <vertical> <horizontal>` — the horizontal component is what
+    // eats into the content box on a fixed-width, border-box button.
+    const parts = padding!.split(/\s+/);
+    const horizontal = toPx(parts.length > 1 ? parts[1] : parts[0]);
+    const contentWidth = toPx(width!) - horizontal * 2;
+
+    expect(contentWidth).toBeGreaterThanOrEqual(SEND_ICON_PX);
+  });
+
+  it('pins the icon against future padding regressions', () => {
+    expect(stripComments(APP_CSS)).toMatch(
+      /\.send-btn\s*>\s*svg\s*\{[^}]*flex-shrink:\s*0/
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4478

## Root cause

Not the icon mapping — `UiIcon`'s `send` → lucide `Send` entry is correct, as the issue suspected.

`src/App.css` declared `.send-btn` **twice** at equal specificity. The later block (old L1986) re-declared `padding: 0.75rem 1.5rem` and won the cascade, while `width: 40px` still came from the earlier block (old L1274). Under the global `box-sizing: border-box` (`src/index.css`), 48px of horizontal padding inside a 40px box leaves **zero** content width, so the flex child — `<UiIcon name="send" size={16} />` — was squeezed to 0px wide.

The `.send-btn.channel-action-btn` siblings (bell, position) escaped only because their `padding: 0.5rem !important` outranked the duplicate — which is exactly why the report singles out the send button.

## Verified in a browser, not just by reading

Worth doing: flex `min-width: auto` on a replaced SVG could plausibly have resisted the squeeze, which would have made the above analysis wrong. It doesn't. Measured against the real stylesheet in Chrome:

| | send icon | sibling action icon | send button |
|---|---|---|---|
| **before** | **0 × 16** | 16 × 16 | 48 × 40 |
| **after** | 16 × 16 | 16 × 16 | 40 × 40 |

## Two corrections to the issue report

- **Not theme-specific.** Reproduces on the default Catppuccin theme; High Contrast Dark was incidental. (`--ctp-accent-text` is `#000000` on `--ctp-blue` — fine contrast. The icon wasn't the wrong color; it had no width.)
- **Mobile was broken the same way.** The duplicate sits *after* the `@media (max-width: 768px)` `.send-btn` override, silently shadowing it — the same cascade-ordering trap as #3532. Confirmed broken before (icon 0 × 16 at 400px wide) and fixed after (44px button, 16 × 16 icon).

## The fix

Collapse the two blocks into one, keeping **the values the cascade actually produced** (blue background, `--radius-lg`, `1rem`) so the button's appearance is unchanged — the only computed-style change is horizontal padding, `1.5rem` → `0.5rem`. Pin `.send-btn > svg { flex-shrink: 0 }` so a future padding/width regression can't collapse the icon again.

## Test plan

- [x] New `src/styles/sendButtonIcon.test.ts` — jsdom implements neither cross-stylesheet cascade nor layout, so this asserts on stylesheet source: one unconditional `.send-btn` rule, and a box model that leaves room for the 16px icon.
- [x] **Confirmed it's a real regression test**: all 3 assertions fail against the unfixed `App.css` and pass after. (My first draft passed on broken code because it read only the first rule — rewritten to resolve declarations the way the cascade does, last-wins.)
- [x] Full Vitest suite — `success: true`, 3947 files, 12875 passed, 0 failed.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint:ci` — no FAIL lines.

## Follow-up (not fixed here)

Four other top-level selectors are still declared twice in `App.css` — `.dm-selector` (699, 1878), `.node-select` (703, 1883), `.device-info` (814, 1060), `.message-input-container` (1245, 1908). Same fragility class; out of scope for this fix. Also noting the `.send-btn:hover` box-shadow is a green-tinted glow (`rgba(166, 227, 161, 0.4)`) on a now-blue button — preserved as-is since it's pre-existing rendered behavior, but it looks like a leftover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_