### PR TITLE
feat(nav): unify Meshtastic/MeshCore per-source navigation (#4473)

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -119,73 +119,9 @@
   overflow: hidden;
 }
 
-/* Sub-toolbar (narrow left strip) */
-.meshcore-sub-toolbar {
-  width: 56px;
-  background: var(--ctp-mantle);
-  border-right: 1px solid var(--ctp-surface1);
-  display: flex;
-  flex-direction: column;
-  padding: 0.5rem 0;
-  flex-shrink: 0;
-  transition: width 0.18s ease;
-}
-
-.meshcore-sub-toolbar.expanded {
-  width: 220px;
-}
-
-.meshcore-sub-toolbar-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 0.75rem;
-  margin: 0.1rem 0.4rem;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  color: var(--ctp-subtext0);
-  border: none;
-  background: transparent;
-  font-size: 0.9rem;
-  text-align: left;
-  width: calc(100% - 0.8rem);
-}
-
-.meshcore-sub-toolbar-item:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
-}
-
-.meshcore-sub-toolbar-item.active {
-  background: var(--ctp-surface1);
-  color: var(--ctp-mauve);
-}
-
-.meshcore-sub-toolbar-item .icon {
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.1rem;
-  flex-shrink: 0;
-  position: relative;
-}
-
-/* Unread red-dot indicator overlaid on the nav icon (#3891). Anchored to the
-   icon's top-right so it stays put whether the toolbar is collapsed or
-   expanded. */
-.meshcore-nav-unread-dot {
-  position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 8px;
-  height: 8px;
-  background: var(--ctp-red);
-  border-radius: var(--radius-full);
-  border: 1px solid var(--ctp-mantle);
-  pointer-events: none;
-}
+/* The sub-toolbar is now the shared SourceNav (#4473) — its structural
+   styles live in src/components/nav/SourceNav.module.css, and the MeshCore
+   rail widths in MeshCoreSubToolbar.module.css. */
 
 /* Per-contact unread red-dot in the Node Details (DM) contact list (#3891). */
 .meshcore-dm-unread-dot {
@@ -196,30 +132,6 @@
   border-radius: var(--radius-full);
   flex-shrink: 0;
   margin-right: 2px;
-}
-
-.meshcore-sub-toolbar.collapsed .meshcore-sub-toolbar-item .label {
-  display: none;
-}
-
-.meshcore-sub-toolbar-spacer { flex: 1; }
-
-.meshcore-sub-toolbar-toggle {
-  margin: 0.25rem 0.4rem;
-  background: transparent;
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-subtext0);
-  border-radius: var(--radius-md);
-  padding: 0.35rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.meshcore-sub-toolbar-toggle:hover {
-  color: var(--ctp-text);
-  background: var(--ctp-surface1);
 }
 
 /* Content area */
@@ -1638,60 +1550,11 @@
     flex-direction: column-reverse;
   }
 
-  /* --- Sub-toolbar: horizontal bottom bar --- */
-  .meshcore-sub-toolbar {
-    width: 100%;
-    flex-direction: row;
-    border-right: none;
-    border-top: 1px solid var(--ctp-surface1);
-    padding: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    flex-shrink: 0;
-  }
-
-  .meshcore-sub-toolbar.expanded {
-    width: 100%;
-  }
-
-  .meshcore-sub-toolbar-item {
-    flex-direction: column;
-    gap: 0.2rem;
-    padding: 0.5rem 0.2rem;
-    margin: 0;
-    border-radius: 0;
-    /* Share the row equally so every tab (up to 9: …Configuration,
-       Automations, Settings) stays on-screen without relying on a
-       horizontal scroll the user can't see. */
-    flex: 1 1 0;
-    min-width: 0;
-    width: auto;
-    text-align: center;
-    justify-content: center;
-    font-size: 0.7rem;
-  }
-
-  .meshcore-sub-toolbar-item .icon {
-    font-size: 1.2rem;
-  }
-
-  .meshcore-sub-toolbar-item .label {
-    display: block !important;
-    font-size: 0.65rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 100%;
-  }
-
-  .meshcore-sub-toolbar-spacer {
-    display: none;
-  }
-
-  .meshcore-sub-toolbar-toggle {
-    display: none;
-  }
+  /* The bottom-bar treatment moved to the shared SourceNav (#4473). The old
+     rules here split the row evenly (`flex: 1 1 0; min-width: 0`), which gave
+     each of 11 entries ~35px on a phone and ellipsised every label down to a
+     few characters. SourceNav sizes items to their content and scrolls the bar
+     instead. */
 
   /* --- Status bar: compact --- */
   .meshcore-status-bar {

--- a/src/components/MeshCore/MeshCoreSubToolbar.module.css
+++ b/src/components/MeshCore/MeshCoreSubToolbar.module.css
@@ -1,0 +1,12 @@
+/*
+ * MeshCore-specific geometry for the shared SourceNav (#4473).
+ *
+ * Everything structural — item layout, unread dot, the mobile bottom bar —
+ * lives in SourceNav.module.css. This file only carries the width pair the
+ * MeshCore sub-toolbar has always used, so the two source types can share a
+ * component without being forced to share a rail width.
+ */
+.subToolbar {
+  --source-nav-collapsed-width: 56px;
+  --source-nav-expanded-width: 220px;
+}

--- a/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
@@ -29,8 +29,10 @@ describe('MeshCoreSubToolbar', () => {
     const { container } = render(
       <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
     );
-    // Each nav item's .icon span should contain an <svg> from lucide-react.
-    const iconSpans = container.querySelectorAll('.meshcore-sub-toolbar-item .icon');
+    // Each nav item's icon span should contain an <svg> from lucide-react.
+    // Selectors are the stable data-* hooks SourceNav emits (#4473); its class
+    // names come from a CSS module and are hashed at build time.
+    const iconSpans = container.querySelectorAll('[data-source-nav-item] [data-source-nav-icon]');
     expect(iconSpans.length).toBeGreaterThan(0);
     iconSpans.forEach((span) => expect(span.querySelector('svg')).not.toBeNull());
   });
@@ -41,7 +43,7 @@ describe('MeshCoreSubToolbar', () => {
     const { container } = render(
       <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
     );
-    const firstIcon = container.querySelector('.meshcore-sub-toolbar-item .icon');
+    const firstIcon = container.querySelector('[data-source-nav-item] [data-source-nav-icon]');
     expect(firstIcon?.querySelector('svg')).toBeNull();
     expect(firstIcon?.textContent).toBe('🗺️');
     iconStyle = 'lucide'; // reset for other tests
@@ -59,11 +61,11 @@ describe('MeshCoreSubToolbar', () => {
         unread={{ channels: true, dms: false }}
       />,
     );
-    const dots = container.querySelectorAll('.meshcore-nav-unread-dot');
+    const dots = container.querySelectorAll('[data-source-nav-unread]');
     expect(dots.length).toBe(1);
-    const channelsItem = Array.from(container.querySelectorAll('.meshcore-sub-toolbar-item'))
+    const channelsItem = Array.from(container.querySelectorAll('[data-source-nav-item]'))
       .find((el) => el.textContent?.includes('Channels'));
-    expect(channelsItem?.querySelector('.meshcore-nav-unread-dot')).not.toBeNull();
+    expect(channelsItem?.querySelector('[data-source-nav-unread]')).not.toBeNull();
   });
 
   it('renders no unread dots when none are flagged', () => {
@@ -71,7 +73,7 @@ describe('MeshCoreSubToolbar', () => {
     const { container } = render(
       <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
     );
-    expect(container.querySelectorAll('.meshcore-nav-unread-dot').length).toBe(0);
+    expect(container.querySelectorAll('[data-source-nav-unread]').length).toBe(0);
   });
 
   it('renders the Configuration tab when configuration:read is granted', () => {

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
-import { UiIcon, type UiIconName } from '../icons';
+import { type UiIconName } from '../icons';
+import { SourceNav, type SourceNavItem } from '../nav/SourceNav';
+import styles from './MeshCoreSubToolbar.module.css';
 
 export type MeshCoreView = 'nodes' | 'channels' | 'rooms' | 'dms' | 'telemetry' | 'packets' | 'info' | 'configuration' | 'automations' | 'notifications' | 'settings';
 
@@ -39,6 +41,12 @@ const ITEMS: Item[] = [
   { id: 'settings', labelKey: 'meshcore.nav.settings', fallback: 'Settings', icon: 'settings' },
 ];
 
+/**
+ * MeshCore's per-source nav. Presentation is delegated to the shared
+ * {@link SourceNav} (#4473) so this and the Meshtastic sidebar can no longer
+ * drift; what stays here is MeshCore's own item list, permission gating and
+ * view-local selection state.
+ */
 export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
   view,
   onSelect,
@@ -54,42 +62,36 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
   const canReadAutomation = hasPermission('automation', 'read');
   const canReadPackets = hasPermission('packetmonitor', 'read');
 
+  const items = useMemo<SourceNavItem[]>(() => {
+    return ITEMS.filter(item => {
+      if (item.id === 'configuration' && !canReadConfig) return false;
+      if (item.id === 'automations' && !canReadAutomation) return false;
+      if (item.id === 'packets' && !canReadPackets) return false;
+      // Notifications preferences are per-user — only meaningful when signed in.
+      if (item.id === 'notifications' && !isAuthenticated) return false;
+      // Info is per-source only — it reads /api/sources/:id/meshcore/info.
+      if (item.id === 'info' && !showInfo) return false;
+      return true;
+    }).map(item => ({
+      id: item.id,
+      label: t(item.labelKey, item.fallback),
+      icon: item.icon,
+      onClick: () => onSelect(item.id),
+      unread: unread[item.id] ?? false,
+    }));
+  }, [t, onSelect, unread, showInfo, canReadConfig, canReadAutomation, canReadPackets, isAuthenticated]);
+
   return (
-    <aside className={`meshcore-sub-toolbar ${expanded ? 'expanded' : 'collapsed'}`}>
-      {ITEMS.map(item => {
-        if (item.id === 'configuration' && !canReadConfig) return null;
-        if (item.id === 'automations' && !canReadAutomation) return null;
-        if (item.id === 'packets' && !canReadPackets) return null;
-        // Notifications preferences are per-user — only meaningful when signed in.
-        if (item.id === 'notifications' && !isAuthenticated) return null;
-        // Info is per-source only — it reads /api/sources/:id/meshcore/info.
-        if (item.id === 'info' && !showInfo) return null;
-        const label = t(item.labelKey, item.fallback);
-        return (
-          <button
-            key={item.id}
-            className={`meshcore-sub-toolbar-item ${view === item.id ? 'active' : ''}`}
-            onClick={() => onSelect(item.id)}
-            title={!expanded ? label : undefined}
-          >
-            <span className="icon">
-              <UiIcon name={item.icon} size={20} />
-              {unread[item.id] && <span className="meshcore-nav-unread-dot" aria-hidden="true" />}
-            </span>
-            <span className="label">{label}</span>
-          </button>
-        );
-      })}
-      <div className="meshcore-sub-toolbar-spacer" />
-      <button
-        className="meshcore-sub-toolbar-toggle"
-        onClick={onToggleExpanded}
-        title={expanded
-          ? t('meshcore.nav.collapse', 'Collapse')
-          : t('meshcore.nav.expand', 'Expand')}
-      >
-        <UiIcon name={expanded ? 'back' : 'forward'} size={18} />
-      </button>
-    </aside>
+    <SourceNav
+      className={styles.subToolbar}
+      sections={[{ items }]}
+      activeId={view}
+      collapsed={!expanded}
+      mobileVariant="bottom-bar"
+      onToggleCollapsed={onToggleExpanded}
+      collapseLabel={t('meshcore.nav.collapse', 'Collapse')}
+      expandLabel={t('meshcore.nav.expand', 'Expand')}
+      ariaLabel={t('meshcore.nav.label', 'MeshCore navigation')}
+    />
   );
 };

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,30 +1,32 @@
+/*
+ * The sidebar is now the shared SourceNav (#4473) with `.sidebar` layered on for
+ * app-shell positioning. Structure — nav list, items, section headers, unread
+ * dots, collapsed behaviour — lives in src/components/nav/SourceNav.module.css.
+ *
+ * Width and theme are handed over as custom properties rather than plain
+ * declarations: SourceNav reads them, so the values apply by inheritance and
+ * cannot depend on which stylesheet the bundler emits first. Redeclaring
+ * `width`/`background` here instead would put two equal-specificity rules in a
+ * race — the failure mode that hid the send button in #4478.
+ */
 .sidebar {
+  --source-nav-collapsed-width: calc(60px + env(safe-area-inset-left, 0px));
+  --source-nav-expanded-width: calc(240px + env(safe-area-inset-left, 0px));
+  --source-nav-bg: var(--ctp-base);
+  --source-nav-border: 1px solid var(--ctp-surface1);
+
   position: fixed;
   left: 0;
   top: 0; /* Full page height from top of viewport */
   bottom: 0;
   height: 100vh;
   height: 100dvh; /* Dynamic viewport height - accounts for mobile browser chrome */
-  width: calc(60px + env(safe-area-inset-left, 0px)); /* Add safe area to width so content has full 60px */
-  background: var(--ctp-base);
-  border-right: 1px solid var(--ctp-surface1);
   transition: width 0.3s ease, transform 0.3s ease;
   z-index: 10001; /* Above header (10000) so it overlays cleanly */
-  display: flex;
-  flex-direction: column;
   padding-top: env(safe-area-inset-top); /* Account for iPhone notch/status bar */
   padding-bottom: max(1rem, env(safe-area-inset-bottom)); /* Account for iPhone home indicator */
   padding-left: env(safe-area-inset-left); /* Account for iPhone landscape notch */
   box-sizing: border-box; /* Include padding in height calculation */
-}
-
-.sidebar.collapsed {
-  width: calc(60px + env(safe-area-inset-left, 0px));
-}
-
-/* When expanded on desktop, show full width */
-.sidebar:not(.collapsed) {
-  width: calc(240px + env(safe-area-inset-left, 0px));
 }
 
 /* The old .sidebar-footer / .version-text / .news-link rules are gone: the
@@ -166,98 +168,10 @@
   text-overflow: ellipsis;
 }
 
-.sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  /* The controls and footer are in-flow siblings now (#4436), so no bottom
-     strip needs reserving here — just a little breathing room. */
-  padding: 8px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  flex: 1;
-}
-
-.sidebar-section-header {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--ctp-subtext0);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  padding: 12px 12px 4px 12px;
-  margin-top: 8px;
-}
-
-.sidebar-section {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.sidebar-nav-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  color: var(--ctp-text);
-  cursor: pointer;
-  transition: background-color 0.2s;
-  text-align: left;
-  font-size: 14px;
-  position: relative;
-  white-space: nowrap;
-}
-
-.sidebar-nav-item:hover {
-  background: var(--ctp-surface0);
-}
-
-.sidebar-nav-item.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
-}
-
-.sidebar-nav-item .nav-icon {
-  font-size: 18px;
-  width: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.sidebar-nav-item .nav-label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.sidebar.collapsed .sidebar-nav-item {
-  justify-content: center;
-  padding: 10px;
-}
-
-.sidebar.collapsed .nav-label {
-  display: none;
-}
-
-.nav-notification-dot {
-  width: 8px;
-  height: 8px;
-  background: var(--ctp-red);
-  border-radius: var(--radius-full);
-  flex-shrink: 0;
-  margin-left: auto;
-}
-
-.sidebar.collapsed .nav-notification-dot {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-}
+/* The nav list, section headers, items, labels, unread dots and their collapsed
+   variants all moved to SourceNav.module.css (#4473) — the whole point being
+   that MeshCore and Meshtastic can no longer drift apart. Only app-shell
+   concerns (positioning, header, controls, scrollbars) stay in this file. */
 
 /* Main content always accounts for narrow sidebar */
 /* Removed old layout-affecting rules - sidebar now floats over content */
@@ -265,20 +179,18 @@
 /* Mobile responsive - portrait only */
 @media (max-width: 768px) and (orientation: portrait) {
   .sidebar {
-    /* Collapsed by default - show as hamburger icon only */
-    width: 48px;
+    /* Collapsed by default - show as hamburger icon only. Set through the
+       custom properties SourceNav reads, not a `width` declaration, so this
+       can't end up racing the module's own width rule on stylesheet order. */
+    --source-nav-collapsed-width: 48px;
+    --source-nav-expanded-width: 240px;
     padding-bottom: 6rem; /* Extra padding on mobile for home indicator */
     padding-bottom: max(6rem, calc(env(safe-area-inset-bottom) + 4rem));
   }
 
   .sidebar:not(.collapsed) {
     /* When expanded, slide in from left */
-    width: 240px;
     box-shadow: 2px 0 16px rgba(0, 0, 0, 0.3);
-  }
-
-  .sidebar.collapsed {
-    width: 48px;
   }
 
   .app-main {
@@ -315,23 +227,8 @@
   }
 }
 
-/* Scrollbar styling for sidebar */
-.sidebar-nav::-webkit-scrollbar {
-  width: 6px;
-}
-
-.sidebar-nav::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.sidebar-nav::-webkit-scrollbar-thumb {
-  background: var(--ctp-surface2);
-  border-radius: var(--radius-xs);
-}
-
-.sidebar-nav::-webkit-scrollbar-thumb:hover {
-  background: var(--ctp-overlay0);
-}
+/* Scrollbar styling moved with the nav list into SourceNav.module.css (#4473) —
+   `.sidebar-nav` no longer exists in the markup. */
 
 /* Mobile landscape - increased threshold to catch more devices */
 @media (max-height: 700px) and (orientation: landscape) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { TabType } from '../types/ui';
 import { ResourceType } from '../types/permission';
 import { UiIcon, type UiIconName } from './icons';
 import SidebarFooter from './SidebarFooter';
+import { SourceNav, type SourceNavItem, type SourceNavSection } from './nav/SourceNav';
 
 interface UnreadCountsData {
   channels?: {[channelId: number]: number};
@@ -63,7 +64,6 @@ const Sidebar: React.FC<SidebarProps> = ({
   mqttReadOnly = false,
 }) => {
   const { t } = useTranslation();
-  const icon = (name: UiIconName) => <UiIcon name={name} size={20} />;
 
   // Pin state persisted to localStorage - when pinned, sidebar won't auto-collapse on nav click
   const [isPinned, setIsPinned] = useState(() => {
@@ -124,205 +124,172 @@ const Sidebar: React.FC<SidebarProps> = ({
     return () => window.removeEventListener('resize', updateSidebarWidth);
   }, [isCollapsed]);
 
-  const NavItem: React.FC<{
-    id: TabType;
-    label: string;
-    icon: React.ReactNode;
-    onClick?: () => void;
-    showNotification?: boolean;
-  }> = ({ id, label, icon, onClick, showNotification }) => {
-    const handleClick = () => {
-      // Auto-collapse sidebar when navigation item is clicked (if expanded and not pinned)
+  /**
+   * Build a SourceNav item. Navigation still auto-collapses an unpinned
+   * sidebar, and still defaults to `setActiveTab(id)` when no custom handler is
+   * given — SourceNav owns presentation only (#4473).
+   */
+  const navItem = (
+    id: TabType,
+    label: string,
+    iconName: UiIconName,
+    opts: { onClick?: () => void; unread?: boolean } = {}
+  ): SourceNavItem => ({
+    id,
+    label,
+    icon: iconName,
+    unread: opts.unread,
+    onClick: () => {
       if (!isCollapsed && !isPinned) {
         setIsCollapsed(true);
       }
-      // Execute the custom onClick or default setActiveTab
-      if (onClick) {
-        onClick();
+      if (opts.onClick) {
+        opts.onClick();
       } else {
         setActiveTab(id);
       }
-    };
+    },
+  });
 
-    return (
-      <button
-        className={`sidebar-nav-item ${activeTab === id ? 'active' : ''}`}
-        onClick={handleClick}
-        title={isCollapsed ? label : ''}
-      >
-        <span className="nav-icon">{icon}</span>
-        {!isCollapsed && <span className="nav-label">{label}</span>}
-        {showNotification && <span className="nav-notification-dot"></span>}
-      </button>
-    );
-  };
+  const mainItems: SourceNavItem[] = [
+    /* Labelled "Map" (#4325) — the tab is the map + node list, and the Map icon
+       never matched the old "Nodes" label. The `nodes` tab id and the
+       `nav.nodes` locale key are deliberately unchanged: the id is part of the
+       route (/source/:id/nodes) so renaming it would break existing bookmarks,
+       and the key is what every locale file is already translated against. Same
+       divergence as `nav.messages`, which reads "Node Details". */
+    navItem('nodes', t('nav.nodes'), 'nodes'),
+    ...(hasAnyChannelPermission()
+      ? [navItem('channels', t('nav.channels'), 'channels', {
+          onClick: onChannelsClick,
+          unread: unreadCountsData?.channels
+            ? Object.values(unreadCountsData.channels).some(count => count > 0)
+            : false,
+        })]
+      : []),
+    ...(hasPermission('messages', 'read')
+      ? [navItem('messages', t('nav.messages'), 'directMessages', {
+          onClick: onMessagesClick,
+          unread: unreadCountsData?.directMessages
+            ? Object.values(unreadCountsData.directMessages).some(count => count > 0)
+            : false,
+        })]
+      : []),
+    /* Search opens an overlay rather than switching tabs, so its id never
+       matches activeTab and it simply never renders active. */
+    ...(onSearchClick && hasAnySearchPermission()
+      ? [navItem('search' as TabType, t('nav.search'), 'search', { onClick: onSearchClick })]
+      : []),
+    ...(hasPermission('info', 'read') ? [navItem('info', t('nav.info'), 'info')] : []),
+    ...(hasPermission('dashboard', 'read') ? [navItem('dashboard', t('nav.dashboard'), 'dashboard')] : []),
+    ...(packetLogEnabled && hasPermission('packetmonitor', 'read')
+      ? [navItem('packetmonitor', t('nav.packet_monitor', 'Packet Monitor'), 'activity')]
+      : []),
+  ];
 
-  const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
-    !isCollapsed ? <div className="sidebar-section-header">{title}</div> : null
-  );
+  const configItems: SourceNavItem[] = [
+    /* 'settings' is sourcey (Phase 6 #4416); this nav link guards the whole
+       Settings tab, most of whose routes are unscoped, so anySource mirrors the
+       server's union check. */
+    ...(hasPermission('settings', 'read', { anySource: true })
+      ? [navItem('settings', t('nav.settings'), 'settings')]
+      : []),
+    ...(!mqttReadOnly && hasPermission('automation', 'read')
+      ? [navItem('automation', t('nav.automation'), 'bot')]
+      : []),
+    ...(!mqttReadOnly && hasPermission('configuration', 'read')
+      ? [navItem('configuration', t('nav.device'), 'configuration')]
+      : []),
+    /* MQTT Bridge sources have no device-config surface; surface a dedicated
+       bridge Configuration page instead. */
+    ...(mqttReadOnly && hasPermission('sources', 'read')
+      ? [navItem('mqtt-config', t('nav.mqtt_bridge_config', 'Configuration'), 'configuration')]
+      : []),
+    ...(isAuthenticated ? [navItem('notifications', t('nav.notifications'), 'notifications')] : []),
+  ];
+
+  const adminItems: SourceNavItem[] = [
+    ...(isAdmin ? [navItem('users', t('nav.users'), 'users')] : []),
+    ...(isAdmin && !mqttReadOnly ? [navItem('admin', t('nav.admin_commands'), 'zap')] : []),
+    ...(hasPermission('audit', 'read') ? [navItem('audit', t('nav.audit_log'), 'reports')] : []),
+    ...(hasPermission('security', 'read') ? [navItem('security', t('nav.security'), 'security')] : []),
+  ];
+
+  const sections: SourceNavSection[] = [
+    { title: t('nav.section_main'), items: mainItems },
+    { title: t('nav.section_configuration'), items: configItems },
+    ...(adminItems.length > 0
+      ? [{ title: t('nav.section_admin'), items: adminItems }]
+      : []),
+  ];
 
   return (
-    <aside className={`sidebar ${isCollapsed ? 'collapsed' : ''}`}>
-      <div className="sidebar-header">
-        <img src={`${baseUrl}/logo.png`} alt="MeshMonitor Logo" className="sidebar-logo" />
-        {!isCollapsed && (
-          <div className="sidebar-header-text">
-            <div className="sidebar-app-name">MeshMonitor</div>
-            {connectedNodeName && (
-              <div className="sidebar-node-name">{connectedNodeName}</div>
-            )}
-          </div>
-        )}
-      </div>
-
-      <nav className="sidebar-nav">
-        <SectionHeader title={t('nav.section_main')} />
-        <div className="sidebar-section">
-          {/* Labelled "Map" (#4325) — the tab is the map + node list, and the
-              Map icon never matched the old "Nodes" label. The `nodes` tab id
-              and the `nav.nodes` locale key are deliberately unchanged: the id
-              is part of the route (/source/:id/nodes) so renaming it would
-              break existing bookmarks, and the key is what every locale file
-              is already translated against. Same divergence as `nav.messages`,
-              which reads "Node Details". */}
-          <NavItem id="nodes" label={t('nav.nodes')} icon={icon('nodes')} />
-          {hasAnyChannelPermission() && (
-            <NavItem
-              id="channels"
-              label={t('nav.channels')}
-              icon={icon('channels')}
-              onClick={onChannelsClick}
-              showNotification={
-                unreadCountsData?.channels
-                  ? Object.values(unreadCountsData.channels).some(count => count > 0)
-                  : false
-              }
-            />
-          )}
-          {hasPermission('messages', 'read') && (
-            <NavItem
-              id="messages"
-              label={t('nav.messages')}
-              icon={icon('directMessages')}
-              onClick={onMessagesClick}
-              showNotification={
-                unreadCountsData?.directMessages
-                  ? Object.values(unreadCountsData.directMessages).some(count => count > 0)
-                  : false
-              }
-            />
-          )}
-          {onSearchClick && hasAnySearchPermission() && (
-            <button
-              className="sidebar-nav-item"
-              onClick={() => {
-                if (!isCollapsed && !isPinned) setIsCollapsed(true);
-                onSearchClick();
-              }}
-              title={isCollapsed ? t('nav.search') : ''}
-            >
-              <span className="nav-icon">{icon('search')}</span>
-              {!isCollapsed && <span className="nav-label">{t('nav.search')}</span>}
-            </button>
-          )}
-          {hasPermission('info', 'read') && (
-            <NavItem id="info" label={t('nav.info')} icon={icon('info')} />
-          )}
-          {hasPermission('dashboard', 'read') && (
-            <NavItem id="dashboard" label={t('nav.dashboard')} icon={icon('dashboard')} />
-          )}
-          {packetLogEnabled && hasPermission('packetmonitor', 'read') && (
-            <NavItem id="packetmonitor" label={t('nav.packet_monitor', 'Packet Monitor')} icon={icon('activity')} />
-          )}
-        </div>
-
-        <SectionHeader title={t('nav.section_configuration')} />
-        <div className="sidebar-section">
-          {/* 'settings' is sourcey (Phase 6 #4416); this nav link guards the
-              whole Settings tab, most of whose routes are unscoped, so
-              anySource mirrors the server's union check. */}
-          {hasPermission('settings', 'read', { anySource: true }) && (
-            <NavItem id="settings" label={t('nav.settings')} icon={icon('settings')} />
-          )}
-          {!mqttReadOnly && hasPermission('automation', 'read') && (
-            <NavItem id="automation" label={t('nav.automation')} icon={icon('bot')} />
-          )}
-          {!mqttReadOnly && hasPermission('configuration', 'read') && (
-            <NavItem id="configuration" label={t('nav.device')} icon={icon('configuration')} />
-          )}
-          {/* MQTT Bridge sources have no device-config surface; surface a
-              dedicated bridge Configuration page instead. */}
-          {mqttReadOnly && hasPermission('sources', 'read') && (
-            <NavItem id="mqtt-config" label={t('nav.mqtt_bridge_config', 'Configuration')} icon={icon('configuration')} />
-          )}
-          {isAuthenticated && (
-            <NavItem id="notifications" label={t('nav.notifications')} icon={icon('notifications')} />
-          )}
-        </div>
-
-        {(isAdmin || hasPermission('audit', 'read') || hasPermission('security', 'read')) && (
-          <>
-            <SectionHeader title={t('nav.section_admin')} />
-            <div className="sidebar-section">
-              {isAdmin && (
-                <>
-                  <NavItem id="users" label={t('nav.users')} icon={icon('users')} />
-                  {!mqttReadOnly && (
-                    <NavItem id="admin" label={t('nav.admin_commands')} icon={icon('zap')} />
-                  )}
-                </>
-              )}
-              {hasPermission('audit', 'read') && (
-                <NavItem id="audit" label={t('nav.audit_log')} icon={icon('reports')} />
-              )}
-              {hasPermission('security', 'read') && (
-                <NavItem id="security" label={t('nav.security')} icon={icon('security')} />
+    <SourceNav
+      className={`sidebar ${isCollapsed ? 'collapsed' : ''}`}
+      sections={sections}
+      activeId={activeTab}
+      collapsed={isCollapsed}
+      /* Still a left rail on phones. The bottom-bar variant is the eventual
+         target (#4473), but the whole app layout is positioned off
+         `--sidebar-width`, so that move is its own change. */
+      mobileVariant="rail"
+      ariaLabel={t('nav.section_main')}
+      header={
+        <div className="sidebar-header">
+          <img src={`${baseUrl}/logo.png`} alt="MeshMonitor Logo" className="sidebar-logo" />
+          {!isCollapsed && (
+            <div className="sidebar-header-text">
+              <div className="sidebar-app-name">MeshMonitor</div>
+              {connectedNodeName && (
+                <div className="sidebar-node-name">{connectedNodeName}</div>
               )}
             </div>
-          </>
-        )}
-      </nav>
-
-      {/* Pin/collapse controls sit in normal flow directly above the footer.
-          They used to be absolutely positioned at a hardcoded `bottom: 70px`,
-          which assumed the old three-item footer; the shared SidebarFooter
-          (#4436) is taller — and much taller in the 60px collapsed rail, where
-          its six icons wrap — so the controls landed on top of it. */}
-      <div className="sidebar-controls">
-        {!isCollapsed && (
+          )}
+        </div>
+      }
+      /* Pin/collapse controls sit in normal flow directly above the footer.
+         They used to be absolutely positioned at a hardcoded `bottom: 70px`,
+         which assumed the old three-item footer; the shared SidebarFooter
+         (#4436) is taller — and much taller in the 60px collapsed rail, where
+         its six icons wrap — so the controls landed on top of it. */
+      controls={
+        <div className="sidebar-controls">
+          {!isCollapsed && (
+            <button
+              className={`sidebar-pin ${isPinned ? 'pinned' : ''}`}
+              onClick={togglePin}
+              title={isPinned ? t('nav.unpin_sidebar') : t('nav.pin_sidebar')}
+            >
+              <UiIcon name="pin" size={18} />
+            </button>
+          )}
           <button
-            className={`sidebar-pin ${isPinned ? 'pinned' : ''}`}
-            onClick={togglePin}
-            title={isPinned ? t('nav.unpin_sidebar') : t('nav.pin_sidebar')}
+            className="sidebar-toggle"
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            title={isCollapsed ? t('nav.expand_sidebar') : t('nav.collapse_sidebar')}
           >
-            <UiIcon name="pin" size={18} />
+            <UiIcon name={isCollapsed ? 'forward' : 'back'} size={18} />
           </button>
-        )}
-        <button
-          className="sidebar-toggle"
-          onClick={() => setIsCollapsed(!isCollapsed)}
-          title={isCollapsed ? t('nav.expand_sidebar') : t('nav.collapse_sidebar')}
-        >
-          <UiIcon name={isCollapsed ? 'forward' : 'back'} size={18} />
-        </button>
-      </div>
-
-      {/* Shared footer (issue #4436) — same link set as the unified
-          dashboard sidebar. Users/Settings clicks switch tabs here, matching
-          the main-nav entries above. `narrowIcons` packs the icon row into the
-          collapsed rail instead of letting it wrap one-icon-per-line. */}
-      <SidebarFooter
-        isAdmin={isAdmin}
-        canReadSettings={hasPermission('settings', 'read', { anySource: true })}
-        onUsersClick={() => setActiveTab('users')}
-        onSettingsClick={() => setActiveTab('settings')}
-        onNewsClick={onNewsClick}
-        hideVersion={isCollapsed}
-        narrowIcons={isCollapsed}
-        pinToBottom
-        hideOnCompactLandscape
-      />
-    </aside>
+        </div>
+      }
+      /* Shared footer (issue #4436) — same link set as the unified dashboard
+         sidebar. Users/Settings clicks switch tabs here, matching the main-nav
+         entries above. `narrowIcons` packs the icon row into the collapsed rail
+         instead of letting it wrap one-icon-per-line. */
+      footer={
+        <SidebarFooter
+          isAdmin={isAdmin}
+          canReadSettings={hasPermission('settings', 'read', { anySource: true })}
+          onUsersClick={() => setActiveTab('users')}
+          onSettingsClick={() => setActiveTab('settings')}
+          onNewsClick={onNewsClick}
+          hideVersion={isCollapsed}
+          narrowIcons={isCollapsed}
+          pinToBottom
+          hideOnCompactLandscape
+        />
+      }
+    />
   );
 };
 

--- a/src/components/nav/SourceNav.mobile.test.ts
+++ b/src/components/nav/SourceNav.mobile.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for the mobile bottom bar (#4473).
+ *
+ * The reported defect is a layout failure: the MeshCore bottom bar laid its
+ * items out as `flex: 1 1 0` with `min-width: 0`, so 11 entries split a ~390px
+ * phone into ~35px each and every label ellipsised down to a few characters
+ * ("Configuration" → "Con…"). jsdom implements no layout and no cascade, so a
+ * render test cannot catch this; these assertions read the stylesheet source.
+ *
+ * Uses a root-relative `resolve()` like the other stylesheet assertions under
+ * src/components (see NodesTab.test.tsx). `import.meta.url` is not usable here:
+ * Vite rewrites it to an http URL for files in this directory, and
+ * `fileURLToPath` rejects that.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(resolve('src/components/nav/SourceNav.module.css'), 'utf-8');
+
+/** Body of the `.mobileBottomBar .item` rule inside the mobile media query. */
+const itemRule = css.match(/\.mobileBottomBar \.item \{([^}]*)\}/)?.[1] ?? '';
+
+describe('SourceNav mobile bottom bar (#4473)', () => {
+  it('sizes bottom-bar items to their content rather than splitting the row evenly', () => {
+    expect(itemRule).not.toBe('');
+    // The exact declaration that crushed the labels.
+    expect(itemRule).not.toMatch(/flex:\s*1\s+1\s+0/);
+    expect(itemRule).toMatch(/flex:\s*0\s+0\s+auto/);
+  });
+
+  it('gives each item a minimum width so labels stay legible', () => {
+    const min = itemRule.match(/min-width:\s*(\d+)px/);
+    expect(min).not.toBeNull();
+    expect(Number(min![1])).toBeGreaterThanOrEqual(60);
+  });
+
+  it('scrolls the bar sideways instead of compressing it', () => {
+    const barRule = css.match(/\.mobileBottomBar \{([^}]*)\}/)?.[1] ?? '';
+    expect(barRule).toMatch(/overflow-x:\s*auto/);
+  });
+
+  it('keeps labels visible on the bar even when the desktop rail is collapsed', () => {
+    // An icon-only bottom bar is the other half of the reported complaint.
+    expect(css).toMatch(/\.mobileBottomBar\.collapsed \.label[\s\S]{0,120}display:\s*block/);
+  });
+
+  it('themes through custom properties so consumer stylesheets cannot race it', () => {
+    // Overriding background/width from an equal-specificity rule in another
+    // stylesheet would make the result depend on bundler emit order — the
+    // failure mode behind #4478.
+    expect(css).toMatch(/--source-nav-bg:/);
+    expect(css).toMatch(/background:\s*var\(--source-nav-bg\)/);
+    expect(css).toMatch(/--source-nav-collapsed-width:/);
+  });
+});

--- a/src/components/nav/SourceNav.module.css
+++ b/src/components/nav/SourceNav.module.css
@@ -1,0 +1,281 @@
+/*
+ * Shared per-source navigation (issue #4473).
+ *
+ * Widths are driven by custom properties so each consumer can keep its own
+ * geometry without forking the rules: Meshtastic's sidebar is 60/240, MeshCore's
+ * sub-toolbar 56/220.
+ */
+.nav {
+  --source-nav-collapsed-width: 60px;
+  --source-nav-expanded-width: 240px;
+  /*
+   * Themeable bits go through custom properties rather than plain declarations
+   * so a consumer (e.g. `.sidebar`) can retheme the nav by *inheritance*, which
+   * is immune to stylesheet order. Overriding `background` from another
+   * equal-specificity rule instead would make the result depend on CSS import
+   * order — the exact failure mode that hid the send button in #4478.
+   */
+  --source-nav-bg: var(--ctp-mantle);
+  --source-nav-border: 1px solid var(--ctp-surface1);
+
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  background: var(--source-nav-bg);
+  border-right: var(--source-nav-border);
+  transition: width 0.18s ease;
+  box-sizing: border-box;
+}
+
+.collapsed {
+  width: var(--source-nav-collapsed-width);
+}
+
+.expanded {
+  width: var(--source-nav-expanded-width);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Carried over from Sidebar.css with the nav list (#4473). */
+.list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.list::-webkit-scrollbar-thumb {
+  background: var(--ctp-surface2);
+  border-radius: var(--radius-xs);
+}
+
+.list::-webkit-scrollbar-thumb:hover {
+  background: var(--ctp-overlay0);
+}
+
+.sectionHeader {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ctp-subtext0);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 12px 12px 4px 12px;
+  margin-top: 8px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--ctp-text);
+  cursor: pointer;
+  transition: background-color 0.2s;
+  text-align: left;
+  font-size: 14px;
+  position: relative;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.item:hover {
+  background: var(--ctp-surface0);
+}
+
+.active {
+  background: var(--ctp-blue);
+  color: var(--ctp-crust);
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Anchored to the icon's top-right so it holds position collapsed or expanded. */
+.unreadDot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 8px;
+  height: 8px;
+  background: var(--ctp-red);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--ctp-mantle);
+  pointer-events: none;
+}
+
+.collapsed .item {
+  justify-content: center;
+  padding: 10px;
+}
+
+.collapsed .label {
+  display: none;
+}
+
+.controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0 8px 8px 8px;
+  flex-shrink: 0;
+}
+
+.collapsed .controls {
+  justify-content: center;
+}
+
+.toggle {
+  background: transparent;
+  border: 1px solid var(--ctp-surface2);
+  color: var(--ctp-subtext0);
+  border-radius: var(--radius-md);
+  padding: 0.35rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.toggle:hover {
+  color: var(--ctp-text);
+  background: var(--ctp-surface1);
+}
+
+/* ============================================================
+ * Mobile — 768px breakpoint
+ * ============================================================ */
+
+@media (max-width: 768px) {
+  /*
+   * Bottom bar. The bug this fixes (#4473): items used to be `flex: 1 1 0` with
+   * `min-width: 0`, so 11 entries split a ~390px phone into ~35px each and every
+   * label ellipsised to two or three characters.
+   *
+   * Items now size to their content with a floor, and the bar scrolls sideways
+   * instead. A label is either fully readable or scrolled to — never shredded.
+   */
+  .mobileBottomBar {
+    width: 100%;
+    flex-direction: row;
+    align-items: stretch;
+    border-right: none;
+    border-top: var(--source-nav-border);
+    padding: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+
+  .mobileBottomBar::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Width is a row-layout concept here; the collapsed/expanded rail widths
+     must not leak into the bar. */
+  .mobileBottomBar.collapsed,
+  .mobileBottomBar.expanded {
+    width: 100%;
+  }
+
+  .mobileBottomBar .list {
+    flex-direction: row;
+    flex: 1;
+    padding: 0;
+    gap: 0;
+    overflow: visible;
+  }
+
+  .mobileBottomBar .section {
+    flex-direction: row;
+    gap: 0;
+  }
+
+  /* Section headers are a vertical-rail affordance; they'd break the row. */
+  .mobileBottomBar .sectionHeader {
+    display: none;
+  }
+
+  .mobileBottomBar .item {
+    flex: 0 0 auto;
+    min-width: 64px;
+    max-width: 120px;
+    width: auto;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.2rem;
+    padding: 0.5rem 0.6rem;
+    margin: 0;
+    border-radius: 0;
+    text-align: center;
+    font-size: 0.7rem;
+  }
+
+  /* Labels stay visible on the bar even when the desktop rail is collapsed —
+     an icon-only bottom bar is exactly the affordance gap #4473 reported. */
+  .mobileBottomBar.collapsed .label,
+  .mobileBottomBar .label {
+    display: block;
+    flex: none;
+    font-size: 0.65rem;
+    line-height: 1.2;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mobileBottomBar.collapsed .item {
+    padding: 0.5rem 0.6rem;
+  }
+
+  .mobileBottomBar .active {
+    /* A filled pill is too heavy at bar size; underline the active entry. */
+    background: transparent;
+    color: var(--ctp-blue);
+    box-shadow: inset 0 -2px 0 0 var(--ctp-blue);
+  }
+
+  /* The collapse toggle is meaningless on a bottom bar. */
+  .mobileBottomBar .controls {
+    display: none;
+  }
+
+  /* Vertical rail on mobile — narrower, but structurally unchanged. */
+  .mobileRail.collapsed {
+    width: 48px;
+  }
+}

--- a/src/components/nav/SourceNav.test.tsx
+++ b/src/components/nav/SourceNav.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../../contexts/IconStyleContext', () => ({
+  useIconStyleOptional: () => 'lucide' as const,
+}));
+
+import { SourceNav, type SourceNavSection } from './SourceNav';
+
+const sections: SourceNavSection[] = [
+  {
+    title: 'Main',
+    items: [
+      { id: 'nodes', label: 'Nodes', icon: 'nodes', onClick: () => {} },
+      { id: 'channels', label: 'Channels', icon: 'channels', onClick: () => {}, unread: true },
+    ],
+  },
+  {
+    title: 'Configuration',
+    items: [{ id: 'settings', label: 'Settings', icon: 'settings', onClick: () => {} }],
+  },
+];
+
+describe('SourceNav', () => {
+  it('marks only the active item', () => {
+    const { container } = render(
+      <SourceNav sections={sections} activeId="channels" collapsed={false} />
+    );
+    const active = container.querySelectorAll('[data-active="true"]');
+    expect(active.length).toBe(1);
+    expect(active[0].getAttribute('data-source-nav-item')).toBe('channels');
+    expect(active[0].getAttribute('aria-current')).toBe('page');
+  });
+
+  it('renders an unread dot only on flagged items', () => {
+    const { container } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed={false} />
+    );
+    const dots = container.querySelectorAll('[data-source-nav-unread]');
+    expect(dots.length).toBe(1);
+    expect(dots[0].closest('[data-source-nav-item]')?.getAttribute('data-source-nav-item'))
+      .toBe('channels');
+  });
+
+  it('fires the item onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <SourceNav
+        sections={[{ items: [{ id: 'nodes', label: 'Nodes', icon: 'nodes', onClick }] }]}
+        activeId="nodes"
+        collapsed={false}
+      />
+    );
+    fireEvent.click(screen.getByText('Nodes'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides section headers and shows tooltips when collapsed', () => {
+    const { container, rerender } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed={false} />
+    );
+    expect(container.querySelectorAll('[data-source-nav-section-header]').length).toBe(2);
+    expect(container.querySelector('[data-source-nav-item="nodes"]')?.getAttribute('title'))
+      .toBeNull();
+
+    rerender(<SourceNav sections={sections} activeId="nodes" collapsed />);
+    // Collapsed rails show no text, so the tooltip is the only affordance left.
+    expect(container.querySelectorAll('[data-source-nav-section-header]').length).toBe(0);
+    expect(container.querySelector('[data-source-nav-item="nodes"]')?.getAttribute('title'))
+      .toBe('Nodes');
+  });
+
+  it('renders the built-in toggle only when no controls slot is supplied', () => {
+    const onToggle = vi.fn();
+    const { container, rerender } = render(
+      <SourceNav
+        sections={sections}
+        activeId="nodes"
+        collapsed={false}
+        onToggleCollapsed={onToggle}
+      />
+    );
+    const toggle = container.querySelector('[data-source-nav-toggle]');
+    expect(toggle).not.toBeNull();
+    fireEvent.click(toggle!);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <SourceNav
+        sections={sections}
+        activeId="nodes"
+        collapsed={false}
+        onToggleCollapsed={onToggle}
+        controls={<div data-testid="custom-controls" />}
+      />
+    );
+    expect(container.querySelector('[data-source-nav-toggle]')).toBeNull();
+    expect(screen.getByTestId('custom-controls')).toBeDefined();
+  });
+
+  it('exposes the mobile variant so consumers can opt into the bottom bar', () => {
+    const { container, rerender } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed />
+    );
+    // Bottom bar is the default.
+    expect(container.querySelector('[data-source-nav]')?.getAttribute('data-mobile-variant'))
+      .toBe('bottom-bar');
+
+    rerender(<SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="rail" />);
+    expect(container.querySelector('[data-source-nav]')?.getAttribute('data-mobile-variant'))
+      .toBe('rail');
+  });
+});

--- a/src/components/nav/SourceNav.tsx
+++ b/src/components/nav/SourceNav.tsx
@@ -1,0 +1,171 @@
+/**
+ * SourceNav — the one navigation primitive shared by every per-source view
+ * (issue #4473).
+ *
+ * Meshtastic sources and MeshCore sources used to ship two independently-built
+ * navs — `Sidebar` (icon-only rail) and `MeshCoreSubToolbar` (bottom bar with
+ * labels). They didn't share a design, so a fix to one never reached the other;
+ * the phone bottom bar in particular crushed 11 items to ~35px each and
+ * ellipsised every label down to a few characters.
+ *
+ * This component owns the *presentation* only. Each consumer keeps its own item
+ * list, permission gating, state ownership and routing model — Meshtastic's nav
+ * is app-level and routed, MeshCore's is view-local `useState`, and unifying
+ * those is deliberately out of scope here.
+ *
+ * Layout hooks for tests are stable `data-*` attributes, not class names: the
+ * styling lives in a CSS module whose class names are hashed at build time.
+ */
+import React from 'react';
+import { UiIcon, type UiIconName } from '../icons';
+import styles from './SourceNav.module.css';
+
+export interface SourceNavItem {
+  /** Stable id — compared against `activeId` to mark the active entry. */
+  id: string;
+  label: string;
+  icon: UiIconName;
+  onClick: () => void;
+  /** Renders a red unread dot on the icon (#3891). */
+  unread?: boolean;
+}
+
+export interface SourceNavSection {
+  /** Rendered as a section header when expanded; omit for an unlabelled group. */
+  title?: string;
+  items: SourceNavItem[];
+}
+
+export interface SourceNavProps {
+  sections: SourceNavSection[];
+  activeId: string;
+  /** Icon-only rail (desktop) / compact (mobile). */
+  collapsed: boolean;
+  /**
+   * How the nav presents itself below the 768px breakpoint.
+   * - `bottom-bar`: horizontal, bottom-docked, scrolls sideways with readable
+   *   labels. Items size to their content instead of being split evenly, which
+   *   is what made labels unreadable before.
+   * - `rail`: stays a vertical left rail.
+   *
+   * Meshtastic is still `rail` because the whole app layout keys off
+   * `--sidebar-width`; moving it to `bottom-bar` is follow-up work.
+   */
+  mobileVariant?: 'bottom-bar' | 'rail';
+  /** Slot above the nav (Meshtastic's logo/app-name block). */
+  header?: React.ReactNode;
+  /** Slot below the nav, above the footer (pin/collapse controls). */
+  controls?: React.ReactNode;
+  /** Slot pinned to the bottom (SidebarFooter). */
+  footer?: React.ReactNode;
+  /**
+   * When provided and `controls` is not, renders the built-in collapse toggle.
+   * Consumers with their own control cluster pass `controls` instead.
+   */
+  onToggleCollapsed?: () => void;
+  collapseLabel?: string;
+  expandLabel?: string;
+  /** Extra class on the root, for consumer-specific positioning. */
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const SourceNav: React.FC<SourceNavProps> = ({
+  sections,
+  activeId,
+  collapsed,
+  mobileVariant = 'bottom-bar',
+  header,
+  controls,
+  footer,
+  onToggleCollapsed,
+  collapseLabel = 'Collapse',
+  expandLabel = 'Expand',
+  className,
+  ariaLabel,
+}) => {
+  const rootClasses = [
+    styles.nav,
+    collapsed ? styles.collapsed : styles.expanded,
+    mobileVariant === 'bottom-bar' ? styles.mobileBottomBar : styles.mobileRail,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <aside
+      className={rootClasses}
+      data-source-nav=""
+      data-collapsed={collapsed ? 'true' : 'false'}
+      data-mobile-variant={mobileVariant}
+      aria-label={ariaLabel}
+    >
+      {header}
+
+      <nav className={styles.list}>
+        {sections.map((section, index) => (
+          <React.Fragment key={section.title ?? `section-${index}`}>
+            {section.title && !collapsed && (
+              <div className={styles.sectionHeader} data-source-nav-section-header="">
+                {section.title}
+              </div>
+            )}
+            <div className={styles.section} data-source-nav-section="">
+              {section.items.map(item => {
+                const isActive = item.id === activeId;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={`${styles.item} ${isActive ? styles.active : ''}`}
+                    data-source-nav-item={item.id}
+                    data-active={isActive ? 'true' : 'false'}
+                    aria-current={isActive ? 'page' : undefined}
+                    onClick={item.onClick}
+                    // Collapsed rails show no text, so the tooltip is the only
+                    // affordance naming the destination.
+                    title={collapsed ? item.label : undefined}
+                  >
+                    <span className={styles.icon} data-source-nav-icon="">
+                      <UiIcon name={item.icon} size={20} />
+                      {item.unread && (
+                        <span
+                          className={styles.unreadDot}
+                          data-source-nav-unread=""
+                          aria-hidden="true"
+                        />
+                      )}
+                    </span>
+                    <span className={styles.label} data-source-nav-label="">
+                      {item.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </React.Fragment>
+        ))}
+      </nav>
+
+      {controls ?? (onToggleCollapsed && (
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={styles.toggle}
+            data-source-nav-toggle=""
+            onClick={onToggleCollapsed}
+            title={collapsed ? expandLabel : collapseLabel}
+            aria-label={collapsed ? expandLabel : collapseLabel}
+          >
+            <UiIcon name={collapsed ? 'forward' : 'back'} size={18} />
+          </button>
+        </div>
+      ))}
+
+      {footer}
+    </aside>
+  );
+};
+
+export default SourceNav;


### PR DESCRIPTION
Addresses #4473 (phase 1 of 2 — see *Follow-up* below).

## What changed

Meshtastic and MeshCore shipped two independently-built navigation trees — `Sidebar` (icon-only rail) and `MeshCoreSubToolbar` (bottom bar with labels). They shared no design, so fixing one never fixed the other.

New `src/components/nav/SourceNav.tsx` is the single presentational nav both now render. It owns item rendering, section headers, active state, unread dots, collapse behaviour and the mobile treatment.

What each consumer **keeps**: its own item list, permission gating, state ownership and routing model. Meshtastic's nav is app-level and routed (`/source/:id/<tab>`); MeshCore's is view-local `useState` and not URL-addressable at all. Unifying *that* is a much larger change and is deliberately not attempted here.

## The mobile bug, measured

The bottom bar laid its items out `flex: 1 1 0; min-width: 0`, so every entry got an equal sliver regardless of label length. Measured in Chrome at a 400px viewport with the real 11-item list:

| | item width | labels truncated | bar scrolls |
|---|---|---|---|
| **before** | 36.4px (all equal) | **11 / 11** | ❌ no |
| **after** | 64–96px (content-sized) | **0 / 11** | ✅ yes |

**This is worse than the issue reported.** Not only was every label cut to a few characters — the bar did not scroll either, so the truncated entries were simply unreachable on a phone.

A note on how that was established: my first before/after harness wrapped the items in the *new* `.list`/`.section` elements, which changes how `flex: 1 1 0` distributes and understated the damage as 5/11 truncated. Rebuilding the baseline from the real pre-change DOM and CSS (`git show HEAD:…/MeshCorePage.css`) produced the 11/11 figure above. Worth stating plainly because the first number was wrong and would have flattered the fix.

## Cascade safety

Theme and width cross the component boundary as custom properties (`--source-nav-bg`, `--source-nav-border`, `--source-nav-collapsed-width`, `--source-nav-expanded-width`) rather than plain declarations in the consumer stylesheets.

That's deliberate: `.sidebar` and `.nav` would otherwise both declare `background`/`width` at equal specificity, and which one wins would depend on bundler emit order. That is exactly the failure mode that hid the send button in #4478, fixed earlier today. Custom properties apply by inheritance, so order can't matter. `SourceNav.mobile.test.ts` asserts this holds.

## Test plan

- [x] `src/components/nav/SourceNav.test.tsx` — 6 behavioural tests (active item, unread dots, click, collapsed tooltips/headers, controls slot, mobile variant).
- [x] `src/components/nav/SourceNav.mobile.test.ts` — 5 stylesheet assertions for the layout fix. jsdom has no layout or cascade, so a render test cannot catch this.
- [x] **Confirmed these are real regression tests**: re-introducing `flex: 1 1 0; min-width: 0` fails the two load-bearing assertions.
- [x] Verified in Chrome at 400px (bottom bar) and 1280px (60px rail, vertical, labels hidden when collapsed).
- [x] Existing `MeshCoreSubToolbar` tests retargeted to the stable `data-*` hooks — CSS-module class names are hashed and are not valid selectors. All 6 still pass unchanged in intent.
- [x] Full Vitest suite — `success: true`, 3956 files, 12907 passed, 0 failed (baseline 12875).
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.

## Follow-up (phase 2, not in this PR)

You asked for the scrollable bottom bar on **both** source types. Meshtastic still uses `mobileVariant="rail"` here because the app shell is positioned off `--sidebar-width`, which is load-bearing in 8+ stylesheets plus `sidebarWidth.ts` and `NodesTab.tsx` layout math. Flipping it means driving that to 0 on mobile and re-checking every `left: var(--sidebar-width)` / `margin-left` consumer (AppHeader, SaveBar, AppBanners, nodes.css map container, BackupManagement) plus bottom-inset for the new bar. The `mobileVariant` prop is the seam; that change is worth reviewing on its own rather than buried in this refactor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_