### PR TITLE
fix(admin): decouple remote commands from HTTP requests

### DIFF
--- a/docs/features/admin-commands.md
+++ b/docs/features/admin-commands.md
@@ -356,7 +356,19 @@ The Admin Commands tab supports managing nodes that are not directly connected t
 
 1. **Session Passkey Management**: MeshMonitor automatically handles authentication with remote nodes using session passkeys
 2. **Per-Node Storage**: Configuration data is stored separately for each node to prevent conflicts
-3. **Mesh Communication**: Commands are sent through the mesh network to reach remote nodes
+3. **Asynchronous Execution**: MeshMonitor accepts a valid remote command immediately, then acquires the passkey and transmits outside the browser's original HTTP request
+4. **Completion Polling**: The Admin Commands tab remains in its existing loading state while it checks the protected operation endpoint for completion
+5. **Mesh Communication**: Commands are sent through the mesh network to reach remote nodes
+
+Local-node commands remain synchronous. Remote `POST /api/admin/commands` requests return `202 Accepted` with an opaque operation ID. Administrators can check `GET /api/admin/commands/:operationId`; both endpoints require admin authentication. Operation records contain only the command, source and destination identifiers, lifecycle state, and timestamps. Command parameters and session keys are not retained.
+
+Remote operations move through `pending` or `running` before reaching `succeeded`, `failed`, `timed_out`, or `rejected`. The current phase can be `queued`, `acquiring_passkey`, `sending`, `awaiting_ack`, or `complete`. Terminal results remain available in memory for five minutes. A missing operation (including after a server restart) returns `ADMIN_OPERATION_NOT_FOUND`, which the web client presents as an interrupted operation rather than a success.
+
+### Confirmation Semantics
+
+Favorite, unfavorite, ignore, and unignore commands wait for a routing ACK from the remote node. A confirmed ACK means the remote node processed the packet. An explicit routing rejection is reported as rejected and the interface does not update its local favorite/ignore state. An ACK timeout is uncertain: the packet may still have applied, so MeshMonitor preserves the existing optimistic state behavior and shows a warning. Other remote commands are considered successful after transmission, matching their previous behavior.
+
+Stable failure codes distinguish session-passkey timeout (`REMOTE_PASSKEY_TIMEOUT`), transport failure (`TRANSPORT_FAILURE`), routing rejection (`ROUTING_REJECTED`), and missing or expired operation state (`ADMIN_OPERATION_NOT_FOUND`).
 
 ### Remote Node Operations
 
@@ -421,4 +433,3 @@ All admin commands work with remote nodes:
 - [Device Configuration](/features/device) - Local device configuration
 - [Settings](/features/settings) - General MeshMonitor settings
 - [Meshtastic Official Documentation](https://meshtastic.org/docs/) - Meshtastic protocol documentation
-

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -18,9 +18,16 @@ import { DeviceConfigurationSection } from './admin-commands/DeviceConfiguration
 import AutoFavoriteManagementSection from './admin-commands/AutoFavoriteManagementSection';
 import { ModuleConfigurationSection } from './admin-commands/ModuleConfigurationSection';
 import { useAdminCommandsState } from './admin-commands/useAdminCommandsState';
-import { buildNodeOptions, filterNodes, sortNodeOptionsForRemoteAdmin, type NodeOption } from './admin-commands/nodeOptionsUtils';
+import {
+  buildNodeOptions,
+  filterNodes,
+  shouldApplyOptimisticNodeState,
+  sortNodeOptionsForRemoteAdmin,
+  type NodeOption,
+} from './admin-commands/nodeOptionsUtils';
 import { createEmptyChannelSlot, createChannelFromResponse, isRetryableChannelError, countLoadedChannels } from './admin-commands/channelLoadingUtils';
 import { UiIcon } from './icons';
+import type { AdminCommandResponse, AdminCommandSuccessResponse } from '../types/adminOperations';
 
 interface AdminCommandsTabProps {
   nodes: any[];
@@ -1441,13 +1448,18 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
 
     setIsExecuting(true);
     try {
-      const result = await apiService.post<{ success: boolean; message: string }>('/api/admin/commands', {
+      const response = await apiService.post<AdminCommandResponse>('/api/admin/commands', {
         command,
         nodeNum: selectedNodeNum,
         ...(sourceId ? { sourceId } : {}),
         ...params
       });
-      showToast(result.message || t('admin_commands.command_executed', { command }), 'success');
+      const result: AdminCommandSuccessResponse = 'operation' in response
+        ? await apiService.waitForAdminOperation(response.operation.id)
+        : response;
+      if (!['setFavoriteNode', 'removeFavoriteNode', 'setIgnoredNode', 'removeIgnoredNode'].includes(command)) {
+        showToast(result.message || t('admin_commands.command_executed', { command }), 'success');
+      }
       return result;
     } catch (error: any) {
       // A 409 TX_DISABLED can still slip through as a race (TX flipped off
@@ -1513,17 +1525,17 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      const res: any = await executeCommand('setFavoriteNode', { favoriteNodeNum: nodeManagementNodeNum });
+      const res = await executeCommand('setFavoriteNode', { favoriteNodeNum: nodeManagementNodeNum });
       const ack = res?.ack;
       // For a remote node the backend waits for the routing ACK. A definitive
       // routing rejection means the favorite did NOT apply — don't optimistically
       // mark it. 'confirmed' or 'timeout' (uncertain) keep the optimistic update.
-      const rejected = ack && !ack.acked && !ack.timedOut;
+      const rejected = !shouldApplyOptimisticNodeState(ack);
       if (ack?.acked) {
         showToast(t('admin_commands.node_favorite_confirmed', { nodeNum: nodeManagementNodeNum }), 'success');
       } else if (ack?.timedOut) {
         showToast(t('admin_commands.node_favorite_no_ack', { nodeNum: nodeManagementNodeNum }), 'warning');
-      } else if (rejected) {
+      } else if (rejected && ack) {
         showToast(t('admin_commands.node_favorite_rejected', { nodeNum: nodeManagementNodeNum, status: ack.status }), 'error');
       } else {
         showToast(t('admin_commands.node_set_favorite', { nodeNum: nodeManagementNodeNum }), 'success');
@@ -1557,14 +1569,14 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      const res: any = await executeCommand('removeFavoriteNode', { favoriteNodeNum: nodeManagementNodeNum });
+      const res = await executeCommand('removeFavoriteNode', { favoriteNodeNum: nodeManagementNodeNum });
       const ack = res?.ack;
-      const rejected = ack && !ack.acked && !ack.timedOut;
+      const rejected = !shouldApplyOptimisticNodeState(ack);
       if (ack?.acked) {
         showToast(t('admin_commands.node_unfavorite_confirmed', { nodeNum: nodeManagementNodeNum }), 'success');
       } else if (ack?.timedOut) {
         showToast(t('admin_commands.node_favorite_no_ack', { nodeNum: nodeManagementNodeNum }), 'warning');
-      } else if (rejected) {
+      } else if (rejected && ack) {
         showToast(t('admin_commands.node_favorite_rejected', { nodeNum: nodeManagementNodeNum, status: ack.status }), 'error');
       } else {
         showToast(t('admin_commands.node_removed_favorite', { nodeNum: nodeManagementNodeNum }), 'success');
@@ -1598,22 +1610,32 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      await executeCommand('setIgnoredNode', { targetNodeNum: nodeManagementNodeNum });
-      showToast(t('admin_commands.node_set_ignored', { nodeNum: nodeManagementNodeNum }), 'success');
-      // Optimistically update state - use remote status if managing remote node, otherwise local
-      if (isManagingRemoteNode) {
-        setRemoteNodeStatus(prev => {
-          const newMap = new Map(prev);
-          const current = newMap.get(nodeManagementNodeNum) || { isFavorite: false, isIgnored: false };
-          newMap.set(nodeManagementNodeNum, { ...current, isIgnored: true });
-          return newMap;
-        });
+      const res = await executeCommand('setIgnoredNode', { targetNodeNum: nodeManagementNodeNum });
+      const ack = res?.ack;
+      const rejected = !shouldApplyOptimisticNodeState(ack);
+      if (ack?.timedOut) {
+        showToast(t('admin_commands.node_favorite_no_ack', { nodeNum: nodeManagementNodeNum }), 'warning');
+      } else if (rejected && ack) {
+        showToast(`${t('admin_commands.failed_execute_command')}: ${ack.status}`, 'error');
       } else {
-        setNodeOptions(prev => prev.map(node => 
-          node.nodeNum === nodeManagementNodeNum 
-            ? { ...node, isIgnored: true }
-            : node
-        ));
+        showToast(t('admin_commands.node_set_ignored', { nodeNum: nodeManagementNodeNum }), 'success');
+      }
+      if (!rejected) {
+        // Optimistically update state - use remote status if managing remote node, otherwise local
+        if (isManagingRemoteNode) {
+          setRemoteNodeStatus(prev => {
+            const newMap = new Map(prev);
+            const current = newMap.get(nodeManagementNodeNum) || { isFavorite: false, isIgnored: false };
+            newMap.set(nodeManagementNodeNum, { ...current, isIgnored: true });
+            return newMap;
+          });
+        } else {
+          setNodeOptions(prev => prev.map(node =>
+            node.nodeNum === nodeManagementNodeNum
+              ? { ...node, isIgnored: true }
+              : node
+          ));
+        }
       }
     } catch (error) {
       // Error already handled by executeCommand (toast shown)
@@ -1627,22 +1649,32 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      await executeCommand('removeIgnoredNode', { targetNodeNum: nodeManagementNodeNum });
-      showToast(t('admin_commands.node_removed_ignored', { nodeNum: nodeManagementNodeNum }), 'success');
-      // Optimistically update state - use remote status if managing remote node, otherwise local
-      if (isManagingRemoteNode) {
-        setRemoteNodeStatus(prev => {
-          const newMap = new Map(prev);
-          const current = newMap.get(nodeManagementNodeNum) || { isFavorite: false, isIgnored: false };
-          newMap.set(nodeManagementNodeNum, { ...current, isIgnored: false });
-          return newMap;
-        });
+      const res = await executeCommand('removeIgnoredNode', { targetNodeNum: nodeManagementNodeNum });
+      const ack = res?.ack;
+      const rejected = !shouldApplyOptimisticNodeState(ack);
+      if (ack?.timedOut) {
+        showToast(t('admin_commands.node_favorite_no_ack', { nodeNum: nodeManagementNodeNum }), 'warning');
+      } else if (rejected && ack) {
+        showToast(`${t('admin_commands.failed_execute_command')}: ${ack.status}`, 'error');
       } else {
-        setNodeOptions(prev => prev.map(node => 
-          node.nodeNum === nodeManagementNodeNum 
-            ? { ...node, isIgnored: false }
-            : node
-        ));
+        showToast(t('admin_commands.node_removed_ignored', { nodeNum: nodeManagementNodeNum }), 'success');
+      }
+      if (!rejected) {
+        // Optimistically update state - use remote status if managing remote node, otherwise local
+        if (isManagingRemoteNode) {
+          setRemoteNodeStatus(prev => {
+            const newMap = new Map(prev);
+            const current = newMap.get(nodeManagementNodeNum) || { isFavorite: false, isIgnored: false };
+            newMap.set(nodeManagementNodeNum, { ...current, isIgnored: false });
+            return newMap;
+          });
+        } else {
+          setNodeOptions(prev => prev.map(node =>
+            node.nodeNum === nodeManagementNodeNum
+              ? { ...node, isIgnored: false }
+              : node
+          ));
+        }
       }
     } catch (error) {
       // Error already handled by executeCommand (toast shown)

--- a/src/components/AdminCommandsTab.txDisabled.test.tsx
+++ b/src/components/AdminCommandsTab.txDisabled.test.tsx
@@ -32,6 +32,7 @@ const h = vi.hoisted(() => ({
   invalidateQueries: vi.fn(),
   showToast: vi.fn(),
   apiPost: vi.fn(),
+  apiWaitForAdminOperation: vi.fn(),
   txStatus: { isTxDisabled: false },
 }));
 
@@ -62,6 +63,7 @@ vi.mock('../services/api', () => ({
   default: {
     setBaseUrl: vi.fn(),
     post: h.apiPost,
+    waitForAdminOperation: h.apiWaitForAdminOperation,
     exportChannel: vi.fn(),
     importChannel: vi.fn(),
     getAllChannels: vi.fn().mockResolvedValue([]),
@@ -109,6 +111,7 @@ beforeEach(() => {
   localStorage.clear();
   h.txStatus.isTxDisabled = false;
   h.apiPost.mockResolvedValue({});
+  h.apiWaitForAdminOperation.mockResolvedValue({ success: true, message: 'completed' });
 });
 
 describe('AdminCommandsTab — remote-node admin gating while TX disabled (#4294)', () => {
@@ -204,6 +207,65 @@ describe('AdminCommandsTab — remote-node admin gating while TX disabled (#4294
 
     await waitFor(() => {
       expect(h.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['txStatus'] });
+    });
+  });
+
+  it('keeps existing controls disabled while a remote operation is polled', async () => {
+    let completeOperation!: (value: { success: true; message: string }) => void;
+    const operationResult = new Promise<{ success: true; message: string }>(resolve => {
+      completeOperation = resolve;
+    });
+    h.apiPost.mockResolvedValue({
+      success: true,
+      operation: {
+        id: 'op-1', sourceId: 'source-1', destinationNodeNum: 200,
+        command: 'setDeviceConfig', status: 'pending', phase: 'queued',
+        createdAt: 1, updatedAt: 1,
+      },
+    });
+    h.apiWaitForAdminOperation.mockReturnValue(operationResult);
+    expandSections(['admin-reboot-purge']);
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+    selectRemoteNode();
+
+    fireEvent.click(screen.getByTestId('device-save'));
+    await waitFor(() => expect(h.apiWaitForAdminOperation).toHaveBeenCalledWith('op-1'));
+    expect(screen.getByText('admin_commands.reboot_device').closest('button')).toBeDisabled();
+
+    completeOperation({ success: true, message: 'completed' });
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.reboot_device').closest('button')).not.toBeDisabled();
+      expect(h.showToast).toHaveBeenCalledWith('completed', 'success');
+    });
+  });
+
+  it('does not poll when a local command returns its existing synchronous response', async () => {
+    h.apiPost.mockResolvedValue({ success: true, message: 'local completed' });
+    render(<AdminCommandsTab nodes={[localNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    fireEvent.click(screen.getByTestId('device-save'));
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledWith('local completed', 'success'));
+
+    expect(h.apiWaitForAdminOperation).not.toHaveBeenCalled();
+  });
+
+  it('shows an interrupted remote operation as an error', async () => {
+    h.apiPost.mockResolvedValue({
+      success: true,
+      operation: {
+        id: 'lost-op', sourceId: 'source-1', destinationNodeNum: 200,
+        command: 'setDeviceConfig', status: 'pending', phase: 'queued',
+        createdAt: 1, updatedAt: 1,
+      },
+    });
+    h.apiWaitForAdminOperation.mockRejectedValue(new Error('The admin operation was interrupted'));
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+    selectRemoteNode();
+
+    fireEvent.click(screen.getByTestId('device-save'));
+
+    await waitFor(() => {
+      expect(h.showToast).toHaveBeenCalledWith('The admin operation was interrupted', 'error');
     });
   });
 });

--- a/src/components/admin-commands/nodeOptionsUtils.test.ts
+++ b/src/components/admin-commands/nodeOptionsUtils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { shouldApplyOptimisticNodeState } from './nodeOptionsUtils';
+
+describe('shouldApplyOptimisticNodeState', () => {
+  it('allows local sends and confirmed remote ACKs', () => {
+    expect(shouldApplyOptimisticNodeState()).toBe(true);
+    expect(shouldApplyOptimisticNodeState({
+      acked: true,
+      timedOut: false,
+      errorReason: null,
+      status: 'confirmed',
+    })).toBe(true);
+  });
+
+  it('keeps the optimistic favorite/ignore state after an uncertain ACK timeout', () => {
+    expect(shouldApplyOptimisticNodeState({
+      acked: false,
+      timedOut: true,
+      errorReason: null,
+      status: 'timeout',
+    })).toBe(true);
+  });
+
+  it('does not update favorite/ignore state after an explicit routing rejection', () => {
+    expect(shouldApplyOptimisticNodeState({
+      acked: false,
+      timedOut: false,
+      errorReason: 5,
+      status: 'MAX_RETRANSMIT',
+    })).toBe(false);
+  });
+});

--- a/src/components/admin-commands/nodeOptionsUtils.ts
+++ b/src/components/admin-commands/nodeOptionsUtils.ts
@@ -1,3 +1,5 @@
+import type { AdminCommandAck } from '../../types/adminOperations';
+
 export interface NodeOption {
   nodeNum: number;
   nodeId: string;
@@ -110,3 +112,10 @@ export function filterNodes(nodes: NodeOption[], searchQuery: string): NodeOptio
   });
 }
 
+/**
+ * ACK timeouts are uncertain, so preserve the existing optimistic update.
+ * Only an explicit routing rejection prevents favorite/ignore state changes.
+ */
+export function shouldApplyOptimisticNodeState(ack?: AdminCommandAck): boolean {
+  return !ack || ack.acked || ack.timedOut;
+}

--- a/src/server/routes/adminRoutes.test.ts
+++ b/src/server/routes/adminRoutes.test.ts
@@ -13,6 +13,7 @@ import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/route
 import { sourceManagerRegistry, type ISourceManager } from '../sourceManagerRegistry.js';
 import { TxDisabledError } from '../errors/txDisabledError.js';
 import protobufService from '../protobufService.js';
+import { adminOperationService } from '../services/adminOperationService.js';
 
 // channelUrlService is dynamically imported inside export-config/import-config —
 // mock it so those handlers don't need a real base64url-encoded channel blob.
@@ -55,6 +56,242 @@ describe('adminRoutes — requireAdmin() gate', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ success: true });
     expect(Array.isArray(res.body.suppressedNodes)).toBe(true);
+  });
+});
+
+describe('adminRoutes — asynchronous remote admin commands (#4482)', () => {
+  let harness: RouteTestHarness;
+
+  function makeCommandManager(overrides: Record<string, unknown> = {}): ISourceManager {
+    return {
+      sourceId: harness.sourceA,
+      sourceType: 'meshtastic_tcp',
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockReturnValue({
+        sourceId: harness.sourceA,
+        sourceName: 'Source A',
+        sourceType: 'meshtastic_tcp',
+        connected: true,
+      }),
+      getLocalNodeInfo: vi.fn().mockReturnValue({
+        nodeNum: 1,
+        nodeId: '!00000001',
+        longName: 'Local',
+        shortName: 'LOC',
+      }),
+      startDistanceDeleteScheduler: vi.fn().mockResolvedValue(undefined),
+      stopDistanceDeleteScheduler: vi.fn(),
+      isTransportReady: vi.fn().mockReturnValue(true),
+      canTransmit: vi.fn().mockReturnValue(true),
+      getSessionPasskey: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4])),
+      requestRemoteSessionPasskey: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4])),
+      sendAdminCommand: vi.fn().mockResolvedValue(undefined),
+      sendAdminCommandAwaitAck: vi.fn().mockResolvedValue({
+        acked: true,
+        timedOut: false,
+        errorReason: null,
+      }),
+      ...overrides,
+    } as unknown as ISourceManager;
+  }
+
+  async function waitForTerminal(agent: Awaited<ReturnType<RouteTestHarness['loginAs']>>, operationId: string) {
+    let response;
+    await vi.waitFor(async () => {
+      response = await agent.get(`/commands/${operationId}`);
+      expect(['succeeded', 'failed', 'timed_out', 'rejected']).toContain(response.body.operation?.status);
+    });
+    return response!;
+  }
+
+  beforeEach(async () => {
+    adminOperationService.clear();
+    vi.spyOn(protobufService, 'createRebootMessage').mockReturnValue(new Uint8Array([1]));
+    vi.spyOn(protobufService, 'createSetFavoriteNodeMessage').mockReturnValue(new Uint8Array([2]));
+    vi.spyOn(protobufService, 'createRemoveFavoriteNodeMessage').mockReturnValue(new Uint8Array([3]));
+    vi.spyOn(protobufService, 'createSetIgnoredNodeMessage').mockReturnValue(new Uint8Array([4]));
+    vi.spyOn(protobufService, 'createRemoveIgnoredNodeMessage').mockReturnValue(new Uint8Array([5]));
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', adminRoutes),
+    });
+  });
+
+  afterEach(async () => {
+    adminOperationService.clear();
+    await sourceManagerRegistry.removeManager(harness.sourceA);
+    await harness.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('returns 202 before a remote passkey request finishes', async () => {
+    let resolvePasskey!: (value: Uint8Array | null) => void;
+    const passkey = new Promise<Uint8Array | null>(resolve => { resolvePasskey = resolve; });
+    await sourceManagerRegistry.addManager(makeCommandManager({
+      getSessionPasskey: vi.fn().mockReturnValue(null),
+      requestRemoteSessionPasskey: vi.fn().mockReturnValue(passkey),
+    }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const response = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'reboot',
+    });
+
+    expect(response.status).toBe(202);
+    expect(response.body.operation).toMatchObject({
+      command: 'reboot',
+      sourceId: harness.sourceA,
+      destinationNodeNum: 999,
+      status: 'pending',
+      phase: 'queued',
+    });
+    resolvePasskey(null);
+  });
+
+  it('keeps local commands synchronous with a 200 response', async () => {
+    const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+    await sourceManagerRegistry.addManager(makeCommandManager({ sendAdminCommand }));
+
+    const agent = await harness.loginAs(harness.admin);
+    const response = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 1,
+      command: 'reboot',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ success: true, message: expect.stringContaining('reboot') });
+    expect(response.body.operation).toBeUndefined();
+    expect(sendAdminCommand).toHaveBeenCalledOnce();
+  });
+
+  it('rejects invalid input and TX-disabled remote commands before acceptance', async () => {
+    await sourceManagerRegistry.addManager(makeCommandManager({ canTransmit: vi.fn().mockReturnValue(false) }));
+    const agent = await harness.loginAs(harness.admin);
+
+    const invalid = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'setOwner',
+    });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.code).toBe('INVALID_ADMIN_COMMAND');
+
+    const txDisabled = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'reboot',
+    });
+    expect(txDisabled.status).toBe(409);
+    expect(txDisabled.body.code).toBe('TX_DISABLED');
+  });
+
+  it('protects operation status and returns 404 for lost or expired IDs', async () => {
+    const limited = await harness.loginAs(harness.limited);
+    expect((await limited.get('/commands/not-present')).status).toBe(403);
+
+    const admin = await harness.loginAs(harness.admin);
+    const missing = await admin.get('/commands/not-present');
+    expect(missing.status).toBe(404);
+    expect(missing.body.code).toBe('ADMIN_OPERATION_NOT_FOUND');
+  });
+
+  it('records passkey timeout and successful background transmission', async () => {
+    await sourceManagerRegistry.addManager(makeCommandManager({
+      getSessionPasskey: vi.fn().mockReturnValue(null),
+      requestRemoteSessionPasskey: vi.fn().mockResolvedValue(null),
+    }));
+    const agent = await harness.loginAs(harness.admin);
+    const failedPost = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'reboot',
+    });
+    const failed = await waitForTerminal(agent, failedPost.body.operation.id);
+    expect(failed.body.operation).toMatchObject({
+      status: 'timed_out',
+      error: { code: 'REMOTE_PASSKEY_TIMEOUT' },
+    });
+
+    await sourceManagerRegistry.removeManager(harness.sourceA);
+    const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+    await sourceManagerRegistry.addManager(makeCommandManager({ sendAdminCommand }));
+    const successPost = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'reboot',
+    });
+    const success = await waitForTerminal(agent, successPost.body.operation.id);
+    expect(success.body.operation.status).toBe('succeeded');
+    expect(sendAdminCommand).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['setFavoriteNode', { favoriteNodeNum: 42 }],
+    ['removeFavoriteNode', { favoriteNodeNum: 42 }],
+    ['setIgnoredNode', { targetNodeNum: 42 }],
+    ['removeIgnoredNode', { targetNodeNum: 42 }],
+  ])('awaits routing ACKs for %s', async (command, params) => {
+    const sendAdminCommandAwaitAck = vi.fn().mockResolvedValue({
+      acked: true,
+      timedOut: false,
+      errorReason: null,
+    });
+    await sourceManagerRegistry.addManager(makeCommandManager({ sendAdminCommandAwaitAck }));
+    const agent = await harness.loginAs(harness.admin);
+    const accepted = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command,
+      ...params,
+    });
+    const completed = await waitForTerminal(agent, accepted.body.operation.id);
+
+    expect(completed.body.operation).toMatchObject({
+      status: 'succeeded',
+      result: { ack: { acked: true, status: 'confirmed' } },
+    });
+    expect(sendAdminCommandAwaitAck).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [{ acked: false, timedOut: true, errorReason: null }, 'timed_out', undefined],
+    [{ acked: false, timedOut: false, errorReason: 5 }, 'rejected', 'ROUTING_REJECTED'],
+  ])('maps ACK outcome %o to %s', async (ack, expectedStatus, expectedCode) => {
+    await sourceManagerRegistry.addManager(makeCommandManager({
+      sendAdminCommandAwaitAck: vi.fn().mockResolvedValue(ack),
+    }));
+    const agent = await harness.loginAs(harness.admin);
+    const accepted = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'setFavoriteNode',
+      favoriteNodeNum: 42,
+    });
+    const completed = await waitForTerminal(agent, accepted.body.operation.id);
+
+    expect(completed.body.operation.status).toBe(expectedStatus);
+    expect(completed.body.operation.error?.code).toBe(expectedCode);
+  });
+
+  it('captures a rejected background transport promise', async () => {
+    await sourceManagerRegistry.addManager(makeCommandManager({
+      sendAdminCommand: vi.fn().mockRejectedValue(new Error('serial transport closed')),
+    }));
+    const agent = await harness.loginAs(harness.admin);
+    const accepted = await agent.post('/commands').send({
+      sourceId: harness.sourceA,
+      nodeNum: 999,
+      command: 'reboot',
+    });
+    const completed = await waitForTerminal(agent, accepted.body.operation.id);
+
+    expect(completed.body.operation).toMatchObject({
+      status: 'failed',
+      error: { code: 'TRANSPORT_FAILURE', message: 'serial transport closed' },
+    });
   });
 });
 

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -24,6 +24,12 @@ import { autoFavoriteManagementScheduler } from '../services/autoFavoriteManagem
 import protobufService from '../protobufService.js';
 import { fail } from '../utils/apiResponse.js';
 import { isTxDisabledError } from '../errors/txDisabledError.js';
+import {
+  AdminOperationFailure,
+  adminOperationService,
+  type AdminOperationContext,
+} from '../services/adminOperationService.js';
+import type { AdminCommandResult } from '../../types/adminOperations.js';
 
 const router = express.Router();
 
@@ -1351,309 +1357,375 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
   }
 });
 
+type AdminCommandManager = ReturnType<typeof resolveSourceManager>;
+type AdminCommandConfig = Record<string, unknown> & {
+  latitude?: number;
+  longitude?: number;
+  altitude?: number;
+  fixedPosition?: boolean;
+  publicKey?: unknown;
+  privateKey?: unknown;
+  isManaged?: boolean;
+  serialEnabled?: boolean;
+  debugLogApiEnabled?: boolean;
+  adminChannelEnabled?: boolean;
+};
+interface AdminCommandParams {
+  [key: string]: unknown;
+  seconds?: number;
+  longName?: string;
+  shortName?: string;
+  isUnmessagable?: boolean;
+  isLicensed?: boolean;
+  channelIndex?: number;
+  config?: AdminCommandConfig;
+  latitude?: number;
+  longitude?: number;
+  altitude?: number;
+  nodeNum?: number;
+  favoriteNodeNum?: number;
+  targetNodeNum?: number;
+}
+
+const ACKNOWLEDGED_REMOTE_COMMANDS = new Set([
+  'setFavoriteNode',
+  'removeFavoriteNode',
+  'setIgnoredNode',
+  'removeIgnoredNode',
+]);
+
+function validateAdminCommand(command: string, params: AdminCommandParams): string | null {
+  switch (command) {
+    case 'reboot':
+    case 'purgeNodeDb':
+    case 'beginEditSettings':
+    case 'commitEditSettings':
+      return null;
+    case 'setOwner':
+      return !params.longName || !params.shortName
+        ? 'longName and shortName are required for setOwner'
+        : null;
+    case 'setChannel':
+      return params.channelIndex === undefined || !params.config
+        ? 'channelIndex and config are required for setChannel'
+        : null;
+    case 'setDeviceConfig':
+    case 'setLoRaConfig':
+    case 'setPositionConfig':
+    case 'setMQTTConfig':
+    case 'setBluetoothConfig':
+    case 'setNetworkConfig':
+    case 'setNeighborInfoConfig':
+    case 'setTelemetryConfig':
+    case 'setStatusMessageConfig':
+    case 'setTrafficManagementConfig':
+    case 'setSecurityConfig':
+      return !params.config ? `config is required for ${command}` : null;
+    case 'setFixedPosition':
+      return params.latitude === undefined || params.longitude === undefined
+        ? 'latitude and longitude are required for setFixedPosition'
+        : null;
+    case 'removeNode':
+      return params.nodeNum === undefined ? 'nodeNum is required for removeNode' : null;
+    case 'setFavoriteNode':
+    case 'removeFavoriteNode':
+      return params.favoriteNodeNum === undefined
+        ? `favoriteNodeNum is required for ${command}`
+        : null;
+    case 'setIgnoredNode':
+    case 'removeIgnoredNode':
+      return params.targetNodeNum === undefined
+        ? `targetNodeNum is required for ${command}`
+        : null;
+    default:
+      return `Unknown command: ${command}`;
+  }
+}
+
+async function executeAdminCommand(
+  acManager: AdminCommandManager,
+  command: string,
+  params: AdminCommandParams,
+  destinationNodeNum: number,
+  localNodeNum: number,
+  isLocalNode: boolean,
+  operation?: AdminOperationContext,
+): Promise<AdminCommandResult> {
+  let sessionPasskey: Uint8Array | null = null;
+  if (!isLocalNode) {
+    operation?.setPhase('acquiring_passkey');
+    sessionPasskey = acManager.getSessionPasskey(destinationNodeNum);
+    if (sessionPasskey) {
+      logger.debug(`🔑 Using cached session passkey for admin command to remote node ${destinationNodeNum}`);
+    } else {
+      logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one for admin command...`);
+      sessionPasskey = await acManager.requestRemoteSessionPasskey(destinationNodeNum);
+      if (!sessionPasskey) {
+        throw new AdminOperationFailure(
+          'REMOTE_PASSKEY_TIMEOUT',
+          `Failed to obtain session passkey for remote node ${destinationNodeNum}. The node may be unreachable or not responding.`,
+        );
+      }
+    }
+  }
+
+  let adminMessage: Uint8Array;
+
+  switch (command) {
+    case 'reboot':
+      adminMessage = protobufService.createRebootMessage(params.seconds || 10, sessionPasskey || undefined);
+      break;
+    case 'setOwner':
+      adminMessage = protobufService.createSetOwnerMessage(
+        params.longName!,
+        params.shortName!,
+        params.isUnmessagable,
+        sessionPasskey || undefined,
+        params.isLicensed,
+      );
+      break;
+    case 'setChannel':
+      adminMessage = protobufService.createSetChannelMessage(
+        params.channelIndex!,
+        params.config as Parameters<typeof protobufService.createSetChannelMessage>[1],
+        sessionPasskey || undefined,
+      );
+      break;
+    case 'setDeviceConfig':
+      adminMessage = protobufService.createSetDeviceConfigMessage(params.config, sessionPasskey || undefined);
+      break;
+    case 'setLoRaConfig':
+      adminMessage = protobufService.createSetLoRaConfigMessage(params.config, sessionPasskey || undefined);
+      break;
+    case 'setPositionConfig': {
+      const { latitude, longitude, altitude, ...positionConfig } = params.config!;
+      if (latitude !== undefined && longitude !== undefined && positionConfig.fixedPosition) {
+        const setPositionMsg = protobufService.createSetFixedPositionMessage(
+          latitude,
+          longitude,
+          altitude || 0,
+          sessionPasskey || undefined,
+        );
+        operation?.setPhase('sending');
+        await acManager.sendAdminCommand(setPositionMsg, destinationNodeNum);
+
+        if (isLocalNode && localNodeNum) {
+          const localNodeId = `!${localNodeNum.toString(16).padStart(8, '0')}`;
+          await databaseService.nodes.upsertNode({
+            nodeNum: localNodeNum,
+            nodeId: localNodeId,
+            latitude,
+            longitude,
+            altitude: altitude || 0,
+            positionTimestamp: Date.now(),
+          });
+          logger.debug(`⚙️ Updated local node ${localNodeId} position in database: lat=${latitude}, lon=${longitude}`);
+        }
+      }
+      adminMessage = protobufService.createSetPositionConfigMessage(positionConfig, sessionPasskey || undefined);
+      break;
+    }
+    case 'setMQTTConfig':
+      adminMessage = protobufService.createSetMQTTConfigMessage(params.config, sessionPasskey || undefined);
+      break;
+    case 'setBluetoothConfig':
+      adminMessage = protobufService.createSetDeviceConfigMessageGeneric('bluetooth', params.config, sessionPasskey || undefined);
+      break;
+    case 'setNetworkConfig':
+      adminMessage = protobufService.createSetNetworkConfigMessage(params.config, sessionPasskey || undefined);
+      break;
+    case 'setNeighborInfoConfig':
+      adminMessage = protobufService.createSetNeighborInfoConfigMessage(params.config, sessionPasskey || undefined);
+      break;
+    case 'setTelemetryConfig':
+      adminMessage = protobufService.createSetModuleConfigMessageGeneric('telemetry', params.config, sessionPasskey || undefined);
+      break;
+    case 'setStatusMessageConfig':
+      adminMessage = protobufService.createSetModuleConfigMessageGeneric('statusmessage', params.config, sessionPasskey || undefined);
+      break;
+    case 'setTrafficManagementConfig':
+      adminMessage = protobufService.createSetModuleConfigMessageGeneric('trafficmanagement', params.config, sessionPasskey || undefined);
+      break;
+    case 'setSecurityConfig': {
+      let configToSend: AdminCommandConfig;
+      if (isLocalNode) {
+        const existingKeys = acManager.getSecurityKeys();
+        configToSend = {
+          ...params.config,
+          publicKey: params.config!.publicKey || existingKeys.publicKey,
+          privateKey: params.config!.privateKey || existingKeys.privateKey,
+        };
+        logger.debug('Preserving existing public/private keys for local node security config update');
+      } else {
+        const { publicKey: _publicKey, privateKey: _privateKey, ...remoteConfig } = params.config!;
+        configToSend = remoteConfig;
+        logger.debug('Excluding publicKey/privateKey from remote node security config update');
+      }
+      adminMessage = protobufService.createSetSecurityConfigMessage(configToSend, sessionPasskey || undefined);
+      break;
+    }
+    case 'setFixedPosition':
+      adminMessage = protobufService.createSetFixedPositionMessage(
+        params.latitude!,
+        params.longitude!,
+        params.altitude || 0,
+        sessionPasskey || undefined,
+      );
+      break;
+    case 'purgeNodeDb':
+      adminMessage = protobufService.createPurgeNodeDbMessage(params.seconds || 0, sessionPasskey || undefined);
+      break;
+    case 'beginEditSettings':
+      adminMessage = protobufService.createBeginEditSettingsMessage(sessionPasskey || undefined);
+      break;
+    case 'commitEditSettings':
+      adminMessage = protobufService.createCommitEditSettingsMessage(sessionPasskey || undefined);
+      break;
+    case 'removeNode':
+      adminMessage = protobufService.createRemoveNodeMessage(params.nodeNum!, sessionPasskey || undefined);
+      break;
+    case 'setFavoriteNode':
+      adminMessage = protobufService.createSetFavoriteNodeMessage(params.favoriteNodeNum!, sessionPasskey || undefined);
+      break;
+    case 'removeFavoriteNode':
+      adminMessage = protobufService.createRemoveFavoriteNodeMessage(params.favoriteNodeNum!, sessionPasskey || undefined);
+      break;
+    case 'setIgnoredNode':
+      adminMessage = protobufService.createSetIgnoredNodeMessage(params.targetNodeNum!, sessionPasskey || undefined);
+      break;
+    case 'removeIgnoredNode':
+      adminMessage = protobufService.createRemoveIgnoredNodeMessage(params.targetNodeNum!, sessionPasskey || undefined);
+      break;
+    default:
+      throw new AdminOperationFailure('INVALID_ADMIN_COMMAND', `Unknown command: ${command}`);
+  }
+
+  operation?.setPhase('sending');
+  let ack: AdminCommandResult['ack'];
+  if (!isLocalNode && ACKNOWLEDGED_REMOTE_COMMANDS.has(command)) {
+    operation?.setPhase('awaiting_ack');
+    const routingAck = await acManager.sendAdminCommandAwaitAck(adminMessage, destinationNodeNum);
+    ack = {
+      acked: routingAck.acked,
+      timedOut: routingAck.timedOut,
+      errorReason: routingAck.errorReason,
+      status: routingAck.timedOut
+        ? 'timeout'
+        : (routingAck.acked ? 'confirmed' : getRoutingErrorName(routingAck.errorReason ?? -1)),
+    };
+  } else {
+    await acManager.sendAdminCommand(adminMessage, destinationNodeNum);
+  }
+
+  if (command === 'setSecurityConfig' && isLocalNode && params.config) {
+    acManager.updateCachedDeviceConfig('security', {
+      isManaged: params.config.isManaged,
+      serialEnabled: params.config.serialEnabled,
+      debugLogApiEnabled: params.config.debugLogApiEnabled,
+      adminChannelEnabled: params.config.adminChannelEnabled,
+    });
+  }
+
+  if (command === 'setFixedPosition' && isLocalNode && localNodeNum) {
+    const localNodeId = `!${localNodeNum.toString(16).padStart(8, '0')}`;
+    await databaseService.nodes.upsertNode({
+      nodeNum: localNodeNum,
+      nodeId: localNodeId,
+      latitude: params.latitude,
+      longitude: params.longitude,
+      altitude: params.altitude || 0,
+      positionTimestamp: Date.now(),
+    });
+    logger.debug(`⚙️ Updated local node ${localNodeId} position in database: lat=${params.latitude}, lon=${params.longitude}`);
+  }
+
+  if (!isLocalNode) {
+    try {
+      await databaseService.updateNodeRemoteAdminStatusAsync(destinationNodeNum, true, null, acManager.sourceId);
+      logger.debug(`✅ Updated hasRemoteAdmin=true for node ${destinationNodeNum} after successful '${command}' command`);
+    } catch (dbError) {
+      logger.error(`Failed to update hasRemoteAdmin for node ${destinationNodeNum}:`, dbError);
+    }
+  }
+
+  return {
+    message: `Admin command '${command}' sent to node ${destinationNodeNum}`,
+    ...(ack ? { ack } : {}),
+  };
+}
+
+router.get('/commands/:operationId', requireAdmin(), (req, res) => {
+  const operation = adminOperationService.get(req.params.operationId);
+  if (!operation) {
+    return fail(res, 404, 'ADMIN_OPERATION_NOT_FOUND', 'Admin operation was not found or has expired');
+  }
+  return res.json({ success: true, operation });
+});
+
 router.post('/commands', requireAdmin(), async (req, res) => {
   try {
-    const { command, nodeNum, sourceId: acSourceId, ...params } = req.body;
+    const { command, nodeNum, sourceId: acSourceId, ...params } = req.body as AdminCommandParams & {
+      command?: string;
+      sourceId?: string;
+    };
 
     if (!command) {
-      return res.status(400).json({ error: 'Command is required' });
+      return fail(res, 400, 'INVALID_ADMIN_COMMAND', 'Command is required');
     }
 
     const acManager = resolveSourceManager(acSourceId);
     const destinationNodeNum = nodeNum !== undefined ? Number(nodeNum) : (acManager.getLocalNodeInfo()?.nodeNum || 0);
+    if (!Number.isFinite(destinationNodeNum)) {
+      return fail(res, 400, 'INVALID_ADMIN_COMMAND', 'nodeNum must be a number');
+    }
     const localNodeNum = acManager.getLocalNodeInfo()?.nodeNum || 0;
     const isLocalNode = destinationNodeNum === 0 || destinationNodeNum === localNodeNum;
+    const validationError = validateAdminCommand(command, params);
+    if (validationError) {
+      return fail(res, 400, 'INVALID_ADMIN_COMMAND', validationError);
+    }
 
-    // Get or request session passkey for remote nodes
-    let sessionPasskey: Uint8Array | null = null;
     if (!isLocalNode) {
-      sessionPasskey = acManager.getSessionPasskey(destinationNodeNum);
-      if (sessionPasskey) {
-        logger.debug(`🔑 Using cached session passkey for admin command to remote node ${destinationNodeNum}`);
-      } else {
-        logger.debug(`🔑 No cached passkey for remote node ${destinationNodeNum}, requesting new one for admin command...`);
-        sessionPasskey = await acManager.requestRemoteSessionPasskey(destinationNodeNum);
-        if (!sessionPasskey) {
-          logger.error(`❌ Failed to obtain session passkey for remote node ${destinationNodeNum} after 45s`);
-          return res.status(500).json({ error: `Failed to obtain session passkey for remote node ${destinationNodeNum}. The node may be unreachable or not responding.` });
-        }
+      if (!acManager.isTransportReady()) {
+        return fail(res, 503, 'SOURCE_NOT_CONNECTED', 'The selected source is not connected');
       }
-    }
+      if (!acManager.canTransmit()) {
+        return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
+      }
 
-    let adminMessage: Uint8Array;
-
-    // Create the appropriate admin message based on command type
-    switch (command) {
-      case 'reboot':
-        adminMessage = protobufService.createRebootMessage(params.seconds || 10, sessionPasskey || undefined);
-        break;
-      case 'setOwner':
-        if (!params.longName || !params.shortName) {
-          return res.status(400).json({ error: 'longName and shortName are required for setOwner' });
-        }
-        adminMessage = protobufService.createSetOwnerMessage(
-          params.longName,
-          params.shortName,
-          params.isUnmessagable,
-          sessionPasskey || undefined,
-          params.isLicensed
-        );
-        break;
-      case 'setChannel':
-        if (params.channelIndex === undefined || !params.config) {
-          return res.status(400).json({ error: 'channelIndex and config are required for setChannel' });
-        }
-        adminMessage = protobufService.createSetChannelMessage(
-          params.channelIndex,
-          params.config,
-          sessionPasskey || undefined
-        );
-        break;
-      case 'setDeviceConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setDeviceConfig' });
-        }
-        adminMessage = protobufService.createSetDeviceConfigMessage(params.config, sessionPasskey || undefined);
-        break;
-      case 'setLoRaConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setLoRaConfig' });
-        }
-        adminMessage = protobufService.createSetLoRaConfigMessage(params.config, sessionPasskey || undefined);
-        break;
-      case 'setPositionConfig': {
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setPositionConfig' });
-        }
-        // Extract position coordinates from config - these must be sent via a separate
-        // setFixedPosition admin message, as Config.PositionConfig has no lat/lon/alt fields.
-        // Per protobuf docs, set_fixed_position automatically sets fixedPosition=true on the device.
-        // No delay needed: the local node queues both packets and the mesh protocol guarantees
-        // FIFO delivery from the same source, with natural spacing from radio transmission time.
-        const { latitude, longitude, altitude, ...positionConfig } = params.config;
-        if (latitude !== undefined && longitude !== undefined && positionConfig.fixedPosition) {
-          const setPositionMsg = protobufService.createSetFixedPositionMessage(
-            latitude,
-            longitude,
-            altitude || 0,
-            sessionPasskey || undefined
-          );
-          await acManager.sendAdminCommand(setPositionMsg, destinationNodeNum);
-
-          // Immediately update the local node's position in the database so it's correct
-          // before any stale position broadcast arrives from the device firmware.
-          if (isLocalNode && localNodeNum) {
-            const localNodeId = `!${localNodeNum.toString(16).padStart(8, '0')}`;
-            await databaseService.nodes.upsertNode({
-              nodeNum: localNodeNum,
-              nodeId: localNodeId,
-              latitude,
-              longitude,
-              altitude: altitude || 0,
-              positionTimestamp: Date.now(),
-            });
-            logger.debug(`⚙️ Updated local node ${localNodeId} position in database: lat=${latitude}, lon=${longitude}`);
+      const operation = adminOperationService.create(
+        { sourceId: acManager.sourceId, destinationNodeNum, command },
+        async (context) => {
+          try {
+            return await executeAdminCommand(
+              acManager,
+              command,
+              params,
+              destinationNodeNum,
+              localNodeNum,
+              false,
+              context,
+            );
+          } catch (error) {
+            if (isTxDisabledError(error)) {
+              throw new AdminOperationFailure('TX_DISABLED', 'Transmit is disabled on this source');
+            }
+            throw error;
           }
-        }
-        adminMessage = protobufService.createSetPositionConfigMessage(positionConfig, sessionPasskey || undefined);
-        break;
-      }
-      case 'setMQTTConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setMQTTConfig' });
-        }
-        adminMessage = protobufService.createSetMQTTConfigMessage(params.config, sessionPasskey || undefined);
-        break;
-      case 'setBluetoothConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setBluetoothConfig' });
-        }
-        adminMessage = protobufService.createSetDeviceConfigMessageGeneric('bluetooth', params.config, sessionPasskey || undefined);
-        break;
-      case 'setNetworkConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setNetworkConfig' });
-        }
-        adminMessage = protobufService.createSetNetworkConfigMessage(params.config, sessionPasskey || undefined);
-        break;
-      case 'setNeighborInfoConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setNeighborInfoConfig' });
-        }
-        adminMessage = protobufService.createSetNeighborInfoConfigMessage(params.config, sessionPasskey || undefined);
-        break;
-      case 'setTelemetryConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setTelemetryConfig' });
-        }
-        adminMessage = protobufService.createSetModuleConfigMessageGeneric('telemetry', params.config, sessionPasskey || undefined);
-        break;
-      case 'setStatusMessageConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setStatusMessageConfig' });
-        }
-        adminMessage = protobufService.createSetModuleConfigMessageGeneric('statusmessage', params.config, sessionPasskey || undefined);
-        break;
-      case 'setTrafficManagementConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setTrafficManagementConfig' });
-        }
-        adminMessage = protobufService.createSetModuleConfigMessageGeneric('trafficmanagement', params.config, sessionPasskey || undefined);
-        break;
-      case 'setSecurityConfig':
-        if (!params.config) {
-          return res.status(400).json({ error: 'config is required for setSecurityConfig' });
-        }
-        // IMPORTANT: Preserve existing public/private keys when updating security config
-        // If we don't include them, the firmware may reset them to empty/random values
-        // Only do this for LOCAL node - for remote nodes we don't have their private key
-        {
-          let configToSend = params.config;
-          if (isLocalNode) {
-            const existingKeys = acManager.getSecurityKeys();
-            configToSend = {
-              ...params.config,
-              // Include existing keys if not explicitly provided
-              publicKey: params.config.publicKey || existingKeys.publicKey,
-              privateKey: params.config.privateKey || existingKeys.privateKey
-            };
-            logger.debug('Preserving existing public/private keys for local node security config update');
-          } else {
-            // For remote nodes, explicitly exclude publicKey/privateKey to let firmware preserve them
-            // We don't have the remote node's private key, so we can't include it
-            const { publicKey, privateKey, ...remoteConfig } = params.config;
-            configToSend = remoteConfig;
-            logger.debug('Excluding publicKey/privateKey from remote node security config update');
-          }
-          adminMessage = protobufService.createSetSecurityConfigMessage(configToSend, sessionPasskey || undefined);
-        }
-        break;
-      case 'setFixedPosition':
-        if (params.latitude === undefined || params.longitude === undefined) {
-          return res.status(400).json({ error: 'latitude and longitude are required for setFixedPosition' });
-        }
-        adminMessage = protobufService.createSetFixedPositionMessage(
-          params.latitude,
-          params.longitude,
-          params.altitude || 0,
-          sessionPasskey || undefined
-        );
-        break;
-      case 'purgeNodeDb':
-        adminMessage = protobufService.createPurgeNodeDbMessage(params.seconds || 0, sessionPasskey || undefined);
-        break;
-      case 'beginEditSettings':
-        adminMessage = protobufService.createBeginEditSettingsMessage(sessionPasskey || undefined);
-        break;
-      case 'commitEditSettings':
-        adminMessage = protobufService.createCommitEditSettingsMessage(sessionPasskey || undefined);
-        break;
-      case 'removeNode':
-        if (params.nodeNum === undefined) {
-          return res.status(400).json({ error: 'nodeNum is required for removeNode' });
-        }
-        adminMessage = protobufService.createRemoveNodeMessage(params.nodeNum, sessionPasskey || undefined);
-        break;
-      case 'setFavoriteNode':
-        // Use favoriteNodeNum to avoid collision with destination nodeNum
-        if (params.favoriteNodeNum === undefined) {
-          return res.status(400).json({ error: 'favoriteNodeNum is required for setFavoriteNode' });
-        }
-        adminMessage = protobufService.createSetFavoriteNodeMessage(params.favoriteNodeNum, sessionPasskey || undefined);
-        break;
-      case 'removeFavoriteNode':
-        // Use favoriteNodeNum to avoid collision with destination nodeNum
-        if (params.favoriteNodeNum === undefined) {
-          return res.status(400).json({ error: 'favoriteNodeNum is required for removeFavoriteNode' });
-        }
-        adminMessage = protobufService.createRemoveFavoriteNodeMessage(params.favoriteNodeNum, sessionPasskey || undefined);
-        break;
-      case 'setIgnoredNode':
-        // Use targetNodeNum to avoid collision with destination nodeNum
-        if (params.targetNodeNum === undefined) {
-          return res.status(400).json({ error: 'targetNodeNum is required for setIgnoredNode' });
-        }
-        adminMessage = protobufService.createSetIgnoredNodeMessage(params.targetNodeNum, sessionPasskey || undefined);
-        break;
-      case 'removeIgnoredNode':
-        // Use targetNodeNum to avoid collision with destination nodeNum
-        if (params.targetNodeNum === undefined) {
-          return res.status(400).json({ error: 'targetNodeNum is required for removeIgnoredNode' });
-        }
-        adminMessage = protobufService.createRemoveIgnoredNodeMessage(params.targetNodeNum, sessionPasskey || undefined);
-        break;
-      default:
-        return res.status(400).json({ error: `Unknown command: ${command}` });
+        },
+      );
+      return res.status(202).json({ success: true, operation });
     }
 
-    // Send the admin command. For favorite changes to a REMOTE node we wait for
-    // the destination's routing ACK (admin packets set want_response) so the UI
-    // can confirm the remote node actually processed it. Everything else (and
-    // local-node favorites) fires as before.
-    const isFavoriteCommand = command === 'setFavoriteNode' || command === 'removeFavoriteNode';
-    let favoriteAck: { acked: boolean; errorReason: number | null; timedOut: boolean } | null = null;
-    if (isFavoriteCommand && !isLocalNode) {
-      favoriteAck = await acManager.sendAdminCommandAwaitAck(adminMessage, destinationNodeNum);
-    } else {
-      await acManager.sendAdminCommand(adminMessage, destinationNodeNum);
-    }
-
-    // For setSecurityConfig on the local node, update the cached config immediately
-    // so the frontend reads back the correct values before the next config sync
-    if (command === 'setSecurityConfig' && isLocalNode && params.config) {
-      acManager.updateCachedDeviceConfig('security', {
-        isManaged: params.config.isManaged,
-        serialEnabled: params.config.serialEnabled,
-        debugLogApiEnabled: params.config.debugLogApiEnabled,
-        adminChannelEnabled: params.config.adminChannelEnabled
-      });
-    }
-
-    // For setFixedPosition on the local node, immediately update the database
-    // so it's correct before any stale position broadcast arrives from the device firmware.
-    if (command === 'setFixedPosition' && isLocalNode && localNodeNum) {
-      const localNodeId = `!${localNodeNum.toString(16).padStart(8, '0')}`;
-      await databaseService.nodes.upsertNode({
-        nodeNum: localNodeNum,
-        nodeId: localNodeId,
-        latitude: params.latitude,
-        longitude: params.longitude,
-        altitude: params.altitude || 0,
-        positionTimestamp: Date.now(),
-      });
-      logger.debug(`⚙️ Updated local node ${localNodeId} position in database: lat=${params.latitude}, lon=${params.longitude}`);
-    }
-
-    // If command succeeded on a remote node, update hasRemoteAdmin flag
-    if (!isLocalNode) {
-      try {
-        await databaseService.updateNodeRemoteAdminStatusAsync(
-          destinationNodeNum,
-          true,
-          null,  // Don't overwrite existing metadata, just set the flag
-          acManager.sourceId
-        );
-        logger.debug(`✅ Updated hasRemoteAdmin=true for node ${destinationNodeNum} after successful '${command}' command`);
-      } catch (dbError) {
-        logger.error(`Failed to update hasRemoteAdmin for node ${destinationNodeNum}:`, dbError);
-        // Continue with response even if database update fails
-      }
-    }
-
-    res.json({
-      success: true,
-      message: `Admin command '${command}' sent to node ${destinationNodeNum}`,
-      ...(favoriteAck ? {
-        ack: {
-          acked: favoriteAck.acked,
-          timedOut: favoriteAck.timedOut,
-          errorReason: favoriteAck.errorReason,
-          status: favoriteAck.timedOut
-            ? 'timeout'
-            : (favoriteAck.acked ? 'confirmed' : getRoutingErrorName(favoriteAck.errorReason ?? -1)),
-        }
-      } : {})
-    });
+    const result = await executeAdminCommand(
+      acManager,
+      command,
+      params,
+      destinationNodeNum,
+      localNodeNum,
+      true,
+    );
+    return res.json({ success: true, ...result });
   } catch (error: any) {
     if (isTxDisabledError(error)) {
       return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');

--- a/src/server/services/adminOperationService.test.ts
+++ b/src/server/services/adminOperationService.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AdminOperationFailure, AdminOperationService } from './adminOperationService.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('AdminOperationService', () => {
+  let scheduled: Array<() => void>;
+  let now: number;
+  let service: AdminOperationService;
+
+  beforeEach(() => {
+    scheduled = [];
+    now = 1000;
+    service = new AdminOperationService({
+      now: () => now,
+      schedule: (callback) => scheduled.push(callback),
+    });
+  });
+
+  it('returns a pending snapshot before starting background work', () => {
+    const executor = vi.fn();
+    const operation = service.create(
+      { sourceId: 'source-a', destinationNodeNum: 123, command: 'reboot' },
+      executor,
+    );
+
+    expect(operation).toMatchObject({
+      sourceId: 'source-a',
+      destinationNodeNum: 123,
+      command: 'reboot',
+      status: 'pending',
+      phase: 'queued',
+    });
+    expect(executor).not.toHaveBeenCalled();
+    expect(service.get(operation.id)).toEqual(operation);
+  });
+
+  it('tracks phase changes and successful completion', async () => {
+    const completion = deferred<{ message: string }>();
+    const operation = service.create(
+      { sourceId: 'source-a', destinationNodeNum: 123, command: 'setOwner' },
+      async ({ setPhase }) => {
+        setPhase('sending');
+        return completion.promise;
+      },
+    );
+
+    scheduled.shift()!();
+    await vi.waitFor(() => expect(service.get(operation.id)?.phase).toBe('sending'));
+    now = 2000;
+    completion.resolve({ message: 'sent' });
+
+    await vi.waitFor(() => expect(service.get(operation.id)?.status).toBe('succeeded'));
+    expect(service.get(operation.id)).toMatchObject({
+      phase: 'complete',
+      updatedAt: 2000,
+      result: { message: 'sent' },
+    });
+  });
+
+  it.each([
+    [{ acked: false, timedOut: true, errorReason: null, status: 'timeout' }, 'timed_out'],
+    [{ acked: false, timedOut: false, errorReason: 5, status: 'MAX_RETRANSMIT' }, 'rejected'],
+  ] as const)('maps ACK result %o to %s', async (ack, expectedStatus) => {
+    const operation = service.create(
+      { sourceId: 'source-a', destinationNodeNum: 123, command: 'setFavoriteNode' },
+      async () => ({ message: 'sent', ack: { ...ack } }),
+    );
+    scheduled.shift()!();
+
+    await vi.waitFor(() => expect(service.get(operation.id)?.status).toBe(expectedStatus));
+  });
+
+  it('maps passkey timeout to a stable timeout error', async () => {
+    const operation = service.create(
+      { sourceId: 'source-a', destinationNodeNum: 123, command: 'reboot' },
+      async () => { throw new AdminOperationFailure('REMOTE_PASSKEY_TIMEOUT', 'Remote node did not respond'); },
+    );
+    scheduled.shift()!();
+
+    await vi.waitFor(() => expect(service.get(operation.id)?.status).toBe('timed_out'));
+    expect(service.get(operation.id)?.error).toEqual({
+      code: 'REMOTE_PASSKEY_TIMEOUT',
+      message: 'Remote node did not respond',
+    });
+  });
+
+  it('captures unexpected background rejection without leaking an unhandled promise', async () => {
+    const failure = deferred<{ message: string }>();
+    const operation = service.create(
+      { sourceId: 'source-a', destinationNodeNum: 123, command: 'reboot' },
+      async () => failure.promise,
+    );
+    scheduled.shift()!();
+    failure.reject(new Error('transport closed'));
+
+    await vi.waitFor(() => expect(service.get(operation.id)?.status).toBe('failed'));
+    expect(service.get(operation.id)?.error).toEqual({
+      code: 'TRANSPORT_FAILURE',
+      message: 'transport closed',
+    });
+  });
+
+  it('expires terminal operation results after the retention window', async () => {
+    const expiringService = new AdminOperationService({ retentionMs: 200 });
+    const operation = expiringService.create(
+      { sourceId: 'source-a', destinationNodeNum: 123, command: 'reboot' },
+      async () => ({ message: 'sent' }),
+    );
+
+    await vi.waitFor(() => expect(expiringService.get(operation.id)?.status).toBe('succeeded'));
+    await vi.waitFor(() => expect(expiringService.get(operation.id)).toBeUndefined());
+  });
+});

--- a/src/server/services/adminOperationService.ts
+++ b/src/server/services/adminOperationService.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  AdminCommandResult,
+  AdminOperation,
+  AdminOperationError,
+  AdminOperationPhase,
+  AdminOperationStatus,
+} from '../../types/adminOperations.js';
+import { logger } from '../../utils/logger.js';
+
+const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
+
+export class AdminOperationFailure extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AdminOperationFailure';
+  }
+}
+
+export interface AdminOperationContext {
+  setPhase(phase: Exclude<AdminOperationPhase, 'queued' | 'complete'>): void;
+}
+
+type AdminOperationExecutor = (context: AdminOperationContext) => Promise<AdminCommandResult>;
+
+interface CreateAdminOperationInput {
+  sourceId: string;
+  destinationNodeNum: number;
+  command: string;
+}
+
+interface AdminOperationServiceOptions {
+  retentionMs?: number;
+  now?: () => number;
+  schedule?: (callback: () => void) => void;
+}
+
+/**
+ * Tracks short-lived remote-admin work after its initiating HTTP request has
+ * returned. Operations intentionally remain process-local: a server restart
+ * interrupts the underlying radio transaction too, so restoring stale rows
+ * from a database would imply continuity that does not exist.
+ */
+export class AdminOperationService {
+  private readonly operations = new Map<string, AdminOperation>();
+  private readonly retentionMs: number;
+  private readonly now: () => number;
+  private readonly schedule: (callback: () => void) => void;
+
+  constructor(options: AdminOperationServiceOptions = {}) {
+    this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS;
+    this.now = options.now ?? Date.now;
+    this.schedule = options.schedule ?? ((callback) => { setImmediate(callback); });
+  }
+
+  create(input: CreateAdminOperationInput, executor: AdminOperationExecutor): AdminOperation {
+    const timestamp = this.now();
+    const operation: AdminOperation = {
+      id: randomUUID(),
+      sourceId: input.sourceId,
+      destinationNodeNum: input.destinationNodeNum,
+      command: input.command,
+      status: 'pending',
+      phase: 'queued',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    this.operations.set(operation.id, operation);
+
+    this.schedule(() => {
+      void this.run(operation.id, executor);
+    });
+
+    return this.snapshot(operation);
+  }
+
+  get(operationId: string): AdminOperation | undefined {
+    const operation = this.operations.get(operationId);
+    return operation ? this.snapshot(operation) : undefined;
+  }
+
+  /** Test seam; production cleanup is timer-driven. */
+  clear(): void {
+    this.operations.clear();
+  }
+
+  private async run(operationId: string, executor: AdminOperationExecutor): Promise<void> {
+    const operation = this.operations.get(operationId);
+    if (!operation) return;
+
+    this.update(operation, 'running', 'acquiring_passkey');
+    try {
+      const result = await executor({
+        setPhase: (phase) => {
+          const current = this.operations.get(operationId);
+          if (current && !this.isTerminal(current.status)) {
+            this.update(current, 'running', phase);
+          }
+        },
+      });
+
+      const status: AdminOperationStatus = result.ack?.timedOut
+        ? 'timed_out'
+        : (result.ack && !result.ack.acked ? 'rejected' : 'succeeded');
+      operation.status = status;
+      operation.phase = 'complete';
+      operation.result = result;
+      if (status === 'rejected') {
+        operation.error = {
+          code: 'ROUTING_REJECTED',
+          message: `The remote node rejected the command: ${result.ack?.status || 'unknown routing error'}`,
+        };
+      }
+      operation.updatedAt = this.now();
+    } catch (error) {
+      const failure = this.toOperationError(error);
+      operation.status = failure.code === 'REMOTE_PASSKEY_TIMEOUT' ? 'timed_out' : 'failed';
+      operation.phase = 'complete';
+      operation.error = failure;
+      operation.updatedAt = this.now();
+      logger.error(
+        `[AdminOperation] ${operation.command} for node ${operation.destinationNodeNum} failed: ${failure.message}`,
+      );
+    } finally {
+      const timer = setTimeout(() => this.operations.delete(operationId), this.retentionMs);
+      timer.unref?.();
+    }
+  }
+
+  private update(
+    operation: AdminOperation,
+    status: AdminOperationStatus,
+    phase: AdminOperationPhase,
+  ): void {
+    operation.status = status;
+    operation.phase = phase;
+    operation.updatedAt = this.now();
+  }
+
+  private isTerminal(status: AdminOperationStatus): boolean {
+    return status === 'succeeded' || status === 'failed' || status === 'timed_out' || status === 'rejected';
+  }
+
+  private toOperationError(error: unknown): AdminOperationError {
+    if (error instanceof AdminOperationFailure) {
+      return { code: error.code, message: error.message };
+    }
+    return {
+      code: 'TRANSPORT_FAILURE',
+      message: error instanceof Error ? error.message : 'Failed to execute admin command',
+    };
+  }
+
+  private snapshot(operation: AdminOperation): AdminOperation {
+    return {
+      ...operation,
+      ...(operation.result ? { result: { ...operation.result, ...(operation.result.ack ? { ack: { ...operation.result.ack } } : {}) } } : {}),
+      ...(operation.error ? { error: { ...operation.error } } : {}),
+    };
+  }
+}
+
+export const adminOperationService = new AdminOperationService();

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -1226,3 +1226,86 @@ describe('ApiService BASE_URL Support', () => {
     });
   });
 });
+
+describe('ApiService remote admin operation polling', () => {
+  beforeEach(() => {
+    (apiService as any).baseUrl = '';
+    (apiService as any).configFetched = true;
+    mockFetch.mockReset();
+  });
+
+  it('polls until a remote command reaches a terminal result', async () => {
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        success: true,
+        operation: {
+          id: 'op-1', status: 'running', phase: 'sending', command: 'reboot',
+          sourceId: 'source-a', destinationNodeNum: 9, createdAt: 1, updatedAt: 2,
+        },
+      }))
+      .mockResolvedValueOnce(createMockResponse({
+        success: true,
+        operation: {
+          id: 'op-1', status: 'succeeded', phase: 'complete', command: 'reboot',
+          sourceId: 'source-a', destinationNodeNum: 9, createdAt: 1, updatedAt: 3,
+          result: { message: 'sent' },
+        },
+      }));
+
+    await expect(apiService.waitForAdminOperation('op-1', 0)).resolves.toEqual({
+      success: true,
+      message: 'sent',
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns uncertain ACK timeouts and routing rejections to the caller', async () => {
+    for (const [status, ack] of [
+      ['timed_out', { acked: false, timedOut: true, errorReason: null, status: 'timeout' }],
+      ['rejected', { acked: false, timedOut: false, errorReason: 5, status: 'MAX_RETRANSMIT' }],
+    ] as const) {
+      mockFetch.mockResolvedValueOnce(createMockResponse({
+        success: true,
+        operation: {
+          id: `op-${status}`, status, phase: 'complete', command: 'setFavoriteNode',
+          sourceId: 'source-a', destinationNodeNum: 9, createdAt: 1, updatedAt: 2,
+          result: { message: 'sent', ack },
+        },
+      }));
+
+      await expect(apiService.waitForAdminOperation(`op-${status}`, 0)).resolves.toMatchObject({ ack });
+    }
+  });
+
+  it('surfaces background failures with their stable code', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({
+      success: true,
+      operation: {
+        id: 'op-failed', status: 'failed', phase: 'complete', command: 'reboot',
+        sourceId: 'source-a', destinationNodeNum: 9, createdAt: 1, updatedAt: 2,
+        error: { code: 'TRANSPORT_FAILURE', message: 'transport closed' },
+      },
+    }));
+
+    await expect(apiService.waitForAdminOperation('op-failed', 0)).rejects.toMatchObject({
+      code: 'TRANSPORT_FAILURE',
+      message: 'transport closed',
+    });
+  });
+
+  it('presents a lost operation as interrupted after restart or expiry', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ...createMockResponse({
+        success: false,
+        code: 'ADMIN_OPERATION_NOT_FOUND',
+        error: 'Admin operation was not found or has expired',
+      }, false),
+      status: 404,
+    });
+
+    await expect(apiService.waitForAdminOperation('lost', 0)).rejects.toMatchObject({
+      code: 'ADMIN_OPERATION_INTERRUPTED',
+      status: 409,
+    });
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -9,6 +9,10 @@ import {
   validateIntervalMinutes
 } from '../utils/validation';
 import { logger } from '../utils/logger.js';
+import type {
+  AdminCommandSuccessResponse,
+  AdminOperationStatusResponse,
+} from '../types/adminOperations.js';
 
 export type SignalTrend = 'improving' | 'stable' | 'degrading' | 'insufficient';
 
@@ -251,6 +255,54 @@ class ApiService {
   // Generic POST method
   async post<T>(endpoint: string, body?: any): Promise<T> {
     return this.request<T>('POST', endpoint, body);
+  }
+
+  async waitForAdminOperation(
+    operationId: string,
+    pollIntervalMs = 1000,
+    timeoutMs = 90_000,
+  ): Promise<AdminCommandSuccessResponse> {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < timeoutMs) {
+      let response: AdminOperationStatusResponse;
+      try {
+        response = await this.get<AdminOperationStatusResponse>(
+          `/api/admin/commands/${encodeURIComponent(operationId)}`,
+        );
+      } catch (error) {
+        if (error instanceof ApiError && error.code === 'ADMIN_OPERATION_NOT_FOUND') {
+          throw new ApiError(
+            'The admin operation was interrupted by a server restart or expired before completion',
+            409,
+            { code: 'ADMIN_OPERATION_INTERRUPTED', body: error.body },
+          );
+        }
+        throw error;
+      }
+
+      const { operation } = response;
+      if (operation.status === 'failed' || (operation.status === 'timed_out' && operation.error)) {
+        throw new ApiError(operation.error?.message || 'Admin operation failed', 500, {
+          code: operation.error?.code || 'ADMIN_COMMAND_FAILED',
+          body: operation.error,
+        });
+      }
+      if (operation.status === 'succeeded' || operation.status === 'timed_out' || operation.status === 'rejected') {
+        if (!operation.result) {
+          throw new ApiError('Admin operation completed without a result', 500, {
+            code: 'ADMIN_OPERATION_INVALID_RESULT',
+          });
+        }
+        return { success: true, ...operation.result };
+      }
+
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new ApiError('Timed out while checking admin operation status', 504, {
+      code: 'ADMIN_OPERATION_STATUS_TIMEOUT',
+    });
   }
 
   // Generic PUT method

--- a/src/types/adminOperations.ts
+++ b/src/types/adminOperations.ts
@@ -1,0 +1,60 @@
+export type AdminOperationStatus =
+  | 'pending'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'timed_out'
+  | 'rejected';
+
+export type AdminOperationPhase =
+  | 'queued'
+  | 'acquiring_passkey'
+  | 'sending'
+  | 'awaiting_ack'
+  | 'complete';
+
+export interface AdminCommandAck {
+  acked: boolean;
+  timedOut: boolean;
+  errorReason: number | null;
+  status: string;
+}
+
+export interface AdminCommandResult {
+  message: string;
+  ack?: AdminCommandAck;
+}
+
+export interface AdminOperationError {
+  code: string;
+  message: string;
+}
+
+export interface AdminOperation {
+  id: string;
+  sourceId: string;
+  destinationNodeNum: number;
+  command: string;
+  status: AdminOperationStatus;
+  phase: AdminOperationPhase;
+  createdAt: number;
+  updatedAt: number;
+  result?: AdminCommandResult;
+  error?: AdminOperationError;
+}
+
+export interface AdminOperationAcceptedResponse {
+  success: true;
+  operation: AdminOperation;
+}
+
+export interface AdminOperationStatusResponse {
+  success: true;
+  operation: AdminOperation;
+}
+
+export interface AdminCommandSuccessResponse extends AdminCommandResult {
+  success: true;
+}
+
+export type AdminCommandResponse = AdminCommandSuccessResponse | AdminOperationAcceptedResponse;


### PR DESCRIPTION
## Summary

- return `202 Accepted` for validated remote admin commands and execute passkey acquisition/transmission outside the Express request lifecycle
- add an admin-protected, in-memory operation status API with UUID identifiers, explicit phases/statuses, stable error codes, and five-minute terminal retention
- keep the existing frontend promise/loading/toast flow by polling operation status, including optimistic timeout semantics and explicit rejection handling for favorite/ignore commands
- preserve synchronous `200` behavior for local-node commands and add no new UI
- document the asynchronous API and confirmation/failure semantics

## Root cause

A remote admin request could synchronously spend up to 45 seconds acquiring a session passkey and then another 30 seconds awaiting a routing ACK. Holding the HTTP request open for that mesh work made otherwise valid commands vulnerable to proxy/origin disconnects and HTML `502` responses.

## API compatibility

- Local commands retain their existing synchronous `200` response.
- Remote commands now return `202` with an operation snapshot.
- The bundled frontend polls `GET /api/admin/commands/:operationId` until a terminal result, so existing control disabling, command sequencing, and toast behavior are preserved.
- Favorite, unfavorite, ignore, and unignore await routing ACKs. ACK timeout remains uncertain/optimistic; explicit rejection does not mutate client state.

## Validation

Passed:

- targeted operation, route, API, and frontend tests: 117/117
- `npm run lint:ci`
- `npm run typecheck`
- `npm run build`
- `npm run build:server`
- `npm run docs:build`

Repository baselines observed locally:

- `npm run lint` reports the existing raw-lint baseline (2,275 findings); the enforced lint ratchet passes and improves touched-file counts.
- `npm run typecheck:tests` reports 405 existing test-type errors, with none in files changed by this PR.
- `npm run test:run` completed 12,917 passing tests and reported eight failures in unrelated MeshCore virtual-node timing and link-preview URL-validation tests. The same two files remain reproducibly failing when run alone in this local Node 25 environment; no code in those paths is changed here.

Fixes #4482
