### PR TITLE
feat(nav): move the Meshtastic phone nav to the shared bottom bar (#4473)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1415,7 +1415,11 @@ body {
   /* Update layout dimensions for mobile - !important needed to override theme-specific selectors */
   :root {
     --header-height: 40px !important;
-    --sidebar-width: 48px !important;
+    /* The nav is a bottom bar on phones (#4473 phase 2), so it occupies no
+       horizontal space and everything positioned off this variable spans the
+       full width. Vertical room is reserved via --app-nav-bar-height. */
+    --sidebar-width: 0px !important;
+    --app-nav-bar-height: 56px;
   }
 
   /* Reduce font size globally on mobile */
@@ -1436,8 +1440,13 @@ body {
   .app-main {
     padding: 0.5rem;
     padding-top: calc(var(--header-height) + 0.5rem); /* Account for fixed header + desired padding */
-    padding-bottom: max(0.5rem, env(safe-area-inset-bottom)); /* Account for iPhone home indicator */
-    padding-left: 56px; /* 48px sidebar + 8px gap */
+    /* Clear the bottom bar as well as the iPhone home indicator — the bar is
+       fixed and would otherwise cover the end of the content. */
+    padding-bottom: calc(
+      var(--app-nav-bar-height, 56px) + max(0.5rem, env(safe-area-inset-bottom))
+    );
+    /* Was 56px to clear the old 48px left rail; the rail is gone. */
+    padding-left: 0.5rem;
     margin-left: 0 !important;
     width: 100% !important;
   }
@@ -2964,12 +2973,18 @@ body {
 @media (max-height: 500px) and (orientation: landscape) {
   :root {
     --header-height: 40px !important;
-    --sidebar-width: 48px !important;
+    /* Bottom bar here too (#4473 phase 2) — SourceNav's mobile query covers
+       this viewport as well, so the two stay in agreement. Shorter bar: vertical
+       space is the scarce axis in landscape. */
+    --sidebar-width: 0px !important;
+    --app-nav-bar-height: 44px;
   }
 
   .app-main {
     padding-top: calc(var(--header-height) + 0.25rem);
-    padding-bottom: max(0.25rem, env(safe-area-inset-bottom));
+    padding-bottom: calc(
+      var(--app-nav-bar-height, 44px) + max(0.25rem, env(safe-area-inset-bottom))
+    );
   }
 
   /* Compact channel conversation for landscape */

--- a/src/App.css
+++ b/src/App.css
@@ -1502,11 +1502,16 @@ body {
     /* The base .app-main reserves env(safe-area-inset-bottom) via its
        padding-bottom, but .send-message-form (the bottom-most element) ALSO
        pads itself by that inset — applying the home-indicator gap twice and
-       leaving dead space below the input. Drop it here so the send bar owns
-       the safe area (its background reaches the screen edge, its controls stay
-       above the indicator). env() is 0 on non-notch devices/desktop, so this
-       is a no-op there. */
-    padding-bottom: 0;
+       leaving dead space below the input. So the safe-area component is
+       deliberately NOT repeated here; the send bar owns it (its background
+       reaches the screen edge, its controls stay above the indicator).
+       env() is 0 on non-notch devices/desktop, so that part is a no-op there.
+
+       The bar height, however, must still be reserved: this used to be a flat
+       `0`, which was correct while nothing occupied the bottom strip. Since the
+       mobile nav became a bottom bar (#4473 phase 2) a flat 0 runs the compose
+       row — send, location and bell — underneath it. */
+    padding-bottom: var(--app-nav-bar-height, 56px);
   }
 
   /* The page-level bottom spacer (.app-main::after) would add dead space

--- a/src/components/SaveBar/SaveBar.css
+++ b/src/components/SaveBar/SaveBar.css
@@ -16,6 +16,18 @@
   left: var(--sidebar-collapsed-width, 60px);
 }
 
+/*
+ * On mobile the nav is a bottom bar (#4473 phase 2), which docks in the same
+ * strip as this one. Sit above it rather than sharing the space — the save bar
+ * is an action surface and must stay reachable.
+ */
+@media (max-width: 768px), (max-height: 500px) and (orientation: landscape) {
+  .save-bar {
+    bottom: calc(var(--app-nav-bar-height, 56px) + env(safe-area-inset-bottom, 0px));
+    padding-bottom: 0;
+  }
+}
+
 @keyframes saveBarSlideIn {
   from {
     transform: translateY(100%);

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -176,41 +176,6 @@
 /* Main content always accounts for narrow sidebar */
 /* Removed old layout-affecting rules - sidebar now floats over content */
 
-/* Mobile responsive - portrait only */
-@media (max-width: 768px) and (orientation: portrait) {
-  .sidebar {
-    /* Collapsed by default - show as hamburger icon only. Set through the
-       custom properties SourceNav reads, not a `width` declaration, so this
-       can't end up racing the module's own width rule on stylesheet order. */
-    --source-nav-collapsed-width: 48px;
-    --source-nav-expanded-width: 240px;
-    padding-bottom: 6rem; /* Extra padding on mobile for home indicator */
-    padding-bottom: max(6rem, calc(env(safe-area-inset-bottom) + 4rem));
-  }
-
-  .sidebar:not(.collapsed) {
-    /* When expanded, slide in from left */
-    box-shadow: 2px 0 16px rgba(0, 0, 0, 0.3);
-  }
-
-  .app-main {
-    margin-left: 0 !important;
-    width: 100% !important;
-  }
-
-  /* Show toggle button prominently on mobile */
-  .sidebar-toggle {
-    background: var(--ctp-blue);
-    color: var(--ctp-crust);
-    right: 6px;
-  }
-
-  .sidebar.collapsed .sidebar-toggle {
-    /* Make hamburger menu more visible when collapsed on mobile */
-    background: var(--ctp-blue);
-    color: var(--ctp-crust);
-  }
-}
 
 /* Mobile responsive - landscape: minimal changes to fix layout */
 @media (orientation: landscape) and (max-height: 700px) {
@@ -258,35 +223,14 @@
     display: none; /* Hide node name to save space */
   }
 
-  .sidebar-nav {
-    padding: 2px 4px 40px 4px !important; /* Minimal padding - override mobile portrait */
-    gap: 1px;
-    flex: 1;
-    min-height: 0; /* Allow flex shrinking */
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
-  }
+  /* `.sidebar-nav`, `.sidebar-nav-item` and `.sidebar-section*` rules were
+     removed here too: those classes moved into SourceNav.module.css in
+     #4473 phase 1, so the landscape overrides had been matching nothing. */
 
-  .sidebar-nav-item {
-    padding: 5px 8px;
-    font-size: 12px;
-    min-height: 28px; /* Ensure minimum tap target */
-  }
 
-  .sidebar-nav-item .nav-icon {
-    font-size: 16px;
-    width: 20px;
-  }
 
-  .sidebar-section-header {
-    font-size: 9px;
-    padding: 4px 8px 2px 8px;
-    margin-top: 2px;
-  }
 
-  .sidebar-section {
-    gap: 1px;
-  }
+
 
   /* The footer hides itself in landscape (SidebarFooter's
      hideOnCompactLandscape) to maximize nav space, so the controls can float
@@ -313,15 +257,7 @@
     width: calc(48px + env(safe-area-inset-left, 0px)) !important;
   }
 
-  .sidebar.collapsed .sidebar-nav {
-    overflow-y: auto !important;
-    -webkit-overflow-scrolling: touch;
-  }
 
-  .sidebar.collapsed .sidebar-nav-item {
-    max-width: 100% !important;
-    overflow: hidden !important;
-  }
 
   .sidebar.collapsed .sidebar-header {
     padding: 4px;
@@ -334,28 +270,8 @@
     height: 28px;
   }
 
-  .sidebar.collapsed .sidebar-nav {
-    padding: 4px 4px 40px 4px !important;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
 
-  .sidebar.collapsed .sidebar-nav-item {
-    padding: 8px;
-    justify-content: center;
-    min-height: 32px;
-    display: flex;
-    align-items: center;
-  }
 
-  .sidebar.collapsed .sidebar-nav-item .nav-icon {
-    font-size: 18px;
-    width: auto;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 
   .sidebar.collapsed .sidebar-controls {
     bottom: 4px;
@@ -366,5 +282,63 @@
     width: 32px;
     height: 32px;
     font-size: 14px;
+  }
+}
+
+
+/* ============================================================================
+ * MOBILE BOTTOM BAR — MUST STAY LAST IN THIS FILE (#4473 phase 2)
+ *
+ * The two landscape blocks above set `.sidebar` padding with `!important` to
+ * compact the vertical rail. Among `!important` declarations at equal
+ * specificity the LAST one wins, so when this block sat before them the bar
+ * inherited 2px/8px of rail padding: 53.7px tall against the 44px the shell
+ * reserves, leaving content and the save bar underneath it.
+ *
+ * Same cascade-order trap as nodes.css (#3532). Do not move this block up.
+ * ============================================================================ */
+/*
+ * Mobile — the sidebar is a bottom bar (#4473 phase 2).
+ *
+ * Matches SourceNav.module.css's mobile query exactly (width OR landscape
+ * phone), not portrait-only as before: the two must agree or the shell reserves
+ * space for a rail the nav isn't drawing, or vice versa.
+ */
+@media (max-width: 768px), (max-height: 500px) and (orientation: landscape) {
+  .sidebar {
+    /* Undo the full-height fixed rail. SourceNav's .mobileBottomBar docks
+       itself; these override the geometry `.sidebar` sets unconditionally
+       above, which would otherwise keep it pinned top-to-bottom. */
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: auto;
+    /*
+     * `!important` only to beat the two `@media (max-height: 700px) and
+     * (orientation: landscape)` blocks further down, which set padding with
+     * `!important` to compact the *rail*. On a bottom bar that padding is just
+     * height: it inflated the landscape bar to 53.7px against the 44px the
+     * shell reserves, so content and the save bar sat under it.
+     */
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    border-right: none;
+    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.25);
+    /*
+     * Down from 10001. As a slide-in left rail the sidebar had to overlay the
+     * page; as a bottom bar it is shell furniture, and every modal/overlay in
+     * the app (z-index 1000..10002) should cover it the way it covers the rest
+     * of the page. 900 still clears ordinary page content, and the header
+     * (10000) and banners (9999) are top-anchored so they never overlap it.
+     */
+    z-index: 900;
+  }
+
+  .app-main {
+    margin-left: 0 !important;
+    width: 100% !important;
   }
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -108,10 +108,22 @@ const Sidebar: React.FC<SidebarProps> = ({
   // Update CSS custom property when sidebar collapse state changes
   React.useEffect(() => {
     const updateSidebarWidth = () => {
-      const isMobile = window.matchMedia('(max-width: 768px)').matches;
-      const baseCollapsedWidth = isMobile ? 48 : 60;
-      const baseExpandedWidth = 240;
-      const baseWidth = isCollapsed ? baseCollapsedWidth : baseExpandedWidth;
+      // Mirrors the two mobile media queries in App.css — keep in sync.
+      const isMobile =
+        window.matchMedia('(max-width: 768px)').matches ||
+        window.matchMedia('(max-height: 500px) and (orientation: landscape)').matches;
+
+      if (isMobile) {
+        // The nav is a bottom bar on phones (#4473 phase 2), so it occupies no
+        // horizontal space at all. Everything positioned off `--sidebar-width`
+        // (app-main, header, banners, save bar, the map/list split) correctly
+        // spans the full width once this is 0; vertical room for the bar is
+        // reserved separately via `--app-nav-bar-height`.
+        document.documentElement.style.setProperty('--sidebar-width', '0px');
+        return;
+      }
+
+      const baseWidth = isCollapsed ? 60 : 240;
       // Use calc() to include safe-area-inset-left for iPhone notch in landscape
       document.documentElement.style.setProperty(
         '--sidebar-width',
@@ -229,10 +241,10 @@ const Sidebar: React.FC<SidebarProps> = ({
       sections={sections}
       activeId={activeTab}
       collapsed={isCollapsed}
-      /* Still a left rail on phones. The bottom-bar variant is the eventual
-         target (#4473), but the whole app layout is positioned off
-         `--sidebar-width`, so that move is its own change. */
-      mobileVariant="rail"
+      /* Phones get the same scrollable bottom bar as MeshCore (#4473 phase 2).
+         The app shell reserves room for it via `--sidebar-width: 0` plus
+         `--app-nav-bar-height` — see updateSidebarWidth() below and App.css. */
+      mobileVariant="bottom-bar"
       ariaLabel={t('nav.section_main')}
       header={
         <div className="sidebar-header">

--- a/src/components/nav/SourceNav.mobile.test.ts
+++ b/src/components/nav/SourceNav.mobile.test.ts
@@ -42,7 +42,24 @@ describe('SourceNav mobile bottom bar (#4473)', () => {
 
   it('keeps labels visible on the bar even when the desktop rail is collapsed', () => {
     // An icon-only bottom bar is the other half of the reported complaint.
-    expect(css).toMatch(/\.mobileBottomBar\.collapsed \.label[\s\S]{0,120}display:\s*block/);
+    expect(css).toMatch(/\.mobileBottomBar \.label \{[^}]*display:\s*block/);
+  });
+
+  it('keeps bottom-bar rules one class deep so the landscape block can override them', () => {
+    // A `.mobileBottomBar.collapsed .item` rule (specificity 0,3,0) outranks the
+    // landscape override (0,2,0) wherever it sits in the file. That is what left
+    // the landscape bar 63px tall while the shell reserved 44px for it.
+    // Comments are stripped first — the note above this rule in the stylesheet
+    // quotes the very selector being banned.
+    const rules = css.replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(rules).not.toMatch(/\.mobileBottomBar\.(collapsed|expanded)\s+\.(item|label)\b/);
+  });
+
+  it('reserves a bar height for the app shell in both orientations', () => {
+    // App.css reserves --app-nav-bar-height to keep content clear of the bar;
+    // these must stay in step or content sits under it.
+    expect(css).toMatch(/--source-nav-bar-height:\s*56px/);
+    expect(css).toMatch(/--source-nav-bar-height:\s*44px/);
   });
 
   it('themes through custom properties so consumer stylesheets cannot race it', () => {

--- a/src/components/nav/SourceNav.module.css
+++ b/src/components/nav/SourceNav.module.css
@@ -175,10 +175,17 @@
 }
 
 /* ============================================================
- * Mobile — 768px breakpoint
+ * Mobile
+ *
+ * Both conditions, not just the width one. A landscape phone (e.g. 800x400) is
+ * WIDER than 768px but is still the mobile layout — App.css's two `:root`
+ * mobile blocks and Sidebar's updateSidebarWidth() both treat it that way. If
+ * this query covered only max-width, such a viewport would zero
+ * `--sidebar-width` while the nav still rendered as a vertical rail, and page
+ * content would slide underneath it.
  * ============================================================ */
 
-@media (max-width: 768px) {
+@media (max-width: 768px), (max-height: 500px) and (orientation: landscape) {
   /*
    * Bottom bar. The bug this fixes (#4473): items used to be `flex: 1 1 0` with
    * `min-width: 0`, so 11 entries split a ~390px phone into ~35px each and every
@@ -245,9 +252,21 @@
     font-size: 0.7rem;
   }
 
-  /* Labels stay visible on the bar even when the desktop rail is collapsed —
-     an icon-only bottom bar is exactly the affordance gap #4473 reported. */
-  .mobileBottomBar.collapsed .label,
+  /*
+   * Labels stay visible on the bar even when the desktop rail is collapsed —
+   * an icon-only bottom bar is exactly the affordance gap #4473 reported.
+   *
+   * Deliberately ONE class deep (`.mobileBottomBar .label`, not
+   * `.mobileBottomBar.collapsed .label`). It beats the `.collapsed .label`
+   * rule above on source order at equal specificity, and staying at that depth
+   * leaves the landscape block below — same specificity, later in the file —
+   * able to override it. A compound `.mobileBottomBar.collapsed` version would
+   * outrank the landscape rule no matter where it sat, which is precisely the
+   * bug that made the landscape bar 63px tall while the shell reserved 44px.
+   *
+   * Ordering within one authored file is fine; #4478's hazard was two files
+   * racing, which is why theme/width still cross the boundary as properties.
+   */
   .mobileBottomBar .label {
     display: block;
     flex: none;
@@ -258,10 +277,6 @@
     text-overflow: ellipsis;
   }
 
-  .mobileBottomBar.collapsed .item {
-    padding: 0.5rem 0.6rem;
-  }
-
   .mobileBottomBar .active {
     /* A filled pill is too heavy at bar size; underline the active entry. */
     background: transparent;
@@ -269,13 +284,54 @@
     box-shadow: inset 0 -2px 0 0 var(--ctp-blue);
   }
 
-  /* The collapse toggle is meaningless on a bottom bar. */
-  .mobileBottomBar .controls {
+  /*
+   * A logo block, a pin/collapse cluster and a footer are vertical-rail
+   * affordances — laid out in a horizontal bar they'd eat the row and push the
+   * nav items off-screen. MeshCore passes none of these; Meshtastic passes all
+   * three, which is why the bar only needed this once Meshtastic joined it.
+   */
+  .mobileBottomBar .controls,
+  .mobileBottomBar .controlsSlot,
+  .mobileBottomBar .headerSlot,
+  .mobileBottomBar .footerSlot {
     display: none;
+  }
+
+  /*
+   * Dock the bar. A consumer may position itself as a full-height fixed rail
+   * (`.sidebar` is `top:0; bottom:0; height:100dvh`), so the bar has to undo
+   * that rather than assume static flow.
+   */
+  .mobileBottomBar {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: auto;
+    max-height: none;
+    /* Published so the app shell can reserve room for the bar. */
+    --source-nav-bar-height: 56px;
   }
 
   /* Vertical rail on mobile — narrower, but structurally unchanged. */
   .mobileRail.collapsed {
     width: 48px;
+  }
+}
+
+/* Landscape phones: vertical space is the scarce axis, so shrink the bar.
+   Must stay in step with `--app-nav-bar-height: 44px` in App.css's matching
+   landscape block, which is what reserves room for it. */
+@media (max-height: 500px) and (orientation: landscape) {
+  .mobileBottomBar {
+    --source-nav-bar-height: 44px;
+  }
+
+  .mobileBottomBar .item {
+    padding: 0.25rem 0.6rem;
+  }
+
+  .mobileBottomBar .label {
+    font-size: 0.6rem;
   }
 }

--- a/src/components/nav/SourceNav.tsx
+++ b/src/components/nav/SourceNav.tsx
@@ -101,7 +101,10 @@ export const SourceNav: React.FC<SourceNavProps> = ({
       data-mobile-variant={mobileVariant}
       aria-label={ariaLabel}
     >
-      {header}
+      {/* Wrapped so the bottom-bar variant can hide them: a logo block, a
+          pin/collapse cluster and a footer are all vertical-rail affordances
+          that make no sense laid out in a horizontal bar. */}
+      {header && <div className={styles.headerSlot} data-source-nav-header="">{header}</div>}
 
       <nav className={styles.list}>
         {sections.map((section, index) => (
@@ -148,8 +151,10 @@ export const SourceNav: React.FC<SourceNavProps> = ({
         ))}
       </nav>
 
-      {controls ?? (onToggleCollapsed && (
-        <div className={styles.controls}>
+      {controls ? (
+        <div className={styles.controlsSlot} data-source-nav-controls="">{controls}</div>
+      ) : (onToggleCollapsed && (
+        <div className={`${styles.controls} ${styles.controlsSlot}`} data-source-nav-controls="">
           <button
             type="button"
             className={styles.toggle}
@@ -163,7 +168,7 @@ export const SourceNav: React.FC<SourceNavProps> = ({
         </div>
       ))}
 
-      {footer}
+      {footer && <div className={styles.footerSlot} data-source-nav-footer="">{footer}</div>}
     </aside>
   );
 };

--- a/src/styles/bottomBarClearance.test.ts
+++ b/src/styles/bottomBarClearance.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression tests for content sitting UNDER the mobile bottom bar (#4473 phase 2).
+ *
+ * Moving the Meshtastic phone nav from a left rail to a bottom bar means every
+ * full-height surface has to reserve space at the bottom instead of the left.
+ * Two surfaces opt out of the normal `.app-main` flow and were missed on the
+ * first pass — both were reported/found only by driving the running app:
+ *
+ *   1. Channels tab — `.app-main:has(.channels-tab-content)` zeroed its
+ *      padding-bottom (correct when nothing occupied the bottom strip), which
+ *      ran the compose row's send/location/bell buttons under the bar.
+ *   2. DM tab — `.messages-split-view { height: 100% }` over-constrained the
+ *      `position: fixed` top/bottom pair it inherits from `.nodes-split-view`,
+ *      so height won, `bottom` was ignored, and the box overshot the viewport.
+ *
+ * jsdom does no layout and no cascade, so these read the stylesheet source, in
+ * the same style as the other stylesheet assertions under src/ (see
+ * NodesTab.test.tsx). They are cheap guards on the two specific declarations
+ * whose regression is invisible until someone opens the tab on a phone.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const appCss = readFileSync(resolve('src/App.css'), 'utf-8');
+const nodesCss = readFileSync(resolve('src/styles/nodes.css'), 'utf-8');
+
+/** Body of a rule, searched by exact selector text at any indent. */
+function ruleBody(css: string, selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = css.match(new RegExp(escaped + '\\s*\\{([^}]*)\\}'));
+  return m ? m[1] : null;
+}
+
+describe('mobile bottom-bar clearance (#4473)', () => {
+  it('the channels tab reserves the bar height instead of zeroing it', () => {
+    const body = ruleBody(appCss, '.app-main:has(.channels-tab-content)');
+    expect(body).not.toBeNull();
+
+    const pb = body!.match(/padding-bottom:\s*([^;]+)/)?.[1].trim();
+    expect(pb).toBeDefined();
+    // A flat `0` is what put send/location/bell under the bar.
+    expect(pb).not.toBe('0');
+    expect(pb).toMatch(/var\(--app-nav-bar-height/);
+    // The safe-area inset is deliberately NOT repeated here — .send-message-form
+    // already applies it, and doubling it leaves dead space below the input.
+    expect(pb).not.toMatch(/env\(safe-area-inset-bottom/);
+  });
+
+  it('the DM split view lets its fixed top/bottom pair define the box', () => {
+    // Scoped to the mobile block: the desktop rule has no height declaration.
+    const mobile = nodesCss.slice(nodesCss.indexOf('@media (max-width: 768px)'));
+    const body = ruleBody(mobile, '.messages-split-view');
+    expect(body).not.toBeNull();
+
+    const h = body!.match(/(?:^|;)\s*height:\s*([^;]+)/)?.[1].trim();
+    expect(h).toBeDefined();
+    // `100%` over-constrains position:fixed + top + bottom; height wins and the
+    // box overshoots the viewport, hiding the compose row behind the bar.
+    expect(h).not.toBe('100%');
+    expect(h).toBe('auto');
+  });
+
+  it('the map/list split view clears the bar', () => {
+    const mobile = nodesCss.slice(nodesCss.indexOf('@media (max-width: 768px)'));
+    const body = ruleBody(mobile, '.nodes-split-view');
+    expect(body).not.toBeNull();
+    expect(body!).toMatch(/bottom:\s*calc\([^;]*--app-nav-bar-height/);
+    // The old left-rail offset must be gone — the rail no longer exists.
+    expect(body!).not.toMatch(/left:\s*48px/);
+  });
+
+  it('app-main reserves the bar height in both mobile orientations', () => {
+    // Portrait block and landscape block each declare their own bar height.
+    const portrait = appCss.slice(appCss.indexOf('@media (max-width: 768px)'));
+    expect(portrait).toMatch(/--app-nav-bar-height:\s*56px/);
+    expect(appCss).toMatch(/--app-nav-bar-height:\s*44px/);
+    // And --sidebar-width collapses so horizontal offsets stop reserving a rail.
+    expect(appCss).toMatch(/--sidebar-width:\s*0px\s*!important/);
+  });
+});

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1242,9 +1242,15 @@
     display: none !important;
   }
 
-  /* Make messages split view fill available height on mobile */
+  /* Make messages split view fill available height on mobile.
+     `height: auto`, NOT `100%`: this element is `position: fixed` with both
+     `top` and `bottom` set by .nodes-split-view above, and an explicit height
+     over-constrains that pair — height wins and `bottom` is ignored, so the box
+     ran from 48px to 828px on a 780px viewport, putting the DM compose row
+     under the new bottom bar (#4473 phase 2). Letting top/bottom define the box
+     is what makes it track the bar's reserved space. */
   .messages-split-view {
-    height: 100%;
+    height: auto;
   }
 
   /* Adjust main content for Messages tab */

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1195,9 +1195,11 @@
 @media (max-width: 768px) {
   .nodes-split-view {
     top: 48px; /* Mobile header is 48px */
-    left: 48px; /* Mobile collapsed sidebar is 48px */
-    /* Account for iPhone safe area at bottom */
-    bottom: env(safe-area-inset-bottom, 0);
+    /* The left rail became a bottom bar (#4473 phase 2), so the map/list split
+       spans the full width and instead has to clear the bar, which is fixed
+       over the bottom of the viewport. */
+    left: 0;
+    bottom: calc(var(--app-nav-bar-height, 56px) + env(safe-area-inset-bottom, 0px));
   }
 
   /* Make filter popup narrower on mobile */

--- a/src/utils/sidebarWidth.ts
+++ b/src/utils/sidebarWidth.ts
@@ -29,9 +29,11 @@ export const NODE_SIDEBAR_DESKTOP_MAX_FRACTION = 0.5;
 /**
  * Whether the viewport is in the app's mobile layout.
  *
- * Deliberately mirrors the two `:root { --sidebar-width: 48px }` media queries
- * in App.css rather than inventing a third definition of "mobile". Keep the two
- * in sync: if those queries change, this changes with them.
+ * Deliberately mirrors the two `:root { --sidebar-width: … }` media queries in
+ * App.css rather than inventing a third definition of "mobile". Keep the two in
+ * sync: if those queries change, this changes with them. (Those blocks now set
+ * the width to 0 — the mobile nav is a bottom bar, #4473 phase 2 — but the
+ * breakpoints they key off are unchanged.)
  *
  * Note this does NOT catch a 1366x768 laptop (width > 768, height > 500), so
  * desktop keeps its 50% split.
@@ -51,9 +53,10 @@ export function isMobileLayout(viewportWidth: number, viewportHeight: number): b
  *
  * @param availableWidth Width of the split-view container — NOT the viewport.
  *   The container is `position: fixed; left: var(--sidebar-width); right: 0`, so
- *   it already excludes the app rail (48px mobile / 60px desktop). Measuring the
- *   container rather than subtracting a hardcoded rail width keeps this correct
- *   if the rail ever changes.
+ *   it already excludes the app rail (0 on mobile, where the nav is a bottom
+ *   bar; 60px desktop). Measuring the container rather than subtracting a
+ *   hardcoded rail width is exactly what let the mobile rail become a bottom bar
+ *   (#4473 phase 2) without touching this function.
  * @param mobile Result of isMobileLayout() for the current viewport.
  *
  * Mobile: the whole container, so the list can cover the map entirely.


### PR DESCRIPTION
Closes #4473 (phase 2 of 2 — phase 1 was #4481).

Meshtastic now uses the same scrollable bottom bar as MeshCore on phones, instead of a 48px icon-only rail. That completes the consolidation: both source types share one nav component *and* one mobile treatment.

## Why this wasn't just a prop flip

The app shell is positioned off `--sidebar-width`. On mobile that variable now resolves to **0** — a bottom bar takes no horizontal space — and vertical room is reserved separately via a new `--app-nav-bar-height` (56px portrait, 44px landscape).

`sidebarWidth.ts` needed **no logic change** — it measures the split container rather than subtracting a hardcoded rail width, exactly as its own comment claimed. Only the comment needed correcting.

## Stacking

The nav drops to `z-index: 900` on mobile. As a slide-in rail it had to overlay the page at 10001; as shell furniture, every modal and overlay in the app (1000..10002) should cover it. `.save-bar` is lifted clear of the bar rather than sharing the strip, since it's an action surface.

## Compose row hidden behind the bar — found by testing the deployed build

**An earlier revision of this PR claimed the layout work was complete. It wasn't.** Testing the running container turned up the send/location/bell buttons hidden behind the bar on Meshtastic sources. Two separate causes, both on surfaces that opt out of the normal `.app-main` flow — precisely where a bottom-strip reservation breaks, and precisely what spot-checking the map view missed.

1. **Channels.** `.app-main:has(.channels-tab-content)` set `padding-bottom: 0`. Correct while nothing occupied the bottom strip — its purpose is to avoid applying `env(safe-area-inset-bottom)` twice, since `.send-message-form` pads itself. It now reserves `var(--app-nav-bar-height)` and still deliberately omits the safe-area component. Measured before the fix: bar top 727.3, `.send-btn` spanning 735.4–779.4.

2. **DM.** `.messages-split-view { height: 100% }` over-constrained the `position: fixed` top/bottom pair it inherits from `.nodes-split-view`. An explicit height wins and `bottom` is silently dropped, so the box ran 48 → **828px** on a 780px viewport. `height: auto` lets top/bottom define it.

## Two cascade traps found by measuring the compiled bundle

A hand-built harness passed both. Only building the app and measuring the compiled cascade in Chrome exposed them.

1. **Specificity trap from phase 1.** `.mobileBottomBar.collapsed .item` (0,3,0) outranks the landscape override (0,2,0) *wherever it sits*. Those compound rules were redundant, so they're gone, and a test bans that selector shape.

2. **Cascade-order trap.** Even with `!important`, the bar's padding lost to a later `@media (max-height: 700px) and (orientation: landscape)` block that also uses `!important` — among `!important` at equal specificity, **last wins**. The block moved to the end of `Sidebar.css` with a banner saying it must stay there. Same trap `nodes.css` documents from #3532. Symptom: the landscape bar was 53.7px tall against 44px reserved.

Also removed 8 dead rules targeting `.sidebar-nav*` / `.sidebar-section*` — classes that moved into the CSS module in phase 1.

## Verified on the running container

Full sweep of all 15 nav tabs at 390×780 signed in as admin, checking fixed containers that overshoot the bar **and** interactive elements occluded by it via `elementFromPoint` (real hit-testing, not geometry):

- **Clean:** Map, Channels, Node Details, Info, Dashboard, Packet Monitor, Settings, Automation, Device, Users, Admin Commands, Audit Log
- **Flagged → false positive:** Notifications, Security — static controls below the fold on scrollable pages; scrolling to the bottom leaves nothing occluded
- **Skipped:** Search (opens an overlay)

| viewport | nav | bar vs reserved | labels truncated | compose row |
|---|---|---|---|---|
| 390×780 portrait | bottom bar, docked | 52.7 ≤ 56 | 0 / 15 | 723.4 vs bar 727.3, clickable |
| 800×400 landscape | bottom bar, docked | 43.7 ≤ 44 | 0 / 15 | 323 vs bar 356.3, clickable |
| 1440×900 desktop | 60px full-height rail | n/a — unchanged | n/a | n/a |

Desktop untouched: same rail, header/pin/footer chrome visible, labels hidden when collapsed, `z-index: 10001`.

## Test plan

- [x] `src/styles/bottomBarClearance.test.ts` — 4 assertions pinning both compose-row fixes and the `--app-nav-bar-height` reservations.
- [x] 3 assertions in `SourceNav.mobile.test.ts` (single-class-depth rule ban; bar heights for both orientations; label display).
- [x] Full Vitest suite — `success: true`, 12913 passed, 0 failed.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.
- [x] Verified against the **served** bundle on the dev container, not just source.

## Known pre-existing issue (not touched)

`@media (max-height: 700px) and (orientation: landscape)` forces `.sidebar.collapsed { width: 48px !important }`, while `updateSidebarWidth()` reports 60px for that same range (e.g. 1000×650 — too wide and too tall to be "mobile"). Rail renders 48px, shell reserves 60px. Predates this work; worth a follow-up issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
