### PR TITLE
fix(admin): decouple session-passkey and config-import from the HTTP request

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -720,11 +720,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           
           // First, ensure we have a session passkey
           try {
-            const passkeyResponse = await apiService.post<{
+            const passkeyResponse = await apiService.ensureSessionPasskey<{
               success: boolean;
               hasPasskey: boolean;
               remainingSeconds: number | null;
-            }>('/api/admin/ensure-session-passkey', {
+            }>({
               nodeNum: selectedNodeNum,
               ...(sourceId ? { sourceId } : {})
             });
@@ -973,11 +973,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       // Note: This is done once before retries since the passkey persists
       if (isRemoteNode) {
         try {
-          const passkeyResponse = await apiService.post<{
+          const passkeyResponse = await apiService.ensureSessionPasskey<{
             success: boolean;
             hasPasskey: boolean;
             remainingSeconds: number | null;
-          }>('/api/admin/ensure-session-passkey', {
+          }>({
             nodeNum: selectedNodeNum,
             ...(sourceId ? { sourceId } : {})
           });
@@ -1260,11 +1260,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         
         // First, ensure we have a session passkey (prevents conflicts from parallel requests)
         try {
-          const passkeyResponse = await apiService.post<{
+          const passkeyResponse = await apiService.ensureSessionPasskey<{
             success: boolean;
             hasPasskey: boolean;
             remainingSeconds: number | null;
-          }>('/api/admin/ensure-session-passkey', {
+          }>({
             nodeNum: selectedNodeNum,
             ...(sourceId ? { sourceId } : {})
           });

--- a/src/server/routes/adminRoutes.asyncOperations.test.ts
+++ b/src/server/routes/adminRoutes.asyncOperations.test.ts
@@ -261,6 +261,76 @@ describe('adminRoutes — async remote-admin operations (#4482)', () => {
     });
   });
 
+  describe('POST /ensure-session-passkey (follow-up)', () => {
+    it('answers immediately from cache without opening an operation', async () => {
+      const requestRemoteSessionPasskey = vi.fn(() => new Promise(() => {}));
+      await sourceManagerRegistry.addManager(makeFakeManager({
+        getSessionPasskey: vi.fn().mockReturnValue(new Uint8Array([1])),
+        getSessionPasskeyStatus: vi.fn().mockReturnValue({ hasPasskey: true, remainingSeconds: 250 }),
+        requestRemoteSessionPasskey,
+      }));
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/ensure-session-passkey')
+        .send({ nodeNum: REMOTE_NODE_NUM, sourceId: harness.sourceA });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ success: true, hasPasskey: true, remainingSeconds: 250 });
+      expect(res.body.operationId).toBeUndefined();
+      expect(requestRemoteSessionPasskey).not.toHaveBeenCalled();
+    });
+
+    it('returns 202 while acquisition is outstanding, then settles with the status', async () => {
+      let release: (v: Uint8Array) => void = () => {};
+      const gate = new Promise<Uint8Array>((resolve) => { release = resolve; });
+      await sourceManagerRegistry.addManager(makeFakeManager({
+        getSessionPasskey: vi.fn().mockReturnValue(null),
+        requestRemoteSessionPasskey: vi.fn(() => gate),
+        getSessionPasskeyStatus: vi.fn().mockReturnValue({ hasPasskey: true, remainingSeconds: 300 }),
+      }));
+
+      const agent = await harness.loginAs(harness.admin);
+      const accepted = await agent.post('/ensure-session-passkey')
+        .send({ nodeNum: REMOTE_NODE_NUM, sourceId: harness.sourceA });
+
+      // Would have blocked ~45s before the follow-up.
+      expect(accepted.status).toBe(202);
+      expect(typeof accepted.body.operationId).toBe('string');
+
+      release(new Uint8Array([7]));
+      const settled = await waitForSettled(agent, accepted.body.operationId);
+      expect(settled.status).toBe('succeeded');
+      expect(settled.result).toMatchObject({ hasPasskey: true, remainingSeconds: 300 });
+    });
+
+    it('records a timeout as PASSKEY_TIMEOUT', async () => {
+      await sourceManagerRegistry.addManager(makeFakeManager({
+        getSessionPasskey: vi.fn().mockReturnValue(null),
+        requestRemoteSessionPasskey: vi.fn().mockResolvedValue(null),
+      }));
+
+      const agent = await harness.loginAs(harness.admin);
+      const accepted = await agent.post('/ensure-session-passkey')
+        .send({ nodeNum: REMOTE_NODE_NUM, sourceId: harness.sourceA });
+
+      const settled = await waitForSettled(agent, accepted.body.operationId);
+      expect(settled.status).toBe('failed');
+      expect(settled.error.code).toBe('PASSKEY_TIMEOUT');
+    });
+
+    it('still answers the local node synchronously', async () => {
+      await sourceManagerRegistry.addManager(makeFakeManager({}));
+      const agent = await harness.loginAs(harness.admin);
+
+      const res = await agent.post('/ensure-session-passkey')
+        .send({ nodeNum: LOCAL_NODE_NUM, sourceId: harness.sourceA });
+
+      expect(res.status).toBe(200);
+      expect(res.body.operationId).toBeUndefined();
+      expect(adminOperationService.size()).toBe(0);
+    });
+  });
+
   describe('GET /operations/:id', () => {
     it('404s an unknown id', async () => {
       const agent = await harness.loginAs(harness.admin);

--- a/src/server/routes/adminRoutes.asyncOperations.test.ts
+++ b/src/server/routes/adminRoutes.asyncOperations.test.ts
@@ -19,6 +19,15 @@ import { adminOperationService } from '../services/adminOperationService.js';
 import { TxDisabledError } from '../errors/txDisabledError.js';
 import { loadProtobufDefinitions } from '../protobufLoader.js';
 
+// import-config dynamically imports this; mock it so the tests don't need a
+// real base64url-encoded channel blob.
+vi.mock('../services/channelUrlService.js', () => ({
+  default: {
+    decodeUrl: vi.fn(),
+    encodeUrl: vi.fn().mockReturnValue('meshtastic://mock-url'),
+  },
+}));
+
 const LOCAL_NODE_NUM = 1;
 const REMOTE_NODE_NUM = 0x0badbeef;
 
@@ -328,6 +337,69 @@ describe('adminRoutes — async remote-admin operations (#4482)', () => {
       expect(res.status).toBe(200);
       expect(res.body.operationId).toBeUndefined();
       expect(adminOperationService.size()).toBe(0);
+    });
+  });
+
+  describe('POST /import-config (follow-up)', () => {
+    it('runs the whole remote import from a COLD passkey behind one operation', async () => {
+      // The #4315 tests all start with a cached passkey, so the acquisition leg
+      // of the import path was never exercised end-to-end. This covers the full
+      // chain: 202 → acquire → channel sends → settled result.
+      let release: (v: Uint8Array) => void = () => {};
+      const gate = new Promise<Uint8Array>((resolve) => { release = resolve; });
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      await sourceManagerRegistry.addManager(makeFakeManager({
+        getSessionPasskey: vi.fn().mockReturnValue(null),
+        requestRemoteSessionPasskey: vi.fn(() => gate),
+        sendAdminCommand,
+        requestRemoteConfig: vi.fn().mockResolvedValue(null),
+        getRemoteNodeConfig: vi.fn().mockReturnValue(null),
+      }));
+
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: [{ name: 'gauntlet', psk: 'none' }],
+        loraConfig: undefined,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const accepted = await agent.post('/import-config').send({
+        sourceId: harness.sourceA, nodeNum: REMOTE_NODE_NUM, url: 'meshtastic://mock',
+      });
+
+      // Accepted while the passkey is still outstanding — nothing sent yet.
+      expect(accepted.status).toBe(202);
+      expect(sendAdminCommand).not.toHaveBeenCalled();
+
+      release(new Uint8Array([9]));
+      const settled = await waitForSettled(agent, accepted.body.operationId, 120);
+      expect(settled.status).toBe('succeeded');
+      expect(settled.result.imported.channels).toBe(1);
+      expect(sendAdminCommand).toHaveBeenCalled();
+    });
+
+    it('records a cold-passkey timeout as a failed import rather than a partial success', async () => {
+      const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
+      await sourceManagerRegistry.addManager(makeFakeManager({
+        getSessionPasskey: vi.fn().mockReturnValue(null),
+        requestRemoteSessionPasskey: vi.fn().mockResolvedValue(null),
+        sendAdminCommand,
+      }));
+
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: [{ name: 'gauntlet', psk: 'none' }],
+        loraConfig: undefined,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const accepted = await agent.post('/import-config').send({
+        sourceId: harness.sourceA, nodeNum: REMOTE_NODE_NUM, url: 'meshtastic://mock',
+      });
+
+      const settled = await waitForSettled(agent, accepted.body.operationId, 120);
+      expect(settled.status).toBe('failed');
+      expect(sendAdminCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routes/adminRoutes.asyncOperations.test.ts
+++ b/src/server/routes/adminRoutes.asyncOperations.test.ts
@@ -378,6 +378,37 @@ describe('adminRoutes — async remote-admin operations (#4482)', () => {
       expect(sendAdminCommand).toHaveBeenCalled();
     });
 
+    it('reports channels that failed to import instead of counting only successes', async () => {
+      // A per-channel failure is absorbed by the loop; the result must still
+      // distinguish "1 channel" from "1 of 2 channels".
+      const sendAdminCommand = vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('radio dropped it'));
+      await sourceManagerRegistry.addManager(makeFakeManager({
+        getSessionPasskey: vi.fn().mockReturnValue(new Uint8Array([1])),
+        sendAdminCommand,
+        requestRemoteConfig: vi.fn().mockResolvedValue(null),
+        getRemoteNodeConfig: vi.fn().mockReturnValue(null),
+      }));
+
+      const channelUrlService = (await import('../services/channelUrlService.js')).default;
+      (channelUrlService.decodeUrl as any).mockReturnValue({
+        channels: [{ name: 'ok', psk: 'none' }, { name: 'doomed', psk: 'none' }],
+        loraConfig: undefined,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const accepted = await agent.post('/import-config').send({
+        sourceId: harness.sourceA, nodeNum: REMOTE_NODE_NUM, url: 'meshtastic://mock',
+      });
+
+      const settled = await waitForSettled(agent, accepted.body.operationId, 200);
+      expect(settled.status).toBe('succeeded');
+      expect(settled.result.imported.channels).toBe(1);
+      expect(settled.result.imported.failedChannels).toBe(1);
+      expect(settled.result.imported.failedChannelDetails).toEqual([{ index: 1, name: 'doomed' }]);
+    });
+
     it('records a cold-passkey timeout as a failed import rather than a partial success', async () => {
       const sendAdminCommand = vi.fn().mockResolvedValue(undefined);
       await sourceManagerRegistry.addManager(makeFakeManager({
@@ -399,6 +430,9 @@ describe('adminRoutes — async remote-admin operations (#4482)', () => {
 
       const settled = await waitForSettled(agent, accepted.body.operationId, 120);
       expect(settled.status).toBe('failed');
+      // Reaches the detached closure's outer catch: the passkey throw is not
+      // absorbed by the per-channel/per-LoRa handlers inside runImport.
+      expect(settled.error.code).toBe('IMPORT_CONFIG_FAILED');
       expect(sendAdminCommand).not.toHaveBeenCalled();
     });
   });

--- a/src/server/routes/adminRoutes.test.ts
+++ b/src/server/routes/adminRoutes.test.ts
@@ -299,9 +299,10 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
         url: 'meshtastic://mock',
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202); // remote import is now async (#4482)
       expect(requestRemoteConfig).toHaveBeenCalledWith(999, 5, false);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
+      // The send happens in the background now — wait for it.
+      await vi.waitFor(() => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything()));
       spy.mockRestore();
     });
 
@@ -327,9 +328,10 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
         url: 'meshtastic://mock',
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202); // remote import is now async (#4482)
       expect(requestRemoteConfig).toHaveBeenCalledWith(999, 5, false);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
+      // The send happens in the background now — wait for it.
+      await vi.waitFor(() => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything()));
       spy.mockRestore();
     });
 
@@ -361,8 +363,9 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
         url: 'meshtastic://mock',
       });
 
-      expect(res.status).toBe(200);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
+      expect(res.status).toBe(202); // remote import is now async (#4482)
+      // The send happens in the background now — wait for it.
+      await vi.waitFor(() => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything()));
       spy.mockRestore();
     });
 
@@ -391,8 +394,9 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
         url: 'meshtastic://mock',
       });
 
-      expect(res.status).toBe(200);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
+      expect(res.status).toBe(202); // remote import is now async (#4482)
+      // The send happens in the background now — wait for it.
+      await vi.waitFor(() => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything()));
       spy.mockRestore();
     });
 
@@ -417,8 +421,9 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
         url: 'meshtastic://mock',
       });
 
-      expect(res.status).toBe(200);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything());
+      expect(res.status).toBe(202); // remote import is now async (#4482)
+      // The send happens in the background now — wait for it.
+      await vi.waitFor(() => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: false }), expect.anything()));
       spy.mockRestore();
     });
 
@@ -443,8 +448,9 @@ describe('adminRoutes — TX-disabled mapping + txEnabled preservation (#4294)',
         url: 'meshtastic://mock',
       });
 
-      expect(res.status).toBe(200);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything());
+      expect(res.status).toBe(202); // remote import is now async (#4482)
+      // The send happens in the background now — wait for it.
+      await vi.waitFor(() => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ hopLimit: 3, txEnabled: true }), expect.anything()));
       spy.mockRestore();
     });
   });

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -707,7 +707,7 @@ router.post('/ensure-session-passkey', requireAdmin(), async (req, res) => {
       return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
     }
     logger.error('Error ensuring session passkey:', error);
-    res.status(500).json({ error: error.message || 'Failed to ensure session passkey' });
+    return fail(res, 500, 'PASSKEY_FAILED', error.message || 'Failed to ensure session passkey');
   }
 });
 
@@ -1212,6 +1212,7 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
     // Explicitly typed: inference no longer reaches the pushes now that they
     // happen inside the runImport thunk below.
     const importedChannels: Array<{ index: number; name: string }> = [];
+    const failedChannels: Array<{ index: number; name: string }> = [];
     let loraImported = false;
     let requiresReboot = false;
 
@@ -1337,7 +1338,12 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
             // exhibits the same drop pattern as local TCP under burst.
             await new Promise(resolve => setTimeout(resolve, 1000));
           } catch (error) {
+            // Individual channel failures don't abort the import (pre-existing
+            // behavior), but they must not vanish either — running detached
+            // means the caller has no log to correlate against, so record them
+            // and report the count in the result.
             logger.error(`❌ Failed to import channel ${i}:`, error);
+            failedChannels.push({ index: i, name: channel.name || '(unnamed)' });
           }
         }
       }
@@ -1406,6 +1412,10 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
         channels: importedChannels.length,
         channelDetails: importedChannels,
         loraConfig: loraImported,
+        // Additive: a partial import previously reported only its successes,
+        // so a caller could not tell "3 channels" from "3 of 5 channels".
+        failedChannels: failedChannels.length,
+        failedChannelDetails: failedChannels,
       },
       requiresReboot,
     };
@@ -1457,7 +1467,7 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       return fail(res, 409, 'TX_DISABLED', 'Transmit is disabled on this source');
     }
     logger.error('Error importing configuration:', error);
-    res.status(500).json({ error: error.message || 'Failed to import configuration' });
+    return fail(res, 500, 'IMPORT_CONFIG_FAILED', error.message || 'Failed to import configuration');
   }
 });
 

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -646,22 +646,61 @@ router.post('/ensure-session-passkey', requireAdmin(), async (req, res) => {
       return res.json({ success: true, message: 'Local node does not require session passkey' });
     }
 
-    // Check if we already have a valid session passkey
-    let sessionPasskey = espManager.getSessionPasskey(destinationNodeNum);
-    if (!sessionPasskey) {
-      logger.debug(`Requesting session passkey for remote node ${destinationNodeNum}`);
-      sessionPasskey = await espManager.requestRemoteSessionPasskey(destinationNodeNum);
-      if (!sessionPasskey) {
-        return res.status(500).json({ error: `Failed to obtain session passkey for remote node ${destinationNodeNum}` });
-      }
+    // Already cached — answer immediately, no mesh round-trip needed.
+    const cachedPasskey = espManager.getSessionPasskey(destinationNodeNum);
+    if (cachedPasskey) {
+      return res.json({
+        success: true,
+        message: 'Session passkey available',
+        ...espManager.getSessionPasskeyStatus(destinationNodeNum)
+      });
     }
 
-    // Return status with expiry info
-    const status = espManager.getSessionPasskeyStatus(destinationNodeNum);
-    return res.json({
+    // Acquisition costs up to 45s of mesh time. Holding the request open for
+    // that is what produced upstream 502s (#4482), so hand back an operation
+    // id and finish in the background.
+    const operation = adminOperationService.create({
+      command: 'ensureSessionPasskey',
+      sourceId: espManager.sourceId,
+      destinationNodeNum,
+      userId: req.session?.userId ?? null,
+    });
+
+    void (async () => {
+      try {
+        adminOperationService.setStatus(operation.id, 'awaiting_passkey');
+        logger.debug(`Requesting session passkey for remote node ${destinationNodeNum}`);
+        const passkey = await espManager.requestRemoteSessionPasskey(destinationNodeNum);
+        if (!passkey) {
+          adminOperationService.fail(operation.id, {
+            code: 'PASSKEY_TIMEOUT',
+            message: `Failed to obtain session passkey for remote node ${destinationNodeNum}`,
+          });
+          return;
+        }
+        adminOperationService.succeed(operation.id, {
+          message: 'Session passkey available',
+          ...espManager.getSessionPasskeyStatus(destinationNodeNum),
+        });
+      } catch (error) {
+        if (isTxDisabledError(error)) {
+          adminOperationService.fail(operation.id, { code: 'TX_DISABLED', message: 'Transmit is disabled on this source' });
+          return;
+        }
+        logger.error(`Error ensuring session passkey (operation ${operation.id}):`, error);
+        const coded = error as { code?: string; message?: string } | null;
+        adminOperationService.fail(operation.id, {
+          code: coded?.code || 'PASSKEY_FAILED',
+          message: coded?.message || 'Failed to ensure session passkey',
+        });
+      }
+    })();
+
+    return res.status(202).json({
       success: true,
-      message: 'Session passkey available',
-      ...status
+      operationId: operation.id,
+      status: operation.status,
+      message: `Session passkey requested for node ${destinationNodeNum}`,
     });
   } catch (error: any) {
     if (isTxDisabledError(error)) {
@@ -1170,10 +1209,20 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
 
     logger.debug(`📥 Decoded ${decoded.channels?.length || 0} channels, LoRa config: ${!!decoded.loraConfig}`);
 
-    const importedChannels = [];
+    // Explicitly typed: inference no longer reaches the pushes now that they
+    // happen inside the runImport thunk below.
+    const importedChannels: Array<{ index: number; name: string }> = [];
     let loraImported = false;
     let requiresReboot = false;
 
+    // The import body below is wrapped in a thunk rather than being awaited
+    // inline: importing to a REMOTE node blocks on the session passkey (up to
+    // 45s) and then a burst of admin sends, which is exactly the HTTP hold that
+    // produced upstream 502s (#4482). Local imports still await it directly.
+    //
+    // Its contents are deliberately left at their original indentation so the
+    // diff stays reviewable — only the wrapper lines are new.
+    const runImport = async () => {
     if (isLocalNode) {
       // Use existing local import logic
       try {
@@ -1338,14 +1387,56 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
       }
     }
 
-    res.json({
-      success: true,
+    return {
       imported: {
         channels: importedChannels.length,
         channelDetails: importedChannels,
         loraConfig: loraImported,
       },
       requiresReboot,
+    };
+    };
+
+    if (isLocalNode) {
+      const result = await runImport();
+      return res.json({ success: true, ...result });
+    }
+
+    // Remote import: accept now, finish on the mesh's schedule (#4482).
+    const operation = adminOperationService.create({
+      command: 'importConfig',
+      sourceId: aicManager.sourceId,
+      destinationNodeNum,
+      userId: req.session?.userId ?? null,
+    });
+
+    void (async () => {
+      try {
+        adminOperationService.setStatus(operation.id, 'awaiting_passkey');
+        const result = await runImport();
+        adminOperationService.succeed(operation.id, {
+          message: `Configuration imported to node ${destinationNodeNum}`,
+          ...result,
+        });
+      } catch (error) {
+        if (isTxDisabledError(error)) {
+          adminOperationService.fail(operation.id, { code: 'TX_DISABLED', message: 'Transmit is disabled on this source' });
+          return;
+        }
+        logger.error(`Error importing configuration (operation ${operation.id}):`, error);
+        const coded = error as { code?: string; message?: string } | null;
+        adminOperationService.fail(operation.id, {
+          code: coded?.code || 'IMPORT_CONFIG_FAILED',
+          message: coded?.message || 'Failed to import configuration',
+        });
+      }
+    })();
+
+    return res.status(202).json({
+      success: true,
+      operationId: operation.id,
+      status: operation.status,
+      message: `Configuration import accepted for node ${destinationNodeNum}`,
     });
   } catch (error: any) {
     if (isTxDisabledError(error)) {

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -1221,7 +1221,15 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
     // produced upstream 502s (#4482). Local imports still await it directly.
     //
     // Its contents are deliberately left at their original indentation so the
-    // diff stays reviewable — only the wrapper lines are new.
+    // diff stays reviewable — only the wrapper lines are new. That makes the
+    // `return { ... }` at the end read like a handler-level return; it is the
+    // thunk's.
+    //
+    // The thunk mutates `importedChannels`/`loraImported`/`requiresReboot` from
+    // the enclosing scope. Safe because it runs exactly once per request — the
+    // local path awaits it, the remote path hands it to a single detached
+    // closure — but it is NOT reusable or independently testable as written.
+    // Anything that would call it twice must hoist that state inside first.
     const runImport = async () => {
     if (isLocalNode) {
       // Use existing local import logic
@@ -1291,6 +1299,12 @@ router.post('/import-config', requireAdmin(), async (req, res) => {
     } else {
       // For remote node, use admin commands via aicManager
       // Ensure session passkey
+      //
+      // TODO(#4482): this passkey is acquired once and reused for every send
+      // below. Session passkeys carry a TTL (see getSessionPasskeyStatus), so a
+      // long import over a slow link can outlive it and the later sends then go
+      // out with a stale key. Pre-existing, but running detached makes it more
+      // reachable — a re-check (and re-acquire) between sends is the fix.
       let sessionPasskey = aicManager.getSessionPasskey(destinationNodeNum);
       if (!sessionPasskey) {
         sessionPasskey = await aicManager.requestRemoteSessionPasskey(destinationNodeNum);

--- a/src/server/services/adminOperationService.ts
+++ b/src/server/services/adminOperationService.ts
@@ -51,6 +51,12 @@ export interface AdminOperationAck {
 export interface AdminOperationResult {
   message: string;
   ack?: AdminOperationAck;
+  /**
+   * Endpoint-specific payload merged into the result — e.g. import counts from
+   * `/import-config`, or passkey expiry info from `/ensure-session-passkey`.
+   * The client spreads the whole result, so these reach the caller unchanged.
+   */
+  [key: string]: unknown;
 }
 
 export interface AdminOperationError {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -721,7 +721,23 @@ class ApiService {
       throw new Error(error.error || 'Failed to import configuration');
     }
 
-    return response.json();
+    // Importing to a REMOTE node blocks on the passkey and a burst of admin
+    // sends, so that endpoint answers 202 + operation id (#4482 follow-up).
+    return this.followAdminOperation(await response.json());
+  }
+
+  /**
+   * Ensure a session passkey is cached for a remote node.
+   *
+   * Acquisition costs up to 45s of mesh time, so the endpoint answers 202 +
+   * operation id for remote nodes and this follows it to completion (#4482
+   * follow-up). Local nodes answer synchronously — they need no passkey.
+   */
+  async ensureSessionPasskey<T extends { success: boolean }>(
+    body: Record<string, unknown>,
+  ): Promise<T> {
+    const accepted = await this.post<AdminCommandAccepted>('/api/admin/ensure-session-passkey', body);
+    return this.followAdminOperation<T>(accepted);
   }
 
   async encodeChannelUrl(channelIds: number[], includeLoraConfig: boolean, nodeNum?: number, sourceId?: string | null): Promise<string> {
@@ -1615,7 +1631,21 @@ class ApiService {
     options?: { signal?: AbortSignal },
   ): Promise<T> {
     const accepted = await this.post<AdminCommandAccepted>('/api/admin/commands', body);
+    return this.followAdminOperation<T>(accepted, options);
+  }
 
+  /**
+   * Follow a background admin operation to completion (#4482).
+   *
+   * Shared by every endpoint that can answer 202 + operation id — admin
+   * commands, session-passkey acquisition, and remote config import all block
+   * on the same mesh round-trips and are followed the same way. A response
+   * without an operation id is already final and passes straight through.
+   */
+  private async followAdminOperation<T>(
+    accepted: AdminCommandAccepted,
+    options?: { signal?: AbortSignal },
+  ): Promise<T> {
     // Local node (or any server that answered synchronously): already done.
     if (!accepted?.operationId) {
       return accepted as unknown as T;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -704,7 +704,7 @@ class ApiService {
   }
 
 
-  async importConfig(url: string, nodeNum?: number, sourceId?: string | null): Promise<{ success: boolean; imported: { channels: number; channelDetails: any[]; loraConfig: boolean }; requiresReboot?: boolean }> {
+  async importConfig(url: string, nodeNum?: number, sourceId?: string | null): Promise<{ success: boolean; imported: { channels: number; channelDetails: any[]; loraConfig: boolean; failedChannels?: number; failedChannelDetails?: Array<{ index: number; name: string }> }; requiresReboot?: boolean }> {
     await this.ensureBaseUrl();
     // Use admin endpoint if nodeNum is provided (for remote nodes), otherwise use standard endpoint
     const endpoint = nodeNum !== undefined ? '/api/admin/import-config' : '/api/channels/import-config';

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -723,7 +723,10 @@ class ApiService {
 
     // Importing to a REMOTE node blocks on the passkey and a burst of admin
     // sends, so that endpoint answers 202 + operation id (#4482 follow-up).
-    return this.followAdminOperation(await response.json());
+    // Budget: up to 45s passkey + ~1s pacing per channel (8 max) + a
+    // requestRemoteConfig round-trip, all of which can retransmit. 5 minutes
+    // leaves room for that without the client abandoning a live import.
+    return this.followAdminOperation(await response.json(), { timeoutMs: 300_000 });
   }
 
   /**
@@ -1644,7 +1647,7 @@ class ApiService {
    */
   private async followAdminOperation<T>(
     accepted: AdminCommandAccepted,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<T> {
     // Local node (or any server that answered synchronously): already done.
     if (!accepted?.operationId) {
@@ -1653,9 +1656,12 @@ class ApiService {
 
     const operationId: string = accepted.operationId;
     const startedAt = Date.now();
-    // Comfortably above the ~75s worst case (45s passkey + 30s ACK) so a slow
-    // but healthy mesh is never cut short by the client.
-    const overallTimeoutMs = 120_000;
+    // Default sits above a single command's ~75s worst case (45s passkey +
+    // 30s ACK). Longer operations pass their own budget — a remote config
+    // import adds ~1s of pacing per channel plus a requestRemoteConfig
+    // round-trip on top of the passkey leg, which 120s does not cover with
+    // any margin on a retransmitting link.
+    const overallTimeoutMs = options?.timeoutMs ?? 120_000;
     let delayMs = 500;
 
     for (;;) {


### PR DESCRIPTION
Follow-up to #4482 / #4485 — the remaining handlers with the same blocking pattern.

## Correction to what I reported on #4485

I said the affected handlers were "config export (~L650) and config import (~L1245)". The first was wrong: L650 is **`POST /ensure-session-passkey`**, not export-config. `export-config` reads channels from the DB/cache and never touches the passkey, so it was never affected. The actual pair is `/ensure-session-passkey` and `/import-config`.

## The two handlers

**`POST /ensure-session-passkey`** existed to acquire the passkey, blocking up to 45s doing it. Now:
- If a passkey is already cached it answers **200 immediately** — no mesh round-trip, which is the common case since the frontend calls this to pre-warm before config operations.
- Otherwise it returns **202 + operation id** and acquires in the background.

**`POST /import-config`** on a remote node blocked on the passkey *and* a subsequent burst of admin sends (one per channel, plus LoRa config) — the longest hold of the three endpoints. Its body moves into a `runImport` thunk: local imports still `await` it inline and return 200, remote imports return 202 and run in the background.

The thunk's contents are deliberately left at their **original indentation** so the diff shows only the wrapper lines rather than a 165-line reflow. Worth knowing when reading the diff.

## No new client machinery

Both reuse the operation registry and `GET /operations/:id` from #4485. The polling loop in `ApiService` is extracted into a shared `followAdminOperation`, and three callers now route through it:
- `sendAdminCommand` (unchanged behavior, just refactored onto the shared follower)
- new `ensureSessionPasskey` — replaces the three raw `apiService.post('/api/admin/ensure-session-passkey', …)` call sites in `AdminCommandsTab`
- `importConfig`'s remote branch

`AdminOperationResult` gains an index signature so endpoint-specific payloads (import counts, passkey expiry fields) ride along in the result unchanged — the client spreads the whole result, so callers see the same shape they did before.

## Testing

- Full suite: `success: true`, **12,946 passed / 0 failed**, 0 failed suites. `tsc` clean, `lint:ci` clean with no baseline growth.
- New coverage in `adminRoutes.asyncOperations.test.ts` (+4): cached passkey answers 200 without opening an operation *and without calling the acquisition path at all*; a cold passkey returns 202 while acquisition is outstanding (mock gated on an unresolved promise) then settles with the expiry status; timeout records `PASSKEY_TIMEOUT`; local node still synchronous.
- **Six pre-existing `#4315` import-config tests needed updating** — they asserted 200 and then checked a `createSetLoRaConfigMessage` spy. Remote import now returns 202 and the send happens after the response, so they assert 202 and `await vi.waitFor(...)` the spy. Their actual subject (txEnabled preservation precedence) is unchanged.

## Still not hardware-validated

Same caveat as #4485: no `system-test` label, so the async path has not run against a real remote node. `/import-config` is the one I would most want exercised on hardware — it is the longest sequence and the one the Configuration Import system-test leg covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9