### PR TITLE
fix(meshcore): channel view opens at the top and Delete appears to do nothing

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -811,3 +811,134 @@ describe('MeshCoreChannelsView — explicit Unscoped send (#3888)', () => {
     expect(unscopedBtn.getAttribute('aria-pressed')).toBe('true');
   });
 });
+
+describe('MeshCoreChannelsView — delete prunes the fetched backlog', () => {
+  /**
+   * The stream renders `filtered` = merge(history, messages). `actions.deleteMessage`
+   * only prunes the shared `messages` pool, so a message served from the
+   * per-channel backlog (#4460) was deleted server-side and then immediately
+   * re-rendered from `history` — the delete button looked inert. Verified against
+   * the live API: the row was already gone from the database while still on screen.
+   */
+  function routedFetch(backlog: MeshCoreMessage[]) {
+    return vi.fn((url: string) => {
+      if (url.includes('/api/channels/all')) {
+        return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+      }
+      if (url.includes('/messages/channel-counts')) {
+        return Promise.resolve(jsonResponse({ success: true, counts: { 0: backlog.length } }));
+      }
+      if (/\/messages\/channel\/\d+/.test(url)) {
+        return Promise.resolve(jsonResponse({ success: true, data: backlog, count: backlog.length }));
+      }
+      return Promise.resolve(jsonResponse({ success: true, data: [] }));
+    });
+  }
+
+  const confirmSpy = vi.spyOn(window, 'confirm');
+
+  it('removes a backlog-sourced message from the view once the delete succeeds', async () => {
+    confirmSpy.mockReturnValue(true);
+    csrfFetchMock.mockImplementation(routedFetch([
+      { id: 'from-history', fromPublicKey: 'channel-0', text: 'delete me', timestamp: 100 },
+    ]));
+    const deleteMessage = vi.fn().mockResolvedValue(true);
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}                       // deliberately empty: this row exists ONLY in history
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions({ deleteMessage })}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('delete me')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.click(document.querySelector('.mc-message-delete') as Element);
+    });
+
+    expect(deleteMessage).toHaveBeenCalledWith('from-history');
+    await waitFor(() => expect(screen.queryByText('delete me')).toBeNull());
+  });
+
+  it('keeps the message when the delete request fails', async () => {
+    confirmSpy.mockReturnValue(true);
+    csrfFetchMock.mockImplementation(routedFetch([
+      { id: 'from-history', fromPublicKey: 'channel-0', text: 'keep me', timestamp: 100 },
+    ]));
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions({ deleteMessage: vi.fn().mockResolvedValue(false) })}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('keep me')).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(document.querySelector('.mc-message-delete') as Element);
+    });
+    // Server said no — the row must stay rather than vanish optimistically.
+    expect(screen.getByText('keep me')).toBeTruthy();
+  });
+
+  it('does not delete when the operator cancels the confirm', async () => {
+    confirmSpy.mockReturnValue(false);
+    csrfFetchMock.mockImplementation(routedFetch([
+      { id: 'from-history', fromPublicKey: 'channel-0', text: 'still here', timestamp: 100 },
+    ]));
+    const deleteMessage = vi.fn().mockResolvedValue(true);
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions({ deleteMessage })}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('still here')).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(document.querySelector('.mc-message-delete') as Element);
+    });
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(screen.getByText('still here')).toBeTruthy();
+  });
+
+  it('clears the whole backlog when the channel clear succeeds', async () => {
+    confirmSpy.mockReturnValue(true);
+    csrfFetchMock.mockImplementation(routedFetch([
+      { id: 'h1', fromPublicKey: 'channel-0', text: 'first', timestamp: 100 },
+      { id: 'h2', fromPublicKey: 'channel-0', text: 'second', timestamp: 200 },
+    ]));
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions({ clearChannelMessages: vi.fn().mockResolvedValue(true) })}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('first')).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(document.querySelector('.meshcore-clear-conversation-btn') as Element);
+    });
+    await waitFor(() => expect(screen.queryByText('first')).toBeNull());
+    expect(screen.queryByText('second')).toBeNull();
+  });
+});

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -534,16 +534,37 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   const connected = status?.connected ?? false;
 
   // Per-message delete + whole-channel clear (#3981). Both confirm first.
+  //
+  // Both MUST also prune `history`, not just await the action. The stream renders
+  // `filtered` = merge(history, messages), and the hook's delete/clear only prune
+  // the shared `messages` pool — so anything served from the per-channel backlog
+  // (#4460), which is nearly everything on this view, was deleted server-side and
+  // then immediately re-rendered from `history`. That read as "the delete button
+  // does nothing"; verified against the API, the row was already gone from the
+  // database while still on screen.
   const handleDeleteMessage = useCallback(async (m: MeshCoreMessage) => {
     if (!window.confirm(t('meshcore.confirm_delete_message', 'Delete this message?'))) return;
-    await actions.deleteMessage(m.id);
+    const ok = await actions.deleteMessage(m.id);
+    if (ok) {
+      setHistory(prev => prev.filter(x => x.id !== m.id));
+      setCounts(prev => {
+        const current = prev[activeChannelIdxRef.current];
+        if (typeof current !== 'number') return prev;
+        return { ...prev, [activeChannelIdxRef.current]: Math.max(0, current - 1) };
+      });
+    }
   }, [actions, t]);
   const handleClearChannel = useCallback(async () => {
     if (!window.confirm(t(
       'meshcore.confirm_clear_channel',
       'Clear all messages on this channel? This cannot be undone.',
     ))) return;
-    await actions.clearChannelMessages(active.id);
+    const ok = await actions.clearChannelMessages(active.id);
+    if (ok) {
+      setHistory([]);
+      setHasMoreHistory(false);
+      setCounts(prev => ({ ...prev, [active.id]: 0 }));
+    }
   }, [actions, active, t]);
 
   const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';

--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -7,7 +7,7 @@
  * but not between messages sent on the same day.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -469,5 +469,85 @@ describe('MeshCoreMessageStream route-detail popup', () => {
       <MeshCoreMessageStream messages={[message]} onSend={async () => true} />,
     );
     expect(container.querySelector('.mc-route-chain-link')).toBeNull();
+  });
+});
+
+/**
+ * Regression: the mobile two-pane layout mounts the conversation but hides it
+ * until the operator drills in from the channel/peer list. Measured on the
+ * running app in that state: scrollHeight 0, clientHeight 0, offsetParent null.
+ * The entry scroll fired there, `scrollTop = scrollHeight` was `0 = 0` (a silent
+ * no-op), and the one shot was spent — so drilling in left the view pinned at
+ * the top of a 17,000px backlog with nothing left to re-trigger it.
+ */
+describe('MeshCoreMessageStream entry scroll on a hidden pane (#4473 follow-up)', () => {
+  let resizeCallbacks: Array<() => void>;
+  let scrollHeightValue: number;
+
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: (time: number) => void) => { cb(0); return 0; });
+    resizeCallbacks = [];
+    scrollHeightValue = 0; // hidden: no layout
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(cb: () => void) { resizeCallbacks.push(cb); }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() { return scrollHeightValue; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight;
+  });
+
+  const msgs = () => {
+    const now = Date.now();
+    return [msg('a', now - 2000, 'first'), msg('b', now - 1000, 'second')];
+  };
+
+  it('defers the entry scroll while the pane is hidden, then runs it on reveal', () => {
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={msgs()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    // Hidden — the shot must NOT be spent.
+    expect(list.scrollTop).toBe(0);
+
+    // Operator drills in: the pane gains layout and the observer fires.
+    scrollHeightValue = 900;
+    act(() => { resizeCallbacks.forEach(cb => cb()); });
+
+    expect(list.scrollTop).toBe(900);
+  });
+
+  it('does not re-scroll on later resizes once the entry scroll has run', () => {
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={msgs()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+
+    scrollHeightValue = 900;
+    act(() => { resizeCallbacks.forEach(cb => cb()); });
+    expect(list.scrollTop).toBe(900);
+
+    // User scrolls up to read history; a later resize (keyboard, rotate) must
+    // not yank them back to the bottom.
+    list.scrollTop = 120;
+    scrollHeightValue = 1400;
+    act(() => { resizeCallbacks.forEach(cb => cb()); });
+    expect(list.scrollTop).toBe(120);
   });
 });

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -164,6 +164,29 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     key: conversationKey,
     done: false,
   });
+
+  /**
+   * Perform the one-shot entry scroll, but only when the list is actually laid
+   * out. Returns whether it ran, so callers know not to mark the shot spent.
+   *
+   * The `scrollHeight` check is the load-bearing part. On mobile both the
+   * channels and DM views render a two-pane layout where the conversation is
+   * MOUNTED but hidden until the operator drills in from the list — measured
+   * there: `scrollHeight: 0`, `clientHeight: 0`, `offsetParent: null`. Assigning
+   * `scrollTop = scrollHeight` is then `0 = 0`, a silent no-op that still burnt
+   * the one shot, so drilling in left the viewport pinned at the very top of a
+   * 17,000px backlog with nothing left to re-trigger it.
+   *
+   * Deliberately keys off `scrollHeight` alone, not `clientHeight`: a hidden
+   * subtree zeroes both, while jsdom reports clientHeight 0 for everything, so a
+   * clientHeight guard would disable the entry scroll in every test.
+   */
+  const runEntryScroll = useCallback((container: HTMLDivElement): boolean => {
+    if (container.scrollHeight === 0) return false;
+    container.scrollTop = container.scrollHeight;
+    return true;
+  }, []);
+
   useEffect(() => {
     const container = listRef.current;
     if (!container) return;
@@ -176,11 +199,28 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     if (state.done) return;
     // Wait for the (possibly async) backlog before committing the entry scroll.
     if (messages.length === 0) return;
-    state.done = true;
     requestAnimationFrame(() => {
-      container.scrollTop = container.scrollHeight;
+      // Re-check inside the frame: the pane may still be hidden.
+      if (entryScrollRef.current.done) return;
+      if (runEntryScroll(container)) entryScrollRef.current.done = true;
     });
-  }, [conversationKey, messages.length]);
+  }, [conversationKey, messages.length, runEntryScroll]);
+
+  // Complete a deferred entry scroll the moment the list gains a real size —
+  // i.e. when the hidden conversation pane is revealed. Nothing else changes at
+  // that point (no new messages, no key change), so without this observer the
+  // effect above has no trigger left to fire on.
+  useEffect(() => {
+    const container = listRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      const state = entryScrollRef.current;
+      if (state.done) return;
+      if (runEntryScroll(container)) state.done = true;
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [runEntryScroll]);
 
   // Auto-scroll on new messages only when the user is already near the bottom.
   useEffect(() => {


### PR DESCRIPTION
Two independent, **pre-existing** bugs on the MeshCore channel view, both reported from the running app. Both date to the per-channel history introduced in #4461 — neither file was touched by the #4473 nav work (verified against both merge commits).

## 1. Delete appeared to do nothing

The stream renders `filtered` = merge(`history`, `messages`), but `actions.deleteMessage` only prunes the shared `messages` pool. Anything served from the per-channel backlog (#4460) — which is nearly everything on this view — was deleted server-side and then immediately re-rendered from `history`.

Confirmed against the live API while reproducing:

```
serverStillHasIt: false     ← the row was already gone from the database
uiRows:          [...still showing it...]
```

`handleDeleteMessage` and `handleClearChannel` now prune `history` (and the count badge) **on success, and only on success** — a failed delete leaves the row rather than vanishing optimistically.

DM view needs no change: it builds its list purely from the shared pool, with no separate `history`.

## 2. Channel opened at the top instead of the newest message

**Mobile only**, which is why desktop testing missed it — desktop lands at the bottom correctly every time.

The mobile two-pane layout mounts the conversation but hides it until the operator drills in from the list. Measured in that state:

```
clientHeight: 0   scrollHeight: 0   offsetParent: null
```

The entry scroll fired there, `scrollTop = scrollHeight` was `0 = 0` — a silent no-op — but the one shot was already spent. Drilling in then left the view pinned at the very top of a 17,000px backlog with nothing left to re-trigger it.

The scroll no longer spends the shot until the list has real layout, and a `ResizeObserver` completes it the moment the pane is revealed. **This fixes the DM view too**, which shares the component.

One implementation note worth flagging: the guard keys off `scrollHeight` alone, **not** `clientHeight`. A hidden subtree zeroes both, but jsdom reports `clientHeight: 0` for *everything* — a clientHeight guard silently disabled the entry scroll in every test, including two existing ones that had been passing.

## Verified on the running container

390×780, both MeshCore sources:

| | before | after |
|---|---|---|
| entry scroll distance from bottom | 16774 px | **0** |
| delete: rows in UI | 202 → 202 | 202 → **201** |
| delete: row still in DB | already gone | gone |

Also removed the bogus 2082-dated message from both sources while confirming the fix (`futureLeftOnServer: 0` on each).

## Test plan

- [x] 4 new tests in `MeshCoreChannelsView.test.tsx` — delete prunes the backlog; failed delete keeps the row; cancelled confirm is a no-op; clear empties the backlog.
- [x] 2 new tests in `MeshCoreMessageStream.test.tsx` — entry scroll defers while hidden then runs on reveal; does not re-scroll on later resizes (so reading history isn't interrupted by a keyboard/rotate).
- [x] **Confirmed real regressions**: reverting each fix fails exactly the corresponding tests (2 and 2).
- [x] All 23 pre-existing stream tests still pass.
- [x] Full Vitest suite — `success: true`, 12954 passed, 0 failed.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
