### PR TITLE
docs(admin): document asynchronous remote-admin execution

### DIFF
--- a/docs/features/admin-commands.md
+++ b/docs/features/admin-commands.md
@@ -356,7 +356,60 @@ The Admin Commands tab supports managing nodes that are not directly connected t
 
 1. **Session Passkey Management**: MeshMonitor automatically handles authentication with remote nodes using session passkeys
 2. **Per-Node Storage**: Configuration data is stored separately for each node to prevent conflicts
-3. **Mesh Communication**: Commands are sent through the mesh network to reach remote nodes
+3. **Asynchronous Execution**: MeshMonitor accepts a valid remote command immediately, then acquires the session passkey and transmits outside the browser's original HTTP request
+4. **Completion Polling**: The Admin Commands tab stays in its existing loading state while it checks the protected operation endpoint for completion
+5. **Mesh Communication**: Commands are sent through the mesh network to reach remote nodes
+
+Local-node commands remain synchronous. A remote command can legitimately take
+over a minute of mesh time — up to 45 seconds acquiring the session passkey, plus
+up to 30 seconds awaiting a routing ACK — and holding an HTTP request open that
+long is unreliable behind a reverse proxy or CDN, which is what this split
+avoids.
+
+Remote `POST /api/admin/commands` requests return `202 Accepted` with an opaque
+operation ID. Progress is read from `GET /api/admin/operations/:id`; both
+endpoints require admin authentication, and an operation is visible only to the
+administrator who started it. Session-passkey acquisition
+(`POST /api/admin/ensure-session-passkey`) and remote configuration import
+(`POST /api/admin/import-config`) follow the same pattern — except that a
+passkey request answers `200` immediately when one is already cached, since no
+mesh round-trip is needed.
+
+Operation records hold only the command name, the source and destination
+identifiers, lifecycle state, and timestamps. **Command parameters and session
+keys are never retained.**
+
+Remote operations move through `pending`, `awaiting_passkey`, `sending`, and
+`awaiting_ack` before reaching a terminal `succeeded` or `failed`. Terminal
+results stay readable for ten minutes, so a browser whose polling was
+interrupted can still recover the outcome. Operation state lives in memory only:
+after a server restart a lookup returns `OPERATION_NOT_FOUND`, which the web
+client reports as an interrupted operation rather than a success.
+
+Failure codes distinguish session-passkey timeout (`PASSKEY_TIMEOUT`), a source
+with transmit disabled (`TX_DISABLED`), a failed configuration import
+(`IMPORT_CONFIG_FAILED`), and missing or expired operation state
+(`OPERATION_NOT_FOUND`).
+
+### Confirmation Semantics
+
+Favorite, unfavorite, ignore, and unignore commands sent to a remote node wait
+for a routing ACK:
+
+- **Confirmed** — the remote node processed the packet, and the interface
+  updates to match.
+- **Rejected** — an explicit routing rejection. The command did not apply, so
+  the interface leaves its local favorite/ignore state unchanged.
+- **No ACK (timeout)** — genuinely uncertain. The packet may still have applied,
+  so MeshMonitor keeps the optimistic update and shows a warning rather than
+  claiming either outcome.
+
+Other remote commands are reported as successful once transmitted, matching
+their previous behavior.
+
+A remote configuration import reports both what landed and what did not: a
+partial import returns the channels it imported *and* the count and names of any
+that failed, so "1 channel" is distinguishable from "1 of 2 channels".
 
 ### Remote Node Operations
 

--- a/docs/features/admin-commands.md
+++ b/docs/features/admin-commands.md
@@ -371,16 +371,20 @@ operation ID. Progress is read from `GET /api/admin/operations/:id`; both
 endpoints require admin authentication, and an operation is visible only to the
 administrator who started it. Session-passkey acquisition
 (`POST /api/admin/ensure-session-passkey`) and remote configuration import
-(`POST /api/admin/import-config`) follow the same pattern — except that a
-passkey request answers `200` immediately when one is already cached, since no
-mesh round-trip is needed.
+(`POST /api/admin/import-config`) follow the same pattern: an uncached passkey
+acquisition returns `202` and completes in the background, while a request for a
+passkey that is **already cached** answers `200` immediately, since no mesh
+round-trip is needed.
 
 Operation records hold only the command name, the source and destination
-identifiers, lifecycle state, and timestamps. **Command parameters and session
-keys are never retained.**
+identifiers, the requesting administrator, lifecycle state, and timestamps.
+**Command parameters and session keys are never retained.**
 
 Remote operations move through `pending`, `awaiting_passkey`, `sending`, and
-`awaiting_ack` before reaching a terminal `succeeded` or `failed`. Terminal
+`awaiting_ack` before reaching a terminal `succeeded` or `failed`. Not every
+command visits every state — a configuration import, for example, goes from
+`awaiting_passkey` straight to its terminal state, since it sends a sequence of
+packets rather than awaiting a single routing ACK. Terminal
 results stay readable for ten minutes, so a browser whose polling was
 interrupted can still recover the outcome. Operation state lives in memory only:
 after a server restart a lookup returns `OPERATION_NOT_FOUND`, which the web
@@ -404,8 +408,10 @@ for a routing ACK:
   so MeshMonitor keeps the optimistic update and shows a warning rather than
   claiming either outcome.
 
-Other remote commands are reported as successful once transmitted, matching
-their previous behavior.
+Other remote commands await no routing ACK and are reported as successful once
+transmitted, matching their previous behavior. That is not the same as never
+failing: a command still fails if it cannot be sent at all — for example when
+transmit is disabled on the source (`TX_DISABLED`).
 
 A remote configuration import reports both what landed and what did not: a
 partial import returns the channels it imported *and* the count and names of any


### PR DESCRIPTION
Documents the async remote-admin behavior that shipped in #4485 / #4486 (issue #4482) with no user-facing docs.

## Credit and context

**The prose here originates from @wilhel1812's PR #4483.** They reported the underlying bug (with browser network logs and host-level `MAX_RETRANSMIT` / proxy correlation), it became issue #4482, and they then opened a complete fix — including the documentation — at 13:43Z on 2026-08-01.

I opened #4485 at 14:28Z, 45 minutes later, without checking for open PRs against the issue, and it merged first. That left #4483 conflicting through no fault of its author. The two implementations converged on the same design; the one thing theirs had that mine did not was this documentation.

This ports it, adapted to the endpoint and error-code names that actually shipped. #4483 can be closed with a link here once this lands.

## What it documents

In the **Remote Node Support** section:

- Asynchronous execution and completion polling, as numbered behaviors alongside the existing ones
- The contract: remote commands return `202 Accepted` + an opaque operation ID, polled at `GET /api/admin/operations/:id`, both admin-authenticated, an operation visible only to the admin who started it
- That `ensure-session-passkey` and `import-config` follow the same pattern, except a **cached** passkey still answers `200` immediately since no mesh round-trip is needed
- **A privacy property the implementation already holds but never stated:** operation records keep only the command name, source/destination identifiers, lifecycle state, and timestamps — never command parameters or session keys. I verified this against `AdminOperation` rather than copying the claim across.
- Lifecycle states, ten-minute terminal retention, and that operation state is in-memory only — a restart yields `OPERATION_NOT_FOUND`, which the client reports as *interrupted*, not success
- Failure codes: `PASSKEY_TIMEOUT`, `TX_DISABLED`, `IMPORT_CONFIG_FAILED`, `OPERATION_NOT_FOUND`

New **Confirmation Semantics** subsection for favorite/unfavorite/ignore/unignore — confirmed vs. rejected vs. timeout-is-uncertain, and why the optimistic update survives a timeout but not a rejection. That behavior was implemented in #4485 (including the new ignore/unignore parity) but documented nowhere a user would look.

Also notes that a partial config import reports the channels that failed alongside those that landed, so "1 channel" is distinguishable from "1 of 2 channels" (#4486).

## Adaptations from #4483

Their doc described their API; these are the shipped names:

| #4483 | shipped |
|---|---|
| `GET /api/admin/commands/:operationId` | `GET /api/admin/operations/:id` |
| `pending`/`running` + separate phase axis | single axis: `pending` → `awaiting_passkey` → `sending` → `awaiting_ack` |
| `succeeded`/`failed`/`timed_out`/`rejected` | `succeeded`/`failed` (ACK outcome carried in the result) |
| `REMOTE_PASSKEY_TIMEOUT`, `TRANSPORT_FAILURE`, `ROUTING_REJECTED`, `ADMIN_OPERATION_NOT_FOUND` | `PASSKEY_TIMEOUT`, `TX_DISABLED`, `IMPORT_CONFIG_FAILED`, `OPERATION_NOT_FOUND` |
| five-minute retention | ten-minute retention |

Worth recording: **@wilhel1812's four-state terminal model is more expressive than what shipped.** Surfacing `timed_out` and `rejected` as operation states beats burying both in `result.ack`, since a caller reading only `status` learns more. The shipped version's advantage was needing no change to the frontend's existing ACK handling. Reworking it now would churn recently-reviewed code, so it's better as its own issue than as part of a docs PR.

## Testing

Docs-only — no code changes. Every factual claim was checked against the merged implementation (`adminOperationService.ts`, `adminRoutes.ts`, `api.ts`) rather than carried over on trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9