### PR TITLE
fix(meshcore): anon auth banner, channel-sync data loss, and reply/trigger ordering

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -7,7 +7,7 @@
  *   - filters messages per channel (received + locally-sent)
  *   - passes the active channelIdx to actions.sendMessage on broadcast
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({
@@ -31,8 +31,10 @@ vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
 }));
 
+// Mutable so a test can simulate a read-only / anonymous viewer.
+let permissionFn: (resource: string, action: string) => boolean = () => true;
 vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: () => ({ hasPermission: () => true }),
+  useAuth: () => ({ hasPermission: (r: string, a: string) => permissionFn(r, a) }),
 }));
 
 const csrfFetchMock = vi.fn();
@@ -940,5 +942,76 @@ describe('MeshCoreChannelsView — delete prunes the fetched backlog', () => {
     });
     await waitFor(() => expect(screen.queryByText('first')).toBeNull());
     expect(screen.queryByText('second')).toBeNull();
+  });
+});
+
+describe('MeshCoreChannelsView — read-only viewers skip send-side lookups', () => {
+  /**
+   * `config/default-scope` and `saved-regions` are `requireAuth()` +
+   * `configuration: read`, and exist only to populate the scope-override
+   * control (a send-side affordance). Firing them for an anonymous viewer
+   * always 401s; `fetchSavedRegions` then surfaced the raw body
+   * ("Authentication required") as a banner over an otherwise-working channel,
+   * which read as "you can't view this channel".
+   */
+  function routedFetch() {
+    return vi.fn((url: string) => {
+      if (url.includes('/api/channels/all')) {
+        return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+      }
+      if (url.includes('/messages/channel-counts')) {
+        return Promise.resolve(jsonResponse({ success: true, counts: { 0: 0 } }));
+      }
+      if (/\/messages\/channel\/\d+/.test(url)) {
+        return Promise.resolve(jsonResponse({ success: true, data: [], count: 0 }));
+      }
+      return Promise.resolve(jsonResponse({ success: true, data: [] }));
+    });
+  }
+
+  afterEach(() => { permissionFn = () => true; });
+
+  it('does not call the auth-only scope lookups without messages:write', async () => {
+    permissionFn = (resource, action) => !(resource === 'messages' && action === 'write');
+    csrfFetchMock.mockImplementation(routedFetch());
+    const getDefaultScope = vi.fn().mockResolvedValue('');
+    const fetchSavedRegions = vi.fn().mockResolvedValue([]);
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions({ getDefaultScope, fetchSavedRegions })}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    // Wait for the channel list to settle so the effects have had their chance.
+    await waitFor(() => expect(document.querySelector('.mc-channel-row')).toBeTruthy());
+    expect(getDefaultScope).not.toHaveBeenCalled();
+    expect(fetchSavedRegions).not.toHaveBeenCalled();
+  });
+
+  it('still calls them for a viewer who can send', async () => {
+    permissionFn = () => true;
+    csrfFetchMock.mockImplementation(routedFetch());
+    const getDefaultScope = vi.fn().mockResolvedValue('');
+    const fetchSavedRegions = vi.fn().mockResolvedValue([]);
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions({ getDefaultScope, fetchSavedRegions })}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => expect(fetchSavedRegions).toHaveBeenCalled());
+    expect(getDefaultScope).toHaveBeenCalled();
   });
 });

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -22,6 +22,7 @@ import { MeshCoreContact, formatMeshCoreChannelName } from '../../utils/meshcore
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { useAuth } from '../../contexts/AuthContext';
 import { loadChannelLastRead, markChannelRead as persistChannelRead } from './meshcoreUnreadStore';
+import { compareMeshCoreMessages } from './messageOrder';
 import { UiIcon } from '../icons';
 
 const MOBILE_BREAKPOINT = 768;
@@ -474,7 +475,11 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     for (const m of messages) {
       if (activeFilter(m)) byId.set(m.id, m);
     }
-    return Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp);
+    // NOT a raw `timestamp` sort: received messages carry the remote's
+    // whole-second `sender_timestamp` while our own sends are ms-precision
+    // Date.now(), so a same-second auto-reply sorted BEFORE its own trigger.
+    // See ./messageOrder.ts.
+    return Array.from(byId.values()).sort(compareMeshCoreMessages);
   }, [history, messages, activeFilter]);
 
   // Mark the active channel read up to its newest visible message. Runs whenever

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -319,8 +319,14 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // every status/message/node update from the mesh, even with zero user
   // interaction (#3880).
   const { getDefaultScope, fetchSavedRegions, discoverRegions } = actions;
+
+  // Both lookups below exist only to populate the scope-override control, which
+  // is a SEND-side affordance. Their routes are `requireAuth()` +
+  // `configuration: read`, so firing them for a read-only (or anonymous) viewer
+  // is guaranteed to 401 and buys nothing. Gate on `canSend` so the requests are
+  // never made rather than made and ignored.
   useEffect(() => {
-    if (!status?.connected) return;
+    if (!canSend || !status?.connected) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -331,12 +337,13 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       }
     })();
     return () => { cancelled = true; };
-  }, [status?.connected, getDefaultScope]);
+  }, [canSend, status?.connected, getDefaultScope]);
 
   // Load the global saved-regions catalog (#3770) for the override suggestions.
   // This is a cheap local DB read (no radio traffic), so it's safe to run on
   // mount / source change regardless of connection state.
   useEffect(() => {
+    if (!canSend) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -347,7 +354,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       }
     })();
     return () => { cancelled = true; };
-  }, [fetchSavedRegions, sourceId]);
+  }, [canSend, fetchSavedRegions, sourceId]);
 
   // Union of saved + discovered regions, de-duplicated, for the override
   // datalist. Saved regions come first (operator-curated), then any extra

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -111,6 +111,26 @@ export interface MeshCoreMessage {
   scopeCode?: number | null;
   /** Region name resolved from the scope code; null = unscoped or unknown scope (#3742 Ph2). */
   scopeName?: string | null;
+  /**
+   * MeshMonitor's own wall clock (ms) at the moment this message was created or
+   * observed — NOT the sender's clock.
+   *
+   * `timestamp` cannot order messages reliably: a received message takes its
+   * time from the wire's `sender_timestamp`, which MeshCore carries in whole
+   * SECONDS, while a locally-sent message is stamped `Date.now()` to the
+   * millisecond. An auto-responder replying inside the same second therefore
+   * sorted BEFORE the message that triggered it — observed in the field: the
+   * trigger stamped …213050, the reply stamped …213000 despite arriving 1.4s
+   * later.
+   *
+   * Ordering therefore compares `timestamp` at second granularity — all the
+   * wire actually gives us — and breaks ties on this field, a single monotonic
+   * clock across both directions. Display still uses `timestamp`.
+   *
+   * Optional: rows persisted before this field existed carry no value, and
+   * `compareMeshCoreMessages` falls back to `timestamp` for those.
+   */
+  receivedAt?: number;
 }
 
 export interface ConnectionStatus {

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -1023,17 +1023,23 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  /**
+   * Saved-regions catalog for the scope-override datalist.
+   *
+   * Deliberately does NOT surface a global error, matching `getDefaultScope`
+   * above: this only feeds optional autocomplete suggestions, and its route is
+   * `requireAuth()` + `configuration: read`. Reporting the failure meant an
+   * anonymous read-only viewer opening a MeshCore channel got the raw 401 body
+   * — "Authentication required" — as a banner across a page that was otherwise
+   * working, which reads as "you can't view this channel".
+   */
   const fetchSavedRegions = useCallback(async (): Promise<SavedRegion[] | null> => {
     try {
       const response = await csrfFetch(`${mcPrefix}/saved-regions`);
       const data = await response.json();
-      if (!data.success) {
-        setError(data.error || 'Failed to load saved regions');
-        return null;
-      }
+      if (!data.success) return null;
       return Array.isArray(data.regions) ? (data.regions as SavedRegion[]) : [];
     } catch (_err) {
-      setError('Failed to load saved regions');
       return null;
     }
   }, [mcPrefix, csrfFetch]);

--- a/src/components/MeshCore/messageOrder.test.ts
+++ b/src/components/MeshCore/messageOrder.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Ordering tests built from a real observed inversion.
+ *
+ * On a MeshCore channel, a remote auto-responder's reply rendered ABOVE the
+ * message that triggered it. The captured rows:
+ *
+ *   trigger (ours)   id "sent-1785604213050-…"  timestamp 1785604213050
+ *   reply   (remote) id "1785604214478-…"       timestamp 1785604213000
+ *
+ * The reply was observed 1.4 s AFTER the trigger, yet carried a timestamp 50 ms
+ * earlier — the remote can only express whole seconds via `sender_timestamp`,
+ * while our own send is stamped Date.now() to the millisecond.
+ */
+import { describe, it, expect } from 'vitest';
+import { compareMeshCoreMessages, sortMeshCoreMessages } from './messageOrder';
+
+type M = { id: string; timestamp: number; receivedAt?: number; text?: string };
+
+const TRIGGER: M = {
+  id: 'sent-1785604213050-juy7prb66',
+  timestamp: 1785604213050,
+  receivedAt: 1785604213050,
+  text: 'testing send on newly created channel',
+};
+const REPLY: M = {
+  id: '1785604214478-x87tbdp3t',
+  timestamp: 1785604213000, // remote clock, whole seconds — EARLIER than the trigger
+  receivedAt: 1785604214478, // but actually observed 1.4s later
+  text: '🤖 Copy, …',
+};
+
+describe('compareMeshCoreMessages', () => {
+  it('puts a same-second auto-reply AFTER the message that triggered it', () => {
+    const ordered = sortMeshCoreMessages([REPLY, TRIGGER]);
+    expect(ordered.map(m => m.text)).toEqual([TRIGGER.text, REPLY.text]);
+  });
+
+  it('is not fooled by the raw timestamps, which are inverted', () => {
+    // Guard the premise: a naive timestamp sort genuinely gets this wrong.
+    const naive = [REPLY, TRIGGER].sort((a, b) => a.timestamp - b.timestamp);
+    expect(naive[0].text).toBe(REPLY.text);
+  });
+
+  it('still orders messages from different seconds by their stated time', () => {
+    const older: M = { id: 'a', timestamp: 1785604100000, receivedAt: 1785604999999 };
+    const newer: M = { id: 'b', timestamp: 1785604300000, receivedAt: 1785604000000 };
+    // Even though `receivedAt` disagrees, a whole second of difference in the
+    // sender's time wins — receivedAt is only a tie-break.
+    expect(sortMeshCoreMessages([newer, older]).map(m => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('falls back to timestamp when receivedAt is absent (legacy rows)', () => {
+    const a: M = { id: 'a', timestamp: 1785604213000 };
+    const b: M = { id: 'b', timestamp: 1785604213900 };
+    // Same second, no observation clock — ordering must stay stable and total,
+    // not depend on input order.
+    expect(sortMeshCoreMessages([b, a]).map(m => m.id)).toEqual(sortMeshCoreMessages([a, b]).map(m => m.id));
+  });
+
+  it('mixes legacy and new rows without throwing away the new ordering signal', () => {
+    const legacy: M = { id: 'legacy', timestamp: 1785604213000 };
+    const fresh: M = { id: 'fresh', timestamp: 1785604213000, receivedAt: 1785604213800 };
+    // legacy falls back to timestamp (…000) so it precedes fresh (…800).
+    expect(sortMeshCoreMessages([fresh, legacy]).map(m => m.id)).toEqual(['legacy', 'fresh']);
+  });
+
+  it('is a total order — identical clocks fall back to id, never input order', () => {
+    const a: M = { id: 'aaa', timestamp: 1000, receivedAt: 1000 };
+    const b: M = { id: 'bbb', timestamp: 1000, receivedAt: 1000 };
+    expect(compareMeshCoreMessages(a, b)).toBeLessThan(0);
+    expect(compareMeshCoreMessages(b, a)).toBeGreaterThan(0);
+    expect(compareMeshCoreMessages(a, a)).toBe(0);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [REPLY, TRIGGER];
+    sortMeshCoreMessages(input);
+    expect(input.map(m => m.id)).toEqual([REPLY.id, TRIGGER.id]);
+  });
+});

--- a/src/components/MeshCore/messageOrder.ts
+++ b/src/components/MeshCore/messageOrder.ts
@@ -1,0 +1,69 @@
+/**
+ * Ordering for MeshCore message streams.
+ *
+ * Sorting on `timestamp` alone is wrong, because the two directions do not
+ * share a clock or a resolution:
+ *
+ *   received:  timestamp = sender_timestamp * 1000   ← remote clock, WHOLE SECONDS
+ *   sent:      timestamp = Date.now()                ← our clock, milliseconds
+ *
+ * A remote auto-responder that replies within the same second as the message
+ * that triggered it therefore sorts BEFORE its own trigger. Observed in the
+ * field on a MeshCore channel:
+ *
+ *   trigger (ours)   timestamp 1785604213050   created 1785604213050
+ *   reply   (remote) timestamp 1785604213000   observed 1785604214478
+ *
+ * The reply arrived 1.4 s later but carried a timestamp 50 ms earlier, purely
+ * because the remote could only express whole seconds.
+ *
+ * So: compare `timestamp` truncated to the second — the real resolution of the
+ * wire format — and break ties with `receivedAt`, MeshMonitor's own monotonic
+ * clock, which is stamped identically for both directions. Sub-second detail in
+ * a locally-sent `timestamp` is deliberately NOT used for ordering; it is
+ * precision we cannot have for the other side, and trusting it is exactly what
+ * produced the inversion.
+ *
+ * Display continues to use `timestamp` — the sender's stated time is still the
+ * honest thing to show.
+ */
+import type { MeshCoreMessage } from './hooks/useMeshCore';
+
+/** Whole-second bucket of a message's stated time. */
+function timestampSecond(m: Pick<MeshCoreMessage, 'timestamp'>): number {
+  return Math.floor((m.timestamp ?? 0) / 1000);
+}
+
+/**
+ * Tie-break clock. Falls back to `timestamp` for rows persisted before
+ * `receivedAt` existed, which keeps legacy history in a stable, sensible order
+ * instead of collapsing it all to zero.
+ */
+function observedAt(m: Pick<MeshCoreMessage, 'timestamp' | 'receivedAt'>): number {
+  return typeof m.receivedAt === 'number' ? m.receivedAt : (m.timestamp ?? 0);
+}
+
+/**
+ * Comparator for oldest-first message streams. Stable and total: equal seconds
+ * fall back to the observed clock, and identical observed clocks fall back to
+ * `id` so the order never depends on input sequence.
+ */
+export function compareMeshCoreMessages(
+  a: Pick<MeshCoreMessage, 'id' | 'timestamp' | 'receivedAt'>,
+  b: Pick<MeshCoreMessage, 'id' | 'timestamp' | 'receivedAt'>,
+): number {
+  const bySecond = timestampSecond(a) - timestampSecond(b);
+  if (bySecond !== 0) return bySecond;
+
+  const byObserved = observedAt(a) - observedAt(b);
+  if (byObserved !== 0) return byObserved;
+
+  return String(a.id).localeCompare(String(b.id));
+}
+
+/** Convenience: oldest-first copy of a message list. */
+export function sortMeshCoreMessages<T extends Pick<MeshCoreMessage, 'id' | 'timestamp' | 'receivedAt'>>(
+  messages: T[],
+): T[] {
+  return [...messages].sort(compareMeshCoreMessages);
+}

--- a/src/server/meshcoreManager.channels.test.ts
+++ b/src/server/meshcoreManager.channels.test.ts
@@ -238,6 +238,67 @@ describe('MeshCoreManager — syncChannelsFromDevice', () => {
     // Deleted the stale empty-slot row at idx 1.
     expect(deleteCalls).toEqual([{ id: 1, sourceId: 'test-source' }]);
   });
+
+  /**
+   * `getChannels()` enumerates until the firmware errors, so a timeout part-way
+   * through the scan TRUNCATES the list rather than failing it. Treating a slot
+   * that was never reported as "deleted" turned a transient read into permanent
+   * loss of the channel definition — a configured second channel vanished from
+   * the UI while its messages (a different table) survived.
+   */
+  it('does NOT delete rows for slots the device never reported (truncated scan)', async () => {
+    const { manager, deleteCalls, upsertCalls } = makeManager({
+      preExistingRows: [
+        { id: 0, name: 'Public', psk: 'p' },
+        { id: 1, name: 'Gauntlet', psk: 'g' },
+      ],
+      // Scan stopped after slot 0 — slot 1 is absent, NOT reported-as-empty.
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 0, name: 'Public', secret_hex: 'aa'.repeat(16) }],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+
+    expect(upsertCalls.map(c => c.data.id)).toEqual([0]);
+    expect(deleteCalls).toEqual([]); // Gauntlet survives.
+  });
+
+  it('does NOT delete anything when the scan returns no slots at all', async () => {
+    const { manager, deleteCalls } = makeManager({
+      preExistingRows: [
+        { id: 0, name: 'Public', psk: 'p' },
+        { id: 1, name: 'Gauntlet', psk: 'g' },
+      ],
+      getChannelsResponse: { success: true, data: [] },
+    });
+    await manager.syncChannelsFromDevice();
+
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it('still deletes a slot the device reports as empty even when others are absent', async () => {
+    // Slot 1 is positively reported empty (a real out-of-band delete), while
+    // slot 5 was never reached. Only 1 may go.
+    const zero = '00'.repeat(16);
+    const { manager, deleteCalls } = makeManager({
+      preExistingRows: [
+        { id: 0, name: 'Public', psk: 'p' },
+        { id: 1, name: 'Gone', psk: 'x' },
+        { id: 5, name: 'Unreached', psk: 'y' },
+      ],
+      getChannelsResponse: {
+        success: true,
+        data: [
+          { channel_idx: 0, name: 'Public', secret_hex: 'aa'.repeat(16) },
+          { channel_idx: 1, name: '', secret_hex: zero },
+        ],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+
+    expect(deleteCalls).toEqual([{ id: 1, sourceId: 'test-source' }]);
+  });
 });
 
 describe('MeshCoreManager — setChannel / deleteChannel', () => {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -558,6 +558,19 @@ export interface MeshCoreMessage {
   toPublicKey?: string; // null for broadcast
   text: string;
   timestamp: number;
+  /**
+   * MeshMonitor's own wall clock (ms) when this message was created or observed
+   * — NOT the sender's clock, and stamped identically for both directions.
+   *
+   * `timestamp` cannot order a stream: a received message takes its time from
+   * the wire's `sender_timestamp`, which MeshCore carries in whole SECONDS,
+   * while a locally-sent message gets `Date.now()` to the millisecond. A remote
+   * auto-responder replying inside the same second therefore sorted BEFORE its
+   * own trigger (observed: trigger …213050, reply …213000 despite arriving
+   * 1.4 s later). Ordering compares `timestamp` per-second and breaks ties on
+   * this field — see src/components/MeshCore/messageOrder.ts.
+   */
+  receivedAt?: number;
   rssi?: number;
   snr?: number;
   /**
@@ -1109,6 +1122,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         rssi: dbMsg.rssi ?? undefined,
         snr: dbMsg.snr ?? undefined,
         sourceId: dbMsg.sourceId ?? undefined,
+        // The DB's createdAt IS our own observation clock — same semantic as
+        // receivedAt — so historical rows order correctly too, with no migration.
+        receivedAt: dbMsg.createdAt ?? undefined,
         hopCount: dbMsg.hopCount ?? null,
         routePath: dbMsg.routePath ?? null,
         scopeCode: dbMsg.scopeCode ?? null,
@@ -1601,6 +1617,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         toPublicKey: this.localNode?.publicKey || 'local',
         text: data.text,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
+        // Our own clock, for ordering. `timestamp` above is the REMOTE's and
+        // only whole-seconds, so it cannot order against our ms-precision
+        // sends (see components/MeshCore/messageOrder.ts).
+        receivedAt: Date.now(),
         snr: data.snr,
         sourceId: this.sourceId,
         hopCount,
@@ -1637,6 +1657,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         fromName,
         text: body,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
+        // Our own clock, for ordering. `timestamp` above is the REMOTE's and
+        // only whole-seconds, so it cannot order against our ms-precision
+        // sends (see components/MeshCore/messageOrder.ts).
+        receivedAt: Date.now(),
         snr: data.snr,
         sourceId: this.sourceId,
         hopCount,
@@ -1672,6 +1696,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         toPublicKey: roomFullKey,
         text: data.text,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
+        // Our own clock, for ordering. `timestamp` above is the REMOTE's and
+        // only whole-seconds, so it cannot order against our ms-precision
+        // sends (see components/MeshCore/messageOrder.ts).
+        receivedAt: Date.now(),
         snr: data.snr,
         sourceId: this.sourceId,
         messageType: 'room_post',
@@ -2574,6 +2602,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         fromPublicKey: match[1],
         text: match[2],
         timestamp: Date.now(),
+        receivedAt: Date.now(),
         sourceId: this.sourceId,
       };
       this.addMessage(message);
@@ -3225,6 +3254,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           toPublicKey: sentToPublicKey,
           text: text,
           timestamp: Date.now(),
+          receivedAt: Date.now(),
           sourceId: this.sourceId,
           expectedAckCrc: ackCrc ?? undefined,
           estTimeout: estTimeout ?? undefined,
@@ -4902,6 +4932,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           toPublicKey: roomPublicKey,
           text,
           timestamp: Date.now(),
+          receivedAt: Date.now(),
           sourceId: this.sourceId,
           messageType: 'room_post',
         };
@@ -5957,6 +5988,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         rssi: dbMsg.rssi ?? undefined,
         snr: dbMsg.snr ?? undefined,
         sourceId: dbMsg.sourceId ?? undefined,
+        // The DB's createdAt IS our own observation clock — same semantic as
+        // receivedAt — so historical rows order correctly too, with no migration.
+        receivedAt: dbMsg.createdAt ?? undefined,
         hopCount: dbMsg.hopCount ?? null,
         routePath: dbMsg.routePath ?? null,
         scopeCode: dbMsg.scopeCode ?? null,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2405,9 +2405,21 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * typically 40 on Companion builds) leaks into the UI.
    *
    * After syncing the configured slots we also delete any stale DB rows for
-   * this source whose idx is no longer reported as configured by the
-   * device — so an out-of-band delete via meshcore-cli is reflected on the
-   * next sync, and a previous "leaked empty slots" install gets cleaned up.
+   * this source whose idx the device POSITIVELY REPORTED as unconfigured — so
+   * an out-of-band delete via meshcore-cli is reflected on the next sync, and a
+   * previous "leaked empty slots" install gets cleaned up.
+   *
+   * A slot the device did not report at all is deliberately left alone. That
+   * distinction matters because `getChannels()` enumerates until the firmware
+   * errors: a timeout or hiccup part-way through the scan truncates the list
+   * rather than failing it, so slot 0 can come back alone while slots 1..n are
+   * simply missing. Treating "absent" as "deleted" turned a transient read into
+   * permanent loss of the channel definition — observed in the field, where a
+   * second configured channel vanished from the UI while its messages (a
+   * different table) survived. Absent is unknown, not empty.
+   *
+   * Mirrors the same decision `refreshContacts` already makes ("deliberately
+   * won't wipe on empty") for the contact list.
    *
    * MeshCore has no push event for channel changes, so callers should invoke
    * this on connect and after every local write.
@@ -2434,18 +2446,37 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       );
     }
 
-    // Reconcile: remove DB rows for slots the device no longer treats as
-    // configured. This covers (a) out-of-band deletes via meshcore-cli and
+    // Reconcile: remove DB rows for slots the device positively reported as
+    // unconfigured. This covers (a) out-of-band deletes via meshcore-cli and
     // (b) cleanup of legacy installs that had unconfigured-slot rows from
     // before the filter landed.
+    //
+    // `reportedIdxSet` is every slot the firmware actually answered for. A row
+    // whose idx is NOT in it carries no evidence either way — the enumeration
+    // may simply have stopped short — so it is preserved. Only "reported AND
+    // not configured" is treated as a delete.
+    const reportedIdxSet = new Set(channels.map(ch => ch.channelIdx));
     const configuredIdxSet = new Set(configured.map(ch => ch.channelIdx));
     const existing = await databaseService.channels.getAllChannels(this.sourceId);
     let removed = 0;
+    let preserved = 0;
     for (const row of existing) {
-      if (!configuredIdxSet.has(row.id)) {
-        await databaseService.channels.deleteChannel(row.id, this.sourceId);
-        removed++;
+      if (configuredIdxSet.has(row.id)) continue;
+      if (!reportedIdxSet.has(row.id)) {
+        // Unreported: the scan never reached this slot. Leave it be.
+        preserved++;
+        continue;
       }
+      await databaseService.channels.deleteChannel(row.id, this.sourceId);
+      removed++;
+    }
+
+    if (preserved > 0) {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] Channel scan returned ${channels.length} slot(s); ` +
+        `kept ${preserved} DB row(s) the device did not report (possible truncated read). ` +
+        'Re-run a sync once the device is responsive to reconcile properly.',
+      );
     }
 
     logger.debug(

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -137,6 +137,16 @@ export interface ResourceDefinition {
 }
 
 export const RESOURCES: readonly ResourceDefinition[] = [
+  // Listed first on purpose: MeshCoreSourcePage gates its ENTIRE surface on
+  // `connection: read`, so without it every other grant on a MeshCore source is
+  // inert and the user just sees "You do not have permission to view this
+  // MeshCore source". Granting it is the first thing you need, so it reads
+  // first.
+  {
+    id: 'connection',
+    name: 'Connection',
+    description: 'Required to open a source. Also controls connect/disconnect.',
+  },
   { id: 'dashboard', name: 'Dashboard', description: 'View statistics and system info' },
   { id: 'nodes', name: 'Node List', description: 'View and manage mesh nodes' },
   { id: 'channel_0', name: 'Channel 0 (Primary)', description: 'View and send messages to channel 0' },
@@ -153,7 +163,6 @@ export const RESOURCES: readonly ResourceDefinition[] = [
   { id: 'info', name: 'Info', description: 'Telemetry and network information' },
   { id: 'automation', name: 'Automation', description: 'Automated tasks and announcements' },
   { id: 'automations', name: 'Automation Engine', description: 'Create and manage global automations and variables (Advanced Mode)' },
-  { id: 'connection', name: 'Connection', description: 'Control node connection (disconnect/reconnect)' },
   { id: 'traceroute', name: 'Traceroute', description: 'Initiate traceroute requests to nodes' },
   { id: 'audit', name: 'Audit Log', description: 'View and manage audit logs (admin only)' },
   { id: 'security', name: 'Security', description: 'View security scan results and key management' },


### PR DESCRIPTION
Three MeshCore fixes found by driving the running app. All **pre-existing** — none introduced by the #4473 nav work (verified against both of its merge commits).

Supersedes #4489, whose commit is included here (it was stacked on the pre-squash version of #4488 and had gone conflicting).

---

## 1. Spurious "Authentication required" over the channel view

An anonymous viewer with read grants got a page-level banner that reads as "you can't view this channel", on a page that was otherwise working.

Reproduced in an anonymous session — two of four failing calls were the cause:

| call | status |
|---|---|
| `config/default-scope` | **401** ← the banner |
| `saved-regions` | **401** ← the banner |

Both are `requireAuth()` + `configuration: read` and exist **only** to populate the scope-override datalist — a send-side control a read-only viewer cannot use. `fetchSavedRegions` surfaced the raw 401 body through `setError`, turning `{"error":"Authentication required"}` into a banner.

- Gate both lookups on `canSend` — never requested for a viewer who cannot send.
- Drop the `setError`, matching `getDefaultScope` directly above it. Optional autocomplete suggestions must not raise a page-level error.

**Permissions UI:** `connection` moves to the top of `RESOURCES`, reworded to *"Required to open a source."* `MeshCoreSourcePage` gates its **entire** surface on `connection: read`, so without it every other grant is inert and the operator sees only "You do not have permission to view this MeshCore source". Note that gate is **MeshCore-only** — no Meshtastic path checks it, despite the comment there claiming parity.

## 2. Channel rows deleted for slots the device never reported

`syncChannelsFromDevice()` reconciled by deleting rows absent from the scan. `getChannels()` enumerates until the firmware errors, so a partial scan returns success with a **short list** rather than failing — and every unlisted slot was treated as deleted.

Absent is unknown, not empty. Deletion now requires the firmware to have **positively reported** the slot as unconfigured; unreached slots are preserved and logged at warn. This mirrors the decision `refreshContacts` already makes at the adjacent call site ("deliberately won't wipe on empty").

**Scope note, stated plainly:** this is hardening, **not** the fix for the report that prompted it. Debug logging showed that device returned its full 40-slot table with 39 empty (`Synced 1 configured channel(s) ... filtered out 39 empty slot(s)`) — a complete scan of a device that genuinely no longer had the channel, so the reconcile was correct. The partial-scan hazard is real regardless: the sibling source was simultaneously failing `get_channels` with a native command timeout.

## 3. Auto-responder replies sorted above their own trigger

Captured from the running app:

```
trigger (ours)   id sent-1785604213050-…   timestamp 1785604213050
reply   (remote) id 1785604214478-…        timestamp 1785604213000
```

The reply was observed **1.4 s after** the trigger but carried a timestamp **50 ms earlier**, because the two directions share neither a clock nor a resolution:

```
received: timestamp = sender_timestamp * 1000   ← remote, WHOLE SECONDS
sent:     timestamp = Date.now()                ← ours, milliseconds
```

Sub-second precision on our own sends is precision we can never have for the other side, and trusting it is what produced the inversion.

Adds `receivedAt` — MeshMonitor's own clock, stamped identically at all **six** message-creation sites (3 received, 3 sent) — plus a shared comparator in `messageOrder.ts`: compare `timestamp` at **second** granularity (the wire's real resolution), tie-break on `receivedAt`, fall back to `id` so the order is total and never depends on input sequence. Display still uses `timestamp`.

**No migration:** `meshcore_messages` already persists `createdAt` with exactly this meaning, so rehydration maps `createdAt → receivedAt` and **existing history reorders too**. Legacy rows without it fall back to `timestamp`.

The DM view is unchanged — it doesn't sort, inheriting pool arrival order, which is already causally correct.

## Verified on the running container

- Anonymous session: banner gone, neither auth-only endpoint requested at all.
- Ordering, on the exact reported pair — trigger now precedes its reply despite both rendering `1:10:13 PM`. A second pair sent later has **byte-identical timestamps** across three messages; only `receivedAt` separates them, and they order correctly.
- Historical rows reordered with no re-sending, via the `createdAt` mapping.

## Test plan

- [x] 3 tests for the sync guard (truncated scan, empty scan, reported-empty still deletes).
- [x] 7 tests for the comparator, built from the **real captured values** — including one asserting the premise, that a naive `timestamp` sort genuinely inverts them, so the fix can't be quietly neutered.
- [x] 2 tests for the read-only gating.
- [x] **All confirmed real regressions**: reverting each fix fails exactly its own tests (3, 2, 1).
- [x] Full Vitest suite — `success: true`, **12966 passed, 0 failed**.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.

## Follow-ups not addressed here

- `channel_0..7` are offered on MeshCore sources but are **inert** — no MeshCore code path consults `channel_N`. Granting `channel_0` there looks like it should grant channel access and does nothing; channel content needs `messages: read` (the server names it in its 403 body). Hiding them for MeshCore sources would be its own change.
- `get_channels` intermittently times out on these companions, so a source's channel list can silently never sync. Worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
