### PR TITLE
chore(release): 4.13.3-rc5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.3-rc4",
+  "version": "4.13.3-rc5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.3-rc4",
+  "version": "4.13.3-rc5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.3-rc4
-appVersion: "4.13.3-rc4"
+version: 4.13.3-rc5
+appVersion: "4.13.3-rc5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc4",
+  "version": "4.13.3-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.3-rc4",
+      "version": "4.13.3-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc4",
+  "version": "4.13.3-rc5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.13.3-rc5** across all five version files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`).

## Changes since rc4 (12)

**Remote admin no longer holds an HTTP request across mesh round-trips** — issue #4482, fixed by #4485 and #4486. Commands, session-passkey acquisition, and remote config import all return `202 Accepted` with an operation id and complete in the background, polled via `GET /api/admin/operations/:id`. This fixes the reported upstream 502s behind a reverse proxy, where a single remote admin action could legitimately hold a connection open for up to 75s. Remote ignore/unignore also gained the routing-ACK confirmation that only favorites had. Documented in #4490.

**Admin messages now use the node's configured LoRa hop limit** (#4479) instead of a hardcoded 3, so nodes more than 3 hops away are administrable at all.

**`GET /stats` no longer 500s when `sourceId` is omitted** (#4470) — the cross-source aggregate path had never worked.

**MeshCore:** anon auth banner, channel-sync data loss, reply/trigger ordering (#4491); channel view scroll position and Delete (#4488); hop/route/scope preserved in channel message history (#4475).

**Navigation:** unified Meshtastic/MeshCore per-source navigation (#4481) and moved the Meshtastic phone nav to the shared bottom bar (#4484).

<details>
<summary>Full commit list</summary>

```
58d59ac7 docs(admin): document asynchronous remote-admin execution (#4490)
0687d6cf fix(api): GET /stats returns 500 whenever sourceId is omitted (#4470)
fdd983c2 fix(meshcore): anon auth banner, channel-sync data loss, and reply/trigger ordering (#4491)
6fde8514 fix(admin): decouple session-passkey and config-import from the HTTP request (#4486)
aaadb58b fix(meshcore): channel view opens at the top and Delete appears to do nothing (#4488)
ff158c7a feat(nav): move the Meshtastic phone nav to the shared bottom bar (#4473) (#4484)
d90ed1d3 fix(admin): decouple remote-admin commands from the HTTP request (#4482) (#4485)
97947e22 feat(nav): unify Meshtastic/MeshCore per-source navigation (#4473) (#4481)
92f7632d fix(admin): send admin messages at the node's configured hop limit (#4479)
14fa0057 fix(ui): restore the send-message button icon (#4478) (#4480)
c649635d fix(messaging): stop older-message loads from force-scrolling to bottom (#4477)
78890f62 fix(meshcore): preserve hop/route/scope info in channel message history (#4474) (#4475)
```

</details>

## Why the system-test label matters on this one

Release bumps always carry it, but it is doing real work here: **this is the first build to exercise the async remote-admin paths against actual hardware.** None of #4485, #4486, or #4479 was hardware-validated when merged — they shipped on unit and route coverage alone.

The legs worth watching:
- **Configuration Import** — drives `/api/admin/import-config`, the longest of the newly-async sequences (passkey acquisition, then a burst of per-channel admin sends with 1s pacing). It also exercises the hop-limit change, since admin packets now carry the device's configured value rather than 3.
- **Quick Start / Reverse Proxy** — real HTTP paths through a proxy, which is the failure mode #4482 was about.

If Configuration Import fails, check the rig's `tx_enabled` and modem preset before assuming the diff — that state has masqueraded as unrelated timeouts before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cgD5kSurLjdeVkZ6PcQD9