### PR TITLE
fix(nav,map): iOS PWA bottom-nav safe area + map controls clearance and zoom-to-fit

### DIFF
--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -363,3 +363,52 @@ describe('NodesTab', () => {
     });
   });
 });
+
+describe('map controls: attribution clearance + zoom-to-fit (#4495, #4496)', () => {
+  const nodesCss = readFileSync(resolve('src/styles/nodes.css'), 'utf8');
+
+  /** Body of a rule inside the LATER mobile override block, per this file's #3532 note. */
+  function mobileOverrideRule(selector: string): string {
+    // lastIndexOf, NOT indexOf: an earlier NOTE comment cross-references this
+    // same phrase, and anchoring on it sliced in the BASE rule instead.
+    const block = nodesCss.slice(nodesCss.lastIndexOf('Map Controls (mobile override)'));
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return block.match(new RegExp(escaped + '\\s*\\{([^}]*)\\}'))?.[1] ?? '';
+  }
+
+  it('bounds the mobile controls panel so it cannot reach the attribution strip', () => {
+    // Raising z-index cannot fix this: the attribution is inside Leaflet's
+    // `.leaflet-bottom` (z-index 1000) while this panel must stay at 997 to
+    // yield to the Sources drawer (999). Geometry is the only lever.
+    const rule = mobileOverrideRule('.map-controls');
+    expect(rule).toMatch(/max-height:\s*calc\(/);
+    // The z-index that forces the geometric approach must still be there.
+    expect(rule).toMatch(/z-index:\s*997/);
+  });
+
+  it('lets a long feature list scroll inside the bounded panel', () => {
+    // Base .map-controls is `overflow: hidden`, so without this the excess is
+    // clipped rather than reachable.
+    expect(nodesCss).toMatch(/\.map-controls \.map-controls-body \{[^}]*overflow-y:\s*auto/);
+  });
+
+  it('styles the zoom-to-fit button and gives it a disabled state', () => {
+    expect(nodesCss).toMatch(/\.map-controls-fit-btn/);
+    expect(nodesCss).toMatch(/\.map-controls-fit-btn:disabled \{[^}]*cursor:\s*not-allowed/);
+  });
+
+  it('wires the fit button to a counter, not a boolean', () => {
+    // A boolean would fire once and never re-fit on a second tap.
+    const src = readFileSync(resolve('src/components/NodesTab.tsx'), 'utf8');
+    expect(src).toMatch(/setFitAllRequest\(n => n \+ 1\)/);
+    expect(src).toMatch(/<FitAllNodesController\s+request=\{fitAllRequest\}/);
+  });
+
+  it('fits to the OFFSET marker positions, matching the pins the user sees', () => {
+    // Fitting to raw centres could leave a visible pin just outside the
+    // viewport — the #4016/#4155 single-position rule.
+    const src = readFileSync(resolve('src/components/NodesTab.tsx'), 'utf8');
+    const memo = src.match(/const fitAllPositions[\s\S]{0,400}/)?.[0] ?? '';
+    expect(memo).toMatch(/nodePositions\.get\(node\.nodeNum\)/);
+  });
+});

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -262,6 +262,47 @@ const DefaultCenterController: React.FC<{
 };
 
 /**
+ * Zooms the map to fit every positioned node (#4496).
+ *
+ * The button lives in `.map-controls`, a SIBLING of MapContainer with no access
+ * to the map instance. Rather than plumb the instance outward, this follows the
+ * same shape as TracerouteBoundsController below — a controller inside the map
+ * reacting to a prop. `request` is a monotonically increasing counter so
+ * repeated clicks re-fit even when the node set hasn't changed; a boolean would
+ * only ever fire once.
+ */
+const FitAllNodesController: React.FC<{
+  request: number;
+  positions: Array<[number, number]>;
+}> = ({ request, positions }) => {
+  const map = useMap();
+  const lastHandled = useRef(0);
+
+  useEffect(() => {
+    if (request === 0 || request === lastHandled.current) return;
+    lastHandled.current = request;
+    if (positions.length === 0) return;
+
+    if (positions.length === 1) {
+      // fitBounds on zero-area bounds snaps to max zoom; centring reads better.
+      map.setView(positions[0], Math.max(map.getZoom(), 14), { animate: true });
+      return;
+    }
+
+    map.fitBounds(positions, {
+      padding: [50, 50],
+      animate: true,
+      duration: 0.5,
+      // Matches TracerouteBoundsController: a tight cluster shouldn't slam to
+      // street level.
+      maxZoom: 15,
+    });
+  }, [request, positions, map]);
+
+  return null;
+};
+
+/**
  * Controller component that zooms the map to fit the traceroute bounds
  * Must be placed inside MapContainer to access the map instance
  */
@@ -856,6 +897,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   const [geoJsonLayers, setGeoJsonLayers] = useState<GeoJsonLayer[]>([]);
   // mapStyles/activeStyleId/activeStyleJson now live in SettingsContext
   // (issue #4348) so DashboardMap can share the same active style.
+
+  // Zoom-to-fit-all request counter (#4496). A counter rather than a boolean so
+  // repeated taps re-fit even when the node set is unchanged; FitAllNodesController
+  // inside the map watches it.
+  const [fitAllRequest, setFitAllRequest] = useState(0);
 
   // Track if map controls are collapsed
   const [isMapControlsCollapsed, setIsMapControlsCollapsed] = useState(() => {
@@ -1513,6 +1559,17 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // needed. `markerRefs` itself is still populated (via each descriptor's
   // `add` event handler below) purely for App.tsx's "open popup for selected
   // node" effect and this component's `onOmsClick`.
+
+  // Zoom-to-fit-all target set (#4496). Uses the same OFFSET marker positions
+  // as the pins and the measure tool, per the #4016/#4155 single-position rule —
+  // fitting to raw centres could leave a visible pin just outside the viewport.
+  const fitAllPositions: Array<[number, number]> = React.useMemo(
+    () => nodesWithPosition
+      .map(node => nodePositions.get(node.nodeNum))
+      .filter((p): p is [number, number] => Array.isArray(p)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on nodePositions like measurePoints below
+    [nodePositions, nodesWithPosition.map(n => n.nodeNum).join(',')],
+  );
 
   // #3636: measurement endpoints — nearest-node snapping picks from these.
   // Use the OFFSET marker position (nodePositions), not the raw center, so the
@@ -2410,6 +2467,23 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 <div className="map-controls-title">
                   Features
                 </div>
+                {/* Zoom to fit all nodes (#4496). Sits in the header so it stays
+                    reachable when the panel is collapsed — the whole point is a
+                    one-tap re-frame, which a click-to-expand-first would spoil. */}
+                <button
+                  className="map-controls-fit-btn"
+                  onClick={() => setFitAllRequest(n => n + 1)}
+                  disabled={fitAllPositions.length === 0}
+                  title={
+                    fitAllPositions.length === 0
+                      ? 'No positioned nodes to zoom to'
+                      : `Zoom to fit all ${fitAllPositions.length} positioned nodes`
+                  }
+                  aria-label="Zoom to fit all nodes"
+                  onMouseDown={(e) => e.stopPropagation()}
+                >
+                  <UiIcon name="target" size={16} />
+                </button>
                 <button
                   className="map-controls-collapse-btn"
                   onClick={handleCollapseMapControls}
@@ -2763,6 +2837,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 targetZoom={mapCenterTargetZoom}
               />
               <TracerouteBoundsController bounds={tracerouteBounds} />
+              <FitAllNodesController request={fitAllRequest} positions={fitAllPositions} />
               <ZoomHandler onZoomChange={setMapZoom} />
               <MapPositionHandler />
               <WaypointMapEventBridge

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -320,9 +320,20 @@
      * `!important` to compact the *rail*. On a bottom bar that padding is just
      * height: it inflated the landscape bar to 53.7px against the 44px the
      * shell reserves, so content and the save bar sat under it.
+     *
+     * padding-bottom keeps the safe-area inset rather than flattening to 0
+     * (#4497). A flat 0 here ALSO beat SourceNav's own
+     * `padding-bottom: env(safe-area-inset-bottom)`, docking the bar flush to
+     * the screen edge in an iOS standalone PWA — which put the tab row inside
+     * the home-indicator swipe zone, so taps ran the system gesture instead of
+     * hitting the tab.
+     *
+     * Growing the bar by the inset does NOT break the shell's reservations:
+     * App.css already reserves `--app-nav-bar-height + safe-area-inset-bottom`,
+     * and .save-bar / .nodes-split-view offset by that same sum.
      */
     padding-top: 0 !important;
-    padding-bottom: 0 !important;
+    padding-bottom: env(safe-area-inset-bottom, 0px) !important;
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
     border-right: none;

--- a/src/components/nav/SourceNav.mobile.test.ts
+++ b/src/components/nav/SourceNav.mobile.test.ts
@@ -71,3 +71,43 @@ describe('SourceNav mobile bottom bar (#4473)', () => {
     expect(css).toMatch(/--source-nav-collapsed-width:/);
   });
 });
+
+/**
+ * iOS PWA bottom-nav regressions (#4497). Reported on an iPhone 14 Pro Max
+ * standalone PWA install; all three are stylesheet-level, which jsdom cannot
+ * evaluate, so these assert on source the same way the rest of this file does.
+ */
+describe('iOS PWA bottom bar (#4497)', () => {
+  const sidebarCss = readFileSync(resolve('src/components/Sidebar.css'), 'utf-8');
+
+  it('does not flatten the bar padding-bottom to zero, which killed the safe-area inset', () => {
+    // `.sidebar` needs !important to beat the landscape-rail blocks, but a flat
+    // `0` also beat SourceNav's own env(safe-area-inset-bottom), docking the bar
+    // flush to the screen edge inside the iOS home-indicator gesture zone.
+    const mobileBlock = sidebarCss.slice(
+      sidebarCss.indexOf('@media (max-width: 768px), (max-height: 500px) and (orientation: landscape)')
+    );
+    const rule = mobileBlock.match(/\.sidebar \{([\s\S]*?)\n {2}\}/)?.[1] ?? '';
+    expect(rule).not.toBe('');
+    expect(rule).not.toMatch(/padding-bottom:\s*0\s*!important/);
+    expect(rule).toMatch(/padding-bottom:\s*env\(safe-area-inset-bottom[^;]*\)\s*!important/);
+  });
+
+  it('keeps the safe-area inset on the bar itself too', () => {
+    expect(css).toMatch(/\.mobileBottomBar \{[^}]*padding-bottom:\s*env\(safe-area-inset-bottom/);
+  });
+
+  it('guards the horizontal scroll against iOS edge-swipe chaining', () => {
+    const bar = css.match(/\.mobileBottomBar \{([^}]*)\}/)?.[1] ?? '';
+    expect(bar).toMatch(/touch-action:\s*pan-x/);
+    expect(bar).toMatch(/overscroll-behavior-x:\s*contain/);
+  });
+
+  it('fades whichever edge still has tabs beyond it', () => {
+    // mask-image, not an ::after overlay — a pseudo-element inside a scroll
+    // container scrolls away with the content.
+    expect(css).toMatch(/\.mobileBottomBar\[data-overflow-end='true'\][^}]*mask-image/);
+    expect(css).toMatch(/\.mobileBottomBar\[data-overflow-start='true'\][^}]*mask-image/);
+    expect(css).not.toMatch(/\.mobileBottomBar[^{]*::after[^}]*linear-gradient/);
+  });
+});

--- a/src/components/nav/SourceNav.module.css
+++ b/src/components/nav/SourceNav.module.css
@@ -206,10 +206,53 @@
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
     padding-bottom: env(safe-area-inset-bottom, 0px);
+    /*
+     * Keep a horizontal drag on the bar as a scroll of THIS element (#4497).
+     * `pan-x` declares horizontal panning as the only gesture we want here, and
+     * `contain` stops scroll chaining once an end is reached — chaining is what
+     * let a swipe on the bar fall through to Safari's back-swipe / app-switcher
+     * edge gesture and kick the user out of the PWA.
+     *
+     * Partial mitigation, to be honest about it: the iOS home-indicator and
+     * app-switcher gestures are OS-level and CSS cannot fully suppress them.
+     * The safe-area padding above is what actually lifts the tap targets clear
+     * of the home-indicator zone; these two only stop the scroll chaining.
+     */
+    touch-action: pan-x;
+    overscroll-behavior-x: contain;
   }
 
   .mobileBottomBar::-webkit-scrollbar {
     display: none;
+  }
+
+  /*
+   * Scroll affordance (#4497): there are more tabs than fit on a phone, with
+   * nothing to suggest the row scrolls, so tabs get missed entirely. Fade
+   * whichever edge still has content beyond it.
+   *
+   * `mask-image` rather than an ::after overlay, because a pseudo-element
+   * inside a scroll container scrolls away with the content; a mask applies to
+   * the element's own box and stays put. The data attributes come from
+   * SourceNav's scroll position, so a bar whose tabs all fit shows no fade.
+   */
+  .mobileBottomBar[data-overflow-end='true'] {
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent 100%);
+    mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent 100%);
+  }
+
+  .mobileBottomBar[data-overflow-start='true'] {
+    -webkit-mask-image: linear-gradient(to right, transparent 0, #000 28px);
+    mask-image: linear-gradient(to right, transparent 0, #000 28px);
+  }
+
+  .mobileBottomBar[data-overflow-start='true'][data-overflow-end='true'] {
+    -webkit-mask-image: linear-gradient(
+      to right, transparent 0, #000 28px, #000 calc(100% - 28px), transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right, transparent 0, #000 28px, #000 calc(100% - 28px), transparent 100%
+    );
   }
 
   /* Width is a row-layout concept here; the collapsed/expanded rail widths

--- a/src/components/nav/SourceNav.test.tsx
+++ b/src/components/nav/SourceNav.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 vi.mock('../../contexts/IconStyleContext', () => ({
   useIconStyleOptional: () => 'lucide' as const,
@@ -112,5 +112,58 @@ describe('SourceNav', () => {
     rerender(<SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="rail" />);
     expect(container.querySelector('[data-source-nav]')?.getAttribute('data-mobile-variant'))
       .toBe('rail');
+  });
+});
+
+/**
+ * Scroll-cue state (#4497). The fade is driven by data attributes measured from
+ * the live scroll position, so a bar whose tabs all fit shows no fade at all.
+ */
+describe('SourceNav overflow cue', () => {
+  function setMetrics(el: HTMLElement, { scrollWidth, clientWidth, scrollLeft }: {
+    scrollWidth: number; clientWidth: number; scrollLeft: number;
+  }) {
+    Object.defineProperty(el, 'scrollWidth', { configurable: true, get: () => scrollWidth });
+    Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => clientWidth });
+    Object.defineProperty(el, 'scrollLeft', { configurable: true, writable: true, value: scrollLeft });
+  }
+
+  const render1 = () =>
+    render(<SourceNav sections={sections} activeId="nodes" collapsed />);
+
+  it('shows no fade when every tab fits', () => {
+    const { container } = render1();
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    setMetrics(nav, { scrollWidth: 300, clientWidth: 300, scrollLeft: 0 });
+    act(() => { nav.dispatchEvent(new Event('scroll')); });
+    expect(nav.getAttribute('data-overflow-start')).toBe('false');
+    expect(nav.getAttribute('data-overflow-end')).toBe('false');
+  });
+
+  it('fades the trailing edge when tabs continue past the right', () => {
+    const { container } = render1();
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    setMetrics(nav, { scrollWidth: 900, clientWidth: 300, scrollLeft: 0 });
+    act(() => { nav.dispatchEvent(new Event('scroll')); });
+    expect(nav.getAttribute('data-overflow-start')).toBe('false');
+    expect(nav.getAttribute('data-overflow-end')).toBe('true');
+  });
+
+  it('fades both edges mid-scroll', () => {
+    const { container } = render1();
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    setMetrics(nav, { scrollWidth: 900, clientWidth: 300, scrollLeft: 300 });
+    act(() => { nav.dispatchEvent(new Event('scroll')); });
+    expect(nav.getAttribute('data-overflow-start')).toBe('true');
+    expect(nav.getAttribute('data-overflow-end')).toBe('true');
+  });
+
+  it('drops the trailing fade once scrolled to the end', () => {
+    const { container } = render1();
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    setMetrics(nav, { scrollWidth: 900, clientWidth: 300, scrollLeft: 600 });
+    act(() => { nav.dispatchEvent(new Event('scroll')); });
+    expect(nav.getAttribute('data-overflow-start')).toBe('true');
+    expect(nav.getAttribute('data-overflow-end')).toBe('false');
   });
 });

--- a/src/components/nav/SourceNav.tsx
+++ b/src/components/nav/SourceNav.tsx
@@ -16,7 +16,7 @@
  * Layout hooks for tests are stable `data-*` attributes, not class names: the
  * styling lives in a CSS module whose class names are hashed at build time.
  */
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { UiIcon, type UiIconName } from '../icons';
 import styles from './SourceNav.module.css';
 
@@ -93,12 +93,56 @@ export const SourceNav: React.FC<SourceNavProps> = ({
     .filter(Boolean)
     .join(' ');
 
+  /**
+   * Which edges of the bottom bar still have tabs beyond them (#4497). The
+   * stylesheet turns these into edge fades — the only cue that the row scrolls
+   * at all, since there are more tabs than fit a phone and the scrollbar is
+   * hidden.
+   *
+   * Measured rather than assumed: a bar whose tabs all fit shows no fade.
+   */
+  const navRef = useRef<HTMLElement | null>(null);
+  const [overflow, setOverflow] = useState({ start: false, end: false });
+
+  useEffect(() => {
+    const el = navRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      // 1px slack: fractional scroll offsets otherwise leave a fade stuck on
+      // at a hard end.
+      const atStart = el.scrollLeft <= 1;
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
+      const scrollable = el.scrollWidth > el.clientWidth + 1;
+      setOverflow(prev => {
+        const next = { start: scrollable && !atStart, end: scrollable && !atEnd };
+        return prev.start === next.start && prev.end === next.end ? prev : next;
+      });
+    };
+
+    measure();
+    el.addEventListener('scroll', measure, { passive: true });
+    // Tab set and viewport both change the answer: permissions can add or drop
+    // entries, and rotation changes how many fit.
+    const observer =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+    observer?.observe(el);
+
+    return () => {
+      el.removeEventListener('scroll', measure);
+      observer?.disconnect();
+    };
+  }, [sections, collapsed, mobileVariant]);
+
   return (
     <aside
+      ref={navRef}
       className={rootClasses}
       data-source-nav=""
       data-collapsed={collapsed ? 'true' : 'false'}
       data-mobile-variant={mobileVariant}
+      data-overflow-start={overflow.start ? 'true' : 'false'}
+      data-overflow-end={overflow.end ? 'true' : 'false'}
       aria-label={ariaLabel}
     >
       {/* Wrapped so the bottom-bar variant can hide them: a logo block, a

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1411,6 +1411,11 @@
 
   .map-controls .map-controls-body {
     padding: 0.5rem;
+    /* Paired with the `max-height` in the later mobile override (#4495): once
+       the panel is bounded, a long feature list scrolls inside it rather than
+       growing down over the attribution. The base `.map-controls` sets
+       `overflow: hidden`, so without this the excess is just clipped. */
+    overflow-y: auto;
   }
 
   .map-controls .map-controls-drag-handle {
@@ -2387,6 +2392,18 @@
        opacity:0/pointer-events:none, so this has no effect on the normal
        map-controls interaction. */
     z-index: 997;
+    /*
+     * Keep the panel clear of the Leaflet attribution strip (#4495).
+     *
+     * Raising z-index cannot solve this: the attribution lives in Leaflet's
+     * own `.leaflet-bottom`, which ships `z-index: 1000`, while this panel must
+     * stay at 997 to yield to the Sources drawer (999). 997 < 1000, so wherever
+     * the two overlap the attribution wins — which is exactly the report.
+     * Bounding the height means they never overlap in the first place.
+     *
+     * 16px top offset + ~34px for the attribution strip and a little air.
+     */
+    max-height: calc(100% - 50px);
   }
 }
 
@@ -2536,7 +2553,10 @@
 }
 
 /* Map controls collapse button */
-.map-controls-collapse-btn {
+/* Zoom-to-fit-all shares the collapse button's shape so the header reads as one
+   control cluster (#4496). */
+.map-controls-collapse-btn,
+.map-controls-fit-btn {
   background: var(--ctp-surface1);
   border: none;
   border-radius: var(--radius-sm);
@@ -2554,9 +2574,17 @@
   flex-shrink: 0;
 }
 
-.map-controls-collapse-btn:hover {
+.map-controls-collapse-btn:hover,
+.map-controls-fit-btn:hover:not(:disabled) {
   background: var(--ctp-surface2);
   transform: scale(1.1);
+}
+
+/* No positioned nodes to fit — stays visible so the control doesn't shift
+   around, but reads as unavailable. */
+.map-controls-fit-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .map-controls-collapse-btn:active {


### PR DESCRIPTION
Closes #4497, #4495, #4496.

Two commits: #4497 is a nav bug; #4495/#4496 both touch `.map-controls` and the issues ask for their placement to be coordinated, so they land together.

---

## #4497 — iOS PWA bottom nav

Reported on an iPhone 14 Pro Max standalone install.

### A. Safe-area padding was zeroed — **a regression I introduced in #4484**

The `padding-bottom: 0 !important` I added to `.sidebar` (to beat the two landscape-rail blocks that also set padding with `!important`) *also* beat SourceNav's own `padding-bottom: env(safe-area-inset-bottom)`. The bar docked flush to the screen edge, putting the tab row inside the iOS home-indicator swipe zone — so taps near it ran the system gesture instead of hitting a tab.

I flagged at the time that the `!important` was load-bearing for the landscape case; I didn't check what else it outranked.

Now `env(safe-area-inset-bottom) !important`, which satisfies both constraints. Nothing else shifts — App.css already reserves `--app-nav-bar-height + safe-area-inset-bottom`, and `.save-bar` / `.nodes-split-view` offset by that same sum.

### B. Horizontal scroll could eject the user from the PWA

Adds `touch-action: pan-x` and `overscroll-behavior-x: contain` so a drag on the bar can't chain out to Safari's back-swipe / app-switcher edge gesture.

**Partial by nature, stated plainly:** the iOS home-indicator and app-switcher gestures are OS-level and CSS cannot suppress them. Fix A is what actually lifts the tap targets clear of the gesture zone; B only stops the scroll chaining. Worth confirming on real hardware — a true standalone PWA can't be reproduced in desktop Chrome.

### C. No cue that the bar scrolls

Edge fades driven by the **measured** scroll position, so a bar whose tabs all fit shows no fade at all. Uses `mask-image` rather than an `::after` overlay, because a pseudo-element inside a scroll container scrolls away with the content.

---

## #4495 — map controls covered by the attribution

**z-index cannot fix this, and the measurement proves it:** the attribution lives in Leaflet's own `.leaflet-bottom` at `z-index: 1000`, while `.map-controls` must stay at `997` to yield to the Sources drawer (999). 997 < 1000, so wherever they overlap the attribution wins.

Bounding the panel's height means they never overlap at all, with the body scrolling when the feature list is long (the base rule is `overflow: hidden`, so the excess would otherwise just be clipped).

Verified at 390×780: panel bottom **515**, attribution top **707**, `overlap: false`.

Deliberately **not** the icon-row redesign the reporter floated — the position fix addresses the complaint without a layout rethink, and keeps the existing drag behaviour and muscle memory. That redesign remains open as its own idea.

## #4496 — zoom to fit all nodes

A `target`-icon button in the controls header. It sits in the header so it stays reachable while the panel is collapsed: one-tap re-framing is the point, and click-to-expand-first would spoil it.

`.map-controls` is a **sibling** of `MapContainer` with no access to the map instance, so this follows the shape already in the file (`TracerouteBoundsController`): a controller inside the map reacting to a prop. The prop is a monotonically increasing **counter**, not a boolean, so repeated taps re-fit even when the node set hasn't changed.

Fits to the **offset** marker positions, matching the pins the user actually sees, per the #4016/#4155 single-position rule — fitting raw centres could leave a visible pin just outside the viewport. The single-node case centres rather than calling `fitBounds`, which snaps to max zoom on zero-area bounds.

Verified live: zoomed in until **0 of 206** markers were on screen; one tap returned **176 / 176** positioned nodes to view with padding.

---

## Test plan

- [x] 8 tests for #4497 — safe-area rule, gesture guards, mask-based fades, and 4 behavioural tests for the overflow-cue state machine (fits / trailing / both / scrolled-to-end).
- [x] 5 tests for #4495 + #4496 — bounded panel, scrollable body, button styling + disabled state, counter-not-boolean wiring, offset-position source.
- [x] **All confirmed real regressions**: reverting the fixes fails exactly 7 and 5 respectively.
- [x] Full Vitest suite — `success: true`, **12987 passed, 0 failed**.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.
- [x] Verified on the running dev container at 390×780, measured rather than eyeballed.

## Note for reviewers

One of the new tests initially anchored its CSS lookup on a phrase that also appears in an earlier cross-reference comment, so it sliced in the *base* `.map-controls` rule instead of the mobile override and failed. Fixed to `lastIndexOf`. Mentioning it because `src/styles/nodes.css` has a documented history of exactly this cascade-order confusion (#3532).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
