### PR TITLE
chore(dev): allow https://mm-dev.yeraze.online as a CORS origin

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,7 +72,7 @@ services:
       - SESSION_SECRET=qlskjerhqlwkjehrlqkwejh
       - BASE_URL=/meshmonitor
       - TZ=America/New_York
-      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,https://meshdev.yeraze.online
+      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,https://meshdev.yeraze.online,https://mm-dev.yeraze.online
       - TRUST_PROXY=1
       - COOKIE_SECURE=false
       - DISABLE_ANONYMOUS=${DISABLE_ANONYMOUS:-false}
@@ -120,7 +120,7 @@ services:
       - SESSION_SECRET=qlskjerhqlwkjehrlqkwejh
       - BASE_URL=/meshmonitor
       - TZ=America/New_York
-      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,http://spire.yeraze.online:8081,https://meshdev.yeraze.online
+      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,http://spire.yeraze.online:8081,https://meshdev.yeraze.online,https://mm-dev.yeraze.online
       - TRUST_PROXY=1
       - COOKIE_SECURE=false
       - DISABLE_ANONYMOUS=${DISABLE_ANONYMOUS:-false}
@@ -189,7 +189,7 @@ services:
       - SESSION_SECRET=qlskjerhqlwkjehrlqkwejh
       - BASE_URL=/meshmonitor
       - TZ=America/New_York
-      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,https://meshdev.yeraze.online
+      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,https://meshdev.yeraze.online,https://mm-dev.yeraze.online
       - TRUST_PROXY=1
       - COOKIE_SECURE=false
       - DISABLE_ANONYMOUS=${DISABLE_ANONYMOUS:-false}


### PR DESCRIPTION
Adds `https://mm-dev.yeraze.online` to `ALLOWED_ORIGINS` in `docker-compose.dev.yml`, across all three profiles (sqlite, postgres, mysql) so it survives a backend switch — alongside the `sentry` / `spire` / `meshdev.yeraze.online` entries already there.

## Origin only, no path

The request was for `https://mm-dev.yeraze.online/meshmonitor/`, but the value has to be the bare origin. The check is:

```js
allowedOrigins.includes(origin)
```

an exact string match against the browser's `Origin` header — which is scheme + host + port and **never** carries a path. A value ending in `/meshmonitor/` could not match anything. That prefix is already handled by `BASE_URL=/meshmonitor`.

Verified against the running server rather than assumed:

| `Origin` sent | result |
|---|---|
| `https://mm-dev.yeraze.online` | ✅ echoed in `Access-Control-Allow-Origin` |
| `https://mm-dev.yeraze.online/meshmonitor/` | ❌ rejected |
| `https://evil.example.com` | ❌ rejected (control) |

## Note for anyone editing origins later

`.env` also defines `ALLOWED_ORIGINS`, but it is **inert** for these services: Compose's `environment:` block overrides `env_file:`, and all three services set the variable inline. Editing `.env` to change origins will appear to do nothing.

Config-only change — no application code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_