### PR TITLE
feat(nodes): name the position source on the Node Details badge (#4498)

### DIFF
--- a/src/components/NodeDetailsBlock.position.test.tsx
+++ b/src/components/NodeDetailsBlock.position.test.tsx
@@ -161,3 +161,75 @@ describe('NodeDetailsBlock position source pill (#4432)', () => {
     expect(screen.queryByText(/^±/)).not.toBeInTheDocument();
   });
 });
+
+/**
+ * #4498 — the Position badge showed a generic "GPS" for every real fix. The
+ * protobuf's LocSource has been decoded and stored since #4176, but PR #4188
+ * wired it only into the map popups, never this card.
+ */
+describe('NodeDetailsBlock position source badge (#4498)', () => {
+  const positioned = { latitude: 35.1, longitude: -80.6 };
+
+  it.each([
+    [2, 'Internal GPS'],
+    [3, 'External GPS'],
+    [1, 'Manual'],
+  ])('names the source when the device reported LocSource %i', (src, label) => {
+    render(<NodeDetailsBlock node={{ ...baseNode, position: positioned, positionLocationSource: src }} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it.each([
+    ['unset (0)', 0],
+    ['absent', undefined],
+  ])('keeps the generic "GPS" wording when the source is %s', (_label, src) => {
+    render(<NodeDetailsBlock node={{ ...baseNode, position: positioned, positionLocationSource: src }} />);
+    expect(screen.getByText('GPS')).toBeInTheDocument();
+  });
+
+  it('still says "Override" for a manually placed pin, not the LocSource', () => {
+    // positionIsOverride is MeshMonitor's own concept and outranks whatever the
+    // device last reported.
+    render(
+      <NodeDetailsBlock
+        node={{ ...baseNode, position: positioned, positionIsOverride: true, positionLocationSource: 2 }}
+      />,
+    );
+    expect(screen.getByText('Override')).toBeInTheDocument();
+    expect(screen.queryByText('Internal GPS')).toBeNull();
+  });
+});
+
+describe('NodeDetailsBlock position accuracy "Exact" (#4498)', () => {
+  const positioned = { latitude: 35.1, longitude: -80.6 };
+
+  it('labels a full-precision fix Exact', () => {
+    render(<NodeDetailsBlock node={{ ...baseNode, position: positioned, positionPrecisionBits: 32 }} />);
+    expect(screen.getByText('Exact')).toBeInTheDocument();
+  });
+
+  it('labels a user override Exact', () => {
+    render(<NodeDetailsBlock node={{ ...baseNode, position: positioned, positionIsOverride: true }} />);
+    expect(screen.getByText('Exact')).toBeInTheDocument();
+  });
+
+  it('says NOTHING when precision is unreported — unknown is not exact', () => {
+    // The load-bearing case. hasAccuracyCell() is false for full precision, for
+    // an override, AND for unset/zero bits; only the first two are genuinely
+    // exact. Claiming "Exact" here would assert something the device never told
+    // us.
+    for (const bits of [undefined, null, 0]) {
+      const { unmount } = render(
+        <NodeDetailsBlock node={{ ...baseNode, position: positioned, positionPrecisionBits: bits as never }} />,
+      );
+      expect(screen.queryByText('Exact')).toBeNull();
+      unmount();
+    }
+  });
+
+  it('shows the error bar rather than Exact for an imprecise fix', () => {
+    render(<NodeDetailsBlock node={{ ...baseNode, position: positioned, positionPrecisionBits: 16 }} />);
+    expect(screen.queryByText('Exact')).toBeNull();
+    expect(screen.getByText(/±/)).toBeInTheDocument();
+  });
+});

--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeviceInfo } from '../types/device';
-import { getHardwareModelName, parseNodeId } from '../utils/nodeHelpers';
+import { formatLocationSource, getHardwareModelName, parseNodeId } from '../utils/nodeHelpers';
 import { getDeviceRoleName } from '../utils/deviceRole';
 import { getHardwareImageUrl } from '../utils/hardwareImages';
 import { formatRelativeTime } from '../utils/datetime';
@@ -153,6 +153,17 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
     label: string;
     tooltip: string;
     accuracy: string | null;
+    /**
+     * True only when the position is known to carry no error bar — NOT merely
+     * when `accuracy` is null (#4498).
+     *
+     * `hasAccuracyCell` is false for three different reasons: full precision
+     * (bits >= 32), an override, and unset/zero precision bits. The first two
+     * are genuinely exact; the third means the device never told us how precise
+     * the fix was. Labelling all three "Exact" would assert something we don't
+     * know, so the unknown case still renders nothing.
+     */
+    exact: boolean;
   } = node.positionIsOverride
     ? {
         kind: 'override',
@@ -163,6 +174,7 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
         ),
         // A user placed this pin exactly where they meant it — no error bar.
         accuracy: null,
+        exact: true,
       }
     : node.positionIsEstimated
       ? {
@@ -178,14 +190,31 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
               : null,
             distanceUnit,
           ),
+          exact: false,
         }
       : {
           kind: 'gps',
-          label: t('node_details.position_source_gps', 'GPS'),
-          tooltip: t(
-            'node_details.position_source_gps_tooltip',
-            'Position reported by the device.',
-          ),
+          // Name the actual source when the device reported one (#4498). The
+          // protobuf's LocSource has been decoded and stored since #4176, but
+          // PR #4188 wired it only into the map popups — this card kept showing
+          // a generic "GPS" for a manually-entered fix as readily as an
+          // internal one. formatLocationSource returns null for LOC_UNSET or an
+          // absent value, so nodes that never reported a source keep the exact
+          // pre-#4498 wording.
+          label:
+            formatLocationSource(node.positionLocationSource) ??
+            t('node_details.position_source_gps', 'GPS'),
+          tooltip:
+            formatLocationSource(node.positionLocationSource) !== null
+              ? t(
+                  'node_details.position_source_gps_tooltip_sourced',
+                  'Position reported by the device ({{source}}).',
+                  { source: formatLocationSource(node.positionLocationSource) },
+                )
+              : t(
+                  'node_details.position_source_gps_tooltip',
+                  'Position reported by the device.',
+                ),
           // Only imprecise fixes (1..31 bits) have a meaningful error bar; full
           // precision and unset both fall through to no radius. hasAccuracyCell
           // is the same gate the map uses to draw its accuracy square.
@@ -197,6 +226,9 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
                   distanceUnit,
                 )
               : null,
+          // >= 32 bits is a full-precision fix. null/0 means the device didn't
+          // report precision at all — unknown, not exact.
+          exact: node.positionPrecisionBits != null && node.positionPrecisionBits >= 32,
         };
 
   const handleSaveNotes = async () => {
@@ -498,11 +530,15 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
               >
                 {positionSource.label}
               </span>
-              {positionSource.accuracy && (
+              {positionSource.accuracy ? (
                 <span className="node-detail-secondary node-detail-position-accuracy">
                   {positionSource.accuracy}
                 </span>
-              )}
+              ) : positionSource.exact ? (
+                <span className="node-detail-secondary node-detail-position-accuracy">
+                  {t('node_details.position_accuracy_exact', 'Exact')}
+                </span>
+              ) : null}
             </div>
           </div>
         )}


### PR DESCRIPTION
Closes #4498.

The Position card showed a generic **"GPS"** for every real fix. The protobuf's `location_source` (LocSource) has been decoded, stored and formatted since #4176, but PR #4188 wired it only into the map popups — `NodeDetailsBlock` was never updated, so a manually-entered fix and an internal GPS fix looked identical.

Wires the existing `formatLocationSource()` into the `gps` branch, so the badge reads **Internal GPS** / **External GPS** / **Manual**. The helper returns `null` for `LOC_UNSET` or an absent value, so nodes that never reported a source keep the exact pre-#4498 wording.

## The "Exact" bonus, done differently to what the issue proposed

The issue suggests labelling the null-accuracy case "Exact". Implemented, but **not** as a blanket rule — `hasAccuracyCell()` returns false for three different reasons:

| reason | genuinely exact? |
|---|---|
| full precision (bits ≥ 32) | ✅ yes |
| user override | ✅ yes |
| **unset / zero precision bits** | ❌ **no — unknown** |

Only the first two are exact. The third means the device never told us how precise the fix was, and labelling it "Exact" would assert something we don't know. So the unknown case still renders nothing, and a test pins that specifically.

## Test plan

- [x] 9 new tests — LocSource 1/2/3 naming, generic "GPS" for unset/absent, `Override` still outranking LocSource, `Exact` for full precision and for overrides, **nothing** for unreported precision, error bar for an imprecise fix.
- [x] **Confirmed real regressions**: 5 fail without the change; the other 4 guard unchanged behaviour and correctly pass either way.
- [x] Full Vitest suite — `success: true`, 13007 passed, 0 failed.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
