### PR TITLE
feat(admin): expose the retry-attempt controls in the UI (#4487 follow-up)

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -66,6 +66,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
 
   // UI and non-config state (keep as useState for now)
   const [selectedNodeNum, setSelectedNodeNum] = useState<number | null>(null);
+  // Per-send retry override (#4487). null = defer to the `adminRetryAttempts`
+  // setting; a number overrides it for commands sent from this tab, for the one
+  // stubborn node rather than a global change.
+  const [retryAttemptsOverride, setRetryAttemptsOverride] = useState<number | null>(null);
   const [isExecuting, setIsExecuting] = useState(false);
   const [nodeOptions, setNodeOptions] = useState<NodeOption[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -1448,6 +1452,9 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         command,
         nodeNum: selectedNodeNum,
         ...(sourceId ? { sourceId } : {}),
+        // Omitted unless explicitly set, so the server falls back to the
+        // adminRetryAttempts setting rather than this tab pinning a value.
+        ...(retryAttemptsOverride != null ? { retryAttempts: retryAttemptsOverride } : {}),
         ...params
       });
       showToast(result.message || t('admin_commands.command_executed', { command }), 'success');
@@ -1465,7 +1472,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
     } finally {
       setIsExecuting(false);
     }
-  }, [selectedNodeNum, sourceId, remoteAdminBlocked, showToast, t]);
+  }, [selectedNodeNum, sourceId, remoteAdminBlocked, retryAttemptsOverride, showToast, t]);
 
   const handleReboot = useCallback(async () => {
     if (!confirm(t('admin_commands.reboot_confirmation', { seconds: rebootSeconds }))) {
@@ -2450,6 +2457,34 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       {/* Node Selection Section */}
       <div id="admin-target-node" className="settings-section">
         <h3>{t('admin_commands.target_node')}</h3>
+        {/* Per-send retry override (#4487). Blank defers to the global
+            adminRetryAttempts setting, so this only ever narrows scope to the
+            node currently being worked on. */}
+        <div className="setting-item">
+          <label htmlFor="adminRetryAttemptsOverride">
+            {t('admin_commands.retry_attempts_label', 'Attempts for this command')}
+            <span className="setting-description">
+              {t('admin_commands.retry_attempts_description', 'Leave blank to use the Remote Administration setting. Only a command that gets no reply is retried — one the node refuses is never resent. Range 1–10.')}
+            </span>
+          </label>
+          <input
+            id="adminRetryAttemptsOverride"
+            type="number"
+            min="1"
+            max="10"
+            className="setting-input"
+            style={{ width: '120px' }}
+            placeholder={t('admin_commands.retry_attempts_placeholder', 'default')}
+            value={retryAttemptsOverride ?? ''}
+            disabled={isExecuting}
+            onChange={(e) => {
+              const raw = e.target.value.trim();
+              if (raw === '') { setRetryAttemptsOverride(null); return; }
+              const n = parseInt(raw, 10);
+              setRetryAttemptsOverride(Number.isNaN(n) ? null : Math.min(10, Math.max(1, n)));
+            }}
+          />
+        </div>
         <div className="setting-item">
           <label>
             {t('admin_commands.select_node_description')}

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -120,6 +120,7 @@ interface SettingsDraft {
   homoglyphEnabled: boolean;
   localStatsIntervalMinutes: number;
   meshcoreCliTimeoutSeconds: number;
+  adminRetryAttempts: number;
   analyticsProvider: string;
   analyticsConfig: Record<string, string>;
   appriseApiServerUrl: string;
@@ -230,6 +231,7 @@ interface SettingsTabProps {
 const GLOBAL_SECTIONS = new Set([
   'settings-language', 'settings-units', 'settings-appearance', 'settings-link-previews', 'settings-privacy', 'settings-meshcore-messaging', 'settings-map',
   'settings-security',
+  'settings-remote-admin',
   'settings-apprise-server', 'settings-elevation', 'settings-atak-cot', 'settings-backup', 'settings-channel-database',
   'settings-maintenance', 'settings-analytics',
   // Position estimation is a single global, cross-source batch job (issue
@@ -412,6 +414,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     homoglyphEnabled: false,
     localStatsIntervalMinutes: NODE_DISPLAY_NUMERIC_DEFAULTS.localStatsIntervalMinutes,
     meshcoreCliTimeoutSeconds: 15,
+    adminRetryAttempts: 1,
     analyticsProvider: 'none',
     analyticsConfig: {},
     appriseApiServerUrl: '',
@@ -437,6 +440,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // MeshCore CLI console reply-timeout (seconds), issue #4027. Local-only server-backed setting
   // (no SettingsContext prop), mirroring localStats above.
   const [initialMeshcoreCliTimeoutSeconds, setInitialMeshcoreCliTimeoutSeconds] = useState(15);
+  const [initialAdminRetryAttempts, setInitialAdminRetryAttempts] = useState(1);
   const [initialAnalyticsProvider, setInitialAnalyticsProvider] = useState<string>('none');
   const [initialAnalyticsConfig, setInitialAnalyticsConfig] = useState<string>('{}');
   const [initialAppriseApiServerUrl, setInitialAppriseApiServerUrl] = useState<string>('');
@@ -550,6 +554,13 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           const cliTimeout = Number.isFinite(cliTimeoutParsed) ? Math.min(60, Math.max(1, cliTimeoutParsed)) : 15;
           updateField('meshcoreCliTimeoutSeconds', cliTimeout);
           setInitialMeshcoreCliTimeoutSeconds(cliTimeout);
+
+          // Load remote-admin retry attempts (#4487). Absent/invalid => 1, i.e.
+          // a single attempt, matching the server's own fallback exactly.
+          const retryParsed = parseInt(settings.adminRetryAttempts || '1', 10);
+          const retryAttempts = Number.isFinite(retryParsed) ? Math.min(10, Math.max(1, retryParsed)) : 1;
+          updateField('adminRetryAttempts', retryAttempts);
+          setInitialAdminRetryAttempts(retryAttempts);
 
           // Load node dimming initial values from server (#4412 Phase 3 WP4(c):
           // the trio now lands on the draft via updateField, like every other
@@ -689,6 +700,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       homoglyphEnabled: initialHomoglyphEnabled,
       localStatsIntervalMinutes: initialLocalStatsIntervalMinutes,
       meshcoreCliTimeoutSeconds: initialMeshcoreCliTimeoutSeconds,
+      adminRetryAttempts: initialAdminRetryAttempts,
       analyticsProvider: initialAnalyticsProvider,
       analyticsConfig: parsedAnalyticsConfig,
       appriseApiServerUrl: initialAppriseApiServerUrl,
@@ -706,7 +718,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       linkPreviewsEnabled, discardInvalidPositions, noIndexEnabled, meshcoreChannelRetryEnabled, showIncompleteNodes,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
-      initialPacketMonitorSettings, initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialMeshcoreCliTimeoutSeconds,
+      initialPacketMonitorSettings, initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialMeshcoreCliTimeoutSeconds, initialAdminRetryAttempts,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl, initialExternalUrl, initialElevationEnabled, initialElevationSourceUrl,
       initialCotFeedEnabled, initialCotFeedPort]);
 
@@ -878,6 +890,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setInitialHomoglyphEnabled(d.homoglyphEnabled);
     setInitialLocalStatsIntervalMinutes(d.localStatsIntervalMinutes);
     setInitialMeshcoreCliTimeoutSeconds(d.meshcoreCliTimeoutSeconds);
+    setInitialAdminRetryAttempts(d.adminRetryAttempts);
     setInitialAnalyticsProvider(d.analyticsProvider);
     setInitialAnalyticsConfig(JSON.stringify(d.analyticsConfig));
     setInitialAppriseApiServerUrl(d.appriseApiServerUrl.trim());
@@ -945,6 +958,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         homoglyphEnabled: String(draft.homoglyphEnabled),
         localStatsIntervalMinutes: draft.localStatsIntervalMinutes.toString(),
         meshcoreCliTimeoutSeconds: draft.meshcoreCliTimeoutSeconds.toString(),
+        adminRetryAttempts: draft.adminRetryAttempts.toString(),
         nodeHopsCalculation: draft.nodeHopsCalculation,
         nodeDimmingEnabled: draft.nodeDimmingEnabled ? '1' : '0',
         nodeDimmingStartHours: draft.nodeDimmingStartHours.toString(),
@@ -1458,6 +1472,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         { id: 'settings-security', label: t('settings.security', 'Security') },
         { id: 'settings-packet-monitor', label: t('settings.packet_monitor') },
         { id: 'settings-solar', label: t('settings.solar_monitoring') },
+        ...(isAdmin ? [{ id: 'settings-remote-admin', label: t('settings.remote_admin_section', 'Remote Administration') }] : []),
         ...(isAdmin ? [{ id: 'settings-apprise-server', label: t('settings.apprise_server_section', 'Apprise API Server') }] : []),
         ...(isAdmin ? [{ id: 'settings-elevation', label: t('settings.elevation_section', 'Elevation / Terrain') }] : []),
         { id: 'settings-backup', label: t('settings.system_backup', 'System Backup') },
@@ -2327,6 +2342,30 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               </div>
             </>
           )}
+        </div>}
+
+        {show('settings-remote-admin') && isAdmin && <div id="settings-remote-admin" className="settings-section">
+          <h3>{t('settings.remote_admin_section', 'Remote Administration')}</h3>
+          <div className="setting-item">
+            <label htmlFor="adminRetryAttempts">
+              {t('settings.admin_retry_attempts_label', 'Admin command attempts')}
+              <span className="setting-description">
+                {t('settings.admin_retry_attempts_description', 'How many times a remote admin command is attempted before giving up. Only a command that gets NO reply is retried — one the node explicitly refuses is never resent. Raise this for nodes on weak or lossy links. Each extra attempt is additional airtime, so the default of 1 sends exactly once. Range 1–10; default 1.')}
+              </span>
+            </label>
+            <input
+              id="adminRetryAttempts"
+              type="number"
+              min="1"
+              max="10"
+              value={draft.adminRetryAttempts}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                updateField('adminRetryAttempts', Number.isNaN(n) ? 1 : Math.min(10, Math.max(1, n)));
+              }}
+              className="setting-input"
+            />
+          </div>
         </div>}
 
         {show('settings-apprise-server') && isAdmin && <div id="settings-apprise-server" className="settings-section">

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -476,6 +476,11 @@ describe('Settings Persistence', () => {
         // MeshCore CLI console reply-timeout (#4027) — loaded directly by
         // SettingsTab and read server-side by the /cli routes, not via SettingsContext.
         'meshcoreCliTimeoutSeconds',
+        // Remote-admin retry attempts (#4487) — same shape: SettingsTab loads it
+        // straight from the settings API, and only the admin routes read it when
+        // deciding whether to re-send a timed-out command. No frontend state
+        // depends on it, so it never reaches SettingsContext.
+        'adminRetryAttempts',
         // Analytics — backend injects into HTML, frontend doesn't need them
         'analyticsProvider', 'analyticsConfig',
         // Apprise API server URL (#3012) — loaded directly by SettingsTab,


### PR DESCRIPTION
Follow-up to #4502.

#4502 shipped the retry mechanism and registered `adminRetryAttempts` in `VALID_SETTINGS_KEYS` — but never wired it into the Settings UI. The result: the feature could only be enabled by POSTing to the settings API by hand, and the per-send `retryAttempts` override only by crafting the request body yourself. Neither was reachable from the app, which made the setting *look* wired up when it wasn't. My miss.

## What's added

**Settings → Remote Administration** (new, admin-only): an "Admin command attempts" input, 1–10, default 1. Wired through every place the settings recipe calls for — the `SettingsDraft` type, `buildBaseline()`, the `initial*` snapshot and its dep array, the server load path, the post-save re-seed, and the hand-maintained `handleSave` literal.

**Admin Commands → Target Node**: a per-send "Attempts for this command" box. Blank defers to the setting, so it only ever narrows scope to the node being worked on — the key is omitted from the request body entirely when unset, leaving the server's own fallback in charge.

## Two things the tooling caught, not review

**`server.settings-persistence.test.ts`** failed with `expected ['adminRetryAttempts'] to equal []`. Every key `SettingsTab` sends must either be loaded by `SettingsContext` or be a known server-only key — this guards the #2048 class of bug where a setting is saved but never read back. `adminRetryAttempts` is genuinely server-only (only the admin routes read it, no frontend state depends on it), so it joins the allowlist beside `meshcoreCliTimeoutSeconds` with the same reasoning spelled out.

**The lint ratchet** flagged `react-hooks/exhaustive-deps` going 1→2. Not a style nit: the `executeCommand` `useCallback` now reads `retryAttemptsOverride`, so without the dep it captures a stale value and sends the **previous** override. `tsc` was perfectly happy, and it only misbehaves on the second send after changing the value — the ratchet was the only thing in the pipeline that would have caught it.

## Test plan

- [x] Full Vitest suite — `success: true`, **13017 passed, 0 failed**.
- [x] `server.settings-persistence.test.ts` passes, including the source-extraction check over the `handleSave` literal.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` back to no FAIL lines.

## Note

Retry remains **opt-in**: the default is still 1 attempt, so nothing changes until an operator sets it. That's deliberate — every extra attempt is real airtime on a shared band.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
