### PR TITLE
feat(meshcore): show SNR on directly-received messages (#4504)

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -551,3 +551,67 @@ describe('MeshCoreMessageStream entry scroll on a hidden pane (#4473 follow-up)'
     expect(list.scrollTop).toBe(120);
   });
 });
+
+/**
+ * #4504 — a directly-received message showed nothing but the word "direct".
+ * SNR is the only thing left that says anything about the link.
+ */
+describe('MeshCoreMessageStream direct-message signal (#4504)', () => {
+  const now = Date.now();
+
+  it('shows SNR on a directly-received message', () => {
+    render(
+      <MeshCoreMessageStream
+        messages={[{ ...msg('a', now, 'hello'), hopCount: 0, snr: 7.25 }]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    expect(screen.getByText(/SNR 7\.3 dB/)).toBeTruthy();
+  });
+
+  it('adds RSSI only when the message actually carries it', () => {
+    const { container, rerender } = render(
+      <MeshCoreMessageStream
+        messages={[{ ...msg('a', now, 'hello'), hopCount: 0, snr: 5 }]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    // MeshCore's message push carries SNR but no RSSI, so this is the normal case.
+    expect(container.textContent).not.toMatch(/RSSI/);
+
+    rerender(
+      <MeshCoreMessageStream
+        messages={[{ ...msg('a', now, 'hello'), hopCount: 0, snr: 5, rssi: -92 }]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    expect(container.textContent).toMatch(/RSSI -92 dBm/);
+  });
+
+  it('does NOT show signal on a relayed message — it would misattribute the link', () => {
+    // On a multi-hop message these values describe the hop from the LAST
+    // repeater, not from the sender whose name sits beside them.
+    const { container } = render(
+      <MeshCoreMessageStream
+        messages={[{ ...msg('a', now, 'hello'), hopCount: 2, routePath: 'a3,7f', snr: 7 }]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    expect(container.textContent).not.toMatch(/SNR/);
+  });
+
+  it('still renders "direct" when the message carries no SNR at all', () => {
+    render(
+      <MeshCoreMessageStream
+        messages={[{ ...msg('a', now, 'hello'), hopCount: 0 }]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    expect(screen.getByText(/direct/)).toBeTruthy();
+  });
+});

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -505,7 +505,36 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
               {!outgoing && typeof m.hopCount === 'number' && (
                 <div className="mc-message-route" title={t('meshcore.route_tooltip', 'How this message reached you')}>
                   {m.hopCount === 0 ? (
-                    <><UiIcon name="location" size={13} /> {t('meshcore.route_direct', 'direct')}</>
+                    <>
+                      <UiIcon name="location" size={13} /> {t('meshcore.route_direct', 'direct')}
+                      {/*
+                        Signal quality for a directly-received message (#4504).
+                        A direct message otherwise shows nothing but the word
+                        "direct" — SNR/RSSI is the only thing left that says
+                        anything about the link.
+
+                        Shown ONLY for hopCount === 0 on purpose. On a relayed
+                        message these values describe the hop from the LAST
+                        repeater, not from the sender, so presenting them next to
+                        the sender's name would misattribute the measurement.
+
+                        RSSI renders only when present: MeshCore's message push
+                        carries SNR but no RSSI (that lives on the separate
+                        LogRxData OTA feed), so today this is SNR in practice and
+                        RSSI lights up automatically if the field is ever filled.
+                      */}
+                      {typeof m.snr === 'number' && (
+                        <> · <span
+                          className="mc-message-signal"
+                          title={t('meshcore.signal_tooltip', 'Signal quality of the direct link from the sender')}
+                        >
+                          {t('meshcore.snr_label', 'SNR')} {m.snr.toFixed(1)} dB
+                          {typeof m.rssi === 'number' && (
+                            <> · {t('meshcore.rssi_label', 'RSSI')} {m.rssi} dBm</>
+                          )}
+                        </span></>
+                      )}
+                    </>
                   ) : (
                     <><UiIcon name="route" size={13} /> {m.hopCount} {m.hopCount === 1 ? t('meshcore.hop', 'hop') : t('meshcore.hops', 'hops')}</>
                   )}

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -729,6 +729,9 @@
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
 .mc-message-route { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+/* Signal quality on a directly-received message (#4504). Same muted treatment
+   as the rest of the route row — it is provenance, not content. */
+.mc-message-signal { color: var(--ctp-subtext0); white-space: nowrap; }
 .mc-message-scope { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 /* Clickable relay-hash chain — opens the route-detail modal (repeater names). */
 .mc-route-chain-link {

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -103,6 +103,25 @@ export interface MeshCoreMessage {
    *  self-echo correlation (#3700). Best-effort; `name` is null when the relay
    *  hash couldn't be resolved to a known contact. */
   heardBy?: Array<{ hash: string; name?: string | null; snr?: number | null }>;
+  /**
+   * Signal-to-noise ratio (dB) of the received packet, as reported by the
+   * companion. The server has always sent this; the client type just never
+   * declared it, so the UI could not read it (#4504).
+   *
+   * On a RELAYED message this describes the hop from the last repeater, not
+   * from the sender — which is why the stream only surfaces it for direct
+   * messages, where it unambiguously describes the sender's link.
+   */
+  snr?: number;
+  /**
+   * Received signal strength (dBm).
+   *
+   * Not populated by MeshCore's message push, which carries SNR only — RSSI
+   * lives on the separate LogRxData OTA feed. Declared so the UI renders it
+   * automatically if a message ever does carry it, rather than silently
+   * dropping the field.
+   */
+  rssi?: number;
   /** Hop count for a received message; null/undefined = direct or unknown (#3742). */
   hopCount?: number | null;
   /** Relay-hash chain the message traveled, comma-separated (e.g. "a3,7f,02") (#3742). */


### PR DESCRIPTION
Closes #4504.

A directly-received MeshCore message showed nothing but the word **"direct"** — no indication of how good the link actually was. SNR is the one thing left that says anything about it.

## The data was already there — the client type wasn't

The companion reports SNR, the manager stores it, and `getChannelMessages` forwards it. What was missing: the **client-side `MeshCoreMessage` type never declared `snr`/`rssi`**, so no component could read a field the server had been sending all along. Declaring it is most of the fix.

## Only on direct messages, deliberately

Rendered for `hopCount === 0` only. On a relayed message these values describe the hop from the **last repeater**, not from the sender whose name sits right beside them — showing it there would misattribute the measurement to the wrong node. Direct is also exactly the case the issue describes.

A message with no SNR still renders "direct" as before.

## RSSI: declared, but it won't appear yet — and that needs saying

The issue asks for SNR *and* RSSI. **RSSI is not available on MeshCore's message path.** The message push carries SNR only; RSSI lives on the separate `LogRxData` OTA feed (`[0x88][snr×4][rssi][frame]`).

Surfacing real RSSI means correlating each message to its OTA packet-log row — a substantially larger change, and the packet log is opt-in, so the row is frequently absent entirely. That deserves its own issue and a look at how reliably a message can be matched to an OTA row before it's promised.

What's here renders RSSI **conditionally**, so it appears automatically if the field is ever populated rather than the value being silently dropped. Today, in practice, you'll see SNR.

## Test plan

- [x] 4 new tests — SNR renders on a direct message; RSSI appears only when actually present; **no** signal shown on a relayed message (the misattribution guard); "direct" still renders with no SNR at all.
- [x] **Confirmed real regressions**: 2 fail without the change; the other 2 guard behaviour that must not change and correctly pass either way.
- [x] Full Vitest suite — `success: true`, **13021 passed, 0 failed**.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
