### PR TITLE
feat(meshcore): carry RSSI onto received messages (#4504 follow-up)

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1622,6 +1622,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         // sends (see components/MeshCore/messageOrder.ts).
         receivedAt: Date.now(),
         snr: data.snr,
+        // Correlated from the same buffered LogRxData as snr (#4504). Present
+        // only when that correlation succeeded — the UI renders it
+        // conditionally rather than showing a placeholder.
+        rssi: data.rssi,
         sourceId: this.sourceId,
         hopCount,
         // Raw packed path_len byte (0xff = direct) so the Virtual Node bridge
@@ -1662,6 +1666,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         // sends (see components/MeshCore/messageOrder.ts).
         receivedAt: Date.now(),
         snr: data.snr,
+        // Correlated from the same buffered LogRxData as snr (#4504). Present
+        // only when that correlation succeeded — the UI renders it
+        // conditionally rather than showing a placeholder.
+        rssi: data.rssi,
         sourceId: this.sourceId,
         hopCount,
         // Raw packed path_len byte (0xff = direct) so the Virtual Node bridge

--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -447,3 +447,94 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     expect(msg.data.snr).toBeUndefined();
   });
 });
+
+/**
+ * RSSI correlation onto received messages (#4504).
+ *
+ * The companion's ContactMsgRecv / ChannelMsgRecv frames carry only
+ * `pubKeyPrefix|channelIdx, pathLen, txtType, senderTimestamp, text` — no
+ * signal metadata at all. SNR and RSSI arrive on the preceding LogRxData push,
+ * which this backend already buffers and correlates by freshness + hop count
+ * (the #3589 guard). RSSI was parsed there all along and simply never added to
+ * the buffer, so it never reached the message.
+ */
+describe('MeshCoreNativeBackend — RSSI on received messages (#4504)', () => {
+  beforeEach(() => installMockModule());
+  afterEach(() => __setMeshCoreModule(null));
+
+  // TXT_MSG, DIRECT, pathLen 0xff → 0 hops.
+  const directTxt = () => Uint8Array.from([0x02, 0x02, 0xff]);
+  // GRP_TXT, DIRECT, pathLen 0xff → 0 hops.
+  const directGrp = () => Uint8Array.from([0x05, 0x02, 0xff]);
+
+  it('attaches RSSI (with SNR) to a DM from the preceding LogRxData', async () => {
+    const { conn, events } = await connectedBackend();
+    conn.emit(PushCodes.LogRxData, { lastSnr: 6.5, lastRssi: -47, raw: directTxt() });
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
+      pathLen: 0xff, txtType: 0, senderTimestamp: 1700000001, text: 'hi',
+    });
+
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg.data.snr).toBe(6.5);
+    expect(msg.data.rssi).toBe(-47);
+  });
+
+  it('attaches RSSI to a channel message too', async () => {
+    const { conn, events } = await connectedBackend();
+    conn.emit(PushCodes.LogRxData, { lastSnr: 4, lastRssi: -61, raw: directGrp() });
+    conn.emit(ResponseCodes.ChannelMsgRecv, {
+      channelIdx: 0, pathLen: 0xff, txtType: 0, senderTimestamp: 1700000002, text: 'yo',
+    });
+
+    const msg = events.find((e) => e.event_type === 'channel_message');
+    expect(msg.data.snr).toBe(4);
+    expect(msg.data.rssi).toBe(-61);
+  });
+
+  it('leaves RSSI undefined when no LogRxData preceded the message', async () => {
+    // Backend started without raw logging, or the push was missed. Better to
+    // show nothing than to attach a neighbouring packet's signal.
+    const { conn, events } = await connectedBackend();
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
+      pathLen: 0xff, txtType: 0, senderTimestamp: 1700000003, text: 'orphan',
+    });
+
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg.data.rssi).toBeUndefined();
+    expect(msg.data.snr).toBeUndefined();
+  });
+
+  it('does not attach a mismatched packet\'s RSSI (the #3589 guard still holds)', async () => {
+    // Buffered packet is 2 hops; the message says direct. Different packets —
+    // attaching would report another node's signal strength as this sender's.
+    const { conn, events } = await connectedBackend();
+    conn.emit(PushCodes.LogRxData, {
+      lastSnr: 9, lastRssi: -20,
+      raw: Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]), // TXT_MSG, FLOOD, 2 hops
+    });
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
+      pathLen: 0xff, txtType: 0, senderTimestamp: 1700000004, text: 'direct',
+    });
+
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg.data.rssi).toBeUndefined();
+  });
+
+  it('consumes the buffer once — a second message gets no stale RSSI', async () => {
+    const { conn, events } = await connectedBackend();
+    conn.emit(PushCodes.LogRxData, { lastSnr: 3, lastRssi: -70, raw: directTxt() });
+    const recv = (ts: number, text: string) => conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
+      pathLen: 0xff, txtType: 0, senderTimestamp: ts, text,
+    });
+    recv(1700000005, 'first');
+    recv(1700000006, 'second');
+
+    const msgs = events.filter((e) => e.event_type === 'contact_message');
+    expect(msgs[0].data.rssi).toBe(-70);
+    expect(msgs[1].data.rssi).toBeUndefined();
+  });
+});

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -228,7 +228,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * captured). {@link consumePendingPath} matches by hop count and takes the
    * oldest unconsumed entry, so concurrent packets no longer evict each other.
    */
-  private pendingTxtMsgPaths: Array<{ hops: string[]; rawPathLen: number; snr?: number; rawHex?: string; bufferedAt: number }> = [];
+  private pendingTxtMsgPaths: Array<{ hops: string[]; rawPathLen: number; snr?: number; rssi?: number; rawHex?: string; bufferedAt: number }> = [];
 
   /**
    * Maximum age (ms) of a buffered LogRxData path before we treat it as stale
@@ -392,10 +392,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
    *     correlate, so {ROUTE} resolved to "—" for any routed message
    *     (issue #3710). We decode the packed byte to a hop count first.
    *
-   * Returns `{ hops, snr }` to attach, or `undefined` when the buffer is
+   * Returns `{ hops, snr, rssi }` to attach, or `undefined` when the buffer is
    * absent, stale, or for a different packet.
    */
-  private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number; rawHex?: string } | undefined {
+  private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number; rssi?: number; rawHex?: string } | undefined {
     const now = Date.now();
     // Drop stale entries first — a buffer whose matching recv never arrived
     // would mis-correlate route/SNR/scope if attached to a later message
@@ -428,7 +428,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
     if (idx === -1) return undefined;
 
     const [buffered] = this.pendingTxtMsgPaths.splice(idx, 1); // consume-once
-    return { hops: buffered.hops, snr: buffered.snr, rawHex: buffered.rawHex };
+    return { hops: buffered.hops, snr: buffered.snr, rssi: buffered.rssi, rawHex: buffered.rawHex };
   }
 
   private wirePushEvents(): void {
@@ -483,7 +483,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
             // each other's route/SNR/scope. Remaining limitation: if LogRxData
             // arrives AFTER its own recv (rare ordering), that packet's buffer is
             // still missed — inherent to the adjacency-buffer design.
-            this.pendingTxtMsgPaths.push({ hops, rawPathLen: pkt.pathLen, snr, rawHex: bytesToHex(raw), bufferedAt: Date.now() });
+            this.pendingTxtMsgPaths.push({ hops, rawPathLen: pkt.pathLen, snr, rssi, rawHex: bytesToHex(raw), bufferedAt: Date.now() });
             // Backstop against unbounded growth (recv-less LogRxData bursts).
             if (this.pendingTxtMsgPaths.length > MeshCoreNativeBackend.PENDING_PATH_MAX_ENTRIES) {
               this.pendingTxtMsgPaths.shift();
@@ -567,6 +567,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // not available (e.g. backend started without raw logging).
         path_hops: consumedPath?.hops,
         snr: consumedPath?.snr,
+        // RSSI rides the same buffered LogRxData as SNR (#4504). It was already
+        // parsed from the OTA metadata; it just never reached the message.
+        rssi: consumedPath?.rssi,
         // Raw OTA bytes (from the same preceding LogRxData) so the manager can
         // resolve the scope/region the message was sent under (#3742 Phase 2).
         raw_hex: consumedPath?.rawHex,
@@ -585,6 +588,8 @@ export class MeshCoreNativeBackend extends EventEmitter {
         path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
         path_hops: consumedPath?.hops,
         snr: consumedPath?.snr,
+        // Same buffered LogRxData that carries SNR (#4504).
+        rssi: consumedPath?.rssi,
         // Raw OTA bytes for scope/region resolution (#3742 Phase 2).
         raw_hex: consumedPath?.rawHex,
       });


### PR DESCRIPTION
Follow-up to #4505 / #4504.

## I got the earlier assessment wrong

#4505 shipped SNR and said RSSI was unavailable — that it needed fuzzy message-to-OTA correlation, deserved its own issue, and wanted a measurement pass before anyone trusted the number.

That was wrong. I'd read the manager and the packet-log service, but not `meshcoreNativeBackend.ts`, **where the correlation already exists and has for some time.**

`consumePendingPath()` buffers each `LogRxData` push and matches it to the following message frame by **freshness + hop count**, with a 500ms staleness window, a consume-once FIFO, and an explicit guard against the exact mis-attribution bug I was worried about (#3589). It already extracts `hops`, `snr` and `rawHex` from that buffer.

And RSSI was already being parsed right beside SNR:

```ts
const snr  = typeof rx?.lastSnr  === 'number' ? rx.lastSnr  : undefined;
const rssi = typeof rx?.lastRssi === 'number' ? rx.lastRssi : undefined;  // ← parsed, never used
```

…then never added to the buffer, so it never reached the message.

**Correction to the #4505 text:** SNR and RSSI do *not* arrive on separate channels. They arrive together on the same `LogRxData` push; only RSSI was dropped on the floor. The claim was right about the wire frames — `ContactMsgRecv` / `ChannelMsgRecv` carry `pathLen`, `txtType`, `senderTimestamp`, `text` and no signal metadata whatsoever — and wrong about the plumbing above them.

## The change

Five lines of wiring: carry `rssi` in the buffer entry, return it from `consumePendingPath`, and pass it through both received-message payloads. The manager attaches it beside `snr`.

`room_message` is **deliberately excluded**, matching the existing SNR treatment — the backend consumes and *discards* a room post's buffer specifically so it can't leak stale signal onto the next message.

Nothing downstream needed touching: `insertMessage` persists it, `getChannelMessages` already forwards it, and #4505's UI already renders RSSI conditionally. It simply starts appearing.

## Test plan

- [x] 5 new tests: RSSI attaches to a DM and to a channel message; **undefined** when no `LogRxData` preceded (backend without raw logging); **undefined** when the buffered packet's hop count doesn't match (the #3589 guard — a 2-hop buffer must not attach to a direct message); consume-once, so a second message gets no stale RSSI.
- [x] **Confirmed real regressions**: 3 fail without the change; the 2 negative guards correctly pass either way, since they assert behaviour that must not change.
- [x] Full Vitest suite — `success: true`, **13026 passed, 0 failed**.
- [x] `npx tsc --noEmit` clean; `npm run lint:ci` no FAIL lines.

## Worth knowing

The correlation is adjacency-based, and the backend documents its own limitation: if `LogRxData` arrives *after* its own recv event (rare ordering), that packet's buffer is missed and both SNR and RSSI are simply absent. That's the pre-existing design and this change inherits it — the failure mode is a missing value, never a wrong one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB)_
