### PR TITLE
fix(automation): match the Primary/unnamed channel in "On channels"

### DIFF
--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -242,8 +242,8 @@ describe('multi-channel trigger filter (#3974)', () => {
     it('extracts non-empty names from the channels array', () => {
       expect(messageFilterChannelNames({ channels: chans('gauntlet', 'ops') })).toEqual(['gauntlet', 'ops']);
     });
-    it('drops blank names and ignores non-object entries', () => {
-      expect(messageFilterChannelNames({ channels: [{ name: '' }, { name: 'ops' }, 'x', null, {}] })).toEqual(['ops']);
+    it('keeps a blank name (the Primary/unnamed-slot-0 marker, #4507) but drops non-object entries', () => {
+      expect(messageFilterChannelNames({ channels: [{ name: '' }, { name: 'ops' }, 'x', null, {}] })).toEqual(['', 'ops']);
     });
     it('returns [] when channels is absent or not an array', () => {
       expect(messageFilterChannelNames({})).toEqual([]);
@@ -258,10 +258,12 @@ describe('multi-channel trigger filter (#3974)', () => {
     it('is true for a populated channels array', () => {
       expect(messageFilterUsesChannelName({ channels: chans('gauntlet') })).toBe(true);
     });
-    it('is false when neither is set / all blank', () => {
+    it('is false when neither is set', () => {
       expect(messageFilterUsesChannelName({})).toBe(false);
       expect(messageFilterUsesChannelName({ channelName: '' })).toBe(false);
-      expect(messageFilterUsesChannelName({ channels: [{ name: '' }] })).toBe(false);
+    });
+    it('is true for a Primary-only selection (a blank-name entry, #4507)', () => {
+      expect(messageFilterUsesChannelName({ channels: [{ name: '' }] })).toBe(true);
     });
   });
 
@@ -293,6 +295,12 @@ describe('multi-channel trigger filter (#3974)', () => {
       expect(messageMatchesFilter(msg({ text: 'ping' }), { channels: chans('ops'), textContains: 'ping' }, 'Ops')).toBe(true);
       expect(messageMatchesFilter(msg({ text: 'pong' }), { channels: chans('ops'), textContains: 'ping' }, 'Ops')).toBe(false);
     });
+    it('fires on the Primary/unnamed slot-0 channel when its blank name is selected (#4507)', () => {
+      const withPrimary = [...chans('ops'), { name: '', protocol: 'meshtastic' }];
+      expect(messageMatchesFilter(msg(), { channels: withPrimary }, '')).toBe(true);
+      // Selecting only Primary must not fall through to "no filter" and match every channel.
+      expect(messageMatchesFilter(msg(), { channels: [{ name: '', protocol: 'meshtastic' }] }, 'gauntlet')).toBe(false);
+    });
   });
 
   describe('meshCoreMessageMatchesFilter OR-list (MeshCore)', () => {
@@ -313,6 +321,10 @@ describe('multi-channel trigger filter (#3974)', () => {
     it('Meshtastic-only filters (from/to/portnum) still force a non-match', () => {
       expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('ops'), from: 5 }, 'Ops')).toBe(false);
     });
+    it('fires on the Primary/unnamed channel when its blank name is selected (#4507)', () => {
+      const withPrimary = [...chans('ops'), { name: '', protocol: 'meshcore' }];
+      expect(meshCoreMessageMatchesFilter(mcMsg({ fromPublicKey: 'channel-1' }), { channels: withPrimary }, '')).toBe(true);
+    });
   });
 
   describe('describeMessageFilterMiss / describeMeshCoreFilterMiss OR-list reasons', () => {
@@ -328,6 +340,10 @@ describe('multi-channel trigger filter (#3974)', () => {
     it('explains a MeshCore multi-channel miss', () => {
       expect(describeMeshCoreFilterMiss(mcMsg({ fromPublicKey: 'channel-1' }), { channels: chans('ops') }, 'Primary'))
         .toBe('channel name "Primary" not in [ops]');
+    });
+    it('returns undefined when a blank resolved name matches a selected Primary entry (#4507)', () => {
+      const withPrimary = [...chans('gauntlet'), { name: '', protocol: 'meshtastic' }];
+      expect(describeMessageFilterMiss(msg(), { channels: withPrimary }, '')).toBeUndefined();
     });
   });
 });

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -339,16 +339,18 @@ export function buildScheduleContext(sourceId: string | null, timestamp: number)
  * Extract the channel names a `trigger.message` filter targets via the multi-select
  * `channels` field (#3974). Entries are `{ name, protocol? }` — the same shape the
  * builder's `channelMulti` renderer emits and `action.sendMessage` resolves. Matching
- * is name-based (protocol is a UI hint only), mirroring the legacy scalar `channelName`
- * check. Empty/blank names are dropped (Primary can't be name-matched, same as legacy).
+ * is name-based (protocol is a UI hint only). An empty string is a legitimate,
+ * meaningful entry here — it's how the "(Primary)" checkbox represents a source's
+ * unnamed slot-0 channel (#4507) — so it is kept, not dropped; only entries that
+ * aren't a `{ name: string }` object are excluded.
  */
 export function messageFilterChannelNames(params: Record<string, unknown> = {}): string[] {
   if (!Array.isArray(params.channels)) return [];
   return (params.channels as unknown[])
     .map((c) => (c && typeof c === 'object' && typeof (c as Record<string, unknown>).name === 'string'
       ? ((c as Record<string, unknown>).name as string)
-      : ''))
-    .filter((n) => n.length > 0);
+      : null))
+    .filter((n): n is string => n !== null);
 }
 
 /**
@@ -373,10 +375,13 @@ export function messageMatchesFilter(msg: DbMessage, params: Record<string, unkn
   if (params.to != null && Number(msg.toNodeNum) !== Number(params.to)) return false;
   // Multi-channel OR-list (#3974) takes precedence over the legacy scalar
   // channel/channelName fields: fire if the resolved name matches ANY entry.
+  // A resolved name of '' (Primary's unnamed slot-0) is a legitimate match
+  // target (#4507) — only an unresolved (null/undefined) name never matches.
   const channelNames = messageFilterChannelNames(params);
   if (channelNames.length > 0) {
-    const resolved = channelName?.toLowerCase();
-    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) return false;
+    if (channelName == null) return false;
+    const resolved = channelName.toLowerCase();
+    if (!channelNames.some((n) => n.toLowerCase() === resolved)) return false;
   } else {
     if (params.channel != null && Number(msg.channel) !== Number(params.channel)) return false;
     // Channel-by-name: portable across sources where the channel sits in a
@@ -421,8 +426,9 @@ export function meshCoreMessageMatchesFilter(
   const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
   const channelNames = messageFilterChannelNames(params);
   if (channelNames.length > 0) {
-    const resolved = channelName?.toLowerCase();
-    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) return false;
+    if (channelName == null) return false;
+    const resolved = channelName.toLowerCase();
+    if (!channelNames.some((n) => n.toLowerCase() === resolved)) return false;
   } else {
     if (params.channel != null && Number(channelIdx) !== Number(params.channel)) return false;
     if (typeof params.channelName === 'string' && params.channelName.length > 0) {
@@ -462,8 +468,8 @@ export function describeMessageFilterMiss(
   if (params.to != null && Number(msg.toNodeNum) !== Number(params.to)) return `recipient #${msg.toNodeNum} ≠ to #${params.to}`;
   const channelNames = messageFilterChannelNames(params);
   if (channelNames.length > 0) {
-    const resolved = channelName?.toLowerCase();
-    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) {
+    const resolved = channelName == null ? null : channelName.toLowerCase();
+    if (resolved == null || !channelNames.some((n) => n.toLowerCase() === resolved)) {
       return `channel name "${channelName ?? '(unresolved)'}" not in [${channelNames.join(', ')}]`;
     }
   } else {
@@ -498,8 +504,8 @@ export function describeMeshCoreFilterMiss(
   const channelIdx = parseMeshCoreChannelIdx(msg.fromPublicKey);
   const channelNames = messageFilterChannelNames(params);
   if (channelNames.length > 0) {
-    const resolved = channelName?.toLowerCase();
-    if (!resolved || !channelNames.some((n) => n.toLowerCase() === resolved)) {
+    const resolved = channelName == null ? null : channelName.toLowerCase();
+    if (resolved == null || !channelNames.some((n) => n.toLowerCase() === resolved)) {
       return `channel name "${channelName ?? '(unresolved)'}" not in [${channelNames.join(', ')}]`;
     }
   } else {


### PR DESCRIPTION
## Summary

Fixes #4507 — an automation's "On channels" multi-select never fires for the Primary channel.

- Meshtastic's slot-0 Primary channel is stored with `name: ""` whenever the device is running a preset (LongFast/MediumFast/etc.) rather than a custom name (see `meshtasticManager.ts`'s `processChannelProtobuf`). Checking "(Primary)" in the automation builder therefore selects a `{ name: "" }` entry.
- `messageFilterChannelNames()` in `src/server/services/automation/triggerContext.ts` intentionally dropped blank names ("Primary can't be name-matched"), and the match check also treated a *resolved* blank channel name as automatically non-matching (`!resolved`, where `''` is falsy). Once the rule also selected any other real-named channel, Primary's `""` was silently excluded from the list, so it could never fire — while messages on other selected channels worked fine.
- `action.sendMessage`'s channel-by-name resolution (`actionExecutor.ts`) already does plain string equality and isn't affected — this bug was trigger-side only.

## Fix

- `messageFilterChannelNames()` now keeps an explicit blank name as a legitimate selection (only non-`{name: string}` entries are dropped).
- `messageMatchesFilter`, `meshCoreMessageMatchesFilter`, `describeMessageFilterMiss`, and `describeMeshCoreFilterMiss` now only refuse to match when the channel name couldn't be *resolved* (`null`/`undefined`), not when it resolves to `''`.

## Test plan

- [x] Updated/added unit tests in `src/server/services/automation/triggerContext.test.ts` covering: Primary selected alongside other named channels (Meshtastic + MeshCore), Primary-only selection no longer degrading to "match any channel", and the live-trace miss-explainer returning `undefined` (a hit) for a Primary match.
- [x] `npx vitest run src/server/services/automation/` — 499/499 passing.
- [x] `npx eslint` on the touched files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JrrbJk223Tt1MbpVT899ST)_