### PR TITLE
docs(automations): say which text operators are case-sensitive (#4507)

### DIFF
--- a/src/components/automations/AutomationBuilder.regexHint.test.tsx
+++ b/src/components/automations/AutomationBuilder.regexHint.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * AutomationBuilder — the #4507 case-sensitivity guidance on `condition.string`
+ * actually reaches the DOM.
+ *
+ * This is a render test rather than a catalog-data test on purpose. A condition
+ * block's `description` is never rendered (only the trigger's is), so guidance
+ * written there would be invisible while every data-level assertion still
+ * passed. Only `FieldDef.help` renders, and only this test proves it.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AutomationBuilder from './AutomationBuilder';
+import type { WorkflowForm } from './compile';
+
+// Override the global i18n mock so t(key, default) returns the English default.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string | Record<string, unknown>) =>
+      typeof defaultValue === 'string' ? defaultValue : key,
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+/** A workflow whose single condition is a text comparison using `op`. */
+function renderWithStringOp(op: string) {
+  const form: WorkflowForm = {
+    trigger: { type: 'trigger.message', params: {} },
+    rules: [
+      {
+        conditions: [{ type: 'condition.string', params: { field: 'text', op, value: '' } }],
+        actions: [{ type: 'action.nothing', params: {} }],
+      },
+    ],
+    combine: null,
+  };
+  return render(
+    <AutomationBuilder
+      form={form} variables={[]} sources={[]} channels={[]} scripts={[]} regions={[]}
+      onChange={() => {}}
+    />,
+  );
+}
+
+describe('AutomationBuilder — string condition case guidance (#4507)', () => {
+  it('always shows which operators ignore case', () => {
+    renderWithStringOp('contains');
+    expect(screen.getByText(/ignore case/i)).toBeInTheDocument();
+    expect(screen.getByText(/case-sensitive/i)).toBeInTheDocument();
+  });
+
+  it('shows the (?i) hint when the operator is regex', () => {
+    renderWithStringOp('regex');
+    expect(screen.getByText(/\(\?i\)/)).toBeInTheDocument();
+  });
+
+  it('does not show the (?i) hint for non-regex operators', () => {
+    renderWithStringOp('contains');
+    expect(screen.queryByText(/\(\?i\)/)).not.toBeInTheDocument();
+  });
+
+  it('renders exactly one Value input whichever operator is selected', () => {
+    // The two `value` FieldDef variants share a param name; if their showIf
+    // guards ever overlap the user sees two inputs bound to the same key.
+    for (const op of ['contains', 'regex', 'eq']) {
+      const { unmount } = renderWithStringOp(op);
+      expect(screen.getAllByText('Value'), `op=${op}`).toHaveLength(1);
+      unmount();
+    }
+  });
+});

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { fieldVisible, ACTIONS, TRIGGERS, numericFields, stringFields, STRING_OP_OPTIONS, type FieldDef } from './catalog';
+import { fieldVisible, ACTIONS, CONDITIONS, TRIGGERS, numericFields, stringFields, STRING_OP_OPTIONS, type FieldDef } from './catalog';
 import { HOP_COUNT_EMOJIS } from '../../utils/hopEmoji';
 
 describe('fieldVisible', () => {
@@ -220,5 +220,38 @@ describe('Auto-Ack parity catalog additions (#4340 Phase 3)', () => {
       expect(fieldVisible(maxAttemptsField as FieldDef, { to: '{{ trigger.from }}' })).toBe(true);
       expect(fieldVisible(maxAttemptsField as FieldDef, { to: 123 })).toBe(true);
     });
+  });
+});
+
+describe("condition.string regex case-sensitivity hint (#4507)", () => {
+  const def = CONDITIONS.find((c) => c.type === 'condition.string');
+  const valueFields = (def?.fields ?? []).filter((f) => f.name === 'value');
+
+  it('warns on the operator select that casing differs between operators', () => {
+    const op = def?.fields.find((f) => f.name === 'op');
+    // The evaluator lower-cases both sides for contains/startsWith/endsWith/in
+    // but not for eq/neq/regex. Only `help` is rendered for a condition block —
+    // its `description` is not — so the note has to live here.
+    expect(op?.help).toMatch(/ignore case/i);
+    expect(op?.help).toMatch(/case-sensitive/i);
+  });
+
+  it('offers the (?i) workaround only on the regex operator', () => {
+    const regexValue = valueFields.find((f) => f.showIf?.equals === 'regex');
+    expect(regexValue?.help).toMatch(/\(\?i\)/);
+    expect(regexValue?.placeholder).toMatch(/\(\?i\)/);
+  });
+
+  it('shows exactly one Value input for every operator', () => {
+    // Both variants share the param name `value` so a typed value survives an
+    // operator switch. That makes overlap a real hazard: two visible fields
+    // would render duplicate inputs on a duplicate React key.
+    expect(valueFields.length).toBe(2);
+    for (const { value: op } of STRING_OP_OPTIONS) {
+      const visible = valueFields.filter((f) => fieldVisible(f, { op }));
+      expect(visible, `op=${op} should show exactly one Value field`).toHaveLength(1);
+    }
+    // Freshly-added block, before an operator has been chosen.
+    expect(valueFields.filter((f) => fieldVisible(f, {}))).toHaveLength(1);
   });
 });

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -296,11 +296,39 @@ export const CONDITIONS: BlockDef[] = [
   {
     type: 'condition.string',
     label: 'Text comparison',
+    // NOTE: a condition block's `description` is not rendered — only the
+    // trigger's is (AutomationBuilder.tsx). Guidance for these operators has to
+    // live in a field's `help`, which is why the casing note sits on `op` below.
     description: 'Compare text — message text, node name, role name…',
     fields: [
       { name: 'field', label: 'Field', kind: 'fieldselect' },
-      { name: 'op', label: 'Operator', kind: 'select', options: STRING_OP_OPTIONS },
-      { name: 'value', label: 'Value', kind: 'text', tokens: true, placeholder: 'e.g. ROUTER' },
+      {
+        name: 'op', label: 'Operator', kind: 'select', options: STRING_OP_OPTIONS,
+        // Casing is NOT uniform across these operators, and nothing said so
+        // until a user hit it (#4507): stringCompare() lower-cases both sides
+        // for every operator except `eq`, `neq` and `regex`. Only `eq` and
+        // `regex` are named below because `neq` is deliberately absent from
+        // STRING_OP_OPTIONS — naming an operator the dropdown doesn't offer
+        // would be worse than saying nothing. See stringCompare() in
+        // server/services/automation/conditionEvaluator.ts.
+        help: '“Equals” and “matches regex” are case-sensitive. The other operators ignore case.',
+      },
+      // Two `value` variants sharing one param name: same stored key, so the
+      // typed value survives switching operators, while the regex case gets its
+      // own placeholder and help. They MUST stay mutually exclusive — both
+      // visible would render a duplicate input on a duplicate React key.
+      {
+        name: 'value', label: 'Value', kind: 'text', tokens: true, placeholder: 'e.g. ROUTER',
+        showIf: { field: 'op', notEquals: 'regex' },
+      },
+      // `(?i)` works because the evaluator compiles with RE2
+      // (src/utils/safeRegex.ts) — plain JS RegExp rejects inline flags.
+      {
+        name: 'value', label: 'Value', kind: 'text', tokens: true,
+        placeholder: 'e.g. (?i)^(test|ping)',
+        help: 'Case-sensitive. Prefix with (?i) to ignore case — e.g. (?i)^(test|ping).',
+        showIf: { field: 'op', equals: 'regex' },
+      },
     ],
   },
   {

--- a/src/server/services/automation/conditionEvaluator.test.ts
+++ b/src/server/services/automation/conditionEvaluator.test.ts
@@ -232,6 +232,39 @@ describe('evaluateCondition', () => {
     expect(await evaluateCondition(node('condition.string', { field: 'text', op: 'notContains', value: 'xyz' }), ctx({ text: 'ping' }))).toBe(true);
   });
 
+  /**
+   * #4507: casing is NOT uniform across the string operators, and nothing in the
+   * builder said so. `contains`/`startsWith`/`endsWith`/`in` lower-case both
+   * sides; `eq`/`neq`/`regex` compare raw. The builder's copy now states this,
+   * so pin the behaviour that copy describes.
+   */
+  it('string: contains-family ignores case but eq and regex do not (#4507)', async () => {
+    const str = (op: string, value: string, text: string) =>
+      evaluateCondition(node('condition.string', { field: 'text', op, value }), ctx({ text }));
+
+    // Case-insensitive family.
+    expect(await str('contains', 'ping', 'PING the mesh')).toBe(true);
+    expect(await str('startsWith', 'ping', 'PING the mesh')).toBe(true);
+    expect(await str('endsWith', 'mesh', 'PING the MESH')).toBe(true);
+    expect(await str('in', 'ping, test', 'PING')).toBe(true);
+
+    // Case-sensitive family — the surprise that got reported.
+    expect(await str('eq', 'ping', 'PING')).toBe(false);
+    expect(await str('regex', '^(test|ping)', 'PING')).toBe(false);
+  });
+
+  it('string: (?i) makes a regex case-insensitive — the workaround the builder suggests (#4507)', async () => {
+    // Load-bearing on the engine being RE2 (src/utils/safeRegex.ts). JavaScript's
+    // own RegExp throws on inline flags, so swapping the engine back would make
+    // both this test and the builder's hint wrong at the same time.
+    const rx = (value: string, text: string) =>
+      evaluateCondition(node('condition.string', { field: 'text', op: 'regex', value }), ctx({ text }));
+
+    expect(await rx('(?i)^(test|ping)', 'PING')).toBe(true);
+    expect(await rx('(?i)^(test|ping)', 'Test 123')).toBe(true);
+    expect(await rx('(?i)^(test|ping)', 'pong')).toBe(false);
+  });
+
   it('node.completeness: `in complete, unknown` reproduces AutoAck\'s skip-incomplete gate (#4340 Phase 3)', async () => {
     const gate = node('condition.string', { field: 'node.completeness', op: 'in', value: 'complete, unknown' });
     // complete row → passes


### PR DESCRIPTION
Follow-up to #4508, which fixed the reported matching behaviour but left the second half of #4507 — the reporter also asked for a hint that regex matching is case-sensitive, and that `(?i)` works around it.

## The problem

The string-comparison operators disagree about casing, and nothing in the builder said so. `stringCompare()` lower-cases both sides for `contains`, `startsWith`, `endsWith`, `notContains`, `in` and `notIn`, but compares raw for `eq`, `neq` and `regex`.

So `contains: ping` matches `PING`, while `matches regex: ^(test|ping)` does not. Same block, same-looking inputs, opposite answers. That reads as a bug rather than a rule.

## The change

Copy plus tests. No behaviour change.

- **`Operator`** gains help naming which side of the split it's on.
- **`Value`** becomes two mutually-exclusive variants sharing the `value` param name, so a typed value survives an operator switch. The regex variant carries a `(?i)` placeholder and help.

## Two things worth flagging in review

**The `(?i)` advice is only true because of RE2.** JavaScript's own `RegExp` throws on inline flags, so this hint would be actively wrong under a stock engine. It works because `compileUserRegex` uses RE2 (`src/utils/safeRegex.ts`). Verified rather than assumed — there's a test asserting `(?i)^(test|ping)` matches `PING` but not `pong`, which fails if the engine is ever swapped back.

**The obvious place to put this copy is invisible.** My first attempt put it in the block's `description` — but a *condition* block's description is never rendered; only a trigger's is (`AutomationBuilder.tsx:299`). Only `FieldDef.help` renders. `AutomationBuilder.regexHint.test.tsx` is a render test specifically because a data-level test would have passed while the user saw nothing.

The copy also deliberately does **not** mention `neq`. The evaluator supports it, but `STRING_OP_OPTIONS` never offers it in the dropdown — naming an operator the user cannot select is worse than saying nothing.

## Verification

- New tests fail on `origin/main` and pass here — checked by restoring `catalog.ts` from main and re-running (all 3 catalog tests correctly failed).
- Full suite: **13,039 passed, 0 failed**.
- `npm run lint:ci`: clean. `tsc --noEmit`: clean.
- The two `value` variants are asserted to be mutually exclusive across every operator in `STRING_OP_OPTIONS` plus the unset case — overlap would render duplicate inputs on a duplicate React key.

Closes #4507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB