### PR TITLE
chore(release): 4.13.3-rc6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.3-rc5",
+  "version": "4.13.3-rc6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.3-rc5",
+  "version": "4.13.3-rc6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.3-rc5
-appVersion: "4.13.3-rc5"
+version: 4.13.3-rc6
+appVersion: "4.13.3-rc6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc5",
+  "version": "4.13.3-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.3-rc5",
+      "version": "4.13.3-rc6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc5",
+  "version": "4.13.3-rc6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump only — no code changes.

Bumps all five version files required by CLAUDE.md:

| File | |
|---|---|
| `package.json` | 4.13.3-rc5 → 4.13.3-rc6 |
| `package-lock.json` | regenerated via `npm install --package-lock-only` |
| `helm/meshmonitor/Chart.yaml` | `version` + `appVersion` |
| `desktop/src-tauri/tauri.conf.json` | |
| `desktop/package.json` | |

## Notes

- The lockfile diff is the **two version entries only** — no dependency churn.
- `git grep 4.13.3-rc5` is clean outside the changelog.
- Heads up: there is a stale `origin/chore/bump-version-rc6` branch left over from the 3.10.0 cycle. It is unrelated to this PR and could be deleted.

Per the release convention, this carries the `system-test` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB