### PR TITLE
fix(meshcore): clear zero-hop ping result when the selected contact changes

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -437,6 +437,8 @@ describe('MeshCoreContactDetailPanel', () => {
       const PK2 = 'b'.repeat(64);
       const contactA: MeshCoreContact = { publicKey: PK, advType: 2 };
       const contactB: MeshCoreContact = { publicKey: PK2, advType: 2 };
+      // The Promise executor runs synchronously, so resolvePing is assigned
+      // before render() returns — safe to use below without an intermediate await.
       let resolvePing: (value: { ok: true; hopHash: string; rttMs: number; snrToTarget: number; snrFromTarget: number }) => void;
       const onPingZeroHop = vi.fn().mockImplementation(
         () => new Promise((resolve) => { resolvePing = resolve; }),

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -395,5 +395,86 @@ describe('MeshCoreContactDetailPanel', () => {
         expect(status).not.toContain('SNR at node');
       });
     });
+
+    it('clears a stale ping result when the selected contact changes (#4514)', async () => {
+      const PK2 = 'b'.repeat(64);
+      const contactA: MeshCoreContact = { publicKey: PK, advType: 2 };
+      const contactB: MeshCoreContact = { publicKey: PK2, advType: 2 };
+      const onPingZeroHop = vi.fn().mockResolvedValue({
+        ok: true, hopHash: 'aa', rttMs: 100, snrToTarget: 5, snrFromTarget: 2,
+      });
+
+      const { rerender } = render(
+        <MeshCoreContactDetailPanel
+          contact={contactA}
+          publicKey={PK}
+          onPingZeroHop={onPingZeroHop}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: PING_LABEL }));
+      await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Direct — in range'));
+
+      // Switch to a different contact — the previous ping result must not
+      // bleed into the new contact's card.
+      rerender(
+        <MeshCoreContactDetailPanel
+          contact={contactB}
+          publicKey={PK2}
+          onPingZeroHop={onPingZeroHop}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      expect(screen.queryByText('Zero-Hop Ping')).toBeNull();
+      expect(screen.queryByRole('status')).toBeNull();
+    });
+
+    it('ignores an in-flight ping reply for a contact the user has since navigated away from (#4514)', async () => {
+      const PK2 = 'b'.repeat(64);
+      const contactA: MeshCoreContact = { publicKey: PK, advType: 2 };
+      const contactB: MeshCoreContact = { publicKey: PK2, advType: 2 };
+      let resolvePing: (value: { ok: true; hopHash: string; rttMs: number; snrToTarget: number; snrFromTarget: number }) => void;
+      const onPingZeroHop = vi.fn().mockImplementation(
+        () => new Promise((resolve) => { resolvePing = resolve; }),
+      );
+
+      const { rerender } = render(
+        <MeshCoreContactDetailPanel
+          contact={contactA}
+          publicKey={PK}
+          onPingZeroHop={onPingZeroHop}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      // Kick off a ping for contact A, then navigate away before it resolves.
+      fireEvent.click(screen.getByRole('button', { name: PING_LABEL }));
+
+      rerender(
+        <MeshCoreContactDetailPanel
+          contact={contactB}
+          publicKey={PK2}
+          onPingZeroHop={onPingZeroHop}
+          canWriteNodes
+          isCompanion
+        />,
+      );
+
+      // Contact A's ping reply now arrives late — it must not paint onto
+      // contact B's card.
+      resolvePing!({ ok: true, hopHash: 'aa', rttMs: 100, snrToTarget: 5, snrFromTarget: 2 });
+
+      await waitFor(() => expect(onPingZeroHop).toHaveBeenCalledWith(PK));
+      // Give the resolved promise's .then a tick to run.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(screen.queryByText('Zero-Hop Ping')).toBeNull();
+      expect(screen.queryByRole('status')).toBeNull();
+    });
   });
 });

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import {
@@ -114,6 +114,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const { t } = useTranslation();
   const { timeFormat, dateFormat } = useSettings();
   const { sourceId } = useSource();
+  // Tracks the currently-selected contact synchronously (unlike the
+  // `publicKey` prop, which an in-flight async closure captured at call
+  // time and won't see update) so a stale ping reply can detect that the
+  // user has since switched contacts.
+  const publicKeyRef = useRef(publicKey);
+  publicKeyRef.current = publicKey;
   const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
     return localStorage.getItem(COLLAPSED_KEY) === 'true';
   });
@@ -183,6 +189,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setExportSuccess(false);
     setNeighboursLoading(false);
     setNeighboursData(null);
+    setPinging(false);
+    setPingResult(null);
   }, [publicKey]);
 
   // Auto-load stored neighbor data from the database for repeaters.
@@ -277,12 +285,20 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
 
   const handlePingZeroHop = async () => {
     if (!onPingZeroHop || pinging) return;
+    const pingedKey = publicKey;
     setPinging(true);
     setPingResult(null);
     try {
-      setPingResult(await onPingZeroHop(publicKey));
+      const result = await onPingZeroHop(pingedKey);
+      // The contact may have changed while the ping was in flight — don't
+      // paint a stale reply onto whichever contact is now selected.
+      if (pingedKey === publicKeyRef.current) {
+        setPingResult(result);
+      }
     } finally {
-      setPinging(false);
+      if (pingedKey === publicKeyRef.current) {
+        setPinging(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- `MeshCoreContactDetailPanel`'s contact-change effect resets every other transient action-result state (`traceResult`, `neighboursData`, `shareError`, etc.) when the selected contact changes, but it never reset `pingResult`/`pinging`. So the Zero-Hop Ping result card from a previous contact stayed on screen after switching contacts, reading as a ping result for the wrong node.
- Also fixed a related async race: if a ping is still in flight when the user switches contacts, the reply could resolve after the switch and get painted onto the newly-selected contact. Guarded with a ref tracking the currently-selected `publicKey` (a plain closure variable wouldn't see the prop update, since each render captures its own binding).

## Changes

- `src/components/MeshCore/MeshCoreContactDetailPanel.tsx`: reset `pingResult`/`pinging` in the existing per-contact cleanup effect; added a `publicKeyRef` and check it before committing a ping reply to state.
- `src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx`: two regression tests — result clears on contact switch, and a stale in-flight reply for a since-abandoned contact is discarded.

Fixes #4514

## Test plan

- [x] `npx vitest run src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx` — 21/21 passing, including the two new regression tests
- [x] `npx vitest run src/components/MeshCore` — 262/262 passing (full component suite)
- [x] `npm run lint:ci` — clean, no new violations
- [ ] Manual UI verification (not performed in this session)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqQCsGmExyeVQaGramhYVa)_