### PR TITLE
fix(meshcore): don't paint a stale reply onto the wrong contact (#4517)

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -479,4 +479,97 @@ describe('MeshCoreContactDetailPanel', () => {
       expect(screen.queryByRole('status')).toBeNull();
     });
   });
+
+  /**
+   * #4517 — the same async race #4514/#4515 fixed for Zero-Hop Ping existed in
+   * every other action on this panel: `await` a reply, then unconditionally
+   * write it to state. The contact-change effect clears these fields on
+   * switch, so the failure is specifically a reply landing *after* that clear
+   * and repainting one contact's data onto another's card.
+   */
+  describe('stale replies after a contact switch (#4517)', () => {
+    const PK2 = 'b'.repeat(64);
+    /** pathLen > 0 is required for the Trace Path button to be offered. */
+    const contactA: MeshCoreContact = { publicKey: PK, advType: 2, pathLen: 2 };
+    const contactB: MeshCoreContact = { publicKey: PK2, advType: 2, pathLen: 2 };
+
+    /** A promise whose resolution the test controls. */
+    function deferred<T>() {
+      let resolve!: (v: T) => void;
+      const promise = new Promise<T>((r) => { resolve = r; });
+      return { promise, resolve };
+    }
+
+    it("does not paint contact A's trace result onto contact B", async () => {
+      const d = deferred<{ hops: { index: number; snr: number }[]; lastSnr: number }>();
+      const onTracePath = vi.fn().mockReturnValue(d.promise);
+
+      const props = { onTracePath, canWriteNodes: true, isCompanion: true } as const;
+      const { rerender } = render(
+        <MeshCoreContactDetailPanel contact={contactA} publicKey={PK} {...props} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Trace Path' }));
+      rerender(<MeshCoreContactDetailPanel contact={contactB} publicKey={PK2} {...props} />);
+
+      // A's reply arrives only now, with B on screen.
+      d.resolve({ hops: [{ index: 0, snr: 7 }], lastSnr: 5 });
+      await waitFor(() => expect(onTracePath).toHaveBeenCalledWith(PK));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(screen.queryByText('Trace Path Results')).toBeNull();
+    });
+
+    it("does not paint contact A's neighbours onto contact B", async () => {
+      const d = deferred<{ total: number; neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[] }>();
+      const onGetNeighbours = vi.fn().mockReturnValue(d.promise);
+
+      const props = { onGetNeighbours, isCompanion: true } as const;
+      const { rerender } = render(
+        <MeshCoreContactDetailPanel contact={contactA} publicKey={PK} {...props} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Neighbours' }));
+      rerender(<MeshCoreContactDetailPanel contact={contactB} publicKey={PK2} {...props} />);
+
+      d.resolve({ total: 3, neighbours: [{ publicKeyPrefix: 'ff', heardSecondsAgo: 10, snr: 4 }] });
+      await waitFor(() => expect(onGetNeighbours).toHaveBeenCalledWith(PK, { count: 20 }));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(screen.queryByText(/3 total/)).toBeNull();
+    });
+
+    it('still shows a reply for the contact the user is actually on', async () => {
+      // The guard must not be so eager that it drops legitimate results.
+      const onTracePath = vi.fn().mockResolvedValue({ hops: [{ index: 0, snr: 7 }], lastSnr: 5 });
+      render(
+        <MeshCoreContactDetailPanel
+          contact={contactA} publicKey={PK}
+          onTracePath={onTracePath} canWriteNodes isCompanion
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Trace Path' }));
+      await waitFor(() => expect(screen.getByText('Trace Path Results')).toBeInTheDocument());
+    });
+
+    it('guards every async handler, including ones added later', async () => {
+      // The point of routing these through one `beginContactAction()` helper is
+      // that the next handler cannot quietly skip the check. Asserted at the
+      // source level because a behavioural test can only cover the handlers
+      // that exist today.
+      const { readFileSync } = await import('node:fs');
+      const { resolve } = await import('node:path');
+      const src = readFileSync(
+        resolve('src/components/MeshCore/MeshCoreContactDetailPanel.tsx'), 'utf8',
+      );
+      const handlers = [...src.matchAll(/const (handle\w+) = async \(\) => \{([\s\S]*?)\n {2}\};/g)];
+      expect(handlers.length).toBeGreaterThan(5);
+
+      const unguarded = handlers
+        .filter((m) => /await on[A-Z]/.test(m[2]) && !m[2].includes('beginContactAction()'))
+        .map((m) => m[1]);
+      expect(unguarded, `unguarded handlers: ${unguarded.join(', ')}`).toEqual([]);
+    });
+  });
+
 });

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -116,10 +116,30 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const { sourceId } = useSource();
   // Tracks the currently-selected contact synchronously (unlike the
   // `publicKey` prop, which an in-flight async closure captured at call
-  // time and won't see update) so a stale ping reply can detect that the
-  // user has since switched contacts.
+  // time and won't see update) so a stale reply can detect that the user
+  // has since switched contacts.
   const publicKeyRef = useRef(publicKey);
   publicKeyRef.current = publicKey;
+
+  /**
+   * Every action on this panel is "for the contact that was selected when the
+   * button was pressed". Call this first; the predicate it returns is false
+   * once the user has moved on, which is the signal to drop the reply on the
+   * floor rather than paint it onto whoever is selected now.
+   *
+   * The contact-change effect already clears these fields on switch, so the
+   * bug this guards is specifically a reply landing *after* that clear
+   * (#4514 for ping, #4517 for trace path, and the rest of the handlers here,
+   * which all had the identical shape).
+   *
+   * One guard used by every handler, rather than the same three-line check
+   * copy-pasted nine times — a check that exists in nine places is a check
+   * that will exist in eight after the next handler is added.
+   */
+  const beginContactAction = useCallback(() => {
+    const startedFor = publicKeyRef.current;
+    return () => startedFor === publicKeyRef.current;
+  }, []);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
     return localStorage.getItem(COLLAPSED_KEY) === 'true';
   });
@@ -266,11 +286,13 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
 
   const handleTracePath = async () => {
     if (!onTracePath || tracing) return;
+    const isCurrent = beginContactAction();
     setTracing(true);
     setTraceError(null);
     setTraceResult(null);
     try {
       const result = await onTracePath(publicKey);
+      if (!isCurrent()) return;
       if (result) {
         setTraceResult(result);
       } else {
@@ -279,26 +301,21 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
         );
       }
     } finally {
-      setTracing(false);
+      if (isCurrent()) setTracing(false);
     }
   };
 
   const handlePingZeroHop = async () => {
     if (!onPingZeroHop || pinging) return;
-    const pingedKey = publicKey;
+    const isCurrent = beginContactAction();
     setPinging(true);
     setPingResult(null);
     try {
-      const result = await onPingZeroHop(pingedKey);
-      // The contact may have changed while the ping was in flight — don't
-      // paint a stale reply onto whichever contact is now selected.
-      if (pingedKey === publicKeyRef.current) {
-        setPingResult(result);
-      }
+      const result = await onPingZeroHop(publicKey);
+      if (!isCurrent()) return;
+      setPingResult(result);
     } finally {
-      if (pingedKey === publicKeyRef.current) {
-        setPinging(false);
-      }
+      if (isCurrent()) setPinging(false);
     }
   };
 
@@ -311,27 +328,30 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     if (typeof window !== 'undefined' && !window.confirm(confirmMessage)) {
       return;
     }
+    const isCurrent = beginContactAction();
     setResetting(true);
     setResetError(null);
     try {
       const ok = await onResetPath(publicKey);
+      if (!isCurrent()) return;
       if (!ok) {
         setResetError(
           t('meshcore.contact_details.reset_path_error', 'Reset path failed.'),
         );
       }
     } finally {
-      setResetting(false);
+      if (isCurrent()) setResetting(false);
     }
   };
 
   const handleDiscoverPath = async () => {
     if (!onDiscoverPath || discovering) return;
+    const isCurrent = beginContactAction();
     setDiscovering(true);
     try {
       await onDiscoverPath(publicKey);
     } finally {
-      setDiscovering(false);
+      if (isCurrent()) setDiscovering(false);
     }
   };
 
@@ -398,10 +418,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
       );
       return;
     }
+    const isCurrent = beginContactAction();
     setEditorSaving(true);
     setEditorError(null);
     try {
       const ok = await onSetOutPath(publicKey, joinPathHops(editorHops), editorHashBytes);
+      if (!isCurrent()) return;
       if (!ok) {
         setEditorError(
           t('meshcore.contact_details.edit_path_save_failed', 'Save failed.'),
@@ -410,7 +432,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
         setEditorOpen(false);
       }
     } finally {
-      setEditorSaving(false);
+      if (isCurrent()) setEditorSaving(false);
     }
   };
 
@@ -423,11 +445,13 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     if (typeof window !== 'undefined' && !window.confirm(confirmMessage)) {
       return;
     }
+    const isCurrent = beginContactAction();
     setSharing(true);
     setShareError(null);
     setShareSuccess(false);
     try {
       const result = await onShareContact(publicKey);
+      if (!isCurrent()) return;
       if (result.ok) {
         setShareSuccess(true);
         window.setTimeout(() => setShareSuccess(false), 2200);
@@ -438,7 +462,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
         );
       }
     } finally {
-      setSharing(false);
+      if (isCurrent()) setSharing(false);
     }
   };
 
@@ -449,26 +473,33 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
       `Remove ${name} from the device's contact list? This cannot be undone.`,
     );
     if (typeof window !== 'undefined' && !window.confirm(confirmMessage)) return;
+    const isCurrent = beginContactAction();
     setRemoving(true);
     setRemoveError(null);
     try {
       const ok = await onRemoveContact(publicKey);
+      if (!isCurrent()) return;
       if (!ok) {
         setRemoveError(t('meshcore.contact_details.remove_contact_error', 'Remove contact failed.'));
       }
     } finally {
-      setRemoving(false);
+      if (isCurrent()) setRemoving(false);
     }
   };
 
   const handleExportContact = async () => {
     if (!onExportContact || exporting) return;
+    const isCurrent = beginContactAction();
     setExporting(true);
     setExportSuccess(false);
     try {
       const bytes = await onExportContact(publicKey);
       if (bytes) {
         const url = `meshcore://${bytes.map(b => b.toString(16).padStart(2, '0')).join('')}`;
+        // The copy itself still happens after a contact switch: the user asked
+        // to export *this* contact and is presumably about to paste it. Only
+        // the on-screen confirmation is suppressed, since that would otherwise
+        // appear on the newly-selected contact's card.
         try {
           await navigator.clipboard.writeText(url);
         } catch {
@@ -477,25 +508,29 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             url,
           );
         }
-        setExportSuccess(true);
-        window.setTimeout(() => setExportSuccess(false), 2200);
+        if (isCurrent()) {
+          setExportSuccess(true);
+          window.setTimeout(() => setExportSuccess(false), 2200);
+        }
       }
     } finally {
-      setExporting(false);
+      if (isCurrent()) setExporting(false);
     }
   };
 
   const handleGetNeighbours = async () => {
     if (!onGetNeighbours || neighboursLoading) return;
+    const isCurrent = beginContactAction();
     setNeighboursLoading(true);
     setNeighboursData(null);
     try {
       const result = await onGetNeighbours(publicKey, { count: 20 });
+      if (!isCurrent()) return;
       if (result) {
         setNeighboursData({ ...result, fetchedAt: Date.now() });
       }
     } finally {
-      setNeighboursLoading(false);
+      if (isCurrent()) setNeighboursLoading(false);
     }
   };
 


### PR DESCRIPTION
Closes #4517. Follow-up to #4515.

## The bug is wider than reported

#4517 names `handleTracePath`. Auditing the file, **every** async handler had the identical shape — `await` a reply, then unconditionally write it to state:

| Handler | What a late reply does |
|---|---|
| `handleTracePath` | paints contact A's trace onto B *(the reported one)* |
| `handleGetNeighbours` | paints contact A's neighbours onto B |
| `handleResetPath` / `handleShareContact` / `handleRemoveContact` / `handleSaveEditor` | flashes a spurious error or success on the wrong contact |
| `handleExportContact` | shows "copied" on the wrong contact |
| `handleDiscoverPath` | can leave a stuck spinner |
| `handlePingZeroHop` | already fixed in #4515 |

The contact-change effect *does* clear all of these on switch — so this is specifically the "reply arrives after the clear" variant, not "stale card lingers".

## One guard, not nine

The obvious fix is to copy #4515's three-line check into each handler. I didn't, because a check that exists in nine places is a check that will exist in eight after the next handler is added. Instead there's a single `beginContactAction()`: call it first, and the predicate it returns is false once the user has moved on.

`handlePingZeroHop`'s bespoke `pingedKey === publicKeyRef.current` check is folded into the same helper, so there's one mechanism rather than two.

**A test enforces the invariant at the source level** — it scans the component for handlers that `await on*` and fails listing any that lack the guard. A behavioural test can only ever cover the handlers that exist today.

## One deliberate asymmetry

`handleExportContact` is only half-guarded. The clipboard write still happens after a contact switch, because the user asked to export *that* contact and is presumably about to paste it; silently not copying would be worse. Only the on-screen confirmation is suppressed, since that would otherwise appear on the newly-selected card.

## Verification

Four new tests: trace-path race, neighbours race, the source-level guard invariant, and one asserting a reply for the contact you're *actually on* still displays — so the fix can't pass by being over-eager and dropping everything.

Confirmed the three behavioural/structural ones **fail against `main`** and pass here. Panel suite 25/25. Full suite **13,061 passed, 0 failed**. `lint:ci` and `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB