### PR TITLE
chore(deps): bump codeql-action init/autobuild/analyze to v4.37.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Replaces Dependabot PRs **#4521**, **#4519** and **#4531**.

## Why those three can't be merged as-is

Dependabot opened one PR per action — `init`, `autobuild`, `analyze` — each bumping a single `uses:` line in `.github/workflows/codeql.yml` and leaving the other two on the old SHA. CodeQL requires its actions to be the same version, so **all three PRs fail on the Autobuild step**:

```
Initialize CodeQL   ✓
Autobuild           ✗   <- version mismatch against init/analyze
Perform CodeQL Analysis  (skipped)
```

Merging any one of them individually would leave `main` in that same broken state. Only the combined bump is valid, so this PR moves all three references to `f205ea1c…` (v4.37.4) at once.

`upload-sarif` already moved to this SHA in #4527 — it lives in `ci.yml`, a separate workflow, which is why that PR passed on its own and was safe to merge alone.

After this lands, all four `codeql-action` references in the repo are on one SHA — verified no `e4fba868…` remains under `.github/`.

## Follow-up

Once this is merged, #4519, #4521 and #4531 should be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB