### PR TITLE
ci: wait on CodeQL and ClamAV before auto-merging Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,20 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # "Quick Tests" retired with pr-tests.yml (its coverage was a strict
           # subset of "Test Suite"); "Documentation Build" moved into ci.yml.
-          check-regexp: '(Build Check|Test Suite|Security Scan|Docker Build|Documentation Build).*'
+          #
+          # `Analyze` (CodeQL) and `ClamAV Scan` were missing here, and that was
+          # not harmless: Dependabot's codeql-action bumps are *patch* updates,
+          # so they qualify for auto-merge, and CodeQL is the one thing they can
+          # break. #4519/#4521/#4531 each bumped a single codeql-action step,
+          # leaving codeql.yml pinning two different versions, and every one of
+          # them failed on Autobuild — while every check in this list stayed
+          # green. With auto-merge enabled they would have merged themselves and
+          # broken CodeQL on main.
+          #
+          # Deliberately NOT listed: `security/snyk` and `claude-review` (an
+          # outage or a non-deterministic review would stall every bump), and
+          # `Auto-merge Dependabot PRs` (this job — it would wait on itself).
+          check-regexp: '(Build Check|Test Suite|Security Scan|Docker Build|Documentation Build|ClamAV Scan|Analyze).*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           allowed-conclusions: success,skipped,neutral


### PR DESCRIPTION
Follow-up to enabling `allow_auto_merge` on the repo.

## The gap

Now that auto-merge is on, the wait step is what decides whether a bump merges itself. Its regexp covered five checks but **not `Analyze` (CodeQL)** or `ClamAV Scan`.

That is not theoretical. Dependabot's `codeql-action` bumps are **patch** updates, so they qualify for auto-merge — and CodeQL is precisely what they can break. Today, #4519/#4521/#4531 each bumped one `codeql-action` step, leaving `codeql.yml` pinning two versions at once. All three failed on Autobuild, **while every check in the old regexp stayed green**. Had auto-merge been on this morning, they would have merged themselves and broken CodeQL on `main`.

## The change

```diff
-check-regexp: '(Build Check|Test Suite|Security Scan|Docker Build|Documentation Build).*'
+check-regexp: '(Build Check|Test Suite|Security Scan|Docker Build|Documentation Build|ClamAV Scan|Analyze).*'
```

Verified against the actual check names on a recent PR — it now matches exactly 9 checks and nothing else:

| Waited on | Not waited on |
|---|---|
| Test Suite (22.x / 24.x / 25.x), Build Check, Docker Build, Documentation Build, Security Scan, ClamAV Scan, **Analyze** | `security/snyk`, `claude-review`, `CodeQL`, `Trivy`, `PR Comment`, `Auto-merge Dependabot PRs` |

The exclusions are deliberate:
- **`security/snyk`** is an external status — an outage would stall every bump.
- **`claude-review`** is non-deterministic; gating merges on it invites permanent stalls.
- **`Auto-merge Dependabot PRs`** is this job. It would wait on itself.
- **`CodeQL` / `Trivy`** report with no owning workflow (integration-provided), so I left them out rather than risk waiting on a check that may not always post. `Analyze` is the real CodeQL gate and *is* covered.

Paired with required status checks on the `protect main` ruleset, so the gate exists at the GitHub level too rather than living only in this regexp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB