### PR TITLE
fix(meshcore): honour per-channel permissions on channel messages

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -529,6 +529,44 @@ describe('MeshCoreMessageStream entry scroll on a hidden pane (#4473 follow-up)'
     expect(list.scrollTop).toBe(900);
   });
 
+  it('does not spend the entry scroll on an EMPTY list that has layout', () => {
+    // The empty state ("No messages on this channel yet") is itself laid out,
+    // so the container has a real height before any message arrives. The
+    // observer used to fire there, scroll to the bottom of the placeholder,
+    // trivially succeed, and burn the one shot — leaving the view at the top
+    // once the backlog landed.
+    //
+    // Seen on the anonymous read-only view, where the absent compose box shifts
+    // render timing enough to expose it (list went 1 child -> 203 in one step,
+    // scrollTop stuck at 0 over a 16,000px history).
+    const { container, rerender } = render(
+      <MeshCoreMessageStream
+        messages={[]}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+
+    // Empty, but laid out — this must NOT consume the shot.
+    scrollHeightValue = 741;
+    act(() => { resizeCallbacks.forEach(cb => cb()); });
+    expect(list.scrollTop).toBe(0);
+
+    // Backlog arrives and the list grows: the shot must still be available.
+    scrollHeightValue = 16148;
+    rerender(
+      <MeshCoreMessageStream
+        messages={msgs()}
+        conversationKey="channel-0"
+        onSend={async () => true}
+      />,
+    );
+    act(() => { resizeCallbacks.forEach(cb => cb()); });
+
+    expect(list.scrollTop).toBe(16148);
+  });
+
   it('does not re-scroll on later resizes once the entry scroll has run', () => {
     const { container } = render(
       <MeshCoreMessageStream

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -210,12 +210,31 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   // i.e. when the hidden conversation pane is revealed. Nothing else changes at
   // that point (no new messages, no key change), so without this observer the
   // effect above has no trigger left to fire on.
+  //
+  // Read through a ref so the observer is created once per mount: putting the
+  // message count in the dep array would tear down and rebuild it on every
+  // incoming message.
+  const messageCountRef = useRef(messages.length);
+  messageCountRef.current = messages.length;
+
   useEffect(() => {
     const container = listRef.current;
     if (!container || typeof ResizeObserver === 'undefined') return;
     const observer = new ResizeObserver(() => {
       const state = entryScrollRef.current;
       if (state.done) return;
+      // The empty state ("No messages on this channel yet") is itself laid out,
+      // so the container has a real, non-zero height BEFORE any message
+      // arrives. Without this guard the observer fires on that empty list,
+      // scrolls to the bottom of ~700px of placeholder, trivially succeeds, and
+      // spends the one shot — so when the backlog lands there is nothing left
+      // to trigger on and the view sits at the top of a 16,000px history.
+      //
+      // Observed on the anonymous read-only view, where the absent compose box
+      // changes render timing enough to expose it: the list went 1 child ->
+      // 203 children in a single step, while an authenticated session rendered
+      // progressively and scrolled correctly by luck of ordering.
+      if (messageCountRef.current === 0) return;
       if (runEntryScroll(container)) state.done = true;
     });
     observer.observe(container);

--- a/src/server/routes/meshcoreMessagingRoutes.channelPermissions.test.ts
+++ b/src/server/routes/meshcoreMessagingRoutes.channelPermissions.test.ts
@@ -1,0 +1,192 @@
+/**
+ * MeshCore channel messages — per-channel permission gating.
+ *
+ * The bug: the MeshCore channel *list* (`/api/channels/all`) gates on
+ * `channel_${idx}`, but the channel *messages* route gated on the global
+ * `messages` resource. Granting a user "Public: Read" on a MeshCore source
+ * therefore showed the channel in the sidebar with nothing in it — the list
+ * call returned 200 and every message call returned 403.
+ *
+ * Uses the real-middleware harness rather than mocked permission lambdas,
+ * because the thing under test *is* the permission logic: a fake
+ * `checkPermissionAsync` would happily pass while the real SQL denied.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+// A stand-in MeshCore manager: the guard requires a registered manager of the
+// right type before any handler runs.
+const fakeManager = {
+  isMeshCore: true,
+  getChannelMessages: vi.fn().mockResolvedValue([
+    { id: 'm1', text: 'hello public', channelIdx: 0, timestamp: 100 },
+  ]),
+  getChannelMessageCounts: vi.fn().mockImplementation(async (idxs: number[]) =>
+    Object.fromEntries(idxs.map((i) => [i, 10 + i])),
+  ),
+  getChannelLatestTimestamps: vi.fn().mockImplementation(async (idxs: number[]) =>
+    Object.fromEntries(idxs.map((i) => [i, 1000 + i])),
+  ),
+  getMessages: vi.fn().mockResolvedValue([]),
+};
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: vi.fn(() => fakeManager) },
+}));
+vi.mock('../sourceManagerTypes.js', () => ({
+  isMeshCoreManager: (m: unknown) => !!m,
+  isMeshtasticManager: () => false,
+  getPrimaryMeshtasticManager: () => null,
+}));
+
+const { default: meshcoreRoutes } = await import('./meshcoreRoutes.js');
+
+describe('MeshCore channel messages — per-channel permissions', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/:id/meshcore', meshcoreRoutes),
+    });
+  });
+  afterEach(async () => { await harness.cleanup(); });
+
+  const chanUrl = (src: string, idx: number) => `/${src}/meshcore/messages/channel/${idx}`;
+
+  describe('the reported bug', () => {
+    it('channel_0:read alone is enough to read channel 0', async () => {
+      // Exactly the grant an operator makes via "Public: Read". Before the fix
+      // this returned 403 asking for `messages`.
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(chanUrl(harness.sourceA, 0));
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+    });
+
+    it('works for the anonymous user, not just logged-in ones', async () => {
+      // The reported case was anonymous. optionalAuth falls back to the
+      // anonymous row, so the grant must be honoured there too.
+      await harness.grant(harness.anonymous.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(null);
+
+      const res = await agent.get(chanUrl(harness.sourceA, 0));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('still denies what it should', () => {
+    it('a grant on channel 0 does not open channel 3', async () => {
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(chanUrl(harness.sourceA, 3));
+      expect(res.status).toBe(403);
+    });
+
+    it('names the per-channel resource in the 403, not `messages`', async () => {
+      // Reporting `messages` is what made this hard to diagnose: the operator
+      // had granted the channel and the error pointed at a different resource.
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(chanUrl(harness.sourceA, 3));
+      expect(res.body.required).toEqual({ resource: 'channel_3', action: 'read' });
+    });
+
+    it('a grant on one source does not leak into another', async () => {
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      expect((await agent.get(chanUrl(harness.sourceA, 0))).status).toBe(200);
+      expect((await agent.get(chanUrl(harness.sourceB, 0))).status).toBe(403);
+    });
+
+    it('does not open the DM list, which is not a channel', async () => {
+      // DMs stay on `messages` — a channel grant must not expose private
+      // conversations.
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(`/${harness.sourceA}/meshcore/messages`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('backwards compatibility', () => {
+    it('a legacy `messages:read` grant still reads channels', async () => {
+      // The check is a union on purpose. Requiring `channel_${idx}` alone would
+      // revoke access from every existing install that granted only `messages`.
+      await harness.grant(harness.limited.id, 'messages', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      expect((await agent.get(chanUrl(harness.sourceA, 0))).status).toBe(200);
+      expect((await agent.get(chanUrl(harness.sourceA, 5))).status).toBe(200);
+    });
+
+    it('channels above 7 fall back to `messages` (no channel_8 resource exists)', async () => {
+      await harness.grant(harness.limited.id, 'messages', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(chanUrl(harness.sourceA, 12));
+      expect(res.status).toBe(200);
+    });
+
+    it('a channel_0 grant does NOT reach channels above 7', async () => {
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(chanUrl(harness.sourceA, 12));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('channel-counts filters instead of refusing', () => {
+    const countsUrl = (src: string, chans: string) =>
+      `/${src}/meshcore/messages/channel-counts?channels=${chans}`;
+
+    it('returns counts only for the channels the user may read', async () => {
+      // A single all-or-nothing gate would 403 this whole request just because
+      // channels 1 and 2 are not readable, hiding channel 0's badge too.
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(countsUrl(harness.sourceA, '0,1,2'));
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body.counts)).toEqual(['0']);
+    });
+
+    it('returns an empty map rather than 403 when nothing is readable', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(countsUrl(harness.sourceA, '0,1,2'));
+      expect(res.status).toBe(200);
+      expect(res.body.counts).toEqual({});
+    });
+
+    it('admins see every requested channel', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get(countsUrl(harness.sourceA, '0,1,2'));
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body.counts).sort()).toEqual(['0', '1', '2']);
+    });
+  });
+
+  describe('writes', () => {
+    it('channel_0:write allows clearing channel 0', async () => {
+      (fakeManager as unknown as { clearChannelMessages?: unknown }).clearChannelMessages =
+        vi.fn().mockResolvedValue(3);
+      await harness.grant(harness.limited.id, 'channel_0', 'write', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.delete(chanUrl(harness.sourceA, 0));
+      expect(res.status).not.toBe(403);
+    });
+
+    it('read alone does not permit clearing', async () => {
+      await harness.grant(harness.limited.id, 'channel_0', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.delete(chanUrl(harness.sourceA, 0));
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/src/server/routes/meshcoreMessagingRoutes.ts
+++ b/src/server/routes/meshcoreMessagingRoutes.ts
@@ -16,7 +16,8 @@ import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
 import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.js';
-import { managerFor, VALIDATION, isValidPublicKey, isValidMessage, auditMeshcoreEvent } from './meshcoreRouteShared.js';
+import { managerFor, VALIDATION, isValidPublicKey, isValidMessage, auditMeshcoreEvent,
+  requireMeshcoreChannelAccess, canAccessMeshcoreChannel } from './meshcoreRouteShared.js';
 
 const router = Router({ mergeParams: true });
 
@@ -60,7 +61,7 @@ router.get('/messages', optionalAuth(), requirePermission('messages', 'read', { 
  * #4460), mirroring the Meshtastic `/api/messages/channel/:channel` endpoint.
  * `hasMore` in the response tells the client whether an older page exists.
  */
-router.get('/messages/channel/:idx', optionalAuth(), requirePermission('messages', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.get('/messages/channel/:idx', optionalAuth(), requireMeshcoreChannelAccess('read'), async (req: Request, res: Response) => {
   try {
     const idx = parseInt(req.params.idx, 10);
     if (isNaN(idx) || idx < 0) {
@@ -107,7 +108,7 @@ router.get('/messages/channel/:idx', optionalAuth(), requirePermission('messages
  * message timestamp per channel (`latestTimestamps`) for the unread indicator
  * (#3703) — channels with no messages are omitted from that map.
  */
-router.get('/messages/channel-counts', optionalAuth(), requirePermission('messages', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.get('/messages/channel-counts', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const raw = (req.query.channels as string | undefined) ?? '';
     const indices = raw
@@ -115,7 +116,26 @@ router.get('/messages/channel-counts', optionalAuth(), requirePermission('messag
       .map((s) => parseInt(s.trim(), 10))
       .filter((n) => Number.isInteger(n) && n >= 0);
     // De-dupe and cap to a sane number of channels per request.
-    const unique = Array.from(new Set(indices)).slice(0, 64);
+    const requested = Array.from(new Set(indices)).slice(0, 64);
+
+    // This endpoint takes a LIST, so a single all-or-nothing gate is wrong: a
+    // user who can read one channel would get a 403 for asking about several.
+    // Filter to the channels they may read and answer for those — an empty
+    // result leaks nothing.
+    const user = (req as Request & { user?: { id: number; isAdmin?: boolean } }).user;
+    if (!user) {
+      return res.status(401).json({ error: 'Authentication required', code: 'UNAUTHORIZED' });
+    }
+    const sourceId = typeof req.params.id === 'string' && req.params.id.length > 0
+      ? req.params.id
+      : undefined;
+    const unique = user.isAdmin
+      ? requested
+      : (await Promise.all(
+          requested.map(async (idx) =>
+            (await canAccessMeshcoreChannel(user.id, idx, 'read', sourceId)) ? idx : null),
+        )).filter((idx): idx is number => idx !== null);
+
     const manager = managerFor(req, res);
     const [counts, latestTimestamps] = unique.length > 0
       ? await Promise.all([
@@ -155,7 +175,7 @@ router.delete('/messages', requireAuth(), requirePermission('messages', 'write',
  * Clear every message on a channel index for this source (#3981). Registered
  * before /messages/:id so the two-segment path wins the route match.
  */
-router.delete('/messages/channel/:idx', requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.delete('/messages/channel/:idx', requireAuth(), requireMeshcoreChannelAccess('write'), async (req: Request, res: Response) => {
   try {
     const idx = parseInt(req.params.idx, 10);
     if (isNaN(idx) || idx < 0) {

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -293,3 +293,89 @@ export function isValidConnectionParams(params: {
   }
   return { valid: true };
 }
+
+/**
+ * Per-channel permission support for MeshCore channels (#4491 follow-up).
+ *
+ * MeshCore's channel routes originally gated on the global `messages`
+ * resource, while the channel *list* (`/api/channels/all`) gates on
+ * `channel_${idx}` like Meshtastic does. Granting a user "Public: Read" on a
+ * MeshCore source therefore made the channel appear with no messages in it —
+ * the list check passed and the message check did not.
+ *
+ * These helpers let the message routes honour `channel_${idx}` the way
+ * Meshtastic's `/api/messages/channel/:channel` does.
+ */
+
+/**
+ * RBAC resource for a channel slot, or null when the index has none.
+ * Only slots 0-7 exist as resources; MeshCore can carry higher indices, and
+ * those stay on the `messages` resource because there is nothing finer to
+ * check them against.
+ */
+export function channelResourceFor(idx: number): import('../../types/permission.js').ResourceType | null {
+  return Number.isInteger(idx) && idx >= 0 && idx <= 7
+    ? (`channel_${idx}` as import('../../types/permission.js').ResourceType)
+    : null;
+}
+
+/**
+ * True when `userId` may read/write MeshCore channel `idx` on `sourceId`.
+ *
+ * The check is deliberately a UNION of the per-channel resource and the legacy
+ * `messages` resource. Requiring `channel_${idx}` alone would be the tidier
+ * model, but it would silently revoke access from every existing install where
+ * a user has `messages` and no per-channel grant. Additive means the reported
+ * bug is fixed without anyone losing access they have today.
+ */
+export async function canAccessMeshcoreChannel(
+  userId: number,
+  idx: number,
+  action: 'read' | 'write',
+  sourceId?: string,
+): Promise<boolean> {
+  const resource = channelResourceFor(idx);
+  if (resource && await databaseService.checkPermissionAsync(userId, resource, action, sourceId)) {
+    return true;
+  }
+  return databaseService.checkPermissionAsync(userId, 'messages', action, sourceId);
+}
+
+/**
+ * Gate a `/messages/channel/:idx` route on that channel's permission.
+ *
+ * Must be mounted AFTER `optionalAuth()` (reads) or `requireAuth()` (writes) —
+ * both attach `req.user`, with `optionalAuth` falling back to the anonymous
+ * user, which is the case this whole helper exists to make work.
+ */
+export function requireMeshcoreChannelAccess(action: 'read' | 'write') {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const idx = parseInt(req.params.idx, 10);
+    if (!Number.isInteger(idx) || idx < 0) {
+      return res.status(400).json({ success: false, error: 'idx must be a non-negative integer' });
+    }
+
+    const user = (req as Request & { user?: { id: number; isAdmin?: boolean } }).user;
+    if (!user) {
+      return res.status(401).json({ error: 'Authentication required', code: 'UNAUTHORIZED' });
+    }
+    if (user.isAdmin) return next();
+
+    const sourceId = typeof req.params.id === 'string' && req.params.id.length > 0
+      ? req.params.id
+      : undefined;
+
+    if (await canAccessMeshcoreChannel(user.id, idx, action, sourceId)) {
+      return next();
+    }
+
+    return res.status(403).json({
+      error: 'Insufficient permissions',
+      code: 'FORBIDDEN',
+      // Name the per-channel resource when one exists — that is the grant the
+      // operator actually needs to make, and reporting `messages` here is what
+      // made this confusing to debug in the first place.
+      required: { resource: channelResourceFor(idx) ?? 'messages', action },
+    });
+  };
+}


### PR DESCRIPTION
Granting anonymous **"Public: Read"** on a MeshCore source showed the channel in the sidebar with **no messages in it**.

## Root cause

Two surfaces disagreed about which resource governs a MeshCore channel:

| Endpoint | Gated on | Anonymous result |
|---|---|---|
| `/api/channels/all` (channel list) | `channel_0` | **200** — channel appears |
| `/meshcore/messages/channel/0` | `messages` | **403** — no messages |

So the grant made the channel visible and its contents unreachable. Worse, the 403 named `messages` — a resource the operator was never asked to grant — which is what made it hard to place.

Meshtastic's `/api/messages/channel/:channel` has always gated on `channel_${n}`. MeshCore now matches.

## Why the check is a union, not a replacement

The tidier model is "`channel_${idx}` only". I didn't do that: it would **silently revoke access** from every existing install where a user holds `messages` and no per-channel grant. The check accepts either, so the bug is fixed without taking anything away from anyone.

## Three details

- **`channel-counts` filters instead of refusing.** It takes a list; an all-or-nothing gate meant asking about `0,1,2` with only channel 0 readable 403'd the whole request, hiding channel 0's badge too. It now returns counts for the readable subset, and an empty map rather than a 403.
- **Slots above 7 stay on `messages`** — only `channel_0`..`channel_7` exist as resources, so there is nothing finer to check against.
- **DMs stay on `messages`.** A channel grant must not expose private conversations. There's a test for exactly this.

## Verification

Reproduced and fixed against the **running dev container as a real anonymous user**, not just in tests:

| Before | After | Case |
|---|---|---|
| 403 | **200, messages returned** | channel 0 (anon holds `channel_0:read`) |
| 403 | **200, `counts={"0":…}`** | counts for `0,1,2` — 1 and 2 filtered out |
| 403 | **403, now names `channel_3`** | channel 3 (no grant) |
| 403 | **403** | DM list — correctly unchanged |

14 harness-based tests (real session + real `checkPermissionAsync`, per CLAUDE.md — a mocked permission lambda cannot catch a regression in the logic under test). Confirmed **7 of them fail against `main`**; the 7 that pass either way are the "still denies" and back-compat cases, which must hold before and after.

Full suite: **13,088 passed, 0 failed**. `lint:ci` and `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB