### PR TITLE
docs(automations): say the TRIGGER regex is case-sensitive too (#4507)

### DIFF
--- a/src/components/automations/AutomationBuilder.regexHint.test.tsx
+++ b/src/components/automations/AutomationBuilder.regexHint.test.tsx
@@ -10,7 +10,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import AutomationBuilder from './AutomationBuilder';
 import type { WorkflowForm } from './compile';
 
@@ -45,21 +45,40 @@ function renderWithStringOp(op: string) {
   );
 }
 
+/**
+ * Scope every assertion to the CONDITION block. The trigger's own "Text matches
+ * regex" field carries similar copy (#4507 follow-up), so a document-wide query
+ * matches two elements and these tests would pass or fail for the wrong reason.
+ */
+function conditionBlock() {
+  const block = screen.getByText('Operator').closest('.ae-block');
+  if (!block) throw new Error('condition block not found');
+  return within(block as HTMLElement);
+}
+
 describe('AutomationBuilder — string condition case guidance (#4507)', () => {
   it('always shows which operators ignore case', () => {
     renderWithStringOp('contains');
-    expect(screen.getByText(/ignore case/i)).toBeInTheDocument();
-    expect(screen.getByText(/case-sensitive/i)).toBeInTheDocument();
+    expect(conditionBlock().getByText(/ignore case/i)).toBeInTheDocument();
+    expect(conditionBlock().getByText(/case-sensitive/i)).toBeInTheDocument();
   });
 
   it('shows the (?i) hint when the operator is regex', () => {
     renderWithStringOp('regex');
-    expect(screen.getByText(/\(\?i\)/)).toBeInTheDocument();
+    expect(conditionBlock().getByText(/\(\?i\)/)).toBeInTheDocument();
   });
 
   it('does not show the (?i) hint for non-regex operators', () => {
     renderWithStringOp('contains');
-    expect(screen.queryByText(/\(\?i\)/)).not.toBeInTheDocument();
+    expect(conditionBlock().queryByText(/\(\?i\)/)).not.toBeInTheDocument();
+  });
+
+  it('the trigger carries its own regex hint, independent of the condition', () => {
+    // Guards the scoping above: if the trigger hint disappears, these tests
+    // must not silently start passing against the wrong element.
+    renderWithStringOp('contains');
+    expect(screen.getByText(/A regular expression matched against the message text/i))
+      .toHaveTextContent(/\(\?i\)/);
   });
 
   it('renders exactly one Value input whichever operator is selected', () => {

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -255,3 +255,24 @@ describe("condition.string regex case-sensitivity hint (#4507)", () => {
     expect(valueFields.filter((f) => fieldVisible(f, {}))).toHaveLength(1);
   });
 });
+
+describe("trigger.message regex case-sensitivity hint (#4507 follow-up)", () => {
+  const trigger = TRIGGERS.find((t) => t.type === 'trigger.message');
+  const field = (n: string) => trigger?.fields.find((f) => f.name === n);
+
+  it('warns that the trigger regex is case-sensitive', () => {
+    // The original #4507 fix only covered the `condition.string` block. The
+    // trigger's own regex field is the surface most users reach first, and it
+    // sits directly under "Text contains", which advertises itself as
+    // case-INsensitive — so saying nothing here reads as "same rules".
+    expect(field('regex')?.help).toMatch(/case-sensitive/i);
+    expect(field('regex')?.help).toMatch(/\(\?i\)/);
+    expect(field('regex')?.placeholder).toMatch(/\(\?i\)/);
+  });
+
+  it('still describes "Text contains" as case-insensitive', () => {
+    // Pins the contrast the new copy draws. If this ever becomes
+    // case-sensitive, the regex field's help becomes a lie.
+    expect(field('textContains')?.help).toMatch(/case-insensitive/i);
+  });
+});

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -89,7 +89,18 @@ export const TRIGGERS: BlockDef[] = [
     description: 'Fires when a text message arrives.',
     fields: [
       { name: 'textContains', label: 'Text contains', kind: 'text', placeholder: 'e.g. ping', help: 'Case-insensitive substring match. Leave blank to match any text.' },
-      { name: 'regex', label: 'Text matches regex', kind: 'text', placeholder: 'e.g. ^(test|ping)', advanced: true, help: 'A regular expression matched against the message text.' },
+      // The field directly above says "Case-insensitive substring match", so
+      // silence here reads as "same rules apply". It is not: messageMatchesFilter
+      // lower-cases both sides for textContains and matches the regex against
+      // raw text (triggerContext.ts). #4509 documented this on the
+      // `condition.string` block and missed the trigger, which is the surface
+      // most users actually reach for.
+      {
+        name: 'regex', label: 'Text matches regex', kind: 'text',
+        placeholder: 'e.g. (?i)^(test|ping)', advanced: true,
+        help: 'A regular expression matched against the message text. '
+          + 'Case-sensitive, unlike "Text contains" above — prefix with (?i) to ignore case, e.g. (?i)^(test|ping).',
+      },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', advanced: true, help: 'Match messages that arrive on ANY of these channels (unified by name across your sources). An OR-list — leave none to match any channel. When set, this overrides the single-channel fields below.' },
       { name: 'channelName', label: 'On channel (name)', kind: 'text', placeholder: 'any', advanced: true, help: 'Match by channel name (case-insensitive) — portable across sources where the same channel sits in a different slot. Preferred over the channel # below. Ignored when "On channels" above is set.' },
       { name: 'channel', label: 'On channel #', kind: 'number', placeholder: 'any', advanced: true, help: 'Match by raw channel index. Note: the same channel can be a different index on different sources — use the name above for cross-source automations. Ignored when "On channels" above is set.' },

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -212,6 +212,22 @@ describe('messageMatchesFilter', () => {
     expect(messageMatchesFilter(msg(), { from: 999 })).toBe(false);
     expect(messageMatchesFilter(msg(), { channel: 2 })).toBe(false);
   });
+  it('matches regex case-SENSITIVELY, unlike textContains (#4507 follow-up)', () => {
+    // These two fields sit next to each other in the trigger form and disagree
+    // about casing. The regex field's help text now says so; this pins the
+    // behaviour that claim rests on.
+    expect(messageMatchesFilter(msg({ text: 'PING' }), { textContains: 'ping' })).toBe(true);
+    expect(messageMatchesFilter(msg({ text: 'PING' }), { regex: '^(test|ping)' })).toBe(false);
+  });
+
+  it('honours an inline (?i) flag on the trigger regex (#4507 follow-up)', () => {
+    // Only true because the engine compiles with RE2 (src/utils/safeRegex.ts);
+    // stock JS RegExp rejects inline flags outright. If the engine is ever
+    // swapped, this fails and the help text stops being true.
+    expect(messageMatchesFilter(msg({ text: 'PING' }), { regex: '(?i)^(test|ping)' })).toBe(true);
+    expect(messageMatchesFilter(msg({ text: 'pong' }), { regex: '(?i)^(test|ping)' })).toBe(false);
+  });
+
   it('matches textContains case-insensitively', () => {
     expect(messageMatchesFilter(msg({ text: 'PING me' }), { textContains: 'ping' })).toBe(true);
     expect(messageMatchesFilter(msg({ text: 'hello' }), { textContains: 'ping' })).toBe(false);


### PR DESCRIPTION
You were right that #4507 wasn't visible — **I fixed the wrong surface.**

#4509 put the casing note on the `condition.string` block, which only appears once you add a condition. The field people actually reach first is the trigger's own **"Text matches regex"**, and that had no hint at all.

Worse, it sits **directly beneath "Text contains"**, whose help says *"Case-insensitive substring match."* Silence on the regex field reads as "same rules apply" — and they don't:

```js
// triggerContext.ts — messageMatchesFilter()
text.toLowerCase().includes(params.textContains.toLowerCase())  // insensitive
compileUserRegex(params.regex).test(text)                        // SENSITIVE
```

## The change

Same note and `(?i)` workaround as the condition block, plus a placeholder that shows it:

> A regular expression matched against the message text. **Case-sensitive, unlike "Text contains" above** — prefix with `(?i)` to ignore case, e.g. `(?i)^(test|ping)`.

## Test fix worth reviewing

The #4509 render tests asserted on the **whole document**. With a second legitimate source of `(?i)` on screen they matched two elements and failed outright — the full suite caught it. They now scope to the condition block, and there's a new test asserting the trigger hint exists *separately*, so the scoping cannot quietly start passing against the wrong element.

## Verification

Two evaluator tests pin what the copy claims, rather than trusting the read:

| Input | Filter | Result |
|---|---|---|
| `PING` | `textContains: ping` | matches |
| `PING` | `regex: ^(test\|ping)` | **does not match** |
| `PING` | `regex: (?i)^(test\|ping)` | matches |

The last is only true because the engine compiles with RE2 — stock JS `RegExp` rejects inline flags — so that test also guards the engine choice.

Confirmed rendering in the running dev container:

```
help       : A regular expression matched against the message text. Case-sensitive,
             unlike "Text contains" above — prefix with (?i) to ignore case, …
placeholder: e.g. (?i)^(test|ping)
```

Full suite: **13,094 passed, 0 failed**. `lint:ci` and `tsc` clean. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB