### PR TITLE
chore(release): open 4.14.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.13.3-rc6",
+  "version": "4.14.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.13.3-rc6",
+  "version": "4.14.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.13.3-rc6
-appVersion: "4.13.3-rc6"
+version: 4.14.0
+appVersion: "4.14.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc6",
+  "version": "4.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.13.3-rc6",
+      "version": "4.14.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.13.3-rc6",
+  "version": "4.14.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump only — no code changes.

## Why a minor, not another 4.13.3 rc

Since **v4.13.2**: 50 commits — **13 `feat`**, 17 `fix`, 16 `chore`, 3 `docs`, 1 `ci`. No `BREAKING CHANGE` markers, no `!:` commits. Thirteen features on a *patch* number is the wrong shape.

The features aren't incidental:

- **Analyzer Observer (#4457)** — a new subsystem across three phases (backend, publisher service, UI)
- **Navigation overhaul (#4473)** — unified per-source nav + Meshtastic phone bottom bar. Every user sees this on first launch.
- **Admin ACK outcomes + opt-in auto-retry (#4487/#4492)** — new behaviour and new settings
- Position provenance/accuracy on Node Details (#4432, #4498)
- MeshCore SNR/RSSI on messages (#4504), discovery results (#4516)
- Packet Monitor type-to-filter (#4512)

Plus infrastructure users will feel: **better-sqlite3 12 → 13** (N-API rework of the database driver) and **MeshCore per-channel permission semantics** (#4537 — additive, but grants behave differently).

## It also unblocks a promise already made

Four docs say the v1 root paths are **removed in 4.14** — `api-reference.md`, `API.md`, `REST_API.md` (*"These paths will be REMOVED in 4.14. Migrate before upgrading."*) and `API_REFERENCE.md`. Those paths are still live and still emitting `Warning: 299`.

**#4189** removes them and has been held specifically until 4.14 opened. It is now unblocked — but merging it is a **separate decision** and is deliberately not part of this PR, because it turns 4.14.0 into a release that removes public API endpoints.

## Changes

| File | |
|---|---|
| `package.json` | 4.13.3-rc6 → **4.14.0** |
| `package-lock.json` | regenerated (`--package-lock-only`) |
| `helm/meshmonitor/Chart.yaml` | `version` + `appVersion` |
| `desktop/src-tauri/tauri.conf.json` | |
| `desktop/package.json` | |

Lockfile diff is the **two version entries only** — no dependency churn. `git grep 4.13.3-rc6` is clean outside the changelog.

## Note

This sets the version to a bare `4.14.0`, as asked — not `4.14.0-rc1`. If you'd rather stabilise through release candidates first (the 4.13.x line ran to rc6), that's a one-word change here before merge.

Per the release convention, this carries the `system-test` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB