### PR TITLE
docs(blog): v4.14.0 release announcement

### DIFF
--- a/docs/blog/2026-08-03-v4.14.0-release.md
+++ b/docs/blog/2026-08-03-v4.14.0-release.md
@@ -1,0 +1,109 @@
+---
+id: news-2026-08-03-v4-14-0-release
+title: MeshMonitor v4.14.0 - Analyzer Observer, Unified Navigation & the v1 API Cleanup
+date: '2026-08-03T18:00:00Z'
+category: release
+priority: critical
+minVersion: 4.14.0
+tags: [release, meshcore, analyzer-observer, navigation, api, breaking-change]
+---
+
+MeshMonitor **v4.14.0** is a bigger release than the version number jump suggests. The headline is the **MeshCore Analyzer Observer** — publish what your Companion hears to a regional analyzer without a second app fighting for the serial port. Alongside it: **one navigation system** across Meshtastic and MeshCore sources, **admin commands that tell you what actually happened**, and a lot more signal detail on MeshCore messages.
+
+It also removes the deprecated v1 API root paths on the schedule we published in 4.13. **If you have scripts hitting `/api/v1/nodes?sourceId=…`, read the breaking-change section before upgrading.**
+
+## ⚠️ Breaking: the v1 API root paths are gone
+
+4.13 moved the v1 mesh-data endpoints under `/api/v1/sources/{sourceId}/…` and kept the old root paths alive for one release, answering with a `Warning: 299` header. That grace period ends here.
+
+**These paths now return 404:**
+
+```
+/api/v1/nodes            /api/v1/telemetry        /api/v1/network
+/api/v1/messages         /api/v1/traceroutes      /api/v1/status
+/api/v1/channels         /api/v1/packets          /api/v1/position-history
+```
+
+**Migrate by moving the source into the path:**
+
+```bash
+# Before (4.13, deprecated)
+curl -H "Authorization: Bearer mm_v1_…" \
+  "https://your-host/api/v1/nodes?sourceId=abc123"
+
+# After (4.14)
+curl -H "Authorization: Bearer mm_v1_…" \
+  "https://your-host/api/v1/sources/abc123/nodes"
+```
+
+Don't know your source id? `GET /api/v1/sources` lists them — or use the literal `default` to target your primary source: `/api/v1/sources/default/nodes`.
+
+The `/api/upgrade/*` endpoints, which had been returning `410 Gone` since 4.13, are also removed.
+
+If you're unsure whether anything still calls the old paths, upgrade a test instance first and watch for 404s in your logs. The [v1 source-scoping announcement](/blog/2026-07-13-v1-api-source-scoping) has the full migration guide.
+
+## MeshCore Analyzer Observer
+
+Regional MeshCore analyzers (FL Mesh, LetsMesh, and compatible brokers) build their coverage maps from observer nodes. Running one used to mean a second application competing with MeshMonitor for your Companion's serial port.
+
+Now MeshMonitor can be the observer. Point it at a MeshCore-Analyzer-compatible MQTT broker and every packet your Companion hears gets relayed, so your node shows up on the regional analyzer.
+
+**It is observation-only, deliberately:** MeshMonitor never subscribes to the broker, never injects broker traffic back onto your mesh, and never transmits on your behalf. It publishes what the radio already heard — nothing more.
+
+Full setup lives in [MeshCore Analyzer Observer](/features/meshcore-analyzer-observer).
+
+## One navigation system
+
+Meshtastic and MeshCore sources used to ship two separately-built navigations that didn't share a design, so a fix to one never reached the other. On a phone the MeshCore bar in particular crushed eleven items into roughly 35px each and ellipsised every label down to a few characters.
+
+Both now use the same navigation component:
+
+- **On phones**, a bottom bar that **scrolls sideways with readable labels**. Items size to their content instead of being split evenly — the thing that made labels unreadable before. Edge fades show there's more to scroll.
+- **On desktop**, the familiar rail, with the same behaviour on both source types.
+- **iOS PWA** users get proper safe-area handling, so the bar clears the home indicator instead of sitting under it.
+
+If you use MeshMonitor on a phone, this is the change you'll notice first.
+
+## Admin commands that tell you the truth
+
+Remote admin used to collapse every non-success into one vague failure.
+
+- **Distinct ACK outcomes.** A command that was *rejected* by the node now reads differently from one that *timed out* — different problems, different fixes.
+- **Opt-in auto-retry.** Turn it on and a retryable failure is retried automatically with a linear backoff, with the attempt count and delay configurable in Settings.
+- **Commands survive the HTTP request.** Remote-admin commands, session-passkey operations and config import no longer die if the browser navigates away mid-flight.
+- Admin messages are now sent at **the node's configured hop limit** rather than a hardcoded default.
+
+## MeshCore signal detail
+
+- **SNR and RSSI on directly-received messages.** A message that arrived zero-hop now shows how well you heard it, right in the conversation.
+- **"Discover Nodes" shows its results.** Instead of a toast saying "7 contacts returned (2 new)", you get the list: each responder's name, a public-key snippet, and **SNR in both directions** — how well you hear them *and* how well they hear you. New nodes are badged.
+- **Per-channel permissions actually work.** Granting a user read access to a specific MeshCore channel now does what it says. Previously the channel appeared in the sidebar with no messages in it, because the list and the messages were checking different permissions.
+- **Replies land on the right contact.** Trace Path, Neighbours, Ping and the rest no longer paint a late reply onto whichever contact you switched to while waiting.
+
+## Node details you can trust
+
+- **Position provenance and accuracy.** Node Details now shows where a position came from and how precise it is, with the **source named on the badge** — GPS, fixed, or estimated. A dot on the map is only as good as its origin, and now you can see it.
+- **Null Island estimates** are no longer presented as real positions.
+
+## Packet Monitor: type to filter
+
+The `from_node` and last-hop filters were native dropdowns with one entry per node. On a large mesh that's a very long scroll, and on mobile a native select gives you no way to type-to-jump at all.
+
+Both are now **searchable comboboxes**. Type any part of a name — or the hex node id you're reading off the packet table — and the list narrows as you go. Full keyboard support, and it works on a phone.
+
+## Also in this release
+
+- **Automations:** the "On channels" filter now matches the Primary/unnamed channel correctly, and the builder says which text operators ignore case — plus how to make a regex case-insensitive.
+- **Messaging:** loading older messages no longer yanks you back to the bottom, and MeshCore channel history preserves hop/route/scope detail.
+- **PWA:** notification taps deep-link to the right source.
+- **`GET /stats`** no longer 500s when `sourceId` is omitted.
+- **better-sqlite3 13.** The database driver moved to a major version built on N-API. Verified at runtime on amd64, arm64 and armv7 before shipping.
+- Plus the usual dependency updates and polish. The [full changelog](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md) has every entry.
+
+## Upgrading
+
+Standard upgrade — no migration steps beyond the API change above. The database schema migrates automatically on first boot.
+
+If you script against the REST API, **check for the deprecated root paths before you upgrade**. Everything else is drop-in.
+
+As always, most of what's here started as a detailed bug report or a feature request. Thank you — keep them coming.


### PR DESCRIPTION
Release announcement for **v4.14.0**. Docs-only — no application code touched.

## Structure

It **leads with the breaking change** instead of burying it under the feature tour. The v1 root-path removal (#4189) is the one thing in this release that can break a working install, so it gets the top slot with a before/after `curl`, the full list of the nine dead paths, and the `default` source alias for anyone who doesn't want to look up source ids.

Then the features, ordered by how many people they affect:

1. **Analyzer Observer** (#4457) — the headline
2. **Unified navigation** (#4473) — the thing phone users notice first
3. **Admin ACK outcomes + auto-retry** (#4487/#4492)
4. **MeshCore signal detail** — SNR/RSSI on messages, discovery results, per-channel permissions
5. **Position provenance** (#4432/#4498)
6. **Packet Monitor type-to-filter** (#4512)

## Accuracy

Claims were checked against the merged code rather than commit titles:

- The nine removed paths match the actual mounts deleted from `v1/index.ts`
- The `default` alias is real — it has its own suite (`sourceParam.defaultAlias.test.ts`)
- `upgradeRoutes.ts` is confirmed deleted
- The Analyzer Observer description follows `docs/features/meshcore-analyzer-observer.md`, including the observation-only guarantees (never subscribes, never injects, never transmits)

## Build

- `npm run docs:build` succeeds; the post renders (`2026-08-03-v4.14.0-release.html`)
- Both internal links resolve — `/blog/2026-07-13-v1-api-source-scoping` and `/features/meshcore-analyzer-observer`
- `npm run docs:news` picks it up (`lastUpdated=2026-08-03T18:00:00Z`), so it reaches the in-app News feed. `docs/public/news.json` is build-generated and untracked, so nothing to commit there.

Frontmatter uses `priority: critical` — the only other posts at that level are breaking-change announcements, which this is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9NzRtqE8eSMS8tvAeodUB