### PR TITLE
fix(admin): stop implying remote favorite/ignored status is known (#4511)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3912,6 +3912,9 @@
   "admin_commands.already_ignored": "Already Ignored",
   "admin_commands.set_as_ignored": "Set as Ignored",
   "admin_commands.remove_ignored": "Remove Ignored",
+  "admin_commands.remote_status_unknown": "current status unknown",
+  "admin_commands.remote_status_from_session": "(from this session's commands, not a readback)",
+  "admin_commands.remote_status_readback_note": "Remote target: the admin protocol has no query that returns a node's favorite or ignored list, so MeshMonitor can set and clear these flags but cannot read the device's current state. Any status shown above comes from commands sent in this session.",
   "admin_commands.firmware_requirement_note": "Note: These commands require firmware version 2.7.0 or higher. The target device must be selected in the \"Target Node\" section above.",
 
   "admin_commands.failed_load_owner_info": "Failed to load owner info",

--- a/src/components/AdminCommandsTab.remoteFavoriteStatus.test.tsx
+++ b/src/components/AdminCommandsTab.remoteFavoriteStatus.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #4511: the Remote Admin "Node Management" panel must not imply it knows a
+ * remote node's favorite/ignored state. The admin protocol has no query that
+ * reads those flags back (admin.proto only defines set/remove), so:
+ *
+ *  - with a remote admin target and nothing sent yet, the selected-node line
+ *    says the status is unknown, and the standing readback note renders;
+ *  - the node picker's Favorite/Ignored badges (which come from OUR node's DB)
+ *    are hidden while the target is remote — showing them there is the
+ *    mislabel bug from #950;
+ *  - with a local target nothing changes: badges show, no notes.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const h = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  showToast: vi.fn(),
+  apiPost: vi.fn(),
+  apiSendAdminCommand: vi.fn(),
+}));
+
+// `t` MUST be a stable reference across renders — see the note in
+// AdminCommandsTab.txDisabled.test.tsx; a fresh identity loops forever.
+vi.mock('react-i18next', () => {
+  const t = (_key: string, fallback?: string | Record<string, unknown>) => (typeof fallback === 'string' ? fallback : _key);
+  return { useTranslation: () => ({ t }) };
+});
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: h.invalidateQueries }),
+}));
+
+vi.mock('./ToastContainer', () => ({ useToast: () => ({ showToast: h.showToast }) }));
+vi.mock('../hooks/useResolvedSourceId', () => ({ useResolvedSourceId: () => 'source-1' }));
+vi.mock('../hooks/useTxStatus', () => ({ useTxStatus: () => ({ isTxDisabled: false }) }));
+
+vi.mock('../services/api', () => ({
+  default: {
+    setBaseUrl: vi.fn(),
+    post: h.apiPost,
+    sendAdminCommand: h.apiSendAdminCommand,
+    exportChannel: vi.fn(),
+    importChannel: vi.fn(),
+    getAllChannels: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('./SectionNav', () => ({ default: () => null }));
+vi.mock('./configuration/ImportConfigModal', () => ({ ImportConfigModal: () => null }));
+vi.mock('./configuration/ExportConfigModal', () => ({ ExportConfigModal: () => null }));
+vi.mock('./admin-commands/ModuleConfigurationSection', () => ({ ModuleConfigurationSection: () => null }));
+vi.mock('./admin-commands/AutoFavoriteManagementSection', () => ({ default: () => null }));
+vi.mock('./admin-commands/DeviceConfigurationSection', () => ({ DeviceConfigurationSection: () => null }));
+
+import AdminCommandsTab from './AdminCommandsTab';
+
+const LOCAL_NODE_ID = '!00000064';
+const localNode = {
+  nodeNum: 100,
+  user: { id: LOCAL_NODE_ID, longName: 'Local Node', shortName: 'LOC1' },
+  isFavorite: true,
+};
+const remoteNode = {
+  nodeNum: 200,
+  user: { id: '!000000c8', longName: 'Remote Node', shortName: 'REM1' },
+  isIgnored: true,
+};
+
+/** Open the Node Management section so its controls are in the DOM. */
+function expandNodeManagement() {
+  localStorage.setItem('adminCommandsExpandedSections', JSON.stringify({ 'admin-node-management': true }));
+}
+
+/** Pick the admin *target* (which device we send commands to). */
+function selectAdminTarget(name: string) {
+  const input = screen.getByPlaceholderText('Local Node');
+  fireEvent.focus(input);
+  fireEvent.click(screen.getByText(name));
+}
+
+/** Pick the node the favorite/ignore command acts on. */
+function selectManagedNode(name: string) {
+  const input = screen.getByPlaceholderText('admin_commands.search_node_to_manage');
+  fireEvent.focus(input);
+  fireEvent.click(screen.getByText(name));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  h.apiPost.mockResolvedValue({});
+  h.apiSendAdminCommand.mockResolvedValue({});
+});
+
+describe('AdminCommandsTab — remote favorite/ignored status is not readable (#4511)', () => {
+  it('marks the status unknown and renders the readback note when the admin target is remote', async () => {
+    expandNodeManagement();
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    selectAdminTarget('Remote Node');
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.remote_status_readback_note')).toBeInTheDocument();
+    });
+
+    selectManagedNode('Remote Node');
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.remote_status_unknown')).toBeInTheDocument();
+    });
+    // Nothing was sent this session, so the "from this session" wording must
+    // not appear -- it would read as a confirmed state.
+    expect(screen.queryByText("admin_commands.remote_status_from_session")).not.toBeInTheDocument();
+  });
+
+  it('hides the local-DB Favorite/Ignored badges in the node picker while the target is remote', async () => {
+    expandNodeManagement();
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    selectAdminTarget('Remote Node');
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.remote_status_readback_note')).toBeInTheDocument();
+    });
+
+    // Open the management picker; local node is a favorite and remote node is
+    // ignored in OUR DB -- neither badge describes the remote target's NodeDB.
+    fireEvent.focus(screen.getByPlaceholderText('admin_commands.search_node_to_manage'));
+    expect(screen.queryByText('admin_commands.favorite')).not.toBeInTheDocument();
+    expect(screen.queryByText('admin_commands.ignored')).not.toBeInTheDocument();
+  });
+
+  it('keeps local-target behaviour unchanged: badges show, no readback notes', async () => {
+    expandNodeManagement();
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    // Default target is the local node -- no target switch needed.
+    selectManagedNode('Local Node');
+
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.favorite')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('admin_commands.remote_status_unknown')).not.toBeInTheDocument();
+    expect(screen.queryByText('admin_commands.remote_status_readback_note')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AdminCommandsTab.remoteFavoriteStatus.test.tsx
+++ b/src/components/AdminCommandsTab.remoteFavoriteStatus.test.tsx
@@ -131,6 +131,30 @@ describe('AdminCommandsTab — remote favorite/ignored status is not readable (#
     expect(screen.queryByText('admin_commands.ignored')).not.toBeInTheDocument();
   });
 
+  it('switches to the "from this session" wording once a favorite command is acked', async () => {
+    // The optimistic remoteNodeStatus entry is the only thing that can ever
+    // populate a remote target's status — assert the acked path lands there
+    // rather than leaving the line stuck on "unknown".
+    h.apiSendAdminCommand.mockResolvedValue({ success: true, message: 'ok', ack: { acked: true, timedOut: false } });
+    expandNodeManagement();
+    render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);
+
+    selectAdminTarget('Remote Node');
+    selectManagedNode('Remote Node');
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.remote_status_unknown')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('admin_commands.set_as_favorite'));
+
+    await waitFor(() => {
+      expect(screen.getByText('admin_commands.remote_status_from_session')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('admin_commands.remote_status_unknown')).not.toBeInTheDocument();
+    // The badge itself is the optimistic value, still not a readback.
+    expect(screen.getByText('admin_commands.favorite')).toBeInTheDocument();
+  });
+
   it('keeps local-target behaviour unchanged: badges show, no readback notes', async () => {
     expandNodeManagement();
     render(<AdminCommandsTab nodes={[localNode, remoteNode]} currentNodeId={LOCAL_NODE_ID} channels={[]} />);

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -3515,7 +3515,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                       <div style={{ fontWeight: '500', color: 'var(--ctp-text)', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
                         <span>{node.longName}</span>
                         {node.isLocal && <span style={{ color: 'var(--ctp-blue)', fontSize: '0.85rem' }}>({t('admin_commands.local_node_indicator')})</span>}
-                        {node.isFavorite && (
+                        {/* These badges come from OUR node's DB. While the admin
+                            target is a remote device they describe the wrong
+                            device, so hide them rather than mislabel remote
+                            state (#4511, the display bug behind #950). */}
+                        {!isManagingRemoteNode && node.isFavorite && (
                           <span style={{ 
                             backgroundColor: 'var(--ctp-yellow)', 
                             color: 'var(--ctp-base)', 
@@ -3527,9 +3531,9 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                             <UiIcon name="favorite" /> {t('admin_commands.favorite')}
                           </span>
                         )}
-                        {node.isIgnored && (
-                          <span style={{ 
-                            backgroundColor: 'var(--ctp-red)', 
+                        {!isManagingRemoteNode && node.isIgnored && (
+                          <span style={{
+                            backgroundColor: 'var(--ctp-red)',
                             color: 'var(--ctp-base)', 
                             padding: '0.125rem 0.5rem', 
                             borderRadius: '4px', 
@@ -3555,22 +3559,38 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           </div>
           {nodeManagementNodeNum !== null && (() => {
             const selectedNode = nodeOptions.find(n => n.nodeNum === nodeManagementNodeNum);
-            // When managing a remote node, only use remote status (don't fall back to local status)
-            // When managing local node, use local status from nodeOptions
-            const remoteStatus = isManagingRemoteNode ? remoteNodeStatus.get(nodeManagementNodeNum) : null;
-            const isFavorite = isManagingRemoteNode 
-              ? (remoteStatus?.isFavorite ?? false)  // Remote: only use remote status, default to false
-              : (selectedNode?.isFavorite ?? false);  // Local: use local status
-            const isIgnored = isManagingRemoteNode 
-              ? (remoteStatus?.isIgnored ?? false)    // Remote: only use remote status, default to false
-              : (selectedNode?.isIgnored ?? false);   // Local: use local status
+            // Favorite/ignored live in the *target* device's own NodeDB, and the
+            // admin protocol has no query that reads them back (#4511). So for a
+            // remote target the only honest source is what this session has sent
+            // (remoteNodeStatus, set optimistically by the handlers above) —
+            // and "unknown" until the user sends something. A local target reads
+            // straight from our own DB, which is authoritative.
+            const remoteStatus = isManagingRemoteNode ? remoteNodeStatus.get(nodeManagementNodeNum) : undefined;
+            const isFavorite = isManagingRemoteNode
+              ? (remoteStatus?.isFavorite ?? false)
+              : (selectedNode?.isFavorite ?? false);
+            const isIgnored = isManagingRemoteNode
+              ? (remoteStatus?.isIgnored ?? false)
+              : (selectedNode?.isIgnored ?? false);
+            const favoriteBadge = <span style={{ color: 'var(--ctp-yellow)' }}><UiIcon name="favorite" /> {t('admin_commands.favorite')}</span>;
+            const ignoredBadge = <span style={{ color: 'var(--ctp-red)', marginLeft: '0.5rem' }}><UiIcon name="blocked" /> {t('admin_commands.ignored')}</span>;
             return (
               <div style={{ marginTop: '0.75rem', fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
                 {t('admin_commands.selected')}: {selectedNode?.longName || t('admin_commands.node_fallback', { nodeNum: nodeManagementNodeNum })}
-                {(isFavorite || isIgnored) && (
+                {isManagingRemoteNode ? (
                   <span style={{ marginLeft: '0.5rem' }}>
-                    {isFavorite && <span style={{ color: 'var(--ctp-yellow)' }}><UiIcon name="favorite" /> {t('admin_commands.favorite')}</span>}
-                    {isIgnored && <span style={{ color: 'var(--ctp-red)', marginLeft: '0.5rem' }}><UiIcon name="blocked" /> {t('admin_commands.ignored')}</span>}
+                    {isFavorite && favoriteBadge}
+                    {isIgnored && ignoredBadge}
+                    <span style={{ marginLeft: '0.5rem', fontStyle: 'italic' }}>
+                      {remoteStatus
+                        ? t('admin_commands.remote_status_from_session')
+                        : t('admin_commands.remote_status_unknown')}
+                    </span>
+                  </span>
+                ) : (isFavorite || isIgnored) && (
+                  <span style={{ marginLeft: '0.5rem' }}>
+                    {isFavorite && favoriteBadge}
+                    {isIgnored && ignoredBadge}
                   </span>
                 )}
               </div>
@@ -3680,6 +3700,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             })()}
           </div>
         </div>
+        {isManagingRemoteNode && (
+          <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext1)', fontStyle: 'italic' }}>
+            {t('admin_commands.remote_status_readback_note')}
+          </p>
+        )}
         <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext1)', fontStyle: 'italic' }}>
           {t('admin_commands.firmware_requirement_note')}
         </p>


### PR DESCRIPTION
Closes #4511.

## Problem

The Remote Admin **Node Management** panel could not show a remote node's favorite/ignored state, and never said so.

`AdminMessage` defines only `set_favorite_node` / `remove_favorite_node` / `set_ignored_node` / `remove_ignored_node` (`protobufs/meshtastic/admin.proto:407,412,448,453`). There is no admin query that returns a node's favorite or ignored list, so the panel rendered an empty status line — which reads as "not favorited" rather than "unknown".

Worse, the node picker still rendered Favorite/Ignored badges taken from **our** node's DB while the admin target was a remote device. That is the same mislabel #950 removed from the selected-node line but left in the dropdown.

## Correction to the issue's triage

The issue calls `remoteNodeStatus` dead state. It is not — `setRemoteNodeStatus` is called at four sites (`AdminCommandsTab.tsx:1544/1585/1629/1670`) as an optimistic update after a non-rejected set/remove. It is kept, and it is what backs the new "from this session" wording.

## Changes

- Hide the picker's Favorite/Ignored badges while the admin target is remote.
- Selected-node line says `current status unknown` for a remote target until this session sends a command, then marks the status `(from this session's commands, not a readback)`.
- Standing note under the favorite/ignored controls explaining the protocol limit.
- Local-target behaviour is unchanged: badges show, no notes.

Three new `admin_commands.*` keys in `public/locales/en.json` (en-only, matching recent convention).

## Testing

- New `src/components/AdminCommandsTab.remoteFavoriteStatus.test.tsx` — 3 cases: unknown-status + note on a remote target, picker badges hidden on a remote target, local target unchanged.
- `AdminCommandsTab` suites: 9/9 pass, `success: true`.
- Full Vitest suite: 13092 passed / 1 failed — the failure is `EmbedMap.test.tsx` "marks a segment MQTT via isMqtt", unrelated to this change and passing on its own (14/14); flaky under parallel load.
- `tsc --noEmit` clean; `npm run lint:ci` gate clean (no in-repo FAILs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX