### PR TITLE
Fix: hot-swap Analyzer Observer publisher on signing-key change

### DIFF
--- a/src/server/routes/sourceObserverRoutes.test.ts
+++ b/src/server/routes/sourceObserverRoutes.test.ts
@@ -35,6 +35,7 @@ const UNCLAMPED_PRIV = '00'.repeat(31) + 'ff' + '00'.repeat(32);
 
 const mockSourceRegistry = vi.hoisted(() => ({
   getManager: vi.fn(),
+  reconfigureObserver: vi.fn(),
 }));
 vi.mock('../sourceManagerRegistry.js', () => ({
   sourceManagerRegistry: mockSourceRegistry,
@@ -82,6 +83,8 @@ describe('sourceObserverRoutes', () => {
 
     mockSourceRegistry.getManager.mockReset();
     mockSourceRegistry.getManager.mockReturnValue(undefined);
+    mockSourceRegistry.reconfigureObserver.mockReset();
+    mockSourceRegistry.reconfigureObserver.mockResolvedValue(true);
     setMeshCoreObserverKeyStoreForTesting(new MeshCoreObserverKeyStore('test-secret', true));
   });
 
@@ -217,6 +220,47 @@ describe('sourceObserverRoutes', () => {
 
     const getRes = await agent.get(`/api/sources/${SOURCE_ID}/observer/key`);
     expect(getRes.body.data.stored).toBe(false);
+  });
+
+  // ── Publisher hot-swap on key change (#4543) ────────────────────────────
+
+  it('PUT /key hot-swaps the running observer publisher so it picks up the new key', async () => {
+    const agent = await agentFor();
+    const res = await agent.put(`/api/sources/${SOURCE_ID}/observer/key`).send({ privateKey: PRIV });
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledTimes(1);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledWith(SOURCE_ID, undefined);
+  });
+
+  it('POST /key/import hot-swaps the running observer publisher so it picks up the new key', async () => {
+    mockSourceRegistry.getManager.mockReturnValue({
+      sourceType: 'meshcore',
+      exportPrivateKey: vi.fn().mockResolvedValue(PRIV),
+    });
+    const agent = await agentFor();
+    const res = await agent.post(`/api/sources/${SOURCE_ID}/observer/key/import`);
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledTimes(1);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledWith(SOURCE_ID, undefined);
+  });
+
+  it('DELETE /key hot-swaps the running observer publisher after clearing the key', async () => {
+    const agent = await agentFor();
+    await agent.put(`/api/sources/${SOURCE_ID}/observer/key`).send({ privateKey: PRIV });
+    mockSourceRegistry.reconfigureObserver.mockClear();
+
+    const res = await agent.delete(`/api/sources/${SOURCE_ID}/observer/key`);
+    expect(res.status).toBe(200);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledTimes(1);
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalledWith(SOURCE_ID, undefined);
+  });
+
+  it('a failing reconfigureObserver does not break the key-store response (best-effort)', async () => {
+    mockSourceRegistry.reconfigureObserver.mockRejectedValueOnce(new Error('boom'));
+    const agent = await agentFor();
+    const res = await agent.put(`/api/sources/${SOURCE_ID}/observer/key`).send({ privateKey: PRIV });
+    expect(res.status).toBe(200);
+    expect(res.body.data.stored).toBe(true);
   });
 
   it('non-meshcore source -> 400 INVALID_PARAMETER on every route', async () => {

--- a/src/server/routes/sourceObserverRoutes.ts
+++ b/src/server/routes/sourceObserverRoutes.ts
@@ -39,6 +39,32 @@ const router = Router({ mergeParams: true });
 const HEX_128 = /^[0-9a-fA-F]{128}$/;
 
 /**
+ * Hot-swap the running Analyzer Observer publisher (if any) so it re-mints
+ * against the signing key that was just stored/cleared, without requiring
+ * the operator to disable/re-enable the whole source (#4543). The publisher
+ * only mints a token at `start()` and on its renewal timer — a key written
+ * to the store after the publisher is already up (e.g. `configured: true,
+ * keyStored: false` at boot) is otherwise never picked up until the source
+ * itself restarts. Passes the source's own unchanged `observer` block
+ * through `reconfigureObserver` purely to trigger the stop/restart; this is
+ * a no-op on config, matching the hot-swap branch in `sourceRoutes.ts`'s PUT
+ * handler. Best-effort: a source with no registered manager (or a manager
+ * type without `reconfigureObserver`) just resolves to `false` — the key is
+ * still stored either way.
+ */
+async function refreshObserverPublisher(source: Source): Promise<void> {
+  try {
+    const cfg = (source.config as Record<string, unknown> | undefined) ?? {};
+    await sourceManagerRegistry.reconfigureObserver(
+      source.id,
+      cfg.observer as Record<string, unknown> | undefined,
+    );
+  } catch (error) {
+    logger.warn(`Could not refresh Analyzer Observer publisher for source ${source.id}:`, error);
+  }
+}
+
+/**
  * Shared preamble for every route: look up the source and reject anything
  * that isn't a `meshcore` source. Writes the error response itself and
  * returns `null` so callers can `if (!source) return;`.
@@ -126,6 +152,7 @@ router.post(
 
       await store.store(source.id, hex, publicKey, 'device');
       auditMeshcoreEvent(req, 'meshcore_observer_key_import', 'configuration', { sourceId: source.id });
+      await refreshObserverPublisher(source);
       const status = await store.status(source.id);
       ok(res, status);
     } catch (error) {
@@ -175,6 +202,7 @@ router.put(
       const publicKey = await deriveObserverPublicKey(trimmed);
       await store.store(source.id, trimmed, publicKey, 'manual');
       auditMeshcoreEvent(req, 'meshcore_observer_key_set', 'configuration', { sourceId: source.id });
+      await refreshObserverPublisher(source);
       const status = await store.status(source.id);
       ok(res, status);
     } catch (error) {
@@ -199,6 +227,7 @@ router.delete(
       const store = getMeshCoreObserverKeyStore();
       await store.clear(source.id);
       auditMeshcoreEvent(req, 'meshcore_observer_key_clear', 'configuration', { sourceId: source.id });
+      await refreshObserverPublisher(source);
       const status = await store.status(source.id);
       ok(res, status);
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #4543 — importing (or manually setting, or clearing) the MeshCore Analyzer Observer signing key never woke up an already-running publisher, so it kept reporting `No observer signing key stored for this source` until the operator disabled and re-enabled the whole source.

- **Root cause:** `MeshCoreObserverPublisher` only mints a broker auth token in `start()` and on its hourly renewal timer. The key-management routes (`POST /key/import`, `PUT /key`, `DELETE /key` in `src/server/routes/sourceObserverRoutes.ts`) persisted the key to the credential store but never signaled the running publisher to retry — only a full source disable/re-enable rebuilds the manager and calls `start()` again.
- **Fix:** reuse the existing `sourceManagerRegistry.reconfigureObserver()` hot-swap (already used by the source-edit form when the observer's broker settings change: stop → re-derive config → restart if connected) after each key mutation. This restarts just the publisher — the Companion device connection is untouched — so it re-mints against the current key immediately.
- Best-effort: wrapped in try/catch so a source with no registered manager, or one whose manager doesn't support `reconfigureObserver`, doesn't affect the key-store response — the key write itself always succeeds independently.

## Test plan

- [x] Added `reconfigureObserver` to the mocked `sourceManagerRegistry` in `sourceObserverRoutes.test.ts` and asserted it's called (with the source's own unchanged `observer` config) after `PUT /key`, `POST /key/import`, and `DELETE /key`.
- [x] Added a test confirming a rejected `reconfigureObserver()` doesn't break the key-store response (best-effort semantics).
- [x] `npx vitest run src/server/routes/sourceObserverRoutes.test.ts src/server/routes/sourceRoutes.observerReconfigure.test.ts src/server/routes/sourceObserverRoutes.perSource.test.ts` — all 32 tests pass.
- [x] `npx tsc --noEmit` — no new errors.
- [x] `npx eslint` on touched files — clean.

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9XZ3NGYeM2PeuptomKr7Q)_