### PR TITLE
docs(site-gallery): add Norway Østlandet Mesh

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -106,6 +106,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Norway Østlandet Mesh
+- **URL**: [meshmonitor.vidda.uk](https://meshmonitor.vidda.uk/)
+- **Network**: Norway Østlandet Mesh
+- **Location**: Østlandet, Norway
+- **Description**: Public MeshMonitor instance monitoring Meshtastic networks across Østlandet, Norway.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary
- Adds the "Norway Østlandet Mesh" public MeshMonitor instance (https://meshmonitor.vidda.uk/) to `docs/site-gallery.md`, per the Site Gallery Submission workflow.

## Details
- Site URL: https://meshmonitor.vidda.uk
- Network: Norway Østlandet Mesh
- Location: Østlandet, Norway
- Contact: @wilhel1812

Closes #4545

## Test plan
- [x] Docs-only change; no code paths affected.
- [x] Verified the new entry follows the existing entry format (URL / Network / Location / Description) and that no duplicate entry for this site already existed in the file.

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMS4g1JtP4sfnsAJkZjHP7)_