### PR TITLE
fix: buffer DeviceMetadata that arrives before MyNodeInfo

### DIFF
--- a/src/server/meshtasticManager.bridgedNode.test.ts
+++ b/src/server/meshtasticManager.bridgedNode.test.ts
@@ -118,12 +118,18 @@ describe('MeshtasticManager - bridged node detection', () => {
       expect(manager.isLocalNodeBridged()).toBe(true);
     });
 
-    it('does nothing when localNodeInfo is not yet initialised', async () => {
+    it('buffers instead of applying when localNodeInfo is not yet initialised', async () => {
+      // The flags cannot be stored without an identity to hang them on, but
+      // dropping them lost bridged-node detection for the whole session. They
+      // are held until processMyNodeInfo() drains them — see
+      // meshtasticManager.deviceMetadataRace.test.ts.
       manager.localNodeInfo = null;
+      manager.pendingDeviceMetadata = null;
       await expect(
         manager.processDeviceMetadata({ hasWifi: false, hasEthernet: false })
       ).resolves.toBeUndefined();
       expect(manager.isLocalNodeBridged()).toBe(false);
+      expect(manager.pendingDeviceMetadata).toEqual({ hasWifi: false, hasEthernet: false });
     });
   });
 });

--- a/src/server/meshtasticManager.deviceMetadataRace.test.ts
+++ b/src/server/meshtasticManager.deviceMetadataRace.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Regression tests for the MyNodeInfo / DeviceMetadata race.
+ *
+ * The firmware sends MyNodeInfo and DeviceMetadata back-to-back in the same
+ * config-download burst, and MeshtasticManager processes inbound frames
+ * concurrently (packetConcurrencyLimit, default 4). DeviceMetadata could
+ * therefore overtake the DB awaits inside processMyNodeInfo() and find
+ * localNodeInfo still null.
+ *
+ * The old handler dropped the payload in that window. Because the DB write
+ * lives in the same branch, nodes.firmwareVersion also stayed null, so the next
+ * reconnect read the empty column back and the source showed
+ * "Firmware Version: Not Available" forever. The capability flags were lost the
+ * same way, mis-gating isLocalNodeBridged() and the OTA firmware-update UI.
+ *
+ * DeviceMetadata is now buffered and drained once local identity is known.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+const mockGetNode = vi.fn();
+const mockUpsertNodeAsync = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+    upsertNodeAsync: mockUpsertNodeAsync,
+    deleteNodeAsync: vi.fn().mockResolvedValue(undefined),
+    suppressGhostNodeAsync: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+      getSettingForSource: vi.fn((_sourceId: string, key: string) => mockGetSetting(key)),
+      setSettingForSource: vi.fn((_sourceId: string, key: string, value: string) => mockSetSetting(key, value)),
+    },
+    nodes: {
+      getNode: mockGetNode,
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      upsertNode: mockUpsertNodeAsync,
+    },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+}));
+
+const LOCAL_NODE_NUM = 0x11111111;
+const FIRMWARE = '2.7.11.abcdef';
+
+describe('MeshtasticManager - DeviceMetadata arriving before MyNodeInfo', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSetting.mockResolvedValue(null);
+    mockGetNode.mockResolvedValue(null);
+    mockUpsertNodeAsync.mockResolvedValue(undefined);
+
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+    manager.localNodeInfo = null;
+    manager.pendingDeviceMetadata = null;
+  });
+
+  it('buffers metadata that loses the race and applies it once MyNodeInfo lands', async () => {
+    // Hold every settings read so MyNodeInfo is parked inside its DB awaits,
+    // exactly where the real race window is.
+    let releaseDb!: () => void;
+    const dbGate = new Promise<void>((resolve) => { releaseDb = resolve; });
+    mockGetSetting.mockImplementation(async () => { await dbGate; return null; });
+
+    const myInfoDone = manager.processMyNodeInfo({ myNodeNum: LOCAL_NODE_NUM, rebootCount: 3 });
+
+    // DeviceMetadata overtakes MyNodeInfo — identity is not established yet.
+    await manager.processDeviceMetadata({
+      firmwareVersion: FIRMWARE,
+      hasWifi: true,
+      hasBluetooth: true,
+      hasEthernet: false,
+    });
+    expect(manager.localNodeInfo).toBeNull();
+    expect(manager.pendingDeviceMetadata).not.toBeNull();
+
+    releaseDb();
+    await myInfoDone;
+
+    expect(manager.localNodeInfo.firmwareVersion).toBe(FIRMWARE);
+    expect(manager.localNodeInfo.hasWifi).toBe(true);
+    expect(manager.localNodeInfo.hasEthernet).toBe(false);
+    expect(manager.isLocalNodeBridged()).toBe(false);
+    expect(manager.pendingDeviceMetadata).toBeNull();
+  });
+
+  it('persists the buffered firmware version so a reconnect does not read back an empty column', async () => {
+    await manager.processDeviceMetadata({ firmwareVersion: FIRMWARE, hasWifi: true });
+    expect(mockUpsertNodeAsync).not.toHaveBeenCalled();
+
+    await manager.processMyNodeInfo({ myNodeNum: LOCAL_NODE_NUM, rebootCount: 1 });
+
+    expect(mockUpsertNodeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ nodeNum: LOCAL_NODE_NUM, firmwareVersion: FIRMWARE }),
+      expect.anything(),
+    );
+  });
+
+  it('drains the buffer when MyNodeInfo takes the same-device reboot-merge path', async () => {
+    // Same physical device, new nodeNum: processMyNodeInfo returns early from
+    // the merge branch, so the drain cannot hang off the normal tail.
+    mockGetSetting.mockImplementation(async (key: string) => {
+      if (key.includes('localNodeNum')) return String(0x22222222);
+      if (key.includes('localNodeId')) return '!22222222';
+      if (key.includes('localDeviceId')) return 'aabbccdd';
+      return null;
+    });
+    mockGetNode.mockResolvedValue(null);
+
+    await manager.processDeviceMetadata({ firmwareVersion: FIRMWARE, hasWifi: true });
+
+    await manager.processMyNodeInfo({
+      myNodeNum: LOCAL_NODE_NUM,
+      rebootCount: 2,
+      deviceId: Buffer.from('aabbccdd', 'hex'),
+    });
+
+    expect(manager.localNodeInfo.nodeNum).toBe(LOCAL_NODE_NUM);
+    expect(manager.localNodeInfo.firmwareVersion).toBe(FIRMWARE);
+    expect(manager.pendingDeviceMetadata).toBeNull();
+  });
+
+  it('leaves the stored firmware version alone when metadata carries none', async () => {
+    manager.localNodeInfo = {
+      nodeNum: LOCAL_NODE_NUM,
+      nodeId: '!11111111',
+      longName: 'Test Local Node',
+      shortName: 'TLN',
+      firmwareVersion: FIRMWARE,
+    };
+
+    await manager.processDeviceMetadata({ hasWifi: false, hasEthernet: false });
+
+    expect(manager.localNodeInfo.firmwareVersion).toBe(FIRMWARE);
+    expect(manager.isLocalNodeBridged()).toBe(true);
+    expect(mockUpsertNodeAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshtasticManager.deviceMetadataRace.test.ts
+++ b/src/server/meshtasticManager.deviceMetadataRace.test.ts
@@ -131,6 +131,26 @@ describe('MeshtasticManager - DeviceMetadata arriving before MyNodeInfo', () => 
     expect(manager.pendingDeviceMetadata).toBeNull();
   });
 
+  it('keeps the last frame when metadata arrives twice before MyNodeInfo', async () => {
+    // The buffer holds one frame. A second arrival before identity is known
+    // restates the same device, so last-one-wins is the intended behaviour.
+    await manager.processDeviceMetadata({ firmwareVersion: '2.7.10.stale', hasWifi: false });
+    await manager.processDeviceMetadata({ firmwareVersion: FIRMWARE, hasWifi: true });
+
+    await manager.processMyNodeInfo({ myNodeNum: LOCAL_NODE_NUM, rebootCount: 1 });
+
+    expect(manager.localNodeInfo.firmwareVersion).toBe(FIRMWARE);
+    expect(manager.localNodeInfo.hasWifi).toBe(true);
+    expect(mockUpsertNodeAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ firmwareVersion: FIRMWARE }),
+      expect.anything(),
+    );
+    expect(mockUpsertNodeAsync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ firmwareVersion: '2.7.10.stale' }),
+      expect.anything(),
+    );
+  });
+
   it('leaves the stored firmware version alone when metadata carries none', async () => {
     manager.localNodeInfo = {
       nodeNum: LOCAL_NODE_NUM,

--- a/src/server/meshtasticManager.deviceMetadataRace.test.ts
+++ b/src/server/meshtasticManager.deviceMetadataRace.test.ts
@@ -127,6 +127,9 @@ describe('MeshtasticManager - DeviceMetadata arriving before MyNodeInfo', () => 
     });
 
     expect(manager.localNodeInfo.nodeNum).toBe(LOCAL_NODE_NUM);
+    // Both merge lookups are mocked null, so the merge branch itself assigns
+    // firmwareVersion: null. Seeing FIRMWARE here proves the drain ran after
+    // the branch's early return — that is the whole point of this test.
     expect(manager.localNodeInfo.firmwareVersion).toBe(FIRMWARE);
     expect(manager.pendingDeviceMetadata).toBeNull();
   });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -790,6 +790,12 @@ class MeshtasticManager implements ISourceManager {
   })();
   private packetActiveCount: number = 0;
   private packetWaiters: Array<() => void> = [];
+  // DeviceMetadata that arrived before localNodeInfo existed. MyNodeInfo and
+  // DeviceMetadata are sent back-to-back in the same config-download burst, and
+  // inbound frames run concurrently (packetConcurrencyLimit above), so metadata
+  // can overtake the DB awaits inside processMyNodeInfo(). Buffered here and
+  // drained by processMyNodeInfo() — see processDeviceMetadata().
+  private pendingDeviceMetadata: Record<string, unknown> | null = null;
   private localNodeInfo: {
     nodeNum: number;
     nodeId: string;
@@ -4640,7 +4646,34 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
-  private async processMyNodeInfo(myNodeInfo: any): Promise<void> {
+  private async processMyNodeInfo(myNodeInfo: Record<string, unknown>): Promise<void> {
+    try {
+      await this.processMyNodeInfoImpl(myNodeInfo);
+    } finally {
+      // Every exit path of the impl either assigns this.localNodeInfo or leaves
+      // an already-assigned one in place, so this is the one place guaranteed to
+      // run once local identity is known.
+      await this.drainPendingDeviceMetadata();
+    }
+  }
+
+  /**
+   * Apply a DeviceMetadata frame that arrived before localNodeInfo existed.
+   * No-op when nothing was buffered or identity is still unknown.
+   */
+  private async drainPendingDeviceMetadata(): Promise<void> {
+    const pending = this.pendingDeviceMetadata;
+    if (!pending || !this.localNodeInfo) return;
+    this.pendingDeviceMetadata = null;
+    try {
+      logger.debug('📱 Applying buffered DeviceMetadata now that local node identity is known');
+      await this.processDeviceMetadata(pending);
+    } catch (error) {
+      logger.error('❌ Failed to apply buffered DeviceMetadata:', error);
+    }
+  }
+
+  private async processMyNodeInfoImpl(myNodeInfo: any): Promise<void> {
     logger.debug('📱 Processing MyNodeInfo for local device');
     logger.debug('📱 MyNodeInfo contents:', JSON.stringify(myNodeInfo, null, 2));
 
@@ -5290,43 +5323,58 @@ class MeshtasticManager implements ISourceManager {
     logger.debug('📱 Processing DeviceMetadata:', JSON.stringify(metadata, null, 2));
     logger.debug('📱 Firmware version:', metadata.firmwareVersion);
 
+    // MyNodeInfo establishes local identity and DeviceMetadata follows it in the
+    // same config-download burst, but inbound frames are processed concurrently
+    // (packetConcurrencyLimit), so metadata can overtake the DB awaits inside
+    // processMyNodeInfo() and find localNodeInfo still null. Buffer rather than
+    // drop: dropping left firmwareVersion permanently null on that source (the
+    // UI's "Firmware Version: Not Available"), because the DB write below lives
+    // in the same branch, so the next reconnect read the same empty column back.
+    // It also left hasWifi/hasEthernet unknown, mis-gating isLocalNodeBridged()
+    // and the OTA firmware-update UI.
+    if (!this.localNodeInfo) {
+      this.pendingDeviceMetadata = metadata;
+      logger.debug('📱 Buffered DeviceMetadata — local node identity not established yet');
+      return;
+    }
+
+    const localNodeInfo = this.localNodeInfo;
+
     // Capture the node's transport-capability flags (proto3 bools decode to a
     // concrete true/false). These drive isLocalNodeBridged() — a serial/BLE-only
     // node fronted by a TCP proxy reports both false and cannot do OTA updates.
     // Captured independently of firmwareVersion so detection works even if the
     // firmware string is momentarily empty.
-    if (this.localNodeInfo) {
-      this.localNodeInfo.hasWifi = metadata.hasWifi === true;
-      this.localNodeInfo.hasEthernet = metadata.hasEthernet === true;
-      this.localNodeInfo.hasBluetooth = metadata.hasBluetooth === true;
-      // Firmware 2.8 build capability, surfaced alongside the transport flags so
-      // the local node reports it the same way a remote node does (#3923).
-      this.localNodeInfo.hasXeddsa = metadata.hasXeddsa === true;
-      if (this.isLocalNodeBridged()) {
-        logger.debug('🌉 Connected node reports no native WiFi/Ethernet — treating as a bridged node (OTA firmware update disabled)');
-      }
+    localNodeInfo.hasWifi = metadata.hasWifi === true;
+    localNodeInfo.hasEthernet = metadata.hasEthernet === true;
+    localNodeInfo.hasBluetooth = metadata.hasBluetooth === true;
+    // Firmware 2.8 build capability, surfaced alongside the transport flags so
+    // the local node reports it the same way a remote node does (#3923).
+    localNodeInfo.hasXeddsa = metadata.hasXeddsa === true;
+    if (this.isLocalNodeBridged()) {
+      logger.debug('🌉 Connected node reports no native WiFi/Ethernet — treating as a bridged node (OTA firmware update disabled)');
     }
 
     // Update local node info with firmware version (always allowed, even if locked)
-    if (this.localNodeInfo && metadata.firmwareVersion) {
+    if (metadata.firmwareVersion) {
       // Only update firmware version, don't touch other fields
-      this.localNodeInfo.firmwareVersion = metadata.firmwareVersion;
+      localNodeInfo.firmwareVersion = metadata.firmwareVersion;
       // Clear favorites support cache since firmware version changed
       this.favoritesSupportCache = null;
       logger.debug(`📱 Updated firmware version: ${metadata.firmwareVersion}`);
 
       // Update the database with the firmware version
-      if (this.localNodeInfo.nodeNum) {
+      if (localNodeInfo.nodeNum) {
         const nodeData = {
-          nodeNum: this.localNodeInfo.nodeNum,
-          nodeId: this.localNodeInfo.nodeId,
+          nodeNum: localNodeInfo.nodeNum,
+          nodeId: localNodeInfo.nodeId,
           firmwareVersion: metadata.firmwareVersion
         };
         await databaseService.upsertNodeAsync(nodeData, this.sourceId);
-        logger.debug(`📱 Saved firmware version to database for node ${this.localNodeInfo.nodeId}`);
+        logger.debug(`📱 Saved firmware version to database for node ${localNodeInfo.nodeId}`);
       }
     } else {
-      logger.debug('⚠️ Cannot update firmware - localNodeInfo not initialized yet');
+      logger.debug('⚠️ DeviceMetadata carried no firmware version — leaving stored value untouched');
     }
   }
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4652,14 +4652,17 @@ class MeshtasticManager implements ISourceManager {
     } finally {
       // Every exit path of the impl either assigns this.localNodeInfo or leaves
       // an already-assigned one in place, so this is the one place guaranteed to
-      // run once local identity is known.
+      // run once local identity is known. That includes the isLocked early
+      // return: draining there is intentional, because processDeviceMetadata()
+      // updates the firmware version even on a locked local node.
       await this.drainPendingDeviceMetadata();
     }
   }
 
   /**
    * Apply a DeviceMetadata frame that arrived before localNodeInfo existed.
-   * No-op when nothing was buffered or identity is still unknown.
+   * No-op when nothing was buffered or identity is still unknown — including
+   * when the impl threw before assigning identity.
    */
   private async drainPendingDeviceMetadata(): Promise<void> {
     const pending = this.pendingDeviceMetadata;
@@ -5332,6 +5335,9 @@ class MeshtasticManager implements ISourceManager {
     // in the same branch, so the next reconnect read the same empty column back.
     // It also left hasWifi/hasEthernet unknown, mis-gating isLocalNodeBridged()
     // and the OTA firmware-update UI.
+    // Holds one frame: the firmware sends DeviceMetadata once per config
+    // download, so a second arrival before MyNodeInfo would be a redundant
+    // restatement of the same device — last one wins.
     if (!this.localNodeInfo) {
       this.pendingDeviceMetadata = metadata;
       logger.debug('📱 Buffered DeviceMetadata — local node identity not established yet');


### PR DESCRIPTION
## Problem

A user with two Meshtastic TCP sources sees `Firmware Version: Not Available` in the MeshMonitor UI for one of them, while **both** virtual nodes report the correct firmware with the `-MM4.14.0` suffix.

## Root cause

The firmware sends `MyNodeInfo` and `DeviceMetadata` back-to-back in the same config-download burst. Inbound frames are not serialized — `meshtasticManager.ts:1488` does `void this.processIncomingData(data)` behind a semaphore of 4 (`PACKET_CONCURRENCY_LIMIT`, default 4).

`processMyNodeInfo()` performs 4–6 sequential DB awaits (settings reads, `device_id` check, `getNode`, upserts) *before* assigning `this.localNodeInfo`. `DeviceMetadata` can run straight through that gap and find `localNodeInfo === null`.

The old handler logged `⚠️ Cannot update firmware - localNodeInfo not initialized yet` and **discarded the payload**. Two consequences:

- The DB write lives in the same branch, so `nodes.firmwareVersion` stayed null too. On the next reconnect `processMyNodeInfo()` reads that empty column back — the source is stuck showing "Not Available" until a reconnect happens to win the race.
- `hasWifi` / `hasEthernet` / `hasBluetooth` / `hasXeddsa` were lost in the identical window, leaving `isLocalNodeBridged()` and the OTA firmware-update gate running on unknowns.

Why the VN masked it: `virtualNodeServer.ts:1000` replays the **raw cached `metadata` frame** and only rewrites the version string to append `-MM<version>`. It never consults `localNodeInfo` for this, so VN clients see the real firmware either way. That divergence is the tell, not a second bug.

Why only one of two sources: pure timing — TCP burst shape and DB latency differ per source.

## Fix

- Buffer the frame in a new `pendingDeviceMetadata` field instead of dropping it.
- Drain it from `processMyNodeInfo()` once local identity is known.
- The drain hangs off a wrapper's `finally` block, so it also covers the early-return same-device reboot-merge path (`:4754`), which returns before the normal tail.

## Tests

New `src/server/meshtasticManager.deviceMetadataRace.test.ts` (4 tests). The primary one gates every settings read on a deferred promise to park `processMyNodeInfo()` inside its DB awaits, fires `processDeviceMetadata()` through the window, then asserts the version and capability flags land after release. Others cover DB persistence, the reboot-merge path, and metadata carrying no firmware version.

Updated the stale `bridgedNode` test that asserted the old drop-on-null behavior.

- Full Vitest suite: 13102 passed, 0 failed (713 pending = PG/MySQL skips; no schema touched)
- `tsc --noEmit` clean
- `lint:ci` clean — the two new signatures are typed `Record<string, unknown>` rather than `any` so the ratchet baseline does not grow

## Upgrade note

The affected source's `nodes.firmwareVersion` column is already null. This fix populates it on the next reconnect, not retroactively — one container restart or source reconnect after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX