### PR TITLE
feat(meshcore): strict receive-only mode — Phase 1 backend enforcement (#4547)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
@@ -2,9 +2,51 @@
 
 **Epic issue:** #4547
 **Status:**
-- [ ] Phase 1 — Backend: setting + central command-aware TX guard (branch `feature/meshcore-receive-only-backend`)
+- [x] Phase 1 — Backend: setting + central command-aware TX guard (branch `feature/meshcore-receive-only-backend`)
 - [ ] Phase 2 — Frontend: gating UX
 - [ ] Phase 3 — Virtual Node gating + docs
+
+## Phase 1 deviations & findings (2026-08-04)
+
+Spec: `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md`. Five work packages,
+8 commits, ~350 lines of production code and ~1,900 lines of tests.
+
+- **`requestNeighbors` gets NO guard.** It branches on `validateMeshCorePubKey`: the remote
+  branch (`ensureSavedLogin` + `sendCliCommand`) transmits and throws via its already-guarded
+  downstream primitives; the local branch (`sendLocalCliCommand('neighbors')`) is serial-only
+  and must keep working. Its route `POST /neighbors/request` therefore gets **no**
+  `requireMeshcoreTx()` middleware — only the `failIfTxDisabled` catch mapping. Gating the
+  method wholesale would have broken a legitimate local read.
+- **This doc was wrong about `settings.allowlist.test.ts`.** That test is fully structural;
+  adding the key to **both** `VALID_SETTINGS_KEYS` and `PER_SOURCE_SETTINGS_KEYS` keeps it
+  green **unmodified**. A required edit there means the key went in the wrong array.
+  `PerSourceSettingKey` is derived (`typeof PER_SOURCE_SETTINGS_KEYS[number]`), so it needs
+  no edit either.
+- **`actionExecutor.ts` lives at `src/server/services/automation/`**, not `src/server/automation/`.
+  Confirmed: MeshCore automations degrade to `{ skipped: true, reason: 'TX_DISABLED' }` with
+  zero automation-engine changes, purely by reusing the branded `TxDisabledError`.
+- **`resolveSourceManager()` is Meshtastic-only by design** — a MeshCore `sourceId` falls back
+  to the primary/fallback Meshtastic manager. `GET /api/device/tx-status` therefore narrows via
+  `sourceManagerRegistry.getManager()` + `isMeshCoreManager` directly, before the existing
+  Meshtastic path.
+- **`ping` and `shutdown` verified serial-only** (`meshcoreNativeBackend.ts:1815-1820`):
+  `shutdown` calls `this.disconnect()` (transport teardown), `ping` returns `{ pong: true }`
+  in-process. Neither touches the radio. The radio probe is `pingContactZeroHop`, which goes
+  out as `trace_path` and is on the RF list.
+- **Pre-existing gap fixed:** the client `SourceRadioSummary` mirror (`src/types/elevation.ts`)
+  was missing `txEnabled` / `udpRelayEnabled` / `canTransmit` entirely — the server had them,
+  the client type did not. Added alongside `receiveOnly`.
+- **Known limitation, deferred to Phase 2 as a product question:** flipping receive-only ON
+  mid-retry-chain parks that specific DM/channel message rather than auto-resuming when the
+  flag goes off again. Recurring schedulers (pathfinding, announce, timer triggers) all resume
+  correctly because the check lives inside the callback, not around the timer install. Adding a
+  re-arm mechanism was deliberately not invented inside the highest-risk work package.
+- **Reviewer note:** `tsconfig.json` excludes `src/**/*.test.ts`, so `npm run typecheck` never
+  checks test files, and Vitest strips types via esbuild without checking. A separate tsc run
+  with tests included was done for this phase and reported no errors — worth repeating on any
+  phase that adds significant test-only typing.
+- **Verification:** full Vitest suite 14,006 tests / 0 failures (`success: true` via JSON
+  reporter); `npm run lint:ci` clean of in-repo failures; `tsc` clean including test files.
 
 **Goal:** Give MeshCore sources a strict receive-only mode that guarantees the physical
 Companion never transmits over LoRa, while RX, the Analyzer Observer, the packet log,

--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
@@ -1,0 +1,197 @@
+# MeshCore Strict Receive-Only Mode — Epic Plan
+
+**Epic issue:** #4547
+**Status:**
+- [ ] Phase 1 — Backend: setting + central command-aware TX guard (branch `feature/meshcore-receive-only-backend`)
+- [ ] Phase 2 — Frontend: gating UX
+- [ ] Phase 3 — Virtual Node gating + docs
+
+**Goal:** Give MeshCore sources a strict receive-only mode that guarantees the physical
+Companion never transmits over LoRa, while RX, the Analyzer Observer, the packet log,
+contact/telemetry/route updates, and read-only Virtual Node access all keep working.
+
+## Hard constraint (verified)
+
+`@liamcottle/meshcore.js` v1.13.0 and the Companion firmware protocol expose **no**
+radio-level TX kill switch. The full `CommandCodes` set has no `txEnabled` / `disableTx` /
+`radioOff` equivalent; `SetOtherParams(38)` carries only manual-add-contacts, telemetry
+modes and advert-location policy; `SetTxPower(12)` lowers power but never stops TX.
+
+**Implication:** unlike Meshtastic (`lora.txEnabled` is a firmware kill switch), MeshCore
+receive-only must be enforced **entirely inside MeshMonitor**. It cannot stop
+firmware-autonomous transmissions (link-layer ACKs, on-device advert schedules configured
+outside MeshMonitor). This limitation must be documented in Phase 3.
+
+## Interview decisions (2026-08-04)
+
+1. **Storage:** new per-source setting key `meshcoreReceiveOnly` in
+   `PER_SOURCE_SETTINGS_KEYS` (`src/server/constants/settings.ts`), stored as
+   `source:{id}:meshcoreReceiveOnly`. No DB migration — matches every existing MeshCore
+   per-source toggle (`meshcoreRespondToDiscovery`, `meshcoreAutoAck*`, …).
+2. **Strictness:** block **all RF**, allow **local serial config**. Blocked: messages, DMs,
+   adverts, remote CLI, logins, traceroute/path discovery, telemetry & status requests,
+   neighbours (binary req), node discovery, ANON_REQ, share-contact, discovery
+   auto-responses, and every scheduler/automation that transmits. Allowed: setName,
+   setRadio, setTxPower, setCoords, channel CRUD, RTC sync, stats, device query, reboot,
+   contact import/export, local UART CLI (except the synthetic `advert` verb).
+3. **Virtual Node:** stays up and serves reads; the 9 TX-causing commands return an `Err`
+   frame. (Issue explicitly asks for read-only VN access.)
+4. **Scope:** applies to **all MeshCore sources**, not just Companion — repeater sources'
+   CLI verbs can transmit too.
+5. **Auto-TX toggles:** settings are **preserved untouched**. Schedulers keep ticking but
+   skip with a state-change log (mirrors the Meshtastic pattern). UI shows each affected
+   section disabled with a "paused — receive-only mode" note, so disabling receive-only
+   restores prior behavior exactly. Never clear a user's automation config.
+6. **Phases:** 3, one PR each, each independently mergeable.
+
+## Reuse template — the Meshtastic TX-disabled epic (#4294)
+
+Phase 1 must reuse, not re-invent:
+
+| Mechanism | File |
+|---|---|
+| `TxDisabledError` + `TX_DISABLED_CODE` + `isTxDisabledError()` | `src/server/errors/txDisabledError.ts` |
+| `canTransmit()` guard idiom (throw for user actions, silent-skip for schedulers) | `src/server/meshtasticManager.ts:9195` |
+| Route mapping `fail(res, 409, 'TX_DISABLED', …)` | `messageRoutes.ts:1324`, `meshRequestRoutes.ts:42`, … |
+| Automation skip-and-record — already converts a thrown `TxDisabledError` | `automation/actionExecutor.ts:141-155` (`pushOrSkipTxDisabled`) |
+| `GET /api/device/tx-status` shape | `src/server/routes/deviceStatusRoutes.ts:9` |
+| `useTxStatus` hook + `utils/txDisabled.ts` + `AppBanners` banner | `src/hooks/useTxStatus.ts`, `src/components/AppBanners/AppBanners.tsx` |
+| Per-source settings plumbing | `src/server/constants/settings.ts`, `databaseService.settings.getSettingForSource` |
+
+Because `actionExecutor` already handles `TxDisabledError`, MeshCore automations degrade
+correctly with **zero new automation-engine code** as long as the MeshCore TX primitives
+throw the same error type.
+
+## TX inventory (survey 2026-08-04)
+
+### Two chokepoints
+
+| # | Chokepoint | Location | Note |
+|---|---|---|---|
+| A | `MeshCoreManager.sendBridgeCommand()` | `meshcoreManager.ts:1620` | 50+ call sites, carries **both** RF and serial-only commands → the gate must be **command-name aware** (allowlist/denylist of bridge command names). |
+| B | `MeshCoreNativeBackend.handleDiscoverRequest()` → `sendToRadioFrame` | `meshcoreNativeBackend.ts:798-838`, TX at `:831` | **Bypasses `sendCommand`/`dispatch` entirely.** Autonomous push-event-driven RF TX. Highest-risk miss. |
+
+### RF-transmitting bridge commands (denylist seed)
+
+`send_message`, `send_advert`, `discover_path`, `discover_nodes`, `request_owner`,
+`request_regions`, `trace_path`, `share_contact`, `get_neighbours`, `login`, `get_status`,
+`send_cli`, `request_telemetry`, `reset_path` (forces next send to flood).
+
+Serial-only (must stay allowed): `get_channels`, `set_channel`, `delete_channel`,
+`get_self_info`, `get_contacts`, `remove_contact`, `export_contact`, `import_contact`,
+`reboot`, `export_private_key`, `import_private_key`, `set_name`, `set_radio`,
+`set_tx_power`, `set_coords`, `set_advert_loc_policy`, `set_telemetry_mode_*`,
+`set_other_params`, `get_stats`, `get_device_time`, `set_device_time`, `device_query`,
+`set_flood_scope`, `set_out_path`.
+
+### Manager methods that must throw when receive-only (`meshcoreManager.ts`)
+
+`sendMessage` :3072 · `sendMessageWithResult` :3083 · `performScopedSend` :3253 (core
+primitive) · `sendAdvert` :3669 · `resetContactPath` :3710 · `discoverContactPath` :3753 ·
+`discoverNodes` :3789 · `fetchOwnerName` :3888 · `discoverRegions` :4021 ·
+`traceContactPath` :4106 · `tracePathRaw` :4171 · `pingContactZeroHop` :4223 ·
+`shareContact` :4310 · `getNeighbours` :4667 · `loginToNode` :4787 · `requestNodeStatus`
+:4825 · `ensureGuestLogin` :4893 · `ensureSavedLogin` :4924 · `loginToRoom` :4957 ·
+`sendRoomPost` :4990 · `requestNeighbors` :5051 (remote branch) · `sendCliCommand` :5185 ·
+`runCliCommandLocked` :5228 · `requestRemoteTelemetry` :5678 · `requestRemoteTelemetryRaw`
+:5725 · `runSyntheticLocalCli` :5344 (only the `advert` verb).
+
+### Timer/scheduler paths that must silently skip
+
+DM ACK retry :3417/:3459 → :3499 · channel retry :3576/:3616 → :3655 · auto-pathfinding
+:6429 (:6503, :6506) · auto-announce :6597/:6660 (:6702, :6722) · timer triggers
+:6754/:6824 (:6842, :6846) · auto-responder :7050 (:7113, :7117) · auto-acknowledge :7313
+(:7442, :7446) · `services/meshcoreRemoteTelemetryScheduler.ts` (:428, :475, :484) ·
+`services/meshcoreRoomSyncScheduler.ts` (:145) · discovery responder
+`meshcoreNativeBackend.ts:831`.
+
+Not gated (no RF): `startDeviceTimeSync` :4639, `schedulePathRefresh` :2908,
+`services/meshcoreTelemetryPoller.ts`, `services/meshcoreObserverPublisher.ts`.
+
+`connect()` (:1131-1345) re-arms four autonomous TX schedulers on every reconnect — the
+guard must hold across reconnects, not just at arm time.
+
+### Routes to map to `409 TX_DISABLED`
+
+`meshcoreMessagingRoutes.ts` :255 /messages/send · :365 /rooms/login · :419
+/rooms/login-with-saved · :474 /rooms/post
+`meshcoreContactsRoutes.ts` :167 reset-path · :205 discover-path · :247 /discover · :290
+/regions/discover · :313 trace-path · :358 ping · :486 share · **:652 `GET`
+/contacts/:pk/neighbours** · :757 telemetry/poll · :1011 /neighbors/request
+`meshcoreAdminRoutes.ts` :44 /admin/login · :127 /admin/cli · :360 /admin/login-with-saved ·
+**:433 `GET` /admin/status/:pk** · :230 /cli (only the `advert` verb)
+`meshcoreDeviceRoutes.ts` :262 /advert
+`meshcoreAutomationRoutes.ts` :580 /automation/announce/send · :646
+/automation/timers/:triggerId/run
+
+Two **GET** routes transmit — easy to miss with a POST-only sweep.
+`meshcoreRouteGuard` (`meshcoreRouteShared.ts:43`) is the natural place for a shared helper.
+
+### Virtual Node commands to reject (Phase 3) — `meshcoreVirtualNodeServer.ts`
+
+`SendChannelTxtMsg` :525/:1143 · `SendTxtMsg` :528/:1172 · CLI relay `handleSendCliTxtMsg`
+:1264 · `SendSelfAdvert` :536/:768 · `SendLogin` :544/:803 · `SendTracePath` :551/:846 ·
+`SendTelemetryReq` :555/:882 · `SendStatusReq` :559/:927 · `SendBinaryReq` :565/:963.
+All other handlers (AppStart, GetContacts, GetChannel, SyncNextMessage, device time,
+battery, config setters, ExportPrivateKey) stay functional.
+
+## Phases
+
+### Phase 1 — Backend: setting + central command-aware guard
+- Add `meshcoreReceiveOnly` to `PER_SOURCE_SETTINGS_KEYS` (+ `PerSourceSettingKey`, and the
+  exact-equality assertion in `settings.allowlist.test.ts`).
+- `MeshCoreManager.isReceiveOnly()` / `canTransmit()` reading the per-source setting, with a
+  cached value refreshed on settings write and on `connect()`; log state changes at info,
+  never per-tick.
+- Command-aware gate inside `sendBridgeCommand` (denylist above) throwing `TxDisabledError`
+  — the belt-and-braces choke point that catches any future TX path.
+- Explicit guards in the listed manager primitives (better error sites than the generic one).
+- Explicit guard in `meshcoreNativeBackend.handleDiscoverRequest` (chokepoint B).
+- Scheduler/auto-ack/auto-responder silent skips with state-change logging.
+- Route mapping to `fail(res, 409, 'TX_DISABLED', 'Transmission blocked: this MeshCore
+  source is configured for receive-only operation.')`.
+- Extend `GET /api/device/tx-status` (or a MeshCore-aware equivalent) so the frontend can
+  read receive-only state per source.
+- Tests: guard unit tests, denylist coverage test (asserts every RF bridge command is
+  gated), scheduler skip tests, route-harness 409 tests, discovery-responder test,
+  `*.perSource.test.ts` isolation test.
+
+**Exit criteria:** with `meshcoreReceiveOnly=true` on a source, no code path reaches the
+radio; every listed route returns 409; serial config still works; full Vitest suite green.
+
+### Phase 2 — Frontend: gating UX
+- Toggle in `MeshCoreSettingsView.tsx` with an explanatory note (and the firmware-limitation
+  caveat).
+- Reuse/extend `useTxStatus` so MeshCore sources report receive-only; banner via `AppBanners`.
+- Disable + tooltip every MeshCore TX control: messaging send box, advert button, admin
+  login/CLI, discover/regions/trace/ping/share/neighbours, telemetry poll, room post,
+  automation "send now"/"run now" buttons.
+- "Paused — receive-only mode" notes on auto-ack / auto-announce / auto-responder /
+  pathfinding / timer-trigger sections (settings stay editable-but-inert or disabled — pick
+  one and be consistent).
+- Graceful 409 handling (toast, not crash) wherever a race slips through.
+- Tests: component disabled-state tests.
+
+**Exit criteria:** every MeshCore TX surface visibly disabled with a reason; browser-validated.
+
+### Phase 3 — Virtual Node gating + docs
+- Reject the 9 VN TX commands with an `Err` frame; keep read paths serving.
+- Tests for each rejected command + a read-path regression test.
+- User doc page (`docs/features/…`) modeled on `docs/features/receive-only-mode.md`,
+  documenting what still works, what is blocked, and the firmware limitation.
+- REST API docs: 409 `TX_DISABLED` on the MeshCore routes; i18n strings across locales.
+
+**Exit criteria:** a third-party MeshCore client on the VN port cannot transmit; docs shipped.
+
+## Risks / easy misses
+
+1. `meshcoreNativeBackend.ts:831` discovery auto-response — the only TX that never touches
+   `sendBridgeCommand`.
+2. Raw ANON_REQ / discover frames at `meshcoreNativeBackend.ts:1084, 1129, 1200, 1272` —
+   inside `dispatch`, so the command-name gate covers them, but a `sendTextMessage` grep
+   would not.
+3. Two GET routes that transmit.
+4. The Virtual Node port bypasses the whole HTTP API.
+5. Timer-driven retries (DM ACK, channel) fire long after the originating request returned.
+6. `connect()` re-arms schedulers on every reconnect.
+7. `sendLocalCliCommand('advert')` — the local-CLI path becomes RF for this one verb.

--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md
@@ -1,0 +1,1054 @@
+# MeshCore Strict Receive-Only — Phase 1 Implementation Spec (Backend)
+
+**Epic:** #4547 · **Epic plan:** `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md`
+**Branch:** `feature/meshcore-receive-only-backend` · **Worktree:** `/home/yeraze/Development/meshmonitor-mc-rxonly-p1`
+**Scope:** Phase 1 only — the setting, the command-aware TX guard, scheduler skips, route
+mapping, and the backend half of the frontend read path. No UI work. No Virtual Node work.
+
+Every line reference in this document was verified against the worktree on 2026-08-04. Where
+the epic plan's numbers had drifted or were wrong, the correction is called out inline.
+
+---
+
+## 1. Reuse inventory (read this before writing any code)
+
+Nothing in this list may be re-implemented. Extend it or call it.
+
+### 1.1 Error type — reuse verbatim
+
+`src/server/errors/txDisabledError.ts` (16 lines, complete):
+
+```ts
+export const TX_DISABLED_CODE = 'TX_DISABLED' as const;
+export class TxDisabledError extends Error {
+  readonly isTxDisabledError = true as const;
+  readonly code = TX_DISABLED_CODE;
+  constructor(message = 'Transmit is disabled on this source’s radio') { … }
+}
+export function isTxDisabledError(e: unknown): e is TxDisabledError
+```
+
+Do **not** create a `MeshCoreReceiveOnlyError`. The whole point of reusing `TxDisabledError`
+is that `actionExecutor` (§1.3) and the frontend's `code === 'TX_DISABLED'` handling already
+work. Pass a MeshCore-specific *message* to the existing constructor instead.
+
+### 1.2 Guard idiom — mirror `MeshtasticManager`
+
+- `isTxEnabled()` — `src/server/meshtasticManager.ts:9095` — raw device truth, sync, no DB.
+- `canTransmit()` — `:9141` — `isTxEnabled() || isUdpBroadcastRelayEnabled()`. **Synchronous
+  and free of DB access.** This is non-negotiable for MeshCore too: `computeSourceRadioSummary`
+  (§1.7) is a sync function, and per-packet guards must not hit SQLite.
+- **User-initiated → throw:** `:9167`, `:9349`, `:9401`, `:9480`, `:9553`, `:9784`, `:10512`,
+  `:10620` — all the shape `if (!this.canTransmit()) throw new TxDisabledError();`
+- **Scheduler → silent skip:** `:2278` (auto-ack), `:2440` (auto-responder), `:3354` (timer
+  trigger), `:4373`-ish (auto-traceroute), `:10156`, `:10931` — all the shape
+  `if (!this.canTransmit()) { logger.debug('… Skipping - TX disabled on this source'); return; }`
+- **State-change-only log:** `src/server/meshtasticManager.ts:4373-4387` — captures
+  `prevCanTransmit`, mutates, re-reads `nextCanTransmit`, and emits `logger.info` **only when
+  the two differ**. Copy this shape exactly. Everything else is `logger.debug`.
+
+### 1.3 Automation — zero new code required
+
+`src/server/services/automation/actionExecutor.ts:145-155` (note: the epic plan's path
+`automation/actionExecutor.ts` is wrong — it lives under `services/`):
+
+```ts
+async function pushOrSkipTxDisabled<T>(results: unknown[], fn: () => Promise<T>): Promise<void> {
+  try { results.push(await fn()); }
+  catch (error) {
+    if (isTxDisabledError(error)) { results.push({ skipped: true, reason: 'TX_DISABLED' }); return; }
+    throw error;
+  }
+}
+```
+
+Because MeshCore send primitives will throw the same branded error, MeshCore automation
+actions degrade to `{ skipped: true, reason: 'TX_DISABLED' }` with **no change to
+`actionExecutor.ts` or `meshActionDeps.ts`**. Do not touch those files.
+
+### 1.4 Route plumbing — extend, do not fork
+
+`src/server/routes/meshcoreRouteShared.ts`:
+- `managerFor(_req, res): MeshCoreManager` (`:31`) — returns `res.locals.meshcoreManager`,
+  already narrowed and cached by the router-level guard. Never call `getManager()` again in a
+  handler.
+- `meshcoreRouteGuard(req, res, next)` (`:43`) — validates `:id`, resolves + narrows via
+  `isMeshCoreManager`, caches on `res.locals`. Every new TX guard **must run after this**.
+- `VALIDATION` (`:66`) and `auditMeshcoreEvent` (`:162`) — reuse as-is.
+
+`src/server/utils/apiResponse.ts`:
+- `ok(res, data?)` → `{ success: true, data }`. **Do not** convert existing bare-payload
+  handlers; Phase 1 adds no new success shapes.
+- `fail(res, status, code, message, extra?)` → `{ success: false, error, code, ...extra }`.
+  Always safe. This is how every 409 is emitted.
+
+### 1.5 Per-source settings plumbing
+
+- `src/server/constants/settings.ts` — `VALID_SETTINGS_KEYS` (~`:100`-`:340`),
+  `PER_SOURCE_SETTINGS_KEYS` (`:346`), `PerSourceSettingKey` (`:555`),
+  `GLOBAL_ONLY_SETTINGS_KEYS` (`:590`-ish), `PER_SOURCE_KEYS_NOT_POSTABLE` (`:605`-ish).
+  Existing MeshCore per-source neighbours to copy: `meshcoreRespondToDiscovery`,
+  `meshcoreAutoPathfindingEnabled` (`:431`), `meshcoreAutoResponderEnabled` (`:475`),
+  `meshcoreDefaultScope` (`:480`).
+- `databaseService.settings.getSettingForSource(sourceId, key)` — the only read API. Existing
+  MeshCore uses: `meshcoreManager.ts:1606`, `:3229`, `:3929`, `:6433`, `:6601`, `:6714`.
+- **Settings-write side-effect channel:** `SettingsCallbacks` in
+  `src/server/routes/settingsRoutes.ts:~120-160`, injected via `setSettingsCallbacks()` and
+  implemented in `src/server/server.ts` (see `restartAnnounceScheduler` at `server.ts:848`).
+  The per-source write branch is `settingsRoutes.ts:806-882`. This is the mechanism for cache
+  invalidation on settings write — **do not invent an event bus.**
+
+### 1.6 Backend state push — the `setRespondToDiscovery` precedent
+
+The exact pattern for pushing manager state into `MeshCoreNativeBackend` already exists:
+- `MeshCoreNativeBackend.setRespondToDiscovery(enabled)` — `meshcoreNativeBackend.ts:782`
+- `MeshCoreManager.setRespondToDiscovery(enabled)` — `meshcoreManager.ts:3937`
+- Applied on connect inside `startNativeBackend()` — `meshcoreManager.ts:1604-1613`
+- Applied on settings write from a route — `meshcoreConfigRoutes.ts:60`
+
+Copy this exact three-point pattern for receive-only. Nothing new is required.
+
+### 1.7 Frontend read path — already exists
+
+- `computeSourceRadioSummary(sourceId)` — `src/server/routes/sourceRoutes.ts:434`, synchronous,
+  try/catch-wrapped, already has an `isMeshCoreManager(mgr)` branch returning
+  `{ frequencyMhz }`. Attached at `sourceRoutes.ts:496` to `GET /api/sources`.
+- Server interface `SourceRadioSummary` — `sourceRoutes.ts:414` (already carries
+  `txEnabled` / `udpRelayEnabled` / `canTransmit` for Meshtastic).
+- Client mirror — `src/types/elevation.ts:40`, consumed by `src/hooks/useDashboardData.ts:34`.
+- `GET /api/device/tx-status` — `src/server/routes/deviceStatusRoutes.ts:9`, shape
+  `{ txEnabled, udpRelayEnabled, canTransmit }`, resolved via `resolveSourceManager`.
+
+### 1.8 Test utilities
+
+- `createRouteTestApp()` / `RouteTestHarness` — `src/server/test-helpers/routeTestApp.ts`
+  (`:135` factory; `:72` `sourceA`, `:74` `sourceB`, `:78` `limited`, `:96` `grant`,
+  `loginAs`, `cleanup`). **Mandatory for all new route tests.**
+- Canonical template: `src/server/routes/sourceRoutes.permissions.test.ts`.
+- Existing MeshCore route-test files (mock `sourceManagerRegistry`, not the DB — that part
+  stays correct): `meshcoreRoutes.test.ts` (see the `setRespondToDiscovery` mock at `:65` and
+  its assertions at `:2045-2077`), `meshcoreRoutes.zeroHopPing.test.ts`,
+  `meshcoreMessagingRoutes.channelPermissions.test.ts`.
+- Discovery-responder harness already exists: `src/server/meshcoreNativeBackend.discovery.test.ts`
+  (`:271-303` drives `setRespondToDiscovery(true)` and asserts frames). Extend this file's
+  patterns rather than building a new backend harness.
+- `*.perSource.test.ts` precedent: `src/server/meshtasticManager.autoAckTokens.perSource.test.ts`,
+  `src/server/services/meshcoreObserverPublisher.perSource.test.ts`.
+- Source-extraction test precedent (for the denylist-completeness test):
+  `src/server/server.settings-persistence.test.ts` reads source text and asserts on it.
+
+### 1.9 New subsystems, justified
+
+| New thing | Closest existing | Why new |
+|---|---|---|
+| `src/server/constants/meshcoreTx.ts` | `meshcoreRouteShared.ts` `DANGEROUS_CLI_COMMANDS` | The denylist must be importable by the manager, the native backend, the routes **and** a test that cross-checks it against source text. Putting it in `meshcoreRouteShared.ts` would make the manager import a routes module (layering inversion). `constants/` is where `settings.ts` and `meshtastic.ts` already live. |
+| `requireMeshcoreTx` middleware | `requireMeshcoreChannelAccess` (`meshcoreRouteShared.ts:351`) | Same file, same idiom — this is an extension of existing plumbing, not a new subsystem. |
+| Nothing else | — | No new error class, no new event bus, no new DB column, no migration, no new API surface beyond two additive response fields. |
+
+---
+
+## 2. File-by-file changes
+
+### 2.1 `src/server/constants/settings.ts` — the setting key
+
+Add `'meshcoreReceiveOnly'` to **both** arrays:
+
+1. `VALID_SETTINGS_KEYS` — insert adjacent to `'meshcoreDefaultScope'` (currently `:310`).
+2. `PER_SOURCE_SETTINGS_KEYS` — insert adjacent to `'meshcoreDefaultScope'` (currently `:480`).
+
+Do **not** add it to `GLOBAL_ONLY_SETTINGS_KEYS` or `PER_SOURCE_KEYS_NOT_POSTABLE`.
+
+Storage: `source:{sourceId}:meshcoreReceiveOnly`, string `'true'` / `'false'`. No migration.
+
+**`PerSourceSettingKey` needs no third edit — verified 2026-08-04.** `settings.ts:555` reads
+exactly:
+
+```ts
+export type PerSourceSettingKey = typeof PER_SOURCE_SETTINGS_KEYS[number];
+```
+
+It is a **derived** type, not a hand-written union, and `PER_SOURCE_SETTINGS_KEYS` closes with
+`] as const;` at `:553`. Adding the string literal to the array widens the type automatically.
+WP1 therefore edits exactly two array literals in this file and nothing else.
+
+**Correction to the epic plan.** The epic says the key "must be added to the exact-equality
+assertion in `settings.allowlist.test.ts`". It must not — that test is fully structural:
+`:27-28` (`missing` ⊆ not-postable), `:44-47` (disjointness), `:77-88` (no duplicates),
+`:135-136` (`PER_SOURCE_KEYS_NOT_POSTABLE.size === 17`). Adding the key to **both** arrays
+keeps all four green with zero test edits. Adding it to only `PER_SOURCE_SETTINGS_KEYS` breaks
+the size-17 pin. Implementers must run `settings.allowlist.test.ts` and confirm it passes
+**unmodified** — a required edit there means the key was added to the wrong place.
+
+### 2.2 `src/server/constants/meshcoreTx.ts` — NEW: the denylist
+
+```ts
+/**
+ * MeshCore receive-only mode (#4547) — bridge-command classification.
+ *
+ * `sendBridgeCommand` carries BOTH over-the-air commands and local serial
+ * config commands, so the receive-only gate must be command-name aware.
+ *
+ * FAIL-CLOSED: `isRfBridgeCommand()` returns true for any name not explicitly
+ * listed as serial-only. A bridge command added in the future without touching
+ * this file is therefore BLOCKED in receive-only mode rather than silently
+ * transmitting. `meshcoreTx.test.ts` additionally fails the build so the
+ * omission is caught at review time, not at runtime.
+ */
+
+/** Commands that put energy on the LoRa radio. Blocked in receive-only mode. */
+export const RF_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
+  'send_message',
+  'send_advert',
+  'send_cli',
+  'discover_path',
+  'discover_nodes',
+  'request_owner',
+  'request_regions',
+  'request_telemetry',
+  'trace_path',
+  'share_contact',
+  'get_neighbours',
+  'login',
+  'get_status',
+  'reset_path',
+]);
+
+/** Local-serial-only commands. Allowed in receive-only mode. */
+export const SERIAL_ONLY_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
+  'get_channels', 'set_channel', 'delete_channel',
+  'get_self_info', 'get_contacts', 'remove_contact',
+  'export_contact', 'import_contact',
+  'export_private_key', 'import_private_key',
+  'set_name', 'set_radio', 'set_tx_power', 'set_coords',
+  'set_advert_loc_policy', 'set_other_params', 'set_flood_scope', 'set_out_path',
+  'set_telemetry_mode_base', 'set_telemetry_mode_loc', 'set_telemetry_mode_env',
+  'get_stats', 'get_device_time', 'set_device_time', 'device_query',
+  'reboot', 'shutdown', 'ping',
+]);
+
+export function isRfBridgeCommand(cmd: string): boolean {
+  return !SERIAL_ONLY_BRIDGE_COMMANDS.has(cmd);
+}
+
+/** Local-CLI verbs (Companion synthetic CLI and Repeater serial CLI) that transmit. */
+export const RF_LOCAL_CLI_VERBS: ReadonlySet<string> = new Set(['advert']);
+
+export function isTransmittingLocalCliVerb(command: string): boolean {
+  const verb = command.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+  return RF_LOCAL_CLI_VERBS.has(verb);
+}
+
+/** Single user-facing message for every receive-only rejection. */
+export const MESHCORE_RECEIVE_ONLY_MESSAGE =
+  'Transmission blocked: this MeshCore source is configured for receive-only operation.';
+```
+
+**Counts, verified.** `meshcoreManager.ts` issues 37 distinct `sendBridgeCommand` literals;
+`meshcoreNativeBackend.ts`'s dispatch switch handles 42 cases (the 37 plus
+`set_telemetry_mode_base|loc|env`, `shutdown`, `ping`). 14 RF + 28 serial-only = 42. The
+completeness test (§3.1) pins this.
+
+**`reset_path` rationale.** It does not itself put a frame on the air; it clears the stored
+out-path so the *next* send floods. It is denylisted deliberately: in receive-only mode there
+is no legitimate next send, the UI groups it with discover-path, and blocking it keeps the
+route surface coherent. Documented here so a future reader does not "fix" it.
+
+**`import_contact` / `export_contact` / `share_contact`.** `share_contact` transmits (it
+broadcasts our contact card) → RF. `import_contact` / `export_contact` are local record
+operations → serial-only. Do not conflate them.
+
+**`ping` and `shutdown` — verified serial-only, do not re-derive.** Both appear only in the
+native backend's dispatch switch, never in the manager's inventory, so they were classified
+from source, not from the survey. Bodies read on 2026-08-04:
+
+```ts
+// meshcoreNativeBackend.ts:1815-1816
+case 'shutdown':
+  await this.disconnect();
+  return { ok: true };
+
+// meshcoreNativeBackend.ts:1819-1820
+case 'ping':
+  return { pong: true };
+```
+
+`shutdown` tears down the local transport (`this.disconnect()`) — no `c.*` connection call, no
+frame. `ping` is a pure in-process liveness reply that never touches `this.connection` at all;
+it is **not** a zero-hop radio probe (the radio probe is `pingContactZeroHop`, which goes out
+as `trace_path` and is correctly on the RF list). Both stay in
+`SERIAL_ONLY_BRIDGE_COMMANDS`. Do not move them.
+
+### 2.3 `src/server/meshcoreManager.ts` — state, gate, guards, skips
+
+#### 2.3.1 State (add near the other per-source cached settings)
+
+```ts
+/** Cached per-source `meshcoreReceiveOnly`. Sync-readable; refreshed on connect and on settings write. */
+private receiveOnly = false;
+
+/** True when this source is configured strictly receive-only (#4547). */
+isReceiveOnly(): boolean { return this.receiveOnly; }
+
+/**
+ * Whether this source may put energy on the radio. Sync, no DB access —
+ * mirrors MeshtasticManager.canTransmit() (meshtasticManager.ts:9141) so
+ * per-command guards and the sync computeSourceRadioSummary can both use it.
+ */
+canTransmit(): boolean { return !this.receiveOnly; }
+
+/**
+ * Apply a new receive-only value. Logs ONLY on a state change (info), never
+ * per tick. Pushes the value into the native backend so chokepoint B
+ * (handleDiscoverRequest) sees it too.
+ */
+setReceiveOnly(enabled: boolean): void {
+  const prev = this.receiveOnly;
+  this.receiveOnly = enabled;
+  this.nativeBackend?.setReceiveOnly(enabled);
+  if (prev !== enabled) {
+    logger.info(enabled
+      ? `🚫 [MeshCore:${this.sourceId}] Receive-only mode ON — all transmissions blocked, autonomous senders paused`
+      : `📡 [MeshCore:${this.sourceId}] Receive-only mode OFF — transmissions and autonomous senders resume`);
+  }
+}
+
+/**
+ * Re-read `meshcoreReceiveOnly` from the DB and apply it. On read failure the
+ * PREVIOUS cached value is retained — a transient DB error must never silently
+ * re-enable transmission on a source the user configured receive-only.
+ */
+async refreshReceiveOnly(): Promise<boolean> {
+  try {
+    const raw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreReceiveOnly');
+    this.setReceiveOnly(raw === 'true');
+  } catch (err) {
+    logger.warn(`[MeshCore:${this.sourceId}] Failed to read meshcoreReceiveOnly, keeping cached value (${this.receiveOnly}):`, err);
+  }
+  return this.receiveOnly;
+}
+
+/** Throw the shared TxDisabledError when this source is receive-only. */
+private requireTransmit(): void {
+  if (!this.canTransmit()) throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+}
+```
+
+Import `TxDisabledError` from `./errors/txDisabledError.js` and the constants from
+`./constants/meshcoreTx.js`.
+
+#### 2.3.2 Refresh points — must survive reconnects
+
+1. **`connect()` (`:1131`)** — `await this.refreshReceiveOnly();` **early**, before the
+   auto-announce-on-start block at `:1289` and before `startNativeBackend()` (`:1563`). Placing
+   it inside `startNativeBackend()` is wrong: that method runs only for Companion sources, and
+   receive-only applies to repeater/serial sources too (interview decision 4).
+   `connect()` re-arms four autonomous TX schedulers on every reconnect, so this refresh is
+   what makes the guard survive a reconnect.
+2. **`startNativeBackend()` (`:1604`-`:1613`)** — add
+   `this.nativeBackend.setReceiveOnly(this.receiveOnly);` immediately alongside the existing
+   `setRespondToDiscovery` call, so a freshly-constructed backend inherits the cached value.
+3. **Settings write** — via the new `SettingsCallbacks` entry (§2.6).
+
+#### 2.3.3 Chokepoint A — `sendBridgeCommand` (`:1620`)
+
+```ts
+private async sendBridgeCommand(cmd: string, params: Record<string, any>, timeout = 30000): Promise<BridgeResponse> {
+  if (!this.nativeBackend) throw new Error('Native backend not ready');
+  // Receive-only (#4547): command-name aware — this method carries BOTH RF and
+  // local serial commands. Fail-closed on unknown names (see meshcoreTx.ts).
+  if (this.receiveOnly && isRfBridgeCommand(cmd)) {
+    throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+  }
+  return this.nativeBackend.sendCommand(cmd, params, timeout);
+}
+```
+
+This is the belt-and-braces net. The explicit per-method guards below exist because they
+produce better error sites and stop work earlier (e.g. before a multi-step loop starts) —
+they do not replace this.
+
+#### 2.3.4 Explicit guards — 24 methods
+
+Each method below gets `this.requireTransmit();`. Line numbers verified 2026-08-04.
+**`requestNeighbors` is deliberately absent — see §2.3.4b.**
+
+| Method | Line | Method | Line |
+|---|---|---|---|
+| `sendMessage` | 3072 | `shareContact` | 4310 |
+| `sendMessageWithResult` | 3083 | `getNeighbours` | 4667 |
+| `performScopedSend` | 3253 | `loginToNode` | 4787 |
+| `sendAdvert` | 3669 | `requestNodeStatus` | 4825 |
+| `resetContactPath` | 3710 | `ensureGuestLogin` | 4893 |
+| `discoverContactPath` | 3753 | `ensureSavedLogin` | 4924 |
+| `discoverNodes` | 3789 | `loginToRoom` | 4957 |
+| `fetchOwnerName` | 3888 | `sendRoomPost` | 4990 |
+| `discoverRegions` | 4021 | `sendCliCommand` | 5185 |
+| `traceContactPath` | 4106 | `runCliCommandLocked` | 5228 |
+| `tracePathRaw` | 4171 | `requestRemoteTelemetry` | 5678 |
+| `pingContactZeroHop` | 4223 | `requestRemoteTelemetryRaw` | 5725 |
+
+`sendAdvert` (`:3669`) matters twice: its Companion branch goes through
+`sendBridgeCommand('send_advert')` (`:3687`) and its Repeater branch goes through
+`sendRepeaterCommand('advert')` (`:3676`), which bypasses the bridge gate entirely. The guard
+at the top of `sendAdvert` is the only thing covering the repeater branch.
+
+##### Insertion point — the rule, and the six methods where it is not "line 1"
+
+**Rule.** The guard goes **after** every existing validation / early-return check (device-type,
+`!this.connected`, key-format, cache-hit short-circuits) and **before** the first statement
+that mutates instance state, acquires a lock, starts a timer, or performs I/O. A guard placed
+after a mutation leaves orphaned state behind when it throws.
+
+The 18 methods not listed below open with a run of pure validation checks, so the guard is
+simply the first statement after that run. The six that need care — each was read in full on
+2026-08-04:
+
+| Method | Line | First mutation / cost | Correct insertion point |
+|---|---|---|---|
+| `sendMessageWithResult` | 3083 | Acquires the per-source scope-assert→send lock (the comment block at `:3096`-onward) | After the `!this.connected` (`:3084`) and `REPEATER` (`:3089`) early returns, **before** the lock chain |
+| `performScopedSend` | 3253 | Body is one big `try {` (`:3261`) whose first act is asserting the device's global flood scope — a real device write | **Before** the `try`, i.e. the first statement of the method body |
+| `getNeighbours` | 4667 | `await this.ensureSavedLogin(publicKey)` at `:4677` — itself an RF login, and it sits *outside* the `try` | After the two early returns at `:4671`-`:4672`, **before** the `ensureSavedLogin` call, so the login is never attempted |
+| `ensureGuestLogin` | 4893 | — (cache read first: `guestLoggedInNodes.has(publicKey)` at `:4894`) | **After** the cache-hit short-circuit. An already-established session must still return `true` — no TX is needed to reuse it. Guarding at line 1 would wrongly fail a cached session |
+| `sendCliCommand` | 5185 | Installs a promise into `this.cliCommandLocks` at `:5211`-`:5216` | After the validation run ending at `:5203` (`trimmed.length === 0`), **before** `const prior = this.cliCommandLocks.get(...)` |
+| `runCliCommandLocked` | 5228 | The whole body is `return new Promise(...)`; the executor's first act is tearing down a stale `pendingCliReplies` entry (`:5236`-`:5241`) and it later installs a timer + pending entry | **Before** `return new Promise(...)` — the first statement of the method body. A throw inside the executor would become a rejection only *after* the stale-entry teardown has run |
+
+**`recordMeshTx()` is not a hazard — verified.** All four call sites (`:4187` `tracePathRaw`,
+`:4274` `pingContactZeroHop`, `:5706` `requestRemoteTelemetry`, `:5739`
+`requestRemoteTelemetryRaw`) sit **after** a successful `sendBridgeCommand` response, as
+post-send bookkeeping. A guard at the top of those methods short-circuits long before
+`recordMeshTx()` is reachable, so no last-TX timestamp can be corrupted. Recorded here so
+implementers do not re-derive it.
+
+**Contract change to expect.** Several of these methods currently return `false` / `null` /
+a structured `{ ok: false, reason }` rather than throwing (`sendAdvert`, `resetContactPath`,
+`discoverContactPath`, `pingContactZeroHop`, `shareContact`, `sendRoomPost`, …). Adding
+`requireTransmit()` makes them *throw* in receive-only mode. That is intended and matches the
+Meshtastic pattern: schedulers never reach the throw (they silent-skip first, §2.3.6), and
+routes convert it via `failIfTxDisabled` (§2.5.1). Any other caller that treats a rejection as
+fatal must be checked during WP2.
+
+#### 2.3.4b `requestNeighbors` (`:5051`) — gate the remote branch only
+
+**Do NOT put `requireTransmit()` at the top of this method.** Verified body: it has two
+mutually exclusive branches selected by `validateMeshCorePubKey(publicKey)`:
+
+```ts
+const sanitizedTargetKey = validateMeshCorePubKey(publicKey);
+let reply: string;
+if (sanitizedTargetKey !== null) {
+  await this.ensureSavedLogin(sanitizedTargetKey);              // RF  (:5069)
+  const result = await this.sendCliCommand(sanitizedTargetKey, 'neighbors'); // RF (:5070)
+  reply = result.reply;
+} else {
+  const result = await this.sendLocalCliCommand('neighbors');   // serial-only (:5074)
+  reply = result.reply;
+}
+```
+
+The local branch (`publicKey` absent) reads the **locally attached** node's neighbour table
+over serial and puts nothing on the air. Interview decision 2 keeps local serial reads working,
+so blocking it would be a functional regression.
+
+**Implementation:** add no guard here at all. The remote branch is already covered — both
+`ensureSavedLogin` (`:4924`) and `sendCliCommand` (`:5185`) carry their own guards from the
+§2.3.4 table, so the remote path throws `TxDisabledError` naturally at `:5069`, while the local
+path (`sendLocalCliCommand`, whose only gate is the `advert` verb, §2.3.5) runs untouched.
+The everything-downstream-is-guarded property is what makes the no-guard choice safe; the WP2
+test in §3.2 pins both halves so a later refactor cannot silently break it.
+
+#### 2.3.5 Local CLI — gate the verb, not the CLI
+
+- **`sendLocalCliCommand` (`:5304`)** — after the existing empty-command check, add:
+  ```ts
+  if (this.receiveOnly && isTransmittingLocalCliVerb(trimmed)) {
+    throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+  }
+  ```
+  This single site covers **both** dispatch branches: the Repeater/Room-Server
+  `sendRepeaterCommand` path (`:5322`) and the Companion `runSyntheticLocalCli` path (`:5327`).
+  `ver`, `stats`, `clock`, `help` and every repeater `get`/`set` verb stay working.
+- **`runSyntheticLocalCli` (`:5344`)** — the `advert` branch is already covered by
+  `sendBridgeCommand('send_advert')`; no additional guard needed there. Do **not** gate the
+  whole method.
+- **Do NOT gate `sendRepeaterCommand` (`:2707`) wholesale.** Its other callers are pure config:
+  `get name` / `get radio` (`:2842`-`:2843`), `set name` (`:5408`), `set radio` (`:5439`),
+  `set tx` (`:5479`). Blocking them would break interview decision 2 (local serial config stays
+  allowed).
+
+#### 2.3.6 Scheduler / timer / auto-* silent skips
+
+Shape at every site (mirrors `meshtasticManager.ts:2278`, `:2440`, `:3354`):
+
+```ts
+if (!this.canTransmit()) {
+  logger.debug(`⏭️ [MeshCore:${this.sourceId}] <what>: Skipping - receive-only mode`);
+  return;
+}
+```
+
+`logger.debug` only. The single `logger.info` lives in `setReceiveOnly()` and fires only on a
+state change.
+
+**Placement rule — this is the load-bearing detail.** The skip must be the **first** statement
+inside the timer/interval/cron callback, *before* it reaches any guarded primitive. A guarded
+primitive throwing inside a bare `setTimeout` callback produces an unhandled rejection, not a
+skip. Verified sites:
+
+| Path | Callback / entry | TX site |
+|---|---|---|
+| DM ACK retry | `scheduleDmAckTimeout` `:3417`, `setTimeout` cb `:3428` | → `performScopedSend` |
+| Channel retry | retry `setTimeout` cb `:3593` | → `performScopedSend` |
+| Auto-pathfinding | `:6429`-ish loop; jitter `setTimeout` `:6545`; inner sleeps `:6528` | `:6503`, `:6506` |
+| Auto-announce | `:6597` / `:6660` | `:6702`, `:6722` |
+| Auto-announce advert | `autoAnnounceAdvertTimer` `:6719` | `:6722` |
+| Timer triggers | `:6754` / `:6824` | `:6842`, `:6846` |
+| Auto-responder | `checkAutoResponder` `:7050` | `:7113`, `:7117` |
+| Auto-acknowledge | `checkAutoAcknowledge` `:7313` | `:7442`, `:7446` |
+
+For the auto-pathfinding loop, the check goes both at loop entry **and** inside the per-target
+iteration, because the loop `await`s between targets (`:6528`) and the flag can flip mid-run.
+
+**Confirmed NOT gated** (no RF): `startDeviceTimeSync` (`:4639`), `schedulePathRefresh`
+(`:2908` — verified: its callback calls `refreshContacts()` → `get_contacts`, serial-only),
+`services/meshcoreTelemetryPoller.ts`, `services/meshcoreObserverPublisher.ts`,
+`startHeartbeat` (`:6221`), `scheduleNextReconnect` (`:6388`).
+
+### 2.4 `src/server/meshcoreNativeBackend.ts` — chokepoint B
+
+The backend is a **different class** from the manager and holds no `databaseService` handle.
+It learns the state by push, exactly like `respondToDiscovery`:
+
+```ts
+/** Receive-only mirror pushed by the manager (#4547). Same mechanism as respondToDiscovery. */
+private receiveOnly = false;
+
+/** Set by MeshCoreManager.setReceiveOnly() and on connect in startNativeBackend(). */
+setReceiveOnly(enabled: boolean): void { this.receiveOnly = enabled; }
+```
+
+Place `setReceiveOnly` immediately after `setRespondToDiscovery` (`:782`).
+
+**Guard 1 — `handleDiscoverRequest` (`:798`).** First statement, before the existing
+`if (!this.respondToDiscovery) return;`:
+
+```ts
+if (this.receiveOnly) {
+  logger.debug(`[MeshCoreNative:${this.sourceId}] Discovery request ignored - receive-only mode`);
+  return;
+}
+```
+
+This is the highest-risk path in the epic: it is push-driven (`PushCodes` handler at `:687`),
+it never touches `sendCommand`/`dispatch`, and it calls `c.sendToRadioFrame(out)` directly at
+`:831`. It is already rate-limited to 4/120s, so `logger.debug` here cannot spam.
+
+**Guard 2 — `sendCommand()` (belt-and-braces, also pre-covers Phase 3).** At the top of the
+public `sendCommand(cmd, params, timeout)`:
+
+```ts
+if (this.receiveOnly && isRfBridgeCommand(cmd)) {
+  throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+}
+```
+
+This closes the gap for any caller that reaches the backend without going through
+`MeshCoreManager.sendBridgeCommand` (the Virtual Node server in Phase 3, and the raw
+ANON_REQ / discover frames at `:1084`, `:1129`, `:1200`, `:1272`, which sit inside `dispatch`
+and are therefore reached only via `sendCommand`). Double-gating is harmless — both throw the
+identical branded error.
+
+### 2.5 Routes — `409 TX_DISABLED`
+
+#### 2.5.1 Two new exports in `src/server/routes/meshcoreRouteShared.ts`
+
+```ts
+/**
+ * Router middleware: reject a request on a receive-only MeshCore source with
+ * 409 TX_DISABLED. MUST be placed AFTER requirePermission(...) so a 403 still
+ * wins over a 409 for an unauthorized caller, and after meshcoreRouteGuard so
+ * res.locals.meshcoreManager is populated.
+ */
+export function requireMeshcoreTx() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const mgr = res.locals.meshcoreManager as MeshCoreManager | undefined;
+    if (mgr?.isReceiveOnly?.()) {
+      return fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
+    }
+    next();
+  };
+}
+
+/**
+ * Inline guard for handlers that transmit only on some inputs (e.g. POST /cli
+ * with the `advert` verb). Returns true when it has already sent the 409.
+ */
+export function rejectIfReceiveOnly(req: Request, res: Response): boolean {
+  if (managerFor(req, res).isReceiveOnly()) {
+    fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Catch-block mapping: converts a TxDisabledError raised mid-request (the flag
+ * flipped between the pre-check and the send) into 409 instead of 500.
+ * Returns true when it has already sent the response.
+ */
+export function failIfTxDisabled(res: Response, error: unknown): boolean {
+  if (isTxDisabledError(error)) {
+    fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
+    return true;
+  }
+  return false;
+}
+```
+
+Every touched handler's existing `catch` block gets `if (failIfTxDisabled(res, error)) return;`
+as its first line, ahead of the existing 500 path.
+
+#### 2.5.2 Route call sites — verified line numbers
+
+`requireMeshcoreTx()` inserted after `requirePermission(...)` in the middleware list:
+
+| File | Line | Method + path |
+|---|---|---|
+| `meshcoreMessagingRoutes.ts` | 255 | `POST /messages/send` |
+| | 365 | `POST /rooms/login` |
+| | 419 | `POST /rooms/login-with-saved` |
+| | 474 | `POST /rooms/post` |
+| `meshcoreContactsRoutes.ts` | 167 (`'/contacts/:publicKey/reset-path'` @168) | `POST` |
+| | 205 (`…/discover-path` @206) | `POST` |
+| | 247 (`'/discover'` @248) | `POST` |
+| | 290 (`'/regions/discover'` @291) | `POST` |
+| | 313 (`…/trace-path` @314) | `POST` |
+| | 358 (`…/ping` @359) | `POST` |
+| | 486 (`…/share` @487) | `POST` |
+| | **652 (`…/neighbours` @653)** | **`GET`** ← easy miss |
+| | 757 (`'/nodes/:publicKey/telemetry/poll'` @758) | `POST` |
+| `meshcoreAdminRoutes.ts` | 44 | `POST /admin/login` |
+| | 127 | `POST /admin/cli` |
+| | 360 | `POST /admin/login-with-saved` |
+| | **433** | **`GET /admin/status/:publicKey`** ← easy miss |
+| `meshcoreDeviceRoutes.ts` | 262 | `POST /advert` |
+| `meshcoreAutomationRoutes.ts` | 580 (`'/automation/announce/send'` @581) | `POST` |
+| | 646 (`'/automation/timers/:triggerId/run'` @647) | `POST` |
+
+Conditional transmitters — **do NOT add the `requireMeshcoreTx()` middleware to these**; an
+unconditional 409 would break a path that never touches the radio:
+
+| File | Line | Route | Handling |
+|---|---|---|---|
+| `meshcoreAdminRoutes.ts` | 230 | `POST /cli` | Inline `rejectIfReceiveOnly(req, res)` guarded by `isTransmittingLocalCliVerb(body.command)` — 409 for `advert`, normal execution for `ver` / `stats` / `clock` / `help` |
+| `meshcoreContactsRoutes.ts` | 1011 | `POST /neighbors/request` | **No pre-check.** Rely on the primitive throw + `failIfTxDisabled(res, error)` in the catch block |
+
+**`POST /neighbors/request` — correction (see §2.3.4b).** The epic plan listed this as an
+unconditional 409 route. It is not: the handler forwards to
+`MeshCoreManager.requestNeighbors(publicKey?)`, which reads the **local** node's neighbour
+table over serial when `publicKey` is absent. Blocking the whole route would break a
+receive-only-legal local read. Correct handling:
+
+- Add **no** `requireMeshcoreTx()` middleware.
+- Add `if (failIfTxDisabled(res, error)) return;` as the first line of the existing catch block.
+- A request **with** a `publicKey` → `requestNeighbors` → `ensureSavedLogin` throws
+  `TxDisabledError` → catch maps it to `409 TX_DISABLED`.
+- A request **without** a `publicKey` → local serial read → normal `200`, even while
+  receive-only.
+
+**Two GET routes transmit** (`contacts/:pk/neighbours` @652, `admin/status/:pk` @433). A
+POST-only sweep misses both. Call this out in the PR description.
+
+**Explicitly NOT gated** (serial-only, must keep working): `PUT /contacts/:publicKey/out-path`
+(`meshcoreContactsRoutes.ts:407`), `GET/POST /contacts/:publicKey/export|import` (`:571`,
+`:607`), `DELETE /contacts/:publicKey` (`:525`), every `/config/*` route in
+`meshcoreConfigRoutes.ts` (`/config/discoverable` `:28`/`:50`, `/config/default-scope` `:75`/
+`:98`, `/config/sync-time` `:212`, `/config/reboot` `:251`, `/config/private-key` `:290`/`:321`),
+`POST /connect` / `POST /disconnect` (`meshcoreDeviceRoutes.ts:50`, `:105`), and all
+`GET` read routes.
+
+### 2.6 `src/server/routes/settingsRoutes.ts` + `src/server/server.ts` — cache invalidation
+
+`settingsRoutes.ts`, in `interface SettingsCallbacks` (~`:155`, next to
+`restartAutoDeleteByDistanceService`):
+
+```ts
+// MeshCore receive-only (#4547): the manager caches the flag for sync,
+// DB-free guards, so a scoped save must push the new value immediately
+// rather than waiting for the source to reconnect.
+refreshMeshcoreReceiveOnly?: (sourceId: string) => void;
+```
+
+In the per-source write branch (`:806`-`:882`), next to the existing
+`localStatsIntervalMinutes` / `autoDeleteByDistance*` blocks:
+
+```ts
+if ('meshcoreReceiveOnly' in filteredSettings) {
+  callbacks.refreshMeshcoreReceiveOnly?.(sourceId);
+}
+```
+
+`server.ts`, in the `setSettingsCallbacks({...})` object (alongside `restartAnnounceScheduler`
+at `:848`):
+
+```ts
+refreshMeshcoreReceiveOnly: (sourceId: string) => {
+  const mgr = sourceManagerRegistry.getManager(sourceId);
+  if (mgr && isMeshCoreManager(mgr)) void mgr.refreshReceiveOnly();
+},
+```
+
+Use `isMeshCoreManager` from `sourceManagerTypes.ts` — never `instanceof`, never an `as any`
+cast (CLAUDE.md hard rule, and `no-explicit-any` is an ESLint error).
+
+The callback fires **after** `setSourceSettings()` has persisted, so `refreshReceiveOnly()`'s
+DB read observes the value the user just saved (same post-write-read rationale documented at
+`settingsRoutes.ts:~857`).
+
+### 2.7 Frontend read contract (Phase 1 ships the backend half)
+
+**Decision: `GET /api/sources` → `radio` is the primary read path.** Rationale:
+- It is already per-source and already multi-source-aware, which is what a MeshCore receive-only
+  UI needs (one source can be receive-only while its siblings transmit).
+- `computeSourceRadioSummary` is already synchronous and already has an `isMeshCoreManager`
+  branch — `canTransmit()` being sync (§2.3.1) makes this a two-line change.
+- The client type and consumer already exist (`src/types/elevation.ts:40`,
+  `src/hooks/useDashboardData.ts:34`), so Phase 2 gets the data with no new fetch.
+- Rejected alternative: a new `GET /api/sources/:id/meshcore/tx-status` endpoint — an extra
+  round trip per source and a fourth place to keep in sync.
+
+`src/server/routes/sourceRoutes.ts`:
+- Extend `interface SourceRadioSummary` (`:414`) with:
+  ```ts
+  /** MeshCore only (#4547). True when the source is configured strictly receive-only. */
+  receiveOnly?: boolean;
+  ```
+  (`canTransmit?: boolean` already exists at the end of the interface — reuse it, do not add a
+  second field.)
+- In the `isMeshCoreManager(mgr)` branch of `computeSourceRadioSummary` (~`:487`):
+  ```ts
+  const freq = mgr.getLocalNode()?.radioFreq;
+  return {
+    frequencyMhz: typeof freq === 'number' && Number.isFinite(freq) ? freq : null,
+    receiveOnly: mgr.isReceiveOnly(),
+    canTransmit: mgr.canTransmit(),
+  };
+  ```
+  Both are sync and cannot throw; the surrounding try/catch already covers the accessor.
+
+`src/types/elevation.ts` — mirror `receiveOnly?: boolean` onto the client
+`SourceRadioSummary` (`:40`). `canTransmit` should already be there; add it if not. Purely
+additive, no consumer changes in Phase 1.
+
+**Secondary: `GET /api/device/tx-status`.** Extend `deviceStatusRoutes.ts:9` so `useTxStatus` +
+`AppBanners` keep working unchanged on a MeshCore-primary install:
+
+```ts
+const mgr = resolveSourceManager(txSourceId);
+if (isMeshCoreManager(mgr)) {
+  const canTx = mgr.canTransmit();
+  return res.json({ txEnabled: canTx, udpRelayEnabled: false, canTransmit: canTx });
+}
+// …existing Meshtastic path unchanged…
+```
+
+Keep the existing bare-object wire shape (`res.json`, not `ok()`) — `ApiService` does not
+unwrap `data` and `useTxStatus` reads the fields directly. **Implementer must first verify
+that `resolveSourceManager(sourceId)` (`src/server/utils/resolveSourceManager.ts`) returns
+MeshCore managers for an explicit `?sourceId=`.** If it is Meshtastic-only, resolve via
+`sourceManagerRegistry.getManager(sourceId)` + `isMeshCoreManager` inside this handler instead
+and note it in the PR. If neither works cleanly, drop this secondary path — `/api/sources` is
+the required one and is sufficient for Phase 2.
+
+---
+
+## 3. Test plan
+
+All tests are standard Vitest files inside the existing suite. No standalone scripts. All
+DatabaseService mocks use `mockResolvedValue`. No `any` (ESLint ratchet).
+
+### 3.1 `src/server/constants/meshcoreTx.test.ts` — denylist completeness (REQUIRED)
+
+The regression net for "someone adds a new bridge command and forgets to classify it."
+
+- Read `src/server/meshcoreNativeBackend.ts` and `src/server/meshcoreManager.ts` as text
+  (`fs.readFileSync`, precedent: `server.settings-persistence.test.ts`).
+- Extract every `case '<name>':` in the backend's dispatch switch and every
+  `sendBridgeCommand('<name>'` / `sendBridgeCommand(\n '<name>'` literal in the manager
+  (there is one multi-line call site at `meshcoreManager.ts:4259-4260` — the regex must
+  tolerate a newline between `(` and the literal).
+- Assert every extracted name appears in exactly one of `RF_BRIDGE_COMMANDS` /
+  `SERIAL_ONLY_BRIDGE_COMMANDS`. Failure message must name the unclassified command and point
+  at `meshcoreTx.ts`.
+- Assert the two sets are disjoint.
+- Assert current sizes: 14 RF / 28 serial-only / 42 total (a deliberate pin, like
+  `PER_SOURCE_KEYS_NOT_POSTABLE.size`).
+- Assert fail-closed: `isRfBridgeCommand('some_command_that_does_not_exist') === true`.
+- Assert `isTransmittingLocalCliVerb`: `'advert'`, `'ADVERT'`, `' advert '` → true;
+  `'ver'`, `'stats radio'`, `'clock'`, `'help'`, `'get name'` → false.
+
+### 3.2 `src/server/meshcoreManager.receiveOnly.test.ts` — guards
+
+- `canTransmit()` / `isReceiveOnly()` default to transmit-allowed on a fresh manager.
+- `refreshReceiveOnly()` reads `getSettingForSource(sourceId, 'meshcoreReceiveOnly')`
+  (`mockResolvedValue('true')`) and flips the flag.
+- A DB read that rejects leaves the previously-cached value intact (fail-safe, §2.3.1).
+- `setReceiveOnly` emits exactly one `logger.info` on a change and **zero** on a repeat of the
+  same value (spy on the logger).
+- Every method in the §2.3.4 table rejects with an error satisfying `isTxDisabledError(err)`
+  and carrying `code === 'TX_DISABLED'`.
+- `sendBridgeCommand` (exercised via a serial-only public method, e.g. `getChannels` /
+  `setDeviceName`) still reaches the backend while receive-only. At minimum cover
+  `get_channels`, `set_name`, `set_radio`, `get_stats`, `device_query`, `set_device_time`.
+- `sendBridgeCommand('send_message', …)` throws even when the calling method's own guard is
+  bypassed (call the private via a narrowly-typed test accessor, not `as any`).
+- `sendLocalCliCommand('advert')` throws; `sendLocalCliCommand('ver')` does not.
+- **`requestNeighbors` branch split (§2.3.4b) — REQUIRED.** While receive-only:
+  - `requestNeighbors('<64-hex key>')` (remote branch) rejects with an
+    `isTxDisabledError`-satisfying error, and `sendCliCommand` is never reached.
+  - `requestNeighbors()` and `requestNeighbors(undefined)` (local branch) **resolve normally**,
+    reach `sendLocalCliCommand('neighbors')`, and return parsed neighbours. This is the
+    regression net for the "gate the whole method" mistake.
+- **Insertion-point checks (§2.3.4).** For each of the six methods with a non-trivial insertion
+  point, assert that throwing left no orphaned state: `sendCliCommand` did not add an entry to
+  `cliCommandLocks`; `runCliCommandLocked` did not add an entry to `pendingCliReplies` and
+  started no timer; `ensureGuestLogin` with an already-cached session returns `true` instead of
+  throwing; `getNeighbours` never calls `ensureSavedLogin`.
+- `connect()` calls `refreshReceiveOnly()` before arming schedulers, and does so again on a
+  second `connect()` (reconnect survival).
+- `setReceiveOnly(true)` propagates to `nativeBackend.setReceiveOnly` (spy).
+
+### 3.3 `src/server/meshcoreManager.receiveOnlySchedulers.test.ts` — silent skips
+
+For each of DM-ACK retry, channel retry, auto-pathfinding, auto-announce, auto-announce advert,
+timer triggers, auto-responder, auto-acknowledge (use fake timers):
+
+- With receive-only ON: the tick completes, `sendBridgeCommand` is never called, **no promise
+  rejection escapes** (assert via an `unhandledRejection` listener or by awaiting the tick and
+  asserting it resolves), and the interval/cron is still armed afterwards.
+- Run ≥ 5 ticks and assert `logger.info` was called **0 times** across them (no per-tick spam);
+  `logger.debug` may be called.
+- With receive-only OFF: the same tick does reach the send primitive (proves the skip is
+  conditional, not a permanent disable).
+
+Also extend `src/server/services/meshcoreRemoteTelemetryScheduler.test.ts`: with a receive-only
+manager, `tickOneManager` returns before calling `requestRemoteTelemetry`. Add matching
+coverage for `MeshCoreRoomSyncScheduler.tickOneManager` (`meshcoreRoomSyncScheduler.ts:109`,
+which calls `manager.loginToRoom` at `:145`) — a new
+`src/server/services/meshcoreRoomSyncScheduler.test.ts` if none exists.
+
+### 3.4 `src/server/meshcoreNativeBackend.receiveOnly.test.ts` — chokepoint B
+
+Model on `src/server/meshcoreNativeBackend.discovery.test.ts:271-303`.
+
+- `setRespondToDiscovery(true)` + `setReceiveOnly(true)` + inbound `0x8E` discovery frame →
+  `sendToRadioFrame` **not** called.
+- Same, with `setReceiveOnly(false)` → `sendToRadioFrame` called once with a frame whose
+  `out[0] === 55` (proves the negative case is not vacuous).
+- `setReceiveOnly(true)` then `sendCommand('send_message', {})` rejects with a
+  `isTxDisabledError`-satisfying error.
+- `setReceiveOnly(true)` then `sendCommand('get_contacts', {})` does **not** throw on the gate.
+
+### 3.5 `src/server/routes/meshcoreRoutes.receiveOnly.test.ts` — 409 mapping
+
+Uses `createRouteTestApp()` (mandatory for new route tests) with the MeshCore routers mounted
+and `sourceManagerRegistry` mocked to return a fake MeshCore manager (mock-registry pattern is
+still correct; only the DB/permission mocking is replaced by the harness).
+
+- Every route in the §2.5.2 table returns `409` with body
+  `{ success: false, code: 'TX_DISABLED', error: MESHCORE_RECEIVE_ONLY_MESSAGE }`. **Both GET
+  routes must have their own explicit cases.**
+- `POST /admin/cli` with `{ command: 'advert' }` → 409; with `{ command: 'ver' }` → not 409.
+  (Note: `/cli` is `meshcoreAdminRoutes.ts:230`; `/admin/cli` at `:127` is remote-admin and is
+  unconditionally gated.)
+- Ordering: an **unauthorized** user hitting a gated route on a receive-only source still gets
+  `403`, not `409` (proves `requireMeshcoreTx` sits after `requirePermission`).
+- Negative control: with receive-only OFF, the same routes do not return 409.
+- Serial-config still works while receive-only: `POST /config/discoverable`,
+  `POST /config/sync-time`, `PUT /contacts/:publicKey/out-path`, `GET /contacts`,
+  `GET /messages` all succeed.
+- Race mapping: a handler whose manager method throws `TxDisabledError` mid-request (mock the
+  manager to reject) returns 409, not 500.
+
+### 3.6 `src/server/meshcoreManager.receiveOnly.perSource.test.ts` — isolation (REQUIRED)
+
+- Two `MeshCoreManager` instances, `source-a` and `source-b`.
+- `getSettingForSource` mocked to return `'true'` only for `('source-a', 'meshcoreReceiveOnly')`.
+- After `refreshReceiveOnly()` on both: A throws `TxDisabledError` from `sendMessage`; B sends
+  successfully.
+- `refreshMeshcoreReceiveOnly('source-a')` (via the callback) does not change B's cached flag.
+- `computeSourceRadioSummary`-shaped assertion: A reports `{ receiveOnly: true, canTransmit: false }`,
+  B reports `{ receiveOnly: false, canTransmit: true }`.
+
+### 3.7 `src/server/routes/sourceRoutes.radio.test.ts` — extend
+
+Add a MeshCore-source case asserting `radio.receiveOnly` and `radio.canTransmit` appear on
+`GET /api/sources`, both when the flag is on and off. Existing Meshtastic assertions must be
+unchanged.
+
+### 3.8 `src/server/constants/settings.allowlist.test.ts` — run, do not edit
+
+Must pass **unmodified**. A required edit there means the key landed in the wrong array (§2.1).
+
+### 3.9 Whole-suite requirement
+
+Full Vitest suite green (0 failures) before PR. Confirm `success: true` via the JSON reporter —
+`rtk`'s `PASS (N) FAIL (0)` summary counts assertion failures only. This change touches no
+schema and adds no migration, so the PostgreSQL/MySQL containers are not required, but
+`npm run lint:ci` must be clean (judge in-repo failures only:
+`npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` → empty).
+
+---
+
+## 4. Work packages
+
+All agents share the one worktree, so **file overlap forces sequencing**.
+
+| File | WP1 | WP2 | WP3 | WP4 | WP5 |
+|---|---|---|---|---|---|
+| `constants/settings.ts`, `constants/meshcoreTx.ts` | ✅ | | | | |
+| `meshcoreManager.ts` | ✅ | ✅ | ✅ | | |
+| `meshcoreNativeBackend.ts` | | | ✅ | | |
+| `routes/settingsRoutes.ts`, `server.ts` | ✅ | | | | |
+| `services/meshcore*Scheduler.ts` | | | ✅ | | |
+| `routes/meshcoreRouteShared.ts` + 5 meshcore route files | | | | ✅ | |
+| `routes/sourceRoutes.ts`, `routes/deviceStatusRoutes.ts`, `types/elevation.ts` | | | | | ✅ |
+
+**Dependency order:** `WP1` → then `WP2` → `WP3` (strictly sequential: both edit
+`meshcoreManager.ts`), with `WP4` and `WP5` running **in parallel** alongside WP2/WP3 (no file
+overlap with them, and none with each other).
+
+```
+WP1 ──┬── WP2 ── WP3
+      ├── WP4        (parallel)
+      └── WP5        (parallel)
+```
+
+---
+
+### WP1 — Foundations: setting, denylist, manager state, invalidation
+
+**Files:** `src/server/constants/settings.ts`, `src/server/constants/meshcoreTx.ts` (new),
+`src/server/meshcoreManager.ts` (state block + `connect()` refresh + `startNativeBackend()`
+push + `sendBridgeCommand` gate **only**), `src/server/routes/settingsRoutes.ts`,
+`src/server/server.ts`.
+**Tests:** §3.1 (`meshcoreTx.test.ts`), and the state/refresh/`sendBridgeCommand` subset of §3.2.
+
+**Acceptance:**
+- `meshcoreReceiveOnly` is in `VALID_SETTINGS_KEYS` and `PER_SOURCE_SETTINGS_KEYS`;
+  `settings.allowlist.test.ts` passes **unmodified**.
+- `isReceiveOnly()` / `canTransmit()` / `setReceiveOnly()` / `refreshReceiveOnly()` exist with
+  the §2.3.1 signatures; `canTransmit()` is synchronous and performs no DB access.
+- `sendBridgeCommand` throws `TxDisabledError` for every RF command and passes every
+  serial-only command while receive-only.
+- `isRfBridgeCommand` is fail-closed; `meshcoreTx.test.ts` fails if a `case` is added to the
+  native backend without classification (verify by temporarily adding a fake case).
+- `POST /api/settings?sourceId=X` with `meshcoreReceiveOnly` invokes
+  `refreshMeshcoreReceiveOnly(X)`; a second `connect()` re-reads the flag.
+- `tsc` clean, no new `any`.
+
+### WP2 — Manager primitive guards + local CLI verb gate
+
+**Files:** `src/server/meshcoreManager.ts` only. **Depends on:** WP1.
+**Tests:** remainder of §3.2.
+
+**Acceptance:**
+- All 24 methods in the §2.3.4 table call `this.requireTransmit()`, and each has a test
+  asserting `isTxDisabledError`.
+- **Guard placement (anti-regression, REQUIRED).** For every guarded method, the
+  `requireTransmit()` call sits **after** the existing validation / early-return run and
+  **before** the first statement that mutates instance state, acquires a lock, starts a timer,
+  or performs I/O. Reviewer checks the six methods named in §2.3.4 explicitly —
+  `sendMessageWithResult` (:3083), `performScopedSend` (:3253), `getNeighbours` (:4667),
+  `ensureGuestLogin` (:4893), `sendCliCommand` (:5185), `runCliCommandLocked` (:5228) — against
+  the insertion points given there. The orphaned-state assertions in §3.2 must be present and
+  passing; a guard that throws after a lock/timer/pending-map write fails this package even if
+  every other test is green. `recordMeshTx()` needs no attention (verified post-send at all
+  four sites).
+- **`requestNeighbors` (:5051) is NOT gated** (§2.3.4b). Its remote branch throws via
+  `ensureSavedLogin` / `sendCliCommand`; its local branch still works. Both halves have tests.
+- `sendLocalCliCommand('advert')` throws on both Companion and Repeater device types;
+  `ver` / `stats` / `clock` / `help` / `get name` / `set radio` still work.
+- `sendRepeaterCommand` is **not** gated wholesale — `set name` / `set radio` / `set tx` /
+  `get name` / `get radio` still function while receive-only (assert at least two).
+- No route file, backend file, or scheduler file touched.
+
+### WP3 — Scheduler silent skips + native backend (chokepoint B)
+
+**Files:** `src/server/meshcoreManager.ts` (timer/auto-* callbacks only),
+`src/server/meshcoreNativeBackend.ts`, `src/server/services/meshcoreRemoteTelemetryScheduler.ts`,
+`src/server/services/meshcoreRoomSyncScheduler.ts`.
+**Depends on:** WP2 (same file). **Tests:** §3.3, §3.4.
+
+**Acceptance:**
+- Every path in the §2.3.6 table skips first-statement-in-callback, logs at `debug`, and leaves
+  its timer/cron armed.
+- Across ≥ 5 ticks with receive-only ON, `logger.info` fires zero times; the only `info` is the
+  one-shot state-change line in `setReceiveOnly`.
+- No unhandled promise rejection from any timer path (explicitly asserted).
+- `handleDiscoverRequest` emits no `sendToRadioFrame` while receive-only; it does when the flag
+  is off.
+- `MeshCoreNativeBackend.setReceiveOnly` exists and `sendCommand` gates RF commands.
+- Both scheduler services return before their TX call.
+
+### WP4 — Route layer: shared helpers + 409 mapping
+
+**Files:** `src/server/routes/meshcoreRouteShared.ts`, `meshcoreMessagingRoutes.ts`,
+`meshcoreContactsRoutes.ts`, `meshcoreAdminRoutes.ts`, `meshcoreDeviceRoutes.ts`,
+`meshcoreAutomationRoutes.ts`. **Depends on:** WP1. **Parallel with:** WP2, WP3, WP5.
+**Tests:** §3.5.
+
+**Acceptance:**
+- `requireMeshcoreTx`, `rejectIfReceiveOnly`, `failIfTxDisabled` exported from
+  `meshcoreRouteShared.ts`, all emitting via `fail(res, 409, TX_DISABLED_CODE, …)`.
+- All 20 unconditional routes in §2.5.2 (including **both GET routes**) return 409.
+- The two conditional routes behave per §2.5.2: `POST /cli` returns 409 only for the `advert`
+  verb; `POST /neighbors/request` returns 409 only when a `publicKey` is supplied.
+- `POST /neighbors/request` with a `publicKey` → 409; **without** a `publicKey` → not 409
+  (local serial read still works while receive-only). Both cases required.
+- A 403 still beats a 409 for an unauthorized caller.
+- Every touched handler's catch block maps `TxDisabledError` → 409 rather than 500.
+- Config/read/connect routes listed as "explicitly NOT gated" still return their normal
+  responses while receive-only.
+- Tests use `createRouteTestApp()`; no new `vi.mock('../../services/database.js', …)`.
+
+### WP5 — Frontend read contract + per-source isolation
+
+**Files:** `src/server/routes/sourceRoutes.ts`, `src/server/routes/deviceStatusRoutes.ts`,
+`src/types/elevation.ts`. **Depends on:** WP1. **Parallel with:** WP2, WP3, WP4.
+**Tests:** §3.6, §3.7.
+
+**Acceptance:**
+- `GET /api/sources` returns `radio.receiveOnly` and `radio.canTransmit` for MeshCore sources;
+  the Meshtastic branch and every existing field are byte-identical.
+- `src/types/elevation.ts` `SourceRadioSummary` mirrors the new field.
+- `GET /api/device/tx-status?sourceId=<meshcore>` reports the receive-only state in the existing
+  `{ txEnabled, udpRelayEnabled, canTransmit }` shape — **or** the PR documents why
+  `resolveSourceManager` could not resolve a MeshCore manager and this half was dropped.
+- `meshcoreManager.receiveOnly.perSource.test.ts` proves source A's flag does not affect
+  source B, in both the manager guards and the radio summary.
+
+---
+
+## 5. Phase 1 exit criteria
+
+1. With `meshcoreReceiveOnly=true` on a MeshCore source, no code path reaches
+   `sendToRadioFrame` or an RF bridge command — verified by the denylist test, the backend
+   discovery test, and the manager guard tests.
+2. Every route in §2.5.2 returns `409 TX_DISABLED`; serial config, contact CRUD, reads, and
+   connect/disconnect all still work.
+3. Schedulers keep ticking and skip silently; no per-tick log spam; no unhandled rejections;
+   no user automation setting is mutated.
+4. The flag survives `connect()` reconnects and takes effect on a settings write without a
+   restart.
+5. `GET /api/sources` exposes the state per source for Phase 2.
+6. Full Vitest suite green; `npm run lint:ci` clean of in-repo failures; no new `any`; no new
+   emoji/Unicode icon stand-ins in any user-facing string.
+
+## 6. Known non-goals for Phase 1
+
+- No UI. No toggle, no banner, no disabled controls (Phase 2).
+- No Virtual Node command rejection (Phase 3) — though `MeshCoreNativeBackend.sendCommand`'s
+  gate (§2.4) already blocks any VN command that routes through it.
+- No user-facing docs (Phase 3).
+- MeshMonitor cannot stop firmware-autonomous transmissions (link-layer ACKs, on-device advert
+  schedules set outside MeshMonitor). Documented in Phase 3; do not attempt a workaround here.

--- a/src/server/constants/meshcoreTx.test.ts
+++ b/src/server/constants/meshcoreTx.test.ts
@@ -39,11 +39,42 @@ function extractSendBridgeCommandLiterals(source: string): string[] {
   return [...names];
 }
 
+/**
+ * Isolate the source text of `private async dispatch(cmd: string, ...)` —
+ * the bridge-command switch — by brace-counting from its signature to the
+ * matching close brace. Anchoring here (rather than scanning the whole file)
+ * keeps this test from tripping on an unrelated lowercase `case` label in
+ * some other switch (push codes, status codes, etc.) added later.
+ */
+function extractDispatchMethodSource(source: string): string {
+  const marker = 'private async dispatch(cmd: string';
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error(
+      "Could not locate 'private async dispatch(cmd: string' in meshcoreNativeBackend.ts — " +
+        'has the bridge-command dispatch method been renamed or reshaped? Update the marker in ' +
+        'extractDispatchMethodSource to match.',
+    );
+  }
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  let i = braceStart;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(start, i + 1);
+}
+
 function extractDispatchCaseLiterals(source: string): string[] {
+  const dispatchSource = extractDispatchMethodSource(source);
   const re = /case '([a-z_]+)':/g;
   const names = new Set<string>();
   let match: RegExpExecArray | null;
-  while ((match = re.exec(source)) !== null) {
+  while ((match = re.exec(dispatchSource)) !== null) {
     names.add(match[1]);
   }
   return [...names];

--- a/src/server/constants/meshcoreTx.test.ts
+++ b/src/server/constants/meshcoreTx.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  RF_BRIDGE_COMMANDS,
+  SERIAL_ONLY_BRIDGE_COMMANDS,
+  isRfBridgeCommand,
+  isTransmittingLocalCliVerb,
+} from './meshcoreTx.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Denylist-completeness test (#4547 Phase 1 §3.1).
+ *
+ * Reads meshcoreManager.ts and meshcoreNativeBackend.ts as text and extracts
+ * every bridge-command literal each file references, then asserts every one
+ * is classified in exactly one of RF_BRIDGE_COMMANDS / SERIAL_ONLY_BRIDGE_COMMANDS.
+ *
+ * This is the regression net for "someone adds a new bridge command and
+ * forgets to classify it." A new `case '<name>':` added to the native
+ * backend's dispatch switch without a matching entry in meshcoreTx.ts fails
+ * this test at review time (verified manually during implementation by
+ * temporarily adding a fake case and confirming this test fails, then
+ * removing it).
+ */
+
+function extractSendBridgeCommandLiterals(source: string): string[] {
+  // Matches `sendBridgeCommand('name'` and `sendBridgeCommand(\n  'name'`
+  // (tolerates a newline/whitespace between the open paren and the literal —
+  // there is one multi-line call site for 'trace_path').
+  const re = /sendBridgeCommand\(\s*'([a-z_]+)'/g;
+  const names = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    names.add(match[1]);
+  }
+  return [...names];
+}
+
+function extractDispatchCaseLiterals(source: string): string[] {
+  const re = /case '([a-z_]+)':/g;
+  const names = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    names.add(match[1]);
+  }
+  return [...names];
+}
+
+describe('meshcoreTx denylist completeness (#4547)', () => {
+  const managerSource = fs.readFileSync(
+    path.join(__dirname, '../meshcoreManager.ts'),
+    'utf-8',
+  );
+  const backendSource = fs.readFileSync(
+    path.join(__dirname, '../meshcoreNativeBackend.ts'),
+    'utf-8',
+  );
+
+  const managerCommands = extractSendBridgeCommandLiterals(managerSource);
+  const backendCommands = extractDispatchCaseLiterals(backendSource);
+  const allCommands = new Set<string>([...managerCommands, ...backendCommands]);
+
+  it('extracted at least the expected command literals from source', () => {
+    // Sanity check that the extraction itself isn't silently returning
+    // nothing (e.g. a renamed method breaking the regex).
+    expect(managerCommands.length).toBeGreaterThan(0);
+    expect(backendCommands.length).toBeGreaterThan(0);
+  });
+
+  it('classifies every extracted command name in exactly one of the two sets', () => {
+    const unclassified = [...allCommands].filter(
+      (cmd) => !RF_BRIDGE_COMMANDS.has(cmd) && !SERIAL_ONLY_BRIDGE_COMMANDS.has(cmd),
+    );
+    expect(
+      unclassified,
+      `Unclassified bridge command(s) found in source: ${unclassified.join(', ')}. ` +
+        `Add each to either RF_BRIDGE_COMMANDS or SERIAL_ONLY_BRIDGE_COMMANDS in ` +
+        `src/server/constants/meshcoreTx.ts.`,
+    ).toEqual([]);
+
+    const doubleClassified = [...allCommands].filter(
+      (cmd) => RF_BRIDGE_COMMANDS.has(cmd) && SERIAL_ONLY_BRIDGE_COMMANDS.has(cmd),
+    );
+    expect(doubleClassified).toEqual([]);
+  });
+
+  it('RF_BRIDGE_COMMANDS and SERIAL_ONLY_BRIDGE_COMMANDS are disjoint', () => {
+    const overlap = [...RF_BRIDGE_COMMANDS].filter((cmd) => SERIAL_ONLY_BRIDGE_COMMANDS.has(cmd));
+    expect(overlap).toEqual([]);
+  });
+
+  it('pins the current classification sizes (deliberate, like PER_SOURCE_KEYS_NOT_POSTABLE.size)', () => {
+    expect(RF_BRIDGE_COMMANDS.size).toBe(14);
+    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(28);
+    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(42);
+  });
+});
+
+describe('isRfBridgeCommand (#4547)', () => {
+  it('returns true (fail-closed) for a command name not in either set', () => {
+    expect(isRfBridgeCommand('some_command_that_does_not_exist')).toBe(true);
+  });
+
+  it('returns false for every serial-only command', () => {
+    for (const cmd of SERIAL_ONLY_BRIDGE_COMMANDS) {
+      expect(isRfBridgeCommand(cmd)).toBe(false);
+    }
+  });
+
+  it('returns true for every RF command', () => {
+    for (const cmd of RF_BRIDGE_COMMANDS) {
+      expect(isRfBridgeCommand(cmd)).toBe(true);
+    }
+  });
+});
+
+describe('isTransmittingLocalCliVerb (#4547)', () => {
+  it.each(['advert', 'ADVERT', ' advert '])('returns true for %j', (cmd) => {
+    expect(isTransmittingLocalCliVerb(cmd)).toBe(true);
+  });
+
+  it.each(['ver', 'stats radio', 'clock', 'help', 'get name'])('returns false for %j', (cmd) => {
+    expect(isTransmittingLocalCliVerb(cmd)).toBe(false);
+  });
+});

--- a/src/server/constants/meshcoreTx.ts
+++ b/src/server/constants/meshcoreTx.ts
@@ -1,0 +1,59 @@
+/**
+ * MeshCore receive-only mode (#4547) — bridge-command classification.
+ *
+ * `sendBridgeCommand` carries BOTH over-the-air commands and local serial
+ * config commands, so the receive-only gate must be command-name aware.
+ *
+ * FAIL-CLOSED: `isRfBridgeCommand()` returns true for any name not explicitly
+ * listed as serial-only. A bridge command added in the future without touching
+ * this file is therefore BLOCKED in receive-only mode rather than silently
+ * transmitting. `meshcoreTx.test.ts` additionally fails the build so the
+ * omission is caught at review time, not at runtime.
+ */
+
+/** Commands that put energy on the LoRa radio. Blocked in receive-only mode. */
+export const RF_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
+  'send_message',
+  'send_advert',
+  'send_cli',
+  'discover_path',
+  'discover_nodes',
+  'request_owner',
+  'request_regions',
+  'request_telemetry',
+  'trace_path',
+  'share_contact',
+  'get_neighbours',
+  'login',
+  'get_status',
+  'reset_path',
+]);
+
+/** Local-serial-only commands. Allowed in receive-only mode. */
+export const SERIAL_ONLY_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
+  'get_channels', 'set_channel', 'delete_channel',
+  'get_self_info', 'get_contacts', 'remove_contact',
+  'export_contact', 'import_contact',
+  'export_private_key', 'import_private_key',
+  'set_name', 'set_radio', 'set_tx_power', 'set_coords',
+  'set_advert_loc_policy', 'set_other_params', 'set_flood_scope', 'set_out_path',
+  'set_telemetry_mode_base', 'set_telemetry_mode_loc', 'set_telemetry_mode_env',
+  'get_stats', 'get_device_time', 'set_device_time', 'device_query',
+  'reboot', 'shutdown', 'ping',
+]);
+
+export function isRfBridgeCommand(cmd: string): boolean {
+  return !SERIAL_ONLY_BRIDGE_COMMANDS.has(cmd);
+}
+
+/** Local-CLI verbs (Companion synthetic CLI and Repeater serial CLI) that transmit. */
+export const RF_LOCAL_CLI_VERBS: ReadonlySet<string> = new Set(['advert']);
+
+export function isTransmittingLocalCliVerb(command: string): boolean {
+  const verb = command.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+  return RF_LOCAL_CLI_VERBS.has(verb);
+}
+
+/** Single user-facing message for every receive-only rejection. */
+export const MESHCORE_RECEIVE_ONLY_MESSAGE =
+  'Transmission blocked: this MeshCore source is configured for receive-only operation.';

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -308,6 +308,9 @@ export const VALID_SETTINGS_KEYS = [
   // traffic (DMs, adverts, requests) unless a channel overrides it. Empty =
   // unscoped (legacy '*' / null region).
   'meshcoreDefaultScope',
+  // MeshCore strict receive-only mode (#4547) — per source. Blocks every
+  // RF-transmitting command/scheduler on this MeshCore source when true.
+  'meshcoreReceiveOnly',
   // Terrain Link Profile / elevation backend (#4111 Phase 1). Global (not
   // per-source) — elevation is source-agnostic public DEM data.
   // `elevationEnabled` is the public availability flag the Map Analysis page
@@ -478,6 +481,8 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'meshcoreTimerTriggers',
   // MeshCore default region/scope (#3667) — per source (per node)
   'meshcoreDefaultScope',
+  // MeshCore strict receive-only mode (#4547) — per source (#4547 §2.1)
+  'meshcoreReceiveOnly',
   // Node Display (#4412 / per-source node display epic). All ten keys in the
   // Settings → Node Display section are per-source as of Phase 1; Phase 2 converts
   // the server reads to getSettingForSource(). `localStatsIntervalMinutes` is

--- a/src/server/meshcoreManager.receiveOnly.perSource.test.ts
+++ b/src/server/meshcoreManager.receiveOnly.perSource.test.ts
@@ -1,0 +1,132 @@
+/**
+ * MeshCore strict receive-only mode (#4547 epic, Phase 1 WP5) — per-source
+ * isolation (spec §3.6).
+ *
+ * The whole point of this file: `meshcoreReceiveOnly` is a per-source
+ * setting (CLAUDE.md "Per-source scoping is mandatory"). Two independent
+ * `MeshCoreManager` instances must never leak the flag into one another —
+ * neither through the manager's own TX guards nor through the
+ * `computeSourceRadioSummary`-shaped read the dashboard consumes
+ * (`src/server/routes/sourceRoutes.ts`).
+ *
+ * See docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md §3.6.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+import { isTxDisabledError } from './errors/txDisabledError.js';
+
+const SOURCE_A = 'source-a';
+const SOURCE_B = 'source-b';
+
+/** Only source-a's meshcoreReceiveOnly setting is 'true'; everything else reads null. */
+function mockPerSourceReceiveOnly(): void {
+  vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+    async (sourceId: string, key: string) => {
+      if (sourceId === SOURCE_A && key === 'meshcoreReceiveOnly') return 'true';
+      return null;
+    },
+  );
+}
+
+/**
+ * A manager wired just enough to reach the receive-only guard inside
+ * `sendMessage` → `sendMessageWithResult`: connected, a non-repeater device
+ * type, and `performScopedSend` stubbed so a "successful send" doesn't need
+ * a real device/DB round trip (that machinery is exercised by its own
+ * tests elsewhere; this file only cares about the receive-only gate).
+ */
+function connectedCompanion(sourceId: string): MeshCoreManager {
+  const m = new MeshCoreManager(sourceId);
+  (m as any).connected = true;
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).performScopedSend = vi.fn().mockResolvedValue({ ok: true });
+  return m;
+}
+
+describe('MeshCoreManager receive-only — per-source isolation (#4547 WP5)', () => {
+  beforeEach(() => {
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('refreshReceiveOnly() on both managers only flips the flag for the source whose setting is true', async () => {
+    mockPerSourceReceiveOnly();
+    const a = new MeshCoreManager(SOURCE_A);
+    const b = new MeshCoreManager(SOURCE_B);
+
+    await a.refreshReceiveOnly();
+    await b.refreshReceiveOnly();
+
+    expect(a.isReceiveOnly()).toBe(true);
+    expect(a.canTransmit()).toBe(false);
+    expect(b.isReceiveOnly()).toBe(false);
+    expect(b.canTransmit()).toBe(true);
+  });
+
+  it('source A rejects sendMessage with TxDisabledError while source B sends successfully', async () => {
+    mockPerSourceReceiveOnly();
+    const a = connectedCompanion(SOURCE_A);
+    const b = connectedCompanion(SOURCE_B);
+
+    await a.refreshReceiveOnly();
+    await b.refreshReceiveOnly();
+
+    let caught: unknown;
+    try {
+      await a.sendMessage('hello from A');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isTxDisabledError(caught)).toBe(true);
+    expect((a as any).performScopedSend).not.toHaveBeenCalled();
+
+    const bOk = await b.sendMessage('hello from B');
+    expect(bOk).toBe(true);
+    expect((b as any).performScopedSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshMeshcoreReceiveOnly-style targeted refresh of source A does not change source B\'s cached flag', async () => {
+    // Simulates the settings-write callback (settingsRoutes.ts → server.ts
+    // refreshMeshcoreReceiveOnly(sourceId)): only the manager for the
+    // written sourceId is refreshed.
+    const a = new MeshCoreManager(SOURCE_A);
+    const b = new MeshCoreManager(SOURCE_B);
+
+    // Both start false (default).
+    expect(a.isReceiveOnly()).toBe(false);
+    expect(b.isReceiveOnly()).toBe(false);
+
+    mockPerSourceReceiveOnly();
+    await a.refreshReceiveOnly(); // only A is refreshed, as the real callback does
+
+    expect(a.isReceiveOnly()).toBe(true);
+    expect(b.isReceiveOnly()).toBe(false);
+    expect(b.canTransmit()).toBe(true);
+  });
+
+  it('computeSourceRadioSummary-shaped read: A reports receiveOnly/canTransmit true/false, B reports the opposite', async () => {
+    mockPerSourceReceiveOnly();
+    const a = new MeshCoreManager(SOURCE_A);
+    const b = new MeshCoreManager(SOURCE_B);
+    await a.refreshReceiveOnly();
+    await b.refreshReceiveOnly();
+
+    // Mirrors the isMeshCoreManager branch added to computeSourceRadioSummary
+    // in src/server/routes/sourceRoutes.ts (#4547 WP5).
+    const summaryOf = (m: MeshCoreManager) => ({
+      receiveOnly: m.isReceiveOnly(),
+      canTransmit: m.canTransmit(),
+    });
+
+    expect(summaryOf(a)).toEqual({ receiveOnly: true, canTransmit: false });
+    expect(summaryOf(b)).toEqual({ receiveOnly: false, canTransmit: true });
+  });
+});

--- a/src/server/meshcoreManager.receiveOnly.test.ts
+++ b/src/server/meshcoreManager.receiveOnly.test.ts
@@ -1,0 +1,273 @@
+/**
+ * MeshCore strict receive-only mode (#4547 epic, Phase 1 WP1 — Foundations).
+ *
+ * Covers only the WP1 slice: manager state (isReceiveOnly/canTransmit),
+ * refreshReceiveOnly() DB read + fail-safe caching, setReceiveOnly()'s
+ * state-change-only logging + native-backend push, the sendBridgeCommand
+ * command-name-aware gate, and that connect() refreshes the flag on every
+ * (re)connect. The per-method requireTransmit() guards (WP2), scheduler
+ * silent-skips and native-backend chokepoint B (WP3) are covered by their
+ * own test files, not here.
+ *
+ * See docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md §2.3.1-2.3.3, §3.2.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager, ConnectionType, type MeshCoreConfig } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+import { isTxDisabledError } from './errors/txDisabledError.js';
+
+const TEST_CONFIG: MeshCoreConfig = {
+  connectionType: ConnectionType.SERIAL,
+  firmwareType: 'companion',
+  serialPort: '/dev/ttyTEST',
+};
+
+/**
+ * Narrow, `any`-free accessor for the private `sendBridgeCommand` method —
+ * exercised directly so the gate is tested independently of any individual
+ * public method's own guard (which is WP2's responsibility, not WP1's).
+ */
+type SendBridgeCommandFn = (
+  cmd: string,
+  params: Record<string, unknown>,
+  timeout?: number,
+) => Promise<unknown>;
+
+function sendBridgeCommandOf(manager: MeshCoreManager): SendBridgeCommandFn {
+  return (manager as unknown as { sendBridgeCommand: SendBridgeCommandFn }).sendBridgeCommand.bind(
+    manager,
+  );
+}
+
+function freshManager(sourceId = 'test-source'): MeshCoreManager {
+  return new MeshCoreManager(sourceId);
+}
+
+describe('MeshCoreManager receive-only state (#4547 WP1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to transmit-allowed on a fresh manager', () => {
+    const m = freshManager();
+    expect(m.isReceiveOnly()).toBe(false);
+    expect(m.canTransmit()).toBe(true);
+  });
+
+  it('refreshReceiveOnly() reads the per-source setting and flips the flag', async () => {
+    const m = freshManager('src-a');
+    const getSpy = vi.spyOn(databaseService.settings, 'getSettingForSource').mockResolvedValue('true');
+
+    const result = await m.refreshReceiveOnly();
+
+    expect(result).toBe(true);
+    expect(m.isReceiveOnly()).toBe(true);
+    expect(m.canTransmit()).toBe(false);
+    expect(getSpy).toHaveBeenCalledWith('src-a', 'meshcoreReceiveOnly');
+  });
+
+  it('refreshReceiveOnly() sets false when the stored value is anything other than the string "true"', async () => {
+    const m = freshManager();
+    vi.spyOn(databaseService.settings, 'getSettingForSource').mockResolvedValue(null);
+
+    const result = await m.refreshReceiveOnly();
+
+    expect(result).toBe(false);
+    expect(m.isReceiveOnly()).toBe(false);
+  });
+
+  it('a DB read that rejects leaves the previously-cached value intact (fail-safe)', async () => {
+    const m = freshManager();
+    vi.spyOn(databaseService.settings, 'getSettingForSource').mockResolvedValueOnce('true');
+    await m.refreshReceiveOnly();
+    expect(m.isReceiveOnly()).toBe(true);
+
+    vi.spyOn(databaseService.settings, 'getSettingForSource').mockRejectedValueOnce(new Error('db unavailable'));
+    const result = await m.refreshReceiveOnly();
+
+    expect(result).toBe(true);
+    expect(m.isReceiveOnly()).toBe(true);
+  });
+
+  it('setReceiveOnly logs exactly one info line on a state change, and none on a repeat of the same value', () => {
+    const m = freshManager();
+    // Spy AFTER construction — the constructor itself logs an unrelated
+    // "Manager initialized" info line that must not be counted here.
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    m.setReceiveOnly(true);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+
+    m.setReceiveOnly(true); // repeat — no new log
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+
+    m.setReceiveOnly(false); // state change back — one more log
+    expect(infoSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('setReceiveOnly propagates the value to nativeBackend.setReceiveOnly', () => {
+    const m = freshManager();
+    const backendSpy = vi.fn();
+    (m as any).nativeBackend = { setReceiveOnly: backendSpy };
+
+    m.setReceiveOnly(true);
+
+    expect(backendSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('setReceiveOnly is a no-op toward the backend when none is attached', () => {
+    const m = freshManager();
+    expect(() => m.setReceiveOnly(true)).not.toThrow();
+  });
+});
+
+describe('MeshCoreManager.sendBridgeCommand receive-only gate (#4547 WP1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws a TxDisabledError for an RF command while receive-only, without reaching the backend', async () => {
+    const m = freshManager();
+    m.setReceiveOnly(true);
+    const backendSend = vi.fn().mockResolvedValue({ ok: true });
+    (m as any).nativeBackend = { sendCommand: backendSend, setReceiveOnly: vi.fn() };
+    const send = sendBridgeCommandOf(m);
+
+    await expect(send('send_message', {})).rejects.toMatchObject({
+      isTxDisabledError: true,
+      code: 'TX_DISABLED',
+    });
+    expect(backendSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects with an error satisfying isTxDisabledError()', async () => {
+    const m = freshManager();
+    m.setReceiveOnly(true);
+    (m as any).nativeBackend = { sendCommand: vi.fn(), setReceiveOnly: vi.fn() };
+    const send = sendBridgeCommandOf(m);
+
+    let caught: unknown;
+    try {
+      await send('send_advert', {});
+    } catch (err) {
+      caught = err;
+    }
+    expect(isTxDisabledError(caught)).toBe(true);
+  });
+
+  it('does not gate RF commands when not receive-only', async () => {
+    const m = freshManager();
+    const backendSend = vi.fn().mockResolvedValue({ ok: true });
+    (m as any).nativeBackend = { sendCommand: backendSend, setReceiveOnly: vi.fn() };
+    const send = sendBridgeCommandOf(m);
+
+    await send('send_message', { text: 'hi' });
+
+    expect(backendSend).toHaveBeenCalledWith('send_message', { text: 'hi' }, expect.any(Number));
+  });
+
+  it.each(['get_channels', 'set_name', 'set_radio', 'get_stats', 'device_query', 'set_device_time'])(
+    'still reaches the backend for serial-only command %s while receive-only',
+    async (cmd) => {
+      const m = freshManager();
+      m.setReceiveOnly(true);
+      const backendSend = vi.fn().mockResolvedValue({ ok: true });
+      (m as any).nativeBackend = { sendCommand: backendSend, setReceiveOnly: vi.fn() };
+      const send = sendBridgeCommandOf(m);
+
+      await send(cmd, {});
+
+      expect(backendSend).toHaveBeenCalledWith(cmd, {}, expect.any(Number));
+    },
+  );
+
+  it('fails closed: an unclassified command name is blocked while receive-only', async () => {
+    const m = freshManager();
+    m.setReceiveOnly(true);
+    const backendSend = vi.fn().mockResolvedValue({ ok: true });
+    (m as any).nativeBackend = { sendCommand: backendSend, setReceiveOnly: vi.fn() };
+    const send = sendBridgeCommandOf(m);
+
+    await expect(send('some_future_command_nobody_classified', {})).rejects.toMatchObject({
+      isTxDisabledError: true,
+    });
+    expect(backendSend).not.toHaveBeenCalled();
+  });
+
+  it('still throws "Native backend not ready" (not TX_DISABLED) when no backend is attached, receive-only or not', async () => {
+    const m = freshManager();
+    const send = sendBridgeCommandOf(m);
+    await expect(send('get_channels', {})).rejects.toThrow('Native backend not ready');
+  });
+});
+
+describe('MeshCoreManager.connect() refreshes receive-only on every (re)connect (#4547 WP1)', () => {
+  beforeEach(() => {
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(databaseService.meshcore, 'getRecentMessages').mockResolvedValue([]);
+    vi.spyOn(databaseService.settings, 'getSettingForSource').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubHeavyConnectSideEffects(m: MeshCoreManager): ReturnType<typeof vi.fn> {
+    const startNativeBackendSpy = vi.fn().mockResolvedValue(undefined);
+    (m as any).startNativeBackend = startNativeBackendSpy;
+    (m as any).refreshLocalNode = vi.fn().mockResolvedValue(undefined);
+    (m as any).seedContactsFromDb = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshContacts = vi.fn().mockResolvedValue(undefined);
+    (m as any).refreshKnownScopes = vi.fn().mockResolvedValue(undefined);
+    (m as any).startVirtualNodeServer = vi.fn().mockResolvedValue(undefined);
+    (m as any).startAutoPathfinding = vi.fn().mockResolvedValue(undefined);
+    (m as any).startAutoAnnounce = vi.fn().mockResolvedValue(undefined);
+    (m as any).startTimerTriggers = vi.fn().mockResolvedValue(undefined);
+    (m as any).distanceDeleteScheduler = { start: vi.fn().mockResolvedValue(undefined), stop: vi.fn() };
+    return startNativeBackendSpy;
+  }
+
+  it('calls refreshReceiveOnly() before the native backend starts', async () => {
+    const m = freshManager();
+    const refreshSpy = vi.spyOn(m, 'refreshReceiveOnly');
+    const startNativeBackendSpy = stubHeavyConnectSideEffects(m);
+
+    const ok = await m.connect(TEST_CONFIG);
+
+    expect(ok).toBe(true);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(startNativeBackendSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      startNativeBackendSpy.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('refreshes again on a second connect() (reconnect survival)', async () => {
+    const m = freshManager();
+    const refreshSpy = vi.spyOn(m, 'refreshReceiveOnly');
+    stubHeavyConnectSideEffects(m);
+    // connect() calls disconnect() first when already connected; stub it so
+    // the second call doesn't try to tear down the (stubbed) native backend.
+    (m as any).disconnect = vi.fn().mockResolvedValue(undefined);
+
+    await m.connect(TEST_CONFIG);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    await m.connect(TEST_CONFIG);
+    expect(refreshSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('a receive-only flag set by refreshReceiveOnly on connect is reflected by canTransmit()', async () => {
+    vi.spyOn(databaseService.settings, 'getSettingForSource').mockResolvedValue('true');
+    const m = freshManager();
+    stubHeavyConnectSideEffects(m);
+
+    await m.connect(TEST_CONFIG);
+
+    expect(m.isReceiveOnly()).toBe(true);
+    expect(m.canTransmit()).toBe(false);
+  });
+});

--- a/src/server/meshcoreManager.receiveOnly.test.ts
+++ b/src/server/meshcoreManager.receiveOnly.test.ts
@@ -517,6 +517,32 @@ describe('MeshCoreManager.sendLocalCliCommand verb gate (#4547 WP2 §2.3.5)', ()
     expect(result.reply).toContain('1.16');
     expect(backendSend).toHaveBeenCalledWith('device_query', {}, expect.any(Number));
   });
+
+  it('does not block a non-transmitting Repeater verb ("get name") — reaches the serial CLI', async () => {
+    const m = freshManager();
+    internals(m).connected = true;
+    internals(m).deviceType = MeshCoreDeviceType.REPEATER;
+    const writes: string[] = [];
+    internals(m).serialPort = {
+      isOpen: true,
+      write: (data: string) => {
+        writes.push(data);
+        // sendRepeaterCommand registers its 'serial_data' listener and calls
+        // write() synchronously (before any await), so emitting here — still
+        // inside the write() call — reaches an already-registered listener.
+        // First line echoes the command (skipped by the handler), second
+        // line is the terminator that resolves the pending promise.
+        m.emit('serial_data', data.replace(/\r$/, ''));
+        m.emit('serial_data', 'OK - name: test-repeater');
+      },
+    };
+    m.setReceiveOnly(true);
+
+    const result = await m.sendLocalCliCommand('get name');
+
+    expect(result.reply).toContain('OK - name: test-repeater');
+    expect(writes).toEqual(['get name\r']);
+  });
 });
 
 describe('MeshCoreManager guard insertion-point / orphaned-state checks (#4547 WP2)', () => {

--- a/src/server/meshcoreManager.receiveOnly.test.ts
+++ b/src/server/meshcoreManager.receiveOnly.test.ts
@@ -1,18 +1,26 @@
 /**
- * MeshCore strict receive-only mode (#4547 epic, Phase 1 WP1 — Foundations).
+ * MeshCore strict receive-only mode (#4547 epic, Phase 1).
  *
- * Covers only the WP1 slice: manager state (isReceiveOnly/canTransmit),
+ * WP1 slice (unchanged): manager state (isReceiveOnly/canTransmit),
  * refreshReceiveOnly() DB read + fail-safe caching, setReceiveOnly()'s
  * state-change-only logging + native-backend push, the sendBridgeCommand
  * command-name-aware gate, and that connect() refreshes the flag on every
- * (re)connect. The per-method requireTransmit() guards (WP2), scheduler
- * silent-skips and native-backend chokepoint B (WP3) are covered by their
- * own test files, not here.
+ * (re)connect.
  *
- * See docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md §2.3.1-2.3.3, §3.2.
+ * WP2 slice (this addition): the 24 explicit `requireTransmit()` guards from
+ * §2.3.4, the `sendLocalCliCommand` verb gate (§2.3.5), the `requestNeighbors`
+ * branch split (§2.3.4b — remote branch gated via its downstream guards,
+ * local branch deliberately ungated), the insertion-point / orphaned-state
+ * checks for the six non-trivial methods, and proof that `sendRepeaterCommand`
+ * is NOT gated wholesale.
+ *
+ * Scheduler silent-skips and native-backend chokepoint B (WP3) are covered by
+ * their own test files, not here.
+ *
+ * See docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md §2.3.4, §2.3.4b, §2.3.5, §3.2.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MeshCoreManager, ConnectionType, type MeshCoreConfig } from './meshcoreManager.js';
+import { MeshCoreManager, ConnectionType, MeshCoreDeviceType, type MeshCoreConfig, type MeshCoreContact } from './meshcoreManager.js';
 import { logger } from '../utils/logger.js';
 import databaseService from '../services/database.js';
 import { isTxDisabledError } from './errors/txDisabledError.js';
@@ -42,6 +50,84 @@ function sendBridgeCommandOf(manager: MeshCoreManager): SendBridgeCommandFn {
 
 function freshManager(sourceId = 'test-source'): MeshCoreManager {
   return new MeshCoreManager(sourceId);
+}
+
+/** Minimal shape of the native backend needed by the WP2 guard tests. */
+interface FakeNativeBackend {
+  sendCommand: (cmd: string, params: Record<string, unknown>, timeout?: number) => Promise<{
+    id?: string;
+    success: boolean;
+    data?: Record<string, unknown>;
+    error?: string;
+  }>;
+  setReceiveOnly: (enabled: boolean) => void;
+}
+
+/** Minimal shape of the serial port needed by the sendRepeaterCommand tests. */
+interface FakeSerialPort {
+  isOpen: boolean;
+  write: (data: string) => void;
+}
+
+/**
+ * Narrow, `any`-free accessor for the private fields the WP2 guard-placement
+ * and orphaned-state tests need to poke directly (device-type/connected
+ * preconditions, the native backend, the serial port, and the lock/pending-
+ * reply maps). Mirrors the `sendBridgeCommandOf` accessor above.
+ */
+interface ManagerInternals {
+  connected: boolean;
+  deviceType: MeshCoreDeviceType;
+  contacts: Map<string, MeshCoreContact>;
+  nativeBackend: FakeNativeBackend | undefined;
+  serialPort: FakeSerialPort | null;
+  cliCommandLocks: Map<string, Promise<unknown>>;
+  pendingCliReplies: Map<string, unknown>;
+  guestLoggedInNodes: Set<string>;
+}
+
+function internals(manager: MeshCoreManager): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+type PerformScopedSendFn = (
+  text: string,
+  toPublicKey?: string,
+  channelIdx?: number,
+  scopeOverride?: string | null,
+  isAutoRetry?: boolean,
+  autoRetryOnMiss?: boolean,
+) => Promise<{ ok: boolean }>;
+
+function performScopedSendOf(manager: MeshCoreManager): PerformScopedSendFn {
+  return (manager as unknown as { performScopedSend: PerformScopedSendFn }).performScopedSend.bind(manager);
+}
+
+type RunCliCommandLockedFn = (
+  fullKey: string,
+  prefixKey: string,
+  command: string,
+  timeoutMs: number,
+) => Promise<{ reply: string; elapsedMs: number }>;
+
+function runCliCommandLockedOf(manager: MeshCoreManager): RunCliCommandLockedFn {
+  return (manager as unknown as { runCliCommandLocked: RunCliCommandLockedFn }).runCliCommandLocked.bind(manager);
+}
+
+/** Valid-format 64-char hex public key used throughout the WP2 guard tests. */
+const HEX_PUBKEY = 'a'.repeat(64);
+
+function makeContact(publicKey: string, overrides: Partial<MeshCoreContact> = {}): MeshCoreContact {
+  return { publicKey, ...overrides };
+}
+
+function companionSetup(m: MeshCoreManager): void {
+  internals(m).deviceType = MeshCoreDeviceType.COMPANION;
+}
+
+function companionConnectedSetup(m: MeshCoreManager): void {
+  internals(m).deviceType = MeshCoreDeviceType.COMPANION;
+  internals(m).connected = true;
 }
 
 describe('MeshCoreManager receive-only state (#4547 WP1)', () => {
@@ -269,5 +355,250 @@ describe('MeshCoreManager.connect() refreshes receive-only on every (re)connect 
 
     expect(m.isReceiveOnly()).toBe(true);
     expect(m.canTransmit()).toBe(false);
+  });
+});
+
+/**
+ * WP2 — the 24 explicit `requireTransmit()` guards from §2.3.4. Each case
+ * supplies just enough state to pass the method's OWN pre-existing
+ * validation (device-type / connected / format checks) so the guard is
+ * actually reached, then asserts the call rejects with a `TxDisabledError`.
+ * `runCliCommandLocked` is deliberately excluded from this table — it is not
+ * declared `async`, so the guard throws SYNCHRONOUSLY before a Promise is
+ * even returned; it gets its own test below alongside the other
+ * insertion-point / orphaned-state checks.
+ */
+interface GuardCase {
+  name: string;
+  setup?: (m: MeshCoreManager) => void;
+  invoke: (m: MeshCoreManager) => Promise<unknown>;
+}
+
+const GUARD_CASES: GuardCase[] = [
+  { name: 'sendMessage', invoke: (m) => m.sendMessage('hi') },
+  {
+    name: 'sendMessageWithResult',
+    setup: (m) => { internals(m).connected = true; },
+    invoke: (m) => m.sendMessageWithResult('hi'),
+  },
+  { name: 'performScopedSend', invoke: (m) => performScopedSendOf(m)('hi') },
+  {
+    name: 'sendAdvert',
+    setup: (m) => { internals(m).connected = true; },
+    invoke: (m) => m.sendAdvert(),
+  },
+  { name: 'resetContactPath', setup: companionConnectedSetup, invoke: (m) => m.resetContactPath(HEX_PUBKEY) },
+  { name: 'discoverContactPath', setup: companionConnectedSetup, invoke: (m) => m.discoverContactPath(HEX_PUBKEY) },
+  { name: 'discoverNodes', setup: companionConnectedSetup, invoke: (m) => m.discoverNodes(0x0c) },
+  { name: 'fetchOwnerName', setup: companionSetup, invoke: (m) => m.fetchOwnerName(HEX_PUBKEY) },
+  { name: 'discoverRegions', setup: companionSetup, invoke: (m) => m.discoverRegions() },
+  { name: 'traceContactPath', setup: companionConnectedSetup, invoke: (m) => m.traceContactPath(HEX_PUBKEY) },
+  {
+    name: 'tracePathRaw',
+    setup: companionConnectedSetup,
+    invoke: (m) => m.tracePathRaw(new Uint8Array([1])),
+  },
+  {
+    name: 'pingContactZeroHop',
+    setup: (m) => {
+      companionConnectedSetup(m);
+      internals(m).contacts.set(HEX_PUBKEY, makeContact(HEX_PUBKEY));
+    },
+    invoke: (m) => m.pingContactZeroHop(HEX_PUBKEY),
+  },
+  { name: 'shareContact', setup: companionConnectedSetup, invoke: (m) => m.shareContact(HEX_PUBKEY) },
+  { name: 'getNeighbours', setup: companionConnectedSetup, invoke: (m) => m.getNeighbours(HEX_PUBKEY) },
+  { name: 'loginToNode', setup: companionSetup, invoke: (m) => m.loginToNode(HEX_PUBKEY, 'pw') },
+  { name: 'requestNodeStatus', setup: companionSetup, invoke: (m) => m.requestNodeStatus(HEX_PUBKEY) },
+  { name: 'ensureGuestLogin', invoke: (m) => m.ensureGuestLogin(HEX_PUBKEY) },
+  { name: 'ensureSavedLogin', setup: companionConnectedSetup, invoke: (m) => m.ensureSavedLogin(HEX_PUBKEY) },
+  { name: 'loginToRoom', invoke: (m) => m.loginToRoom(HEX_PUBKEY, 'pw') },
+  {
+    name: 'sendRoomPost',
+    setup: (m) => { internals(m).connected = true; },
+    invoke: (m) => m.sendRoomPost('hi', HEX_PUBKEY),
+  },
+  { name: 'sendCliCommand', setup: companionConnectedSetup, invoke: (m) => m.sendCliCommand(HEX_PUBKEY, 'neighbors') },
+  { name: 'requestRemoteTelemetry', setup: companionConnectedSetup, invoke: (m) => m.requestRemoteTelemetry(HEX_PUBKEY) },
+  {
+    name: 'requestRemoteTelemetryRaw',
+    setup: companionConnectedSetup,
+    invoke: (m) => m.requestRemoteTelemetryRaw(HEX_PUBKEY),
+  },
+];
+
+describe.each(GUARD_CASES)('MeshCoreManager.$name requireTransmit() guard (#4547 WP2 §2.3.4)', ({ setup, invoke }) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects with a TxDisabledError while receive-only', async () => {
+    const m = freshManager();
+    setup?.(m);
+    m.setReceiveOnly(true);
+
+    await expect(invoke(m)).rejects.toMatchObject({ isTxDisabledError: true, code: 'TX_DISABLED' });
+  });
+});
+
+describe('MeshCoreManager.requestNeighbors branch split stays ungated (#4547 WP2 §2.3.4b)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('remote branch (publicKey supplied) rejects via ensureSavedLogin, never reaching sendCliCommand', async () => {
+    const m = freshManager();
+    companionConnectedSetup(m);
+    m.setReceiveOnly(true);
+    const sendCliSpy = vi.spyOn(m, 'sendCliCommand');
+
+    await expect(m.requestNeighbors(HEX_PUBKEY)).rejects.toMatchObject({ isTxDisabledError: true });
+    expect(sendCliSpy).not.toHaveBeenCalled();
+  });
+
+  it('local branch (no publicKey) resolves normally, reaching sendLocalCliCommand("neighbors")', async () => {
+    const m = freshManager();
+    m.setReceiveOnly(true);
+    const localCliSpy = vi.spyOn(m, 'sendLocalCliCommand').mockResolvedValue({ reply: '', elapsedMs: 1 });
+
+    const result = await m.requestNeighbors();
+
+    expect(localCliSpy).toHaveBeenCalledWith('neighbors');
+    expect(result).toEqual({ neighbors: [] });
+  });
+
+  it('local branch also resolves when publicKey is explicitly undefined', async () => {
+    const m = freshManager();
+    m.setReceiveOnly(true);
+    const localCliSpy = vi.spyOn(m, 'sendLocalCliCommand').mockResolvedValue({ reply: '', elapsedMs: 1 });
+
+    await expect(m.requestNeighbors(undefined)).resolves.toEqual({ neighbors: [] });
+    expect(localCliSpy).toHaveBeenCalledWith('neighbors');
+  });
+});
+
+describe('MeshCoreManager.sendLocalCliCommand verb gate (#4547 WP2 §2.3.5)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(['advert', 'ADVERT', ' advert '])(
+    'throws TxDisabledError for the transmitting verb %j on a Companion',
+    async (cmd) => {
+      const m = freshManager();
+      companionConnectedSetup(m);
+      m.setReceiveOnly(true);
+
+      await expect(m.sendLocalCliCommand(cmd)).rejects.toMatchObject({
+        isTxDisabledError: true,
+        code: 'TX_DISABLED',
+      });
+    },
+  );
+
+  it('throws TxDisabledError for "advert" on a Repeater too (single gate covers both dispatch branches)', async () => {
+    const m = freshManager();
+    internals(m).connected = true;
+    internals(m).deviceType = MeshCoreDeviceType.REPEATER;
+    m.setReceiveOnly(true);
+
+    await expect(m.sendLocalCliCommand('advert')).rejects.toMatchObject({ isTxDisabledError: true });
+  });
+
+  it('does not block "ver" — reaches the (serial-only) device_query bridge command', async () => {
+    const m = freshManager();
+    companionConnectedSetup(m);
+    const backendSend = vi.fn().mockResolvedValue({ success: true, data: { ver: '1.16' } });
+    internals(m).nativeBackend = { sendCommand: backendSend, setReceiveOnly: vi.fn() };
+    m.setReceiveOnly(true);
+
+    const result = await m.sendLocalCliCommand('ver');
+
+    expect(result.reply).toContain('1.16');
+    expect(backendSend).toHaveBeenCalledWith('device_query', {}, expect.any(Number));
+  });
+});
+
+describe('MeshCoreManager guard insertion-point / orphaned-state checks (#4547 WP2)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sendCliCommand: throwing leaves no entry behind in cliCommandLocks', async () => {
+    const m = freshManager();
+    companionConnectedSetup(m);
+    m.setReceiveOnly(true);
+
+    await expect(m.sendCliCommand(HEX_PUBKEY, 'neighbors')).rejects.toMatchObject({ isTxDisabledError: true });
+    expect(internals(m).cliCommandLocks.size).toBe(0);
+  });
+
+  it('runCliCommandLocked: throws synchronously before installing a pendingCliReplies entry or a timer', () => {
+    const m = freshManager();
+    m.setReceiveOnly(true);
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    const fn = runCliCommandLockedOf(m);
+
+    let caught: unknown;
+    try {
+      fn(HEX_PUBKEY, HEX_PUBKEY.substring(0, 12), 'neighbors', 5000);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isTxDisabledError(caught)).toBe(true);
+    expect(internals(m).pendingCliReplies.size).toBe(0);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('ensureGuestLogin: an already-cached session returns true instead of throwing while receive-only', async () => {
+    const m = freshManager();
+    internals(m).guestLoggedInNodes.add(HEX_PUBKEY);
+    m.setReceiveOnly(true);
+
+    await expect(m.ensureGuestLogin(HEX_PUBKEY)).resolves.toBe(true);
+  });
+
+  it('getNeighbours: throws before ever calling ensureSavedLogin', async () => {
+    const m = freshManager();
+    companionConnectedSetup(m);
+    m.setReceiveOnly(true);
+    const ensureSpy = vi.spyOn(m, 'ensureSavedLogin');
+
+    await expect(m.getNeighbours(HEX_PUBKEY)).rejects.toMatchObject({ isTxDisabledError: true });
+    expect(ensureSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('MeshCoreManager.sendRepeaterCommand is not gated wholesale (#4547 WP2)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('setName still functions on a Repeater while receive-only (serial-only "set name")', async () => {
+    vi.useFakeTimers();
+    const m = freshManager();
+    internals(m).deviceType = MeshCoreDeviceType.REPEATER;
+    internals(m).serialPort = { isOpen: true, write: vi.fn() };
+    m.setReceiveOnly(true);
+
+    const resultPromise = m.setName('Test Node');
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(resultPromise).resolves.toBe(true);
+  });
+
+  it('setRadio still functions on a Repeater while receive-only (serial-only "set radio")', async () => {
+    vi.useFakeTimers();
+    const m = freshManager();
+    internals(m).deviceType = MeshCoreDeviceType.REPEATER;
+    internals(m).serialPort = { isOpen: true, write: vi.fn() };
+    m.setReceiveOnly(true);
+
+    const resultPromise = m.setRadio(915, 250, 7, 5);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(resultPromise).resolves.toBe(true);
   });
 });

--- a/src/server/meshcoreManager.receiveOnlySchedulers.test.ts
+++ b/src/server/meshcoreManager.receiveOnlySchedulers.test.ts
@@ -1,0 +1,539 @@
+/**
+ * MeshCore strict receive-only mode (#4547 epic, Phase 1) — WP3: scheduler /
+ * timer / auto-* silent skips.
+ *
+ * Covers every site in spec §2.3.6: DM-ack retry, channel retry,
+ * auto-pathfinding (loop entry + per-target), auto-announce (+ its advert
+ * burst), timer triggers (interval + cron), auto-responder, auto-acknowledge.
+ *
+ * For each site:
+ *  - receive-only ON: the tick completes with NO call to the guarded send
+ *    primitive, no unhandled promise rejection, and (where applicable) the
+ *    underlying timer/interval/cron stays armed.
+ *  - receive-only OFF: the same tick DOES reach the primitive — proves the
+ *    skip is conditional, not a permanent disable.
+ *
+ * A dedicated test also proves the log-volume contract: across >= 5 ticks
+ * with receive-only ON, logger.info is never called (only logger.debug) —
+ * the sole logger.info call lives in setReceiveOnly() itself on a state
+ * change, which each test explicitly excludes from its assertion window.
+ *
+ * See docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md §2.3.6, §3.3.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreMessage } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+
+interface BridgeCall { cmd: string; params: Record<string, unknown>; }
+
+/** Shared manager factory: companion, connected, records every bridge call. */
+function makeManager(): { manager: MeshCoreManager; bridgeCalls: BridgeCall[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'send_message') {
+      if (!params.to) return { id: '1', success: true, data: {} };
+      return { id: '1', success: true, data: { expectedAckCrc: 111, estTimeout: 8000 } };
+    }
+    if (cmd === 'reset_path') return { id: '1', success: true };
+    if (cmd === 'discover_path') return { id: '1', success: true, data: {} };
+    if (cmd === 'get_neighbours') return { id: '1', success: true, data: { total: 0, neighbours: [] } };
+    if (cmd === 'send_advert') return { id: '1', success: true, data: {} };
+    return { id: '1', success: true, data: {} };
+  };
+
+  vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
+    getChannelById: vi.fn(async () => null),
+    updateChannelScope: vi.fn(async () => {}),
+    upsertChannel: vi.fn(async () => {}),
+    getAllChannels: vi.fn(async () => []),
+    deleteChannel: vi.fn(async () => {}),
+  } as any);
+
+  return { manager: m, bridgeCalls };
+}
+
+const sends = (calls: BridgeCall[]) => calls.filter(c => c.cmd === 'send_message');
+const resets = (calls: BridgeCall[]) => calls.filter(c => c.cmd === 'reset_path');
+
+const PUBKEY = 'b'.repeat(64);
+
+describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
+  let unhandled: unknown[] = [];
+  const onUnhandled = (err: unknown) => { unhandled.push(err); };
+
+  beforeEach(() => {
+    unhandled = [];
+    process.on('unhandledRejection', onUnhandled);
+    vi.useFakeTimers();
+    vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(databaseService.settings, 'getSettingForSource').mockResolvedValue(null);
+    vi.spyOn(databaseService.settings, 'setSourceSetting').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandled);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------- DM ack retry
+
+  describe('DM ack retry (handleDmAckTimeout)', () => {
+    it('receive-only ON: the ack-timeout tick skips the resend, no unhandled rejection', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      await manager.sendMessageWithResult('hello', PUBKEY);
+      expect(sends(bridgeCalls)).toHaveLength(1);
+
+      manager.setReceiveOnly(true);
+      const infoSpy = vi.spyOn(logger, 'info');
+      infoSpy.mockClear();
+
+      await vi.advanceTimersByTimeAsync(10_000); // ack-timeout fires
+      await Promise.resolve();
+
+      expect(sends(bridgeCalls)).toHaveLength(1); // no retry sent
+      expect(resets(bridgeCalls)).toHaveLength(0);
+      expect(unhandled).toHaveLength(0);
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it('receive-only OFF: the same ack-timeout tick resends normally', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      await manager.sendMessageWithResult('hello', PUBKEY);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(sends(bridgeCalls)).toHaveLength(2);
+    });
+  });
+
+  // ---------------------------------------------------------------- Channel retry
+
+  describe('Channel retry (handleChannelRetryTimeout)', () => {
+    function withChannelRetry(_manager: MeshCoreManager) {
+      vi.spyOn(databaseService.settings, 'getSettingAsBoolean').mockResolvedValue(true);
+      vi.spyOn(databaseService.meshcore, 'getHeardRepeatersForMessage').mockResolvedValue([]);
+    }
+
+    it('receive-only ON: the 30s retry window skips the resend, no unhandled rejection', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      withChannelRetry(manager);
+
+      await manager.sendMessage('hi', undefined, 0, undefined, true);
+      expect(sends(bridgeCalls)).toHaveLength(1);
+      expect((manager as any).pendingChannelRetries.size).toBe(1);
+
+      manager.setReceiveOnly(true);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await Promise.resolve();
+
+      expect(sends(bridgeCalls)).toHaveLength(1); // no resend
+      expect(unhandled).toHaveLength(0);
+    });
+
+    it('receive-only OFF: zero repeaters heard within 30s still triggers exactly one resend', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      withChannelRetry(manager);
+
+      await manager.sendMessage('hi', undefined, 0, undefined, true);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(sends(bridgeCalls)).toHaveLength(2);
+    });
+  });
+
+  // ---------------------------------------------------------------- Auto-pathfinding
+
+  describe('Auto-pathfinding (executeRun)', () => {
+    function mockPathfindingSettings() {
+      vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+        async (_sourceId: string | null | undefined, key: string) => {
+          switch (key) {
+            case 'meshcoreAutoPathfindingEnabled': return 'true';
+            case 'meshcoreAutoPathfindingPathDiscoveryEnabled': return 'true';
+            case 'meshcoreAutoPathfindingNeighborsEnabled': return 'true';
+            case 'meshcoreAutoPathfindingIntervalMinutes': return '3';
+            case 'meshcoreAutoPathfindingRepeatHours': return '1';
+            default: return null;
+          }
+        },
+      );
+      vi.spyOn(databaseService, 'getMeshcorePathfindingFilterSettingsAsync').mockResolvedValue({
+        enabled: false, targetKeys: [], contactsEnabled: false, regexEnabled: false, nameRegex: '.*',
+        lastHeardEnabled: false, lastHeardHours: 168, hopsEnabled: false, hopsMin: 0, hopsMax: 10,
+        signalEnabled: false, rssiMin: -200, snrMin: -100,
+      });
+    }
+
+    beforeEach(() => {
+      vi.spyOn(Math, 'random').mockReturnValue(0); // deterministic zero jitter
+    });
+
+    it('receive-only ON at loop entry: no target is ever contacted, interval stays armed', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      mockPathfindingSettings();
+      (manager as any).contacts = new Map([
+        [PUBKEY, { publicKey: PUBKEY, advType: MeshCoreDeviceType.COMPANION }],
+      ]);
+      manager.setReceiveOnly(true);
+
+      await manager.startAutoPathfinding();
+      await vi.advanceTimersByTimeAsync(0); // zero jitter -> executeRun fires immediately
+
+      expect(bridgeCalls.filter(c => c.cmd === 'discover_path' || c.cmd === 'get_neighbours')).toHaveLength(0);
+      expect((manager as any).autoPathfindingTimer).not.toBeNull(); // still armed
+      expect(unhandled).toHaveLength(0);
+    });
+
+    it('receive-only OFF: loop entry reaches discover_path for an eligible target', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      mockPathfindingSettings();
+      (manager as any).contacts = new Map([
+        [PUBKEY, { publicKey: PUBKEY, advType: MeshCoreDeviceType.COMPANION }],
+      ]);
+
+      await manager.startAutoPathfinding();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(bridgeCalls.filter(c => c.cmd === 'discover_path')).toHaveLength(1);
+    });
+
+    it('receive-only flips mid-run: the per-target re-check stops before the next target', async () => {
+      const { manager, bridgeCalls } = makeManager();
+      mockPathfindingSettings();
+      const companionKey = 'c'.repeat(64);
+      const repeaterKey = 'd'.repeat(64);
+      (manager as any).contacts = new Map([
+        [companionKey, { publicKey: companionKey, advType: MeshCoreDeviceType.COMPANION }],
+        [repeaterKey, { publicKey: repeaterKey, advType: MeshCoreDeviceType.REPEATER }],
+      ]);
+
+      // Flip the flag ON right after the first target's bridge call succeeds,
+      // simulating a concurrent settings write landing mid-loop.
+      const originalSendBridgeCommand = (manager as any).sendBridgeCommand.bind(manager);
+      (manager as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+        const result = await originalSendBridgeCommand(cmd, params);
+        if (cmd === 'discover_path') manager.setReceiveOnly(true);
+        return result;
+      };
+
+      await manager.startAutoPathfinding();
+      await vi.advanceTimersByTimeAsync(0); // fire executeRun (zero jitter)
+      await vi.advanceTimersByTimeAsync(3 * 60 * 1000); // the inter-target sleep
+
+      expect(bridgeCalls.filter(c => c.cmd === 'discover_path')).toHaveLength(1);
+      // The second (repeater) target's get_neighbours — and the ensureSavedLogin
+      // it would otherwise throw from — is never reached.
+      expect(bridgeCalls.filter(c => c.cmd === 'get_neighbours')).toHaveLength(0);
+      expect(unhandled).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------- Auto-announce
+
+  describe('Auto-announce (runAutoAnnounceCycle) + advert burst', () => {
+    it('receive-only ON: skips before any settings read or send', async () => {
+      const { manager } = makeManager();
+      const getSettingSpy = vi.spyOn(databaseService.settings, 'getSettingForSource');
+      const sendMessage = vi.fn().mockResolvedValue(true);
+      (manager as any).sendMessage = sendMessage;
+      manager.setReceiveOnly(true);
+
+      const result = await manager.runAutoAnnounceCycle('cron');
+
+      expect(result).toEqual({ sent: 0, total: 0 });
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(getSettingSpy).not.toHaveBeenCalled();
+    });
+
+    it('receive-only OFF: reaches sendMessage for each configured channel', async () => {
+      const { manager } = makeManager();
+      const announceSettings: Record<string, string | null> = {
+        meshcoreAutoAnnounceMessage: 'hello mesh',
+        meshcoreAutoAnnounceChannelIndexes: '0',
+        meshcoreAutoAnnounceAdvertEnabled: 'false',
+      };
+      vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+        async (_sourceId: string, key: string) => (key in announceSettings ? announceSettings[key] : null),
+      );
+      const sendMessage = vi.fn().mockResolvedValue(true);
+      (manager as any).sendMessage = sendMessage;
+
+      const result = await manager.runAutoAnnounceCycle('cron');
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(result.sent).toBe(1);
+    });
+
+    it('advert burst: receive-only ON when the burst timer fires skips sendAdvert', async () => {
+      const { manager } = makeManager();
+      const announceSettings: Record<string, string | null> = {
+        meshcoreAutoAnnounceMessage: 'hello mesh',
+        meshcoreAutoAnnounceChannelIndexes: '0',
+        meshcoreAutoAnnounceAdvertEnabled: 'true',
+        meshcoreAutoAnnounceAdvertDelaySeconds: '30',
+      };
+      vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+        async (_sourceId: string, key: string) => (key in announceSettings ? announceSettings[key] : null),
+      );
+      (manager as any).sendMessage = vi.fn().mockResolvedValue(true);
+      const sendAdvert = vi.fn().mockResolvedValue(true);
+      (manager as any).sendAdvert = sendAdvert;
+
+      await manager.runAutoAnnounceCycle('cron');
+      expect((manager as any).autoAnnounceAdvertTimer).not.toBeNull();
+
+      // Flag flips ON during the burst delay.
+      manager.setReceiveOnly(true);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await Promise.resolve();
+
+      expect(sendAdvert).not.toHaveBeenCalled();
+      expect(unhandled).toHaveLength(0);
+    });
+
+    it('advert burst: receive-only OFF fires sendAdvert after the delay', async () => {
+      const { manager } = makeManager();
+      const announceSettings: Record<string, string | null> = {
+        meshcoreAutoAnnounceMessage: 'hello mesh',
+        meshcoreAutoAnnounceChannelIndexes: '0',
+        meshcoreAutoAnnounceAdvertEnabled: 'true',
+        meshcoreAutoAnnounceAdvertDelaySeconds: '30',
+      };
+      vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+        async (_sourceId: string, key: string) => (key in announceSettings ? announceSettings[key] : null),
+      );
+      (manager as any).sendMessage = vi.fn().mockResolvedValue(true);
+      const sendAdvert = vi.fn().mockResolvedValue(true);
+      (manager as any).sendAdvert = sendAdvert;
+
+      await manager.runAutoAnnounceCycle('cron');
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(sendAdvert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------- Timer triggers
+
+  describe('Timer triggers (armTimerTrigger)', () => {
+    const intervalTrigger = {
+      id: 'timer-1',
+      name: 'Every 5m',
+      enabled: true,
+      scheduleType: 'interval' as const,
+      intervalMinutes: 5,
+      responseType: 'text' as const,
+      response: 'hi',
+      destination: 'channel' as const,
+      channelIndex: 0,
+    };
+
+    it('interval: receive-only ON skips runTimerTrigger, interval stays armed across 5 ticks, no logger.info', async () => {
+      const { manager } = makeManager();
+      const runTimerTrigger = vi.fn().mockResolvedValue({ ok: true });
+      (manager as any).runTimerTrigger = runTimerTrigger;
+      manager.setReceiveOnly(true);
+
+      const infoSpy = vi.spyOn(logger, 'info');
+
+      (manager as any).armTimerTrigger(intervalTrigger);
+      expect((manager as any).timerTriggerIntervals.size).toBe(1);
+      infoSpy.mockClear(); // exclude the one-shot "armed" log from the window we assert on
+
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      }
+
+      expect(runTimerTrigger).not.toHaveBeenCalled();
+      expect((manager as any).timerTriggerIntervals.size).toBe(1); // still armed
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(unhandled).toHaveLength(0);
+    });
+
+    it('interval: receive-only OFF calls runTimerTrigger on each tick', async () => {
+      const { manager } = makeManager();
+      const runTimerTrigger = vi.fn().mockResolvedValue({ ok: true });
+      (manager as any).runTimerTrigger = runTimerTrigger;
+
+      (manager as any).armTimerTrigger(intervalTrigger);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+      expect(runTimerTrigger).toHaveBeenCalledTimes(2);
+    });
+
+    it('cron: receive-only ON skips runTimerTrigger, cron stays armed', async () => {
+      const { manager } = makeManager();
+      const runTimerTrigger = vi.fn().mockResolvedValue({ ok: true });
+      (manager as any).runTimerTrigger = runTimerTrigger;
+      manager.setReceiveOnly(true);
+
+      const cronTrigger = { ...intervalTrigger, id: 'timer-2', scheduleType: 'cron' as const, cronExpression: '* * * * *' };
+      (manager as any).armTimerTrigger(cronTrigger);
+      expect((manager as any).timerTriggerCrons.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(61_000); // cross a minute boundary
+
+      expect(runTimerTrigger).not.toHaveBeenCalled();
+      expect((manager as any).timerTriggerCrons.size).toBe(1); // still armed
+      expect(unhandled).toHaveLength(0);
+    });
+
+    it('cron: receive-only OFF calls runTimerTrigger once the minute boundary passes', async () => {
+      const { manager } = makeManager();
+      const runTimerTrigger = vi.fn().mockResolvedValue({ ok: true });
+      (manager as any).runTimerTrigger = runTimerTrigger;
+
+      const cronTrigger = { ...intervalTrigger, id: 'timer-3', scheduleType: 'cron' as const, cronExpression: '* * * * *' };
+      (manager as any).armTimerTrigger(cronTrigger);
+
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      expect(runTimerTrigger).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------- Auto-responder
+
+  describe('Auto-responder (checkAutoResponder)', () => {
+    const trigger = {
+      id: 't1', name: 'ping', enabled: true, pattern: '^ping',
+      responseType: 'text' as const, response: 'pong',
+      channels: [] as number[], listenDMs: true, replyAsDM: true, cooldownSeconds: 0,
+    };
+    const message: MeshCoreMessage = {
+      id: 'm1', fromPublicKey: PUBKEY, text: 'ping', timestamp: Date.now(),
+    };
+
+    it('receive-only ON: skips before any settings read or send', async () => {
+      const { manager } = makeManager();
+      const getSettingSpy = vi.spyOn(databaseService.settings, 'getSettingForSource');
+      const sendMessage = vi.fn().mockResolvedValue(true);
+      (manager as any).sendMessage = sendMessage;
+      manager.setReceiveOnly(true);
+
+      await (manager as any).checkAutoResponder(message, true, undefined);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(getSettingSpy).not.toHaveBeenCalled();
+    });
+
+    it('receive-only OFF: a matching trigger reaches sendMessage', async () => {
+      const { manager } = makeManager();
+      vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+        async (_sourceId: string, key: string) => {
+          if (key === 'meshcoreAutoResponderEnabled') return 'true';
+          if (key === 'meshcoreAutoResponderTriggers') return JSON.stringify([trigger]);
+          return null;
+        },
+      );
+      const sendMessage = vi.fn().mockResolvedValue(true);
+      (manager as any).sendMessage = sendMessage;
+
+      await (manager as any).checkAutoResponder(message, true, undefined);
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------- Auto-acknowledge
+
+  describe('Auto-acknowledge (checkAutoAcknowledge)', () => {
+    const message: MeshCoreMessage = {
+      id: 'm1', fromPublicKey: PUBKEY, text: 'ping', timestamp: Date.now(),
+    };
+
+    it('receive-only ON: skips before any settings read or send', async () => {
+      const { manager } = makeManager();
+      const getSettingSpy = vi.spyOn(databaseService.settings, 'getSettingForSource');
+      const sendMessage = vi.fn().mockResolvedValue(true);
+      (manager as any).sendMessage = sendMessage;
+      manager.setReceiveOnly(true);
+
+      await (manager as any).checkAutoAcknowledge(message, true, undefined, null, null);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(getSettingSpy).not.toHaveBeenCalled();
+    });
+
+    it('receive-only OFF: a matching regex reaches sendMessage', async () => {
+      const { manager } = makeManager();
+      const autoAckSettings: Record<string, string | null> = {
+        meshcoreAutoAckEnabled: 'true',
+        meshcoreAutoAckRegex: '^ping',
+        meshcoreAutoAckDirectMessages: 'true',
+        meshcoreAutoAckCooldownSeconds: '0',
+        meshcoreAutoAckUseDM: 'true',
+        meshcoreAutoAckMessage: 'ack',
+        meshcoreAutoAckPreSendDelaySeconds: '0',
+      };
+      vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+        async (_sourceId: string, key: string) => (key in autoAckSettings ? autoAckSettings[key] : null),
+      );
+      const sendMessage = vi.fn().mockResolvedValue(true);
+      (manager as any).sendMessage = sendMessage;
+      (manager as any).contacts = new Map([[PUBKEY, { publicKey: PUBKEY, advName: 'Bob' }]]);
+
+      await (manager as any).checkAutoAcknowledge(message, true, undefined, null, null);
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------- Aggregate log-volume check
+
+  it('across >= 5 skipped ticks on distinct schedulers, logger.info fires zero times', async () => {
+    const { manager } = makeManager();
+    const runTimerTrigger = vi.fn().mockResolvedValue({ ok: true });
+    (manager as any).runTimerTrigger = runTimerTrigger;
+    (manager as any).sendMessage = vi.fn().mockResolvedValue(true);
+
+    manager.setReceiveOnly(true);
+    const infoSpy = vi.spyOn(logger, 'info');
+
+    (manager as any).armTimerTrigger(intervalTriggerFixture());
+    infoSpy.mockClear(); // exclude the one-shot "armed" log from the window we assert on
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    }
+    await (manager as any).checkAutoResponder(
+      { id: 'm1', fromPublicKey: PUBKEY, text: 'ping', timestamp: Date.now() },
+      true,
+      undefined,
+    );
+    await (manager as any).checkAutoAcknowledge(
+      { id: 'm2', fromPublicKey: PUBKEY, text: 'ping', timestamp: Date.now() },
+      true,
+      undefined,
+      null,
+      null,
+    );
+
+    expect(runTimerTrigger).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(unhandled).toHaveLength(0);
+  });
+});
+
+function intervalTriggerFixture() {
+  return {
+    id: 'timer-agg',
+    name: 'Every 5m',
+    enabled: true,
+    scheduleType: 'interval' as const,
+    intervalMinutes: 5,
+    responseType: 'text' as const,
+    response: 'hi',
+    destination: 'channel' as const,
+    channelIndex: 0,
+  };
+}

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -3484,6 +3484,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * creates a new message nor re-arms the timer itself.
    */
   private async handleDmAckTimeout(ackCrc: number): Promise<void> {
+    // Receive-only (#4547): first statement, before any pending-map bookkeeping
+    // or the guarded resetContactPath()/performScopedSend() primitives below.
+    if (!this.canTransmit()) {
+      logger.debug(`⏭️ [MeshCore:${this.sourceId}] DM ack retry: Skipping - receive-only mode`);
+      return;
+    }
     const pending = this.pendingDmRetries.get(ackCrc);
     if (!pending) return; // already acked (or manager torn down) — nothing to do
     this.pendingDmRetries.delete(ackCrc);
@@ -3641,6 +3647,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * concurrent send (#3667).
    */
   private async handleChannelRetryTimeout(messageId: string): Promise<void> {
+    // Receive-only (#4547): first statement, before any pending-map bookkeeping
+    // or the guarded performScopedSend() primitive below.
+    if (!this.canTransmit()) {
+      logger.debug(`⏭️ [MeshCore:${this.sourceId}] Channel retry: Skipping - receive-only mode`);
+      return;
+    }
     const pending = this.pendingChannelRetries.get(messageId);
     if (!pending) return; // already cleared (disconnect) — nothing to do
     this.pendingChannelRetries.delete(messageId);
@@ -6564,6 +6576,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     logger.info(`[MeshCore:${this.sourceId}] Auto-pathfinding: starting (pathDiscovery=${pathDiscoveryEnabled}, neighbors=${neighborsEnabled}, interval=${intervalMinutes}m, repeat=${repeatHours}h, jitter=${Math.round(initialJitterMs / 1000)}s)`);
 
     const executeRun = async () => {
+      // Receive-only (#4547): loop entry — before any guarded primitive.
+      if (!this.canTransmit()) {
+        logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-pathfinding: Skipping - receive-only mode`);
+        return;
+      }
       if (!this.connected) {
         logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: skipping — not connected`);
         return;
@@ -6603,6 +6620,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
 
       for (let i = 0; i < targets.length; i++) {
         if (!this.connected) break;
+        // Receive-only (#4547): re-checked per-target — the loop awaits
+        // between targets, so the flag can flip mid-run.
+        if (!this.canTransmit()) {
+          logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-pathfinding: Skipping remaining targets - receive-only mode`);
+          break;
+        }
         const t = targets[i];
         try {
           if (t.op === 'discover_path') {
@@ -6764,6 +6787,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * so the route handler can surface partial failures.
    */
   async runAutoAnnounceCycle(reason: 'cron' | 'interval' | 'on_start' | 'manual'): Promise<{ sent: number; total: number }> {
+    // Receive-only (#4547): first statement, before any guarded primitive.
+    if (!this.canTransmit()) {
+      logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-announce: Skipping (${reason}) - receive-only mode`);
+      return { sent: 0, total: 0 };
+    }
     if (!this.connected) {
       logger.debug(`[MeshCore:${this.sourceId}] Auto-announce: skipping (${reason}) — not connected`);
       return { sent: 0, total: 0 };
@@ -6824,6 +6852,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       if (this.autoAnnounceAdvertTimer) clearTimeout(this.autoAnnounceAdvertTimer);
       this.autoAnnounceAdvertTimer = setTimeout(() => {
         this.autoAnnounceAdvertTimer = null;
+        // Receive-only (#4547): first statement in this callback, before the
+        // guarded sendAdvert() primitive — the flag can flip during the delay.
+        if (!this.canTransmit()) {
+          logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-announce advert burst: Skipping - receive-only mode`);
+          return;
+        }
         if (!this.connected) return;
         void this.sendAdvert().catch((err: Error) => {
           logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: advert burst failed: ${err.message}`);
@@ -6895,6 +6929,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         return;
       }
       const handle = setInterval(() => {
+        // Receive-only (#4547): first statement in the interval callback,
+        // before it reaches runTimerTrigger()'s guarded send primitives.
+        if (!this.canTransmit()) {
+          logger.debug(`⏭️ [MeshCore:${this.sourceId}] Timer trigger ${trigger.id}: Skipping - receive-only mode`);
+          return;
+        }
         void this.runTimerTrigger(trigger.id).catch((err: Error) => {
           logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id} run failed: ${err.message}`);
         });
@@ -6909,6 +6949,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       }
       try {
         const job = scheduleCron(expr, () => {
+          // Receive-only (#4547): first statement in the cron callback,
+          // before it reaches runTimerTrigger()'s guarded send primitives.
+          if (!this.canTransmit()) {
+            logger.debug(`⏭️ [MeshCore:${this.sourceId}] Timer trigger ${trigger.id}: Skipping - receive-only mode`);
+            return;
+          }
           void this.runTimerTrigger(trigger.id).catch((err: Error) => {
             logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id} run failed: ${err.message}`);
           });
@@ -7161,6 +7207,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     route: string | null = null,
   ): Promise<void> {
     try {
+      // Receive-only (#4547): first statement inside the try, before any
+      // guarded send primitive (and before the settings reads below).
+      if (!this.canTransmit()) {
+        logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-responder: Skipping - receive-only mode`);
+        return;
+      }
       const enabledRaw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoResponderEnabled');
       if (enabledRaw !== 'true') return;
 
@@ -7424,6 +7476,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     route: string | null,
   ): Promise<void> {
     try {
+      // Receive-only (#4547): first statement inside the try, before any
+      // guarded send primitive (and before the settings reads below).
+      if (!this.canTransmit()) {
+        logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-ack: Skipping - receive-only mode`);
+        return;
+      }
       const settings = databaseService.settings;
       const sourceId = this.sourceId;
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -24,7 +24,7 @@ import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
 import { resolveMessageScope } from './meshcoreScopeResolve.js';
 import { TxDisabledError } from './errors/txDisabledError.js';
-import { isRfBridgeCommand, MESHCORE_RECEIVE_ONLY_MESSAGE } from './constants/meshcoreTx.js';
+import { isRfBridgeCommand, isTransmittingLocalCliVerb, MESHCORE_RECEIVE_ONLY_MESSAGE } from './constants/meshcoreTx.js';
 import {
   parseMeshCoreIgnoreList,
   isMeshCoreIgnoreListEmpty,
@@ -3093,6 +3093,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * when only channel 0 was supported (issue follow-up to MeshCore channels plan).
    */
   async sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null, autoRetryOnMiss: boolean = false): Promise<boolean> {
+    this.requireTransmit();
     return (await this.sendMessageWithResult(text, toPublicKey, channelIdx, scopeOverride, autoRetryOnMiss)).ok;
   }
 
@@ -3113,6 +3114,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       logger.warn('[MeshCore] Repeaters cannot send messages');
       return { ok: false };
     }
+
+    this.requireTransmit();
 
     // Serialise the scope-assert→send pair per source (#3667). The device's
     // flood scope is a single global setting; two concurrent sends with
@@ -3281,6 +3284,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     isAutoRetry: boolean = false,
     autoRetryOnMiss: boolean = false,
   ): Promise<MeshCoreSendResult> {
+    this.requireTransmit();
     try {
       const isChannelSend = !toPublicKey && channelIdx !== undefined;
 
@@ -3694,6 +3698,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       return false;
     }
 
+    this.requireTransmit();
+
     if (this.deviceType === MeshCoreDeviceType.REPEATER) {
       try {
         await this.sendRepeaterCommand('advert');
@@ -3738,6 +3744,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (!this.connected) {
       return false;
     }
+    this.requireTransmit();
     try {
       const response = await this.sendBridgeCommand('reset_path', { public_key: publicKey });
       if (!response.success) {
@@ -3781,6 +3788,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (!this.connected) {
       return false;
     }
+    this.requireTransmit();
     try {
       const response = await this.sendBridgeCommand('discover_path', { public_key: publicKey }, 15000);
       if (!response.success) {
@@ -3827,6 +3835,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (!this.connected) {
       return empty;
     }
+    this.requireTransmit();
     // 32-bit correlation tag so responses can be matched to this request.
     const tag = Math.floor(Math.random() * 0xffffffff) >>> 0;
     this.activeDiscovery = { seen: new Set(), returned: 0, newCount: 0, nodes: new Map() };
@@ -3910,6 +3919,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    */
   async fetchOwnerName(publicKey: string): Promise<string | null> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    this.requireTransmit();
     try {
       // Install a zero-hop direct out_path so the ANON_REQ routes direct instead
       // of flooding into the void (firmware drops flooded OWNER reqs). Best-effort
@@ -4099,6 +4109,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       return { regions: [], perRepeater: [] };
     }
+    this.requireTransmit();
 
     // 1. Run a 0-hop discovery sweep and resolve it to the subset of known
     //    repeater/room-server contacts that answered, ordered by arrival.
@@ -4187,6 +4198,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (!this.connected) {
       return null;
     }
+    this.requireTransmit();
     const contact = this.contacts.get(publicKey);
     if (!contact?.outPath || contact.pathLen == null || contact.pathLen <= 0) {
       logger.warn(`[MeshCore] Trace-path: no known path for ${publicKey.substring(0, 16)}…`);
@@ -4247,6 +4259,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
     if (!this.connected) return null;
     if (!path || path.length === 0) return null;
+    this.requireTransmit();
     try {
       // No sendWithDefaultScope wrapper (unlike requestRemoteTelemetryRaw): a
       // trace follows the explicit path it is given rather than flooding on an
@@ -4315,6 +4328,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         error: 'Contact is not known to this source.',
       };
     }
+    this.requireTransmit();
 
     // MeshCore path hashes are the leading byte(s) of the node's public key
     // (`Identity::isHashMatch`). meshcore.js sends SendTracePath with flags=0,
@@ -4388,6 +4402,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (!this.connected) {
       return { ok: false, error: 'Source is disconnected.' };
     }
+    this.requireTransmit();
     try {
       // Use a short dedicated timeout (not the 30s default) so a firmware that
       // never acks CMD_SHARE_CONTACT fails fast instead of hanging the request.
@@ -4747,6 +4762,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // neighbours query behind a guest/admin login, and this binary path (like
     // the CLI `neighbors` path) otherwise fails with no session. Never
     // anonymous-logs-in (see ensureSavedLogin).
+    this.requireTransmit();
     await this.ensureSavedLogin(publicKey);
     try {
       const response = await this.sendBridgeCommand('get_neighbours', {
@@ -4863,6 +4879,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       return null;
     }
 
+    this.requireTransmit();
+
     try {
       // A login request floods when the path to the node is unknown, so it
       // carries the default scope (#3667).
@@ -4899,6 +4917,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       return null;
     }
+
+    this.requireTransmit();
 
     try {
       const response = await this.sendBridgeCommand('get_status', {
@@ -4965,6 +4985,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    */
   async ensureGuestLogin(publicKey: string): Promise<boolean> {
     if (this.guestLoggedInNodes.has(publicKey)) return true;
+    this.requireTransmit();
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return false;
     if (!this.connected) return false;
     const ok = (await this.loginToNode(publicKey, '')) !== null;
@@ -4997,6 +5018,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   async ensureSavedLogin(publicKey: string): Promise<boolean> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return false;
     if (!this.connected) return false;
+    this.requireTransmit();
 
     let cred;
     try {
@@ -5028,6 +5050,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * tracks state in roomLoggedInNodes so the UI can show login status.
    */
   async loginToRoom(publicKey: string, password: string): Promise<boolean> {
+    this.requireTransmit();
     const maxAttempts = 3;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const ok = await this.loginToNode(publicKey, password);
@@ -5069,6 +5092,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       logger.warn('[MeshCore] Repeaters cannot send messages');
       return false;
     }
+    this.requireTransmit();
     try {
       const response = await this.sendBridgeCommand('send_message', {
         text,
@@ -5275,6 +5299,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       throw new Error('CLI command must be non-empty');
     }
 
+    this.requireTransmit();
+
     const prefixKey = normalizedKey.substring(0, 12);
     const timeoutMs = opts.timeoutMs ?? 15_000;
 
@@ -5304,6 +5330,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     command: string,
     timeoutMs: number,
   ): Promise<{ reply: string; elapsedMs: number }> {
+    this.requireTransmit();
     return new Promise<{ reply: string; elapsedMs: number }>((resolve, reject) => {
       // A stale pending entry should be impossible because of the
       // per-prefix lock, but guard against it: an entry left over from a
@@ -5384,6 +5411,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     const trimmed = command.trim();
     if (trimmed.length === 0) {
       throw new Error('Command must be non-empty');
+    }
+    if (this.receiveOnly && isTransmittingLocalCliVerb(trimmed)) {
+      throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
     }
     const sentAt = Date.now();
     const timeoutMs = opts.timeoutMs ?? 10_000;
@@ -5756,6 +5786,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (!this.connected) return null;
     if (!publicKey) return null;
 
+    this.requireTransmit();
+
     try {
       const params: Record<string, unknown> = { public_key: publicKey };
       if (typeof timeoutSecs === 'number' && Number.isFinite(timeoutSecs) && timeoutSecs > 0) {
@@ -5799,6 +5831,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
     if (!this.connected) return null;
     if (!publicKey) return null;
+    this.requireTransmit();
     try {
       const response = await this.sendWithDefaultScope(() =>
         this.sendBridgeCommand('request_telemetry', { public_key: publicKey }, 45_000),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -23,6 +23,8 @@ import { replaceMeshCoreAnnounceTokens } from './utils/meshcoreAnnounceTokens.js
 import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
 import { resolveMessageScope } from './meshcoreScopeResolve.js';
+import { TxDisabledError } from './errors/txDisabledError.js';
+import { isRfBridgeCommand, MESHCORE_RECEIVE_ONLY_MESSAGE } from './constants/meshcoreTx.js';
 import {
   parseMeshCoreIgnoreList,
   isMeshCoreIgnoreListEmpty,
@@ -860,6 +862,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   // refreshed on connect and whenever a scope changes.
   private knownScopes: Set<string> = new Set();
 
+  /** Cached per-source `meshcoreReceiveOnly`. Sync-readable; refreshed on connect and on settings write. */
+  private receiveOnly = false;
+
   // Shared state
   private localNode: MeshCoreNode | null = null;
   private contacts: Map<string, MeshCoreContact> = new Map();
@@ -1193,6 +1198,13 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // backend's socket-drop events are treated as real (and so a late event
     // from the previous backend, already nulled, stays suppressed).
     this.intentionalTeardown = false;
+
+    // Receive-only (#4547): re-read the persisted per-source flag before the
+    // backend connects and schedulers arm, so every reconnect re-applies it
+    // rather than reusing a stale in-memory value from a previous connect().
+    // This applies to Repeater/serial sources too, not just Companion, so it
+    // must run here rather than inside startNativeBackend().
+    await this.refreshReceiveOnly();
 
     try {
       if (this.config.connectionType === ConnectionType.SERIAL && this.config.firmwareType === 'repeater') {
@@ -1611,6 +1623,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     } catch (err) {
       logger.warn(`[MeshCore:${this.sourceId}] Failed to read meshcoreRespondToDiscovery:`, err);
     }
+
+    // Receive-only (#4547): a freshly-constructed backend starts with its own
+    // default (false); push the manager's already-refreshed cached value so it
+    // doesn't miss a beat between connect() reading the setting and this
+    // backend coming online.
+    this.nativeBackend.setReceiveOnly(this.receiveOnly);
   }
 
   /**
@@ -1620,6 +1638,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   private async sendBridgeCommand(cmd: string, params: Record<string, any>, timeout: number = 30000): Promise<BridgeResponse> {
     if (!this.nativeBackend) {
       throw new Error('Native backend not ready');
+    }
+    // Receive-only (#4547): command-name aware — this method carries BOTH RF
+    // and local serial commands. Fail-closed on unknown names (meshcoreTx.ts).
+    if (this.receiveOnly && isRfBridgeCommand(cmd)) {
+      throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
     }
     return this.nativeBackend.sendCommand(cmd, params, timeout);
   }
@@ -3938,6 +3961,56 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     await databaseService.settings.setSourceSetting(this.sourceId, 'meshcoreRespondToDiscovery', enabled ? 'true' : 'false');
     this.nativeBackend?.setRespondToDiscovery(enabled);
     logger.info(`[MeshCore:${this.sourceId}] Discovery responder ${enabled ? 'enabled' : 'disabled'}`);
+  }
+
+  /** True when this source is configured strictly receive-only (#4547). */
+  isReceiveOnly(): boolean {
+    return this.receiveOnly;
+  }
+
+  /**
+   * Whether this source may put energy on the radio. Sync, no DB access —
+   * mirrors MeshtasticManager.canTransmit() (meshtasticManager.ts:9141) so
+   * per-command guards and the sync computeSourceRadioSummary can both use it.
+   */
+  canTransmit(): boolean {
+    return !this.receiveOnly;
+  }
+
+  /**
+   * Apply a new receive-only value. Logs ONLY on a state change (info), never
+   * per tick. Pushes the value into the native backend so chokepoint B
+   * (handleDiscoverRequest) sees it too.
+   */
+  setReceiveOnly(enabled: boolean): void {
+    const prev = this.receiveOnly;
+    this.receiveOnly = enabled;
+    this.nativeBackend?.setReceiveOnly(enabled);
+    if (prev !== enabled) {
+      logger.info(enabled
+        ? `🚫 [MeshCore:${this.sourceId}] Receive-only mode ON — all transmissions blocked, autonomous senders paused`
+        : `📡 [MeshCore:${this.sourceId}] Receive-only mode OFF — transmissions and autonomous senders resume`);
+    }
+  }
+
+  /**
+   * Re-read `meshcoreReceiveOnly` from the DB and apply it. On read failure the
+   * PREVIOUS cached value is retained — a transient DB error must never silently
+   * re-enable transmission on a source the user configured receive-only.
+   */
+  async refreshReceiveOnly(): Promise<boolean> {
+    try {
+      const raw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreReceiveOnly');
+      this.setReceiveOnly(raw === 'true');
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] Failed to read meshcoreReceiveOnly, keeping cached value (${this.receiveOnly}):`, err);
+    }
+    return this.receiveOnly;
+  }
+
+  /** Throw the shared TxDisabledError when this source is receive-only. */
+  private requireTransmit(): void {
+    if (!this.canTransmit()) throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
   }
 
   /**

--- a/src/server/meshcoreNativeBackend.receiveOnly.test.ts
+++ b/src/server/meshcoreNativeBackend.receiveOnly.test.ts
@@ -1,0 +1,167 @@
+/**
+ * MeshCore strict receive-only mode (#4547 epic, Phase 1) — WP3: native
+ * backend chokepoint B.
+ *
+ * `handleDiscoverRequest` is the highest-risk path in the epic: it is
+ * push-event driven (never touches `sendCommand`/`dispatch`) and calls
+ * `c.sendToRadioFrame(out)` directly. This file proves the receive-only
+ * guard sits ahead of it (no frame goes out while ON) with a matching
+ * non-vacuous negative case (a frame DOES go out when OFF), plus the
+ * belt-and-braces `sendCommand()` gate.
+ *
+ * Model: src/server/meshcoreNativeBackend.discovery.test.ts:255-303.
+ * See docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md §2.4, §3.4.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { vi } from 'vitest';
+import { MeshCoreNativeBackend, __setMeshCoreModule } from './meshcoreNativeBackend.js';
+import { isTxDisabledError } from './errors/txDisabledError.js';
+
+const ResponseCodes = {
+  Ok: 0, Err: 1, ContactsStart: 2, Contact: 3, EndOfContacts: 4,
+  SelfInfo: 5, Sent: 6, ContactMsgRecv: 7, ChannelMsgRecv: 8,
+  CurrTime: 9, NoMoreMessages: 10, Stats: 24,
+};
+const PushCodes = {
+  Advert: 0x80, PathUpdated: 0x81, MsgWaiting: 0x83, NewAdvert: 0x8a,
+  BinaryResponse: 0x8c, ControlData: 0x8e,
+};
+const StatsTypes = { Core: 0, Radio: 1, Packets: 2 };
+const SelfAdvertTypes = { ZeroHop: 0, Flood: 1 };
+const BinaryRequestTypes = { GetTelemetryData: 0x03 };
+const AdvType = { None: 0, Chat: 1, Repeater: 2, Room: 3 };
+const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
+
+class MockConnection extends EventEmitter {
+  sentFrames: Uint8Array[] = [];
+  addOrUpdateContact = vi.fn().mockResolvedValue(undefined);
+  getContacts = vi.fn<[], Promise<any[]>>().mockResolvedValue([]);
+  async connect() { /* no-op */ }
+  async close() { /* no-op */ }
+  async getSelfInfo() {
+    return { type: AdvType.Chat, publicKey: Uint8Array.from(Array(32).fill(0)), name: 'TestNode' };
+  }
+  sendToRadioFrame(frame: Uint8Array) {
+    this.sentFrames.push(frame);
+    setImmediate(() => this.emit(ResponseCodes.Ok));
+  }
+}
+
+function installMockModule(): void {
+  __setMeshCoreModule({
+    NodeJSSerialConnection: MockConnection as any,
+    TCPConnection: MockConnection as any,
+    Constants: {
+      ResponseCodes, PushCodes, StatsTypes, SelfAdvertTypes,
+      BinaryRequestTypes, AdvType, TxtTypes,
+    } as any,
+    CayenneLpp: { parse: () => [] } as any,
+    Packet: {} as any,
+  });
+}
+
+async function connectedBackend(): Promise<{ backend: MeshCoreNativeBackend; conn: MockConnection }> {
+  const backend = new MeshCoreNativeBackend('src-rx-only', {
+    connectionType: 'serial',
+    serialPort: '/dev/ttyUSB0',
+  });
+  await backend.connect();
+  const conn = (backend as any).connection as MockConnection;
+  return { backend, conn };
+}
+
+/** Build an inbound NODE_DISCOVER_REQ 0x8E push frame. */
+function buildDiscoverReq(opts: { snrX4: number; filter: number; tag: number }): Uint8Array {
+  return Uint8Array.from([
+    0x8e,
+    opts.snrX4 & 0xff,
+    0x00, // rssi
+    0xff, // path_len
+    0x80, // CTL_TYPE_NODE_DISCOVER_REQ, prefix_only=false
+    opts.filter & 0xff,
+    opts.tag & 0xff,
+    (opts.tag >>> 8) & 0xff,
+    (opts.tag >>> 16) & 0xff,
+    (opts.tag >>> 24) & 0xff,
+  ]);
+}
+
+// Our mock self is a Chat (companion) node.
+const selfTypeBit = 1 << AdvType.Chat;
+
+describe('MeshCoreNativeBackend receive-only (#4547 WP3, chokepoint B)', () => {
+  beforeEach(() => installMockModule());
+  afterEach(() => __setMeshCoreModule(null));
+
+  describe('handleDiscoverRequest — the highest-risk push-driven path', () => {
+    it('receive-only ON: no frame goes out even when discoverable is on and the filter matches', async () => {
+      const { backend, conn } = await connectedBackend();
+      backend.setRespondToDiscovery(true);
+      backend.setReceiveOnly(true);
+
+      conn.emit('rx', buildDiscoverReq({ snrX4: 24, filter: selfTypeBit, tag: 0xaabbccdd }));
+
+      expect(conn.sentFrames).toHaveLength(0);
+    });
+
+    it('receive-only OFF: the same request DOES produce a CMD 55 frame (non-vacuous negative)', async () => {
+      const { backend, conn } = await connectedBackend();
+      backend.setRespondToDiscovery(true);
+      // receive-only left at its default (false).
+
+      conn.emit('rx', buildDiscoverReq({ snrX4: 24, filter: selfTypeBit, tag: 0xaabbccdd }));
+
+      const resp = conn.sentFrames.find((f) => f[0] === 55);
+      expect(resp).toBeDefined();
+    });
+
+    it('receive-only ON takes priority even before the respondToDiscovery opt-in check', async () => {
+      const { backend, conn } = await connectedBackend();
+      // respondToDiscovery left OFF (default) AND receive-only ON — either
+      // alone would block the frame; this proves the receive-only check is
+      // reached first (it is literally the first statement in the method).
+      backend.setReceiveOnly(true);
+
+      conn.emit('rx', buildDiscoverReq({ snrX4: 24, filter: selfTypeBit, tag: 0xaabbccdd }));
+
+      expect(conn.sentFrames).toHaveLength(0);
+    });
+  });
+
+  describe('sendCommand() — belt-and-braces gate', () => {
+    it('receive-only ON: an RF command rejects with a TxDisabledError before dispatch runs', async () => {
+      const { backend } = await connectedBackend();
+      backend.setReceiveOnly(true);
+
+      let caught: unknown;
+      try {
+        await backend.sendCommand('send_message', {});
+        throw new Error('expected sendCommand to reject');
+      } catch (err) {
+        caught = err;
+      }
+      expect(isTxDisabledError(caught)).toBe(true);
+    });
+
+    it('receive-only ON: a serial-only command does not throw on the gate', async () => {
+      const { backend, conn } = await connectedBackend();
+      backend.setReceiveOnly(true);
+      conn.getContacts.mockResolvedValue([]);
+
+      const res = await backend.sendCommand('get_contacts', {});
+
+      expect(res.success).toBe(true);
+    });
+
+    it('receive-only OFF: an RF command reaches dispatch normally (non-vacuous negative)', async () => {
+      const { backend } = await connectedBackend();
+
+      const res = await backend.sendCommand('get_stats', {});
+
+      // Serial-only regardless of the flag; proves sendCommand doesn't
+      // misclassify when receive-only is off.
+      expect(res.success).toBeDefined();
+    });
+  });
+});

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -14,6 +14,8 @@
 import { EventEmitter } from 'events';
 import { createHash } from 'node:crypto';
 import { logger } from '../utils/logger.js';
+import { TxDisabledError } from './errors/txDisabledError.js';
+import { isRfBridgeCommand, MESHCORE_RECEIVE_ONLY_MESSAGE } from './constants/meshcoreTx.js';
 
 // Lazy meshcore.js import. Hold the module reference so tests can swap it
 // out by calling `__setMeshCoreModule(...)`. The default load path is the
@@ -268,6 +270,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * the manager from the per-source `meshcoreRespondToDiscovery` setting.
    */
   private respondToDiscovery: boolean = false;
+  /**
+   * Receive-only mirror pushed by the manager (#4547). Same push mechanism
+   * as `respondToDiscovery` — this class holds no `databaseService` handle,
+   * so it learns the state from `MeshCoreManager.setReceiveOnly()` /
+   * `startNativeBackend()`, never by reading settings itself.
+   */
+  private receiveOnly: boolean = false;
   /**
    * Timestamps (ms) of recent discovery responses we've sent, for rate
    * limiting. Mirrors the firmware repeater's "max 4 per 120s" guard so an
@@ -784,6 +793,16 @@ export class MeshCoreNativeBackend extends EventEmitter {
   }
 
   /**
+   * Set by `MeshCoreManager.setReceiveOnly()` and on connect in
+   * `startNativeBackend()` (#4547). Gates chokepoint B: this class is the
+   * only place that can put a frame on the air without going through
+   * `MeshCoreManager.sendBridgeCommand`.
+   */
+  setReceiveOnly(enabled: boolean): void {
+    this.receiveOnly = enabled;
+  }
+
+  /**
    * Reply to an inbound NODE_DISCOVER_REQ (0x8E control push) with a zero-hop
    * NODE_DISCOVER_RESP carrying our public key, so the requester discovers us.
    * Mirrors the firmware repeater's responder, but for our companion node.
@@ -794,8 +813,17 @@ export class MeshCoreNativeBackend extends EventEmitter {
    *   [55][0x90|selfType][our inbound SNR×4][tag(4 LE)][pubkey (32B, or 8B if prefix_only)]
    *
    * Gated on the opt-in flag, a type-filter match, and a 4-per-120s rate limit.
+   *
+   * #4547: this is the single most important guard in the receive-only epic.
+   * It is push-event driven (never touches `sendCommand`/`dispatch`) and
+   * calls `c.sendToRadioFrame(out)` directly below — the receive-only check
+   * MUST be the first statement, ahead of even the `respondToDiscovery` gate.
    */
   private handleDiscoverRequest(frame: Uint8Array): void {
+    if (this.receiveOnly) {
+      logger.debug(`[MeshCoreNative:${this.sourceId}] Discovery request ignored - receive-only mode`);
+      return;
+    }
     if (!this.respondToDiscovery) return;
     const c = this.connection;
     const selfKey: Uint8Array | undefined = this.cachedSelfInfo?.publicKey;
@@ -876,6 +904,14 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * doesn't need to special-case the transport.
    */
   async sendCommand(cmd: string, params: Record<string, unknown>, timeoutMs: number = 30000): Promise<BridgeShapedResponse> {
+    // Receive-only (#4547): belt-and-braces gate for any caller that reaches
+    // this backend without going through MeshCoreManager.sendBridgeCommand
+    // (e.g. a future Virtual Node caller, or the raw ANON_REQ/discover paths
+    // inside dispatch()). Thrown before the try/catch below so it rejects
+    // the promise instead of being swallowed into a {success:false} shape.
+    if (this.receiveOnly && isRfBridgeCommand(cmd)) {
+      throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+    }
     const id = `${++this.commandSeq}`;
     try {
       const data = await this.withTimeout(this.dispatch(cmd, params), timeoutMs, cmd);

--- a/src/server/routes/deviceStatusRoutes.test.ts
+++ b/src/server/routes/deviceStatusRoutes.test.ts
@@ -17,13 +17,25 @@ vi.mock('../auth/authMiddleware.js', () => ({
   requireAdmin: () => (req: any, _res: any, next: any) => { req.user = { id: 1, isAdmin: true }; next(); },
 }));
 
+// #4547 Phase 1 WP5: a MeshCore sourceId is resolved via the registry +
+// isMeshCoreManager directly (resolveSourceManager() is Meshtastic-only by
+// design and would silently fall back to the wrong manager, see the
+// doc comment on that helper and deviceStatusRoutes.ts).
+const mockGetManager = vi.hoisted(() => vi.fn());
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: { getManager: mockGetManager },
+}));
+
 import deviceStatusRoutes from './deviceStatusRoutes.js';
 
 const app = express();
 app.use(express.json());
 app.use('/', deviceStatusRoutes);
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetManager.mockReturnValue(null);
+});
 
 describe('GET /device/tx-status', () => {
   beforeEach(() => mockManager.isUdpBroadcastRelayEnabled.mockReturnValue(false));
@@ -53,6 +65,47 @@ describe('GET /device/tx-status', () => {
     expect(res.body.txEnabled).toBe(false);
     expect(res.body.udpRelayEnabled).toBe(true);
     expect(res.body.canTransmit).toBe(true);
+  });
+
+  // #4547 Phase 1 WP5: an explicit MeshCore ?sourceId= reports THAT source's
+  // receive-only state, not the Meshtastic resolveSourceManager() fallback's.
+  describe('MeshCore source (#4547)', () => {
+    it('reports the receive-only source as unable to transmit', async () => {
+      mockGetManager.mockReturnValue({
+        sourceType: 'meshcore',
+        canTransmit: () => false,
+      });
+
+      const res = await request(app).get('/device/tx-status?sourceId=meshcore-a');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ txEnabled: false, udpRelayEnabled: false, canTransmit: false });
+      // The Meshtastic fallback path must not have been consulted.
+      expect(mockManager.getDeviceConfig).not.toHaveBeenCalled();
+    });
+
+    it('reports a transmit-capable MeshCore source as canTransmit: true', async () => {
+      mockGetManager.mockReturnValue({
+        sourceType: 'meshcore',
+        canTransmit: () => true,
+      });
+
+      const res = await request(app).get('/device/tx-status?sourceId=meshcore-b');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ txEnabled: true, udpRelayEnabled: false, canTransmit: true });
+    });
+
+    it('falls back to the Meshtastic resolveSourceManager() path when the sourceId is not a registered MeshCore manager', async () => {
+      mockGetManager.mockReturnValue(null); // not registered as MeshCore
+      mockManager.getDeviceConfig.mockResolvedValue({ lora: {} });
+
+      const res = await request(app).get('/device/tx-status?sourceId=meshtastic-a');
+
+      expect(res.status).toBe(200);
+      expect(res.body.txEnabled).toBe(true);
+      expect(mockManager.getDeviceConfig).toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/server/routes/deviceStatusRoutes.ts
+++ b/src/server/routes/deviceStatusRoutes.ts
@@ -2,6 +2,8 @@ import { Router, Request, Response } from 'express';
 import { optionalAuth, requireAdmin } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isMeshCoreManager } from '../sourceManagerTypes.js';
 
 const router = Router();
 
@@ -9,6 +11,20 @@ const router = Router();
 router.get('/device/tx-status', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const txSourceId = req.query.sourceId as string | undefined;
+    // MeshCore (#4547): resolveSourceManager() is Meshtastic-only by design —
+    // an explicit MeshCore sourceId falls back to the primary/fallback
+    // Meshtastic manager rather than returning the MeshCore one (see its
+    // doc comment). Narrow via the registry + isMeshCoreManager directly so
+    // this endpoint reports the MeshCore source's own receive-only state
+    // instead of an unrelated Meshtastic source's.
+    if (txSourceId) {
+      const mgr = sourceManagerRegistry.getManager(txSourceId);
+      if (mgr && isMeshCoreManager(mgr)) {
+        const canTx = mgr.canTransmit();
+        res.json({ txEnabled: canTx, udpRelayEnabled: false, canTransmit: canTx });
+        return;
+      }
+    }
     const txManager = resolveSourceManager(txSourceId);
     const deviceConfig = await txManager.getDeviceConfig();
     const txEnabled = deviceConfig?.lora?.txEnabled !== false; // Default to true if undefined

--- a/src/server/routes/meshcoreAdminRoutes.ts
+++ b/src/server/routes/meshcoreAdminRoutes.ts
@@ -23,7 +23,11 @@ import {
   enhanceNeighborsReply,
   DANGER_COMMAND_PATTERN,
   resolveCliTimeoutMs,
+  requireMeshcoreTx,
+  rejectIfReceiveOnly,
+  failIfTxDisabled,
 } from './meshcoreRouteShared.js';
+import { isTransmittingLocalCliVerb } from '../constants/meshcoreTx.js';
 
 const router = Router({ mergeParams: true });
 
@@ -41,7 +45,7 @@ const router = Router({ mergeParams: true });
  * `configuration:write`; remote_admin was split out so operators can grant
  * one without the other.)
  */
-router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { publicKey, password, rememberPassword } = req.body as {
       publicKey?: string;
@@ -110,6 +114,7 @@ router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
     });
     res.json({ success: true, message: 'Login successful', persisted: false });
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error logging in:', error);
     res.status(500).json({ success: false, error: 'Login error' });
   }
@@ -124,7 +129,7 @@ router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
  * path, ACL eviction, or the remote being offline). Returns 502 when the
  * underlying bridge rejected the send.
  */
-router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { publicKey, command, timeoutMs, confirm } = req.body as {
       publicKey?: string;
@@ -182,6 +187,7 @@ router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermissio
       });
       res.json({ success: true, data: result });
     } catch (err) {
+      if (failIfTxDisabled(res, err)) return;
       const msg = err instanceof Error ? err.message : String(err);
       auditMeshcoreEvent(req, 'meshcore_remote_cli_failed', 'remote_admin', {
         sourceId: req.params.id,
@@ -199,6 +205,7 @@ router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermissio
       res.status(502).json({ success: false, error: msg });
     }
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Unexpected error in /admin/cli:', error);
     res.status(500).json({ success: false, error: 'CLI error' });
   }
@@ -253,6 +260,12 @@ router.post('/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('con
         code: 'DANGER_CONFIRM_REQUIRED',
       });
     }
+    // Receive-only (#4547): /cli carries BOTH transmitting verbs (advert) and
+    // purely local/serial verbs (ver, stats, clock, help, get/set config).
+    // Gate only the transmitting ones so the console stays usable.
+    if (isTransmittingLocalCliVerb(command) && rejectIfReceiveOnly(req, res)) {
+      return;
+    }
     const effectiveTimeout = await resolveCliTimeoutMs(timeoutMs);
 
     try {
@@ -272,6 +285,7 @@ router.post('/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('con
       });
       res.json({ success: true, data: result });
     } catch (err) {
+      if (failIfTxDisabled(res, err)) return;
       const msg = err instanceof Error ? err.message : String(err);
       auditMeshcoreEvent(req, 'meshcore_local_cli_failed', 'configuration', {
         sourceId: req.params.id,
@@ -288,6 +302,7 @@ router.post('/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('con
       res.status(502).json({ success: false, error: msg });
     }
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Unexpected error in /cli:', error);
     res.status(500).json({ success: false, error: 'CLI error' });
   }
@@ -357,7 +372,7 @@ router.get('/admin/credentials-capability', requireAuth(), requirePermission('re
  *   401 STORED_CREDENTIAL_REJECTED — credential decrypted but the remote
  *       rejected the login (remote's admin password probably changed).
  */
-router.post('/admin/login-with-saved', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/admin/login-with-saved', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { publicKey } = req.body as { publicKey?: string };
     if (typeof publicKey !== 'string' || !isValidPublicKey(publicKey)) {
@@ -398,6 +413,7 @@ router.post('/admin/login-with-saved', meshcoreDeviceLimiter, requireAuth(), req
     });
     res.json({ success: true, usedStored: true });
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error in login-with-saved:', error);
     res.status(500).json({ success: false, error: 'Login error' });
   }
@@ -430,7 +446,7 @@ router.delete('/admin/credentials/:publicKey', requireAuth(), requirePermission(
  * Get status from a remote node (requires prior login)
  * Requires authentication - queries remote node
  */
-router.get('/admin/status/:publicKey', requireAuth(), requirePermission('remote_admin', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.get('/admin/status/:publicKey', requireAuth(), requirePermission('remote_admin', 'read', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { publicKey } = req.params;
 
@@ -447,6 +463,7 @@ router.get('/admin/status/:publicKey', requireAuth(), requirePermission('remote_
       res.status(404).json({ success: false, error: 'No status received' });
     }
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error getting node status:', error);
     res.status(500).json({ success: false, error: 'Status error' });
   }

--- a/src/server/routes/meshcoreAutomationRoutes.ts
+++ b/src/server/routes/meshcoreAutomationRoutes.ts
@@ -18,7 +18,7 @@ import { resolveAutoAckPreSendDelaySeconds } from '../autoAckDelay.js';
 import { compileUserRegex } from '../../utils/safeRegex.js';
 import { ok, fail } from '../utils/apiResponse.js';
 import type { MeshcorePathfindingFilterSettings } from '../../services/database.js';
-import { managerFor } from './meshcoreRouteShared.js';
+import { managerFor, requireMeshcoreTx, failIfTxDisabled } from './meshcoreRouteShared.js';
 
 const router = Router({ mergeParams: true });
 
@@ -582,6 +582,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const mgr = managerFor(req, res);
@@ -589,6 +590,7 @@ router.post(
       const status = mgr.getAutoAnnounceStatus();
       res.json({ success: true, data: { ...result, lastRunAt: status.lastRunAt || null } });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error sending manual meshcore announce:', error);
       res.status(500).json({ success: false, error: 'Failed to send announcement' });
     }
@@ -648,6 +650,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const mgr = managerFor(req, res);
@@ -658,6 +661,7 @@ router.post(
       const result = await mgr.runTimerTrigger(triggerId);
       res.json({ success: result.ok, data: result });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error running meshcore timer trigger:', error);
       res.status(500).json({ success: false, error: 'Failed to run timer trigger' });
     }

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -21,7 +21,7 @@ import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddle
 import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
 import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
 import { isBogusPosition } from '../../utils/nullIsland.js';
-import { managerFor, isValidPublicKey, auditMeshcoreEvent, parseHexPathChain } from './meshcoreRouteShared.js';
+import { managerFor, isValidPublicKey, auditMeshcoreEvent, parseHexPathChain, requireMeshcoreTx, failIfTxDisabled } from './meshcoreRouteShared.js';
 import { ok, fail } from '../utils/apiResponse.js';
 import { buildLocalContactRow, withoutLocalFlag, type MeshCoreContactResponse } from './meshcoreLocalContactRow.js';
 
@@ -169,6 +169,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const publicKey = req.params.publicKey;
@@ -187,6 +188,7 @@ router.post(
       }
       res.json({ success: true });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error resetting contact path:', error);
       res.status(500).json({ success: false, error: 'Failed to reset path' });
     }
@@ -207,6 +209,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const publicKey = req.params.publicKey;
@@ -225,6 +228,7 @@ router.post(
       }
       res.json({ success: true });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error discovering contact path:', error);
       res.status(500).json({ success: false, error: 'Failed to discover path' });
     }
@@ -249,6 +253,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const mode = req.body?.mode as MeshCoreDiscoverMode | undefined;
@@ -269,6 +274,7 @@ router.post(
       // backwards compatibility with any client reading the old shape.
       res.json({ success: true, returned, new: newCount, nodes });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error discovering nodes:', error);
       res.status(500).json({ success: false, error: 'Failed to discover nodes' });
     }
@@ -292,11 +298,13 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const result = await managerFor(req, res).discoverRegions();
       res.json({ success: true, ...result });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error discovering regions:', error);
       res.status(500).json({ success: false, error: 'Failed to discover regions' });
     }
@@ -315,6 +323,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const publicKey = req.params.publicKey;
@@ -333,6 +342,7 @@ router.post(
       }
       res.json({ success: true, hops: result.hops, lastSnr: result.lastSnr });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error tracing contact path:', error);
       res.status(500).json({ success: false, error: 'Failed to trace path' });
     }
@@ -360,6 +370,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const publicKey = req.params.publicKey;
@@ -383,6 +394,7 @@ router.post(
         snrFromTarget: result.snrFromTarget,
       });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error pinging contact (zero hop):', error);
       return fail(res, 500, 'MESHCORE_PING_FAILED', 'Failed to ping contact');
     }
@@ -488,6 +500,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const publicKey = req.params.publicKey;
@@ -509,6 +522,7 @@ router.post(
       }
       res.json({ success: true, broadcast: true });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error sharing contact:', error);
       res.status(500).json({ success: false, error: 'Failed to share contact' });
     }
@@ -654,6 +668,7 @@ router.get(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const publicKey = req.params.publicKey;
@@ -695,6 +710,7 @@ router.get(
 
       res.json({ success: true, data: { ...result, neighbours: resolved } });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error getting neighbours:', error);
       res.status(500).json({ success: false, error: 'Failed to get neighbours' });
     }
@@ -759,6 +775,7 @@ router.post(
   meshcoreDeviceLimiter,
   requireAuth(),
   requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
   async (req: Request, res: Response) => {
     try {
       const sourceId = (req.params as { id: string }).id;
@@ -820,6 +837,7 @@ router.post(
         data: { type, written: result.written, sources: result.sources },
       });
     } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
       logger.error('[API] Error polling node telemetry:', error);
       res.status(500).json({ success: false, error: 'Telemetry poll failed' });
     }
@@ -1042,6 +1060,7 @@ router.post('/neighbors/request', meshcoreDeviceLimiter, requireAuth(), requireP
 
     res.json({ success: true, data: { neighbors: result.neighbors, count: result.neighbors.length } });
   } catch (err: any) {
+    if (failIfTxDisabled(res, err)) return;
     const msg = err?.message ?? String(err);
     if (msg.includes('timed out')) {
       return res.status(504).json({ success: false, error: msg, code: 'CLI_TIMEOUT' });

--- a/src/server/routes/meshcoreDeviceRoutes.ts
+++ b/src/server/routes/meshcoreDeviceRoutes.ts
@@ -12,7 +12,7 @@ import { getMeshCoreTelemetryPoller, nodeNumFromPubkey } from '../services/meshc
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
-import { managerFor, isValidConnectionParams } from './meshcoreRouteShared.js';
+import { managerFor, isValidConnectionParams, requireMeshcoreTx, failIfTxDisabled } from './meshcoreRouteShared.js';
 import databaseService from '../../services/database.js';
 import { buildLocalContactRow, withoutLocalFlag, type MeshCoreContactResponse } from './meshcoreLocalContactRow.js';
 
@@ -259,7 +259,7 @@ router.get('/info', optionalAuth(), requirePermission('connection', 'read', { so
  * Send an advertisement
  * Requires authentication - broadcasts on mesh network
  */
-router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('connection', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('connection', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const success = await managerFor(req, res).sendAdvert();
 
@@ -269,6 +269,7 @@ router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('
       res.status(400).json({ success: false, error: 'Failed to send advert' });
     }
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error sending advert:', error);
     res.status(500).json({ success: false, error: 'Advert error' });
   }

--- a/src/server/routes/meshcoreMessagingRoutes.ts
+++ b/src/server/routes/meshcoreMessagingRoutes.ts
@@ -17,7 +17,7 @@ import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddle
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
 import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.js';
 import { managerFor, VALIDATION, isValidPublicKey, isValidMessage, auditMeshcoreEvent,
-  requireMeshcoreChannelAccess, canAccessMeshcoreChannel } from './meshcoreRouteShared.js';
+  requireMeshcoreChannelAccess, canAccessMeshcoreChannel, requireMeshcoreTx, failIfTxDisabled } from './meshcoreRouteShared.js';
 
 const router = Router({ mergeParams: true });
 
@@ -252,7 +252,7 @@ router.delete('/messages/:messageId', requireAuth(), requirePermission('messages
  * Send a message
  * Requires authentication - sends data over mesh network
  */
-router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { text, toPublicKey, channelIdx, scope } = req.body;
 
@@ -324,6 +324,7 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
       res.status(400).json({ success: false, error: 'Failed to send message' });
     }
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error sending message:', error);
     res.status(500).json({ success: false, error: 'Send error' });
   }
@@ -362,7 +363,7 @@ router.get('/rooms/servers', optionalAuth(), requirePermission('messages', 'read
  *   - `password` may be empty for guest/read-only access.
  *   - `rememberPassword: true` persists the password (AES-256-GCM via credential store).
  */
-router.post('/rooms/login', meshcoreDeviceLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/rooms/login', meshcoreDeviceLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { publicKey, password, rememberPassword } = req.body as {
       publicKey?: string;
@@ -406,6 +407,7 @@ router.post('/rooms/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
 
     res.json({ success: true, message: 'Room login successful', persisted: false });
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error logging into room:', error);
     res.status(500).json({ success: false, error: 'Room login error' });
   }
@@ -416,7 +418,7 @@ router.post('/rooms/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
  * Login to a room server using a previously saved credential.
  * Body: { publicKey: string }
  */
-router.post('/rooms/login-with-saved', meshcoreDeviceLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/rooms/login-with-saved', meshcoreDeviceLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { publicKey } = req.body as { publicKey?: string };
     if (typeof publicKey !== 'string' || !isValidPublicKey(publicKey)) {
@@ -440,6 +442,7 @@ router.post('/rooms/login-with-saved', meshcoreDeviceLimiter, requireAuth(), req
     }
     res.json({ success: true, usedStored: true });
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error logging into room with saved credential:', error);
     res.status(500).json({ success: false, error: 'Room login error' });
   }
@@ -471,7 +474,7 @@ router.get('/rooms/credentials', requireAuth(), requirePermission('messages', 'r
  * Send a text post to a room server.
  * Body: { roomPublicKey: string, text: string }
  */
-router.post('/rooms/post', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+router.post('/rooms/post', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), requireMeshcoreTx(), async (req: Request, res: Response) => {
   try {
     const { roomPublicKey, text } = req.body as {
       roomPublicKey?: string;
@@ -493,6 +496,7 @@ router.post('/rooms/post', messageLimiter, requireAuth(), requirePermission('mes
       res.status(400).json({ success: false, error: 'Failed to send room post' });
     }
   } catch (error) {
+    if (failIfTxDisabled(res, error)) return;
     logger.error('[API] Error sending room post:', error);
     res.status(500).json({ success: false, error: 'Room post error' });
   }

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -18,6 +18,9 @@ import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../sourceManagerTypes.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
+import { fail } from '../utils/apiResponse.js';
+import { TX_DISABLED_CODE, isTxDisabledError } from '../errors/txDisabledError.js';
+import { MESHCORE_RECEIVE_ONLY_MESSAGE } from '../constants/meshcoreTx.js';
 
 /**
  * Resolve the manager for a request. Mounted only under
@@ -58,6 +61,47 @@ export function meshcoreRouteGuard(req: Request, res: Response, next: NextFuncti
   // Cache the narrowed manager so managerFor() can avoid a second registry lookup.
   res.locals.meshcoreManager = _guardMgr as MeshCoreManager;
   next();
+}
+
+/**
+ * Router middleware: reject a request on a receive-only MeshCore source with
+ * 409 TX_DISABLED (#4547). MUST be placed AFTER requirePermission(...) so a
+ * 403 still wins over a 409 for an unauthorized caller, and after
+ * meshcoreRouteGuard so res.locals.meshcoreManager is populated.
+ */
+export function requireMeshcoreTx() {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    const mgr = res.locals.meshcoreManager as MeshCoreManager | undefined;
+    if (mgr?.isReceiveOnly?.()) {
+      return fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
+    }
+    next();
+  };
+}
+
+/**
+ * Inline guard for handlers that transmit only on some inputs (e.g. POST /cli
+ * with the `advert` verb). Returns true when it has already sent the 409.
+ */
+export function rejectIfReceiveOnly(req: Request, res: Response): boolean {
+  if (managerFor(req, res).isReceiveOnly()) {
+    fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Catch-block mapping: converts a TxDisabledError raised mid-request (the
+ * flag flipped between the pre-check and the send) into 409 instead of 500.
+ * Returns true when it has already sent the response.
+ */
+export function failIfTxDisabled(res: Response, error: unknown): boolean {
+  if (isTxDisabledError(error)) {
+    fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -68,11 +68,25 @@ export function meshcoreRouteGuard(req: Request, res: Response, next: NextFuncti
  * 409 TX_DISABLED (#4547). MUST be placed AFTER requirePermission(...) so a
  * 403 still wins over a 409 for an unauthorized caller, and after
  * meshcoreRouteGuard so res.locals.meshcoreManager is populated.
+ *
+ * Fails CLOSED: if `res.locals.meshcoreManager` is missing — meaning
+ * meshcoreRouteGuard was skipped, or ran against a source whose manager
+ * vanished between the guard and here — this cannot verify the source is
+ * safe to transmit on, so it refuses the request rather than letting it
+ * through. Mirrors meshcoreRouteGuard's own "no manager for source" 404
+ * shape so callers see one consistent error for an unresolvable manager.
  */
 export function requireMeshcoreTx() {
-  return (_req: Request, res: Response, next: NextFunction) => {
+  return (req: Request, res: Response, next: NextFunction) => {
     const mgr = res.locals.meshcoreManager as MeshCoreManager | undefined;
-    if (mgr?.isReceiveOnly?.()) {
+    if (!mgr) {
+      const sourceId = (req.params as { id?: string }).id;
+      return res.status(404).json({
+        success: false,
+        error: `No MeshCore manager for source ${sourceId}`,
+      });
+    }
+    if (mgr.isReceiveOnly()) {
       return fail(res, 409, TX_DISABLED_CODE, MESHCORE_RECEIVE_ONLY_MESSAGE);
     }
     next();

--- a/src/server/routes/meshcoreRoutes.receiveOnly.test.ts
+++ b/src/server/routes/meshcoreRoutes.receiveOnly.test.ts
@@ -14,7 +14,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Request, Response } from 'express';
 import meshcoreRoutes from './meshcoreRoutes.js';
+import { requireMeshcoreTx } from './meshcoreRouteShared.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 import { TxDisabledError } from '../errors/txDisabledError.js';
 import { MESHCORE_RECEIVE_ONLY_MESSAGE } from '../constants/meshcoreTx.js';
@@ -328,6 +330,32 @@ describe('MeshCore receive-only — 409 TX_DISABLED mapping (#4547)', () => {
         .send({ publicKey: VALID_PK });
       expect(res.status).toBe(409);
       expect(res.body).toMatchObject({ success: false, code: 'TX_DISABLED' });
+    });
+  });
+});
+
+describe('requireMeshcoreTx() fails closed when the manager is unresolved (code review, #4550)', () => {
+  /**
+   * meshcoreRouteGuard always populates res.locals.meshcoreManager before
+   * requireMeshcoreTx runs in the real router chain, so this exercises the
+   * middleware directly to prove it refuses the request rather than passing
+   * it through when that invariant is somehow violated (guard skipped, or a
+   * future manager type lacking isReceiveOnly()).
+   */
+  it('returns 404 and never calls next() when res.locals.meshcoreManager is absent', () => {
+    const req = { params: { id: 'missing-source' } } as unknown as Request;
+    const jsonMock = vi.fn();
+    const statusMock = vi.fn().mockReturnValue({ json: jsonMock });
+    const res = { locals: {}, status: statusMock } as unknown as Response;
+    const next = vi.fn();
+
+    requireMeshcoreTx()(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(statusMock).toHaveBeenCalledWith(404);
+    expect(jsonMock).toHaveBeenCalledWith({
+      success: false,
+      error: 'No MeshCore manager for source missing-source',
     });
   });
 });

--- a/src/server/routes/meshcoreRoutes.receiveOnly.test.ts
+++ b/src/server/routes/meshcoreRoutes.receiveOnly.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Route test — MeshCore receive-only mode (#4547), 409 TX_DISABLED mapping.
+ *
+ * Covers Phase 1 WP4 (docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md
+ * §2.5 / §3.5): the `requireMeshcoreTx()` middleware on every unconditional
+ * transmitting route, the inline `rejectIfReceiveOnly()` guard on the two
+ * conditional routes, and the `failIfTxDisabled()` catch-block mapping for a
+ * mid-request race.
+ *
+ * Uses `createRouteTestApp()` per CLAUDE.md: real express-session + real auth
+ * middleware + real checkPermissionAsync against the singleton's `:memory:`
+ * SQLite DB. Only `sourceManagerRegistry` is mocked (non-DB) with a stub
+ * MeshCore manager whose `isReceiveOnly()` flag is toggled per test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import meshcoreRoutes from './meshcoreRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { TxDisabledError } from '../errors/txDisabledError.js';
+import { MESHCORE_RECEIVE_ONLY_MESSAGE } from '../constants/meshcoreTx.js';
+
+const VALID_PK = 'a'.repeat(64);
+
+/**
+ * A MeshCore manager stub exposing every method reached by the routes under
+ * test, with success-shaped defaults so the "receive-only OFF" negative
+ * control exercises real handler logic (not just an unrelated 500/400).
+ * `isReceiveOnly()` reads a mutable flag toggled per-test via `setReceiveOnly`.
+ * Individual methods can be overridden per-test to simulate a mid-request
+ * race (the manager throwing `TxDisabledError` after the pre-check passed).
+ */
+function makeStubManager(sourceId: string) {
+  let receiveOnly = false;
+  return {
+    sourceId,
+    sourceType: 'meshcore' as const,
+    setReceiveOnly: (v: boolean) => { receiveOnly = v; },
+    isReceiveOnly: () => receiveOnly,
+    canTransmit: () => !receiveOnly,
+
+    // ---- reads / connection ----
+    getConnectionStatus: () => ({ connected: true, deviceType: 1, config: null }),
+    getLocalNode: () => null,
+    getContacts: () => [],
+    getAllNodes: async () => [],
+    getRecentMessages: (_limit?: number) => [],
+    getChannelMessages: async () => [],
+    getChannelMessageCounts: async () => ({}),
+    getChannelLatestTimestamps: async () => ({}),
+    isConnected: () => true,
+    getLastMeshTxAt: () => 0,
+    recordMeshTx: (_now?: number) => {},
+
+    // ---- messaging (RF) ----
+    sendMessage: async (..._args: unknown[]) => true,
+    loginToRoom: async (..._args: unknown[]) => true,
+    sendRoomPost: async (..._args: unknown[]) => true,
+    getRoomServers: () => [],
+    isRoomLoggedIn: () => false,
+
+    // ---- contacts (RF) ----
+    resetContactPath: async (..._args: unknown[]) => true,
+    discoverContactPath: async (..._args: unknown[]) => true,
+    discoverNodes: async (..._args: unknown[]) => ({ returned: 0, newCount: 0, nodes: [] }),
+    discoverRegions: async () => ({ regions: [], byRepeater: {} }),
+    traceContactPath: async (..._args: unknown[]) => ({ hops: [], lastSnr: 0 }),
+    pingContactZeroHop: async (..._args: unknown[]) => ({
+      ok: true, hopHash: 'aa', rttMs: 1, snrToTarget: 1, snrFromTarget: 1,
+    }),
+    shareContact: async (..._args: unknown[]) => ({ ok: true }),
+    getNeighbours: async (..._args: unknown[]) => ({ neighbours: [] }),
+    // POST /neighbors/request's remote branch 404s unless this resolves to a
+    // Repeater (advType 2) contact — see meshcoreContactsRoutes.ts:1011.
+    resolveContactByPrefix: (_prefix: string) => ({ publicKey: VALID_PK, advType: 2, advName: 'stub-repeater', name: 'stub-repeater' }),
+    getContact: (_pk: string) => null,
+
+    // ---- serial-only contacts ----
+    setContactOutPath: async (..._args: unknown[]) => true,
+    removeContact: async (..._args: unknown[]) => true,
+    forgetLocalContact: async (..._args: unknown[]) => true,
+    exportContact: async (..._args: unknown[]) => [1, 2, 3],
+    importContact: async (..._args: unknown[]) => true,
+    setNodeFavorite: async (..._args: unknown[]) => {},
+
+    // ---- neighbors (conditional route) ----
+    // Mirrors the real manager: the remote branch (publicKey present) throws
+    // only while receive-only; the local branch (no publicKey) never gates.
+    requestNeighbors: async (publicKey?: string) => {
+      if (publicKey && receiveOnly) throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+      return { neighbors: [] };
+    },
+
+    // ---- admin ----
+    loginToNode: async (..._args: unknown[]) => true,
+    sendCliCommand: async (..._args: unknown[]) => ({ reply: 'ok', elapsedMs: 1 }),
+    sendLocalCliCommand: async (command: string) => ({ reply: `ok:${command}`, elapsedMs: 1 }),
+    requestNodeStatus: async (..._args: unknown[]) => ({ battery: 100 }),
+
+    // ---- device ----
+    connect: async () => true,
+    disconnect: async () => {},
+    getStatsCore: async () => ({}),
+    getStatsRadio: async () => ({}),
+    getStatsPackets: async () => ({}),
+    sendAdvert: async () => true,
+
+    // ---- serial-only device config ----
+    setRespondToDiscovery: async (_enabled: boolean) => {},
+    syncDeviceTime: async () => ({ ok: true }),
+
+    // ---- automation ----
+    getAutoPathfindingStatus: () => ({ enabled: false, lastRunAt: null }),
+    startAutoPathfinding: async () => {},
+    getAutoAnnounceStatus: () => ({ lastRunAt: null }),
+    runAutoAnnounceCycle: async (_trigger: string) => ({ sent: true }),
+    startAutoAnnounce: async () => {},
+    startTimerTriggers: async () => {},
+    runTimerTrigger: async (_id: string) => ({ ok: true }),
+    resetAutoResponderRegexCache: () => {},
+    previewAnnouncementMessage: async (_msg: string) => '',
+  };
+}
+
+type StubManager = ReturnType<typeof makeStubManager>;
+
+// The registry mock is hoisted; build it once and mutate the manager map from
+// inside each test via the exported `__managers` handle.
+const managers = new Map<string, StubManager>();
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: (sourceId: string) => managers.get(sourceId),
+    getAllManagers: () => Array.from(managers.values()),
+  },
+}));
+
+describe('MeshCore receive-only — 409 TX_DISABLED mapping (#4547)', () => {
+  let harness: RouteTestHarness;
+  let mgr: StubManager;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/sources/:id/meshcore', meshcoreRoutes),
+    });
+    mgr = makeStubManager(harness.sourceA);
+    managers.set(harness.sourceA, mgr);
+  });
+
+  afterEach(async () => {
+    managers.clear();
+    await harness.cleanup();
+  });
+
+  const base = (sourceId: string) => `/sources/${sourceId}/meshcore`;
+
+  /** Every unconditionally-gated route from spec §2.5.2, with a valid request. */
+  const unconditionalRoutes: Array<{
+    name: string;
+    method: 'get' | 'post';
+    path: string;
+    body?: Record<string, unknown>;
+  }> = [
+    { name: 'POST /messages/send', method: 'post', path: '/messages/send', body: { text: 'hi' } },
+    { name: 'POST /rooms/login', method: 'post', path: '/rooms/login', body: { publicKey: VALID_PK, password: '' } },
+    { name: 'POST /rooms/login-with-saved', method: 'post', path: '/rooms/login-with-saved', body: { publicKey: VALID_PK } },
+    { name: 'POST /rooms/post', method: 'post', path: '/rooms/post', body: { roomPublicKey: VALID_PK, text: 'hi' } },
+    { name: 'POST /contacts/:publicKey/reset-path', method: 'post', path: `/contacts/${VALID_PK}/reset-path` },
+    { name: 'POST /contacts/:publicKey/discover-path', method: 'post', path: `/contacts/${VALID_PK}/discover-path` },
+    { name: 'POST /discover', method: 'post', path: '/discover', body: { mode: 'nearby' } },
+    { name: 'POST /regions/discover', method: 'post', path: '/regions/discover' },
+    { name: 'POST /contacts/:publicKey/trace-path', method: 'post', path: `/contacts/${VALID_PK}/trace-path` },
+    { name: 'POST /contacts/:publicKey/ping', method: 'post', path: `/contacts/${VALID_PK}/ping` },
+    { name: 'POST /contacts/:publicKey/share', method: 'post', path: `/contacts/${VALID_PK}/share` },
+    { name: 'GET /contacts/:publicKey/neighbours', method: 'get', path: `/contacts/${VALID_PK}/neighbours` },
+    { name: 'POST /nodes/:publicKey/telemetry/poll', method: 'post', path: `/nodes/${VALID_PK}/telemetry/poll`, body: { type: 'status' } },
+    { name: 'POST /admin/login', method: 'post', path: '/admin/login', body: { publicKey: VALID_PK, password: '' } },
+    { name: 'POST /admin/cli', method: 'post', path: '/admin/cli', body: { publicKey: VALID_PK, command: 'ver' } },
+    { name: 'POST /admin/login-with-saved', method: 'post', path: '/admin/login-with-saved', body: { publicKey: VALID_PK } },
+    { name: 'GET /admin/status/:publicKey', method: 'get', path: `/admin/status/${VALID_PK}` },
+    { name: 'POST /advert', method: 'post', path: '/advert' },
+    { name: 'POST /automation/announce/send', method: 'post', path: '/automation/announce/send' },
+    { name: 'POST /automation/timers/:triggerId/run', method: 'post', path: '/automation/timers/t1/run' },
+  ];
+
+  it('sanity: exactly 20 unconditional routes are under test (spec §2.5.2)', () => {
+    expect(unconditionalRoutes).toHaveLength(20);
+  });
+
+  describe.each(unconditionalRoutes)('$name', ({ method, path }) => {
+    it('returns 409 TX_DISABLED while receive-only', async () => {
+      mgr.setReceiveOnly(true);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent[method](base(harness.sourceA) + path).send({});
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({
+        success: false,
+        code: 'TX_DISABLED',
+        error: MESHCORE_RECEIVE_ONLY_MESSAGE,
+      });
+    });
+
+    it('does not return 409 while receive-only is off', async () => {
+      mgr.setReceiveOnly(false);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent[method](base(harness.sourceA) + path).send({});
+      expect(res.status).not.toBe(409);
+    });
+  });
+
+  describe('ordering — 403 beats 409', () => {
+    it('an unauthorized caller on a receive-only source gets 403, not 409', async () => {
+      mgr.setReceiveOnly(true);
+      // No grants for `limited` — requirePermission must fire before requireMeshcoreTx.
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post(base(harness.sourceA) + '/messages/send').send({ text: 'hi' });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /cli (local, conditional — meshcoreAdminRoutes.ts:230)', () => {
+    it('returns 409 for the advert verb while receive-only', async () => {
+      mgr.setReceiveOnly(true);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post(base(harness.sourceA) + '/cli').send({ command: 'advert' });
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ success: false, code: 'TX_DISABLED' });
+    });
+
+    it('does not gate the ver verb while receive-only', async () => {
+      mgr.setReceiveOnly(true);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post(base(harness.sourceA) + '/cli').send({ command: 'ver' });
+      expect(res.status).not.toBe(409);
+    });
+
+    it('advert still works when receive-only is off', async () => {
+      mgr.setReceiveOnly(false);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post(base(harness.sourceA) + '/cli').send({ command: 'advert' });
+      expect(res.status).not.toBe(409);
+    });
+  });
+
+  describe('POST /neighbors/request (conditional — meshcoreContactsRoutes.ts:1011)', () => {
+    it('returns 409 when a publicKey is supplied (remote branch) while receive-only', async () => {
+      mgr.setReceiveOnly(true);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(base(harness.sourceA) + '/neighbors/request')
+        .send({ publicKey: VALID_PK });
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ success: false, code: 'TX_DISABLED' });
+    });
+
+    it('does not return 409 without a publicKey (local branch) while receive-only', async () => {
+      mgr.setReceiveOnly(true);
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post(base(harness.sourceA) + '/neighbors/request').send({});
+      expect(res.status).not.toBe(409);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('serial-config / read / connect routes stay unaffected while receive-only', () => {
+    beforeEach(() => {
+      mgr.setReceiveOnly(true);
+    });
+
+    it('POST /config/discoverable still succeeds', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(base(harness.sourceA) + '/config/discoverable')
+        .send({ enabled: true });
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /config/sync-time still succeeds', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post(base(harness.sourceA) + '/config/sync-time').send({});
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /contacts/:publicKey/out-path still succeeds', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .put(base(harness.sourceA) + `/contacts/${VALID_PK}/out-path`)
+        .send({ outPath: '' });
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /contacts still succeeds', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get(base(harness.sourceA) + '/contacts');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /messages still succeeds', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get(base(harness.sourceA) + '/messages');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('race mapping — mid-request TxDisabledError maps to 409, not 500', () => {
+    it('POST /messages/send: receive-only OFF at the pre-check, but the primitive throws', async () => {
+      mgr.setReceiveOnly(false); // requireMeshcoreTx() passes
+      mgr.sendMessage = async () => {
+        throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+      };
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post(base(harness.sourceA) + '/messages/send').send({ text: 'hi' });
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ success: false, code: 'TX_DISABLED' });
+    });
+
+    it('POST /neighbors/request (conditional, no pre-check): the primitive throws and still maps to 409', async () => {
+      // No middleware gates this route at all, so the only way it can 409 is
+      // the manager primitive itself throwing — simulate that directly rather
+      // than relying on the receive-only flag (see the dedicated conditional
+      // test above for the flag-driven path).
+      mgr.setReceiveOnly(false);
+      mgr.requestNeighbors = async () => {
+        throw new TxDisabledError(MESHCORE_RECEIVE_ONLY_MESSAGE);
+      };
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .post(base(harness.sourceA) + '/neighbors/request')
+        .send({ publicKey: VALID_PK });
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ success: false, code: 'TX_DISABLED' });
+    });
+  });
+});

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -81,6 +81,10 @@ const meshcoreManager = {
   recordMeshTx: vi.fn(),
   // Fire-and-forget scope-cache refresh invoked by the saved-regions routes (#3829).
   notifySavedRegionsChanged: vi.fn(),
+  // Receive-only TX guard (#4547) — requireMeshcoreTx() calls this unconditionally
+  // on every gated route, so the stub must declare it like the real manager does.
+  isReceiveOnly: vi.fn().mockReturnValue(false),
+  canTransmit: vi.fn().mockReturnValue(true),
 };
 
 vi.mock('../meshcoreManager.js', () => ({

--- a/src/server/routes/meshcoreRoutes.zeroHopPing.test.ts
+++ b/src/server/routes/meshcoreRoutes.zeroHopPing.test.ts
@@ -23,6 +23,11 @@ vi.mock('../sourceManagerRegistry.js', () => {
     sourceId,
     sourceType: 'meshcore' as const,
     pingContactZeroHop: pingMock,
+    // Receive-only TX guard (#4547) — requireMeshcoreTx() calls this
+    // unconditionally on every gated route, so the stub must declare it
+    // like the real manager does.
+    isReceiveOnly: () => false,
+    canTransmit: () => true,
   });
   const managers = new Map([
     ['rt-source-a', stubFor('rt-source-a')],

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -153,6 +153,10 @@ export interface SettingsCallbacks {
   // intervalHours arg. A null sourceId is a no-op (no global scheduler).
   restartAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
   stopAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
+  // MeshCore receive-only (#4547): the manager caches the flag for sync,
+  // DB-free guards, so a scoped save must push the new value immediately
+  // rather than waiting for the source to reconnect.
+  refreshMeshcoreReceiveOnly?: (sourceId: string) => void;
   // ATAK/CoT Phase 3 (issue #3691): global singleton (not per-source). Re-read
   // cotFeedEnabled/cotFeedPort and (re)start or stop the CoT feed server.
   restartCotFeed?: () => void;
@@ -877,6 +881,13 @@ router.post('/', requirePermission('settings', 'write', { sourceIdFrom: 'query' 
       if (INACTIVE_NODE_KEYS.some((key) => key in filteredSettings)) {
         callbacks.rescheduleInactiveNodeService?.(sourceId);
         logger.debug(`✅ Inactive node check rescheduled (source: ${sourceId})`);
+      }
+
+      // MeshCore receive-only (#4547): the manager caches this flag for sync,
+      // DB-free guards, so a scoped save must push the new value immediately
+      // rather than waiting for the source to reconnect.
+      if ('meshcoreReceiveOnly' in filteredSettings) {
+        callbacks.refreshMeshcoreReceiveOnly?.(sourceId);
       }
 
       await auditSettingsWrite(req, currentSettings, filteredSettings, sourceId);

--- a/src/server/routes/sourceRoutes.radio.test.ts
+++ b/src/server/routes/sourceRoutes.radio.test.ts
@@ -196,12 +196,14 @@ describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
     expect(a.radio.frequencyMhz).toBeCloseTo(915.5, 3);
   });
 
-  it('includes a meshcore radio summary ({ frequencyMhz }) derived from getLocalNode().radioFreq', async () => {
+  it('includes a meshcore radio summary ({ frequencyMhz, receiveOnly, canTransmit }) derived from getLocalNode().radioFreq / isReceiveOnly() / canTransmit()', async () => {
     mockGetManager.mockImplementation((sourceId: string) => {
       if (sourceId !== harness.sourceB) return null;
       return {
         sourceType: 'meshcore',
         getLocalNode: () => ({ publicKey: 'abc', name: 'MC', advType: 1, radioFreq: 869.525 }),
+        isReceiveOnly: () => false,
+        canTransmit: () => true,
       };
     });
 
@@ -209,7 +211,46 @@ describe('GET /api/sources — radio summary (#4111 P3 WP-1)', () => {
     const res = await agent.get('/');
 
     const b = res.body.find((s: { id: string }) => s.id === harness.sourceB);
-    expect(b.radio).toEqual({ frequencyMhz: 869.525 });
+    expect(b.radio).toEqual({ frequencyMhz: 869.525, receiveOnly: false, canTransmit: true });
+  });
+
+  // #4547 Phase 1 WP5: receiveOnly/canTransmit must reflect the MeshCore
+  // manager's own per-source state, both when the flag is on and off.
+  it('reports receiveOnly: true / canTransmit: false on the meshcore summary when the source is strictly receive-only (#4547)', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceB) return null;
+      return {
+        sourceType: 'meshcore',
+        getLocalNode: () => ({ publicKey: 'abc', name: 'MC', advType: 1, radioFreq: 869.525 }),
+        isReceiveOnly: () => true,
+        canTransmit: () => false,
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const b = res.body.find((s: { id: string }) => s.id === harness.sourceB);
+    expect(b.radio).toEqual({ frequencyMhz: 869.525, receiveOnly: true, canTransmit: false });
+  });
+
+  it('reports receiveOnly: false / canTransmit: true on the meshcore summary when the source can transmit (#4547)', async () => {
+    mockGetManager.mockImplementation((sourceId: string) => {
+      if (sourceId !== harness.sourceB) return null;
+      return {
+        sourceType: 'meshcore',
+        getLocalNode: () => ({ publicKey: 'abc', name: 'MC', advType: 1, radioFreq: 869.525 }),
+        isReceiveOnly: () => false,
+        canTransmit: () => true,
+      };
+    });
+
+    const agent = await harness.loginAs(null);
+    const res = await agent.get('/');
+
+    const b = res.body.find((s: { id: string }) => s.id === harness.sourceB);
+    expect(b.radio.receiveOnly).toBe(false);
+    expect(b.radio.canTransmit).toBe(true);
   });
 
   it('returns radio: null when no manager is registered for the source', async () => {

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -427,6 +427,8 @@ interface SourceRadioSummary {
    * read THIS, not `txEnabled` (#4394).
    */
   canTransmit?: boolean;
+  /** MeshCore only (#4547). True when the source is configured strictly receive-only. */
+  receiveOnly?: boolean;
 }
 
 // Wrapped in try/catch so a manager that throws from getCurrentConfig()/
@@ -465,7 +467,11 @@ function computeSourceRadioSummary(sourceId: string): SourceRadioSummary | null 
       // localNode is a private field on MeshCoreManager — use the public
       // accessor rather than reaching into it directly.
       const freq = mgr.getLocalNode()?.radioFreq;
-      return { frequencyMhz: typeof freq === 'number' && Number.isFinite(freq) ? freq : null };
+      return {
+        frequencyMhz: typeof freq === 'number' && Number.isFinite(freq) ? freq : null,
+        receiveOnly: mgr.isReceiveOnly(),
+        canTransmit: mgr.canTransmit(),
+      };
     }
     return null; // MQTT / bridge sources have no local radio.
   } catch (error) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -593,7 +593,7 @@ import meshcoreRoutes from './routes/meshcoreRoutes.js';
 import mqttPacketRoutes from './routes/mqttPacketRoutes.js';
 import atakRoutes from './routes/atakRoutes.js';
 // meshcoreConfigFromSource / ensureMeshCoreManagerStarted moved to bootstrapSources.ts
-import { isMeshtasticManager } from './sourceManagerTypes.js';
+import { isMeshtasticManager, isMeshCoreManager } from './sourceManagerTypes.js';
 import { MeshCoreTelemetryPoller, setMeshCoreTelemetryPoller } from './services/meshcoreTelemetryPoller.js';
 import {
   MeshCoreRemoteTelemetryScheduler,
@@ -912,6 +912,12 @@ setSettingsCallbacks({
     if (!sourceId) return;
     const mgr = sourceManagerRegistry.getManager(sourceId);
     mgr?.stopDistanceDeleteScheduler();
+  },
+  // MeshCore receive-only (#4547): push the freshly-saved flag into the
+  // manager's sync cache immediately, rather than waiting for a reconnect.
+  refreshMeshcoreReceiveOnly: (sourceId: string) => {
+    const mgr = sourceManagerRegistry.getManager(sourceId);
+    if (mgr && isMeshCoreManager(mgr)) void mgr.refreshReceiveOnly();
   },
   // ATAK/CoT Phase 3 (issue #3691): global singleton, not per-source.
   restartCotFeed: () => { void cotFeedService.startFromSettings(); },

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -195,6 +195,8 @@ interface FakeManagerState {
   guestLoginResult: boolean;
   /** Order of sub-call invocations within tickOneManager for ordering assertions. */
   callOrder: string[];
+  /** #4547: strict receive-only flag. Defaults to false (transmit-allowed). */
+  receiveOnly: boolean;
 }
 
 function makeFakeManager(init: Partial<FakeManagerState>): MeshCoreManager & { _state: FakeManagerState } {
@@ -208,11 +210,13 @@ function makeFakeManager(init: Partial<FakeManagerState>): MeshCoreManager & { _
     guestLoginCalledFor: [],
     guestLoginResult: true,
     callOrder: [],
+    receiveOnly: false,
     ...init,
   };
   const m: any = {
     sourceId: state.sourceId,
     isConnected: () => state.connected,
+    isReceiveOnly: () => state.receiveOnly,
     getLastMeshTxAt: () => state.lastMeshTxAt,
     recordMeshTx: (when: number = Date.now()) => {
       state.lastMeshTxAt = when;
@@ -738,5 +742,59 @@ describe('statusToTelemetryRows', () => {
     const rows = statusToTelemetryRows({ uptimeSecs: 0, queueLen: 0 }, 'pk', 1, 0);
     const types = rows.map((r) => r.telemetryType).sort();
     expect(types).toEqual(['mc_status_queue_len', 'mc_status_uptime_secs']);
+  });
+});
+
+// ============ Receive-only (#4547 WP3) ============
+
+describe('MeshCoreRemoteTelemetryScheduler.tickOneManager — receive-only (#4547)', () => {
+  it('returns before requestNodeStatus/ensureGuestLogin/requestRemoteTelemetry when receive-only', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ lastMeshTxAt: 0, receiveOnly: true });
+    const getNodes = vi.fn().mockResolvedValue([
+      makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+    ]);
+    const markRequested = vi.fn();
+    const insertSpy = vi.fn().mockResolvedValue(0);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: { getTelemetryEnabledNodes: getNodes, markTelemetryRequested: markRequested, upsertNode: vi.fn().mockResolvedValue(undefined) },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      now: () => now,
+    });
+
+    await scheduler.tickOneManager(manager);
+
+    // The skip fires before even reading eligible nodes — no DB read, no
+    // stamp, no request of any kind.
+    expect(getNodes).not.toHaveBeenCalled();
+    expect(markRequested).not.toHaveBeenCalled();
+    expect((manager as any)._state.callOrder).toEqual([]);
+    expect((manager as any)._state.lastRequestedKey).toBeNull();
+  });
+
+  it('a connected, non-receive-only manager still ticks normally (non-vacuous negative)', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ lastMeshTxAt: 0, receiveOnly: false });
+    const getNodes = vi.fn().mockResolvedValue([
+      makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+    ]);
+    const markRequested = vi.fn().mockResolvedValue(undefined);
+    const insertSpy = vi.fn().mockResolvedValue(1);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: { getTelemetryEnabledNodes: getNodes, markTelemetryRequested: markRequested, upsertNode: vi.fn().mockResolvedValue(undefined) },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      now: () => now,
+    });
+
+    await scheduler.tickOneManager(manager);
+
+    expect(getNodes).toHaveBeenCalled();
+    expect((manager as any)._state.callOrder).toContain('requestRemoteTelemetry');
   });
 });

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -345,6 +345,15 @@ export class MeshCoreRemoteTelemetryScheduler {
   /** Process a single manager. Visible for tests. */
   async tickOneManager(manager: MeshCoreManager): Promise<void> {
     if (!manager.isConnected()) return;
+    // Receive-only (#4547): first statement after the connectivity check,
+    // before any guarded send primitive (requestNodeStatus/ensureGuestLogin/
+    // requestRemoteTelemetry). requestRemoteTelemetry has no local try/catch
+    // and would otherwise rely on tick()'s per-manager catch two layers up —
+    // this skip keeps it from ever getting there.
+    if (manager.isReceiveOnly()) {
+      logger.debug(`[MeshCoreRemoteTelem:${manager.sourceId}] Skipping - receive-only mode`);
+      return;
+    }
 
     const now = this.nowFn();
     const sinceLastTx = now - manager.getLastMeshTxAt();

--- a/src/server/services/meshcoreRoomSyncScheduler.test.ts
+++ b/src/server/services/meshcoreRoomSyncScheduler.test.ts
@@ -1,0 +1,179 @@
+/**
+ * MeshCoreRoomSyncScheduler tests.
+ *
+ * Covers the pure helpers (`isRoomSyncEligible`, `pickMostOverdueRoom`) and
+ * the receive-only (#4547 WP3) skip in `tickOneManager`: a receive-only
+ * source must never reach `manager.loginToRoom()` — the room-sync login
+ * itself IS a transmission (CMD_LOGIN), so this scheduler's send primitive is
+ * the login call, not a separate "send" step.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  MeshCoreRoomSyncScheduler,
+  isRoomSyncEligible,
+  pickMostOverdueRoom,
+} from './meshcoreRoomSyncScheduler.js';
+import type { MeshCoreManager } from '../meshcoreManager.js';
+import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
+import type { MeshCoreCredentialStore } from './meshcoreCredentialStore.js';
+import databaseService from '../../services/database.js';
+
+function makeNode(over: Partial<{
+  publicKey: string;
+  roomSyncEnabled: boolean;
+  roomSyncIntervalMinutes: number;
+  lastRoomSyncAt: number | null;
+}>) {
+  return {
+    publicKey: 'pk-x',
+    roomSyncEnabled: true,
+    roomSyncIntervalMinutes: 60,
+    lastRoomSyncAt: null,
+    ...over,
+  };
+}
+
+describe('isRoomSyncEligible', () => {
+  it('rejects disabled nodes', () => {
+    expect(isRoomSyncEligible(makeNode({ roomSyncEnabled: false }), 0)).toBe(false);
+  });
+
+  it('rejects an interval below the 60-minute floor', () => {
+    expect(isRoomSyncEligible(makeNode({ roomSyncIntervalMinutes: 30 }), 1_000_000)).toBe(false);
+  });
+
+  it('accepts a node never synced before', () => {
+    expect(isRoomSyncEligible(makeNode({ lastRoomSyncAt: null }), 100_000_000)).toBe(true);
+  });
+
+  it('rejects a node still inside its interval', () => {
+    const now = 100_000_000;
+    const node = makeNode({ roomSyncIntervalMinutes: 60, lastRoomSyncAt: now - 30 * 60_000 });
+    expect(isRoomSyncEligible(node, now)).toBe(false);
+  });
+
+  it('accepts a node past its interval', () => {
+    const now = 100_000_000;
+    const node = makeNode({ roomSyncIntervalMinutes: 60, lastRoomSyncAt: now - 61 * 60_000 });
+    expect(isRoomSyncEligible(node, now)).toBe(true);
+  });
+});
+
+describe('pickMostOverdueRoom', () => {
+  it('returns undefined when nothing is eligible', () => {
+    expect(pickMostOverdueRoom([makeNode({ roomSyncEnabled: false })], 1_000_000)).toBeUndefined();
+  });
+
+  it('picks the most overdue eligible room, publicKey as tiebreaker', () => {
+    const now = 100_000_000;
+    const a = makeNode({ publicKey: 'aaa', lastRoomSyncAt: now - 70 * 60_000 });
+    const b = makeNode({ publicKey: 'bbb', lastRoomSyncAt: now - 120 * 60_000 });
+    expect(pickMostOverdueRoom([a, b], now)?.publicKey).toBe('bbb');
+  });
+});
+
+// ============ tickOneManager — receive-only (#4547 WP3) ============
+
+interface FakeManagerState {
+  sourceId: string;
+  connected: boolean;
+  receiveOnly: boolean;
+  lastMeshTxAt: number;
+  loginCalledFor: string[];
+  loginResult: boolean;
+}
+
+function makeFakeManager(init: Partial<FakeManagerState>): MeshCoreManager & { _state: FakeManagerState } {
+  const state: FakeManagerState = {
+    sourceId: 'src-a',
+    connected: true,
+    receiveOnly: false,
+    lastMeshTxAt: 0,
+    loginCalledFor: [],
+    loginResult: true,
+    ...init,
+  };
+  const m: any = {
+    sourceId: state.sourceId,
+    sourceType: 'meshcore',
+    isConnected: () => state.connected,
+    isReceiveOnly: () => state.receiveOnly,
+    getLastMeshTxAt: () => state.lastMeshTxAt,
+    recordMeshTx: (when: number = Date.now()) => { state.lastMeshTxAt = when; },
+    loginToRoom: async (publicKey: string, _password: string) => {
+      state.loginCalledFor.push(publicKey);
+      return state.loginResult;
+    },
+    _state: state,
+  };
+  return m as MeshCoreManager & { _state: FakeManagerState };
+}
+
+function makeRegistry(managers: MeshCoreManager[]): SourceManagerRegistry {
+  return { getAllManagers: () => managers } as unknown as SourceManagerRegistry;
+}
+
+function makeCredentialStore(): MeshCoreCredentialStore {
+  return {
+    loadRoom: vi.fn().mockResolvedValue({ kind: 'ok', password: 'secret' }),
+  } as unknown as MeshCoreCredentialStore;
+}
+
+describe('MeshCoreRoomSyncScheduler.tickOneManager — receive-only (#4547)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns before loginToRoom (and before the room-node DB read) when receive-only', async () => {
+    const manager = makeFakeManager({ receiveOnly: true });
+    const getRoomNodes = vi.spyOn(databaseService.meshcore, 'getRoomSyncEnabledNodes').mockResolvedValue([
+      { publicKey: 'pk-a', advType: 3, roomSyncIntervalMinutes: 60, lastRoomSyncAt: null } as any,
+    ]);
+    const credentialStore = makeCredentialStore();
+    const scheduler = new MeshCoreRoomSyncScheduler({
+      registry: makeRegistry([manager]),
+      credentialStore,
+      now: () => 10_000_000,
+    });
+
+    await (scheduler as any).tickOneManager(manager.sourceId, manager);
+
+    expect(getRoomNodes).not.toHaveBeenCalled();
+    expect((manager as any)._state.loginCalledFor).toEqual([]);
+  });
+
+  it('a connected, non-receive-only manager still reaches loginToRoom (non-vacuous negative)', async () => {
+    const manager = makeFakeManager({ receiveOnly: false });
+    vi.spyOn(databaseService.meshcore, 'getRoomSyncEnabledNodes').mockResolvedValue([
+      { publicKey: 'pk-a', advType: 3, roomSyncIntervalMinutes: 60, lastRoomSyncAt: null } as any,
+    ]);
+    vi.spyOn(databaseService.meshcore, 'updateLastRoomSyncAt').mockResolvedValue(undefined);
+    const credentialStore = makeCredentialStore();
+    const scheduler = new MeshCoreRoomSyncScheduler({
+      registry: makeRegistry([manager]),
+      credentialStore,
+      now: () => 10_000_000,
+    });
+
+    await (scheduler as any).tickOneManager(manager.sourceId, manager);
+
+    expect((manager as any)._state.loginCalledFor).toEqual(['pk-a']);
+  });
+
+  it('tick() skips a receive-only manager entirely without touching the DB or credential store', async () => {
+    const manager = makeFakeManager({ receiveOnly: true, connected: true });
+    const getRoomNodes = vi.spyOn(databaseService.meshcore, 'getRoomSyncEnabledNodes').mockResolvedValue([]);
+    const credentialStore = makeCredentialStore();
+    const scheduler = new MeshCoreRoomSyncScheduler({
+      registry: makeRegistry([manager]),
+      credentialStore,
+      now: () => 10_000_000,
+    });
+
+    await scheduler.tick();
+
+    expect(getRoomNodes).not.toHaveBeenCalled();
+    expect((credentialStore.loadRoom as any)).not.toHaveBeenCalled();
+    expect((manager as any)._state.loginCalledFor).toEqual([]);
+  });
+});

--- a/src/server/services/meshcoreRoomSyncScheduler.ts
+++ b/src/server/services/meshcoreRoomSyncScheduler.ts
@@ -107,6 +107,13 @@ export class MeshCoreRoomSyncScheduler {
   }
 
   private async tickOneManager(sourceId: string, manager: MeshCoreManager): Promise<void> {
+    // Receive-only (#4547): first statement, before any guarded send
+    // primitive (loginToRoom).
+    if (manager.isReceiveOnly()) {
+      logger.debug(`[RoomSyncScheduler:${sourceId}] Skipping - receive-only mode`);
+      return;
+    }
+
     const now = this.now();
 
     // Respect per-source mesh TX spacing.

--- a/src/types/elevation.ts
+++ b/src/types/elevation.ts
@@ -43,6 +43,18 @@ export interface SourceRadioSummary {
   regionName?: string;
   /** Meshtastic only — drives RX-sensitivity auto-seed. */
   modemPreset?: number;
+  /** Meshtastic only. Fail-open true (matches firmware default) when the field is unset. */
+  txEnabled?: boolean;
+  /** Meshtastic only. `network.enabledProtocols & UDP_BROADCAST` — a LAN peer relays our sends (#4394). */
+  udpRelayEnabled?: boolean;
+  /**
+   * Whether sends from this source have any path onto the mesh. Meshtastic:
+   * `txEnabled || udpRelayEnabled`. MeshCore: `!receiveOnly`. Consumers gating
+   * "can this source send?" must read THIS, not `txEnabled` alone (#4394).
+   */
+  canTransmit?: boolean;
+  /** MeshCore only (#4547). True when the source is configured strictly receive-only. */
+  receiveOnly?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Phase 1 of 3 — Backend enforcement for MeshCore strict receive-only mode

Closes part of #4547. Epic plan: `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md`.
Phase spec: `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md`.

Adds a per-source `meshcoreReceiveOnly` setting that guarantees a MeshCore source never
transmits over LoRa, while RX, the Analyzer Observer, the packet log, and contact/telemetry/
route updates all keep working.

**No UI in this PR** (Phase 2) and **no Virtual Node gating** (Phase 3).

### Why this can't delegate to firmware

`@liamcottle/meshcore.js` v1.13.0 and the Companion protocol expose **no** radio-level TX kill
switch — no `txEnabled`/`disableTx`/`radioOff` equivalent anywhere in `CommandCodes`.
`SetTxPower` lowers power but never stops TX. So unlike Meshtastic (`lora.txEnabled` is a
firmware kill switch), this is enforced entirely in MeshMonitor. It cannot stop
firmware-autonomous transmissions (link-layer ACKs, on-device advert schedules set outside
MeshMonitor) — documented for users in Phase 3.

### How it's enforced

Two chokepoints, because MeshCore has two:

1. **`MeshCoreManager.sendBridgeCommand`** carries *both* RF and local serial commands, so the
   gate is **command-name aware** (`src/server/constants/meshcoreTx.ts`). It is **fail-closed**:
   any bridge command not explicitly listed as serial-only is blocked, so a future command added
   without touching that file cannot silently transmit. A completeness test scans both source
   files and fails the build on an unclassified command (verified by temporarily adding a fake
   `case` and confirming the test fails).
2. **`MeshCoreNativeBackend.handleDiscoverRequest`** — the discovery auto-responder is
   push-event driven, never touches `sendCommand`/`dispatch`, and calls `sendToRadioFrame`
   directly. It is the single most important guard here and is the literal first statement,
   ahead of even the `respondToDiscovery` gate.

On top of those: 24 explicit primitive guards, 10 scheduler/auto-* silent skips, and 22 gated
routes.

### Behaviour

- **User-initiated paths throw** the existing branded `TxDisabledError`; routes map it to
  `409 TX_DISABLED` with `"Transmission blocked: this MeshCore source is configured for
  receive-only operation."`
- **Schedulers silently skip** and stay armed — settings are never mutated, so turning
  receive-only off restores prior behaviour exactly. One `info` log on state change only; skips
  log at `debug`, so no per-tick spam.
- **Local serial config still works**: set name/radio/tx-power/coords, channel CRUD, RTC sync,
  stats, device query, reboot, contact import/export, and local CLI (except the `advert` verb).
- **Automations degrade for free** — reusing `TxDisabledError` means `pushOrSkipTxDisabled` in
  `actionExecutor.ts` already converts MeshCore sends to `{ skipped: true, reason: 'TX_DISABLED' }`
  with zero automation-engine changes.

### Two GET routes transmit

`GET /contacts/:publicKey/neighbours` and `GET /admin/status/:publicKey` both put frames on the
air. A POST-only sweep misses them; both are gated and have their own explicit tests.

### Reuse (no new subsystems)

Reuses `TxDisabledError`, the `SettingsCallbacks` invalidation channel, `fail()`/`ok()`,
`managerFor()`/`meshcoreRouteGuard`, `isMeshCoreManager`, and the existing per-source settings
plumbing. **No new error class, no event bus, no DB column, no migration.**

### Notable findings

- `requestNeighbors` is deliberately **not** guarded — its local `sendLocalCliCommand('neighbors')`
  branch is serial-only and must keep working; the remote branch throws via its guarded
  downstream primitives.
- `resolveSourceManager()` is Meshtastic-only by design, so `/api/device/tx-status` narrows via
  the registry directly for MeshCore sources.
- Fixed a pre-existing gap: the client `SourceRadioSummary` mirror was missing
  `txEnabled`/`udpRelayEnabled`/`canTransmit` entirely.

### Testing

- Full Vitest suite: **14,006 tests, 0 failures** (`success: true` via JSON reporter; 713 skipped
  are the PG/MySQL suites — this change touches no schema and adds no migration).
- New coverage: denylist completeness, 24 primitive guards, 8 scheduler skip sites with ON/OFF
  pairs plus an `unhandledRejection` listener and a 5-tick "zero `info` logs" assertion, the
  discovery-responder chokepoint (with a non-vacuous negative proving a frame IS sent when the
  flag is off), 22 routes × {409-when-on, not-409-when-off}, 403-beats-409 ordering, and a
  per-source isolation test.
- `npm run lint:ci` clean of in-repo failures; `tsc` clean including test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf
